### PR TITLE
fix(ui): surface the paginated fallback on Cost Optimization

### DIFF
--- a/ui/litellm-dashboard/src/app/(dashboard)/cost-optimization/_components/CacheLeakageCard.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/cost-optimization/_components/CacheLeakageCard.test.tsx
@@ -156,6 +156,17 @@ describe("CacheLeakageCard", () => {
     ).toBeInTheDocument();
   });
 
+  it("keeps the streaming note off while a fresh range loads over the previous range's rows", () => {
+    const day = dayWithKeys("2026-07-12", {
+      "hash-leaky": key("leaky-key", { prompt_tokens: 10000, cache_read_input_tokens: 0 }),
+    });
+    const { queryByText } = renderWith([day], { loading: true });
+
+    expect(
+      queryByText("Data is still loading; rows and totals will update as the rest of the range arrives."),
+    ).not.toBeInTheDocument();
+  });
+
   it("drops the streaming note once the range has settled", () => {
     const day = dayWithKeys("2026-07-12", {
       "hash-leaky": key("leaky-key", { prompt_tokens: 10000, cache_read_input_tokens: 0 }),

--- a/ui/litellm-dashboard/src/app/(dashboard)/cost-optimization/_components/CacheLeakageCard.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/cost-optimization/_components/CacheLeakageCard.test.tsx
@@ -2,6 +2,7 @@ import { fireEvent, render } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 
 import type { DailyData, KeyMetricWithMetadata, SpendMetrics } from "@/components/UsagePage/types";
+import type { DailyActivityRange } from "./useDailyActivityRange";
 
 vi.mock("@/components/shared/advanced_date_picker", () => ({
   __esModule: true,
@@ -59,7 +60,7 @@ const dayWithModels = (date: string, models: Record<string, Partial<SpendMetrics
   },
 });
 
-const renderWith = (results: DailyData[]) =>
+const renderWith = (results: DailyData[], overrides: Partial<DailyActivityRange> = {}) =>
   render(
     <CacheLeakageCard
       activity={{
@@ -68,6 +69,10 @@ const renderWith = (results: DailyData[]) =>
         results,
         loading: false,
         isFetchingMore: false,
+        progress: { currentPage: 1, totalPages: 1 },
+        cancelled: false,
+        cancel: vi.fn(),
+        ...overrides,
       }}
     />,
   );
@@ -137,5 +142,28 @@ describe("CacheLeakageCard", () => {
 
     expect(getByText("No key usage in this range.")).toBeInTheDocument();
     expect(queryByRole("table")).not.toBeInTheDocument();
+  });
+
+  it("tells the user the table is still filling in while fallback pages stream", () => {
+    const day = dayWithKeys("2026-07-12", {
+      "hash-leaky": key("leaky-key", { prompt_tokens: 10000, cache_read_input_tokens: 0 }),
+    });
+    const { getByText, getByRole } = renderWith([day], { isFetchingMore: true });
+
+    expect(getByRole("table")).toBeInTheDocument();
+    expect(
+      getByText("Data is still loading; rows and totals will update as the rest of the range arrives."),
+    ).toBeInTheDocument();
+  });
+
+  it("drops the streaming note once the range has settled", () => {
+    const day = dayWithKeys("2026-07-12", {
+      "hash-leaky": key("leaky-key", { prompt_tokens: 10000, cache_read_input_tokens: 0 }),
+    });
+    const { queryByText } = renderWith([day]);
+
+    expect(
+      queryByText("Data is still loading; rows and totals will update as the rest of the range arrives."),
+    ).not.toBeInTheDocument();
   });
 });

--- a/ui/litellm-dashboard/src/app/(dashboard)/cost-optimization/_components/CacheLeakageCard.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/cost-optimization/_components/CacheLeakageCard.tsx
@@ -123,7 +123,7 @@ const CacheLeakageCard: React.FC<CacheLeakageCardProps> = ({ activity }) => {
           </Tabs>
         </CardHeader>
         <CardContent>
-          {rows.length > 0 && (loading || isFetchingMore) && (
+          {rows.length > 0 && isFetchingMore && (
             <p className="mb-2 text-sm text-muted-foreground">
               Data is still loading; rows and totals will update as the rest of the range arrives.
             </p>

--- a/ui/litellm-dashboard/src/app/(dashboard)/cost-optimization/_components/CacheLeakageCard.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/cost-optimization/_components/CacheLeakageCard.tsx
@@ -123,6 +123,11 @@ const CacheLeakageCard: React.FC<CacheLeakageCardProps> = ({ activity }) => {
           </Tabs>
         </CardHeader>
         <CardContent>
+          {rows.length > 0 && (loading || isFetchingMore) && (
+            <p className="mb-2 text-sm text-muted-foreground">
+              Data is still loading; rows and totals will update as the rest of the range arrives.
+            </p>
+          )}
           {rows.length === 0 ? (
             <p className="py-8 text-center text-sm text-muted-foreground">
               {loading || isFetchingMore ? "Loading..." : `No ${emptyNoun} usage in this range.`}

--- a/ui/litellm-dashboard/src/app/(dashboard)/cost-optimization/_components/CostOptimizationView.activity.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/cost-optimization/_components/CostOptimizationView.activity.test.tsx
@@ -54,7 +54,7 @@ describe("CostOptimizationView daily activity", () => {
     useAuthorizedMock.mockReturnValue({ accessToken: "test-token", userId: "u1", userRole: "proxy_admin" });
     const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
 
-    const { getByRole, getByTestId, findByTestId } = render(
+    const { getByRole, getByTestId, findByTestId, queryByText } = render(
       <QueryClientProvider client={queryClient}>
         <CostOptimizationView accessToken="test-token" userId="u1" userRole="proxy_admin" />
       </QueryClientProvider>,
@@ -67,5 +67,28 @@ describe("CostOptimizationView daily activity", () => {
 
     expect(mockUserDailyActivityAggregatedCall).toHaveBeenCalledTimes(1);
     expect(mockUserDailyActivityCall).not.toHaveBeenCalled();
+    expect(queryByText(/Currently fetching spend data/)).not.toBeInTheDocument();
+  });
+
+  it("shows the fetch-progress banner while the paginated fallback streams pages in", async () => {
+    mockUserDailyActivityAggregatedCall.mockReset();
+    mockUserDailyActivityCall.mockReset();
+    mockUserDailyActivityAggregatedCall.mockRejectedValue(new Error("aggregated unavailable"));
+    mockUserDailyActivityCall.mockImplementation((...args: unknown[]) =>
+      args[3] === 1
+        ? Promise.resolve({ results: [], metadata: { total_pages: 3, has_more: true, page: 1 } })
+        : new Promise(() => {}),
+    );
+    useAuthorizedMock.mockReturnValue({ accessToken: "test-token", userId: "u1", userRole: "proxy_admin" });
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+
+    const { findByText, getByRole } = render(
+      <QueryClientProvider client={queryClient}>
+        <CostOptimizationView accessToken="test-token" userId="u1" userRole="proxy_admin" />
+      </QueryClientProvider>,
+    );
+
+    expect(await findByText(/Currently fetching spend data: fetched 1 \/ 3 pages/)).toBeInTheDocument();
+    expect(getByRole("button", { name: "Stop" })).toBeInTheDocument();
   });
 });

--- a/ui/litellm-dashboard/src/app/(dashboard)/cost-optimization/_components/CostOptimizationView.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/cost-optimization/_components/CostOptimizationView.tsx
@@ -4,6 +4,7 @@ import React from "react";
 import { Info, PiggyBank } from "lucide-react";
 
 import useCan from "@/app/(dashboard)/hooks/useCan";
+import PaginationStatusAlerts from "@/components/shared/PaginationStatusAlerts";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import UsageTab from "./UsageTab";
 import PromptCompressionTab from "./PromptCompressionTab";
@@ -62,6 +63,12 @@ const CostOptimizationView: React.FC<CostOptimizationViewProps> = ({ accessToken
         </p>
       </div>
 
+      <PaginationStatusAlerts
+        isFetchingMore={activity.isFetchingMore}
+        cancelled={activity.cancelled}
+        progress={activity.progress}
+        cancel={activity.cancel}
+      />
       <Tabs defaultValue="usage" onValueChange={handleTabChange}>
         <TabsList variant="line" className="h-auto w-full justify-start rounded-none p-0">
           <TabsTrigger value="usage" className="flex-none rounded-none px-4 py-2">

--- a/ui/litellm-dashboard/src/app/(dashboard)/cost-optimization/_components/PromptCachingTab.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/cost-optimization/_components/PromptCachingTab.test.tsx
@@ -33,6 +33,9 @@ describe("PromptCachingTab", () => {
       results: [],
       loading: false,
       isFetchingMore: false,
+      progress: { currentPage: 1, totalPages: 1 },
+      cancelled: false,
+      cancel: vi.fn(),
     };
     const { getByTestId } = render(<PromptCachingTab accessToken="test-token" activity={activity} />);
 

--- a/ui/litellm-dashboard/src/app/(dashboard)/cost-optimization/_components/UsageTab.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/cost-optimization/_components/UsageTab.test.tsx
@@ -121,6 +121,9 @@ const renderWith = (results: DailyData[], options: RenderOptions = {}) => {
         results,
         loading: false,
         isFetchingMore: false,
+        progress: { currentPage: 1, totalPages: 1 },
+        cancelled: false,
+        cancel: vi.fn(),
       }}
     />,
   );

--- a/ui/litellm-dashboard/src/app/(dashboard)/cost-optimization/_components/useDailyActivityRange.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/cost-optimization/_components/useDailyActivityRange.test.tsx
@@ -3,10 +3,19 @@ import { describe, expect, it, vi } from "vitest";
 
 const mockUsePaginatedDailyActivity = vi.fn();
 
+const mockCancel = vi.fn();
+
 vi.mock("@/app/(dashboard)/usage/_components/hooks/usePaginatedDailyActivity", () => ({
   usePaginatedDailyActivity: (args: unknown) => {
     mockUsePaginatedDailyActivity(args);
-    return { data: { results: [] }, loading: false, isFetchingMore: false };
+    return {
+      data: { results: [] },
+      loading: false,
+      isFetchingMore: false,
+      progress: { currentPage: 4, totalPages: 9 },
+      cancelled: false,
+      cancel: mockCancel,
+    };
   },
 }));
 
@@ -39,6 +48,14 @@ describe("useDailyActivityRange", () => {
     expect(mockUsePaginatedDailyActivity).toHaveBeenLastCalledWith(
       expect.objectContaining({ aggregatedFetchFn: userDailyActivityAggregatedCall }),
     );
+  });
+
+  it("forwards the pagination progress and cancel affordances instead of dropping them", () => {
+    const { result } = renderHook(() => useDailyActivityRange("test-token", "u1", "proxy_admin"));
+
+    expect(result.current.progress).toEqual({ currentPage: 4, totalPages: 9 });
+    expect(result.current.cancelled).toBe(false);
+    expect(result.current.cancel).toBe(mockCancel);
   });
 
   it("stays disabled until an access token is available", () => {

--- a/ui/litellm-dashboard/src/app/(dashboard)/cost-optimization/_components/useDailyActivityRange.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/cost-optimization/_components/useDailyActivityRange.ts
@@ -18,6 +18,9 @@ export interface DailyActivityRange {
   results: DailyData[];
   loading: boolean;
   isFetchingMore: boolean;
+  progress: { currentPage: number; totalPages: number };
+  cancelled: boolean;
+  cancel: () => void;
 }
 
 export const useDailyActivityRange = (
@@ -33,7 +36,7 @@ export const useDailyActivityRange = (
   const endTime = dateValue.to ?? null;
   const effectiveUserId = all_admin_roles.includes(userRole) ? null : userId;
 
-  const { data, loading, isFetchingMore } = usePaginatedDailyActivity({
+  const { data, loading, isFetchingMore, progress, cancelled, cancel } = usePaginatedDailyActivity({
     fetchFn: userDailyActivityCall,
     aggregatedFetchFn: userDailyActivityAggregatedCall,
     args: [accessToken, startTime, endTime, effectiveUserId, true],
@@ -46,5 +49,8 @@ export const useDailyActivityRange = (
     results: data.results as DailyData[],
     loading,
     isFetchingMore,
+    progress,
+    cancelled,
+    cancel,
   };
 };

--- a/ui/litellm-dashboard/src/app/(dashboard)/usage/_components/components/EntityUsage/EntityUsage.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/usage/_components/components/EntityUsage/EntityUsage.tsx
@@ -15,10 +15,9 @@ import { Card as ShadcnCard, CardContent, CardHeader, CardTitle } from "@/compon
 import { hasCapability, type Capability } from "@/utils/capabilities";
 import { formatNumberWithCommas } from "@/utils/dataUtils";
 import type { DateRangePickerValue } from "@/components/shared/date_picker_types";
-import { ChevronDown, ChevronRight, ExternalLink, Info, Loader2 } from "lucide-react";
+import { ChevronDown, ChevronRight, Info } from "lucide-react";
 import type { ColumnDef } from "@tanstack/react-table";
-import { Alert, AlertDescription } from "@/components/shared/Alert";
-import { Button } from "@/components/ui/button";
+import PaginationStatusAlerts from "@/components/shared/PaginationStatusAlerts";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import React, { type ReactNode, useMemo, useState } from "react";
@@ -643,57 +642,20 @@ const EntityUsage: React.FC<EntityUsageProps> = ({
 
   return (
     <div style={{ width: "100%" }} className="relative">
-      {isFetchingMore && (
-        <Alert variant="warning" className="mb-2">
-          <AlertDescription className="flex items-center justify-between text-inherit">
-            <span>
-              <Loader2 className="mr-2 inline size-4 animate-spin align-text-bottom" />
-              Currently fetching spend data: fetched {progress.currentPage} / {progress.totalPages} pages. Charts will
-              update periodically as data loads. Moving off of this page will stop and reset this. To continue using the
-              UI in the meantime,{" "}
-              <a href={window.location.href} target="_blank" rel="noopener noreferrer">
-                open a new tab <ExternalLink className="inline size-3.5 align-text-bottom" />
-              </a>
-              .
-            </span>
-            <Button variant="destructive" onClick={cancel}>
-              Stop
-            </Button>
-          </AlertDescription>
-        </Alert>
-      )}
-      {cancelled && (
-        <Alert variant="info" className="mb-2">
-          <AlertDescription className="text-inherit">
-            Showing partial data ({progress.currentPage}/{progress.totalPages} pages loaded)
-          </AlertDescription>
-        </Alert>
-      )}
-      {agentIsFetchingMore && showAgentBreakdown && (
-        <Alert variant="warning" className="mb-2">
-          <AlertDescription className="flex items-center justify-between text-inherit">
-            <span>
-              <Loader2 className="mr-2 inline size-4 animate-spin align-text-bottom" />
-              Currently fetching agent data: fetched {agentProgress.currentPage} / {agentProgress.totalPages} pages.
-              Charts will update periodically as data loads. Moving off of this page will stop and reset this. To
-              continue using the UI in the meantime,{" "}
-              <a href={window.location.href} target="_blank" rel="noopener noreferrer">
-                open a new tab <ExternalLink className="inline size-3.5 align-text-bottom" />
-              </a>
-              .
-            </span>
-            <Button variant="destructive" onClick={agentCancel}>
-              Stop
-            </Button>
-          </AlertDescription>
-        </Alert>
-      )}
-      {agentCancelled && showAgentBreakdown && (
-        <Alert variant="info" className="mb-2">
-          <AlertDescription className="text-inherit">
-            Showing partial agent data ({agentProgress.currentPage}/{agentProgress.totalPages} pages loaded)
-          </AlertDescription>
-        </Alert>
+      <PaginationStatusAlerts
+        isFetchingMore={isFetchingMore}
+        cancelled={cancelled}
+        progress={progress}
+        cancel={cancel}
+      />
+      {showAgentBreakdown && (
+        <PaginationStatusAlerts
+          isFetchingMore={agentIsFetchingMore}
+          cancelled={agentCancelled}
+          progress={agentProgress}
+          cancel={agentCancel}
+          subject="agent data"
+        />
       )}
       <UsageExportHeader
         dateValue={dateValue}

--- a/ui/litellm-dashboard/src/app/(dashboard)/usage/_components/components/UsagePageView.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/usage/_components/components/UsagePageView.tsx
@@ -6,12 +6,13 @@
  * Works at 1m+ spend logs, by querying an aggregate table instead.
  */
 
-import { ChevronDown, ChevronRight, Download, ExternalLink, Info, Loader2, Sparkles, X } from "lucide-react";
+import { ChevronDown, ChevronRight, Download, Info, Sparkles, X } from "lucide-react";
 import type { DateRangePickerValue } from "@/components/shared/date_picker_types";
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import { BarChart } from "@/components/shared/charts";
 import { Alert, AlertAction, AlertDescription, AlertTitle } from "@/components/shared/Alert";
+import PaginationStatusAlerts from "@/components/shared/PaginationStatusAlerts";
 import { Button } from "@/components/ui/button";
 import { Card as ShadcnCard, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
@@ -473,33 +474,12 @@ const UsagePage: React.FC<UsagePageProps> = ({ teams, organizations }) => {
             />
             <AdvancedDatePicker value={dateValue} onValueChange={handleDateChange} />
           </div>
-          {paginatedResult.isFetchingMore && (
-            <Alert variant="warning" className="mb-2">
-              <AlertDescription className="flex items-center justify-between text-inherit">
-                <span>
-                  <Loader2 className="mr-2 inline size-4 animate-spin align-text-bottom" />
-                  Currently fetching spend data: fetched {paginatedResult.progress.currentPage} /{" "}
-                  {paginatedResult.progress.totalPages} pages. Charts will update periodically as data loads. Moving off
-                  of this page will stop and reset this. To continue using the UI in the meantime,{" "}
-                  <a href={window.location.href} target="_blank" rel="noopener noreferrer">
-                    open a new tab <ExternalLink className="inline size-3.5 align-text-bottom" />
-                  </a>
-                  .
-                </span>
-                <Button variant="destructive" onClick={paginatedResult.cancel}>
-                  Stop
-                </Button>
-              </AlertDescription>
-            </Alert>
-          )}
-          {paginatedResult.cancelled && (
-            <Alert variant="info" className="mb-2">
-              <AlertDescription className="text-inherit">
-                Showing partial data ({paginatedResult.progress.currentPage}/{paginatedResult.progress.totalPages} pages
-                loaded)
-              </AlertDescription>
-            </Alert>
-          )}
+          <PaginationStatusAlerts
+            isFetchingMore={paginatedResult.isFetchingMore}
+            cancelled={paginatedResult.cancelled}
+            progress={paginatedResult.progress}
+            cancel={paginatedResult.cancel}
+          />
           {/* Your Usage / Global Usage Panel */}
           {(usageView === "global" || usageView === "my-usage") && (
             <>

--- a/ui/litellm-dashboard/src/components/shared/PaginationStatusAlerts.test.tsx
+++ b/ui/litellm-dashboard/src/components/shared/PaginationStatusAlerts.test.tsx
@@ -1,0 +1,62 @@
+import { fireEvent, render } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import PaginationStatusAlerts from "./PaginationStatusAlerts";
+
+describe("PaginationStatusAlerts", () => {
+  it("shows page progress and wires the Stop button while fetching", () => {
+    const cancel = vi.fn();
+    const { getByRole, getByText } = render(
+      <PaginationStatusAlerts
+        isFetchingMore={true}
+        cancelled={false}
+        progress={{ currentPage: 7, totalPages: 42 }}
+        cancel={cancel}
+      />,
+    );
+
+    expect(getByText(/Currently fetching spend data: fetched 7 \/ 42 pages/)).toBeInTheDocument();
+    fireEvent.click(getByRole("button", { name: "Stop" }));
+    expect(cancel).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows the partial-data notice after a cancel, frozen at the last fetched page", () => {
+    const { getByText } = render(
+      <PaginationStatusAlerts
+        isFetchingMore={false}
+        cancelled={true}
+        progress={{ currentPage: 7, totalPages: 42 }}
+        cancel={vi.fn()}
+      />,
+    );
+
+    expect(getByText("Showing partial spend data (7/42 pages loaded)")).toBeInTheDocument();
+  });
+
+  it("names the subject it is fetching", () => {
+    const { getByText } = render(
+      <PaginationStatusAlerts
+        isFetchingMore={true}
+        cancelled={false}
+        progress={{ currentPage: 1, totalPages: 3 }}
+        cancel={vi.fn()}
+        subject="agent data"
+      />,
+    );
+
+    expect(getByText(/Currently fetching agent data: fetched 1 \/ 3 pages/)).toBeInTheDocument();
+  });
+
+  it("renders nothing when idle", () => {
+    const { container } = render(
+      <PaginationStatusAlerts
+        isFetchingMore={false}
+        cancelled={false}
+        progress={{ currentPage: 1, totalPages: 1 }}
+        cancel={vi.fn()}
+      />,
+    );
+
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/ui/litellm-dashboard/src/components/shared/PaginationStatusAlerts.tsx
+++ b/ui/litellm-dashboard/src/components/shared/PaginationStatusAlerts.tsx
@@ -11,12 +11,6 @@ interface PaginationStatusAlertsProps {
   subject?: string;
 }
 
-/**
- * The fetching-progress and partial-data banners shown while a daily activity
- * range streams in page by page. Rendered wherever usePaginatedDailyActivity
- * falls back to pagination; both banners stay hidden on the single-shot
- * aggregated path because it never sets isFetchingMore or cancelled.
- */
 const PaginationStatusAlerts = ({
   isFetchingMore,
   cancelled,

--- a/ui/litellm-dashboard/src/components/shared/PaginationStatusAlerts.tsx
+++ b/ui/litellm-dashboard/src/components/shared/PaginationStatusAlerts.tsx
@@ -1,0 +1,57 @@
+import { ExternalLink, Loader2 } from "lucide-react";
+
+import { Alert, AlertDescription } from "@/components/shared/Alert";
+import { Button } from "@/components/ui/button";
+
+interface PaginationStatusAlertsProps {
+  isFetchingMore: boolean;
+  cancelled: boolean;
+  progress: { currentPage: number; totalPages: number };
+  cancel: () => void;
+  subject?: string;
+}
+
+/**
+ * The fetching-progress and partial-data banners shown while a daily activity
+ * range streams in page by page. Rendered wherever usePaginatedDailyActivity
+ * falls back to pagination; both banners stay hidden on the single-shot
+ * aggregated path because it never sets isFetchingMore or cancelled.
+ */
+const PaginationStatusAlerts = ({
+  isFetchingMore,
+  cancelled,
+  progress,
+  cancel,
+  subject = "spend data",
+}: PaginationStatusAlertsProps) => (
+  <>
+    {isFetchingMore && (
+      <Alert variant="warning" className="mb-2">
+        <AlertDescription className="flex items-center justify-between text-inherit">
+          <span>
+            <Loader2 className="mr-2 inline size-4 animate-spin align-text-bottom" />
+            Currently fetching {subject}: fetched {progress.currentPage} / {progress.totalPages} pages. Charts will
+            update periodically as data loads. Moving off of this page will stop and reset this. To continue using the
+            UI in the meantime,{" "}
+            <a href={window.location.href} target="_blank" rel="noopener noreferrer">
+              open a new tab <ExternalLink className="inline size-3.5 align-text-bottom" />
+            </a>
+            .
+          </span>
+          <Button variant="destructive" onClick={cancel}>
+            Stop
+          </Button>
+        </AlertDescription>
+      </Alert>
+    )}
+    {cancelled && (
+      <Alert variant="info" className="mb-2">
+        <AlertDescription className="text-inherit">
+          Showing partial {subject} ({progress.currentPage}/{progress.totalPages} pages loaded)
+        </AlertDescription>
+      </Alert>
+    )}
+  </>
+);
+
+export default PaginationStatusAlerts;


### PR DESCRIPTION
## TLDR

Problem this solves:

- Cost Optimization gave no sign data was still streaming in
- Values and cache leakage tables silently churned during fallback loads
- No way to stop a long paginated load

How it solves it:

- Page now shows the Usage page's fetch-progress banner with a Stop button
- Cache leakage tables say they are still filling in mid-stream
- Banner extracted into one shared component, deleting three inline copies

## User Flow

Before: during a slow load the user watches numbers change with no explanation and no way out

1. They open http://localhost:4000/ui/cost-optimization on a deployment where the single-shot summary endpoint is failing, so the page loads the range page by page
2. Every card and chart keeps shifting for the whole load, and the only hint is a small "Loading..." under one card
3. They open the Prompt Caching tab and the Cache leakage table shows full-looking rows whose token counts and ordering keep reshuffling as pages arrive
4. Nothing on the page offers a way to stop the load short of navigating away

After: the same degraded load announces itself, reports progress, and can be stopped

1. They open http://localhost:4000/ui/cost-optimization under the same failing summary endpoint
2. A banner appears above the tabs: "Currently fetching spend data: fetched 4 / 30 pages", with a Stop button and a link to keep working in a new tab
3. The Prompt Caching tab's Cache leakage table carries a note that data is still loading and rows will update as the rest of the range arrives
4. Clicking Stop halts the load and the banner switches to "Showing partial spend data (16/30 pages loaded)"
5. On a healthy deployment nothing changes: the page loads in one request and no banner ever appears

## Relevant issues

- Surfaces the paginated fallback on Cost Optimization: progress banner, Stop button, and a still-loading note on the cache leakage tables (Pylon #7539)
- Extracts the Usage page's fetch banner into a shared PaginationStatusAlerts component, replacing three near-verbatim inline copies
- Companion to #37643, which fixed the data-correctness half of the same customer report

## Linear ticket

Resolves LIT-5700

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Setup: live proxy on localhost:4000 backed by real Postgres, LiteLLM_DailyUserSpend seeded with 29,002 rows across four dates so the range spans 30 pages at the UI's page size. The fallback legs force the aggregated route to return 500 (the route was temporarily patched in the running rig to raise, identically for Before and After); the happy-path legs run the unmodified route

### Before (c164944d40)

#### Fallback streams silently with no progress or cancel

1. Open http://localhost:4000/ui/cost-optimization while `curl -s -o /dev/null -w "%{http_code}" "http://localhost:4000/user/daily/activity/aggregated?start_date=2026-08-10&end_date=2026-08-17&timezone=420" -H "Authorization: Bearer sk-1234"` returns 500
2. The network log shows the aggregated call fail once, then GET /user/daily/activity page by page; the only visible hint is "Loading..." under the Total saved card while every number climbs for ~12 seconds
3. The page's only role=alert element is the static "This is an experimental dashboard" note, so there is no progress indication and no way to stop the load

#### Cache leakage table presents partial rows as final

1. Mid-stream, open the Prompt Caching tab
2. The Cache leakage by virtual key table renders full-looking rows with no loading indication, and two screenshots seconds apart show the token counts reshuffling (944,400 then 1,070,000 for the top key)

### After (8425b570b6)

#### Fallback streams silently with no progress or cancel

1. Same forced-500 rig, same reload of http://localhost:4000/ui/cost-optimization
2. A warning banner renders above the tabs: "Currently fetching spend data: fetched 4 / 30 pages. Charts will update periodically as data loads..." with a Stop button
3. Clicking Stop halts the stream and swaps the banner to "Showing partial spend data (16/30 pages loaded)"

#### Cache leakage table presents partial rows as final

1. Mid-stream, the Prompt Caching tab's table now shows "Data is still loading; rows and totals will update as the rest of the range arrives." directly above the rows

#### Happy path unchanged

1. Restore the unmodified aggregated route and reload the page
2. The network log shows exactly one request, GET /user/daily/activity/aggregated returning 200, and a DOM probe confirms no fetch banner exists (`document.body.textContent.includes("Currently fetching spend data")` is false)

## Type

🐛 Bug Fix

## Caveats (if any)

- Usage page banner text changes one word: the post-cancel notice now reads "Showing partial spend data" instead of "Showing partial data", a deliberate unification from the shared component's subject prop
- Open PR #36022 adds failed/incomplete surfacing around the same Usage page banner area and will need a small rebase over the extraction

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only loading/status presentation; no auth, data, or fetch-logic changes beyond forwarding existing hook fields.
> 
> **Overview**
> When Cost Optimization falls back to page-by-page daily activity, the page now shows the same fetch-progress banner and Stop control as Usage, instead of silently reshuffling numbers.
> 
> `useDailyActivityRange` forwards `progress`, `cancelled`, and `cancel` from the paginated hook. Cache leakage tables add a still-loading note while extra pages stream in (not during a full range reload).
> 
> The duplicated Usage/EntityUsage banners are extracted into shared `PaginationStatusAlerts` (optional `subject` for agent vs spend data). Happy-path single-shot loads still show no banner.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8425b570b688ade015a985d1a1a174aa25260f48. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->