### PR TITLE
fix(cost): bill audio input tokens at base rate when model has no audio price

### DIFF
--- a/litellm/litellm_core_utils/llm_cost_calc/utils.py
+++ b/litellm/litellm_core_utils/llm_cost_calc/utils.py
@@ -662,7 +662,13 @@ def _calculate_input_cost(
 
     ### AUDIO COST
     if prompt_tokens_details["audio_tokens"]:
-        audio_cost_key: Final = _get_service_tier_cost_key("input_cost_per_audio_token", service_tier)
+        tier_audio_cost_key: Final = _get_service_tier_cost_key("input_cost_per_audio_token", service_tier)
+        has_audio_price: Final = (
+            model_info.get(tier_audio_cost_key) is not None
+            or model_info.get("input_cost_per_audio_token") is not None
+            or model_info.get("input_cost_per_audio_per_second") is not None
+        )
+        audio_cost_key: Final = tier_audio_cost_key if has_audio_price else "input_cost_per_token"
         prompt_cost += calculate_cost_component(model_info, audio_cost_key, prompt_tokens_details["audio_tokens"])
 
     ### IMAGE TOKEN COST

--- a/tests/test_litellm/litellm_core_utils/llm_cost_calc/test_llm_cost_calc_utils.py
+++ b/tests/test_litellm/litellm_core_utils/llm_cost_calc/test_llm_cost_calc_utils.py
@@ -1476,6 +1476,59 @@ def test_string_cost_values_edge_cases():
     assert round(completion_cost, 12) == round(expected_completion_cost, 12)
 
 
+def test_audio_input_tokens_fall_back_to_base_rate_when_no_audio_price():
+    """Audio input tokens must bill at input_cost_per_token when the model has no audio rate.
+
+    Regression: models like gemini-2.5-pro report audio prompt tokens separately from text
+    but ship without input_cost_per_audio_token, which previously billed those tokens at $0.
+    """
+    model_info: ModelInfo = {
+        "input_cost_per_token": 1.25e-6,
+        "output_cost_per_token": 1e-5,
+    }
+
+    usage = Usage(
+        prompt_tokens=9700,
+        completion_tokens=0,
+        total_tokens=9700,
+        prompt_tokens_details=PromptTokensDetailsWrapper(
+            audio_tokens=9600, cached_tokens=0, text_tokens=100, image_tokens=None
+        ),
+    )
+
+    prompt_cost, _ = generic_cost_per_token(
+        model="gemini-2.5-pro", usage=usage, custom_llm_provider="vertex_ai", model_info=model_info
+    )
+
+    expected_prompt_cost = (100 + 9600) * 1.25e-6
+    assert round(prompt_cost, 12) == round(expected_prompt_cost, 12)
+
+
+def test_audio_input_tokens_use_audio_rate_when_present():
+    """When input_cost_per_audio_token exists it takes precedence over the base rate."""
+    model_info: ModelInfo = {
+        "input_cost_per_token": 1.25e-6,
+        "input_cost_per_audio_token": 5e-6,
+        "output_cost_per_token": 1e-5,
+    }
+
+    usage = Usage(
+        prompt_tokens=9700,
+        completion_tokens=0,
+        total_tokens=9700,
+        prompt_tokens_details=PromptTokensDetailsWrapper(
+            audio_tokens=9600, cached_tokens=0, text_tokens=100, image_tokens=None
+        ),
+    )
+
+    prompt_cost, _ = generic_cost_per_token(
+        model="gemini-2.5-pro", usage=usage, custom_llm_provider="vertex_ai", model_info=model_info
+    )
+
+    expected_prompt_cost = 100 * 1.25e-6 + 9600 * 5e-6
+    assert round(prompt_cost, 12) == round(expected_prompt_cost, 12)
+
+
 def test_string_cost_values_with_threshold():
     """Test that string cost values work correctly with threshold pricing."""
     from unittest.mock import patch


### PR DESCRIPTION
## TLDR

Problem this solves:

- audio input (prompt) tokens are billed at $0 for models that have no `input_cost_per_audio_token`
- 37 shipped models (gemini-2.5-pro, gemini-3-pro-preview, vertex gemini-3.x-flash, xai grok-4-1-fast) undercharge the audio portion by ~97x

How it solves it:

- fall back to `input_cost_per_token` for audio input tokens when the model has no audio-specific rate, mirroring the image and video branches

## Relevant issues

## Type

🐛 Bug Fix

## Changes

In `generic_cost_per_token`, audio prompt tokens are subtracted out of the text bucket and then priced by `_calculate_input_cost` through `input_cost_per_audio_token`. That branch had no fallback, so a model that declares `supports_audio_input` and a non-zero `input_cost_per_token` but no `input_cost_per_audio_token` billed its audio prompt tokens at $0. Image and video input tokens already fall back to `input_cost_per_token`, and output audio falls back to the base completion rate; input audio was the lone exception. This adds the same fallback: when no audio-specific key is present, audio input bills at `input_cost_per_token`. The check reads the raw `model_info` value, so a present-but-unparseable audio price still resolves to 0 and the existing edge-case behavior is preserved.

## Screenshots / Proof of Fix

For `gemini-2.5-pro` with ~9,600 audio prompt tokens plus 100 text tokens, input cost goes from `$0.000125` (audio billed at 0) to `$0.012125` (audio billed at the base rate). Two regression tests were added: the first fails on the unpatched code and passes after; the second confirms an explicit `input_cost_per_audio_token` still takes precedence so the fallback never over-applies. The full test file passes (172/172).

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
