### PR TITLE
feat(ui): let admins supply a dark-mode variant of their custom logo

### DIFF
--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -15255,6 +15255,29 @@ def get_logo_url():
     return {"logo_url": ""}
 
 
+def _serve_custom_ui_logo(candidate: str) -> Response | None:
+    """Serve one admin-configured logo, or None when it is unusable so the caller falls back."""
+    from litellm.proxy.common_utils.static_asset_utils import (
+        resolve_validated_local_image_path,
+    )
+
+    # Remote logo URLs are loaded by the browser. The proxy should not fetch
+    # arbitrary admin-configured URLs server-side.
+    if candidate.startswith(("http://", "https://")):
+        return RedirectResponse(url=candidate)
+
+    safe_logo: Final = resolve_validated_local_image_path(candidate)
+    if safe_logo is None:
+        verbose_proxy_logger.warning(
+            "Custom UI logo %r is not a supported image file or does not exist, falling back",
+            candidate,
+        )
+        return None
+
+    safe_logo_path, media_type = safe_logo
+    return FileResponse(safe_logo_path, media_type=media_type)
+
+
 @app.get("/get_image", include_in_schema=False)
 async def get_image(theme: Literal["light", "dark"] | None = None):
     """Get logo to show on admin UI"""
@@ -15293,31 +15316,33 @@ async def get_image(theme: Literal["light", "dark"] | None = None):
     if assets_dir != current_dir and not os.path.exists(default_logo):
         default_logo = default_site_logo
 
-    logo_path = os.getenv("UI_LOGO_PATH", default_logo)
-    verbose_proxy_logger.debug("Reading logo from path: %s", logo_path)
+    custom_logo_candidates: Final = tuple(
+        candidate.strip()
+        for candidate in (
+            os.getenv("UI_LOGO_PATH_DARK", "") if theme == "dark" else "",
+            os.getenv("UI_LOGO_PATH", ""),
+        )
+        if candidate.strip()
+    )
+    verbose_proxy_logger.debug("Custom logo candidates, in fallback order: %s", custom_logo_candidates)
+
+    custom_logo_response: Final = next(
+        (
+            response
+            for response in (_serve_custom_ui_logo(candidate) for candidate in custom_logo_candidates)
+            if response is not None
+        ),
+        None,
+    )
+    if custom_logo_response is not None:
+        return custom_logo_response
 
     from litellm.proxy.common_utils.static_asset_utils import (
         resolve_validated_local_image_path,
     )
 
-    if logo_path != default_logo and not logo_path.startswith(("http://", "https://")):
-        safe_logo = resolve_validated_local_image_path(logo_path)
-        if safe_logo is not None:
-            safe_logo_path, media_type = safe_logo
-            return FileResponse(safe_logo_path, media_type=media_type)
-        verbose_proxy_logger.warning(
-            "UI_LOGO_PATH %r is not a supported image file or does not exist, falling back to default logo",
-            logo_path,
-        )
-        logo_path = default_logo
-
-    # Remote logo URLs are loaded by the browser. The proxy should not fetch
-    # arbitrary admin-configured URLs server-side.
-    if logo_path.startswith(("http://", "https://")):
-        return RedirectResponse(url=logo_path)
-
     # Default logo (resolved from the bundled asset, not user-controlled).
-    safe_logo = resolve_validated_local_image_path(logo_path)
+    safe_logo: Final = resolve_validated_local_image_path(default_logo)
     if safe_logo is not None:
         safe_logo_path, media_type = safe_logo
         return FileResponse(safe_logo_path, media_type=media_type)

--- a/litellm/proxy/ui_crud_endpoints/proxy_setting_endpoints.py
+++ b/litellm/proxy/ui_crud_endpoints/proxy_setting_endpoints.py
@@ -110,6 +110,7 @@ def _config_param_db(repo: _HasConfigParamTable) -> _PrismaTableActions[_ConfigP
 # reflect a deployment branded purely through process env.
 _UI_THEME_FIELD_ENV_VARS: Final[dict[str, str]] = {
     "logo_url": "UI_LOGO_PATH",
+    "logo_url_dark": "UI_LOGO_PATH_DARK",
     "favicon_url": "LITELLM_FAVICON_URL",
 }
 
@@ -154,6 +155,14 @@ class UIThemeConfig(BaseModel):
     logo_url: str | None = Field(
         default=None,
         description="URL or path to custom logo image. Can be a local file path or HTTP/HTTPS URL",
+    )
+
+    logo_url_dark: str | None = Field(
+        default=None,
+        description=(
+            "URL or path to a custom logo image for dark mode. Can be a local file path or HTTP/HTTPS URL. "
+            "Leave unset to reuse logo_url in dark mode"
+        ),
     )
 
     # Favicon configuration
@@ -1184,6 +1193,7 @@ async def update_ui_theme_settings(
     )
 
     _validate_public_image_url(theme_config.logo_url, "logo_url")
+    _validate_public_image_url(theme_config.logo_url_dark, "logo_url_dark")
     _validate_public_image_url(theme_config.favicon_url, "favicon_url")
 
     if store_model_in_db is not True:
@@ -1204,16 +1214,18 @@ async def update_ui_theme_settings(
         config["litellm_settings"] = {}
     config["litellm_settings"]["ui_theme_config"] = theme_data
 
-    # UI_LOGO_PATH and LITELLM_FAVICON_URL are the only environment variables
-    # this endpoint owns. A non-empty value sets the var; an empty or missing
-    # one clears it back to the default. Apply to the live process immediately,
-    # then persist only these two keys so an unrelated env var (a YAML/OS value
-    # merged in by get_config) is never snapshotted into the DB.
+    # The vars below are the only environment variables this endpoint owns, and
+    # they must stay in step with _UI_THEME_FIELD_ENV_VARS. A non-empty value
+    # sets the var; an empty or missing one clears it back to the default. Apply
+    # to the live process immediately, then persist only those keys so an
+    # unrelated env var (a YAML/OS value merged in by get_config) is never
+    # snapshotted into the DB.
     def _clean(url: str | None) -> str | None:
         return url if url is not None and url.strip() else None
 
     env_updates: Final[dict[str, str | None]] = {
         "UI_LOGO_PATH": _clean(theme_config.logo_url),
+        "UI_LOGO_PATH_DARK": _clean(theme_config.logo_url_dark),
         "LITELLM_FAVICON_URL": _clean(theme_config.favicon_url),
     }
     for env_key, env_value in env_updates.items():

--- a/tests/test_litellm/proxy/proxy_server/test_routes_misc.py
+++ b/tests/test_litellm/proxy/proxy_server/test_routes_misc.py
@@ -225,14 +225,72 @@ def test_get_image_without_theme_still_serves_the_light_jpeg(client, monkeypatch
 
 
 def test_get_image_dark_theme_keeps_serving_a_custom_ui_logo(client, monkeypatch, tmp_path):
-    """A custom UI_LOGO_PATH has no dark variant yet, so dark mode must fall back to the
-    admin's own logo rather than replacing it with LiteLLM's."""
+    """With no UI_LOGO_PATH_DARK set, dark mode falls back to the admin's own light logo
+    rather than replacing their branding with LiteLLM's."""
     custom_logo = tmp_path / "custom.png"
     custom_logo.write_bytes(PNG_SIGNATURE + b"custom-logo-marker")
     monkeypatch.setenv("UI_LOGO_PATH", str(custom_logo))
     response = client.get("/get_image", params={"theme": "dark"})
     shape = {"status": response.status_code, "body": response.content}
     assert shape == {"status": 200, "body": PNG_SIGNATURE + b"custom-logo-marker"}
+
+
+def test_get_image_dark_theme_prefers_the_dark_custom_logo(client, monkeypatch, tmp_path):
+    """UI_LOGO_PATH_DARK outranks UI_LOGO_PATH when the dark logo is requested."""
+    light_logo = tmp_path / "light.png"
+    light_logo.write_bytes(PNG_SIGNATURE + b"light-marker")
+    dark_logo = tmp_path / "dark.png"
+    dark_logo.write_bytes(PNG_SIGNATURE + b"dark-marker")
+    monkeypatch.setenv("UI_LOGO_PATH", str(light_logo))
+    monkeypatch.setenv("UI_LOGO_PATH_DARK", str(dark_logo))
+
+    response = client.get("/get_image", params={"theme": "dark"})
+
+    shape = {"status": response.status_code, "body": response.content}
+    assert shape == {"status": 200, "body": PNG_SIGNATURE + b"dark-marker"}
+
+
+def test_get_image_unusable_dark_logo_falls_back_to_the_light_custom_logo(client, monkeypatch, tmp_path):
+    """A broken UI_LOGO_PATH_DARK must not drop the admin all the way to LiteLLM's own
+    logo while their light logo is still perfectly serviceable."""
+    light_logo = tmp_path / "light.png"
+    light_logo.write_bytes(PNG_SIGNATURE + b"light-marker")
+    monkeypatch.setenv("UI_LOGO_PATH", str(light_logo))
+    monkeypatch.setenv("UI_LOGO_PATH_DARK", str(tmp_path / "missing.png"))
+
+    response = client.get("/get_image", params={"theme": "dark"})
+
+    shape = {"status": response.status_code, "body": response.content}
+    assert shape == {"status": 200, "body": PNG_SIGNATURE + b"light-marker"}
+
+
+def test_get_image_light_theme_ignores_the_dark_custom_logo(client, monkeypatch, tmp_path):
+    """The dark logo must never leak into a light-mode request."""
+    light_logo = tmp_path / "light.png"
+    light_logo.write_bytes(PNG_SIGNATURE + b"light-marker")
+    dark_logo = tmp_path / "dark.png"
+    dark_logo.write_bytes(PNG_SIGNATURE + b"dark-marker")
+    monkeypatch.setenv("UI_LOGO_PATH", str(light_logo))
+    monkeypatch.setenv("UI_LOGO_PATH_DARK", str(dark_logo))
+
+    response = client.get("/get_image")
+
+    shape = {"status": response.status_code, "body": response.content}
+    assert shape == {"status": 200, "body": PNG_SIGNATURE + b"light-marker"}
+
+
+def test_get_image_dark_logo_alone_still_serves_the_bundled_light_logo_in_light_mode(client, monkeypatch):
+    """Setting only UI_LOGO_PATH_DARK leaves light mode on the bundled default."""
+    monkeypatch.delenv("UI_LOGO_PATH", raising=False)
+    monkeypatch.setenv("UI_LOGO_PATH_DARK", "https://cdn.example.invalid/logo-dark.png")
+
+    response = client.get("/get_image")
+
+    shape = {
+        "status": response.status_code,
+        "media_type": response.headers.get("content-type", "").split(";")[0],
+    }
+    assert shape == {"status": 200, "media_type": "image/jpeg"}
 
 
 def test_get_image_redirects_remote_url(client, monkeypatch):

--- a/tests/test_litellm/proxy/ui_crud_endpoints/test_proxy_setting_endpoints.py
+++ b/tests/test_litellm/proxy/ui_crud_endpoints/test_proxy_setting_endpoints.py
@@ -1064,11 +1064,15 @@ class TestProxySettingEndpoints:
         assert mock_proxy_config["save_call_count"]() == 1
 
         # env vars are persisted through the dedicated per-key path, and ONLY
-        # the two keys this endpoint owns are touched. The unrelated SSO env
+        # the keys this endpoint owns are touched. The unrelated SSO env
         # vars in the merged config are never snapshotted.
         env_updates = mock_proxy_config["env_updates"]()
         assert env_updates == [
-            {"UI_LOGO_PATH": "https://example.com/new-logo.png", "LITELLM_FAVICON_URL": None}
+            {
+                "UI_LOGO_PATH": "https://example.com/new-logo.png",
+                "UI_LOGO_PATH_DARK": None,
+                "LITELLM_FAVICON_URL": None,
+            }
         ]
 
     def test_update_ui_theme_settings_with_favicon(
@@ -1097,13 +1101,89 @@ class TestProxySettingEndpoints:
 
         assert os.environ["UI_LOGO_PATH"] == "https://example.com/new-logo.png"
         assert os.environ["LITELLM_FAVICON_URL"] == "https://example.com/custom-favicon.ico"
-        # Only the two owned keys are persisted, both with their new values
+        # Only the owned keys are persisted, each with its new value
         assert mock_proxy_config["env_updates"]() == [
             {
                 "UI_LOGO_PATH": "https://example.com/new-logo.png",
+                "UI_LOGO_PATH_DARK": None,
                 "LITELLM_FAVICON_URL": "https://example.com/custom-favicon.ico",
             }
         ]
+
+    def test_update_ui_theme_settings_with_dark_logo(
+        self, mock_proxy_config, mock_auth, monkeypatch
+    ):
+        """A dark-mode logo is stored and applied to the live process like the light one."""
+        monkeypatch.setenv("LITELLM_SALT_KEY", "test_salt_key")
+        monkeypatch.setattr("litellm.proxy.proxy_server.store_model_in_db", True)
+
+        new_theme = {
+            "logo_url": "https://example.com/logo.png",
+            "logo_url_dark": "https://example.com/logo-dark.png",
+        }
+
+        response = client.patch("/update/ui_theme_settings", json=new_theme)
+
+        assert response.status_code == 200
+        assert response.json()["theme_config"]["logo_url_dark"] == "https://example.com/logo-dark.png"
+        assert os.environ["UI_LOGO_PATH_DARK"] == "https://example.com/logo-dark.png"
+        assert mock_proxy_config["env_updates"]() == [
+            {
+                "UI_LOGO_PATH": "https://example.com/logo.png",
+                "UI_LOGO_PATH_DARK": "https://example.com/logo-dark.png",
+                "LITELLM_FAVICON_URL": None,
+            }
+        ]
+
+    def test_update_ui_theme_settings_rejects_local_path_dark_logo(
+        self, mock_proxy_config, mock_auth, monkeypatch
+    ):
+        """The dark logo is served by the unauthenticated /get_image, so a local
+        filesystem path must be refused exactly as it is for the light logo."""
+        monkeypatch.setenv("LITELLM_SALT_KEY", "test_salt_key")
+        monkeypatch.setattr("litellm.proxy.proxy_server.store_model_in_db", True)
+
+        response = client.patch(
+            "/update/ui_theme_settings",
+            json={"logo_url_dark": "/etc/passwd"},
+        )
+
+        assert response.status_code == 400
+        assert "logo_url_dark" in str(response.json())
+
+    def test_update_ui_theme_settings_persists_every_env_var_it_resolves(
+        self, mock_proxy_config, mock_auth, monkeypatch
+    ):
+        """Read and write must cover the same env vars.
+
+        /get/ui_theme_settings resolves each field through _UI_THEME_FIELD_ENV_VARS,
+        so a var missing from the update path would read back from an env value the
+        save never cleared, and the settings page would show a field it cannot unset.
+        """
+        from litellm.proxy.ui_crud_endpoints.proxy_setting_endpoints import (
+            _UI_THEME_FIELD_ENV_VARS,
+        )
+
+        monkeypatch.setenv("LITELLM_SALT_KEY", "test_salt_key")
+        monkeypatch.setattr("litellm.proxy.proxy_server.store_model_in_db", True)
+
+        response = client.patch("/update/ui_theme_settings", json={})
+
+        assert response.status_code == 200
+        persisted = mock_proxy_config["env_updates"]()
+        assert len(persisted) == 1
+        assert set(persisted[0]) == set(_UI_THEME_FIELD_ENV_VARS.values())
+
+    def test_get_ui_theme_settings_surfaces_dark_logo_from_process_env(
+        self, mock_proxy_config, monkeypatch
+    ):
+        """A dark logo supplied only as a process env var must surface in the read."""
+        monkeypatch.setenv("UI_LOGO_PATH_DARK", "https://cdn.example.com/logo-dark.png")
+
+        response = client.get("/get/ui_theme_settings")
+
+        assert response.status_code == 200
+        assert response.json()["values"]["logo_url_dark"] == "https://cdn.example.com/logo-dark.png"
 
     def test_update_ui_theme_settings_clear_favicon(
         self, mock_proxy_config, mock_auth, monkeypatch

--- a/ui/litellm-dashboard/src/app/(dashboard)/ui-theme/UIThemeSettings.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/ui-theme/UIThemeSettings.test.tsx
@@ -7,10 +7,18 @@ import { toast } from "@/lib/toast";
 import UIThemeSettings from "./UIThemeSettings";
 
 const setLogoUrl = vi.fn();
+const setLogoUrlDark = vi.fn();
 const setFaviconUrl = vi.fn();
 
 vi.mock("@/contexts/ThemeContext", () => ({
-  useTheme: () => ({ logoUrl: null, setLogoUrl, faviconUrl: null, setFaviconUrl }),
+  useTheme: () => ({
+    logoUrl: null,
+    setLogoUrl,
+    logoUrlDark: null,
+    setLogoUrlDark,
+    faviconUrl: null,
+    setFaviconUrl,
+  }),
 }));
 
 vi.mock("@/components/networking", () => ({
@@ -19,6 +27,7 @@ vi.mock("@/components/networking", () => ({
 }));
 
 const LOGO_PLACEHOLDER = "https://example.com/logo.png";
+const LOGO_DARK_PLACEHOLDER = "https://example.com/logo-dark.png";
 const FAVICON_PLACEHOLDER = "https://example.com/favicon.ico";
 
 const okResponse = (values: Record<string, string | null> = {}) =>
@@ -76,9 +85,30 @@ describe("UIThemeSettings", () => {
     await waitFor(() => expect(patchCalls()).toHaveLength(1));
     expect(bodyOf(patchCalls()[0])).toEqual({
       logo_url: "https://a.test/logo.png",
+      logo_url_dark: null,
       favicon_url: "https://a.test/fav.ico",
     });
     await waitFor(() => expect(toast.success).toHaveBeenCalledWith("Theme settings updated successfully!"));
+  });
+
+  it("should load and save a separate dark-mode logo url", async () => {
+    const user = userEvent.setup();
+    fetchMock.mockImplementation(() => okResponse({ logo_url_dark: "https://cdn.example.com/logo-dark.svg" }));
+
+    render(<UIThemeSettings userID="user-1" userRole="Admin" accessToken="sk-test" />);
+
+    await waitFor(() => {
+      expect(screen.getByPlaceholderText(LOGO_DARK_PLACEHOLDER)).toHaveValue("https://cdn.example.com/logo-dark.svg");
+    });
+    expect(setLogoUrlDark).toHaveBeenCalledWith("https://cdn.example.com/logo-dark.svg");
+
+    fireEvent.change(screen.getByPlaceholderText(LOGO_DARK_PLACEHOLDER), {
+      target: { value: "https://a.test/logo-dark.png" },
+    });
+    await user.click(screen.getByRole("button", { name: "Save Changes" }));
+
+    await waitFor(() => expect(patchCalls()).toHaveLength(1));
+    expect(bodyOf(patchCalls()[0]).logo_url_dark).toBe("https://a.test/logo-dark.png");
   });
 
   it("should surface a backend failure when saving fails", async () => {
@@ -109,10 +139,12 @@ describe("UIThemeSettings", () => {
     await user.click(screen.getByRole("button", { name: "Reset to Default" }));
 
     await waitFor(() => expect(patchCalls()).toHaveLength(1));
-    expect(bodyOf(patchCalls()[0])).toEqual({ logo_url: null, favicon_url: null });
+    expect(bodyOf(patchCalls()[0])).toEqual({ logo_url: null, logo_url_dark: null, favicon_url: null });
     expect(screen.getByPlaceholderText(LOGO_PLACEHOLDER)).toHaveValue("");
+    expect(screen.getByPlaceholderText(LOGO_DARK_PLACEHOLDER)).toHaveValue("");
     expect(screen.getByPlaceholderText(FAVICON_PLACEHOLDER)).toHaveValue("");
     expect(setLogoUrl).toHaveBeenLastCalledWith(null);
+    expect(setLogoUrlDark).toHaveBeenLastCalledWith(null);
     expect(setFaviconUrl).toHaveBeenLastCalledWith(null);
     await waitFor(() => expect(toast.success).toHaveBeenCalledWith("Theme settings reset to default!"));
   });

--- a/ui/litellm-dashboard/src/app/(dashboard)/ui-theme/UIThemeSettings.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/ui-theme/UIThemeSettings.tsx
@@ -15,8 +15,9 @@ interface UIThemeSettingsProps {
 }
 
 const UIThemeSettings: React.FC<UIThemeSettingsProps> = ({ userID, userRole, accessToken }) => {
-  const { setLogoUrl, setFaviconUrl } = useTheme();
+  const { setLogoUrl, setLogoUrlDark, setFaviconUrl } = useTheme();
   const [logoUrlInput, setLogoUrlInput] = useState<string>("");
+  const [logoUrlDarkInput, setLogoUrlDarkInput] = useState<string>("");
   const [faviconUrlInput, setFaviconUrlInput] = useState<string>("");
   const [loading, setLoading] = useState(false);
 
@@ -40,8 +41,10 @@ const UIThemeSettings: React.FC<UIThemeSettingsProps> = ({ userID, userRole, acc
       if (response.ok) {
         const data = await response.json();
         setLogoUrlInput(data.values?.logo_url || "");
+        setLogoUrlDarkInput(data.values?.logo_url_dark || "");
         setFaviconUrlInput(data.values?.favicon_url || "");
         setLogoUrl(data.values?.logo_url || null);
+        setLogoUrlDark(data.values?.logo_url_dark || null);
         setFaviconUrl(data.values?.favicon_url || null);
       }
     } catch (error) {
@@ -62,12 +65,14 @@ const UIThemeSettings: React.FC<UIThemeSettingsProps> = ({ userID, userRole, acc
         },
         body: JSON.stringify({
           logo_url: logoUrlInput || null,
+          logo_url_dark: logoUrlDarkInput || null,
           favicon_url: faviconUrlInput || null,
         }),
       });
       if (response.ok) {
         toast.success("Theme settings updated successfully!");
         setLogoUrl(logoUrlInput || null);
+        setLogoUrlDark(logoUrlDarkInput || null);
         setFaviconUrl(faviconUrlInput || null);
       } else {
         throw new Error("Failed to update settings");
@@ -82,8 +87,10 @@ const UIThemeSettings: React.FC<UIThemeSettingsProps> = ({ userID, userRole, acc
 
   const handleReset = async () => {
     setLogoUrlInput("");
+    setLogoUrlDarkInput("");
     setFaviconUrlInput("");
     setLogoUrl(null);
+    setLogoUrlDark(null);
     setFaviconUrl(null);
     setLoading(true);
     try {
@@ -95,7 +102,7 @@ const UIThemeSettings: React.FC<UIThemeSettingsProps> = ({ userID, userRole, acc
           [getGlobalLitellmHeaderName()]: `Bearer ${accessToken}`,
           "Content-Type": "application/json",
         },
-        body: JSON.stringify({ logo_url: null, favicon_url: null }),
+        body: JSON.stringify({ logo_url: null, logo_url_dark: null, favicon_url: null }),
       });
       if (response.ok) {
         toast.success("Theme settings reset to default!");
@@ -139,6 +146,23 @@ const UIThemeSettings: React.FC<UIThemeSettingsProps> = ({ userID, userRole, acc
             />
             <p className="mt-1 text-xs text-muted-foreground">
               Enter a URL for your custom logo or leave empty for default
+            </p>
+          </div>
+          <div>
+            <Label htmlFor="ui-theme-logo-url-dark" className="mb-2">
+              Custom Logo URL (dark mode)
+            </Label>
+            <Input
+              id="ui-theme-logo-url-dark"
+              placeholder="https://example.com/logo-dark.png"
+              value={logoUrlDarkInput}
+              onChange={(event) => {
+                setLogoUrlDarkInput(event.target.value);
+                setLogoUrlDark(event.target.value || null);
+              }}
+            />
+            <p className="mt-1 text-xs text-muted-foreground">
+              Enter a URL for a logo suited to dark backgrounds, or leave empty to reuse the logo above
             </p>
           </div>
           <div>

--- a/ui/litellm-dashboard/src/components/leftnav.test.tsx
+++ b/ui/litellm-dashboard/src/components/leftnav.test.tsx
@@ -154,6 +154,22 @@ describe("Sidebar (leftnav)", () => {
     expect(dark).toHaveAttribute("src", "https://cdn.example.com/logo.png");
   });
 
+  it("falls back to the light logo when a configured dark logo fails to load", () => {
+    mockUseThemeImpl = () => ({
+      ...unbrandedTheme(),
+      logoUrl: "https://cdn.example.com/logo.png",
+      logoUrlDark: "https://cdn.example.com/gone.png",
+    });
+    renderWithProviders(<Sidebar {...defaultProps} />);
+
+    const [, dark] = Array.from(screen.getByRole("link", { name: /litellm home/i }).querySelectorAll("img"));
+    expect(dark).toHaveAttribute("src", "https://cdn.example.com/gone.png");
+
+    fireEvent.error(dark);
+
+    expect(dark).toHaveAttribute("src", "https://cdn.example.com/logo.png");
+  });
+
   it("renders all top-level (non-nested) tabs for admin", () => {
     renderWithProviders(<Sidebar {...defaultProps} />);
 

--- a/ui/litellm-dashboard/src/components/leftnav.test.tsx
+++ b/ui/litellm-dashboard/src/components/leftnav.test.tsx
@@ -62,8 +62,17 @@ vi.mock("@/app/(dashboard)/hooks/uiConfig/useUIConfig", () => {
 
 // The redesigned sidebar reads the custom logo from ThemeContext; the test tree
 // has no ThemeProvider, so stub the hook.
+const unbrandedTheme = () => ({
+  logoUrl: null as string | null,
+  logoUrlDark: null as string | null,
+  faviconUrl: null as string | null,
+  setLogoUrl: vi.fn(),
+  setLogoUrlDark: vi.fn(),
+  setFaviconUrl: vi.fn(),
+});
+let mockUseThemeImpl = unbrandedTheme;
 vi.mock("@/contexts/ThemeContext", () => ({
-  useTheme: () => ({ logoUrl: null, faviconUrl: null, setLogoUrl: vi.fn(), setFaviconUrl: vi.fn() }),
+  useTheme: () => mockUseThemeImpl(),
 }));
 
 // Version tag + logout target come from network hooks; keep them inert in unit tests.
@@ -97,6 +106,7 @@ describe("Sidebar (leftnav)", () => {
   afterEach(() => {
     mockUseAuthorized.mockReset();
     mockUseOrganizations.mockReset();
+    mockUseThemeImpl = unbrandedTheme;
   });
 
   it("should link the logo to the UI home route rather than the proxy origin", () => {
@@ -118,6 +128,30 @@ describe("Sidebar (leftnav)", () => {
     expect(classesOf(light).has("hidden")).toBe(false);
     expect(classesOf(dark).has("hidden")).toBe(true);
     expect(classesOf(dark).has("dark:block")).toBe(true);
+  });
+
+  it("prefers a configured dark logo over the light one in dark mode", () => {
+    mockUseThemeImpl = () => ({
+      ...unbrandedTheme(),
+      logoUrl: "https://cdn.example.com/logo.png",
+      logoUrlDark: "https://cdn.example.com/logo-dark.png",
+    });
+    renderWithProviders(<Sidebar {...defaultProps} />);
+
+    const [light, dark] = Array.from(screen.getByRole("link", { name: /litellm home/i }).querySelectorAll("img"));
+
+    expect(light).toHaveAttribute("src", "https://cdn.example.com/logo.png");
+    expect(dark).toHaveAttribute("src", "https://cdn.example.com/logo-dark.png");
+  });
+
+  it("reuses the light custom logo in dark mode when no dark one is configured", () => {
+    mockUseThemeImpl = () => ({ ...unbrandedTheme(), logoUrl: "https://cdn.example.com/logo.png" });
+    renderWithProviders(<Sidebar {...defaultProps} />);
+
+    const [light, dark] = Array.from(screen.getByRole("link", { name: /litellm home/i }).querySelectorAll("img"));
+
+    expect(light).toHaveAttribute("src", "https://cdn.example.com/logo.png");
+    expect(dark).toHaveAttribute("src", "https://cdn.example.com/logo.png");
   });
 
   it("renders all top-level (non-nested) tabs for admin", () => {

--- a/ui/litellm-dashboard/src/components/leftnav.tsx
+++ b/ui/litellm-dashboard/src/components/leftnav.tsx
@@ -435,7 +435,7 @@ const Sidebar_: React.FC<SidebarProps> = ({
   const { userId, accessToken, userRole, isViewOnly } = useAuthorized();
   const isOrgAdmin = useIsOrgAdmin();
   const { data: teams } = useTeams();
-  const { logoUrl } = useTheme();
+  const { logoUrl, logoUrlDark } = useTheme();
   const { data: healthData } = useHealthReadinessDetails(accessToken);
   const logout = useLogout(accessToken);
 
@@ -605,7 +605,7 @@ const Sidebar_: React.FC<SidebarProps> = ({
   };
 
   const logoSrc = logoUrl || `${baseUrl}/get_image`;
-  const darkLogoSrc = logoUrl || `${baseUrl}/get_image?theme=dark`;
+  const darkLogoSrc = logoUrlDark || logoUrl || `${baseUrl}/get_image?theme=dark`;
 
   return (
     <Sidebar collapsed={collapsed}>

--- a/ui/litellm-dashboard/src/components/leftnav.tsx
+++ b/ui/litellm-dashboard/src/components/leftnav.tsx
@@ -436,6 +436,7 @@ const Sidebar_: React.FC<SidebarProps> = ({
   const isOrgAdmin = useIsOrgAdmin();
   const { data: teams } = useTeams();
   const { logoUrl, logoUrlDark } = useTheme();
+  const [erroredDarkLogo, setErroredDarkLogo] = useState<string | null>(null);
   const { data: healthData } = useHealthReadinessDetails(accessToken);
   const logout = useLogout(accessToken);
 
@@ -605,7 +606,8 @@ const Sidebar_: React.FC<SidebarProps> = ({
   };
 
   const logoSrc = logoUrl || `${baseUrl}/get_image`;
-  const darkLogoSrc = logoUrlDark || logoUrl || `${baseUrl}/get_image?theme=dark`;
+  const reachableDarkLogo = logoUrlDark === erroredDarkLogo ? null : logoUrlDark;
+  const darkLogoSrc = reachableDarkLogo || logoUrl || `${baseUrl}/get_image?theme=dark`;
 
   return (
     <Sidebar collapsed={collapsed}>
@@ -614,7 +616,13 @@ const Sidebar_: React.FC<SidebarProps> = ({
           <div className="flex min-w-0 items-center gap-2">
             <Link href={migratedHref("")} className="flex min-w-0 items-center" aria-label="LiteLLM home">
               <img src={logoSrc} alt="LiteLLM" className={cn(LOGO_CLASS_NAME, "dark:hidden")} />
-              <img src={darkLogoSrc} alt="" aria-hidden className={cn(LOGO_CLASS_NAME, "hidden dark:block")} />
+              <img
+                src={darkLogoSrc}
+                alt=""
+                aria-hidden
+                onError={() => setErroredDarkLogo(logoUrlDark)}
+                className={cn(LOGO_CLASS_NAME, "hidden dark:block")}
+              />
             </Link>
             {version && (
               <Badge

--- a/ui/litellm-dashboard/src/contexts/ThemeContext.tsx
+++ b/ui/litellm-dashboard/src/contexts/ThemeContext.tsx
@@ -4,6 +4,8 @@ import { getProxyBaseUrl } from "@/components/networking";
 interface ThemeContextType {
   logoUrl: string | null;
   setLogoUrl: (url: string | null) => void;
+  logoUrlDark: string | null;
+  setLogoUrlDark: (url: string | null) => void;
   faviconUrl: string | null;
   setFaviconUrl: (url: string | null) => void;
 }
@@ -25,6 +27,7 @@ interface ThemeProviderProps {
 
 export const ThemeProvider: React.FC<ThemeProviderProps> = ({ children, accessToken }) => {
   const [logoUrl, setLogoUrl] = useState<string | null>(null);
+  const [logoUrlDark, setLogoUrlDark] = useState<string | null>(null);
   const [faviconUrl, setFaviconUrl] = useState<string | null>(null);
 
   useEffect(() => {
@@ -41,6 +44,9 @@ export const ThemeProvider: React.FC<ThemeProviderProps> = ({ children, accessTo
           const data = await response.json();
           if (data.values?.logo_url) {
             setLogoUrl(data.values.logo_url);
+          }
+          if (data.values?.logo_url_dark) {
+            setLogoUrlDark(data.values.logo_url_dark);
           }
           if (data.values?.favicon_url) {
             setFaviconUrl(data.values.favicon_url);
@@ -71,6 +77,8 @@ export const ThemeProvider: React.FC<ThemeProviderProps> = ({ children, accessTo
   }, [faviconUrl]);
 
   return (
-    <ThemeContext.Provider value={{ logoUrl, setLogoUrl, faviconUrl, setFaviconUrl }}>{children}</ThemeContext.Provider>
+    <ThemeContext.Provider value={{ logoUrl, setLogoUrl, logoUrlDark, setLogoUrlDark, faviconUrl, setFaviconUrl }}>
+      {children}
+    </ThemeContext.Provider>
   );
 };

--- a/ui/litellm-dashboard/src/lib/http/schema.d.ts
+++ b/ui/litellm-dashboard/src/lib/http/schema.d.ts
@@ -34691,6 +34691,11 @@ export interface components {
              * @description URL or path to custom logo image. Can be a local file path or HTTP/HTTPS URL
              */
             logo_url?: string | null;
+            /**
+             * Logo Url Dark
+             * @description URL or path to a custom logo image for dark mode. Can be a local file path or HTTP/HTTPS URL. Leave unset to reuse logo_url in dark mode
+             */
+            logo_url_dark?: string | null;
         };
         /**
          * UIThemeSettingsResponse


### PR DESCRIPTION
## TLDR

Problem this solves:

- A custom logo shows its light artwork on a dark sidebar
- Admins had no way to supply a dark version

How it solves it:

- Adds `UI_LOGO_PATH_DARK` and a `logo_url_dark` theme setting
- Dark mode falls back to the light logo when it is unset
- A broken dark logo falls back too, never to LiteLLM's

## User Flow

Before: an admin who branded the dashboard with their own logo sees that light-background logo on the dark sidebar, and there is nothing they can set to fix it

1. They set `UI_LOGO_PATH` to their company logo and restart the proxy
2. They open http://localhost:4000/ui/ with dark styling applied and see their light logo on the dark sidebar
3. They look through http://localhost:4000/ui/?page=ui-theme and find only one logo field, so there is no dark option to set

After: the same admin can supply a dark logo, and doing nothing still keeps their branding

1. They open http://localhost:4000/ui/?page=ui-theme and see a second field, "Custom Logo URL (dark mode)", which says it reuses the logo above when left empty
2. They leave it empty, and dark mode keeps showing their own light logo rather than LiteLLM's
3. They fill it in with a dark-background version and save
4. Dark mode now shows that logo, and light mode still shows the original
5. If the dark logo later 404s or is deleted, dark mode drops back to their light logo instead of reverting to LiteLLM branding

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Shared setup: two stand-in customer logos, deliberately different shapes so the served bytes identify themselves, and a proxy on `http://localhost:4001` restarted for each case

```
customer-light.png: PNG image data, 40 x 10, 8-bit/color RGB, non-interlaced
customer-dark.png:  PNG image data, 60 x 20, 8-bit/color RGBA, non-interlaced
```

### Before (edbb3429a3)

#### Only UI_LOGO_PATH set, asking for the dark logo

1. `UI_LOGO_PATH=customer-light.png`, no dark var exists to set
2. `curl -s -o dark.out 'http://localhost:4001/get_image?theme=dark'; file dark.out`

```
dark.out: PNG image data, 40 x 10, 8-bit/color RGB, non-interlaced
```

The light artwork, which is the only outcome reachable here: `grep -c UI_LOGO_PATH_DARK litellm/proxy/proxy_server.py` returns 0 at this commit

#### Both logos set

1. There is no `UI_LOGO_PATH_DARK`, so this case cannot be expressed

#### A broken dark logo

1. There is no `UI_LOGO_PATH_DARK`, so this case cannot be expressed

### After (dab098b479)

#### Only UI_LOGO_PATH set, asking for the dark logo

1. `curl -s -o light.out http://localhost:4001/get_image` and `curl -s -o dark.out 'http://localhost:4001/get_image?theme=dark'`

```
light: HTTP 200 93B
dark:  HTTP 200 93B
```

2. `cmp light.out dark.out` exits silently, so an admin who never sets a dark logo keeps their own logo in dark mode

This case is deliberately identical to Before. The fallback already existed, and the point here is that adding the dark option does not disturb it

#### Both logos set

1. `UI_LOGO_PATH=customer-light.png UI_LOGO_PATH_DARK=customer-dark.png`, then the same two requests

```
light: HTTP 200 93B
dark:  HTTP 200 119B
```

2. `file -b light.out dark.out`

```
PNG image data, 40 x 10, 8-bit/color RGB, non-interlaced
PNG image data, 60 x 20, 8-bit/color RGBA, non-interlaced
```

#### A broken dark logo

1. `UI_LOGO_PATH_DARK=does-not-exist.png` with the light logo still valid
2. `curl -s -o dark.out 'http://localhost:4001/get_image?theme=dark'; file -b dark.out`

```
dark:  HTTP 200 93B
PNG image data, 40 x 10, 8-bit/color RGB, non-interlaced
```

3. The proxy log says why, and the admin keeps their own branding rather than reverting to LiteLLM's

```
2026-08-20 12:11:24 - LiteLLM Proxy - WARNING - proxy_server.py:15271 - _serve_custom_ui_logo() - Custom UI logo '.../does-not-exist.png' is not a supported image file or does not exist, falling back
```

#### No custom logo at all

1. With both vars unset, `cmp` against the bundled files passes on each theme

```
light: HTTP 200 24694B
dark:  HTTP 200 35771B
light == bundled logo.jpg
dark  == bundled logo_dark.png
```

## Type

🆕 New Feature

## Caveats (if any)

- A dark logo alone leaves light mode on the bundled default
- Dark mode toggle still not shipped, so this lands ahead of it
- `logo_url_dark` accepts http(s) URLs only, like `logo_url`

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

