### PR TITLE
fix(cli): keep the --pkce refresh token in the OS keychain, not in token.json

### DIFF
--- a/litellm/litellm_core_utils/cli_token_utils.py
+++ b/litellm/litellm_core_utils/cli_token_utils.py
@@ -4,10 +4,10 @@ CLI Token Utilities
 SDK-level utilities for reading the credential minted by `lite login`.
 
 Non-secret metadata lives in ~/.litellm/token.json. The secret material (the
-bearer key, plus a JWT when one is issued) lives in the OS keychain when the
-machine has one, and in that same 0600 file otherwise. This module hides the
-split from callers, and migrates a legacy plaintext file into the keychain the
-first time it reads one.
+bearer key, the refresh token that renews it, and a JWT when one is issued)
+lives in the OS keychain when the machine has one, and in that same 0600 file
+otherwise. This module hides the split from callers, and migrates a plaintext
+file into the keychain the first time it reads one.
 
 This module has no dependencies on proxy code and can be safely imported at the SDK level.
 """
@@ -111,13 +111,20 @@ class CliTokenSecret(BaseModel):
     secret minted for one server is never handed to another, even if the
     metadata file is edited underneath us. `timestamp` is the sign-in this
     secret came from, which is what decides it against a secret still on disk.
+
+    Every field a thief could sign in with belongs here, which is why the
+    refresh token is one of them: it buys a fresh key from the proxy on demand,
+    so leaving it on disk would leave the login readable there. `key` is
+    optional because the file can hold a refresh token without one, and moving
+    that into the keychain must not invent a key to go with it.
     """
 
     model_config = ConfigDict(frozen=True)
 
     base_url: str
-    key: str
+    key: str | None = None
     jwt_token: str = ""
+    refresh_token: str | None = None
     timestamp: float = 0.0
 
 
@@ -155,7 +162,7 @@ def save_cli_token(record: CliTokenRecord, *, vault: SecretVault = SYSTEM_KEYRIN
     staged: Final = _stage_token_file(_without_secret(stamped))
     if isinstance(staged, CredentialNotSaved):
         return staged
-    outcome: Final = SecretStored() if stamped.key is None else vault.write(_encode_secret(stamped, stamped.key))
+    outcome: Final = vault.write(_encode_secret(stamped)) if _holds_a_secret(stamped) else SecretStored()
     if isinstance(outcome, SecretStored):
         return outcome if _commit_token_file(staged) else CredentialNotRecorded()
     discard_staged_json(staged)
@@ -390,8 +397,9 @@ def _apply_vault_secret(record: CliTokenRecord, blob: str, vault: SecretVault) -
     secret is usually left on disk by a keychain that would not take it, which makes the file the
     fresher of the two. It is the older one when a login the keychain did take could not replace
     the file afterwards, and serving that one would put a superseded credential back in use. Equal
-    stamps are one login sitting in both stores, left by a migration whose scrub was refused, so
-    that branch retries the migration rather than trading one credential for another.
+    stamps are one login sitting in both stores, left by a migration whose scrub was refused or by
+    an upgrade that took the key into the keychain and left the refresh token behind, so that branch
+    rejoins the halves and retries the migration rather than trading one credential for another.
 
     A scrub the file refuses leaves that superseded secret where it lies, which is the state the
     login already named when it could not replace the file, and which `lite logout` reports rather
@@ -400,21 +408,46 @@ def _apply_vault_secret(record: CliTokenRecord, blob: str, vault: SecretVault) -
     superseded one back out.
     """
     secret: Final = _decode_secret(blob, record.base_url)
-    if secret is None or (record.key is not None and secret.timestamp <= record.timestamp):
-        return _migrate_file_secret(record, vault)
+    if secret is None or (_holds_a_secret(record) and secret.timestamp <= record.timestamp):
+        return _migrate_file_secret(_rejoined(record, secret), vault, replacing=secret)
     _scrub_file_secret(record)
     return record.model_copy(
         update=MappingProxyType(
             {
                 "key": secret.key,
                 "jwt_token": secret.jwt_token,
+                "refresh_token": secret.refresh_token,
                 "timestamp": max(secret.timestamp, record.timestamp),
             }
         )
     )
 
 
-def _migrate_file_secret(record: CliTokenRecord, vault: SecretVault) -> CliTokenRecord | None:
+def _rejoined(record: CliTokenRecord, secret: CliTokenSecret | None) -> CliTokenRecord:
+    """Put one sign-in's secret material back together when each store holds part of it.
+
+    Upgrading from the release that kept only the key in the keychain leaves the refresh token
+    behind in the file, so a single login sits across both stores. Filling in whatever the file is
+    missing before the migration writes its entry is what stops that write from replacing a live key
+    with nothing. Only a matching stamp is one login. Two stamps are two logins, and pairing one's
+    key with the other's refresh token would build a credential neither store ever held.
+    """
+    if secret is None or secret.timestamp != record.timestamp:
+        return record
+    return record.model_copy(
+        update=MappingProxyType(
+            {
+                "key": record.key if record.key is not None else secret.key,
+                "jwt_token": record.jwt_token or secret.jwt_token,
+                "refresh_token": record.refresh_token if record.refresh_token is not None else secret.refresh_token,
+            }
+        )
+    )
+
+
+def _migrate_file_secret(
+    record: CliTokenRecord, vault: SecretVault, *, replacing: CliTokenSecret | None = None
+) -> CliTokenRecord | None:
     """Move a file-held secret into the vault, but only once the file's copy can be taken away.
 
     The scrubbed file is staged first so a directory that will not accept it stops the migration
@@ -426,23 +459,28 @@ def _migrate_file_secret(record: CliTokenRecord, vault: SecretVault) -> CliToken
     asked to take the new entry back, so the migration finishes on a directory that would only ever
     have refused it. Rolling back is the last resort, and a rollback the keychain also refuses
     leaves the secret in both stores until the next read, which retries this same migration.
+
+    Only an entry this migration put there is taken back. `replacing` names one that was already in
+    the keychain, whose material the new entry carries forward, so erasing it would take away the
+    half the file never had, and a machine that refuses the scrub is exactly the one with nowhere
+    else to keep it. The next read finds the same two halves and tries the move again.
     """
-    if record.key is None:
+    if not _holds_a_secret(record):
         return None
     staged: Final = _stage_scrubbed_file(record)
     if staged is None:
         return record
-    if not isinstance(vault.write(_encode_secret(record, record.key)), SecretStored):
+    if not isinstance(vault.write(_encode_secret(record)), SecretStored):
         discard_staged_json(staged)
         return record
-    if not _commit_token_file(staged) and not _overwrite_file_secret(record):
+    if not _commit_token_file(staged) and not _overwrite_file_secret(record) and replacing is None:
         vault.erase()
     return record
 
 
 def _scrub_file_secret(record: CliTokenRecord) -> bool:
     """Leave no secret material in the token file once the vault holds it"""
-    if record.key is None and not record.jwt_token:
+    if not _holds_a_secret(record):
         return True
     staged: Final = _stage_scrubbed_file(record)
     if staged is not None and _commit_token_file(staged):
@@ -487,13 +525,22 @@ def _commit_token_file(staged: str) -> bool:
     return True
 
 
+def _holds_a_secret(record: CliTokenRecord) -> bool:
+    """Whether the record carries anything that would sign someone in as this user"""
+    return record.key is not None or bool(record.jwt_token) or record.refresh_token is not None
+
+
 def _without_secret(record: CliTokenRecord) -> CliTokenRecord:
-    return record.model_copy(update=MappingProxyType({"key": None, "jwt_token": ""}))
+    return record.model_copy(update=MappingProxyType({"key": None, "jwt_token": "", "refresh_token": None}))
 
 
-def _encode_secret(record: CliTokenRecord, key: str) -> str:
+def _encode_secret(record: CliTokenRecord) -> str:
     return CliTokenSecret(
-        base_url=record.base_url, key=key, jwt_token=record.jwt_token, timestamp=record.timestamp
+        base_url=record.base_url,
+        key=record.key,
+        jwt_token=record.jwt_token,
+        refresh_token=record.refresh_token,
+        timestamp=record.timestamp,
     ).model_dump_json()
 
 

--- a/litellm/proxy/client/README.md
+++ b/litellm/proxy/client/README.md
@@ -331,7 +331,7 @@ sequenceDiagram
     
     CLI->>Proxy: Poll /sso/cli/poll/login_id with poll_secret header
     Proxy->>CLI: Return {"status": "ready", "key": "jwt"}
-    CLI->>CLI: Save key to the OS keychain (metadata to ~/.litellm/token.json)
+    CLI->>CLI: Save the secret to the OS keychain (metadata to ~/.litellm/token.json)
 ```
 
 ### Authentication Commands
@@ -365,7 +365,7 @@ The CLI provides these authentication commands:
 
 ### Token Storage
 
-The key itself goes into the OS keychain (macOS Keychain, Windows Credential Manager, or the Linux Secret Service) under service `litellm-cli`, account `credential`. Only the non-secret session metadata is written to `~/.litellm/token.json`, in a `0700` directory with `0600` file permissions:
+The key itself, together with the refresh token that renews a `--pkce` credential, goes into the OS keychain (macOS Keychain, Windows Credential Manager, or the Linux Secret Service) under service `litellm-cli`, account `credential`. Only the non-secret session metadata is written to `~/.litellm/token.json`, in a `0700` directory with `0600` file permissions:
 
 ```json
 {
@@ -378,7 +378,7 @@ The key itself goes into the OS keychain (macOS Keychain, Windows Credential Man
 }
 ```
 
-Keychain storage needs the `keyring` package, which ships with `pip install 'litellm[cli]'`. Headless boxes and CI runners usually have no keychain either. In all of those cases the key stays in the same `0600` file alongside the metadata, exactly as it did before, and `lite login` names which one applies: the package is missing, the machine has no keychain, or you set `LITELLM_CLI_DISABLE_KEYRING=1` to force the file even where a keychain exists. A `token.json` written by an older `lite` keeps working and is moved into the keychain, and scrubbed from the file, the first time a keychain-capable `lite` reads it.
+Keychain storage needs the `keyring` package, which ships with `pip install 'litellm[cli]'`. Headless boxes and CI runners usually have no keychain either. In all of those cases the key and the refresh token stay in the same `0600` file alongside the metadata, exactly as they did before, and `lite login` names which one applies: the package is missing, the machine has no keychain, or you set `LITELLM_CLI_DISABLE_KEYRING=1` to force the file even where a keychain exists. A `token.json` written by an older `lite` keeps working and is moved into the keychain, and scrubbed from the file, the first time a keychain-capable `lite` reads it. That includes a refresh token left behind by the release that moved only the key.
 
 `lite logout` clears both stores. If the keychain is locked at that moment it says so, and re-running it once the keychain is unlocked finishes the job.
 

--- a/tests/test_litellm/litellm_core_utils/test_cli_token_utils.py
+++ b/tests/test_litellm/litellm_core_utils/test_cli_token_utils.py
@@ -80,8 +80,28 @@ def _write_metadata_only_file(home):
     return path
 
 
-def _blob(base_url=SERVER, key="sk-vault", jwt_token="", timestamp=0.0):
-    return json.dumps({"base_url": base_url, "key": key, "jwt_token": jwt_token, "timestamp": timestamp})
+def _blob(base_url=SERVER, key="sk-vault", jwt_token="", timestamp=0.0, refresh_token=None):
+    return json.dumps(
+        {
+            "base_url": base_url,
+            "key": key,
+            "jwt_token": jwt_token,
+            "refresh_token": refresh_token,
+            "timestamp": timestamp,
+        }
+    )
+
+
+def _write_key_only_keychain_file(home, *, refresh_token="rt-live", timestamp=2000.0):
+    """What the release that kept only the key in the keychain left on disk: metadata, plus the
+    refresh token in the clear."""
+    path = _token_file(home)
+    path.parent.mkdir(exist_ok=True)
+    path.write_text(
+        json.dumps({"base_url": SERVER, "user_id": "u-1", "refresh_token": refresh_token, "timestamp": timestamp})
+    )
+    path.chmod(0o600)
+    return path
 
 
 _REAL_MKSTEMP = tempfile.mkstemp
@@ -160,6 +180,56 @@ class TestLoadCliToken:
         record = load_cli_token(vault=vault)
 
         assert (record.key, record.jwt_token) == ("sk-a", "jwt-a")
+
+    def test_the_refresh_token_round_trips_through_the_vault(self, isolated_home, secret_vault_factory):
+        """A refresh token mints a fresh key from the proxy on demand, so it is the credential just
+        as much as the key is, and it has to come back out of the keychain to be usable."""
+        _write_metadata_only_file(isolated_home)
+        vault = secret_vault_factory(blob=_blob(key="sk-a", refresh_token="rt-a"))
+
+        record = load_cli_token(vault=vault)
+
+        assert (record.key, record.refresh_token) == ("sk-a", "rt-a")
+
+    def test_a_plaintext_refresh_token_is_moved_off_disk(self, isolated_home, secret_vault_factory):
+        path = _write_legacy_file(isolated_home, refresh_token="rt-legacy")
+        vault = secret_vault_factory()
+
+        record = load_cli_token(vault=vault)
+
+        assert record.refresh_token == "rt-legacy"
+        assert "rt-legacy" not in path.read_text()
+        assert json.loads(vault.blob)["refresh_token"] == "rt-legacy"
+
+    def test_an_upgrade_that_left_the_refresh_token_on_disk_rejoins_it_with_the_key(
+        self, isolated_home, secret_vault_factory
+    ):
+        """The release before this one took the key into the keychain and left the refresh token
+        behind, so upgrading finds one sign-in split across both stores. The read has to end with
+        the whole credential in the keychain, not with whichever half it happened to prefer."""
+        path = _write_key_only_keychain_file(isolated_home)
+        vault = secret_vault_factory(blob=_blob(key="sk-live", timestamp=2000.0))
+
+        record = load_cli_token(vault=vault)
+
+        assert (record.key, record.refresh_token) == ("sk-live", "rt-live")
+        assert "rt-live" not in path.read_text()
+        assert json.loads(vault.blob)["key"] == "sk-live"
+        assert json.loads(vault.blob)["refresh_token"] == "rt-live"
+
+    def test_a_superseded_refresh_token_on_disk_never_outlives_the_keychain(
+        self, isolated_home, secret_vault_factory
+    ):
+        """Two stores, two sign-ins, and the newer one is in the keychain. Handing back its key with
+        the older one's refresh token would build a credential neither store ever held, and would
+        renew the login the user already replaced."""
+        path = _write_legacy_file(isolated_home, key="sk-old", refresh_token="rt-old", timestamp=1000.0)
+        vault = secret_vault_factory(blob=_blob(key="sk-new", refresh_token="rt-new", timestamp=2000.0))
+
+        record = load_cli_token(vault=vault)
+
+        assert (record.key, record.refresh_token) == ("sk-new", "rt-new")
+        assert "rt-old" not in path.read_text()
 
     def test_legacy_plaintext_file_still_authenticates_and_is_migrated(self, isolated_home, secret_vault_factory):
         """A token.json written by an older `lite` keeps working, and reading it moves the secret
@@ -360,6 +430,36 @@ class TestSaveCliToken:
         assert "sk-new" not in _token_file(isolated_home).read_text()
         assert json.loads(vault.blob)["key"] == "sk-new"
         assert load_cli_token(vault=vault).key == "sk-new"
+
+    def test_the_refresh_token_goes_to_the_keychain_and_never_to_the_file(
+        self, isolated_home, secret_vault_factory
+    ):
+        vault = secret_vault_factory()
+
+        stored = save_cli_token(
+            CliTokenRecord(base_url=SERVER, key="sk-new", refresh_token="rt-new", timestamp=time.time()),
+            vault=vault,
+        )
+
+        assert stored == SecretStored()
+        assert "rt-new" not in _token_file(isolated_home).read_text()
+        assert json.loads(vault.blob)["refresh_token"] == "rt-new"
+        assert load_cli_token(vault=vault).refresh_token == "rt-new"
+
+    def test_the_refresh_token_falls_back_to_the_owner_only_file_with_the_key(
+        self, isolated_home, secret_vault_factory
+    ):
+        """A machine with no keychain keeps the whole credential in the 0600 file, refresh token
+        included, because a renewal that cannot be stored logs the user out on the next command."""
+        vault = secret_vault_factory(available=False, failure=KeyringNotInstalled())
+
+        save_cli_token(
+            CliTokenRecord(base_url=SERVER, key="sk-new", refresh_token="rt-new", timestamp=time.time()),
+            vault=vault,
+        )
+
+        assert json.loads(_token_file(isolated_home).read_text())["refresh_token"] == "rt-new"
+        assert load_cli_token(vault=vault).refresh_token == "rt-new"
 
     def test_falls_back_to_the_owner_only_file_when_there_is_no_keychain(self, isolated_home, secret_vault_factory):
         stored = save_cli_token(
@@ -628,6 +728,26 @@ class TestScrubFailure:
         assert json.loads(path.read_text()).get("key") is None
 
 
+    @pytest.mark.skipif(os.geteuid() == 0, reason="root ignores file permissions")
+    def test_a_rejoin_the_file_refuses_never_takes_the_key_with_it(
+        self, isolated_home, secret_vault_factory, monkeypatch
+    ):
+        """Rolling the rejoined entry back would erase a key that was safely in the keychain before
+        this read began, and the file it would fall back to is the one that has just refused to be
+        rewritten. The duplicate refresh token stays until a later read can finish the move."""
+        path = _write_key_only_keychain_file(isolated_home)
+        vault = secret_vault_factory(blob=_blob(key="sk-live", timestamp=2000.0))
+        monkeypatch.setattr("litellm.litellm_core_utils.private_json.os.replace", _refuse_replace)
+        path.chmod(0o400)
+
+        record = load_cli_token(vault=vault)
+
+        assert (record.key, record.refresh_token) == ("sk-live", "rt-live")
+        assert json.loads(vault.blob)["key"] == "sk-live"
+        assert json.loads(vault.blob)["refresh_token"] == "rt-live"
+        assert vault.erases == 0
+
+
 class TestClearCliToken:
     def test_removes_the_credential_from_both_stores(self, isolated_home, secret_vault_factory):
         vault = secret_vault_factory()
@@ -717,12 +837,14 @@ class TestClearCliToken:
     ):
         """Keeping a record of the unreachable keychain must never mean keeping the cleartext copy
         the user just asked to be rid of."""
-        _write_legacy_file(isolated_home)
+        _write_legacy_file(isolated_home, refresh_token="rt-legacy")
         vault = secret_vault_factory(available=False, failure=KeyringUnreachable())
 
         clear_cli_token(vault=vault)
 
-        assert "sk-legacy" not in _token_file(isolated_home).read_text()
+        left_on_disk = _token_file(isolated_home).read_text()
+        assert "sk-legacy" not in left_on_disk
+        assert "rt-legacy" not in left_on_disk
 
     def test_a_repeat_logout_never_answers_its_own_warning_with_an_all_clear(
         self, isolated_home, secret_vault_factory


### PR DESCRIPTION
## TLDR

Problem this solves:

- `lite login --pkce` leaves its refresh token in a cleartext file
- Any program running as the user can trade it for a key
- #37566 moved the key to the keychain but not the refresh token

How it solves it:

- The refresh token now goes into the keychain beside the key
- Every silent renewal puts the new pair there too
- An upgraded machine rejoins its two halves, then scrubs the file
- A box with no keychain keeps both halves in one owner-only file

## User Flow

Before: a developer signs in with `lite login --pkce`, and although their key is out of reach in the OS keychain, the refresh token that mints keys is in a cleartext file, so any program running as them can trade it for a working key

1. The developer runs `lite --base-url https://litellm-domain login --pkce`, approves the sign-in in the browser, and sees `Login successful!` followed by `Credential stored in your OS keychain.`
2. They send POST https://litellm-domain/v1/chat/completions through the CLI and get a 200 with a completion
3. They run `cat ~/.litellm/token.json` and see no key, but a `refresh_token` in the clear next to their gateway URL and a `token_endpoint` saying where to send it
4. A build script or editor extension running as that developer reads that file and sends POST https://litellm-domain/token with `grant_type=refresh_token` and that value, getting a 200 and a key of its own
5. It sends POST https://litellm-domain/v1/chat/completions with that key and gets a 200 completion, billed to the developer and carrying their role
6. A day later the developer's key expires, the next `lite` command renews it silently, and `cat ~/.litellm/token.json` shows the rotated refresh token sitting in the file exactly as before
7. Copying that one file to another machine reproduces the developer's access there, with no keychain and no consent prompt in the way

After: the same sign-in puts both halves in the keychain, so the file has nothing left for that program to trade

1. The developer runs `lite --base-url https://litellm-domain login --pkce`, approves the sign-in in the browser, and sees `Login successful!` followed by `Credential stored in your OS keychain.`
2. They send POST https://litellm-domain/v1/chat/completions through the CLI and get a 200 with a completion
3. They run `cat ~/.litellm/token.json` and see their gateway URL, user id, role, sign-in time, and endpoints, with no key and no refresh token in it
4. A build script or editor extension reading that file finds nothing to send to POST https://litellm-domain/token, so there is no request for it to make
5. A day later the developer's key expires, the next `lite` command renews it silently, and `cat ~/.litellm/token.json` still shows neither half; `security find-generic-password -s litellm-cli -a credential -w` on macOS, or Credential Manager on Windows, holds the renewed pair
6. `lite logout` still sends POST https://litellm-domain/revoke first, so replaying that refresh token at POST https://litellm-domain/token afterwards comes back 400 `invalid_grant`
7. A developer whose last sign-in was on the previous release is not asked to sign in again: their next command authenticates, the refresh token moves off disk into the keychain entry that already held their key, and renewal keeps working
8. On a headless box with no keychain, the same sign-in says so and stores both halves in `~/.litellm/token.json`, readable only by the developer, and everything keeps working

Before, a second program running as that developer could mint keys for their whole role for as long as the login lived, on any machine the token file was copied to. After, it finds nothing in the file to mint with, and the OS gates the keychain entry that holds the pair

## Relevant issues

Docs for this change: https://github.com/BerriAI/litellm-docs/pull/967

## Linear ticket

Resolves LIT-5855

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Shared setup for every case below: a proxy built from the commit under test, on a random free port, with a real Postgres and a real Anthropic key, and a stub SSO provider standing in for the company IdP

```
$ cat config.yaml
model_list:
  - model_name: haiku
    litellm_params:
      model: anthropic/claude-haiku-4-5
      api_key: os.environ/ANTHROPIC_API_KEY

general_settings:
  master_key: os.environ/LITELLM_MASTER_KEY

$ python litellm/proxy/proxy_cli.py --config config.yaml --port 9821 --num_workers 1
```

Each case runs in a throwaway `$HOME` with the `litellm-cli` keychain entry deleted first, so it starts from a machine that has never signed in. Two commands do the work in every case, the sign-in and one real provider call:

```
$ lite --base-url http://localhost:9821 login --pkce
$ lite --base-url http://localhost:9821 http request POST /v1/chat/completions \
    -j '{"model":"haiku","max_tokens":40,"messages":[{"role":"user","content":"Reply with exactly: QA5855 <case> <commit> authenticated this call"}]}'
```

The browser half of the sign-in, opening the authorize URL and approving the consent page, is driven with `curl` so the run is scriptable. The provider-call steps show the `content` field taken out of the 200 the proxy answered with, so the sentence in it names the case and the commit that call ran against. Two small helpers print what the token file and the keychain entry hold, truncating any secret to `...REDACTED...`, and a third prints sha256 fingerprints (first 12 characters) so the same secret can be recognized across the two stores without printing it. The second process is this, a program with the developer's file access and nothing else:

```
$ cat scavenger.py
import json, os, pathlib, requests
rec = json.loads((pathlib.Path(os.environ["HOME"])/".litellm"/"token.json").read_text())
print("secret-looking fields on disk:", [k for k in ("key", "jwt_token", "refresh_token") if rec.get(k)])
print("bearer token it can read straight out of the file:", repr(rec.get("key") or ""))
r = requests.post(rec["token_endpoint"], data={
    "grant_type": "refresh_token", "refresh_token": rec["refresh_token"], "client_id": rec["client_id"],
}, timeout=15)
print("POST", rec["token_endpoint"], "with the file's refresh_token ->", r.status_code)
minted = r.json().get("access_token", "") if r.ok else ""
print("access token it minted:", (minted[:12] + "...REDACTED...") if minted else "(none)")
if minted:
    c = requests.post(rec["base_url"] + "/v1/chat/completions",
                      headers={"Authorization": "Bearer " + minted},
                      json={"model": "haiku", "max_tokens": 30,
                            "messages": [{"role": "user", "content": "stolen refresh token probe"}]}, timeout=60)
    print("chat completion with the minted key ->", c.status_code,
          "-- THE FILE ALONE STILL BUYS A WORKING CREDENTIAL" if c.ok else "-- rejected")
```

### Before (edbb3429a3)

#### `lite login --pkce`, and what another program running as the user can lift

1. Sign in

```
Login successful!
Credential stored in your OS keychain.
```

2. Read the token file the sign-in left behind

```
--- $HOME/.litellm/token.json ---
  base_url:             'http://localhost:9821'
  user_id:              'qa5855_run9kc_user'
  user_email:           'unknown'
  user_role:            'cli'
  auth_header_name:     'Authorization'
  jwt_token:            ''
  timestamp:            1787252096.858134
  expires_at:           1787338496.8581052
  refresh_token:        '...REDACTED...'
  client_id:            '...REDACTED...'
  token_endpoint:       'http://localhost:9821/token'
  revocation_endpoint:  'http://localhost:9821/revoke'
  resource:             'http://localhost:9821'
```

3. Read the OS keychain entry the same way `lite` does

```
--- the OS keychain entry ---
keychain blob base_url:       http://localhost:9821
keychain blob key:            ...REDACTED...
keychain blob refresh_token:  (empty)
keychain blob timestamp:      1787252096.858134
preflight entry left over:    NO
```

4. Make a real provider call on the credential

```
"content": "QA5855 PKCE edbb3429a3 authenticated this call"
```

5. Run a second process that can read the user's files but not their keychain

```
secret-looking fields on disk: ['refresh_token']
bearer token it can read straight out of the file: ''
POST http://localhost:9821/token with the file's refresh_token -> 200
access token it minted: ...REDACTED...
chat completion with the minted key -> 200 -- THE FILE ALONE STILL BUYS A WORKING CREDENTIAL
```

#### Silent renewal, then `lite logout`

1. Sign in again in a fresh `$HOME` and fingerprint both stores

```
  token.json  key=(none)        refresh_token=d26ff2afa64d  timestamp=1787252104.614069
  keychain   key=aa3e44ee03bf  refresh_token=(none)        timestamp=1787252104.614069
```

2. Expire the key by hand, then make an ordinary provider call, which renews it silently

```
  expires_at set to 60 seconds ago; everything else untouched
"content": "QA5855 RENEWED edbb3429a3 authenticated this call"
```

3. Look at where the renewed pair went

```
  renewed key is in the keychain:       YES
  renewed key is in token.json:         NO
  refresh token is in token.json:       YES
  token.json  key=(none)        refresh_token=47ba78c6b138  timestamp=1787252106.22711
  keychain   key=cffe67d5ecb7  refresh_token=(none)        timestamp=1787252106.22711
```

4. Stash the live refresh token out of band, log out, and replay it

```
  (stashed the refresh token out of band, to replay it after logout)
$ lite --base-url http://localhost:9821 logout
Logged out successfully. Authentication token cleared.
--- both stores after logout ---
drwx------@ 2 mateo  wheel   64 Aug 20 11:55 .
drwxr-xr-x@ 4 mateo  wheel  128 Aug 20 11:55 ..
keychain slot: security: SecKeychainSearchCopyNext: The specified item could not be found in the keychain.
--- can the revoked refresh token still buy a key? ---
  POST http://localhost:9821/token -> 400
   {"error":"invalid_grant","error_description":"the refresh token was already used"}
```

#### A machine with no usable keychain

1. Sign in with the keychain turned off

```
Login successful!
Keychain storage is off (LITELLM_CLI_DISABLE_KEYRING). Credential stored in $HOME/.litellm/token.json (owner-only).
```

2. Look at the file, the keychain slot, and a real provider call on the credential

```
  -rw-------  $HOME/.litellm/token.json
  base_url:             'http://localhost:9821'
  key:                  '...REDACTED...'
  user_id:              'qa5855_run9kc_user'
  user_email:           'unknown'
  user_role:            'cli'
  auth_header_name:     'Authorization'
  jwt_token:            ''
  timestamp:            1787252112.64877
  expires_at:           1787338512.64848
  refresh_token:        '...REDACTED...'
  client_id:            '...REDACTED...'
  token_endpoint:       'http://localhost:9821/token'
  revocation_endpoint:  'http://localhost:9821/revoke'
  resource:             'http://localhost:9821'
keychain slot: security: SecKeychainSearchCopyNext: The specified item could not be found in the keychain.
"content": "QA5855 NO-KEYCHAIN edbb3429a3 authenticated this call"
```

#### A machine upgrading from the previous release

1. Sign in, then run an ordinary command, and fingerprint what a second process can still reach

```
$ lite --base-url http://localhost:9821 whoami
Authenticated
User Email: unknown
User ID: qa5855_run9kc_user
User Role: cli
Token age: 0.0 hours
Key expires in: 24.0 hours, renewed on next use
--- fingerprints after that command (sha256, first 12) ---
  token.json  key=(none)        refresh_token=bbcf9d39989e  timestamp=1787252121.2757492
  keychain   key=62cba6794212  refresh_token=(none)        timestamp=1787252121.2757492
--- what a second process can still read out of the file ---
secret-looking fields on disk: ['refresh_token']
bearer token it can read straight out of the file: ''
POST http://localhost:9821/token with the file's refresh_token -> 200
```

### After (0f1e09b555)

#### `lite login --pkce`, and what another program running as the user can lift

1. Sign in

```
Login successful!
Credential stored in your OS keychain.
```

2. Read the token file the sign-in left behind

```
--- $HOME/.litellm/token.json ---
  base_url:             'http://localhost:9821'
  user_id:              'qa5855_run9kc_user'
  user_email:           'unknown'
  user_role:            'cli'
  auth_header_name:     'Authorization'
  jwt_token:            ''
  timestamp:            1787251479.257664
  expires_at:           1787337879.257642
  client_id:            '...REDACTED...'
  token_endpoint:       'http://localhost:9821/token'
  revocation_endpoint:  'http://localhost:9821/revoke'
  resource:             'http://localhost:9821'
```

3. Read the OS keychain entry the same way `lite` does

```
--- the OS keychain entry, read in-process ---
keychain blob base_url:       http://localhost:9821
keychain blob key:            ...REDACTED...
keychain blob refresh_token:  ...REDACTED...
keychain blob timestamp:      1787251479.257664
preflight entry left over:    NO
```

4. Run a second process that can read the user's files but not their keychain

```
secret-looking fields on disk: NONE
bearer token it can read straight out of the file: ''
no refresh_token on disk, so there is nothing to POST to http://localhost:9821/token
```

5. Make a real provider call on the credential

```
"content": "QA5855 PKCE 0f1e09b555 authenticated this call"
```

#### Silent renewal, then `lite logout`

1. Expire the key by hand, then make an ordinary provider call, which renews it silently

```
--- expiring the stored credential by hand (expires_at -> the past) ---
  expires_at set to 60 seconds ago; everything else untouched
--- next ordinary command, which must renew silently ---
"content": "QA5855 RENEWED 0f1e09b555 authenticated this call"
```

2. Look at where the renewed pair went

```
  renewed key is in the keychain:       YES
  renewed key is in token.json:         NO
  refresh token is in token.json:       NO
keychain blob base_url:       http://localhost:9821
keychain blob key:            ...REDACTED...
keychain blob refresh_token:  ...REDACTED...
keychain blob timestamp:      1787251483.7432919
preflight entry left over:    NO
```

3. Stash the live refresh token out of band, log out, and replay it

```
  (stashed the refresh token out of band, to replay it after logout)
$ lite --base-url http://localhost:9821 logout
Logged out successfully. Authentication token cleared.
--- both stores after logout ---
drwx------@ 2 mateo  wheel   64 Aug 20 11:44 .
drwxr-xr-x@ 4 mateo  wheel  128 Aug 20 11:44 ..
keychain slot: security: SecKeychainSearchCopyNext: The specified item could not be found in the keychain.
--- can the revoked refresh token still buy a key? ---
  POST http://localhost:9821/token -> 400
   {"error":"invalid_grant","error_description":"the refresh token was already used"}
```

#### A machine with no usable keychain

1. Sign in with the keychain turned off

```
Login successful!
Keychain storage is off (LITELLM_CLI_DISABLE_KEYRING). Credential stored in $HOME/.litellm/token.json (owner-only).
```

2. Look at the file and the keychain slot

```
  -rw-------  $HOME/.litellm/token.json
  base_url:             'http://localhost:9821'
  key:                  '...REDACTED...'
  user_id:              'qa5855_run9kc_user'
  user_email:           'unknown'
  user_role:            'cli'
  auth_header_name:     'Authorization'
  jwt_token:            ''
  timestamp:            1787251807.264811
  expires_at:           1787338207.264778
  refresh_token:        '...REDACTED...'
  client_id:            '...REDACTED...'
  token_endpoint:       'http://localhost:9821/token'
  revocation_endpoint:  'http://localhost:9821/revoke'
  resource:             'http://localhost:9821'
keychain slot: security: SecKeychainSearchCopyNext: The specified item could not be found in the keychain.
```

3. Make a real provider call on the credential

```
"content": "QA5855 NO-KEYCHAIN 0f1e09b555 authenticated this call"
```

4. Expire the key by hand and renew from the file alone

```
  expires_at set to 60 seconds ago; everything else untouched
"content": "QA5855 NO-KEYCHAIN RENEWED 0f1e09b555 authenticated this call"
  -rw-------  $HOME/.litellm/token.json
  token.json  key=d71e192a54cb  refresh_token=b02b1d5b8892  timestamp=1787251810.453588
  keychain   key=(none)        refresh_token=(none)        timestamp=None
```

5. Stash the live refresh token out of band, log out, and replay it

```
  (stashed the refresh token out of band, to replay it after logout)
$ lite --base-url http://localhost:9821 logout
Logged out locally, but your OS keychain could not be checked, so a credential stored there by an earlier login may still be usable.
Unset LITELLM_CLI_DISABLE_KEYRING and run 'lite logout' again to clear it.
drwxr-xr-x@ 4 mateo  wheel  128 Aug 20 11:50 ..
-rw-------@ 1 mateo  wheel  576 Aug 20 11:50 token.json
keychain slot: security: SecKeychainSearchCopyNext: The specified item could not be found in the keychain.
--- the file logout kept, with the secret taken out of it ---
  base_url:             'http://localhost:9821'
  user_id:              'qa5855_run9kc_user'
  user_email:           'unknown'
  user_role:            'cli'
  auth_header_name:     'Authorization'
  jwt_token:            ''
  timestamp:            1787251810.453588
  expires_at:           1787338210.4535801
  client_id:            '...REDACTED...'
  token_endpoint:       'http://localhost:9821/token'
  revocation_endpoint:  'http://localhost:9821/revoke'
  resource:             'http://localhost:9821'
--- can the revoked refresh token still buy a key? ---
  POST http://localhost:9821/token -> 400
   {"error":"invalid_grant","error_description":"the refresh token was already used"}
```

#### A machine upgrading from the previous release

1. Sign in with the previous release's `lite`, so the machine starts in the state that release leaves behind

```
Login successful!
Credential stored in your OS keychain.
```
```
--- $HOME/.litellm/token.json, as the previous release left it ---
  base_url:             'http://localhost:9821'
  user_id:              'qa5855_run9kc_user'
  user_email:           'unknown'
  user_role:            'cli'
  auth_header_name:     'Authorization'
  jwt_token:            ''
  timestamp:            1787251741.624086
  expires_at:           1787338141.624031
  refresh_token:        '...REDACTED...'
  client_id:            '...REDACTED...'
  token_endpoint:       'http://localhost:9821/token'
  revocation_endpoint:  'http://localhost:9821/revoke'
  resource:             'http://localhost:9821'
--- the OS keychain entry, as the previous release left it ---
keychain blob base_url:       http://localhost:9821
keychain blob key:            ...REDACTED...
keychain blob refresh_token:  (empty)
keychain blob timestamp:      1787251741.624086
preflight entry left over:    NO
--- fingerprints of the two halves (sha256, first 12) ---
  token.json  key=(none)        refresh_token=ebf7ab6523ae  timestamp=1787251741.624086
  keychain   key=ffd060b3063d  refresh_token=(none)        timestamp=1787251741.624086
```

2. Upgrade, then run one ordinary command

```
$ lite --base-url http://localhost:9821 whoami
Authenticated
User Email: unknown
User ID: qa5855_run9kc_user
User Role: cli
Token age: 0.0 hours
Key expires in: 24.0 hours, renewed on next use
--- $HOME/.litellm/token.json now ---
  base_url:             'http://localhost:9821'
  user_id:              'qa5855_run9kc_user'
  user_email:           'unknown'
  user_role:            'cli'
  auth_header_name:     'Authorization'
  jwt_token:            ''
  timestamp:            1787251741.624086
  expires_at:           1787338141.624031
  client_id:            '...REDACTED...'
  token_endpoint:       'http://localhost:9821/token'
  revocation_endpoint:  'http://localhost:9821/revoke'
  resource:             'http://localhost:9821'
--- the OS keychain entry now ---
keychain blob base_url:       http://localhost:9821
keychain blob key:            ...REDACTED...
keychain blob refresh_token:  ...REDACTED...
keychain blob timestamp:      1787251741.624086
preflight entry left over:    NO
--- fingerprints again: the same key, and the refresh token moved store ---
  token.json  key=(none)        refresh_token=(none)        timestamp=1787251741.624086
  keychain   key=ffd060b3063d  refresh_token=ebf7ab6523ae  timestamp=1787251741.624086
```

3. Run a second process that can read the user's files but not their keychain

```
secret-looking fields on disk: NONE
bearer token it can read straight out of the file: ''
no refresh_token on disk, so there is nothing to POST to http://localhost:9821/token
```

4. Make a real provider call on the rejoined credential

```
"content": "QA5855 UPGRADED 0f1e09b555 authenticated this call"
```

5. Expire the key by hand, and renew on the refresh token that came off disk

```
  expires_at set to 60 seconds ago; everything else untouched
"content": "QA5855 UPGRADED-RENEWED 0f1e09b555 authenticated this call"
  token.json  key=(none)        refresh_token=(none)        timestamp=1787251752.03856
  keychain   key=6a6982cdbc23  refresh_token=0b1dfd40a310  timestamp=1787251752.03856
```

## Type

🐛 Bug Fix

## Caveats (if any)

- A rejoin needs one keychain write to finish
- A keychain that refuses writes keeps the refresh token on disk
- `LITELLM_CLI_DISABLE_KEYRING=1` boxes keep today's exposure
- Two halves from different sign-ins are not merged
- Renewal now needs keychain access, as the key already did
- Going back to the previous release stops silent renewal
- A keychain that refuses reads gives a vaguer hint

The upgrade path rejoins the two halves and then writes them back as one entry, so a machine whose keychain answers reads but refuses writes keeps its refresh token in `token.json` and tries again on the next command. That is the same pre-flight cost #37566 named for the key, and `LITELLM_CLI_DISABLE_KEYRING=1` is still the way off it. Nothing is lost when the write fails: the file keeps what it had, and the key already in the keychain is left alone rather than rolled back

The rejoin only merges a file half and a keychain half that carry the same sign-in stamp, which is one login split across the two stores by the upgrade. Halves with different stamps are two different sign-ins, and the newer one wins whole, exactly as it did before this PR

A `--pkce` credential renews itself, and the refresh token that does it now lives where the key does, so an install that cannot reach the keychain cannot renew either. That is the same boundary the key was already behind: an install without the `cli` extra could not read the key it needed, and now it cannot read the refresh token either

A machine that takes this release and then goes back to the previous one has its refresh token in a store that release does not read, so silent renewal stops and `lite logout` no longer has the token it revokes with, which leaves that refresh token live on the gateway until it expires. Nothing is lost or corrupted: the previous release still reads the key out of the keychain and keeps serving requests on it, both stores stay exactly as they were, `lite login --pkce` puts the machine back on a renewing credential, and coming back to this release picks the pair up again and renews on it. Writing the refresh token to both stores through the transition would make the downgrade seamless, and it would also keep the cleartext copy this PR exists to remove, so the downgrade pays the cost instead

On a machine whose keychain cannot be read, two strings get vaguer. `lite up` says to run `lite login` where it used to say `lite login --pkce`, and `lite whoami` drops the ", renewed on next use" it appends to the expiry. Both read the same presence test, whether the record in hand carries a refresh token, and a keychain that cannot be read makes the answer no. The line directly above each of them already names the real problem, that the credential is in the keychain and something is blocking it, so the user is told what to fix either way

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
- [x] `0f1e09b5558160ad18db40387d63ebb90a1daf4a` passes /live-pr-risk, with its findings recorded under Caveats

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes how CLI auth secrets (including refresh tokens that mint new keys) are stored, migrated, and scrubbed. Incorrect rejoin or rollback logic could leak credentials or drop a live login.
> 
> **Overview**
> Stops `lite login --pkce` from leaving the refresh token in `~/.litellm/token.json`. The refresh token is now treated as secret material and stored in the OS keychain with the bearer key (or in the same 0600 file when there is no keychain).
> 
> On load, a split upgrade state (key already in the keychain, refresh token still on disk) is **rejoined** only when both halves share the same sign-in stamp, then migrated and scrubbed. Migration will not roll back a pre-existing keychain entry if the file cannot be rewritten. Different stamps still pick the newer login whole, so an old refresh token is never paired with a newer key.
> 
> `CliTokenSecret.key` is optional so a file that holds only a refresh token can move into the keychain without inventing a key. Logout still strips refresh tokens from disk even when the keychain cannot be cleared.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0f1e09b5558160ad18db40387d63ebb90a1daf4a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
