### PR TITLE
fix: order CLI SSO team choices by alias then id for a stable consent default

### DIFF
--- a/litellm/proxy/management_endpoints/ui_sso.py
+++ b/litellm/proxy/management_endpoints/ui_sso.py
@@ -2203,6 +2203,18 @@ def _cli_sso_team_detail(team_row: Mapping[str, object]) -> CliSsoTeamDetail:
     )
 
 
+def _cli_sso_team_sort_key(detail: CliSsoTeamDetail) -> tuple[str, str]:
+    """Stable, predictable order for a user's team choices.
+
+    The DB returns rows in an arbitrary order, so the consent page (and the
+    classic login team choice, which shares this lookup) would preselect
+    whichever team happened to come back first -- silently binding a user who
+    takes the default to a team they did not mean to pick. Order by alias
+    case-insensitively, with team_id as a deterministic tiebreaker.
+    """
+    return ((detail.team_alias or "").casefold(), detail.team_id or "")
+
+
 async def fetch_cli_sso_team_details(
     prisma_client: PrismaClient,
     teams: Sequence[str],
@@ -2218,7 +2230,10 @@ async def fetch_cli_sso_team_details(
     except Exception as e:
         verbose_proxy_logger.error("Error fetching team details for CLI SSO session: %s", e)
         return None
-    return tuple(_cli_sso_team_detail(team_row.model_dump()) for team_row in prisma_teams)
+    details: Final = (
+        _cli_sso_team_detail(team_row.model_dump()) for team_row in prisma_teams
+    )
+    return tuple(sorted(details, key=_cli_sso_team_sort_key))
 
 
 def _cli_sso_session_teams(team_details: Sequence[CliSsoTeamDetail]) -> list[str]:

--- a/litellm/proxy/management_endpoints/ui_sso.py
+++ b/litellm/proxy/management_endpoints/ui_sso.py
@@ -2230,9 +2230,7 @@ async def fetch_cli_sso_team_details(
     except Exception as e:
         verbose_proxy_logger.error("Error fetching team details for CLI SSO session: %s", e)
         return None
-    details: Final = (
-        _cli_sso_team_detail(team_row.model_dump()) for team_row in prisma_teams
-    )
+    details: Final = (_cli_sso_team_detail(team_row.model_dump()) for team_row in prisma_teams)
     return tuple(sorted(details, key=_cli_sso_team_sort_key))
 
 

--- a/tests/test_litellm/proxy/management_endpoints/test_ui_sso.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_ui_sso.py
@@ -8344,3 +8344,50 @@ class TestPersistReturnToCookieSharedHelper:
         resp = Response()
         _persist_return_to_cookie(resp, "https://cp.example.com/ui?page=models")
         assert "litellm_cp_return_to=" in self._cookie(resp)
+
+
+@pytest.mark.asyncio
+async def test_fetch_cli_sso_team_details_orders_by_alias_then_id():
+    """CLI SSO team choices must come back in a stable order.
+
+    The consent page preselects the first team, so an arbitrary DB order can
+    silently bind a user who takes the default to a team they did not mean to
+    pick. Teams must be ordered by alias case-insensitively, then team_id as a
+    deterministic tiebreaker. Regression for the CLI login consent page.
+    """
+    from unittest.mock import AsyncMock, MagicMock, patch
+
+    from litellm.proxy.management_endpoints import ui_sso as ui_sso_mod
+
+    def _row(team_id, alias):
+        row = MagicMock()
+        row.model_dump.return_value = {
+            "team_id": team_id,
+            "team_alias": alias,
+            "models": [],
+        }
+        return row
+
+    # Deliberately scrambled DB order, mixed case, plus an alias-less team.
+    rows = [
+        _row("35551", "forge-team-b-35551"),
+        _row("10000", "Forge-Team-A-35551"),
+        _row("99999", None),
+    ]
+    repo = MagicMock()
+    repo.find_many = AsyncMock(return_value=rows)
+
+    with patch.object(ui_sso_mod, "TeamRepository", return_value=MagicMock()), patch.object(
+        ui_sso_mod, "_team_detail_db", return_value=repo
+    ):
+        result = await ui_sso_mod.fetch_cli_sso_team_details(
+            prisma_client=MagicMock(), teams=["35551", "10000", "99999"]
+        )
+
+    assert result is not None
+    # None alias sorts first (""), then case-insensitive "Forge-Team-A" < "forge-team-b".
+    assert [d.team_alias for d in result] == [
+        None,
+        "Forge-Team-A-35551",
+        "forge-team-b-35551",
+    ]

--- a/tests/test_litellm/proxy/management_endpoints/test_ui_sso.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_ui_sso.py
@@ -8391,3 +8391,23 @@ async def test_fetch_cli_sso_team_details_orders_by_alias_then_id():
         "Forge-Team-A-35551",
         "forge-team-b-35551",
     ]
+
+
+def test_cli_sso_team_sort_key_case_insensitive_with_id_tiebreaker():
+    """Directly exercise the sort key, including the alias-None and team_id-None
+    fallbacks, so ordering is stable regardless of how the DB row is shaped.
+    """
+    from litellm.proxy.management_endpoints import ui_sso as ui_sso_mod
+
+    CliSsoTeamDetail = ui_sso_mod.CliSsoTeamDetail
+    key = ui_sso_mod._cli_sso_team_sort_key
+
+    a = CliSsoTeamDetail(team_id="2", team_alias="Alpha", team_models=())
+    b = CliSsoTeamDetail(team_id="1", team_alias="alpha", team_models=())
+    c = CliSsoTeamDetail(team_id=None, team_alias=None, team_models=())
+
+    # Both `or ""` fallbacks are taken for c.
+    assert key(c) == ("", "")
+    # Case-insensitive alias equality falls back to team_id ("1" < "2");
+    # the alias-less team sorts first.
+    assert [t.team_id for t in sorted([a, b, c], key=key)] == [None, "1", "2"]


### PR DESCRIPTION
## TLDR

**Problem:** The CLI login consent page (`lite login --pkce`, added in #37626) lists a user's teams in whatever order the database returns them and preselects the first. On the same proxy with the same user that order isn't stable, so a user who clicks **Approve** without touching the dropdown can be bound to a team they didn't mean to pick — and their first call then fails with `403 team not allowed to access model` if that team's allowlist doesn't cover the model.

**Fix:** Sort the teams in the shared CLI-SSO team lookup (`_fetch_cli_sso_team_details`) by **alias, case-insensitively, then `team_id` as a deterministic tiebreaker**. Because the classic `lite login` team choice uses the same lookup, sorting there fixes both flows in one place, as the issue notes.

Fixes #37642

## Changes

- `litellm/proxy/management_endpoints/ui_sso.py`
  - Add `_cli_sso_team_sort_key(detail)` → `(alias.casefold(), team_id)`.
  - `_fetch_cli_sso_team_details(...)` now returns the details sorted by that key instead of raw DB order.

## Testing

Added `test_fetch_cli_sso_team_details_orders_by_alias_then_id` in `tests/test_litellm/proxy/management_endpoints/test_ui_sso.py`: the mocked DB returns teams in scrambled, mixed-case order (plus an alias-less team) and the test asserts the result comes back ordered `alias` (case-insensitive) then `id`.

```
tests/test_litellm/proxy/management_endpoints/test_ui_sso.py::test_fetch_cli_sso_team_details_orders_by_alias_then_id PASSED
```
