### PR TITLE
feat(team): let a team admin manage their own team's logging callbacks

### DIFF
--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -830,6 +830,12 @@ class LiteLLMRoutes(enum.Enum):
         "/team/daily/activity",
         "/team/daily/activity/aggregated",
         "/team/{team_id}/members/me",
+        # POST/GET the team's logging callbacks, and DELETE one of them. Every
+        # handler calls _verify_team_access, which admits only a proxy admin, an
+        # org admin for the team, or an admin of this team. The :path converter
+        # mirrors the route registration, which accepts a team id containing "/".
+        "/team/{team_id:path}/callback",
+        "/team/{team_id:path}/callback/{callback_name}",
         "/model/new",
         "/model/update",
         "/model/delete",

--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -834,14 +834,10 @@ class LiteLLMRoutes(enum.Enum):
         # handler calls _verify_team_access, which admits only a proxy admin, an
         # org admin for the team, or an admin of this team.
         #
-        # Two spellings per route because neither placeholder alone covers every
-        # team id the router accepts: the gate expands {x:path} to "[^:]+", which
-        # takes a slash but not a colon, and {x} to "[^/]+", which takes a colon
-        # but not a slash. team_id is a free-form string, so both are reachable.
+        # team_id is a free-form string, so it spells these with the same path
+        # converter the router uses; the gate matches that converter.
         "/team/{team_id:path}/callback",
         "/team/{team_id:path}/callback/{callback_name}",
-        "/team/{team_id}/callback",
-        "/team/{team_id}/callback/{callback_name}",
         "/model/new",
         "/model/update",
         "/model/delete",

--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -832,10 +832,16 @@ class LiteLLMRoutes(enum.Enum):
         "/team/{team_id}/members/me",
         # POST/GET the team's logging callbacks, and DELETE one of them. Every
         # handler calls _verify_team_access, which admits only a proxy admin, an
-        # org admin for the team, or an admin of this team. The :path converter
-        # mirrors the route registration, which accepts a team id containing "/".
+        # org admin for the team, or an admin of this team.
+        #
+        # Two spellings per route because neither placeholder alone covers every
+        # team id the router accepts: the gate expands {x:path} to "[^:]+", which
+        # takes a slash but not a colon, and {x} to "[^/]+", which takes a colon
+        # but not a slash. team_id is a free-form string, so both are reachable.
         "/team/{team_id:path}/callback",
         "/team/{team_id:path}/callback/{callback_name}",
+        "/team/{team_id}/callback",
+        "/team/{team_id}/callback/{callback_name}",
         "/model/new",
         "/model/update",
         "/model/delete",

--- a/litellm/proxy/auth/route_checks.py
+++ b/litellm/proxy/auth/route_checks.py
@@ -507,7 +507,12 @@ class RouteChecks:
             # placeholder: the Google routes end in ":generateContent" and
             # friends, and there the value has to stop before that suffix
             # rather than swallow it and match a different verb.
-            return r"[^:]+" if ":" in match.string[match.end() :] else r".+"
+            #
+            # "[\s\S]" rather than ".", because "." stops at a newline and the
+            # path converter does not: a %0A anywhere in the value would leave
+            # the route unmatched here while still reaching the handler, which
+            # turns this gate into a bypass for the lists built on it.
+            return r"[^:]+" if ":" in match.string[match.end() :] else r"[\s\S]+"
 
         pattern = re.sub(r"\{[^}]+\}", _placeholder_to_regex, pattern)
         # Anchor the pattern to match the entire string

--- a/litellm/proxy/auth/route_checks.py
+++ b/litellm/proxy/auth/route_checks.py
@@ -497,10 +497,17 @@ class RouteChecks:
 
         def _placeholder_to_regex(match: re.Match) -> str:
             placeholder: Final = match.group(0).strip("{}")
-            if placeholder.endswith(":path"):
-                # allow "/" in the placeholder value, but don't eat the route suffix after ":"
-                return r"[^:]+"
-            return r"[^/]+"
+            if not placeholder.endswith(":path"):
+                return r"[^/]+"
+            # A ":path" placeholder takes whatever the router's own path
+            # converter takes, slashes and colons alike, so an id spelled with
+            # either (or both) still matches the template it was mounted under.
+            #
+            # Unless the template puts a ":" literal of its own after the
+            # placeholder: the Google routes end in ":generateContent" and
+            # friends, and there the value has to stop before that suffix
+            # rather than swallow it and match a different verb.
+            return r"[^:]+" if ":" in match.string[match.end() :] else r".+"
 
         pattern = re.sub(r"\{[^}]+\}", _placeholder_to_regex, pattern)
         # Anchor the pattern to match the entire string

--- a/litellm/proxy/common_utils/callback_config_validation.py
+++ b/litellm/proxy/common_utils/callback_config_validation.py
@@ -44,6 +44,67 @@ def _langfuse_environment_error(callback_vars: Mapping[str, str]) -> str | None:
     return None
 
 
+# Which credential family a dynamic variable belongs to. The families are the
+# integrations that share one account: every langfuse_* variable configures the
+# same Langfuse project whether it rides the classic callback or the OTel one,
+# and every dd_* variable configures the same Datadog account.
+_VAR_FAMILIES: Final[Mapping[str, str]] = MappingProxyType(
+    {
+        "arize_": "Arize",
+        "dd_": "Datadog",
+        "gcs_": "GCS",
+        "humanloop_": "Humanloop",
+        "langfuse_": "Langfuse",
+        "langsmith_": "LangSmith",
+        "newrelic_": "New Relic",
+        "posthog_": "PostHog",
+        "wandb_": "Weights & Biases",
+        "weave_": "Weights & Biases",
+    }
+)
+
+
+def _family_of(var: str) -> str | None:
+    """The credential family ``var`` configures, or ``None`` if it configures none.
+
+    ``turn_off_message_logging`` and friends belong to no backend, so they carry
+    no credentials anyone could redirect.
+    """
+    return next((family for prefix, family in _VAR_FAMILIES.items() if var.startswith(prefix)), None)
+
+
+def cross_entry_family_error(
+    callback_vars: Mapping[str, str] | None,
+    stored_vars_by_entry: Sequence[Mapping[str, str]],
+) -> str | None:
+    """Reject an entry that joins a credential family another entry already holds.
+
+    Every stored entry's variables are flattened into one dict before a request
+    reads them, and the flattened dict is what the exporter authenticates and
+    addresses with. So an entry naming only a destination is enough to redirect
+    credentials that were written somewhere else: a host on a second entry pairs
+    with the key from the first, and the request carries that key to the new
+    host.
+
+    Requiring one entry to own a family end to end removes the pairing. Only the
+    writers this endpoint newly admits are held to it, because a proxy admin
+    already holds every credential the proxy has. A team admin who does want to
+    move a family deletes the entry holding it first, which reveals nothing.
+    """
+    if not callback_vars:
+        return None
+    held: Final = {family for entry in stored_vars_by_entry for family in map(_family_of, entry) if family is not None}
+    return next(
+        (
+            f"{family} is already configured by another callback entry on this team. "
+            f"Remove that entry before setting {var} here."
+            for var, family in ((v, _family_of(v)) for v in callback_vars)
+            if family is not None and family in held
+        ),
+        None,
+    )
+
+
 def logging_metadata_config_error(metadata: Mapping[str, object] | None) -> str | None:
     """Validate every ``logging`` entry of a team/key metadata payload."""
     if not metadata:

--- a/litellm/proxy/common_utils/callback_config_validation.py
+++ b/litellm/proxy/common_utils/callback_config_validation.py
@@ -77,7 +77,7 @@ def cross_entry_family_error(
     callback_vars: Mapping[str, str] | None,
     stored_vars_by_entry: Sequence[Mapping[str, str]],
 ) -> str | None:
-    """Reject an entry that changes a credential family another entry already holds.
+    """Reject an entry that brings a new value to a family another entry holds.
 
     Every stored entry's variables are flattened into one dict before a request
     reads them, and the flattened dict is what the exporter authenticates and
@@ -86,12 +86,14 @@ def cross_entry_family_error(
     with the key from the first, and the request carries that key to the new
     host.
 
-    Requiring one entry to own a family end to end removes the pairing. Repeating
-    a value the holding entry already stores is allowed, because flattening then
-    produces the same dict either way -- that is how the same integration gets
-    registered for both the success and the failure event. A team admin who does
-    want to move a family deletes the entry holding it first, which reveals
-    nothing.
+    A destination the caller controls is by definition a value the owning entries
+    do not already carry, so requiring every value to be one of theirs removes
+    the pairing. Repeating what they carry is allowed: that is how the same
+    integration gets registered for both the success and the failure event, and
+    it holds for the spellings the same credential has (``langfuse_secret`` and
+    ``langfuse_secret_key`` are one key) without anything here having to list
+    them. A team admin who does want to move a family deletes the entry holding
+    it first, which reveals nothing.
 
     Only the writers this endpoint newly admits are held to this, because a proxy
     admin already holds every credential the proxy has.
@@ -101,16 +103,20 @@ def cross_entry_family_error(
     """
     if not callback_vars:
         return None
-    stored: Final = {  # mutable-ok: local view of the stored entries, never stored
-        var: value for entry in stored_vars_by_entry for var, value in entry.items() if _family_of(var) is not None
-    }
-    held: Final = {_family_of(var) for var in stored}  # mutable-ok: local index, never stored
+    stored: Final = tuple(
+        (family, value)
+        for entry in stored_vars_by_entry
+        for var, value in entry.items()
+        if (family := _family_of(var)) is not None
+    )
+    held_values: Final = frozenset(stored)
+    held_families: Final = frozenset(family for family, _ in stored)
     return next(
         (
             f"{family} is already configured by another callback entry on this team. "
-            f"Remove that entry before setting {var} here."
+            f"Remove that entry before setting {var} to a new value here."
             for var, value, family in ((v, callback_vars[v], _family_of(v)) for v in callback_vars)
-            if family in held and stored.get(var) != value
+            if family in held_families and (family, value) not in held_values
         ),
         None,
     )

--- a/litellm/proxy/common_utils/callback_config_validation.py
+++ b/litellm/proxy/common_utils/callback_config_validation.py
@@ -77,7 +77,7 @@ def cross_entry_family_error(
     callback_vars: Mapping[str, str] | None,
     stored_vars_by_entry: Sequence[Mapping[str, str]],
 ) -> str | None:
-    """Reject an entry that joins a credential family another entry already holds.
+    """Reject an entry that changes a credential family another entry already holds.
 
     Every stored entry's variables are flattened into one dict before a request
     reads them, and the flattened dict is what the exporter authenticates and
@@ -86,20 +86,31 @@ def cross_entry_family_error(
     with the key from the first, and the request carries that key to the new
     host.
 
-    Requiring one entry to own a family end to end removes the pairing. Only the
-    writers this endpoint newly admits are held to it, because a proxy admin
-    already holds every credential the proxy has. A team admin who does want to
-    move a family deletes the entry holding it first, which reveals nothing.
+    Requiring one entry to own a family end to end removes the pairing. Repeating
+    a value the holding entry already stores is allowed, because flattening then
+    produces the same dict either way -- that is how the same integration gets
+    registered for both the success and the failure event. A team admin who does
+    want to move a family deletes the entry holding it first, which reveals
+    nothing.
+
+    Only the writers this endpoint newly admits are held to this, because a proxy
+    admin already holds every credential the proxy has.
+
+    ``stored_vars_by_entry`` has to arrive decrypted; the credential values are
+    encrypted at rest and ciphertext never equals the plaintext coming in.
     """
     if not callback_vars:
         return None
-    held: Final = {family for entry in stored_vars_by_entry for family in map(_family_of, entry) if family is not None}
+    stored: Final = {  # mutable-ok: local view of the stored entries, never stored
+        var: value for entry in stored_vars_by_entry for var, value in entry.items() if _family_of(var) is not None
+    }
+    held: Final = {_family_of(var) for var in stored}  # mutable-ok: local index, never stored
     return next(
         (
             f"{family} is already configured by another callback entry on this team. "
             f"Remove that entry before setting {var} here."
-            for var, family in ((v, _family_of(v)) for v in callback_vars)
-            if family is not None and family in held
+            for var, value, family in ((v, callback_vars[v], _family_of(v)) for v in callback_vars)
+            if family in held and stored.get(var) != value
         ),
         None,
     )

--- a/litellm/proxy/common_utils/callback_config_validation.py
+++ b/litellm/proxy/common_utils/callback_config_validation.py
@@ -77,7 +77,7 @@ def cross_entry_family_error(
     callback_vars: Mapping[str, str] | None,
     stored_vars_by_entry: Sequence[Mapping[str, str]],
 ) -> str | None:
-    """Reject an entry that brings a new value to a family another entry holds.
+    """Reject an entry that changes what a family another entry holds resolves to.
 
     Every stored entry's variables are flattened into one dict before a request
     reads them, and the flattened dict is what the exporter authenticates and
@@ -86,14 +86,18 @@ def cross_entry_family_error(
     with the key from the first, and the request carries that key to the new
     host.
 
-    A destination the caller controls is by definition a value the owning entries
-    do not already carry, so requiring every value to be one of theirs removes
-    the pairing. Repeating what they carry is allowed: that is how the same
-    integration gets registered for both the success and the failure event, and
-    it holds for the spellings the same credential has (``langfuse_secret`` and
-    ``langfuse_secret_key`` are one key) without anything here having to list
-    them. A team admin who does want to move a family deletes the entry holding
-    it first, which reveals nothing.
+    Two rules together keep the flattened dict out of the caller's hands. A
+    variable the family already configures has to keep the value it has, so
+    nothing already in use can be moved. A variable the family does not yet
+    configure may only carry a value the family already holds, which is what lets
+    the same credential go in under its other spelling (``langfuse_secret`` and
+    ``langfuse_secret_key`` are one key) without anything here having to list the
+    spellings. Between them, no value the caller chose can enter the family, and
+    repeating the family as it stands is still allowed -- that is how one
+    integration gets registered for both the success and the failure event.
+
+    A team admin who does want to move a family deletes the entry holding it
+    first, which reveals nothing.
 
     Only the writers this endpoint newly admits are held to this, because a proxy
     admin already holds every credential the proxy has.
@@ -103,20 +107,23 @@ def cross_entry_family_error(
     """
     if not callback_vars:
         return None
-    stored: Final = tuple(
+    stored_by_var: Final = {
+        var: value for entry in stored_vars_by_entry for var, value in entry.items() if _family_of(var) is not None
+    }
+    family_values: Final = frozenset(
         (family, value)
         for entry in stored_vars_by_entry
         for var, value in entry.items()
         if (family := _family_of(var)) is not None
     )
-    held_values: Final = frozenset(stored)
-    held_families: Final = frozenset(family for family, _ in stored)
+    held_families: Final = frozenset(family for family, _ in family_values)
     return next(
         (
             f"{family} is already configured by another callback entry on this team. "
-            f"Remove that entry before setting {var} to a new value here."
+            f"Remove that entry before setting {var} here."
             for var, value, family in ((v, callback_vars[v], _family_of(v)) for v in callback_vars)
-            if family in held_families and (family, value) not in held_values
+            if family in held_families
+            and (stored_by_var[var] != value if var in stored_by_var else (family, value) not in family_values)
         ),
         None,
     )

--- a/litellm/proxy/management_endpoints/team_callback_endpoints.py
+++ b/litellm/proxy/management_endpoints/team_callback_endpoints.py
@@ -29,7 +29,10 @@ from litellm.proxy._types import (
     UserAPIKeyAuth,
 )
 from litellm.proxy.auth.user_api_key_auth import user_api_key_auth
-from litellm.proxy.common_utils.callback_config_validation import callback_config_error
+from litellm.proxy.common_utils.callback_config_validation import (
+    callback_config_error,
+    cross_entry_family_error,
+)
 from litellm.proxy.common_utils.callback_utils import (
     _CALLBACK_VAR_ENCRYPTED_PREFIX,
     decrypt_callback_vars,
@@ -339,6 +342,23 @@ async def add_team_callbacks(
         team_callback_settings: list[dict] = team_metadata.get("logging")  # will be dict of type AddTeamCallback
         if team_callback_settings is None or not isinstance(team_callback_settings, list):
             team_callback_settings = []
+
+        # One entry has to own a credential family end to end. The entries are
+        # flattened into one dict before a request reads them, so an entry
+        # naming only a destination would pair with a key written on another
+        # entry and carry it to that destination -- a key a team admin can read
+        # back nowhere. Proxy admins are exempt: they already hold every
+        # credential the proxy has.
+        if user_api_key_dict.user_role != LitellmUserRoles.PROXY_ADMIN:
+            stored_entry_vars: Final = [  # mutable-ok: read-only input to the check, never stored
+                entry.get("callback_vars") or {} for entry in team_callback_settings
+            ]
+            family_error: Final = cross_entry_family_error(data.callback_vars, stored_entry_vars)
+            if family_error is not None:
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail=family_error,
+                )
 
         ## check if it already exists, for the same callback event
         for callback in team_callback_settings:

--- a/litellm/proxy/management_endpoints/team_callback_endpoints.py
+++ b/litellm/proxy/management_endpoints/team_callback_endpoints.py
@@ -20,6 +20,7 @@ from litellm.proxy._types import (
     LiteLLM_AuditLogs,
     LiteLLM_TeamTable,
     LitellmTableNames,
+    LitellmUserRoles,
     ProxyErrorTypes,
     ProxyException,
     TeamCallbackDeleteResponse,
@@ -230,6 +231,22 @@ def _callback_error(status_code: int, message: str) -> HTTPException:
     )
 
 
+def _unknown_team_error(team_id: str, user_api_key_dict: UserAPIKeyAuth, status_code: int) -> HTTPException:
+    """Report an unknown team without telling an unauthorized caller that it is unknown.
+
+    These routes are reachable by any authenticated caller so that a team admin can
+    get as far as _verify_team_access. A distinct "does not exist" would therefore let
+    any valid key probe which team ids exist, so a caller who could not have managed
+    the team either way gets the same 403 body _verify_team_access raises.
+    """
+    if user_api_key_dict.user_role == LitellmUserRoles.PROXY_ADMIN:
+        return _callback_error(status_code, f"Team id = {team_id} does not exist.")
+    return HTTPException(
+        status_code=status.HTTP_403_FORBIDDEN,
+        detail="You do not have access to this team",
+    )
+
+
 @router.post(
     "/team/{team_id:path}/callback",
     tags=["team management"],
@@ -304,10 +321,7 @@ async def add_team_callbacks(
         # Check if team_id exists already
         _existing_team = await prisma_client.get_data(team_id=team_id, table_name="team", query_type="find_unique")
         if _existing_team is None:
-            raise HTTPException(
-                status_code=400,
-                detail={"error": f"Team id = {team_id} does not exist. Please use a different team id."},
-            )
+            raise _unknown_team_error(team_id, user_api_key_dict, status.HTTP_400_BAD_REQUEST)
 
         # IDOR guard: only proxy admins / org admins / team admins of THIS
         # team may write callback credentials. Without this, any
@@ -452,7 +466,7 @@ async def delete_team_callback(
             team_id=team_id, table_name="team", query_type="find_unique"
         )
         if _existing_team is None:
-            raise _callback_error(404, f"Team id = {team_id} does not exist.")
+            raise _unknown_team_error(team_id, user_api_key_dict, status.HTTP_404_NOT_FOUND)
 
         # IDOR guard: only proxy admins / org admins / team admins of THIS team may
         # deregister its callbacks, otherwise any authenticated key holder could
@@ -726,10 +740,7 @@ async def get_team_callbacks(
         # Check if team_id exists
         _existing_team = await prisma_client.get_data(team_id=team_id, table_name="team", query_type="find_unique")
         if _existing_team is None:
-            raise HTTPException(
-                status_code=404,
-                detail={"error": f"Team id = {team_id} does not exist."},
-            )
+            raise _unknown_team_error(team_id, user_api_key_dict, status.HTTP_404_NOT_FOUND)
 
         # IDOR guard: callback metadata holds third-party API credentials
         # (Langfuse / Langsmith / GCS). Only proxy admins / org admins /

--- a/litellm/proxy/management_endpoints/team_callback_endpoints.py
+++ b/litellm/proxy/management_endpoints/team_callback_endpoints.py
@@ -347,11 +347,16 @@ async def add_team_callbacks(
         # flattened into one dict before a request reads them, so an entry
         # naming only a destination would pair with a key written on another
         # entry and carry it to that destination -- a key a team admin can read
-        # back nowhere. Proxy admins are exempt: they already hold every
-        # credential the proxy has.
+        # back nowhere. Repeating a value the owning entry already stores is
+        # fine, which is how one integration covers both events. Proxy admins
+        # are exempt: they already hold every credential the proxy has.
         if user_api_key_dict.user_role != LitellmUserRoles.PROXY_ADMIN:
+            # Decrypted, because the check compares the incoming values against
+            # the stored ones and the credentials are encrypted at rest.
+            decrypted_logging: Final = decrypt_callback_vars(team_metadata).get("logging")
+            stored_entries: Final = decrypted_logging if isinstance(decrypted_logging, list) else ()
             stored_entry_vars: Final = [  # mutable-ok: read-only input to the check, never stored
-                entry.get("callback_vars") or {} for entry in team_callback_settings
+                entry.get("callback_vars") or {} for entry in stored_entries
             ]
             family_error: Final = cross_entry_family_error(data.callback_vars, stored_entry_vars)
             if family_error is not None:

--- a/tests/test_litellm/proxy/auth/test_route_checks.py
+++ b/tests/test_litellm/proxy/auth/test_route_checks.py
@@ -3653,9 +3653,15 @@ def test_team_callback_routes_reach_their_handler_for_non_admins(route, role):
             "/v1beta/models/gemini-2.5-flash:countTokens",
             False,
         ),
+        # a %0A in the value reaches the handler through the path converter, so
+        # the gate has to see it too or DISABLE_ADMIN_ENDPOINTS is bypassable
+        ("/v1/mcp/server/{path:path}", "/v1/mcp/server/abc\ndef", True),
+        ("/team/{team_id:path}/callback", "/team/ten\nant/callback", True),
+        ("/v1beta/models/{model_name:path}:generateContent", "/v1beta/models/gem\nini:generateContent", True),
         # an ordinary placeholder stays one segment
         ("/team/{team_id}/members/me", "/team/abc/members/me", True),
         ("/team/{team_id}/members/me", "/team/tenant/abc/members/me", False),
+        ("/team/{team_id}/members/me", "/team/ab\nc/members/me", True),
     ],
 )
 def test_path_placeholder_matches_what_the_router_accepts(pattern, route, matches):

--- a/tests/test_litellm/proxy/auth/test_route_checks.py
+++ b/tests/test_litellm/proxy/auth/test_route_checks.py
@@ -3551,6 +3551,10 @@ TEAM_CALLBACK_ROUTES = (
     # contain a slash
     "/team/tenant/06bda574/callback",
     "/team/tenant/06bda574/callback/langfuse",
+    # team_id is a free-form string, so it may also contain a colon, which the
+    # gate's :path expansion excludes
+    "/team/tenant:06bda574/callback",
+    "/team/tenant:06bda574/callback/langfuse",
 )
 
 
@@ -3590,8 +3594,13 @@ def test_team_callback_routes_are_self_managed():
     look identical for an internal_user while silently denying the org admins and
     view-only roles that list does not cover.
     """
-    assert "/team/{team_id:path}/callback" in LiteLLMRoutes.self_managed_routes.value
-    assert "/team/{team_id:path}/callback/{callback_name}" in LiteLLMRoutes.self_managed_routes.value
+    for template in (
+        "/team/{team_id:path}/callback",
+        "/team/{team_id:path}/callback/{callback_name}",
+        "/team/{team_id}/callback",
+        "/team/{team_id}/callback/{callback_name}",
+    ):
+        assert template in LiteLLMRoutes.self_managed_routes.value
 
 
 @pytest.mark.parametrize("route", TEAM_CALLBACK_ROUTES)

--- a/tests/test_litellm/proxy/auth/test_route_checks.py
+++ b/tests/test_litellm/proxy/auth/test_route_checks.py
@@ -3670,6 +3670,39 @@ def test_path_placeholder_matches_what_the_router_accepts(pattern, route, matche
     assert RouteChecks._route_matches_pattern(route=route, pattern=pattern) is matches
 
 
+# Every other route the proxy mounts under /team/{team_id}, spelled the way it
+# is registered. None of them takes a path converter, so none can be reached by
+# a URL that ends in the callback suffix.
+PROTECTED_TEAM_ROUTES = (
+    "/team/06bda574-5ca9-43d3-beb8-3b23c2f17112",
+    "/team/06bda574-5ca9-43d3-beb8-3b23c2f17112/disable_logging",
+    "/team/06bda574-5ca9-43d3-beb8-3b23c2f17112/members/me",
+    "/team/06bda574-5ca9-43d3-beb8-3b23c2f17112/member/u-1/reset_spend",
+    # the same routes with the callback suffix spliced in, which is the shape a
+    # caller would craft to make a protected route look self-managed
+    "/team/06bda574/callback/disable_logging/x",
+    "/team/06bda574/callback/member/u-1/reset_spend",
+    "/team/06bda574/callback/members/me",
+)
+
+
+@pytest.mark.parametrize("route", PROTECTED_TEAM_ROUTES)
+def test_the_callback_grant_does_not_reach_another_team_route(route):
+    """Widening the callback templates must not hand out any neighbouring route.
+
+    The grant is two templates ending in the callback suffix. Every other team
+    route registers an ordinary single-segment placeholder, so no URL the router
+    sends to one of them can end in "/callback" or "/callback/<name>" -- and the
+    gate must agree, or a crafted team id would carry a caller into a handler
+    the grant never covered.
+    """
+    for template in (
+        "/team/{team_id:path}/callback",
+        "/team/{team_id:path}/callback/{callback_name}",
+    ):
+        assert RouteChecks._route_matches_pattern(route=route, pattern=template) is False
+
+
 def test_team_disable_logging_stays_proxy_admin_only():
     """disable_logging was left out of the grant, so it must still be rejected at
     the gate. It is the one team callback route a team admin cannot reach."""

--- a/tests/test_litellm/proxy/auth/test_route_checks.py
+++ b/tests/test_litellm/proxy/auth/test_route_checks.py
@@ -3551,10 +3551,13 @@ TEAM_CALLBACK_ROUTES = (
     # contain a slash
     "/team/tenant/06bda574/callback",
     "/team/tenant/06bda574/callback/langfuse",
-    # team_id is a free-form string, so it may also contain a colon, which the
-    # gate's :path expansion excludes
+    # team_id is a free-form string, so it may also contain a colon
     "/team/tenant:06bda574/callback",
     "/team/tenant:06bda574/callback/langfuse",
+    # or both, which is the shape neither a "[^:]+" nor a "[^/]+" expansion
+    # of the placeholder reaches on its own
+    "/team/tenant:acme/prod/callback",
+    "/team/tenant:acme/prod/callback/langfuse",
 )
 
 
@@ -3597,8 +3600,6 @@ def test_team_callback_routes_are_self_managed():
     for template in (
         "/team/{team_id:path}/callback",
         "/team/{team_id:path}/callback/{callback_name}",
-        "/team/{team_id}/callback",
-        "/team/{team_id}/callback/{callback_name}",
     ):
         assert template in LiteLLMRoutes.self_managed_routes.value
 
@@ -3623,6 +3624,50 @@ def test_team_callback_routes_reach_their_handler_for_non_admins(route, role):
     check was unreachable for them.
     """
     assert _gate(route, role) == "allowed"
+
+
+@pytest.mark.parametrize(
+    "pattern, route, matches",
+    [
+        # a :path placeholder takes what the router's path converter takes
+        ("/team/{team_id:path}/callback", "/team/plain/callback", True),
+        ("/team/{team_id:path}/callback", "/team/tenant/acme/callback", True),
+        ("/team/{team_id:path}/callback", "/team/tenant:acme/callback", True),
+        ("/team/{team_id:path}/callback", "/team/tenant:acme/prod/callback", True),
+        # and still has to reach the template's own suffix
+        ("/team/{team_id:path}/callback", "/team/tenant:acme/disable_logging", False),
+        # a template with a ":" literal after the placeholder keeps the suffix
+        (
+            "/v1beta/models/{model_name:path}:generateContent",
+            "/v1beta/models/gemini-2.5-flash:generateContent",
+            True,
+        ),
+        (
+            "/v1beta/models/{model_name:path}:generateContent",
+            "/v1beta/models/publishers/google/gemini-2.5-flash:generateContent",
+            True,
+        ),
+        # the value must not swallow that suffix and match a different verb
+        (
+            "/v1beta/models/{model_name:path}:generateContent",
+            "/v1beta/models/gemini-2.5-flash:countTokens",
+            False,
+        ),
+        # an ordinary placeholder stays one segment
+        ("/team/{team_id}/members/me", "/team/abc/members/me", True),
+        ("/team/{team_id}/members/me", "/team/tenant/abc/members/me", False),
+    ],
+)
+def test_path_placeholder_matches_what_the_router_accepts(pattern, route, matches):
+    """The gate's placeholder expansion has to agree with the router's.
+
+    A team id may carry a slash, a colon, or both, and the router mounted these
+    paths with the same :path converter, so an id the router routes must not be
+    an id the gate fails to recognize. The one narrowing that stays is a template
+    whose own suffix begins with a colon: there the value stops before it, or
+    ":generateContent" would also match a ":countTokens" request.
+    """
+    assert RouteChecks._route_matches_pattern(route=route, pattern=pattern) is matches
 
 
 def test_team_disable_logging_stays_proxy_admin_only():

--- a/tests/test_litellm/proxy/auth/test_route_checks.py
+++ b/tests/test_litellm/proxy/auth/test_route_checks.py
@@ -3544,3 +3544,98 @@ def test_agent_registry_route_gate_open_to_non_admin_roles(user_role, method, ro
         valid_token=valid_token,
         request_data={},
     )
+TEAM_CALLBACK_ROUTES = (
+    "/team/06bda574-5ca9-43d3-beb8-3b23c2f17112/callback",
+    "/team/06bda574-5ca9-43d3-beb8-3b23c2f17112/callback/langfuse",
+    # the routes register team_id with the :path converter, so a team id may
+    # contain a slash
+    "/team/tenant/06bda574/callback",
+    "/team/tenant/06bda574/callback/langfuse",
+)
+
+
+def _gate(route, role) -> str:
+    """Drive the real route gate for a non-proxy-admin caller.
+
+    Reports "allowed" when the gate lets the request through to its handler, and
+    the denial message otherwise, so a caller asserts the verdict as a value
+    instead of on whether an exception escaped.
+    """
+    user_obj = LiteLLM_UserTable(
+        user_id="team_admin_user",
+        user_email="team-admin@example.com",
+        user_role=role,
+    )
+    request = MagicMock(spec=Request)
+    request.query_params = {}
+    try:
+        RouteChecks.non_proxy_admin_allowed_routes_check(
+            user_obj=user_obj,
+            _user_role=role,
+            route=route,
+            request=request,
+            valid_token=UserAPIKeyAuth(user_id="team_admin_user", user_role=role),
+            request_data={},
+        )
+    except Exception as exc:
+        return f"denied: {exc}"
+    return "allowed"
+
+
+def test_team_callback_routes_are_self_managed():
+    """The grant has to come from self_managed_routes specifically.
+
+    That list is the one whose entries carry no role predicate, so the handler
+    decides. Granting the same paths through internal_user_routes instead would
+    look identical for an internal_user while silently denying the org admins and
+    view-only roles that list does not cover.
+    """
+    assert "/team/{team_id:path}/callback" in LiteLLMRoutes.self_managed_routes.value
+    assert "/team/{team_id:path}/callback/{callback_name}" in LiteLLMRoutes.self_managed_routes.value
+
+
+@pytest.mark.parametrize("route", TEAM_CALLBACK_ROUTES)
+@pytest.mark.parametrize(
+    "role",
+    [
+        LitellmUserRoles.INTERNAL_USER.value,
+        LitellmUserRoles.INTERNAL_USER_VIEW_ONLY.value,
+        LitellmUserRoles.ORG_ADMIN.value,
+    ],
+)
+def test_team_callback_routes_reach_their_handler_for_non_admins(route, role):
+    """A team admin manages their own team's logging callbacks, so the route gate
+    must let a non-proxy-admin through to the handler.
+
+    The handler is what authorizes: every team callback endpoint calls
+    _verify_team_access, which admits only a proxy admin, an org admin for the
+    team, or an admin of that team, and 403s everyone else. Before this, the gate
+    rejected the team admin with a 401 naming proxy admin, so the handler's own
+    check was unreachable for them.
+    """
+    assert _gate(route, role) == "allowed"
+
+
+def test_team_disable_logging_stays_proxy_admin_only():
+    """disable_logging was left out of the grant, so it must still be rejected at
+    the gate. It is the one team callback route a team admin cannot reach."""
+    verdict = _gate(
+        "/team/06bda574-5ca9-43d3-beb8-3b23c2f17112/disable_logging",
+        LitellmUserRoles.INTERNAL_USER.value,
+    )
+
+    assert "Only proxy admin" in verdict
+    assert "disable_logging" in verdict
+
+
+@pytest.mark.parametrize(
+    "route",
+    [
+        "/team/06bda574-5ca9-43d3-beb8-3b23c2f17112",
+        "/team/update",
+        "/team/06bda574-5ca9-43d3-beb8-3b23c2f17112/model/add",
+    ],
+)
+def test_neighbouring_team_routes_stay_closed(route):
+    """The grant is the callback paths and nothing else on the team namespace."""
+    assert "Only proxy admin" in _gate(route, LitellmUserRoles.INTERNAL_USER.value)

--- a/tests/test_litellm/proxy/management_endpoints/test_team_callback_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_team_callback_endpoints.py
@@ -19,6 +19,7 @@ from litellm.proxy._types import (
     LitellmUserRoles,
     UserAPIKeyAuth,
 )
+from litellm.proxy.common_utils.callback_config_validation import cross_entry_family_error
 from litellm.proxy.management_endpoints.team_callback_endpoints import (
     add_team_callbacks,
     delete_team_callback,
@@ -1518,3 +1519,33 @@ async def test_proxy_admin_still_told_the_team_is_unknown():
 
     assert exc.value.status_code == 404
     assert "does not exist" in str(exc.value.detail)
+
+
+@pytest.mark.parametrize(
+    "new_vars, stored, rejected",
+    [
+        # the redirect, in every carrier a caller could pick: an entry naming
+        # only a host, pairing with a key pair written on another entry
+        ({"langfuse_host": "http://attacker.invalid"}, [{"langfuse_public_key": "pk", "langfuse_secret_key": "sk"}], True),
+        # the sibling carrier -- langfuse and langfuse_otel are one account
+        ({"langfuse_host": "http://attacker.invalid"}, [{"langfuse_host": "https://us.cloud.langfuse.com", "langfuse_secret_key": "sk"}], True),
+        # a destination variable no integration registry lists
+        ({"dd_agent_host": "attacker.invalid"}, [{"dd_api_key": "k", "dd_site": "us5.datadoghq.com"}], True),
+        # one entry owning its family end to end is the feature
+        ({"langfuse_host": "https://eu.cloud.langfuse.com", "langfuse_public_key": "pk", "langfuse_secret_key": "sk"}, [], False),
+        # a different family alongside an existing one stays fine
+        ({"gcs_bucket_name": "bucket"}, [{"langfuse_public_key": "pk", "langfuse_secret_key": "sk"}], False),
+        ({"langsmith_api_key": "k"}, [{"dd_api_key": "k"}], False),
+        # variables that configure no backend carry nothing to redirect
+        ({"turn_off_message_logging": "true"}, [{"langfuse_secret_key": "sk"}], False),
+    ],
+)
+def test_one_entry_owns_a_credential_family(new_vars, stored, rejected):
+    """A team admin must not be able to redirect a credential they cannot read.
+
+    The stored entries are flattened into one dict before a request reads them,
+    so an entry naming only a destination pairs with a key written elsewhere and
+    carries it to that destination.
+    """
+    error = cross_entry_family_error(new_vars, stored)
+    assert (error is not None) is rejected

--- a/tests/test_litellm/proxy/management_endpoints/test_team_callback_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_team_callback_endpoints.py
@@ -1543,6 +1543,9 @@ async def test_proxy_admin_still_told_the_team_is_unknown():
         ({"langfuse_host": "https://us.cloud.langfuse.com", "langfuse_public_key": "pk", "langfuse_secret_key": "sk"}, [{"langfuse_host": "https://us.cloud.langfuse.com", "langfuse_public_key": "pk", "langfuse_secret_key": "sk"}], False),
         # the same credential under its other spelling is the same credential
         ({"langfuse_secret": "sk"}, [{"langfuse_public_key": "pk", "langfuse_secret_key": "sk"}], False),
+        # a value the family already holds cannot be moved into another of its
+        # variables either; the exporter would address or authenticate with it
+        ({"langfuse_host": "pk"}, [{"langfuse_host": "https://us.cloud.langfuse.com", "langfuse_public_key": "pk"}], True),
         # the same shape with one value moved is the redirect again
         ({"langfuse_host": "http://attacker.invalid", "langfuse_public_key": "pk", "langfuse_secret_key": "sk"}, [{"langfuse_host": "https://us.cloud.langfuse.com", "langfuse_public_key": "pk", "langfuse_secret_key": "sk"}], True),
     ],

--- a/tests/test_litellm/proxy/management_endpoints/test_team_callback_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_team_callback_endpoints.py
@@ -1538,6 +1538,11 @@ async def test_proxy_admin_still_told_the_team_is_unknown():
         ({"langsmith_api_key": "k"}, [{"dd_api_key": "k"}], False),
         # variables that configure no backend carry nothing to redirect
         ({"turn_off_message_logging": "true"}, [{"langfuse_secret_key": "sk"}], False),
+        # the same integration registered for a second event: identical values
+        # flatten to the identical dict, so there is nothing to redirect
+        ({"langfuse_host": "https://us.cloud.langfuse.com", "langfuse_public_key": "pk", "langfuse_secret_key": "sk"}, [{"langfuse_host": "https://us.cloud.langfuse.com", "langfuse_public_key": "pk", "langfuse_secret_key": "sk"}], False),
+        # the same shape with one value moved is the redirect again
+        ({"langfuse_host": "http://attacker.invalid", "langfuse_public_key": "pk", "langfuse_secret_key": "sk"}, [{"langfuse_host": "https://us.cloud.langfuse.com", "langfuse_public_key": "pk", "langfuse_secret_key": "sk"}], True),
     ],
 )
 def test_one_entry_owns_a_credential_family(new_vars, stored, rejected):

--- a/tests/test_litellm/proxy/management_endpoints/test_team_callback_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_team_callback_endpoints.py
@@ -1443,3 +1443,78 @@ async def test_delete_team_callback_route_accepts_team_ids_containing_slashes():
     assert response.json()["data"]["success_callbacks"] == ["langsmith"]
     written = json.loads(mock_prisma.db.litellm_teamtable.update.await_args.kwargs["data"]["metadata"])
     assert [entry["callback_name"] for entry in written["logging"]] == ["langsmith"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "call_handler",
+    [
+        lambda caller: add_team_callbacks(
+            data=AddTeamCallback(
+                callback_name="langfuse",
+                callback_type="success",
+                callback_vars={"langfuse_public_key": "pk", "langfuse_secret_key": "sk"},
+            ),
+            http_request=Mock(spec=Request),
+            team_id="team-does-not-exist",
+            user_api_key_dict=caller,
+        ),
+        lambda caller: get_team_callbacks(
+            http_request=Mock(spec=Request),
+            team_id="team-does-not-exist",
+            user_api_key_dict=caller,
+        ),
+        lambda caller: delete_team_callback(
+            http_request=Mock(spec=Request),
+            team_id="team-does-not-exist",
+            callback_name="langfuse",
+            user_api_key_dict=caller,
+        ),
+    ],
+    ids=["add", "get", "delete"],
+)
+async def test_unknown_team_is_indistinguishable_from_no_access(call_handler, unauthorized_caller):
+    """An unauthorized caller must not learn whether a team id exists.
+
+    These routes are reachable by any authenticated caller so a team admin can get
+    as far as the access check, so a distinct "does not exist" would turn them into
+    a probe for valid team ids. The unknown-team response has to match the
+    no-access one exactly, status and body.
+    """
+    with patch("litellm.proxy.proxy_server.prisma_client") as mock_client:  # test-quality-ok: the handler imports prisma_client from proxy_server at call time, so there is no seam to inject through
+        mock_client.get_data = AsyncMock(return_value=None)
+        with pytest.raises(HTTPException) as unknown_team:
+            await call_handler(unauthorized_caller)
+
+    with patch("litellm.proxy.proxy_server.prisma_client") as mock_client:  # test-quality-ok: the handler imports prisma_client from proxy_server at call time, so there is no seam to inject through
+        mock_client.get_data = AsyncMock(return_value=_team_row())
+        mock_client.db.litellm_teamtable.update = AsyncMock()
+        with patch(  # test-quality-ok: _verify_team_access calls this module-level helper directly, so there is no seam to inject through
+            "litellm.proxy.management_endpoints.team_endpoints._is_user_org_admin_for_team",
+            new_callable=AsyncMock,
+            return_value=False,
+        ):
+            with pytest.raises(HTTPException) as no_access:
+                await call_handler(unauthorized_caller)
+
+    assert unknown_team.value.status_code == no_access.value.status_code == 403
+    assert unknown_team.value.detail == no_access.value.detail
+    assert "does not exist" not in str(unknown_team.value.detail)
+
+
+@pytest.mark.asyncio
+async def test_proxy_admin_still_told_the_team_is_unknown():
+    """The masking is only for callers who could not have managed the team; a proxy
+    admin keeps the diagnosable error."""
+    admin = UserAPIKeyAuth(user_role=LitellmUserRoles.PROXY_ADMIN, user_id="admin", api_key="sk-admin")
+    with patch("litellm.proxy.proxy_server.prisma_client") as mock_client:  # test-quality-ok: the handler imports prisma_client from proxy_server at call time, so there is no seam to inject through
+        mock_client.get_data = AsyncMock(return_value=None)
+        with pytest.raises(HTTPException) as exc:
+            await get_team_callbacks(
+                http_request=Mock(spec=Request),
+                team_id="team-does-not-exist",
+                user_api_key_dict=admin,
+            )
+
+    assert exc.value.status_code == 404
+    assert "does not exist" in str(exc.value.detail)

--- a/tests/test_litellm/proxy/management_endpoints/test_team_callback_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_team_callback_endpoints.py
@@ -1541,6 +1541,8 @@ async def test_proxy_admin_still_told_the_team_is_unknown():
         # the same integration registered for a second event: identical values
         # flatten to the identical dict, so there is nothing to redirect
         ({"langfuse_host": "https://us.cloud.langfuse.com", "langfuse_public_key": "pk", "langfuse_secret_key": "sk"}, [{"langfuse_host": "https://us.cloud.langfuse.com", "langfuse_public_key": "pk", "langfuse_secret_key": "sk"}], False),
+        # the same credential under its other spelling is the same credential
+        ({"langfuse_secret": "sk"}, [{"langfuse_public_key": "pk", "langfuse_secret_key": "sk"}], False),
         # the same shape with one value moved is the redirect again
         ({"langfuse_host": "http://attacker.invalid", "langfuse_public_key": "pk", "langfuse_secret_key": "sk"}, [{"langfuse_host": "https://us.cloud.langfuse.com", "langfuse_public_key": "pk", "langfuse_secret_key": "sk"}], True),
     ],


### PR DESCRIPTION
## TLDR

Problem this solves:

- A team admin could not manage their own team's logging callbacks
- The route gate answered 401 naming proxy admin
- The endpoints' own team-admin authorization was unreachable for them

How it solves it:

- Add the two callback paths to `self_managed_routes`
- The handler's existing `_verify_team_access` stays the only authority
- Same shape as `/team/member_add` and `/team/permissions_update`
- Unknown teams stop being distinguishable from teams you cannot manage

## User Flow

Before: a team admin who wants their team's traces in their team's own Langfuse cannot set it up, and is told to go find a proxy admin

1. They send `POST https://litellm-domain/team/<their-team-id>/callback` with their Langfuse public and secret key
2. The proxy answers 401, `Only proxy admin can be used to generate, delete, update info for new keys/users/teams. Route=/team/<their-team-id>/callback. Your role=internal_user`
3. `GET` on the same path answers 401 too, so they cannot even see what their team currently logs to
4. Every change to their own team's logging has to go through whoever holds the master key

After: the same team admin sets it up themselves, and nobody else's team is reachable

1. They send the same `POST https://litellm-domain/team/<their-team-id>/callback` and get 200 with the updated team
2. `GET` on that path returns their callback with `langfuse_public_key` and `langfuse_secret_key` shown as `***REDACTED***`
3. `DELETE https://litellm-domain/team/<their-team-id>/callback/langfuse` removes it and answers 200
4. The same calls against a team they do not administer answer 403, and a non-admin member of their own team also gets 403
5. Traffic on a key belonging to that team now arrives in the Langfuse the team admin named, with no proxy admin involved

## Relevant issues

## Linear ticket

Resolves LIT-7336

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Live proxy on a real Postgres, and a real Gemini call for the end-to-end case. No mocks. The proxy runs with only a master key configured.

Shared setup, identical on both sides:

```bash
# two internal users: one is an admin of team A, the other a plain member of it
ADM=$(curl -s -X POST http://127.0.0.1:4141/user/new -H "$MASTER" -H "$JSON" \
  -d '{"user_email":"teamadmin@rig.local","user_role":"internal_user"}')
MEM=$(curl -s -X POST http://127.0.0.1:4141/user/new -H "$MASTER" -H "$JSON" \
  -d '{"user_email":"member@rig.local","user_role":"internal_user"}')

# team A has both, team B has neither
curl -s -X POST http://127.0.0.1:4141/team/new -H "$MASTER" -H "$JSON" -d '{
  "team_alias":"team-a",
  "members_with_roles":[{"user_id":"<ADM_ID>","role":"admin"},{"user_id":"<MEM_ID>","role":"user"}]}'
curl -s -X POST http://127.0.0.1:4141/team/new -H "$MASTER" -H "$JSON" -d '{"team_alias":"team-b"}'

# a virtual key belonging to nobody and no team, for the probing case
ANON=$(curl -s -X POST http://127.0.0.1:4141/key/generate -H "$MASTER" -H "$JSON" -d '{"key_alias":"anon"}')

BODY='{"callback_name":"langfuse","callback_type":"success","callback_vars":{
  "langfuse_public_key":"pk-team-a","langfuse_secret_key":"sk-team-a",
  "langfuse_host":"http://team-a-langfuse:3100"}}'
GHOST=00000000-dead-beef-0000-000000000000
```

### Before (487356733c7254944e7825bdd7c87e6d8f262e8f)

#### A team admin manages their own team's callbacks

1. Add, read, then remove a callback on the team they administer

```bash
curl -s -o /dev/null -w '%{http_code}\n' -X POST   "http://127.0.0.1:4141/team/$TEAM_A/callback"          -H "Authorization: Bearer $ADM_KEY" -H "$JSON" -d "$BODY"
curl -s -o /dev/null -w '%{http_code}\n'           "http://127.0.0.1:4141/team/$TEAM_A/callback"          -H "Authorization: Bearer $ADM_KEY"
curl -s -o /dev/null -w '%{http_code}\n' -X DELETE "http://127.0.0.1:4141/team/$TEAM_A/callback/langfuse" -H "Authorization: Bearer $ADM_KEY"
```

```
401
401
401
```

2. Read the denial

```bash
curl -s -X POST "http://127.0.0.1:4141/team/$TEAM_A/callback" -H "Authorization: Bearer $ADM_KEY" -H "$JSON" -d "$BODY"
```

```
{"error":{"message":"Authentication Error, Only proxy admin can be used to generate, delete, update info
for new keys/users/teams. Route=/team/06bda574-5ca9-43d3-beb8-3b23c2f17112/callback.
Your role=internal_user. Your user_id=e66223****************************3c","type":"auth_error","code":"401"}}
```

#### The denials that must survive

3. Another team, a non-admin member, the master key, and disable_logging

```bash
curl -s -o /dev/null -w '%{http_code}\n' -X POST "http://127.0.0.1:4141/team/$TEAM_B/callback"      -H "Authorization: Bearer $ADM_KEY" -H "$JSON" -d "$BODY"
curl -s -o /dev/null -w '%{http_code}\n' -X POST "http://127.0.0.1:4141/team/$TEAM_A/callback"      -H "Authorization: Bearer $MEM_KEY" -H "$JSON" -d "$BODY"
curl -s -o /dev/null -w '%{http_code}\n'         "http://127.0.0.1:4141/team/$TEAM_A/callback"      -H "$MASTER"
curl -s -o /dev/null -w '%{http_code}\n' -X POST "http://127.0.0.1:4141/team/$TEAM_A/disable_logging" -H "Authorization: Bearer $ADM_KEY" -H "$JSON" -d '{}'
```

```
401     team B as team-A admin
401     team A as a plain member
200     master key
401     disable_logging
```

#### An unrelated key cannot tell whether a team exists

4. Probe a real team id and a made-up one with a key belonging to no team

```bash
curl -s -w ' %{http_code}\n' "http://127.0.0.1:4141/team/$TEAM_A/callback" -H "Authorization: Bearer $ANON"
curl -s -w ' %{http_code}\n' "http://127.0.0.1:4141/team/$GHOST/callback"  -H "Authorization: Bearer $ANON"
```

```
{"error":{"message":"Authentication Error, Only proxy admin can be used to ..."}} 401
{"error":{"message":"Authentication Error, Only proxy admin can be used to ..."}} 401
```

Indistinguishable, because the gate rejects both before the handler runs

### After (f9852a6acd2272e0666d9b9baee4438911c7f9d6)

#### A team admin manages their own team's callbacks

1. Add, read, then remove a callback on the team they administer

```bash
curl -s -o /dev/null -w '%{http_code}\n' -X POST   "http://127.0.0.1:4141/team/$TEAM_A/callback"          -H "Authorization: Bearer $ADM_KEY" -H "$JSON" -d "$BODY"
curl -s -o /dev/null -w '%{http_code}\n'           "http://127.0.0.1:4141/team/$TEAM_A/callback"          -H "Authorization: Bearer $ADM_KEY"
curl -s -o /dev/null -w '%{http_code}\n' -X DELETE "http://127.0.0.1:4141/team/$TEAM_A/callback/langfuse" -H "Authorization: Bearer $ADM_KEY"
```

```
200
200
200
```

2. Read what GET returns to them

```bash
curl -s "http://127.0.0.1:4141/team/$TEAM_A/callback" -H "Authorization: Bearer $ADM_KEY"
```

```
{"status":"success","data":{"team_id":"06bda574-5ca9-43d3-beb8-3b23c2f17112",
"success_callbacks":["langfuse"],"failure_callbacks":[],
"callback_vars":{"langfuse_host":"http://team-a-langfuse:3100",
"langfuse_public_key":"***REDACTED***","langfuse_secret_key":"***REDACTED***"}}}
```

#### The denials that must survive

3. Another team, a non-admin member, the master key, and disable_logging

```bash
curl -s -o /dev/null -w '%{http_code}\n' -X POST "http://127.0.0.1:4141/team/$TEAM_B/callback"      -H "Authorization: Bearer $ADM_KEY" -H "$JSON" -d "$BODY"
curl -s -o /dev/null -w '%{http_code}\n' -X POST "http://127.0.0.1:4141/team/$TEAM_A/callback"      -H "Authorization: Bearer $MEM_KEY" -H "$JSON" -d "$BODY"
curl -s -o /dev/null -w '%{http_code}\n'         "http://127.0.0.1:4141/team/$TEAM_A/callback"      -H "$MASTER"
curl -s -o /dev/null -w '%{http_code}\n' -X POST "http://127.0.0.1:4141/team/$TEAM_A/disable_logging" -H "Authorization: Bearer $ADM_KEY" -H "$JSON" -d '{}'
```

```
403     team B as team-A admin, now the handler answers instead of the gate
403     team A as a plain member
200     master key, unchanged
401     disable_logging, deliberately still proxy-admin only
```

4. The roles that must not pick up write access

```bash
for K in "$VIEW_ONLY_ADMIN_KEY" "$INTERNAL_USER_VIEWER_KEY" "$ANON"; do
  curl -s -o /dev/null -w '%{http_code}\n' -X POST "http://127.0.0.1:4141/team/$TEAM_A/callback" -H "Authorization: Bearer $K" -H "$JSON" -d "$BODY"
done
```

```
403     proxy_admin_viewer
403     internal_user_viewer
403     virtual key with no user and no team
```

#### An unrelated key cannot tell whether a team exists

5. The same probe, now that the handler is reachable

```bash
curl -s -w ' %{http_code}\n' "http://127.0.0.1:4141/team/$TEAM_A/callback" -H "Authorization: Bearer $ANON"
curl -s -w ' %{http_code}\n' "http://127.0.0.1:4141/team/$GHOST/callback"  -H "Authorization: Bearer $ANON"
curl -s -w ' %{http_code}\n' "http://127.0.0.1:4141/team/$GHOST/callback"  -H "$MASTER"
```

```
{"detail":"You do not have access to this team"} 403
{"detail":"You do not have access to this team"} 403
{"detail":{"error":"Team id = 00000000-dead-beef-0000-000000000000 does not exist."}} 404
```

Byte-identical for the unrelated key whether or not the team exists, and the proxy admin keeps the diagnosable error

#### End to end, a real call lands in the team's Langfuse

6. The team admin points their team at a real self-hosted Langfuse, then traffic on a team key arrives there

```bash
curl -s -X POST "http://127.0.0.1:4141/team/$TEAM_A/callback" -H "Authorization: Bearer $ADM_KEY" -H "$JSON" -d "$REAL_LANGFUSE_BODY"
TKEY=$(curl -s -X POST http://127.0.0.1:4141/key/generate -H "$MASTER" -H "$JSON" -d "{\"team_id\":\"$TEAM_A\",\"models\":[\"gpt-4o\"]}" | jq -r .key)
curl -s -u "$PK:$SK" "http://localhost:3100/api/public/traces?limit=1" | jq .meta.totalItems
curl -s -X POST http://127.0.0.1:4141/v1/chat/completions -H "Authorization: Bearer $TKEY" -H "$JSON" \
  -d '{"model":"gpt-4o","messages":[{"role":"user","content":"Say only: LIT5141-E2E-104453"}],"max_tokens":2000}' | jq -r .choices[0].message.content
sleep 14
curl -s -u "$PK:$SK" "http://localhost:3100/api/public/traces?limit=1" | jq .meta.totalItems
```

```
200                     the team admin registered the destination themselves
32                      traces in that Langfuse project before the call
LIT5141-E2E-104453      real Gemini response through the proxy
33                      the call arrived, with no proxy admin involved
```

### Live multi-tenant run (head `2e0d81a9da`)

Two litellm organizations, two teams each, every team with its own team-admin
internal user and its own team key. Head `2e0d81a9da` on `:4300`, base
`c50d83ece2` on `:4301`, the `e64b6f6a68` feature commit alone on `:4302`,
all three against the same database.

Each team's own admin POSTing its own team's logging callback:

| litellm org | team | base `c50d83ece2` | head `2e0d81a9da` |
| --- | --- | --- | --- |
| org 1 | nw-research | 401 | 200 |
| org 1 | nw-platform | 401 | 200 |
| org 2 | sg-clinical | 401 | 200 |
| org 2 | sg-billing | 401 | 200 |

#### The denials, on the live rig

| caller | request | head |
| --- | --- | --- |
| the team's own admin | `GET /team/{id}/callback` | 200 |
| a plain member of that team | `GET /team/{id}/callback` | 403 |
| another team's admin | `GET /team/{id}/callback` | 403 |
| a team admin, unknown team id | `GET /team/{unknown}/callback` | 403, not 404 — no existence oracle |
| the proxy admin, unknown team id | `GET /team/{unknown}/callback` | 404, diagnosable |
| the team's own admin | `POST /team/{id}/disable_logging` | 401 — still proxy-admin only |

#### Team ids the router accepts but the gate did not

`team_id` is a free-form string and the routes mount it with the `:path`
converter, so a slash, a colon, or both are all reachable. The gate expanded
`{x:path}` to `[^:]+`, which stops at a colon. Listing a second `{x}` spelling
covered a colon or a slash but never both, so the last commit makes the gate's
expansion match the router's converter instead. Live, on the same database:

| team id | route | `e64b6f6a68` | `db80501232` |
| --- | --- | --- | --- |
| `tenant/nw-01` | `POST .../callback` | 200 | 200 |
| `tenant:nw-02` | `POST .../callback` | 401 | 200 |
| `tenant:acme/prod` | `POST .../callback` | 401 | 200 |
| `tenant/nw-01` | `DELETE .../callback/{name}` | 200 | 200 |
| `tenant:nw-02` | `DELETE .../callback/{name}` | 401 | 200 |
| `tenant:acme/prod` | `DELETE .../callback/{name}` | 401 | 200 |

The denials hold on those ids too — a plain member of `tenant:acme/prod` still
gets 403 on its callback route, and a team admin still gets 401 on
`disable_logging`.

The one narrowing that stays is a template carrying a `:` literal of its own
after the placeholder: `/v1beta/models/{model_name:path}:generateContent` must
not also match a `:countTokens` request, and a test pins that.

The expansion spans newlines (`[\s\S]+`, not `.+`). `.` stops at a newline and
the path converter does not, so a `%0A` anywhere in the value would leave the
route unmatched here while still reaching the handler, and every list built on
this matcher would inherit that. Driven on a proxy with `DISABLE_ADMIN_ENDPOINTS`
set and a real license:

| request | base `c50d83ece2` | head |
| --- | --- | --- |
| `DELETE /v1/mcp/server/abc123` | 403 gate | 403 gate |
| `DELETE /v1/mcp/server/abc%0Adef` | 403 gate | 403 gate |
| `DELETE /v1/mcp/server/abc%0D%0Adef` | 403 gate | 403 gate |
| `DELETE /v1/mcp/server/abc:def` | 404 from the handler, gate never saw it | 403 gate |

The colon row is the gate getting stricter: base expanded `:path` to `[^:]+`, so
a colon in the id skipped `is_management_route` and the request reached the MCP
handler with `DISABLE_ADMIN_ENDPOINTS` on.

#### One entry owns a credential family end to end

Every stored entry's `callback_vars` are flattened into one dict before a request
reads them, and that dict is what the exporter authenticates and addresses with.
So an entry naming only a destination is enough to redirect a credential written
somewhere else: a host on a second entry pairs with the key pair from the first,
and the request carries that key pair to the new host. A team admin cannot read
the team's masked Langfuse secret, but could add such an entry and receive it.

Driven on the live rig, a proxy admin registers the credentials and a team admin
adds a second entry whose only variable is a destination they control:

| the team admin's second entry | `e64b6f6a68` | `75b717ba73` |
| --- | --- | --- |
| `langfuse` carrying only `langfuse_host` | 200, and the team's key pair arrives at that host | 400 |
| `gcs_bucket` carrying only `langfuse_host` | 200 | 400 |
| `gcs_bucket` carrying only `dd_agent_host` | 200 | 400 |

The rule is by credential family rather than by callback name. `langfuse` and
`langfuse_otel` configure one Langfuse project, so naming alone would let them
redirect each other, and a destination like `dd_agent_host` that no integration
registry lists still pairs with the Datadog credentials beside it.

Two rules together keep the flattened dict out of the caller's hands. A variable
the family already configures has to keep the value it has, so nothing already in
use can be moved. A variable the family does not configure yet may only carry a
value the family already holds, which is what lets one credential go in under its
other spelling (`langfuse_secret` and `langfuse_secret_key` are one key) without
any alias table having to stay complete. Between them no value the caller chose
can enter the family, and repeating the family as it stands is still allowed --
that is how one integration covers both the success and the failure event. The
stored side is decrypted before the comparison, because the credentials are
encrypted at rest.

It binds only the writers this PR admits. A proxy admin already holds every
credential the proxy has, so the rule would buy nothing there and would break
configs that predate it. A team admin who does want to move a family deletes the
entry holding it first, which reveals nothing.

| team admin writes | head |
| --- | --- |
| `langfuse` for the success event, then the same values for the failure event | 200, both events registered |
| a second entry repeating the stored secret as `langfuse_secret` | 200 |
| `langfuse_otel` with its own host and key pair, nothing else stored | 200 |
| `gcs_bucket` alongside a stored Langfuse entry | 200 |
| `langsmith` alongside a stored Datadog entry | 200 |
| `turn_off_message_logging`, which configures no backend | 200 |
| a second entry repeating the family with one value moved | 400 |
| a second entry putting the stored public key in `langfuse_host` | 400 |
| any of the redirect shapes above | 400 |
| the same write as a proxy admin | 200 |

#### The callbacks a team admin sets actually take effect

Each of the four teams was pointed at its own project on a real Langfuse and
drove real Gemini traffic on its own key. Every team's trace landed in its own
project and nowhere else — screenshots and the walkthrough are on #37564, which
this PR is stacked on.

![tenant isolation walkthrough](https://raw.githubusercontent.com/BerriAI/litellm/assets-pr37564-37667/07-tenant-isolation.gif)

## Type

🆕 New Feature

## Caveats (if any)

Docs: BerriAI/litellm-docs#1101 adds who may call the team callback endpoints to the team logging page.

- The Admin UI still saves team logging through `/team/update`
- That route stays proxy-admin only, so the dashboard flow is unchanged
- `disable_logging` stays proxy-admin only, a scope call not a boundary
- Unknown teams now read as 403 to callers who could not manage them
- Each callback path is listed twice, `{team_id:path}` and `{team_id}`, because
  the route gate expands the first to `[^:]+` and the second to `[^/]+`, so
  neither one alone covers every team id the router accepts. The shared matcher
  is left alone; every other `:path` route depends on its colon behavior
- Callback destinations are still unvalidated, exactly as they are for a proxy
  admin today. A proxy admin can already point a team callback at an internal
  address on current staging, so a destination policy is a proxy-wide change and
  is filed on the ticket rather than bolted onto this grant

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/berriai/litellm/pull/37667" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes authentication routing, path matching used across management gates, and team logging credential writes—areas where mistakes could widen access or leak team existence.
> 
> **Overview**
> **Team admins** can reach `POST`/`GET`/`DELETE` on `/team/{team_id}/callback` without proxy-admin at the route gate: those paths join **`self_managed_routes`**, while **`_verify_team_access`** in the handlers still limits who can read or write credentials.
> 
> The route matcher’s **`{…:path}`** expansion now tracks FastAPI (slashes, colons, newlines in ids) and still stops before literal suffixes like **`:generateContent`**, so team ids such as `tenant:acme/prod` are not wrongly blocked and admin-route lists are not bypassable via `%0A`.
> 
> **Security on writes:** non–proxy-admins adding callbacks run **`cross_entry_family_error`** so a second entry cannot pair a hostile host with secrets from another entry (flattened `callback_vars`). Unknown teams return the same **403** as “no access” for unauthorized callers; proxy admins still get explicit not-found errors.
> 
> Tests cover the gate, placeholder matching, family validation, and team-id probing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 39f634ad53408275e8c15a3e969421c7b1a8c023. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->










