### PR TITLE
fix(mcp): normalize auth schemes so MCP egress emits exactly one prefix

### DIFF
--- a/litellm/experimental_mcp_client/client.py
+++ b/litellm/experimental_mcp_client/client.py
@@ -51,6 +51,42 @@ def to_basic_auth(auth_value: str) -> str:
     return base64.b64encode(auth_value.encode("utf-8")).decode()
 
 
+def strip_auth_scheme(auth_value: str, scheme: str) -> str:
+    """Return ``auth_value`` with a leading ``<scheme> `` removed, or unchanged when absent.
+
+    Callers supply both a bare credential and a complete header value, so prefixing
+    unconditionally yields ``Bearer Bearer <jwt>``. Scheme names are case-insensitive per
+    RFC 7235. A credential is required after the scheme, so both a token that merely begins
+    with the scheme text and a scheme with nothing behind it are returned untouched.
+    Surrounding whitespace is left to ``_strip_header_whitespace`` at header-build time.
+    """
+    scheme_name, _, remainder = auth_value.lstrip().partition(" ")
+    credential: Final = remainder.lstrip()
+    if credential and scheme_name.lower() == scheme.lower():
+        return credential
+    return auth_value
+
+
+def to_basic_credentials(auth_value: str) -> str:
+    """Return the base64 credentials for a ``Basic`` header, encoding only when needed.
+
+    ``Basic <credentials>`` carries credentials that are already encoded, so encoding the whole
+    value again would bury the scheme inside the payload. This has to run before
+    :func:`to_basic_auth` rather than at header-build time, where no prefix is left to find.
+    A schemed value whose remainder does not decode is the bare ``username:password`` shape with
+    the scheme written in front of it, and is encoded rather than forwarded as an invalid header;
+    a pair always contains ``:``, which is outside the base64 alphabet, so the two never collide.
+    """
+    credentials: Final = strip_auth_scheme(auth_value, "Basic")
+    if credentials == auth_value:
+        return to_basic_auth(auth_value)
+    try:
+        base64.b64decode(credentials, validate=True)
+    except ValueError:
+        return to_basic_auth(credentials)
+    return credentials
+
+
 def _strip_header_whitespace(headers: dict[str, str]) -> dict[str, str]:
     return {
         (key.strip() if isinstance(key, str) else key): (value.strip() if isinstance(value, str) else value)
@@ -441,16 +477,15 @@ class MCPClient:
                 except BaseException as e:
                     verbose_logger.debug("Error during http_client cleanup: %s", e)
 
-    def update_auth_value(self, mcp_auth_value: str | dict[str, str]):
+    def update_auth_value(self, mcp_auth_value: str | dict[str, str]) -> None:
         """
         Set the authentication header for the MCP client.
         """
         if isinstance(mcp_auth_value, dict):
             self._mcp_auth_value = mcp_auth_value
+        elif self.auth_type == MCPAuth.basic:
+            self._mcp_auth_value = to_basic_credentials(mcp_auth_value)
         else:
-            if self.auth_type == MCPAuth.basic:
-                # Assuming mcp_auth_value is in format "username:password", convert it when updating
-                mcp_auth_value = to_basic_auth(mcp_auth_value)
             self._mcp_auth_value = mcp_auth_value
 
     def _get_auth_headers(self) -> dict:
@@ -459,19 +494,20 @@ class MCPClient:
         if self._mcp_auth_value:
             if isinstance(self._mcp_auth_value, str):
                 if self.auth_type == MCPAuth.bearer_token:
-                    headers["Authorization"] = f"Bearer {self._mcp_auth_value}"
+                    headers["Authorization"] = f"Bearer {strip_auth_scheme(self._mcp_auth_value, 'Bearer')}"
                 elif self.auth_type == MCPAuth.basic:
                     headers["Authorization"] = f"Basic {self._mcp_auth_value}"
                 elif self.auth_type == MCPAuth.api_key:
                     headers["X-API-Key"] = self._mcp_auth_value
                 elif self.auth_type == MCPAuth.authorization:
+                    # This auth type means the caller owns the whole header value.
                     headers["Authorization"] = self._mcp_auth_value
                 elif self.auth_type == MCPAuth.oauth2:
-                    headers["Authorization"] = f"Bearer {self._mcp_auth_value}"
+                    headers["Authorization"] = f"Bearer {strip_auth_scheme(self._mcp_auth_value, 'Bearer')}"
                 elif self.auth_type == MCPAuth.token:
-                    headers["Authorization"] = f"token {self._mcp_auth_value}"
+                    headers["Authorization"] = f"token {strip_auth_scheme(self._mcp_auth_value, 'token')}"
                 elif self.auth_type == MCPAuth.oauth2_token_exchange:
-                    headers["Authorization"] = f"Bearer {self._mcp_auth_value}"
+                    headers["Authorization"] = f"Bearer {strip_auth_scheme(self._mcp_auth_value, 'Bearer')}"
             elif isinstance(self._mcp_auth_value, dict):
                 headers.update(self._mcp_auth_value)
         # Note: aws_sigv4 auth is not handled here — SigV4 requires per-request

--- a/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
+++ b/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
@@ -46,7 +46,7 @@ from litellm.constants import (
     MCP_TOOL_LISTING_TIMEOUT,
 )
 from litellm.exceptions import BlockedPiiEntityError, GuardrailRaisedException
-from litellm.experimental_mcp_client.client import MCPClient, MCPSigV4Auth
+from litellm.experimental_mcp_client.client import MCPClient, MCPSigV4Auth, strip_auth_scheme
 from litellm.integrations.custom_guardrail import (
     _sync_guardrail_info_to_logging_obj,  # pyright: ignore[reportPrivateUsage] - the same bridge @log_guardrail_information uses; reimplementing it here would fork the metadata-key logic
 )
@@ -841,12 +841,17 @@ def _without_authorization(
 
 
 def _format_byok_openapi_auth_header(mcp_server: MCPServer, mcp_auth_header: str) -> str:
-    """Format a raw BYOK credential for OpenAPI tool ``Authorization`` injection."""
+    """Format a raw BYOK credential for OpenAPI tool ``Authorization`` injection.
+
+    A non-BYOK server short-circuits ``_resolve_byok_mcp_auth_header``, so the value here can also
+    be the deprecated global ``x-mcp-auth``, which is a complete header value and would otherwise
+    be given a second scheme.
+    """
     if mcp_server.auth_type == MCPAuth.api_key:
-        return f"ApiKey {mcp_auth_header}"
+        return f"ApiKey {strip_auth_scheme(mcp_auth_header, 'ApiKey')}"
     if mcp_server.auth_type == MCPAuth.basic:
-        return f"Basic {mcp_auth_header}"
-    return f"Bearer {mcp_auth_header}"
+        return f"Basic {strip_auth_scheme(mcp_auth_header, 'Basic')}"
+    return f"Bearer {strip_auth_scheme(mcp_auth_header, 'Bearer')}"
 
 
 def _openapi_forwarded_extra_headers(

--- a/tests/test_litellm/experimental_mcp_client/test_mcp_client.py
+++ b/tests/test_litellm/experimental_mcp_client/test_mcp_client.py
@@ -1,4 +1,5 @@
 import asyncio
+import base64
 import os
 import sys
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -27,11 +28,16 @@ from litellm.experimental_mcp_client.client import (
     MCPClient,
     _as_read_timeout,
     _first_non_cancelled_cause,
+    strip_auth_scheme,
 )
 from litellm.proxy._experimental.mcp_server.faults.list_outcomes import (
     classify_list_exception,
     list_fault_http_status,
 )
+from litellm.proxy._experimental.mcp_server.mcp_server_manager import (
+    _format_byok_openapi_auth_header,
+)
+from litellm.types.mcp_server.mcp_server_manager import MCPServer
 from litellm.types.mcp import MCPAuth, MCPStdioConfig, MCPTransport
 
 
@@ -887,3 +893,159 @@ async def test_read_timeout_logs_an_actionable_line_that_quiet_on_error_cannot_d
     assert timeout_lines, f"expected an actionable timeout warning, got {warnings}"
     assert "http://upstream.local/mcp" in timeout_lines[0], "the line must name the server that stopped answering"
     assert "0.5s" in timeout_lines[0], "the line must name the budget that elapsed"
+
+
+class TestAuthSchemeNormalization:
+    """MCP egress must emit exactly one authorization scheme.
+
+    Callers supply both a bare credential and a complete header value (the latter whenever it is
+    passed through from ``x-mcp-auth`` / ``Authorization``), and the second shape used to be given
+    a second scheme, which upstream servers reject as a malformed token.
+    """
+
+    @pytest.mark.parametrize(
+        "auth_type, auth_value",
+        [
+            (MCPAuth.bearer_token, "bare-token"),
+            (MCPAuth.bearer_token, "Bearer bare-token"),
+            (MCPAuth.bearer_token, "bearer bare-token"),
+            (MCPAuth.bearer_token, "  BEARER   bare-token"),
+            (MCPAuth.oauth2, "bare-token"),
+            (MCPAuth.oauth2, "Bearer bare-token"),
+            (MCPAuth.oauth2_token_exchange, "bare-token"),
+            (MCPAuth.oauth2_token_exchange, "Bearer bare-token"),
+        ],
+    )
+    def test_bearer_family_emits_exactly_one_scheme(self, auth_type, auth_value):
+        client = MCPClient(server_url="http://example.com/mcp", auth_type=auth_type, auth_value=auth_value)
+
+        assert client._get_auth_headers()["Authorization"] == "Bearer bare-token"
+
+    @pytest.mark.parametrize("auth_value", ["bare-token", "token bare-token", "TOKEN bare-token"])
+    def test_token_scheme_emits_exactly_one_scheme(self, auth_value):
+        client = MCPClient(server_url="http://example.com/mcp", auth_type=MCPAuth.token, auth_value=auth_value)
+
+        assert client._get_auth_headers()["Authorization"] == "token bare-token"
+
+    @pytest.mark.parametrize(
+        "auth_type, auth_value",
+        [
+            (MCPAuth.bearer_token, "Bearertoken"),
+            (MCPAuth.oauth2, "Bearer.eyJzdWIiOiJhYmMifQ.sig"),
+            (MCPAuth.token, "tokenish"),
+        ],
+    )
+    def test_a_credential_merely_starting_with_the_scheme_text_is_left_intact(self, auth_type, auth_value):
+        """RFC 7235 requires whitespace between scheme and credential, so a token whose first
+        characters happen to spell the scheme is a credential, not a schemed value."""
+        client = MCPClient(server_url="http://example.com/mcp", auth_type=auth_type, auth_value=auth_value)
+
+        scheme = "token" if auth_type == MCPAuth.token else "Bearer"
+        assert client._get_auth_headers()["Authorization"] == f"{scheme} {auth_value}"
+
+    @pytest.mark.parametrize(
+        "auth_type, auth_value, expected",
+        [
+            (MCPAuth.bearer_token, "Bearer ", "Bearer Bearer"),
+            (MCPAuth.bearer_token, "Bearer    ", "Bearer Bearer"),
+        ],
+    )
+    def test_a_scheme_with_no_credential_behind_it_still_produces_a_header(self, auth_type, auth_value, expected):
+        """Treating this as a schemed value would leave nothing to send, and a request with no
+        Authorization at all is harder to diagnose upstream than a visibly wrong one."""
+        client = MCPClient(server_url="http://example.com/mcp", auth_type=auth_type, auth_value=auth_value)
+
+        assert client._get_auth_headers()["Authorization"] == expected
+
+    def test_basic_with_a_scheme_and_no_credential_still_produces_a_header(self):
+        client = MCPClient(server_url="http://example.com/mcp", auth_type=MCPAuth.basic, auth_value="Basic ")
+
+        assert "Authorization" in client._get_auth_headers()
+
+    def test_basic_accepts_an_already_encoded_schemed_value_without_re_encoding_it(self):
+        """Stripping the scheme at header-build time cannot fix this shape: ``to_basic_auth`` has by
+        then encoded the whole ``Basic ...`` string, leaving no prefix to find."""
+        encoded = base64.b64encode(b"user:pass").decode()
+
+        client = MCPClient(
+            server_url="http://example.com/mcp",
+            auth_type=MCPAuth.basic,
+            auth_value=f"Basic {encoded}",
+        )
+
+        header = client._get_auth_headers()["Authorization"]
+        assert header == f"Basic {encoded}"
+        assert base64.b64decode(header.split(" ", 1)[1]) == b"user:pass"
+
+    @pytest.mark.parametrize("auth_value", ["user:pass", "Basic user:pass", "basic user:pass"])
+    def test_basic_always_emits_encoded_credentials(self, auth_value):
+        """A schemed value whose remainder is raw rather than encoded is still a username/password
+        pair, so it is encoded rather than forwarded as an invalid RFC 7617 header."""
+        client = MCPClient(server_url="http://example.com/mcp", auth_type=MCPAuth.basic, auth_value=auth_value)
+
+        header = client._get_auth_headers()["Authorization"]
+        assert base64.b64decode(header.split(" ", 1)[1]) == b"user:pass"
+
+    def test_authorization_auth_type_is_passed_through_verbatim(self):
+        """``MCPAuth.authorization`` means the caller owns the whole header value."""
+        client = MCPClient(
+            server_url="http://example.com/mcp",
+            auth_type=MCPAuth.authorization,
+            auth_value="Bearer Bearer deliberately-doubled",
+        )
+
+        assert client._get_auth_headers()["Authorization"] == "Bearer Bearer deliberately-doubled"
+
+    def test_api_key_credential_is_not_treated_as_a_schemed_value(self):
+        client = MCPClient(
+            server_url="http://example.com/mcp",
+            auth_type=MCPAuth.api_key,
+            auth_value="Bearer looks-schemed",
+        )
+
+        assert client._get_auth_headers()["X-API-Key"] == "Bearer looks-schemed"
+
+
+@pytest.mark.parametrize(
+    "auth_value, scheme, expected",
+    [
+        ("Bearer abc", "Bearer", "abc"),
+        ("bearer abc", "Bearer", "abc"),
+        ("  Bearer   abc  ", "Bearer", "abc  "),
+        ("abc", "Bearer", "abc"),
+        ("Bearerabc", "Bearer", "Bearerabc"),
+        ("Basic abc", "Bearer", "Basic abc"),
+        ("token abc", "token", "abc"),
+        ("Basic abc", "Basic", "abc"),
+        ("Bearer ", "Bearer", "Bearer "),
+        ("Bearer   ", "Bearer", "Bearer   "),
+    ],
+)
+def test_strip_auth_scheme(auth_value, scheme, expected):
+    assert strip_auth_scheme(auth_value, scheme) == expected
+
+
+@pytest.mark.parametrize(
+    "auth_type, auth_value, expected",
+    [
+        (MCPAuth.bearer_token, "Bearer jwt", "Bearer jwt"),
+        (MCPAuth.bearer_token, "jwt", "Bearer jwt"),
+        (MCPAuth.api_key, "ApiKey secret", "ApiKey secret"),
+        (MCPAuth.api_key, "secret", "ApiKey secret"),
+        (MCPAuth.basic, "Basic dXNlcjpwYXNz", "Basic dXNlcjpwYXNz"),
+    ],
+)
+def test_openapi_byok_auth_header_emits_exactly_one_scheme(auth_type, auth_value, expected):
+    """A non-BYOK server short-circuits ``_resolve_byok_mcp_auth_header``, so this formatter also
+    receives the deprecated global ``x-mcp-auth``, which is already a complete header value."""
+    server = MCPServer(
+        server_id="s1",
+        name="openapi-server",
+        url="http://example.com/mcp",
+        transport=MCPTransport.http,
+        auth_type=auth_type,
+        spec_path="/tmp/spec.json",
+    )
+
+    assert server.is_byok is False
+    assert _format_byok_openapi_auth_header(server, auth_value) == expected


### PR DESCRIPTION
## TLDR

Problem this solves:

- MCP egress sent `Authorization: Bearer Bearer <jwt>`, upstream 401s
- Only users with no stored OAuth credential were hit
- `Basic` had a worse form: double base64 encoding
- OpenAPI-backed servers doubled it on their own path

How it solves it:

- Strip one leading scheme before rebuilding the header
- Match case-insensitively, require a credential behind it
- `Basic` normalizes before encoding, not after
- Same helper on the OpenAPI injection path
- `MCPAuth.authorization` still passes through verbatim

## User Flow

Before: a developer calling an MCP server through the gateway gets no tools back, and the upstream logs a malformed token

1. A proxy admin defines an MCP server with `auth_type: oauth2`, `oauth2_flow: authorization_code` and `delegate_auth_to_upstream: true`
2. The developer, who has never completed the OAuth sign-in for that server, sends GET https://litellm-domain/mcp-rest/tools/list with `x-mcp-auth: Bearer <their jwt>`
3. They get HTTP 200 carrying `"tools": []` and `"message": "Failed to get tools from servers: <server>: auth_required"`
4. The upstream server's log shows `token is malformed: could not base64 decode header: illegal base64 data at input byte 6` and a 401
5. Calling a tool by name fails too, because the tool never appeared in the catalog
6. A colleague who did complete the sign-in for the same server hits it successfully in the same minute, so the failure looks like a flaky upstream rather than a header the gateway built wrong

After: the same request lists tools and the tool call succeeds

1. Same server definition, no config change
2. The same developer, still with no stored credential, sends the same GET https://litellm-domain/mcp-rest/tools/list with `x-mcp-auth: Bearer <their jwt>`
3. They get HTTP 200 with the upstream's tools listed and `"error": null`
4. The upstream server's log shows `mcp-auth: verified access token` and a 200
5. Calling a tool by name returns the tool's result
6. Both developers now behave identically, whether or not either has a stored credential

## Relevant issues

## Linear ticket

Resolves LIT-5893

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Shared setup, identical on both legs. A real upstream MCP server (python-sdk `FastMCP`, streamable HTTP) sits behind a verifier that mirrors the reporter's Go server: it strips one `Bearer `, base64-decodes the JWT header segment, and 401s on the first illegal byte. It logs every `Authorization` value it receives and how it judged it.

`config.yaml`:

```yaml
mcp_servers:
  lit5893upstream:
    transport: "http"
    url: "http://127.0.0.1:8893/mcp"
    auth_type: "oauth2"
    oauth2_flow: "authorization_code"
    delegate_auth_to_upstream: true
    authorization_url: "http://127.0.0.1:8893/authorize"
    token_url: "http://127.0.0.1:8893/token"
    client_id: "lit5893-client"

general_settings:
  master_key: sk-lit5893
  store_model_in_db: false
```

The calling key has no stored OAuth credential for that server, which is the case the report says fails every time. `JWT` below is `eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ1c2VyQGV4YW1wbGUuY29tIn0.sig`

### Before (d542c82f0eb92a787a34ae768c236504f57bdb15)

#### tools/list

1. Command

```
curl -s -w '\nHTTP %{http_code}\n' http://127.0.0.1:4893/mcp-rest/tools/list \
  -H 'x-litellm-api-key: sk-lit5893' -H "x-mcp-auth: Bearer $JWT"
```

2. Output

```
{"tools":[],"error":"partial_failure","message":"Failed to get tools from servers: lit5893upstream: auth_required"}
HTTP 200
```

#### tools/call

1. Command

```
curl -s -w '\nHTTP %{http_code}\n' http://127.0.0.1:4893/mcp-rest/tools/call \
  -H 'x-litellm-api-key: sk-lit5893' -H "x-mcp-auth: Bearer $JWT" \
  -H 'Content-Type: application/json' \
  -d '{"name": "lit5893upstream-echo", "arguments": {"text": "LIT-5893"}, "server_id": "af181f5b922f4b106719d668e2b3145d"}'
```

2. Output

```
{"detail":{"error":"internal_server_error","message":"An unexpected error occurred: Tool echo not found"}}
HTTP 500
```

#### what the upstream received

1. Command

```
cat upstream.log
```

2. Output

```
POST /mcp Authorization='Bearer Bearer eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ1c2VyQGV4YW1wbGUuY29tIn0.sig'
  -> 401 {"level":"warn","error":"token is malformed: could not base64 decode header: illegal base64 data at input byte 6"}
```

### After (a807beafbedc1b07a81aa53fd1f4bf044a351487)

#### tools/list

1. Command

```
curl -s -w '\nHTTP %{http_code}\n' http://127.0.0.1:4893/mcp-rest/tools/list \
  -H 'x-litellm-api-key: sk-lit5893' -H "x-mcp-auth: Bearer $JWT"
```

2. Output

```
{"tools":[{"name":"echo","title":null,"description":"Echo the given text back.","inputSchema":{"properties":{"text":{"title":"Text","type":"string"}},"required":["text"],"title":"echoArguments","type":"object"},"outputSchema":null,"icons":null,"annotations":null,"_meta":null,"execution":null,"mcp_info":{"server_name":"lit5893upstream","description":"LIT-5893 stub upstream that logs the Authorization header it receives","server_id":"af181f5b922f4b106719d668e2b3145d","alias":null}}],"error":null,"message":"Successfully retrieved tools"}
HTTP 200
```

#### tools/call

1. Command

```
curl -s -w '\nHTTP %{http_code}\n' http://127.0.0.1:4893/mcp-rest/tools/call \
  -H 'x-litellm-api-key: sk-lit5893' -H "x-mcp-auth: Bearer $JWT" \
  -H 'Content-Type: application/json' \
  -d '{"name": "lit5893upstream-echo", "arguments": {"text": "LIT-5893"}, "server_id": "af181f5b922f4b106719d668e2b3145d"}'
```

2. Output

```
{"_meta":null,"content":[{"type":"text","text":"echo: LIT-5893","annotations":null,"_meta":null}],"structuredContent":{"result":"echo: LIT-5893"},"isError":false}
HTTP 200
```

#### what the upstream received

1. Command

```
cat upstream.log
```

2. Output

```
POST /mcp Authorization='Bearer eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ1c2VyQGV4YW1wbGUuY29tIn0.sig'
  -> 200 mcp-auth: verified access token
```

## Type

🐛 Bug Fix

## Review notes

Scope is the v1 egress path only, and the v2 outbound-credentials resolver deliberately needs no change. Its passthrough arm forwards the caller's `Authorization` verbatim and prefixes nothing, and its shared-key arm reads `server.authentication_token`, an operator-configured static token that is never a passed-through header, so neither arm can meet a schemed credential the way `_get_auth_headers` does. A server reaches the fixed path exactly when `to_server_spec` defers to v1: oauth2 with `delegate_auth_to_upstream`, the static-header auth types with no `authentication_token` configured, and every BYOK server.

`_format_byok_openapi_auth_header` is in scope and fixed. Its per-server arms are already guarded, and its docstring reasons about exactly this, but a non-BYOK server short-circuits `_resolve_byok_mcp_auth_header` and hands it the deprecated global `x-mcp-auth` unguarded, so the identical caller input doubled there too. Verified directly: a non-BYOK `spec_path` server with `auth_type: bearer_token` and `Bearer <jwt>` produced `Bearer Bearer <jwt>`. Leaving it would have shipped a fix that works on HTTP/SSE servers and still 401s on OpenAPI-backed ones.

Two further sites share the defect's shape but not its producer, and are deliberately left for a separate change: the OpenAPI registration block in `mcp_server_manager.py` and `ApiKeyConfig.header` in `outbound_credentials/types.py`. Both format `server.authentication_token`, so reaching them needs an operator to paste a whole header into a config field. That is a policy question (normalize silently, or reject at config-load time) that does not belong inside a bug fix, so both are filed as LIT-5901 together with a separate encoding bug found beside them: the OpenAPI block does not base64-encode for `basic` while the client path does, so one of the two is wrong regardless of scheme doubling.

A sibling sweep after the fix landed found one more site with the same root cause on a different consumer, filed as LIT-5900. `_extract_bearer_token` strips the inbound scheme with a case-sensitive `startswith("Bearer ")`, and its output becomes the RFC 8693 `subject_token` in the token-exchange body rather than a header, so a lowercase `authorization: bearer <jwt>` sends a schemed subject token to the IdP. Nothing in this PR can mask it, since the value never passes through `_get_auth_headers`

## Caveats

- `Basic` needed a different fix site than the ticket proposed
- `MCPAuth.authorization` deliberately untouched: caller owns that header
- Upstream is a stub MCP server; MCP egress bills no provider
- v2 resolver unchanged, reasoning in Review notes above
- `MCPAuth.none` drops a passthrough credential; separate pre-existing bug
- A tab-separated credential still doubles: `partition(" ")` matches a space only. Tab is invalid per RFC 7235 and litellm emits none, so it is filed as LIT-5900 rather than churning this PR
- A pre-encoded `basic` credential sent without the `Basic ` prefix is still encoded twice, unchanged from before this PR

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

