### PR TITLE
fix(mcp): let a salt-key-orphaned OAuth credential be replaced by re-authorization

### DIFF
--- a/litellm/proxy/_experimental/mcp_server/db.py
+++ b/litellm/proxy/_experimental/mcp_server/db.py
@@ -1224,14 +1224,28 @@ def _decode_user_credential(stored: str) -> str | None:
         return None
 
 
-def _decode_oauth_payload(stored: str) -> OAuthCredentialPayload | None:
-    """Return the OAuth2 payload dict if ``stored`` holds one, else ``None``.
+def _warn_undecryptable_credential(user_id: str, server_id: str) -> None:
+    """Log the one credential state that otherwise reads as "user never authorized"."""
+    verbose_proxy_logger.warning(
+        "MCP user credential for user=%s server=%s could not be decrypted (likely written under a "
+        "previous LITELLM_SALT_KEY); the user is treated as not connected and must re-authorize.",
+        user_id,
+        server_id,
+    )
+
+
+def _parse_oauth_payload(decoded: str | None) -> OAuthCredentialPayload | None:
+    """Return the OAuth2 payload dict if ``decoded`` holds one, else ``None``.
 
     A row is considered an OAuth2 credential iff its decoded value parses as
     a JSON object with ``"type": "oauth2"``.  Plain BYOK credentials (which
     share the same column) decode to a non-JSON string and return ``None``.
+
+    Callers that need to tell an unreadable row from a readable non-OAuth2 one
+    pass the result of :func:`_decode_user_credential` so a single decode
+    answers both questions: ``None`` there means the value can be neither
+    decrypted nor base64-decoded, so no caller can ever recover it.
     """
-    decoded: Final = _decode_user_credential(stored)
     if decoded is None:
         return None
     parsed: OAuthCredentialPayload | None
@@ -1242,6 +1256,11 @@ def _decode_oauth_payload(stored: str) -> OAuthCredentialPayload | None:
     if isinstance(parsed, dict) and parsed.get("type") == "oauth2":
         return parsed
     return None
+
+
+def _decode_oauth_payload(stored: str) -> OAuthCredentialPayload | None:
+    """Return the OAuth2 payload dict held in ``stored``, else ``None``."""
+    return _parse_oauth_payload(_decode_user_credential(stored))
 
 
 async def rotate_mcp_user_credentials_master_key(prisma_client: PrismaClient, new_master_key: str):
@@ -1415,15 +1434,25 @@ async def store_user_oauth_credential(
     # (e.g. during token refresh), saving an extra DB round-trip.
     if not skip_byok_guard:
         existing: Final = await _db_find_user_credential_row(prisma_client, user_id, server_id)
-        if existing is not None and _decode_oauth_payload(existing.credential_b64) is None:
-            # Existing row is either a BYOK secret or an OAuth2 row that no
-            # longer decrypts (e.g. after a salt-key rotation).  In either
-            # case, refuse to overwrite — the caller would clobber data
-            # that may still be recoverable.
-            raise ValueError(
-                f"Existing credential for user {user_id} and server "
-                f"{server_id} could not be verified as an OAuth2 token. "
-                f"Refusing to overwrite."
+        decoded: Final = _decode_user_credential(existing.credential_b64) if existing is not None else None
+        if existing is not None and _parse_oauth_payload(decoded) is None:
+            # Refuse only while the row still holds readable content, which is a live BYOK
+            # secret that overwriting would destroy.  A row that does not decode was written
+            # under a different LITELLM_SALT_KEY, and one that decodes to nothing holds no
+            # secret at all; refusing either preserves nothing and instead wedges the user
+            # out of the OAuth flow for good, since re-authorizing is their only recovery.
+            if decoded:
+                raise ValueError(
+                    f"Existing credential for user {user_id} and server "
+                    f"{server_id} could not be verified as an OAuth2 token. "
+                    f"Refusing to overwrite."
+                )
+            verbose_proxy_logger.warning(
+                "store_user_oauth_credential: existing credential for user=%s server=%s could not be "
+                "decrypted (likely written under a previous LITELLM_SALT_KEY); replacing it with the "
+                "newly authorized OAuth2 token.",
+                user_id,
+                server_id,
             )
 
     encoded: Final = encrypt_value_helper(json.dumps(payload))
@@ -1461,7 +1490,10 @@ async def get_user_oauth_credential(
     row: Final = await _db_find_user_credential_row(prisma_client, user_id, server_id)
     if row is None:
         return None
-    return _decode_oauth_payload(row.credential_b64)
+    decoded: Final = _decode_user_credential(row.credential_b64)
+    if decoded is None:
+        _warn_undecryptable_credential(user_id, server_id)
+    return _parse_oauth_payload(decoded)
 
 
 async def list_user_oauth_credentials(
@@ -1473,7 +1505,10 @@ async def list_user_oauth_credentials(
     rows: Final = await _db_find_user_credential_rows(prisma_client, {"user_id": user_id})
     results: Final[list[OAuthCredentialPayload]] = []
     for row in rows:
-        payload = _decode_oauth_payload(row.credential_b64)
+        decoded = _decode_user_credential(row.credential_b64)
+        if decoded is None:
+            _warn_undecryptable_credential(user_id, row.server_id)
+        payload = _parse_oauth_payload(decoded)
         if payload is None:
             continue
         payload["server_id"] = row.server_id

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_db_credentials.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_db_credentials.py
@@ -535,6 +535,164 @@ async def test_byok_guard_allows_overwriting_existing_oauth():
     assert _stored_value(prisma) != oauth_row.credential_b64
 
 
+# ── Recovery from an unplanned LITELLM_SALT_KEY change ────────────────────────
+
+PREVIOUS_SALT_KEY = "the-salt-key-this-deployment-used-before-9999"
+
+
+def _row_written_under_previous_salt_key(monkeypatch, payload: str):
+    """A row encrypted under a salt key the proxy no longer holds.
+
+    Asserts the fixture really is undecryptable under the current key, so a test
+    built on it cannot pass by accident.
+    """
+    monkeypatch.setenv("LITELLM_SALT_KEY", PREVIOUS_SALT_KEY)
+    encrypted = encrypt_value_helper(payload)
+    monkeypatch.setenv("LITELLM_SALT_KEY", SALT_KEY)
+    assert _decode_user_credential(encrypted) is None, "fixture must not decrypt under the current salt key"
+    row = MagicMock()
+    row.credential_b64 = encrypted
+    row.user_id = "alice"
+    row.server_id = "srv-1"
+    return row
+
+
+@pytest.mark.asyncio
+async def test_reauthorization_replaces_row_written_under_previous_salt_key(monkeypatch):
+    # The wedged user: their row cannot be decrypted, so refusing preserves nothing.
+    old_payload = json.dumps({"type": "oauth2", "access_token": "tok-written-before-rotation"})
+    prisma = _make_prisma_with_existing(row=_row_written_under_previous_salt_key(monkeypatch, old_payload))
+
+    await store_user_oauth_credential(prisma, "alice", "srv-1", "tok-after-reauthorization")
+
+    # The replacement must decrypt under the CURRENT key and be the newly authorized token.
+    replacement = MagicMock()
+    replacement.credential_b64 = _stored_value(prisma)
+    replacement.server_id = "srv-1"
+    prisma.db.litellm_mcpusercredentials.find_unique = AsyncMock(return_value=replacement)
+    stored = await get_user_oauth_credential(prisma, "alice", "srv-1")
+    assert stored is not None
+    assert stored["access_token"] == "tok-after-reauthorization"
+
+
+@pytest.mark.asyncio
+async def test_readable_byok_is_still_refused_after_a_salt_key_change(monkeypatch):
+    # A legacy plain-base64 BYOK secret stays readable across a salt-key change, so
+    # the recovery path must not use it as an excuse to clobber a live credential.
+    monkeypatch.setenv("LITELLM_SALT_KEY", "a-completely-different-salt-key-4321")
+    prisma = _make_prisma_with_existing(row=_legacy_row("sk-live-byok-secret"))
+
+    with pytest.raises(ValueError, match="could not be verified as an OAuth2"):
+        await store_user_oauth_credential(prisma, "alice", "srv-1", "tok")
+
+    prisma.db.litellm_mcpusercredentials.upsert.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_recovery_warns_with_identifiers_and_never_logs_credentials(monkeypatch, caplog):
+    import logging
+
+    old_payload = json.dumps({"type": "oauth2", "access_token": "tok-written-before-rotation"})
+    row = _row_written_under_previous_salt_key(monkeypatch, old_payload)
+    prisma = _make_prisma_with_existing(row=row)
+
+    with caplog.at_level(logging.WARNING, logger="LiteLLM Proxy"):
+        await store_user_oauth_credential(prisma, "alice", "srv-1", "tok-after-reauthorization")
+
+    messages = [rec.getMessage() for rec in caplog.records]
+    matching = [m for m in messages if "could not be decrypted" in m and "replacing it" in m]
+    assert len(matching) == 1, f"expected one recovery warning, got {messages}"
+    assert "user=alice" in matching[0] and "server=srv-1" in matching[0]
+    for secret in ("tok-after-reauthorization", "tok-written-before-rotation", row.credential_b64):
+        assert secret not in matching[0]
+
+
+@pytest.mark.asyncio
+async def test_get_user_oauth_credential_warns_when_row_cannot_be_decrypted(monkeypatch, caplog):
+    import logging
+
+    old_payload = json.dumps({"type": "oauth2", "access_token": "tok-written-before-rotation"})
+    prisma = _make_prisma_with_existing(row=_row_written_under_previous_salt_key(monkeypatch, old_payload))
+
+    with caplog.at_level(logging.WARNING, logger="LiteLLM Proxy"):
+        assert await get_user_oauth_credential(prisma, "alice", "srv-1") is None
+
+    matching = [rec.getMessage() for rec in caplog.records if "could not be decrypted" in rec.getMessage()]
+    assert len(matching) == 1, f"expected one read-path warning, got {[r.getMessage() for r in caplog.records]}"
+    assert "user=alice" in matching[0] and "server=srv-1" in matching[0]
+
+
+@pytest.mark.asyncio
+async def test_list_user_oauth_credentials_warns_per_row_when_rows_cannot_be_decrypted(monkeypatch, caplog):
+    # The bulk prefetch is the other read path, and it is by definition the multi-server case:
+    # a warning naming the wrong server sends the operator to the wrong place. Two wedged rows
+    # plus one healthy one, so a warning built from a constant or from the first row is caught.
+    import logging
+
+    old_payload = json.dumps({"type": "oauth2", "access_token": "tok-written-before-rotation"})
+    wedged_one = _row_written_under_previous_salt_key(monkeypatch, old_payload)
+    wedged_two = _row_written_under_previous_salt_key(monkeypatch, old_payload)
+    wedged_two.server_id = "srv-2"
+
+    prisma = _make_prisma_with_existing(row=None)
+    await store_user_oauth_credential(prisma, "alice", "srv-3", "tok-healthy")
+    healthy = MagicMock()
+    healthy.credential_b64 = _stored_value(prisma)
+    healthy.server_id = "srv-3"
+    prisma.db.litellm_mcpusercredentials.find_many = AsyncMock(return_value=[wedged_one, healthy, wedged_two])
+
+    with caplog.at_level(logging.WARNING, logger="LiteLLM Proxy"):
+        result = await list_user_oauth_credentials(prisma, "alice")
+
+    assert [cred["server_id"] for cred in result] == ["srv-3"]
+    matching = [rec.getMessage() for rec in caplog.records if "could not be decrypted" in rec.getMessage()]
+    assert len(matching) == 2, f"expected one warning per wedged row, got {matching}"
+    assert all("user=alice" in message for message in matching)
+    assert {"srv-1", "srv-2"} == {message.split("server=")[1].split(" ")[0] for message in matching}
+
+
+@pytest.mark.asyncio
+async def test_skip_byok_guard_does_not_read_the_existing_row(monkeypatch):
+    # The refresh paths pass skip_byok_guard=True precisely to save a DB round-trip on the
+    # hottest MCP path, so the flag has to actually suppress the lookup, not just the raise.
+    prisma = _make_prisma_with_existing(row=_legacy_row("plain-byok-key"))
+
+    await store_user_oauth_credential(prisma, "alice", "srv-1", "tok", skip_byok_guard=True)
+
+    prisma.db.litellm_mcpusercredentials.find_unique.assert_not_awaited()
+    prisma.db.litellm_mcpusercredentials.upsert.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_blank_credential_row_is_replaced_rather_than_refused():
+    # A blank value decodes to "" rather than None, so it is not a decryption failure, but it
+    # holds no secret either. Pinned deliberately: the guard exists to protect readable
+    # content, and refusing here would wedge the user while preserving nothing.
+    blank = MagicMock()
+    blank.credential_b64 = ""
+    blank.user_id = "alice"
+    blank.server_id = "srv-1"
+    assert _decode_user_credential(blank.credential_b64) == "", "fixture must decode to empty, not None"
+    prisma = _make_prisma_with_existing(row=blank)
+
+    await store_user_oauth_credential(prisma, "alice", "srv-1", "tok-after-reauthorization")
+
+    prisma.db.litellm_mcpusercredentials.upsert.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_readable_byok_row_does_not_warn_on_the_read_path(caplog):
+    # A BYOK row is not a decryption failure; warning on it would train operators to ignore the log.
+    import logging
+
+    prisma = _make_prisma_with_existing(row=_legacy_row("sk-live-byok-secret"))
+
+    with caplog.at_level(logging.WARNING, logger="LiteLLM Proxy"):
+        assert await get_user_oauth_credential(prisma, "alice", "srv-1") is None
+
+    assert [rec.getMessage() for rec in caplog.records if "could not be decrypted" in rec.getMessage()] == []
+
+
 # ── list_user_oauth_credentials ───────────────────────────────────────────────
 
 


### PR DESCRIPTION
## TLDR

Problem this solves:

- A salt-key change leaves MCP OAuth users permanently unable to reconnect
- Re-authorizing succeeds upstream, then the proxy refuses to save the token
- An undecryptable credential looks exactly like "never connected" in the logs

How it solves it:

- Refuse the overwrite only when the stored value is genuinely readable
- Replace an undecryptable row with the newly authorized token, and log it
- Warn on both read paths, naming the user and server, never the value

## User Flow

Before: after the proxy admin changes `LITELLM_SALT_KEY`, a developer whose MCP server was already connected can never reconnect it

1. They call `GET https://litellm-domain/v1/mcp/tools` with their key and get `{"tools":[]}` where that server's tools used to be
2. They re-run the connect flow for the server, which completes at the identity provider and hands back a fresh token
3. They send `POST https://litellm-domain/v1/mcp/server/<server_id>/oauth-user-credential` with that token
4. The proxy answers `500 {"error":{"message":"Internal server error","type":"internal_server_error"}}`, with nothing in the response saying why
5. `GET /v1/mcp/tools` still returns `{"tools":[]}`, and repeating steps 2 to 4 changes nothing, indefinitely
6. A colleague who had never connected that server completes the identical flow and gets `200`, which makes the failure look specific to the first developer rather than systemic

After: the same reconnect succeeds and the server's tools come back

1. They call `GET https://litellm-domain/v1/mcp/tools` with their key and get `{"tools":[]}` where that server's tools used to be
2. They re-run the connect flow for the server, which completes at the identity provider and hands back a fresh token
3. They send `POST https://litellm-domain/v1/mcp/server/<server_id>/oauth-user-credential` with that token
4. The proxy answers `200` with `has_credential: true` and a fresh `expires_at`
5. `GET /v1/mcp/tools` lists that server's tools again, and calls to them reach the server carrying the new token
6. A developer who has their own API key saved for a bring-your-own-key server still cannot have it replaced by connecting that server over OAuth, so no live secret becomes overwritable

## Relevant issues

## Linear ticket

Resolves LIT-5892

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Live proxy on Postgres 16, one OAuth2 MCP server and one bring-your-own-key MCP server, both pointed at a stub upstream that records the `Authorization` header of every request it receives, so each leg shows the credential LiteLLM actually sent rather than just the status code the caller saw.

Shared setup, run once against the unfixed tree:

```
$ LITELLM_SALT_KEY=OLD-SALT-KEY-lit5892-aaaa   # the proxy the user originally connected against
$ curl -X POST /v1/mcp/server/$OAUTH_SID/oauth-user-credential -H "Authorization: Bearer $UK" \
    -d '{"access_token":"token-minted-under-OLD-salt-key","refresh_token":"refresh-old","expires_in":86400}'
{"server_id":"dfc832f4-...","has_credential":true,"expires_at":"2026-08-21T19:51:35Z","is_expired":false}  HTTP 200

$ curl /v1/mcp/tools -H "Authorization: Bearer $UK"
  HTTP 200
  upstream MCP server received: tools/list	Bearer token-minted-under-OLD-salt-key
  stored row: KM9BVLt_iwQLuV_9Bn_YrE...
```

Then the salt key is changed to `NEW-SALT-KEY-lit5892-bbbb` and the proxy restarted. The stored row is untouched, so it is now ciphertext under a key the proxy no longer holds. Each leg starts from that state: the setup above is replayed on the unfixed tree before the After leg, so both legs face a row holding the same token written under the same old key. The ciphertext differs between the two prefixes below only because each write draws a fresh nonce.

### Before (d542c82f0e)

#### The wedged user re-authorizes

1. Egress for the wedged user, and what the upstream server actually received

```
$ curl /v1/mcp/tools -H "Authorization: Bearer $UK"
{"tools":[]}  HTTP 200
  upstream MCP server received: <the proxy never reached it>
```

2. The user re-runs the OAuth flow and presents the newly issued token

```
$ curl -X POST /v1/mcp/server/$OAUTH_SID/oauth-user-credential -H "Authorization: Bearer $UK" \
    -d '{"access_token":"token-minted-AFTER-salt-key-change","refresh_token":"refresh-new","expires_in":86400}'
{"error":{"message":"Internal server error","type":"internal_server_error"}}  HTTP 500
  stored row now: KM9BVLt_iwQLuV_9Bn_YrE...
```

3. Egress after the re-authorization attempt, unchanged

```
$ curl /v1/mcp/tools -H "Authorization: Bearer $UK"
  HTTP 200
  upstream MCP server received: <the proxy never reached it>
```

4. The only trace anywhere, and it names nothing the operator can act on

```
ValueError: Existing credential for user wedged-user and server dfc832f4-... could not be verified as an OAuth2 token. Refusing to overwrite.
```

#### A live bring-your-own-key secret is not overwritten

1. Save a BYOK secret under the current salt key, then try to clobber it by connecting OAuth

```
$ curl -X POST /v1/mcp/server/$BYOK_SID/user-credential -H "Authorization: Bearer $BK" \
    -d '{"credential":"sk-live-byok-secret","save":true}'
{"server_id":"165c4f40-...","has_credential":true}  HTTP 200

$ curl -X POST /v1/mcp/server/$BYOK_SID/oauth-user-credential -H "Authorization: Bearer $BK" \
    -d '{"access_token":"attacker-token","expires_in":86400}'
{"error":{"message":"Internal server error","type":"internal_server_error"}}  HTTP 500
  BYOK row before: MdUI-JgO1PDJcBZZ6FHi6Q...
  BYOK row after:  MdUI-JgO1PDJcBZZ6FHi6Q...
  => BYOK secret preserved
```

### After (645103d5e4)

#### The wedged user re-authorizes

1. Egress for the wedged user, and what the upstream server actually received

```
$ curl /v1/mcp/tools -H "Authorization: Bearer $UK"
{"tools":[]}  HTTP 200
  upstream MCP server received: <the proxy never reached it>
```

2. The user re-runs the OAuth flow and presents the newly issued token

```
$ curl -X POST /v1/mcp/server/$OAUTH_SID/oauth-user-credential -H "Authorization: Bearer $UK" \
    -d '{"access_token":"token-minted-AFTER-salt-key-change","refresh_token":"refresh-new","expires_in":86400}'
{"server_id":"dfc832f4-...","has_credential":true,"expires_at":"2026-08-21T19:52:08Z","is_expired":false}  HTTP 200
  stored row now: C09E9xOSRXbS3HGpMO-tHI...
```

3. Egress after the re-authorization, now carrying the token that was just issued

```
$ curl /v1/mcp/tools -H "Authorization: Bearer $UK"
  HTTP 200
  upstream MCP server received: tools/list	Bearer token-minted-AFTER-salt-key-change
```

4. The proxy log now says what happened, on the read path and on the write path

```
LiteLLM Proxy:WARNING: MCP user credential for user=wedged-user server=dfc832f4-... could not be decrypted
  (likely written under a previous LITELLM_SALT_KEY); the user is treated as not connected and must re-authorize.
LiteLLM Proxy:WARNING: store_user_oauth_credential: existing credential for user=wedged-user server=dfc832f4-...
  could not be decrypted (likely written under a previous LITELLM_SALT_KEY); replacing it with the newly
  authorized OAuth2 token.
```

#### A live bring-your-own-key secret is not overwritten

1. Save a BYOK secret under the current salt key, then try to clobber it by connecting OAuth

```
$ curl -X POST /v1/mcp/server/$BYOK_SID/user-credential -H "Authorization: Bearer $BK" \
    -d '{"credential":"sk-live-byok-secret","save":true}'
{"server_id":"165c4f40-...","has_credential":true}  HTTP 200

$ curl -X POST /v1/mcp/server/$BYOK_SID/oauth-user-credential -H "Authorization: Bearer $BK" \
    -d '{"access_token":"attacker-token","expires_in":86400}'
{"error":{"message":"Internal server error","type":"internal_server_error"}}  HTTP 500
  BYOK row before: 8m-wtNbO3hlmJ_ngMZd83x...
  BYOK row after:  8m-wtNbO3hlmJ_ngMZd83x...
  => BYOK secret preserved
```

## Type

🐛 Bug Fix

## Review notes

The discriminator this turns on is that `_decode_user_credential` returns a string for anything readable and `None` only when a value can be neither decrypted nor base64-decoded. Driving it over 300 rows per encryption algorithm, written under a previous salt key and read back under the current one, classified 0 of 600 as readable, under both the legacy XSalsa20-Poly1305 format and the versioned `v2:gcm:` AES-256-GCM one, with same-key OAuth rows, same-key BYOK rows and legacy plain-base64 BYOK rows as positive controls

Eleven mutants, one per behaviour, all die on the tests added here: restoring the old unconditional refusal, dropping the guard entirely, silencing either read path, warning on every non-OAuth row, attributing a bulk-path warning to a constant server or to the batch's first row, swapping the two identifiers, inspecting the payload about to be written instead of the row already stored, refusing a blank row, and ignoring the caller's `skip_byok_guard` opt-out

A blank `credential_b64` decodes to an empty string rather than to `None`, because `base64.urlsafe_b64decode` discards non-alphabet characters and the decrypt helper short-circuits on an empty buffer. The guard therefore tests the decoded value for content rather than for `None`: a row holding nothing is not a secret worth protecting. No in-app writer can produce one, since every write goes through `encrypt_value_helper`, so this only reaches a row edited or restored outside LiteLLM

Switching `encryption_algorithm` between `xsalsa20-poly1305` and `aes-256-gcm` never manufactures a false orphan. Decryption detects the format from the `v2:gcm:` prefix before any base64 work, and all four write-algorithm by read-algorithm combinations read back cleanly

The sibling `LiteLLM_MCPUserEnvVars.values_b64` column already takes exactly this position: `_decode_user_env_vars` warns and returns empty on a decrypt failure, and `merge_user_env_vars` then overwrites the undecryptable blob. This brings `credential_b64` in line with it

Greptile flagged that the read path decoded a failed credential twice. That was correct, so `_decode_oauth_payload` is now split into a decode and a parse: each read decodes once and the warning condition reads directly off that single result, which also let the separate predicate helper go away

Greptile also suggested throttling the read-path warning. I kept it per-read deliberately. A process-global once-only flag is the wrong shape here, because the condition is per user and per server and it clears the moment that user re-authorizes: the reported incident had two affected users, and a once-only warning would have named one of them and gone quiet forever. The sibling `values_b64` column takes the same per-read position today. The volume is bounded by wedged users only, and it is the signal whose absence made this take 35 minutes to diagnose

`rotate_mcp_user_credentials_master_key` is unchanged. It is the planned-rotation path and correctly skips what it cannot read; this is the unplanned case, where it was never run

## Caveats (if any)

- Encrypted BYOK secrets are also unreadable post-rotation, so OAuth can now replace them
- Not data loss: that value was already unrecoverable with the key the proxy holds
- A pod that boots without the salt key reads every encrypted row as orphaned
- Re-authorizing on that pod replaces a secret a correctly-keyed pod could still read
- Legacy plain-base64 rows stay readable throughout, so they stay protected
- Deleting an undecryptable credential is still a no-op, left as follow-up
- `purge_user_oauth_credentials_for_server` still treats such a row as non-OAuth
- The dashboard still shows an undecryptable credential as connected, per the ticket

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

