### PR TITLE
refactor(ui): mark dark as beta in the theme menu instead of the toolbar

### DIFF
--- a/ui/litellm-dashboard/src/components/ThemeToggle/ThemeToggle.test.tsx
+++ b/ui/litellm-dashboard/src/components/ThemeToggle/ThemeToggle.test.tsx
@@ -16,7 +16,7 @@ const openMenu = async () => {
   await screen.findByRole("menu");
 };
 
-const pick = async (label: string) => userEvent.click(screen.getByRole("menuitemradio", { name: label }));
+const pick = async (label: string | RegExp) => userEvent.click(screen.getByRole("menuitemradio", { name: label }));
 
 beforeEach(() => {
   localStorage.clear();
@@ -33,7 +33,7 @@ describe("ThemeToggle", () => {
     await openMenu();
 
     expect(screen.getByRole("menuitemradio", { name: "Light" })).toBeChecked();
-    expect(screen.getByRole("menuitemradio", { name: "Dark" })).not.toBeChecked();
+    expect(screen.getByRole("menuitemradio", { name: /^Dark/ })).not.toBeChecked();
     expect(screen.getByRole("menuitemradio", { name: "System" })).not.toBeChecked();
   });
 
@@ -41,7 +41,7 @@ describe("ThemeToggle", () => {
     renderToggle();
     await openMenu();
 
-    await pick("Dark");
+    await pick(/^Dark/);
 
     expect(document.documentElement).toHaveClass("dark");
     expect(localStorage.getItem("theme")).toBe("dark");
@@ -50,7 +50,7 @@ describe("ThemeToggle", () => {
   it("hands control back to the system preference when asked", async () => {
     renderToggle();
     await openMenu();
-    await pick("Dark");
+    await pick(/^Dark/);
 
     await pick("System");
 
@@ -58,15 +58,20 @@ describe("ThemeToggle", () => {
     expect(document.documentElement).not.toHaveClass("dark");
   });
 
-  it("flags dark mode as experimental, and only while it is on", async () => {
+  it("marks dark as beta in the menu, and leaves the other choices unmarked", async () => {
     renderToggle();
     await openMenu();
-    expect(screen.queryByText("Experimental")).not.toBeInTheDocument();
 
-    await pick("Dark");
-    expect(screen.getByText("Experimental")).toBeInTheDocument();
+    expect(screen.getByRole("menuitemradio", { name: /^Dark/ })).toHaveTextContent("Beta");
+    expect(screen.getByRole("menuitemradio", { name: "Light" })).not.toHaveTextContent("Beta");
+    expect(screen.getByRole("menuitemradio", { name: "System" })).not.toHaveTextContent("Beta");
+  });
 
-    await pick("Light");
-    expect(screen.queryByText("Experimental")).not.toBeInTheDocument();
+  it("keeps the beta marker inside the menu rather than in the toolbar", async () => {
+    renderToggle();
+    await openMenu();
+    await pick(/^Dark/);
+
+    expect(screen.getByRole("button", { name: "Theme" })).not.toHaveTextContent("Beta");
   });
 });

--- a/ui/litellm-dashboard/src/components/ThemeToggle/ThemeToggle.tsx
+++ b/ui/litellm-dashboard/src/components/ThemeToggle/ThemeToggle.tsx
@@ -15,46 +15,43 @@ import {
 } from "@/components/ui/dropdown-menu";
 
 const THEMES = [
-  { value: "system", label: "System", Icon: Monitor },
-  { value: "light", label: "Light", Icon: Sun },
-  { value: "dark", label: "Dark", Icon: Moon },
+  { value: "system", label: "System", Icon: Monitor, beta: false },
+  { value: "light", label: "Light", Icon: Sun, beta: false },
+  { value: "dark", label: "Dark", Icon: Moon, beta: true },
 ] as const;
 
 const ThemeToggle: React.FC = () => {
   const { theme, setTheme, resolvedTheme } = useTheme();
-  const isDark = resolvedTheme === "dark";
 
   return (
-    <span className="flex items-center gap-1">
-      {isDark && (
-        <Badge
-          variant="outline"
-          className="px-1.5 py-0 text-[10px] font-medium text-muted-foreground"
-          title="Dark mode is still being rolled out, so some surfaces may not be styled yet"
-        >
-          Experimental
-        </Badge>
-      )}
-      <DropdownMenu>
-        <DropdownMenuTrigger
-          render={
-            <Button variant="ghost" size="icon-sm" aria-label="Theme" title="Theme" className="text-muted-foreground" />
-          }
-        >
-          {isDark ? <Moon /> : <Sun />}
-        </DropdownMenuTrigger>
-        <DropdownMenuContent align="end" className="w-36">
-          <DropdownMenuRadioGroup value={theme ?? "light"} onValueChange={setTheme}>
-            {THEMES.map(({ value, label, Icon }) => (
-              <DropdownMenuRadioItem key={value} value={value}>
-                <Icon />
-                {label}
-              </DropdownMenuRadioItem>
-            ))}
-          </DropdownMenuRadioGroup>
-        </DropdownMenuContent>
-      </DropdownMenu>
-    </span>
+    <DropdownMenu>
+      <DropdownMenuTrigger
+        render={
+          <Button variant="ghost" size="icon-sm" aria-label="Theme" title="Theme" className="text-muted-foreground" />
+        }
+      >
+        {resolvedTheme === "dark" ? <Moon /> : <Sun />}
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="w-40">
+        <DropdownMenuRadioGroup value={theme ?? "light"} onValueChange={setTheme}>
+          {THEMES.map(({ value, label, Icon, beta }) => (
+            <DropdownMenuRadioItem key={value} value={value}>
+              <Icon />
+              {label}
+              {beta && (
+                <Badge
+                  variant="secondary"
+                  className="px-1 py-0 text-[10px] font-medium text-muted-foreground"
+                  title="Dark mode is still being rolled out, so some surfaces may not be styled yet"
+                >
+                  Beta
+                </Badge>
+              )}
+            </DropdownMenuRadioItem>
+          ))}
+        </DropdownMenuRadioGroup>
+      </DropdownMenuContent>
+    </DropdownMenu>
   );
 };
 


### PR DESCRIPTION
## TLDR

Problem this solves:

- Experimental badge sat in the toolbar next to the theme icon
- Reads as if the whole theme control were experimental
- Only visible after picking dark, too late to warn

How it solves it:

- Badge moves into the menu, onto the Dark entry
- Reads Dark - Beta, labelling exactly the one caveated choice
- Warning now shows before the choice, not after
- Toolbar gets its width back

## User Flow

Before: an admin picks dark and a badge appears next to the icon, so they cannot tell what it is calling experimental

1. They open https://litellm-domain/ui/ and click the sun icon in the top bar
2. The menu offers System, Light and Dark with nothing distinguishing them
3. They pick Dark, and only then does an Experimental badge appear in the toolbar
4. The badge sits beside the theme icon, so it reads as a warning about the theme control itself

After: the caveat rides the Dark entry in the menu, so it is clear and it lands before the choice

1. They open https://litellm-domain/ui/ and click the sun icon in the top bar
2. The menu offers System, Light and Dark, with a Beta tag on Dark only
3. They pick Dark, and the page turns dark with no badge added to the toolbar
4. Reopening the menu still shows the Beta tag on Dark, so the caveat stays discoverable

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Setup, run once for each side:

1. `bash ui/litellm-dashboard/build_ui.sh` to rebuild the Admin UI into the proxy
2. `python litellm/proxy/proxy_cli.py --config litellm/proxy/dev_config.yaml --detailed_debug` to serve it
3. Open http://localhost:4000/ui/ and log in with the master key

### Before (933e28d900)

1. Land on http://localhost:4000/ui/?page=api-keys and click the sun icon in the top bar
2. Screenshot the open menu, System, Light and Dark all read alike with no beta marking
3. Pick Dark, and screenshot the toolbar now carrying an Experimental badge beside the icon

### After (61382aca4a)

1. Land on http://localhost:4000/ui/?page=api-keys and click the sun icon in the top bar
2. Screenshot the open menu, Dark now carries a Beta tag while System and Light do not
3. Pick Dark, and screenshot the toolbar holding just the moon icon, no badge
4. Reopen the menu and screenshot the Beta tag still on Dark

Menu open on a light dashboard, with the Beta tag riding the Dark entry and nothing marking System or Light

![Theme menu, light](https://raw.githubusercontent.com/BerriAI/litellm/litellm_ui_dark_mode_beta_tag_screenshots/theme-menu-light.png)

Dark picked, so the toolbar holds just the moon with no badge beside it, and reopening the menu still shows the tag on Dark

![Theme menu, dark](https://raw.githubusercontent.com/BerriAI/litellm/litellm_ui_dark_mode_beta_tag_screenshots/theme-menu-dark.png)

## Type

🧹 Refactoring

## Caveats (if any)

- Dark mode itself is unchanged, only how it is labelled

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
