### PR TITLE
fix(a2a): accept the whole JSON-RPC id union the spec defines

### DIFF
--- a/litellm/types/agents.py
+++ b/litellm/types/agents.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 from typing import TYPE_CHECKING, Any, Final, Literal
 
-from pydantic import BaseModel, PrivateAttr
+from pydantic import BaseModel, PrivateAttr, StrictInt
 from typing_extensions import Required, TypedDict
 
 from litellm.types.llms.base import LiteLLMPydanticObjectBase
@@ -315,10 +315,23 @@ def _normalize_a2a_jsonrpc_response(
     The a2a SDK may omit ``id`` on error payloads even when the upstream agent
     returned it. Backfill from the outbound request id so LiteLLM can surface the
     agent error instead of failing Pydantic validation.
+
+    JSON-RPC 2.0 requires the response id to equal the request id, so a string or
+    integer request id is carried over as-is. Anything else is stringified, which
+    is the only representation the response model accepts.
+
+    A caller that supplied no id leaves the response id null, which is what the
+    spec requires for an error that cannot be correlated to a request. ``bool`` counts
+    as "anything else" despite subclassing ``int``, so ``true`` is never relayed as
+    ``1``, where it would collide with a real integer id.
     """
     normalized: Final = dict(response_dict)
-    if normalized.get("id") is None and request_id is not None:
-        normalized["id"] = str(request_id)
+    if isinstance(normalized.get("id"), bool):
+        normalized["id"] = str(normalized["id"])
+    elif normalized.get("id") is None and request_id is not None:
+        normalized["id"] = (
+            request_id if isinstance(request_id, (str, int)) and not isinstance(request_id, bool) else str(request_id)
+        )
     return normalized
 
 
@@ -331,7 +344,7 @@ class LiteLLMSendMessageResponse(LiteLLMPydanticObjectBase):
     """
 
     # A2A response fields
-    id: str
+    id: str | StrictInt | None = None
     jsonrpc: str = "2.0"
     result: dict[str, Any] | None = None
     error: dict[str, Any] | None = None
@@ -360,8 +373,9 @@ class LiteLLMSendMessageResponse(LiteLLMPydanticObjectBase):
         Returns:
             LiteLLMSendMessageResponse with _hidden_params support
         """
-        response_dict = response.model_dump(mode="json", exclude_none=True)
-        response_dict = _normalize_a2a_jsonrpc_response(response_dict, request_id=request_id)
+        response_dict: Final = _normalize_a2a_jsonrpc_response(
+            response.model_dump(mode="json", exclude_none=True), request_id=request_id
+        )
         return cls(**response_dict)
 
     @classmethod

--- a/tests/test_litellm/a2a_protocol/test_send_message_response.py
+++ b/tests/test_litellm/a2a_protocol/test_send_message_response.py
@@ -32,12 +32,102 @@ def test_from_dict_preserves_existing_id():
     assert response.id == "upstream-id"
 
 
-def test_from_dict_without_request_id_still_requires_id():
-    try:
-        LiteLLMSendMessageResponse.from_dict(
-            {"jsonrpc": "2.0", "error": {"code": -32054, "message": "x"}}
-        )
-    except Exception as exc:
-        assert "id" in str(exc).lower()
-    else:
-        raise AssertionError("expected validation error when id and request_id missing")
+def test_from_dict_preserves_integer_id_echoed_by_upstream():
+    """JSON-RPC 2.0 types ``id`` as string|integer|null, and pydantic v2 does not
+    coerce int to str, so a str-only annotation rejects an upstream agent that
+    echoes an integer id. The value AND the type must survive."""
+    payload = {
+        "id": 42,
+        "jsonrpc": "2.0",
+        "result": {"kind": "task"},
+    }
+
+    response = LiteLLMSendMessageResponse.from_dict(payload, request_id="r1")
+
+    assert response.id == 42
+    assert isinstance(response.id, int)
+
+
+def test_from_dict_preserves_falsy_integer_id():
+    """``0`` is a legal JSON-RPC id and is falsy, so it must not be mistaken for an
+    absent id and backfilled from the request id."""
+    payload = {"id": 0, "jsonrpc": "2.0", "result": {}}
+
+    response = LiteLLMSendMessageResponse.from_dict(payload, request_id="r1")
+
+    assert response.id == 0
+
+
+def test_backfilled_id_keeps_the_request_id_type():
+    """The proxy's A2A endpoint reads the caller's ``id`` straight off the request
+    body, so it can be an integer. JSON-RPC requires the response id to equal the
+    request id, so backfilling an omitted id must not stringify it: a caller that
+    sent ``7`` cannot correlate a response carrying ``"7"``. One test, both
+    directions, so neither can regress unnoticed."""
+    agent_error = {
+        "jsonrpc": "2.0",
+        "error": {"code": -32054, "message": "Session not found"},
+    }
+
+    from_int = LiteLLMSendMessageResponse.from_dict(agent_error, request_id=7)
+    from_str = LiteLLMSendMessageResponse.from_dict(agent_error, request_id="7")
+
+    assert from_int.id == 7
+    assert isinstance(from_int.id, int)
+    assert from_str.id == "7"
+    assert isinstance(from_str.id, str)
+
+
+def test_from_dict_accepts_null_id_when_the_error_cannot_be_correlated():
+    """JSON-RPC 2.0 section 5 requires ``id`` to be null on an error that cannot be
+    matched to a request, which is exactly the case where the caller supplied no id
+    for the backfill to use. Rejecting it turned an agent's error into a proxy 500."""
+    response = LiteLLMSendMessageResponse.from_dict(
+        {"jsonrpc": "2.0", "error": {"code": -32054, "message": "x"}}
+    )
+
+    assert response.id is None
+    assert response.error == {"code": -32054, "message": "x"}
+
+
+def test_from_dict_accepts_null_id_echoed_by_upstream():
+    """An agent may answer an uncorrelatable request with an explicit ``"id": null``.
+    That is a well-formed response, not a validation failure."""
+    response = LiteLLMSendMessageResponse.from_dict(
+        {"id": None, "jsonrpc": "2.0", "error": {"code": -32600, "message": "bad"}}
+    )
+
+    assert response.id is None
+
+
+def test_id_accepts_every_member_of_the_json_rpc_union_and_nothing_else():
+    """One test pinning the whole ``string | integer | null`` union the spec defines,
+    so widening the annotation cannot silently become "accept anything"."""
+    for accepted in ("s1", 42, 0, None):
+        assert LiteLLMSendMessageResponse(id=accepted).id == accepted
+
+    # ``True``/``False`` are in here because bool subclasses int: a non-strict integer
+    # half would accept them and relay them as 1/0. Direct construction bypasses
+    # normalization, so the model has to hold this line on its own.
+    for rejected in (True, False, 1.5, ["a"], {"a": 1}):
+        try:
+            LiteLLMSendMessageResponse(id=rejected)
+        except Exception:
+            continue
+        raise AssertionError(f"id={rejected!r} is outside the JSON-RPC union and must be rejected")
+
+
+def test_boolean_id_is_never_relayed_as_an_integer():
+    """``bool`` subclasses ``int``, so widening the annotation to accept integers also
+    made pydantic coerce a boolean id to 1 or 0. That is worse than rejecting it: an id
+    of ``1`` collides with a real integer id another in-flight request may be using.
+    Both directions in one test, since either alone leaves the other free to regress."""
+    agent_error = {"jsonrpc": "2.0", "error": {"code": -32054, "message": "x"}}
+
+    echoed = LiteLLMSendMessageResponse.from_dict({"id": True, "jsonrpc": "2.0", "result": {}})
+    backfilled = LiteLLMSendMessageResponse.from_dict(agent_error, request_id=True)
+
+    assert echoed.id == "True"
+    assert backfilled.id == "True"
+    assert not isinstance(echoed.id, int)
+    assert not isinstance(backfilled.id, int)


### PR DESCRIPTION
## TLDR

Problem this solves:

- JSON-RPC allows `string | integer | null`; our A2A response model required `str`
- An agent echoing an integer id got a 500, not the agent's reply
- A null id, which the spec mandates for uncorrelatable errors, also 500'd
- Five distinct failing cases across `message/send` and `tasks/get`

How it solves it:

- Widen the A2A response model's `id` to the full spec union
- Keep the caller's id type when backfilling an id the agent omitted
- Exclude `bool`, which subclasses `int`, so `true` never returns as `1`

## User Flow

Before: a developer whose A2A client numbers its JSON-RPC requests (`"id": 42`) cannot call any agent through the proxy at all

1. They register an agent and send POST https://litellm-domain/a2a/my-agent with `{"jsonrpc":"2.0","id":42,"method":"message/send","params":{...}}`
2. They get back HTTP 500 and `{"error":{"code":-32603,"message":"Internal error: 1 validation error for LiteLLMSendMessageResponse\nid\n  Input should be a valid string ..."}}`
3. The agent itself ran fine and answered, so nothing in its access log explains the failure
4. They retry with `"id": "42"` and it returns HTTP 200 with the agent's reply
5. `tasks/get` with `"id": 42` fails the same way, as does `"id": 0`
6. Dropping the id entirely does not help either: the agent's reply comes back as the same HTTP 500

After: the same requests succeed, and the id comes back as the value and type they sent

1. They send the same POST https://litellm-domain/a2a/my-agent with `"id": 42`
2. They get HTTP 200 and the agent's reply, carrying `"id": 42` as a number
3. `tasks/get` with `"id": 42` and with `"id": 0` both return HTTP 200 with the id unchanged
4. Omitting the id returns the agent's reply instead of a 500
5. String ids keep working exactly as before
6. When an agent answers an error without echoing the id, the reply carries `42` rather than `"42"`, so the client can still match it to its request

## Relevant issues

## Linear ticket

Resolves LIT-2818

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

Live proxy against a stub upstream agent that echoes the caller's JSON-RPC id back verbatim and logs every inbound request. The two string-id cases are controls: they must return a real 200 with the agent's reply on both sides, or the failing cases mean nothing.

Shared setup, identical for both runs:

```yaml
# a2a_config.yaml
general_settings:
  master_key: sk-a2aint-1234

agents:
  - agent_name: stub-echo-agent
    agent_card_params:
      protocolVersion: "0.3.0"
      name: stub-echo-agent
      url: "http://127.0.0.1:8137/"
      version: "1.0.0"
      capabilities: {streaming: false}
      defaultInputModes: ["text/plain"]
      defaultOutputModes: ["text/plain"]
      skills: []
```

```bash
python litellm/proxy/proxy_cli.py --config a2a_config.yaml --port 4137
```

Every case below is the same curl with only the `id` and `method` changing:

```bash
curl -sS -w '\nHTTP %{http_code}\n' -X POST http://127.0.0.1:4137/a2a/stub-echo-agent \
  -H 'Authorization: Bearer sk-a2aint-1234' -H 'Content-Type: application/json' \
  -d '<the body shown under each case>'
```

### Before (fc3b160fb5)

Code under test, `litellm/types/agents.py:334`, is `    id: str`

#### message/send, string id (control)

1. Body `{"jsonrpc":"2.0","id":"ctl-1","method":"message/send","params":{"message":{"role":"user","messageId":"m1","parts":[{"kind":"text","text":"hi"}]}}}`
2. Output

```
{"id":"ctl-1","jsonrpc":"2.0","result":{"kind":"message","messageId":"stub-msg-1","parts":[{"kind":"text","text":"echoed"}],"role":"agent"}}
HTTP 200
```

#### message/send, integer id

1. Body `{"jsonrpc":"2.0","id":42,"method":"message/send","params":{"message":{"role":"user","messageId":"m1","parts":[{"kind":"text","text":"hi"}]}}}`
2. Output

```
{"jsonrpc":"2.0","id":42,"error":{"code":-32603,"message":"Internal error: 1 validation error for LiteLLMSendMessageResponse\nid\n  Input should be a valid string [type=string_type, input_value=42, input_type=int]\n    For further information visit https://errors.pydantic.dev/2.13/v/string_type"}}
HTTP 500
```

#### tasks/get, string id (control)

1. Body `{"jsonrpc":"2.0","id":"ctl-2","method":"tasks/get","params":{"id":"stub-task-1"}}`
2. Output

```
{"id":"ctl-2","jsonrpc":"2.0","result":{"kind":"task","id":"stub-task-1","contextId":"stub-ctx-1","status":{"state":"completed"}}}
HTTP 200
```

#### tasks/get, integer id

1. Body `{"jsonrpc":"2.0","id":42,"method":"tasks/get","params":{"id":"stub-task-1"}}`
2. Output

```
{"jsonrpc":"2.0","id":42,"error":{"code":-32603,"message":"Internal error: 1 validation error for LiteLLMSendMessageResponse\nid\n  Input should be a valid string [type=string_type, input_value=42, input_type=int]\n    For further information visit https://errors.pydantic.dev/2.13/v/string_type"}}
HTTP 500
```

#### tasks/get, falsy integer id

1. Body `{"jsonrpc":"2.0","id":0,"method":"tasks/get","params":{"id":"stub-task-1"}}`
2. Output

```
{"jsonrpc":"2.0","id":0,"error":{"code":-32603,"message":"Internal error: 1 validation error for LiteLLMSendMessageResponse\nid\n  Input should be a valid string [type=string_type, input_value=0, input_type=int]\n    For further information visit https://errors.pydantic.dev/2.13/v/string_type"}}
HTTP 500
```

#### tasks/get, id omitted so the agent answers with a null id

1. Body `{"jsonrpc":"2.0","method":"tasks/get","params":{"id":"stub-task-1"}}`
2. Output

```
{"jsonrpc":"2.0","id":null,"error":{"code":-32603,"message":"Internal error: 1 validation error for LiteLLMSendMessageResponse\nid\n  Input should be a valid string [type=string_type, input_value=None, input_type=NoneType]\n    For further information visit https://errors.pydantic.dev/2.13/v/string_type"}}
HTTP 500
```

#### tasks/get, boolean id (not a legal JSON-RPC id)

1. Body `{"jsonrpc":"2.0","id":true,"method":"tasks/get","params":{"id":"stub-task-1"}}`
2. Output

```
{"jsonrpc":"2.0","id":true,"error":{"code":-32603,"message":"Internal error: 1 validation error for LiteLLMSendMessageResponse\nid\n  Input should be a valid string [type=string_type, input_value=True, input_type=bool]\n    For further information visit https://errors.pydantic.dev/2.13/v/string_type"}}
HTTP 500
```

#### upstream access log for the run

1. The stub logged every inbound request, so the agent was reached and answered on all seven legs; the failures are entirely proxy-side

```
UPSTREAM GET /.well-known/agent-card.json
UPSTREAM POST / method='message/send' id='ce6ece59-3927-4aeb-b25b-2e8f99c6c35a' id_type=str
UPSTREAM GET /.well-known/agent-card.json
UPSTREAM POST / method='message/send' id='2d49544e-0f82-46bc-b233-6a50a7d17acd' id_type=str
UPSTREAM POST / method='tasks/get' id='ctl-2' id_type=str
UPSTREAM POST / method='tasks/get' id=42 id_type=int
UPSTREAM POST / method='tasks/get' id=0 id_type=int
UPSTREAM POST / method='tasks/get' id=None id_type=NoneType
UPSTREAM POST / method='tasks/get' id=True id_type=bool
```

### After (4affda47b1)

Code under test, `litellm/types/agents.py:347`, is `    id: str | StrictInt | None = None`

#### message/send, string id (control)

1. Body `{"jsonrpc":"2.0","id":"ctl-1","method":"message/send","params":{"message":{"role":"user","messageId":"m1","parts":[{"kind":"text","text":"hi"}]}}}`
2. Output

```
{"id":"ctl-1","jsonrpc":"2.0","result":{"kind":"message","messageId":"stub-msg-1","parts":[{"kind":"text","text":"echoed"}],"role":"agent"}}
HTTP 200
```

#### message/send, integer id

1. Body `{"jsonrpc":"2.0","id":42,"method":"message/send","params":{"message":{"role":"user","messageId":"m1","parts":[{"kind":"text","text":"hi"}]}}}`
2. Output, id returned as a number

```
{"id":42,"jsonrpc":"2.0","result":{"kind":"message","messageId":"stub-msg-1","parts":[{"kind":"text","text":"echoed"}],"role":"agent"}}
HTTP 200
```

#### tasks/get, string id (control)

1. Body `{"jsonrpc":"2.0","id":"ctl-2","method":"tasks/get","params":{"id":"stub-task-1"}}`
2. Output

```
{"id":"ctl-2","jsonrpc":"2.0","result":{"kind":"task","id":"stub-task-1","contextId":"stub-ctx-1","status":{"state":"completed"}}}
HTTP 200
```

#### tasks/get, integer id

1. Body `{"jsonrpc":"2.0","id":42,"method":"tasks/get","params":{"id":"stub-task-1"}}`
2. Output, id returned as a number

```
{"id":42,"jsonrpc":"2.0","result":{"kind":"task","id":"stub-task-1","contextId":"stub-ctx-1","status":{"state":"completed"}}}
HTTP 200
```

#### tasks/get, falsy integer id

1. Body `{"jsonrpc":"2.0","id":0,"method":"tasks/get","params":{"id":"stub-task-1"}}`
2. Output, `0` is preserved rather than read as absent

```
{"id":0,"jsonrpc":"2.0","result":{"kind":"task","id":"stub-task-1","contextId":"stub-ctx-1","status":{"state":"completed"}}}
HTTP 200
```

#### tasks/get, id omitted so the agent answers with a null id

1. Body `{"jsonrpc":"2.0","method":"tasks/get","params":{"id":"stub-task-1"}}`
2. Output, the agent's reply is relayed

```
{"jsonrpc":"2.0","result":{"kind":"task","id":"stub-task-1","contextId":"stub-ctx-1","status":{"state":"completed"}}}
HTTP 200
```

#### tasks/get, boolean id (not a legal JSON-RPC id)

1. Body `{"jsonrpc":"2.0","id":true,"method":"tasks/get","params":{"id":"stub-task-1"}}`
2. Output, stringified rather than relayed as `1`, which would collide with a real integer id

```
{"id":"True","jsonrpc":"2.0","result":{"kind":"task","id":"stub-task-1","contextId":"stub-ctx-1","status":{"state":"completed"}}}
HTTP 200
```

#### upstream access log for the run

1. Same shape as the Before run, confirming the only variable was the response model

```
UPSTREAM GET /.well-known/agent-card.json
UPSTREAM POST / method='message/send' id='33acb5d6-e696-43d0-822f-cbd4feafe8f1' id_type=str
UPSTREAM GET /.well-known/agent-card.json
UPSTREAM POST / method='message/send' id='565fbe21-b50c-4a8a-b0dc-4009bb0095c1' id_type=str
UPSTREAM POST / method='tasks/get' id='ctl-2' id_type=str
UPSTREAM POST / method='tasks/get' id=42 id_type=int
UPSTREAM POST / method='tasks/get' id=0 id_type=int
UPSTREAM POST / method='tasks/get' id=None id_type=NoneType
UPSTREAM POST / method='tasks/get' id=True id_type=bool
```

## Review notes

Greptile filed the boolean trap twice and was right both times, including against my own reply. `bool` subclasses `int`, so widening to accept integers made pydantic coerce a boolean id to `1` or `0`, which is worse than the 500 it replaced because `1` collides with a real integer id another in-flight request may be using.

My first correction guarded only `_normalize_a2a_jsonrpc_response`, and I said in a review reply that the annotation was guarded too. That was wrong: direct construction bypasses normalization, and the follow-up P1 saying so is accurate. The field is now `str | StrictInt | None`, which accepts exactly `string | integer | null` and rejects `bool`, `float`, `list` and `dict` on every path including direct construction. Only the integer half needs strictness, since `bool` subclasses `int` and not `str`.

Getting there without raising a type ceiling took some measuring, which is worth recording. The ceilings in `basedpyright-code-budget.json` are ratcheted to the exact current count, so any `+1` reds `lint`. `StrictStr | StrictInt` costs two `reportUnknownVariableType` (basedpyright cannot resolve either pydantic symbol here) and a `field_validator` costs one of those plus a `reportUntypedFunctionDecorator` against a ceiling of 27. `str | StrictInt` costs exactly one, paid for by giving `response_dict` in `from_a2a_response` a real binding instead of an untyped rebind. Net per-rule delta against the merge base is zero on every rule.

Rebased onto `fc3b160fb5` to pick up #37671, which added the `ruff check --config ruff-tests.toml tests` step. That job checks out the PR head rather than the merge ref, so the step ran against a tree predating the config file it names, and no rerun could clear it. Both proof legs above were re-captured after the rebase.

This supersedes #29196, which proposed the same `str | int | None` widening for LIT-2818 in May. That branch targets `litellm_oss_agent_shin_daily_branch`, predates `_normalize_a2a_jsonrpc_response`, and would conflict.

## Type

🐛 Bug Fix

## Caveats

- A null id is omitted from the response, not emitted as `"id": null`
- That follows the endpoint's existing `exclude_none` dump, unchanged here
- Bridge-backed agents still stringify the id; separate, larger change
- That path narrows `request_id: str` across six provider packages

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
