### PR TITLE
fix(proxy): rewrap chained batch output file IDs

### DIFF
--- a/litellm/proxy/openai_files_endpoints/common_utils.py
+++ b/litellm/proxy/openai_files_endpoints/common_utils.py
@@ -1160,8 +1160,17 @@ async def ensure_batch_response_managed_file_ids(
 
     for file_attr in ("output_file_id", "error_file_id"):
         raw_file_id = getattr(response, file_attr, None)
-        if not raw_file_id or _is_base64_encoded_unified_file_id(raw_file_id):
+        if not raw_file_id:
             continue
+        if _is_base64_encoded_unified_file_id(raw_file_id):
+            try:
+                managed_file = await ManagedFileRepository(prisma_client).table.find_first(
+                    where={"unified_file_id": raw_file_id}
+                )
+                if managed_file:
+                    continue
+            except Exception:
+                continue
         try:
             new_unified_file_id = managed_files_obj.get_unified_output_file_id(
                 output_file_id=raw_file_id,

--- a/tests/test_litellm/enterprise/proxy/test_batch_update_db_managed_output_file_id.py
+++ b/tests/test_litellm/enterprise/proxy/test_batch_update_db_managed_output_file_id.py
@@ -1,10 +1,12 @@
 """Regression: update_batch_in_database must not persist raw provider output_file_id."""
 
+import base64
 import json
 from types import SimpleNamespace
 from typing import Optional
-import pytest
 from unittest.mock import AsyncMock, MagicMock
+
+import pytest
 
 from litellm.proxy._types import UserAPIKeyAuth
 from litellm.proxy.openai_files_endpoints.common_utils import (
@@ -211,6 +213,64 @@ async def test_ensure_batch_response_normalizes_error_file_id():
     assert response.output_file_id == unified_id
     assert response.error_file_id == unified_id
     assert mock_managed_files.get_unified_output_file_id.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_ensure_batch_response_rewraps_chained_proxy_output_file_id():
+    upstream_unified_file_id = base64.urlsafe_b64encode(
+        b"litellm_proxy:application/json;unified_id,upstream-uuid;target_model_names,upstream-model;llm_output_file_id,upstream-file;llm_output_file_model_id,upstream-model-id"
+    ).decode().rstrip("=")
+    front_proxy_unified_file_id = "file-front-proxy-output"
+    response = _build_batch_response(
+        output_file_id=upstream_unified_file_id,
+        hidden_params={"model_id": "front-proxy-model-id", "model_name": "litellm_proxy/upstream-model"},
+    )
+    mock_managed_files = _build_managed_files_mock(unified_id=front_proxy_unified_file_id)
+
+    await ensure_batch_response_managed_file_ids(
+        response=response,
+        managed_files_obj=mock_managed_files,
+        prisma_client=_build_prisma_mock(),
+        verbose_proxy_logger=MagicMock(),
+        user_api_key_dict=UserAPIKeyAuth(user_id="user-abc"),
+    )
+
+    assert response.output_file_id == front_proxy_unified_file_id
+    mock_managed_files.get_unified_output_file_id.assert_called_once_with(
+        output_file_id=upstream_unified_file_id,
+        model_id="front-proxy-model-id",
+        model_name="litellm_proxy/upstream-model",
+    )
+    assert mock_managed_files.store_unified_file_id.call_args.kwargs["model_mappings"] == {
+        "front-proxy-model-id": upstream_unified_file_id
+    }
+
+
+@pytest.mark.asyncio
+async def test_ensure_batch_response_preserves_registered_output_file_id():
+    registered_unified_file_id = base64.urlsafe_b64encode(
+        b"litellm_proxy:application/json;unified_id,front-uuid;target_model_names,front-model;llm_output_file_id,front-file;llm_output_file_model_id,front-model-id"
+    ).decode().rstrip("=")
+    response = _build_batch_response(
+        output_file_id=registered_unified_file_id,
+        hidden_params={"model_id": "front-proxy-model-id", "model_name": "litellm_proxy/upstream-model"},
+    )
+    mock_managed_files = _build_managed_files_mock()
+    mock_prisma = _build_prisma_mock()
+    mock_prisma.db.litellm_managedfiletable.find_first = AsyncMock(
+        return_value=SimpleNamespace(unified_file_id=registered_unified_file_id)
+    )
+
+    await ensure_batch_response_managed_file_ids(
+        response=response,
+        managed_files_obj=mock_managed_files,
+        prisma_client=mock_prisma,
+        verbose_proxy_logger=MagicMock(),
+        user_api_key_dict=UserAPIKeyAuth(user_id="user-abc"),
+    )
+
+    assert response.output_file_id == registered_unified_file_id
+    mock_managed_files.get_unified_output_file_id.assert_not_called()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## TLDR

Problem this solves:

- Completed chained batches expose upstream file IDs
- The front proxy cannot fetch those results

How it solves it:

- Registers unknown upstream managed IDs under the front deployment
- Preserves IDs already registered by the front proxy

## User Flow

Before: a developer can create and complete a batch through the front proxy, but cannot download its results there

1. They POST https://front-proxy/v1/files with a batch JSONL file
2. They POST https://front-proxy/v1/batches with that returned input file ID
3. GET https://front-proxy/v1/batches/{batch_id} returns `completed` and an output file ID
4. GET https://front-proxy/v1/files/{output_file_id}/content returns a routing error

After: the same completed batch result is fetched through the front proxy

1. They POST https://front-proxy/v1/files with the same batch JSONL file
2. They POST https://front-proxy/v1/batches with that returned input file ID
3. GET https://front-proxy/v1/batches/{batch_id} returns `completed` and a front proxy output file ID
4. GET https://front-proxy/v1/files/{output_file_id}/content returns the JSONL result

## Relevant issues

Fixes #37352

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] Focused regression tests pass locally
- [ ] My PR passes all required CI/CD checks
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile Confidence Score of at least 4/5 before requesting a maintainer review

## Screenshots / Proof of Fix

Live two-proxy verification needs credentials and a runnable Postgres-backed proxy environment, which are unavailable in this workspace. The focused provider-free regression tests verify that an unknown upstream managed output ID is rewrapped and a front-proxy-registered ID is unchanged

## Type

🐛 Bug Fix

## Caveats (if any)

- Draft pending live two-proxy curl verification and CI

### Final Attestation

- [x] The tests cover chained output rewrapping and registered-ID preservation