### PR TITLE
feat(integrations): add Openlayer as an OTEL logging callback

### DIFF
--- a/litellm/__init__.py
+++ b/litellm/__init__.py
@@ -161,6 +161,7 @@ _custom_logger_compatible_callbacks_literal = Literal[
     "vantage",
     "posthog",
     "levo",
+    "openlayer",
     "compression_interception",
     "newrelic",
 ]

--- a/litellm/integrations/openlayer/__init__.py
+++ b/litellm/integrations/openlayer/__init__.py
@@ -1,0 +1,3 @@
+from litellm.integrations.openlayer.openlayer import OpenlayerLogger
+
+__all__ = ("OpenlayerLogger",)

--- a/litellm/integrations/openlayer/openlayer.py
+++ b/litellm/integrations/openlayer/openlayer.py
@@ -1,0 +1,78 @@
+import os
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Final
+
+from litellm.integrations.opentelemetry import OpenTelemetry
+from litellm.types.integrations.base_health_check import IntegrationHealthCheckStatus
+
+if TYPE_CHECKING:
+    from litellm.types.integrations.arize import Protocol
+
+OPENLAYER_DEFAULT_ENDPOINT: Final = "https://api.openlayer.com/v1/otel"
+
+
+@dataclass(frozen=True, slots=True)
+class OpenlayerConfig:
+    """Resolved Openlayer OTLP settings."""
+
+    otlp_auth_headers: str
+    protocol: "Protocol"
+    endpoint: str
+
+
+class OpenlayerLogger(OpenTelemetry):
+    """Openlayer logger that extends OpenTelemetry for OTLP integration."""
+
+    @staticmethod
+    def get_openlayer_config() -> OpenlayerConfig:
+        """Build the Openlayer OTLP configuration from the environment.
+
+        ``OPENLAYER_OTEL_ENDPOINT`` overrides the managed endpoint for
+        self-hosted deployments. The endpoint is a base URL: the ``/v1/traces``
+        signal path is appended, idempotently, by the exporter setup on both the
+        v1 and v2 paths.
+
+        Returns:
+            OpenlayerConfig: endpoint, protocol and OTLP auth headers.
+
+        Raises:
+            ValueError: If a required environment variable is missing.
+        """
+        api_key: Final = os.environ.get("OPENLAYER_API_KEY", None)
+        pipeline_id: Final = os.environ.get("OPENLAYER_INFERENCE_PIPELINE_ID", None)
+        endpoint: Final = os.environ.get("OPENLAYER_OTEL_ENDPOINT") or OPENLAYER_DEFAULT_ENDPOINT
+
+        if not api_key:
+            raise ValueError(
+                "OPENLAYER_API_KEY environment variable is required for the "
+                "Openlayer integration. Find it under Workspace settings, API keys."
+            )
+        if not pipeline_id:
+            raise ValueError(
+                "OPENLAYER_INFERENCE_PIPELINE_ID environment variable is required "
+                "for the Openlayer integration. It selects the inference pipeline "
+                "traces are published to."
+            )
+
+        protocol: Final[Protocol] = "otlp_http"
+        otlp_auth_headers: Final = ",".join(
+            (
+                f"Authorization=Bearer {api_key}",
+                f"x-bt-parent=pipeline_id:{pipeline_id}",
+            )
+        )
+
+        return OpenlayerConfig(
+            otlp_auth_headers=otlp_auth_headers,
+            protocol=protocol,
+            endpoint=endpoint,
+        )
+
+    async def async_health_check(self) -> IntegrationHealthCheckStatus:
+        """Report whether the Openlayer credentials are configured."""
+        try:
+            self.get_openlayer_config()
+        except ValueError as e:
+            return IntegrationHealthCheckStatus(status="unhealthy", error_message=str(e))
+
+        return IntegrationHealthCheckStatus(status="healthy", error_message=None)

--- a/litellm/integrations/otel/model/config.py
+++ b/litellm/integrations/otel/model/config.py
@@ -38,6 +38,7 @@ class ExporterOwner(str, Enum):
     LANGFUSE_OTEL = "langfuse_otel"
     WEAVE_OTEL = "weave_otel"
     LEVO = "levo"
+    OPENLAYER = "openlayer"
     AGENTOPS = "agentops"
 
 

--- a/litellm/integrations/otel/presets/__init__.py
+++ b/litellm/integrations/otel/presets/__init__.py
@@ -21,6 +21,7 @@ from litellm.integrations.otel.presets.langfuse import (
 )
 from litellm.integrations.otel.presets.langtrace import langtrace_preset
 from litellm.integrations.otel.presets.levo import levo_preset
+from litellm.integrations.otel.presets.openlayer import openlayer_preset
 from litellm.integrations.otel.presets.phoenix import (
     phoenix_preset,
     phoenix_project_headers,
@@ -37,6 +38,7 @@ PRESET_BY_CALLBACK: Final[dict[str, Preset]] = {
     "langfuse_otel": langfuse_preset,
     "langtrace": langtrace_preset,
     "levo": levo_preset,
+    "openlayer": openlayer_preset,
     "weave_otel": weave_preset,
 }
 
@@ -109,6 +111,7 @@ __all__ = [
     "langfuse_preset",
     "langtrace_preset",
     "levo_preset",
+    "openlayer_preset",
     "phoenix_preset",
     "project_routing_headers",
     "weave_preset",

--- a/litellm/integrations/otel/presets/openlayer.py
+++ b/litellm/integrations/otel/presets/openlayer.py
@@ -1,0 +1,38 @@
+"""Openlayer preset.
+
+Reads its config through ``OpenlayerLogger.get_openlayer_config`` so the v1 and
+v2 paths cannot drift. Adds no mapper vocabulary: Openlayer reads the canonical
+GenAI attributes the always-present ``genai`` mapper emits, and ``mapper_names``
+is logger-wide rather than per-exporter, so a vocabulary added here would also
+be stamped on spans bound for a co-configured backend.
+"""
+
+from typing import Final
+
+from litellm.integrations.openlayer.openlayer import OpenlayerLogger as _V1Openlayer
+from litellm.integrations.otel.model.config import (
+    ExporterOwner,
+    ExporterSpec,
+    OpenTelemetryV2Config,
+)
+
+
+def openlayer_preset(
+    *,
+    config_overrides: OpenTelemetryV2Config | None = None,
+) -> OpenTelemetryV2Config:
+    cfg: Final = _V1Openlayer.get_openlayer_config()
+    base: Final = config_overrides or OpenTelemetryV2Config()
+    return base.model_copy(
+        update={  # mutable-ok: model_copy(update=) requires a dict
+            "exporters": [  # mutable-ok: field is declared list[ExporterSpec] and update= does not coerce
+                *base.exporters,
+                ExporterSpec(
+                    kind="otlp_http",
+                    endpoint=cfg.endpoint,
+                    headers=cfg.otlp_auth_headers,
+                    owner=ExporterOwner.OPENLAYER,
+                ),
+            ],
+        }
+    )

--- a/litellm/litellm_core_utils/custom_logger_registry.py
+++ b/litellm/litellm_core_utils/custom_logger_registry.py
@@ -87,6 +87,7 @@ class CustomLoggerRegistry:
         "langtrace": OpenTelemetry,
         "weave_otel": OpenTelemetry,
         "levo": OpenTelemetry,
+        "openlayer": OpenTelemetry,
         "mlflow": MlflowLogger,
         "langfuse": LangfusePromptManagement,
         "otel": OpenTelemetry,

--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -4140,6 +4140,31 @@ def _init_custom_logger_compatible_class(
             _arize_phoenix_otel_logger: Final = ArizePhoenixLogger(config=otel_config, callback_name="arize_phoenix")
             _in_memory_loggers.append(_arize_phoenix_otel_logger)
             return _arize_phoenix_otel_logger
+        elif logging_integration == "openlayer":
+            _v2 = _maybe_construct_otel_v2("openlayer", _in_memory_loggers)
+            if _v2 is not None:
+                return _v2
+            from litellm.integrations.openlayer.openlayer import OpenlayerLogger
+            from litellm.integrations.opentelemetry import (
+                OpenTelemetry,
+                OpenTelemetryConfig,
+            )
+
+            openlayer_config: Final = OpenlayerLogger.get_openlayer_config()
+            otel_config = OpenTelemetryConfig(
+                exporter=openlayer_config.protocol,
+                endpoint=openlayer_config.endpoint,
+                headers=openlayer_config.otlp_auth_headers,
+            )
+
+            # Check if OpenlayerLogger instance already exists
+            for callback in _in_memory_loggers:
+                if isinstance(callback, OpenlayerLogger) and callback.callback_name == "openlayer":
+                    return callback
+
+            _openlayer_otel_logger: Final = OpenlayerLogger(config=otel_config, callback_name="openlayer")
+            _in_memory_loggers.append(_openlayer_otel_logger)
+            return _openlayer_otel_logger
         elif logging_integration == "levo":
             _v2 = _maybe_construct_otel_v2("levo", _in_memory_loggers)
             if _v2 is not None:

--- a/tests/test_litellm/integrations/otel/test_otel_v2_presets.py
+++ b/tests/test_litellm/integrations/otel/test_otel_v2_presets.py
@@ -160,3 +160,168 @@ def test_agentops_endpoint_points_at_live_host():
     # so a typo or stale domain can never ship again.
     assert _AGENTOPS_ENDPOINT == "https://otlp.agentops.ai/v1/traces"
     assert "agentops.cloud" not in _AGENTOPS_ENDPOINT
+
+
+OPENLAYER_ENV = (
+    "OPENLAYER_API_KEY",
+    "OPENLAYER_INFERENCE_PIPELINE_ID",
+    "OPENLAYER_OTEL_ENDPOINT",
+)
+
+
+def _openlayer_spec(monkeypatch, **env):
+    from litellm.integrations.otel.model.config import ExporterOwner
+    from litellm.integrations.otel.presets.openlayer import openlayer_preset
+
+    for name in OPENLAYER_ENV:
+        monkeypatch.delenv(name, raising=False)
+    for name, value in env.items():
+        monkeypatch.setenv(name, value)
+    cfg = openlayer_preset()
+    return next(e for e in cfg.exporters if e.owner == ExporterOwner.OPENLAYER)
+
+
+def test_openlayer_preset_sends_key_and_pipeline_as_headers(monkeypatch):
+    from litellm.integrations.openlayer.openlayer import OPENLAYER_DEFAULT_ENDPOINT
+
+    spec = _openlayer_spec(
+        monkeypatch,
+        OPENLAYER_API_KEY="sk-ol-123",
+        OPENLAYER_INFERENCE_PIPELINE_ID="cb47e4f7-15a0-4e70-bd6e-7b1b4b54e434",
+    )
+    assert spec.kind == "otlp_http"
+    assert spec.endpoint == OPENLAYER_DEFAULT_ENDPOINT
+    assert spec.headers == "Authorization=Bearer sk-ol-123,x-bt-parent=pipeline_id:cb47e4f7-15a0-4e70-bd6e-7b1b4b54e434"
+
+
+def test_openlayer_pipeline_id_survives_header_parsing(monkeypatch):
+    """The colon in ``pipeline_id:<uuid>`` must survive parse_headers."""
+    spec = _openlayer_spec(
+        monkeypatch,
+        OPENLAYER_API_KEY="sk-ol-123",
+        OPENLAYER_INFERENCE_PIPELINE_ID="cb47e4f7-15a0-4e70-bd6e-7b1b4b54e434",
+    )
+    headers = providers.parse_headers(spec.headers)
+    assert headers["x-bt-parent"] == "pipeline_id:cb47e4f7-15a0-4e70-bd6e-7b1b4b54e434"
+    assert headers["authorization"] == "Bearer sk-ol-123"
+
+
+def test_openlayer_endpoint_resolves_to_the_traces_signal_path():
+    """The signal path is appended once, whichever spelling is configured."""
+    from litellm.integrations.openlayer.openlayer import OPENLAYER_DEFAULT_ENDPOINT
+
+    resolved = "https://api.openlayer.com/v1/otel/v1/traces"
+    assert providers._otlp_traces_endpoint(OPENLAYER_DEFAULT_ENDPOINT) == resolved
+    assert providers._otlp_traces_endpoint(resolved) == resolved
+
+
+def test_openlayer_self_hosted_endpoint_override(monkeypatch):
+    spec = _openlayer_spec(
+        monkeypatch,
+        OPENLAYER_API_KEY="sk-ol-123",
+        OPENLAYER_INFERENCE_PIPELINE_ID="p-1",
+        OPENLAYER_OTEL_ENDPOINT="https://openlayer.internal/v1/otel",
+    )
+    assert spec.endpoint == "https://openlayer.internal/v1/otel"
+
+
+@pytest.mark.parametrize(
+    "env, missing",
+    [
+        ({}, "OPENLAYER_API_KEY"),
+        ({"OPENLAYER_API_KEY": "sk-ol-123"}, "OPENLAYER_INFERENCE_PIPELINE_ID"),
+        ({"OPENLAYER_INFERENCE_PIPELINE_ID": "p-1"}, "OPENLAYER_API_KEY"),
+    ],
+)
+def test_openlayer_names_the_missing_credential(monkeypatch, env, missing):
+    from litellm.integrations.otel.presets.openlayer import openlayer_preset
+
+    for name in OPENLAYER_ENV:
+        monkeypatch.delenv(name, raising=False)
+    for name, value in env.items():
+        monkeypatch.setenv(name, value)
+    with pytest.raises(ValueError, match=missing):
+        openlayer_preset()
+
+
+def test_openlayer_adds_no_mapper_vocabulary(monkeypatch):
+    from litellm.integrations.otel.model.config import OpenTelemetryV2Config
+    from litellm.integrations.otel.presets.openlayer import openlayer_preset
+
+    monkeypatch.setenv("OPENLAYER_API_KEY", "sk-ol-123")
+    monkeypatch.setenv("OPENLAYER_INFERENCE_PIPELINE_ID", "p-1")
+    assert openlayer_preset().mapper_names == OpenTelemetryV2Config().mapper_names
+
+
+def test_openlayer_is_registered_as_a_callback_name():
+    import litellm
+    from litellm.integrations.otel.model.config import ExporterOwner
+    from litellm.integrations.otel.presets import PRESET_BY_CALLBACK
+    from litellm.integrations.otel.presets.openlayer import openlayer_preset
+
+    assert "openlayer" in litellm._known_custom_logger_compatible_callbacks
+    assert PRESET_BY_CALLBACK["openlayer"] is openlayer_preset
+    assert ExporterOwner("openlayer") is ExporterOwner.OPENLAYER
+
+
+def test_openlayer_v1_config_matches_the_preset(monkeypatch):
+    from litellm.integrations.openlayer.openlayer import OpenlayerLogger
+
+    monkeypatch.setenv("OPENLAYER_API_KEY", "sk-ol-123")
+    monkeypatch.setenv("OPENLAYER_INFERENCE_PIPELINE_ID", "p-1")
+    monkeypatch.delenv("OPENLAYER_OTEL_ENDPOINT", raising=False)
+
+    v1 = OpenlayerLogger.get_openlayer_config()
+    spec = _openlayer_spec(monkeypatch, OPENLAYER_API_KEY="sk-ol-123", OPENLAYER_INFERENCE_PIPELINE_ID="p-1")
+    assert (v1.endpoint, v1.protocol, v1.otlp_auth_headers) == (
+        spec.endpoint,
+        spec.kind,
+        spec.headers,
+    )
+
+
+def test_openlayer_health_check_reports_configured(monkeypatch):
+    import asyncio
+
+    from litellm.integrations.openlayer.openlayer import OpenlayerLogger
+
+    monkeypatch.setenv("OPENLAYER_API_KEY", "sk-ol-123")
+    monkeypatch.setenv("OPENLAYER_INFERENCE_PIPELINE_ID", "p-1")
+    result = asyncio.run(OpenlayerLogger.async_health_check(OpenlayerLogger))
+    assert result["status"] == "healthy"
+
+
+def test_openlayer_health_check_names_the_missing_credential(monkeypatch):
+    import asyncio
+
+    from litellm.integrations.openlayer.openlayer import OpenlayerLogger
+
+    for name in OPENLAYER_ENV:
+        monkeypatch.delenv(name, raising=False)
+    result = asyncio.run(OpenlayerLogger.async_health_check(OpenlayerLogger))
+    assert result["status"] == "unhealthy"
+    assert "OPENLAYER_API_KEY" in result["error_message"]
+
+
+def test_openlayer_callback_builds_the_v1_logger_when_v2_is_off(monkeypatch):
+    """Without LITELLM_OTEL_V2 the callback resolves to the v1 logger."""
+    from litellm.integrations.openlayer.openlayer import OpenlayerLogger
+    from litellm.integrations.otel.model.config import is_otel_v2_enabled
+    from litellm.litellm_core_utils.litellm_logging import (
+        _init_custom_logger_compatible_class,
+    )
+
+    monkeypatch.delenv("LITELLM_OTEL_V2", raising=False)
+    is_otel_v2_enabled.cache_clear()
+    monkeypatch.setenv("OPENLAYER_API_KEY", "sk-ol-123")
+    monkeypatch.setenv("OPENLAYER_INFERENCE_PIPELINE_ID", "p-1")
+    monkeypatch.delenv("OPENLAYER_OTEL_ENDPOINT", raising=False)
+    try:
+        logger = _init_custom_logger_compatible_class("openlayer", internal_usage_cache=None, llm_router=None)
+        assert isinstance(logger, OpenlayerLogger)
+        assert logger.callback_name == "openlayer"
+        expected = OpenlayerLogger.get_openlayer_config()
+        assert logger.OTEL_ENDPOINT == expected.endpoint
+        assert logger.OTEL_HEADERS == expected.otlp_auth_headers
+    finally:
+        is_otel_v2_enabled.cache_clear()


### PR DESCRIPTION
## TLDR

Problem this solves:

- Openlayer had no named callback in LiteLLM
- Routing traces there meant hand-writing OTLP env vars
- One of those header values contains a colon
- The endpoint is easy to get wrong and 404s

How it solves it:

- Adds an `openlayer` callback for SDK and proxy
- Reads two env vars, plus one optional override
- Builds the endpoint and headers for the user
- Works on both the v1 and v2 OTel paths

## User Flow

Before: an engineer who wants their gateway traffic in Openlayer sets `callbacks: ["openlayer"]`, and the gateway will not start

1. They put `callbacks: ["openlayer"]` under `litellm_settings` in `config.yaml`
2. They start the gateway and it exits during startup with `ValueError: Empty module name`
3. `POST http://0.0.0.0:4000/v1/chat/completions` returns nothing: `curl: (7) Failed to connect to 0.0.0.0 port 4000`
4. To get traces flowing they instead hand-write `OTEL_ENDPOINT` and a two-part `OTEL_HEADERS` string, and a wrong endpoint path silently 404s every export

After: the same config starts, and their requests show up in Openlayer with model, tokens and cost

1. They set `OPENLAYER_API_KEY` and `OPENLAYER_INFERENCE_PIPELINE_ID`, keep `callbacks: ["openlayer"]`, and start the gateway
2. The gateway starts and answers `GET http://0.0.0.0:4000/health/liveliness`
3. They send `POST http://0.0.0.0:4000/v1/chat/completions` with `gpt-4o-mini` and get `HTTP 200` with a completion and a usage object
4. They open the Data view of their inference pipeline and see that request as a row carrying provider `OpenAI`, model `gpt-4o-mini`, prompt and completion token counts, cost and latency

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Shared setup for every case below. `config.yaml`:

```yaml
model_list:
  - model_name: gpt-4o-mini
    litellm_params:
      model: openai/gpt-4o-mini
      api_key: os.environ/OPENAI_API_KEY

litellm_settings:
  callbacks: ["openlayer"]
```

Environment, with a real OpenAI key and a real Openlayer workspace key and pipeline:

```shell
export OPENAI_API_KEY="sk-proj-..."
export OPENLAYER_API_KEY="sk-ol-..."
export OPENLAYER_INFERENCE_PIPELINE_ID="cb47e4f7-15a0-4e70-bd6e-7b1b4b54e434"
export LITELLM_MASTER_KEY=sk-1234
export OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT=span_and_event
```

Start command, and the request every case sends:

```shell
python -m litellm.proxy.proxy_cli --config config.yaml --port 4000

curl -sS -w 'HTTP %{http_code}\n' -L -X POST 'http://0.0.0.0:4000/v1/chat/completions' \
  -H 'Content-Type: application/json' -H 'Authorization: Bearer sk-1234' \
  -d '{"model": "gpt-4o-mini", "messages": [{"role": "user", "content": "Reply with one word: proxy-qa"}], "max_tokens": 16}'
```

These are real OpenAI calls billed to a real key, and the rows below are real rows read back from the Openlayer API

### Before (abdde94ad5)

1. Start the gateway with the config above:

```
File "litellm/proxy/common_utils/callback_utils.py", line 375, in initialize_callbacks_on_proxy
File "litellm/proxy/types_utils/utils.py", line 65, in get_instance_fn
ValueError: Empty module name
```

2. The process exits during startup, so the request never reaches a provider:

```
curl: (7) Failed to connect to 0.0.0.0 port 4000 after 0 ms: Could not connect to server
HTTP 000
```

3. Nothing arrives in the Openlayer pipeline, because nothing was ever sent

### After (4eb7bfdf8e)

#### Default, no `LITELLM_OTEL_V2`

1. Start the gateway with the same config. It starts, and `GET /health/liveliness` answers

2. Send the request:

```
HTTP 200
  id     : chatcmpl-EF692thMQe6ejk1fIb2CPiSbq2xee
  content: 'Understood.'
  usage  : {'completion_tokens': 3, 'prompt_tokens': 18, 'total_tokens': 21}
```

3. Read the row back from the pipeline. The trace arrives with the gateway request at the root and the model call nested under it:

```
root: Received Proxy Server Request   latency=3068ms   status=success
  - auth
  - proxy_pre_call
  - litellm_request        provider=OpenAI  model=gpt-4o-mini
    - raw_gen_ai_request
  - router
```

#### `LITELLM_OTEL_V2=true`

1. Start the gateway with `LITELLM_OTEL_V2=true` and the same config

2. Send the request:

```
HTTP 200
  id     : chatcmpl-EF6DRPVVK9JhQ6e3CafJUBq6k4ywr
  content: 'Understood.'
  usage  : {'completion_tokens': 3, 'prompt_tokens': 19, 'total_tokens': 22}
```

3. Read the row back from the pipeline. Provider, model, token counts and cost are all populated, and the model call is typed as a chat completion:

```
inference_id: fSxA3MFZj7OHT15to7+Gmg==
  provider          = OpenAI
  model             = gpt-4o-mini
  openlayer_cost    = 4.649999e-06
  promptTokens      = 19
  completionTokens  = 3
  openlayer_latency = 137.311
  status            = success
  - chat gpt-4o-mini   type=chat_completion  provider=OpenAI  model=gpt-4o-mini  cost=4.649999e-06
```

## Type

🆕 New Feature

## Caveats (if any)

- Cost lands on the v2 path, not the default path
- Response text needs an Openlayer-side ingest fix, in flight
- No per-request team or key credentials yet
- v2 needs `opentelemetry-api` 1.40 or older

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
