### PR TITLE
fix(proxy): split agent inference and management routes so admin nodes can create agents

### DIFF
--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -515,15 +515,28 @@ class LiteLLMRoutes(enum.Enum):
     # allowed_routes=["mcp_routes"], which should cover both halves.
     mcp_routes = mcp_inference_routes + mcp_management_routes
 
-    agent_routes = [
-        "/v1/agents",
-        "/v1/agents/{agent_id}",
+    # A2A agent invocation / discovery routes — data-plane. Gated by DISABLE_LLM_API_ENDPOINTS.
+    agent_inference_routes = (
         "/agents",
         "/a2a/{agent_id}",
         "/a2a/{agent_id}/message/send",
         "/a2a/{agent_id}/message/stream",
         "/a2a/{agent_id}/.well-known/agent-card.json",
-    ]
+    )
+
+    # Agent registry CRUD routes — control-plane. Gated by DISABLE_ADMIN_ENDPOINTS.
+    # The handlers in agent_endpoints/endpoints.py enforce proxy-admin on writes and
+    # scope reads by role, so these also appear in self_managed_routes.
+    agent_management_routes = (
+        "/v1/agents",
+        "/v1/agents/{agent_id}",
+        "/v1/agents/make_public",
+        "/v1/agents/{agent_id}/make_public",
+    )
+
+    # Backwards-compat union — virtual keys may be configured with
+    # allowed_routes=["agent_routes"], which should cover both halves.
+    agent_routes = agent_inference_routes + agent_management_routes
 
     google_routes = [
         "/v1beta/models/{model_name:path}:countTokens",
@@ -563,7 +576,7 @@ class LiteLLMRoutes(enum.Enum):
         + apply_guardrail_routes
         + mcp_inference_routes
         + litellm_native_routes
-        + agent_routes
+        + list(agent_inference_routes)
         + model_info_routes
     )
     info_routes = [
@@ -664,6 +677,7 @@ class LiteLLMRoutes(enum.Enum):
         ]
         + key_management_routes
         + mcp_management_routes
+        + list(agent_management_routes)
     )
 
     spend_tracking_routes = [
@@ -836,6 +850,9 @@ class LiteLLMRoutes(enum.Enum):
         # proxy admin, or team admin naming their own team via team_id
         "/auto_router/test_routing",
         "/auto_router/validate_complexity_router_config",
+        # Agent registry - reads are role-scoped and writes are proxy-admin-gated
+        # inside agent_endpoints/endpoints.py
+        *agent_management_routes,
     ]  # routes that manage their own allowed/disallowed logic
 
     ## Org Admin Routes ##

--- a/litellm/proxy/auth/route_checks.py
+++ b/litellm/proxy/auth/route_checks.py
@@ -1,4 +1,5 @@
 import re
+from collections.abc import Sequence
 from typing import Final
 
 from fastapi import HTTPException, Request, status
@@ -163,6 +164,19 @@ class RouteChecks:
                         # these paths are admin-only management writes and
                         # are intentionally not covered.
                         if RouteChecks._is_get_mcp_server_discovery_route(route=route, request=request):
+                            return True
+
+                        # Agent registry CRUD moved from llm_api_routes into
+                        # management_routes so DISABLE_LLM_API_ENDPOINTS stops
+                        # blocking it. Keys configured with
+                        # allowed_routes=["llm_api_routes"] before that split
+                        # could reach these paths, so keep them reachable here;
+                        # the handlers in agent_endpoints/endpoints.py still
+                        # enforce proxy-admin on writes and scope reads by role.
+                        if RouteChecks.check_route_access(
+                            route=route,
+                            allowed_routes=LiteLLMRoutes.agent_management_routes.value,
+                        ):
                             return True
 
         # check if wildcard pattern is allowed
@@ -367,7 +381,7 @@ class RouteChecks:
         if RouteChecks.check_route_access(route=route, allowed_routes=LiteLLMRoutes.mcp_inference_routes.value):
             return True
 
-        if RouteChecks.check_route_access(route=route, allowed_routes=LiteLLMRoutes.agent_routes.value):
+        if RouteChecks.check_route_access(route=route, allowed_routes=LiteLLMRoutes.agent_inference_routes.value):
             return True
 
         if route in LiteLLMRoutes.litellm_native_routes.value:
@@ -558,13 +572,13 @@ class RouteChecks:
         return False
 
     @staticmethod
-    def check_route_access(route: str, allowed_routes: list[str]) -> bool:
+    def check_route_access(route: str, allowed_routes: Sequence[str]) -> bool:
         """
         Check if a route has access by checking both exact matches and patterns
 
         Args:
             route (str): The route to check
-            allowed_routes (list): List of allowed routes/patterns
+            allowed_routes (Sequence): Allowed routes/patterns
 
         Returns:
             bool: True if route is allowed, False otherwise
@@ -579,10 +593,12 @@ class RouteChecks:
         # wildcard match route is in allowed_routes
         # e.g calling /anthropic/v1/messages is allowed if allowed_routes has /anthropic/*
         #########################################################
-        wildcard_allowed_routes = [route for route in allowed_routes if RouteChecks._is_wildcard_pattern(pattern=route)]
-        for allowed_route in wildcard_allowed_routes:
-            if RouteChecks._route_matches_wildcard_pattern(route=route, pattern=allowed_route):
-                return True
+        if any(
+            RouteChecks._route_matches_wildcard_pattern(route=route, pattern=allowed_route)
+            for allowed_route in allowed_routes
+            if RouteChecks._is_wildcard_pattern(pattern=allowed_route)
+        ):
+            return True
 
         #########################################################
         # pattern match route is in allowed_routes

--- a/ruff-strict-budget.json
+++ b/ruff-strict-budget.json
@@ -174,7 +174,7 @@
     "limit": 176
   },
   "RUF012": {
-    "limit": 241
+    "limit": 240
   },
   "RUF015": {
     "limit": 8

--- a/tests/enterprise/litellm_enterprise/proxy/auth/test_route_checks.py
+++ b/tests/enterprise/litellm_enterprise/proxy/auth/test_route_checks.py
@@ -373,3 +373,63 @@ class TestEnterpriseRouteChecksErrorMessages:
             # Should not raise exception for premium users
             result = EnterpriseRouteChecks.is_management_routes_disabled()
             assert result is True
+
+
+@patch("litellm.proxy.proxy_server.premium_user", True)
+class TestEnterpriseRouteChecksAgentManagement:
+    """Regression tests for LIT-2069: the Admin UI Agents tab could not create an
+    external agent on nodes with DISABLE_LLM_API_ENDPOINTS set, because agent
+    registry CRUD (/v1/agents*) was classified as an LLM API route. It is now a
+    management route, so DISABLE_ADMIN_ENDPOINTS gates it instead. Uses the real
+    is_llm_api_route / is_management_route classifiers (not mocks)."""
+
+    @pytest.mark.parametrize(
+        "route",
+        [
+            "/v1/agents",
+            "/v1/agents/abc-123",
+            "/v1/agents/make_public",
+            "/v1/agents/abc-123/make_public",
+        ],
+    )
+    def test_agent_management_allowed_when_llm_api_disabled(self, route):
+        with patch.dict(os.environ, {"DISABLE_LLM_API_ENDPOINTS": "true"}, clear=False):
+            os.environ.pop("DISABLE_ADMIN_ENDPOINTS", None)
+            # Should not raise - agent CRUD is a management route, not llm_api.
+            EnterpriseRouteChecks.should_call_route(route)
+
+    @pytest.mark.parametrize(
+        "route",
+        [
+            "/v1/agents",
+            "/v1/agents/abc-123",
+        ],
+    )
+    def test_agent_management_blocked_when_admin_disabled(self, route):
+        with patch.dict(os.environ, {"DISABLE_ADMIN_ENDPOINTS": "true"}, clear=False):
+            os.environ.pop("DISABLE_LLM_API_ENDPOINTS", None)
+            with pytest.raises(HTTPException) as exc_info:
+                EnterpriseRouteChecks.should_call_route(route)
+
+            assert exc_info.value.status_code == 403
+            assert "Management routes are disabled for this instance." in str(
+                exc_info.value.detail
+            )
+
+    @pytest.mark.parametrize(
+        "route",
+        [
+            "/a2a/abc-123/message/send",
+            "/a2a/abc-123/message/stream",
+        ],
+    )
+    def test_agent_inference_still_blocked_when_llm_api_disabled(self, route):
+        with patch.dict(os.environ, {"DISABLE_LLM_API_ENDPOINTS": "true"}, clear=False):
+            os.environ.pop("DISABLE_ADMIN_ENDPOINTS", None)
+            with pytest.raises(HTTPException) as exc_info:
+                EnterpriseRouteChecks.should_call_route(route)
+
+            assert exc_info.value.status_code == 403
+            assert "LLM API routes are disabled for this instance." in str(
+                exc_info.value.detail
+            )

--- a/tests/test_litellm/proxy/auth/test_route_checks.py
+++ b/tests/test_litellm/proxy/auth/test_route_checks.py
@@ -3428,3 +3428,104 @@ def test_auto_router_dry_runs_share_model_new_audience(user_role, dry_run_route)
     # Anchor so parity cannot be satisfied by both routes 403ing for everyone
     if user_role == LitellmUserRoles.INTERNAL_USER.value:
         assert outcome(dry_run_route) == "allowed"
+
+
+AGENT_MANAGEMENT_ROUTES = [
+    "/v1/agents",
+    "/v1/agents/abc-123",
+    "/v1/agents/make_public",
+    "/v1/agents/abc-123/make_public",
+]
+
+AGENT_INFERENCE_ROUTES = [
+    "/a2a/abc-123",
+    "/a2a/abc-123/message/send",
+    "/a2a/abc-123/message/stream",
+    "/a2a/abc-123/.well-known/agent-card.json",
+]
+
+
+@pytest.mark.parametrize("route", AGENT_MANAGEMENT_ROUTES)
+def test_agent_management_routes_classified_as_management_not_llm_api(route):
+    """Agent registry CRUD must be management routes, not llm_api routes.
+
+    Regression for the Admin UI Agents tab failing with "LLM API routes are
+    disabled for this instance." on admin nodes that set
+    DISABLE_LLM_API_ENDPOINTS.
+    """
+
+    assert RouteChecks.is_llm_api_route(route=route) is False
+    assert RouteChecks.is_management_route(route=route) is True
+
+
+@pytest.mark.parametrize("route", AGENT_INFERENCE_ROUTES)
+def test_agent_inference_routes_stay_llm_api(route):
+    """A2A invocation stays on the data plane, gated by DISABLE_LLM_API_ENDPOINTS."""
+
+    assert RouteChecks.is_llm_api_route(route=route) is True
+    assert RouteChecks.is_management_route(route=route) is False
+
+
+@pytest.mark.parametrize("route", AGENT_MANAGEMENT_ROUTES + AGENT_INFERENCE_ROUTES)
+def test_agent_routes_union_still_covers_both_halves(route):
+    """Keys configured with allowed_routes=["agent_routes"] must keep both halves."""
+
+    assert (
+        RouteChecks.check_route_access(
+            route=route, allowed_routes=LiteLLMRoutes.agent_routes.value
+        )
+        is True
+    )
+
+
+@pytest.mark.parametrize("route", AGENT_MANAGEMENT_ROUTES)
+@pytest.mark.parametrize("method", ["GET", "POST", "DELETE"])
+def test_virtual_key_llm_api_routes_allows_agent_registry(route, method):
+    """Keys with allowed_routes=["llm_api_routes"] could reach agent CRUD before the
+    inference/management split and must still reach it after.
+
+    Writes remain proxy-admin-only inside agent_endpoints/endpoints.py, so this
+    carve-out is not method-aware.
+    """
+
+    valid_token = UserAPIKeyAuth(user_id="test_user", allowed_routes=["llm_api_routes"])
+
+    assert (
+        RouteChecks.is_virtual_key_allowed_to_call_route(
+            route=route,
+            valid_token=valid_token,
+            request=_mock_request(method),
+        )
+        is True
+    )
+
+
+@pytest.mark.parametrize(
+    "user_role",
+    [
+        LitellmUserRoles.INTERNAL_USER.value,
+        LitellmUserRoles.INTERNAL_USER_VIEW_ONLY.value,
+        None,
+    ],
+)
+@pytest.mark.parametrize("method, route", [("GET", "/v1/agents"), ("POST", "/v1/agents")])
+def test_agent_registry_route_gate_open_to_non_admin_roles(user_role, method, route):
+    """Non-admin callers reached agent CRUD through llm_api_routes before the split.
+
+    The route gate must keep letting them through so the handlers can scope the
+    listing by role and 403 non-admin writes themselves.
+    """
+
+    valid_token = UserAPIKeyAuth(user_id="test_user", user_role=user_role)
+    request = MagicMock(spec=Request)
+    request.method = method
+    request.query_params = {}
+
+    RouteChecks.non_proxy_admin_allowed_routes_check(
+        user_obj=LiteLLM_UserTable(user_id="test_user", user_role=user_role),
+        _user_role=user_role,
+        route=route,
+        request=request,
+        valid_token=valid_token,
+        request_data={},
+    )


### PR DESCRIPTION
## TLDR

Problem this solves:

- Admin UI Agents tab cannot create an agent on admin nodes
- Agent registry CRUD was gated by `DISABLE_LLM_API_ENDPOINTS`
- Every `/v1/agents` call 403s with an LLM-API error

How it solves it:

- Split agent routes into inference and management halves
- Registry CRUD now rides `management_routes`, like MCP server CRUD
- `agent_routes` stays the union so existing keys keep working

## User Flow

Before: an admin on a control-plane node (started with `DISABLE_LLM_API_ENDPOINTS=true`) cannot register an external agent at all

1. They open https://litellm-domain/ui/?page=agents and click "Add Agent"
2. They fill in the agent name and the external agent's card URL, then click "Create agent"
3. The dialog shows "Failed to create agent: LLM API routes are disabled for this instance."
4. Sending the same request by hand, POST https://litellm-domain/v1/agents with the agent name and card, returns 403 `{"detail":"LLM API routes are disabled for this instance."}`
5. GET https://litellm-domain/v1/agents returns the same 403, so the Agents tab cannot even list what is already registered

After: the same admin registers the agent and sees it in the list, while chat traffic stays turned off on that node

1. They open https://litellm-domain/ui/?page=agents and click "Add Agent"
2. They fill in the agent name and the external agent's card URL, then click "Create agent"
3. The dialog reports success and hands back an id like `b2bb289f-eeab-4285-a62f-e67de32514cd`
4. POST https://litellm-domain/v1/agents by hand returns 200 with the stored agent card
5. GET https://litellm-domain/v1/agents returns 200 and lists the new agent
6. POST https://litellm-domain/v1/chat/completions still returns 403 `{"detail":"LLM API routes are disabled for this instance."}`, so the node stays control-plane only

## Relevant issues

## Linear ticket

Resolves LIT-2069

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

Shared setup, run against a live proxy on port 4077 with a real database and an enterprise license:

```
DISABLE_LLM_API_ENDPOINTS=true python litellm/proxy/proxy_cli.py --config litellm/proxy/dev_config.yaml --port 4077 --use_v2_migration_resolver
```

Cases 4 and 5 use a second run of the same proxy with `DISABLE_LLM_API_ENDPOINTS` unset, plus two keys minted through `/key/generate`: one owned by an internal user, one restricted to `allowed_routes=["llm_api_routes"]`.

### Before (2dcd453860)

#### create an external agent

1. `curl -sS -w "\nHTTP %{http_code}\n" -X POST http://localhost:4077/v1/agents -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" -d @agent.json`
2. ```
   {"detail":"LLM API routes are disabled for this instance."}
   HTTP 403
   ```

#### list agents in the Agents tab

1. `curl -sS -w "\nHTTP %{http_code}\n" http://localhost:4077/v1/agents -H "Authorization: Bearer sk-1234"`
2. ```
   {"detail":"LLM API routes are disabled for this instance."}
   HTTP 403
   ```

#### LLM inference stays disabled on this node

1. `curl -sS -w "\nHTTP %{http_code}\n" -X POST http://localhost:4077/v1/chat/completions -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" -d '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"ping"}]}'`
2. ```
   {"detail":"LLM API routes are disabled for this instance."}
   HTTP 403
   ```

#### an internal user's key lists agents on a normal node

1. `curl -sS -w "\nHTTP %{http_code}\n" http://localhost:4077/v1/agents -H "Authorization: Bearer <internal-user-key>"`
2. `HTTP 200`

#### a key restricted to allowed_routes=[llm_api_routes] lists agents

1. `curl -sS -w "\nHTTP %{http_code}\n" http://localhost:4077/v1/agents -H "Authorization: Bearer <llm_api_routes-key>"`
2. `HTTP 200`

### After (e094730fb3)

#### create an external agent

1. `curl -sS -w "\nHTTP %{http_code}\n" -X POST http://localhost:4077/v1/agents -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" -d @agent.json`
2. ```
   {"agent_id":"b2bb289f-eeab-4285-a62f-e67de32514cd","agent_name":"lit-2069-demo-tip","litellm_params":{},"agent_card_params":{"url":"https://external-agent.example.com/","name":"External Hello Agent","version":"1.0.0","provider":{"url":"http://localhost:4077","organization":"LiteLLM Proxy"},"description":"external a2a agent","capabilities":{"streaming":true},"protocolVersion":"1.0","defaultInputModes":["text"],"defaultOutputModes":["text"],"supportedInterfaces":[{"url":"http://localhost:4077/a2a/b2bb289f-eeab-4285-a62f-e67de32514cd","protocolBinding":"JSONRPC","protocolVersion":"1.0"}]},"spend":0.0,"created_at":"2026-08-20T22:17:14.417000Z","created_by":"default_user_id"}
   HTTP 200
   ```

#### list agents in the Agents tab

1. `curl -sS -w "\nHTTP %{http_code}\n" http://localhost:4077/v1/agents -H "Authorization: Bearer sk-1234"`
2. ```
   ["lit-2069-demo-tip"]
   HTTP 200
   ```

#### LLM inference stays disabled on this node

1. `curl -sS -w "\nHTTP %{http_code}\n" -X POST http://localhost:4077/v1/chat/completions -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" -d '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"ping"}]}'`
2. ```
   {"detail":"LLM API routes are disabled for this instance."}
   HTTP 403
   ```

#### an internal user's key lists agents on a normal node

1. `curl -sS -w "\nHTTP %{http_code}\n" http://localhost:4077/v1/agents -H "Authorization: Bearer <internal-user-key>"`
2. `HTTP 200`

#### a key restricted to allowed_routes=[llm_api_routes] lists agents

1. `curl -sS -w "\nHTTP %{http_code}\n" http://localhost:4077/v1/agents -H "Authorization: Bearer <llm_api_routes-key>"`
2. `HTTP 200`

## Type

🐛 Bug Fix

## Caveats (if any)

- `DISABLE_ADMIN_ENDPOINTS` now blocks `/v1/agents` too
- That is the intended half of the split, matching MCP server CRUD
- Agent invocation under `/a2a/...` is unaffected and stays data-plane
- The generic UI error text from the ticket is already fixed on staging

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
