### PR TITLE
feat(router): per-group supported reasoning efforts via model-map intersection

### DIFF
--- a/litellm/llms/openai/chat/gpt_5_transformation.py
+++ b/litellm/llms/openai/chat/gpt_5_transformation.py
@@ -16,7 +16,7 @@ def _normalize_reasoning_effort_for_chat_completion(
 ) -> str | None:
     """Convert reasoning_effort to the string format expected by OpenAI chat completion API.
 
-    The chat completion API expects a simple string: 'none', 'low', 'medium', 'high', or 'xhigh'.
+    The chat completion API expects a simple effort string ('none' through 'ultra').
     Config/deployments may pass the Responses API format: {'effort': 'high', 'summary': 'detailed'}.
     """
     if value is None:
@@ -222,8 +222,8 @@ class OpenAIGPT5Config(OpenAIGPTConfig):
                 if "reasoning_effort" in optional_params:
                     optional_params["reasoning_effort"] = normalized
 
-        if effective_effort == "xhigh":
-            # xhigh is an opt-in capability: only allow if model explicitly supports it.
+        if effective_effort in ("xhigh", "ultra"):
+            # xhigh/ultra are opt-in capabilities: only allow if model explicitly supports them.
             if not self._supports_reasoning_effort_level(model, effective_effort):
                 if litellm.drop_params or drop_params:
                     non_default_params.pop("reasoning_effort", None)

--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -6562,7 +6562,9 @@
         "supports_web_search": true,
         "supports_none_reasoning_effort": true,
         "supports_xhigh_reasoning_effort": true,
-        "supports_minimal_reasoning_effort": false
+        "supports_minimal_reasoning_effort": false,
+        "supports_max_reasoning_effort": true,
+        "supports_ultra_reasoning_effort": true
     },
     "azure/gpt-5.6-sol": {
         "cache_read_input_token_cost": 5e-07,
@@ -6613,7 +6615,9 @@
         "supports_web_search": true,
         "supports_none_reasoning_effort": true,
         "supports_xhigh_reasoning_effort": true,
-        "supports_minimal_reasoning_effort": false
+        "supports_minimal_reasoning_effort": false,
+        "supports_max_reasoning_effort": true,
+        "supports_ultra_reasoning_effort": true
     },
     "azure/gpt-5.6-terra": {
         "cache_read_input_token_cost": 2e-07,
@@ -6664,7 +6668,9 @@
         "supports_web_search": true,
         "supports_none_reasoning_effort": true,
         "supports_xhigh_reasoning_effort": true,
-        "supports_minimal_reasoning_effort": false
+        "supports_minimal_reasoning_effort": false,
+        "supports_max_reasoning_effort": true,
+        "supports_ultra_reasoning_effort": true
     },
     "azure/gpt-5.6-luna": {
         "cache_read_input_token_cost": 2e-08,
@@ -6715,7 +6721,9 @@
         "supports_web_search": true,
         "supports_none_reasoning_effort": true,
         "supports_xhigh_reasoning_effort": true,
-        "supports_minimal_reasoning_effort": false
+        "supports_minimal_reasoning_effort": false,
+        "supports_max_reasoning_effort": true,
+        "supports_ultra_reasoning_effort": true
     },
     "azure/us/gpt-5.6": {
         "cache_read_input_token_cost": 5.5e-07,
@@ -6762,7 +6770,9 @@
         "supports_web_search": true,
         "supports_none_reasoning_effort": true,
         "supports_xhigh_reasoning_effort": true,
-        "supports_minimal_reasoning_effort": false
+        "supports_minimal_reasoning_effort": false,
+        "supports_max_reasoning_effort": true,
+        "supports_ultra_reasoning_effort": true
     },
     "azure/us/gpt-5.6-sol": {
         "cache_read_input_token_cost": 5.5e-07,
@@ -6810,7 +6820,9 @@
         "supports_web_search": true,
         "supports_none_reasoning_effort": true,
         "supports_xhigh_reasoning_effort": true,
-        "supports_minimal_reasoning_effort": false
+        "supports_minimal_reasoning_effort": false,
+        "supports_max_reasoning_effort": true,
+        "supports_ultra_reasoning_effort": true
     },
     "azure/us/gpt-5.6-terra": {
         "cache_read_input_token_cost": 2.2e-07,
@@ -6858,7 +6870,9 @@
         "supports_web_search": true,
         "supports_none_reasoning_effort": true,
         "supports_xhigh_reasoning_effort": true,
-        "supports_minimal_reasoning_effort": false
+        "supports_minimal_reasoning_effort": false,
+        "supports_max_reasoning_effort": true,
+        "supports_ultra_reasoning_effort": true
     },
     "azure/us/gpt-5.6-luna": {
         "cache_read_input_token_cost": 2.2e-08,
@@ -6906,7 +6920,9 @@
         "supports_web_search": true,
         "supports_none_reasoning_effort": true,
         "supports_xhigh_reasoning_effort": true,
-        "supports_minimal_reasoning_effort": false
+        "supports_minimal_reasoning_effort": false,
+        "supports_max_reasoning_effort": true,
+        "supports_ultra_reasoning_effort": true
     },
     "azure/eu/gpt-5.6": {
         "cache_read_input_token_cost": 5.5e-07,
@@ -6953,7 +6969,9 @@
         "supports_web_search": true,
         "supports_none_reasoning_effort": true,
         "supports_xhigh_reasoning_effort": true,
-        "supports_minimal_reasoning_effort": false
+        "supports_minimal_reasoning_effort": false,
+        "supports_max_reasoning_effort": true,
+        "supports_ultra_reasoning_effort": true
     },
     "azure/eu/gpt-5.6-sol": {
         "cache_read_input_token_cost": 5.5e-07,
@@ -7001,7 +7019,9 @@
         "supports_web_search": true,
         "supports_none_reasoning_effort": true,
         "supports_xhigh_reasoning_effort": true,
-        "supports_minimal_reasoning_effort": false
+        "supports_minimal_reasoning_effort": false,
+        "supports_max_reasoning_effort": true,
+        "supports_ultra_reasoning_effort": true
     },
     "azure/eu/gpt-5.6-terra": {
         "cache_read_input_token_cost": 2.2e-07,
@@ -7049,7 +7069,9 @@
         "supports_web_search": true,
         "supports_none_reasoning_effort": true,
         "supports_xhigh_reasoning_effort": true,
-        "supports_minimal_reasoning_effort": false
+        "supports_minimal_reasoning_effort": false,
+        "supports_max_reasoning_effort": true,
+        "supports_ultra_reasoning_effort": true
     },
     "azure/eu/gpt-5.6-luna": {
         "cache_read_input_token_cost": 2.2e-08,
@@ -7097,7 +7119,9 @@
         "supports_web_search": true,
         "supports_none_reasoning_effort": true,
         "supports_xhigh_reasoning_effort": true,
-        "supports_minimal_reasoning_effort": false
+        "supports_minimal_reasoning_effort": false,
+        "supports_max_reasoning_effort": true,
+        "supports_ultra_reasoning_effort": true
     },
     "azure/gpt-5.5": {
         "deprecation_date": "2027-10-26",
@@ -26101,7 +26125,9 @@
         "supports_tool_choice": true,
         "supports_vision": true,
         "supports_web_search": true,
-        "supports_xhigh_reasoning_effort": true
+        "supports_xhigh_reasoning_effort": true,
+        "supports_max_reasoning_effort": true,
+        "supports_ultra_reasoning_effort": true
     },
     "gpt-5.6-sol": {
         "cache_creation_input_token_cost": 6.25e-06,
@@ -26165,7 +26191,9 @@
         "supports_tool_choice": true,
         "supports_vision": true,
         "supports_web_search": true,
-        "supports_xhigh_reasoning_effort": true
+        "supports_xhigh_reasoning_effort": true,
+        "supports_max_reasoning_effort": true,
+        "supports_ultra_reasoning_effort": true
     },
     "gpt-5.6-terra": {
         "cache_creation_input_token_cost": 2.5e-06,
@@ -26228,7 +26256,9 @@
         "supports_tool_choice": true,
         "supports_vision": true,
         "supports_web_search": true,
-        "supports_xhigh_reasoning_effort": true
+        "supports_xhigh_reasoning_effort": true,
+        "supports_max_reasoning_effort": true,
+        "supports_ultra_reasoning_effort": true
     },
     "gpt-5.6-luna": {
         "cache_creation_input_token_cost": 2.5e-07,
@@ -26291,7 +26321,9 @@
         "supports_tool_choice": true,
         "supports_vision": true,
         "supports_web_search": true,
-        "supports_xhigh_reasoning_effort": true
+        "supports_xhigh_reasoning_effort": true,
+        "supports_max_reasoning_effort": true,
+        "supports_ultra_reasoning_effort": true
     },
     "gpt-5.6-cyber": {
         "cache_creation_input_token_cost": 1.5625e-05,
@@ -26330,7 +26362,9 @@
         "supports_web_search": true,
         "source": "https://platform.openai.com/docs/models/gpt-5.6-cyber",
         "supports_computer_use": true,
-        "supports_parallel_function_calling": true
+        "supports_parallel_function_calling": true,
+        "supports_max_reasoning_effort": true,
+        "supports_ultra_reasoning_effort": true
     },
     "daybreak-red-latest": {
         "cache_creation_input_token_cost": 1.5625e-05,
@@ -48488,7 +48522,9 @@
         "supports_reasoning": true,
         "supports_response_schema": true,
         "supports_tool_choice": true,
-        "supports_vision": true
+        "supports_vision": true,
+        "supports_max_reasoning_effort": true,
+        "supports_ultra_reasoning_effort": true
     },
     "bedrock_mantle/openai.gpt-5.6-terra": {
         "input_cost_per_token": 2.2e-06,
@@ -48520,7 +48556,9 @@
         "supports_reasoning": true,
         "supports_response_schema": true,
         "supports_tool_choice": true,
-        "supports_vision": true
+        "supports_vision": true,
+        "supports_max_reasoning_effort": true,
+        "supports_ultra_reasoning_effort": true
     },
     "bedrock_mantle/openai.gpt-5.6-luna": {
         "input_cost_per_token": 2.2e-07,
@@ -48552,7 +48590,9 @@
         "supports_reasoning": true,
         "supports_response_schema": true,
         "supports_tool_choice": true,
-        "supports_vision": true
+        "supports_vision": true,
+        "supports_max_reasoning_effort": true,
+        "supports_ultra_reasoning_effort": true
     },
     "bedrock_mantle/openai.gpt-5.5": {
         "input_cost_per_token": 5.5e-06,

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -165,6 +165,10 @@ from litellm.router_utils.pre_call_checks.model_rate_limit_check import (
 from litellm.router_utils.pre_call_checks.prompt_caching_deployment_check import (
     PromptCachingDeploymentCheck,
 )
+from litellm.router_utils.reasoning_effort_capability import (
+    intersect_supported_reasoning_efforts,
+    resolve_supported_reasoning_efforts,
+)
 from litellm.router_utils.router_callbacks.track_deployment_metrics import (
     increment_deployment_failures_for_current_minute,
     increment_deployment_successes_for_current_minute,
@@ -9540,6 +9544,11 @@ class Router:
                     _deployment_tpm = model_info.get("tpm")
                 if model_info.get("rpm", None) is not None and _deployment_rpm is None:
                     _deployment_rpm = model_info.get("rpm")
+
+            model_group_info.supported_reasoning_efforts = intersect_supported_reasoning_efforts(
+                model_group_info.supported_reasoning_efforts,
+                resolve_supported_reasoning_efforts(model_info),
+            )
 
             if _deployment_tpm is not None:
                 if total_tpm is None:

--- a/litellm/router_utils/reasoning_effort_capability.py
+++ b/litellm/router_utils/reasoning_effort_capability.py
@@ -1,0 +1,52 @@
+"""Resolve which reasoning_effort values a deployment, and by intersection a model group, accepts.
+
+The model-map flags carry different polarity per level, mirroring the provider gates
+(gpt_5_transformation.py restricts xhigh to explicit opt-in and treats minimal/low as opt-out;
+anthropic/chat/transformation.py rejects only xhigh/max without an explicit flag): medium and high
+are unconditional for any reasoning model, none/minimal/low are supported unless the map explicitly
+says false, and xhigh/max require an explicit true. Shipping the resolved list keeps that polarity
+in one place instead of re-encoding it in every consumer.
+"""
+
+from collections.abc import Mapping, Sequence
+from typing import Final
+
+REASONING_EFFORT_CAPABILITY_ORDER: Final = ("none", "minimal", "low", "medium", "high", "xhigh", "max")
+
+_OPT_OUT_FLAGS: Final = (
+    ("none", "supports_none_reasoning_effort"),
+    ("minimal", "supports_minimal_reasoning_effort"),
+    ("low", "supports_low_reasoning_effort"),
+)
+_OPT_IN_FLAGS: Final = (
+    ("xhigh", "supports_xhigh_reasoning_effort"),
+    ("max", "supports_max_reasoning_effort"),
+)
+_UNCONDITIONAL_EFFORTS: Final = frozenset(("medium", "high"))
+
+
+def resolve_supported_reasoning_efforts(model_info: Mapping[str, object]) -> tuple[str, ...] | None:
+    """None = no capability metadata for this deployment (e.g. a model absent from the model map,
+    whose stub info carries no supports_reasoning key at all); () = reasoning unsupported."""
+    if "supports_reasoning" not in model_info:
+        return None
+    if model_info.get("supports_reasoning") is not True:
+        return ()
+    opt_out: Final = frozenset(effort for effort, flag in _OPT_OUT_FLAGS if model_info.get(flag) is not False)
+    opt_in: Final = frozenset(effort for effort, flag in _OPT_IN_FLAGS if model_info.get(flag) is True)
+    allowed: Final = opt_out | _UNCONDITIONAL_EFFORTS | opt_in
+    return tuple(effort for effort in REASONING_EFFORT_CAPABILITY_ORDER if effort in allowed)
+
+
+def intersect_supported_reasoning_efforts(
+    current: Sequence[str] | None,
+    resolved: Sequence[str] | None,
+) -> tuple[str, ...] | None:
+    """Deployments without metadata (None) never narrow the group; an effort survives only when
+    every deployment with metadata accepts it, so the group offers nothing routing could reject."""
+    if resolved is None:
+        return tuple(current) if current is not None else None
+    if current is None:
+        return tuple(resolved)
+    keep: Final = frozenset(current) & frozenset(resolved)
+    return tuple(effort for effort in REASONING_EFFORT_CAPABILITY_ORDER if effort in keep)

--- a/litellm/router_utils/reasoning_effort_capability.py
+++ b/litellm/router_utils/reasoning_effort_capability.py
@@ -11,7 +11,7 @@ in one place instead of re-encoding it in every consumer.
 from collections.abc import Mapping, Sequence
 from typing import Final
 
-REASONING_EFFORT_CAPABILITY_ORDER: Final = ("none", "minimal", "low", "medium", "high", "xhigh", "max")
+REASONING_EFFORT_CAPABILITY_ORDER: Final = ("none", "minimal", "low", "medium", "high", "xhigh", "max", "ultra")
 
 _OPT_OUT_FLAGS: Final = (
     ("none", "supports_none_reasoning_effort"),
@@ -21,6 +21,7 @@ _OPT_OUT_FLAGS: Final = (
 _OPT_IN_FLAGS: Final = (
     ("xhigh", "supports_xhigh_reasoning_effort"),
     ("max", "supports_max_reasoning_effort"),
+    ("ultra", "supports_ultra_reasoning_effort"),
 )
 _UNCONDITIONAL_EFFORTS: Final = frozenset(("medium", "high"))
 

--- a/litellm/types/llms/openai.py
+++ b/litellm/types/llms/openai.py
@@ -1807,7 +1807,7 @@ ResponsesAPIStreamingResponse = Annotated[
 ]
 
 
-REASONING_EFFORT = Literal["none", "minimal", "low", "medium", "high", "xhigh"]
+REASONING_EFFORT = Literal["none", "minimal", "low", "medium", "high", "xhigh", "max", "ultra"]
 
 
 class OpenAIRealtimeStreamSession(TypedDict, total=False):

--- a/litellm/types/router.py
+++ b/litellm/types/router.py
@@ -635,6 +635,7 @@ class ModelGroupInfo(BaseModel):
     supports_url_context: bool = Field(default=False)
     supports_reasoning: bool = Field(default=False)
     supports_function_calling: bool = Field(default=False)
+    supported_reasoning_efforts: tuple[str, ...] | None = Field(default=None)
     supported_openai_params: list[str] | None = Field(default=[])
     configurable_clientside_auth_params: CONFIGURABLE_CLIENTSIDE_AUTH_PARAMS = None
 

--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -163,6 +163,7 @@ class ProviderSpecificModelInfo(TypedDict, total=False):
     supports_low_reasoning_effort: bool | None
     supports_xhigh_reasoning_effort: bool | None
     supports_max_reasoning_effort: bool | None
+    supports_ultra_reasoning_effort: ReadOnly[bool | None]
     supports_output_config: bool | None
     supports_image_size: bool | None
     bedrock_output_config_effort_ceiling: Literal["low", "medium", "high", "max", "xhigh"] | None

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -5761,6 +5761,7 @@ def _get_model_info_helper(
                 supports_low_reasoning_effort=_model_info.get("supports_low_reasoning_effort", None),
                 supports_xhigh_reasoning_effort=_model_info.get("supports_xhigh_reasoning_effort", None),
                 supports_max_reasoning_effort=_model_info.get("supports_max_reasoning_effort", None),
+                supports_ultra_reasoning_effort=_model_info.get("supports_ultra_reasoning_effort", None),
                 bedrock_output_config_effort_ceiling=_model_info.get("bedrock_output_config_effort_ceiling", None),
                 bedrock_converse_supports_strict_tools=_model_info.get("bedrock_converse_supports_strict_tools", None),
                 supports_computer_use=_model_info.get("supports_computer_use", None),

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -6562,7 +6562,9 @@
         "supports_web_search": true,
         "supports_none_reasoning_effort": true,
         "supports_xhigh_reasoning_effort": true,
-        "supports_minimal_reasoning_effort": false
+        "supports_minimal_reasoning_effort": false,
+        "supports_max_reasoning_effort": true,
+        "supports_ultra_reasoning_effort": true
     },
     "azure/gpt-5.6-sol": {
         "cache_read_input_token_cost": 5e-07,
@@ -6613,7 +6615,9 @@
         "supports_web_search": true,
         "supports_none_reasoning_effort": true,
         "supports_xhigh_reasoning_effort": true,
-        "supports_minimal_reasoning_effort": false
+        "supports_minimal_reasoning_effort": false,
+        "supports_max_reasoning_effort": true,
+        "supports_ultra_reasoning_effort": true
     },
     "azure/gpt-5.6-terra": {
         "cache_read_input_token_cost": 2e-07,
@@ -6664,7 +6668,9 @@
         "supports_web_search": true,
         "supports_none_reasoning_effort": true,
         "supports_xhigh_reasoning_effort": true,
-        "supports_minimal_reasoning_effort": false
+        "supports_minimal_reasoning_effort": false,
+        "supports_max_reasoning_effort": true,
+        "supports_ultra_reasoning_effort": true
     },
     "azure/gpt-5.6-luna": {
         "cache_read_input_token_cost": 2e-08,
@@ -6715,7 +6721,9 @@
         "supports_web_search": true,
         "supports_none_reasoning_effort": true,
         "supports_xhigh_reasoning_effort": true,
-        "supports_minimal_reasoning_effort": false
+        "supports_minimal_reasoning_effort": false,
+        "supports_max_reasoning_effort": true,
+        "supports_ultra_reasoning_effort": true
     },
     "azure/us/gpt-5.6": {
         "cache_read_input_token_cost": 5.5e-07,
@@ -6762,7 +6770,9 @@
         "supports_web_search": true,
         "supports_none_reasoning_effort": true,
         "supports_xhigh_reasoning_effort": true,
-        "supports_minimal_reasoning_effort": false
+        "supports_minimal_reasoning_effort": false,
+        "supports_max_reasoning_effort": true,
+        "supports_ultra_reasoning_effort": true
     },
     "azure/us/gpt-5.6-sol": {
         "cache_read_input_token_cost": 5.5e-07,
@@ -6810,7 +6820,9 @@
         "supports_web_search": true,
         "supports_none_reasoning_effort": true,
         "supports_xhigh_reasoning_effort": true,
-        "supports_minimal_reasoning_effort": false
+        "supports_minimal_reasoning_effort": false,
+        "supports_max_reasoning_effort": true,
+        "supports_ultra_reasoning_effort": true
     },
     "azure/us/gpt-5.6-terra": {
         "cache_read_input_token_cost": 2.2e-07,
@@ -6858,7 +6870,9 @@
         "supports_web_search": true,
         "supports_none_reasoning_effort": true,
         "supports_xhigh_reasoning_effort": true,
-        "supports_minimal_reasoning_effort": false
+        "supports_minimal_reasoning_effort": false,
+        "supports_max_reasoning_effort": true,
+        "supports_ultra_reasoning_effort": true
     },
     "azure/us/gpt-5.6-luna": {
         "cache_read_input_token_cost": 2.2e-08,
@@ -6906,7 +6920,9 @@
         "supports_web_search": true,
         "supports_none_reasoning_effort": true,
         "supports_xhigh_reasoning_effort": true,
-        "supports_minimal_reasoning_effort": false
+        "supports_minimal_reasoning_effort": false,
+        "supports_max_reasoning_effort": true,
+        "supports_ultra_reasoning_effort": true
     },
     "azure/eu/gpt-5.6": {
         "cache_read_input_token_cost": 5.5e-07,
@@ -6953,7 +6969,9 @@
         "supports_web_search": true,
         "supports_none_reasoning_effort": true,
         "supports_xhigh_reasoning_effort": true,
-        "supports_minimal_reasoning_effort": false
+        "supports_minimal_reasoning_effort": false,
+        "supports_max_reasoning_effort": true,
+        "supports_ultra_reasoning_effort": true
     },
     "azure/eu/gpt-5.6-sol": {
         "cache_read_input_token_cost": 5.5e-07,
@@ -7001,7 +7019,9 @@
         "supports_web_search": true,
         "supports_none_reasoning_effort": true,
         "supports_xhigh_reasoning_effort": true,
-        "supports_minimal_reasoning_effort": false
+        "supports_minimal_reasoning_effort": false,
+        "supports_max_reasoning_effort": true,
+        "supports_ultra_reasoning_effort": true
     },
     "azure/eu/gpt-5.6-terra": {
         "cache_read_input_token_cost": 2.2e-07,
@@ -7049,7 +7069,9 @@
         "supports_web_search": true,
         "supports_none_reasoning_effort": true,
         "supports_xhigh_reasoning_effort": true,
-        "supports_minimal_reasoning_effort": false
+        "supports_minimal_reasoning_effort": false,
+        "supports_max_reasoning_effort": true,
+        "supports_ultra_reasoning_effort": true
     },
     "azure/eu/gpt-5.6-luna": {
         "cache_read_input_token_cost": 2.2e-08,
@@ -7097,7 +7119,9 @@
         "supports_web_search": true,
         "supports_none_reasoning_effort": true,
         "supports_xhigh_reasoning_effort": true,
-        "supports_minimal_reasoning_effort": false
+        "supports_minimal_reasoning_effort": false,
+        "supports_max_reasoning_effort": true,
+        "supports_ultra_reasoning_effort": true
     },
     "azure/gpt-5.5": {
         "deprecation_date": "2027-10-26",
@@ -26101,7 +26125,9 @@
         "supports_tool_choice": true,
         "supports_vision": true,
         "supports_web_search": true,
-        "supports_xhigh_reasoning_effort": true
+        "supports_xhigh_reasoning_effort": true,
+        "supports_max_reasoning_effort": true,
+        "supports_ultra_reasoning_effort": true
     },
     "gpt-5.6-sol": {
         "cache_creation_input_token_cost": 6.25e-06,
@@ -26165,7 +26191,9 @@
         "supports_tool_choice": true,
         "supports_vision": true,
         "supports_web_search": true,
-        "supports_xhigh_reasoning_effort": true
+        "supports_xhigh_reasoning_effort": true,
+        "supports_max_reasoning_effort": true,
+        "supports_ultra_reasoning_effort": true
     },
     "gpt-5.6-terra": {
         "cache_creation_input_token_cost": 2.5e-06,
@@ -26228,7 +26256,9 @@
         "supports_tool_choice": true,
         "supports_vision": true,
         "supports_web_search": true,
-        "supports_xhigh_reasoning_effort": true
+        "supports_xhigh_reasoning_effort": true,
+        "supports_max_reasoning_effort": true,
+        "supports_ultra_reasoning_effort": true
     },
     "gpt-5.6-luna": {
         "cache_creation_input_token_cost": 2.5e-07,
@@ -26291,7 +26321,9 @@
         "supports_tool_choice": true,
         "supports_vision": true,
         "supports_web_search": true,
-        "supports_xhigh_reasoning_effort": true
+        "supports_xhigh_reasoning_effort": true,
+        "supports_max_reasoning_effort": true,
+        "supports_ultra_reasoning_effort": true
     },
     "gpt-5.6-cyber": {
         "cache_creation_input_token_cost": 1.5625e-05,
@@ -26330,7 +26362,9 @@
         "supports_web_search": true,
         "source": "https://platform.openai.com/docs/models/gpt-5.6-cyber",
         "supports_computer_use": true,
-        "supports_parallel_function_calling": true
+        "supports_parallel_function_calling": true,
+        "supports_max_reasoning_effort": true,
+        "supports_ultra_reasoning_effort": true
     },
     "daybreak-red-latest": {
         "cache_creation_input_token_cost": 1.5625e-05,
@@ -48488,7 +48522,9 @@
         "supports_reasoning": true,
         "supports_response_schema": true,
         "supports_tool_choice": true,
-        "supports_vision": true
+        "supports_vision": true,
+        "supports_max_reasoning_effort": true,
+        "supports_ultra_reasoning_effort": true
     },
     "bedrock_mantle/openai.gpt-5.6-terra": {
         "input_cost_per_token": 2.2e-06,
@@ -48520,7 +48556,9 @@
         "supports_reasoning": true,
         "supports_response_schema": true,
         "supports_tool_choice": true,
-        "supports_vision": true
+        "supports_vision": true,
+        "supports_max_reasoning_effort": true,
+        "supports_ultra_reasoning_effort": true
     },
     "bedrock_mantle/openai.gpt-5.6-luna": {
         "input_cost_per_token": 2.2e-07,
@@ -48552,7 +48590,9 @@
         "supports_reasoning": true,
         "supports_response_schema": true,
         "supports_tool_choice": true,
-        "supports_vision": true
+        "supports_vision": true,
+        "supports_max_reasoning_effort": true,
+        "supports_ultra_reasoning_effort": true
     },
     "bedrock_mantle/openai.gpt-5.5": {
         "input_cost_per_token": 5.5e-06,

--- a/model_prices_and_context_window.schema.json
+++ b/model_prices_and_context_window.schema.json
@@ -691,6 +691,9 @@
         "supports_tool_search": {
           "type": "boolean"
         },
+        "supports_ultra_reasoning_effort": {
+          "type": "boolean"
+        },
         "supports_url_context": {
           "type": "boolean"
         },

--- a/tests/test_litellm/llms/openai/test_gpt5_transformation.py
+++ b/tests/test_litellm/llms/openai/test_gpt5_transformation.py
@@ -1309,3 +1309,23 @@ def test_responses_gpt54_allow_temperature_effort_none(
         drop_params=False,
     )
     assert params["temperature"] == 0.7
+
+
+def test_gpt5_6_allows_reasoning_effort_ultra(config: OpenAIConfig):
+    params = config.map_openai_params(
+        non_default_params={"reasoning_effort": "ultra"},
+        optional_params={},
+        model="gpt-5.6",
+        drop_params=False,
+    )
+    assert params["reasoning_effort"] == "ultra"
+
+
+def test_gpt5_rejects_reasoning_effort_ultra_for_other_models(config: OpenAIConfig):
+    with pytest.raises(litellm.utils.UnsupportedParamsError):
+        config.map_openai_params(
+            non_default_params={"reasoning_effort": "ultra"},
+            optional_params={},
+            model="gpt-5.1",
+            drop_params=False,
+        )

--- a/tests/test_litellm/proxy/response_api_endpoints/test_endpoints.py
+++ b/tests/test_litellm/proxy/response_api_endpoints/test_endpoints.py
@@ -1352,7 +1352,9 @@ class TestParseCursorModelVariant:
             ("gemini-3.0-pro-thinking-low", "gemini-3.0-pro", "low"),
             ("claude-opus-5-fast", "claude-opus-5", None),
             ("gpt-5.6-sol", "gpt-5.6-sol", None),
-            ("foo-thinking-ultra-fast", "foo-thinking-ultra", None),
+            ("gpt-5.6-thinking-ultra-fast", "gpt-5.6", "ultra"),
+            ("gpt-5.6-thinking-max", "gpt-5.6", "max"),
+            ("foo-thinking-mega-fast", "foo-thinking-mega", None),
             ("-thinking-high", "-thinking-high", None),
         ],
     )

--- a/tests/test_litellm/router_utils/test_reasoning_effort_capability.py
+++ b/tests/test_litellm/router_utils/test_reasoning_effort_capability.py
@@ -1,0 +1,71 @@
+from litellm.router_utils.reasoning_effort_capability import (
+    intersect_supported_reasoning_efforts,
+    resolve_supported_reasoning_efforts,
+)
+
+
+class TestResolveSupportedReasoningEfforts:
+    def test_no_metadata_resolves_to_unknown(self):
+        assert resolve_supported_reasoning_efforts({}) is None
+
+    def test_non_reasoning_model_supports_no_efforts(self):
+        assert resolve_supported_reasoning_efforts({"supports_reasoning": None}) == ()
+        assert resolve_supported_reasoning_efforts({"supports_reasoning": False}) == ()
+
+    def test_reasoning_model_with_no_flags_gets_the_opt_out_levels_only(self):
+        # The kimi shape: supports_reasoning true, zero effort flags. medium/high are unconditional,
+        # none/minimal/low are opt-out so absence means supported, xhigh/max are opt-in so absence
+        # means unsupported.
+        assert resolve_supported_reasoning_efforts({"supports_reasoning": True}) == (
+            "none",
+            "minimal",
+            "low",
+            "medium",
+            "high",
+        )
+
+    def test_explicit_false_removes_an_opt_out_level(self):
+        # The gpt-5.5-pro shape from the model map: only medium/high/xhigh are accepted upstream.
+        resolved = resolve_supported_reasoning_efforts(
+            {
+                "supports_reasoning": True,
+                "supports_none_reasoning_effort": False,
+                "supports_minimal_reasoning_effort": False,
+                "supports_low_reasoning_effort": False,
+                "supports_xhigh_reasoning_effort": True,
+            }
+        )
+        assert resolved == ("medium", "high", "xhigh")
+
+    def test_explicit_true_adds_the_opt_in_levels(self):
+        # The claude-opus shape: xhigh and max explicitly true, everything else absent.
+        resolved = resolve_supported_reasoning_efforts(
+            {
+                "supports_reasoning": True,
+                "supports_xhigh_reasoning_effort": True,
+                "supports_max_reasoning_effort": True,
+            }
+        )
+        assert resolved == ("none", "minimal", "low", "medium", "high", "xhigh", "max")
+
+    def test_opt_in_flag_set_false_stays_excluded(self):
+        resolved = resolve_supported_reasoning_efforts(
+            {"supports_reasoning": True, "supports_xhigh_reasoning_effort": False}
+        )
+        assert resolved is not None
+        assert "xhigh" not in resolved
+
+
+class TestIntersectSupportedReasoningEfforts:
+    def test_unknown_never_narrows(self):
+        assert intersect_supported_reasoning_efforts(["medium", "high"], None) == ("medium", "high")
+        assert intersect_supported_reasoning_efforts(None, ["medium", "high"]) == ("medium", "high")
+        assert intersect_supported_reasoning_efforts(None, None) is None
+
+    def test_intersection_keeps_canonical_order(self):
+        assert intersect_supported_reasoning_efforts(
+            ["max", "high", "medium", "xhigh"], ["xhigh", "medium", "minimal"]
+        ) == ("medium", "xhigh")
+
+    def test_disjoint_sets_intersect_to_empty(self):
+        assert intersect_supported_reasoning_efforts(["max"], ["minimal"]) == ()

--- a/tests/test_litellm/router_utils/test_reasoning_effort_capability.py
+++ b/tests/test_litellm/router_utils/test_reasoning_effort_capability.py
@@ -48,6 +48,14 @@ class TestResolveSupportedReasoningEfforts:
         )
         assert resolved == ("none", "minimal", "low", "medium", "high", "xhigh", "max")
 
+    def test_ultra_is_opt_in(self):
+        without_flag = resolve_supported_reasoning_efforts({"supports_reasoning": True})
+        with_flag = resolve_supported_reasoning_efforts(
+            {"supports_reasoning": True, "supports_ultra_reasoning_effort": True}
+        )
+        assert without_flag is not None and "ultra" not in without_flag
+        assert with_flag is not None and with_flag[-1] == "ultra"
+
     def test_opt_in_flag_set_false_stays_excluded(self):
         resolved = resolve_supported_reasoning_efforts(
             {"supports_reasoning": True, "supports_xhigh_reasoning_effort": False}

--- a/tests/test_litellm/test_router.py
+++ b/tests/test_litellm/test_router.py
@@ -8721,3 +8721,87 @@ class TestAzureBaseModelFallbackLogging:
             deployment=None, received_model_name="my-group", id="azure-base-model-test-id"
         )
         assert model_info["max_input_tokens"] == litellm.model_cost["azure/gpt-4o-mini"]["max_input_tokens"]
+
+def test_model_group_info_intersects_supported_reasoning_efforts():
+    router = litellm.Router(
+        model_list=[
+            {
+                "model_name": "smart-group",
+                "litellm_params": {"model": "anthropic/opus-like"},
+                "model_info": {"id": "opus-like-deployment"},
+            },
+            {
+                "model_name": "smart-group",
+                "litellm_params": {"model": "openai/mini-like"},
+                "model_info": {"id": "mini-like-deployment"},
+            },
+        ]
+    )
+
+    def _model_info(model_id: str, model_name: str):
+        if model_id == "opus-like-deployment":
+            return {
+                "key": model_name,
+                "litellm_provider": "anthropic",
+                "mode": "chat",
+                "supports_reasoning": True,
+                "supports_xhigh_reasoning_effort": True,
+                "supports_max_reasoning_effort": True,
+            }
+        return {
+            "key": model_name,
+            "litellm_provider": "openai",
+            "mode": "chat",
+            "supports_reasoning": True,
+            "supports_none_reasoning_effort": False,
+            "supports_minimal_reasoning_effort": True,
+            "supports_xhigh_reasoning_effort": False,
+        }
+
+    with patch.object(router, "get_deployment_model_info", side_effect=_model_info):
+        result = router._set_model_group_info(
+            model_group="smart-group",
+            user_facing_model_group_name="smart-group",
+        )
+
+    assert result is not None
+    # opus-like offers all seven levels, mini-like lacks none/xhigh/max; only the common set survives,
+    # so the group never advertises an effort routing could hand to a deployment that rejects it.
+    assert result.supported_reasoning_efforts == ("minimal", "low", "medium", "high")
+
+
+def test_model_group_info_reasoning_efforts_ignore_deployments_without_metadata():
+    router = litellm.Router(
+        model_list=[
+            {
+                "model_name": "smart-group",
+                "litellm_params": {"model": "anthropic/opus-like"},
+                "model_info": {"id": "opus-like-deployment"},
+            },
+            {
+                "model_name": "smart-group",
+                "litellm_params": {"model": "openai/unmapped-model"},
+                "model_info": {"id": "unmapped-deployment"},
+            },
+        ]
+    )
+
+    def _model_info(model_id: str, model_name: str):
+        if model_id == "opus-like-deployment":
+            return {
+                "key": model_name,
+                "litellm_provider": "anthropic",
+                "mode": "chat",
+                "supports_reasoning": True,
+                "supports_max_reasoning_effort": True,
+            }
+        return {"key": model_name, "litellm_provider": "openai", "mode": "chat"}
+
+    with patch.object(router, "get_deployment_model_info", side_effect=_model_info):
+        result = router._set_model_group_info(
+            model_group="smart-group",
+            user_facing_model_group_name="smart-group",
+        )
+
+    assert result is not None
+    assert result.supported_reasoning_efforts == ("none", "minimal", "low", "medium", "high", "max")

--- a/tests/test_litellm/test_utils.py
+++ b/tests/test_litellm/test_utils.py
@@ -996,6 +996,7 @@ def test_aaamodel_prices_and_context_window_json_is_valid():
                 "supports_none_reasoning_effort": {"type": "boolean"},
                 "supports_xhigh_reasoning_effort": {"type": "boolean"},
                 "supports_max_reasoning_effort": {"type": "boolean"},
+                "supports_ultra_reasoning_effort": {"type": "boolean"},
                 "supports_adaptive_thinking": {"type": "boolean"},
                 "thinking_always_on": {"type": "boolean"},
                 "supports_mid_conversation_system": {"type": "boolean"},

--- a/ui/litellm-dashboard/src/components/add_model/ComplexityRouterConfig.test.tsx
+++ b/ui/litellm-dashboard/src/components/add_model/ComplexityRouterConfig.test.tsx
@@ -8,7 +8,12 @@ vi.mock(
 );
 
 const mockModelInfo = [
-  { model_group: "gpt-4", mode: "chat", supports_reasoning: true },
+  {
+    model_group: "gpt-4",
+    mode: "chat",
+    supports_reasoning: true,
+    supported_reasoning_efforts: ["medium", "high", "xhigh"],
+  },
   { model_group: "gpt-3.5-turbo", mode: "chat" },
   { model_group: "claude-3-opus", mode: "chat", supports_reasoning: true },
   { model_group: "text-embedding-3-small", mode: "embedding" },
@@ -941,5 +946,39 @@ describe("ComplexityRouterConfig reasoning effort gating", () => {
     expect(
       screen.getByRole("combobox", { name: "Reasoning effort for gpt-3.5-turbo in the Simple tier" }),
     ).toHaveTextContent("low");
+  });
+});
+
+describe("ComplexityRouterConfig per-model effort filtering", () => {
+  it("offers only the efforts the model group supports", async () => {
+    renderWithProviders(<ComplexityRouterConfig {...baseProps} />);
+    const user = userEvent.setup();
+    await user.click(screen.getByRole("combobox", { name: "Reasoning effort for gpt-4 in the Complex tier" }));
+    const options = (await screen.findAllByRole("option")).map((option) => option.textContent);
+    expect(options).toEqual(["Default", "medium", "high", "xhigh"]);
+  });
+
+  it("falls back to every effort when the group only reports supports_reasoning", async () => {
+    renderWithProviders(<ComplexityRouterConfig {...baseProps} />);
+    const user = userEvent.setup();
+    await user.click(
+      screen.getByRole("combobox", { name: "Reasoning effort for claude-3-opus in the Reasoning tier" }),
+    );
+    const options = (await screen.findAllByRole("option")).map((option) => option.textContent);
+    expect(options).toEqual(["Default", "none", "minimal", "low", "medium", "high", "xhigh"]);
+  });
+
+  // Hand-authored configs can carry a level outside the supported set (e.g. max); it must render
+  // and stay clearable rather than being masked as Default.
+  it("keeps showing a stored effort outside the supported set", () => {
+    renderWithProviders(
+      <ComplexityRouterConfig
+        {...baseProps}
+        value={{ ...defaultValue, tier_model_params: { COMPLEX: { "gpt-4": { reasoning_effort: "max" } } } }}
+      />,
+    );
+    expect(screen.getByRole("combobox", { name: "Reasoning effort for gpt-4 in the Complex tier" })).toHaveTextContent(
+      "max",
+    );
   });
 });

--- a/ui/litellm-dashboard/src/components/add_model/ComplexityRouterConfig.tsx
+++ b/ui/litellm-dashboard/src/components/add_model/ComplexityRouterConfig.tsx
@@ -14,6 +14,7 @@ import AdaptiveRoutingConfig from "./AdaptiveRoutingConfig";
 import ClassificationMethodConfig from "./ClassificationMethodConfig";
 import {
   REASONING_EFFORT_OPTIONS,
+  ReasoningEffort,
   TierModelParamsByTier,
   pruneTierModelParams,
   resolveComplexityDefaultModel,
@@ -275,7 +276,11 @@ const ComplexityRouterConfig: React.FC<ComplexityRouterConfigProps> = ({
     });
   };
 
-  const handleTierModelEffortChange = (tier: keyof ComplexityTiers, model: string, effort: string | undefined) => {
+  const handleTierModelEffortChange = (
+    tier: keyof ComplexityTiers,
+    model: string,
+    effort: ReasoningEffort | undefined,
+  ) => {
     onChange({
       ...value,
       tier_model_params: setTierModelReasoningEffort(value.tier_model_params, tier, model, effort),

--- a/ui/litellm-dashboard/src/components/add_model/ComplexityRouterConfig.tsx
+++ b/ui/litellm-dashboard/src/components/add_model/ComplexityRouterConfig.tsx
@@ -13,7 +13,7 @@ import { ModelGroup } from "@/components/llm_calls/fetch_models";
 import AdaptiveRoutingConfig from "./AdaptiveRoutingConfig";
 import ClassificationMethodConfig from "./ClassificationMethodConfig";
 import {
-  ReasoningEffort,
+  REASONING_EFFORT_OPTIONS,
   TierModelParamsByTier,
   pruneTierModelParams,
   resolveComplexityDefaultModel,
@@ -251,8 +251,13 @@ const ComplexityRouterConfig: React.FC<ComplexityRouterConfigProps> = ({
   const defaultModel = resolveComplexityDefaultModel(value.tiers, value.default_model);
 
   // Embedding models can't serve a chat-completion role, so they're excluded here.
-  const reasoningModels = new Set(
-    modelInfo.filter((model) => model.supports_reasoning).map((model) => model.model_group),
+  // The backend list is the per-group intersection of accepted effort levels; when a proxy does not
+  // send it yet, fall back to the coarse supports_reasoning gate with every level offered.
+  const effortOptionsByModel: Record<string, string[]> = Object.fromEntries(
+    modelInfo.map((model) => [
+      model.model_group,
+      model.supported_reasoning_efforts ?? (model.supports_reasoning ? [...REASONING_EFFORT_OPTIONS] : []),
+    ]),
   );
 
   const modelOptions = modelInfo
@@ -270,11 +275,7 @@ const ComplexityRouterConfig: React.FC<ComplexityRouterConfigProps> = ({
     });
   };
 
-  const handleTierModelEffortChange = (
-    tier: keyof ComplexityTiers,
-    model: string,
-    effort: ReasoningEffort | undefined,
-  ) => {
+  const handleTierModelEffortChange = (tier: keyof ComplexityTiers, model: string, effort: string | undefined) => {
     onChange({
       ...value,
       tier_model_params: setTierModelReasoningEffort(value.tier_model_params, tier, model, effort),
@@ -365,7 +366,7 @@ const ComplexityRouterConfig: React.FC<ComplexityRouterConfigProps> = ({
                   <TierModelEffortRows
                     tierLabel={label}
                     models={value.tiers[tier]}
-                    reasoningModels={reasoningModels}
+                    effortOptionsByModel={effortOptionsByModel}
                     paramsByModel={value.tier_model_params?.[tier]}
                     onEffortChange={(model, effort) => handleTierModelEffortChange(tier, model, effort)}
                   />

--- a/ui/litellm-dashboard/src/components/add_model/TierModelEffortRows.tsx
+++ b/ui/litellm-dashboard/src/components/add_model/TierModelEffortRows.tsx
@@ -2,35 +2,41 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@
 import { SimpleTooltip } from "@/components/ui/tooltip";
 import { Info } from "lucide-react";
 import React from "react";
-import { REASONING_EFFORT_OPTIONS, ReasoningEffort, TierModelParams } from "./complexity_router_tiers";
+import { TierModelParams } from "./complexity_router_tiers";
 
 const PROVIDER_DEFAULT = "__provider_default__";
 
-const asEffort = (params: TierModelParams | undefined): ReasoningEffort | undefined => {
+const storedEffort = (params: TierModelParams | undefined): string | undefined => {
   const stored = params?.reasoning_effort;
-  if (typeof stored !== "string") return undefined;
-  return REASONING_EFFORT_OPTIONS.find((option) => option === stored);
+  return typeof stored === "string" && stored ? stored : undefined;
 };
 
 interface TierModelEffortRowsProps {
   tierLabel: string;
   models: string[];
-  reasoningModels: ReadonlySet<string>;
+  effortOptionsByModel: Record<string, string[]>;
   paramsByModel: Record<string, TierModelParams> | undefined;
-  onEffortChange: (model: string, effort: ReasoningEffort | undefined) => void;
+  onEffortChange: (model: string, effort: string | undefined) => void;
 }
 
 const TierModelEffortRows: React.FC<TierModelEffortRowsProps> = ({
   tierLabel,
   models,
-  reasoningModels,
+  effortOptionsByModel,
   paramsByModel,
   onEffortChange,
 }) => {
-  const shown = models.filter(
-    (model) => reasoningModels.has(model) || Object.keys(paramsByModel?.[model] ?? {}).length > 0,
-  );
-  if (shown.length === 0) return null;
+  const rows = models
+    .map((model) => {
+      const effort = storedEffort(paramsByModel?.[model]);
+      const supported = effortOptionsByModel[model] ?? [];
+      // A stored effort outside the supported set (hand-authored, or capabilities changed since it
+      // was saved) stays listed so it renders and can be cleared.
+      const options = effort !== undefined && !supported.includes(effort) ? [...supported, effort] : supported;
+      return { model, effort, options };
+    })
+    .filter(({ model, options }) => options.length > 0 || Object.keys(paramsByModel?.[model] ?? {}).length > 0);
+  if (rows.length === 0) return null;
   return (
     <div className="mt-2 space-y-1">
       <div className="flex items-center gap-1">
@@ -41,18 +47,17 @@ const TierModelEffortRows: React.FC<TierModelEffortRowsProps> = ({
           <Info className="size-3 text-muted-foreground/70" />
         </SimpleTooltip>
       </div>
-      {shown.map((model) => (
+      {rows.map(({ model, effort, options }) => (
         <div key={model} className="flex items-center justify-between gap-2">
           <span className="truncate text-xs">{model}</span>
           <Select
             items={[
               { value: PROVIDER_DEFAULT, label: "Default" },
-              ...REASONING_EFFORT_OPTIONS.map((option) => ({ value: option, label: option })),
+              ...options.map((option) => ({ value: option, label: option })),
             ]}
-            value={asEffort(paramsByModel?.[model]) ?? PROVIDER_DEFAULT}
+            value={effort ?? PROVIDER_DEFAULT}
             onValueChange={(selected: string | null) =>
-              selected !== null &&
-              onEffortChange(model, selected === PROVIDER_DEFAULT ? undefined : (selected as ReasoningEffort))
+              selected !== null && onEffortChange(model, selected === PROVIDER_DEFAULT ? undefined : selected)
             }
           >
             <SelectTrigger
@@ -64,7 +69,7 @@ const TierModelEffortRows: React.FC<TierModelEffortRowsProps> = ({
             </SelectTrigger>
             <SelectContent>
               <SelectItem value={PROVIDER_DEFAULT}>Default</SelectItem>
-              {REASONING_EFFORT_OPTIONS.map((option) => (
+              {options.map((option) => (
                 <SelectItem key={option} value={option}>
                   {option}
                 </SelectItem>

--- a/ui/litellm-dashboard/src/components/add_model/TierModelEffortRows.tsx
+++ b/ui/litellm-dashboard/src/components/add_model/TierModelEffortRows.tsx
@@ -2,11 +2,11 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@
 import { SimpleTooltip } from "@/components/ui/tooltip";
 import { Info } from "lucide-react";
 import React from "react";
-import { TierModelParams } from "./complexity_router_tiers";
+import { ReasoningEffort, TierModelParams } from "./complexity_router_tiers";
 
 const PROVIDER_DEFAULT = "__provider_default__";
 
-const storedEffort = (params: TierModelParams | undefined): string | undefined => {
+const storedEffort = (params: TierModelParams | undefined): ReasoningEffort | undefined => {
   const stored = params?.reasoning_effort;
   return typeof stored === "string" && stored ? stored : undefined;
 };
@@ -16,7 +16,7 @@ interface TierModelEffortRowsProps {
   models: string[];
   effortOptionsByModel: Record<string, string[]>;
   paramsByModel: Record<string, TierModelParams> | undefined;
-  onEffortChange: (model: string, effort: string | undefined) => void;
+  onEffortChange: (model: string, effort: ReasoningEffort | undefined) => void;
 }
 
 const TierModelEffortRows: React.FC<TierModelEffortRowsProps> = ({

--- a/ui/litellm-dashboard/src/components/add_model/complexity_router_tiers.ts
+++ b/ui/litellm-dashboard/src/components/add_model/complexity_router_tiers.ts
@@ -90,7 +90,7 @@ export const setTierModelReasoningEffort = (
   current: TierModelParamsByTier | undefined,
   tier: string,
   model: string,
-  effort: ReasoningEffort | undefined,
+  effort: string | undefined,
 ): TierModelParamsByTier | undefined => {
   const { reasoning_effort: _dropped, ...rest } = current?.[tier]?.[model] ?? {};
   const params = effort === undefined ? rest : { ...rest, reasoning_effort: effort };

--- a/ui/litellm-dashboard/src/components/add_model/complexity_router_tiers.ts
+++ b/ui/litellm-dashboard/src/components/add_model/complexity_router_tiers.ts
@@ -12,6 +12,12 @@ export type TierModelParamsByTier = Record<string, Record<string, TierModelParam
  */
 export const REASONING_EFFORT_OPTIONS = ["none", "minimal", "low", "medium", "high", "xhigh"] as const;
 
+/**
+ * Open on purpose: the valid set is per model group at runtime (supported_reasoning_efforts), and
+ * hand-authored configs can carry any level, so the known literals only add autocompletion.
+ */
+export type ReasoningEffort = (typeof REASONING_EFFORT_OPTIONS)[number] | (string & {});
+
 const asRecord = (raw: unknown): Record<string, unknown> | undefined =>
   typeof raw === "object" && raw !== null && !Array.isArray(raw) ? (raw as Record<string, unknown>) : undefined;
 
@@ -94,7 +100,7 @@ export const setTierModelReasoningEffort = (
   current: TierModelParamsByTier | undefined,
   tier: string,
   model: string,
-  effort: string | undefined,
+  effort: ReasoningEffort | undefined,
 ): TierModelParamsByTier | undefined => {
   const { reasoning_effort: _dropped, ...rest } = current?.[tier]?.[model] ?? {};
   const params = effort === undefined ? rest : { ...rest, reasoning_effort: effort };

--- a/ui/litellm-dashboard/src/components/add_model/complexity_router_tiers.ts
+++ b/ui/litellm-dashboard/src/components/add_model/complexity_router_tiers.ts
@@ -5,8 +5,12 @@ export type TierModelParams = Record<string, unknown>;
 
 export type TierModelParamsByTier = Record<string, Record<string, TierModelParams>>;
 
+/**
+ * Fallback offered only when a proxy does not report supported_reasoning_efforts per model group.
+ * max is deliberately absent: it is opt-in per model in the model map, so a capability-blind list
+ * must not offer it; a proxy that reports capabilities supplies max itself where supported.
+ */
 export const REASONING_EFFORT_OPTIONS = ["none", "minimal", "low", "medium", "high", "xhigh"] as const;
-export type ReasoningEffort = (typeof REASONING_EFFORT_OPTIONS)[number];
 
 const asRecord = (raw: unknown): Record<string, unknown> | undefined =>
   typeof raw === "object" && raw !== null && !Array.isArray(raw) ? (raw as Record<string, unknown>) : undefined;

--- a/ui/litellm-dashboard/src/components/llm_calls/fetch_models.test.tsx
+++ b/ui/litellm-dashboard/src/components/llm_calls/fetch_models.test.tsx
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { modelAvailableCall } from "@/components/networking";
+import { modelAvailableCall, modelHubCall } from "@/components/networking";
 import { fetchAvailableModelsForTeam } from "./fetch_models";
 
 vi.mock("@/components/networking", () => ({
@@ -29,5 +29,40 @@ describe("fetchAvailableModelsForTeam", () => {
     modelAvailableCallMock.mockResolvedValue({ data: [] });
 
     expect(await fetchAvailableModelsForTeam("token", "team-123")).toEqual([]);
+  });
+});
+
+describe("fetchAvailableModelsForTeam capability join", () => {
+  it("carries model-group capabilities onto team-allowed names that have a group entry", async () => {
+    modelAvailableCallMock.mockResolvedValue({ data: [{ id: "gpt-5-mini" }, { id: "team-only-byok" }] });
+    vi.mocked(modelHubCall).mockResolvedValue({
+      data: [
+        {
+          model_group: "gpt-5-mini",
+          mode: "chat",
+          supports_reasoning: true,
+          supported_reasoning_efforts: ["minimal", "low", "medium", "high"],
+        },
+      ],
+    });
+
+    const models = await fetchAvailableModelsForTeam("token", "team-123");
+
+    expect(models).toEqual([
+      {
+        model_group: "gpt-5-mini",
+        mode: "chat",
+        supports_reasoning: true,
+        supported_reasoning_efforts: ["minimal", "low", "medium", "high"],
+      },
+      { model_group: "team-only-byok" },
+    ]);
+  });
+
+  it("keeps the team list usable when the group-info fetch fails", async () => {
+    modelAvailableCallMock.mockResolvedValue({ data: [{ id: "gpt-5-mini" }] });
+    vi.mocked(modelHubCall).mockRejectedValue(new Error("boom"));
+
+    expect(await fetchAvailableModelsForTeam("token", "team-123")).toEqual([{ model_group: "gpt-5-mini" }]);
   });
 });

--- a/ui/litellm-dashboard/src/components/llm_calls/fetch_models.tsx
+++ b/ui/litellm-dashboard/src/components/llm_calls/fetch_models.tsx
@@ -19,13 +19,21 @@ interface AvailableModel {
   supported_reasoning_efforts?: string[] | null;
 }
 
+/**
+ * /models carries no capability metadata, so the team-allowed names are joined against
+ * /model_group/info; a name without a group entry keeps every capability field absent (unknown).
+ */
 export const fetchAvailableModelsForTeam = async (accessToken: string, teamId: string): Promise<ModelGroup[]> => {
-  const response = await modelAvailableCall(accessToken, "", "", false, teamId);
+  const [response, groups] = await Promise.all([
+    modelAvailableCall(accessToken, "", "", false, teamId),
+    fetchAvailableModels(accessToken).catch(() => [] as ModelGroup[]),
+  ]);
+  const byGroup = new Map(groups.map((group) => [group.model_group, group]));
   const modelNames: string[] = (response?.data ?? []).map((model: { id: string }) => model.id);
 
   return excludeProxyWideSentinel(Array.from(new Set(modelNames)))
     .sort((a, b) => a.localeCompare(b))
-    .map((model) => ({ model_group: model }));
+    .map((model) => byGroup.get(model) ?? { model_group: model });
 };
 
 /**

--- a/ui/litellm-dashboard/src/components/llm_calls/fetch_models.tsx
+++ b/ui/litellm-dashboard/src/components/llm_calls/fetch_models.tsx
@@ -7,6 +7,7 @@ export interface ModelGroup {
   model_group: string;
   mode?: string;
   supports_reasoning?: boolean;
+  supported_reasoning_efforts?: string[];
 }
 
 interface AvailableModel {
@@ -15,6 +16,7 @@ interface AvailableModel {
   id?: string | null;
   mode?: string | null;
   supports_reasoning?: boolean | null;
+  supported_reasoning_efforts?: string[] | null;
 }
 
 export const fetchAvailableModelsForTeam = async (accessToken: string, teamId: string): Promise<ModelGroup[]> => {
@@ -39,6 +41,7 @@ export const fetchAvailableModels = async (accessToken: string): Promise<ModelGr
           model_group: item.model_group || item.id || item.model_name || "",
           mode: item.mode || undefined,
           supports_reasoning: item.supports_reasoning === true || undefined,
+          supported_reasoning_efforts: item.supported_reasoning_efforts ?? undefined,
         }))
         .filter((model: ModelGroup) => model.model_group !== "");
 

--- a/ui/litellm-dashboard/src/components/llm_calls/fetch_models.tsx
+++ b/ui/litellm-dashboard/src/components/llm_calls/fetch_models.tsx
@@ -19,11 +19,18 @@ interface AvailableModel {
   supported_reasoning_efforts?: string[] | null;
 }
 
+const toModelGroup = (item: AvailableModel): ModelGroup => ({
+  model_group: item.model_group || item.id || item.model_name || "",
+  ...(item.mode && { mode: item.mode }),
+  ...(item.supports_reasoning === true && { supports_reasoning: true }),
+  ...(item.supported_reasoning_efforts && { supported_reasoning_efforts: item.supported_reasoning_efforts }),
+});
+
 /**
  * /models carries no capability metadata, so the team-allowed names are joined against
- * /model_group/info; a name without a group entry keeps every capability field absent (unknown).
- * The group-info endpoint serves team-scoped tokens (row-filtered, verified live), and a failed
- * fetch is console.error'd by fetchAvailableModels before the empty fallback here.
+ * /model_group/info (one extra parallel request; the endpoint has no team filter of its own, and it
+ * serves team-scoped tokens row-filtered, verified live). A name without a group entry keeps every
+ * capability field absent; a failed group fetch is console.error'd by fetchAvailableModels.
  */
 export const fetchAvailableModelsForTeam = async (accessToken: string, teamId: string): Promise<ModelGroup[]> => {
   const [response, groups] = await Promise.all([
@@ -44,21 +51,11 @@ export const fetchAvailableModelsForTeam = async (accessToken: string, teamId: s
 export const fetchAvailableModels = async (accessToken: string): Promise<ModelGroup[]> => {
   try {
     const fetchedModels = await modelHubCall(accessToken);
-
-    if (fetchedModels?.data.length > 0) {
-      const models: ModelGroup[] = fetchedModels.data
-        .map((item: AvailableModel) => ({
-          model_group: item.model_group || item.id || item.model_name || "",
-          mode: item.mode || undefined,
-          supports_reasoning: item.supports_reasoning === true || undefined,
-          supported_reasoning_efforts: item.supported_reasoning_efforts ?? undefined,
-        }))
-        .filter((model: ModelGroup) => model.model_group !== "");
-
-      models.sort((a, b) => a.model_group.localeCompare(b.model_group));
-      return Array.from(new Map(models.map((model) => [model.model_group, model])).values());
-    }
-    return [];
+    const models: ModelGroup[] = (fetchedModels?.data ?? [])
+      .map(toModelGroup)
+      .filter((model: ModelGroup) => model.model_group !== "")
+      .sort((a: ModelGroup, b: ModelGroup) => a.model_group.localeCompare(b.model_group));
+    return Array.from(new Map(models.map((model) => [model.model_group, model])).values());
   } catch (error) {
     console.error("Error fetching model info:", error);
     throw error;

--- a/ui/litellm-dashboard/src/components/llm_calls/fetch_models.tsx
+++ b/ui/litellm-dashboard/src/components/llm_calls/fetch_models.tsx
@@ -19,12 +19,15 @@ interface AvailableModel {
   supported_reasoning_efforts?: string[] | null;
 }
 
-const toModelGroup = (item: AvailableModel): ModelGroup => ({
-  model_group: item.model_group || item.id || item.model_name || "",
-  ...(item.mode && { mode: item.mode }),
-  ...(item.supports_reasoning === true && { supports_reasoning: true }),
-  ...(item.supported_reasoning_efforts && { supported_reasoning_efforts: item.supported_reasoning_efforts }),
-});
+const toModelGroup = (item: AvailableModel): ModelGroup => {
+  const groupName = (item.model_group || item.id || item.model_name) ?? "";
+  return {
+    model_group: groupName,
+    ...(item.mode && { mode: item.mode }),
+    ...(item.supports_reasoning === true && { supports_reasoning: true }),
+    ...(item.supported_reasoning_efforts && { supported_reasoning_efforts: item.supported_reasoning_efforts }),
+  };
+};
 
 /**
  * /models carries no capability metadata, so the team-allowed names are joined against

--- a/ui/litellm-dashboard/src/components/llm_calls/fetch_models.tsx
+++ b/ui/litellm-dashboard/src/components/llm_calls/fetch_models.tsx
@@ -22,6 +22,8 @@ interface AvailableModel {
 /**
  * /models carries no capability metadata, so the team-allowed names are joined against
  * /model_group/info; a name without a group entry keeps every capability field absent (unknown).
+ * The group-info endpoint serves team-scoped tokens (row-filtered, verified live), and a failed
+ * fetch is console.error'd by fetchAvailableModels before the empty fallback here.
  */
 export const fetchAvailableModelsForTeam = async (accessToken: string, teamId: string): Promise<ModelGroup[]> => {
   const [response, groups] = await Promise.all([

--- a/ui/litellm-dashboard/src/lib/http/schema.d.ts
+++ b/ui/litellm-dashboard/src/lib/http/schema.d.ts
@@ -29522,6 +29522,8 @@ export interface components {
              * @default []
              */
             supported_openai_params: string[] | null;
+            /** Supported Reasoning Efforts */
+            supported_reasoning_efforts?: string[] | null;
             /**
              * Supports Function Calling
              * @default false


### PR DESCRIPTION
## TLDR

Problem this solves:

- Effort dropdown offers levels many models reject upstream
- GPT, Claude, and Kimi accept different reasoning_effort sets
- No per-group capability data reaches the dashboard

How it solves it:

- Model groups report supported_reasoning_efforts, intersected across deployments
- Per-level polarity resolved in one backend function
- Dropdown offers only what every deployment accepts

## User Flow

Follows #37673 (merged), which added the per-model reasoning effort dropdown this PR filters

Before: an operator configuring a tier picks an effort the model rejects at request time

1. They open http://localhost:4000/ui/?page=models-and-endpoints, Add Model, Auto Router, and select gpt-5-mini for the Medium tier
2. The Reasoning effort dropdown offers none through xhigh for every reasoning model alike
3. They pick xhigh for gpt-5-mini; the save succeeds because nothing validates levels
4. Requests classified Medium now fail: the provider rejects xhigh for that model, and the operator only finds out from error logs

After: the dropdown only offers what the whole model group accepts

1. Same page, same Add Model flow, same tier picker
2. gpt-5-mini's dropdown offers Default, minimal, low, medium, high; a claude-opus group offers everything up to xhigh and max; a model absent from the model map keeps the full list since nothing is known about it
3. xhigh cannot be picked for gpt-5-mini, so the failing configuration can no longer be created
4. A hand-authored config carrying an out-of-set level still renders it and lets them clear it

## Relevant issues

The intersection semantics are deliberate: a group mixing deployments offers only levels every deployment accepts, so routing can never hand an effort to a deployment that rejects it. Per-level polarity mirrors the provider gates: medium/high unconditional, none/minimal/low opt-out, xhigh/max opt-in

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

Live rig: proxy from this branch on localhost:4381, dedicated Postgres, model_list carrying anthropic/claude-opus-5 as opus-5 and openai/gpt-5-mini

### Before (merge base cb4eb82249, where #37673 merged)

GET /model_group/info carries no per-effort capability, and the dropdown offers the same six levels for every reasoning model

### After (PR tip 54b7b69ab0)

```
$ curl http://localhost:4381/model_group/info -H "Authorization: Bearer $MASTER_KEY" | jq '.data[] | {model_group, supported_reasoning_efforts}'
{"model_group": "opus-5", "supported_reasoning_efforts": ["none","minimal","low","medium","high","xhigh","max"]}
{"model_group": "gpt-5-mini", "supported_reasoning_efforts": ["minimal","low","medium","high"]}
{"model_group": "gpt-5.6", "supported_reasoning_efforts": ["none","low","medium","high","xhigh","max","ultra"]}
```

Matches the model map exactly: claude-opus-5 sets xhigh and max true, gpt-5-mini sets none and xhigh false. A kimi-style entry with supports_reasoning true and no effort flags resolves to none/minimal/low/medium/high, and a deployment missing from the map contributes nothing to the intersection instead of zeroing it

UI steps to screenshot on this branch: 1) /ui/?page=models-and-endpoints, Add Model, Auto Router, add gpt-5-mini to a tier and open its Reasoning effort dropdown: only Default, minimal, low, medium, high, 2) add opus-5 to a tier and open its dropdown: all seven levels including max, 3) save, reopen the edit modal, and confirm the same filtered options

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches router model-group metadata and GPT-5 param gating, so incorrect intersection polarity could hide valid efforts or still advertise ones a mixed group would reject. Dashboard filtering is UI-only and does not change request routing.
> 
> **Overview**
> **Model groups now report `supported_reasoning_efforts`**, the intersection of what every mapped deployment accepts, so the auto-router effort dropdown no longer offers levels a provider would reject.
> 
> A new resolver encodes per-level polarity in one place: `medium`/`high` always, `none`/`minimal`/`low` unless explicitly false, `xhigh`/`max`/`ultra` only when opted in. Deployments missing capability metadata do not shrink the group.
> 
> The dashboard joins team-allowed names with `/model_group/info` and filters the dropdown to that list (fallback: all known levels when only `supports_reasoning` is set). Stored out-of-set values still render so they can be cleared.
> 
> Also adds **`ultra`** (and `max` flags) for gpt-5.6-family models, gates `ultra` like `xhigh` in GPT-5 chat mapping, and treats `ultra`/`max` as Cursor `-thinking-` suffixes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9f14c228bfa4d3ebfe2bb06c548d2912807780d9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->











