### PR TITLE
fix(streaming): price partial-stream spend rows at the real model and keep prompt and cache fields

### DIFF
--- a/litellm/litellm_core_utils/streaming_handler.py
+++ b/litellm/litellm_core_utils/streaming_handler.py
@@ -2326,7 +2326,7 @@ class CustomStreamWrapper:
                 return
             if self.model:
                 partial_response.model = self.model
-            zero_fill_missing_cache_usage_fields(usage)
+            backfill_missing_cache_usage_fields(usage)
             self.logging_obj.model_call_details["combined_usage_object"] = usage
             self.logging_obj.model_call_details["response_cost"] = (
                 self.logging_obj._response_cost_calculator(result=partial_response) or 0.0
@@ -2447,13 +2447,33 @@ class CustomStreamWrapper:
         return chunk
 
 
-def zero_fill_missing_cache_usage_fields(usage: Usage) -> None:
-    if getattr(usage, "cache_creation_input_tokens", None) is None:
-        usage.cache_creation_input_tokens = 0  # rebind-ok: in-place zero-fill is the contract
+def _cache_token_count(details: PromptTokensDetailsWrapper | None, keys: tuple[str, ...]) -> int:
+    for key in keys:
+        value = getattr(details, key, None)
+        if isinstance(value, int) and not isinstance(value, bool) and value:
+            return value
+    return 0
+
+
+def backfill_missing_cache_usage_fields(usage: Usage) -> None:
+    """Give partial-stream usage the same cache fields a complete stream reports.
+
+    Carries OpenAI-style ``prompt_tokens_details`` counts up to the Anthropic-style
+    top-level keys, defaulting to zero. It must carry the real count rather than a
+    flat zero: downstream readers treat these keys as authoritative once present and
+    skip their own normalization, so a zero here would overwrite a real cache read.
+    """
+    details: Final = usage.prompt_tokens_details
     if getattr(usage, "cache_read_input_tokens", None) is None:
-        usage.cache_read_input_tokens = 0  # rebind-ok: in-place zero-fill is the contract
+        usage.cache_read_input_tokens = _cache_token_count(  # rebind-ok: in-place backfill is the contract
+            details, ("cached_tokens",)
+        )
+    if getattr(usage, "cache_creation_input_tokens", None) is None:
+        usage.cache_creation_input_tokens = _cache_token_count(  # rebind-ok: in-place backfill is the contract
+            details, ("cache_write_tokens", "cache_creation_tokens")
+        )
     if usage.prompt_tokens_details is None:
-        usage.prompt_tokens_details = PromptTokensDetailsWrapper(cached_tokens=0)  # rebind-ok: zero-fill in place
+        usage.prompt_tokens_details = PromptTokensDetailsWrapper(cached_tokens=0)  # rebind-ok: backfill in place
 
 
 _TokenDetails = TypeVar("_TokenDetails", PromptTokensDetailsWrapper, CompletionTokensDetailsWrapper)

--- a/litellm/litellm_core_utils/streaming_handler.py
+++ b/litellm/litellm_core_utils/streaming_handler.py
@@ -2315,10 +2315,18 @@ class CustomStreamWrapper:
         if self.logging_obj is None or not self.chunks:
             return
         try:
-            partial_response: Final = litellm.stream_chunk_builder(chunks=self.chunks)
+            partial_response: Final = litellm.stream_chunk_builder(
+                chunks=self.chunks,
+                messages=self.messages if isinstance(self.messages, list) else None,
+            )
+            if partial_response is None:
+                return
             usage: Final = cast(Usage | None, getattr(partial_response, "usage", None))
             if usage is None:
                 return
+            if self.model:
+                partial_response.model = self.model
+            zero_fill_missing_cache_usage_fields(usage)
             self.logging_obj.model_call_details["combined_usage_object"] = usage
             self.logging_obj.model_call_details["response_cost"] = (
                 self.logging_obj._response_cost_calculator(result=partial_response) or 0.0
@@ -2437,6 +2445,15 @@ class CustomStreamWrapper:
                 return chunk[_length_of_sse_data_prefix:]
 
         return chunk
+
+
+def zero_fill_missing_cache_usage_fields(usage: Usage) -> None:
+    if getattr(usage, "cache_creation_input_tokens", None) is None:
+        usage.cache_creation_input_tokens = 0  # rebind-ok: in-place zero-fill is the contract
+    if getattr(usage, "cache_read_input_tokens", None) is None:
+        usage.cache_read_input_tokens = 0  # rebind-ok: in-place zero-fill is the contract
+    if usage.prompt_tokens_details is None:
+        usage.prompt_tokens_details = PromptTokensDetailsWrapper(cached_tokens=0)  # rebind-ok: zero-fill in place
 
 
 _TokenDetails = TypeVar("_TokenDetails", PromptTokensDetailsWrapper, CompletionTokensDetailsWrapper)

--- a/litellm/proxy/common_request_processing.py
+++ b/litellm/proxy/common_request_processing.py
@@ -277,6 +277,26 @@ def _deferred_stream_logging_is_armed(request_data: dict) -> bool:
     )
 
 
+def _assembled_model_came_from_a_later_chunk(chunks: list, assembled_model: object) -> bool:
+    """Report whether stream_chunk_builder picked a model the first chunk did not carry.
+
+    Azure Model Router puts the routed model on the chunks after the first one, and the
+    proxy deliberately leaves those chunks unrestamped so the builder can recover it. The
+    assembled model is then more specific than the wrapper's, so the caller has to leave
+    it alone rather than stamping the wrapper's model over it.
+    """
+    first_chunk: Final = chunks[0]
+    first_chunk_model: Final = (
+        first_chunk.get("model") if isinstance(first_chunk, dict) else getattr(first_chunk, "model", None)
+    )
+    return (
+        isinstance(first_chunk_model, str)
+        and isinstance(assembled_model, str)
+        and bool(assembled_model)
+        and assembled_model != first_chunk_model
+    )
+
+
 async def _bill_partial_streamed_spend_on_disconnect(request_data: dict, response: object) -> bool:
     """
     A client disconnect throws GeneratorExit/CancelledError into the streaming
@@ -328,7 +348,11 @@ async def _bill_partial_streamed_spend_on_disconnect(request_data: dict, respons
     if partial_response is None:
         return False
     wrapper_model: Final = getattr(response, "model", None)
-    if isinstance(wrapper_model, str) and wrapper_model:
+    if (
+        isinstance(wrapper_model, str)
+        and wrapper_model
+        and not _assembled_model_came_from_a_later_chunk(chunks, partial_response.model)
+    ):
         partial_response.model = wrapper_model
     partial_usage: Final = getattr(partial_response, "usage", None)
     if isinstance(partial_usage, Usage):

--- a/litellm/proxy/common_request_processing.py
+++ b/litellm/proxy/common_request_processing.py
@@ -43,6 +43,9 @@ from litellm.litellm_core_utils.llm_response_utils.get_headers import (
     get_response_headers,
 )
 from litellm.litellm_core_utils.safe_json_dumps import safe_dumps
+from litellm.litellm_core_utils.streaming_handler import (
+    zero_fill_missing_cache_usage_fields,
+)
 from litellm.proxy._types import ProxyException, UserAPIKeyAuth
 from litellm.proxy.auth.auth_checks import can_key_call_resolved_model
 from litellm.proxy.auth.auth_utils import check_response_size_is_safe
@@ -324,6 +327,12 @@ async def _bill_partial_streamed_spend_on_disconnect(request_data: dict, respons
         return False
     if partial_response is None:
         return False
+    wrapper_model: Final = getattr(response, "model", None)
+    if isinstance(wrapper_model, str) and wrapper_model:
+        partial_response.model = wrapper_model
+    partial_usage: Final = getattr(partial_response, "usage", None)
+    if isinstance(partial_usage, Usage):
+        zero_fill_missing_cache_usage_fields(partial_usage)
     try:
         await logging_obj.dispatch_success_handlers(
             partial_response,

--- a/litellm/proxy/common_request_processing.py
+++ b/litellm/proxy/common_request_processing.py
@@ -44,7 +44,7 @@ from litellm.litellm_core_utils.llm_response_utils.get_headers import (
 )
 from litellm.litellm_core_utils.safe_json_dumps import safe_dumps
 from litellm.litellm_core_utils.streaming_handler import (
-    zero_fill_missing_cache_usage_fields,
+    backfill_missing_cache_usage_fields,
 )
 from litellm.proxy._types import ProxyException, UserAPIKeyAuth
 from litellm.proxy.auth.auth_checks import can_key_call_resolved_model
@@ -332,7 +332,7 @@ async def _bill_partial_streamed_spend_on_disconnect(request_data: dict, respons
         partial_response.model = wrapper_model
     partial_usage: Final = getattr(partial_response, "usage", None)
     if isinstance(partial_usage, Usage):
-        zero_fill_missing_cache_usage_fields(partial_usage)
+        backfill_missing_cache_usage_fields(partial_usage)
     try:
         await logging_obj.dispatch_success_handlers(
             partial_response,

--- a/litellm/proxy/common_request_processing.py
+++ b/litellm/proxy/common_request_processing.py
@@ -303,12 +303,15 @@ def _assembled_model_is_the_name_the_client_asked_for(request_data: dict, assemb
     """Report whether the assembled model is the public name the proxy stamps onto chunks.
 
     That stamp is what leaves an unpriced alias on the partial response, so the deployment's
-    own model has to go back on before the row is costed.
+    own model has to go back on before the row is costed. Pre-call processing rewrites
+    `request_data["model"]` for aliasing and routing, so the client's own name wins when it
+    is there, in the same order the proxy picks the name it stamps.
     """
-    return assembled_model in (
-        request_data.get("_litellm_client_requested_model"),
-        request_data.get("model"),
+    client_requested_model: Final = request_data.get("_litellm_client_requested_model")
+    stamped_model: Final = (
+        client_requested_model if isinstance(client_requested_model, str) else request_data.get("model")
     )
+    return isinstance(stamped_model, str) and assembled_model == stamped_model
 
 
 async def _bill_partial_streamed_spend_on_disconnect(request_data: dict, response: object) -> bool:

--- a/litellm/proxy/common_request_processing.py
+++ b/litellm/proxy/common_request_processing.py
@@ -281,9 +281,11 @@ def _assembled_model_came_from_a_later_chunk(chunks: list, assembled_model: obje
     """Report whether stream_chunk_builder picked a model the first chunk did not carry.
 
     Azure Model Router puts the routed model on the chunks after the first one, and the
-    proxy deliberately leaves those chunks unrestamped so the builder can recover it. The
-    assembled model is then more specific than the wrapper's, so the caller has to leave
-    it alone rather than stamping the wrapper's model over it.
+    proxy deliberately leaves those chunks unrestamped so the builder can recover it.
+
+    A stored chunk that carries usage is a pre-restamp copy of the one the proxy saw, so
+    an alias-restamped stream reaches the builder with the same shape: a first chunk that
+    disagrees with the rest. Those two are only told apart by what the client asked for.
     """
     first_chunk: Final = chunks[0]
     first_chunk_model: Final = (
@@ -294,6 +296,18 @@ def _assembled_model_came_from_a_later_chunk(chunks: list, assembled_model: obje
         and isinstance(assembled_model, str)
         and bool(assembled_model)
         and assembled_model != first_chunk_model
+    )
+
+
+def _assembled_model_is_the_name_the_client_asked_for(request_data: dict, assembled_model: object) -> bool:
+    """Report whether the assembled model is the public name the proxy stamps onto chunks.
+
+    That stamp is what leaves an unpriced alias on the partial response, so the deployment's
+    own model has to go back on before the row is costed.
+    """
+    return assembled_model in (
+        request_data.get("_litellm_client_requested_model"),
+        request_data.get("model"),
     )
 
 
@@ -348,11 +362,10 @@ async def _bill_partial_streamed_spend_on_disconnect(request_data: dict, respons
     if partial_response is None:
         return False
     wrapper_model: Final = getattr(response, "model", None)
-    if (
-        isinstance(wrapper_model, str)
-        and wrapper_model
-        and not _assembled_model_came_from_a_later_chunk(chunks, partial_response.model)
-    ):
+    builder_recovered_the_routed_model: Final = _assembled_model_came_from_a_later_chunk(
+        chunks, partial_response.model
+    ) and not _assembled_model_is_the_name_the_client_asked_for(request_data, partial_response.model)
+    if isinstance(wrapper_model, str) and wrapper_model and not builder_recovered_the_routed_model:
         partial_response.model = wrapper_model
     partial_usage: Final = getattr(partial_response, "usage", None)
     if isinstance(partial_usage, Usage):

--- a/tests/test_litellm/litellm_core_utils/test_streaming_handler.py
+++ b/tests/test_litellm/litellm_core_utils/test_streaming_handler.py
@@ -3459,7 +3459,7 @@ def test_record_partial_usage_for_failure_counts_prompt_tokens_from_request_mess
     assert stashed.prompt_tokens > 0
 
 
-def test_record_partial_usage_for_failure_zero_fills_missing_cache_fields():
+def test_record_partial_usage_for_failure_backfills_missing_cache_fields():
     wrapper, logging_obj = _wrapper_with_partial_chunks(chunk_model="gpt-4o-mini")
 
     wrapper._record_partial_usage_for_failure()
@@ -3469,6 +3469,24 @@ def test_record_partial_usage_for_failure_zero_fills_missing_cache_fields():
     assert stashed.cache_read_input_tokens == 0
     assert stashed.prompt_tokens_details is not None
     assert stashed.prompt_tokens_details.cached_tokens == 0
+
+
+def test_record_partial_usage_for_failure_carries_up_openai_style_cached_tokens():
+    recovered = Usage(
+        prompt_tokens=1000,
+        completion_tokens=10,
+        total_tokens=1010,
+        prompt_tokens_details=PromptTokensDetailsWrapper(cached_tokens=500),
+    )
+    wrapper, logging_obj = _wrapper_with_partial_chunks(
+        chunk_model="gpt-4o-mini", usage=recovered
+    )
+
+    wrapper._record_partial_usage_for_failure()
+
+    stashed = logging_obj.model_call_details["combined_usage_object"]
+    assert stashed.cache_read_input_tokens == 500
+    assert stashed.cache_creation_input_tokens == 0
 
 
 def test_record_partial_usage_for_failure_keeps_cache_values_recovered_from_chunks():

--- a/tests/test_litellm/litellm_core_utils/test_streaming_handler.py
+++ b/tests/test_litellm/litellm_core_utils/test_streaming_handler.py
@@ -3388,6 +3388,110 @@ def test_record_partial_usage_for_failure_noop_without_chunks():
     assert "combined_usage_object" not in logging_obj.model_call_details
 
 
+def _wrapper_with_partial_chunks(
+    chunk_model: str,
+    usage: Optional[Usage] = None,
+    model: str = "gpt-4o-mini",
+    custom_llm_provider: str = "openai",
+) -> tuple:
+    logging_obj = Logging(
+        model=model,
+        messages=[{"role": "user", "content": "Tell me a long story"}],
+        stream=True,
+        call_type="completion",
+        start_time=time.time(),
+        litellm_call_id="partial-usage-alias",
+        function_id="1245",
+    )
+    logging_obj.model_call_details["custom_llm_provider"] = custom_llm_provider
+    logging_obj.optional_params = {}
+    wrapper = CustomStreamWrapper(
+        completion_stream=None,
+        model=model,
+        logging_obj=logging_obj,
+        custom_llm_provider=custom_llm_provider,
+    )
+    wrapper.chunks = [
+        ModelResponseStream(
+            id="chatcmpl-partial-alias-1",
+            created=1742056047,
+            model=chunk_model,
+            object="chat.completion.chunk",
+            choices=[
+                StreamingChoices(
+                    finish_reason=None,
+                    index=0,
+                    delta=Delta(
+                        content="The Roman Empire began when", role="assistant"
+                    ),
+                )
+            ],
+            usage=usage,
+        )
+    ]
+    return wrapper, logging_obj
+
+
+def test_record_partial_usage_for_failure_prices_alias_restamped_chunks_at_real_model():
+    wrapper, logging_obj = _wrapper_with_partial_chunks(
+        chunk_model="bedrock-claude-opus-5",
+        usage=Usage(prompt_tokens=40, completion_tokens=5, total_tokens=45),
+        model="us.anthropic.claude-opus-5",
+        custom_llm_provider="bedrock",
+    )
+    assert "bedrock/bedrock-claude-opus-5" not in litellm.model_cost
+
+    wrapper._record_partial_usage_for_failure()
+
+    stashed = logging_obj.model_call_details["combined_usage_object"]
+    assert stashed.completion_tokens == 5
+    rates = litellm.model_cost["us.anthropic.claude-opus-5"]
+    expected = 40 * rates["input_cost_per_token"] + 5 * rates["output_cost_per_token"]
+    assert logging_obj.model_call_details["response_cost"] == pytest.approx(expected)
+
+
+def test_record_partial_usage_for_failure_counts_prompt_tokens_from_request_messages():
+    wrapper, logging_obj = _wrapper_with_partial_chunks(chunk_model="my-public-alias")
+
+    wrapper._record_partial_usage_for_failure()
+
+    stashed = logging_obj.model_call_details["combined_usage_object"]
+    assert stashed.prompt_tokens > 0
+
+
+def test_record_partial_usage_for_failure_zero_fills_missing_cache_fields():
+    wrapper, logging_obj = _wrapper_with_partial_chunks(chunk_model="gpt-4o-mini")
+
+    wrapper._record_partial_usage_for_failure()
+
+    stashed = logging_obj.model_call_details["combined_usage_object"]
+    assert stashed.cache_creation_input_tokens == 0
+    assert stashed.cache_read_input_tokens == 0
+    assert stashed.prompt_tokens_details is not None
+    assert stashed.prompt_tokens_details.cached_tokens == 0
+
+
+def test_record_partial_usage_for_failure_keeps_cache_values_recovered_from_chunks():
+    recovered = Usage(
+        prompt_tokens=40,
+        completion_tokens=5,
+        total_tokens=45,
+        cache_read_input_tokens=7,
+        cache_creation_input_tokens=3,
+    )
+    wrapper, logging_obj = _wrapper_with_partial_chunks(
+        chunk_model="gpt-4o-mini", usage=recovered
+    )
+
+    wrapper._record_partial_usage_for_failure()
+
+    stashed = logging_obj.model_call_details["combined_usage_object"]
+    assert stashed.cache_read_input_tokens == 7
+    assert stashed.cache_creation_input_tokens == 3
+    assert stashed.prompt_tokens_details is not None
+    assert stashed.prompt_tokens_details.cached_tokens == 7
+
+
 @pytest.mark.parametrize("sync_mode", [True, False])
 @pytest.mark.asyncio
 async def test_stream_chunk_builder_raise_at_end_of_stream_still_recovers_usage(

--- a/tests/test_litellm/proxy/test_common_request_processing.py
+++ b/tests/test_litellm/proxy/test_common_request_processing.py
@@ -5519,6 +5519,91 @@ class TestStreamingClientDisconnectBilling:
 
         proxy_logging_obj._arelease_max_parallel_requests_on_disconnect.assert_awaited_once()
 
+    async def _bill_and_collect_success_event(self, prepare=None):
+        recorder = _RecordingSuccessLogger()
+        original_callbacks = litellm.callbacks
+        litellm.callbacks = [recorder]
+        try:
+            response = await self._start_partial_stream()
+            if prepare is not None:
+                prepare(response)
+            billed = await _bill_partial_streamed_spend_on_disconnect(
+                {"litellm_logging_obj": response.logging_obj}, response
+            )
+            assert billed is True
+            for _ in range(50):
+                if recorder.success_events:
+                    break
+                await asyncio.sleep(0.1)
+        finally:
+            litellm.callbacks = original_callbacks
+        assert len(recorder.success_events) == 1
+        return recorder.success_events[0]
+
+    @pytest.mark.asyncio
+    async def test_disconnect_billing_prices_alias_restamped_chunks_at_real_model(self):
+        assert "openai/my-public-alias" not in litellm.model_cost
+
+        def restamp_chunks_to_alias(response):
+            for chunk in response.chunks:
+                chunk.model = "my-public-alias"
+
+        event = await self._bill_and_collect_success_event(restamp_chunks_to_alias)
+
+        assert event["response_obj"].model == "gpt-4o-mini"
+        standard_logging_object = event["kwargs"]["standard_logging_object"]
+        assert standard_logging_object["response_cost"] > 0.0
+
+    @pytest.mark.asyncio
+    async def test_disconnect_billing_zero_fills_missing_cache_fields(self):
+        event = await self._bill_and_collect_success_event()
+
+        usage = event["response_obj"].usage
+        assert getattr(usage, "cache_creation_input_tokens", None) == 0
+        assert getattr(usage, "cache_read_input_tokens", None) == 0
+        assert usage.prompt_tokens_details is not None
+        assert usage.prompt_tokens_details.cached_tokens == 0
+
+    @pytest.mark.asyncio
+    async def test_disconnect_billing_keeps_cache_values_recovered_from_chunks(self):
+        from litellm.types.utils import (
+            Delta,
+            ModelResponseStream,
+            StreamingChoices,
+            Usage,
+        )
+
+        def append_usage_chunk(response):
+            response.chunks.append(
+                ModelResponseStream(
+                    id=response.chunks[0].id,
+                    model="gpt-4o-mini",
+                    object="chat.completion.chunk",
+                    choices=[
+                        StreamingChoices(
+                            finish_reason=None,
+                            index=0,
+                            delta=Delta(content=" and more", role="assistant"),
+                        )
+                    ],
+                    usage=Usage(
+                        prompt_tokens=40,
+                        completion_tokens=5,
+                        total_tokens=45,
+                        cache_read_input_tokens=7,
+                        cache_creation_input_tokens=3,
+                    ),
+                )
+            )
+
+        event = await self._bill_and_collect_success_event(append_usage_chunk)
+
+        usage = event["response_obj"].usage
+        assert getattr(usage, "cache_read_input_tokens", None) == 7
+        assert getattr(usage, "cache_creation_input_tokens", None) == 3
+        assert usage.prompt_tokens_details is not None
+        assert usage.prompt_tokens_details.cached_tokens == 7
+
 
 def _apply_stream_usage_tracking(
     data: dict,

--- a/tests/test_litellm/proxy/test_common_request_processing.py
+++ b/tests/test_litellm/proxy/test_common_request_processing.py
@@ -5519,7 +5519,7 @@ class TestStreamingClientDisconnectBilling:
 
         proxy_logging_obj._arelease_max_parallel_requests_on_disconnect.assert_awaited_once()
 
-    async def _bill_and_collect_success_event(self, prepare=None):
+    async def _bill_and_collect_success_event(self, prepare=None, request_data=None):
         recorder = _RecordingSuccessLogger()
         original_callbacks = litellm.callbacks
         litellm.callbacks = [recorder]
@@ -5528,7 +5528,7 @@ class TestStreamingClientDisconnectBilling:
             if prepare is not None:
                 prepare(response)
             billed = await _bill_partial_streamed_spend_on_disconnect(
-                {"litellm_logging_obj": response.logging_obj}, response
+                {"litellm_logging_obj": response.logging_obj, **(request_data or {})}, response
             )
             assert billed is True
             for _ in range(50):
@@ -5555,13 +5555,38 @@ class TestStreamingClientDisconnectBilling:
         assert standard_logging_object["response_cost"] > 0.0
 
     @pytest.mark.asyncio
+    async def test_disconnect_billing_prices_a_partly_restamped_chunk_list_at_real_model(self):
+        """
+        A chunk that carries usage is stored as a copy before the proxy restamps the
+        one it forwards, so an aliased stream can reach billing with its first chunk
+        still on the deployment model and the rest on the client's name.
+        """
+        assert "openai/my-public-alias" not in litellm.model_cost
+
+        def restamp_only_the_chunks_the_proxy_forwarded(response):
+            for chunk in response.chunks[1:]:
+                chunk.model = "my-public-alias"
+
+        event = await self._bill_and_collect_success_event(
+            restamp_only_the_chunks_the_proxy_forwarded,
+            request_data={"model": "my-public-alias"},
+        )
+
+        assert event["response_obj"].model == "gpt-4o-mini"
+        standard_logging_object = event["kwargs"]["standard_logging_object"]
+        assert standard_logging_object["response_cost"] > 0.0
+
+    @pytest.mark.asyncio
     async def test_disconnect_billing_keeps_the_model_azure_model_router_picked(self):
         def restamp_like_azure_model_router(response):
             response.chunks[0].model = "azure-model-router"
             for chunk in response.chunks[1:]:
                 chunk.model = "gpt-4.1-nano-2025-04-14"
 
-        event = await self._bill_and_collect_success_event(restamp_like_azure_model_router)
+        event = await self._bill_and_collect_success_event(
+            restamp_like_azure_model_router,
+            request_data={"model": "azure-model-router"},
+        )
 
         assert event["response_obj"].model == "gpt-4.1-nano-2025-04-14"
         standard_logging_object = event["kwargs"]["standard_logging_object"]

--- a/tests/test_litellm/proxy/test_common_request_processing.py
+++ b/tests/test_litellm/proxy/test_common_request_processing.py
@@ -5555,6 +5555,19 @@ class TestStreamingClientDisconnectBilling:
         assert standard_logging_object["response_cost"] > 0.0
 
     @pytest.mark.asyncio
+    async def test_disconnect_billing_keeps_the_model_azure_model_router_picked(self):
+        def restamp_like_azure_model_router(response):
+            response.chunks[0].model = "azure-model-router"
+            for chunk in response.chunks[1:]:
+                chunk.model = "gpt-4.1-nano-2025-04-14"
+
+        event = await self._bill_and_collect_success_event(restamp_like_azure_model_router)
+
+        assert event["response_obj"].model == "gpt-4.1-nano-2025-04-14"
+        standard_logging_object = event["kwargs"]["standard_logging_object"]
+        assert standard_logging_object["response_cost"] > 0.0
+
+    @pytest.mark.asyncio
     async def test_disconnect_billing_backfills_missing_cache_fields(self):
         event = await self._bill_and_collect_success_event()
 

--- a/tests/test_litellm/proxy/test_common_request_processing.py
+++ b/tests/test_litellm/proxy/test_common_request_processing.py
@@ -5593,6 +5593,31 @@ class TestStreamingClientDisconnectBilling:
         assert standard_logging_object["response_cost"] > 0.0
 
     @pytest.mark.asyncio
+    async def test_disconnect_billing_keeps_the_routed_model_when_request_data_model_was_rewritten(self):
+        """
+        Pre-call processing rewrites request_data["model"] for aliasing and routing, so the
+        routed model on the later chunks can end up matching it. Only the name the client
+        sent says whether the proxy restamped this stream.
+        """
+
+        def restamp_like_azure_model_router(response):
+            response.chunks[0].model = "azure-model-router"
+            for chunk in response.chunks[1:]:
+                chunk.model = "gpt-4.1-nano-2025-04-14"
+
+        event = await self._bill_and_collect_success_event(
+            restamp_like_azure_model_router,
+            request_data={
+                "model": "gpt-4.1-nano-2025-04-14",
+                "_litellm_client_requested_model": "azure-model-router",
+            },
+        )
+
+        assert event["response_obj"].model == "gpt-4.1-nano-2025-04-14"
+        standard_logging_object = event["kwargs"]["standard_logging_object"]
+        assert standard_logging_object["response_cost"] > 0.0
+
+    @pytest.mark.asyncio
     async def test_disconnect_billing_backfills_missing_cache_fields(self):
         event = await self._bill_and_collect_success_event()
 

--- a/tests/test_litellm/proxy/test_common_request_processing.py
+++ b/tests/test_litellm/proxy/test_common_request_processing.py
@@ -5555,7 +5555,7 @@ class TestStreamingClientDisconnectBilling:
         assert standard_logging_object["response_cost"] > 0.0
 
     @pytest.mark.asyncio
-    async def test_disconnect_billing_zero_fills_missing_cache_fields(self):
+    async def test_disconnect_billing_backfills_missing_cache_fields(self):
         event = await self._bill_and_collect_success_event()
 
         usage = event["response_obj"].usage
@@ -5563,6 +5563,48 @@ class TestStreamingClientDisconnectBilling:
         assert getattr(usage, "cache_read_input_tokens", None) == 0
         assert usage.prompt_tokens_details is not None
         assert usage.prompt_tokens_details.cached_tokens == 0
+
+    @pytest.mark.asyncio
+    async def test_disconnect_billing_carries_up_openai_style_cached_tokens(self):
+        from litellm.types.utils import (
+            Delta,
+            ModelResponseStream,
+            PromptTokensDetailsWrapper,
+            StreamingChoices,
+            Usage,
+        )
+
+        def append_openai_style_cached_usage_chunk(response):
+            response.chunks.append(
+                ModelResponseStream(
+                    id=response.chunks[0].id,
+                    model="gpt-4o-mini",
+                    object="chat.completion.chunk",
+                    choices=[
+                        StreamingChoices(
+                            finish_reason=None,
+                            index=0,
+                            delta=Delta(content=" and more", role="assistant"),
+                        )
+                    ],
+                    usage=Usage(
+                        prompt_tokens=1000,
+                        completion_tokens=10,
+                        total_tokens=1010,
+                        prompt_tokens_details=PromptTokensDetailsWrapper(
+                            cached_tokens=500
+                        ),
+                    ),
+                )
+            )
+
+        event = await self._bill_and_collect_success_event(
+            append_openai_style_cached_usage_chunk
+        )
+
+        usage = event["response_obj"].usage
+        assert getattr(usage, "cache_read_input_tokens", None) == 500
+        assert getattr(usage, "cache_creation_input_tokens", None) == 0
 
     @pytest.mark.asyncio
     async def test_disconnect_billing_keeps_cache_values_recovered_from_chunks(self):


### PR DESCRIPTION
## TLDR

Problem this solves:

- Streams cut mid-response log `"spend": 0.0` despite billable tokens
- Proxy-side stream-cap rows also log `prompt_tokens: 0`
- Partial rows drop the cache token fields full rows carry

How it solves it:

- Price the partial rebuild at the deployment's real model, not the client alias
- Pass the request messages so prompt tokens get counted
- Carry the cache token fields onto partial rows, with the provider's real counts where it sent them

## User Flow

Before: a developer whose stream gets cut mid-response is billed nothing for it, and the spend row loses token detail too

1. They send POST https://litellm-domain/v1/chat/completions with `"model": "bedrock-claude-opus-5"` and `"stream": true`, and text chunks start arriving
2. Their client gives up at its own 12 second timeout and closes the connection after ~126 chunks
3. GET https://litellm-domain/spend/logs?request_id=chatcmpl-... shows the row with 296 completion tokens but `"spend": 0.0`, and its usage object is missing the cache token fields every completed request reports at 0
4. On a proxy configured to cap stream duration at 6 seconds, the same request ends with a `408` error chunk instead, and that row is worse: `"prompt_tokens": 0`, `"spend": 0.0`, usage object `null`

After: the same cut streams get priced at the model's real rates and keep their token detail

1. They send the same POST https://litellm-domain/v1/chat/completions with `"model": "bedrock-claude-opus-5"` and `"stream": true`
2. Their client gives up at its 12 second timeout, same as before
3. GET https://litellm-domain/spend/logs?request_id=chatcmpl-... now shows non-zero spend for the streamed completion tokens, priced at the underlying model's per-token rates, with the cache token fields present at 0 like any completed request
4. The proxy-cap `408` row now carries the real prompt token count and non-zero spend for the tokens streamed before the cut

## Relevant issues

## Linear ticket

Resolves LIT-5840

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Live runs against Bedrock `us.anthropic.claude-opus-5`, real spend, no mocks. Shared setup for every case below:

`config.yaml`

```yaml
model_list:
  - model_name: bedrock-claude-opus-5
    litellm_params:
      model: bedrock/us.anthropic.claude-opus-5
      aws_region_name: us-east-1

general_settings:
  master_key: os.environ/LITELLM_MASTER_KEY
  database_url: os.environ/DATABASE_URL
```

Every spend row below is read back the way a user would, through `GET /spend/logs?request_id=<id>` with the master key, piped to `jq` for the fields in question. Rates for pricing checks: input $5.5e-06, output $2.75e-05 per token.

### Before (9432f401452836f366ec3bece81be8043733a011)

#### Case A: client hangs up mid-stream on /v1/chat/completions

1. Send a control request that runs to completion:

```
curl -s -N "http://127.0.0.1:PORT/v1/chat/completions" \
  -H "Authorization: Bearer $KEY" -H "Content-Type: application/json" \
  -d '{"model":"bedrock-claude-opus-5","stream":true,"stream_options":{"include_usage":true},"max_tokens":600,
       "messages":[{"role":"user","content":"Write about 400 words on how rivers shape landscapes."}]}'

a1 response id: chatcmpl-17f0bb81-d88d-4bb3-9a19-935db3d12e9c, chunks: 155
```

2. Send the same kind of request and hang up at 12 seconds:

```
curl -s -N --max-time 12 "http://127.0.0.1:PORT/v1/chat/completions" \
  -H "Authorization: Bearer $KEY" -H "Content-Type: application/json" \
  -d '{"model":"bedrock-claude-opus-5","stream":true,"stream_options":{"include_usage":true},"max_tokens":4000,
       "messages":[{"role":"user","content":"Write 1500 words about the history of lighthouses."}]}'

curl exit: 28
b1 response id: chatcmpl-736193e3-a7d9-4d92-8a18-6f5757cf3b13, chunks: 126
```

3. Read the control row, which is priced and carries the cache fields at 0:

```json
{
  "request_id": "chatcmpl-17f0bb81-d88d-4bb3-9a19-935db3d12e9c",
  "status": "success",
  "prompt_tokens": 25,
  "completion_tokens": 600,
  "spend": 0.0166375,
  "model": "bedrock/us.anthropic.claude-opus-5",
  "usage_object": {
    "total_tokens": 625, "prompt_tokens": 25, "completion_tokens": 600,
    "prompt_tokens_details": {"text_tokens": 25, "cached_tokens": 0, "cache_write_tokens": 0, "cache_creation_tokens": 0},
    "cache_read_input_tokens": 0,
    "cache_creation_input_tokens": 0
  }
}
```

4. Read the row for the stream that got hung up on, which counted 296 completion tokens and billed nothing, with no cache fields at all:

```json
{
  "request_id": "chatcmpl-736193e3-a7d9-4d92-8a18-6f5757cf3b13",
  "status": "success",
  "prompt_tokens": 20,
  "completion_tokens": 296,
  "spend": 0.0,
  "model": "bedrock/us.anthropic.claude-opus-5",
  "usage_object": {
    "total_tokens": 316, "prompt_tokens": 20, "completion_tokens": 296,
    "prompt_tokens_details": null,
    "completion_tokens_details": null
  },
  "error_information": {"error_code": "499", "error_class": "ClientDisconnected", "error_message": "Client disconnected the request"}
}
```

#### Case B: proxy cuts the stream at its duration cap on /v1/chat/completions

1. Boot the proxy with `LITELLM_MAX_STREAMING_DURATION_SECONDS=6` and send a long stream:

```
curl -s -N -w "total=%{time_total}s http=%{http_code}\n" "http://127.0.0.1:PORT/v1/chat/completions" \
  -H "Authorization: Bearer $KEY" -H "Content-Type: application/json" \
  -d '{"model":"bedrock-claude-opus-5","stream":true,"stream_options":{"include_usage":true},"max_tokens":4000,"thinking":{"type":"disabled"},
       "messages":[{"role":"user","content":"Write 1500 words about the history of lighthouses."}]}'

total=8.071515s http=200
x-litellm-call-id: c50380a4-d092-4625-8bfc-46281a8d1fd3
chunks: 99
data: {"error": {"message": "litellm.Timeout: Stream exceeded max streaming duration of 6.0s (elapsed 6.3s)", "type": null, "param": null, "code": "408"}}
```

2. Read the row: no prompt tokens, no spend, no usage object, though 219 completion tokens streamed:

```json
{
  "request_id": "c50380a4-d092-4625-8bfc-46281a8d1fd3",
  "status": "failure",
  "prompt_tokens": 0,
  "completion_tokens": 219,
  "spend": 0.0,
  "model": "bedrock/us.anthropic.claude-opus-5",
  "usage_object": null,
  "error_information": {"error_code": "408", "error_class": "Timeout", "llm_provider": "bedrock",
    "error_message": "litellm.Timeout: Stream exceeded max streaming duration of 6.0s (elapsed 6.3s)"}
}
```

#### Case C: proxy cuts the stream at its duration cap on /v1/responses

1. Same proxy, same cap, on the responses route:

```
curl -s -N -w "total=%{time_total}s http=%{http_code}\n" "http://127.0.0.1:PORT/v1/responses" \
  -H "Authorization: Bearer $KEY" -H "Content-Type: application/json" \
  -d '{"model":"bedrock-claude-opus-5","stream":true,"max_output_tokens":4000,
       "input":"Write 1500 words about the history of lighthouses."}'

total=7.558630s http=200
x-litellm-call-id: 9af3d402-257c-4c88-9782-f3c79129de21
chunks: 36
data: {"error": {"message": "litellm.Timeout: Stream exceeded max streaming duration of 6.0s (elapsed 6.0s)", "code": "408"}}
```

2. Read the row: prompt tokens 0 again, so the 81 streamed output tokens are the only thing billed:

```json
{
  "request_id": "9af3d402-257c-4c88-9782-f3c79129de21",
  "status": "failure",
  "prompt_tokens": 0,
  "completion_tokens": 81,
  "spend": 0.0022275,
  "model": "bedrock-claude-opus-5",
  "model_group": "",
  "usage_object": null,
  "error_information": {"error_code": "408", "error_class": "Timeout", "llm_provider": "bedrock"}
}
```

### After (08014933477131f40357808bc12f93c90f7e4ad3)

#### Case A: client hangs up mid-stream on /v1/chat/completions

1. Same control request:

```
curl -s -N "http://127.0.0.1:PORT/v1/chat/completions" \
  -H "Authorization: Bearer $KEY" -H "Content-Type: application/json" \
  -d '{"model":"bedrock-claude-opus-5","stream":true,"stream_options":{"include_usage":true},"max_tokens":600,
       "messages":[{"role":"user","content":"Write about 400 words on how rivers shape landscapes."}]}'

a1 response id: chatcmpl-72ff40bb-b926-4774-8bd3-07c06e37ab83, chunks: 149
```

2. Same request hung up on at 12 seconds:

```
curl -s -N --max-time 12 "http://127.0.0.1:PORT/v1/chat/completions" \
  -H "Authorization: Bearer $KEY" -H "Content-Type: application/json" \
  -d '{"model":"bedrock-claude-opus-5","stream":true,"stream_options":{"include_usage":true},"max_tokens":4000,
       "messages":[{"role":"user","content":"Write 1500 words about the history of lighthouses."}]}'

curl exit: 28
b1 response id: chatcmpl-80db78a2-cc2c-4048-bc54-e4906040d659, chunks: 142
```

3. Control row, unchanged, priced at `25 * 5.5e-06 + 600 * 2.75e-05 = 0.0166375`:

```json
{
  "request_id": "chatcmpl-72ff40bb-b926-4774-8bd3-07c06e37ab83",
  "status": "success",
  "prompt_tokens": 25,
  "completion_tokens": 600,
  "spend": 0.0166375,
  "model": "bedrock/us.anthropic.claude-opus-5",
  "usage_object": {
    "total_tokens": 625, "prompt_tokens": 25, "completion_tokens": 600,
    "prompt_tokens_details": {"text_tokens": 25, "cached_tokens": 0, "cache_write_tokens": 0, "cache_creation_tokens": 0},
    "cache_read_input_tokens": 0,
    "cache_creation_input_tokens": 0
  },
  "error_information": null
}
```

4. The hung-up row is now billed at the model's real rates, `20 * 5.5e-06 + 316 * 2.75e-05 = 0.0088`, and carries the same cache fields at 0:

```json
{
  "request_id": "chatcmpl-80db78a2-cc2c-4048-bc54-e4906040d659",
  "status": "success",
  "prompt_tokens": 20,
  "completion_tokens": 316,
  "spend": 0.0088,
  "model": "bedrock/us.anthropic.claude-opus-5",
  "usage_object": {
    "total_tokens": 336, "prompt_tokens": 20, "completion_tokens": 316,
    "prompt_tokens_details": {"cached_tokens": 0},
    "cache_read_input_tokens": 0,
    "cache_creation_input_tokens": 0
  },
  "error_information": {"error_code": "499", "error_class": "ClientDisconnected", "error_message": "Client disconnected the request"}
}
```

#### Case B: proxy cuts the stream at its duration cap on /v1/chat/completions

1. Same cap, same request:

```
curl -s -N -w "total=%{time_total}s http=%{http_code}\n" "http://127.0.0.1:PORT/v1/chat/completions" \
  -H "Authorization: Bearer $KEY" -H "Content-Type: application/json" \
  -d '{"model":"bedrock-claude-opus-5","stream":true,"stream_options":{"include_usage":true},"max_tokens":4000,"thinking":{"type":"disabled"},
       "messages":[{"role":"user","content":"Write 1500 words about the history of lighthouses."}]}'

total=8.227816s http=200
x-litellm-call-id: 79786692-c5dd-4d33-a31d-1bc367faae2e
chunks: 99
data: {"error": {"message": "litellm.Timeout: Stream exceeded max streaming duration of 6.0s (elapsed 6.1s)", "type": null, "param": null, "code": "408"}}
```

2. The row now has a real prompt token count and is billed `20 * 5.5e-06 + 232 * 2.75e-05 = 0.00649`:

```json
{
  "request_id": "79786692-c5dd-4d33-a31d-1bc367faae2e",
  "status": "failure",
  "prompt_tokens": 20,
  "completion_tokens": 232,
  "spend": 0.00649,
  "model": "bedrock/us.anthropic.claude-opus-5",
  "model_group": "bedrock-claude-opus-5",
  "usage_object": null,
  "error_information": {"error_code": "408", "error_class": "Timeout", "llm_provider": "bedrock",
    "error_message": "litellm.Timeout: Stream exceeded max streaming duration of 6.0s (elapsed 6.1s)"}
}
```

#### Case C: proxy cuts the stream at its duration cap on /v1/responses

1. Same proxy, same cap, on the responses route:

```
curl -s -N -w "total=%{time_total}s http=%{http_code}\n" "http://127.0.0.1:PORT/v1/responses" \
  -H "Authorization: Bearer $KEY" -H "Content-Type: application/json" \
  -d '{"model":"bedrock-claude-opus-5","stream":true,"max_output_tokens":4000,
       "input":"Write 1500 words about the history of lighthouses."}'

total=7.906010s http=200
x-litellm-call-id: 1f44b81d-c4d4-4a0a-82be-24ab1b52dcc6
chunks: 66
data: {"error": {"message": "litellm.Timeout: Stream exceeded max streaming duration of 6.0s (elapsed 6.0s)", "code": "408"}}
```

2. Prompt tokens are counted here too now, so the row is billed `20 * 5.5e-06 + 116 * 2.75e-05 = 0.0033`:

```json
{
  "request_id": "1f44b81d-c4d4-4a0a-82be-24ab1b52dcc6",
  "status": "failure",
  "prompt_tokens": 20,
  "completion_tokens": 116,
  "spend": 0.0033,
  "model": "bedrock-claude-opus-5",
  "model_group": "",
  "usage_object": null,
  "error_information": {"error_code": "408", "error_class": "Timeout", "llm_provider": "bedrock",
    "error_message": "litellm.Timeout: Stream exceeded max streaming duration of 6.0s (elapsed 6.0s)"}
}
```

### Notes from the runs

- /v1/messages streams ignore the duration cap, so no partial row there
- Failure rows leave usage_object null; detail sits elsewhere in metadata
- /v1/responses rows log the alias as model, model_group empty
- None of those three is changed by this PR
- The lighthouse prompt counts 20 prompt tokens on every row here; the control row's 25 is a different prompt

## Type

🐛 Bug Fix

## Caveats (if any)

- A partial row now carries the provider's real cache counts when the stream reported them, and zero otherwise. `cost_calculator.py` has a branch that reads the presence of `cache_read_input_tokens` as "this usage object is Anthropic-shaped" and folds the cache counts back into prompt tokens. It only runs when the caller passes `custom_cost_per_token` or `custom_cost_per_second`, and the partial-stream path passes neither, so it cannot fire here. I left it alone rather than change shared cost code every caller goes through
- The two tests that check cache counts survive from the chunks also pass at the merge base. They are there so a later change cannot go back to zeroing the fields unconditionally, not to demonstrate this fix
- The disconnect path keeps the model the chunk builder found on a later chunk only when it is not the name the client sent. That is what tells an Azure Model Router stream apart from an alias-restamped one, since both reach billing with a first chunk that disagrees with the rest: a chunk carrying usage is stored as a copy before the proxy restamps the one it forwards. No automated test drives the proxy's own restamp, so the unit tests build both shapes by editing the stored chunks
- The proxy-cut failure path in `streaming_handler.py` has no access to the client's model name, so it always prices at the deployment's model. An Azure Model Router stream cut by the duration cap is billed at the router deployment rather than the routed model, which is what a completed stream on that route logs today
- Passing `messages` into the partial rebuild changes the prompt token count on every interrupted async stream, SDK callers included, not only proxy rows. `token_counter` raises on `messages=None` and `ChunkProcessor.calculate_usage` turns that into `prompt_tokens = 0`, so the old number was exactly zero whenever no chunk reported prompt tokens. It is a tiktoken estimate now, which can differ from the provider's own count for non-OpenAI tokenizers or when tools and system content sit outside `messages`

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches spend tracking for interrupted streams (disconnect and mid-flight failure). Wrong model selection could misprice rows, but the change is isolated to partial-billing paths and is covered by unit tests.
> 
> **Overview**
> Interrupted streams (client disconnect or mid-flight failure) now log **non-zero spend** at the **deployment model**, not an unpriced public alias, and keep prompt/cache token fields that complete rows already report.
> 
> **Pricing.** `_record_partial_usage_for_failure` restamps the rebuilt response with `self.model` before cost calc, and passes request `messages` so prompt tokens are counted. Disconnect billing in `_bill_partial_streamed_spend_on_disconnect` prefers the wrapper’s real model unless Azure Model Router recovered a later-chunk routed name (distinguished from alias restamping via `_litellm_client_requested_model`).
> 
> **Cache fields.** New `backfill_missing_cache_usage_fields` copies OpenAI-style `prompt_tokens_details` counts onto Anthropic-style `cache_read_input_tokens` / `cache_creation_input_tokens` (or zeros them) so partial rows match complete ones without overwriting real cache counts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 08014933477131f40357808bc12f93c90f7e4ad3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



