### PR TITLE
fix(containers): surface provider errors from container file content endpoint

### DIFF
--- a/litellm/llms/custom_httpx/container_handler.py
+++ b/litellm/llms/custom_httpx/container_handler.py
@@ -39,6 +39,10 @@ RESPONSE_TYPES: Final[dict[str, type]] = {
     "DeleteContainerFileResponse": DeleteContainerFileResponse,
 }
 
+ContainerEndpointResponse = (
+    ContainerFileListResponse | ContainerFileObject | DeleteContainerFileResponse | bytes | dict[str, object]
+)
+
 
 def _load_endpoints_config() -> dict:
     """Load the endpoints configuration from JSON file."""
@@ -99,6 +103,51 @@ def _build_query_params(
         if value is not None:
             params[param_name] = str(value) if not isinstance(value, str) else value
     return params
+
+
+def _error_message_from_response(response: httpx.Response) -> str:
+    try:
+        body: Final = response.json()
+    except ValueError:
+        return response.text
+
+    if isinstance(body, dict) and isinstance(body.get("error"), dict):
+        message: Final = body["error"].get("message")
+        if isinstance(message, str):
+            return message
+
+    return response.text
+
+
+def _transform_response(
+    response: httpx.Response,
+    returns_binary: bool,
+    response_type_name: str,
+) -> ContainerEndpointResponse:
+    from litellm.llms.base_llm.chat.transformation import BaseLLMException
+
+    if httpx.codes.is_error(response.status_code):
+        raise BaseLLMException(
+            status_code=response.status_code,
+            message=_error_message_from_response(response),
+            headers=dict(response.headers),
+        )
+
+    if returns_binary:
+        return response.content
+
+    response_json: Final = response.json()
+    if "error" in response_json:
+        raise BaseLLMException(
+            status_code=response.status_code,
+            message=response_json.get("error", {}).get("message", str(response_json)),
+            headers=dict(response.headers),
+        )
+
+    response_type: Final = RESPONSE_TYPES.get(response_type_name)
+    if response_type:
+        return response_type(**response_json)
+    return response_json
 
 
 def _prepare_multipart_file_upload(
@@ -270,27 +319,11 @@ class GenericContainerHandler:
             else:
                 raise ValueError(f"Unsupported HTTP method: {method}")
 
-            # For binary responses, return raw content
-            if returns_binary:
-                return response.content
-
-            # Check for error response
-            response_json: Final = response.json()
-            if "error" in response_json:
-                from litellm.llms.base_llm.chat.transformation import BaseLLMException
-
-                error_msg: Final = response_json.get("error", {}).get("message", str(response_json))
-                raise BaseLLMException(
-                    status_code=response.status_code,
-                    message=error_msg,
-                    headers=dict(response.headers),
-                )
-
-            # Parse response
-            response_type: Final = RESPONSE_TYPES.get(endpoint_config["response_type"])
-            if response_type:
-                return response_type(**response_json)
-            return response_json
+            return _transform_response(
+                response=response,
+                returns_binary=returns_binary,
+                response_type_name=endpoint_config["response_type"],
+            )
 
         except Exception as e:
             raise e
@@ -378,27 +411,11 @@ class GenericContainerHandler:
             else:
                 raise ValueError(f"Unsupported HTTP method: {method}")
 
-            # For binary responses, return raw content
-            if returns_binary:
-                return response.content
-
-            # Check for error response
-            response_json: Final = response.json()
-            if "error" in response_json:
-                from litellm.llms.base_llm.chat.transformation import BaseLLMException
-
-                error_msg: Final = response_json.get("error", {}).get("message", str(response_json))
-                raise BaseLLMException(
-                    status_code=response.status_code,
-                    message=error_msg,
-                    headers=dict(response.headers),
-                )
-
-            # Parse response
-            response_type: Final = RESPONSE_TYPES.get(endpoint_config["response_type"])
-            if response_type:
-                return response_type(**response_json)
-            return response_json
+            return _transform_response(
+                response=response,
+                returns_binary=returns_binary,
+                response_type_name=endpoint_config["response_type"],
+            )
 
         except Exception as e:
             raise e

--- a/tests/test_litellm/llms/custom_httpx/test_container_handler.py
+++ b/tests/test_litellm/llms/custom_httpx/test_container_handler.py
@@ -1,0 +1,102 @@
+from unittest.mock import MagicMock
+
+import httpx
+import pytest
+
+import litellm
+from litellm.llms.base_llm.chat.transformation import BaseLLMException
+from litellm.llms.custom_httpx.container_handler import generic_container_handler
+from litellm.llms.custom_httpx.http_handler import AsyncHTTPHandler, HTTPHandler
+from litellm.types.router import GenericLiteLLMParams
+from litellm.utils import ProviderConfigManager
+
+FILE_NOT_FOUND_BODY = {
+    "error": {
+        "message": "File not found.",
+        "type": "invalid_request_error",
+        "param": None,
+        "code": None,
+    }
+}
+
+
+def _sync_client(response: httpx.Response) -> HTTPHandler:
+    handler = HTTPHandler()
+    handler.client = httpx.Client(transport=httpx.MockTransport(lambda _request: response))
+    return handler
+
+
+def _async_client(response: httpx.Response) -> AsyncHTTPHandler:
+    handler = AsyncHTTPHandler()
+    handler.client = httpx.AsyncClient(transport=httpx.MockTransport(lambda _request: response))
+    return handler
+
+
+def _handle(endpoint_name: str, client, **overrides):
+    return generic_container_handler.handle(
+        endpoint_name=endpoint_name,
+        container_provider_config=ProviderConfigManager.get_provider_container_config(
+            provider=litellm.LlmProviders.OPENAI
+        ),
+        litellm_params=GenericLiteLLMParams(api_key="sk-test"),
+        logging_obj=MagicMock(),
+        client=client,
+        container_id="cntr_real",
+        file_id="cfile_nonexistent",
+        **overrides,
+    )
+
+
+def test_binary_endpoint_raises_on_error_status():
+    with pytest.raises(BaseLLMException) as exc_info:
+        _handle(
+            "retrieve_container_file_content",
+            _sync_client(httpx.Response(404, json=FILE_NOT_FOUND_BODY)),
+        )
+
+    assert exc_info.value.status_code == 404
+    assert exc_info.value.message == "File not found."
+
+
+@pytest.mark.asyncio
+async def test_async_binary_endpoint_raises_on_error_status():
+    with pytest.raises(BaseLLMException) as exc_info:
+        await _handle(
+            "aretrieve_container_file_content",
+            _async_client(httpx.Response(404, json=FILE_NOT_FOUND_BODY)),
+            _is_async=True,
+        )
+
+    assert exc_info.value.status_code == 404
+    assert exc_info.value.message == "File not found."
+
+
+def test_binary_endpoint_returns_raw_content_on_success():
+    content = _handle(
+        "retrieve_container_file_content",
+        _sync_client(httpx.Response(200, content=b"\x00binary-payload")),
+    )
+
+    assert content == b"\x00binary-payload"
+
+
+def test_error_status_with_non_json_body_surfaces_response_text():
+    with pytest.raises(BaseLLMException) as exc_info:
+        _handle(
+            "retrieve_container_file_content",
+            _sync_client(httpx.Response(502, content=b"<html>bad gateway</html>")),
+        )
+
+    assert exc_info.value.status_code == 502
+    assert exc_info.value.message == "<html>bad gateway</html>"
+
+
+def test_json_endpoint_still_raises_provider_error_message():
+    with pytest.raises(BaseLLMException) as exc_info:
+        _handle(
+            "retrieve_container_file",
+            _sync_client(httpx.Response(404, json=FILE_NOT_FOUND_BODY)),
+        )
+
+    assert exc_info.value.status_code == 404
+    assert exc_info.value.message == "File not found."


### PR DESCRIPTION
## TLDR

Problem this solves:

- Missing container file content returned 200 with an empty-looking payload
- The provider's 404 body came back as opaque bytes
- Only binary container endpoints were affected

How it solves it:

- Check the response status before the binary short-circuit
- Raise the provider's error for every container file endpoint
- Fall back to the response text when the error body is not JSON

## User Flow

Before: a developer downloading a container file gets a 200 back for an id that does not exist, so their code writes the gateway's error text to disk as if it were the file

1. They upload a file and get back an id like `cfile_6a8786d8c4048191bfdc2c8737559715`
2. They later request GET https://litellm-domain/v1/containers/cntr_abc/files/cfile_nonexistent/content for an id that has since been removed
3. The response is `200 OK` with `content-type: application/octet-stream`, so their client treats it as file bytes
4. The bytes are actually `{"error": {"message": "File not found.", ...}}`, which they save as a 96-byte file and only discover when something downstream chokes on it
5. Asking for the same missing id's metadata at GET https://litellm-domain/v1/containers/cntr_abc/files/cfile_nonexistent does return `404`, so the two routes disagree about whether the file exists

After: the same download returns a 404 the client can act on, matching what the metadata route already said

1. They upload a file and get back an id like `cfile_6a8786d8c4048191bfdc2c8737559715`
2. They request GET https://litellm-domain/v1/containers/cntr_abc/files/cfile_nonexistent/content for the id that has since been removed
3. The response is `404` with `content-type: application/json` and the body `{"error":{"message":"litellm.NotFoundError: NotFoundError: OpenAIException - File not found.",...}}`
4. Their client raises instead of writing a bogus file, and retry or fallback logic runs
5. GET https://litellm-domain/v1/containers/cntr_abc/files/cfile_nonexistent still returns `404`, so both routes now agree
6. Downloading a file that does exist is unchanged: `200` with `content-type: application/octet-stream` and the real bytes

## Relevant issues

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Shared setup, a proxy on localhost:4000 with one OpenAI model and `master_key: sk-1234`, plus a container and a real uploaded file so the success path is covered on both sides

```bash
curl -sS http://localhost:4000/v1/containers -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
  -d '{"name":"pr-proof","expires_after":{"anchor":"last_active_at","minutes":10}}'
printf 'hello from litellm container files\n' > proof.txt
curl -sS "http://localhost:4000/v1/containers/$CID/files" -H "Authorization: Bearer sk-1234" -F "file=@proof.txt"
```

### Before (1d7f675e52)

#### Content of a container file that does not exist

1. `curl -sS -o body -w "status=%{http_code}\ncontent_type=%{content_type}\n" "http://localhost:4000/v1/containers/$CID/files/cfile_nonexistent/content" -H "Authorization: Bearer sk-1234"`
2. Output:

```
status=200
content_type=application/octet-stream
{
  "error": {
    "message": "File not found.",
    "type": "invalid_request_error",
    "param": null,
    "code": null
  }
}
```

#### Metadata of the same missing file

1. `curl -sS -o body -w "status=%{http_code}\n" "http://localhost:4000/v1/containers/$CID/files/cfile_nonexistent" -H "Authorization: Bearer sk-1234"`
2. Output:

```
status=404
{"error":{"message":"litellm.NotFoundError: NotFoundError: OpenAIException - File not found.","type":null,"param":null,"code":"404"}}
```

#### Content of a file that does exist

1. `curl -sS -o body -w "status=%{http_code}\ncontent_type=%{content_type}\n" "http://localhost:4000/v1/containers/$CID/files/$FID/content" -H "Authorization: Bearer sk-1234"`
2. Output:

```
status=200
content_type=application/octet-stream
hello from litellm container files
```

### After (c18d6749bf)

#### Content of a container file that does not exist

1. `curl -sS -o body -w "status=%{http_code}\ncontent_type=%{content_type}\n" "http://localhost:4000/v1/containers/$CID/files/cfile_nonexistent/content" -H "Authorization: Bearer sk-1234"`
2. Output:

```
status=404
content_type=application/json
{"error":{"message":"litellm.NotFoundError: NotFoundError: OpenAIException - File not found.","type":null,"param":null,"code":"404"}}
```

#### Metadata of the same missing file

1. `curl -sS -o body -w "status=%{http_code}\n" "http://localhost:4000/v1/containers/$CID/files/cfile_nonexistent" -H "Authorization: Bearer sk-1234"`
2. Output:

```
status=404
{"error":{"message":"litellm.NotFoundError: NotFoundError: OpenAIException - File not found.","type":null,"param":null,"code":"404"}}
```

#### Content of a file that does exist

1. `curl -sS -o body -w "status=%{http_code}\ncontent_type=%{content_type}\n" "http://localhost:4000/v1/containers/$CID/files/$FID/content" -H "Authorization: Bearer sk-1234"`
2. Output:

```
status=200
content_type=application/octet-stream
hello from litellm container files
```

## Type

🐛 Bug Fix

## Caveats (if any)

- Non-2xx now raises on every container file endpoint, not just binary ones

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
