### PR TITLE
test(ci): serve /moderations from the canned OpenAI mock

### DIFF
--- a/tests/_fake_openai_endpoint_server.py
+++ b/tests/_fake_openai_endpoint_server.py
@@ -245,9 +245,9 @@ def _moderation_result() -> dict[str, object]:
 
 
 async def moderations(request: Request) -> Response:
-    body = await _parse_body(request)
-    raw_input = body.get("input", "")
-    count = len(raw_input) if isinstance(raw_input, list) else 1
+    body: Final = await _parse_body(request)
+    raw_input: Final = body.get("input", "")
+    count: Final = len(raw_input) if isinstance(raw_input, list) else 1
     return JSONResponse(
         {
             "id": f"modr-{uuid.uuid4().hex[:24]}",

--- a/tests/_fake_openai_endpoint_server.py
+++ b/tests/_fake_openai_endpoint_server.py
@@ -8,11 +8,11 @@ those jobs failed with ``404 Application not found`` even though nothing in the
 PR was broken.
 
 This process is the local stand-in. A model points its ``api_base`` here and
-gets back a well-formed chat/text/embedding response with realistic ``usage`` so
-cost tracking and spend accounting still exercise their real code paths. The one
-behavioral special case mirrors the old hosted mock: a request whose ``model``
-is ``429`` returns HTTP 429 so rate-limit and cooldown tests still have
-something to trip on.
+gets back a well-formed chat/text/embedding/moderation response with realistic
+``usage`` so cost tracking and spend accounting still exercise their real code
+paths. The one behavioral special case mirrors the old hosted mock: a request
+whose ``model`` is ``429`` returns HTTP 429 so rate-limit and cooldown tests
+still have something to trip on.
 """
 
 from __future__ import annotations
@@ -35,6 +35,21 @@ _SLOW_MODEL: Final = "slow-endpoint"
 _SLOW_RESPONSE_SECONDS: Final = 3.0
 _PROMPT_TOKENS: Final = 20
 _COMPLETION_TOKENS: Final = 20
+_MODERATION_CATEGORIES: Final = (
+    "harassment",
+    "harassment/threatening",
+    "hate",
+    "hate/threatening",
+    "illicit",
+    "illicit/violent",
+    "self-harm",
+    "self-harm/instructions",
+    "self-harm/intent",
+    "sexual",
+    "sexual/minors",
+    "violence",
+    "violence/graphic",
+)
 
 
 def _usage() -> dict[str, int]:
@@ -220,6 +235,28 @@ async def triton_embeddings(_request: Request) -> Response:
     )
 
 
+def _moderation_result() -> dict[str, object]:
+    return {
+        "flagged": False,
+        "categories": {category: False for category in _MODERATION_CATEGORIES},
+        "category_scores": {category: 0.0 for category in _MODERATION_CATEGORIES},
+        "category_applied_input_types": {category: ["text"] for category in _MODERATION_CATEGORIES},
+    }
+
+
+async def moderations(request: Request) -> Response:
+    body = await _parse_body(request)
+    raw_input = body.get("input", "")
+    count = len(raw_input) if isinstance(raw_input, list) else 1
+    return JSONResponse(
+        {
+            "id": f"modr-{uuid.uuid4().hex[:24]}",
+            "model": _requested_model(body),
+            "results": [_moderation_result() for _ in range(max(count, 1))],
+        }
+    )
+
+
 async def list_models(_request: Request) -> Response:
     return JSONResponse(
         {
@@ -247,6 +284,8 @@ app = Starlette(
         Route("/embeddings", embeddings, methods=["POST"]),
         Route("/v1/embeddings", embeddings, methods=["POST"]),
         Route("/triton/embeddings", triton_embeddings, methods=["POST"]),
+        Route("/moderations", moderations, methods=["POST"]),
+        Route("/v1/moderations", moderations, methods=["POST"]),
         Route("/models", list_models, methods=["GET"]),
         Route("/v1/models", list_models, methods=["GET"]),
     ]

--- a/tests/local_testing/test_fake_openai_endpoint.py
+++ b/tests/local_testing/test_fake_openai_endpoint.py
@@ -16,6 +16,7 @@ from pathlib import Path
 
 import httpx
 import pytest
+from openai.types import ModerationCreateResponse
 
 from tests.fake_openai_endpoint import (
     _LOCAL_DEFAULT,
@@ -54,6 +55,20 @@ def test_chat_completion_shape():
     body = response.json()
     assert body["choices"][0]["message"]["content"]
     assert body["usage"]["total_tokens"] == 40
+
+
+def test_moderations_route_parses_as_an_openai_response():
+    base = ensure_fake_openai_endpoint()
+    response = httpx.post(
+        f"{base}/v1/moderations",
+        json={"input": ["I want to harm someone", "hello"], "model": "omni-moderation-latest"},
+        timeout=10,
+    )
+    assert response.status_code == 200
+    parsed = ModerationCreateResponse.model_validate(response.json())
+    assert parsed.model == "omni-moderation-latest"
+    assert len(parsed.results) == 2
+    assert parsed.results[0].categories.violence is False
 
 
 def test_triton_embeddings_route():

--- a/tests/local_testing/test_fake_openai_endpoint.py
+++ b/tests/local_testing/test_fake_openai_endpoint.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import re
 from pathlib import Path
+from typing import Final
 
 import httpx
 import pytest
@@ -58,14 +59,14 @@ def test_chat_completion_shape():
 
 
 def test_moderations_route_parses_as_an_openai_response():
-    base = ensure_fake_openai_endpoint()
-    response = httpx.post(
+    base: Final = ensure_fake_openai_endpoint()
+    response: Final = httpx.post(
         f"{base}/v1/moderations",
         json={"input": ["I want to harm someone", "hello"], "model": "omni-moderation-latest"},
         timeout=10,
     )
     assert response.status_code == 200
-    parsed = ModerationCreateResponse.model_validate(response.json())
+    parsed: Final = ModerationCreateResponse.model_validate(response.json())
     assert parsed.model == "omni-moderation-latest"
     assert len(parsed.results) == 2
     assert parsed.results[0].categories.violence is False


### PR DESCRIPTION
## TLDR

Problem this solves:

- The proxy E2E moderations test 404s on `litellm_internal_staging`
- The canned OpenAI mock the job boots never served `/moderations`

How it solves it:

- The mock now answers `/moderations` and `/v1/moderations`
- Its body is OpenAI-shaped, one result per input item

## User Flow

Before: a contributor's CI run goes red on a moderations test their PR never touched

1. They add the `run-ci` label and the `proxy_logging_guardrails_model_info_tests` job starts
2. The job boots a proxy on `otel_test_config.yaml`, whose only OpenAI deployment is a wildcard pointed at the canned mock endpoint
3. The test sends POST `http://0.0.0.0:4000/moderations` with `{"input": "I want to harm someone", "model": "omni-moderation-latest"}`
4. The response is HTTP 404 with `{"error":{"message":"Not Found","type":null,"param":null,"code":"404"}}`, and the job goes red
5. The sibling request that omits `model` still returns 200, so only the model-bearing case fails

After: the same run is green, and both moderation shapes come back with a moderation result

1. They add the `run-ci` label and the `proxy_logging_guardrails_model_info_tests` job starts
2. The job boots a proxy on `otel_test_config.yaml`, whose only OpenAI deployment is a wildcard pointed at the canned mock endpoint
3. The test sends POST `http://0.0.0.0:4000/moderations` with `{"input": "I want to harm someone", "model": "omni-moderation-latest"}`
4. The response is HTTP 200 carrying a `modr-...` id and a full `results[0]` with `categories`, `category_scores` and `category_applied_input_types`
5. The sibling request that omits `model` still returns 200, unchanged

## Relevant issues

Unblocks the `proxy_logging_guardrails_model_info_tests` job on https://github.com/BerriAI/litellm/pull/37721

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

This PR changes no proxy code, so one proxy process serves both sides: only the mock endpoint behind the config's `openai/*` deployment is swapped between Before and After. The proxy listens on 4010 rather than 4000 because another local proxy already held 4000

Shared setup, run once:

```
git show 1d7f675e52:tests/_fake_openai_endpoint_server.py > /tmp/mock_before.py

PYTHONPATH=$PWD LITELLM_MASTER_KEY=sk-1234 FAKE_OPENAI_API_BASE=http://127.0.0.1:8191 \
  COHERE_API_KEY=fake-cohere RECORDER_COHERE_BASE_URL=http://127.0.0.1:8191 OTEL_EXPORTER=in_memory \
  python litellm/proxy/proxy_cli.py --config litellm/proxy/example_config_yaml/otel_test_config.yaml --port 4010
```

### Before (1d7f675e52)

#### moderations with a model in the body

1. Start the merge base's mock behind the config's `openai/*` deployment

```
python /tmp/mock_before.py --host 127.0.0.1 --port 8191
```

2. Send the request the failing CI test sends

```
curl -s -w '\nHTTP %{http_code}\n' -X POST 'http://localhost:4010/moderations' \
  -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' \
  -d '{"input":"I want to harm someone","model":"omni-moderation-latest"}'
```

```
{"error":{"message":"Not Found","type":null,"param":null,"code":"404"}}
HTTP 404
```

#### moderations with no model in the body

1. Send the same request without `model`

```
curl -s -o /tmp/out.json -w 'HTTP %{http_code}\n' -X POST 'http://localhost:4010/moderations' \
  -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' \
  -d '{"input":"I want to harm someone"}'; head -c 150 /tmp/out.json
```

```
HTTP 200
{"id":"modr-9891","model":"omni-moderation-latest","results":[{"categories":{"harassment":false,"harassment_threatening":false,"hate":false,"hate_thre
```

### After (bab7e16004)

#### moderations with a model in the body

1. Restart the mock from this branch, same port, same proxy process

```
python tests/_fake_openai_endpoint_server.py --host 127.0.0.1 --port 8191
```

2. Send the identical request

```
curl -s -o /tmp/out.json -w 'HTTP %{http_code}\n' -X POST 'http://localhost:4010/moderations' \
  -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' \
  -d '{"input":"I want to harm someone","model":"omni-moderation-latest"}'; head -c 170 /tmp/out.json
```

```
HTTP 200
{"id":"modr-de6a206033214a70aedb4971","model":"omni-moderation-latest","results":[{"categories":{"harassment":false,"harassment_threatening":false,"hate":false,"hate_thre
```

#### moderations with no model in the body

1. Send the same request without `model`

```
curl -s -o /tmp/out.json -w 'HTTP %{http_code}\n' -X POST 'http://localhost:4010/moderations' \
  -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' \
  -d '{"input":"I want to harm someone"}'; head -c 150 /tmp/out.json
```

```
HTTP 200
{"id":"modr-3555","model":"omni-moderation-latest","results":[{"categories":{"harassment":false,"harassment_threatening":false,"hate":false,"hate_thre
```

## Type

✅ Test

## Caveats (if any)

- The mock always answers not-flagged; it does not read the input
- The no-model case still calls OpenAI for real
- Local proxy ran on 4010 because another proxy held 4000

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
