### PR TITLE
fix(redis): apply Azure AD and GCP IAM auth to every async client path

### DIFF
--- a/litellm/_redis.py
+++ b/litellm/_redis.py
@@ -17,6 +17,7 @@ from typing import Final
 
 import redis
 import redis.asyncio as async_redis
+from redis.credentials import CredentialProvider
 
 from litellm import get_secret, get_secret_str
 from litellm._redis_credential_provider import (
@@ -134,6 +135,7 @@ def _get_redis_cluster_kwargs(client=None):
         "ssl_check_hostname",
         "ssl_ca_certs",
         "redis_connect_func",  # Needed for sync clusters and IAM detection
+        "credential_provider",
         "gcp_service_account",
         "gcp_ssl_ca_certs",
         "azure_redis_ad_token",
@@ -574,6 +576,20 @@ def _init_async_redis_sentinel(redis_kwargs) -> async_redis.Redis:
     return sentinel.master_for(service_name, **connection_kwargs)
 
 
+def _async_credential_provider(redis_connect_func: object | None) -> CredentialProvider | None:
+    """Async redis-py never calls ``redis_connect_func``; it authenticates through a
+    ``CredentialProvider``, which it consults per connection so the token refreshes."""
+    gcp_service_account: Final = getattr(redis_connect_func, "_gcp_service_account", None)
+    if gcp_service_account is not None:
+        return GCPIAMCredentialProvider(gcp_service_account)
+
+    azure_credential: Final = getattr(redis_connect_func, "_azure_credential", None)
+    if azure_credential is not None:
+        return AzureADCredentialProvider(azure_credential, username=os.environ.get("REDIS_USERNAME") or None)
+
+    return None
+
+
 def get_redis_client(**env_overrides):
     redis_kwargs: Final = _get_redis_client_logic(**env_overrides)
 
@@ -601,6 +617,11 @@ def get_redis_async_client(
     **env_overrides,
 ) -> async_redis.Redis | async_redis.RedisCluster:
     redis_kwargs: Final = _get_redis_client_logic(**env_overrides)
+    credential_provider: Final = _async_credential_provider(redis_kwargs.pop("redis_connect_func", None))
+    if credential_provider is not None:
+        redis_kwargs["credential_provider"] = credential_provider
+        redis_kwargs.pop("username", None)
+        redis_kwargs.pop("password", None)
 
     if "startup_nodes" in redis_kwargs:
         from redis.cluster import ClusterNode
@@ -610,23 +631,6 @@ def get_redis_async_client(
         for arg in redis_kwargs:
             if arg in args:
                 cluster_kwargs[arg] = redis_kwargs[arg]
-
-        # Handle GCP IAM authentication for async clusters
-        redis_connect_func = cluster_kwargs.pop("redis_connect_func", None)
-
-        # Use a CredentialProvider so the IAM token is regenerated on every new
-        # connection — mirrors the sync path where redis_connect_func is invoked
-        # per connection.  Without this, the token would expire after ~1 hour.
-        if redis_connect_func and hasattr(redis_connect_func, "_gcp_service_account"):
-            cluster_kwargs["credential_provider"] = GCPIAMCredentialProvider(redis_connect_func._gcp_service_account)
-        # Handle Azure AD authentication for async clusters via CredentialProvider
-        # so the credential's internal cache + silent refresh runs per connection
-        # (mirrors GCP IAM above; avoids static-token-baked-in-pool expiry).
-        elif redis_connect_func and hasattr(redis_connect_func, "_azure_credential"):
-            cluster_kwargs["credential_provider"] = AzureADCredentialProvider(
-                redis_connect_func._azure_credential,
-                username=os.environ.get("REDIS_USERNAME") or None,
-            )
 
         new_startup_nodes: Final[list[ClusterNode]] = []
 
@@ -667,19 +671,6 @@ def get_redis_async_client(
     if "sentinel_nodes" in redis_kwargs and "service_name" in redis_kwargs:
         return _init_async_redis_sentinel(redis_kwargs)
 
-    # Wrap GCP / Azure AD auth in a CredentialProvider for the standard async
-    # Redis client. The async client doesn't support redis_connect_func, but it
-    # does honour credential_provider — which is called per connection, so the
-    # underlying SDK can refresh tokens silently before they expire.
-    redis_connect_func = redis_kwargs.pop("redis_connect_func", None)
-    if redis_connect_func and hasattr(redis_connect_func, "_azure_credential"):
-        redis_kwargs["credential_provider"] = AzureADCredentialProvider(
-            redis_connect_func._azure_credential,
-            username=os.environ.get("REDIS_USERNAME") or None,
-        )
-    elif redis_connect_func and hasattr(redis_connect_func, "_gcp_service_account"):
-        redis_kwargs["credential_provider"] = GCPIAMCredentialProvider(redis_connect_func._gcp_service_account)
-
     _pretty_print_redis_config(redis_kwargs=redis_kwargs)
 
     if connection_pool is not None:
@@ -694,6 +685,11 @@ def get_redis_connection_pool(
     **env_overrides,
 ) -> async_redis.BlockingConnectionPool | None:
     redis_kwargs: Final = _get_redis_client_logic(**env_overrides)
+    credential_provider: Final = _async_credential_provider(redis_kwargs.pop("redis_connect_func", None))
+    if credential_provider is not None:
+        redis_kwargs["credential_provider"] = credential_provider
+        redis_kwargs.pop("username", None)
+        redis_kwargs.pop("password", None)
     verbose_logger.debug("get_redis_connection_pool: redis_kwargs", redis_kwargs)
 
     if "startup_nodes" in redis_kwargs:
@@ -713,18 +709,6 @@ def get_redis_connection_pool(
                     redis_kwargs["max_connections"],
                 )
         return async_redis.BlockingConnectionPool.from_url(**pool_kwargs)
-
-    # Wrap GCP / Azure AD auth in a CredentialProvider so pool-managed
-    # connections re-fetch tokens via the SDK's internal cache + silent refresh
-    # rather than reusing a single token captured at pool creation.
-    redis_connect_func: Final = redis_kwargs.pop("redis_connect_func", None)
-    if redis_connect_func and hasattr(redis_connect_func, "_azure_credential"):
-        redis_kwargs["credential_provider"] = AzureADCredentialProvider(
-            redis_connect_func._azure_credential,
-            username=os.environ.get("REDIS_USERNAME") or None,
-        )
-    elif redis_connect_func and hasattr(redis_connect_func, "_gcp_service_account"):
-        redis_kwargs["credential_provider"] = GCPIAMCredentialProvider(redis_connect_func._gcp_service_account)
 
     if redis_kwargs.pop("ssl", None):
         redis_kwargs["connection_class"] = async_redis.SSLConnection

--- a/litellm/_redis.py
+++ b/litellm/_redis.py
@@ -552,11 +552,11 @@ def _init_redis_sentinel(redis_kwargs) -> redis.Redis:
 
 
 def _sentinel_auth_kwargs(connection_kwargs: dict, sentinel_password: str | None) -> dict:
-    """The Sentinel monitors are separate servers with their own password, and redis-py refuses a
-    password passed alongside a credential provider, so the data node's provider stays behind once
-    a Sentinel password is configured."""
-    superseded: Final = frozenset({"credential_provider"}) if sentinel_password else frozenset()
-    kept: Final = ((k, v) for k, v in connection_kwargs.items() if k not in superseded)
+    """The Sentinel monitors are separate servers that authenticate with their own password, so the
+    data node's credential provider never belongs on them: leaving it there makes redis-py send the
+    data node's token to a monitor, which fails whether the monitor is unauthenticated or has its
+    own password."""
+    kept: Final = ((k, v) for k, v in connection_kwargs.items() if k != "credential_provider")
     return dict(kept, password=sentinel_password)
 
 

--- a/litellm/_redis.py
+++ b/litellm/_redis.py
@@ -577,10 +577,12 @@ def _init_async_redis_sentinel(redis_kwargs) -> async_redis.Redis:
 
 
 def _async_credential_provider(redis_connect_func: object | None) -> CredentialProvider | None:
-    """``redis_connect_func`` runs the AUTH exchange with the blocking client API, so on an
-    async connection its ``send_command``/``read_response`` calls return coroutines nobody
-    awaits and every connect fails. Async paths authenticate through a ``CredentialProvider``
-    instead, which redis-py consults per connection so the token stays fresh."""
+    """The Azure AD and GCP IAM connect funcs run their AUTH exchange with the blocking client
+    API, so on an async connection their ``send_command``/``read_response`` calls return
+    coroutines nobody awaits and every connect fails. Async paths authenticate through a
+    ``CredentialProvider`` instead, which redis-py consults per connection so the token stays
+    fresh. Any other ``redis_connect_func`` is left where it is, since redis-py awaits it
+    itself when it is a coroutine function."""
     gcp_service_account: Final = getattr(redis_connect_func, "_gcp_service_account", None)
     if gcp_service_account is not None:
         return GCPIAMCredentialProvider(gcp_service_account)
@@ -588,12 +590,6 @@ def _async_credential_provider(redis_connect_func: object | None) -> CredentialP
     azure_credential: Final = getattr(redis_connect_func, "_azure_credential", None)
     if azure_credential is not None:
         return AzureADCredentialProvider(azure_credential, username=os.environ.get("REDIS_USERNAME") or None)
-
-    if redis_connect_func is not None:
-        verbose_logger.warning(
-            "REDIS: dropping redis_connect_func, which an async connection cannot run. "
-            "Configure Azure AD or GCP IAM auth so a credential provider handles the token instead."
-        )
 
     return None
 
@@ -625,11 +621,11 @@ def get_redis_async_client(
     **env_overrides,
 ) -> async_redis.Redis | async_redis.RedisCluster:
     redis_kwargs: Final = _get_redis_client_logic(**env_overrides)
-    credential_provider: Final = _async_credential_provider(redis_kwargs.pop("redis_connect_func", None))
+    credential_provider: Final = _async_credential_provider(redis_kwargs.get("redis_connect_func"))
     if credential_provider is not None:
         redis_kwargs["credential_provider"] = credential_provider
-        redis_kwargs.pop("username", None)
-        redis_kwargs.pop("password", None)
+        for superseded in ("redis_connect_func", "username", "password"):
+            redis_kwargs.pop(superseded, None)
 
     if "startup_nodes" in redis_kwargs:
         from redis.cluster import ClusterNode
@@ -693,11 +689,11 @@ def get_redis_connection_pool(
     **env_overrides,
 ) -> async_redis.BlockingConnectionPool | None:
     redis_kwargs: Final = _get_redis_client_logic(**env_overrides)
-    credential_provider: Final = _async_credential_provider(redis_kwargs.pop("redis_connect_func", None))
+    credential_provider: Final = _async_credential_provider(redis_kwargs.get("redis_connect_func"))
     if credential_provider is not None:
         redis_kwargs["credential_provider"] = credential_provider
-        redis_kwargs.pop("username", None)
-        redis_kwargs.pop("password", None)
+        for superseded in ("redis_connect_func", "username", "password"):
+            redis_kwargs.pop(superseded, None)
     verbose_logger.debug("get_redis_connection_pool: redis_kwargs", redis_kwargs)
 
     if "startup_nodes" in redis_kwargs:

--- a/litellm/_redis.py
+++ b/litellm/_redis.py
@@ -589,6 +589,12 @@ def _async_credential_provider(redis_connect_func: object | None) -> CredentialP
     if azure_credential is not None:
         return AzureADCredentialProvider(azure_credential, username=os.environ.get("REDIS_USERNAME") or None)
 
+    if redis_connect_func is not None:
+        verbose_logger.warning(
+            "REDIS: dropping redis_connect_func, which an async connection cannot run. "
+            "Configure Azure AD or GCP IAM auth so a credential provider handles the token instead."
+        )
+
     return None
 
 

--- a/litellm/_redis.py
+++ b/litellm/_redis.py
@@ -577,8 +577,10 @@ def _init_async_redis_sentinel(redis_kwargs) -> async_redis.Redis:
 
 
 def _async_credential_provider(redis_connect_func: object | None) -> CredentialProvider | None:
-    """Async redis-py never calls ``redis_connect_func``; it authenticates through a
-    ``CredentialProvider``, which it consults per connection so the token refreshes."""
+    """``redis_connect_func`` runs the AUTH exchange with the blocking client API, so on an
+    async connection its ``send_command``/``read_response`` calls return coroutines nobody
+    awaits and every connect fails. Async paths authenticate through a ``CredentialProvider``
+    instead, which redis-py consults per connection so the token stays fresh."""
     gcp_service_account: Final = getattr(redis_connect_func, "_gcp_service_account", None)
     if gcp_service_account is not None:
         return GCPIAMCredentialProvider(gcp_service_account)

--- a/litellm/_redis.py
+++ b/litellm/_redis.py
@@ -648,6 +648,7 @@ def get_redis_async_client(
         for item in redis_kwargs["startup_nodes"]:
             new_startup_nodes.append(ClusterNode(**item))
         cluster_kwargs.pop("startup_nodes", None)
+        cluster_kwargs.pop("redis_connect_func", None)
 
         # Default to a periodic health check + TCP keepalive so a connection silently dropped
         # by a cluster restart (e.g. ElastiCache Serverless maintenance) is revalidated and

--- a/litellm/_redis.py
+++ b/litellm/_redis.py
@@ -551,14 +551,22 @@ def _init_redis_sentinel(redis_kwargs) -> redis.Redis:
     return sentinel.master_for(service_name, **connection_kwargs)
 
 
+def _sentinel_auth_kwargs(connection_kwargs: dict, sentinel_password: str | None) -> dict:
+    """The Sentinel monitors are separate servers with their own password, and redis-py refuses a
+    password passed alongside a credential provider, so the data node's provider stays behind once
+    a Sentinel password is configured."""
+    superseded: Final = frozenset({"credential_provider"}) if sentinel_password else frozenset()
+    kept: Final = ((k, v) for k, v in connection_kwargs.items() if k not in superseded)
+    return dict(kept, password=sentinel_password)
+
+
 def _init_async_redis_sentinel(redis_kwargs) -> async_redis.Redis:
     sentinel_nodes: Final = redis_kwargs.get("sentinel_nodes")
     sentinel_password: Final = redis_kwargs.get("sentinel_password")
     service_name: Final = redis_kwargs.get("service_name")
     connection_kwargs: Final = _get_redis_sentinel_connection_kwargs(redis_kwargs)
     connection_kwargs.setdefault("socket_timeout", REDIS_SOCKET_TIMEOUT)
-    sentinel_kwargs: Final = dict(connection_kwargs)
-    sentinel_kwargs["password"] = sentinel_password
+    sentinel_kwargs: Final = _sentinel_auth_kwargs(connection_kwargs, sentinel_password)
 
     if not sentinel_nodes or not service_name:
         raise ValueError("Both 'sentinel_nodes' and 'service_name' are required for Redis Sentinel.")

--- a/litellm/_redis.py
+++ b/litellm/_redis.py
@@ -594,6 +594,18 @@ def _async_credential_provider(redis_connect_func: object | None) -> CredentialP
     return None
 
 
+def _async_auth_kwargs(redis_kwargs: dict) -> dict:
+    """Swaps a connect func an async path cannot run for the equivalent credential provider,
+    which supersedes any static username or password redis-py would otherwise reject it with."""
+    credential_provider: Final = _async_credential_provider(redis_kwargs.get("redis_connect_func"))
+    if credential_provider is None:
+        return redis_kwargs
+
+    superseded: Final = frozenset({"redis_connect_func", "username", "password"})
+    kept: Final = ((k, v) for k, v in redis_kwargs.items() if k not in superseded)
+    return dict(kept, credential_provider=credential_provider)  # mutable-ok: the branches below mutate these kwargs
+
+
 def get_redis_client(**env_overrides):
     redis_kwargs: Final = _get_redis_client_logic(**env_overrides)
 
@@ -620,12 +632,7 @@ def get_redis_async_client(
     connection_pool: async_redis.BlockingConnectionPool | None = None,
     **env_overrides,
 ) -> async_redis.Redis | async_redis.RedisCluster:
-    redis_kwargs: Final = _get_redis_client_logic(**env_overrides)
-    credential_provider: Final = _async_credential_provider(redis_kwargs.get("redis_connect_func"))
-    if credential_provider is not None:
-        redis_kwargs["credential_provider"] = credential_provider
-        for superseded in ("redis_connect_func", "username", "password"):
-            redis_kwargs.pop(superseded, None)
+    redis_kwargs: Final = _async_auth_kwargs(_get_redis_client_logic(**env_overrides))
 
     if "startup_nodes" in redis_kwargs:
         from redis.cluster import ClusterNode
@@ -688,12 +695,7 @@ def get_redis_async_client(
 def get_redis_connection_pool(
     **env_overrides,
 ) -> async_redis.BlockingConnectionPool | None:
-    redis_kwargs: Final = _get_redis_client_logic(**env_overrides)
-    credential_provider: Final = _async_credential_provider(redis_kwargs.get("redis_connect_func"))
-    if credential_provider is not None:
-        redis_kwargs["credential_provider"] = credential_provider
-        for superseded in ("redis_connect_func", "username", "password"):
-            redis_kwargs.pop(superseded, None)
+    redis_kwargs: Final = _async_auth_kwargs(_get_redis_client_logic(**env_overrides))
     verbose_logger.debug("get_redis_connection_pool: redis_kwargs", redis_kwargs)
 
     if "startup_nodes" in redis_kwargs:

--- a/tests/test_litellm/test_redis.py
+++ b/tests/test_litellm/test_redis.py
@@ -1005,3 +1005,22 @@ def test_async_url_keeps_a_coroutine_connect_func(build_pool):
 
     assert pool.connection_kwargs["redis_connect_func"] is connect
     assert "credential_provider" not in pool.connection_kwargs
+
+
+def test_async_cluster_drops_a_connect_func_it_cannot_pass_on():
+    """redis-py's async RedisCluster has no redis_connect_func parameter, so a connect func that
+    is not translated into a credential provider has to be dropped rather than forwarded.
+    """
+
+    async def connect(connection):
+        return None
+
+    redis_kwargs = {
+        "startup_nodes": [{"host": "cluster-node", "port": 6379}],
+        "redis_connect_func": connect,
+    }
+
+    with patch("litellm._redis._get_redis_client_logic", return_value=redis_kwargs):
+        client = get_redis_async_client()
+
+    assert isinstance(client, async_redis.RedisCluster)

--- a/tests/test_litellm/test_redis.py
+++ b/tests/test_litellm/test_redis.py
@@ -1034,13 +1034,19 @@ def test_async_cluster_drops_a_connect_func_it_cannot_pass_on():
     ],
     ids=["azure_ad", "gcp_iam"],
 )
-def test_async_sentinel_keeps_the_credential_provider_off_the_monitors(markers, provider_cls):
-    """The Sentinel monitors authenticate with their own password, and redis-py refuses a password
-    passed alongside a credential provider, so only the data node may carry the provider.
+@pytest.mark.parametrize(
+    "sentinel_password",
+    [None, "sentinel-secret"],
+    ids=["unauthenticated_monitors", "password_protected_monitors"],
+)
+def test_async_sentinel_keeps_the_credential_provider_off_the_monitors(markers, provider_cls, sentinel_password):
+    """The Sentinel monitors are separate servers with their own password, so the data node's token
+    never belongs on them: redis-py refuses it next to a Sentinel password, and sends it to an
+    unauthenticated monitor as an AUTH the monitor rejects.
     """
     redis_kwargs = {
         "sentinel_nodes": [("sentinel-1", 26379)],
-        "sentinel_password": "sentinel-secret",
+        "sentinel_password": sentinel_password,
         "service_name": "mymaster",
         "redis_connect_func": SimpleNamespace(**markers),
     }
@@ -1050,9 +1056,12 @@ def test_async_sentinel_keeps_the_credential_provider_off_the_monitors(markers, 
             get_redis_async_client()
 
     sentinel_kwargs = mock_sentinel_cls.call_args[1]["sentinel_kwargs"]
-    assert sentinel_kwargs["password"] == "sentinel-secret"
+    assert sentinel_kwargs["password"] == sentinel_password
     assert "credential_provider" not in sentinel_kwargs
-    async_redis.Connection(host="sentinel-1", port=26379, **sentinel_kwargs)
+
+    monitor_connection = async_redis.Connection(host="sentinel-1", port=26379, **sentinel_kwargs)
+    assert monitor_connection.credential_provider is None
+    assert bool(monitor_connection.username or monitor_connection.password) is bool(sentinel_password)
 
     master_kwargs = mock_sentinel_cls.return_value.master_for.call_args[1]
     assert isinstance(master_kwargs["credential_provider"], provider_cls)

--- a/tests/test_litellm/test_redis.py
+++ b/tests/test_litellm/test_redis.py
@@ -1024,3 +1024,36 @@ def test_async_cluster_drops_a_connect_func_it_cannot_pass_on():
         client = get_redis_async_client()
 
     assert isinstance(client, async_redis.RedisCluster)
+
+
+@pytest.mark.parametrize(
+    "markers, provider_cls",
+    [
+        (AZURE_AD_CONNECT_FUNC, AzureADCredentialProvider),
+        (GCP_IAM_CONNECT_FUNC, GCPIAMCredentialProvider),
+    ],
+    ids=["azure_ad", "gcp_iam"],
+)
+def test_async_sentinel_keeps_the_credential_provider_off_the_monitors(markers, provider_cls):
+    """The Sentinel monitors authenticate with their own password, and redis-py refuses a password
+    passed alongside a credential provider, so only the data node may carry the provider.
+    """
+    redis_kwargs = {
+        "sentinel_nodes": [("sentinel-1", 26379)],
+        "sentinel_password": "sentinel-secret",
+        "service_name": "mymaster",
+        "redis_connect_func": SimpleNamespace(**markers),
+    }
+
+    with patch("litellm._redis.async_redis.Sentinel") as mock_sentinel_cls:
+        with patch("litellm._redis._get_redis_client_logic", return_value=redis_kwargs):
+            get_redis_async_client()
+
+    sentinel_kwargs = mock_sentinel_cls.call_args[1]["sentinel_kwargs"]
+    assert sentinel_kwargs["password"] == "sentinel-secret"
+    assert "credential_provider" not in sentinel_kwargs
+    async_redis.Connection(host="sentinel-1", port=26379, **sentinel_kwargs)
+
+    master_kwargs = mock_sentinel_cls.return_value.master_for.call_args[1]
+    assert isinstance(master_kwargs["credential_provider"], provider_cls)
+    assert "password" not in master_kwargs

--- a/tests/test_litellm/test_redis.py
+++ b/tests/test_litellm/test_redis.py
@@ -1,4 +1,5 @@
 import json
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -14,6 +15,7 @@ from litellm._redis import (
 )
 from litellm.constants import REDIS_CLUSTER_HEALTH_CHECK_INTERVAL
 from litellm._redis_credential_provider import (
+    AzureADCredentialProvider,
     GCPIAMCredentialProvider,
     _token_cache,
 )
@@ -910,3 +912,74 @@ def test_url_allowlist_always_carries_socket_timeouts():
     allowed = _get_redis_url_kwargs()
     assert "socket_timeout" in allowed
     assert "socket_connect_timeout" in allowed
+
+
+AZURE_AD_CONNECT_FUNC = {"_azure_credential": object()}
+GCP_IAM_CONNECT_FUNC = {"_gcp_service_account": "projects/-/serviceAccounts/sa@project.iam.gserviceaccount.com"}
+
+
+@pytest.mark.parametrize(
+    "markers, provider_cls",
+    [
+        (AZURE_AD_CONNECT_FUNC, AzureADCredentialProvider),
+        (GCP_IAM_CONNECT_FUNC, GCPIAMCredentialProvider),
+    ],
+    ids=["azure_ad", "gcp_iam"],
+)
+def test_async_url_client_authenticates_through_credential_provider(markers, provider_cls):
+    """A REDIS_URL config with Azure AD or GCP IAM must still reach the server with a credential.
+
+    The async client accepts redis_connect_func as a kwarg but never calls it, so the url
+    branch has to hand the connection a CredentialProvider or it authenticates with nothing.
+    """
+    redis_kwargs = {
+        "url": "rediss://redis-host:6380",
+        "redis_connect_func": SimpleNamespace(**markers),
+    }
+
+    with patch("litellm._redis._get_redis_client_logic", return_value=redis_kwargs):
+        client = get_redis_async_client()
+
+    connection_kwargs = client.connection_pool.connection_kwargs
+    assert isinstance(connection_kwargs.get("credential_provider"), provider_cls)
+    assert "redis_connect_func" not in connection_kwargs
+
+
+@pytest.mark.parametrize(
+    "markers, provider_cls",
+    [
+        (AZURE_AD_CONNECT_FUNC, AzureADCredentialProvider),
+        (GCP_IAM_CONNECT_FUNC, GCPIAMCredentialProvider),
+    ],
+    ids=["azure_ad", "gcp_iam"],
+)
+def test_async_url_connection_pool_authenticates_through_credential_provider(markers, provider_cls):
+    """Same for the pool-based path: every connection the pool hands out needs the provider."""
+    redis_kwargs = {
+        "url": "rediss://redis-host:6380",
+        "redis_connect_func": SimpleNamespace(**markers),
+    }
+
+    with patch("litellm._redis._get_redis_client_logic", return_value=redis_kwargs):
+        pool = get_redis_connection_pool()
+
+    assert isinstance(pool.connection_kwargs.get("credential_provider"), provider_cls)
+    assert "redis_connect_func" not in pool.connection_kwargs
+
+
+def test_async_url_client_drops_username_alongside_credential_provider():
+    """redis-py refuses a connection given both a username and a credential_provider, and
+    AzureADCredentialProvider already carries REDIS_USERNAME, so the username must be dropped.
+    """
+    redis_kwargs = {
+        "url": "rediss://redis-host:6380",
+        "username": "redis-user",
+        "redis_connect_func": SimpleNamespace(**AZURE_AD_CONNECT_FUNC),
+    }
+
+    with patch("litellm._redis._get_redis_client_logic", return_value=redis_kwargs):
+        client = get_redis_async_client()
+
+    pool = client.connection_pool
+    assert "username" not in pool.connection_kwargs
+    pool.connection_class(**pool.connection_kwargs)

--- a/tests/test_litellm/test_redis.py
+++ b/tests/test_litellm/test_redis.py
@@ -929,8 +929,9 @@ GCP_IAM_CONNECT_FUNC = {"_gcp_service_account": "projects/-/serviceAccounts/sa@p
 def test_async_url_client_authenticates_through_credential_provider(markers, provider_cls):
     """A REDIS_URL config with Azure AD or GCP IAM must still reach the server with a credential.
 
-    The async client accepts redis_connect_func as a kwarg but never calls it, so the url
-    branch has to hand the connection a CredentialProvider or it authenticates with nothing.
+    The url branch forwards redis_connect_func straight to the async connection, which runs
+    its AUTH exchange with the blocking client API and dies, so the branch has to hand the
+    connection a CredentialProvider instead.
     """
     redis_kwargs = {
         "url": "rediss://redis-host:6380",
@@ -983,3 +984,24 @@ def test_async_url_client_drops_username_alongside_credential_provider():
     pool = client.connection_pool
     assert "username" not in pool.connection_kwargs
     pool.connection_class(**pool.connection_kwargs)
+
+
+@pytest.mark.parametrize("build_pool", [False, True], ids=["client", "pool"])
+def test_async_url_keeps_a_coroutine_connect_func(build_pool):
+    """redis-py awaits a coroutine redis_connect_func on an async connection, so one we cannot
+    turn into a credential provider has to be left where it is rather than dropped.
+    """
+
+    async def connect(connection):
+        return None
+
+    redis_kwargs = {
+        "url": "rediss://redis-host:6380",
+        "redis_connect_func": connect,
+    }
+
+    with patch("litellm._redis._get_redis_client_logic", return_value=redis_kwargs):
+        pool = get_redis_connection_pool() if build_pool else get_redis_async_client().connection_pool
+
+    assert pool.connection_kwargs["redis_connect_func"] is connect
+    assert "credential_provider" not in pool.connection_kwargs


### PR DESCRIPTION
## TLDR

Problem this solves:

- Async Redis clients from `REDIS_URL` never authenticated at all
- Their connection pools failed the exact same way
- So did async Sentinel clients
- Azure AD and GCP IAM Redis caching was silently dead

How it solves it:

- Build the credential provider once, before any branch
- URL, pool, sentinel, and cluster paths all inherit it
- Let `credential_provider` through the cluster kwargs filter
- Leave a coroutine connect func for redis-py to await
- Drop it where the async cluster client cannot accept it
- Keep the data node's token off the Sentinel monitors
- Regression tests cover every one of those paths

## User Flow

Before: an admin running two proxy replicas that cache into a managed Redis with Microsoft Entra ID gets no shared cache at all, so every replica pays the provider separately

1. They set `REDIS_URL=rediss://<their-cache>.<region>.redis.azure.net:10000`, `REDIS_USERNAME=<the identity's object id>`, and `REDIS_AZURE_AD_TOKEN=true`, turn on `cache: true` with `cache_params.type: redis`, and start two replicas
2. They call `GET /cache/ping` on replica A and get `503 Service Unavailable` with `{"message": "Service Unhealthy"}`
3. They send `POST /v1/chat/completions` to replica A and are billed for it, `x-litellm-response-cost: 0.000645`
4. They send the identical `POST /v1/chat/completions` to replica B and are billed a second time, `x-litellm-response-cost: 0.000675`, coming back with a different response id and no `x-litellm-cache-key` header
5. Their proxy logs fill with `AuthenticationError: Azure AD authentication failed for Redis`, followed by `Redis circuit breaker is open`
6. They connect to the cache themselves and find it empty, so nothing either replica did ever reached it

After: the same setup authenticates, so the second replica serves the answer out of Redis instead of buying it again

1. They set the same three environment variables, turn on the same cache config, and start two replicas
2. They call `GET /cache/ping` on replica A and get `200 OK` with `{"status":"healthy","cache_type":"redis","ping_response":true,"set_cache_response":"success"}`
3. They send `POST /v1/chat/completions` to replica A and are billed for it, `x-litellm-response-cost: 0.00035`
4. They send the identical `POST /v1/chat/completions` to replica B and get back the same response id as replica A carrying `x-litellm-cache-key: 6c2debe1...`, so no second call to the provider happens
5. Their proxy logs carry no Redis authentication errors at all
6. They connect to the cache themselves and find the cache key sitting there next to the proxy's own config keys

## Relevant issues

## Linear ticket

Related to LIT-5889

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Everything below ran against a real Azure Managed Redis (Balanced_B0, TLS, access keys **Disabled**, so Microsoft Entra ID is the only way in) and the real OpenAI API. No mocks, real spend. Before is the merge base `cb4eb82249` on ports 47311 and 47313, After is the PR tip `c09643ac4c` on ports 56981 and 56249

Shared setup, identical on both sides. Two proxy replicas point at that one cache, which is what an HA deployment looks like and what makes a shared cache observable at all: a single replica hides the whole bug behind its own in-memory layer, still answering "Cache Hit!" while Redis is unreachable

```bash
export REDIS_URL='rediss://litellm-lit5889-redis.eastus2.redis.azure.net:10000'
export REDIS_USERNAME='<object id of the Entra identity>'
export REDIS_AZURE_AD_TOKEN='true'

$ cat config.yaml
model_list:
  - model_name: gpt-5.6
    litellm_params:
      model: openai/gpt-5.6
      api_key: os.environ/OPENAI_API_KEY
litellm_settings:
  cache: true
  cache_params:
    type: redis

$ python litellm/proxy/proxy_cli.py --config config.yaml --port <replica A port> --detailed_debug
$ python litellm/proxy/proxy_cli.py --config config.yaml --port <replica B port> --detailed_debug
```

Shared background, and the reason the fix takes the shape it does. Three redis-py legs against that same cache, driven by LiteLLM's own Azure AD helpers, showing that an async connection cannot authenticate through a `redis_connect_func` no matter which code path hands it one

```
redis-py 5.3.1, server rediss://litellm-lit5889-redis.eastus2.redis.azure.net:10000
1. sync client + redis_connect_func      : PING -> True
2. async client + redis_connect_func     : AuthenticationError: Azure AD authentication failed for Redis
3. async client + credential_provider    : PING -> True
```

Leg 2 fails because that connect function runs the AUTH exchange with the blocking client API, so on an async connection `send_command` and `read_response` hand back coroutines nobody awaits. Python says so itself in the same run

```
litellm/_redis.py:314: RuntimeWarning: coroutine 'AbstractConnection.send_command' was never awaited
  self.send_command("AUTH", *auth_args, check_health=False)
```

### Before (cb4eb82249)

#### Cache health on replica A

1. `curl -s -i http://127.0.0.1:47311/cache/ping -H "Authorization: Bearer sk-1234"`

```
HTTP/1.1 503 Service Unavailable
{"error":{"message":"{\"message\": \"Service Unhealthy\", ...
```

#### The same completion on two replicas sharing one cache

1. `curl -s -i http://127.0.0.1:47311/v1/chat/completions -H "Authorization: Bearer sk-1234" -H 'Content-Type: application/json' -d '{"model":"gpt-5.6","messages":[{"role":"user","content":"Reply with exactly: lit5889 before probe"}]}'`

```
HTTP/1.1 200 OK
x-litellm-response-cost: 0.000645
x-litellm-cache-key: <absent>
body id: chatcmpl-EF5z2Zc8Riy9I3MYoCYnVwce8q8Bp
body content: lit5889 before probe
```

2. The identical request against replica B on port 47313, billed all over again and answering with a different id

```
HTTP/1.1 200 OK
x-litellm-response-cost: 0.000675
x-litellm-cache-key: <absent>
body id: chatcmpl-EF5z4zm1mztUElYsqVpNgiz2Gi7JD
body content: lit5889 before probe
```

#### What actually reached the Redis server

1. Connecting to the cache directly and listing its keys

```
keys matching '*': 0
```

2. Replica A's log over that run

```
  14 Azure AD authentication failed for Redis
   4 circuit breaker is open — skipping async_get_cache
  17 circuit breaker is open — skipping async_set_cache
```

### After (c09643ac4c)

#### Cache health on replica A

1. `curl -s -i http://127.0.0.1:56981/cache/ping -H "Authorization: Bearer sk-1234"`

```
HTTP/1.1 200 OK
{"status":"healthy","cache_type":"redis","ping_response":true,"set_cache_response":"success", ...
```

#### The same completion on two replicas sharing one cache

1. `curl -s -i http://127.0.0.1:56981/v1/chat/completions -H "Authorization: Bearer sk-1234" -H 'Content-Type: application/json' -d '{"model":"gpt-5.6","messages":[{"role":"user","content":"Reply with exactly: lit5889 after6 probe"}]}'`

```
HTTP/1.1 200 OK
x-litellm-response-cost: 0.00035
x-litellm-cache-key: <absent>
body id: chatcmpl-EF6tzdlwAN7DkG6m0QfIAFyBSBL7L
body content: lit5889 after6 probe
```

2. The identical request against replica B on port 56249, which now serves replica A's own answer with a cache key instead of calling the provider a second time

```
HTTP/1.1 200 OK
x-litellm-cache-key: bf79f7bcbbf817e07c2fceace95d8060e92b97c746bbc90eb234ab50fe3d31b9
body id: chatcmpl-EF6tzdlwAN7DkG6m0QfIAFyBSBL7L
body content: lit5889 after6 probe
```

#### What actually reached the Redis server

1. Connecting to the cache directly and listing its keys, which is where replica A's write landed and where replica B's read found it

```
keys matching '*': 14
   86d4ac816220d30f86882fe349625d1b1a9a2b7b4821e2ae1c9e5ee050c5896a
   bf79f7bcbbf817e07c2fceace95d8060e92b97c746bbc90eb234ab50fe3d31b9
   litellm_config:param:anthropic_beta_headers_reload_config
   litellm_config:param:environment_variables
   litellm_config:param:general_settings
```

2. Replica A's log over that run, with no Redis authentication errors and no circuit breaker trips at all

```
(no matches)
```

## Type

🐛 Bug Fix

## Caveats (if any)

- Managed Redis wants `REDIS_USERNAME` set to the identity's object id
- A blocking custom `redis_connect_func` still cannot run on async
- The cluster and Sentinel paths are proven by construction, not live

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

- [x] c09643ac4c0053c4d5514ecf199041c6013070b5 passes /live-pr-risk
