### PR TITLE
fix(ui): stop the Add Model mapping table from looping the page

### DIFF
--- a/ui/litellm-dashboard/eslint-suppressions.json
+++ b/ui/litellm-dashboard/eslint-suppressions.json
@@ -1468,9 +1468,6 @@
     },
     "local/no-complex-jsx-arrow": {
       "count": 1
-    },
-    "react-hooks/set-state-in-effect": {
-      "count": 2
     }
   },
   "src/components/add_model/handle_add_auto_router_submit.tsx": {

--- a/ui/litellm-dashboard/src/components/add_model/conditional_public_model_name.test.tsx
+++ b/ui/litellm-dashboard/src/components/add_model/conditional_public_model_name.test.tsx
@@ -1,7 +1,27 @@
 import { render, screen } from "@testing-library/react";
+import React, { useEffect, useRef } from "react";
+import { useFormContext, useWatch } from "react-hook-form";
 import { describe, expect, it } from "vitest";
 import { MountedFormHost } from "../../../tests/mounted-form-host";
+import type { MountedFormValues } from "../common_components/MountedFormField";
 import ConditionalPublicModelName from "./conditional_public_model_name";
+
+const WRITE_BUDGET = 20;
+
+const LoopGuard: React.FC = () => {
+  const form = useFormContext<MountedFormValues>();
+  const mappings = useWatch({ control: form.control, name: "model_mappings" });
+  const writes = useRef(0);
+
+  useEffect(() => {
+    writes.current += 1;
+    if (writes.current > WRITE_BUDGET) {
+      throw new Error(`model_mappings changed ${WRITE_BUDGET}+ times: the mapping effects are looping`);
+    }
+  }, [mappings]);
+
+  return null;
+};
 
 describe("ConditionalPublicModelName", () => {
   it("should render", () => {
@@ -24,5 +44,29 @@ describe("ConditionalPublicModelName", () => {
     expect(screen.getByText("Model Mappings")).toBeInTheDocument();
     expect(screen.getByText("Public Model Name")).toBeInTheDocument();
     expect(screen.getByText("LiteLLM Model Name")).toBeInTheDocument();
+  });
+
+  it("settles after rewriting the custom placeholder mapping to the entered model name", () => {
+    render(
+      <MountedFormHost
+        defaultValues={{
+          model: ["custom"],
+          custom_model_name: "my-custom-model",
+          model_mappings: [
+            {
+              public_name: "custom",
+              litellm_model: "custom",
+            },
+          ],
+        }}
+      >
+        <ConditionalPublicModelName />
+        <LoopGuard />
+      </MountedFormHost>,
+    );
+
+    expect(screen.getByDisplayValue("my-custom-model")).toBeInTheDocument();
+    expect(screen.getByText("my-custom-model")).toBeInTheDocument();
+    expect(screen.queryByDisplayValue("custom")).not.toBeInTheDocument();
   });
 });

--- a/ui/litellm-dashboard/src/components/add_model/conditional_public_model_name.tsx
+++ b/ui/litellm-dashboard/src/components/add_model/conditional_public_model_name.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useMemo } from "react";
 import type { ColumnDef } from "@tanstack/react-table";
 import { useFormContext, useWatch } from "react-hook-form";
 import { DataTable } from "@/components/shared/DataTable";
@@ -12,6 +12,13 @@ interface ModelMapping {
   public_name: string;
   litellm_model: string;
 }
+
+const sameMappings = (left: readonly ModelMapping[], right: readonly ModelMapping[]): boolean =>
+  left.length === right.length &&
+  left.every(
+    (mapping, index) =>
+      mapping.public_name === right[index].public_name && mapping.litellm_model === right[index].litellm_model,
+  );
 
 const modelMappingsRule = {
   validator: async (_: unknown, value: unknown) => {
@@ -29,15 +36,14 @@ const modelMappingsRule = {
 
 const ConditionalPublicModelName: React.FC = () => {
   const form = useFormContext<MountedFormValues>();
-  const [tableKey, setTableKey] = useState(0); // Add a key to force table re-render
 
-  // Watch the 'model' field for changes and ensure it's always an array
   const modelValue = useWatch({ control: form.control, name: "model" }) || [];
-  const selectedModels = Array.isArray(modelValue) ? modelValue : [modelValue];
+  const selectionKey = JSON.stringify(Array.isArray(modelValue) ? modelValue : [modelValue]);
+  const selectedModels = useMemo(() => JSON.parse(selectionKey) as string[], [selectionKey]);
   const customModelName = useWatch({ control: form.control, name: "custom_model_name" }) as string | undefined;
   const showPublicModelName = !selectedModels.includes("all-wildcard");
   const selectedProvider = useWatch({ control: form.control, name: "custom_llm_provider" });
-  // Force table to re-render when custom model name changes
+
   useEffect(() => {
     if (customModelName && selectedModels.includes("custom")) {
       const currentMappings = (form.getValues("model_mappings") as ModelMapping[]) || [];
@@ -56,8 +62,9 @@ const ConditionalPublicModelName: React.FC = () => {
         }
         return mapping;
       });
-      form.setValue("model_mappings", updatedMappings);
-      setTableKey((prev) => prev + 1); // Force table re-render
+      if (!sameMappings(currentMappings, updatedMappings)) {
+        form.setValue("model_mappings", updatedMappings);
+      }
     }
   }, [customModelName, selectedModels, selectedProvider, form]);
 
@@ -109,7 +116,6 @@ const ConditionalPublicModelName: React.FC = () => {
         });
 
         form.setValue("model_mappings", mappings);
-        setTableKey((prev) => prev + 1); // Force table re-render
       }
     }
   }, [selectedModels, customModelName, selectedProvider, form]);
@@ -210,7 +216,6 @@ const ConditionalPublicModelName: React.FC = () => {
     >
       {(control) => (
         <DataTable
-          key={tableKey} // Add key to force re-render
           data={(control.value as ModelMapping[] | undefined) ?? []}
           columns={columns}
           getRowId={(row) => row.litellm_model}


### PR DESCRIPTION
## TLDR

Problem this solves:

- Add Model crashes the page when you type a custom model name
- The provider API base and key fields vanish with it
- Adding a custom-named model through the UI is impossible

How it solves it:

- Drop the remount counter the mappings table no longer needs
- Key the mapping effects off selection contents, not array identity
- Write model_mappings only when they actually change

## User Flow

Before: an admin adding an OpenAI-compatible deployment under their own public name loses the whole page the moment they name it

1. They open https://litellm-domain/ui/?page=models and click the Add Model tab
2. They pick "OpenAI-Compatible Endpoints (Together AI, etc.)" as the provider, and the API Base and OpenAI API Key fields appear below
3. In LiteLLM Model Name(s) they pick "Custom Model Name (Enter below)", which reveals a free-text name box
4. They type a name into that box, and the entire form is replaced by "This page couldn't load / Reload to try again, or go back."
5. Reloading returns an empty form, so there is no way to finish adding the model

After: the same admin types the name, the form stays put, and the model is created and serves traffic

1. They open https://litellm-domain/ui/?page=models and click the Add Model tab
2. They pick "OpenAI-Compatible Endpoints (Together AI, etc.)" as the provider, and the API Base and OpenAI API Key fields appear below
3. In LiteLLM Model Name(s) they pick "Custom Model Name (Enter below)", which reveals a free-text name box
4. They type a name into that box, the Model Mappings table updates to show that name on both sides, and the API Base and OpenAI API Key fields are still there
5. They fill in the API base and key, Test Connect succeeds, Add Model reports "created successfully", and POST https://litellm-domain/v1/chat/completions with that model name returns a completion

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Shared setup, run once from the repo root, leave both running:

```
python litellm/proxy/proxy_cli.py --config litellm/proxy/dev_config.yaml --detailed_debug 2>&1 | tee litellm.log
```

```
cd ui/litellm-dashboard && npm run dev
```

### Before (3d3946059d)

1. Check out 3d3946059d, restart `npm run dev`, and open http://localhost:3000/models-and-endpoints
2. Click the "Add Model" tab
3. In "Provider", type `OpenAI-Compatible Endpoints (Together AI, etc.)` and pick that option. API Base and OpenAI API Key appear below the OR divider
4. In "LiteLLM Model Name(s)", open the dropdown and pick "Custom Model Name (Enter below)", then press Escape
5. Type `my-custom-model` into the "Enter custom model name" box
6. Screenshot: the form is gone, replaced by "This page couldn't load". The browser console shows `Minified React error #185` (maximum update depth exceeded)

### After (e39cb874f5)

1. Check out e39cb874f5, restart `npm run dev`, and open http://localhost:3000/models-and-endpoints
2. Click the "Add Model" tab
3. In "Provider", type `OpenAI-Compatible Endpoints (Together AI, etc.)` and pick that option. API Base and OpenAI API Key appear below the OR divider
4. In "LiteLLM Model Name(s)", open the dropdown and pick "Custom Model Name (Enter below)", then press Escape
5. Type `my-custom-model` into the "Enter custom model name" box
6. Screenshot: the form is intact, Model Mappings shows `my-custom-model` under both Public Model Name and LiteLLM Model Name, and API Base and OpenAI API Key are still on screen
7. Fill API Base with an OpenAI-compatible base URL and OpenAI API Key with its key, click "Test Connect", and screenshot the success panel
8. Click "Add Model" and screenshot the "created successfully" toast
9. Serve traffic with it:

```
curl -s http://localhost:4000/v1/chat/completions -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" -d '{"model":"my-custom-model","messages":[{"role":"user","content":"hi"}]}'
```

## Type

🐛 Bug Fix

## Caveats (if any)

- RouterConfigBuilder still carries a set-state-in-effect suppression

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
