### PR TITLE
test: assert the prefixed model the responses bridge now hands back

### DIFF
--- a/tests/llm_translation/test_openai.py
+++ b/tests/llm_translation/test_openai.py
@@ -1469,7 +1469,6 @@ def test_responses_gpt54_with_xhigh_reasoning():
         mock_responses.assert_called_once()
         request_body = mock_responses.call_args.kwargs
 
-        # The responses prefix should be stripped before routing.
-        assert request_body["model"] == "gpt-5.4"
+        assert request_body["model"] == "openai/gpt-5.4"
         # chat-completions reasoning_effort must map to Responses API reasoning.
         assert request_body["reasoning"] == {"effort": "xhigh"}


### PR DESCRIPTION
## TLDR

Problem this solves:

- `llm_translation_testing` is red on a stale assertion
- `a369cb0da7` changed what the responses bridge hands `responses()`
- It updated the bridge's own tests but not this one

How it solves it:

- Assert the prefixed model id the bridge now passes
- Drop the comment that claims the opposite

## User Flow

This PR touches one test file, so no end user flow changes. The provider still receives `gpt-5.4` either way; only the layer at which the prefix is stripped moved

## Relevant issues

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

The test mocks `litellm.responses` and stops at request build, so it makes no provider call and runs offline. That makes a real red-then-green run possible on this one, and it is what I captured

### Before (cc812cdfc7)

1. `uv run python -m pytest tests/llm_translation/test_openai.py::test_responses_gpt54_with_xhigh_reasoning -q`
2. `FAILED ... AssertionError: assert 'openai/gpt-5.4' == 'gpt-5.4'` / `1 failed, 1 warning in 0.12s`
3. Matches CircleCI on the same commit: https://app.circleci.com/workflow/e36bb1a2-ff9a-4587-ba96-7817672f1780/job/2336be10-b943-4eb1-946b-474d50756181

### After (d93d30da39)

1. `uv run python -m pytest tests/llm_translation/test_openai.py::test_responses_gpt54_with_xhigh_reasoning -q`
2. `1 passed, 1 warning in 0.08s`
3. `uv run python -m pytest tests/test_litellm/completion_extras/litellm_responses_transformation/ -q`
4. `88 passed, 7 warnings in 0.81s`, so the bridge's own suite is unaffected

## Type

✅ Test

## Caveats (if any)

- Only four perplexity Agent API models change behavior per `a369cb0da7`
- `llm_translation_testing` stays red on unrelated Together AI 503s

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
