### PR TITLE
test: point the live together_ai suites at a model together still serves

### DIFF
--- a/tests/llm_translation/test_together_ai.py
+++ b/tests/llm_translation/test_together_ai.py
@@ -20,7 +20,7 @@ import pytest
 class TestTogetherAI(BaseLLMChatTest):
     def get_base_completion_call_args(self) -> dict:
         litellm.set_verbose = True
-        return {"model": "together_ai/Qwen/Qwen2.5-7B-Instruct-Turbo"}
+        return {"model": "together_ai/openai/gpt-oss-20b"}
 
     def test_tool_call_no_arguments(self, tool_call_no_arguments):
         """Test that tool calls with no arguments is translated correctly. Relevant issue: https://github.com/BerriAI/litellm/issues/6833"""

--- a/tests/local_testing/test_completion.py
+++ b/tests/local_testing/test_completion.py
@@ -67,7 +67,7 @@ def test_completion_custom_provider_model_name():
     try:
         litellm.cache = None
         response = completion(
-            model="together_ai/Qwen/Qwen2.5-7B-Instruct-Turbo",
+            model="together_ai/openai/gpt-oss-20b",
             messages=messages,
             logger_fn=logger_fn,
         )
@@ -2817,7 +2817,7 @@ def test_customprompt_together_ai():
         print(litellm.success_callback)
         print(litellm._async_success_callback)
         response = completion(
-            model="together_ai/Qwen/Qwen2.5-7B-Instruct-Turbo",
+            model="together_ai/openai/gpt-oss-20b",
             messages=messages,
             roles={
                 "system": {
@@ -3657,7 +3657,7 @@ def test_completion_together_ai_stream():
     messages = [{"content": user_message, "role": "user"}]
     try:
         response = completion(
-            model="together_ai/Qwen/Qwen2.5-7B-Instruct-Turbo",
+            model="together_ai/openai/gpt-oss-20b",
             messages=messages,
             stream=True,
             max_tokens=5,

--- a/tests/local_testing/test_text_completion.py
+++ b/tests/local_testing/test_text_completion.py
@@ -4036,7 +4036,7 @@ def test_async_text_completion_together_ai():
     async def test_get_response():
         try:
             response = await litellm.atext_completion(
-                model="together_ai/Qwen/Qwen2.5-7B-Instruct-Turbo",
+                model="together_ai/openai/gpt-oss-20b",
                 prompt="good morning",
                 max_tokens=10,
             )


### PR DESCRIPTION
## TLDR

Problem this solves:

- Every live together_ai call in CI 503s since 2026-08-20
- Together reports no incident in either failure window
- `Qwen2.5-7B-Instruct-Turbo` is absent from their monitored components
- It also carries null pricing in the cost map

How it solves it:

- Repoint the live suites at `openai/gpt-oss-20b`
- Cheapest priced together_ai entry with the needed capabilities
- Together monitors it as a served component

## User Flow

This PR touches test files only, so no end user flow changes. What changes is which together_ai model the live conformance suites call

## Relevant issues

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [ ] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

These are live provider calls and there is no together_ai key on my machine, so I cannot run the before and after against Together from here. The failing evidence is in CI, and CI is where the after has to be captured. What I could verify offline is recorded below

### Before (02e67cd715)

#### live together_ai calls

1. `ci/circleci: llm_translation_testing` -> 17 `TestTogetherAI` failures, `ci/circleci: local_testing_part1` -> 3, `ci/circleci: local_testing_part2` -> 1
2. All identical: `litellm.ServiceUnavailableError: Together_aiException - Service unavailable`
3. Two runs 2.5h apart, same result: https://app.circleci.com/workflow/6ec42f1c-28b9-415e-b210-721c56c4c368 and https://app.circleci.com/workflow/e36bb1a2-ff9a-4587-ba96-7817672f1780
4. Every `TestTogetherAI` test that makes a live call is in that failure set

#### cost map, run locally

1. `litellm.get_model_info("together_ai/Qwen/Qwen2.5-7B-Instruct-Turbo")`
2. `in=0 out=0`, and the raw catalog entry is `input_cost_per_token: null, output_cost_per_token: null`

### After (bf920257f9)

#### cost map, run locally

1. `litellm.get_model_info("together_ai/openai/gpt-oss-20b")`
2. `in=5e-08 out=2e-07 fc=True schema=True toolchoice=True mode=chat`, so pricing and every capability these suites exercise resolve

#### live together_ai calls

Run triggered by the `run-ci` label on this commit: https://app.circleci.com/workflow/a1ec69c5-d91d-4db3-bf4d-c981c9512894

1. `llm_translation_testing` -> `TestTogetherAI` returns 23 passes and 0 failures, so every live call in the class got through
2. `local_testing_part1` -> `test_completion_custom_provider_model_name`, `test_customprompt_together_ai` and `test_completion_together_ai_stream` all pass
3. `local_testing_part2` -> `test_async_text_completion_together_ai` passes
4. No `Service unavailable` anywhere in the run, so the 503s were the model and not the account
5. `test_json_response_nested_json_schema` and `test_json_response_nested_pydantic_obj` also pass now, so gpt-oss-20b clears the grammar compiler limit that was failing them on 08-19

`llm_translation_testing` is still red, on `test_azure_openai_responses_bridge`, which is unrelated to together_ai and already fails the same way on the base. Same run on `litellm_internal_staging` at `cc812cdf`: https://app.circleci.com/workflow/e36bb1a2-ff9a-4587-ba96-7817672f1780. It is the azure sibling of the assertion #37744 corrected in `test_openai.py`, and it needs its own one-line change

## Type

✅ Test

## Caveats (if any)

- `test_multiple_deployments.py` keeps the old id, it is green and cassette-backed
- The one remaining red in `llm_translation_testing` is pre-existing on the base and out of scope here

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

