### PR TITLE
fix(proxy): restore model pricing in /v2/model/info after a request

### DIFF
--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -12475,7 +12475,7 @@ def _enrich_model_info_with_litellm_data(
             except Exception:
                 litellm_model_info = {}
     for k, v in litellm_model_info.items():
-        if k not in model_info:
+        if model_info.get(k) is None:
             model_info[k] = v
     model["model_info"] = model_info
     # don't return the api key / vertex credentials

--- a/tests/test_litellm/proxy/proxy_server/test_routes_model_info.py
+++ b/tests/test_litellm/proxy/proxy_server/test_routes_model_info.py
@@ -69,6 +69,31 @@ def test_v2_model_info_in_openapi_schema():
     assert "get" in schema["paths"]["/v2/model/info"]
 
 
+def test_v2_model_info_enrichment_heals_none_valued_cost_keys():
+    """A deployment that has served a request carries its cost keys as explicit None, because
+    Deployment materialises every unset ModelInfo field. Backfilling only absent keys left those
+    None values unhealed, so this route reported no pricing for exactly the models in use."""
+    from litellm.proxy.proxy_server import _enrich_model_info_with_litellm_data
+
+    base = {
+        "model_name": "claude-haiku-4-5",
+        "litellm_params": {"model": "anthropic/claude-haiku-4-5-20251001"},
+    }
+
+    absent = _enrich_model_info_with_litellm_data(model={**base, "model_info": {"id": "abc"}})
+    expected = absent["model_info"]["input_cost_per_token"]
+    assert expected is not None
+
+    served = _enrich_model_info_with_litellm_data(
+        model={
+            **base,
+            "model_info": {"id": "abc", "input_cost_per_token": None, "output_cost_per_token": None},
+        }
+    )
+    assert served["model_info"]["input_cost_per_token"] == expected
+    assert served["model_info"]["output_cost_per_token"] is not None
+
+
 # ---------------------------------------------------------------------------
 # GET /v1/model/info, GET /model/info
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## TLDR

Problem this solves:

- Calling a model blanks its price on the Model Management page
- Only the models you actually use lose their pricing
- The price never returns without a manual cost-map reload

How it solves it:

- A served deployment stores its cost keys as explicit null
- Backfill skipped those, filling only fully absent keys
- Treat null the same as absent when backfilling

## User Flow

Before: an admin watching the Model Management page sees pricing disappear from exactly the models their team is using, which reads as though the busy models are the misconfigured ones

1. They open https://litellm-domain/ui/?page=models and see a price in the Costs column for every model
2. Their team sends a normal request to one of those models through POST https://litellm-domain/chat/completions, which succeeds and is billed correctly
3. They reload https://litellm-domain/ui/?page=models and the Costs column for that one model is now blank, while every model nobody called still shows its price
4. The blank never fills back in on its own, and the more models the team uses, the more of the page goes blank

After: the Costs column keeps showing prices for models that are in use

1. They open https://litellm-domain/ui/?page=models and see a price in the Costs column for every model
2. Their team sends the same request to the same model, which succeeds and is billed the same
3. They reload https://litellm-domain/ui/?page=models and that model still shows its price
4. Continued traffic does not blank the column, so the page reflects configuration rather than usage

## Relevant issues

Fixes #37637

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

`Deployment` normalises `model_info` through the `ModelInfo` model, which materialises every unset cost field as `None`, so a deployment that has served a request holds `input_cost_per_token: None` rather than no key at all. The enrichment pass filled only keys that were absent, so those nulls stayed forever.

Exercising the enrichment directly at 1132329245, once with the keys absent (a freshly reloaded deployment) and once with them null (a deployment that has served a request):

Before:

```
ABSENT keys  -> input_cost_per_token = 1e-06
None keys    -> input_cost_per_token = None      <- blank in the UI, permanently
```

After:

```
ABSENT keys  -> input_cost_per_token = 1e-06
None keys    -> input_cost_per_token = 1e-06
```

For a live check, start the proxy with two models, GET /v2/model/info and note both prices, send one POST /chat/completions to just one of them, then GET /v2/model/info again. On current staging the called model reports null prices while the untouched one keeps its own. With this change both keep their prices, and http://localhost:4000/ui/?page=models shows a populated Costs column for both

## Type

🐛 Bug Fix

## Caveats (if any)

- Reporting only, cost tracking was always correct
- `_get_proxy_model_info` has the same backfill shape, but its only caller passes `exclude_none=True`, so it cannot hit this today and is left alone to keep this change isolated
