### PR TITLE
test: assert the prefixed model the azure responses bridge now hands back

### DIFF
--- a/tests/llm_translation/test_azure_openai.py
+++ b/tests/llm_translation/test_azure_openai.py
@@ -650,7 +650,7 @@ def test_azure_openai_responses_bridge():
         mock_responses.assert_called_once()
         assert (
             mock_responses.call_args.kwargs["model"]
-            == "test-azure-computer-use-preview"
+            == "azure/test-azure-computer-use-preview"
         )
         assert mock_responses.call_args.kwargs["custom_llm_provider"] == "azure"
 


### PR DESCRIPTION
## TLDR

Problem this solves:

- `llm_translation_testing` is red on one azure test
- The bridge deliberately kept the provider prefix
- Two assertions still expected the bare model id
- #37744 fixed one of them, this is the other

How it solves it:

- Expect `azure/test-azure-computer-use-preview`, matching the bridge
- One expected value moves, nothing else

## User Flow

This PR touches a test file only, so no end user flow changes. What changes is the model id one assertion expects the chat-to-responses bridge to hand back

## Relevant issues

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

This is a test-only assertion change and the suite it lives in needs azure credentials that only CI holds, so CI is where both sides have to be captured

### Before (6eacdbfbf0)

#### ci/circleci: llm_translation_testing

1. `test_azure_openai_responses_bridge` fails at `tests/llm_translation/test_azure_openai.py:651`
2. `AssertionError: assert 'azure/test-azure-computer-use-preview' == 'test-azure-computer-use-preview'`
3. Captured on `litellm_internal_staging` at `cc812cdf`, an ancestor of this merge base that carries the identical assertion: https://app.circleci.com/workflow/e36bb1a2-ff9a-4587-ba96-7817672f1780
4. It is the only `test_azure_openai` failure in that job, so nothing else in the file is implicated

### After (461aa193d4)

#### ci/circleci: llm_translation_testing

Run triggered by the `run-ci` label on this commit: https://app.circleci.com/workflow/5f3ebfc8-bc03-4930-a2f2-3f04e4dc7b46

1. `test_azure_openai_responses_bridge` passes, so the assertion now matches what the bridge hands back
2. The job is still red, on 16 `TestTogetherAI` failures that have nothing to do with this change
3. Those are the same live together_ai calls #37746 repoints, and they fail here because this branch sits on the base that still names the retired model
4. So the two PRs are each red on what the other fixes, and this job goes green once #37746 lands and staging merges back in

## Type

✅ Test

## Caveats (if any)

- The bridge behaviour is correct already, only the assertion was stale
- `custom_llm_provider` assertion on the next line stays untouched
- Job stays red on together_ai until #37746 merges, unrelated to this change

