### PR TITLE
fix(fal_ai): price gpt-image-2 per size and quality from request params

### DIFF
--- a/litellm/litellm_core_utils/llm_cost_calc/utils.py
+++ b/litellm/litellm_core_utils/llm_cost_calc/utils.py
@@ -1371,6 +1371,7 @@ class CostCalculatorUtils:
             return fal_ai_image_cost_calculator(
                 model=model,
                 image_response=completion_response,
+                optional_params=optional_params,
             )
         elif custom_llm_provider == litellm.LlmProviders.RUNWAYML.value:
             from litellm.llms.runwayml.cost_calculator import (

--- a/litellm/llms/fal_ai/cost_calculator.py
+++ b/litellm/llms/fal_ai/cost_calculator.py
@@ -61,6 +61,8 @@ def cost_calculator(
     """
     if not isinstance(image_response, ImageResponse):
         raise ValueError(f"image_response must be of type ImageResponse got type={type(image_response)}")
+    # the proxy cost path passes the provider-prefixed model name
+    model = model.removeprefix(f"{litellm.LlmProviders.FAL_AI.value}/")
     num_images: Final[int] = len(image_response.data) if image_response.data else 0
     keyed_cost_per_image: Final = _keyed_cost_per_image(model=model, optional_params=optional_params)
     if keyed_cost_per_image is not None:

--- a/litellm/llms/fal_ai/cost_calculator.py
+++ b/litellm/llms/fal_ai/cost_calculator.py
@@ -1,25 +1,73 @@
-from typing import Any, Final
+from collections.abc import Mapping
+from types import MappingProxyType
+from typing import Final
 
 import litellm
 from litellm.types.utils import ImageResponse
 
+FAL_KEYED_PRICING_DEFAULT_QUALITY: Final[str] = "high"
+FAL_TEXT_TO_IMAGE_DEFAULT_SIZE: Final[str] = "1024-x-768"
+FAL_NAMED_IMAGE_SIZES: Final[Mapping[str, str]] = MappingProxyType(
+    {
+        "square_hd": "1024-x-1024",
+        "square": "512-x-512",
+        "portrait_4_3": "768-x-1024",
+        "portrait_16_9": "576-x-1024",
+        "landscape_4_3": "1024-x-768",
+        "landscape_16_9": "1024-x-576",
+    }
+)
+
+
+def _keyed_size(model: str, optional_params: Mapping[str, object]) -> str | None:
+    image_size: Final = optional_params.get("image_size")
+    if image_size is None:
+        return None if model.endswith("/edit") else FAL_TEXT_TO_IMAGE_DEFAULT_SIZE
+    if isinstance(image_size, Mapping):
+        width: Final = image_size.get("width")
+        height: Final = image_size.get("height")
+        if isinstance(width, int) and isinstance(height, int):
+            return f"{width}-x-{height}"
+        return None
+    if isinstance(image_size, str):
+        return FAL_NAMED_IMAGE_SIZES.get(image_size)
+    return None
+
+
+def _keyed_cost_per_image(model: str, optional_params: Mapping[str, object] | None) -> float | None:
+    if optional_params is None:
+        return None
+    size: Final = _keyed_size(model=model, optional_params=optional_params)
+    if size is None:
+        return None
+    raw_quality: Final = optional_params.get("quality")
+    quality: Final = (
+        raw_quality if isinstance(raw_quality, str) and raw_quality != "auto" else FAL_KEYED_PRICING_DEFAULT_QUALITY
+    )
+    keyed_entry: Final = litellm.model_cost.get(f"fal_ai/{quality}/{size}/{model}")
+    if keyed_entry is None:
+        return None
+    keyed_cost: Final = keyed_entry.get("output_cost_per_image")
+    return float(keyed_cost) if isinstance(keyed_cost, (int, float)) else None
+
 
 def cost_calculator(
     model: str,
-    image_response: Any,
+    image_response: object,
+    optional_params: Mapping[str, object] | None = None,
 ) -> float:
     """
     fal.ai image generation cost calculator
     """
+    if not isinstance(image_response, ImageResponse):
+        raise ValueError(f"image_response must be of type ImageResponse got type={type(image_response)}")
+    num_images: Final[int] = len(image_response.data) if image_response.data else 0
+    keyed_cost_per_image: Final = _keyed_cost_per_image(model=model, optional_params=optional_params)
+    if keyed_cost_per_image is not None:
+        return keyed_cost_per_image * num_images
     _model_info: Final = litellm.get_model_info(
         model=model,
         custom_llm_provider=litellm.LlmProviders.FAL_AI.value,
     )
     output_cost_per_image: Final[float] = _model_info.get("output_cost_per_image") or 0.0
-    num_images: int = 0
-    if isinstance(image_response, ImageResponse):
-        if image_response.data:
-            num_images = len(image_response.data)
-        return output_cost_per_image * num_images
-    else:
-        raise ValueError(f"image_response must be of type ImageResponse got type={type(image_response)}")
+    return output_cost_per_image * num_images

--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -17400,10 +17400,190 @@
     "fal_ai/openai/gpt-image-2": {
         "litellm_provider": "fal_ai",
         "metadata": {
-            "notes": "OpenAI gpt-image-2 served through fal.ai. fal bills by token, so the flat output_cost_per_image here is fal's published per-image rate for a default request (quality=high, image_size=landscape_4_3 at 1024x768). Other canonical sizes at high quality: 1024x1024 $0.211, 1024x1536 $0.165, 1920x1080 $0.158, 2560x1440 $0.222, 3840x2160 $0.401"
+            "notes": "OpenAI gpt-image-2 served through fal.ai. fal bills by token but publishes deterministic per-image prices per size and quality, mirrored here as keyed entries fal_ai/{quality}/{width}-x-{height}/openai/gpt-image-2 that litellm's fal_ai cost calculator picks from the request params. This flat entry is the fallback when no keyed entry matches and carries the default request rate (quality=high, image_size=landscape_4_3 at 1024x768). quality=auto is priced as high"
         },
         "mode": "image_generation",
         "output_cost_per_image": 0.145,
+        "source": "https://fal.ai/models/openai/gpt-image-2",
+        "supported_endpoints": [
+            "/v1/images/generations"
+        ],
+        "supports_vision": true
+    },
+    "fal_ai/low/1024-x-768/openai/gpt-image-2": {
+        "litellm_provider": "fal_ai",
+        "mode": "image_generation",
+        "output_cost_per_image": 0.005,
+        "source": "https://fal.ai/models/openai/gpt-image-2",
+        "supported_endpoints": [
+            "/v1/images/generations"
+        ],
+        "supports_vision": true
+    },
+    "fal_ai/low/1024-x-1024/openai/gpt-image-2": {
+        "litellm_provider": "fal_ai",
+        "mode": "image_generation",
+        "output_cost_per_image": 0.006,
+        "source": "https://fal.ai/models/openai/gpt-image-2",
+        "supported_endpoints": [
+            "/v1/images/generations"
+        ],
+        "supports_vision": true
+    },
+    "fal_ai/low/1024-x-1536/openai/gpt-image-2": {
+        "litellm_provider": "fal_ai",
+        "mode": "image_generation",
+        "output_cost_per_image": 0.005,
+        "source": "https://fal.ai/models/openai/gpt-image-2",
+        "supported_endpoints": [
+            "/v1/images/generations"
+        ],
+        "supports_vision": true
+    },
+    "fal_ai/low/1920-x-1080/openai/gpt-image-2": {
+        "litellm_provider": "fal_ai",
+        "mode": "image_generation",
+        "output_cost_per_image": 0.005,
+        "source": "https://fal.ai/models/openai/gpt-image-2",
+        "supported_endpoints": [
+            "/v1/images/generations"
+        ],
+        "supports_vision": true
+    },
+    "fal_ai/low/2560-x-1440/openai/gpt-image-2": {
+        "litellm_provider": "fal_ai",
+        "mode": "image_generation",
+        "output_cost_per_image": 0.007,
+        "source": "https://fal.ai/models/openai/gpt-image-2",
+        "supported_endpoints": [
+            "/v1/images/generations"
+        ],
+        "supports_vision": true
+    },
+    "fal_ai/low/3840-x-2160/openai/gpt-image-2": {
+        "litellm_provider": "fal_ai",
+        "mode": "image_generation",
+        "output_cost_per_image": 0.012,
+        "source": "https://fal.ai/models/openai/gpt-image-2",
+        "supported_endpoints": [
+            "/v1/images/generations"
+        ],
+        "supports_vision": true
+    },
+    "fal_ai/medium/1024-x-768/openai/gpt-image-2": {
+        "litellm_provider": "fal_ai",
+        "mode": "image_generation",
+        "output_cost_per_image": 0.037,
+        "source": "https://fal.ai/models/openai/gpt-image-2",
+        "supported_endpoints": [
+            "/v1/images/generations"
+        ],
+        "supports_vision": true
+    },
+    "fal_ai/medium/1024-x-1024/openai/gpt-image-2": {
+        "litellm_provider": "fal_ai",
+        "mode": "image_generation",
+        "output_cost_per_image": 0.053,
+        "source": "https://fal.ai/models/openai/gpt-image-2",
+        "supported_endpoints": [
+            "/v1/images/generations"
+        ],
+        "supports_vision": true
+    },
+    "fal_ai/medium/1024-x-1536/openai/gpt-image-2": {
+        "litellm_provider": "fal_ai",
+        "mode": "image_generation",
+        "output_cost_per_image": 0.042,
+        "source": "https://fal.ai/models/openai/gpt-image-2",
+        "supported_endpoints": [
+            "/v1/images/generations"
+        ],
+        "supports_vision": true
+    },
+    "fal_ai/medium/1920-x-1080/openai/gpt-image-2": {
+        "litellm_provider": "fal_ai",
+        "mode": "image_generation",
+        "output_cost_per_image": 0.04,
+        "source": "https://fal.ai/models/openai/gpt-image-2",
+        "supported_endpoints": [
+            "/v1/images/generations"
+        ],
+        "supports_vision": true
+    },
+    "fal_ai/medium/2560-x-1440/openai/gpt-image-2": {
+        "litellm_provider": "fal_ai",
+        "mode": "image_generation",
+        "output_cost_per_image": 0.056,
+        "source": "https://fal.ai/models/openai/gpt-image-2",
+        "supported_endpoints": [
+            "/v1/images/generations"
+        ],
+        "supports_vision": true
+    },
+    "fal_ai/medium/3840-x-2160/openai/gpt-image-2": {
+        "litellm_provider": "fal_ai",
+        "mode": "image_generation",
+        "output_cost_per_image": 0.101,
+        "source": "https://fal.ai/models/openai/gpt-image-2",
+        "supported_endpoints": [
+            "/v1/images/generations"
+        ],
+        "supports_vision": true
+    },
+    "fal_ai/high/1024-x-768/openai/gpt-image-2": {
+        "litellm_provider": "fal_ai",
+        "mode": "image_generation",
+        "output_cost_per_image": 0.145,
+        "source": "https://fal.ai/models/openai/gpt-image-2",
+        "supported_endpoints": [
+            "/v1/images/generations"
+        ],
+        "supports_vision": true
+    },
+    "fal_ai/high/1024-x-1024/openai/gpt-image-2": {
+        "litellm_provider": "fal_ai",
+        "mode": "image_generation",
+        "output_cost_per_image": 0.211,
+        "source": "https://fal.ai/models/openai/gpt-image-2",
+        "supported_endpoints": [
+            "/v1/images/generations"
+        ],
+        "supports_vision": true
+    },
+    "fal_ai/high/1024-x-1536/openai/gpt-image-2": {
+        "litellm_provider": "fal_ai",
+        "mode": "image_generation",
+        "output_cost_per_image": 0.165,
+        "source": "https://fal.ai/models/openai/gpt-image-2",
+        "supported_endpoints": [
+            "/v1/images/generations"
+        ],
+        "supports_vision": true
+    },
+    "fal_ai/high/1920-x-1080/openai/gpt-image-2": {
+        "litellm_provider": "fal_ai",
+        "mode": "image_generation",
+        "output_cost_per_image": 0.158,
+        "source": "https://fal.ai/models/openai/gpt-image-2",
+        "supported_endpoints": [
+            "/v1/images/generations"
+        ],
+        "supports_vision": true
+    },
+    "fal_ai/high/2560-x-1440/openai/gpt-image-2": {
+        "litellm_provider": "fal_ai",
+        "mode": "image_generation",
+        "output_cost_per_image": 0.222,
+        "source": "https://fal.ai/models/openai/gpt-image-2",
+        "supported_endpoints": [
+            "/v1/images/generations"
+        ],
+        "supports_vision": true
+    },
+    "fal_ai/high/3840-x-2160/openai/gpt-image-2": {
+        "litellm_provider": "fal_ai",
+        "mode": "image_generation",
+        "output_cost_per_image": 0.401,
         "source": "https://fal.ai/models/openai/gpt-image-2",
         "supported_endpoints": [
             "/v1/images/generations"
@@ -17413,7 +17593,7 @@
     "fal_ai/gpt-image-2": {
         "litellm_provider": "fal_ai",
         "metadata": {
-            "notes": "Alias of fal_ai/openai/gpt-image-2, which litellm also accepts without the openai/ prefix. Same rate, see that entry for the size and quality caveat"
+            "notes": "Alias of fal_ai/openai/gpt-image-2, which litellm also accepts without the openai/ prefix. Same rates, including the keyed fal_ai/{quality}/{width}-x-{height}/gpt-image-2 entries; see that entry for details"
         },
         "mode": "image_generation",
         "output_cost_per_image": 0.145,
@@ -17423,13 +17603,373 @@
         ],
         "supports_vision": true
     },
+    "fal_ai/low/1024-x-768/gpt-image-2": {
+        "litellm_provider": "fal_ai",
+        "mode": "image_generation",
+        "output_cost_per_image": 0.005,
+        "source": "https://fal.ai/models/openai/gpt-image-2",
+        "supported_endpoints": [
+            "/v1/images/generations"
+        ],
+        "supports_vision": true
+    },
+    "fal_ai/low/1024-x-1024/gpt-image-2": {
+        "litellm_provider": "fal_ai",
+        "mode": "image_generation",
+        "output_cost_per_image": 0.006,
+        "source": "https://fal.ai/models/openai/gpt-image-2",
+        "supported_endpoints": [
+            "/v1/images/generations"
+        ],
+        "supports_vision": true
+    },
+    "fal_ai/low/1024-x-1536/gpt-image-2": {
+        "litellm_provider": "fal_ai",
+        "mode": "image_generation",
+        "output_cost_per_image": 0.005,
+        "source": "https://fal.ai/models/openai/gpt-image-2",
+        "supported_endpoints": [
+            "/v1/images/generations"
+        ],
+        "supports_vision": true
+    },
+    "fal_ai/low/1920-x-1080/gpt-image-2": {
+        "litellm_provider": "fal_ai",
+        "mode": "image_generation",
+        "output_cost_per_image": 0.005,
+        "source": "https://fal.ai/models/openai/gpt-image-2",
+        "supported_endpoints": [
+            "/v1/images/generations"
+        ],
+        "supports_vision": true
+    },
+    "fal_ai/low/2560-x-1440/gpt-image-2": {
+        "litellm_provider": "fal_ai",
+        "mode": "image_generation",
+        "output_cost_per_image": 0.007,
+        "source": "https://fal.ai/models/openai/gpt-image-2",
+        "supported_endpoints": [
+            "/v1/images/generations"
+        ],
+        "supports_vision": true
+    },
+    "fal_ai/low/3840-x-2160/gpt-image-2": {
+        "litellm_provider": "fal_ai",
+        "mode": "image_generation",
+        "output_cost_per_image": 0.012,
+        "source": "https://fal.ai/models/openai/gpt-image-2",
+        "supported_endpoints": [
+            "/v1/images/generations"
+        ],
+        "supports_vision": true
+    },
+    "fal_ai/medium/1024-x-768/gpt-image-2": {
+        "litellm_provider": "fal_ai",
+        "mode": "image_generation",
+        "output_cost_per_image": 0.037,
+        "source": "https://fal.ai/models/openai/gpt-image-2",
+        "supported_endpoints": [
+            "/v1/images/generations"
+        ],
+        "supports_vision": true
+    },
+    "fal_ai/medium/1024-x-1024/gpt-image-2": {
+        "litellm_provider": "fal_ai",
+        "mode": "image_generation",
+        "output_cost_per_image": 0.053,
+        "source": "https://fal.ai/models/openai/gpt-image-2",
+        "supported_endpoints": [
+            "/v1/images/generations"
+        ],
+        "supports_vision": true
+    },
+    "fal_ai/medium/1024-x-1536/gpt-image-2": {
+        "litellm_provider": "fal_ai",
+        "mode": "image_generation",
+        "output_cost_per_image": 0.042,
+        "source": "https://fal.ai/models/openai/gpt-image-2",
+        "supported_endpoints": [
+            "/v1/images/generations"
+        ],
+        "supports_vision": true
+    },
+    "fal_ai/medium/1920-x-1080/gpt-image-2": {
+        "litellm_provider": "fal_ai",
+        "mode": "image_generation",
+        "output_cost_per_image": 0.04,
+        "source": "https://fal.ai/models/openai/gpt-image-2",
+        "supported_endpoints": [
+            "/v1/images/generations"
+        ],
+        "supports_vision": true
+    },
+    "fal_ai/medium/2560-x-1440/gpt-image-2": {
+        "litellm_provider": "fal_ai",
+        "mode": "image_generation",
+        "output_cost_per_image": 0.056,
+        "source": "https://fal.ai/models/openai/gpt-image-2",
+        "supported_endpoints": [
+            "/v1/images/generations"
+        ],
+        "supports_vision": true
+    },
+    "fal_ai/medium/3840-x-2160/gpt-image-2": {
+        "litellm_provider": "fal_ai",
+        "mode": "image_generation",
+        "output_cost_per_image": 0.101,
+        "source": "https://fal.ai/models/openai/gpt-image-2",
+        "supported_endpoints": [
+            "/v1/images/generations"
+        ],
+        "supports_vision": true
+    },
+    "fal_ai/high/1024-x-768/gpt-image-2": {
+        "litellm_provider": "fal_ai",
+        "mode": "image_generation",
+        "output_cost_per_image": 0.145,
+        "source": "https://fal.ai/models/openai/gpt-image-2",
+        "supported_endpoints": [
+            "/v1/images/generations"
+        ],
+        "supports_vision": true
+    },
+    "fal_ai/high/1024-x-1024/gpt-image-2": {
+        "litellm_provider": "fal_ai",
+        "mode": "image_generation",
+        "output_cost_per_image": 0.211,
+        "source": "https://fal.ai/models/openai/gpt-image-2",
+        "supported_endpoints": [
+            "/v1/images/generations"
+        ],
+        "supports_vision": true
+    },
+    "fal_ai/high/1024-x-1536/gpt-image-2": {
+        "litellm_provider": "fal_ai",
+        "mode": "image_generation",
+        "output_cost_per_image": 0.165,
+        "source": "https://fal.ai/models/openai/gpt-image-2",
+        "supported_endpoints": [
+            "/v1/images/generations"
+        ],
+        "supports_vision": true
+    },
+    "fal_ai/high/1920-x-1080/gpt-image-2": {
+        "litellm_provider": "fal_ai",
+        "mode": "image_generation",
+        "output_cost_per_image": 0.158,
+        "source": "https://fal.ai/models/openai/gpt-image-2",
+        "supported_endpoints": [
+            "/v1/images/generations"
+        ],
+        "supports_vision": true
+    },
+    "fal_ai/high/2560-x-1440/gpt-image-2": {
+        "litellm_provider": "fal_ai",
+        "mode": "image_generation",
+        "output_cost_per_image": 0.222,
+        "source": "https://fal.ai/models/openai/gpt-image-2",
+        "supported_endpoints": [
+            "/v1/images/generations"
+        ],
+        "supports_vision": true
+    },
+    "fal_ai/high/3840-x-2160/gpt-image-2": {
+        "litellm_provider": "fal_ai",
+        "mode": "image_generation",
+        "output_cost_per_image": 0.401,
+        "source": "https://fal.ai/models/openai/gpt-image-2",
+        "supported_endpoints": [
+            "/v1/images/generations"
+        ],
+        "supports_vision": true
+    },
     "fal_ai/openai/gpt-image-2/edit": {
         "litellm_provider": "fal_ai",
         "metadata": {
-            "notes": "Editing endpoint of gpt-image-2 on fal.ai, reached through the image generation path with fal's image_urls param since /v1/images/edits is not wired for fal_ai. Same rate as fal_ai/openai/gpt-image-2, see that entry for the size and quality caveat"
+            "notes": "Editing endpoint of gpt-image-2 on fal.ai, reached through the image generation path with fal's image_urls param since /v1/images/edits is not wired for fal_ai. Prices include one input image and live in keyed entries fal_ai/{quality}/{width}-x-{height}/openai/gpt-image-2/edit. This flat entry is the fallback for the default edit request (quality=high, image_size=auto, inferred from the input image, priced as 1024x768 high)"
         },
         "mode": "image_generation",
-        "output_cost_per_image": 0.145,
+        "output_cost_per_image": 0.151,
+        "source": "https://fal.ai/models/openai/gpt-image-2/edit",
+        "supported_endpoints": [
+            "/v1/images/generations"
+        ],
+        "supports_vision": true
+    },
+    "fal_ai/low/1024-x-768/openai/gpt-image-2/edit": {
+        "litellm_provider": "fal_ai",
+        "mode": "image_generation",
+        "output_cost_per_image": 0.011,
+        "source": "https://fal.ai/models/openai/gpt-image-2/edit",
+        "supported_endpoints": [
+            "/v1/images/generations"
+        ],
+        "supports_vision": true
+    },
+    "fal_ai/low/1024-x-1024/openai/gpt-image-2/edit": {
+        "litellm_provider": "fal_ai",
+        "mode": "image_generation",
+        "output_cost_per_image": 0.015,
+        "source": "https://fal.ai/models/openai/gpt-image-2/edit",
+        "supported_endpoints": [
+            "/v1/images/generations"
+        ],
+        "supports_vision": true
+    },
+    "fal_ai/low/1024-x-1536/openai/gpt-image-2/edit": {
+        "litellm_provider": "fal_ai",
+        "mode": "image_generation",
+        "output_cost_per_image": 0.018,
+        "source": "https://fal.ai/models/openai/gpt-image-2/edit",
+        "supported_endpoints": [
+            "/v1/images/generations"
+        ],
+        "supports_vision": true
+    },
+    "fal_ai/low/1920-x-1080/openai/gpt-image-2/edit": {
+        "litellm_provider": "fal_ai",
+        "mode": "image_generation",
+        "output_cost_per_image": 0.017,
+        "source": "https://fal.ai/models/openai/gpt-image-2/edit",
+        "supported_endpoints": [
+            "/v1/images/generations"
+        ],
+        "supports_vision": true
+    },
+    "fal_ai/low/2560-x-1440/openai/gpt-image-2/edit": {
+        "litellm_provider": "fal_ai",
+        "mode": "image_generation",
+        "output_cost_per_image": 0.019,
+        "source": "https://fal.ai/models/openai/gpt-image-2/edit",
+        "supported_endpoints": [
+            "/v1/images/generations"
+        ],
+        "supports_vision": true
+    },
+    "fal_ai/low/3840-x-2160/openai/gpt-image-2/edit": {
+        "litellm_provider": "fal_ai",
+        "mode": "image_generation",
+        "output_cost_per_image": 0.024,
+        "source": "https://fal.ai/models/openai/gpt-image-2/edit",
+        "supported_endpoints": [
+            "/v1/images/generations"
+        ],
+        "supports_vision": true
+    },
+    "fal_ai/medium/1024-x-768/openai/gpt-image-2/edit": {
+        "litellm_provider": "fal_ai",
+        "mode": "image_generation",
+        "output_cost_per_image": 0.043,
+        "source": "https://fal.ai/models/openai/gpt-image-2/edit",
+        "supported_endpoints": [
+            "/v1/images/generations"
+        ],
+        "supports_vision": true
+    },
+    "fal_ai/medium/1024-x-1024/openai/gpt-image-2/edit": {
+        "litellm_provider": "fal_ai",
+        "mode": "image_generation",
+        "output_cost_per_image": 0.061,
+        "source": "https://fal.ai/models/openai/gpt-image-2/edit",
+        "supported_endpoints": [
+            "/v1/images/generations"
+        ],
+        "supports_vision": true
+    },
+    "fal_ai/medium/1024-x-1536/openai/gpt-image-2/edit": {
+        "litellm_provider": "fal_ai",
+        "mode": "image_generation",
+        "output_cost_per_image": 0.054,
+        "source": "https://fal.ai/models/openai/gpt-image-2/edit",
+        "supported_endpoints": [
+            "/v1/images/generations"
+        ],
+        "supports_vision": true
+    },
+    "fal_ai/medium/1920-x-1080/openai/gpt-image-2/edit": {
+        "litellm_provider": "fal_ai",
+        "mode": "image_generation",
+        "output_cost_per_image": 0.053,
+        "source": "https://fal.ai/models/openai/gpt-image-2/edit",
+        "supported_endpoints": [
+            "/v1/images/generations"
+        ],
+        "supports_vision": true
+    },
+    "fal_ai/medium/2560-x-1440/openai/gpt-image-2/edit": {
+        "litellm_provider": "fal_ai",
+        "mode": "image_generation",
+        "output_cost_per_image": 0.068,
+        "source": "https://fal.ai/models/openai/gpt-image-2/edit",
+        "supported_endpoints": [
+            "/v1/images/generations"
+        ],
+        "supports_vision": true
+    },
+    "fal_ai/medium/3840-x-2160/openai/gpt-image-2/edit": {
+        "litellm_provider": "fal_ai",
+        "mode": "image_generation",
+        "output_cost_per_image": 0.113,
+        "source": "https://fal.ai/models/openai/gpt-image-2/edit",
+        "supported_endpoints": [
+            "/v1/images/generations"
+        ],
+        "supports_vision": true
+    },
+    "fal_ai/high/1024-x-768/openai/gpt-image-2/edit": {
+        "litellm_provider": "fal_ai",
+        "mode": "image_generation",
+        "output_cost_per_image": 0.151,
+        "source": "https://fal.ai/models/openai/gpt-image-2/edit",
+        "supported_endpoints": [
+            "/v1/images/generations"
+        ],
+        "supports_vision": true
+    },
+    "fal_ai/high/1024-x-1024/openai/gpt-image-2/edit": {
+        "litellm_provider": "fal_ai",
+        "mode": "image_generation",
+        "output_cost_per_image": 0.219,
+        "source": "https://fal.ai/models/openai/gpt-image-2/edit",
+        "supported_endpoints": [
+            "/v1/images/generations"
+        ],
+        "supports_vision": true
+    },
+    "fal_ai/high/1024-x-1536/openai/gpt-image-2/edit": {
+        "litellm_provider": "fal_ai",
+        "mode": "image_generation",
+        "output_cost_per_image": 0.178,
+        "source": "https://fal.ai/models/openai/gpt-image-2/edit",
+        "supported_endpoints": [
+            "/v1/images/generations"
+        ],
+        "supports_vision": true
+    },
+    "fal_ai/high/1920-x-1080/openai/gpt-image-2/edit": {
+        "litellm_provider": "fal_ai",
+        "mode": "image_generation",
+        "output_cost_per_image": 0.158,
+        "source": "https://fal.ai/models/openai/gpt-image-2/edit",
+        "supported_endpoints": [
+            "/v1/images/generations"
+        ],
+        "supports_vision": true
+    },
+    "fal_ai/high/2560-x-1440/openai/gpt-image-2/edit": {
+        "litellm_provider": "fal_ai",
+        "mode": "image_generation",
+        "output_cost_per_image": 0.234,
+        "source": "https://fal.ai/models/openai/gpt-image-2/edit",
+        "supported_endpoints": [
+            "/v1/images/generations"
+        ],
+        "supports_vision": true
+    },
+    "fal_ai/high/3840-x-2160/openai/gpt-image-2/edit": {
+        "litellm_provider": "fal_ai",
+        "mode": "image_generation",
+        "output_cost_per_image": 0.413,
         "source": "https://fal.ai/models/openai/gpt-image-2/edit",
         "supported_endpoints": [
             "/v1/images/generations"

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -17400,10 +17400,190 @@
     "fal_ai/openai/gpt-image-2": {
         "litellm_provider": "fal_ai",
         "metadata": {
-            "notes": "OpenAI gpt-image-2 served through fal.ai. fal bills by token, so the flat output_cost_per_image here is fal's published per-image rate for a default request (quality=high, image_size=landscape_4_3 at 1024x768). Other canonical sizes at high quality: 1024x1024 $0.211, 1024x1536 $0.165, 1920x1080 $0.158, 2560x1440 $0.222, 3840x2160 $0.401"
+            "notes": "OpenAI gpt-image-2 served through fal.ai. fal bills by token but publishes deterministic per-image prices per size and quality, mirrored here as keyed entries fal_ai/{quality}/{width}-x-{height}/openai/gpt-image-2 that litellm's fal_ai cost calculator picks from the request params. This flat entry is the fallback when no keyed entry matches and carries the default request rate (quality=high, image_size=landscape_4_3 at 1024x768). quality=auto is priced as high"
         },
         "mode": "image_generation",
         "output_cost_per_image": 0.145,
+        "source": "https://fal.ai/models/openai/gpt-image-2",
+        "supported_endpoints": [
+            "/v1/images/generations"
+        ],
+        "supports_vision": true
+    },
+    "fal_ai/low/1024-x-768/openai/gpt-image-2": {
+        "litellm_provider": "fal_ai",
+        "mode": "image_generation",
+        "output_cost_per_image": 0.005,
+        "source": "https://fal.ai/models/openai/gpt-image-2",
+        "supported_endpoints": [
+            "/v1/images/generations"
+        ],
+        "supports_vision": true
+    },
+    "fal_ai/low/1024-x-1024/openai/gpt-image-2": {
+        "litellm_provider": "fal_ai",
+        "mode": "image_generation",
+        "output_cost_per_image": 0.006,
+        "source": "https://fal.ai/models/openai/gpt-image-2",
+        "supported_endpoints": [
+            "/v1/images/generations"
+        ],
+        "supports_vision": true
+    },
+    "fal_ai/low/1024-x-1536/openai/gpt-image-2": {
+        "litellm_provider": "fal_ai",
+        "mode": "image_generation",
+        "output_cost_per_image": 0.005,
+        "source": "https://fal.ai/models/openai/gpt-image-2",
+        "supported_endpoints": [
+            "/v1/images/generations"
+        ],
+        "supports_vision": true
+    },
+    "fal_ai/low/1920-x-1080/openai/gpt-image-2": {
+        "litellm_provider": "fal_ai",
+        "mode": "image_generation",
+        "output_cost_per_image": 0.005,
+        "source": "https://fal.ai/models/openai/gpt-image-2",
+        "supported_endpoints": [
+            "/v1/images/generations"
+        ],
+        "supports_vision": true
+    },
+    "fal_ai/low/2560-x-1440/openai/gpt-image-2": {
+        "litellm_provider": "fal_ai",
+        "mode": "image_generation",
+        "output_cost_per_image": 0.007,
+        "source": "https://fal.ai/models/openai/gpt-image-2",
+        "supported_endpoints": [
+            "/v1/images/generations"
+        ],
+        "supports_vision": true
+    },
+    "fal_ai/low/3840-x-2160/openai/gpt-image-2": {
+        "litellm_provider": "fal_ai",
+        "mode": "image_generation",
+        "output_cost_per_image": 0.012,
+        "source": "https://fal.ai/models/openai/gpt-image-2",
+        "supported_endpoints": [
+            "/v1/images/generations"
+        ],
+        "supports_vision": true
+    },
+    "fal_ai/medium/1024-x-768/openai/gpt-image-2": {
+        "litellm_provider": "fal_ai",
+        "mode": "image_generation",
+        "output_cost_per_image": 0.037,
+        "source": "https://fal.ai/models/openai/gpt-image-2",
+        "supported_endpoints": [
+            "/v1/images/generations"
+        ],
+        "supports_vision": true
+    },
+    "fal_ai/medium/1024-x-1024/openai/gpt-image-2": {
+        "litellm_provider": "fal_ai",
+        "mode": "image_generation",
+        "output_cost_per_image": 0.053,
+        "source": "https://fal.ai/models/openai/gpt-image-2",
+        "supported_endpoints": [
+            "/v1/images/generations"
+        ],
+        "supports_vision": true
+    },
+    "fal_ai/medium/1024-x-1536/openai/gpt-image-2": {
+        "litellm_provider": "fal_ai",
+        "mode": "image_generation",
+        "output_cost_per_image": 0.042,
+        "source": "https://fal.ai/models/openai/gpt-image-2",
+        "supported_endpoints": [
+            "/v1/images/generations"
+        ],
+        "supports_vision": true
+    },
+    "fal_ai/medium/1920-x-1080/openai/gpt-image-2": {
+        "litellm_provider": "fal_ai",
+        "mode": "image_generation",
+        "output_cost_per_image": 0.04,
+        "source": "https://fal.ai/models/openai/gpt-image-2",
+        "supported_endpoints": [
+            "/v1/images/generations"
+        ],
+        "supports_vision": true
+    },
+    "fal_ai/medium/2560-x-1440/openai/gpt-image-2": {
+        "litellm_provider": "fal_ai",
+        "mode": "image_generation",
+        "output_cost_per_image": 0.056,
+        "source": "https://fal.ai/models/openai/gpt-image-2",
+        "supported_endpoints": [
+            "/v1/images/generations"
+        ],
+        "supports_vision": true
+    },
+    "fal_ai/medium/3840-x-2160/openai/gpt-image-2": {
+        "litellm_provider": "fal_ai",
+        "mode": "image_generation",
+        "output_cost_per_image": 0.101,
+        "source": "https://fal.ai/models/openai/gpt-image-2",
+        "supported_endpoints": [
+            "/v1/images/generations"
+        ],
+        "supports_vision": true
+    },
+    "fal_ai/high/1024-x-768/openai/gpt-image-2": {
+        "litellm_provider": "fal_ai",
+        "mode": "image_generation",
+        "output_cost_per_image": 0.145,
+        "source": "https://fal.ai/models/openai/gpt-image-2",
+        "supported_endpoints": [
+            "/v1/images/generations"
+        ],
+        "supports_vision": true
+    },
+    "fal_ai/high/1024-x-1024/openai/gpt-image-2": {
+        "litellm_provider": "fal_ai",
+        "mode": "image_generation",
+        "output_cost_per_image": 0.211,
+        "source": "https://fal.ai/models/openai/gpt-image-2",
+        "supported_endpoints": [
+            "/v1/images/generations"
+        ],
+        "supports_vision": true
+    },
+    "fal_ai/high/1024-x-1536/openai/gpt-image-2": {
+        "litellm_provider": "fal_ai",
+        "mode": "image_generation",
+        "output_cost_per_image": 0.165,
+        "source": "https://fal.ai/models/openai/gpt-image-2",
+        "supported_endpoints": [
+            "/v1/images/generations"
+        ],
+        "supports_vision": true
+    },
+    "fal_ai/high/1920-x-1080/openai/gpt-image-2": {
+        "litellm_provider": "fal_ai",
+        "mode": "image_generation",
+        "output_cost_per_image": 0.158,
+        "source": "https://fal.ai/models/openai/gpt-image-2",
+        "supported_endpoints": [
+            "/v1/images/generations"
+        ],
+        "supports_vision": true
+    },
+    "fal_ai/high/2560-x-1440/openai/gpt-image-2": {
+        "litellm_provider": "fal_ai",
+        "mode": "image_generation",
+        "output_cost_per_image": 0.222,
+        "source": "https://fal.ai/models/openai/gpt-image-2",
+        "supported_endpoints": [
+            "/v1/images/generations"
+        ],
+        "supports_vision": true
+    },
+    "fal_ai/high/3840-x-2160/openai/gpt-image-2": {
+        "litellm_provider": "fal_ai",
+        "mode": "image_generation",
+        "output_cost_per_image": 0.401,
         "source": "https://fal.ai/models/openai/gpt-image-2",
         "supported_endpoints": [
             "/v1/images/generations"
@@ -17413,7 +17593,7 @@
     "fal_ai/gpt-image-2": {
         "litellm_provider": "fal_ai",
         "metadata": {
-            "notes": "Alias of fal_ai/openai/gpt-image-2, which litellm also accepts without the openai/ prefix. Same rate, see that entry for the size and quality caveat"
+            "notes": "Alias of fal_ai/openai/gpt-image-2, which litellm also accepts without the openai/ prefix. Same rates, including the keyed fal_ai/{quality}/{width}-x-{height}/gpt-image-2 entries; see that entry for details"
         },
         "mode": "image_generation",
         "output_cost_per_image": 0.145,
@@ -17423,13 +17603,373 @@
         ],
         "supports_vision": true
     },
+    "fal_ai/low/1024-x-768/gpt-image-2": {
+        "litellm_provider": "fal_ai",
+        "mode": "image_generation",
+        "output_cost_per_image": 0.005,
+        "source": "https://fal.ai/models/openai/gpt-image-2",
+        "supported_endpoints": [
+            "/v1/images/generations"
+        ],
+        "supports_vision": true
+    },
+    "fal_ai/low/1024-x-1024/gpt-image-2": {
+        "litellm_provider": "fal_ai",
+        "mode": "image_generation",
+        "output_cost_per_image": 0.006,
+        "source": "https://fal.ai/models/openai/gpt-image-2",
+        "supported_endpoints": [
+            "/v1/images/generations"
+        ],
+        "supports_vision": true
+    },
+    "fal_ai/low/1024-x-1536/gpt-image-2": {
+        "litellm_provider": "fal_ai",
+        "mode": "image_generation",
+        "output_cost_per_image": 0.005,
+        "source": "https://fal.ai/models/openai/gpt-image-2",
+        "supported_endpoints": [
+            "/v1/images/generations"
+        ],
+        "supports_vision": true
+    },
+    "fal_ai/low/1920-x-1080/gpt-image-2": {
+        "litellm_provider": "fal_ai",
+        "mode": "image_generation",
+        "output_cost_per_image": 0.005,
+        "source": "https://fal.ai/models/openai/gpt-image-2",
+        "supported_endpoints": [
+            "/v1/images/generations"
+        ],
+        "supports_vision": true
+    },
+    "fal_ai/low/2560-x-1440/gpt-image-2": {
+        "litellm_provider": "fal_ai",
+        "mode": "image_generation",
+        "output_cost_per_image": 0.007,
+        "source": "https://fal.ai/models/openai/gpt-image-2",
+        "supported_endpoints": [
+            "/v1/images/generations"
+        ],
+        "supports_vision": true
+    },
+    "fal_ai/low/3840-x-2160/gpt-image-2": {
+        "litellm_provider": "fal_ai",
+        "mode": "image_generation",
+        "output_cost_per_image": 0.012,
+        "source": "https://fal.ai/models/openai/gpt-image-2",
+        "supported_endpoints": [
+            "/v1/images/generations"
+        ],
+        "supports_vision": true
+    },
+    "fal_ai/medium/1024-x-768/gpt-image-2": {
+        "litellm_provider": "fal_ai",
+        "mode": "image_generation",
+        "output_cost_per_image": 0.037,
+        "source": "https://fal.ai/models/openai/gpt-image-2",
+        "supported_endpoints": [
+            "/v1/images/generations"
+        ],
+        "supports_vision": true
+    },
+    "fal_ai/medium/1024-x-1024/gpt-image-2": {
+        "litellm_provider": "fal_ai",
+        "mode": "image_generation",
+        "output_cost_per_image": 0.053,
+        "source": "https://fal.ai/models/openai/gpt-image-2",
+        "supported_endpoints": [
+            "/v1/images/generations"
+        ],
+        "supports_vision": true
+    },
+    "fal_ai/medium/1024-x-1536/gpt-image-2": {
+        "litellm_provider": "fal_ai",
+        "mode": "image_generation",
+        "output_cost_per_image": 0.042,
+        "source": "https://fal.ai/models/openai/gpt-image-2",
+        "supported_endpoints": [
+            "/v1/images/generations"
+        ],
+        "supports_vision": true
+    },
+    "fal_ai/medium/1920-x-1080/gpt-image-2": {
+        "litellm_provider": "fal_ai",
+        "mode": "image_generation",
+        "output_cost_per_image": 0.04,
+        "source": "https://fal.ai/models/openai/gpt-image-2",
+        "supported_endpoints": [
+            "/v1/images/generations"
+        ],
+        "supports_vision": true
+    },
+    "fal_ai/medium/2560-x-1440/gpt-image-2": {
+        "litellm_provider": "fal_ai",
+        "mode": "image_generation",
+        "output_cost_per_image": 0.056,
+        "source": "https://fal.ai/models/openai/gpt-image-2",
+        "supported_endpoints": [
+            "/v1/images/generations"
+        ],
+        "supports_vision": true
+    },
+    "fal_ai/medium/3840-x-2160/gpt-image-2": {
+        "litellm_provider": "fal_ai",
+        "mode": "image_generation",
+        "output_cost_per_image": 0.101,
+        "source": "https://fal.ai/models/openai/gpt-image-2",
+        "supported_endpoints": [
+            "/v1/images/generations"
+        ],
+        "supports_vision": true
+    },
+    "fal_ai/high/1024-x-768/gpt-image-2": {
+        "litellm_provider": "fal_ai",
+        "mode": "image_generation",
+        "output_cost_per_image": 0.145,
+        "source": "https://fal.ai/models/openai/gpt-image-2",
+        "supported_endpoints": [
+            "/v1/images/generations"
+        ],
+        "supports_vision": true
+    },
+    "fal_ai/high/1024-x-1024/gpt-image-2": {
+        "litellm_provider": "fal_ai",
+        "mode": "image_generation",
+        "output_cost_per_image": 0.211,
+        "source": "https://fal.ai/models/openai/gpt-image-2",
+        "supported_endpoints": [
+            "/v1/images/generations"
+        ],
+        "supports_vision": true
+    },
+    "fal_ai/high/1024-x-1536/gpt-image-2": {
+        "litellm_provider": "fal_ai",
+        "mode": "image_generation",
+        "output_cost_per_image": 0.165,
+        "source": "https://fal.ai/models/openai/gpt-image-2",
+        "supported_endpoints": [
+            "/v1/images/generations"
+        ],
+        "supports_vision": true
+    },
+    "fal_ai/high/1920-x-1080/gpt-image-2": {
+        "litellm_provider": "fal_ai",
+        "mode": "image_generation",
+        "output_cost_per_image": 0.158,
+        "source": "https://fal.ai/models/openai/gpt-image-2",
+        "supported_endpoints": [
+            "/v1/images/generations"
+        ],
+        "supports_vision": true
+    },
+    "fal_ai/high/2560-x-1440/gpt-image-2": {
+        "litellm_provider": "fal_ai",
+        "mode": "image_generation",
+        "output_cost_per_image": 0.222,
+        "source": "https://fal.ai/models/openai/gpt-image-2",
+        "supported_endpoints": [
+            "/v1/images/generations"
+        ],
+        "supports_vision": true
+    },
+    "fal_ai/high/3840-x-2160/gpt-image-2": {
+        "litellm_provider": "fal_ai",
+        "mode": "image_generation",
+        "output_cost_per_image": 0.401,
+        "source": "https://fal.ai/models/openai/gpt-image-2",
+        "supported_endpoints": [
+            "/v1/images/generations"
+        ],
+        "supports_vision": true
+    },
     "fal_ai/openai/gpt-image-2/edit": {
         "litellm_provider": "fal_ai",
         "metadata": {
-            "notes": "Editing endpoint of gpt-image-2 on fal.ai, reached through the image generation path with fal's image_urls param since /v1/images/edits is not wired for fal_ai. Same rate as fal_ai/openai/gpt-image-2, see that entry for the size and quality caveat"
+            "notes": "Editing endpoint of gpt-image-2 on fal.ai, reached through the image generation path with fal's image_urls param since /v1/images/edits is not wired for fal_ai. Prices include one input image and live in keyed entries fal_ai/{quality}/{width}-x-{height}/openai/gpt-image-2/edit. This flat entry is the fallback for the default edit request (quality=high, image_size=auto, inferred from the input image, priced as 1024x768 high)"
         },
         "mode": "image_generation",
-        "output_cost_per_image": 0.145,
+        "output_cost_per_image": 0.151,
+        "source": "https://fal.ai/models/openai/gpt-image-2/edit",
+        "supported_endpoints": [
+            "/v1/images/generations"
+        ],
+        "supports_vision": true
+    },
+    "fal_ai/low/1024-x-768/openai/gpt-image-2/edit": {
+        "litellm_provider": "fal_ai",
+        "mode": "image_generation",
+        "output_cost_per_image": 0.011,
+        "source": "https://fal.ai/models/openai/gpt-image-2/edit",
+        "supported_endpoints": [
+            "/v1/images/generations"
+        ],
+        "supports_vision": true
+    },
+    "fal_ai/low/1024-x-1024/openai/gpt-image-2/edit": {
+        "litellm_provider": "fal_ai",
+        "mode": "image_generation",
+        "output_cost_per_image": 0.015,
+        "source": "https://fal.ai/models/openai/gpt-image-2/edit",
+        "supported_endpoints": [
+            "/v1/images/generations"
+        ],
+        "supports_vision": true
+    },
+    "fal_ai/low/1024-x-1536/openai/gpt-image-2/edit": {
+        "litellm_provider": "fal_ai",
+        "mode": "image_generation",
+        "output_cost_per_image": 0.018,
+        "source": "https://fal.ai/models/openai/gpt-image-2/edit",
+        "supported_endpoints": [
+            "/v1/images/generations"
+        ],
+        "supports_vision": true
+    },
+    "fal_ai/low/1920-x-1080/openai/gpt-image-2/edit": {
+        "litellm_provider": "fal_ai",
+        "mode": "image_generation",
+        "output_cost_per_image": 0.017,
+        "source": "https://fal.ai/models/openai/gpt-image-2/edit",
+        "supported_endpoints": [
+            "/v1/images/generations"
+        ],
+        "supports_vision": true
+    },
+    "fal_ai/low/2560-x-1440/openai/gpt-image-2/edit": {
+        "litellm_provider": "fal_ai",
+        "mode": "image_generation",
+        "output_cost_per_image": 0.019,
+        "source": "https://fal.ai/models/openai/gpt-image-2/edit",
+        "supported_endpoints": [
+            "/v1/images/generations"
+        ],
+        "supports_vision": true
+    },
+    "fal_ai/low/3840-x-2160/openai/gpt-image-2/edit": {
+        "litellm_provider": "fal_ai",
+        "mode": "image_generation",
+        "output_cost_per_image": 0.024,
+        "source": "https://fal.ai/models/openai/gpt-image-2/edit",
+        "supported_endpoints": [
+            "/v1/images/generations"
+        ],
+        "supports_vision": true
+    },
+    "fal_ai/medium/1024-x-768/openai/gpt-image-2/edit": {
+        "litellm_provider": "fal_ai",
+        "mode": "image_generation",
+        "output_cost_per_image": 0.043,
+        "source": "https://fal.ai/models/openai/gpt-image-2/edit",
+        "supported_endpoints": [
+            "/v1/images/generations"
+        ],
+        "supports_vision": true
+    },
+    "fal_ai/medium/1024-x-1024/openai/gpt-image-2/edit": {
+        "litellm_provider": "fal_ai",
+        "mode": "image_generation",
+        "output_cost_per_image": 0.061,
+        "source": "https://fal.ai/models/openai/gpt-image-2/edit",
+        "supported_endpoints": [
+            "/v1/images/generations"
+        ],
+        "supports_vision": true
+    },
+    "fal_ai/medium/1024-x-1536/openai/gpt-image-2/edit": {
+        "litellm_provider": "fal_ai",
+        "mode": "image_generation",
+        "output_cost_per_image": 0.054,
+        "source": "https://fal.ai/models/openai/gpt-image-2/edit",
+        "supported_endpoints": [
+            "/v1/images/generations"
+        ],
+        "supports_vision": true
+    },
+    "fal_ai/medium/1920-x-1080/openai/gpt-image-2/edit": {
+        "litellm_provider": "fal_ai",
+        "mode": "image_generation",
+        "output_cost_per_image": 0.053,
+        "source": "https://fal.ai/models/openai/gpt-image-2/edit",
+        "supported_endpoints": [
+            "/v1/images/generations"
+        ],
+        "supports_vision": true
+    },
+    "fal_ai/medium/2560-x-1440/openai/gpt-image-2/edit": {
+        "litellm_provider": "fal_ai",
+        "mode": "image_generation",
+        "output_cost_per_image": 0.068,
+        "source": "https://fal.ai/models/openai/gpt-image-2/edit",
+        "supported_endpoints": [
+            "/v1/images/generations"
+        ],
+        "supports_vision": true
+    },
+    "fal_ai/medium/3840-x-2160/openai/gpt-image-2/edit": {
+        "litellm_provider": "fal_ai",
+        "mode": "image_generation",
+        "output_cost_per_image": 0.113,
+        "source": "https://fal.ai/models/openai/gpt-image-2/edit",
+        "supported_endpoints": [
+            "/v1/images/generations"
+        ],
+        "supports_vision": true
+    },
+    "fal_ai/high/1024-x-768/openai/gpt-image-2/edit": {
+        "litellm_provider": "fal_ai",
+        "mode": "image_generation",
+        "output_cost_per_image": 0.151,
+        "source": "https://fal.ai/models/openai/gpt-image-2/edit",
+        "supported_endpoints": [
+            "/v1/images/generations"
+        ],
+        "supports_vision": true
+    },
+    "fal_ai/high/1024-x-1024/openai/gpt-image-2/edit": {
+        "litellm_provider": "fal_ai",
+        "mode": "image_generation",
+        "output_cost_per_image": 0.219,
+        "source": "https://fal.ai/models/openai/gpt-image-2/edit",
+        "supported_endpoints": [
+            "/v1/images/generations"
+        ],
+        "supports_vision": true
+    },
+    "fal_ai/high/1024-x-1536/openai/gpt-image-2/edit": {
+        "litellm_provider": "fal_ai",
+        "mode": "image_generation",
+        "output_cost_per_image": 0.178,
+        "source": "https://fal.ai/models/openai/gpt-image-2/edit",
+        "supported_endpoints": [
+            "/v1/images/generations"
+        ],
+        "supports_vision": true
+    },
+    "fal_ai/high/1920-x-1080/openai/gpt-image-2/edit": {
+        "litellm_provider": "fal_ai",
+        "mode": "image_generation",
+        "output_cost_per_image": 0.158,
+        "source": "https://fal.ai/models/openai/gpt-image-2/edit",
+        "supported_endpoints": [
+            "/v1/images/generations"
+        ],
+        "supports_vision": true
+    },
+    "fal_ai/high/2560-x-1440/openai/gpt-image-2/edit": {
+        "litellm_provider": "fal_ai",
+        "mode": "image_generation",
+        "output_cost_per_image": 0.234,
+        "source": "https://fal.ai/models/openai/gpt-image-2/edit",
+        "supported_endpoints": [
+            "/v1/images/generations"
+        ],
+        "supports_vision": true
+    },
+    "fal_ai/high/3840-x-2160/openai/gpt-image-2/edit": {
+        "litellm_provider": "fal_ai",
+        "mode": "image_generation",
+        "output_cost_per_image": 0.413,
         "source": "https://fal.ai/models/openai/gpt-image-2/edit",
         "supported_endpoints": [
             "/v1/images/generations"

--- a/tests/test_litellm/llms/fal_ai/image_generation/test_fal_ai_gpt_image_2_transformation.py
+++ b/tests/test_litellm/llms/fal_ai/image_generation/test_fal_ai_gpt_image_2_transformation.py
@@ -128,19 +128,23 @@ def test_transform_image_generation_request():
 
 
 @pytest.mark.parametrize(
-    "model",
+    ("model", "expected_cost_for_two_images"),
     [
-        "openai/gpt-image-2",
-        "gpt-image-2",
-        "openai/gpt-image-2/edit",
+        ("openai/gpt-image-2", 0.29),
+        ("gpt-image-2", 0.29),
+        ("openai/gpt-image-2/edit", 0.302),
     ],
 )
-def test_cost_calculator_uses_registry_price(model, monkeypatch: pytest.MonkeyPatch):
+def test_cost_calculator_uses_registry_price(
+    model, expected_cost_for_two_images, monkeypatch: pytest.MonkeyPatch
+):
+    monkeypatch.setenv("LITELLM_LOCAL_MODEL_COST_MAP", "True")
     monkeypatch.setattr(litellm, "model_cost", litellm.get_model_cost_map(url=""))
+    litellm.get_model_info.cache_clear()
     response = ImageResponse(
         data=[
             ImageObject(url="https://v3b.fal.media/files/b/one.png"),
             ImageObject(url="https://v3b.fal.media/files/b/two.png"),
         ]
     )
-    assert cost_calculator(model=model, image_response=response) == pytest.approx(0.29)
+    assert cost_calculator(model=model, image_response=response) == pytest.approx(expected_cost_for_two_images)

--- a/tests/test_litellm/llms/fal_ai/test_cost_calculator.py
+++ b/tests/test_litellm/llms/fal_ai/test_cost_calculator.py
@@ -1,0 +1,128 @@
+import pytest
+
+import litellm
+from litellm.litellm_core_utils.llm_cost_calc.utils import CostCalculatorUtils
+from litellm.llms.fal_ai.cost_calculator import cost_calculator
+from litellm.types.utils import ImageObject, ImageResponse
+
+
+@pytest.fixture(autouse=True)
+def _use_local_model_cost_map(monkeypatch):
+    monkeypatch.setenv("LITELLM_LOCAL_MODEL_COST_MAP", "True")
+    monkeypatch.setattr(litellm, "model_cost", litellm.get_model_cost_map(url=""))
+    litellm.get_model_info.cache_clear()
+    yield
+    litellm.get_model_info.cache_clear()
+
+
+def _image_response(num_images: int = 1) -> ImageResponse:
+    return ImageResponse(data=[ImageObject(url="https://example.com/img.png") for _ in range(num_images)])
+
+
+def test_high_quality_1024x1024_uses_keyed_price():
+    cost = cost_calculator(
+        model="openai/gpt-image-2",
+        image_response=_image_response(),
+        optional_params={"quality": "high", "image_size": {"width": 1024, "height": 1024}},
+    )
+    assert cost == pytest.approx(0.211)
+
+
+def test_alias_model_uses_keyed_price():
+    cost = cost_calculator(
+        model="gpt-image-2",
+        image_response=_image_response(),
+        optional_params={"quality": "high", "image_size": {"width": 1024, "height": 1024}},
+    )
+    assert cost == pytest.approx(0.211)
+
+
+def test_default_request_priced_at_default_size_and_quality():
+    cost = cost_calculator(
+        model="openai/gpt-image-2",
+        image_response=_image_response(),
+        optional_params={},
+    )
+    assert cost == pytest.approx(0.145)
+
+
+def test_auto_quality_priced_as_high():
+    cost = cost_calculator(
+        model="openai/gpt-image-2",
+        image_response=_image_response(),
+        optional_params={"quality": "auto", "image_size": {"width": 1024, "height": 1024}},
+    )
+    assert cost == pytest.approx(0.211)
+
+
+def test_low_quality_4k_uses_keyed_price():
+    cost = cost_calculator(
+        model="openai/gpt-image-2",
+        image_response=_image_response(),
+        optional_params={"quality": "low", "image_size": {"width": 3840, "height": 2160}},
+    )
+    assert cost == pytest.approx(0.012)
+
+
+def test_named_fal_size_uses_keyed_price():
+    cost = cost_calculator(
+        model="openai/gpt-image-2",
+        image_response=_image_response(),
+        optional_params={"quality": "high", "image_size": "square_hd"},
+    )
+    assert cost == pytest.approx(0.211)
+
+
+def test_edit_model_uses_keyed_edit_price():
+    cost = cost_calculator(
+        model="openai/gpt-image-2/edit",
+        image_response=_image_response(),
+        optional_params={"quality": "high", "image_size": {"width": 1024, "height": 1024}},
+    )
+    assert cost == pytest.approx(0.219)
+
+
+def test_edit_model_without_size_falls_back_to_flat_price():
+    cost = cost_calculator(
+        model="openai/gpt-image-2/edit",
+        image_response=_image_response(),
+        optional_params={"quality": "high"},
+    )
+    assert cost == pytest.approx(0.151)
+
+
+def test_missing_optional_params_falls_back_to_flat_price():
+    cost = cost_calculator(
+        model="openai/gpt-image-2",
+        image_response=_image_response(),
+        optional_params=None,
+    )
+    assert cost == pytest.approx(0.145)
+
+
+def test_unlisted_size_falls_back_to_flat_price():
+    cost = cost_calculator(
+        model="openai/gpt-image-2",
+        image_response=_image_response(),
+        optional_params={"quality": "high", "image_size": {"width": 999, "height": 999}},
+    )
+    assert cost == pytest.approx(0.145)
+
+
+def test_keyed_price_multiplies_per_image():
+    cost = cost_calculator(
+        model="openai/gpt-image-2",
+        image_response=_image_response(num_images=2),
+        optional_params={"quality": "high", "image_size": {"width": 1024, "height": 1024}},
+    )
+    assert cost == pytest.approx(0.422)
+
+
+def test_route_image_generation_passes_optional_params_to_fal():
+    cost = CostCalculatorUtils.route_image_generation_cost_calculator(
+        model="openai/gpt-image-2",
+        completion_response=_image_response(),
+        custom_llm_provider="fal_ai",
+        optional_params={"quality": "high", "image_size": {"width": 1024, "height": 1024}},
+    )
+    assert cost == pytest.approx(0.211)

--- a/tests/test_litellm/llms/fal_ai/test_cost_calculator.py
+++ b/tests/test_litellm/llms/fal_ai/test_cost_calculator.py
@@ -37,6 +37,24 @@ def test_alias_model_uses_keyed_price():
     assert cost == pytest.approx(0.211)
 
 
+def test_provider_prefixed_model_uses_keyed_price():
+    cost = cost_calculator(
+        model="fal_ai/openai/gpt-image-2",
+        image_response=_image_response(),
+        optional_params={"quality": "high", "image_size": {"width": 1024, "height": 1024}},
+    )
+    assert cost == pytest.approx(0.211)
+
+
+def test_provider_prefixed_edit_model_uses_keyed_edit_price():
+    cost = cost_calculator(
+        model="fal_ai/openai/gpt-image-2/edit",
+        image_response=_image_response(),
+        optional_params={"quality": "high", "image_size": {"width": 1024, "height": 1024}},
+    )
+    assert cost == pytest.approx(0.219)
+
+
 def test_default_request_priced_at_default_size_and_quality():
     cost = cost_calculator(
         model="openai/gpt-image-2",
@@ -121,6 +139,16 @@ def test_keyed_price_multiplies_per_image():
 def test_route_image_generation_passes_optional_params_to_fal():
     cost = CostCalculatorUtils.route_image_generation_cost_calculator(
         model="openai/gpt-image-2",
+        completion_response=_image_response(),
+        custom_llm_provider="fal_ai",
+        optional_params={"quality": "high", "image_size": {"width": 1024, "height": 1024}},
+    )
+    assert cost == pytest.approx(0.211)
+
+
+def test_route_image_generation_with_provider_prefixed_model_uses_keyed_price():
+    cost = CostCalculatorUtils.route_image_generation_cost_calculator(
+        model="fal_ai/openai/gpt-image-2",
         completion_response=_image_response(),
         custom_llm_provider="fal_ai",
         optional_params={"quality": "high", "image_size": {"width": 1024, "height": 1024}},


### PR DESCRIPTION
## TLDR

Problem this solves:

- fal bills gpt-image-2 per size and quality, litellm charged flat $0.145
- a $0.006 low-quality image was logged as $0.145, 24x over
- a $0.211 high-quality 1024x1024 image was logged 31% under
- the edit endpoint was priced at the generation rate

How it solves it:

- adds fal's published price table as keyed cost-map entries
- cost calculator picks the entry from the request's size and quality
- unlisted sizes and missing params fall back to the flat entry

## User Flow

Before: a developer generating a high-quality 1024x1024 image with fal gpt-image-2 sees $0.145 in spend logs while fal bills them $0.211

1. They send POST http://litellm-domain/v1/images/generations with `{"model": "fal_ai/openai/gpt-image-2", "prompt": "a red bicycle", "size": "1024x1024", "quality": "hd"}`
2. The image comes back 200, and the `x-litellm-response-cost` header reads `0.145`
3. They open http://litellm-domain/ui/?page=logs and the request shows $0.145 spend, though fal's dashboard bills the same call at $0.211

After: the same request is logged at fal's actual $0.211 price

1. They send POST http://litellm-domain/v1/images/generations with `{"model": "fal_ai/openai/gpt-image-2", "prompt": "a red bicycle", "size": "1024x1024", "quality": "hd"}`
2. The image comes back 200, and the `x-litellm-response-cost` header reads `0.211`
3. They open http://litellm-domain/ui/?page=logs and the request shows $0.211 spend, matching fal's bill

## Relevant issues

Follow-up to #37729, which added fal gpt-image-2 support with a single flat price

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Both legs boot a real DB-backed proxy from the exact commit under test (own Postgres, random free ports, `LITELLM_LOCAL_MODEL_COST_MAP=True`) and hit the real fal API with the same two requests, differing only in the commit the proxy was booted from

### Before (987478abe48ecec29d32c8f60ebbe49acfb83c80)

Tree proof

```
/private/tmp/falqa37751-before
987478abe48ecec29d32c8f60ebbe49acfb83c80
/private/tmp/falqa37751-before/litellm/__init__.py
```

1. hd 1024x1024

```
curl -sS -m 180 -X POST http://127.0.0.1:41983/v1/images/generations \
  -H "Authorization: Bearer sk-falqa-before" -H "Content-Type: application/json" \
  -d '{"model": "fal_ai/openai/gpt-image-2", "prompt": "a red bicycle", "size": "1024x1024", "quality": "hd"}'
```

```
HTTP/1.1 200 OK
x-litellm-call-id: 46c6dc33-d1ab-4cb7-bc81-b905ab44f0b1
x-litellm-response-cost: 0.145
```

Image (verified live, image/png): https://v3b.fal.media/files/b/0aa72a6b/eQv-lG5O96zx7i7Qn6qhW_SHEPbKvK.png

```
curl -s "http://127.0.0.1:41983/spend/logs?request_id=46c6dc33-d1ab-4cb7-bc81-b905ab44f0b1" -H "Authorization: Bearer sk-falqa-before"
```

```json
{"request_id": "46c6dc33-d1ab-4cb7-bc81-b905ab44f0b1", "call_type": "aimage_generation", "spend": 0.145, "model": "fal_ai/openai/gpt-image-2", "custom_llm_provider": "fal_ai", "api_base": "https://fal.run/openai/gpt-image-2", "status": "success"}
```

2. low 1024x1024

```
curl -sS -m 180 -X POST http://127.0.0.1:41983/v1/images/generations \
  -H "Authorization: Bearer sk-falqa-before" -H "Content-Type: application/json" \
  -d '{"model": "fal_ai/openai/gpt-image-2", "prompt": "a red bicycle", "size": "1024x1024", "quality": "low"}'
```

```
HTTP/1.1 200 OK
x-litellm-call-id: aa6ba115-5b75-48d0-b487-46d8327e39d2
x-litellm-response-cost: 0.145
```

Image (verified live, image/png): https://v3b.fal.media/files/b/0aa72a7b/OyUU7fZeWk4EtaIydEEVB_bq4RstLp.png

```
curl -s "http://127.0.0.1:41983/spend/logs?request_id=aa6ba115-5b75-48d0-b487-46d8327e39d2" -H "Authorization: Bearer sk-falqa-before"
```

```json
{"request_id": "aa6ba115-5b75-48d0-b487-46d8327e39d2", "call_type": "aimage_generation", "spend": 0.145, "model": "fal_ai/openai/gpt-image-2", "custom_llm_provider": "fal_ai", "api_base": "https://fal.run/openai/gpt-image-2", "status": "success"}
```

Both qualities billed the flat $0.145: the low image is overcharged 24x and the hd image undercharged 31%, even though fal really rendered different qualities upstream

### After (d5e6a0c9b8b262e097033f56e2aa4a8d5275bd22)

Tree proof

```
/private/tmp/falprice37738
d5e6a0c9b8b262e097033f56e2aa4a8d5275bd22
/private/tmp/falprice37738/litellm/__init__.py
```

1. hd 1024x1024

```
curl -sS -m 300 -X POST http://127.0.0.1:18734/v1/images/generations \
  -H "Authorization: Bearer sk-falqa-after2" -H "Content-Type: application/json" \
  -d '{"model": "fal_ai/openai/gpt-image-2", "prompt": "a red bicycle", "size": "1024x1024", "quality": "hd"}'
```

```
HTTP/1.1 200 OK
x-litellm-call-id: 7daa6ad4-76b1-46bc-8474-638091e70a1c
x-litellm-response-cost: 0.211
```

Image (verified live, image/png): https://v3b.fal.media/files/b/0aa72b03/5BWQE6p0ULdTRT1BcrvwP_8zGtRjC9.png

```
curl -s "http://127.0.0.1:18734/spend/logs?request_id=7daa6ad4-76b1-46bc-8474-638091e70a1c" -H "Authorization: Bearer sk-falqa-after2"
```

```json
{"request_id": "7daa6ad4-76b1-46bc-8474-638091e70a1c", "call_type": "aimage_generation", "spend": 0.211, "model": "fal_ai/openai/gpt-image-2", "custom_llm_provider": "fal_ai", "status": "success"}
```

2. low 1024x1024

```
curl -sS -m 300 -X POST http://127.0.0.1:18734/v1/images/generations \
  -H "Authorization: Bearer sk-falqa-after2" -H "Content-Type: application/json" \
  -d '{"model": "fal_ai/openai/gpt-image-2", "prompt": "a red bicycle", "size": "1024x1024", "quality": "low"}'
```

```
HTTP/1.1 200 OK
x-litellm-call-id: 476058c0-b355-41ba-8de3-41f99114a9fc
x-litellm-response-cost: 0.006
```

Image (verified live, image/png): https://v3b.fal.media/files/b/0aa72b13/W5u_yHg0GF1VIFxdEDCSY_2PLUZKpz.png

```
curl -s "http://127.0.0.1:18734/spend/logs?request_id=476058c0-b355-41ba-8de3-41f99114a9fc" -H "Authorization: Bearer sk-falqa-after2"
```

```json
{"request_id": "476058c0-b355-41ba-8de3-41f99114a9fc", "call_type": "aimage_generation", "spend": 0.006, "model": "fal_ai/openai/gpt-image-2", "custom_llm_provider": "fal_ai", "status": "success"}
```

The hd request is billed $0.211 and the low request $0.006, matching fal's price table, and the totals agree end to end:

```
curl -s http://127.0.0.1:18734/global/spend -H "Authorization: Bearer sk-falqa-after2"
{"spend":0.217,"max_budget":0.0}
```

Notes from the runs, all pre-existing behavior this PR leaves alone:

- response body echoes quality and size as null
- image-generation spend rows carry no cost_breakdown
- x-litellm-key-spend header lags one request

## Type

🐛 Bug Fix

## Caveats (if any)

- quality `auto` is priced as high, fal's documented default
- unlisted or custom sizes fall back to the flat entry
- flat edit price corrected from $0.145 to $0.151

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

- [x] d5e6a0c9b8b262e097033f56e2aa4a8d5275bd22 passes /live-pr-risk

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes spend/cost calculation for fal gpt-image-2 (including edit), so logged spend and budgets can shift vs the previous flat $0.145 rate. Unlisted sizes still fall back to the flat entry.
> 
> **Overview**
> Prices fal.ai `gpt-image-2` (and `/edit`) from the request's quality and size instead of always charging the default flat per-image rate.
> 
> The fal cost calculator now looks up keyed cost-map entries `fal_ai/{quality}/{width}-x-{height}/…` from `optional_params` (named fal sizes, width/height maps, `quality=auto` as high). Missing params or unlisted sizes still use the flat model entry. Edit fallback is corrected to $0.151. Generation and alias models keep $0.145 as the unmatched default.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d5e6a0c9b8b262e097033f56e2aa4a8d5275bd22. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->