### PR TITLE
fix: add moonshot/kimi-k3 to the cost map on main

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -30025,6 +30025,23 @@
         "supports_video_input": true,
         "supports_vision": true
     },
+    "moonshot/kimi-k3": {
+        "cache_read_input_token_cost": 3e-07,
+        "input_cost_per_token": 3e-06,
+        "litellm_provider": "moonshot",
+        "max_input_tokens": 1048576,
+        "max_output_tokens": 1048576,
+        "max_tokens": 1048576,
+        "mode": "chat",
+        "output_cost_per_token": 1.5e-05,
+        "source": "https://platform.kimi.ai/docs/pricing/chat-k3",
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true,
+        "supports_video_input": true,
+        "supports_vision": true
+    },
     "moonshot/kimi-latest": {
         "cache_read_input_token_cost": 1.5e-07,
         "deprecation_date": "2026-01-28",

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -30025,6 +30025,23 @@
         "supports_video_input": true,
         "supports_vision": true
     },
+    "moonshot/kimi-k3": {
+        "cache_read_input_token_cost": 3e-07,
+        "input_cost_per_token": 3e-06,
+        "litellm_provider": "moonshot",
+        "max_input_tokens": 1048576,
+        "max_output_tokens": 1048576,
+        "max_tokens": 1048576,
+        "mode": "chat",
+        "output_cost_per_token": 1.5e-05,
+        "source": "https://platform.kimi.ai/docs/pricing/chat-k3",
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true,
+        "supports_video_input": true,
+        "supports_vision": true
+    },
     "moonshot/kimi-latest": {
         "cache_read_input_token_cost": 1.5e-07,
         "deprecation_date": "2026-01-28",


### PR DESCRIPTION
## TLDR

Problem this solves:

- `moonshot/kimi-k3` is missing from `main`'s cost map, so models.litellm.ai doesn't list it
- The entry is in review for `litellm_internal_staging` in #37552, but the hosted map reads `main`

How it solves it:

- Cherry-picks the #37552 cost map entry onto a `litellm_hotfix_*` branch targeting `main`
- Data-only: `model_prices_and_context_window.json` plus the backup copy, nothing else

## User Flow

Before: a developer looking up Kimi K3 on the hosted model catalog finds nothing

1. They open https://models.litellm.ai and search "kimi-k3"
2. The only match is the Azure Foundry variant `azure_ai/FW-Kimi-K3`; the native `moonshot/kimi-k3` is absent
3. They open https://models.litellm.ai/model/moonshot/kimi-k3 and get no pricing or context data

After: the same search shows the native Moonshot entry with real pricing

1. They open https://models.litellm.ai and search "kimi-k3"
2. `moonshot/kimi-k3` appears with $3.00/M input, $0.30/M cache read, $15.00/M output, 1,048,576-token context
3. The model page shows reasoning, vision, video input, and tool calling support

## Relevant issues

Data-only hotfix that copies the cost map entry from #37552, which is in review for `litellm_internal_staging`. models.litellm.ai and released litellm versions fetch `model_prices_and_context_window.json` from the `main` branch at runtime, so the hosted map won't show Kimi K3 until the entry reaches `main`. Same pattern as #30076. Pricing matches Moonshot's own published rates ([platform.kimi.ai](https://platform.kimi.ai/docs/pricing/chat-k3)): $3.00/M cache-miss input, $0.30/M cache hit, $15.00/M output, over a 1,048,576-token context. Those are the direct-API rates the `moonshot/` prefix bills against, so resellers like OpenRouter quote different numbers and aren't the reference here. The `fireworks_ai/*` and `azure_ai/*` kimi-k3 serverless variants are separate work that landed on `litellm_internal_staging` via #37658, which superseded #37512; this PR only adds the native `moonshot/kimi-k3` key, which that changeset doesn't touch

## Linear ticket

Resolves LIT-5226

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have added meaningful tests (n/a: data-only cherry-pick of the #37552 entry)
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more (for this data-only change, the same checks CI runs pass locally: `jq empty`, `ci_cd/check_files_match.py`, `ci_cd/generate_model_prices_schema.py --check`)
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

models.litellm.ai renders whatever `https://raw.githubusercontent.com/BerriAI/litellm/main/model_prices_and_context_window.json` serves, so the proof below curls the same file the site fetches, at the merge base and at the PR tip

### Before (007bd43cfb6eeeabe94d6aa77bd05dd3aa6aa1bf)

1. `curl -s https://raw.githubusercontent.com/BerriAI/litellm/007bd43cfb6eeeabe94d6aa77bd05dd3aa6aa1bf/model_prices_and_context_window.json | jq '."moonshot/kimi-k3"'`

```
null
```

### After (ef1cde433ea7c6dd1515de06c6d0d748fae4a197)

1. `curl -s https://raw.githubusercontent.com/BerriAI/litellm/ef1cde433ea7c6dd1515de06c6d0d748fae4a197/model_prices_and_context_window.json | jq '."moonshot/kimi-k3" | {input_cost_per_token, cache_read_input_token_cost, output_cost_per_token, max_input_tokens}'`

```
{
  "input_cost_per_token": 0.000003,
  "cache_read_input_token_cost": 3E-7,
  "output_cost_per_token": 0.000015,
  "max_input_tokens": 1048576
}
```

2. Once this merges, https://models.litellm.ai shows the same JSON on its next fetch of the `main` map

## Type

🐛 Bug Fix

## Caveats (if any)

- Entry is byte-identical to #37552's, so pricing changes there need a follow-up here
- Merging current `litellm_internal_staging` into this branch auto-merges the cost map with no conflict, so the staging promote is unaffected
- `max_output_tokens` mirrors the context window like the other `moonshot/kimi-*` entries, since Moonshot publishes no separate output cap

### Final Attestation

- [ ] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

