### PR TITLE
fix(anthropic): resolve the provider exactly once on /v1/messages

### DIFF
--- a/litellm/llms/anthropic/experimental_pass_through/adapters/handler.py
+++ b/litellm/llms/anthropic/experimental_pass_through/adapters/handler.py
@@ -21,6 +21,7 @@ from litellm.llms.anthropic.experimental_pass_through.context_management import 
 )
 from litellm.llms.anthropic.experimental_pass_through.utils import (
     is_reasoning_auto_summary_enabled,
+    local_model_name,
 )
 from litellm.types.llms.anthropic_messages.anthropic_response import (
     AnthropicMessagesResponse,
@@ -358,9 +359,9 @@ class LiteLLMMessagesToCompletionTransformationHandler:
         except Exception:
             pass
 
-        if isinstance(model, str) and model and not model.startswith("responses/"):
-            # Prefix model with "responses/" to route to OpenAI Responses API
-            completion_kwargs["model"] = f"responses/{model}"
+        if isinstance(model, str) and model and "responses/" not in model:
+            local_model: Final = model.removeprefix(f"{custom_llm_provider}/")
+            completion_kwargs["model"] = f"{custom_llm_provider}/responses/{local_model}"
 
         auto_summary: Final = is_reasoning_auto_summary_enabled()
 
@@ -616,7 +617,7 @@ class LiteLLMMessagesToCompletionTransformationHandler:
         if stream:
             transformed_stream: Final = ANTHROPIC_ADAPTER.translate_completion_output_params_streaming(
                 completion_response,
-                model=model,
+                model=local_model_name(model, kwargs.get("custom_llm_provider")),
                 tool_name_mapping=tool_name_mapping,
                 polyfill_result=polyfill_result,
                 is_async=True,
@@ -750,7 +751,7 @@ class LiteLLMMessagesToCompletionTransformationHandler:
         if stream:
             transformed_stream: Final = ANTHROPIC_ADAPTER.translate_completion_output_params_streaming(
                 completion_response,
-                model=model,
+                model=local_model_name(model, kwargs.get("custom_llm_provider")),
                 tool_name_mapping=tool_name_mapping,
                 polyfill_result=polyfill_result,
                 is_async=False,

--- a/litellm/llms/anthropic/experimental_pass_through/messages/handler.py
+++ b/litellm/llms/anthropic/experimental_pass_through/messages/handler.py
@@ -533,7 +533,7 @@ def anthropic_messages_handler(
         _shared_kwargs: Final = dict(
             max_tokens=max_tokens,
             messages=messages,
-            model=model,
+            model=original_model,
             metadata=metadata,
             stop_sequences=stop_sequences,
             stream=stream,

--- a/litellm/llms/anthropic/experimental_pass_through/messages/handler.py
+++ b/litellm/llms/anthropic/experimental_pass_through/messages/handler.py
@@ -42,15 +42,46 @@ from .utils import AnthropicMessagesRequestUtils, mock_response
 _RESPONSES_API_PROVIDERS: Final = frozenset({"openai"})
 
 
-def _should_route_to_responses_api(custom_llm_provider: str | None) -> bool:
-    """Return True when the provider should use the Responses API path.
+def _bridges_to_responses_api(model: str, custom_llm_provider: str) -> bool:
+    from litellm.main import responses_api_bridge_check
+
+    model_info, _ = responses_api_bridge_check(model=model, custom_llm_provider=custom_llm_provider)
+    return model_info.get("mode") == "responses"
+
+
+def _responses_mode_is_lost_by_prefix_strip(
+    requested_model: str, resolved_model: str, custom_llm_provider: str
+) -> bool:
+    """Whether a Responses-only deployment stops looking like one once its provider prefix is stripped.
+
+    ``litellm.completion`` re-derives the Responses bridge from the stripped id alone, so a
+    deployment id such as ``perplexity/perplexity/sonar`` (mode ``responses``) is shadowed by the
+    chat entry ``perplexity/sonar`` and would otherwise be sent to chat/completions.
+    """
+    if requested_model == resolved_model:
+        return False
+    return _bridges_to_responses_api(requested_model, custom_llm_provider) and not _bridges_to_responses_api(
+        resolved_model, custom_llm_provider
+    )
+
+
+def _should_route_to_responses_api(
+    custom_llm_provider: str | None,
+    requested_model: str | None = None,
+    resolved_model: str | None = None,
+) -> bool:
+    """Return True when the request should use the Responses API path.
 
     Set ``litellm.use_chat_completions_url_for_anthropic_messages = True`` to
     opt out and route OpenAI/Azure requests through chat/completions instead.
     """
     if litellm.use_chat_completions_url_for_anthropic_messages:
         return False
-    return custom_llm_provider in _RESPONSES_API_PROVIDERS
+    if custom_llm_provider in _RESPONSES_API_PROVIDERS:
+        return True
+    if custom_llm_provider is None or requested_model is None or resolved_model is None:
+        return False
+    return _responses_mode_is_lost_by_prefix_strip(requested_model, resolved_model, custom_llm_provider)
 
 
 def _deployment_passes_through_anthropic_messages(model_info: object) -> bool:
@@ -551,7 +582,7 @@ def anthropic_messages_handler(
             custom_llm_provider=custom_llm_provider,
             **kwargs,
         )
-        if _should_route_to_responses_api(custom_llm_provider):
+        if _should_route_to_responses_api(custom_llm_provider, original_model, model):
             return LiteLLMMessagesToResponsesAPIHandler.anthropic_messages_handler(**_shared_kwargs)
 
         # The in-gateway context_management polyfill runs inside

--- a/litellm/llms/anthropic/experimental_pass_through/responses_adapters/handler.py
+++ b/litellm/llms/anthropic/experimental_pass_through/responses_adapters/handler.py
@@ -19,6 +19,7 @@ from litellm.types.llms.anthropic_messages.anthropic_response import (
 )
 from litellm.types.llms.openai import ResponsesAPIResponse
 
+from ..utils import local_model_name
 from .streaming_iterator import AnthropicResponsesStreamWrapper
 from .transformation import LiteLLMAnthropicToResponsesAPIAdapter
 
@@ -179,7 +180,9 @@ class LiteLLMMessagesToResponsesAPIHandler:
         result: Final = await litellm.aresponses(**responses_kwargs)
 
         if stream:
-            wrapper: Final = AnthropicResponsesStreamWrapper(responses_stream=result, model=model)
+            wrapper: Final = AnthropicResponsesStreamWrapper(
+                responses_stream=result, model=local_model_name(model, kwargs.get("custom_llm_provider"))
+            )
             return wrapper.async_anthropic_sse_wrapper()
 
         if not isinstance(result, ResponsesAPIResponse):
@@ -257,7 +260,9 @@ class LiteLLMMessagesToResponsesAPIHandler:
         result: Final = litellm.responses(**responses_kwargs)
 
         if stream:
-            wrapper: Final = AnthropicResponsesStreamWrapper(responses_stream=result, model=model)
+            wrapper: Final = AnthropicResponsesStreamWrapper(
+                responses_stream=result, model=local_model_name(model, kwargs.get("custom_llm_provider"))
+            )
             return wrapper.async_anthropic_sse_wrapper()
 
         if not isinstance(result, ResponsesAPIResponse):

--- a/litellm/llms/anthropic/experimental_pass_through/utils.py
+++ b/litellm/llms/anthropic/experimental_pass_through/utils.py
@@ -13,6 +13,11 @@ def prompt_cache_key_from_user_id(user_id: object) -> str | None:
     return str(user_id)[:OPENAI_MAX_PROMPT_CACHE_KEY_LENGTH] or None
 
 
+def local_model_name(model: str, custom_llm_provider: object) -> str:
+    """The id the provider itself knows, for reporting back to the caller in ``message_start``."""
+    return model.removeprefix(f"{custom_llm_provider}/") if isinstance(custom_llm_provider, str) else model
+
+
 def is_reasoning_auto_summary_enabled() -> bool:
     """Check whether the default 'summary: detailed' injection is enabled (opt-in)."""
     return litellm.reasoning_auto_summary or os.getenv("LITELLM_REASONING_AUTO_SUMMARY", "false").lower() == "true"

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_handler_prompt_cache_key.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_handler_prompt_cache_key.py
@@ -66,5 +66,5 @@ def test_prepare_completion_kwargs_keeps_prompt_cache_key_through_responses_rero
         {"custom_llm_provider": "openai"},
         thinking={"type": "enabled", "budget_tokens": 1024},
     )
-    assert completion_kwargs["model"] == "responses/openai/gpt-5.6-luna"
+    assert completion_kwargs["model"] == "openai/responses/gpt-5.6-luna"
     assert completion_kwargs["prompt_cache_key"] == "session-abc"

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_anthropic_experimental_pass_through_messages_handler.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_anthropic_experimental_pass_through_messages_handler.py
@@ -1004,27 +1004,43 @@ def test_first_party_claude_4_8_plus_cost_map_entries_carry_mid_conversation_sys
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    "requested_model, expected_wire_model",
+    "requested_model, expected_wire_model, expected_url",
     [
-        ("perplexity/perplexity/kimi-k3", "perplexity/kimi-k3"),
-        ("perplexity/sonar", "sonar"),
+        (
+            "perplexity/perplexity/kimi-k3",
+            "perplexity/kimi-k3",
+            "https://api.perplexity.ai/v1/responses",
+        ),
+        (
+            "perplexity/perplexity/sonar",
+            "perplexity/sonar",
+            "https://api.perplexity.ai/v1/responses",
+        ),
+        ("perplexity/sonar", "sonar", "https://api.perplexity.ai/chat/completions"),
     ],
 )
-async def test_messages_strips_provider_prefix_exactly_once(requested_model, expected_wire_model):
+async def test_messages_strips_provider_prefix_exactly_once(
+    requested_model, expected_wire_model, expected_url
+):
     """
     BerriAI/litellm#37716: only the leading provider segment may be stripped on the way upstream.
 
     A multi-segment id such as perplexity/perplexity/kimi-k3 must reach the provider as
     perplexity/kimi-k3, matching what /v1/chat/completions and /v1/responses already send.
 
+    The endpoint is asserted alongside the body because perplexity/perplexity/sonar is a
+    Responses-only deployment whose bare id perplexity/sonar is an ordinary chat model, so
+    stripping the prefix must not also move the request onto chat/completions.
+
     The subject is the outbound request, so the transport is cut at the wire rather than
-    stubbed with a response body: these two ids take different bridges (chat completions
+    stubbed with a response body: these ids take different bridges (chat completions
     versus the Responses API) and would otherwise need different response shapes.
     """
     captured = {}
 
     async def fake_send(self, request, **kwargs):
         captured["body"] = json.loads(request.content)
+        captured["url"] = str(request.url)
         raise httpx.ConnectError("cut at the wire", request=request)
 
     with (
@@ -1039,6 +1055,7 @@ async def test_messages_strips_provider_prefix_exactly_once(requested_model, exp
         )
 
     assert captured["body"]["model"] == expected_wire_model
+    assert captured["url"] == expected_url
 
 
 @pytest.mark.asyncio

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_anthropic_experimental_pass_through_messages_handler.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_anthropic_experimental_pass_through_messages_handler.py
@@ -217,7 +217,10 @@ async def _async_return(value):
 
 def test_anthropic_experimental_pass_through_messages_handler_custom_llm_provider():
     """
-    Test that litellm.completion is called when a custom LLM provider is given
+    Test that litellm.completion is called when a custom LLM provider is given.
+
+    Provider resolution now happens exactly once, inside litellm.completion itself
+    (BerriAI/litellm#37716), so the handler passes the original unresolved model through.
     """
     from litellm.llms.anthropic.experimental_pass_through.messages.handler import (
         anthropic_messages_handler,
@@ -241,7 +244,7 @@ def test_anthropic_experimental_pass_through_messages_handler_custom_llm_provide
         # Verify that the custom provider was passed through
         call_kwargs = mock_completion.call_args.kwargs
         assert call_kwargs["custom_llm_provider"] == "my-custom-llm"
-        assert call_kwargs["model"] == "my-custom-llm/my-custom-model"
+        assert call_kwargs["model"] == "my-custom-model"
         assert call_kwargs["api_key"] == "test-api-key"
 
 
@@ -997,3 +1000,91 @@ def test_first_party_claude_4_8_plus_cost_map_entries_carry_mid_conversation_sys
         and info.get("supports_mid_conversation_system") is not True
     ]
     assert missing == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "requested_model, expected_wire_model",
+    [
+        ("perplexity/perplexity/kimi-k3", "perplexity/kimi-k3"),
+        ("perplexity/sonar", "sonar"),
+    ],
+)
+async def test_messages_strips_provider_prefix_exactly_once(requested_model, expected_wire_model):
+    """
+    BerriAI/litellm#37716: only the leading provider segment may be stripped on the way upstream.
+
+    A multi-segment id such as perplexity/perplexity/kimi-k3 must reach the provider as
+    perplexity/kimi-k3, matching what /v1/chat/completions and /v1/responses already send.
+
+    The subject is the outbound request, so the transport is cut at the wire rather than
+    stubbed with a response body: these two ids take different bridges (chat completions
+    versus the Responses API) and would otherwise need different response shapes.
+    """
+    captured = {}
+
+    async def fake_send(self, request, **kwargs):
+        captured["body"] = json.loads(request.content)
+        raise httpx.ConnectError("cut at the wire", request=request)
+
+    with (
+        patch.object(httpx.AsyncClient, "send", fake_send),
+        pytest.raises(litellm.exceptions.InternalServerError),
+    ):
+        await litellm.anthropic.messages.acreate(
+            max_tokens=100,
+            messages=[{"role": "user", "content": "ping"}],
+            model=requested_model,
+            api_key="test-api-key",
+        )
+
+    assert captured["body"]["model"] == expected_wire_model
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "requested_model, expected_reported_model",
+    [
+        ("perplexity/perplexity/kimi-k3", "perplexity/kimi-k3"),
+        ("perplexity/sonar", "sonar"),
+    ],
+)
+async def test_messages_streaming_reports_provider_local_model(requested_model, expected_reported_model):
+    """
+    BerriAI/litellm#37716: the wire keeps every segment, so ``message_start`` must still
+    report the id the provider itself knows rather than the caller's prefixed deployment id.
+    """
+
+    class _EmptyStream:
+        def __aiter__(self):
+            return self
+
+        async def __anext__(self):
+            raise StopAsyncIteration
+
+    with patch("litellm.acompletion", new=AsyncMock(return_value=_EmptyStream())):
+        stream = await litellm.anthropic.messages.acreate(
+            max_tokens=100,
+            messages=[{"role": "user", "content": "ping"}],
+            model=requested_model,
+            api_key="test-api-key",
+            stream=True,
+        )
+        first_event = await stream.__anext__()
+
+    assert json.loads(first_event.decode().split("data: ", 1)[1])["message"]["model"] == expected_reported_model
+
+
+def test_messages_sync_streaming_reports_provider_local_model():
+    """Same guarantee as the async bridge, at the sync call site."""
+    with patch("litellm.completion", new=MagicMock(return_value=iter(()))):
+        stream = litellm.anthropic.messages.create(
+            max_tokens=100,
+            messages=[{"role": "user", "content": "ping"}],
+            model="perplexity/perplexity/kimi-k3",
+            api_key="test-api-key",
+            stream=True,
+        )
+        first_event = next(iter(stream))
+
+    assert json.loads(first_event.decode().split("data: ", 1)[1])["message"]["model"] == "perplexity/kimi-k3"

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/responses_adapters/test_responses_adapters_handler.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/responses_adapters/test_responses_adapters_handler.py
@@ -1,9 +1,15 @@
+import json
 import os
 import sys
+from unittest.mock import AsyncMock, patch
+
+import pytest
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../../../..")))
 
+import litellm
 from litellm.llms.anthropic.experimental_pass_through.responses_adapters.handler import (
+    LiteLLMMessagesToResponsesAPIHandler,
     _build_responses_kwargs,
 )
 
@@ -43,3 +49,36 @@ def test_build_responses_kwargs_without_metadata_sets_no_prompt_cache_key():
     )
     assert "user" not in responses_kwargs
     assert "prompt_cache_key" not in responses_kwargs
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "requested_model, expected_reported_model",
+    [
+        ("openai/gpt-5.6-luna", "gpt-5.6-luna"),
+        ("perplexity/perplexity/kimi-k3", "perplexity/kimi-k3"),
+    ],
+)
+async def test_streaming_message_start_reports_the_provider_local_model(requested_model, expected_reported_model):
+    """
+    BerriAI/litellm#37716 sends the caller's unresolved id down this bridge so the provider
+    resolves it once. ``message_start`` is a reporting field rather than a wire value, so it
+    keeps naming the model as the provider knows it, with only the leading provider segment gone.
+    """
+
+    async def empty_stream():
+        return
+        yield
+
+    with patch.object(litellm, "aresponses", AsyncMock(return_value=empty_stream())):
+        sse = await LiteLLMMessagesToResponsesAPIHandler.async_anthropic_messages_handler(
+            max_tokens=1024,
+            messages=MESSAGES,
+            model=requested_model,
+            stream=True,
+            custom_llm_provider=requested_model.split("/")[0],
+        )
+        events = [json.loads(chunk.decode().split("data: ", 1)[1]) async for chunk in sse]
+
+    message_start = next(e for e in events if e["type"] == "message_start")
+    assert message_start["message"]["model"] == expected_reported_model


### PR DESCRIPTION
## TLDR

Problem this solves:

- `/v1/messages` drops a segment from `provider/vendor/model` deployment ids
- Perplexity rejects the truncated id with HTTP 400 `Invalid model`
- `/v1/chat/completions` and `/v1/responses` send the same deployment correctly
- Once the id is repaired, the endpoint still has to follow it, or Agent deployments answer off the chat route

How it solves it:

- `/v1/messages` hands its bridges the caller's id unresolved
- Provider resolution then runs once instead of twice
- The endpoint is chosen from the id the admin configured, not the stripped one
- `message_start` still reports the model as the provider names it

## User Flow

Before: a developer whose gateway fronts Perplexity Agent deployments finds `/v1/messages` either rejects them outright or quietly answers off the wrong Perplexity endpoint, while `/v1/responses` serves both fine

1. The proxy admin configures two deployments, `kimi-k3` pointing at `perplexity/perplexity/kimi-k3` and `agent-sonar` pointing at `perplexity/perplexity/sonar`
2. The developer sends POST `http://litellm-domain/v1/responses` with `"model": "kimi-k3"` and gets HTTP 200 with the reply
3. The developer sends the same prompt to POST `http://litellm-domain/v1/messages` with `"model": "kimi-k3"` and gets HTTP 400 reading `Invalid model 'kimi-k3'`, naming a model nobody configured or asked for
4. The developer sends POST `http://litellm-domain/v1/responses` with `"model": "agent-sonar"` and gets HTTP 200 from Perplexity's Agent endpoint
5. The developer sends the same prompt to POST `http://litellm-domain/v1/messages` with `"model": "agent-sonar"` and gets HTTP 200 that came off Perplexity's chat endpoint instead, so the two routes disagree on what that one deployment is
6. Deployments whose id has only two segments answer on `/v1/messages` normally, so the failure looks arbitrary and the developer has no way to tell which of their deployments are affected

After: both deployments answer on `/v1/messages` exactly the way they already answer on `/v1/responses`

1. The proxy admin configures the same two deployments
2. The developer sends POST `http://litellm-domain/v1/responses` with `"model": "kimi-k3"` and gets HTTP 200 with the reply
3. The developer sends the same prompt to POST `http://litellm-domain/v1/messages` with `"model": "kimi-k3"` and now gets HTTP 200, with Perplexity asked for `perplexity/kimi-k3`, matching what the other two routes already sent
4. The developer sends POST `http://litellm-domain/v1/responses` with `"model": "agent-sonar"` and gets HTTP 200 from Perplexity's Agent endpoint
5. The developer sends the same prompt to POST `http://litellm-domain/v1/messages` with `"model": "agent-sonar"` and now gets HTTP 200 off that same Agent endpoint, so all three routes agree on the deployment
6. Ordinary two-segment deployments such as `perplexity/sonar` keep answering on `/v1/messages` off the chat endpoint, unchanged

## Relevant issues

Fixes #37716

## Linear ticket

Resolves [LIT-5995](https://linear.app/litellm-ai/issue/LIT-5995)

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).
## Screenshots / Proof of Fix

Real Perplexity credentials and real billed calls on both legs. No stand-in endpoint, no mocks, no patched source. One proxy per leg on its own random high port, same config on both.

`qa_config.yaml`:

```yaml
model_list:
  - model_name: kimi-k3
    litellm_params:
      model: perplexity/perplexity/kimi-k3
      api_key: os.environ/PERPLEXITYAI_API_KEY
  - model_name: agent-sonar
    litellm_params:
      model: perplexity/perplexity/sonar
      api_key: os.environ/PERPLEXITYAI_API_KEY
  - model_name: chat-sonar
    litellm_params:
      model: perplexity/sonar
      api_key: os.environ/PERPLEXITYAI_API_KEY
general_settings:
  master_key: sk-lit5995
```

`kimi-k3` and `agent-sonar` are the two shapes at issue, both `perplexity/perplexity/<model>`, both `mode: responses` in the cost map. `chat-sonar` is the control: an ordinary chat deployment that must not change route. Every call uses the client SDK a caller would actually reach for, the Anthropic SDK for `/v1/messages` and the OpenAI SDK for `/v1/responses`, and the same prompt throughout:

```python
messages_client = anthropic.Anthropic(base_url=f"http://127.0.0.1:{PORT}", api_key="sk-lit5995")
messages_client.messages.with_raw_response.create(
    model=MODEL, max_tokens=512,
    messages=[{"role": "user", "content": "What is 2+2? Answer in one word."}])

responses_client = openai.OpenAI(base_url=f"http://127.0.0.1:{PORT}/v1", api_key="sk-lit5995")
responses_client.responses.with_raw_response.create(
    model=MODEL, input="What is 2+2? Answer in one word.", max_output_tokens=512)
```

| Step | Route | Model | Before `1d7f675e52` | After `9399f2a4e4` |
|---|---|---|---|---|
| A | `/v1/responses` | kimi-k3 | 200 | 200 |
| B | `/v1/messages` | kimi-k3 | 400 | 200 |
| C | `/v1/responses` | agent-sonar | 200 | 200 |
| D | `/v1/messages` | agent-sonar | 200, wrong endpoint | 200, right endpoint |
| E | `/v1/messages` | chat-sonar | 200 | 200 |

### Before (1d7f675e52)

#### B. Multi-segment deployment on /v1/messages

1. Run:

```
messages_client.messages.with_raw_response.create(model="kimi-k3", ...)
```

2. Observe a 400 naming a model nobody configured, `kimi-k3` rather than `perplexity/kimi-k3`:

```
HTTP 400

{
  "error": {
    "message": "litellm.BadRequestError: PerplexityException - Invalid model 'kimi-k3'. Permitted models can be found in the documentation at https://docs.perplexity.ai/docs/getting-started/models.. Received Model Group=kimi-k3\nAvailable Model Group Fallbacks=None",
    "code": "400"
  }
}
```

#### A. The same deployment on /v1/responses

1. Run:

```
responses_client.responses.with_raw_response.create(model="kimi-k3", ...)
```

2. Observe 200, which is why the `/v1/messages` failure reads as arbitrary. The provider is asked for `perplexity/kimi-k3` and answers:

```
HTTP 200

x-litellm-model-name: perplexity/perplexity/kimi-k3
x-litellm-model-api-base: https://api.perplexity.ai
x-litellm-response-cost: 0.00163

{
  "id": "resp_I4L_kC0eF1nlzY47_7rizs7Gz_v_...",
  "model": "kimi-k3",
  "object": "response",
  "output": [{"content": [{"text": "Four.", "type": "output_text"}], "role": "assistant", "type": "message"}],
  "status": "completed",
  "usage": {"input_tokens": 116, "output_tokens": 96, "total_tokens": 212}
}
```

#### C. Agent deployment on /v1/responses

1. Run:

```
responses_client.responses.with_raw_response.create(model="agent-sonar", ...)
```

2. Observe 200 off Perplexity's Agent endpoint, 37 input tokens because the Agent prepends its own context:

```
HTTP 200

x-litellm-model-name: perplexity/perplexity/sonar
x-litellm-model-api-base: https://api.perplexity.ai
x-litellm-response-cost: 2e-05

{
  "id": "resp_5gYj3CzLJp5m7DpwMHRDICSAl2FZZq8...",
  "model": "agent-sonar",
  "object": "response",
  "output": [{"content": [{"text": "Four", "type": "output_text"}], "role": "assistant", "type": "message"}],
  "status": "completed",
  "usage": {"input_tokens": 37, "output_tokens": 5, "total_tokens": 42}
}
```

#### D. The same Agent deployment on /v1/messages

1. Run:

```
messages_client.messages.with_raw_response.create(model="agent-sonar", ...)
```

2. Observe a 200 that only looks right. Compare its 12 input tokens against step C's 37 on the very same deployment: this answer came off Perplexity's chat endpoint as bare `sonar`, not off the Agent endpoint the deployment is configured for. It survives only because the double-stripped id happens to name a real chat model:

```
HTTP 200

x-litellm-model-name: perplexity/perplexity/sonar
x-litellm-response-cost: 1.3000000000000001e-05

{
  "id": "9c798359-6e05-48b8-84a1-1532377be150",
  "type": "message",
  "role": "assistant",
  "model": "agent-sonar",
  "usage": {"input_tokens": 12, "output_tokens": 1},
  "content": [{"type": "text", "text": "4"}],
  "stop_reason": "end_turn"
}
```

#### E. Ordinary chat deployment on /v1/messages

1. Run:

```
messages_client.messages.with_raw_response.create(model="chat-sonar", ...)
```

2. Observe 200 off the chat endpoint, the control for the change below:

```
HTTP 200

x-litellm-model-name: perplexity/sonar
x-litellm-response-cost: 1.5e-05

{
  "id": "9dd01d8a-27c3-4994-af77-b90672bde59d",
  "type": "message",
  "role": "assistant",
  "model": "chat-sonar",
  "usage": {"input_tokens": 12, "output_tokens": 3},
  "content": [{"type": "text", "text": "**4**"}],
  "stop_reason": "end_turn"
}
```

### After (9399f2a4e4)

#### B. Multi-segment deployment on /v1/messages

1. Run:

```
messages_client.messages.with_raw_response.create(model="kimi-k3", ...)
```

2. Observe the reply, with the provider asked for `perplexity/kimi-k3` exactly as `/v1/responses` already asked:

```
HTTP 200

x-litellm-model-name: perplexity/perplexity/kimi-k3
x-litellm-response-cost: 0.001044

{
  "id": "chatcmpl-1d0cd71b-96b3-43c8-abc3-d27227157dff",
  "type": "message",
  "role": "assistant",
  "model": "kimi-k3",
  "usage": {"input_tokens": 16, "output_tokens": 48, "cache_read_input_tokens": 92},
  "content": [{"type": "text", "text": "Four"}],
  "stop_reason": "end_turn"
}
```

#### A. The same deployment on /v1/responses

1. Run:

```
responses_client.responses.with_raw_response.create(model="kimi-k3", ...)
```

2. Observe it unchanged:

```
HTTP 200

x-litellm-model-name: perplexity/perplexity/kimi-k3
x-litellm-model-api-base: https://api.perplexity.ai
x-litellm-response-cost: 0.0018

{
  "id": "resp_A99PC0iZRgQr22FEof1GNBCpEmTheVIcrZV...",
  "model": "kimi-k3",
  "object": "response",
  "output": [{"content": [{"text": "Four", "type": "output_text"}], "role": "assistant", "type": "message"}],
  "status": "completed",
  "usage": {"input_tokens": 116, "output_tokens": 113, "total_tokens": 229}
}
```

#### C. Agent deployment on /v1/responses

1. Run:

```
responses_client.responses.with_raw_response.create(model="agent-sonar", ...)
```

2. Observe it unchanged, 37 input tokens again:

```
HTTP 200

x-litellm-model-name: perplexity/perplexity/sonar
x-litellm-model-api-base: https://api.perplexity.ai
x-litellm-response-cost: 2e-05

{
  "id": "resp_IeZnyLoMEYT2lK13yCyz8JjGf0A5evF7YT5...",
  "model": "agent-sonar",
  "object": "response",
  "output": [{"content": [{"text": "Four", "type": "output_text"}], "role": "assistant", "type": "message"}],
  "status": "completed",
  "usage": {"input_tokens": 37, "output_tokens": 5, "total_tokens": 42}
}
```

#### D. The same Agent deployment on /v1/messages

1. Run:

```
messages_client.messages.with_raw_response.create(model="agent-sonar", ...)
```

2. Observe 200 whose 37 input and 5 output tokens now match step C exactly, so `/v1/messages` and `/v1/responses` are hitting the same Perplexity endpoint for the same deployment:

```
HTTP 200

x-litellm-model-name: perplexity/perplexity/sonar
x-litellm-response-cost: 4.2e-05

{
  "id": "resp_bGl0ZWxsbTpjdXN0b21fbGxtX3Byb3ZpZGVyOnBlcnBsZXhpdHk7...",
  "type": "message",
  "role": "assistant",
  "model": "agent-sonar",
  "usage": {"input_tokens": 37, "output_tokens": 5},
  "content": [{"type": "text", "text": "Four"}],
  "stop_reason": "end_turn"
}
```

#### E. Ordinary chat deployment on /v1/messages

1. Run:

```
messages_client.messages.with_raw_response.create(model="chat-sonar", ...)
```

2. Observe it unchanged, still 12 input tokens off the chat endpoint:

```
HTTP 200

x-litellm-model-name: perplexity/sonar
x-litellm-response-cost: 1.3000000000000001e-05

{
  "id": "ffe746ce-65fb-43d2-aec5-3e11c7302c23",
  "type": "message",
  "role": "assistant",
  "model": "chat-sonar",
  "usage": {"input_tokens": 12, "output_tokens": 1},
  "content": [{"type": "text", "text": "Four"}],
  "stop_reason": "end_turn"
}
```

Sweeping the whole cost map for deployments the endpoint rule could move, `perplexity/perplexity/sonar` is the only one: 54 Responses-mode deployments were checked and 1 changes route.

## Type

🐛 Bug Fix

## Caveats (if any)

- Step D changes for anyone already calling a `perplexity/perplexity/sonar` style deployment on `/v1/messages`: it now reaches the Agent endpoint instead of chat, so replies, token counts and cost move to the Agent's. That is the point of the fix, and it is what `/v1/responses` has always done for the same deployment, but it is a visible change rather than a pure repair
- The sweep above puts the blast radius at exactly that one deployment shape
- The two bridges label the top-level `id` differently, `chatcmpl-` on the completion bridge and a base64 LiteLLM composite on the Responses bridge, where the Anthropic contract wants `msg_`. Pre-existing on both, untouched here
- `/v1/messages` still drops Perplexity's `citations` and `search_results`, and its recorded cost omits the Agent's per-request search fee. Pre-existing, not in scope
- `kimi-k3` needs `max_output_tokens` on `/v1/responses` or Perplexity 400s the request. Identical on both legs, reproduced with a bare curl and no proxy in the path

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Anthropic `/v1/messages` routing and model-id rewriting for chat vs Responses bridges. Wrong routing could send requests to the wrong provider endpoint, but tests cover multi-segment ids and both stream paths.
> 
> **Overview**
> Stops `/v1/messages` from stripping extra segments off multi-part deployment ids (e.g. `perplexity/perplexity/kimi-k3`), which previously sent a truncated model name upstream and 400'd while chat/completions and responses worked.
> 
> Bridges now receive the **unresolved** caller id so provider resolution happens once. Responses-only deployments whose stripped id looks like a chat model (e.g. `perplexity/perplexity/sonar`) stay on the Responses path. Streaming `message_start` still reports the provider-local name via `local_model_name`. The OpenAI thinking reroute now inserts `responses/` after the provider (`openai/responses/...`) instead of prefixing `responses/` on the full id.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9399f2a4e449bf8d50ca28db36fea56f203fb589. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


