### PR TITLE
fix(cognition): price swe-1.7 at the standard tier, add swe-1.7-lightning

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -48949,6 +48949,16 @@
         "source": "https://docs.devin.ai/windsurf/plugins/cascade/models"
     },
     "cognition/swe-1.7": {
+        "input_cost_per_token": 5e-07,
+        "output_cost_per_token": 2.5e-06,
+        "cache_read_input_token_cost": 2e-07,
+        "litellm_provider": "cognition",
+        "mode": "chat",
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "source": "https://docs.devin.ai/desktop/models"
+    },
+    "cognition/swe-1.7-lightning": {
         "input_cost_per_token": 2.5e-06,
         "output_cost_per_token": 1.25e-05,
         "cache_read_input_token_cost": 1e-06,
@@ -48956,7 +48966,7 @@
         "mode": "chat",
         "supports_function_calling": true,
         "supports_prompt_caching": true,
-        "source": "https://docs.devin.ai/windsurf/plugins/cascade/models"
+        "source": "https://docs.devin.ai/desktop/models"
     },
     "pinstripes/ps/glm-4.5-air": {
         "max_tokens": 128000,

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -48949,6 +48949,16 @@
         "source": "https://docs.devin.ai/windsurf/plugins/cascade/models"
     },
     "cognition/swe-1.7": {
+        "input_cost_per_token": 5e-07,
+        "output_cost_per_token": 2.5e-06,
+        "cache_read_input_token_cost": 2e-07,
+        "litellm_provider": "cognition",
+        "mode": "chat",
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "source": "https://docs.devin.ai/desktop/models"
+    },
+    "cognition/swe-1.7-lightning": {
         "input_cost_per_token": 2.5e-06,
         "output_cost_per_token": 1.25e-05,
         "cache_read_input_token_cost": 1e-06,
@@ -48956,7 +48966,7 @@
         "mode": "chat",
         "supports_function_calling": true,
         "supports_prompt_caching": true,
-        "source": "https://docs.devin.ai/windsurf/plugins/cascade/models"
+        "source": "https://docs.devin.ai/desktop/models"
     },
     "pinstripes/ps/glm-4.5-air": {
         "max_tokens": 128000,

--- a/tests/test_litellm/llms/openai_like/test_cognition_provider.py
+++ b/tests/test_litellm/llms/openai_like/test_cognition_provider.py
@@ -111,33 +111,51 @@ class TestCognitionProviderIdentity:
 
 class TestCognitionCostTracking:
     @pytest.mark.parametrize(
-        "model, input_cost, output_cost",
+        "model, input_cost, output_cost, cache_read_cost",
         [
-            ("cognition/swe-1.6", 5e-07, 2.5e-06),
-            ("cognition/swe-1.7", 2.5e-06, 1.25e-05),
+            ("cognition/swe-1.6", 5e-07, 2.5e-06, 2e-07),
+            ("cognition/swe-1.7", 5e-07, 2.5e-06, 2e-07),
+            ("cognition/swe-1.7-lightning", 2.5e-06, 1.25e-05, 1e-06),
         ],
     )
-    def test_cost_map_entries(self, model: str, input_cost: float, output_cost: float):
+    def test_cost_map_entries(self, model: str, input_cost: float, output_cost: float, cache_read_cost: float):
         info = litellm.get_model_info(model=model)
 
         assert info["litellm_provider"] == "cognition"
         assert info["mode"] == "chat"
         assert info["input_cost_per_token"] == input_cost
         assert info["output_cost_per_token"] == output_cost
+        assert info["cache_read_input_token_cost"] == cache_read_cost
 
-    def test_cost_differs_from_openai_pricing(self):
+    @pytest.mark.parametrize(
+        "model, expected_prompt_cost, expected_completion_cost",
+        [
+            ("cognition/swe-1.7", 0.5, 2.5),
+            ("cognition/swe-1.7-lightning", 2.5, 12.5),
+        ],
+    )
+    def test_cost_differs_from_openai_pricing(
+        self, model: str, expected_prompt_cost: float, expected_completion_cost: float
+    ):
         """A cognition-prefixed model must never be priced off an OpenAI cost entry."""
         from litellm.cost_calculator import cost_per_token
 
         prompt_cost, completion_cost = cost_per_token(
-            model="cognition/swe-1.7",
+            model=model,
             prompt_tokens=1_000_000,
             completion_tokens=1_000_000,
             custom_llm_provider="cognition",
         )
 
-        assert prompt_cost == pytest.approx(2.5)
-        assert completion_cost == pytest.approx(12.5)
+        assert prompt_cost == pytest.approx(expected_prompt_cost)
+        assert completion_cost == pytest.approx(expected_completion_cost)
+
+    def test_lightning_is_five_times_the_standard_tier(self):
+        standard = litellm.get_model_info(model="cognition/swe-1.7")
+        lightning = litellm.get_model_info(model="cognition/swe-1.7-lightning")
+
+        assert lightning["input_cost_per_token"] == pytest.approx(standard["input_cost_per_token"] * 5)
+        assert lightning["output_cost_per_token"] == pytest.approx(standard["output_cost_per_token"] * 5)
 
     def test_supported_endpoints_matrix(self):
         matrix = json.loads((Path(litellm.__file__).parent / "provider_endpoints_support_backup.json").read_text())
@@ -168,6 +186,30 @@ class TestCognitionRouting:
             model="swe",
             messages=[{"role": "user", "content": "hi"}],
             mock_response="hello from swe",
+        )
+
+        usage = response.usage
+        expected = usage.prompt_tokens * 5e-07 + usage.completion_tokens * 2.5e-06
+        assert response._hidden_params["response_cost"] == pytest.approx(expected)
+
+    @pytest.mark.asyncio
+    async def test_router_spend_uses_the_lightning_entry_for_lightning(self):
+        """The Lightning tier is its own model, costed off its own entry."""
+        from litellm import Router
+
+        router = Router(
+            model_list=[
+                {
+                    "model_name": "swe-lightning",
+                    "litellm_params": {"model": "cognition/swe-1.7-lightning", "api_key": "sk-test"},
+                }
+            ]
+        )
+
+        response = await router.acompletion(
+            model="swe-lightning",
+            messages=[{"role": "user", "content": "hi"}],
+            mock_response="hello from swe lightning",
         )
 
         usage = response.usage


### PR DESCRIPTION
## TLDR

Problem this solves:

- `cognition/swe-1.7` shipped with the Lightning tier's prices
- Every swe-1.7 call is costed 5x too high
- The Lightning tier has no cost map entry at all

How it solves it:

- swe-1.7 drops to $0.50 in / $2.50 out per million
- New `cognition/swe-1.7-lightning` entry keeps the 5x numbers
- Source field now points at the page listing both tiers

## User Flow

Before: an admin running Cognition through the proxy is charged five times what Cognition bills, and cannot price the Lightning tier at all.

1. They add a deployment with `model: cognition/swe-1.7` to their config and restart the proxy.
2. They open `GET https://litellm-domain/model/info` and read swe-1.7 back at $2.50 per million input tokens, $12.50 per million output, $1.00 per million cache reads.
3. They price a 1M-in / 1M-out request with `POST https://litellm-domain/spend/calculate`, sending that usage under `"model": "cognition/swe-1.7"`, and get `{"cost":15.0}`. Cognition's own bill for the same usage is $3.00.
4. They try the faster tier on the same route with `"model": "cognition/swe-1.7-lightning"` and get a 500 back: `This model isn't mapped yet. model=cognition/swe-1.7-lightning, custom_llm_provider=cognition`.
5. Their spend dashboard and their invoice disagree by 5x on every swe-1.7 request.

After: the same admin sees Cognition's published price for swe-1.7, and the Lightning tier prices as its own model.

1. They add a deployment with `model: cognition/swe-1.7` to their config and restart the proxy.
2. They open `GET https://litellm-domain/model/info` and read swe-1.7 back at $0.50 per million input tokens, $2.50 per million output, $0.20 per million cache reads.
3. They price the same 1M-in / 1M-out request with `POST https://litellm-domain/spend/calculate` and get `{"cost":3.0}`, which is what Cognition charges.
4. They add a second deployment with `model: cognition/swe-1.7-lightning`, and the same `POST` for it returns `{"cost":15.0}` with `/model/info` showing $2.50 / $12.50 / $1.00.
5. Their spend dashboard matches their invoice on both tiers.

## Relevant issues

## Linear ticket

Resolves LIT-5930

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

The published price these runs are measured against is Cognition's own model list at https://docs.devin.ai/desktop/models, which embeds the table as raw JSON: uid `swe-1-7` is $0.50 in / $2.50 out / $0.20 cache read per million tokens, uid `swe-1-7-lightning` is $2.50 / $12.50 / $1.00.

Shared setup, a live proxy from a fresh worktree with its own venv, on a random free port:

    cat > config.yaml <<'YAML'
    model_list:
      - model_name: swe-1.7
        litellm_params:
          model: cognition/swe-1.7
          api_key: os.environ/COGNITION_API_KEY
      - model_name: swe-1.7-lightning
        litellm_params:
          model: cognition/swe-1.7-lightning
          api_key: os.environ/COGNITION_API_KEY
    general_settings:
      master_key: sk-lit5930
    YAML

    ./.venv/bin/litellm --config config.yaml --port $PORT --detailed_debug

The usage payload both sides send to `/spend/calculate` is 1,000,000 prompt tokens and 1,000,000 completion tokens, so the returned cost reads directly as dollars per million in plus dollars per million out.

### Before (f1c4145f86)

#### swe-1.7 pricing

1. `curl -s -X POST http://127.0.0.1:$PORT/spend/calculate -H 'Authorization: Bearer sk-lit5930' -H 'Content-Type: application/json' -d '{"completion_response": {"id":"chatcmpl-1","object":"chat.completion","created":1755648000,"model":"cognition/swe-1.7","choices":[{"index":0,"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}],"usage":{"prompt_tokens":1000000,"completion_tokens":1000000,"total_tokens":2000000}}}'`
2. `{"cost":15.0}`, where Cognition's price for that usage is $3.00.
3. `curl -s http://127.0.0.1:$PORT/model/info -H 'Authorization: Bearer sk-lit5930'` reports the swe-1.7 deployment at `input_cost_per_token: 2.5e-06`, `output_cost_per_token: 1.25e-05`, `cache_read_input_token_cost: 1e-06`.
4. The same `/spend/calculate` call for `cognition/swe-1.6`, the sibling that went in correctly, returns `{"cost":3.0}`.

#### swe-1.7-lightning pricing

1. The same `/spend/calculate` call with `"model":"cognition/swe-1.7-lightning"`.
2. `{"error":{"message":"This model isn't mapped yet. model=cognition/swe-1.7-lightning, custom_llm_provider=cognition. Add it here - https://github.com/BerriAI/litellm/blob/main/model_prices_and_context_window.json.","type":"None","param":"None","code":"500"}}`

### After (7d999a1586)

#### swe-1.7 pricing

1. The same `/spend/calculate` call for `cognition/swe-1.7`.
2. `{"cost":3.0}`, matching Cognition's published $0.50 + $2.50.
3. `curl -s http://127.0.0.1:$PORT/model/info -H 'Authorization: Bearer sk-lit5930'` reports the swe-1.7 deployment at `in 5e-07 out 2.5e-06 cache_read 2e-07 provider cognition`.
4. The `cognition/swe-1.6` call still returns `{"cost":3.0}`, unchanged.

#### swe-1.7-lightning pricing

1. The same `/spend/calculate` call with `"model":"cognition/swe-1.7-lightning"`.
2. `{"cost":15.0}`, matching Cognition's published $2.50 + $12.50, and `/model/info` reports that deployment at `in 2.5e-06 out 1.25e-05 cache_read 1e-06 provider cognition`.

Unit tests at the tip:

    $ uv run pytest tests/test_litellm/llms/openai_like/test_cognition_provider.py -q
    17 passed

    $ uv run pytest tests/test_litellm/test_model_prices_schema.py tests/test_litellm/litellm_core_utils/test_get_model_cost_map.py tests/test_litellm/proxy/proxy_server/test_routes_model_cost_map.py -q
    57 passed

    $ uv run python ci_cd/check_files_match.py
    Passed! Files model_prices_and_context_window.json and litellm/model_prices_and_context_window_backup.json match.

## Type

🐛 Bug Fix

## Caveats (if any)

- swe-1.6 keeps its existing Cascade-page source link
- `swe-1.7-medium` and `swe-1.7-lightning-medium` stay unmapped, at the same published rates as the Max rows
- Cognition provisions endpoints per customer and no key is reachable here, so the proof prices requests through `/spend/calculate` and `/model/info` instead of billing a live completion

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
