### PR TITLE
fix(proxy): preserve Anthropic rate limit headers

### DIFF
--- a/litellm/litellm_core_utils/llm_response_utils/get_headers.py
+++ b/litellm/litellm_core_utils/llm_response_utils/get_headers.py
@@ -1,5 +1,12 @@
 from typing import Final
 
+_PROVIDER_HEADERS_TO_PASSTHROUGH: Final = frozenset(
+    {
+        "anthropic-ratelimit-unified-status",
+        "retry-after",
+    }
+)
+
 
 def get_response_headers(_response_headers: dict | None = None) -> dict:
     """
@@ -28,7 +35,10 @@ def get_response_headers(_response_headers: dict | None = None) -> dict:
     if "x-ratelimit-remaining-tokens" in _response_headers:
         openai_headers["x-ratelimit-remaining-tokens"] = _response_headers["x-ratelimit-remaining-tokens"]
     llm_provider_headers: Final = _get_llm_provider_headers(_response_headers)
-    return {**llm_provider_headers, **openai_headers}
+    passthrough_headers: Final = {
+        key: value for key, value in _response_headers.items() if key.lower() in _PROVIDER_HEADERS_TO_PASSTHROUGH
+    }
+    return {**llm_provider_headers, **openai_headers, **passthrough_headers}
 
 
 def _get_llm_provider_headers(response_headers: dict) -> dict:

--- a/tests/test_litellm/test_exception_header_preservation.py
+++ b/tests/test_litellm/test_exception_header_preservation.py
@@ -278,6 +278,22 @@ class TestProxyHeaderExtraction:
         assert result.get("llm_provider-x-request-id") == "req-abc123"
         assert result.get("llm_provider-x-ms-region") == "eastus"
 
+    def test_get_response_headers_preserves_anthropic_rate_limit_headers(self):
+        """Anthropic-compatible clients need these headers on the downstream 429."""
+        from litellm.litellm_core_utils.llm_response_utils.get_headers import (
+            get_response_headers,
+        )
+
+        result = get_response_headers(
+            {
+                "Anthropic-RateLimit-Unified-Status": "rejected",
+                "Retry-After": "287441",
+            }
+        )
+
+        assert result["Anthropic-RateLimit-Unified-Status"] == "rejected"
+        assert result["Retry-After"] == "287441"
+
     def test_proxy_can_extract_headers_from_exception_response(self):
         """Simulate how proxy extracts headers from exception.response.headers."""
         from litellm.litellm_core_utils.llm_response_utils.get_headers import (


### PR DESCRIPTION
## Problem
LiteLLM's Anthropic-compatible gateway can strip the upstream `anthropic-ratelimit-unified-status` and `retry-after` headers from a 429 response. Claude Code then treats a provider quota rejection as a retryable throttle and can retry indefinitely.

## Root Cause
`get_response_headers` preserved OpenAI-compatible rate-limit headers and prefixed other provider headers as `llm_provider-*`, but did not expose the two protocol headers that Anthropic-compatible clients read directly.

## Solution
Pass through the two protocol-level headers case-insensitively while retaining the existing provider-prefixed header behavior for other upstream headers.

## Changes
- Add a small allowlist for `anthropic-ratelimit-unified-status` and `retry-after`.
- Preserve those headers in the downstream response header map.
- Add a regression test using mixed-case upstream header names.

## Testing
- Baseline: `py -3.10 -m uv run --python 3.12 --project . pytest tests/test_litellm/test_exception_header_preservation.py -q` — 15 passed.
- Final focused: same command — 16 passed.
- `py -3.10 -m uv run --python 3.12 --project . ruff format --check litellm/litellm_core_utils/llm_response_utils/get_headers.py` — passed.
- `py -3.10 -m uv run --python 3.12 --project . ruff check litellm/litellm_core_utils/llm_response_utils/get_headers.py tests/test_litellm/test_exception_header_preservation.py` — passed.
- `py -3.10 -m uv run --python 3.12 --project . python -m py_compile litellm/litellm_core_utils/llm_response_utils/get_headers.py tests/test_litellm/test_exception_header_preservation.py` — passed.
- `git diff --check` — passed.
- Broader proxy tests were not verified because the local environment lacks `prisma`.
- Basedpyright was attempted; the touched helper retains existing unparameterized `dict` typing diagnostics, so the typecheck is not reported as passed.

## Compatibility/Risk
Only two known Anthropic-compatible protocol headers are added as bare downstream headers. Other provider headers keep their existing `llm_provider-*` representation, and the existing OpenAI rate-limit header behavior is unchanged.

## Notes for Reviewer
The issue's provider-specific 429 response was reduced to a provider-independent header-preservation regression: the test verifies the exact case-insensitive mapping used by the proxy exception path. No provider call or credential is required.

## Linked Issue
Fixes #37754