### PR TITLE
fix(messages): preserve null content for tool calls

### DIFF
--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -7703,7 +7703,12 @@ def cleanup_none_field_in_message(message: AllMessageValues):
     remove None fields in the message - e.g. {"function": None} - some providers raise validation errors
     """
     new_message: Final = message.copy()
-    return {k: v for k, v in new_message.items() if v is not None}
+    return {
+        k: v
+        for k, v in new_message.items()
+        if v is not None
+        or (k == "content" and new_message.get("role") == "assistant" and new_message.get("tool_calls"))
+    }
 
 
 def validate_chat_completion_user_messages(messages: list[AllMessageValues]):

--- a/tests/test_litellm/test_message_normalization.py
+++ b/tests/test_litellm/test_message_normalization.py
@@ -1,0 +1,33 @@
+from litellm.utils import cleanup_none_field_in_message
+
+
+def test_cleanup_preserves_null_content_for_assistant_tool_calls():
+    message = {
+        "role": "assistant",
+        "content": None,
+        "tool_calls": [
+            {
+                "id": "call_1",
+                "type": "function",
+                "function": {"name": "get_weather", "arguments": "{}"},
+            }
+        ],
+    }
+
+    result = cleanup_none_field_in_message(message)
+
+    assert result == message
+    assert "content" in result
+
+
+def test_cleanup_still_removes_unneeded_null_fields():
+    message = {
+        "role": "assistant",
+        "content": None,
+        "tool_calls": None,
+        "function_call": None,
+    }
+
+    result = cleanup_none_field_in_message(message)
+
+    assert result == {"role": "assistant"}


### PR DESCRIPTION
## Problem
Assistant tool-call turns commonly use `content: null`, but LiteLLM removes that key before sending the message to an OpenAI-compatible provider. Strict providers then reject the history because `content` is missing, interrupting multi-turn agent tool use.

## Root Cause
`cleanup_none_field_in_message` removed every `None` value without considering the OpenAI tool-call message contract. The helper is used by the normal message preprocessing path before the provider SDK boundary.

## Solution
Preserve `content: null` specifically for assistant messages that contain tool calls, while continuing to remove unrelated optional `None` fields.

## Changes
- Keep the assistant `content` key when `tool_calls` are present, even when its value is `None`.
- Add regressions for tool-call messages and for ordinary nullable fields that should still be removed.

## Testing
- Baseline prompt-template suite: `py -3.10 -m uv run --python 3.12 --project . pytest tests/test_litellm/litellm_core_utils/prompt_templates/test_litellm_core_utils_prompt_templates_factory.py -q` — 97 passed.
- Final prompt-template plus message-normalization suites — 99 passed.
- `py -3.10 -m uv run --python 3.12 --project . ruff format --check litellm/utils.py tests/test_litellm/test_message_normalization.py` — passed.
- `py -3.10 -m uv run --python 3.12 --project . ruff check litellm/utils.py tests/test_litellm/test_message_normalization.py` — passed.
- `py -3.10 -m uv run --python 3.12 --project . python -m py_compile litellm/utils.py tests/test_litellm/test_message_normalization.py` — passed.
- `git diff --check` — passed.
- Full repository suite and dedicated typecheck were not run; they are not required to exercise this isolated message-normalization change in the current environment.

## Compatibility/Risk
This preserves one OpenAI-spec-compatible field only for assistant tool-call messages. Other `None` fields continue to be removed, and messages without tool calls retain the prior normalization behavior.

## Notes for Reviewer
The regression does not require a provider, API key, proxy, or network service. It asserts the exact dictionary shape that reaches the provider boundary and the unchanged cleanup behavior for unrelated nullable fields.

## Linked Issue
Fixes #37711