### PR TITLE
fix(sagemaker_chat): send the inference component header and honor hf_model_name

### DIFF
--- a/litellm/llms/sagemaker/chat/transformation.py
+++ b/litellm/llms/sagemaker/chat/transformation.py
@@ -54,7 +54,30 @@ class SagemakerChatConfig(OpenAIGPTConfig, BaseAWSLLM):
         api_key: str | None = None,
         api_base: str | None = None,
     ) -> dict:
-        return headers
+        inference_component_name: Final = optional_params.get("model_id")
+        if not isinstance(inference_component_name, str):
+            return headers
+        return {**headers, "X-Amzn-SageMaker-Inference-Component": inference_component_name}
+
+    def transform_request(
+        self,
+        model: str,
+        messages: list[AllMessageValues],  # mutable-ok: matches the base chat transform signature
+        optional_params: dict,  # mutable-ok: matches the base chat transform signature
+        litellm_params: dict,  # mutable-ok: matches the base chat transform signature
+        headers: dict,  # mutable-ok: matches the base chat transform signature
+    ) -> dict:  # mutable-ok: the handler sends this body straight to httpx
+        request: Final = super().transform_request(
+            model=model,
+            messages=messages,
+            optional_params=optional_params,
+            litellm_params=litellm_params,
+            headers=headers,
+        )
+        served_model_name: Final = litellm_params.get("hf_model_name")
+        if not isinstance(served_model_name, str):
+            return request
+        return {**request, "model": served_model_name}
 
     def get_complete_url(
         self,

--- a/tests/test_litellm/llms/sagemaker/test_sagemaker_chat_transformation.py
+++ b/tests/test_litellm/llms/sagemaker/test_sagemaker_chat_transformation.py
@@ -19,6 +19,8 @@ from unittest.mock import MagicMock
 import httpx
 import pytest
 
+import litellm
+from litellm.llms.custom_httpx.http_handler import HTTPHandler
 from litellm.llms.sagemaker.chat.transformation import SagemakerChatConfig
 
 
@@ -233,3 +235,85 @@ def test_decoder_reassembles_frames_across_arbitrary_byte_boundaries(split_size)
     ]
 
     assert texts == [f"token{i} " for i in range(len(frames))]
+
+
+_INFERENCE_COMPONENT_HEADER = "X-Amzn-SageMaker-Inference-Component"
+
+_STUB_COMPLETION_RESPONSE = {
+    "id": "chatcmpl-test",
+    "object": "chat.completion",
+    "created": 1700000000,
+    "model": "served-model",
+    "choices": [{"index": 0, "message": {"role": "assistant", "content": "hi"}, "finish_reason": "stop"}],
+    "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+}
+
+
+class _RequestCapturingHTTPHandler(HTTPHandler):
+    """Injected transport that records exactly what sagemaker_chat put on the wire."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.request_headers: dict[str, str] = {}
+        self.request_body: dict = {}
+
+    def post(self, url: str, headers=None, data=None, **kwargs) -> httpx.Response:
+        self.request_headers = dict(headers or {})
+        self.request_body = json.loads(data)
+        return httpx.Response(200, json=_STUB_COMPLETION_RESPONSE, request=httpx.Request("POST", url))
+
+
+def _invoke_sagemaker_chat(monkeypatch, **extra_params) -> _RequestCapturingHTTPHandler:
+    """Drive one sagemaker_chat completion against an injected transport.
+
+    A Bedrock API key short-circuits SigV4 inside `BaseAWSLLM._sign_request`, which would hide
+    whether the inference-component header is really covered by the signature, so it is cleared.
+    """
+    monkeypatch.delenv("AWS_BEARER_TOKEN_BEDROCK", raising=False)
+    client = _RequestCapturingHTTPHandler()
+    litellm.completion(
+        model="sagemaker_chat/my-endpoint",
+        messages=[{"role": "user", "content": "hi"}],
+        aws_access_key_id="AKIATESTTESTTESTTEST",
+        aws_secret_access_key="test-secret-key",
+        aws_region_name="us-east-1",
+        client=client,
+        **extra_params,
+    )
+    return client
+
+
+def test_model_id_is_sent_as_a_signed_inference_component_header(monkeypatch):
+    """`model_id` names an inference component and must reach SageMaker as a signed header.
+
+    Endpoints backed by inference components reject any request without
+    `X-Amzn-SageMaker-Inference-Component` with HTTP 400 INFERENCE_COMPONENT_NAME_MISSING, so the
+    header has to be built before `sign_request` runs and end up inside SignedHeaders.
+    """
+    client = _invoke_sagemaker_chat(monkeypatch, model_id="my-inference-component")
+
+    assert client.request_headers[_INFERENCE_COMPONENT_HEADER] == "my-inference-component"
+    assert "x-amzn-sagemaker-inference-component" in client.request_headers["Authorization"]
+
+
+def test_no_inference_component_header_when_model_id_is_unset(monkeypatch):
+    """Plain endpoints must not receive the header at all, not even an empty one."""
+    client = _invoke_sagemaker_chat(monkeypatch)
+
+    assert not any(name.lower() == _INFERENCE_COMPONENT_HEADER.lower() for name in client.request_headers)
+
+
+def test_hf_model_name_becomes_the_body_model(monkeypatch):
+    """`hf_model_name` names the served model, and containers that validate the body's `model`
+    404 on the endpoint name, so it has to replace it rather than ride along as an extra field."""
+    client = _invoke_sagemaker_chat(monkeypatch, hf_model_name="org/served-model")
+
+    assert client.request_body["model"] == "org/served-model"
+    assert "hf_model_name" not in client.request_body
+
+
+def test_body_model_stays_the_endpoint_name_when_hf_model_name_is_unset(monkeypatch):
+    """Without `hf_model_name` the body must keep the model it has today."""
+    client = _invoke_sagemaker_chat(monkeypatch)
+
+    assert client.request_body["model"] == "my-endpoint"


### PR DESCRIPTION
## TLDR

Problem this solves:

- `sagemaker_chat` never sends the inference component header
- Endpoints backed by inference components answer 400 and fail
- Request body names the endpoint, not the served model
- Containers that validate the body's model answer 404

How it solves it:

- Build the header from `model_id`, before the request is signed
- Mirrors what the legacy `sagemaker` provider already does
- Use `hf_model_name` as the body's model when set
- Endpoints setting neither keep the exact request they send today

## User Flow

Before: an operator whose model is deployed as a SageMaker inference component cannot get a single completion through without hand-editing the request

1. They add `model: sagemaker_chat/<endpoint-name>` to the proxy config with `model_id: <inference-component-name>` and `hf_model_name: <served-model-name>`, then start the proxy
2. They open https://litellm-domain/ui/?page=llm-playground, pick that model, and send "hi", which posts to https://litellm-domain/v1/chat/completions
3. They get back a 400 reading `SagemakerException - {"ErrorCode":"INFERENCE_COMPONENT_NAME_MISSING","Message":"Inference Component Name header is required for endpoints to which you plan to deploy inference components. Please include Inference Component Name header or consider using SageMaker models."}`, and nothing ever reaches their container
4. They add `extra_headers: {"X-Amzn-SageMaker-Inference-Component": "<inference-component-name>"}` to that model and restart, which finally gets the request past AWS
5. Their container now answers 404 `The model '<endpoint-name>' does not exist.`, because the request asked for the endpoint by name instead of the model the container actually serves
6. They only get an answer by overriding the served model name on every single request

After: the same config works on the first try, with no `extra_headers` and nothing overridden per request

1. They add `model: sagemaker_chat/<endpoint-name>` to the proxy config with `model_id: <inference-component-name>` and `hf_model_name: <served-model-name>`, then start the proxy
2. They open https://litellm-domain/ui/?page=llm-playground, pick that model, and send "hi", which posts to https://litellm-domain/v1/chat/completions
3. They get back a 200 carrying a real assistant message generated by the deployed model
4. They send the same request with curl against https://litellm-domain/v1/chat/completions and see the same 200
5. An operator on a plain endpoint that sets neither `model_id` nor `hf_model_name` sends the same request and gets the same 200 they got before this change

## Relevant issues

Fixes #9909

## Linear ticket

Resolves LIT-2853

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

QA ran against a live SageMaker endpoint backed by a real inference component in us-east-1, serving `Qwen/Qwen2.5-0.5B-Instruct` on vLLM 0.27.1. Two matched worktrees, each with its own venv, its own `.env` and its own random port, differing only in the commit the proxy booted from: before `a66a10b1b5` (this PR's merge base), after `2ea633d223` (this PR's head). Real AWS, real GPU, no mocks.

Config under test, the same file on both legs:

```yaml
model_list:
  - model_name: sagemaker-vllm
    litellm_params:
      model: sagemaker_chat/<endpoint-name>
      model_id: <inference-component-name>
      hf_model_name: Qwen/Qwen2.5-0.5B-Instruct
      aws_region_name: us-east-1
      max_tokens: 16
```

### Before (`a66a10b1b5`): HTTP 400, the request never reaches the container

```bash
curl -sS -w '\nHTTP_STATUS=%{http_code}\n' http://127.0.0.1:$PORT/v1/chat/completions \
  -H 'Content-Type: application/json' -H "Authorization: Bearer $LITELLM_MASTER_KEY" \
  -d '{"model":"sagemaker-vllm","messages":[{"role":"user","content":"Say hello in three words."}]}'
```

```
{"error":{"message":"litellm.BadRequestError: SagemakerException - {\"ErrorCode\":\"INFERENCE_COMPONENT_NAME_MISSING\",\"Message\":\"Inference Component Name header is required for endpoints to which you plan to deploy inference components. Please include Inference Component Name header or consider using SageMaker models.\"}. Received Model Group=sagemaker-vllm\nAvailable Model Group Fallbacks=None","type":null,"param":null,"code":"400"}}
HTTP_STATUS=400
```

Same flow through the OpenAI Python SDK (`openai==2.54.0`) pointed at the proxy:

```
CLIENT_ERROR BadRequestError status: 400
body: {'message': 'litellm.BadRequestError: SagemakerException - {"ErrorCode":"INFERENCE_COMPONENT_NAME_MISSING","Message":"Inference Component Name header is required for endpoints to which you plan to deploy inference components. Please include Inference Component Name header or consider using SageMaker models."}. Received Model Group=sagemaker-vllm\nAvailable Model Group Fallbacks=None', 'type': None, 'param': None, 'code': '400'}
```

### After (`2ea633d223`): HTTP 200 and a real completion

```bash
curl -sS -w '\nHTTP_STATUS=%{http_code}\n' http://127.0.0.1:$PORT/v1/chat/completions \
  -H 'Content-Type: application/json' -H "Authorization: Bearer $LITELLM_MASTER_KEY" \
  -d '{"model":"sagemaker-vllm","messages":[{"role":"user","content":"Say hello in three words."}]}'
```

```
{"id":"chatcmpl-85a534ec4a337f57","created":1787281556,"model":"sagemaker-vllm","object":"chat.completion","system_fingerprint":"vllm-0.27.1-889a35c9","choices":[{"finish_reason":"stop","index":0,"message":{"content":"Hello, how are you?","role":"assistant"}}],"usage":{"completion_tokens":7,"prompt_tokens":35,"total_tokens":42}}
HTTP_STATUS=200
```

Same flow through the OpenAI Python SDK:

```
CLIENT_SUCCESS
{
  "id": "chatcmpl-a1d61b3484d8b9c5",
  "choices": [{"finish_reason": "stop", "index": 0,
               "message": {"content": "Hello! How can I help you today?", "role": "assistant"}}],
  "created": 1787281555,
  "model": "sagemaker-vllm",
  "object": "chat.completion",
  "system_fingerprint": "vllm-0.27.1-889a35c9",
  "usage": {"completion_tokens": 10, "prompt_tokens": 35, "total_tokens": 45}
}
```

### Regression legs, so nothing changes for endpoints that set neither key

Every row below is the same curl and the same SDK call, only the config differs. The 400s are the correct result: an endpoint that requires the header still says it is missing, rather than a new "Inference Component ... not found" error, which is what AWS answers when a wrong header is actually sent.

| Config | Before | After |
|---|---|---|
| `model_id` + `hf_model_name` | 400 missing | 200 |
| `model_id` only | 400 missing | 200 |
| neither key | 400 missing | 400 missing |
| `hf_model_name` only | 400 missing | 400 missing |

The `model_id` only row is the reporter's exact config from #9909, and it flips on the header change alone.

### One half is not provable on this rig, stated plainly

The header fix proves itself end to end above. The `hf_model_name` fix does not, and this run did not pretend otherwise. vLLM 0.27.1's `/invocations` route ignores the request body's `model` outright: sending the endpoint name, and then outright nonsense, both returned 200, and the response always echoes back the served model. So the client sees the same 200 whether or not the body was rewritten. The difference appears only in the outbound request, where the `model_id` only leg sends the endpoint name and the leg with `hf_model_name` sends `Qwen/Qwen2.5-0.5B-Instruct`. That is wire evidence rather than something an end user observes, so it is flagged here instead of being presented as proof. The regression tests in this PR assert it on the wire directly. Users whose container does validate the body's model see it as the 404 in the User Flow above; this rig's container is not one of them.

### Things the QA legs saw that the diff does not show

- `inference_component_name` config key is dead, silently ignored
- Config keys leak into the outbound JSON body generally
- This PR neither causes nor worsens either; both predate it
- Response `model` echoes the proxy alias, not the served model
- Request-body `model_id` overrides the configured inference component
- Before this PR `extra_headers` overrode it more freely still

## Type

🐛 Bug Fix

## Caveats (if any)

- `hf_model_name` only affects `sagemaker_chat`, not the legacy provider
- Header value comes from `model_id`, the key the legacy provider already uses

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes signed AWS request headers and outbound JSON for SageMaker chat. Behavior is gated on optional params, but a wrong header or body model would 400/404 live endpoints.
> 
> **Overview**
> Makes `sagemaker_chat` work with SageMaker inference-component endpoints and containers that validate the served model name.
> 
> When `model_id` is set, `validate_environment` now adds `X-Amzn-SageMaker-Inference-Component` before SigV4 so the header is signed (matching the legacy `sagemaker` provider). When `hf_model_name` is set, `transform_request` overwrites the request body's `model` with that served name instead of the endpoint name. Endpoints that set neither keep the previous request shape.
> 
> Tests drive a real `completion()` through a capturing HTTP client and assert the signed header and body rewrite, plus the no-op cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2ea633d223e57777edf39edb2c3ca6b18c0266d2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

- [x] 2ea633d223e57777edf39edb2c3ca6b18c0266d2 passes /live-pr-risk

