### PR TITLE
fix(proxy): forward anthropic 429 rate-limit headers on /v1/messages

### DIFF
--- a/litellm/proxy/anthropic_endpoints/endpoints.py
+++ b/litellm/proxy/anthropic_endpoints/endpoints.py
@@ -2,6 +2,7 @@
 Unified /v1/messages endpoint - (Anthropic Spec)
 """
 
+from collections.abc import Mapping
 from typing import Final
 
 from fastapi import APIRouter, Depends, HTTPException, Request, Response
@@ -27,6 +28,43 @@ from litellm.proxy.common_utils.http_parsing_utils import _read_request_body
 from litellm.types.utils import TokenCountResponse
 
 router: Final = APIRouter()
+
+
+# Upstream response headers forwarded unprefixed on the /v1/messages error
+# path. Restricted to Anthropic-native rate-limit headers so a hostile upstream
+# cannot spoof proxy-owned ``x-litellm-*`` metadata or set browser/framing
+# headers on the proxy's own response.
+_FORWARDABLE_UPSTREAM_HEADERS: Final = frozenset({"retry-after", "request-id"})
+_FORWARDABLE_UPSTREAM_PREFIX: Final = "anthropic-"
+
+
+def _extract_upstream_anthropic_headers(e: Exception) -> Mapping[str, str]:
+    """Return the upstream provider's Anthropic-native rate-limit headers from a
+    mapped LiteLLM exception, so they survive the proxy's error wrapping.
+
+    The ``/v1/messages`` endpoint speaks the Anthropic protocol, so these are
+    forwarded unprefixed — unlike the OpenAI-format path, which namespaces
+    upstream headers under ``llm_provider-``. Keys are lowercased and limited to
+    an allowlist (``retry-after``, ``request-id``, ``anthropic-*``) so a hostile
+    upstream cannot forge case-variant ``x-litellm-*`` headers or inject
+    browser/framing headers. Source order: ``litellm_response_headers`` (set by
+    the exception mapper), then ``e.headers``, then ``e.response.headers``.
+    """
+    raw = getattr(e, "litellm_response_headers", None) or getattr(e, "headers", None)
+    if not raw:
+        _response = getattr(e, "response", None)
+        raw = getattr(_response, "headers", None) if _response is not None else None
+    if not raw:
+        return {}
+    try:
+        items = raw.items()
+    except AttributeError:
+        return {}
+    return {
+        key: str(v)
+        for k, v in items
+        if (key := str(k).lower()) in _FORWARDABLE_UPSTREAM_HEADERS or key.startswith(_FORWARDABLE_UPSTREAM_PREFIX)
+    }
 
 
 def _strip_total_tokens_from_anthropic_response(response: Any) -> None:
@@ -201,7 +239,9 @@ async def anthropic_response(
         model_info: Final = litellm_metadata.get("model_info", {}) or {}
         model_id: Final = model_info.get("id", "") or ""
 
-        # Get headers
+        # Preserve upstream rate-limit headers so clients can fail fast on 429 (#37754).
+        upstream_headers: Final = _extract_upstream_anthropic_headers(e)
+
         headers: Final = ProxyBaseLLMRequestProcessing.get_custom_headers(
             user_api_key_dict=user_api_key_dict,
             call_id=data.get("litellm_call_id", ""),
@@ -220,7 +260,7 @@ async def anthropic_response(
             type=getattr(e, "type", "None"),
             param=getattr(e, "param", "None"),
             code=getattr(e, "status_code", 500),
-            headers=headers,
+            headers={**upstream_headers, **headers},  # proxy-owned headers win
         )
 
 

--- a/tests/test_litellm/proxy/anthropic_endpoints/test_endpoints.py
+++ b/tests/test_litellm/proxy/anthropic_endpoints/test_endpoints.py
@@ -307,3 +307,169 @@ class TestStripTotalTokensFeatureFlag(unittest.TestCase):
         import litellm
 
         assert litellm.strip_anthropic_total_tokens is False
+
+
+class TestUpstreamRateLimitHeaderPassthrough:
+    """Issue #37754: on a 429 from an Anthropic-compatible upstream (e.g. GLM),
+    the `/v1/messages` endpoint must forward the upstream's Anthropic-native
+    rate-limit headers (`retry-after`, `anthropic-ratelimit-unified-status`)
+    to the client. Without them, Claude Code treats the 429 as a transient
+    throttle and retries forever.
+    """
+
+    def _build_upstream_ratelimit_exception(self):
+        """Produce the exception the proxy sees when an Anthropic-compatible
+        upstream returns 429, through the REAL litellm exception mapping so
+        `litellm_response_headers` is populated exactly as in production."""
+        import httpx
+
+        import litellm
+        from litellm.llms.anthropic.common_utils import AnthropicError
+
+        upstream_headers = httpx.Headers(
+            {
+                "anthropic-ratelimit-unified-status": "rejected",
+                "retry-after": "287441",
+                "request-id": "20260821091810b67f7ae6443d450c",
+                # A vendor header that MUST be stripped before the proxy
+                # forwards it as its own response header.
+                "set-cookie": "acw_tc=abc; path=/; HttpOnly",
+            }
+        )
+        raw = AnthropicError(
+            status_code=429,
+            message=(
+                '{"type":"error","error":{"type":"rate_limit_error",'
+                '"code":"1310","message":"quota exhausted"}}'
+            ),
+            headers=upstream_headers,
+        )
+        try:
+            litellm.exception_type(
+                model="glm-5.2",
+                original_exception=raw,
+                custom_llm_provider="anthropic",
+            )
+        except Exception as mapped:
+            return mapped
+        raise AssertionError("exception_type did not raise")
+
+    @pytest.mark.asyncio
+    async def test_429_forwards_anthropic_ratelimit_headers(self):
+        import litellm.proxy.anthropic_endpoints.endpoints as ep
+        import litellm.proxy.proxy_server as proxy_server
+        from litellm.proxy._types import ProxyException, UserAPIKeyAuth
+
+        mapped = self._build_upstream_ratelimit_exception()
+
+        with (
+            patch.object(ep, "_read_request_body", new=AsyncMock(return_value={"model": "glm"})),
+            patch.object(
+                ep.ProxyBaseLLMRequestProcessing,
+                "base_process_llm_request",
+                new=AsyncMock(side_effect=mapped),
+            ),
+            patch.object(proxy_server, "proxy_logging_obj") as mock_logging,
+        ):
+            mock_logging.post_call_failure_hook = AsyncMock()
+            with pytest.raises(ProxyException) as exc_info:
+                await ep.anthropic_response(
+                    fastapi_response=MagicMock(),
+                    request=MagicMock(),
+                    user_api_key_dict=UserAPIKeyAuth(),
+                )
+
+        raised = exc_info.value
+        headers = {k.lower(): v for k, v in (raised.headers or {}).items()}
+        assert raised.code == "429"
+        # The two headers the issue is about — forwarded verbatim (unprefixed).
+        assert headers.get("anthropic-ratelimit-unified-status") == "rejected"
+        assert headers.get("retry-after") == "287441"
+        # Unsafe vendor headers must not leak onto the proxy's own response.
+        assert "set-cookie" not in headers
+        # LiteLLM's own headers are still present.
+        assert "x-litellm-version" in headers
+        mock_logging.post_call_failure_hook.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_upstream_cannot_spoof_litellm_headers(self):
+        """A hostile upstream must not be able to forge proxy-owned x-litellm-*
+        metadata — including via case-variant header names, which HTTP treats as
+        the same header. Only allowlisted Anthropic-native headers pass."""
+        import litellm.proxy.anthropic_endpoints.endpoints as ep
+        import litellm.proxy.proxy_server as proxy_server
+        from litellm.proxy._types import ProxyException, UserAPIKeyAuth
+
+        mapped = self._build_upstream_ratelimit_exception()
+        mapped.litellm_response_headers = {
+            "retry-after": "287441",
+            "x-litellm-version": "spoofed",  # exact-case spoof
+            "X-LiteLLM-Model-ID": "forged-model",  # case-variant spoof
+            "X-LiteLLM-Response-Cost": "999.99",
+        }
+
+        with (
+            patch.object(ep, "_read_request_body", new=AsyncMock(return_value={"model": "glm"})),
+            patch.object(
+                ep.ProxyBaseLLMRequestProcessing,
+                "base_process_llm_request",
+                new=AsyncMock(side_effect=mapped),
+            ),
+            patch.object(proxy_server, "proxy_logging_obj") as mock_logging,
+        ):
+            mock_logging.post_call_failure_hook = AsyncMock()
+            with pytest.raises(ProxyException) as exc_info:
+                await ep.anthropic_response(
+                    fastapi_response=MagicMock(),
+                    request=MagicMock(),
+                    user_api_key_dict=UserAPIKeyAuth(),
+                )
+
+        raised_headers = exc_info.value.headers or {}
+        headers = {k.lower(): v for k, v in raised_headers.items()}
+        # The legit rate-limit header still passes.
+        assert headers.get("retry-after") == "287441"
+        # No forged value reaches the client, under any casing.
+        assert all(v not in ("spoofed", "forged-model", "999.99") for v in raised_headers.values())
+        # No case-variant duplicate x-litellm-* key survived.
+        assert [k for k in raised_headers if k.lower() == "x-litellm-model-id"] in ([], ["x-litellm-model-id"])
+
+    def test_extract_upstream_headers_empty_when_none(self):
+        """No upstream headers anywhere -> empty dict (no crash)."""
+        from litellm.proxy.anthropic_endpoints.endpoints import (
+            _extract_upstream_anthropic_headers,
+        )
+
+        e = Exception("boom")
+        assert _extract_upstream_anthropic_headers(e) == {}
+
+    def test_extract_upstream_headers_non_mapping_source(self):
+        """A header source that isn't a mapping (no .items()) is tolerated -> {}."""
+        from litellm.proxy.anthropic_endpoints.endpoints import (
+            _extract_upstream_anthropic_headers,
+        )
+
+        e = Exception("boom")
+        e.litellm_response_headers = ["retry-after", "10"]  # list, not a mapping
+        assert _extract_upstream_anthropic_headers(e) == {}
+
+    def test_extract_upstream_headers_strips_unsafe(self):
+        from litellm.proxy.anthropic_endpoints.endpoints import (
+            _extract_upstream_anthropic_headers,
+        )
+
+        e = Exception("boom")
+        e.litellm_response_headers = {
+            "retry-after": "10",
+            "Anthropic-RateLimit-Unified-Status": "rejected",  # case-normalized to lowercase
+            "set-cookie": "x=1",
+            "content-length": "123",
+            "access-control-allow-origin": "*",
+            "X-LiteLLM-Model-ID": "forged",  # proxy-owned namespace, must be dropped
+            "x-process-time": "0.1",  # not allowlisted
+        }
+        out = {k: v for k, v in _extract_upstream_anthropic_headers(e).items()}
+        assert out == {
+            "retry-after": "10",
+            "anthropic-ratelimit-unified-status": "rejected",
+        }


### PR DESCRIPTION
## TLDR

Problem this solves:

- 429s from Anthropic-protocol backends drop `retry-after`
- `anthropic-ratelimit-unified-status` is also stripped on 429
- Claude Code then retries a rejected quota forever

How it solves it:

- `/v1/messages` now forwards upstream 429 response headers
- Anthropic-native headers pass through unprefixed to the client
- Unsafe headers (cookies, CORS, framing) stay stripped

## User Flow

Before: a developer using Claude Code against a LiteLLM gateway backed by an Anthropic-compatible model hits a quota 429 and their client retries endlessly

1. They send POST https://litellm-domain/v1/messages with the full `anthropic-beta` header and a body that trips the backend's weekly/monthly quota
2. The backend replies 429 with `anthropic-ratelimit-unified-status: rejected` and `retry-after: 287441`
3. The gateway returns 429 to Claude Code, but the response has neither `retry-after` nor `anthropic-ratelimit-unified-status`
4. Claude Code reads the bare 429 as a transient throttle and keeps re-sending the request in a tight loop

After: the same 429 carries the two headers through, so Claude Code recognizes the rejection and stops

1. They send the same POST https://litellm-domain/v1/messages with the same `anthropic-beta` header and body
2. The backend replies 429 with `anthropic-ratelimit-unified-status: rejected` and `retry-after: 287441`
3. The gateway now returns 429 with `anthropic-ratelimit-unified-status: rejected` and `retry-after: 287441` present on the response
4. Claude Code sees `rejected` and fails fast instead of retrying

## Relevant issues

Fixes #37754

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Shared setup: an Anthropic-compatible upstream returns the issue's exact quota 429 — `anthropic-ratelimit-unified-status: rejected`, `retry-after: 287441` — and the `/v1/messages` handler is driven with it. The steps print the response headers the gateway hands back to the client.

### Before (a112ba5f63)

1. Drive the `/v1/messages` handler with the upstream 429 and inspect the returned headers:

```
=== response headers returned to client ===
  x-litellm-key-spend: 0.0
  x-litellm-response-cost: 0
  x-litellm-version: 1.99.0

status_code: 429
forwards anthropic-ratelimit-unified-status: False
forwards retry-after                       : False
```

2. Both rate-limit headers are absent — the client cannot tell the quota was rejected, matching the report.

### After (a112ba5f63)

1. Same upstream 429, same handler, with this change applied:

```
=== response headers returned to client ===
  anthropic-ratelimit-unified-status: rejected
  request-id: 20260821091810b67f7ae6443d450c
  retry-after: 287441
  x-litellm-key-spend: 0.0
  x-litellm-response-cost: 0
  x-litellm-version: 1.99.0

status_code: 429
forwards anthropic-ratelimit-unified-status: True
forwards retry-after                       : True
```

2. Both headers now reach the client unprefixed; a hostile upstream `set-cookie` is stripped.
3. `uv run pytest tests/test_litellm/proxy/anthropic_endpoints/test_endpoints.py -v` → 17 passed (4 new cases for this fix).

## Type

🐛 Bug Fix

## Caveats (if any)

- Upstream framing/browser-security headers remain stripped by design.
- LiteLLM's own `x-litellm-*` headers win on any key collision.


### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
