### PR TITLE
test: enforce PT011 and PT014 so a broad pytest.raises cannot pass on the wrong error

### DIFF
--- a/ruff-tests.toml
+++ b/ruff-tests.toml
@@ -20,6 +20,12 @@
 # PT012   a `pytest.raises` block that runs on past the raising call. Everything after
 #         that call is dead, so an `assert` sitting there is never checked. Keep the
 #         block to the call itself and put the assertions below it
+# PT011   `pytest.raises(Exception)` / `(ValueError)` / `(OSError)` with no `match=`. The
+#         block passes on any error that broad, so the TypeError a refactor introduced
+#         reads as the rejection under test. Pin the message the code actually raises
+# PT014   the same `parametrize` case listed twice. The copy re-runs an assertion that
+#         already passed and adds no coverage, and it usually marks a case someone meant
+#         to vary and forgot to edit
 #
 # No target-version here on purpose: it resolves from requires-python (>=3.10), so
 # 3.11-only builtins like BaseExceptionGroup are correctly flagged in a tree that
@@ -27,4 +33,4 @@
 
 line-length = 120
 
-lint.select = ["F821", "B011", "B015", "B017", "B018", "PT012", "PT015", "PLR0133", "PLW0127"]
+lint.select = ["F821", "B011", "B015", "B017", "B018", "PT011", "PT012", "PT014", "PT015", "PLR0133", "PLW0127"]

--- a/tests/enterprise/litellm_enterprise/integrations/test_prometheus.py
+++ b/tests/enterprise/litellm_enterprise/integrations/test_prometheus.py
@@ -400,7 +400,7 @@ def test_invalid_metric_name_validation():
     litellm.prometheus_metrics_config = test_config
 
     # Creating PrometheusLogger should raise ValueError due to invalid metric
-    with pytest.raises(ValueError) as exc_info:
+    with pytest.raises(ValueError, match='Configuration validation failed') as exc_info:
         PrometheusLogger()
 
     # Verify error message contains information about invalid metric
@@ -429,7 +429,7 @@ def test_invalid_labels_validation():
     litellm.prometheus_metrics_config = test_config
 
     # Creating PrometheusLogger should raise ValueError due to invalid labels
-    with pytest.raises(ValueError) as exc_info:
+    with pytest.raises(ValueError, match='Configuration validation failed') as exc_info:
         PrometheusLogger()
 
     # Verify error message contains information about invalid labels
@@ -598,7 +598,7 @@ def test_invalid_exclude_metric_name_raises(reset_prometheus_exclude_settings):
     litellm.prometheus_exclude_labels = None
     litellm.prometheus_exclude_metrics = ["not_a_real_metric"]
 
-    with pytest.raises(ValueError) as exc_info:
+    with pytest.raises(ValueError, match='Prometheus exclude configuration validation failed') as exc_info:
         PrometheusLogger()
 
     assert "not_a_real_metric" in str(exc_info.value)
@@ -612,7 +612,7 @@ def test_invalid_exclude_label_name_raises(reset_prometheus_exclude_settings):
     litellm.prometheus_exclude_metrics = None
     litellm.prometheus_exclude_labels = ["not_a_real_label"]
 
-    with pytest.raises(ValueError) as exc_info:
+    with pytest.raises(ValueError, match='Prometheus exclude configuration validation failed') as exc_info:
         PrometheusLogger()
 
     assert "not_a_real_label" in str(exc_info.value)

--- a/tests/enterprise/litellm_enterprise/proxy/guardrails/test_bedrock_apply_guardrail.py
+++ b/tests/enterprise/litellm_enterprise/proxy/guardrails/test_bedrock_apply_guardrail.py
@@ -141,7 +141,7 @@ async def test_bedrock_apply_guardrail_api_failure():
         mock_api_request.side_effect = Exception("API connection failed")
 
         # Test the apply_guardrail method should raise an exception
-        with pytest.raises(Exception) as exc_info:
+        with pytest.raises(Exception, match='Bedrock guardrail failed: API connection failed') as exc_info:
             await guardrail.apply_guardrail(
                 inputs={"texts": ["This is a test message"]},
                 request_data={},

--- a/tests/enterprise/litellm_enterprise/proxy/hooks/test_managed_files.py
+++ b/tests/enterprise/litellm_enterprise/proxy/hooks/test_managed_files.py
@@ -1653,7 +1653,7 @@ async def test_afile_retrieve_raises_error_when_no_router_and_file_object_none()
 
     unified_file_id = "test-unified-file-id"
 
-    with pytest.raises(Exception) as exc_info:
+    with pytest.raises(Exception, match='LiteLLM Managed File object with id=test-unified-file-id') as exc_info:
         await proxy_managed_files.afile_retrieve(
             file_id=unified_file_id,
             litellm_parent_otel_span=None,
@@ -1719,7 +1719,7 @@ async def test_afile_retrieve_raises_error_for_non_managed_file():
     # Mock get_unified_file_id to return None (file not found)
     proxy_managed_files.get_unified_file_id = AsyncMock(return_value=None)
 
-    with pytest.raises(Exception) as exc_info:
+    with pytest.raises(Exception, match='LiteLLM Managed File object with id=non-existent-file-id') as exc_info:
         await proxy_managed_files.afile_retrieve(
             file_id="non-existent-file-id",
             litellm_parent_otel_span=None,
@@ -2027,7 +2027,7 @@ async def test_list_batches_from_managed_objects_table_provider_filter_raises_ex
     )
 
     # Filtering by provider should raise Exception
-    with pytest.raises(Exception) as exc_info:
+    with pytest.raises(Exception, match="Filtering by 'provider' is not supported when using managed") as exc_info:
         await proxy_managed_files.list_user_batches(
             user_api_key_dict=UserAPIKeyAuth(user_id="test-user"),
             limit=10,
@@ -2053,7 +2053,7 @@ async def test_list_batches_from_managed_objects_table_target_model_name_filter_
     )
 
     # Filtering by provider should raise Exception
-    with pytest.raises(Exception) as exc_info:
+    with pytest.raises(Exception, match="Filtering by 'target_model_names' is not supported when") as exc_info:
         await proxy_managed_files.list_user_batches(
             user_api_key_dict=UserAPIKeyAuth(user_id="test-user"),
             limit=10,

--- a/tests/enterprise/litellm_enterprise/proxy/management_endpoints/test_project_endpoints_prisma.py
+++ b/tests/enterprise/litellm_enterprise/proxy/management_endpoints/test_project_endpoints_prisma.py
@@ -448,7 +448,7 @@ def test_check_team_project_limits_models_not_in_team():
         models=["gpt-5.5", "claude-3"],  # claude-3 not in team
     )
 
-    with pytest.raises(Exception) as exc_info:
+    with pytest.raises(Exception, match="not in team's allowed models\\. Team allowed models") as exc_info:
         _check_team_project_limits(team_object=team, data=data)
 
     assert "claude-3" in str(exc_info.value.detail)
@@ -476,7 +476,7 @@ def test_check_team_project_limits_budget_exceeds_team():
         max_budget=150.0,  # exceeds team's 100.0
     )
 
-    with pytest.raises(Exception) as exc_info:
+    with pytest.raises(Exception, match='Project max_budget') as exc_info:
         _check_team_project_limits(team_object=team, data=data)
 
     assert "exceeds team's max_budget" in str(exc_info.value.detail)
@@ -551,7 +551,7 @@ def test_check_team_project_limits_tpm_exceeds_team():
         tpm_limit=20000,  # exceeds team's 10000
     )
 
-    with pytest.raises(Exception) as exc_info:
+    with pytest.raises(Exception, match='Project tpm_limit') as exc_info:
         _check_team_project_limits(team_object=team, data=data)
 
     assert "exceeds team's tpm_limit" in str(exc_info.value.detail)
@@ -577,7 +577,7 @@ def test_check_team_project_limits_negative_budget():
         max_budget=-10.0,
     )
 
-    with pytest.raises(Exception) as exc_info:
+    with pytest.raises(Exception, match='max_budget cannot be negative\\. Received') as exc_info:
         _check_team_project_limits(team_object=team, data=data)
 
     assert "cannot be negative" in str(exc_info.value.detail)
@@ -604,7 +604,7 @@ def test_check_team_project_limits_soft_budget_gte_max():
         soft_budget=100.0,  # equal to max, should fail
     )
 
-    with pytest.raises(Exception) as exc_info:
+    with pytest.raises(Exception, match='must be strictly lower than max_budget') as exc_info:
         _check_team_project_limits(team_object=team, data=data)
 
     assert "must be strictly lower" in str(exc_info.value.detail)

--- a/tests/guardrails_tests/test_dynamoai_guardrails.py
+++ b/tests/guardrails_tests/test_dynamoai_guardrails.py
@@ -61,7 +61,7 @@ async def test_dynamoai_blocks_content_with_block_action():
         guardrail.should_run_guardrail = MagicMock(return_value=True)
 
         # Test that the guardrail raises ValueError for blocked content
-        with pytest.raises(ValueError) as exc_info:
+        with pytest.raises(ValueError, match='violation\\(s\\) detected') as exc_info:
             await guardrail.async_pre_call_hook(
                 data=request_data,
                 user_api_key_dict=UserAPIKeyAuth(),

--- a/tests/guardrails_tests/test_eu_ai_act_article5.py
+++ b/tests/guardrails_tests/test_eu_ai_act_article5.py
@@ -211,7 +211,7 @@ class TestEUAIActArticle5ConditionalMatching:
         # Apply guardrail
         if expected == "BLOCK":
             # Should raise an exception or return modified response indicating block
-            with pytest.raises(Exception) as exc_info:
+            with pytest.raises(Exception, match='Content blocked: eu_ai_act_article') as exc_info:
                 await content_filter_guardrail.apply_guardrail(
                     inputs={"texts": [sentence]},
                     request_data=request_data,

--- a/tests/guardrails_tests/test_eu_ai_act_french_3_scenarios.py
+++ b/tests/guardrails_tests/test_eu_ai_act_french_3_scenarios.py
@@ -83,7 +83,7 @@ class TestEUAIActFrench3Scenarios:
         print(f"{'='*70}\n")
 
         # Should raise an exception (blocked)
-        with pytest.raises(Exception) as exc_info:
+        with pytest.raises(Exception, match="prohibited_practices_fr conditional match 'concevoir \\+") as exc_info:
             await content_filter_guardrail.apply_guardrail(
                 inputs={"texts": [sentence]},
                 request_data=request_data,
@@ -123,7 +123,7 @@ class TestEUAIActFrench3Scenarios:
         print(f"{'='*70}\n")
 
         # Should raise an exception (blocked)
-        with pytest.raises(Exception) as exc_info:
+        with pytest.raises(Exception, match="prohibited_practices_fr conditional match 'créer \\+") as exc_info:
             await content_filter_guardrail.apply_guardrail(
                 inputs={"texts": [sentence]},
                 request_data=request_data,
@@ -194,7 +194,7 @@ class TestEUAIActFrench3Scenarios:
         print(f"{'='*70}\n")
 
         # Should raise an exception (blocked by conditional matching)
-        with pytest.raises(Exception) as exc_info:
+        with pytest.raises(Exception, match="prohibited_practices_fr conditional match 'développer \\+") as exc_info:
             await content_filter_guardrail.apply_guardrail(
                 inputs={"texts": [sentence]},
                 request_data=request_data,
@@ -278,7 +278,7 @@ class TestFrenchEdgeCases:
         request_data = {"messages": [{"role": "user", "content": sentence}]}
 
         # Should still block (no exception bypass)
-        with pytest.raises(Exception) as exc_info:
+        with pytest.raises(Exception, match="prohibited_practices_fr conditional match 'créer \\+ crédit") as exc_info:
             await content_filter_guardrail.apply_guardrail(
                 inputs={"texts": [sentence]},
                 request_data=request_data,

--- a/tests/guardrails_tests/test_sg_mas_ai_guardrails.py
+++ b/tests/guardrails_tests/test_sg_mas_ai_guardrails.py
@@ -55,7 +55,7 @@ def _make_guardrail(yaml_filename: str, category_name: str) -> ContentFilterGuar
 
 async def _expect_block(guardrail: ContentFilterGuardrail, sentence: str, reason: str):
     request_data = {"messages": [{"role": "user", "content": sentence}]}
-    with pytest.raises(Exception) as exc_info:
+    with pytest.raises(Exception, match='Content blocked: sg_mas_') as exc_info:
         await guardrail.apply_guardrail(
             inputs={"texts": [sentence]},
             request_data=request_data,

--- a/tests/guardrails_tests/test_sg_pdpa_guardrails.py
+++ b/tests/guardrails_tests/test_sg_pdpa_guardrails.py
@@ -62,7 +62,7 @@ def _make_guardrail(yaml_filename: str, category_name: str) -> ContentFilterGuar
 async def _expect_block(guardrail: ContentFilterGuardrail, sentence: str, reason: str):
     """Assert that the guardrail BLOCKS the sentence."""
     request_data = {"messages": [{"role": "user", "content": sentence}]}
-    with pytest.raises(Exception) as exc_info:
+    with pytest.raises(Exception, match='Content blocked: sg_pdpa_') as exc_info:
         await guardrail.apply_guardrail(
             inputs={"texts": [sentence]},
             request_data=request_data,

--- a/tests/litellm_utils_tests/test_hashicorp.py
+++ b/tests/litellm_utils_tests/test_hashicorp.py
@@ -432,7 +432,7 @@ def test_hashicorp_get_url_rejects_path_traversal(monkeypatch, malicious_secret_
     monkeypatch.setenv("HCP_VAULT_TOKEN", "test-token-for-get-url-only")
     manager = HashicorpSecretManager()
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match='Invalid secret_name'):
         manager.get_url(malicious_secret_name)
 
 

--- a/tests/litellm_utils_tests/test_utils.py
+++ b/tests/litellm_utils_tests/test_utils.py
@@ -2147,7 +2147,7 @@ def test_validate_user_messages_invalid_content_type():
 
     messages = [{"content": [{"type": "invalid_type", "text": "Hello"}]}]
 
-    with pytest.raises(Exception) as e:
+    with pytest.raises(Exception, match='Please ensure all messages are valid OpenAI chat completion') as e:
         validate_chat_completion_user_messages(messages)
 
     assert "Invalid message" in str(e)

--- a/tests/litellm_utils_tests/test_validate_tool_choice.py
+++ b/tests/litellm_utils_tests/test_validate_tool_choice.py
@@ -37,27 +37,27 @@ def test_validate_tool_choice_cursor_format():
 def test_validate_tool_choice_invalid_dict():
     """Test that invalid dict formats raise exceptions."""
     # Missing both type and function
-    with pytest.raises(Exception) as exc_info:
+    with pytest.raises(Exception, match='Invalid tool choice, tool_choice=\\{\\}\\. Please ensure') as exc_info:
         validate_chat_completion_tool_choice({})
     assert "Invalid tool choice" in str(exc_info.value)
 
     # Invalid type value
-    with pytest.raises(Exception) as exc_info:
+    with pytest.raises(Exception, match="Invalid tool choice, tool_choice=\\{'type': 'invalid'\\}\\.") as exc_info:
         validate_chat_completion_tool_choice({"type": "invalid"})
     assert "Invalid tool choice" in str(exc_info.value)
 
     # Has type but missing function when type is "function"
-    with pytest.raises(Exception) as exc_info:
+    with pytest.raises(Exception, match="Invalid tool choice, tool_choice=\\{'type': 'function'\\}\\.") as exc_info:
         validate_chat_completion_tool_choice({"type": "function"})
     assert "Invalid tool choice" in str(exc_info.value)
 
 
 def test_validate_tool_choice_invalid_type():
     """Test that invalid types raise exceptions."""
-    with pytest.raises(Exception) as exc_info:
+    with pytest.raises(Exception, match="<class 'int'>\\. Expecting str, or dict\\. Please ensure") as exc_info:
         validate_chat_completion_tool_choice(123)
     assert "Got=<class 'int'>" in str(exc_info.value)
 
-    with pytest.raises(Exception) as exc_info:
+    with pytest.raises(Exception, match="Invalid tool choice, tool_choice=\\[\\]\\. Got=<class 'list'>\\.") as exc_info:
         validate_chat_completion_tool_choice([])
     assert "Got=<class 'list'>" in str(exc_info.value)

--- a/tests/llm_responses_api_testing/test_responses_hooks.py
+++ b/tests/llm_responses_api_testing/test_responses_hooks.py
@@ -295,7 +295,7 @@ async def test_responses_streaming_failure_triggers_failure_handlers():
         call_type=CallTypes.responses.value,
     )
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="boom"):
         iterator._process_chunk('{"delta": "chunk"}')
 
     # allow failure callbacks to run

--- a/tests/llm_translation/test_bedrock_completion.py
+++ b/tests/llm_translation/test_bedrock_completion.py
@@ -1890,7 +1890,7 @@ def test_bedrock_completion_test_4(modify_params):
         ]
         assert transformed_messages == expected_messages
     else:
-        with pytest.raises(Exception) as e:
+        with pytest.raises(Exception, match=r"litellm\.modify_params") as e:
             litellm.completion(**data)
         assert "litellm.modify_params" in str(e.value)
 

--- a/tests/llm_translation/test_llm_response_utils/test_convert_dict_to_chat_completion.py
+++ b/tests/llm_translation/test_llm_response_utils/test_convert_dict_to_chat_completion.py
@@ -982,7 +982,7 @@ def test_convert_to_model_response_object_with_real_error():
         },
     }
 
-    with pytest.raises(Exception) as exc_info:
+    with pytest.raises(Exception) as exc_info:  # noqa: PT011  # message rides on .message, str() is empty
         convert_to_model_response_object(
             model_response_object=ModelResponse(),
             response_object=response_object,
@@ -1243,7 +1243,7 @@ def test_convert_to_model_response_object_with_error_code_only():
         },
     }
 
-    with pytest.raises(Exception) as exc_info:  # noqa: B017  # bare Exception raised, so status_code is the assertion
+    with pytest.raises(Exception) as exc_info:  # noqa: B017, PT011  # bare Exception, empty message, so status_code is the assertion
         convert_to_model_response_object(
             model_response_object=ModelResponse(),
             response_object=response_object,
@@ -1423,7 +1423,7 @@ def test_error_message_includes_function_args():
         "choices": [{"index": 0}],
     }
 
-    with pytest.raises(Exception) as exc_info:
+    with pytest.raises(Exception, match='in convert_to_model_response_object') as exc_info:
         convert_to_model_response_object(
             model_response_object=ModelResponse(),
             response_object=response_object,

--- a/tests/llm_translation/test_prompt_factory.py
+++ b/tests/llm_translation/test_prompt_factory.py
@@ -1845,7 +1845,7 @@ def test_parse_tool_call_arguments_malformed_json():
         parse_tool_call_arguments,
     )
 
-    with pytest.raises(ValueError) as exc_info:
+    with pytest.raises(ValueError, match="Failed to parse tool call arguments for tool 'load_skill") as exc_info:
         parse_tool_call_arguments(
             '{"skill_name": "pptx',
             tool_name="load_skill",
@@ -1877,7 +1877,7 @@ def test_convert_to_anthropic_tool_invoke_malformed_json():
         }
     ]
 
-    with pytest.raises(ValueError) as exc_info:
+    with pytest.raises(ValueError, match="Failed to parse tool call arguments for tool 'bad_tool") as exc_info:
         convert_to_anthropic_tool_invoke(tool_calls)
 
     error_msg = str(exc_info.value)
@@ -2023,7 +2023,7 @@ def test_parse_tool_call_arguments_still_raises_for_unrepairable():
         parse_tool_call_arguments,
     )
 
-    with pytest.raises(ValueError) as exc_info:
+    with pytest.raises(ValueError, match="Failed to parse tool call arguments for tool 'test_tool") as exc_info:
         parse_tool_call_arguments(
             '{"key": "unterminated',
             tool_name="test_tool",

--- a/tests/llm_translation/test_triton.py
+++ b/tests/llm_translation/test_triton.py
@@ -45,7 +45,7 @@ def test_split_embedding_by_shape_fails_with_shape_value_error():
             "data": [1, 2, 3, 4, 5, 6],
         }
     ]
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match='Shape must be of length'):
         TritonEmbeddingConfig.split_embedding_by_shape(
             data[0]["data"], data[0]["shape"]
         )

--- a/tests/llm_translation/test_unit_test_bedrock_invoke.py
+++ b/tests/llm_translation/test_unit_test_bedrock_invoke.py
@@ -59,7 +59,7 @@ def test_transform_request_invalid_provider(bedrock_transformer):
     """Test request transformation with invalid provider"""
     messages = [{"role": "user", "content": "Hello"}]
 
-    with pytest.raises(Exception) as exc_info:
+    with pytest.raises(Exception, match='Bedrock Invoke HTTPX: Unknown provider=None') as exc_info:
         bedrock_transformer.transform_request(
             model="invalid.model",
             messages=messages,

--- a/tests/local_testing/test_auth_utils.py
+++ b/tests/local_testing/test_auth_utils.py
@@ -264,10 +264,6 @@ def test_get_end_user_id_from_request_body_backwards_compatibility():
             ["gpt-3.5-turbo", "gpt-4o-mini-general-deployment"],
         ),
         ({"model": "gpt-3.5-turbo"}, "gpt-3.5-turbo"),
-        (
-            {"model": "gpt-3.5-turbo, gpt-4o-mini-general-deployment"},
-            ["gpt-3.5-turbo", "gpt-4o-mini-general-deployment"],
-        ),
     ],
 )
 def test_get_model_from_request(request_data, expected_model):

--- a/tests/local_testing/test_exceptions.py
+++ b/tests/local_testing/test_exceptions.py
@@ -1433,7 +1433,7 @@ async def test_exception_bubbling_up(sync_mode, stream_mode, model):
                 sync_stream=sync_mode,
             )
 
-    with pytest.raises(Exception) as exc_info:
+    with pytest.raises(Exception, match='litellm\\.BadRequestError: OpenAIException - Invalid value') as exc_info:
         await _call_with_bad_role()
 
     assert exc_info.value.code == "invalid_value"

--- a/tests/local_testing/test_file_types.py
+++ b/tests/local_testing/test_file_types.py
@@ -23,13 +23,13 @@ class TestFileConsts:
     def test_get_file_extension_from_mime_type(self):
         assert get_file_extension_from_mime_type("audio/aac") == "aac"
         assert get_file_extension_from_mime_type("application/pdf") == "pdf"
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match='Unknown extension for mime type: application'):
             get_file_extension_from_mime_type("application/unknown")
 
     def test_get_file_type_from_extension(self):
         assert get_file_type_from_extension("aac") == FileType.AAC
         assert get_file_type_from_extension("pdf") == FileType.PDF
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match='Unknown file type for extension: unknown'):
             get_file_type_from_extension("unknown")
 
     def test_get_file_extension_for_file_type(self):

--- a/tests/local_testing/test_get_model_info.py
+++ b/tests/local_testing/test_get_model_info.py
@@ -134,7 +134,6 @@ def test_get_model_info_bedrock_region():
         "ft:gpt-3.5-turbo:my-org:custom_suffix:id",
         "ft:gpt-4-0613:my-org:custom_suffix:id",
         "ft:davinci-002:my-org:custom_suffix:id",
-        "ft:gpt-4-0613:my-org:custom_suffix:id",
         "ft:babbage-002:my-org:custom_suffix:id",
         "gpt-35-turbo",
         "ada",

--- a/tests/local_testing/test_router_budget_limiter.py
+++ b/tests/local_testing/test_router_budget_limiter.py
@@ -160,7 +160,7 @@ async def test_provider_budgets_e2e_test_expect_to_fail():
     await asyncio.sleep(2.5)
 
     for _ in range(3):
-        with pytest.raises(Exception) as exc_info:
+        with pytest.raises(Exception, match="Exceeded budget for provider") as exc_info:
             await router.acompletion(
                 messages=[{"role": "user", "content": "Hello, how are you?"}],
                 model="anthropic/claude-sonnet-4-5-20250929",
@@ -594,7 +594,7 @@ async def test_deployment_budgets_e2e_test_expect_to_fail():
     await asyncio.sleep(2.5)
 
     for _ in range(3):
-        with pytest.raises(Exception) as exc_info:
+        with pytest.raises(Exception, match="Exceeded budget for deployment") as exc_info:
             await router.acompletion(
                 messages=[{"role": "user", "content": "Hello, how are you?"}],
                 model="openai/gpt-4o-mini",
@@ -646,7 +646,7 @@ async def test_tag_budgets_e2e_test_expect_to_fail():
     await asyncio.sleep(2.5)
 
     for _ in range(3):
-        with pytest.raises(Exception) as exc_info:
+        with pytest.raises(Exception, match=f"Exceeded budget for tag='{TAG_NAME}'") as exc_info:
             await router.acompletion(
                 messages=[{"role": "user", "content": "Hello, how are you?"}],
                 model="openai/gpt-4o-mini",

--- a/tests/local_testing/test_router_fallbacks.py
+++ b/tests/local_testing/test_router_fallbacks.py
@@ -1430,7 +1430,7 @@ async def test_router_fallbacks_default_and_model_specific_fallbacks(sync_mode):
                 messages=[{"role": "user", "content": "Hey, how's it going?"}],
             )
 
-    with pytest.raises(Exception) as exc_info:
+    with pytest.raises(Exception, match='litellm\\.AuthenticationError: AuthenticationError') as exc_info:
         await _call_bad_model()
     assert isinstance(
         exc_info.value, litellm.AuthenticationError

--- a/tests/logging_callback_tests/test_standard_logging_payload.py
+++ b/tests/logging_callback_tests/test_standard_logging_payload.py
@@ -293,7 +293,7 @@ def test_cleanup_timestamps():
     assert all(isinstance(x, float) for x in result)
 
     # Test invalid input
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="start_time is required, got=invalid of type <class 'str'>"):
         StandardLoggingPayloadSetup.cleanup_timestamps(
             "invalid", end_float, completion_float
         )

--- a/tests/multi_instance_e2e_tests/test_update_team_e2e.py
+++ b/tests/multi_instance_e2e_tests/test_update_team_e2e.py
@@ -143,7 +143,7 @@ async def test_team_blocking_behavior_multi_instance():
         assert team_info_4001["blocked"] is True, "Team should be blocked after update"
 
         # 8. Make a chat completion request on port 4000 with a new prompt; expect it to be blocked.
-        with pytest.raises(Exception) as excinfo:
+        with pytest.raises(Exception, match="(?i)blocked") as excinfo:
             await chat_completion_on_port(
                 session,
                 key=key,
@@ -157,7 +157,7 @@ async def test_team_blocking_behavior_multi_instance():
         ), f"Expected error indicating team blocked, got: {error_msg}"
 
         # 9. Make a chat completion request on port 4000 with a new prompt; expect it to be blocked.
-        with pytest.raises(Exception) as excinfo:
+        with pytest.raises(Exception, match="(?i)blocked") as excinfo:
             await chat_completion_on_port(
                 session,
                 key=key,
@@ -171,7 +171,7 @@ async def test_team_blocking_behavior_multi_instance():
         ), f"Expected error indicating team blocked, got: {error_msg}"
 
         # 9. Repeat the chat completion request with another new prompt; expect it to be blocked.
-        with pytest.raises(Exception) as excinfo_second:
+        with pytest.raises(Exception, match="(?i)blocked") as excinfo_second:
             await chat_completion_on_port(
                 session,
                 key=key,

--- a/tests/ocr_tests/test_ocr_azure_document_intelligence.py
+++ b/tests/ocr_tests/test_ocr_azure_document_intelligence.py
@@ -101,7 +101,7 @@ class TestAzureDocumentIntelligencePagesParam:
             cfg.map_ocr_params({"pages": [True, False]}, {}, "prebuilt-layout")
 
     def test_map_ocr_params_unsupported_type_raises(self, cfg):
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match='based, Mistral-style\\) or a string like'):
             cfg.map_ocr_params({"pages": 5}, {}, "prebuilt-layout")
 
     def test_get_complete_url_appends_pages_query(self, cfg):

--- a/tests/otel_tests/test_e2e_model_access.py
+++ b/tests/otel_tests/test_e2e_model_access.py
@@ -3,6 +3,7 @@ import asyncio
 import aiohttp
 import json
 from httpx import AsyncClient
+from openai import PermissionDeniedError
 from typing import Any, Optional, List, Literal
 
 
@@ -134,7 +135,7 @@ async def test_model_access_update():
         await mock_chat_completion(session=session, key=key, model="openai/gpt-5.5")
 
         # Should fail with gpt-5-mini
-        with pytest.raises(Exception) as exc_info:
+        with pytest.raises(PermissionDeniedError) as exc_info:
             await mock_chat_completion(
                 session=session, key=key, model="openai/gpt-5-mini"
             )
@@ -157,7 +158,7 @@ async def test_model_access_update():
         )
 
         # Non-OpenAI model should still fail
-        with pytest.raises(Exception) as exc_info:
+        with pytest.raises(PermissionDeniedError) as exc_info:
             await mock_chat_completion(
                 session=session, key=key, model="anthropic/claude-2"
             )
@@ -254,7 +255,7 @@ async def test_team_model_access_update():
         await mock_chat_completion(session=session, key=key, model="openai/gpt-5.5")
 
         # Should fail with gpt-5-mini
-        with pytest.raises(Exception) as exc_info:
+        with pytest.raises(PermissionDeniedError) as exc_info:
             await mock_chat_completion(
                 session=session, key=key, model="openai/gpt-5-mini"
             )
@@ -279,7 +280,7 @@ async def test_team_model_access_update():
         )
 
         # Non-OpenAI model should still fail
-        with pytest.raises(Exception) as exc_info:
+        with pytest.raises(PermissionDeniedError) as exc_info:
             await mock_chat_completion(
                 session=session, key=key, model="anthropic/claude-2"
             )

--- a/tests/proxy_admin_ui_tests/test_key_management.py
+++ b/tests/proxy_admin_ui_tests/test_key_management.py
@@ -1340,6 +1340,6 @@ async def test_team_model_alias(prisma_client, requested_model, should_pass):
         }, "Expected model aliases to be present"
     else:
         # Verify the key fails with non-aliased models
-        with pytest.raises(Exception) as exc_info:
+        with pytest.raises(ProxyException) as exc_info:
             await user_api_key_auth(request=request, api_key=f"Bearer {generated_key}")
         assert exc_info.value.type == ProxyErrorTypes.key_model_access_denied

--- a/tests/proxy_admin_ui_tests/test_role_based_access.py
+++ b/tests/proxy_admin_ui_tests/test_role_based_access.py
@@ -9,7 +9,7 @@ from litellm._uuid import uuid
 from datetime import datetime
 
 from dotenv import load_dotenv
-from fastapi import Request
+from fastapi import HTTPException, Request
 from fastapi.routing import APIRoute
 
 load_dotenv()
@@ -530,7 +530,7 @@ async def test_user_role_permissions(prisma_client, route, user_role, expected_r
             print(f"Auth passed as expected for {route} with role {user_role}")
         else:
             # Should raise an error
-            with pytest.raises(Exception) as exc_info:
+            with pytest.raises((ProxyException, HTTPException)) as exc_info:
                 await user_api_key_auth(request=request, api_key=bearer_token)
             print(f"Auth failed as expected for {route} with role {user_role}")
             print(f"Error message: {str(exc_info.value)}")

--- a/tests/proxy_unit_tests/test_auth_checks.py
+++ b/tests/proxy_unit_tests/test_auth_checks.py
@@ -173,7 +173,7 @@ async def test_can_key_call_model(model, expect_to_work):
     if expect_to_work:
         await can_key_call_model(**args)
     else:
-        with pytest.raises(Exception) as e:
+        with pytest.raises(Exception, match='key not allowed to access model\\. This key can only access') as e:
             await can_key_call_model(**args)
 
         print(e)
@@ -958,7 +958,7 @@ async def test_can_key_call_model_with_aliases(model, alias_map, expect_to_work)
             llm_router=router,
         )
     else:
-        with pytest.raises(Exception) as e:
+        with pytest.raises(Exception, match='key not allowed to access model\\. This key can only access') as e:
             await can_key_call_model(
                 model=model,
                 llm_model_list=llm_model_list,

--- a/tests/proxy_unit_tests/test_jwt.py
+++ b/tests/proxy_unit_tests/test_jwt.py
@@ -1583,7 +1583,7 @@ async def test_auth_jwt_mismatched_key_fails(monkeypatch):
 
     h = JWTHandler()
     with patch.object(h, "get_public_key", new=AsyncMock(return_value=rsa_jwk)):
-        with pytest.raises(Exception) as exc:
+        with pytest.raises(Exception, match='Validation fails: Expecting a PEM-formatted key\\.') as exc:
             await h.auth_jwt(token)
         assert "Validation fails" in str(exc.value)
 
@@ -1826,7 +1826,7 @@ async def test_multi_issuer_jwt_unknown_issuer_without_global_jwks_rejected(
         kid="issuer-key",
     )
 
-    with pytest.raises(Exception) as exc:
+    with pytest.raises(Exception, match='Missing JWT Public Key URL from environment\\.') as exc:
         await jwt_handler.auth_jwt(token=token)
 
     assert "Missing JWT Public Key URL" in str(exc.value)
@@ -1857,7 +1857,7 @@ async def test_multi_issuer_jwt_rejects_wrong_audience(monkeypatch):
         kid="issuer-key",
     )
 
-    with pytest.raises(Exception) as exc:
+    with pytest.raises(Exception, match="Validation fails: Audience doesn't match") as exc:
         await jwt_handler.auth_jwt(token=token)
 
     assert "Validation fails" in str(exc.value)
@@ -1900,7 +1900,7 @@ async def test_multi_issuer_jwt_same_kid_does_not_cross_issuer_keys(monkeypatch)
         kid=shared_kid,
     )
 
-    with pytest.raises(Exception) as exc:
+    with pytest.raises(Exception, match='Validation fails: Signature verification failed') as exc:
         await jwt_handler.auth_jwt(token=token)
 
     assert "Validation fails" in str(exc.value)
@@ -1953,7 +1953,7 @@ def test_multi_issuer_jwt_requires_audience_unless_explicitly_disabled(
     issuer = "https://issuer.example.com"
     jwks_url = f"{issuer}/keys"
 
-    with pytest.raises(Exception) as exc:
+    with pytest.raises(Exception, match='must configure audience or set') as exc:
         LiteLLM_JWTAuth(
             issuers=[
                 {

--- a/tests/proxy_unit_tests/test_proxy_utils.py
+++ b/tests/proxy_unit_tests/test_proxy_utils.py
@@ -1026,7 +1026,7 @@ def test_enforced_params_check(
     from litellm.proxy.litellm_pre_call_utils import _enforced_params_check
 
     if expected_error:
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match='in request body\\. This is a required param'):
             _enforced_params_check(
                 request_body=request_body,
                 general_settings=general_settings,
@@ -2626,7 +2626,7 @@ async def test_during_call_hook_parallel_execution_with_error():
     try:
         litellm.callbacks = [FailingGuardrail()]
 
-        with pytest.raises(ValueError) as exc_info:
+        with pytest.raises(ValueError, match='Guardrail violation detected!') as exc_info:
             await proxy_logging.during_call_hook(
                 data={
                     "model": "gpt-4",

--- a/tests/proxy_unit_tests/test_update_spend.py
+++ b/tests/proxy_unit_tests/test_update_spend.py
@@ -166,7 +166,7 @@ async def test_update_spend_logs_non_connection_error():
     prisma_client.db.litellm_spendlogs.create_many = create_many_mock
 
     # Execute and verify it raises immediately without retrying
-    with pytest.raises(ValueError) as exc_info:
+    with pytest.raises(ValueError, match='Unexpected database error') as exc_info:
         await update_spend(prisma_client, None, proxy_logging_obj)
 
     # Verify error message

--- a/tests/router_unit_tests/test_router_helper_utils.py
+++ b/tests/router_unit_tests/test_router_helper_utils.py
@@ -90,7 +90,7 @@ def test_routing_strategy_init_invalid_strategy(model_list):
     router = Router(model_list=model_list)
 
     # Test common mistake: "simple" instead of "simple-shuffle"
-    with pytest.raises(ValueError) as exc_info:
+    with pytest.raises(ValueError, match="usage-based-routing', 'provider-budget-routing'\\]\\. Check") as exc_info:
         router.routing_strategy_init(
             routing_strategy="simple", routing_strategy_args={}
         )
@@ -106,7 +106,7 @@ def test_routing_strategy_init_invalid_strategy(model_list):
     assert "Router SDK" in error_msg
 
     # Test completely invalid strategy
-    with pytest.raises(ValueError) as exc_info:
+    with pytest.raises(ValueError, match="usage-based-routing', 'provider-budget-routing'\\]\\. Check") as exc_info:
         router.routing_strategy_init(
             routing_strategy="not-a-real-strategy", routing_strategy_args={}
         )

--- a/tests/store_model_in_db_tests/test_mcp_servers.py
+++ b/tests/store_model_in_db_tests/test_mcp_servers.py
@@ -471,7 +471,7 @@ def test_validate_mcp_server_name_direct():
     validate_mcp_server_name("valid name")
 
     # Test that invalid names with hyphens raise exceptions
-    with pytest.raises(Exception) as exc_info:
+    with pytest.raises(Exception, match="Server name cannot contain '-'\\. Use an alternative") as exc_info:
         validate_mcp_server_name("invalid-name")
     assert "cannot contain" in str(exc_info.value)
 

--- a/tests/test_litellm/enterprise/enterprise_callbacks/send_emails/test_sendgrid_email.py
+++ b/tests/test_litellm/enterprise/enterprise_callbacks/send_emails/test_sendgrid_email.py
@@ -104,7 +104,7 @@ async def test_send_email_missing_api_key():
     try:
         logger = SendGridEmailLogger()
 
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match='SENDGRID_API_KEY is not set'):
             await logger.send_email(
                 from_email="test@example.com",
                 to_email=["recipient@example.com"],

--- a/tests/test_litellm/enterprise/proxy/test_managed_files_hook.py
+++ b/tests/test_litellm/enterprise/proxy/test_managed_files_hook.py
@@ -471,7 +471,7 @@ async def test_afile_content_error_reports_unified_id_not_provider_uri():
     mock_router.get_deployment_credentials_with_provider = MagicMock(return_value=None)
     mock_router.afile_content = AsyncMock(side_effect=Exception("deployment failed"))
 
-    with pytest.raises(Exception) as exc_info:
+    with pytest.raises(Exception, match='LiteLLM Managed File object with') as exc_info:
         await managed_files.afile_content(
             file_id=unified_file_id,
             litellm_parent_otel_span=None,

--- a/tests/test_litellm/integrations/cloudzero/test_cloudzero_database.py
+++ b/tests/test_litellm/integrations/cloudzero/test_cloudzero_database.py
@@ -51,7 +51,7 @@ async def test_get_usage_data_rejects_invalid_limit(monkeypatch: pytest.MonkeyPa
     """limit must coerce to int or raise ValueError before hitting the DB."""
     db, query_mock = _setup_db(monkeypatch, [])
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match='limit must be an integer'):
         await db.get_usage_data(limit="invalid")
 
     assert query_mock.await_count == 0

--- a/tests/test_litellm/integrations/cloudzero/test_cz_stream_api.py
+++ b/tests/test_litellm/integrations/cloudzero/test_cz_stream_api.py
@@ -108,7 +108,7 @@ class TestCloudZeroStreamer:
         """Test _parse_and_convert_timestamp method with invalid timestamp."""
         streamer = CloudZeroStreamer("test-key", "test-connection")
 
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="Could not parse timestamp 'invalid-timestamp': Invalid"):
             streamer._parse_and_convert_timestamp("invalid-timestamp")
 
     def test_prepare_batch_payload(self):

--- a/tests/test_litellm/integrations/focus/test_focus_database.py
+++ b/tests/test_litellm/integrations/focus/test_focus_database.py
@@ -68,7 +68,7 @@ async def test_should_accept_string_timestamps(monkeypatch: pytest.MonkeyPatch):
 async def test_should_reject_invalid_limit(monkeypatch: pytest.MonkeyPatch):
     db, query_mock = _setup_db(monkeypatch, [])
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match='limit must be an integer'):
         await db.get_usage_data(limit="invalid")
 
     assert query_mock.await_count == 0

--- a/tests/test_litellm/integrations/focus/test_s3_destination.py
+++ b/tests/test_litellm/integrations/focus/test_s3_destination.py
@@ -20,7 +20,7 @@ def _window(freq: str = "hourly", hour: int = 5) -> FocusTimeWindow:
 
 
 def test_should_require_bucket_name():
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match='bucket_name must be provided for S'):
         FocusS3Destination(prefix="focus", config={})
 
 

--- a/tests/test_litellm/integrations/gitlab/test_gitlab_client.py
+++ b/tests/test_litellm/integrations/gitlab/test_gitlab_client.py
@@ -95,9 +95,9 @@ def enc_project(p):  # how client encodes project in urls
 # Constructor / config tests
 # -----------------------------
 def test_init_requires_project_and_token():
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match='project and access_token are required'):
         GitLabClient({"project": "p"})
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match='project and access_token are required'):
         GitLabClient({"access_token": "t"})
 
 
@@ -127,7 +127,7 @@ def test_set_ref_updates_effective_ref():
     c = make_client(branch="main")
     c.set_ref("feature/x")
     assert c.ref == "feature/x"
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match='ref must be a non-empty string'):
         c.set_ref("")
 
 
@@ -193,12 +193,12 @@ def test_get_file_content_permission_errors_are_mapped():
     raw_url = f"https://gitlab.example.com/api/v4/projects/{enc_project('group/sub/repo')}/repository/files/secure%2Ffile.prompt/raw?ref=main"
     # raise_for_status will be called, so return 403 response (not an exception from transport)
     c.http_handler.routes[raw_url] = FakeResponse(status_code=403)
-    with pytest.raises(Exception) as ei:
+    with pytest.raises(Exception, match="Check your GitLab permissions for project 'group") as ei:
         c.get_file_content("secure/file.prompt")
     assert "Access denied" in str(ei.value)
 
     c.http_handler.routes[raw_url] = FakeResponse(status_code=401)
-    with pytest.raises(Exception) as ei2:
+    with pytest.raises(Exception, match='Authentication failed\\. Check your GitLab token and') as ei2:
         c.get_file_content("secure/file.prompt")
     assert "Authentication failed" in str(ei2.value)
 

--- a/tests/test_litellm/integrations/levo/test_levo.py
+++ b/tests/test_litellm/integrations/levo/test_levo.py
@@ -198,7 +198,7 @@ class TestLevoIntegration(unittest.TestCase):
         """Test health check returns unhealthy status when required vars are missing."""
         # Try to create logger without required env vars
         # This should fail during config, but we can test health check logic
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match='LEVOAI_API_KEY environment variable is required for Levo'):
             LevoLogger.get_levo_config()
 
     @patch.dict(

--- a/tests/test_litellm/integrations/otel/test_otel_v2_metrics.py
+++ b/tests/test_litellm/integrations/otel/test_otel_v2_metrics.py
@@ -554,7 +554,7 @@ def test_token_type_rejected_from_either_list(attributes, monkeypatch):
     recorder rather than silently ignored, so the misconfig is caught at all."""
     recorder = _recorder(monkeypatch, attributes)
     kwargs, response_obj, start, end = _build_call()
-    with pytest.raises(ValueError) as exc_info:
+    with pytest.raises(ValueError, match='otel\\.attributes: gen_ai\\.token\\.type is a structural') as exc_info:
         recorder.record(kwargs, response_obj, start, end)
     # The dedicated discriminator guard, not the generic unknown-name path: assert
     # the specific reason so dropping that guard (and falling through to "unknown

--- a/tests/test_litellm/integrations/test_langfuse.py
+++ b/tests/test_litellm/integrations/test_langfuse.py
@@ -1163,7 +1163,7 @@ def test_max_langfuse_clients_limit():
         assert litellm.initialized_langfuse_clients == 2
 
         # Third client should fail with exception
-        with pytest.raises(Exception) as exc_info:
+        with pytest.raises(Exception, match='Max langfuse clients reached') as exc_info:
             logger3 = LangFuseLogger(
                 langfuse_public_key="test_key_3",
                 langfuse_secret="test_secret_3",

--- a/tests/test_litellm/litellm_core_utils/prompt_templates/test_litellm_core_utils_prompt_templates_factory.py
+++ b/tests/test_litellm/litellm_core_utils/prompt_templates/test_litellm_core_utils_prompt_templates_factory.py
@@ -1169,7 +1169,7 @@ def test_bedrock_image_processor_content_type_fallback_failure():
     # Test with URL without recognizable extension
     image_url = "https://example.com/unknown-file"
 
-    with pytest.raises(ValueError) as excinfo:
+    with pytest.raises(ValueError, match='Unable to determine content type from URL: https') as excinfo:
         BedrockImageProcessor._post_call_image_processing(mock_response, image_url)
 
     assert "Unable to determine content type" in str(excinfo.value)

--- a/tests/test_litellm/litellm_core_utils/test_initialize_dynamic_callback_params.py
+++ b/tests/test_litellm/litellm_core_utils/test_initialize_dynamic_callback_params.py
@@ -110,7 +110,7 @@ def test_top_level_kwargs_overrides_metadata_slots():
 def test_env_reference_at_top_level_raises_with_guidance():
     kwargs = {"langfuse_public_key": "os.environ/LANGFUSE_PUBLIC_KEY"}
 
-    with pytest.raises(ValueError) as exc_info:
+    with pytest.raises(ValueError, match="Callback param 'langfuse_public_key' \\(from request body\\)") as exc_info:
         initialize_standard_callback_dynamic_params(kwargs)
 
     message = str(exc_info.value)
@@ -127,7 +127,7 @@ def test_env_reference_in_metadata_raises_with_guidance():
         }
     }
 
-    with pytest.raises(ValueError) as exc_info:
+    with pytest.raises(ValueError, match="Callback param 'langsmith_api_key' \\(from metadata\\) contains") as exc_info:
         initialize_standard_callback_dynamic_params(kwargs)
 
     message = str(exc_info.value)

--- a/tests/test_litellm/litellm_core_utils/test_llm_judge.py
+++ b/tests/test_litellm/litellm_core_utils/test_llm_judge.py
@@ -27,7 +27,7 @@ def test_parse_json_verdict_tolerates_fences_and_prose(raw, expected):
 
 
 def test_parse_json_verdict_rejects_non_object():
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match='judge response is not a JSON object'):
         parse_json_verdict('["not", "an", "object"]')
     with pytest.raises((json.JSONDecodeError, ValueError)):
         parse_json_verdict("no json here at all")

--- a/tests/test_litellm/litellm_core_utils/test_streaming_handler.py
+++ b/tests/test_litellm/litellm_core_utils/test_streaming_handler.py
@@ -982,7 +982,7 @@ async def test_bedrock_validation_error_raises_directly(logging_obj: Logging):
         make_call=_raise_400,
     )
 
-    with pytest.raises(Exception) as excinfo:
+    with pytest.raises(Exception, match='litellm\\.BadRequestError: BedrockException') as excinfo:
         await response.__anext__()
     assert not isinstance(excinfo.value, MidStreamFallbackError)
     assert getattr(excinfo.value, "status_code", None) == 400
@@ -2722,7 +2722,7 @@ def test_dispatch_text_completion_codestral_requires_string(
     is a programming error and must surface loudly."""
     initialized_custom_stream_wrapper.custom_llm_provider = "text-completion-codestral"
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="chunk is not a string: \\{'not': 'a string'\\}"):
         _run_dispatch(initialized_custom_stream_wrapper, {"not": "a string"})
 
 

--- a/tests/test_litellm/litellm_core_utils/test_token_counter.py
+++ b/tests/test_litellm/litellm_core_utils/test_token_counter.py
@@ -763,24 +763,6 @@ class TestTokenizerSelection(unittest.TestCase):
                 ],
             }
         ],
-        [
-            {
-                "role": "user",
-                "content": [
-                    {
-                        "type": "text",
-                        "text": "These are some sample images from a movie. Based on these images, what do you think the tone of the movie is?",
-                    },
-                    {
-                        "type": "text",
-                        "image_url": {
-                            "url": "https://gratisography.com/wp-content/uploads/2024/11/gratisography-augmented-reality-800x525.jpg",
-                            "detail": "high",
-                        },
-                    },
-                ],
-            }
-        ],
     ],
 )
 def test_bad_input_token_counter(model, messages):
@@ -1174,7 +1156,7 @@ def test_count_content_list_rejects_unknown_type():
     """
     from litellm.litellm_core_utils.token_counter import _count_content_list
 
-    with pytest.raises(ValueError) as exc_info:
+    with pytest.raises(ValueError, match='Error getting number of tokens from content list: Invalid') as exc_info:
         _count_content_list(
             count_function=len,
             content_list=[{"type": "totally_unknown_block"}],

--- a/tests/test_litellm/litellm_core_utils/test_url_utils.py
+++ b/tests/test_litellm/litellm_core_utils/test_url_utils.py
@@ -100,12 +100,12 @@ class TestEncodeUrlPathSegment:
 
     @pytest.mark.parametrize("value", ["", ".", "..", None])
     def test_rejects_empty_and_dot_segments(self, value):
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="resource_id (is required|cannot be a dot path segment)"):
             encode_url_path_segment(value, field_name="resource_id")
 
     @pytest.mark.parametrize("value", ["../model", "model/../other", "/model"])
     def test_rejects_dot_segments_in_multi_segment_paths(self, value):
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="model (is required|cannot be a dot path segment)"):
             encode_url_path_segments(value, field_name="model")
 
 

--- a/tests/test_litellm/llms/aiml/image_generation/test_aiml_image_generation_transformation.py
+++ b/tests/test_litellm/llms/aiml/image_generation/test_aiml_image_generation_transformation.py
@@ -113,7 +113,7 @@ def test_flux_style_request_still_remaps_to_legacy_fields():
 
 
 def test_openai_style_unsupported_param_raises_without_drop_params():
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match='Supported parameters are'):
         AimlImageGenerationConfig().map_openai_params(
             non_default_params={"image_size": {"width": 1024, "height": 1024}},
             optional_params={},

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_mcp_handler.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_mcp_handler.py
@@ -61,7 +61,7 @@ def test_anthropic_messages_handler_skips_the_gateway_on_recursion():
         "litellm.llms.anthropic.experimental_pass_through.messages.mcp_handler.anthropic_messages_with_mcp",
         new=AsyncMock(return_value={"routed": True}),
     ) as routed:
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match='anthropic_messages_handler is not implemented for sync calls'):
             anthropic_messages_handler(
                 max_tokens=100,
                 messages=[{"role": "user", "content": "hi"}],
@@ -80,7 +80,7 @@ def test_anthropic_messages_handler_leaves_native_tools_alone():
         "litellm.llms.anthropic.experimental_pass_through.messages.mcp_handler.anthropic_messages_with_mcp",
         new=AsyncMock(return_value={"routed": True}),
     ) as routed:
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match='anthropic_messages_handler is not implemented for sync calls'):
             anthropic_messages_handler(
                 max_tokens=100,
                 messages=[{"role": "user", "content": "hi"}],

--- a/tests/test_litellm/llms/azure_ai/rerank/test_azure_ai_rerank_transformation.py
+++ b/tests/test_litellm/llms/azure_ai/rerank/test_azure_ai_rerank_transformation.py
@@ -16,7 +16,7 @@ class TestAzureAIRerankConfigGetCompleteUrl:
         self.model = "azure_ai/cohere-rerank-v3-english"
 
     def test_api_base_required(self):
-        with pytest.raises(ValueError) as exc_info:
+        with pytest.raises(ValueError, match='Azure AI API Base is required\\. api_base=None\\. Set in') as exc_info:
             self.config.get_complete_url(api_base=None, model=self.model)
 
         assert "api_base=None" in str(exc_info.value)
@@ -31,7 +31,7 @@ class TestAzureAIRerankConfigGetCompleteUrl:
         ],
     )
     def test_api_base_requires_scheme(self, api_base):
-        with pytest.raises(ValueError) as exc_info:
+        with pytest.raises(ValueError, match='Azure AI API Base must be an absolute URL including scheme') as exc_info:
             self.config.get_complete_url(api_base=api_base, model=self.model)
 
         error_message = str(exc_info.value).lower()

--- a/tests/test_litellm/llms/bedrock/test_base_aws_llm.py
+++ b/tests/test_litellm/llms/bedrock/test_base_aws_llm.py
@@ -1944,7 +1944,7 @@ def test_role_assumption_access_denied_raises_when_different_role():
         with patch.object(
             base_aws_llm, "_is_already_running_as_role", return_value=False
         ):
-            with pytest.raises(Exception) as exc_info:
+            with pytest.raises(Exception, match='An error occurred \\(AccessDenied\\) when calling the') as exc_info:
                 base_aws_llm._auth_with_aws_role(
                     aws_access_key_id=None,
                     aws_secret_access_key=None,
@@ -1969,7 +1969,7 @@ def test_role_assumption_non_access_denied_error_propagated():
     )
 
     with patch("boto3.client", return_value=mock_sts_client):
-        with pytest.raises(Exception) as exc_info:
+        with pytest.raises(Exception, match='An error occurred \\(MalformedPolicyDocument\\) when calling') as exc_info:
             base_aws_llm._auth_with_aws_role(
                 aws_access_key_id=None,
                 aws_secret_access_key=None,

--- a/tests/test_litellm/llms/bedrock_mantle/test_bedrock_mantle_responses_transformation.py
+++ b/tests/test_litellm/llms/bedrock_mantle/test_bedrock_mantle_responses_transformation.py
@@ -109,7 +109,7 @@ class TestBedrockMantleResponsesURL:
         monkeypatch.delenv("BEDROCK_MANTLE_API_BASE", raising=False)
         monkeypatch.delenv("AWS_REGION", raising=False)
         cfg = BedrockMantleResponsesAPIConfig()
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="api\\.aws\\.attacker\\.example/'\\. Region names must contain only"):
             cfg.get_complete_url(
                 api_base=None,
                 litellm_params={
@@ -1418,7 +1418,7 @@ class TestBedrockMantleResponsesSigV4:
         signer.get_credentials = MagicMock(side_effect=NoCredentialsError())
         cfg = BedrockMantleResponsesAPIConfig(aws_signer=signer)
 
-        with pytest.raises(ValueError) as exc:
+        with pytest.raises(ValueError, match='Bedrock Mantle auth failed: no Bearer token and no usable') as exc:
             cfg.sign_request(
                 headers={},
                 optional_params={"aws_region_name": "us-east-2"},
@@ -1448,7 +1448,7 @@ class TestBedrockMantleResponsesSigV4:
         signer.get_credentials = MagicMock(side_effect=cred_error)
         cfg = BedrockMantleResponsesAPIConfig(aws_signer=signer)
 
-        with pytest.raises(ValueError) as exc:
+        with pytest.raises(ValueError, match='Bedrock Mantle auth failed: no Bearer token and no usable') as exc:
             cfg.sign_request(
                 headers={},
                 optional_params={"aws_region_name": "us-east-2"},

--- a/tests/test_litellm/llms/bedrock_mantle/test_bedrock_mantle_transformation.py
+++ b/tests/test_litellm/llms/bedrock_mantle/test_bedrock_mantle_transformation.py
@@ -107,7 +107,7 @@ class TestBedrockMantleConfig:
         monkeypatch.delenv("BEDROCK_MANTLE_API_BASE", raising=False)
         monkeypatch.delenv("AWS_REGION", raising=False)
         cfg = BedrockMantleChatConfig()
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="api\\.aws\\.attacker\\.example/'\\. Region names must contain only"):
             cfg._get_openai_compatible_provider_info(
                 None,
                 None,
@@ -416,7 +416,7 @@ class TestBedrockMantleChatAuth:
         signer.get_credentials = MagicMock(side_effect=NoCredentialsError())
         cfg = BedrockMantleChatConfig(aws_signer=signer)
 
-        with pytest.raises(ValueError) as exc:
+        with pytest.raises(ValueError, match='Bedrock Mantle auth failed: no Bearer token and no usable') as exc:
             cfg.sign_request(
                 headers={},
                 optional_params={"aws_region_name": "us-east-2"},

--- a/tests/test_litellm/llms/bytez/chat/test_bytez_chat_transformation.py
+++ b/tests/test_litellm/llms/bytez/chat/test_bytez_chat_transformation.py
@@ -38,7 +38,7 @@ class TestBytezChatConfig:
         config = BytezChatConfig()
         headers = {}
 
-        with pytest.raises(Exception) as excinfo:
+        with pytest.raises(Exception, match='Missing api_key, make sure you pass in your api key') as excinfo:
             config.validate_environment(
                 headers=headers,
                 model=TEST_MODEL,

--- a/tests/test_litellm/llms/deepinfra/test_deepinfra_rerank_transformation.py
+++ b/tests/test_litellm/llms/deepinfra/test_deepinfra_rerank_transformation.py
@@ -258,7 +258,7 @@ class TestDeepinfraRerankTransform:
         status_code = 401
         headers = {"content-type": "application/json"}
 
-        with pytest.raises(Exception) as exc_info:
+        with pytest.raises(Exception, match='Authentication failed') as exc_info:
             self.config.get_error_class(error_message, status_code, headers)
 
         # The method should raise a BaseLLMException
@@ -271,7 +271,7 @@ class TestDeepinfraRerankTransform:
         status_code = 404
         headers = {"content-type": "application/json"}
 
-        with pytest.raises(Exception) as exc_info:
+        with pytest.raises(Exception, match='Model not found') as exc_info:
             self.config.get_error_class(error_message, status_code, headers)
 
         # Should extract the nested error message
@@ -284,7 +284,7 @@ class TestDeepinfraRerankTransform:
         status_code = 503
         headers = {"content-type": "application/json"}
 
-        with pytest.raises(Exception) as exc_info:
+        with pytest.raises(Exception, match='Service unavailable') as exc_info:
             self.config.get_error_class(error_message, status_code, headers)
 
         # Should extract the string detail
@@ -296,7 +296,7 @@ class TestDeepinfraRerankTransform:
         status_code = 500
         headers = {"content-type": "application/json"}
 
-        with pytest.raises(Exception) as exc_info:
+        with pytest.raises(Exception, match='Invalid JSON error message') as exc_info:
             self.config.get_error_class(error_message, status_code, headers)
 
         # Should use the original error message when JSON parsing fails

--- a/tests/test_litellm/llms/fal_ai/image_generation/test_fal_ai_nano_banana_transformation.py
+++ b/tests/test_litellm/llms/fal_ai/image_generation/test_fal_ai_nano_banana_transformation.py
@@ -113,7 +113,7 @@ def test_response_format_is_ignored():
 
 
 def test_unsupported_param_raises_without_drop_params():
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="Supported parameters are \\['n', 'response_format', 'size'\\]\\."):
         FalAINanoBananaConfig().map_openai_params(
             non_default_params={"style": "vivid"},
             optional_params={},

--- a/tests/test_litellm/llms/featherless_ai/chat/test_featherless_chat_transformation.py
+++ b/tests/test_litellm/llms/featherless_ai/chat/test_featherless_chat_transformation.py
@@ -44,7 +44,7 @@ class TestFeatherlessAIConfig:
         """Test error handling when API key is missing"""
         config = FeatherlessAIConfig()
 
-        with pytest.raises(ValueError) as excinfo:
+        with pytest.raises(ValueError, match='Missing Featherless AI API Key') as excinfo:
             config.validate_environment(
                 headers={},
                 model="featherless-ai/Qwerky-72B",
@@ -112,7 +112,7 @@ class TestFeatherlessAIConfig:
             "tool_choice": {"type": "function", "function": {"name": "get_weather"}}
         }
         optional_params = {}
-        with pytest.raises(Exception) as excinfo:
+        with pytest.raises(Exception, match="litellm\\.UnsupportedParamsError: Featherless AI doesn't") as excinfo:
             config.map_openai_params(
                 non_default_params=non_default_params,
                 optional_params=optional_params,
@@ -138,7 +138,7 @@ class TestFeatherlessAIConfig:
         assert "tools" not in result
 
         # Test with tools and drop_params=False
-        with pytest.raises(Exception) as excinfo:
+        with pytest.raises(Exception, match="litellm\\.UnsupportedParamsError: Featherless AI doesn't") as excinfo:
             config.map_openai_params(
                 non_default_params=non_default_params,
                 optional_params=optional_params,

--- a/tests/test_litellm/llms/fireworks_ai/rerank/test_fireworks_ai_rerank_transformation.py
+++ b/tests/test_litellm/llms/fireworks_ai/rerank/test_fireworks_ai_rerank_transformation.py
@@ -301,7 +301,7 @@ class TestFireworksAIRerankTransform:
         mock_logging = MagicMock()
         model_response = RerankResponse()
 
-        with pytest.raises(Exception) as exc_info:
+        with pytest.raises(Exception, match='Failed to parse response: Invalid JSON: line') as exc_info:
             self.config.transform_rerank_response(
                 model=self.model,
                 raw_response=mock_response,

--- a/tests/test_litellm/llms/gemini/image_edit/test_gemini_image_edit_transformation.py
+++ b/tests/test_litellm/llms/gemini/image_edit/test_gemini_image_edit_transformation.py
@@ -244,7 +244,7 @@ class TestGeminiImageEditTransformation:
     def test_transform_image_edit_request_without_image_raises(self) -> None:
         optional_params = {}
 
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match='Gemini image edit requires at least one image\\.'):
             self.config.transform_image_edit_request(
                 model=self.model,
                 prompt=self.prompt,

--- a/tests/test_litellm/llms/gemini/test_gemini_client_setup.py
+++ b/tests/test_litellm/llms/gemini/test_gemini_client_setup.py
@@ -28,7 +28,7 @@ def test_gemini_completion_no_api_key():
                 del os.environ[key]
 
         # Test without mock_response to ensure actual API key validation
-        with pytest.raises(Exception) as exc_info:
+        with pytest.raises(Exception, match='in _complete_vertex_ai_beta') as exc_info:
             completion(
                 model="gemini/gemini-1.5-flash",
                 messages=[{"role": "user", "content": "Test message"}],
@@ -60,7 +60,7 @@ def test_gemini_completion_no_api_key_with_mock():
         with patch("litellm.get_secret") as mock_get_secret:
             mock_get_secret.return_value = None
 
-            with pytest.raises(Exception) as exc_info:
+            with pytest.raises(Exception, match='in _complete_vertex_ai_beta') as exc_info:
                 completion(
                     model="gemini/gemini-1.5-flash",
                     messages=[{"role": "user", "content": "Test message"}],

--- a/tests/test_litellm/llms/hosted_vllm/test_hosted_vllm_rerank_transformation.py
+++ b/tests/test_litellm/llms/hosted_vllm/test_hosted_vllm_rerank_transformation.py
@@ -109,7 +109,7 @@ class TestHostedVLLMRerankTransform:
         )
         assert url2 == "https://api.example.com/rerank"
         # Raises if api_base is None
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match='api_base must be provided for Hosted VLLM rerank'):
             self.config.get_complete_url(None, self.model)
 
     def test_transform_response(self):

--- a/tests/test_litellm/llms/langflow/chat/test_langflow_chat_transformation.py
+++ b/tests/test_litellm/llms/langflow/chat/test_langflow_chat_transformation.py
@@ -46,7 +46,7 @@ def test_langflow_config_get_complete_url():
 
 def test_langflow_config_get_complete_url_requires_api_base():
     config = LangFlowConfig()
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match='api_base is required for LangFlow\\. Set it via'):
         config.get_complete_url(
             api_base=None,
             api_key=None,

--- a/tests/test_litellm/llms/modelscope/image_generation/test_modelscope_image_gen_transformation.py
+++ b/tests/test_litellm/llms/modelscope/image_generation/test_modelscope_image_gen_transformation.py
@@ -154,7 +154,7 @@ class TestModelScopeImageGenerationTransformation:
         mock_get_secret.return_value = None
         headers = {}
 
-        with pytest.raises(ValueError) as exc_info:
+        with pytest.raises(ValueError, match='MODELSCOPE_API_KEY is not set\\. Please set it via') as exc_info:
             self.config.validate_environment(
                 headers=headers,
                 model=self.model,
@@ -367,7 +367,7 @@ class TestModelScopeImageGenerationTransformation:
 
         model_response = ImageResponse(data=[])
 
-        with pytest.raises(Exception) as exc_info:
+        with pytest.raises(Exception, match='litellm\\.BadRequestError: ModelScope error: Invalid prompt') as exc_info:
             self.config.transform_image_generation_response(
                 model=self.model,
                 raw_response=mock_response,
@@ -393,7 +393,7 @@ class TestModelScopeImageGenerationTransformation:
 
         model_response = ImageResponse(data=[])
 
-        with pytest.raises(Exception) as exc_info:
+        with pytest.raises(Exception, match='litellm\\.InternalServerError: Error parsing ModelScope') as exc_info:
             self.config.transform_image_generation_response(
                 model=self.model,
                 raw_response=mock_response,

--- a/tests/test_litellm/llms/novita/chat/test_novita_chat_transformation.py
+++ b/tests/test_litellm/llms/novita/chat/test_novita_chat_transformation.py
@@ -47,7 +47,7 @@ class TestNovitaConfig:
         """Test error handling when API key is missing"""
         config = NovitaConfig()
 
-        with pytest.raises(ValueError) as excinfo:
+        with pytest.raises(ValueError, match='Missing Novita AI API Key - A call is being made to novita') as excinfo:
             config.validate_environment(
                 headers={},
                 model="novita/meta-llama/llama-3.3-70b-instruct",

--- a/tests/test_litellm/llms/oci/chat/test_oci_chat_transformation.py
+++ b/tests/test_litellm/llms/oci/chat/test_oci_chat_transformation.py
@@ -98,7 +98,7 @@ class TestOCIChatConfig:
             config = OCIChatConfig()
             headers = {}
 
-            with pytest.raises(Exception) as excinfo:
+            with pytest.raises(Exception, match='Missing required parameters: oci_user, oci_fingerprint') as excinfo:
                 config.validate_environment(
                     headers=headers,
                     model=TEST_MODEL,
@@ -272,7 +272,7 @@ class TestOCIChatConfig:
             "oci_serving_mode": "INVALID_MODE",
         }
 
-        with pytest.raises(Exception) as excinfo:
+        with pytest.raises(Exception, match="kwarg `oci_serving_mode` must be either 'ON_DEMAND' or") as excinfo:
             config.transform_request(
                 model=TEST_MODEL_NAME,
                 messages=TEST_MESSAGES,  # type: ignore
@@ -892,7 +892,7 @@ class TestOCISignerSupport:
 
         optional_params = {"oci_signer": MockSigner(), "method": "INVALID"}
 
-        with pytest.raises(ValueError) as excinfo:
+        with pytest.raises(ValueError, match='Unsupported HTTP method: INVALID') as excinfo:
             config.sign_request(
                 headers={},
                 optional_params=optional_params,
@@ -1604,7 +1604,7 @@ class TestOCIKeyNormalization:
 
         # We can't fully test signing without a real key, but we can verify
         # the error message indicates the key was processed (not a type error)
-        with pytest.raises(Exception) as exc_info:
+        with pytest.raises(Exception, match='why-can-t-i-import-my-pem-file for more details\\.') as exc_info:
             sign_with_manual_credentials(
                 headers={},
                 optional_params=optional_params,
@@ -1630,7 +1630,7 @@ class TestOCIKeyNormalization:
             "oci_key": crlf_pem,
         }
 
-        with pytest.raises(Exception) as exc_info:
+        with pytest.raises(Exception, match='why-can-t-i-import-my-pem-file for more details\\.') as exc_info:
             sign_with_manual_credentials(
                 headers={},
                 optional_params=optional_params,
@@ -1692,7 +1692,7 @@ class TestOCIValidateEnvironment:
 
     def test_missing_required_credentials_raises_error(self, config):
         """Test that missing required credentials raise an error."""
-        with pytest.raises(Exception) as exc_info:
+        with pytest.raises(Exception, match='Missing required parameters: oci_user, oci_fingerprint') as exc_info:
             config.validate_environment(
                 headers={},
                 model="oci/xai.grok-3",
@@ -1875,7 +1875,7 @@ class TestOCIImageUrlTransformation:
             }
         ]
 
-        with pytest.raises(Exception) as exc_info:
+        with pytest.raises(Exception, match='Prop `image_url` must be a string or an object with a `url`') as exc_info:
             adapt_messages_to_generic_oci_standard(messages)
 
         assert "image_url" in str(exc_info.value)
@@ -1899,7 +1899,7 @@ class TestOCIImageUrlTransformation:
             }
         ]
 
-        with pytest.raises(Exception) as exc_info:
+        with pytest.raises(Exception, match='Prop `image_url` must be a string or an object with a `url`') as exc_info:
             adapt_messages_to_generic_oci_standard(messages)
 
         assert "image_url" in str(exc_info.value)

--- a/tests/test_litellm/llms/pg_vector/vector_stores/test_pg_vector_transformation.py
+++ b/tests/test_litellm/llms/pg_vector/vector_stores/test_pg_vector_transformation.py
@@ -42,7 +42,7 @@ class TestPGVectorStoreConfig:
         litellm_params = GenericLiteLLMParams()
         headers = {}
 
-        with pytest.raises(ValueError) as exc_info:
+        with pytest.raises(ValueError, match='PG Vector API key is required\\. Set PG_VECTOR_API_KEY') as exc_info:
             config.validate_environment(headers, litellm_params)
 
         assert "PG Vector API key is required" in str(exc_info.value)
@@ -84,7 +84,7 @@ class TestPGVectorStoreConfig:
         config = PGVectorStoreConfig()
         litellm_params = {}
 
-        with pytest.raises(ValueError) as exc_info:
+        with pytest.raises(ValueError, match='PG Vector API base URL is required\\. Set') as exc_info:
             config.get_complete_url(None, litellm_params)
 
         assert "PG Vector API base URL is required" in str(exc_info.value)

--- a/tests/test_litellm/llms/recraft/image_edit/test_recraft_image_edit_transformation.py
+++ b/tests/test_litellm/llms/recraft/image_edit/test_recraft_image_edit_transformation.py
@@ -167,7 +167,7 @@ class TestRecraftImageEditTransformation:
         mock_response.status_code = 500
         mock_response.headers = {}
 
-        with pytest.raises(Exception) as exc_info:
+        with pytest.raises(Exception, match='Error transforming image edit response: Invalid JSON: line') as exc_info:
             self.config.transform_image_edit_response(
                 model=self.model,
                 raw_response=mock_response,

--- a/tests/test_litellm/llms/recraft/image_generation/test_recraft_image_gen_transformation.py
+++ b/tests/test_litellm/llms/recraft/image_generation/test_recraft_image_gen_transformation.py
@@ -64,7 +64,7 @@ class TestRecraftImageGenerationTransformation:
         non_default_params = {"n": 2, "unsupported_param": "value"}
         optional_params = {}
 
-        with pytest.raises(ValueError) as exc_info:
+        with pytest.raises(ValueError, match='Supported parameters are') as exc_info:
             self.config.map_openai_params(
                 non_default_params=non_default_params,
                 optional_params=optional_params,
@@ -171,7 +171,7 @@ class TestRecraftImageGenerationTransformation:
         mock_get_secret.return_value = None
         headers = {}
 
-        with pytest.raises(ValueError) as exc_info:
+        with pytest.raises(ValueError, match='RECRAFT_API_KEY is not set') as exc_info:
             self.config.validate_environment(
                 headers=headers,
                 model=self.model,
@@ -248,7 +248,7 @@ class TestRecraftImageGenerationTransformation:
 
         model_response = ImageResponse(data=[])
 
-        with pytest.raises(Exception) as exc_info:
+        with pytest.raises(Exception, match='Error transforming image generation response: Invalid JSON') as exc_info:
             self.config.transform_image_generation_response(
                 model=self.model,
                 raw_response=mock_response,

--- a/tests/test_litellm/llms/stability/image_generation/test_stability_image_generation.py
+++ b/tests/test_litellm/llms/stability/image_generation/test_stability_image_generation.py
@@ -83,7 +83,7 @@ class TestStabilityImageGenerationConfig:
         non_default_params = {"unsupported_param": "value"}
         optional_params = {}
 
-        with pytest.raises(ValueError) as exc_info:
+        with pytest.raises(ValueError, match="Supported parameters are \\['n', 'size',") as exc_info:
             self.config.map_openai_params(
                 non_default_params=non_default_params,
                 optional_params=optional_params,
@@ -168,7 +168,7 @@ class TestStabilityImageGenerationConfig:
 
     def test_validate_environment_raises_without_api_key(self):
         """Test that validate_environment raises error without API key"""
-        with pytest.raises(ValueError) as exc_info:
+        with pytest.raises(ValueError, match='STABILITY_API_KEY is not set\\. Please set it via') as exc_info:
             self.config.validate_environment(
                 headers={},
                 model="stability/sd3",
@@ -251,7 +251,7 @@ class TestStabilityImageGenerationConfig:
         model_response = ImageResponse(data=[])
         mock_logging = MagicMock()
 
-        with pytest.raises(Exception) as exc_info:
+        with pytest.raises(Exception, match='Content was filtered by Stability AI safety systems') as exc_info:
             self.config.transform_image_generation_response(
                 model="stability/sd3",
                 raw_response=mock_response,

--- a/tests/test_litellm/llms/tinyfish/test_tinyfish_search.py
+++ b/tests/test_litellm/llms/tinyfish/test_tinyfish_search.py
@@ -697,7 +697,7 @@ class TestErrorHandling:
             }
         }
         mock_response = _make_mock_response(body, status_code=400)
-        with pytest.raises(Exception) as exc_info:
+        with pytest.raises(Exception, match='TinyFish Search: query is required\\. See https') as exc_info:
             config.transform_search_response(
                 raw_response=mock_response, logging_obj=None
             )
@@ -713,7 +713,7 @@ class TestErrorHandling:
         mock_response = _make_mock_response(
             body, status_code=429, headers={"Retry-After": "60"}
         )
-        with pytest.raises(Exception) as exc_info:
+        with pytest.raises(Exception, match='TinyFish Search: rate limit exceeded\\. See https') as exc_info:
             config.transform_search_response(
                 raw_response=mock_response, logging_obj=None
             )
@@ -728,7 +728,7 @@ class TestErrorHandling:
         config = TinyfishSearchConfig()
         body = {"errors": [{"code": "10000", "message": "Internal"}]}
         mock_response = _make_mock_response(body, status_code=502)
-        with pytest.raises(Exception) as exc_info:
+        with pytest.raises(Exception, match='TinyFish Search') as exc_info:
             config.transform_search_response(
                 raw_response=mock_response, logging_obj=None
             )
@@ -742,7 +742,7 @@ class TestErrorHandling:
         mock_response = _make_mock_response(
             json_data=None, status_code=502, text="<html>Bad Gateway</html>"
         )
-        with pytest.raises(Exception) as exc_info:
+        with pytest.raises(Exception, match='TinyFish Search: <html>Bad Gateway<') as exc_info:
             config.transform_search_response(
                 raw_response=mock_response, logging_obj=None
             )
@@ -756,7 +756,7 @@ class TestErrorHandling:
         mock_response = _make_mock_response(
             json_data=None, status_code=200, text="not json"
         )
-        with pytest.raises(Exception) as exc_info:
+        with pytest.raises(Exception, match='TinyFish Search: Expected JSON response, got: not json\\.') as exc_info:
             config.transform_search_response(
                 raw_response=mock_response, logging_obj=None
             )
@@ -785,7 +785,7 @@ class TestErrorHandling:
         # check TinyFish's schema, not their own input.
         config = TinyfishSearchConfig()
         mock_response = _make_mock_response({"query": "x"})  # no `results` key
-        with pytest.raises(Exception) as exc_info:
+        with pytest.raises(Exception, match='validation error for SearchResponse') as exc_info:
             config.transform_search_response(
                 raw_response=mock_response, logging_obj=None
             )

--- a/tests/test_litellm/llms/vertex_ai/files/test_vertex_ai_files_integration.py
+++ b/tests/test_litellm/llms/vertex_ai/files/test_vertex_ai_files_integration.py
@@ -159,7 +159,7 @@ class TestVertexAIFilesIntegration:
         # This test ensures the type annotations and error messages include vertex_ai
 
         # Test that calling with unsupported provider raises appropriate error
-        with pytest.raises(Exception) as exc_info:
+        with pytest.raises(Exception, match="unsupported_provider' is not a valid LlmProviders") as exc_info:
             litellm.file_content(
                 file_id="test-file-id",
                 custom_llm_provider="unsupported_provider",  # This should fail

--- a/tests/test_litellm/llms/vertex_ai/test_vertex_ai_common_utils.py
+++ b/tests/test_litellm/llms/vertex_ai/test_vertex_ai_common_utils.py
@@ -33,7 +33,7 @@ def test_validate_vertex_location_accepts_valid(location):
     ["attacker.example/", "evil.com#", "us.attacker.example", "us/../..", "US", "us_central1", "-us", "", None],
 )
 def test_validate_vertex_location_rejects_invalid(location):
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="vertex_location is required|Invalid vertex_location format"):
         validate_vertex_location(location)
 
 

--- a/tests/test_litellm/llms/volcengine/responses/test_volcengine_responses_transformation.py
+++ b/tests/test_litellm/llms/volcengine/responses/test_volcengine_responses_transformation.py
@@ -137,7 +137,7 @@ class TestVolcengineResponsesAPITransformation:
         monkeypatch.delenv("ARK_API_KEY", raising=False)
         monkeypatch.delenv("VOLCENGINE_API_KEY", raising=False)
 
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match='Volcengine API key is required\\. Set ARK_API_KEY /'):
             config.validate_environment(headers={}, model="volcengine/demo", litellm_params={})
 
     def test_unsupported_params_are_dropped_with_extra_body(self):

--- a/tests/test_litellm/llms/volcengine/test_volcengine_embedding.py
+++ b/tests/test_litellm/llms/volcengine/test_volcengine_embedding.py
@@ -202,7 +202,7 @@ def test_volcengine_embedding_error_scenarios():
                 k: v for k, v in scenario.items() if k != "expected_error_pattern"
             }
 
-            with pytest.raises(Exception) as exc_info:
+            with pytest.raises(Exception, match=f"(?i){scenario['expected_error_pattern']}") as exc_info:
                 litellm.embedding(input=["test"], **test_params)
 
             # Verify error message contains expected pattern

--- a/tests/test_litellm/llms/voyage/rerank/test_voyage_rerank_transformation.py
+++ b/tests/test_litellm/llms/voyage/rerank/test_voyage_rerank_transformation.py
@@ -227,7 +227,7 @@ class TestVoyageRerankTransform:
         mock_logging = MagicMock()
         model_response = RerankResponse()
 
-        with pytest.raises(Exception) as exc_info:
+        with pytest.raises(Exception, match='Unauthorized') as exc_info:
             self.config.transform_rerank_response(
                 model=self.model,
                 raw_response=mock_response,
@@ -248,7 +248,7 @@ class TestVoyageRerankTransform:
         mock_logging = MagicMock()
         model_response = RerankResponse()
 
-        with pytest.raises(Exception) as exc_info:
+        with pytest.raises(Exception, match='Failed to parse response: Invalid JSON response') as exc_info:
             self.config.transform_rerank_response(
                 model=self.model,
                 raw_response=mock_response,

--- a/tests/test_litellm/llms/voyage/test_voyage_multimodal_embedding.py
+++ b/tests/test_litellm/llms/voyage/test_voyage_multimodal_embedding.py
@@ -195,7 +195,7 @@ class TestVoyageMultimodalEmbeddings:
 
         monkeypatch.setattr(module, "get_secret_str", lambda name: None)
         config = VoyageMultimodalEmbeddingConfig()
-        with pytest.raises(ValueError) as exc_info:
+        with pytest.raises(ValueError, match='Voyage API key is required for multimodal embeddings\\. Set') as exc_info:
             config.validate_environment(
                 {}, "voyage-multimodal-3.5", [], {}, {}, api_key=None
             )
@@ -207,7 +207,7 @@ class TestVoyageMultimodalEmbeddings:
         )
 
         config = VoyageMultimodalEmbeddingConfig()
-        with pytest.raises(ValueError) as exc_info:
+        with pytest.raises(ValueError, match='Voyage multimodal embeddings require a non-empty') as exc_info:
             config._normalize_content_item({"type": "image_url", "image_url": {}})
         assert "image_url" in str(exc_info.value)
 

--- a/tests/test_litellm/llms/xai/test_xai_key_fallback.py
+++ b/tests/test_litellm/llms/xai/test_xai_key_fallback.py
@@ -168,7 +168,7 @@ def test_responses_config_raises_when_no_key_is_available(monkeypatch):
     monkeypatch.setattr(litellm, "api_key", None)
     monkeypatch.delenv("XAI_API_KEY", raising=False)
 
-    with pytest.raises(ValueError) as exc_info:
+    with pytest.raises(ValueError, match='XAI API key is required\\. Set api_key, litellm\\.xai_key') as exc_info:
         XAIResponsesAPIConfig().validate_environment({}, "xai/grok-3-mini", None)
 
     error_message = str(exc_info.value)

--- a/tests/test_litellm/proxy/_experimental/mcp_server/auth/test_user_api_key_auth_mcp.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/auth/test_user_api_key_auth_mcp.py
@@ -8185,7 +8185,7 @@ class TestGetUserObjectPermission:
                 return_value=None,
             ),
         ):
-            with pytest.raises(ValueError):
+            with pytest.raises(ValueError, match="user 'human-dangling' names object_permission_id"):
                 await MCPRequestHandler._get_user_object_permission(auth)
 
     async def test_no_user_id_places_no_ceiling(self):

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_discoverable_endpoints.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_discoverable_endpoints.py
@@ -2698,13 +2698,6 @@ async def test_token_endpoint_respects_x_forwarded_host():
         (
             "http://localhost:4000/",
             "https",
-            "proxy.example.com",
-            "8443",
-            "https://proxy.example.com:8443",
-        ),
-        (
-            "http://localhost:4000/",
-            "https",
             "proxy.example.com:443",
             None,
             "https://proxy.example.com",

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_short_mcp_tool_prefix.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_short_mcp_tool_prefix.py
@@ -79,7 +79,7 @@ class TestShortPrefixHelpers:
         assert compute_short_server_prefix("abc") != compute_short_server_prefix("abd")
 
     def test_short_prefix_requires_server_id(self):
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match='compute_short_server_prefix requires a non-empty server_id'):
             compute_short_server_prefix("")
 
     def test_flag_defaults_to_false(self):

--- a/tests/test_litellm/proxy/auth/test_auth_checks.py
+++ b/tests/test_litellm/proxy/auth/test_auth_checks.py
@@ -268,7 +268,7 @@ def test_get_experimental_ui_login_jwt_auth_token_invalid(
     invalid_sso_user_defined_values,
 ):
     """Test generating JWT token with missing user role"""
-    with pytest.raises(Exception) as exc_info:
+    with pytest.raises(Exception, match='User role is required for experimental UI login') as exc_info:
         ExperimentalUIJWTToken.get_experimental_ui_login_jwt_auth_token(
             invalid_sso_user_defined_values
         )
@@ -883,7 +883,7 @@ async def test_get_user_object_wraps_db_outage_as_valueerror_preserving_context(
     mock_cache.async_set_cache = AsyncMock()
 
     with patch("litellm.proxy.auth.auth_checks._should_check_db", return_value=True):
-        with pytest.raises(ValueError) as exc_info:
+        with pytest.raises(ValueError, match="User doesn't exist in db\\.") as exc_info:
             await get_user_object(
                 user_id="outage-contract-probe-user",
                 prisma_client=mock_prisma_client,

--- a/tests/test_litellm/proxy/auth/test_auth_hot_path_network_requests.py
+++ b/tests/test_litellm/proxy/auth/test_auth_hot_path_network_requests.py
@@ -540,7 +540,7 @@ async def test_get_user_object_missing_user_negative_cache():
     mock_prisma.db.litellm_usertable.find_unique = AsyncMock(return_value=None)
 
     for _ in range(3):
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="User doesn't exist in db\\."):
             await get_user_object(
                 user_id=user_id,
                 prisma_client=mock_prisma,
@@ -570,7 +570,7 @@ async def test_get_user_object_missing_user_rechecks_after_expiry():
     mock_prisma.db.litellm_usertable = MagicMock()
     mock_prisma.db.litellm_usertable.find_unique = AsyncMock(return_value=None)
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="User doesn't exist in db\\."):
         await get_user_object(
             user_id=user_id,
             prisma_client=mock_prisma,
@@ -586,7 +586,7 @@ async def test_get_user_object_missing_user_rechecks_after_expiry():
         time.time() - (db_cache_expiry + 1),
     )
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="User doesn't exist in db\\."):
         await get_user_object(
             user_id=user_id,
             prisma_client=mock_prisma,

--- a/tests/test_litellm/proxy/auth/test_auth_utils.py
+++ b/tests/test_litellm/proxy/auth/test_auth_utils.py
@@ -1588,7 +1588,7 @@ class TestCheckCompleteCredentialsBlocksSSRF:
             "litellm.proxy.auth.auth_utils.validate_url",
             side_effect=SSRFError(f"blocked: {blocked_url}"),
         ):
-            with pytest.raises(ValueError) as exc_info:
+            with pytest.raises(ValueError, match='is rejected by the SSRF guard') as exc_info:
                 check_complete_credentials(
                     {
                         "model": "gpt-4",
@@ -2144,7 +2144,7 @@ class TestIsRequestBodySafeBlocksEndpointTargetingFields:
         ],
     )
     def test_endpoint_targeting_field_in_request_body_is_rejected(self, field):
-        with pytest.raises(ValueError) as exc:
+        with pytest.raises(ValueError, match='Rejected Request') as exc:
             is_request_body_safe(
                 request_body={"model": "gpt-4", field: "https://attacker.example"},
                 general_settings={},
@@ -2165,7 +2165,7 @@ class TestIsRequestBodySafeBlocksEndpointTargetingFields:
         # on the blocklist into an SSRF / credential-exfil hole. Verify
         # that supplying an api_key (alongside the banned param) does NOT
         # bypass the gate — it can only be opened by an admin opt-in.
-        with pytest.raises(ValueError) as exc:
+        with pytest.raises(ValueError, match='Rejected Request') as exc:
             is_request_body_safe(
                 request_body={
                     "model": "gpt-4",
@@ -2722,7 +2722,7 @@ class TestObservabilityCallbackBans:
         ],
     )
     def test_observability_field_in_request_body_root_is_rejected(self, field):
-        with pytest.raises(ValueError) as exc:
+        with pytest.raises(ValueError, match='Rejected Request') as exc:
             is_request_body_safe(
                 request_body={"model": "gpt-4", field: "attacker-value"},
                 general_settings={},
@@ -2752,7 +2752,7 @@ class TestObservabilityCallbackBans:
         # Verifies the metadata walk: a value smuggled inside ``metadata``
         # or ``litellm_metadata`` is just as dangerous as the same field
         # at the body root, and must hit the same gate.
-        with pytest.raises(ValueError) as exc:
+        with pytest.raises(ValueError, match='Rejected Request') as exc:
             is_request_body_safe(
                 request_body={
                     "model": "gpt-4",
@@ -2787,7 +2787,7 @@ class TestObservabilityCallbackBans:
         )
 
     def test_observability_field_in_litellm_params_metadata_is_rejected(self):
-        with pytest.raises(ValueError) as exc:
+        with pytest.raises(ValueError, match='Rejected Request: turn_off_message_logging is not allowed') as exc:
             is_request_body_safe(
                 request_body={
                     "model": "gpt-4",
@@ -2814,7 +2814,7 @@ class TestObservabilityCallbackBans:
         # the ``isinstance(dict)`` guard.
         import json
 
-        with pytest.raises(ValueError) as exc:
+        with pytest.raises(ValueError, match='Rejected Request: langfuse_host is not allowed in request') as exc:
             is_request_body_safe(
                 request_body={
                     "model": "gpt-4",
@@ -2887,7 +2887,7 @@ def test_model_level_allow_does_not_skip_subsequent_banned_params(monkeypatch):
         lambda model, param, request_body_value, llm_router: param == "api_base",
     )
 
-    with pytest.raises(ValueError) as exc:
+    with pytest.raises(ValueError, match='Rejected Request: langfuse_host is not allowed in request') as exc:
         is_request_body_safe(
             request_body={
                 "model": "gpt-4",
@@ -2958,7 +2958,7 @@ class TestPricingInjectionBlocked:
         ],
     )
     def test_pricing_field_rejected_by_default(self, field, value):
-        with pytest.raises(ValueError) as exc:
+        with pytest.raises(ValueError, match='Rejected Request') as exc:
             is_request_body_safe(
                 request_body={"model": "gpt-4", field: value},
                 general_settings={},

--- a/tests/test_litellm/proxy/auth/test_handle_jwt.py
+++ b/tests/test_litellm/proxy/auth/test_handle_jwt.py
@@ -2589,7 +2589,7 @@ async def test_find_and_validate_raises_when_required_team_not_found():
     # Token without team info
     jwt_token = {"sub": "user-1"}
 
-    with pytest.raises(Exception) as exc_info:
+    with pytest.raises(Exception, match="No team found in token\\. Checked team_id field 'None' and") as exc_info:
         await JWTAuthManager.find_and_validate_specific_team_id(
             jwt_handler=jwt_handler,
             jwt_valid_token=jwt_token,
@@ -2916,7 +2916,7 @@ async def test_find_and_validate_specific_team_id_hints_bracket_notation():
     # token has roles as a list — dot-notation won't find anything
     token = {"roles": ["team1"]}
 
-    with pytest.raises(Exception) as exc_info:
+    with pytest.raises(Exception, match="is not supported\\. Use 'roles' instead — LiteLLM") as exc_info:
         await JWTAuthManager.find_and_validate_specific_team_id(
             jwt_handler=handler,
             jwt_valid_token=token,
@@ -2947,7 +2947,7 @@ async def test_find_and_validate_specific_team_id_hints_bracket_index_notation()
     handler = _make_jwt_handler("roles[0]")
     token = {"roles": ["team1"]}
 
-    with pytest.raises(Exception) as exc_info:
+    with pytest.raises(Exception, match="is not supported in team_id_jwt_field\\. Use 'roles' instead") as exc_info:
         await JWTAuthManager.find_and_validate_specific_team_id(
             jwt_handler=handler,
             jwt_valid_token=token,
@@ -2977,7 +2977,7 @@ async def test_find_and_validate_specific_team_id_no_hint_for_valid_field():
     handler = _make_jwt_handler("appid")
     token = {}  # no appid — triggers the "no team found" path
 
-    with pytest.raises(Exception) as exc_info:
+    with pytest.raises(Exception, match="No team found in token\\. Checked team_id field 'appid' and") as exc_info:
         await JWTAuthManager.find_and_validate_specific_team_id(
             jwt_handler=handler,
             jwt_valid_token=token,
@@ -4807,7 +4807,7 @@ async def test_multi_issuer_jwt_unknown_issuer_falls_back_to_global_jwks(monkeyp
         kid="issuer-key",
     )
 
-    with pytest.raises(Exception) as exc:
+    with pytest.raises(Exception, match='Missing JWT Public Key URL from environment\\.') as exc:
         await jwt_handler.auth_jwt(token=token)
 
     assert "Missing JWT Public Key URL from environment." in str(exc.value)
@@ -4838,7 +4838,7 @@ async def test_multi_issuer_jwt_rejects_wrong_audience(monkeypatch):
         kid="issuer-key",
     )
 
-    with pytest.raises(Exception) as exc:
+    with pytest.raises(Exception, match="Validation fails: Audience doesn't match") as exc:
         await jwt_handler.auth_jwt(token=token)
 
     assert "Validation fails" in str(exc.value)
@@ -4881,7 +4881,7 @@ async def test_multi_issuer_jwt_same_kid_does_not_cross_issuer_keys(monkeypatch)
         kid=shared_kid,
     )
 
-    with pytest.raises(Exception) as exc:
+    with pytest.raises(Exception, match='Validation fails: Signature verification failed') as exc:
         await jwt_handler.auth_jwt(token=token)
 
     assert "Validation fails" in str(exc.value)
@@ -4936,7 +4936,7 @@ def test_multi_issuer_jwt_requires_audience_unless_explicitly_disabled(
     issuer = "https://issuer.example.com"
     jwks_url = f"{issuer}/keys"
 
-    with pytest.raises(Exception) as exc:
+    with pytest.raises(Exception, match='must configure audience or set') as exc:
         LiteLLM_JWTAuth(
             issuers=[
                 {
@@ -4953,7 +4953,7 @@ def test_multi_issuer_jwt_rejects_audience_with_disable_audience_validation():
     issuer = "https://issuer.example.com"
     jwks_url = f"{issuer}/keys"
 
-    with pytest.raises(Exception) as exc:
+    with pytest.raises(Exception, match='cannot set audience and disable_audience_validation=True') as exc:
         LiteLLM_JWTAuth(
             issuers=[
                 {

--- a/tests/test_litellm/proxy/auth/test_oauth2_proxy_hook.py
+++ b/tests/test_litellm/proxy/auth/test_oauth2_proxy_hook.py
@@ -141,7 +141,7 @@ async def test_refuses_to_map_non_identity_fields(configure_proxy, privileged_fi
     configure_proxy(mappings={privileged_field: f"x-{privileged_field}"})
     request = _request_with_headers({f"x-{privileged_field}": "proxy_admin"})
 
-    with pytest.raises(ValueError) as exc:
+    with pytest.raises(ValueError, match='proxy auth refuses to map non-identity UserAPIKeyAuth') as exc:
         await handle_oauth2_proxy_request(request)
     assert privileged_field in str(exc.value)
 

--- a/tests/test_litellm/proxy/auth/test_route_checks.py
+++ b/tests/test_litellm/proxy/auth/test_route_checks.py
@@ -42,7 +42,7 @@ def test_non_admin_config_update_route_rejected():
     request.query_params = {}
 
     # Test that calling /config/update route raises HTTPException with 403 status
-    with pytest.raises(Exception) as exc_info:
+    with pytest.raises(Exception, match='Only proxy admin can be used to generate, delete, update') as exc_info:
         RouteChecks.non_proxy_admin_allowed_routes_check(
             user_obj=user_obj,
             _user_role=LitellmUserRoles.INTERNAL_USER.value,
@@ -134,7 +134,7 @@ def test_user_banner_update_rejected_for_non_admin():
     request = MagicMock(spec=Request)
     request.query_params = {}
 
-    with pytest.raises(Exception) as exc_info:
+    with pytest.raises(Exception, match='Only proxy admin can be used to generate, delete, update') as exc_info:
         RouteChecks.non_proxy_admin_allowed_routes_check(
             user_obj=user_obj,
             _user_role=LitellmUserRoles.INTERNAL_USER.value,
@@ -1814,7 +1814,7 @@ def test_internal_user_blocked_from_global_spend_routes(route):
     request = MagicMock(spec=Request)
     request.query_params = {}
 
-    with pytest.raises(Exception) as exc_info:
+    with pytest.raises(Exception, match='Only proxy admin can be used to generate, delete, update') as exc_info:
         RouteChecks.non_proxy_admin_allowed_routes_check(
             user_obj=user_obj,
             _user_role=LitellmUserRoles.INTERNAL_USER.value,
@@ -1843,7 +1843,7 @@ def test_internal_user_view_only_blocked_from_global_spend_routes(route):
     request = MagicMock(spec=Request)
     request.query_params = {}
 
-    with pytest.raises(Exception) as exc_info:
+    with pytest.raises(Exception, match='Only proxy admin can be used to generate, delete, update') as exc_info:
         RouteChecks.non_proxy_admin_allowed_routes_check(
             user_obj=user_obj,
             _user_role=LitellmUserRoles.INTERNAL_USER_VIEW_ONLY.value,
@@ -2046,7 +2046,7 @@ def test_internal_user_blocked_from_admin_viewer_logs_routes(route):
     if route not in INTERNAL_USER_BLOCKED_SUBSET:
         return
 
-    with pytest.raises(Exception) as exc_info:
+    with pytest.raises(Exception, match='Only proxy admin can be used to generate, delete, update') as exc_info:
         RouteChecks.non_proxy_admin_allowed_routes_check(
             user_obj=user_obj,
             _user_role=LitellmUserRoles.INTERNAL_USER.value,
@@ -2530,7 +2530,7 @@ def test_non_admin_non_team_admin_cannot_access_config_update_but_can_attempt_re
     )
 
     # /config/update is still blocked
-    with pytest.raises(Exception) as exc_info:
+    with pytest.raises(Exception, match='Only proxy admin can be used to generate, delete, update') as exc_info:
         RouteChecks.non_proxy_admin_allowed_routes_check(
             user_obj=user_obj,
             _user_role=LitellmUserRoles.INTERNAL_USER.value,
@@ -3188,7 +3188,7 @@ def test_internal_user_blocked_from_search_tool_writes(route):
     request = MagicMock(spec=Request)
     request.query_params = {}
 
-    with pytest.raises(Exception) as exc_info:
+    with pytest.raises(Exception, match='Only proxy admin can be used to generate, delete, update') as exc_info:
         RouteChecks.non_proxy_admin_allowed_routes_check(
             user_obj=user_obj,
             _user_role=LitellmUserRoles.INTERNAL_USER.value,

--- a/tests/test_litellm/proxy/auth/test_user_api_key_auth.py
+++ b/tests/test_litellm/proxy/auth/test_user_api_key_auth.py
@@ -5337,7 +5337,7 @@ async def test_random_non_sk_token_is_rejected(monkeypatch):
         patch("litellm.proxy.proxy_server.master_key", "sk-master"),
         patch("litellm.proxy.proxy_server.prisma_client", MagicMock()),
     ):
-        with pytest.raises(Exception) as exc_info:
+        with pytest.raises(Exception, match='LiteLLM Virtual Key expected\\.') as exc_info:
             await user_api_key_auth(
                 request=mock_request,
                 api_key="Bearer not-a-real-token",
@@ -5539,7 +5539,7 @@ async def test_real_jwt_still_requires_license_when_jwt_auth_enabled(monkeypatch
         patch("litellm.proxy.proxy_server.master_key", "sk-master"),
         patch("litellm.proxy.proxy_server.prisma_client", None),
     ):
-        with pytest.raises(Exception) as exc_info:
+        with pytest.raises(Exception, match='JWT Auth is an enterprise only feature\\. You must be a') as exc_info:
             await user_api_key_auth(
                 request=mock_request,
                 api_key=f"Bearer {jwt_token}",

--- a/tests/test_litellm/proxy/client/cli/test_auth_commands.py
+++ b/tests/test_litellm/proxy/client/cli/test_auth_commands.py
@@ -84,7 +84,7 @@ class TestPollingErrorSurfacing:
         }
 
         with patch("requests.get", return_value=mock_response) as mock_get, patch("time.sleep"):
-            with pytest.raises(ValueError) as exc_info:
+            with pytest.raises(ValueError, match='Your litellm CLI is out of date and uses a login flow') as exc_info:
                 _poll_for_ready_data("http://test/sso/cli/poll/sk-legacy")
 
         assert mock_get.call_count == 1
@@ -151,7 +151,7 @@ class TestStartCliSsoFlowErrors:
         mock_response.status_code = 404
 
         with patch("requests.post", return_value=mock_response):
-            with pytest.raises(ValueError) as exc_info:
+            with pytest.raises(ValueError, match='Either --base-url is wrong, or the proxy is older than') as exc_info:
                 _start_cli_sso_flow("https://old-proxy.example.com")
 
         message = str(exc_info.value)
@@ -167,7 +167,7 @@ class TestStartCliSsoFlowErrors:
         mock_response.json.return_value = {"detail": "Too many CLI login attempts. Try again later."}
 
         with patch("requests.post", return_value=mock_response):
-            with pytest.raises(ValueError) as exc_info:
+            with pytest.raises(ValueError, match='Too many CLI login attempts\\. Try again later\\.') as exc_info:
                 _start_cli_sso_flow("https://test.example.com")
 
         assert "HTTP 429" in str(exc_info.value)
@@ -183,7 +183,7 @@ class TestStartCliSsoFlowErrors:
         mock_response.text = "<html>Sign in to corporate VPN</html>"
 
         with patch("requests.post", return_value=mock_response):
-            with pytest.raises(ValueError) as exc_info:
+            with pytest.raises(ValueError, match='A proxy, load balancer, or auth gateway in front of') as exc_info:
                 _start_cli_sso_flow("https://test.example.com")
 
         message = str(exc_info.value)
@@ -197,7 +197,7 @@ class TestStartCliSsoFlowErrors:
         from litellm.proxy.client.cli.commands.auth import _start_cli_sso_flow
 
         with patch("requests.post", side_effect=requests.ConnectionError("Connection refused")):
-            with pytest.raises(ValueError) as exc_info:
+            with pytest.raises(ValueError, match='Connection refused\\. Check that the proxy is running') as exc_info:
                 _start_cli_sso_flow("https://unreachable.example.com")
 
         message = str(exc_info.value)

--- a/tests/test_litellm/proxy/client/cli/test_pkce_login.py
+++ b/tests/test_litellm/proxy/client/cli/test_pkce_login.py
@@ -622,7 +622,7 @@ def test_fresh_api_key_never_hands_out_a_rotated_key_it_could_not_save():
     def save(_record):
         raise OSError("disk full")
 
-    with pytest.raises(OSError):
+    with pytest.raises(OSError, match="disk full"):
         _fresh(STORED, save, http, now=lambda: 999_950.0)
 
 

--- a/tests/test_litellm/proxy/client/test_models.py
+++ b/tests/test_litellm/proxy/client/test_models.py
@@ -472,14 +472,14 @@ def test_get_invalid_params():
     client = ModelsManagementClient(base_url="http://localhost:8000")
 
     # Test with no parameters
-    with pytest.raises(ValueError) as exc_info:
+    with pytest.raises(ValueError, match='Exactly one of model_id or model_name must be provided') as exc_info:
         client.get()
     assert "Exactly one of model_id or model_name must be provided" in str(
         exc_info.value
     )
 
     # Test with both parameters
-    with pytest.raises(ValueError) as exc_info:
+    with pytest.raises(ValueError, match='Exactly one of model_id or model_name must be provided') as exc_info:
         client.get(model_id="123", model_name="gpt-4")
     assert "Exactly one of model_id or model_name must be provided" in str(
         exc_info.value

--- a/tests/test_litellm/proxy/common_utils/test_callback_utils.py
+++ b/tests/test_litellm/proxy/common_utils/test_callback_utils.py
@@ -586,7 +586,7 @@ def test_initialize_callbacks_on_proxy_rejects_class_valued_entry(probe_config_p
     silently never run the hook. Config load must fail instead."""
     entry = f"{_PROBE_MODULE_NAME}.FloorMaxTokens"
 
-    with pytest.raises(ValueError) as exc_info:
+    with pytest.raises(ValueError, match='litellm_settings\\.callbacks entry') as exc_info:
         _load_callbacks([entry], probe_config_path)
 
     message = str(exc_info.value)
@@ -609,7 +609,7 @@ def test_initialize_callbacks_on_proxy_rejects_non_dispatchable_values(
 ):
     entry = f"{_PROBE_MODULE_NAME}.{attribute}"
 
-    with pytest.raises(ValueError) as exc_info:
+    with pytest.raises(ValueError, match='litellm_settings\\.callbacks entry') as exc_info:
         _load_callbacks([entry], probe_config_path)
 
     message = str(exc_info.value)
@@ -621,7 +621,7 @@ def test_initialize_callbacks_on_proxy_rejects_non_dispatchable_values(
 def test_initialize_callbacks_on_proxy_rejects_class_valued_non_list_value(probe_config_path):
     entry = f"{_PROBE_MODULE_NAME}.FloorMaxTokens"
 
-    with pytest.raises(ValueError) as exc_info:
+    with pytest.raises(ValueError, match='litellm_settings\\.callbacks entry') as exc_info:
         _load_callbacks(entry, probe_config_path)
 
     assert entry in str(exc_info.value)

--- a/tests/test_litellm/proxy/common_utils/test_path_utils.py
+++ b/tests/test_litellm/proxy/common_utils/test_path_utils.py
@@ -42,5 +42,5 @@ class TestSafeFilename:
             safe_filename("..")
 
     def test_empty_rejected(self):
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match='Empty or unsafe filename'):
             safe_filename("")

--- a/tests/test_litellm/proxy/common_utils/test_timezone_utils.py
+++ b/tests/test_litellm/proxy/common_utils/test_timezone_utils.py
@@ -130,16 +130,16 @@ def test_parse_budget_reset_time_unset_defaults_to_midnight():
 
 
 def test_parse_budget_reset_time_invalid_string_raises():
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="hour 'HH:MM' or 'HH:MM:SS' string, e\\.g\\."):
         parse_budget_reset_time("25:00")
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="Invalid budget_reset_time 'noon'; expected a"):
         parse_budget_reset_time("noon")
 
 
 def test_parse_budget_reset_time_non_string_raises():
     # Unquoted "12:00" in YAML parses to the int 720; it must fail loudly,
     # not silently fall back to midnight.
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="hour 'HH:MM' string, e\\.g\\."):
         parse_budget_reset_time(720)
 
 

--- a/tests/test_litellm/proxy/db/db_transaction_queue/test_spend_logs_partition_manager.py
+++ b/tests/test_litellm/proxy/db/db_transaction_queue/test_spend_logs_partition_manager.py
@@ -308,9 +308,9 @@ async def test_partition_maintenance_issues_nothing_when_the_budget_is_already_s
 
 
 def test_unsupported_interval_raises():
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match='Unsupported partition interval: year'):
         period_start(date(2026, 6, 1), "year")
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match='Unsupported partition interval: year'):
         next_period_start(date(2026, 6, 1), "year")
 
 

--- a/tests/test_litellm/proxy/db/test_prisma_planned_engine_restart.py
+++ b/tests/test_litellm/proxy/db/test_prisma_planned_engine_restart.py
@@ -913,7 +913,7 @@ async def test_health_check_alerts_for_non_connection_errors_during_a_replacemen
         await _yield_to_loop()
         assert wrapper._reconnection_lock.locked() is True
 
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match='malformed SELECT'):
             await client.health_check()
 
         gate.set()

--- a/tests/test_litellm/proxy/db/test_spend_log_tool_index.py
+++ b/tests/test_litellm/proxy/db/test_spend_log_tool_index.py
@@ -327,7 +327,7 @@ class TestFlushToolUsageTransactions:
     async def test_non_connection_errors_do_not_retry(self):
         prisma = MagicMock()
         prisma.db.batch_ = MagicMock(side_effect=ValueError("bad data"))
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="bad data"):
             await flush_tool_usage_transactions(prisma_client=prisma, transactions=[_transaction("r1")])
         prisma.db.batch_.assert_called_once()
 

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_bedrock_invoke_guardrail_checks.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_bedrock_invoke_guardrail_checks.py
@@ -56,7 +56,7 @@ def _patched(guardrail: BedrockGuardrail, http_response):
 
 
 def test_init_rejects_both_identifier_and_checks():
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match='Bedrock guardrail accepts either'):
         BedrockGuardrail(guardrailIdentifier="gid", checks=CONTENT_FILTER_CHECKS)
 
 
@@ -304,7 +304,7 @@ async def test_truncated_pii_ignored_when_pii_check_not_configured():
 
 @pytest.mark.asyncio
 async def test_checks_with_guardrail_version_rejected():
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match='Bedrock guardrail accepts either'):
         BedrockGuardrail(checks=CONTENT_FILTER_CHECKS, guardrailVersion="DRAFT")
 
 

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_enkryptai.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_enkryptai.py
@@ -178,7 +178,7 @@ class TestEnkryptAIGuardrailHooks:
         with patch.object(
             enkryptai_guardrail.async_handler, "post", return_value=mock_response
         ):
-            with pytest.raises(ValueError) as exc_info:
+            with pytest.raises(ValueError, match='violation\\(s\\) detected') as exc_info:
                 await enkryptai_guardrail.async_pre_call_hook(
                     user_api_key_dict=mock_user_api_key_dict,
                     cache=MagicMock(),

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_generic_guardrail_api.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_generic_guardrail_api.py
@@ -767,7 +767,7 @@ class TestErrorHandling:
                 "API Error", request=MagicMock(), response=MagicMock(status_code=500)
             ),
         ):
-            with pytest.raises(Exception) as exc_info:
+            with pytest.raises(Exception, match='Generic Guardrail API failed: API Error') as exc_info:
                 await generic_guardrail.apply_guardrail(
                     inputs={"texts": ["test"]},
                     request_data=mock_request_data_input,
@@ -786,7 +786,7 @@ class TestErrorHandling:
             "post",
             side_effect=httpx.RequestError("Connection failed", request=MagicMock()),
         ):
-            with pytest.raises(Exception) as exc_info:
+            with pytest.raises(Exception, match='Generic Guardrail API failed: Connection failed') as exc_info:
                 await generic_guardrail.apply_guardrail(
                     inputs={"texts": ["test"]},
                     request_data=mock_request_data_input,
@@ -810,7 +810,7 @@ class TestErrorHandling:
             "post",
             side_effect=httpx.RequestError("Connection failed", request=MagicMock()),
         ):
-            with pytest.raises(Exception) as exc_info:
+            with pytest.raises(Exception, match='Generic Guardrail API failed: Connection failed') as exc_info:
                 await guardrail.apply_guardrail(
                     inputs={"texts": ["test"]},
                     request_data=mock_request_data_input,

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_model_armor.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_model_armor.py
@@ -2334,7 +2334,7 @@ async def test_async_moderation_hook_api_error_fail_on_error_true():
         }
 
         # Should raise the exception since fail_on_error is True
-        with pytest.raises(Exception) as exc_info:
+        with pytest.raises(Exception, match="API Error") as exc_info:
             await guardrail.async_moderation_hook(
                 data=request_data,
                 user_api_key_dict=mock_user_api_key_dict,
@@ -2374,7 +2374,7 @@ async def test_async_moderation_hook_api_error_fail_on_error_false():
 
         # Even with fail_on_error=False, the decorator may still raise the exception
         # This test verifies that the exception is properly logged and handled
-        with pytest.raises(Exception) as exc_info:
+        with pytest.raises(Exception, match="API Error") as exc_info:
             await guardrail.async_moderation_hook(
                 data=request_data,
                 user_api_key_dict=mock_user_api_key_dict,
@@ -2865,7 +2865,7 @@ async def test_skip_unscannable_still_fails_closed_on_api_error():
         "post",
         AsyncMock(side_effect=Exception("model armor upstream 500")),
     ):
-        with pytest.raises(Exception) as exc_info:
+        with pytest.raises(Exception, match='model armor upstream') as exc_info:
             await guardrail.async_pre_call_hook(
                 user_api_key_dict=UserAPIKeyAuth(),
                 cache=MagicMock(spec=DualCache),

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_panw_prisma_airs.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_panw_prisma_airs.py
@@ -5652,7 +5652,7 @@ class TestPanwAirsTimeoutCoercion:
         assert isinstance(params.timeout, float)
 
     def test_litellm_params_rejects_garbage_timeout(self):
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match='validation error for LitellmParams'):
             LitellmParams(
                 guardrail="panw_prisma_airs",
                 mode="pre_call",

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_straiker.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_straiker.py
@@ -90,12 +90,12 @@ def test_config_model_wiring():
 
 
 def test_init_rejects_empty_api_key():
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match='api_key must be non-empty'):
         StraikerGuardrail(api_key="")
 
 
 def test_init_rejects_invalid_fallback():
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="unreachable_fallback must be 'fail_open' or 'fail_closed';"):
         StraikerGuardrail(api_key="k", unreachable_fallback="nope")
 
 
@@ -109,7 +109,7 @@ def test_supported_hooks_limited_to_pre_and_post():
 
 
 def test_during_call_mode_rejected_at_init():
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match='Event hook GuardrailEventHooks\\.during_call is not in the'):
         StraikerGuardrail(api_key="k", event_hook="during_call")
 
 

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_tool_permission.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_tool_permission.py
@@ -124,7 +124,7 @@ class TestToolPermissionGuardrail:
         assert rule_id is None
 
     def test_rule_requires_name_or_type(self):
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match='validation error for ToolPermissionRule'):
             ToolPermissionGuardrail(
                 guardrail_name="invalid-rule",
                 rules=[{"id": "no_target", "decision": "allow"}],
@@ -1042,7 +1042,7 @@ class TestToolPermissionGuardrailInMemoryUpdate:
         assert guardrail._check_tool_permission("Secret")[0] is False
         assert guardrail._check_tool_permission("Other")[0] is True
 
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="Invalid regex for tool_name in rule 'bad': unterminated"):
             guardrail.update_in_memory_litellm_params(
                 LitellmParams(
                     guardrail="tool_permission",

--- a/tests/test_litellm/proxy/guardrails/test_llm_as_a_judge.py
+++ b/tests/test_litellm/proxy/guardrails/test_llm_as_a_judge.py
@@ -230,7 +230,7 @@ def test_parse_judge_verdict_reraises_when_no_json():
 
 def test_parse_judge_verdict_rejects_json_non_object():
     """Valid JSON that is not an object (e.g. a bare list) raises ValueError."""
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match='judge response is not a JSON object'):
         _parse_judge_verdict("[1, 2, 3]")
 
 

--- a/tests/test_litellm/proxy/hooks/test_sensitive_data_routing.py
+++ b/tests/test_litellm/proxy/hooks/test_sensitive_data_routing.py
@@ -227,7 +227,7 @@ class TestCustomGuardrailSensitiveDataRouting:
 
         request_data = {"model": "gpt-4"}
 
-        with pytest.raises(ValueError) as exc_info:
+        with pytest.raises(ValueError, match='Cannot route sensitive data without a session_id\\. Ensure') as exc_info:
             guardrail.raise_sensitive_data_route_exception(
                 route_to_model="on-premise-model",
                 request_data=request_data,

--- a/tests/test_litellm/proxy/hooks/test_tpm_concurrent.py
+++ b/tests/test_litellm/proxy/hooks/test_tpm_concurrent.py
@@ -150,7 +150,7 @@ async def test_no_leak_on_over_limit_rejection(rate_limiter):
         f"estimated={estimated}, limit={user_api_key_dict.tpm_limit}"
     )
 
-    with pytest.raises(Exception) as exc_info:
+    with pytest.raises(Exception, match='Limit type: tokens\\. Current limit') as exc_info:
         await handler.async_pre_call_hook(
             user_api_key_dict=user_api_key_dict,
             cache=cache,
@@ -685,7 +685,7 @@ async def test_contentless_request_reserves_minimum(rate_limiter):
         f"counter should be 2, got {counter_after_two}"
     )
 
-    with pytest.raises(Exception) as exc_info:
+    with pytest.raises(Exception, match='Limit type: tokens\\. Current limit') as exc_info:
         await handler.async_pre_call_hook(
             user_api_key_dict=user_api_key_dict,
             cache=cache,
@@ -1319,7 +1319,7 @@ async def test_project_otpm_rejects_multiple_completion_candidates(rate_limiter)
         "n": 10,
     }
 
-    with pytest.raises(Exception) as exc_info:
+    with pytest.raises(Exception, match='Rate limit exceeded for model_per_project_otpm') as exc_info:
         await handler.async_pre_call_hook(
             user_api_key_dict=user_api_key_dict,
             cache=cache,
@@ -1347,7 +1347,7 @@ async def test_project_otpm_reserves_largest_conflicting_output_cap(rate_limiter
         "max_completion_tokens": 100,
     }
 
-    with pytest.raises(Exception) as exc_info:
+    with pytest.raises(Exception, match='Rate limit exceeded for model_per_project_otpm') as exc_info:
         await handler.async_pre_call_hook(
             user_api_key_dict=user_api_key_dict,
             cache=cache,
@@ -1377,7 +1377,7 @@ async def test_project_otpm_rejects_google_genai_native_output_cap(
         project_metadata={"model_otpm_limit": {model: 50}},
     )
 
-    with pytest.raises(Exception) as exc_info:
+    with pytest.raises(Exception, match='Rate limit exceeded for model_per_project_otpm') as exc_info:
         await handler.async_pre_call_hook(
             user_api_key_dict=user_api_key_dict,
             cache=cache,
@@ -1411,7 +1411,7 @@ async def test_project_otpm_rejects_google_genai_native_candidate_count(
         project_metadata={"model_otpm_limit": {model: 150}},
     )
 
-    with pytest.raises(Exception) as exc_info:
+    with pytest.raises(Exception, match='Rate limit exceeded for model_per_project_otpm') as exc_info:
         await handler.async_pre_call_hook(
             user_api_key_dict=user_api_key_dict,
             cache=cache,
@@ -1500,7 +1500,7 @@ async def test_project_otpm_over_limit_rolls_back_itpm_reservation(rate_limiter)
         "max_tokens": 500,  # blows past the 10-token OTPM limit
     }
 
-    with pytest.raises(Exception) as exc_info:
+    with pytest.raises(Exception, match='Rate limit exceeded for model_per_project_otpm') as exc_info:
         await handler.async_pre_call_hook(
             user_api_key_dict=user_api_key_dict,
             cache=cache,
@@ -2003,7 +2003,7 @@ async def test_otpm_rejection_does_not_double_refund_combined_tpm(rate_limiter):
         rate_limit_type="tokens",
     )
 
-    with pytest.raises(Exception) as exc_info:
+    with pytest.raises(Exception, match='Rate limit exceeded for model_per_project_otpm') as exc_info:
         await handler.async_pre_call_hook(
             user_api_key_dict=user_api_key_dict,
             cache=cache,
@@ -2060,7 +2060,7 @@ async def test_project_itpm_rejects_pretokenized_embedding_input(
         "input": embedding_input,
     }
 
-    with pytest.raises(Exception) as exc_info:
+    with pytest.raises(Exception, match='Rate limit exceeded for model_per_project_itpm') as exc_info:
         await handler.async_pre_call_hook(
             user_api_key_dict=user_api_key_dict,
             cache=cache,
@@ -2250,7 +2250,7 @@ async def test_itpm_reservation_accounts_for_audio_content_not_just_text(rate_li
         ],
     }
 
-    with pytest.raises(Exception) as exc_info:
+    with pytest.raises(Exception, match='Rate limit exceeded for model_per_project_itpm') as exc_info:
         await handler.async_pre_call_hook(
             user_api_key_dict=user_api_key_dict,
             cache=cache,
@@ -2361,7 +2361,7 @@ async def test_itpm_rejects_large_audio_payload_that_would_pass_flat_estimate(
         ],
     }
 
-    with pytest.raises(Exception) as exc_info:
+    with pytest.raises(Exception, match='Rate limit exceeded for model_per_project_itpm') as exc_info:
         await handler.async_pre_call_hook(
             user_api_key_dict=user_api_key_dict,
             cache=cache,
@@ -2622,7 +2622,7 @@ async def test_explicit_zero_output_responses_call_reserves_effective_provider_m
         },
     )
 
-    with pytest.raises(Exception) as exc_info:
+    with pytest.raises(Exception, match='Rate limit exceeded for model_per_project_otpm') as exc_info:
         await handler.async_pre_call_hook(
             user_api_key_dict=user_api_key_dict,
             cache=cache,
@@ -2850,7 +2850,7 @@ async def test_otpm_rejection_releases_stashed_parallel_slot(rate_limiter):
         "rate_limit": {"tokens_per_unit": 5, "window_size": 60},
     }
 
-    with pytest.raises(Exception) as exc_info:
+    with pytest.raises(Exception, match='Rate limit exceeded for model_per_project_otpm') as exc_info:
         await handler._reserve_project_io_tokens_or_raise(
             descriptors=[otpm_descriptor],
             data=data,
@@ -3296,7 +3296,7 @@ async def test_rerank_query_and_documents_enforce_project_itpm(
         project_metadata={"model_itpm_limit": {"rerank-model": 100}},
     )
 
-    with pytest.raises(Exception) as exc_info:
+    with pytest.raises(Exception, match='Rate limit exceeded for model_per_project_itpm') as exc_info:
         await handler.async_pre_call_hook(
             user_api_key_dict=user_api_key_dict,
             cache=cache,

--- a/tests/test_litellm/proxy/management_endpoints/test_key_management_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_key_management_endpoints.py
@@ -10179,7 +10179,7 @@ async def test_update_key_creator_reassigned_key_blocked(monkeypatch):
     mock_request = MagicMock()
     mock_request.query_params = {}
 
-    with pytest.raises(Exception) as exc:
+    with pytest.raises(Exception, match='User can only create keys for themselves\\. Got') as exc:
         await update_key_fn(
             request=mock_request,
             data=UpdateKeyRequest(key=test_hashed_token, key_alias="hijacked"),

--- a/tests/test_litellm/proxy/management_endpoints/test_mcp_management_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_mcp_management_endpoints.py
@@ -2325,7 +2325,7 @@ class TestTemporaryMCPSessionEndpoints:
             "litellm.proxy.management_endpoints.mcp_management_endpoints.validate_and_normalize_mcp_server_payload",
             MagicMock(),
         ):
-            with pytest.raises(Exception) as exc_info:
+            with pytest.raises(Exception, match='User does not have permission to create temporary mcp') as exc_info:
                 await add_session_mcp_server(
                     payload=payload,
                     user_api_key_dict=non_admin,

--- a/tests/test_litellm/proxy/management_endpoints/test_model_management_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_model_management_endpoints.py
@@ -140,7 +140,7 @@ class TestModelManagementAuthChecks:
     @pytest.mark.asyncio
     async def test_can_user_make_team_model_call_non_premium_fails(self):
         """Test that non-premium users cannot make team model calls"""
-        with pytest.raises(Exception) as exc_info:
+        with pytest.raises(Exception, match='You must be a LiteLLM Enterprise user to use this feature\\.') as exc_info:
             ModelManagementAuthChecks.can_user_make_team_model_call(
                 team_id="test_team",
                 user_api_key_dict=self.admin_user,
@@ -195,7 +195,7 @@ class TestModelManagementAuthChecks:
         )
         prisma_client = MockPrismaClient(team_exists=True)
 
-        with pytest.raises(Exception) as exc_info:
+        with pytest.raises(Exception, match='You must be a LiteLLM Enterprise user to use this feature\\.') as exc_info:
             await ModelManagementAuthChecks.allow_team_model_action(
                 model_params=model_params,
                 user_api_key_dict=self.admin_user,
@@ -216,7 +216,7 @@ class TestModelManagementAuthChecks:
         )
         prisma_client = MockPrismaClient(team_exists=False)
 
-        with pytest.raises(Exception) as exc_info:
+        with pytest.raises(Exception, match="Team id=nonexistent_team does not exist in db'\\}") as exc_info:
             await ModelManagementAuthChecks.allow_team_model_action(
                 model_params=model_params,
                 user_api_key_dict=self.admin_user,
@@ -257,7 +257,7 @@ class TestModelManagementAuthChecks:
         )
         prisma_client = MockPrismaClient(team_exists=True, user_admin=False)
 
-        with pytest.raises(Exception) as exc_info:
+        with pytest.raises(Exception, match="Team ID=test_team does not match the API key's team") as exc_info:
             await ModelManagementAuthChecks.can_user_make_model_call(
                 model_params=model_params,
                 user_api_key_dict=self.normal_user,
@@ -1483,7 +1483,7 @@ class TestTeamModelUpdate:
             "litellm.proxy.proxy_server.premium_user",
             True,
         ):
-            with pytest.raises(Exception) as exc_info:
+            with pytest.raises(Exception, match="does not match the API key's team ID=None, OR you are") as exc_info:
                 await _update_team_model_in_db(
                     db_model=db_model,
                     patch_data=patch_data,
@@ -3256,7 +3256,7 @@ class TestPatchModelBlockedAuthGate:
                 new=AsyncMock(return_value=None),
             ),
         ):
-            with pytest.raises(Exception) as exc_info:
+            with pytest.raises(Exception, match="Only proxy admins can change a model's blocked flag\\.") as exc_info:
                 await patch_model(
                     model_id="m1",
                     patch_data=updateDeployment(blocked=True),

--- a/tests/test_litellm/proxy/management_endpoints/test_ptu_model_settings.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_ptu_model_settings.py
@@ -58,7 +58,7 @@ def test_model_info_accepts_valid_ptu_fields():
 
 
 def test_model_info_rejects_non_positive_count():
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match='value_error, input_value'):
         ModelInfo(
             id="x",
             team_id="t",
@@ -69,7 +69,7 @@ def test_model_info_rejects_non_positive_count():
 
 
 def test_model_info_rejects_negative_rate():
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match='value_error, input_value'):
         ModelInfo(
             id="x",
             team_id="t",
@@ -82,7 +82,7 @@ def test_model_info_rejects_negative_rate():
 def test_model_info_rejects_a_count_beyond_the_cap():
     """flat cost multiplies the count by a float, and an unbounded int overflows that
     conversion, which aborted the rollup for every team rather than skipping one model."""
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match='validation error for ModelInfo'):
         ModelInfo(id="x", team_id="t", ptu_count=10**400, cost_per_ptu_per_hour=2.0)
 
 
@@ -95,12 +95,12 @@ def test_model_info_accepts_a_count_at_the_cap():
 def test_model_info_rejects_a_non_finite_rate(rate):
     """NaN compares False against every bound, so a bare `< 0` check let it through and the
     deployment then accrued a flat cost of nan."""
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match='value_error, input_value'):
         ModelInfo(id="x", team_id="t", ptu_count=5, cost_per_ptu_per_hour=rate)
 
 
 def test_model_info_rejects_a_rate_beyond_the_cap():
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match='validation error for ModelInfo'):
         ModelInfo(id="x", team_id="t", ptu_count=5, cost_per_ptu_per_hour=ModelInfo.MAX_COST_PER_PTU_PER_HOUR * 2)
 
 
@@ -148,7 +148,7 @@ def test_validate_helper_passes_full_config():
 def test_model_info_rejects_effective_to_before_from():
     import datetime
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match='validation error for ModelInfo'):
         ModelInfo(
             id="x",
             team_id="t",
@@ -186,7 +186,7 @@ def test_model_info_compares_mixed_naive_and_aware_timestamps():
     )
     assert info.ptu_effective_to is not None
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match='validation error for ModelInfo'):
         ModelInfo(
             id="x",
             team_id="t",
@@ -698,7 +698,7 @@ class TestAddNewModelPtuGate:
         with ExitStack() as stack:
             for active_patch in patches:
                 stack.enter_context(active_patch)
-            with pytest.raises(Exception) as exc:
+            with pytest.raises(Exception, match='PTU cost attribution is disabled, so ptu_count') as exc:
                 await add_new_model(model_params=self._ptu_deployment("ptu-gate-model"), user_api_key_dict=admin)
 
         assert PTU_COST_ATTRIBUTION_ENV_VAR in str(exc.value)
@@ -1273,7 +1273,7 @@ class TestPtuDeploymentsAreNotBilledPerToken:
         with ExitStack() as stack:
             for active_patch in patches:
                 stack.enter_context(active_patch)
-            with pytest.raises(Exception) as exc:
+            with pytest.raises(Exception, match='A PTU deployment bills by reserved capacity, so') as exc:
                 await add_new_model(model_params=deployment, user_api_key_dict=admin)
 
         assert "input_cost_per_token" in str(exc.value)

--- a/tests/test_litellm/proxy/management_endpoints/usage_endpoints/test_ai_usage_chat.py
+++ b/tests/test_litellm/proxy/management_endpoints/usage_endpoints/test_ai_usage_chat.py
@@ -458,7 +458,7 @@ class TestUsageAiChatServiceAccountGuard:
             _resolve_fetch_kwargs,
         )
 
-        with pytest.raises(ValueError) as exc_info:
+        with pytest.raises(ValueError, match='Non-admin caller has user_id=None; refusing to issue an') as exc_info:
             _resolve_fetch_kwargs(
                 fn_name="get_usage_data",
                 fn_args={"start_date": "2025-01-01", "end_date": "2025-01-31"},

--- a/tests/test_litellm/proxy/management_helpers/test_team_metadata_validation.py
+++ b/tests/test_litellm/proxy/management_helpers/test_team_metadata_validation.py
@@ -671,7 +671,7 @@ async def test_non_callable_validator_is_rejected_with_clean_500():
 
 
 def test_parse_schema_duplicate_error_lists_offending_keys():
-    with pytest.raises(ValueError) as exc_info:
+    with pytest.raises(ValueError, match='team_metadata_schema contains duplicate keys: app_name') as exc_info:
         parse_team_metadata_schema(
             [{"key": "cost_center"}, {"key": "app_name"}, {"key": "cost_center"}, {"key": "app_name"}]
         )

--- a/tests/test_litellm/proxy/openai_files_endpoint/test_batch_guardrails.py
+++ b/tests/test_litellm/proxy/openai_files_endpoint/test_batch_guardrails.py
@@ -781,7 +781,7 @@ async def test_the_rewrite_closes_its_own_output_when_it_cannot_finish():
     original_read = bg._read_spooled
     bg._read_spooled = _boom
     try:
-        with pytest.raises(OSError):
+        with pytest.raises(OSError, match='no space left on device'):
             rewrite_batch_input_file(source, result)
     finally:
         bg.tempfile.SpooledTemporaryFile = real

--- a/tests/test_litellm/proxy/pass_through_endpoints/test_llm_pass_through_endpoints.py
+++ b/tests/test_litellm/proxy/pass_through_endpoints/test_llm_pass_through_endpoints.py
@@ -2714,7 +2714,7 @@ class TestMilvusProxyRoute:
                 None
             )
 
-            with pytest.raises(Exception) as exc_info:
+            with pytest.raises(Exception, match='Vector store not found for missing-store') as exc_info:
                 await milvus_proxy_route(
                     endpoint="vectors/search",
                     request=mock_request,
@@ -2779,7 +2779,7 @@ class TestMilvusProxyRoute:
                 mock_vector_store
             )
 
-            with pytest.raises(Exception) as exc_info:
+            with pytest.raises(Exception, match='api_base not found in vector store configuration for') as exc_info:
                 await milvus_proxy_route(
                     endpoint="vectors/search",
                     request=mock_request,
@@ -2988,7 +2988,7 @@ class TestOpenAIPassthroughRoute:
             "litellm.proxy.pass_through_endpoints.llm_passthrough_endpoints.passthrough_endpoint_router.get_credentials",
             return_value=None,
         ):
-            with pytest.raises(Exception) as exc_info:
+            with pytest.raises(Exception, match="Required 'OPENAI_API_KEY' in environment to make") as exc_info:
                 await openai_proxy_route(
                     endpoint="v1/chat/completions",
                     request=mock_request,
@@ -3177,7 +3177,7 @@ class TestCursorProxyRoute:
                 [],
             ),
         ):
-            with pytest.raises(Exception) as exc_info:
+            with pytest.raises(Exception, match='Cursor API key not found\\. Add Cursor credentials via') as exc_info:
                 await cursor_proxy_route(
                     endpoint="v0/agents",
                     request=mock_request,

--- a/tests/test_litellm/proxy/policy_engine/test_policy_versioning.py
+++ b/tests/test_litellm/proxy/policy_engine/test_policy_versioning.py
@@ -157,7 +157,7 @@ class TestUpdatePolicyDraftOnly:
         prod_row = _make_row(policy_id="pid-1", version_status="production")
         prisma.db.litellm_policytable.find_unique = AsyncMock(return_value=prod_row)
 
-        with pytest.raises(Exception) as exc_info:
+        with pytest.raises(Exception, match='Error updating policy in DB: Only draft versions can be') as exc_info:
             await registry.update_policy_in_db(
                 policy_id="pid-1",
                 policy_request=PolicyUpdateRequest(description="new"),
@@ -341,7 +341,7 @@ class TestUpdateVersionStatus:
         draft = _make_row(policy_id="d-1", version_status="draft")
         prisma.db.litellm_policytable.find_unique = AsyncMock(return_value=draft)
 
-        with pytest.raises(Exception) as exc_info:
+        with pytest.raises(Exception, match='Error updating version status: Cannot promote draft') as exc_info:
             await registry.update_version_status(
                 policy_id="d-1",
                 new_status="production",

--- a/tests/test_litellm/proxy/proxy_server/test_proxy_config.py
+++ b/tests/test_litellm/proxy/proxy_server/test_proxy_config.py
@@ -1504,7 +1504,7 @@ async def test_ProxyConfig__init_non_llm_configs_premium_invalid_worker_registry
 async def test_ProxyConfig__init_non_llm_configs_worker_registry_requires_premium(monkeypatch):
     monkeypatch.setattr("litellm.proxy.proxy_server.premium_user", False)
     pc = ProxyConfig()
-    with pytest.raises(ValueError) as exc_info:
+    with pytest.raises(ValueError, match='Trying to use `worker_registry`You must be a LiteLLM') as exc_info:
         await pc._init_non_llm_configs(
             config={
                 "worker_registry": [
@@ -1769,7 +1769,7 @@ def test_ProxyConfig_initialize_secret_manager_none_noop():
 
 def test_ProxyConfig_initialize_secret_manager_invalid_kms_raises():
     pc = ProxyConfig()
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match='Invalid Key Management System selected'):
         pc.initialize_secret_manager(key_management_system="not-a-real-kms")
 
 

--- a/tests/test_litellm/proxy/spend_tracking/test_spend_management_endpoints.py
+++ b/tests/test_litellm/proxy/spend_tracking/test_spend_management_endpoints.py
@@ -3263,7 +3263,7 @@ async def test_provider_budget_over(disable_budget_sync):
         model_list=MODEL_LIST,
     )
 
-    with pytest.raises(Exception) as e:
+    with pytest.raises(Exception, match='No deployments available - crossed budget: Exceeded budget') as e:
         await router.acompletion(
             model="azure-gpt-4o",
             messages=[{"role": "user", "content": "Hello, world!"}],
@@ -5096,7 +5096,7 @@ def test_resolve_spend_report_scope_missing_caller_value_400():
 
 @pytest.mark.parametrize("bad_column", ["metadata", "end_user", "evil; DROP TABLE", ""])
 def test_scoped_spend_report_sql_rejects_unknown_column(bad_column):
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match='Unsupported spend report scope column'):
         spend_management_endpoints._scoped_spend_report_sql(scope_column=bad_column)
 
 

--- a/tests/test_litellm/proxy/test_common_request_processing.py
+++ b/tests/test_litellm/proxy/test_common_request_processing.py
@@ -435,7 +435,7 @@ class TestProxyBaseLLMRequestProcessing:
 
         # Test with invalid header value (should raise ValueError when converting to float)
         headers_with_invalid = {"x-litellm-stream-timeout": "invalid"}
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="could not convert string to float: 'invalid"):
             LiteLLMProxyRequestSetup._get_stream_timeout_from_request(headers_with_invalid)
 
     @pytest.mark.asyncio

--- a/tests/test_litellm/proxy/test_enforce_user_param.py
+++ b/tests/test_litellm/proxy/test_enforce_user_param.py
@@ -56,7 +56,7 @@ class TestEnforceUserParamPostGetFiltering:
             new_callable=AsyncMock,
             return_value=True,
         ):
-            with pytest.raises(Exception) as exc_info:
+            with pytest.raises(Exception, match="user' param not passed in\\. 'enforce_user_param'=True") as exc_info:
                 await common_checks(
                     request_body=request_body,
                     team_object=None,
@@ -175,7 +175,7 @@ class TestEnforceUserParamPostGetFiltering:
             new_callable=AsyncMock,
             return_value=True,
         ):
-            with pytest.raises(Exception) as exc_info:
+            with pytest.raises(Exception, match="user' param not passed in\\. 'enforce_user_param'=True") as exc_info:
                 await common_checks(
                     request_body=request_body,
                     team_object=None,
@@ -405,7 +405,7 @@ class TestEnforceUserParamEdgeCases:
             new_callable=AsyncMock,
             return_value=True,
         ):
-            with pytest.raises(Exception) as exc_info:
+            with pytest.raises(Exception, match="user' param not passed in\\. 'enforce_user_param'=True") as exc_info:
                 await common_checks(
                     request_body=request_body,
                     team_object=None,

--- a/tests/test_litellm/proxy/test_litellm_pre_call_utils.py
+++ b/tests/test_litellm/proxy/test_litellm_pre_call_utils.py
@@ -2279,12 +2279,12 @@ def test_get_num_retries_from_request():
 
     # Test case 7: Header present with invalid value (should raise ValueError when int() is called)
     headers_with_invalid = {"x-litellm-num-retries": "invalid"}
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match='invalid literal for int\\(\\) with base'):
         LiteLLMProxyRequestSetup._get_num_retries_from_request(headers_with_invalid)
 
     # Test case 8: Header present with float string (should raise ValueError when int() is called)
     headers_with_float = {"x-litellm-num-retries": "3.5"}
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match='invalid literal for int\\(\\) with base'):
         LiteLLMProxyRequestSetup._get_num_retries_from_request(headers_with_float)
 
     # Test case 9: Header present with negative number
@@ -2324,7 +2324,7 @@ def test_get_keepalive_seconds_from_request():
 
     # Header present with invalid value raises ValueError, matching the other
     # x-litellm-* numeric header helpers (_get_timeout_from_request, etc.)
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="could not convert string to float: 'not-a-number"):
         LiteLLMProxyRequestSetup._get_keepalive_seconds_from_request(
             {"x-litellm-keepalive-seconds": "not-a-number"}
         )

--- a/tests/test_litellm/proxy/test_proxy_server.py
+++ b/tests/test_litellm/proxy/test_proxy_server.py
@@ -1507,7 +1507,7 @@ def test_team_info_masking():
         "langfuse_public_key": "public-test-key",
     }
 
-    with pytest.raises(Exception) as exc_info:
+    with pytest.raises(Exception, match="secr\\*\\*\\*\\*\\*\\*\\*-key', 'langfuse_public_key':") as exc_info:
         proxy_config._get_team_config(
             team_id="test_dev",
             all_teams_config=[team1_info],

--- a/tests/test_litellm/proxy/test_spend_log_cleanup.py
+++ b/tests/test_litellm/proxy/test_spend_log_cleanup.py
@@ -82,10 +82,10 @@ def test_spend_log_cleanup_cron_scheduling():
     assert trigger_weekly is not None
 
     # Invalid cron expression should raise ValueError
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match='Wrong number of fields; got'):
         CronTrigger.from_crontab("invalid cron")
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match='is higher than the maximum value'):
         CronTrigger.from_crontab("60 25 * * *")  # Invalid minute and hour
 
 

--- a/tests/test_litellm/proxy/test_team_org_move.py
+++ b/tests/test_litellm/proxy/test_team_org_move.py
@@ -97,7 +97,7 @@ class TestValidateTeamOrgChange:
         team = _make_team(member_ids=["sso-user-001"])
         org = _make_org(members=[])
 
-        with pytest.raises(Exception) as exc_info:
+        with pytest.raises(Exception, match='Cannot move team to organization\\. Team has user_id') as exc_info:
             validate_team_org_change(
                 team=team, organization=org, llm_router=router, is_proxy_admin=False
             )

--- a/tests/test_litellm/proxy/utils/helpers/test_team_configs.py
+++ b/tests/test_litellm/proxy/utils/helpers/test_team_configs.py
@@ -66,7 +66,7 @@ def test_is_valid_team_configs_short_circuits_when_team_id_none():
 def test_is_valid_team_configs_raises_on_model_not_in_team_models():
     team_config = {"models": ["gpt-4o"]}
     request_data = {"model": "claude-haiku"}
-    with pytest.raises(Exception) as exc_info:
+    with pytest.raises(Exception, match='claude-haiku\\.  Valid models for team are') as exc_info:
         _is_valid_team_configs(
             team_id="team-1",
             team_config=team_config,

--- a/tests/test_litellm/proxy/utils/prisma_and_spend/test_proxy_update_spend.py
+++ b/tests/test_litellm/proxy/utils/prisma_and_spend/test_proxy_update_spend.py
@@ -561,7 +561,7 @@ async def test_update_spend_logs_does_not_requeue_non_transport_failures(
     proxy_logging.failure_handler = AsyncMock()
     mock_prisma_client.spend_log_transactions = []
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="bad payload"):
         await ProxyUpdateSpend.update_spend_logs(
             n_retry_times=1,
             prisma_client=mock_prisma_client,

--- a/tests/test_litellm/proxy/utils/proxy_logging/test_callback_capabilities_class.py
+++ b/tests/test_litellm/proxy/utils/proxy_logging/test_callback_capabilities_class.py
@@ -181,7 +181,7 @@ def test_has_streaming_callbacks_error_when_resolution_fails(monkeypatch):
         "get_custom_logger_compatible_class",
         lambda *a, **kw: (_ for _ in ()).throw(ValueError("nope")),
     )
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="nope"):
         ProxyLogging.has_streaming_callbacks()
 
 

--- a/tests/test_litellm/responses/test_responses_websocket_all_providers.py
+++ b/tests/test_litellm/responses/test_responses_websocket_all_providers.py
@@ -84,7 +84,7 @@ class TestResponsesAPIWebSocketSupport:
 
     def test_azure_websocket_url_requires_api_base(self):
         config = AzureOpenAIResponsesAPIConfig()
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match='api_base is required for Azure WebSocket'):
             config.get_websocket_url(api_base=None, litellm_params={})
 
     def test_azure_model_not_in_websocket_url(self):

--- a/tests/test_litellm/router_strategy/adaptive_router/test_bandit.py
+++ b/tests/test_litellm/router_strategy/adaptive_router/test_bandit.py
@@ -100,7 +100,7 @@ def test_score_combines_quality_and_cost():
 
 
 def test_pick_best_empty_dict_raises():
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match='pick_best called with no models'):
         pick_best({}, {})
 
 

--- a/tests/test_litellm/router_strategy/test_router_tag_routing.py
+++ b/tests/test_litellm/router_strategy/test_router_tag_routing.py
@@ -656,7 +656,7 @@ async def test_negation_all_excluded_raises():
         enable_tag_filtering=True,
     )
 
-    with pytest.raises(Exception) as exc_info:
+    with pytest.raises(Exception, match='Not allowed to access model due to tags configuration\\.') as exc_info:
         await router.acompletion(
             model="gpt-4",
             messages=[{"role": "user", "content": "hi"}],
@@ -699,7 +699,7 @@ async def test_negation_ban_only_cannot_escape_default_pool():
     # Sending only "!default" must NOT route to the paid deployment.
     # The base pool for ban-only is the default pool; banning the only
     # default deployment should raise rather than falling through to paid.
-    with pytest.raises(Exception) as exc_info:
+    with pytest.raises(Exception, match='Not allowed to access model due to tags configuration\\.') as exc_info:
         await router.acompletion(
             model="gpt-4",
             messages=[{"role": "user", "content": "hi"}],
@@ -969,7 +969,7 @@ async def test_negation_exhausts_entire_fallback_chain():
         enable_tag_filtering=True,
     )
 
-    with pytest.raises(Exception) as exc_info:
+    with pytest.raises(Exception, match='Not allowed to access model due to tags configuration\\.') as exc_info:
         await router.acompletion(
             model="primary",
             messages=[{"role": "user", "content": "hi"}],
@@ -1719,7 +1719,7 @@ async def test_required_and_unmatched_raises_by_default():
         enable_tag_filtering=True,
     )
 
-    with pytest.raises(Exception) as exc_info:
+    with pytest.raises(Exception, match='Not allowed to access model due to tags configuration\\.') as exc_info:
         await router.acompletion(
             model="gpt-4",
             messages=[{"role": "user", "content": "hi"}],
@@ -1751,7 +1751,7 @@ async def test_required_and_combined_with_positive_unmatched_raises_by_default()
         enable_tag_filtering=True,
     )
 
-    with pytest.raises(Exception) as exc_info:
+    with pytest.raises(Exception, match='Not allowed to access model due to tags configuration\\.') as exc_info:
         await router.acompletion(
             model="gpt-4",
             messages=[{"role": "user", "content": "hi"}],
@@ -1973,7 +1973,7 @@ async def test_negation_combined_with_positive_unmatched_raises_by_default():
         enable_tag_filtering=True,
     )
 
-    with pytest.raises(Exception) as exc_info:
+    with pytest.raises(Exception, match='Not allowed to access model due to tags configuration\\.') as exc_info:
         await router.acompletion(
             model="gpt-4",
             messages=[{"role": "user", "content": "hi"}],
@@ -2131,7 +2131,7 @@ async def test_mixed_constraint_survivor_unmatched_by_positive_tag_raises_by_def
         enable_tag_filtering=True,
     )
 
-    with pytest.raises(Exception) as exc_info:
+    with pytest.raises(Exception, match='Not allowed to access model due to tags configuration\\.') as exc_info:
         await router.acompletion(
             model="gpt-4",
             messages=[{"role": "user", "content": "hi"}],
@@ -2224,7 +2224,7 @@ async def test_allow_fail_open_denied_when_request_includes_unknown_tag():
         enable_tag_filtering=True,
     )
 
-    with pytest.raises(Exception) as exc_info:
+    with pytest.raises(Exception, match='Not allowed to access model due to tags configuration\\.') as exc_info:
         await router.acompletion(
             model="gpt-4",
             messages=[{"role": "user", "content": "hi"}],
@@ -2538,7 +2538,7 @@ async def test_plain_tag_exhaustion_with_universal_default_tag_raises_by_default
         "litellm.router._async_get_cooldown_deployments",
         new=AsyncMock(return_value=["quality-high-1", "quality-high-2"]),
     ):
-        with pytest.raises(Exception) as exc_info:
+        with pytest.raises(Exception, match='Not allowed to access model due to tags configuration\\.') as exc_info:
             await router.acompletion(
                 model="gpt-4",
                 messages=[{"role": "user", "content": "hi"}],
@@ -2767,7 +2767,7 @@ async def test_allow_fail_open_raises_when_inherited_constraint_alone_is_unsatis
     # allow_fail_open unset.
     router = _eu_region_router()
 
-    with pytest.raises(Exception) as exc_info:
+    with pytest.raises(Exception, match='Not allowed to access model due to tags configuration\\.') as exc_info:
         await router.acompletion(
             model="chat",
             messages=[{"role": "user", "content": "hi"}],
@@ -2941,7 +2941,7 @@ async def test_tagged_request_direct_to_plain_group_still_rejected():
     # tag filtering must reject exactly as before.
     router = _tagged_marker_router()
 
-    with pytest.raises(Exception) as exc_info:
+    with pytest.raises(Exception, match='Not allowed to access model due to tags configuration\\.') as exc_info:
         await router.acompletion(
             model="gemini-flash",
             messages=[{"role": "user", "content": "hi"}],
@@ -2962,7 +2962,7 @@ async def test_caller_forged_consumption_stamp_is_neutralized_by_the_hook():
     # tag filtering runs.
     router = _tagged_marker_router()
 
-    with pytest.raises(Exception) as exc_info:
+    with pytest.raises(Exception, match='Not allowed to access model due to tags configuration\\.') as exc_info:
         await router.acompletion(
             model="gemini-flash",
             messages=[{"role": "user", "content": "hi"}],
@@ -2984,7 +2984,7 @@ async def test_inherited_constraint_still_applies_to_the_routed_tier():
     # &region:eu comes from key/team policy (present in inherited_tags):
     # consuming the router-selecting "route" tag must not also discard the
     # inherited requirement, so a tier without the tag still raises...
-    with pytest.raises(Exception) as exc_info:
+    with pytest.raises(Exception, match='Not allowed to access model due to tags configuration\\.') as exc_info:
         await _tagged_marker_router().acompletion(
             model="gpt4o",
             messages=[{"role": "user", "content": "hi"}],

--- a/tests/test_litellm/sandbox/test_e2b_sandbox.py
+++ b/tests/test_litellm/sandbox/test_e2b_sandbox.py
@@ -293,7 +293,7 @@ async def test_public_lifecycle_create_run_delete():
 
 @pytest.mark.asyncio
 async def test_unsupported_provider_raises():
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="not-a-provider' is not a valid SandboxProviders"):
         await litellm.acreate_sandbox(provider="not-a-provider")
 
 

--- a/tests/test_litellm/secret_managers/test_base_secret_manager.py
+++ b/tests/test_litellm/secret_managers/test_base_secret_manager.py
@@ -32,7 +32,7 @@ from litellm.secret_managers.base_secret_manager import raise_if_unsafe_secret_n
     ],
 )
 def test_raise_if_unsafe_secret_name_rejects_traversal_and_line_breaks(secret_name):
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match='Invalid secret_name'):
         raise_if_unsafe_secret_name(secret_name)
 
 

--- a/tests/test_litellm/test_github_close_low_quality_prs.py
+++ b/tests/test_litellm/test_github_close_low_quality_prs.py
@@ -697,7 +697,7 @@ class TestListOpenItemsNoCap:
 
     def test_list_open_items_rejects_unknown_kind(self, closer_module):
         shared = self._shared(closer_module)
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="kind must be 'pr' or 'issue', got 'both"):
             shared.list_open_items("both", repo="o/r", fields="number")
 
     def test_fetch_open_prs_delegates_with_no_cap(self, closer_module, monkeypatch):

--- a/tests/test_litellm/test_github_triage_with_llm.py
+++ b/tests/test_litellm/test_github_triage_with_llm.py
@@ -665,11 +665,11 @@ class TestParseVerdict:
         assert triage_module.parse_verdict(raw)["verdict"] == "pass"
 
     def test_should_raise_for_unparseable_text(self, triage_module):
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match='could not extract JSON from LLM response: not even close to'):
             triage_module.parse_verdict("not even close to json")
 
     def test_should_raise_for_empty(self, triage_module):
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match='empty LLM response'):
             triage_module.parse_verdict("")
 
 

--- a/tests/test_litellm/test_redact_string_in_error_paths.py
+++ b/tests/test_litellm/test_redact_string_in_error_paths.py
@@ -234,7 +234,7 @@ class TestRouterFallbackFailureTracebackRedaction:
                 raise ValueError(f"primary deployment failed api_key={secret}")
             except ValueError as original_exception:
                 with caplog.at_level(logging.DEBUG, logger="LiteLLM Router"):
-                    with pytest.raises(ValueError):
+                    with pytest.raises(ValueError, match='primary deployment failed api_key=sk-testsecretvalu'):
                         await router.async_function_with_fallbacks_common_utils(
                             e=original_exception,
                             disable_fallbacks=False,

--- a/tests/test_litellm/test_redis.py
+++ b/tests/test_litellm/test_redis.py
@@ -131,7 +131,7 @@ def test_get_redis_url_from_environment_missing_host_port(monkeypatch):
     monkeypatch.delenv("REDIS_PORT", raising=False)
 
     # Call the function and expect a ValueError
-    with pytest.raises(ValueError) as excinfo:
+    with pytest.raises(ValueError, match="Either 'REDIS_URL' or both 'REDIS_HOST' and 'REDIS_PORT") as excinfo:
         get_redis_url_from_environment()
 
     # Check the error message
@@ -149,7 +149,7 @@ def test_get_redis_url_from_environment_missing_port(monkeypatch):
     monkeypatch.setenv("REDIS_HOST", "redis-server")
 
     # Call the function and expect a ValueError
-    with pytest.raises(ValueError) as excinfo:
+    with pytest.raises(ValueError, match="Either 'REDIS_URL' or both 'REDIS_HOST' and 'REDIS_PORT") as excinfo:
         get_redis_url_from_environment()
 
     # Check the error message

--- a/tests/test_litellm/test_router.py
+++ b/tests/test_litellm/test_router.py
@@ -953,7 +953,7 @@ async def test_arouter_filter_team_based_models():
     assert result is not None
 
     # FAILS
-    with pytest.raises(Exception) as e:
+    with pytest.raises(Exception, match='No deployments available for selected model, Try again in') as e:
         result = await router.acompletion(
             model="gpt-3.5-turbo",
             messages=[{"role": "user", "content": "Hello, world!"}],
@@ -1225,7 +1225,7 @@ def test_add_invalid_provider_to_router():
         ],
     )
 
-    with pytest.raises(Exception) as e:
+    with pytest.raises(Exception, match='Unsupported provider - vertex_ai_eu') as e:
         router.add_deployment(
             Deployment(
                 model_name="vertex_ai/*",
@@ -1320,7 +1320,7 @@ async def test_router_ageneric_api_call_with_fallbacks_helper():
     with patch.object(router, "async_get_available_deployment") as mock_get_deployment:
         mock_get_deployment.side_effect = Exception("No deployment available")
 
-        with pytest.raises(Exception) as exc_info:
+        with pytest.raises(Exception, match='No deployment available') as exc_info:
             await router._ageneric_api_call_with_fallbacks_helper(
                 model="gpt-3.5-turbo",
                 original_generic_function=mock_generic_function,
@@ -1394,7 +1394,7 @@ async def test_router_ageneric_api_call_with_fallbacks_helper():
                 with patch.object(
                     router, "async_routing_strategy_pre_call_checks"
                 ) as mock_pre_call_checks:
-                    with pytest.raises(Exception) as exc_info:
+                    with pytest.raises(Exception, match='Mock failure') as exc_info:
                         await router._ageneric_api_call_with_fallbacks_helper(
                             model="gpt-3.5-turbo",
                             original_generic_function=mock_failing_function,
@@ -3737,7 +3737,7 @@ def test_count_pre_call_check_tokens_across_api_surfaces():
     assert string_input_tokens > 0
     assert list_input_tokens > 0
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match='Either messages or input must be provided to count tokens'):
         router._count_pre_call_check_tokens(messages=None, input=None)
 
 

--- a/tests/test_litellm/test_router_model_cost_isolation.py
+++ b/tests/test_litellm/test_router_model_cost_isolation.py
@@ -1706,7 +1706,7 @@ def test_an_incomplete_reservation_is_refused_rather_than_served(dropped):
     state the operator was trying to leave."""
     incomplete = {k: v for k, v in _PTU_MODEL_INFO.items() if k != dropped}
 
-    with pytest.raises(ValueError) as raised:
+    with pytest.raises(ValueError, match="PTU configuration on model 'gpt") as raised:
         _ptu_router(model_info=incomplete, litellm_params={"input_cost_per_token": 5e-06})
 
     assert "gpt-4o-ptu" in str(raised.value)
@@ -1726,7 +1726,7 @@ def test_the_refusal_reason_is_the_one_the_model_endpoint_answers_with(dropped, 
     incomplete = {k: v for k, v in _PTU_MODEL_INFO.items() if k != dropped}
 
     assert ptu_config_error(incomplete) == expected
-    with pytest.raises(ValueError) as raised:
+    with pytest.raises(ValueError, match="PTU configuration on model 'gpt") as raised:
         _ptu_router(model_info=incomplete)
 
     assert expected in str(raised.value)

--- a/tests/test_litellm/test_utils.py
+++ b/tests/test_litellm/test_utils.py
@@ -4370,7 +4370,7 @@ class TestVertexEmbeddingEncodingFormat:
         assert "encoding_format" not in optional_params
 
     def test_encoding_format_base64_still_rejected_without_drop_params(self):
-        with pytest.raises(Exception) as excinfo:
+        with pytest.raises(Exception, match='To drop these, set `litellm\\.drop_params=True` or for proxy') as excinfo:
             litellm.utils.get_optional_params_embeddings(
                 model="gemini-embedding-001",
                 encoding_format="base64",

--- a/tests/test_litellm/types/test_router.py
+++ b/tests/test_litellm/types/test_router.py
@@ -87,5 +87,5 @@ def test_pricing_strings_are_coerced_to_float():
 
 
 def test_invalid_pricing_is_rejected():
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match='validation error for ModelInfo'):
         ModelInfo(id="x", input_cost_per_token="free")


### PR DESCRIPTION
## TLDR

Problem this solves:

- `pytest.raises(Exception)` with no `match=` passes on any error
- An unrelated crash reads as the rejection under test
- 317 such sites, plus 4 parametrize cases listed twice

How it solves it:

- Selects ruff `PT011` and `PT014` in `ruff-tests.toml`, already wired to CI
- Pins each site to the message the code actually raised
- Patterns come from running the sites and recording the real error
- Narrows 6 sites to a concrete type instead

## User Flow

Before: a proxy admin gives a key two models, and the 403 that names those models can quietly stop naming them

1. They POST https://litellm-domain/key/generate with `"models": ["gpt-5.5"]` and get back a key
2. Someone using that key sends POST https://litellm-domain/v1/chat/completions for `claude-sonnet-4-5`
3. The gateway answers 403 saying the key is not allowed to access that model, and lists the models the key can access, so they know what to ask for
4. A later change reworks that path and the same request now answers 403 with only `Access denied for model claude-sonnet-4-5`
5. CI stays green: the test guarding that 403 accepts any error at all, so the caller loses the list and no one finds out until a customer asks why the error stopped telling them anything

After: that change turns CI red before it ships

1. The same rework is made
2. CI runs the same test file and it fails, printing the wording it expected and the message it got
3. The same holds when a refactor makes a helper crash before it ever reaches its own validation: the crash no longer passes for the rejection it replaced
4. A new test that catches a bare `Exception` without pinning the message is rejected at lint time, so the next one cannot go quiet either

## Relevant issues

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

This PR changes lint config and tests, so there is no proxy route to curl. The proof is three mutations: break a behavior a test exists to police, and show the old test does not notice while the new one does. Every command is identical on both sides; only the `tests/` tree differs.

The three mutations, applied one at a time and reverted after each run:

```
filename_message_reworded            litellm/proxy/common_utils/path_utils.py
                                    a rejected upload filename stops saying it was empty
                                    or unsafe and just says "Invalid filename"

prefix_helper_crashes_first         litellm/proxy/_experimental/mcp_server/utils.py
                                    a refactor makes the short-prefix helper crash before
                                    it reaches its own empty-server_id check

model_denial_stops_naming_the_key   litellm/proxy/auth/auth_checks.py
                                    the 403 for a model a key cannot use stops listing the
                                    models it can use
```

### Before (354f497faf)

#### The rejected filename stops saying why

1. Apply `filename_message_reworded`, then run

```
pytest tests/test_litellm/proxy/common_utils/test_path_utils.py::TestSafeFilename::test_empty_rejected -q
```

2. Output:

```
1 passed, 2 warnings in 1.54s
```

#### A helper crashes before reaching its own check

1. Apply `prefix_helper_crashes_first`, then run

```
pytest tests/test_litellm/proxy/_experimental/mcp_server/test_short_mcp_tool_prefix.py::TestShortPrefixHelpers::test_short_prefix_requires_server_id -q
```

2. Output:

```
1 passed, 2 warnings in 1.94s
```

#### The 403 stops listing the models the key can use

1. Apply `model_denial_stops_naming_the_key`, then run

```
pytest tests/proxy_unit_tests/test_auth_checks.py::test_can_key_call_model -q
```

2. Output:

```
2 passed, 1 warning in 0.07s
```

### After (b76def0e5d)

#### The rejected filename stops saying why

1. Apply `filename_message_reworded`, then run

```
pytest tests/test_litellm/proxy/common_utils/test_path_utils.py::TestSafeFilename::test_empty_rejected -q
```

2. Output:

```
1 failed, 2 warnings in 1.75s
```

#### A helper crashes before reaching its own check

1. Apply `prefix_helper_crashes_first`, then run

```
pytest tests/test_litellm/proxy/_experimental/mcp_server/test_short_mcp_tool_prefix.py::TestShortPrefixHelpers::test_short_prefix_requires_server_id -q
```

2. Output:

```
1 failed, 2 warnings in 1.76s
```

#### The 403 stops listing the models the key can use

1. Apply `model_denial_stops_naming_the_key`, then run

```
pytest tests/proxy_unit_tests/test_auth_checks.py::test_can_key_call_model -q
```

2. Output:

```
1 failed, 1 passed, 1 warning in 0.15s
```

### Rule and regression numbers

`ruff check --config ruff-tests.toml tests` went from 317 `PT011` and 4 `PT014` findings to zero. Ruff has no autofix for either, so 291 sites took a pattern recorded by running them under a plugin that logged the concrete exception and message per call site, and the remaining 26 were resolved by hand: 18 took the message the test itself plants, 6 narrowed to a real type, and 2 kept a `noqa` because their exception carries an empty `str()`.

The 144 touched test files were run in full at both hashes. 196 tests fail identically on each side, all of them live-provider tests with no Fireworks, Azure, Gemini or Bedrock credentials on this machine. Nothing is new and nothing disappeared.

## Type

🧹 Refactoring
🚄 Infrastructure
✅ Test

## Caveats (if any)

- 6 sites narrowed to a real type instead of a `match=`
- 2 sites keep a `noqa`: their exception carries an empty `str()`

### Final Attestation

- [ ] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
