### PR TITLE
fix(redis): guard cluster-mode disconnect against a None connection pool

### DIFF
--- a/litellm/caching/redis_cache.py
+++ b/litellm/caching/redis_cache.py
@@ -1367,7 +1367,8 @@ class RedisCache(BaseCache):
         self.redis_client.flushall()
 
     async def disconnect(self):
-        await self.async_redis_conn_pool.disconnect(inuse_connections=True)
+        if self.async_redis_conn_pool is not None:
+            await self.async_redis_conn_pool.disconnect(inuse_connections=True)
         try:
             self.redis_client.close()
         except Exception as e:

--- a/litellm/caching/redis_cluster_cache.py
+++ b/litellm/caching/redis_cluster_cache.py
@@ -56,6 +56,11 @@ class RedisClusterCache(RedisCache):
         async_redis_cluster_client: Final = self.init_async_client()
         return await async_redis_cluster_client.mget_nonatomic(keys=keys)
 
+    async def disconnect(self):
+        if self.redis_async_redis_cluster_client is not None:
+            await self.redis_async_redis_cluster_client.aclose()
+        await super().disconnect()
+
     async def test_connection(self) -> dict:
         """
         Test the Redis Cluster connection.

--- a/tests/test_litellm/caching/test_redis_cluster_cache.py
+++ b/tests/test_litellm/caching/test_redis_cluster_cache.py
@@ -1,7 +1,7 @@
 import json
 import os
 import sys
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from fastapi.testclient import TestClient
@@ -65,6 +65,40 @@ async def test_redis_cluster_async_batch_get(mock_init_redis_cluster):
     # Verify mget_nonatomic was called instead of mget
     mock_redis.mget_nonatomic.assert_called_once()
     assert not mock_redis.mget.called
+
+
+@pytest.mark.asyncio
+@patch("litellm._redis.get_redis_connection_pool")
+@patch("litellm._redis.get_redis_client")
+@patch("litellm.caching.redis_cache.RedisCache._setup_health_pings")
+async def test_redis_cluster_disconnect_does_not_raise(
+    mock_health, mock_get_client, mock_get_pool
+):
+    """
+    Regression test for https://github.com/BerriAI/litellm/issues/37137
+
+    Proxy shutdown crashed with `AttributeError: 'NoneType' object has no
+    attribute 'disconnect'` whenever Redis cluster mode was enabled, because
+    `get_redis_connection_pool` returns None for cluster configs
+    (`startup_nodes`) but `RedisCache.disconnect` unconditionally called
+    `.disconnect()` on it.
+    """
+    mock_get_client.return_value = MagicMock()
+    mock_get_pool.return_value = None
+
+    cache = RedisClusterCache(
+        startup_nodes=[{"host": "localhost", "port": 6379}],
+        password="hello",
+    )
+    assert cache.async_redis_conn_pool is None
+
+    mock_cluster_client = MagicMock()
+    mock_cluster_client.aclose = AsyncMock()
+    cache.redis_async_redis_cluster_client = mock_cluster_client
+
+    await cache.disconnect()
+
+    mock_cluster_client.aclose.assert_awaited_once()
 
 
 @patch("litellm._redis.get_redis_connection_pool")


### PR DESCRIPTION
## TLDR

Problem this solves:

- Proxy shutdown always crashes with AttributeError when Redis cluster mode is enabled
- get_redis_connection_pool returns None for cluster configs, but disconnect() always called .disconnect() on it

How it solves it:

- Guards RedisCache.disconnect against a None async_redis_conn_pool
- Gives RedisClusterCache its own disconnect that closes the async cluster client it keeps on redis_async_redis_cluster_client, then delegates to the base class

## User Flow

Before: an operator running LiteLLM with Redis cluster mode sees the proxy fail to shut down cleanly

1. The operator starts the proxy with Redis cluster config (startup_nodes) and later stops it (e.g. `SIGTERM`, or a container/orchestrator restart)
2. The proxy logs `AttributeError: 'NoneType' object has no attribute 'disconnect'` during shutdown
3. Uvicorn logs `Application shutdown failed. Exiting.`

After: the same shutdown completes cleanly

1. The operator starts the proxy with the same Redis cluster config and stops it the same way
2. The proxy disconnects from Redis and shuts down with no AttributeError in the logs

## Relevant issues

Fixes #37137

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/caching/test_redis_cluster_cache.py -v`
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

I don't have a real Redis cluster (or docker/redis-server) available in this environment to run a live proxy against, so I can't capture the actual shutdown log the way this template asks for. The added regression test constructs a real `RedisClusterCache` (cluster mode, no real network needed since redis-py doesn't connect at construction time) and calls `disconnect()`, which raises `AttributeError` before this fix and passes after:

```
uv run pytest tests/test_litellm/caching/test_redis_cluster_cache.py -k test_redis_cluster_disconnect_does_not_raise -v
```

If you can spin up a real Redis Cluster, the live before/after would be: start the proxy with `REDIS_CLUSTER_NODES` set, send `SIGTERM`, and check the logs for the `AttributeError` (before) vs. a clean shutdown (after).

## Type

🐛 Bug Fix

## Caveats (if any)

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
