### PR TITLE
test(redis): cover host/port Azure Entra config alongside credential_provider

### DIFF
--- a/tests/test_litellm/test_redis.py
+++ b/tests/test_litellm/test_redis.py
@@ -986,6 +986,33 @@ def test_async_url_client_drops_username_alongside_credential_provider():
     pool.connection_class(**pool.connection_kwargs)
 
 
+def test_async_host_client_drops_username_alongside_credential_provider():
+    """
+    Regression test for https://github.com/BerriAI/litellm/issues/37335
+
+    A host/port (non-URL) Azure Entra config -- e.g. REDIS_AZURE_AD_TOKEN=true with
+    REDIS_USERNAME set and no REDIS_PASSWORD -- must not reach redis-py with both
+    `username` and `credential_provider` set, since redis-py rejects that combination
+    outright. AzureADCredentialProvider already carries REDIS_USERNAME, so the plain
+    `username` kwarg must be dropped on this path too, not just the REDIS_URL one.
+    """
+    redis_kwargs = {
+        "host": "redis-host",
+        "port": 6380,
+        "ssl": True,
+        "username": "redis-user",
+        "redis_connect_func": SimpleNamespace(**AZURE_AD_CONNECT_FUNC),
+    }
+
+    with patch("litellm._redis._get_redis_client_logic", return_value=redis_kwargs):
+        client = get_redis_async_client()
+
+    pool = client.connection_pool
+    assert pool.connection_kwargs.get("username") is None
+    assert isinstance(pool.connection_kwargs.get("credential_provider"), AzureADCredentialProvider)
+    pool.connection_class(**pool.connection_kwargs)
+
+
 @pytest.mark.parametrize("build_pool", [False, True], ids=["client", "pool"])
 def test_async_url_keeps_a_coroutine_connect_func(build_pool):
     """redis-py awaits a coroutine redis_connect_func on an async connection, so one we cannot


### PR DESCRIPTION
## TLDR

Problem this solves:

- The existing username/credential_provider conflict test only covers the REDIS_URL branch of get_redis_async_client
- The reported host/port Azure Entra config (REDIS_AZURE_AD_TOKEN + REDIS_USERNAME, no REDIS_URL) had no direct regression test

How it solves it:

- Adds a test exercising the host/port branch with an Azure AD credential_provider and a plain username set
- Asserts the username is dropped and instantiates the real redis-py Connection class, which is where redis-py's own conflict check actually fires

## Relevant issues

Fixes #37335

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/test_redis.py -v`
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

Investigating this issue, I found `_async_auth_kwargs` in `litellm/_redis.py` already strips `username`/`password` whenever an Azure AD or GCP IAM `credential_provider` is present, and this already applies uniformly to the host/port branch, not just the REDIS_URL one -- so the reported crash does not reproduce against the current code on this branch. There was, however, no test covering that host/port path directly (only the REDIS_URL path was covered).

I don't have a live Azure Managed Redis instance with Entra ID / service principal auth in this environment to curl against. Instead, I confirmed the fix at the unit level: I verified that redis-py's `'username' and 'password' cannot be passed along with 'credential_provider'` check only fires once a `Connection` object is actually instantiated (not at `Redis()` construction), confirmed the new test passes against current code, and confirmed it fails (raising that exact redis-py error) if the username-stripping step in `_async_auth_kwargs` is reverted:

```
uv run pytest tests/test_litellm/test_redis.py -k test_async_host_client_drops_username_alongside_credential_provider -v
```

If you have a live Azure Managed Redis instance with Entra ID auth, the real before/after would be: configure `REDIS_AZURE_AD_TOKEN=true`, `REDIS_USERNAME=<service-principal-object-id>`, `REDIS_SSL=true`, no `REDIS_PASSWORD`, start the proxy, and hit `GET /cache/ping`.

## Type

✅ Test

## Caveats (if any)

- No source change: this closes a test-coverage gap for a scenario that current code already handles correctly

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR