### PR TITLE
fix(cisco-ai-defense): preserve request direction for tool definitions

### DIFF
--- a/litellm/proxy/guardrails/guardrail_hooks/cisco_ai_defense/cisco_ai_defense.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/cisco_ai_defense/cisco_ai_defense.py
@@ -1866,7 +1866,7 @@ class CiscoAIDefenseGuardrail(_CiscoAIDefenseMcpMixin, CustomGuardrail):
 
         tool_text: Final = CiscoAIDefenseGuardrail._extract_tool_definition_text(data)
         if tool_text:
-            messages.append({"role": "system", "content": tool_text})
+            messages.append({"role": "tool", "content": tool_text})
 
         return messages
 

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_cisco_ai_defense_chat.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_cisco_ai_defense_chat.py
@@ -1834,6 +1834,31 @@ class TestCiscoAIDefenseToolDefinitionBypass:
         )
 
     @pytest.mark.asyncio
+    async def test_pre_call_sends_tool_definitions_as_final_tool_message(self):
+        g = _make_guardrail(event_hook="pre_call")
+        data = self._tools_request("Fetch weather data")
+        data["messages"] = [
+            {"role": "system", "content": "Follow the security policy."},
+            {"role": "user", "content": "First question"},
+            {"role": "assistant", "content": "First answer"},
+            {"role": "user", "content": "Current question"},
+        ]
+        post_mock = AsyncMock(return_value=_safe_response())
+
+        with _patch_inspection_post(g, post_mock):
+            await g.async_pre_call_hook(
+                user_api_key_dict=UserAPIKeyAuth(),
+                cache=DualCache(),
+                data=data,
+                call_type="completion",
+            )
+
+        sent_messages = post_mock.call_args.kwargs["json"]["messages"]
+        assert sent_messages[:-1] == data["messages"]
+        assert sent_messages[-1]["role"] == "tool"
+        assert "get_weather" in sent_messages[-1]["content"]
+
+    @pytest.mark.asyncio
     async def test_pre_call_scans_legacy_functions_definitions(self):
         g = _make_guardrail(event_hook="pre_call")
         data = {
@@ -1884,7 +1909,7 @@ class TestCiscoAIDefenseToolDefinitionBypass:
         cisco_resp = _redact_response(
             sanitized_messages=[
                 {"role": "user", "content": "what's the weather?"},
-                {"role": "system", "content": "[REDACTED] tool description"},
+                {"role": "tool", "content": "[REDACTED] tool description"},
             ]
         )
 


### PR DESCRIPTION
## TLDR

Problem this solves:

- MCP tool context can flip request inspection to response mode
- Unsafe multi-turn requests may bypass the configured guardrail

How it solves it:

- Mark inspection-only tool definitions with the `tool` role
- Preserve message history and add direction regression coverage

## User Flow

Before: an application with Cisco AI Defense and an MCP server selected receives a model response for a request the guardrail should block

1. The operator enables GPT-4o, Cisco AI Defense pre-call inspection, and any MCP server
2. The client sends `POST http://localhost:4000/v1/chat/completions` with multi-turn messages and tool definitions
3. The client receives HTTP 200 with a model response instead of a guardrail error
4. An authenticated caller can continue the unsafe multi-turn sequence

After: the same MCP-enabled request is inspected as input and blocked before reaching the model

1. The operator enables GPT-4o, Cisco AI Defense pre-call inspection, and any MCP server
2. The client sends `POST http://localhost:4000/v1/chat/completions` with the same multi-turn messages and tool definitions
3. The client receives HTTP 400 with the configured guardrail block response
4. An authenticated caller can no longer bypass the guardrail this way

## Relevant issues


## Linear ticket

Resolves LIT-8016
## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The test file covering my change passes locally
- [x] My PR passes all required CI/CD checks
- [x] My PR's scope is isolated to one specific problem
- [x] I have received a Greptile Confidence Score of at least 4/5

## Screenshots / Proof of Fix

Shared setup:

- LiteLLM configured with GPT-4o
- Cisco AI Defense enabled for pre-call inspection
- An MCP server selected in both runs

### Before (fad8116cdc)

1. Send the MCP-enabled multi-turn request to `POST /v1/chat/completions`
2. Observe HTTP `200`, indicating the request was allowed

### After (5513d2603d)

1. Send the same MCP-enabled multi-turn request to `POST /v1/chat/completions`
2. Observe HTTP `400`, indicating the guardrail blocked the request


## Validation

- `118` Cisco AI Defense chat tests passed
- `make lint` passed
- Ruff formatting and lint checks passed

## Type

Bug Fix

## Caveats (if any)

- Only the Cisco chat inspection payload role changes
- The provider-bound model request remains unchanged

### Final Attestation

- [x] The tests cover message history, direction, and redaction behavior


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Security-sensitive guardrail behavior changes how inspection payloads are labeled; scope is limited to Cisco chat inspect messages and does not alter upstream model requests.
> 
> **Overview**
> Fixes a **Cisco AI Defense pre-call bypass** when chat requests include **tool definitions** (common with MCP-enabled setups). The guardrail still flattens `tools` / `functions` into an extra inspection-only message, but that message now uses role **`tool`** instead of **`system`**, so Cisco treats the scan as **request/input** rather than misclassifying it as response-side traffic.
> 
> **Tests** assert the flattened definitions are appended as the **last** message with role `tool` (conversation history unchanged) and that **redact** mocks use the same role so the synthetic tool-definition message is **not** written into the real `messages` array.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 85be9e526f98e7c8d47ca284085f2e6f1ef8422f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->