### PR TITLE
perf(ci): cache uv dependencies in the lint job

### DIFF
--- a/.github/workflows/test-linting.yml
+++ b/.github/workflows/test-linting.yml
@@ -67,6 +67,17 @@ jobs:
         with:
           version: "0.10.9"
 
+      - name: Cache uv dependencies
+        if: steps.changes.outputs.decision != 'skip'
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: |
+            ~/.cache/uv
+            .venv
+          key: ${{ runner.os }}-uv-lint-${{ hashFiles('uv.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-uv-lint-
+
       - name: Clean Python cache
         if: steps.changes.outputs.decision != 'skip'
         run: |


### PR DESCRIPTION
## TLDR

Problem this solves:

- `lint` is the slowest required check, 9 of last 10 staging PRs
- It reinstalls every dependency from scratch on every run
- That one step is 2.8 min of a 9.5 min p50 job

How it solves it:

- Cache `~/.cache/uv` and `.venv` keyed on `uv.lock`
- Same block `_test-unit-base.yml` already uses
- Own `lint` key namespace, since group sets differ

## User Flow

No end-user behavior changes. This is CI-only: it changes how long a required
check takes, not what it reports. Contributors see the same pass/fail on the
same rules, sooner.

## Relevant issues

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

The change is a CI wall-clock change, so the measurement is the workflow run
itself. `test-linting.yml` triggers only on `pull_request`, so the After side
is this PR's own run and lands once it completes.

### Before (e17988f4fe)

#### Slowest required check, last 10 merged staging PRs

1. Query the ruleset for the required contexts, then time every check run on each PR head:

```
gh api repos/BerriAI/litellm/rules/branches/litellm_internal_staging \
  --jq '.[] | select(.type=="required_status_checks") | .parameters.required_status_checks[].context' > req.txt

for SHA in $(gh pr list -R BerriAI/litellm --base litellm_internal_staging --state merged --limit 10 --json headRefOid --jq '.[].headRefOid'); do
  gh api "repos/BerriAI/litellm/commits/$SHA/check-runs?per_page=100" --paginate \
    --jq '.check_runs[] | select(.conclusion=="success" or .conclusion=="failure") | [((((.completed_at|fromdateiso8601)-(.started_at|fromdateiso8601))/60)*10|round/10), .name] | @tsv' \
   | awk -F'\t' 'NR==FNR{r[$0];next} $2 in r' req.txt - | sort -rn | head -1
done
```

2. Output, minutes and check name:

```
9.6	lint
8.9	lint
10	lint
9.2	lint
9.1	lint
9.7	lint
8.5	proxy-endpoints / Run tests
10	lint
9.9	lint
9.4	lint
```

#### Where the time goes inside lint

1. Step durations for the most recent staging `lint` run:

```
gh api "repos/BerriAI/litellm/actions/runs/32439641315/jobs?per_page=100" \
  --jq '.jobs[] | select(.name=="lint") | .steps[] | select(.conclusion!=null) | [((((.completed_at|fromdateiso8601)-(.started_at|fromdateiso8601))/60)*10|round/10), .name] | @tsv' | sort -rn | head -4
```

2. Output:

```
2.8	Install dependencies
2.3	Check type-discipline budget (... delta vs base)
1.6	Check test-quality budget (... delta vs base)
0.1	Set up uv
```

3. No `Cache uv dependencies` step exists in that list; the job caches only Prisma binaries.

### After (0105e497a5)

Pending this PR's own `lint` run. Expect `Install dependencies` to drop to
roughly the unit tier's cached cost on the second and later runs, when the
`uv.lock` key hits.

## Type

🚄 Infrastructure

## Caveats (if any)

- First run on this branch is a cache miss, so no gain yet
- Gain lands from the second run onward, per `uv.lock`
- `.venv` is cached the same way the unit tier already does
