### PR TITLE
perf(ci): fan the budget checkers out across cores

### DIFF
--- a/scripts/check_test_quality.py
+++ b/scripts/check_test_quality.py
@@ -102,11 +102,13 @@ from __future__ import annotations
 
 import ast
 import io
+import os
 import re
 import sys
 import tokenize
 from collections.abc import Iterable, Iterator, Mapping, Sequence
 from dataclasses import dataclass
+from multiprocessing import Pool
 from pathlib import Path
 from types import MappingProxyType
 from typing import Final, NamedTuple
@@ -692,13 +694,36 @@ def collect_paths(raw: Iterable[str]) -> Iterator[Path]:
             yield candidate
 
 
+PARALLEL_MIN_PATHS = 200
+MAX_WORKERS = 8
+
+
+def _worker_count(path_count: int) -> int:
+    """1 when the run is too small to repay process startup, else one worker per
+    core up to MAX_WORKERS."""
+    if path_count < PARALLEL_MIN_PATHS:
+        return 1
+    return max(1, min(os.cpu_count() or 1, MAX_WORKERS))
+
+
+def scan_paths(paths: Sequence[Path]) -> tuple[Violation, ...]:
+    """check_file over every path. Pure per-file work, so it fans out across
+    processes; callers sort, which is what keeps output order stable."""
+    workers = _worker_count(len(paths))
+    if workers == 1:
+        return tuple(v for path in paths for v in check_file(path))
+    with Pool(workers) as pool:
+        return tuple(v for found in pool.imap_unordered(check_file, paths, chunksize=32) for v in found)
+
+
 def main(argv: Sequence[str]) -> int:
     paths: Final = tuple(a for a in argv if not a.startswith("-"))
     if not paths:
         print("usage: check_test_quality.py <files-or-dirs>...", file=sys.stderr)
         return 2
 
-    violations: Final = sorted(v for path in collect_paths(paths) for v in check_file(path))
+    targets: Final = tuple(collect_paths(paths))
+    violations: Final = sorted(scan_paths(targets))
     for violation in violations:
         print(violation.render())
 

--- a/scripts/check_type_discipline.py
+++ b/scripts/check_type_discipline.py
@@ -114,10 +114,12 @@ from __future__ import annotations
  
 import ast
 import io
+import os
 import re
 import sys
 import tokenize
 from dataclasses import dataclass
+from multiprocessing import Pool
 from pathlib import Path
 from collections.abc import Iterable, Iterator, Mapping, Sequence
 from typing import NamedTuple
@@ -1070,13 +1072,36 @@ def collect_paths(raw: Iterable[str]) -> Iterator[Path]:
             yield p
  
  
+PARALLEL_MIN_PATHS = 200
+MAX_WORKERS = 8
+
+
+def _worker_count(path_count: int) -> int:
+    """1 when the run is too small to repay process startup, else one worker per
+    core up to MAX_WORKERS."""
+    if path_count < PARALLEL_MIN_PATHS:
+        return 1
+    return max(1, min(os.cpu_count() or 1, MAX_WORKERS))
+
+
+def scan_paths(paths: Sequence[Path]) -> tuple[Violation, ...]:
+    """check_file over every path. Pure per-file work, so it fans out across
+    processes; callers sort, which is what keeps output order stable."""
+    workers = _worker_count(len(paths))
+    if workers == 1:
+        return tuple(v for path in paths for v in check_file(path))
+    with Pool(workers) as pool:
+        return tuple(v for found in pool.imap_unordered(check_file, paths, chunksize=32) for v in found)
+
+
 def main(argv: Sequence[str]) -> int:
     paths = tuple(a for a in argv if not a.startswith("-"))
     if not paths:
         print("usage: check_type_discipline.py <files-or-dirs>...", file=sys.stderr)
         return 2
  
-    violations = sorted(v for path in collect_paths(paths) for v in check_file(path))
+    targets = tuple(collect_paths(paths))
+    violations = sorted(scan_paths(targets))
     for v in violations:
         print(v.render())
  

--- a/tests/test_litellm/test_check_test_quality.py
+++ b/tests/test_litellm/test_check_test_quality.py
@@ -8,6 +8,8 @@ in the test body.
 """
 
 import importlib.util
+import os
+import subprocess
 import sys
 from pathlib import Path
 
@@ -548,3 +550,56 @@ def test_the_read_may_sit_a_statement_above_the_store(tmp_path):
 def test_a_loop_storing_under_a_key_that_is_not_the_loop_variable_is_not_an_inventory(tmp_path):
     source = _HELPER_DICT_CONFTEST.replace("state[attr] =", 'state["fixed"] =')
     assert [v.code for v in checker.check_file(_written(tmp_path, source))] == []
+
+
+def _corpus(tmp_path, count):
+    for index in range(count):
+        (tmp_path / f"test_gen_{index}.py").write_text(
+            f"def test_flagged_{index}():\n    compute()\n\n\ndef test_clean_{index}():\n    assert compute() == {index}\n",
+            encoding="utf-8",
+        )
+    return tuple(sorted(tmp_path.rglob("*.py")))
+
+
+def _run_checker(target):
+    completed = subprocess.run(
+        [sys.executable, str(_MODULE_PATH), str(target)],
+        capture_output=True, text=True, timeout=300,
+    )
+    return completed.stdout.splitlines()
+
+
+def test_worker_count_stays_serial_below_the_threshold():
+    assert checker._worker_count(checker.PARALLEL_MIN_PATHS - 1) == 1
+
+
+def test_worker_count_fans_out_at_the_threshold():
+    assert checker._worker_count(checker.PARALLEL_MIN_PATHS) == max(
+        1, min(os.cpu_count() or 1, checker.MAX_WORKERS)
+    )
+
+
+def test_worker_count_never_exceeds_the_cap():
+    assert checker._worker_count(100_000) <= checker.MAX_WORKERS
+
+
+def test_scan_paths_below_the_threshold_returns_every_violation(tmp_path):
+    paths = _corpus(tmp_path, 3)
+    assert checker._worker_count(len(paths)) == 1
+    assert [v.code for v in checker.scan_paths(paths)] == ["TQ001"] * 3
+
+
+def test_a_fanned_out_run_reports_exactly_what_a_serial_run_reports(tmp_path):
+    paths = _corpus(tmp_path, checker.PARALLEL_MIN_PATHS + 5)
+    assert checker._worker_count(len(paths)) > 1, "corpus must cross the fan-out threshold"
+    serial = [v.render() for v in sorted(v for path in paths for v in checker.check_file(path))]
+    assert serial, "corpus must produce violations or the comparison proves nothing"
+    assert _run_checker(tmp_path) == serial
+
+
+def test_a_fanned_out_run_reports_each_generated_file_exactly_once(tmp_path):
+    paths = _corpus(tmp_path, checker.PARALLEL_MIN_PATHS + 5)
+    reported = _run_checker(tmp_path)
+    assert len(reported) == len(paths)
+    assert len({line.split(":")[0] for line in reported}) == len(paths)
+    assert all(" TQ001 " in line for line in reported)

--- a/tests/test_litellm/test_check_test_quality.py
+++ b/tests/test_litellm/test_check_test_quality.py
@@ -13,6 +13,8 @@ import subprocess
 import sys
 from pathlib import Path
 
+import pytest
+
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 _MODULE_PATH = _REPO_ROOT / "scripts" / "check_test_quality.py"
 _spec = importlib.util.spec_from_file_location("check_test_quality", _MODULE_PATH)
@@ -552,7 +554,11 @@ def test_a_loop_storing_under_a_key_that_is_not_the_loop_variable_is_not_an_inve
     assert [v.code for v in checker.check_file(_written(tmp_path, source))] == []
 
 
-def _corpus(tmp_path, count):
+_FANS_OUT = checker._worker_count(checker.PARALLEL_MIN_PATHS) > 1
+_SERIAL_ONLY = "one usable core, so scan_paths stays serial and there is no fan-out to compare"
+
+
+def _corpus(tmp_path: Path, count: int) -> tuple[Path, ...]:
     for index in range(count):
         (tmp_path / f"test_gen_{index}.py").write_text(
             f"def test_flagged_{index}():\n    compute()\n\n\ndef test_clean_{index}():\n    assert compute() == {index}\n",
@@ -561,7 +567,7 @@ def _corpus(tmp_path, count):
     return tuple(sorted(tmp_path.rglob("*.py")))
 
 
-def _run_checker(target):
+def _run_checker(target: Path) -> list[str]:
     completed = subprocess.run(
         [sys.executable, str(_MODULE_PATH), str(target)],
         capture_output=True, text=True, timeout=300,
@@ -589,14 +595,15 @@ def test_scan_paths_below_the_threshold_returns_every_violation(tmp_path):
     assert [v.code for v in checker.scan_paths(paths)] == ["TQ001"] * 3
 
 
+@pytest.mark.skipif(not _FANS_OUT, reason=_SERIAL_ONLY)
 def test_a_fanned_out_run_reports_exactly_what_a_serial_run_reports(tmp_path):
     paths = _corpus(tmp_path, checker.PARALLEL_MIN_PATHS + 5)
-    assert checker._worker_count(len(paths)) > 1, "corpus must cross the fan-out threshold"
     serial = [v.render() for v in sorted(v for path in paths for v in checker.check_file(path))]
     assert serial, "corpus must produce violations or the comparison proves nothing"
     assert _run_checker(tmp_path) == serial
 
 
+@pytest.mark.skipif(not _FANS_OUT, reason=_SERIAL_ONLY)
 def test_a_fanned_out_run_reports_each_generated_file_exactly_once(tmp_path):
     paths = _corpus(tmp_path, checker.PARALLEL_MIN_PATHS + 5)
     reported = _run_checker(tmp_path)

--- a/tests/test_litellm/test_check_type_discipline.py
+++ b/tests/test_litellm/test_check_type_discipline.py
@@ -8,7 +8,9 @@ a test fail. The comment-scanner cases are the regression for the readline path:
 
 import importlib.util
 import json
+import os
 import re
+import subprocess
 import sys
 from pathlib import Path
 
@@ -695,3 +697,56 @@ def test_budget_covers_exactly_the_checker_rules():
     for spec in budget.values():
         assert isinstance(spec["limit"], int)
         assert spec["limit"] >= 0
+
+
+def _corpus(tmp_path, count):
+    for index in range(count):
+        (tmp_path / f"mod_{index}.py").write_text(
+            f"def build_{index}(items: list[int]) -> None:\n    return None\n",
+            encoding="utf-8",
+        )
+    return tuple(sorted(tmp_path.rglob("*.py")))
+
+
+def _run_checker(target):
+    completed = subprocess.run(
+        [sys.executable, str(_MODULE_PATH), str(target)],
+        capture_output=True, text=True, timeout=300,
+    )
+    return completed.stdout.splitlines()
+
+
+def test_worker_count_stays_serial_below_the_threshold():
+    assert checker._worker_count(checker.PARALLEL_MIN_PATHS - 1) == 1
+
+
+def test_worker_count_fans_out_at_the_threshold():
+    assert checker._worker_count(checker.PARALLEL_MIN_PATHS) == max(
+        1, min(os.cpu_count() or 1, checker.MAX_WORKERS)
+    )
+
+
+def test_worker_count_never_exceeds_the_cap():
+    assert checker._worker_count(100_000) <= checker.MAX_WORKERS
+
+
+def test_scan_paths_below_the_threshold_returns_every_violation(tmp_path):
+    paths = _corpus(tmp_path, 3)
+    assert checker._worker_count(len(paths)) == 1
+    found = checker.scan_paths(paths)
+    assert found and len({v.path for v in found}) == 3
+
+
+def test_a_fanned_out_run_reports_exactly_what_a_serial_run_reports(tmp_path):
+    paths = _corpus(tmp_path, checker.PARALLEL_MIN_PATHS + 5)
+    assert checker._worker_count(len(paths)) > 1, "corpus must cross the fan-out threshold"
+    serial = [v.render() for v in sorted(v for path in paths for v in checker.check_file(path))]
+    assert serial, "corpus must produce violations or the comparison proves nothing"
+    assert _run_checker(tmp_path) == serial
+
+
+def test_a_fanned_out_run_reports_each_generated_file_exactly_once(tmp_path):
+    paths = _corpus(tmp_path, checker.PARALLEL_MIN_PATHS + 5)
+    reported = _run_checker(tmp_path)
+    assert reported
+    assert len({line.split(":")[0] for line in reported}) == len(paths)

--- a/tests/test_litellm/test_check_type_discipline.py
+++ b/tests/test_litellm/test_check_type_discipline.py
@@ -14,6 +14,8 @@ import subprocess
 import sys
 from pathlib import Path
 
+import pytest
+
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 _MODULE_PATH = _REPO_ROOT / "scripts" / "check_type_discipline.py"
 _spec = importlib.util.spec_from_file_location("check_type_discipline", _MODULE_PATH)
@@ -699,7 +701,11 @@ def test_budget_covers_exactly_the_checker_rules():
         assert spec["limit"] >= 0
 
 
-def _corpus(tmp_path, count):
+_FANS_OUT = checker._worker_count(checker.PARALLEL_MIN_PATHS) > 1
+_SERIAL_ONLY = "one usable core, so scan_paths stays serial and there is no fan-out to compare"
+
+
+def _corpus(tmp_path: Path, count: int) -> tuple[Path, ...]:
     for index in range(count):
         (tmp_path / f"mod_{index}.py").write_text(
             f"def build_{index}(items: list[int]) -> None:\n    return None\n",
@@ -708,7 +714,7 @@ def _corpus(tmp_path, count):
     return tuple(sorted(tmp_path.rglob("*.py")))
 
 
-def _run_checker(target):
+def _run_checker(target: Path) -> list[str]:
     completed = subprocess.run(
         [sys.executable, str(_MODULE_PATH), str(target)],
         capture_output=True, text=True, timeout=300,
@@ -737,14 +743,15 @@ def test_scan_paths_below_the_threshold_returns_every_violation(tmp_path):
     assert found and len({v.path for v in found}) == 3
 
 
+@pytest.mark.skipif(not _FANS_OUT, reason=_SERIAL_ONLY)
 def test_a_fanned_out_run_reports_exactly_what_a_serial_run_reports(tmp_path):
     paths = _corpus(tmp_path, checker.PARALLEL_MIN_PATHS + 5)
-    assert checker._worker_count(len(paths)) > 1, "corpus must cross the fan-out threshold"
     serial = [v.render() for v in sorted(v for path in paths for v in checker.check_file(path))]
     assert serial, "corpus must produce violations or the comparison proves nothing"
     assert _run_checker(tmp_path) == serial
 
 
+@pytest.mark.skipif(not _FANS_OUT, reason=_SERIAL_ONLY)
 def test_a_fanned_out_run_reports_each_generated_file_exactly_once(tmp_path):
     paths = _corpus(tmp_path, checker.PARALLEL_MIN_PATHS + 5)
     reported = _run_checker(tmp_path)


### PR DESCRIPTION
## TLDR

Problem this solves:

- `lint` is the slowest required check, 9 of last 10 staging PRs
- Its two budget checkers are 2.3 min and 1.6 min
- Both walk thousands of files single-threaded

How it solves it:

- `check_file` is pure per-file work, so fan it out
- Process pool over the file list, callers still sort
- Small runs stay serial; worker count is capped

## User Flow

No end-user behavior changes. This is CI-only, and the rules report exactly
what they reported before: same violations, same order, same per-rule counts.
Contributors see the same pass/fail, sooner.

## Relevant issues

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

Both checkers are invoked by the gate wrappers as subprocesses, so the runnable
proof is the checker itself over the same tree, timed and diffed. Shared setup,
capturing the pre-change scripts from the merge base:

```
git show origin/litellm_internal_staging:scripts/check_type_discipline.py > /tmp/td_serial.py
git show origin/litellm_internal_staging:scripts/check_test_quality.py   > /tmp/tq_serial.py
```

### Before (e17988f4fe)

#### type-discipline over litellm/

1. `/usr/bin/time -p python /tmp/td_serial.py litellm > /tmp/td_before.txt`
2. Output:

```
real 17.77
user 17.15
sys 0.18
```

#### test-quality over tests/

1. `/usr/bin/time -p python /tmp/tq_serial.py tests > /tmp/tq_before.txt`
2. Output:

```
real 14.40
user 13.74
sys 0.20
```

### After (a7aeaff10c)

#### type-discipline over litellm/

1. `/usr/bin/time -p python scripts/check_type_discipline.py litellm > /tmp/td_after.txt`
2. Output:

```
real 2.97
user 19.58
sys 0.31
```

3. `wc -l /tmp/td_before.txt /tmp/td_after.txt && cmp /tmp/td_before.txt /tmp/td_after.txt && echo IDENTICAL`

```
   78768 /tmp/td_before.txt
   78768 /tmp/td_after.txt
IDENTICAL
```

#### test-quality over tests/

1. `/usr/bin/time -p python scripts/check_test_quality.py tests > /tmp/tq_after.txt`
2. Output:

```
real 2.30
user 16.40
sys 0.39
```

3. `wc -l /tmp/tq_before.txt /tmp/tq_after.txt && cmp /tmp/tq_before.txt /tmp/tq_after.txt && echo IDENTICAL`

```
    6321 /tmp/tq_before.txt
    6321 /tmp/tq_after.txt
IDENTICAL
```

4. Per-rule counts on both sides, `grep -oE 'TQ00[0-9]' ... | sort | uniq -c`:

```
before   747 TQ001  742 TQ002 1077 TQ003  768 TQ004 2836 TQ005   34 TQ006  117 TQ007
after    747 TQ001  742 TQ002 1077 TQ003  768 TQ004 2836 TQ005   34 TQ006  117 TQ007
```

#### Both gates still pass against the merge base

1. `python scripts/test_quality_gate.py --base origin/litellm_internal_staging`
2. `python scripts/type_discipline_gate.py --base origin/litellm_internal_staging`

```
OK: every TQ rule is within its test-suite ceiling (base origin/litellm_internal_staging)
OK: every LIT rule is within its codebase ceiling (base origin/litellm_internal_staging)
```

## Type

🚄 Infrastructure

## Caveats (if any)

- Speedup tracks runner cores; capped at 8 workers
- New tests drive the real CLI, since the pool needs an importable entry point
- Wall clock falls, total CPU rises slightly, as expected

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
