### PR TITLE
ci: run the keyless caching tests that ran in no job

### DIFF
--- a/.github/ci-coverage-allowlist.yml
+++ b/.github/ci-coverage-allowlist.yml
@@ -5,24 +5,21 @@ description: >-
 
 test_paths:
   - reason: >-
-      The caching suite in tests/local_testing, which runs nowhere. Every job that globs that
-      directory either deselects it (local_testing_part1 and part2 carry `-k "... and not caching
-      and not cache"`) or keeps only another keyword (langfuse, router, assistants), and no job
-      names these files the way redis_caching_unit_tests names test_dual_cache.py. Measured
-      2026-08-20 by collecting the directory under each job's own selector: 118 tests across
-      these eight files are selected by none of them. Listed so the gap is a decision rather
-      than an accident, and so the --slices guard has a baseline to ratchet down from. Revisit
-      when tests/local_testing is ported off CircleCI, where the keyless part of this suite
-      belongs in a real job
+      What is left of the caching suite in tests/local_testing that runs nowhere. Every job that
+      globs that directory either deselects it (local_testing_part1 and part2 carry `-k "... and
+      not caching and not cache"`) or keeps only another keyword (langfuse, router, assistants),
+      and no job names these files the way redis_caching_unit_tests names test_dual_cache.py.
+      The gap was eight files and 118 tests when measured 2026-08-20; the five keyless ones now
+      run in the caching-local shard, leaving these three. Measured 2026-08-21 with no provider
+      credentials and no Redis: test_caching.py needs both (37 of 65 fail without them),
+      test_disk_cache_unit_tests.py needs OPENAI_API_KEY for 2 of its 4, and
+      test_gcs_cache_unit_tests.py needs GCS credentials for all 4. They want the keyless/live
+      split that porting tests/local_testing off CircleCI will force, not a job that is red by
+      construction
     paths:
-      - tests/local_testing/test_cache_preset_key.py
       - tests/local_testing/test_caching.py
-      - tests/local_testing/test_caching_handler.py
       - tests/local_testing/test_disk_cache_unit_tests.py
       - tests/local_testing/test_gcs_cache_unit_tests.py
-      - tests/local_testing/test_prompt_caching.py
-      - tests/local_testing/test_responses_stream_cache_keys.py
-      - tests/local_testing/test_unit_test_caching.py
   - reason: >-
       The end-to-end suite runs against a deployed proxy from its own in-cluster rig rather than
       from a pull request; it needs a live gateway and provider credentials no PR job holds

--- a/.github/scripts/assert_ci_coverage.py
+++ b/.github/scripts/assert_ci_coverage.py
@@ -312,8 +312,23 @@ def _matchable_names(relative_path: str) -> frozenset[str]:
     )
 
 
+def _workflow_named_tokens() -> frozenset[str]:
+    """Test tokens a GitHub Actions job names directly.
+
+    A CircleCI `-k` that deselects a file no longer means the file runs nowhere once a
+    workflow names it, so the slice check has to credit those the same way the census does.
+    """
+    return _invoked_test_tokens(
+        scalar
+        for path in _config_files()
+        if path != CIRCLECI_CONFIG
+        for scalar in _scalars(yaml.safe_load(path.read_text(encoding="utf-8")), path.name)
+    )
+
+
 def _deselected_everywhere(allowlist: Allowlist) -> tuple[Finding, ...]:
     slices: Final = _slices()
+    named_by_workflow: Final = _workflow_named_tokens()
     globbed: Final = tuple(
         path
         for path in _test_files()
@@ -326,6 +341,7 @@ def _deselected_everywhere(allowlist: Allowlist) -> tuple[Finding, ...]:
         )
         for path in globbed
         if not allowlist.covers_test(path)
+        and not any(_token_covers(token, path) for token in named_by_workflow)
         and not any(slice_.claims(path, _matchable_names(path)) for slice_ in slices)
     )
 

--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -200,6 +200,19 @@ jobs:
             timeout-minutes: 20
             job-timeout-minutes: 55
 
+          - shard: caching-local
+            artifact-name: caching-local
+            test-path: >-
+              tests/local_testing/test_cache_preset_key.py
+              tests/local_testing/test_caching_handler.py
+              tests/local_testing/test_prompt_caching.py
+              tests/local_testing/test_responses_stream_cache_keys.py
+              tests/local_testing/test_unit_test_caching.py
+            workers: 2
+            reruns: 2
+            timeout-minutes: 20
+            job-timeout-minutes: 55
+
           - shard: responses-caching-types
             artifact-name: responses-caching-types
             test-path: >-

--- a/tests/test_litellm/test_assert_ci_coverage.py
+++ b/tests/test_litellm/test_assert_ci_coverage.py
@@ -280,3 +280,27 @@ def test_a_dockerfile_directory_entry_is_stale_because_only_an_exact_path_exempt
         dockerfiles=("docker/Dockerfile.database",),
     )
     assert [f.subject for f in findings] == ["docker"]
+
+
+def test_a_workflow_that_names_a_file_clears_it_from_the_slice_check():
+    named = coverage._workflow_named_tokens()
+    assert named, "the workflows must name some test paths or the check proves nothing"
+    assert any(
+        coverage._token_covers(token, "tests/local_testing/test_caching_handler.py")
+        for token in named
+    )
+
+
+def test_the_slice_check_credits_only_workflows_never_the_circleci_config():
+    named = coverage._workflow_named_tokens()
+    circleci_only = "tests/proxy_admin_ui_tests"
+    assert not any(coverage._token_covers(token, f"{circleci_only}/test_key_management.py") for token in named), (
+        "a tree only CircleCI globs must not be credited to a workflow"
+    )
+
+
+def test_a_file_no_workflow_names_is_still_reported_when_every_slice_drops_it():
+    named = coverage._workflow_named_tokens()
+    assert not any(
+        coverage._token_covers(token, "tests/local_testing/test_caching.py") for token in named
+    ), "test_caching.py is allowlisted, not run; crediting it would hide a real gap"


### PR DESCRIPTION
## TLDR

Problem this solves:

- 8 caching files, 118 tests, ran in no job at all
- Every job globbing them deselects them via `-k`
- They counted as covered the whole time

How it solves it:

- 5 of them need nothing; run them as a `caching-local` shard
- The other 3 stay allowlisted, with what they need recorded
- Fix the slice guard, which could not see a workflow naming a file

## User Flow

No end-user behavior changes. This is CI-only. 45 caching tests that never
executed now execute on every PR, so a caching regression that previously
reached a release has a chance to fail a check instead.

## Relevant issues

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

Every run below is with no provider credentials and no Redis, which is the
condition a PR job runs under:

```
env -u OPENAI_API_KEY -u ANTHROPIC_API_KEY -u REDIS_HOST -u REDIS_PORT -u REDIS_PASSWORD ...
```

### Before (ff02d5cfc0)

#### The eight files, and which of them can actually run

1. Run each of the eight on its own:

```
for F in test_cache_preset_key test_caching_handler test_disk_cache_unit_tests \
         test_gcs_cache_unit_tests test_responses_stream_cache_keys \
         test_unit_test_caching test_prompt_caching; do
  printf "  %-34s " "$F"
  pytest "tests/local_testing/$F.py" -q --timeout=90 2>&1 | tail -1
done
```

2. Output:

```
  test_cache_preset_key              3 passed, 1 warning in 0.04s
  test_caching_handler               28 passed, 7 warnings in 6.35s
  test_disk_cache_unit_tests         2 failed, 2 passed, 1 warning in 1.47s
  test_gcs_cache_unit_tests          4 failed, 1 warning in 6.90s
  test_responses_stream_cache_keys   3 passed, 1 warning in 0.03s
  test_unit_test_caching             10 passed, 1 warning in 0.19s
  test_prompt_caching                1 passed, 1 warning in 0.03s
```

3. And the eighth, the big one:

```
pytest tests/local_testing/test_caching.py -q --timeout=90 -n 4 2>&1 | tail -1
```

```
37 failed, 23 passed, 5 skipped, 7 warnings, 6 rerun in 24.51s
```

4. The disk-cache failures name their cause:

```
openai.OpenAIError: The api_key client option must be set either by passing api_key to the client or by setting the OPENAI_API_KEY environment variable
```

### After (a6f58e2d58)

#### The five keyless files run green together, as the shard runs them

1. Same selection and worker count as the new matrix entry:

```
pytest tests/local_testing/test_cache_preset_key.py tests/local_testing/test_caching_handler.py \
       tests/local_testing/test_prompt_caching.py tests/local_testing/test_responses_stream_cache_keys.py \
       tests/local_testing/test_unit_test_caching.py -q -n 2 --timeout=120
```

2. Output:

```
45 passed, 9 warnings in 8.02s
```

#### All three guards green

1. Run the census, the shard guard and the slice guard:

```
python .github/scripts/assert_ci_coverage.py
python .github/scripts/assert_ci_coverage.py --shards
python .github/scripts/assert_ci_coverage.py --slices
```

```
OK: 2430 test files and 10 Dockerfiles are each invoked by at least one job or carry an explicit allowlist entry.
OK: all 345 test children across 3 sharded trees are assigned to a shard.
OK: no test file is globbed by a job and then deselected by every -k across 36 slices.
```

#### The slice guard was fixed, not neutered

1. Drop the new shard, leaving the five off the allowlist. The guard must report them again:

```
ERROR: test files a -k expression removes from every job that globs them
  - tests/local_testing/test_cache_preset_key.py: globbed by a job, then deselected by every one of their -k expressions
  - tests/local_testing/test_caching_handler.py: globbed by a job, then deselected by every one of their -k expressions
  - tests/local_testing/test_prompt_caching.py: globbed by a job, then deselected by every one of their -k expressions
  - tests/local_testing/test_responses_stream_cache_keys.py: globbed by a job, then deselected by every one of their -k expressions
  - tests/local_testing/test_unit_test_caching.py: globbed by a job, then deselected by every one of their -k expressions
```

2. Restore the shard, then plant a genuinely dead file by removing `test_caching.py` from the allowlist. Still caught:

```
ERROR: test files a -k expression removes from every job that globs them
  - tests/local_testing/test_caching.py: globbed by a job, then deselected by every one of their -k expressions
```

3. Restore, green again:

```
OK: no test file is globbed by a job and then deselected by every -k across 36 slices.
```

## Type

🚄 Infrastructure
✅ Test

## Caveats (if any)

- Allowlist drops from 8 caching entries to 3
- The 3 remaining want the keyless/live split, not a red job
- New shard check is not in the ruleset; that needs an admin

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
