### PR TITLE
fix(ollama): fix streaming tool call finish_reason, arguments format, and parallel index

### DIFF
--- a/litellm/llms/ollama/chat/transformation.py
+++ b/litellm/llms/ollama/chat/transformation.py
@@ -421,6 +421,12 @@ class OllamaChatConfig(BaseConfig):
 class OllamaChatCompletionResponseIterator(BaseModelResponseIterator):
     started_reasoning_content: bool = False
     finished_reasoning_content: bool = False
+    saw_tool_calls: bool = False
+
+    def __init__(self, streaming_response, sync_stream: bool, json_mode: bool | None = False) -> None:
+        super().__init__(streaming_response, sync_stream, json_mode)
+        self.response_id: str = str(uuid.uuid4())
+        self._tool_call_index: int = 0
 
     def _is_function_call_complete(self, function_args: str | dict) -> bool:
         if isinstance(function_args, dict):
@@ -466,12 +472,17 @@ class OllamaChatCompletionResponseIterator(BaseModelResponseIterator):
             # process tool calls - if complete function arg - add id to tool call
             tool_calls: Final = chunk["message"].get("tool_calls")
             if tool_calls is not None:
+                self.saw_tool_calls = True
                 for tool_call in tool_calls:
+                    tool_call["index"] = self._tool_call_index
+                    self._tool_call_index += 1
                     function_args = tool_call.get("function").get("arguments")
                     if function_args is not None and len(function_args) > 0:
+                        if isinstance(function_args, dict):
+                            tool_call["function"]["arguments"] = json.dumps(function_args)
                         is_function_call_complete = self._is_function_call_complete(function_args)
                         if is_function_call_complete:
-                            tool_call["id"] = str(uuid.uuid4())
+                            tool_call["id"] = f"call_{uuid.uuid4()}"
 
             # PROCESS REASONING CONTENT
             reasoning_content: str | None = None
@@ -506,9 +517,7 @@ class OllamaChatCompletionResponseIterator(BaseModelResponseIterator):
 
             if chunk["done"] is True:
                 finish_reason = chunk.get("done_reason") or "stop"
-                # Override finish_reason when tool_calls are present
-                # Fixes: https://github.com/BerriAI/litellm/issues/18922
-                if tool_calls is not None:
+                if finish_reason == "stop" and (tool_calls is not None or self.saw_tool_calls):
                     finish_reason = "tool_calls"
                 choices = [
                     StreamingChoices(
@@ -530,7 +539,7 @@ class OllamaChatCompletionResponseIterator(BaseModelResponseIterator):
             )
 
             return ModelResponseStream(
-                id=str(uuid.uuid4()),
+                id=self.response_id,
                 object="chat.completion.chunk",
                 created=int(time.time()),  # ollama created_at is in UTC
                 usage=usage,

--- a/tests/test_litellm/llms/ollama/test_ollama_chat_transformation.py
+++ b/tests/test_litellm/llms/ollama/test_ollama_chat_transformation.py
@@ -1,4 +1,5 @@
 import inspect
+import json
 import os
 import sys
 from typing import cast
@@ -906,3 +907,169 @@ class TestOllamaToolCallTransformation:
         assert tool_msg["content"] == "Sunny, 72°F"
         assert "tool_call_id" in tool_msg, "tool_call_id must be forwarded to Ollama"
         assert tool_msg["tool_call_id"] == "call_abc123"
+
+
+class TestOllamaStreamingToolCalls:
+    """Regression tests for ollama_chat streaming tool call defects."""
+
+    @staticmethod
+    def _make_tool_call_chunk(tool_name: str, arguments: dict, done: bool = False, done_reason: str = "stop") -> dict:
+        return {
+            "model": "qwen3:14b",
+            "created_at": "2025-01-11T00:00:00.000000Z",
+            "message": {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {"function": {"name": tool_name, "arguments": arguments}}
+                ],
+            },
+            "done": done,
+            "done_reason": done_reason if done else None,
+            "prompt_eval_count": 10,
+            "eval_count": 5,
+        }
+
+    @staticmethod
+    def _make_done_chunk(done_reason: str = "stop") -> dict:
+        return {
+            "model": "qwen3:14b",
+            "created_at": "2025-01-11T00:00:00.000000Z",
+            "message": {"role": "assistant", "content": ""},
+            "done": True,
+            "done_reason": done_reason,
+            "prompt_eval_count": 10,
+            "eval_count": 5,
+        }
+
+    def test_streaming_chunks_have_consistent_id(self):
+        iterator = OllamaChatCompletionResponseIterator(
+            streaming_response=iter([]),
+            sync_stream=True,
+        )
+        expected_id = iterator.response_id
+
+        chunk1 = {
+            "model": "qwen3:14b",
+            "created_at": "2025-01-11T00:00:00.000000Z",
+            "message": {"role": "assistant", "content": "Hello"},
+            "done": False,
+        }
+        chunk2 = {
+            "model": "qwen3:14b",
+            "created_at": "2025-01-11T00:00:00.000000Z",
+            "message": {"role": "assistant", "content": " world"},
+            "done": True,
+            "done_reason": "stop",
+            "prompt_eval_count": 5,
+            "eval_count": 2,
+        }
+
+        result1 = iterator.chunk_parser(chunk1)
+        result2 = iterator.chunk_parser(chunk2)
+
+        assert result1.id == expected_id
+        assert result2.id == expected_id
+
+    def test_streaming_tool_call_id_has_call_prefix(self):
+        iterator = OllamaChatCompletionResponseIterator(
+            streaming_response=iter([]),
+            sync_stream=True,
+        )
+
+        result = iterator.chunk_parser(self._make_tool_call_chunk("get_weather", {"location": "Tokyo"}, done=True))
+        tool_call = result.choices[0].delta.tool_calls[0]
+        assert tool_call["id"].startswith("call_")
+
+    def test_streaming_arguments_converted_to_json_string(self):
+        iterator = OllamaChatCompletionResponseIterator(
+            streaming_response=iter([]),
+            sync_stream=True,
+        )
+
+        result = iterator.chunk_parser(self._make_tool_call_chunk("get_weather", {"location": "Tokyo"}, done=True))
+        arguments = result.choices[0].delta.tool_calls[0]["function"]["arguments"]
+        assert isinstance(arguments, str)
+        assert json.loads(arguments) == {"location": "Tokyo"}
+
+    def test_streaming_finish_reason_tool_calls_in_done_chunk(self):
+        iterator = OllamaChatCompletionResponseIterator(
+            streaming_response=iter([]),
+            sync_stream=True,
+        )
+
+        result = iterator.chunk_parser(self._make_tool_call_chunk("get_weather", {"location": "Tokyo"}, done=True))
+        assert result.choices[0].finish_reason == "tool_calls"
+
+    def test_streaming_saw_tool_calls_propagates_to_done_chunk(self):
+        iterator = OllamaChatCompletionResponseIterator(
+            streaming_response=iter([]),
+            sync_stream=True,
+        )
+
+        iterator.chunk_parser(self._make_tool_call_chunk("get_weather", {"location": "Tokyo"}))
+        result = iterator.chunk_parser(self._make_done_chunk())
+        assert result.choices[0].finish_reason == "tool_calls"
+
+    def test_streaming_length_finish_reason_preserved_with_tool_calls(self):
+        iterator = OllamaChatCompletionResponseIterator(
+            streaming_response=iter([]),
+            sync_stream=True,
+        )
+
+        iterator.chunk_parser(self._make_tool_call_chunk("get_weather", {"location": "Tokyo"}))
+        result = iterator.chunk_parser(self._make_done_chunk(done_reason="length"))
+        assert result.choices[0].finish_reason == "length"
+
+    def test_streaming_parallel_tool_calls_get_unique_indices(self):
+        iterator = OllamaChatCompletionResponseIterator(
+            streaming_response=iter([]),
+            sync_stream=True,
+        )
+
+        chunk1 = {
+            "model": "qwen3:14b",
+            "created_at": "2025-01-11T00:00:00.000000Z",
+            "message": {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "function": {
+                            "name": "get_weather",
+                            "arguments": {"city": "Tokyo"},
+                        }
+                    }
+                ],
+            },
+            "done": False,
+        }
+        chunk2 = {
+            "model": "qwen3:14b",
+            "created_at": "2025-01-11T00:00:00.000000Z",
+            "message": {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "function": {
+                            "name": "get_time",
+                            "arguments": {"timezone": "America/New_York"},
+                        }
+                    }
+                ],
+            },
+            "done": False,
+        }
+
+        result1 = iterator.chunk_parser(chunk1)
+        result2 = iterator.chunk_parser(chunk2)
+
+        tc1 = result1.choices[0].delta.tool_calls[0]
+        tc2 = result2.choices[0].delta.tool_calls[0]
+        assert tc1["index"] == 0
+        assert tc2["index"] == 1
+        assert tc1["function"]["name"] == "get_weather"
+        assert tc2["function"]["name"] == "get_time"
+        assert json.loads(tc1["function"]["arguments"]) == {"city": "Tokyo"}
+        assert json.loads(tc2["function"]["arguments"]) == {"timezone": "America/New_York"}


### PR DESCRIPTION
## TLDR

Problem this solves:

- Streamed tool calls through `ollama_chat` ended with `finish_reason: "stop"` instead of `"tool_calls"`
- `function.arguments` arrived as a dict instead of a JSON string in streaming
- Parallel tool calls all got `index: 0`, merging them into one malformed call
- Each streaming chunk got a different response `id` and tool call ids lacked the `call_` prefix

How it solves it:

- Track `saw_tool_calls` across chunks and upgrade `finish_reason` on the done chunk, gated on `"stop"` so `"length"` passes through
- Serialize dict arguments to JSON strings in the streaming chunk parser
- Track a persistent `_tool_call_index` counter so each tool call gets a sequential index
- Generate a stable `response_id` once per stream and prefix tool call ids with `call_`

## User Flow

Before: a developer using an OpenAI-compatible client through a LiteLLM proxy to an Ollama backend sends a request that triggers two parallel tool calls, but only the first call survives and its arguments are corrupted

1. They send `POST /v1/chat/completions` with `"stream": true`, two tools, and a message asking for both
2. The SSE stream delivers two `delta.tool_calls` chunks, both with `"index": 0`
3. Their client accumulates both calls into the same slot, concatenating arguments into `{"city": "Tokyo"}{"timezone": "America/New_York"}`
4. The final chunk arrives with `"finish_reason": "stop"`, so the client treats the turn as ordinary text and never dispatches the tools

After: the same request delivers each tool call with a unique index and the correct finish reason, so the client dispatches both

1. They send the same `POST /v1/chat/completions` with `"stream": true`, two tools, and the same message
2. The SSE stream delivers two `delta.tool_calls` chunks, the first with `"index": 0` and the second with `"index": 1`
3. Their client accumulates each call into its own slot, preserving both argument objects
4. The final chunk arrives with `"finish_reason": "tool_calls"`, so the client dispatches both tools

## Relevant issues

Fixes #33678
Fixes #35663

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Proxy config: `ollama_chat` route to a remote Ollama instance. Real streaming LLM calls, no mocks. Anonymized endpoint and key.

Request payload used for all cases:

```json
{"model": "ollama_chat/<model>", "stream": true, "tools": [
  {"type": "function", "function": {"name": "get_weather", "parameters": {"type": "object", "properties": {"city": {"type": "string"}}, "required": ["city"]}}},
  {"type": "function", "function": {"name": "get_time", "parameters": {"type": "object", "properties": {"timezone": {"type": "string"}}, "required": ["timezone"]}}}
], "messages": [{"role": "user", "content": "What is the weather in Tokyo and the time in New York? Call both tools."}]}
```

### Before (ff02d5cfc0)

#### Parallel tool calls (separate chunks)

1. `curl -sN http://localhost:4000/v1/chat/completions -H "Authorization: Bearer $LITELLM_KEY" -H "Content-Type: application/json" -d '<payload above with model ollama_chat/glm-5.1>'`
2. Tool call chunks arrive with both indices set to 0:

```
data: {"choices":[{"delta":{"tool_calls":[{"id":"call_...","function":{"arguments":"{\"city\": \"Tokyo\"}","name":"get_weather"},"type":"function","index":0}]}}]}
data: {"choices":[{"delta":{"tool_calls":[{"id":"call_...","function":{"arguments":"{\"timezone\": \"America/New_York\"}","name":"get_time"},"type":"function","index":0}]}}]}
data: {"choices":[{"delta":{},"finish_reason":"stop"}]}
```

3. The final chunk reports `"finish_reason": "stop"` instead of `"tool_calls"`, and both tool calls share `"index": 0`

#### Single tool call

1. Same request with one tool and a single-call prompt
2. Tool call chunk arrives with `"finish_reason": "stop"` on the done chunk, tool call id without `call_` prefix

#### Plain text (no tools)

1. Same request without `tools` array
2. Final chunk reports `"finish_reason": "stop"` (correct, unaffected)

### After (04694c13a6)

#### Parallel tool calls (separate chunks)

1. `curl -sN http://localhost:4000/v1/chat/completions -H "Authorization: Bearer $LITELLM_KEY" -H "Content-Type: application/json" -d '<payload above with model ollama_chat/glm-5.1>'`
2. Tool call chunks arrive with sequential indices:

```
data: {"id":"eed04fdd-...","choices":[{"delta":{"tool_calls":[{"id":"call_7bc17b2c-...","function":{"arguments":"{\"city\": \"Tokyo\"}","name":"get_weather"},"type":"function","index":0}]}}]}
data: {"id":"eed04fdd-...","choices":[{"delta":{"tool_calls":[{"id":"call_30ea4e4a-...","function":{"arguments":"{\"timezone\": \"America/New_York\"}","name":"get_time"},"type":"function","index":1}]}}]}
data: {"id":"eed04fdd-...","choices":[{"delta":{},"finish_reason":"tool_calls"}]}
```

3. Both tool calls have unique indices (`0` and `1`), unique `call_`-prefixed ids, arguments are JSON strings, and the final chunk reports `"finish_reason": "tool_calls"`

#### Parallel tool calls (same chunk)

1. Same payload with model `ollama_chat/qwen3.5:397b`
2. Both tool calls arrive in a single delta with correct indices:

```
data: {"id":"69e2eead-...","choices":[{"delta":{"tool_calls":[
  {"id":"call_cef017c0-...","function":{"arguments":"{\"city\": \"Tokyo\"}","name":"get_weather"},"type":"function","index":0},
  {"id":"call_dc041897-...","function":{"arguments":"{\"timezone\": \"New York\"}","name":"get_time"},"type":"function","index":1}
]}}]}
data: {"id":"69e2eead-...","choices":[{"delta":{},"finish_reason":"tool_calls"}]}
```

#### Single tool call

1. Same request with one tool and a single-call prompt
2. Tool call chunk has `call_`-prefixed id, JSON string arguments, and done chunk reports `"finish_reason": "tool_calls"`

#### Plain text (no tools)

1. Same request without `tools` array
2. Final chunk reports `"finish_reason": "stop"` (correct, unaffected)

#### Length truncation with tool calls

1. Same request with `"max_tokens": 1` and a tool-warranted prompt
2. Final chunk reports `"finish_reason": "length"` (not overridden to `"tool_calls"`, preserving the truncation signal)

## Type

🐛 Bug Fix

## Caveats (if any)

- Only `ollama_chat/` streaming is fixed; `ollama/` (generate endpoint) streaming tool calls are a separate problem tracked in #35711
- The `finish_reason` override is gated on `"stop"` to preserve `"length"` and other non-stop reasons, matching the existing `streaming_handler.py` finalizer

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR