### PR TITLE
perf(ci): cache the Rust build the unit shards compile from scratch

### DIFF
--- a/.github/actions/cache-cargo-build/action.yml
+++ b/.github/actions/cache-cargo-build/action.yml
@@ -1,0 +1,33 @@
+name: "Cache the Rust build"
+description: >-
+  Cache the Cargo registry and target directory the root package's build needs,
+  so only the first job on a given Cargo.lock compiles the bridge from scratch.
+
+  litellm builds through maturin, which compiles litellm-rust/crates/python-bridge
+  before it can produce a wheel. `uv sync` therefore pays a full release build in
+  every job that installs the workspace: measured at 2m40s per unit shard on
+  2026-08-21, more than the whole unit tier spends running tests. Cargo rebuilds
+  only what changed when its target directory survives, so a warm job pays for
+  the bridge crate alone.
+
+  CARGO_TARGET_DIR is exported rather than left to default because uv builds the
+  wheel from its own working directory, and only an absolute path lands the
+  artifacts somewhere a cache can find them again.
+
+runs:
+  using: composite
+  steps:
+    - name: Point Cargo at a cacheable target directory
+      shell: bash
+      run: echo "CARGO_TARGET_DIR=${{ github.workspace }}/.cargo-target" >> "$GITHUB_ENV"
+
+    - name: Restore the Cargo registry and target directory
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+      with:
+        path: |
+          ~/.cargo/registry
+          ~/.cargo/git
+          ${{ github.workspace }}/.cargo-target
+        key: ${{ runner.os }}-cargo-uv-build-${{ hashFiles('litellm-rust/Cargo.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-cargo-uv-build-

--- a/.github/actions/cache-cargo-build/action.yml
+++ b/.github/actions/cache-cargo-build/action.yml
@@ -4,30 +4,28 @@ description: >-
   so only the first job on a given Cargo.lock compiles the bridge from scratch.
 
   litellm builds through maturin, which compiles litellm-rust/crates/python-bridge
-  before it can produce a wheel. `uv sync` therefore pays a full release build in
-  every job that installs the workspace: measured at 2m40s per unit shard on
-  2026-08-21, more than the whole unit tier spends running tests. Cargo rebuilds
-  only what changed when its target directory survives, so a warm job pays for
-  the bridge crate alone.
+  in release mode before it can produce a wheel. `uv sync` therefore pays a full
+  build in every job that installs the workspace: measured at 2m40s per unit shard
+  on 2026-08-21, more than the whole unit tier spends running tests. Nothing caught
+  it, because the uv cache holds wheels uv downloads rather than wheels it builds,
+  and a path dependency whose source moves every commit could never hit that cache
+  anyway. Cargo rebuilds only what changed when its target directory survives, so a
+  warm job pays for the bridge crate alone.
 
-  CARGO_TARGET_DIR is exported rather than left to default because uv builds the
-  wheel from its own working directory, and only an absolute path lands the
-  artifacts somewhere a cache can find them again.
+  The key namespace is separate from test-rust.yml's. Both cache the same directory,
+  but that workflow fills it with debug and clippy artifacts, which a release build
+  cannot reuse, and a shared key would let whichever ran first deny the other a save.
 
 runs:
   using: composite
   steps:
-    - name: Point Cargo at a cacheable target directory
-      shell: bash
-      run: echo "CARGO_TARGET_DIR=${{ github.workspace }}/.cargo-target" >> "$GITHUB_ENV"
-
     - name: Restore the Cargo registry and target directory
       uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
       with:
         path: |
           ~/.cargo/registry
           ~/.cargo/git
-          ${{ github.workspace }}/.cargo-target
-        key: ${{ runner.os }}-cargo-uv-build-${{ hashFiles('litellm-rust/Cargo.lock') }}
+          litellm-rust/target
+        key: ${{ runner.os }}-cargo-release-${{ hashFiles('litellm-rust/Cargo.lock') }}
         restore-keys: |
-          ${{ runner.os }}-cargo-uv-build-
+          ${{ runner.os }}-cargo-release-

--- a/.github/workflows/_test-unit-base.yml
+++ b/.github/workflows/_test-unit-base.yml
@@ -27,7 +27,7 @@ on:
         default: 20
       job-timeout-minutes:
         description: >-
-          Backstop for the whole job. Keep it >= `timeout-minutes` plus 35: 30 for
+          Backstop for the whole job. Keep it >= `timeout-minutes` plus 40: 35 for
           the per-step ceilings on the setup steps below, and 5 for the runner
           overhead the job clock charges but no step owns (job init, step
           transitions, post-job cleanup). That headroom is what makes the test
@@ -36,7 +36,7 @@ on:
           arithmetic, so the sum is passed in rather than computed.
         required: false
         type: number
-        default: 55
+        default: 60
       max-failures:
         description: "Stop after this many failures"
         required: false

--- a/.github/workflows/_test-unit-base.yml
+++ b/.github/workflows/_test-unit-base.yml
@@ -103,6 +103,11 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-uv-
 
+      - name: Cache the Rust build
+        if: steps.changes.outputs.decision != 'skip'
+        timeout-minutes: 5
+        uses: ./.github/actions/cache-cargo-build
+
       - name: Install dependencies
         if: steps.changes.outputs.decision != 'skip'
         timeout-minutes: 8

--- a/.github/workflows/check-ui-api-types.yml
+++ b/.github/workflows/check-ui-api-types.yml
@@ -67,6 +67,10 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-uv-
 
+      - name: Cache the Rust build
+        if: steps.changes.outputs.relevant == 'true'
+        uses: ./.github/actions/cache-cargo-build
+
       - name: Install backend dependencies
         if: steps.changes.outputs.relevant == 'true'
         run: .github/scripts/uv_sync_with_retries.sh --frozen --group ci --group proxy-dev --extra google --extra proxy --extra semantic-router

--- a/.github/workflows/mutation-test.yml
+++ b/.github/workflows/mutation-test.yml
@@ -53,6 +53,9 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-uv-
 
+      - name: Cache the Rust build
+        uses: ./.github/actions/cache-cargo-build
+
       - name: Install dependencies
         run: |
           .github/scripts/uv_sync_with_retries.sh --frozen --group ci --group proxy-dev --extra google --extra proxy --extra semantic-router --extra saml

--- a/.github/workflows/publish-basedpyright-base-counts.yml
+++ b/.github/workflows/publish-basedpyright-base-counts.yml
@@ -43,6 +43,9 @@ jobs:
         with:
           version: "0.10.9"
 
+      - name: Cache the Rust build
+        uses: ./.github/actions/cache-cargo-build
+
       - name: Cache Prisma binaries
         uses: ./.github/actions/cache-prisma-binaries
 

--- a/.github/workflows/test-code-quality.yml
+++ b/.github/workflows/test-code-quality.yml
@@ -56,6 +56,9 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-uv-
 
+      - name: Cache the Rust build
+        uses: ./.github/actions/cache-cargo-build
+
       - name: Install dependencies
         run: uv sync --frozen --all-groups --all-extras
 

--- a/.github/workflows/test-linting.yml
+++ b/.github/workflows/test-linting.yml
@@ -78,6 +78,10 @@ jobs:
         run: |
           uv lock --check || (echo "❌ uv.lock is out of sync with pyproject.toml. Run 'uv lock' locally and commit the result." && exit 1)
 
+      - name: Cache the Rust build
+        if: steps.changes.outputs.decision != 'skip'
+        uses: ./.github/actions/cache-cargo-build
+
       - name: Install dependencies
         if: steps.changes.outputs.decision != 'skip'
         run: |

--- a/.github/workflows/test-mcp.yml
+++ b/.github/workflows/test-mcp.yml
@@ -47,6 +47,10 @@ jobs:
         with:
           version: "0.10.9"
 
+      - name: Cache the Rust build
+        if: steps.changes.outputs.decision != 'skip'
+        uses: ./.github/actions/cache-cargo-build
+
       - name: Install dependencies
         if: steps.changes.outputs.decision != 'skip'
         run: |

--- a/.github/workflows/test-terraform-provider.yml
+++ b/.github/workflows/test-terraform-provider.yml
@@ -88,6 +88,9 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-uv-
 
+      - name: Cache the Rust build
+        uses: ./.github/actions/cache-cargo-build
+
       - name: Install dependencies
         run: |
           .github/scripts/uv_sync_with_retries.sh --frozen --group ci --group proxy-dev --extra google --extra proxy --extra semantic-router

--- a/.github/workflows/test-unit-documentation.yml
+++ b/.github/workflows/test-unit-documentation.yml
@@ -67,6 +67,10 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-uv-
 
+      - name: Cache the Rust build
+        if: steps.changes.outputs.decision != 'skip'
+        uses: ./.github/actions/cache-cargo-build
+
       - name: Install dependencies
         if: steps.changes.outputs.decision != 'skip'
         run: |

--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -55,7 +55,7 @@ jobs:
             workers: 2
             reruns: 1
             timeout-minutes: 20
-            job-timeout-minutes: 55
+            job-timeout-minutes: 60
 
           - shard: enterprise-routing
             artifact-name: enterprise-routing
@@ -67,7 +67,7 @@ jobs:
             workers: 2
             reruns: 2
             timeout-minutes: 20
-            job-timeout-minutes: 55
+            job-timeout-minutes: 60
 
           - shard: integrations
             artifact-name: integrations
@@ -75,7 +75,7 @@ jobs:
             workers: 2
             reruns: 3
             timeout-minutes: 20
-            job-timeout-minutes: 55
+            job-timeout-minutes: 60
 
           - shard: Vertex AI
             artifact-name: llm-vertex-ai
@@ -83,7 +83,7 @@ jobs:
             workers: 1
             reruns: 2
             timeout-minutes: 20
-            job-timeout-minutes: 55
+            job-timeout-minutes: 60
 
           - shard: All Other Providers
             artifact-name: llm-other-providers
@@ -91,7 +91,7 @@ jobs:
             workers: 2
             reruns: 2
             timeout-minutes: 20
-            job-timeout-minutes: 55
+            job-timeout-minutes: 60
 
           - shard: misc
             artifact-name: misc
@@ -122,7 +122,7 @@ jobs:
             workers: 2
             reruns: 2
             timeout-minutes: 20
-            job-timeout-minutes: 55
+            job-timeout-minutes: 60
 
           - shard: proxy-auth
             artifact-name: proxy-auth
@@ -134,7 +134,7 @@ jobs:
             workers: 2
             reruns: 2
             timeout-minutes: 20
-            job-timeout-minutes: 55
+            job-timeout-minutes: 60
 
           - shard: proxy-endpoints
             artifact-name: proxy-endpoints
@@ -171,7 +171,7 @@ jobs:
             workers: 2
             reruns: 2
             timeout-minutes: 20
-            job-timeout-minutes: 55
+            job-timeout-minutes: 60
 
           - shard: proxy-server
             artifact-name: proxy-server
@@ -179,7 +179,7 @@ jobs:
             workers: 4
             reruns: 2
             timeout-minutes: 60
-            job-timeout-minutes: 95
+            job-timeout-minutes: 100
 
           - shard: proxy-infra
             artifact-name: proxy-infra
@@ -198,7 +198,7 @@ jobs:
             workers: 2
             reruns: 2
             timeout-minutes: 20
-            job-timeout-minutes: 55
+            job-timeout-minutes: 60
 
           - shard: responses-caching-types
             artifact-name: responses-caching-types
@@ -209,7 +209,7 @@ jobs:
             workers: 2
             reruns: 2
             timeout-minutes: 20
-            job-timeout-minutes: 55
+            job-timeout-minutes: 60
     uses: ./.github/workflows/_test-unit-base.yml
     with:
       test-path: ${{ matrix.test-path }}

--- a/.github/workflows/weekly_load_anomaly.yml
+++ b/.github/workflows/weekly_load_anomaly.yml
@@ -47,6 +47,9 @@ jobs:
         with:
           version: "0.10.9"
 
+      - name: Cache the Rust build
+        uses: ./.github/actions/cache-cargo-build
+
       - name: Install dependencies
         run: |
           .github/scripts/uv_sync_with_retries.sh --frozen --group ci --group proxy-dev --extra proxy

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ __pycache__/
 litellm/rust_bridge/_native*.so
 litellm/rust_bridge/_native*.pyd
 litellm-rust/target/
+.cargo-target/
 
 # Python package build output
 dist/

--- a/.gitignore
+++ b/.gitignore
@@ -17,7 +17,6 @@ __pycache__/
 litellm/rust_bridge/_native*.so
 litellm/rust_bridge/_native*.pyd
 litellm-rust/target/
-.cargo-target/
 
 # Python package build output
 dist/


### PR DESCRIPTION
## TLDR

Problem this solves:

- Every job that installs the workspace compiles the Rust bridge
- maturin builds it in release mode before any wheel exists
- 163s a unit shard, 11 shards, plus five more workflows
- Nothing caches it, so every job pays in full

How it solves it:

- Cache Cargo's registry and target directory, keyed on `Cargo.lock`
- Cargo then rebuilds only the crate that changed
- Wired into all ten workflows that sync the workspace

## User Flow

No end-user behavior changes. This is CI wall clock. A contributor opening a PR
waits on the same checks, each of which stops paying a full release build of the
Rust bridge before it can start doing its own work.

## Relevant issues

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

Numbers below are the `Install dependencies` step, read from the GitHub Actions
jobs API. Before is the last staging run of each workflow, after is this branch.

### Before (ff02d5cfc0)

#### Where the time goes in one unit shard

1. Read the step log for `core-utils / Run tests` in the last staging run of
   `test-unit.yml`
2. The whole step is three local packages being built, and `litellm` is the one
   with a Rust extension behind it:

```
07:03:47  Building litellm @ file:///home/runner/work/litellm/litellm
07:03:47  Building litellm-enterprise @ ...
07:03:47  Building litellm-proxy-extras @ ...
07:06:28  Prepared 3 packages in 2m 40s
07:06:28  Installed 3 packages in 2ms
```

#### Across the eleven unit shards

1. Mean and total of the same step, over the run's eleven `Run tests` jobs
2. Output:

```
Install dependencies     n=11  mean=   163s  total=  1794s
Run tests                n=11  mean=   195s  total=  2149s
```

#### The other five workflows that sync the workspace

```
lint                                       165s
test-mcp / test                            177s
documentation                              163s
Verify schema.d.ts matches the OpenAPI     154s
code-quality                               138s
```

### After (7b2a6222a0)

#### Across the eleven unit shards

1. Same measurement on this branch
2. Output:

```
Cache the Rust build     n=11  mean=     5s  total=    59s
Install dependencies     n=11  mean=    34s  total=   369s
```

3. The cache is a hit and the build is what is left of the step:

```
08:13:35  key: Linux-cargo-release-723fc218a0833e635166f83ee295ea7dcd567e4f1128b6378a069afd358be1f1
08:13:35  Cache hit for: Linux-cargo-release-723fc218a0...
08:13:37  Received 247491720 of 247491720 (100.0%), 147.7 MBs/sec
08:14:08  Prepared 3 packages in 28.07s
```

#### The other five workflows that sync the workspace

```
lint                                        37s
test-mcp / test                             35s
documentation                               39s
Verify schema.d.ts matches the OpenAPI      37s
code-quality                                32s
```

#### What that adds up to

1. 11 x 129s on the unit tier plus 106s to 142s on each of the other five
2. Roughly 32 minutes of runner time per PR, and about two minutes off the wall
   clock of every one of those checks

#### Cold and warm

1. The first job on a new `Cargo.lock` still builds from scratch and saves the
   entry, and every job after that restores it. The 236 MB entry above was
   written by an earlier run on this PR and read by all eleven shards here
2. Locally, the same build measures 34s cold against 8s warm, including after a
   Python-only edit and after a Rust-only edit

## Type

🚄 Infrastructure

## Caveats (if any)

- The key namespace is separate from test-rust.yml's debug artifacts
- The setup ceiling moves 30m to 35m, so job backstops follow
- test-linting.yml is also touched by #37783

- The counts publisher syncs inside `type_check_gate.py`, not a step
- `weekly_load_anomaly.yml` still has no uv cache, left as its own change

### Final Attestation

- [ ] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

