### PR TITLE
fix(zai): translate response_format into a forced tool call

### DIFF
--- a/litellm/llms/base_llm/chat/transformation.py
+++ b/litellm/llms/base_llm/chat/transformation.py
@@ -219,8 +219,12 @@ class BaseConfig(ABC):
                 function=ChatCompletionToolParamFunctionChunk(name=RESPONSE_FORMAT_TOOL_NAME, parameters=json_schema),
             )
 
-            optional_params.setdefault("tools", [])
-            optional_params["tools"].append(_tool)
+            # Rebind instead of appending: _map_openai_params aliases the caller's own
+            # tools list into optional_params, so append() would mutate it across calls.
+            optional_params["tools"] = [  # mutable-ok: JSON request body
+                *optional_params.get("tools", []),
+                _tool,
+            ]
             if enforce_tool_choice:
                 optional_params["tool_choice"] = _tool_choice
 

--- a/litellm/llms/openai/openai.py
+++ b/litellm/llms/openai/openai.py
@@ -616,6 +616,9 @@ class OpenAIChatCompletion(BaseLLM, BaseOpenAILLM):
             inference_params = optional_params.copy()
             stream_options: Final[dict | None] = inference_params.pop("stream_options", None)
             stream: Final[bool | None] = inference_params.pop("stream", False)
+            # Set by BaseConfig._add_response_format_to_tools, not an SDK argument. The
+            # OpenAI SDK rejects unknown kwargs, so it has to come off before the call.
+            json_mode: Final[bool | None] = inference_params.pop("json_mode", False)
             provider_config: BaseConfig | None = None
 
             if custom_llm_provider is not None and model is not None:
@@ -693,6 +696,7 @@ class OpenAIChatCompletion(BaseLLM, BaseOpenAILLM):
                                 drop_params=drop_params,
                                 fake_stream=fake_stream,
                                 shared_session=shared_session,
+                                json_mode=json_mode,
                             )
 
                     data = provider_config.transform_request(
@@ -766,6 +770,7 @@ class OpenAIChatCompletion(BaseLLM, BaseOpenAILLM):
                             response_object=stringified_response,
                             model_response_object=model_response,
                             _response_headers=headers,
+                            convert_tool_call_to_json_mode=json_mode,
                         )
                         if fake_stream is True:
                             return self.mock_streaming(
@@ -849,6 +854,7 @@ class OpenAIChatCompletion(BaseLLM, BaseOpenAILLM):
         stream_options: dict | None = None,
         fake_stream: bool = False,
         shared_session: Optional["ClientSession"] = None,
+        json_mode: bool | None = None,
     ):
         response = None
         data = await provider_config.async_transform_request(
@@ -903,6 +909,7 @@ class OpenAIChatCompletion(BaseLLM, BaseOpenAILLM):
                     model_response_object=model_response,
                     hidden_params={"headers": headers},
                     _response_headers=headers,
+                    convert_tool_call_to_json_mode=json_mode,
                 )
 
                 # Call agentic completion hooks (e.g., for websearch_interception)

--- a/litellm/llms/zai/chat/transformation.py
+++ b/litellm/llms/zai/chat/transformation.py
@@ -43,6 +43,7 @@ class ZAIChatConfig(OpenAIGPTConfig):
             "stop",
             "tools",
             "tool_choice",
+            "response_format",
         ]
 
         import litellm
@@ -54,3 +55,61 @@ class ZAIChatConfig(OpenAIGPTConfig):
             pass
 
         return base_params
+
+    def map_openai_params(
+        self,
+        non_default_params: dict,
+        optional_params: dict,
+        model: str,
+        drop_params: bool,
+    ) -> dict:
+        """
+        Translate response_format into a forced tool call.
+
+        GLM ignores response_format but honours a forced tool call, so a schema only
+        survives the round trip as one. See BerriAI/litellm#37720.
+        """
+        response_format: Final = non_default_params.get("response_format")
+        optional_params = super().map_openai_params(
+            non_default_params=non_default_params,
+            optional_params=optional_params,
+            model=model,
+            drop_params=drop_params,
+        )
+        if not self._should_translate_response_format(non_default_params, response_format):
+            return optional_params
+
+        # super() copied response_format through as an allowlisted param. GLM ignores
+        # it, so trade it for the tool call the model does honour.
+        optional_params.pop("response_format", None)
+        return self._add_response_format_to_tools(
+            optional_params=optional_params,
+            value=response_format,
+            is_response_format_supported=False,
+        )
+
+    @staticmethod
+    def _should_translate_response_format(non_default_params: dict, response_format: dict | None) -> bool:
+        """
+        Only translate when the forced tool call can actually be unwrapped again.
+
+        Otherwise response_format is left to pass through: GLM ignores it, which is
+        the pre-existing behaviour and better than an unusable tool call.
+        """
+        if response_format is None:
+            return False
+        # Forcing json_tool_call would hijack a caller that is genuinely using tools.
+        if non_default_params.get("tools"):
+            return False
+        # The unwrap back into message.content only runs on non-streaming responses.
+        if non_default_params.get("stream"):
+            return False
+        # Mirror _add_response_format_to_tools' own extraction, key presence included,
+        # so this never pops response_format for a schema the helper would ignore.
+        if "response_schema" in response_format:
+            json_schema = response_format["response_schema"]
+        elif "json_schema" in response_format:
+            json_schema = response_format["json_schema"].get("schema")
+        else:
+            json_schema = None
+        return bool(json_schema)

--- a/tests/test_litellm/llms/zai/test_zai_response_format.py
+++ b/tests/test_litellm/llms/zai/test_zai_response_format.py
@@ -1,0 +1,274 @@
+"""
+Tests for response_format support on the Z.AI (GLM) provider.
+
+GLM ignores response_format but honours a forced tool call, so litellm translates a
+schema into one. Regression cover for BerriAI/litellm#37720.
+"""
+
+import json
+
+import httpx
+import pytest
+
+import litellm
+from litellm.constants import RESPONSE_FORMAT_TOOL_NAME
+from litellm.llms.zai.chat.transformation import ZAIChatConfig
+from litellm.utils import get_optional_params
+
+ZAI_URL = "https://api.z.ai/api/paas/v4/chat/completions"
+
+SCHEMA = {
+    "type": "object",
+    "properties": {"entities": {"type": "array", "items": {"type": "string"}}},
+    "required": ["entities"],
+    "additionalProperties": False,
+}
+JSON_SCHEMA_FORMAT = {
+    "type": "json_schema",
+    "json_schema": {"name": "ents", "strict": True, "schema": SCHEMA},
+}
+TOOL_ARGUMENTS = json.dumps({"entities": ["Alice", "service"]})
+MESSAGES = [{"role": "user", "content": "Extract entities from: Alice deployed a service."}]
+
+
+@pytest.fixture
+def tool_call_reply():
+    """Z.AI reply to a forced json_tool_call: the schema-valid payload is the arguments."""
+    return {
+        "id": "chatcmpl-zai-rf",
+        "object": "chat.completion",
+        "created": 1677652288,
+        "model": "glm-5-turbo",
+        "choices": [
+            {
+                "index": 0,
+                "finish_reason": "tool_calls",
+                "message": {
+                    "role": "assistant",
+                    "content": None,
+                    "tool_calls": [
+                        {
+                            "id": "call_1",
+                            "type": "function",
+                            "function": {
+                                "name": RESPONSE_FORMAT_TOOL_NAME,
+                                "arguments": TOOL_ARGUMENTS,
+                            },
+                        }
+                    ],
+                },
+            }
+        ],
+        "usage": {"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15},
+    }
+
+
+def test_response_format_is_a_supported_param():
+    """response_format must be allowlisted, or get_optional_params drops it before mapping."""
+    assert "response_format" in ZAIChatConfig().get_supported_openai_params(model="glm-5-turbo")
+
+
+def test_json_schema_becomes_a_forced_tool_call():
+    optional_params = get_optional_params(
+        model="glm-5-turbo",
+        custom_llm_provider="zai",
+        response_format=JSON_SCHEMA_FORMAT,
+    )
+
+    assert "response_format" not in optional_params, "GLM ignores response_format; it must be translated"
+    assert optional_params["tools"] == [
+        {
+            "type": "function",
+            "function": {"name": RESPONSE_FORMAT_TOOL_NAME, "parameters": SCHEMA},
+        }
+    ]
+    assert optional_params["tool_choice"] == {
+        "type": "function",
+        "function": {"name": RESPONSE_FORMAT_TOOL_NAME},
+    }
+    assert optional_params["json_mode"] is True
+
+
+def test_json_schema_is_translated_even_when_drop_params_is_set():
+    """The silent-drop path in the bug report: drop_params must no longer swallow the schema."""
+    optional_params = get_optional_params(
+        model="glm-5-turbo",
+        custom_llm_provider="zai",
+        response_format=JSON_SCHEMA_FORMAT,
+        drop_params=True,
+    )
+
+    assert optional_params["tools"][0]["function"]["parameters"] == SCHEMA
+    assert optional_params["json_mode"] is True
+
+
+def test_json_object_is_forwarded_unchanged():
+    """No schema to translate. GLM returns arbitrary-shaped but valid JSON, so forward it."""
+    optional_params = get_optional_params(
+        model="glm-5-turbo",
+        custom_llm_provider="zai",
+        response_format={"type": "json_object"},
+    )
+
+    assert optional_params["response_format"] == {"type": "json_object"}
+    assert "json_mode" not in optional_params
+    assert "tools" not in optional_params
+
+
+def _caller_tool():
+    return {
+        "type": "function",
+        "function": {"name": "get_weather", "parameters": {"type": "object", "properties": {}}},
+    }
+
+
+def test_caller_supplied_tools_are_left_alone():
+    """
+    Forcing json_tool_call would hijack a caller that is genuinely using tools, and an
+    unforced one would leave nothing constraining the model. Neither is translated.
+    """
+    optional_params = get_optional_params(
+        model="glm-5-turbo",
+        custom_llm_provider="zai",
+        tools=[_caller_tool()],
+        response_format=JSON_SCHEMA_FORMAT,
+    )
+
+    assert optional_params["tools"] == [_caller_tool()]
+    assert "tool_choice" not in optional_params
+    assert optional_params["response_format"] == JSON_SCHEMA_FORMAT
+    assert "json_mode" not in optional_params
+
+
+def test_caller_tools_list_is_not_mutated_across_calls():
+    """
+    _map_openai_params aliases the caller's list into optional_params, so appending the
+    generated tool would corrupt a module-level TOOLS list on every turn of an agent loop.
+    """
+    caller_tools = [_caller_tool()]
+
+    for _ in range(3):
+        get_optional_params(
+            model="glm-5-turbo",
+            custom_llm_provider="zai",
+            tools=caller_tools,
+            response_format=JSON_SCHEMA_FORMAT,
+        )
+
+    assert [tool["function"]["name"] for tool in caller_tools] == ["get_weather"]
+
+
+def test_base_helper_does_not_mutate_the_tools_it_is_given():
+    """Direct cover for the shared helper, which azure and fireworks_ai also call."""
+    caller_tools = [_caller_tool()]
+    optional_params = ZAIChatConfig()._add_response_format_to_tools(
+        optional_params={"tools": caller_tools},
+        value=JSON_SCHEMA_FORMAT,
+        is_response_format_supported=False,
+    )
+
+    assert len(optional_params["tools"]) == 2
+    assert [tool["function"]["name"] for tool in caller_tools] == ["get_weather"]
+
+
+def test_falsy_response_schema_is_not_silently_dropped():
+    """
+    The helper extracts response_schema by key presence, so a present-but-empty one makes
+    it a no-op. Translating anyway would pop response_format and lose the schema entirely.
+    """
+    response_format = {
+        "type": "json_schema",
+        "response_schema": {},
+        "json_schema": {"name": "ents", "schema": SCHEMA},
+    }
+
+    optional_params = get_optional_params(
+        model="glm-5-turbo",
+        custom_llm_provider="zai",
+        response_format=response_format,
+    )
+
+    assert optional_params["response_format"] == response_format
+    assert "tools" not in optional_params
+
+
+def test_completion_unwraps_the_tool_call_into_content(respx_mock, tool_call_reply, monkeypatch):
+    """End-to-end: json_mode must not reach the SDK, and the arguments become the content."""
+    monkeypatch.setenv("ZAI_API_KEY", "test-api-key")
+    monkeypatch.setattr(litellm, "disable_aiohttp_transport", True)
+    route = respx_mock.post(ZAI_URL).mock(return_value=httpx.Response(200, json=tool_call_reply))
+
+    response = litellm.completion(
+        model="zai/glm-5-turbo",
+        messages=MESSAGES,
+        response_format=JSON_SCHEMA_FORMAT,
+        max_tokens=100,
+    )
+
+    assert json.loads(response.choices[0].message.content) == {"entities": ["Alice", "service"]}
+    assert response.choices[0].message.tool_calls is None
+    assert response.choices[0].finish_reason == "stop"
+
+    request_body = json.loads(route.calls[0].request.content)
+    assert "json_mode" not in request_body, "json_mode is internal; the OpenAI SDK rejects it"
+    assert request_body["tool_choice"]["function"]["name"] == RESPONSE_FORMAT_TOOL_NAME
+
+
+@pytest.mark.asyncio
+async def test_acompletion_unwraps_the_tool_call_into_content(respx_mock, tool_call_reply, monkeypatch):
+    monkeypatch.setenv("ZAI_API_KEY", "test-api-key")
+    monkeypatch.setattr(litellm, "disable_aiohttp_transport", True)
+    route = respx_mock.post(ZAI_URL).mock(return_value=httpx.Response(200, json=tool_call_reply))
+
+    response = await litellm.acompletion(
+        model="zai/glm-5-turbo",
+        messages=MESSAGES,
+        response_format=JSON_SCHEMA_FORMAT,
+        max_tokens=100,
+    )
+
+    assert json.loads(response.choices[0].message.content) == {"entities": ["Alice", "service"]}
+    assert response.choices[0].finish_reason == "stop"
+
+    request_body = json.loads(route.calls[0].request.content)
+    assert "json_mode" not in request_body
+
+
+def test_streaming_is_left_untranslated(respx_mock, monkeypatch):
+    """
+    The unwrap back into message.content only runs on non-streaming responses, so a
+    forced tool call here would hand the caller a stream of unusable tool_calls.
+    """
+    monkeypatch.setenv("ZAI_API_KEY", "test-api-key")
+    monkeypatch.setattr(litellm, "disable_aiohttp_transport", True)
+    chunk = {
+        "id": "chatcmpl-zai-rf",
+        "object": "chat.completion.chunk",
+        "created": 1677652288,
+        "model": "glm-5-turbo",
+        "choices": [{"index": 0, "delta": {"role": "assistant", "content": "hi"}, "finish_reason": "stop"}],
+    }
+    route = respx_mock.post(ZAI_URL).mock(
+        return_value=httpx.Response(
+            200,
+            text=f"data: {json.dumps(chunk)}\n\ndata: [DONE]\n\n",
+            headers={"content-type": "text/event-stream"},
+        )
+    )
+
+    chunks = list(
+        litellm.completion(
+            model="zai/glm-5-turbo",
+            messages=MESSAGES,
+            response_format=JSON_SCHEMA_FORMAT,
+            max_tokens=100,
+            stream=True,
+        )
+    )
+
+    assert [chunk.choices[0].delta.content for chunk in chunks][0] == "hi"
+    request_body = json.loads(route.calls[0].request.content)
+    assert "json_mode" not in request_body
+    assert "tool_choice" not in request_body, "a forced tool call cannot be unwrapped mid-stream"
+    assert request_body["response_format"] == JSON_SCHEMA_FORMAT
+    assert request_body["stream"] is True


### PR DESCRIPTION
## TLDR

Problem this solves:

- `zai` never forwarded `response_format`, so GLM structured output was impossible
- Silent under `drop_params`: proxy returns 200, downstream JSON parsing fails
- The existing schema-to-tool-call translation was unreachable from the OpenAI SDK handler

How it solves it:

- Allowlist `response_format` on `zai` and translate a schema to a forced tool call
- Pop the internal `json_mode` flag in the OpenAI SDK handler, as `azure` already does
- Unwrap that tool call back into `message.content`, so callers see plain JSON

## User Flow

Before: a developer whose app asks a GLM model for JSON against a strict schema gets prose back, and their parser fails on every response

1. They add `model_name: glm-5-turbo` with `litellm_params.model: zai/glm-5-turbo` to the proxy config, with `litellm_settings.drop_params: true`
2. They send POST https://litellm-domain/v1/chat/completions with `"response_format": {"type": "json_schema", "json_schema": {"name": "ents", "strict": true, "schema": {...}}}`
3. The response comes back HTTP 200 with `choices[0].message.content` holding prose or a markdown table, not JSON
4. Their app's `json.loads` on that content raises, so every request fails downstream while https://litellm-domain/ui/?page=logs shows a clean 200
5. Turning `drop_params` off replaces the silent failure with HTTP 400 `zai does not support parameters: ['response_format']`, so there is no configuration that works

After: the same request returns JSON matching the schema they asked for

1. They add the same `glm-5-turbo` deployment to the proxy config, with or without `drop_params`
2. They send the same POST https://litellm-domain/v1/chat/completions with the same strict `json_schema`
3. The response comes back HTTP 200 with `choices[0].message.content` holding `{"entities": ["Alice", "service"]}` and `finish_reason: "stop"`
4. Their app's `json.loads` succeeds and the parsed object satisfies the schema

## Relevant issues

Fixes #37720

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Live calls against the GLM Coding Plan endpoint (`ZAI_API_BASE=https://api.z.ai/api/coding/paas/v4`), no mocks. Shared setup for every case below:

```python
SCHEMA = {"type": "object",
          "properties": {"entities": {"type": "array", "items": {"type": "string"}}},
          "required": ["entities"], "additionalProperties": False}
RESPONSE_FORMAT = {"type": "json_schema",
                   "json_schema": {"name": "ents", "strict": True, "schema": SCHEMA}}
PROMPT = 'Extract entities from: "Alice deployed a service."'

litellm.completion(model=MODEL, api_base=os.environ["ZAI_API_BASE"],
                   messages=[{"role": "user", "content": PROMPT}],
                   response_format=RESPONSE_FORMAT, max_tokens=3000,
                   drop_params=DROP_PARAMS)
```

### Before (9432f40145)

#### glm-5.3

1. `drop_params=False` -> `litellm.UnsupportedParamsError: zai does not support parameters: ['response_format'], for model=glm-5.3`
2. `drop_params=True` -> HTTP 200, `message.content` is a markdown table:

```
**Entities extracted:**

| Entity | Type |
|--------|------|
| Alice | PERSON |

**Notes:**
- "Alice" is the only named entity in the sentence (a person's name).
- "service" is a generic common noun ...
```

3. `json.loads` on that content raises `Expecting value: line 1 column 1 (char 0)`. SCHEMA-VALID: NO

#### glm-5-turbo

1. `drop_params=False` -> `litellm.UnsupportedParamsError: zai does not support parameters: ['response_format'], for model=glm-5-turbo`
2. `drop_params=True` -> HTTP 200, `message.content` is prose:

```
Here are the entities extracted from the sentence:

* **Alice** -> Person
* **service** -> Software / System / IT Asset

*(Note: "deployed" is an action/verb, not an entity)*
```

3. `json.loads` on that content raises `Expecting value: line 1 column 1 (char 0)`. SCHEMA-VALID: NO

### After (95e321cc75)

#### glm-5.3

1. `drop_params=False` -> HTTP 200, `message.content` is `{"entities":["Alice", "service"]}`
2. `drop_params=True` -> HTTP 200, `message.content` is `{"entities":["Alice", "deployed", "service"]}`
3. `json.loads` succeeds on both and the object satisfies the schema. SCHEMA-VALID: YES

#### glm-5-turbo

1. `drop_params=False` -> HTTP 200, `message.content` is `{"entities":["Alice","service"]}`
2. `drop_params=True` -> HTTP 200, `message.content` is `{"entities":["Alice","service"]}`
3. `json.loads` succeeds on both and the object satisfies the schema. SCHEMA-VALID: YES

## Type

🐛 Bug Fix

## Caveats (if any)

- `glm-4.7` emits no tool call, so it stays unfixed by this
- Streaming is deliberately untranslated: a forced tool call cannot be unwrapped mid-stream
- `tools` plus `response_format` is untranslated too; nothing could force both
- `enforce_validation` still cannot see `response_format` here, unchanged from before
- Model metadata (`supports_response_schema`) is still wrong for `zai`; separate PR

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

AI assistance used: Yes
Investigation, code, and tests written with Claude Code.
