### PR TITLE
ci: run the enterprise package suite in GitHub Actions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1274,40 +1274,6 @@ jobs:
           paths:
             - search_coverage.xml
             - search_coverage
-  litellm_mapped_enterprise_tests:
-    docker:
-      - *python312_image
-    working_directory: ~/project
-    resource_class: large
-
-    steps:
-      - checkout
-      - skip_if_unrelated_changes
-      - setup_google_dns
-      - install_uv
-      - install_rust
-      - run:
-          name: Install Dependencies
-          command: |
-            uv sync --frozen --all-groups --all-extras --python 3.12
-      - setup_litellm_enterprise_pip
-      - run:
-          name: Run enterprise tests
-          command: |
-            uv run --no-sync python -m prisma generate
-            mkdir -p test-results
-            TEST_FILES=$(circleci tests glob "tests/enterprise/**/test_*.py")
-            echo "$TEST_FILES" | circleci tests run \
-              --verbose \
-              --command="tr ' ' '\\n' | awk '/\\.py/ {print; next} {sub(/\\.[A-Z][^.]*$/, \"\"); gsub(/\\./, \"/\"); print \$0 \".py\"}' | xargs uv run --no-sync python -m pytest \
-                -v -x \
-                --junitxml=test-results/junit-enterprise.xml \
-                --durations=10 \
-                -n 4"
-          no_output_timeout: 15m
-      # Store test results
-      - store_test_results:
-          path: test-results
   batches_testing:
     docker:
       - *python312_image
@@ -3167,8 +3133,6 @@ workflows:
           filters: *main_branches
       - search_testing:
           filters: *main_branches
-      - litellm_mapped_enterprise_tests:
-          filters: *main_branches
       - batches_testing:
           filters: *main_branches
       - litellm_utils_testing:
@@ -3191,7 +3155,6 @@ workflows:
             - guardrails_testing
             - ocr_testing
             - search_testing
-            - litellm_mapped_enterprise_tests
             - batches_testing
             - litellm_utils_testing
             - pass_through_unit_testing

--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -200,6 +200,14 @@ jobs:
             timeout-minutes: 20
             job-timeout-minutes: 55
 
+          - shard: enterprise-package
+            artifact-name: enterprise-package
+            test-path: "tests/enterprise"
+            workers: 4
+            reruns: 2
+            timeout-minutes: 20
+            job-timeout-minutes: 55
+
           - shard: responses-caching-types
             artifact-name: responses-caching-types
             test-path: >-


### PR DESCRIPTION
## TLDR

Problem this solves:

- tests/enterprise runs only on CircleCI, which gates nothing
- 13 files and 244 tests with no say in a merge
- They cover enterprise guardrails, auth and management endpoints

How it solves it:

- Add the suite as a required GitHub Actions shard
- Delete the CircleCI job so it runs once

## User Flow

No end-user behavior changes. A contributor who breaks the enterprise package's
guardrail, auth or management endpoint behavior now sees a red required check
instead of a CircleCI job nobody waits on.

## Relevant issues

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

### Before (ff02d5cfc0)

#### No GitHub Actions job runs the suite

1. `grep -rl "tests/enterprise" .github/workflows/`
2. No output. The only job that runs it is CircleCI's `litellm_mapped_enterprise_tests`

#### The census only accepts it because CircleCI counts

1. Remove the shard this PR adds, then `python .github/scripts/assert_ci_coverage.py`
2. With the CircleCI job also gone, every file is named:

```
  - tests/enterprise/litellm_enterprise/enterprise_callbacks: 1 test file(s) invoked by no job: test_prometheus_logging_callbacks.py
  - tests/enterprise/litellm_enterprise/integrations: 3 test file(s) invoked by no job: test_custom_guardrail.py, test_prometheus.py, test_prometheus_unit_tests.py
  - tests/enterprise/litellm_enterprise/proxy/auth: 2 test file(s) invoked by no job: test_route_checks.py, test_user_api_key_auth.py
```

### After (88fbfd2fd8)

#### The shard runs and passes in GitHub Actions

1. `enterprise-package / Run tests` on this PR's run of `test-unit.yml`
2. Output:

```
============ 240 passed, 4 skipped, 9 warnings in 251.61s (0:04:11) ============
```

#### It needs no credential

1. Strip every credential-shaped variable from the environment, neutralise the
   repo `.env`, and run the suite against the unit base's exact dependency set
   (`uv sync --frozen --group ci --group proxy-dev --extra google --extra proxy
   --extra semantic-router --extra saml`)
2. Output:

```
240 passed, 4 skipped, 289 warnings in 247.34s (0:04:07)
```

#### Why only this suite

1. The same keyless run over every suite in this CircleCI group, on 2026-08-21
2. Only `tests/enterprise` comes back clean, so the rest each need a live-API
   lane before they can be required checks:

```
enterprise                   240 passed, 4 skipped
router_unit_tests             10 failed, 309 passed
guardrails_tests              22 failed, 464 passed
litellm_utils_tests           15 failed, 252 passed
pass_through_unit_tests       31 failed, 206 passed
logging_callback_tests        70 failed, 284 passed
llm_responses_api_testing     71 failed,  75 passed
search_tests                  11 failed,  61 passed
batches_tests                  6 failed,  40 passed
ocr_tests                      7 failed,  16 passed
audio_tests                   23 failed,   3 passed
unified_google_tests          19 failed,   0 passed
image_gen_tests               (live only)
agent_tests                   (collection error without credentials)
```

#### The census is satisfied without an allowlist entry

```
OK: 2430 test files and 10 Dockerfiles are each invoked by at least one job or carry an explicit allowlist entry.
OK: all 345 test children across 3 sharded trees are assigned to a shard.
OK: no test file is globbed by a job and then deselected by every -k across 35 slices.
```

## Type

🚄 Infrastructure
✅ Test

## Caveats (if any)

- Other CircleCI suites in this group carry a live-API minority
- Those need a scheduled lane first, so they are not ported here

### Final Attestation

- [ ] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

