### PR TITLE
fix(proxy): preserve AssemblyAI binary uploads and EU path routing

### DIFF
--- a/litellm/proxy/auth/user_api_key_auth.py
+++ b/litellm/proxy/auth/user_api_key_auth.py
@@ -107,6 +107,13 @@ except ImportError as e:
 
 user_api_key_service_logger_obj: Final = ServiceLogging()  # used for tracking latency on OTEL
 
+_ASSEMBLYAI_UPLOAD_ROUTES: Final = frozenset(
+    (
+        "/assemblyai/v2/upload",
+        "/eu.assemblyai/v2/upload",
+    )
+)
+
 
 def _normalize_public_auth_route(route: str) -> str:
     if route != "/" and route.endswith("/"):
@@ -1058,6 +1065,15 @@ async def _read_request_body_deferring_parse_failure(
     except ProxyException as parse_exception:
         return {}, parse_exception  # mutable-ok: request_data is a plain dict across the whole auth path
     return populate_request_with_path_params(request_data=parsed_body, request=request), None
+
+
+async def _read_request_data_for_auth(
+    request: Request,
+    route: str,
+) -> tuple[dict, ProxyException | None]:  # mutable-ok: request_data is a plain dict across the whole auth path
+    if request.method == "POST" and route.rstrip("/") in _ASSEMBLYAI_UPLOAD_ROUTES:
+        return {}, None  # mutable-ok: request_data is a plain dict across the whole auth path
+    return await _read_request_body_deferring_parse_failure(request=request)
 
 
 async def _record_unparsable_body_failure(
@@ -2644,8 +2660,8 @@ async def user_api_key_auth(
     # close, and the trace never reaches the backend.
     _ensure_parent_otel_span_on_request_state(request)
 
-    request_data, body_parse_exception = await _read_request_body_deferring_parse_failure(request=request)
     route: Final[str] = get_request_route(request=request)
+    request_data, body_parse_exception = await _read_request_data_for_auth(request=request, route=route)
     ## CHECK IF ROUTE IS ALLOWED
 
     # Run the whole auth phase inside a live ``auth`` span so the DB lookups it

--- a/litellm/proxy/auth/user_api_key_auth.py
+++ b/litellm/proxy/auth/user_api_key_auth.py
@@ -93,6 +93,7 @@ from litellm.proxy.utils import (
 )
 from litellm.repositories.table_repositories import TeamMembershipRepository
 from litellm.secret_managers.main import get_secret_bool
+from litellm.types.passthrough_endpoints.assembly_ai import ASSEMBLYAI_UPLOAD_ROUTES
 from litellm.types.services import ServiceTypes
 
 try:
@@ -106,13 +107,6 @@ except ImportError as e:
     enterprise_custom_auth = None
 
 user_api_key_service_logger_obj: Final = ServiceLogging()  # used for tracking latency on OTEL
-
-_ASSEMBLYAI_UPLOAD_ROUTES: Final = frozenset(
-    (
-        "/assemblyai/v2/upload",
-        "/eu.assemblyai/v2/upload",
-    )
-)
 
 
 def _normalize_public_auth_route(route: str) -> str:
@@ -1080,7 +1074,7 @@ async def _read_request_data_for_auth(
     request: Request,
     route: str,
 ) -> tuple[dict, ProxyException | None]:  # mutable-ok: request_data is a plain dict across the whole auth path
-    if _request_http_method(request) == "POST" and route.rstrip("/") in _ASSEMBLYAI_UPLOAD_ROUTES:
+    if _request_http_method(request) == "POST" and route.rstrip("/") in ASSEMBLYAI_UPLOAD_ROUTES:
         return {}, None  # mutable-ok: request_data is a plain dict across the whole auth path
     return await _read_request_body_deferring_parse_failure(request=request)
 

--- a/litellm/proxy/auth/user_api_key_auth.py
+++ b/litellm/proxy/auth/user_api_key_auth.py
@@ -1067,11 +1067,20 @@ async def _read_request_body_deferring_parse_failure(
     return populate_request_with_path_params(request_data=parsed_body, request=request), None
 
 
+def _request_http_method(request: Request) -> str | None:
+    scope: Final = getattr(request, "scope", None)
+    if isinstance(scope, dict):
+        method: Final = scope.get("method")
+        return method if isinstance(method, str) else None
+    fallback_method: Final = getattr(request, "method", None)
+    return fallback_method if isinstance(fallback_method, str) else None
+
+
 async def _read_request_data_for_auth(
     request: Request,
     route: str,
 ) -> tuple[dict, ProxyException | None]:  # mutable-ok: request_data is a plain dict across the whole auth path
-    if request.method == "POST" and route.rstrip("/") in _ASSEMBLYAI_UPLOAD_ROUTES:
+    if _request_http_method(request) == "POST" and route.rstrip("/") in _ASSEMBLYAI_UPLOAD_ROUTES:
         return {}, None  # mutable-ok: request_data is a plain dict across the whole auth path
     return await _read_request_body_deferring_parse_failure(request=request)
 

--- a/litellm/proxy/pass_through_endpoints/llm_passthrough_endpoints.py
+++ b/litellm/proxy/pass_through_endpoints/llm_passthrough_endpoints.py
@@ -1358,17 +1358,29 @@ async def assemblyai_proxy_route(
 
     ## check for streaming
     is_streaming_request = False
-    # assemblyai is streaming when 'stream' = True is in the body
-    if request.method == "POST":
+    is_upload_request: Final = request.method == "POST" and encoded_endpoint == "/v2/upload"
+    if is_upload_request:
+        setattr(
+            request.state,
+            LITELLM_PASS_THROUGH_RAW_BODY_STATE_KEY,
+            await request.body(),
+        )
+    elif request.method == "POST":
         _request_body: Final = await request.json()
         if _request_body.get("stream"):
             is_streaming_request = True
+
+    content_type: Final = request.headers.get("content-type")
+    assemblyai_headers: Final = {
+        "Authorization": f"{assemblyai_api_key}",
+        **({"Content-Type": content_type} if content_type else {}),
+    }
 
     ## CREATE PASS-THROUGH
     endpoint_func: Final = create_pass_through_route(
         endpoint=endpoint,
         target=str(updated_url),
-        custom_headers={"Authorization": f"{assemblyai_api_key}"},
+        custom_headers=assemblyai_headers,
         is_streaming_request=is_streaming_request,
     )  # dynamically construct pass-through endpoint based on incoming path
     received_value: Final = await endpoint_func(

--- a/litellm/proxy/pass_through_endpoints/llm_provider_handlers/assembly_passthrough_logging_handler.py
+++ b/litellm/proxy/pass_through_endpoints/llm_provider_handlers/assembly_passthrough_logging_handler.py
@@ -292,7 +292,8 @@ class AssemblyAIPassthroughLoggingHandler:
         """
         if url is None:
             return None
-        if urlparse(url).hostname == "eu.assemblyai.com":
+        parsed_url: Final = urlparse(url)
+        if parsed_url.hostname == "eu.assemblyai.com" or "eu.assemblyai" in parsed_url.path.split("/"):
             return "eu"
         return None
 

--- a/litellm/proxy/pass_through_endpoints/llm_provider_handlers/assembly_passthrough_logging_handler.py
+++ b/litellm/proxy/pass_through_endpoints/llm_provider_handlers/assembly_passthrough_logging_handler.py
@@ -293,7 +293,10 @@ class AssemblyAIPassthroughLoggingHandler:
         if url is None:
             return None
         parsed_url: Final = urlparse(url)
-        if parsed_url.hostname == "eu.assemblyai.com" or "eu.assemblyai" in parsed_url.path.split("/"):
+        if parsed_url.hostname in (
+            "eu.assemblyai.com",
+            "api.eu.assemblyai.com",
+        ) or "eu.assemblyai" in parsed_url.path.split("/"):
             return "eu"
         return None
 

--- a/litellm/proxy/pass_through_endpoints/pass_through_endpoints.py
+++ b/litellm/proxy/pass_through_endpoints/pass_through_endpoints.py
@@ -867,7 +867,9 @@ async def pass_through_request(
         # But if custom_body is provided (e.g., JSON parsed despite multipart content-type), use it
         is_multipart: Final = HttpPassThroughEndpointHelpers.is_multipart(request) and not custom_body
 
-        if custom_body:
+        if state_raw_body is not None:
+            _parsed_body = {}
+        elif custom_body:
             _parsed_body = custom_body
         elif is_multipart:
             # Don't parse multipart body here - it will be handled by make_multipart_http_request

--- a/litellm/types/passthrough_endpoints/assembly_ai.py
+++ b/litellm/types/passthrough_endpoints/assembly_ai.py
@@ -2,3 +2,9 @@ from typing import Final
 
 ASSEMBLY_AI_POLLING_INTERVAL: Final = 10
 ASSEMBLY_AI_MAX_POLLING_ATTEMPTS: Final = 180
+ASSEMBLYAI_UPLOAD_ROUTES: Final = frozenset(
+    (
+        "/assemblyai/v2/upload",
+        "/eu.assemblyai/v2/upload",
+    )
+)

--- a/tests/pass_through_unit_tests/test_assemblyai_unit_tests_passthrough.py
+++ b/tests/pass_through_unit_tests/test_assemblyai_unit_tests_passthrough.py
@@ -114,6 +114,20 @@ def test_poll_assembly_for_transcript_response(
             )
 
 
+@pytest.mark.parametrize(
+    ("url", "expected"),
+    (
+        ("http://localhost:4000/eu.assemblyai/v2/upload", "eu"),
+        ("http://127.0.0.1:4000/eu.assemblyai/v2/transcript", "eu"),
+        ("http://localhost:4000/assemblyai/v2/upload", None),
+        ("https://eu.assemblyai.com/v2/upload", "eu"),
+        (None, None),
+    ),
+)
+def test_get_assembly_region_from_proxy_path(url, expected):
+    assert AssemblyAIPassthroughLoggingHandler._get_assembly_region_from_url(url) == expected
+
+
 def test_is_assemblyai_route():
     """
     Test that the is_assemblyai_route method correctly identifies AssemblyAI routes

--- a/tests/pass_through_unit_tests/test_assemblyai_unit_tests_passthrough.py
+++ b/tests/pass_through_unit_tests/test_assemblyai_unit_tests_passthrough.py
@@ -121,6 +121,8 @@ def test_poll_assembly_for_transcript_response(
         ("http://127.0.0.1:4000/eu.assemblyai/v2/transcript", "eu"),
         ("http://localhost:4000/assemblyai/v2/upload", None),
         ("https://eu.assemblyai.com/v2/upload", "eu"),
+        ("https://api.eu.assemblyai.com/v2/transcript/abc", "eu"),
+        ("https://api.assemblyai.com/v2/transcript/abc", None),
         (None, None),
     ),
 )

--- a/tests/test_litellm/proxy/auth/test_user_api_key_auth.py
+++ b/tests/test_litellm/proxy/auth/test_user_api_key_auth.py
@@ -36,6 +36,7 @@ from litellm.proxy.auth.user_api_key_auth import (
     _check_key_model_budget_with_fallback,
     _PendingAutoRegister,
     _matches_routing_override,
+    _read_request_data_for_auth,
     _reserve_budget_after_common_checks,
     _route_requires_auth_despite_public,
     _routing_selector_matches_claim,
@@ -52,6 +53,27 @@ class _RoutingRequest:
         self.headers = headers or {}
         self.query_params = query_params or {}
         self.state = SimpleNamespace()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "route",
+    (
+        "/assemblyai/v2/upload",
+        "/eu.assemblyai/v2/upload",
+        "/eu.assemblyai/v2/upload/",
+    ),
+)
+async def test_regression_assemblyai_upload_auth_does_not_read_binary_body(route):
+    request = MagicMock()
+    request.method = "POST"
+    request.body = AsyncMock(return_value=bytes(range(256)) * 12289)
+
+    request_data, body_parse_exception = await _read_request_data_for_auth(request=request, route=route)
+
+    assert request_data == {}
+    assert body_parse_exception is None
+    request.body.assert_not_awaited()
 
 
 def test_get_api_key():

--- a/tests/test_litellm/proxy/auth/test_user_api_key_auth.py
+++ b/tests/test_litellm/proxy/auth/test_user_api_key_auth.py
@@ -12,7 +12,7 @@ sys.path.insert(
 )  # Adds the parent directory to the system path
 
 import pytest
-from fastapi import status
+from fastapi import Request, status
 
 import litellm
 import litellm.proxy.proxy_server
@@ -37,6 +37,7 @@ from litellm.proxy.auth.user_api_key_auth import (
     _PendingAutoRegister,
     _matches_routing_override,
     _read_request_data_for_auth,
+    _request_http_method,
     _reserve_budget_after_common_checks,
     _route_requires_auth_despite_public,
     _routing_selector_matches_claim,
@@ -74,6 +75,25 @@ async def test_regression_assemblyai_upload_auth_does_not_read_binary_body(route
     assert request_data == {}
     assert body_parse_exception is None
     request.body.assert_not_awaited()
+
+
+def test_request_http_method_from_scope_without_method():
+    request = Request({"type": "http", "path": "/chat/completions", "headers": []})
+
+    assert _request_http_method(request) is None
+
+
+@pytest.mark.asyncio
+async def test_read_request_data_for_auth_does_not_require_http_method():
+    request = Request({"type": "http", "path": "/chat/completions", "headers": []})
+
+    request_data, body_parse_exception = await _read_request_data_for_auth(
+        request=request,
+        route="/chat/completions",
+    )
+
+    assert request_data == {}
+    assert body_parse_exception is None
 
 
 def test_get_api_key():

--- a/tests/test_litellm/proxy/pass_through_endpoints/test_llm_pass_through_endpoints.py
+++ b/tests/test_litellm/proxy/pass_through_endpoints/test_llm_pass_through_endpoints.py
@@ -23,6 +23,7 @@ from litellm.proxy.pass_through_endpoints.llm_passthrough_endpoints import (
     BaseOpenAIPassThroughHandler,
     RouteChecks,
     _join_url_paths,
+    assemblyai_proxy_route,
     azure_proxy_route,
     bedrock_llm_proxy_route,
     bedrock_proxy_route,
@@ -40,7 +41,67 @@ from litellm.proxy.pass_through_endpoints.llm_passthrough_endpoints import (
     vllm_proxy_route,
 )
 from litellm.proxy._types import LitellmUserRoles, UserAPIKeyAuth
+from litellm.types.passthrough_endpoints.pass_through_endpoints import (
+    LITELLM_PASS_THROUGH_RAW_BODY_STATE_KEY,
+)
 from litellm.types.passthrough_endpoints.vertex_ai import VertexPassThroughCredentials
+
+
+@pytest.mark.asyncio
+async def test_regression_assemblyai_upload_preserves_raw_body_and_content_type():
+    raw_audio = b"\xff\x00binary-audio"
+    messages = ({"type": "http.request", "body": raw_audio, "more_body": False},)
+    message_iterator = iter(messages)
+
+    async def receive():
+        return next(message_iterator)
+
+    request = Request(
+        {
+            "type": "http",
+            "http_version": "1.1",
+            "method": "POST",
+            "scheme": "http",
+            "path": "/eu.assemblyai/v2/upload",
+            "raw_path": b"/eu.assemblyai/v2/upload",
+            "query_string": b"",
+            "headers": [(b"content-type", b"audio/mp4")],
+            "client": ("127.0.0.1", 1234),
+            "server": ("testserver", 80),
+        },
+        receive,
+    )
+
+    async def forward_request(**kwargs):
+        assert getattr(
+            kwargs["request"].state,
+            LITELLM_PASS_THROUGH_RAW_BODY_STATE_KEY,
+        ) == raw_audio
+        return {"upload_url": "https://cdn.assemblyai.com/upload/test"}
+
+    with (
+        patch(
+            "litellm.proxy.pass_through_endpoints.llm_passthrough_endpoints.passthrough_endpoint_router.get_credentials",
+            return_value="provider-key",
+        ),
+        patch(
+            "litellm.proxy.pass_through_endpoints.llm_passthrough_endpoints.create_pass_through_route",
+            return_value=forward_request,
+        ) as create_route,
+    ):
+        response = await assemblyai_proxy_route(
+            endpoint="v2/upload",
+            request=request,
+            fastapi_response=Response(),
+            user_api_key_dict=UserAPIKeyAuth(api_key="virtual-key"),
+        )
+
+    assert response == {"upload_url": "https://cdn.assemblyai.com/upload/test"}
+    assert create_route.call_args.kwargs["target"] == "https://api.eu.assemblyai.com/v2/upload"
+    assert create_route.call_args.kwargs["custom_headers"] == {
+        "Authorization": "provider-key",
+        "Content-Type": "audio/mp4",
+    }
 
 
 class TestVertexPassthroughGetVertexBaseUrl:

--- a/tests/test_litellm/proxy/pass_through_endpoints/test_pass_through_endpoints.py
+++ b/tests/test_litellm/proxy/pass_through_endpoints/test_pass_through_endpoints.py
@@ -3249,6 +3249,67 @@ async def test_pass_through_request_non_streaming_uses_content_for_state_raw_bod
 
 
 @pytest.mark.asyncio
+async def test_regression_pass_through_skips_json_parse_for_binary_state_raw_body():
+    raw_audio = b"\xff\x00binary-body"
+
+    mock_request = MagicMock(spec=Request)
+    mock_request.method = "POST"
+    mock_request.query_params = QueryParams({})
+    mock_request.headers = Headers({"Content-Type": "audio/mp4"})
+    mock_request.state = SimpleNamespace()
+    setattr(mock_request.state, LITELLM_PASS_THROUGH_RAW_BODY_STATE_KEY, raw_audio)
+    mock_request.body = AsyncMock(return_value=raw_audio)
+
+    mock_user = MagicMock()
+    mock_user.api_key = "sk-test"
+
+    upstream = httpx.Response(
+        status_code=200,
+        headers={"content-type": "application/json"},
+        content=b'{"upload_url": "https://cdn.assemblyai.com/upload/test"}',
+        request=httpx.Request("POST", "https://api.eu.assemblyai.com/v2/upload"),
+    )
+
+    mock_async_client = AsyncMock()
+    mock_async_client.build_request = MagicMock(return_value=MagicMock())
+    mock_async_client.send = AsyncMock(return_value=upstream)
+    mock_client_obj = MagicMock()
+    mock_client_obj.client = mock_async_client
+
+    with (
+        patch(
+            "litellm.proxy.pass_through_endpoints.pass_through_endpoints.get_async_httpx_client",
+            return_value=mock_client_obj,
+        ),
+        patch(
+            "litellm.proxy.proxy_server.proxy_logging_obj.pre_call_hook",
+            new=AsyncMock(side_effect=lambda **kwargs: kwargs["data"]),
+        ),
+        patch(
+            "litellm.proxy.proxy_server.proxy_logging_obj.post_call_response_headers_hook",
+            new=AsyncMock(return_value={}),
+        ),
+        patch(
+            "litellm.proxy.pass_through_endpoints.pass_through_endpoints.pass_through_endpoint_logging.pass_through_async_success_handler",
+            new=AsyncMock(),
+        ),
+    ):
+        await pass_through_request(
+            request=mock_request,
+            target="https://api.eu.assemblyai.com/v2/upload",
+            custom_headers={"content-type": "audio/mp4"},
+            user_api_key_dict=mock_user,
+            stream=False,
+        )
+
+    mock_request.body.assert_not_awaited()
+    mock_async_client.build_request.assert_called_once()
+    build_kw = mock_async_client.build_request.call_args[1]
+    assert build_kw.get("content") == raw_audio
+    assert "json" not in build_kw
+
+
+@pytest.mark.asyncio
 async def test_pass_through_request_streaming_uses_content_for_state_raw_body():
     """Streaming pass-through with state raw body must use build_request(..., content=...)."""
     raw_signed = b'{"model":"m","stream":true}'


### PR DESCRIPTION
## TLDR

Problem this solves:

- Binary POST `/eu.assemblyai/v2/upload` is rejected as invalid JSON
- `/eu.assemblyai/*` is forwarded to the US AssemblyAI host instead of EU

How it solves it:

- Skip JSON body parsing on the two `/v2/upload` routes and forward the raw bytes
- Treat `eu.assemblyai` in the proxy path as the EU region

## User Flow

Before: a developer uploading audio through the EU pass-through route gets a 400 and never reaches AssemblyAI

1. They send POST http://localhost:4000/eu.assemblyai/v2/upload with `Content-Type: audio/mp4` and a 1.2 MB binary body, authorized with the proxy master key
2. The proxy returns HTTP 400 with `Invalid JSON payload: str is not valid UTF-8: surrogates not allowed`
3. No `upload_url` comes back, so they cannot start a transcript against the EU region

After: the same upload is accepted and AssemblyAI EU returns an upload URL

1. They send the same POST http://localhost:4000/eu.assemblyai/v2/upload with `Content-Type: audio/mp4` and the same 1.2 MB binary body
2. The proxy returns HTTP 200 and `{"upload_url":"https://cdn.assemblyai.com/upload/..."}`
3. They can POST http://localhost:4000/eu.assemblyai/v2/transcript with that `audio_url` against the EU endpoint

## Relevant issues

Fixes #28747

Related: #22014 (open; it guards `request.json()` by content-type but still JSON-parses the body during auth, which is the 400 above)

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Shared setup: LiteLLM proxy on localhost with `ASSEMBLYAI_API_KEY` set, master key auth, no database. Payload is 1_200_000 bytes of non-UTF-8 audio (`binary-regression\x00\xff` repeated)

### Before (ff02d5cfc080c2d550d6eedbe4d9188677a9aa85)

1. `POST http://127.0.0.1:4001/eu.assemblyai/v2/upload` with `Content-Type: audio/mp4` and the 1.2 MB binary body
2. HTTP 400
3. `{"error":{"message":"Invalid JSON payload: str is not valid UTF-8: surrogates not allowed: line 1 column 1 (char 0)","type":"invalid_request_error","param":"request_body","code":"400"}}`

### After (d24cc855bf6bc63af99c49fb7bef7d35e2f3f4a6)

1. `POST http://127.0.0.1:4000/eu.assemblyai/v2/upload` with `Content-Type: audio/mp4` and the same 1.2 MB binary body
2. HTTP 200
3. `{"upload_url":"https://cdn.assemblyai.com/upload/8cc9f822c1455c4868a66370312850ec1ce2a4f408a008b886287e42837463a9/dff03083-6f70-47cf-9529-dd53d272d9e4"}`

## Type

🐛 Bug Fix

## Caveats (if any)

- JSON parsing is skipped only for `/assemblyai/v2/upload` and `/eu.assemblyai/v2/upload`, not for every non-JSON content-type
- This does not add AssemblyAI as a chat model alias; it only repairs the existing pass-through

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR






