### PR TITLE
fix(responses): derive streaming capability from base_model for custom deployment names

### DIFF
--- a/litellm/llms/base_llm/responses/transformation.py
+++ b/litellm/llms/base_llm/responses/transformation.py
@@ -237,8 +237,9 @@ class BaseResponsesAPIConfig(ABC):
         model: str | None,
         stream: bool | None,
         custom_llm_provider: str | None = None,
+        base_model: str | None = None,
     ) -> bool:
-        """Returns True if litellm should fake a stream for the given model and stream value"""
+        """Returns True if litellm should fake a stream for the given model, stream value and base_model fallback"""
         return False
 
     def supports_native_websocket(self) -> bool:

--- a/litellm/llms/manus/responses/transformation.py
+++ b/litellm/llms/manus/responses/transformation.py
@@ -52,6 +52,7 @@ class ManusResponsesAPIConfig(OpenAIResponsesAPIConfig):
         model: str | None,
         stream: bool | None,
         custom_llm_provider: str | None = None,
+        base_model: str | None = None,
     ) -> bool:
         """
         Manus API doesn't support real-time streaming.

--- a/litellm/llms/openai/responses/transformation.py
+++ b/litellm/llms/openai/responses/transformation.py
@@ -427,6 +427,7 @@ class OpenAIResponsesAPIConfig(BaseResponsesAPIConfig):
         model: str | None,
         stream: bool | None,
         custom_llm_provider: str | None = None,
+        base_model: str | None = None,
     ) -> bool:
         if stream is not True:
             return False
@@ -436,6 +437,7 @@ class OpenAIResponsesAPIConfig(BaseResponsesAPIConfig):
                     litellm.utils.supports_native_streaming(
                         model=model,
                         custom_llm_provider=custom_llm_provider,
+                        base_model=base_model,
                     )
                     is False
                 ):

--- a/litellm/llms/volcengine/responses/transformation.py
+++ b/litellm/llms/volcengine/responses/transformation.py
@@ -407,6 +407,7 @@ class VolcEngineResponsesAPIConfig(OpenAIResponsesAPIConfig):
         model: str | None,
         stream: bool | None,
         custom_llm_provider: str | None = None,
+        base_model: str | None = None,
     ) -> bool:
         """
         Volcengine Responses API supports native streaming; never fall back to fake stream.

--- a/litellm/responses/main.py
+++ b/litellm/responses/main.py
@@ -1111,6 +1111,9 @@ def responses(
         if custom_llm_provider is None:
             raise ValueError("custom_llm_provider is required but passed as None")
 
+        deployment_model_info: Final = kwargs.get("model_info")
+        base_model: Final = deployment_model_info.get("base_model") if isinstance(deployment_model_info, dict) else None
+
         response = base_llm_http_handler.response_api_handler(
             model=model,
             input=input,
@@ -1125,7 +1128,10 @@ def responses(
             _is_async=_is_async,
             client=kwargs.get("client"),
             fake_stream=responses_api_provider_config.should_fake_stream(
-                model=model, stream=stream, custom_llm_provider=custom_llm_provider
+                model=model,
+                stream=stream,
+                custom_llm_provider=custom_llm_provider,
+                base_model=base_model,
             ),
             litellm_metadata=kwargs.get("litellm_metadata", {}),
             shared_session=kwargs.get("shared_session"),

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -2301,38 +2301,42 @@ def supports_url_context(model: str, custom_llm_provider: str | None = None) -> 
     )
 
 
-def supports_native_streaming(model: str, custom_llm_provider: str | None) -> bool:
+def supports_native_streaming(model: str, custom_llm_provider: str | None, base_model: str | None = None) -> bool:
     """
     Check if the given model supports native streaming and return a boolean value.
 
     Parameters:
     model (str): The model name to be checked.
     custom_llm_provider (str): The provider to be checked.
+    base_model (str): Optional fallback looked up when ``model`` is not in the
+        model cost map, e.g. a custom Azure deployment name whose underlying
+        model is identified by the deployment's ``model_info.base_model``.
 
     Returns:
     bool: True if the model supports native streaming, False otherwise.
-
-    Raises:
-    Exception: If the given model is not found in model_prices_and_context_window.json.
+    A model found in the model cost map answers from its own entry; ``base_model``
+    is only consulted when ``model`` itself is unknown.
     """
-    try:
-        model, custom_llm_provider, _, _ = litellm.get_llm_provider(
-            model=model, custom_llm_provider=custom_llm_provider
-        )
-
-        model_info: Final = _get_model_info_helper(model=model, custom_llm_provider=custom_llm_provider)
-        supports_native_streaming = model_info.get("supports_native_streaming", True)
-        if supports_native_streaming is None:
-            supports_native_streaming = True
-        return supports_native_streaming
-    except Exception as e:
-        verbose_logger.debug(
-            "Model not found or error in checking supports_native_streaming support. You passed model=%s, custom_llm_provider=%s. Error: %s",
-            model,
-            custom_llm_provider,
-            e,
-        )
-        return False
+    for candidate in (model, base_model):
+        if candidate is None:
+            continue
+        try:
+            resolved_model, resolved_provider, _, _ = litellm.get_llm_provider(
+                model=candidate, custom_llm_provider=custom_llm_provider
+            )
+            supports = _get_model_info_helper(model=resolved_model, custom_llm_provider=resolved_provider).get(
+                "supports_native_streaming", True
+            )
+        except Exception as e:
+            verbose_logger.debug(
+                "Model not found or error in checking supports_native_streaming support. You passed model=%s, custom_llm_provider=%s. Error: %s",
+                candidate,
+                custom_llm_provider,
+                e,
+            )
+            continue
+        return supports is not False
+    return False
 
 
 def supports_response_schema(model: str, custom_llm_provider: str | None = None) -> bool:

--- a/tests/test_litellm/llms/openai/responses/test_openai_responses_transformation.py
+++ b/tests/test_litellm/llms/openai/responses/test_openai_responses_transformation.py
@@ -1598,3 +1598,38 @@ class TestPromptCacheOptionsOnResponsesPath:
             "text": "hi",
             "prompt_cache_breakpoint": {"mode": "explicit"},
         }
+class TestShouldFakeStreamBaseModelFallback:
+    def setup_method(self):
+        self.config = OpenAIResponsesAPIConfig()
+
+    def test_unknown_model_with_streaming_base_model_streams_natively(self):
+        assert (
+            self.config.should_fake_stream(
+                model="azure/my-custom-ptu-deployment",
+                stream=True,
+                custom_llm_provider="azure",
+                base_model="gpt-4o",
+            )
+            is False
+        )
+
+    def test_unknown_model_without_base_model_fake_streams(self):
+        assert (
+            self.config.should_fake_stream(
+                model="azure/my-custom-ptu-deployment",
+                stream=True,
+                custom_llm_provider="azure",
+            )
+            is True
+        )
+
+    def test_stream_not_requested_never_fake_streams(self):
+        assert (
+            self.config.should_fake_stream(
+                model="azure/my-custom-ptu-deployment",
+                stream=None,
+                custom_llm_provider="azure",
+                base_model="gpt-4o",
+            )
+            is False
+        )

--- a/tests/test_litellm/responses/test_responses_fake_stream_base_model.py
+++ b/tests/test_litellm/responses/test_responses_fake_stream_base_model.py
@@ -1,0 +1,28 @@
+from unittest.mock import MagicMock, patch
+
+import litellm
+
+
+def _fake_stream_passed_to_handler(**extra_kwargs):
+    with patch(
+        "litellm.responses.main.base_llm_http_handler.response_api_handler",
+        return_value=MagicMock(),
+    ) as mock_handler:
+        litellm.responses(
+            model="azure/my-custom-ptu-deployment",
+            input="hello",
+            stream=True,
+            api_key="fake-api-key",
+            api_base="https://fake.openai.azure.com",
+            api_version="2025-01-01-preview",
+            **extra_kwargs,
+        )
+    return mock_handler.call_args.kwargs["fake_stream"]
+
+
+def test_responses_streams_natively_when_model_info_base_model_streams():
+    assert _fake_stream_passed_to_handler(model_info={"base_model": "azure/gpt-4o"}) is False
+
+
+def test_responses_fake_streams_without_base_model():
+    assert _fake_stream_passed_to_handler() is True

--- a/tests/test_litellm/test_utils.py
+++ b/tests/test_litellm/test_utils.py
@@ -4989,3 +4989,74 @@ def test_completion_does_not_leak_rust_flag_into_provider_request_body():
     create_kwargs = mock_client.chat.completions.with_raw_response.create.call_args.kwargs
     assert "rust" not in create_kwargs
     assert "rust" not in (create_kwargs.get("extra_body") or {})
+
+
+class TestSupportsNativeStreamingBaseModelFallback:
+    def test_unknown_model_falls_back_to_streaming_base_model(self):
+        assert (
+            litellm.utils.supports_native_streaming(
+                model="azure/my-custom-ptu-deployment",
+                custom_llm_provider="azure",
+                base_model="gpt-4o",
+            )
+            is True
+        )
+
+    def test_unknown_model_falls_back_to_provider_qualified_base_model(self):
+        assert (
+            litellm.utils.supports_native_streaming(
+                model="azure/my-custom-ptu-deployment",
+                custom_llm_provider="azure",
+                base_model="azure/gpt-4o",
+            )
+            is True
+        )
+
+    def test_unknown_model_with_cross_provider_base_model_returns_false(self):
+        assert (
+            litellm.utils.supports_native_streaming(
+                model="azure/my-custom-ptu-deployment",
+                custom_llm_provider="azure",
+                base_model="gemini/gemini-2.5-flash",
+            )
+            is False
+        )
+
+    def test_unknown_model_falls_back_to_non_streaming_base_model(self):
+        assert (
+            litellm.utils.supports_native_streaming(
+                model="my-custom-o1-pro-deployment",
+                custom_llm_provider="openai",
+                base_model="o1-pro",
+            )
+            is False
+        )
+
+    def test_known_model_capability_wins_over_base_model(self):
+        assert (
+            litellm.utils.supports_native_streaming(
+                model="o1-pro",
+                custom_llm_provider="openai",
+                base_model="gpt-4o",
+            )
+            is False
+        )
+
+    def test_unknown_model_and_unknown_base_model_returns_false(self):
+        assert (
+            litellm.utils.supports_native_streaming(
+                model="azure/my-custom-ptu-deployment",
+                custom_llm_provider="azure",
+                base_model="my-equally-unknown-base-model",
+            )
+            is False
+        )
+
+    def test_unknown_model_without_base_model_returns_false(self):
+        assert (
+            litellm.utils.supports_native_streaming(
+                model="azure/my-custom-ptu-deployment",
+                custom_llm_provider="azure",
+            )
+            is False
+        )


### PR DESCRIPTION
## TLDR

Problem this solves:

- Responses API silently fake-streams custom Azure deployment names
- Capability lookup checks the routed name, never `base_model`
- Client gets SSE, but nothing arrives until completion

How it solves it:

- `supports_native_streaming()` falls back to `base_model` on cost-map miss
- Responses `should_fake_stream()` receives the deployment's `model_info.base_model`
- Models found in the cost map answer from their own entry

## User Flow

Before: a developer streaming from an Azure PTU deployment (custom deployment name, `base_model` set for cost tracking) gets no first-token latency benefit

1. They send POST https://litellm-domain/v1/responses with `"model": "gpt-5.4-csvo-ptu"` and `"stream": true`
2. The connection stays silent for the entire generation, then every SSE event arrives at once: a 60 second answer means 60 seconds with no output
3. They check the provider side and the Azure diagnostic logs show the call as a non-streaming request, even though they asked for a stream

After: the same request streams for real

1. They send the same POST https://litellm-domain/v1/responses with `"model": "gpt-5.4-csvo-ptu"` and `"stream": true`
2. Token-sized delta events start arriving within the model's normal first-token latency and continue progressively until completion
3. The Azure diagnostic logs show the call as a streaming request

## Relevant issues

Fixes #37800

Previously reported as #21090 (same call chain on /v1/responses, auto-closed as stale): fixed by this PR for deployments that declare `base_model`, unchanged otherwise. Also fixes the streaming symptom of #12744 for deployments that set Base Model. #31243, #27717 and #28782 are analogous capability-resolution bugs in other gates (reasoning effort, thinking, model-family detection); this PR does not change those gates

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

Real calls against an Azure OpenAI (Sweden Central) resource holding a deployment named `gpt-5.4-csvo-ptu`, backed by the `gpt-5.4` model. Proxy config `proof.yaml`, two entries for the same deployment, one with `base_model` and one without:

```yaml
model_list:
  - model_name: gpt-5.4-csvo-ptu
    litellm_params:
      model: azure/gpt-5.4-csvo-ptu
      custom_llm_provider: azure
      api_base: os.environ/AZURE_API_BASE
      api_version: "2025-04-01-preview"
      tenant_id: os.environ/AZURE_TENANT_ID
      client_id: os.environ/AZURE_CLIENT_ID
      client_secret: os.environ/AZURE_CLIENT_SECRET
    model_info:
      base_model: azure/gpt-5.4
  - model_name: csvo-ptu-no-base-model
    litellm_params:
      model: azure/gpt-5.4-csvo-ptu
      custom_llm_provider: azure
      api_base: os.environ/AZURE_API_BASE
      api_version: "2025-04-01-preview"
      tenant_id: os.environ/AZURE_TENANT_ID
      client_id: os.environ/AZURE_CLIENT_ID
      client_secret: os.environ/AZURE_CLIENT_SECRET
general_settings:
  master_key: sk-proof-1234
```

Commands per case: start the proxy, stream the request through curl with a wall-clock timestamp per SSE line, summarize with awk

```bash
litellm --config proof.yaml --port 41234
```

```bash
START=$EPOCHREALTIME
curl -sN http://127.0.0.1:41234/v1/responses \
  -H "Authorization: Bearer sk-proof-1234" -H "Content-Type: application/json" \
  -d '{"model":"<MODEL>","input":"Write a numbered list counting from 1 to 150, one number per line. No other text.","stream":true}' |
while IFS= read -r line; do [ -n "$line" ] && echo "$EPOCHREALTIME ${line:0:60}"; done > run.log
awk -v t0="$START" '/output_text.delta/{n++; if(!d){d=1; fd=$1-t0}} {last=$1-t0} END{printf "events %d | text deltas %d | first delta at %.2fs | last event at %.2fs\n", NR, n, fd, last}' run.log
```

### Before (ff02d5cfc0)

#### custom deployment name with base_model

1. Run the commands above with `"model":"gpt-5.4-csvo-ptu"`
2. Summary: `events 108 | text deltas 99 | first delta at 3.47s | last event at 3.48s`
3. run.log (first 2, first delta, last): every line lands in the same 10ms window after the full generation, and the deltas are uniform 5-character synthetic chunks

```
1787300206.421098 data: {"type":"response.created","response":{"id":"resp_7cVH
1787300206.421935 data: {"type":"response.in_progress","response":{"id":"resp_
1787300206.422492 data: {"type":"response.output_text.delta","item_id":"msg_08
1787300206.429131 data: [DONE]
```

#### custom deployment name without base_model

1. Run the commands above with `"model":"csvo-ptu-no-base-model"`
2. Summary: `events 108 | text deltas 99 | first delta at 14.17s | last event at 14.18s`

### After (22bda31133)

#### custom deployment name with base_model

1. Run the commands above with `"model":"gpt-5.4-csvo-ptu"`
2. Summary: `events 308 | text deltas 299 | first delta at 2.21s | last event at 7.57s`
3. run.log (first 2, first delta, last): the first token delta arrives 2.2s in and delivery continues for 5.4s, native token-sized deltas

```
1787300255.660809 data: {"type":"response.created","response":{"id":"resp_3oPJ
1787300255.665022 data: {"type":"response.in_progress","response":{"id":"resp_
1787300256.020167 data: {"type":"response.output_text.delta","item_id":"msg_06
1787300261.380220 data: [DONE]
```

#### custom deployment name without base_model

1. Run the commands above with `"model":"csvo-ptu-no-base-model"`
2. Summary: `events 108 | text deltas 99 | first delta at 3.24s | last event at 3.24s`, the conservative fake-stream fallback is preserved when no base_model is declared

Reproduction note for reviewers: the defect needs `custom_llm_provider` set explicitly in `litellm_params` (the router's legacy cost-map registration then writes a double-prefixed `azure/azure/<name>` key the capability lookup never reads). Omit it and the registration lands on a usable key, masking the bug, which is why minimal configs may not reproduce it. `api_version` does not matter: verified live on both `2025-04-01-preview` and `v1`

## Type

🐛 Bug Fix

## Caveats (if any)

- `base_model` is consulted only when the routed name misses the cost map
- Deployments without `base_model` keep today's fake-stream fallback
- `should_fake_stream()` gains a keyword arg; external subclasses overriding the old 3-arg signature need the same addition (all in-repo overriders are updated)

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
