### PR TITLE
fix(perplexity): route Agent API models on chat completions without a cost-map entry

### DIFF
--- a/litellm/llms/perplexity/responses/transformation.py
+++ b/litellm/llms/perplexity/responses/transformation.py
@@ -22,6 +22,18 @@ from litellm.types.router import GenericLiteLLMParams
 from litellm.types.utils import LlmProviders
 
 
+def perplexity_uses_agent_api(model: str) -> bool:
+    """Whether a Perplexity model id names the Agent API rather than the chat endpoint.
+
+    Agent API ids keep their own vendor namespace once litellm's ``perplexity/`` prefix is
+    stripped (``perplexity/sonar``, ``openai/gpt-5.2``, ``preset/pro-search``), while chat,
+    embedding and search ids are a single segment (``sonar``, ``sonar-pro``). Reading the id
+    keeps routing independent of the cost map, which does not carry every model Perplexity
+    serves and whose flat ``perplexity/sonar`` chat entry otherwise shadows the Agent API one.
+    """
+    return "/" in model
+
+
 class PerplexityResponsesConfig(OpenAIResponsesAPIConfig):
     def get_supported_openai_params(self, model: str) -> list:
         """Ref: https://docs.perplexity.ai/api-reference/responses-post"""

--- a/litellm/main.py
+++ b/litellm/main.py
@@ -105,6 +105,7 @@ from litellm.llms.cohere.common_utils import CohereModelInfo
 from litellm.llms.custom_httpx.http_handler import AsyncHTTPHandler, HTTPHandler
 from litellm.llms.openai.chat.gpt_5_transformation import OpenAIGPT5Config
 from litellm.llms.openai_like.json_loader import JSONProviderRegistry
+from litellm.llms.perplexity.responses.transformation import perplexity_uses_agent_api
 from litellm.llms.vertex_ai.common_utils import (
     VertexAIModelRoute,
     get_vertex_ai_model_route,
@@ -1038,6 +1039,9 @@ def responses_api_bridge_check(
             model = model.replace("responses/", "")
             mode = "responses"
             model_info["mode"] = mode
+
+    if custom_llm_provider == "perplexity" and perplexity_uses_agent_api(model):
+        model_info["mode"] = "responses"
 
     # OpenAI/Azure GPT-5 chat-completions that need Responses-only fields (e.g.
     # ``reasoningSummary`` in ``extra_body``) must be bridged; Chat Completions rejects

--- a/tests/test_litellm/llms/perplexity/responses/test_perplexity_responses_transformation.py
+++ b/tests/test_litellm/llms/perplexity/responses/test_perplexity_responses_transformation.py
@@ -18,7 +18,10 @@ sys.path.insert(0, os.path.abspath("../../../../.."))
 
 from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObj
 from litellm.llms.base_llm.chat.transformation import BaseLLMException
-from litellm.llms.perplexity.responses.transformation import PerplexityResponsesConfig
+from litellm.llms.perplexity.responses.transformation import (
+    PerplexityResponsesConfig,
+    perplexity_uses_agent_api,
+)
 from litellm.types.llms.openai import ResponsesAPIOptionalRequestParams
 from litellm.types.utils import LlmProviders
 from litellm.utils import ProviderConfigManager
@@ -590,3 +593,55 @@ class TestPerplexityResponsesTransformation:
         assert result.type == "response.completed"
         assert result.response.usage.cost == 0.0003
         assert isinstance(result.response.usage.cost, float)
+
+
+class TestPerplexityAgentApiRouting:
+    """Routing an Agent API deployment to /v1/responses must not depend on the cost map.
+
+    ``completion()`` picks the responses bridge off ``mode`` in the cost map, so an Agent API
+    model litellm ships no pricing for was unroutable on /v1/chat/completions, and
+    ``perplexity/perplexity/sonar`` resolved to the older flat ``perplexity/sonar`` chat entry
+    several steps before the doubled-prefix key. Both went out on Perplexity's chat endpoint
+    and came back 400 naming a model id nobody wrote.
+    """
+
+    @pytest.mark.parametrize(
+        "model",
+        [
+            "perplexity/sonar",
+            "perplexity/glm-5.2",
+            "perplexity/nemotron-3-ultra-550b-a55b",
+            "openai/gpt-5.2",
+            "anthropic/claude-opus-4-7",
+            "preset/pro-search",
+        ],
+    )
+    def test_agent_api_models_bridge_to_responses(self, model):
+        from litellm.main import responses_api_bridge_check
+
+        model_info, _ = responses_api_bridge_check(model=model, custom_llm_provider="perplexity")
+
+        assert model_info.get("mode") == "responses"
+
+    @pytest.mark.parametrize("model", ["sonar", "sonar-pro", "sonar-reasoning", "llama-3.1-70b-instruct"])
+    def test_chat_models_stay_on_chat_completions(self, model):
+        from litellm.main import responses_api_bridge_check
+
+        model_info, _ = responses_api_bridge_check(model=model, custom_llm_provider="perplexity")
+
+        assert model_info.get("mode") != "responses"
+
+    def test_other_providers_keep_a_slash_in_the_model_name_on_chat(self):
+        from litellm.main import responses_api_bridge_check
+
+        model_info, _ = responses_api_bridge_check(
+            model="meta-llama/Llama-3.3-70B-Instruct", custom_llm_provider="together_ai"
+        )
+
+        assert model_info.get("mode") != "responses"
+
+    def test_agent_api_ids_are_told_apart_by_their_vendor_namespace(self):
+        assert perplexity_uses_agent_api("perplexity/sonar") is True
+        assert perplexity_uses_agent_api("preset/pro-search") is True
+        assert perplexity_uses_agent_api("sonar") is False
+        assert perplexity_uses_agent_api("sonar-pro") is False


### PR DESCRIPTION
## TLDR

Problem this solves:

- Agent API models 400 on `/v1/chat/completions`, work on `/v1/responses`
- Routing needs a cost-map `mode: responses` entry that often is missing
- `perplexity/perplexity/sonar` resolves to the older flat chat entry

How it solves it:

- Read the Agent API from the model id, not pricing data
- Vendor-namespaced ids (`perplexity/sonar`, `openai/gpt-5.2`) take the bridge
- Single-segment ids (`sonar`, `sonar-pro`) stay on chat completions

## User Flow

Before: a developer whose OpenAI-SDK app calls a Perplexity Agent API model gets a 400 naming a model they never asked for

1. Their proxy admin adds a deployment `pplx-nemotron-ultra` pointing at `perplexity/perplexity/nemotron-3-ultra-550b-a55b` and restarts the proxy
2. They send POST https://litellm-domain/v1/responses with `"model": "pplx-nemotron-ultra"` and get a 200 whose output text reads `pong`
3. They point their OpenAI SDK at the proxy and send POST https://litellm-domain/v1/chat/completions with the same `"model": "pplx-nemotron-ultra"`
4. They get a 400 reading `Invalid model 'perplexity/nemotron-3-ultra-550b-a55b'. Permitted models can be found in the documentation at https://docs.perplexity.ai/docs/getting-started/models.`, naming a model id neither they nor their admin ever wrote
5. Their admin swaps in `perplexity/perplexity/sonar` and the same POST returns 400 `Invalid model 'perplexity/sonar'`
6. Only `perplexity/perplexity/glm-5.2` answers on https://litellm-domain/v1/chat/completions, so the endpoint looks healthy for one model and broken for the rest

After: the same request answers on `/v1/chat/completions` exactly as it does on `/v1/responses`

1. Their proxy admin adds a deployment `pplx-nemotron-ultra` pointing at `perplexity/perplexity/nemotron-3-ultra-550b-a55b` and restarts the proxy
2. They send POST https://litellm-domain/v1/responses with `"model": "pplx-nemotron-ultra"` and get a 200 whose output text reads `pong`
3. They point their OpenAI SDK at the proxy and send POST https://litellm-domain/v1/chat/completions with the same `"model": "pplx-nemotron-ultra"`
4. They get a 200 whose message content reads `pong`
5. Their admin swaps in `perplexity/perplexity/sonar` and that deployment answers 200 on https://litellm-domain/v1/chat/completions too
6. Every Agent API deployment answers on https://litellm-domain/v1/chat/completions, and a legacy `perplexity/sonar` deployment keeps going to the chat endpoint as before

## Relevant issues

Fixes #37761

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

I do not have a Perplexity key, so the upstream here is a local stand-in that answers the Agent API and rejects unknown chat models the way Perplexity does, rather than api.perplexity.ai. That is enough to show which endpoint and which model id litellm sends, which is the whole of this bug, but the 400 text below is replayed from the issue rather than earned from Perplexity. Worth a maintainer re-running it against a real key before merge

Shared setup, a proxy on port 33958 with four deployments pointed at the stand-in:

```yaml
model_list:
  - model_name: pplx-sonar
    litellm_params: {model: perplexity/perplexity/sonar, api_key: fake-key, api_base: http://127.0.0.1:8919}
  - model_name: pplx-nemotron-ultra
    litellm_params: {model: perplexity/perplexity/nemotron-3-ultra-550b-a55b, api_key: fake-key, api_base: http://127.0.0.1:8919}
  - model_name: pplx-glm-5.2
    litellm_params: {model: perplexity/perplexity/glm-5.2, api_key: fake-key, api_base: http://127.0.0.1:8919}
  - model_name: pplx-legacy-sonar
    litellm_params: {model: perplexity/sonar, api_key: fake-key, api_base: http://127.0.0.1:8919}

general_settings:
  master_key: sk-1234
```

Every case sends the same body, varying only `model`:

```bash
curl -sS -i http://localhost:33958/v1/chat/completions \
  -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' \
  -d '{"model":"<name>","messages":[{"role":"user","content":"Reply with exactly: pong"}]}'
```

### Before (ff02d5cfc)

#### pplx-sonar, an Agent API model litellm ships pricing for

1. Run the curl above with `"model":"pplx-sonar"`
2. `HTTP/1.1 400 Bad Request`, body `{"error":{"message":"litellm.BadRequestError: PerplexityException - Invalid model 'perplexity/sonar'. Permitted models can be found in the documentation at https://docs.perplexity.ai/docs/getting-started/models.. Received Model Group=pplx-sonar\nAvailable Model Group Fallbacks=None","type":null,"param":null,"code":"400"}}`
3. The upstream recorded `POST /chat/completions model='perplexity/sonar'`, the Agent API id sent to the chat endpoint

#### pplx-nemotron-ultra, an Agent API model with no cost-map entry

1. Run the curl above with `"model":"pplx-nemotron-ultra"`
2. `HTTP/1.1 400 Bad Request`, body `{"error":{"message":"litellm.BadRequestError: PerplexityException - Invalid model 'perplexity/nemotron-3-ultra-550b-a55b'. ...","code":"400"}}`
3. The upstream recorded `POST /chat/completions model='perplexity/nemotron-3-ultra-550b-a55b'`

#### pplx-glm-5.2, the Agent API model whose cost-map entry is reachable

1. Run the curl above with `"model":"pplx-glm-5.2"`
2. `HTTP/1.1 200 OK`, body `{"id":"chatcmpl-f2361bbb-...","model":"pplx-glm-5.2","choices":[{"finish_reason":"stop","index":0,"message":{"content":"pong","role":"assistant"}}],"usage":{"completion_tokens":1,"prompt_tokens":9,"total_tokens":10}}`
3. The upstream recorded `POST /v1/responses model='perplexity/glm-5.2'`

#### pplx-legacy-sonar, a plain chat deployment

1. Run the curl above with `"model":"pplx-legacy-sonar"`
2. `HTTP/1.1 200 OK`, body `{"id":"c1","model":"pplx-legacy-sonar","choices":[{"finish_reason":"stop","index":0,"message":{"content":"pong","role":"assistant",...}}],"usage":{"completion_tokens":1,"prompt_tokens":9,"total_tokens":10}}`
3. The upstream recorded `POST /chat/completions model='sonar'`

### After (076c710c5)

#### pplx-sonar, an Agent API model litellm ships pricing for

1. Run the curl above with `"model":"pplx-sonar"`
2. `HTTP/1.1 200 OK`, body `{"id":"chatcmpl-a55c13f9-0229-4a3c-8e10-0034aff90711","model":"pplx-sonar","choices":[{"finish_reason":"stop","index":0,"message":{"content":"pong","role":"assistant"}}],"usage":{"completion_tokens":1,"prompt_tokens":9,"total_tokens":10}}`
3. The upstream recorded `POST /v1/responses model='perplexity/sonar'`

#### pplx-nemotron-ultra, an Agent API model with no cost-map entry

1. Run the curl above with `"model":"pplx-nemotron-ultra"`
2. `HTTP/1.1 200 OK`, body `{"id":"chatcmpl-9b4d9a2b-a104-4959-85ba-d19870d8817e","model":"pplx-nemotron-ultra","choices":[{"finish_reason":"stop","index":0,"message":{"content":"pong","role":"assistant"}}],"usage":{"completion_tokens":1,"prompt_tokens":9,"total_tokens":10}}`
3. The upstream recorded `POST /v1/responses model='perplexity/nemotron-3-ultra-550b-a55b'`

#### pplx-glm-5.2, the Agent API model whose cost-map entry is reachable

1. Run the curl above with `"model":"pplx-glm-5.2"`
2. `HTTP/1.1 200 OK`, body `{"id":"chatcmpl-8fc01d08-7e37-418a-bfbb-33d4c94575b4","model":"pplx-glm-5.2","choices":[{"finish_reason":"stop","index":0,"message":{"content":"pong","role":"assistant"}}],"usage":{"completion_tokens":1,"prompt_tokens":9,"total_tokens":10}}`
3. The upstream recorded `POST /v1/responses model='perplexity/glm-5.2'`, unchanged from Before

#### pplx-legacy-sonar, a plain chat deployment

1. Run the curl above with `"model":"pplx-legacy-sonar"`
2. `HTTP/1.1 200 OK`, body `{"id":"c1","model":"pplx-legacy-sonar","choices":[{"finish_reason":"stop","index":0,"message":{"content":"pong","role":"assistant",...}}],"usage":{"completion_tokens":1,"prompt_tokens":9,"total_tokens":10}}`
3. The upstream recorded `POST /chat/completions model='sonar'`, unchanged from Before

## Type

🐛 Bug Fix

## Caveats (if any)

- Proof of fix used a local stand-in, not api.perplexity.ai
- Leaves the missing cost-map entries the issue also asks for
- Those four models will bill at zero until pricing lands
- Does not touch `_get_model_info_helper` ordering, deliberately kept last

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
