### PR TITLE
perf(ci): give the two longest unit shards the runner's spare cores

### DIFF
--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -168,7 +168,7 @@ jobs:
               tests/test_litellm/proxy/ui_crud_endpoints
               tests/test_litellm/proxy/config_resolvers
               tests/test_litellm/proxy/utils
-            workers: 2
+            workers: 4
             reruns: 2
             timeout-minutes: 20
             job-timeout-minutes: 55
@@ -195,7 +195,7 @@ jobs:
               tests/test_litellm/proxy/types_utils
               tests/test_litellm/proxy/logging_endpoints
               tests/test_litellm/proxy/test_*.py
-            workers: 2
+            workers: 4
             reruns: 2
             timeout-minutes: 20
             job-timeout-minutes: 55


### PR DESCRIPTION
## TLDR

Problem this solves:

- proxy-endpoints and proxy-infra are the unit tier's critical path
- 358s and 325s of pytest, measured on staging
- Both run 2 xdist workers on a 4-vCPU runner

How it solves it:

- Raise both to 4 workers, matching proxy-server
- No second job, so no second setup to pay for

## User Flow

No end-user behavior changes. This is CI wall clock. A contributor waits less for
the two checks that finish last.

## Relevant issues

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

Shared setup: both sides read the `Run tests` step duration off a completed
`test-unit.yml` run, so the number is pytest alone and excludes checkout,
install, and the Rust build.

```
gh api "repos/BerriAI/litellm/actions/runs/<id>/jobs?per_page=100" \
  --jq '.jobs[] | select(.name|endswith("/ Run tests"))
        | "\(([.steps[]|select(.name=="Run tests")|((.completed_at|fromdate)-(.started_at|fromdate))][0]))\t\(.name)"' \
  | sort -rn
```

### Before (ff02d5cfc0)

#### Every unit shard, slowest first

1. Run 32456962579, staging, the merge base of this PR:

```
358	proxy-endpoints / Run tests
325	proxy-infra / Run tests
268	All Other Providers / Run tests
265	misc / Run tests
174	integrations / Run tests
166	proxy-auth / Run tests
144	enterprise-routing / Run tests
140	Vertex AI / Run tests
107	proxy-server / Run tests
104	core-utils / Run tests
98	responses-caching-types / Run tests
```

2. proxy-endpoints sets the tier's critical path at 358s, and it is 93s clear of
   the next shard, so nothing else finishing sooner helps

### After (b0a759dc25)

#### Every unit shard, slowest first

1. Run 32464569689, this PR's tip:

```
256	misc / Run tests
253	All Other Providers / Run tests
246	proxy-infra / Run tests
233	proxy-endpoints / Run tests
176	integrations / Run tests
165	proxy-auth / Run tests
138	enterprise-routing / Run tests
135	Vertex AI / Run tests
118	responses-caching-types / Run tests
108	proxy-server / Run tests
102	core-utils / Run tests
```

2. proxy-endpoints drops 358s to 233s and proxy-infra 325s to 246s, so the
   critical path is now misc at 256s: 102s off the unit tier

3. All 66 checks pass, so the extra concurrency did not surface order dependence
   in either shard

## Type

🚄 Infrastructure

## Caveats (if any)

- More workers can surface order dependence; the run here is the check
- Vertex AI stays at 1 worker, untouched
- misc is the next shard to split, not this PR

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
