### PR TITLE
fix(models): avoid AttributeError on LiteLLM_ProxyModelTable revalidation

### DIFF
--- a/litellm/models/model.py
+++ b/litellm/models/model.py
@@ -29,6 +29,8 @@ class LiteLLM_ProxyModelTable(LiteLLMPydanticObjectBase):
     @model_validator(mode="before")
     @classmethod
     def check_potential_json_str(cls, values):
+        if not isinstance(values, dict):
+            return values
         if isinstance(values.get("litellm_params"), str):
             try:
                 values["litellm_params"] = json.loads(values["litellm_params"])

--- a/tests/test_litellm/models/test_models.py
+++ b/tests/test_litellm/models/test_models.py
@@ -130,6 +130,26 @@ class TestModel:
         assert model.litellm_params == {"model": "gpt-4"}
         assert model.model_info == {"team_id": "t1"}
 
+    def test_accepts_existing_model_instance_during_revalidation(self):
+        # 1. Validate from dictionary input (dict branch in validator)
+        raw_dict = {
+            "model_id": "m1",
+            "model_name": "gpt-4",
+            "litellm_params": {"model": "gpt-4"},
+            "model_info": {"id": "m1"},
+            "blocked": True,
+        }
+        model_from_dict = LiteLLM_ProxyModelTable.model_validate(raw_dict)
+        assert model_from_dict.model_id == "m1"
+        assert model_from_dict.blocked is True
+
+        # 2. Revalidate from existing model instance (non-dict branch in validator)
+        reparsed = LiteLLM_ProxyModelTable.model_validate(model_from_dict)
+        assert reparsed.model_id == "m1"
+        assert reparsed.model_info == {"id": "m1"}
+        assert reparsed.blocked is True
+
+
     def test_team_helpers_none_when_no_model_info(self):
         model = LiteLLM_ProxyModelTable(
             model_id="m1", model_name="gpt-4", litellm_params={}, model_info=None


### PR DESCRIPTION
## TLDR

Problem this solves:
- POST /model/block and POST /model/unblock fail with HTTP 500 AttributeError during Pydantic response validation

How it solves it:
- Return non-dict inputs unchanged in LiteLLM_ProxyModelTable.check_potential_json_str before accessing dict keys

## Relevant issues

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks
- [x] My PR's scope is as isolated as possible

## Proof of Fix

Before fix:
POST /model/block -> HTTP 500 (AttributeError: 'LiteLLM_ProxyModelTable' object has no attribute 'get')

After fix:
POST /model/block -> HTTP 200 OK with model details payload

## Type

🐛 Bug Fix

## Changes

- `litellm/models/model.py`: Type-guard `values` in `check_potential_json_str` validator to handle `LiteLLM_ProxyModelTable` instances during response revalidation.
- `tests/test_litellm/models/test_models.py`: Add regression test for `model_validate` on an existing `LiteLLM_ProxyModelTable` instance.

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR