### PR TITLE
test(proxy): pin the request-body rules `proxy/_types.py` enforces

### DIFF
--- a/tests/test_litellm/proxy/test_proxy_types.py
+++ b/tests/test_litellm/proxy/test_proxy_types.py
@@ -177,3 +177,107 @@ def test_project_io_token_limits_are_stored_in_metadata(request_type):
 
     assert request.metadata == limits
     assert request.model_dump(exclude_none=True)["metadata"] == limits
+
+
+def test_a_jwt_issuer_must_pick_audience_validation_or_opt_out():
+    from pydantic import ValidationError
+
+    from litellm.proxy._types import JWTIssuerConfig
+
+    with pytest.raises(ValidationError, match="must configure audience or set disable_audience_validation"):
+        JWTIssuerConfig(issuer="https://issuer.example.com")
+
+    with pytest.raises(ValidationError, match="cannot set audience and disable_audience_validation"):
+        JWTIssuerConfig(
+            issuer="https://issuer.example.com",
+            audience="litellm-proxy",
+            disable_audience_validation=True,
+        )
+
+    assert JWTIssuerConfig(issuer="https://issuer.example.com", audience="litellm-proxy").audience == "litellm-proxy"
+    assert (
+        JWTIssuerConfig(issuer="https://issuer.example.com", disable_audience_validation=True).audience
+        is None
+    )
+
+
+def test_a_jwt_issuer_rejects_a_field_it_does_not_define():
+    from pydantic import ValidationError
+
+    from litellm.proxy._types import JWTIssuerConfig
+
+    with pytest.raises(ValidationError, match="Extra inputs are not permitted"):
+        JWTIssuerConfig(issuer="https://issuer.example.com", audience="a", jwks_uri="https://issuer/jwks")
+
+
+def test_a_temp_budget_needs_both_halves_or_neither():
+    from pydantic import ValidationError
+
+    from litellm.proxy._types import UpdateKeyRequest
+
+    with pytest.raises(ValidationError, match="temp_budget_increase and temp_budget_expiry must be set together"):
+        UpdateKeyRequest(key="sk-1234", temp_budget_increase=10)
+
+    with pytest.raises(ValidationError, match="temp_budget_increase and temp_budget_expiry must be set together"):
+        UpdateKeyRequest(key="sk-1234", temp_budget_expiry="2026-01-01")
+
+    both = UpdateKeyRequest(key="sk-1234", temp_budget_increase=10, temp_budget_expiry="2026-01-01")
+    assert both.temp_budget_increase == 10
+
+
+def test_an_empty_max_budget_is_read_as_no_limit():
+    from litellm.proxy._types import GenerateKeyRequest
+
+    assert GenerateKeyRequest(max_budget="").max_budget is None
+    assert GenerateKeyRequest(max_budget=25).max_budget == 25
+
+
+def test_an_organization_member_can_only_take_a_role_the_organization_has():
+    from pydantic import ValidationError
+
+    from litellm.proxy._types import LitellmUserRoles, OrganizationMemberUpdateRequest
+
+    with pytest.raises(ValidationError, match="Invalid role"):
+        OrganizationMemberUpdateRequest(
+            organization_id="org-1", user_id="user-1", role=LitellmUserRoles.PROXY_ADMIN
+        )
+
+    allowed = OrganizationMemberUpdateRequest(
+        organization_id="org-1", user_id="user-1", role=LitellmUserRoles.ORG_ADMIN
+    )
+    assert allowed.role == LitellmUserRoles.ORG_ADMIN
+
+
+def test_an_llm_backed_injection_check_needs_the_call_it_would_make():
+    from pydantic import ValidationError
+
+    from litellm.proxy._types import LiteLLMPromptInjectionParams
+
+    for missing in ("llm_api_name", "llm_api_system_prompt", "llm_api_fail_call_string"):
+        complete = {
+            "llm_api_name": "gpt-4o",
+            "llm_api_system_prompt": "is this an injection",
+            "llm_api_fail_call_string": "yes",
+        }
+        del complete[missing]
+        with pytest.raises(ValidationError, match=f"{missing} must be provided"):
+            LiteLLMPromptInjectionParams(llm_api_check=True, **complete)
+
+    assert LiteLLMPromptInjectionParams(llm_api_check=False).llm_api_name is None
+
+
+@pytest.mark.parametrize(
+    "field, forged, default",
+    [
+        ("mcp_admitted_user_subject", "someone-else", False),
+        ("mcp_source_team_rpm_limits", {"team-1": 10_000}, None),
+        ("mcp_session_resource_server_id", "server-1", None),
+        ("via_virtual_key", "sk-someone-elses-key", False),
+    ],
+)
+def test_a_server_only_marker_is_not_taken_from_the_caller(field, forged, default):
+    from litellm.proxy._types import UserAPIKeyAuth
+
+    auth = UserAPIKeyAuth(api_key="sk-1234", **{field: forged})
+
+    assert getattr(auth, field) == default


### PR DESCRIPTION
## TLDR

Problem this solves:

- `proxy/_types.py` is 4,945 lines of accepted request bodies
- Its mapped test file is 9 tests
- Eight rules that reject a request had none

How it solves it:

- One test per rule, asserted through the model, not the endpoint
- Rewriting any of the eight to its opposite now fails

## User Flow

No end-user behavior changes. A management API caller sending a body one of
these rules refuses keeps getting the same refusal, and now a change to that
refusal has to be deliberate.

## Relevant issues

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

Shared setup: each of the eight rules is rewritten to its opposite in
`litellm/proxy/_types.py`, one at a time, and the mapped test file is run
against it. A rule is pinned when the run fails.

```
for each rule:
    invert the guard in litellm/proxy/_types.py
    uv run pytest tests/test_litellm/proxy/test_proxy_types.py -x -q
    killed if the run fails
```

The eight rewrites: the JWT audience requirement, the audience-and-opt-out
conflict, the temp-budget pairing, the empty `max_budget` string, the
organization role list, the `llm_api_name` requirement, the `via_virtual_key`
strip, and `extra: forbid` on `JWTIssuerConfig`.

### Before (ff02d5cfc0)

1. `uv run pytest tests/test_litellm/proxy/test_proxy_types.py -q`

```
9 passed, 2 warnings in 1.72s
```

2. The eight rewrites, against that file:

```
SURVIVED  audience guard inverted
SURVIVED  audience conflict guard dropped
SURVIVED  temp budget pairing loosened
SURVIVED  empty max_budget passed through
SURVIVED  org role check inverted
SURVIVED  llm_api_name requirement dropped
SURVIVED  via_virtual_key accepted from caller
SURVIVED  jwt issuer accepts extra fields

kill rate: 0/8
```

### After (0f5580dee7)

1. `uv run pytest tests/test_litellm/proxy/test_proxy_types.py -q`

```
19 passed, 2 warnings in 1.66s
```

2. The same eight rewrites:

```
KILLED    audience guard inverted
KILLED    audience conflict guard dropped
KILLED    temp budget pairing loosened
KILLED    empty max_budget passed through
KILLED    org role check inverted
KILLED    llm_api_name requirement dropped
KILLED    via_virtual_key accepted from caller
KILLED    jwt issuer accepts extra fields

kill rate: 8/8
```

## Type

✅ Test

## Caveats (if any)

- `JWTIssuerConfig` had no test anywhere in the suite before this
- 20 of the file's 28 validators are still unpinned
- The tests assert on the model, so they say nothing about status codes

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

