### PR TITLE
test(llm_http_handler): pin the websocket and callback gates the request path branches on

### DIFF
--- a/tests/test_litellm/llms/custom_httpx/test_llm_http_handler.py
+++ b/tests/test_litellm/llms/custom_httpx/test_llm_http_handler.py
@@ -24,7 +24,10 @@ from litellm.llms.base_llm.chat.transformation import BaseLLMException
 from litellm.llms.custom_httpx.http_handler import AsyncHTTPHandler, HTTPHandler
 from litellm.llms.custom_httpx.llm_http_handler import (
     BaseLLMHTTPHandler,
+    _collect_ws_project_quota_callbacks,
     _google_genai_streaming_hidden_params,
+    _has_pre_call_deployment_hook,
+    _rust_responses_websocket_enabled,
 )
 from litellm.types.llms.openai import ResponsesAPIResponse
 from litellm.types.router import GenericLiteLLMParams
@@ -2445,3 +2448,82 @@ async def test_generic_http_handler_async_streaming_forwards_provider_response_h
 
     collected = [chunk async for chunk in response]
     assert "".join([chunk.choices[0].delta.content or "" for chunk in collected]) == "hi"
+
+
+@pytest.mark.parametrize(
+    "custom_llm_provider, litellm_params, expected",
+    [
+        ("openai", GenericLiteLLMParams(rust=True), True),
+        ("openai", GenericLiteLLMParams(), False),
+        ("openai", GenericLiteLLMParams(rust=False), False),
+        ("azure", GenericLiteLLMParams(rust=True), False),
+        ("hosted_vllm", GenericLiteLLMParams(rust=True), False),
+        (None, GenericLiteLLMParams(rust=True), False),
+    ],
+)
+def test_the_rust_responses_websocket_needs_both_openai_and_the_rust_flag(
+    custom_llm_provider, litellm_params, expected
+):
+    assert _rust_responses_websocket_enabled(custom_llm_provider, litellm_params) is expected
+
+
+def test_a_plain_callback_does_not_advertise_a_pre_call_deployment_hook(monkeypatch):
+    from litellm.integrations.custom_logger import CustomLogger
+
+    class _PlainLogger(CustomLogger):
+        pass
+
+    logging_obj = Mock()
+    logging_obj.dynamic_success_callbacks = []
+
+    monkeypatch.setattr(litellm, "callbacks", [])
+    assert _has_pre_call_deployment_hook(logging_obj) is False
+
+    monkeypatch.setattr(litellm, "callbacks", [_PlainLogger()])
+    assert _has_pre_call_deployment_hook(logging_obj) is False
+
+
+def test_a_callback_that_overrides_the_deployment_hook_is_detected(monkeypatch):
+    from litellm.integrations.custom_logger import CustomLogger
+
+    class _DeploymentHookLogger(CustomLogger):
+        async def async_pre_call_deployment_hook(self, kwargs, call_type):
+            return None
+
+    class _InheritsTheHook(_DeploymentHookLogger):
+        pass
+
+    logging_obj = Mock()
+    logging_obj.dynamic_success_callbacks = []
+
+    monkeypatch.setattr(litellm, "callbacks", [_DeploymentHookLogger()])
+    assert _has_pre_call_deployment_hook(logging_obj) is True
+
+    monkeypatch.setattr(litellm, "callbacks", [_InheritsTheHook()])
+    assert _has_pre_call_deployment_hook(logging_obj) is True
+
+    monkeypatch.setattr(litellm, "callbacks", [])
+    logging_obj.dynamic_success_callbacks = [_DeploymentHookLogger()]
+    assert _has_pre_call_deployment_hook(logging_obj) is True
+
+
+def test_only_callbacks_that_can_charge_a_frame_are_collected_for_ws_quota(monkeypatch):
+    from litellm.integrations.custom_logger import CustomLogger
+
+    class _PlainLogger(CustomLogger):
+        pass
+
+    class _QuotaLogger(CustomLogger):
+        async def enforce_project_io_token_quota_for_frame(self, *args, **kwargs):
+            return None
+
+    class _NotCallableAttribute:
+        enforce_project_io_token_quota_for_frame = "not a method"
+
+    plain, quota, decoy = _PlainLogger(), _QuotaLogger(), _NotCallableAttribute()
+
+    monkeypatch.setattr(litellm, "callbacks", [plain, decoy])
+    assert _collect_ws_project_quota_callbacks() == ()
+
+    monkeypatch.setattr(litellm, "callbacks", [plain, quota, decoy])
+    assert _collect_ws_project_quota_callbacks() == (quota,)


### PR DESCRIPTION
## TLDR

Problem this solves:

- Four predicates pick the WebSocket, hook and quota paths
- None of them is asserted anywhere in the suite
- All four can be reversed with the file still green

How it solves it:

- Nine cases asserting those four contracts directly
- All four reversals now fail

## User Flow

No end-user behavior changes. A developer calling
https://litellm-domain/v1/responses keeps reaching the same transport, and the
four ways that choice could silently flip now fail in CI first.

## Relevant issues

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

Shared setup: six decisions in `litellm/llms/custom_httpx/llm_http_handler.py`
are rewritten to their opposite, one at a time, and the mapped test file is run
against each.

```
for each rewrite:
    apply it to litellm/llms/custom_httpx/llm_http_handler.py
    uv run pytest tests/test_litellm/llms/custom_httpx/test_llm_http_handler.py -q
    killed if the run fails
```

### Before (ff02d5cfc0)

1. `uv run pytest tests/test_litellm/llms/custom_httpx/test_llm_http_handler.py -q`

```
66 passed, 7 warnings in 0.38s
```

2. The six rewrites:

```
SURVIVED  rust websocket gate ignores the provider
SURVIVED  rust websocket gate ignores the flag
KILLED    dynamic success callbacks dropped
KILLED    string callbacks never resolved
SURVIVED  deployment hook reported on the base method
SURVIVED  ws quota callbacks not filtered

kill rate: 2/6
```

3. The two that already fail do so through `_has_agentic_completion_hook`. The
   four that survive each change where a request goes: a non-openai provider
   sent down the rust WebSocket path, every plain callback claiming a pre-call
   deployment hook, and callbacks that cannot charge a frame handed to the
   quota loop

### After (0d709550aa)

1. `uv run pytest tests/test_litellm/llms/custom_httpx/test_llm_http_handler.py -q`

```
75 passed, 7 warnings in 0.40s
```

2. The same six rewrites:

```
KILLED    rust websocket gate ignores the provider
KILLED    rust websocket gate ignores the flag
KILLED    dynamic success callbacks dropped
KILLED    string callbacks never resolved
KILLED    deployment hook reported on the base method
KILLED    ws quota callbacks not filtered

kill rate: 6/6
```

## Type

✅ Test

## Caveats (if any)

- Two of the six were already caught, so this closes four gaps
- The quota callback test duck-types, matching how the source discovers them
- A non-callable attribute of the same name is covered as a decoy
- Hook detection is asserted through an intermediate subclass too

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
