### PR TITLE
fix(sambanova): keep content lists that carry non-text parts

### DIFF
--- a/litellm/llms/sambanova/chat.py
+++ b/litellm/llms/sambanova/chat.py
@@ -14,6 +14,14 @@ from litellm.llms.openai.chat.gpt_transformation import OpenAIGPTConfig
 from litellm.types.llms.openai import AllMessageValues
 
 
+def _has_text_only_content(message: AllMessageValues) -> bool:
+    """Whether the message content is a string, or a list holding text parts only."""
+    content = message.get("content")
+    if not isinstance(content, list):
+        return True
+    return all(isinstance(part, str) or (isinstance(part, dict) and part.get("type") == "text") for part in content)
+
+
 class SambanovaConfig(OpenAIGPTConfig):
     """
     Reference: https://docs.sambanova.ai/cloud/api-reference/
@@ -117,14 +125,22 @@ class SambanovaConfig(OpenAIGPTConfig):
         """
         Transform messages to handle content list conversion.
 
-        SambaNova API doesn't support content as a list - only string content.
-        This converts content lists like [{"type": "text", "text": "..."}] to strings.
+        SambaNova's API takes a string for `content`, and its vision models also take
+        the OpenAI content-list form with `image_url` parts. Flatten only the messages
+        whose list is entirely text: flattening a list that carries an `image_url` (or
+        any other non-text part) drops the attachment, and the model then answers as if
+        nothing was sent - HTTP 200 and no error, so the loss is silent.
         """
 
+        def _transform():
+            # handle_messages_with_content_list_to_str_conversion mutates the messages it
+            # is given, so passing the text-only subset converts exactly those.
+            handle_messages_with_content_list_to_str_conversion([m for m in messages if _has_text_only_content(m)])
+            return messages
+
         async def _async_transform():
-            return handle_messages_with_content_list_to_str_conversion(messages)
+            return _transform()
 
         if is_async:
             return _async_transform()
-        messages = handle_messages_with_content_list_to_str_conversion(messages)
-        return messages
+        return _transform()

--- a/tests/test_litellm/llms/sambanova/test_chat.py
+++ b/tests/test_litellm/llms/sambanova/test_chat.py
@@ -1,0 +1,101 @@
+"""
+Unit tests for SambaNova chat message transformation
+"""
+
+import pytest
+
+from litellm.llms.sambanova.chat import SambanovaConfig
+
+
+class TestSambanovaNonTextContentParts:
+    """
+    Content lists that carry a non-text part must keep their list form.
+    """
+
+    def test_content_list_with_image_is_preserved(self):
+        """
+        A content list carrying an `image_url` part must NOT be flattened.
+
+        SambaNova's API accepts the OpenAI content-list form with `image_url`, and its
+        vision models read it. Flattening dropped the image while still returning HTTP
+        200, so the model answered as if nothing had been attached.
+        """
+        config = SambanovaConfig()
+
+        image_part = {
+            "type": "image_url",
+            "image_url": {"url": "data:image/png;base64,iVBORw0KGgo="},
+        }
+        messages = [
+            {
+                "role": "user",
+                "content": [{"type": "text", "text": "What colour is this?"}, image_part],
+            }
+        ]
+
+        transformed_messages = config._transform_messages(
+            messages=messages, model="sambanova/gemma-4-31B-it", is_async=False
+        )
+
+        content = transformed_messages[0]["content"]
+        assert isinstance(content, list)
+        assert content[0] == {"type": "text", "text": "What colour is this?"}
+        assert content[1] == image_part
+
+    def test_string_content_is_left_alone(self):
+        """A message whose content is already a string passes through untouched."""
+        config = SambanovaConfig()
+
+        messages = [{"role": "user", "content": "Hello"}]
+
+        transformed_messages = config._transform_messages(
+            messages=messages, model="sambanova/gemma-4-31B-it", is_async=False
+        )
+
+        assert transformed_messages[0]["content"] == "Hello"
+
+    def test_text_only_messages_are_still_flattened_alongside_image_messages(self):
+        """
+        Mixed conversation: text-only lists are flattened as before, and only the
+        message that carries the image keeps its list form.
+        """
+        config = SambanovaConfig()
+
+        messages = [
+            {"role": "user", "content": [{"type": "text", "text": "Hello"}]},
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "And this?"},
+                    {"type": "image_url", "image_url": {"url": "https://example.com/a.png"}},
+                ],
+            },
+        ]
+
+        transformed_messages = config._transform_messages(
+            messages=messages, model="sambanova/gemma-4-31B-it", is_async=False
+        )
+
+        assert transformed_messages[0]["content"] == "Hello"
+        assert isinstance(transformed_messages[1]["content"], list)
+
+    @pytest.mark.asyncio
+    async def test_async_transform_preserves_image_content(self):
+        """The async path must behave like the sync one."""
+        config = SambanovaConfig()
+
+        messages = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "What colour is this?"},
+                    {"type": "image_url", "image_url": {"url": "https://example.com/a.png"}},
+                ],
+            }
+        ]
+
+        transformed_messages = await config._transform_messages(
+            messages=messages, model="sambanova/gemma-4-31B-it", is_async=True
+        )
+
+        assert isinstance(transformed_messages[0]["content"], list)


### PR DESCRIPTION
## TLDR

Problem this solves:

- The `sambanova` provider flattens every content list to a string
- `image_url` parts are dropped, so vision models answer as if nothing was attached

How it solves it:

- Flatten only the messages whose content list is entirely text

## User Flow

Before: a developer sending an image to a SambaNova vision model gets an answer that ignores it, with no error to explain why.

1. They send POST `http://litellm-domain/v1/chat/completions` with `"model": "sambanova/gemma-4-31B-it"` and a content list holding a `text` part and an `image_url` part
2. `HTTP 200` comes back, and the answer says no image was attached
3. The reported `prompt_tokens` matches the text alone, so nothing hints that the attachment was lost

After: the same request is answered from the image.

1. They send the same POST `http://litellm-domain/v1/chat/completions`
2. `HTTP 200` comes back with an answer describing the image
3. `prompt_tokens` now includes the image, so the usage reflects what was sent

## Relevant issues

Fixes #37609

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally: `uv run pytest tests/llm_translation/test_sambanova_chat_transformation.py tests/test_litellm/llms/sambanova -q` gives 7 passed
- [ ] My PR passes all required CI/CD checks (to be confirmed on the first CI run)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** (Greptile reviews once the PR is opened)

## Screenshots / Proof of Fix

Shared setup, a live SambaNova key and a 3x1 PNG whose bands are green, magenta and yellow:

```bash
ffmpeg -y -f lavfi -i "color=c=green:s=120x120:d=1" -f lavfi -i "color=c=magenta:s=120x120:d=1" \
  -f lavfi -i "color=c=yellow:s=120x120:d=1" \
  -filter_complex "[0:v][1:v][2:v]hstack=inputs=3[v]" -map "[v]" -frames:v 1 colors3.png

cat > verify.py <<'PY'
import base64, json, os
import litellm

b64 = base64.b64encode(open("colors3.png", "rb").read()).decode()
res = litellm.completion(
    model="sambanova/gemma-4-31B-it",
    api_key=os.environ["SAMBANOVA_API_KEY"],
    max_tokens=64,
    messages=[{"role": "user", "content": [
        {"type": "text", "text": "Name the three colours in this image from left to right. If no image is attached, answer exactly: NO IMAGE"},
        {"type": "image_url", "image_url": {"url": f"data:image/png;base64,{b64}"}},
    ]}],
)
print(json.dumps({"content": res.choices[0].message.content, "usage": res.usage.model_dump()}))
PY
```

The numbers below were measured on base 6fcdea03, with and without this change. The branch has since been rebased onto current `litellm_internal_staging`, with the commit message and the tests changed but not the transformation itself.

### Before (6fcdea03)

1. `python verify.py`
2. Observed, with the timing fields of SambaNova's usage trimmed:

   ```text
   {"content": "NO IMAGE", "usage": {"completion_tokens": 2, "prompt_tokens": 36, "total_tokens": 38, ...}}
   ```

### After (b7a0f9ee)

1. `python verify.py`
2. Observed, naming the bands and counting the image in the prompt:

   ```text
   {"content": "Green, magenta, yellow", "usage": {"completion_tokens": 5, "prompt_tokens": 290, "total_tokens": 295, ...}}
   ```

## Type

🐛 Bug Fix

## Caveats (if any)

- Text-only content lists are still flattened, so the existing tests hold unchanged
- SambaNova rejects video parts itself, so this does not make video work

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
