### PR TITLE
perf(ollama_chat): estimate token counts only when Ollama omits them

### DIFF
--- a/litellm/llms/ollama/chat/transformation.py
+++ b/litellm/llms/ollama/chat/transformation.py
@@ -386,10 +386,19 @@ class OllamaChatConfig(BaseConfig):
                 model_response.choices[0].finish_reason = "tool_calls"
         model_response.created = int(time.time())
         model_response.model = "ollama_chat/" + model
-        prompt_tokens = response_json.get("prompt_eval_count", litellm.token_counter(messages=messages))
-        completion_tokens: Final = response_json.get(
-            "eval_count",
-            litellm.token_counter(text=response_json["message"]["content"]),
+        # Ollama reports both counts, so only fall back to the estimator when a count is
+        # missing. Passing token_counter as the default argument of dict.get evaluates it
+        # on every response, which costs a tokenization pass per call and lets a counter
+        # failure discard a response Ollama already produced.
+        reported_prompt_tokens: Final = response_json.get("prompt_eval_count")
+        prompt_tokens: Final = (
+            reported_prompt_tokens if reported_prompt_tokens is not None else litellm.token_counter(messages=messages)
+        )
+        reported_completion_tokens: Final = response_json.get("eval_count")
+        completion_tokens: Final = (
+            reported_completion_tokens
+            if reported_completion_tokens is not None
+            else litellm.token_counter(text=response_json["message"]["content"])
         )
         setattr(
             model_response,

--- a/tests/test_litellm/llms/ollama/test_ollama_chat_transformation.py
+++ b/tests/test_litellm/llms/ollama/test_ollama_chat_transformation.py
@@ -906,3 +906,102 @@ class TestOllamaToolCallTransformation:
         assert tool_msg["content"] == "Sunny, 72°F"
         assert "tool_call_id" in tool_msg, "tool_call_id must be forwarded to Ollama"
         assert tool_msg["tool_call_id"] == "call_abc123"
+
+
+class TestOllamaChatUsageCounts:
+    """Tests for how usage is taken from Ollama's response."""
+
+    @staticmethod
+    def _transform(config, ollama_response, messages):
+        import json
+        from unittest.mock import MagicMock
+
+        from litellm.types.utils import Choices, Message, ModelResponse
+
+        mock_response = MagicMock()
+        mock_response.json.return_value = ollama_response
+        mock_response.text = json.dumps(ollama_response)
+
+        model_response = ModelResponse()
+        model_response.choices = [Choices(message=Message(content=""), index=0)]
+
+        return config.transform_response(
+            model="qwen3:14b",
+            raw_response=mock_response,
+            model_response=model_response,
+            logging_obj=MagicMock(),
+            request_data={},
+            messages=messages,
+            optional_params={},
+            litellm_params={},
+            encoding=None,
+            api_key=None,
+            json_mode=False,
+        )
+
+    def test_reported_counts_skip_the_estimator(self):
+        """
+        When Ollama reports both counts, `litellm.token_counter` must not run.
+
+        Passing it as the default argument of `dict.get` evaluates it on every
+        response: it costs a tokenization pass per call, and a counter failure
+        discards a response Ollama already produced. Content types the counter
+        does not handle (a `video_url` block reaches Ollama's route because
+        `extract_images_from_message` only collects `image_url`) therefore turned
+        a 200 into a 500.
+        """
+        from unittest.mock import patch
+
+        import litellm
+
+        ollama_response = {
+            "model": "qwen3:14b",
+            "created_at": "2025-01-11T00:00:00.000000Z",
+            "message": {"role": "assistant", "content": "Hello!"},
+            "done": True,
+            "prompt_eval_count": 100,
+            "eval_count": 50,
+        }
+        messages = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "Describe this."},
+                    {
+                        "type": "video_url",
+                        "video_url": {"url": "data:video/mp4;base64,AAAA"},
+                    },
+                ],
+            }
+        ]
+
+        with patch.object(
+            litellm, "token_counter", side_effect=AssertionError("estimator ran")
+        ):
+            result = self._transform(OllamaChatConfig(), ollama_response, messages)
+
+        assert result.usage.prompt_tokens == 100
+        assert result.usage.completion_tokens == 50
+        assert result.usage.total_tokens == 150
+
+    def test_missing_counts_fall_back_to_the_estimator(self):
+        """When Ollama omits a count, the estimator fills it in."""
+        from unittest.mock import patch
+
+        import litellm
+
+        ollama_response = {
+            "model": "qwen3:14b",
+            "created_at": "2025-01-11T00:00:00.000000Z",
+            "message": {"role": "assistant", "content": "Hello!"},
+            "done": True,
+        }
+        messages = [{"role": "user", "content": "Hi"}]
+
+        with patch.object(litellm, "token_counter", return_value=7) as counter:
+            result = self._transform(OllamaChatConfig(), ollama_response, messages)
+
+        assert counter.call_count == 2
+        assert result.usage.prompt_tokens == 7
+        assert result.usage.completion_tokens == 7
+


### PR DESCRIPTION
## TLDR

Problem this solves:

- `ollama_chat` runs `token_counter` on every response although Ollama reports both counts
- A counter failure then discards a response Ollama already produced

How it solves it:

- Read `prompt_eval_count` and `eval_count` first, and estimate only when one is missing

## User Flow

Before: every call to an Ollama-backed deployment pays for a token count the gateway already has, and a request the counter cannot handle fails after the model ran.

1. A developer sends POST `http://litellm-domain/v1/chat/completions` to an Ollama-backed model
2. The answer comes back with usage, having also spent a full tokenization pass over the prompt and the completion on the gateway
3. When the request carries a content part the counter does not handle, such as a `video_url` block, the caller instead gets `HTTP 500` even though Ollama's log shows the generation finished with `POST /api/chat` 200

After: the reported counts are used as they are, and such a request returns the answer.

1. The developer sends the same POST `http://litellm-domain/v1/chat/completions`
2. The answer comes back with the same usage, without the extra tokenization pass
3. The request carrying a `video_url` block now returns `HTTP 200` with the answer and Ollama's counts

## Relevant issues

Related to #28071. #37817 fixes the counter itself; this PR is independent of it: it stops the route from calling the counter when Ollama has already reported the numbers.

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally: `uv run pytest tests/test_litellm/llms/ollama -q` gives 73 passed
- [ ] My PR passes all required CI/CD checks (to be confirmed on the first CI run)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** (Greptile reviews once the PR is opened)

## Screenshots / Proof of Fix

Shared setup, a throwaway Ollama the gateway can reach and one request carrying a `video_url` part:

```bash
docker container run -d --name ollama-verify -p 11439:11434 ollama/ollama:latest
docker container exec ollama-verify ollama pull qwen3:0.6b

cat > config.yaml <<'YAML'
model_list:
  - model_name: qwen3-0.6b
    litellm_params:
      model: ollama_chat/qwen3:0.6b
      # the Ollama container as reachable from wherever the proxy runs
      api_base: http://172.16.0.4:11434
YAML

cat > payload.json <<'JSON'
{
  "model": "qwen3-0.6b",
  "max_tokens": 32,
  "messages": [
    {
      "role": "user",
      "content": [
        {"type": "text", "text": "Reply with the single word: ok"},
        {"type": "video_url", "video_url": {"url": "data:video/mp4;base64,AAAAIGZ0eXBpc29t"}}
      ]
    }
  ]
}
JSON
```

### Before (ff02d5cf)

1. `litellm --config config.yaml --port 4099`, then
   `curl -sS -w '\nHTTP %{http_code}\n' http://127.0.0.1:4099/v1/chat/completions -H 'Content-Type: application/json' -H 'Authorization: Bearer sk-1234' -d @payload.json`
2. Observed, with the traceback trimmed to the frame that reaches the counter:

   ```text
   {"error":{"message":"litellm.APIConnectionError: Error getting number of tokens from content list: Invalid content item type: video_url. Expected str or dict with 'type' field (text, image_url, tool_use, tool_result, thinking, tool_reference)., default_token_count=None
   ...
     File "litellm/llms/ollama/chat/transformation.py", line 389, in transform_response
       prompt_tokens = response_json.get("prompt_eval_count", litellm.token_counter(messages=messages))
   ...
   HTTP 500
   ```

3. Ollama's own access log for that window shows the generation finishing three times, once per gateway retry:

   ```text
   [GIN] 2026/08/21 - 13:39:45 | 200 |  4.778656905s | POST     "/api/chat"
   [GIN] 2026/08/21 - 13:39:46 | 200 |  362.181405ms | POST     "/api/chat"
   [GIN] 2026/08/21 - 13:39:48 | 200 |  327.857829ms | POST     "/api/chat"
   ```

### After (cc65ba58)

1. The same two commands.
2. Observed, with the usage taken from Ollama's own counts:

   ```text
   {"id":"chatcmpl-b119f940-ea6b-45e2-9f68-5b9a0eb3c477","created":1787319606,"model":"qwen3-0.6b","object":"chat.completion","choices":[{"finish_reason":"length","index":0,"message":{"content":"","role":"assistant","reasoning_content":"Okay, the user wants me to reply with the single word \"ok\" after some text. Let me check the previous messages to understand the context."}}],"usage":{"completion_tokens":32,"prompt_tokens":17,"total_tokens":49}}
   HTTP 200
   ```

## Type

🐛 Bug Fix
🚄 Infrastructure

## Caveats (if any)

- Touches the same test file as #37817, so one of the two will need a trivial rebase
- Streaming already reads the reported counts and is untouched

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
