### PR TITLE
perf(ci): cache the Cargo build the unit shards redo on every job

### DIFF
--- a/.github/workflows/_test-unit-base.yml
+++ b/.github/workflows/_test-unit-base.yml
@@ -27,7 +27,7 @@ on:
         default: 20
       job-timeout-minutes:
         description: >-
-          Backstop for the whole job. Keep it >= `timeout-minutes` plus 35: 30 for
+          Backstop for the whole job. Keep it >= `timeout-minutes` plus 40: 35 for
           the per-step ceilings on the setup steps below, and 5 for the runner
           overhead the job clock charges but no step owns (job init, step
           transitions, post-job cleanup). That headroom is what makes the test
@@ -36,7 +36,7 @@ on:
           arithmetic, so the sum is passed in rather than computed.
         required: false
         type: number
-        default: 55
+        default: 60
       max-failures:
         description: "Stop after this many failures"
         required: false
@@ -102,6 +102,30 @@ jobs:
           key: ${{ runner.os }}-uv-${{ hashFiles('uv.lock') }}
           restore-keys: |
             ${{ runner.os }}-uv-
+
+      # `litellm` itself is built by maturin, so every uv sync compiles the pyo3
+      # bridge and its Rust dependency tree from scratch. That is the ~3 minutes
+      # the `Install dependencies` step costs on a run where the uv cache is a
+      # clean hit, on every shard, on every PR. Cargo keyed on Cargo.lock is the
+      # part that carries across commits: the dependency crates do not change
+      # when a Python file does.
+      #
+      # Deliberately a different key prefix from test-rust.yml's. That workflow
+      # caches a debug-profile target for clippy; a maturin wheel is a release
+      # build, so sharing the lineage would restore artifacts this step cannot
+      # use and evict the ones it can.
+      - name: Cache Cargo registry and target
+        if: steps.changes.outputs.decision != 'skip'
+        timeout-minutes: 5
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            litellm-rust/target
+          key: ${{ runner.os }}-maturin-cargo-${{ hashFiles('litellm-rust/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-maturin-cargo-
 
       - name: Install dependencies
         if: steps.changes.outputs.decision != 'skip'

--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -55,7 +55,7 @@ jobs:
             workers: 2
             reruns: 1
             timeout-minutes: 20
-            job-timeout-minutes: 55
+            job-timeout-minutes: 60
 
           - shard: enterprise-routing
             artifact-name: enterprise-routing
@@ -67,7 +67,7 @@ jobs:
             workers: 2
             reruns: 2
             timeout-minutes: 20
-            job-timeout-minutes: 55
+            job-timeout-minutes: 60
 
           - shard: integrations
             artifact-name: integrations
@@ -75,7 +75,7 @@ jobs:
             workers: 2
             reruns: 3
             timeout-minutes: 20
-            job-timeout-minutes: 55
+            job-timeout-minutes: 60
 
           - shard: Vertex AI
             artifact-name: llm-vertex-ai
@@ -83,7 +83,7 @@ jobs:
             workers: 1
             reruns: 2
             timeout-minutes: 20
-            job-timeout-minutes: 55
+            job-timeout-minutes: 60
 
           - shard: All Other Providers
             artifact-name: llm-other-providers
@@ -91,7 +91,7 @@ jobs:
             workers: 2
             reruns: 2
             timeout-minutes: 20
-            job-timeout-minutes: 55
+            job-timeout-minutes: 60
 
           - shard: misc
             artifact-name: misc
@@ -122,7 +122,7 @@ jobs:
             workers: 2
             reruns: 2
             timeout-minutes: 20
-            job-timeout-minutes: 55
+            job-timeout-minutes: 60
 
           - shard: proxy-auth
             artifact-name: proxy-auth
@@ -134,7 +134,7 @@ jobs:
             workers: 2
             reruns: 2
             timeout-minutes: 20
-            job-timeout-minutes: 55
+            job-timeout-minutes: 60
 
           - shard: proxy-endpoints
             artifact-name: proxy-endpoints
@@ -171,7 +171,7 @@ jobs:
             workers: 2
             reruns: 2
             timeout-minutes: 20
-            job-timeout-minutes: 55
+            job-timeout-minutes: 60
 
           - shard: proxy-server
             artifact-name: proxy-server
@@ -179,7 +179,7 @@ jobs:
             workers: 4
             reruns: 2
             timeout-minutes: 60
-            job-timeout-minutes: 95
+            job-timeout-minutes: 100
 
           - shard: proxy-infra
             artifact-name: proxy-infra
@@ -198,7 +198,7 @@ jobs:
             workers: 2
             reruns: 2
             timeout-minutes: 20
-            job-timeout-minutes: 55
+            job-timeout-minutes: 60
 
           - shard: responses-caching-types
             artifact-name: responses-caching-types
@@ -209,7 +209,7 @@ jobs:
             workers: 2
             reruns: 2
             timeout-minutes: 20
-            job-timeout-minutes: 55
+            job-timeout-minutes: 60
     uses: ./.github/workflows/_test-unit-base.yml
     with:
       test-path: ${{ matrix.test-path }}


### PR DESCRIPTION
## TLDR

Problem this solves:

- `litellm` is a maturin package, so uv sync compiles Rust
- Every unit shard pays ~3 minutes for that, every PR
- Nothing caches the Cargo registry or target dir

How it solves it:

- Cache both, keyed on Cargo.lock, like test-rust.yml
- `Install dependencies` drops to ~0.6 min on a hit

## User Flow

No end-user behavior changes. A contributor opening a PR sees the same unit
checks with the same names and the same results, roughly two minutes sooner per
shard, and the slowest required unit check lands in under seven minutes instead
of just under ten.

## Relevant issues

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

Shared setup: both sides are real Unit Tests runs. Before is the last staging
run before this branch, after is a warm dispatch on the branch. Step and job
durations come from the runs themselves.

```
gh api "repos/BerriAI/litellm/actions/runs/<id>/jobs?per_page=100" --jq '
  .jobs[] | select(.conclusion=="success" and (.name|endswith("Run tests"))) |
  "\(.name) TOTAL=\((((.completed_at|fromdate)-(.started_at|fromdate))/60*10|round)/10)m " +
  ([.steps[] | select(.name|test("Install dep")) |
    "install=\((((.completed_at|fromdate)-(.started_at|fromdate))/60*10|round)/10)"] | join(""))'
```

### Before (ff02d5cfc0, run 32456962579)

#### what the install step costs

1. The command above

```
proxy-endpoints          TOTAL=9.9m  install=3
proxy-infra              TOTAL=9.3m  install=2.9
All Other Providers      TOTAL=7.9m  install=2.6
misc                     TOTAL=8m    install=2.7
integrations             TOTAL=6.4m  install=2.7
enterprise-routing       TOTAL=6m    install=2.8
proxy-auth               TOTAL=6m    install=2.5
Vertex AI                TOTAL=5.9m  install=2.8
proxy-server             TOTAL=5.1m  install=2.6
responses-caching-types  TOTAL=5.1m  install=2.7
core-utils               TOTAL=5.1m  install=2.7
```

2. What that step is doing, from the proxy-endpoints job log

```
uv sync attempt 1/5
   Building litellm @ file:///home/runner/work/litellm/litellm
   Building litellm-enterprise @ file:///home/runner/work/litellm/litellm/enterprise
   Building litellm-proxy-extras @ file:///home/runner/work/litellm/litellm/litellm-proxy-extras
Prepared 3 packages in 2m 59s
```

The uv cache is a clean hit on that run. The three minutes are the maturin
build of the pyo3 bridge and the Rust crates under it.

### After (ee0bb35d8a, run 32472561343)

#### what the install step costs

1. The same command

```
proxy-endpoints          TOTAL=6.5m  install=0.6
proxy-infra              TOTAL=6.9m  install=0.6
All Other Providers      TOTAL=6.2m  install=0.7
misc                     TOTAL=5.1m  install=0.5
integrations             TOTAL=4.2m  install=0.6
enterprise-routing       TOTAL=3.4m  install=0.5
proxy-auth               TOTAL=3.6m  install=0.6
Vertex AI                TOTAL=3.2m  install=0.6
proxy-server             TOTAL=3m    install=0.7
responses-caching-types  TOTAL=3.5m  install=0.6
core-utils               TOTAL=3m    install=0.5
```

2. All 11 shards green, and the cache the cold run left behind

```
Linux-maturin-cargo-723fc218a0833e635166f83ee295ea7dcd567e4f1128b6378a069afd358be1f1  236MB
```

Slowest required unit check 9.9m -> 6.9m, total 74.7 job-minutes -> 48.6

## Type

🚄 Infrastructure

## Caveats (if any)

- The first run on a new Cargo.lock is a miss and pays full price
- 236MB added to the repo cache, on its own key prefix
- Deliberately not shared with test-rust.yml's debug-profile target
- Job totals carry runner noise, the install step delta does not
- The new step's ceiling moves each job backstop 55 -> 60

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
