### PR TITLE
fix: skip Vercel AI Gateway rows without token pricing in the price updater

### DIFF
--- a/.github/scripts/auto_update_price_and_context_window_file.py
+++ b/.github/scripts/auto_update_price_and_context_window_file.py
@@ -85,10 +85,23 @@ def transform_openrouter_data(data):
 def transform_vercel_ai_gateway_data(data):
     transformed = {}
     for row in data:
+        pricing = row.get("pricing") or {}
+        # Skip rows without token pricing or token limits. The gateway also
+        # lists embedding, image, video and audio models whose entries omit
+        # pricing.input/pricing.output or context_window entirely, and those
+        # cannot be expressed as cost-per-token entries.
+        if (
+            row.get("context_window") is None
+            or row.get("max_tokens") is None
+            or pricing.get("input") is None
+            or pricing.get("output") is None
+        ):
+            continue
+
         obj = {
             "max_tokens": row["context_window"],
-            "input_cost_per_token": float(row["pricing"]["input"]),
-            "output_cost_per_token": float(row["pricing"]["output"]),
+            "input_cost_per_token": float(pricing["input"]),
+            "output_cost_per_token": float(pricing["output"]),
             'max_output_tokens': row['max_tokens'],
             'max_input_tokens': row["context_window"],
         }


### PR DESCRIPTION
## Title

fix: skip Vercel AI Gateway rows without token pricing in the price updater

## Relevant issues

None filed; the failing runs are the evidence.

## Type

🐛 Bug Fix

## Changes

The weekly "Updates model_prices_and_context_window.json" job has failed on every run since April. From run 31916496571:

```
  File ".../auto_update_price_and_context_window_file.py", line 91, in transform_vercel_ai_gateway_data
KeyError: 'output'
```

`transform_vercel_ai_gateway_data` indexes `context_window`, `max_tokens`, `pricing["input"]` and `pricing["output"]` on every row, but the gateway's `/v1/models` also lists embedding, image, video and audio models whose rows omit those fields. Against the live endpoint today: **350 rows, 108 with no `pricing.output`, 73 with no `pricing.input`, 16 with no `context_window` at all** (fish-audio, wan video, flux image, qwen embedding models). The first such row kills the whole update, so no automated price refresh has landed in months.

The fix skips rows missing any of the four required fields, in the guarded style the OpenRouter transform in the same file already uses for its optional fields. Rows without token pricing cannot be represented as cost-per-token entries in `model_prices_and_context_window.json` anyway.

Verified against a snapshot of the live endpoint taken today:

| | result |
|---|---|
| current code | `KeyError: 'output'` on row 10, `alibaba/qwen3-embedding-0.6b`, matching the CI traceback |
| with this change | 240 of 350 rows transform; the 110 skipped are exactly the embedding, image, video and audio models |

I could not run the workflow end to end since it is schedule/dispatch-only; the harness above exercises the changed function with the real API payload. Happy to add the skipped-row ids to the job log if you want visibility into what gets excluded.
