### PR TITLE
feat(bedrock): serve gpt-5.6 cross-region inference profiles on bedrock runtime

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -48545,6 +48545,156 @@
         "supports_tool_choice": true,
         "supports_vision": true
     },
+    "us.openai.gpt-5.6-sol": {
+        "input_cost_per_token": 5.5e-06,
+        "input_cost_per_token_above_272k_tokens": 1.1e-05,
+        "cache_creation_input_token_cost": 6.875e-06,
+        "cache_creation_input_token_cost_above_272k_tokens": 1.375e-05,
+        "cache_read_input_token_cost": 5.5e-07,
+        "cache_read_input_token_cost_above_272k_tokens": 1.1e-06,
+        "output_cost_per_token": 3.3e-05,
+        "output_cost_per_token_above_272k_tokens": 4.95e-05,
+        "litellm_provider": "bedrock_converse",
+        "max_input_tokens": 1000000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "chat",
+        "supported_modalities": [
+            "text",
+            "image"
+        ],
+        "supported_output_modalities": [
+            "text"
+        ],
+        "supports_function_calling": true,
+        "supports_tool_choice": true,
+        "supports_vision": true
+    },
+    "global.openai.gpt-5.6-sol": {
+        "input_cost_per_token": 5e-06,
+        "input_cost_per_token_above_272k_tokens": 1e-05,
+        "cache_creation_input_token_cost": 6.25e-06,
+        "cache_creation_input_token_cost_above_272k_tokens": 1.25e-05,
+        "cache_read_input_token_cost": 5e-07,
+        "cache_read_input_token_cost_above_272k_tokens": 1e-06,
+        "output_cost_per_token": 3e-05,
+        "output_cost_per_token_above_272k_tokens": 4.5e-05,
+        "litellm_provider": "bedrock_converse",
+        "max_input_tokens": 1000000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "chat",
+        "supported_modalities": [
+            "text",
+            "image"
+        ],
+        "supported_output_modalities": [
+            "text"
+        ],
+        "supports_function_calling": true,
+        "supports_tool_choice": true,
+        "supports_vision": true
+    },
+    "us.openai.gpt-5.6-terra": {
+        "input_cost_per_token": 2.2e-06,
+        "input_cost_per_token_above_272k_tokens": 4.4e-06,
+        "cache_creation_input_token_cost": 2.75e-06,
+        "cache_creation_input_token_cost_above_272k_tokens": 5.5e-06,
+        "cache_read_input_token_cost": 2.2e-07,
+        "cache_read_input_token_cost_above_272k_tokens": 4.4e-07,
+        "output_cost_per_token": 1.32e-05,
+        "output_cost_per_token_above_272k_tokens": 1.98e-05,
+        "litellm_provider": "bedrock_converse",
+        "max_input_tokens": 1000000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "chat",
+        "supported_modalities": [
+            "text",
+            "image"
+        ],
+        "supported_output_modalities": [
+            "text"
+        ],
+        "supports_function_calling": true,
+        "supports_tool_choice": true,
+        "supports_vision": true
+    },
+    "global.openai.gpt-5.6-terra": {
+        "input_cost_per_token": 2e-06,
+        "input_cost_per_token_above_272k_tokens": 4e-06,
+        "cache_creation_input_token_cost": 2.5e-06,
+        "cache_creation_input_token_cost_above_272k_tokens": 5e-06,
+        "cache_read_input_token_cost": 2e-07,
+        "cache_read_input_token_cost_above_272k_tokens": 4e-07,
+        "output_cost_per_token": 1.2e-05,
+        "output_cost_per_token_above_272k_tokens": 1.8e-05,
+        "litellm_provider": "bedrock_converse",
+        "max_input_tokens": 1000000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "chat",
+        "supported_modalities": [
+            "text",
+            "image"
+        ],
+        "supported_output_modalities": [
+            "text"
+        ],
+        "supports_function_calling": true,
+        "supports_tool_choice": true,
+        "supports_vision": true
+    },
+    "us.openai.gpt-5.6-luna": {
+        "input_cost_per_token": 2.2e-07,
+        "input_cost_per_token_above_272k_tokens": 4.4e-07,
+        "cache_creation_input_token_cost": 2.75e-07,
+        "cache_creation_input_token_cost_above_272k_tokens": 5.5e-07,
+        "cache_read_input_token_cost": 2.2e-08,
+        "cache_read_input_token_cost_above_272k_tokens": 4.4e-08,
+        "output_cost_per_token": 1.32e-06,
+        "output_cost_per_token_above_272k_tokens": 1.98e-06,
+        "litellm_provider": "bedrock_converse",
+        "max_input_tokens": 1000000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "chat",
+        "supported_modalities": [
+            "text",
+            "image"
+        ],
+        "supported_output_modalities": [
+            "text"
+        ],
+        "supports_function_calling": true,
+        "supports_tool_choice": true,
+        "supports_vision": true
+    },
+    "global.openai.gpt-5.6-luna": {
+        "input_cost_per_token": 2e-07,
+        "input_cost_per_token_above_272k_tokens": 4e-07,
+        "cache_creation_input_token_cost": 2.5e-07,
+        "cache_creation_input_token_cost_above_272k_tokens": 5e-07,
+        "cache_read_input_token_cost": 2e-08,
+        "cache_read_input_token_cost_above_272k_tokens": 4e-08,
+        "output_cost_per_token": 1.2e-06,
+        "output_cost_per_token_above_272k_tokens": 1.8e-06,
+        "litellm_provider": "bedrock_converse",
+        "max_input_tokens": 1000000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "chat",
+        "supported_modalities": [
+            "text",
+            "image"
+        ],
+        "supported_output_modalities": [
+            "text"
+        ],
+        "supports_function_calling": true,
+        "supports_tool_choice": true,
+        "supports_vision": true
+    },
     "bedrock_mantle/openai.gpt-5.5": {
         "input_cost_per_token": 5.5e-06,
         "cache_read_input_token_cost": 5.5e-07,

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -48545,6 +48545,156 @@
         "supports_tool_choice": true,
         "supports_vision": true
     },
+    "us.openai.gpt-5.6-sol": {
+        "input_cost_per_token": 5.5e-06,
+        "input_cost_per_token_above_272k_tokens": 1.1e-05,
+        "cache_creation_input_token_cost": 6.875e-06,
+        "cache_creation_input_token_cost_above_272k_tokens": 1.375e-05,
+        "cache_read_input_token_cost": 5.5e-07,
+        "cache_read_input_token_cost_above_272k_tokens": 1.1e-06,
+        "output_cost_per_token": 3.3e-05,
+        "output_cost_per_token_above_272k_tokens": 4.95e-05,
+        "litellm_provider": "bedrock_converse",
+        "max_input_tokens": 1000000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "chat",
+        "supported_modalities": [
+            "text",
+            "image"
+        ],
+        "supported_output_modalities": [
+            "text"
+        ],
+        "supports_function_calling": true,
+        "supports_tool_choice": true,
+        "supports_vision": true
+    },
+    "global.openai.gpt-5.6-sol": {
+        "input_cost_per_token": 5e-06,
+        "input_cost_per_token_above_272k_tokens": 1e-05,
+        "cache_creation_input_token_cost": 6.25e-06,
+        "cache_creation_input_token_cost_above_272k_tokens": 1.25e-05,
+        "cache_read_input_token_cost": 5e-07,
+        "cache_read_input_token_cost_above_272k_tokens": 1e-06,
+        "output_cost_per_token": 3e-05,
+        "output_cost_per_token_above_272k_tokens": 4.5e-05,
+        "litellm_provider": "bedrock_converse",
+        "max_input_tokens": 1000000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "chat",
+        "supported_modalities": [
+            "text",
+            "image"
+        ],
+        "supported_output_modalities": [
+            "text"
+        ],
+        "supports_function_calling": true,
+        "supports_tool_choice": true,
+        "supports_vision": true
+    },
+    "us.openai.gpt-5.6-terra": {
+        "input_cost_per_token": 2.2e-06,
+        "input_cost_per_token_above_272k_tokens": 4.4e-06,
+        "cache_creation_input_token_cost": 2.75e-06,
+        "cache_creation_input_token_cost_above_272k_tokens": 5.5e-06,
+        "cache_read_input_token_cost": 2.2e-07,
+        "cache_read_input_token_cost_above_272k_tokens": 4.4e-07,
+        "output_cost_per_token": 1.32e-05,
+        "output_cost_per_token_above_272k_tokens": 1.98e-05,
+        "litellm_provider": "bedrock_converse",
+        "max_input_tokens": 1000000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "chat",
+        "supported_modalities": [
+            "text",
+            "image"
+        ],
+        "supported_output_modalities": [
+            "text"
+        ],
+        "supports_function_calling": true,
+        "supports_tool_choice": true,
+        "supports_vision": true
+    },
+    "global.openai.gpt-5.6-terra": {
+        "input_cost_per_token": 2e-06,
+        "input_cost_per_token_above_272k_tokens": 4e-06,
+        "cache_creation_input_token_cost": 2.5e-06,
+        "cache_creation_input_token_cost_above_272k_tokens": 5e-06,
+        "cache_read_input_token_cost": 2e-07,
+        "cache_read_input_token_cost_above_272k_tokens": 4e-07,
+        "output_cost_per_token": 1.2e-05,
+        "output_cost_per_token_above_272k_tokens": 1.8e-05,
+        "litellm_provider": "bedrock_converse",
+        "max_input_tokens": 1000000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "chat",
+        "supported_modalities": [
+            "text",
+            "image"
+        ],
+        "supported_output_modalities": [
+            "text"
+        ],
+        "supports_function_calling": true,
+        "supports_tool_choice": true,
+        "supports_vision": true
+    },
+    "us.openai.gpt-5.6-luna": {
+        "input_cost_per_token": 2.2e-07,
+        "input_cost_per_token_above_272k_tokens": 4.4e-07,
+        "cache_creation_input_token_cost": 2.75e-07,
+        "cache_creation_input_token_cost_above_272k_tokens": 5.5e-07,
+        "cache_read_input_token_cost": 2.2e-08,
+        "cache_read_input_token_cost_above_272k_tokens": 4.4e-08,
+        "output_cost_per_token": 1.32e-06,
+        "output_cost_per_token_above_272k_tokens": 1.98e-06,
+        "litellm_provider": "bedrock_converse",
+        "max_input_tokens": 1000000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "chat",
+        "supported_modalities": [
+            "text",
+            "image"
+        ],
+        "supported_output_modalities": [
+            "text"
+        ],
+        "supports_function_calling": true,
+        "supports_tool_choice": true,
+        "supports_vision": true
+    },
+    "global.openai.gpt-5.6-luna": {
+        "input_cost_per_token": 2e-07,
+        "input_cost_per_token_above_272k_tokens": 4e-07,
+        "cache_creation_input_token_cost": 2.5e-07,
+        "cache_creation_input_token_cost_above_272k_tokens": 5e-07,
+        "cache_read_input_token_cost": 2e-08,
+        "cache_read_input_token_cost_above_272k_tokens": 4e-08,
+        "output_cost_per_token": 1.2e-06,
+        "output_cost_per_token_above_272k_tokens": 1.8e-06,
+        "litellm_provider": "bedrock_converse",
+        "max_input_tokens": 1000000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "chat",
+        "supported_modalities": [
+            "text",
+            "image"
+        ],
+        "supported_output_modalities": [
+            "text"
+        ],
+        "supports_function_calling": true,
+        "supports_tool_choice": true,
+        "supports_vision": true
+    },
     "bedrock_mantle/openai.gpt-5.5": {
         "input_cost_per_token": 5.5e-06,
         "cache_read_input_token_cost": 5.5e-07,

--- a/tests/test_litellm/llms/bedrock/test_cross_region_inference_profile_mapping.py
+++ b/tests/test_litellm/llms/bedrock/test_cross_region_inference_profile_mapping.py
@@ -1,13 +1,132 @@
 """Test Bedrock cross-region inference profile model mapping"""
 
+import json
 import os
 import sys
+from functools import lru_cache
+from pathlib import Path
+from typing import NamedTuple
+
+import pytest
 
 sys.path.insert(0, os.path.abspath("../../../.."))
 
+import litellm
+from litellm.llms.bedrock.chat.converse_transformation import AmazonConverseConfig
+from litellm.llms.bedrock.common_utils import BedrockModelInfo
 from litellm.utils import _get_model_info_helper
 from litellm.cost_calculator import completion_cost
-from litellm.types.utils import ModelResponse, Usage, Choices, Message
+from litellm.types.utils import (
+    Choices,
+    Message,
+    ModelResponse,
+    PromptTokensDetailsWrapper,
+    Usage,
+)
+
+
+@pytest.fixture
+def local_model_cost_map(monkeypatch):
+    """Resolve models against this checkout's cost map instead of the network-fetched
+    ``main`` copy, which lags this branch until merge."""
+    original_converse_models = set(litellm.bedrock_converse_models)
+    monkeypatch.setenv("LITELLM_LOCAL_MODEL_COST_MAP", "True")
+    monkeypatch.setattr(litellm, "model_cost", litellm.get_model_cost_map(url=""))
+    litellm.get_model_info.cache_clear()
+    try:
+        litellm.bedrock_converse_models.update(
+            key
+            for key, value in litellm.model_cost.items()
+            if isinstance(value, dict)
+            and value.get("litellm_provider") == "bedrock_converse"
+        )
+        yield
+    finally:
+        litellm.bedrock_converse_models.clear()
+        litellm.bedrock_converse_models.update(original_converse_models)
+        litellm.get_model_info.cache_clear()
+
+
+class GptProfile(NamedTuple):
+    model_id: str
+    input_cost: float
+    input_cost_above_272k: float
+    cache_write: float
+    cache_write_above_272k: float
+    cache_read: float
+    cache_read_above_272k: float
+    output_cost: float
+    output_cost_above_272k: float
+
+
+GPT_5_6_PROFILES = [
+    GptProfile(
+        model_id="us.openai.gpt-5.6-sol",
+        input_cost=5.5e-06, input_cost_above_272k=1.1e-05,
+        cache_write=6.875e-06, cache_write_above_272k=1.375e-05,
+        cache_read=5.5e-07, cache_read_above_272k=1.1e-06,
+        output_cost=3.3e-05, output_cost_above_272k=4.95e-05,
+    ),
+    GptProfile(
+        model_id="global.openai.gpt-5.6-sol",
+        input_cost=5e-06, input_cost_above_272k=1e-05,
+        cache_write=6.25e-06, cache_write_above_272k=1.25e-05,
+        cache_read=5e-07, cache_read_above_272k=1e-06,
+        output_cost=3e-05, output_cost_above_272k=4.5e-05,
+    ),
+    GptProfile(
+        model_id="us.openai.gpt-5.6-terra",
+        input_cost=2.2e-06, input_cost_above_272k=4.4e-06,
+        cache_write=2.75e-06, cache_write_above_272k=5.5e-06,
+        cache_read=2.2e-07, cache_read_above_272k=4.4e-07,
+        output_cost=1.32e-05, output_cost_above_272k=1.98e-05,
+    ),
+    GptProfile(
+        model_id="global.openai.gpt-5.6-terra",
+        input_cost=2e-06, input_cost_above_272k=4e-06,
+        cache_write=2.5e-06, cache_write_above_272k=5e-06,
+        cache_read=2e-07, cache_read_above_272k=4e-07,
+        output_cost=1.2e-05, output_cost_above_272k=1.8e-05,
+    ),
+    GptProfile(
+        model_id="us.openai.gpt-5.6-luna",
+        input_cost=2.2e-07, input_cost_above_272k=4.4e-07,
+        cache_write=2.75e-07, cache_write_above_272k=5.5e-07,
+        cache_read=2.2e-08, cache_read_above_272k=4.4e-08,
+        output_cost=1.32e-06, output_cost_above_272k=1.98e-06,
+    ),
+    GptProfile(
+        model_id="global.openai.gpt-5.6-luna",
+        input_cost=2e-07, input_cost_above_272k=4e-07,
+        cache_write=2.5e-07, cache_write_above_272k=5e-07,
+        cache_read=2e-08, cache_read_above_272k=4e-08,
+        output_cost=1.2e-06, output_cost_above_272k=1.8e-06,
+    ),
+]
+
+
+@lru_cache(maxsize=1)
+def _packaged_cost_map():
+    """The map litellm actually resolves against, for fields ModelInfoBase drops."""
+    path = Path(litellm.__file__).parent / "model_prices_and_context_window_backup.json"
+    return json.loads(path.read_text())
+
+
+def _bedrock_response(model, usage):
+    return ModelResponse(
+        id="test",
+        created=1234567890,
+        model=model,
+        object="chat.completion",
+        choices=[
+            Choices(
+                finish_reason="stop",
+                index=0,
+                message=Message(content="OK", role="assistant"),
+            )
+        ],
+        usage=usage,
+    )
 
 
 def test_bedrock_cross_region_inference_profile_mapping():
@@ -52,3 +171,140 @@ def test_proxy_cost_calculation_scenario():
     )
     expected_cost = (100 * 8e-07) + (50 * 4e-06)
     assert cost == expected_cost
+
+
+@pytest.mark.parametrize("profile", GPT_5_6_PROFILES, ids=lambda p: p.model_id)
+def test_bedrock_gpt_5_6_profiles_route_to_converse(profile, local_model_cost_map):
+    """GPT-5.6 is served by Converse on bedrock-runtime, never by Invoke."""
+    assert BedrockModelInfo.get_bedrock_route(f"bedrock/{profile.model_id}") == "converse"
+
+
+@pytest.mark.parametrize("profile", GPT_5_6_PROFILES, ids=lambda p: p.model_id)
+def test_bedrock_gpt_5_6_published_rates(profile, local_model_cost_map):
+    """Geo and Global profiles carry their own published rates, per context tier."""
+    model_info = _get_model_info_helper(
+        model=f"bedrock/{profile.model_id}", custom_llm_provider="bedrock"
+    )
+
+    assert model_info["litellm_provider"] == "bedrock_converse"
+    assert model_info["mode"] == "chat"
+    assert model_info["max_input_tokens"] == 1000000
+    assert model_info["input_cost_per_token"] == profile.input_cost
+    assert (
+        model_info["input_cost_per_token_above_272k_tokens"]
+        == profile.input_cost_above_272k
+    )
+    assert model_info["output_cost_per_token"] == profile.output_cost
+    assert (
+        model_info["output_cost_per_token_above_272k_tokens"]
+        == profile.output_cost_above_272k
+    )
+    assert model_info["cache_creation_input_token_cost"] == profile.cache_write
+    assert (
+        model_info["cache_creation_input_token_cost_above_272k_tokens"]
+        == profile.cache_write_above_272k
+    )
+    assert model_info["cache_read_input_token_cost"] == profile.cache_read
+    assert (
+        model_info["cache_read_input_token_cost_above_272k_tokens"]
+        == profile.cache_read_above_272k
+    )
+
+
+def test_bedrock_gpt_5_6_above_272k_tier_applies_to_cost(local_model_cost_map):
+    """A prompt over 272K tokens is billed at the long-context rate, not the base rate."""
+    response = _bedrock_response(
+        "bedrock/us.openai.gpt-5.6-sol",
+        Usage(prompt_tokens=300000, completion_tokens=1000, total_tokens=301000),
+    )
+
+    cost = completion_cost(
+        completion_response=response,
+        model="bedrock/us.openai.gpt-5.6-sol",
+        custom_llm_provider="bedrock",
+    )
+
+    assert cost == pytest.approx((300000 * 1.1e-05) + (1000 * 4.95e-05), rel=1e-9)
+
+
+def test_bedrock_gpt_5_6_bills_cache_read_tokens(local_model_cost_map):
+    """Bedrock caches long prefixes implicitly and reports them, so a cache-read turn
+    must be billed at the cache rate rather than dropped to zero."""
+    usage = Usage(
+        prompt_tokens=15611,
+        completion_tokens=5,
+        total_tokens=15616,
+        prompt_tokens_details=PromptTokensDetailsWrapper(cached_tokens=15609),
+    )
+    response = _bedrock_response("bedrock/us.openai.gpt-5.6-sol", usage)
+
+    cost = completion_cost(
+        completion_response=response,
+        model="bedrock/us.openai.gpt-5.6-sol",
+        custom_llm_provider="bedrock",
+    )
+
+    expected = (2 * 5.5e-06) + (15609 * 5.5e-07) + (5 * 3.3e-05)
+    assert cost == pytest.approx(expected, rel=1e-9)
+    # Without cache_read_input_token_cost the cached prefix bills at zero.
+    assert cost > (15611 * 5.5e-06) * 0.1
+
+
+def test_bedrock_gpt_5_6_bills_cache_write_tokens(local_model_cost_map):
+    """The write side of the same cache cycle is billed at the 30m cache-write rate."""
+    usage = Usage(
+        prompt_tokens=15611,
+        completion_tokens=5,
+        total_tokens=15616,
+        cache_creation_input_tokens=15609,
+    )
+    response = _bedrock_response("bedrock/us.openai.gpt-5.6-sol", usage)
+
+    cost = completion_cost(
+        completion_response=response,
+        model="bedrock/us.openai.gpt-5.6-sol",
+        custom_llm_provider="bedrock",
+    )
+
+    expected = (2 * 5.5e-06) + (15609 * 6.875e-06) + (5 * 3.3e-05)
+    assert cost == pytest.approx(expected, rel=1e-9)
+
+
+@pytest.mark.parametrize("profile", GPT_5_6_PROFILES, ids=lambda p: p.model_id)
+def test_bedrock_gpt_5_6_advertises_only_converse_supported_features(
+    profile, local_model_cost_map
+):
+    model_info = _get_model_info_helper(
+        model=f"bedrock/{profile.model_id}", custom_llm_provider="bedrock"
+    )
+
+    assert model_info["supports_function_calling"] is True
+    assert model_info["supports_tool_choice"] is True
+    assert model_info["supports_vision"] is True
+
+    # Bedrock rejects an explicit cachePoint block for these models, so the flag that
+    # offers caller-driven caching stays off even though the cache rates are declared.
+    assert not model_info.get("supports_prompt_caching")
+
+    # ModelInfoBase drops these two, so they are read from the map litellm resolves.
+    raw = _packaged_cost_map()[profile.model_id]
+    assert raw["supported_modalities"] == ["text", "image"]
+    assert raw["supported_output_modalities"] == ["text"]
+    # No bedrock_converse entry declares supported_endpoints; these models are reachable
+    # on chat completions and on the Responses API without it.
+    assert "supported_endpoints" not in raw
+
+
+@pytest.mark.parametrize("profile", GPT_5_6_PROFILES, ids=lambda p: p.model_id)
+def test_bedrock_gpt_5_6_offers_tools_but_not_reasoning(profile, local_model_cost_map):
+    """Converse rejects the Anthropic-shaped thinking block LiteLLM emits for
+    reasoning_effort, so neither reasoning param may be offered yet, while the tool
+    params these models do accept must be."""
+    supported = AmazonConverseConfig().get_supported_openai_params(
+        model=f"bedrock/{profile.model_id}"
+    )
+
+    assert "tools" in supported
+    assert "tool_choice" in supported
+    assert "reasoning_effort" not in supported
+    assert "thinking" not in supported


### PR DESCRIPTION
## TLDR

Problem this solves:

- Every GPT-5.6 request to Bedrock Runtime fails with 400
- LiteLLM does not know these model IDs, so misroutes them
- US and Global routing cost different amounts per token
- Cached prompt tokens go unpriced, so spend reads low

How it solves it:

- Add the six `us.` and `global.` GPT-5.6 model IDs
- Route them through Converse instead of Invoke
- Give each ID its own input, output and cache prices
- Cached tokens now bill at the cache rate, not zero
- Skip the caching and reasoning flags Bedrock rejects

## User Flow

Before: a developer pointing an app at GPT-5.6 on Bedrock gets a 400 on every request, on every endpoint, so the model is unusable

1. They add a deployment for `bedrock/us.openai.gpt-5.6-sol` with `aws_region_name: us-east-1`, then restart the proxy
2. They send POST `http://localhost:4000/v1/chat/completions` with `{"model": "gpt56-sol-geo", "messages": [{"role": "user", "content": "Reply with exactly: OK"}], "max_tokens": 16}`
3. They get back 400 and `Unsupported parameter: 'max_tokens' is not supported with this model.`
4. They point Codex at the same deployment, which sends POST `/v1/responses`, and get the same 400
5. They retry with a `tools` array and get back 400 and `bedrock does not support parameters: ['tools']`
6. They open `http://localhost:4000/ui/?page=logs` and every attempt is recorded at $0 spend

After: the same deployment answers on chat completions and on the Responses API, and every turn records the spend AWS actually charges

1. They add the same deployment for `bedrock/us.openai.gpt-5.6-sol` with `aws_region_name: us-east-1`, then restart the proxy
2. They send the same POST `/v1/chat/completions` and get back 200, the assistant's reply, and real token counts
3. Codex's POST `/v1/responses` returns 200 with `status: completed`
4. The same request with a `tools` array returns 200 with a `tool_calls` entry naming the function the model picked
5. They send a long prompt twice; the second turn reports most of its input as cached and is billed at the cache-read rate rather than at zero
6. They open `http://localhost:4000/ui/?page=logs` and see non-zero spend, with the Global profile costing less than the US profile for an identical request

## Relevant issues

Fixes #37285

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

GPT-5.6 reached the `bedrock-runtime` data plane on 2026-08-17, separately from the `bedrock-mantle` path that #33412 covered. On runtime these models are served only through cross-region inference profiles, which the control plane confirms:

```
$ aws bedrock get-foundation-model --region us-east-1 --model-identifier openai.gpt-5.6-sol \
    --query 'modelDetails.{in:inputModalities,out:outputModalities,inf:inferenceTypesSupported}'
{ "in": ["TEXT","IMAGE"], "out": ["TEXT"], "inf": ["INFERENCE_PROFILE"] }
```

`INFERENCE_PROFILE` with no `ON_DEMAND` is why this adds `us.` and `global.` keys and no bare key, and the modality lists are where `supported_modalities` comes from. Every rate, including the cache-write and cache-read columns, is transcribed from the AWS model cards:

- https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-openai-gpt-56-sol.html
- https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-openai-gpt-56-terra.html
- https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-openai-gpt-56-luna.html

### Setup

Real Bedrock in `us-east-1`, no mocks. Same config and same six cases on both sides.

```yaml
# config.yaml
model_list:
  - model_name: gpt56-sol-geo
    litellm_params:
      model: bedrock/us.openai.gpt-5.6-sol
      aws_region_name: us-east-1
  - model_name: gpt56-terra-geo
    litellm_params:
      model: bedrock/us.openai.gpt-5.6-terra
      aws_region_name: us-east-1
  - model_name: gpt56-luna-geo
    litellm_params:
      model: bedrock/us.openai.gpt-5.6-luna
      aws_region_name: us-east-1
  - model_name: gpt56-sol-global
    litellm_params:
      model: bedrock/global.openai.gpt-5.6-sol
      aws_region_name: us-east-1
litellm_settings:
  drop_params: false
```

```bash
LITELLM_LOCAL_MODEL_COST_MAP=True LITELLM_MASTER_KEY=sk-1234 \
  uv run python litellm/proxy/proxy_cli.py --config config.yaml --port 4000
```

```bash
# A, B  chat completions on each profile
curl -sS -D - http://localhost:4000/v1/chat/completions -H "Authorization: Bearer sk-1234" \
  -H "Content-Type: application/json" \
  -d '{"model":"gpt56-sol-geo","messages":[{"role":"user","content":"Reply with exactly: OK"}],"max_tokens":16}'
# B repeats it with "model":"gpt56-sol-global"

# C  the Responses API, which is what Codex speaks
curl -sS -D - http://localhost:4000/v1/responses -H "Authorization: Bearer sk-1234" \
  -H "Content-Type: application/json" \
  -d '{"model":"gpt56-sol-geo","input":"Reply with exactly: OK","max_output_tokens":64}'

# D  tool calling
curl -sS -D - http://localhost:4000/v1/chat/completions -H "Authorization: Bearer sk-1234" \
  -H "Content-Type: application/json" \
  -d '{"model":"gpt56-luna-geo","messages":[{"role":"user","content":"Weather in Paris? Use the tool."}],
       "tools":[{"type":"function","function":{"name":"get_weather","description":"Get weather",
       "parameters":{"type":"object","properties":{"city":{"type":"string"}},"required":["city"]}}}],
       "max_tokens":128}'

# E  prompt caching: POST a ~16.8k-token prefix to /v1/responses twice
# F  streaming: case A plus "stream":true,"stream_options":{"include_usage":true}
```

### Before (ff02d5cfc0)

Every case fails, and nothing is billed.

| Case | Status | Response |
|---|---|---|
| A. chat completions, Geo | `400` | `Unsupported parameter: 'max_tokens' is not supported with this model.` |
| B. chat completions, Global | `400` | same `unsupported_parameter` |
| C. `/v1/responses` (Codex) | `400` | same `unsupported_parameter` |
| D. tool calling | `400` | `bedrock does not support parameters: ['tools']` |
| E. prompt caching, both calls | `400` | same `unsupported_parameter`, `x-litellm-response-cost: 0` |
| F. streaming | `400` | same `unsupported_parameter` |

Case A in full, the others differ only in the model or endpoint:

```
HTTP/1.1 400 Bad Request
x-litellm-response-cost: 0

litellm.BadRequestError: BedrockException - {"error":{"code":"unsupported_parameter",
"message":"Unsupported parameter: 'max_tokens' is not supported with this model.",
"param":"max_tokens","type":"invalid_request_error"}}
```

Case D differs, failing before the request is even sent:

```
HTTP/1.1 400 Bad Request

litellm.UnsupportedParamsError: bedrock does not support parameters: ['tools'],
for model=us.openai.gpt-5.6-luna. To drop these, set `litellm.drop_params=True`
```

### After (86efa2bcfd)

Every case succeeds, and each is billed at its profile's published rate.

| Case | Status | Cost | Result |
|---|---|---|---|
| A. chat completions, Geo | `200` | `0.0002255` | `'OK'`, 11 in / 5 out |
| B. chat completions, Global | `200` | `0.000205` | `'OK'`, same 11 in / 5 out |
| C. `/v1/responses` (Codex) | `200` | `0.0002255` | `status: completed`, `text: ['OK']` |
| D. tool calling | `200` | `3.41e-05` | `get_weather {"city": "Paris"}`, `finish: tool_calls` |
| E. caching, call 1 (write) | `200` | `0.115737875` | `cache_write_tokens: 16809` |
| E. caching, call 2 (read) | `200` | `0.00942095` | `cached_tokens: 16809` |
| F. streaming | `200` | – | 6 chunks, `'alpha beta gamma'`, `finish: stop` |

**A and B are the Global discount reaching spend.** Identical token counts, different bills, because each profile carries its own published rate rather than sharing one:

```
A  x-litellm-response-cost: 0.0002255                 11 x 5.5e-06 + 5 x 3.3e-05
B  x-litellm-response-cost: 0.00020500000000000002    11 x 5e-06   + 5 x 3e-05
```

**C is why Codex works.** Same bill as A for the same work, so spend is consistent whichever surface the client speaks:

```
HTTP/1.1 200 OK
x-litellm-response-cost: 0.0002255
status: completed | text: ['OK'] | input_tokens: 11 output_tokens: 5
```

**E is the cache-cost fix.** One cache cycle, write then read, both reconciling against the published rates:

```
call 1  x-litellm-response-cost: 0.115737875
        input_tokens: 16811  cached_tokens: 0      cache_write_tokens: 16809
        = 2 x 5.5e-06 + 16809 x 6.875e-06 + 5 x 3.3e-05

call 2  x-litellm-response-cost: 0.00942095
        input_tokens: 16811  cached_tokens: 16809  cache_write_tokens: 0
        = 2 x 5.5e-06 + 16809 x 5.5e-07  + 5 x 3.3e-05
```

Without the cache-cost fields, call 2 bills only its 2 uncached tokens, at `0.000176`.

**F is streaming**, reassembled from the SSE stream:

```
chunks: 6 | content: 'alpha beta gamma' | finish: stop
usage: {'prompt_tokens': 14, 'completion_tokens': 7}
```

### Why two fields are deliberately absent

**`supports_prompt_caching`.** Caching does work on these models, as case E shows, and the rates are declared so it bills correctly. But this flag is narrower than "the model can cache": its only request-mutating consumer is `AnthropicCacheControlHook`, which injects Anthropic-shaped `cache_control` blocks that become Converse `cachePoint` blocks Bedrock refuses. AWS documents GPT-5.6's own caching as `prompt_cache_breakpoint` with `prompt_cache_options.ttl` on the Responses API, a different mechanism the hook does not speak. Setting the flag is therefore harmful, not merely inaccurate. With it on and an operator running `enable_anthropic_prompt_caching: true`, even an 11-token request fails:

```
HTTP/1.1 500 Internal Server Error
BedrockException - {"message":"You invoked an unsupported model or your request did not
allow prompt caching. See the documentation for more information."}
```

That is the failure that withdrew #37307. `cost_calculator.py` reads the rate fields without consulting the flag, so the cache costs stand on their own.

**`supported_endpoints`.** No `bedrock_converse` entry declares it, 0 of 152, and these models need no such gating: cases A and C answer on both surfaces without it. The Mantle entries in #33412 declare `["/v1/responses"]` because that surface serves only that path.

### Independent verification (86efa2bcfd)

Both legs were re-run at these same two commits against real Bedrock in `us-east-1`, and reproduce the result above: all six cases fail at `ff02d5cfc0`, all six succeed at `86efa2bcfd`. `/v1/messages` was covered as well, and it answers in the correct Anthropic shape billed at the luna Geo rate. Notes a reviewer cannot get from the diff:

- Streaming responses carry no cost header; pre-existing, PR leaves alone
- `/v1/responses` body reports `cost: null` while header prices it; pre-existing
- `/v1/models` omits metadata for aliases, not cost-map keys; pre-existing
- `supports_prompt_caching` reads `None`, not `false`; this PR omits it
- Converse handler resolves credentials before bearer token; pre-existing
- Merges into current staging cleanly; costs identical on merged tree

## Type

🆕 New Feature

## Caveats (if any)

- Geo and Global keys only; AWS serves no on-demand id
- Bare `openai.gpt-5.6-*` stays unmapped by design
- Reasoning left off; see below for the shape that works
- India `in.` profiles need the shared prefix list changed

Reasoning is the one capability left on the table. `reasoning_effort` currently raises `UnsupportedParamsError`, because for a non-gpt-oss, non-Nova model the Converse transform emits an Anthropic-shaped `thinking` block, which these models reject with `unknown_parameter`. The shape they do accept is `additionalModelRequestFields {"reasoning": {"effort": "low"}}`, confirmed against live Bedrock. Wiring that up is a change to `_handle_reasoning_effort_parameter` rather than a cost-map change, it overlaps the open PRs on that function, and it is the same defect #34105 tracks for other non-Anthropic Bedrock models, so it is deliberately out of scope here.

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Cost-map and test-only change; no routing or auth logic is rewritten. Incorrect prices would misbill spend, but runtime still uses the existing Converse path.
> 
> **Overview**
> Adds **US and Global** Bedrock Runtime IDs for GPT-5.6 (`sol`, `terra`, `luna`) so those models are recognized as `bedrock_converse` instead of falling through to Invoke (which 400s).
> 
> Each profile has its own input/output prices, 272k long-context tiers, and cache write/read rates. Prompt caching is **not** advertised (`supports_prompt_caching` stays off) so LiteLLM will not inject Converse `cachePoint` blocks Bedrock rejects, while cache tokens still bill from the rate fields. Tools and vision are on; reasoning is left off because Converse would emit an Anthropic `thinking` block these models reject.
> 
> Tests pin Converse routing, published rates, >272k billing, and cache-read/write cost so cached prefixes are not billed at zero.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 86efa2bcfde555e519140f6d9721e9570aada2d2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

- [x] 86efa2bcfde555e519140f6d9721e9570aada2d2 passes /live-pr-risk
