### PR TITLE
fix(ci): stop the mutation report publishing a score it never measured

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -341,9 +341,13 @@ filterwarnings = [
 paths_to_mutate = [
     "litellm/proxy/management_endpoints/",
 ]
+# Only the unit tier that maps to paths_to_mutate. mutmut times and
+# coverage-maps this whole set once before mutating, so a tier that needs a
+# seeded database (tests/proxy_behavior/) kills the run before it starts, and
+# a mutation score is only meaningful against the tests that claim to cover
+# the mutated code anyway.
 tests_dir = [
     "tests/test_litellm/proxy/management_endpoints/",
-    "tests/proxy_behavior/management/",
 ]
 also_copy = [
     "litellm/",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -364,10 +364,16 @@ mutate_only_covered_lines = true
 # - rerunning a "failed" test on a mutant would mask which mutants are killed
 #   vs. survive, so reruns are wrong for mutation testing regardless.
 # - xdist is unnecessary inside mutmut (mutmut handles its own parallelism).
+# test_saml_sso.py cannot run inside mutmut's mutants/ sandbox: the copied tree
+# re-imports cryptography's hash classes under a second identity, so x509 .sign()
+# rejects the SHA256 instance the fixture builds with "Algorithm must be a
+# registered hash algorithm". Nothing to do with mutation coverage, and one
+# erroring test is enough to end the stats phase before any mutant runs.
 pytest_add_cli_args = [
     "-p", "no:retry",
     "-p", "no:rerunfailures",
     "-p", "no:xdist",
+    "--ignore=tests/test_litellm/proxy/management_endpoints/test_saml_sso.py",
 ]
 
 [tool.coverage.run]

--- a/scripts/mutation_report.py
+++ b/scripts/mutation_report.py
@@ -231,12 +231,14 @@ def render_meta_style_mutant(
     return "\n".join(out)
 
 
-UNRESOLVED_STATUSES: Final = ("no_tests", "skipped", "suspicious", "timeout", "segfault")
+RESOLVED_KEYS: Final = frozenset({"killed", "survived", "total"})
 
 
 def unresolved_counts(stats: dict) -> dict[str, int]:
-    """Statuses that mean a mutant was never actually put in front of the tests."""
-    return {k: stats.get(k, 0) for k in UNRESOLVED_STATUSES if stats.get(k, 0)}
+    """Every non-zero count that is neither a kill nor a survivor means a mutant did not
+    reach the tests. Reading it as "anything else" rather than as a list of known statuses
+    keeps a status this reporter has never met from passing as a clean sweep."""
+    return {k: v for k, v in sorted(stats.items()) if k not in RESOLVED_KEYS and isinstance(v, int) and v > 0}
 
 
 def clean_sweep_is_provable(stats: dict | None) -> bool:
@@ -287,13 +289,8 @@ def render(config: dict, results: MutmutResults, stats: dict | None) -> str:
     out.append("## Summary")
     out.append("")
     if stats:
-        total = stats.get("total", 0) or sum(
-            stats.get(k, 0)
-            for k in (
-                "killed",
-                "survived",
-                *UNRESOLVED_STATUSES,
-            )
+        total = stats.get("total", 0) or (
+            stats.get("killed", 0) + stats.get("survived", 0) + sum(unresolved_counts(stats).values())
         )
         killed = stats.get("killed", 0)
         survived = stats.get("survived", 0)

--- a/scripts/mutation_report.py
+++ b/scripts/mutation_report.py
@@ -231,6 +231,25 @@ def render_meta_style_mutant(
     return "\n".join(out)
 
 
+def clean_sweep_is_provable(stats: dict | None) -> bool:
+    """`mutmut results` omits killed mutants, so its silence is equally consistent with a
+    perfect run and with a run that never started. Only the stats file can tell them apart."""
+    return bool(stats) and stats.get("killed", 0) > 0
+
+
+def no_survivors_verdict(results: MutmutResults, stats: dict | None) -> str:
+    if clean_sweep_is_provable(stats):
+        return "**No surviving mutants, and the run killed some, so the test suite caught every mutation.**"
+    if stats:
+        return "**Not one mutant was killed. This is not a passing score.**"
+    return (
+        f"**mutmut-cicd-stats.json is missing and `mutmut results` printed {results.reported} "
+        "verdict(s), none of them a survivor. Since that command never lists killed mutants, a "
+        "clean sweep and a run that mutated nothing look identical from here. This is not a "
+        "passing score.**"
+    )
+
+
 def render(config: dict, results: MutmutResults, stats: dict | None) -> str:
     survivors = list(results.survivors)
     by_function: dict[tuple[str, str], list[tuple[str, str]]] = defaultdict(list)
@@ -274,12 +293,7 @@ def render(config: dict, results: MutmutResults, stats: dict | None) -> str:
     out.append("")
 
     if not survivors:
-        out.append(
-            "**No surviving mutants — the test suite caught every mutation.**"
-            if results.reported
-            else "**mutmut reported no mutants at all. The run did not finish; this is "
-            "not a passing score.**"
-        )
+        out.append(no_survivors_verdict(results, stats))
         out.append("")
         return "\n".join(out)
 
@@ -431,10 +445,10 @@ def main() -> int:
         f"Wrote {out_path} ({len(results.survivors)} survivor"
         f"{'s' if len(results.survivors) != 1 else ''}, {len(report)} chars)"
     )
-    if not results.reported and stats is None:
+    if not results.survivors and not clean_sweep_is_provable(stats):
         print(
-            "error: mutmut produced no results, so the report cannot say anything "
-            "about the suite",
+            "error: nothing was shown to have been killed, so the report cannot say "
+            "anything about the suite",
             file=sys.stderr,
         )
         return 1

--- a/scripts/mutation_report.py
+++ b/scripts/mutation_report.py
@@ -233,13 +233,20 @@ def render_meta_style_mutant(
 
 def clean_sweep_is_provable(stats: dict | None) -> bool:
     """`mutmut results` omits killed mutants, so its silence is equally consistent with a
-    perfect run and with a run that never started. Only the stats file can tell them apart."""
-    return bool(stats) and stats.get("killed", 0) > 0
+    perfect run and with a run that never started. Only the stats file can tell them apart,
+    and only when it agrees that nothing survived."""
+    return bool(stats) and stats.get("killed", 0) > 0 and stats.get("survived", 0) == 0
 
 
 def no_survivors_verdict(results: MutmutResults, stats: dict | None) -> str:
     if clean_sweep_is_provable(stats):
         return "**No surviving mutants, and the run killed some, so the test suite caught every mutation.**"
+    if stats and stats.get("survived", 0) > 0:
+        return (
+            f"**mutmut-cicd-stats.json counts {stats['survived']} surviving mutant(s) that "
+            "`mutmut results` did not list, so the two disagree and neither can be trusted. "
+            "This is not a passing score.**"
+        )
     if stats:
         return "**Not one mutant was killed. This is not a passing score.**"
     return (

--- a/scripts/mutation_report.py
+++ b/scripts/mutation_report.py
@@ -22,7 +22,7 @@ import tomllib
 from collections import defaultdict
 from difflib import SequenceMatcher
 from pathlib import Path
-from typing import NamedTuple
+from typing import Final, NamedTuple
 from textwrap import dedent
 
 ROOT = Path(__file__).resolve().parent.parent
@@ -231,11 +231,21 @@ def render_meta_style_mutant(
     return "\n".join(out)
 
 
+UNRESOLVED_STATUSES: Final = ("no_tests", "skipped", "suspicious", "timeout", "segfault")
+
+
+def unresolved_counts(stats: dict) -> dict[str, int]:
+    """Statuses that mean a mutant was never actually put in front of the tests."""
+    return {k: stats.get(k, 0) for k in UNRESOLVED_STATUSES if stats.get(k, 0)}
+
+
 def clean_sweep_is_provable(stats: dict | None) -> bool:
     """`mutmut results` omits killed mutants, so its silence is equally consistent with a
     perfect run and with a run that never started. Only the stats file can tell them apart,
-    and only when it agrees that nothing survived."""
-    return bool(stats) and stats.get("killed", 0) > 0 and stats.get("survived", 0) == 0
+    and only when it agrees that nothing survived and every mutant reached the tests."""
+    if not stats or stats.get("killed", 0) <= 0 or stats.get("survived", 0) != 0:
+        return False
+    return not unresolved_counts(stats)
 
 
 def no_survivors_verdict(results: MutmutResults, stats: dict | None) -> str:
@@ -246,6 +256,12 @@ def no_survivors_verdict(results: MutmutResults, stats: dict | None) -> str:
             f"**mutmut-cicd-stats.json counts {stats['survived']} surviving mutant(s) that "
             "`mutmut results` did not list, so the two disagree and neither can be trusted. "
             "This is not a passing score.**"
+        )
+    if stats and unresolved_counts(stats):
+        unresolved = ", ".join(f"{v} {k.replace('_', ' ')}" for k, v in unresolved_counts(stats).items())
+        return (
+            f"**No survivors, but {unresolved}, so those mutants never reached the tests "
+            "and the suite was not shown to catch them. This is not a passing score.**"
         )
     if stats:
         return "**Not one mutant was killed. This is not a passing score.**"
@@ -276,11 +292,7 @@ def render(config: dict, results: MutmutResults, stats: dict | None) -> str:
             for k in (
                 "killed",
                 "survived",
-                "no_tests",
-                "skipped",
-                "suspicious",
-                "timeout",
-                "segfault",
+                *UNRESOLVED_STATUSES,
             )
         )
         killed = stats.get("killed", 0)
@@ -290,10 +302,8 @@ def render(config: dict, results: MutmutResults, stats: dict | None) -> str:
         out.append(f"- Killed: **{killed}**")
         out.append(f"- Survived: **{survived}**")
         out.append(f"- Mutation score: **{score:.1f}%**")
-        for k in ("no_tests", "skipped", "suspicious", "timeout", "segfault"):
-            v = stats.get(k, 0)
-            if v:
-                out.append(f"- {k.replace('_', ' ').title()}: {v}")
+        for k, v in unresolved_counts(stats).items():
+            out.append(f"- {k.replace('_', ' ').title()}: {v}")
     else:
         out.append(f"- Survivors found: **{len(survivors)}**")
         out.append("- (mutmut-cicd-stats.json not available — full counts unavailable)")

--- a/scripts/mutation_report.py
+++ b/scripts/mutation_report.py
@@ -22,6 +22,7 @@ import tomllib
 from collections import defaultdict
 from difflib import SequenceMatcher
 from pathlib import Path
+from typing import NamedTuple
 from textwrap import dedent
 
 ROOT = Path(__file__).resolve().parent.parent
@@ -33,16 +34,24 @@ def load_mutmut_config() -> dict:
         return tomllib.load(f)["tool"]["mutmut"]
 
 
-def get_survivors() -> list[str]:
+class MutmutResults(NamedTuple):
+    survivors: tuple[str, ...]
+    reported: int
+
+
+def get_survivors() -> MutmutResults:
     proc = subprocess.run(
         [*MUTMUT_INVOCATION, "results"], capture_output=True, text=True, check=False
     )
-    survivors = []
-    for line in proc.stdout.splitlines():
-        m = re.match(r"\s*(\S+):\s*survived\s*$", line)
-        if m:
-            survivors.append(m.group(1))
-    return survivors
+    verdicts = tuple(
+        m.groups()
+        for line in proc.stdout.splitlines()
+        if (m := re.match(r"\s*(\S+):\s*(\w+)\s*$", line))
+    )
+    return MutmutResults(
+        survivors=tuple(name for name, verdict in verdicts if verdict == "survived"),
+        reported=len(verdicts),
+    )
 
 
 def get_mutmut_show(mutant_name: str) -> str:
@@ -222,7 +231,8 @@ def render_meta_style_mutant(
     return "\n".join(out)
 
 
-def render(config: dict, survivors: list[str], stats: dict | None) -> str:
+def render(config: dict, results: MutmutResults, stats: dict | None) -> str:
+    survivors = list(results.survivors)
     by_function: dict[tuple[str, str], list[tuple[str, str]]] = defaultdict(list)
     for survivor in survivors:
         module_path, function_name, mutant_num = parse_mutant_name(survivor)
@@ -264,7 +274,12 @@ def render(config: dict, survivors: list[str], stats: dict | None) -> str:
     out.append("")
 
     if not survivors:
-        out.append("**No surviving mutants — the test suite caught every mutation.**")
+        out.append(
+            "**No surviving mutants — the test suite caught every mutation.**"
+            if results.reported
+            else "**mutmut reported no mutants at all. The run did not finish; this is "
+            "not a passing score.**"
+        )
         out.append("")
         return "\n".join(out)
 
@@ -407,15 +422,22 @@ def main() -> int:
         except json.JSONDecodeError as exc:
             print(f"warning: could not parse {stats_file}: {exc}", file=sys.stderr)
 
-    survivors = get_survivors()
-    report = render(config, survivors, stats)
+    results = get_survivors()
+    report = render(config, results, stats)
 
     out_path = ROOT / "mutation-report.md"
     out_path.write_text(report)
     print(
-        f"Wrote {out_path} ({len(survivors)} survivor"
-        f"{'s' if len(survivors) != 1 else ''}, {len(report)} chars)"
+        f"Wrote {out_path} ({len(results.survivors)} survivor"
+        f"{'s' if len(results.survivors) != 1 else ''}, {len(report)} chars)"
     )
+    if not results.reported and stats is None:
+        print(
+            "error: mutmut produced no results, so the report cannot say anything "
+            "about the suite",
+            file=sys.stderr,
+        )
+        return 1
     return 0
 
 

--- a/scripts/mutation_report.py
+++ b/scripts/mutation_report.py
@@ -46,7 +46,7 @@ def get_survivors() -> MutmutResults:
     verdicts = tuple(
         m.groups()
         for line in proc.stdout.splitlines()
-        if (m := re.match(r"\s*(\S+):\s*(\w+)\s*$", line))
+        if (m := re.match(r"\s*(\S+):\s*(\S.*?)\s*$", line))
     )
     return MutmutResults(
         survivors=tuple(name for name, verdict in verdicts if verdict == "survived"),

--- a/tests/test_litellm/test_mutation_report.py
+++ b/tests/test_litellm/test_mutation_report.py
@@ -36,6 +36,16 @@ def test_a_run_that_killed_every_mutant_says_so():
     assert "not a passing score" not in rendered
 
 
+def test_stats_counting_survivors_results_never_listed_is_not_a_clean_sweep():
+    rendered = report.render(
+        _CONFIG, report.MutmutResults(survivors=(), reported=0), {"killed": 48, "survived": 3}
+    )
+
+    assert "not a passing score" in rendered
+    assert "caught every mutation" not in rendered
+    assert "3 surviving mutant(s)" in rendered
+
+
 def test_no_survivors_without_a_kill_is_not_a_clean_sweep():
     rendered = report.render(
         _CONFIG, report.MutmutResults(survivors=(), reported=48), {"killed": 0, "survived": 0}

--- a/tests/test_litellm/test_mutation_report.py
+++ b/tests/test_litellm/test_mutation_report.py
@@ -46,6 +46,19 @@ def test_stats_counting_survivors_results_never_listed_is_not_a_clean_sweep():
     assert "3 surviving mutant(s)" in rendered
 
 
+def test_mutants_that_never_reached_the_tests_are_not_a_clean_sweep():
+    rendered = report.render(
+        _CONFIG,
+        report.MutmutResults(survivors=(), reported=0),
+        {"killed": 48, "survived": 0, "no_tests": 4, "timeout": 1},
+    )
+
+    assert "not a passing score" in rendered
+    assert "caught every mutation" not in rendered
+    assert "4 no tests" in rendered
+    assert "1 timeout" in rendered
+
+
 def test_no_survivors_without_a_kill_is_not_a_clean_sweep():
     rendered = report.render(
         _CONFIG, report.MutmutResults(survivors=(), reported=48), {"killed": 0, "survived": 0}

--- a/tests/test_litellm/test_mutation_report.py
+++ b/tests/test_litellm/test_mutation_report.py
@@ -28,10 +28,30 @@ def test_a_run_that_reported_nothing_is_not_a_clean_sweep():
 
 
 def test_a_run_that_killed_every_mutant_says_so():
-    rendered = report.render(_CONFIG, report.MutmutResults(survivors=(), reported=12), None)
+    rendered = report.render(
+        _CONFIG, report.MutmutResults(survivors=(), reported=0), {"killed": 48, "survived": 0}
+    )
 
     assert "caught every mutation" in rendered
     assert "not a passing score" not in rendered
+
+
+def test_no_survivors_without_a_kill_is_not_a_clean_sweep():
+    rendered = report.render(
+        _CONFIG, report.MutmutResults(survivors=(), reported=48), {"killed": 0, "survived": 0}
+    )
+
+    assert "not a passing score" in rendered
+    assert "caught every mutation" not in rendered
+
+
+def test_no_survivors_and_no_stats_cannot_claim_a_sweep():
+    """`mutmut results` never lists killed mutants, so with the stats file missing an
+    empty survivor list is equally consistent with a perfect run and a dead one."""
+    rendered = report.render(_CONFIG, report.MutmutResults(survivors=(), reported=48), None)
+
+    assert "not a passing score" in rendered
+    assert "caught every mutation" not in rendered
 
 
 def test_survivors_are_read_out_of_the_verdicts_they_came_with(monkeypatch):
@@ -73,7 +93,6 @@ def test_every_multi_word_verdict_mutmut_can_emit_still_counts(monkeypatch):
 
     assert results.survivors == ()
     assert results.reported == 4
-    assert "not a passing score" not in report.render(_CONFIG, results, None)
 
 
 def test_an_empty_mutmut_results_reports_nothing_rather_than_zero_survivors(monkeypatch):

--- a/tests/test_litellm/test_mutation_report.py
+++ b/tests/test_litellm/test_mutation_report.py
@@ -50,7 +50,30 @@ def test_survivors_are_read_out_of_the_verdicts_they_came_with(monkeypatch):
     assert results.survivors == (
         "litellm.proxy.management_endpoints.key_management_endpoints.x_2",
     )
-    assert results.reported == 2
+    assert results.reported == 3
+
+
+def test_every_multi_word_verdict_mutmut_can_emit_still_counts(monkeypatch):
+    class _Proc:
+        stdout = "".join(
+            f"litellm.proxy.management_endpoints.key_management_endpoints.x_{i}: {verdict}\n"
+            for i, verdict in enumerate(
+                (
+                    "no tests",
+                    "not checked",
+                    "caught by type check",
+                    "check was interrupted by user",
+                )
+            )
+        )
+
+    monkeypatch.setattr(report.subprocess, "run", lambda *a, **k: _Proc())
+
+    results = report.get_survivors()
+
+    assert results.survivors == ()
+    assert results.reported == 4
+    assert "not a passing score" not in report.render(_CONFIG, results, None)
 
 
 def test_an_empty_mutmut_results_reports_nothing_rather_than_zero_survivors(monkeypatch):

--- a/tests/test_litellm/test_mutation_report.py
+++ b/tests/test_litellm/test_mutation_report.py
@@ -1,0 +1,62 @@
+"""Tests for scripts/mutation_report.py.
+
+The report is the only thing anyone reads after a mutation run, so the one thing it
+must never do is describe a run that produced nothing as a run that killed everything.
+`render` decides that wording and `get_survivors` supplies the evidence for it, so both
+are tested directly.
+"""
+
+import importlib.util
+import sys
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_MODULE_PATH = _REPO_ROOT / "scripts" / "mutation_report.py"
+_spec = importlib.util.spec_from_file_location("mutation_report", _MODULE_PATH)
+report = importlib.util.module_from_spec(_spec)
+sys.modules[_spec.name] = report
+_spec.loader.exec_module(report)
+
+_CONFIG = {"paths_to_mutate": ["litellm/proxy/management_endpoints/"], "tests_dir": ["tests/"]}
+
+
+def test_a_run_that_reported_nothing_is_not_a_clean_sweep():
+    rendered = report.render(_CONFIG, report.MutmutResults(survivors=(), reported=0), None)
+
+    assert "not a passing score" in rendered
+    assert "caught every mutation" not in rendered
+
+
+def test_a_run_that_killed_every_mutant_says_so():
+    rendered = report.render(_CONFIG, report.MutmutResults(survivors=(), reported=12), None)
+
+    assert "caught every mutation" in rendered
+    assert "not a passing score" not in rendered
+
+
+def test_survivors_are_read_out_of_the_verdicts_they_came_with(monkeypatch):
+    class _Proc:
+        stdout = (
+            "litellm.proxy.management_endpoints.key_management_endpoints.x_1: killed\n"
+            "litellm.proxy.management_endpoints.key_management_endpoints.x_2: survived\n"
+            "litellm.proxy.management_endpoints.key_management_endpoints.x_3: no tests\n"
+            "not a verdict line at all\n"
+        )
+
+    monkeypatch.setattr(report.subprocess, "run", lambda *a, **k: _Proc())
+
+    results = report.get_survivors()
+
+    assert results.survivors == (
+        "litellm.proxy.management_endpoints.key_management_endpoints.x_2",
+    )
+    assert results.reported == 2
+
+
+def test_an_empty_mutmut_results_reports_nothing_rather_than_zero_survivors(monkeypatch):
+    class _Proc:
+        stdout = ""
+
+    monkeypatch.setattr(report.subprocess, "run", lambda *a, **k: _Proc())
+
+    assert report.get_survivors() == report.MutmutResults(survivors=(), reported=0)

--- a/tests/test_litellm/test_mutation_report.py
+++ b/tests/test_litellm/test_mutation_report.py
@@ -59,6 +59,18 @@ def test_mutants_that_never_reached_the_tests_are_not_a_clean_sweep():
     assert "1 timeout" in rendered
 
 
+def test_a_status_the_reporter_has_never_met_still_blocks_a_clean_sweep():
+    rendered = report.render(
+        _CONFIG,
+        report.MutmutResults(survivors=(), reported=0),
+        {"killed": 48, "survived": 0, "check_was_interrupted_by_user": 2},
+    )
+
+    assert "not a passing score" in rendered
+    assert "caught every mutation" not in rendered
+    assert "2 check was interrupted by user" in rendered
+
+
 def test_no_survivors_without_a_kill_is_not_a_clean_sweep():
     rendered = report.render(
         _CONFIG, report.MutmutResults(survivors=(), reported=48), {"killed": 0, "survived": 0}


### PR DESCRIPTION
## TLDR

Problem this solves:

- The mutation workflow has not finished a run since May
- Its test set includes a tier needing a seeded database
- With zero results the report still claimed a clean sweep

How it solves it:

- Narrow `tests_dir` to the unit tier that maps to the mutated code
- The report separates no survivors from no results, and exits 1

## User Flow

No end-user behavior changes and no proxy code is touched. This is the
manually-dispatched mutation workflow and the script that writes its summary

## Relevant issues

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

This workflow only runs on `workflow_dispatch`, so the evidence is the dispatches
themselves rather than a local command.

### Before (ff02d5cfc0)

#### 1. what the run did

1. Dispatch `mutation-test.yml`, run 32475268575. Every setup step passed, mutmut
   wrote all 48 mutant files, then `Run mutmut` failed

```
failed to collect stats. runner returned 1
FAILED tests/proxy_behavior/management/test_scratch_teardown.py::test_a2_scratch_actor_lands_in_db
```

#### 2. what it published

1. `gh run download 32475268575 --repo BerriAI/litellm; head -8 mutation-report.md`

```
# Mutation Test Report

## Summary

- Survivors found: **0**
- (mutmut-cicd-stats.json not available — full counts unavailable)

**No surviving mutants — the test suite caught every mutation.**
```

2. `gh api repos/BerriAI/litellm/actions/runs/32475268575/jobs --jq '.jobs[0].steps[] | select(.name|startswith("Run mutmut") or startswith("Generate")) | "\(.conclusion) \(.name)"'`

```
failure Run mutmut
success Generate detailed mutation report
```

### After (01fd99f411)

#### 1. what the run did

1. Dispatch `mutation-test.yml` on this branch. The database blocker is gone: run
   32477695014 ran 208 of the configured tests and ended on one error, from
   `test_saml_sso.py` building an x509 certificate inside mutmut's `mutants/`
   sandbox

```
208 passed, 2 warnings, 1 error in 132.68s (0:02:12)
TypeError: Algorithm must be a registered hash algorithm.
failed to collect stats. runner returned 1
error: mutmut produced no results, so the report cannot say anything about the suite
```

2. Run 32476663383 is why the fix is the test set and not a database. That
   dispatch added Postgres and a schema push; the same test then failed on
   missing seed rows instead

```
prisma.errors.ForeignKeyViolationError: Foreign key constraint failed on the field: `LiteLLM_OrganizationMembership_organization_id_fkey (index)`
```

3. Run 32481213728, with that one file excluded, cleared every phase that killed the
   earlier runs and mutated for 75 minutes before `mutmut run` itself exited 1. Its report
   step then printed

```
error: mutmut produced no results, so the report cannot say anything about the suite
```

   which is this branch doing the job it was opened for: the same shape of run published
   "No surviving mutants, so the test suite caught every mutation" before. This PR still
   claims no score. It claims that a run measuring nothing now says so.

   What stopped that run is now named rather than hidden. mutmut ended with

```
Stopping early, because we could not find any test case for any mutant.
It seems that the selected tests do not cover any code that we mutated.
```

   `paths_to_mutate` and `tests_dir` are the matching halves of one directory, so the
   next thing to check is whether the tests running inside the `mutants/` sandbox import
   the mutated copy of litellm at all or the installed one. That is a hypothesis, not a
   measurement, and it belongs to a follow-up rather than to this PR

#### 2. what it publishes

1. `uv run pytest tests/test_litellm/test_mutation_report.py -q -p no:randomly`

```
7 passed, 1 warning in 0.17s
```

2. The same seven against the script as it stands on staging

```
7 failed, 1 warning in 0.20s
```

## Type

🚄 Infrastructure

✅ Test

## Caveats (if any)

- No dispatch has yet produced a mutation score; that is still open
- The mutmut step failing already made the job red before this
- What was wrong is the published verdict, and its step passed
- `tests/proxy_behavior/management/` keeps needing a seeded database
- The saml exclusion is a sandbox limitation, not a skipped test
- Touches `pyproject.toml`, so it needs more than one reviewer
- The verdict parser keeps mutmut's four multi-word statuses whole
- A clean sweep now needs a non-zero killed count from the stats file
- Stats counting survivors the results never listed fails the report
- Mutants that never reached the tests block a sweep and get named
- Unresolved means anything that is not a kill or a survivor

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR






