### PR TITLE
fix(pricing): add missing cache_read_input_token_cost for azure/us/ a…

### DIFF
--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -3712,6 +3712,7 @@
         "supports_vision": true
     },
     "azure/eu/gpt-4o-2024-11-20": {
+        "cache_read_input_token_cost": 1.375e-06,
         "deprecation_date": "2027-04-14",
         "cache_creation_input_token_cost": 1.38e-06,
         "input_cost_per_token": 2.75e-06,
@@ -8462,6 +8463,7 @@
         "supports_vision": true
     },
     "azure/us/gpt-4o-2024-11-20": {
+        "cache_read_input_token_cost": 1.375e-06,
         "deprecation_date": "2027-04-14",
         "cache_creation_input_token_cost": 1.38e-06,
         "input_cost_per_token": 2.75e-06,


### PR DESCRIPTION
## What this fixes

`azure/us/gpt-4o-2024-11-20` and `azure/eu/gpt-4o-2024-11-20` are missing `cache_read_input_token_cost` in `model_prices_and_context_window.json`. Every other azure data-zone gpt-4o entry carries this field at 1.375e-06 (1.1x the OpenAI base rate of 1.25e-06), but these two were never populated — so cached prompt tokens resolve to $0 in billing.

## Change

Added `cache_read_input_token_cost: 1.375e-06` to both entries, matching the pattern from `azure/us/gpt-4o-2024-08-06` and `azure/eu/gpt-4o-2024-08-06`.

## Verification

| model | input_cost | cache_read (before) | cache_read (after) |
|-------|-----------|--------------------|--------------------|
| azure/us/gpt-4o-2024-11-20 | 2.75e-06 | None | 1.375e-06 |
| azure/eu/gpt-4o-2024-11-20 | 2.75e-06 | None | 1.375e-06 |
| azure/us/gpt-4o-2024-08-06 (control) | 2.75e-06 | 1.375e-06 | — |

Fixes #37823