### PR TITLE
fix(pricing): add missing cache_read_input_token_cost to azure/us/ and azure/eu/ gpt-4o-2024-11-20

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -3714,6 +3714,7 @@
     "azure/eu/gpt-4o-2024-11-20": {
         "deprecation_date": "2027-04-14",
         "cache_creation_input_token_cost": 1.38e-06,
+        "cache_read_input_token_cost": 1.375e-06,
         "input_cost_per_token": 2.75e-06,
         "litellm_provider": "azure",
         "max_input_tokens": 128000,
@@ -8464,6 +8465,7 @@
     "azure/us/gpt-4o-2024-11-20": {
         "deprecation_date": "2027-04-14",
         "cache_creation_input_token_cost": 1.38e-06,
+        "cache_read_input_token_cost": 1.375e-06,
         "input_cost_per_token": 2.75e-06,
         "litellm_provider": "azure",
         "max_input_tokens": 128000,

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -3714,6 +3714,7 @@
     "azure/eu/gpt-4o-2024-11-20": {
         "deprecation_date": "2027-04-14",
         "cache_creation_input_token_cost": 1.38e-06,
+        "cache_read_input_token_cost": 1.375e-06,
         "input_cost_per_token": 2.75e-06,
         "litellm_provider": "azure",
         "max_input_tokens": 128000,
@@ -8464,6 +8465,7 @@
     "azure/us/gpt-4o-2024-11-20": {
         "deprecation_date": "2027-04-14",
         "cache_creation_input_token_cost": 1.38e-06,
+        "cache_read_input_token_cost": 1.375e-06,
         "input_cost_per_token": 2.75e-06,
         "litellm_provider": "azure",
         "max_input_tokens": 128000,

--- a/tests/test_litellm/test_cost_calculator.py
+++ b/tests/test_litellm/test_cost_calculator.py
@@ -3778,13 +3778,15 @@ def test_completion_cost_prices_anthropic_shaped_cache_read_tokens():
 
 
 @pytest.mark.parametrize("model", ["azure/us/gpt-4o-2024-11-20", "azure/eu/gpt-4o-2024-11-20"])
-def test_azure_data_zone_gpt4o_nov_cache_read_cost(model: str) -> None:
+def test_azure_data_zone_gpt4o_nov_cache_read_cost(
+    model: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """Regression: azure/us/ and azure/eu/ gpt-4o-2024-11-20 were missing
     cache_read_input_token_cost, so cache-read tokens were billed at $0.
     Every other azure data-zone gpt-4o entry applies the standard 1.1x uplift
     over the OpenAI rate (1.25e-06 -> 1.375e-06); these two must too."""
-    os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = "True"
-    litellm.model_cost = litellm.get_model_cost_map(url="")
+    monkeypatch.setenv("LITELLM_LOCAL_MODEL_COST_MAP", "True")
+    monkeypatch.setattr(litellm, "model_cost", litellm.get_model_cost_map(url=""))
 
     model_info = litellm.model_cost.get(model)
     assert model_info is not None, f"Missing price map entry: {model}"

--- a/tests/test_litellm/test_cost_calculator.py
+++ b/tests/test_litellm/test_cost_calculator.py
@@ -3775,3 +3775,36 @@ def test_completion_cost_prices_anthropic_shaped_cache_read_tokens():
     )
 
     assert cost == pytest.approx(3 * 5e-6 + 4014 * 5e-7 + 5 * 3e-5, rel=1e-9)
+
+
+@pytest.mark.parametrize("model", ["azure/us/gpt-4o-2024-11-20", "azure/eu/gpt-4o-2024-11-20"])
+def test_azure_data_zone_gpt4o_nov_cache_read_cost(model: str) -> None:
+    """Regression: azure/us/ and azure/eu/ gpt-4o-2024-11-20 were missing
+    cache_read_input_token_cost, so cache-read tokens were billed at $0.
+    Every other azure data-zone gpt-4o entry applies the standard 1.1x uplift
+    over the OpenAI rate (1.25e-06 -> 1.375e-06); these two must too."""
+    os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = "True"
+    litellm.model_cost = litellm.get_model_cost_map(url="")
+
+    model_info = litellm.model_cost.get(model)
+    assert model_info is not None, f"Missing price map entry: {model}"
+    assert model_info.get("cache_read_input_token_cost") == 1.375e-06, (
+        f"{model} cache_read_input_token_cost should be 1.375e-06 (1.1x the OpenAI rate), "
+        f"got {model_info.get('cache_read_input_token_cost')}"
+    )
+
+    prompt_cost, _ = cost_per_token(
+        model=model,
+        prompt_tokens=1000,
+        completion_tokens=0,
+        custom_llm_provider="azure",
+        usage_object=Usage(
+            prompt_tokens=1000,
+            completion_tokens=0,
+            prompt_tokens_details=PromptTokensDetailsWrapper(cached_tokens=1000),
+        ),
+    )
+    assert prompt_cost == pytest.approx(1000 * 1.375e-06), (
+        f"Cache-read cost for 1000 tokens on {model} should be "
+        f"{1000 * 1.375e-06}, got {prompt_cost}"
+    )


### PR DESCRIPTION
## TLDR

Problem this solves:

- `azure/us/gpt-4o-2024-11-20` and `azure/eu/gpt-4o-2024-11-20` missing `cache_read_input_token_cost`
- Cache-read tokens on those deployments billed at $0 instead of the correct rate

How it solves it:

- Adds `cache_read_input_token_cost: 1.375e-06` to both entries
- Matches the 1.1x data-zone uplift already on every other `azure/us/` and `azure/eu/` gpt-4o entry

## User Flow

Before: a team using `azure/us/gpt-4o-2024-11-20` with a large cached system prompt sees cache reads billed at zero

1. They POST `https://litellm-domain/v1/chat/completions` with `model: azure/us/gpt-4o-2024-11-20` and a prompt containing a large previously-cached block
2. Azure returns usage with `prompt_tokens_details.cached_tokens: 5000`
3. They open `https://litellm-domain/ui/?page=logs` and see the request logged at spend that excludes cache-read tokens: $0 instead of ~$0.007

After: the same request is billed correctly

1. Same request
2. Same Azure response with `prompt_tokens_details.cached_tokens: 5000`
3. `https://litellm-domain/ui/?page=logs` shows the request at full spend including cache-read tokens at 1.375e-06/token (~$0.007)

## Relevant issues

Fixes #37823

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally — local Python 3.10 env blocks litellm import (NotRequired missing from typing); delegating to CI
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

This fix is a data correction with no provider API call involved. The proof is the price map values before and after.

Shared setup: run `python -c "import json; d=json.load(open('model_prices_and_context_window.json')); [print(k, d[k].get('cache_read_input_token_cost')) for k in ['azure/us/gpt-4o-2024-11-20','azure/eu/gpt-4o-2024-11-20','azure/us/gpt-4o-2024-08-06']]"` at the repo root

### Before (ff02d5cfc0)

1. Command output:
   ```
   azure/us/gpt-4o-2024-11-20 None
   azure/eu/gpt-4o-2024-11-20 None
   azure/us/gpt-4o-2024-08-06 1.375e-06
   ```
2. `azure/us/` and `azure/eu/` return `None` for cache_read while the same-family `azure/us/gpt-4o-2024-08-06` returns the correct 1.375e-06

### After (d80663a2f7)

1. Command output:
   ```
   azure/us/gpt-4o-2024-11-20 1.375e-06
   azure/eu/gpt-4o-2024-11-20 1.375e-06
   azure/us/gpt-4o-2024-08-06 1.375e-06
   ```
2. All three entries now return the same value; cache-read tokens on these deployments are no longer billed at $0

## Type

🐛 Bug Fix

## Caveats (if any)

- `azure/gpt-4o-2024-11-20` (non-regional) already had `cache_read_input_token_cost: 1.25e-06` (OpenAI rate, no uplift) and is not changed

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
