### PR TITLE
test: route the cost-calculator tests through a local-cost-map fixture

### DIFF
--- a/test-quality-budget.json
+++ b/test-quality-budget.json
@@ -6,13 +6,13 @@
     "limit": 742
   },
   "TQ003": {
-    "limit": 1078
+    "limit": 1076
   },
   "TQ004": {
-    "limit": 768
+    "limit": 740
   },
   "TQ005": {
-    "limit": 2832
+    "limit": 2802
   },
   "TQ006": {
     "limit": 34

--- a/tests/test_litellm/test_cost_calculator.py
+++ b/tests/test_litellm/test_cost_calculator.py
@@ -1,13 +1,4 @@
-import os
-import sys
-
 import pytest
-
-sys.path.insert(
-    0, os.path.abspath("../..")
-)  # Adds the parent directory to the system path
-
-
 from pydantic import BaseModel
 
 import litellm
@@ -22,6 +13,12 @@ from litellm.cost_calculator import (
 from litellm.types.llms.openai import OpenAIRealtimeStreamList
 from litellm.types.utils import ModelInfo, ModelResponse, PromptTokensDetailsWrapper, Usage
 from litellm.utils import TranscriptionResponse
+
+
+@pytest.fixture
+def _local_model_cost_map(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("LITELLM_LOCAL_MODEL_COST_MAP", "True")
+    monkeypatch.setattr(litellm, "model_cost", litellm.get_model_cost_map(url=""))
 
 
 def test_cost_per_token_duplicate_openai_prefix_matches_model_cost(monkeypatch):
@@ -93,14 +90,12 @@ def test_cost_per_token_non_string_model_does_not_hang():
     assert result.get("status") in ("returned", "raised")
 
 
-def test_completion_cost_uses_response_model_for_dynamic_routing():
+def test_completion_cost_uses_response_model_for_dynamic_routing(_local_model_cost_map):
     """
     Test that completion_cost uses the model from the response object
     when the input model (e.g., azure-model-router) is not in model_cost.
     This supports Azure Model Router and similar dynamic routing scenarios.
     """
-    os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = "True"
-    litellm.model_cost = litellm.get_model_cost_map(url="")
 
     # Simulate Azure Model Router: input is generic router, response has actual model
     response = ModelResponse(
@@ -139,9 +134,7 @@ def test_cost_calculator_with_response_cost_in_additional_headers():
     assert result == 1000
 
 
-def test_baseten_model_api_pricing_entries():
-    os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = "True"
-    litellm.model_cost = litellm.get_model_cost_map(url="")
+def test_baseten_model_api_pricing_entries(_local_model_cost_map):
 
     expected_pricing = {
         "baseten/nvidia/Nemotron-120B-A12B": (3e-07, 7.5e-07),
@@ -165,9 +158,7 @@ def test_baseten_model_api_pricing_entries():
         assert model_info["output_cost_per_token"] == output_cost
 
 
-def test_wandb_model_api_pricing_entries():
-    os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = "True"
-    litellm.model_cost = litellm.get_model_cost_map(url="")
+def test_wandb_model_api_pricing_entries(_local_model_cost_map):
 
     expected_pricing = {
         "wandb/moonshotai/Kimi-K2.5": (6e-07, 3e-06),
@@ -182,9 +173,7 @@ def test_wandb_model_api_pricing_entries():
         assert model_info["output_cost_per_token"] == output_cost
 
 
-def test_openrouter_qwen36_plus_model_info():
-    os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = "True"
-    litellm.model_cost = litellm.get_model_cost_map(url="")
+def test_openrouter_qwen36_plus_model_info(_local_model_cost_map):
 
     model_info = litellm.model_cost.get("openrouter/qwen/qwen3.6-plus")
 
@@ -208,9 +197,7 @@ def test_openrouter_qwen36_plus_model_info():
         "github_copilot/mai-code-1-flash-internal",
     ],
 )
-def test_github_copilot_mai_code_1_flash_pricing(model):
-    os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = "True"
-    litellm.model_cost = litellm.get_model_cost_map(url="")
+def test_github_copilot_mai_code_1_flash_pricing(model, _local_model_cost_map):
 
     model_info = litellm.model_cost.get(model)
 
@@ -238,9 +225,7 @@ def test_github_copilot_mai_code_1_flash_pricing(model):
     assert completion_usd == pytest.approx(500 * 4.5e-06)
 
 
-def test_cost_calculator_with_usage(monkeypatch):
-    os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = "True"
-    litellm.model_cost = litellm.get_model_cost_map(url="")
+def test_cost_calculator_with_usage(monkeypatch, _local_model_cost_map):
 
     usage = Usage(
         prompt_tokens=120,
@@ -320,11 +305,9 @@ def test_cost_calculator_with_usage(monkeypatch):
     assert result == expected_cost, f"Got {result}, Expected {expected_cost}"
 
 
-def test_transcription_cost_uses_token_pricing():
+def test_transcription_cost_uses_token_pricing(_local_model_cost_map):
     from litellm import completion_cost
 
-    os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = "True"
-    litellm.model_cost = litellm.get_model_cost_map(url="")
 
     usage = Usage(
         prompt_tokens=14,
@@ -348,11 +331,9 @@ def test_transcription_cost_uses_token_pricing():
     assert pytest.approx(cost, rel=1e-6) == expected_cost
 
 
-def test_transcription_cost_falls_back_to_duration():
+def test_transcription_cost_falls_back_to_duration(_local_model_cost_map):
     from litellm import completion_cost
 
-    os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = "True"
-    litellm.model_cost = litellm.get_model_cost_map(url="")
 
     response = TranscriptionResponse(text="demo text")
     response.duration = 10.0
@@ -368,14 +349,12 @@ def test_transcription_cost_falls_back_to_duration():
     assert pytest.approx(cost, rel=1e-6) == expected_cost
 
 
-def test_vertex_chirp_3_transcription_cost_from_duration():
+def test_vertex_chirp_3_transcription_cost_from_duration(_local_model_cost_map):
     """Regression: the chirp_3 cost map entry shipped with output_cost_per_second 0.0,
     and cost_per_second prefers output_cost_per_second whenever it is not None, so
     every transcription priced to $0.00 instead of using input_cost_per_second."""
     from litellm import completion_cost
 
-    os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = "True"
-    litellm.model_cost = litellm.get_model_cost_map(url="")
 
     response = TranscriptionResponse(text="demo text")
     response.duration = 18.0
@@ -1127,9 +1106,7 @@ def test_tiered_pricing_only_deployment_completion_cost_is_nonzero():
     assert cost > 0
 
 
-def test_azure_realtime_cost_calculator():
-    os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = "True"
-    litellm.model_cost = litellm.get_model_cost_map(url="")
+def test_azure_realtime_cost_calculator(_local_model_cost_map):
 
     cost = handle_realtime_stream_cost_calculation(
         results=[
@@ -1152,7 +1129,7 @@ def test_azure_realtime_cost_calculator():
     assert cost > 0
 
 
-def test_azure_audio_output_cost_calculation():
+def test_azure_audio_output_cost_calculation(_local_model_cost_map):
     """
     Test that Azure audio models correctly calculate costs for audio output tokens.
 
@@ -1162,8 +1139,6 @@ def test_azure_audio_output_cost_calculation():
     """
     from litellm.types.utils import Choices, CompletionTokensDetailsWrapper, Message
 
-    os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = "True"
-    litellm.model_cost = litellm.get_model_cost_map(url="")
 
     # Scenario from issue #19764:
     # Input: 17 text tokens, 0 audio tokens
@@ -1672,7 +1647,7 @@ def test_gemini_25_explicit_caching_cost_direct_usage():
     assert expected_actual_cost == total_cost
 
 
-def test_azure_ai_cache_cost_calculation():
+def test_azure_ai_cache_cost_calculation(_local_model_cost_map):
     """
     Test that azure_ai provider correctly calculates cache costs using generic_cost_per_token.
 
@@ -1683,8 +1658,6 @@ def test_azure_ai_cache_cost_calculation():
     from litellm.litellm_core_utils.llm_cost_calc.utils import generic_cost_per_token
     from litellm.types.utils import PromptTokensDetailsWrapper, Usage
 
-    os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = "True"
-    litellm.model_cost = litellm.get_model_cost_map(url="")
 
     # Register a custom azure_ai model with cache pricing
     test_model_id = "test-azure-ai-claude-model"
@@ -2286,12 +2259,10 @@ def test_azure_image_generation_cost_calculator():
     assert cost > 0.079
 
 
-def test_completion_cost_extracts_service_tier_from_response():
+def test_completion_cost_extracts_service_tier_from_response(_local_model_cost_map):
     """Test that completion_cost extracts service_tier from completion_response object."""
     from litellm import completion_cost
 
-    os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = "True"
-    litellm.model_cost = litellm.get_model_cost_map(url="")
 
     # Test with gpt-5-nano which has flex pricing
     model = "gpt-5-nano"
@@ -2338,12 +2309,10 @@ def test_completion_cost_extracts_service_tier_from_response():
     ), f"Flex pricing should be ~50% of standard, got {flex_ratio:.2f}"
 
 
-def test_completion_cost_extracts_service_tier_from_usage():
+def test_completion_cost_extracts_service_tier_from_usage(_local_model_cost_map):
     """Test that completion_cost extracts service_tier from usage object."""
     from litellm import completion_cost
 
-    os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = "True"
-    litellm.model_cost = litellm.get_model_cost_map(url="")
 
     # Test with gpt-5-nano which has flex pricing
     model = "gpt-5-nano"
@@ -2397,12 +2366,10 @@ def test_completion_cost_extracts_service_tier_from_usage():
     ), f"Flex pricing should be ~50% of standard, got {flex_ratio:.2f}"
 
 
-def test_completion_cost_service_tier_priority():
+def test_completion_cost_service_tier_priority(_local_model_cost_map):
     """Test that service_tier extraction follows priority: optional_params > completion_response > usage."""
     from litellm import completion_cost
 
-    os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = "True"
-    litellm.model_cost = litellm.get_model_cost_map(url="")
 
     # Test with gpt-5-nano which has flex pricing
     model = "gpt-5-nano"
@@ -2457,12 +2424,10 @@ def test_completion_cost_service_tier_priority():
     ), "Costs from params and usage should be similar (both flex)"
 
 
-def test_completion_cost_service_tier_for_bedrock():
+def test_completion_cost_service_tier_for_bedrock(_local_model_cost_map):
     """Test that Bedrock cost calculation applies service_tier-specific pricing."""
     from litellm import completion_cost
 
-    os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = "True"
-    litellm.model_cost = litellm.get_model_cost_map(url="")
 
     model = "bedrock/us-east-1/test-bedrock-service-tier-cost-model"
     litellm.register_model(
@@ -2507,7 +2472,7 @@ def test_completion_cost_service_tier_for_bedrock():
     assert priority_cost > default_cost > flex_cost > 0
 
 
-def test_completion_cost_service_tier_for_anthropic():
+def test_completion_cost_service_tier_for_anthropic(_local_model_cost_map):
     """
     Anthropic priority-tier requests must be priced at the priority rate.
 
@@ -2519,8 +2484,6 @@ def test_completion_cost_service_tier_for_anthropic():
     from litellm import completion_cost
     from litellm.llms.anthropic.chat.transformation import AnthropicConfig
 
-    os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = "True"
-    litellm.model_cost = litellm.get_model_cost_map(url="")
 
     model = "claude-test-service-tier-cost-model"
     litellm.register_model(
@@ -2561,7 +2524,9 @@ def test_completion_cost_service_tier_for_anthropic():
     assert priority_cost == pytest.approx(2 * standard_cost)
 
 
-def test_completion_cost_anthropic_auto_tier_uses_served_priority_rate():
+def test_completion_cost_anthropic_auto_tier_uses_served_priority_rate(
+    _local_model_cost_map,
+):
     """
     Proxy billing path regression for LIT-3771.
 
@@ -2574,8 +2539,6 @@ def test_completion_cost_anthropic_auto_tier_uses_served_priority_rate():
     from litellm import completion_cost
     from litellm.llms.anthropic.chat.transformation import AnthropicConfig
 
-    os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = "True"
-    litellm.model_cost = litellm.get_model_cost_map(url="")
 
     model = "claude-test-auto-tier-cost-model"
     litellm.register_model(
@@ -2613,7 +2576,9 @@ def test_completion_cost_anthropic_auto_tier_uses_served_priority_rate():
     assert cost == pytest.approx(expected_priority)
 
 
-def test_completion_cost_non_string_service_tier_defers_to_served_tier():
+def test_completion_cost_non_string_service_tier_defers_to_served_tier(
+    _local_model_cost_map,
+):
     """
     Regression: a non-string request-level ``service_tier`` (reachable via
     ``allowed_openai_params``/``drop_params``) must not crash cost tracking.
@@ -2627,8 +2592,6 @@ def test_completion_cost_non_string_service_tier_defers_to_served_tier():
     from litellm import completion_cost
     from litellm.llms.anthropic.chat.transformation import AnthropicConfig
 
-    os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = "True"
-    litellm.model_cost = litellm.get_model_cost_map(url="")
 
     model = "claude-test-non-string-tier-cost-model"
     litellm.register_model(
@@ -2665,7 +2628,9 @@ def test_completion_cost_non_string_service_tier_defers_to_served_tier():
     assert cost == pytest.approx(expected_priority)
 
 
-def test_completion_cost_non_string_response_service_tier_defers_to_served_tier():
+def test_completion_cost_non_string_response_service_tier_defers_to_served_tier(
+    _local_model_cost_map,
+):
     """
     Regression: a non-string ``service_tier`` on the response object must not
     crash cost tracking.
@@ -2679,8 +2644,6 @@ def test_completion_cost_non_string_response_service_tier_defers_to_served_tier(
     from litellm import completion_cost
     from litellm.llms.anthropic.chat.transformation import AnthropicConfig
 
-    os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = "True"
-    litellm.model_cost = litellm.get_model_cost_map(url="")
 
     model = "claude-test-response-non-string-tier-cost-model"
     litellm.register_model(
@@ -2718,7 +2681,9 @@ def test_completion_cost_non_string_response_service_tier_defers_to_served_tier(
     assert cost == pytest.approx(expected_priority)
 
 
-def test_completion_cost_non_string_usage_service_tier_prices_standard():
+def test_completion_cost_non_string_usage_service_tier_prices_standard(
+    _local_model_cost_map,
+):
     """
     Regression: a non-string ``service_tier`` on the usage object must not crash
     cost tracking.
@@ -2729,8 +2694,6 @@ def test_completion_cost_non_string_usage_service_tier_prices_standard():
     """
     from litellm import completion_cost
 
-    os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = "True"
-    litellm.model_cost = litellm.get_model_cost_map(url="")
 
     model = "claude-test-usage-non-string-tier-cost-model"
     litellm.register_model(
@@ -2764,7 +2727,9 @@ def test_completion_cost_non_string_usage_service_tier_prices_standard():
     assert cost == pytest.approx(expected_standard)
 
 
-def test_anthropic_cost_per_token_prices_cache_at_served_tier_with_multiplier():
+def test_anthropic_cost_per_token_prices_cache_at_served_tier_with_multiplier(
+    _local_model_cost_map,
+):
     """
     Regression for the cache/tier interaction in the Anthropic geo/speed path.
 
@@ -2780,8 +2745,6 @@ def test_anthropic_cost_per_token_prices_cache_at_served_tier_with_multiplier():
     )
     from litellm.types.utils import PromptTokensDetailsWrapper, Usage
 
-    os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = "True"
-    litellm.model_cost = litellm.get_model_cost_map(url="")
 
     model = "claude-test-priority-cache-fast-model"
     litellm.register_model(
@@ -2853,7 +2816,7 @@ def test_anthropic_geo_multiplier_applies_to_cache_tokens(monkeypatch):
     from litellm.types.utils import PromptTokensDetailsWrapper, Usage
 
     monkeypatch.setenv("LITELLM_LOCAL_MODEL_COST_MAP", "True")
-    litellm.model_cost = litellm.get_model_cost_map(url="")
+    monkeypatch.setattr(litellm, "model_cost", litellm.get_model_cost_map(url=""))
 
     model = "claude-test-geo-cache-model"
     _register_anthropic_geo_cache_model(model)
@@ -2895,7 +2858,7 @@ def test_anthropic_geo_and_fast_multipliers_compose(monkeypatch):
     from litellm.types.utils import PromptTokensDetailsWrapper, Usage
 
     monkeypatch.setenv("LITELLM_LOCAL_MODEL_COST_MAP", "True")
-    litellm.model_cost = litellm.get_model_cost_map(url="")
+    monkeypatch.setattr(litellm, "model_cost", litellm.get_model_cost_map(url=""))
 
     model = "claude-test-geo-fast-cache-model"
     _register_anthropic_geo_cache_model(model)
@@ -3100,7 +3063,7 @@ def test_gemini_implicit_caching_cost_calculation():
     )
 
 
-def test_additional_costs_only_for_azure_ai():
+def test_additional_costs_only_for_azure_ai(_local_model_cost_map):
     """
     Test that _get_additional_costs is only called for azure_ai provider.
 
@@ -3111,8 +3074,6 @@ def test_additional_costs_only_for_azure_ai():
     """
     from litellm.cost_calculator import _get_additional_costs
 
-    os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = "True"
-    litellm.model_cost = litellm.get_model_cost_map(url="")
 
     # Non-azure_ai providers should return None
     result = _get_additional_costs(
@@ -3140,7 +3101,7 @@ def test_additional_costs_only_for_azure_ai():
     assert result is None, "Vertex AI should have no additional costs"
 
 
-def test_openrouter_gemini_3_1_flash_lite_preview_pricing():
+def test_openrouter_gemini_3_1_flash_lite_preview_pricing(_local_model_cost_map):
     """
     Test that openrouter/google/gemini-3.1-flash-lite-preview has a pricing entry.
 
@@ -3150,8 +3111,6 @@ def test_openrouter_gemini_3_1_flash_lite_preview_pricing():
     model_prices_and_context_window.json when other Gemini 3.x variants were present.
     This caused ValueError: This model isn't mapped yet during router pre-call checks.
     """
-    os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = "True"
-    litellm.model_cost = litellm.get_model_cost_map(url="")
 
     model_name = "openrouter/google/gemini-3.1-flash-lite-preview"
     model_info = litellm.model_cost.get(model_name)
@@ -3164,9 +3123,7 @@ def test_openrouter_gemini_3_1_flash_lite_preview_pricing():
     assert model_info["max_output_tokens"] == 65536
 
 
-def test_gemini_3_1_flash_lite_pricing():
-    os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = "True"
-    litellm.model_cost = litellm.get_model_cost_map(url="")
+def test_gemini_3_1_flash_lite_pricing(_local_model_cost_map):
 
     for model_name in (
         "gemini-3.1-flash-lite",
@@ -3489,7 +3446,7 @@ def test_custom_pricing_without_cache_keys_preserves_legacy_behavior():
     assert cost == pytest.approx(expected)
 
 
-def test_openrouter_gemini_3_1_flash_lite_stable_pricing():
+def test_openrouter_gemini_3_1_flash_lite_stable_pricing(_local_model_cost_map):
     """
     Test that openrouter/google/gemini-3.1-flash-lite (stable, no -preview suffix)
     has a pricing entry.
@@ -3505,8 +3462,6 @@ def test_openrouter_gemini_3_1_flash_lite_stable_pricing():
     Pricing matches the existing -preview entry one-for-one (input $0.25/M, output
     $1.50/M, cache-read $0.025/M) — Google did not change costs at the GA cutover.
     """
-    os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = "True"
-    litellm.model_cost = litellm.get_model_cost_map(url="")
 
     model_name = "openrouter/google/gemini-3.1-flash-lite"
     model_info = litellm.model_cost.get(model_name)
@@ -3520,7 +3475,7 @@ def test_openrouter_gemini_3_1_flash_lite_stable_pricing():
     assert model_info["max_output_tokens"] == 65536
 
 
-def test_completion_cost_logs_reasoning_and_cache_breakdown():
+def test_completion_cost_logs_reasoning_and_cache_breakdown(_local_model_cost_map):
     """
     completion_cost must surface explicit reasoning and cache-read costs into the
     cost_breakdown stored on the logging object, so they end up in the spend logs
@@ -3531,8 +3486,6 @@ def test_completion_cost_logs_reasoning_and_cache_breakdown():
     from litellm.litellm_core_utils.litellm_logging import Logging
     from litellm.types.utils import Choices, CompletionTokensDetailsWrapper, Message
 
-    os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = "True"
-    litellm.model_cost = litellm.get_model_cost_map(url="")
 
     logging_obj = Logging(
         model="gemini-2.5-flash",
@@ -3750,13 +3703,13 @@ def test_combine_usage_objects_sums_mirrored_cache_write_fields_once():
     assert combined_pair.prompt_tokens_details.cache_creation_tokens == 100
 
 
-def test_completion_cost_prices_anthropic_shaped_cache_read_tokens():
+def test_completion_cost_prices_anthropic_shaped_cache_read_tokens(
+    _local_model_cost_map,
+):
     """Regression: an Anthropic /v1/messages response reports cache reads as top-level
     cache_read_input_tokens with input_tokens excluding them. Reading that usage as
     Responses API usage dropped the cache tokens and billed the whole prompt at the
     uncached input rate, overstating spend on cache hits."""
-    os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = "True"
-    litellm.model_cost = litellm.get_model_cost_map(url="")
 
     response = {
         "id": "msg_1",


### PR DESCRIPTION
## TLDR

Problem this solves:

- 28 cost-calculator tests leave `LITELLM_LOCAL_MODEL_COST_MAP` set session-wide
- they also leave `litellm.model_cost` swapped to the local snapshot
- two more assigned model_cost by hand despite taking monkeypatch

How it solves it:

- those 28 tests request a new `_local_model_cost_map` fixture
- the fixture uses `monkeypatch`, so a failing test still restores
- drops a `sys.path.insert` that resolved against the working directory

## User Flow

Before: a proxy admin reports a cost discrepancy, and the maintainer checking it locally reads a stale price

1. The maintainer runs the unit tier in one process, cost-calculator tests included
2. A later test in that process reads `litellm.model_cost` and gets the checked-in snapshot, not the live map
3. Any price quoted from that run reflects the snapshot, so the answer sent back can disagree with what the proxy actually charged

After: the same run reads the live map, so the answer matches the proxy

1. The maintainer runs the same unit tier in one process, cost-calculator tests included
2. The cost-calculator tests put `LITELLM_LOCAL_MODEL_COST_MAP` and `litellm.model_cost` back when each one finishes
3. A later test reads the live map, so a quoted price matches what the proxy charged

## Relevant issues

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

The leak is only visible from outside the pytest process, so the probe runs the file in-process and reads the environment back afterwards. `LITELLM_LOCAL_MODEL_COST_MAP` is not part of the conftest snapshot, so nothing else restores it.

```python
# leakprobe.py
import os, pytest
os.environ.pop("LITELLM_LOCAL_MODEL_COST_MAP", None)
pytest.main(["tests/test_litellm/test_cost_calculator.py", "-q", "-p", "no:randomly"])
print("LITELLM_LOCAL_MODEL_COST_MAP after:", repr(os.environ.get("LITELLM_LOCAL_MODEL_COST_MAP")))
```

### Before (ff02d5cfc0)

1. `python leakprobe.py`
2. `89 passed`, then `LITELLM_LOCAL_MODEL_COST_MAP after: 'True'`

### After (cff2af5fb4)

1. `python leakprobe.py`
2. `89 passed`, then `LITELLM_LOCAL_MODEL_COST_MAP after: None`

## Type

🧹 Refactoring
✅ Test

## Caveats (if any)

- `litellm.model_cost` restores via the conftest snapshot either way

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
