### PR TITLE
fix(responses): stop closing a message item the tool-only stream never opened

### DIFF
--- a/litellm/responses/litellm_completion_transformation/streaming_iterator.py
+++ b/litellm/responses/litellm_completion_transformation/streaming_iterator.py
@@ -759,9 +759,31 @@ class LiteLLMCompletionStreamingIterator(ResponsesAPIStreamingIterator):
             ),
         )
 
+    def _message_item_was_never_opened(self, litellm_complete_object: ModelResponse) -> bool:
+        """True when this turn produced tool calls only, so no message item exists.
+
+        ``_ensure_output_item_for_chunk`` deliberately opens no message item for a
+        tool-first chunk, and a turn with no assistant text has nothing to put in one.
+        Emitting the message ``.done`` events anyway would reference an item the client
+        never saw opened, which clients that track output items by id reject.
+        """
+        if self.sent_content_part_added_event:
+            return False
+        message: Final = litellm_complete_object.choices[0].message
+        if getattr(message, "content", None) or getattr(message, "reasoning_content", None):
+            return False
+        return bool(getattr(message, "tool_calls", None))
+
     def return_default_done_events(
         self, litellm_complete_object: ModelResponse
     ) -> BaseLiteLLMOpenAIResponseObject | None:
+        if self._message_item_was_never_opened(litellm_complete_object):
+            # Latch the flags so is_stream_finished() still reports done and the
+            # stream proceeds straight to response.completed.
+            self.sent_output_text_done_event = True
+            self.sent_output_content_part_done_event = True
+            self.sent_output_item_done_event = True
+            return None
         if self.sent_output_text_done_event is False:
             self.sent_output_text_done_event = True
             return self.create_output_text_done_event(litellm_complete_object)

--- a/tests/test_litellm/responses/litellm_completion_transformation/test_streaming_iterator_transformation.py
+++ b/tests/test_litellm/responses/litellm_completion_transformation/test_streaming_iterator_transformation.py
@@ -628,3 +628,150 @@ def test_streamed_anthropic_tool_call_events_correlate_on_normalized_item_id():
     assert item_dones[0].item.call_id == "toolu_01AbCdEf"
     for evt in deltas + dones:
         assert evt.item_id == added[0].item.id
+
+class _FakeChatCompletionStream:
+    """Minimal stand-in for CustomStreamWrapper: yields chunks, carries logging_obj."""
+
+    def __init__(self, chunks):
+        self._chunks = iter(chunks)
+        self.logging_obj = None
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        return next(self._chunks)
+
+
+def _tool_chunk(content=None, tool_calls=None, finish_reason=None):
+    return ModelResponseStream(
+        id="chatcmpl-a83572f7",
+        created=123,
+        model="claude-sonnet-4-6",
+        object="chat.completion.chunk",
+        choices=[
+            StreamingChoices(
+                finish_reason=finish_reason,
+                index=0,
+                delta=Delta(
+                    role="assistant", content=content, tool_calls=tool_calls
+                ),
+            )
+        ],
+    )
+
+
+_WEB_SEARCH_TOOL_CALL = [
+    {
+        "id": "tooluse_8G8H6h8nrt79WT4b8sHNd0",
+        "type": "function",
+        "function": {"name": "web_search", "arguments": '{"query":"floppy disks"}'},
+    }
+]
+
+
+def _drive(chunks):
+    """Run the whole stream and return (event type, item id) for every event."""
+    iterator = LiteLLMCompletionStreamingIterator(
+        model="claude-sonnet-4-6",
+        litellm_custom_stream_wrapper=_FakeChatCompletionStream(chunks),
+        request_input="Search the web for floppy disks.",
+        responses_api_request={},
+    )
+    iterator.litellm_custom_stream_wrapper.__anext__ = AsyncMock()
+    return [
+        (
+            event.type,
+            getattr(event, "item_id", None)
+            or getattr(getattr(event, "item", None), "id", None),
+        )
+        for event in iterator
+    ]
+
+
+def _unopened_done_events(events):
+    """Every *.done whose item id was never introduced by a matching *.added."""
+    opened = {
+        item_id
+        for event_type, item_id in events
+        if event_type
+        in (
+            ResponsesAPIStreamEvents.OUTPUT_ITEM_ADDED,
+            ResponsesAPIStreamEvents.CONTENT_PART_ADDED,
+        )
+    }
+    return [
+        (event_type, item_id)
+        for event_type, item_id in events
+        if event_type
+        in (
+            ResponsesAPIStreamEvents.OUTPUT_ITEM_DONE,
+            ResponsesAPIStreamEvents.CONTENT_PART_DONE,
+            ResponsesAPIStreamEvents.OUTPUT_TEXT_DONE,
+        )
+        and item_id not in opened
+    ]
+
+
+def test_tool_only_turn_does_not_close_a_message_item_it_never_opened():
+    """A tool call with no assistant text must not emit message .done events.
+
+    _ensure_output_item_for_chunk opens no message item for a tool-first chunk, so
+    emitting output_text.done / content_part.done / output_item.done for one leaves
+    three events pointing at an id the client never saw. Clients that track output
+    items by id (e.g. the Vercel AI SDK) abort the run on that.
+    """
+    events = _drive(
+        [
+            _tool_chunk(content="", tool_calls=_WEB_SEARCH_TOOL_CALL),
+            _tool_chunk(finish_reason="tool_calls"),
+        ]
+    )
+
+    assert _unopened_done_events(events) == []
+    # The tool call itself is still opened and closed as before.
+    assert (
+        ResponsesAPIStreamEvents.OUTPUT_ITEM_ADDED,
+        "tooluse_8G8H6h8nrt79WT4b8sHNd0",
+    ) in events
+    assert (
+        ResponsesAPIStreamEvents.OUTPUT_ITEM_DONE,
+        "tooluse_8G8H6h8nrt79WT4b8sHNd0",
+    ) in events
+    assert events[-1][0] == ResponsesAPIStreamEvents.RESPONSE_COMPLETED
+
+
+def test_tool_call_with_text_still_closes_its_message_item():
+    """Control: text alongside the tool call keeps the full message item lifecycle."""
+    events = _drive(
+        [
+            _tool_chunk(content="Let me search."),
+            _tool_chunk(content="", tool_calls=_WEB_SEARCH_TOOL_CALL),
+            _tool_chunk(finish_reason="tool_calls"),
+        ]
+    )
+
+    assert _unopened_done_events(events) == []
+    message_id = next(
+        item_id
+        for event_type, item_id in events
+        if event_type == ResponsesAPIStreamEvents.OUTPUT_ITEM_ADDED
+        and item_id.startswith("msg_")
+    )
+    for done_event in (
+        ResponsesAPIStreamEvents.OUTPUT_TEXT_DONE,
+        ResponsesAPIStreamEvents.CONTENT_PART_DONE,
+        ResponsesAPIStreamEvents.OUTPUT_ITEM_DONE,
+    ):
+        assert (done_event, message_id) in events
+
+
+def test_text_only_turn_still_closes_its_message_item():
+    """Control: the ordinary no-tool-calls stream is untouched."""
+    events = _drive([_tool_chunk(content="Floppy disks are obsolete."), _tool_chunk(finish_reason="stop")])
+
+    assert _unopened_done_events(events) == []
+    assert any(
+        event_type == ResponsesAPIStreamEvents.OUTPUT_TEXT_DONE
+        for event_type, _ in events
+    )

--- a/tests/test_litellm/responses/litellm_completion_transformation/test_streaming_iterator_transformation.py
+++ b/tests/test_litellm/responses/litellm_completion_transformation/test_streaming_iterator_transformation.py
@@ -732,11 +732,11 @@ def test_tool_only_turn_does_not_close_a_message_item_it_never_opened():
     # The tool call itself is still opened and closed as before.
     assert (
         ResponsesAPIStreamEvents.OUTPUT_ITEM_ADDED,
-        "tooluse_8G8H6h8nrt79WT4b8sHNd0",
+        "fc_tooluse_8G8H6h8nrt79WT4b8sHNd0",
     ) in events
     assert (
         ResponsesAPIStreamEvents.OUTPUT_ITEM_DONE,
-        "tooluse_8G8H6h8nrt79WT4b8sHNd0",
+        "fc_tooluse_8G8H6h8nrt79WT4b8sHNd0",
     ) in events
     assert events[-1][0] == ResponsesAPIStreamEvents.RESPONSE_COMPLETED
 


### PR DESCRIPTION
## Title

fix(responses): stop closing a message item the tool-only stream never opened

## Relevant issues

Fixes #37852

## Pre-Submission checklist

- [x] I have added a testing section to describe the changes below
- [x] The unit tests added here fail before the change and pass after it

## Type

🐛 Bug Fix

## Changes

`POST /v1/responses` with `stream: true`, against an Anthropic-family model that returns a **tool call with no accompanying text**, emits three events that close a message item that was never opened:

```
response.output_text.done    item_id=chatcmpl-<uuid>   <-- never had content_part.added
response.content_part.done   item_id=chatcmpl-<uuid>   <-- never had content_part.added
response.output_item.done    id=chatcmpl-<uuid>        <-- never had output_item.added
```

Note the id prefix: `chatcmpl-`, not the `msg_` id used when a message item is opened normally.

### Root cause

`_ensure_output_item_for_chunk` has an explicit tool-first branch that opens **no** message item:

```python
# Tool-first
if hasattr(delta, "tool_calls") and delta.tool_calls:
    # Tool calls already handled via _queue_tool_call_delta_events
    # DO NOT create message item
    return
```

The end of the stream did not mirror that. `return_default_done_events` emitted the message `.done` triple unconditionally, and each `create_*` helper falls back to `self._cached_item_id`, which `_transform_chat_completion_chunk_to_response_api_chunk` had already filled in with the chat completion chunk id. So the ids in the `.done` events are ones no `.added` event ever introduced.

Per the Responses API contract every `*.done` must be preceded by its `*.added` for the same `item_id`. Clients that track output items by id reject the stream: the Vercel AI SDK (`ai`, used by CopilotKit and OpenCode) raises `text part <id> not found` and aborts the run **before the tool result is delivered**, so agentic tool-calling loops break on the first tool call. The same request is well formed as soon as the model emits any text alongside the tool call, which is what makes this look intermittent in normal agent use.

### Fix

Skip the message `.done` triple when no message item was opened and the turn has no assistant text to report, latching the three sent flags so `is_stream_finished()` still reports done and the stream proceeds to `response.completed`.

The guard is deliberately narrow, so the paths that do open a message item are untouched:

- `sent_content_part_added_event` is set only where the message item is actually opened, so it is the direct record of "a message item exists".
- The `content` / `reasoning_content` check means a turn that has something to report always keeps its `.done` events, including the reasoning-then-tool-call shape where `create_output_content_part_done_event` emits a `reasoning_text` part.
- `tool_calls` must be present, so this only applies to the tool-only turn.

## Testing

Three tests in `tests/test_litellm/responses/litellm_completion_transformation/test_tool_call_streaming_transformation.py` drive the sync iterator over a whole stream and assert that no `.done` event carries an item id that no `.added` event introduced.

```
# unpatched
1 failed, 8 passed
FAILED test_tool_only_turn_does_not_close_a_message_item_it_never_opened

# patched
9 passed
```

The other two are controls that pass either way: tool call **with** text, and a plain text-only turn, both of which must keep the full message item lifecycle.

Wider control, same tree:

```
python3 -m pytest tests/test_litellm/responses/ -q
469 passed in 59.04s

python3 -m pytest tests/test_litellm/test_responses_streaming_container_ownership.py -q
7 passed
```

`ruff check` on both touched files reports exactly the same findings before and after this change (the 12 in `streaming_iterator.py` are pre-existing on the base branch; the test file is clean).

**What I did not verify:** I do not have a live proxy with real Anthropic or Bedrock credentials, so this is not confirmed end to end against a real provider. The evidence above is unit-level, driving the real `LiteLLMCompletionStreamingIterator` over a chunk sequence shaped like the one in the issue. Reviewers with proxy access may want to re-run the `curl` from #37852 before merging.

## One thing deliberately left alone

`response.completed` also lists an empty message item in `response.output`:

```json
{"type": "message", "id": "chatcmpl-...", "status": "completed", "role": "assistant",
 "content": [{"type": "output_text", "text": ""}]}
```

That item is built by `LiteLLMCompletionResponsesConfig.transform_chat_completion_response_to_responses_api_response`, which is shared with the **non-streaming** path. I checked, and a non-streaming `/v1/responses` call for the same tool-only completion returns the identical empty message item, so this is not a streaming bug and removing it would change the response shape for every provider on both paths. It is out of scope here and left for a separate decision. This PR fixes the streaming event pairing, which is what breaks the clients in the report.
