### PR TITLE
fix(responses): map Bedrock Mantle context overflow to ContextWindowExceededError

### DIFF
--- a/litellm/litellm_core_utils/exception_mapping_utils.py
+++ b/litellm/litellm_core_utils/exception_mapping_utils.py
@@ -811,6 +811,24 @@ def _map_openai_like_exception(
             )
 
 
+_BEDROCK_MANTLE_CONTEXT_WINDOW_PATTERN: Final = re.compile(r"prompt tokens \((\d+)\) exceed model maximum \((\d+)\)")
+
+
+def _get_bedrock_mantle_context_window_message(error_str: str) -> str | None:
+    """
+    Mantle reports context overflow as a structured validation error rather than
+    the plain-text patterns Bedrock itself uses, so it needs its own detection and a
+    message clients recognize as context overflow (litellm/litellm#36546).
+    """
+    if "invalid_request_error" not in error_str and "validation_error" not in error_str:
+        return None
+    match = _BEDROCK_MANTLE_CONTEXT_WINDOW_PATTERN.search(error_str)
+    if match is None:
+        return None
+    prompt_tokens, max_tokens = match.groups()
+    return f"prompt is too long: {prompt_tokens} tokens > {max_tokens} maximum"
+
+
 def _map_bedrock_exception(
     *,
     model: str,
@@ -821,6 +839,14 @@ def _map_bedrock_exception(
     exception_provider: str,
     extra_information: str,
 ) -> None:
+    if custom_llm_provider == "bedrock_mantle":
+        mantle_context_window_message = _get_bedrock_mantle_context_window_message(error_str)
+        if mantle_context_window_message is not None:
+            raise ContextWindowExceededError(
+                message=mantle_context_window_message,
+                model=model,
+                llm_provider=custom_llm_provider,
+            )
     if (
         "too many tokens" in error_str
         or "expected maxLength:" in error_str

--- a/tests/test_litellm/litellm_core_utils/test_exception_mapping_utils.py
+++ b/tests/test_litellm/litellm_core_utils/test_exception_mapping_utils.py
@@ -785,3 +785,27 @@ def test_bedrock_mantle_400_maps_to_bad_request():
 
     assert excinfo.value.status_code == 400
     assert "Invalid 'input'" in excinfo.value.message
+    assert type(excinfo.value) is litellm.BadRequestError
+
+
+def test_bedrock_mantle_context_overflow_maps_to_context_window_exceeded():
+    from litellm.llms.base_llm.chat.transformation import BaseLLMException
+
+    original_exception = BaseLLMException(
+        status_code=400,
+        message=(
+            '{"error":{"code":"validation_error",'
+            '"message":"prompt tokens (1055489) exceed model maximum (1050000) for openai.gpt-5.6-sol",'
+            '"param":null,"type":"invalid_request_error"}}'
+        ),
+    )
+
+    with pytest.raises(litellm.ContextWindowExceededError) as excinfo:
+        exception_type(
+            model="openai.gpt-5.6-sol",
+            original_exception=original_exception,
+            custom_llm_provider="bedrock_mantle",
+        )
+
+    assert excinfo.value.status_code == 400
+    assert "prompt is too long: 1055489 tokens > 1050000 maximum" in excinfo.value.message


### PR DESCRIPTION
## TLDR

Problem this solves:

- Bedrock Mantle context overflow surfaces as a plain 400 client error
- Claude Code only detects overflow via the phrase "prompt is too long"

How it solves it:

- Detects Mantle's structured `validation_error` token-count message
- Raises `ContextWindowExceededError` with that phrase in the message

## User Flow

Before: a Claude Code user whose prompt exceeds a Bedrock Mantle model's context window gets an ordinary error with no automatic recovery

1. They send a prompt larger than the model's context window through Claude Code to a Bedrock Mantle model
2. Mantle rejects it with HTTP 400 and body `{"error":{"code":"validation_error","message":"prompt tokens (400007) exceed model maximum (278528) for openai.gpt-5.5",...}}`
3. Claude Code does not recognize this wording as context overflow, so it does not run reactive compaction and the request just fails

After: the same overflow is recognized and triggers Claude Code's compaction path

1. They send the same prompt
2. Mantle rejects it the same way
3. The client-facing error message now reads "prompt is too long: 400007 tokens > 278528 maximum"
4. Claude Code recognizes the phrase and runs reactive compaction instead of surfacing a dead-end error

## Relevant issues

Follow-up to #36580 (comment https://github.com/BerriAI/litellm/pull/36580#issuecomment-5372977134)

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

All runs below are live calls against the real `bedrock-mantle.us-east-1.api.aws` endpoint with real AWS SigV4 credentials, no mocks

Setup: `litellm.responses(model="bedrock_mantle/openai.gpt-5.5", input=..., aws_region_name="us-east-1")`

### Before (c1662258df4a20c115fc184403de4b9e73535ede)

#### Context overflow

1. Send `input` built from 400007 tokens worth of text (model maximum is 278528)
2. Mantle returns HTTP 400 with body `{"error":{"code":"validation_error","message":"prompt tokens (400007) exceed model maximum (278528) for openai.gpt-5.5","param":null,"type":"invalid_request_error"}}`
3. LiteLLM raises `litellm.BadRequestError: BedrockException - {"error":{"code":"validation_error","message":"prompt tokens (400007) exceed model maximum (278528) for openai.gpt-5.5",...}}`, an ordinary 400 with no "prompt is too long" phrase

#### Unrelated validation error (must stay unaffected)

1. Send a malformed `input` item: `[{"type": "not_a_real_type", "text": "hi"}]`
2. Mantle returns HTTP 400 with body `{"error":{"code":"validation_error","message":"invalid request body: Invalid 'input': value did not match any expected variant","param":null,"type":"invalid_request_error"}}`
3. LiteLLM raises `litellm.BadRequestError: BedrockException - {"error":{"code":"validation_error","message":"invalid request body: Invalid 'input': ...`

### After (ec59c95f02, unchanged at current head fe8e2eeb15 — a pure rebase onto staging for an unrelated lint fix, no code delta)

#### Context overflow

1. Send the same `input` built from 400007 tokens worth of text
2. Mantle returns the same HTTP 400 body
3. LiteLLM now raises `litellm.ContextWindowExceededError: litellm.BadRequestError: prompt is too long: 400007 tokens > 278528 maximum`, status code 400

#### Unrelated validation error (must stay unaffected)

1. Send the same malformed `input` item
2. Mantle returns the same HTTP 400 body
3. LiteLLM still raises the ordinary `litellm.BadRequestError: BedrockException - {"error":{"code":"validation_error","message":"invalid request body: Invalid 'input': ...`, unchanged from Before

Targeted regression tests also passed:

`uv run --no-sync pytest tests/test_litellm/litellm_core_utils/test_exception_mapping_utils.py tests/test_litellm/llms/bedrock_mantle/ -q` -> 232 passed

## Type

Bug Fix

## Caveats (if any)

- The token counts in the reproduction (400007 / 278528) come from `openai.gpt-5.5`'s real context window, chosen over the larger `gpt-5.6` models to keep the live repro cheap
- The exact wording match is scoped to Mantle's `validation_error` shape; a differently-worded overflow message would need its own pattern

## Review notes

Greptile's one open finding (P2) asks to move the Mantle regex/parser out of `exception_mapping_utils.py` into the provider layer. Kept it in place: this file already holds 18 provider-specific `_map_<provider>_exception` functions, and `_map_bedrock_exception` itself already does inline Bedrock-specific substring matching (`AccessDeniedException`, `too many tokens`, and 5 more) right next to the new Mantle branch. This file is the codebase's established shared home for per-provider error classification, dispatched by `custom_llm_provider`; the new code follows that same shape one level down for the Mantle sub-provider that #36580 already routed through this exact function, so moving it out would fragment the pattern rather than isolate it

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
