### PR TITLE
test(lint): clear the two PT011/PT012 violations left on the test tree

### DIFF
--- a/tests/proxy_unit_tests/test_unit_test_max_model_budget_limiter.py
+++ b/tests/proxy_unit_tests/test_unit_test_max_model_budget_limiter.py
@@ -1210,18 +1210,19 @@ async def test_a_pre_upgrade_counter_keyed_on_the_request_model_still_enforces(e
     model_max_budget = {"gpt-4": {"budget_limit": 10.0, "time_period": "1d"}}
     await limiter.dual_cache.async_set_cache(key=f"{prefix}:entity-1:openai/gpt-4:1d", value=25.0, ttl=86400)
 
+    if entity_type == Litellm_EntityType.KEY:
+        budget_check = limiter.is_key_within_model_budget(
+            user_api_key_dict=UserAPIKeyAuth(token="entity-1", model_max_budget=model_max_budget),
+            model="openai/gpt-4",
+        )
+    else:
+        budget_check = limiter.is_end_user_within_model_budget(
+            end_user_id="entity-1",
+            end_user_model_max_budget=model_max_budget,
+            model="openai/gpt-4",
+        )
     with pytest.raises(litellm.BudgetExceededError) as exc_info:
-        if entity_type == Litellm_EntityType.KEY:
-            await limiter.is_key_within_model_budget(
-                user_api_key_dict=UserAPIKeyAuth(token="entity-1", model_max_budget=model_max_budget),
-                model="openai/gpt-4",
-            )
-        else:
-            await limiter.is_end_user_within_model_budget(
-                end_user_id="entity-1",
-                end_user_model_max_budget=model_max_budget,
-                model="openai/gpt-4",
-            )
+        await budget_check
     assert exc_info.value.current_cost == 25.0
 
 

--- a/tests/proxy_unit_tests/test_user_api_key_auth.py
+++ b/tests/proxy_unit_tests/test_user_api_key_auth.py
@@ -1357,9 +1357,8 @@ async def test_user_model_budget_is_enforced_through_user_api_key_auth(over_budg
         new=fake_get_user_object,
     ):
         if expect_refusal:
-            with pytest.raises(Exception) as exc:
+            with pytest.raises(Exception, match=r"(?i)budget") as exc:
                 await user_api_key_auth(request=request, api_key="Bearer " + key)
-            assert "budget" in str(exc.value).lower()
             assert user_id in str(exc.value)
         else:
             result = await user_api_key_auth(request=request, api_key="Bearer " + key)


### PR DESCRIPTION
## TLDR

Problem this solves:

- The test-tree ruff gate is red on staging itself
- Every PR rebased onto staging inherits the failing lint check

How it solves it:

- Sets a match on the broad pytest.raises in test_user_api_key_auth
- Hoists the branch out of the raises block in the budget limiter test

## User Flow

Before: a contributor rebases any branch onto litellm_internal_staging and the lint check fails on files they never touched

1. They push a rebased branch and open the PR checks page
2. The lint job fails with PT011 at tests/proxy_unit_tests/test_user_api_key_auth.py:1360 and PT012 at tests/proxy_unit_tests/test_unit_test_max_model_budget_limiter.py:1213
3. Both files are byte-identical to the base branch, so nothing in their diff can fix it

After: the same rebase gets a green lint check

1. They push a rebased branch and open the PR checks page
2. `uv run ruff check --config ruff-tests.toml tests` reports All checks passed
3. Both edited tests still pass (3 and 11 relevant cases respectively)

## Relevant issues

The rules landed in #37731; these two violations were left behind on the tree it gated

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

### Before (merge base 4307b34aca)

```
$ uv run ruff check --config ruff-tests.toml tests
PT012 pytest.raises() block should contain a single simple statement  (test_unit_test_max_model_budget_limiter.py:1213)
PT011 pytest.raises(Exception) is too broad  (test_user_api_key_auth.py:1360)
Found 2 errors.
```

### After (PR tip 349d55c1e1)

```
$ uv run ruff check --config ruff-tests.toml tests
All checks passed!
$ pytest tests/proxy_unit_tests/test_unit_test_max_model_budget_limiter.py -k "prefix or entity"  # 3 passed
$ pytest tests/proxy_unit_tests/test_user_api_key_auth.py -k "model_max_budget or user_model"     # 11 passed
```

The refusal test keeps asserting on the budget message via the match parameter and still checks the user id lands in the error
