### PR TITLE
fix(mcp): deny the interactive dcr_bridge authorize for a user without server access

### DIFF
--- a/basedpyright-code-budget.json
+++ b/basedpyright-code-budget.json
@@ -84,7 +84,7 @@
     "limit": 56
   },
   "reportPrivateUsage": {
-    "limit": 1823
+    "limit": 1822
   },
   "reportRedeclaration": {
     "limit": 8

--- a/litellm/proxy/_experimental/mcp_server/auth/user_api_key_auth_mcp.py
+++ b/litellm/proxy/_experimental/mcp_server/auth/user_api_key_auth_mcp.py
@@ -160,7 +160,7 @@ def _is_mcp_admitted_user_subject(user_api_key_auth: UserAPIKeyAuth | None) -> b
     """True when this auth is a keyless subject admitted by the gateway session / bridge user
     path, as opposed to a JWT or other keyless auth that merely lacks a ``team_id``.
 
-    Reads the server-only ``mcp_admitted_user_subject`` field, set only by ``_reload_admitted_user``. It
+    Reads the server-only ``mcp_admitted_user_subject`` field, set only by ``reload_admitted_user``. It
     is deliberately NOT a ``metadata`` key, which is caller-controlled at key creation and so forgeable
     on a personal key to gain the team grant union or dodge the egress scrub; this field cannot be."""
     return user_api_key_auth is not None and user_api_key_auth.mcp_admitted_user_subject is True
@@ -812,7 +812,7 @@ class MCPRequestHandler:
 
         Identity-only sibling of :meth:`_admit_dcr_bridge_delegate`: the session token seals no
         upstream credential (those are vaulted per user, resolved at egress), so authorization is
-        resolved fresh via :meth:`_reload_admitted_user` + the centralized policy gate rather than a
+        resolved fresh via :meth:`reload_admitted_user` + the centralized policy gate rather than a
         mint-time snapshot. Pre-DB gates (size, IP, route allowlist) run first, mirroring the standard
         pipeline. Fails closed with the requested scope's ``invalid_token`` challenge on an expired,
         tampered, foreign, or refresh token, or a missing/deactivated/policy-rejected user."""
@@ -835,7 +835,7 @@ class MCPRequestHandler:
         match result:
             case SessionBearerAdmitted():
                 try:
-                    admitted: Final = await MCPRequestHandler._reload_admitted_user(result.principal.user_id)
+                    admitted: Final = await MCPRequestHandler.reload_admitted_user(result.principal.user_id)
                     admitted.mcp_session_resource_server_id = result.principal.resource_server_id
                     await MCPRequestHandler._enforce_admitted_live_policy(
                         admitted=admitted, request=request, route=route
@@ -893,12 +893,12 @@ class MCPRequestHandler:
             case "key_hash":
                 return await MCPRequestHandler._reload_admitted_key(identity.subject)
             case "user_id":
-                return await MCPRequestHandler._reload_admitted_user(identity.subject)
+                return await MCPRequestHandler.reload_admitted_user(identity.subject)
             case _:
                 assert_never(identity.subject_type)
 
     @staticmethod
-    async def _reload_admitted_user(user_id: str) -> UserAPIKeyAuth:
+    async def reload_admitted_user(user_id: str) -> UserAPIKeyAuth:
         """Reload the live user an interactively-minted envelope references and admit them as themselves.
 
         The user's own object permission and ``org_id`` ride on the returned ``UserAPIKeyAuth``, and the

--- a/litellm/proxy/_experimental/mcp_server/discoverable_endpoints.py
+++ b/litellm/proxy/_experimental/mcp_server/discoverable_endpoints.py
@@ -750,6 +750,55 @@ def _redirect_to_upstream_authorize(
     return RedirectResponse(urlunparse(parsed_auth_url._replace(query=urlencode(merged_params))))
 
 
+def _bridge_access_denied_redirect(redirect_uri: str, state: str, mcp_server: MCPServer) -> RedirectResponse:
+    """RFC 6749 section 4.1.2.1 denial for the interactive bridge authorize, delivered to the
+    already-validated client redirect_uri so a DCR client surfaces the failure at connect time."""
+    server_label: Final = mcp_server.alias or mcp_server.server_name or mcp_server.server_id
+    params: Final = {
+        "error": "access_denied",
+        "error_description": (
+            f"the signed-in user has no access to MCP server '{server_label}' on this gateway; "
+            "grant it through a team or user object permission, or mark the server allow_all_keys"
+        ),
+        **({"state": state} if state else {}),
+    }
+    return RedirectResponse(_append_query_params(redirect_uri, params), status_code=302)
+
+
+async def _bridge_authorize_access_denial(
+    litellm_user_id: str,
+    mcp_server: MCPServer,
+    redirect_uri: str,
+    state: str,
+) -> RedirectResponse | None:
+    """The denial redirect for a signed-in user who cannot reach the target server, or None to proceed.
+
+    Admits the user exactly as MCP egress will (the same ``reload_admitted_user`` constructor and the
+    same ``get_allowed_mcp_servers`` resolver), so an envelope is minted only when the resulting
+    session can actually list and call the server's tools. Without this gate the flow completes, the
+    client shows connected, and every tool request fail-closes to an empty list with nothing telling
+    the operator why. An availability fault (5xx, e.g. a DB outage's 503) propagates; an unknown or
+    deactivated user denies like a missing grant, fail closed.
+    """
+    from litellm.proxy._experimental.mcp_server.auth.user_api_key_auth_mcp import (
+        MCPRequestHandler,
+    )
+    from litellm.proxy._experimental.mcp_server.mcp_server_manager import (
+        global_mcp_server_manager,
+    )
+
+    try:
+        admitted: Final = await MCPRequestHandler.reload_admitted_user(litellm_user_id)
+    except HTTPException as exc:
+        if exc.status_code >= 500:
+            raise
+        return _bridge_access_denied_redirect(redirect_uri, state, mcp_server)
+    allowed_server_ids: Final = await global_mcp_server_manager.get_allowed_mcp_servers(admitted)
+    if mcp_server.server_id in allowed_server_ids:
+        return None
+    return _bridge_access_denied_redirect(redirect_uri, state, mcp_server)
+
+
 async def authorize_with_server(
     request: Request,
     mcp_server: MCPServer,
@@ -819,6 +868,14 @@ async def authorize_with_server(
         litellm_user_id = _user_id_from_session_cookie(request)
         if litellm_user_id is None:
             return _redirect_to_litellm_login(request)
+        denial: Final = await _bridge_authorize_access_denial(
+            litellm_user_id=litellm_user_id,
+            mcp_server=mcp_server,
+            redirect_uri=redirect_uri,
+            state=state,
+        )
+        if denial is not None:
+            return denial
 
     encoded_state: Final = encode_state_with_base_url(
         base_url=base_url,

--- a/litellm/proxy/_experimental/mcp_server/ui_session_utils.py
+++ b/litellm/proxy/_experimental/mcp_server/ui_session_utils.py
@@ -91,7 +91,7 @@ async def admitted_user_context(user_api_key_auth: UserAPIKeyAuth) -> UserAPIKey
     )
 
     try:
-        admitted: Final = await MCPRequestHandler._reload_admitted_user(user_id)
+        admitted: Final = await MCPRequestHandler.reload_admitted_user(user_id)
     except HTTPException as e:
         verbose_logger.warning("MCP dashboard session: admitted-subject reload failed for %s: %s", user_id, e.detail)
         return None

--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -2812,7 +2812,7 @@ class UserAPIKeyAuth(LiteLLM_VerificationTokenView):  # the expected response ob
     request_route: str | None = None
     is_session_token: bool = False
     # Server-only marker set exclusively by the MCP gateway admission path
-    # (_reload_admitted_user) for a keyless user-subject admitted via a gateway DCR session
+    # (reload_admitted_user) for a keyless user-subject admitted via a gateway DCR session
     # bearer or bridge envelope. Not a DB column and never populated from caller-controlled key
     # metadata or JWT claims, so it cannot be forged to gain the team-inherited MCP grant union
     # or to escape the caller-Authorization egress scrub. exclude=True keeps it out of serialization.

--- a/tests/test_litellm/proxy/_experimental/mcp_server/auth/test_user_api_key_auth_mcp.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/auth/test_user_api_key_auth_mcp.py
@@ -5232,7 +5232,7 @@ class TestMCPDcrBridgeDelegateAdmission:
     @contextlib.contextmanager
     def _patch_user_reload(*, return_value=None, side_effect=None):
         """Patch the user-subject reload path an interactively-minted envelope takes: the
-        ``get_user_object`` lookup ``_reload_admitted_user`` runs (which also drives the SCIM gate),
+        ``get_user_object`` lookup ``reload_admitted_user`` runs (which also drives the SCIM gate),
         plus the ``prisma_client`` / ``user_api_key_cache`` globals. The centralized gate's own
         fetches fail-safe to None under the MagicMock prisma, so an unblocked user admits. Yields the
         ``get_user_object`` mock so a caller can assert the sealed user_id was the reload key."""

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_discoverable_endpoints.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_discoverable_endpoints.py
@@ -5199,11 +5199,18 @@ async def test_interactive_bridge_gateway_code_for_another_server_is_rejected_40
 async def test_interactive_bridge_authorize_seals_sso_user_into_state():
     """On the short-circuit bridge oauth_delegate arm, authorize captures the SSO user from the UI
     session cookie and seals it (and the target server) into the encrypted OAuth state, so the
-    callback can later mint a user-bound gateway code; it still proceeds to the upstream redirect."""
+    callback can later mint a user-bound gateway code; it still proceeds to the upstream redirect.
+    The access gate runs for real against a granted resolver, so its interface stays exercised."""
     from litellm.proxy._experimental.mcp_server.discoverable_endpoints import authorize_with_server
+    from litellm.proxy._experimental.mcp_server.mcp_server_manager import (
+        global_mcp_server_manager,
+    )
+    from litellm.proxy._types import UserAPIKeyAuth
     from litellm.types.mcp import MCPAuth
 
     server = _bridge_server(auth_type=MCPAuth.oauth_delegate, client_id="admin-client", registration_url=None)
+    admitted = UserAPIKeyAuth(user_id="sso-user-42")
+    admitted.mcp_admitted_user_subject = True
     captured: dict = {}
 
     def _capture(**kwargs):
@@ -5214,6 +5221,15 @@ async def test_interactive_bridge_authorize_seals_sso_user_into_state():
         patch(
             "litellm.proxy._experimental.mcp_server.byok_oauth_endpoints._user_id_from_session_cookie",
             return_value="sso-user-42",
+        ),
+        patch(
+            "litellm.proxy._experimental.mcp_server.auth.user_api_key_auth_mcp.MCPRequestHandler.reload_admitted_user",
+            new=AsyncMock(return_value=admitted),
+        ),
+        patch.object(
+            global_mcp_server_manager,
+            "get_allowed_mcp_servers",
+            new=AsyncMock(return_value=[server.server_id]),
         ),
         patch(
             "litellm.proxy._experimental.mcp_server.discoverable_endpoints.encode_state_with_base_url",
@@ -5233,6 +5249,147 @@ async def test_interactive_bridge_authorize_seals_sso_user_into_state():
     assert captured["litellm_user_id"] == "sso-user-42"
     assert captured["mcp_server_id"] == server.server_id
     assert "/sso/key/generate" not in response.headers["location"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("user_can_reach_server", [True, False])
+async def test_bridge_authorize_gates_on_the_egress_server_access_resolver(user_can_reach_server):
+    """The interactive dcr_bridge oauth_delegate authorize admits the signed-in user the way MCP
+    egress will and refuses with an RFC 6749 access_denied redirect when that admitted subject
+    cannot reach the target server, instead of minting an envelope whose every tool request would
+    fail-closed to an empty list (#36358). A user the resolver grants proceeds upstream unchanged."""
+    from urllib.parse import parse_qs, urlparse
+
+    from fastapi import Request
+
+    from litellm.proxy._experimental.mcp_server.discoverable_endpoints import authorize
+    from litellm.proxy._experimental.mcp_server.mcp_server_manager import (
+        global_mcp_server_manager,
+    )
+    from litellm.proxy._types import UserAPIKeyAuth
+
+    server = _bridge_server(auth_type=MCPAuth.oauth_delegate, client_id="upstream-app", registration_url=None)
+    global_mcp_server_manager.registry.clear()
+    global_mcp_server_manager.registry[server.server_id] = server
+
+    admitted = UserAPIKeyAuth(user_id="bridge-user-1")
+    admitted.mcp_admitted_user_subject = True
+    allowed = [server.server_id] if user_can_reach_server else []
+
+    mock_request = MagicMock(spec=Request)
+    mock_request.base_url = "https://litellm.example.com/"
+    mock_request.headers = {}
+
+    client_redirect = "http://127.0.0.1:60108/callback"
+    try:
+        with (
+            patch(
+                "litellm.proxy._experimental.mcp_server.byok_oauth_endpoints._user_id_from_session_cookie",
+                return_value="bridge-user-1",
+            ),
+            patch(
+                "litellm.proxy._experimental.mcp_server.auth.user_api_key_auth_mcp.MCPRequestHandler.reload_admitted_user",
+                new=AsyncMock(return_value=admitted),
+            ) as mock_reload,
+            patch.object(
+                global_mcp_server_manager,
+                "get_allowed_mcp_servers",
+                new=AsyncMock(return_value=allowed),
+            ) as mock_allowed,
+            patch(
+                "litellm.proxy._experimental.mcp_server.discoverable_endpoints.encrypt_value_helper",
+                return_value="mocked_encrypted_state",
+            ),
+        ):
+            response = await authorize(
+                request=mock_request,
+                client_id="dcr_client_id",
+                mcp_server_name="bridge_srv",
+                redirect_uri=client_redirect,
+                state="client-state-1",
+                code_challenge="a" * 43,
+                code_challenge_method="S256",
+            )
+    finally:
+        global_mcp_server_manager.registry.clear()
+
+    mock_reload.assert_awaited_once_with("bridge-user-1")
+    mock_allowed.assert_awaited_once_with(admitted)
+    location = response.headers["location"]
+    if user_can_reach_server:
+        assert response.status_code == 307
+        assert location.startswith("https://provider.com/oauth/authorize")
+    else:
+        assert response.status_code == 302
+        assert location.startswith(client_redirect)
+        query = parse_qs(urlparse(location).query)
+        assert query["error"] == ["access_denied"]
+        assert query["state"] == ["client-state-1"]
+        assert "bridge_srv" in query["error_description"][0]
+        assert "provider.com" not in location
+        assert "set-cookie" not in {k.lower() for k in response.headers}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("reload_status,expect_denial", [(401, True), (500, False), (503, False)])
+async def test_bridge_authorize_reload_failure_denies_or_stays_retryable(reload_status, expect_denial):
+    """An unknown or deactivated signed-in user denies like a missing grant (fail closed); a DB
+    outage keeps its retryable 503 instead of masquerading as an access denial."""
+    from urllib.parse import parse_qs, urlparse
+
+    from fastapi import Request
+
+    from litellm.proxy._experimental.mcp_server.discoverable_endpoints import authorize
+    from litellm.proxy._experimental.mcp_server.mcp_server_manager import (
+        global_mcp_server_manager,
+    )
+
+    server = _bridge_server(auth_type=MCPAuth.oauth_delegate, client_id="upstream-app", registration_url=None)
+    global_mcp_server_manager.registry.clear()
+    global_mcp_server_manager.registry[server.server_id] = server
+
+    mock_request = MagicMock(spec=Request)
+    mock_request.base_url = "https://litellm.example.com/"
+    mock_request.headers = {}
+
+    try:
+        with (
+            patch(
+                "litellm.proxy._experimental.mcp_server.byok_oauth_endpoints._user_id_from_session_cookie",
+                return_value="bridge-user-1",
+            ),
+            patch(
+                "litellm.proxy._experimental.mcp_server.auth.user_api_key_auth_mcp.MCPRequestHandler.reload_admitted_user",
+                new=AsyncMock(side_effect=HTTPException(status_code=reload_status, detail="x")),
+            ),
+        ):
+            if expect_denial:
+                response = await authorize(
+                    request=mock_request,
+                    client_id="dcr_client_id",
+                    mcp_server_name="bridge_srv",
+                    redirect_uri="http://127.0.0.1:60108/callback",
+                    state="client-state-1",
+                    code_challenge="a" * 43,
+                    code_challenge_method="S256",
+                )
+                assert response.status_code == 302
+                query = parse_qs(urlparse(response.headers["location"]).query)
+                assert query["error"] == ["access_denied"]
+            else:
+                with pytest.raises(HTTPException) as exc_info:
+                    await authorize(
+                        request=mock_request,
+                        client_id="dcr_client_id",
+                        mcp_server_name="bridge_srv",
+                        redirect_uri="http://127.0.0.1:60108/callback",
+                        state="client-state-1",
+                        code_challenge="a" * 43,
+                        code_challenge_method="S256",
+                    )
+                assert exc_info.value.status_code == reload_status
+    finally:
+        global_mcp_server_manager.registry.clear()
 
 
 @pytest.mark.asyncio

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_rest_endpoints.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_rest_endpoints.py
@@ -796,7 +796,7 @@ class TestListToolsRestAPI:
             return admitted_auth
 
         monkeypatch.setattr(
-            "litellm.proxy._experimental.mcp_server.auth.user_api_key_auth_mcp.MCPRequestHandler._reload_admitted_user",
+            "litellm.proxy._experimental.mcp_server.auth.user_api_key_auth_mcp.MCPRequestHandler.reload_admitted_user",
             fake_reload,
         )
 
@@ -912,7 +912,7 @@ class TestListToolsRestAPI:
             return ["toolset-tool-1"]
 
         monkeypatch.setattr(
-            "litellm.proxy._experimental.mcp_server.auth.user_api_key_auth_mcp.MCPRequestHandler._reload_admitted_user",
+            "litellm.proxy._experimental.mcp_server.auth.user_api_key_auth_mcp.MCPRequestHandler.reload_admitted_user",
             record_reload,
         )
         monkeypatch.setattr(

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_ui_session_utils.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_ui_session_utils.py
@@ -137,7 +137,7 @@ async def test_build_effective_auth_contexts_appends_admitted_user_context(monke
     )
     reload_mock = AsyncMock(return_value=admitted_auth)
     monkeypatch.setattr(
-        "litellm.proxy._experimental.mcp_server.auth.user_api_key_auth_mcp.MCPRequestHandler._reload_admitted_user",
+        "litellm.proxy._experimental.mcp_server.auth.user_api_key_auth_mcp.MCPRequestHandler.reload_admitted_user",
         reload_mock,
     )
 
@@ -153,7 +153,7 @@ async def test_build_effective_auth_contexts_never_widens_caller_passed_keys(mon
     normal_user = UserAPIKeyAuth(team_id="regular-team", user_id="user-1")
     reload_mock = AsyncMock()
     monkeypatch.setattr(
-        "litellm.proxy._experimental.mcp_server.auth.user_api_key_auth_mcp.MCPRequestHandler._reload_admitted_user",
+        "litellm.proxy._experimental.mcp_server.auth.user_api_key_auth_mcp.MCPRequestHandler.reload_admitted_user",
         reload_mock,
     )
 
@@ -172,7 +172,7 @@ async def test_build_effective_auth_contexts_survives_admitted_reload_failure(mo
         AsyncMock(return_value=["team-a"]),
     )
     monkeypatch.setattr(
-        "litellm.proxy._experimental.mcp_server.auth.user_api_key_auth_mcp.MCPRequestHandler._reload_admitted_user",
+        "litellm.proxy._experimental.mcp_server.auth.user_api_key_auth_mcp.MCPRequestHandler.reload_admitted_user",
         AsyncMock(side_effect=HTTPException(status_code=503, detail="db down")),
     )
 
@@ -191,7 +191,7 @@ async def test_acting_user_auth_returns_admitted_subject_for_non_admin_sessions(
     admitted_auth = UserAPIKeyAuth(user_id="user-42")
     reload_mock = AsyncMock(return_value=admitted_auth)
     monkeypatch.setattr(
-        "litellm.proxy._experimental.mcp_server.auth.user_api_key_auth_mcp.MCPRequestHandler._reload_admitted_user",
+        "litellm.proxy._experimental.mcp_server.auth.user_api_key_auth_mcp.MCPRequestHandler.reload_admitted_user",
         reload_mock,
     )
 
@@ -207,7 +207,7 @@ async def test_acting_user_auth_keeps_admin_sessions_and_passed_keys_unchanged(m
 
     reload_mock = AsyncMock()
     monkeypatch.setattr(
-        "litellm.proxy._experimental.mcp_server.auth.user_api_key_auth_mcp.MCPRequestHandler._reload_admitted_user",
+        "litellm.proxy._experimental.mcp_server.auth.user_api_key_auth_mcp.MCPRequestHandler.reload_admitted_user",
         reload_mock,
     )
 
@@ -226,7 +226,7 @@ async def test_acting_user_auth_falls_back_to_session_auth_on_reload_failure(mon
 
     user_auth = UserAPIKeyAuth(team_id=UI_SESSION_TOKEN_TEAM_ID, user_id="user-9", user_role="internal_user")
     monkeypatch.setattr(
-        "litellm.proxy._experimental.mcp_server.auth.user_api_key_auth_mcp.MCPRequestHandler._reload_admitted_user",
+        "litellm.proxy._experimental.mcp_server.auth.user_api_key_auth_mcp.MCPRequestHandler.reload_admitted_user",
         AsyncMock(side_effect=HTTPException(status_code=503, detail="db down")),
     )
 
@@ -252,7 +252,7 @@ async def test_admitted_user_context_carries_the_request_span(monkeypatch):
         parent_otel_span=parent_span,
     )
     monkeypatch.setattr(
-        "litellm.proxy._experimental.mcp_server.auth.user_api_key_auth_mcp.MCPRequestHandler._reload_admitted_user",
+        "litellm.proxy._experimental.mcp_server.auth.user_api_key_auth_mcp.MCPRequestHandler.reload_admitted_user",
         AsyncMock(return_value=UserAPIKeyAuth(user_id="user-42")),
     )
 

--- a/tests/test_litellm/proxy/management_endpoints/test_mcp_management_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_mcp_management_endpoints.py
@@ -6560,7 +6560,7 @@ class TestConnectedAppViewAnnotation:
                 AsyncMock(return_value=[caller_auth]),
             ),
             patch(
-                "litellm.proxy._experimental.mcp_server.auth.user_api_key_auth_mcp.MCPRequestHandler._reload_admitted_user",
+                "litellm.proxy._experimental.mcp_server.auth.user_api_key_auth_mcp.MCPRequestHandler.reload_admitted_user",
                 reload_mock,
             ),
         ):
@@ -6592,7 +6592,7 @@ class TestConnectedAppViewAnnotation:
                 mock_manager,
             ),
             patch(
-                "litellm.proxy._experimental.mcp_server.auth.user_api_key_auth_mcp.MCPRequestHandler._reload_admitted_user",
+                "litellm.proxy._experimental.mcp_server.auth.user_api_key_auth_mcp.MCPRequestHandler.reload_admitted_user",
                 AsyncMock(return_value=UserAPIKeyAuth(user_id="test_user_id")),
             ),
         ):
@@ -6635,7 +6635,7 @@ class TestConnectedAppViewAnnotation:
                 AsyncMock(return_value=[]),
             ),
             patch(
-                "litellm.proxy._experimental.mcp_server.auth.user_api_key_auth_mcp.MCPRequestHandler._reload_admitted_user",
+                "litellm.proxy._experimental.mcp_server.auth.user_api_key_auth_mcp.MCPRequestHandler.reload_admitted_user",
                 AsyncMock(return_value=admitted_auth),
             ),
         ):
@@ -6663,7 +6663,7 @@ class TestConnectedAppViewAnnotation:
                 AsyncMock(return_value=[caller_auth]),
             ),
             patch(
-                "litellm.proxy._experimental.mcp_server.auth.user_api_key_auth_mcp.MCPRequestHandler._reload_admitted_user",
+                "litellm.proxy._experimental.mcp_server.auth.user_api_key_auth_mcp.MCPRequestHandler.reload_admitted_user",
                 AsyncMock(side_effect=HTTPException(status_code=401, detail="expired")),
             ),
         ):
@@ -6691,7 +6691,7 @@ class TestConnectedAppViewAnnotation:
                 AsyncMock(return_value=[caller_auth]),
             ),
             patch(
-                "litellm.proxy._experimental.mcp_server.auth.user_api_key_auth_mcp.MCPRequestHandler._reload_admitted_user",
+                "litellm.proxy._experimental.mcp_server.auth.user_api_key_auth_mcp.MCPRequestHandler.reload_admitted_user",
                 reload_mock,
             ),
         ):
@@ -6725,7 +6725,7 @@ class TestConnectedAppViewAnnotation:
                 AsyncMock(return_value=[caller_auth]),
             ),
             patch(
-                "litellm.proxy._experimental.mcp_server.auth.user_api_key_auth_mcp.MCPRequestHandler._reload_admitted_user",
+                "litellm.proxy._experimental.mcp_server.auth.user_api_key_auth_mcp.MCPRequestHandler.reload_admitted_user",
                 reload_mock,
             ),
         ):
@@ -6756,7 +6756,7 @@ class TestConnectedAppViewAnnotation:
                 AsyncMock(return_value=[caller_auth]),
             ),
             patch(
-                "litellm.proxy._experimental.mcp_server.auth.user_api_key_auth_mcp.MCPRequestHandler._reload_admitted_user",
+                "litellm.proxy._experimental.mcp_server.auth.user_api_key_auth_mcp.MCPRequestHandler.reload_admitted_user",
                 reload_mock,
             ),
         ):


### PR DESCRIPTION
## TLDR

Problem this solves:

- dcr_bridge oauth_delegate connect flow succeeds for users who cannot reach the server
- The client then shows connected with zero tools and no explanation
- Root cause of the silent failure reported in #36358

How it solves it:

- The interactive bridge authorize now checks server access for the signed-in user
- Same reload and same allowed-servers resolver MCP egress uses, nothing mirrored
- Denied users get an RFC 6749 access_denied redirect at connect time

## User Flow

Before: an operator adds their gateway's dcr_bridge MCP server as a claude.ai custom connector and ends up connected with no tools and no clue why

1. They add `https://litellm-domain/mcp/example_bridge` as a custom connector and click connect
2. The browser walks register, sign-in, upstream OAuth, and callback; every leg returns 200
3. claude.ai shows the connector as Connected
4. The tools list is empty ("This connector has no tools available") and the upstream MCP server's own logs show it never received a request

After: the same operator finds out at connect time, with an error naming the fix

1. They add the same connector and click connect
2. After sign-in, the flow immediately returns to claude.ai with `error=access_denied` and the description "the signed-in user has no access to MCP server 'example_bridge' on this gateway; grant it through a team or user object permission, or mark the server allow_all_keys"
3. claude.ai shows the authorization as failed instead of pretending to be connected
4. Once the operator grants the user the server (or sets `allow_all_keys: true`), the same connect flow completes and tools list and run

## Relevant issues

Addresses the silent failure behind #36358. The issue's traced mechanism (the v2 resolver discarding the admission-injected credential in `_create_mcp_client`) does not reproduce: on the reporter's own version (v1.97.0-rc.1) and on current staging, a user who does have a grant gets the unsealed upstream credential delivered correctly through the v2 PassthroughConfig path, proven live below. The observed symptom (connected, zero tools, upstream session count 0) comes from the allowed-servers scope filter failing closed for a bridge-admitted user with no litellm-side grant, silently

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Shared setup: proxy on `localhost:4610` backed by Postgres, a stub upstream MCP server on `:8933` that 401s unless it receives `Authorization: Bearer real_upstream_token_12345` and counts every authed request, and a stub IdP on `:8934` whose `/token` returns that bearer as `access_token`. Three DB-defined MCP servers, all `auth_type: oauth_delegate, dcr_bridge: true`, pointed at the stub upstream: `bridge_gated` (signed-in user has no grant), `example_bridge` (user granted via object permission), `bridge_open` (`allow_all_keys: true`). The walk simulates an external DCR client: POST `/login`, POST `/{server}/register`, GET `/{server}/authorize` following redirects, POST `/{server}/token`, then MCP initialize and tools/list against `/mcp/{server}` with the minted envelope bearer and no cookies

### Before (40b8300ac2)

#### no grant: every leg 200, connected, silently zero tools

1. `GET /example_bridge/authorize?...` returns 307 to the stub IdP, the callback returns 302 with a gateway code, `POST /example_bridge/token` returns 200 with `{"access_token": "llm_env_...", "token_type": "Bearer"}`
2. MCP initialize with that bearer returns 200, `tools/list` returns `{"jsonrpc":"2.0","id":2,"result":{"tools":[]}}`
3. Stub upstream stats: `{"authed_requests": 0, "unauthed_requests": 0, "last_auth_header": null}`, the upstream was never contacted

#### with grant: works, proving the credential path was never the bug

1. Same walk after `POST /user/update` with `{"object_permission": {"mcp_servers": ["example_bridge"]}}`
2. `tools/list` returns the `example_bridge-echo` tool
3. Stub upstream stats: `{"authed_requests": 3, ..., "last_auth_header": "Bearer real_upstream_token_12345"}`

### After (f9ecf18984)

#### no grant: denied loudly at connect time

1. `GET /bridge_gated/authorize?...&state=probe_state_xyz` returns 302 straight back to the client: `http://127.0.0.1:9777/callback?error=access_denied&error_description=the+signed-in+user+has+no+access+to+MCP+server+%27bridge_gated%27...&state=probe_state_xyz`
2. The upstream IdP is never engaged for this flow and no envelope is minted

#### with grant: byte-identical success

1. Same walk against `example_bridge` completes; `tools/list` returns `example_bridge-echo`
2. Stub upstream stats advanced by exactly the three expected authed requests, `last_auth_header: "Bearer real_upstream_token_12345"`

#### allow_all_keys: byte-identical success

1. Same walk against `bridge_open` completes; `tools/list` returns `bridge_open-echo`
2. `tools/call` on `bridge_open-echo` with `{"text": "proof-36358"}` returns `"echo: proof-36358"` through the gateway

## Type

🐛 Bug Fix

## Caveats (if any)

- Promotes `reload_admitted_user` to public per review: it already had a cross-module consumer in ui_session_utils, and the gate adds a second; the freed reportPrivateUsage budget is ratcheted down

- Key-hash-subject envelopes never pass this authorize leg; key scoping already governs them
- A grant revoked after mint still fail-closes silently at egress, as any scoped principal does
- The relay bridge arm (true_passthrough) is deliberately ungated; egress admits it anonymously by design

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
