### PR TITLE
fix(pricing): add undated azure aliases for gpt-audio-mini and gpt-realtime-mini

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -5135,7 +5135,7 @@
         "max_input_tokens": 32000,
         "max_output_tokens": 4096,
         "max_tokens": 4096,
-        "mode": "chat",
+        "mode": "realtime",
         "output_cost_per_audio_token": 2e-05,
         "output_cost_per_token": 2.4e-06,
         "supported_endpoints": [

--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -4881,6 +4881,37 @@
         "supports_tool_choice": true,
         "supports_vision": false
     },
+    "azure/gpt-audio-mini": {
+        "input_cost_per_audio_token": 1e-05,
+        "input_cost_per_token": 6e-07,
+        "litellm_provider": "azure",
+        "max_input_tokens": 128000,
+        "max_output_tokens": 16384,
+        "max_tokens": 16384,
+        "mode": "chat",
+        "output_cost_per_audio_token": 2e-05,
+        "output_cost_per_token": 2.4e-06,
+        "supported_endpoints": [
+            "/v1/chat/completions"
+        ],
+        "supported_modalities": [
+            "text",
+            "audio"
+        ],
+        "supported_output_modalities": [
+            "text",
+            "audio"
+        ],
+        "supports_function_calling": true,
+        "supports_native_streaming": true,
+        "supports_parallel_function_calling": true,
+        "supports_prompt_caching": false,
+        "supports_reasoning": false,
+        "supports_response_schema": false,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_vision": false
+    },
     "azure/gpt-audio-mini-2025-10-06": {
         "deprecation_date": "2027-04-06",
         "input_cost_per_audio_token": 1e-05,
@@ -5075,6 +5106,38 @@
         "mode": "realtime",
         "output_cost_per_audio_token": 6.4e-05,
         "output_cost_per_token": 1.6e-05,
+        "supported_endpoints": [
+            "/v1/realtime"
+        ],
+        "supported_modalities": [
+            "text",
+            "image",
+            "audio"
+        ],
+        "supported_output_modalities": [
+            "text",
+            "audio"
+        ],
+        "supports_audio_input": true,
+        "supports_audio_output": true,
+        "supports_function_calling": true,
+        "supports_parallel_function_calling": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true
+    },
+    "azure/gpt-realtime-mini": {
+        "cache_creation_input_audio_token_cost": 3e-07,
+        "cache_read_input_token_cost": 6e-08,
+        "input_cost_per_audio_token": 1e-05,
+        "input_cost_per_image": 8e-07,
+        "input_cost_per_token": 6e-07,
+        "litellm_provider": "azure",
+        "max_input_tokens": 32000,
+        "max_output_tokens": 4096,
+        "max_tokens": 4096,
+        "mode": "chat",
+        "output_cost_per_audio_token": 2e-05,
+        "output_cost_per_token": 2.4e-06,
         "supported_endpoints": [
             "/v1/realtime"
         ],

--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -4882,6 +4882,7 @@
         "supports_vision": false
     },
     "azure/gpt-audio-mini": {
+        "deprecation_date": "2027-04-06",
         "input_cost_per_audio_token": 1e-05,
         "input_cost_per_token": 6e-07,
         "litellm_provider": "azure",

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -5135,7 +5135,7 @@
         "max_input_tokens": 32000,
         "max_output_tokens": 4096,
         "max_tokens": 4096,
-        "mode": "chat",
+        "mode": "realtime",
         "output_cost_per_audio_token": 2e-05,
         "output_cost_per_token": 2.4e-06,
         "supported_endpoints": [

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -4881,6 +4881,37 @@
         "supports_tool_choice": true,
         "supports_vision": false
     },
+    "azure/gpt-audio-mini": {
+        "input_cost_per_audio_token": 1e-05,
+        "input_cost_per_token": 6e-07,
+        "litellm_provider": "azure",
+        "max_input_tokens": 128000,
+        "max_output_tokens": 16384,
+        "max_tokens": 16384,
+        "mode": "chat",
+        "output_cost_per_audio_token": 2e-05,
+        "output_cost_per_token": 2.4e-06,
+        "supported_endpoints": [
+            "/v1/chat/completions"
+        ],
+        "supported_modalities": [
+            "text",
+            "audio"
+        ],
+        "supported_output_modalities": [
+            "text",
+            "audio"
+        ],
+        "supports_function_calling": true,
+        "supports_native_streaming": true,
+        "supports_parallel_function_calling": true,
+        "supports_prompt_caching": false,
+        "supports_reasoning": false,
+        "supports_response_schema": false,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_vision": false
+    },
     "azure/gpt-audio-mini-2025-10-06": {
         "deprecation_date": "2027-04-06",
         "input_cost_per_audio_token": 1e-05,
@@ -5075,6 +5106,38 @@
         "mode": "realtime",
         "output_cost_per_audio_token": 6.4e-05,
         "output_cost_per_token": 1.6e-05,
+        "supported_endpoints": [
+            "/v1/realtime"
+        ],
+        "supported_modalities": [
+            "text",
+            "image",
+            "audio"
+        ],
+        "supported_output_modalities": [
+            "text",
+            "audio"
+        ],
+        "supports_audio_input": true,
+        "supports_audio_output": true,
+        "supports_function_calling": true,
+        "supports_parallel_function_calling": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true
+    },
+    "azure/gpt-realtime-mini": {
+        "cache_creation_input_audio_token_cost": 3e-07,
+        "cache_read_input_token_cost": 6e-08,
+        "input_cost_per_audio_token": 1e-05,
+        "input_cost_per_image": 8e-07,
+        "input_cost_per_token": 6e-07,
+        "litellm_provider": "azure",
+        "max_input_tokens": 32000,
+        "max_output_tokens": 4096,
+        "max_tokens": 4096,
+        "mode": "chat",
+        "output_cost_per_audio_token": 2e-05,
+        "output_cost_per_token": 2.4e-06,
         "supported_endpoints": [
             "/v1/realtime"
         ],

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -4882,6 +4882,7 @@
         "supports_vision": false
     },
     "azure/gpt-audio-mini": {
+        "deprecation_date": "2027-04-06",
         "input_cost_per_audio_token": 1e-05,
         "input_cost_per_token": 6e-07,
         "litellm_provider": "azure",

--- a/tests/test_litellm/test_azure_audio_price_aliases.py
+++ b/tests/test_litellm/test_azure_audio_price_aliases.py
@@ -46,3 +46,22 @@ def test_undated_azure_audio_alias_matches_dated_entry(undated, dated):
 
     assert undated_info.get("litellm_provider") == "azure"
     assert undated_info.get("mode") == dated_info.get("mode")
+
+
+@pytest.mark.parametrize(
+    "undated, dated",
+    [
+        ("azure/gpt-audio-mini", "azure/gpt-audio-mini-2025-10-06"),
+        ("azure/gpt-realtime-mini", "azure/gpt-realtime-mini-2025-10-06"),
+    ],
+)
+def test_undated_azure_audio_alias_is_exact_mirror(undated, dated):
+    """The undated alias must be a byte-for-byte mirror of its dated entry —
+    covers every field (incl. realtime-specific cache/audio cost keys) so any
+    future drift between the pair is caught, not just the core COST_FIELDS."""
+    model_map = litellm.model_cost
+    assert undated in model_map, f"{undated} missing from model cost map"
+    assert model_map[undated] == model_map[dated], (
+        f"{undated} must exactly mirror {dated}; "
+        f"diff keys: {[k for k in set(model_map[undated]) | set(model_map[dated]) if model_map[undated].get(k) != model_map[dated].get(k)]}"
+    )

--- a/tests/test_litellm/test_azure_audio_price_aliases.py
+++ b/tests/test_litellm/test_azure_audio_price_aliases.py
@@ -1,0 +1,48 @@
+"""Undated azure aliases for the audio models must exist and match their dated
+variants — Azure deployments are commonly created against the undated model
+name, and `base_model: azure/gpt-audio-mini` previously resolved to nothing
+(text tokens billed at $0). Issue #33170."""
+
+import pytest
+
+import litellm
+
+
+@pytest.fixture(autouse=True)
+def _use_local_model_cost_map(monkeypatch):
+    original_model_cost = litellm.model_cost
+    monkeypatch.setenv("LITELLM_LOCAL_MODEL_COST_MAP", "True")
+    litellm.model_cost = litellm.get_model_cost_map(url="")
+    try:
+        yield
+    finally:
+        litellm.model_cost = original_model_cost
+
+
+COST_FIELDS = (
+    "input_cost_per_token",
+    "output_cost_per_token",
+    "input_cost_per_audio_token",
+    "output_cost_per_audio_token",
+)
+
+
+@pytest.mark.parametrize(
+    "undated, dated",
+    [
+        ("azure/gpt-audio-mini", "azure/gpt-audio-mini-2025-10-06"),
+        ("azure/gpt-realtime-mini", "azure/gpt-realtime-mini-2025-10-06"),
+    ],
+)
+def test_undated_azure_audio_alias_matches_dated_entry(undated, dated):
+    undated_info = litellm.get_model_info(undated)
+    dated_info = litellm.get_model_info(dated)
+
+    for field in COST_FIELDS:
+        assert undated_info.get(field) == dated_info.get(field), field
+        # the production symptom was text tokens billed at $0 — make sure the
+        # alias carries real, non-zero prices
+        assert (undated_info.get(field) or 0) > 0, f"{undated}.{field} must be non-zero"
+
+    assert undated_info.get("litellm_provider") == "azure"
+    assert undated_info.get("mode") == dated_info.get("mode")

--- a/tests/test_litellm/test_azure_audio_price_aliases.py
+++ b/tests/test_litellm/test_azure_audio_price_aliases.py
@@ -7,16 +7,7 @@ import pytest
 
 import litellm
 
-
-@pytest.fixture(autouse=True)
-def _use_local_model_cost_map(monkeypatch):
-    original_model_cost = litellm.model_cost
-    monkeypatch.setenv("LITELLM_LOCAL_MODEL_COST_MAP", "True")
-    litellm.model_cost = litellm.get_model_cost_map(url="")
-    try:
-        yield
-    finally:
-        litellm.model_cost = original_model_cost
+pytestmark = pytest.mark.usefixtures("local_model_cost_map")
 
 
 COST_FIELDS = (
@@ -40,8 +31,6 @@ def test_undated_azure_audio_alias_matches_dated_entry(undated, dated):
 
     for field in COST_FIELDS:
         assert undated_info.get(field) == dated_info.get(field), field
-        # the production symptom was text tokens billed at $0 — make sure the
-        # alias carries real, non-zero prices
         assert (undated_info.get(field) or 0) > 0, f"{undated}.{field} must be non-zero"
 
     assert undated_info.get("litellm_provider") == "azure"

--- a/tests/test_litellm/test_azure_audio_price_aliases.py
+++ b/tests/test_litellm/test_azure_audio_price_aliases.py
@@ -1,7 +1,12 @@
 """Undated azure aliases for the audio models must exist and match their dated
-variants — Azure deployments are commonly created against the undated model
-name, and `base_model: azure/gpt-audio-mini` previously resolved to nothing
-(text tokens billed at $0). Issue #33170."""
+variants. Azure deployments are commonly created under an admin-chosen name, so
+the served model name means nothing to the cost lookup and `base_model:
+azure/gpt-audio-mini` is what prices the call. That key resolved to nothing, the
+lookup raised "This model isn't mapped yet", and the proxy logged the request at
+$0. Issue #33170."""
+
+import json
+from pathlib import Path
 
 import pytest
 
@@ -17,14 +22,19 @@ COST_FIELDS = (
     "output_cost_per_audio_token",
 )
 
-
-@pytest.mark.parametrize(
-    "undated, dated",
-    [
-        ("azure/gpt-audio-mini", "azure/gpt-audio-mini-2025-10-06"),
-        ("azure/gpt-realtime-mini", "azure/gpt-realtime-mini-2025-10-06"),
-    ],
+ALIAS_PAIRS = (
+    ("azure/gpt-audio-mini", "azure/gpt-audio-mini-2025-10-06"),
+    ("azure/gpt-realtime-mini", "azure/gpt-realtime-mini-2025-10-06"),
 )
+
+
+def _load_root_cost_map() -> dict:
+    root_map_path = Path(__file__).parents[2] / "model_prices_and_context_window.json"
+    with open(root_map_path) as f:
+        return json.load(f)
+
+
+@pytest.mark.parametrize("undated, dated", ALIAS_PAIRS)
 def test_undated_azure_audio_alias_matches_dated_entry(undated, dated):
     undated_info = litellm.get_model_info(undated)
     dated_info = litellm.get_model_info(dated)
@@ -37,20 +47,29 @@ def test_undated_azure_audio_alias_matches_dated_entry(undated, dated):
     assert undated_info.get("mode") == dated_info.get("mode")
 
 
-@pytest.mark.parametrize(
-    "undated, dated",
-    [
-        ("azure/gpt-audio-mini", "azure/gpt-audio-mini-2025-10-06"),
-        ("azure/gpt-realtime-mini", "azure/gpt-realtime-mini-2025-10-06"),
-    ],
-)
+@pytest.mark.parametrize("undated, dated", ALIAS_PAIRS)
 def test_undated_azure_audio_alias_is_exact_mirror(undated, dated):
-    """The undated alias must be a byte-for-byte mirror of its dated entry —
-    covers every field (incl. realtime-specific cache/audio cost keys) so any
-    future drift between the pair is caught, not just the core COST_FIELDS."""
+    """The undated alias must be a byte-for-byte mirror of its dated entry, covering
+    every field (incl. realtime-specific cache/audio cost keys) so any future drift
+    between the pair is caught, not just the core COST_FIELDS."""
     model_map = litellm.model_cost
     assert undated in model_map, f"{undated} missing from model cost map"
     assert model_map[undated] == model_map[dated], (
         f"{undated} must exactly mirror {dated}; "
         f"diff keys: {[k for k in set(model_map[undated]) | set(model_map[dated]) if model_map[undated].get(k) != model_map[dated].get(k)]}"
+    )
+
+
+@pytest.mark.parametrize("undated, dated", ALIAS_PAIRS)
+def test_undated_azure_audio_alias_is_in_the_root_cost_map(undated, dated):
+    """`local_model_cost_map` pins `litellm.model_cost` to the packaged backup, but a
+    proxy left on its defaults fetches the root map instead, and that is the copy
+    that ships to the CDN. An alias added to only one of the two files still bills
+    $0 for every proxy reading the other, which is the very bug this file guards, so
+    assert the root map directly and assert the two files agree."""
+    root_map = _load_root_cost_map()
+    assert undated in root_map, f"{undated} missing from the root cost map"
+    assert root_map[undated] == root_map[dated], f"{undated} must exactly mirror {dated} in the root cost map"
+    assert root_map[undated] == litellm.model_cost[undated], (
+        f"{undated} differs between the root cost map and the packaged backup"
     )

--- a/tests/test_litellm/test_gpt_realtime_mode.py
+++ b/tests/test_litellm/test_gpt_realtime_mode.py
@@ -10,6 +10,7 @@ from litellm.types.utils import ModelInfoBase
 REALTIME_ONLY_GPT_MODELS = (
     "azure/gpt-realtime-2025-08-28",
     "azure/gpt-realtime-1.5-2026-02-23",
+    "azure/gpt-realtime-mini",
     "azure/gpt-realtime-mini-2025-10-06",
     "gpt-realtime",
     "gpt-realtime-1.5",


### PR DESCRIPTION
> [!NOTE]
> This is a copy of #33291 by @mihidumh, pushed to a `litellm_`-prefixed branch so the full CircleCI pipeline (which doesn't run on fork PRs) can execute. Commit authorship is preserved, so full credit goes to the original author

## TLDR

Problem this solves:

- Price map has no `azure/gpt-audio-mini` or `azure/gpt-realtime-mini` key
- Azure deployments carry admin-chosen names, so `model_info.base_model` is what prices them
- `base_model: azure/gpt-audio-mini` pins the lookup to a key that isn't there
- The lookup raises `This model isn't mapped yet`, the proxy swallows it, and the call is logged at $0
- Realtime sessions on `azure/gpt-realtime-mini` hit the same missing key with or without `base_model`, so they log $0 too

How it solves it:

- Add both undated keys mirroring their `-2025-10-06` dated entries
- Keep the packaged backup map byte-for-byte in sync
- Test pins each alias to its dated entry in both maps, so drift fails CI

## User Flow

Before: a team pricing an Azure audio deployment through `base_model` gets no cost header at all and $0 spend, on calls Azure does invoice them for

1. The proxy admin creates an Azure deployment of gpt-audio-mini under their own name, `audio-mini-prod`, registers it as `model: azure/audio-mini-prod` with `model_info.base_model: azure/gpt-audio-mini` so the gateway knows what to price it as, and restarts the proxy
2. Their app sends `POST https://litellm-domain/v1/chat/completions` with `"model": "audio-mini"`, `"modalities": ["text", "audio"]`, an audio config, and a short prompt
3. A 200 comes back with the spoken reply, and the `usage` block shows real counts, with the completion tokens split into text and audio
4. The response carries no `x-litellm-response-cost` header at all, and `x-litellm-response-cost-original`, `-input`, `-output`, and `x-litellm-key-spend` all read `0.0`
5. They open `https://litellm-domain/ui/?page=logs` and that request shows $0 spend
6. Key, team, and budget limits keyed on spend never trip, however much audio the team generates

After: the same call comes back priced, so the header and the logs page match what Azure charges

1. The proxy admin creates an Azure deployment of gpt-audio-mini under their own name, `audio-mini-prod`, registers it as `model: azure/audio-mini-prod` with `model_info.base_model: azure/gpt-audio-mini` so the gateway knows what to price it as, and restarts the proxy
2. Their app sends `POST https://litellm-domain/v1/chat/completions` with `"model": "audio-mini"`, `"modalities": ["text", "audio"]`, an audio config, and a short prompt
3. A 200 comes back with the spoken reply, and the `usage` block shows real counts, with the completion tokens split into text and audio
4. The response now carries `x-litellm-response-cost` with a non-zero figure, billing text at $0.60 per million in and $2.40 per million out, and audio at $10 per million in and $20 per million out
5. They open `https://litellm-domain/ui/?page=logs` and that request shows the real spend
6. Budgets and rate limits keyed on spend behave as configured

## Relevant issues

Fixes #33170

## Linear ticket

Resolves LIT-5990

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Live proxy against real Azure on both legs, real audio generation, real spend. Same config, same request, only the commit the proxy booted from differs.

`audio-mini-prod` is a real Azure deployment of gpt-audio-mini created under an admin-chosen name, which is exactly why `model_info.base_model` is what prices it:

```yaml
model_list:
  - model_name: audio-mini
    litellm_params:
      model: azure/audio-mini-prod
      api_base: os.environ/AZURE_API_BASE
      api_key: os.environ/AZURE_API_KEY
      api_version: "2025-04-01-preview"
    model_info:
      base_model: azure/gpt-audio-mini

general_settings:
  master_key: sk-1234
```

### Before, at merge base `0a5fa4fdc6599eb236c8116f9ce77e1ec29f83ae`

```bash
curl -sS -m 180 -D headers.txt -o body.json \
  -X POST http://localhost:49117/v1/chat/completions \
  -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' \
  -d '{"model":"audio-mini","modalities":["text","audio"],"audio":{"voice":"alloy","format":"wav"},"messages":[{"role":"user","content":"Say hello in five words"}]}'
grep -iE '^(HTTP/|x-litellm-)' headers.txt
```

```
HTTP/1.1 200 OK
x-litellm-call-id: ba2545fb-493a-4044-9620-adf127bc89b9
x-litellm-model-id: 1ac40176d38b5e599737c9a62f93effef92adcf44fd2865cbdd5792416c017b9
x-litellm-model-name: azure/audio-mini-prod
x-litellm-model-api-base: https://<redacted>.services.ai.azure.com
x-litellm-version: 1.99.0
x-litellm-response-cost-original: 0.0
x-litellm-response-cost-discount-amount: 0.0
x-litellm-response-cost-margin-amount: 0.0
x-litellm-response-cost-margin-percent: 0.0
x-litellm-response-cost-input: 0.0
x-litellm-response-cost-output: 0.0
x-litellm-response-cost-tool-usage: 0.0
x-litellm-key-spend: 0.0
x-litellm-response-duration-ms: 760.146
x-litellm-model-group: audio-mini
x-litellm-attempted-retries: 0
x-litellm-attempted-fallbacks: 0
```

No `x-litellm-response-cost` header at all, and every cost field reads `0.0`, against a response that really did generate audio:

```json
"usage": {"completion_tokens":51,"prompt_tokens":12,"total_tokens":63,
  "completion_tokens_details":{"audio_tokens":37,"text_tokens":14,"reasoning_tokens":0},
  "prompt_tokens_details":{"audio_tokens":0,"cached_tokens":0,"text_tokens":12,"image_tokens":0}}
```

Transcript `"Hello to you right now."`, with `audio.data` carrying a real wav payload starting `UklGRv////9XQVZFZm10`

### After, at `e1c97eb3ee4570320ccf58c4fb6285e7c81a4692` (the PR tip)

```bash
curl -sS -m 180 -D - http://127.0.0.1:45623/v1/chat/completions \
  -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' \
  -d '{"model":"audio-mini","modalities":["text","audio"],"audio":{"voice":"alloy","format":"wav"},"messages":[{"role":"user","content":"Say hello in five words"}]}'
```

```
HTTP/1.1 200 OK
x-litellm-call-id: 42d0ba5c-89b2-4d5c-9554-516e1e8a3f74
x-litellm-model-id: 10bc6bba59114493c8bb0e5c5dc0345538816f5ea56a81d1911773347be24992
x-litellm-model-name: azure/audio-mini-prod
x-litellm-model-api-base: https://<redacted>.services.ai.azure.com
x-litellm-version: 1.99.0
x-litellm-response-cost: 0.0013032
x-litellm-response-cost-original: 0.0013032
x-litellm-response-cost-discount-amount: 0.0
x-litellm-response-cost-margin-amount: 0.0
x-litellm-response-cost-margin-percent: 0.0
x-litellm-response-cost-input: 7.2e-06
x-litellm-response-cost-output: 0.001296
x-litellm-response-cost-tool-usage: 0.0
x-litellm-key-spend: 0.0013032
x-litellm-response-duration-ms: 1753.59
llm_provider-x-ms-served-model: gpt-audio-mini-2025-10-06
llm_provider-x-ms-region: East US 2
x-litellm-model-group: audio-mini
x-litellm-attempted-retries: 0
x-litellm-attempted-fallbacks: 0
```

```json
"usage": {"completion_tokens":78,"prompt_tokens":12,"total_tokens":90,
  "completion_tokens_details":{"audio_tokens":63,"text_tokens":15,"reasoning_tokens":0},
  "prompt_tokens_details":{"audio_tokens":0,"cached_tokens":0,"text_tokens":12,"image_tokens":0}}
```

Transcript `"Hello to you, my friend!"`. The arithmetic is exact on all three figures: input `12 * 6e-07 = 7.2e-06`, output `15 * 2.4e-06 + 63 * 2e-05 = 0.001296`, total `0.0013032`

### Realtime sessions, the same flip, with no `base_model` involved

A second A/B ran a real proxy at the merge base and at this tip against a live Azure `gpt-realtime-mini` deployment, drove a websocket session on `/v1/realtime`, and read the spend rows back out of each side's Postgres.

Base:

```
model                   | model_group              | call_type  | spend | prompt | completion
azure/gpt-realtime-mini | realtime-undated         | _arealtime | 0     | 112    | 5
azure/gpt-realtime-mini | realtime-dated-basemodel | _arealtime | 0     | 112    | 5
```

Head:

```
model                   | model_group              | call_type  | spend     | prompt | completion
azure/gpt-realtime-mini | realtime-undated         | _arealtime | 4.464e-05 | 112    | 5
azure/gpt-realtime-mini | realtime-dated-basemodel | _arealtime | 4.464e-05 | 112    | 5
```

Identical sessions and identical token counts, logged at `$0` before and at a real figure after. The realtime path dials the deployment's own `azure/gpt-realtime-mini`, so it needs no `base_model` to hit the missing key

### Nothing that already worked changed

The same A/B compared both sides across the map-reading surfaces. `/v1/models` is byte-identical between base and head, with and without `include_metadata` and `return_wildcard_routes`, so no new model is exposed to clients. Chat audio deployments that already billed correctly bill the same rates on both sides. The only endpoints that differ are the ones that report model metadata (`/model/info`, `/model_group/info`, `/model/deprecations`), and each differs only by the two new keys' own data.

Two reporting surfaces move in the fix's direction. `/model/deprecations` listed an undated Azure deployment under the OpenAI entry before (`litellm_provider: openai`, `2027-01-20`) and lists it under the Azure entry now (`azure`, `2027-04-06`). `/health` probes an `azure/gpt-realtime-mini` deployment as a realtime model rather than a chat one, and it reports healthy on both sides.

Observed alongside the runs, none of it caused or made worse by this PR:

- Azure 400s text-only requests to a gpt-audio-mini deployment
- Text tokens bill on top of audio tokens
- Azure returns the underlying model and version, not the deployment
- Without `base_model`, the same deployment already billed correctly

The one thing this PR does change beyond the header is `/v1/model/info`, which reported `0` prices and `mode: null` for both aliases before

## Type

🐛 Bug Fix

## Caveats (if any)

- Alias mirrors the only dated Azure entry, `-2025-10-06`
- It carries that entry's `deprecation_date`, matching most undated map keys
- A newer dated Azure snapshot would need the alias repointed
- Realtime sessions on `azure/gpt-realtime-mini` go from zero recorded spend to charged. Anyone running that deployment today will see spend appear where their dashboards read $0, and key or team budgets that could never be reached before can now trip
- The realtime cost path never consults `model_info.base_model`. It resolves from the model the session reports and the deployment's own model name, which is why adding the undated alias is what fixes it, and why pinning `base_model` on a realtime deployment does nothing for cost either way. That behavior is pre-existing and untouched here
- A deployment pinned to `azure/gpt-realtime-mini` now reports `mode: realtime`, so `/health` probes it over a websocket instead of as a chat model. That is the correct probe for it, but a deployment that answers chat probes while websockets are blocked would flip from healthy to unhealthy on upgrade
- Azure rejects text-only requests to a gpt-audio-mini deployment with a 400, so every call in the flow above carries audio on one side

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Data-only pricing map plus tests; no auth or request-path changes. Realtime alias now reports mode realtime, which can change health-check probing for that base_model.
> 
> **Overview**
> Fixes Azure audio/realtime spend being logged at **$0** when deployments are priced via `base_model: azure/gpt-audio-mini` or `azure/gpt-realtime-mini` (issue #33170). Those undated keys were missing, so cost lookup failed and the proxy swallowed the error.
> 
> Adds both aliases as exact mirrors of the dated `-2025-10-06` entries in the root and packaged cost maps (chat + audio for audio-mini; realtime + cache/image costs for realtime-mini). Tests require the aliases to exist, match their dated counterparts field-for-field, and stay in sync across both JSON files.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e1c97eb3ee4570320ccf58c4fb6285e7c81a4692. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

- [x] e1c97eb3ee4570320ccf58c4fb6285e7c81a4692 passes /live-pr-risk

