### PR TITLE
fix(anthropic_messages): gate sampling params on /v1/messages like /chat/completions

### DIFF
--- a/litellm/llms/anthropic/experimental_pass_through/messages/utils.py
+++ b/litellm/llms/anthropic/experimental_pass_through/messages/utils.py
@@ -44,6 +44,7 @@ class AnthropicMessagesRequestUtils:
         filtered_params: Final = {k: v for k, v in params.items() if k in valid_keys and v is not None}
         if model is not None:
             from litellm.llms.anthropic.chat.transformation import AnthropicConfig
+            from litellm.llms.anthropic.common_utils import AnthropicModelInfo
 
             AnthropicConfig._maybe_drop_speed_param(
                 model=model,
@@ -51,6 +52,22 @@ class AnthropicMessagesRequestUtils:
                 drop_params=drop_params,
                 custom_llm_provider=custom_llm_provider,
             )
+            # Claude 4.7+ removed sampling params (the API 400s on top_p, top_k,
+            # and any temperature other than 1). Mirror the /chat/completions
+            # gating — drop under drop_params, else raise a clean client-side
+            # 400 — instead of forwarding a known-rejected param upstream, where
+            # router fallbacks would mask the provider 400 as a silent model
+            # downgrade.
+            for param in ("temperature", "top_p", "top_k"):
+                if param in filtered_params:
+                    AnthropicModelInfo._apply_sampling_param(  # pyright: ignore[reportPrivateUsage]  # same gating the /chat/completions path applies; forking it would drift
+                        optional_params=filtered_params,
+                        model=model,
+                        param=param,
+                        value=filtered_params.pop(param),
+                        drop_params=drop_params,
+                        output_key=param,
+                    )
         return cast(AnthropicMessagesRequestOptionalParams, filtered_params)
 
 

--- a/litellm/llms/anthropic/experimental_pass_through/messages/utils.py
+++ b/litellm/llms/anthropic/experimental_pass_through/messages/utils.py
@@ -52,12 +52,6 @@ class AnthropicMessagesRequestUtils:
                 drop_params=drop_params,
                 custom_llm_provider=custom_llm_provider,
             )
-            # Claude 4.7+ removed sampling params (the API 400s on top_p, top_k,
-            # and any temperature other than 1). Mirror the /chat/completions
-            # gating — drop under drop_params, else raise a clean client-side
-            # 400 — instead of forwarding a known-rejected param upstream, where
-            # router fallbacks would mask the provider 400 as a silent model
-            # downgrade.
             for param in ("temperature", "top_p", "top_k"):
                 if param in filtered_params:
                     AnthropicModelInfo._apply_sampling_param(  # pyright: ignore[reportPrivateUsage]  # same gating the /chat/completions path applies; forking it would drift

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_request_optional_param_utils.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_request_optional_param_utils.py
@@ -6,6 +6,8 @@ Regression tests for the /v1/messages request-parse fast paths:
   while resolving the (static) type hints only once per process.
 """
 
+import pytest
+
 import litellm
 from litellm.llms.anthropic.experimental_pass_through.messages.utils import (
     AnthropicMessagesRequestUtils,
@@ -90,87 +92,59 @@ def test_drop_params_keeps_speed_for_supporting_model():
     assert result == {"speed": "fast"}
 
 
-def test_drop_params_strips_sampling_params_for_unsupported_model():
-    # claude-opus-4-7 removed sampling params (supports_sampling_params: false
-    # in the model map) — with drop_params they must be stripped instead of
-    # forwarded raw (the API 400s on them).
-    original = litellm.drop_params
-    litellm.drop_params = True
-    try:
-        result = (
-            AnthropicMessagesRequestUtils.get_requested_anthropic_messages_optional_param(
-                params={"temperature": 0.3, "top_p": 0.9, "top_k": 40, "stream": True},
-                model="claude-opus-4-7",
-            )
-        )
-    finally:
-        litellm.drop_params = original
+def test_drop_params_strips_sampling_params_for_unsupported_model(monkeypatch):
+    # claude-opus-4-7 has supports_sampling_params: false in the model map; the
+    # API 400s on these rather than ignoring them.
+    monkeypatch.setattr(litellm, "drop_params", False)
+    result = AnthropicMessagesRequestUtils.get_requested_anthropic_messages_optional_param(
+        params={"temperature": 0.3, "top_p": 0.9, "top_k": 40, "stream": True},
+        model="claude-opus-4-7",
+        drop_params=True,
+    )
 
     assert result == {"stream": True}
 
 
-def test_drop_params_strips_sampling_params_for_provider_prefixed_model():
+def test_drop_params_strips_sampling_params_for_provider_prefixed_model(monkeypatch):
     # Vertex-routed ids must resolve the same capability flag.
-    original = litellm.drop_params
-    litellm.drop_params = True
-    try:
-        result = (
-            AnthropicMessagesRequestUtils.get_requested_anthropic_messages_optional_param(
-                params={"temperature": 0.3, "top_p": 0.9, "top_k": 40},
-                model="vertex_ai/claude-opus-4-7",
-            )
-        )
-    finally:
-        litellm.drop_params = original
+    monkeypatch.setattr(litellm, "drop_params", False)
+    result = AnthropicMessagesRequestUtils.get_requested_anthropic_messages_optional_param(
+        params={"temperature": 0.3, "top_p": 0.9, "top_k": 40},
+        model="vertex_ai/claude-opus-4-7",
+        drop_params=True,
+    )
 
     assert result == {}
 
 
-def test_sampling_params_kept_for_supporting_model():
-    original = litellm.drop_params
-    litellm.drop_params = True
-    try:
-        result = (
-            AnthropicMessagesRequestUtils.get_requested_anthropic_messages_optional_param(
-                params={"temperature": 0.3, "top_p": 0.9, "top_k": 40},
-                model="claude-sonnet-4-6",
-            )
-        )
-    finally:
-        litellm.drop_params = original
+def test_sampling_params_kept_for_supporting_model(monkeypatch):
+    monkeypatch.setattr(litellm, "drop_params", False)
+    result = AnthropicMessagesRequestUtils.get_requested_anthropic_messages_optional_param(
+        params={"temperature": 0.3, "top_p": 0.9, "top_k": 40},
+        model="claude-sonnet-4-6",
+        drop_params=True,
+    )
 
     assert result == {"temperature": 0.3, "top_p": 0.9, "top_k": 40}
 
 
-def test_temperature_1_kept_for_unsupported_model():
-    # temperature=1 stays the one allowed value on models that removed
-    # sampling params.
-    original = litellm.drop_params
-    litellm.drop_params = True
-    try:
-        result = (
-            AnthropicMessagesRequestUtils.get_requested_anthropic_messages_optional_param(
-                params={"temperature": 1},
-                model="claude-opus-4-7",
-            )
-        )
-    finally:
-        litellm.drop_params = original
+def test_temperature_1_kept_for_unsupported_model(monkeypatch):
+    # temperature=1 is the one value these models still accept.
+    monkeypatch.setattr(litellm, "drop_params", False)
+    result = AnthropicMessagesRequestUtils.get_requested_anthropic_messages_optional_param(
+        params={"temperature": 1},
+        model="claude-opus-4-7",
+        drop_params=True,
+    )
 
     assert result == {"temperature": 1}
 
 
-def test_sampling_param_raises_clean_400_without_drop_params():
-    import pytest
-
-    original = litellm.drop_params
-    litellm.drop_params = False
-    try:
-        with pytest.raises(litellm.utils.UnsupportedParamsError):
-            AnthropicMessagesRequestUtils.get_requested_anthropic_messages_optional_param(
-                params={"temperature": 0.3},
-                model="claude-opus-4-7",
-                drop_params=False,
-            )
-    finally:
-        litellm.drop_params = original
+def test_sampling_param_raises_clean_400_without_drop_params(monkeypatch):
+    monkeypatch.setattr(litellm, "drop_params", False)
+    with pytest.raises(litellm.utils.UnsupportedParamsError, match="does not support temperature"):
+        AnthropicMessagesRequestUtils.get_requested_anthropic_messages_optional_param(
+            params={"temperature": 0.3},
+            model="claude-opus-4-7",
+            drop_params=False,
+        )

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_request_optional_param_utils.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_request_optional_param_utils.py
@@ -88,3 +88,89 @@ def test_drop_params_keeps_speed_for_supporting_model():
         litellm.drop_params = original
 
     assert result == {"speed": "fast"}
+
+
+def test_drop_params_strips_sampling_params_for_unsupported_model():
+    # claude-opus-4-7 removed sampling params (supports_sampling_params: false
+    # in the model map) — with drop_params they must be stripped instead of
+    # forwarded raw (the API 400s on them).
+    original = litellm.drop_params
+    litellm.drop_params = True
+    try:
+        result = (
+            AnthropicMessagesRequestUtils.get_requested_anthropic_messages_optional_param(
+                params={"temperature": 0.3, "top_p": 0.9, "top_k": 40, "stream": True},
+                model="claude-opus-4-7",
+            )
+        )
+    finally:
+        litellm.drop_params = original
+
+    assert result == {"stream": True}
+
+
+def test_drop_params_strips_sampling_params_for_provider_prefixed_model():
+    # Vertex-routed ids must resolve the same capability flag.
+    original = litellm.drop_params
+    litellm.drop_params = True
+    try:
+        result = (
+            AnthropicMessagesRequestUtils.get_requested_anthropic_messages_optional_param(
+                params={"temperature": 0.3, "top_p": 0.9, "top_k": 40},
+                model="vertex_ai/claude-opus-4-7",
+            )
+        )
+    finally:
+        litellm.drop_params = original
+
+    assert result == {}
+
+
+def test_sampling_params_kept_for_supporting_model():
+    original = litellm.drop_params
+    litellm.drop_params = True
+    try:
+        result = (
+            AnthropicMessagesRequestUtils.get_requested_anthropic_messages_optional_param(
+                params={"temperature": 0.3, "top_p": 0.9, "top_k": 40},
+                model="claude-sonnet-4-6",
+            )
+        )
+    finally:
+        litellm.drop_params = original
+
+    assert result == {"temperature": 0.3, "top_p": 0.9, "top_k": 40}
+
+
+def test_temperature_1_kept_for_unsupported_model():
+    # temperature=1 stays the one allowed value on models that removed
+    # sampling params.
+    original = litellm.drop_params
+    litellm.drop_params = True
+    try:
+        result = (
+            AnthropicMessagesRequestUtils.get_requested_anthropic_messages_optional_param(
+                params={"temperature": 1},
+                model="claude-opus-4-7",
+            )
+        )
+    finally:
+        litellm.drop_params = original
+
+    assert result == {"temperature": 1}
+
+
+def test_sampling_param_raises_clean_400_without_drop_params():
+    import pytest
+
+    original = litellm.drop_params
+    litellm.drop_params = False
+    try:
+        with pytest.raises(litellm.utils.UnsupportedParamsError):
+            AnthropicMessagesRequestUtils.get_requested_anthropic_messages_optional_param(
+                params={"temperature": 0.3},
+                model="claude-opus-4-7",
+                drop_params=False,
+            )
+    finally:
+        litellm.drop_params = original


### PR DESCRIPTION
> [!NOTE]
> This is a copy of #35057 by @mihidumh, pushed to a `litellm_`-prefixed branch on `BerriAI/litellm` so the full CircleCI suite (which does not run on fork PRs) can execute against it. Commit authorship is preserved: the commit is unchanged and still authored by @mihidumh. Full credit for the investigation, fix, and live-provider repro goes to the original author

## TLDR

Problem this solves:

- `/v1/messages` forwards `temperature`/`top_p`/`top_k` raw to models that removed them
- Provider 400s; router fallbacks mask them as silent model downgrades
- `/chat/completions` already drops the same params for the same models

How it solves it:

- Reuse the chat path's `AnthropicModelInfo._apply_sampling_param` gating in the `/v1/messages` param builder
- Drop under `drop_params` (matching `/chat/completions`), else clean client-side 400
- No-op for models that still support sampling params (`temperature=1` stays allowed everywhere)

## User Flow

Before: a developer whose app sends a temperature on the Anthropic-native route gets a provider 400, and once fallbacks are configured, a quietly older model instead

1. With the gateway's `drop_params` turned on, they send POST `https://litellm-domain/v1/messages` with `{"model": "claude-sonnet-5", "max_tokens": 16, "temperature": 0.3, "messages": [{"role": "user", "content": "say ok"}]}`
2. They get back HTTP 400 carrying the provider's own wording, `` `temperature` is deprecated for this model ``, along with a `req_011Ce...` request id, so the call was made and rejected upstream
3. They send the same model and temperature to POST `https://litellm-domain/v1/chat/completions` and get HTTP 200 with an answer, so the two routes disagree on identical input
4. They turn `drop_params` off and try step 1 again, and the 400 comes back byte for byte identical, because the Anthropic-native route never consulted the setting at all
5. `top_p` and `top_k` fail the same way, and adding `"stream": true` returns the same 400 with no events at all rather than a stream
6. On a model group that has router fallbacks configured, step 1 returns HTTP 200 instead, answered by an older model generation, and only the response's `model` field reveals that the model they asked for was never used

After: the same request succeeds with the unsupported sampling params dropped, and the two routes finally agree

1. With `drop_params` on, they send the same POST `https://litellm-domain/v1/messages` with `"temperature": 0.3` on `claude-sonnet-5`
2. They get HTTP 200 with the assistant's reply, and the temperature never reached the provider
3. `top_p` gets the same treatment, and `"stream": true` now streams normally, ending in `message_stop` at HTTP 200
4. POST `https://litellm-domain/v1/chat/completions` with the same model and temperature still returns HTTP 200, so both routes now behave alike
5. With `drop_params` off, they instead get an immediate HTTP 400 from the gateway reading `claude-sonnet-5 does not support temperature=0.3. Only temperature=1 is supported.`, raised before any provider call goes out, so there is no upstream request to pay for or fall back from
6. A model that still supports sampling params, like `claude-sonnet-4-6`, keeps receiving the exact temperature it was sent
7. Because step 1 no longer fails, a group with fallbacks configured stays on the model that was actually requested instead of silently dropping to an older generation

## Relevant issues

Fixes #35053

Original PR: #35057

## Linear ticket

Resolves LIT-5989

## Type

🐛 Bug Fix

## Changes

- `litellm/llms/anthropic/experimental_pass_through/messages/utils.py`: after the existing `_maybe_drop_speed_param` gate, run `temperature`/`top_p`/`top_k` through `AnthropicModelInfo._apply_sampling_param`, the same helper the `/chat/completions` path uses, so both surfaces make the same decision from the same source of truth
- `tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_request_optional_param_utils.py`: new coverage for the gating

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

Shared setup for both sides, a proxy booted from the worktree at the named commit against the real Anthropic API, no mocks:

```yaml
model_list:
  - model_name: claude-sonnet-5
    litellm_params:
      model: anthropic/claude-sonnet-5
      api_key: os.environ/ANTHROPIC_API_KEY
  - model_name: claude-sonnet-4-6
    litellm_params:
      model: anthropic/claude-sonnet-4-6
      api_key: os.environ/ANTHROPIC_API_KEY

litellm_settings:
  drop_params: true

general_settings:
  master_key: sk-qa5989
```

`claude-sonnet-5` carries `supports_sampling_params: false` in the model map; `claude-sonnet-4-6` has no such key, so it counts as supporting them and serves as the regression control. Case F re-runs case A against a second proxy booted from the same config with `drop_params: false`.

### Before (dd64331967b8421e592fb4b12e1280b1db3845e9)

#### A: /v1/messages, unsupported model, temperature

1. `curl -sS -w '\nHTTP %{http_code}\n' -X POST http://127.0.0.1:37421/v1/messages -H 'Authorization: Bearer sk-qa5989' -H 'Content-Type: application/json' -d '{"model":"claude-sonnet-5","max_tokens":16,"temperature":0.3,"messages":[{"role":"user","content":"say ok"}]}'`
2. ```
   {"error":{"message":"{\"type\":\"error\",\"error\":{\"type\":\"invalid_request_error\",\"message\":\"`temperature` is deprecated for this model.\"},\"request_id\":\"req_011CeGtCXj9aFBtFc4NqTiBY\"}. Received Model Group=claude-sonnet-5\nAvailable Model Group Fallbacks=None","type":"None","param":"None","code":"400"}}
   HTTP 400
   ```

#### B: /v1/messages, unsupported model, top_p

1. `curl -sS -w '\nHTTP %{http_code}\n' -X POST http://127.0.0.1:37421/v1/messages -H 'Authorization: Bearer sk-qa5989' -H 'Content-Type: application/json' -d '{"model":"claude-sonnet-5","max_tokens":16,"top_p":0.9,"messages":[{"role":"user","content":"say ok"}]}'`
2. ```
   {"error":{"message":"{\"type\":\"error\",\"error\":{\"type\":\"invalid_request_error\",\"message\":\"`top_p` is deprecated for this model.\"},\"request_id\":\"req_011CeGtCZ7jqq8nXH128zRYy\"}. Received Model Group=claude-sonnet-5\nAvailable Model Group Fallbacks=None","type":"None","param":"None","code":"400"}}
   HTTP 400
   ```

#### C: /chat/completions, same model and temperature

1. `curl -sS -w '\nHTTP %{http_code}\n' -X POST http://127.0.0.1:37421/v1/chat/completions -H 'Authorization: Bearer sk-qa5989' -H 'Content-Type: application/json' -d '{"model":"claude-sonnet-5","max_tokens":16,"temperature":0.3,"messages":[{"role":"user","content":"say ok"}]}'`
2. `{"id":"chatcmpl-0930850a-e84d-4b00-a5a2-4a15e31e0649",...,"choices":[{"finish_reason":"stop","index":0,"message":{"content":"Ok","role":"assistant",...}}],...}` at HTTP 200, the route that already gates correctly

#### D: /v1/messages, model that supports sampling params (control)

1. `curl -sS -w '\nHTTP %{http_code}\n' -X POST http://127.0.0.1:37421/v1/messages -H 'Authorization: Bearer sk-qa5989' -H 'Content-Type: application/json' -d '{"model":"claude-sonnet-4-6","max_tokens":16,"temperature":0.3,"messages":[{"role":"user","content":"say ok"}]}'`
2. `{"model":"claude-sonnet-4-6","id":"msg_011CeGtD1K5c775fywqgG2WQ",...,"content":[{"type":"text","text":"ok"}],"stop_reason":"end_turn",...}` at HTTP 200

#### E: /v1/messages, unsupported model, temperature, streaming

1. `curl -sS -N -w '\nHTTP %{http_code}\n' -X POST http://127.0.0.1:37421/v1/messages -H 'Authorization: Bearer sk-qa5989' -H 'Content-Type: application/json' -d '{"model":"claude-sonnet-5","max_tokens":16,"temperature":0.3,"stream":true,"messages":[{"role":"user","content":"say ok"}]}'`
2. No SSE at all, just a single JSON error body:
   ```
   {"error":{"message":"{\"type\":\"error\",\"error\":{\"type\":\"invalid_request_error\",\"message\":\"`temperature` is deprecated for this model.\"},\"request_id\":\"req_011CeGtDKiNNTZYqB3dap2rd\"}. Received Model Group=claude-sonnet-5\nAvailable Model Group Fallbacks=None","type":"None","param":"None","code":"400"}}
   HTTP 400
   ```

#### F: /v1/messages, unsupported model, temperature, `drop_params: false`

1. `curl -sS -w '\nHTTP %{http_code}\n' -X POST http://127.0.0.1:48113/v1/messages -H 'Authorization: Bearer sk-qa5989' -H 'Content-Type: application/json' -d '{"model":"claude-sonnet-5","max_tokens":16,"temperature":0.3,"messages":[{"role":"user","content":"say ok"}]}'`
2. Byte for byte the same provider 400 as case A, `` `temperature` is deprecated for this model `` with `req_011CeGtFX53Ndr6cN6Q584yG`, at HTTP 400. The route never consulted `drop_params`, so both settings behave identically here

### After (c0118e5b7a)

Captured at 1a408d7d448b013ea31e4f6af6c4d8b6be30ada8; the only commit since is `c0118e5b7a`, which deletes six comment lines and changes no executable code.

#### A: /v1/messages, unsupported model, temperature

1. `curl -sS -w '\nHTTP %{http_code}\n' -X POST http://127.0.0.1:22117/v1/messages -H 'Authorization: Bearer sk-qa5989' -H 'Content-Type: application/json' -d '{"model":"claude-sonnet-5","max_tokens":16,"temperature":0.3,"messages":[{"role":"user","content":"say ok"}]}'`
2. ```
   {"model":"claude-sonnet-5","id":"msg_011CeGtBHCFqaZVN34jYbioW","type":"message","role":"assistant","content":[{"type":"text","text":"Ok"}],"stop_reason":"end_turn","stop_sequence":null,"stop_details":null,"usage":{"input_tokens":9,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":5,"service_tier":"standard","inference_geo":"global"}}
   HTTP 200
   ```
3. The proxy's outbound body for this call carries no `temperature` key, so the param was dropped rather than forwarded

#### B: /v1/messages, unsupported model, top_p

1. `curl -sS -w '\nHTTP %{http_code}\n' -X POST http://127.0.0.1:22117/v1/messages -H 'Authorization: Bearer sk-qa5989' -H 'Content-Type: application/json' -d '{"model":"claude-sonnet-5","max_tokens":16,"top_p":0.9,"messages":[{"role":"user","content":"say ok"}]}'`
2. ```
   {"model":"claude-sonnet-5","id":"msg_011CeGtBi1VpZCFV15BgWPJZ","type":"message","role":"assistant","content":[{"type":"text","text":"Okay"}],"stop_reason":"end_turn",...,"usage":{"input_tokens":9,"output_tokens":5,"service_tier":"standard","inference_geo":"global"}}
   HTTP 200
   ```

#### C: /chat/completions, same model and temperature

1. `curl -sS -w '\nHTTP %{http_code}\n' -X POST http://127.0.0.1:22117/v1/chat/completions -H 'Authorization: Bearer sk-qa5989' -H 'Content-Type: application/json' -d '{"model":"claude-sonnet-5","max_tokens":16,"temperature":0.3,"messages":[{"role":"user","content":"say ok"}]}'`
2. `{"id":"chatcmpl-27c9d65c-0021-436c-b79e-5af2da070c49",...,"choices":[{"finish_reason":"stop","index":0,"message":{"content":"Ok","role":"assistant",...}}],...}` at HTTP 200, unchanged, so the two routes now agree

#### D: /v1/messages, model that supports sampling params (control)

1. `curl -sS -w '\nHTTP %{http_code}\n' -X POST http://127.0.0.1:22117/v1/messages -H 'Authorization: Bearer sk-qa5989' -H 'Content-Type: application/json' -d '{"model":"claude-sonnet-4-6","max_tokens":16,"temperature":0.3,"messages":[{"role":"user","content":"say ok"}]}'`
2. `{"model":"claude-sonnet-4-6","id":"msg_011CeGtCPBSm1NgZNDm7jp2f",...,"content":[{"type":"text","text":"ok"}],"stop_reason":"end_turn",...}` at HTTP 200
3. The outbound body for this one still carries `temperature: 0.3`, so supporting models are untouched

#### E: /v1/messages, unsupported model, temperature, streaming

1. `curl -sS -N -w '\nHTTP %{http_code}\n' -X POST http://127.0.0.1:22117/v1/messages -H 'Authorization: Bearer sk-qa5989' -H 'Content-Type: application/json' -d '{"model":"claude-sonnet-5","max_tokens":16,"temperature":0.3,"stream":true,"messages":[{"role":"user","content":"say ok"}]}'`
2. A real 23-line SSE stream at HTTP 200, opening with:
   ```
   event: message_start
   data: {"type":"message_start","message":{"model":"claude-sonnet-5","id":"msg_011CeGtD1ie4hc3UmzLhJaoY","type":"message","role":"assistant","content":[],"stop_reason":null,...}}

   event: content_block_start
   data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}

   event: content_block_delta
   data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Ok"}}
   ```
   ending in `message_delta` with `stop_reason: end_turn`, then `message_stop`

#### F: /v1/messages, unsupported model, temperature, `drop_params: false`

1. `curl -sS -w '\nHTTP %{http_code}\n' -X POST http://127.0.0.1:48166/v1/messages -H 'Authorization: Bearer sk-qa5989' -H 'Content-Type: application/json' -d '{"model":"claude-sonnet-5","max_tokens":16,"temperature":0.3,"messages":[{"role":"user","content":"say ok"}]}'`
2. ```
   {"error":{"message":"litellm.UnsupportedParamsError: claude-sonnet-5 does not support temperature=0.3. Only temperature=1 is supported. To drop unsupported params, set `litellm.drop_params = True`.. Received Model Group=claude-sonnet-5\nAvailable Model Group Fallbacks=None","type":"None","param":null,"code":"400"}}
   HTTP 400
   ```
3. That proxy's debug log holds zero `POST Request Sent from LiteLLM` markers for the call, so the 400 was raised client-side and nothing reached Anthropic

### Unit tests

`tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_request_optional_param_utils.py` passes 10/10 at the tip. Reverting only `utils.py` to the merge base fails 3 of them (`test_drop_params_strips_sampling_params_for_unsupported_model`, `test_drop_params_strips_sampling_params_for_provider_prefixed_model`, `test_sampling_param_raises_clean_400_without_drop_params`), so the new coverage genuinely pins the fix.
