### PR TITLE
fix(router): don't log 'Could not identify azure model' when the deployment name resolves from the cost map

### DIFF
--- a/litellm/router.py
+++ b/litellm/router.py
@@ -9154,14 +9154,9 @@ class Router:
 
         ## SET MODEL TO 'model=' - if base_model is None + not azure
         if custom_llm_provider == "azure" and base_model is None:
-            # the `if model is None` fallback below resolves the deployment's
-            # model name against the model cost map — when the name is a known
-            # azure key (e.g. deployment model "azure/gpt-4o"), that resolution
-            # gives correct max tokens / costs and there is nothing for the
-            # operator to fix, so don't spam an ERROR on every request.
-            # membership alone isn't enough: Router init auto-registers every
-            # deployment name into litellm.model_cost as a zeroed stub, so
-            # require the entry to carry usable limits/costs.
+            # Router init auto-registers every deployment name into
+            # litellm.model_cost as a zeroed stub, so membership alone can't
+            # tell a resolvable name apart; require usable limits/costs.
             _azure_fallback_key = _model if _model.startswith("azure/") else f"azure/{_model}"
             _fallback_entry = litellm.model_cost.get(_azure_fallback_key)
             _fallback_resolves = _fallback_entry is not None and (

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -9154,10 +9154,32 @@ class Router:
 
         ## SET MODEL TO 'model=' - if base_model is None + not azure
         if custom_llm_provider == "azure" and base_model is None:
-            verbose_router_logger.error(
-                "Could not identify azure model '%s'. Set azure 'base_model' for accurate max tokens, cost tracking, etc.- https://docs.litellm.ai/docs/proxy/cost_tracking#spend-tracking-for-azure-openai-models",
-                _model,
+            # the `if model is None` fallback below resolves the deployment's
+            # model name against the model cost map — when the name is a known
+            # azure key (e.g. deployment model "azure/gpt-4o"), that resolution
+            # gives correct max tokens / costs and there is nothing for the
+            # operator to fix, so don't spam an ERROR on every request.
+            # membership alone isn't enough: Router init auto-registers every
+            # deployment name into litellm.model_cost as a zeroed stub, so
+            # require the entry to carry usable limits/costs.
+            _azure_fallback_key = _model if _model.startswith("azure/") else f"azure/{_model}"
+            _fallback_entry = litellm.model_cost.get(_azure_fallback_key) or {}
+            _fallback_resolves = (
+                _fallback_entry.get("max_input_tokens") is not None
+                or _fallback_entry.get("max_tokens") is not None
+                or (_fallback_entry.get("input_cost_per_token") or 0) > 0
             )
+            if _fallback_resolves:
+                verbose_router_logger.debug(
+                    "Azure deployment '%s' has no base_model set; using '%s' from the model cost map for max tokens, cost tracking, etc.",
+                    _model,
+                    _azure_fallback_key,
+                )
+            else:
+                verbose_router_logger.error(
+                    "Could not identify azure model '%s'. Set azure 'base_model' for accurate max tokens, cost tracking, etc.- https://docs.litellm.ai/docs/proxy/cost_tracking#spend-tracking-for-azure-openai-models",
+                    _model,
+                )
         elif custom_llm_provider != "azure":
             model = _model
 

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -9163,10 +9163,10 @@ class Router:
             # deployment name into litellm.model_cost as a zeroed stub, so
             # require the entry to carry usable limits/costs.
             _azure_fallback_key = _model if _model.startswith("azure/") else f"azure/{_model}"
-            _fallback_entry = litellm.model_cost.get(_azure_fallback_key) or {}
-            _fallback_resolves = (
-                _fallback_entry.get("max_input_tokens") is not None
-                or _fallback_entry.get("max_tokens") is not None
+            _fallback_entry = litellm.model_cost.get(_azure_fallback_key)
+            _fallback_resolves = _fallback_entry is not None and (
+                (_fallback_entry.get("max_input_tokens") or 0) > 0
+                or (_fallback_entry.get("max_tokens") or 0) > 0
                 or (_fallback_entry.get("input_cost_per_token") or 0) > 0
             )
             if _fallback_resolves:

--- a/tests/test_litellm/test_router.py
+++ b/tests/test_litellm/test_router.py
@@ -8639,3 +8639,92 @@ class TestAutoRoutedRequestMarker:
         await router.async_pre_routing_hook(model="gemini-flash", request_kwargs=request_kwargs)
 
         assert AUTO_ROUTED_REQUEST_METADATA_KEY not in request_kwargs["metadata"]
+
+
+class TestAzureBaseModelFallbackLogging:
+    """When an azure deployment has no base_model but its model name is a known
+    azure key in the cost map, get_router_model_info resolves it via the
+    fallback — so it must not log the per-request 'Could not identify azure
+    model' ERROR. The ERROR must remain for genuinely unmappable deployment
+    names. Issue #33172."""
+
+    @pytest.fixture(autouse=True)
+    def _use_local_model_cost_map(self, monkeypatch):
+        monkeypatch.setenv("LITELLM_LOCAL_MODEL_COST_MAP", "True")
+        original_model_cost = litellm.model_cost
+        litellm.model_cost = litellm.get_model_cost_map(url="")
+        yield
+        litellm.model_cost = original_model_cost
+
+    def _router_with_azure_deployment(self, deployment_model: str):
+        return litellm.Router(
+            model_list=[
+                {
+                    "model_name": "my-group",
+                    "litellm_params": {
+                        "model": deployment_model,
+                        "api_key": "fake-key",
+                        "api_base": "https://fake.openai.azure.com",
+                    },
+                    "model_info": {"id": "azure-base-model-test-id"},
+                }
+            ]
+        )
+
+    def test_map_known_deployment_name_resolves_without_error_log(self):
+        router = self._router_with_azure_deployment("azure/gpt-4o")
+
+        with patch(
+            "litellm.router.verbose_router_logger.error"
+        ) as mock_error:
+            model_info = router.get_router_model_info(
+                deployment=None, received_model_name="my-group", id="azure-base-model-test-id"
+            )
+
+        assert not any(
+            "Could not identify azure model" in str(call)
+            for call in mock_error.call_args_list
+        ), f"unexpected error log: {mock_error.call_args_list}"
+        # the fallback resolution must actually surface the map values
+        assert model_info["max_input_tokens"] == litellm.model_cost["azure/gpt-4o"]["max_input_tokens"]
+        assert model_info["input_cost_per_token"] == litellm.model_cost["azure/gpt-4o"]["input_cost_per_token"]
+
+    def test_unmappable_deployment_name_still_logs_error(self):
+        router = self._router_with_azure_deployment("azure/my-custom-deployment-name")
+
+        with patch(
+            "litellm.router.verbose_router_logger.error"
+        ) as mock_error:
+            model_info = router.get_router_model_info(
+                deployment=None, received_model_name="my-group", id="azure-base-model-test-id"
+            )
+
+        assert any(
+            "Could not identify azure model" in str(call)
+            for call in mock_error.call_args_list
+        ), "expected the error log for an unmappable azure deployment name"
+        # unmappable names resolve to a zeroed stub — unchanged behavior
+        assert model_info.get("max_input_tokens") is None
+
+    def test_explicit_base_model_still_wins(self):
+        router = litellm.Router(
+            model_list=[
+                {
+                    "model_name": "my-group",
+                    "litellm_params": {
+                        "model": "azure/some-deployment",
+                        "api_key": "fake-key",
+                        "api_base": "https://fake.openai.azure.com",
+                    },
+                    "model_info": {
+                        "id": "azure-base-model-test-id",
+                        "base_model": "azure/gpt-4o-mini",
+                    },
+                }
+            ]
+        )
+
+        model_info = router.get_router_model_info(
+            deployment=None, received_model_name="my-group", id="azure-base-model-test-id"
+        )
+        assert model_info["max_input_tokens"] == litellm.model_cost["azure/gpt-4o-mini"]["max_input_tokens"]

--- a/tests/test_litellm/test_router.py
+++ b/tests/test_litellm/test_router.py
@@ -8641,20 +8641,13 @@ class TestAutoRoutedRequestMarker:
         assert AUTO_ROUTED_REQUEST_METADATA_KEY not in request_kwargs["metadata"]
 
 
+@pytest.mark.usefixtures("local_model_cost_map")
 class TestAzureBaseModelFallbackLogging:
     """When an azure deployment has no base_model but its model name is a known
     azure key in the cost map, get_router_model_info resolves it via the
-    fallback — so it must not log the per-request 'Could not identify azure
+    fallback, so it must not log the per-request 'Could not identify azure
     model' ERROR. The ERROR must remain for genuinely unmappable deployment
     names. Issue #33172."""
-
-    @pytest.fixture(autouse=True)
-    def _use_local_model_cost_map(self, monkeypatch):
-        monkeypatch.setenv("LITELLM_LOCAL_MODEL_COST_MAP", "True")
-        original_model_cost = litellm.model_cost
-        litellm.model_cost = litellm.get_model_cost_map(url="")
-        yield
-        litellm.model_cost = original_model_cost
 
     def _router_with_azure_deployment(self, deployment_model: str):
         return litellm.Router(


### PR DESCRIPTION
> [!NOTE]
> Copy of #33292 by @mihidumh, pushed to a `litellm_` branch so the full CircleCI suite runs. Commit authorship is preserved; full credit to the original author. The only difference from the original branch is that 476 regenerated `litellm/proxy/_experimental/out` build files that were accidentally swept into the second commit have been dropped, and the base has been updated to latest `litellm_internal_staging` (one trivial append conflict in `tests/test_litellm/test_router.py` resolved by keeping both new test classes)

## Relevant issues

Fixes #33172

Original PR: #33292

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

## Screenshots / Proof of Fix

Production observation by the original author (litellm proxy 1.92.0 on Azure, real traffic): every request to a multi-deployment azure group without `base_model` logs

```
Could not identify azure model 'gpt-5.4'. Set azure 'base_model' for accurate max tokens, cost tracking, etc.
```

thousands of ERROR lines a day, even though `azure/gpt-5.4` is an exact key in the shipped cost map and `get_router_model_info`'s existing `if model is None: model = _model` fallback resolves it correctly. The original author verified on a live proxy that hand-setting `model_info.base_model = litellm_params.model` on every such row (56 rows on one env) changes nothing about resolution and only silences the log; the ERROR was spurious for exactly the deployments that need no operator action

Membership in `litellm.model_cost` cannot be the discriminator on its own: `Router.__init__` auto-registers every deployment name into the map as a zeroed stub (`register_model: model=... not in built-in cost map ... will default to 0`). The check therefore requires the fallback entry to carry usable limits/costs

Unit tests (new `TestAzureBaseModelFallbackLogging` in `tests/test_litellm/test_router.py`):

Before (base): `test_map_known_deployment_name_resolves_without_error_log` FAILS (spurious ERROR fires); the other 2 pass

After (this branch):

```
$ pytest tests/test_litellm/test_router.py::TestAzureBaseModelFallbackLogging -q
3 passed
```

covering: (1) map-known deployment name resolves with no ERROR and model_info carries the map's max tokens/costs, (2) genuinely unmappable name still logs the ERROR and returns the zeroed stub unchanged, (3) explicit `base_model` still wins

## Type

🐛 Bug Fix

## Changes

- In `get_router_model_info`'s azure branch: when `base_model` is unset, check whether the `azure/<deployment model name>` entry in the cost map carries usable limits/costs (guarding against Router-init's zeroed auto-registration stubs). If so, log at **debug**; the existing fallback resolution handles it. Otherwise keep the existing **error**
- No behavior change to resolution or returned model_info; logging level only

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Logging-only change in Azure model-info lookup; cost/token resolution behavior is unchanged.
> 
> **Overview**
> Stops `get_router_model_info` from ERROR-logging “Could not identify azure model” on every request when an Azure deployment has no `base_model` but the name already maps to a real cost-map entry (usable max tokens or input cost). Those cases now log at debug; genuinely unmappable names still ERROR.
> 
> Resolution and returned `model_info` are unchanged. Router-init zeroed stubs are ignored so membership in `litellm.model_cost` alone is not treated as a hit. Tests cover known names, unmappable names, and explicit `base_model`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 80b7d53f3d084711ed5e716536b6354f051030f8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->