### PR TITLE
test(lint): fix PT011/PT012 introduced by #37736, blocking lint on every PR

### DIFF
--- a/tests/proxy_unit_tests/test_unit_test_max_model_budget_limiter.py
+++ b/tests/proxy_unit_tests/test_unit_test_max_model_budget_limiter.py
@@ -1210,18 +1210,19 @@ async def test_a_pre_upgrade_counter_keyed_on_the_request_model_still_enforces(e
     model_max_budget = {"gpt-4": {"budget_limit": 10.0, "time_period": "1d"}}
     await limiter.dual_cache.async_set_cache(key=f"{prefix}:entity-1:openai/gpt-4:1d", value=25.0, ttl=86400)
 
+    if entity_type == Litellm_EntityType.KEY:
+        check = limiter.is_key_within_model_budget(
+            user_api_key_dict=UserAPIKeyAuth(token="entity-1", model_max_budget=model_max_budget),
+            model="openai/gpt-4",
+        )
+    else:
+        check = limiter.is_end_user_within_model_budget(
+            end_user_id="entity-1",
+            end_user_model_max_budget=model_max_budget,
+            model="openai/gpt-4",
+        )
     with pytest.raises(litellm.BudgetExceededError) as exc_info:
-        if entity_type == Litellm_EntityType.KEY:
-            await limiter.is_key_within_model_budget(
-                user_api_key_dict=UserAPIKeyAuth(token="entity-1", model_max_budget=model_max_budget),
-                model="openai/gpt-4",
-            )
-        else:
-            await limiter.is_end_user_within_model_budget(
-                end_user_id="entity-1",
-                end_user_model_max_budget=model_max_budget,
-                model="openai/gpt-4",
-            )
+        await check
     assert exc_info.value.current_cost == 25.0
 
 

--- a/tests/proxy_unit_tests/test_user_api_key_auth.py
+++ b/tests/proxy_unit_tests/test_user_api_key_auth.py
@@ -1357,9 +1357,8 @@ async def test_user_model_budget_is_enforced_through_user_api_key_auth(over_budg
         new=fake_get_user_object,
     ):
         if expect_refusal:
-            with pytest.raises(Exception) as exc:
+            with pytest.raises(Exception, match=r"(?i)budget") as exc:
                 await user_api_key_auth(request=request, api_key="Bearer " + key)
-            assert "budget" in str(exc.value).lower()
             assert user_id in str(exc.value)
         else:
             result = await user_api_key_auth(request=request, api_key="Bearer " + key)


### PR DESCRIPTION
## TLDR

`ruff check --config ruff-tests.toml tests` is red on `litellm_internal_staging`, which blocks the lint job for every open PR into it (including unrelated ones — it's a whole-tree check, not delta-vs-base).

Both violations landed in #37736, merged the day before B017/PT012 started being enforced whole-tree in #37731/#37748, so no delta-vs-base gate caught them at the time.

## Changes

- `tests/proxy_unit_tests/test_user_api_key_auth.py`: `pytest.raises(Exception)` with no `match=` (B017) — any `Exception` subtype, including one from an unrelated regression, satisfies the assert and reads as a pass. Narrowed to `match=r"(?i)budget"`, which preserves the `assert "budget" in str(exc.value).lower()` it replaces.
- `tests/proxy_unit_tests/test_unit_test_max_model_budget_limiter.py`: an `if/else` selecting between two different awaited calls, both inside `pytest.raises()` (PT012) — the block must hold a single simple statement so a coroutine built in the wrong branch can't silently never run. Coroutine is now built outside the block and awaited inside it.

## Verification

- `uv run --no-sync ruff check --config ruff-tests.toml tests`: clean.
- Both tests pass as edited.
- Mutation-checked each: injecting an unrelated exception / dropping the pre-seeded spend still fails the test, confirming the restructuring didn't weaken what's being asserted.

## Pre-Submission checklist

- [x] I have added meaningful tests (N/A — test-only lint fix, no behavior change)
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
