### PR TITLE
fix(ui): drive auto-router usage from the shared cost-optimization time picker

### DIFF
--- a/ui/litellm-dashboard/src/app/(dashboard)/cost-optimization/_components/AutoRouterBenchmarksTab.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/cost-optimization/_components/AutoRouterBenchmarksTab.test.tsx
@@ -9,6 +9,16 @@ import { ApiError } from "@/lib/http/client";
 vi.mock("./useAutoRouterBenchmarks", () => ({ useAutoRouterBenchmarks: vi.fn() }));
 vi.mock("@/app/(dashboard)/hooks/models/useModels", () => ({ useAutoRouters: vi.fn() }));
 vi.mock("./ShadowEvalSection", () => ({ default: () => <div data-testid="shadow-eval-section" /> }));
+vi.mock("@/components/shared/advanced_date_picker", () => ({
+  __esModule: true,
+  default: ({ onValueChange }: { onValueChange: (value: { from?: Date; to?: Date }) => void }) => (
+    <button
+      type="button"
+      data-testid="date-picker"
+      onClick={() => onValueChange({ from: new Date(2026, 7, 1), to: new Date(2026, 7, 5) })}
+    />
+  ),
+}));
 
 import { useAutoRouters } from "@/app/(dashboard)/hooks/models/useModels";
 
@@ -112,12 +122,28 @@ const response = (groups: AutoRouterBenchmarkGroup[], shared: Totals = totals())
 });
 
 const renderTab = () => {
+  const dateValue = { from: new Date(2026, 6, 6), to: new Date(2026, 7, 5) };
+  const onDateChange = vi.fn();
+  const activity = {
+    dateValue,
+    onDateChange,
+    results: [],
+    loading: false,
+    isFetchingMore: false,
+    progress: { currentPage: 1, totalPages: 1 },
+    cancelled: false,
+    cancel: vi.fn(),
+  };
   const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
-  return render(
-    <QueryClientProvider client={queryClient}>
-      <AutoRouterBenchmarksTab accessToken="sk-test" />
-    </QueryClientProvider>,
-  );
+  return {
+    dateValue,
+    onDateChange,
+    ...render(
+      <QueryClientProvider client={queryClient}>
+        <AutoRouterBenchmarksTab accessToken="sk-test" activity={activity} />
+      </QueryClientProvider>,
+    ),
+  };
 };
 
 describe("AutoRouterBenchmarksTab", () => {
@@ -304,20 +330,15 @@ describe("AutoRouterBenchmarksTab", () => {
     expect(screen.queryByText("-0%")).not.toBeInTheDocument();
   });
 
-  it("requests the default thirty day window and widens or narrows it from the picker", () => {
+  it("queries the shared picker's range and pushes picker changes back to the shared state", () => {
     mockHook({ data: response([group()]) });
-    renderTab();
+    const { dateValue, onDateChange } = renderTab();
 
-    expect(vi.mocked(useAutoRouterBenchmarks)).toHaveBeenCalledWith("sk-test", "30d");
-    expect(screen.getByText("Last 30 days")).toBeInTheDocument();
+    expect(vi.mocked(useAutoRouterBenchmarks)).toHaveBeenCalledWith("sk-test", dateValue);
+    expect(screen.getByText("Jul 6 – Aug 5 (UTC)")).toBeInTheDocument();
 
-    fireEvent.click(screen.getByRole("tab", { name: "7d" }));
-    expect(vi.mocked(useAutoRouterBenchmarks)).toHaveBeenCalledWith("sk-test", "7d");
-    expect(screen.getByText("Last 7 days")).toBeInTheDocument();
-
-    fireEvent.click(screen.getByRole("tab", { name: "24h" }));
-    expect(vi.mocked(useAutoRouterBenchmarks)).toHaveBeenCalledWith("sk-test", "24h");
-    expect(screen.getByText("Last 24 hours")).toBeInTheDocument();
+    fireEvent.click(screen.getByTestId("date-picker"));
+    expect(onDateChange).toHaveBeenCalledWith({ from: new Date(2026, 7, 1), to: new Date(2026, 7, 5) });
   });
 
   it("shows usage by default and mounts shadow evals only when its sub-tab is selected", () => {
@@ -347,11 +368,11 @@ describe("AutoRouterBenchmarksTab", () => {
     expect(screen.getByTestId("shadow-eval-section")).toBeInTheDocument();
   });
 
-  it("keeps the window picker reachable while a window has no sessions", () => {
+  it("keeps the range picker reachable while a window has no sessions", () => {
     mockHook({ data: response([], zeroTotals) });
     renderTab();
 
-    expect(screen.getByRole("tab", { name: "30d" })).toBeInTheDocument();
+    expect(screen.getByTestId("date-picker")).toBeInTheDocument();
     expect(screen.getByText("All auto-routers")).toBeInTheDocument();
   });
 });

--- a/ui/litellm-dashboard/src/app/(dashboard)/cost-optimization/_components/AutoRouterBenchmarksTab.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/cost-optimization/_components/AutoRouterBenchmarksTab.tsx
@@ -4,6 +4,7 @@ import React, { useState } from "react";
 
 import type { AutoRouterDeployment } from "@/app/(dashboard)/hooks/models/useModels";
 import { useAutoRouters } from "@/app/(dashboard)/hooks/models/useModels";
+import AdvancedDatePicker from "@/components/shared/advanced_date_picker";
 import { Badge } from "@/components/ui/badge";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
@@ -15,7 +16,6 @@ import { formatNumberWithCommas } from "@/utils/dataUtils";
 
 import {
   ALL_ROUTERS,
-  WINDOW_LABELS,
   bucketRows,
   bucketTurnsTotal,
   durationLabel,
@@ -27,13 +27,13 @@ import {
   type AutoRouterBenchmarksResponse,
   type AutoRouterCacheStats,
   type BenchmarkView,
-  type BenchmarkWindow,
   type BucketRow,
 } from "./autoRouterBenchmarks";
-import { usd } from "./costOptimizationUtils";
+import { formatRangeLabel, usd } from "./costOptimizationUtils";
 import ShadowEvalSection from "./ShadowEvalSection";
 import TierTurnsChart from "./TierTurnsChart";
 import { useAutoRouterBenchmarks } from "./useAutoRouterBenchmarks";
+import { DailyActivityRange } from "./useDailyActivityRange";
 
 const Message: React.FC<{ children: React.ReactNode }> = ({ children }) => (
   <p className="py-8 text-center text-sm text-muted-foreground">{children}</p>
@@ -248,7 +248,8 @@ const BenchmarksBody: React.FC<BenchmarksBodyProps> = ({ isPending, error, data,
       <p className="text-xs text-muted-foreground">
         Compares your actual routed spend with the estimated cost of using only the most expensive model configured in
         the auto-router. It accounts for both the cache savings from staying on one model and the added cache costs from
-        switching models.
+        switching models. The range counts whole sessions that overlap it, so totals can differ slightly from the
+        Overall tab, which buckets savings by UTC day.
       </p>
 
       <div className="space-y-4">
@@ -266,32 +267,28 @@ const BenchmarksBody: React.FC<BenchmarksBodyProps> = ({ isPending, error, data,
 
 interface AutoRouterBenchmarksTabProps {
   accessToken: string | null;
+  activity: DailyActivityRange;
 }
 
-const UsageView: React.FC<AutoRouterBenchmarksTabProps> = ({ accessToken }) => {
-  const [range, setRange] = useState<BenchmarkWindow>("30d");
-  const { data, isPending, error } = useAutoRouterBenchmarks(accessToken, range);
+const UsageView: React.FC<AutoRouterBenchmarksTabProps> = ({ accessToken, activity }) => {
+  const { dateValue, onDateChange } = activity;
+  const { data, isPending, error } = useAutoRouterBenchmarks(accessToken, dateValue);
   const [selectedKey, setSelectedKey] = useState<string>(ALL_ROUTERS);
   const { data: autoRouters } = useAutoRouters();
 
   const groups = data?.groups ?? [];
   const selectedLabel = data ? viewFor(data, selectedKey).label : "All auto-routers";
+  const rangeLabel = formatRangeLabel(dateValue.from, dateValue.to);
 
   return (
     <div className="w-full space-y-6">
       <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
         <div>
           <h2 className="text-xl font-semibold text-foreground">Auto-router usage</h2>
-          <p className="mt-1 text-sm text-muted-foreground">{WINDOW_LABELS[range]}</p>
+          {rangeLabel && <p className="mt-1 text-sm text-muted-foreground">{rangeLabel} (UTC)</p>}
         </div>
         <div className="flex w-full flex-col gap-3 sm:w-auto sm:flex-row sm:items-center">
-          <Tabs value={range} onValueChange={(value) => setRange(value === "7d" || value === "24h" ? value : "30d")}>
-            <TabsList>
-              <TabsTrigger value="30d">30d</TabsTrigger>
-              <TabsTrigger value="7d">7d</TabsTrigger>
-              <TabsTrigger value="24h">24h</TabsTrigger>
-            </TabsList>
-          </Tabs>
+          <AdvancedDatePicker value={dateValue} onValueChange={onDateChange} />
           <div className="w-full sm:w-64">
             <Select value={selectedKey} onValueChange={(value: string | null) => setSelectedKey(value ?? ALL_ROUTERS)}>
               <SelectTrigger className="w-full">
@@ -321,7 +318,7 @@ const UsageView: React.FC<AutoRouterBenchmarksTabProps> = ({ accessToken }) => {
   );
 };
 
-const AutoRouterBenchmarksTab: React.FC<AutoRouterBenchmarksTabProps> = ({ accessToken }) => {
+const AutoRouterBenchmarksTab: React.FC<AutoRouterBenchmarksTabProps> = ({ accessToken, activity }) => {
   const [visitedTabs, setVisitedTabs] = useState<readonly string[]>(["usage"]);
 
   const handleTabChange = (value: unknown) => {
@@ -344,7 +341,7 @@ const AutoRouterBenchmarksTab: React.FC<AutoRouterBenchmarksTabProps> = ({ acces
       </TabsList>
 
       <TabsContent value="usage" keepMounted={visitedTabs.includes("usage")}>
-        <UsageView accessToken={accessToken} />
+        <UsageView accessToken={accessToken} activity={activity} />
       </TabsContent>
       <TabsContent value="shadow-evals" keepMounted={visitedTabs.includes("shadow-evals")}>
         <ShadowEvalSection />

--- a/ui/litellm-dashboard/src/app/(dashboard)/cost-optimization/_components/CostOptimizationView.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/cost-optimization/_components/CostOptimizationView.tsx
@@ -101,7 +101,7 @@ const CostOptimizationView: React.FC<CostOptimizationViewProps> = ({ accessToken
               <PromptCachingTab accessToken={accessToken} activity={activity} />
             </TabsContent>
             <TabsContent value="autorouter-usage" keepMounted={visitedTabs.includes("autorouter-usage")}>
-              <AutoRouterBenchmarksTab accessToken={accessToken} />
+              <AutoRouterBenchmarksTab accessToken={accessToken} activity={activity} />
             </TabsContent>
           </>
         )}

--- a/ui/litellm-dashboard/src/app/(dashboard)/cost-optimization/_components/autoRouterBenchmarks.test.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/cost-optimization/_components/autoRouterBenchmarks.test.ts
@@ -10,7 +10,6 @@ import {
   groupLabel,
   pctLabel,
   viewFor,
-  windowFor,
   type AutoRouterBenchmarkGroup,
   type AutoRouterBenchmarksResponse,
   type AutoRouterCacheStats,
@@ -150,21 +149,6 @@ describe("expiredMissShare", () => {
       return_misses_expired: 0,
     };
     expect(expiredMissShare(cache(nothingMeasured))).toBeNull();
-  });
-});
-
-describe("windowFor", () => {
-  const noon = new Date("2026-08-05T12:00:00Z");
-
-  it("derives each picker range as UTC calendar days ending today", () => {
-    expect(windowFor("30d", noon)).toEqual({ start_date: "2026-07-06", end_date: "2026-08-05" });
-    expect(windowFor("7d", noon)).toEqual({ start_date: "2026-07-29", end_date: "2026-08-05" });
-    expect(windowFor("24h", noon)).toEqual({ start_date: "2026-08-04", end_date: "2026-08-05" });
-  });
-
-  it("uses UTC days, not the local calendar", () => {
-    const lateEvening = new Date("2026-08-05T23:30:00-05:00");
-    expect(windowFor("24h", lateEvening)).toEqual({ start_date: "2026-08-05", end_date: "2026-08-06" });
   });
 });
 

--- a/ui/litellm-dashboard/src/app/(dashboard)/cost-optimization/_components/autoRouterBenchmarks.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/cost-optimization/_components/autoRouterBenchmarks.ts
@@ -7,21 +7,6 @@ export type AutoRouterCacheStats = components["schemas"]["AutoRouterCacheStats"]
 
 export const ALL_ROUTERS = "__all__";
 
-export type BenchmarkWindow = "30d" | "7d" | "24h";
-
-const WINDOW_DAYS: Record<BenchmarkWindow, number> = { "30d": 30, "7d": 7, "24h": 1 };
-
-export const WINDOW_LABELS: Record<BenchmarkWindow, string> = {
-  "30d": "Last 30 days",
-  "7d": "Last 7 days",
-  "24h": "Last 24 hours",
-};
-
-export const windowFor = (range: BenchmarkWindow, now: Date): { start_date: string; end_date: string } => ({
-  start_date: new Date(now.getTime() - WINDOW_DAYS[range] * 24 * 60 * 60 * 1000).toISOString().slice(0, 10),
-  end_date: now.toISOString().slice(0, 10),
-});
-
 export interface BenchmarkView {
   label: string;
   stats: AutoRouterBenchmarkTotals | AutoRouterBenchmarkGroup;

--- a/ui/litellm-dashboard/src/app/(dashboard)/cost-optimization/_components/useAutoRouterBenchmarks.test.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/cost-optimization/_components/useAutoRouterBenchmarks.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@/components/networking", () => ({ formatDate: vi.fn() }));
+vi.mock("@/lib/http/api", () => ({ $api: { useQuery: vi.fn() } }));
+
+import { benchmarksWindow } from "./useAutoRouterBenchmarks";
+
+const localDay =
+  (offsetHours: number) =>
+  (d: Date): string =>
+    new Date(d.getTime() + offsetHours * 3_600_000).toISOString().slice(0, 10);
+
+const pacific = localDay(-7);
+const tokyo = localDay(+9);
+
+describe("benchmarksWindow", () => {
+  it("passes a historical range through as the picked local calendar days", () => {
+    const now = new Date("2026-08-21T19:00:00Z");
+    const range = { from: new Date("2026-07-06T19:00:00Z"), to: new Date("2026-08-05T19:00:00Z") };
+    expect(benchmarksWindow(range, now, pacific)).toEqual({ start_date: "2026-07-06", end_date: "2026-08-05" });
+  });
+
+  it("keeps a range ending today unchanged while the local and UTC days still agree", () => {
+    const now = new Date("2026-08-21T19:00:00Z");
+    const range = { from: new Date("2026-07-22T19:00:00Z"), to: now };
+    expect(benchmarksWindow(range, now, pacific)).toEqual({ start_date: "2026-07-22", end_date: "2026-08-21" });
+  });
+
+  it("extends a range ending today to the current UTC day once UTC rolls past local midnight", () => {
+    const now = new Date("2026-08-22T03:00:00Z");
+    const range = { from: new Date("2026-07-22T19:00:00Z"), to: now };
+    expect(benchmarksWindow(range, now, pacific)).toEqual({ start_date: "2026-07-22", end_date: "2026-08-22" });
+  });
+
+  it("never shrinks a range for a caller east of UTC whose local day is already tomorrow", () => {
+    const now = new Date("2026-08-21T19:00:00Z");
+    const range = { from: new Date("2026-07-22T19:00:00Z"), to: now };
+    expect(benchmarksWindow(range, now, tokyo)).toEqual({ start_date: "2026-07-23", end_date: "2026-08-22" });
+  });
+
+  it("sends no dates while the picker is missing either end", () => {
+    const now = new Date("2026-08-21T19:00:00Z");
+    expect(benchmarksWindow({ from: now }, now, pacific)).toEqual({});
+    expect(benchmarksWindow({ to: now }, now, pacific)).toEqual({});
+  });
+});

--- a/ui/litellm-dashboard/src/app/(dashboard)/cost-optimization/_components/useAutoRouterBenchmarks.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/cost-optimization/_components/useAutoRouterBenchmarks.ts
@@ -3,14 +3,30 @@ import { $api } from "@/lib/http/api";
 
 import type { DateRange } from "./useDailyActivityRange";
 
+/**
+ * The endpoint cuts on UTC days but the picker hands back local dates, so west of UTC a
+ * range ending today would hide sessions started after UTC midnight. Extend it to the
+ * current UTC day (only the empty future is added), mirroring include_current_utc_day.
+ */
+export const benchmarksWindow = (
+  range: DateRange,
+  now: Date,
+  toLocalDay: (d: Date) => string = formatDate,
+): { start_date: string; end_date: string } | Record<string, never> => {
+  if (!range.from || !range.to) return {};
+  const end_date = toLocalDay(range.to);
+  const utcToday = now.toISOString().slice(0, 10);
+  const endsToday = end_date >= toLocalDay(now);
+  return {
+    start_date: toLocalDay(range.from),
+    end_date: endsToday && utcToday > end_date ? utcToday : end_date,
+  };
+};
+
 export const useAutoRouterBenchmarks = (accessToken: string | null, range: DateRange) =>
   $api.useQuery(
     "get",
     "/auto_router/benchmarks",
-    {
-      params: {
-        query: range.from && range.to ? { start_date: formatDate(range.from), end_date: formatDate(range.to) } : {},
-      },
-    },
+    { params: { query: benchmarksWindow(range, new Date()) } },
     { enabled: Boolean(accessToken && range.from && range.to), retry: false },
   );

--- a/ui/litellm-dashboard/src/app/(dashboard)/cost-optimization/_components/useAutoRouterBenchmarks.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/cost-optimization/_components/useAutoRouterBenchmarks.ts
@@ -1,11 +1,16 @@
+import { formatDate } from "@/components/networking";
 import { $api } from "@/lib/http/api";
 
-import { windowFor, type BenchmarkWindow } from "./autoRouterBenchmarks";
+import type { DateRange } from "./useDailyActivityRange";
 
-export const useAutoRouterBenchmarks = (accessToken: string | null, range: BenchmarkWindow) =>
+export const useAutoRouterBenchmarks = (accessToken: string | null, range: DateRange) =>
   $api.useQuery(
     "get",
     "/auto_router/benchmarks",
-    { params: { query: windowFor(range, new Date()) } },
-    { enabled: Boolean(accessToken), retry: false },
+    {
+      params: {
+        query: range.from && range.to ? { start_date: formatDate(range.from), end_date: formatDate(range.to) } : {},
+      },
+    },
+    { enabled: Boolean(accessToken && range.from && range.to), retry: false },
   );


### PR DESCRIPTION
## TLDR

Problem this solves:

- Overall tab and Auto-Router tab showed different auto-router savings
- Overall used the time range picker, Auto-Router used its own 24h/7d/30d toggle

How it solves it:

- Auto-Router usage now reads the page's shared Select Time Range picker
- Removes the tab-local 24h/7d/30d toggle and its window math
- A range ending today extends to the current UTC day, like the Overall reads

## User Flow

Before: an admin comparing savings across tabs sees numbers that look contradictory

1. They open https://litellm-domain/ui/cost-optimization and the Overall tab shows Auto-router savings of $1,447.76 for the picked range of the last 30 days
2. They click the Auto-Router tab, which defaults to its own "24h" toggle and shows Total estimated savings of $156.37
3. Nothing on either tab says the two figures cover different windows, so the dashboard looks broken

After: both tabs answer for the same window, picked in one place

1. They open https://litellm-domain/ui/cost-optimization and the Overall tab shows Auto-router savings for the picked range
2. They click the Auto-Router tab and see the same Select Time Range picker with the same range already applied, and the totals now line up with the Overall card
3. Changing the range on either tab changes it everywhere, and fine print on the Auto-Router tab explains the remaining small difference: its totals count whole sessions overlapping the range while the Overall tab buckets by UTC day

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Setup for the parity case: proxy on this branch at localhost:4200, a complexity auto-router with tiers claude-haiku-4-5 (SIMPLE), claude-sonnet-4-5 (MEDIUM), claude-opus-4-5 (COMPLEX and REASONING) at public per-token prices, llm classifier on haiku. Upstream is an internal gateway fronting the real Anthropic-served models rather than api.anthropic.com directly (the local Anthropic key is out of credit; the calls are real completions with real spend). The QA database had zero auto-router traffic for the day before the run

### Before (8122cfc1ec)

#### Shared range across tabs

1. Open http://localhost:4000/ui/cost-optimization, note the Auto-router savings card and the picked range on the Overall tab
2. Click the Auto-Router tab: it shows its own 24h/7d/30d toggle defaulting to 24h, so its Total estimated savings covers a different window than the Overall card and the two figures disagree

#### Savings parity on real traffic

1. The Auto-Router tab cannot be set to the Overall tab's picked range at all, so the two savings figures cannot be compared like for like

### After (aaa97577af)

#### Shared range across tabs

1. Open http://localhost:4000/ui/cost-optimization, note the Auto-router savings card and the picked range on the Overall tab
2. Click the Auto-Router tab: the same Select Time Range picker appears with the same range already applied and the toggle is gone
3. Change the range on the Auto-Router tab, return to Overall, and see the same range applied there too
4. West of UTC after 5pm local, start a fresh session through an auto-router and see it counted on both tabs without waiting for local midnight

#### Savings parity on real traffic

1. Send 9 chat completions of mixed complexity through the router: `for p in "what is 2+2?" ... "architect a multi-region active-active postgres deployment..."; do curl -s http://localhost:4200/v1/chat/completions -H "Authorization: Bearer $KEY" -d '{"model":"auto_router_real","max_tokens":150,"messages":[{"role":"user","content":"'"$p"'"}]}'; done` (all 9 return real completions; the classifier spreads them SIMPLE 3, MEDIUM 2, COMPLEX 2, REASONING 2)
2. `curl -s "http://localhost:4200/auto_router/benchmarks?start_date=2026-08-21&end_date=2026-08-21" -H "Authorization: Bearer $KEY"` returns `sessions 9, spend 0.020592, saved_spend 0.004138, baseline_spend 0.024730` (this feeds the Auto-Router tab's Total estimated savings)
3. `curl -s "http://localhost:4200/user/daily/activity?start_date=2026-08-21&end_date=2026-08-21&timezone=420&include_current_utc_day=true" -H "Authorization: Bearer $KEY"` returns `autorouter_savings_spend 0.004138` for the day (this feeds the Overall tab's Auto-router savings card)
4. Parity: `0.004138 - 0.004138 = 0.000000000`, an exact match on the same window; the per-model breakdown agrees too (opus turns save 0 because opus is the baseline, sonnet saves 0.003090, haiku saves 0.001048)
5. The Overall day's total spend (0.025839) exceeds the router's own spend (0.020592) by exactly the internal classifier calls' cost, which both savings figures correctly exclude

## Type

🐛 Bug Fix

## Caveats (if any)

- Small residual difference stays by design: sessions overlapping the range count whole, per-day UTC buckets do not; fine print on the tab now says so
- The benchmarks endpoint has no timezone param, so the live-end UTC extension mirrors `_adjust_dates_for_timezone` client side; historical dates stay pass-through, matching the daily-activity policy
- The parity run's upstream was the internal gateway rather than api.anthropic.com; a direct-key re-run is owed once the Anthropic account has credit
