### PR TITLE
chore(codeowners): own the proxy-extras migrations directory

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,6 @@
-/ui/ @yuneng-jiang @ryan-crabbe-berri
-/litellm/proxy/_experimental/out/ @yuneng-jiang @ryan-crabbe-berri
+/ui/ @yuneng-berri @ryan-crabbe-berri
+/litellm/proxy/_experimental/out/ @yuneng-berri @ryan-crabbe-berri
 /ui/litellm-dashboard/src/lib/http/schema.d.ts
 /model_prices_and_context_window.json @mateo-berri
 /litellm/model_prices_and_context_window_backup.json @mateo-berri
+/litellm-proxy-extras/litellm_proxy_extras/migrations/ @yuneng-berri @ryan-crabbe-berri


### PR DESCRIPTION
## TLDR

Problem this solves:

- Prisma migrations merge with no owning reviewer
- Two existing CODEOWNERS rules name an unknown owner
- Those rules are inert, so nobody gets requested

How it solves it:

- Adds the proxy-extras migrations directory to CODEOWNERS
- Repoints the two broken entries at a write-access account

## User Flow

Before: a contributor changing a schema migration gets it reviewed by whoever happens to look

1. They open a PR touching `litellm-proxy-extras/litellm_proxy_extras/migrations/`
2. The PR's Reviewers box stays empty, with no owner attached to the path
3. Separately, a PR touching `/ui/` also gets no automatic reviewer, because the rule covering it names an account without write access

After: the same PR pulls in the owning reviewers automatically

1. They open a PR touching `litellm-proxy-extras/litellm_proxy_extras/migrations/`
2. The PR's Reviewers box now lists the migrations owners, added by GitHub as code owners
3. A PR touching `/ui/` now does the same, since that rule resolves to a real write-access account

## Relevant issues

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

Note on the first two boxes: this PR changes only `.github/CODEOWNERS`, which has no importable code and no mapped test file, so there is nothing to unit test. GitHub's own CODEOWNERS validator is the authority on whether the file is correct, and its before/after output is below in place of tests.

## Screenshots / Proof of Fix

GitHub validates CODEOWNERS server-side and reports every rule it cannot resolve. A rule listing an owner without write access is silently dropped, so the validator is exactly what decides whether these entries do anything.

Shared setup:

```bash
gh api "repos/BerriAI/litellm/codeowners/errors?ref=<ref>"
```

### Before (0a5fa4fdc6599eb236c8116f9ce77e1ec29f83ae)

1. Ask GitHub to validate the file on the merge base

```bash
gh api "repos/BerriAI/litellm/codeowners/errors?ref=litellm_internal_staging" \
  --jq '.errors[] | "line \(.line): \(.kind) -> \(.source)"'
```

2. Two rules come back rejected, so neither is in force, and no rule covers the migrations directory at all

```
line 1: Unknown owner -> /ui/ @yuneng-jiang @ryan-crabbe-berri

line 2: Unknown owner -> /litellm/proxy/_experimental/out/ @yuneng-jiang @ryan-crabbe-berri
```

3. Read the full message on one of them to see why it was dropped

```bash
gh api "repos/BerriAI/litellm/codeowners/errors?ref=litellm_internal_staging" \
  --jq '.errors[0].suggestion'
```

```
make sure @yuneng-jiang exists and has write access to the repository
```

4. Confirm the cause directly: the named account resolves, but only at read

```bash
gh api repos/BerriAI/litellm/collaborators/yuneng-jiang/permission --jq .permission
```

```
read
```

### After (6f73e5fb2a9075cc30c7e66294cb28951a8565c4)

1. Ask GitHub to validate the file on this PR's branch

```bash
gh api "repos/BerriAI/litellm/codeowners/errors?ref=litellm_%2Fmigrations-code-owner-c09d78" --jq '.errors'
```

2. The error list is empty, so every rule in the file now resolves and takes effect

```
[]
```

3. Confirm both owners on the new migrations rule hold write access

```bash
for u in yuneng-berri ryan-crabbe-berri; do
  echo "$u: $(gh api repos/BerriAI/litellm/collaborators/$u/permission --jq .permission)"
done
```

```
yuneng-berri: write
ryan-crabbe-berri: write
```

4. Confirm the new rule is the one matching the migrations path

```bash
git show HEAD:.github/CODEOWNERS | grep migrations
```

```
/litellm-proxy-extras/litellm_proxy_extras/migrations/ @yuneng-berri @ryan-crabbe-berri
```

## Type

🚄 Infrastructure

## Caveats (if any)

- `@yuneng-jiang` is a read-only account, not a separate person
- Ownership applies to PRs opened after this merges

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
