### PR TITLE
test: enforce F811 so a duplicate definition cannot silently replace the first

### DIFF
--- a/ruff-tests.toml
+++ b/ruff-tests.toml
@@ -26,6 +26,9 @@
 # PT014   the same `parametrize` case listed twice. The copy re-runs an assertion that
 #         already passed and adds no coverage, and it usually marks a case someone meant
 #         to vary and forgot to edit
+# F811    a name bound twice where the first binding was never used. Mostly a repeated
+#         import, but the same rule is what catches a second `def test_x` silently
+#         replacing the first, and a local that shadows an import the module still calls
 #
 # No target-version here on purpose: it resolves from requires-python (>=3.10), so
 # 3.11-only builtins like BaseExceptionGroup are correctly flagged in a tree that
@@ -33,4 +36,4 @@
 
 line-length = 120
 
-lint.select = ["F821", "B011", "B015", "B017", "B018", "PT011", "PT012", "PT014", "PT015", "PLR0133", "PLW0127"]
+lint.select = ["F811", "F821", "B011", "B015", "B017", "B018", "PT011", "PT012", "PT014", "PT015", "PLR0133", "PLW0127"]

--- a/tests/audio_tests/test_audio_speech.py
+++ b/tests/audio_tests/test_audio_speech.py
@@ -12,7 +12,6 @@ from litellm._uuid import uuid
 from dotenv import load_dotenv
 
 load_dotenv()
-import os
 
 sys.path.insert(
     0, os.path.abspath("../..")
@@ -452,7 +451,7 @@ async def test_azure_ava_tts_with_custom_voice():
     Test that when using a custom Azure voice (en-US-AndrewNeural),
     the SSML request body contains the selected voice.
     """
-    from unittest.mock import AsyncMock, MagicMock, patch
+    from unittest.mock import AsyncMock, patch
     import httpx
 
     # Mock response
@@ -497,7 +496,7 @@ async def test_azure_ava_tts_fable_voice_mapping():
     Test that when using OpenAI voice 'fable',
     it gets mapped to Azure voice 'en-GB-RyanNeural' in the SSML.
     """
-    from unittest.mock import AsyncMock, MagicMock, patch
+    from unittest.mock import AsyncMock, patch
     import httpx
 
     # Mock response
@@ -544,7 +543,7 @@ async def test_aws_polly_tts_with_native_voice():
     Verifies the request is formatted correctly for the Polly API.
     """
     import json
-    from unittest.mock import MagicMock, patch
+    from unittest.mock import patch
     import httpx
 
     # Mock response - Polly returns audio bytes directly
@@ -592,7 +591,7 @@ async def test_aws_polly_tts_with_openai_voice_mapping():
     Verifies that OpenAI voices are correctly mapped to Polly voices.
     """
     import json
-    from unittest.mock import MagicMock, patch
+    from unittest.mock import patch
     import httpx
 
     mock_response_content = b"fake_audio_data"
@@ -634,7 +633,7 @@ async def test_aws_polly_tts_with_ssml():
     Verifies that SSML is detected and TextType is set correctly.
     """
     import json
-    from unittest.mock import MagicMock, patch
+    from unittest.mock import patch
     import httpx
 
     mock_response_content = b"fake_audio_data"

--- a/tests/audio_tests/test_whisper.py
+++ b/tests/audio_tests/test_whisper.py
@@ -44,7 +44,6 @@ load_dotenv()
 sys.path.insert(
     0, os.path.abspath("../")
 )  # Adds the parent directory to the system path
-import litellm
 from litellm import Router
 
 
@@ -146,7 +145,6 @@ async def test_whisper_log_pre_call():
     from litellm.litellm_core_utils.litellm_logging import Logging
     from datetime import datetime
     from unittest.mock import patch, MagicMock
-    from litellm.integrations.custom_logger import CustomLogger
 
     custom_logger = CustomLogger()
 

--- a/tests/enterprise/conftest.py
+++ b/tests/enterprise/conftest.py
@@ -35,7 +35,6 @@ def setup_and_teardown():
         0, os.path.abspath("../..")
     )  # Adds the project directory to the system path
 
-    import litellm
     from litellm import Router
 
     importlib.reload(litellm)

--- a/tests/enterprise/litellm_enterprise/integrations/test_prometheus.py
+++ b/tests/enterprise/litellm_enterprise/integrations/test_prometheus.py
@@ -755,7 +755,6 @@ class MockHistogram:
 @pytest.fixture
 def mock_prometheus_logger():
     """Create a PrometheusLogger with mocked metrics to test increment logic"""
-    from unittest.mock import patch
 
     collectors = list(REGISTRY._collector_to_names.keys())
     for collector in collectors:
@@ -1186,7 +1185,7 @@ async def test_langfuse_callback_failure_metric(prometheus_logger):
     This test verifies that when Langfuse logging fails, the 
     litellm_callback_logging_failures_metric is incremented with callback_name="langfuse".
     """
-    from unittest.mock import MagicMock, patch
+    from unittest.mock import MagicMock
 
     from litellm.integrations.langfuse.langfuse_prompt_management import (
         LangfusePromptManagement,
@@ -1242,7 +1241,7 @@ async def test_langfuse_otel_callback_failure_metric(prometheus_logger):
     This test verifies that when Langfuse OTEL logging fails, the 
     litellm_callback_logging_failures_metric is incremented with callback_name="langfuse_otel".
     """
-    from unittest.mock import MagicMock, patch
+    from unittest.mock import MagicMock
 
     from litellm.integrations.langfuse.langfuse_otel import LangfuseOtelLogger
 

--- a/tests/enterprise/litellm_enterprise/integrations/test_prometheus_unit_tests.py
+++ b/tests/enterprise/litellm_enterprise/integrations/test_prometheus_unit_tests.py
@@ -19,7 +19,7 @@ import os
 sys.path.insert(
     0, os.path.abspath("../..")
 )  # Adds the parent directory to the system-path
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import pytest
 

--- a/tests/guardrails_tests/test_custom_guardrail.py
+++ b/tests/guardrails_tests/test_custom_guardrail.py
@@ -26,10 +26,8 @@ from litellm.integrations.custom_guardrail import CustomGuardrail
 
 from typing import Any, Dict, List, Literal, Optional, Union
 
-import litellm
 from litellm._logging import verbose_proxy_logger
 from litellm.caching.caching import DualCache
-from litellm.integrations.custom_guardrail import CustomGuardrail
 from litellm.proxy._types import UserAPIKeyAuth
 from litellm.proxy.guardrails.guardrail_helpers import should_proceed_based_on_metadata
 from litellm.types.guardrails import GuardrailEventHooks

--- a/tests/litellm_utils_tests/conftest.py
+++ b/tests/litellm_utils_tests/conftest.py
@@ -42,7 +42,6 @@ def setup_and_teardown():
         0, os.path.abspath("../..")
     )  # Adds the project directory to the system path
 
-    import litellm
 
     importlib.reload(litellm)
 

--- a/tests/litellm_utils_tests/test_aws_secret_manager.py
+++ b/tests/litellm_utils_tests/test_aws_secret_manager.py
@@ -13,8 +13,6 @@ import litellm.types.utils
 load_dotenv()
 import io
 
-import sys
-import os
 
 # Ensure the project root is in the Python path
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../../..")))

--- a/tests/litellm_utils_tests/test_hashicorp.py
+++ b/tests/litellm_utils_tests/test_hashicorp.py
@@ -4,7 +4,6 @@ import pytest
 from dotenv import load_dotenv
 
 load_dotenv()
-import os
 import httpx
 
 sys.path.insert(

--- a/tests/litellm_utils_tests/test_health_check.py
+++ b/tests/litellm_utils_tests/test_health_check.py
@@ -785,19 +785,19 @@ async def test_image_generation_health_check_prompt(monkeypatch):
 
     # Default prompt is used when env var is unset
     monkeypatch.delenv("DEFAULT_HEALTH_CHECK_PROMPT", raising=False)
-    litellm_constants, health_check = reload_modules()
-    health_check_calls = await run_health_check(health_check)
+    reloaded_constants, reloaded_health_check = reload_modules()
+    health_check_calls = await run_health_check(reloaded_health_check)
 
     assert len(health_check_calls) == 1
     assert (
-        health_check_calls[0]["prompt"] == litellm_constants.DEFAULT_HEALTH_CHECK_PROMPT
+        health_check_calls[0]["prompt"] == reloaded_constants.DEFAULT_HEALTH_CHECK_PROMPT
     )
 
     # Environment override should change the prompt without code changes
     override_prompt = "environment override prompt"
     monkeypatch.setenv("DEFAULT_HEALTH_CHECK_PROMPT", override_prompt)
-    litellm_constants, health_check = reload_modules()
-    health_check_calls = await run_health_check(health_check)
+    _, reloaded_health_check = reload_modules()
+    health_check_calls = await run_health_check(reloaded_health_check)
 
     assert len(health_check_calls) == 1
     assert health_check_calls[0]["prompt"] == override_prompt

--- a/tests/litellm_utils_tests/test_logging_callback_manager.py
+++ b/tests/litellm_utils_tests/test_logging_callback_manager.py
@@ -243,7 +243,7 @@ async def test_slack_alerting_callback_registration(callback_manager):
     from litellm.caching.caching import DualCache
     from litellm.proxy.utils import ProxyLogging
     from litellm.integrations.SlackAlerting.slack_alerting import SlackAlerting
-    from unittest.mock import AsyncMock, patch
+    from unittest.mock import patch
 
     # Mock the async HTTP handler
     with patch(

--- a/tests/litellm_utils_tests/test_proxy_budget_reset.py
+++ b/tests/litellm_utils_tests/test_proxy_budget_reset.py
@@ -8,7 +8,6 @@ import pytest
 from dotenv import load_dotenv
 
 load_dotenv()
-import os
 
 from litellm.proxy._types import LiteLLM_BudgetTableFull
 

--- a/tests/litellm_utils_tests/test_secret_manager.py
+++ b/tests/litellm_utils_tests/test_secret_manager.py
@@ -9,7 +9,6 @@ from dotenv import load_dotenv
 import json
 
 load_dotenv()
-import os
 import tempfile
 from uuid import uuid4
 

--- a/tests/llm_responses_api_testing/base_responses_api.py
+++ b/tests/llm_responses_api_testing/base_responses_api.py
@@ -16,7 +16,6 @@ import litellm
 from abc import ABC, abstractmethod
 
 from litellm.integrations.custom_logger import CustomLogger
-import json
 from litellm.types.utils import StandardLoggingPayload
 from litellm.types.llms.openai import (
     ResponseCompletedEvent,

--- a/tests/llm_responses_api_testing/conftest.py
+++ b/tests/llm_responses_api_testing/conftest.py
@@ -81,7 +81,6 @@ def setup_and_teardown():
         0, os.path.abspath("../..")
     )  # Adds the project directory to the system path
 
-    import litellm
 
     importlib.reload(litellm)
 

--- a/tests/llm_responses_api_testing/test_anthropic_responses_api.py
+++ b/tests/llm_responses_api_testing/test_anthropic_responses_api.py
@@ -24,7 +24,6 @@ from litellm.types.llms.openai import (
     ResponseAPIUsage,
     IncompleteDetails,
 )
-import litellm
 from litellm.llms.custom_httpx.http_handler import AsyncHTTPHandler
 from base_responses_api import BaseResponsesAPITest
 from openai.types.responses.function_tool import FunctionTool

--- a/tests/llm_responses_api_testing/test_azure_responses_api.py
+++ b/tests/llm_responses_api_testing/test_azure_responses_api.py
@@ -52,7 +52,7 @@ async def test_azure_responses_api_status_error():
     Test that 'status' field is not sent in the final request body to Azure API.
     The status field should be filtered out from input messages before making the API call.
     """
-    from unittest.mock import AsyncMock, MagicMock
+    from unittest.mock import MagicMock
     import json
 
     request_data = {
@@ -193,7 +193,6 @@ async def test_azure_responses_api_headers_with_llm_provider_prefix():
     in response._hidden_params["headers"] instead of additional_headers, making them
     accessible via completion.headers in the same way as the completion API.
     """
-    import json
     import httpx
 
     mock_response_data = {

--- a/tests/llm_responses_api_testing/test_openai_responses_api.py
+++ b/tests/llm_responses_api_testing/test_openai_responses_api.py
@@ -13,7 +13,6 @@ import json
 sys.path.insert(0, os.path.abspath("../.."))
 import litellm
 from litellm.integrations.custom_logger import CustomLogger
-import json
 from litellm.types.utils import StandardLoggingPayload
 from litellm.types.llms.openai import (
     ResponseCompletedEvent,

--- a/tests/llm_translation/test_anthropic_completion.py
+++ b/tests/llm_translation/test_anthropic_completion.py
@@ -14,7 +14,6 @@ from litellm.llms.anthropic.chat import ModelResponseIterator
 
 load_dotenv()
 import io
-import os
 
 sys.path.insert(
     0, os.path.abspath("../..")
@@ -360,7 +359,6 @@ def test_process_anthropic_headers_with_no_matching_headers():
 )
 def test_anthropic_tool_use(tool_type, tool_config, message_content):
     """Test Anthropic tool use with computer use and web fetch tools."""
-    from litellm import completion
 
     litellm._turn_on_debug()
 
@@ -951,7 +949,6 @@ def test_anthropic_citations_api():
     """
     Test the citations API
     """
-    from litellm import completion
 
     try:
         resp = completion(
@@ -997,7 +994,6 @@ def test_anthropic_citations_api():
 
 
 def test_anthropic_citations_api_streaming():
-    from litellm import completion
 
     resp = completion(
         model="claude-sonnet-4-5-20250929",
@@ -1044,7 +1040,6 @@ def test_anthropic_citations_api_streaming():
     ],
 )
 def test_anthropic_thinking_output(model):
-    from litellm import completion
 
     litellm._turn_on_debug()
 
@@ -1111,7 +1106,6 @@ def test_anthropic_thinking_output_stream(model):
 
 
 def test_anthropic_custom_headers():
-    from litellm import completion
     from litellm.llms.custom_httpx.http_handler import HTTPHandler
 
     client = HTTPHandler()
@@ -1528,7 +1522,6 @@ def test_anthropic_tool_cache_control():
 
 
 def test_anthropic_streaming():
-    from litellm import completion
 
     request_data = {
         "messages": [

--- a/tests/llm_translation/test_azure_ai.py
+++ b/tests/llm_translation/test_azure_ai.py
@@ -19,7 +19,6 @@ from litellm.llms.custom_httpx.http_handler import HTTPHandler
 
 load_dotenv()
 import io
-import os
 
 sys.path.insert(
     0, os.path.abspath("../..")

--- a/tests/llm_translation/test_azure_openai.py
+++ b/tests/llm_translation/test_azure_openai.py
@@ -255,7 +255,6 @@ def test_get_azure_ad_token_from_username_password(
 
 
 def test_azure_openai_gpt_4o_naming(monkeypatch):
-    from openai import AzureOpenAI
     from pydantic import BaseModel, Field
 
     monkeypatch.setenv("AZURE_API_VERSION", "2024-10-21")
@@ -302,7 +301,6 @@ def test_azure_gpt_4o_with_tool_call_and_response_format(api_version):
     from pydantic import BaseModel
     import litellm
 
-    from openai import AzureOpenAI
 
     client = AzureOpenAI(
         api_key="fake-key",

--- a/tests/llm_translation/test_bedrock_agents.py
+++ b/tests/llm_translation/test_bedrock_agents.py
@@ -8,7 +8,6 @@ import litellm.types
 
 load_dotenv()
 import io
-import os
 import json
 
 sys.path.insert(
@@ -67,7 +66,7 @@ async def test_bedrock_agents_with_streaming():
 
 def test_bedrock_agents_with_custom_params():
     litellm._turn_on_debug()
-    from unittest.mock import MagicMock, patch
+    from unittest.mock import MagicMock
     from litellm.llms.custom_httpx.http_handler import HTTPHandler
 
     client = HTTPHandler()

--- a/tests/llm_translation/test_bedrock_completion.py
+++ b/tests/llm_translation/test_bedrock_completion.py
@@ -13,7 +13,6 @@ import litellm.types
 
 load_dotenv()
 import io
-import os
 import json
 
 sys.path.insert(

--- a/tests/llm_translation/test_bedrock_dynamic_auth_params_unit_tests.py
+++ b/tests/llm_translation/test_bedrock_dynamic_auth_params_unit_tests.py
@@ -15,13 +15,7 @@ from litellm.llms.custom_httpx.http_handler import HTTPHandler
 from unittest.mock import Mock
 from litellm.llms.bedrock.base_aws_llm import BaseAWSLLM
 
-import json
-import pytest
-from unittest.mock import patch, Mock
 
-import litellm
-from litellm.llms.custom_httpx.http_handler import HTTPHandler
-from litellm.llms.bedrock.base_aws_llm import BaseAWSLLM
 
 
 def test_bedrock_completion_with_region_name():

--- a/tests/llm_translation/test_bedrock_govcloud.py
+++ b/tests/llm_translation/test_bedrock_govcloud.py
@@ -475,7 +475,6 @@ class TestBedrockGovCloudSupport:
     @patch("litellm.llms.custom_httpx.http_handler.HTTPHandler.post")
     def test_govcloud_completion_with_cost_tracking(self, mock_post):
         """Test that completion requests with cost tracking use correct pricing for GovCloud models"""
-        from litellm import completion
         from unittest.mock import Mock
         import json
 

--- a/tests/llm_translation/test_cohere.py
+++ b/tests/llm_translation/test_cohere.py
@@ -6,7 +6,6 @@ from dotenv import load_dotenv
 
 load_dotenv()
 import io
-import os
 
 sys.path.insert(
     0, os.path.abspath("../..")
@@ -18,7 +17,6 @@ import pytest
 import litellm
 from litellm import RateLimitError, Timeout, completion, completion_cost, embedding
 from unittest.mock import AsyncMock, patch
-from litellm import RateLimitError, Timeout, completion, completion_cost, embedding
 from litellm.llms.custom_httpx.http_handler import AsyncHTTPHandler
 
 litellm.num_retries = 3

--- a/tests/llm_translation/test_infinity.py
+++ b/tests/llm_translation/test_infinity.py
@@ -11,11 +11,9 @@ sys.path.insert(
 
 import litellm
 
-import json
 import os
 import sys
-from datetime import datetime
-from unittest.mock import patch, MagicMock, AsyncMock
+from unittest.mock import patch, MagicMock
 
 import pytest
 
@@ -23,7 +21,6 @@ sys.path.insert(
     0, os.path.abspath("../..")
 )  # Adds the parent directory to the system-path
 from test_rerank import assert_response_shape
-import litellm
 
 from base_embedding_unit_tests import BaseLLMEmbeddingTest
 from litellm.llms.custom_httpx.http_handler import HTTPHandler, AsyncHTTPHandler

--- a/tests/llm_translation/test_minimax_tts.py
+++ b/tests/llm_translation/test_minimax_tts.py
@@ -139,7 +139,6 @@ class TestMinimaxTextToSpeechConfig:
 
         # Mock both litellm.api_key and get_secret_str to return None
         import litellm
-        from unittest.mock import patch
 
         original_api_key = litellm.api_key
         try:
@@ -274,7 +273,6 @@ class TestMinimaxSpeechIntegration:
 
     def test_speech_mock_response(self):
         """Test speech synthesis with mocked response"""
-        from unittest.mock import MagicMock, patch
 
         # Create mock audio data (hex-encoded as MiniMax returns)
         mock_audio_bytes = b"fake audio data for testing"

--- a/tests/llm_translation/test_mistral_api.py
+++ b/tests/llm_translation/test_mistral_api.py
@@ -11,7 +11,6 @@ from litellm.llms.anthropic.chat import ModelResponseIterator
 
 load_dotenv()
 import io
-import os
 
 sys.path.insert(
     0, os.path.abspath("../..")

--- a/tests/llm_translation/test_nvidia_nim.py
+++ b/tests/llm_translation/test_nvidia_nim.py
@@ -11,13 +11,12 @@ sys.path.insert(
 
 import httpx
 import pytest
-from unittest.mock import patch, MagicMock, AsyncMock
+from unittest.mock import patch, MagicMock
 
 import litellm
 from litellm import Choices, Message, ModelResponse, EmbeddingResponse, Usage
 from litellm import completion
 from base_rerank_unit_tests import BaseLLMRerankTest
-import litellm
 
 
 def test_completion_nvidia_nim():

--- a/tests/llm_translation/test_openai_o1.py
+++ b/tests/llm_translation/test_openai_o1.py
@@ -134,7 +134,6 @@ def test_litellm_responses():
     """
     ensures that type of completion_tokens_details is correctly handled / returned
     """
-    from litellm import ModelResponse
     from litellm.types.utils import CompletionTokensDetails
 
     response = ModelResponse(

--- a/tests/llm_translation/test_rerank.py
+++ b/tests/llm_translation/test_rerank.py
@@ -8,7 +8,6 @@ from dotenv import load_dotenv
 
 load_dotenv()
 import io
-import os
 from typing import Optional, Dict
 
 sys.path.insert(

--- a/tests/llm_translation/test_text_completion_unit_tests.py
+++ b/tests/llm_translation/test_text_completion_unit_tests.py
@@ -6,7 +6,7 @@ from unittest.mock import AsyncMock
 import pytest
 import httpx
 from respx import MockRouter
-from unittest.mock import patch, MagicMock, AsyncMock
+from unittest.mock import patch, MagicMock
 
 sys.path.insert(
     0, os.path.abspath("../..")

--- a/tests/llm_translation/test_triton.py
+++ b/tests/llm_translation/test_triton.py
@@ -15,9 +15,7 @@ sys.path.insert(
 import pytest
 import litellm
 
-import pytest
 from litellm.llms.triton.embedding.transformation import TritonEmbeddingConfig
-import litellm
 
 from tests.fake_openai_endpoint import FAKE_OPENAI_API_BASE
 

--- a/tests/llm_translation/test_unit_test_bedrock_invoke.py
+++ b/tests/llm_translation/test_unit_test_bedrock_invoke.py
@@ -9,7 +9,6 @@ import json
 
 load_dotenv()
 import io
-import os
 
 sys.path.insert(0, os.path.abspath("../.."))
 from unittest.mock import AsyncMock, Mock, patch

--- a/tests/load_tests/conftest.py
+++ b/tests/load_tests/conftest.py
@@ -1,0 +1,5 @@
+from tests.load_tests.memory_leak_utils import (  # noqa: F401  # re-exported so pytest resolves these fixtures by name
+    limit_memory,
+    mock_server,
+    test_router,
+)

--- a/tests/load_tests/test_linear_memory_growth.py
+++ b/tests/load_tests/test_linear_memory_growth.py
@@ -21,12 +21,7 @@ pytest tests/load_tests/test_linear_memory_growth.py -v
 
 import pytest
 
-from tests.load_tests.memory_leak_utils import (
-    limit_memory,  # noqa: F401  # pytest fixture used via dependency injection
-    mock_server,  # noqa: F401  # pytest fixture used via dependency injection
-    run_memory_baseline_test,
-    test_router,  # noqa: F401  # pytest fixture used via dependency injection
-)
+from tests.load_tests.memory_leak_utils import run_memory_baseline_test
 
 # Memory limit for all linear memory growth tests
 MEMORY_LIMIT = "40 MB"

--- a/tests/load_tests/test_memory_usage.py
+++ b/tests/load_tests/test_memory_usage.py
@@ -8,7 +8,6 @@ from dotenv import load_dotenv
 
 load_dotenv()
 import io
-import os
 
 sys.path.insert(
     0, os.path.abspath("../..")
@@ -21,13 +20,11 @@ from litellm.router import Router
 from typing import Optional
 from unittest.mock import MagicMock, patch
 
-import asyncio
 import pytest
 import os
 import litellm
 from typing import Callable, Any
 
-import tracemalloc
 import gc
 from typing import Type
 from pydantic import BaseModel

--- a/tests/local_testing/cache_unit_tests.py
+++ b/tests/local_testing/cache_unit_tests.py
@@ -9,7 +9,6 @@ from litellm._uuid import uuid
 from dotenv import load_dotenv
 
 load_dotenv()
-import os
 
 sys.path.insert(
     0, os.path.abspath("../..")

--- a/tests/local_testing/test_acompletion_fallbacks.py
+++ b/tests/local_testing/test_acompletion_fallbacks.py
@@ -12,7 +12,6 @@ sys.path.insert(
 import concurrent
 
 from dotenv import load_dotenv
-import asyncio
 import litellm
 
 

--- a/tests/local_testing/test_aim_guardrails.py
+++ b/tests/local_testing/test_aim_guardrails.py
@@ -463,7 +463,6 @@ async def test_post_call_stream__all_chunks_are_valid(monkeypatch, length: int):
 
 @pytest.mark.asyncio
 async def test_post_call_stream__blocked_chunks(monkeypatch):
-    from litellm.proxy.proxy_server import StreamingCallbackError
 
     init_guardrails_v2(
         all_guardrails=[

--- a/tests/local_testing/test_amazing_vertex_completion.py
+++ b/tests/local_testing/test_amazing_vertex_completion.py
@@ -6,7 +6,6 @@ from dotenv import load_dotenv
 
 load_dotenv()
 import io
-import os
 
 from test_streaming import streaming_format_tests
 

--- a/tests/local_testing/test_anthropic_prompt_caching.py
+++ b/tests/local_testing/test_anthropic_prompt_caching.py
@@ -7,7 +7,6 @@ from dotenv import load_dotenv
 
 load_dotenv()
 import io
-import os
 
 from test_streaming import streaming_format_tests
 
@@ -210,7 +209,6 @@ def anthropic_messages():
 @pytest.mark.asyncio
 async def test_anthropic_vertex_ai_prompt_caching(anthropic_messages, sync_mode):
     litellm._turn_on_debug()
-    from litellm.llms.custom_httpx.http_handler import HTTPHandler, AsyncHTTPHandler
 
     load_vertex_ai_credentials()
 

--- a/tests/local_testing/test_auth_utils.py
+++ b/tests/local_testing/test_auth_utils.py
@@ -6,7 +6,6 @@ import traceback
 from dotenv import load_dotenv
 
 load_dotenv()
-import os
 
 sys.path.insert(
     0, os.path.abspath("../..")

--- a/tests/local_testing/test_azure_openai.py
+++ b/tests/local_testing/test_azure_openai.py
@@ -7,7 +7,6 @@ from dotenv import load_dotenv
 
 load_dotenv()
 import io
-import os
 
 sys.path.insert(
     0, os.path.abspath("../..")

--- a/tests/local_testing/test_basic_python_version.py
+++ b/tests/local_testing/test_basic_python_version.py
@@ -215,9 +215,7 @@ def test_locked_aiohttp_version_is_not_pool_poisoning():
 
 import os
 import subprocess
-import time
 
-import pytest
 import requests
 
 

--- a/tests/local_testing/test_blocked_user_list.py
+++ b/tests/local_testing/test_blocked_user_list.py
@@ -14,12 +14,10 @@ from dotenv import load_dotenv
 from fastapi import Request
 
 load_dotenv()
-import os
 
 sys.path.insert(
     0, os.path.abspath("../..")
 )  # Adds the parent directory to the system path
-import asyncio
 import logging
 
 import pytest
@@ -57,7 +55,6 @@ verbose_proxy_logger.setLevel(level=logging.DEBUG)
 
 from starlette.datastructures import URL
 
-from litellm.caching.caching import DualCache
 from litellm.proxy._types import (
     BlockUsers,
     DynamoDBArgs,

--- a/tests/local_testing/test_braintrust.py
+++ b/tests/local_testing/test_braintrust.py
@@ -13,12 +13,10 @@ from dotenv import load_dotenv
 from fastapi import Request
 
 load_dotenv()
-import os
 
 sys.path.insert(
     0, os.path.abspath("../..")
 )  # Adds the parent directory to the system path
-import asyncio
 import logging
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -29,7 +27,6 @@ from litellm.llms.custom_httpx.http_handler import HTTPHandler
 
 
 def test_braintrust_logging():
-    import litellm
 
     litellm.set_verbose = True
 
@@ -53,7 +50,6 @@ def test_braintrust_logging():
 
 
 def test_braintrust_logging_specific_project_id():
-    import litellm
 
     litellm.set_verbose = True
 

--- a/tests/local_testing/test_caching.py
+++ b/tests/local_testing/test_caching.py
@@ -7,7 +7,6 @@ from litellm._uuid import uuid
 from dotenv import load_dotenv
 
 load_dotenv()
-import os
 import json
 
 sys.path.insert(
@@ -33,7 +32,6 @@ from datetime import timedelta
 messages = [{"role": "user", "content": "who is ishaan Github?  "}]
 # comment
 
-import random
 import string
 
 

--- a/tests/local_testing/test_caching_ssl.py
+++ b/tests/local_testing/test_caching_ssl.py
@@ -7,7 +7,6 @@ import traceback
 from dotenv import load_dotenv
 
 load_dotenv()
-import os
 
 sys.path.insert(
     0, os.path.abspath("../..")

--- a/tests/local_testing/test_completion.py
+++ b/tests/local_testing/test_completion.py
@@ -7,7 +7,6 @@ from dotenv import load_dotenv
 
 load_dotenv()
 import io
-import os
 
 sys.path.insert(
     0, os.path.abspath("../..")
@@ -1380,7 +1379,6 @@ def test_ollama_image():
     """
 
     import base64
-    import io
 
     from PIL import Image
 

--- a/tests/local_testing/test_completion_with_retries.py
+++ b/tests/local_testing/test_completion_with_retries.py
@@ -3,7 +3,6 @@ import traceback
 from dotenv import load_dotenv
 
 load_dotenv()
-import os
 
 sys.path.insert(
     0, os.path.abspath("../..")
@@ -207,7 +206,6 @@ async def test_responses_retry_on_auth_error(sync_mode):
     This validates that the @client decorator properly handles responses/aresponses retries.
     """
     from unittest.mock import patch
-    import openai
 
     num_retries = 2
 

--- a/tests/local_testing/test_config.py
+++ b/tests/local_testing/test_config.py
@@ -10,7 +10,6 @@ from dotenv import load_dotenv
 
 load_dotenv()
 import io
-import os
 
 sys.path.insert(
     0, os.path.abspath("../..")

--- a/tests/local_testing/test_cost_calc.py
+++ b/tests/local_testing/test_cost_calc.py
@@ -6,7 +6,6 @@ from dotenv import load_dotenv
 
 load_dotenv()
 import io
-import os
 
 sys.path.insert(
     0, os.path.abspath("../..")

--- a/tests/local_testing/test_dual_cache.py
+++ b/tests/local_testing/test_dual_cache.py
@@ -7,7 +7,6 @@ from litellm._uuid import uuid
 from dotenv import load_dotenv
 
 load_dotenv()
-import os
 
 sys.path.insert(
     0, os.path.abspath("../..")

--- a/tests/local_testing/test_dynamic_rate_limit_handler.py
+++ b/tests/local_testing/test_dynamic_rate_limit_handler.py
@@ -13,7 +13,6 @@ from typing import Optional, Tuple
 from dotenv import load_dotenv
 
 load_dotenv()
-import os
 
 sys.path.insert(
     0, os.path.abspath("../..")

--- a/tests/local_testing/test_embedding.py
+++ b/tests/local_testing/test_embedding.py
@@ -314,7 +314,6 @@ def test_openai_azure_embedding():
         pytest.fail(f"Error occurred: {e}")
 
 
-from openai.types.embedding import Embedding
 
 
 def _openai_mock_response(*args, **kwargs):
@@ -570,7 +569,6 @@ def test_hf_embedding():
 
 # test_hf_embedding()
 
-from unittest.mock import MagicMock, patch
 
 
 def tgi_mock_post(*args, **kwargs):

--- a/tests/local_testing/test_function_call_parsing.py
+++ b/tests/local_testing/test_function_call_parsing.py
@@ -8,7 +8,6 @@ from dotenv import load_dotenv
 
 load_dotenv()
 import io
-import os
 
 sys.path.insert(
     0, os.path.abspath("../..")

--- a/tests/local_testing/test_function_calling.py
+++ b/tests/local_testing/test_function_calling.py
@@ -6,7 +6,6 @@ from dotenv import load_dotenv
 
 load_dotenv()
 import io
-import os
 
 sys.path.insert(
     0, os.path.abspath("../..")

--- a/tests/local_testing/test_function_setup.py
+++ b/tests/local_testing/test_function_setup.py
@@ -5,7 +5,7 @@ import traceback
 from dotenv import load_dotenv
 
 load_dotenv()
-import os, io
+import io
 
 sys.path.insert(
     0, os.path.abspath("../..")

--- a/tests/local_testing/test_get_optional_params_embeddings.py
+++ b/tests/local_testing/test_get_optional_params_embeddings.py
@@ -5,7 +5,7 @@ import traceback
 from dotenv import load_dotenv
 
 load_dotenv()
-import os, io
+import io
 
 sys.path.insert(
     0, os.path.abspath("../..")

--- a/tests/local_testing/test_helicone_integration.py
+++ b/tests/local_testing/test_helicone_integration.py
@@ -131,7 +131,6 @@ def test_helicone_removes_otel_span_from_metadata():
     to prevent JSON serialization errors.
     """
     from litellm.integrations.helicone import HeliconeLogger
-    from unittest.mock import MagicMock
 
     # Create a mock span object (similar to what OpenTelemetry would create)
     mock_span = MagicMock()

--- a/tests/local_testing/test_least_busy_routing.py
+++ b/tests/local_testing/test_least_busy_routing.py
@@ -11,7 +11,6 @@ import traceback
 from dotenv import load_dotenv
 
 load_dotenv()
-import os
 
 sys.path.insert(
     0, os.path.abspath("../..")

--- a/tests/local_testing/test_llm_guard.py
+++ b/tests/local_testing/test_llm_guard.py
@@ -9,7 +9,6 @@ import traceback
 from dotenv import load_dotenv
 
 load_dotenv()
-import os
 
 sys.path.insert(
     0, os.path.abspath("../..")

--- a/tests/local_testing/test_lowest_cost_routing.py
+++ b/tests/local_testing/test_lowest_cost_routing.py
@@ -7,7 +7,7 @@ import traceback
 from dotenv import load_dotenv
 
 load_dotenv()
-import os, copy
+import copy
 
 sys.path.insert(
     0, os.path.abspath("../..")

--- a/tests/local_testing/test_lowest_latency_routing.py
+++ b/tests/local_testing/test_lowest_latency_routing.py
@@ -13,7 +13,6 @@ from dotenv import load_dotenv
 
 load_dotenv()
 import copy
-import os
 
 sys.path.insert(
     0, os.path.abspath("../..")

--- a/tests/local_testing/test_ollama.py
+++ b/tests/local_testing/test_ollama.py
@@ -8,7 +8,6 @@ from dotenv import load_dotenv
 
 load_dotenv()
 import io
-import os
 
 sys.path.insert(
     0, os.path.abspath("../..")

--- a/tests/local_testing/test_openai_moderations_hook.py
+++ b/tests/local_testing/test_openai_moderations_hook.py
@@ -9,7 +9,6 @@ import traceback
 from dotenv import load_dotenv
 
 load_dotenv()
-import os
 
 sys.path.insert(
     0, os.path.abspath("../..")
@@ -41,8 +40,6 @@ async def test_openai_moderation_error_raising(monkeypatch):
     _api_key = hash_token("sk-12345")
     user_api_key_dict = UserAPIKeyAuth(api_key=_api_key)
     local_cache = DualCache()
-
-    from litellm.proxy.proxy_server import llm_router
 
     llm_router = litellm.Router(
         model_list=[

--- a/tests/local_testing/test_prompt_injection_detection.py
+++ b/tests/local_testing/test_prompt_injection_detection.py
@@ -7,7 +7,6 @@ import traceback
 from dotenv import load_dotenv
 
 load_dotenv()
-import os
 
 sys.path.insert(
     0, os.path.abspath("../..")

--- a/tests/local_testing/test_pydantic.py
+++ b/tests/local_testing/test_pydantic.py
@@ -6,7 +6,6 @@ from dotenv import load_dotenv
 
 load_dotenv()
 import io
-import os
 
 sys.path.insert(
     0, os.path.abspath("../..")

--- a/tests/local_testing/test_router_budget_limiter.py
+++ b/tests/local_testing/test_router_budget_limiter.py
@@ -4,7 +4,7 @@ import traceback
 from dotenv import load_dotenv
 
 load_dotenv()
-import os, copy
+import copy
 
 sys.path.insert(
     0, os.path.abspath("../..")

--- a/tests/local_testing/test_router_cooldown_handlers.py
+++ b/tests/local_testing/test_router_cooldown_handlers.py
@@ -536,7 +536,6 @@ async def test_high_traffic_cooldowns_all_healthy_deployments():
 
     all_deployment_ids = router.get_model_ids()
 
-    import random
     from collections import defaultdict
 
     # Create a defaultdict to track successes and failures for each model ID
@@ -629,7 +628,6 @@ async def test_high_traffic_cooldowns_one_bad_deployment():
 
     all_deployment_ids = router.get_model_ids()
 
-    import random
     from collections import defaultdict
 
     # Create a defaultdict to track successes and failures for each model ID
@@ -727,7 +725,6 @@ async def test_high_traffic_cooldowns_one_rate_limited_deployment():
 
     all_deployment_ids = router.get_model_ids()
 
-    import random
     from collections import defaultdict
 
     # Create a defaultdict to track successes and failures for each model ID

--- a/tests/local_testing/test_router_debug_logs.py
+++ b/tests/local_testing/test_router_debug_logs.py
@@ -10,7 +10,6 @@ sys.path.insert(
     0, os.path.abspath("../..")
 )  # Adds the parent directory to the system path
 
-import asyncio
 import logging
 
 import litellm

--- a/tests/local_testing/test_router_timeout.py
+++ b/tests/local_testing/test_router_timeout.py
@@ -150,7 +150,6 @@ def test_router_timeout_with_retries_anthropic_model(num_retries, expected_call_
     If request hits custom timeout, ensure it's retried.
     """
     from litellm.llms.custom_httpx.http_handler import HTTPHandler
-    import time
 
     litellm.num_retries = num_retries
     litellm.request_timeout = 0.000001

--- a/tests/local_testing/test_sagemaker.py
+++ b/tests/local_testing/test_sagemaker.py
@@ -7,7 +7,6 @@ from dotenv import load_dotenv
 
 load_dotenv()
 import io
-import os
 import litellm
 from test_streaming import streaming_format_tests
 
@@ -20,7 +19,6 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-import litellm
 from litellm import RateLimitError, Timeout, completion, completion_cost, embedding
 from litellm.llms.custom_httpx.http_handler import AsyncHTTPHandler, HTTPHandler
 from litellm.litellm_core_utils.prompt_templates.factory import anthropic_messages_pt

--- a/tests/local_testing/test_secret_detect_hook.py
+++ b/tests/local_testing/test_secret_detect_hook.py
@@ -15,7 +15,6 @@ from datetime import datetime
 from dotenv import load_dotenv
 
 load_dotenv()
-import os
 
 sys.path.insert(
     0, os.path.abspath("../..")
@@ -34,7 +33,6 @@ from litellm_enterprise.enterprise_callbacks.secret_detection import (
 )
 from litellm.proxy.proxy_server import chat_completion
 from litellm.proxy.utils import ProxyLogging, hash_token
-from litellm.router import Router
 
 from tests.fake_openai_endpoint import FAKE_OPENAI_API_BASE
 

--- a/tests/local_testing/test_stream_chunk_builder.py
+++ b/tests/local_testing/test_stream_chunk_builder.py
@@ -9,11 +9,11 @@ from typing import List
 from litellm.types.utils import StreamingChoices, ChatCompletionAudioResponse
 
 
-def check_non_streaming_response(completion):
-    assert completion.choices[0].message.audio is not None, "Audio response is missing"
-    print("audio", completion.choices[0].message.audio)
+def check_non_streaming_response(response):
+    assert response.choices[0].message.audio is not None, "Audio response is missing"
+    print("audio", response.choices[0].message.audio)
     assert isinstance(
-        completion.choices[0].message.audio, ChatCompletionAudioResponse
+        response.choices[0].message.audio, ChatCompletionAudioResponse
     ), "Invalid audio response type"
     assert len(completion.choices[0].message.audio.data) > 0, "Audio data is empty"
 
@@ -594,7 +594,6 @@ def test_stream_chunk_builder_multiple_tool_calls():
 
 
 def test_stream_chunk_builder_openai_prompt_caching():
-    from openai import OpenAI
     from pydantic import BaseModel
 
     client = OpenAI(
@@ -639,7 +638,6 @@ def test_stream_chunk_builder_openai_prompt_caching():
 @pytest.mark.flaky(retries=5, delay=2)
 def test_stream_chunk_builder_openai_audio_output_usage():
     from pydantic import BaseModel
-    from openai import OpenAI
     from typing import Optional
 
     client = OpenAI(
@@ -720,7 +718,6 @@ def test_stream_chunk_builder_tool_calls_list():
         Function,
         ModelResponseStream,
         Delta,
-        StreamingChoices,
         ChatCompletionDeltaToolCall,
     )
 

--- a/tests/local_testing/test_streaming.py
+++ b/tests/local_testing/test_streaming.py
@@ -951,7 +951,6 @@ def test_vertex_ai_stream(provider):
 
     load_vertex_ai_credentials()
     litellm.set_verbose = True
-    import random
 
     test_models = ["gemini-2.5-flash-lite"]
     for model in test_models:
@@ -2352,7 +2351,6 @@ def test_success_callback_streaming():
 from typing import List, Optional
 
 #### STREAMING + FUNCTION CALLING ###
-from pydantic import BaseModel
 
 
 class Function(BaseModel):
@@ -2569,7 +2567,6 @@ def test_azure_streaming_and_function_calling():
 
 @pytest.mark.asyncio
 async def test_azure_astreaming_and_function_calling():
-    from litellm._uuid import uuid
 
     tools = [
         {

--- a/tests/local_testing/test_text_completion.py
+++ b/tests/local_testing/test_text_completion.py
@@ -8,7 +8,6 @@ from dotenv import load_dotenv
 
 load_dotenv()
 import io
-import os
 
 sys.path.insert(
     0, os.path.abspath("../..")

--- a/tests/local_testing/test_tpm_rpm_routing_v2.py
+++ b/tests/local_testing/test_tpm_rpm_routing_v2.py
@@ -12,7 +12,6 @@ from typing import Dict
 from dotenv import load_dotenv
 
 load_dotenv()
-import os
 
 sys.path.insert(
     0, os.path.abspath("../..")
@@ -399,9 +398,7 @@ async def test_multiple_potential_deployments(sync_mode):
 
 def test_single_deployment_tpm_zero():
     import os
-    from datetime import datetime
 
-    import litellm
 
     model_list = [
         {

--- a/tests/local_testing/test_update_spend.py
+++ b/tests/local_testing/test_update_spend.py
@@ -14,12 +14,10 @@ from dotenv import load_dotenv
 from fastapi import Request
 
 load_dotenv()
-import os
 
 sys.path.insert(
     0, os.path.abspath("../..")
 )  # Adds the parent directory to the system path
-import asyncio
 import logging
 
 import pytest
@@ -54,7 +52,6 @@ verbose_proxy_logger.setLevel(level=logging.DEBUG)
 
 from starlette.datastructures import URL
 
-from litellm.caching.caching import DualCache
 from litellm.proxy._types import (
     BlockUsers,
     DynamoDBArgs,

--- a/tests/logging_callback_tests/test_alerting.py
+++ b/tests/logging_callback_tests/test_alerting.py
@@ -19,7 +19,6 @@ from litellm.types.integrations.slack_alerting import AlertType
 # import logging
 # logging.basicConfig(level=logging.DEBUG)
 sys.path.insert(0, os.path.abspath("../.."))
-import asyncio
 import os
 import unittest.mock
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -132,8 +131,6 @@ def test_init():
     print("passed testing slack alerting init")
 
 
-from datetime import datetime, timedelta
-from unittest.mock import AsyncMock, patch
 
 
 @pytest.fixture
@@ -342,7 +339,6 @@ async def test_daily_reports_redis_cache_scheduler():
     # we need this to be 0 so it actualy sends the report
     slack_alerting.alerting_args.daily_report_frequency = 0
 
-    from litellm.router import AlertingConfig
 
     router = litellm.Router(
         model_list=[
@@ -382,7 +378,6 @@ async def test_daily_reports_redis_cache_scheduler():
 @pytest.mark.asyncio
 @pytest.mark.skip(reason="Local test. Test if slack alerts are sent.")
 async def test_send_llm_exception_to_slack():
-    from litellm.router import AlertingConfig
 
     # on async success
     router = litellm.Router(

--- a/tests/logging_callback_tests/test_built_in_tools_cost_tracking.py
+++ b/tests/logging_callback_tests/test_built_in_tools_cost_tracking.py
@@ -9,7 +9,6 @@ from fastapi.routing import APIRoute
 
 load_dotenv()
 import io
-import os
 import time
 import json
 
@@ -102,7 +101,6 @@ async def test_openai_web_search_logging_cost_tracking(
 ):
     """Test web search cost tracking with different search context sizes"""
     test_custom_logger = await _setup_web_search_test()
-    from litellm._uuid import uuid
 
     request_kwargs = {
         "model": "openai/gpt-5-search-api",

--- a/tests/logging_callback_tests/test_gcs_pub_sub.py
+++ b/tests/logging_callback_tests/test_gcs_pub_sub.py
@@ -15,7 +15,6 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
-import litellm
 from litellm import completion
 from litellm._logging import verbose_logger
 from litellm.integrations.gcs_pubsub.pub_sub import *

--- a/tests/logging_callback_tests/test_generic_api_callback.py
+++ b/tests/logging_callback_tests/test_generic_api_callback.py
@@ -16,7 +16,6 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
-import litellm
 from litellm import completion
 from litellm._logging import verbose_logger
 from litellm.integrations.gcs_pubsub.pub_sub import *

--- a/tests/logging_callback_tests/test_moderations_api_logging.py
+++ b/tests/logging_callback_tests/test_moderations_api_logging.py
@@ -9,7 +9,6 @@ from fastapi.routing import APIRoute
 
 load_dotenv()
 import io
-import os
 import time
 import json
 

--- a/tests/logging_callback_tests/test_opentelemetry_unit_tests.py
+++ b/tests/logging_callback_tests/test_opentelemetry_unit_tests.py
@@ -9,8 +9,6 @@ import traceback
 from dotenv import load_dotenv
 
 load_dotenv()
-import os
-import asyncio
 
 sys.path.insert(
     0, os.path.abspath("../..")

--- a/tests/logging_callback_tests/test_spend_logs.py
+++ b/tests/logging_callback_tests/test_spend_logs.py
@@ -9,7 +9,6 @@ from fastapi.routing import APIRoute
 
 load_dotenv()
 import io
-import os
 import time
 
 # this file is to test litellm/proxy

--- a/tests/logging_callback_tests/test_token_counting.py
+++ b/tests/logging_callback_tests/test_token_counting.py
@@ -9,7 +9,6 @@ from fastapi.routing import APIRoute
 
 load_dotenv()
 import io
-import os
 import time
 import json
 

--- a/tests/logging_callback_tests/test_unit_test_litellm_logging.py
+++ b/tests/logging_callback_tests/test_unit_test_litellm_logging.py
@@ -19,8 +19,6 @@ from litellm._service_logger import ServiceLogging
 import asyncio
 
 
-from litellm.litellm_core_utils.litellm_logging import Logging
-import litellm
 
 service_logger = ServiceLogging()
 

--- a/tests/logging_callback_tests/test_view_request_resp_logs.py
+++ b/tests/logging_callback_tests/test_view_request_resp_logs.py
@@ -10,9 +10,7 @@ import logging
 import tempfile
 from litellm._uuid import uuid
 
-import json
 from datetime import datetime, timedelta, timezone
-from datetime import datetime
 
 import pytest
 

--- a/tests/mcp_tests/conftest.py
+++ b/tests/mcp_tests/conftest.py
@@ -33,7 +33,6 @@ def setup_and_teardown():
         0, os.path.abspath("../..")
     )  # Adds the project directory to the system path
 
-    import litellm
     from litellm import Router
 
     importlib.reload(litellm)

--- a/tests/mcp_tests/test_mcp_litellm_client.py
+++ b/tests/mcp_tests/test_mcp_litellm_client.py
@@ -13,7 +13,6 @@ from mcp.client.stdio import stdio_client
 import os
 from litellm import experimental_mcp_client
 import litellm
-import pytest
 import json
 
 

--- a/tests/openai_endpoints_tests/test_openai_batches_endpoint.py
+++ b/tests/openai_endpoints_tests/test_openai_batches_endpoint.py
@@ -15,7 +15,6 @@ from unittest.mock import patch, MagicMock, AsyncMock
 BASE_URL = "http://localhost:4000"  # Replace with your actual base URL
 API_KEY = "sk-1234"  # Replace with your actual API key
 
-from openai import OpenAI
 
 client = OpenAI(base_url=BASE_URL, api_key=API_KEY)
 

--- a/tests/pass_through_unit_tests/test_assemblyai_unit_tests_passthrough.py
+++ b/tests/pass_through_unit_tests/test_assemblyai_unit_tests_passthrough.py
@@ -15,20 +15,13 @@ import litellm
 from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObj
 
 
-import json
 import os
 import sys
-from datetime import datetime
-from unittest.mock import AsyncMock, Mock, patch
 
 sys.path.insert(
     0, os.path.abspath("../..")
 )  # Adds the parent directory to the system-path
 
-import httpx
-import pytest
-import litellm
-from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObj
 from litellm.proxy.pass_through_endpoints.llm_provider_handlers.assembly_passthrough_logging_handler import (
     AssemblyAIPassthroughLoggingHandler,
     AssemblyAITranscriptResponse,

--- a/tests/pass_through_unit_tests/test_unit_test_passthrough_router.py
+++ b/tests/pass_through_unit_tests/test_unit_test_passthrough_router.py
@@ -7,7 +7,6 @@ from unittest.mock import AsyncMock, Mock, patch, MagicMock
 sys.path.insert(0, os.path.abspath("../.."))  #
 
 import unittest
-from unittest.mock import patch
 from litellm.proxy.pass_through_endpoints.passthrough_endpoint_router import (
     PassthroughEndpointRouter,
 )

--- a/tests/pass_through_unit_tests/test_vertex_ai_live_passthrough.py
+++ b/tests/pass_through_unit_tests/test_vertex_ai_live_passthrough.py
@@ -440,9 +440,6 @@ class TestVertexAILivePassthroughIntegration:
 
     def test_vertex_ai_live_route_detection(self):
         """Test that the route detection works correctly"""
-        from litellm.proxy.pass_through_endpoints.success_handler import (
-            PassThroughEndpointLogging,
-        )
 
         handler = PassThroughEndpointLogging()
 
@@ -464,9 +461,6 @@ class TestVertexAILivePassthroughIntegration:
         self, mock_handler_class, mock_logging_obj
     ):
         """Test the success handler integration with Vertex AI Live"""
-        from litellm.proxy.pass_through_endpoints.success_handler import (
-            PassThroughEndpointLogging,
-        )
 
         # Mock the handler
         mock_handler = MagicMock()

--- a/tests/proxy_admin_ui_tests/conftest.py
+++ b/tests/proxy_admin_ui_tests/conftest.py
@@ -22,7 +22,6 @@ def setup_and_teardown():
         0, os.path.abspath("../..")
     )  # Adds the project directory to the system path
 
-    import litellm
     from litellm import Router
 
     importlib.reload(litellm)

--- a/tests/proxy_admin_ui_tests/test_key_management.py
+++ b/tests/proxy_admin_ui_tests/test_key_management.py
@@ -12,7 +12,6 @@ from unittest.mock import MagicMock, patch
 
 load_dotenv()
 import io
-import os
 import time
 
 # this file is to test litellm/proxy
@@ -893,9 +892,6 @@ async def test_key_update_with_model_specific_params(prisma_client):
     setattr(litellm.proxy.proxy_server, "master_key", "sk-1234")
     await litellm.proxy.proxy_server.prisma_client.connect()
 
-    from litellm.proxy.management_endpoints.key_management_endpoints import (
-        update_key_fn,
-    )
     from litellm.proxy._types import UpdateKeyRequest
 
     new_key = await generate_key_fn(

--- a/tests/proxy_admin_ui_tests/test_role_based_access.py
+++ b/tests/proxy_admin_ui_tests/test_role_based_access.py
@@ -14,7 +14,6 @@ from fastapi.routing import APIRoute
 
 load_dotenv()
 import io
-import os
 import time
 
 # this file is to test litellm/proxy
@@ -77,7 +76,6 @@ from litellm.proxy.utils import PrismaClient, ProxyLogging, hash_token, update_s
 
 verbose_proxy_logger.setLevel(level=logging.DEBUG)
 
-from starlette.datastructures import URL
 
 from litellm.caching.caching import DualCache
 from litellm.proxy._types import *

--- a/tests/proxy_admin_ui_tests/test_route_check_unit_tests.py
+++ b/tests/proxy_admin_ui_tests/test_route_check_unit_tests.py
@@ -11,7 +11,6 @@ from fastapi.routing import APIRoute
 
 load_dotenv()
 import io
-import os
 import time
 
 
@@ -23,7 +22,7 @@ sys.path.insert(
 import asyncio
 import logging
 
-from fastapi import HTTPException, Request
+from fastapi import HTTPException
 import pytest
 from litellm.proxy.auth.route_checks import RouteChecks
 from litellm.proxy._types import LiteLLM_UserTable, LitellmUserRoles, UserAPIKeyAuth

--- a/tests/proxy_admin_ui_tests/test_usage_endpoints.py
+++ b/tests/proxy_admin_ui_tests/test_usage_endpoints.py
@@ -25,7 +25,6 @@ from fastapi.routing import APIRoute
 
 load_dotenv()
 import io
-import os
 import time
 
 # this file is to test litellm/proxy

--- a/tests/proxy_unit_tests/test_aproxy_startup.py
+++ b/tests/proxy_unit_tests/test_aproxy_startup.py
@@ -5,7 +5,7 @@ import traceback
 from dotenv import load_dotenv
 
 load_dotenv()
-import os, io
+import io
 
 # this file is to test litellm/proxy
 

--- a/tests/proxy_unit_tests/test_audit_logs_proxy.py
+++ b/tests/proxy_unit_tests/test_audit_logs_proxy.py
@@ -10,7 +10,6 @@ from fastapi.routing import APIRoute
 
 
 import io
-import os
 import time
 
 # this file is to test litellm/proxy
@@ -24,7 +23,6 @@ import logging
 load_dotenv()
 
 import pytest
-from litellm._uuid import uuid
 import litellm
 from litellm._logging import verbose_proxy_logger
 

--- a/tests/proxy_unit_tests/test_auth_checks.py
+++ b/tests/proxy_unit_tests/test_auth_checks.py
@@ -6,7 +6,6 @@ import traceback
 from dotenv import load_dotenv
 
 load_dotenv()
-import os
 
 sys.path.insert(
     0, os.path.abspath("../..")
@@ -478,7 +477,6 @@ async def test_virtual_key_max_budget_check(
     2. Raises BudgetExceededError when spend >= max_budget
     """
     from litellm.proxy.auth.auth_checks import _virtual_key_max_budget_check
-    from litellm.proxy.utils import ProxyLogging
 
     # Setup test data
     valid_token = UserAPIKeyAuth(
@@ -836,7 +834,6 @@ async def test_can_user_call_model_with_no_default_models():
 @pytest.mark.asyncio
 async def test_get_fuzzy_user_object():
     from litellm.proxy.auth.auth_checks import _get_fuzzy_user_object
-    from litellm.proxy.utils import PrismaClient
     from unittest.mock import AsyncMock, MagicMock
 
     # Setup mock Prisma client

--- a/tests/proxy_unit_tests/test_banned_keyword_list.py
+++ b/tests/proxy_unit_tests/test_banned_keyword_list.py
@@ -8,7 +8,6 @@ import traceback
 from dotenv import load_dotenv
 
 load_dotenv()
-import os
 
 sys.path.insert(
     0, os.path.abspath("../..")

--- a/tests/proxy_unit_tests/test_e2e_pod_lock_manager.py
+++ b/tests/proxy_unit_tests/test_e2e_pod_lock_manager.py
@@ -14,7 +14,6 @@ from unittest.mock import MagicMock, patch
 
 load_dotenv()
 import io
-import os
 import time
 import fakeredis
 

--- a/tests/proxy_unit_tests/test_jwt.py
+++ b/tests/proxy_unit_tests/test_jwt.py
@@ -14,7 +14,6 @@ from litellm._uuid import uuid
 from dotenv import load_dotenv
 
 load_dotenv()
-import os
 
 sys.path.insert(
     0, os.path.abspath("../..")

--- a/tests/proxy_unit_tests/test_key_generate_prisma.py
+++ b/tests/proxy_unit_tests/test_key_generate_prisma.py
@@ -33,7 +33,6 @@ import httpx
 
 load_dotenv()
 import io
-import os
 import time
 
 # this file is to test litellm/proxy

--- a/tests/proxy_unit_tests/test_proxy_config_unit_test.py
+++ b/tests/proxy_unit_tests/test_proxy_config_unit_test.py
@@ -11,7 +11,6 @@ import litellm.proxy.proxy_server
 
 load_dotenv()
 import io
-import os
 
 # this file is to test litellm/proxy
 

--- a/tests/proxy_unit_tests/test_proxy_custom_auth.py
+++ b/tests/proxy_unit_tests/test_proxy_custom_auth.py
@@ -6,7 +6,6 @@ from dotenv import load_dotenv
 
 load_dotenv()
 import io
-import os
 
 # this file is to test litellm/proxy
 

--- a/tests/proxy_unit_tests/test_proxy_custom_logger.py
+++ b/tests/proxy_unit_tests/test_proxy_custom_logger.py
@@ -3,7 +3,7 @@ import traceback
 from dotenv import load_dotenv
 
 load_dotenv()
-import os, io, asyncio
+import io, asyncio
 
 # this file is to test litellm/proxy
 

--- a/tests/proxy_unit_tests/test_proxy_encrypt_decrypt.py
+++ b/tests/proxy_unit_tests/test_proxy_encrypt_decrypt.py
@@ -6,7 +6,6 @@ from dotenv import load_dotenv
 
 load_dotenv()
 import io
-import os
 
 sys.path.insert(
     0, os.path.abspath("../..")

--- a/tests/proxy_unit_tests/test_proxy_exception_mapping.py
+++ b/tests/proxy_unit_tests/test_proxy_exception_mapping.py
@@ -10,7 +10,6 @@ from dotenv import load_dotenv
 load_dotenv()
 import asyncio
 import io
-import os
 
 sys.path.insert(
     0, os.path.abspath("../..")

--- a/tests/proxy_unit_tests/test_proxy_pass_user_config.py
+++ b/tests/proxy_unit_tests/test_proxy_pass_user_config.py
@@ -3,7 +3,7 @@ import traceback
 from dotenv import load_dotenv
 
 load_dotenv()
-import os, io
+import io
 
 # this file is to test litellm/proxy
 

--- a/tests/proxy_unit_tests/test_proxy_reject_logging.py
+++ b/tests/proxy_unit_tests/test_proxy_reject_logging.py
@@ -18,7 +18,6 @@ from datetime import datetime
 from dotenv import load_dotenv
 
 load_dotenv()
-import os
 
 sys.path.insert(
     0, os.path.abspath("../..")
@@ -45,7 +44,6 @@ from litellm.proxy.proxy_server import (
     embeddings,
 )
 from litellm.proxy.utils import ProxyLogging, hash_token
-from litellm.router import Router
 
 
 class testLogger(CustomLogger):

--- a/tests/proxy_unit_tests/test_proxy_routes.py
+++ b/tests/proxy_unit_tests/test_proxy_routes.py
@@ -5,7 +5,6 @@ from dotenv import load_dotenv
 
 load_dotenv()
 import io
-import os
 
 # this file is to test litellm/proxy
 

--- a/tests/proxy_unit_tests/test_proxy_server.py
+++ b/tests/proxy_unit_tests/test_proxy_server.py
@@ -11,7 +11,6 @@ import litellm.proxy.proxy_server
 load_dotenv()
 import io
 import json
-import os
 
 # this file is to test litellm/proxy
 
@@ -872,7 +871,6 @@ def test_health(client_no_auth):
 
 # test_add_new_model()
 
-from litellm.integrations.custom_logger import CustomLogger
 
 
 class MyCustomHandler(CustomLogger):
@@ -1110,7 +1108,7 @@ async def test_get_team_redis(client_no_auth):
 
 import random
 from litellm._uuid import uuid
-from unittest.mock import AsyncMock, MagicMock, PropertyMock, patch
+from unittest.mock import PropertyMock
 
 from litellm.proxy._types import (
     LitellmUserRoles,
@@ -1138,7 +1136,7 @@ def mock_prisma_client():
 )
 @pytest.mark.asyncio
 @pytest.mark.skip(reason="Requires reliable external DB connection (prisma).")
-async def test_create_user_default_budget(prisma_client, user_role):
+async def test_create_user_default_budget(prisma_client, user_role):  # noqa: F811  # pytest fixture, not a redefinition
 
     setattr(litellm.proxy.proxy_server, "prisma_client", prisma_client)
     setattr(litellm.proxy.proxy_server, "master_key", "sk-1234")
@@ -1179,7 +1177,7 @@ async def test_create_user_default_budget(prisma_client, user_role):
 @pytest.mark.parametrize("new_member_method", ["user_id", "user_email"])
 @pytest.mark.asyncio
 @pytest.mark.skip(reason="Requires reliable external DB connection (prisma).")
-async def test_create_team_member_add(prisma_client, new_member_method):
+async def test_create_team_member_add(prisma_client, new_member_method):  # noqa: F811  # pytest fixture, not a redefinition
     import time
 
     from fastapi import Request
@@ -1291,7 +1289,7 @@ async def test_create_team_member_add(prisma_client, new_member_method):
 @pytest.mark.parametrize("team_route", ["/team/member_add", "/team/member_delete"])
 @pytest.mark.asyncio
 async def test_create_team_member_add_team_admin_user_api_key_auth(
-    prisma_client, team_member_role, team_route
+    prisma_client, team_member_role, team_route  # noqa: F811  # pytest fixture, not a redefinition
 ):
     import time
 
@@ -1353,7 +1351,7 @@ async def test_create_team_member_add_team_admin_user_api_key_auth(
 @pytest.mark.parametrize("user_role", ["admin", "user"])
 @pytest.mark.asyncio
 async def test_create_team_member_add_team_admin(
-    prisma_client, new_member_method, user_role
+    prisma_client, new_member_method, user_role  # noqa: F811  # pytest fixture, not a redefinition
 ):
     """
     Relevant issue - https://github.com/BerriAI/litellm/issues/5300
@@ -1495,7 +1493,7 @@ async def test_create_team_member_add_team_admin(
 
 @pytest.mark.asyncio
 @pytest.mark.skip(reason="Requires reliable external DB connection (prisma).")
-async def test_user_info_team_list(prisma_client):
+async def test_user_info_team_list(prisma_client):  # noqa: F811  # pytest fixture, not a redefinition
     """Assert user_info for admin calls team_list function"""
     from litellm.proxy._types import LiteLLM_UserTable
 
@@ -1535,7 +1533,7 @@ async def test_user_info_team_list(prisma_client):
 
 @pytest.mark.skip(reason="Local test")
 @pytest.mark.asyncio
-async def test_add_callback_via_key(prisma_client):
+async def test_add_callback_via_key(prisma_client):  # noqa: F811  # pytest fixture, not a redefinition
     """
     Test if callback specified in key, is used.
     """
@@ -2151,7 +2149,7 @@ async def test_model_info_alias_without_prisma(hidden):
 @pytest.mark.parametrize("hidden", [True, False])
 @pytest.mark.asyncio
 @pytest.mark.skip(reason="Requires reliable external DB connection (prisma).")
-async def test_proxy_model_group_alias_checks(prisma_client, hidden):
+async def test_proxy_model_group_alias_checks(prisma_client, hidden):  # noqa: F811  # pytest fixture, not a redefinition
     """
     Check if model group alias is returned on
 
@@ -2232,7 +2230,7 @@ async def test_proxy_model_group_alias_checks(prisma_client, hidden):
 
 @pytest.mark.asyncio
 @pytest.mark.skip(reason="Requires reliable external DB connection (prisma).")
-async def test_proxy_model_group_info_rerank(prisma_client):
+async def test_proxy_model_group_info_rerank(prisma_client):  # noqa: F811  # pytest fixture, not a redefinition
     """
     Check if rerank model is returned on the following endpoints
 
@@ -3035,7 +3033,7 @@ async def test_update_config_success_callback_normalization():
     setattr(proxy_server, "prisma_client", MockPrisma())
 
     class MockProxyConfig:
-        async def add_deployment(self, prisma_client=None, proxy_logging_obj=None):
+        async def add_deployment(self, prisma_client=None, proxy_logging_obj=None):  # noqa: F811  # pytest fixture, not a redefinition
             return None
 
     setattr(proxy_server, "proxy_config", MockProxyConfig())

--- a/tests/proxy_unit_tests/test_proxy_setting_guardrails.py
+++ b/tests/proxy_unit_tests/test_proxy_setting_guardrails.py
@@ -8,7 +8,6 @@ from dotenv import load_dotenv
 load_dotenv()
 import asyncio
 import io
-import os
 
 sys.path.insert(
     0, os.path.abspath("../..")

--- a/tests/proxy_unit_tests/test_unit_test_proxy_hooks.py
+++ b/tests/proxy_unit_tests/test_unit_test_proxy_hooks.py
@@ -17,7 +17,6 @@ async def test_disable_spend_logs():
     Test that the spend logs are not written to the database when disable_spend_logs is True
     """
     # Mock the necessary components
-    import asyncio
 
     mock_prisma_client = Mock()
     mock_prisma_client.spend_log_transactions = []

--- a/tests/proxy_unit_tests/test_user_api_key_auth.py
+++ b/tests/proxy_unit_tests/test_user_api_key_auth.py
@@ -559,7 +559,6 @@ def test_get_api_key_from_custom_header_different_casing():
     )
 
 
-from litellm.proxy._types import LitellmUserRoles
 
 
 @pytest.mark.parametrize(

--- a/tests/router_unit_tests/conftest.py
+++ b/tests/router_unit_tests/conftest.py
@@ -48,7 +48,6 @@ def setup_and_teardown():
         0, os.path.abspath("../..")
     )  # Adds the project directory to the system path
 
-    import litellm
 
     from litellm.litellm_core_utils.logging_worker import GLOBAL_LOGGING_WORKER
 

--- a/tests/router_unit_tests/test_router_cooldown_utils.py
+++ b/tests/router_unit_tests/test_router_cooldown_utils.py
@@ -27,10 +27,6 @@ from litellm.router_utils.router_callbacks.track_deployment_metrics import (
     increment_deployment_successes_for_current_minute,
 )
 
-import pytest
-from unittest.mock import patch
-from litellm import Router
-from litellm.router_utils.cooldown_handlers import _should_cooldown_deployment
 
 load_dotenv()
 

--- a/tests/router_unit_tests/test_router_index_management.py
+++ b/tests/router_unit_tests/test_router_index_management.py
@@ -2,7 +2,6 @@ import sys
 import os
 import pytest
 import ast
-import ast
 
 sys.path.insert(
     0, os.path.abspath("../..")

--- a/tests/store_model_in_db_tests/test_callbacks_in_db.py
+++ b/tests/store_model_in_db_tests/test_callbacks_in_db.py
@@ -14,7 +14,6 @@ import aiohttp
 import os
 import dotenv
 from dotenv import load_dotenv
-import pytest
 from openai import AsyncOpenAI, APIConnectionError
 from openai.types.chat import ChatCompletion
 

--- a/tests/store_model_in_db_tests/test_team_models.py
+++ b/tests/store_model_in_db_tests/test_team_models.py
@@ -5,7 +5,6 @@ import json
 from openai import AsyncOpenAI
 from litellm._uuid import uuid
 from httpx import AsyncClient
-from litellm._uuid import uuid
 import os
 
 TEST_MASTER_KEY = "sk-1234"

--- a/tests/test_callbacks_on_proxy.py
+++ b/tests/test_callbacks_on_proxy.py
@@ -13,7 +13,6 @@ import re
 import dotenv
 from collections import Counter
 from dotenv import load_dotenv
-import pytest
 
 load_dotenv()
 

--- a/tests/test_fallbacks.py
+++ b/tests/test_fallbacks.py
@@ -289,10 +289,8 @@ async def test_chat_completion_client_fallbacks_with_custom_message(has_access):
                 pytest.fail("Expected this to work: {}".format(str(e)))
 
 
-import asyncio
 from openai import AsyncOpenAI
 from typing import List
-import time
 
 
 async def make_request(client: AsyncOpenAI, model: str) -> bool:

--- a/tests/test_litellm/caching/test_caching_handler.py
+++ b/tests/test_litellm/caching/test_caching_handler.py
@@ -14,7 +14,7 @@ sys.path.insert(
     0, os.path.abspath("../../..")
 )  # Adds the parent directory to the system path
 from datetime import datetime
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock
 
 from litellm.caching.caching_handler import LLMCachingHandler
 

--- a/tests/test_litellm/google_genai/test_google_genai_adapter.py
+++ b/tests/test_litellm/google_genai/test_google_genai_adapter.py
@@ -15,11 +15,9 @@ sys.path.insert(
     0, os.path.abspath("../../..")
 )  # Adds the parent directory to the system path
 
-import json
 import os
 import sys
 
-import pytest
 
 import litellm
 

--- a/tests/test_litellm/google_genai/test_google_genai_main.py
+++ b/tests/test_litellm/google_genai/test_google_genai_main.py
@@ -13,11 +13,9 @@ sys.path.insert(
     0, os.path.abspath("../../..")
 )  # Adds the parent directory to the system path
 
-import json
 import os
 import sys
 
-import pytest
 
 import litellm
 

--- a/tests/test_litellm/integrations/test_galileo.py
+++ b/tests/test_litellm/integrations/test_galileo.py
@@ -112,7 +112,6 @@ def test_galileo_input_text_from_messages():
 
 
 def test_galileo_get_output_str_responses_api(galileo_v2_env):
-    from litellm.types.llms.openai import ResponsesAPIResponse
 
     logger = GalileoObserve()
     resp_dict = {

--- a/tests/test_litellm/integrations/test_langfuse.py
+++ b/tests/test_litellm/integrations/test_langfuse.py
@@ -14,7 +14,6 @@ from litellm.integrations.langfuse import langfuse as langfuse_module
 from litellm.integrations.langfuse.langfuse import LangFuseLogger
 
 sys.path.insert(0, os.path.abspath("../.."))
-from litellm.integrations.langfuse.langfuse import LangFuseLogger
 
 # Import LangfuseUsageDetails directly from the module where it's defined
 from litellm.types.integrations.langfuse import *

--- a/tests/test_litellm/litellm_core_utils/prompt_templates/test_litellm_core_utils_prompt_templates_factory.py
+++ b/tests/test_litellm/litellm_core_utils/prompt_templates/test_litellm_core_utils_prompt_templates_factory.py
@@ -332,7 +332,6 @@ def test_bedrock_get_document_format_fallback_mimes():
     This tests the fallback mechanism when mimetypes.guess_all_extensions returns empty results,
     which can happen in Docker containers where mimetypes depends on OS-installed MIME types.
     """
-    from unittest.mock import patch
 
     # Test DOCX fallback
     docx_mime = (

--- a/tests/test_litellm/litellm_core_utils/test_token_counter.py
+++ b/tests/test_litellm/litellm_core_utils/test_token_counter.py
@@ -13,7 +13,7 @@ import tiktoken
 sys.path.insert(
     0, os.path.abspath("../../..")
 )  # Adds the parent directory to the system path
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, patch
 
 import litellm
 from litellm import create_pretrained_tokenizer, decode, encode, get_modified_max_tokens
@@ -634,7 +634,6 @@ def test_token_counter():
 
 
 import unittest
-from unittest.mock import MagicMock, patch
 
 from litellm.utils import _select_tokenizer_helper, claude_json_str, encoding
 

--- a/tests/test_litellm/llms/anthropic/batches/test_transformation.py
+++ b/tests/test_litellm/llms/anthropic/batches/test_transformation.py
@@ -619,7 +619,6 @@ def test_transform_response_reraises_unexpected_error(config):
 # automatically. See base_batches_config_test.py.
 # --------------------------------------------------------------------------- #
 
-from litellm.types.utils import LlmProviders  # noqa: E402
 from tests.test_litellm.llms.base_llm.batches.base_batches_config_test import (  # noqa: E402
     BatchesConfigContractTests,
 )

--- a/tests/test_litellm/llms/azure/image_generation/test_azure_image_generation_init.py
+++ b/tests/test_litellm/llms/azure/image_generation/test_azure_image_generation_init.py
@@ -312,7 +312,6 @@ def test_azure_image_generation_base_model_vs_deployment_name():
       model: azure/gpt-image-15  # deployment name (URL only)
       base_model: gpt-image-1.5  # optional, for LiteLLM metadata
     """
-    from unittest.mock import MagicMock
 
     # Setup test parameters
     azure_chat_completion = AzureChatCompletion()
@@ -385,7 +384,6 @@ async def test_azure_aimage_generation_base_model_vs_deployment_name():
     Async variant of test_azure_image_generation_base_model_vs_deployment_name:
     deployment in URL, no ``model`` in the JSON body sent to Azure.
     """
-    from unittest.mock import MagicMock
 
     # Setup test parameters
     azure_chat_completion = AzureChatCompletion()

--- a/tests/test_litellm/llms/fireworks_ai/completion/test_fireworks_ai_text_completion_transformation.py
+++ b/tests/test_litellm/llms/fireworks_ai/completion/test_fireworks_ai_text_completion_transformation.py
@@ -18,7 +18,6 @@ from litellm.llms.fireworks_ai.completion.transformation import (
 def force_local_model_cost(monkeypatch):
     """Force local model cost map usage for all tests in this file."""
     monkeypatch.setenv("LITELLM_LOCAL_MODEL_COST_MAP", "True")
-    import litellm
     from litellm.litellm_core_utils.get_model_cost_map import get_model_cost_map
 
     litellm.model_cost = get_model_cost_map(url=litellm.model_cost_map_url)

--- a/tests/test_litellm/llms/github_copilot/test_github_copilot_transformation.py
+++ b/tests/test_litellm/llms/github_copilot/test_github_copilot_transformation.py
@@ -11,7 +11,6 @@ import pytest
 sys.path.insert(0, os.path.abspath("../.."))
 
 import httpx
-import pytest
 from respx import MockRouter
 
 import litellm

--- a/tests/test_litellm/llms/ollama/test_ollama_chat_transformation.py
+++ b/tests/test_litellm/llms/ollama/test_ollama_chat_transformation.py
@@ -86,7 +86,6 @@ class TestOllamaChatConfigResponseFormat:
     def test_transform_request_loads_config_parameters(self):
         """Test that transform_request loads config parameters without overriding existing optional_params"""
         # Set config parameters on the class
-        import litellm
 
         litellm.OllamaChatConfig(num_ctx=8000, temperature=0.0)
 
@@ -383,7 +382,6 @@ class TestOllamaToolCalling:
         import json
         from unittest.mock import MagicMock
 
-        import litellm
         from litellm.types.utils import Choices, Message, ModelResponse
 
         config = OllamaChatConfig()

--- a/tests/test_litellm/llms/openai/chat/test_openai_gpt_transformation.py
+++ b/tests/test_litellm/llms/openai/chat/test_openai_gpt_transformation.py
@@ -16,7 +16,6 @@ from litellm.llms.openai.chat.gpt_transformation import (
     OpenAIChatCompletionStreamingHandler,
     OpenAIGPTConfig,
 )
-from litellm.llms.openai.chat.gpt_5_transformation import OpenAIGPT5Config
 
 
 class TestOpenAIGPTConfig:

--- a/tests/test_litellm/llms/openai/realtime/test_openai_realtime_handler.py
+++ b/tests/test_litellm/llms/openai/realtime/test_openai_realtime_handler.py
@@ -97,7 +97,6 @@ def test_openai_realtime_handler_model_parameter_inclusion():
 
 
 import asyncio
-from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 

--- a/tests/test_litellm/llms/vertex_ai/gemini/test_vertex_and_google_ai_studio_gemini.py
+++ b/tests/test_litellm/llms/vertex_ai/gemini/test_vertex_and_google_ai_studio_gemini.py
@@ -5273,7 +5273,6 @@ class TestModelResponseIteratorCleanup:
         return obj
 
     def test_aclose_closes_iterator_and_response(self):
-        import asyncio
         from unittest.mock import AsyncMock, MagicMock
 
         from litellm.llms.vertex_ai.gemini.vertex_and_google_ai_studio_gemini import (
@@ -5323,7 +5322,6 @@ class TestModelResponseIteratorCleanup:
         mock_response.close.assert_called_once()
 
     def test_aclose_without_response_does_not_raise(self):
-        import asyncio
         from unittest.mock import AsyncMock, MagicMock
 
         from litellm.llms.vertex_ai.gemini.vertex_and_google_ai_studio_gemini import (
@@ -5345,7 +5343,6 @@ class TestModelResponseIteratorCleanup:
         mock_iterator.aclose.assert_awaited_once()
 
     def test_aclose_tolerates_iterator_error(self):
-        import asyncio
         from unittest.mock import AsyncMock, MagicMock
 
         from litellm.llms.vertex_ai.gemini.vertex_and_google_ai_studio_gemini import (
@@ -5372,7 +5369,6 @@ class TestModelResponseIteratorCleanup:
 
     def test_custom_stream_wrapper_aclose_triggers_model_response_iterator_aclose(self):
         """CustomStreamWrapper.aclose() must propagate to ModelResponseIterator.aclose()."""
-        import asyncio
         from unittest.mock import AsyncMock, MagicMock
 
         from litellm.litellm_core_utils.streaming_handler import CustomStreamWrapper

--- a/tests/test_litellm/llms/watsonx/test_watsonx_common_utils.py
+++ b/tests/test_litellm/llms/watsonx/test_watsonx_common_utils.py
@@ -41,9 +41,9 @@ class TestGenerateIAMToken:
         # Verify get_secret_str was called with correct keys in order
         # Note: get_watsonx_iam_url() also calls get_secret_str("WATSONX_IAM_URL")
         calls = [
-            call[0][0]
-            for call in mock_get_secret_str.call_args_list
-            if call[0][0] != "WATSONX_IAM_URL"
+            recorded[0][0]
+            for recorded in mock_get_secret_str.call_args_list
+            if recorded[0][0] != "WATSONX_IAM_URL"
         ]
         assert "WX_API_KEY" in calls
         assert "WATSONX_API_KEY" in calls
@@ -155,9 +155,9 @@ class TestGenerateIAMToken:
             # Verify get_secret_str was called with expected keys (checking short-circuit behavior)
             # Note: get_watsonx_iam_url() also calls get_secret_str("WATSONX_IAM_URL"), so we filter that out
             actual_calls = [
-                call[0][0]
-                for call in mock_get_secret_str.call_args_list
-                if call[0][0] != "WATSONX_IAM_URL"
+                recorded[0][0]
+                for recorded in mock_get_secret_str.call_args_list
+                if recorded[0][0] != "WATSONX_IAM_URL"
             ]
             assert (
                 actual_calls == expected_calls
@@ -189,9 +189,9 @@ class TestGenerateIAMToken:
         # Verify get_secret_str was NOT called for API keys (since api_key was provided)
         # Note: get_watsonx_iam_url() calls get_secret_str("WATSONX_IAM_URL"), which is expected
         api_key_calls = [
-            call[0][0]
-            for call in mock_get_secret_str.call_args_list
-            if call[0][0] not in ["WATSONX_IAM_URL"]
+            recorded[0][0]
+            for recorded in mock_get_secret_str.call_args_list
+            if recorded[0][0] not in ["WATSONX_IAM_URL"]
         ]
         assert (
             len(api_key_calls) == 0
@@ -219,9 +219,9 @@ class TestGenerateIAMToken:
         # Verify get_secret_str was called for all possible API keys
         # Note: get_watsonx_iam_url() also calls get_secret_str("WATSONX_IAM_URL")
         calls = [
-            call[0][0]
-            for call in mock_get_secret_str.call_args_list
-            if call[0][0] != "WATSONX_IAM_URL"
+            recorded[0][0]
+            for recorded in mock_get_secret_str.call_args_list
+            if recorded[0][0] != "WATSONX_IAM_URL"
         ]
         assert "WX_API_KEY" in calls
         assert "WATSONX_API_KEY" in calls

--- a/tests/test_litellm/passthrough/test_passthrough_main.py
+++ b/tests/test_litellm/passthrough/test_passthrough_main.py
@@ -14,7 +14,6 @@ sys.path.insert(
 )  # Adds the parent directory to the system path
 
 
-from unittest.mock import MagicMock, patch
 
 import litellm
 from litellm.passthrough.main import allm_passthrough_route, llm_passthrough_route

--- a/tests/test_litellm/proxy/auth/test_model_checks.py
+++ b/tests/test_litellm/proxy/auth/test_model_checks.py
@@ -700,7 +700,6 @@ def test_expand_wildcard_deployments_non_wildcard_passthrough():
 
 def test_expand_wildcard_deployments_openai_wildcard():
     """openai/* should expand into ≥1 known openai model entries."""
-    from unittest.mock import patch
 
     from litellm.proxy.auth.model_checks import (
         expand_wildcard_deployments_for_model_info,

--- a/tests/test_litellm/proxy/auth/test_route_checks.py
+++ b/tests/test_litellm/proxy/auth/test_route_checks.py
@@ -1791,7 +1791,6 @@ def test_proxy_admin_viewer_can_access_global_spend_tags():
 # Routes returning proxy-wide spend across every team / customer / api_key.
 # Sourced from `LiteLLMRoutes.global_spend_tracking_routes` so any future
 # additions to that list are exercised by these tests automatically.
-from litellm.proxy._types import LiteLLMRoutes
 
 GLOBAL_SPEND_ROUTES = LiteLLMRoutes.global_spend_tracking_routes.value
 
@@ -2617,10 +2616,7 @@ def test_available_roles_accessible_to_non_admin_users(user_role):
 
 # ── _user_is_org_admin tests ──────────────────────────────────────────────────
 
-from datetime import datetime
 
-from litellm.proxy._types import LiteLLM_OrganizationMembershipTable
-from litellm.proxy.auth.auth_checks_organization import _user_is_org_admin
 
 
 def _make_org_admin_user(org_id: str) -> LiteLLM_UserTable:

--- a/tests/test_litellm/proxy/client/cli/test_keys_commands.py
+++ b/tests/test_litellm/proxy/client/cli/test_keys_commands.py
@@ -124,7 +124,6 @@ def test_async_keys_generate_error_handling(mock_keys_client, cli_runner):
 
 
 def test_async_keys_delete_error_handling(mock_keys_client, cli_runner):
-    import requests
 
     # Mock a connection error that would normally happen in CI
     mock_keys_client.return_value.delete.side_effect = (
@@ -146,7 +145,6 @@ def test_async_keys_delete_error_handling(mock_keys_client, cli_runner):
 def test_async_keys_delete_http_error_handling(mock_keys_client, cli_runner):
     from unittest.mock import Mock
 
-    import requests
 
     # Create a mock response object for HTTPError
     mock_response = Mock()

--- a/tests/test_litellm/proxy/db/test_db_spend_update_writer.py
+++ b/tests/test_litellm/proxy/db/test_db_spend_update_writer.py
@@ -197,7 +197,7 @@ def test_enqueue_tool_registry_upsert_reads_every_choice():
 
     db_writer._enqueue_tool_registry_upsert(kwargs={}, completion_response=response)
 
-    enqueued = [call.args[0]["tool_name"] for call in db_writer.tool_discovery_queue.add_update.call_args_list]
+    enqueued = [c.args[0]["tool_name"] for c in db_writer.tool_discovery_queue.add_update.call_args_list]
     assert enqueued == ["tool_alpha", "tool_beta"]
 
 

--- a/tests/test_litellm/proxy/db/test_exception_handler.py
+++ b/tests/test_litellm/proxy/db/test_exception_handler.py
@@ -6,7 +6,7 @@ from unittest.mock import MagicMock, patch
 
 import httpx
 import pytest
-from fastapi import HTTPException, Request, status
+from fastapi import HTTPException, Request
 from prisma import errors as prisma_errors
 from prisma.errors import (
     ClientNotConnectedError,

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_model_armor.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_model_armor.py
@@ -1964,7 +1964,6 @@ async def test_model_armor_guardrail_status_intervened_vs_failed():
 
 def mock_open(read_data=""):
     """Helper to create a mock file object"""
-    import io
     from unittest.mock import MagicMock
 
     file_object = io.StringIO(read_data)

--- a/tests/test_litellm/proxy/guardrails/test_qostodian_nexus_guardrail.py
+++ b/tests/test_litellm/proxy/guardrails/test_qostodian_nexus_guardrail.py
@@ -16,7 +16,6 @@ from unittest.mock import MagicMock
 
 def test_qostodian_nexus_initialization_with_defaults():
     """Test QostodianNexus initializes with default values."""
-    import os
     from unittest.mock import patch
     from litellm.proxy.guardrails.guardrail_hooks.qohash import QostodianNexus
 
@@ -171,7 +170,6 @@ def test_qostodian_nexus_get_config_model():
 
 def test_qostodian_nexus_env_vars():
     """Test that QOSTODIAN_NEXUS_API_BASE env var is picked up correctly."""
-    import os
     from unittest.mock import patch
     from litellm.proxy.guardrails.guardrail_hooks.qohash import QostodianNexus
 

--- a/tests/test_litellm/proxy/health_endpoints/test_health_endpoints.py
+++ b/tests/test_litellm/proxy/health_endpoints/test_health_endpoints.py
@@ -1321,7 +1321,6 @@ def test_get_callback_identifier_string_and_object_with_callback_name():
     - Object with callback_name attribute
     - Object with empty/None callback_name (should fall through to other checks)
     """
-    from litellm.proxy.health_endpoints._health_endpoints import get_callback_identifier
 
     # Test 1: String callback should be returned as-is
     assert get_callback_identifier("datadog") == "datadog"
@@ -1353,7 +1352,6 @@ def test_get_callback_identifier_custom_logger_registry_and_fallback():
     - Object with callback_name that matches registry entry
     - Fallback to callback_name() helper function
     """
-    from litellm.proxy.health_endpoints._health_endpoints import get_callback_identifier
     from litellm.litellm_core_utils.custom_logger_registry import CustomLoggerRegistry
 
     # Test 1: Object registered in CustomLoggerRegistry (without callback_name attribute)

--- a/tests/test_litellm/proxy/hooks/test_parallel_request_limiter_v3.py
+++ b/tests/test_litellm/proxy/hooks/test_parallel_request_limiter_v3.py
@@ -1575,7 +1575,6 @@ async def test_async_increment_tokens_with_ttl_preservation():
     3. Second call: Increment same keys
     4. Verify TTL decreased but wasn't reset to 60s
     """
-    import os
     import time
 
     from litellm.caching.redis_cache import RedisCache

--- a/tests/test_litellm/proxy/management_endpoints/scim/test_scim_v2_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/scim/test_scim_v2_endpoints.py
@@ -58,7 +58,6 @@ from litellm.types.proxy.management_endpoints.scim_v2 import (
     SCIMUserGroup,
     SCIMUserName,
 )
-from litellm.proxy._types import ProxyException
 
 
 @pytest.mark.asyncio

--- a/tests/test_litellm/proxy/management_endpoints/test_auto_router_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_auto_router_endpoints.py
@@ -482,7 +482,6 @@ class TestAutoRouterBenchmarks:
 from datetime import datetime, timedelta, timezone
 from unittest.mock import AsyncMock, MagicMock
 
-from fastapi import HTTPException
 
 from litellm.proxy.management_endpoints.auto_router_endpoints import (
     get_shadow_eval_job,

--- a/tests/test_litellm/proxy/management_endpoints/test_team_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_team_endpoints.py
@@ -4529,7 +4529,6 @@ async def test_new_team_org_scoped_budget_bypasses_user_limit():
     from fastapi import Request
 
     from litellm.proxy._types import (
-        LiteLLM_OrganizationTable,
         LiteLLM_UserTable,
         NewTeamRequest,
         UserAPIKeyAuth,
@@ -4674,7 +4673,6 @@ async def test_new_team_org_scoped_models_bypasses_user_limit():
     from fastapi import Request
 
     from litellm.proxy._types import (
-        LiteLLM_OrganizationTable,
         LiteLLM_UserTable,
         NewTeamRequest,
         UserAPIKeyAuth,
@@ -4964,7 +4962,6 @@ async def test_new_team_org_scoped_budget_exceeds_org_limit():
 
     from litellm.proxy._types import (
         LiteLLM_BudgetTable,
-        LiteLLM_OrganizationTable,
         NewTeamRequest,
         ProxyException,
         UserAPIKeyAuth,
@@ -5044,7 +5041,6 @@ async def test_new_team_org_scoped_models_not_in_org_models():
 
     from litellm.proxy._types import (
         LiteLLM_BudgetTable,
-        LiteLLM_OrganizationTable,
         NewTeamRequest,
         ProxyException,
         UserAPIKeyAuth,
@@ -5633,7 +5629,6 @@ async def test_update_team_org_scoped_budget_exceeds_org_limit():
 
     from litellm.proxy._types import (
         LiteLLM_BudgetTable,
-        LiteLLM_OrganizationTable,
         ProxyException,
         UpdateTeamRequest,
         UserAPIKeyAuth,
@@ -5813,7 +5808,6 @@ async def test_update_team_org_scoped_budget_bypasses_user_limit(
 
     from litellm.proxy._types import (
         LiteLLM_BudgetTable,
-        LiteLLM_OrganizationTable,
         LiteLLM_UserTable,
         UpdateTeamRequest,
         UserAPIKeyAuth,
@@ -5929,7 +5923,6 @@ async def test_update_team_org_scoped_models_bypasses_user_limit(
     from fastapi import Request
 
     from litellm.proxy._types import (
-        LiteLLM_OrganizationTable,
         UpdateTeamRequest,
         UserAPIKeyAuth,
     )
@@ -6031,7 +6024,6 @@ async def test_update_team_org_scoped_models_not_in_org_models():
     from fastapi import Request
 
     from litellm.proxy._types import (
-        LiteLLM_OrganizationTable,
         ProxyException,
         UpdateTeamRequest,
         UserAPIKeyAuth,
@@ -6120,7 +6112,6 @@ async def test_update_team_org_scoped_models_with_all_proxy_models(
     from fastapi import Request
 
     from litellm.proxy._types import (
-        LiteLLM_OrganizationTable,
         SpecialModelNames,
         UpdateTeamRequest,
         UserAPIKeyAuth,
@@ -6403,7 +6394,6 @@ async def test_new_team_org_scoped_tpm_exceeds_org_limit():
 
     from litellm.proxy._types import (
         LiteLLM_BudgetTable,
-        LiteLLM_OrganizationTable,
         NewTeamRequest,
         ProxyException,
         UserAPIKeyAuth,
@@ -6479,7 +6469,6 @@ async def test_new_team_org_scoped_rpm_exceeds_org_limit():
 
     from litellm.proxy._types import (
         LiteLLM_BudgetTable,
-        LiteLLM_OrganizationTable,
         NewTeamRequest,
         ProxyException,
         UserAPIKeyAuth,
@@ -6556,7 +6545,6 @@ async def test_new_team_org_scoped_tpm_rpm_bypasses_user_limit():
 
     from litellm.proxy._types import (
         LiteLLM_BudgetTable,
-        LiteLLM_OrganizationTable,
         LiteLLM_TeamTable,
         NewTeamRequest,
         UserAPIKeyAuth,
@@ -6665,7 +6653,6 @@ async def test_update_team_org_scoped_tpm_exceeds_org_limit():
 
     from litellm.proxy._types import (
         LiteLLM_BudgetTable,
-        LiteLLM_OrganizationTable,
         ProxyException,
         UpdateTeamRequest,
         UserAPIKeyAuth,
@@ -6752,7 +6739,6 @@ async def test_update_team_org_scoped_rpm_exceeds_org_limit():
 
     from litellm.proxy._types import (
         LiteLLM_BudgetTable,
-        LiteLLM_OrganizationTable,
         ProxyException,
         UpdateTeamRequest,
         UserAPIKeyAuth,
@@ -6842,7 +6828,6 @@ async def test_update_team_org_scoped_tpm_rpm_bypasses_user_limit(
 
     from litellm.proxy._types import (
         LiteLLM_BudgetTable,
-        LiteLLM_OrganizationTable,
         LiteLLM_TeamTable,
         UpdateTeamRequest,
         UserAPIKeyAuth,
@@ -6948,7 +6933,6 @@ async def test_update_team_guardrails_with_org_id(
     from fastapi import Request
 
     from litellm.proxy._types import (
-        LiteLLM_OrganizationTable,
         LiteLLM_TeamTable,
         UpdateTeamRequest,
         UserAPIKeyAuth,

--- a/tests/test_litellm/proxy/pass_through_endpoints/test_llm_pass_through_endpoints.py
+++ b/tests/test_litellm/proxy/pass_through_endpoints/test_llm_pass_through_endpoints.py
@@ -2405,9 +2405,6 @@ class TestMilvusProxyRoute:
         """
         Test successful Milvus proxy route with valid managed vector store index
         """
-        from litellm.proxy.pass_through_endpoints.llm_passthrough_endpoints import (
-            milvus_proxy_route,
-        )
 
         collection_name = "dall-e-6"
         vector_store_name = "milvus-store-1"
@@ -2518,9 +2515,6 @@ class TestMilvusProxyRoute:
         """
         from fastapi import HTTPException
 
-        from litellm.proxy.pass_through_endpoints.llm_passthrough_endpoints import (
-            milvus_proxy_route,
-        )
 
         mock_request = MagicMock(spec=Request)
         mock_response = MagicMock(spec=Response)
@@ -2555,9 +2549,6 @@ class TestMilvusProxyRoute:
         """
         from fastapi import HTTPException
 
-        from litellm.proxy.pass_through_endpoints.llm_passthrough_endpoints import (
-            milvus_proxy_route,
-        )
 
         mock_request = MagicMock(spec=Request)
         mock_response = MagicMock(spec=Response)
@@ -2587,9 +2578,6 @@ class TestMilvusProxyRoute:
         """
         from fastapi import HTTPException
 
-        from litellm.proxy.pass_through_endpoints.llm_passthrough_endpoints import (
-            milvus_proxy_route,
-        )
 
         collection_name = "test-collection"
 
@@ -2629,9 +2617,6 @@ class TestMilvusProxyRoute:
         """
         from fastapi import HTTPException
 
-        from litellm.proxy.pass_through_endpoints.llm_passthrough_endpoints import (
-            milvus_proxy_route,
-        )
 
         collection_name = "unmanaged-collection"
 
@@ -2672,9 +2657,6 @@ class TestMilvusProxyRoute:
         """
         Test that missing vector store raises Exception
         """
-        from litellm.proxy.pass_through_endpoints.llm_passthrough_endpoints import (
-            milvus_proxy_route,
-        )
 
         collection_name = "test-collection"
         vector_store_name = "missing-store"
@@ -2731,9 +2713,6 @@ class TestMilvusProxyRoute:
         """
         Test that missing api_base raises Exception
         """
-        from litellm.proxy.pass_through_endpoints.llm_passthrough_endpoints import (
-            milvus_proxy_route,
-        )
 
         collection_name = "test-collection"
         vector_store_name = "milvus-store-1"
@@ -2797,9 +2776,6 @@ class TestMilvusProxyRoute:
         """
         Test that endpoint without leading slash is handled correctly
         """
-        from litellm.proxy.pass_through_endpoints.llm_passthrough_endpoints import (
-            milvus_proxy_route,
-        )
 
         collection_name = "test-collection"
         vector_store_name = "milvus-store-1"
@@ -2877,9 +2853,6 @@ class TestOpenAIPassthroughRoute:
         This verifies the fix for issue #18865 where /openai/v1/responses was being
         routed to LiteLLM's native implementation instead of passthrough
         """
-        from litellm.proxy.pass_through_endpoints.llm_passthrough_endpoints import (
-            openai_proxy_route,
-        )
 
         # Mock request for Responses API
         mock_request = MagicMock(spec=Request)
@@ -2931,9 +2904,6 @@ class TestOpenAIPassthroughRoute:
         """
         Test that /openai_passthrough works for chat completions
         """
-        from litellm.proxy.pass_through_endpoints.llm_passthrough_endpoints import (
-            openai_proxy_route,
-        )
 
         mock_request = MagicMock(spec=Request)
         mock_request.method = "POST"
@@ -2976,9 +2946,6 @@ class TestOpenAIPassthroughRoute:
         """
         Test that missing OPENAI_API_KEY raises an exception
         """
-        from litellm.proxy.pass_through_endpoints.llm_passthrough_endpoints import (
-            openai_proxy_route,
-        )
 
         mock_request = MagicMock(spec=Request)
         mock_response = MagicMock(spec=Response)
@@ -3003,9 +2970,6 @@ class TestOpenAIPassthroughRoute:
         """
         Test that /openai_passthrough works for Assistants API endpoints
         """
-        from litellm.proxy.pass_through_endpoints.llm_passthrough_endpoints import (
-            openai_proxy_route,
-        )
 
         mock_request = MagicMock(spec=Request)
         mock_request.method = "POST"

--- a/tests/test_litellm/proxy/prompts/test_prompt_endpoints.py
+++ b/tests/test_litellm/proxy/prompts/test_prompt_endpoints.py
@@ -206,7 +206,7 @@ class TestPromptVersionsEndpoint:
         """
         Test that get_prompt_versions returns all versions of a prompt sorted by version number
         """
-        from unittest.mock import MagicMock, patch
+        from unittest.mock import patch
 
         from litellm.proxy._types import LitellmUserRoles, UserAPIKeyAuth
         from litellm.proxy.prompts.prompt_endpoints import get_prompt_versions

--- a/tests/test_litellm/proxy/test_common_request_processing.py
+++ b/tests/test_litellm/proxy/test_common_request_processing.py
@@ -28,7 +28,6 @@ from litellm.proxy.common_request_processing import (
     _get_cost_breakdown_from_logging_obj,
     _has_attribute_error_in_chain,
     _is_azure_model_router_request,
-    _UpstreamClosingStreamingResponse,
     open_sse_before_first_byte,
     ttft_keepalive_interval,
     _override_openai_response_model,

--- a/tests/test_litellm/proxy/test_litellm_pre_call_utils.py
+++ b/tests/test_litellm/proxy/test_litellm_pre_call_utils.py
@@ -2736,10 +2736,8 @@ def test_add_headers_to_llm_call_by_model_group_existing_headers_in_data():
         litellm.model_group_settings = original_model_group_settings
 
 
-import json
 import time
 from typing import Optional
-from unittest.mock import AsyncMock
 
 from fastapi.responses import Response
 

--- a/tests/test_litellm/proxy/test_proxy_server.py
+++ b/tests/test_litellm/proxy/test_proxy_server.py
@@ -3344,7 +3344,7 @@ async def test_write_config_to_file(monkeypatch):
     """
     Do not write config to file if store_model_in_db is True
     """
-    from unittest.mock import AsyncMock, MagicMock, mock_open, patch
+    from unittest.mock import AsyncMock, MagicMock, patch
 
     from litellm.proxy.proxy_server import ProxyConfig
 
@@ -3392,7 +3392,7 @@ async def test_write_config_to_file_when_store_model_in_db_false(monkeypatch):
     """
     Test that config IS written to file when store_model_in_db is False
     """
-    from unittest.mock import AsyncMock, MagicMock, mock_open, patch
+    from unittest.mock import AsyncMock, MagicMock, patch
 
     from litellm.proxy.proxy_server import ProxyConfig
 

--- a/tests/test_litellm/responses/litellm_completion_transformation/test_session_handler_with_cold_storage.py
+++ b/tests/test_litellm/responses/litellm_completion_transformation/test_session_handler_with_cold_storage.py
@@ -36,7 +36,6 @@ class TestColdStorageObjectKeyIntegration:
         This test verifies that the StandardLoggingMetadata TypedDict has the
         cold_storage_object_key field for storing S3/GCS object keys.
         """
-        from litellm.types.utils import StandardLoggingMetadata
 
         # Create a StandardLoggingMetadata instance with cold_storage_object_key
         metadata = StandardLoggingMetadata(

--- a/tests/test_litellm/router_strategy/test_base_routing_strategy.py
+++ b/tests/test_litellm/router_strategy/test_base_routing_strategy.py
@@ -12,7 +12,6 @@ sys.path.insert(
 import asyncio
 from unittest.mock import MagicMock, patch
 
-import pytest
 
 from litellm.caching.caching import DualCache
 from litellm.caching.redis_cache import RedisPipelineIncrementOperation

--- a/tests/test_litellm/test_utils.py
+++ b/tests/test_litellm/test_utils.py
@@ -1374,7 +1374,7 @@ def test_get_provider_rerank_config():
     Test the get_provider_rerank_config function for various providers
     """
     from litellm import HostedVLLMRerankConfig
-    from litellm.utils import LlmProviders, ProviderConfigManager
+    from litellm.utils import LlmProviders
 
     # Test for hosted_vllm provider
     config = ProviderConfigManager.get_provider_rerank_config(
@@ -1497,7 +1497,7 @@ def test_get_model_info_shows_supports_computer_use():
 def test_pre_process_non_default_params(model, custom_llm_provider):
     from pydantic import BaseModel
 
-    from litellm.utils import ProviderConfigManager, pre_process_non_default_params
+    from litellm.utils import pre_process_non_default_params
 
     provider_config = ProviderConfigManager.get_provider_chat_config(
         model=model, provider=LlmProviders(custom_llm_provider)
@@ -2364,7 +2364,6 @@ def test_anthropic_claude_4_invoke_chat_provider_config():
     from litellm.llms.bedrock.chat.invoke_transformations.anthropic_claude3_transformation import (
         AmazonAnthropicClaudeConfig,
     )
-    from litellm.utils import ProviderConfigManager
 
     config = ProviderConfigManager.get_provider_chat_config(
         model="invoke/us.anthropic.claude-sonnet-4-20250514-v1:0",
@@ -3251,7 +3250,6 @@ class TestProxyLoggingBudgetAlerts:
 def test_azure_ai_claude_provider_config():
     """Test that Azure AI Claude models return AzureAnthropicConfig for proper tool transformation."""
     from litellm import AzureAIStudioConfig, AzureAnthropicConfig
-    from litellm.utils import ProviderConfigManager
 
     # Claude models should return AzureAnthropicConfig
     config = ProviderConfigManager.get_provider_chat_config(
@@ -4319,7 +4317,6 @@ class TestGetOptionalParamsTencent:
         from litellm.llms.tencent.messages.transformation import (
             TencentAnthropicMessagesConfig,
         )
-        from litellm.utils import ProviderConfigManager
 
         config = ProviderConfigManager.get_provider_anthropic_messages_config(
             model="deepseek-v4-pro",

--- a/tests/test_litellm/vector_stores/test_vector_store_registry.py
+++ b/tests/test_litellm/vector_stores/test_vector_store_registry.py
@@ -13,7 +13,7 @@ sys.path.insert(
 )  # Adds the parent directory to the system path
 
 from datetime import datetime, timezone
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import litellm
 from litellm.types.vector_stores import LiteLLM_ManagedVectorStore

--- a/tests/test_team_logging.py
+++ b/tests/test_team_logging.py
@@ -7,7 +7,6 @@ import aiohttp
 import os
 import dotenv
 from dotenv import load_dotenv
-import pytest
 
 load_dotenv()
 

--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -7,7 +7,6 @@ import time
 from openai import AsyncOpenAI
 from tests.test_team import list_teams
 from typing import Optional
-from tests.test_keys import generate_key
 from fastapi import HTTPException
 
 
@@ -320,7 +319,6 @@ async def test_user_model_access():
 import json
 from litellm._uuid import uuid
 import pytest
-import aiohttp
 from typing import Dict, Tuple
 
 

--- a/tests/unified_google_tests/conftest.py
+++ b/tests/unified_google_tests/conftest.py
@@ -150,7 +150,6 @@ def setup_and_teardown(request):
         0, os.path.abspath("../..")
     )  # Adds the project directory to the system path
 
-    import litellm
 
     if "google_genai_proxy_url" not in request.fixturenames:
         importlib.reload(litellm)

--- a/tests/vector_store_tests/base_vector_store_test.py
+++ b/tests/vector_store_tests/base_vector_store_test.py
@@ -15,7 +15,6 @@ sys.path.insert(
 import litellm
 from abc import ABC, abstractmethod
 from litellm.integrations.custom_logger import CustomLogger
-import json
 from litellm.types.utils import StandardLoggingPayload
 
 

--- a/tests/vector_store_tests/conftest.py
+++ b/tests/vector_store_tests/conftest.py
@@ -22,7 +22,6 @@ def setup_and_teardown():
         0, os.path.abspath("../..")
     )  # Adds the project directory to the system path
 
-    import litellm
     from litellm import Router
 
     importlib.reload(litellm)


### PR DESCRIPTION
## TLDR

Problem this solves:

- A name bound twice keeps only the second binding
- A local can shadow an import the module still calls
- 344 such sites, and nothing stops the next one

How it solves it:

- Selects ruff `F811` in `ruff-tests.toml`, already wired to CI
- 311 were repeated imports and came out with ruff's own fix
- 33 needed a decision: shadowed imports, rebound closures, fixtures
- Load-test fixtures move to a conftest, which is how pytest shares them

## User Flow

Before: a developer edits the watsonx credential lookup and the test that checks which secrets it reads can stop compiling its own assertion

1. They set `WATSONX_API_KEY` and send POST https://litellm-domain/v1/chat/completions for a watsonx model
2. The call succeeds, because the gateway read the key from the environment
3. Someone changes which environment names that lookup tries, and the test guarding it builds its expected list with a variable named `call` that has quietly replaced the `call` helper the same file imports
4. The next person to use that helper in the file gets a confusing failure that has nothing to do with their change, because the name no longer means what the import says it means

After: the shadowing is rejected before it lands

1. The same edit is made
2. CI flags the local that took over an imported name, so the file keeps one meaning per name
3. The same check refuses a second `def test_x` that would silently replace the first, so a test cannot disappear by being renamed onto its neighbour

## Relevant issues

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

This PR changes lint config and tests, so there is no proxy route to curl. The check that matters for a change made mostly of deletions is that no test went missing and no module stopped importing, so both sides collect the whole suite and the counts are compared.

### Before (4b29702418)

1. Run

```
pytest tests --collect-only -q --continue-on-collection-errors
```

2. Output:

```
46989/46991 tests collected (2 deselected), 70 errors in 20.12s
```

### After (e9d40a8f73)

1. Run

```
pytest tests --collect-only -q --continue-on-collection-errors
```

2. Output:

```
46989/46991 tests collected (2 deselected), 70 errors in 41.76s
```

3. Run

```
ruff check --config ruff-tests.toml tests
```

4. Output:

```
All checks passed!
```

### Rule and regression numbers

`ruff check --config ruff-tests.toml tests` went from 344 `F811` findings to zero. Identical collection on both sides: the same 46989 tests, and the same 70 pre-existing collection errors, all of them modules that fail to import for missing credentials or optional dependencies. Nothing new and nothing gone.

## Type

🧹 Refactoring
🚄 Infrastructure
✅ Test

## Caveats (if any)

- Nine `prisma_client` parameters keep a narrow `noqa` with the reason
- `tests/load_tests/conftest.py` is new, so pytest shares those fixtures
- 311 of 344 sites are ruff's own safe fix, so the diff is mostly deletions

### Final Attestation

- [ ] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
