### PR TITLE
fix: keep image content lists intact for sambanova vision requests

### DIFF
--- a/litellm/llms/sambanova/chat.py
+++ b/litellm/llms/sambanova/chat.py
@@ -26,9 +26,7 @@ def _flatten_text_only_messages(
     """
     for message in messages:
         content = message.get("content")
-        if isinstance(content, list) and all(
-            isinstance(part, dict) and part.get("type") == "text" for part in content
-        ):
+        if isinstance(content, list) and all(isinstance(part, dict) and part.get("type") == "text" for part in content):
             texts = convert_content_list_to_str(message=message)
             if texts:
                 message["content"] = texts

--- a/litellm/llms/sambanova/chat.py
+++ b/litellm/llms/sambanova/chat.py
@@ -8,10 +8,31 @@ from collections.abc import Coroutine
 from typing import Any, Final, Literal, overload
 
 from litellm.litellm_core_utils.prompt_templates.common_utils import (
-    handle_messages_with_content_list_to_str_conversion,
+    convert_content_list_to_str,
 )
 from litellm.llms.openai.chat.gpt_transformation import OpenAIGPTConfig
 from litellm.types.llms.openai import AllMessageValues
+
+
+def _flatten_text_only_messages(
+    messages: list[AllMessageValues],
+) -> list[AllMessageValues]:
+    """
+    Flatten a message's content list to a plain string only when it contains
+    text alone. A content list that carries any non-text part (e.g. image_url)
+    is left as a list so that part still reaches the SambaNova API, which
+    accepts content lists for vision-capable models. Flattening those would
+    drop the image and silently return a text-only answer.
+    """
+    for message in messages:
+        content = message.get("content")
+        if isinstance(content, list) and all(
+            isinstance(part, dict) and part.get("type") == "text" for part in content
+        ):
+            texts = convert_content_list_to_str(message=message)
+            if texts:
+                message["content"] = texts
+    return messages
 
 
 class SambanovaConfig(OpenAIGPTConfig):
@@ -117,14 +138,15 @@ class SambanovaConfig(OpenAIGPTConfig):
         """
         Transform messages to handle content list conversion.
 
-        SambaNova API doesn't support content as a list - only string content.
-        This converts content lists like [{"type": "text", "text": "..."}] to strings.
+        Text-only content lists like [{"type": "text", "text": "..."}] are
+        flattened to a plain string. Content lists that carry non-text parts
+        (e.g. image_url) are left intact so those parts still reach the
+        SambaNova API, which accepts content lists for vision-capable models.
         """
 
         async def _async_transform():
-            return handle_messages_with_content_list_to_str_conversion(messages)
+            return _flatten_text_only_messages(messages)
 
         if is_async:
             return _async_transform()
-        messages = handle_messages_with_content_list_to_str_conversion(messages)
-        return messages
+        return _flatten_text_only_messages(messages)

--- a/tests/llm_translation/test_sambanova_chat_transformation.py
+++ b/tests/llm_translation/test_sambanova_chat_transformation.py
@@ -2,7 +2,6 @@
 Unit tests for SambaNova chat message transformation
 """
 
-import pytest
 from litellm.llms.sambanova.chat import SambanovaConfig
 
 

--- a/tests/llm_translation/test_sambanova_chat_transformation.py
+++ b/tests/llm_translation/test_sambanova_chat_transformation.py
@@ -102,3 +102,34 @@ class TestSambanovaContentListHandling:
         assert transformed_messages[1]["content"] == "What is the weather?"
         assert transformed_messages[2]["content"] == "I need your location."
         assert transformed_messages[3]["content"] == "I'm in San Francisco"
+
+    def test_content_list_with_image_url_is_preserved(self):
+        """
+        A content list carrying a non-text part (image_url) must stay a list so
+        the image reaches the SambaNova API, instead of being flattened to a
+        text-only string that silently drops the image.
+        """
+        config = SambanovaConfig()
+
+        image_part = {
+            "type": "image_url",
+            "image_url": {"url": "data:image/png;base64,aGVsbG8="},
+        }
+        messages = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "What colors are in this image?"},
+                    image_part,
+                ],
+            }
+        ]
+
+        transformed_messages = config._transform_messages(
+            messages=messages, model="sambanova/gpt-oss-120b", is_async=False
+        )
+
+        content = transformed_messages[0]["content"]
+        assert isinstance(content, list)
+        assert image_part in content
+        assert any(part.get("type") == "image_url" for part in content)


### PR DESCRIPTION
## TLDR

Problem this solves:

- SambaNova vision requests silently drop the image and answer text-only.

How it solves it:

- Flatten a content list to a string only when it is text-only.

## User Flow

Before: a developer sends an image to a vision-capable SambaNova model and the model answers as if no image was attached.

1. They call a `sambanova/<model>` completion with a message whose content is `[{type: text}, {type: image_url}]`.
2. LiteLLM flattens the whole content list to the text string, so the image never leaves the gateway.
3. The model replies that no image was provided.

After: the same request keeps the image, so the model sees it.

1. They call the same `sambanova/<model>` completion with text + `image_url`.
2. LiteLLM leaves that content list intact (only text-only lists are flattened).
3. The model answers about the image.

## Screenshots / Proof of Fix

`SambanovaConfig._transform_messages` unconditionally ran `handle_messages_with_content_list_to_str_conversion`, which flattens every content list to its text — dropping `image_url` parts. It now flattens only messages whose content list is text-only; a list carrying any non-text part is left as a list.

![before: image dropped / after: image preserved, text-only still flattened](https://github.com/user-attachments/assets/1aac00c9-d003-476d-bed3-dee3b8b9a341)

### Before (247eaaa)

1. `_transform_messages([{role: user, content: [text, image_url]}])` returns `content: "colors?"` (a `str`) — the image is gone.

### After (aa05a5e)

1. The same call returns `content` as a `list` still containing the `image_url` part.
2. A text-only list (`[{type: text}]`) still flattens to a string, and a plain string is unchanged.

## Type

🐛 Bug Fix
✅ Test

## Caveats (if any)

- Video parts remain unsupported by the SambaNova API; this change is scoped to images / non-text parts on the request path.

## QA runbook

- tests/llm_translation/test_sambanova_chat_transformation.py::TestSambanovaContentListHandling::test_content_list_with_image_url_is_preserved - a content list carrying an image_url stays a list through `_transform_messages`.
  - [ ] Build a user message with `content: [{type: text}, {type: image_url}]`
  - [ ] Call `SambanovaConfig()._transform_messages(messages=..., model="sambanova/...", is_async=False)`
  - [ ] Expect `content` to still be a list containing the image_url part (text-only lists still flatten to a string)
  - [ ] Sanity check: asserts the image part survives, not merely that the call did not raise

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

Fixes #37609
