### PR TITLE
fix(anthropic): reconcile enum with declared type in output_format schema

### DIFF
--- a/litellm/llms/anthropic/chat/transformation.py
+++ b/litellm/llms/anthropic/chat/transformation.py
@@ -1,7 +1,8 @@
 import json
 import re
 import time
-from collections.abc import Mapping, Sequence
+from collections.abc import Callable, Mapping, Sequence
+from types import MappingProxyType
 from typing import TYPE_CHECKING, Any, Final, NoReturn, cast
 
 import httpx
@@ -122,15 +123,31 @@ else:
 _ANTHROPIC_TOOL_NAME_INVALID_CHARS: Final = re.compile(r"[^a-zA-Z0-9_-]")
 _ANTHROPIC_TOOL_NAME_MAX_LEN: Final = 128
 
-_ENUM_TYPE_CHECKS: Final[dict[str, Any]] = {
-    "null": lambda v: v is None,
-    "boolean": lambda v: isinstance(v, bool),
-    "integer": lambda v: isinstance(v, int) and not isinstance(v, bool),
-    "number": lambda v: isinstance(v, (int, float)) and not isinstance(v, bool),
-    "string": lambda v: isinstance(v, str),
-    "array": lambda v: isinstance(v, list),
-    "object": lambda v: isinstance(v, dict),
-}
+_ENUM_TYPE_CHECKS: Final[Mapping[str, Callable[[Any], bool]]] = MappingProxyType(
+    {
+        "null": lambda v: v is None,
+        "boolean": lambda v: isinstance(v, bool),
+        "integer": lambda v: isinstance(v, int) and not isinstance(v, bool),
+        "number": lambda v: isinstance(v, (int, float)) and not isinstance(v, bool),
+        "string": lambda v: isinstance(v, str),
+        "array": lambda v: isinstance(v, list),
+        "object": lambda v: isinstance(v, dict),
+    }
+)
+
+
+def _enum_conflicts_with_declared_type(schema: Mapping[str, Any]) -> bool:
+    """Whether ``schema``'s ``enum`` cannot match its declared ``type``."""
+    enum_values: Final = schema.get("enum")
+    declared_type: Final = schema.get("type")
+    if not isinstance(enum_values, list) or declared_type is None:
+        return False
+    if isinstance(declared_type, list):
+        return True
+    check: Final = _ENUM_TYPE_CHECKS.get(declared_type)
+    return check is not None and not all(check(value) for value in enum_values)
+
+
 # Single, internal-only key on ``litellm_params`` used to thread the per-
 # request reverse map (sanitized -> original) from request build to response
 # parsing. ``litellm_params`` is never serialized to a provider; ``optional_
@@ -575,8 +592,12 @@ class AnthropicConfig(AnthropicModelInfo, BaseConfig):
             else:
                 result["description"] = constraint_note
 
+        drops_conflicting_type: Final = _enum_conflicts_with_declared_type(schema)
+
         for key, value in schema.items():
             if key in unsupported_fields:
+                continue
+            if key == "type" and drops_conflicting_type:
                 continue
             if key == "description" and "description" in result:
                 # Already handled above
@@ -602,16 +623,6 @@ class AnthropicConfig(AnthropicModelInfo, BaseConfig):
                 ]
             else:
                 result[key] = value
-
-        enum_values = result.get("enum")
-        declared_type = result.get("type")
-        if isinstance(enum_values, list) and declared_type is not None:
-            if isinstance(declared_type, list):
-                result.pop("type")
-            else:
-                check = _ENUM_TYPE_CHECKS.get(declared_type)
-                if check is not None and not all(check(v) for v in enum_values):
-                    result.pop("type")
 
         # Anthropic requires additionalProperties=false for object schemas
         # See: https://docs.anthropic.com/en/docs/build-with-claude/structured-outputs

--- a/litellm/llms/anthropic/chat/transformation.py
+++ b/litellm/llms/anthropic/chat/transformation.py
@@ -121,6 +121,16 @@ else:
 # response side.
 _ANTHROPIC_TOOL_NAME_INVALID_CHARS: Final = re.compile(r"[^a-zA-Z0-9_-]")
 _ANTHROPIC_TOOL_NAME_MAX_LEN: Final = 128
+
+_ENUM_TYPE_CHECKS: Final[dict[str, Any]] = {
+    "null": lambda v: v is None,
+    "boolean": lambda v: isinstance(v, bool),
+    "integer": lambda v: isinstance(v, int) and not isinstance(v, bool),
+    "number": lambda v: isinstance(v, (int, float)) and not isinstance(v, bool),
+    "string": lambda v: isinstance(v, str),
+    "array": lambda v: isinstance(v, list),
+    "object": lambda v: isinstance(v, dict),
+}
 # Single, internal-only key on ``litellm_params`` used to thread the per-
 # request reverse map (sanitized -> original) from request build to response
 # parsing. ``litellm_params`` is never serialized to a provider; ``optional_
@@ -592,6 +602,16 @@ class AnthropicConfig(AnthropicModelInfo, BaseConfig):
                 ]
             else:
                 result[key] = value
+
+        enum_values = result.get("enum")
+        declared_type = result.get("type")
+        if isinstance(enum_values, list) and declared_type is not None:
+            if isinstance(declared_type, list):
+                result.pop("type")
+            else:
+                check = _ENUM_TYPE_CHECKS.get(declared_type)
+                if check is not None and not all(check(v) for v in enum_values):
+                    result.pop("type")
 
         # Anthropic requires additionalProperties=false for object schemas
         # See: https://docs.anthropic.com/en/docs/build-with-claude/structured-outputs

--- a/tests/test_litellm/llms/anthropic/test_anthropic_schema_filter.py
+++ b/tests/test_litellm/llms/anthropic/test_anthropic_schema_filter.py
@@ -417,3 +417,94 @@ class TestFilterAnthropicOutputSchema:
         result = AnthropicConfig.filter_anthropic_output_schema(schema)
 
         assert result["additionalProperties"] is False
+
+    def test_drops_union_type_alongside_enum(self):
+        """A union ``type`` can never match a single declared type.
+
+        Anthropic rejects it with "Invalid schema: Enum value 'low' does not
+        match declared type '['string', 'null']'". ``enum`` is the tighter
+        constraint, so the conflicting ``type`` is dropped.
+        """
+        schema = {
+            "type": "object",
+            "properties": {
+                "confidence": {
+                    "enum": ["low", "medium", "high", None],
+                    "type": ["string", "null"],
+                }
+            },
+        }
+
+        result = AnthropicConfig.filter_anthropic_output_schema(schema)
+
+        assert "type" not in result["properties"]["confidence"]
+        assert result["properties"]["confidence"]["enum"] == [
+            "low",
+            "medium",
+            "high",
+            None,
+        ]
+
+    def test_drops_type_when_an_enum_value_does_not_match_it(self):
+        """``enum: ["x", None]`` with ``type: "string"`` is rejected too."""
+        schema = {
+            "type": "object",
+            "properties": {"a": {"enum": ["x", None], "type": "string"}},
+        }
+
+        result = AnthropicConfig.filter_anthropic_output_schema(schema)
+
+        assert "type" not in result["properties"]["a"]
+
+    def test_preserves_type_when_every_enum_value_matches(self):
+        """The non-conflicting case must be left exactly as-is."""
+        schema = {
+            "type": "object",
+            "properties": {"a": {"enum": ["x", "y"], "type": "string"}},
+        }
+
+        result = AnthropicConfig.filter_anthropic_output_schema(schema)
+
+        assert result["properties"]["a"]["type"] == "string"
+        assert result["properties"]["a"]["enum"] == ["x", "y"]
+
+    def test_integer_enum_satisfies_number_type(self):
+        """JSON Schema ``number`` accepts integers, so this is not a conflict."""
+        schema = {
+            "type": "object",
+            "properties": {"a": {"enum": [1, 2], "type": "number"}},
+        }
+
+        result = AnthropicConfig.filter_anthropic_output_schema(schema)
+
+        assert result["properties"]["a"]["type"] == "number"
+
+    def test_bool_enum_does_not_satisfy_integer_type(self):
+        """``bool`` is a Python ``int`` subclass but is not a JSON integer."""
+        schema = {
+            "type": "object",
+            "properties": {"a": {"enum": [True], "type": "integer"}},
+        }
+
+        result = AnthropicConfig.filter_anthropic_output_schema(schema)
+
+        assert "type" not in result["properties"]["a"]
+
+    def test_normalizes_enum_type_inside_array_items(self):
+        """Normalization applies at every recursion site, not just top level."""
+        schema = {
+            "type": "object",
+            "properties": {
+                "rows": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {"c": {"enum": ["a", None], "type": ["string", "null"]}},
+                    },
+                }
+            },
+        }
+
+        result = AnthropicConfig.filter_anthropic_output_schema(schema)
+
+        assert "type" not in result["properties"]["rows"]["items"]["properties"]["c"]


### PR DESCRIPTION
## Relevant issues

Fixes #37881

## User Flow

**Before:** the structured-output request is rejected the moment a field is a nullable enum.

1. A developer sends `POST https://<proxy>/v1/chat/completions` with `"model": "claude-sonnet-5"`, a prompt, and a `response_format` of `type: json_schema` whose `confidence` property is `{"enum": ["low","medium","high",null], "type": ["string","null"]}` (exactly what Pydantic emits for an `Optional[SomeEnum]` field).
2. The call returns `HTTP 400`: `output_format.schema: Invalid schema: Enum value 'low' does not match declared type '['string', 'null']'`.
3. The developer hand-strips the `"type"` key, leaving only the `enum`, and re-sends the same `POST /v1/chat/completions`; it now returns `HTTP 200`, so every Pydantic-generated schema has to be edited by hand before it goes through.

**After:** the same nullable-enum schema is accepted as-is.

1. The developer sends the same `POST https://<proxy>/v1/chat/completions` with the same `response_format` (`confidence` still `{"enum": ["low","medium","high",null], "type": ["string","null"]}`).
2. The call returns `HTTP 200` with `choices[0].message.content` a valid JSON object such as `{"confidence":"high"}` that matches the schema.
3. No hand-editing: the untouched `Optional[SomeEnum]` schema works directly against the native `output_format` path


## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (lint, format, unit tests) — `ruff format` clean, target suite green
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** (pending automatic review)

## Screenshots / Proof of Fix

### Root cause

Anthropic cross-validates `enum` against `type` in structured outputs — every enum value must match a **single** declared type. `filter_anthropic_output_schema` never reconciled the two (`grep -c '"enum"'` on the file returns **0**), so `type` was passed through verbatim by the terminal `else: result[key] = value` and reached Anthropic alongside the `enum`:

```
output_format.schema: Invalid schema: Enum value 'low' does not match declared type '['string', 'null']'
```

This is a different class from the constraint-stripping work in #33981 / #34313 / #34319 / #35811 — those handled keywords Anthropic *doesn't support*. Here both keywords are fully supported; the conflict is between them.

Pydantic emits exactly the failing shape for `Optional[SomeEnum]`, so any caller with a nullable enum field on the native `output_format` path is affected. `vertex_ai` is unaffected (forced onto the permissive tool-use path, #18625 / #19201).

### Before (staging, v1.99.0)

```python
AnthropicConfig.filter_anthropic_output_schema(
    {"type": "object", "properties": {
        "confidence": {"enum": ["low","medium","high",None], "type": ["string","null"]}}}
)["properties"]["confidence"]
# -> {'enum': ['low','medium','high',None], 'type': ['string','null']}   <-- 400s at Anthropic
```

Live, against a real `azure_ai/claude-sonnet-4-6` deployment addressed directly by `model_id` (so a `vertex_ai` fallback could not mask it):

```
enum + type:["string","null"]                    -> HTTP 400
enum + type:["string","null"] (no null in enum)  -> HTTP 400
enum:["x",null] + type:"string"                  -> HTTP 400
enum + type:"string"  (matching)                 -> HTTP 200
enum with NO type key                            -> HTTP 200   <-- the accepted form
```

### After (commit `b3e071c`)

The conflicting `type` is dropped and the schema is accepted. Verified end-to-end with a real production schema that 400s as-is: after this normalization its `confidence` field becomes `{"enum": ["low","medium","high",null]}`, and the same request returns **HTTP 200** from Azure.

```
$ uv run pytest tests/test_litellm/llms/anthropic/test_anthropic_schema_filter.py -q
27 passed
```

Regression check on `tests/test_litellm/llms/anthropic/`: **21 failed / 723 passed with this change vs 21 failed / 717 passed unmodified** — identical pre-existing failure set, +6 new passing tests. (The pre-existing failures and two collection errors are a missing local `orjson`; they reproduce unmodified.)

### Why the drop is conditional

`type` is removed **only** when it genuinely conflicts — a union array, or a scalar type some enum value doesn't match. A matching `enum` + scalar `type` is left untouched.

That is load-bearing, not stylistic: `test_preserves_valid_fields` asserts `result == schema` for `{"type": "string", "enum": ["active","inactive"]}`. An unconditional drop would break it. This also means the fix does **not** contradict #22500, which deliberately preserved `enum` alongside `type` — that behaviour is retained for every non-conflicting schema.

## Type

🐛 Bug Fix

## Changes

- `litellm/llms/anthropic/chat/transformation.py` — add `_ENUM_TYPE_CHECKS` (JSON-type predicates) and, in `filter_anthropic_output_schema`, drop `type` when it conflicts with `enum`. Placed after the key loop and before the `additionalProperties` coercion so a dropped `type` can never skip that step. The function already recurses into `properties`/`items`/`$defs`/`anyOf`/`allOf`, so nested and array-item enums are covered with no extra plumbing.
- `tests/test_litellm/llms/anthropic/test_anthropic_schema_filter.py` — 6 tests: union type, null-in-enum with scalar type, the matching case preserved, `integer` enum satisfying `number`, `bool` not satisfying `integer`, and normalization inside array items.

### Semantic caveat (disclosed)

JSON Schema semantics are an intersection: valid values = `enum` ∩ `type`. When some enum values don't match the declared type, those values were formally *unreachable* — e.g. `{"enum": ["low", null], "type": "string"}` strictly permits only `"low"`. Dropping `type` makes `null` reachable, so this is a widening, not a no-op.

I think that's the right call: such a schema is almost always the nullable-enum idiom, the author's intent is evidently to allow `null`, and the strict reading makes the schema self-contradictory — but it is a behaviour change and reviewers should see it named. Where the types already agree, dropping is lossless and this PR doesn't do it anyway.

Two smaller notes: a mixed-type enum (`[1, "a", null]`) has no single valid `type`, so there is nothing to preserve; and if a conflicting schema also carries `format`/`pattern`, those lose their type anchor — in practice inert, since `enum` already pins the value set to a finite list.

### Scope notes

- Complements rather than competes with #31750, which proposes bailing off `output_format` to the tool path when unsupported constructs appear. Its detection set is the numeric/length constraint keywords, so an `enum` + union-`type` schema still goes native and still 400s under it. Normalization is the smaller fix; if #31750 lands, this remains correct.
- #29624 wires the Bedrock native structured-outputs path into this same function, so Bedrock would inherit this fix — which also speaks to the comment on #19444 reporting that family still broken on Bedrock.
- I probed 49 JSON Schema constructs in isolation against a live native-path deployment to check this wasn't another one-at-a-time fix: 45 pass, 3 fail from this bug, and 1 from recursive `$ref` — a documented Anthropic limitation, not a LiteLLM gap. To my knowledge this closes the last LiteLLM-side gap in this family.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: localized schema normalization before the Anthropic API; only drops `type` when it conflicts with `enum`, which can slightly widen valid values for contradictory nullable-enum schemas.
> 
> **Overview**
> Fixes Anthropic **HTTP 400** on native structured outputs when Pydantic-style schemas combine **`enum`** with a **`type`** that cannot hold every enum value (e.g. `Optional[Enum]` → `type: ["string", "null"]` plus enum including `null`).
> 
> **`filter_anthropic_output_schema`** now detects conflicts via **`_enum_conflicts_with_declared_type`** (union `type` arrays, or scalar `type` where any enum value fails JSON-type checks) and **skips emitting `type`** while keeping **`enum`**. Matching pairs like `enum: ["active","inactive"]` with `type: "string"` are unchanged. Recursion through `properties`, `items`, etc. applies the same rule.
> 
> Six unit tests cover union types, null in enum, preserved matches, `number` vs integer enums, bool vs integer, and nested array items.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 846913f3c4822d8aae4a2144b86b17a8ad8e8b0a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

---

### Reviewer QA: live proof at tip `846913f3c`

Two local proxies, same config and the same real model `anthropic/claude-sonnet-5`, base `litellm_internal_staging` vs this PR's head, real Anthropic API and no mocks. Same request body for every row.

Main repro (nullable enum, the `Optional[SomeEnum]` shape):

```bash
curl -sS -w '\nHTTP:%{http_code}\n' "$PROXY/v1/chat/completions" \
  -H "Authorization: Bearer $KEY" -H 'Content-Type: application/json' -d '{
    "model":"claude-struct",
    "messages":[{"role":"user","content":"How confident are you that 2+2=4? Emit a minimal valid object."}],
    "max_tokens":150,
    "response_format":{"type":"json_schema","json_schema":{"name":"r","schema":{
      "type":"object",
      "properties":{"confidence":{"enum":["low","medium","high",null],"type":["string","null"]}},
      "required":["confidence"]}}}
  }'
```

Base (before):
```
{"error":{"message":"litellm.BadRequestError: AnthropicException - {...\"message\":\"output_format.schema: Invalid schema: Enum value 'low' does not match declared type '['string', 'null']'\"...}. Received Model Group=claude-struct","code":"400"}}
HTTP:400
```

Head (after):
```
{"id":"chatcmpl-...","object":"chat.completion","model":"claude-struct","choices":[{"finish_reason":"stop","index":0,"message":{"content":"{\"confidence\":\"high\"}","role":"assistant"}}],"usage":{"completion_tokens":12,"prompt_tokens":240,"total_tokens":252}}
HTTP:200
```

Full A/B matrix, base vs head against the same live proxy pair:

| Schema | Base | Head |
|---|---|---|
| enum + matching scalar type | 200 | 200 |
| plain typed object, no enum | 200 | 200 |
| integer enum + number type | 200 | 200 |
| null-in-enum + scalar string | 400 | 200 |
| union type + enum (main repro) | 400 | 200 |
| nested array-items enum conflict | 400 | 200 |

Every schema Anthropic already accepted is unchanged (200 stays 200); only the three it already rejected flip 400 to 200. The fix is a strict widening with no regression on the preserved paths, and the recursion reaches nested and array-item enums.

- [x] `846913f3c` passes /live-pr-risk. Full dependency graph of `filter_anthropic_output_schema` traced: its only caller is the native `output_format` path via `map_response_format_to_anthropic_output_format`, the new predicate helpers are module-private, and Bedrock is not yet wired in. Driven live base vs head with real Anthropic calls; no previously-working dependent path regresses
