### PR TITLE
fix(cost): charge input_cost_per_request in the generic cost path

### DIFF
--- a/litellm/cost_calculator.py
+++ b/litellm/cost_calculator.py
@@ -653,6 +653,7 @@ def cost_per_token(
         if (
             (model_info.get("input_cost_per_token") or 0.0) > 0
             or (model_info.get("output_cost_per_token") or 0.0) > 0
+            or (model_info.get("input_cost_per_request") or 0.0) > 0
             or model_info.get("tiered_pricing") is not None
         ):
             return generic_cost_per_token(

--- a/litellm/litellm_core_utils/llm_cost_calc/utils.py
+++ b/litellm/litellm_core_utils/llm_cost_calc/utils.py
@@ -918,6 +918,11 @@ def generic_cost_per_token(
         service_tier=service_tier,
     )
 
+    ## FLAT PER-REQUEST COST
+    input_cost_per_request: Final = model_info.get("input_cost_per_request")
+    if input_cost_per_request:
+        prompt_cost += input_cost_per_request
+
     ## CALCULATE OUTPUT COST
     text_tokens = 0
     audio_tokens = 0

--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -233,6 +233,7 @@ class ModelInfoBase(ProviderSpecificModelInfo, total=False):
     input_cost_per_token_above_512k_tokens: float | None  # MiniMax-M3: prompts >512K priced at 2x input
     input_cost_per_character_above_128k_tokens: float | None  # only for vertex ai models
     input_cost_per_query: float | None  # only for rerank models
+    input_cost_per_request: ReadOnly[float | None]  # flat per-request pricing
     input_cost_per_image: float | None  # only for vertex ai models
     input_cost_per_image_token: float | None  # for gpt-image-1 and similar models
     input_cost_per_video_token: float | None  # for gemini omni models with video input
@@ -3323,6 +3324,7 @@ class MirroredPricingParams(BaseModel):
 class CustomPricingLiteLLMParams(MirroredPricingParams):
     ## CUSTOM PRICING ##
     input_cost_per_second: float | None = None
+    input_cost_per_request: float | None = None
     output_cost_per_second: float | None = None
     output_cost_per_second_1080p: float | None = None
     input_cost_per_pixel: float | None = None

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -5673,6 +5673,7 @@ def _get_model_info_helper(
                 ),
                 input_cost_per_token_above_512k_tokens=_model_info.get("input_cost_per_token_above_512k_tokens", None),
                 input_cost_per_query=_model_info.get("input_cost_per_query", None),
+                input_cost_per_request=_model_info.get("input_cost_per_request", None),
                 input_cost_per_second=_model_info.get("input_cost_per_second", None),
                 input_cost_per_audio_token=_model_info.get("input_cost_per_audio_token", None),
                 input_cost_per_image_token=_model_info.get("input_cost_per_image_token", None),

--- a/tests/test_litellm/litellm_core_utils/llm_cost_calc/test_llm_cost_calc_utils.py
+++ b/tests/test_litellm/litellm_core_utils/llm_cost_calc/test_llm_cost_calc_utils.py
@@ -3604,3 +3604,114 @@ def test_generic_cost_per_token_grok_46_long_context(_local_model_cost_map):
     )
     assert prompt_cost == pytest.approx(200_000 * 4e-06 + 50_000 * 1e-06)
     assert completion_cost == pytest.approx(1_000 * 1.2e-05)
+
+
+@pytest.fixture
+def flat_per_request_model():
+    """Register a synthetic model whose only price is a flat per-request rate."""
+    from litellm.utils import _invalidate_model_cost_lowercase_map
+
+    model = "openai/flat-rate-test-model"
+    prev = litellm.model_cost.get(model)
+    litellm.model_cost[model] = {
+        "input_cost_per_request": 0.05,
+        "input_cost_per_token": 0.0,
+        "output_cost_per_token": 0.0,
+        "litellm_provider": "openai",
+        "mode": "chat",
+    }
+    _invalidate_model_cost_lowercase_map()
+    try:
+        yield model
+    finally:
+        if prev is None:
+            litellm.model_cost.pop(model, None)
+        else:
+            litellm.model_cost[model] = prev
+        _invalidate_model_cost_lowercase_map()
+
+
+def test_flat_per_request_cost_applies_once(flat_per_request_model):
+    """A flat per-request price bills the same regardless of token counts."""
+    from litellm.types.utils import Usage
+
+    small_usage = Usage(prompt_tokens=10, completion_tokens=5, total_tokens=15)
+    large_usage = Usage(prompt_tokens=10_000, completion_tokens=5_000, total_tokens=15_000)
+
+    small_prompt_cost, small_completion_cost = generic_cost_per_token(
+        model=flat_per_request_model,
+        usage=small_usage,
+        custom_llm_provider="openai",
+    )
+    large_prompt_cost, large_completion_cost = generic_cost_per_token(
+        model=flat_per_request_model,
+        usage=large_usage,
+        custom_llm_provider="openai",
+    )
+
+    assert small_prompt_cost == pytest.approx(0.05)
+    assert small_completion_cost == 0.0
+    assert large_prompt_cost == pytest.approx(0.05)
+    assert large_completion_cost == 0.0
+
+
+def test_flat_per_request_cost_is_added_to_token_cost():
+    """The flat rate stacks on top of token pricing rather than replacing it."""
+    from litellm.utils import _invalidate_model_cost_lowercase_map
+    from litellm.types.utils import Usage
+
+    model = "openai/flat-plus-tokens-test-model"
+    litellm.model_cost[model] = {
+        "input_cost_per_request": 0.05,
+        "input_cost_per_token": 1e-05,
+        "output_cost_per_token": 2e-05,
+        "litellm_provider": "openai",
+        "mode": "chat",
+    }
+    _invalidate_model_cost_lowercase_map()
+    try:
+        usage = Usage(prompt_tokens=100, completion_tokens=50, total_tokens=150)
+        prompt_cost, completion_cost = generic_cost_per_token(
+            model=model,
+            usage=usage,
+            custom_llm_provider="openai",
+        )
+        assert prompt_cost == pytest.approx(0.05 + 100 * 1e-05)
+        assert completion_cost == pytest.approx(50 * 2e-05)
+    finally:
+        litellm.model_cost.pop(model, None)
+        _invalidate_model_cost_lowercase_map()
+
+
+def test_flat_per_request_cost_routes_through_cost_per_token():
+    """The generic cost_per_token dispatch must not skip a model whose only
+    pricing is a flat per-request rate.
+
+    Uses a provider with no dedicated cost_per_token branch, so the model
+    genuinely reaches the generic fallback whose guard is under test.
+    """
+    from litellm.cost_calculator import cost_per_token
+    from litellm.types.utils import Usage
+    from litellm.utils import _invalidate_model_cost_lowercase_map
+
+    model = "groq/flat-rate-only-test-model"
+    litellm.model_cost[model] = {
+        "input_cost_per_request": 0.05,
+        "input_cost_per_token": 0.0,
+        "output_cost_per_token": 0.0,
+        "litellm_provider": "groq",
+        "mode": "chat",
+    }
+    _invalidate_model_cost_lowercase_map()
+    try:
+        usage = Usage(prompt_tokens=10, completion_tokens=5, total_tokens=15)
+        prompt_cost, completion_cost = cost_per_token(
+            model=model,
+            custom_llm_provider="groq",
+            usage_object=usage,
+        )
+        assert prompt_cost == pytest.approx(0.05)
+        assert completion_cost == 0.0
+    finally:
+        litellm.model_cost.pop(model, None)
+        _invalidate_model_cost_lowercase_map()

--- a/ui/litellm-dashboard/src/lib/http/schema.d.ts
+++ b/ui/litellm-dashboard/src/lib/http/schema.d.ts
@@ -27521,6 +27521,8 @@ export interface components {
             input_cost_per_pixel?: number | null;
             /** Input Cost Per Query */
             input_cost_per_query?: number | null;
+            /** Input Cost Per Request */
+            input_cost_per_request?: number | null;
             /** Input Cost Per Second */
             input_cost_per_second?: number | null;
             /** Input Cost Per Token */
@@ -36730,6 +36732,8 @@ export interface components {
             input_cost_per_pixel?: number | null;
             /** Input Cost Per Query */
             input_cost_per_query?: number | null;
+            /** Input Cost Per Request */
+            input_cost_per_request?: number | null;
             /** Input Cost Per Second */
             input_cost_per_second?: number | null;
             /** Input Cost Per Token */


### PR DESCRIPTION
## Problem

`input_cost_per_request` has been a key in the model cost map for a long time —
four `perplexity/*-online` entries carry it today — but nothing on the generic
cost path reads it:

- `generic_cost_per_token` never adds it to the prompt cost.
- `cost_per_token`'s generic fallback treats a model whose only pricing is a
  flat per-request rate as having no pricing at all, and returns `(0.0, 0.0)`
  before `generic_cost_per_token` is ever called.

Any provider on the generic path with flat per-request pricing therefore tracks
$0 spend.

## Solution

Surface `input_cost_per_request` on `ModelInfo`, charge it in
`generic_cost_per_token` on top of any token pricing rather than replacing it,
and admit it to the generic fallback's pricing guard so such a model reaches
that function at all. It also joins `CustomPricingLiteLLMParams` so a
per-deployment override stays isolated from shared backend keys.

Nine lines of source change; no provider-specific logic.

⚠️ Providers with a dedicated `cost_per_token` branch do **not** route through
this path and are deliberately unaffected — including Perplexity, whose online
models keep billing through `perplexity_cost_per_token`. Fixing those is a
separate change with its own behavioural blast radius, so it is not bundled here.

## Testing

`tests/test_litellm/litellm_core_utils/llm_cost_calc/` — 240 passed.

Three new tests, each verified to fail without the change:

- `test_flat_per_request_cost_applies_once` — flat rate is independent of token count.
- `test_flat_per_request_cost_is_added_to_token_cost` — it stacks on token pricing.
- `test_flat_per_request_cost_routes_through_cost_per_token` — covers the
  fallback guard specifically. It uses a provider with no dedicated
  `cost_per_token` branch, because a provider that has one short-circuits before
  the guard and the test would pass whether or not the guard were fixed.

Tests register synthetic models rather than relying on any shipped entry, so
they do not depend on the cost map's contents.
