### PR TITLE
fix(caching): drop the cached value from Redis write-error logs

### DIFF
--- a/litellm/caching/redis_cache.py
+++ b/litellm/caching/redis_cache.py
@@ -27,6 +27,8 @@ from litellm.constants import (
     REDIS_CIRCUIT_BREAKER_ENABLED,
     REDIS_CIRCUIT_BREAKER_FAILURE_THRESHOLD,
     REDIS_CIRCUIT_BREAKER_RECOVERY_TIMEOUT,
+    REDIS_ERROR_LOG_HEAD_BYTES,
+    REDIS_ERROR_LOG_TAIL_BYTES,
 )
 from litellm.litellm_core_utils.core_helpers import _get_parent_otel_span_from_kwargs
 from litellm.litellm_core_utils.coroutine_checker import coroutine_checker
@@ -215,6 +217,42 @@ def _record_swallowed_redis_failure(breaker: RedisCircuitBreaker, exc: BaseExcep
         return
     breaker.record_failure()
     _swallowed_redis_failures.set(_swallowed_redis_failures.get() + 1)
+
+
+_UNRENDERABLE_REDIS_ERROR: Final = "UnrenderableException: <exception could not be rendered>"
+
+
+def _redis_error_text(exc: BaseException) -> str:
+    """Render ``exc`` for an error log without letting it carry the cached payload.
+
+    Dropping the value argument does not close the path on its own, because a Redis
+    client can put the command it failed on, key and value included, into the exception.
+    redis-py rewraps every pipelined failure as
+    ``Command # N (<the whole command>) of pipeline caused error: <reason>``, so on the
+    pipeline paths the value arrives through ``str(exc)`` while the value argument reads
+    ``None``. The client does that wrapping, so even a short generic server error
+    produces the long line.
+
+    Bounded at both ends because the two shapes put the diagnostic at opposite ends: a
+    connection error leads with the reason, the pipeline wrapper trails with it, and a
+    head-only bound would print part of the command and drop the reason. Bounded in
+    bytes so a non-ASCII payload cannot exceed the budget several times over.
+
+    ``__str__`` is caller-controlled code and every caller is an ``except`` block that
+    exists to keep the request alive, so rendering must never raise. Everything after
+    the guard operates on ``bytes`` and cannot.
+    """
+    try:
+        name: Final = type(exc).__name__
+        raw: Final = str(exc).encode("utf-8", "replace")
+    except BaseException:  # noqa: BLE001  # __str__ is caller-controlled and can raise anything, KeyboardInterrupt included
+        return _UNRENDERABLE_REDIS_ERROR
+    if len(raw) <= REDIS_ERROR_LOG_HEAD_BYTES + REDIS_ERROR_LOG_TAIL_BYTES:
+        return f"{name}: {raw.decode('utf-8', 'replace')}"
+    head: Final = raw[:REDIS_ERROR_LOG_HEAD_BYTES].decode("utf-8", "replace")
+    tail: Final = raw[len(raw) - REDIS_ERROR_LOG_TAIL_BYTES :].decode("utf-8", "replace")
+    dropped: Final = len(raw) - REDIS_ERROR_LOG_HEAD_BYTES - REDIS_ERROR_LOG_TAIL_BYTES
+    return f"{name}: {head} ...[truncated {dropped} bytes]... {tail}"
 
 
 async def _run_under_circuit_breaker(
@@ -537,7 +575,7 @@ class RedisCache(BaseCache):
             _duration = end_time - start_time
             verbose_logger.error(
                 "LiteLLM Redis Caching: increment_cache() - Got exception from REDIS %s, key=%s, value_bytes=%s",
-                str(e),
+                _redis_error_text(e),
                 key,
                 len(str(value)),
             )
@@ -710,7 +748,7 @@ class RedisCache(BaseCache):
             )
             verbose_logger.error(
                 "LiteLLM Redis Caching: async set() - Got exception from REDIS %s, key=%r, value_bytes=%s",
-                str(e),
+                _redis_error_text(e),
                 key,
                 len(str(value)),
             )
@@ -762,7 +800,7 @@ class RedisCache(BaseCache):
             )
             verbose_logger.error(
                 "LiteLLM Redis Caching: async set() - Got exception from REDIS %s, key=%s, value_bytes=%s",
-                str(e),
+                _redis_error_text(e),
                 key,
                 len(str(value)),
             )
@@ -849,7 +887,7 @@ class RedisCache(BaseCache):
 
             verbose_logger.error(
                 "LiteLLM Redis Caching: async set_cache_pipeline() - Got exception from REDIS %s, num_keys=%s, value_bytes=%s",
-                str(e),
+                _redis_error_text(e),
                 len(cache_list),
                 sum(len(str(cache_value)) for _, cache_value in cache_list),
             )
@@ -896,7 +934,7 @@ class RedisCache(BaseCache):
             # NON blocking - notify users Redis is throwing an exception
             verbose_logger.error(
                 "LiteLLM Redis Caching: async set() - Got exception from REDIS %s, key=%s, value_bytes=%s",
-                str(e),
+                _redis_error_text(e),
                 key,
                 len(str(value)),
             )
@@ -936,7 +974,7 @@ class RedisCache(BaseCache):
             # NON blocking - notify users Redis is throwing an exception
             verbose_logger.error(
                 "LiteLLM Redis Caching: async set_cache_sadd() - Got exception from REDIS %s, key=%s, value_bytes=%s",
-                str(e),
+                _redis_error_text(e),
                 key,
                 len(str(value)),
             )
@@ -1009,7 +1047,7 @@ class RedisCache(BaseCache):
             )
             verbose_logger.error(
                 "LiteLLM Redis Caching: async async_increment() - Got exception from REDIS %s, key=%s, value_bytes=%s",
-                str(e),
+                _redis_error_text(e),
                 key,
                 len(str(value)),
             )

--- a/litellm/caching/redis_cache.py
+++ b/litellm/caching/redis_cache.py
@@ -536,9 +536,10 @@ class RedisCache(BaseCache):
             end_time = time.time()
             _duration = end_time - start_time
             verbose_logger.error(
-                "LiteLLM Redis Caching: increment_cache() - Got exception from REDIS %s, Writing value=%s",
+                "LiteLLM Redis Caching: increment_cache() - Got exception from REDIS %s, key=%s, value_bytes=%s",
                 str(e),
-                value,
+                key,
+                len(str(value)),
             )
             raise e
 
@@ -708,10 +709,10 @@ class RedisCache(BaseCache):
                 )
             )
             verbose_logger.error(
-                "LiteLLM Redis Caching: async set() - Got exception from REDIS %s, key=%r, value=%r",
+                "LiteLLM Redis Caching: async set() - Got exception from REDIS %s, key=%r, value_bytes=%s",
                 str(e),
                 key,
-                value,
+                len(str(value)),
             )
             raise e
 
@@ -760,9 +761,10 @@ class RedisCache(BaseCache):
                 )
             )
             verbose_logger.error(
-                "LiteLLM Redis Caching: async set() - Got exception from REDIS %s, Writing value=%s",
+                "LiteLLM Redis Caching: async set() - Got exception from REDIS %s, key=%s, value_bytes=%s",
                 str(e),
-                value,
+                key,
+                len(str(value)),
             )
             _record_swallowed_redis_failure(self._circuit_breaker, e)
 
@@ -809,7 +811,6 @@ class RedisCache(BaseCache):
         start_time: Final = time.time()
 
         print_verbose(f"Set Async Redis Cache: key list: {cache_list}\nttl={ttl}, redis_version={self.redis_version}")
-        cache_value: Final = None
         try:
             async with _redis_client.pipeline(transaction=False) as pipe:
                 results: Final = await self._pipeline_helper(pipe, cache_list, ttl)
@@ -847,9 +848,10 @@ class RedisCache(BaseCache):
             )
 
             verbose_logger.error(
-                "LiteLLM Redis Caching: async set_cache_pipeline() - Got exception from REDIS %s, Writing value=%s",
+                "LiteLLM Redis Caching: async set_cache_pipeline() - Got exception from REDIS %s, num_keys=%s, value_bytes=%s",
                 str(e),
-                cache_value,
+                len(cache_list),
+                sum(len(str(cache_value)) for _, cache_value in cache_list),
             )
             _record_swallowed_redis_failure(self._circuit_breaker, e)
 
@@ -893,9 +895,10 @@ class RedisCache(BaseCache):
             )
             # NON blocking - notify users Redis is throwing an exception
             verbose_logger.error(
-                "LiteLLM Redis Caching: async set() - Got exception from REDIS %s, Writing value=%s",
+                "LiteLLM Redis Caching: async set() - Got exception from REDIS %s, key=%s, value_bytes=%s",
                 str(e),
-                value,
+                key,
+                len(str(value)),
             )
             raise e
 
@@ -932,9 +935,10 @@ class RedisCache(BaseCache):
             )
             # NON blocking - notify users Redis is throwing an exception
             verbose_logger.error(
-                "LiteLLM Redis Caching: async set_cache_sadd() - Got exception from REDIS %s, Writing value=%s",
+                "LiteLLM Redis Caching: async set_cache_sadd() - Got exception from REDIS %s, key=%s, value_bytes=%s",
                 str(e),
-                value,
+                key,
+                len(str(value)),
             )
             _record_swallowed_redis_failure(self._circuit_breaker, e)
 
@@ -1004,9 +1008,10 @@ class RedisCache(BaseCache):
                 )
             )
             verbose_logger.error(
-                "LiteLLM Redis Caching: async async_increment() - Got exception from REDIS %s, Writing value=%s",
+                "LiteLLM Redis Caching: async async_increment() - Got exception from REDIS %s, key=%s, value_bytes=%s",
                 str(e),
-                value,
+                key,
+                len(str(value)),
             )
             raise e
 

--- a/litellm/constants.py
+++ b/litellm/constants.py
@@ -381,6 +381,10 @@ REDIS_CONNECTION_POOL_TIMEOUT: Final = int(os.getenv("REDIS_CONNECTION_POOL_TIME
 REDIS_CIRCUIT_BREAKER_FAILURE_THRESHOLD: Final = int(os.getenv("REDIS_CIRCUIT_BREAKER_FAILURE_THRESHOLD", 5))
 REDIS_CIRCUIT_BREAKER_RECOVERY_TIMEOUT: Final = int(os.getenv("REDIS_CIRCUIT_BREAKER_RECOVERY_TIMEOUT", 60))
 REDIS_CIRCUIT_BREAKER_ENABLED: Final = os.getenv("REDIS_CIRCUIT_BREAKER_ENABLED", "true").lower() == "true"
+# Head and tail budget for the Redis error text in RedisCache error logs, sized so every
+# observed redis-py error message survives intact while a wrapped command cannot
+REDIS_ERROR_LOG_HEAD_BYTES: Final = 120
+REDIS_ERROR_LOG_TAIL_BYTES: Final = 60
 # Seconds of idle before a Redis cluster connection is validated with a PING and
 # reconnected if dead, so a connection silently dropped by a cluster restart
 # (e.g. ElastiCache Serverless maintenance) is not reused while broken

--- a/tests/test_litellm/caching/test_redis_cache.py
+++ b/tests/test_litellm/caching/test_redis_cache.py
@@ -751,3 +751,160 @@ async def test_async_set_cache_sadd_error_log_omits_the_cached_value(
     assert all(member_marker not in message for message in logged)
     assert any("Connection closed by server." in message for message in logged)
     assert any("lit4930" in message for message in logged)
+
+
+# Dropping the value argument is only half the path. redis-py rewraps every pipelined
+# failure as "Command # N (<the whole command>) of pipeline caused error: <reason>", so
+# the cached value reaches the same ERROR log through the exception text while the value
+# argument reads None. The failure still has to be reported; the payload does not.
+
+
+def _payload_bearing_error(reason_first: bool, marker: str) -> str:
+    """A redis error text carrying a response body, in each of the two observed shapes."""
+    body = f"{'x' * 200}{marker}{'x' * 200}"
+    if reason_first:
+        return f"Connection closed by server. {body}"
+    return f"Command # 1 (SET litellm:lit4930 {body}) of pipeline caused error: READONLY You can't write against a read only replica."
+
+
+@pytest.mark.asyncio
+async def test_async_set_cache_error_log_bounds_the_exception_text(
+    monkeypatch, redis_no_ping, caplog
+):
+    """The exception text is bounded, so a client that embeds the command cannot use it
+    as a second route for the value into the log."""
+    from redis.exceptions import ConnectionError as RedisConnectionError
+
+    monkeypatch.setenv("REDIS_HOST", "https://my-test-host")
+    redis_cache = RedisCache()
+
+    response_marker = "exception-slot-marker"
+    redis_error = RedisConnectionError(
+        _payload_bearing_error(reason_first=True, marker=response_marker)
+    )
+
+    mock_redis_instance = AsyncMock()
+    mock_redis_instance.set.side_effect = redis_error
+
+    with caplog.at_level(logging.ERROR, logger="LiteLLM"), patch.object(
+        redis_cache, "init_async_client", return_value=mock_redis_instance
+    ):
+        await redis_cache.async_set_cache("lit4930", {"choices": []})
+
+    logged = [
+        record.getMessage()
+        for record in caplog.records
+        if "async set()" in record.getMessage()
+    ]
+    assert logged, "a failed cache write still has to be reported"
+    assert all(
+        response_marker not in message for message in logged
+    ), "the payload embedded in the exception must not reach the log record"
+    assert any(
+        "Connection closed by server." in message for message in logged
+    ), "the reason leads this shape, so bounding must keep it"
+    assert any("ConnectionError:" in message for message in logged)
+    assert any("truncated" in message for message in logged)
+    assert all(len(message) < 500 for message in logged)
+
+
+@pytest.mark.asyncio
+async def test_async_set_cache_pipeline_error_log_keeps_the_reason_at_the_tail(
+    monkeypatch, redis_no_ping, caplog
+):
+    """redis-py's pipeline wrapper puts the command first and the reason last, so a
+    head-only bound would print part of the payload and drop the only diagnostic."""
+    from redis.exceptions import ResponseError
+
+    monkeypatch.setenv("REDIS_HOST", "https://my-test-host")
+    redis_cache = RedisCache()
+
+    response_marker = "pipeline-exception-slot-marker"
+    redis_error = ResponseError(
+        _payload_bearing_error(reason_first=False, marker=response_marker)
+    )
+
+    mock_redis_instance = AsyncMock()
+    mock_redis_instance.pipeline = MagicMock(side_effect=redis_error)
+
+    with caplog.at_level(logging.ERROR, logger="LiteLLM"), patch.object(
+        redis_cache, "init_async_client", return_value=mock_redis_instance
+    ):
+        await redis_cache.async_set_cache_pipeline(
+            cache_list=[("lit4930", {"choices": []})]
+        )
+
+    logged = [
+        record.getMessage()
+        for record in caplog.records
+        if "async set_cache_pipeline()" in record.getMessage()
+    ]
+    assert logged, "a failed pipeline write still has to be reported"
+    assert all(
+        response_marker not in message for message in logged
+    ), "the payload embedded in the exception must not reach the log record"
+    assert any(
+        "READONLY" in message for message in logged
+    ), "the reason trails this shape, so a head-only bound would lose it"
+    assert any("truncated" in message for message in logged)
+    assert all(len(message) < 500 for message in logged)
+
+
+@pytest.mark.parametrize(
+    "raised",
+    [
+        pytest.param(ValueError("no"), id="exception"),
+        pytest.param(KeyboardInterrupt("no"), id="base_exception"),
+    ],
+)
+def test_redis_error_text_never_raises(raised):
+    """__str__ is caller-controlled code and this runs inside except blocks that exist
+    to keep the request alive, so an unrenderable exception has to render to something."""
+    from litellm.caching.redis_cache import _redis_error_text
+
+    class Unrenderable(Exception):
+        def __str__(self):
+            raise raised
+
+    try:
+        rendered = _redis_error_text(Unrenderable())
+    except BaseException as escaped:  # noqa: BLE001  # the regression is precisely that anything escapes here
+        pytest.fail(f"rendering must not re-raise: {escaped!r}")
+
+    assert "UnrenderableException" in rendered
+
+
+@pytest.mark.asyncio
+async def test_error_log_survives_an_exception_that_cannot_be_rendered(
+    monkeypatch, redis_no_ping, caplog
+):
+    """End to end: a write whose error cannot be rendered is still a swallowed write,
+    not a failed request."""
+    from redis.exceptions import ConnectionError as RedisConnectionError
+
+    class UnrenderableRedisError(RedisConnectionError):
+        def __str__(self):
+            raise ValueError("__str__ is caller-controlled code")
+
+    monkeypatch.setenv("REDIS_HOST", "https://my-test-host")
+    redis_cache = RedisCache()
+
+    mock_redis_instance = AsyncMock()
+    mock_redis_instance.set.side_effect = UnrenderableRedisError()
+
+    with caplog.at_level(logging.ERROR, logger="LiteLLM"), patch.object(
+        redis_cache, "init_async_client", return_value=mock_redis_instance
+    ):
+        try:
+            await redis_cache.async_set_cache("lit4930", {"choices": []})
+        except BaseException as escaped:  # noqa: BLE001  # the regression is precisely that anything escapes here
+            pytest.fail(f"rendering the exception must not escalate the failure: {escaped!r}")
+
+    logged = [
+        record.getMessage()
+        for record in caplog.records
+        if "async set()" in record.getMessage()
+    ]
+    assert logged, "the write failure still has to be reported"
+    assert any("UnrenderableException" in message for message in logged)
+    assert any("lit4930" in message for message in logged)

--- a/tests/test_litellm/caching/test_redis_cache.py
+++ b/tests/test_litellm/caching/test_redis_cache.py
@@ -1,4 +1,5 @@
 import asyncio
+import logging
 import os
 import sys
 from unittest.mock import MagicMock, patch
@@ -613,3 +614,140 @@ async def test_only_connectivity_failures_open_the_breaker(error, opens_breaker)
         await _run_under_circuit_breaker(breaker, "op", failing_call)
 
     assert breaker.is_open() is opens_breaker
+
+
+# Every Redis write error logged the value being written (#11157), so an ordinary
+# retryable failure — a pooled socket the server had already reaped, a read timeout —
+# put the full upstream response object (choices[].message.content included) into the
+# proxy's ERROR log, where it is shipped to wherever the proxy's stdout goes. The
+# failure still has to be reported; the payload does not belong in the report.
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "fail_at",
+    [
+        pytest.param("client", id="client_init_failure"),
+        pytest.param("write", id="write_failure"),
+    ],
+)
+async def test_async_set_cache_error_log_omits_the_cached_value(
+    fail_at, monkeypatch, redis_no_ping, caplog
+):
+    """A failed async_set_cache must report the error and the key, never the value."""
+    from redis.exceptions import ConnectionError as RedisConnectionError
+
+    monkeypatch.setenv("REDIS_HOST", "https://my-test-host")
+    redis_cache = RedisCache()
+
+    response_marker = "response-body-marker"
+    value = {"choices": [{"message": {"content": f"{response_marker} " * 20}}]}
+    redis_error = RedisConnectionError("Connection closed by server.")
+
+    mock_redis_instance = AsyncMock()
+    if fail_at == "write":
+        mock_redis_instance.set.side_effect = redis_error
+        client_patch = patch.object(
+            redis_cache, "init_async_client", return_value=mock_redis_instance
+        )
+    else:
+        client_patch = patch.object(
+            redis_cache, "init_async_client", side_effect=redis_error
+        )
+
+    with caplog.at_level(logging.ERROR, logger="LiteLLM"), client_patch:
+        if fail_at == "client":
+            with pytest.raises(RedisConnectionError):
+                await redis_cache.async_set_cache("lit4930", value)
+        else:
+            await redis_cache.async_set_cache("lit4930", value)
+
+    logged = [
+        record.getMessage()
+        for record in caplog.records
+        if "async set()" in record.getMessage()
+    ]
+    assert logged, "a failed cache write still has to be reported"
+    assert all(
+        response_marker not in message for message in logged
+    ), "the cached value must not reach the log record"
+    assert any("Connection closed by server." in message for message in logged)
+    assert any("lit4930" in message for message in logged)
+    assert any(
+        "value_bytes=" in message for message in logged
+    ), "the size of the dropped write is the accounting the value used to carry"
+
+
+@pytest.mark.asyncio
+async def test_async_set_cache_pipeline_error_log_omits_the_cached_values(
+    monkeypatch, redis_no_ping, caplog
+):
+    """Same contract for the bulk path, which logged a `cache_value` that was
+    unconditionally None — it leaked nothing here only because it reported nothing."""
+    from redis.exceptions import TimeoutError as RedisTimeoutError
+
+    monkeypatch.setenv("REDIS_HOST", "https://my-test-host")
+    redis_cache = RedisCache()
+
+    response_marker = "pipeline-body-marker"
+    cache_list = [
+        ("lit4930", {"choices": [{"message": {"content": f"{response_marker} " * 20}}]}),
+        ("lit4931", {"choices": [{"message": {"content": f"{response_marker} " * 20}}]}),
+    ]
+    redis_error = RedisTimeoutError("Timeout reading from my-test-host:6379")
+
+    mock_redis_instance = AsyncMock()
+    mock_redis_instance.pipeline = MagicMock(side_effect=redis_error)
+
+    with caplog.at_level(logging.ERROR, logger="LiteLLM"), patch.object(
+        redis_cache, "init_async_client", return_value=mock_redis_instance
+    ):
+        await redis_cache.async_set_cache_pipeline(cache_list=cache_list)
+
+    logged = [
+        record.getMessage()
+        for record in caplog.records
+        if "async set_cache_pipeline()" in record.getMessage()
+    ]
+    assert logged, "a failed pipeline write still has to be reported"
+    assert all(
+        response_marker not in message for message in logged
+    ), "the cached values must not reach the log record"
+    assert any("Timeout reading from my-test-host:6379" in message for message in logged)
+    assert any(
+        "num_keys=2" in message for message in logged
+    ), "how much was dropped is what the operator needs from this line"
+
+
+@pytest.mark.asyncio
+async def test_async_set_cache_sadd_error_log_omits_the_cached_value(
+    monkeypatch, redis_no_ping, caplog
+):
+    """The set-member path takes caller-supplied values too, and swallows its error."""
+    from redis.exceptions import ConnectionError as RedisConnectionError
+
+    monkeypatch.setenv("REDIS_HOST", "https://my-test-host")
+    redis_cache = RedisCache()
+
+    member_marker = "sadd-member-marker"
+    redis_error = RedisConnectionError("Connection closed by server.")
+
+    mock_redis_instance = AsyncMock()
+    mock_redis_instance.sadd.side_effect = redis_error
+
+    with caplog.at_level(logging.ERROR, logger="LiteLLM"), patch.object(
+        redis_cache, "init_async_client", return_value=mock_redis_instance
+    ):
+        await redis_cache.async_set_cache_sadd(
+            key="lit4930", value=[f"{member_marker}-1", f"{member_marker}-2"], ttl=60
+        )
+
+    logged = [
+        record.getMessage()
+        for record in caplog.records
+        if "async set_cache_sadd()" in record.getMessage()
+    ]
+    assert logged, "a failed sadd still has to be reported"
+    assert all(member_marker not in message for message in logged)
+    assert any("Connection closed by server." in message for message in logged)
+    assert any("lit4930" in message for message in logged)


### PR DESCRIPTION
## TLDR

Problem this solves:

- A failed Redis cache write logs the whole value at ERROR.
- For the response cache that value is the full completion.
- Routine failures trigger it: reaped idle socket, read timeout.
- `turn_off_message_logging` does not reach this module.

How it solves it:

- Log the exception, the key, and the value's size.
- Same shape as `async_increment_pipeline`, which already logs error-only.
- All 7 value-logging error sites in the file, not one.
- Full values still available at DEBUG via `print_verbose`.

## User Flow

Before: a developer using a proxy with Redis caching enabled has their model's answer copied verbatim into the operator's log stream whenever Redis hiccups.

1. The proxy admin enables the response cache (`litellm_settings.cache: true`, `type: redis`) and sets `turn_off_message_logging: true`.
2. The developer sends `POST https://litellm-domain/v1/chat/completions` with `{"model": "...", "messages": [...]}` and gets a normal `200` back with their answer.
3. Redis closes a pooled connection it has held idle past its own `timeout` (or a reply arrives past the socket timeout), so the proxy's write of that cached answer fails.
4. The developer's answer text — `choices[].message.content`, verbatim, plus the id, model and usage — is written to the proxy's stdout at `ERROR` level and shipped wherever pod logs go.
5. Nothing in the API response changes, so neither the developer nor the admin has any signal that it happened.
6. Anyone with read access to the proxy's log store can now read that developer's answer, for as long as those logs are retained.

After: the same Redis hiccup is still reported, but with accounting instead of the answer.

1. The proxy admin enables the response cache the same way.
2. The developer sends the same `POST https://litellm-domain/v1/chat/completions` and gets the same `200`.
3. Redis closes the same pooled connection and the same cache write fails.
4. The proxy logs `Got exception from REDIS Connection closed by server., key=<cache key>, value_bytes=259` at `ERROR` — the failure, what it was for, and how much was dropped.
5. Nothing in the API response changes.
6. A reader of the proxy's log store learns that a write failed and how big it was; they can no longer read the developer's answer out of it.

## Relevant issues

Fixes #11157

## Relation to #11157 and the open #36484

Found the same way #11157 was, on a production deployment: full response bodies sitting in the
proxy's pod logs after routine cache-write failures — no failover, no outage, no misconfiguration,
just a pooled socket the Redis server had reaped past its own idle `timeout`. Reproduced against
this PR's base below, with a real Redis and no mocks.

- **#11157** (May 2025, "Redis cache timeout causes message content to leak into logs") reported exactly this line, with `turn_off_message_logging: true` already set. A second reporter pinned the offending `verbose_logger.error(..., value)` call in Aug 2025. It was auto-closed `not_planned` by the stale bot in Nov 2025 without a maintainer reply, and the behaviour is unchanged on `main` and `litellm_internal_staging` today.
- **#36484** (open, based on `litellm_internal_staging`) wraps the same values in `redact_string`. That helper is a *secrets* scrubber — PEM blocks, `AKIA…`, `Bearer …`, `sk-…`, `api_key=`, connection strings. It has no notion of message content, so applied to a cached completion it leaves `choices[].message.content` fully intact — checkable in one line:

  ```python
  >>> from litellm.litellm_core_utils.secret_redaction import redact_string
  >>> payload = str({"id": "chatcmpl-x", "model": "gpt-4.1-mini", "choices": [{"index": 0,
  ...     "message": {"role": "assistant", "content": "the full model reply, for this caller only"}}],
  ...     "usage": {"prompt_tokens": 41, "completion_tokens": 512}})
  >>> redact_string(payload) == payload
  True
  ```

  It also does not touch `async_set_cache_pipeline` at all. This PR is complementary, not a duplicate: it removes the payload from the record rather than pattern-matching inside it. Happy to rebase on whichever lands first.

## Why every site, not just the response-cache ones

`grep -n "Writing value=" litellm/caching/redis_cache.py` returns 6 hits, and a 7th site logs `value=%r` under a different format string. They are the same defect written seven times, so the PR closes the class rather than leaving five copies for the next report:

| line | method | what its value can hold |
|---|---|---|
| 539 | `increment_cache` | counter |
| 711 | `async_set_cache` (client init) | **full response object** |
| 763 | `async_set_cache` (write) | **full response object** |
| 850 | `async_set_cache_pipeline` | see below |
| 896 | `async_set_cache_sadd` (client init) | caller-supplied set members |
| 935 | `async_set_cache_sadd` (write) | caller-supplied set members |
| 1007 | `async_increment` | counter |

Two notes on that table:

- The `async_set_cache_pipeline` line logged a `cache_value` local that was assigned `None` at the top of the method and never reassigned — the values live in `cache_list`. So that line has only ever printed `Writing value=None`: it leaked nothing, but it also reported nothing. It now reports `num_keys` and `value_bytes`.
- Line 711's format string is `key=%r, value=%r`, so it is not in the `Writing value=` grep, but it leaks the same object on the same method. It is included.

Debug-level value logging is deliberately untouched — `print_verbose` on these same paths already dumps keys and values, so anyone debugging a cache problem loses nothing by turning `LITELLM_LOG=DEBUG` on. The change is only to what is emitted at ERROR, by default, with no opt-out.

## Second commit: the exception argument is the other half of the same path

Dropping the value argument does not close the path on its own. A Redis client can put the command it failed on, key and value included, into the exception it raises: redis-py rewraps every pipelined failure as `Command # N (<the whole command>) of pipeline caused error: <reason>`, so on the pipeline paths the cached value arrives through `str(e)` while the value argument reads `None`. The client does that wrapping, not the server, so even a short generic error reply produces the long line, and nothing in this process bounds its size.

The second commit renders the exception at those same seven sites through `_redis_error_text`, which prints the exception type, a bounded head and a bounded tail. Both ends, because the two shapes put the diagnostic at opposite ends: a connection error leads with the reason, the pipeline wrapper above trails with it, and a head-only bound would print part of the command while dropping the only diagnostic. The cut is made on the UTF-8 encoding rather than on characters, so a non-ASCII payload cannot exceed the budget several times over.

`__str__` is caller-controlled code and every caller here is an `except` block that exists to keep the request alive, so the render is guarded and falls back to a static string rather than turning a swallowed cache miss into a failed request. Five new tests cover it: the two error shapes, a raising `__str__` in both its `Exception` and `BaseException` forms, and the end-to-end swallowed-write path.

This bounds the message, it does not erase it. A client that puts its diagnostic past the budget still gets the head and the tail.

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally: `uv run pytest tests/test_litellm/caching/test_redis_cache.py -v` → 53 passed (44 pre-existing + 9 new)
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

Shared setup — a real `redis-server`, no mocks, no stubbed client. The failure is induced the way production hits it: the server reaps the pooled connection (`CLIENT KILL TYPE normal`, the same outcome as redis's own idle `timeout`), and the next write lands on the dead socket.

```bash
docker run -d --rm --name repro-redis -p 127.0.0.1:6399:6379 redis:7-alpine
```

```python
# repro.py
import asyncio, logging, subprocess, sys
from litellm.caching.redis_cache import RedisCache

logging.basicConfig(level=logging.ERROR, stream=sys.stdout)
RESPONSE = {
    "id": "chatcmpl-repro-demo",
    "model": "gpt-4.1-mini",
    "choices": [{"index": 0, "message": {"role": "assistant",
                 "content": "SENSITIVE-USER-ANSWER: the full model reply, meant only for this caller"}}],
    "usage": {"prompt_tokens": 41, "completion_tokens": 512},
}

async def main():
    cache = RedisCache(host="127.0.0.1", port=6399, socket_timeout=2.0)
    await cache.async_set_cache("repro:warmup", RESPONSE)          # succeeds
    subprocess.run(["docker", "exec", "repro-redis", "redis-cli",
                    "CLIENT", "KILL", "TYPE", "normal"], check=True, capture_output=True)
    await cache.async_set_cache("repro:leak", RESPONSE)            # lands on the dead socket

asyncio.run(main())
```

### Before (9821b451e3b204816ff939240fe4b6eba2f931bc)

1. `python repro.py`
2. Observed — the cached completion is in the log record:

```
LiteLLM:ERROR: redis_cache.py:762 - LiteLLM Redis Caching: async set() - Got exception from REDIS
Connection closed by server., Writing value={'id': 'chatcmpl-repro-demo', 'model': 'gpt-4.1-mini',
'choices': [{'index': 0, 'message': {'role': 'assistant', 'content': 'SENSITIVE-USER-ANSWER: the full
model reply, meant only for this caller'}}], 'usage': {'prompt_tokens': 41, 'completion_tokens': 512}}
```

3. With this PR's tests applied on top of this base but the source left alone: `uv run pytest tests/test_litellm/caching/test_redis_cache.py -k omits_the_cached -v` → **4 failed** ("the cached value must not reach the log record")

### After (79a019d1f4afc44278f626d2ae08f3e1fd608827)

1. `python repro.py`
2. Observed — the same failure, reported without the payload:

```
LiteLLM:ERROR: redis_cache.py:763 - LiteLLM Redis Caching: async set() - Got exception from REDIS
Connection closed by server., key=repro:leak, value_bytes=259
```

3. `uv run pytest tests/test_litellm/caching/test_redis_cache.py -v` → **53 passed** (44 pre-existing + 9 new)

## Type

🐛 Bug Fix

## Caveats (if any)

- ERROR-level only; DEBUG `print_verbose` value dumps are unchanged.
- Keys are still logged, as before, on purpose.
- `value_bytes` is `len(str(value))`, a size, not a serialised length.
- It is computed eagerly, on an error path only.
- The exception text is bounded, not removed; the head and tail budget still prints.
- Overlaps #36484's lines; happy to rebase either way.

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR