### PR TITLE
fix(ptu): warn when config.yaml declares PTU while attribution is off

### DIFF
--- a/litellm/litellm_core_utils/ptu_pricing.py
+++ b/litellm/litellm_core_utils/ptu_pricing.py
@@ -124,6 +124,14 @@ def ptu_identity_error(
     return None
 
 
+PTU_MODEL_INFO_FIELDS: Final = ("ptu_count", "cost_per_ptu_per_hour", "ptu_effective_from", "ptu_effective_to")
+
+
+def declares_ptu(model_info: Mapping[str, object]) -> bool:
+    """Whether any PTU field is set here, including one too malformed to charge."""
+    return any(model_info.get(field) is not None for field in PTU_MODEL_INFO_FIELDS)
+
+
 def ptu_config_error(model_info: Mapping[str, object], *, model_name: str | None = None) -> str | None:
     """Why this PTU configuration cannot be honoured, else None.
 

--- a/litellm/proxy/management_endpoints/model_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/model_management_endpoints.py
@@ -27,6 +27,7 @@ from litellm.constants import LITELLM_PROXY_ADMIN_NAME
 from litellm.litellm_core_utils.ptu_pricing import (
     CUSTOM_PRICING_FIELDS,
     PTU_EMPTIED_PRICING_FIELDS,
+    PTU_MODEL_INFO_FIELDS,
     PTU_ZEROED_PRICING_FIELDS,
     PTU_ZEROED_TABLE_FIELDS,
     SEARCH_CONTEXT_SIZES,
@@ -247,7 +248,6 @@ def _raise_on_strategy_router_write_violation(
     )
 
 
-_PTU_MODEL_INFO_FIELDS: Final = ("ptu_count", "cost_per_ptu_per_hour", "ptu_effective_from", "ptu_effective_to")
 _PTU_PRICED_PAIR: Final = frozenset({"ptu_count", "cost_per_ptu_per_hour"})
 
 
@@ -261,7 +261,7 @@ def _explicitly_cleared_ptu_fields(model_info: ModelInfo | None) -> frozenset[st
         return frozenset()
     return frozenset(
         field
-        for field in _PTU_MODEL_INFO_FIELDS
+        for field in PTU_MODEL_INFO_FIELDS
         if field in model_info.model_fields_set and getattr(model_info, field) is None
     )
 
@@ -294,7 +294,7 @@ def _raise_if_ptu_cost_attribution_disabled(incoming_model_info: Mapping[str, ob
     """
     if is_ptu_cost_attribution_enabled():
         return
-    supplied: Final = tuple(field for field in _PTU_MODEL_INFO_FIELDS if incoming_model_info.get(field) is not None)
+    supplied: Final = tuple(field for field in PTU_MODEL_INFO_FIELDS if incoming_model_info.get(field) is not None)
     if not supplied:
         return
     raise HTTPException(

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -66,6 +66,8 @@ from litellm.litellm_core_utils.credential_accessor import CredentialAccessor
 from litellm.litellm_core_utils.dd_tracing import tracer
 from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLogging
 from litellm.litellm_core_utils.ptu_pricing import (
+    PTU_COST_ATTRIBUTION_ENV_VAR,
+    declares_ptu,
     is_ptu_cost_attribution_enabled,
     ptu_config_error,
     ptu_identity_error,
@@ -8233,6 +8235,21 @@ class Router:
             if isinstance(entry.get("model_info"), dict) and entry["model_info"].get("id") is not None
         )
         duplicate_ids: Final = frozenset(model_id for model_id in declared_ids if declared_ids.count(model_id) > 1)
+
+        ptu_declared: Final = tuple(
+            str(entry.get("model_name"))
+            for entry in original_model_list
+            if isinstance(entry.get("model_info"), dict)
+            and entry["model_info"].get("db_model") is not True
+            and declares_ptu(entry["model_info"])
+        )
+        if ptu_declared and not is_ptu_cost_attribution_enabled():
+            verbose_router_logger.warning(
+                "PTU fields are set on config.yaml deployment(s) %s, but PTU cost attribution is disabled, so no "
+                "flat cost accrues and this traffic is billed per token. Set %s=True to enable it",
+                ", ".join(ptu_declared),
+                PTU_COST_ATTRIBUTION_ENV_VAR,
+            )
 
         for model in original_model_list:
             _model_name = model.pop("model_name")

--- a/tests/test_litellm/test_router_model_cost_isolation.py
+++ b/tests/test_litellm/test_router_model_cost_isolation.py
@@ -8,6 +8,7 @@ should still use the built-in pricing.
 """
 
 import copy
+import logging
 import os
 import re
 import sys
@@ -2007,3 +2008,127 @@ def test_a_falsy_id_is_still_scanned_for_collisions():
                     },
                 ]
             )
+
+
+# --- a reservation declared while the feature is off says so ------------------------
+
+
+def _ptu_warnings(caplog):
+    return tuple(
+        record.getMessage()
+        for record in caplog.records
+        if record.name == "LiteLLM Router" and record.levelno == logging.WARNING and "PTU" in record.getMessage()
+    )
+
+
+def test_a_reservation_declared_while_the_feature_is_off_is_warned_about(caplog):
+    """The deployment serves and bills per token, so without this the operator believes they
+    reserved capacity and sees no signal anywhere that nothing accrues."""
+    with caplog.at_level(logging.WARNING, logger="LiteLLM Router"):
+        _ptu_router(ptu_enabled=False)
+
+    warnings = _ptu_warnings(caplog)
+
+    assert len(warnings) == 1
+    assert "gpt-4o-ptu" in warnings[0]
+    assert "LITELLM_ENABLE_PTU_COST_ATTRIBUTION" in warnings[0]
+
+
+def test_a_reservation_is_not_warned_about_while_the_feature_is_on(caplog):
+    with caplog.at_level(logging.WARNING, logger="LiteLLM Router"):
+        _ptu_router()
+
+    assert _ptu_warnings(caplog) == ()
+
+
+def test_a_deployment_carrying_no_ptu_field_is_not_warned_about(caplog):
+    """Most of every config.yaml, so warning here would fire on proxies that never asked."""
+    with caplog.at_level(logging.WARNING, logger="LiteLLM Router"):
+        _ptu_router(model_info={"team_id": "team-alpha"}, ptu_enabled=False)
+
+    assert _ptu_warnings(caplog) == ()
+
+
+def test_a_half_written_reservation_is_warned_about(caplog):
+    """A count with no rate is not a chargeable reservation, but the operator still meant to
+    declare one, so what they wrote is what decides whether they hear about it."""
+    half_written = {k: v for k, v in _PTU_MODEL_INFO.items() if k != "cost_per_ptu_per_hour"}
+
+    with caplog.at_level(logging.WARNING, logger="LiteLLM Router"):
+        _ptu_router(model_info=half_written, ptu_enabled=False)
+
+    assert len(_ptu_warnings(caplog)) == 1
+
+
+@pytest.mark.parametrize(
+    "typo",
+    [
+        {"ptu_count": 0},
+        {"ptu_count": 0, "cost_per_ptu_per_hour": 0, "ptu_effective_from": None},
+    ],
+    ids=["count out of range", "every value still a zero placeholder"],
+)
+def test_a_reservation_dropped_by_a_typo_is_warned_about(caplog, typo):
+    """An out-of-range value fails ModelInfo before the flag is ever consulted, so the
+    deployment stops serving on a proxy that never enabled PTU. The warning is what tells the
+    operator which feature the entry that vanished belonged to.
+
+    Built the way proxy_server builds it, since dropping rather than raising is what
+    ``ignore_invalid_deployments`` does and config.yaml is loaded with it on.
+    """
+    with patch.dict(os.environ, {"LITELLM_ENABLE_PTU_COST_ATTRIBUTION": ""}, clear=False):
+        with caplog.at_level(logging.WARNING, logger="LiteLLM Router"):
+            router = Router(
+                ignore_invalid_deployments=True,
+                model_list=[
+                    {
+                        "model_name": "gpt-4o-ptu",
+                        "litellm_params": {"model": "azure/gpt-4o", "api_key": "k", "api_base": "https://e.azure.com"},
+                        "model_info": {**_PTU_MODEL_INFO, **typo},
+                    }
+                ],
+            )
+
+    assert router.model_list == []
+    assert len(_ptu_warnings(caplog)) == 1
+
+
+def test_a_db_backed_reservation_is_not_warned_about(caplog):
+    """/model/new already answered the caller with a 400, so repeating it on every reload
+    would report the operator's own rejected write back to them as a standing problem."""
+    with caplog.at_level(logging.WARNING, logger="LiteLLM Router"):
+        _ptu_router(model_info={**_PTU_MODEL_INFO, "db_model": True}, ptu_enabled=False)
+
+    assert _ptu_warnings(caplog) == ()
+
+
+def test_every_declaring_deployment_is_named(caplog):
+    """One line naming all of them, so a reload does not bury the config in repeats."""
+    with patch.dict(os.environ, {"LITELLM_ENABLE_PTU_COST_ATTRIBUTION": ""}, clear=False):
+        with caplog.at_level(logging.WARNING, logger="LiteLLM Router"):
+            Router(
+                model_list=[
+                    {
+                        "model_name": "azure-ptu-east",
+                        "litellm_params": {"model": "azure/gpt-4o", "api_key": "k", "api_base": "https://e.azure.com"},
+                        "model_info": dict(_PTU_MODEL_INFO),
+                    },
+                    {
+                        "model_name": "azure-ptu-west",
+                        "litellm_params": {"model": "azure/gpt-4o", "api_key": "k", "api_base": "https://w.azure.com"},
+                        "model_info": {**_PTU_MODEL_INFO, "id": "ptu-alpha-westus"},
+                    },
+                    {
+                        "model_name": "plain-gpt-4o",
+                        "litellm_params": {"model": "azure/gpt-4o", "api_key": "k", "api_base": "https://p.azure.com"},
+                        "model_info": {"id": "plain"},
+                    },
+                ]
+            )
+
+    warnings = _ptu_warnings(caplog)
+
+    assert len(warnings) == 1
+    assert "azure-ptu-east" in warnings[0]
+    assert "azure-ptu-west" in warnings[0]
+    assert "plain-gpt-4o" not in warnings[0]


### PR DESCRIPTION
## TLDR

Problem this solves:

- PTU in config.yaml accrues nothing while the feature is off
- Nothing anywhere says so, so operators assume it is on
- A typo drops the deployment with no hint which feature it was

How it solves it:

- Registration names the declaring deployments once, at startup
- The line points at the env var that turns attribution on
- Behavior is unchanged: nothing is stripped, rejected, or rescued
- The same field list the endpoint gate reads now has one home

## User Flow

Before: an admin reserves Azure PTU capacity in config.yaml, and their team's spend never reflects it

1. They add `ptu_count`, `cost_per_ptu_per_hour`, `ptu_effective_from` and `team_id` to a deployment in config.yaml
2. They restart the proxy, which starts cleanly and logs nothing about the reservation
3. They send traffic to that model and it answers normally
4. Days later they open https://litellm-domain/ui/?page=usage, filter to the team, and see only per-token spend; the hourly reservation they configured is nowhere
5. Nothing in the startup log, the model page, or the usage page ever mentioned that the feature was switched off

After: the same restart tells them the feature is off and names the variable that turns it on

1. They add the same fields to the same deployment in config.yaml
2. They restart the proxy and the startup log says PTU fields are set on `azure-ptu`, that attribution is disabled so no flat cost accrues and the traffic bills per token, and that `LITELLM_ENABLE_PTU_COST_ATTRIBUTION=True` enables it
3. They set that variable and restart; the line is gone
4. They send traffic, and https://litellm-domain/ui/?page=usage now shows the reservation's hourly cost against the team

## Relevant issues

## Linear ticket

Refs LIT-5809

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

Shared setup, both sides. A real Gemini deployment carrying a reservation, alongside an ordinary one, with `LITELLM_ENABLE_PTU_COST_ATTRIBUTION` unset:

```yaml
model_list:
  - model_name: gemini-ptu
    litellm_params:
      model: gemini/gemini-2.5-flash
      api_key: os.environ/GEMINI_API_KEY
    model_info:
      id: gemini-ptu-eastus
      team_id: team-alpha
      ptu_count: 100
      cost_per_ptu_per_hour: 0.02
      ptu_effective_from: "2026-01-01T00:00:00Z"
  - model_name: gemini-ondemand
    litellm_params:
      model: gemini/gemini-2.5-flash
      api_key: os.environ/GEMINI_API_KEY
```

The typo case reuses the same file with `ptu_count: 0`. Both sides run against the same Postgres, launched with `python -m litellm.proxy.proxy_cli --config <file>`

### Before (b9bff0998c)

#### A reservation declared while attribution is off

1. Start the proxy on the config above, then read the startup log for anything naming PTU:

```
$ grep -ci "PTU cost attribution is disabled" base_valid.log
0
$ grep -i "ptu" base_valid.log | grep -v register_model
    gemini-ptu
```

2. The only mention is the deployment's own name in the model list. Nothing says the feature is off
3. The deployment registers and serves:

```
$ curl -s http://127.0.0.1:4892/model/info -H "Authorization: Bearer sk-..." | jq -r '.data[] | "\(.model_name) | ptu_count=\(.model_info.ptu_count)"'
gemini-ptu | ptu_count=100
gemini-ondemand | ptu_count=null
```

#### A typo in the same reservation

1. Restart on the same file with `ptu_count: 0`, then read the log:

```
$ grep -ci "PTU cost attribution is disabled" base_typo.log
0
$ grep "Error creating deployment" base_typo.log | head -1
19:17:57 - LiteLLM Router:ERROR: router.py:7797 - Error creating deployment: 1 validation error for ModelInfo
```

2. The deployment is gone, and the error names a pydantic model rather than the feature:

```
$ curl -s http://127.0.0.1:4892/model/info -H "Authorization: Bearer sk-..." | jq -r '[.data[].model_name]'
["gemini-ondemand"]
```

### After (e378503886)

#### A reservation declared while attribution is off

1. Start the proxy on the same config. The startup log now says so, once:

```
$ grep -c "PTU cost attribution is disabled" flagoff.log
1
$ grep "PTU cost attribution" flagoff.log
19:13:18 - LiteLLM Router:WARNING: router.py:8247 - PTU fields are set on config.yaml
deployment(s) gemini-ptu, but PTU cost attribution is disabled, so no flat cost accrues
and this traffic is billed per token. Set LITELLM_ENABLE_PTU_COST_ATTRIBUTION=True to enable it
```

2. Only the declaring deployment is named; `gemini-ondemand` is not
3. The deployment registers and serves exactly as before:

```
$ curl -s http://127.0.0.1:4891/model/info -H "Authorization: Bearer sk-..." | jq -r '.data[] | "\(.model_name) | id=\(.model_info.id)"'
gemini-ptu | id=gemini-ptu-eastus
gemini-ondemand | id=76058c439c2182aa7c8fd6a55729eb958321073699bf718f5cc5f7a34bf0d8af
```

4. A real call through it, on a team key, confirms the line's claim about per-token billing:

```
$ curl -s -X POST http://127.0.0.1:4891/v1/chat/completions -H "Authorization: Bearer sk-<team key>" \
    -H "Content-Type: application/json" \
    -d '{"model":"gemini-ptu","messages":[{"role":"user","content":"Reply with the single word: reserved"}]}'
reply: reserved
usage: {'completion_tokens': 28, 'prompt_tokens': 8, 'total_tokens': 36}
```

```
$ psql -tAc "select model_group, spend, ptu_flat_cost is not null from ..."
gemini-ptu|7.24e-05        <- billed per token
team-alpha|7.24e-05|0      <- LiteLLM_DailyTeamSpend: no flat cost accrued
```

#### The feature switched on

1. Restart with `LITELLM_ENABLE_PTU_COST_ATTRIBUTION=True` on the same config:

```
$ grep -c "PTU cost attribution is disabled" flagon.log
0
$ curl -s http://127.0.0.1:4891/model/info -H "Authorization: Bearer sk-..." | jq -r '.data[] | "\(.model_name) | ptu_count=\(.model_info.ptu_count)"'
gemini-ptu | ptu_count=100
gemini-ondemand | ptu_count=null
```

2. The line is gone and the deployment is unchanged

#### A typo in the same reservation

1. Restart on the `ptu_count: 0` file with attribution still off. Both lines now appear together:

```
$ grep -E "PTU cost attribution is disabled|Error creating deployment" typo.log
19:14:17 - LiteLLM Router:WARNING: router.py:8247 - PTU fields are set on config.yaml
deployment(s) gemini-ptu, but PTU cost attribution is disabled, ...
19:14:17 - LiteLLM Router:ERROR: router.py:7799 - Error creating deployment: 1 validation
error for ModelInfo
```

2. The deployment is still dropped, unchanged from base; what is new is that the operator can see which feature the vanished entry belonged to:

```
$ curl -s http://127.0.0.1:4891/model/info -H "Authorization: Bearer sk-..." | jq -r '[.data[].model_name]'
["gemini-ondemand"]
```

## Blast radius

Driven base b9bff0998c versus head e378503886 on two proxies against one Postgres, config shapes only, no mocks. Registration was byte-identical on both sides in every case: a window-only reservation, an unparseable date, an organization fan-out, a 250-deployment config, a plain config, and a database-backed reservation created while the feature was on and then read back with it off. The organization fan-out warns once rather than once per expansion, and a live session logged one line across boot, three POST /model/new calls, and 45 seconds of the model refresh loop.

The four PTU field names were declared twice, once in `ptu_pricing` and once in `model_management_endpoints`, so this collapses them into the `ptu_pricing` copy that both already import. The order is load bearing, since the endpoint joins the list into its 400 body; that response is byte-identical to base, checked by diffing the two bodies.

## Type

🐛 Bug Fix

## Caveats (if any)

- The typo still drops the deployment; only the silence is fixed
- Fires once per Router build, so once per boot or reload
- The flag is read only when a config deployment declares PTU
- Past roughly 230 declaring deployments stdout truncation elides some names
- A window with no count or rate now warns; it accrued nothing before either

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Logging-only operator signal plus a shared field-list constant. Billing, registration, and API validation behavior are unchanged.
> 
> **Overview**
> When `config.yaml` deployments set PTU fields while `LITELLM_ENABLE_PTU_COST_ATTRIBUTION` is off, the router now logs a **single warning** naming those deployments and the env var that enables attribution. Traffic still bills per token; nothing is stripped, rejected, or rescued.
> 
> The warning covers incomplete or invalid PTU blobs (so a dropped typo still names the feature). DB-backed models are skipped because `/model/new` already 400s. `PTU_MODEL_INFO_FIELDS` and `declares_ptu()` now live in `ptu_pricing` so the endpoint gate and this check share one field list.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e378503886a09f8c167153405b8ec16b15fb5679. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->