### PR TITLE
test: say whether a match= pattern is a regex or a literal (ruff RUF043)

### DIFF
--- a/ruff-tests.toml
+++ b/ruff-tests.toml
@@ -32,6 +32,10 @@
 # PT017   an `assert` on the caught error inside `except`. Nothing runs the handler when
 #         the call stops raising, so the test goes green on the exact regression it was
 #         written to catch. `pytest.raises` fails when the call succeeds
+# RUF043  a `match=` pattern carrying regex metacharacters in a plain string. `match=` is
+#         `re.search`, so a `.` copied out of an error message is a wildcard and the block
+#         accepts messages the author never meant to accept. Mark a real regex raw, wrap a
+#         literal message in `re.escape`, and the pattern says which one it is
 #
 # No target-version here on purpose: it resolves from requires-python (>=3.10), so
 # 3.11-only builtins like BaseExceptionGroup are correctly flagged in a tree that
@@ -53,4 +57,5 @@ lint.select = [
     "PT017",
     "PLR0133",
     "PLW0127",
+    "RUF043",
 ]

--- a/tests/llm_translation/test_containers_api.py
+++ b/tests/llm_translation/test_containers_api.py
@@ -63,7 +63,7 @@ def test_container_files_api():
 
         # 3. Try retrieve non-existent file metadata (should raise error)
         print("3. Testing retrieve_container_file (expect error)...")
-        with pytest.raises(Exception, match="(?i)not found|invalid"):
+        with pytest.raises(Exception, match=r"(?i)not found|invalid"):
             retrieve_container_file(
                 container_id=container.id,
                 file_id="cfile_nonexistent",

--- a/tests/llm_translation/test_litellm_proxy_provider.py
+++ b/tests/llm_translation/test_litellm_proxy_provider.py
@@ -1,5 +1,6 @@
 import json
 import os
+import re
 import sys
 from datetime import datetime
 from io import BytesIO
@@ -578,7 +579,7 @@ def test_litellm_gateway_from_sdk_with_response_cost_in_additional_headers():
 
 
 def test_litellm_gateway_from_sdk_with_thinking_param():
-    with pytest.raises(Exception, match="Connection error.") as exc_info:
+    with pytest.raises(Exception, match=re.escape("Connection error.")) as exc_info:
         response = litellm.completion(
             model="litellm_proxy/anthropic.claude-sonnet-4-5-20250929-v1:0",
             messages=[{"role": "user", "content": "Hello world"}],

--- a/tests/local_testing/test_embedding.py
+++ b/tests/local_testing/test_embedding.py
@@ -1,5 +1,6 @@
 import json
 import os
+import re
 import sys
 import traceback
 
@@ -536,13 +537,13 @@ def test_demo_tokens_as_input_to_embeddings_fails_for_titan():
 
     with pytest.raises(
         litellm.BadRequestError,
-        match='litellm.BadRequestError: BedrockException - {"message":"Malformed input request: expected type: String, found: JSONArray, please reformat your input and try again."}',
+        match=re.escape('litellm.BadRequestError: BedrockException - {"message":"Malformed input request: expected type: String, found: JSONArray, please reformat your input and try again."}'),
     ):
         litellm.embedding(model="amazon.titan-embed-text-v1", input=[[1]])
 
     with pytest.raises(
         litellm.BadRequestError,
-        match='litellm.BadRequestError: BedrockException - {"message":"Malformed input request: expected type: String, found: Integer, please reformat your input and try again."}',
+        match=re.escape('litellm.BadRequestError: BedrockException - {"message":"Malformed input request: expected type: String, found: Integer, please reformat your input and try again."}'),
     ):
         litellm.embedding(
             model="amazon.titan-embed-text-v1",

--- a/tests/local_testing/test_embedding.py
+++ b/tests/local_testing/test_embedding.py
@@ -537,13 +537,19 @@ def test_demo_tokens_as_input_to_embeddings_fails_for_titan():
 
     with pytest.raises(
         litellm.BadRequestError,
-        match=re.escape('litellm.BadRequestError: BedrockException - {"message":"Malformed input request: expected type: String, found: JSONArray, please reformat your input and try again."}'),
+        match=re.escape(
+            'litellm.BadRequestError: BedrockException - {"message":"Malformed input request: '
+            'expected type: String, found: JSONArray, please reformat your input and try again."}'
+        ),
     ):
         litellm.embedding(model="amazon.titan-embed-text-v1", input=[[1]])
 
     with pytest.raises(
         litellm.BadRequestError,
-        match=re.escape('litellm.BadRequestError: BedrockException - {"message":"Malformed input request: expected type: String, found: Integer, please reformat your input and try again."}'),
+        match=re.escape(
+            'litellm.BadRequestError: BedrockException - {"message":"Malformed input request: '
+            'expected type: String, found: Integer, please reformat your input and try again."}'
+        ),
     ):
         litellm.embedding(
             model="amazon.titan-embed-text-v1",

--- a/tests/local_testing/test_rules.py
+++ b/tests/local_testing/test_rules.py
@@ -2,6 +2,7 @@
 #    This tests setting rules before / after making llm api calls
 import asyncio
 import os
+import re
 import sys
 import time
 import traceback
@@ -82,7 +83,7 @@ def test_post_call_rule():
     litellm.post_call_rules = [my_post_call_rule]
 
     ### completion
-    with pytest.raises(Exception, match="This violates LiteLLM Proxy Rules. Response too short") as exc_info:
+    with pytest.raises(Exception, match=re.escape("This violates LiteLLM Proxy Rules. Response too short")) as exc_info:
         completion(
             model="gpt-3.5-turbo",
             messages=[{"role": "user", "content": "say sorry"}],
@@ -118,7 +119,7 @@ def test_post_call_rule_streaming():
         stream=True,
     )
 
-    with pytest.raises(Exception, match="This violates LiteLLM Proxy Rules. Response too short") as exc_info:
+    with pytest.raises(Exception, match=re.escape("This violates LiteLLM Proxy Rules. Response too short")) as exc_info:
         list(response)
     assert "This violates LiteLLM Proxy Rules. Response too short" in exc_info.value.message
 

--- a/tests/multi_instance_e2e_tests/test_update_team_e2e.py
+++ b/tests/multi_instance_e2e_tests/test_update_team_e2e.py
@@ -143,7 +143,7 @@ async def test_team_blocking_behavior_multi_instance():
         assert team_info_4001["blocked"] is True, "Team should be blocked after update"
 
         # 8. Make a chat completion request on port 4000 with a new prompt; expect it to be blocked.
-        with pytest.raises(Exception, match="(?i)blocked") as excinfo:
+        with pytest.raises(Exception, match=r"(?i)blocked") as excinfo:
             await chat_completion_on_port(
                 session,
                 key=key,
@@ -157,7 +157,7 @@ async def test_team_blocking_behavior_multi_instance():
         ), f"Expected error indicating team blocked, got: {error_msg}"
 
         # 9. Make a chat completion request on port 4000 with a new prompt; expect it to be blocked.
-        with pytest.raises(Exception, match="(?i)blocked") as excinfo:
+        with pytest.raises(Exception, match=r"(?i)blocked") as excinfo:
             await chat_completion_on_port(
                 session,
                 key=key,
@@ -171,7 +171,7 @@ async def test_team_blocking_behavior_multi_instance():
         ), f"Expected error indicating team blocked, got: {error_msg}"
 
         # 9. Repeat the chat completion request with another new prompt; expect it to be blocked.
-        with pytest.raises(Exception, match="(?i)blocked") as excinfo_second:
+        with pytest.raises(Exception, match=r"(?i)blocked") as excinfo_second:
             await chat_completion_on_port(
                 session,
                 key=key,

--- a/tests/proxy_admin_ui_tests/test_role_based_access.py
+++ b/tests/proxy_admin_ui_tests/test_role_based_access.py
@@ -3,6 +3,7 @@ RBAC tests
 """
 
 import os
+import re
 import sys
 import traceback
 from litellm._uuid import uuid
@@ -411,7 +412,7 @@ async def test_org_admin_create_user_team_wrong_org_permissions(prisma_client):
     request.body = return_body
 
     with pytest.raises(
-        Exception, match="You do not have a role within the selected organization. Passed organization_id"
+        Exception, match=re.escape("You do not have a role within the selected organization. Passed organization_id")
     ) as exc_info:
         response = await user_api_key_auth(request=request, api_key="Bearer " + new_key)
     e = exc_info.value

--- a/tests/proxy_unit_tests/test_key_generate_prisma.py
+++ b/tests/proxy_unit_tests/test_key_generate_prisma.py
@@ -20,6 +20,7 @@
 # function to validate a request - async def user_auth(request: Request):
 
 import os
+import re
 import sys
 import traceback
 from litellm._uuid import uuid
@@ -1498,7 +1499,9 @@ def test_key_generate_with_custom_auth(prisma_client):
             await litellm.proxy.proxy_server.prisma_client.connect()
             request = GenerateKeyRequest()
 
-            with pytest.raises(Exception, match="This violates LiteLLM Proxy Rules. No team id provided.") as exc_info:
+            with pytest.raises(
+                Exception, match=re.escape("This violates LiteLLM Proxy Rules. No team id provided.")
+            ) as exc_info:
                 key = await generate_key_fn(
                     request,
                     user_api_key_dict=UserAPIKeyAuth(
@@ -3045,7 +3048,9 @@ async def test_custom_api_key_header_name(prisma_client):
             "headers": [],
         }
     )
-    with pytest.raises(Exception, match="Malformed API Key passed in. Ensure Key has `Bearer ` prefix") as exc_info:
+    with pytest.raises(
+        Exception, match=re.escape("Malformed API Key passed in. Ensure Key has `Bearer ` prefix")
+    ) as exc_info:
         result = await user_api_key_auth(request=request, api_key="Bearer sk-1234")
     e = exc_info.value
     print("failed with error", e)

--- a/tests/router_unit_tests/test_router_helper_utils.py
+++ b/tests/router_unit_tests/test_router_helper_utils.py
@@ -1832,7 +1832,7 @@ def test_init_auto_router_deployment_duplicate_model_name(mock_auto_router, mode
     )
 
     with pytest.raises(
-        ValueError, match="Auto-router deployment test-auto-router with tags .* already exists"
+        ValueError, match=r"Auto-router deployment test-auto-router with tags .* already exists"
     ):
         router.init_auto_router_deployment(deployment)
 

--- a/tests/test_litellm/integrations/bitbucket/test_bitbucket_prompt_manager.py
+++ b/tests/test_litellm/integrations/bitbucket/test_bitbucket_prompt_manager.py
@@ -1,5 +1,6 @@
 import json
 import os
+import re
 import sys
 from unittest.mock import MagicMock, patch
 
@@ -158,7 +159,7 @@ def test_bitbucket_client_get_file_content_access_denied(mock_get):
 
     client = BitBucketClient(config)
 
-    with pytest.raises(Exception, match="Access denied to file 'test.prompt'"):
+    with pytest.raises(Exception, match=re.escape("Access denied to file 'test.prompt'")):
         client.get_file_content("test.prompt")
 
 

--- a/tests/test_litellm/integrations/gitlab/test_gitlab_prompt_manager.py
+++ b/tests/test_litellm/integrations/gitlab/test_gitlab_prompt_manager.py
@@ -1,4 +1,5 @@
 import os
+import re
 import sys
 from unittest.mock import MagicMock, patch
 
@@ -172,7 +173,7 @@ def test_gitlab_client_get_file_content_access_denied(mock_get):
     mock_get.side_effect = err
 
     client = GitLabClient({"project": "g/s/r", "access_token": "tok"})
-    with pytest.raises(Exception, match="Access denied to file 'test.prompt'"):
+    with pytest.raises(Exception, match=re.escape("Access denied to file 'test.prompt'")):
         client.get_file_content("test.prompt")
 
 

--- a/tests/test_litellm/integrations/test_openmeter.py
+++ b/tests/test_litellm/integrations/test_openmeter.py
@@ -33,7 +33,7 @@ class TestOpenMeterIntegration:
     def test_openmeter_logger_missing_api_key(self):
         """Test that OpenMeterLogger raises exception when API key is missing"""
         os.environ.pop("OPENMETER_API_KEY", None)
-        with pytest.raises(Exception, match="Missing keys.*OPENMETER_API_KEY"):
+        with pytest.raises(Exception, match=r"Missing keys.*OPENMETER_API_KEY"):
             OpenMeterLogger()
 
     def test_common_logic_with_string_user(self):

--- a/tests/test_litellm/litellm_core_utils/test_url_utils.py
+++ b/tests/test_litellm/litellm_core_utils/test_url_utils.py
@@ -100,12 +100,12 @@ class TestEncodeUrlPathSegment:
 
     @pytest.mark.parametrize("value", ["", ".", "..", None])
     def test_rejects_empty_and_dot_segments(self, value):
-        with pytest.raises(ValueError, match="resource_id (is required|cannot be a dot path segment)"):
+        with pytest.raises(ValueError, match=r"resource_id (is required|cannot be a dot path segment)"):
             encode_url_path_segment(value, field_name="resource_id")
 
     @pytest.mark.parametrize("value", ["../model", "model/../other", "/model"])
     def test_rejects_dot_segments_in_multi_segment_paths(self, value):
-        with pytest.raises(ValueError, match="model (is required|cannot be a dot path segment)"):
+        with pytest.raises(ValueError, match=r"model (is required|cannot be a dot path segment)"):
             encode_url_path_segments(value, field_name="model")
 
 

--- a/tests/test_litellm/llms/anthropic/test_anthropic_common_utils.py
+++ b/tests/test_litellm/llms/anthropic/test_anthropic_common_utils.py
@@ -929,7 +929,7 @@ class TestValidateEnvironmentAuthToken:
         config = AnthropicModelInfo()
         with mock_patch.dict("os.environ", {}, clear=True):
             with pytest.raises(
-                Exception, match="ANTHROPIC_API_KEY.*ANTHROPIC_AUTH_TOKEN"
+                Exception, match=r"ANTHROPIC_API_KEY.*ANTHROPIC_AUTH_TOKEN"
             ):
                 config.validate_environment(
                     headers={},

--- a/tests/test_litellm/llms/bedrock/chat/test_converse_transformation.py
+++ b/tests/test_litellm/llms/bedrock/chat/test_converse_transformation.py
@@ -3025,7 +3025,7 @@ def test_request_metadata_key_constraints():
     long_key = "a" * 257
     invalid_metadata = {long_key: "value"}
 
-    with pytest.raises(Exception, match="(?i)key length|256 characters"):
+    with pytest.raises(Exception, match=r"(?i)key length|256 characters"):
         config.transform_request(
             model="anthropic.claude-haiku-4-5-20251001-v1:0",
             messages=messages,
@@ -3037,7 +3037,7 @@ def test_request_metadata_key_constraints():
     # Test empty key
     invalid_metadata = {"": "value"}
 
-    with pytest.raises(Exception, match="(?i)key length|empty"):
+    with pytest.raises(Exception, match=r"(?i)key length|empty"):
         config.transform_request(
             model="anthropic.claude-haiku-4-5-20251001-v1:0",
             messages=messages,
@@ -3057,7 +3057,7 @@ def test_request_metadata_value_constraints():
     long_value = "a" * 257
     invalid_metadata = {"key": long_value}
 
-    with pytest.raises(Exception, match="(?i)value length|256 characters"):
+    with pytest.raises(Exception, match=r"(?i)value length|256 characters"):
         config.transform_request(
             model="anthropic.claude-haiku-4-5-20251001-v1:0",
             messages=messages,

--- a/tests/test_litellm/llms/oci/chat/test_oci_generic_chat.py
+++ b/tests/test_litellm/llms/oci/chat/test_oci_generic_chat.py
@@ -106,7 +106,7 @@ class TestGenericToolCallErrors:
             )
 
     def test_non_string_id_raises(self):
-        with pytest.raises(OCIError, match="id.*must be a string"):
+        with pytest.raises(OCIError, match=r"id.*must be a string"):
             adapt_messages_to_generic_oci_standard_tool_call(
                 "assistant",
                 [
@@ -126,7 +126,7 @@ class TestGenericToolCallErrors:
             )
 
     def test_non_string_function_name_raises(self):
-        with pytest.raises(OCIError, match="function.name.*must be a string"):
+        with pytest.raises(OCIError, match=r"function\.name.*must be a string"):
             adapt_messages_to_generic_oci_standard_tool_call(
                 "assistant",
                 [
@@ -139,7 +139,7 @@ class TestGenericToolCallErrors:
             )
 
     def test_non_string_arguments_raises(self):
-        with pytest.raises(OCIError, match="arguments.*must be a JSON string"):
+        with pytest.raises(OCIError, match=r"arguments.*must be a JSON string"):
             adapt_messages_to_generic_oci_standard_tool_call(
                 "assistant",
                 [

--- a/tests/test_litellm/llms/vertex_ai/files/test_vertex_ai_files_handler.py
+++ b/tests/test_litellm/llms/vertex_ai/files/test_vertex_ai_files_handler.py
@@ -3,6 +3,7 @@ Test Vertex AI files handler functionality
 """
 
 import asyncio
+import re
 from types import MappingProxyType
 import pytest
 from unittest.mock import AsyncMock, patch
@@ -180,7 +181,7 @@ class TestVertexAIFilesHandler:
             # Should raise ValueError for failed download
             with pytest.raises(
                 ValueError,
-                match="Failed to download file from GCS: gs://test-bucket/litellm-vertex-files/uploads/abc-test-file.txt",
+                match=re.escape("Failed to download file from GCS: gs://test-bucket/litellm-vertex-files/uploads/abc-test-file.txt"),
             ):
                 await self.handler.afile_content(
                     file_content_request=file_content_request,

--- a/tests/test_litellm/llms/vertex_ai/files/test_vertex_ai_files_handler.py
+++ b/tests/test_litellm/llms/vertex_ai/files/test_vertex_ai_files_handler.py
@@ -181,7 +181,10 @@ class TestVertexAIFilesHandler:
             # Should raise ValueError for failed download
             with pytest.raises(
                 ValueError,
-                match=re.escape("Failed to download file from GCS: gs://test-bucket/litellm-vertex-files/uploads/abc-test-file.txt"),
+                match=re.escape(
+                    "Failed to download file from GCS: "
+                    "gs://test-bucket/litellm-vertex-files/uploads/abc-test-file.txt"
+                ),
             ):
                 await self.handler.afile_content(
                     file_content_request=file_content_request,

--- a/tests/test_litellm/llms/vertex_ai/test_vertex_ai_common_utils.py
+++ b/tests/test_litellm/llms/vertex_ai/test_vertex_ai_common_utils.py
@@ -33,7 +33,7 @@ def test_validate_vertex_location_accepts_valid(location):
     ["attacker.example/", "evil.com#", "us.attacker.example", "us/../..", "US", "us_central1", "-us", "", None],
 )
 def test_validate_vertex_location_rejects_invalid(location):
-    with pytest.raises(ValueError, match="vertex_location is required|Invalid vertex_location format"):
+    with pytest.raises(ValueError, match=r"vertex_location is required|Invalid vertex_location format"):
         validate_vertex_location(location)
 
 

--- a/tests/test_litellm/proxy/client/cli/test_agents.py
+++ b/tests/test_litellm/proxy/client/cli/test_agents.py
@@ -255,7 +255,7 @@ class TestRunAgent:
         assert calls["args"] == ("claude", "--resume")
 
     def test_missing_binary_raises_with_install_hint(self):
-        with pytest.raises(AgentRunError, match="claude.*Install it first"):
+        with pytest.raises(AgentRunError, match=r"claude.*Install it first"):
             run_agent(
                 "http://localhost:4000",
                 "sk-key",

--- a/tests/test_litellm/proxy/db/test_db_url_settings.py
+++ b/tests/test_litellm/proxy/db/test_db_url_settings.py
@@ -504,7 +504,7 @@ def test_apply_to_env_rejects_pinned_sqlite_direct_url(monkeypatch):
     monkeypatch.setenv("DATABASE_URL", "postgresql://u:p@writer.example.com:5432/db")
     monkeypatch.setenv("DIRECT_URL", "sqlite:///data/litellm.db")
 
-    with pytest.raises(RuntimeError, match="DIRECT_URL.*sqlite"):
+    with pytest.raises(RuntimeError, match=r"DIRECT_URL.*sqlite"):
         _apply()
 
 
@@ -514,7 +514,7 @@ def test_apply_to_env_rejects_pinned_non_postgres_reader(monkeypatch):
         "DATABASE_URL_READ_REPLICA", "mysql://u:p@reader.example.com:3306/db"
     )
 
-    with pytest.raises(RuntimeError, match="DATABASE_URL_READ_REPLICA.*mysql"):
+    with pytest.raises(RuntimeError, match=r"DATABASE_URL_READ_REPLICA.*mysql"):
         _apply()
 
 

--- a/tests/test_litellm/proxy/proxy_server/test_proxy_config.py
+++ b/tests/test_litellm/proxy/proxy_server/test_proxy_config.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 from types import SimpleNamespace
 from typing import Any, Dict
 from unittest.mock import AsyncMock, MagicMock
@@ -303,7 +304,7 @@ def test_resolve_routing_plugins_rejects_non_routing_plugin(tmp_path):
     plugin_file = tmp_path / "bad_rs_plugin.py"
     plugin_file.write_text("not_a_plugin = object()\n")
 
-    with pytest.raises(ValueError, match="router_settings.plugins"):
+    with pytest.raises(ValueError, match=re.escape("router_settings.plugins")):
         resolve_routing_plugins(
             plugin_paths=["bad_rs_plugin.not_a_plugin"],
             config_file_path=str(tmp_path / "config.yaml"),

--- a/tests/test_litellm/proxy/test_proxy_server.py
+++ b/tests/test_litellm/proxy/test_proxy_server.py
@@ -2,6 +2,7 @@ import asyncio
 import importlib
 import json
 import os
+import re
 import socket
 import subprocess
 import sys
@@ -2683,7 +2684,7 @@ async def test_get_config_from_file(tmp_path, monkeypatch):
     with open(empty_file, "w") as f:
         f.write("")  # Write empty content which will result in None when loaded
 
-    with pytest.raises(Exception, match="Config cannot be None or Empty."):
+    with pytest.raises(Exception, match=re.escape("Config cannot be None or Empty.")):
         await proxy_config._get_config_from_file(str(empty_file))
 
     # Test Case 5: Using global user_config_file_path when no config_file_path provided

--- a/tests/test_litellm/sandbox/test_opensandbox_sandbox.py
+++ b/tests/test_litellm/sandbox/test_opensandbox_sandbox.py
@@ -490,7 +490,7 @@ async def test_create_waits_for_endpoint_resolution(monkeypatch):
 async def test_create_raises_when_endpoint_is_missing():
     client = FakeHTTPClient(endpoint_json={"headers": {"X": "y"}})
 
-    with pytest.raises(TimeoutError, match="execd endpoint.*not ready"):
+    with pytest.raises(TimeoutError, match=r"execd endpoint.*not ready"):
         await OpenSandboxSandboxConfig().acreate_sandbox(
             api_key="", api_base=TEST_API_BASE, ready_timeout=0, client=client
         )

--- a/tests/test_litellm/test_router_model_cost_isolation.py
+++ b/tests/test_litellm/test_router_model_cost_isolation.py
@@ -9,6 +9,7 @@ should still use the built-in pricing.
 
 import copy
 import os
+import re
 import sys
 from unittest.mock import patch
 
@@ -1892,7 +1893,7 @@ def test_a_reservation_without_a_declared_id_is_refused():
     duplicate is permanent."""
     anonymous = {k: v for k, v in _PTU_MODEL_INFO.items() if k != "id"}
 
-    with pytest.raises(ValueError, match="model_info.id is required"):
+    with pytest.raises(ValueError, match=re.escape("model_info.id is required")):
         _ptu_router(model_info=anonymous)
 
 
@@ -1976,7 +1977,7 @@ def test_a_bare_yaml_date_bound_does_not_escape_the_id_rule():
 
     windowed = {k: v for k, v in _PTU_MODEL_INFO.items() if k != "id"}
 
-    with pytest.raises(ValueError, match="model_info.id is required"):
+    with pytest.raises(ValueError, match=re.escape("model_info.id is required")):
         _ptu_router(model_info={**windowed, "ptu_effective_to": _dt.date(2027, 1, 1)})
 
 


### PR DESCRIPTION
## TLDR

Problem this solves:

- `match=` is `re.search`, so a copied `.` is a wildcard
- The block then accepts messages nobody meant to accept
- 25 such patterns, and nothing stops the next one

How it solves it:

- Selects ruff `RUF043` in `ruff-tests.toml`, already wired to CI
- A real regex gets an `r` prefix, so the intent is on the page
- A literal message gets `re.escape`, so every character means itself
- One `\.` where a literal dot sat inside a real regex

## User Flow

Before: an operator who declares a PTU reservation can have the field name change under them, because the test guarding the message passes either way

1. They add a deployment to config.yaml with PTU fields set and no `model_info.id`
2. The proxy refuses to start and says `model_info.id is required when PTU fields are set`
3. They add `model_info: {id: ...}` and the deployment comes up billing under the id they own
4. Someone renames the field in that message to `model_info_id`, and CI stays green, because the test pinning the message reads the dot as "any character"
5. The next operator copies `model_info.id` out of the docs, the proxy does not recognise it, and their reservation bills under a hash of the credential instead

After: the message cannot drift without CI going red

1. The same rename is made
2. The test fails, because the pattern now demands the field name exactly as written
3. The message and the docs keep naming the same field, so the operator's reservation stays under one identity

## Relevant issues

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

This PR changes lint config and tests, so there is no proxy route to curl. What matters for a rule that claims to catch patterns which accept the wrong message is whether one of them actually does, so a message a test pins is renamed and the test is run on both sides.

The mutation: in `litellm/litellm_core_utils/ptu_pricing.py`, the refusal `"model_info.id is required when PTU fields are set..."` is renamed to `"model_info_id is required..."`. The test pins that message with `match="model_info.id is required"`, where the dot matches the underscore.

### Before (66b930b540)

1. Run

```
pytest "tests/test_litellm/test_router_model_cost_isolation.py::test_a_reservation_without_a_declared_id_is_refused"
```

2. Output:

```
1 passed, 1 warning in 0.18s
```

The field named in the error is no longer the field the docs name, and the test that pins it still passes.

### After (91599aef69)

1. Run

```
pytest "tests/test_litellm/test_router_model_cost_isolation.py::test_a_reservation_without_a_declared_id_is_refused"
```

2. Output:

```
FAILED tests/test_litellm/test_router_model_cost_isolation.py::test_a_reservation_without_a_declared_id_is_refused
1 failed, 1 warning in 0.19s
```

3. Run

```
ruff check --config ruff-tests.toml tests
```

4. Output:

```
All checks passed!
```

### Rule and regression numbers

`ruff check --config ruff-tests.toml tests` went from 25 `RUF043` findings to zero. Running the touched files that need neither network nor a database gives the same tally on both sides, 1113 passed and 140 errors, every error pre-existing and all of them one fixture the router helper module cannot build here.

Thirteen patterns were deliberate regexes and only needed marking raw, eleven were the message itself and now go through `re.escape`, and one had a literal dot sitting inside a real regex, so only that dot is escaped.

The first commit is separate on purpose: the `match=` literals PR #37887 minted carry the same hazard, and they are escaped before the rule that would have caught them turns on.

## Type

🧹 Refactoring
🚄 Infrastructure
✅ Test

## Caveats (if any)

- `re.escape` makes trailing periods literal, so each message was read first
- A raw prefix silences the rule without narrowing a genuinely broad `.*`

### Final Attestation

- [ ] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
