### PR TITLE
fix(otel): emit gen_ai.provider.name for metrics in semconv experimental mode

### DIFF
--- a/litellm/integrations/opentelemetry.py
+++ b/litellm/integrations/opentelemetry.py
@@ -1612,13 +1612,13 @@ class OpenTelemetry(OTELGenAISemconvMixin, CustomLogger):
     def _record_metrics(self, kwargs, response_obj, start_time, end_time):
         duration_s: Final = (end_time - start_time).total_seconds()
         params: Final = kwargs.get("litellm_params") or {}
-        provider: Final = params.get("custom_llm_provider", "Unknown")
+        provider: Final = params.get("custom_llm_provider") or kwargs.get("custom_llm_provider") or "Unknown"
 
         common_attrs = {
             "gen_ai.operation.name": (
                 self._gen_ai_operation_name(kwargs) if self._gen_ai_semconv_latest_experimental else "chat"
             ),
-            "gen_ai.system": provider,
+            ("gen_ai.provider.name" if self._gen_ai_semconv_latest_experimental else "gen_ai.system"): provider,
             "gen_ai.request.model": kwargs.get("model"),
             "gen_ai.framework": "litellm",
         }

--- a/tests/logging_callback_tests/test_opentelemetry_unit_tests.py
+++ b/tests/logging_callback_tests/test_opentelemetry_unit_tests.py
@@ -9,8 +9,6 @@ import traceback
 from dotenv import load_dotenv
 
 load_dotenv()
-import os
-import asyncio
 
 sys.path.insert(
     0, os.path.abspath("../..")
@@ -213,3 +211,35 @@ class TestOpentelemetryUnitTests(BaseLoggingCallbackTest):
         mock_span.set_attribute.assert_called_with(
             ErrorAttributes.ERROR_MESSAGE, "Fallback error message"
         )
+
+    def test_record_metrics_semconv_provider_name(self):
+        """
+        Test that _record_metrics emits gen_ai.provider.name under semconv mode.
+        """
+        from litellm.integrations.opentelemetry import OpenTelemetry
+        from litellm.integrations.opentelemetry_utils.gen_ai_semconv import OTELSemconvCategory
+
+        otel_integration = OpenTelemetry()
+        mock_histogram = MagicMock()
+        otel_integration._operation_duration_histogram = mock_histogram
+
+        # Case 1: Default legacy mode
+        kwargs = {
+            "litellm_params": {"custom_llm_provider": "anthropic"},
+            "model": "claude-3-5-sonnet",
+        }
+        start = datetime.now()
+        end = datetime.now()
+        otel_integration._record_metrics(kwargs, None, start, end)
+        call_attrs = mock_histogram.record.call_args[1]["attributes"]
+        assert call_attrs.get("gen_ai.system") == "anthropic"
+
+        # Case 2: Semconv experimental mode
+        otel_integration.config.semconv_stability_opt_in = {
+            OTELSemconvCategory.GEN_AI_LATEST_EXPERIMENTAL
+        }
+        otel_integration._record_metrics(kwargs, None, start, end)
+        call_attrs = mock_histogram.record.call_args[1]["attributes"]
+        assert call_attrs.get("gen_ai.provider.name") == "anthropic"
+        assert "gen_ai.system" not in call_attrs
+

--- a/tests/logging_callback_tests/test_opentelemetry_unit_tests.py
+++ b/tests/logging_callback_tests/test_opentelemetry_unit_tests.py
@@ -223,7 +223,6 @@ class TestOpentelemetryUnitTests(BaseLoggingCallbackTest):
         mock_histogram = MagicMock()
         otel_integration._operation_duration_histogram = mock_histogram
 
-        # Case 1: Default legacy mode
         kwargs = {
             "litellm_params": {"custom_llm_provider": "anthropic"},
             "model": "claude-3-5-sonnet",
@@ -234,7 +233,6 @@ class TestOpentelemetryUnitTests(BaseLoggingCallbackTest):
         call_attrs = mock_histogram.record.call_args[1]["attributes"]
         assert call_attrs.get("gen_ai.system") == "anthropic"
 
-        # Case 2: Semconv experimental mode
         otel_integration.config.semconv_stability_opt_in = {
             OTELSemconvCategory.GEN_AI_LATEST_EXPERIMENTAL
         }


### PR DESCRIPTION
## Summary

Fixes the emitted GenAI provider attribute in `OpenTelemetry._record_metrics()`:
- When `OTEL_SEMCONV_STABILITY_OPT_IN=gen_ai_latest_experimental` is active, metric histograms now emit `gen_ai.provider.name` (aligning with OpenTelemetry GenAI Semantic Conventions) instead of the superseded `gen_ai.system`.
- Added robust fallback to `kwargs.get("custom_llm_provider")` when not present in `litellm_params`.
- Added unit test `test_record_metrics_semconv_provider_name`.

## Motivation

Issue #36759: `gen_ai.system` is deprecated in current OpenTelemetry GenAI Semantic Conventions and superseded by `gen_ai.provider.name`. When experimental semconv is enabled, metric records were still emitting the legacy `gen_ai.system` key, creating schema inconsistencies across metrics and trace spans.

## Changes

- `litellm/integrations/opentelemetry.py`: Use `gen_ai.provider.name` for metric common attributes under experimental semconv mode.
- `tests/logging_callback_tests/test_opentelemetry_unit_tests.py`: Added test assertion for metric attributes under both legacy and semconv modes.

## Tests

- Added `test_record_metrics_semconv_provider_name` verifying attribute emission.
