### PR TITLE
fix(complexity-router): retune default tier boundaries to 0.10 / 0.25 / 0.50

### DIFF
--- a/litellm/router_strategy/complexity_router/README.md
+++ b/litellm/router_strategy/complexity_router/README.md
@@ -34,6 +34,8 @@ The weighted sum is mapped to tiers using configurable boundaries:
 | COMPLEX | 0.25 - 0.50 | `medium_complex` | Technical, multi-part requests |
 | REASONING | > 0.50 | `complex_reasoning` | Chain-of-thought, analysis |
 
+The three boundaries must ascend, and any key you leave out is filled from the shipped default, so setting one boundary without the others can put them out of order. A set that decreases would strand the tier between the inverted pair and silently route its traffic to a costlier one, so it is rejected at config load with a message naming the resolved values. Set every boundary you need to move, not just one.
+
 Tier names are defaults you can rename with [`tier_labels`](#renaming-the-tiers). The three `tier_boundaries` keys are named after those defaults but they are scorer knobs, not tiers: each one names the gap between two rungs and is persisted by name on every routing decision, so they stay `simple_medium` / `medium_complex` / `complex_reasoning` no matter what you call the tiers. The column above tells a renamed deployment which knob it is turning.
 
 ## Configuration

--- a/litellm/router_strategy/complexity_router/README.md
+++ b/litellm/router_strategy/complexity_router/README.md
@@ -29,10 +29,10 @@ The weighted sum is mapped to tiers using configurable boundaries:
 
 | Tier | Score Range | Boundary key below it | Typical Use |
 |------|-------------|-----------------------|-------------|
-| SIMPLE | < 0.15 | - | Basic questions, greetings |
-| MEDIUM | 0.15 - 0.35 | `simple_medium` | Standard queries |
-| COMPLEX | 0.35 - 0.60 | `medium_complex` | Technical, multi-part requests |
-| REASONING | > 0.60 | `complex_reasoning` | Chain-of-thought, analysis |
+| SIMPLE | < 0.10 | - | Basic questions, greetings |
+| MEDIUM | 0.10 - 0.25 | `simple_medium` | Standard queries |
+| COMPLEX | 0.25 - 0.50 | `medium_complex` | Technical, multi-part requests |
+| REASONING | > 0.50 | `complex_reasoning` | Chain-of-thought, analysis |
 
 Tier names are defaults you can rename with [`tier_labels`](#renaming-the-tiers). The three `tier_boundaries` keys are named after those defaults but they are scorer knobs, not tiers: each one names the gap between two rungs and is persisted by name on every routing decision, so they stay `simple_medium` / `medium_complex` / `complex_reasoning` no matter what you call the tiers. The column above tells a renamed deployment which knob it is turning.
 
@@ -120,9 +120,9 @@ model_list:
         
         # Tier boundaries (normalized scores)
         tier_boundaries:
-          simple_medium: 0.15
-          medium_complex: 0.35
-          complex_reasoning: 0.60
+          simple_medium: 0.10
+          medium_complex: 0.25
+          complex_reasoning: 0.50
         
         # Token count thresholds
         token_thresholds:

--- a/litellm/router_strategy/complexity_router/README.md
+++ b/litellm/router_strategy/complexity_router/README.md
@@ -32,7 +32,7 @@ The weighted sum is mapped to tiers using configurable boundaries:
 | SIMPLE | < 0.10 | - | Basic questions, greetings |
 | MEDIUM | 0.10 - 0.25 | `simple_medium` | Standard queries |
 | COMPLEX | 0.25 - 0.50 | `medium_complex` | Technical, multi-part requests |
-| REASONING | > 0.50 | `complex_reasoning` | Chain-of-thought, analysis |
+| REASONING | >= 0.50 | `complex_reasoning` | Chain-of-thought, analysis |
 
 The three boundaries must ascend, and any key you leave out is filled from the shipped default, so setting one boundary without the others can put them out of order. A set that decreases would strand the tier between the inverted pair and silently route its traffic to a costlier one, so it is rejected at config load with a message naming the resolved values. Set every boundary you need to move, not just one.
 

--- a/litellm/router_strategy/complexity_router/complexity_router.py
+++ b/litellm/router_strategy/complexity_router/complexity_router.py
@@ -48,6 +48,7 @@ from .config import (
     DEFAULT_REASONING_KEYWORDS,
     DEFAULT_SIMPLE_KEYWORDS,
     DEFAULT_TECHNICAL_KEYWORDS,
+    DEFAULT_TIER_BOUNDARIES,
     PLAN_MODE_SYSTEM_SENTINELS,
     PLAN_MODE_TAIL_SENTINELS,
     PLAN_MODE_TOOL_NAME,
@@ -1097,9 +1098,9 @@ class ComplexityRouter(CustomLogger):
         """
         boundaries: Final = self.config.tier_boundaries
         return StandardLoggingRoutingDecisionTierBoundaries(
-            simple_medium=boundaries.get("simple_medium", 0.15),
-            medium_complex=boundaries.get("medium_complex", 0.35),
-            complex_reasoning=boundaries.get("complex_reasoning", 0.60),
+            simple_medium=boundaries.get("simple_medium", DEFAULT_TIER_BOUNDARIES["simple_medium"]),
+            medium_complex=boundaries.get("medium_complex", DEFAULT_TIER_BOUNDARIES["medium_complex"]),
+            complex_reasoning=boundaries.get("complex_reasoning", DEFAULT_TIER_BOUNDARIES["complex_reasoning"]),
         )
 
     def _build_routing_decision(

--- a/litellm/router_strategy/complexity_router/complexity_router.py
+++ b/litellm/router_strategy/complexity_router/complexity_router.py
@@ -48,7 +48,6 @@ from .config import (
     DEFAULT_REASONING_KEYWORDS,
     DEFAULT_SIMPLE_KEYWORDS,
     DEFAULT_TECHNICAL_KEYWORDS,
-    DEFAULT_TIER_BOUNDARIES,
     PLAN_MODE_SYSTEM_SENTINELS,
     PLAN_MODE_TAIL_SENTINELS,
     PLAN_MODE_TOOL_NAME,
@@ -56,6 +55,7 @@ from .config import (
     ClassificationRubric,
     ComplexityRouterConfig,
     ComplexityTier,
+    resolve_tier_boundaries,
 )
 
 if TYPE_CHECKING:
@@ -1096,11 +1096,11 @@ class ComplexityRouter(CustomLogger):
         Shared by score-to-tier mapping and the per-request routing decision snapshot,
         so a logged decision always reflects the boundaries that actually applied.
         """
-        boundaries: Final = self.config.tier_boundaries
+        resolved: Final = resolve_tier_boundaries(self.config.tier_boundaries)
         return StandardLoggingRoutingDecisionTierBoundaries(
-            simple_medium=boundaries.get("simple_medium", DEFAULT_TIER_BOUNDARIES["simple_medium"]),
-            medium_complex=boundaries.get("medium_complex", DEFAULT_TIER_BOUNDARIES["medium_complex"]),
-            complex_reasoning=boundaries.get("complex_reasoning", DEFAULT_TIER_BOUNDARIES["complex_reasoning"]),
+            simple_medium=resolved["simple_medium"],
+            medium_complex=resolved["medium_complex"],
+            complex_reasoning=resolved["complex_reasoning"],
         )
 
     def _build_routing_decision(

--- a/litellm/router_strategy/complexity_router/config.py
+++ b/litellm/router_strategy/complexity_router/config.py
@@ -372,6 +372,15 @@ DEFAULT_TIER_BOUNDARIES: Final[dict[str, float]] = {
 }
 
 
+def resolve_tier_boundaries(boundaries: Mapping[str, float]) -> Mapping[str, float]:
+    """The three boundaries in effect, with the shipped default filling in each key the config omits.
+
+    The single place omitted keys are filled, so a validator and the scorer cannot disagree about
+    what a partially specified tier_boundaries actually means.
+    """
+    return MappingProxyType({key: boundaries.get(key, default) for key, default in DEFAULT_TIER_BOUNDARIES.items()})
+
+
 # ─── Default Token Thresholds ───
 
 DEFAULT_TOKEN_THRESHOLDS: Final[dict[str, int]] = {
@@ -1103,6 +1112,35 @@ class ComplexityRouterConfig(BaseModel):
             raise ValueError(f"adaptive=True tier pools must be non-empty; empty tiers: {empty}")
         self.tiers = normalized
         return self
+
+    @model_validator(mode="after")
+    def _validate_tier_boundaries_ascend(self) -> "ComplexityRouterConfig":
+        # The score-to-tier mapping is a sequential comparison chain, so a boundary that sits below the one
+        # under it makes the tier between them unreachable and silently sends its traffic to a costlier tier.
+        # Resolved, not raw: omitting a key is the common way to arrive here, since the omitted key is filled
+        # from a shipped default that knows nothing about the boundary the operator did set.
+        resolved: Final = resolve_tier_boundaries(self.tier_boundaries)
+        simple_medium, medium_complex, complex_reasoning = (
+            resolved["simple_medium"],
+            resolved["medium_complex"],
+            resolved["complex_reasoning"],
+        )
+        if simple_medium <= medium_complex <= complex_reasoning:
+            return self
+        stranded: Final = tuple(
+            tier
+            for tier, inverted in (
+                ("MEDIUM", simple_medium > medium_complex),
+                ("COMPLEX", medium_complex > complex_reasoning),
+            )
+            if inverted
+        )
+        raise ValueError(
+            f"tier_boundaries must ascend, but resolve to simple_medium={simple_medium}, "
+            f"medium_complex={medium_complex}, complex_reasoning={complex_reasoning}, leaving "
+            f"{' and '.join(stranded)} unreachable. Boundaries you omit are filled from the shipped "
+            f"defaults {DEFAULT_TIER_BOUNDARIES}, so set every boundary you need to move, not just one."
+        )
 
     @model_validator(mode="after")
     def _validate_semantic_matching(self) -> "ComplexityRouterConfig":

--- a/litellm/router_strategy/complexity_router/config.py
+++ b/litellm/router_strategy/complexity_router/config.py
@@ -366,9 +366,9 @@ DEFAULT_DIMENSION_WEIGHTS: Final[dict[str, float]] = {
 # ─── Default Tier Boundaries ───
 
 DEFAULT_TIER_BOUNDARIES: Final[dict[str, float]] = {
-    "simple_medium": 0.15,  # Lower threshold to catch more MEDIUM cases
-    "medium_complex": 0.35,  # Lower threshold to catch technical COMPLEX cases
-    "complex_reasoning": 0.60,  # Reasoning tier reserved for explicit reasoning markers
+    "simple_medium": 0.10,
+    "medium_complex": 0.25,
+    "complex_reasoning": 0.50,
 }
 
 

--- a/litellm/router_strategy/complexity_router/config.py
+++ b/litellm/router_strategy/complexity_router/config.py
@@ -1115,10 +1115,11 @@ class ComplexityRouterConfig(BaseModel):
 
     @model_validator(mode="after")
     def _validate_tier_boundaries_ascend(self) -> "ComplexityRouterConfig":
-        # The score-to-tier mapping is a sequential comparison chain, so a boundary that sits below the one
-        # under it makes the tier between them unreachable and silently sends its traffic to a costlier tier.
-        # Resolved, not raw: omitting a key is the common way to arrive here, since the omitted key is filled
-        # from a shipped default that knows nothing about the boundary the operator did set.
+        # The score-to-tier mapping is a sequential comparison chain, so a boundary below the one under it
+        # asks for a tier starting above the tier above it, which no score satisfies, and the stranded tier's
+        # traffic silently lands on a costlier one. Equal boundaries pass: an empty band is coherent.
+        # Resolved, not raw, because filling an omitted key from a shipped default is the usual way an
+        # operator arrives here without having written anything out of order.
         resolved: Final = resolve_tier_boundaries(self.tier_boundaries)
         simple_medium, medium_complex, complex_reasoning = (
             resolved["simple_medium"],

--- a/tests/test_litellm/router_strategy/test_complexity_router.py
+++ b/tests/test_litellm/router_strategy/test_complexity_router.py
@@ -297,22 +297,25 @@ class TestReasoningMarkerScoring:
         assert tier == ComplexityTier.REASONING
 
     def test_floor_defaults_to_simple_medium_and_follows_it(self, mock_router_instance, basic_config):
-        """Unset tracks simple_medium, so moving that boundary moves the floor with it."""
+        """Unset tracks simple_medium, so moving that boundary moves the floor with it.
+
+        Both arms carry the fixture's other two boundaries unchanged: simple_medium is the only
+        variable, and boundaries must ascend, so the pair above it cannot be left to fill from
+        shipped defaults that sit below the value under test.
+        """
         prompt = (
             "Give me the pros and cons, step by step, of moving our checkout service to an event-driven architecture."
         )
+        boundaries = basic_config["tier_boundaries"]
         low = ComplexityRouter(
             model_name="test-complexity-router",
             litellm_router_instance=mock_router_instance,
-            complexity_router_config={**basic_config, "tier_boundaries": {"simple_medium": 0.20}},
+            complexity_router_config={**basic_config, "tier_boundaries": {**boundaries, "simple_medium": 0.20}},
         )
         high = ComplexityRouter(
             model_name="test-complexity-router",
             litellm_router_instance=mock_router_instance,
-            complexity_router_config={
-                **basic_config,
-                "tier_boundaries": {"simple_medium": 0.30, "medium_complex": 0.35, "complex_reasoning": 0.50},
-            },
+            complexity_router_config={**basic_config, "tier_boundaries": {**boundaries, "simple_medium": 0.30}},
         )
         assert low._effective_reasoning_override_min_score() == 0.20
         assert high._effective_reasoning_override_min_score() == 0.30

--- a/tests/test_litellm/router_strategy/test_complexity_router.py
+++ b/tests/test_litellm/router_strategy/test_complexity_router.py
@@ -37,6 +37,7 @@ from litellm.router_strategy.complexity_router.config import (
     DEFAULT_CLASSIFIER_CONTEXT_WINDOW_SIZE,
     DEFAULT_COMPLEXITY_CONFIG,
     DEFAULT_TECHNICAL_KEYWORDS,
+    DEFAULT_TIER_BOUNDARIES,
     ClassifierLLMConfig,
     ComplexityRouterConfig,
     ComplexityTier,
@@ -600,6 +601,44 @@ class TestPreRoutingHook:
         )
         assert result is not None
         assert result.model == "o1-preview"  # REASONING tier model
+
+
+class TestEffectiveTierBoundaries:
+    """Test how configured boundaries resolve against the shipped defaults."""
+
+    def test_unconfigured_boundaries_resolve_to_the_shipped_defaults(self, mock_router_instance):
+        """A router with no tier_boundaries runs on DEFAULT_TIER_BOUNDARIES, not on stale literals."""
+        router = ComplexityRouter(
+            model_name="test-complexity-router",
+            litellm_router_instance=mock_router_instance,
+            complexity_router_config={"tiers": {"SIMPLE": "a", "MEDIUM": "b", "COMPLEX": "c", "REASONING": "d"}},
+        )
+        assert dict(router._effective_tier_boundaries()) == DEFAULT_TIER_BOUNDARIES
+
+    def test_partial_boundaries_fill_missing_keys_from_the_defaults(self, mock_router_instance):
+        """Overriding one boundary must not strand the other two on a second, drifting copy of the defaults."""
+        router = ComplexityRouter(
+            model_name="test-complexity-router",
+            litellm_router_instance=mock_router_instance,
+            complexity_router_config={
+                "tiers": {"SIMPLE": "a", "MEDIUM": "b", "COMPLEX": "c", "REASONING": "d"},
+                "tier_boundaries": {"simple_medium": 0.42},
+            },
+        )
+        assert dict(router._effective_tier_boundaries()) == {
+            "simple_medium": 0.42,
+            "medium_complex": DEFAULT_TIER_BOUNDARIES["medium_complex"],
+            "complex_reasoning": DEFAULT_TIER_BOUNDARIES["complex_reasoning"],
+        }
+
+    def test_defaults_stay_ordered_and_within_the_scoring_range(self):
+        """The tiers only all remain reachable while the boundaries ascend."""
+        simple_medium, medium_complex, complex_reasoning = (
+            DEFAULT_TIER_BOUNDARIES["simple_medium"],
+            DEFAULT_TIER_BOUNDARIES["medium_complex"],
+            DEFAULT_TIER_BOUNDARIES["complex_reasoning"],
+        )
+        assert 0 < simple_medium < medium_complex < complex_reasoning < 1
 
 
 class TestConfigOverrides:
@@ -5074,7 +5113,7 @@ class TestRoutingDecisionContents:
         assert isinstance(decision["score"], float)
         assert any("short" in signal for signal in decision["signals"])
         # The snapshot must reflect the CONFIGURED boundaries (the fixture overrides the
-        # 0.15/0.35/0.60 defaults), so a logged row stays truthful after config edits.
+        # shipped defaults), so a logged row stays truthful after config edits.
         assert decision["tier_boundaries"] == {
             "simple_medium": 0.25,
             "medium_complex": 0.50,

--- a/tests/test_litellm/router_strategy/test_complexity_router.py
+++ b/tests/test_litellm/router_strategy/test_complexity_router.py
@@ -309,7 +309,10 @@ class TestReasoningMarkerScoring:
         high = ComplexityRouter(
             model_name="test-complexity-router",
             litellm_router_instance=mock_router_instance,
-            complexity_router_config={**basic_config, "tier_boundaries": {"simple_medium": 0.30}},
+            complexity_router_config={
+                **basic_config,
+                "tier_boundaries": {"simple_medium": 0.30, "medium_complex": 0.35, "complex_reasoning": 0.50},
+            },
         )
         assert low._effective_reasoning_override_min_score() == 0.20
         assert high._effective_reasoning_override_min_score() == 0.30
@@ -622,14 +625,50 @@ class TestEffectiveTierBoundaries:
             litellm_router_instance=mock_router_instance,
             complexity_router_config={
                 "tiers": {"SIMPLE": "a", "MEDIUM": "b", "COMPLEX": "c", "REASONING": "d"},
-                "tier_boundaries": {"simple_medium": 0.42},
+                "tier_boundaries": {"simple_medium": 0.2},
             },
         )
         assert dict(router._effective_tier_boundaries()) == {
-            "simple_medium": 0.42,
+            "simple_medium": 0.2,
             "medium_complex": DEFAULT_TIER_BOUNDARIES["medium_complex"],
             "complex_reasoning": DEFAULT_TIER_BOUNDARIES["complex_reasoning"],
         }
+
+    def test_omitting_a_boundary_below_one_that_is_set_is_rejected(self, mock_router_instance):
+        """The trap this guards: one boundary set high, the rest filled from lower shipped defaults."""
+        with pytest.raises(ValidationError, match="MEDIUM unreachable"):
+            ComplexityRouter(
+                model_name="test-complexity-router",
+                litellm_router_instance=mock_router_instance,
+                complexity_router_config={
+                    "tiers": {"SIMPLE": "a", "MEDIUM": "b", "COMPLEX": "c", "REASONING": "d"},
+                    "tier_boundaries": {"simple_medium": 0.30},
+                },
+            )
+
+    def test_fully_specified_decreasing_boundaries_are_rejected(self, mock_router_instance):
+        """An operator can also strand a tier without omitting anything."""
+        with pytest.raises(ValidationError, match="COMPLEX unreachable"):
+            ComplexityRouter(
+                model_name="test-complexity-router",
+                litellm_router_instance=mock_router_instance,
+                complexity_router_config={
+                    "tiers": {"SIMPLE": "a", "MEDIUM": "b", "COMPLEX": "c", "REASONING": "d"},
+                    "tier_boundaries": {"simple_medium": 0.10, "medium_complex": 0.60, "complex_reasoning": 0.50},
+                },
+            )
+
+    def test_equal_boundaries_are_allowed(self, mock_router_instance):
+        """Collapsing a tier to an empty band is a deliberate way to take it out of rotation."""
+        router = ComplexityRouter(
+            model_name="test-complexity-router",
+            litellm_router_instance=mock_router_instance,
+            complexity_router_config={
+                "tiers": {"SIMPLE": "a", "MEDIUM": "b", "COMPLEX": "c", "REASONING": "d"},
+                "tier_boundaries": {"simple_medium": 0.25, "medium_complex": 0.25, "complex_reasoning": 0.50},
+            },
+        )
+        assert router._effective_tier_boundaries()["medium_complex"] == 0.25
 
     def test_defaults_stay_ordered_and_within_the_scoring_range(self):
         """The tiers only all remain reachable while the boundaries ascend."""

--- a/tests/test_litellm/router_strategy/test_complexity_router.py
+++ b/tests/test_litellm/router_strategy/test_complexity_router.py
@@ -661,8 +661,15 @@ class TestEffectiveTierBoundaries:
                 },
             )
 
-    def test_equal_boundaries_are_allowed(self, mock_router_instance):
-        """Collapsing a tier to an empty band is a deliberate way to take it out of rotation."""
+    def test_equal_boundaries_are_accepted_and_close_the_band(self, mock_router_instance):
+        """Equal boundaries are accepted, and they leave the tier between them unreachable.
+
+        With simple_medium == medium_complex, MEDIUM's band is zero width: the strict `<` below it
+        already claims every lower score for SIMPLE, and every score from that value up falls
+        through to COMPLEX. The validator still allows it because a non-decreasing set is coherent,
+        it just describes an empty band, where a decreasing pair asks for a tier that starts above
+        the tier above it and no score can satisfy that.
+        """
         router = ComplexityRouter(
             model_name="test-complexity-router",
             litellm_router_instance=mock_router_instance,
@@ -671,7 +678,11 @@ class TestEffectiveTierBoundaries:
                 "tier_boundaries": {"simple_medium": 0.25, "medium_complex": 0.25, "complex_reasoning": 0.50},
             },
         )
-        assert router._effective_tier_boundaries()["medium_complex"] == 0.25
+        assert dict(router._effective_tier_boundaries()) == {
+            "simple_medium": 0.25,
+            "medium_complex": 0.25,
+            "complex_reasoning": 0.50,
+        }
 
     def test_defaults_stay_ordered_and_within_the_scoring_range(self):
         """The tiers only all remain reachable while the boundaries ascend."""

--- a/tests/test_litellm/router_strategy/test_quality_router.py
+++ b/tests/test_litellm/router_strategy/test_quality_router.py
@@ -408,7 +408,7 @@ class TestPreRoutingHook:
         request in the session, and carries no signal about how requests differ. Before
         the fix this system prompt alone supplied 5 codePresence + 2 technicalTerms
         keyword matches, saturating both dimensions and crossing the default
-        simple_medium boundary (0.15) purely from harness text, independent of the ask."""
+        simple_medium boundary purely from harness text, independent of the ask."""
         agent_system_prompt = (
             "You are Claude Code, Anthropic's official CLI for Claude.\n"
             "You are an interactive agent that helps users with software engineering tasks.\n\n"

--- a/ui/litellm-dashboard/src/components/add_model/ComplexityRouterConfig.test.tsx
+++ b/ui/litellm-dashboard/src/components/add_model/ComplexityRouterConfig.test.tsx
@@ -69,10 +69,10 @@ describe("ComplexityRouterConfig", () => {
   it("should show score thresholds in the classification section", () => {
     renderWithProviders(<ComplexityRouterConfig {...baseProps} />);
     fireEvent.click(screen.getByText("Advanced: Classification Method"));
-    expect(screen.getByText(/Score < 0.15/)).toBeInTheDocument();
-    expect(screen.getByText(/Score 0.15 - 0.35/)).toBeInTheDocument();
-    expect(screen.getByText(/Score 0.35 - 0.60/)).toBeInTheDocument();
-    expect(screen.getByText(/Score > 0.60/)).toBeInTheDocument();
+    expect(screen.getByText(/Score < 0.10/)).toBeInTheDocument();
+    expect(screen.getByText(/Score 0.10 - 0.25/)).toBeInTheDocument();
+    expect(screen.getByText(/Score 0.25 - 0.50/)).toBeInTheDocument();
+    expect(screen.getByText(/Score > 0.50/)).toBeInTheDocument();
   });
 
   it("should default to heuristic and hide classifier model/timeout fields", () => {

--- a/ui/litellm-dashboard/src/components/add_model/HeuristicScoringConfig.test.tsx
+++ b/ui/litellm-dashboard/src/components/add_model/HeuristicScoringConfig.test.tsx
@@ -41,7 +41,7 @@ describe("HeuristicScoringConfig", () => {
   it("prefills the shipped defaults", async () => {
     await render(BASE);
 
-    expect(screen.getByLabelText("Simple to Medium")).toHaveValue("0.15");
+    expect(screen.getByLabelText("Simple to Medium")).toHaveValue("0.1");
     expect(screen.getByLabelText("Long above")).toHaveValue("400");
     expect(screen.getByTestId("dimension-weight-total")).toHaveTextContent("total 1.00");
   });
@@ -57,8 +57,8 @@ describe("HeuristicScoringConfig", () => {
 
     expect((onChange.mock.calls.at(-1)?.[0] as ComplexityRouterConfigValue).tier_boundaries).toEqual({
       simple_medium: 0.22,
-      medium_complex: 0.35,
-      complex_reasoning: 0.6,
+      medium_complex: 0.25,
+      complex_reasoning: 0.5,
     });
   });
 
@@ -184,7 +184,7 @@ describe("ClassificationMethodConfig scorer gating", () => {
 
     expect(screen.getByText(/Score < 0.22/)).toBeInTheDocument();
     expect(screen.getByText(/Score 0.44 - 0.66/)).toBeInTheDocument();
-    expect(screen.queryByText(/0.15/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/0.10/)).not.toBeInTheDocument();
   });
 
   it("states the configured override floor in the reasoning-marker aside, not the boundary", () => {
@@ -196,7 +196,7 @@ describe("ClassificationMethodConfig scorer gating", () => {
   it("falls back to the Simple to Medium boundary when no override floor is set", () => {
     renderWithProviders(<ClassificationMethodConfig {...props} value={BASE} />);
 
-    expect(screen.getByText(/2\+ reasoning markers with a score of at least 0\.15/)).toBeInTheDocument();
+    expect(screen.getByText(/2\+ reasoning markers with a score of at least 0\.10/)).toBeInTheDocument();
   });
 
   it("renders a row for every scored dimension", async () => {

--- a/ui/litellm-dashboard/tests/mocks/complexityScorerDefaults.ts
+++ b/ui/litellm-dashboard/tests/mocks/complexityScorerDefaults.ts
@@ -10,7 +10,7 @@ import type { ComplexityScorerDefaults } from "@/components/networking";
  * which is how the failure path is covered.
  */
 export const SHIPPED_SCORER_DEFAULTS: ComplexityScorerDefaults = {
-  tier_boundaries: { simple_medium: 0.15, medium_complex: 0.35, complex_reasoning: 0.6 },
+  tier_boundaries: { simple_medium: 0.1, medium_complex: 0.25, complex_reasoning: 0.5 },
   token_thresholds: { simple: 15, complex: 400 },
   dimension_weights: {
     codePresence: 0.3,


### PR DESCRIPTION
## TLDR

Problem this solves:

- Stock boundaries park technical, multi-part prompts in cheap tiers
- Scorer rarely clears 0.35, so COMPLEX is nearly unreachable
- Overriding one boundary silently left the other two stale
- Decreasing boundaries strand a tier, and nothing checked

How it solves it:

- Retunes shipped defaults to 0.10 / 0.25 / 0.50
- Labelled eval accuracy goes from 28/29 to 29/29
- Missing boundaries now fill from the one canonical default
- Config load rejects boundaries that do not ascend

## User Flow

Before: a developer sending a detailed engineering question to an auto router gets the cheapest model back, and the answer is thinner than the question deserves

1. Their admin configures an auto router named `smart-router` with four tiers and no custom score boundaries
2. They send POST https://litellm-domain/v1/chat/completions with `"model": "smart-router"` and ask a multi-part networking question spanning use cases, performance, and packet loss
3. The reply comes back from the cheapest tier model, visible as `claude-haiku-4-5-20251001` in the `x-litellm-model-name` response header
4. They send a second request asking for a distributed rate limiter in Python backed by Redis, and it comes back from the second-cheapest tier
5. They open https://litellm-domain/ui/?page=logs and see both requests billed against the bottom two tiers, so they stop trusting the router and pin a model by hand

After: the same two requests reach models that match the question

1. Their admin configures the same auto router, still with no custom score boundaries
2. They send the same multi-part networking question to `"model": "smart-router"`
3. The reply now comes from the mid tier, `claude-sonnet-4-5-20250929` in `x-litellm-model-name`
4. The rate limiter request now comes from the tier above that, `claude-sonnet-4-6`
5. https://litellm-domain/ui/?page=logs shows both at the tier the prompt warranted, and an admin who preferred the old split can set `tier_boundaries` back to 0.15 / 0.35 / 0.60

## Relevant issues

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

Shared setup, identical on both sides. The auto router deliberately sets no `tier_boundaries`, so it runs on whatever the build ships, and each tier points at a real model through a live gateway

```yaml
model_list:
  - model_name: tier-simple
    litellm_params:
      model: openai/claude-haiku-4-5-20251001
      api_base: https://gateway.litellm-sandbox.ai/v1
      api_key: os.environ/GW_KEY
  - model_name: tier-medium
    litellm_params:
      model: openai/claude-sonnet-4-5-20250929
      api_base: https://gateway.litellm-sandbox.ai/v1
      api_key: os.environ/GW_KEY
  - model_name: tier-complex
    litellm_params:
      model: openai/claude-sonnet-4-6
      api_base: https://gateway.litellm-sandbox.ai/v1
      api_key: os.environ/GW_KEY
  - model_name: tier-reasoning
    litellm_params:
      model: openai/claude-sonnet-5
      api_base: https://gateway.litellm-sandbox.ai/v1
      api_key: os.environ/GW_KEY

  - model_name: smart-router
    litellm_params:
      model: auto_router/complexity_router
      complexity_router_config:
        tiers:
          SIMPLE: tier-simple
          MEDIUM: tier-medium
          COMPLEX: tier-complex
          REASONING: tier-reasoning

general_settings:
  master_key: sk-1234
```

Both runs boot the proxy the same way, then read back the tier that actually served each request

```bash
python litellm/proxy/proxy_cli.py --config boundaries_proof.yaml --port 4055

curl -s http://localhost:4055/public/complexity_router/scorer_defaults

curl -s -D - -o /dev/null http://localhost:4055/v1/chat/completions \
  -H 'Content-Type: application/json' -H 'Authorization: Bearer sk-1234' \
  -d '{"model":"smart-router","max_tokens":16,"messages":[{"role":"user","content":"<prompt>"}]}' \
  | grep -i 'x-litellm-model-name\|x-litellm-response-cost'
```

### Before (76d46274c1)

#### Shipped boundaries

1. `curl -s http://localhost:4055/public/complexity_router/scorer_defaults`
2. `{'simple_medium': 0.15, 'medium_complex': 0.35, 'complex_reasoning': 0.6}`

#### Multi-part networking question

1. Prompt: "Explain the differences between TCP and UDP protocols, including use cases for each, performance implications, and how they handle packet loss in distributed systems"
2. `x-litellm-model-name: openai/claude-haiku-4-5-20251001`, `x-litellm-response-cost: 0.000115`, so it lands on SIMPLE

#### Distributed rate limiter

1. Prompt: "Implement a rate limiter using the token bucket algorithm in Python that supports multiple rate limit tiers and can be used across distributed systems with Redis as the backend"
2. `x-litellm-model-name: openai/claude-sonnet-4-5-20250929`, `x-litellm-response-cost: 0.000357`, so it lands on MEDIUM

#### A router that sets only `simple_medium: 0.30`

1. Boot the same config with `tier_boundaries: {simple_medium: 0.30}` added to the router
2. The proxy starts with no complaint, and the router serves traffic with MEDIUM silently unreachable, so everything that tier would have taken is billed at COMPLEX

### After (07ebcd5f85)

#### Shipped boundaries

1. `curl -s http://localhost:4055/public/complexity_router/scorer_defaults`
2. `{'simple_medium': 0.1, 'medium_complex': 0.25, 'complex_reasoning': 0.5}`

#### Multi-part networking question

1. Same prompt as above
2. `x-litellm-model-name: openai/claude-sonnet-4-5-20250929`, `x-litellm-response-cost: 0.000345`, so it now lands on MEDIUM

#### Distributed rate limiter

1. Same prompt as above
2. `x-litellm-model-name: openai/claude-sonnet-4-6`, `x-litellm-response-cost: 0.000357`, so it now lands on COMPLEX

#### A router that sets only `simple_medium: 0.30`

1. Boot the same config with `tier_boundaries: {simple_medium: 0.30}` added to the router
2. Startup now names the problem: `tier_boundaries must ascend, but resolve to simple_medium=0.3, medium_complex=0.25, complex_reasoning=0.5, leaving MEDIUM unreachable. Boundaries you omit are filled from the shipped defaults {'simple_medium': 0.1, 'medium_complex': 0.25, 'complex_reasoning': 0.5}, so set every boundary you need to move, not just one.`
3. The proxy still starts and every other deployment keeps serving; only that router is dropped, and a request to it returns `litellm.BadRequestError: You passed in model=smart-router. There are no healthy deployments for this model.`

Both prompts are labelled COMPLEX in the in-repo eval set, so each moves toward its label. Across that whole set the retune moves 5 of 29 cases up a tier and takes accuracy from 28/29 to 29/29

## Type

🐛 Bug Fix

## Caveats (if any)

- Higher tiers cost more; deployments watching spend should re-baseline
- `reasoning_override_min_score` tracks `simple_medium`, so its floor drops too
- Labelled eval set is only 29 cases
- Old behaviour is one `tier_boundaries` block away
- A router with non-ascending boundaries now 400s instead of misrouting
- Editing one boundary in the UI rewrites the untouched two

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default routing so more traffic hits costlier models, and configs that previously started with inverted partial boundaries now fail validation instead of silently misrouting.
> 
> **Overview**
> Lowers the shipped complexity-router score cutoffs from **0.15 / 0.35 / 0.60** to **0.10 / 0.25 / 0.50**, so technical and multi-part prompts land in **MEDIUM/COMPLEX** instead of cheap tiers. Docs, dashboard defaults, and tests follow the same numbers. Unset `reasoning_override_min_score` still tracks `simple_medium`, so that floor drops with it.
> 
> Adds `resolve_tier_boundaries` as the only place omitted keys are filled from `DEFAULT_TIER_BOUNDARIES`, and a config validator that rejects non-ascending resolved boundaries (partial overrides that invert a default are the usual trap). Equal boundaries still pass (empty band). Operators who want the old split can set `tier_boundaries` explicitly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bee423818000811bce130958a31afa346ffaba67. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->