### PR TITLE
test(e2e): bypass the proxy response cache in the mid-conversation system and fallback tests

### DIFF
--- a/tests/e2e/llm_translation/endpoints_client.py
+++ b/tests/e2e/llm_translation/endpoints_client.py
@@ -87,6 +87,7 @@ class RichMessagesRequest(BaseModel):
     max_tokens: int = 64
     system: list[TextBlock]
     messages: list[RichMessage]
+    cache: dict[str, bool] = {"no-cache": True}
 
 
 class CompletionsRequest(BaseModel):

--- a/tests/e2e/router/reliability_support.py
+++ b/tests/e2e/router/reliability_support.py
@@ -56,7 +56,7 @@ def chat_override(
         json=ReliabilityChatBody(
             model=model,
             messages=[ChatMessage(role="user", content=content)],
-            max_tokens=16,
+            max_tokens=64,
             stream=stream,
             router_settings_override=override,
         ),

--- a/tests/e2e/router/test_reliability_fallbacks_e2e.py
+++ b/tests/e2e/router/test_reliability_fallbacks_e2e.py
@@ -49,7 +49,7 @@ class TestReliabilityFallbacks:
         resources.defer(lambda: client.proxy.delete_model(model_id))
 
         resp = chat_override(
-            client.proxy, scoped_key, primary, "say hi",
+            client.proxy, scoped_key, primary, f"say hi {unique_marker()}",
             override=RouterSettingsOverride(fallbacks=[{primary: ["gpt-5.5"]}]),
         )
         _assert_served_by_fallback(resp)
@@ -63,7 +63,7 @@ class TestReliabilityFallbacks:
         resources.defer(lambda: client.proxy.delete_model(model_id))
 
         resp = chat_override(
-            client.proxy, scoped_key, primary, "say hi",
+            client.proxy, scoped_key, primary, f"say hi {unique_marker()}",
             override=RouterSettingsOverride(fallbacks=[{primary: ["gpt-5.5"]}]),
         )
         _assert_served_by_fallback(resp)


### PR DESCRIPTION
## TLDR

Problem this solves:

- `litellm-e2e` has been red on every build since 2026-08-20: the three `test_unflagged_model_converts_system_reminder_and_succeeds` tests (Azure Foundry, Vertex, Bedrock Invoke) fail deterministically in `_prime_prompt_cache` with `prompt cache never became readable in full within 60.0s`
- Build 50 also lost both `TestReliabilityFallbacks` tests to a single empty gpt-5.5 completion

How it solves it:

- The priming helper re-sends an identical `/v1/messages` body until the usage shows the full prefix read back three times in a row. The e2e stack runs with the litellm response cache on, so every resend after the first is served from redis with the first call's usage (`cache_read_input_tokens` never grows) and the streak can never form. `RichMessagesRequest` now sends `cache: {"no-cache": true}`, the same bypass `test_cache_control.py` already uses; the key is honored by the `@client` cache check and filtered out before the provider request
- The two fallback tests sent the same `"say hi"` / `max_tokens=16` body to the `gpt-5.5` fallback, so one `finish_reason=length` completion with empty content served the second test from the response cache and failed both. Each test now uses a unique prompt, and `chat_override` leaves gpt-5.5 64 tokens to emit text

Test-only change; no product code touched.

## Relevant issues

Follows up #36968, which added the consecutive-read priming check. Failing builds: litellm-e2e 43–50 (e.g. https://buildkite.com/berriai-1/litellm-e2e/builds/50).

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review
