### PR TITLE
fix(ui): render team and org tpm/rpm limits of 0 as 0 instead of Unlimited

### DIFF
--- a/ui/litellm-dashboard/src/app/(dashboard)/organizations/_components/OrganizationsTable.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/organizations/_components/OrganizationsTable.test.tsx
@@ -165,6 +165,20 @@ describe("OrganizationsTable", () => {
     expect(screen.getByText("RPM: Unlimited")).toBeInTheDocument();
   });
 
+  it("renders a tpm/rpm limit of 0 as 0, never as Unlimited", () => {
+    render(
+      <OrganizationsTable
+        {...baseProps}
+        organizations={[makeOrganization({ litellm_budget_table: { max_budget: null, tpm_limit: 0, rpm_limit: 0 } })]}
+      />,
+    );
+
+    expect(screen.getByText("TPM: 0")).toBeInTheDocument();
+    expect(screen.getByText("RPM: 0")).toBeInTheDocument();
+    expect(screen.queryByText("TPM: Unlimited")).not.toBeInTheDocument();
+    expect(screen.queryByText("RPM: Unlimited")).not.toBeInTheDocument();
+  });
+
   it("renders loading skeletons instead of rows while loading", () => {
     render(
       <OrganizationsTable

--- a/ui/litellm-dashboard/src/app/(dashboard)/organizations/_components/OrganizationsTableColumns.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/organizations/_components/OrganizationsTableColumns.tsx
@@ -28,8 +28,8 @@ function OrganizationLimitsCell({ organization }: { organization: Organization }
   const { tpm_limit, rpm_limit } = getOrganizationBudget(organization);
   return (
     <div className="flex flex-col text-xs text-muted-foreground">
-      <span>TPM: {tpm_limit ? tpm_limit : "Unlimited"}</span>
-      <span>RPM: {rpm_limit ? rpm_limit : "Unlimited"}</span>
+      <span>TPM: {tpm_limit ?? "Unlimited"}</span>
+      <span>RPM: {rpm_limit ?? "Unlimited"}</span>
     </div>
   );
 }

--- a/ui/litellm-dashboard/src/components/organization/organization_view.test.tsx
+++ b/ui/litellm-dashboard/src/components/organization/organization_view.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { fireEvent, screen, waitFor } from "@testing-library/react";
+import { fireEvent, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { vi, test, expect, beforeEach } from "vitest";
 import { renderWithProviders } from "../../../tests/test-utils";
@@ -289,4 +289,38 @@ test("should keep unsaved settings edits when switching tabs and back", async ()
   await user.click(screen.getByRole("tab", { name: "Settings" }));
 
   expect(screen.getByLabelText(/Organization Name/i)).toHaveValue("Renamed Org");
+});
+
+test("renders a tpm/rpm limit of 0 as 0 in the overview and settings tabs, never as Unlimited", async () => {
+  const zeroLimitOrg = {
+    ...mockOrg,
+    litellm_budget_table: { ...mockOrg.litellm_budget_table, tpm_limit: 0, rpm_limit: 0 },
+  };
+  mockUseOrganization.mockReturnValue({ data: zeroLimitOrg, isLoading: false } as unknown as ReturnType<
+    typeof useOrganization
+  >);
+
+  const user = userEvent.setup();
+  renderWithProviders(
+    <OrganizationInfoView
+      organizationId="org_123"
+      onClose={() => {}}
+      accessToken="test-token"
+      is_org_admin={false}
+      is_proxy_admin={true}
+      userModels={[]}
+      editOrg={false}
+    />,
+  );
+
+  const overview = await screen.findByRole("tabpanel", { name: "Overview" });
+  expect(within(overview).getByText("TPM: 0")).toBeInTheDocument();
+  expect(within(overview).getByText("RPM: 0")).toBeInTheDocument();
+
+  await user.click(screen.getByRole("tab", { name: "Settings" }));
+  const settings = await screen.findByRole("tabpanel", { name: "Settings" });
+  expect(within(settings).getByText("TPM: 0")).toBeInTheDocument();
+  expect(within(settings).getByText("RPM: 0")).toBeInTheDocument();
+  expect(screen.queryByText("TPM: Unlimited")).not.toBeInTheDocument();
+  expect(screen.queryByText("RPM: Unlimited")).not.toBeInTheDocument();
 });

--- a/ui/litellm-dashboard/src/components/organization/organization_view.tsx
+++ b/ui/litellm-dashboard/src/components/organization/organization_view.tsx
@@ -206,8 +206,8 @@ const OrganizationInfoView: React.FC<OrganizationInfoProps> = ({
               <CardContent>
                 <p className="text-sm text-muted-foreground">Rate Limits</p>
                 <div className="mt-2 text-sm text-foreground">
-                  <p>TPM: {orgData.litellm_budget_table.tpm_limit || "Unlimited"}</p>
-                  <p>RPM: {orgData.litellm_budget_table.rpm_limit || "Unlimited"}</p>
+                  <p>TPM: {orgData.litellm_budget_table.tpm_limit ?? "Unlimited"}</p>
+                  <p>RPM: {orgData.litellm_budget_table.rpm_limit ?? "Unlimited"}</p>
                   {orgData.litellm_budget_table.max_parallel_requests && (
                     <p>Max Parallel Requests: {orgData.litellm_budget_table.max_parallel_requests}</p>
                   )}
@@ -311,8 +311,8 @@ const OrganizationInfoView: React.FC<OrganizationInfoProps> = ({
                   </div>
                   <div>
                     <p className="font-medium text-foreground">Rate Limits</p>
-                    <div>TPM: {orgData.litellm_budget_table.tpm_limit || "Unlimited"}</div>
-                    <div>RPM: {orgData.litellm_budget_table.rpm_limit || "Unlimited"}</div>
+                    <div>TPM: {orgData.litellm_budget_table.tpm_limit ?? "Unlimited"}</div>
+                    <div>RPM: {orgData.litellm_budget_table.rpm_limit ?? "Unlimited"}</div>
                   </div>
                   <div>
                     <p className="font-medium text-foreground">Budget</p>

--- a/ui/litellm-dashboard/src/components/team/EditMembership.integration.test.tsx
+++ b/ui/litellm-dashboard/src/components/team/EditMembership.integration.test.tsx
@@ -110,7 +110,7 @@ describe("EditMembership submit payload", () => {
     expect(submitted()).toStrictEqual(expected);
   });
 
-  it("collapses falsy budget and limit values to null and a missing model list to an empty array", async () => {
+  it("keeps stored 0 budget and limits as 0 on an untouched save, collapsing only empty strings and a missing model list", async () => {
     renderEdit(teamMemberConfig, {
       user_id: "u1",
       user_email: "a@b.com",
@@ -128,10 +128,10 @@ describe("EditMembership submit payload", () => {
       user_email: "a@b.com",
       user_id: "u1",
       role: "user",
-      max_budget_in_team: null,
+      max_budget_in_team: 0,
       budget_duration: null,
-      tpm_limit: null,
-      rpm_limit: null,
+      tpm_limit: 0,
+      rpm_limit: 0,
       allowed_models: [],
     });
   });

--- a/ui/litellm-dashboard/src/components/team/TeamInfo.test.tsx
+++ b/ui/litellm-dashboard/src/components/team/TeamInfo.test.tsx
@@ -319,6 +319,34 @@ describe("TeamInfoView", () => {
       expect(screen.getByText(/of \$1,000\.00/)).toBeInTheDocument();
     });
 
+    it("renders a tpm/rpm/budget limit of 0 as 0 in the overview and settings tabs, never as Unlimited or No Limit", async () => {
+      vi.mocked(networking.teamInfoCall).mockResolvedValue(
+        createMockTeamData({
+          tpm_limit: 0,
+          rpm_limit: 0,
+          team_member_budget_table: { max_budget: 0, budget_duration: null, tpm_limit: 0, rpm_limit: 0 },
+        }),
+      );
+
+      renderWithProviders(<TeamInfoView {...defaultProps} />);
+
+      const overview = await screen.findByRole("tabpanel", { name: "Overview" });
+      expect(within(overview).getByText("TPM: 0")).toBeInTheDocument();
+      expect(within(overview).getByText("RPM: 0")).toBeInTheDocument();
+
+      await userEvent.setup({ delay: null }).click(screen.getByRole("tab", { name: "Settings" }));
+      const settings = await screen.findByRole("tabpanel", { name: "Settings" });
+      expect(within(settings).getByText("TPM: 0")).toBeInTheDocument();
+      expect(within(settings).getByText("RPM: 0")).toBeInTheDocument();
+      expect(within(settings).getByText("TPM Limit: 0")).toBeInTheDocument();
+      expect(within(settings).getByText("RPM Limit: 0")).toBeInTheDocument();
+      expect(within(settings).getByText("Max Budget: 0")).toBeInTheDocument();
+      expect(screen.queryByText("TPM: Unlimited")).not.toBeInTheDocument();
+      expect(screen.queryByText("RPM: Unlimited")).not.toBeInTheDocument();
+      expect(screen.queryByText("TPM Limit: No Limit")).not.toBeInTheDocument();
+      expect(screen.queryByText("RPM Limit: No Limit")).not.toBeInTheDocument();
+    });
+
     it("should display guardrails in overview when present", async () => {
       vi.mocked(networking.teamInfoCall).mockResolvedValue(
         createMockTeamData({

--- a/ui/litellm-dashboard/src/components/team/TeamInfo.tsx
+++ b/ui/litellm-dashboard/src/components/team/TeamInfo.tsx
@@ -971,8 +971,8 @@ const TeamInfoView: React.FC<TeamInfoProps> = ({
           <Card className="block p-6">
             <p>Rate Limits</p>
             <div className="mt-2">
-              <p>TPM: {info.tpm_limit || "Unlimited"}</p>
-              <p>RPM: {info.rpm_limit || "Unlimited"}</p>
+              <p>TPM: {info.tpm_limit ?? "Unlimited"}</p>
+              <p>RPM: {info.rpm_limit ?? "Unlimited"}</p>
               {info.max_parallel_requests && <p>Max Parallel Requests: {info.max_parallel_requests}</p>}
               {(() => {
                 const modelTpm = (info.metadata?.model_tpm_limit ?? {}) as Record<string, number>;
@@ -1760,8 +1760,8 @@ const TeamInfoView: React.FC<TeamInfoProps> = ({
               </div>
               <div>
                 <p className="font-medium">Rate Limits</p>
-                <div>TPM: {info.tpm_limit || "Unlimited"}</div>
-                <div>RPM: {info.rpm_limit || "Unlimited"}</div>
+                <div>TPM: {info.tpm_limit ?? "Unlimited"}</div>
+                <div>RPM: {info.rpm_limit ?? "Unlimited"}</div>
                 {(() => {
                   const modelTpm = (info.metadata?.model_tpm_limit ?? {}) as Record<string, number>;
                   const modelRpm = (info.metadata?.model_rpm_limit ?? {}) as Record<string, number>;
@@ -1811,11 +1811,11 @@ const TeamInfoView: React.FC<TeamInfoProps> = ({
                     <Info className="ml-1 inline size-3.5 align-text-bottom" />
                   </SimpleTooltip>
                 </p>
-                <div>Max Budget: {info.team_member_budget_table?.max_budget || "No Limit"}</div>
+                <div>Max Budget: {info.team_member_budget_table?.max_budget ?? "No Limit"}</div>
                 <div>Budget Duration: {info.team_member_budget_table?.budget_duration || "No Limit"}</div>
                 <div>Key Duration: {info.metadata?.team_member_key_duration || "No Limit"}</div>
-                <div>TPM Limit: {info.team_member_budget_table?.tpm_limit || "No Limit"}</div>
-                <div>RPM Limit: {info.team_member_budget_table?.rpm_limit || "No Limit"}</div>
+                <div>TPM Limit: {info.team_member_budget_table?.tpm_limit ?? "No Limit"}</div>
+                <div>RPM Limit: {info.team_member_budget_table?.rpm_limit ?? "No Limit"}</div>
               </div>
               <div>
                 <p className="font-medium">Router Settings</p>

--- a/ui/litellm-dashboard/src/components/team/TeamMemberTab.test.tsx
+++ b/ui/litellm-dashboard/src/components/team/TeamMemberTab.test.tsx
@@ -1,4 +1,4 @@
-import { screen } from "@testing-library/react";
+import { screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { renderWithProviders } from "../../../tests/test-utils";
@@ -320,6 +320,38 @@ describe("TeamMembersComponent", () => {
 
     expect(mockSetIsEditMemberModalVisible).toHaveBeenCalledWith(true);
     expect(mockSetSelectedEditMember).toHaveBeenCalled();
+  });
+
+  it("keeps a member's stored 0 limits as 0 in the table and in the edit payload, never unlimited", async () => {
+    const user = userEvent.setup();
+    vi.mocked(isProxyAdminRole).mockReturnValue(true);
+    const teamData = createMockTeamData();
+    teamData.team_memberships[0].litellm_budget_table = {
+      ...teamData.team_memberships[0].litellm_budget_table,
+      max_budget: 0,
+      tpm_limit: 0,
+      rpm_limit: 0,
+    };
+
+    renderWithProviders(
+      <TeamMembersComponent
+        teamData={teamData}
+        canEditTeam={true}
+        handleMemberDelete={mockHandleMemberDelete}
+        setSelectedEditMember={mockSetSelectedEditMember}
+        setIsEditMemberModalVisible={mockSetIsEditMemberModalVisible}
+        setIsAddMemberModalVisible={mockSetIsAddMemberModalVisible}
+      />,
+    );
+
+    const memberRow = screen.getByRole("row", { name: /user1@test\.com/ });
+    expect(within(memberRow).getByText("0 RPM / 0 TPM")).toBeInTheDocument();
+    expect(within(memberRow).queryByText("No Limits")).not.toBeInTheDocument();
+
+    await user.click(within(memberRow).getByTestId("edit-member"));
+
+    const zeroLimitsMember = { user_id: "user1@test.com", max_budget_in_team: 0, tpm_limit: 0, rpm_limit: 0 };
+    expect(mockSetSelectedEditMember).toHaveBeenCalledWith(expect.objectContaining(zeroLimitsMember));
   });
 
   it("should call setIsAddMemberModalVisible when Add Member button is clicked", async () => {

--- a/ui/litellm-dashboard/src/components/team/TeamMemberTab.test.tsx
+++ b/ui/litellm-dashboard/src/components/team/TeamMemberTab.test.tsx
@@ -325,12 +325,17 @@ describe("TeamMembersComponent", () => {
   it("keeps a member's stored 0 limits as 0 in the table and in the edit payload, never unlimited", async () => {
     const user = userEvent.setup();
     vi.mocked(isProxyAdminRole).mockReturnValue(true);
-    const teamData = createMockTeamData();
-    teamData.team_memberships[0].litellm_budget_table = {
-      ...teamData.team_memberships[0].litellm_budget_table,
-      max_budget: 0,
-      tpm_limit: 0,
-      rpm_limit: 0,
+    const baseTeamData = createMockTeamData();
+    const teamData = {
+      ...baseTeamData,
+      team_memberships: baseTeamData.team_memberships.map((membership, index) =>
+        index === 0
+          ? {
+              ...membership,
+              litellm_budget_table: { ...membership.litellm_budget_table, max_budget: 0, tpm_limit: 0, rpm_limit: 0 },
+            }
+          : membership,
+      ),
     };
 
     renderWithProviders(

--- a/ui/litellm-dashboard/src/components/team/TeamMemberTab.tsx
+++ b/ui/litellm-dashboard/src/components/team/TeamMemberTab.tsx
@@ -71,8 +71,8 @@ export default function TeamMemberTab({
     const rpmLimit = membership?.litellm_budget_table?.rpm_limit;
     const tpmLimit = membership?.litellm_budget_table?.tpm_limit;
 
-    const rpmText = rpmLimit ? `${formatNumber(rpmLimit)} RPM` : null;
-    const tpmText = tpmLimit ? `${formatNumber(tpmLimit)} TPM` : null;
+    const rpmText = rpmLimit != null ? `${formatNumber(rpmLimit)} RPM` : null;
+    const tpmText = tpmLimit != null ? `${formatNumber(tpmLimit)} TPM` : null;
 
     const limits = [rpmText, tpmText].filter(Boolean);
     return limits.length > 0 ? limits.join(" / ") : "No Limits";
@@ -191,9 +191,9 @@ export default function TeamMemberTab({
         const membership = teamData.team_memberships.find((tm) => tm.user_id === record.user_id);
         const enhancedMember = {
           ...record,
-          max_budget_in_team: membership?.litellm_budget_table?.max_budget || null,
-          tpm_limit: membership?.litellm_budget_table?.tpm_limit || null,
-          rpm_limit: membership?.litellm_budget_table?.rpm_limit || null,
+          max_budget_in_team: membership?.litellm_budget_table?.max_budget ?? null,
+          tpm_limit: membership?.litellm_budget_table?.tpm_limit ?? null,
+          rpm_limit: membership?.litellm_budget_table?.rpm_limit ?? null,
           budget_duration: membership?.litellm_budget_table?.budget_duration || null,
           allowed_models: membership?.litellm_budget_table?.allowed_models || [],
         };

--- a/ui/litellm-dashboard/src/components/team/memberFormValues.test.ts
+++ b/ui/litellm-dashboard/src/components/team/memberFormValues.test.ts
@@ -82,7 +82,7 @@ describe("buildMemberFormValues", () => {
     });
   });
 
-  it("collapses falsy budgets and limits to null and a missing model list to an empty array", () => {
+  it("keeps a stored budget or limit of 0 as 0 because only null means unlimited", () => {
     expect(
       buildMemberFormValues(
         "edit",
@@ -93,12 +93,28 @@ describe("buildMemberFormValues", () => {
       user_email: "a@b.com",
       user_id: "u1",
       role: "user",
+      max_budget_in_team: 0,
+      budget_duration: null,
+      tpm_limit: 0,
+      rpm_limit: 0,
+      allowed_models: [],
+    });
+  });
+
+  it("collapses missing budgets and limits to null and a missing model list to an empty array", () => {
+    const unlimitedMember = {
+      user_email: "a@b.com",
+      user_id: "u1",
+      role: "user",
       max_budget_in_team: null,
       budget_duration: null,
       tpm_limit: null,
       rpm_limit: null,
       allowed_models: [],
-    });
+    };
+    expect(
+      buildMemberFormValues("edit", { user_email: "a@b.com", user_id: "u1", role: "user" }, teamConfig),
+    ).toStrictEqual(unlimitedMember);
   });
 
   it("falls back to the configured default role when the member has none", () => {

--- a/ui/litellm-dashboard/src/components/team/memberFormValues.ts
+++ b/ui/litellm-dashboard/src/components/team/memberFormValues.ts
@@ -43,9 +43,9 @@ export const buildMemberFormValues = (
     const seeded: MemberFormValues = {
       ...initialData,
       role: (initialData.role as string) || config.defaultRole,
-      max_budget_in_team: initialData.max_budget_in_team || null,
-      tpm_limit: initialData.tpm_limit || null,
-      rpm_limit: initialData.rpm_limit || null,
+      max_budget_in_team: initialData.max_budget_in_team ?? null,
+      tpm_limit: initialData.tpm_limit ?? null,
+      rpm_limit: initialData.rpm_limit ?? null,
       budget_duration: initialData.budget_duration || null,
       allowed_models: initialData.allowed_models || [],
     };


### PR DESCRIPTION
## TLDR

Problem this solves:

- Team and org views render tpm_limit / rpm_limit of 0 as "Unlimited"
- 0 is a hard block on the backend, null is unlimited
- Edit Member dialog rewrites a stored 0 to null on an untouched Save

How it solves it:

- Every limit display site uses a nullish check instead of a falsy one
- Member form seeding keeps 0 for budget, tpm and rpm limits
- Regression tests cover each display site and the form seeding

## User Flow

Before: an admin who set a team's TPM limit to 0 to block it sees the team described as unlimited, and re-saving a blocked member quietly unblocks them

1. They send POST https://litellm-domain/team/update with `{"team_id": "...", "tpm_limit": 0}` and get back `tpm_limit: 0`
2. A key on that team sends POST https://litellm-domain/v1/chat/completions and gets 429 "Rate limit exceeded for team ... Current limit: 0"
3. They open https://litellm-domain/ui/?page=teams, click the team, and the Overview reads "TPM: Unlimited" and "RPM: Unlimited"
4. On the Members tab they click Edit on a member whose limit is stored as 0, change nothing, and click Save
5. The request to POST https://litellm-domain/team/member_update carries `"tpm_limit": null`, and that member's hard block is gone

After: the same admin sees the 0 they set, and saving a member without touching the limit leaves it at 0

1. They send POST https://litellm-domain/team/update with `{"team_id": "...", "tpm_limit": 0}` and get back `tpm_limit: 0`
2. A key on that team sends POST https://litellm-domain/v1/chat/completions and gets 429 "Rate limit exceeded for team ... Current limit: 0"
3. They open https://litellm-domain/ui/?page=teams, click the team, and the Overview reads "TPM: 0" and "RPM: 0"
4. On the Members tab they click Edit on a member whose limit is stored as 0, change nothing, and click Save
5. The request to POST https://litellm-domain/team/member_update carries `"tpm_limit": 0`, and the member stays blocked

## Relevant issues

## Linear ticket

Resolves LIT-5760

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Shared setup, against a local proxy on :4000 with the dashboard dev server on :3000

```bash
curl -s http://localhost:4000/team/new -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" -d '{"team_alias":"tpm-zero","tpm_limit":0,"rpm_limit":0}'
```

```bash
curl -s http://localhost:4000/team/member_add -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" -d '{"team_id":"<team_id from above>","member":{"role":"user","user_email":"blocked@example.com"},"tpm_limit":0}'
```

### Before (7481649830)

#### Team overview renders 0 as Unlimited

1. Open http://localhost:3000/teams/ and click `tpm-zero`
2. Overview shows "TPM: Unlimited" and "RPM: Unlimited"

#### Edit Member rewrites 0 to null

1. On the Members tab click Edit on blocked@example.com, leave every field untouched, click Save
2. The `/team/member_update` request body in the browser network tab carries `"tpm_limit": null`

### After (d124a002e6)

#### Team overview renders 0 as Unlimited

1. Open http://localhost:3000/teams/ and click `tpm-zero`
2. Overview shows "TPM: 0" and "RPM: 0"

#### Edit Member rewrites 0 to null

1. On the Members tab click Edit on blocked@example.com, leave every field untouched, click Save
2. The `/team/member_update` request body carries `"tpm_limit": 0`

## Type

🐛 Bug Fix

## Caveats (if any)

- 0 still renders as a bare 0 rather than an explicit "blocked" label; whether 0 should stay a supported way to block a team is a separate decision

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

