### PR TITLE
fix: cache-read price on 3 realtime rows that disagree with their own siblings (10x)

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -5061,8 +5061,8 @@
         "supports_tool_choice": true
     },
     "azure/gpt-realtime-2025-08-28": {
-        "cache_creation_input_audio_token_cost": 4e-06,
-        "cache_read_input_token_cost": 4e-06,
+        "cache_creation_input_audio_token_cost": 4e-07,
+        "cache_read_input_token_cost": 4e-07,
         "deprecation_date": "2027-03-02",
         "input_cost_per_audio_token": 3.2e-05,
         "input_cost_per_image": 5e-06,
@@ -5094,8 +5094,8 @@
         "supports_tool_choice": true
     },
     "azure/gpt-realtime-1.5-2026-02-23": {
-        "cache_creation_input_audio_token_cost": 4e-06,
-        "cache_read_input_token_cost": 4e-06,
+        "cache_creation_input_audio_token_cost": 4e-07,
+        "cache_read_input_token_cost": 4e-07,
         "deprecation_date": "2027-08-24",
         "input_cost_per_audio_token": 3.2e-05,
         "input_cost_per_image": 5e-06,
@@ -27915,6 +27915,7 @@
     "gpt-realtime-mini": {
         "cache_creation_input_audio_token_cost": 3e-07,
         "cache_read_input_audio_token_cost": 3e-07,
+        "cache_read_input_token_cost": 6e-08,
         "deprecation_date": "2027-01-20",
         "input_cost_per_audio_token": 1e-05,
         "input_cost_per_token": 6e-07,

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -5061,8 +5061,8 @@
         "supports_tool_choice": true
     },
     "azure/gpt-realtime-2025-08-28": {
-        "cache_creation_input_audio_token_cost": 4e-06,
-        "cache_read_input_token_cost": 4e-06,
+        "cache_creation_input_audio_token_cost": 4e-07,
+        "cache_read_input_token_cost": 4e-07,
         "deprecation_date": "2027-03-02",
         "input_cost_per_audio_token": 3.2e-05,
         "input_cost_per_image": 5e-06,
@@ -5094,8 +5094,8 @@
         "supports_tool_choice": true
     },
     "azure/gpt-realtime-1.5-2026-02-23": {
-        "cache_creation_input_audio_token_cost": 4e-06,
-        "cache_read_input_token_cost": 4e-06,
+        "cache_creation_input_audio_token_cost": 4e-07,
+        "cache_read_input_token_cost": 4e-07,
         "deprecation_date": "2027-08-24",
         "input_cost_per_audio_token": 3.2e-05,
         "input_cost_per_image": 5e-06,
@@ -27915,6 +27915,7 @@
     "gpt-realtime-mini": {
         "cache_creation_input_audio_token_cost": 3e-07,
         "cache_read_input_audio_token_cost": 3e-07,
+        "cache_read_input_token_cost": 6e-08,
         "deprecation_date": "2027-01-20",
         "input_cost_per_audio_token": 1e-05,
         "input_cost_per_token": 6e-07,


### PR DESCRIPTION
## TLDR

Problem this solves:

- Two `azure/gpt-realtime` rows charge a cache hit the full uncached price
- Their `openai/` twins, identical elsewhere, charge one tenth
- `gpt-realtime-mini` has no cached-text price at all

How it solves it:

- Set both azure rows' cached-input fields to `4e-07`
- Give `gpt-realtime-mini` the `6e-08` its own dated sibling already has
- Five values, three rows, checked against Azure's retail price API

## User Flow

Before: a team moves a realtime voice app from OpenAI to Azure to cut costs, and their own dashboard tells them caching stopped working.

1. They run the app against `gpt-realtime-2025-08-28` on OpenAI and see cached text tokens logged at $0.40 per 1M
2. They switch the deployment to `azure/gpt-realtime-2025-08-28`, changing nothing else
3. `https://litellm-domain/ui/?page=logs` now prices the same cached tokens at $4.00 per 1M — caching appears to save nothing on Azure
4. They spend an afternoon looking for a caching misconfiguration on the Azure side that is not there, because Azure billed them $0.40 the whole time

After: the same switch leaves the cached-token price alone.

1. They run the app against `gpt-realtime-2025-08-28` on OpenAI and see cached text tokens logged at $0.40 per 1M
2. They switch the deployment to `azure/gpt-realtime-2025-08-28`, changing nothing else
3. `https://litellm-domain/ui/?page=logs` prices the same cached tokens at $0.40 per 1M
4. The saving they moved for shows up where they expected it

## Why these three rows are wrong

**The two azure rows.** `azure/gpt-realtime-2025-08-28` and `azure/gpt-realtime-1.5-2026-02-23` carry `4e-06` in both `cache_read_input_token_cost` and `cache_creation_input_audio_token_cost` — the same figure as `input_cost_per_token`. Every other cost field in those rows is byte-identical to the `openai/` rows for the same models, and those set both cached fields to `4e-07`.

They are also the only two realtime rows in the file where a cache hit costs a full miss. Every other azure realtime row already carries a discount: `azure/gpt-4o-realtime-preview-2024-12-17` goes $5.00 → $2.50, `azure/gpt-realtime-mini` goes $0.60 → $0.06.

Azure's own retail price API agrees. Every gpt-realtime generation Microsoft currently meters prices cached input at exactly one tenth of uncached, with no exceptions:

| meter | uncached | cached |
| --- | ---: | ---: |
| `gpt-realtime-2 Text inp Gl 1M Tokens` | $4.00 | $0.40 |
| `gpt-realtime-2 Audio inp Gl 1M Tokens` | $32.00 | $0.40 |
| `gpt-realtime-2 Image inp Gl 1M Tokens` | $5.00 | $0.50 |
| `gpt-realtime-2.1-mini Text inp Gl 1M Tokens` | $0.60 | $0.06 |
| `gpt-realtime-2.1-mini Audio inp Gl 1M Tokens` | $10.00 | $0.30 |

```bash
curl -sG 'https://prices.azure.com/api/retail/prices' \
  --data-urlencode "\$filter=contains(meterName, 'gpt-realtime')" \
  | python3 -c "import json,sys; [print(x['meterName'], x['retailPrice']) for x in json.load(sys.stdin)['Items']]" \
  | sort -u
```

Read 2026-08-22. Note that the API no longer meters the 2025-08-28 generation itself, so this is the ratio evidence rather than that row's own line item; the byte-identical `openai/` twin is the direct evidence for the figure.

**`gpt-realtime-mini`.** This row has no `cache_read_input_token_cost` key at all, so cached text tokens fall back to the full `6e-07`. Its own dated sibling `gpt-realtime-mini-2025-10-06` and the `azure/gpt-realtime-mini` mirror both carry `6e-08`. It already has `cache_read_input_audio_token_cost`, so the audio half was filled in and the text half was missed.

## Verifying this diff

```bash
python3 - <<'EOF'
import json, urllib.request
old = json.load(urllib.request.urlopen(
  "https://raw.githubusercontent.com/BerriAI/litellm/litellm_internal_staging/model_prices_and_context_window.json"))
new = json.load(open("model_prices_and_context_window.json"))
assert set(old) == set(new)
changed = {k: {f: (old[k].get(f), new[k].get(f))
               for f in set(old[k]) | set(new[k]) if old[k].get(f) != new[k].get(f)}
           for k in old if old[k] != new[k]}
for k, fields in changed.items():
    print(k, fields)
assert set(changed) == {"gpt-realtime-mini", "azure/gpt-realtime-2025-08-28",
                        "azure/gpt-realtime-1.5-2026-02-23"}
for k, fields in changed.items():
    for f in fields: assert "cache" in f, (k, f)
print("three rows, cache fields only")
EOF
cmp model_prices_and_context_window.json litellm/model_prices_and_context_window_backup.json
```

## A gap I noticed but did not fill

Azure now meters `gpt-realtime-2`, `gpt-realtime-2.1` and `gpt-realtime-2.1-mini`, all three with full price lines in the API call above, including a regional `DZ` tier at a 10% premium. This file has those three only under `openai/`; there are no `azure/` rows for them. I have left that alone so this PR stays one problem wide. If you want them, say so and I will send them with the meter names as the source.

## Relevant issues

None found — I searched open issues for `gpt-realtime` and for `cache_read_input_token_cost` before filing.

## Linear ticket

## Pre-Submission checklist

- [ ] I have added meaningful tests
- [x] The handful of test files covering my change pass locally
- [x] My PR passes all required CI/CD checks
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile Confidence Score of at least 4/5

Straight answer on the tests box rather than a tick: this changes five numbers in a data file and no code path, so the check is the script above, which I have run. If you want a standing guard, the one that would have caught all three is an assertion that `cache_read_input_token_cost < input_cost_per_token` wherever both exist — it passes on the whole file today except for these two rows, which is how I found them. Say the word and I will add it.

I also have #37930 open against the same file (a separate unit bug in the `wandb/*` rows). They touch different lines but git will want a rebase on whichever lands second — happy to do that on request.

Greptile has not run yet at the time of opening.
