### PR TITLE
feat(providers): add minirouter

### DIFF
--- a/litellm/llms/openai_like/providers.json
+++ b/litellm/llms/openai_like/providers.json
@@ -168,6 +168,11 @@
     },
     "supported_endpoints": ["/v1/chat/completions", "/v1/responses"]
   },
+  "minirouter": {
+    "base_url": "https://api.minirouter.sh/v1",
+    "api_key_env": "MINIROUTER_API_KEY",
+    "api_base_env": "MINIROUTER_API_BASE"
+  },
   "meta": {
     "base_url": "https://api.meta.ai/v1",
     "api_key_env": "META_API_KEY",

--- a/litellm/provider_endpoints_support_backup.json
+++ b/litellm/provider_endpoints_support_backup.json
@@ -1991,6 +1991,23 @@
         "interactions": true
       }
     },
+    "minirouter": {
+      "display_name": "minirouter (`minirouter`)",
+      "url": "https://minirouter.sh/integrations/litellm",
+      "endpoints": {
+        "chat_completions": true,
+        "messages": false,
+        "responses": false,
+        "embeddings": false,
+        "image_generations": false,
+        "audio_transcriptions": false,
+        "audio_speech": false,
+        "moderations": false,
+        "batches": false,
+        "rerank": false,
+        "a2a": false
+      }
+    },
     "sap": {
       "display_name": "SAP Generative AI Hub (`sap`)",
       "url": "https://docs.litellm.ai/docs/providers/sap",

--- a/provider_endpoints_support.json
+++ b/provider_endpoints_support.json
@@ -2018,6 +2018,23 @@
         "a2a": false
       }
     },
+    "minirouter": {
+      "display_name": "minirouter (`minirouter`)",
+      "url": "https://minirouter.sh/integrations/litellm",
+      "endpoints": {
+        "chat_completions": true,
+        "messages": false,
+        "responses": false,
+        "embeddings": false,
+        "image_generations": false,
+        "audio_transcriptions": false,
+        "audio_speech": false,
+        "moderations": false,
+        "batches": false,
+        "rerank": false,
+        "a2a": false
+      }
+    },
     "pinstripes": {
       "display_name": "Pinstripes (`pinstripes`)",
       "url": "https://docs.litellm.ai/docs/providers/pinstripes",

--- a/tests/test_litellm/proxy/public_endpoints/test_public_endpoints.py
+++ b/tests/test_litellm/proxy/public_endpoints/test_public_endpoints.py
@@ -834,6 +834,16 @@ def test_get_supported_endpoints_chat_completions_present(reset_endpoints_cache)
     assert len(chat["providers"]) > 0
 
 
+def test_get_supported_endpoints_includes_minirouter(reset_endpoints_cache):
+    endpoints = _make_client().get("/public/endpoints").json()["endpoints"]
+    chat = next(item for item in endpoints if item["key"] == "chat_completions")
+
+    minirouter = next(
+        provider for provider in chat["providers"] if provider["slug"] == "minirouter"
+    )
+    assert minirouter["display_name"] == "minirouter"
+
+
 def test_get_supported_endpoints_display_names_have_no_slug_suffix(
     reset_endpoints_cache,
 ):


### PR DESCRIPTION
## TLDR

Problem this solves:

- minirouter models cannot be routed through LiteLLM

How it solves it:

- Add minirouter to `openai_like/providers.json`
- Register the endpoint and API key variables

minirouter is an OpenAI-compatible gateway (https://minirouter.sh) over the Vercel AI Gateway catalog. Model IDs use `<lab>/<model>`, for example `minirouter/anthropic/claude-sonnet-4.6`

## User Flow

Before: a developer's minirouter completion stops at provider resolution

1. They set `MINIROUTER_API_KEY` and call `litellm.completion(model="minirouter/anthropic/claude-sonnet-4.6", messages=[...])`
2. LiteLLM rejects `minirouter` before POST https://api.minirouter.sh/v1/chat/completions

After: the same completion routes to minirouter's OpenAI-compatible endpoint

1. They set `MINIROUTER_API_KEY` and call `litellm.completion(model="minirouter/anthropic/claude-sonnet-4.6", messages=[...])`
2. LiteLLM sends POST https://api.minirouter.sh/v1/chat/completions and returns an OpenAI-compatible response

## Relevant issues

## Linear ticket

## Pre-Submission checklist

- [ ] I have added meaningful tests
- [ ] The handful of test files covering my change pass locally
- [ ] My PR passes all required CI/CD checks
- [x] My PR's scope is as isolated as possible
- [ ] I have received a Greptile Confidence Score of at least 4/5

## Delays in PR merge?

If you're seeing a delay, ping the LiteLLM Team in Slack #pr-review

## Screenshots / Proof of Fix

Live completion proof is pending because this checkout has no `MINIROUTER_API_KEY`

Local verification confirms `minirouter/meta/llama-3.3-70b` resolves to `https://api.minirouter.sh/v1`, both JSON files parse, and the provider documentation check passes

Docs: https://minirouter.sh/integrations/litellm

## Type

🆕 New Feature

## Caveats (if any)

- Live completion and proxy tests need a minirouter key

### Final Attestation

- [ ] The tests check the right things, including edge cases