### PR TITLE
feat(guardrails): structured conversation on response scans

### DIFF
--- a/litellm/llms/anthropic/chat/guardrail_translation/handler.py
+++ b/litellm/llms/anthropic/chat/guardrail_translation/handler.py
@@ -44,10 +44,8 @@ from litellm.types.llms.anthropic import (
 )
 from litellm.types.llms.openai import (
     AllMessageValues,
-    ChatCompletionAssistantToolCall,
     ChatCompletionRequest,
     ChatCompletionToolCallChunk,
-    ChatCompletionToolCallFunctionChunk,
     ChatCompletionToolParam,
 )
 from litellm.types.utils import (
@@ -111,6 +109,17 @@ class ExtractedInput:
 
 
 EMPTY_EXTRACTED_INPUT: Final = ExtractedInput(scanned=(), images=())
+
+
+@dataclass(frozen=True, slots=True)
+class _ScopedRequestView:
+    """The request as guardrail scans see it, with the operator scoping applied."""
+
+    translated_request: ChatCompletionRequest
+    full_messages: tuple[AllMessageValues, ...]
+    scoped_indices: tuple[int, ...]
+    hoisted_system_message: AllMessageValues | None
+    has_midturn_system_message: bool
 
 
 class AnthropicMessagesHandler(BaseTranslation):
@@ -316,36 +325,57 @@ class AnthropicMessagesHandler(BaseTranslation):
         )
         return result if result else None
 
+    def _scoped_request_view(
+        self,
+        data: dict,  # mutable-ok: API request payload
+        guardrail_to_apply: "CustomGuardrail",
+    ) -> "_ScopedRequestView":
+        """
+        Translate the request the way guardrail scans see it: exclude the
+        trusted top-level prompt, hoist it back unless skip_system, keep
+        in-sequence system entries in scope. Single source of truth for the
+        request and response scans, which must not disagree.
+        """
+        skip_system: Final = effective_skip_system_message_for_guardrail(guardrail_to_apply)
+        translation_source: Final = {  # mutable-ok: API message payload
+            key: value for key, value in data.items() if key != "system"
+        }
+        translated_request: Final = self._translate_to_openai(translation_source)
+        translated_messages: Final = tuple(translated_request.get("messages") or ())
+        has_midturn_system_message: Final = any(
+            str(message.get("role") or "").lower() == "system" for message in translated_messages
+        )
+        hoisted_system_message: Final = None if skip_system else self._hoisted_top_level_system_message(data)
+        full_messages: Final = (
+            (hoisted_system_message, *translated_messages)
+            if hoisted_system_message is not None
+            else translated_messages
+        )
+        # skip_system already excluded the trusted top-level prompt (it is simply
+        # not hoisted); in-sequence system entries are untrusted and stay in scope.
+        scoped_indices: Final = scoped_structured_message_indices(
+            full_messages,
+            scan_only_tool_results=effective_scan_only_tool_results_for_guardrail(guardrail_to_apply),
+            skip_system=False,
+            skip_tool=effective_skip_tool_message_for_guardrail(guardrail_to_apply),
+        )
+        return _ScopedRequestView(
+            translated_request=translated_request,
+            full_messages=full_messages,
+            scoped_indices=scoped_indices,
+            hoisted_system_message=hoisted_system_message,
+            has_midturn_system_message=has_midturn_system_message,
+        )
+
     def scoped_request_conversation(
         self,
         request_data: dict,  # mutable-ok: API request payload
         guardrail_to_apply: "CustomGuardrail",
     ) -> tuple[AllMessageValues, ...] | None:
-        """
-        Mirror the request scan's scoping: translate without the trusted
-        top-level prompt, hoist it back unless skip_system, and keep
-        in-sequence system entries in scope.
-        """
         if request_data.get("messages") is None:
             return None
-        skip_system: Final = effective_skip_system_message_for_guardrail(guardrail_to_apply)
-        translation_source: Final = {  # mutable-ok: API message payload
-            key: value for key, value in request_data.items() if key != "system"
-        }
-        translated_messages: Final = self._translate_to_openai(translation_source).get("messages")
-        hoisted_system_message: Final = None if skip_system else self._hoisted_top_level_system_message(request_data)
-        full_structured_messages: Final = (
-            (hoisted_system_message, *(translated_messages or ()))
-            if hoisted_system_message is not None
-            else tuple(translated_messages or ())
-        )
-        scoped_indices: Final = scoped_structured_message_indices(
-            full_structured_messages,
-            scan_only_tool_results=effective_scan_only_tool_results_for_guardrail(guardrail_to_apply),
-            skip_system=False,
-            skip_tool=effective_skip_tool_message_for_guardrail(guardrail_to_apply),
-        )
-        return tuple(full_structured_messages[index] for index in scoped_indices) or None
+        view: Final = self._scoped_request_view(request_data, guardrail_to_apply)
+        return tuple(view.full_messages[index] for index in view.scoped_indices) or None
 
     def request_tools_for_guardrail(
         self,
@@ -356,10 +386,14 @@ class AnthropicMessagesHandler(BaseTranslation):
             return None
         if not request_data.get("tools"):
             return None
-        translation_source: Final = {  # mutable-ok: API message payload
-            key: value for key, value in request_data.items() if key != "system"
-        }
-        tools: Final = self._translate_to_openai(translation_source).get("tools")
+        probe: Final = self._translate_to_openai(
+            {  # mutable-ok: API message payload
+                "model": request_data.get("model") or "",
+                "messages": [],  # mutable-ok: API message payload
+                "tools": request_data["tools"],
+            }
+        )
+        tools: Final = probe.get("tools")
         return tuple(tools) if tools else None
 
     async def process_input_messages(
@@ -382,33 +416,17 @@ class AnthropicMessagesHandler(BaseTranslation):
         # Exclude only the trusted top-level prompt. In-sequence system entries are untrusted
         # and must stay aligned with texts_to_check for positional masking. When the top-level
         # prompt is included, the pre-existing count mismatch disables positional masking.
-        translation_source: Final = {  # mutable-ok: API message payload
-            key: value for key, value in data.items() if key != "system"
-        }
-        chat_completion_compatible_request: Final = self._translate_to_openai(translation_source)
+        view: Final = self._scoped_request_view(data, guardrail_to_apply)
+        full_structured_messages: Final = view.full_messages
+        has_midturn_system_message: Final = view.has_midturn_system_message
+        hoisted_system_message: Final = view.hoisted_system_message
+        scoped_message_indices: Final = view.scoped_indices
+        structured_messages: Final = [  # mutable-ok: GenericGuardrailAPIInputs takes list
+            full_structured_messages[index] for index in scoped_message_indices
+        ]
 
-        full_structured_messages: Final = cast(
-            list[AllMessageValues],
-            chat_completion_compatible_request.get("messages", []),
-        )
-        has_midturn_system_message: Final = any(
-            str(message.get("role") or "").lower() == "system" for message in full_structured_messages
-        )
-        hoisted_system_message: Final = None if skip_system else self._hoisted_top_level_system_message(data)
-        if hoisted_system_message is not None:
-            full_structured_messages.insert(0, hoisted_system_message)
-        # skip_system already excluded the trusted top-level prompt (it is simply not hoisted);
-        # in-sequence system entries are untrusted and always stay in scope.
-        scoped_message_indices: Final = scoped_structured_message_indices(
-            full_structured_messages,
-            scan_only_tool_results=scan_only_tool_results,
-            skip_system=False,
-            skip_tool=skip_tool,
-        )
-        structured_messages: Final = [full_structured_messages[index] for index in scoped_message_indices]
-
-        tools_to_check: Final[list[ChatCompletionToolParam]] = (
-            [] if scan_only_tool_results else chat_completion_compatible_request.get("tools", [])
+        tools_to_check: Final[list[ChatCompletionToolParam]] = (  # mutable-ok: GenericGuardrailAPIInputs takes list
+            [] if scan_only_tool_results else list(view.translated_request.get("tools") or ())
         )
 
         # Step 1: Extract all text content and images
@@ -944,18 +962,12 @@ class AnthropicMessagesHandler(BaseTranslation):
                 response,
             )
 
-            structured_conversation: Final = self.response_scan_conversation(
+            self.attach_response_scan_context(
+                inputs,
                 request_data,
                 guardrail_to_apply,
                 self.assistant_turn_from_extraction(texts_to_check, tool_calls_to_check),
             )
-            if structured_conversation:
-                inputs["structured_messages"] = list(
-                    structured_conversation
-                )  # mutable-ok: GenericGuardrailAPIInputs takes list
-                response_scan_tools: Final = self.request_tools_for_guardrail(request_data, guardrail_to_apply)
-                if response_scan_tools:
-                    inputs["tools"] = list(response_scan_tools)  # mutable-ok: GenericGuardrailAPIInputs takes list
 
             guardrailed_inputs: Final = await guardrail_to_apply.apply_guardrail(
                 inputs=inputs,
@@ -1024,17 +1036,15 @@ class AnthropicMessagesHandler(BaseTranslation):
                         key="response",
                     )
                     stream_tool_calls: Final = tuple(
-                        ChatCompletionAssistantToolCall(
-                            id=tool_call.id,
-                            type="function",
-                            function=ChatCompletionToolCallFunctionChunk(
-                                name=tool_call.function.name,
-                                arguments=tool_call.function.arguments,
-                            ),
+                        self.assistant_tool_call(
+                            tool_call_id=tool_call.id,
+                            name=tool_call.function.name,
+                            arguments=tool_call.function.arguments,
                         )
                         for tool_call in tool_calls_list or ()
                     )
-                    structured_conversation: Final = self.response_scan_conversation(
+                    self.attach_response_scan_context(
+                        guardrail_inputs,
                         prepared_request_data,
                         guardrail_to_apply,
                         self.assistant_turn_from_extraction(
@@ -1042,17 +1052,6 @@ class AnthropicMessagesHandler(BaseTranslation):
                             stream_tool_calls,
                         ),
                     )
-                    if structured_conversation:
-                        guardrail_inputs["structured_messages"] = list(
-                            structured_conversation
-                        )  # mutable-ok: GenericGuardrailAPIInputs takes list
-                        response_scan_tools: Final = self.request_tools_for_guardrail(
-                            prepared_request_data, guardrail_to_apply
-                        )
-                        if response_scan_tools:
-                            guardrail_inputs["tools"] = list(
-                                response_scan_tools
-                            )  # mutable-ok: GenericGuardrailAPIInputs takes list
                     _guardrailed_inputs = await guardrail_to_apply.apply_guardrail(
                         inputs=guardrail_inputs,
                         request_data=prepared_request_data,

--- a/litellm/llms/anthropic/chat/guardrail_translation/handler.py
+++ b/litellm/llms/anthropic/chat/guardrail_translation/handler.py
@@ -314,6 +314,53 @@ class AnthropicMessagesHandler(BaseTranslation):
         )
         return result if result else None
 
+    def scoped_request_conversation(
+        self,
+        request_data: dict,
+        guardrail_to_apply: "CustomGuardrail",
+    ) -> list[AllMessageValues] | None:
+        """
+        Mirror the request scan's scoping: translate without the trusted
+        top-level prompt, hoist it back unless skip_system, and keep
+        in-sequence system entries in scope.
+        """
+        if request_data.get("messages") is None:
+            return None
+        skip_system: Final = effective_skip_system_message_for_guardrail(guardrail_to_apply)
+        translation_source: Final = {  # mutable-ok: API message payload
+            key: value for key, value in request_data.items() if key != "system"
+        }
+        full_structured_messages: Final = cast(
+            list[AllMessageValues],
+            self._translate_to_openai(translation_source).get("messages", []),
+        )
+        hoisted_system_message: Final = None if skip_system else self._hoisted_top_level_system_message(request_data)
+        if hoisted_system_message is not None:
+            full_structured_messages.insert(0, hoisted_system_message)
+        scoped_indices: Final = scoped_structured_message_indices(
+            full_structured_messages,
+            scan_only_tool_results=effective_scan_only_tool_results_for_guardrail(guardrail_to_apply),
+            skip_system=False,
+            skip_tool=effective_skip_tool_message_for_guardrail(guardrail_to_apply),
+        )
+        scoped: Final = [full_structured_messages[index] for index in scoped_indices]
+        return scoped or None
+
+    def request_tools_for_guardrail(
+        self,
+        request_data: dict,
+        guardrail_to_apply: "CustomGuardrail",
+    ) -> list[ChatCompletionToolParam] | None:
+        if effective_scan_only_tool_results_for_guardrail(guardrail_to_apply):
+            return None
+        if not request_data.get("tools"):
+            return None
+        translation_source: Final = {  # mutable-ok: API message payload
+            key: value for key, value in request_data.items() if key != "system"
+        }
+        tools: Final = self._translate_to_openai(translation_source).get("tools", [])
+        return list(tools) if tools else None
+
     async def process_input_messages(
         self,
         data: dict,
@@ -896,6 +943,17 @@ class AnthropicMessagesHandler(BaseTranslation):
                 response,
             )
 
+            structured_conversation: Final = self.response_scan_conversation(
+                request_data,
+                guardrail_to_apply,
+                self.assistant_turn_from_extraction(texts_to_check, tool_calls_to_check),
+            )
+            if structured_conversation:
+                inputs["structured_messages"] = structured_conversation
+                response_scan_tools: Final = self.request_tools_for_guardrail(request_data, guardrail_to_apply)
+                if response_scan_tools:
+                    inputs["tools"] = response_scan_tools
+
             guardrailed_inputs: Final = await guardrail_to_apply.apply_guardrail(
                 inputs=inputs,
                 request_data=request_data,
@@ -962,6 +1020,24 @@ class AnthropicMessagesHandler(BaseTranslation):
                         user_api_key_dict,
                         key="response",
                     )
+                    stream_tool_call_dicts: Final = tuple(
+                        tool_call.model_dump() for tool_call in tool_calls_list or ()
+                    )
+                    structured_conversation: Final = self.response_scan_conversation(
+                        prepared_request_data,
+                        guardrail_to_apply,
+                        self.assistant_turn_from_extraction(
+                            [string_so_far] if isinstance(string_so_far, str) and string_so_far else [],
+                            stream_tool_call_dicts,
+                        ),
+                    )
+                    if structured_conversation:
+                        guardrail_inputs["structured_messages"] = structured_conversation
+                        response_scan_tools: Final = self.request_tools_for_guardrail(
+                            prepared_request_data, guardrail_to_apply
+                        )
+                        if response_scan_tools:
+                            guardrail_inputs["tools"] = response_scan_tools
                     _guardrailed_inputs = await guardrail_to_apply.apply_guardrail(
                         inputs=guardrail_inputs,
                         request_data=prepared_request_data,

--- a/litellm/llms/anthropic/chat/guardrail_translation/handler.py
+++ b/litellm/llms/anthropic/chat/guardrail_translation/handler.py
@@ -44,8 +44,10 @@ from litellm.types.llms.anthropic import (
 )
 from litellm.types.llms.openai import (
     AllMessageValues,
+    ChatCompletionAssistantToolCall,
     ChatCompletionRequest,
     ChatCompletionToolCallChunk,
+    ChatCompletionToolCallFunctionChunk,
     ChatCompletionToolParam,
 )
 from litellm.types.utils import (
@@ -316,9 +318,9 @@ class AnthropicMessagesHandler(BaseTranslation):
 
     def scoped_request_conversation(
         self,
-        request_data: dict,
+        request_data: dict,  # mutable-ok: API request payload
         guardrail_to_apply: "CustomGuardrail",
-    ) -> list[AllMessageValues] | None:
+    ) -> tuple[AllMessageValues, ...] | None:
         """
         Mirror the request scan's scoping: translate without the trusted
         top-level prompt, hoist it back unless skip_system, and keep
@@ -330,27 +332,26 @@ class AnthropicMessagesHandler(BaseTranslation):
         translation_source: Final = {  # mutable-ok: API message payload
             key: value for key, value in request_data.items() if key != "system"
         }
-        full_structured_messages: Final = cast(
-            list[AllMessageValues],
-            self._translate_to_openai(translation_source).get("messages", []),
-        )
+        translated_messages: Final = self._translate_to_openai(translation_source).get("messages")
         hoisted_system_message: Final = None if skip_system else self._hoisted_top_level_system_message(request_data)
-        if hoisted_system_message is not None:
-            full_structured_messages.insert(0, hoisted_system_message)
+        full_structured_messages: Final = (
+            (hoisted_system_message, *(translated_messages or ()))
+            if hoisted_system_message is not None
+            else tuple(translated_messages or ())
+        )
         scoped_indices: Final = scoped_structured_message_indices(
             full_structured_messages,
             scan_only_tool_results=effective_scan_only_tool_results_for_guardrail(guardrail_to_apply),
             skip_system=False,
             skip_tool=effective_skip_tool_message_for_guardrail(guardrail_to_apply),
         )
-        scoped: Final = [full_structured_messages[index] for index in scoped_indices]
-        return scoped or None
+        return tuple(full_structured_messages[index] for index in scoped_indices) or None
 
     def request_tools_for_guardrail(
         self,
-        request_data: dict,
+        request_data: dict,  # mutable-ok: API request payload
         guardrail_to_apply: "CustomGuardrail",
-    ) -> list[ChatCompletionToolParam] | None:
+    ) -> tuple[ChatCompletionToolParam, ...] | None:
         if effective_scan_only_tool_results_for_guardrail(guardrail_to_apply):
             return None
         if not request_data.get("tools"):
@@ -358,8 +359,8 @@ class AnthropicMessagesHandler(BaseTranslation):
         translation_source: Final = {  # mutable-ok: API message payload
             key: value for key, value in request_data.items() if key != "system"
         }
-        tools: Final = self._translate_to_openai(translation_source).get("tools", [])
-        return list(tools) if tools else None
+        tools: Final = self._translate_to_openai(translation_source).get("tools")
+        return tuple(tools) if tools else None
 
     async def process_input_messages(
         self,
@@ -949,10 +950,12 @@ class AnthropicMessagesHandler(BaseTranslation):
                 self.assistant_turn_from_extraction(texts_to_check, tool_calls_to_check),
             )
             if structured_conversation:
-                inputs["structured_messages"] = structured_conversation
+                inputs["structured_messages"] = list(
+                    structured_conversation
+                )  # mutable-ok: GenericGuardrailAPIInputs takes list
                 response_scan_tools: Final = self.request_tools_for_guardrail(request_data, guardrail_to_apply)
                 if response_scan_tools:
-                    inputs["tools"] = response_scan_tools
+                    inputs["tools"] = list(response_scan_tools)  # mutable-ok: GenericGuardrailAPIInputs takes list
 
             guardrailed_inputs: Final = await guardrail_to_apply.apply_guardrail(
                 inputs=inputs,
@@ -1020,24 +1023,36 @@ class AnthropicMessagesHandler(BaseTranslation):
                         user_api_key_dict,
                         key="response",
                     )
-                    stream_tool_call_dicts: Final = tuple(
-                        tool_call.model_dump() for tool_call in tool_calls_list or ()
+                    stream_tool_calls: Final = tuple(
+                        ChatCompletionAssistantToolCall(
+                            id=tool_call.id,
+                            type="function",
+                            function=ChatCompletionToolCallFunctionChunk(
+                                name=tool_call.function.name,
+                                arguments=tool_call.function.arguments,
+                            ),
+                        )
+                        for tool_call in tool_calls_list or ()
                     )
                     structured_conversation: Final = self.response_scan_conversation(
                         prepared_request_data,
                         guardrail_to_apply,
                         self.assistant_turn_from_extraction(
-                            [string_so_far] if isinstance(string_so_far, str) and string_so_far else [],
-                            stream_tool_call_dicts,
+                            (string_so_far,) if isinstance(string_so_far, str) and string_so_far else (),
+                            stream_tool_calls,
                         ),
                     )
                     if structured_conversation:
-                        guardrail_inputs["structured_messages"] = structured_conversation
+                        guardrail_inputs["structured_messages"] = list(
+                            structured_conversation
+                        )  # mutable-ok: GenericGuardrailAPIInputs takes list
                         response_scan_tools: Final = self.request_tools_for_guardrail(
                             prepared_request_data, guardrail_to_apply
                         )
                         if response_scan_tools:
-                            guardrail_inputs["tools"] = response_scan_tools
+                            guardrail_inputs["tools"] = list(
+                                response_scan_tools
+                            )  # mutable-ok: GenericGuardrailAPIInputs takes list
                     _guardrailed_inputs = await guardrail_to_apply.apply_guardrail(
                         inputs=guardrail_inputs,
                         request_data=prepared_request_data,

--- a/litellm/llms/base_llm/guardrail_translation/base_translation.py
+++ b/litellm/llms/base_llm/guardrail_translation/base_translation.py
@@ -1,6 +1,14 @@
 from abc import ABC, abstractmethod
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any, Final, Optional
+from typing import TYPE_CHECKING, Any, Final, Optional, cast
+
+from litellm.llms.base_llm.guardrail_translation.utils import (
+    effective_scan_only_tool_results_for_guardrail,
+    effective_skip_system_message_for_guardrail,
+    effective_skip_tool_message_for_guardrail,
+    scoped_structured_message_indices,
+)
 
 if TYPE_CHECKING:
     from litellm.integrations.custom_guardrail import (
@@ -9,7 +17,7 @@ if TYPE_CHECKING:
     )
     from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObj
     from litellm.proxy._types import UserAPIKeyAuth
-    from litellm.types.llms.openai import AllMessageValues
+    from litellm.types.llms.openai import AllMessageValues, ChatCompletionToolParam
 
 
 @dataclass(slots=True)
@@ -156,6 +164,82 @@ class BaseTranslation(ABC):
         Returns None if no convertible content is found.
         """
         return None
+
+    def scoped_request_conversation(
+        self,
+        request_data: dict,
+        guardrail_to_apply: "CustomGuardrail",
+    ) -> list["AllMessageValues"] | None:
+        """
+        The request conversation as the guardrail's request scan saw it: the
+        handler's structured messages with the operator scoping flags applied.
+
+        Override when the request scan scopes differently (e.g. Anthropic's
+        top-level system prompt hoisting).
+        """
+        structured_messages: Final = self.get_structured_messages(request_data)
+        if not structured_messages:
+            return None
+        scoped_indices: Final = scoped_structured_message_indices(
+            structured_messages,
+            scan_only_tool_results=effective_scan_only_tool_results_for_guardrail(guardrail_to_apply),
+            skip_system=effective_skip_system_message_for_guardrail(guardrail_to_apply),
+            skip_tool=effective_skip_tool_message_for_guardrail(guardrail_to_apply),
+        )
+        scoped: Final = [structured_messages[index] for index in scoped_indices]
+        return scoped or None
+
+    def response_scan_conversation(
+        self,
+        request_data: dict | None,
+        guardrail_to_apply: "CustomGuardrail",
+        response_turns: Sequence["AllMessageValues"],
+    ) -> list["AllMessageValues"] | None:
+        """
+        Full conversation for a response scan: the scoped request conversation
+        with the model's response turns appended.
+
+        Returns None when the request context is unavailable (SDK/direct-call
+        path fabricates request_data without messages); guardrails then fall
+        back to scanning the extracted texts.
+        """
+        if request_data is None:
+            return None
+        request_conversation: Final = self.scoped_request_conversation(request_data, guardrail_to_apply)
+        if request_conversation is None:
+            return None
+        return [*request_conversation, *response_turns]
+
+    def request_tools_for_guardrail(
+        self,
+        request_data: dict,
+        guardrail_to_apply: "CustomGuardrail",
+    ) -> list["ChatCompletionToolParam"] | None:
+        """
+        The request's tool definitions in the shape the request scan sends them.
+
+        Override in tool-capable handlers; default returns None.
+        """
+        return None
+
+    @staticmethod
+    def assistant_turn_from_extraction(
+        texts: Sequence[str],
+        tool_calls: Sequence[Mapping[str, object]] | None = None,
+    ) -> list["AllMessageValues"]:
+        """
+        One OpenAI-shape assistant turn built from the texts and tool calls a
+        handler's response extraction collected; empty when there is nothing.
+        """
+        tool_call_items: Final = tuple(tool_calls or ())
+        if not texts and not tool_call_items:
+            return []
+        turn: Final = {
+            "role": "assistant",
+            "content": "\n".join(texts),
+            **({"tool_calls": list(tool_call_items)} if tool_call_items else {}),
+        }
+        return [cast("AllMessageValues", turn)]
 
     def extract_request_tool_names(self, data: dict) -> list[str]:
         """

--- a/litellm/llms/base_llm/guardrail_translation/base_translation.py
+++ b/litellm/llms/base_llm/guardrail_translation/base_translation.py
@@ -12,6 +12,7 @@ from litellm.llms.base_llm.guardrail_translation.utils import (
 from litellm.types.llms.openai import (
     ChatCompletionAssistantMessage,
     ChatCompletionAssistantToolCall,
+    ChatCompletionToolCallFunctionChunk,
 )
 
 if TYPE_CHECKING:
@@ -21,7 +22,12 @@ if TYPE_CHECKING:
     )
     from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObj
     from litellm.proxy._types import UserAPIKeyAuth
-    from litellm.types.llms.openai import AllMessageValues, ChatCompletionToolParam
+    from litellm.types.llms.openai import (
+        AllMessageValues,
+        ChatCompletionToolCallChunk,
+        ChatCompletionToolParam,
+    )
+    from litellm.types.utils import GenericGuardrailAPIInputs
 
 
 @dataclass(slots=True)
@@ -203,15 +209,38 @@ class BaseTranslation(ABC):
         with the model's response turns appended.
 
         Returns None when the request context is unavailable (SDK/direct-call
-        path fabricates request_data without messages); guardrails then fall
-        back to scanning the extracted texts.
+        path fabricates request_data without messages) or when nothing was
+        extracted from the response; guardrails then fall back to scanning the
+        extracted texts and tool calls, which must not be shadowed by a
+        conversation that lacks a response turn.
         """
-        if request_data is None:
+        if request_data is None or not response_turns:
             return None
         request_conversation: Final = self.scoped_request_conversation(request_data, guardrail_to_apply)
         if request_conversation is None:
             return None
         return (*request_conversation, *response_turns)
+
+    def attach_response_scan_context(
+        self,
+        inputs: "GenericGuardrailAPIInputs",
+        request_data: dict | None,  # mutable-ok: API request payload
+        guardrail_to_apply: "CustomGuardrail",
+        response_turns: Sequence["AllMessageValues"],
+    ) -> None:
+        """
+        Put the response-scan conversation and the request's tools on ``inputs``
+        when the request context allows building them; no-op otherwise.
+        """
+        structured_conversation: Final = self.response_scan_conversation(
+            request_data, guardrail_to_apply, response_turns
+        )
+        if structured_conversation is None or request_data is None:
+            return
+        inputs["structured_messages"] = list(structured_conversation)  # rebind-ok: out-param; field type is list
+        response_scan_tools: Final = self.request_tools_for_guardrail(request_data, guardrail_to_apply)
+        if response_scan_tools:
+            inputs["tools"] = list(response_scan_tools)  # rebind-ok: out-parameter; the field type is a list
 
     def request_tools_for_guardrail(
         self,
@@ -226,15 +255,37 @@ class BaseTranslation(ABC):
         return None
 
     @staticmethod
+    def assistant_tool_call(
+        tool_call_id: str | None,
+        name: str | None,
+        arguments: str,
+    ) -> ChatCompletionAssistantToolCall:
+        """One assistant-message tool call in the OpenAI wire shape."""
+        return ChatCompletionAssistantToolCall(
+            id=tool_call_id,
+            type="function",
+            function=ChatCompletionToolCallFunctionChunk(name=name, arguments=arguments),
+        )
+
+    @staticmethod
     def assistant_turn_from_extraction(
         texts: Sequence[str],
-        tool_calls: Sequence["ChatCompletionAssistantToolCall"] | None = None,
+        tool_calls: Sequence["ChatCompletionAssistantToolCall | ChatCompletionToolCallChunk"] | None = None,
     ) -> tuple["ChatCompletionAssistantMessage", ...]:
         """
         One OpenAI-shape assistant turn built from the texts and tool calls a
         handler's response extraction collected; empty when there is nothing.
+        Tool calls are normalized to the assistant-message shape, dropping
+        extraction-only fields such as ``index``.
         """
-        tool_call_items: Final = tuple(tool_calls or ())
+        tool_call_items: Final = tuple(
+            BaseTranslation.assistant_tool_call(
+                tool_call_id=item.get("id"),
+                name=item["function"].get("name"),
+                arguments=item["function"].get("arguments") or "",
+            )
+            for item in tool_calls or ()
+        )
         if not texts and not tool_call_items:
             return ()
         if tool_call_items:

--- a/litellm/llms/base_llm/guardrail_translation/base_translation.py
+++ b/litellm/llms/base_llm/guardrail_translation/base_translation.py
@@ -1,13 +1,17 @@
 from abc import ABC, abstractmethod
-from collections.abc import Mapping, Sequence
+from collections.abc import Sequence
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any, Final, Optional, cast
+from typing import TYPE_CHECKING, Any, Final, Optional
 
 from litellm.llms.base_llm.guardrail_translation.utils import (
     effective_scan_only_tool_results_for_guardrail,
     effective_skip_system_message_for_guardrail,
     effective_skip_tool_message_for_guardrail,
     scoped_structured_message_indices,
+)
+from litellm.types.llms.openai import (
+    ChatCompletionAssistantMessage,
+    ChatCompletionAssistantToolCall,
 )
 
 if TYPE_CHECKING:
@@ -167,9 +171,9 @@ class BaseTranslation(ABC):
 
     def scoped_request_conversation(
         self,
-        request_data: dict,
+        request_data: dict,  # mutable-ok: API request payload
         guardrail_to_apply: "CustomGuardrail",
-    ) -> list["AllMessageValues"] | None:
+    ) -> tuple["AllMessageValues", ...] | None:
         """
         The request conversation as the guardrail's request scan saw it: the
         handler's structured messages with the operator scoping flags applied.
@@ -186,15 +190,14 @@ class BaseTranslation(ABC):
             skip_system=effective_skip_system_message_for_guardrail(guardrail_to_apply),
             skip_tool=effective_skip_tool_message_for_guardrail(guardrail_to_apply),
         )
-        scoped: Final = [structured_messages[index] for index in scoped_indices]
-        return scoped or None
+        return tuple(structured_messages[index] for index in scoped_indices) or None
 
     def response_scan_conversation(
         self,
-        request_data: dict | None,
+        request_data: dict | None,  # mutable-ok: API request payload
         guardrail_to_apply: "CustomGuardrail",
         response_turns: Sequence["AllMessageValues"],
-    ) -> list["AllMessageValues"] | None:
+    ) -> tuple["AllMessageValues", ...] | None:
         """
         Full conversation for a response scan: the scoped request conversation
         with the model's response turns appended.
@@ -208,13 +211,13 @@ class BaseTranslation(ABC):
         request_conversation: Final = self.scoped_request_conversation(request_data, guardrail_to_apply)
         if request_conversation is None:
             return None
-        return [*request_conversation, *response_turns]
+        return (*request_conversation, *response_turns)
 
     def request_tools_for_guardrail(
         self,
-        request_data: dict,
+        request_data: dict,  # mutable-ok: API request payload
         guardrail_to_apply: "CustomGuardrail",
-    ) -> list["ChatCompletionToolParam"] | None:
+    ) -> tuple["ChatCompletionToolParam", ...] | None:
         """
         The request's tool definitions in the shape the request scan sends them.
 
@@ -225,21 +228,24 @@ class BaseTranslation(ABC):
     @staticmethod
     def assistant_turn_from_extraction(
         texts: Sequence[str],
-        tool_calls: Sequence[Mapping[str, object]] | None = None,
-    ) -> list["AllMessageValues"]:
+        tool_calls: Sequence["ChatCompletionAssistantToolCall"] | None = None,
+    ) -> tuple["ChatCompletionAssistantMessage", ...]:
         """
         One OpenAI-shape assistant turn built from the texts and tool calls a
         handler's response extraction collected; empty when there is nothing.
         """
         tool_call_items: Final = tuple(tool_calls or ())
         if not texts and not tool_call_items:
-            return []
-        turn: Final = {
-            "role": "assistant",
-            "content": "\n".join(texts),
-            **({"tool_calls": list(tool_call_items)} if tool_call_items else {}),
-        }
-        return [cast("AllMessageValues", turn)]
+            return ()
+        if tool_call_items:
+            turn_with_tools: Final[ChatCompletionAssistantMessage] = {
+                "role": "assistant",
+                "content": "\n".join(texts),
+                "tool_calls": list(tool_call_items),  # mutable-ok: the message field type is a list
+            }
+            return (turn_with_tools,)
+        turn: Final[ChatCompletionAssistantMessage] = {"role": "assistant", "content": "\n".join(texts)}
+        return (turn,)
 
     def extract_request_tool_names(self, data: dict) -> list[str]:
         """

--- a/litellm/llms/openai/chat/guardrail_translation/handler.py
+++ b/litellm/llms/openai/chat/guardrail_translation/handler.py
@@ -36,15 +36,12 @@ from litellm.main import stream_chunk_builder
 from litellm.types.llms.openai import (
     AllMessageValues,
     ChatCompletionAssistantMessage,
-    ChatCompletionAssistantToolCall,
-    ChatCompletionToolCallFunctionChunk,
     ChatCompletionToolParam,
 )
 from litellm.types.proxy.guardrails.guardrail_hooks.generic_guardrail_api import (
     coerce_stream_holdback_value,
 )
 from litellm.types.utils import (
-    ChatCompletionMessageToolCall,
     Choices,
     GenericGuardrailAPIInputs,
     ModelResponse,
@@ -403,16 +400,9 @@ class OpenAIChatCompletionsHandler(BaseTranslation):
             if hasattr(response, "model") and response.model:
                 inputs["model"] = response.model
 
-            structured_conversation: Final = self.response_scan_conversation(
-                request_data, guardrail_to_apply, self._build_response_turns(response)
+            self.attach_response_scan_context(
+                inputs, request_data, guardrail_to_apply, self._build_response_turns(response)
             )
-            if structured_conversation:
-                inputs["structured_messages"] = list(
-                    structured_conversation
-                )  # mutable-ok: GenericGuardrailAPIInputs takes list
-                response_scan_tools: Final = self.request_tools_for_guardrail(request_data, guardrail_to_apply)
-                if response_scan_tools:
-                    inputs["tools"] = list(response_scan_tools)  # mutable-ok: GenericGuardrailAPIInputs takes list
 
             guardrailed_inputs: Final = await guardrail_to_apply.apply_guardrail(
                 inputs=inputs,
@@ -866,16 +856,13 @@ class OpenAIChatCompletionsHandler(BaseTranslation):
 
     def _choice_assistant_turn(self, choice: Choices) -> ChatCompletionAssistantMessage | None:
         tool_calls: Final = tuple(
-            ChatCompletionAssistantToolCall(
-                id=tool_call.id,
-                type="function",
-                function=ChatCompletionToolCallFunctionChunk(
-                    name=tool_call.function.name,
-                    arguments=tool_call.function.arguments,
-                ),
+            self.assistant_tool_call(
+                tool_call_id=converted.get("id"),
+                name=(converted.get("function") or {}).get("name"),
+                arguments=(converted.get("function") or {}).get("arguments") or "",
             )
             for tool_call in choice.message.tool_calls or ()
-            if isinstance(tool_call, ChatCompletionMessageToolCall)
+            if (converted := self._convert_tool_call_to_dict(tool_call)) is not None and converted.get("function")
         )
         content: Final = choice.message.content
         if content is None and not tool_calls:

--- a/litellm/llms/openai/chat/guardrail_translation/handler.py
+++ b/litellm/llms/openai/chat/guardrail_translation/handler.py
@@ -33,11 +33,18 @@ from litellm.llms.base_llm.guardrail_translation.utils import (
     scoped_structured_message_indices,
 )
 from litellm.main import stream_chunk_builder
-from litellm.types.llms.openai import AllMessageValues, ChatCompletionToolParam
+from litellm.types.llms.openai import (
+    AllMessageValues,
+    ChatCompletionAssistantMessage,
+    ChatCompletionAssistantToolCall,
+    ChatCompletionToolCallFunctionChunk,
+    ChatCompletionToolParam,
+)
 from litellm.types.proxy.guardrails.guardrail_hooks.generic_guardrail_api import (
     coerce_stream_holdback_value,
 )
 from litellm.types.utils import (
+    ChatCompletionMessageToolCall,
     Choices,
     GenericGuardrailAPIInputs,
     ModelResponse,
@@ -400,10 +407,12 @@ class OpenAIChatCompletionsHandler(BaseTranslation):
                 request_data, guardrail_to_apply, self._build_response_turns(response)
             )
             if structured_conversation:
-                inputs["structured_messages"] = structured_conversation
+                inputs["structured_messages"] = list(
+                    structured_conversation
+                )  # mutable-ok: GenericGuardrailAPIInputs takes list
                 response_scan_tools: Final = self.request_tools_for_guardrail(request_data, guardrail_to_apply)
                 if response_scan_tools:
-                    inputs["tools"] = response_scan_tools
+                    inputs["tools"] = list(response_scan_tools)  # mutable-ok: GenericGuardrailAPIInputs takes list
 
             guardrailed_inputs: Final = await guardrail_to_apply.apply_guardrail(
                 inputs=inputs,
@@ -843,39 +852,43 @@ class OpenAIChatCompletionsHandler(BaseTranslation):
 
     def request_tools_for_guardrail(
         self,
-        request_data: dict,
+        request_data: dict,  # mutable-ok: API request payload
         guardrail_to_apply: "CustomGuardrail",
-    ) -> list[ChatCompletionToolParam] | None:
+    ) -> tuple[ChatCompletionToolParam, ...] | None:
         if effective_scan_only_tool_results_for_guardrail(guardrail_to_apply):
             return None
         tools: Final = request_data.get("tools")
-        return cast(list[ChatCompletionToolParam], tools) if tools else None
+        return tuple(tools) if tools else None
 
-    def _build_response_turns(self, response: "ModelResponse") -> list[AllMessageValues]:
+    def _build_response_turns(self, response: "ModelResponse") -> tuple[ChatCompletionAssistantMessage, ...]:
         """Assistant turns for the response-scan conversation, one per choice."""
-        return [
-            turn
-            for choice in response.choices
-            if isinstance(choice, litellm.Choices) and (turn := self._choice_assistant_turn(choice)) is not None
-        ]
+        return tuple(turn for choice in response.choices if (turn := self._choice_assistant_turn(choice)) is not None)
 
-    def _choice_assistant_turn(self, choice: Choices) -> AllMessageValues | None:
-        tool_call_dicts: Final = tuple(
-            converted
-            for tool_call in (choice.message.tool_calls or [])
-            if (converted := self._convert_tool_call_to_dict(tool_call)) is not None
+    def _choice_assistant_turn(self, choice: Choices) -> ChatCompletionAssistantMessage | None:
+        tool_calls: Final = tuple(
+            ChatCompletionAssistantToolCall(
+                id=tool_call.id,
+                type="function",
+                function=ChatCompletionToolCallFunctionChunk(
+                    name=tool_call.function.name,
+                    arguments=tool_call.function.arguments,
+                ),
+            )
+            for tool_call in choice.message.tool_calls or ()
+            if isinstance(tool_call, ChatCompletionMessageToolCall)
         )
         content: Final = choice.message.content
-        if content is None and not tool_call_dicts:
+        if content is None and not tool_calls:
             return None
-        return cast(
-            AllMessageValues,
-            {
+        if tool_calls:
+            turn_with_tools: Final[ChatCompletionAssistantMessage] = {
                 "role": "assistant",
                 "content": content,
-                **({"tool_calls": list(tool_call_dicts)} if tool_call_dicts else {}),
-            },
-        )
+                "tool_calls": list(tool_calls),  # mutable-ok: the message field type is a list
+            }
+            return turn_with_tools
+        turn: Final[ChatCompletionAssistantMessage] = {"role": "assistant", "content": content}
+        return turn
 
     def _convert_tool_call_to_dict(self, tool_call: dict[str, Any] | Any) -> dict[str, Any] | None:
         """

--- a/litellm/llms/openai/chat/guardrail_translation/handler.py
+++ b/litellm/llms/openai/chat/guardrail_translation/handler.py
@@ -396,6 +396,15 @@ class OpenAIChatCompletionsHandler(BaseTranslation):
             if hasattr(response, "model") and response.model:
                 inputs["model"] = response.model
 
+            structured_conversation: Final = self.response_scan_conversation(
+                request_data, guardrail_to_apply, self._build_response_turns(response)
+            )
+            if structured_conversation:
+                inputs["structured_messages"] = structured_conversation
+                response_scan_tools: Final = self.request_tools_for_guardrail(request_data, guardrail_to_apply)
+                if response_scan_tools:
+                    inputs["tools"] = response_scan_tools
+
             guardrailed_inputs: Final = await guardrail_to_apply.apply_guardrail(
                 inputs=inputs,
                 request_data=request_data,
@@ -831,6 +840,42 @@ class OpenAIChatCompletionsHandler(BaseTranslation):
                 if tool_call_dict:
                     tool_calls_to_check.append(tool_call_dict)
                     tool_call_task_mappings.append((choice_idx, int(tool_call_idx)))
+
+    def request_tools_for_guardrail(
+        self,
+        request_data: dict,
+        guardrail_to_apply: "CustomGuardrail",
+    ) -> list[ChatCompletionToolParam] | None:
+        if effective_scan_only_tool_results_for_guardrail(guardrail_to_apply):
+            return None
+        tools: Final = request_data.get("tools")
+        return cast(list[ChatCompletionToolParam], tools) if tools else None
+
+    def _build_response_turns(self, response: "ModelResponse") -> list[AllMessageValues]:
+        """Assistant turns for the response-scan conversation, one per choice."""
+        return [
+            turn
+            for choice in response.choices
+            if isinstance(choice, litellm.Choices) and (turn := self._choice_assistant_turn(choice)) is not None
+        ]
+
+    def _choice_assistant_turn(self, choice: Choices) -> AllMessageValues | None:
+        tool_call_dicts: Final = tuple(
+            converted
+            for tool_call in (choice.message.tool_calls or [])
+            if (converted := self._convert_tool_call_to_dict(tool_call)) is not None
+        )
+        content: Final = choice.message.content
+        if content is None and not tool_call_dicts:
+            return None
+        return cast(
+            AllMessageValues,
+            {
+                "role": "assistant",
+                "content": content,
+                **({"tool_calls": list(tool_call_dicts)} if tool_call_dicts else {}),
+            },
+        )
 
     def _convert_tool_call_to_dict(self, tool_call: dict[str, Any] | Any) -> dict[str, Any] | None:
         """

--- a/litellm/llms/openai/responses/guardrail_translation/handler.py
+++ b/litellm/llms/openai/responses/guardrail_translation/handler.py
@@ -248,6 +248,20 @@ class OpenAIResponsesHandler(BaseTranslation):
             ) = LiteLLMCompletionResponsesConfig.transform_responses_api_tools_to_chat_completion_tools(tools)
             tools_to_check.extend(cast(list[ChatCompletionToolParam], transformed_tools))
 
+    def scoped_request_conversation(
+        self,
+        request_data: dict,  # mutable-ok: API request payload
+        guardrail_to_apply: "CustomGuardrail",
+    ) -> tuple[AllMessageValues, ...] | None:
+        """
+        This surface's request scan sends its structured messages without the
+        operator scoping flags (the input path applies none), so the response
+        scan mirrors that; request and response scans must not disagree about
+        the conversation.
+        """
+        structured_messages: Final = self.get_structured_messages(request_data)
+        return tuple(structured_messages) if structured_messages else None
+
     def request_tools_for_guardrail(
         self,
         request_data: dict,  # mutable-ok: API request payload
@@ -467,18 +481,12 @@ class OpenAIResponsesHandler(BaseTranslation):
             if response_model:
                 inputs["model"] = response_model
 
-            structured_conversation: Final = self.response_scan_conversation(
+            self.attach_response_scan_context(
+                inputs,
                 request_data,
                 guardrail_to_apply,
                 self.assistant_turn_from_extraction(texts_to_check, tool_calls_to_check),
             )
-            if structured_conversation:
-                inputs["structured_messages"] = list(
-                    structured_conversation
-                )  # mutable-ok: GenericGuardrailAPIInputs takes list
-                response_scan_tools: Final = self.request_tools_for_guardrail(request_data, guardrail_to_apply)
-                if response_scan_tools:
-                    inputs["tools"] = list(response_scan_tools)  # mutable-ok: GenericGuardrailAPIInputs takes list
 
             guardrailed_inputs: Final = await guardrail_to_apply.apply_guardrail(
                 inputs=inputs,
@@ -570,18 +578,12 @@ class OpenAIResponsesHandler(BaseTranslation):
                 if response_model:
                     inputs["model"] = response_model
 
-                structured_conversation: Final = self.response_scan_conversation(
+                self.attach_response_scan_context(
+                    inputs,
                     request_data,
                     guardrail_to_apply,
                     self.assistant_turn_from_extraction(texts_to_check, tool_calls_to_check),
                 )
-                if structured_conversation:
-                    inputs["structured_messages"] = list(
-                        structured_conversation
-                    )  # mutable-ok: GenericGuardrailAPIInputs takes list
-                    response_scan_tools: Final = self.request_tools_for_guardrail(request_data, guardrail_to_apply)
-                    if response_scan_tools:
-                        inputs["tools"] = list(response_scan_tools)  # mutable-ok: GenericGuardrailAPIInputs takes list
 
                 guardrailed_inputs: Final = await guardrail_to_apply.apply_guardrail(
                     inputs=inputs,

--- a/litellm/llms/openai/responses/guardrail_translation/handler.py
+++ b/litellm/llms/openai/responses/guardrail_translation/handler.py
@@ -250,15 +250,15 @@ class OpenAIResponsesHandler(BaseTranslation):
 
     def request_tools_for_guardrail(
         self,
-        request_data: dict,
+        request_data: dict,  # mutable-ok: API request payload
         guardrail_to_apply: "CustomGuardrail",
-    ) -> list[ChatCompletionToolParam] | None:
+    ) -> tuple[ChatCompletionToolParam, ...] | None:
         raw_tools: Final = request_data.get("tools")
         if not raw_tools:
             return None
-        tools_to_check: Final[list[ChatCompletionToolParam]] = []
+        tools_to_check: Final[list[ChatCompletionToolParam]] = []  # mutable-ok: _extract_and_transform_tools appends
         self._extract_and_transform_tools(raw_tools, tools_to_check)
-        return tools_to_check or None
+        return tuple(tools_to_check) or None
 
     def _remap_tools_to_responses_api_format(self, guardrailed_tools: list[Any]) -> list[dict[str, object]]:
         """
@@ -473,10 +473,12 @@ class OpenAIResponsesHandler(BaseTranslation):
                 self.assistant_turn_from_extraction(texts_to_check, tool_calls_to_check),
             )
             if structured_conversation:
-                inputs["structured_messages"] = structured_conversation
+                inputs["structured_messages"] = list(
+                    structured_conversation
+                )  # mutable-ok: GenericGuardrailAPIInputs takes list
                 response_scan_tools: Final = self.request_tools_for_guardrail(request_data, guardrail_to_apply)
                 if response_scan_tools:
-                    inputs["tools"] = response_scan_tools
+                    inputs["tools"] = list(response_scan_tools)  # mutable-ok: GenericGuardrailAPIInputs takes list
 
             guardrailed_inputs: Final = await guardrail_to_apply.apply_guardrail(
                 inputs=inputs,
@@ -574,10 +576,12 @@ class OpenAIResponsesHandler(BaseTranslation):
                     self.assistant_turn_from_extraction(texts_to_check, tool_calls_to_check),
                 )
                 if structured_conversation:
-                    inputs["structured_messages"] = structured_conversation
+                    inputs["structured_messages"] = list(
+                        structured_conversation
+                    )  # mutable-ok: GenericGuardrailAPIInputs takes list
                     response_scan_tools: Final = self.request_tools_for_guardrail(request_data, guardrail_to_apply)
                     if response_scan_tools:
-                        inputs["tools"] = response_scan_tools
+                        inputs["tools"] = list(response_scan_tools)  # mutable-ok: GenericGuardrailAPIInputs takes list
 
                 guardrailed_inputs: Final = await guardrail_to_apply.apply_guardrail(
                     inputs=inputs,

--- a/litellm/llms/openai/responses/guardrail_translation/handler.py
+++ b/litellm/llms/openai/responses/guardrail_translation/handler.py
@@ -248,6 +248,18 @@ class OpenAIResponsesHandler(BaseTranslation):
             ) = LiteLLMCompletionResponsesConfig.transform_responses_api_tools_to_chat_completion_tools(tools)
             tools_to_check.extend(cast(list[ChatCompletionToolParam], transformed_tools))
 
+    def request_tools_for_guardrail(
+        self,
+        request_data: dict,
+        guardrail_to_apply: "CustomGuardrail",
+    ) -> list[ChatCompletionToolParam] | None:
+        raw_tools: Final = request_data.get("tools")
+        if not raw_tools:
+            return None
+        tools_to_check: Final[list[ChatCompletionToolParam]] = []
+        self._extract_and_transform_tools(raw_tools, tools_to_check)
+        return tools_to_check or None
+
     def _remap_tools_to_responses_api_format(self, guardrailed_tools: list[Any]) -> list[dict[str, object]]:
         """
         Remap guardrail-returned tools (Chat Completion format) back to
@@ -455,6 +467,17 @@ class OpenAIResponsesHandler(BaseTranslation):
             if response_model:
                 inputs["model"] = response_model
 
+            structured_conversation: Final = self.response_scan_conversation(
+                request_data,
+                guardrail_to_apply,
+                self.assistant_turn_from_extraction(texts_to_check, tool_calls_to_check),
+            )
+            if structured_conversation:
+                inputs["structured_messages"] = structured_conversation
+                response_scan_tools: Final = self.request_tools_for_guardrail(request_data, guardrail_to_apply)
+                if response_scan_tools:
+                    inputs["tools"] = response_scan_tools
+
             guardrailed_inputs: Final = await guardrail_to_apply.apply_guardrail(
                 inputs=inputs,
                 request_data=request_data,
@@ -544,6 +567,17 @@ class OpenAIResponsesHandler(BaseTranslation):
                 response_model = response_obj.get("model")
                 if response_model:
                     inputs["model"] = response_model
+
+                structured_conversation: Final = self.response_scan_conversation(
+                    request_data,
+                    guardrail_to_apply,
+                    self.assistant_turn_from_extraction(texts_to_check, tool_calls_to_check),
+                )
+                if structured_conversation:
+                    inputs["structured_messages"] = structured_conversation
+                    response_scan_tools: Final = self.request_tools_for_guardrail(request_data, guardrail_to_apply)
+                    if response_scan_tools:
+                        inputs["tools"] = response_scan_tools
 
                 guardrailed_inputs: Final = await guardrail_to_apply.apply_guardrail(
                     inputs=inputs,

--- a/litellm/proxy/guardrails/guardrail_hooks/akto/akto.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/akto/akto.py
@@ -162,12 +162,19 @@ class AktoGuardrail(CustomGuardrail):
     def build_request_body(
         inputs: GenericGuardrailAPIInputs,
         request_data: dict | None = None,
+        *,
+        prefer_structured_messages: bool = True,
     ) -> dict[str, Any]:
-        """Build the LLM request body from guardrail inputs (messages, model, tools)."""
+        """Build the LLM request body from guardrail inputs (messages, model, tools).
+
+        ``prefer_structured_messages`` is False on response scans, where
+        ``structured_messages`` carries the response turns too and would
+        misrepresent the request in the ingested payload.
+        """
         model: Final = inputs.get("model", "") or ""
         body: Final[dict[str, Any]] = {"model": model}
 
-        structured: Final = inputs.get("structured_messages")
+        structured: Final = inputs.get("structured_messages") if prefer_structured_messages else None
         if structured:
             body["messages"] = structured
         elif request_data is not None and request_data.get("messages"):
@@ -232,7 +239,9 @@ class AktoGuardrail(CustomGuardrail):
         """
         request_path: Final = self.extract_request_path(request_data)
         request_headers: Final = self.build_request_headers(request_data)
-        request_body: Final = self.build_request_body(inputs, request_data)
+        request_body: Final = self.build_request_body(
+            inputs, request_data, prefer_structured_messages=not include_response
+        )
         tag: Final = self.build_tag_metadata(request_data)
 
         response_payload = json.dumps({})  # Empty body wrapper when no response yet

--- a/litellm/proxy/guardrails/guardrail_hooks/grayswan/grayswan.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/grayswan/grayswan.py
@@ -2,9 +2,11 @@
 
 import os
 import time
+from collections.abc import Mapping, Sequence
 from typing import TYPE_CHECKING, Any, Final, Literal, Optional
 
 from fastapi import HTTPException
+from typing_extensions import NotRequired, ReadOnly, TypedDict
 
 from litellm._logging import verbose_proxy_logger
 from litellm.integrations.custom_guardrail import (
@@ -26,6 +28,14 @@ if TYPE_CHECKING:
 
 GRAYSWAN_BLOCK_ERROR_MSG: Final = "Blocked by Gray Swan Guardrail"
 GRAYSWAN_CONVERSATION_CACHE_KEY: Final = "_grayswan_request_conversation"
+
+
+class MonitorTurn(TypedDict):
+    """One conversation turn in the monitor payload."""
+
+    role: ReadOnly[str]
+    content: ReadOnly[str]
+    tool_calls: NotRequired[ReadOnly[tuple[Mapping[str, Any], ...]]]
 
 
 class GraySwanGuardrailMissingSecrets(Exception):
@@ -209,7 +219,7 @@ class GraySwanGuardrail(CustomGuardrail):
                 input_type,
             )
 
-            dynamic_body: Final = self.get_guardrail_dynamic_request_body_params(request_data) or {}
+            dynamic_body: Final = self.get_guardrail_dynamic_request_body_params(request_data)
             if dynamic_body:
                 verbose_proxy_logger.debug("Gray Swan Guardrail: dynamic extra_body=%s", safe_dumps(dynamic_body))
 
@@ -527,9 +537,9 @@ class GraySwanGuardrail(CustomGuardrail):
     def _build_monitor_input(
         self,
         inputs: GenericGuardrailAPIInputs,
-        request_data: dict,
+        request_data: dict,  # mutable-ok: the shared per-request state dict every hook receives; the request scan caches on it
         input_type: Literal["request", "response"],
-    ) -> tuple[list[dict[str, Any]], list[dict[str, Any]] | None]:
+    ) -> tuple[tuple[Mapping[str, Any], ...], tuple[Mapping[str, Any], ...] | None]:
         """Build the monitor conversation from the translation layer's scoped view.
 
         Request scans send `structured_messages` and `tools` exactly as the unified
@@ -547,58 +557,57 @@ class GraySwanGuardrail(CustomGuardrail):
             return conversation, tools
         response_turns: Final = self._build_response_turns(inputs)
         if not response_turns:
-            return [], None
+            return (), None
         cached: Final = self._cached_request_conversation(request_data)
         if cached is None:
             return self._texts_fallback(inputs, "assistant"), None
-        return [*cached[0], *response_turns], cached[1]
+        return (*cached[0], *response_turns), cached[1]
 
     def _cache_request_conversation(
         self,
-        request_data: dict,
-        conversation: list[dict[str, Any]],
-        tools: list[dict[str, Any]] | None,
+        request_data: dict,  # mutable-ok: the shared per-request state dict every hook receives; caching on it is the point
+        conversation: tuple[Mapping[str, Any], ...],
+        tools: tuple[Mapping[str, Any], ...] | None,
     ) -> None:
         metadata: Final = request_data.setdefault(
-            "metadata", {}
+            "metadata",
+            {},  # mutable-ok: request metadata is shared mutable state other hooks also write to
         )  # rebind-ok: response scans replay the request-time scoped conversation and request_data is the only object shared across hooks
         if isinstance(metadata, dict):
             metadata[GRAYSWAN_CONVERSATION_CACHE_KEY] = (conversation, tools)
 
     def _cached_request_conversation(
-        self, request_data: dict
-    ) -> tuple[list[dict[str, Any]], list[dict[str, Any]] | None] | None:
+        self, request_data: Mapping[str, Any]
+    ) -> tuple[tuple[Mapping[str, Any], ...], tuple[Mapping[str, Any], ...] | None] | None:
         metadata: Final = request_data.get("metadata")
         cached: Final = metadata.get(GRAYSWAN_CONVERSATION_CACHE_KEY) if isinstance(metadata, dict) else None
         if isinstance(cached, tuple) and len(cached) == 2:
             return cached
         return None
 
-    def _build_response_turns(self, inputs: GenericGuardrailAPIInputs) -> list[dict[str, Any]]:
-        texts: Final = [
-            text if isinstance(text, str) else str(text) for text in inputs.get("texts", []) if text is not None
-        ]
+    def _build_response_turns(self, inputs: GenericGuardrailAPIInputs) -> tuple[Mapping[str, Any], ...]:
         tool_calls: Final = self._sanitize_json_list(inputs.get("tool_calls"))
-        text_turns: Final = [{"role": "assistant", "content": text} for text in texts if text]
+        text_turns: Final = tuple(self._turn("assistant", text) for text in inputs.get("texts", ()) if text)
         if not tool_calls:
             return text_turns
-        base: Final = text_turns or [{"role": "assistant", "content": ""}]
-        return [*base[:-1], {**base[-1], "tool_calls": tool_calls}]
+        base: Final = text_turns or (self._turn("assistant", ""),)
+        final_turn: Final[MonitorTurn] = {**base[-1], "tool_calls": tool_calls}
+        return (*base[:-1], final_turn)
 
-    def _texts_fallback(self, inputs: GenericGuardrailAPIInputs, role: str) -> list[dict[str, Any]]:
-        return [
-            {"role": role, "content": text if isinstance(text, str) else str(text)}
-            for text in inputs.get("texts", [])
-            if text is not None
-        ]
+    def _texts_fallback(self, inputs: GenericGuardrailAPIInputs, role: str) -> tuple[MonitorTurn, ...]:
+        return tuple(self._turn(role, text) for text in inputs.get("texts", ()))
 
-    def _sanitize_json_list(self, value: object) -> list[dict[str, Any]] | None:
+    def _turn(self, role: str, content: str) -> MonitorTurn:
+        turn: Final[MonitorTurn] = {"role": role, "content": content}
+        return turn
+
+    def _sanitize_json_list(self, value: object) -> tuple[Mapping[str, Any], ...] | None:
         if not isinstance(value, list) or not value:
             return None
         sanitized: Final = safe_json_loads(safe_dumps(value), default=None)
         if not isinstance(sanitized, list):
             return None
-        items: Final = [item for item in sanitized if isinstance(item, dict)]
+        items: Final = tuple(item for item in sanitized if isinstance(item, dict))
         if len(items) != len(sanitized):
             verbose_proxy_logger.debug(
                 "Gray Swan Guardrail: dropped %d non-dict conversation item(s)",
@@ -608,11 +617,11 @@ class GraySwanGuardrail(CustomGuardrail):
 
     def _prepare_payload(
         self,
-        messages: list[dict[str, Any]],
+        messages: Sequence[Mapping[str, Any]],
         dynamic_body: dict,
         request_data: dict,
         logging_obj: Optional["LiteLLMLoggingObj"] = None,
-        tools: list[dict[str, Any]] | None = None,
+        tools: Sequence[Mapping[str, Any]] | None = None,
     ) -> dict[str, Any] | None:
         payload: Final[dict[str, Any]] = {"messages": messages}
         if tools:

--- a/litellm/proxy/guardrails/guardrail_hooks/grayswan/grayswan.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/grayswan/grayswan.py
@@ -187,7 +187,10 @@ class GraySwanGuardrail(CustomGuardrail):
                 input_type,
             )
 
-            dynamic_body: Final = self.get_guardrail_dynamic_request_body_params(request_data)
+            dynamic_body: Final = (
+                self.get_guardrail_dynamic_request_body_params(request_data)
+                or {}  # mutable-ok: empty fallback when the client sent a null extra_body
+            )
             if dynamic_body:
                 verbose_proxy_logger.debug("Gray Swan Guardrail: dynamic extra_body=%s", safe_dumps(dynamic_body))
 
@@ -521,7 +524,7 @@ class GraySwanGuardrail(CustomGuardrail):
         if conversation:
             return conversation, self._sanitize_json_list(inputs.get("tools"))
         if input_type == "request":
-            return self._texts_fallback(inputs, "user"), None
+            return self._texts_fallback(inputs), None
         return self._build_response_turns(inputs), None
 
     def _build_response_turns(self, inputs: GenericGuardrailAPIInputs) -> tuple[Mapping[str, Any], ...]:
@@ -533,8 +536,8 @@ class GraySwanGuardrail(CustomGuardrail):
         final_turn: Final[MonitorTurn] = {**base[-1], "tool_calls": tool_calls}
         return (*base[:-1], final_turn)
 
-    def _texts_fallback(self, inputs: GenericGuardrailAPIInputs, role: str) -> tuple[MonitorTurn, ...]:
-        return tuple(self._turn(role, text) for text in inputs.get("texts", ()))
+    def _texts_fallback(self, inputs: GenericGuardrailAPIInputs) -> tuple[MonitorTurn, ...]:
+        return tuple(self._turn("user", text) for text in inputs.get("texts", ()))
 
     def _turn(self, role: str, content: str) -> MonitorTurn:
         turn: Final[MonitorTurn] = {"role": role, "content": content}

--- a/litellm/proxy/guardrails/guardrail_hooks/grayswan/grayswan.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/grayswan/grayswan.py
@@ -124,12 +124,6 @@ class GraySwanGuardrail(CustomGuardrail):
         self.streaming_end_of_stream_only = streaming_end_of_stream_only
         self.streaming_sampling_rate = streaming_sampling_rate
 
-        verbose_proxy_logger.debug(
-            "GraySwan __init__: streaming_end_of_stream_only=%s, streaming_sampling_rate=%s",
-            streaming_end_of_stream_only,
-            streaming_sampling_rate,
-        )
-
         super().__init__(
             guardrail_name=guardrail_name,
             supported_event_hooks=list(self.get_supported_event_hooks()),
@@ -143,25 +137,6 @@ class GraySwanGuardrail(CustomGuardrail):
             GuardrailEventHooks.during_call,
             GuardrailEventHooks.post_call,
         ]
-
-    # ------------------------------------------------------------------
-    # Debug override to trace post_call issues
-    # ------------------------------------------------------------------
-
-    def should_run_guardrail(self, data, event_type) -> bool:
-        """Override to add debug logging."""
-        result: Final = super().should_run_guardrail(data, event_type)
-        # Check if apply_guardrail is in __dict__
-        has_apply_guardrail: Final = "apply_guardrail" in type(self).__dict__
-        verbose_proxy_logger.debug(
-            "GraySwan DEBUG: should_run_guardrail event_type=%s, result=%s, event_hook=%s, has_apply_guardrail=%s, class=%s",
-            event_type,
-            result,
-            self.event_hook,
-            has_apply_guardrail,
-            type(self).__name__,
-        )
-        return result
 
     # ------------------------------------------------------------------
     # Unified Guardrail Interface (works with ALL endpoints automatically)
@@ -199,13 +174,6 @@ class GraySwanGuardrail(CustomGuardrail):
             HTTPException: If content is blocked (block mode)
             Exception: If guardrail check fails
         """
-        # DEBUG: Log when apply_guardrail is called
-        verbose_proxy_logger.debug(
-            "GraySwan DEBUG: apply_guardrail called with input_type=%s, texts=%s",
-            input_type,
-            inputs.get("texts", [])[:100] if inputs.get("texts") else "NONE",
-        )
-
         start_time: Final = time.time()
         try:
             messages, tools = self._build_monitor_input(inputs, request_data, input_type)

--- a/litellm/proxy/guardrails/guardrail_hooks/grayswan/grayswan.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/grayswan/grayswan.py
@@ -25,6 +25,7 @@ if TYPE_CHECKING:
     from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObj
 
 GRAYSWAN_BLOCK_ERROR_MSG: Final = "Blocked by Gray Swan Guardrail"
+GRAYSWAN_CONVERSATION_CACHE_KEY: Final = "_grayswan_request_conversation"
 
 
 class GraySwanGuardrailMissingSecrets(Exception):
@@ -165,16 +166,18 @@ class GraySwanGuardrail(CustomGuardrail):
         logging_obj: Optional["LiteLLMLoggingObj"] = None,
     ) -> GenericGuardrailAPIInputs:
         """
-        Apply Gray Swan guardrail to extracted text content.
+        Apply Gray Swan guardrail to the conversation the translation layer produced.
 
-        This method is called by the unified guardrail system which handles
-        extracting text from any request format (OpenAI, Anthropic, etc.).
+        This method is called by the unified guardrail system, which normalizes any
+        request format (OpenAI, Anthropic, etc.) and applies operator scoping flags.
 
         Args:
             inputs: Dictionary containing:
-                - texts: List of texts to scan
+                - texts: List of extracted texts (fallback scan content)
+                - structured_messages: Normalized, scoped conversation (request scans)
+                - tools: Scoped tool definitions (request scans)
+                - tool_calls: Tool calls emitted by the model (response scans)
                 - images: Optional list of images (not currently used by GraySwan)
-                - tool_calls: Optional list of tool calls (not currently used)
             request_data: The original request data
             input_type: "request" for pre-call, "response" for post-call
             logging_obj: Optional logging object
@@ -193,34 +196,27 @@ class GraySwanGuardrail(CustomGuardrail):
             inputs.get("texts", [])[:100] if inputs.get("texts") else "NONE",
         )
 
-        texts: Final = inputs.get("texts", [])
-        if not texts:
-            verbose_proxy_logger.debug("Gray Swan Guardrail: No texts to scan")
-            return inputs
-
-        verbose_proxy_logger.debug(
-            "Gray Swan Guardrail: Scanning %d text(s) for %s",
-            len(texts),
-            input_type,
-        )
-
-        # Convert texts to messages format for GraySwan API
-        # Use "user" role for request content, "assistant" for response content
-        role: Final = "assistant" if input_type == "response" else "user"
-        messages: Final = [{"role": role, "content": text} for text in texts]
-
-        # Get dynamic params from request metadata
-        dynamic_body: Final = self.get_guardrail_dynamic_request_body_params(request_data) or {}
-        if dynamic_body:
-            verbose_proxy_logger.debug("Gray Swan Guardrail: dynamic extra_body=%s", safe_dumps(dynamic_body))
-
-        # Prepare and send payload
-        payload: Final = self._prepare_payload(messages, dynamic_body, request_data, logging_obj)
-        if payload is None:
-            return inputs
-
         start_time: Final = time.time()
         try:
+            messages, tools = self._build_monitor_input(inputs, request_data, input_type)
+            if not messages:
+                verbose_proxy_logger.debug("Gray Swan Guardrail: No content to scan")
+                return inputs
+
+            verbose_proxy_logger.debug(
+                "Gray Swan Guardrail: Scanning %d message(s) for %s",
+                len(messages),
+                input_type,
+            )
+
+            dynamic_body: Final = self.get_guardrail_dynamic_request_body_params(request_data) or {}
+            if dynamic_body:
+                verbose_proxy_logger.debug("Gray Swan Guardrail: dynamic extra_body=%s", safe_dumps(dynamic_body))
+
+            payload: Final = self._prepare_payload(messages, dynamic_body, request_data, logging_obj, tools=tools)
+            if payload is None:
+                return inputs
+
             response_json: Final = await self._call_grayswan_api(payload)
             is_output: Final = input_type == "response"
             result: Final = self._process_response_internal(
@@ -528,14 +524,99 @@ class GraySwanGuardrail(CustomGuardrail):
                 forwarded_headers[str(key)] = str(value)
         return forwarded_headers or None
 
+    def _build_monitor_input(
+        self,
+        inputs: GenericGuardrailAPIInputs,
+        request_data: dict,
+        input_type: Literal["request", "response"],
+    ) -> tuple[list[dict[str, Any]], list[dict[str, Any]] | None]:
+        """Build the monitor conversation from the translation layer's scoped view.
+
+        Request scans send `structured_messages` and `tools` exactly as the unified
+        guardrail system produced them (normalized per API surface, operator scoping
+        flags applied) and cache them on the request. Response scans replay the
+        cached conversation and append the response turns. Without a structured
+        view, the pre-existing texts-only wrapping is kept.
+        """
+        if input_type == "request":
+            conversation: Final = self._sanitize_json_list(inputs.get("structured_messages"))
+            if not conversation:
+                return self._texts_fallback(inputs, "user"), None
+            tools: Final = self._sanitize_json_list(inputs.get("tools"))
+            self._cache_request_conversation(request_data, conversation, tools)
+            return conversation, tools
+        response_turns: Final = self._build_response_turns(inputs)
+        if not response_turns:
+            return [], None
+        cached: Final = self._cached_request_conversation(request_data)
+        if cached is None:
+            return self._texts_fallback(inputs, "assistant"), None
+        return [*cached[0], *response_turns], cached[1]
+
+    def _cache_request_conversation(
+        self,
+        request_data: dict,
+        conversation: list[dict[str, Any]],
+        tools: list[dict[str, Any]] | None,
+    ) -> None:
+        metadata: Final = request_data.setdefault(
+            "metadata", {}
+        )  # rebind-ok: response scans replay the request-time scoped conversation and request_data is the only object shared across hooks
+        if isinstance(metadata, dict):
+            metadata[GRAYSWAN_CONVERSATION_CACHE_KEY] = (conversation, tools)
+
+    def _cached_request_conversation(
+        self, request_data: dict
+    ) -> tuple[list[dict[str, Any]], list[dict[str, Any]] | None] | None:
+        metadata: Final = request_data.get("metadata")
+        cached: Final = metadata.get(GRAYSWAN_CONVERSATION_CACHE_KEY) if isinstance(metadata, dict) else None
+        if isinstance(cached, tuple) and len(cached) == 2:
+            return cached
+        return None
+
+    def _build_response_turns(self, inputs: GenericGuardrailAPIInputs) -> list[dict[str, Any]]:
+        texts: Final = [
+            text if isinstance(text, str) else str(text) for text in inputs.get("texts", []) if text is not None
+        ]
+        tool_calls: Final = self._sanitize_json_list(inputs.get("tool_calls"))
+        text_turns: Final = [{"role": "assistant", "content": text} for text in texts if text]
+        if not tool_calls:
+            return text_turns
+        base: Final = text_turns or [{"role": "assistant", "content": ""}]
+        return [*base[:-1], {**base[-1], "tool_calls": tool_calls}]
+
+    def _texts_fallback(self, inputs: GenericGuardrailAPIInputs, role: str) -> list[dict[str, Any]]:
+        return [
+            {"role": role, "content": text if isinstance(text, str) else str(text)}
+            for text in inputs.get("texts", [])
+            if text is not None
+        ]
+
+    def _sanitize_json_list(self, value: object) -> list[dict[str, Any]] | None:
+        if not isinstance(value, list) or not value:
+            return None
+        sanitized: Final = safe_json_loads(safe_dumps(value), default=None)
+        if not isinstance(sanitized, list):
+            return None
+        items: Final = [item for item in sanitized if isinstance(item, dict)]
+        if len(items) != len(sanitized):
+            verbose_proxy_logger.debug(
+                "Gray Swan Guardrail: dropped %d non-dict conversation item(s)",
+                len(sanitized) - len(items),
+            )
+        return items or None
+
     def _prepare_payload(
         self,
-        messages: list[dict[str, str]],
+        messages: list[dict[str, Any]],
         dynamic_body: dict,
         request_data: dict,
         logging_obj: Optional["LiteLLMLoggingObj"] = None,
+        tools: list[dict[str, Any]] | None = None,
     ) -> dict[str, Any] | None:
         payload: Final[dict[str, Any]] = {"messages": messages}
+        if tools:
+            payload["tools"] = tools
 
         categories: Final = dynamic_body.get("categories") or self.categories
         if categories:

--- a/litellm/proxy/guardrails/guardrail_hooks/grayswan/grayswan.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/grayswan/grayswan.py
@@ -27,7 +27,6 @@ if TYPE_CHECKING:
     from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObj
 
 GRAYSWAN_BLOCK_ERROR_MSG: Final = "Blocked by Gray Swan Guardrail"
-GRAYSWAN_CONVERSATION_CACHE_KEY: Final = "_grayswan_request_conversation"
 
 
 class MonitorTurn(TypedDict):
@@ -159,8 +158,9 @@ class GraySwanGuardrail(CustomGuardrail):
         Args:
             inputs: Dictionary containing:
                 - texts: List of extracted texts (fallback scan content)
-                - structured_messages: Normalized, scoped conversation (request scans)
-                - tools: Scoped tool definitions (request scans)
+                - structured_messages: Normalized, scoped conversation (response
+                  scans carry the request conversation plus the response turns)
+                - tools: Scoped tool definitions
                 - tool_calls: Tool calls emitted by the model (response scans)
                 - images: Optional list of images (not currently used by GraySwan)
             request_data: The original request data
@@ -176,7 +176,7 @@ class GraySwanGuardrail(CustomGuardrail):
         """
         start_time: Final = time.time()
         try:
-            messages, tools = self._build_monitor_input(inputs, request_data, input_type)
+            messages, tools = self._build_monitor_input(inputs, input_type)
             if not messages:
                 verbose_proxy_logger.debug("Gray Swan Guardrail: No content to scan")
                 return inputs
@@ -505,53 +505,24 @@ class GraySwanGuardrail(CustomGuardrail):
     def _build_monitor_input(
         self,
         inputs: GenericGuardrailAPIInputs,
-        request_data: dict,  # mutable-ok: the shared per-request state dict every hook receives; the request scan caches on it
         input_type: Literal["request", "response"],
     ) -> tuple[tuple[Mapping[str, Any], ...], tuple[Mapping[str, Any], ...] | None]:
         """Build the monitor conversation from the translation layer's scoped view.
 
-        Request scans send `structured_messages` and `tools` exactly as the unified
-        guardrail system produced them (normalized per API surface, operator scoping
-        flags applied) and cache them on the request. Response scans replay the
-        cached conversation and append the response turns. Without a structured
-        view, the pre-existing texts-only wrapping is kept.
+        Both scan types send `structured_messages` and `tools` exactly as the
+        unified guardrail system produced them (normalized per API surface,
+        operator scoping flags applied; response scans carry the request
+        conversation with the response turns appended). Without a structured
+        view, request scans keep the pre-existing texts-only wrapping and
+        response scans send context-free assistant turns (the SDK/direct-call
+        path, where no request conversation exists).
         """
+        conversation: Final = self._sanitize_json_list(inputs.get("structured_messages"))
+        if conversation:
+            return conversation, self._sanitize_json_list(inputs.get("tools"))
         if input_type == "request":
-            conversation: Final = self._sanitize_json_list(inputs.get("structured_messages"))
-            if not conversation:
-                return self._texts_fallback(inputs, "user"), None
-            tools: Final = self._sanitize_json_list(inputs.get("tools"))
-            self._cache_request_conversation(request_data, conversation, tools)
-            return conversation, tools
-        response_turns: Final = self._build_response_turns(inputs)
-        if not response_turns:
-            return (), None
-        cached: Final = self._cached_request_conversation(request_data)
-        if cached is None:
-            return self._texts_fallback(inputs, "assistant"), None
-        return (*cached[0], *response_turns), cached[1]
-
-    def _cache_request_conversation(
-        self,
-        request_data: dict,  # mutable-ok: the shared per-request state dict every hook receives; caching on it is the point
-        conversation: tuple[Mapping[str, Any], ...],
-        tools: tuple[Mapping[str, Any], ...] | None,
-    ) -> None:
-        metadata: Final = request_data.setdefault(
-            "metadata",
-            {},  # mutable-ok: request metadata is shared mutable state other hooks also write to
-        )  # rebind-ok: response scans replay the request-time scoped conversation and request_data is the only object shared across hooks
-        if isinstance(metadata, dict):
-            metadata[GRAYSWAN_CONVERSATION_CACHE_KEY] = (conversation, tools)
-
-    def _cached_request_conversation(
-        self, request_data: Mapping[str, Any]
-    ) -> tuple[tuple[Mapping[str, Any], ...], tuple[Mapping[str, Any], ...] | None] | None:
-        metadata: Final = request_data.get("metadata")
-        cached: Final = metadata.get(GRAYSWAN_CONVERSATION_CACHE_KEY) if isinstance(metadata, dict) else None
-        if isinstance(cached, tuple) and len(cached) == 2:
-            return cached
-        return None
+            return self._texts_fallback(inputs, "user"), None
+        return self._build_response_turns(inputs), None
 
     def _build_response_turns(self, inputs: GenericGuardrailAPIInputs) -> tuple[Mapping[str, Any], ...]:
         tool_calls: Final = self._sanitize_json_list(inputs.get("tool_calls"))

--- a/litellm/proxy/guardrails/guardrail_hooks/hiddenlayer/hiddenlayer.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/hiddenlayer/hiddenlayer.py
@@ -211,7 +211,9 @@ class HiddenlayerGuardrail(CustomGuardrail):
         hl_request_metadata["requester_id"] = headers.get("hl-requester-id") or "LiteLLM"
         project_id: Final = headers.get("hl-project-id")
 
-        if scan_params := inputs.get("structured_messages"):
+        # Response scans keep the texts path: their structured_messages carry the
+        # whole conversation, whose last turn is not necessarily the scan target.
+        if input_type == "request" and (scan_params := inputs.get("structured_messages")):
             last_msg: Final = scan_params[-1]
             result: _HiddenlayerResponse = await self._call_hiddenlayer(
                 project_id,

--- a/litellm/proxy/guardrails/guardrail_hooks/openai/moderations.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/openai/moderations.py
@@ -195,8 +195,10 @@ class OpenAIModerationGuardrail(OpenAIGuardrailBase, CustomGuardrail):
         # Extract text to moderate from inputs
         text_to_moderate: str | None = None
 
-        # Prefer structured_messages if available (has role context)
-        if structured_messages := inputs.get("structured_messages"):
+        # Prefer structured_messages if available (has role context). Response
+        # scans moderate the model output via texts; the conversation would
+        # point moderation back at the user prompt.
+        if input_type == "request" and (structured_messages := inputs.get("structured_messages")):
             text_to_moderate = self.get_user_prompt(structured_messages)
 
         # Fall back to texts

--- a/litellm/proxy/guardrails/guardrail_hooks/promptguard/promptguard.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/promptguard/promptguard.py
@@ -105,7 +105,11 @@ class PromptGuardGuardrail(CustomGuardrail):
         structured_messages: Final = inputs.get("structured_messages", [])
         model: Final = inputs.get("model")
 
-        if structured_messages:
+        # Response scans keep the texts path: the redact write-back extracts
+        # user-role texts, which would clobber the response texts if the
+        # conversation were sent instead.
+        use_structured: Final = input_type == "request" and bool(structured_messages)
+        if use_structured:
             messages = list(structured_messages)
         elif texts:
             messages = [{"role": "user", "content": text} for text in texts]
@@ -175,7 +179,7 @@ class PromptGuardGuardrail(CustomGuardrail):
         if decision == "redact":
             redacted: Final = result.get("redacted_messages")
             if redacted:
-                if structured_messages:
+                if use_structured:
                     inputs["structured_messages"] = redacted
                 if "texts" in inputs:
                     extracted: Final = self._extract_texts_from_messages(

--- a/litellm/proxy/guardrails/guardrail_hooks/qualifire/qualifire.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/qualifire/qualifire.py
@@ -424,8 +424,10 @@ class QualifireGuardrail(CustomGuardrail):
         # Get dynamic params from request body (allows runtime overrides)
         dynamic_params: Final = self.get_guardrail_dynamic_request_body_params(request_data=request_data)
 
-        # Extract messages from structured_messages or request_data
-        messages: list[AllMessageValues] | None = inputs.get("structured_messages")
+        # Extract messages from structured_messages or request_data. Response
+        # scans keep the request_data path: their structured_messages carry the
+        # model's answer too, which would land in `messages` on top of `output`.
+        messages: list[AllMessageValues] | None = inputs.get("structured_messages") if input_type == "request" else None
         if not messages:
             messages = request_data.get("messages")
 

--- a/tests/test_litellm/llms/anthropic/chat/guardrail_translation/test_anthropic_guardrail_handler.py
+++ b/tests/test_litellm/llms/anthropic/chat/guardrail_translation/test_anthropic_guardrail_handler.py
@@ -1823,3 +1823,141 @@ class TestAnthropicMessagesScanOnlyToolResults:
 
         assert guardrail.captured_inputs is not None
         assert guardrail.captured_inputs.get("images") == ["TOOL_IMG"]
+
+
+class MockInputsRecordingGuardrail(CustomGuardrail):
+    """Records the inputs of every apply_guardrail call without modifying anything."""
+
+    def __init__(self):
+        super().__init__(guardrail_name="inputs-recording")
+        self.calls: list = []
+
+    async def apply_guardrail(
+        self,
+        inputs: GenericGuardrailAPIInputs,
+        request_data: dict,
+        input_type: Literal["request", "response"],
+        logging_obj: Optional[Any] = None,
+    ) -> GenericGuardrailAPIInputs:
+        import copy
+
+        self.calls.append((input_type, copy.deepcopy(dict(inputs))))
+        return inputs
+
+
+class TestAnthropicResponseScanConversation:
+    """Response scans receive the request conversation (with the top-level system
+    prompt hoisted, mirroring the request scan) plus the model's assistant turn,
+    and the request's tools translated to OpenAI shape."""
+
+    def _request_data(self, **overrides) -> dict:
+        data = {
+            "model": "claude-sonnet-4-5",
+            "system": "you are a helpful assistant",
+            "messages": [{"role": "user", "content": "what's the weather?"}],
+            **overrides,
+        }
+        return {key: value for key, value in data.items() if value is not None}
+
+    @pytest.mark.asyncio
+    async def test_response_scan_receives_hoisted_system_and_assistant_turn(self):
+        handler = AnthropicMessagesHandler()
+        guardrail = MockInputsRecordingGuardrail()
+        response = {
+            "id": "msg_1",
+            "model": "claude-sonnet-4-5",
+            "content": [{"type": "text", "text": "Sunny today."}],
+        }
+
+        await handler.process_output_response(
+            response=response,
+            guardrail_to_apply=guardrail,
+            request_data=self._request_data(),
+        )
+
+        input_type, inputs = guardrail.calls[-1]
+        assert input_type == "response"
+        conversation = inputs["structured_messages"]
+        assert conversation[0]["role"] == "system"
+        assert "helpful assistant" in str(conversation[0]["content"])
+        assert conversation[1] == {"role": "user", "content": "what's the weather?"}
+        assert conversation[-1] == {"role": "assistant", "content": "Sunny today."}
+
+    @pytest.mark.asyncio
+    async def test_skip_system_excludes_hoisted_prompt_from_response_scan(self):
+        handler = AnthropicMessagesHandler()
+        guardrail = MockInputsRecordingGuardrail()
+        guardrail.skip_system_message_in_guardrail = True
+        response = {
+            "id": "msg_1",
+            "model": "claude-sonnet-4-5",
+            "content": [{"type": "text", "text": "Sunny today."}],
+        }
+
+        await handler.process_output_response(
+            response=response,
+            guardrail_to_apply=guardrail,
+            request_data=self._request_data(),
+        )
+
+        _, inputs = guardrail.calls[-1]
+        conversation = inputs["structured_messages"]
+        assert all(message["role"] != "system" for message in conversation)
+        assert conversation[0] == {"role": "user", "content": "what's the weather?"}
+        assert conversation[-1] == {"role": "assistant", "content": "Sunny today."}
+
+    @pytest.mark.asyncio
+    async def test_response_scan_includes_translated_tools_and_tool_call_turn(self):
+        handler = AnthropicMessagesHandler()
+        guardrail = MockInputsRecordingGuardrail()
+        request_data = self._request_data(
+            system=None,
+            tools=[
+                {
+                    "name": "get_weather",
+                    "description": "look up weather",
+                    "input_schema": {"type": "object", "properties": {}},
+                }
+            ],
+        )
+        response = {
+            "id": "msg_1",
+            "model": "claude-sonnet-4-5",
+            "content": [
+                {"type": "text", "text": "Checking."},
+                {"type": "tool_use", "id": "toolu_1", "name": "get_weather", "input": {"city": "Paris"}},
+            ],
+        }
+
+        await handler.process_output_response(
+            response=response,
+            guardrail_to_apply=guardrail,
+            request_data=request_data,
+        )
+
+        _, inputs = guardrail.calls[-1]
+        assistant_turn = inputs["structured_messages"][-1]
+        assert assistant_turn["role"] == "assistant"
+        assert assistant_turn["content"] == "Checking."
+        assert assistant_turn["tool_calls"][0]["function"]["name"] == "get_weather"
+        assert inputs["tools"][0]["function"]["name"] == "get_weather"
+
+    @pytest.mark.asyncio
+    async def test_response_scan_without_request_messages_sends_no_conversation(self):
+        handler = AnthropicMessagesHandler()
+        guardrail = MockInputsRecordingGuardrail()
+        response = {
+            "id": "msg_1",
+            "model": "claude-sonnet-4-5",
+            "content": [{"type": "text", "text": "Hello."}],
+        }
+
+        await handler.process_output_response(
+            response=response,
+            guardrail_to_apply=guardrail,
+            request_data=None,
+        )
+
+        _, inputs = guardrail.calls[-1]
+        assert "structured_messages" not in inputs
+        assert inputs["texts"] == ["Hello."]

--- a/tests/test_litellm/llms/anthropic/chat/guardrail_translation/test_anthropic_guardrail_handler.py
+++ b/tests/test_litellm/llms/anthropic/chat/guardrail_translation/test_anthropic_guardrail_handler.py
@@ -1830,7 +1830,7 @@ class MockInputsRecordingGuardrail(CustomGuardrail):
 
     def __init__(self):
         super().__init__(guardrail_name="inputs-recording")
-        self.calls: list = []
+        self.calls: list[tuple[str, dict]] = []
 
     async def apply_guardrail(
         self,
@@ -1940,6 +1940,9 @@ class TestAnthropicResponseScanConversation:
         assert assistant_turn["role"] == "assistant"
         assert assistant_turn["content"] == "Checking."
         assert assistant_turn["tool_calls"][0]["function"]["name"] == "get_weather"
+        assert "index" not in assistant_turn["tool_calls"][0], (
+            "extraction-only fields must not leak into the assistant-message tool call shape"
+        )
         assert inputs["tools"][0]["function"]["name"] == "get_weather"
 
     @pytest.mark.asyncio

--- a/tests/test_litellm/llms/anthropic/chat/guardrail_translation/test_anthropic_guardrail_handler.py
+++ b/tests/test_litellm/llms/anthropic/chat/guardrail_translation/test_anthropic_guardrail_handler.py
@@ -1907,6 +1907,41 @@ class TestAnthropicResponseScanConversation:
         assert conversation[-1] == {"role": "assistant", "content": "Sunny today."}
 
     @pytest.mark.asyncio
+    async def test_skip_system_scoping_matches_request_scan(self):
+        handler = AnthropicMessagesHandler()
+        guardrail = MockInputsRecordingGuardrail()
+        guardrail.skip_system_message_in_guardrail = True
+        request_data = self._request_data(
+            system="trusted top-level system prompt",
+            messages=[
+                {"role": "user", "content": "safe text"},
+                {"role": "system", "content": "prohibited correction"},
+                {"role": "user", "content": "continue"},
+            ],
+        )
+        response = {
+            "id": "msg_1",
+            "model": "claude-sonnet-4-5",
+            "content": [{"type": "text", "text": "Done."}],
+        }
+
+        await handler.process_input_messages(data=dict(request_data), guardrail_to_apply=guardrail)
+        await handler.process_output_response(
+            response=response,
+            guardrail_to_apply=guardrail,
+            request_data=dict(request_data),
+        )
+
+        (request_type, request_inputs), (response_type, response_inputs) = guardrail.calls
+        assert (request_type, response_type) == ("request", "response")
+        request_conversation = request_inputs["structured_messages"]
+        response_conversation = response_inputs["structured_messages"]
+        assert [message["role"] for message in request_conversation] == ["user", "system", "user"]
+        assert response_conversation[: len(request_conversation)] == request_conversation
+        assert response_conversation[len(request_conversation) :] == [{"role": "assistant", "content": "Done."}]
+        assert "trusted top-level system prompt" not in str(response_conversation)
+
+    @pytest.mark.asyncio
     async def test_response_scan_includes_translated_tools_and_tool_call_turn(self):
         handler = AnthropicMessagesHandler()
         guardrail = MockInputsRecordingGuardrail()

--- a/tests/test_litellm/llms/openai/chat/guardrail_translation/test_openai_guardrail_handler.py
+++ b/tests/test_litellm/llms/openai/chat/guardrail_translation/test_openai_guardrail_handler.py
@@ -1564,3 +1564,214 @@ class TestScanOnlyToolResults:
         assert data["messages"][3]["content"] == "page says [BLOCKED] here"
         assert data["messages"][3]["tool_call_id"] == "call_1"
         assert data["messages"][4]["content"] == "and then?"
+
+
+class RecordingGuardrail(CustomGuardrail):
+    """Captures the inputs of every apply_guardrail call without modifying anything."""
+
+    def __init__(self):
+        super().__init__(guardrail_name="recording")
+        self.calls: list = []
+
+    async def apply_guardrail(
+        self,
+        inputs: GenericGuardrailAPIInputs,
+        request_data: dict,
+        input_type: Literal["request", "response"],
+        logging_obj: Optional[Any] = None,
+    ) -> GenericGuardrailAPIInputs:
+        import copy
+
+        self.calls.append((input_type, copy.deepcopy(dict(inputs))))
+        return inputs
+
+
+class TestResponseScanConversation:
+    """Response scans receive the request conversation with the model's assistant
+    turns appended (inputs["structured_messages"]) plus the request's tool
+    definitions (inputs["tools"]), so conversation-context guardrails see the
+    same dialogue on both scans without caching state between hooks."""
+
+    def _response(self, *choices: Choices) -> ModelResponse:
+        return ModelResponse(
+            id="chatcmpl-1",
+            created=1234567890,
+            model="gpt-4",
+            object="chat.completion",
+            choices=list(choices),
+        )
+
+    @pytest.mark.asyncio
+    async def test_response_scan_receives_conversation_and_tools(self):
+        handler = OpenAIChatCompletionsHandler()
+        guardrail = RecordingGuardrail()
+        request_data = {
+            "messages": [
+                {"role": "system", "content": "be helpful"},
+                {"role": "user", "content": "what's the weather?"},
+            ],
+            "tools": [{"type": "function", "function": {"name": "get_weather", "parameters": {}}}],
+        }
+        response = self._response(
+            Choices(
+                finish_reason="tool_calls",
+                index=0,
+                message=Message(
+                    content="Checking now.",
+                    role="assistant",
+                    tool_calls=[
+                        ChatCompletionMessageToolCall(
+                            id="call_1",
+                            type="function",
+                            function=Function(name="get_weather", arguments='{"city": "Paris"}'),
+                        )
+                    ],
+                ),
+            )
+        )
+
+        await handler.process_output_response(response, guardrail, request_data=request_data)
+
+        input_type, inputs = guardrail.calls[-1]
+        assert input_type == "response"
+        assert inputs["structured_messages"] == [
+            {"role": "system", "content": "be helpful"},
+            {"role": "user", "content": "what's the weather?"},
+            {
+                "role": "assistant",
+                "content": "Checking now.",
+                "tool_calls": [
+                    {
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {"name": "get_weather", "arguments": '{"city": "Paris"}'},
+                    }
+                ],
+            },
+        ]
+        assert inputs["tools"] == request_data["tools"]
+
+    @pytest.mark.asyncio
+    async def test_response_scan_scoping_matches_request_scan(self):
+        handler = OpenAIChatCompletionsHandler()
+        guardrail = RecordingGuardrail()
+        guardrail.skip_system_message_in_guardrail = True
+        guardrail.skip_tool_message_in_guardrail = True
+        request_data = {
+            "messages": [
+                {"role": "system", "content": "SYSTEM-PROMPT"},
+                {"role": "user", "content": "run the tool"},
+                {"role": "tool", "tool_call_id": "call_1", "content": "TOOL-RESULT"},
+                {"role": "user", "content": "summarize"},
+            ]
+        }
+
+        await handler.process_input_messages(data=dict(request_data), guardrail_to_apply=guardrail)
+        response = self._response(
+            Choices(finish_reason="stop", index=0, message=Message(content="Done.", role="assistant"))
+        )
+        await handler.process_output_response(response, guardrail, request_data=dict(request_data))
+
+        (_, request_inputs), (_, response_inputs) = guardrail.calls
+        request_conversation = request_inputs["structured_messages"]
+        response_conversation = response_inputs["structured_messages"]
+        assert response_conversation[: len(request_conversation)] == request_conversation
+        assert response_conversation[len(request_conversation) :] == [{"role": "assistant", "content": "Done."}]
+        assert all(m["role"] not in ("system", "tool") for m in response_conversation)
+
+    @pytest.mark.asyncio
+    async def test_scan_only_tool_results_scopes_response_conversation_and_tools(self):
+        handler = OpenAIChatCompletionsHandler()
+        guardrail = RecordingGuardrail()
+        guardrail.scan_only_tool_results = True
+        request_data = {
+            "messages": [
+                {"role": "user", "content": "fetch the page"},
+                {"role": "tool", "tool_call_id": "call_1", "content": "page content"},
+            ],
+            "tools": [{"type": "function", "function": {"name": "fetch", "parameters": {}}}],
+        }
+        response = self._response(
+            Choices(finish_reason="stop", index=0, message=Message(content="Summary.", role="assistant"))
+        )
+
+        await handler.process_output_response(response, guardrail, request_data=request_data)
+
+        _, inputs = guardrail.calls[-1]
+        assert inputs["structured_messages"] == [
+            {"role": "tool", "tool_call_id": "call_1", "content": "page content"},
+            {"role": "assistant", "content": "Summary."},
+        ]
+        assert "tools" not in inputs
+
+    @pytest.mark.asyncio
+    async def test_sdk_path_without_request_data_sends_no_conversation(self):
+        handler = OpenAIChatCompletionsHandler()
+        guardrail = RecordingGuardrail()
+        response = self._response(
+            Choices(finish_reason="stop", index=0, message=Message(content="Hello.", role="assistant"))
+        )
+
+        await handler.process_output_response(response, guardrail, request_data=None)
+
+        _, inputs = guardrail.calls[-1]
+        assert "structured_messages" not in inputs
+        assert "tools" not in inputs
+        assert inputs["texts"] == ["Hello."]
+
+    @pytest.mark.asyncio
+    async def test_multi_choice_response_appends_one_turn_per_choice(self):
+        handler = OpenAIChatCompletionsHandler()
+        guardrail = RecordingGuardrail()
+        request_data = {"messages": [{"role": "user", "content": "pick one"}]}
+        response = self._response(
+            Choices(finish_reason="stop", index=0, message=Message(content="candidate one", role="assistant")),
+            Choices(finish_reason="stop", index=1, message=Message(content="candidate two", role="assistant")),
+        )
+
+        await handler.process_output_response(response, guardrail, request_data=request_data)
+
+        _, inputs = guardrail.calls[-1]
+        assert inputs["structured_messages"] == [
+            {"role": "user", "content": "pick one"},
+            {"role": "assistant", "content": "candidate one"},
+            {"role": "assistant", "content": "candidate two"},
+        ]
+
+    @pytest.mark.asyncio
+    async def test_end_of_stream_scan_receives_conversation(self):
+        from litellm.types.utils import Delta, ModelResponseStream, StreamingChoices
+
+        handler = OpenAIChatCompletionsHandler()
+        guardrail = RecordingGuardrail()
+        request_data = {"messages": [{"role": "user", "content": "say hi"}]}
+        chunks = [
+            ModelResponseStream(
+                id="chatcmpl-1",
+                created=1234567890,
+                model="gpt-4",
+                object="chat.completion.chunk",
+                choices=[
+                    StreamingChoices(index=0, finish_reason=None, delta=Delta(content="hi ", role="assistant"))
+                ],
+            ),
+            ModelResponseStream(
+                id="chatcmpl-1",
+                created=1234567890,
+                model="gpt-4",
+                object="chat.completion.chunk",
+                choices=[StreamingChoices(index=0, finish_reason="stop", delta=Delta(content="there"))],
+            ),
+        ]
+
+        await handler.process_output_streaming_response(
+            responses_so_far=chunks,
+            guardrail_to_apply=guardrail,
+            request_data=request_data,
+        )
+
+        _, inputs = guardrail.calls[-1]
+        assert inputs["structured_messages"] == [
+            {"role": "user", "content": "say hi"},
+            {"role": "assistant", "content": "hi there"},
+        ]

--- a/tests/test_litellm/llms/openai/chat/guardrail_translation/test_openai_guardrail_handler.py
+++ b/tests/test_litellm/llms/openai/chat/guardrail_translation/test_openai_guardrail_handler.py
@@ -1571,7 +1571,7 @@ class RecordingGuardrail(CustomGuardrail):
 
     def __init__(self):
         super().__init__(guardrail_name="recording")
-        self.calls: list = []
+        self.calls: list[tuple[str, dict]] = []
 
     async def apply_guardrail(
         self,
@@ -1775,3 +1775,13 @@ class TestResponseScanConversation:
             {"role": "user", "content": "say hi"},
             {"role": "assistant", "content": "hi there"},
         ]
+
+    @pytest.mark.asyncio
+    async def test_empty_response_turns_yield_no_conversation(self):
+        """A conversation without a response turn would shadow the tool_calls/texts
+        fallback in conversation-preferring guardrails, so none is built."""
+        handler = OpenAIChatCompletionsHandler()
+        guardrail = RecordingGuardrail()
+        request_data = {"messages": [{"role": "user", "content": "hi"}]}
+
+        assert handler.response_scan_conversation(request_data, guardrail, []) is None

--- a/tests/test_litellm/llms/openai/responses/test_openai_responses_guardrail_handler.py
+++ b/tests/test_litellm/llms/openai/responses/test_openai_responses_guardrail_handler.py
@@ -1241,7 +1241,7 @@ class MockInputsRecordingGuardrail(CustomGuardrail):
 
     def __init__(self):
         super().__init__(guardrail_name="inputs-recording")
-        self.calls: list = []
+        self.calls: list[tuple[str, dict]] = []
 
     async def apply_guardrail(
         self,

--- a/tests/test_litellm/llms/openai/responses/test_openai_responses_guardrail_handler.py
+++ b/tests/test_litellm/llms/openai/responses/test_openai_responses_guardrail_handler.py
@@ -1234,3 +1234,164 @@ class TestOpenAIResponsesHandlerToolInjection:
         names = [t.get("name") for t in result["tools"]]
         assert "get_weather" in names
         assert "injected_tool" in names
+
+
+class MockInputsRecordingGuardrail(CustomGuardrail):
+    """Records the inputs of every apply_guardrail call without modifying anything."""
+
+    def __init__(self):
+        super().__init__(guardrail_name="inputs-recording")
+        self.calls: list = []
+
+    async def apply_guardrail(
+        self,
+        inputs: GenericGuardrailAPIInputs,
+        request_data: dict,
+        input_type: Literal["request", "response"],
+        logging_obj: Optional[Any] = None,
+    ) -> GenericGuardrailAPIInputs:
+        import copy
+
+        self.calls.append((input_type, copy.deepcopy(dict(inputs))))
+        return inputs
+
+
+class TestResponsesResponseScanConversation:
+    """Response scans receive the request conversation (input plus instructions,
+    translated to chat shape) with the model's assistant turn appended, and the
+    request's tools translated to chat-completion shape."""
+
+    def _response(self, output: list) -> ResponsesAPIResponse:
+        return ResponsesAPIResponse(
+            id="resp_1",
+            created_at=1234567890,
+            model="gpt-4",
+            object="response",
+            status="completed",
+            output=output,
+        )
+
+    @pytest.mark.asyncio
+    async def test_response_scan_receives_conversation_and_tools(self):
+        handler = OpenAIResponsesHandler()
+        guardrail = MockInputsRecordingGuardrail()
+        request_data = {
+            "model": "gpt-4",
+            "instructions": "be helpful",
+            "input": [{"role": "user", "content": "what's the weather?"}],
+            "tools": [
+                {
+                    "type": "function",
+                    "name": "get_weather",
+                    "parameters": {"type": "object", "properties": {}},
+                }
+            ],
+        }
+        response = self._response(
+            [
+                {
+                    "type": "message",
+                    "id": "msg_1",
+                    "status": "completed",
+                    "role": "assistant",
+                    "content": [{"type": "output_text", "text": "Sunny today."}],
+                }
+            ]
+        )
+
+        await handler.process_output_response(response, guardrail, request_data=request_data)
+
+        input_type, inputs = guardrail.calls[-1]
+        assert input_type == "response"
+        conversation = inputs["structured_messages"]
+        expected_request_conversation = handler.get_structured_messages(request_data)
+        assert conversation[:-1] == expected_request_conversation
+        assert conversation[0]["role"] == "system"
+        assert "be helpful" in str(conversation[0]["content"])
+        assert conversation[-1] == {"role": "assistant", "content": "Sunny today."}
+        assert inputs["tools"][0]["function"]["name"] == "get_weather"
+
+    @pytest.mark.asyncio
+    async def test_response_scan_appends_tool_call_turn(self):
+        handler = OpenAIResponsesHandler()
+        guardrail = MockInputsRecordingGuardrail()
+        request_data = {
+            "model": "gpt-4",
+            "input": [{"role": "user", "content": "look it up"}],
+        }
+        response = self._response(
+            [
+                {
+                    "type": "function_call",
+                    "id": "fc_1",
+                    "call_id": "call_1",
+                    "name": "get_weather",
+                    "arguments": '{"city": "Paris"}',
+                    "status": "completed",
+                }
+            ]
+        )
+
+        await handler.process_output_response(response, guardrail, request_data=request_data)
+
+        _, inputs = guardrail.calls[-1]
+        assistant_turn = inputs["structured_messages"][-1]
+        assert assistant_turn["role"] == "assistant"
+        assert assistant_turn["tool_calls"][0]["function"]["name"] == "get_weather"
+
+    @pytest.mark.asyncio
+    async def test_response_scan_without_request_data_sends_no_conversation(self):
+        handler = OpenAIResponsesHandler()
+        guardrail = MockInputsRecordingGuardrail()
+        response = self._response(
+            [
+                {
+                    "type": "message",
+                    "id": "msg_1",
+                    "status": "completed",
+                    "role": "assistant",
+                    "content": [{"type": "output_text", "text": "Hello."}],
+                }
+            ]
+        )
+
+        await handler.process_output_response(response, guardrail, request_data=None)
+
+        _, inputs = guardrail.calls[-1]
+        assert "structured_messages" not in inputs
+        assert inputs["texts"] == ["Hello."]
+
+    @pytest.mark.asyncio
+    async def test_streaming_completed_event_receives_conversation(self):
+        handler = OpenAIResponsesHandler()
+        guardrail = MockInputsRecordingGuardrail()
+        request_data = {
+            "model": "gpt-4",
+            "input": [{"role": "user", "content": "say hi"}],
+        }
+        final_chunk = {
+            "type": "response.completed",
+            "response": {
+                "model": "gpt-4",
+                "output": [
+                    {
+                        "type": "message",
+                        "id": "msg_1",
+                        "status": "completed",
+                        "role": "assistant",
+                        "content": [{"type": "output_text", "text": "hi there"}],
+                    }
+                ],
+            },
+        }
+
+        await handler.process_output_streaming_response(
+            responses_so_far=[final_chunk],
+            guardrail_to_apply=guardrail,
+            request_data=request_data,
+        )
+
+        _, inputs = guardrail.calls[-1]
+        conversation = inputs["structured_messages"]
+        assert conversation[-1] == {"role": "assistant", "content": "hi there"}
+        assert conversation[:-1] == handler.get_structured_messages(request_data)

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/openai/test_moderations.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/openai/test_moderations.py
@@ -994,8 +994,10 @@ async def test_openai_moderation_initialize_guardrail_forwards_streaming_flags()
 @pytest.mark.asyncio
 async def test_openai_moderation_response_scan_moderates_output_not_user_prompt():
     """On response scans the conversation is available in structured_messages,
-    but moderation must still target the model output carried in texts."""
-    from unittest.mock import AsyncMock
+    but moderation must still target the model output carried in texts. The fake
+    moderation endpoint flags only the harmful model answer: moderating the
+    (benign) user prompt instead would let the flagged output through."""
+    from fastapi import HTTPException
 
     from litellm.types.utils import GenericGuardrailAPIInputs
 
@@ -1004,34 +1006,33 @@ async def test_openai_moderation_response_scan_moderates_output_not_user_prompt(
             guardrail_name="test-openai-moderation",
         )
 
-        mock_response = OpenAIModerationResponse(
-            id="modr-123",
-            model="omni-moderation-latest",
-            results=[
-                OpenAIModerationResult(
-                    flagged=False,
-                    categories={},
-                    category_scores={},
-                    category_applied_input_types={},
-                )
-            ],
-        )
-
-        with patch.object(
-            guardrail, "async_make_request", new_callable=AsyncMock, return_value=mock_response
-        ) as mock_request:
-            inputs = GenericGuardrailAPIInputs(
-                texts=["the model's answer"],
-                structured_messages=[
-                    {"role": "user", "content": "the user's question"},
-                    {"role": "assistant", "content": "the model's answer"},
+        async def moderate(input_text: str) -> OpenAIModerationResponse:
+            flagged = "harmful answer" in input_text
+            return OpenAIModerationResponse(
+                id="modr-123",
+                model="omni-moderation-latest",
+                results=[
+                    OpenAIModerationResult(
+                        flagged=flagged,
+                        categories={"violence": flagged},
+                        category_scores={"violence": 0.99 if flagged else 0.0},
+                        category_applied_input_types={"violence": []},
+                    )
                 ],
             )
 
-            await guardrail.apply_guardrail(
-                inputs=inputs,
-                request_data={},
-                input_type="response",
+        with patch.object(guardrail, "async_make_request", side_effect=moderate):
+            inputs = GenericGuardrailAPIInputs(
+                texts=["a harmful answer"],
+                structured_messages=[
+                    {"role": "user", "content": "a benign question"},
+                    {"role": "assistant", "content": "a harmful answer"},
+                ],
             )
 
-            assert mock_request.call_args.kwargs["input_text"] == "the model's answer"
+            with pytest.raises(HTTPException):
+                await guardrail.apply_guardrail(
+                    inputs=inputs,
+                    request_data={},
+                    input_type="response",
+                )

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/openai/test_moderations.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/openai/test_moderations.py
@@ -989,3 +989,49 @@ async def test_openai_moderation_initialize_guardrail_forwards_streaming_flags()
             assert guardrail.streaming_sampling_rate == 2
     finally:
         litellm.logging_callback_manager._reset_all_callbacks()
+
+
+@pytest.mark.asyncio
+async def test_openai_moderation_response_scan_moderates_output_not_user_prompt():
+    """On response scans the conversation is available in structured_messages,
+    but moderation must still target the model output carried in texts."""
+    from unittest.mock import AsyncMock
+
+    from litellm.types.utils import GenericGuardrailAPIInputs
+
+    with patch.dict(os.environ, {"OPENAI_API_KEY": "test-key"}):
+        guardrail = OpenAIModerationGuardrail(
+            guardrail_name="test-openai-moderation",
+        )
+
+        mock_response = OpenAIModerationResponse(
+            id="modr-123",
+            model="omni-moderation-latest",
+            results=[
+                OpenAIModerationResult(
+                    flagged=False,
+                    categories={},
+                    category_scores={},
+                    category_applied_input_types={},
+                )
+            ],
+        )
+
+        with patch.object(
+            guardrail, "async_make_request", new_callable=AsyncMock, return_value=mock_response
+        ) as mock_request:
+            inputs = GenericGuardrailAPIInputs(
+                texts=["the model's answer"],
+                structured_messages=[
+                    {"role": "user", "content": "the user's question"},
+                    {"role": "assistant", "content": "the model's answer"},
+                ],
+            )
+
+            await guardrail.apply_guardrail(
+                inputs=inputs,
+                request_data={},
+                input_type="response",
+            )
+
+            assert mock_request.call_args.kwargs["input_text"] == "the model's answer"

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_akto.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_akto.py
@@ -1,0 +1,31 @@
+"""Tests for the Akto guardrail's ingest payload construction."""
+
+from litellm.proxy.guardrails.guardrail_hooks.akto.akto import AktoGuardrail
+
+
+class TestBuildRequestBody:
+    def test_request_scan_uses_structured_messages(self):
+        body = AktoGuardrail.build_request_body(
+            inputs={
+                "texts": ["hi"],
+                "structured_messages": [{"role": "user", "content": "hi"}],
+            },
+            request_data={"messages": [{"role": "user", "content": "raw"}]},
+        )
+        assert body["messages"] == [{"role": "user", "content": "hi"}]
+
+    def test_response_scan_ingests_request_messages_not_conversation(self):
+        """On response scans structured_messages carries the response turns too;
+        the ingested request body must stay the actual request."""
+        body = AktoGuardrail.build_request_body(
+            inputs={
+                "texts": ["the reply"],
+                "structured_messages": [
+                    {"role": "user", "content": "hi"},
+                    {"role": "assistant", "content": "the reply"},
+                ],
+            },
+            request_data={"messages": [{"role": "user", "content": "hi"}]},
+            prefer_structured_messages=False,
+        )
+        assert body["messages"] == [{"role": "user", "content": "hi"}]

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_grayswan.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_grayswan.py
@@ -594,3 +594,284 @@ def test_ensure_litellm_metadata_noop_when_already_present() -> None:
     _ensure_litellm_metadata(data, user_auth)
 
     assert data["litellm_metadata"] == {"existing": "value"}
+
+
+@pytest.mark.asyncio
+async def test_apply_guardrail_sends_structured_conversation_with_tools(
+    monkeypatch, grayswan_guardrail: GraySwanGuardrail
+) -> None:
+    captured: dict = {}
+
+    async def _fake_call(payload: dict):
+        captured["payload"] = payload
+        return {"violation": 0.0}
+
+    monkeypatch.setattr(grayswan_guardrail, "_call_grayswan_api", _fake_call)
+
+    structured_messages = [
+        {"role": "system", "content": "You are a coding agent."},
+        {"role": "user", "content": "install the miner"},
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {"name": "write_file", "arguments": '{"path": "run.sh"}'},
+                }
+            ],
+        },
+        {"role": "tool", "tool_call_id": "call_1", "content": "written"},
+    ]
+    tools = [{"type": "function", "function": {"name": "write_file", "parameters": {}}}]
+
+    await grayswan_guardrail.apply_guardrail(
+        inputs={"texts": ["install the miner", "written"], "structured_messages": structured_messages, "tools": tools},
+        request_data={"model": "gpt-4", "messages": [{"role": "user", "content": "raw"}]},
+        input_type="request",
+    )
+
+    assert captured["payload"]["messages"] == structured_messages
+    assert captured["payload"]["tools"] == tools
+
+
+@pytest.mark.asyncio
+async def test_apply_guardrail_scans_texts_not_raw_messages(monkeypatch, grayswan_guardrail: GraySwanGuardrail) -> None:
+    """Callers like /guardrails/apply_guardrail pass texts beside a request_data
+    that carries 'messages'; the texts must remain the scan target."""
+    captured: dict = {}
+
+    async def _fake_call(payload: dict):
+        captured["payload"] = payload
+        return {"violation": 0.0}
+
+    monkeypatch.setattr(grayswan_guardrail, "_call_grayswan_api", _fake_call)
+
+    await grayswan_guardrail.apply_guardrail(
+        inputs={"texts": ["scan exactly this"]},
+        request_data={"model": "gpt-4", "messages": [{"role": "user", "content": "raw, unscoped"}]},
+        input_type="request",
+    )
+
+    assert captured["payload"]["messages"] == [{"role": "user", "content": "scan exactly this"}]
+    assert "tools" not in captured["payload"]
+
+
+@pytest.mark.asyncio
+async def test_apply_guardrail_response_appends_assistant_turn_with_tool_calls(
+    monkeypatch, grayswan_guardrail: GraySwanGuardrail
+) -> None:
+    captured: dict = {}
+
+    async def _fake_call(payload: dict):
+        captured["payload"] = payload
+        return {"violation": 0.0}
+
+    monkeypatch.setattr(grayswan_guardrail, "_call_grayswan_api", _fake_call)
+
+    structured_messages = [{"role": "user", "content": "write a script"}]
+    response_tool_calls = [
+        {
+            "id": "call_9",
+            "type": "function",
+            "function": {"name": "write_file", "arguments": '{"path": "x.sh", "content": "xmrig"}'},
+        }
+    ]
+    request_data: dict = {"model": "gpt-4"}
+
+    await grayswan_guardrail.apply_guardrail(
+        inputs={"texts": ["write a script"], "structured_messages": structured_messages},
+        request_data=request_data,
+        input_type="request",
+    )
+    await grayswan_guardrail.apply_guardrail(
+        inputs={"texts": ["sure, writing it now"], "tool_calls": response_tool_calls},
+        request_data=request_data,
+        input_type="response",
+    )
+
+    assert captured["payload"]["messages"][:-1] == structured_messages
+    assert captured["payload"]["messages"][-1] == {
+        "role": "assistant",
+        "content": "sure, writing it now",
+        "tool_calls": response_tool_calls,
+    }
+
+
+@pytest.mark.asyncio
+async def test_apply_guardrail_scans_tool_call_only_response(
+    monkeypatch, grayswan_guardrail: GraySwanGuardrail
+) -> None:
+    captured: dict = {}
+
+    async def _fake_call(payload: dict):
+        captured["payload"] = payload
+        return {"violation": 0.0}
+
+    monkeypatch.setattr(grayswan_guardrail, "_call_grayswan_api", _fake_call)
+
+    response_tool_calls = [{"id": "call_2", "type": "function", "function": {"name": "run", "arguments": "{}"}}]
+    request_data: dict = {"model": "gpt-4"}
+
+    await grayswan_guardrail.apply_guardrail(
+        inputs={"texts": ["go"], "structured_messages": [{"role": "user", "content": "go"}]},
+        request_data=request_data,
+        input_type="request",
+    )
+    await grayswan_guardrail.apply_guardrail(
+        inputs={"texts": [], "tool_calls": response_tool_calls},
+        request_data=request_data,
+        input_type="response",
+    )
+
+    assert captured["payload"]["messages"][0] == {"role": "user", "content": "go"}
+    assert captured["payload"]["messages"][-1]["tool_calls"] == response_tool_calls
+    assert captured["payload"]["messages"][-1]["content"] == ""
+
+
+@pytest.mark.asyncio
+async def test_apply_guardrail_wraps_texts_when_no_conversation_available(
+    monkeypatch, grayswan_guardrail: GraySwanGuardrail
+) -> None:
+    captured: dict = {}
+
+    async def _fake_call(payload: dict):
+        captured["payload"] = payload
+        return {"violation": 0.0}
+
+    monkeypatch.setattr(grayswan_guardrail, "_call_grayswan_api", _fake_call)
+
+    await grayswan_guardrail.apply_guardrail(
+        inputs={"texts": ["a prompt for an image"]},
+        request_data={},
+        input_type="request",
+    )
+
+    assert captured["payload"]["messages"] == [{"role": "user", "content": "a prompt for an image"}]
+    assert "tools" not in captured["payload"]
+
+
+@pytest.mark.asyncio
+async def test_apply_guardrail_response_without_request_scan_wraps_texts(
+    monkeypatch, grayswan_guardrail: GraySwanGuardrail
+) -> None:
+    captured: dict = {}
+
+    async def _fake_call(payload: dict):
+        captured["payload"] = payload
+        return {"violation": 0.0}
+
+    monkeypatch.setattr(grayswan_guardrail, "_call_grayswan_api", _fake_call)
+
+    await grayswan_guardrail.apply_guardrail(
+        inputs={"texts": ["a model reply"]},
+        request_data={"model": "gpt-4", "messages": [{"role": "user", "content": "raw"}]},
+        input_type="response",
+    )
+
+    assert captured["payload"]["messages"] == [{"role": "assistant", "content": "a model reply"}]
+    assert "tools" not in captured["payload"]
+
+
+@pytest.mark.asyncio
+async def test_apply_guardrail_empty_response_is_not_scanned(
+    monkeypatch, grayswan_guardrail: GraySwanGuardrail
+) -> None:
+    calls: list = []
+
+    async def _fake_call(payload: dict):
+        calls.append(payload)
+        return {"violation": 0.0}
+
+    monkeypatch.setattr(grayswan_guardrail, "_call_grayswan_api", _fake_call)
+
+    request_data: dict = {"model": "gpt-4"}
+    await grayswan_guardrail.apply_guardrail(
+        inputs={"texts": ["go"], "structured_messages": [{"role": "user", "content": "go"}]},
+        request_data=request_data,
+        input_type="request",
+    )
+    inputs: dict = {"texts": []}
+    result = await grayswan_guardrail.apply_guardrail(
+        inputs=inputs,
+        request_data=request_data,
+        input_type="response",
+    )
+
+    assert len(calls) == 1
+    assert result is inputs
+
+
+@pytest.mark.asyncio
+async def test_apply_guardrail_multiple_response_texts_get_separate_turns(
+    monkeypatch, grayswan_guardrail: GraySwanGuardrail
+) -> None:
+    captured: dict = {}
+
+    async def _fake_call(payload: dict):
+        captured["payload"] = payload
+        return {"violation": 0.0}
+
+    monkeypatch.setattr(grayswan_guardrail, "_call_grayswan_api", _fake_call)
+
+    request_data: dict = {"model": "gpt-4"}
+    await grayswan_guardrail.apply_guardrail(
+        inputs={"texts": ["pick one"], "structured_messages": [{"role": "user", "content": "pick one"}]},
+        request_data=request_data,
+        input_type="request",
+    )
+    await grayswan_guardrail.apply_guardrail(
+        inputs={"texts": ["candidate one", "candidate two"]},
+        request_data=request_data,
+        input_type="response",
+    )
+
+    assert captured["payload"]["messages"][-2:] == [
+        {"role": "assistant", "content": "candidate one"},
+        {"role": "assistant", "content": "candidate two"},
+    ]
+
+
+@pytest.mark.asyncio
+async def test_apply_guardrail_request_tools_never_come_from_raw_request(
+    monkeypatch, grayswan_guardrail: GraySwanGuardrail
+) -> None:
+    captured: dict = {}
+
+    async def _fake_call(payload: dict):
+        captured["payload"] = payload
+        return {"violation": 0.0}
+
+    monkeypatch.setattr(grayswan_guardrail, "_call_grayswan_api", _fake_call)
+
+    await grayswan_guardrail.apply_guardrail(
+        inputs={"texts": ["go"], "structured_messages": [{"role": "user", "content": "go"}]},
+        request_data={"model": "gpt-4", "tools": [{"type": "function", "function": {"name": "scoped_out"}}]},
+        input_type="request",
+    )
+
+    assert "tools" not in captured["payload"]
+
+
+@pytest.mark.asyncio
+async def test_apply_guardrail_build_error_fails_open(monkeypatch, grayswan_guardrail: GraySwanGuardrail) -> None:
+    def _boom(*args, **kwargs):
+        raise TypeError("unexpected shape")
+
+    monkeypatch.setattr(grayswan_guardrail, "_build_monitor_input", _boom)
+
+    inputs: dict = {"texts": ["hello"]}
+    result = await grayswan_guardrail.apply_guardrail(
+        inputs=inputs,
+        request_data={"model": "gpt-4"},
+        input_type="request",
+    )
+
+    assert result is inputs
+
+
+def test_sanitize_json_list_drops_non_dict_items(grayswan_guardrail: GraySwanGuardrail) -> None:
+    assert grayswan_guardrail._sanitize_json_list([{"role": "user", "content": "hi"}, "junk", 3]) == [
+        {"role": "user", "content": "hi"}
+    ]

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_grayswan.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_grayswan.py
@@ -666,9 +666,11 @@ async def test_apply_guardrail_scans_texts_not_raw_messages(monkeypatch, grayswa
 
 
 @pytest.mark.asyncio
-async def test_apply_guardrail_response_appends_assistant_turn_with_tool_calls(
+async def test_apply_guardrail_response_uses_structured_conversation_with_tools(
     monkeypatch, grayswan_guardrail: GraySwanGuardrail
 ) -> None:
+    """The translation layer hands response scans the request conversation with
+    the response turns already appended; the payload sends it verbatim."""
     captured: dict = {}
 
     async def _fake_call(payload: dict):
@@ -677,34 +679,65 @@ async def test_apply_guardrail_response_appends_assistant_turn_with_tool_calls(
 
     monkeypatch.setattr(grayswan_guardrail, "_call_grayswan_api", _fake_call)
 
-    structured_messages = [{"role": "user", "content": "write a script"}]
-    response_tool_calls = [
+    structured_messages = [
+        {"role": "user", "content": "write a script"},
         {
-            "id": "call_9",
-            "type": "function",
-            "function": {"name": "write_file", "arguments": '{"path": "x.sh", "content": "xmrig"}'},
-        }
+            "role": "assistant",
+            "content": "sure, writing it now",
+            "tool_calls": [
+                {
+                    "id": "call_9",
+                    "type": "function",
+                    "function": {"name": "write_file", "arguments": '{"path": "x.sh", "content": "xmrig"}'},
+                }
+            ],
+        },
     ]
-    request_data: dict = {"model": "gpt-4"}
+    tools = [{"type": "function", "function": {"name": "write_file", "parameters": {}}}]
 
     await grayswan_guardrail.apply_guardrail(
-        inputs={"texts": ["write a script"], "structured_messages": structured_messages},
-        request_data=request_data,
-        input_type="request",
-    )
-    await grayswan_guardrail.apply_guardrail(
-        inputs={"texts": ["sure, writing it now"], "tool_calls": response_tool_calls},
-        request_data=request_data,
+        inputs={
+            "texts": ["sure, writing it now"],
+            "structured_messages": structured_messages,
+            "tools": tools,
+        },
+        request_data={"model": "gpt-4"},
         input_type="response",
     )
 
     wire = _wire(captured["payload"])
-    assert wire["messages"][:-1] == structured_messages
-    assert wire["messages"][-1] == {
-        "role": "assistant",
-        "content": "sure, writing it now",
-        "tool_calls": response_tool_calls,
-    }
+    assert wire["messages"] == structured_messages
+    assert wire["tools"] == tools
+
+
+@pytest.mark.asyncio
+async def test_apply_guardrail_response_does_not_read_request_metadata(
+    monkeypatch, grayswan_guardrail: GraySwanGuardrail
+) -> None:
+    """Request scans no longer stash the conversation on request_data, and
+    response scans build the payload from inputs alone."""
+    captured: dict = {}
+
+    async def _fake_call(payload: dict):
+        captured["payload"] = payload
+        return {"violation": 0.0}
+
+    monkeypatch.setattr(grayswan_guardrail, "_call_grayswan_api", _fake_call)
+
+    request_data: dict = {"model": "gpt-4"}
+    await grayswan_guardrail.apply_guardrail(
+        inputs={"texts": ["go"], "structured_messages": [{"role": "user", "content": "go"}]},
+        request_data=request_data,
+        input_type="request",
+    )
+    assert "_grayswan_request_conversation" not in (request_data.get("metadata") or {})
+
+    await grayswan_guardrail.apply_guardrail(
+        inputs={"texts": ["done"]},
+        request_data=request_data,
+        input_type="response",
+    )
+    assert _wire(captured["payload"])["messages"] == [{"role": "assistant", "content": "done"}]
 
 
 @pytest.mark.asyncio
@@ -720,23 +753,15 @@ async def test_apply_guardrail_scans_tool_call_only_response(
     monkeypatch.setattr(grayswan_guardrail, "_call_grayswan_api", _fake_call)
 
     response_tool_calls = [{"id": "call_2", "type": "function", "function": {"name": "run", "arguments": "{}"}}]
-    request_data: dict = {"model": "gpt-4"}
 
     await grayswan_guardrail.apply_guardrail(
-        inputs={"texts": ["go"], "structured_messages": [{"role": "user", "content": "go"}]},
-        request_data=request_data,
-        input_type="request",
-    )
-    await grayswan_guardrail.apply_guardrail(
         inputs={"texts": [], "tool_calls": response_tool_calls},
-        request_data=request_data,
+        request_data={"model": "gpt-4"},
         input_type="response",
     )
 
     wire = _wire(captured["payload"])
-    assert wire["messages"][0] == {"role": "user", "content": "go"}
-    assert wire["messages"][-1]["tool_calls"] == response_tool_calls
-    assert wire["messages"][-1]["content"] == ""
+    assert wire["messages"] == [{"role": "assistant", "content": "", "tool_calls": response_tool_calls}]
 
 
 @pytest.mark.asyncio
@@ -795,20 +820,14 @@ async def test_apply_guardrail_empty_response_is_not_scanned(
 
     monkeypatch.setattr(grayswan_guardrail, "_call_grayswan_api", _fake_call)
 
-    request_data: dict = {"model": "gpt-4"}
-    await grayswan_guardrail.apply_guardrail(
-        inputs={"texts": ["go"], "structured_messages": [{"role": "user", "content": "go"}]},
-        request_data=request_data,
-        input_type="request",
-    )
     inputs: dict = {"texts": []}
     result = await grayswan_guardrail.apply_guardrail(
         inputs=inputs,
-        request_data=request_data,
+        request_data={"model": "gpt-4"},
         input_type="response",
     )
 
-    assert len(calls) == 1
+    assert len(calls) == 0
     assert result is inputs
 
 
@@ -824,19 +843,13 @@ async def test_apply_guardrail_multiple_response_texts_get_separate_turns(
 
     monkeypatch.setattr(grayswan_guardrail, "_call_grayswan_api", _fake_call)
 
-    request_data: dict = {"model": "gpt-4"}
-    await grayswan_guardrail.apply_guardrail(
-        inputs={"texts": ["pick one"], "structured_messages": [{"role": "user", "content": "pick one"}]},
-        request_data=request_data,
-        input_type="request",
-    )
     await grayswan_guardrail.apply_guardrail(
         inputs={"texts": ["candidate one", "candidate two"]},
-        request_data=request_data,
+        request_data={"model": "gpt-4"},
         input_type="response",
     )
 
-    assert _wire(captured["payload"])["messages"][-2:] == [
+    assert _wire(captured["payload"])["messages"] == [
         {"role": "assistant", "content": "candidate one"},
         {"role": "assistant", "content": "candidate two"},
     ]

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_grayswan.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_grayswan.py
@@ -897,3 +897,29 @@ def test_sanitize_json_list_drops_non_dict_items(grayswan_guardrail: GraySwanGua
     assert grayswan_guardrail._sanitize_json_list([{"role": "user", "content": "hi"}, "junk", 3]) == (
         {"role": "user", "content": "hi"},
     )
+
+
+@pytest.mark.asyncio
+async def test_apply_guardrail_scans_despite_null_dynamic_extra_body(
+    monkeypatch, grayswan_guardrail: GraySwanGuardrail
+) -> None:
+    """A client-sent null extra_body must not crash payload construction, which
+    fail_open would turn into a silently skipped scan."""
+    captured: dict = {}
+
+    async def _fake_call(payload: dict):
+        captured["payload"] = payload
+        return {"violation": 0.0}
+
+    monkeypatch.setattr(grayswan_guardrail, "_call_grayswan_api", _fake_call)
+
+    await grayswan_guardrail.apply_guardrail(
+        inputs={"texts": ["hello"]},
+        request_data={
+            "model": "gpt-4",
+            "metadata": {"guardrails": [{"grayswan-test": {"extra_body": None}}]},
+        },
+        input_type="request",
+    )
+
+    assert _wire(captured["payload"])["messages"] == [{"role": "user", "content": "hello"}]

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_grayswan.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_grayswan.py
@@ -1,3 +1,4 @@
+import json
 from typing import Optional
 
 import pytest
@@ -596,6 +597,11 @@ def test_ensure_litellm_metadata_noop_when_already_present() -> None:
     assert data["litellm_metadata"] == {"existing": "value"}
 
 
+def _wire(payload: dict) -> dict:
+    """The JSON wire form of a monitor payload, as the Cygnal API receives it."""
+    return json.loads(json.dumps(payload))
+
+
 @pytest.mark.asyncio
 async def test_apply_guardrail_sends_structured_conversation_with_tools(
     monkeypatch, grayswan_guardrail: GraySwanGuardrail
@@ -632,8 +638,9 @@ async def test_apply_guardrail_sends_structured_conversation_with_tools(
         input_type="request",
     )
 
-    assert captured["payload"]["messages"] == structured_messages
-    assert captured["payload"]["tools"] == tools
+    wire = _wire(captured["payload"])
+    assert wire["messages"] == structured_messages
+    assert wire["tools"] == tools
 
 
 @pytest.mark.asyncio
@@ -654,7 +661,7 @@ async def test_apply_guardrail_scans_texts_not_raw_messages(monkeypatch, grayswa
         input_type="request",
     )
 
-    assert captured["payload"]["messages"] == [{"role": "user", "content": "scan exactly this"}]
+    assert _wire(captured["payload"])["messages"] == [{"role": "user", "content": "scan exactly this"}]
     assert "tools" not in captured["payload"]
 
 
@@ -691,8 +698,9 @@ async def test_apply_guardrail_response_appends_assistant_turn_with_tool_calls(
         input_type="response",
     )
 
-    assert captured["payload"]["messages"][:-1] == structured_messages
-    assert captured["payload"]["messages"][-1] == {
+    wire = _wire(captured["payload"])
+    assert wire["messages"][:-1] == structured_messages
+    assert wire["messages"][-1] == {
         "role": "assistant",
         "content": "sure, writing it now",
         "tool_calls": response_tool_calls,
@@ -725,9 +733,10 @@ async def test_apply_guardrail_scans_tool_call_only_response(
         input_type="response",
     )
 
-    assert captured["payload"]["messages"][0] == {"role": "user", "content": "go"}
-    assert captured["payload"]["messages"][-1]["tool_calls"] == response_tool_calls
-    assert captured["payload"]["messages"][-1]["content"] == ""
+    wire = _wire(captured["payload"])
+    assert wire["messages"][0] == {"role": "user", "content": "go"}
+    assert wire["messages"][-1]["tool_calls"] == response_tool_calls
+    assert wire["messages"][-1]["content"] == ""
 
 
 @pytest.mark.asyncio
@@ -748,7 +757,7 @@ async def test_apply_guardrail_wraps_texts_when_no_conversation_available(
         input_type="request",
     )
 
-    assert captured["payload"]["messages"] == [{"role": "user", "content": "a prompt for an image"}]
+    assert _wire(captured["payload"])["messages"] == [{"role": "user", "content": "a prompt for an image"}]
     assert "tools" not in captured["payload"]
 
 
@@ -770,7 +779,7 @@ async def test_apply_guardrail_response_without_request_scan_wraps_texts(
         input_type="response",
     )
 
-    assert captured["payload"]["messages"] == [{"role": "assistant", "content": "a model reply"}]
+    assert _wire(captured["payload"])["messages"] == [{"role": "assistant", "content": "a model reply"}]
     assert "tools" not in captured["payload"]
 
 
@@ -827,7 +836,7 @@ async def test_apply_guardrail_multiple_response_texts_get_separate_turns(
         input_type="response",
     )
 
-    assert captured["payload"]["messages"][-2:] == [
+    assert _wire(captured["payload"])["messages"][-2:] == [
         {"role": "assistant", "content": "candidate one"},
         {"role": "assistant", "content": "candidate two"},
     ]
@@ -872,6 +881,6 @@ async def test_apply_guardrail_build_error_fails_open(monkeypatch, grayswan_guar
 
 
 def test_sanitize_json_list_drops_non_dict_items(grayswan_guardrail: GraySwanGuardrail) -> None:
-    assert grayswan_guardrail._sanitize_json_list([{"role": "user", "content": "hi"}, "junk", 3]) == [
-        {"role": "user", "content": "hi"}
-    ]
+    assert grayswan_guardrail._sanitize_json_list([{"role": "user", "content": "hi"}, "junk", 3]) == (
+        {"role": "user", "content": "hi"},
+    )

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_hiddenlayer.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_hiddenlayer.py
@@ -1098,3 +1098,37 @@ class TestHiddenlayerGuardrailV2:
         config_model = HiddenlayerGuardrailV2.get_config_model()
         assert config_model is not None
         assert config_model.__name__ == "HiddenlayerGuardrailConfigModel"
+
+
+class TestHiddenlayerResponseScanConversation:
+    @pytest.mark.asyncio
+    async def test_response_scan_ignores_structured_messages(self, monkeypatch):
+        """Response scans now carry the conversation in structured_messages; the
+        v1 guardrail must keep scanning texts instead of str()-coercing the last
+        conversation turn (a tool-call-only turn has content None, and scanning
+        the literal string 'None' would produce junk verdicts)."""
+        monkeypatch.setenv("HIDDENLAYER_API_BASE", "https://my.hiddenlayer")
+        guardrail = HiddenlayerGuardrail(
+            guardrail_name="hiddenlayer", event_hook="post_call", default_on=True
+        )
+
+        async def scan(project_id, metadata, payload, input_type):
+            if payload["messages"][-1]["content"] == "None":
+                return {"evaluation": {"action": "BLOCK"}, "analysis": []}
+            return {}
+
+        inputs = GenericGuardrailAPIInputs(
+            structured_messages=[
+                {"role": "user", "content": "look this up"},
+                {"role": "assistant", "content": None},
+            ]
+        )
+
+        with patch.object(guardrail, "_call_hiddenlayer", side_effect=scan):
+            result = await guardrail.apply_guardrail(
+                inputs=inputs,
+                request_data={},
+                input_type="response",
+            )
+
+        assert result is inputs

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_promptguard.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_promptguard.py
@@ -815,3 +815,46 @@ class TestPromptGuardInitializer:
         from litellm.types.guardrails import SupportedGuardrailIntegrations
 
         assert SupportedGuardrailIntegrations.PROMPTGUARD.value == "promptguard"
+
+
+class TestPromptGuardResponseScanIgnoresConversation:
+    @pytest.mark.asyncio
+    async def test_response_scan_sends_texts_and_redacts_them(
+        self, promptguard_guardrail, mock_request_data
+    ):
+        """A response scan now carries the conversation in structured_messages,
+        but PromptGuard must keep scanning the response texts: sending the
+        conversation would make the user-role redact write-back clobber the
+        response texts with request content."""
+        resp = _make_response(
+            {
+                "decision": "redact",
+                "event_id": "evt-007",
+                "confidence": 0.99,
+                "threat_type": "pii_detected",
+                "redacted_messages": [
+                    {"role": "user", "content": "Your SSN is *********"}
+                ],
+                "threats": [],
+                "latency_ms": 50.0,
+            }
+        )
+        with patch.object(
+            promptguard_guardrail.async_handler, "post", return_value=resp
+        ) as mock_post:
+            result = await promptguard_guardrail.apply_guardrail(
+                inputs={
+                    "texts": ["Your SSN is 123-45-6789"],
+                    "structured_messages": [
+                        {"role": "user", "content": "what's my SSN?"},
+                        {"role": "assistant", "content": "Your SSN is 123-45-6789"},
+                    ],
+                },
+                request_data=mock_request_data,
+                input_type="response",
+            )
+            sent_messages = mock_post.call_args.kwargs["json"]["messages"]
+            assert sent_messages == [
+                {"role": "user", "content": "Your SSN is 123-45-6789"}
+            ]
+            assert result["texts"] == ["Your SSN is *********"]

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_qualifire.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_qualifire.py
@@ -679,3 +679,49 @@ class TestQualifireGuardrailRegistry:
 
         assert "qualifire" in guardrail_class_registry
         assert guardrail_class_registry["qualifire"] == QualifireGuardrail
+
+
+class TestQualifireResponseScanConversation:
+    @pytest.mark.asyncio
+    async def test_response_scan_keeps_request_messages_out_of_conversation(self):
+        """Response scans now receive the whole conversation in structured_messages;
+        Qualifire must keep sending the request messages plus a separate output,
+        not a conversation that already embeds the model's answer."""
+        from litellm.proxy.guardrails.guardrail_hooks.qualifire.qualifire import (
+            QualifireGuardrail,
+        )
+
+        guardrail = QualifireGuardrail(
+            api_key="test_key",
+            prompt_injections=True,
+            guardrail_name="test_guardrail",
+        )
+
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "score": 100,
+            "status": "completed",
+            "evaluationResults": [],
+        }
+        mock_response.raise_for_status = MagicMock()
+        guardrail.async_handler.post = AsyncMock(return_value=mock_response)
+
+        request_messages = [{"role": "user", "content": "what's my balance?"}]
+        inputs = {
+            "texts": ["Your balance is $5"],
+            "structured_messages": request_messages
+            + [{"role": "assistant", "content": "Your balance is $5"}],
+        }
+
+        result = await guardrail.apply_guardrail(
+            inputs=inputs,
+            request_data={"messages": request_messages},
+            input_type="response",
+        )
+
+        assert result is inputs
+        payload = guardrail.async_handler.post.call_args[1]["json"]
+        assert all(m.get("role") != "assistant" for m in payload["messages"]), (
+            "the model's answer belongs in `output`, not in the conversation"
+        )
+        assert payload["output"] == "Your balance is $5"


### PR DESCRIPTION
## TLDR

Problem this solves:

- Conversation guardrails see only flat response texts on post-call scans
- Caching request context in metadata is fragile and hook-order coupled

How it solves it:

- Chat, Anthropic, and Responses handlers build the response-scan conversation
- `structured_messages` = scoped request conversation + response turns, plus `tools`
- Gray Swan guardrail consumes it and drops its metadata cache

## User Flow

Before: a proxy admin running a conversation-context guardrail on responses gets verdicts based on the model reply alone, with no dialogue context

1. They configure the guardrail with `mode: [pre_call, post_call]` and send POST https://litellm-domain/v1/chat/completions with a system prompt, a user question, and tools
2. The pre-call scan receives the whole conversation and the tool definitions
3. The post-call scan receives only the assistant reply text, so a reply that is only harmful in context passes clean
4. The response comes back 200 with the unflagged reply

After: the same request gives the response scan the same conversation the request scan saw, with the model reply appended

1. They send the same POST https://litellm-domain/v1/chat/completions with the same system prompt, user question, and tools
2. The pre-call scan receives the whole conversation and the tool definitions
3. The post-call scan now receives that same conversation with the assistant reply appended, plus the tool definitions, and can judge the reply in context
4. A reply that violates policy in context now comes back flagged; a benign one still returns 200

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Setup: proxy started with `python litellm/proxy/proxy_cli.py --config proof_config.yaml --port 4000`, where the config enables the grayswan guardrail with `mode: [pre_call, post_call]` and `on_flagged_action: monitor`. The Cygnal monitor endpoint is a local logging stub and the model deployments use `mock_response`, because this workstation holds no provider or Cygnal credentials; each run below shows the exact response-scan monitor payload the proxy sent, captured from the stub's request log. Both runs use these two curls

```
curl http://127.0.0.1:4000/chat/completions -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" -d '{"model": "gpt-4o", "messages": [{"role": "system", "content": "You are a weather assistant."}, {"role": "user", "content": "What is the weather in Paris?"}], "tools": [{"type": "function", "function": {"name": "get_weather", "parameters": {"type": "object", "properties": {"city": {"type": "string"}}}}}]}'

curl http://127.0.0.1:4000/v1/messages -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" -d '{"model": "claude-sonnet", "max_tokens": 100, "system": "You are a weather assistant.", "messages": [{"role": "user", "content": "What is the weather in Paris?"}], "tools": [{"name": "get_weather", "description": "look up weather", "input_schema": {"type": "object", "properties": {"city": {"type": "string"}}}}]}'
```

### Before (ff02d5cfc0)

#### /v1/chat/completions

1. Run the chat completions curl above
2. Response-scan monitor payload carries a bare assistant turn, no conversation, no tools:

```json
{"messages": [{"role": "assistant", "content": "It is sunny in Paris today."}]}
```

#### /v1/messages

1. Run the messages curl above
2. Same bare assistant turn:

```json
{"messages": [{"role": "assistant", "content": "It is sunny in Paris today."}]}
```

### After (cc71f33fad)

#### /v1/chat/completions

1. Run the chat completions curl above
2. Response-scan monitor payload now carries the full dialogue and the tool definitions:

```json
{"messages": [{"role": "system", "content": "You are a weather assistant."}, {"role": "user", "content": "What is the weather in Paris?"}, {"role": "assistant", "content": "It is sunny in Paris today."}], "tools": [{"type": "function", "function": {"name": "get_weather", "parameters": {"type": "object", "properties": {"city": {"type": "string"}}}}}]}
```

#### /v1/messages

1. Run the messages curl above
2. Response-scan monitor payload now carries the hoisted system prompt, the dialogue, and the tools translated to function shape:

```json
{"messages": [{"role": "system", "content": "You are a weather assistant."}, {"role": "user", "content": "What is the weather in Paris?"}, {"role": "assistant", "content": "It is sunny in Paris today."}], "tools": [{"type": "function", "function": {"name": "get_weather", "description": "look up weather", "parameters": {"type": "object", "properties": {"city": {"type": "string"}}}}}]}
```

## Type

🆕 New Feature
🧹 Refactoring

## Caveats (if any)

- Behavior change: response scans see the request after pre-call guardrail mutations, which is what the model received
- Generic guardrail API servers now also receive `structured_messages` on response scans, alongside `input_type`
- In-repo guardrails that assumed request-only `structured_messages` are gated: moderation, PromptGuard, Akto, Qualifire, HiddenLayer v1
- Proof uses mock model responses and a Cygnal logging stub; no provider or Cygnal keys on this machine

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
