### PR TITLE
fix(proxy): preserve null team_id keys when exclude_team_id is set (#37292)

### DIFF
--- a/litellm/proxy/management_endpoints/key_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/key_management_endpoints.py
@@ -5911,7 +5911,10 @@ def _build_key_filter_conditions(
         else:
             user_condition["user_id"] = user_id
     if exclude_team_id and isinstance(exclude_team_id, str):
-        user_condition["team_id"] = {"not": exclude_team_id}
+        user_condition["OR"] = [
+            {"team_id": None},
+            {"team_id": {"not": exclude_team_id}},
+        ]
     if organization_id and isinstance(organization_id, str):
         user_condition["organization_id"] = organization_id
 

--- a/tests/test_litellm/proxy/management_endpoints/test_key_management_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_key_management_endpoints.py
@@ -36,6 +36,7 @@ from litellm.proxy.auth.auth_checks import _project_cache_key
 from litellm.proxy.auth.user_api_key_auth import UserAPIKeyAuth
 from litellm.proxy.common_utils.user_api_key_cache import UserApiKeyCache
 from litellm.proxy.management_endpoints.key_management_endpoints import (
+    _build_key_filter_conditions,
     _check_org_key_limits,
     _check_project_key_limits,
     _check_team_key_limits,
@@ -245,11 +246,14 @@ async def test_list_keys_include_created_by_keys():
         elif "created_by" in condition:
             created_by_condition_with_exclude = condition
 
-    # Verify exclude_team_id is applied to user condition
+    # Verify exclude_team_id produces an OR clause that preserves NULL team_id rows
     assert (
         user_condition_with_exclude is not None
     ), "User condition with exclude should be present"
-    assert user_condition_with_exclude["team_id"] == {"not": "excluded-team-123"}
+    assert user_condition_with_exclude["OR"] == [
+        {"team_id": None},
+        {"team_id": {"not": "excluded-team-123"}},
+    ]
 
     # Verify created_by condition still only has created_by filter
     assert (
@@ -257,6 +261,73 @@ async def test_list_keys_include_created_by_keys():
     ), "Created by condition with exclude should be present"
     assert created_by_condition_with_exclude["created_by"] == test_user_id
     assert len(created_by_condition_with_exclude) == 1
+
+
+def test_build_key_filter_conditions_exclude_team_id_preserves_null():
+    """
+    Regression test for #37292: _build_key_filter_conditions must emit an OR
+    clause that retains keys where team_id IS NULL when exclude_team_id is set.
+
+    In SQL, `team_id != 'x'` silently drops rows where team_id is NULL because
+    NULL comparisons evaluate to UNKNOWN (neither TRUE nor FALSE). The fix
+    wraps the condition as OR([{team_id: None}, {team_id: {not: exclude_team_id}}])
+    so that unassigned-team keys are always included.
+    """
+    # Case 1: no user_id (matches the Prometheus metrics caller path)
+    cond = _build_key_filter_conditions(
+        user_id=None,
+        team_id=None,
+        organization_id=None,
+        key_alias=None,
+        key_hash=None,
+        exclude_team_id="litellm-dashboard",
+        admin_team_ids=None,
+    )
+    assert "OR" in cond, "Expected OR key when exclude_team_id is set"
+    assert {"team_id": None} in cond["OR"], (
+        "NULL team_id branch must be present so unassigned keys are not silently dropped"
+    )
+    assert {"team_id": {"not": "litellm-dashboard"}} in cond["OR"]
+
+    # Case 2: user_id provided alongside exclude_team_id
+    cond2 = _build_key_filter_conditions(
+        user_id="user-abc",
+        team_id=None,
+        organization_id=None,
+        key_alias=None,
+        key_hash=None,
+        exclude_team_id="excluded-team",
+        admin_team_ids=None,
+    )
+    assert cond2.get("user_id") == "user-abc"
+    assert cond2.get("OR") == [
+        {"team_id": None},
+        {"team_id": {"not": "excluded-team"}},
+    ]
+
+    # Case 3: exclude_team_id absent — user_id is set directly, no exclude_team_id OR injected.
+    # The top-level OR from _get_condition_to_filter_out_ui_session_tokens is always present;
+    # we assert that user_id appears as a direct key and that no exclude_team_id NOT pattern
+    # exists inside any OR list.
+    cond3 = _build_key_filter_conditions(
+        user_id="user-abc",
+        team_id=None,
+        organization_id=None,
+        key_alias=None,
+        key_hash=None,
+        exclude_team_id=None,
+        admin_team_ids=None,
+    )
+    assert cond3.get("user_id") == "user-abc", (
+        "user_id should be a direct top-level key when no exclude_team_id"
+    )
+    # Verify no exclude_team_id NOT pattern was injected (the only OR should be the
+    # session token filter, which doesn't have {team_id: {not: ...}} entries)
+    top_or = cond3.get("OR", [])
+    assert not any(
+        isinstance(c, dict) and c.get("team_id", {}) == {"not": "any-value"}
+        for c in top_or
+    ), "No {team_id: {not: ...}} pattern should appear when exclude_team_id is absent"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## TLDR

Problem this solves:

- `prometheus_initialize_budget_metrics` emits no spend metrics for API keys with `team_id = NULL`
- SQL `team_id != 'litellm-dashboard'` silently drops rows where `team_id IS NULL` (SQL 3-valued logic)

How it solves it:

- Replace `{team_id: {not: exclude_team_id}}` with `OR([{team_id: None}, {team_id: {not: exclude_team_id}}])`
- Unassigned-team keys now pass the filter alongside keys on other teams

## User Flow

Before: a LiteLLM operator who creates API keys without assigning them to a team sees no budget metrics for those keys in Prometheus

1. They create a key via `POST https://litellm-domain/key/generate` with no `team_id` field — key is stored with `team_id = NULL`
2. They enable `prometheus_initialize_budget_metrics: true` and scrape `https://litellm-domain/metrics`
3. They observe zero `litellm_remaining_api_key_budget_metric` / `litellm_api_key_budget_remaining_hours_metric` series for all their null-team keys — the keys exist in the DB but are invisible to Prometheus

After: the same keys appear in Prometheus metrics immediately after enabling the feature

1. They create a key via `POST https://litellm-domain/key/generate` with no `team_id` field
2. They enable `prometheus_initialize_budget_metrics: true` and scrape `https://litellm-domain/metrics`
3. `litellm_remaining_api_key_budget_metric` and related series are emitted for every null-team key alongside team-assigned keys

## Relevant issues

Fixes #37292

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/proxy/management_endpoints/test_key_management_endpoints.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

### Before (upstream/main — pre-patch)

1. `_build_key_filter_conditions(user_id=None, exclude_team_id="litellm-dashboard", ...)` produced `{team_id: {not: "litellm-dashboard"}}` in the Prisma WHERE clause
2. In SQL this translates to `WHERE team_id != 'litellm-dashboard'`
3. SQL NULL semantics: `NULL != 'litellm-dashboard'` → `UNKNOWN` (not TRUE), so rows with `team_id IS NULL` were silently excluded

### After (911b1bcdf55a12e3945120a88c30578f9a8dbb10)

1. `_build_key_filter_conditions(user_id=None, exclude_team_id="litellm-dashboard", ...)` now produces `{OR: [{team_id: None}, {team_id: {not: "litellm-dashboard"}}]}`
2. In Prisma this translates to `WHERE (team_id IS NULL OR team_id != 'litellm-dashboard')`
3. All null-team keys are now included in the result set

**Test run output (all tests in the file, 12 targeted):**

```
collected 444 items / 432 deselected / 12 selected

test_build_key_filter_conditions_active_applies_gte_and_null PASSED        [  8%]
test_build_key_filter_conditions_agent_id_narrows_visibility PASSED        [ 16%]
test_build_key_filter_conditions_exclude_team_id_preserves_null PASSED     [ 25%]
test_build_key_filter_conditions_expired_applies_lt_clause PASSED          [ 33%]
test_build_key_filter_conditions_expires_now_is_call_time_utc PASSED       [ 41%]
test_build_key_filter_conditions_full_visibility_team_includes_service_accounts PASSED [ 50%]
test_build_key_filter_conditions_invalid_expires_filter_omits_clause PASSED [ 58%]
test_build_key_filter_conditions_key_alias_narrows_team_admin_visibility PASSED [ 66%]
test_build_key_filter_conditions_key_hash_narrows_team_admin_visibility PASSED [ 75%]
test_build_key_filter_conditions_member_only_team_restricts_to_service_accounts PASSED [ 83%]
test_build_key_filter_conditions_no_expires_filter_omits_clause PASSED     [ 91%]
test_list_keys_include_created_by_keys PASSED                              [100%]

============== 12 passed, 432 deselected, 71 warnings in 19.67s ===============
```

## Type

🐛 Bug Fix

## Caveats (if any)

- The `OR` condition replaces the former simple `{not: ...}` at the same precedence level inside the `user_condition` dict — no impact on any other filter path (team_id, organization_id, key_alias, etc.)

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
