### PR TITLE
fix(proxy): let llm_api keys read /model_group/info

### DIFF
--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -567,10 +567,6 @@ class LiteLLMRoutes(enum.Enum):
         "/v1/model/info",
     ]
 
-    model_group_info_routes = [
-        "/model_group/info",
-    ]
-
     llm_api_routes = (
         openai_routes
         + anthropic_routes
@@ -582,7 +578,7 @@ class LiteLLMRoutes(enum.Enum):
         + litellm_native_routes
         + list(agent_inference_routes)
         + model_info_routes
-        + model_group_info_routes
+        + ["/model_group/info"]
     )
     info_routes = [
         "/key/info",

--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -567,6 +567,10 @@ class LiteLLMRoutes(enum.Enum):
         "/v1/model/info",
     ]
 
+    model_group_info_routes = [
+        "/model_group/info",
+    ]
+
     llm_api_routes = (
         openai_routes
         + anthropic_routes
@@ -578,6 +582,7 @@ class LiteLLMRoutes(enum.Enum):
         + litellm_native_routes
         + list(agent_inference_routes)
         + model_info_routes
+        + model_group_info_routes
     )
     info_routes = [
         "/key/info",

--- a/tests/test_litellm/proxy/auth/test_route_checks.py
+++ b/tests/test_litellm/proxy/auth/test_route_checks.py
@@ -527,9 +527,31 @@ def test_virtual_key_llm_api_routes_allows_model_info(route):
     assert result is True
 
 
-@pytest.mark.parametrize("route", ["/model/info", "/v1/model/info"])
+@pytest.mark.parametrize("route", ["/model_group/info"])
+def test_virtual_key_llm_api_routes_allows_model_group_info(route):
+    """AI API virtual keys must be able to read group-level model metadata
+    (pricing, mode, context window) for the groups they can already call.
+    The handler scopes its response to the caller's model access and returns
+    no api_base or credentials.
+    """
+
+    valid_token = UserAPIKeyAuth(
+        user_id="test_user",
+        allowed_routes=["llm_api_routes"],
+    )
+
+    result = RouteChecks.is_virtual_key_allowed_to_call_route(
+        route=route,
+        valid_token=valid_token,
+        request=_mock_request("GET"),
+    )
+
+    assert result is True
+
+
+@pytest.mark.parametrize("route", ["/model/info", "/v1/model/info", "/model_group/info"])
 def test_model_info_not_classified_as_llm_api(route):
-    """Membership in `llm_api_routes` must not promote /model/info to an
+    """Membership in `llm_api_routes` must not promote model-metadata reads to an
     `is_llm_api_route()`. That predicate gates DISABLE_LLM_API_ENDPOINTS,
     global/virtual-key budget enforcement, enforce_user_param and the JWT
     x-litellm-team-id attachment; model metadata is a free read and must stay
@@ -539,10 +561,10 @@ def test_model_info_not_classified_as_llm_api(route):
     assert RouteChecks.is_llm_api_route(route=route) is False
 
 
-@pytest.mark.parametrize("route", ["/v2/model/info", "/model_group/info"])
+@pytest.mark.parametrize("route", ["/v2/model/info"])
 def test_virtual_key_llm_api_routes_denies_other_model_info_routes(route):
-    """The grant is scoped to the two /model/info paths. The paginated Admin UI
-    listing and the model-group endpoint stay outside it.
+    """The grant covers /model_group/info (group-level metadata scoped to the
+    caller's model access) but not the paginated Admin UI deployment listing.
     """
 
     valid_token = UserAPIKeyAuth(


### PR DESCRIPTION
## TLDR

Problem this solves:

- llm_api keys get 403 reading /model_group/info
- A key that can call models cannot see pricing, mode or context limits

How it solves it:

- Adds /model_group/info to the llm_api_routes group
- New model_group_info_routes member keeps is_llm_api_route() unchanged
- Budget reservation and cost tracking behavior stays exactly as before

## User Flow

Before: a developer whose OpenAI-compatible client discovers pricing and limits from /model_group/info gets denied on every metadata read while model calls work

1. The admin creates a scoped key: POST http://localhost:4000/key/generate with `{"key_type": "llm_api"}`
2. The developer sends GET http://localhost:4000/model_group/info with that key
3. The gateway answers 403: "Virtual key is not allowed to call this route. Only allowed to call routes: ['llm_api_routes']. Tried to call route: /model_group/info"
4. GET /v1/models on the same key returns 200, so discovery stops halfway: model names without limits or prices

After: the same request succeeds and returns the group metadata

1. The admin creates the identical POST http://localhost:4000/key/generate key
2. The developer sends the same GET http://localhost:4000/model_group/info
3. The gateway answers 200 with data[] entries carrying input/output cost per token, mode, max_input_tokens, max_output_tokens and supported OpenAI params for each group the key can call
4. GET /v2/model/info on the same key still returns 403, so another user holding only this key gains no access to the Admin UI deployment listing; POST /model/new also stays 403

## Relevant issues

Fixes #37810

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Shared setup: Postgres on localhost:5432, config below, proxy started per commit with `python litellm/proxy/proxy_cli.py --config config.yaml --port <port> --detailed_debug`, master key sk-e2e-1234

```yaml
model_list:
  - model_name: gpt-4o-mini
    litellm_params:
      model: openai/gpt-4o-mini
      api_key: os.environ/OPENAI_API_KEY

general_settings:
  master_key: sk-e2e-1234
```

### Before (b9bff0998c)

1. Create the key:
```
curl -s -X POST http://127.0.0.1:4001/key/generate -H "Authorization: Bearer sk-e2e-1234" -H 'Content-Type: application/json' -d '{"key_type":"llm_api","key_alias":"repro-before"}'
```
2. Confirm the applied preset (GET /key/info): `{"key_type": "llm_api", "allowed_routes": ["llm_api_routes"]}`
3. Hit the routes with this key:
```
for r in /v1/model/info /model/info /v2/model/info /model_group/info /v1/models; do
  printf '%-20s %s\n' "$r" "$(curl -s -o /dev/null -w '%{http_code}' -H "Authorization: Bearer $KEY" http://127.0.0.1:4001$r)"
done
```
Output:
```
/v1/model/info       200
/model/info          200
/v2/model/info       403
/model_group/info    403
/v1/models           200
```
4. Body of the denied /model_group/info response:
```
{"detail":"Virtual key is not allowed to call this route. Only allowed to call routes: ['llm_api_routes']. Tried to call route: /model_group/info"}
```

### After (f54c630064)

Same steps against the same database and config, port 4002:

1. Create the key, confirm the preset: `{"key_type": "llm_api", "allowed_routes": ["llm_api_routes"]}`
2. Route sweep output:
```
/v1/model/info       200
/model/info          200
/v2/model/info       403
/model_group/info    200
/v1/models           200
```
3. The granted response carries group-level metadata only, no api_base and no credentials:
```
{"data":[{"model_group":"gpt-4o-mini","providers":["openai"],"max_input_tokens":128000.0,"max_output_tokens":16384.0,"input_cost_per_token":1.5e-07,"output_cost_per_token":6e-07,"mode":"chat",...}]}
```
4. Writes stay denied for the same key: POST /model/new returns 403, GET /v2/model/info returns 403

## Type

🐛 Bug Fix

## Caveats (if any)

- /v2/model/info intentionally stays outside llm_api_routes, matching the scope recorded in commit 7d6ee2a9c

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR