### PR TITLE
chore(codeowners): add yuneng-berri as owner of the CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,3 +4,4 @@
 /model_prices_and_context_window.json @mateo-berri
 /litellm/model_prices_and_context_window_backup.json @mateo-berri
 /litellm-proxy-extras/litellm_proxy_extras/migrations/ @yuneng-berri @ryan-crabbe-berri
+/.github/CODEOWNERS @yuneng-berri


### PR DESCRIPTION
## TLDR

Problem this solves:

- CODEOWNERS itself has no owner listed
- Ownership of other paths can be changed without an owner seeing it

How it solves it:

- Adds `/.github/CODEOWNERS @yuneng-berri`
- Placed last, so no later rule can override it

## User Flow

Before: a contributor who edits `.github/CODEOWNERS` gets no code owner attached, so a change to who owns `/ui/` or the migrations folder can go through without any of those owners looking at it

1. They open a PR against `litellm_internal_staging` that edits `.github/CODEOWNERS`
2. The Reviewers box on the PR shows no code owner for that file
3. Any approval merges it, and the ownership rules for every other path are now whatever the PR made them

After: the same PR automatically pulls in @yuneng-berri, so ownership changes are seen by an owner

1. They open the same PR against `litellm_internal_staging` that edits `.github/CODEOWNERS`
2. The Reviewers box now lists @yuneng-berri, added automatically and labeled as code owner
3. Steps 1 and 2 are unchanged for every other file in the repo, since no existing rule matched this path before

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have added meaningful tests
- [ ] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

There is no proxy route or LLM call to exercise here, so the end-to-end check is GitHub's own CODEOWNERS resolver reading the file off each ref, which is exactly what decides reviewer assignment

### Before (6a0d03914c)

1. Look for a rule covering the CODEOWNERS file itself

```
$ gh api "repos/BerriAI/litellm/contents/.github/CODEOWNERS?ref=litellm_internal_staging" --jq '.content' | base64 -d | grep -n 'CODEOWNERS'
(no rule matching .github/CODEOWNERS)
```

2. Confirm the file parses cleanly, so the absence above is a real gap and not a broken file

```
$ gh api "repos/BerriAI/litellm/codeowners/errors?ref=litellm_internal_staging" --jq '.errors'
[]
```

### After (71b69a91dd)

1. The rule is now present, on the last line

```
$ gh api "repos/BerriAI/litellm/contents/.github/CODEOWNERS?ref=litellm_/remote-staging-sync-294a37" --jq '.content' | base64 -d | grep -n 'CODEOWNERS'
7:/.github/CODEOWNERS @yuneng-berri
```

2. GitHub still parses the file with zero errors, so the new owner resolves

```
$ gh api "repos/BerriAI/litellm/codeowners/errors?ref=litellm_/remote-staging-sync-294a37" --jq '.errors'
[]
```

## Type

🚄 Infrastructure

## Caveats (if any)

- No tests: CODEOWNERS is config GitHub parses, not code we run
- Only blocks merges if the branch requires Code Owner review
- Line 3 un-owns `schema.d.ts` and is left as is
