### PR TITLE
fix(proxy): keep a failed prisma generate from failing the migration entrypoint

### DIFF
--- a/.github/workflows/image-scan.yml
+++ b/.github/workflows/image-scan.yml
@@ -17,6 +17,8 @@ on:
       - backend/Dockerfile
       - backend/main.py
       - docker/component_entrypoint.sh
+      - docker/entrypoint.sh
+      - litellm/proxy/prisma_migration.py
       - litellm-proxy-extras/**
       - tests/proxy_migration_tests/**
       - uv.lock

--- a/litellm/proxy/prisma_migration.py
+++ b/litellm/proxy/prisma_migration.py
@@ -1,8 +1,9 @@
 """Standalone entrypoint for applying database migrations and generating the Prisma client.
 
-The entrypoint enforces migration failures by default. Set
-ENFORCE_PRISMA_MIGRATION_CHECK=false to preserve log-only behavior for migration and
-Prisma generate failures.
+Migration failures fail the entrypoint by default; set ENFORCE_PRISMA_MIGRATION_CHECK=false
+for log-only behavior. A failed 'prisma generate' is always log-only: every shipped image
+bakes the client at build time, and refreshing it writes into site-packages, which an
+arbitrary non-root uid or a read-only root filesystem cannot do.
 """
 
 import os
@@ -30,13 +31,13 @@ def main() -> int:
     verbose_proxy_logger.info("Running 'prisma generate'...")
     result: Final = subprocess.run(("prisma", "generate"), capture_output=True, text=True)
     verbose_proxy_logger.info("'prisma generate' stdout: %s", result.stdout)
-    exit_code: Final = result.returncode
 
-    if exit_code != 0:
-        verbose_proxy_logger.info("'prisma generate' failed with exit code %s.", exit_code)
-        verbose_proxy_logger.error("'prisma generate' stderr: %s", result.stderr)
-        if enforce_prisma_migration_check:
-            return exit_code
+    if result.returncode != 0:
+        verbose_proxy_logger.warning(
+            "'prisma generate' exited %s; continuing with the client baked at image build time. stderr: %s",
+            result.returncode,
+            result.stderr,
+        )
     return 0
 
 

--- a/tests/test_litellm/proxy/test_prisma_migration.py
+++ b/tests/test_litellm/proxy/test_prisma_migration.py
@@ -34,24 +34,22 @@ class TestPrismaMigration:
 
         mock_run_server.assert_called_once_with(("--skip_server_startup",), standalone_mode=False)
 
+    @pytest.mark.parametrize("env", [{}, {"ENFORCE_PRISMA_MIGRATION_CHECK": "false"}])
     @patch("litellm.proxy.prisma_migration.subprocess.run")
     @patch("litellm.proxy.prisma_migration.run_server")
-    def test_main_returns_prisma_generate_exit_code_when_enforced(
-        self, mock_run_server: MagicMock, mock_subprocess_run: MagicMock
+    def test_main_exits_zero_when_only_prisma_generate_fails(
+        self,
+        mock_run_server: MagicMock,
+        mock_subprocess_run: MagicMock,
+        env: dict[str, str],
     ) -> None:
-        mock_subprocess_run.return_value = MagicMock(returncode=7, stdout="", stderr="")
+        mock_subprocess_run.return_value = MagicMock(
+            returncode=1,
+            stdout="",
+            stderr="PermissionError: [Errno 13] Permission denied: '/app/.venv/lib/python3.13/site-packages/prisma/schema.prisma'",
+        )
 
-        with patch.dict(os.environ, {}, clear=True):
-            assert prisma_migration.main() == 7
-
-    @patch("litellm.proxy.prisma_migration.subprocess.run")
-    @patch("litellm.proxy.prisma_migration.run_server")
-    def test_main_ignores_prisma_generate_exit_code_when_disabled(
-        self, mock_run_server: MagicMock, mock_subprocess_run: MagicMock
-    ) -> None:
-        mock_subprocess_run.return_value = MagicMock(returncode=7, stdout="", stderr="")
-
-        with patch.dict(os.environ, {"ENFORCE_PRISMA_MIGRATION_CHECK": "false"}, clear=True):
+        with patch.dict(os.environ, env, clear=True):
             assert prisma_migration.main() == 0
 
     @patch("litellm.proxy.prisma_migration.subprocess.run")


### PR DESCRIPTION
## TLDR

Problem this solves:

- Migration Job exits 1 after applying every migration
- Only the redundant post-migration `prisma generate` failed
- It cannot write site-packages as non-root
- Blocks rollouts the Job was meant to gate

How it solves it:

- A failed `prisma generate` no longer sets the exit code
- Migration failures stay fatal, unchanged
- image-scan now watches the entrypoint it exercises

## User Flow

Before: a platform engineer upgrading the gateway on a cluster that runs the migrations Job as a non-root uid sees the sync fail even though the database migrated cleanly

1. They set `securityContext.runAsNonRoot: true` on the chart and let ArgoCD sync
2. The pre-upgrade migration Job logs `All migrations have been successfully applied.` and then a `PermissionError` on `.../site-packages/prisma/schema.prisma`
3. The Job finishes as Failed, exit code 1, despite the schema being fully created
4. ArgoCD reports the sync Degraded and never rolls out the new pods, so the release is stuck on a database that is already migrated
5. Their only way forward is `ENFORCE_PRISMA_MIGRATION_CHECK=false`, which also gives up catching genuinely failed migrations

After: the same sync completes, and a genuinely failed migration still stops it

1. They set `securityContext.runAsNonRoot: true` on the chart and let ArgoCD sync
2. The pre-upgrade migration Job logs `All migrations have been successfully applied.` and a warning that the client baked at image build time is being used
3. The Job finishes as Succeeded, exit code 0
4. ArgoCD rolls out the new pods against the migrated schema
5. If the database is genuinely unreachable, the Job still exits 1 and still blocks the rollout, with no need to touch `ENFORCE_PRISMA_MIGRATION_CHECK`

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Shared setup: a Postgres on a `--internal` (no egress) Docker network, and the migration entrypoint run as an arbitrary non-root uid in GID 0, which is what OpenShift restricted-v2 assigns. The entrypoint under test is bind-mounted over the one in a released image so both sides run against an identical bake

```bash
docker network create --internal secfixnet-ab
docker run -d --name pgab --network secfixnet-ab -e POSTGRES_PASSWORD=pw -e POSTGRES_DB=litellm postgres:16-alpine
```

### Before (7a1afa1c40491775ca13bc06626a453cb9a3eafb)

#### Migration succeeds, entrypoint reports failure

1. Run the entrypoint the Helm migrations Job runs, as uid 12345:0

```bash
docker run --rm --network secfixnet-ab --user 12345:0 -e DATABASE_URL=postgresql://postgres:pw@pgab:5432/litellm -e LITELLM_MASTER_KEY=sk-offline-migration-test -e DISABLE_SCHEMA_UPDATE=false -v /tmp/prisma_migration.before.py:/app/litellm/proxy/prisma_migration.py:ro -w /app --entrypoint python ghcr.io/berriai/litellm:v1.97.0-rc.1 litellm/proxy/prisma_migration.py; echo "EXIT CODE: $?"
```

2. Observed output, the schema is applied and the Job still fails

```text
  All migrations have been successfully applied.
  litellm_proxy_extras - INFO - prisma migrate deploy completed
  litellm_proxy_extras - INFO - Post-migration sanity check completed
  PermissionError: [Errno 13] Permission denied: '/app/.venv/lib/python3.13/site-packages/prisma/schema.prisma'
EXIT CODE: 1
```

3. Confirm the database really did migrate

```bash
docker exec pgab psql -U postgres -d litellm -tAc "SELECT count(*) FROM information_schema.tables WHERE table_schema='public';"
```

```text
71
```

#### Unreachable database, default settings

1. Point the same entrypoint at a database that is not there

```bash
docker run --rm --network secfixnet-ab --user 12345:0 -e DATABASE_URL=postgresql://postgres:pw@127.0.0.1:5599/nope -e LITELLM_MASTER_KEY=sk-offline-migration-test -e DISABLE_SCHEMA_UPDATE=false -v /tmp/prisma_migration.before.py:/app/litellm/proxy/prisma_migration.py:ro -w /app --entrypoint python ghcr.io/berriai/litellm:v1.97.0-rc.1 litellm/proxy/prisma_migration.py; echo "EXIT CODE: $?"
```

```text
Database setup failed after multiple retries. The proxy cannot start safely.
EXIT CODE: 1
```

### After (9f79218fdfeb15b16d98a22aace52962b25dbdc9)

#### Migration succeeds, entrypoint reports success

1. Recreate Postgres so the run starts from an empty database

```bash
docker rm -f pgab && docker run -d --name pgab --network secfixnet-ab -e POSTGRES_PASSWORD=pw -e POSTGRES_DB=litellm postgres:16-alpine
docker exec pgab psql -U postgres -d litellm -tAc "SELECT count(*) FROM information_schema.tables WHERE table_schema='public';"
```

```text
0
```

2. Run the same command against the fixed entrypoint

```bash
docker run --rm --network secfixnet-ab --user 12345:0 -e DATABASE_URL=postgresql://postgres:pw@pgab:5432/litellm -e LITELLM_MASTER_KEY=sk-offline-migration-test -e DISABLE_SCHEMA_UPDATE=false -v /tmp/prisma_migration.after.py:/app/litellm/proxy/prisma_migration.py:ro -w /app --entrypoint python ghcr.io/berriai/litellm:v1.97.0-rc.1 litellm/proxy/prisma_migration.py; echo "EXIT CODE: $?"
```

```text
  All migrations have been successfully applied.
  'prisma generate' exited 1; continuing with the client baked at image build time.
EXIT CODE: 0
```

3. Confirm the same schema landed

```bash
docker exec pgab psql -U postgres -d litellm -tAc "SELECT count(*) FROM information_schema.tables WHERE table_schema='public';"
```

```text
71
```

#### Unreachable database, default settings

1. Point the fixed entrypoint at a database that is not there

```bash
docker run --rm --network secfixnet-ab --user 12345:0 -e DATABASE_URL=postgresql://postgres:pw@127.0.0.1:5599/nope -e LITELLM_MASTER_KEY=sk-offline-migration-test -e DISABLE_SCHEMA_UPDATE=false -v /tmp/prisma_migration.after.py:/app/litellm/proxy/prisma_migration.py:ro -w /app --entrypoint python ghcr.io/berriai/litellm:v1.97.0-rc.1 litellm/proxy/prisma_migration.py; echo "EXIT CODE: $?"
```

```text
Database setup failed after multiple retries. The proxy cannot start safely.
EXIT CODE: 1
```

2. Confirm the documented opt-out still works

```bash
docker run --rm --network secfixnet-ab --user 12345:0 -e DATABASE_URL=postgresql://postgres:pw@127.0.0.1:5599/nope -e LITELLM_MASTER_KEY=sk-offline-migration-test -e DISABLE_SCHEMA_UPDATE=false -e ENFORCE_PRISMA_MIGRATION_CHECK=false -v /tmp/prisma_migration.after.py:/app/litellm/proxy/prisma_migration.py:ro -w /app --entrypoint python ghcr.io/berriai/litellm:v1.97.0-rc.1 litellm/proxy/prisma_migration.py; echo "EXIT CODE: $?"
```

```text
EXIT CODE: 0
```

## Type

🐛 Bug Fix

## Caveats (if any)

- The refresh still runs, only its exit code stops counting
- Source checkouts still rely on it; CircleCI ignores its status
- `image-scan` gating this entrypoint is new, expect it on more PRs

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
