### PR TITLE
fix(types): silence pydantic ReadOnly warning on StandardLoggingRoutingDecision

### DIFF
--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -2846,7 +2846,7 @@ class StandardLoggingRoutingDecision(TypedDict, total=False):
     classifier_cost: float
     escalated: bool
     tier_boundaries: StandardLoggingRoutingDecisionTierBoundaries
-    reasoning_override_min_score: ReadOnly[float]
+    reasoning_override_min_score: float  # writable-ok: Pydantic warns on ReadOnly TypedDict fields
     conversation_continuing: bool
     savings_baseline_model: str
     savings_baseline_deployment_id: str


### PR DESCRIPTION
## TLDR

Drops the `ReadOnly` qualifier from `StandardLoggingRoutingDecision.reasoning_override_min_score` so importing litellm no longer prints a pydantic `UserWarning` at startup. Pydantic builds a schema over this TypedDict (it is embedded in the router's pydantic models) and warns on every `ReadOnly` item it meets, so the warning greeted every CLI user before `lite claude` even started. The sibling field `tier_litellm_params` already made the same trade with the same `# writable-ok` marker; this follows it.

## User Flow

**Before**, every `lite` invocation greets the user with a pydantic warning about litellm's own types before the tool even starts

1. With the proxy configured (`LITELLM_PROXY_URL=http://localhost:33279`), the user runs `lite claude` in their terminal
2. Before anything else, the terminal prints `pydantic/_internal/_generate_schema.py:1480: UserWarning: Item 'reasoning_override_min_score' on TypedDict class 'StandardLoggingRoutingDecision' is using the ReadOnly qualifier. Pydantic will not protect items from any mutation on dictionary instances.` followed by a `warnings.warn(` source line
3. Only then does the expected `litellm: routing Claude Code through proxy at http://localhost:33279` line appear, Claude Code starts, and requests flow through `POST http://localhost:33279/v1/messages` normally
4. The same warning opens every later `lite` command and any `python -c "import litellm"`, reading like something is wrong when nothing is

**After**, startup is clean and the only line before Claude Code opens is the routing notice

1. With the proxy configured (`LITELLM_PROXY_URL=http://localhost:33279`), the user runs `lite claude` in their terminal
2. The terminal prints just `litellm: routing Claude Code through proxy at http://localhost:33279`, Claude Code starts, and requests flow through `POST http://localhost:33279/v1/messages` normally
3. Later `lite` commands and `python -c "import litellm"` start silently

## Verification

- `python -W always -c "import litellm"` on the base branch prints the warning once; with this change it prints nothing
- `tests/test_litellm/router_strategy/test_complexity_router.py` passes (the 14 failures in that file are environment-related and identical on the untouched base)
- `make check` passes; the type-discipline gate accepts the `# writable-ok: <reason>` suppression and no other rule fires on the changed line
