### PR TITLE
fix(docker): bump wolfi-base digest for busybox 1.38.0-r1 and openssl 3.6.3-r5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
 # syntax=docker/dockerfile:1.7
 
 # Base image for building
-ARG LITELLM_BUILD_IMAGE=cgr.dev/chainguard/wolfi-base@sha256:42df77a9974d6ec8b17a5ee8bc23b532600a44d705acef2409e0933c1251b45f
+ARG LITELLM_BUILD_IMAGE=cgr.dev/chainguard/wolfi-base@sha256:a31344ab2cb8618db84f535eec56f76f6178b142cb92cb2e48676cc2dcebea72
 
 # Runtime image
-ARG LITELLM_RUNTIME_IMAGE=cgr.dev/chainguard/wolfi-base@sha256:42df77a9974d6ec8b17a5ee8bc23b532600a44d705acef2409e0933c1251b45f
+ARG LITELLM_RUNTIME_IMAGE=cgr.dev/chainguard/wolfi-base@sha256:a31344ab2cb8618db84f535eec56f76f6178b142cb92cb2e48676cc2dcebea72
 ARG UV_IMAGE=ghcr.io/astral-sh/uv:0.11.7@sha256:240fb85ab0f263ef12f492d8476aa3a2e4e1e333f7d67fbdd923d00a506a516a
 # Pinned by digest like the other base images; bump explicitly on Node upgrades.
 ARG UI_BUILD_IMAGE=node:24.19-alpine3.24@sha256:d32cdf619f63fe0471182d08996dd516c6275bb5fd31ae06e55a570bd9e1ad43

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,5 +1,5 @@
-ARG LITELLM_BUILD_IMAGE=cgr.dev/chainguard/wolfi-base@sha256:42df77a9974d6ec8b17a5ee8bc23b532600a44d705acef2409e0933c1251b45f
-ARG LITELLM_RUNTIME_IMAGE=cgr.dev/chainguard/wolfi-base@sha256:42df77a9974d6ec8b17a5ee8bc23b532600a44d705acef2409e0933c1251b45f
+ARG LITELLM_BUILD_IMAGE=cgr.dev/chainguard/wolfi-base@sha256:a31344ab2cb8618db84f535eec56f76f6178b142cb92cb2e48676cc2dcebea72
+ARG LITELLM_RUNTIME_IMAGE=cgr.dev/chainguard/wolfi-base@sha256:a31344ab2cb8618db84f535eec56f76f6178b142cb92cb2e48676cc2dcebea72
 ARG UV_IMAGE=ghcr.io/astral-sh/uv:0.11.7@sha256:240fb85ab0f263ef12f492d8476aa3a2e4e1e333f7d67fbdd923d00a506a516a
 
 FROM $UV_IMAGE AS uvbin

--- a/docker/Dockerfile.database
+++ b/docker/Dockerfile.database
@@ -1,10 +1,10 @@
 # syntax=docker/dockerfile:1.7
 
 # Base image for building
-ARG LITELLM_BUILD_IMAGE=cgr.dev/chainguard/wolfi-base@sha256:42df77a9974d6ec8b17a5ee8bc23b532600a44d705acef2409e0933c1251b45f
+ARG LITELLM_BUILD_IMAGE=cgr.dev/chainguard/wolfi-base@sha256:a31344ab2cb8618db84f535eec56f76f6178b142cb92cb2e48676cc2dcebea72
 
 # Runtime image
-ARG LITELLM_RUNTIME_IMAGE=cgr.dev/chainguard/wolfi-base@sha256:42df77a9974d6ec8b17a5ee8bc23b532600a44d705acef2409e0933c1251b45f
+ARG LITELLM_RUNTIME_IMAGE=cgr.dev/chainguard/wolfi-base@sha256:a31344ab2cb8618db84f535eec56f76f6178b142cb92cb2e48676cc2dcebea72
 ARG UV_IMAGE=ghcr.io/astral-sh/uv:0.11.7@sha256:240fb85ab0f263ef12f492d8476aa3a2e4e1e333f7d67fbdd923d00a506a516a
 # Pinned by digest like the other base images; bump explicitly on Node upgrades.
 ARG UI_BUILD_IMAGE=node:24.19-alpine3.24@sha256:d32cdf619f63fe0471182d08996dd516c6275bb5fd31ae06e55a570bd9e1ad43

--- a/docker/Dockerfile.non_root
+++ b/docker/Dockerfile.non_root
@@ -1,8 +1,8 @@
 # syntax=docker/dockerfile:1.7
 
 # Base images
-ARG LITELLM_BUILD_IMAGE=cgr.dev/chainguard/wolfi-base@sha256:42df77a9974d6ec8b17a5ee8bc23b532600a44d705acef2409e0933c1251b45f
-ARG LITELLM_RUNTIME_IMAGE=cgr.dev/chainguard/wolfi-base@sha256:42df77a9974d6ec8b17a5ee8bc23b532600a44d705acef2409e0933c1251b45f
+ARG LITELLM_BUILD_IMAGE=cgr.dev/chainguard/wolfi-base@sha256:a31344ab2cb8618db84f535eec56f76f6178b142cb92cb2e48676cc2dcebea72
+ARG LITELLM_RUNTIME_IMAGE=cgr.dev/chainguard/wolfi-base@sha256:a31344ab2cb8618db84f535eec56f76f6178b142cb92cb2e48676cc2dcebea72
 ARG PROXY_EXTRAS_SOURCE=published
 ARG UV_IMAGE=ghcr.io/astral-sh/uv:0.11.7@sha256:240fb85ab0f263ef12f492d8476aa3a2e4e1e333f7d67fbdd923d00a506a516a
 # Pinned by digest like the other base images; bump explicitly on Node upgrades.

--- a/gateway/Dockerfile
+++ b/gateway/Dockerfile
@@ -1,5 +1,5 @@
-ARG LITELLM_BUILD_IMAGE=cgr.dev/chainguard/wolfi-base@sha256:42df77a9974d6ec8b17a5ee8bc23b532600a44d705acef2409e0933c1251b45f
-ARG LITELLM_RUNTIME_IMAGE=cgr.dev/chainguard/wolfi-base@sha256:42df77a9974d6ec8b17a5ee8bc23b532600a44d705acef2409e0933c1251b45f
+ARG LITELLM_BUILD_IMAGE=cgr.dev/chainguard/wolfi-base@sha256:a31344ab2cb8618db84f535eec56f76f6178b142cb92cb2e48676cc2dcebea72
+ARG LITELLM_RUNTIME_IMAGE=cgr.dev/chainguard/wolfi-base@sha256:a31344ab2cb8618db84f535eec56f76f6178b142cb92cb2e48676cc2dcebea72
 ARG UV_IMAGE=ghcr.io/astral-sh/uv:0.11.7@sha256:240fb85ab0f263ef12f492d8476aa3a2e4e1e333f7d67fbdd923d00a506a516a
 
 FROM $UV_IMAGE AS uvbin

--- a/migrations/Dockerfile
+++ b/migrations/Dockerfile
@@ -1,5 +1,5 @@
-ARG LITELLM_BUILD_IMAGE=cgr.dev/chainguard/wolfi-base@sha256:42df77a9974d6ec8b17a5ee8bc23b532600a44d705acef2409e0933c1251b45f
-ARG LITELLM_RUNTIME_IMAGE=cgr.dev/chainguard/wolfi-base@sha256:42df77a9974d6ec8b17a5ee8bc23b532600a44d705acef2409e0933c1251b45f
+ARG LITELLM_BUILD_IMAGE=cgr.dev/chainguard/wolfi-base@sha256:a31344ab2cb8618db84f535eec56f76f6178b142cb92cb2e48676cc2dcebea72
+ARG LITELLM_RUNTIME_IMAGE=cgr.dev/chainguard/wolfi-base@sha256:a31344ab2cb8618db84f535eec56f76f6178b142cb92cb2e48676cc2dcebea72
 ARG UV_IMAGE=ghcr.io/astral-sh/uv:0.11.7@sha256:240fb85ab0f263ef12f492d8476aa3a2e4e1e333f7d67fbdd923d00a506a516a
 
 FROM $UV_IMAGE AS uvbin


### PR DESCRIPTION
## TLDR

Problem this solves:

- Pinned wolfi-base is from 2026-07-02 and ships stale apk packages
- Grype flags 16 fixable findings on it, 8 rated High
- The Dockerfile's `apk upgrade` cannot advance them

How it solves it:

- Moves all 6 Dockerfiles to a base carrying the fixed revisions
- busybox 1.38.0-r1, libcrypto3/libssl3 3.6.3-r5, glibc 2.43-r15

## User Flow

Before: an operator scanning the published image sees fixable High findings they cannot clear by rebuilding

1. They pull the published `litellm/litellm` image
2. They run their scanner against it
3. It reports busybox 1.37.0-r61 and libcrypto3/libssl3 3.6.3-r3 as fixable, 8 findings rated High
4. They rebuild the image themselves, expecting the runtime stage's package upgrade to pick up current versions
5. The rebuilt image reports the identical findings, so there is no action available to them

After: the same scan comes back clean

1. They pull the published `litellm/litellm` image
2. They run their scanner against it
3. It reports busybox 1.38.0-r1 and libcrypto3/libssl3 3.6.3-r5
4. No fixable findings are reported

## Relevant issues

## Linear ticket

## Pre-Submission checklist

- [ ] I have added meaningful tests
- [x] The handful of test files covering my change pass locally
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

Both runs build `docker/Dockerfile.non_root` and scan it with the same pinned grype the gate uses, `grype IMG --only-fixed --fail-on high`.

### Before (28887f12c5)

1. `docker build -f docker/Dockerfile.non_root -t litellm-base-before:local .`
2. `grype litellm-base-before:local --only-fixed --fail-on high`

```
NAME        INSTALLED   FIXED IN   TYPE  VULNERABILITY        SEVERITY
libcrypto3  3.6.3-r3    3.6.3-r5   apk   CVE-2026-14456       High
libssl3     3.6.3-r3    3.6.3-r5   apk   CVE-2026-14456       High
libcrypto3  3.6.3-r3    3.6.3-r4   apk   CVE-2026-54876       High
libssl3     3.6.3-r3    3.6.3-r4   apk   CVE-2026-54876       High
busybox     1.37.0-r61  1.38.0-r0  apk   CVE-2026-38754       High
busybox     1.37.0-r61  1.38.0-r1  apk   CVE-2026-38752       High
busybox     1.37.0-r61  1.38.0-r0  apk   CVE-2026-38755       High
busybox     1.37.0-r61  1.38.0-r0  apk   CVE-2026-38753       High
busybox     1.37.0-r61  1.38.0-r0  apk   GHSA-9r55-p3jw-v652  Unknown
busybox     1.37.0-r61  1.38.0-r1  apk   GHSA-fj27-x67r-v4g5  Unknown
busybox     1.37.0-r61  1.38.0-r0  apk   GHSA-jcqv-rj94-jmx3  Unknown
busybox     1.37.0-r61  1.38.0-r0  apk   GHSA-jj7c-h3wm-vjfw  Unknown
libcrypto3  3.6.3-r3    3.6.3-r4   apk   GHSA-5cfw-78wc-wvjq  Unknown
libcrypto3  3.6.3-r3    3.6.3-r5   apk   GHSA-9x89-v382-mjh7  Unknown
libssl3     3.6.3-r3    3.6.3-r4   apk   GHSA-5cfw-78wc-wvjq  Unknown
libssl3     3.6.3-r3    3.6.3-r5   apk   GHSA-9x89-v382-mjh7  Unknown

[0069] ERROR discovered vulnerabilities at or above the severity threshold
```

3. Confirming the runtime stage's `apk upgrade` cannot clear these: `docker run --rm --entrypoint sh cgr.dev/chainguard/wolfi-base@sha256:42df77a9... -c "apk upgrade -a; cat /etc/apk/world"`

```
fetch https://apk.cgr.dev/chainguard/aarch64/APKINDEX.tar.gz
OK: 14 MiB in 15 packages
busybox=1.37.0-r61
libcrypto3=3.6.3-r3
libssl3=3.6.3-r3
glibc=2.43-r10
```

The base writes an exact `=version` constraint for every package it ships, so the upgrade is a no-op even though `apk policy busybox` lists 1.38.0-r1 as available.

### After (f46dd4071c)

1. `docker build -f docker/Dockerfile.non_root -t litellm-digestbump:local .`
2. `grype litellm-digestbump:local --only-fixed --fail-on high; echo "exit=$?"`

```
No vulnerabilities found
exit=0
```

3. Provenance of the new digest: `cosign verify --certificate-oidc-issuer=https://token.actions.githubusercontent.com --certificate-identity=https://github.com/chainguard-images/images/.github/workflows/release.yaml@refs/heads/main cgr.dev/chainguard/wolfi-base@sha256:a31344ab...`

```
Verification for cgr.dev/chainguard/wolfi-base@sha256:a31344ab... --
The following checks were performed on each of these signatures:
  - The cosign claims were validated
  - Existence of the claims in the transparency log was verified offline
  - The code-signing certificate was verified using trusted certificate authority certificates
```

4. The base scans clean on the runner's architecture too: `grype cgr.dev/chainguard/wolfi-base@sha256:a31344ab... --platform linux/amd64 --only-fixed`

```
No vulnerabilities found
```

## Type

🚄 Infrastructure

## Caveats (if any)

- image-scan stays red here until #37947 lands
- #37947 unskips the grype step; this PR is what greens it
- Rebase onto staging after #37947 merges, then re-run
- Base image was published 2026-08-21, inside the usual cooldown
