### PR TITLE
fix(dashboard): don't show a stale provider prompt-cache chip on a response-cache hit

### DIFF
--- a/litellm/constants.py
+++ b/litellm/constants.py
@@ -146,6 +146,7 @@ LITELLM_UI_ALLOW_HEADERS: Final = [
     "x-litellm-adaptive-router-model",
     "x-litellm-applied-guardrails",
     "x-litellm-guardrail-scan-id",
+    "x-litellm-cache-key",
 ]
 
 # Gemini model-specific minimal thinking budget constants

--- a/tests/test_litellm/proxy/test_proxy_server.py
+++ b/tests/test_litellm/proxy/test_proxy_server.py
@@ -78,6 +78,16 @@ def client_no_auth():
     return TestClient(app)
 
 
+def test_cors_exposes_cache_key_header_to_browser_js():
+    from fastapi.middleware.cors import CORSMiddleware
+
+    from litellm.constants import LITELLM_UI_ALLOW_HEADERS
+
+    cors_middleware = next(m for m in app.user_middleware if m.cls is CORSMiddleware)
+    assert cors_middleware.kwargs["expose_headers"] is LITELLM_UI_ALLOW_HEADERS
+    assert "x-litellm-cache-key" in cors_middleware.kwargs["expose_headers"]
+
+
 def test_login_v2_returns_redirect_url_and_sets_cookie(monkeypatch):
     mock_login_result = {"user_id": "test-user"}
     mock_prisma_client = MagicMock()

--- a/ui/litellm-dashboard/src/components/chat_ui/ResponseMetrics.test.tsx
+++ b/ui/litellm-dashboard/src/components/chat_ui/ResponseMetrics.test.tsx
@@ -33,4 +33,22 @@ describe("ResponseMetrics prompt cache chips", () => {
     expect(screen.queryByText(/Cache Read/)).not.toBeInTheDocument();
     expect(screen.queryByText(/Cache Write/)).not.toBeInTheDocument();
   });
+
+  it("shows the response cache indicator instead of the provider cache chips on a response-cache hit", () => {
+    render(
+      <ResponseMetrics
+        usage={{ ...baseUsage, cacheReadTokens: 4695, cacheCreationTokens: 1234, servedFromResponseCache: true }}
+      />,
+    );
+
+    expect(screen.getByText("Response Cache: Hit")).toBeInTheDocument();
+    expect(screen.queryByText(/Cache Read/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Cache Write/)).not.toBeInTheDocument();
+  });
+
+  it("does not show the response cache indicator when the flag is absent", () => {
+    render(<ResponseMetrics usage={baseUsage} />);
+
+    expect(screen.queryByText(/Response Cache/)).not.toBeInTheDocument();
+  });
 });

--- a/ui/litellm-dashboard/src/components/chat_ui/ResponseMetrics.tsx
+++ b/ui/litellm-dashboard/src/components/chat_ui/ResponseMetrics.tsx
@@ -7,11 +7,15 @@ import {
   DatabaseBackup,
   DollarSign,
   Hash,
+  History,
   Lightbulb,
   Wrench,
 } from "lucide-react";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { PROMPT_CACHE_CREATION_TOOLTIP, PROMPT_CACHE_READ_TOOLTIP } from "@/utils/promptCacheUsage";
+
+const RESPONSE_CACHE_TOOLTIP =
+  "This response was replayed from LiteLLM's response cache. The request never reached the provider, so it did not read from or write to the provider's own prompt cache.";
 
 export interface TokenUsage {
   completionTokens?: number;
@@ -21,6 +25,7 @@ export interface TokenUsage {
   cacheReadTokens?: number;
   cacheCreationTokens?: number;
   cost?: number;
+  servedFromResponseCache?: boolean;
 }
 
 interface ResponseMetricsProps {
@@ -51,7 +56,22 @@ function MetricItem({ label, tooltip, icon, value }: MetricItemProps) {
   );
 }
 
+function ResponseCacheIndicator() {
+  return (
+    <MetricItem
+      label="Response Cache"
+      tooltip={RESPONSE_CACHE_TOOLTIP}
+      icon={<History className="size-3" aria-hidden="true" />}
+      value="Hit"
+    />
+  );
+}
+
 function PromptCacheChips({ usage }: { usage?: TokenUsage }) {
+  if (usage?.servedFromResponseCache) {
+    return <ResponseCacheIndicator />;
+  }
+
   const readTokens = usage?.cacheReadTokens ?? 0;
   const creationTokens = usage?.cacheCreationTokens ?? 0;
 

--- a/ui/litellm-dashboard/src/components/llm_calls/chat_completion.test.tsx
+++ b/ui/litellm-dashboard/src/components/llm_calls/chat_completion.test.tsx
@@ -24,6 +24,10 @@ vi.mock("openai", () => ({
   },
 }));
 
+const nonStreamingResponse = (data: unknown, headers: Record<string, string> = {}) => ({
+  withResponse: async () => ({ data, response: { headers: new Headers(headers) } }),
+});
+
 describe("chat_completion", () => {
   const mockUpdateUI = vi.fn();
   const mockChatHistory = [{ role: "user", content: "Hello" }];
@@ -226,25 +230,27 @@ describe("chat_completion", () => {
   });
 
   it("should send a non-streaming request and render the whole message at once when streaming is disabled", async () => {
-    mockCreate.mockResolvedValueOnce({
-      id: "chatcmpl-1",
-      object: "chat.completion",
-      created: 1,
-      model: "gpt-4",
-      choices: [
-        {
-          index: 0,
-          finish_reason: "stop",
-          message: { role: "assistant", content: "Hello there" },
+    mockCreate.mockReturnValueOnce(
+      nonStreamingResponse({
+        id: "chatcmpl-1",
+        object: "chat.completion",
+        created: 1,
+        model: "gpt-4",
+        choices: [
+          {
+            index: 0,
+            finish_reason: "stop",
+            message: { role: "assistant", content: "Hello there" },
+          },
+        ],
+        usage: {
+          completion_tokens: 2,
+          prompt_tokens: 5,
+          total_tokens: 7,
+          cost: 0.25,
         },
-      ],
-      usage: {
-        completion_tokens: 2,
-        prompt_tokens: 5,
-        total_tokens: 7,
-        cost: 0.25,
-      },
-    });
+      }),
+    );
 
     const onTimingData = vi.fn();
     const onUsageData = vi.fn();
@@ -298,24 +304,26 @@ describe("chat_completion", () => {
   });
 
   it("should surface reasoning content and MCP metadata from a non-streaming response", async () => {
-    mockCreate.mockResolvedValueOnce({
-      model: "gpt-4",
-      choices: [
-        {
-          index: 0,
-          finish_reason: "stop",
-          message: {
-            role: "assistant",
-            content: "done",
-            reasoning_content: "thinking",
-            provider_specific_fields: {
-              mcp_tool_calls: [{ id: "call_1", function: { name: "search_docs", arguments: "{}" } }],
-              mcp_call_results: [{ tool_call_id: "call_1", result: "found it" }],
+    mockCreate.mockReturnValueOnce(
+      nonStreamingResponse({
+        model: "gpt-4",
+        choices: [
+          {
+            index: 0,
+            finish_reason: "stop",
+            message: {
+              role: "assistant",
+              content: "done",
+              reasoning_content: "thinking",
+              provider_specific_fields: {
+                mcp_tool_calls: [{ id: "call_1", function: { name: "search_docs", arguments: "{}" } }],
+                mcp_call_results: [{ tool_call_id: "call_1", result: "found it" }],
+              },
             },
           },
-        },
-      ],
-    });
+        ],
+      }),
+    );
 
     const onReasoningContent = vi.fn();
     const onMCPEvent = vi.fn();
@@ -457,5 +465,139 @@ describe("chat_completion prompt cache usage", () => {
 
     expect(usageData).not.toHaveProperty("cacheReadTokens");
     expect(usageData).not.toHaveProperty("cacheCreationTokens");
+  });
+});
+
+describe("chat_completion response cache", () => {
+  const mockUpdateUI = vi.fn();
+  const mockChatHistory = [{ role: "user", content: "Hello" }];
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("flags a non-streaming response-cache hit even though it replays provider prompt-cache usage", async () => {
+    mockCreate.mockReturnValueOnce(
+      nonStreamingResponse(
+        {
+          id: "chatcmpl-replayed",
+          model: "gpt-4",
+          choices: [{ index: 0, finish_reason: "stop", message: { role: "assistant", content: "Hello there" } }],
+          usage: {
+            completion_tokens: 2,
+            prompt_tokens: 5000,
+            total_tokens: 5002,
+            prompt_tokens_details: { cached_tokens: 4695 },
+          },
+        },
+        { "x-litellm-cache-key": "cache-key-abc" },
+      ),
+    );
+
+    const onUsageData = vi.fn();
+
+    await makeOpenAIChatCompletionRequest(
+      mockChatHistory,
+      mockUpdateUI,
+      "gpt-4",
+      "test-token",
+      undefined, // tags
+      undefined, // signal
+      undefined, // onReasoningContent
+      undefined, // onTimingData
+      onUsageData,
+      undefined, // traceId
+      undefined, // vector_store_ids
+      undefined, // guardrails
+      undefined, // policies
+      undefined, // selectedMCPServers
+      undefined, // onImageGenerated
+      undefined, // onSearchResults
+      undefined, // temperature
+      undefined, // max_tokens
+      undefined, // onTotalLatency
+      undefined, // customBaseUrl
+      undefined, // mcpServers
+      undefined, // mcpServerToolRestrictions
+      undefined, // onMCPEvent
+      undefined, // mockTestFallbacks
+      undefined, // mcpToolsets
+      false, // streamingEnabled
+    );
+
+    expect(onUsageData).toHaveBeenCalledWith(
+      expect.objectContaining({ cacheReadTokens: 4695, servedFromResponseCache: true }),
+    );
+  });
+
+  it("does not flag a non-streaming response that missed the response cache", async () => {
+    mockCreate.mockReturnValueOnce(
+      nonStreamingResponse({
+        id: "chatcmpl-fresh",
+        model: "gpt-4",
+        choices: [{ index: 0, finish_reason: "stop", message: { role: "assistant", content: "Hello there" } }],
+        usage: { completion_tokens: 2, prompt_tokens: 5, total_tokens: 7 },
+      }),
+    );
+
+    const onUsageData = vi.fn();
+
+    await makeOpenAIChatCompletionRequest(
+      mockChatHistory,
+      mockUpdateUI,
+      "gpt-4",
+      "test-token",
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      onUsageData,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      false, // streamingEnabled
+    );
+
+    expect(onUsageData).toHaveBeenCalledWith(expect.not.objectContaining({ servedFromResponseCache: true }));
+  });
+
+  it("never flags a streaming response, even when the proxy reports a cache key", async () => {
+    async function* mockStream() {
+      yield {
+        choices: [{ delta: {}, index: 0 }],
+        model: "gpt-4",
+        usage: { completion_tokens: 2, prompt_tokens: 5, total_tokens: 7 },
+      };
+    }
+    mockCreate.mockResolvedValueOnce(mockStream());
+
+    const onUsageData = vi.fn();
+
+    await makeOpenAIChatCompletionRequest(
+      mockChatHistory,
+      mockUpdateUI,
+      "gpt-4",
+      "test-token",
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      onUsageData,
+    );
+
+    expect(onUsageData).toHaveBeenCalledWith(expect.not.objectContaining({ servedFromResponseCache: true }));
   });
 });

--- a/ui/litellm-dashboard/src/components/llm_calls/chat_completion.tsx
+++ b/ui/litellm-dashboard/src/components/llm_calls/chat_completion.tsx
@@ -73,6 +73,7 @@ export async function makeOpenAIChatCompletionRequest(
     const startTime = Date.now();
     let firstTokenReceived = false;
     let timeToFirstToken: number | undefined = undefined;
+    let servedFromResponseCache = false;
 
     // Track MCP metadata cumulatively across chunks
     let mcpMetadata: {
@@ -143,7 +144,13 @@ export async function makeOpenAIChatCompletionRequest(
           { ...requestBody, stream: true, stream_options: { include_usage: true } },
           { signal },
         )
-      : [completionAsSingleChunk(await client.chat.completions.create({ ...requestBody, stream: false }, { signal }))];
+      : await (async () => {
+          const nonStreamingResponse = await client.chat.completions
+            .create({ ...requestBody, stream: false }, { signal })
+            .withResponse();
+          servedFromResponseCache = nonStreamingResponse.response.headers.get("x-litellm-cache-key") !== null;
+          return [completionAsSingleChunk(nonStreamingResponse.data)];
+        })();
 
     for await (const chunk of response) {
       // Process content and measure time to first token
@@ -228,6 +235,7 @@ export async function makeOpenAIChatCompletionRequest(
           promptTokens: chunkWithUsage.usage.prompt_tokens,
           totalTokens: chunkWithUsage.usage.total_tokens,
           ...extractPromptCacheTokens(chunkWithUsage.usage),
+          ...(servedFromResponseCache ? { servedFromResponseCache: true } : {}),
         };
 
         // Check for reasoning tokens

--- a/ui/litellm-dashboard/src/components/llm_calls/responses_api.test.tsx
+++ b/ui/litellm-dashboard/src/components/llm_calls/responses_api.test.tsx
@@ -20,6 +20,10 @@ vi.mock("openai", () => ({
   },
 }));
 
+const nonStreamingResponse = (data: unknown, headers: Record<string, string> = {}) => ({
+  withResponse: async () => ({ data, response: { headers: new Headers(headers) } }),
+});
+
 describe("responses_api", () => {
   const mockUpdateTextUI = vi.fn();
   const messages: MessageType[] = [{ role: "user", content: "Hello" }];
@@ -71,19 +75,21 @@ describe("responses_api", () => {
   });
 
   it("should send a non-streaming request and render the whole output at once when streaming is disabled", async () => {
-    mockResponsesCreate.mockResolvedValueOnce({
-      id: "resp_456",
-      output: [
-        {
-          type: "message",
-          content: [
-            { type: "output_text", text: "Full " },
-            { type: "output_text", text: "answer" },
-          ],
-        },
-      ],
-      usage: { output_tokens: 3, input_tokens: 4, total_tokens: 7 },
-    });
+    mockResponsesCreate.mockReturnValueOnce(
+      nonStreamingResponse({
+        id: "resp_456",
+        output: [
+          {
+            type: "message",
+            content: [
+              { type: "output_text", text: "Full " },
+              { type: "output_text", text: "answer" },
+            ],
+          },
+        ],
+        usage: { output_tokens: 3, input_tokens: 4, total_tokens: 7 },
+      }),
+    );
 
     const onTimingData = vi.fn();
     const onUsageData = vi.fn();
@@ -162,10 +168,12 @@ describe("responses_api", () => {
     expect(onTotalLatency).toHaveBeenCalledTimes(1);
     expect(onTotalLatency).toHaveBeenLastCalledWith(expect.any(Number));
 
-    mockResponsesCreate.mockResolvedValueOnce({
-      id: "resp_latency",
-      output: [{ type: "message", content: [{ type: "output_text", text: "Answer" }] }],
-    });
+    mockResponsesCreate.mockReturnValueOnce(
+      nonStreamingResponse({
+        id: "resp_latency",
+        output: [{ type: "message", content: [{ type: "output_text", text: "Answer" }] }],
+      }),
+    );
 
     await callWithStreaming(false);
     expect(onTotalLatency).toHaveBeenCalledTimes(2);
@@ -224,14 +232,16 @@ describe("responses_api", () => {
   });
 
   it("should replay MCP output items as events for a non-streaming response", async () => {
-    mockResponsesCreate.mockResolvedValueOnce({
-      id: "resp_789",
-      output: [
-        { type: "mcp_call", id: "mcp_1", name: "search_docs", arguments: "{}", output: "found it" },
-        { type: "message", content: [{ type: "output_text", text: "Answer" }] },
-      ],
-      usage: { output_tokens: 1, input_tokens: 1, total_tokens: 2 },
-    });
+    mockResponsesCreate.mockReturnValueOnce(
+      nonStreamingResponse({
+        id: "resp_789",
+        output: [
+          { type: "mcp_call", id: "mcp_1", name: "search_docs", arguments: "{}", output: "found it" },
+          { type: "message", content: [{ type: "output_text", text: "Answer" }] },
+        ],
+        usage: { output_tokens: 1, input_tokens: 1, total_tokens: 2 },
+      }),
+    );
 
     const onMCPEvent = vi.fn();
     const onUsageData = vi.fn();
@@ -399,5 +409,133 @@ describe("responses_api prompt cache usage", () => {
     expect(usageData).not.toHaveProperty("cacheReadTokens");
     expect(usageData).not.toHaveProperty("cacheCreationTokens");
     expect(usageData.promptTokens).toBe(5000);
+  });
+});
+
+describe("responses_api response cache", () => {
+  const mockUpdateTextUI = vi.fn();
+  const messages: MessageType[] = [{ role: "user", content: "Hello" }];
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("flags a non-streaming response-cache hit even though it replays provider prompt-cache usage", async () => {
+    mockResponsesCreate.mockReturnValueOnce(
+      nonStreamingResponse(
+        {
+          id: "resp_replayed",
+          output: [{ type: "message", content: [{ type: "output_text", text: "Full answer" }] }],
+          usage: {
+            output_tokens: 2,
+            input_tokens: 5000,
+            total_tokens: 5002,
+            input_tokens_details: { cached_tokens: 4695 },
+          },
+        },
+        { "x-litellm-cache-key": "cache-key-abc" },
+      ),
+    );
+
+    const onUsageData = vi.fn();
+
+    await makeOpenAIResponsesRequest(
+      messages,
+      mockUpdateTextUI,
+      "gpt-4",
+      "test-token",
+      undefined, // tags
+      undefined, // signal
+      undefined, // onReasoningContent
+      undefined, // onTimingData
+      onUsageData,
+      undefined, // traceId
+      undefined, // vector_store_ids
+      undefined, // guardrails
+      undefined, // policies
+      undefined, // selectedMCPServers
+      undefined, // previousResponseId
+      undefined, // onResponseId
+      undefined, // onMCPEvent
+      undefined, // codeInterpreterEnabled
+      undefined, // onCodeInterpreterResult
+      undefined, // customBaseUrl
+      undefined, // mcpServers
+      undefined, // mcpServerToolRestrictions
+      undefined, // mcpToolsets
+      false, // streamingEnabled
+    );
+
+    expect(onUsageData).toHaveBeenCalledWith(
+      expect.objectContaining({ cacheReadTokens: 4695, servedFromResponseCache: true }),
+      "",
+    );
+  });
+
+  it("does not flag a non-streaming response that missed the response cache", async () => {
+    mockResponsesCreate.mockReturnValueOnce(
+      nonStreamingResponse({
+        id: "resp_fresh",
+        output: [{ type: "message", content: [{ type: "output_text", text: "Full answer" }] }],
+        usage: { output_tokens: 2, input_tokens: 5, total_tokens: 7 },
+      }),
+    );
+
+    const onUsageData = vi.fn();
+
+    await makeOpenAIResponsesRequest(
+      messages,
+      mockUpdateTextUI,
+      "gpt-4",
+      "test-token",
+      undefined, // tags
+      undefined, // signal
+      undefined, // onReasoningContent
+      undefined, // onTimingData
+      onUsageData,
+      undefined, // traceId
+      undefined, // vector_store_ids
+      undefined, // guardrails
+      undefined, // policies
+      undefined, // selectedMCPServers
+      undefined, // previousResponseId
+      undefined, // onResponseId
+      undefined, // onMCPEvent
+      undefined, // codeInterpreterEnabled
+      undefined, // onCodeInterpreterResult
+      undefined, // customBaseUrl
+      undefined, // mcpServers
+      undefined, // mcpServerToolRestrictions
+      undefined, // mcpToolsets
+      false, // streamingEnabled
+    );
+
+    expect(onUsageData).toHaveBeenCalledWith(expect.not.objectContaining({ servedFromResponseCache: true }), "");
+  });
+
+  it("never flags a streaming response, even when the proxy reports a cache key", async () => {
+    async function* mockStream() {
+      yield {
+        type: "response.completed",
+        response: { id: "resp_stream", usage: { output_tokens: 2, input_tokens: 5, total_tokens: 7 } },
+      };
+    }
+    mockResponsesCreate.mockResolvedValueOnce(mockStream());
+
+    const onUsageData = vi.fn();
+
+    await makeOpenAIResponsesRequest(
+      messages,
+      mockUpdateTextUI,
+      "gpt-4",
+      "test-token",
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      onUsageData,
+    );
+
+    expect(onUsageData).toHaveBeenCalledWith(expect.not.objectContaining({ servedFromResponseCache: true }), "");
   });
 });

--- a/ui/litellm-dashboard/src/components/llm_calls/responses_api.tsx
+++ b/ui/litellm-dashboard/src/components/llm_calls/responses_api.tsx
@@ -116,6 +116,7 @@ export async function makeOpenAIResponsesRequest(
   try {
     const startTime = Date.now();
     let firstTokenReceived = false;
+    let servedFromResponseCache = false;
 
     // Format messages for the API
     const formattedInput = messages.map((message) => {
@@ -202,7 +203,15 @@ export async function makeOpenAIResponsesRequest(
 
     // Create request to OpenAI responses API
     // Use 'any' type to avoid TypeScript issues with the experimental API
-    const response = await (client as any).responses.create({ ...requestBody, stream: streamingEnabled }, { signal });
+    const response = streamingEnabled
+      ? await (client as any).responses.create({ ...requestBody, stream: true }, { signal })
+      : await (async () => {
+          const nonStreamingResponse = await (client as any).responses
+            .create({ ...requestBody, stream: false }, { signal })
+            .withResponse();
+          servedFromResponseCache = nonStreamingResponse.response.headers.get("x-litellm-cache-key") !== null;
+          return nonStreamingResponse.data;
+        })();
     const events = streamingEnabled ? response : responseAsEvents(response);
 
     let mcpToolUsed = "";
@@ -292,6 +301,7 @@ export async function makeOpenAIResponsesRequest(
               promptTokens: usage.input_tokens,
               totalTokens: usage.total_tokens,
               ...extractPromptCacheTokens(usage),
+              ...(servedFromResponseCache ? { servedFromResponseCache: true } : {}),
             };
 
             // Add reasoning tokens if available


### PR DESCRIPTION
## TLDR

Problem this solves:

- Playground non-streaming replies show a provider prompt-cache chip for calls that never reached the provider
- The stale chip claims the provider wrote/read its own cache when the response actually came from LiteLLM's Redis response cache

How it solves it:

- Detect a response-cache hit via the `x-litellm-cache-key` response header on the non-streaming path
- Render a "Response Cache: Hit" indicator instead of the provider `Cache Read` / `Cache Write` chips when that flag is set
- Add `x-litellm-cache-key` to the proxy's CORS `expose_headers` allowlist so the dashboard's split-origin dev flow (dashboard on :3000, proxy on :4000) can actually read the header from browser JS

## User Flow

Before: a developer testing prompt caching in the playground with "Stream responses" unchecked cannot tell a response-cache replay from a real provider cache write

1. They open http://localhost:3000/playground, uncheck "Stream responses" in Additional Model Settings, and send a long prompt with cache_control twice in a row
2. Both replies show a `Cache Write` chip with the same token count, because the second reply is a byte-for-byte replay of the first from LiteLLM's Redis response cache
3. Nothing on the metrics bar says the second call never reached the provider, so the chip reads as a real provider cache write

After: the second reply is labeled as a response-cache hit instead of a provider cache write

1. They send the same two requests with "Stream responses" unchecked
2. The first reply shows `Cache Write` with the real token count from the provider
3. The second reply shows `Response Cache: Hit` instead of `Cache Write`, matching what the Logs drawer already reports for the same request

## Relevant issues

## Linear ticket

Resolves LIT-5533

## Review notes

Greptile (4/5) flagged that the proxy's CORS configuration did not expose `x-litellm-cache-key`, so a browser running the dashboard on a different origin than the proxy (the documented `npm run dev` on :3000 against a proxy on :4000) could not read the header via `fetch`/XHR even though curl sees it fine. That's a real gap: `LITELLM_UI_ALLOW_HEADERS` in `litellm/constants.py` is the allowlist the proxy passes as `expose_headers` to `CORSMiddleware`, and it did not include the new header, so both non-streaming producers in this PR would silently keep `servedFromResponseCache` false for any split-origin dashboard session.

Fix: added `x-litellm-cache-key` to `LITELLM_UI_ALLOW_HEADERS`. Added a regression test, `test_cors_exposes_cache_key_header_to_browser_js` in `tests/test_litellm/proxy/test_proxy_server.py`, that inspects the live `app`'s configured `CORSMiddleware` and asserts the header is in `expose_headers`; it fails on the pre-fix constant and passes with the fix (mutation-checked by reverting just `litellm/constants.py`). Verified live against a real cross-origin request (`curl -H "Origin: http://localhost:3000"`) against a running proxy: `access-control-expose-headers` is missing `x-litellm-cache-key` before the fix and includes it after, which is the exact signal a real browser uses to decide header visibility.

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

The playground's non-streaming producers (`makeOpenAIChatCompletionRequest`, `makeOpenAIResponsesRequest`) replay a response-cache hit's stored body verbatim, prompt-cache token fields included, which is the backend condition this bug depends on. The wire-level capture below proves that condition against a live proxy and a real Anthropic call, plus a live cross-origin CORS check proving the header is actually readable by browser JS in the documented split-origin dev flow.

Live proxy: `anthropic/claude-sonnet-5`, Redis response caching enabled (`litellm_settings.cache: true`, `cache_params.type: redis`), two byte-identical non-streaming `POST /v1/chat/completions` sends with a ~5.7k-token cached system block.

### Before (28887f12c5, same backend behavior as a8a3df92fe since the response-cache mechanics are untouched by this PR)

#### Send 1 (miss, real provider call)

1. `curl -s -D headers1.txt -o body1.json http://localhost:4000/v1/chat/completions -H "Authorization: Bearer $MASTER_KEY" -d @request.json`
2. Response id `chatcmpl-478f9ad8-0210-401c-aaf7-6d56749a1ce4`, no `x-litellm-cache-key` header, `usage.cache_creation_input_tokens: 5716`

#### Send 2 (hit, replayed from the response cache)

1. `curl -s -D headers2.txt -o body2.json http://localhost:4000/v1/chat/completions -H "Authorization: Bearer $MASTER_KEY" -d @request.json` (identical body)
2. Response id `chatcmpl-478f9ad8-0210-401c-aaf7-6d56749a1ce4`, same as send 1: no provider call happened
3. `x-litellm-cache-key: ef2f4a5de949c1e1c092d293187ae86df934de33c57fb839a864f6657daa4779` present in the response headers
4. `usage.cache_creation_input_tokens: 5716`, identical to send 1: the playground's `PromptCacheChips` renders `Cache Write: 5716` for this reply on unfixed code, claiming a provider cache write that did not occur

#### CORS gap (Greptile finding, pre-fix `litellm/constants.py`)

1. `curl -sD - -o /dev/null -X POST http://localhost:4901/v1/chat/completions -H "Authorization: Bearer sk-1234" -H "Origin: http://localhost:3000" -d @request.json`
2. `access-control-expose-headers: x-litellm-semantic-filter, x-litellm-semantic-filter-tools, x-litellm-adaptive-router-model, x-litellm-applied-guardrails, x-litellm-guardrail-scan-id` (no `x-litellm-cache-key`)
3. A browser running the dashboard on :3000 against this proxy on :4000 cannot read `x-litellm-cache-key` via `.headers.get(...)`, even on a cache-hit response that carries it, so `servedFromResponseCache` stays false

### After (a8a3df92fe)

#### Regression tests added in this PR

1. `npx vitest run src/components/chat_ui/ResponseMetrics.test.tsx src/components/llm_calls/chat_completion.test.tsx src/components/llm_calls/responses_api.test.tsx`
2. 33/33 tests pass, including three new cases per producer plus `ResponseMetrics` asserting the indicator swap
3. Mutation check: reverting only the three production files (keeping the new tests) fails exactly the new cache-hit assertions and two pre-existing non-streaming tests whose mock shape the fix changed; restoring the fix returns all 33 to green
4. `PYTHONPATH=$(pwd) python -m pytest tests/test_litellm/proxy/test_proxy_server.py -k test_cors_exposes_cache_key_header_to_browser_js -q` passes; reverting only `litellm/constants.py` fails it

#### CORS gap fixed

1. Same live proxy, same request as the CORS gap case above, run against the fixed code (`git checkout HEAD -- litellm/constants.py` restored, proxy restarted, PID changed)
2. `access-control-expose-headers: x-litellm-semantic-filter, x-litellm-semantic-filter-tools, x-litellm-adaptive-router-model, x-litellm-applied-guardrails, x-litellm-guardrail-scan-id, x-litellm-cache-key`
3. `x-litellm-cache-key` is now readable by browser JS in the split-origin dev flow

## Type

🐛 Bug Fix

## Caveats (if any)

- Verified only for the two OpenAI-shaped producers (`chat_completion.tsx`, `responses_api.tsx`); any other surface rendering `ResponseMetrics` with `streamingEnabled: false` inherits the fix automatically since it shares the same `TokenUsage` type and `PromptCacheChips` component
- No live Chrome capture was available in this environment; see "Manual UI verification steps" below for the exact steps to screenshot the fix

## Manual UI verification steps

1. Start a proxy with Redis response caching enabled and a real provider key, e.g. `litellm_settings.cache: true`, `cache_params.type: redis`, and a model with prompt caching support
2. Run the dashboard dev server: `npm run dev` in `ui/litellm-dashboard`, then open http://localhost:3000/playground
3. Under "Additional Model Settings", uncheck "Stream responses"
4. Send a long prompt (long enough to trigger prompt caching) twice in a row, unmodified
5. On the first reply, confirm the metrics bar shows a `Cache Write` chip with a non-zero token count
6. On the second reply, confirm the metrics bar now shows `Response Cache: Hit` instead of `Cache Write`, and that this matches the "Response Cache: Hit" the Logs drawer reports for the same request at http://localhost:4000/ui/?page=logs

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
