### PR TITLE
fix(ui): read reasoning tokens from Responses API output_tokens_details

### DIFF
--- a/ui/litellm-dashboard/src/components/llm_calls/responses_api.test.tsx
+++ b/ui/litellm-dashboard/src/components/llm_calls/responses_api.test.tsx
@@ -400,4 +400,16 @@ describe("responses_api prompt cache usage", () => {
     expect(usageData).not.toHaveProperty("cacheCreationTokens");
     expect(usageData.promptTokens).toBe(5000);
   });
+
+  it("surfaces reasoning tokens from Responses-shape output_tokens_details", async () => {
+    await expect(captureUsage({ output_tokens_details: { reasoning_tokens: 42 } })).resolves.toMatchObject({
+      reasoningTokens: 42,
+    });
+  });
+
+  it("falls back to completion_tokens_details reasoning tokens when output_tokens_details is absent", async () => {
+    await expect(captureUsage({ completion_tokens_details: { reasoning_tokens: 17 } })).resolves.toMatchObject({
+      reasoningTokens: 17,
+    });
+  });
 });

--- a/ui/litellm-dashboard/src/components/llm_calls/responses_api.tsx
+++ b/ui/litellm-dashboard/src/components/llm_calls/responses_api.tsx
@@ -295,8 +295,10 @@ export async function makeOpenAIResponsesRequest(
             };
 
             // Add reasoning tokens if available
-            if (usage.completion_tokens_details?.reasoning_tokens) {
-              usageData.reasoningTokens = usage.completion_tokens_details.reasoning_tokens;
+            const reasoningTokens =
+              usage.output_tokens_details?.reasoning_tokens ?? usage.completion_tokens_details?.reasoning_tokens;
+            if (reasoningTokens) {
+              usageData.reasoningTokens = reasoningTokens;
             }
 
             if (usage.cost !== undefined && usage.cost !== null) {


### PR DESCRIPTION
## TLDR

Problem this solves:

- Admin UI never shows the reasoning-tokens chip for `/v1/responses` calls
- The chip's usage parser read the wrong field for that API shape

How it solves it:

- Read `reasoning_tokens` from `usage.output_tokens_details` first, the field the Responses API actually returns
- Keep `usage.completion_tokens_details` as a fallback for any caller still shaped like Chat Completions

## User Flow

Before: a developer running a reasoning model through the Responses API playground never sees a reasoning-tokens chip, even though the model reasoned and was billed for it

1. They open the chat/playground UI, pick a reasoning-capable model, and send a prompt through `/v1/responses`
2. The proxy streams back a `response.completed` event whose `usage.output_tokens_details.reasoning_tokens` carries the real count, with no `completion_tokens_details` key at all
3. The dashboard's usage parser only checks `usage.completion_tokens_details?.reasoning_tokens`, which is `undefined` for this shape, so no reasoning chip is ever added to the usage row

After: the same flow surfaces the reasoning-tokens chip with the real count

1. They send the same prompt through `/v1/responses`
2. The same `response.completed` event arrives with `usage.output_tokens_details.reasoning_tokens` set
3. The parser now reads that field first, so the usage row includes a reasoning-tokens chip showing the real count

## Relevant issues

## Linear ticket

Resolves LIT-5540

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

This bug is a client-side parsing bug: the proxy's `/v1/responses` output is identical before and after this change, so the before/after split is in what the dashboard's usage parser extracts from that same real payload, not in the HTTP response. Setup and the real captured payload are shared below, then each case runs the exact extraction expression from `responses_api.tsx` at that commit against it.

Shared setup, run once against a live proxy:

```
model_list:
  - model_name: gpt-5.4-mini-reasoning
    litellm_params:
      model: openai/gpt-5.4-mini
      api_key: os.environ/OPENAI_API_KEY
      reasoning_effort: medium
general_settings:
  master_key: sk-lit5540-proof
litellm_settings:
  drop_params: True
```

```
python litellm/proxy/proxy_cli.py --config config.yaml --port 4854

curl -sS http://localhost:4854/v1/responses \
  -H "Authorization: Bearer sk-lit5540-proof" \
  -H "Content-Type: application/json" \
  -d '{"model": "gpt-5.4-mini-reasoning", "input": "In one sentence, why is the sky blue?"}' \
  > resp.json
```

Real captured `usage` from that call:

```json
{
  "input_tokens": 16,
  "input_tokens_details": { "audio_tokens": null, "cached_tokens": 0, "text_tokens": null, "cache_write_tokens": 0 },
  "output_tokens": 46,
  "output_tokens_details": { "reasoning_tokens": 13, "text_tokens": null },
  "total_tokens": 62,
  "cost": null
}
```

No `completion_tokens_details` key appears anywhere in the response.

### Before (7a1afa1c40)

1. `node -e 'const usage = require("./resp.json").usage; console.log(JSON.stringify(usage.completion_tokens_details?.reasoning_tokens));'`, reproducing the extraction this commit used (`usage.completion_tokens_details?.reasoning_tokens`)
2. Output: `undefined`, so `usageData.reasoningTokens` is never set and the dashboard renders no reasoning chip for this real response

### After (1318a92e13)

1. `node -e 'const usage = require("./resp.json").usage; const reasoningTokens = usage.output_tokens_details?.reasoning_tokens ?? usage.completion_tokens_details?.reasoning_tokens; console.log(JSON.stringify(reasoningTokens));'`, reproducing the fixed extraction
2. Output: `13`, matching the real `output_tokens_details.reasoning_tokens` the proxy returned, so `usageData.reasoningTokens = 13` and the chip renders

Regression coverage in `responses_api.test.tsx`: `captureUsage({ output_tokens_details: { reasoning_tokens: 42 } })` resolves with `reasoningTokens: 42` (fails on the pre-fix code), and `captureUsage({ completion_tokens_details: { reasoning_tokens: 17 } })` still resolves with `reasoningTokens: 17`, pinning the fallback.

### Manual UI verification steps

The claude-in-chrome extension was not available in this environment to capture the actual chip rendering, so here are the exact steps to see it live:

1. Run `python litellm/proxy/proxy_cli.py --config litellm/proxy/dev_config.yaml --detailed_debug --reload --use_v2_migration_resolver` from the repo root
2. Run `npm run dev` in `ui/litellm-dashboard`
3. Open http://localhost:3000/ui/?page=llm-playground (or the chat playground page), pick a reasoning-capable model such as `gpt-5.4-mini` with `reasoning_effort` set, and confirm the request mode is Responses API
4. Send any prompt and wait for the response to finish
5. On the base commit `7a1afa1c40` the usage row under the response shows no reasoning-tokens chip; on this PR's head it shows a reasoning-tokens chip with a non-zero count

## Type

🐛 Bug Fix

## Caveats (if any)

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
