### PR TITLE
fix(proxy): make /team/member_delete's four cleanups atomic

### DIFF
--- a/litellm/proxy/management_endpoints/key_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/key_management_endpoints.py
@@ -20,7 +20,7 @@ import secrets
 import traceback
 from collections.abc import Awaitable, Callable, Mapping, Sequence
 from datetime import datetime, timedelta, timezone
-from typing import Any, Final, Literal, Optional, Protocol, TypeVar, cast
+from typing import TYPE_CHECKING, Any, Final, Literal, Optional, Protocol, TypeVar, cast
 
 import fastapi
 import yaml
@@ -147,6 +147,9 @@ from litellm.types.utils import (
     PersonalUIKeyGenerationConfig,
     TeamUIKeyGenerationConfig,
 )
+
+if TYPE_CHECKING:
+    from prisma import Prisma
 
 _PrismaRowT = TypeVar("_PrismaRowT")
 _RepositoryModelT = TypeVar("_RepositoryModelT", bound=BaseModel)
@@ -4337,9 +4340,18 @@ def _transform_verification_tokens_to_deleted_records(
 async def _save_deleted_verification_token_records(
     records: Sequence[Mapping[str, object]],
     prisma_client: PrismaClient,
+    tx: "Prisma | None" = None,
 ) -> None:
-    """Save deleted verification token records to the database."""
+    """Save deleted verification token records to the database.
+
+    ``tx`` runs the write on that transaction's connection instead of a fresh
+    one, so a caller batching this with other writes gets one all-or-nothing
+    commit.
+    """
     if not records:
+        return
+    if tx is not None:
+        await tx.litellm_deletedverificationtoken.create_many(data=records)
         return
     await _deleted_verification_token_table(prisma_client).create_many(data=records)
 
@@ -4349,6 +4361,7 @@ async def _persist_deleted_verification_tokens(
     prisma_client: PrismaClient,
     user_api_key_dict: UserAPIKeyAuth,
     litellm_changed_by: str | None = None,
+    tx: "Prisma | None" = None,
 ) -> None:
     """Persist deleted verification token records by transforming and saving them."""
     records: Final = _transform_verification_tokens_to_deleted_records(
@@ -4359,6 +4372,7 @@ async def _persist_deleted_verification_tokens(
     await _save_deleted_verification_token_records(
         records=records,
         prisma_client=prisma_client,
+        tx=tx,
     )
 
 

--- a/litellm/proxy/management_endpoints/team_endpoints.py
+++ b/litellm/proxy/management_endpoints/team_endpoints.py
@@ -3286,15 +3286,6 @@ async def team_member_delete(
 
     _db_new_team_members: Final[list[dict]] = [m.model_dump() for m in new_team_members]
 
-    _ = await _team_db(prisma_client).update(
-        where={
-            "team_id": data.team_id,
-        },
-        data={"members_with_roles": json.dumps(_db_new_team_members)},
-    )
-
-    _emit_team_members_metric(existing_team_row)
-
     ## DELETE TEAM ID from USER ROW, IF EXISTS ##
     # get user row
     removed_user_ids: Final = frozenset(m.user_id for m in removed_team_members if m.user_id is not None)
@@ -3303,52 +3294,62 @@ async def team_member_delete(
     )
     existing_user_rows: Final[Sequence[LiteLLM_UserTable]] = await _user_db(prisma_client).find_many(where=key_val)
 
-    for existing_user in existing_user_rows:
-        if data.team_id in existing_user.teams:
-            await _user_db(prisma_client).update(
-                where={
-                    "user_id": existing_user.user_id,
-                },
-                data={"teams": {"set": [team for team in existing_user.teams if team != data.team_id]}},
-            )
-
     # Also clean up any existing team membership rows for this user and team
     user_ids_to_delete: Final = removed_user_ids.union(
         (data.user_id,) if data.user_id is not None else (),
         (user.user_id for user in existing_user_rows if user.user_id),
     )
 
-    for _uid in sorted(user_ids_to_delete):
-        await _team_membership_db(prisma_client).delete_many(where={"team_id": data.team_id, "user_id": _uid})
-
     ## DELETE KEYS CREATED BY USER FOR THIS TEAM
-    if user_ids_to_delete:
-        from litellm.proxy.management_endpoints.key_management_endpoints import (
-            _persist_deleted_verification_tokens,
+    # Fetch keys before deletion so their audit records can be persisted alongside the delete.
+    # An empty user_ids_to_delete still resolves cleanly: prisma's "in": [] matches no rows.
+    keys_to_delete: Final[list[LiteLLM_VerificationToken]] = await _tokens_db(prisma_client).find_many(
+        where={
+            "user_id": {"in": sorted(user_ids_to_delete)},
+            "team_id": data.team_id,
+        }
+    )
+
+    # All four cleanups run on one connection so a failure between them leaves
+    # no partial removal: either every write below lands, or none of them do.
+    async with prisma_client.tx() as tx:
+        await tx.litellm_teamtable.update(
+            where={"team_id": data.team_id},
+            data={"members_with_roles": json.dumps(_db_new_team_members)},
         )
 
-        # Fetch keys before deletion to persist them
-        keys_to_delete: Final[list[LiteLLM_VerificationToken]] = await _tokens_db(prisma_client).find_many(
-            where={
-                "user_id": {"in": sorted(user_ids_to_delete)},
-                "team_id": data.team_id,
-            }
-        )
+        for existing_user in existing_user_rows:
+            if data.team_id in existing_user.teams:
+                await tx.litellm_usertable.update(
+                    where={"user_id": existing_user.user_id},
+                    data={"teams": {"set": [team for team in existing_user.teams if team != data.team_id]}},
+                )
 
-        if keys_to_delete:
-            await _persist_deleted_verification_tokens(
-                keys=keys_to_delete,
-                prisma_client=prisma_client,
-                user_api_key_dict=user_api_key_dict,
-                litellm_changed_by=None,
+        for _uid in sorted(user_ids_to_delete):
+            await tx.litellm_teammembership.delete_many(where={"team_id": data.team_id, "user_id": _uid})
+
+        if user_ids_to_delete:
+            if keys_to_delete:
+                from litellm.proxy.management_endpoints.key_management_endpoints import (
+                    _persist_deleted_verification_tokens,
+                )
+
+                await _persist_deleted_verification_tokens(
+                    keys=keys_to_delete,
+                    prisma_client=prisma_client,
+                    user_api_key_dict=user_api_key_dict,
+                    litellm_changed_by=None,
+                    tx=tx,
+                )
+
+            await tx.litellm_verificationtoken.delete_many(
+                where={
+                    "user_id": {"in": sorted(user_ids_to_delete)},
+                    "team_id": data.team_id,
+                }
             )
 
-        await _tokens_db(prisma_client).delete_many(
-            where={
-                "user_id": {"in": sorted(user_ids_to_delete)},
-                "team_id": data.team_id,
-            }
-        )
+    _emit_team_members_metric(existing_team_row)
 
     return existing_team_row
 

--- a/tests/test_litellm/proxy/management_endpoints/test_team_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_team_endpoints.py
@@ -80,6 +80,23 @@ def _wire_team_create_tx(prisma_client):
     prisma_client.db.tx = lambda *_args, **_kwargs: _tx()
 
 
+def _wire_member_delete_tx(prisma_client):
+    """/team/member_delete's four cleanups run inside one transaction, so a mocked
+    client has to hand back its own table mocks out of `tx()` for the existing
+    per-table assertions to keep seeing the calls."""
+    tx = SimpleNamespace(
+        litellm_teamtable=prisma_client.db.litellm_teamtable,
+        litellm_usertable=prisma_client.db.litellm_usertable,
+        litellm_teammembership=prisma_client.db.litellm_teammembership,
+        litellm_verificationtoken=prisma_client.db.litellm_verificationtoken,
+        litellm_deletedverificationtoken=prisma_client.db.litellm_deletedverificationtoken,
+    )
+    tx_cm = MagicMock()
+    tx_cm.__aenter__ = AsyncMock(return_value=tx)
+    tx_cm.__aexit__ = AsyncMock(return_value=None)
+    prisma_client.tx = MagicMock(return_value=tx_cm)
+
+
 # Mock prisma_client
 mock_prisma_client = MagicMock()
 # Set up async mock for db operations
@@ -4147,6 +4164,8 @@ async def test_team_member_delete_cleans_membership(mock_db_client, mock_admin_a
         return_value=MagicMock()
     )
 
+    _wire_member_delete_tx(mock_db_client)
+
     # Execute
     await team_member_delete(
         data=TeamMemberDeleteRequest(team_id=test_team_id, user_id=test_user_id),
@@ -4204,6 +4223,8 @@ async def test_team_member_delete_cleans_verification_tokens(
     mock_db_client.db.litellm_verificationtoken.delete_many = AsyncMock(
         return_value=MagicMock()
     )
+
+    _wire_member_delete_tx(mock_db_client)
 
     await team_member_delete(
         data=TeamMemberDeleteRequest(team_id=test_team_id, user_id=test_user_id),
@@ -4300,6 +4321,8 @@ async def test_team_member_delete_by_email_the_user_row_does_not_carry(
         return_value=MagicMock()
     )
 
+    _wire_member_delete_tx(mock_db_client)
+
     await team_member_delete(
         data=TeamMemberDeleteRequest(team_id=test_team_id, user_email=roster_email),
         user_api_key_dict=mock_admin_auth,
@@ -4316,6 +4339,83 @@ async def test_team_member_delete_by_email_the_user_row_does_not_carry(
     mock_db_client.db.litellm_teammembership.delete_many.assert_awaited_once_with(
         where={"team_id": test_team_id, "user_id": test_user_id}
     )
+
+
+class _InjectedMemberDeleteFailure(Exception):
+    pass
+
+
+@pytest.mark.asyncio
+async def test_team_member_delete_is_atomic_across_its_four_writes(
+    mock_db_client, mock_admin_auth
+):
+    """
+    /team/member_delete's four cleanups (team roster, user.teams, team
+    membership, verification tokens) run as one transaction, so a failure
+    partway through must not leave the removal half applied.
+
+    Failing the second write (the user's ``teams`` update) pins two things a
+    non-transactional implementation gets wrong: the roster write that already
+    ran has to land on the SAME transaction client the failure raises on (so a
+    real database rolls it back too), and the writes still queued behind the
+    failure (membership delete, token delete) must never be attempted at all.
+    """
+    from litellm.proxy._types import TeamMemberDeleteRequest
+    from litellm.proxy.management_endpoints.team_endpoints import team_member_delete
+
+    test_team_id = "team-del-atomic-123"
+    test_user_id = "user-atomic@example.com"
+
+    mock_team_row = MagicMock()
+    mock_team_row.model_dump.return_value = {
+        "team_id": test_team_id,
+        "members_with_roles": [
+            {"user_id": test_user_id, "user_email": None, "role": "user"}
+        ],
+        "team_member_permissions": [],
+        "metadata": {},
+        "models": [],
+        "spend": 0.0,
+    }
+    mock_db_client.db.litellm_teamtable.find_unique = AsyncMock(
+        return_value=mock_team_row
+    )
+    mock_db_client.db.litellm_teamtable.update = AsyncMock(return_value=mock_team_row)
+
+    mock_user_row = MagicMock()
+    mock_user_row.user_id = test_user_id
+    mock_user_row.teams = [test_team_id]
+    mock_db_client.db.litellm_usertable.find_many = AsyncMock(
+        return_value=[mock_user_row]
+    )
+    mock_db_client.db.litellm_usertable.update = AsyncMock(
+        side_effect=_InjectedMemberDeleteFailure("boom between writes 1 and 2")
+    )
+
+    mock_db_client.db.litellm_teammembership = MagicMock()
+    mock_db_client.db.litellm_teammembership.delete_many = AsyncMock()
+
+    mock_db_client.db.litellm_verificationtoken = MagicMock()
+    mock_db_client.db.litellm_verificationtoken.find_many = AsyncMock(return_value=[])
+    mock_db_client.db.litellm_verificationtoken.delete_many = AsyncMock()
+
+    _wire_member_delete_tx(mock_db_client)
+
+    with pytest.raises(_InjectedMemberDeleteFailure):
+        await team_member_delete(
+            data=TeamMemberDeleteRequest(team_id=test_team_id, user_id=test_user_id),
+            user_api_key_dict=mock_admin_auth,
+        )
+
+    # The roster write ran, but on the transaction the injected failure also raised on.
+    mock_db_client.db.litellm_teamtable.update.assert_awaited_once()
+    mock_db_client.tx.assert_called_once()
+    aexit_args = mock_db_client.tx.return_value.__aexit__.await_args.args
+    assert aexit_args[0] is _InjectedMemberDeleteFailure
+
+    # Writes queued behind the failure inside that same transaction never ran.
+    mock_db_client.db.litellm_teammembership.delete_many.assert_not_awaited()
+    mock_db_client.db.litellm_verificationtoken.delete_many.assert_not_awaited()
 
 
 @pytest.mark.asyncio
@@ -7805,6 +7905,8 @@ async def test_team_member_delete_persists_deleted_keys(monkeypatch):
     mock_prisma_client.db.litellm_deletedverificationtoken.create_many = (
         mock_create_many_keys
     )
+
+    _wire_member_delete_tx(mock_prisma_client)
 
     monkeypatch.setattr(
         "litellm.proxy.proxy_server.prisma_client",


### PR DESCRIPTION
## TLDR

Problem this solves:

- `/team/member_delete` writes the team roster, the user's teams list, the team membership row, and the verification token as four separate statements
- A failure between any two writes leaves the removal half applied: the roster can show a member gone while their key and membership row still work

How it solves it:

- Wraps all four writes in one prisma transaction so they commit or roll back together, following the same `tx.<table>` pattern `/team/member_add` and `/team/member_update` already use

## User Flow

Before: an admin removing a member from a team can leave that member with full API access if any of the four database writes `/team/member_delete` performs fails partway through

1. Admin sends POST https://litellm-domain/team/member_delete with `{"team_id": "team-1", "user_id": "user-1"}`
2. A transient database failure partway through the cleanup returns a 500, but the team roster and the user's team list were already updated to drop the member before the failure hit
3. Admin opens https://litellm-domain/ui/?page=teams and sees user-1 no longer listed on the team
4. user-1's API key for that team is still active in the database, so they can keep sending requests to /v1/chat/completions and get billed against the team's budget as if nothing happened

After: the same transient failure now leaves the member fully in place instead of half removed

1. Admin sends the same POST https://litellm-domain/team/member_delete
2. The same transient failure still returns a 500, but the roster, the user's team list, the membership row, and the key are all left untouched
3. Admin opens https://litellm-domain/ui/?page=teams and still sees user-1 listed, matching the fact that nothing was actually removed
4. user-1's key still works, same as before the failed call. Once the admin retries after the transient issue clears, the request returns 200 and the roster, team list, membership row, and key are all removed together, so user-1 can no longer authenticate with that key

## Relevant issues

## Linear ticket

Resolves LIT-5541

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Setup shared by both runs: a fresh Postgres 16 container, schema pushed with `prisma db push`, proxy started with `DISABLE_SCHEMA_UPDATE=true` and no other flags, master key `sk-lit5541-test`. A team is seeded with one extra member who has a per-member budget (so a membership row exists) and an active key:

```
curl -X POST http://localhost:24541/team/new -H "Authorization: Bearer sk-lit5541-test" \
  -d '{"team_id": "lit5541-team", "team_alias": "lit5541"}'
curl -X POST http://localhost:24541/team/member_add -H "Authorization: Bearer sk-lit5541-test" \
  -d '{"team_id": "lit5541-team", "member": {"role": "user", "user_id": "lit5541-user"}}'
curl -X POST http://localhost:24541/team/member_update -H "Authorization: Bearer sk-lit5541-test" \
  -d '{"team_id": "lit5541-team", "user_id": "lit5541-user", "max_budget_in_team": 100}'
curl -X POST http://localhost:24541/key/generate -H "Authorization: Bearer sk-lit5541-test" \
  -d '{"team_id": "lit5541-team", "user_id": "lit5541-user"}'
```

A failure between writes is forced with a Postgres trigger that raises on the third write:

```sql
CREATE OR REPLACE FUNCTION lit5541_block_membership_delete() RETURNS trigger AS $$
BEGIN
  RAISE EXCEPTION 'lit5541 injected failure: membership delete blocked';
END;
$$ LANGUAGE plpgsql;

CREATE TRIGGER lit5541_block_delete
BEFORE DELETE ON "LiteLLM_TeamMembership"
FOR EACH ROW EXECUTE FUNCTION lit5541_block_membership_delete();
```

### Before (490c9f9f3f)

1. With the trigger installed, call the endpoint:
   ```
   curl -X POST http://localhost:24541/team/member_delete -H "Authorization: Bearer sk-lit5541-test" \
     -d '{"team_id": "lit5541-team-before", "user_id": "lit5541-user-a"}'
   ```
   Response: `{"error":{"message":"Internal server error","type":"internal_server_error"}}`, HTTP 500
2. Query the four rows the request touches:
   ```
   SELECT members_with_roles FROM "LiteLLM_TeamTable" WHERE team_id='lit5541-team-before';
   SELECT teams FROM "LiteLLM_UserTable" WHERE user_id='lit5541-user-a';
   SELECT team_id, user_id FROM "LiteLLM_TeamMembership" WHERE team_id='lit5541-team-before';
   SELECT user_id, team_id FROM "LiteLLM_VerificationToken" WHERE team_id='lit5541-team-before';
   ```
   Result: the roster no longer contains `lit5541-user-a` and `LiteLLM_UserTable.teams` is now `{}`, both committed, while the membership row and the verification token are both still present, since the delete on them is what the trigger blocked. The member reads as removed while their key and membership row still work

### After (9c5f874da1)

1. Same seed, same trigger, same call against the team_id `lit5541-team-after` / `lit5541-user-b`:
   ```
   curl -X POST http://localhost:24541/team/member_delete -H "Authorization: Bearer sk-lit5541-test" \
     -d '{"team_id": "lit5541-team-after", "user_id": "lit5541-user-b"}'
   ```
   Response: `{"error":{"message":"Internal server error","type":"internal_server_error"}}`, HTTP 500
2. Same four queries against `lit5541-team-after` / `lit5541-user-b`: the roster still lists `lit5541-user-b`, `LiteLLM_UserTable.teams` still contains the team, the membership row still exists, and the verification token still exists. Nothing committed
3. Drop the trigger and retry the same request:
   ```
   DROP TRIGGER lit5541_block_delete ON "LiteLLM_TeamMembership";
   curl -X POST http://localhost:24541/team/member_delete -H "Authorization: Bearer sk-lit5541-test" \
     -d '{"team_id": "lit5541-team-after", "user_id": "lit5541-user-b"}'
   ```
   Response: 200, with `members_with_roles` down to just the team admin
4. Re-run the same four queries: the roster no longer lists `lit5541-user-b`, `LiteLLM_UserTable.teams` is `{}`, the membership row is gone, the verification token is gone, and `LiteLLM_DeletedVerificationToken` now carries its audit record. All four writes landed together

## Type

🐛 Bug Fix

## Caveats (if any)

- Locking concurrent `/team/member_delete` calls against each other is a separate change, tracked in LIT-5544

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
