### PR TITLE
fix(auth): resolve team object_permission independently in the unresolvable-team fallback

### DIFF
--- a/litellm/proxy/auth/user_api_key_auth.py
+++ b/litellm/proxy/auth/user_api_key_auth.py
@@ -1150,13 +1150,8 @@ async def _resolve_object_permission_for_unresolvable_team(
     parent_otel_span: Span | None,
     proxy_logging_obj: ProxyLogging,
 ) -> LiteLLM_ObjectPermissionTable | None:
-    """Resolve a team's object permission by id when the team row itself cannot be read.
-
-    The token-derived team fallback reconstructs the team from the token's own cached
-    fields, which carry the object_permission id but not the resolved row. Leaving it
-    unset would silently drop any vector-store/MCP restriction the team carried,
-    granting more than the token's own object_permission_id vouches for.
-    """
+    """Re-resolve a team's object permission by id when the team row itself is unreadable, so the
+    token-derived fallback doesn't silently drop it."""
     if object_permission_id is None or prisma_client is None:
         return None
     return await get_object_permission(

--- a/litellm/proxy/auth/user_api_key_auth.py
+++ b/litellm/proxy/auth/user_api_key_auth.py
@@ -49,6 +49,7 @@ from litellm.proxy.auth.auth_checks import (
     common_checks,
     get_end_user_object,
     get_jwt_key_mapping_object,
+    get_object_permission,
     get_project_object,
     get_team_object,
     get_user_object,
@@ -1142,6 +1143,31 @@ async def _record_unparsable_body_failure(
         verbose_proxy_logger.exception("Failed to log the request rejected for an unparsable body: %s", e)
 
 
+async def _resolve_object_permission_for_unresolvable_team(
+    object_permission_id: str | None,
+    prisma_client: PrismaClient | None,
+    user_api_key_cache: UserApiKeyCache,
+    parent_otel_span: Span | None,
+    proxy_logging_obj: ProxyLogging,
+) -> LiteLLM_ObjectPermissionTable | None:
+    """Resolve a team's object permission by id when the team row itself cannot be read.
+
+    The token-derived team fallback reconstructs the team from the token's own cached
+    fields, which carry the object_permission id but not the resolved row. Leaving it
+    unset would silently drop any vector-store/MCP restriction the team carried,
+    granting more than the token's own object_permission_id vouches for.
+    """
+    if object_permission_id is None or prisma_client is None:
+        return None
+    return await get_object_permission(
+        object_permission_id=object_permission_id,
+        prisma_client=prisma_client,
+        user_api_key_cache=user_api_key_cache,
+        parent_otel_span=parent_otel_span,
+        proxy_logging_obj=proxy_logging_obj,
+    )
+
+
 async def _user_api_key_auth_builder(
     request: Request,
     api_key: str,
@@ -2114,6 +2140,13 @@ async def _user_api_key_auth_builder(
                         models=valid_token.team_models,
                         metadata=valid_token.team_metadata,
                         object_permission_id=valid_token.team_object_permission_id,
+                        object_permission=await _resolve_object_permission_for_unresolvable_team(
+                            object_permission_id=valid_token.team_object_permission_id,
+                            prisma_client=prisma_client,
+                            user_api_key_cache=user_api_key_cache,
+                            parent_otel_span=parent_otel_span,
+                            proxy_logging_obj=proxy_logging_obj,
+                        ),
                     )
             else:
                 _team_obj = None

--- a/tests/test_litellm/proxy/auth/test_user_api_key_auth.py
+++ b/tests/test_litellm/proxy/auth/test_user_api_key_auth.py
@@ -3576,20 +3576,8 @@ async def test_auth_flow_never_persists_fallback_team_object_lit_4391():
 
 
 @pytest.mark.asyncio
-async def test_auth_flow_fallback_team_keeps_object_permission_lit_5539():
-    """
-    Regression test for LIT-5539 (team fallback drops team_object_permission).
-
-    When `get_team_object` fails at the "Check 6" team-auth step, the builder
-    reconstructs a team from the token's own cached fields, including
-    `team_object_permission_id`, but historically left `object_permission`
-    itself unset (None). Since the token's own id still names a real,
-    independently-resolvable restriction (e.g. a vector-store/MCP allowlist),
-    dropping it granted more than the credential itself carries.
-
-    Pins: the fallback resolves `team_object_permission` by its id, so the
-    restriction survives an unresolvable team row.
-    """
+async def test_auth_flow_fallback_team_resolves_object_permission_by_id():
+    """The unresolvable-team fallback resolves team_object_permission by its own id instead of leaving it unset."""
     from starlette.datastructures import URL
     from starlette.requests import Request
     from fastapi import HTTPException
@@ -3601,17 +3589,17 @@ async def test_auth_flow_fallback_team_keeps_object_permission_lit_5539():
     )
     from litellm.proxy.auth.user_api_key_auth import _user_api_key_auth_builder
 
-    api_key = "sk-test-lit-5539-object-permission"
+    api_key = "sk-test-fallback-team-object-permission"
     valid_token = UserAPIKeyAuth(
         api_key=api_key,
         token=api_key,
         user_role=LitellmUserRoles.INTERNAL_USER,
-        team_id="team-lit-5539",
-        team_object_permission_id="op-lit-5539",
+        team_id="team-fallback-object-permission",
+        team_object_permission_id="op-fallback-object-permission",
     )
 
     restricted_object_permission = LiteLLM_ObjectPermissionTable(
-        object_permission_id="op-lit-5539",
+        object_permission_id="op-fallback-object-permission",
         vector_stores=["vs-allowed-only"],
         mcp_servers=["mcp-allowed-only"],
     )
@@ -3681,7 +3669,7 @@ async def test_auth_flow_fallback_team_keeps_object_permission_lit_5539():
             )
 
         mock_get_object_permission.assert_awaited_once()
-        assert mock_get_object_permission.await_args.kwargs["object_permission_id"] == "op-lit-5539"
+        assert mock_get_object_permission.await_args.kwargs["object_permission_id"] == "op-fallback-object-permission"
         assert result.team_object_permission == restricted_object_permission
         assert result.team_object_permission.vector_stores == ["vs-allowed-only"]
         assert result.team_object_permission.mcp_servers == ["mcp-allowed-only"]
@@ -3692,15 +3680,9 @@ async def test_auth_flow_fallback_team_keeps_object_permission_lit_5539():
 
 
 @pytest.mark.asyncio
-async def test_auth_flow_fallback_team_object_permission_degrades_to_none_lit_5539():
-    """
-    Counterpart to the resolution test above: when the object_permission row
-    itself cannot be read either (e.g. a total DB outage, not merely the team
-    row being gone), the fallback must not raise and must not fabricate a
-    permission it never read. `team_object_permission` degrades to None,
-    matching the scope every other object_permission reader already treats
-    as "unknown, not evidence of an unrestricted grant".
-    """
+async def test_auth_flow_fallback_team_object_permission_none_when_unreadable():
+    """When the object_permission row is also unreadable, the fallback leaves team_object_permission as None
+    instead of raising or fabricating a grant."""
     from starlette.datastructures import URL
     from starlette.requests import Request
     from fastapi import HTTPException
@@ -3708,13 +3690,13 @@ async def test_auth_flow_fallback_team_object_permission_degrades_to_none_lit_55
     from litellm.proxy._types import LitellmUserRoles, UserAPIKeyAuth
     from litellm.proxy.auth.user_api_key_auth import _user_api_key_auth_builder
 
-    api_key = "sk-test-lit-5539-object-permission-unreadable"
+    api_key = "sk-test-fallback-team-object-permission-unreadable"
     valid_token = UserAPIKeyAuth(
         api_key=api_key,
         token=api_key,
         user_role=LitellmUserRoles.INTERNAL_USER,
-        team_id="team-lit-5539-unreadable",
-        team_object_permission_id="op-lit-5539-unreadable",
+        team_id="team-fallback-object-permission-unreadable",
+        team_object_permission_id="op-fallback-object-permission-unreadable",
     )
 
     mock_cache = AsyncMock()

--- a/tests/test_litellm/proxy/auth/test_user_api_key_auth.py
+++ b/tests/test_litellm/proxy/auth/test_user_api_key_auth.py
@@ -3575,6 +3575,219 @@ async def test_auth_flow_never_persists_fallback_team_object_lit_4391():
             setattr(_proxy_server_mod, k, v)
 
 
+@pytest.mark.asyncio
+async def test_auth_flow_fallback_team_keeps_object_permission_lit_5539():
+    """
+    Regression test for LIT-5539 (team fallback drops team_object_permission).
+
+    When `get_team_object` fails at the "Check 6" team-auth step, the builder
+    reconstructs a team from the token's own cached fields, including
+    `team_object_permission_id`, but historically left `object_permission`
+    itself unset (None). Since the token's own id still names a real,
+    independently-resolvable restriction (e.g. a vector-store/MCP allowlist),
+    dropping it granted more than the credential itself carries.
+
+    Pins: the fallback resolves `team_object_permission` by its id, so the
+    restriction survives an unresolvable team row.
+    """
+    from starlette.datastructures import URL
+    from starlette.requests import Request
+    from fastapi import HTTPException
+
+    from litellm.proxy._types import (
+        LiteLLM_ObjectPermissionTable,
+        LitellmUserRoles,
+        UserAPIKeyAuth,
+    )
+    from litellm.proxy.auth.user_api_key_auth import _user_api_key_auth_builder
+
+    api_key = "sk-test-lit-5539-object-permission"
+    valid_token = UserAPIKeyAuth(
+        api_key=api_key,
+        token=api_key,
+        user_role=LitellmUserRoles.INTERNAL_USER,
+        team_id="team-lit-5539",
+        team_object_permission_id="op-lit-5539",
+    )
+
+    restricted_object_permission = LiteLLM_ObjectPermissionTable(
+        object_permission_id="op-lit-5539",
+        vector_stores=["vs-allowed-only"],
+        mcp_servers=["mcp-allowed-only"],
+    )
+
+    mock_cache = AsyncMock()
+    mock_cache.async_get_cache = AsyncMock(return_value=valid_token)
+    mock_cache.async_set_cache = AsyncMock(return_value=None)
+
+    mock_proxy_logging_obj = MagicMock()
+    mock_proxy_logging_obj.internal_usage_cache = MagicMock()
+    mock_proxy_logging_obj.internal_usage_cache.dual_cache = AsyncMock()
+    mock_proxy_logging_obj.post_call_failure_hook = AsyncMock(return_value=None)
+
+    import litellm.proxy.proxy_server as _proxy_server_mod
+
+    _attrs = {
+        "prisma_client": MagicMock(),
+        "user_api_key_cache": mock_cache,
+        "proxy_logging_obj": mock_proxy_logging_obj,
+        "master_key": "sk-master-key",
+        "general_settings": {},
+        "llm_model_list": [],
+        "llm_router": None,
+        "open_telemetry_logger": None,
+        "model_max_budget_limiter": MagicMock(),
+        "user_custom_auth": None,
+        "jwt_handler": None,
+        "litellm_proxy_admin_name": "admin",
+    }
+    _originals = {k: getattr(_proxy_server_mod, k, None) for k in _attrs}
+
+    try:
+        for k, v in _attrs.items():
+            setattr(_proxy_server_mod, k, v)
+
+        request = Request(scope={"type": "http"})
+        request._url = URL(url="/chat/completions")
+
+        with (
+            patch(
+                "litellm.proxy.auth.resolvers.store.IdentityStore._resolve_key",
+                new_callable=AsyncMock,
+                return_value=valid_token,
+            ),
+            patch(
+                "litellm.proxy.auth.user_api_key_auth.get_team_object",
+                new_callable=AsyncMock,
+                side_effect=HTTPException(
+                    status_code=404,
+                    detail={"error": "Team doesn't exist in db."},
+                ),
+            ),
+            patch(
+                "litellm.proxy.auth.user_api_key_auth.get_object_permission",
+                new_callable=AsyncMock,
+                return_value=restricted_object_permission,
+            ) as mock_get_object_permission,
+        ):
+            result = await _user_api_key_auth_builder(
+                request=request,
+                api_key=f"Bearer {api_key}",
+                azure_api_key_header="",
+                anthropic_api_key_header=None,
+                google_ai_studio_api_key_header=None,
+                azure_apim_header=None,
+                request_data={},
+            )
+
+        mock_get_object_permission.assert_awaited_once()
+        assert mock_get_object_permission.await_args.kwargs["object_permission_id"] == "op-lit-5539"
+        assert result.team_object_permission == restricted_object_permission
+        assert result.team_object_permission.vector_stores == ["vs-allowed-only"]
+        assert result.team_object_permission.mcp_servers == ["mcp-allowed-only"]
+
+    finally:
+        for k, v in _originals.items():
+            setattr(_proxy_server_mod, k, v)
+
+
+@pytest.mark.asyncio
+async def test_auth_flow_fallback_team_object_permission_degrades_to_none_lit_5539():
+    """
+    Counterpart to the resolution test above: when the object_permission row
+    itself cannot be read either (e.g. a total DB outage, not merely the team
+    row being gone), the fallback must not raise and must not fabricate a
+    permission it never read. `team_object_permission` degrades to None,
+    matching the scope every other object_permission reader already treats
+    as "unknown, not evidence of an unrestricted grant".
+    """
+    from starlette.datastructures import URL
+    from starlette.requests import Request
+    from fastapi import HTTPException
+
+    from litellm.proxy._types import LitellmUserRoles, UserAPIKeyAuth
+    from litellm.proxy.auth.user_api_key_auth import _user_api_key_auth_builder
+
+    api_key = "sk-test-lit-5539-object-permission-unreadable"
+    valid_token = UserAPIKeyAuth(
+        api_key=api_key,
+        token=api_key,
+        user_role=LitellmUserRoles.INTERNAL_USER,
+        team_id="team-lit-5539-unreadable",
+        team_object_permission_id="op-lit-5539-unreadable",
+    )
+
+    mock_cache = AsyncMock()
+    mock_cache.async_get_cache = AsyncMock(return_value=valid_token)
+    mock_cache.async_set_cache = AsyncMock(return_value=None)
+
+    mock_proxy_logging_obj = MagicMock()
+    mock_proxy_logging_obj.internal_usage_cache = MagicMock()
+    mock_proxy_logging_obj.internal_usage_cache.dual_cache = AsyncMock()
+    mock_proxy_logging_obj.post_call_failure_hook = AsyncMock(return_value=None)
+
+    import litellm.proxy.proxy_server as _proxy_server_mod
+
+    _attrs = {
+        "prisma_client": MagicMock(),
+        "user_api_key_cache": mock_cache,
+        "proxy_logging_obj": mock_proxy_logging_obj,
+        "master_key": "sk-master-key",
+        "general_settings": {},
+        "llm_model_list": [],
+        "llm_router": None,
+        "open_telemetry_logger": None,
+        "model_max_budget_limiter": MagicMock(),
+        "user_custom_auth": None,
+        "jwt_handler": None,
+        "litellm_proxy_admin_name": "admin",
+    }
+    _originals = {k: getattr(_proxy_server_mod, k, None) for k in _attrs}
+
+    try:
+        for k, v in _attrs.items():
+            setattr(_proxy_server_mod, k, v)
+
+        request = Request(scope={"type": "http"})
+        request._url = URL(url="/chat/completions")
+
+        with (
+            patch(
+                "litellm.proxy.auth.resolvers.store.IdentityStore._resolve_key",
+                new_callable=AsyncMock,
+                return_value=valid_token,
+            ),
+            patch(
+                "litellm.proxy.auth.user_api_key_auth.get_team_object",
+                new_callable=AsyncMock,
+                side_effect=HTTPException(
+                    status_code=404,
+                    detail={"error": "Team doesn't exist in db."},
+                ),
+            ),
+            patch(
+                "litellm.proxy.auth.user_api_key_auth.get_object_permission",
+                new_callable=AsyncMock,
+                return_value=None,
+            ),
+        ):
+            result = await _user_api_key_auth_builder(
+                request=request,
+                api_key=f"Bearer {api_key}",
+                azure_api_key_header="",
+                anthropic_api_key_header=None,
+                google_ai_studio_api_key_header=None,
+                azure_apim_header=None,
+                request_data={},
+            )
+
+        assert result.team_object_permission is None
+
+    finally:
+        for k, v in _originals.items():
+            setattr(_proxy_server_mod, k, v)
+
+
 # ---------------------------------------------------------------------------
 
 # _run_centralized_common_checks — centralized authz gate


### PR DESCRIPTION
## TLDR

Problem this solves:

- When a token's team row cannot be read, the auth fallback dropped the team's object_permission
- That silently widened a token's effective vector-store/MCP/agent access beyond what its own object_permission_id vouches for

How it solves it:

- Resolve the team's object_permission independently by its own object_permission_id when the team row itself is unresolvable
- Matches how vector store access checks and MCP resolvers already treat an unresolvable team

## User Flow

Before: a token whose team's database row becomes unreadable (deleted, or a transient lookup miss with a stale key-level cache) has its effective access silently re-derived without the team's object-permission restriction, even though the restriction still exists in the database

1. An admin creates a team with `object_permission.vector_stores` restricted to one store, and a key scoped to that team
2. The team's underlying database row is later deleted (or otherwise becomes unreadable) while the key stays cached
3. The key sends a request that resolves through the auth layer's unresolvable-team fallback
4. The returned auth object carries `team_object_permission_id` (the restriction's id) but `team_object_permission` itself is `None`, so any code that trusts that field directly sees no restriction at all instead of the one the id names

After: the same fallback re-resolves the restriction by its own id, so the returned auth object accurately reflects it

1. Same team, key, and deleted team row as above
2. The key sends the same request through the same fallback
3. The returned auth object's `team_object_permission` is the actual restricted permission (naming the one allowed vector store), matching `team_object_permission_id`
4. Any caller that reads the field directly sees the true restriction instead of an empty one; a caller could no longer effectively bypass the team's restriction by relying on the field alone

## Relevant issues

## Linear ticket

Resolves LIT-5539

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Setup shared by both runs: a real proxy against real Postgres and real Redis (`enable_redis_auth_cache: true` plus `general_settings.coordination_redis`, so the auth cache is externally inspectable). A team ("owner-team") owns two vector stores, `vs-lit5539-allowed` and `vs-lit5539-forbidden`. A second team ("caller-team") is created with `object_permission.vector_stores: ["vs-lit5539-allowed"]`, and a key is generated scoped to caller-team. One request through the intact team warms both the key-level cache (which bakes in `team_object_permission_id` from a live join) and the team-level cache. The team-level cache entry is then evicted directly in Redis and the team's row is deleted from Postgres, while the object_permission row is left intact, reproducing the exact scenario: the team is unresolvable but its object_permission id is still known. A temporary debug log (not part of the diff) placed immediately after the fallback assignment records `team_object_permission_id` and the resolved `team_object_permission` on the real auth object built for that request

### Before (490c9f9f3faa0ba88b600f57abfb73f9f83b48ff, the merge base this PR is built on; reproduced by locally reverting just this PR's `object_permission=` assignment back to that commit's omission of the kwarg, which is behaviorally identical since both leave it at the pydantic default of `None`)

#### GET /vector_store/list against a key whose team became unresolvable

1. `curl $BASE/vector_store/list -H "Authorization: Bearer $CALLER_KEY"` returns `vs-lit5539-allowed` only (`total_count: 1`)
2. Proxy log for that request: `LIT5539_PROOF team_object_permission_id=891dfb2b-19e2-4ccc-b839-3e458aba97ba team_object_permission=None`, so the auth object built for this request carries the restriction's id but not the restriction itself
3. The HTTP response still happens to be correctly scoped only because `can_user_access_vector_store` independently re-resolves the permission by id when the field is `None`; a caller that trusts `team_object_permission` directly (as a sibling code path, or any future consumer, already does for the identical key-level field) would see no restriction at all

### After (e4272c6122d636e57fe051ec7c58cd1db16a5538)

#### GET /vector_store/list against a key whose team became unresolvable

1. `curl $BASE/vector_store/list -H "Authorization: Bearer $CALLER_KEY"` returns `vs-lit5539-allowed` only (`total_count: 1`)
2. Proxy log for that request: `LIT5539_PROOF team_object_permission_id=31160444-2bbe-405f-9c46-d88fd0610b3b team_object_permission=object_permission_id='31160444-2bbe-405f-9c46-d88fd0610b3b' ... vector_stores=['vs-lit5539-allowed'] ...`, so the auth object now accurately carries the restriction itself, matching its id
3. The list only ever contains `vs-lit5539-allowed`, never `vs-lit5539-forbidden`, in either run, so the observable HTTP behavior is unchanged while the underlying auth object is now correct at the source rather than by accident of one consumer's own defensive re-resolution

## Type

🐛 Bug Fix

## Caveats (if any)

- The vector-store access check already re-resolves the permission by id when the field is `None`, so this fix closes the gap at the source rather than changing today's HTTP-observable behavior for that one endpoint; the risk it removes is any other or future consumer trusting `team_object_permission` directly, the same way the identical key-level field is already trusted elsewhere

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
