### PR TITLE
fix(proxy): omit litellm_batch_guardrail when no guardrail acted

### DIFF
--- a/litellm/proxy/pass_through_endpoints/managed_id_rewriter.py
+++ b/litellm/proxy/pass_through_endpoints/managed_id_rewriter.py
@@ -50,7 +50,7 @@ from litellm.repositories.table_repositories import (
     ManagedFileRepository,
     ManagedObjectRepository,
 )
-from litellm.types.llms.openai import OpenAIFileObject
+from litellm.types.llms.openai import BATCH_GUARDRAIL_RESPONSE_FIELD, OpenAIFileObject
 from litellm.types.passthrough_endpoints.managed_id_rewriter import (
     ManagedFileIdReader,
     ManagedFileIdWriter,
@@ -980,6 +980,7 @@ def _serialize_file_list_item(row: ManagedFileRow) -> dict[str, JsonValue]:
     file_object: Final = _parse_file_object(row.file_object)
     if isinstance(file_object, dict):
         item.update(file_object)
+    item.pop(BATCH_GUARDRAIL_RESPONSE_FIELD, None)
     item["id"] = row.unified_file_id  # managed ID always wins over stored raw id
     return item
 

--- a/litellm/types/llms/openai.py
+++ b/litellm/types/llms/openai.py
@@ -67,8 +67,10 @@ from pydantic import (
     Discriminator,
     Field,
     PrivateAttr,
+    SerializerFunctionWrapHandler,
     field_serializer,
     field_validator,
+    model_serializer,
 )
 from typing_extensions import (
     NotRequired,
@@ -315,6 +317,9 @@ class BatchGuardrailReport(BaseModel):
     """Every record that was redacted or dropped, in file order."""
 
 
+BATCH_GUARDRAIL_RESPONSE_FIELD: Final = "litellm_batch_guardrail"
+
+
 class OpenAIFileObject(BaseModel):
     id: str
     """The file identifier, which can be referenced in the API endpoints."""
@@ -362,6 +367,17 @@ class OpenAIFileObject(BaseModel):
     """
 
     _hidden_params: dict = {"response_cost": 0.0}  # no cost for writing a file
+
+    @model_serializer(mode="wrap")
+    def _omit_absent_batch_guardrail(  # noqa: ANN202  # annotating it replaces the model's serialization schema
+        self, handler: SerializerFunctionWrapHandler
+    ):
+        serialized: Final[Mapping[str, object]] = handler(self)
+        if self.litellm_batch_guardrail is not None:
+            return serialized
+        return {  # mutable-ok: pydantic's json serializer rejects a mapping that is not a dict
+            key: value for key, value in serialized.items() if key != BATCH_GUARDRAIL_RESPONSE_FIELD
+        }
 
     def __contains__(self, key) -> bool:
         # Define custom behavior for the 'in' operator

--- a/tests/test_litellm/proxy/openai_files_endpoint/test_files_endpoint.py
+++ b/tests/test_litellm/proxy/openai_files_endpoint/test_files_endpoint.py
@@ -4166,6 +4166,66 @@ def test_batch_upload_redacts_per_record(monkeypatch, llm_router: Router):
         ProxyLogging._callback_capabilities_cache.clear()
 
 
+PLAIN_UPLOAD_RESPONSE_BODY = {
+    "id": "dummy-id",
+    "object": "file",
+    "bytes": 0,
+    "created_at": 1234567890,
+    "filename": "batch.jsonl",
+    "purpose": "batch",
+    "status": "uploaded",
+    "expires_at": None,
+    "status_details": None,
+}
+
+
+def test_create_file_omits_batch_guardrail_field_when_no_guardrail_configured(monkeypatch, llm_router: Router):
+    """An upload no guardrail is configured for serialises the plain OpenAI file shape."""
+    forwarded_calls = _setup_batch_upload_endpoint(monkeypatch, llm_router)
+    try:
+        response = client.post(
+            "/v1/files",
+            files={"file": ("batch.jsonl", VALID_BATCH_LINE, "application/jsonl")},
+            data={"purpose": "batch"},
+            headers={"Authorization": "Bearer test-key"},
+        )
+    finally:
+        _teardown_batch_upload_endpoint()
+
+    assert response.status_code == 200, response.text
+    assert len(forwarded_calls) == 1
+    assert response.json() == PLAIN_UPLOAD_RESPONSE_BODY
+
+
+def test_create_file_omits_batch_guardrail_field_when_guardrail_made_no_changes(monkeypatch, llm_router: Router):
+    """A guardrail that runs and changes nothing leaves the response the plain OpenAI file shape."""
+    import litellm
+    from litellm.integrations.custom_guardrail import CustomGuardrail
+    from litellm.proxy.utils import ProxyLogging
+
+    class _Passthrough(CustomGuardrail):
+        async def async_pre_call_hook(self, user_api_key_dict, cache, data, call_type):
+            return data
+
+    forwarded_calls = _setup_batch_upload_endpoint(monkeypatch, llm_router)
+    monkeypatch.setattr(litellm, "callbacks", [_Passthrough(guardrail_name="noop", default_on=True)])
+    ProxyLogging._callback_capabilities_cache.clear()
+    try:
+        response = client.post(
+            "/v1/files",
+            files={"file": ("batch.jsonl", VALID_BATCH_LINE, "application/jsonl")},
+            data={"purpose": "batch"},
+            headers={"Authorization": "Bearer test-key"},
+        )
+    finally:
+        _teardown_batch_upload_endpoint()
+        ProxyLogging._callback_capabilities_cache.clear()
+
+    assert response.status_code == 200, response.text
+    assert len(forwarded_calls) == 1
+    assert response.json() == PLAIN_UPLOAD_RESPONSE_BODY
+
+
 def test_batch_upload_closes_the_spools_it_opened(monkeypatch, llm_router: Router):
     """The scan and the rewrite each open a spool; the request owns both and must not leak them."""
     import json as _json

--- a/tests/test_litellm/proxy/pass_through_endpoints/test_managed_id_rewriter.py
+++ b/tests/test_litellm/proxy/pass_through_endpoints/test_managed_id_rewriter.py
@@ -126,3 +126,24 @@ async def test_list_files_limit_above_batch_cap_still_served():
 
     assert result is not None
     assert [item["id"] for item in result["data"]] == [managed_id]
+
+
+@pytest.mark.asyncio
+async def test_list_files_drops_batch_guardrail_key_persisted_by_an_older_proxy():
+    """Rows written before the response serializer dropped the key still carry an explicit null."""
+    managed_id = new_managed_id("openai", "file-abc")
+    row = _file_row(managed_id)
+    row.file_object = {**row.file_object, "litellm_batch_guardrail": None}
+    pc = _prisma_client(file_rows=[row])
+
+    result = await list_passthrough_ids_from_db(
+        provider="openai",
+        route="/openai/v1/files",
+        user_api_key_dict=_user(),
+        prisma_client=pc,
+        query_params={},
+    )
+
+    assert result is not None
+    assert "litellm_batch_guardrail" not in result["data"][0]
+    assert result["data"][0]["filename"] == "test.jsonl"

--- a/tests/test_litellm/types/llms/test_types_llms_openai.py
+++ b/tests/test_litellm/types/llms/test_types_llms_openai.py
@@ -450,3 +450,75 @@ def test_openai_file_object_accepts_pending_status():
         status="pending",
     )
     assert file_obj.status == "pending"
+
+
+class TestOpenAIFileObjectBatchGuardrailSerialization:
+    """The proxy-only `litellm_batch_guardrail` key must reach the wire only when something set it."""
+
+    @staticmethod
+    def _file_object(**overrides):
+        from litellm.types.llms.openai import OpenAIFileObject
+
+        return OpenAIFileObject(
+            id="file-123",
+            object="file",
+            bytes=1024,
+            created_at=1677610602,
+            filename="batch.jsonl",
+            purpose="batch",
+            status="uploaded",
+            **overrides,
+        )
+
+    @staticmethod
+    def _report():
+        from litellm.types.llms.openai import BatchGuardrailRecord, BatchGuardrailReport
+
+        return BatchGuardrailReport(
+            submitted_records=3,
+            modified_records=(BatchGuardrailRecord(line=2, custom_id="dirty", action="redacted"),),
+        )
+
+    @pytest.mark.parametrize("mode", ["python", "json"])
+    def test_key_absent_when_unset(self, mode):
+        assert "litellm_batch_guardrail" not in self._file_object().model_dump(mode=mode)
+
+    @pytest.mark.parametrize("mode", ["python", "json"])
+    def test_key_present_when_set(self, mode):
+        dumped = self._file_object(litellm_batch_guardrail=self._report()).model_dump(mode=mode)
+        assert dumped["litellm_batch_guardrail"]["submitted_records"] == 3
+
+    def test_nested_nulls_of_a_set_report_survive(self):
+        """`exclude_none=True` was rejected as the fix because it would strip these."""
+        dumped = self._file_object(litellm_batch_guardrail=self._report()).model_dump(mode="json")
+        assert dumped["litellm_batch_guardrail"]["modified_records"] == [
+            {"line": 2, "custom_id": "dirty", "action": "redacted", "guardrail": None}
+        ]
+
+    def test_by_alias_dump_also_omits_the_key(self):
+        """Tripwire: the serializer filters a literal key name, which an added alias would bypass."""
+        assert "litellm_batch_guardrail" not in self._file_object().model_dump(mode="json", by_alias=True)
+
+    def test_other_optional_fields_still_serialize_as_null(self):
+        dumped = self._file_object().model_dump(mode="json")
+        assert dumped["expires_at"] is None
+        assert dumped["status_details"] is None
+
+    def test_round_trip_of_a_set_report_is_lossless(self):
+        from litellm.types.llms.openai import OpenAIFileObject
+
+        original = self._file_object(litellm_batch_guardrail=self._report())
+        assert OpenAIFileObject(**original.model_dump()) == original
+
+    def test_serialization_json_schema_still_describes_the_model(self):
+        """A return annotation on the wrap serializer would collapse this to a bare object."""
+        from litellm.types.llms.openai import OpenAIFileObject
+
+        schema = OpenAIFileObject.model_json_schema(mode="serialization")
+        assert "litellm_batch_guardrail" in schema["properties"]
+
+    def test_key_omitted_inside_a_file_list_page(self):
+        from litellm.types.llms.openai import FileListPage
+
+        page = FileListPage(object="list", data=[self._file_object()], has_more=False)
+        assert "litellm_batch_guardrail" not in page.model_dump(mode="json")["data"][0]


### PR DESCRIPTION
## TLDR

Problem this solves:

- Every /v1/files response gained a `litellm_batch_guardrail: null`
- Happens with zero guardrails configured, contradicting the field's own docstring
- Breaks byte-equality with the OpenAI file shape clients were getting before

How it solves it:

- A wrap serializer drops the key when nothing set it
- The populated report still serialises unchanged, nested nulls included
- One model change covers create, retrieve, and list, and the managed-files list route drops the key it already persisted

## User Flow

Before: a developer uploading a plain file to the gateway suddenly gets a field back that OpenAI never sends, on a proxy with no guardrails turned on at all

1. They send POST https://litellm-domain/v1/files with `purpose=user_data` and a text file
2. The 200 comes back with ten keys, the last one `"litellm_batch_guardrail": null`, where OpenAI's own API returns nine
3. Their client, which asserts the response matches the OpenAI file shape, sees an unexpected key and their strict-schema parse fails
4. They send GET https://litellm-domain/v1/files/file-abc123 for the same file and get the same extra null back

After: the same upload returns exactly what OpenAI returns, and the guardrail report only shows up when a guardrail actually did something

1. They send POST https://litellm-domain/v1/files with `purpose=user_data` and a text file
2. The 200 comes back with the nine keys OpenAI itself returns, and no `litellm_batch_guardrail`
3. They send GET https://litellm-domain/v1/files/file-abc123 and get the same nine keys
4. A proxy admin turns on a guardrail, and they send POST https://litellm-domain/v1/files with `purpose=batch` and a JSONL file where one row trips it
5. That 200 does carry `litellm_batch_guardrail`, reporting `submitted_records` and every changed row by `custom_id` and line, exactly as before

## Relevant issues

## Linear ticket

Refs LIT-5276

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

End to end against a live proxy pair, real OpenAI files API, one shared Postgres. Port 4762 is the current build, 4761 is this branch. The guardrail report survives untouched, and the key disappears from the plain upload, the file list, and the retrieve

![proof of fix](https://raw.githubusercontent.com/BerriAI/litellm/assets-pr37964/pr37964-batch-guardrail-absent.gif)

Shared setup, one proxy config, one plain file, one batch file. Two guardrails are on by default so the batch case has something to report, and the plain upload proves the key stays away even when guardrails exist.

```yaml
model_list:
  - model_name: gpt-4o-mini
    litellm_params:
      model: openai/gpt-4o-mini
      api_key: os.environ/OPENAI_API_KEY

files_settings:
  - custom_llm_provider: openai
    api_key: os.environ/OPENAI_API_KEY

guardrails:
  - guardrail_name: "mask-litellm"
    litellm_params:
      guardrail: litellm.proxy.example_config_yaml.custom_guardrail.myCustomGuardrail
      mode: "pre_call"
      default_on: true
  - guardrail_name: "block-bad"
    litellm_params:
      guardrail: litellm.proxy.example_config_yaml.pipeline_test_guardrails.StrictFilter
      mode: "pre_call"
      default_on: true

general_settings:
  master_key: sk-bgabsent-1234
```

```bash
printf 'hello world\n' > plain.txt
cat > batch.jsonl <<'EOF'
{"custom_id":"clean","method":"POST","url":"/v1/chat/completions","body":{"model":"gpt-4o-mini","messages":[{"role":"user","content":"hello world"}]}}
{"custom_id":"dirty","method":"POST","url":"/v1/chat/completions","body":{"model":"gpt-4o-mini","messages":[{"role":"user","content":"tell me about litellm proxy"}]}}
{"custom_id":"blocked","method":"POST","url":"/v1/chat/completions","body":{"model":"gpt-4o-mini","messages":[{"role":"user","content":"this is a bad request"}]}}
EOF
```

Both sides ran against the real OpenAI files API with a real key, same config, same order.

The list route is served from the DB rather than forwarded, so it needs a second config with a database and the managed-id flag on. Same two proxies, same Postgres, so one row is written by the old build and one by the new.

```yaml
general_settings:
  master_key: sk-bgabsent-1234
  passthrough_managed_object_ids: true
  database_url: "postgresql://..."
```


### Before (490c9f9f3f)

#### Plain upload, no guardrail can act

1. `curl -sS -X POST http://127.0.0.1:4762/v1/files -H "Authorization: Bearer $KEY" -F purpose=user_data -F file=@plain.txt`

```json
{"id":"file-LsWJYXvJgfzWoZjUR2QCgJ","bytes":12,"created_at":1787425081,"filename":"plain.txt","object":"file","purpose":"user_data","status":"processed","expires_at":null,"status_details":null,"litellm_batch_guardrail":null}
```

2. `curl -sS http://127.0.0.1:4762/v1/files/file-LsWJYXvJgfzWoZjUR2QCgJ -H "Authorization: Bearer $KEY"`

```json
{"id":"file-LsWJYXvJgfzWoZjUR2QCgJ","bytes":12,"created_at":1787425081,"filename":"plain.txt","object":"file","purpose":"user_data","status":"processed","expires_at":null,"status_details":null,"litellm_batch_guardrail":null}
```

3. For comparison, the same call straight to OpenAI returns nine keys: `bytes, created_at, expires_at, filename, id, object, purpose, status, status_details`

#### Batch upload, guardrails act on two rows

1. `curl -sS -X POST http://127.0.0.1:4762/v1/files -H "Authorization: Bearer $KEY" -F purpose=batch -F file=@batch.jsonl`

```json
{
    "id": "file-HMSed3EWMHm9NKmj3ed6BN",
    "bytes": 331,
    "created_at": 1787425082,
    "filename": "batch.jsonl",
    "object": "file",
    "purpose": "batch",
    "status": "processed",
    "expires_at": 1790017082,
    "status_details": null,
    "litellm_batch_guardrail": {
        "submitted_records": 2,
        "modified_records": [
            {"line": 2, "custom_id": "dirty", "action": "redacted", "guardrail": null},
            {"line": 3, "custom_id": "blocked", "action": "dropped", "guardrail": null}
        ]
    }
}
```

#### File list, one row persisted by an older build

1. `curl -sS http://127.0.0.1:4762/openai_passthrough/v1/files -H "Authorization: Bearer $KEY"`

```json
{
    "object": "list",
    "data": [
        {"id": "bGl0ZWxsbV9wcm94eTpwYXNzdGhyb3VnaDtwcm92aWRlcjpvcGVuYWk7dW5pZmllZF9pZCw0Nzk5ZDBmOS1mMWIzLTRkMDgtODE3MS1lZGUyNTc1ZjA2YTc7cmF3X2lkLGZpbGUtR0ZLNUNCOVVuWk1KWVo0M2FKUmUxZw",
         "object": "file", "created_at": 1787427769, "bytes": 481, "status": "processed",
         "purpose": "batch", "filename": "batch.jsonl", "expires_at": 1790019769, "status_details": null},
        {"id": "bGl0ZWxsbV9wcm94eTpwYXNzdGhyb3VnaDtwcm92aWRlcjpvcGVuYWk7dW5pZmllZF9pZCxmYTQ0ZjA4Mi0wZWQ3LTQ5OGUtYjc1NC04MTM4OTk3MmQ0YzY7cmF3X2lkLGZpbGUtOHdnQnZWOThRdVlBQUQxTGJHSnp5dA",
         "object": "file", "created_at": 1787427725, "bytes": 481, "status": "processed",
         "purpose": "batch", "filename": "batch.jsonl", "expires_at": 1790019725, "status_details": null,
         "litellm_batch_guardrail": null}
    ],
    "has_more": false
}
```

2. `curl -sS http://127.0.0.1:4762/v1/files -H "Authorization: Bearer $KEY"` returns both rows carrying `"litellm_batch_guardrail": null`

### After (8aad40a93a)

#### Plain upload, no guardrail can act

1. `curl -sS -X POST http://127.0.0.1:4761/v1/files -H "Authorization: Bearer $KEY" -F purpose=user_data -F file=@plain.txt`

```json
{"id":"file-TZUb1n69n6KvpyPQFRLrNt","bytes":12,"created_at":1787425082,"filename":"plain.txt","object":"file","purpose":"user_data","status":"processed","expires_at":null,"status_details":null}
```

2. `curl -sS http://127.0.0.1:4761/v1/files/file-TZUb1n69n6KvpyPQFRLrNt -H "Authorization: Bearer $KEY"`

```json
{"id":"file-TZUb1n69n6KvpyPQFRLrNt","bytes":12,"created_at":1787425082,"filename":"plain.txt","object":"file","purpose":"user_data","status":"processed","expires_at":null,"status_details":null}
```

3. Nine keys, matching what OpenAI itself returns

#### Batch upload, guardrails act on two rows

1. `curl -sS -X POST http://127.0.0.1:4761/v1/files -H "Authorization: Bearer $KEY" -F purpose=batch -F file=@batch.jsonl`

```json
{
    "id": "file-AFXB9VPkGVa1kB3uvmTmyo",
    "bytes": 331,
    "created_at": 1787425083,
    "filename": "batch.jsonl",
    "object": "file",
    "purpose": "batch",
    "status": "processed",
    "expires_at": 1790017083,
    "status_details": null,
    "litellm_batch_guardrail": {
        "submitted_records": 2,
        "modified_records": [
            {"line": 2, "custom_id": "dirty", "action": "redacted", "guardrail": null},
            {"line": 3, "custom_id": "blocked", "action": "dropped", "guardrail": null}
        ]
    }
}
```

#### File list, one row persisted by an older build

1. `curl -sS http://127.0.0.1:4761/openai_passthrough/v1/files -H "Authorization: Bearer $KEY"`

```json
{
    "object": "list",
    "data": [
        {"id": "bGl0ZWxsbV9wcm94eTpwYXNzdGhyb3VnaDtwcm92aWRlcjpvcGVuYWk7dW5pZmllZF9pZCw0Nzk5ZDBmOS1mMWIzLTRkMDgtODE3MS1lZGUyNTc1ZjA2YTc7cmF3X2lkLGZpbGUtR0ZLNUNCOVVuWk1KWVo0M2FKUmUxZw",
         "object": "file", "created_at": 1787427769, "bytes": 481, "status": "processed",
         "purpose": "batch", "filename": "batch.jsonl", "expires_at": 1790019769, "status_details": null},
        {"id": "bGl0ZWxsbV9wcm94eTpwYXNzdGhyb3VnaDtwcm92aWRlcjpvcGVuYWk7dW5pZmllZF9pZCxmYTQ0ZjA4Mi0wZWQ3LTQ5OGUtYjc1NC04MTM4OTk3MmQ0YzY7cmF3X2lkLGZpbGUtOHdnQnZWOThRdVlBQUQxTGJHSnp5dA",
         "object": "file", "created_at": 1787427725, "bytes": 481, "status": "processed",
         "purpose": "batch", "filename": "batch.jsonl", "expires_at": 1790019725, "status_details": null}
    ],
    "has_more": false
}
```

The second row is the one the old build wrote, and it comes back clean without any data migration

2. `curl -sS http://127.0.0.1:4761/v1/files -H "Authorization: Bearer $KEY"` returns both rows with the nine OpenAI keys

Byte-identical to the Before run apart from the ids and timestamps OpenAI assigns, including the nested `"guardrail": null`, which is why the fix targets the one top-level key rather than reaching for `exclude_none`

## Type

🐛 Bug Fix

## Caveats (if any)

- DELETE is unaffected; it returns a different shape
- The field stays on the shared model rather than moving to `_hidden_params`, since moving it would change the create route's public body shape a second time
- `OpenAIFileObject.json()` is left alone: it returns a dict from a method contracted to return a string, but it has no callers in this repo and any SDK caller relying on it would break
- The wrap serializer's return annotation is deliberately omitted, because pydantic derives the model's serialization schema from it and any annotation collapses that schema to a bare object

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
