### PR TITLE
fix(ui): repoint the key detail URL to the rotated hash after regenerating

### DIFF
--- a/ui/litellm-dashboard/src/components/VirtualKeysPage/VirtualKeysTable.test.tsx
+++ b/ui/litellm-dashboard/src/components/VirtualKeysPage/VirtualKeysTable.test.tsx
@@ -8,6 +8,7 @@ import { KeyResponse, Team } from "../key_team_helpers/key_list";
 import { useKeyInfo } from "@/app/(dashboard)/hooks/keys/useKeyInfo";
 import { KeysResponse, useKeys } from "@/app/(dashboard)/hooks/keys/useKeys";
 import useTeams from "@/app/(dashboard)/hooks/useTeams";
+import { regenerateKeyCall } from "../networking";
 
 // Resolve debounced values synchronously so an applied filter lands in the useKeys query within the test tick.
 vi.mock("@tanstack/react-pacer/debouncer", async () => {
@@ -24,6 +25,11 @@ vi.mock("@tanstack/react-pacer/debouncer", async () => {
 });
 
 vi.mock("next/navigation", () => ({ useRouter: () => ({ push: vi.fn() }) }));
+
+vi.mock("../networking", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../networking")>()),
+  regenerateKeyCall: vi.fn(),
+}));
 
 vi.mock("@/app/(dashboard)/hooks/useAuthorized", () => ({
   default: vi.fn(() => ({
@@ -387,6 +393,28 @@ it("renders KeyInfoView when the URL has ?key= for a key on the current page, wi
     expect(lastKeyParam(onUrlUpdate)).toBeNull();
   });
   expect(screen.getByTestId("pagination-range")).toBeInTheDocument();
+});
+
+it("repoints ?key= to the rotated hash once the regenerate dialog is dismissed", async () => {
+  const user = userEvent.setup();
+  vi.mocked(regenerateKeyCall).mockResolvedValue({
+    key: "sk-rotated-plaintext",
+    token: null,
+    token_id: "rotated-hash-456",
+  });
+  const onUrlUpdate = vi.fn<OnUrlUpdateFunction>();
+  renderWithProviders(<VirtualKeysTable />, { searchParams: { key: mockKey.token }, onUrlUpdate });
+
+  await user.click(await screen.findByRole("button", { name: /regenerate key/i }));
+  await user.click(await screen.findByRole("button", { name: /^Regenerate$/ }));
+  expect(await screen.findAllByText("sk-rotated-plaintext")).not.toHaveLength(0);
+  expect(lastKeyParam(onUrlUpdate)).toBeUndefined();
+
+  await user.click(screen.getAllByRole("button", { name: "Close" })[0]);
+
+  await waitFor(() => {
+    expect(lastKeyParam(onUrlUpdate)).toBe("rotated-hash-456");
+  });
 });
 
 it("fetches the key by id when the URL has ?key= for a key not in the loaded page", async () => {

--- a/ui/litellm-dashboard/src/components/VirtualKeysPage/VirtualKeysTable.tsx
+++ b/ui/litellm-dashboard/src/components/VirtualKeysPage/VirtualKeysTable.tsx
@@ -20,7 +20,7 @@ import { KeyRound } from "lucide-react";
 import { parseAsString, useQueryState } from "nuqs";
 import React, { useCallback, useMemo, useState } from "react";
 
-import { Team } from "../key_team_helpers/key_list";
+import { KeyResponse, Team } from "../key_team_helpers/key_list";
 import KeyInfoView from "../templates/key_info_view";
 import { getKeyTableColumns, KEY_TABLE_HIDDEN_COLUMNS } from "./keyTableColumns";
 
@@ -139,6 +139,16 @@ export function VirtualKeysTable({ headerActions }: VirtualKeysTableProps) {
     [organizations],
   );
 
+  const handleSelectedKeyDataUpdate = useCallback(
+    (updated: Partial<KeyResponse>) => {
+      const rotatedToken = updated.token ?? updated.token_id;
+      if (!rotatedToken || rotatedToken === selectedKeyId) return;
+      void setSelectedKeyId(rotatedToken);
+      void refetch();
+    },
+    [refetch, selectedKeyId, setSelectedKeyId],
+  );
+
   const formatFilterValue = useCallback(
     (columnId: string, value: unknown): string => {
       const raw = String(value);
@@ -165,6 +175,7 @@ export function VirtualKeysTable({ headerActions }: VirtualKeysTableProps) {
           keyData={selectedKey}
           teams={allTeams}
           onDelete={refetch}
+          onKeyDataUpdate={handleSelectedKeyDataUpdate}
         />
       </div>
     );

--- a/ui/litellm-dashboard/src/components/organisms/RegenerateKeyModal.test.tsx
+++ b/ui/litellm-dashboard/src/components/organisms/RegenerateKeyModal.test.tsx
@@ -427,4 +427,21 @@ describe("RegenerateKeyModal", () => {
       );
     });
   });
+
+  it("should report the rotated hash from token_id when the API leaves token null", async () => {
+    const user = userEvent.setup();
+    mockRegenerateKeyCall.mockResolvedValue({
+      key: "sk-new-regenerated-key",
+      token: null,
+      token_id: "rotated-hash-456",
+    });
+
+    renderWithProviders(<RegenerateKeyModal {...defaultProps} />);
+    await user.click(screen.getByRole("button", { name: /Regenerate/ }));
+
+    await waitFor(() => {
+      expect(mockOnKeyUpdate).toHaveBeenCalledOnce();
+    });
+    expect(mockOnKeyUpdate.mock.calls[0][0].token).toBe("rotated-hash-456");
+  });
 });

--- a/ui/litellm-dashboard/src/components/organisms/RegenerateKeyModal.tsx
+++ b/ui/litellm-dashboard/src/components/organisms/RegenerateKeyModal.tsx
@@ -107,7 +107,7 @@ export function RegenerateKeyModal({ selectedToken, visible, onClose, onKeyUpdat
       // formatted preview, otherwise downstream expiry parsing breaks.
       const updatedKeyData: Partial<KeyResponse> = {
         ...response,
-        token: response.token || response.key_id || selectedToken.token,
+        token: response.token_id || response.token || selectedToken.token,
         key_name: response.key,
         max_budget: formValues.max_budget,
         tpm_limit: formValues.tpm_limit,

--- a/ui/litellm-dashboard/src/components/templates/key_info_view.tsx
+++ b/ui/litellm-dashboard/src/components/templates/key_info_view.tsx
@@ -100,6 +100,9 @@ export default function KeyInfoView({
   // Add local state to maintain key data and track regeneration
   const [currentKeyData, setCurrentKeyData] = useState<KeyResponse | undefined>(keyData);
   const [lastRegeneratedAt, setLastRegeneratedAt] = useState<Date | null>(null);
+  const [keyDataUpdateHeldUntilModalClose, setKeyDataUpdateHeldUntilModalClose] = useState<Partial<KeyResponse> | null>(
+    null,
+  );
   const [isRecentlyRegenerated, setIsRecentlyRegenerated] = useState(false);
   const [policyGuardrails, setPolicyGuardrails] = useState<Record<string, string[]>>({});
   const [loadingPolicies, setLoadingPolicies] = useState(false);
@@ -352,6 +355,7 @@ export default function KeyInfoView({
   };
 
   const handleRegenerateKeyUpdate = (updatedKeyData: Partial<KeyResponse>) => {
+    const regeneratedAt = new Date();
     // Update local state immediately with ALL the new data
     setCurrentKeyData((prevData) => {
       if (!prevData) return undefined;
@@ -359,20 +363,26 @@ export default function KeyInfoView({
         ...prevData,
         ...updatedKeyData, // This should include the new token (key-id)
         // Update the created_at to show when it was regenerated
-        created_at: new Date().toLocaleString(),
+        created_at: regeneratedAt.toLocaleString(),
       };
       return newData;
     });
 
     // Track regeneration timestamp
-    setLastRegeneratedAt(new Date());
+    setLastRegeneratedAt(regeneratedAt);
     setIsRecentlyRegenerated(true);
 
-    if (onKeyDataUpdate) {
-      onKeyDataUpdate({
-        ...updatedKeyData,
-        created_at: new Date().toLocaleString(),
-      });
+    setKeyDataUpdateHeldUntilModalClose({
+      ...updatedKeyData,
+      created_at: regeneratedAt.toLocaleString(),
+    });
+  };
+
+  const handleRegenerateModalClose = () => {
+    setIsRegenerateModalOpen(false);
+    if (keyDataUpdateHeldUntilModalClose) {
+      setKeyDataUpdateHeldUntilModalClose(null);
+      onKeyDataUpdate?.(keyDataUpdateHeldUntilModalClose);
     }
   };
 
@@ -506,7 +516,7 @@ export default function KeyInfoView({
       <RegenerateKeyModal
         selectedToken={currentKeyData}
         visible={isRegenerateModalOpen}
-        onClose={() => setIsRegenerateModalOpen(false)}
+        onClose={handleRegenerateModalClose}
         onKeyUpdate={handleRegenerateKeyUpdate}
       />
 


### PR DESCRIPTION
## TLDR

Problem this solves:

- Regenerating a key breaks that key's detail page URL
- The page then reads "Key not found" on every reload

How it solves it:

- Read the rotated hash from the field the API sends
- Point the page's `?key=` at it on close

## User Flow

Before: an admin who regenerates a key from that key's detail page is dropped on a dead URL and loses the page

1. They open https://litellm-domain/ui/api-keys/?key=&lt;the key's hash&gt; and see the key's detail page
2. They click "Regenerate Key", then "Regenerate" in the dialog, and the new secret is shown once
3. They click "Close"
4. The address bar still carries the hash that was just rotated away, and the page shows "Key not found"
5. Reloading keeps showing "Key not found", so the only way back is the keys list

After: the same admin stays on a working detail page for the key they just regenerated

1. They open the same https://litellm-domain/ui/api-keys/?key=&lt;the key's hash&gt;
2. They click "Regenerate Key", then "Regenerate" in the dialog, and the new secret is shown once
3. They click "Close"
4. The address bar now carries the hash the regeneration produced, and the detail page keeps rendering the key
5. Reloading loads the same key again, and the URL is safe to bookmark or hand to another admin

The secret stays on screen until the admin dismisses the dialog, so the URL swap never cuts short their chance to copy it

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Shared setup, against a proxy on `:4000` with an admin key, to create the key each case walks through:

```
curl -sS -X POST http://localhost:4000/key/generate \
  -H "Authorization: Bearer sk-1234" -H 'Content-Type: application/json' \
  -d '{"key_alias":"regen-url-demo"}' | jq -r '.token'
```

Both cases are also driven as Playwright runs against a real dashboard talking to a real proxy, no mocks and no stubbed responses. The runs cover four checks: the two cases below, plus two adjacent behaviours that must not change

### Before (490c9f9f3f)

#### Regenerating repoints the detail page URL

1. Open http://localhost:4000/ui/api-keys/?key=&lt;the hash printed above&gt;
2. Click "Regenerate Key", then "Regenerate" in the dialog, then "Close"
3. The address bar still carries the pre-regeneration hash, and the page reads "Key not found"

#### The detail page survives a reload after regenerating

1. Repeat the steps above, then reload the page
2. The reload re-requests the stale hash, so the page still reads "Key not found"

#### Both cases as a browser run

```
✓  1 adj-1.spec.ts:14:5 › gate: dashboard talks to the harness proxy (811ms)
✓  2 adj-1.spec.ts:20:5 › cancelling the regenerate modal leaves the ?key= param alone (1.6s)
✓  3 adj-1.spec.ts:36:5 › leaving the key detail view clears the ?key= param (905ms)
✓  4 bug-1.spec.ts:14:5 › gate: dashboard talks to the harness proxy (521ms)
✘  5 bug-1.spec.ts:20:5 › regenerating from the key detail page repoints the ?key= param (11.3s)
✘  6 bug-1.spec.ts:49:5 › the key detail page survives a reload after regenerating (11.3s)

   Expected: "7b24767cde5ed000dcbc07c6807b6163e0f7b8f7a353928cab097c982e060f51"
   Received: "9a97b0bcb7bfde4fbd28738774d41d90ba991bcaaa60b3ea383e8a6e3b8a87b7"
   - Timeout 10000ms exceeded while waiting on the predicate
   > 68 |   await expect.poll(() => new URL(page.url()).searchParams.get("key"), ...).toBe(newHash)
```

### After (713972fecf)

#### Regenerating repoints the detail page URL

1. Open http://localhost:4000/ui/api-keys/?key=&lt;the hash printed above&gt;
2. Click "Regenerate Key", then "Regenerate" in the dialog, then "Close"
3. The address bar now carries the rotated hash, and the detail page keeps rendering the key

#### The detail page survives a reload after regenerating

1. Repeat the steps above, then reload the page
2. The reload requests the rotated hash and the key's detail page comes back, no "Key not found"

#### Both cases as a browser run

```
✓  1 adj-1.spec.ts:14:5 › gate: dashboard talks to the harness proxy (646ms)
✓  2 adj-1.spec.ts:20:5 › cancelling the regenerate modal leaves the ?key= param alone (1.6s)
✓  3 adj-1.spec.ts:36:5 › leaving the key detail view clears the ?key= param (898ms)
✓  4 bug-1.spec.ts:14:5 › gate: dashboard talks to the harness proxy (498ms)
✓  5 bug-1.spec.ts:20:5 › regenerating from the key detail page repoints the ?key= param (1.0s)
✓  6 bug-1.spec.ts:49:5 › the key detail page survives a reload after regenerating (1.5s)

   6 passed (6.9s)
```

The proxy log for that run shows the dashboard asking for the rotated hash and getting it:

```
POST /key/192e46f8244919a6afeb32081b3c1edad6b237085c2b6003ef3eaba68cd6233d/regenerate HTTP/1.1" 200 OK
GET  /key/info?key=a41eeb7a5d2b80ac80aa70fb4b958111f9182207f09015bbb2f5a10ae2e56adb HTTP/1.1" 200 OK
```

## Type

🐛 Bug Fix

## Caveats (if any)

- Falls back to `token`, so older proxies keep working
- URL swap waits for close, keeping the secret visible
