### PR TITLE
fix(databricks): bill cached tokens at cache rates and add missing Claude pricing

### DIFF
--- a/litellm/llms/databricks/cost_calculator.py
+++ b/litellm/llms/databricks/cost_calculator.py
@@ -3,10 +3,31 @@ Helper util for handling databricks-specific cost calculation
 - e.g.: handling 'dbrx-instruct-*'
 """
 
+from types import MappingProxyType
 from typing import Final
 
+from litellm.litellm_core_utils.llm_cost_calc.utils import generic_cost_per_token
 from litellm.types.utils import Usage
-from litellm.utils import get_model_info
+
+_LEGACY_ENDPOINT_NAMES: Final = MappingProxyType(
+    {
+        "dbrx-instruct": "databricks-dbrx-instruct",
+        "meta-llama-3.1-70b-instruct": "databricks-meta-llama-3-1-70b-instruct",
+        "meta-llama-3.1-405b-instruct": "databricks-meta-llama-3-1-405b-instruct",
+        "mixtral-8x7b-instruct-v0.1": "databricks-mixtral-8x7b-instruct",
+        "bge-large-en": "databricks-bge-large-en",
+        "gte-large-en": "databricks-gte-large-en",
+        "llama-2-70b-chat": "databricks-llama-2-70b-chat",
+    }
+)
+
+
+def _registry_key(model: str) -> str:
+    name: Final = model.removeprefix("databricks/")
+    return next(
+        (key for prefix, key in _LEGACY_ENDPOINT_NAMES.items() if name.startswith(prefix)),
+        name,
+    )
 
 
 def cost_per_token(model: str, usage: Usage) -> tuple[float, float]:
@@ -20,36 +41,8 @@ def cost_per_token(model: str, usage: Usage) -> tuple[float, float]:
     Returns:
         Tuple[float, float] - prompt_cost_in_usd, completion_cost_in_usd
     """
-    base_model = model
-    if model.startswith("databricks/dbrx-instruct") or model.startswith("dbrx-instruct"):
-        base_model = "databricks-dbrx-instruct"
-    elif model.startswith("databricks/meta-llama-3.1-70b-instruct") or model.startswith("meta-llama-3.1-70b-instruct"):
-        base_model = "databricks-meta-llama-3-1-70b-instruct"
-    elif model.startswith("databricks/meta-llama-3.1-405b-instruct") or model.startswith(
-        "meta-llama-3.1-405b-instruct"
-    ):
-        base_model = "databricks-meta-llama-3-1-405b-instruct"
-    elif (
-        model.startswith("databricks/mixtral-8x7b-instruct-v0.1")
-        or model.startswith("mixtral-8x7b-instruct-v0.1")
-        or model.startswith("databricks/mixtral-8x7b-instruct-v0.1")
-        or model.startswith("mixtral-8x7b-instruct-v0.1")
-    ):
-        base_model = "databricks-mixtral-8x7b-instruct"
-    elif model.startswith("databricks/bge-large-en") or model.startswith("bge-large-en"):
-        base_model = "databricks-bge-large-en"
-    elif model.startswith("databricks/gte-large-en") or model.startswith("gte-large-en"):
-        base_model = "databricks-gte-large-en"
-    elif model.startswith("databricks/llama-2-70b-chat") or model.startswith("llama-2-70b-chat"):
-        base_model = "databricks-llama-2-70b-chat"
-    ## GET MODEL INFO
-    model_info: Final = get_model_info(model=base_model, custom_llm_provider="databricks")
-
-    ## CALCULATE INPUT COST
-
-    prompt_cost: Final[float] = usage["prompt_tokens"] * model_info["input_cost_per_token"]
-
-    ## CALCULATE OUTPUT COST
-    completion_cost: Final = usage["completion_tokens"] * model_info["output_cost_per_token"]
-
-    return prompt_cost, completion_cost
+    return generic_cost_per_token(
+        model=_registry_key(model),
+        usage=usage,
+        custom_llm_provider="databricks",
+    )

--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -14569,7 +14569,7 @@
     },
     "databricks/databricks-claude-3-7-sonnet": {
         "cache_creation_input_token_cost": 3.7499875e-06,
-        "cache_read_input_token_cost": 2.9999900000000006e-07,
+        "cache_read_input_token_cost": 2.99999e-07,
         "input_cost_per_token": 2.9999900000000002e-06,
         "input_dbu_cost_per_token": 4.2857e-05,
         "litellm_provider": "databricks",
@@ -14591,7 +14591,7 @@
     },
     "databricks/databricks-claude-fable-5": {
         "cache_creation_input_token_cost": 1.2500075e-05,
-        "cache_read_input_token_cost": 1.0000060000000001e-06,
+        "cache_read_input_token_cost": 1.000006e-06,
         "input_cost_per_token": 1.000006e-05,
         "input_dbu_cost_per_token": 0.000142858,
         "litellm_provider": "databricks",
@@ -14602,7 +14602,7 @@
             "notes": "Input/output cost per token is dbu cost * $0.070. Number provided for reference, '*_dbu_cost_per_token' used in actual calculation."
         },
         "mode": "chat",
-        "output_cost_per_token": 5.0000020000000004e-05,
+        "output_cost_per_token": 5.000002e-05,
         "output_dbu_cost_per_token": 0.000714286,
         "prompt_cache_min_tokens": 512,
         "source": "https://www.databricks.com/product/pricing/proprietary-foundation-model-serving",
@@ -14618,8 +14618,8 @@
         "thinking_always_on": true
     },
     "databricks/databricks-claude-haiku-4-5": {
-        "cache_creation_input_token_cost": 1.2500250000000002e-06,
-        "cache_read_input_token_cost": 1.0000200000000002e-07,
+        "cache_creation_input_token_cost": 1.250025e-06,
+        "cache_read_input_token_cost": 1.00002e-07,
         "input_cost_per_token": 1.00002e-06,
         "input_dbu_cost_per_token": 1.4286e-05,
         "litellm_provider": "databricks",
@@ -14685,7 +14685,7 @@
     },
     "databricks/databricks-claude-opus-4-5": {
         "cache_creation_input_token_cost": 6.2500375e-06,
-        "cache_read_input_token_cost": 5.000030000000001e-07,
+        "cache_read_input_token_cost": 5.00003e-07,
         "input_cost_per_token": 5.00003e-06,
         "input_dbu_cost_per_token": 7.1429e-05,
         "litellm_provider": "databricks",
@@ -14708,7 +14708,7 @@
     },
     "databricks/databricks-claude-opus-4-6": {
         "cache_creation_input_token_cost": 6.2500375e-06,
-        "cache_read_input_token_cost": 5.000030000000001e-07,
+        "cache_read_input_token_cost": 5.00003e-07,
         "input_cost_per_token": 5.00003e-06,
         "input_dbu_cost_per_token": 7.1429e-05,
         "litellm_provider": "databricks",
@@ -14730,7 +14730,7 @@
     },
     "databricks/databricks-claude-opus-4-7": {
         "cache_creation_input_token_cost": 6.2500375e-06,
-        "cache_read_input_token_cost": 5.000030000000001e-07,
+        "cache_read_input_token_cost": 5.00003e-07,
         "input_cost_per_token": 5.00003e-06,
         "input_dbu_cost_per_token": 7.1429e-05,
         "litellm_provider": "databricks",
@@ -14741,7 +14741,7 @@
             "notes": "Input/output cost per token is dbu cost * $0.070. Number provided for reference, '*_dbu_cost_per_token' used in actual calculation."
         },
         "mode": "chat",
-        "output_cost_per_token": 2.5000010000000002e-05,
+        "output_cost_per_token": 2.500001e-05,
         "output_dbu_cost_per_token": 0.000357143,
         "prompt_cache_min_tokens": 2048,
         "source": "https://www.databricks.com/product/pricing/proprietary-foundation-model-serving",
@@ -14756,7 +14756,7 @@
     },
     "databricks/databricks-claude-opus-4-8": {
         "cache_creation_input_token_cost": 6.2500375e-06,
-        "cache_read_input_token_cost": 5.000030000000001e-07,
+        "cache_read_input_token_cost": 5.00003e-07,
         "input_cost_per_token": 5.00003e-06,
         "input_dbu_cost_per_token": 7.1429e-05,
         "litellm_provider": "databricks",
@@ -14767,7 +14767,7 @@
             "notes": "Input/output cost per token is dbu cost * $0.070. Number provided for reference, '*_dbu_cost_per_token' used in actual calculation."
         },
         "mode": "chat",
-        "output_cost_per_token": 2.5000010000000002e-05,
+        "output_cost_per_token": 2.500001e-05,
         "output_dbu_cost_per_token": 0.000357143,
         "prompt_cache_min_tokens": 1024,
         "source": "https://www.databricks.com/product/pricing/proprietary-foundation-model-serving",
@@ -14783,7 +14783,7 @@
     },
     "databricks/databricks-claude-opus-5": {
         "cache_creation_input_token_cost": 6.2500375e-06,
-        "cache_read_input_token_cost": 5.000030000000001e-07,
+        "cache_read_input_token_cost": 5.00003e-07,
         "input_cost_per_token": 5.00003e-06,
         "input_dbu_cost_per_token": 7.1429e-05,
         "litellm_provider": "databricks",
@@ -14794,7 +14794,7 @@
             "notes": "Input/output cost per token is dbu cost * $0.070. Number provided for reference, '*_dbu_cost_per_token' used in actual calculation."
         },
         "mode": "chat",
-        "output_cost_per_token": 2.5000010000000002e-05,
+        "output_cost_per_token": 2.500001e-05,
         "output_dbu_cost_per_token": 0.000357143,
         "prompt_cache_min_tokens": 512,
         "source": "https://www.databricks.com/product/pricing/proprietary-foundation-model-serving",
@@ -14810,7 +14810,7 @@
     },
     "databricks/databricks-claude-sonnet-4": {
         "cache_creation_input_token_cost": 3.7499875e-06,
-        "cache_read_input_token_cost": 2.9999900000000006e-07,
+        "cache_read_input_token_cost": 2.99999e-07,
         "input_cost_per_token": 2.9999900000000002e-06,
         "input_dbu_cost_per_token": 4.2857e-05,
         "litellm_provider": "databricks",
@@ -14832,7 +14832,7 @@
     },
     "databricks/databricks-claude-sonnet-4-1": {
         "cache_creation_input_token_cost": 3.7499875e-06,
-        "cache_read_input_token_cost": 2.9999900000000006e-07,
+        "cache_read_input_token_cost": 2.99999e-07,
         "input_cost_per_token": 2.9999900000000002e-06,
         "input_dbu_cost_per_token": 4.2857e-05,
         "litellm_provider": "databricks",
@@ -14854,7 +14854,7 @@
     },
     "databricks/databricks-claude-sonnet-4-5": {
         "cache_creation_input_token_cost": 3.7499875e-06,
-        "cache_read_input_token_cost": 2.9999900000000006e-07,
+        "cache_read_input_token_cost": 2.99999e-07,
         "input_cost_per_token": 2.9999900000000002e-06,
         "input_dbu_cost_per_token": 4.2857e-05,
         "litellm_provider": "databricks",
@@ -14876,7 +14876,7 @@
     },
     "databricks/databricks-claude-sonnet-4-6": {
         "cache_creation_input_token_cost": 3.7499875e-06,
-        "cache_read_input_token_cost": 2.9999900000000006e-07,
+        "cache_read_input_token_cost": 2.99999e-07,
         "input_cost_per_token": 2.9999900000000002e-06,
         "input_dbu_cost_per_token": 4.2857e-05,
         "litellm_provider": "databricks",
@@ -14898,8 +14898,8 @@
     },
     "databricks/databricks-claude-sonnet-5": {
         "cache_creation_input_token_cost": 3.7499875e-06,
-        "cache_read_input_token_cost": 2.9999900000000006e-07,
-        "input_cost_per_token": 2.9999900000000002e-06,
+        "cache_read_input_token_cost": 2.99999e-07,
+        "input_cost_per_token": 2.99999e-06,
         "input_dbu_cost_per_token": 4.2857e-05,
         "litellm_provider": "databricks",
         "max_input_tokens": 1000000,
@@ -14909,7 +14909,7 @@
             "notes": "Input/output cost per token is dbu cost * $0.070. Number provided for reference, '*_dbu_cost_per_token' used in actual calculation. Introductory launch rates of 28.571 input / 142.857 output DBU run through 2026-08-31; the standard rates are listed here because entries carry no expiry date."
         },
         "mode": "chat",
-        "output_cost_per_token": 1.5000020000000002e-05,
+        "output_cost_per_token": 1.500002e-05,
         "output_dbu_cost_per_token": 0.000214286,
         "prompt_cache_min_tokens": 1024,
         "source": "https://www.databricks.com/product/pricing/proprietary-foundation-model-serving",
@@ -14924,7 +14924,7 @@
         "supports_vision": true
     },
     "databricks/databricks-gemini-2-5-flash": {
-        "cache_creation_input_token_cost": 3.0001999999999996e-07,
+        "cache_creation_input_token_cost": 3.0002e-07,
         "cache_read_input_token_cost": 3.0002e-08,
         "input_cost_per_token": 3.0001999999999996e-07,
         "input_dbu_cost_per_token": 4.285999999999999e-06,
@@ -15004,8 +15004,8 @@
         "supports_tool_choice": true
     },
     "databricks/databricks-gemini-3-flash": {
-        "cache_creation_input_token_cost": 6.250300000000001e-07,
-        "cache_read_input_token_cost": 6.250300000000001e-08,
+        "cache_creation_input_token_cost": 6.2503e-07,
+        "cache_read_input_token_cost": 6.2503e-08,
         "input_cost_per_token": 6.2503e-07,
         "input_dbu_cost_per_token": 8.929e-06,
         "litellm_provider": "databricks",
@@ -15044,8 +15044,8 @@
         "supports_tool_choice": true
     },
     "databricks/databricks-gemma-3-12b": {
-        "cache_creation_input_token_cost": 1.5000999999999998e-07,
-        "cache_read_input_token_cost": 1.5000999999999998e-07,
+        "cache_creation_input_token_cost": 1.5001e-07,
+        "cache_read_input_token_cost": 1.5001e-07,
         "input_cost_per_token": 1.5000999999999998e-07,
         "input_dbu_cost_per_token": 2.1429999999999996e-06,
         "litellm_provider": "databricks",
@@ -15115,8 +15115,8 @@
         "supports_prompt_caching": true
     },
     "databricks/databricks-gpt-5-1-codex-mini": {
-        "cache_creation_input_token_cost": 2.4997000000000006e-07,
-        "cache_read_input_token_cost": 2.4997000000000005e-08,
+        "cache_creation_input_token_cost": 2.4997e-07,
+        "cache_read_input_token_cost": 2.4997e-08,
         "input_cost_per_token": 2.4997e-07,
         "input_dbu_cost_per_token": 3.571e-06,
         "litellm_provider": "databricks",
@@ -15133,8 +15133,8 @@
         "supports_prompt_caching": true
     },
     "databricks/databricks-gpt-5-2": {
-        "cache_creation_input_token_cost": 1.7500000000000002e-06,
-        "cache_read_input_token_cost": 1.7500000000000002e-07,
+        "cache_creation_input_token_cost": 1.75e-06,
+        "cache_read_input_token_cost": 1.75e-07,
         "input_cost_per_token": 1.75e-06,
         "input_dbu_cost_per_token": 2.5e-05,
         "litellm_provider": "databricks",
@@ -15151,8 +15151,8 @@
         "supports_prompt_caching": true
     },
     "databricks/databricks-gpt-5-2-codex": {
-        "cache_creation_input_token_cost": 1.7500000000000002e-06,
-        "cache_read_input_token_cost": 1.7500000000000002e-07,
+        "cache_creation_input_token_cost": 1.75e-06,
+        "cache_read_input_token_cost": 1.75e-07,
         "input_cost_per_token": 1.75e-06,
         "input_dbu_cost_per_token": 2.5e-05,
         "litellm_provider": "databricks",
@@ -15169,8 +15169,8 @@
         "supports_prompt_caching": true
     },
     "databricks/databricks-gpt-5-3-codex": {
-        "cache_creation_input_token_cost": 1.7500000000000002e-06,
-        "cache_read_input_token_cost": 1.7500000000000002e-07,
+        "cache_creation_input_token_cost": 1.75e-06,
+        "cache_read_input_token_cost": 1.75e-07,
         "input_cost_per_token": 1.75e-06,
         "input_dbu_cost_per_token": 2.5e-05,
         "litellm_provider": "databricks",
@@ -15206,7 +15206,7 @@
     },
     "databricks/databricks-gpt-5-4-mini": {
         "cache_creation_input_token_cost": 7.4998e-07,
-        "cache_read_input_token_cost": 7.499800000000001e-08,
+        "cache_read_input_token_cost": 7.4998e-08,
         "input_cost_per_token": 7.4998e-07,
         "input_dbu_cost_per_token": 1.0714e-05,
         "litellm_provider": "databricks",
@@ -15224,7 +15224,7 @@
     },
     "databricks/databricks-gpt-5-4-nano": {
         "cache_creation_input_token_cost": 1.9999e-07,
-        "cache_read_input_token_cost": 1.9999000000000003e-08,
+        "cache_read_input_token_cost": 1.9999e-08,
         "input_cost_per_token": 1.9999e-07,
         "input_dbu_cost_per_token": 2.857e-06,
         "litellm_provider": "databricks",
@@ -15241,8 +15241,8 @@
         "supports_prompt_caching": true
     },
     "databricks/databricks-gpt-5-mini": {
-        "cache_creation_input_token_cost": 2.4997000000000006e-07,
-        "cache_read_input_token_cost": 2.4997000000000005e-08,
+        "cache_creation_input_token_cost": 2.4997e-07,
+        "cache_read_input_token_cost": 2.4997e-08,
         "input_cost_per_token": 2.4997000000000006e-07,
         "input_dbu_cost_per_token": 3.571e-06,
         "litellm_provider": "databricks",
@@ -15260,7 +15260,7 @@
     },
     "databricks/databricks-gpt-5-nano": {
         "cache_creation_input_token_cost": 4.998e-08,
-        "cache_read_input_token_cost": 4.998000000000001e-09,
+        "cache_read_input_token_cost": 4.998e-09,
         "input_cost_per_token": 4.998e-08,
         "input_dbu_cost_per_token": 7.14e-07,
         "litellm_provider": "databricks",
@@ -15277,8 +15277,8 @@
         "supports_prompt_caching": true
     },
     "databricks/databricks-gpt-oss-120b": {
-        "cache_creation_input_token_cost": 1.5000999999999998e-07,
-        "cache_read_input_token_cost": 1.5000999999999998e-07,
+        "cache_creation_input_token_cost": 1.5001e-07,
+        "cache_read_input_token_cost": 1.5001e-07,
         "input_cost_per_token": 1.5000999999999998e-07,
         "input_dbu_cost_per_token": 2.1429999999999996e-06,
         "litellm_provider": "databricks",
@@ -15311,8 +15311,8 @@
         "source": "https://www.databricks.com/product/pricing/foundation-model-serving"
     },
     "databricks/databricks-gte-large-en": {
-        "cache_creation_input_token_cost": 1.2999000000000001e-07,
-        "cache_read_input_token_cost": 1.2999000000000001e-07,
+        "cache_creation_input_token_cost": 1.2999e-07,
+        "cache_read_input_token_cost": 1.2999e-07,
         "input_cost_per_token": 1.2999000000000001e-07,
         "input_dbu_cost_per_token": 1.857e-06,
         "litellm_provider": "databricks",
@@ -15382,8 +15382,8 @@
         "supports_tool_choice": true
     },
     "databricks/databricks-meta-llama-3-1-8b-instruct": {
-        "cache_creation_input_token_cost": 1.5000999999999998e-07,
-        "cache_read_input_token_cost": 1.5000999999999998e-07,
+        "cache_creation_input_token_cost": 1.5001e-07,
+        "cache_read_input_token_cost": 1.5001e-07,
         "input_cost_per_token": 1.5000999999999998e-07,
         "input_dbu_cost_per_token": 2.1429999999999996e-06,
         "litellm_provider": "databricks",

--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -14568,8 +14568,8 @@
         "source": "https://www.databricks.com/product/pricing/foundation-model-serving"
     },
     "databricks/databricks-claude-3-7-sonnet": {
-        "cache_creation_input_token_cost": 3.7499875e-06,
-        "cache_read_input_token_cost": 2.99999e-07,
+        "cache_creation_input_token_cost": 3.74997e-06,
+        "cache_read_input_token_cost": 3.0002e-07,
         "input_cost_per_token": 2.9999900000000002e-06,
         "input_dbu_cost_per_token": 4.2857e-05,
         "litellm_provider": "databricks",
@@ -14590,8 +14590,8 @@
         "supports_tool_choice": true
     },
     "databricks/databricks-claude-fable-5": {
-        "cache_creation_input_token_cost": 1.2500075e-05,
-        "cache_read_input_token_cost": 1.000006e-06,
+        "cache_creation_input_token_cost": 1.250004e-05,
+        "cache_read_input_token_cost": 1.00002e-06,
         "input_cost_per_token": 1.000006e-05,
         "input_dbu_cost_per_token": 0.000142858,
         "litellm_provider": "databricks",
@@ -14599,7 +14599,7 @@
         "max_output_tokens": 128000,
         "max_tokens": 128000,
         "metadata": {
-            "notes": "Input/output cost per token is dbu cost * $0.070. Number provided for reference, '*_dbu_cost_per_token' used in actual calculation."
+            "notes": "Costs per token are the published Global DBU rates times $0.070 per DBU. The '*_dbu_cost_per_token' fields are provided for reference; cost calculation reads the dollar '*_cost_per_token' fields."
         },
         "mode": "chat",
         "output_cost_per_token": 5.000002e-05,
@@ -14614,12 +14614,12 @@
         "supports_reasoning": true,
         "supports_sampling_params": false,
         "supports_tool_choice": true,
-        "supports_vision": true,
+        "supports_vision": false,
         "thinking_always_on": true
     },
     "databricks/databricks-claude-haiku-4-5": {
-        "cache_creation_input_token_cost": 1.250025e-06,
-        "cache_read_input_token_cost": 1.00002e-07,
+        "cache_creation_input_token_cost": 1.24999e-06,
+        "cache_read_input_token_cost": 1.0003e-07,
         "input_cost_per_token": 1.00002e-06,
         "input_dbu_cost_per_token": 1.4286e-05,
         "litellm_provider": "databricks",
@@ -14640,8 +14640,8 @@
         "supports_tool_choice": true
     },
     "databricks/databricks-claude-opus-4": {
-        "cache_creation_input_token_cost": 1.8750025e-05,
-        "cache_read_input_token_cost": 1.500002e-06,
+        "cache_creation_input_token_cost": 1.874999e-05,
+        "cache_read_input_token_cost": 1.50003e-06,
         "input_cost_per_token": 1.5000020000000002e-05,
         "input_dbu_cost_per_token": 0.000214286,
         "litellm_provider": "databricks",
@@ -14662,8 +14662,8 @@
         "supports_tool_choice": true
     },
     "databricks/databricks-claude-opus-4-1": {
-        "cache_creation_input_token_cost": 1.8750025e-05,
-        "cache_read_input_token_cost": 1.500002e-06,
+        "cache_creation_input_token_cost": 1.874999e-05,
+        "cache_read_input_token_cost": 1.50003e-06,
         "input_cost_per_token": 1.5000020000000002e-05,
         "input_dbu_cost_per_token": 0.000214286,
         "litellm_provider": "databricks",
@@ -14684,8 +14684,8 @@
         "supports_tool_choice": true
     },
     "databricks/databricks-claude-opus-4-5": {
-        "cache_creation_input_token_cost": 6.2500375e-06,
-        "cache_read_input_token_cost": 5.00003e-07,
+        "cache_creation_input_token_cost": 6.25002e-06,
+        "cache_read_input_token_cost": 5.0001e-07,
         "input_cost_per_token": 5.00003e-06,
         "input_dbu_cost_per_token": 7.1429e-05,
         "litellm_provider": "databricks",
@@ -14707,8 +14707,8 @@
         "supports_output_config": true
     },
     "databricks/databricks-claude-opus-4-6": {
-        "cache_creation_input_token_cost": 6.2500375e-06,
-        "cache_read_input_token_cost": 5.00003e-07,
+        "cache_creation_input_token_cost": 6.25002e-06,
+        "cache_read_input_token_cost": 5.0001e-07,
         "input_cost_per_token": 5.00003e-06,
         "input_dbu_cost_per_token": 7.1429e-05,
         "litellm_provider": "databricks",
@@ -14729,8 +14729,8 @@
         "supports_tool_choice": true
     },
     "databricks/databricks-claude-opus-4-7": {
-        "cache_creation_input_token_cost": 6.2500375e-06,
-        "cache_read_input_token_cost": 5.00003e-07,
+        "cache_creation_input_token_cost": 6.25002e-06,
+        "cache_read_input_token_cost": 5.0001e-07,
         "input_cost_per_token": 5.00003e-06,
         "input_dbu_cost_per_token": 7.1429e-05,
         "litellm_provider": "databricks",
@@ -14738,7 +14738,7 @@
         "max_output_tokens": 128000,
         "max_tokens": 128000,
         "metadata": {
-            "notes": "Input/output cost per token is dbu cost * $0.070. Number provided for reference, '*_dbu_cost_per_token' used in actual calculation."
+            "notes": "Costs per token are the published Global DBU rates times $0.070 per DBU. The '*_dbu_cost_per_token' fields are provided for reference; cost calculation reads the dollar '*_cost_per_token' fields."
         },
         "mode": "chat",
         "output_cost_per_token": 2.500001e-05,
@@ -14755,8 +14755,8 @@
         "supports_vision": true
     },
     "databricks/databricks-claude-opus-4-8": {
-        "cache_creation_input_token_cost": 6.2500375e-06,
-        "cache_read_input_token_cost": 5.00003e-07,
+        "cache_creation_input_token_cost": 6.25002e-06,
+        "cache_read_input_token_cost": 5.0001e-07,
         "input_cost_per_token": 5.00003e-06,
         "input_dbu_cost_per_token": 7.1429e-05,
         "litellm_provider": "databricks",
@@ -14764,7 +14764,7 @@
         "max_output_tokens": 128000,
         "max_tokens": 128000,
         "metadata": {
-            "notes": "Input/output cost per token is dbu cost * $0.070. Number provided for reference, '*_dbu_cost_per_token' used in actual calculation."
+            "notes": "Costs per token are the published Global DBU rates times $0.070 per DBU. The '*_dbu_cost_per_token' fields are provided for reference; cost calculation reads the dollar '*_cost_per_token' fields."
         },
         "mode": "chat",
         "output_cost_per_token": 2.500001e-05,
@@ -14782,8 +14782,8 @@
         "supports_vision": true
     },
     "databricks/databricks-claude-opus-5": {
-        "cache_creation_input_token_cost": 6.2500375e-06,
-        "cache_read_input_token_cost": 5.00003e-07,
+        "cache_creation_input_token_cost": 6.25002e-06,
+        "cache_read_input_token_cost": 5.0001e-07,
         "input_cost_per_token": 5.00003e-06,
         "input_dbu_cost_per_token": 7.1429e-05,
         "litellm_provider": "databricks",
@@ -14791,7 +14791,7 @@
         "max_output_tokens": 128000,
         "max_tokens": 128000,
         "metadata": {
-            "notes": "Input/output cost per token is dbu cost * $0.070. Number provided for reference, '*_dbu_cost_per_token' used in actual calculation."
+            "notes": "Costs per token are the published Global DBU rates times $0.070 per DBU. The '*_dbu_cost_per_token' fields are provided for reference; cost calculation reads the dollar '*_cost_per_token' fields."
         },
         "mode": "chat",
         "output_cost_per_token": 2.500001e-05,
@@ -14809,8 +14809,8 @@
         "supports_vision": true
     },
     "databricks/databricks-claude-sonnet-4": {
-        "cache_creation_input_token_cost": 3.7499875e-06,
-        "cache_read_input_token_cost": 2.99999e-07,
+        "cache_creation_input_token_cost": 3.74997e-06,
+        "cache_read_input_token_cost": 3.0002e-07,
         "input_cost_per_token": 2.9999900000000002e-06,
         "input_dbu_cost_per_token": 4.2857e-05,
         "litellm_provider": "databricks",
@@ -14831,8 +14831,8 @@
         "supports_tool_choice": true
     },
     "databricks/databricks-claude-sonnet-4-1": {
-        "cache_creation_input_token_cost": 3.7499875e-06,
-        "cache_read_input_token_cost": 2.99999e-07,
+        "cache_creation_input_token_cost": 3.74997e-06,
+        "cache_read_input_token_cost": 3.0002e-07,
         "input_cost_per_token": 2.9999900000000002e-06,
         "input_dbu_cost_per_token": 4.2857e-05,
         "litellm_provider": "databricks",
@@ -14853,8 +14853,8 @@
         "supports_tool_choice": true
     },
     "databricks/databricks-claude-sonnet-4-5": {
-        "cache_creation_input_token_cost": 3.7499875e-06,
-        "cache_read_input_token_cost": 2.99999e-07,
+        "cache_creation_input_token_cost": 3.74997e-06,
+        "cache_read_input_token_cost": 3.0002e-07,
         "input_cost_per_token": 2.9999900000000002e-06,
         "input_dbu_cost_per_token": 4.2857e-05,
         "litellm_provider": "databricks",
@@ -14875,8 +14875,8 @@
         "supports_tool_choice": true
     },
     "databricks/databricks-claude-sonnet-4-6": {
-        "cache_creation_input_token_cost": 3.7499875e-06,
-        "cache_read_input_token_cost": 2.99999e-07,
+        "cache_creation_input_token_cost": 3.74997e-06,
+        "cache_read_input_token_cost": 3.0002e-07,
         "input_cost_per_token": 2.9999900000000002e-06,
         "input_dbu_cost_per_token": 4.2857e-05,
         "litellm_provider": "databricks",
@@ -14897,8 +14897,8 @@
         "supports_tool_choice": true
     },
     "databricks/databricks-claude-sonnet-5": {
-        "cache_creation_input_token_cost": 3.7499875e-06,
-        "cache_read_input_token_cost": 2.99999e-07,
+        "cache_creation_input_token_cost": 3.74997e-06,
+        "cache_read_input_token_cost": 3.0002e-07,
         "input_cost_per_token": 2.99999e-06,
         "input_dbu_cost_per_token": 4.2857e-05,
         "litellm_provider": "databricks",
@@ -14906,7 +14906,7 @@
         "max_output_tokens": 128000,
         "max_tokens": 128000,
         "metadata": {
-            "notes": "Input/output cost per token is dbu cost * $0.070. Number provided for reference, '*_dbu_cost_per_token' used in actual calculation. Introductory launch rates of 28.571 input / 142.857 output DBU run through 2026-08-31; the standard rates are listed here because entries carry no expiry date."
+            "notes": "Costs per token are the published Global DBU rates times $0.070 per DBU. The '*_dbu_cost_per_token' fields are provided for reference; cost calculation reads the dollar '*_cost_per_token' fields. Introductory launch rates of 28.571 input / 142.857 output / 35.714 cache write / 2.857 cache read DBU run through 2026-08-31; the standard rates are listed here because entries carry no expiry date."
         },
         "mode": "chat",
         "output_cost_per_token": 1.500002e-05,
@@ -14965,7 +14965,7 @@
     },
     "databricks/databricks-gemini-3-1-flash-lite": {
         "cache_creation_input_token_cost": 3.1248e-07,
-        "cache_read_input_token_cost": 3.1248e-08,
+        "cache_read_input_token_cost": 3.122e-08,
         "input_cost_per_token": 3.1248e-07,
         "input_dbu_cost_per_token": 4.464e-06,
         "litellm_provider": "databricks",
@@ -14985,7 +14985,7 @@
     },
     "databricks/databricks-gemini-3-1-pro": {
         "cache_creation_input_token_cost": 2.49998e-06,
-        "cache_read_input_token_cost": 2.49998e-07,
+        "cache_read_input_token_cost": 2.4997e-07,
         "input_cost_per_token": 2.49998e-06,
         "input_dbu_cost_per_token": 3.5714e-05,
         "litellm_provider": "databricks",
@@ -15005,7 +15005,7 @@
     },
     "databricks/databricks-gemini-3-flash": {
         "cache_creation_input_token_cost": 6.2503e-07,
-        "cache_read_input_token_cost": 6.2503e-08,
+        "cache_read_input_token_cost": 6.251e-08,
         "input_cost_per_token": 6.2503e-07,
         "input_dbu_cost_per_token": 8.929e-06,
         "litellm_provider": "databricks",
@@ -15025,7 +15025,7 @@
     },
     "databricks/databricks-gemini-3-pro": {
         "cache_creation_input_token_cost": 2.49998e-06,
-        "cache_read_input_token_cost": 2.49998e-07,
+        "cache_read_input_token_cost": 2.4997e-07,
         "input_cost_per_token": 2.49998e-06,
         "input_dbu_cost_per_token": 3.5714e-05,
         "litellm_provider": "databricks",
@@ -15062,7 +15062,7 @@
     },
     "databricks/databricks-gpt-5": {
         "cache_creation_input_token_cost": 1.24999e-06,
-        "cache_read_input_token_cost": 1.24999e-07,
+        "cache_read_input_token_cost": 1.2502e-07,
         "input_cost_per_token": 1.24999e-06,
         "input_dbu_cost_per_token": 1.7857e-05,
         "litellm_provider": "databricks",
@@ -15080,7 +15080,7 @@
     },
     "databricks/databricks-gpt-5-1": {
         "cache_creation_input_token_cost": 1.24999e-06,
-        "cache_read_input_token_cost": 1.24999e-07,
+        "cache_read_input_token_cost": 1.2502e-07,
         "input_cost_per_token": 1.24999e-06,
         "input_dbu_cost_per_token": 1.7857e-05,
         "litellm_provider": "databricks",
@@ -15098,7 +15098,7 @@
     },
     "databricks/databricks-gpt-5-1-codex-max": {
         "cache_creation_input_token_cost": 1.24999e-06,
-        "cache_read_input_token_cost": 1.24999e-07,
+        "cache_read_input_token_cost": 1.2502e-07,
         "input_cost_per_token": 1.24999e-06,
         "input_dbu_cost_per_token": 1.7857e-05,
         "litellm_provider": "databricks",
@@ -15116,7 +15116,7 @@
     },
     "databricks/databricks-gpt-5-1-codex-mini": {
         "cache_creation_input_token_cost": 2.4997e-07,
-        "cache_read_input_token_cost": 2.4997e-08,
+        "cache_read_input_token_cost": 2.499e-08,
         "input_cost_per_token": 2.4997e-07,
         "input_dbu_cost_per_token": 3.571e-06,
         "litellm_provider": "databricks",
@@ -15188,7 +15188,7 @@
     },
     "databricks/databricks-gpt-5-4": {
         "cache_creation_input_token_cost": 2.49998e-06,
-        "cache_read_input_token_cost": 2.49998e-07,
+        "cache_read_input_token_cost": 2.4997e-07,
         "input_cost_per_token": 2.49998e-06,
         "input_dbu_cost_per_token": 3.5714e-05,
         "litellm_provider": "databricks",
@@ -15206,7 +15206,7 @@
     },
     "databricks/databricks-gpt-5-4-mini": {
         "cache_creation_input_token_cost": 7.4998e-07,
-        "cache_read_input_token_cost": 7.4998e-08,
+        "cache_read_input_token_cost": 7.497e-08,
         "input_cost_per_token": 7.4998e-07,
         "input_dbu_cost_per_token": 1.0714e-05,
         "litellm_provider": "databricks",
@@ -15224,7 +15224,7 @@
     },
     "databricks/databricks-gpt-5-4-nano": {
         "cache_creation_input_token_cost": 1.9999e-07,
-        "cache_read_input_token_cost": 1.9999e-08,
+        "cache_read_input_token_cost": 2.002e-08,
         "input_cost_per_token": 1.9999e-07,
         "input_dbu_cost_per_token": 2.857e-06,
         "litellm_provider": "databricks",
@@ -15242,7 +15242,7 @@
     },
     "databricks/databricks-gpt-5-mini": {
         "cache_creation_input_token_cost": 2.4997e-07,
-        "cache_read_input_token_cost": 2.4997e-08,
+        "cache_read_input_token_cost": 2.499e-08,
         "input_cost_per_token": 2.4997000000000006e-07,
         "input_dbu_cost_per_token": 3.571e-06,
         "litellm_provider": "databricks",
@@ -15260,7 +15260,7 @@
     },
     "databricks/databricks-gpt-5-nano": {
         "cache_creation_input_token_cost": 4.998e-08,
-        "cache_read_input_token_cost": 4.998e-09,
+        "cache_read_input_token_cost": 4.97e-09,
         "input_cost_per_token": 4.998e-08,
         "input_dbu_cost_per_token": 7.14e-07,
         "litellm_provider": "databricks",

--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -14614,7 +14614,7 @@
         "supports_reasoning": true,
         "supports_sampling_params": false,
         "supports_tool_choice": true,
-        "supports_vision": false,
+        "supports_vision": true,
         "thinking_always_on": true
     },
     "databricks/databricks-claude-haiku-4-5": {

--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -14551,6 +14551,8 @@
         ]
     },
     "databricks/databricks-bge-large-en": {
+        "cache_creation_input_token_cost": 1.0003e-07,
+        "cache_read_input_token_cost": 1.0003e-07,
         "input_cost_per_token": 1.0003e-07,
         "input_dbu_cost_per_token": 1.429e-06,
         "litellm_provider": "databricks",
@@ -14904,7 +14906,7 @@
         "max_output_tokens": 128000,
         "max_tokens": 128000,
         "metadata": {
-            "notes": "Input/output cost per token is dbu cost * $0.070. Number provided for reference, '*_dbu_cost_per_token' used in actual calculation. Anthropic's introductory launch rates (28.571 input / 142.857 output DBU) run through 2026-08-31. The standard rates listed here, equal to Sonnet 4.5 / 4.6, are used instead because pricing carries no expiry date, and undercharging past the window would let spend outrun enforced budgets."
+            "notes": "Input/output cost per token is dbu cost * $0.070. Number provided for reference, '*_dbu_cost_per_token' used in actual calculation. Introductory launch rates of 28.571 input / 142.857 output DBU run through 2026-08-31; the standard rates are listed here because entries carry no expiry date."
         },
         "mode": "chat",
         "output_cost_per_token": 1.5000020000000002e-05,
@@ -15042,6 +15044,8 @@
         "supports_tool_choice": true
     },
     "databricks/databricks-gemma-3-12b": {
+        "cache_creation_input_token_cost": 1.5000999999999998e-07,
+        "cache_read_input_token_cost": 1.5000999999999998e-07,
         "input_cost_per_token": 1.5000999999999998e-07,
         "input_dbu_cost_per_token": 2.1429999999999996e-06,
         "litellm_provider": "databricks",
@@ -15273,6 +15277,8 @@
         "supports_prompt_caching": true
     },
     "databricks/databricks-gpt-oss-120b": {
+        "cache_creation_input_token_cost": 1.5000999999999998e-07,
+        "cache_read_input_token_cost": 1.5000999999999998e-07,
         "input_cost_per_token": 1.5000999999999998e-07,
         "input_dbu_cost_per_token": 2.1429999999999996e-06,
         "litellm_provider": "databricks",
@@ -15288,6 +15294,8 @@
         "source": "https://www.databricks.com/product/pricing/foundation-model-serving"
     },
     "databricks/databricks-gpt-oss-20b": {
+        "cache_creation_input_token_cost": 7e-08,
+        "cache_read_input_token_cost": 7e-08,
         "input_cost_per_token": 7e-08,
         "input_dbu_cost_per_token": 1e-06,
         "litellm_provider": "databricks",
@@ -15303,6 +15311,8 @@
         "source": "https://www.databricks.com/product/pricing/foundation-model-serving"
     },
     "databricks/databricks-gte-large-en": {
+        "cache_creation_input_token_cost": 1.2999000000000001e-07,
+        "cache_read_input_token_cost": 1.2999000000000001e-07,
         "input_cost_per_token": 1.2999000000000001e-07,
         "input_dbu_cost_per_token": 1.857e-06,
         "litellm_provider": "databricks",
@@ -15318,6 +15328,8 @@
         "source": "https://www.databricks.com/product/pricing/foundation-model-serving"
     },
     "databricks/databricks-llama-2-70b-chat": {
+        "cache_creation_input_token_cost": 5.0001e-07,
+        "cache_read_input_token_cost": 5.0001e-07,
         "input_cost_per_token": 5.0001e-07,
         "input_dbu_cost_per_token": 7.143e-06,
         "litellm_provider": "databricks",
@@ -15334,6 +15346,8 @@
         "supports_tool_choice": true
     },
     "databricks/databricks-llama-4-maverick": {
+        "cache_creation_input_token_cost": 5.0001e-07,
+        "cache_read_input_token_cost": 5.0001e-07,
         "input_cost_per_token": 5.0001e-07,
         "input_dbu_cost_per_token": 7.143e-06,
         "litellm_provider": "databricks",
@@ -15350,6 +15364,8 @@
         "supports_tool_choice": true
     },
     "databricks/databricks-meta-llama-3-1-405b-instruct": {
+        "cache_creation_input_token_cost": 5.00003e-06,
+        "cache_read_input_token_cost": 5.00003e-06,
         "input_cost_per_token": 5.00003e-06,
         "input_dbu_cost_per_token": 7.1429e-05,
         "litellm_provider": "databricks",
@@ -15366,6 +15382,8 @@
         "supports_tool_choice": true
     },
     "databricks/databricks-meta-llama-3-1-8b-instruct": {
+        "cache_creation_input_token_cost": 1.5000999999999998e-07,
+        "cache_read_input_token_cost": 1.5000999999999998e-07,
         "input_cost_per_token": 1.5000999999999998e-07,
         "input_dbu_cost_per_token": 2.1429999999999996e-06,
         "litellm_provider": "databricks",
@@ -15381,6 +15399,8 @@
         "source": "https://www.databricks.com/product/pricing/foundation-model-serving"
     },
     "databricks/databricks-meta-llama-3-3-70b-instruct": {
+        "cache_creation_input_token_cost": 5.0001e-07,
+        "cache_read_input_token_cost": 5.0001e-07,
         "input_cost_per_token": 5.0001e-07,
         "input_dbu_cost_per_token": 7.143e-06,
         "litellm_provider": "databricks",
@@ -15397,6 +15417,8 @@
         "supports_tool_choice": true
     },
     "databricks/databricks-meta-llama-3-70b-instruct": {
+        "cache_creation_input_token_cost": 1.00002e-06,
+        "cache_read_input_token_cost": 1.00002e-06,
         "input_cost_per_token": 1.00002e-06,
         "input_dbu_cost_per_token": 1.4286e-05,
         "litellm_provider": "databricks",
@@ -15413,6 +15435,8 @@
         "supports_tool_choice": true
     },
     "databricks/databricks-mixtral-8x7b-instruct": {
+        "cache_creation_input_token_cost": 5.0001e-07,
+        "cache_read_input_token_cost": 5.0001e-07,
         "input_cost_per_token": 5.0001e-07,
         "input_dbu_cost_per_token": 7.143e-06,
         "litellm_provider": "databricks",
@@ -15429,6 +15453,8 @@
         "supports_tool_choice": true
     },
     "databricks/databricks-mpt-30b-instruct": {
+        "cache_creation_input_token_cost": 1.00002e-06,
+        "cache_read_input_token_cost": 1.00002e-06,
         "input_cost_per_token": 1.00002e-06,
         "input_dbu_cost_per_token": 1.4286e-05,
         "litellm_provider": "databricks",
@@ -15445,6 +15471,8 @@
         "supports_tool_choice": true
     },
     "databricks/databricks-mpt-7b-instruct": {
+        "cache_creation_input_token_cost": 5.0001e-07,
+        "cache_read_input_token_cost": 5.0001e-07,
         "input_cost_per_token": 5.0001e-07,
         "input_dbu_cost_per_token": 7.143e-06,
         "litellm_provider": "databricks",

--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -14614,7 +14614,7 @@
         "supports_reasoning": true,
         "supports_sampling_params": false,
         "supports_tool_choice": true,
-        "supports_vision": true,
+        "supports_vision": false,
         "thinking_always_on": true
     },
     "databricks/databricks-claude-haiku-4-5": {

--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -14895,20 +14895,20 @@
         "supports_tool_choice": true
     },
     "databricks/databricks-claude-sonnet-5": {
-        "cache_creation_input_token_cost": 2.4999625e-06,
-        "cache_read_input_token_cost": 1.9999700000000004e-07,
-        "input_cost_per_token": 1.9999700000000004e-06,
-        "input_dbu_cost_per_token": 2.8571e-05,
+        "cache_creation_input_token_cost": 3.7499875e-06,
+        "cache_read_input_token_cost": 2.9999900000000006e-07,
+        "input_cost_per_token": 2.9999900000000002e-06,
+        "input_dbu_cost_per_token": 4.2857e-05,
         "litellm_provider": "databricks",
         "max_input_tokens": 1000000,
         "max_output_tokens": 128000,
         "max_tokens": 128000,
         "metadata": {
-            "notes": "Input/output cost per token is dbu cost * $0.070. Number provided for reference, '*_dbu_cost_per_token' used in actual calculation. Claude Sonnet 5 DBU rates are Anthropic's introductory launch pricing, in effect through 2026-08-31, after which the standard Sonnet 5 rates (equal to Sonnet 4.5 / 4.6) take effect."
+            "notes": "Input/output cost per token is dbu cost * $0.070. Number provided for reference, '*_dbu_cost_per_token' used in actual calculation. Anthropic's introductory launch rates (28.571 input / 142.857 output DBU) run through 2026-08-31. The standard rates listed here, equal to Sonnet 4.5 / 4.6, are used instead because pricing carries no expiry date, and undercharging past the window would let spend outrun enforced budgets."
         },
         "mode": "chat",
-        "output_cost_per_token": 9.999990000000002e-06,
-        "output_dbu_cost_per_token": 0.000142857,
+        "output_cost_per_token": 1.5000020000000002e-05,
+        "output_dbu_cost_per_token": 0.000214286,
         "prompt_cache_min_tokens": 1024,
         "source": "https://www.databricks.com/product/pricing/proprietary-foundation-model-serving",
         "supports_adaptive_thinking": true,

--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -14566,6 +14566,8 @@
         "source": "https://www.databricks.com/product/pricing/foundation-model-serving"
     },
     "databricks/databricks-claude-3-7-sonnet": {
+        "cache_creation_input_token_cost": 3.7499875e-06,
+        "cache_read_input_token_cost": 2.9999900000000006e-07,
         "input_cost_per_token": 2.9999900000000002e-06,
         "input_dbu_cost_per_token": 4.2857e-05,
         "litellm_provider": "databricks",
@@ -14581,10 +14583,41 @@
         "source": "https://www.databricks.com/product/pricing/proprietary-foundation-model-serving",
         "supports_assistant_prefill": true,
         "supports_function_calling": true,
+        "supports_prompt_caching": true,
         "supports_reasoning": true,
         "supports_tool_choice": true
     },
+    "databricks/databricks-claude-fable-5": {
+        "cache_creation_input_token_cost": 1.2500075e-05,
+        "cache_read_input_token_cost": 1.0000060000000001e-06,
+        "input_cost_per_token": 1.000006e-05,
+        "input_dbu_cost_per_token": 0.000142858,
+        "litellm_provider": "databricks",
+        "max_input_tokens": 1000000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "metadata": {
+            "notes": "Input/output cost per token is dbu cost * $0.070. Number provided for reference, '*_dbu_cost_per_token' used in actual calculation."
+        },
+        "mode": "chat",
+        "output_cost_per_token": 5.0000020000000004e-05,
+        "output_dbu_cost_per_token": 0.000714286,
+        "prompt_cache_min_tokens": 512,
+        "source": "https://www.databricks.com/product/pricing/proprietary-foundation-model-serving",
+        "supports_adaptive_thinking": true,
+        "supports_assistant_prefill": false,
+        "supports_function_calling": true,
+        "supports_mid_conversation_system": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_sampling_params": false,
+        "supports_tool_choice": true,
+        "supports_vision": true,
+        "thinking_always_on": true
+    },
     "databricks/databricks-claude-haiku-4-5": {
+        "cache_creation_input_token_cost": 1.2500250000000002e-06,
+        "cache_read_input_token_cost": 1.0000200000000002e-07,
         "input_cost_per_token": 1.00002e-06,
         "input_dbu_cost_per_token": 1.4286e-05,
         "litellm_provider": "databricks",
@@ -14600,10 +14633,13 @@
         "source": "https://www.databricks.com/product/pricing/proprietary-foundation-model-serving",
         "supports_assistant_prefill": true,
         "supports_function_calling": true,
+        "supports_prompt_caching": true,
         "supports_reasoning": true,
         "supports_tool_choice": true
     },
     "databricks/databricks-claude-opus-4": {
+        "cache_creation_input_token_cost": 1.8750025e-05,
+        "cache_read_input_token_cost": 1.500002e-06,
         "input_cost_per_token": 1.5000020000000002e-05,
         "input_dbu_cost_per_token": 0.000214286,
         "litellm_provider": "databricks",
@@ -14619,10 +14655,13 @@
         "source": "https://www.databricks.com/product/pricing/proprietary-foundation-model-serving",
         "supports_assistant_prefill": true,
         "supports_function_calling": true,
+        "supports_prompt_caching": true,
         "supports_reasoning": true,
         "supports_tool_choice": true
     },
     "databricks/databricks-claude-opus-4-1": {
+        "cache_creation_input_token_cost": 1.8750025e-05,
+        "cache_read_input_token_cost": 1.500002e-06,
         "input_cost_per_token": 1.5000020000000002e-05,
         "input_dbu_cost_per_token": 0.000214286,
         "litellm_provider": "databricks",
@@ -14638,10 +14677,13 @@
         "source": "https://www.databricks.com/product/pricing/proprietary-foundation-model-serving",
         "supports_assistant_prefill": true,
         "supports_function_calling": true,
+        "supports_prompt_caching": true,
         "supports_reasoning": true,
         "supports_tool_choice": true
     },
     "databricks/databricks-claude-opus-4-5": {
+        "cache_creation_input_token_cost": 6.2500375e-06,
+        "cache_read_input_token_cost": 5.000030000000001e-07,
         "input_cost_per_token": 5.00003e-06,
         "input_dbu_cost_per_token": 7.1429e-05,
         "litellm_provider": "databricks",
@@ -14657,11 +14699,14 @@
         "source": "https://www.databricks.com/product/pricing/proprietary-foundation-model-serving",
         "supports_assistant_prefill": true,
         "supports_function_calling": true,
+        "supports_prompt_caching": true,
         "supports_reasoning": true,
         "supports_tool_choice": true,
         "supports_output_config": true
     },
     "databricks/databricks-claude-opus-4-6": {
+        "cache_creation_input_token_cost": 6.2500375e-06,
+        "cache_read_input_token_cost": 5.000030000000001e-07,
         "input_cost_per_token": 5.00003e-06,
         "input_dbu_cost_per_token": 7.1429e-05,
         "litellm_provider": "databricks",
@@ -14677,10 +14722,93 @@
         "source": "https://www.databricks.com/product/pricing/proprietary-foundation-model-serving",
         "supports_assistant_prefill": true,
         "supports_function_calling": true,
+        "supports_prompt_caching": true,
         "supports_reasoning": true,
         "supports_tool_choice": true
     },
+    "databricks/databricks-claude-opus-4-7": {
+        "cache_creation_input_token_cost": 6.2500375e-06,
+        "cache_read_input_token_cost": 5.000030000000001e-07,
+        "input_cost_per_token": 5.00003e-06,
+        "input_dbu_cost_per_token": 7.1429e-05,
+        "litellm_provider": "databricks",
+        "max_input_tokens": 1000000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "metadata": {
+            "notes": "Input/output cost per token is dbu cost * $0.070. Number provided for reference, '*_dbu_cost_per_token' used in actual calculation."
+        },
+        "mode": "chat",
+        "output_cost_per_token": 2.5000010000000002e-05,
+        "output_dbu_cost_per_token": 0.000357143,
+        "prompt_cache_min_tokens": 2048,
+        "source": "https://www.databricks.com/product/pricing/proprietary-foundation-model-serving",
+        "supports_adaptive_thinking": true,
+        "supports_assistant_prefill": false,
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_sampling_params": false,
+        "supports_tool_choice": true,
+        "supports_vision": true
+    },
+    "databricks/databricks-claude-opus-4-8": {
+        "cache_creation_input_token_cost": 6.2500375e-06,
+        "cache_read_input_token_cost": 5.000030000000001e-07,
+        "input_cost_per_token": 5.00003e-06,
+        "input_dbu_cost_per_token": 7.1429e-05,
+        "litellm_provider": "databricks",
+        "max_input_tokens": 1000000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "metadata": {
+            "notes": "Input/output cost per token is dbu cost * $0.070. Number provided for reference, '*_dbu_cost_per_token' used in actual calculation."
+        },
+        "mode": "chat",
+        "output_cost_per_token": 2.5000010000000002e-05,
+        "output_dbu_cost_per_token": 0.000357143,
+        "prompt_cache_min_tokens": 1024,
+        "source": "https://www.databricks.com/product/pricing/proprietary-foundation-model-serving",
+        "supports_adaptive_thinking": true,
+        "supports_assistant_prefill": false,
+        "supports_function_calling": true,
+        "supports_mid_conversation_system": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_sampling_params": false,
+        "supports_tool_choice": true,
+        "supports_vision": true
+    },
+    "databricks/databricks-claude-opus-5": {
+        "cache_creation_input_token_cost": 6.2500375e-06,
+        "cache_read_input_token_cost": 5.000030000000001e-07,
+        "input_cost_per_token": 5.00003e-06,
+        "input_dbu_cost_per_token": 7.1429e-05,
+        "litellm_provider": "databricks",
+        "max_input_tokens": 1000000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "metadata": {
+            "notes": "Input/output cost per token is dbu cost * $0.070. Number provided for reference, '*_dbu_cost_per_token' used in actual calculation."
+        },
+        "mode": "chat",
+        "output_cost_per_token": 2.5000010000000002e-05,
+        "output_dbu_cost_per_token": 0.000357143,
+        "prompt_cache_min_tokens": 512,
+        "source": "https://www.databricks.com/product/pricing/proprietary-foundation-model-serving",
+        "supports_adaptive_thinking": true,
+        "supports_assistant_prefill": false,
+        "supports_function_calling": true,
+        "supports_mid_conversation_system": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_sampling_params": false,
+        "supports_tool_choice": true,
+        "supports_vision": true
+    },
     "databricks/databricks-claude-sonnet-4": {
+        "cache_creation_input_token_cost": 3.7499875e-06,
+        "cache_read_input_token_cost": 2.9999900000000006e-07,
         "input_cost_per_token": 2.9999900000000002e-06,
         "input_dbu_cost_per_token": 4.2857e-05,
         "litellm_provider": "databricks",
@@ -14696,10 +14824,13 @@
         "source": "https://www.databricks.com/product/pricing/proprietary-foundation-model-serving",
         "supports_assistant_prefill": true,
         "supports_function_calling": true,
+        "supports_prompt_caching": true,
         "supports_reasoning": true,
         "supports_tool_choice": true
     },
     "databricks/databricks-claude-sonnet-4-1": {
+        "cache_creation_input_token_cost": 3.7499875e-06,
+        "cache_read_input_token_cost": 2.9999900000000006e-07,
         "input_cost_per_token": 2.9999900000000002e-06,
         "input_dbu_cost_per_token": 4.2857e-05,
         "litellm_provider": "databricks",
@@ -14715,10 +14846,13 @@
         "source": "https://www.databricks.com/product/pricing/proprietary-foundation-model-serving",
         "supports_assistant_prefill": true,
         "supports_function_calling": true,
+        "supports_prompt_caching": true,
         "supports_reasoning": true,
         "supports_tool_choice": true
     },
     "databricks/databricks-claude-sonnet-4-5": {
+        "cache_creation_input_token_cost": 3.7499875e-06,
+        "cache_read_input_token_cost": 2.9999900000000006e-07,
         "input_cost_per_token": 2.9999900000000002e-06,
         "input_dbu_cost_per_token": 4.2857e-05,
         "litellm_provider": "databricks",
@@ -14734,10 +14868,13 @@
         "source": "https://www.databricks.com/product/pricing/proprietary-foundation-model-serving",
         "supports_assistant_prefill": true,
         "supports_function_calling": true,
+        "supports_prompt_caching": true,
         "supports_reasoning": true,
         "supports_tool_choice": true
     },
     "databricks/databricks-claude-sonnet-4-6": {
+        "cache_creation_input_token_cost": 3.7499875e-06,
+        "cache_read_input_token_cost": 2.9999900000000006e-07,
         "input_cost_per_token": 2.9999900000000002e-06,
         "input_dbu_cost_per_token": 4.2857e-05,
         "litellm_provider": "databricks",
@@ -14753,10 +14890,40 @@
         "source": "https://www.databricks.com/product/pricing/proprietary-foundation-model-serving",
         "supports_assistant_prefill": true,
         "supports_function_calling": true,
+        "supports_prompt_caching": true,
         "supports_reasoning": true,
         "supports_tool_choice": true
     },
+    "databricks/databricks-claude-sonnet-5": {
+        "cache_creation_input_token_cost": 2.4999625e-06,
+        "cache_read_input_token_cost": 1.9999700000000004e-07,
+        "input_cost_per_token": 1.9999700000000004e-06,
+        "input_dbu_cost_per_token": 2.8571e-05,
+        "litellm_provider": "databricks",
+        "max_input_tokens": 1000000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "metadata": {
+            "notes": "Input/output cost per token is dbu cost * $0.070. Number provided for reference, '*_dbu_cost_per_token' used in actual calculation. Claude Sonnet 5 DBU rates are Anthropic's introductory launch pricing, in effect through 2026-08-31, after which the standard Sonnet 5 rates (equal to Sonnet 4.5 / 4.6) take effect."
+        },
+        "mode": "chat",
+        "output_cost_per_token": 9.999990000000002e-06,
+        "output_dbu_cost_per_token": 0.000142857,
+        "prompt_cache_min_tokens": 1024,
+        "source": "https://www.databricks.com/product/pricing/proprietary-foundation-model-serving",
+        "supports_adaptive_thinking": true,
+        "supports_assistant_prefill": false,
+        "supports_function_calling": true,
+        "supports_mid_conversation_system": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_sampling_params": false,
+        "supports_tool_choice": true,
+        "supports_vision": true
+    },
     "databricks/databricks-gemini-2-5-flash": {
+        "cache_creation_input_token_cost": 3.0001999999999996e-07,
+        "cache_read_input_token_cost": 3.0002e-08,
         "input_cost_per_token": 3.0001999999999996e-07,
         "input_dbu_cost_per_token": 4.285999999999999e-06,
         "litellm_provider": "databricks",
@@ -14771,9 +14938,12 @@
         "output_dbu_cost_per_token": 3.5714e-05,
         "source": "https://www.databricks.com/product/pricing/proprietary-foundation-model-serving",
         "supports_function_calling": true,
+        "supports_prompt_caching": true,
         "supports_tool_choice": true
     },
     "databricks/databricks-gemini-2-5-pro": {
+        "cache_creation_input_token_cost": 1.24999e-06,
+        "cache_read_input_token_cost": 1.24999e-07,
         "input_cost_per_token": 1.24999e-06,
         "input_dbu_cost_per_token": 1.7857e-05,
         "litellm_provider": "databricks",
@@ -14788,9 +14958,12 @@
         "output_dbu_cost_per_token": 0.000142857,
         "source": "https://www.databricks.com/product/pricing/proprietary-foundation-model-serving",
         "supports_function_calling": true,
+        "supports_prompt_caching": true,
         "supports_tool_choice": true
     },
     "databricks/databricks-gemini-3-1-flash-lite": {
+        "cache_creation_input_token_cost": 3.1248e-07,
+        "cache_read_input_token_cost": 3.1248e-08,
         "input_cost_per_token": 3.1248e-07,
         "input_dbu_cost_per_token": 4.464e-06,
         "litellm_provider": "databricks",
@@ -14805,9 +14978,12 @@
         "output_dbu_cost_per_token": 2.6786e-05,
         "source": "https://www.databricks.com/product/pricing/proprietary-foundation-model-serving",
         "supports_function_calling": true,
+        "supports_prompt_caching": true,
         "supports_tool_choice": true
     },
     "databricks/databricks-gemini-3-1-pro": {
+        "cache_creation_input_token_cost": 2.49998e-06,
+        "cache_read_input_token_cost": 2.49998e-07,
         "input_cost_per_token": 2.49998e-06,
         "input_dbu_cost_per_token": 3.5714e-05,
         "litellm_provider": "databricks",
@@ -14822,9 +14998,12 @@
         "output_dbu_cost_per_token": 0.000214286,
         "source": "https://www.databricks.com/product/pricing/proprietary-foundation-model-serving",
         "supports_function_calling": true,
+        "supports_prompt_caching": true,
         "supports_tool_choice": true
     },
     "databricks/databricks-gemini-3-flash": {
+        "cache_creation_input_token_cost": 6.250300000000001e-07,
+        "cache_read_input_token_cost": 6.250300000000001e-08,
         "input_cost_per_token": 6.2503e-07,
         "input_dbu_cost_per_token": 8.929e-06,
         "litellm_provider": "databricks",
@@ -14839,9 +15018,12 @@
         "output_dbu_cost_per_token": 5.3571e-05,
         "source": "https://www.databricks.com/product/pricing/proprietary-foundation-model-serving",
         "supports_function_calling": true,
+        "supports_prompt_caching": true,
         "supports_tool_choice": true
     },
     "databricks/databricks-gemini-3-pro": {
+        "cache_creation_input_token_cost": 2.49998e-06,
+        "cache_read_input_token_cost": 2.49998e-07,
         "input_cost_per_token": 2.49998e-06,
         "input_dbu_cost_per_token": 3.5714e-05,
         "litellm_provider": "databricks",
@@ -14856,6 +15038,7 @@
         "output_dbu_cost_per_token": 0.000214286,
         "source": "https://www.databricks.com/product/pricing/proprietary-foundation-model-serving",
         "supports_function_calling": true,
+        "supports_prompt_caching": true,
         "supports_tool_choice": true
     },
     "databricks/databricks-gemma-3-12b": {
@@ -14874,6 +15057,8 @@
         "source": "https://www.databricks.com/product/pricing/foundation-model-serving"
     },
     "databricks/databricks-gpt-5": {
+        "cache_creation_input_token_cost": 1.24999e-06,
+        "cache_read_input_token_cost": 1.24999e-07,
         "input_cost_per_token": 1.24999e-06,
         "input_dbu_cost_per_token": 1.7857e-05,
         "litellm_provider": "databricks",
@@ -14886,9 +15071,12 @@
         "mode": "chat",
         "output_cost_per_token": 9.999990000000002e-06,
         "output_dbu_cost_per_token": 0.000142857,
-        "source": "https://www.databricks.com/product/pricing/proprietary-foundation-model-serving"
+        "source": "https://www.databricks.com/product/pricing/proprietary-foundation-model-serving",
+        "supports_prompt_caching": true
     },
     "databricks/databricks-gpt-5-1": {
+        "cache_creation_input_token_cost": 1.24999e-06,
+        "cache_read_input_token_cost": 1.24999e-07,
         "input_cost_per_token": 1.24999e-06,
         "input_dbu_cost_per_token": 1.7857e-05,
         "litellm_provider": "databricks",
@@ -14901,9 +15089,12 @@
         "mode": "chat",
         "output_cost_per_token": 9.999990000000002e-06,
         "output_dbu_cost_per_token": 0.000142857,
-        "source": "https://www.databricks.com/product/pricing/proprietary-foundation-model-serving"
+        "source": "https://www.databricks.com/product/pricing/proprietary-foundation-model-serving",
+        "supports_prompt_caching": true
     },
     "databricks/databricks-gpt-5-1-codex-max": {
+        "cache_creation_input_token_cost": 1.24999e-06,
+        "cache_read_input_token_cost": 1.24999e-07,
         "input_cost_per_token": 1.24999e-06,
         "input_dbu_cost_per_token": 1.7857e-05,
         "litellm_provider": "databricks",
@@ -14916,9 +15107,12 @@
         "mode": "chat",
         "output_cost_per_token": 9.999990000000002e-06,
         "output_dbu_cost_per_token": 0.000142857,
-        "source": "https://www.databricks.com/product/pricing/proprietary-foundation-model-serving"
+        "source": "https://www.databricks.com/product/pricing/proprietary-foundation-model-serving",
+        "supports_prompt_caching": true
     },
     "databricks/databricks-gpt-5-1-codex-mini": {
+        "cache_creation_input_token_cost": 2.4997000000000006e-07,
+        "cache_read_input_token_cost": 2.4997000000000005e-08,
         "input_cost_per_token": 2.4997e-07,
         "input_dbu_cost_per_token": 3.571e-06,
         "litellm_provider": "databricks",
@@ -14931,9 +15125,12 @@
         "mode": "chat",
         "output_cost_per_token": 1.99997e-06,
         "output_dbu_cost_per_token": 2.8571e-05,
-        "source": "https://www.databricks.com/product/pricing/proprietary-foundation-model-serving"
+        "source": "https://www.databricks.com/product/pricing/proprietary-foundation-model-serving",
+        "supports_prompt_caching": true
     },
     "databricks/databricks-gpt-5-2": {
+        "cache_creation_input_token_cost": 1.7500000000000002e-06,
+        "cache_read_input_token_cost": 1.7500000000000002e-07,
         "input_cost_per_token": 1.75e-06,
         "input_dbu_cost_per_token": 2.5e-05,
         "litellm_provider": "databricks",
@@ -14946,9 +15143,12 @@
         "mode": "chat",
         "output_cost_per_token": 1.4e-05,
         "output_dbu_cost_per_token": 0.0002,
-        "source": "https://www.databricks.com/product/pricing/proprietary-foundation-model-serving"
+        "source": "https://www.databricks.com/product/pricing/proprietary-foundation-model-serving",
+        "supports_prompt_caching": true
     },
     "databricks/databricks-gpt-5-2-codex": {
+        "cache_creation_input_token_cost": 1.7500000000000002e-06,
+        "cache_read_input_token_cost": 1.7500000000000002e-07,
         "input_cost_per_token": 1.75e-06,
         "input_dbu_cost_per_token": 2.5e-05,
         "litellm_provider": "databricks",
@@ -14961,9 +15161,12 @@
         "mode": "chat",
         "output_cost_per_token": 1.4e-05,
         "output_dbu_cost_per_token": 0.0002,
-        "source": "https://www.databricks.com/product/pricing/proprietary-foundation-model-serving"
+        "source": "https://www.databricks.com/product/pricing/proprietary-foundation-model-serving",
+        "supports_prompt_caching": true
     },
     "databricks/databricks-gpt-5-3-codex": {
+        "cache_creation_input_token_cost": 1.7500000000000002e-06,
+        "cache_read_input_token_cost": 1.7500000000000002e-07,
         "input_cost_per_token": 1.75e-06,
         "input_dbu_cost_per_token": 2.5e-05,
         "litellm_provider": "databricks",
@@ -14976,9 +15179,12 @@
         "mode": "chat",
         "output_cost_per_token": 1.4e-05,
         "output_dbu_cost_per_token": 0.0002,
-        "source": "https://www.databricks.com/product/pricing/proprietary-foundation-model-serving"
+        "source": "https://www.databricks.com/product/pricing/proprietary-foundation-model-serving",
+        "supports_prompt_caching": true
     },
     "databricks/databricks-gpt-5-4": {
+        "cache_creation_input_token_cost": 2.49998e-06,
+        "cache_read_input_token_cost": 2.49998e-07,
         "input_cost_per_token": 2.49998e-06,
         "input_dbu_cost_per_token": 3.5714e-05,
         "litellm_provider": "databricks",
@@ -14991,9 +15197,12 @@
         "mode": "chat",
         "output_cost_per_token": 1.5000020000000002e-05,
         "output_dbu_cost_per_token": 0.000214286,
-        "source": "https://www.databricks.com/product/pricing/proprietary-foundation-model-serving"
+        "source": "https://www.databricks.com/product/pricing/proprietary-foundation-model-serving",
+        "supports_prompt_caching": true
     },
     "databricks/databricks-gpt-5-4-mini": {
+        "cache_creation_input_token_cost": 7.4998e-07,
+        "cache_read_input_token_cost": 7.499800000000001e-08,
         "input_cost_per_token": 7.4998e-07,
         "input_dbu_cost_per_token": 1.0714e-05,
         "litellm_provider": "databricks",
@@ -15006,9 +15215,12 @@
         "mode": "chat",
         "output_cost_per_token": 4.50002e-06,
         "output_dbu_cost_per_token": 6.4286e-05,
-        "source": "https://www.databricks.com/product/pricing/proprietary-foundation-model-serving"
+        "source": "https://www.databricks.com/product/pricing/proprietary-foundation-model-serving",
+        "supports_prompt_caching": true
     },
     "databricks/databricks-gpt-5-4-nano": {
+        "cache_creation_input_token_cost": 1.9999e-07,
+        "cache_read_input_token_cost": 1.9999000000000003e-08,
         "input_cost_per_token": 1.9999e-07,
         "input_dbu_cost_per_token": 2.857e-06,
         "litellm_provider": "databricks",
@@ -15021,9 +15233,12 @@
         "mode": "chat",
         "output_cost_per_token": 1.24999e-06,
         "output_dbu_cost_per_token": 1.7857e-05,
-        "source": "https://www.databricks.com/product/pricing/proprietary-foundation-model-serving"
+        "source": "https://www.databricks.com/product/pricing/proprietary-foundation-model-serving",
+        "supports_prompt_caching": true
     },
     "databricks/databricks-gpt-5-mini": {
+        "cache_creation_input_token_cost": 2.4997000000000006e-07,
+        "cache_read_input_token_cost": 2.4997000000000005e-08,
         "input_cost_per_token": 2.4997000000000006e-07,
         "input_dbu_cost_per_token": 3.571e-06,
         "litellm_provider": "databricks",
@@ -15036,9 +15251,12 @@
         "mode": "chat",
         "output_cost_per_token": 1.9999700000000004e-06,
         "output_dbu_cost_per_token": 2.8571e-05,
-        "source": "https://www.databricks.com/product/pricing/proprietary-foundation-model-serving"
+        "source": "https://www.databricks.com/product/pricing/proprietary-foundation-model-serving",
+        "supports_prompt_caching": true
     },
     "databricks/databricks-gpt-5-nano": {
+        "cache_creation_input_token_cost": 4.998e-08,
+        "cache_read_input_token_cost": 4.998000000000001e-09,
         "input_cost_per_token": 4.998e-08,
         "input_dbu_cost_per_token": 7.14e-07,
         "litellm_provider": "databricks",
@@ -15051,7 +15269,8 @@
         "mode": "chat",
         "output_cost_per_token": 3.9998000000000007e-07,
         "output_dbu_cost_per_token": 5.714000000000001e-06,
-        "source": "https://www.databricks.com/product/pricing/proprietary-foundation-model-serving"
+        "source": "https://www.databricks.com/product/pricing/proprietary-foundation-model-serving",
+        "supports_prompt_caching": true
     },
     "databricks/databricks-gpt-oss-120b": {
         "input_cost_per_token": 1.5000999999999998e-07,

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -14569,7 +14569,7 @@
     },
     "databricks/databricks-claude-3-7-sonnet": {
         "cache_creation_input_token_cost": 3.7499875e-06,
-        "cache_read_input_token_cost": 2.9999900000000006e-07,
+        "cache_read_input_token_cost": 2.99999e-07,
         "input_cost_per_token": 2.9999900000000002e-06,
         "input_dbu_cost_per_token": 4.2857e-05,
         "litellm_provider": "databricks",
@@ -14591,7 +14591,7 @@
     },
     "databricks/databricks-claude-fable-5": {
         "cache_creation_input_token_cost": 1.2500075e-05,
-        "cache_read_input_token_cost": 1.0000060000000001e-06,
+        "cache_read_input_token_cost": 1.000006e-06,
         "input_cost_per_token": 1.000006e-05,
         "input_dbu_cost_per_token": 0.000142858,
         "litellm_provider": "databricks",
@@ -14602,7 +14602,7 @@
             "notes": "Input/output cost per token is dbu cost * $0.070. Number provided for reference, '*_dbu_cost_per_token' used in actual calculation."
         },
         "mode": "chat",
-        "output_cost_per_token": 5.0000020000000004e-05,
+        "output_cost_per_token": 5.000002e-05,
         "output_dbu_cost_per_token": 0.000714286,
         "prompt_cache_min_tokens": 512,
         "source": "https://www.databricks.com/product/pricing/proprietary-foundation-model-serving",
@@ -14618,8 +14618,8 @@
         "thinking_always_on": true
     },
     "databricks/databricks-claude-haiku-4-5": {
-        "cache_creation_input_token_cost": 1.2500250000000002e-06,
-        "cache_read_input_token_cost": 1.0000200000000002e-07,
+        "cache_creation_input_token_cost": 1.250025e-06,
+        "cache_read_input_token_cost": 1.00002e-07,
         "input_cost_per_token": 1.00002e-06,
         "input_dbu_cost_per_token": 1.4286e-05,
         "litellm_provider": "databricks",
@@ -14685,7 +14685,7 @@
     },
     "databricks/databricks-claude-opus-4-5": {
         "cache_creation_input_token_cost": 6.2500375e-06,
-        "cache_read_input_token_cost": 5.000030000000001e-07,
+        "cache_read_input_token_cost": 5.00003e-07,
         "input_cost_per_token": 5.00003e-06,
         "input_dbu_cost_per_token": 7.1429e-05,
         "litellm_provider": "databricks",
@@ -14708,7 +14708,7 @@
     },
     "databricks/databricks-claude-opus-4-6": {
         "cache_creation_input_token_cost": 6.2500375e-06,
-        "cache_read_input_token_cost": 5.000030000000001e-07,
+        "cache_read_input_token_cost": 5.00003e-07,
         "input_cost_per_token": 5.00003e-06,
         "input_dbu_cost_per_token": 7.1429e-05,
         "litellm_provider": "databricks",
@@ -14730,7 +14730,7 @@
     },
     "databricks/databricks-claude-opus-4-7": {
         "cache_creation_input_token_cost": 6.2500375e-06,
-        "cache_read_input_token_cost": 5.000030000000001e-07,
+        "cache_read_input_token_cost": 5.00003e-07,
         "input_cost_per_token": 5.00003e-06,
         "input_dbu_cost_per_token": 7.1429e-05,
         "litellm_provider": "databricks",
@@ -14741,7 +14741,7 @@
             "notes": "Input/output cost per token is dbu cost * $0.070. Number provided for reference, '*_dbu_cost_per_token' used in actual calculation."
         },
         "mode": "chat",
-        "output_cost_per_token": 2.5000010000000002e-05,
+        "output_cost_per_token": 2.500001e-05,
         "output_dbu_cost_per_token": 0.000357143,
         "prompt_cache_min_tokens": 2048,
         "source": "https://www.databricks.com/product/pricing/proprietary-foundation-model-serving",
@@ -14756,7 +14756,7 @@
     },
     "databricks/databricks-claude-opus-4-8": {
         "cache_creation_input_token_cost": 6.2500375e-06,
-        "cache_read_input_token_cost": 5.000030000000001e-07,
+        "cache_read_input_token_cost": 5.00003e-07,
         "input_cost_per_token": 5.00003e-06,
         "input_dbu_cost_per_token": 7.1429e-05,
         "litellm_provider": "databricks",
@@ -14767,7 +14767,7 @@
             "notes": "Input/output cost per token is dbu cost * $0.070. Number provided for reference, '*_dbu_cost_per_token' used in actual calculation."
         },
         "mode": "chat",
-        "output_cost_per_token": 2.5000010000000002e-05,
+        "output_cost_per_token": 2.500001e-05,
         "output_dbu_cost_per_token": 0.000357143,
         "prompt_cache_min_tokens": 1024,
         "source": "https://www.databricks.com/product/pricing/proprietary-foundation-model-serving",
@@ -14783,7 +14783,7 @@
     },
     "databricks/databricks-claude-opus-5": {
         "cache_creation_input_token_cost": 6.2500375e-06,
-        "cache_read_input_token_cost": 5.000030000000001e-07,
+        "cache_read_input_token_cost": 5.00003e-07,
         "input_cost_per_token": 5.00003e-06,
         "input_dbu_cost_per_token": 7.1429e-05,
         "litellm_provider": "databricks",
@@ -14794,7 +14794,7 @@
             "notes": "Input/output cost per token is dbu cost * $0.070. Number provided for reference, '*_dbu_cost_per_token' used in actual calculation."
         },
         "mode": "chat",
-        "output_cost_per_token": 2.5000010000000002e-05,
+        "output_cost_per_token": 2.500001e-05,
         "output_dbu_cost_per_token": 0.000357143,
         "prompt_cache_min_tokens": 512,
         "source": "https://www.databricks.com/product/pricing/proprietary-foundation-model-serving",
@@ -14810,7 +14810,7 @@
     },
     "databricks/databricks-claude-sonnet-4": {
         "cache_creation_input_token_cost": 3.7499875e-06,
-        "cache_read_input_token_cost": 2.9999900000000006e-07,
+        "cache_read_input_token_cost": 2.99999e-07,
         "input_cost_per_token": 2.9999900000000002e-06,
         "input_dbu_cost_per_token": 4.2857e-05,
         "litellm_provider": "databricks",
@@ -14832,7 +14832,7 @@
     },
     "databricks/databricks-claude-sonnet-4-1": {
         "cache_creation_input_token_cost": 3.7499875e-06,
-        "cache_read_input_token_cost": 2.9999900000000006e-07,
+        "cache_read_input_token_cost": 2.99999e-07,
         "input_cost_per_token": 2.9999900000000002e-06,
         "input_dbu_cost_per_token": 4.2857e-05,
         "litellm_provider": "databricks",
@@ -14854,7 +14854,7 @@
     },
     "databricks/databricks-claude-sonnet-4-5": {
         "cache_creation_input_token_cost": 3.7499875e-06,
-        "cache_read_input_token_cost": 2.9999900000000006e-07,
+        "cache_read_input_token_cost": 2.99999e-07,
         "input_cost_per_token": 2.9999900000000002e-06,
         "input_dbu_cost_per_token": 4.2857e-05,
         "litellm_provider": "databricks",
@@ -14876,7 +14876,7 @@
     },
     "databricks/databricks-claude-sonnet-4-6": {
         "cache_creation_input_token_cost": 3.7499875e-06,
-        "cache_read_input_token_cost": 2.9999900000000006e-07,
+        "cache_read_input_token_cost": 2.99999e-07,
         "input_cost_per_token": 2.9999900000000002e-06,
         "input_dbu_cost_per_token": 4.2857e-05,
         "litellm_provider": "databricks",
@@ -14898,8 +14898,8 @@
     },
     "databricks/databricks-claude-sonnet-5": {
         "cache_creation_input_token_cost": 3.7499875e-06,
-        "cache_read_input_token_cost": 2.9999900000000006e-07,
-        "input_cost_per_token": 2.9999900000000002e-06,
+        "cache_read_input_token_cost": 2.99999e-07,
+        "input_cost_per_token": 2.99999e-06,
         "input_dbu_cost_per_token": 4.2857e-05,
         "litellm_provider": "databricks",
         "max_input_tokens": 1000000,
@@ -14909,7 +14909,7 @@
             "notes": "Input/output cost per token is dbu cost * $0.070. Number provided for reference, '*_dbu_cost_per_token' used in actual calculation. Introductory launch rates of 28.571 input / 142.857 output DBU run through 2026-08-31; the standard rates are listed here because entries carry no expiry date."
         },
         "mode": "chat",
-        "output_cost_per_token": 1.5000020000000002e-05,
+        "output_cost_per_token": 1.500002e-05,
         "output_dbu_cost_per_token": 0.000214286,
         "prompt_cache_min_tokens": 1024,
         "source": "https://www.databricks.com/product/pricing/proprietary-foundation-model-serving",
@@ -14924,7 +14924,7 @@
         "supports_vision": true
     },
     "databricks/databricks-gemini-2-5-flash": {
-        "cache_creation_input_token_cost": 3.0001999999999996e-07,
+        "cache_creation_input_token_cost": 3.0002e-07,
         "cache_read_input_token_cost": 3.0002e-08,
         "input_cost_per_token": 3.0001999999999996e-07,
         "input_dbu_cost_per_token": 4.285999999999999e-06,
@@ -15004,8 +15004,8 @@
         "supports_tool_choice": true
     },
     "databricks/databricks-gemini-3-flash": {
-        "cache_creation_input_token_cost": 6.250300000000001e-07,
-        "cache_read_input_token_cost": 6.250300000000001e-08,
+        "cache_creation_input_token_cost": 6.2503e-07,
+        "cache_read_input_token_cost": 6.2503e-08,
         "input_cost_per_token": 6.2503e-07,
         "input_dbu_cost_per_token": 8.929e-06,
         "litellm_provider": "databricks",
@@ -15044,8 +15044,8 @@
         "supports_tool_choice": true
     },
     "databricks/databricks-gemma-3-12b": {
-        "cache_creation_input_token_cost": 1.5000999999999998e-07,
-        "cache_read_input_token_cost": 1.5000999999999998e-07,
+        "cache_creation_input_token_cost": 1.5001e-07,
+        "cache_read_input_token_cost": 1.5001e-07,
         "input_cost_per_token": 1.5000999999999998e-07,
         "input_dbu_cost_per_token": 2.1429999999999996e-06,
         "litellm_provider": "databricks",
@@ -15115,8 +15115,8 @@
         "supports_prompt_caching": true
     },
     "databricks/databricks-gpt-5-1-codex-mini": {
-        "cache_creation_input_token_cost": 2.4997000000000006e-07,
-        "cache_read_input_token_cost": 2.4997000000000005e-08,
+        "cache_creation_input_token_cost": 2.4997e-07,
+        "cache_read_input_token_cost": 2.4997e-08,
         "input_cost_per_token": 2.4997e-07,
         "input_dbu_cost_per_token": 3.571e-06,
         "litellm_provider": "databricks",
@@ -15133,8 +15133,8 @@
         "supports_prompt_caching": true
     },
     "databricks/databricks-gpt-5-2": {
-        "cache_creation_input_token_cost": 1.7500000000000002e-06,
-        "cache_read_input_token_cost": 1.7500000000000002e-07,
+        "cache_creation_input_token_cost": 1.75e-06,
+        "cache_read_input_token_cost": 1.75e-07,
         "input_cost_per_token": 1.75e-06,
         "input_dbu_cost_per_token": 2.5e-05,
         "litellm_provider": "databricks",
@@ -15151,8 +15151,8 @@
         "supports_prompt_caching": true
     },
     "databricks/databricks-gpt-5-2-codex": {
-        "cache_creation_input_token_cost": 1.7500000000000002e-06,
-        "cache_read_input_token_cost": 1.7500000000000002e-07,
+        "cache_creation_input_token_cost": 1.75e-06,
+        "cache_read_input_token_cost": 1.75e-07,
         "input_cost_per_token": 1.75e-06,
         "input_dbu_cost_per_token": 2.5e-05,
         "litellm_provider": "databricks",
@@ -15169,8 +15169,8 @@
         "supports_prompt_caching": true
     },
     "databricks/databricks-gpt-5-3-codex": {
-        "cache_creation_input_token_cost": 1.7500000000000002e-06,
-        "cache_read_input_token_cost": 1.7500000000000002e-07,
+        "cache_creation_input_token_cost": 1.75e-06,
+        "cache_read_input_token_cost": 1.75e-07,
         "input_cost_per_token": 1.75e-06,
         "input_dbu_cost_per_token": 2.5e-05,
         "litellm_provider": "databricks",
@@ -15206,7 +15206,7 @@
     },
     "databricks/databricks-gpt-5-4-mini": {
         "cache_creation_input_token_cost": 7.4998e-07,
-        "cache_read_input_token_cost": 7.499800000000001e-08,
+        "cache_read_input_token_cost": 7.4998e-08,
         "input_cost_per_token": 7.4998e-07,
         "input_dbu_cost_per_token": 1.0714e-05,
         "litellm_provider": "databricks",
@@ -15224,7 +15224,7 @@
     },
     "databricks/databricks-gpt-5-4-nano": {
         "cache_creation_input_token_cost": 1.9999e-07,
-        "cache_read_input_token_cost": 1.9999000000000003e-08,
+        "cache_read_input_token_cost": 1.9999e-08,
         "input_cost_per_token": 1.9999e-07,
         "input_dbu_cost_per_token": 2.857e-06,
         "litellm_provider": "databricks",
@@ -15241,8 +15241,8 @@
         "supports_prompt_caching": true
     },
     "databricks/databricks-gpt-5-mini": {
-        "cache_creation_input_token_cost": 2.4997000000000006e-07,
-        "cache_read_input_token_cost": 2.4997000000000005e-08,
+        "cache_creation_input_token_cost": 2.4997e-07,
+        "cache_read_input_token_cost": 2.4997e-08,
         "input_cost_per_token": 2.4997000000000006e-07,
         "input_dbu_cost_per_token": 3.571e-06,
         "litellm_provider": "databricks",
@@ -15260,7 +15260,7 @@
     },
     "databricks/databricks-gpt-5-nano": {
         "cache_creation_input_token_cost": 4.998e-08,
-        "cache_read_input_token_cost": 4.998000000000001e-09,
+        "cache_read_input_token_cost": 4.998e-09,
         "input_cost_per_token": 4.998e-08,
         "input_dbu_cost_per_token": 7.14e-07,
         "litellm_provider": "databricks",
@@ -15277,8 +15277,8 @@
         "supports_prompt_caching": true
     },
     "databricks/databricks-gpt-oss-120b": {
-        "cache_creation_input_token_cost": 1.5000999999999998e-07,
-        "cache_read_input_token_cost": 1.5000999999999998e-07,
+        "cache_creation_input_token_cost": 1.5001e-07,
+        "cache_read_input_token_cost": 1.5001e-07,
         "input_cost_per_token": 1.5000999999999998e-07,
         "input_dbu_cost_per_token": 2.1429999999999996e-06,
         "litellm_provider": "databricks",
@@ -15311,8 +15311,8 @@
         "source": "https://www.databricks.com/product/pricing/foundation-model-serving"
     },
     "databricks/databricks-gte-large-en": {
-        "cache_creation_input_token_cost": 1.2999000000000001e-07,
-        "cache_read_input_token_cost": 1.2999000000000001e-07,
+        "cache_creation_input_token_cost": 1.2999e-07,
+        "cache_read_input_token_cost": 1.2999e-07,
         "input_cost_per_token": 1.2999000000000001e-07,
         "input_dbu_cost_per_token": 1.857e-06,
         "litellm_provider": "databricks",
@@ -15382,8 +15382,8 @@
         "supports_tool_choice": true
     },
     "databricks/databricks-meta-llama-3-1-8b-instruct": {
-        "cache_creation_input_token_cost": 1.5000999999999998e-07,
-        "cache_read_input_token_cost": 1.5000999999999998e-07,
+        "cache_creation_input_token_cost": 1.5001e-07,
+        "cache_read_input_token_cost": 1.5001e-07,
         "input_cost_per_token": 1.5000999999999998e-07,
         "input_dbu_cost_per_token": 2.1429999999999996e-06,
         "litellm_provider": "databricks",

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -14568,8 +14568,8 @@
         "source": "https://www.databricks.com/product/pricing/foundation-model-serving"
     },
     "databricks/databricks-claude-3-7-sonnet": {
-        "cache_creation_input_token_cost": 3.7499875e-06,
-        "cache_read_input_token_cost": 2.99999e-07,
+        "cache_creation_input_token_cost": 3.74997e-06,
+        "cache_read_input_token_cost": 3.0002e-07,
         "input_cost_per_token": 2.9999900000000002e-06,
         "input_dbu_cost_per_token": 4.2857e-05,
         "litellm_provider": "databricks",
@@ -14590,8 +14590,8 @@
         "supports_tool_choice": true
     },
     "databricks/databricks-claude-fable-5": {
-        "cache_creation_input_token_cost": 1.2500075e-05,
-        "cache_read_input_token_cost": 1.000006e-06,
+        "cache_creation_input_token_cost": 1.250004e-05,
+        "cache_read_input_token_cost": 1.00002e-06,
         "input_cost_per_token": 1.000006e-05,
         "input_dbu_cost_per_token": 0.000142858,
         "litellm_provider": "databricks",
@@ -14599,7 +14599,7 @@
         "max_output_tokens": 128000,
         "max_tokens": 128000,
         "metadata": {
-            "notes": "Input/output cost per token is dbu cost * $0.070. Number provided for reference, '*_dbu_cost_per_token' used in actual calculation."
+            "notes": "Costs per token are the published Global DBU rates times $0.070 per DBU. The '*_dbu_cost_per_token' fields are provided for reference; cost calculation reads the dollar '*_cost_per_token' fields."
         },
         "mode": "chat",
         "output_cost_per_token": 5.000002e-05,
@@ -14614,12 +14614,12 @@
         "supports_reasoning": true,
         "supports_sampling_params": false,
         "supports_tool_choice": true,
-        "supports_vision": true,
+        "supports_vision": false,
         "thinking_always_on": true
     },
     "databricks/databricks-claude-haiku-4-5": {
-        "cache_creation_input_token_cost": 1.250025e-06,
-        "cache_read_input_token_cost": 1.00002e-07,
+        "cache_creation_input_token_cost": 1.24999e-06,
+        "cache_read_input_token_cost": 1.0003e-07,
         "input_cost_per_token": 1.00002e-06,
         "input_dbu_cost_per_token": 1.4286e-05,
         "litellm_provider": "databricks",
@@ -14640,8 +14640,8 @@
         "supports_tool_choice": true
     },
     "databricks/databricks-claude-opus-4": {
-        "cache_creation_input_token_cost": 1.8750025e-05,
-        "cache_read_input_token_cost": 1.500002e-06,
+        "cache_creation_input_token_cost": 1.874999e-05,
+        "cache_read_input_token_cost": 1.50003e-06,
         "input_cost_per_token": 1.5000020000000002e-05,
         "input_dbu_cost_per_token": 0.000214286,
         "litellm_provider": "databricks",
@@ -14662,8 +14662,8 @@
         "supports_tool_choice": true
     },
     "databricks/databricks-claude-opus-4-1": {
-        "cache_creation_input_token_cost": 1.8750025e-05,
-        "cache_read_input_token_cost": 1.500002e-06,
+        "cache_creation_input_token_cost": 1.874999e-05,
+        "cache_read_input_token_cost": 1.50003e-06,
         "input_cost_per_token": 1.5000020000000002e-05,
         "input_dbu_cost_per_token": 0.000214286,
         "litellm_provider": "databricks",
@@ -14684,8 +14684,8 @@
         "supports_tool_choice": true
     },
     "databricks/databricks-claude-opus-4-5": {
-        "cache_creation_input_token_cost": 6.2500375e-06,
-        "cache_read_input_token_cost": 5.00003e-07,
+        "cache_creation_input_token_cost": 6.25002e-06,
+        "cache_read_input_token_cost": 5.0001e-07,
         "input_cost_per_token": 5.00003e-06,
         "input_dbu_cost_per_token": 7.1429e-05,
         "litellm_provider": "databricks",
@@ -14707,8 +14707,8 @@
         "supports_output_config": true
     },
     "databricks/databricks-claude-opus-4-6": {
-        "cache_creation_input_token_cost": 6.2500375e-06,
-        "cache_read_input_token_cost": 5.00003e-07,
+        "cache_creation_input_token_cost": 6.25002e-06,
+        "cache_read_input_token_cost": 5.0001e-07,
         "input_cost_per_token": 5.00003e-06,
         "input_dbu_cost_per_token": 7.1429e-05,
         "litellm_provider": "databricks",
@@ -14729,8 +14729,8 @@
         "supports_tool_choice": true
     },
     "databricks/databricks-claude-opus-4-7": {
-        "cache_creation_input_token_cost": 6.2500375e-06,
-        "cache_read_input_token_cost": 5.00003e-07,
+        "cache_creation_input_token_cost": 6.25002e-06,
+        "cache_read_input_token_cost": 5.0001e-07,
         "input_cost_per_token": 5.00003e-06,
         "input_dbu_cost_per_token": 7.1429e-05,
         "litellm_provider": "databricks",
@@ -14738,7 +14738,7 @@
         "max_output_tokens": 128000,
         "max_tokens": 128000,
         "metadata": {
-            "notes": "Input/output cost per token is dbu cost * $0.070. Number provided for reference, '*_dbu_cost_per_token' used in actual calculation."
+            "notes": "Costs per token are the published Global DBU rates times $0.070 per DBU. The '*_dbu_cost_per_token' fields are provided for reference; cost calculation reads the dollar '*_cost_per_token' fields."
         },
         "mode": "chat",
         "output_cost_per_token": 2.500001e-05,
@@ -14755,8 +14755,8 @@
         "supports_vision": true
     },
     "databricks/databricks-claude-opus-4-8": {
-        "cache_creation_input_token_cost": 6.2500375e-06,
-        "cache_read_input_token_cost": 5.00003e-07,
+        "cache_creation_input_token_cost": 6.25002e-06,
+        "cache_read_input_token_cost": 5.0001e-07,
         "input_cost_per_token": 5.00003e-06,
         "input_dbu_cost_per_token": 7.1429e-05,
         "litellm_provider": "databricks",
@@ -14764,7 +14764,7 @@
         "max_output_tokens": 128000,
         "max_tokens": 128000,
         "metadata": {
-            "notes": "Input/output cost per token is dbu cost * $0.070. Number provided for reference, '*_dbu_cost_per_token' used in actual calculation."
+            "notes": "Costs per token are the published Global DBU rates times $0.070 per DBU. The '*_dbu_cost_per_token' fields are provided for reference; cost calculation reads the dollar '*_cost_per_token' fields."
         },
         "mode": "chat",
         "output_cost_per_token": 2.500001e-05,
@@ -14782,8 +14782,8 @@
         "supports_vision": true
     },
     "databricks/databricks-claude-opus-5": {
-        "cache_creation_input_token_cost": 6.2500375e-06,
-        "cache_read_input_token_cost": 5.00003e-07,
+        "cache_creation_input_token_cost": 6.25002e-06,
+        "cache_read_input_token_cost": 5.0001e-07,
         "input_cost_per_token": 5.00003e-06,
         "input_dbu_cost_per_token": 7.1429e-05,
         "litellm_provider": "databricks",
@@ -14791,7 +14791,7 @@
         "max_output_tokens": 128000,
         "max_tokens": 128000,
         "metadata": {
-            "notes": "Input/output cost per token is dbu cost * $0.070. Number provided for reference, '*_dbu_cost_per_token' used in actual calculation."
+            "notes": "Costs per token are the published Global DBU rates times $0.070 per DBU. The '*_dbu_cost_per_token' fields are provided for reference; cost calculation reads the dollar '*_cost_per_token' fields."
         },
         "mode": "chat",
         "output_cost_per_token": 2.500001e-05,
@@ -14809,8 +14809,8 @@
         "supports_vision": true
     },
     "databricks/databricks-claude-sonnet-4": {
-        "cache_creation_input_token_cost": 3.7499875e-06,
-        "cache_read_input_token_cost": 2.99999e-07,
+        "cache_creation_input_token_cost": 3.74997e-06,
+        "cache_read_input_token_cost": 3.0002e-07,
         "input_cost_per_token": 2.9999900000000002e-06,
         "input_dbu_cost_per_token": 4.2857e-05,
         "litellm_provider": "databricks",
@@ -14831,8 +14831,8 @@
         "supports_tool_choice": true
     },
     "databricks/databricks-claude-sonnet-4-1": {
-        "cache_creation_input_token_cost": 3.7499875e-06,
-        "cache_read_input_token_cost": 2.99999e-07,
+        "cache_creation_input_token_cost": 3.74997e-06,
+        "cache_read_input_token_cost": 3.0002e-07,
         "input_cost_per_token": 2.9999900000000002e-06,
         "input_dbu_cost_per_token": 4.2857e-05,
         "litellm_provider": "databricks",
@@ -14853,8 +14853,8 @@
         "supports_tool_choice": true
     },
     "databricks/databricks-claude-sonnet-4-5": {
-        "cache_creation_input_token_cost": 3.7499875e-06,
-        "cache_read_input_token_cost": 2.99999e-07,
+        "cache_creation_input_token_cost": 3.74997e-06,
+        "cache_read_input_token_cost": 3.0002e-07,
         "input_cost_per_token": 2.9999900000000002e-06,
         "input_dbu_cost_per_token": 4.2857e-05,
         "litellm_provider": "databricks",
@@ -14875,8 +14875,8 @@
         "supports_tool_choice": true
     },
     "databricks/databricks-claude-sonnet-4-6": {
-        "cache_creation_input_token_cost": 3.7499875e-06,
-        "cache_read_input_token_cost": 2.99999e-07,
+        "cache_creation_input_token_cost": 3.74997e-06,
+        "cache_read_input_token_cost": 3.0002e-07,
         "input_cost_per_token": 2.9999900000000002e-06,
         "input_dbu_cost_per_token": 4.2857e-05,
         "litellm_provider": "databricks",
@@ -14897,8 +14897,8 @@
         "supports_tool_choice": true
     },
     "databricks/databricks-claude-sonnet-5": {
-        "cache_creation_input_token_cost": 3.7499875e-06,
-        "cache_read_input_token_cost": 2.99999e-07,
+        "cache_creation_input_token_cost": 3.74997e-06,
+        "cache_read_input_token_cost": 3.0002e-07,
         "input_cost_per_token": 2.99999e-06,
         "input_dbu_cost_per_token": 4.2857e-05,
         "litellm_provider": "databricks",
@@ -14906,7 +14906,7 @@
         "max_output_tokens": 128000,
         "max_tokens": 128000,
         "metadata": {
-            "notes": "Input/output cost per token is dbu cost * $0.070. Number provided for reference, '*_dbu_cost_per_token' used in actual calculation. Introductory launch rates of 28.571 input / 142.857 output DBU run through 2026-08-31; the standard rates are listed here because entries carry no expiry date."
+            "notes": "Costs per token are the published Global DBU rates times $0.070 per DBU. The '*_dbu_cost_per_token' fields are provided for reference; cost calculation reads the dollar '*_cost_per_token' fields. Introductory launch rates of 28.571 input / 142.857 output / 35.714 cache write / 2.857 cache read DBU run through 2026-08-31; the standard rates are listed here because entries carry no expiry date."
         },
         "mode": "chat",
         "output_cost_per_token": 1.500002e-05,
@@ -14965,7 +14965,7 @@
     },
     "databricks/databricks-gemini-3-1-flash-lite": {
         "cache_creation_input_token_cost": 3.1248e-07,
-        "cache_read_input_token_cost": 3.1248e-08,
+        "cache_read_input_token_cost": 3.122e-08,
         "input_cost_per_token": 3.1248e-07,
         "input_dbu_cost_per_token": 4.464e-06,
         "litellm_provider": "databricks",
@@ -14985,7 +14985,7 @@
     },
     "databricks/databricks-gemini-3-1-pro": {
         "cache_creation_input_token_cost": 2.49998e-06,
-        "cache_read_input_token_cost": 2.49998e-07,
+        "cache_read_input_token_cost": 2.4997e-07,
         "input_cost_per_token": 2.49998e-06,
         "input_dbu_cost_per_token": 3.5714e-05,
         "litellm_provider": "databricks",
@@ -15005,7 +15005,7 @@
     },
     "databricks/databricks-gemini-3-flash": {
         "cache_creation_input_token_cost": 6.2503e-07,
-        "cache_read_input_token_cost": 6.2503e-08,
+        "cache_read_input_token_cost": 6.251e-08,
         "input_cost_per_token": 6.2503e-07,
         "input_dbu_cost_per_token": 8.929e-06,
         "litellm_provider": "databricks",
@@ -15025,7 +15025,7 @@
     },
     "databricks/databricks-gemini-3-pro": {
         "cache_creation_input_token_cost": 2.49998e-06,
-        "cache_read_input_token_cost": 2.49998e-07,
+        "cache_read_input_token_cost": 2.4997e-07,
         "input_cost_per_token": 2.49998e-06,
         "input_dbu_cost_per_token": 3.5714e-05,
         "litellm_provider": "databricks",
@@ -15062,7 +15062,7 @@
     },
     "databricks/databricks-gpt-5": {
         "cache_creation_input_token_cost": 1.24999e-06,
-        "cache_read_input_token_cost": 1.24999e-07,
+        "cache_read_input_token_cost": 1.2502e-07,
         "input_cost_per_token": 1.24999e-06,
         "input_dbu_cost_per_token": 1.7857e-05,
         "litellm_provider": "databricks",
@@ -15080,7 +15080,7 @@
     },
     "databricks/databricks-gpt-5-1": {
         "cache_creation_input_token_cost": 1.24999e-06,
-        "cache_read_input_token_cost": 1.24999e-07,
+        "cache_read_input_token_cost": 1.2502e-07,
         "input_cost_per_token": 1.24999e-06,
         "input_dbu_cost_per_token": 1.7857e-05,
         "litellm_provider": "databricks",
@@ -15098,7 +15098,7 @@
     },
     "databricks/databricks-gpt-5-1-codex-max": {
         "cache_creation_input_token_cost": 1.24999e-06,
-        "cache_read_input_token_cost": 1.24999e-07,
+        "cache_read_input_token_cost": 1.2502e-07,
         "input_cost_per_token": 1.24999e-06,
         "input_dbu_cost_per_token": 1.7857e-05,
         "litellm_provider": "databricks",
@@ -15116,7 +15116,7 @@
     },
     "databricks/databricks-gpt-5-1-codex-mini": {
         "cache_creation_input_token_cost": 2.4997e-07,
-        "cache_read_input_token_cost": 2.4997e-08,
+        "cache_read_input_token_cost": 2.499e-08,
         "input_cost_per_token": 2.4997e-07,
         "input_dbu_cost_per_token": 3.571e-06,
         "litellm_provider": "databricks",
@@ -15188,7 +15188,7 @@
     },
     "databricks/databricks-gpt-5-4": {
         "cache_creation_input_token_cost": 2.49998e-06,
-        "cache_read_input_token_cost": 2.49998e-07,
+        "cache_read_input_token_cost": 2.4997e-07,
         "input_cost_per_token": 2.49998e-06,
         "input_dbu_cost_per_token": 3.5714e-05,
         "litellm_provider": "databricks",
@@ -15206,7 +15206,7 @@
     },
     "databricks/databricks-gpt-5-4-mini": {
         "cache_creation_input_token_cost": 7.4998e-07,
-        "cache_read_input_token_cost": 7.4998e-08,
+        "cache_read_input_token_cost": 7.497e-08,
         "input_cost_per_token": 7.4998e-07,
         "input_dbu_cost_per_token": 1.0714e-05,
         "litellm_provider": "databricks",
@@ -15224,7 +15224,7 @@
     },
     "databricks/databricks-gpt-5-4-nano": {
         "cache_creation_input_token_cost": 1.9999e-07,
-        "cache_read_input_token_cost": 1.9999e-08,
+        "cache_read_input_token_cost": 2.002e-08,
         "input_cost_per_token": 1.9999e-07,
         "input_dbu_cost_per_token": 2.857e-06,
         "litellm_provider": "databricks",
@@ -15242,7 +15242,7 @@
     },
     "databricks/databricks-gpt-5-mini": {
         "cache_creation_input_token_cost": 2.4997e-07,
-        "cache_read_input_token_cost": 2.4997e-08,
+        "cache_read_input_token_cost": 2.499e-08,
         "input_cost_per_token": 2.4997000000000006e-07,
         "input_dbu_cost_per_token": 3.571e-06,
         "litellm_provider": "databricks",
@@ -15260,7 +15260,7 @@
     },
     "databricks/databricks-gpt-5-nano": {
         "cache_creation_input_token_cost": 4.998e-08,
-        "cache_read_input_token_cost": 4.998e-09,
+        "cache_read_input_token_cost": 4.97e-09,
         "input_cost_per_token": 4.998e-08,
         "input_dbu_cost_per_token": 7.14e-07,
         "litellm_provider": "databricks",

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -14614,7 +14614,7 @@
         "supports_reasoning": true,
         "supports_sampling_params": false,
         "supports_tool_choice": true,
-        "supports_vision": false,
+        "supports_vision": true,
         "thinking_always_on": true
     },
     "databricks/databricks-claude-haiku-4-5": {

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -14551,6 +14551,8 @@
         ]
     },
     "databricks/databricks-bge-large-en": {
+        "cache_creation_input_token_cost": 1.0003e-07,
+        "cache_read_input_token_cost": 1.0003e-07,
         "input_cost_per_token": 1.0003e-07,
         "input_dbu_cost_per_token": 1.429e-06,
         "litellm_provider": "databricks",
@@ -14904,7 +14906,7 @@
         "max_output_tokens": 128000,
         "max_tokens": 128000,
         "metadata": {
-            "notes": "Input/output cost per token is dbu cost * $0.070. Number provided for reference, '*_dbu_cost_per_token' used in actual calculation. Anthropic's introductory launch rates (28.571 input / 142.857 output DBU) run through 2026-08-31. The standard rates listed here, equal to Sonnet 4.5 / 4.6, are used instead because pricing carries no expiry date, and undercharging past the window would let spend outrun enforced budgets."
+            "notes": "Input/output cost per token is dbu cost * $0.070. Number provided for reference, '*_dbu_cost_per_token' used in actual calculation. Introductory launch rates of 28.571 input / 142.857 output DBU run through 2026-08-31; the standard rates are listed here because entries carry no expiry date."
         },
         "mode": "chat",
         "output_cost_per_token": 1.5000020000000002e-05,
@@ -15042,6 +15044,8 @@
         "supports_tool_choice": true
     },
     "databricks/databricks-gemma-3-12b": {
+        "cache_creation_input_token_cost": 1.5000999999999998e-07,
+        "cache_read_input_token_cost": 1.5000999999999998e-07,
         "input_cost_per_token": 1.5000999999999998e-07,
         "input_dbu_cost_per_token": 2.1429999999999996e-06,
         "litellm_provider": "databricks",
@@ -15273,6 +15277,8 @@
         "supports_prompt_caching": true
     },
     "databricks/databricks-gpt-oss-120b": {
+        "cache_creation_input_token_cost": 1.5000999999999998e-07,
+        "cache_read_input_token_cost": 1.5000999999999998e-07,
         "input_cost_per_token": 1.5000999999999998e-07,
         "input_dbu_cost_per_token": 2.1429999999999996e-06,
         "litellm_provider": "databricks",
@@ -15288,6 +15294,8 @@
         "source": "https://www.databricks.com/product/pricing/foundation-model-serving"
     },
     "databricks/databricks-gpt-oss-20b": {
+        "cache_creation_input_token_cost": 7e-08,
+        "cache_read_input_token_cost": 7e-08,
         "input_cost_per_token": 7e-08,
         "input_dbu_cost_per_token": 1e-06,
         "litellm_provider": "databricks",
@@ -15303,6 +15311,8 @@
         "source": "https://www.databricks.com/product/pricing/foundation-model-serving"
     },
     "databricks/databricks-gte-large-en": {
+        "cache_creation_input_token_cost": 1.2999000000000001e-07,
+        "cache_read_input_token_cost": 1.2999000000000001e-07,
         "input_cost_per_token": 1.2999000000000001e-07,
         "input_dbu_cost_per_token": 1.857e-06,
         "litellm_provider": "databricks",
@@ -15318,6 +15328,8 @@
         "source": "https://www.databricks.com/product/pricing/foundation-model-serving"
     },
     "databricks/databricks-llama-2-70b-chat": {
+        "cache_creation_input_token_cost": 5.0001e-07,
+        "cache_read_input_token_cost": 5.0001e-07,
         "input_cost_per_token": 5.0001e-07,
         "input_dbu_cost_per_token": 7.143e-06,
         "litellm_provider": "databricks",
@@ -15334,6 +15346,8 @@
         "supports_tool_choice": true
     },
     "databricks/databricks-llama-4-maverick": {
+        "cache_creation_input_token_cost": 5.0001e-07,
+        "cache_read_input_token_cost": 5.0001e-07,
         "input_cost_per_token": 5.0001e-07,
         "input_dbu_cost_per_token": 7.143e-06,
         "litellm_provider": "databricks",
@@ -15350,6 +15364,8 @@
         "supports_tool_choice": true
     },
     "databricks/databricks-meta-llama-3-1-405b-instruct": {
+        "cache_creation_input_token_cost": 5.00003e-06,
+        "cache_read_input_token_cost": 5.00003e-06,
         "input_cost_per_token": 5.00003e-06,
         "input_dbu_cost_per_token": 7.1429e-05,
         "litellm_provider": "databricks",
@@ -15366,6 +15382,8 @@
         "supports_tool_choice": true
     },
     "databricks/databricks-meta-llama-3-1-8b-instruct": {
+        "cache_creation_input_token_cost": 1.5000999999999998e-07,
+        "cache_read_input_token_cost": 1.5000999999999998e-07,
         "input_cost_per_token": 1.5000999999999998e-07,
         "input_dbu_cost_per_token": 2.1429999999999996e-06,
         "litellm_provider": "databricks",
@@ -15381,6 +15399,8 @@
         "source": "https://www.databricks.com/product/pricing/foundation-model-serving"
     },
     "databricks/databricks-meta-llama-3-3-70b-instruct": {
+        "cache_creation_input_token_cost": 5.0001e-07,
+        "cache_read_input_token_cost": 5.0001e-07,
         "input_cost_per_token": 5.0001e-07,
         "input_dbu_cost_per_token": 7.143e-06,
         "litellm_provider": "databricks",
@@ -15397,6 +15417,8 @@
         "supports_tool_choice": true
     },
     "databricks/databricks-meta-llama-3-70b-instruct": {
+        "cache_creation_input_token_cost": 1.00002e-06,
+        "cache_read_input_token_cost": 1.00002e-06,
         "input_cost_per_token": 1.00002e-06,
         "input_dbu_cost_per_token": 1.4286e-05,
         "litellm_provider": "databricks",
@@ -15413,6 +15435,8 @@
         "supports_tool_choice": true
     },
     "databricks/databricks-mixtral-8x7b-instruct": {
+        "cache_creation_input_token_cost": 5.0001e-07,
+        "cache_read_input_token_cost": 5.0001e-07,
         "input_cost_per_token": 5.0001e-07,
         "input_dbu_cost_per_token": 7.143e-06,
         "litellm_provider": "databricks",
@@ -15429,6 +15453,8 @@
         "supports_tool_choice": true
     },
     "databricks/databricks-mpt-30b-instruct": {
+        "cache_creation_input_token_cost": 1.00002e-06,
+        "cache_read_input_token_cost": 1.00002e-06,
         "input_cost_per_token": 1.00002e-06,
         "input_dbu_cost_per_token": 1.4286e-05,
         "litellm_provider": "databricks",
@@ -15445,6 +15471,8 @@
         "supports_tool_choice": true
     },
     "databricks/databricks-mpt-7b-instruct": {
+        "cache_creation_input_token_cost": 5.0001e-07,
+        "cache_read_input_token_cost": 5.0001e-07,
         "input_cost_per_token": 5.0001e-07,
         "input_dbu_cost_per_token": 7.143e-06,
         "litellm_provider": "databricks",

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -14614,7 +14614,7 @@
         "supports_reasoning": true,
         "supports_sampling_params": false,
         "supports_tool_choice": true,
-        "supports_vision": true,
+        "supports_vision": false,
         "thinking_always_on": true
     },
     "databricks/databricks-claude-haiku-4-5": {

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -14895,20 +14895,20 @@
         "supports_tool_choice": true
     },
     "databricks/databricks-claude-sonnet-5": {
-        "cache_creation_input_token_cost": 2.4999625e-06,
-        "cache_read_input_token_cost": 1.9999700000000004e-07,
-        "input_cost_per_token": 1.9999700000000004e-06,
-        "input_dbu_cost_per_token": 2.8571e-05,
+        "cache_creation_input_token_cost": 3.7499875e-06,
+        "cache_read_input_token_cost": 2.9999900000000006e-07,
+        "input_cost_per_token": 2.9999900000000002e-06,
+        "input_dbu_cost_per_token": 4.2857e-05,
         "litellm_provider": "databricks",
         "max_input_tokens": 1000000,
         "max_output_tokens": 128000,
         "max_tokens": 128000,
         "metadata": {
-            "notes": "Input/output cost per token is dbu cost * $0.070. Number provided for reference, '*_dbu_cost_per_token' used in actual calculation. Claude Sonnet 5 DBU rates are Anthropic's introductory launch pricing, in effect through 2026-08-31, after which the standard Sonnet 5 rates (equal to Sonnet 4.5 / 4.6) take effect."
+            "notes": "Input/output cost per token is dbu cost * $0.070. Number provided for reference, '*_dbu_cost_per_token' used in actual calculation. Anthropic's introductory launch rates (28.571 input / 142.857 output DBU) run through 2026-08-31. The standard rates listed here, equal to Sonnet 4.5 / 4.6, are used instead because pricing carries no expiry date, and undercharging past the window would let spend outrun enforced budgets."
         },
         "mode": "chat",
-        "output_cost_per_token": 9.999990000000002e-06,
-        "output_dbu_cost_per_token": 0.000142857,
+        "output_cost_per_token": 1.5000020000000002e-05,
+        "output_dbu_cost_per_token": 0.000214286,
         "prompt_cache_min_tokens": 1024,
         "source": "https://www.databricks.com/product/pricing/proprietary-foundation-model-serving",
         "supports_adaptive_thinking": true,

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -14566,6 +14566,8 @@
         "source": "https://www.databricks.com/product/pricing/foundation-model-serving"
     },
     "databricks/databricks-claude-3-7-sonnet": {
+        "cache_creation_input_token_cost": 3.7499875e-06,
+        "cache_read_input_token_cost": 2.9999900000000006e-07,
         "input_cost_per_token": 2.9999900000000002e-06,
         "input_dbu_cost_per_token": 4.2857e-05,
         "litellm_provider": "databricks",
@@ -14581,10 +14583,41 @@
         "source": "https://www.databricks.com/product/pricing/proprietary-foundation-model-serving",
         "supports_assistant_prefill": true,
         "supports_function_calling": true,
+        "supports_prompt_caching": true,
         "supports_reasoning": true,
         "supports_tool_choice": true
     },
+    "databricks/databricks-claude-fable-5": {
+        "cache_creation_input_token_cost": 1.2500075e-05,
+        "cache_read_input_token_cost": 1.0000060000000001e-06,
+        "input_cost_per_token": 1.000006e-05,
+        "input_dbu_cost_per_token": 0.000142858,
+        "litellm_provider": "databricks",
+        "max_input_tokens": 1000000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "metadata": {
+            "notes": "Input/output cost per token is dbu cost * $0.070. Number provided for reference, '*_dbu_cost_per_token' used in actual calculation."
+        },
+        "mode": "chat",
+        "output_cost_per_token": 5.0000020000000004e-05,
+        "output_dbu_cost_per_token": 0.000714286,
+        "prompt_cache_min_tokens": 512,
+        "source": "https://www.databricks.com/product/pricing/proprietary-foundation-model-serving",
+        "supports_adaptive_thinking": true,
+        "supports_assistant_prefill": false,
+        "supports_function_calling": true,
+        "supports_mid_conversation_system": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_sampling_params": false,
+        "supports_tool_choice": true,
+        "supports_vision": true,
+        "thinking_always_on": true
+    },
     "databricks/databricks-claude-haiku-4-5": {
+        "cache_creation_input_token_cost": 1.2500250000000002e-06,
+        "cache_read_input_token_cost": 1.0000200000000002e-07,
         "input_cost_per_token": 1.00002e-06,
         "input_dbu_cost_per_token": 1.4286e-05,
         "litellm_provider": "databricks",
@@ -14600,10 +14633,13 @@
         "source": "https://www.databricks.com/product/pricing/proprietary-foundation-model-serving",
         "supports_assistant_prefill": true,
         "supports_function_calling": true,
+        "supports_prompt_caching": true,
         "supports_reasoning": true,
         "supports_tool_choice": true
     },
     "databricks/databricks-claude-opus-4": {
+        "cache_creation_input_token_cost": 1.8750025e-05,
+        "cache_read_input_token_cost": 1.500002e-06,
         "input_cost_per_token": 1.5000020000000002e-05,
         "input_dbu_cost_per_token": 0.000214286,
         "litellm_provider": "databricks",
@@ -14619,10 +14655,13 @@
         "source": "https://www.databricks.com/product/pricing/proprietary-foundation-model-serving",
         "supports_assistant_prefill": true,
         "supports_function_calling": true,
+        "supports_prompt_caching": true,
         "supports_reasoning": true,
         "supports_tool_choice": true
     },
     "databricks/databricks-claude-opus-4-1": {
+        "cache_creation_input_token_cost": 1.8750025e-05,
+        "cache_read_input_token_cost": 1.500002e-06,
         "input_cost_per_token": 1.5000020000000002e-05,
         "input_dbu_cost_per_token": 0.000214286,
         "litellm_provider": "databricks",
@@ -14638,10 +14677,13 @@
         "source": "https://www.databricks.com/product/pricing/proprietary-foundation-model-serving",
         "supports_assistant_prefill": true,
         "supports_function_calling": true,
+        "supports_prompt_caching": true,
         "supports_reasoning": true,
         "supports_tool_choice": true
     },
     "databricks/databricks-claude-opus-4-5": {
+        "cache_creation_input_token_cost": 6.2500375e-06,
+        "cache_read_input_token_cost": 5.000030000000001e-07,
         "input_cost_per_token": 5.00003e-06,
         "input_dbu_cost_per_token": 7.1429e-05,
         "litellm_provider": "databricks",
@@ -14657,11 +14699,14 @@
         "source": "https://www.databricks.com/product/pricing/proprietary-foundation-model-serving",
         "supports_assistant_prefill": true,
         "supports_function_calling": true,
+        "supports_prompt_caching": true,
         "supports_reasoning": true,
         "supports_tool_choice": true,
         "supports_output_config": true
     },
     "databricks/databricks-claude-opus-4-6": {
+        "cache_creation_input_token_cost": 6.2500375e-06,
+        "cache_read_input_token_cost": 5.000030000000001e-07,
         "input_cost_per_token": 5.00003e-06,
         "input_dbu_cost_per_token": 7.1429e-05,
         "litellm_provider": "databricks",
@@ -14677,10 +14722,93 @@
         "source": "https://www.databricks.com/product/pricing/proprietary-foundation-model-serving",
         "supports_assistant_prefill": true,
         "supports_function_calling": true,
+        "supports_prompt_caching": true,
         "supports_reasoning": true,
         "supports_tool_choice": true
     },
+    "databricks/databricks-claude-opus-4-7": {
+        "cache_creation_input_token_cost": 6.2500375e-06,
+        "cache_read_input_token_cost": 5.000030000000001e-07,
+        "input_cost_per_token": 5.00003e-06,
+        "input_dbu_cost_per_token": 7.1429e-05,
+        "litellm_provider": "databricks",
+        "max_input_tokens": 1000000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "metadata": {
+            "notes": "Input/output cost per token is dbu cost * $0.070. Number provided for reference, '*_dbu_cost_per_token' used in actual calculation."
+        },
+        "mode": "chat",
+        "output_cost_per_token": 2.5000010000000002e-05,
+        "output_dbu_cost_per_token": 0.000357143,
+        "prompt_cache_min_tokens": 2048,
+        "source": "https://www.databricks.com/product/pricing/proprietary-foundation-model-serving",
+        "supports_adaptive_thinking": true,
+        "supports_assistant_prefill": false,
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_sampling_params": false,
+        "supports_tool_choice": true,
+        "supports_vision": true
+    },
+    "databricks/databricks-claude-opus-4-8": {
+        "cache_creation_input_token_cost": 6.2500375e-06,
+        "cache_read_input_token_cost": 5.000030000000001e-07,
+        "input_cost_per_token": 5.00003e-06,
+        "input_dbu_cost_per_token": 7.1429e-05,
+        "litellm_provider": "databricks",
+        "max_input_tokens": 1000000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "metadata": {
+            "notes": "Input/output cost per token is dbu cost * $0.070. Number provided for reference, '*_dbu_cost_per_token' used in actual calculation."
+        },
+        "mode": "chat",
+        "output_cost_per_token": 2.5000010000000002e-05,
+        "output_dbu_cost_per_token": 0.000357143,
+        "prompt_cache_min_tokens": 1024,
+        "source": "https://www.databricks.com/product/pricing/proprietary-foundation-model-serving",
+        "supports_adaptive_thinking": true,
+        "supports_assistant_prefill": false,
+        "supports_function_calling": true,
+        "supports_mid_conversation_system": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_sampling_params": false,
+        "supports_tool_choice": true,
+        "supports_vision": true
+    },
+    "databricks/databricks-claude-opus-5": {
+        "cache_creation_input_token_cost": 6.2500375e-06,
+        "cache_read_input_token_cost": 5.000030000000001e-07,
+        "input_cost_per_token": 5.00003e-06,
+        "input_dbu_cost_per_token": 7.1429e-05,
+        "litellm_provider": "databricks",
+        "max_input_tokens": 1000000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "metadata": {
+            "notes": "Input/output cost per token is dbu cost * $0.070. Number provided for reference, '*_dbu_cost_per_token' used in actual calculation."
+        },
+        "mode": "chat",
+        "output_cost_per_token": 2.5000010000000002e-05,
+        "output_dbu_cost_per_token": 0.000357143,
+        "prompt_cache_min_tokens": 512,
+        "source": "https://www.databricks.com/product/pricing/proprietary-foundation-model-serving",
+        "supports_adaptive_thinking": true,
+        "supports_assistant_prefill": false,
+        "supports_function_calling": true,
+        "supports_mid_conversation_system": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_sampling_params": false,
+        "supports_tool_choice": true,
+        "supports_vision": true
+    },
     "databricks/databricks-claude-sonnet-4": {
+        "cache_creation_input_token_cost": 3.7499875e-06,
+        "cache_read_input_token_cost": 2.9999900000000006e-07,
         "input_cost_per_token": 2.9999900000000002e-06,
         "input_dbu_cost_per_token": 4.2857e-05,
         "litellm_provider": "databricks",
@@ -14696,10 +14824,13 @@
         "source": "https://www.databricks.com/product/pricing/proprietary-foundation-model-serving",
         "supports_assistant_prefill": true,
         "supports_function_calling": true,
+        "supports_prompt_caching": true,
         "supports_reasoning": true,
         "supports_tool_choice": true
     },
     "databricks/databricks-claude-sonnet-4-1": {
+        "cache_creation_input_token_cost": 3.7499875e-06,
+        "cache_read_input_token_cost": 2.9999900000000006e-07,
         "input_cost_per_token": 2.9999900000000002e-06,
         "input_dbu_cost_per_token": 4.2857e-05,
         "litellm_provider": "databricks",
@@ -14715,10 +14846,13 @@
         "source": "https://www.databricks.com/product/pricing/proprietary-foundation-model-serving",
         "supports_assistant_prefill": true,
         "supports_function_calling": true,
+        "supports_prompt_caching": true,
         "supports_reasoning": true,
         "supports_tool_choice": true
     },
     "databricks/databricks-claude-sonnet-4-5": {
+        "cache_creation_input_token_cost": 3.7499875e-06,
+        "cache_read_input_token_cost": 2.9999900000000006e-07,
         "input_cost_per_token": 2.9999900000000002e-06,
         "input_dbu_cost_per_token": 4.2857e-05,
         "litellm_provider": "databricks",
@@ -14734,10 +14868,13 @@
         "source": "https://www.databricks.com/product/pricing/proprietary-foundation-model-serving",
         "supports_assistant_prefill": true,
         "supports_function_calling": true,
+        "supports_prompt_caching": true,
         "supports_reasoning": true,
         "supports_tool_choice": true
     },
     "databricks/databricks-claude-sonnet-4-6": {
+        "cache_creation_input_token_cost": 3.7499875e-06,
+        "cache_read_input_token_cost": 2.9999900000000006e-07,
         "input_cost_per_token": 2.9999900000000002e-06,
         "input_dbu_cost_per_token": 4.2857e-05,
         "litellm_provider": "databricks",
@@ -14753,10 +14890,40 @@
         "source": "https://www.databricks.com/product/pricing/proprietary-foundation-model-serving",
         "supports_assistant_prefill": true,
         "supports_function_calling": true,
+        "supports_prompt_caching": true,
         "supports_reasoning": true,
         "supports_tool_choice": true
     },
+    "databricks/databricks-claude-sonnet-5": {
+        "cache_creation_input_token_cost": 2.4999625e-06,
+        "cache_read_input_token_cost": 1.9999700000000004e-07,
+        "input_cost_per_token": 1.9999700000000004e-06,
+        "input_dbu_cost_per_token": 2.8571e-05,
+        "litellm_provider": "databricks",
+        "max_input_tokens": 1000000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "metadata": {
+            "notes": "Input/output cost per token is dbu cost * $0.070. Number provided for reference, '*_dbu_cost_per_token' used in actual calculation. Claude Sonnet 5 DBU rates are Anthropic's introductory launch pricing, in effect through 2026-08-31, after which the standard Sonnet 5 rates (equal to Sonnet 4.5 / 4.6) take effect."
+        },
+        "mode": "chat",
+        "output_cost_per_token": 9.999990000000002e-06,
+        "output_dbu_cost_per_token": 0.000142857,
+        "prompt_cache_min_tokens": 1024,
+        "source": "https://www.databricks.com/product/pricing/proprietary-foundation-model-serving",
+        "supports_adaptive_thinking": true,
+        "supports_assistant_prefill": false,
+        "supports_function_calling": true,
+        "supports_mid_conversation_system": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_sampling_params": false,
+        "supports_tool_choice": true,
+        "supports_vision": true
+    },
     "databricks/databricks-gemini-2-5-flash": {
+        "cache_creation_input_token_cost": 3.0001999999999996e-07,
+        "cache_read_input_token_cost": 3.0002e-08,
         "input_cost_per_token": 3.0001999999999996e-07,
         "input_dbu_cost_per_token": 4.285999999999999e-06,
         "litellm_provider": "databricks",
@@ -14771,9 +14938,12 @@
         "output_dbu_cost_per_token": 3.5714e-05,
         "source": "https://www.databricks.com/product/pricing/proprietary-foundation-model-serving",
         "supports_function_calling": true,
+        "supports_prompt_caching": true,
         "supports_tool_choice": true
     },
     "databricks/databricks-gemini-2-5-pro": {
+        "cache_creation_input_token_cost": 1.24999e-06,
+        "cache_read_input_token_cost": 1.24999e-07,
         "input_cost_per_token": 1.24999e-06,
         "input_dbu_cost_per_token": 1.7857e-05,
         "litellm_provider": "databricks",
@@ -14788,9 +14958,12 @@
         "output_dbu_cost_per_token": 0.000142857,
         "source": "https://www.databricks.com/product/pricing/proprietary-foundation-model-serving",
         "supports_function_calling": true,
+        "supports_prompt_caching": true,
         "supports_tool_choice": true
     },
     "databricks/databricks-gemini-3-1-flash-lite": {
+        "cache_creation_input_token_cost": 3.1248e-07,
+        "cache_read_input_token_cost": 3.1248e-08,
         "input_cost_per_token": 3.1248e-07,
         "input_dbu_cost_per_token": 4.464e-06,
         "litellm_provider": "databricks",
@@ -14805,9 +14978,12 @@
         "output_dbu_cost_per_token": 2.6786e-05,
         "source": "https://www.databricks.com/product/pricing/proprietary-foundation-model-serving",
         "supports_function_calling": true,
+        "supports_prompt_caching": true,
         "supports_tool_choice": true
     },
     "databricks/databricks-gemini-3-1-pro": {
+        "cache_creation_input_token_cost": 2.49998e-06,
+        "cache_read_input_token_cost": 2.49998e-07,
         "input_cost_per_token": 2.49998e-06,
         "input_dbu_cost_per_token": 3.5714e-05,
         "litellm_provider": "databricks",
@@ -14822,9 +14998,12 @@
         "output_dbu_cost_per_token": 0.000214286,
         "source": "https://www.databricks.com/product/pricing/proprietary-foundation-model-serving",
         "supports_function_calling": true,
+        "supports_prompt_caching": true,
         "supports_tool_choice": true
     },
     "databricks/databricks-gemini-3-flash": {
+        "cache_creation_input_token_cost": 6.250300000000001e-07,
+        "cache_read_input_token_cost": 6.250300000000001e-08,
         "input_cost_per_token": 6.2503e-07,
         "input_dbu_cost_per_token": 8.929e-06,
         "litellm_provider": "databricks",
@@ -14839,9 +15018,12 @@
         "output_dbu_cost_per_token": 5.3571e-05,
         "source": "https://www.databricks.com/product/pricing/proprietary-foundation-model-serving",
         "supports_function_calling": true,
+        "supports_prompt_caching": true,
         "supports_tool_choice": true
     },
     "databricks/databricks-gemini-3-pro": {
+        "cache_creation_input_token_cost": 2.49998e-06,
+        "cache_read_input_token_cost": 2.49998e-07,
         "input_cost_per_token": 2.49998e-06,
         "input_dbu_cost_per_token": 3.5714e-05,
         "litellm_provider": "databricks",
@@ -14856,6 +15038,7 @@
         "output_dbu_cost_per_token": 0.000214286,
         "source": "https://www.databricks.com/product/pricing/proprietary-foundation-model-serving",
         "supports_function_calling": true,
+        "supports_prompt_caching": true,
         "supports_tool_choice": true
     },
     "databricks/databricks-gemma-3-12b": {
@@ -14874,6 +15057,8 @@
         "source": "https://www.databricks.com/product/pricing/foundation-model-serving"
     },
     "databricks/databricks-gpt-5": {
+        "cache_creation_input_token_cost": 1.24999e-06,
+        "cache_read_input_token_cost": 1.24999e-07,
         "input_cost_per_token": 1.24999e-06,
         "input_dbu_cost_per_token": 1.7857e-05,
         "litellm_provider": "databricks",
@@ -14886,9 +15071,12 @@
         "mode": "chat",
         "output_cost_per_token": 9.999990000000002e-06,
         "output_dbu_cost_per_token": 0.000142857,
-        "source": "https://www.databricks.com/product/pricing/proprietary-foundation-model-serving"
+        "source": "https://www.databricks.com/product/pricing/proprietary-foundation-model-serving",
+        "supports_prompt_caching": true
     },
     "databricks/databricks-gpt-5-1": {
+        "cache_creation_input_token_cost": 1.24999e-06,
+        "cache_read_input_token_cost": 1.24999e-07,
         "input_cost_per_token": 1.24999e-06,
         "input_dbu_cost_per_token": 1.7857e-05,
         "litellm_provider": "databricks",
@@ -14901,9 +15089,12 @@
         "mode": "chat",
         "output_cost_per_token": 9.999990000000002e-06,
         "output_dbu_cost_per_token": 0.000142857,
-        "source": "https://www.databricks.com/product/pricing/proprietary-foundation-model-serving"
+        "source": "https://www.databricks.com/product/pricing/proprietary-foundation-model-serving",
+        "supports_prompt_caching": true
     },
     "databricks/databricks-gpt-5-1-codex-max": {
+        "cache_creation_input_token_cost": 1.24999e-06,
+        "cache_read_input_token_cost": 1.24999e-07,
         "input_cost_per_token": 1.24999e-06,
         "input_dbu_cost_per_token": 1.7857e-05,
         "litellm_provider": "databricks",
@@ -14916,9 +15107,12 @@
         "mode": "chat",
         "output_cost_per_token": 9.999990000000002e-06,
         "output_dbu_cost_per_token": 0.000142857,
-        "source": "https://www.databricks.com/product/pricing/proprietary-foundation-model-serving"
+        "source": "https://www.databricks.com/product/pricing/proprietary-foundation-model-serving",
+        "supports_prompt_caching": true
     },
     "databricks/databricks-gpt-5-1-codex-mini": {
+        "cache_creation_input_token_cost": 2.4997000000000006e-07,
+        "cache_read_input_token_cost": 2.4997000000000005e-08,
         "input_cost_per_token": 2.4997e-07,
         "input_dbu_cost_per_token": 3.571e-06,
         "litellm_provider": "databricks",
@@ -14931,9 +15125,12 @@
         "mode": "chat",
         "output_cost_per_token": 1.99997e-06,
         "output_dbu_cost_per_token": 2.8571e-05,
-        "source": "https://www.databricks.com/product/pricing/proprietary-foundation-model-serving"
+        "source": "https://www.databricks.com/product/pricing/proprietary-foundation-model-serving",
+        "supports_prompt_caching": true
     },
     "databricks/databricks-gpt-5-2": {
+        "cache_creation_input_token_cost": 1.7500000000000002e-06,
+        "cache_read_input_token_cost": 1.7500000000000002e-07,
         "input_cost_per_token": 1.75e-06,
         "input_dbu_cost_per_token": 2.5e-05,
         "litellm_provider": "databricks",
@@ -14946,9 +15143,12 @@
         "mode": "chat",
         "output_cost_per_token": 1.4e-05,
         "output_dbu_cost_per_token": 0.0002,
-        "source": "https://www.databricks.com/product/pricing/proprietary-foundation-model-serving"
+        "source": "https://www.databricks.com/product/pricing/proprietary-foundation-model-serving",
+        "supports_prompt_caching": true
     },
     "databricks/databricks-gpt-5-2-codex": {
+        "cache_creation_input_token_cost": 1.7500000000000002e-06,
+        "cache_read_input_token_cost": 1.7500000000000002e-07,
         "input_cost_per_token": 1.75e-06,
         "input_dbu_cost_per_token": 2.5e-05,
         "litellm_provider": "databricks",
@@ -14961,9 +15161,12 @@
         "mode": "chat",
         "output_cost_per_token": 1.4e-05,
         "output_dbu_cost_per_token": 0.0002,
-        "source": "https://www.databricks.com/product/pricing/proprietary-foundation-model-serving"
+        "source": "https://www.databricks.com/product/pricing/proprietary-foundation-model-serving",
+        "supports_prompt_caching": true
     },
     "databricks/databricks-gpt-5-3-codex": {
+        "cache_creation_input_token_cost": 1.7500000000000002e-06,
+        "cache_read_input_token_cost": 1.7500000000000002e-07,
         "input_cost_per_token": 1.75e-06,
         "input_dbu_cost_per_token": 2.5e-05,
         "litellm_provider": "databricks",
@@ -14976,9 +15179,12 @@
         "mode": "chat",
         "output_cost_per_token": 1.4e-05,
         "output_dbu_cost_per_token": 0.0002,
-        "source": "https://www.databricks.com/product/pricing/proprietary-foundation-model-serving"
+        "source": "https://www.databricks.com/product/pricing/proprietary-foundation-model-serving",
+        "supports_prompt_caching": true
     },
     "databricks/databricks-gpt-5-4": {
+        "cache_creation_input_token_cost": 2.49998e-06,
+        "cache_read_input_token_cost": 2.49998e-07,
         "input_cost_per_token": 2.49998e-06,
         "input_dbu_cost_per_token": 3.5714e-05,
         "litellm_provider": "databricks",
@@ -14991,9 +15197,12 @@
         "mode": "chat",
         "output_cost_per_token": 1.5000020000000002e-05,
         "output_dbu_cost_per_token": 0.000214286,
-        "source": "https://www.databricks.com/product/pricing/proprietary-foundation-model-serving"
+        "source": "https://www.databricks.com/product/pricing/proprietary-foundation-model-serving",
+        "supports_prompt_caching": true
     },
     "databricks/databricks-gpt-5-4-mini": {
+        "cache_creation_input_token_cost": 7.4998e-07,
+        "cache_read_input_token_cost": 7.499800000000001e-08,
         "input_cost_per_token": 7.4998e-07,
         "input_dbu_cost_per_token": 1.0714e-05,
         "litellm_provider": "databricks",
@@ -15006,9 +15215,12 @@
         "mode": "chat",
         "output_cost_per_token": 4.50002e-06,
         "output_dbu_cost_per_token": 6.4286e-05,
-        "source": "https://www.databricks.com/product/pricing/proprietary-foundation-model-serving"
+        "source": "https://www.databricks.com/product/pricing/proprietary-foundation-model-serving",
+        "supports_prompt_caching": true
     },
     "databricks/databricks-gpt-5-4-nano": {
+        "cache_creation_input_token_cost": 1.9999e-07,
+        "cache_read_input_token_cost": 1.9999000000000003e-08,
         "input_cost_per_token": 1.9999e-07,
         "input_dbu_cost_per_token": 2.857e-06,
         "litellm_provider": "databricks",
@@ -15021,9 +15233,12 @@
         "mode": "chat",
         "output_cost_per_token": 1.24999e-06,
         "output_dbu_cost_per_token": 1.7857e-05,
-        "source": "https://www.databricks.com/product/pricing/proprietary-foundation-model-serving"
+        "source": "https://www.databricks.com/product/pricing/proprietary-foundation-model-serving",
+        "supports_prompt_caching": true
     },
     "databricks/databricks-gpt-5-mini": {
+        "cache_creation_input_token_cost": 2.4997000000000006e-07,
+        "cache_read_input_token_cost": 2.4997000000000005e-08,
         "input_cost_per_token": 2.4997000000000006e-07,
         "input_dbu_cost_per_token": 3.571e-06,
         "litellm_provider": "databricks",
@@ -15036,9 +15251,12 @@
         "mode": "chat",
         "output_cost_per_token": 1.9999700000000004e-06,
         "output_dbu_cost_per_token": 2.8571e-05,
-        "source": "https://www.databricks.com/product/pricing/proprietary-foundation-model-serving"
+        "source": "https://www.databricks.com/product/pricing/proprietary-foundation-model-serving",
+        "supports_prompt_caching": true
     },
     "databricks/databricks-gpt-5-nano": {
+        "cache_creation_input_token_cost": 4.998e-08,
+        "cache_read_input_token_cost": 4.998000000000001e-09,
         "input_cost_per_token": 4.998e-08,
         "input_dbu_cost_per_token": 7.14e-07,
         "litellm_provider": "databricks",
@@ -15051,7 +15269,8 @@
         "mode": "chat",
         "output_cost_per_token": 3.9998000000000007e-07,
         "output_dbu_cost_per_token": 5.714000000000001e-06,
-        "source": "https://www.databricks.com/product/pricing/proprietary-foundation-model-serving"
+        "source": "https://www.databricks.com/product/pricing/proprietary-foundation-model-serving",
+        "supports_prompt_caching": true
     },
     "databricks/databricks-gpt-oss-120b": {
         "input_cost_per_token": 1.5000999999999998e-07,

--- a/tests/test_litellm/integrations/test_anthropic_cache_control_hook.py
+++ b/tests/test_litellm/integrations/test_anthropic_cache_control_hook.py
@@ -1599,7 +1599,7 @@ class TestEnableAnthropicPromptCaching:
         assert supports_prompt_caching(model=model, custom_llm_provider=provider) is True
         assert self._points(model=model, provider=provider) == []
 
-    def test_databricks_claude_not_injected_despite_caching_support(self, monkeypatch):
+    def test_databricks_claude_not_injected_despite_caching_support(self, monkeypatch, local_model_cost_map):
         from litellm.utils import supports_prompt_caching
 
         monkeypatch.setattr(litellm, "enable_anthropic_prompt_caching", True)

--- a/tests/test_litellm/integrations/test_anthropic_cache_control_hook.py
+++ b/tests/test_litellm/integrations/test_anthropic_cache_control_hook.py
@@ -1599,6 +1599,14 @@ class TestEnableAnthropicPromptCaching:
         assert supports_prompt_caching(model=model, custom_llm_provider=provider) is True
         assert self._points(model=model, provider=provider) == []
 
+    def test_databricks_claude_not_injected_despite_caching_support(self, monkeypatch):
+        from litellm.utils import supports_prompt_caching
+
+        monkeypatch.setattr(litellm, "enable_anthropic_prompt_caching", True)
+        model = "databricks/databricks-claude-sonnet-4-5"
+        assert supports_prompt_caching(model=model, custom_llm_provider="databricks") is True
+        assert self._points(model=model, provider="databricks") == []
+
     def test_model_without_caching_support_not_injected(self, monkeypatch):
         monkeypatch.setattr(litellm, "enable_anthropic_prompt_caching", True)
         assert self._points(model="anthropic.claude-3-5-sonnet-20240620-v1:0", provider="bedrock") == []

--- a/tests/test_litellm/litellm_core_utils/test_fallback_generalizations.py
+++ b/tests/test_litellm/litellm_core_utils/test_fallback_generalizations.py
@@ -378,7 +378,7 @@ def test_shipped_rules_flag_unmapped_fable_as_always_on_thinking(shipped_cost_ma
     "model,provider",
     [
         ("claude-opus-4-9@20260101", "vertex_ai"),
-        ("databricks-claude-opus-5-1", "databricks"),
+        ("databricks-claude-haiku-5-1", "databricks"),
     ],
 )
 def test_shipped_rules_are_provider_neutral_for_unmapped_ids(shipped_cost_map, model, provider):
@@ -388,6 +388,8 @@ def test_shipped_rules_are_provider_neutral_for_unmapped_ids(shipped_cost_map, m
     assert info["supports_adaptive_thinking"] is True
     assert info["supports_mid_conversation_system"] is True
     assert info["supports_function_calling"] is True
+    assert not info.get("input_cost_per_token")
+    assert not info.get("output_cost_per_token")
 
 
 @pytest.mark.parametrize(

--- a/tests/test_litellm/llms/databricks/test_databricks_cost_calculator.py
+++ b/tests/test_litellm/llms/databricks/test_databricks_cost_calculator.py
@@ -1,4 +1,6 @@
+import json
 from collections.abc import Iterator
+from pathlib import Path
 from typing import Final
 
 import pytest
@@ -6,6 +8,17 @@ import pytest
 import litellm
 from litellm.llms.databricks.cost_calculator import cost_per_token
 from litellm.types.utils import ModelInfo, Usage
+
+REPO_ROOT: Final = Path(__file__).parents[4]
+MAIN_PRICES: Final = REPO_ROOT / "model_prices_and_context_window.json"
+BACKUP_PRICES: Final = REPO_ROOT / "litellm" / "model_prices_and_context_window_backup.json"
+NEW_MODELS: Final = (
+    "databricks/databricks-claude-opus-4-7",
+    "databricks/databricks-claude-opus-4-8",
+    "databricks/databricks-claude-opus-5",
+    "databricks/databricks-claude-sonnet-5",
+    "databricks/databricks-claude-fable-5",
+)
 
 
 @pytest.fixture
@@ -89,6 +102,43 @@ def test_new_models_carry_cache_pricing(local_model_cost_map: None, model: str) 
     assert info["cache_creation_input_token_cost"] == pytest.approx(1.25 * info["input_cost_per_token"], rel=1e-4)
     assert info["cache_read_input_token_cost"] == pytest.approx(0.1 * info["input_cost_per_token"], rel=1e-4)
     assert info["supports_prompt_caching"] is True
+
+
+def test_every_priced_databricks_model_declares_cache_rates(local_model_cost_map: None) -> None:
+    undeclared: Final = [
+        model
+        for model, info in litellm.model_cost.items()
+        if model.startswith("databricks/")
+        and info.get("input_cost_per_token") is not None
+        and info.get("cache_read_input_token_cost") is None
+    ]
+
+    assert undeclared == []
+
+
+def test_models_without_a_cache_discount_bill_cache_tokens_at_the_input_rate(
+    local_model_cost_map: None,
+) -> None:
+    model: Final = "databricks/databricks-meta-llama-3-3-70b-instruct"
+    info: Final = _model_info(model)
+    usage: Final = Usage(
+        prompt_tokens=10000,
+        completion_tokens=100,
+        total_tokens=10100,
+        cache_read_input_tokens=8000,
+    )
+
+    prompt_cost, _ = cost_per_token(model=model, usage=usage)
+
+    assert prompt_cost == pytest.approx(10000 * info["input_cost_per_token"])
+
+
+@pytest.mark.parametrize("model", NEW_MODELS)
+def test_backup_price_map_matches_main(model: str) -> None:
+    main_cost: Final = json.loads(MAIN_PRICES.read_text())
+    backup_cost: Final = json.loads(BACKUP_PRICES.read_text())
+
+    assert backup_cost.get(model) == main_cost.get(model)
 
 
 def test_sonnet_5_ships_standard_rates_not_introductory(local_model_cost_map: None) -> None:

--- a/tests/test_litellm/llms/databricks/test_databricks_cost_calculator.py
+++ b/tests/test_litellm/llms/databricks/test_databricks_cost_calculator.py
@@ -63,9 +63,16 @@ PUBLISHED_DBU_PER_MILLION: Final = {
     "databricks/databricks-gemini-2-5-flash": ("5.357", "44.643", "5.357", "0.536"),
 }
 PROMOTIONAL_DISCOUNT: Final = 0.80
-PROMOTIONALLY_DISCOUNTED_MODELS: Final = (
+PROMOTION_EXPIRES: Final = "2027-01-31"
+ENTRIES_STORING_PROMOTIONAL_RATE: Final = (
     "databricks/databricks-gemini-2-5-pro",
     "databricks/databricks-gemini-2-5-flash",
+)
+ENTRIES_STORING_LIST_RATE_DESPITE_PROMOTION: Final = (
+    "databricks/databricks-gemini-3-1-pro",
+    "databricks/databricks-gemini-3-pro",
+    "databricks/databricks-gemini-3-flash",
+    "databricks/databricks-gemini-3-1-flash-lite",
 )
 CACHE_FIELDS: Final = ("cache_creation_input_token_cost", "cache_read_input_token_cost")
 
@@ -136,7 +143,7 @@ def test_new_models_price_at_published_dbu_rates(local_model_cost_map: None, mod
         assert info[field] == _dollars_per_token(dbu_per_million), field
 
 
-@pytest.mark.parametrize("model", sorted(set(PUBLISHED_DBU_PER_MILLION) - set(PROMOTIONALLY_DISCOUNTED_MODELS)))
+@pytest.mark.parametrize("model", sorted(set(PUBLISHED_DBU_PER_MILLION) - set(ENTRIES_STORING_PROMOTIONAL_RATE)))
 def test_cache_rates_derive_from_published_cache_dbu(local_model_cost_map: None, model: str) -> None:
     info: Final = _model_info(model)
     cache_dbu_per_million: Final = PUBLISHED_DBU_PER_MILLION[model][2:]
@@ -222,17 +229,36 @@ def test_sonnet_5_ships_standard_rates_not_introductory(local_model_cost_map: No
         assert sonnet_5[field] == pytest.approx(sonnet_4_6[field]), field
 
 
-@pytest.mark.parametrize("model", PROMOTIONALLY_DISCOUNTED_MODELS)
-def test_promotionally_discounted_entries_price_below_the_published_table(
+@pytest.mark.parametrize("model", ENTRIES_STORING_PROMOTIONAL_RATE)
+def test_entries_storing_the_promotional_rate_price_below_the_published_table(
     local_model_cost_map: None,
     model: str,
 ) -> None:
     info: Final = _model_info(model)
     input_dbu, output_dbu, _, _ = PUBLISHED_DBU_PER_MILLION[model]
+    expiry_hint: Final = f"the gemini promotion expires {PROMOTION_EXPIRES}, after which the list rate applies"
 
-    assert info["input_cost_per_token"] == pytest.approx(_dollars_per_token(input_dbu) * PROMOTIONAL_DISCOUNT, rel=1e-3)
+    assert info["input_cost_per_token"] == pytest.approx(
+        _dollars_per_token(input_dbu) * PROMOTIONAL_DISCOUNT, rel=2e-4
+    ), expiry_hint
     assert info["output_cost_per_token"] == pytest.approx(
-        _dollars_per_token(output_dbu) * PROMOTIONAL_DISCOUNT, rel=1e-3
-    )
+        _dollars_per_token(output_dbu) * PROMOTIONAL_DISCOUNT, rel=2e-4
+    ), expiry_hint
     assert info["cache_creation_input_token_cost"] == pytest.approx(info["input_cost_per_token"])
     assert info["cache_read_input_token_cost"] == pytest.approx(0.1 * info["input_cost_per_token"])
+
+
+@pytest.mark.parametrize("model", ENTRIES_STORING_LIST_RATE_DESPITE_PROMOTION)
+def test_entries_storing_the_list_rate_bill_above_the_promotional_price(
+    local_model_cost_map: None,
+    model: str,
+) -> None:
+    info: Final = _model_info(model)
+    input_dbu, _, _, _ = PUBLISHED_DBU_PER_MILLION[model]
+    list_rate: Final = _dollars_per_token(input_dbu)
+
+    assert info["input_cost_per_token"] == pytest.approx(list_rate, rel=2e-4), (
+        f"{model} moved off the list rate; if it now stores the discount that runs to "
+        f"{PROMOTION_EXPIRES}, move it into ENTRIES_STORING_PROMOTIONAL_RATE"
+    )
+    assert info["cache_creation_input_token_cost"] == pytest.approx(info["input_cost_per_token"])

--- a/tests/test_litellm/llms/databricks/test_databricks_cost_calculator.py
+++ b/tests/test_litellm/llms/databricks/test_databricks_cost_calculator.py
@@ -1,5 +1,5 @@
 import json
-from collections.abc import Iterator
+from decimal import Decimal
 from pathlib import Path
 from typing import Final
 
@@ -20,18 +20,28 @@ NEW_MODELS: Final = (
     "databricks/databricks-claude-fable-5",
 )
 
-
-@pytest.fixture
-def local_model_cost_map(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
-    monkeypatch.setenv("LITELLM_LOCAL_MODEL_COST_MAP", "True")
-    monkeypatch.setattr(litellm, "model_cost", litellm.get_model_cost_map(url=""))
-    litellm.get_model_info.cache_clear()
-    yield
-    litellm.get_model_info.cache_clear()
+DOLLARS_PER_DBU: Final = Decimal("0.070")
+PRICE_FIELDS: Final = (
+    "input_cost_per_token",
+    "output_cost_per_token",
+    "cache_creation_input_token_cost",
+    "cache_read_input_token_cost",
+)
+PUBLISHED_DBU_PER_MILLION: Final = {
+    "databricks/databricks-claude-opus-4-7": ("71.429", "357.143", "89.286", "7.143"),
+    "databricks/databricks-claude-opus-4-8": ("71.429", "357.143", "89.286", "7.143"),
+    "databricks/databricks-claude-opus-5": ("71.429", "357.143", "89.286", "7.143"),
+    "databricks/databricks-claude-sonnet-5": ("42.857", "214.286", "53.571", "4.286"),
+    "databricks/databricks-claude-fable-5": ("142.858", "714.286", "178.572", "14.286"),
+}
 
 
 def _model_info(model: str) -> ModelInfo:
     return litellm.get_model_info(model=model, custom_llm_provider="databricks")
+
+
+def _dollars_per_token(dbu_per_million: str) -> float:
+    return float(Decimal(dbu_per_million) * DOLLARS_PER_DBU / Decimal(10) ** 6)
 
 
 @pytest.mark.parametrize(
@@ -84,23 +94,22 @@ def test_legacy_endpoint_names_still_resolve(local_model_cost_map: None) -> None
     assert completion_cost == pytest.approx(100 * info["output_cost_per_token"])
 
 
-@pytest.mark.parametrize(
-    "model",
-    [
-        "databricks/databricks-claude-opus-4-7",
-        "databricks/databricks-claude-opus-4-8",
-        "databricks/databricks-claude-opus-5",
-        "databricks/databricks-claude-sonnet-5",
-        "databricks/databricks-claude-fable-5",
-    ],
-)
+@pytest.mark.parametrize("model", NEW_MODELS)
+def test_new_models_price_at_published_dbu_rates(local_model_cost_map: None, model: str) -> None:
+    info: Final = _model_info(model)
+
+    for field, dbu_per_million in zip(PRICE_FIELDS, PUBLISHED_DBU_PER_MILLION[model]):
+        assert info[field] == _dollars_per_token(dbu_per_million), field
+
+
+@pytest.mark.parametrize("model", NEW_MODELS)
 def test_new_models_carry_cache_pricing(local_model_cost_map: None, model: str) -> None:
     info: Final = _model_info(model)
 
     assert info["input_cost_per_token"] > 0
     assert info["output_cost_per_token"] > 0
-    assert info["cache_creation_input_token_cost"] == pytest.approx(1.25 * info["input_cost_per_token"], rel=1e-4)
-    assert info["cache_read_input_token_cost"] == pytest.approx(0.1 * info["input_cost_per_token"], rel=1e-4)
+    assert info["cache_creation_input_token_cost"] > info["input_cost_per_token"]
+    assert info["cache_read_input_token_cost"] < info["input_cost_per_token"]
     assert info["supports_prompt_caching"] is True
 
 
@@ -130,7 +139,10 @@ def test_models_without_a_cache_discount_bill_cache_tokens_at_the_input_rate(
 
     prompt_cost, _ = cost_per_token(model=model, usage=usage)
 
+    assert info["cache_read_input_token_cost"] == info["input_cost_per_token"]
+    assert info["cache_creation_input_token_cost"] == info["input_cost_per_token"]
     assert prompt_cost == pytest.approx(10000 * info["input_cost_per_token"])
+    assert prompt_cost > 8000 * info["input_cost_per_token"]
 
 
 @pytest.mark.parametrize("model", NEW_MODELS)
@@ -138,14 +150,31 @@ def test_backup_price_map_matches_main(model: str) -> None:
     main_cost: Final = json.loads(MAIN_PRICES.read_text())
     backup_cost: Final = json.loads(BACKUP_PRICES.read_text())
 
-    assert backup_cost.get(model) == main_cost.get(model)
+    assert model in main_cost
+    assert model in backup_cost
+    assert backup_cost[model] == main_cost[model]
 
 
 def test_sonnet_5_ships_standard_rates_not_introductory(local_model_cost_map: None) -> None:
     sonnet_5: Final = _model_info("databricks/databricks-claude-sonnet-5")
     sonnet_4_6: Final = _model_info("databricks/databricks-claude-sonnet-4-6")
 
-    assert sonnet_5["input_cost_per_token"] == pytest.approx(sonnet_4_6["input_cost_per_token"])
-    assert sonnet_5["output_cost_per_token"] == pytest.approx(sonnet_4_6["output_cost_per_token"])
-    assert sonnet_5["cache_creation_input_token_cost"] == pytest.approx(sonnet_4_6["cache_creation_input_token_cost"])
-    assert sonnet_5["cache_read_input_token_cost"] == pytest.approx(sonnet_4_6["cache_read_input_token_cost"])
+    for field in PRICE_FIELDS:
+        assert sonnet_5[field] == pytest.approx(sonnet_4_6[field]), field
+
+
+@pytest.mark.parametrize(
+    "model",
+    [
+        "databricks/databricks-gemini-2-5-pro",
+        "databricks/databricks-gemini-2-5-flash",
+    ],
+)
+def test_entries_priced_at_an_older_vintage_keep_cache_rates_tied_to_their_own_input(
+    local_model_cost_map: None,
+    model: str,
+) -> None:
+    info: Final = _model_info(model)
+
+    assert info["cache_creation_input_token_cost"] == pytest.approx(info["input_cost_per_token"])
+    assert info["cache_read_input_token_cost"] == pytest.approx(0.1 * info["input_cost_per_token"])

--- a/tests/test_litellm/llms/databricks/test_databricks_cost_calculator.py
+++ b/tests/test_litellm/llms/databricks/test_databricks_cost_calculator.py
@@ -62,7 +62,8 @@ PUBLISHED_DBU_PER_MILLION: Final = {
     "databricks/databricks-gemini-2-5-pro": ("22.321", "178.571", "22.321", "2.232"),
     "databricks/databricks-gemini-2-5-flash": ("5.357", "44.643", "5.357", "0.536"),
 }
-OLDER_VINTAGE_MODELS: Final = (
+PROMOTIONAL_DISCOUNT: Final = 0.80
+PROMOTIONALLY_DISCOUNTED_MODELS: Final = (
     "databricks/databricks-gemini-2-5-pro",
     "databricks/databricks-gemini-2-5-flash",
 )
@@ -135,7 +136,7 @@ def test_new_models_price_at_published_dbu_rates(local_model_cost_map: None, mod
         assert info[field] == _dollars_per_token(dbu_per_million), field
 
 
-@pytest.mark.parametrize("model", sorted(set(PUBLISHED_DBU_PER_MILLION) - set(OLDER_VINTAGE_MODELS)))
+@pytest.mark.parametrize("model", sorted(set(PUBLISHED_DBU_PER_MILLION) - set(PROMOTIONALLY_DISCOUNTED_MODELS)))
 def test_cache_rates_derive_from_published_cache_dbu(local_model_cost_map: None, model: str) -> None:
     info: Final = _model_info(model)
     cache_dbu_per_million: Final = PUBLISHED_DBU_PER_MILLION[model][2:]
@@ -221,12 +222,17 @@ def test_sonnet_5_ships_standard_rates_not_introductory(local_model_cost_map: No
         assert sonnet_5[field] == pytest.approx(sonnet_4_6[field]), field
 
 
-@pytest.mark.parametrize("model", OLDER_VINTAGE_MODELS)
-def test_entries_priced_at_an_older_vintage_keep_cache_rates_tied_to_their_own_input(
+@pytest.mark.parametrize("model", PROMOTIONALLY_DISCOUNTED_MODELS)
+def test_promotionally_discounted_entries_price_below_the_published_table(
     local_model_cost_map: None,
     model: str,
 ) -> None:
     info: Final = _model_info(model)
+    input_dbu, output_dbu, _, _ = PUBLISHED_DBU_PER_MILLION[model]
 
+    assert info["input_cost_per_token"] == pytest.approx(_dollars_per_token(input_dbu) * PROMOTIONAL_DISCOUNT, rel=1e-3)
+    assert info["output_cost_per_token"] == pytest.approx(
+        _dollars_per_token(output_dbu) * PROMOTIONAL_DISCOUNT, rel=1e-3
+    )
     assert info["cache_creation_input_token_cost"] == pytest.approx(info["input_cost_per_token"])
     assert info["cache_read_input_token_cost"] == pytest.approx(0.1 * info["input_cost_per_token"])

--- a/tests/test_litellm/llms/databricks/test_databricks_cost_calculator.py
+++ b/tests/test_litellm/llms/databricks/test_databricks_cost_calculator.py
@@ -28,12 +28,45 @@ PRICE_FIELDS: Final = (
     "cache_read_input_token_cost",
 )
 PUBLISHED_DBU_PER_MILLION: Final = {
-    "databricks/databricks-claude-opus-4-7": ("71.429", "357.143", "89.286", "7.143"),
-    "databricks/databricks-claude-opus-4-8": ("71.429", "357.143", "89.286", "7.143"),
-    "databricks/databricks-claude-opus-5": ("71.429", "357.143", "89.286", "7.143"),
-    "databricks/databricks-claude-sonnet-5": ("42.857", "214.286", "53.571", "4.286"),
     "databricks/databricks-claude-fable-5": ("142.858", "714.286", "178.572", "14.286"),
+    "databricks/databricks-claude-opus-5": ("71.429", "357.143", "89.286", "7.143"),
+    "databricks/databricks-claude-opus-4-8": ("71.429", "357.143", "89.286", "7.143"),
+    "databricks/databricks-claude-opus-4-7": ("71.429", "357.143", "89.286", "7.143"),
+    "databricks/databricks-claude-opus-4-6": ("71.429", "357.143", "89.286", "7.143"),
+    "databricks/databricks-claude-opus-4-5": ("71.429", "357.143", "89.286", "7.143"),
+    "databricks/databricks-claude-opus-4-1": ("214.286", "1071.429", "267.857", "21.429"),
+    "databricks/databricks-claude-opus-4": ("214.286", "1071.429", "267.857", "21.429"),
+    "databricks/databricks-claude-sonnet-5": ("42.857", "214.286", "53.571", "4.286"),
+    "databricks/databricks-claude-sonnet-4-6": ("42.857", "214.286", "53.571", "4.286"),
+    "databricks/databricks-claude-sonnet-4-5": ("42.857", "214.286", "53.571", "4.286"),
+    "databricks/databricks-claude-sonnet-4-1": ("42.857", "214.286", "53.571", "4.286"),
+    "databricks/databricks-claude-sonnet-4": ("42.857", "214.286", "53.571", "4.286"),
+    "databricks/databricks-claude-3-7-sonnet": ("42.857", "214.286", "53.571", "4.286"),
+    "databricks/databricks-claude-haiku-4-5": ("14.286", "71.429", "17.857", "1.429"),
+    "databricks/databricks-gpt-5": ("17.857", "142.857", "17.857", "1.786"),
+    "databricks/databricks-gpt-5-1": ("17.857", "142.857", "17.857", "1.786"),
+    "databricks/databricks-gpt-5-1-codex-max": ("17.857", "142.857", "17.857", "1.786"),
+    "databricks/databricks-gpt-5-1-codex-mini": ("3.571", "28.571", "3.571", "0.357"),
+    "databricks/databricks-gpt-5-mini": ("3.571", "28.571", "3.571", "0.357"),
+    "databricks/databricks-gpt-5-nano": ("0.714", "5.714", "0.714", "0.071"),
+    "databricks/databricks-gpt-5-2": ("25.000", "200.000", "25.000", "2.500"),
+    "databricks/databricks-gpt-5-2-codex": ("25.000", "200.000", "25.000", "2.500"),
+    "databricks/databricks-gpt-5-3-codex": ("25.000", "200.000", "25.000", "2.500"),
+    "databricks/databricks-gpt-5-4": ("35.714", "214.286", "35.714", "3.571"),
+    "databricks/databricks-gpt-5-4-mini": ("10.714", "64.286", "10.714", "1.071"),
+    "databricks/databricks-gpt-5-4-nano": ("2.857", "17.857", "2.857", "0.286"),
+    "databricks/databricks-gemini-3-1-pro": ("35.714", "214.286", "35.714", "3.571"),
+    "databricks/databricks-gemini-3-pro": ("35.714", "214.286", "35.714", "3.571"),
+    "databricks/databricks-gemini-3-flash": ("8.929", "53.571", "8.929", "0.893"),
+    "databricks/databricks-gemini-3-1-flash-lite": ("4.464", "26.786", "4.464", "0.446"),
+    "databricks/databricks-gemini-2-5-pro": ("22.321", "178.571", "22.321", "2.232"),
+    "databricks/databricks-gemini-2-5-flash": ("5.357", "44.643", "5.357", "0.536"),
 }
+OLDER_VINTAGE_MODELS: Final = (
+    "databricks/databricks-gemini-2-5-pro",
+    "databricks/databricks-gemini-2-5-flash",
+)
+CACHE_FIELDS: Final = ("cache_creation_input_token_cost", "cache_read_input_token_cost")
 
 
 def _model_info(model: str) -> ModelInfo:
@@ -102,6 +135,15 @@ def test_new_models_price_at_published_dbu_rates(local_model_cost_map: None, mod
         assert info[field] == _dollars_per_token(dbu_per_million), field
 
 
+@pytest.mark.parametrize("model", sorted(set(PUBLISHED_DBU_PER_MILLION) - set(OLDER_VINTAGE_MODELS)))
+def test_cache_rates_derive_from_published_cache_dbu(local_model_cost_map: None, model: str) -> None:
+    info: Final = _model_info(model)
+    cache_dbu_per_million: Final = PUBLISHED_DBU_PER_MILLION[model][2:]
+
+    for field, dbu_per_million in zip(CACHE_FIELDS, cache_dbu_per_million):
+        assert info[field] == _dollars_per_token(dbu_per_million), field
+
+
 @pytest.mark.parametrize("model", NEW_MODELS)
 def test_new_models_carry_cache_pricing(local_model_cost_map: None, model: str) -> None:
     info: Final = _model_info(model)
@@ -119,7 +161,7 @@ def test_every_priced_databricks_model_declares_cache_rates(local_model_cost_map
         for model, info in litellm.model_cost.items()
         if model.startswith("databricks/")
         and info.get("input_cost_per_token") is not None
-        and info.get("cache_read_input_token_cost") is None
+        and any(info.get(field) is None for field in CACHE_FIELDS)
     ]
 
     assert undeclared == []
@@ -139,10 +181,26 @@ def test_models_without_a_cache_discount_bill_cache_tokens_at_the_input_rate(
 
     prompt_cost, _ = cost_per_token(model=model, usage=usage)
 
-    assert info["cache_read_input_token_cost"] == info["input_cost_per_token"]
-    assert info["cache_creation_input_token_cost"] == info["input_cost_per_token"]
     assert prompt_cost == pytest.approx(10000 * info["input_cost_per_token"])
     assert prompt_cost > 8000 * info["input_cost_per_token"]
+
+
+def test_every_model_without_published_cache_dbu_bills_cache_at_its_own_input_rate(
+    local_model_cost_map: None,
+) -> None:
+    without_published_rates: Final = [
+        model
+        for model, info in litellm.model_cost.items()
+        if model.startswith("databricks/")
+        and info.get("input_cost_per_token")
+        and model not in PUBLISHED_DBU_PER_MILLION
+    ]
+
+    assert len(without_published_rates) == 14
+    for model in without_published_rates:
+        info = _model_info(model)
+        for field in CACHE_FIELDS:
+            assert info[field] == pytest.approx(info["input_cost_per_token"]), (model, field)
 
 
 @pytest.mark.parametrize("model", NEW_MODELS)
@@ -163,13 +221,7 @@ def test_sonnet_5_ships_standard_rates_not_introductory(local_model_cost_map: No
         assert sonnet_5[field] == pytest.approx(sonnet_4_6[field]), field
 
 
-@pytest.mark.parametrize(
-    "model",
-    [
-        "databricks/databricks-gemini-2-5-pro",
-        "databricks/databricks-gemini-2-5-flash",
-    ],
-)
+@pytest.mark.parametrize("model", OLDER_VINTAGE_MODELS)
 def test_entries_priced_at_an_older_vintage_keep_cache_rates_tied_to_their_own_input(
     local_model_cost_map: None,
     model: str,

--- a/tests/test_litellm/llms/databricks/test_databricks_cost_calculator.py
+++ b/tests/test_litellm/llms/databricks/test_databricks_cost_calculator.py
@@ -1,0 +1,90 @@
+from typing import Final
+
+import pytest
+
+import litellm
+from litellm.llms.databricks.cost_calculator import cost_per_token
+from litellm.types.utils import Usage
+
+
+@pytest.fixture
+def local_model_cost_map(monkeypatch):
+    monkeypatch.setenv("LITELLM_LOCAL_MODEL_COST_MAP", "True")
+    monkeypatch.setattr(litellm, "model_cost", litellm.get_model_cost_map(url=""))
+    litellm.get_model_info.cache_clear()
+    yield
+    litellm.get_model_info.cache_clear()
+
+
+def _model_info(model: str) -> dict:
+    return litellm.get_model_info(model=model, custom_llm_provider="databricks")
+
+
+@pytest.mark.parametrize(
+    "model",
+    [
+        "databricks/databricks-claude-opus-4-8",
+        "databricks/databricks-claude-opus-5",
+        "databricks/databricks-claude-sonnet-5",
+    ],
+)
+def test_cached_tokens_bill_at_cache_rates(local_model_cost_map, model):
+    info: Final = _model_info(model)
+    usage: Final = Usage(
+        prompt_tokens=11000,
+        completion_tokens=500,
+        total_tokens=11500,
+        cache_creation_input_tokens=2000,
+        cache_read_input_tokens=8000,
+    )
+
+    prompt_cost, completion_cost = cost_per_token(model=model, usage=usage)
+
+    assert prompt_cost == pytest.approx(
+        1000 * info["input_cost_per_token"]
+        + 2000 * info["cache_creation_input_token_cost"]
+        + 8000 * info["cache_read_input_token_cost"]
+    )
+    assert completion_cost == pytest.approx(500 * info["output_cost_per_token"])
+    assert prompt_cost < 11000 * info["input_cost_per_token"]
+
+
+def test_uncached_request_bills_every_prompt_token_at_the_input_rate(local_model_cost_map):
+    model: Final = "databricks/databricks-claude-sonnet-5"
+    info: Final = _model_info(model)
+    usage: Final = Usage(prompt_tokens=1000, completion_tokens=200, total_tokens=1200)
+
+    prompt_cost, completion_cost = cost_per_token(model=model, usage=usage)
+
+    assert prompt_cost == pytest.approx(1000 * info["input_cost_per_token"])
+    assert completion_cost == pytest.approx(200 * info["output_cost_per_token"])
+
+
+def test_legacy_endpoint_names_still_resolve(local_model_cost_map):
+    info: Final = _model_info("databricks/databricks-mixtral-8x7b-instruct")
+    usage: Final = Usage(prompt_tokens=100, completion_tokens=100, total_tokens=200)
+
+    prompt_cost, completion_cost = cost_per_token(model="databricks/mixtral-8x7b-instruct-v0.1", usage=usage)
+
+    assert prompt_cost == pytest.approx(100 * info["input_cost_per_token"])
+    assert completion_cost == pytest.approx(100 * info["output_cost_per_token"])
+
+
+@pytest.mark.parametrize(
+    "model",
+    [
+        "databricks/databricks-claude-opus-4-7",
+        "databricks/databricks-claude-opus-4-8",
+        "databricks/databricks-claude-opus-5",
+        "databricks/databricks-claude-sonnet-5",
+        "databricks/databricks-claude-fable-5",
+    ],
+)
+def test_new_models_carry_cache_pricing(local_model_cost_map, model):
+    info: Final = _model_info(model)
+
+    assert info["input_cost_per_token"] > 0
+    assert info["output_cost_per_token"] > 0
+    assert info["cache_creation_input_token_cost"] == pytest.approx(1.25 * info["input_cost_per_token"], rel=1e-4)
+    assert info["cache_read_input_token_cost"] == pytest.approx(0.1 * info["input_cost_per_token"], rel=1e-4)
+    assert info["supports_prompt_caching"] is True

--- a/tests/test_litellm/llms/databricks/test_databricks_cost_calculator.py
+++ b/tests/test_litellm/llms/databricks/test_databricks_cost_calculator.py
@@ -1,14 +1,15 @@
+from collections.abc import Iterator
 from typing import Final
 
 import pytest
 
 import litellm
 from litellm.llms.databricks.cost_calculator import cost_per_token
-from litellm.types.utils import Usage
+from litellm.types.utils import ModelInfo, Usage
 
 
 @pytest.fixture
-def local_model_cost_map(monkeypatch):
+def local_model_cost_map(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
     monkeypatch.setenv("LITELLM_LOCAL_MODEL_COST_MAP", "True")
     monkeypatch.setattr(litellm, "model_cost", litellm.get_model_cost_map(url=""))
     litellm.get_model_info.cache_clear()
@@ -16,7 +17,7 @@ def local_model_cost_map(monkeypatch):
     litellm.get_model_info.cache_clear()
 
 
-def _model_info(model: str) -> dict:
+def _model_info(model: str) -> ModelInfo:
     return litellm.get_model_info(model=model, custom_llm_provider="databricks")
 
 
@@ -28,7 +29,7 @@ def _model_info(model: str) -> dict:
         "databricks/databricks-claude-sonnet-5",
     ],
 )
-def test_cached_tokens_bill_at_cache_rates(local_model_cost_map, model):
+def test_cached_tokens_bill_at_cache_rates(local_model_cost_map: None, model: str) -> None:
     info: Final = _model_info(model)
     usage: Final = Usage(
         prompt_tokens=11000,
@@ -49,7 +50,7 @@ def test_cached_tokens_bill_at_cache_rates(local_model_cost_map, model):
     assert prompt_cost < 11000 * info["input_cost_per_token"]
 
 
-def test_uncached_request_bills_every_prompt_token_at_the_input_rate(local_model_cost_map):
+def test_uncached_request_bills_every_prompt_token_at_the_input_rate(local_model_cost_map: None) -> None:
     model: Final = "databricks/databricks-claude-sonnet-5"
     info: Final = _model_info(model)
     usage: Final = Usage(prompt_tokens=1000, completion_tokens=200, total_tokens=1200)
@@ -60,7 +61,7 @@ def test_uncached_request_bills_every_prompt_token_at_the_input_rate(local_model
     assert completion_cost == pytest.approx(200 * info["output_cost_per_token"])
 
 
-def test_legacy_endpoint_names_still_resolve(local_model_cost_map):
+def test_legacy_endpoint_names_still_resolve(local_model_cost_map: None) -> None:
     info: Final = _model_info("databricks/databricks-mixtral-8x7b-instruct")
     usage: Final = Usage(prompt_tokens=100, completion_tokens=100, total_tokens=200)
 
@@ -80,7 +81,7 @@ def test_legacy_endpoint_names_still_resolve(local_model_cost_map):
         "databricks/databricks-claude-fable-5",
     ],
 )
-def test_new_models_carry_cache_pricing(local_model_cost_map, model):
+def test_new_models_carry_cache_pricing(local_model_cost_map: None, model: str) -> None:
     info: Final = _model_info(model)
 
     assert info["input_cost_per_token"] > 0
@@ -88,3 +89,13 @@ def test_new_models_carry_cache_pricing(local_model_cost_map, model):
     assert info["cache_creation_input_token_cost"] == pytest.approx(1.25 * info["input_cost_per_token"], rel=1e-4)
     assert info["cache_read_input_token_cost"] == pytest.approx(0.1 * info["input_cost_per_token"], rel=1e-4)
     assert info["supports_prompt_caching"] is True
+
+
+def test_sonnet_5_ships_standard_rates_not_introductory(local_model_cost_map: None) -> None:
+    sonnet_5: Final = _model_info("databricks/databricks-claude-sonnet-5")
+    sonnet_4_6: Final = _model_info("databricks/databricks-claude-sonnet-4-6")
+
+    assert sonnet_5["input_cost_per_token"] == pytest.approx(sonnet_4_6["input_cost_per_token"])
+    assert sonnet_5["output_cost_per_token"] == pytest.approx(sonnet_4_6["output_cost_per_token"])
+    assert sonnet_5["cache_creation_input_token_cost"] == pytest.approx(sonnet_4_6["cache_creation_input_token_cost"])
+    assert sonnet_5["cache_read_input_token_cost"] == pytest.approx(sonnet_4_6["cache_read_input_token_cost"])


### PR DESCRIPTION
## TLDR

Problem this solves:

- Databricks billed cache reads at the full input rate
- Databricks registry entries carried no cache read or write rates
- Claude Opus 4.7, 4.8, 5, Sonnet 5 and Fable 5 were unpriced

How it solves it:

- Databricks cost calculation now runs through the cache-aware calculator
- Adds cache read and write rates to 42 existing entries
- Adds the five missing Claude entries at published DBU rates

## User Flow

Before: a developer tracking Databricks Claude spend pays full input price for every cached token, and sees no spend at all on the newest models

1. They configure `databricks/databricks-claude-sonnet-4-5` and send POST https://litellm-domain/v1/chat/completions with a prompt long enough to be cached
2. The response comes back 200, reporting 1,500 prompt tokens of which 800 are cache reads and 500 are cache writes, plus 100 completion tokens
3. They send that usage to POST https://litellm-domain/spend/calculate and get back `{"cost": 0.005999987}`, the same amount an entirely uncached request of that size costs
4. They switch to `databricks/databricks-claude-opus-5` and repeat, and https://litellm-domain/spend/calculate returns `{"cost": 0.0}`, so the request lands on https://litellm-domain/ui/?page=logs at $0 spend

After: cache reads and cache writes bill at their own rates, and the newest models report real spend

1. They configure `databricks/databricks-claude-sonnet-4-5` and send POST https://litellm-domain/v1/chat/completions with a prompt long enough to be cached
2. The response comes back 200, reporting 1,500 prompt tokens of which 800 are cache reads and 500 are cache writes, plus 100 completion tokens
3. They send that usage to POST https://litellm-domain/spend/calculate and get back `{"cost": 0.004215001}`, with cache reads and cache writes each billed at their own published rate
4. They switch to `databricks/databricks-claude-opus-5` and repeat, and https://litellm-domain/spend/calculate returns `{"cost": 0.007025025}`, which is what https://litellm-domain/ui/?page=logs now shows for the request

## Relevant issues

## Linear ticket

Resolves LIT-5977

## Pricing sources

Rates come from the published Databricks DBU table for proprietary foundation model serving, converted at the documented $0.070 per DBU that the existing entries already use.

| Model | Input DBU/1M | Output DBU/1M | Cache write DBU/1M | Cache read DBU/1M |
|---|---|---|---|---|
| Opus 4.7 | 71.429 | 357.143 | 89.286 | 7.143 |
| Opus 4.8 | 71.429 | 357.143 | 89.286 | 7.143 |
| Opus 5 | 71.429 | 357.143 | 89.286 | 7.143 |
| Sonnet 5 | 42.857 | 214.286 | 53.571 | 4.286 |
| Fable 5 | 142.858 | 714.286 | 178.572 | 14.286 |

Each dollar figure is that DBU rate multiplied by $0.070, written to the significant digits the multiplication yields. Databricks publishes rates like 71.429 DBU per million tokens rather than round numbers, so the dollar rates come out non-round as well: Opus 5 input is 71.429 x $0.070 = $5.00003 per million tokens, not an even $5.00. A literal such as `3.0002e-07` is therefore the intended cache read rate for Sonnet 5, taken from its published 4.286 cache read DBU, and not a rounding artifact. The values are stored at exactly that precision, so none of them carry the trailing digits a raw float product would leave behind

Cache rates are derived exactly the way input and output are, from the published cache write and cache read DBU for that model, never as a ratio of the input rate. That distinction is worth stating because Databricks does not publish cache rates as clean multiples: Opus 5 lists 7.143 cache read DBU against 71.429 input DBU, giving $0.50001 per million tokens where a flat tenth of input would have given $0.500003. Of the 47 Databricks entries, 33 carry cache rates and the remaining 14 publish none at all and are covered two paragraphs below. Of those 33, 29 take their cache DBU straight from the published table, while `databricks-claude-3-7-sonnet` and `databricks-claude-sonnet-4-1` are absent from it and instead inherit the Sonnet 4 family's rates, which they already match on an implied 42.857 input DBU

Two of those 33 deliberately sit below the published table. `databricks-gemini-2-5-pro` and `databricks-gemini-2-5-flash` carry a 20% promotional discount that the published DBU figures exclude and that runs through 2027-01-31, which is exactly why their stored rates land a factor of 1.25 under the table. They are correct as they stand rather than stale, so this PR does not touch them. Their cache rates follow their own discounted input rate instead of the undiscounted published cache DBU, keeping each entry on a single price list. A test pins both the discount and the cache relationship, so whoever drops the 1.25x when the promotion ends has to move the cache rates with it

That promotion is marked on every Gemini row, not just the 2.5 pair, and six covered models have registry entries. The other four, `databricks-gemini-3-pro`, `databricks-gemini-3-1-pro`, `databricks-gemini-3-flash` and `databricks-gemini-3-1-flash-lite`, store the full list rate and therefore bill about 25% above what Databricks actually charges. Those input and output literals predate this branch and it does not change them. The cache rates it adds for the four are derived from each entry's own stored input rate, which is what Databricks bills a Gemini cache write at, so every field on those entries stays on one price list and a later correction can move all of them together. The tests name the two groups separately for what they store rather than implying the four are exempt from the promotion, and the overcharge is tracked on its own ticket

The change is not uniformly a refund, and it is worth being explicit about the direction. Cache reads fall a long way, 9.7x on the request in the proof below, because they used to bill at the full input rate. Cache writes move the opposite way: they also used to fall back to the input rate, and they now bill the published write premium, 1.25x input on every Claude model here. A workload that writes the cache more often than it reads will see its reported spend go up, and the proof below shows both directions on the same pair of requests.

Sonnet 5 is listed at its standard rates rather than the introductory launch rates (28.571 input and 142.857 output DBU), which run only through 2026-08-31. Pricing entries carry no expiry date, so the choice is which direction to be wrong in. Standard rates overcharge Sonnet 5 by 50% for the nine days left in the introductory window, then become correct on their own. Introductory rates would read correctly for nine days and then undercharge by a third indefinitely, letting real spend outrun an enforced budget with no signal. The introductory numbers are kept in the entry's `metadata.notes`.

Opus 4.7 and Opus 4.8 are both priced from their own published rate of 71.429 input DBU, matching Opus 4.5 and 4.6. Neither had an entry before, so both fell back to the original Opus 4 at 214.286 DBU and billed $15 per million input tokens where Databricks charges $5. Correcting that drops their billed rate threefold, to $5 in and $25 out per million. It is a correction rather than a discount, but it is a visible decrease for anyone already calling either model. Opus 5, Sonnet 5 and Fable 5 had no fallback to land on at all and billed $0, so for those three the change is a rise from nothing to a real rate

The 14 Databricks models that publish no cache pricing at all, the Llama, Mixtral, Gemma, GPT OSS, MPT and embedding entries, get cache rates equal to their input rate. Routing them through the shared calculator otherwise bills a cached token at zero, because that calculator treats a missing cache rate as free, and a model with no caching discount should charge the ordinary input price instead. On a 10,000 token prompt with 8,000 cache reads this is the difference between $0.0050001 and $0.0010000, a fivefold undercharge, and a test now pins every priced Databricks entry to declaring cache rates so no future entry can regress into it.

Registry changes are additive and confined to `databricks/` keys: no entry is removed and no existing rate is changed. Alongside the cache rates, 28 of the 42 existing entries newly declare `supports_prompt_caching`, which they had left off despite the provider supporting it. An old-formula versus new-formula comparison over an uncached usage block came back identical for all 47 Databricks models, and all seven legacy endpoint aliases kept their existing behaviour.

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Shared setup, identical on both legs: two separate proxy processes each booted `litellm --config <cfg> --num_workers 2` on two random free high ports, sharing one Postgres database and one Redis, matching the multi-pod shape customers run. Every request is sent through one instance and its spend is read back through the other. `LITELLM_LOCAL_MODEL_COST_MAP=True` so pricing comes from the checked-out registry. Clients are the OpenAI Python SDK for `/v1/chat/completions` and `/v1/responses` and the Anthropic Python SDK for `/v1/messages`. Cached cases send a large system block carrying `cache_control: {"type": "ephemeral"}` twice, so the second call is a real cache read against Databricks. Model deployments are `databricks/databricks-claude-sonnet-4-5` and `databricks/databricks-claude-opus-5` on a live Databricks workspace.

### Before (a44bb47563cdb6560aacb296a5de250271ec5bda)

#### Cached request on /v1/chat/completions

1. Send the priming call, then the identical call through the other instance with the OpenAI SDK. The second response reports `prompt_tokens 9895`, `cache_read_input_tokens 9882`, `completion_tokens 4`, so only 13 prompt tokens were fresh
2. Read the spend back through the first instance:

```
$ curl -s -H "Authorization: Bearer $KEY" "http://127.0.0.1:18317/spend/logs?request_id=msg_bdrk_013s2cRNWXJKioF38CXe3bd1"
"spend": 0.02974490113, "prompt_tokens": 9895, "completion_tokens": 4, "call_type": "acompletion"
metadata.cost_breakdown = {"input_cost": 0.029684901050000004, "output_cost": 6.000008000000001e-05, "total_cost": 0.029744901130000004}
```

3. That is `9895 * 3.00/1M + 4 * 15.00/1M`, so all 9882 cache-read tokens were billed at the full input rate. At the published cache-read rate the same request costs `0.00306379759`, so the bill is 9.7x too high

#### Unpriced new model on /v1/chat/completions

1. Send a short completion to `databricks/databricks-claude-opus-5`. It returns 200 with content `ok` and usage `prompt_tokens 16`, `completion_tokens 4`, so Databricks really served and really billed it
2. Read the spend back through the other instance:

```
$ curl -s -H "Authorization: Bearer $KEY" "http://127.0.0.1:18317/spend/logs?request_id=msg_bdrk_qas2gynkl4sykjumrcvmh2zoxwov2uricuzt4vlnqv4j7u6t3gfq"
"model": "databricks/databricks-claude-opus-5", "spend": 0.0, "prompt_tokens": 16, "completion_tokens": 4
metadata.cost_breakdown = {"input_cost": 0, "output_cost": 0, "total_cost": 0.0}
```

3. Spend is exactly `0.0` on a real billable request

#### Cached request on /v1/messages

1. Run the same two-call cache flow with the Anthropic SDK. The second response reports `input_tokens 13`, `cache_read_input_tokens 9882`, `output_tokens 4`
2. Read the spend back through the other instance:

```
$ curl -s -H "Authorization: Bearer $KEY" "http://127.0.0.1:19483/spend/logs?request_id=msg_bdrk_01SCsmwARE1jzRz6zykE7pPg"
"spend": 0.02974490113, "prompt_tokens": 9895, "completion_tokens": 4, "call_type": "anthropic_messages"
```

3. Identical to the chat-completions case, so the route makes no difference

#### Cached request on /v1/responses

1. Run the same two-call cache flow with the OpenAI SDK responses API. The second response reports `input_tokens 9895`, `input_tokens_details.cached_tokens 9882`, `output_tokens 4`
2. Read the spend back through the other instance:

```
$ curl -s -H "Authorization: Bearer $KEY" "http://127.0.0.1:19483/spend/logs?request_id=msg_bdrk_016oxJmfGqvkyP7T2BZ28X2t"
"spend": 0.02974490113, "prompt_tokens": 9895, "completion_tokens": 4, "call_type": "aresponses"
```

3. All three cached routes land on the same `0.02974490113`, because the cost calculation never looks at the cache-read split

### After (0a869b72268685b27d5a0be4742221dc8f24d6db)

Commits since this hash (112224a7fe, 9f1191e7a0, 77cae927d5, 15e8a35feb) net to test-only changes: the head's tree differs from it solely in tests/test_litellm/llms/databricks/test_databricks_cost_calculator.py, so proxy behavior at the tip is identical to this proven run

Two proxy instances, each started with `--num_workers 2`, sharing one Postgres and one Redis. Every case is sent through one instance and the spend read back through the other, so the numbers below survive a process boundary. Instance A is `127.0.0.1:39346`, instance B is `127.0.0.1:51566`.

#### Cached request on /v1/chat/completions

1. Send a priming call carrying a ~10k-token `cache_control: {"type": "ephemeral"}` system block through A, then send the identical call again. The second response reports `prompt_tokens 10184`, `cache_read_input_tokens 10170`, `completion_tokens 4`
2. Read the spend back through B:

```
$ curl -s -X GET "http://127.0.0.1:51566/spend/logs?request_id=msg_bdrk_017bQ6PSke7u8NQrc8DUZBgj" -H "Authorization: Bearer $KEY"
"spend": 0.00315320334, "cache_read_input_tokens": 10170,
"cost_breakdown": {"cache_read_cost": 0.0030512034000000003, "total_cost": 0.00315320334}
```

3. That is `14 * 2.99999/1M + 10170 * 0.30002/1M + 4 * 15.00002/1M`, exact to the last digit, against `0.03061189824` under the old full-rate arithmetic, so 9.71x cheaper. The 14 text tokens are `prompt_tokens` minus the cache tokens, because Databricks reports `prompt_tokens` inclusive of them
4. The paired cache write `msg_bdrk_01VhKmwPEhWYxD5SFKhyWvqN` billed `0.038239194840000004`, exactly `14 * 2.99999/1M + 10170 * 3.74997/1M + 4 * 15.00002/1M`, so the write rate is live too

#### Unpriced new model on /v1/chat/completions

1. Send a short completion to `databricks/databricks-claude-opus-5` through B. It returns 200 with usage `prompt_tokens 22`, `completion_tokens 7`
2. Read the spend back through A:

```
$ curl -s -X GET "http://127.0.0.1:39346/spend/logs?request_id=msg_bdrk_pvlfwlgc7ukqwutwf5r5ijxy6bveqbptkgmwxr5d2jfcroftxqta" -H "Authorization: Bearer $KEY"
"spend": 0.00028500073,
"cost_breakdown": {"input_cost": 0.00011000066, "output_cost": 0.00017500007}
```

3. That is `22 * 5.00003/1M + 7 * 25.00001/1M`, non-zero where the same call previously billed nothing, and $5.00003/1M is exactly the published 71.429 input DBU at $0.070 per DBU

#### Cached request on /v1/messages

1. Run the same two-call cache flow with the Anthropic SDK through A. The response reports `input_tokens 14`, `cache_read_input_tokens 10170`, `output_tokens 4`
2. Read the spend back through B:

```
$ curl -s -X GET "http://127.0.0.1:51566/spend/logs?request_id=msg_bdrk_01My8JVDdoCuYuG5tcppUZES" -H "Authorization: Bearer $KEY"
"spend": 0.00315320334, "call_type": "anthropic_messages",
"cost_breakdown": {"cache_read_cost": 0.0030512034000000003}
```

3. Identical to the chat-completions case, down to the cache-read component

#### Cached request on /v1/responses

1. Run the same two-call cache flow with the OpenAI responses SDK through B. The response reports `input_tokens 10184`, `input_tokens_details.cached_tokens 10170`
2. Read the spend back through A:

```
$ curl -s -X GET "http://127.0.0.1:39346/spend/logs?request_id=msg_bdrk_01U4P6UsvoRjADf5shyxg5RC" -H "Authorization: Bearer $KEY"
"spend": 0.00315320334, "call_type": "aresponses",
"cost_breakdown": {"cache_read_cost": 0.0030512034000000003}
```

3. All three cached routes agree on the cache-aware figure, and the previously unpriced model bills at its published rate

Observations from the run, none of them caused or worsened by this PR:

- `spend` stores one ULP below `cost_breakdown.total_cost` on the largest of the values, a float round-trip in that column
- Opus 5 rejects `temperature` upstream, and `drop_params` does not strip it
- `/spend/logs` keys on the provider message id, not the `resp_...` id the responses SDK hands back
- Databricks returns Anthropic-shaped cache fields on all three routes


## Type

🐛 Bug Fix
🆕 New Feature

## Caveats (if any)

- Sonnet 5 ships at standard rates, not the expiring introductory ones
- Opus 4.7 and 4.8 now bill at their own rate, threefold below Opus 4's
- Fable 5 rates come from the published table; no endpoint served to verify
- Fable 5 is the one Claude endpoint Databricks documents as text-only, so it ships without vision
- Cache writes now bill the 1.25x premium instead of falling back to input, so write-heavy spend rises
- Gemini 2.5 Pro and Flash carry a 20% promotion through 2027-01-31, so their cache rates track the discount
- Four Gemini 3 entries store the pre-existing list rate and bill 25% high; untouched here, tracked separately
- Rates assume the US $0.070 per DBU on Global endpoints; other regions and In-geo tiers differ
- Long-context tiers above 200k tokens publish separate higher rates that the registry does not model
- New entries shadow future minor versions, so Opus 5.1 inherits Opus 5 pricing
- Opus 4.9 is still unlisted, so it keeps inheriting Opus 4's threefold-higher rate
- No entry carries a 1h-TTL cache write rate, which would bill zero if Databricks ever returned one
- 28 entries newly declare cache support, but auto cache-control injection stays off for Databricks
- The 42 pre-existing entries keep the older `metadata.notes` wording about the DBU fields
- A pre-existing test swapped `opus-5-1` for `haiku-5-1`, since the new entry makes the former mapped
- Legacy `dbrx-instruct` and `meta-llama-3.1-70b` aliases stay unpriced, unchanged
- Custom per-token pricing double-counts cache tokens, a separate pre-existing bug

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

- [x] 15e8a35feb0bbdbe113c2389bf00c0738cb8bbc4 passes /live-pr-risk

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect reported customer spend and billing for all Databricks traffic, including large corrections for newly mapped Opus models and cache-heavy workloads; risk is mitigated by extensive tests but pricing JSON mistakes would propagate widely.
> 
> **Overview**
> **Databricks spend calculation** now routes through `generic_cost_per_token` instead of multiplying raw `prompt_tokens` by the input rate. Legacy endpoint aliases (e.g. `mixtral-8x7b-instruct-v0.1`) are normalized via a small prefix map before registry lookup, so cache read/write usage fields can bill at their own rates.
> 
> The **model price registry** (main + backup JSON) is updated in bulk for Databricks: `cache_creation_input_token_cost` and `cache_read_input_token_cost` on existing entries, `supports_prompt_caching` on many chat models, and **new** priced entries for Claude Opus 4.7/4.8/5, Sonnet 5, and Fable 5 at published DBU-derived dollar rates.
> 
> **Tests** lock in cached vs uncached math, DBU conversion for new models, legacy alias resolution, promotional vs list Gemini rates, and that Databricks Claude models do not receive automatic `cache_control` injection even when caching is marked supported.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 15e8a35feb0bbdbe113c2389bf00c0738cb8bbc4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
