### PR TITLE
fix(ui): make playground chat bubbles theme-aware

### DIFF
--- a/ui/litellm-dashboard/src/app/(dashboard)/playground/components/chat_ui/ChatMessageBubble.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/playground/components/chat_ui/ChatMessageBubble.test.tsx
@@ -87,6 +87,21 @@ describe("ChatMessageBubble", () => {
     expect(screen.getByText("Hi there")).toBeInTheDocument();
   });
 
+  it.each([
+    { role: "user" as const, bubble: ["bg-info/10", "border-info/20"], avatar: "bg-info/20" },
+    { role: "assistant" as const, bubble: ["bg-card", "border-border"], avatar: "bg-muted" },
+  ])("should paint the $role surface from theme tokens, not fixed colours", ({ role, bubble, avatar }) => {
+    render(<ChatMessageBubble {...defaultProps} message={{ role, content: "Hello" }} />);
+
+    const header = screen.getByText(role).closest("div") as HTMLElement;
+    const surface = header.parentElement as HTMLElement;
+
+    expect(surface).toHaveClass(...bubble);
+    expect(surface).not.toHaveAttribute("style");
+    expect(header.firstElementChild).toHaveClass(avatar);
+    expect(header.firstElementChild).not.toHaveAttribute("style");
+  });
+
   it("should show model badge for assistant messages when model is provided", () => {
     render(<ChatMessageBubble {...defaultProps} message={{ role: "assistant", content: "Reply", model: "gpt-4" }} />);
 

--- a/ui/litellm-dashboard/src/app/(dashboard)/playground/components/chat_ui/ChatMessageBubble.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/playground/components/chat_ui/ChatMessageBubble.tsx
@@ -46,20 +46,16 @@ function ChatMessageBubble({
   return (
     <div className={`mb-4 min-w-0 ${isUser ? "text-right" : "text-left"}`}>
       <div
-        className="inline-block min-w-0 max-w-[92%] overflow-hidden rounded-lg p-3 shadow-xs sm:max-w-[85%] sm:px-4"
-        style={{
-          backgroundColor: isUser ? "#f0f8ff" : "#ffffff",
-          border: isUser ? "1px solid #e6f0fa" : "1px solid #f0f0f0",
-          textAlign: "left",
-        }}
+        className={`inline-block min-w-0 max-w-[92%] overflow-hidden rounded-lg border p-3 text-left text-card-foreground shadow-xs sm:max-w-[85%] sm:px-4 ${
+          isUser ? "border-info/20 bg-info/10" : "border-border bg-card"
+        }`}
       >
         {/* Header: role icon + name + model badge */}
         <div className="mb-1.5 flex min-w-0 items-center gap-2">
           <div
-            className="flex items-center justify-center w-6 h-6 rounded-full mr-1"
-            style={{
-              backgroundColor: isUser ? "#e6f0fa" : "#f5f5f5",
-            }}
+            className={`flex items-center justify-center w-6 h-6 rounded-full mr-1 ${
+              isUser ? "bg-info/20" : "bg-muted"
+            }`}
           >
             {isUser ? (
               <User className="size-3 text-info" aria-hidden="true" />

--- a/ui/litellm-dashboard/src/app/(dashboard)/playground/components/chat_ui/ChatUI.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/playground/components/chat_ui/ChatUI.tsx
@@ -1784,19 +1784,9 @@ const ChatUI: React.FC<ChatUIProps> = ({
                     chatHistory.length > 0 &&
                     chatHistory[chatHistory.length - 1].role === "user" && (
                       <div className="mb-4 text-left">
-                        <div
-                          className="inline-block max-w-[80%] rounded-lg p-3.5 px-4 shadow-xs"
-                          style={{
-                            backgroundColor: "#ffffff",
-                            border: "1px solid #f0f0f0",
-                            textAlign: "left",
-                          }}
-                        >
+                        <div className="inline-block max-w-[80%] rounded-lg border border-border bg-card p-3.5 px-4 text-left text-card-foreground shadow-xs">
                           <div className="mb-1.5 flex items-center gap-2">
-                            <div
-                              className="mr-1 flex h-6 w-6 items-center justify-center rounded-full"
-                              style={{ backgroundColor: "#f5f5f5" }}
-                            >
+                            <div className="mr-1 flex h-6 w-6 items-center justify-center rounded-full bg-muted">
                               <Bot className="size-3 text-muted-foreground" aria-hidden="true" />
                             </div>
                             <strong className="text-sm capitalize">Assistant</strong>


### PR DESCRIPTION
## TLDR

Problem this solves:

- Playground chat bubbles stay white in dark mode
- Message text is dark-on-white, so it is unreadable
- The MCP-events placeholder bubble has the same three fills

How it solves it:

- Swap the inline hex fills for theme tokens
- Assistant bubble becomes `bg-card` over `border-border`
- User bubble becomes the info tint, matching sibling surfaces

## User Flow

Before: someone using the Playground in dark mode cannot read any of the conversation, so the page is unusable for them

1. They open the account menu at https://litellm-domain/ui/ and pick the Dark theme
2. They go to https://litellm-domain/ui/?page=llm-playground, choose a model, and send a message
3. Their own message and the model's reply come back inside two near-white cards on the dark page
4. The text in both cards is drawn in the dark theme's light foreground, so on those white cards it is invisible: only the model badge and the latency row are legible
5. They have to switch back to the Light theme to read anything they just sent or received

After: the same conversation is readable in dark mode, and light mode looks exactly as it did

1. They open the account menu at https://litellm-domain/ui/ and pick the Dark theme
2. They go to https://litellm-domain/ui/?page=llm-playground, choose a model, and send a message
3. Their own message and the model's reply come back inside two dark cards that sit on the dark page
4. Both messages are readable, the user card keeps its blue tint, and the latency row still reads TTFT, total latency and token counts
5. Switching to the Light theme shows the same white and pale-blue cards the page has always had

## Relevant issues

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Shared setup, run once against a proxy started from the branch under test:

```
curl -s -X POST http://localhost:4000/model/new \
  -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
  -d "{\"model_name\":\"claude-sonnet-5\",\"litellm_params\":{\"model\":\"anthropic/claude-sonnet-5\",\"api_key\":\"$ANTHROPIC_API_KEY\"}}"
```

### Before (aae36f4bd4)

1. Open http://localhost:4000/ui/, click the account menu in the top right, and pick Dark
2. Go to http://localhost:4000/ui/?page=llm-playground
3. Pick `claude-sonnet-5` under Select Model, type any message, and hit send
4. Screenshot the reply: both bubbles render as white cards and neither message body is readable
5. Switch the account menu back to Light and screenshot again for the baseline

### After (dc7b1951ca)

1. Open http://localhost:4000/ui/, click the account menu in the top right, and pick Dark
2. Go to http://localhost:4000/ui/?page=llm-playground
3. Pick `claude-sonnet-5` under Select Model, type the same message, and hit send
4. Screenshot the reply: both bubbles are dark, both message bodies are readable, and the user bubble keeps its blue tint
5. Switch the account menu back to Light and screenshot again: the cards look the same as the Before baseline

## Type

🐛 Bug Fix

## Caveats (if any)

- Only the playground bubbles; no wider dark-mode audit
- Light mode keeps the same colour family, at token weights

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
