### PR TITLE
perf(spend_tracking): index LiteLLM_SpendLogs by (api_key, startTime)

### DIFF
--- a/db_scripts/partition_spend_logs.sql
+++ b/db_scripts/partition_spend_logs.sql
@@ -53,6 +53,8 @@ ALTER INDEX IF EXISTS "LiteLLM_SpendLogs_end_user_idx"
     RENAME TO "LiteLLM_SpendLogs_legacy_end_user_idx";
 ALTER INDEX IF EXISTS "LiteLLM_SpendLogs_session_id_idx"
     RENAME TO "LiteLLM_SpendLogs_legacy_session_id_idx";
+ALTER INDEX IF EXISTS "LiteLLM_SpendLogs_api_key_startTime_idx"
+    RENAME TO "LiteLLM_SpendLogs_legacy_api_key_startTime_idx";
 
 CREATE TABLE "LiteLLM_SpendLogs" (
     LIKE "LiteLLM_SpendLogs_legacy" INCLUDING DEFAULTS INCLUDING GENERATED
@@ -77,6 +79,9 @@ CREATE INDEX IF NOT EXISTS "LiteLLM_SpendLogs_end_user_idx"
 
 CREATE INDEX IF NOT EXISTS "LiteLLM_SpendLogs_session_id_idx"
     ON "LiteLLM_SpendLogs" ("session_id");
+
+CREATE INDEX IF NOT EXISTS "LiteLLM_SpendLogs_api_key_startTime_idx"
+    ON "LiteLLM_SpendLogs" ("api_key", "startTime");
 
 -- Safety net: any row whose startTime has no explicit partition lands here so
 -- writes never fail. The cleanup job never drops the DEFAULT partition.

--- a/db_scripts/unpartition_spend_logs.sql
+++ b/db_scripts/unpartition_spend_logs.sql
@@ -40,6 +40,8 @@ ALTER INDEX IF EXISTS "LiteLLM_SpendLogs_end_user_idx"
     RENAME TO "LiteLLM_SpendLogs_partitioned_end_user_idx";
 ALTER INDEX IF EXISTS "LiteLLM_SpendLogs_session_id_idx"
     RENAME TO "LiteLLM_SpendLogs_partitioned_session_id_idx";
+ALTER INDEX IF EXISTS "LiteLLM_SpendLogs_api_key_startTime_idx"
+    RENAME TO "LiteLLM_SpendLogs_partitioned_api_key_startTime_idx";
 
 CREATE TABLE "LiteLLM_SpendLogs" (
     LIKE "LiteLLM_SpendLogs_partitioned" INCLUDING DEFAULTS INCLUDING GENERATED
@@ -59,6 +61,9 @@ CREATE INDEX IF NOT EXISTS "LiteLLM_SpendLogs_end_user_idx"
 
 CREATE INDEX IF NOT EXISTS "LiteLLM_SpendLogs_session_id_idx"
     ON "LiteLLM_SpendLogs" ("session_id");
+
+CREATE INDEX IF NOT EXISTS "LiteLLM_SpendLogs_api_key_startTime_idx"
+    ON "LiteLLM_SpendLogs" ("api_key", "startTime");
 
 INSERT INTO "LiteLLM_SpendLogs"
 SELECT * FROM "LiteLLM_SpendLogs_partitioned"

--- a/litellm-proxy-extras/litellm_proxy_extras/migrations/20260823000000_add_spend_logs_api_key_starttime_index/migration.sql
+++ b/litellm-proxy-extras/litellm_proxy_extras/migrations/20260823000000_add_spend_logs_api_key_starttime_index/migration.sql
@@ -1,0 +1,2 @@
+-- CreateIndex
+CREATE INDEX IF NOT EXISTS "LiteLLM_SpendLogs_api_key_startTime_idx" ON "LiteLLM_SpendLogs"("api_key", "startTime");

--- a/litellm-proxy-extras/litellm_proxy_extras/schema.prisma
+++ b/litellm-proxy-extras/litellm_proxy_extras/schema.prisma
@@ -647,6 +647,7 @@ model LiteLLM_SpendLogs {
   @@index([startTime, request_id])
   @@index([end_user])
   @@index([session_id])
+  @@index([api_key, startTime])
 }
 
 // View spend, model, api_key per request

--- a/litellm/proxy/schema.prisma
+++ b/litellm/proxy/schema.prisma
@@ -647,6 +647,7 @@ model LiteLLM_SpendLogs {
   @@index([startTime, request_id])
   @@index([end_user])
   @@index([session_id])
+  @@index([api_key, startTime])
 }
 
 // View spend, model, api_key per request

--- a/schema.prisma
+++ b/schema.prisma
@@ -647,6 +647,7 @@ model LiteLLM_SpendLogs {
   @@index([startTime, request_id])
   @@index([end_user])
   @@index([session_id])
+  @@index([api_key, startTime])
 }
 
 // View spend, model, api_key per request


### PR DESCRIPTION
## TLDR

Problem this solves:

- `LiteLLM_SpendLogs` has no `api_key` index
- `/spend/logs`, `/spend/logs/ui`, `/key/spend/report`, `/global/spend/report` all filter by `api_key` + date range, so each call scans every logged request on the instance

How it solves it:

- adds `@@index([api_key, startTime])` + matching migration, mirroring the existing `(startTime, request_id)` composite

## User Flow

Before: auditing one key means scanning the whole instance's history

1. Admin calls GET https://litellm-domain/spend/logs?api_key=sk-... (or filters the UI logs page to one key)
2. Response time grows with total instance traffic — measured 94 ms at 1.6M logged requests for a key owning 160 of them

After: the same call answers from the key's own rows

1. Admin makes the same call
2. Response in <1 ms at the same table size; time now tracks the key's own request count

## Relevant issues

None found — surfaced while batch-reading per-key spend for 10,000 keys (that job: 20.5s -> 1.7s with this index).

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have added meaningful tests (index-only change — no behavioral surface to test)
- [ ] The handful of test files covering my change pass locally (n/a — no code path changes)
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** (5/5 received)

## Screenshots / Proof of Fix

Postgres 18, `LiteLLM_SpendLogs` with 1.6M rows across 10k keys, query shape used by the endpoints above:

```sql
SELECT COALESCE(SUM(spend),0) FROM "LiteLLM_SpendLogs"
WHERE api_key = $1 AND "startTime" >= now() - interval '7 days';
```

### Before (aae36f4)

```
->  Parallel Seq Scan on "LiteLLM_SpendLogs"  (actual time=3.739..69.066 rows=53 loops=3)
Execution Time: 93.883 ms
```

### After (555d5d5)

```
->  Bitmap Index Scan on "LiteLLM_SpendLogs_api_key_startTime_idx"
      Index Cond: ((api_key = $1) AND ("startTime" >= (now() - '7 days'::interval)))
Execution Time: 0.7 ms  (~140x)
```

## Type

🚄 Infrastructure

## Caveats (if any)

- no new tests: one index, no code path; schema-sync CI covers the three prisma copies
- plain `CREATE INDEX IF NOT EXISTS` (project style) briefly holds writes on very large tables — operators can pre-create the same name `CONCURRENTLY` and the migration no-ops

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Schema and migration-only; no application logic changes. Large tables may see brief write locking during index creation unless operators pre-build the index `CONCURRENTLY`.
> 
> **Overview**
> Adds a composite database index on **`LiteLLM_SpendLogs` (`api_key`, `startTime`)** so spend endpoints that filter by key and date range can use an index instead of scanning the full table.
> 
> The change is declared in all three Prisma **`LiteLLM_SpendLogs`** schemas and applied via a new **`litellm_proxy_extras`** migration (`CREATE INDEX IF NOT EXISTS "LiteLLM_SpendLogs_api_key_startTime_idx"`). **`partition_spend_logs.sql`** and **`unpartition_spend_logs.sql`** are updated to rename any existing index during table swap and recreate it on the rebuilt table, keeping partitioned installs in sync with Prisma-defined indexes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4c18f557b1c08948348bfb348658cce355ebe6a3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->