### PR TITLE
fix(ui): add the theme toggle to the public model hub navbar

### DIFF
--- a/ui/litellm-dashboard/src/components/navbar.test.tsx
+++ b/ui/litellm-dashboard/src/components/navbar.test.tsx
@@ -272,6 +272,13 @@ describe("Navbar", () => {
     expect(screen.queryByRole("button", { name: /^notifications$/i })).not.toBeInTheDocument();
   });
 
+  it("should keep the theme toggle on public pages", () => {
+    const publicPageProps = { ...defaultProps, isPublicPage: true };
+    renderWithProviders(<Navbar {...publicPageProps} />);
+
+    expect(screen.getByRole("button", { name: /^theme$/i })).toBeInTheDocument();
+  });
+
   it("should handle hide new feature indicators toggle", async () => {
     const user = userEvent.setup();
 

--- a/ui/litellm-dashboard/src/components/navbar.tsx
+++ b/ui/litellm-dashboard/src/components/navbar.tsx
@@ -162,17 +162,19 @@ const Navbar: React.FC<NavbarProps> = ({
               </div>
             )}
 
-            {!isPublicPage && (
-              <div className="flex shrink-0 items-center border-l border-border pl-4">
-                <div className="flex items-center gap-0.5 rounded-lg bg-muted px-1 py-0 transition-colors hover:bg-accent">
-                  <ThemeToggle />
-                  <span className="mx-0.5 h-6 w-px shrink-0 bg-border" aria-hidden />
-                  <NotificationsBell />
-                  <span className="mx-0.5 h-6 w-px shrink-0 bg-border" aria-hidden />
-                  <UserDropdown onLogout={handleLogout} />
-                </div>
+            <div className="flex shrink-0 items-center border-l border-border pl-4">
+              <div className="flex items-center gap-0.5 rounded-lg bg-muted px-1 py-0 transition-colors hover:bg-accent">
+                <ThemeToggle />
+                {!isPublicPage && (
+                  <>
+                    <span className="mx-0.5 h-6 w-px shrink-0 bg-border" aria-hidden />
+                    <NotificationsBell />
+                    <span className="mx-0.5 h-6 w-px shrink-0 bg-border" aria-hidden />
+                    <UserDropdown onLogout={handleLogout} />
+                  </>
+                )}
               </div>
-            )}
+            </div>
           </div>
         </div>
       </div>

--- a/ui/litellm-dashboard/src/components/navbar.tsx
+++ b/ui/litellm-dashboard/src/components/navbar.tsx
@@ -132,7 +132,7 @@ const Navbar: React.FC<NavbarProps> = ({
             </div>
           )}
 
-          <div className="ml-auto flex min-w-0 flex-1 items-center justify-end gap-4">
+          <div className="ml-auto flex min-w-0 flex-1 items-center justify-end gap-4 max-sm:gap-2">
             {showWorkerSwitch && (
               <div className="flex shrink-0 items-center">
                 <WorkerDropdown onWorkerSwitch={handleWorkerSwitch} />
@@ -162,7 +162,7 @@ const Navbar: React.FC<NavbarProps> = ({
               </div>
             )}
 
-            <div className="flex shrink-0 items-center border-l border-border pl-4">
+            <div className="flex shrink-0 items-center border-l border-border pl-4 max-sm:border-l-0 max-sm:pl-2">
               <div className="flex items-center gap-0.5 rounded-lg bg-muted px-1 py-0 transition-colors hover:bg-accent">
                 <ThemeToggle />
                 {!isPublicPage && (


### PR DESCRIPTION
## TLDR

Problem this solves:

- The public AI Hub page has no theme control
- Anyone opening that link is stuck in light mode
- The styles were ready; only the switch was missing

How it solves it:

- Ungate the theme toggle so public pages render it
- Keep the bell and account menu signed-in only

## User Flow

Before: a developer given the shared AI Hub link has no way out of light mode

1. They open https://litellm-domain/ui/model_hub_table
2. The top bar shows Docs, Blog and the community links, and nothing after them
3. Nowhere on the page is there a theme control, so the catalog stays white no matter what their OS or browser prefers
4. They scroll the model, MCP and skill tabs and every card, filter and table row stays light

After: the same page carries the theme control the rest of the dashboard already has

1. They open https://litellm-domain/ui/model_hub_table
2. The top bar now ends with a theme button showing a sun or a moon
3. They click it and get System, Light and Dark, with Dark marked Beta
4. They pick Dark and the whole page repaints: navbar, About and Health cards, the tab strip, the filters and the model table
5. They reload and the choice sticks

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Shared setup, run once from `ui/litellm-dashboard` against a proxy on `:4000`:

```
nvm use $(cat .nvmrc) && npm ci && PORT=3000 npm run dev
```

### Before (aae36f4bd4)

1. `git checkout aae36f4bd4` and restart the dev server
2. Open http://localhost:3000/model_hub_table
3. Screenshot the top bar: it ends at the Slack and GitHub links, with no theme control

### After (4cb466a8dc)

1. `git checkout 4cb466a8dc` and restart the dev server
2. Open http://localhost:3000/model_hub_table
3. Screenshot the top bar: a theme button now sits to the right of the community links
4. Click it, pick Dark, and screenshot the page
5. Reload and confirm the page comes back dark

## Type

🐛 Bug Fix

## Caveats (if any)

- Dark mode still carries its Beta label in the picker
- Public visitors still land on light by default

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
