### PR TITLE
fix(ui): theme the created-key box so it follows dark mode

### DIFF
--- a/ui/litellm-dashboard/src/components/shared/CreatedKeyDisplay.test.tsx
+++ b/ui/litellm-dashboard/src/components/shared/CreatedKeyDisplay.test.tsx
@@ -19,6 +19,15 @@ describe("CreatedKeyDisplay", () => {
     expect(screen.getByText("sk-test-123")).toBeInTheDocument();
   });
 
+  it("should theme the key box with tokens instead of a hardcoded light background", () => {
+    render(<CreatedKeyDisplay apiKey="sk-test-123" />);
+
+    const keyBox = screen.getByText("sk-test-123").parentElement as HTMLElement;
+
+    expect(keyBox).not.toHaveAttribute("style");
+    expect(keyBox).toHaveClass("bg-muted");
+  });
+
   it("should display the security warning", () => {
     render(<CreatedKeyDisplay apiKey="sk-test-123" />);
     expect(screen.getByText(/you will not be able to view it again/i)).toBeInTheDocument();

--- a/ui/litellm-dashboard/src/components/shared/CreatedKeyDisplay.tsx
+++ b/ui/litellm-dashboard/src/components/shared/CreatedKeyDisplay.tsx
@@ -29,15 +29,8 @@ const CreatedKeyDisplay: React.FC<CreatedKeyDisplayProps> = ({ apiKey }) => {
       </p>
 
       <p className="text-sm text-muted-foreground mt-3 mb-1">Virtual Key:</p>
-      <div
-        style={{
-          background: "#f8f8f8",
-          padding: "10px",
-          borderRadius: "5px",
-          marginBottom: "10px",
-        }}
-      >
-        <pre style={{ wordWrap: "break-word", whiteSpace: "normal", margin: 0 }}>{apiKey}</pre>
+      <div className="bg-muted rounded-md p-2.5 mb-2.5">
+        <pre className="m-0 whitespace-normal break-words text-foreground">{apiKey}</pre>
       </div>
 
       <CopyToClipboard text={apiKey} onCopy={handleCopy}>


### PR DESCRIPTION
## TLDR

Problem this solves:

- Created key is unreadable in dark mode
- Key box has a hardcoded light background

How it solves it:

- Use the bg-muted and text-foreground theme tokens
- Drop the inline styles that ignore the theme

## User Flow

Before: an admin on the dark theme creates a virtual key and cannot read the key they were just told to save

1. They open http://localhost:4000/ui/?page=api-keys and switch the dashboard to the dark theme
2. They click "Create New Key", fill in the form, and submit
3. The "Save your Key" dialog opens with the key sitting in a near-white box
4. The key characters render in the dark theme's light text color on that near-white box, so the key is washed out and unreadable
5. Their only option is copying blind with "Copy Virtual Key", or switching back to the light theme to read it

After: the same dialog shows the key at full contrast on the dark theme

1. They open http://localhost:4000/ui/?page=api-keys and switch the dashboard to the dark theme
2. They click "Create New Key", fill in the form, and submit
3. The "Save your Key" dialog opens with the key sitting in a muted box that matches the dark theme
4. The key characters render at full contrast and are readable
5. The light theme is unchanged, and the same dialog in the Add Agent wizard picks up the fix too

## Relevant issues

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Setup: run the proxy with `python litellm/proxy/proxy_cli.py --config litellm/proxy/dev_config.yaml --detailed_debug --reload --use_v2_migration_resolver`, run the dashboard with `npm run dev` in `ui/litellm-dashboard`, open http://localhost:3000/?page=api-keys, and switch the dashboard to the dark theme

### Before (aae36f4bd4)

1. Click "Create New Key", pick a model, and submit
2. Observe the "Save your Key" dialog: the key sits in a near-white box and the characters are washed out to the point of being unreadable

### After (b94a1b890c)

1. Click "Create New Key", pick a model, and submit
2. Observe the "Save your Key" dialog: the box matches the dark theme and the key reads at full contrast
3. Switch back to the light theme and repeat, confirming it looks the same as before this change

## Type

🐛 Bug Fix

## Caveats (if any)

- Other hardcoded backgrounds remain in the logs drawer
