### PR TITLE
fix(ui): restore the public model name tooltip layout in the add model flow

### DIFF
--- a/ui/litellm-dashboard/src/components/add_model/conditional_public_model_name.tsx
+++ b/ui/litellm-dashboard/src/components/add_model/conditional_public_model_name.tsx
@@ -34,6 +34,8 @@ const modelMappingsRule = {
   },
 };
 
+const tooltipCodeClassName = "rounded-sm bg-background/20 px-1 py-0.5 font-mono text-xs";
+
 const ConditionalPublicModelName: React.FC = () => {
   const form = useFormContext<MountedFormValues>();
 
@@ -123,22 +125,22 @@ const ConditionalPublicModelName: React.FC = () => {
   if (!showPublicModelName) return null;
 
   const publicNameTooltipContent = (
-    <>
-      <div className="mb-2 font-normal">The name you specify in your API calls to LiteLLM Proxy</div>
-      <div className="mb-2 font-normal">
+    <div className="flex flex-col gap-2 text-left font-normal">
+      <div>The name you specify in your API calls to LiteLLM Proxy</div>
+      <div>
         <strong>Example:</strong> If you name your public model{" "}
-        <code className="bg-muted px-1 py-0.5 rounded-sm text-xs">example-name</code>, and choose{" "}
-        <code className="bg-muted px-1 py-0.5 rounded-sm text-xs">openai/qwen-plus-latest</code> as the LiteLLM model
+        <code className={tooltipCodeClassName}>example-name</code>, and choose{" "}
+        <code className={tooltipCodeClassName}>openai/qwen-plus-latest</code> as the LiteLLM model
       </div>
-      <div className="mb-2 font-normal">
+      <div>
         <strong>Usage:</strong> You make an API call to the LiteLLM proxy with{" "}
-        <code className="bg-muted px-1 py-0.5 rounded-sm text-xs">model = &quot;example-name&quot;</code>
+        <code className={tooltipCodeClassName}>model = &quot;example-name&quot;</code>
       </div>
-      <div className="font-normal">
-        <strong>Result:</strong> LiteLLM sends{" "}
-        <code className="bg-muted px-1 py-0.5 rounded-sm text-xs">qwen-plus-latest</code> to the provider
+      <div>
+        <strong>Result:</strong> LiteLLM sends <code className={tooltipCodeClassName}>qwen-plus-latest</code> to the
+        provider
       </div>
-    </>
+    </div>
   );
 
   const liteLLMModelTooltipContent = <div>The model name LiteLLM will send to the LLM API</div>;


### PR DESCRIPTION
## TLDR

Problem this solves:

- Public Model Name tooltip renders as four unreadable columns
- Its inline code samples show as blank blocks

How it solves it:

- Wrap the tooltip's blocks in one vertical container
- Tint the code samples from the tooltip's own color

## User Flow

Before: an admin adding a deployment opens the Public Model Name help and gets an unreadable band of text

1. They open http://localhost:4000/ui/?page=llm-model-hub, go to Add Model, pick a provider and a model
2. They scroll to Model Mappings and hover the help icon next to Public Model Name
3. The tooltip opens as four side-by-side columns, each a few words wide, and the model-name samples inside it are blank rectangles with no readable text
4. They close it without learning what the field expects

After: the same tooltip reads as four normal lines with every sample visible

1. They open http://localhost:4000/ui/?page=llm-model-hub, go to Add Model, pick a provider and a model
2. They scroll to Model Mappings and hover the help icon next to Public Model Name
3. The tooltip opens as four stacked lines, and the samples `example-name`, `openai/qwen-plus-latest`, `model = "example-name"` and `qwen-plus-latest` are all legible
4. They read the example and fill the field, in either the light or the dark theme

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Setup, the same for both sides: run the proxy with `python litellm/proxy/proxy_cli.py --config litellm/proxy/dev_config.yaml --detailed_debug`, then run `npm run dev` in `ui/litellm-dashboard` and log in to the dashboard

### Before (aae36f4bd4)

1. Open http://localhost:3000/?page=llm-model-hub and click Add Model
2. Choose OpenAI as the provider and `qwen-plus-latest` as the model, so a row appears under Model Mappings
3. Hover the help icon next to the Public Model Name column header
4. Screenshot the tooltip: four side-by-side columns, blank rectangles where the code samples should be
5. Switch the dashboard to the dark theme and repeat step 3

### After (70dc3d58d0)

1. Open http://localhost:3000/?page=llm-model-hub and click Add Model
2. Choose OpenAI as the provider and `qwen-plus-latest` as the model, so a row appears under Model Mappings
3. Hover the help icon next to the Public Model Name column header
4. Screenshot the tooltip: four stacked lines, every code sample readable
5. Switch the dashboard to the dark theme and repeat step 3, the samples stay readable there too

## Type

🐛 Bug Fix

## Caveats (if any)

- No test added: jsdom cannot observe CSS layout
- A Playwright spec is the only honest guard here

### Final Attestation

- [ ] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
