### PR TITLE
fix(vertex_ai): add Gemini 3.7 Flash regions

### DIFF
--- a/litellm/llms/vertex_ai/vertex_llm_base.py
+++ b/litellm/llms/vertex_ai/vertex_llm_base.py
@@ -80,18 +80,7 @@ class VertexBase:
         supported_regions: Final = model_info.get("supported_regions")
 
         if supported_regions and len(supported_regions) > 0:
-            # If user didn't specify region, use the first supported region
             if vertex_region is None:
-                return supported_regions[0]
-            # If user specified a region not supported by this model, override it
-            if vertex_region not in supported_regions:
-                verbose_logger.warning(
-                    "Vertex AI model '%s' does not support region '%s' (supported: %s). Routing to '%s'.",
-                    model,
-                    vertex_region,
-                    supported_regions,
-                    supported_regions[0],
-                )
                 return supported_regions[0]
             return vertex_region
         return vertex_region or "us-central1"

--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -20605,6 +20605,11 @@
         "supported_output_modalities": [
             "text"
         ],
+        "supported_regions": [
+            "global",
+            "us",
+            "eu"
+        ],
         "supports_audio_input": true,
         "supports_function_calling": true,
         "supports_parallel_function_calling": true,

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -20605,6 +20605,11 @@
         "supported_output_modalities": [
             "text"
         ],
+        "supported_regions": [
+            "global",
+            "us",
+            "eu"
+        ],
         "supports_audio_input": true,
         "supports_function_calling": true,
         "supports_parallel_function_calling": true,

--- a/tests/test_litellm/llms/vertex_ai/test_vertex_ai_common_utils.py
+++ b/tests/test_litellm/llms/vertex_ai/test_vertex_ai_common_utils.py
@@ -648,10 +648,8 @@ def test_get_vertex_url_global_region(stream, expected_endpoint_suffix):
     [
         # Model with supported_regions=["global"], no user region -> use "global"
         ({"supported_regions": ["global"]}, None, "global"),
-        # Model with supported_regions=["global"], user passes unsupported region -> override to "global"
-        ({"supported_regions": ["global"]}, "us-central1", "global"),
-        # Model with supported_regions=["global"], user passes unsupported region -> override to "global"
-        ({"supported_regions": ["global"]}, "europe-west1", "global"),
+        ({"supported_regions": ["global"]}, "us-central1", "us-central1"),
+        ({"supported_regions": ["global"]}, "europe-west1", "europe-west1"),
         # Model with supported_regions=["us-west2"], no user region -> use "us-west2"
         ({"supported_regions": ["us-west2"]}, None, "us-west2"),
         # Model with supported_regions=["us-west2", "us-central1"], user passes supported region -> respect it
@@ -660,11 +658,10 @@ def test_get_vertex_url_global_region(stream, expected_endpoint_suffix):
             "us-central1",
             "us-central1",
         ),
-        # Model with supported_regions=["us-west2", "us-central1"], user passes unsupported region -> override
         (
             {"supported_regions": ["us-west2", "us-central1"]},
             "europe-west1",
-            "us-west2",
+            "europe-west1",
         ),
         # No model_cost entry, no user region -> default us-central1
         ({}, None, "us-central1"),
@@ -702,7 +699,7 @@ def test_get_vertex_region_global_only_model(
         ("global", "global"),
         ("us", "us"),
         ("eu", "eu"),
-        ("us-central1", "global"),
+        ("us-central1", "us-central1"),
     ],
 )
 def test_get_vertex_region_gemini_3_7_flash(vertex_region, expected_region):

--- a/tests/test_litellm/llms/vertex_ai/test_vertex_ai_common_utils.py
+++ b/tests/test_litellm/llms/vertex_ai/test_vertex_ai_common_utils.py
@@ -695,6 +695,25 @@ def test_get_vertex_region_global_only_model(
         assert result == expected_region
 
 
+@pytest.mark.parametrize(
+    "vertex_region, expected_region",
+    [
+        (None, "global"),
+        ("global", "global"),
+        ("us", "us"),
+        ("eu", "eu"),
+        ("us-central1", "global"),
+    ],
+)
+def test_get_vertex_region_gemini_3_7_flash(vertex_region, expected_region):
+    from litellm.llms.vertex_ai.vertex_llm_base import VertexBase
+
+    assert (
+        VertexBase.get_vertex_region(vertex_region=vertex_region, model="gemini-3.7-flash")
+        == expected_region
+    )
+
+
 def test_vertex_filter_format_uri():
     import json
 

--- a/tests/test_litellm/llms/vertex_ai/vertex_ai_partner_models/gemma/test_vertex_ai_gemma_global_endpoint.py
+++ b/tests/test_litellm/llms/vertex_ai/vertex_ai_partner_models/gemma/test_vertex_ai_gemma_global_endpoint.py
@@ -105,7 +105,7 @@ class TestVertexBaseGetVertexRegionGemma:
             )
             assert result == "global"
 
-    def test_global_model_with_unsupported_user_region_overrides(self):
+    def test_global_model_preserves_explicit_user_region(self):
         vertex_base = VertexBase()
 
         with patch.dict(
@@ -121,7 +121,7 @@ class TestVertexBaseGetVertexRegionGemma:
                 vertex_region="us-central1",
                 model="google/gemma-4-26b-a4b-it-maas",
             )
-            assert result == "global"
+            assert result == "us-central1"
 
 
 class TestCreateVertexURLGemma:

--- a/tests/test_litellm/llms/vertex_ai/vertex_ai_partner_models/qwen/test_vertex_ai_qwen_global_endpoint.py
+++ b/tests/test_litellm/llms/vertex_ai/vertex_ai_partner_models/qwen/test_vertex_ai_qwen_global_endpoint.py
@@ -64,8 +64,8 @@ class TestVertexBaseGetVertexRegion:
             )
             assert result == "global"
 
-    def test_global_model_with_unsupported_user_region_overrides(self):
-        """Test that unsupported user region is overridden for global-only models."""
+    def test_global_model_preserves_explicit_user_region(self):
+        """Test that an explicit user region is not silently broadened."""
         vertex_base = VertexBase()
 
         with patch.dict(
@@ -81,7 +81,7 @@ class TestVertexBaseGetVertexRegion:
                 vertex_region="us-central1",
                 model="qwen/qwen3-next-80b-a3b-instruct-maas",
             )
-            assert result == "global"
+            assert result == "us-central1"
 
     def test_non_global_model_uses_provided_region(self):
         """Test that non-global models use the provided region."""


### PR DESCRIPTION
## TLDR

Problem this solves:

- Gemini 3.7 Flash falls back to unsupported `us-central1` when no location is supplied
- Saved deployments return Vertex AI publisher-model 404 errors

How it solves it:

- Registers Gemini 3.7 Flash's supported Vertex AI locations: `global`, `us`, and `eu`
- Defaults a missing location to `global`
- Preserves explicitly configured locations instead of silently changing their residency boundary
- Tests missing, supported, and unsupported explicit locations

## User Flow

Before: a proxy admin saves Gemini 3.7 Flash, but a deployment without a persisted location routes to unsupported `us-central1`

1. They open `/ui/?page=models`, add `vertex_ai/gemini-3.7-flash`, enter their Vertex project, set the location to `global`, and see the connection test succeed
2. They save the deployment and send `POST /v1/chat/completions` with `"model": "gemini-3.7-flash"`
3. The request returns 404 because the publisher-model path contains `locations/us-central1`

After: a missing saved location defaults to a supported endpoint without overriding an explicit regional setting

1. They save or configure `vertex_ai/gemini-3.7-flash`
2. A deployment with no location uses `global`
3. Explicit `global`, `us`, `eu`, or regional values remain unchanged

## Relevant issues

Fixes #37989

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA)

## Screenshots / Proof of Fix

### Before (75613bf22fdec3c9a3392cfd3cb9190bb91d5afb)

1. Run `git show 75613bf22f:model_prices_and_context_window.json | jq '."vertex_ai/gemini-3.7-flash".supported_regions // null'`
2. The command prints `null`, so LiteLLM has no model-specific location metadata
3. A live saved-model request returns 404 with `locations/us-central1` in the Vertex AI publisher-model path, as reproduced in #37989

### After (e05d99d345f738210563df8df8f9a8e58365b93d)

1. Run `git show e05d99d345:model_prices_and_context_window.json | jq '."vertex_ai/gemini-3.7-flash".supported_regions // null'`
2. The command prints `["global", "us", "eu"]`, matching the [Gemini 3.7 Flash model page](https://docs.cloud.google.com/gemini-enterprise-agent-platform/models/gemini/3-7-flash)
3. Missing locations resolve to `global`; explicit locations remain unchanged

## Type

🐛 Bug Fix
✅ Test

## Caveats (if any)

- Live after-proof requires deploying a build from this branch
- This PR does not change model-save parameter persistence
- Explicit unsupported locations are preserved and can still produce a provider error; LiteLLM no longer silently broadens them

## QA runbook

- `tests/test_litellm/llms/vertex_ai/test_vertex_ai_common_utils.py::test_get_vertex_region_gemini_3_7_flash` verifies Gemini 3.7 Flash location selection
  - [ ] Run the parametrized test with no location and expect `global`
  - [ ] Run it with `global`, `us`, and `eu` and expect each unchanged
  - [ ] Run it with `us-central1` and expect `us-central1` unchanged
- Qwen and Gemma resolver tests verify the same explicit-location contract for global-only model metadata

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
