### PR TITLE
fix(bedrock): accept any tool choice

### DIFF
--- a/litellm/llms/bedrock/chat/converse_transformation.py
+++ b/litellm/llms/bedrock/chat/converse_transformation.py
@@ -591,7 +591,7 @@ class AmazonConverseConfig(BaseConfig):
                     message=f"Bedrock doesn't support tool_choice={tool_choice}. To drop it from the call, set `litellm.drop_params = True.",
                     status_code=400,
                 )
-        elif tool_choice == "required":
+        elif tool_choice == "required" or tool_choice == "any":
             return ToolChoiceValuesBlock(any={})
         elif tool_choice == "auto":
             return ToolChoiceValuesBlock(auto={})

--- a/tests/test_litellm/llms/bedrock/chat/test_converse_transformation.py
+++ b/tests/test_litellm/llms/bedrock/chat/test_converse_transformation.py
@@ -4323,6 +4323,7 @@ def test_parallel_tool_calls_emits_typed_auto_tool_choice(parallel_tool_calls, e
     [
         ("auto", {"auto": {}}),
         ("required", {"any": {}}),
+        ("any", {"any": {}}),
         ({"type": "function", "function": {"name": "get_current_weather"}}, {"tool": {"name": "get_current_weather"}}),
     ],
 )


### PR DESCRIPTION
## TLDR

Problem this solves:

- Bedrock rejects OpenAI `tool_choice="any"` despite supporting forced tool use

How it solves it:

- Map `"any"` to Bedrock's existing `{"any": {}}` choice block

## Problem

LiteLLM raises `UnsupportedParamsError` when a Bedrock Converse request uses `tool_choice="any"`. Bedrock accepts the equivalent `any` tool choice block, so clients using the OpenAI value cannot force a tool call through the gateway

## Root Cause

The transformation maps `"required"` to Bedrock's `any` block but does not recognize the OpenAI synonym `"any"`

## Solution

Treat `"any"` and `"required"` as equivalent input values while preserving the existing `auto`, named-tool, and unsupported-value behavior

## Changes

- Added the `"any"` branch to Bedrock Converse tool-choice mapping
- Added a parameterized regression case to the existing transformation test

## Testing

- Focused regression: `..\litellm\.venv\Scripts\python.exe -m pytest tests/test_litellm/llms/bedrock/chat/test_converse_transformation.py -q -k parallel_tool_calls_with_explicit_tool_choice_omits_conflicting_type` -> 4 passed
- Source Ruff check passed
- Full Bedrock Converse transformation file: 182 passed, 5 failed because this environment lacks `boto3`/`botocore` for unrelated live/streaming tests
- Black is not installed in the available virtual environment; Ruff format check reports pre-existing formatting differences in both touched files
- basedpyright reports existing repository-wide typing issues in the touched source file; no new type-specific change was required
- `git diff --check` completed without diff errors

## Compatibility/Risk

This only broadens accepted OpenAI input for Bedrock Converse. Existing mappings and unsupported values are unchanged. No provider API call was made locally because AWS credentials and Bedrock dependencies were unavailable

## Notes for Reviewer

The production change is one conditional branch. The regression asserts that `"any"` produces the same Bedrock `ToolChoiceValuesBlock(any={})` as `"required"`

## Relevant issues

Fixes #37980

## Linear ticket


## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The focused test file passes locally
- [ ] Required CI/CD checks are pending on the new PR
- [x] The PR scope is isolated to one mapping and its regression case
- [ ] Greptile confidence review is pending after publication

## Screenshots / Proof of Fix

### Before (d447be15b96)

#### Bedrock tool choice mapping

1. A caller sends a Bedrock Converse request with `"tool_choice": "any"`
2. The adapter rejects the request with `UnsupportedParamsError`, stating that Bedrock supports `auto`, `required`, or a JSON object

### After (1cfe030ec6c)

#### Bedrock tool choice mapping

1. A caller sends the same request with `"tool_choice": "any"`
2. The adapter maps it to Bedrock's native `{"any": {}}` tool choice block
3. The focused transformation regression passes with the mapped block

No live Bedrock request was run because this environment has no AWS credentials and the required `boto3`/`botocore` packages are unavailable

## Type

Bug Fix

## Caveats (if any)

- Live Bedrock API behavior is not verified locally
- Full transformation coverage needs the repository's complete test dependencies

### Final Attestation

- [x] The focused regression checks the reported edge case and preserves existing mappings