### PR TITLE
fix(streaming): preserve explicit zero usage

### DIFF
--- a/litellm/litellm_core_utils/streaming_chunk_builder_utils.py
+++ b/litellm/litellm_core_utils/streaming_chunk_builder_utils.py
@@ -136,8 +136,8 @@ class _UsageBearingChunk(TypedDict, total=False):
 
 
 class _UsageSummary(TypedDict):
-    prompt_tokens: int | None
-    completion_tokens: int | None
+    prompt_tokens: int
+    completion_tokens: int
     cache_creation_input_tokens: int | None
     cache_read_input_tokens: int | None
     completion_tokens_details: CompletionTokensDetails | None

--- a/litellm/litellm_core_utils/streaming_chunk_builder_utils.py
+++ b/litellm/litellm_core_utils/streaming_chunk_builder_utils.py
@@ -751,6 +751,32 @@ class ChunkProcessor:
             return Usage(**usage_chunk)
         return usage_chunk
 
+    @staticmethod
+    def _update_usage_token_counts(
+        usage_chunk: Usage,
+        usage_chunk_dict: "_UsageSummary",
+        prompt_tokens: int,
+        completion_tokens: int,
+        completion_usage_updates: int,
+    ) -> tuple[int, int, bool, bool, int]:
+        prompt_tokens_provided = "prompt_tokens" in usage_chunk
+        completion_tokens_provided = "completion_tokens" in usage_chunk
+
+        if prompt_tokens_provided and (usage_chunk_dict["prompt_tokens"] > 0 or prompt_tokens == 0):
+            prompt_tokens = usage_chunk_dict["prompt_tokens"]
+        if completion_tokens_provided and (usage_chunk_dict["completion_tokens"] > 0 or completion_tokens == 0):
+            completion_tokens = usage_chunk_dict["completion_tokens"]
+            if completion_tokens > 0:
+                completion_usage_updates += 1
+
+        return (
+            prompt_tokens,
+            completion_tokens,
+            prompt_tokens_provided,
+            completion_tokens_provided,
+            completion_usage_updates,
+        )
+
     def _calculate_usage_per_chunk(
         self,
         chunks: Sequence["_UsageBearingChunk | ModelResponse"],
@@ -796,18 +822,19 @@ class ChunkProcessor:
 
             if usage_chunk is not None:
                 usage_chunk_dict = self._usage_chunk_calculation_helper(usage_chunk)
-                if "prompt_tokens" in usage_chunk:
-                    prompt_tokens_provided = True
-                if "prompt_tokens" in usage_chunk and (usage_chunk_dict["prompt_tokens"] > 0 or prompt_tokens == 0):
-                    prompt_tokens = usage_chunk_dict["prompt_tokens"]
-                if "completion_tokens" in usage_chunk:
-                    completion_tokens_provided = True
-                if "completion_tokens" in usage_chunk and (
-                    usage_chunk_dict["completion_tokens"] > 0 or completion_tokens == 0
-                ):
-                    completion_tokens = usage_chunk_dict["completion_tokens"]
-                    if completion_tokens > 0:
-                        completion_usage_updates += 1
+                (
+                    prompt_tokens,
+                    completion_tokens,
+                    prompt_tokens_provided,
+                    completion_tokens_provided,
+                    completion_usage_updates,
+                ) = self._update_usage_token_counts(
+                    usage_chunk=usage_chunk,
+                    usage_chunk_dict=usage_chunk_dict,
+                    prompt_tokens=prompt_tokens,
+                    completion_tokens=completion_tokens,
+                    completion_usage_updates=completion_usage_updates,
+                )
                 if usage_chunk_dict["cache_creation_input_tokens"] is not None and (
                     usage_chunk_dict["cache_creation_input_tokens"] > 0 or cache_creation_input_tokens is None
                 ):

--- a/litellm/litellm_core_utils/streaming_chunk_builder_utils.py
+++ b/litellm/litellm_core_utils/streaming_chunk_builder_utils.py
@@ -762,19 +762,30 @@ class ChunkProcessor:
         prompt_tokens_provided = "prompt_tokens" in usage_chunk
         completion_tokens_provided = "completion_tokens" in usage_chunk
 
-        if prompt_tokens_provided and (usage_chunk_dict["prompt_tokens"] > 0 or prompt_tokens == 0):
-            prompt_tokens = usage_chunk_dict["prompt_tokens"]
-        if completion_tokens_provided and (usage_chunk_dict["completion_tokens"] > 0 or completion_tokens == 0):
-            completion_tokens = usage_chunk_dict["completion_tokens"]
-            if completion_tokens > 0:
-                completion_usage_updates += 1
+        updated_prompt_tokens = (
+            usage_chunk_dict["prompt_tokens"]
+            if prompt_tokens_provided and (usage_chunk_dict["prompt_tokens"] > 0 or prompt_tokens == 0)
+            else prompt_tokens
+        )
+        updated_completion_tokens = (
+            usage_chunk_dict["completion_tokens"]
+            if completion_tokens_provided and (usage_chunk_dict["completion_tokens"] > 0 or completion_tokens == 0)
+            else completion_tokens
+        )
+        updated_completion_usage_updates = (
+            completion_usage_updates + 1
+            if completion_tokens_provided
+            and (usage_chunk_dict["completion_tokens"] > 0 or completion_tokens == 0)
+            and updated_completion_tokens > 0
+            else completion_usage_updates
+        )
 
         return (
-            prompt_tokens,
-            completion_tokens,
+            updated_prompt_tokens,
+            updated_completion_tokens,
             prompt_tokens_provided,
             completion_tokens_provided,
-            completion_usage_updates,
+            updated_completion_usage_updates,
         )
 
     def _calculate_usage_per_chunk(

--- a/litellm/litellm_core_utils/streaming_chunk_builder_utils.py
+++ b/litellm/litellm_core_utils/streaming_chunk_builder_utils.py
@@ -178,6 +178,7 @@ class ChunkProcessor:
         self.chunks = self._sort_chunks(chunks)
         self.messages = messages
         self.first_chunk = chunks[0]
+        self._usage_fields_provided: tuple[bool, bool] = (False, False)
 
     def _sort_chunks(self, chunks: list) -> list:
         if not chunks:
@@ -795,13 +796,20 @@ class ChunkProcessor:
 
             if usage_chunk is not None:
                 usage_chunk_dict = self._usage_chunk_calculation_helper(usage_chunk)
-                prompt_tokens_provided = prompt_tokens_provided or "prompt_tokens" in usage_chunk
-                completion_tokens_provided = completion_tokens_provided or "completion_tokens" in usage_chunk
-                if usage_chunk_dict["prompt_tokens"] is not None and usage_chunk_dict["prompt_tokens"] > 0:
+                if "prompt_tokens" in usage_chunk:
+                    prompt_tokens_provided = True
+                if "prompt_tokens" in usage_chunk and (
+                    usage_chunk_dict["prompt_tokens"] > 0 or prompt_tokens == 0
+                ):
                     prompt_tokens = usage_chunk_dict["prompt_tokens"]
-                if usage_chunk_dict["completion_tokens"] is not None and usage_chunk_dict["completion_tokens"] > 0:
+                if "completion_tokens" in usage_chunk:
+                    completion_tokens_provided = True
+                if "completion_tokens" in usage_chunk and (
+                    usage_chunk_dict["completion_tokens"] > 0 or completion_tokens == 0
+                ):
                     completion_tokens = usage_chunk_dict["completion_tokens"]
-                    completion_usage_updates += 1
+                    if completion_tokens > 0:
+                        completion_usage_updates += 1
                 if usage_chunk_dict["cache_creation_input_tokens"] is not None and (
                     usage_chunk_dict["cache_creation_input_tokens"] > 0 or cache_creation_input_tokens is None
                 ):
@@ -843,17 +851,20 @@ class ChunkProcessor:
 
         prompt_tokens_details = attach_cache_creation_token_details(prompt_tokens_details, cache_creation_token_details)
 
+        was_anthropic_cursor = completion_tokens == 1
         completion_tokens = self._reset_anthropic_cursor_completion_tokens(
             chunks=chunks,
-            completion_tokens=completion_tokens,
+            completion_tokens=completion_tokens or 0,
             completion_usage_updates=completion_usage_updates,
         )
+        if was_anthropic_cursor and completion_tokens == 0:
+            completion_tokens_provided = False
+
+        self._usage_fields_provided = (prompt_tokens_provided, completion_tokens_provided)
 
         return UsagePerChunk(
             prompt_tokens=prompt_tokens,
-            prompt_tokens_provided=prompt_tokens_provided,
             completion_tokens=completion_tokens,
-            completion_tokens_provided=completion_tokens_provided,
             cache_creation_input_tokens=cache_creation_input_tokens,
             cache_read_input_tokens=cache_read_input_tokens,
             server_tool_use=server_tool_use,
@@ -950,11 +961,12 @@ class ChunkProcessor:
         ]
         prompt_tokens_details: PromptTokensDetailsWrapper | None = calculated_usage_per_chunk["prompt_tokens_details"]
         cost: Final[float | None] = calculated_usage_per_chunk["cost"]
+        prompt_tokens_provided, completion_tokens_provided = self._usage_fields_provided
 
         try:
             returned_usage.prompt_tokens = (
                 prompt_tokens
-                if calculated_usage_per_chunk["prompt_tokens_provided"]
+                if prompt_tokens_provided
                 else token_counter(model=model, messages=messages)
             )
         except Exception:  # don't allow this failing to block a complete streaming response from being returned
@@ -962,7 +974,7 @@ class ChunkProcessor:
             returned_usage.prompt_tokens = 0
         returned_usage.completion_tokens = (
             completion_tokens
-            if calculated_usage_per_chunk["completion_tokens_provided"]
+            if completion_tokens_provided
             else token_counter(
                 model=model,
                 text=completion_output,

--- a/litellm/litellm_core_utils/streaming_chunk_builder_utils.py
+++ b/litellm/litellm_core_utils/streaming_chunk_builder_utils.py
@@ -761,6 +761,8 @@ class ChunkProcessor:
         # # Update usage information if needed
         prompt_tokens = 0
         completion_tokens = 0
+        prompt_tokens_provided = False
+        completion_tokens_provided = False
         # Anthropic's `message_start` SSE event carries usage.output_tokens=1 as a
         # cursor/placeholder; the real value only arrives in `message_delta`.
         # If a stream is cancelled before `message_delta` lands, the last-wins
@@ -793,6 +795,8 @@ class ChunkProcessor:
 
             if usage_chunk is not None:
                 usage_chunk_dict = self._usage_chunk_calculation_helper(usage_chunk)
+                prompt_tokens_provided = prompt_tokens_provided or "prompt_tokens" in usage_chunk
+                completion_tokens_provided = completion_tokens_provided or "completion_tokens" in usage_chunk
                 if usage_chunk_dict["prompt_tokens"] is not None and usage_chunk_dict["prompt_tokens"] > 0:
                     prompt_tokens = usage_chunk_dict["prompt_tokens"]
                 if usage_chunk_dict["completion_tokens"] is not None and usage_chunk_dict["completion_tokens"] > 0:
@@ -847,7 +851,9 @@ class ChunkProcessor:
 
         return UsagePerChunk(
             prompt_tokens=prompt_tokens,
+            prompt_tokens_provided=prompt_tokens_provided,
             completion_tokens=completion_tokens,
+            completion_tokens_provided=completion_tokens_provided,
             cache_creation_input_tokens=cache_creation_input_tokens,
             cache_read_input_tokens=cache_read_input_tokens,
             server_tool_use=server_tool_use,
@@ -946,13 +952,18 @@ class ChunkProcessor:
         cost: Final[float | None] = calculated_usage_per_chunk["cost"]
 
         try:
-            returned_usage.prompt_tokens = prompt_tokens or token_counter(model=model, messages=messages)
+            returned_usage.prompt_tokens = (
+                prompt_tokens
+                if calculated_usage_per_chunk["prompt_tokens_provided"]
+                else token_counter(model=model, messages=messages)
+            )
         except Exception:  # don't allow this failing to block a complete streaming response from being returned
             print_verbose("token_counter failed, assuming prompt tokens is 0")
             returned_usage.prompt_tokens = 0
         returned_usage.completion_tokens = (
             completion_tokens
-            or token_counter(
+            if calculated_usage_per_chunk["completion_tokens_provided"]
+            else token_counter(
                 model=model,
                 text=completion_output,
                 count_response_tokens=True,  # count_response_tokens is a Flag to tell token counter this is a response, No need to add extra tokens we do for input messages

--- a/litellm/litellm_core_utils/streaming_chunk_builder_utils.py
+++ b/litellm/litellm_core_utils/streaming_chunk_builder_utils.py
@@ -798,9 +798,7 @@ class ChunkProcessor:
                 usage_chunk_dict = self._usage_chunk_calculation_helper(usage_chunk)
                 if "prompt_tokens" in usage_chunk:
                     prompt_tokens_provided = True
-                if "prompt_tokens" in usage_chunk and (
-                    usage_chunk_dict["prompt_tokens"] > 0 or prompt_tokens == 0
-                ):
+                if "prompt_tokens" in usage_chunk and (usage_chunk_dict["prompt_tokens"] > 0 or prompt_tokens == 0):
                     prompt_tokens = usage_chunk_dict["prompt_tokens"]
                 if "completion_tokens" in usage_chunk:
                     completion_tokens_provided = True
@@ -965,9 +963,7 @@ class ChunkProcessor:
 
         try:
             returned_usage.prompt_tokens = (
-                prompt_tokens
-                if prompt_tokens_provided
-                else token_counter(model=model, messages=messages)
+                prompt_tokens if prompt_tokens_provided else token_counter(model=model, messages=messages)
             )
         except Exception:  # don't allow this failing to block a complete streaming response from being returned
             print_verbose("token_counter failed, assuming prompt tokens is 0")

--- a/litellm/types/litellm_core_utils/streaming_chunk_builder_utils.py
+++ b/litellm/types/litellm_core_utils/streaming_chunk_builder_utils.py
@@ -5,9 +5,7 @@ from ..utils import CompletionTokensDetails, PromptTokensDetailsWrapper, ServerT
 
 class UsagePerChunk(TypedDict):
     prompt_tokens: int
-    prompt_tokens_provided: bool
     completion_tokens: int
-    completion_tokens_provided: bool
     cache_creation_input_tokens: int | None
     cache_read_input_tokens: int | None
     server_tool_use: ServerToolUse | None

--- a/litellm/types/litellm_core_utils/streaming_chunk_builder_utils.py
+++ b/litellm/types/litellm_core_utils/streaming_chunk_builder_utils.py
@@ -5,7 +5,9 @@ from ..utils import CompletionTokensDetails, PromptTokensDetailsWrapper, ServerT
 
 class UsagePerChunk(TypedDict):
     prompt_tokens: int
+    prompt_tokens_provided: bool
     completion_tokens: int
+    completion_tokens_provided: bool
     cache_creation_input_tokens: int | None
     cache_read_input_tokens: int | None
     server_tool_use: ServerToolUse | None

--- a/tests/test_litellm/litellm_core_utils/test_streaming_chunk_builder_utils.py
+++ b/tests/test_litellm/litellm_core_utils/test_streaming_chunk_builder_utils.py
@@ -592,6 +592,34 @@ def test_stream_chunk_builder_litellm_usage_chunks():
     assert usage.total_tokens == 77
 
 
+def test_stream_chunk_builder_preserves_explicit_zero_usage():
+    chunk = ModelResponseStream(
+        id="chatcmpl-explicit-zero-usage",
+        created=1745513206,
+        model="gpt-5.5",
+        object="chat.completion.chunk",
+        choices=[
+            StreamingChoices(
+                finish_reason="stop",
+                index=0,
+                delta=Delta(content="partial output"),
+            )
+        ],
+        usage=Usage(prompt_tokens=0, completion_tokens=0, total_tokens=0),
+    )
+
+    usage = ChunkProcessor(chunks=[chunk]).calculate_usage(
+        chunks=[chunk],
+        model="gpt-5.5",
+        messages=[{"role": "user", "content": "a non-empty prompt"}],
+        completion_output="partial output",
+    )
+
+    assert usage.prompt_tokens == 0
+    assert usage.completion_tokens == 0
+    assert usage.total_tokens == 0
+
+
 def test_get_model_from_chunks_azure_model_router():
     """
     Test that _get_model_from_chunks finds the actual model from Azure Model Router chunks.


### PR DESCRIPTION
## TLDR

Problem this solves:

- Streaming providers can report zero billable tokens on a disconnected response
- The proxy replaces explicit zero usage with local token estimates

How it solves it:

- Preserve whether prompt and completion usage fields were provided
- Fall back to token counting only when a field is absent
- Preserve Anthropic's existing single-token cursor fallback behavior

## Problem

A client-disconnected streamed response with provider-reported zero usage can be recorded with positive estimated tokens and spend

## Root Cause

Usage aggregation used truthiness, so explicit zero values were indistinguishable from missing provider usage

## Solution

Track field presence outside the public usage aggregate and preserve zero values when providers supplied them. Keep Anthropic's synthetic message-start cursor eligible for text estimation

## Changes

- Track prompt/completion usage presence during stream aggregation
- Preserve explicit zero usage without adding new public usage fields
- Add a regression test for explicit zero prompt and completion usage

## User Flow

Before: a disconnected streamed request with explicit zero usage can receive estimated token counts

1. A client sends a streaming chat completion and disconnects
2. The provider reports zero prompt and completion usage in the partial response
3. The proxy estimates tokens locally and records positive usage or spend

After: the same response preserves the provider's explicit zero usage

1. A client sends the same streaming chat completion and disconnects
2. The provider reports zero prompt and completion usage in the partial response
3. The proxy keeps both values at zero and does not bill estimates as provider usage

## Relevant issues

Fixes #37992

## Testing

- Baseline: focused streaming usage tests 29 passed
- Final: `python -m pytest tests/test_litellm/litellm_core_utils/test_streaming_chunk_builder_utils.py tests/test_litellm/litellm_core_utils/test_streaming_chunk_builder_cursor.py -q` -> 41 passed
- `ruff check` on changed production file -> passed
- `python -m compileall` on changed files -> passed
- `git diff --check` -> passed
- Full basedpyright -> not verified; the sparse checkout reports existing repository diagnostics
- Live provider billing flow -> not run; no provider credentials or billable service were used
- Full proxy/integration suite -> not run locally; CI is running the repository matrix

## Compatibility/Risk

This preserves existing estimation behavior when usage fields are absent, including Anthropic's synthetic cursor case. It changes only the handling of explicitly supplied zero prompt or completion usage

## Notes for Reviewer

The regression uses a non-empty prompt and completion text so the previous truthiness fallback would fail with positive estimates. The internal presence state avoids changing the public aggregate schema

## Screenshots / Proof of Fix

No live provider request was run because this local environment has no provider credentials. The focused regression tests exercise the same usage assembly boundary without network access

## Type

🐛 Bug Fix

## Caveats (if any)

- Full basedpyright and integration coverage remain environment/CI dependent
- Live provider billing was not invoked

### Final Attestation

- [x] The focused regression checks the explicit-zero edge case
- [x] Existing Anthropic cursor fallback tests pass
- [x] The change preserves fallback estimation for missing usage fields