### PR TITLE
fix(azure): add cache_read cost for us/eu gpt-4o-2024-11-20

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -3720,6 +3720,7 @@
     "azure/eu/gpt-4o-2024-11-20": {
         "deprecation_date": "2027-04-14",
         "cache_creation_input_token_cost": 1.38e-06,
+        "cache_read_input_token_cost": 1.375e-06,
         "input_cost_per_token": 2.75e-06,
         "litellm_provider": "azure",
         "max_input_tokens": 128000,
@@ -8534,6 +8535,7 @@
     "azure/us/gpt-4o-2024-11-20": {
         "deprecation_date": "2027-04-14",
         "cache_creation_input_token_cost": 1.38e-06,
+        "cache_read_input_token_cost": 1.375e-06,
         "input_cost_per_token": 2.75e-06,
         "litellm_provider": "azure",
         "max_input_tokens": 128000,

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -3720,6 +3720,7 @@
     "azure/eu/gpt-4o-2024-11-20": {
         "deprecation_date": "2027-04-14",
         "cache_creation_input_token_cost": 1.38e-06,
+        "cache_read_input_token_cost": 1.375e-06,
         "input_cost_per_token": 2.75e-06,
         "litellm_provider": "azure",
         "max_input_tokens": 128000,
@@ -8534,6 +8535,7 @@
     "azure/us/gpt-4o-2024-11-20": {
         "deprecation_date": "2027-04-14",
         "cache_creation_input_token_cost": 1.38e-06,
+        "cache_read_input_token_cost": 1.375e-06,
         "input_cost_per_token": 2.75e-06,
         "litellm_provider": "azure",
         "max_input_tokens": 128000,

--- a/tests/test_litellm/llms/azure/test_azure_cost_calculation.py
+++ b/tests/test_litellm/llms/azure/test_azure_cost_calculation.py
@@ -6,7 +6,8 @@ import pytest
 
 import litellm
 from litellm.llms.azure.cost_calculation import cost_per_token
-from litellm.types.utils import Usage
+from litellm.types.utils import PromptTokensDetailsWrapper, Usage
+from litellm.utils import get_model_info
 
 
 # Register a test model with tier-specific pricing
@@ -73,3 +74,25 @@ class TestAzureServiceTierCostCalculation:
 
         assert abs(none_prompt - standard_prompt) < 1e-10
         assert abs(none_completion - standard_completion) < 1e-10
+
+
+@pytest.mark.parametrize(
+    "model",
+    ["azure/us/gpt-4o-2024-11-20", "azure/eu/gpt-4o-2024-11-20"],
+)
+def test_gpt4o_2024_11_20_data_zone_cache_read_cost(model, local_model_cost_map):
+    model_info = get_model_info(model=model, custom_llm_provider="azure")
+    assert model_info["cache_read_input_token_cost"] == 1.375e-06
+    assert model_info["input_cost_per_token"] == 2.75e-06
+    assert model_info["output_cost_per_token"] == 1.1e-05
+
+    usage = Usage(
+        prompt_tokens=6000,
+        completion_tokens=10,
+        total_tokens=6010,
+        prompt_tokens_details=PromptTokensDetailsWrapper(cached_tokens=5000),
+    )
+    prompt_cost, completion_cost = cost_per_token(model=model, usage=usage)
+
+    assert prompt_cost == pytest.approx((1000 * 2.75e-06) + (5000 * 1.375e-06))
+    assert completion_cost == pytest.approx(10 * 1.1e-05)


### PR DESCRIPTION
## TLDR

Problem this solves:

- azure/us and azure/eu gpt-4o-2024-11-20 billed cache reads at $0

How it solves it:

- set cache_read_input_token_cost to 1.375e-06 on both data-zone keys, matching the 2024-08-06 data-zone entries

## User Flow

Before this change, a team using azure/us/gpt-4o-2024-11-20 with a cached system prompt sees cache reads billed at zero

1. They POST https://litellm-domain/v1/chat/completions with model "azure/us/gpt-4o-2024-11-20" and a prompt containing a large previously-cached block
2. Azure returns usage with prompt_tokens_details.cached_tokens populated (e.g. 5000 cached tokens)
3. They open https://litellm-domain/ui/?page=logs and see spend that reflects only non-cached tokens

After this change, the same request is billed at the data-zone cache-read rate

1. They POST https://litellm-domain/v1/chat/completions with model "azure/us/gpt-4o-2024-11-20" and a prompt containing a large previously-cached block
2. Azure returns usage with prompt_tokens_details.cached_tokens populated (e.g. 5000 cached tokens)
3. https://litellm-domain/ui/?page=logs shows cache-read tokens billed at 1.375e-06 per token (~$0.007 for 5000 tokens)

## Relevant issues

Fixes #37823

## Linear ticket


## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

This is a static cost-map miss. The original report confirmed it by inspecting `model_prices_and_context_window.json` with no provider call

Setup, from repo root:

```
python -c "import json; d=json.load(open('model_prices_and_context_window.json')); print('us', d['azure/us/gpt-4o-2024-11-20'].get('cache_read_input_token_cost')); print('eu', d['azure/eu/gpt-4o-2024-11-20'].get('cache_read_input_token_cost')); print('control', d['azure/us/gpt-4o-2024-08-06'].get('cache_read_input_token_cost'))"
```

### Before (d447be15b9)

1. Ran the command above on `litellm_internal_staging`
2. Observed: `us None` / `eu None` / `control 1.375e-06`

### After (889f4e5ac8)

1. Ran the same command on this branch
2. Observed: `us 1.375e-06` / `eu 1.375e-06` / `control 1.375e-06`

CI can run `uv run pytest tests/test_litellm/llms/azure/test_azure_cost_calculation.py -v`. Local Windows here cannot build the rust python-bridge (`link.exe` missing), so that pytest file is left to CI

## Type

🐛 Bug Fix
✅ Test

## Caveats (if any)


### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
