### PR TITLE
docs(gcp): document OS Config metadata for VPC connector

### DIFF
--- a/terraform/litellm/gcp/README.md
+++ b/terraform/litellm/gcp/README.md
@@ -315,6 +315,25 @@ The `migration_run_command` output is preserved for break-glass manual re-runs.
 required APIs must be enabled (run, sqladmin, redis, secretmanager,
 vpcaccess, compute, servicenetworking, storage, artifactregistry).
 
+If the organization enforces
+`constraints/compute.managed.requireOsConfig`, existing projects also
+need VM Manager (OS Config) enabled in project metadata before apply.
+The Serverless VPC Access connector creates GCE VMs; without this
+metadata the connector operation fails, Terraform's error is vague,
+and Cloud operation logs report an org-policy violation. New projects
+created after the constraint is already on are usually fine. Existing
+projects are not. Set it once per project:
+
+```bash
+gcloud compute project-info add-metadata \
+  --project PROJECT_ID \
+  --metadata=enable-osconfig=TRUE
+```
+
+Do not manage this from the module: project-wide metadata is often
+owned by another Terraform root. Google's setup notes:
+https://docs.cloud.google.com/compute/vm-manager/docs/setup#set_metadata_values
+
 ## TLS
 
 `terraform plan` refuses to provision an HTTP-only LB by default — TLS

--- a/terraform/litellm/gcp/examples/default/TUTORIAL.md
+++ b/terraform/litellm/gcp/examples/default/TUTORIAL.md
@@ -29,6 +29,23 @@ gcloud services enable \
   artifactregistry.googleapis.com
 ```
 
+## Enable VM Manager (OS Config) on existing projects
+
+Skip this on a brand-new project created after
+`constraints/compute.managed.requireOsConfig` is already enforced.
+Existing projects that later get that org policy need this metadata, or
+`terraform apply` fails while creating the Serverless VPC Access
+connector and Terraform's error is vague. Cloud operation logs then
+report an OS Config org-policy violation.
+
+```bash
+gcloud compute project-info add-metadata \
+  --project <your-project-id> \
+  --metadata=enable-osconfig=TRUE
+```
+
+See https://docs.cloud.google.com/compute/vm-manager/docs/setup#set_metadata_values
+
 ## Create the Artifact Registry passthrough to GHCR
 
 Cloud Run only pulls from Artifact Registry, `gcr.io`, or `docker.io`; it rejects `ghcr.io` URIs at apply time. The four LiteLLM images live on GHCR, so the stack needs a remote Artifact Registry repo pointed at GHCR. This is a one-time setup per project.

--- a/terraform/litellm/gcp/network.tf
+++ b/terraform/litellm/gcp/network.tf
@@ -36,6 +36,11 @@ resource "google_service_networking_connection" "psa" {
 # machine_type alone). Defaults: 2 e2-micro instances scale up to 3 — fine
 # for low-to-moderate Cloud Run egress; bump max if your services push
 # heavy private-network traffic.
+#
+# If constraints/compute.managed.requireOsConfig is enforced, existing
+# projects need enable-osconfig=TRUE in project metadata before this
+# connector can be created. The module does not set that metadata
+# (it is often owned by another root). See README.md Quick start.
 resource "google_vpc_access_connector" "this" {
   name          = "${local.name}-conn"
   region        = var.region


### PR DESCRIPTION
## TLDR

Problem this solves:

- GCP Terraform apply fails under requireOsConfig on existing projects, with a vague connector error

How it solves it:

- documents the enable-osconfig=TRUE project-metadata prerequisite on the GCP module README and Cloud Shell tutorial, without managing project-wide metadata in the module

## User Flow

Before this change, an administrator deploying LiteLLM into a Google Cloud org that enforces `constraints/compute.managed.requireOsConfig` cannot finish Terraform on an existing project

1. They configure `BerriAI/litellm/google` for an existing project where that constraint is enforced
2. They run `terraform init` and `terraform apply`
3. Terraform tries to create the Serverless VPC Access connector
4. The connector operation fails. Terraform reports an unclear creation error, and Google Cloud operation logs identify an OS Config organization-policy violation
5. `terraform apply` cannot finish
6. Their workaround is to set `enable-osconfig=TRUE` in project-wide metadata and rerun apply

After this change, the same administrator can see the OS Config prerequisite before Terraform tries to create the connector

1. They configure `BerriAI/litellm/google` for the same existing project
2. `terraform/litellm/gcp/README.md` (Quick start) and `terraform/litellm/gcp/examples/default/TUTORIAL.md` tell them to verify project metadata contains `enable-osconfig=TRUE`
3. They run `gcloud compute project-info add-metadata --project PROJECT_ID --metadata=enable-osconfig=TRUE`
4. They run `terraform init` and `terraform apply`
5. The Serverless VPC Access connector can be created once the org policy is satisfied
6. The rest of the Cloud Run stack can proceed

## Relevant issues

Fixes #37987

## Linear ticket


## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have added meaningful tests
- [ ] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

Docs-only change. No unit tests apply. The GCP module has no terraform test harness for org-policy failures

## Screenshots / Proof of Fix

This is a documentation change for an org-policy failure that needs a GCP project with `constraints/compute.managed.requireOsConfig` enforced. That environment is not available here, so the proof is the published apply path rather than a live `terraform apply`

### Before (d447be15b9)

1. Opened `terraform/litellm/gcp/README.md` at Quick start and `terraform/litellm/gcp/examples/default/TUTORIAL.md` at Prerequisites
2. Observed: APIs and `gcloud auth` are listed. `enable-osconfig=TRUE` and `constraints/compute.managed.requireOsConfig` are not mentioned
3. `terraform/litellm/gcp/network.tf` documents the VPC connector but not the OS Config metadata requirement

### After (184d1c9662)

1. Opened the same README Quick start section
2. Observed the `gcloud compute project-info add-metadata --metadata=enable-osconfig=TRUE` command, plus the note that the module does not own project-wide metadata
3. Opened the Cloud Shell tutorial and observed the same prerequisite before Artifact Registry setup
4. Opened `network.tf` and observed a pointer back to the README for existing projects under `requireOsConfig`

## Type

📖 Documentation

## Caveats (if any)

- Does not add an opt-in `google_compute_project_metadata_item` resource. Project-wide metadata is often owned by another Terraform root, which is the reason the issue asked for docs as the minimum fix

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
