### PR TITLE
fix(openai): raise after unstructured 422 retry exhaustion

### DIFF
--- a/litellm/llms/openai/openai.py
+++ b/litellm/llms/openai/openai.py
@@ -649,7 +649,7 @@ class OpenAIChatCompletion(BaseLLM, BaseOpenAILLM):
             if custom_llm_provider is not None and custom_llm_provider != "openai":
                 model_response.model = f"{custom_llm_provider}/{model}"
 
-            for _ in range(2):  # if call fails due to alternating messages, retry with reformatted message
+            for attempt in range(2):  # if call fails due to alternating messages, retry with reformatted message
                 try:
                     max_retries = inference_params.pop("max_retries", 2)
                     if acompletion is True:
@@ -778,11 +778,10 @@ class OpenAIChatCompletion(BaseLLM, BaseOpenAILLM):
                         return final_response_obj
                 except openai.UnprocessableEntityError as e:
                     ## check if body contains unprocessable params - related issue https://github.com/BerriAI/litellm/issues/4800
-                    if litellm.drop_params is True or drop_params is True:
+                    if attempt == 0 and (litellm.drop_params is True or drop_params is True):
                         inference_params = drop_params_from_unprocessable_entity_error(e, inference_params)
                     else:
                         raise e
-                    # e.message
                 except Exception as e:
                     if print_verbose is not None:
                         print_verbose(f"openai.py: Received openai error - {e}")
@@ -858,7 +857,7 @@ class OpenAIChatCompletion(BaseLLM, BaseOpenAILLM):
             litellm_params=litellm_params,
             headers=headers or {},
         )
-        for _ in range(2):  # if call fails due to alternating messages, retry with reformatted message
+        for attempt in range(2):  # if call fails due to alternating messages, retry with reformatted message
             try:
                 openai_aclient: AsyncOpenAI = self._get_openai_client(
                     is_async=True,
@@ -930,11 +929,10 @@ class OpenAIChatCompletion(BaseLLM, BaseOpenAILLM):
                 return final_response_obj
             except openai.UnprocessableEntityError as e:
                 ## check if body contains unprocessable params - related issue https://github.com/BerriAI/litellm/issues/4800
-                if litellm.drop_params is True or drop_params is True:
+                if attempt == 0 and (litellm.drop_params is True or drop_params is True):
                     data = drop_params_from_unprocessable_entity_error(e, data)
                 else:
                     raise e
-                # e.message
             except Exception as e:
                 exception_response = getattr(e, "response", None)
                 status_code = getattr(e, "status_code", 500)
@@ -1038,7 +1036,7 @@ class OpenAIChatCompletion(BaseLLM, BaseOpenAILLM):
         )
         data["stream"] = True
         data.update(self.get_stream_options(stream_options=stream_options, api_base=api_base))
-        for _ in range(2):
+        for attempt in range(2):
             try:
                 openai_aclient: AsyncOpenAI = self._get_openai_client(
                     is_async=True,
@@ -1081,7 +1079,7 @@ class OpenAIChatCompletion(BaseLLM, BaseOpenAILLM):
                 return streamwrapper
             except openai.UnprocessableEntityError as e:
                 ## check if body contains unprocessable params - related issue https://github.com/BerriAI/litellm/issues/4800
-                if litellm.drop_params is True or drop_params is True:
+                if attempt == 0 and (litellm.drop_params is True or drop_params is True):
                     data = drop_params_from_unprocessable_entity_error(e, data)
                 else:
                     raise e

--- a/tests/test_litellm/llms/openai/test_openai_422_retry_exhaustion.py
+++ b/tests/test_litellm/llms/openai/test_openai_422_retry_exhaustion.py
@@ -1,0 +1,97 @@
+"""
+Regression tests for issue #32221: with drop_params=True, two consecutive 422s
+with an unstructured body must raise instead of silently returning None.
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import httpx
+import openai
+import pytest
+
+from litellm.llms.openai.common_utils import OpenAIError
+from litellm.llms.openai.openai import OpenAIChatCompletion, OpenAIConfig
+from litellm.types.utils import ModelResponse
+
+
+def _unstructured_422_error() -> openai.UnprocessableEntityError:
+    return openai.UnprocessableEntityError(
+        message="Error code: 422 - content moderation rejected the request",
+        response=httpx.Response(
+            422,
+            request=httpx.Request("POST", "https://api.openai.com/v1/chat/completions"),
+            json={"error": {"message": "content moderation rejected the request"}},
+        ),
+        body={"message": "content moderation rejected the request"},
+    )
+
+
+@pytest.mark.asyncio
+async def test_acompletion_raises_after_unstructured_422_retry_exhaustion():
+    mock_client = MagicMock()
+    mock_client.chat.completions.with_raw_response.create = AsyncMock(side_effect=_unstructured_422_error())
+
+    with pytest.raises((openai.UnprocessableEntityError, OpenAIError)) as exc_info:
+        await OpenAIChatCompletion().acompletion(
+            messages=[{"role": "user", "content": "hi"}],
+            optional_params={},
+            litellm_params={},
+            provider_config=OpenAIConfig(),
+            model="gpt-4o",
+            model_response=ModelResponse(),
+            logging_obj=MagicMock(),
+            timeout=30.0,
+            api_key="sk-test",
+            client=mock_client,
+            drop_params=True,
+        )
+
+    assert exc_info.value.status_code == 422
+    assert mock_client.chat.completions.with_raw_response.create.await_count == 2
+
+
+def test_completion_raises_after_unstructured_422_retry_exhaustion():
+    mock_client = MagicMock(spec=openai.OpenAI)
+    mock_client.api_key = "sk-test"
+    mock_client._base_url = MagicMock()
+    mock_client.chat.completions.with_raw_response.create.side_effect = _unstructured_422_error()
+
+    with pytest.raises((openai.UnprocessableEntityError, OpenAIError)) as exc_info:
+        OpenAIChatCompletion().completion(
+            model_response=ModelResponse(),
+            timeout=30.0,
+            optional_params={},
+            litellm_params={},
+            logging_obj=MagicMock(),
+            model="gpt-4o",
+            messages=[{"role": "user", "content": "hi"}],
+            api_key="sk-test",
+            client=mock_client,
+            drop_params=True,
+        )
+
+    assert exc_info.value.status_code == 422
+    assert mock_client.chat.completions.with_raw_response.create.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_async_streaming_raises_after_unstructured_422_retry_exhaustion():
+    mock_client = MagicMock()
+    mock_client.chat.completions.with_raw_response.create = AsyncMock(side_effect=_unstructured_422_error())
+
+    with pytest.raises((openai.UnprocessableEntityError, OpenAIError)) as exc_info:
+        await OpenAIChatCompletion().async_streaming(
+            timeout=30.0,
+            messages=[{"role": "user", "content": "hi"}],
+            optional_params={},
+            litellm_params={},
+            provider_config=OpenAIConfig(),
+            model="gpt-4o",
+            logging_obj=MagicMock(),
+            api_key="sk-test",
+            client=mock_client,
+            drop_params=True,
+        )
+
+    assert exc_info.value.status_code == 422
+    assert mock_client.chat.completions.with_raw_response.create.await_count == 2


### PR DESCRIPTION
## TLDR

Problem this solves:

- drop_params plus an unstructured 422 made the OpenAI handler return None
- the proxy then answered HTTP 200 with body null
- spend logs, failure callbacks, and router fallbacks never ran

How it solves it:

- the first 422 still drops params and retries once
- the second 422 is re-raised instead of falling off the loop
- callers see a 422 and the proxy can fail the request normally

## User Flow

Before: a client calling /v1/chat/completions against an OpenAI-compatible deployment with drop_params enabled gets a fake success when the upstream rejects the request twice with an unstructured 422

1. They POST https://litellm-domain/v1/chat/completions to a deployment that has drop_params true
2. The upstream answers HTTP 422 twice with a message-only body and no detail list
3. The proxy answers HTTP 200 with body `null`
4. Their OpenAI SDK crashes parsing response=None, and the request never appears as a failure in spend logs

After: the same two 422s surface as a real 422, so the client can handle the rejection and the proxy can log the failure

1. They POST the same https://litellm-domain/v1/chat/completions request
2. The upstream still answers HTTP 422 twice with a message-only body
3. The proxy now returns a 422 instead of 200 null
4. Spend logs and failure callbacks can fire, and configured fallbacks can run

## Relevant issues

Fixes #32221

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Shared setup: mocked OpenAI-compatible client that raises `UnprocessableEntityError` twice with body `{"message": "content moderation rejected the request"}` and `drop_params=True`. No live provider call.

### Before (d447be15b9)

1. `uv run pytest tests/test_litellm/llms/openai/test_openai_422_retry_exhaustion.py -v` against this merge base
2. All three cases failed with `Failed: DID NOT RAISE`

### After (e12ab58d13)

1. `uv run pytest tests/test_litellm/llms/openai/test_openai_422_retry_exhaustion.py tests/test_litellm/llms/openai/test_openai_empty_response.py -v`
2. 7 passed in 0.40s, including the three exhaustion cases and the neighboring empty-response tests

## Type

🐛 Bug Fix

## Caveats (if any)

- A prior closed PR (#32222) targeted this issue and was never merged. This is a fresh patch on current staging
- Structured 422 bodies that name a droppable param still get one retry. Only the exhausted unstructured path now raises

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
