### PR TITLE
fix(proxy): propagate multi-worker startup failures

### DIFF
--- a/litellm/proxy/proxy_cli.py
+++ b/litellm/proxy/proxy_cli.py
@@ -282,6 +282,42 @@ class ProxyInitializationHelpers:
         return uvicorn_args
 
     @staticmethod
+    def _run_uvicorn_server(
+        uvicorn_args: dict,
+        num_workers: int,
+        reload: bool,
+    ) -> None:
+        """Run Uvicorn and preserve startup failures from multi-process workers."""
+        import inspect
+
+        import uvicorn
+
+        if num_workers <= 1 or reload:
+            uvicorn.run(**uvicorn_args, workers=num_workers)
+            return
+
+        from uvicorn.supervisors import Multiprocess
+
+        config = uvicorn.Config(**uvicorn_args, workers=num_workers)
+        server = uvicorn.Server(config=config)
+        server_socket = config.bind_socket()
+        try:
+            if "target" in inspect.signature(Multiprocess).parameters:
+                supervisor = Multiprocess(config=config, target=server.run, sockets=[server_socket])
+            else:
+                supervisor = Multiprocess(config=config, sockets=[server_socket])
+            supervisor.run()
+
+            startup_failure_code: Final = getattr(uvicorn.config, "STARTUP_FAILURE", 3)
+            worker_exit_codes: Final = tuple(
+                process.exitcode for process in supervisor.processes if process.exitcode is not None
+            )
+            if startup_failure_code in worker_exit_codes:
+                raise SystemExit(startup_failure_code)
+        finally:
+            server_socket.close()
+
+    @staticmethod
     def _apply_uvicorn_max_requests_jitter(
         uvicorn_args: dict,
         max_requests_before_restart: int | None,
@@ -1072,7 +1108,7 @@ def run_server(
                 ) from e
         else:
             try:
-                import uvicorn
+                importlib.import_module("uvicorn")
             except Exception:
                 raise ImportError("uvicorn, gunicorn needs to be imported. Run - `pip install 'litellm[proxy]'`")
 
@@ -1405,9 +1441,10 @@ def run_server(
 
             if num_workers > 1:
                 start_query_engine_reaper()
-            uvicorn.run(
-                **uvicorn_args,
-                workers=num_workers,
+            ProxyInitializationHelpers._run_uvicorn_server(
+                uvicorn_args=uvicorn_args,
+                num_workers=num_workers,
+                reload=reload,
             )
         elif run_gunicorn is True:
             ProxyInitializationHelpers._run_gunicorn_server(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ Documentation = "https://docs.litellm.ai"
 [project.optional-dependencies]
 proxy = [
     "gunicorn>=23.0.0,<24.0",
-    "uvicorn>=0.33.0,<1.0",
+    "uvicorn>=0.51.0,<1.0",
     "granian>=2.7.4,<3.0",
     "uvloop>=0.21.0,<1.0; sys_platform != 'win32'",
     "fastapi>=0.136.3,<1.0",

--- a/tests/test_litellm/proxy/test_proxy_cli.py
+++ b/tests/test_litellm/proxy/test_proxy_cli.py
@@ -136,6 +136,53 @@ class TestProxyInitializationHelpers:
             )
             assert args["timeout_worker_healthcheck"] == 15
 
+    def test_run_uvicorn_server_propagates_multi_worker_startup_failure(self):
+        class _FakeSocket:
+            def __init__(self):
+                self.closed = False
+
+            def close(self):
+                self.closed = True
+
+        class _FakeConfig:
+            instances = []
+
+            def __init__(self, **kwargs):
+                self.kwargs = kwargs
+                self.socket = _FakeSocket()
+                self.__class__.instances.append(self)
+
+            def bind_socket(self):
+                return self.socket
+
+        class _FakeMultiprocess:
+            instances = []
+
+            def __init__(self, config, sockets):
+                self.processes = [SimpleNamespace(exitcode=3)]
+                self.ran = False
+                self.__class__.instances.append(self)
+
+            def run(self):
+                self.ran = True
+
+        with (
+            patch("uvicorn.Config", _FakeConfig),
+            patch("uvicorn.Server", return_value=MagicMock()),
+            patch("uvicorn.supervisors.Multiprocess", _FakeMultiprocess),
+            patch("uvicorn.config.STARTUP_FAILURE", 3, create=True),
+        ):
+            with pytest.raises(SystemExit) as exc_info:
+                ProxyInitializationHelpers._run_uvicorn_server(
+                    uvicorn_args={"app": "litellm.proxy.proxy_server:app"},
+                    num_workers=2,
+                    reload=False,
+                )
+
+        assert exc_info.value.code == 3
+        assert _FakeMultiprocess.instances[0].ran is True
+        assert _FakeConfig.instances[0].socket.closed is True
+
     def test_installed_uvicorn_supports_worker_flags(self):
         params = inspect.signature(uvicorn.Config.__init__).parameters
         assert "timeout_worker_healthcheck" in params
@@ -1667,7 +1714,9 @@ class TestQueryEngineReaperWiring:
                     )
                 },
             ),
-            patch("uvicorn.run") as mock_uvicorn_run,
+            patch(
+                "litellm.proxy.proxy_cli.ProxyInitializationHelpers._run_uvicorn_server"
+            ) as mock_run_uvicorn,
             patch(
                 "litellm.proxy.proxy_cli.start_query_engine_reaper"
             ) as mock_start_reaper,
@@ -1681,7 +1730,7 @@ class TestQueryEngineReaperWiring:
                 "port": 8000,
             }
             result = runner.invoke(run_server, args)
-        return result, mock_uvicorn_run, mock_start_reaper
+        return result, mock_run_uvicorn, mock_start_reaper
 
     def test_multi_worker_uvicorn_starts_reaper(self):
         result, mock_uvicorn_run, mock_start_reaper = self._invoke_run_server(

--- a/uv.lock
+++ b/uv.lock
@@ -4565,7 +4565,7 @@ requires-dist = [
     { name = "starlette", marker = "extra == 'proxy'", specifier = ">=1.0.1,<2.0" },
     { name = "tiktoken", specifier = ">=0.8.0,<1.0" },
     { name = "tokenizers", specifier = ">=0.21.0,<1.0" },
-    { name = "uvicorn", marker = "extra == 'proxy'", specifier = ">=0.33.0,<1.0" },
+    { name = "uvicorn", marker = "extra == 'proxy'", specifier = ">=0.51.0,<1.0" },
     { name = "uvloop", marker = "sys_platform != 'win32' and extra == 'proxy'", specifier = ">=0.21.0,<1.0" },
     { name = "websockets", marker = "extra == 'proxy'", specifier = ">=15.0.1,<16.0" },
 ]


### PR DESCRIPTION
## TLDR

Problem this solves:

- Multi-worker startup failures currently return exit code 0
- Orchestrators treat the failed boot as a clean shutdown

How it solves it:

- Runs the multi-worker supervisor directly so child exit status is visible
- Propagates Uvicorn's startup failure code back to the LiteLLM CLI

## User Flow

Before: a proxy with an invalid startup configuration can disappear while its process reports success

1. An operator runs `litellm --config config.yaml --port 4000 --num_workers 2`
2. Startup validation fails, the workers log the error, and nothing listens on port 4000
3. The command exits with status 0, so the orchestrator treats the deployment as cleanly stopped

After: the same failed boot is reported as a failure

1. An operator runs `litellm --config config.yaml --port 4000 --num_workers 2`
2. Startup validation fails, the workers log the error, and nothing listens on port 4000
3. The command exits with status 3, so the orchestrator can restart and alert

## Relevant issues

Fixes #37948

## Linear ticket


## Pre-Submission checklist

- [x] I have added a focused regression test
- [ ] My PR passes all required CI/CD checks
- [x] My PR's scope is isolated to multi-worker startup status propagation
- [ ] I have received a Greptile Confidence Score of at least 4/5

## Screenshots / Proof of Fix

The failure path has no successful HTTP response or provider call. The focused regression drives the same supervisor contract used by Uvicorn 0.51.0 and verifies that an exit code of 3 reaches the CLI while the bound socket is closed

### After (539dd77)

1. `python -m py_compile litellm/proxy/proxy_cli.py tests/test_litellm/proxy/test_proxy_cli.py`
2. `uvx --with uvicorn==0.51.0 --with httpx --with python-dotenv --with pydantic --with click python -`
3. Output: `multi-worker startup exit propagation check passed`

## Type

Bug Fix

## Caveats (if any)

- The proxy extra now requires Uvicorn 0.51.0 or newer
- Existing single-worker and reload paths continue using `uvicorn.run`

## QA runbook


### Final Attestation

- [x] The regression test fails if startup code 3 is not propagated