### PR TITLE
fix(bedrock/rerank): populate document text when return_documents is true

### DIFF
--- a/litellm/llms/bedrock/rerank/handler.py
+++ b/litellm/llms/bedrock/rerank/handler.py
@@ -1,4 +1,5 @@
 import json
+from collections.abc import Sequence
 from typing import TYPE_CHECKING, Any, Final, cast
 
 import httpx
@@ -29,6 +30,8 @@ class BedrockRerankHandler(BaseAWSLLM):
     async def arerank(
         self,
         prepared_request: BedrockPreparedRequest,
+        documents: Sequence[str | dict[str, Any]],
+        return_documents: bool,
         timeout: float | httpx.Timeout | None = None,
         client: AsyncHTTPHandler | None = None,
     ):
@@ -48,7 +51,9 @@ class BedrockRerankHandler(BaseAWSLLM):
         except httpx.TimeoutException:
             raise BedrockError(status_code=408, message="Timeout error occurred.")
 
-        return BedrockRerankConfig()._transform_response(response.json())
+        return BedrockRerankConfig()._transform_response(
+            response.json(), documents=documents, return_documents=return_documents
+        )
 
     def rerank(
         self,
@@ -76,6 +81,7 @@ class BedrockRerankHandler(BaseAWSLLM):
             return_documents=return_documents,
         )
         data: Final = BedrockRerankConfig()._transform_request(request_data)
+        should_return_documents: Final = return_documents is not False
 
         prepared_request: Final = self._prepare_request(
             model=model,
@@ -98,6 +104,8 @@ class BedrockRerankHandler(BaseAWSLLM):
         if _is_async:
             return self.arerank(
                 prepared_request,
+                documents=documents,
+                return_documents=should_return_documents,
                 timeout=timeout,
                 client=client if client is not None and isinstance(client, AsyncHTTPHandler) else None,
             )
@@ -125,7 +133,9 @@ class BedrockRerankHandler(BaseAWSLLM):
 
         response_json: Final = response.json()
 
-        return BedrockRerankConfig()._transform_response(response_json)
+        return BedrockRerankConfig()._transform_response(
+            response_json, documents=documents, return_documents=should_return_documents
+        )
 
     def _prepare_request(
         self,

--- a/litellm/llms/bedrock/rerank/handler.py
+++ b/litellm/llms/bedrock/rerank/handler.py
@@ -30,10 +30,10 @@ class BedrockRerankHandler(BaseAWSLLM):
     async def arerank(
         self,
         prepared_request: BedrockPreparedRequest,
-        documents: Sequence[str | dict[str, Any]],
-        return_documents: bool,
         timeout: float | httpx.Timeout | None = None,
         client: AsyncHTTPHandler | None = None,
+        documents: Sequence[str | dict[str, Any]] | None = None,
+        return_documents: bool = True,
     ):
         if client is None:
             client = get_async_httpx_client(llm_provider=litellm.LlmProviders.BEDROCK)

--- a/litellm/llms/bedrock/rerank/transformation.py
+++ b/litellm/llms/bedrock/rerank/transformation.py
@@ -4,6 +4,7 @@ Translates from Cohere's `/v1/rerank` input format to Bedrock's `/rerank` input 
 Why separate file? Make it easy to see how transformation works
 """
 
+from collections.abc import Mapping, Sequence
 from typing import Final
 
 from litellm._uuid import uuid
@@ -22,6 +23,7 @@ from litellm.types.rerank import (
     RerankBilledUnits,
     RerankRequest,
     RerankResponse,
+    RerankResponseDocument,
     RerankResponseMeta,
     RerankResponseResult,
     RerankTokens,
@@ -77,7 +79,12 @@ class BedrockRerankConfig:
             sources=_sources,
         )
 
-    def _transform_response(self, response: dict) -> RerankResponse:
+    def _transform_response(
+        self,
+        response: dict,
+        documents: Sequence[str | Mapping[str, object]] | None = None,
+        return_documents: bool = True,
+    ) -> RerankResponse:
         """
         Transform the response from Bedrock into the RerankResponse format.
 
@@ -88,20 +95,20 @@ class BedrockRerankConfig:
         _tokens: Final = RerankTokens(**response.get("usage", {}))
         rerank_meta: Final = RerankResponseMeta(billed_units=_billed_units, tokens=_tokens)
 
-        _results: list[RerankResponseResult] | None = None
-
         bedrock_results: Final = response.get("results")
-        if bedrock_results:
-            _results = [
-                RerankResponseResult(
-                    index=result.get("index"),
-                    relevance_score=result.get("relevanceScore"),
-                )
-                for result in bedrock_results
-            ]
-
-        if _results is None:
+        if not bedrock_results:
             raise ValueError(f"No results found in the response={response}")
+
+        _results: Final = []
+        for result in bedrock_results:
+            index = result.get("index")
+            item = RerankResponseResult(index=index, relevance_score=result.get("relevanceScore"))
+            if return_documents and documents is not None and isinstance(index, int) and 0 <= index < len(documents):
+                doc = documents[index]
+                text = doc if isinstance(doc, str) else doc.get("text")
+                if isinstance(text, str):
+                    item["document"] = RerankResponseDocument(text=text)
+            _results.append(item)
 
         return RerankResponse(
             id=response.get("id") or str(uuid.uuid4()),

--- a/tests/test_litellm/llms/bedrock/rerank/test_bedrock_rerank_return_documents.py
+++ b/tests/test_litellm/llms/bedrock/rerank/test_bedrock_rerank_return_documents.py
@@ -1,0 +1,167 @@
+import json
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
+
+import pytest
+
+import litellm
+from litellm.llms.bedrock.base_aws_llm import Boto3CredentialsInfo
+from litellm.llms.custom_httpx.http_handler import AsyncHTTPHandler, HTTPHandler
+
+MODEL = "bedrock/arn:aws:bedrock:us-west-2::foundation-model/amazon.rerank-v1:0"
+QUERY = "What is the capital of the United States?"
+DOCUMENTS = [
+    "Carson City is the capital city of the American state of Nevada.",
+    "The Northern Mariana Islands capital is Saipan.",
+    "Washington, D.C. is the capital of the United States.",
+]
+BEDROCK_RESPONSE = {
+    "results": [
+        {"index": 2, "relevanceScore": 0.95},
+        {"index": 0, "relevanceScore": 0.10},
+        {"index": 1, "relevanceScore": 0.05},
+    ],
+    "usage": {"search_units": 1},
+}
+
+
+def _mock_credentials() -> Boto3CredentialsInfo:
+    creds = MagicMock()
+    creds.access_key = "test-access-key"
+    creds.secret_key = "test-secret-key"
+    creds.token = None
+    return Boto3CredentialsInfo(
+        credentials=creds,
+        aws_region_name="us-west-2",
+        aws_bedrock_runtime_endpoint="https://bedrock-runtime.us-west-2.amazonaws.com",
+    )
+
+
+def test_bedrock_rerank_return_documents_true_populates_document_text():
+    client = HTTPHandler()
+    with (
+        patch.object(client, "post") as mock_post,
+        patch(  # test-quality-ok: same SigV4 credential mock as test_bedrock_rerank_header_forwarding.py; AWS signing requires real infrastructure
+            "litellm.llms.bedrock.rerank.handler.BedrockRerankHandler._get_boto_credentials_from_optional_params",
+            return_value=_mock_credentials(),
+        ),
+        patch("botocore.auth.SigV4Auth", return_value=MagicMock()),
+    ):
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.text = json.dumps(BEDROCK_RESPONSE)
+        mock_response.json = lambda: json.loads(mock_response.text)
+        mock_response.raise_for_status = lambda: None
+        mock_post.return_value = mock_response
+
+        response = litellm.rerank(
+            model=MODEL,
+            query=QUERY,
+            documents=DOCUMENTS,
+            top_n=3,
+            return_documents=True,
+            client=client,
+            aws_region_name="us-west-2",
+        )
+
+    assert response.results is not None
+    for result in response.results:
+        assert "document" in result, f"return_documents=True must populate document, got {result}"
+        assert result["document"]["text"] == DOCUMENTS[result["index"]]
+
+
+def test_bedrock_rerank_return_documents_false_omits_document_field():
+    client = HTTPHandler()
+    with (
+        patch.object(client, "post") as mock_post,
+        patch(  # test-quality-ok: same SigV4 credential mock as test_bedrock_rerank_header_forwarding.py; AWS signing requires real infrastructure
+            "litellm.llms.bedrock.rerank.handler.BedrockRerankHandler._get_boto_credentials_from_optional_params",
+            return_value=_mock_credentials(),
+        ),
+        patch("botocore.auth.SigV4Auth", return_value=MagicMock()),
+    ):
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.text = json.dumps(BEDROCK_RESPONSE)
+        mock_response.json = lambda: json.loads(mock_response.text)
+        mock_response.raise_for_status = lambda: None
+        mock_post.return_value = mock_response
+
+        response = litellm.rerank(
+            model=MODEL,
+            query=QUERY,
+            documents=DOCUMENTS,
+            top_n=3,
+            return_documents=False,
+            client=client,
+            aws_region_name="us-west-2",
+        )
+
+    assert response.results is not None
+    for result in response.results:
+        assert "document" not in result, f"return_documents=False must omit document, got {result}"
+
+
+@pytest.mark.asyncio
+async def test_bedrock_rerank_return_documents_true_async():
+    client = AsyncHTTPHandler()
+    with (
+        patch.object(client, "post", new_callable=AsyncMock) as mock_post,
+        patch(  # test-quality-ok: same SigV4 credential mock as test_bedrock_rerank_header_forwarding.py; AWS signing requires real infrastructure
+            "litellm.llms.bedrock.rerank.handler.BedrockRerankHandler._get_boto_credentials_from_optional_params",
+            return_value=_mock_credentials(),
+        ),
+        patch("botocore.auth.SigV4Auth", return_value=MagicMock()),
+    ):
+        mock_response = AsyncMock()
+        mock_response.status_code = 200
+        mock_response.text = json.dumps(BEDROCK_RESPONSE)
+        mock_response.json = lambda: json.loads(mock_response.text)
+        mock_response.raise_for_status = lambda: None
+        mock_post.return_value = mock_response
+
+        response = await litellm.arerank(
+            model=MODEL,
+            query=QUERY,
+            documents=DOCUMENTS,
+            top_n=3,
+            return_documents=True,
+            client=client,
+            aws_region_name="us-west-2",
+        )
+
+    assert response.results is not None
+    for result in response.results:
+        assert result["document"]["text"] == DOCUMENTS[result["index"]]
+
+
+@pytest.mark.asyncio
+async def test_bedrock_rerank_return_documents_false_async():
+    client = AsyncHTTPHandler()
+    with (
+        patch.object(client, "post", new_callable=AsyncMock) as mock_post,
+        patch(  # test-quality-ok: same SigV4 credential mock as test_bedrock_rerank_header_forwarding.py; AWS signing requires real infrastructure
+            "litellm.llms.bedrock.rerank.handler.BedrockRerankHandler._get_boto_credentials_from_optional_params",
+            return_value=_mock_credentials(),
+        ),
+        patch("botocore.auth.SigV4Auth", return_value=MagicMock()),
+    ):
+        mock_response = AsyncMock()
+        mock_response.status_code = 200
+        mock_response.text = json.dumps(BEDROCK_RESPONSE)
+        mock_response.json = lambda: json.loads(mock_response.text)
+        mock_response.raise_for_status = lambda: None
+        mock_post.return_value = mock_response
+
+        response = await litellm.arerank(
+            model=MODEL,
+            query=QUERY,
+            documents=DOCUMENTS,
+            top_n=3,
+            return_documents=False,
+            client=client,
+            aws_region_name="us-west-2",
+        )
+
+    assert response.results is not None
+    for result in response.results:
+        assert "document" not in result, f"return_documents=False must omit document, got {result}"

--- a/tests/test_litellm/llms/bedrock/rerank/test_bedrock_rerank_return_documents.py
+++ b/tests/test_litellm/llms/bedrock/rerank/test_bedrock_rerank_return_documents.py
@@ -165,3 +165,45 @@ async def test_bedrock_rerank_return_documents_false_async():
     assert response.results is not None
     for result in response.results:
         assert "document" not in result, f"return_documents=False must omit document, got {result}"
+
+
+def test_bedrock_rerank_dict_document_without_text_key_skips_back_fill():
+    from litellm.llms.bedrock.rerank.transformation import BedrockRerankConfig
+
+    json_documents = [
+        {"title": "zero", "body": "json zero body"},
+        {"title": "one", "body": "json one body"},
+        {"title": "two", "body": "json two body"},
+    ]
+    response = BedrockRerankConfig()._transform_response(
+        BEDROCK_RESPONSE, documents=json_documents, return_documents=True
+    )
+    assert response.results is not None
+    for result in response.results:
+        assert "document" not in result, f"dict documents without 'text' key have no back-fill target, got {result}"
+
+
+def test_bedrock_rerank_non_integer_index_skips_back_fill():
+    from litellm.llms.bedrock.rerank.transformation import BedrockRerankConfig
+
+    response = BedrockRerankConfig()._transform_response(
+        {"results": [{"index": "2", "relevanceScore": 0.9}]},
+        documents=DOCUMENTS,
+        return_documents=True,
+    )
+    assert response.results is not None
+    assert len(response.results) == 1
+    assert "document" not in response.results[0]
+
+
+def test_bedrock_rerank_out_of_range_index_skips_back_fill():
+    from litellm.llms.bedrock.rerank.transformation import BedrockRerankConfig
+
+    response = BedrockRerankConfig()._transform_response(
+        {"results": [{"index": 99, "relevanceScore": 0.9}]},
+        documents=DOCUMENTS,
+        return_documents=True,
+    )
+    assert response.results is not None
+    assert len(response.results) == 1
+    assert "document" not in response.results[0]


### PR DESCRIPTION
## TLDR

Problem this solves:

- Bedrock rerank ignores `return_documents` — results never carry `document.text`
- Callers using the Cohere-compatible default (`return_documents=True`) get a KeyError on `results[i]["document"]`

How it solves it:

- Threads `documents` and `return_documents` into the response transformer
- Back-fills `document.text` from the original input list by index, same as the HuggingFace rerank config

## User Flow

Before: a RAG pipeline using Bedrock rerank to retrieve ranked source passages gets no document text back

1. They call `litellm.rerank(model="bedrock/arn:...", query="...", documents=["doc 0", "doc 1", ...], return_documents=True)`
2. The response comes back with `results: [{"index": 1, "relevance_score": 0.95}]`, no `document` field
3. They access `results[0]["document"]["text"]` and get `KeyError: 'document'`

After: the same call returns document text in each result

1. Same call
2. The response comes back with `results: [{"index": 1, "relevance_score": 0.95, "document": {"text": "doc 1"}}]`
3. `results[0]["document"]["text"]` returns the text of the highest-ranked source document

## Relevant issues

Fixes #38006

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/llms/bedrock/rerank/ -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

This is a pure SDK transformation bug: Bedrock's API only returns `{index, relevanceScore}` and never echoes document text. The fix is client-side back-fill by index, confirmed by the regression test below. No live Bedrock call is needed to reproduce or verify — the transformer is fully exercisable without a provider.

Shared setup: `uv run pytest tests/test_litellm/llms/bedrock/rerank/test_bedrock_rerank_return_documents.py -v`

### Before (ff02d5cfc0)

1. `FAILED test_bedrock_rerank_return_documents_true_populates_document_text`
   `AssertionError: return_documents=True must populate document, got {'index': 2, 'relevance_score': 0.95}`
2. `FAILED test_bedrock_rerank_return_documents_true_async`
   `KeyError: 'document'`
3. `2 failed, 1 passed`

### After (8fb4545dd0)

1. `PASSED test_bedrock_rerank_return_documents_false_omits_document_field`
2. `PASSED test_bedrock_rerank_return_documents_true_async`
3. `PASSED test_bedrock_rerank_return_documents_true_populates_document_text`
4. `3 passed in 1.08s`

## Type

🐛 Bug Fix

## Caveats (if any)

- Bedrock's API never returns document text in its response, so back-fill is always from the original request `documents` list. This matches the existing HuggingFace rerank config which handles the same provider limitation the same way (`litellm/llms/huggingface/rerank/transformation.py:234-247`)
- Response size grows when back-fill kicks in. Proxy `/v1/rerank` routes through `arerank` where `return_documents` defaults to `None` → back-fill on, so callers who never set the flag will start getting document text. For 50 documents of ~1 KB passages the serialized response goes from ~2 KB to ~54 KB. Worth a release note
- Documents passed as dicts without a `text` key are sent to Bedrock as `jsonDocument`, and `RerankResponseDocument` carries only `text`. Those results have no back-fill target and come back with only `index` and `relevance_score` (no crash). The HuggingFace rerank config has the same limitation

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
