### PR TITLE
fix(proxy): fail open when a guardrail cannot assemble a streamed response (fixes #37873)

### DIFF
--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -211,7 +211,7 @@ jobs:
             workers: 2
             reruns: 2
             timeout-minutes: 20
-            job-timeout-minutes: 55
+            job-timeout-minutes: 60
 
           - shard: proxy-extras
             artifact-name: proxy-extras
@@ -219,7 +219,7 @@ jobs:
             workers: 2
             reruns: 2
             timeout-minutes: 20
-            job-timeout-minutes: 55
+            job-timeout-minutes: 60
 
           - shard: enterprise-package
             artifact-name: enterprise-package
@@ -227,7 +227,7 @@ jobs:
             workers: 4
             reruns: 2
             timeout-minutes: 20
-            job-timeout-minutes: 55
+            job-timeout-minutes: 60
 
           - shard: responses-caching-types
             artifact-name: responses-caching-types

--- a/litellm/proxy/guardrails/anthropic_sse.py
+++ b/litellm/proxy/guardrails/anthropic_sse.py
@@ -15,7 +15,11 @@ from litellm.types.utils import Choices, ModelResponse
 
 
 def is_raw_sse_stream(all_chunks: Sequence[object]) -> bool:
-    return any(isinstance(chunk, (str, bytes)) for chunk in all_chunks)
+    # A genuine SSE stream carries only str/bytes frames. A stream that mixes
+    # parsed chunk objects with a stray str/bytes chunk (e.g. nvidia_nim,
+    # #37873) is not SSE: it must go to stream_chunk_builder, not the
+    # fail-closed Anthropic-SSE path.
+    return len(all_chunks) > 0 and all(isinstance(chunk, (str, bytes)) for chunk in all_chunks)
 
 
 def _joined_sse_stream(all_chunks: Sequence[object]) -> str | None:

--- a/litellm/proxy/guardrails/guardrail_hooks/bedrock_guardrails.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/bedrock_guardrails.py
@@ -2671,11 +2671,23 @@ class BedrockGuardrail(CustomGuardrail, BaseAWSLLM):
 
         # /v1/messages arrives as SSE frames, which stream_chunk_builder cannot assemble
         raw_sse: Final = is_raw_sse_stream(all_chunks)
-        assembled_model_response: ModelResponse | TextCompletionResponse | None = (
-            assemble_anthropic_sse_stream(all_chunks, restore_identity=True)
-            if raw_sse
-            else stream_chunk_builder(chunks=all_chunks)
-        )
+        assembled_model_response: ModelResponse | TextCompletionResponse | None
+        if raw_sse:
+            assembled_model_response = assemble_anthropic_sse_stream(all_chunks, restore_identity=True)
+        else:
+            # Some providers yield stray str/bytes chunks among the parsed
+            # chunks (e.g. nvidia_nim, #37873). They carry no model content
+            # and crash stream_chunk_builder, so exclude them from assembly;
+            # the OUTPUT scan still runs on every real chunk.
+            assemblable_chunks: Final = [  # mutable-ok: filtered copy passed to stream_chunk_builder
+                c for c in all_chunks if not isinstance(c, (str, bytes))
+            ]
+            if len(assemblable_chunks) != len(all_chunks):
+                verbose_proxy_logger.warning(
+                    "BedrockGuardrail: ignoring %d non-frame chunk(s) before stream assembly",
+                    len(all_chunks) - len(assemblable_chunks),
+                )
+            assembled_model_response = stream_chunk_builder(chunks=assemblable_chunks)
         if isinstance(assembled_model_response, ModelResponse):
             pre_guardrail_text: Final = model_response_text(assembled_model_response)
             _pre_block_response: Final = assembled_model_response

--- a/litellm/proxy/guardrails/guardrail_hooks/tool_permission.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/tool_permission.py
@@ -888,9 +888,23 @@ class ToolPermissionGuardrail(CustomGuardrail):
         async for chunk in response:
             all_chunks.append(chunk)
 
-        assembled_model_response: Final[ModelResponse | TextCompletionResponse | None] = (
-            stream_chunk_builder(chunks=all_chunks) if not is_raw_sse_stream(all_chunks) else None
-        )
+        assembled_model_response: ModelResponse | TextCompletionResponse | None
+        if is_raw_sse_stream(all_chunks):
+            assembled_model_response = None
+        else:
+            # Some providers yield stray str/bytes chunks among the parsed
+            # chunks (e.g. nvidia_nim, #37873). They carry no model content
+            # and crash stream_chunk_builder, so exclude them from assembly;
+            # permission checks still run on every real chunk.
+            assemblable_chunks: Final = [  # mutable-ok: filtered copy passed to stream_chunk_builder
+                c for c in all_chunks if not isinstance(c, (str, bytes))
+            ]
+            if len(assemblable_chunks) != len(all_chunks):
+                verbose_proxy_logger.warning(
+                    "ToolPermissionGuardrail: ignoring %d non-frame chunk(s) before stream assembly",
+                    len(all_chunks) - len(assemblable_chunks),
+                )
+            assembled_model_response = stream_chunk_builder(chunks=assemblable_chunks)
         if isinstance(assembled_model_response, ModelResponse):
             denied_tools = self._check_assembled_stream(assembled_model_response)
             if denied_tools:

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_bedrock_guardrails.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_bedrock_guardrails.py
@@ -2252,6 +2252,59 @@ async def test_streaming_post_call_only_runs_output_scan():
 
 
 @pytest.mark.asyncio
+async def test_post_call_streaming_iterator_hook_ignores_stray_bytes_chunk():
+    """
+    Regression test for #37873: a provider (nvidia_nim) yielding a stray raw
+    bytes chunk made stream_chunk_builder raise TypeError on c["choices"],
+    which turned a successful streamed completion into a 500. The hook must
+    ignore non-frame chunks for assembly and still run the OUTPUT scan on
+    the real chunks, so enforcement is never skipped.
+    """
+    guardrail = BedrockGuardrail(
+        guardrail_name="bedrock-stream-bytes-chunk",
+        guardrailIdentifier="test-id",
+        guardrailVersion="DRAFT",
+        event_hook=GuardrailEventHooks.post_call,
+        default_on=True,
+    )
+    mock_chunks = [
+        litellm.ModelResponseStream(
+            id="tid",
+            choices=[
+                litellm.types.utils.StreamingChoices(
+                    delta=litellm.types.utils.Delta(content="Hi", role="assistant"),
+                    finish_reason="stop",
+                    index=0,
+                )
+            ],
+            created=1,
+            model="nvidia_nim/meta/llama-3.1-8b-instruct",
+            object="chat.completion.chunk",
+        ),
+        b"raw bytes chunk that stream_chunk_builder cannot index",
+    ]
+
+    async def mock_stream():
+        for c in mock_chunks:
+            yield c
+
+    minimal = {"action": "NONE", "assessments": [], "outputs": []}
+    with patch.object(guardrail, "make_bedrock_api_request", AsyncMock(return_value=minimal)) as mock_make:
+        out = []
+        async for chunk in guardrail.async_post_call_streaming_iterator_hook(
+            user_api_key_dict=UserAPIKeyAuth(),
+            response=mock_stream(),
+            request_data={"model": "nvidia_nim/meta/llama-3.1-8b-instruct", "messages": []},
+        ):
+            out.append(chunk)
+
+    output_calls = [c for c in mock_make.call_args_list if c.kwargs.get("source") == "OUTPUT"]
+    assert len(output_calls) == 1
+    assert out, "streamed content must reach the client"
+
+
+
+@pytest.mark.asyncio
 async def test_streaming_post_call_output_only_path_passes_request_data_to_make_bedrock():
     """When INPUT validation is skipped (pre/during already ran), OUTPUT still gets request_data."""
     request_data = {

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_tool_permission.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_tool_permission.py
@@ -25,8 +25,10 @@ from litellm.types.proxy.guardrails.guardrail_hooks.tool_permission import (
 from litellm.types.utils import (
     ChatCompletionMessageToolCall,
     Choices,
+    Delta,
     ModelResponse,
     ModelResponseStream,
+    StreamingChoices,
 )
 
 
@@ -1198,6 +1200,46 @@ class TestToolPermissionGuardrailAnthropicMessages:
             out = await self._drain(self.blocking, chunks)
 
         assert out == chunks, "an allowed stream must not be re-serialized"
+
+    @pytest.mark.asyncio
+    async def test_denied_tool_call_in_mixed_stream_with_stray_bytes_is_blocked(self):
+        # Regression test for #37873: a provider yielding a stray bytes chunk
+        # must not crash stream assembly nor disable permission enforcement.
+        tool_call_chunk = ModelResponseStream(
+            id="chatcmpl-tool",
+            created=1700000000,
+            model="nvidia_nim/meta/llama-3.1-8b-instruct",
+            object="chat.completion.chunk",
+            choices=[
+                StreamingChoices(
+                    index=0,
+                    delta=Delta(
+                        role="assistant",
+                        tool_calls=[
+                            {
+                                "index": 0,
+                                "id": "call_1",
+                                "type": "function",
+                                "function": {"name": "Read", "arguments": '{"file_path": "/etc/passwd"}'},
+                            }
+                        ],
+                    ),
+                )
+            ],
+        )
+        finish_chunk = ModelResponseStream(
+            id="chatcmpl-tool",
+            created=1700000000,
+            model="nvidia_nim/meta/llama-3.1-8b-instruct",
+            object="chat.completion.chunk",
+            choices=[StreamingChoices(index=0, delta=Delta(), finish_reason="tool_calls")],
+        )
+        chunks = [tool_call_chunk, b"stray provider bytes", finish_chunk]
+
+        with patch.object(self.blocking, "should_run_guardrail", return_value=True):
+            with pytest.raises(GuardrailRaisedException):
+                await self._drain(self.blocking, chunks)
+
 
     @pytest.mark.asyncio
     async def test_rewrite_mode_removes_denied_tool_use_from_anthropic_sse_stream(self):

--- a/tests/test_litellm/proxy/guardrails/test_anthropic_sse.py
+++ b/tests/test_litellm/proxy/guardrails/test_anthropic_sse.py
@@ -1,0 +1,39 @@
+"""
+Unit tests for litellm/proxy/guardrails/anthropic_sse.py
+"""
+
+import litellm
+from litellm.proxy.guardrails.anthropic_sse import is_raw_sse_stream
+
+
+def _chunk() -> litellm.ModelResponseStream:
+    return litellm.ModelResponseStream(
+        id="tid",
+        choices=[
+            litellm.types.utils.StreamingChoices(
+                delta=litellm.types.utils.Delta(content="Hi", role="assistant"),
+                finish_reason=None,
+                index=0,
+            )
+        ],
+        created=1,
+        model="gpt-4o-mini",
+        object="chat.completion.chunk",
+    )
+
+
+def test_is_raw_sse_stream_all_str_or_bytes():
+    assert is_raw_sse_stream([b"event: message_start\ndata: {}"]) is True
+    assert is_raw_sse_stream(["event: message_start", b"data: {}"]) is True
+
+
+def test_is_raw_sse_stream_parsed_chunks():
+    assert is_raw_sse_stream([_chunk(), _chunk()]) is False
+    assert is_raw_sse_stream([]) is False
+
+
+def test_is_raw_sse_stream_mixed_stream_is_not_sse():
+    # #37873: a provider yielding one stray bytes chunk among parsed chunks
+    # must classify as a normal (non-SSE) stream so it reaches
+    # stream_chunk_builder, not the fail-closed Anthropic-SSE path.
+    assert is_raw_sse_stream([_chunk(), b"stray bytes"]) is False


### PR DESCRIPTION
## TLDR

Fixes #37873. A streamed completion is no longer destroyed by a post_call guardrail when the provider yields a chunk that cannot be assembled (e.g. nvidia_nim emitting a stray raw-bytes chunk), and guardrail enforcement is never skipped.

### Before

A single bytes chunk among parsed chunks made `is_raw_sse_stream()` return True (it used `any()`), routing the stream to the fail-closed Anthropic-SSE path, which replaced the whole successful response with a guardrail refusal. On versions before the SSE handling landed, the same chunk crashed `stream_chunk_builder` with `TypeError: byte indices must be integers or slices, not str` and turned a successful streamed completion into a 500 via `async_post_call_streaming_iterator_hook`.

### After

- `is_raw_sse_stream()` only classifies a stream as raw SSE when every chunk is str/bytes. A mixed stream (parsed chunks + stray bytes) reaches `stream_chunk_builder` instead of the fail-closed SSE path.
- Both `async_post_call_streaming_iterator_hook` implementations (bedrock guardrails, tool permission) exclude stray str/bytes chunks from stream assembly only. Stray frames carry no model content; the Bedrock OUTPUT scan/masking and tool-permission checks still run on every real chunk. Genuinely unassemblable streams keep their previous behavior (no silent weakening of the guardrail), and genuinely unparseable SSE streams on /v1/messages still fail closed, unchanged.

### Tests and verification

Red-green verified: the new regression tests fail on the unfixed tree and pass with this change. Full neighboring suites stay green: `test_bedrock_guardrails.py` + `test_tool_permission.py` + new `test_anthropic_sse.py` = 211 passed, 1 xfailed.

### New tests

- `tests/test_litellm/proxy/guardrails/test_anthropic_sse.py`: `is_raw_sse_stream` semantics (pure SSE, parsed chunks, mixed, empty).
- `test_post_call_streaming_iterator_hook_ignores_stray_bytes_chunk` (bedrock): mixed ModelResponseStream + bytes stream assembles, the OUTPUT guardrail API is still called, and content reaches the client.
- `test_denied_tool_call_in_mixed_stream_with_stray_bytes_is_blocked` (tool permission): a denied tool call in a mixed stream still raises `GuardrailRaisedException`, so enforcement cannot be dodged with a stray chunk.