### PR TITLE
fix(realtime): two azure gpt-realtime rows price a cache read at the full input price

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -5061,8 +5061,8 @@
         "supports_tool_choice": true
     },
     "azure/gpt-realtime-2025-08-28": {
-        "cache_creation_input_audio_token_cost": 4e-06,
-        "cache_read_input_token_cost": 4e-06,
+        "cache_creation_input_audio_token_cost": 4e-07,
+        "cache_read_input_token_cost": 4e-07,
         "deprecation_date": "2027-03-02",
         "input_cost_per_audio_token": 3.2e-05,
         "input_cost_per_image": 5e-06,
@@ -5094,8 +5094,8 @@
         "supports_tool_choice": true
     },
     "azure/gpt-realtime-1.5-2026-02-23": {
-        "cache_creation_input_audio_token_cost": 4e-06,
-        "cache_read_input_token_cost": 4e-06,
+        "cache_creation_input_audio_token_cost": 4e-07,
+        "cache_read_input_token_cost": 4e-07,
         "deprecation_date": "2027-08-24",
         "input_cost_per_audio_token": 3.2e-05,
         "input_cost_per_image": 5e-06,
@@ -27914,6 +27914,7 @@
     },
     "gpt-realtime-mini": {
         "cache_creation_input_audio_token_cost": 3e-07,
+        "cache_read_input_token_cost": 6e-08,
         "cache_read_input_audio_token_cost": 3e-07,
         "deprecation_date": "2027-01-20",
         "input_cost_per_audio_token": 1e-05,

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -5061,8 +5061,8 @@
         "supports_tool_choice": true
     },
     "azure/gpt-realtime-2025-08-28": {
-        "cache_creation_input_audio_token_cost": 4e-06,
-        "cache_read_input_token_cost": 4e-06,
+        "cache_creation_input_audio_token_cost": 4e-07,
+        "cache_read_input_token_cost": 4e-07,
         "deprecation_date": "2027-03-02",
         "input_cost_per_audio_token": 3.2e-05,
         "input_cost_per_image": 5e-06,
@@ -5094,8 +5094,8 @@
         "supports_tool_choice": true
     },
     "azure/gpt-realtime-1.5-2026-02-23": {
-        "cache_creation_input_audio_token_cost": 4e-06,
-        "cache_read_input_token_cost": 4e-06,
+        "cache_creation_input_audio_token_cost": 4e-07,
+        "cache_read_input_token_cost": 4e-07,
         "deprecation_date": "2027-08-24",
         "input_cost_per_audio_token": 3.2e-05,
         "input_cost_per_image": 5e-06,
@@ -27914,6 +27914,7 @@
     },
     "gpt-realtime-mini": {
         "cache_creation_input_audio_token_cost": 3e-07,
+        "cache_read_input_token_cost": 6e-08,
         "cache_read_input_audio_token_cost": 3e-07,
         "deprecation_date": "2027-01-20",
         "input_cost_per_audio_token": 1e-05,


### PR DESCRIPTION
### `cache_read_input_token_cost` equal to `input_cost_per_token`

`azure/gpt-realtime-2025-08-28` and `azure/gpt-realtime-1.5-2026-02-23` both store:

```
"input_cost_per_token": 4e-06,
"cache_read_input_token_cost": 4e-06,
```

A cache read priced at the full input price means the discount never applies. Every other realtime row in the file prices a cache read at 50% (the `gpt-4o` family) or 10% (the `gpt-realtime` family) of input — none at 100%.

Their OpenAI twin settles it. `gpt-realtime-2025-08-28` carries the **same seven cost fields with the same values**, except the two cache fields:

| field | `gpt-realtime-2025-08-28` | `azure/gpt-realtime-2025-08-28` |
|---|---|---|
| `input_cost_per_token` | `4e-06` | `4e-06` |
| `input_cost_per_audio_token` | `3.2e-05` | `3.2e-05` |
| `output_cost_per_token` | `1.6e-05` | `1.6e-05` |
| `output_cost_per_audio_token` | `6.4e-05` | `6.4e-05` |
| `input_cost_per_image` | `5e-06` | `5e-06` |
| `cache_read_input_token_cost` | `4e-07` | **`4e-06`** |
| `cache_creation_input_audio_token_cost` | `4e-07` | **`4e-06`** |

After this PR the two Azure rows match their twin field for field.

### `gpt-realtime-mini` has no cache-read price at all

The undated alias is missing `cache_read_input_token_cost` entirely, while both dated versions of the same model carry it:

| row | `cache_read_input_token_cost` |
|---|---|
| `gpt-realtime-mini` | *(absent)* |
| `gpt-realtime-mini-2025-10-06` | `6e-08` |
| `gpt-realtime-mini-2025-12-15` | `6e-08` |
| `azure/gpt-realtime-mini` | `6e-08` |

Anyone pinned to the floating alias is billed cached text at full input price. Set to `6e-08` to match.

### Scope

Both copies of the registry, 3 rows: 4 values corrected, 1 field added. Nothing else touched.

### Note on the earlier PR

#37932 was closed as superseded by #37902. Re-read on current main today: these rows are unchanged, and #37902's registry diff doesn't contain them — it adds schema key definitions, not these rows. Re-filed against today's main.
