### PR TITLE
fix(model-prices): correct novita gpt-oss vision support

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -46504,7 +46504,7 @@
         "supports_function_calling": true,
         "supports_parallel_function_calling": true,
         "supports_tool_choice": true,
-        "supports_vision": true,
+        "supports_vision": false,
         "supports_system_messages": true,
         "supports_response_schema": true,
         "supports_reasoning": true

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -46504,7 +46504,7 @@
         "supports_function_calling": true,
         "supports_parallel_function_calling": true,
         "supports_tool_choice": true,
-        "supports_vision": true,
+        "supports_vision": false,
         "supports_system_messages": true,
         "supports_response_schema": true,
         "supports_reasoning": true


### PR DESCRIPTION
## TLDR

Problem this solves:

- Text-only model advertised vision support
- Mirrored metadata files disagreed with provider capability

How it solves it:

- Marks vision support false in both entries

## User Flow

Before: an integrator reads LiteLLM model metadata and sees a text-only model advertised as supporting vision

1. They inspect the metadata for `novita/openai/gpt-oss-120b`
2. The entry reports `"supports_vision": true`
3. Their integration may offer image input for a text-only model

After: the same metadata accurately reports that the model does not support vision

1. They inspect the metadata for `novita/openai/gpt-oss-120b`
2. The entry reports `"supports_vision": false`
3. Their integration does not offer image input for this model

## Relevant issues

Fixes #37584

## Linear ticket

## Pre-Submission checklist

- [ ] I have added meaningful tests
- [ ] The handful of test files covering my change pass locally
- [ ] My PR passes all required CI/CD checks
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile Confidence Score of at least 4/5 before requesting a maintainer review

## Screenshots / Proof of Fix

### Before (f005afa)

1. Parsed both model metadata files
2. Each `novita/openai/gpt-oss-120b` entry reported `"supports_vision": true`

### After (5b30339)

1. Parsed both model metadata files after the correction
2. Each `novita/openai/gpt-oss-120b` entry reports `"supports_vision": false`

## Type

🐛 Bug Fix

## Caveats (if any)

## Final Attestation

- [ ] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR