### PR TITLE
perf(proxy): reduce Prisma client import time

### DIFF
--- a/litellm-proxy-extras/litellm_proxy_extras/schema.prisma
+++ b/litellm-proxy-extras/litellm_proxy_extras/schema.prisma
@@ -5,6 +5,7 @@ datasource client {
 
 generator client {
   provider = "prisma-client-py"
+  recursive_type_depth = -1
   binaryTargets = ["native", "debian-openssl-1.1.x", "debian-openssl-3.0.x", "linux-musl", "linux-musl-openssl-3.0.x"]
 }
 

--- a/litellm/proxy/schema.prisma
+++ b/litellm/proxy/schema.prisma
@@ -5,6 +5,7 @@ datasource client {
 
 generator client {
   provider = "prisma-client-py"
+  recursive_type_depth = -1
   binaryTargets = ["native", "debian-openssl-1.1.x", "debian-openssl-3.0.x", "linux-musl", "linux-musl-openssl-3.0.x"]
 }
 

--- a/schema.prisma
+++ b/schema.prisma
@@ -5,6 +5,7 @@ datasource client {
 
 generator client {
   provider = "prisma-client-py"
+  recursive_type_depth = -1
   binaryTargets = ["native", "debian-openssl-1.1.x", "debian-openssl-3.0.x", "linux-musl", "linux-musl-openssl-3.0.x"]
 }
 

--- a/tests/test_litellm/proxy/test_prisma_schema.py
+++ b/tests/test_litellm/proxy/test_prisma_schema.py
@@ -1,0 +1,20 @@
+from pathlib import Path
+from typing import Final
+
+import pytest
+
+
+REPOSITORY_ROOT: Final = Path(__file__).resolve().parents[3]
+SCHEMA_PATHS: Final = (
+    REPOSITORY_ROOT / "schema.prisma",
+    REPOSITORY_ROOT / "litellm/proxy/schema.prisma",
+    REPOSITORY_ROOT / "litellm-proxy-extras/litellm_proxy_extras/schema.prisma",
+)
+
+
+@pytest.mark.parametrize("schema_path", SCHEMA_PATHS)
+def test_prisma_client_uses_recursive_types(schema_path: Path) -> None:
+    schema: Final = schema_path.read_text(encoding="utf-8")
+    generator_settings: Final = schema.partition("generator client {")[2].partition("}")[0]
+
+    assert "recursive_type_depth = -1" in tuple(line.strip() for line in generator_settings.splitlines())

--- a/tests/test_litellm/proxy/test_prisma_schema.py
+++ b/tests/test_litellm/proxy/test_prisma_schema.py
@@ -1,3 +1,4 @@
+import re
 from pathlib import Path
 from typing import Final
 
@@ -17,4 +18,8 @@ def test_prisma_client_uses_recursive_types(schema_path: Path) -> None:
     schema: Final = schema_path.read_text(encoding="utf-8")
     generator_settings: Final = schema.partition("generator client {")[2].partition("}")[0]
 
-    assert "recursive_type_depth = -1" in tuple(line.strip() for line in generator_settings.splitlines())
+    assert re.search(
+        r"^\s*recursive_type_depth\s*=\s*-1\s*$",
+        generator_settings,
+        flags=re.MULTILINE,
+    )


### PR DESCRIPTION
## TLDR

Problem this solves:

- Database-backed startup imports 84,451 generated type classes
- Generated client import used 4.40 seconds and 1.53 GB RSS

How it solves it:

- Enable Prisma's fully recursive type generation
- Cover every packaged schema with a regression test

## User Flow

Before: a proxy admin restarts a database-backed proxy and waits longer for it to accept traffic

1. They start the proxy at `http://localhost:4000`
2. They poll `GET http://localhost:4000/health/liveliness`
3. The endpoint remains unavailable while startup consumes excess CPU and memory
4. The endpoint eventually returns `200`

After: the same proxy becomes available sooner while using less startup memory

1. They start the proxy at `http://localhost:4000`
2. They poll `GET http://localhost:4000/health/liveliness`
3. The endpoint becomes available with less startup CPU and memory
4. The endpoint returns `200`

## Relevant issues

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The focused schema test and Prisma generation pass locally
- [ ] My PR passes all required CI/CD checks
- [x] My PR's scope is as isolated as possible
- [x] I have received a Greptile Confidence Score of at least 4/5

## Screenshots / Proof of Fix

Shared setup: Python 3.11.14, Prisma 0.11.0, and the same current LiteLLM schema on both commits

### Before (f005afa14603)

1. `git show f005afa14603:schema.prisma > before.prisma`
2. `DATABASE_URL=postgresql://diagnostic:diagnostic@127.0.0.1/diagnostic uvx --from prisma==0.11.0 prisma generate --schema before.prisma` generated the client in 407 ms
3. `/usr/bin/time -l uv run --no-project --with prisma==0.11.0 python -c 'import prisma'` took 4.40 seconds with 1,531,199,488 bytes maximum RSS
4. The generated `types.py` contained 623,319 lines and 84,451 classes

### After (b98c7c828e)

1. `DATABASE_URL=postgresql://diagnostic:diagnostic@127.0.0.1/diagnostic uvx --from prisma==0.11.0 prisma generate --schema schema.prisma` generated the client in 210 ms
2. `/usr/bin/time -l uv run --no-project --with prisma==0.11.0 python -c 'import prisma'` took 1.32 seconds with 453,623,808 bytes maximum RSS
3. The generated `types.py` contained 153,737 lines and 18,147 classes

## Type

Infrastructure

## Caveats (if any)

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
