### PR TITLE
fix(ci): give the 55m unit shards the 60m the startup guard requires

### DIFF
--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -211,7 +211,7 @@ jobs:
             workers: 2
             reruns: 2
             timeout-minutes: 20
-            job-timeout-minutes: 55
+            job-timeout-minutes: 60
 
           - shard: proxy-extras
             artifact-name: proxy-extras
@@ -219,7 +219,7 @@ jobs:
             workers: 2
             reruns: 2
             timeout-minutes: 20
-            job-timeout-minutes: 55
+            job-timeout-minutes: 60
 
           - shard: enterprise-package
             artifact-name: enterprise-package
@@ -227,7 +227,7 @@ jobs:
             workers: 4
             reruns: 2
             timeout-minutes: 20
-            job-timeout-minutes: 55
+            job-timeout-minutes: 60
 
           - shard: responses-caching-types
             artifact-name: responses-caching-types


### PR DESCRIPTION
## TLDR

Problem this solves:

- code-quality is red on every PR since the startup guard's pairing fix
- Three unit shards still cap jobs at 55m against a 60m contract

How it solves it:

- caching-local, proxy-extras and enterprise-package get job-timeout-minutes 60
- Matches the 60m every sibling shard row already uses

## User Flow

Before: any contributor's PR fails the code-quality check within about a minute, regardless of what the PR changes

1. They open a PR against litellm_internal_staging and wait for checks
2. code-quality fails in about 1m with "Workflow startup invariants violated: .github/workflows/test-unit.yml: job `unit` gives pytest 20m but caps the job at 55m", repeated for three matrix rows
3. Nothing in their diff explains the failure and re-running produces the same red

After: the same PR gets a green code-quality check

1. They open the same PR and wait for checks
2. code-quality passes: the startup guard reports "Workflow startup invariants hold (setup ceiling 35m)"

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

The change is to the CI workflow itself, so the proof is the guard that gates code-quality, run exactly as CI runs it. No LLM call is involved in this check

### Before (f005afa146)

1. `python tests/code_coverage_tests/check_workflow_startup_safety.py`
2. Output: `ERROR: Workflow startup invariants violated:` followed by `.github/workflows/test-unit.yml: job 'unit' gives pytest 20m but caps the job at 55m. Setup can use up to 35m plus 5m of runner overhead, so the job deadline would preempt pytest; raise job-timeout-minutes to at least 60.` three times (caching-local, proxy-extras, enterprise-package), exit 1. The same error is visible on any current PR's code-quality job, e.g. https://github.com/BerriAI/litellm/actions/runs/32648082917/job/97215342549

### After (c970653d83)

1. `python tests/code_coverage_tests/check_workflow_startup_safety.py`
2. Output: `Workflow startup invariants hold (setup ceiling 35m)`, exit 0

## Type

🚄 Infrastructure

## Caveats (if any)

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI workflow timeout tweaks only; no application, auth, or runtime behavior changes.
> 
> **Overview**
> Raises **`job-timeout-minutes` from 55 to 60** for three unit-test matrix shards in **`test-unit.yml`**: **caching-local**, **proxy-extras**, and **enterprise-package**.
> 
> Those rows already give pytest **20m**; the **code-quality** startup guard requires the job cap to be at least **60m** (20m tests + 35m setup ceiling + 5m runner overhead). The mismatch was failing **code-quality** on every PR with invariant violations while other shards already used **60m**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c970653d83946c71d73ebc6843bf8213ec325486. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->