### PR TITLE
ci: raise three unit shards to the 60m job timeout the safety check requires

### DIFF
--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -211,7 +211,7 @@ jobs:
             workers: 2
             reruns: 2
             timeout-minutes: 20
-            job-timeout-minutes: 55
+            job-timeout-minutes: 60
 
           - shard: proxy-extras
             artifact-name: proxy-extras
@@ -219,7 +219,7 @@ jobs:
             workers: 2
             reruns: 2
             timeout-minutes: 20
-            job-timeout-minutes: 55
+            job-timeout-minutes: 60
 
           - shard: enterprise-package
             artifact-name: enterprise-package
@@ -227,7 +227,7 @@ jobs:
             workers: 4
             reruns: 2
             timeout-minutes: 20
-            job-timeout-minutes: 55
+            job-timeout-minutes: 60
 
           - shard: responses-caching-types
             artifact-name: responses-caching-types


### PR DESCRIPTION
## TLDR

Problem this solves:

- Three unit shards cap the job below the required floor
- `code-quality` fails on every PR against staging
- Left as is, a passing shard can be cancelled mid-run

How it solves it:

- Raise those three shards from 55m to 60m
- Matches the floor the startup safety check computes
- Every other shard in the matrix is already 60m

## User Flow

Before: a contributor opens any PR against staging and one required check fails for a reason unrelated to their change

1. They push a branch and open a PR against `litellm_internal_staging`
2. The `code-quality` check goes red within about 90 seconds
3. The log reads `Workflow startup invariants violated`, naming `job unit gives pytest 20m but caps the job at 55m`, repeated three times
4. Nothing in their diff touches `.github/`, so there is no change they can make to turn it green
5. Their PR cannot satisfy the required checks and stalls

After: the same PR sees `code-quality` pass, and only genuine problems in the contributor's own diff turn it red

1. They push a branch and open a PR against `litellm_internal_staging`
2. The `code-quality` check passes
3. The log reads `Workflow startup invariants hold (setup ceiling 35m)`

## Relevant issues

## Linear ticket

## Pre-Submission checklist

- [ ] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

No new tests: the invariant is already enforced by `tests/code_coverage_tests/check_workflow_startup_safety.py`, which is the check that catches this and is run below

## Screenshots / Proof of Fix

The gate itself is the proof. It is the same command `code-quality` runs

### Before (f005afa1460385a218be8ef1fdfa49998bf93523)

1. `git checkout f005afa146`
2. `uv run --no-sync python ./tests/code_coverage_tests/check_workflow_startup_safety.py; echo "exit=$?"`
3. Observed:

```
ERROR: Workflow startup invariants violated:
  - .github/workflows/test-unit.yml: job `unit` gives pytest 20m but caps the job at 55m. Setup can use up to 35m plus 5m of runner overhead, so the job deadline would preempt pytest; raise job-timeout-minutes to at least 60.
  - .github/workflows/test-unit.yml: job `unit` gives pytest 20m but caps the job at 55m. Setup can use up to 35m plus 5m of runner overhead, so the job deadline would preempt pytest; raise job-timeout-minutes to at least 60.
  - .github/workflows/test-unit.yml: job `unit` gives pytest 20m but caps the job at 55m. Setup can use up to 35m plus 5m of runner overhead, so the job deadline would preempt pytest; raise job-timeout-minutes to at least 60.
exit=1
```

4. The same failure as seen in CI: https://github.com/BerriAI/litellm/actions/runs/32657182427/job/97238173609

### After (08ff358c07c15e5bbc9c42f536bf4ecd698b3d09)

1. `git checkout litellm_fix_unit_shard_job_timeouts`
2. `uv run --no-sync python ./tests/code_coverage_tests/check_workflow_startup_safety.py; echo "exit=$?"`
3. Observed:

```
Workflow startup invariants hold (setup ceiling 35m)
exit=0
```

## Type

🚄 Infrastructure

## Caveats (if any)

- Raises the cap only; shards still get the same 20m pytest budget
- Does not change how long any shard actually runs

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
