### PR TITLE
fix(bedrock): forward static credentials to request signing

### DIFF
--- a/litellm/llms/custom_httpx/llm_http_handler.py
+++ b/litellm/llms/custom_httpx/llm_http_handler.py
@@ -532,7 +532,7 @@ class BaseLLMHTTPHandler:
         if extra_body is not None:
             data = {**data, **extra_body}
 
-        signing_params: Final[dict[str, object]] = {
+        signing_params: Final[dict[str, object]] = {  # mutable-ok: signer needs a fresh dict
             **litellm_params,
             **optional_params,
         }

--- a/litellm/llms/custom_httpx/llm_http_handler.py
+++ b/litellm/llms/custom_httpx/llm_http_handler.py
@@ -532,9 +532,13 @@ class BaseLLMHTTPHandler:
         if extra_body is not None:
             data = {**data, **extra_body}
 
+        signing_params: Final[dict[str, object]] = {
+            **litellm_params,
+            **optional_params,
+        }
         headers, signed_json_body = provider_config.sign_request(
             headers=headers,
-            optional_params=optional_params,
+            optional_params=signing_params,
             request_data=data,
             api_base=api_base,
             api_key=api_key,

--- a/tests/test_litellm/llms/bedrock_mantle/test_bedrock_mantle_transformation.py
+++ b/tests/test_litellm/llms/bedrock_mantle/test_bedrock_mantle_transformation.py
@@ -426,7 +426,24 @@ class TestBedrockMantleChatAuth:
         assert "Bearer" in msg
         assert "SigV4" in msg or "IAM" in msg
 
-    def test_completion_no_bearer_signs_with_sigv4_end_to_end(self, monkeypatch):
+    @pytest.mark.parametrize(
+        ("completion_kwargs", "expected_access_key", "expected_region"),
+        [
+            ({}, "AKIAEXAMPLE", "us-east-2"),
+            (
+                {
+                    "aws_access_key_id": "DEPLOYMENTKEY",
+                    "aws_secret_access_key": "deployment-secret",
+                    "aws_region_name": "eu-west-1",
+                },
+                "DEPLOYMENTKEY",
+                "eu-west-1",
+            ),
+        ],
+    )
+    def test_completion_no_bearer_signs_with_sigv4_end_to_end(
+        self, monkeypatch, completion_kwargs, expected_access_key, expected_region
+    ):
         # The full completion chain (not just sign_request in isolation) must reach
         # the SigV4 path when no Bearer token exists: with api_key=None the parent
         # validate_environment must not short-circuit before sign_request runs.
@@ -477,14 +494,16 @@ class TestBedrockMantleChatAuth:
             response = litellm.completion(
                 model="bedrock_mantle/openai.gpt-oss-120b",
                 messages=[{"role": "user", "content": "hello"}],
+                **completion_kwargs,
             )
 
         assert response.choices[0].message.content == "ok"
         assert len(requests) == 1
         authorization = requests[0]["headers"]["Authorization"]
         assert authorization.startswith("AWS4-HMAC-SHA256")
-        assert "/us-east-2/bedrock/aws4_request" in authorization
-        assert requests[0]["url"].startswith("https://bedrock-mantle.us-east-2.api.aws")
+        assert f"Credential={expected_access_key}/" in authorization
+        assert f"/{expected_region}/bedrock/aws4_request" in authorization
+        assert requests[0]["url"].startswith(f"https://bedrock-mantle.{expected_region}.api.aws")
 
 
 class TestBedrockMantleProjectHeader:


### PR DESCRIPTION
## TLDR

Problem this solves:

- Mantle chat ignored deployment AWS credentials
- Requests could inherit the proxy host identity

How it solves it:

- Signing receives deployment and request parameters together
- Existing credential precedence selects deployment credentials

## User Flow

Before: a developer using a Mantle gpt-oss deployment with static AWS keys gets a local credentials failure

1. The proxy admin configures `bedrock_mantle/openai.gpt-oss-20b` with static AWS keys
2. The developer sends `POST http://localhost:4001/v1/chat/completions` with a user message
3. The proxy returns HTTP 500 saying no usable AWS credentials exist
4. On a host with ambient IAM, the request can use that broader identity instead

After: the same request is signed with the deployment's static AWS keys

1. The proxy admin keeps the same model configuration
2. The developer sends the same chat completions request
3. Dummy keys reach Bedrock and receive HTTP 401 for an invalid security token
4. Real deployment keys can no longer be replaced by the proxy host identity

## Relevant issues

Fixes #38028

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The focused Bedrock Mantle test file passes locally
- [ ] My PR passes all required CI/CD checks
- [x] My PR's scope is as isolated as possible
- [ ] I have received a Greptile Confidence Score of at least 4/5

## Screenshots / Proof of Fix

Shared setup: public AWS documentation sample credentials, no ambient AWS credentials, and direct `bedrock_mantle/openai.gpt-oss-20b` completion against the real AWS endpoint

### Before (f005afa1460385a218be8ef1fdfa49998bf93523)

1. Run the completion with the static sample credentials and region `us-east-2`
2. The call stops locally with `RESULT=local_missing_credentials`

### After (fb8bc937ad6b2ecf43bcf10350407b6d44383b69)

1. Run the identical completion with the same credentials and region
2. AWS responds with an invalid security token and the probe reports `RESULT=reached_bedrock_invalid_security_token`

## Type

Bug Fix

## Caveats (if any)

### Final Attestation

- [x] Rebased onto the current `litellm_internal_staging` branch
- [x] Bedrock Mantle focused suite: `48 passed`
- [x] Production Ruff check/format and test-tree Ruff checks passed

- [x] The tests check deployment and ambient credential precedence across regions
