### PR TITLE
fix(proxy): reject duplicate credential names

### DIFF
--- a/litellm/proxy/credential_endpoints/endpoints.py
+++ b/litellm/proxy/credential_endpoints/endpoints.py
@@ -2,6 +2,7 @@
 CRUD endpoints for storing reusable credentials.
 """
 
+from collections.abc import Sequence
 from typing import Final
 
 from fastapi import APIRouter, Depends, HTTPException, Path, Request, Response
@@ -18,6 +19,10 @@ from litellm.repositories.credentials_repository import CredentialsRepository
 from litellm.types.utils import CreateCredentialItem, CredentialItem
 
 router: Final = APIRouter()
+
+
+def _get_credential_list() -> Sequence[CredentialItem]:
+    return litellm.credential_list
 
 
 class CredentialHelperUtils:
@@ -47,6 +52,7 @@ async def create_credential(
     fastapi_response: Response,
     credential: CreateCredentialItem,
     user_api_key_dict: UserAPIKeyAuth = Depends(user_api_key_auth),
+    credential_list: Sequence[CredentialItem] = Depends(_get_credential_list),
 ):
     """
     [BETA] endpoint. This might change unexpectedly.
@@ -56,6 +62,14 @@ async def create_credential(
     from litellm.proxy.proxy_server import llm_router, prisma_client
 
     try:
+        credential_name_exists: Final = any(
+            existing_credential.credential_name == credential.credential_name for existing_credential in credential_list
+        )
+        if credential_name_exists:
+            raise HTTPException(
+                status_code=409,
+                detail=f"Credential with name '{credential.credential_name}' already exists.",
+            )
         if prisma_client is None:
             raise HTTPException(
                 status_code=500,

--- a/litellm/proxy/credential_endpoints/endpoints.py
+++ b/litellm/proxy/credential_endpoints/endpoints.py
@@ -25,6 +25,22 @@ def _get_credential_list() -> Sequence[CredentialItem]:
     return litellm.credential_list
 
 
+async def _create_credential_record(
+    credentials_repository: CredentialsRepository,
+    data: dict[str, object],  # mutable-ok: repository create requires a concrete dict
+    credential_name: str,
+) -> None:
+    from prisma.errors import UniqueViolationError
+
+    try:
+        await credentials_repository.create(data=data)
+    except UniqueViolationError as error:
+        raise HTTPException(
+            status_code=409,
+            detail=f"Credential with name '{credential_name}' already exists.",
+        ) from error
+
+
 class CredentialHelperUtils:
     @staticmethod
     def encrypt_credential_values(credential: CredentialItem, new_encryption_key: str | None = None) -> CredentialItem:
@@ -103,12 +119,14 @@ async def create_credential(
         encrypted_credential: Final = CredentialHelperUtils.encrypt_credential_values(processed_credential)
         credentials_dict: Final = encrypted_credential.model_dump()
         credentials_dict_jsonified: Final = jsonify_object(credentials_dict)
-        await CredentialsRepository(prisma_client).create(
+        await _create_credential_record(
+            credentials_repository=CredentialsRepository(prisma_client),
             data={
                 **credentials_dict_jsonified,
                 "created_by": user_api_key_dict.user_id,
                 "updated_by": user_api_key_dict.user_id,
-            }
+            },
+            credential_name=credential.credential_name,
         )
 
         ## ADD TO LITELLM ##

--- a/tests/test_litellm/proxy/credential_endpoints/test_endpoints.py
+++ b/tests/test_litellm/proxy/credential_endpoints/test_endpoints.py
@@ -2,12 +2,16 @@
 
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import pytest
+from fastapi import HTTPException
 from fastapi.testclient import TestClient
 
+import litellm
 from litellm.proxy._types import UserAPIKeyAuth
 from litellm.proxy.auth.user_api_key_auth import user_api_key_auth
-from litellm.proxy.credential_endpoints.endpoints import _get_credential_list
+from litellm.proxy.credential_endpoints.endpoints import _create_credential_record, _get_credential_list
 from litellm.proxy.proxy_server import app
+from litellm.repositories.credentials_repository import CredentialsRepository
 from litellm.types.utils import CredentialItem
 
 client = TestClient(app)
@@ -73,6 +77,30 @@ def test_create_credential_rejects_config_defined_name_collision():
     )
 
     assert response.status_code == 409, response.text
+
+
+def test_get_credential_list_returns_the_live_list():
+    assert _get_credential_list() is litellm.credential_list
+
+
+@pytest.mark.asyncio
+async def test_create_credential_maps_database_duplicate_race_to_409():
+    from prisma.errors import UniqueViolationError
+
+    repository = MagicMock(spec=CredentialsRepository)
+    repository.create = AsyncMock(side_effect=UniqueViolationError({}, message="duplicate name"))
+    data = {"credential_name": "shared-credential"}
+
+    with pytest.raises(HTTPException) as exc_info:
+        await _create_credential_record(
+            credentials_repository=repository,
+            data=data,
+            credential_name="shared-credential",
+        )
+
+    assert exc_info.value.status_code == 409
+    assert "already exists" in exc_info.value.detail
+    repository.create.assert_awaited_once_with(data=data)
 
 
 def test_update_credential_answers_404_when_the_credential_does_not_exist():

--- a/tests/test_litellm/proxy/credential_endpoints/test_endpoints.py
+++ b/tests/test_litellm/proxy/credential_endpoints/test_endpoints.py
@@ -2,12 +2,11 @@
 
 from unittest.mock import AsyncMock, MagicMock, patch
 
-import pytest
 from fastapi.testclient import TestClient
-
 
 from litellm.proxy._types import UserAPIKeyAuth
 from litellm.proxy.auth.user_api_key_auth import user_api_key_auth
+from litellm.proxy.credential_endpoints.endpoints import _get_credential_list
 from litellm.proxy.proxy_server import app
 from litellm.types.utils import CredentialItem
 
@@ -35,19 +34,65 @@ def _patch_credential(name: str, body: dict):
             app.dependency_overrides[user_api_key_auth] = previous_override
 
 
+def _post_credential(body: dict, credential_list: tuple[CredentialItem, ...]):
+    missing = object()
+    previous_auth_override = app.dependency_overrides.get(user_api_key_auth, missing)
+    previous_list_override = app.dependency_overrides.get(_get_credential_list, missing)
+    app.dependency_overrides[user_api_key_auth] = _as_admin
+    app.dependency_overrides[_get_credential_list] = lambda: credential_list
+    try:
+        return client.post(
+            "/credentials",
+            json=body,
+            headers={"Authorization": "Bearer test-key"},
+        )
+    finally:
+        if previous_auth_override is missing:
+            app.dependency_overrides.pop(user_api_key_auth, None)
+        else:
+            app.dependency_overrides[user_api_key_auth] = previous_auth_override
+        if previous_list_override is missing:
+            app.dependency_overrides.pop(_get_credential_list, None)
+        else:
+            app.dependency_overrides[_get_credential_list] = previous_list_override
+
+
+def test_create_credential_rejects_config_defined_name_collision():
+    existing = CredentialItem(
+        credential_name="shared-credential",
+        credential_values={"api_key": "config-secret"},
+        credential_info={"description": "defined in config"},
+    )
+    response = _post_credential(
+        {
+            "credential_name": "shared-credential",
+            "credential_values": {"api_key": "replacement-secret"},
+            "credential_info": {},
+        },
+        (existing,),
+    )
+
+    assert response.status_code == 409, response.text
+
+
 def test_update_credential_answers_404_when_the_credential_does_not_exist():
     """Regression: the handler used to ``return handle_exception_on_proxy(e)``, which makes
     the exception the response body and lets FastAPI answer 200, so a write the handler
     rejected read as a success to every caller that checks the status. The dashboard's API
     client branches on the status, so it reported a failed edit as applied."""
-    with patch("litellm.proxy.proxy_server.prisma_client", MagicMock()), patch(
-        "litellm.proxy.credential_endpoints.endpoints.CredentialsRepository"
-    ) as repository:
+    with (
+        patch("litellm.proxy.proxy_server.prisma_client", MagicMock()),
+        patch("litellm.proxy.credential_endpoints.endpoints.CredentialsRepository") as repository,
+    ):
         repository.return_value.find_by_name = AsyncMock(return_value=None)
 
         response = _patch_credential(
             "definitely-not-there",
-            {"credential_name": "definitely-not-there", "credential_values": {"api_key": "sk-x"}, "credential_info": {}},
+            {
+                "credential_name": "definitely-not-there",
+                "credential_values": {"api_key": "sk-x"},
+                "credential_info": {},
+            },
         )
 
     assert response.status_code == 404, f"rejected write answered {response.status_code}: {response.text}"
@@ -73,9 +118,11 @@ def test_update_credential_still_answers_200_on_a_successful_write():
         credential_values={"api_key": "sk-old"},
         credential_info={"custom_llm_provider": "openai"},
     )
-    with patch("litellm.proxy.proxy_server.prisma_client", MagicMock()), patch(
-        "litellm.proxy.proxy_server.master_key", "sk-test-master"
-    ), patch("litellm.proxy.credential_endpoints.endpoints.CredentialsRepository") as repository:
+    with (
+        patch("litellm.proxy.proxy_server.prisma_client", MagicMock()),
+        patch("litellm.proxy.proxy_server.master_key", "sk-test-master"),
+        patch("litellm.proxy.credential_endpoints.endpoints.CredentialsRepository") as repository,
+    ):
         repository.return_value.find_by_name = AsyncMock(return_value=stored)
         repository.return_value.update_by_name = AsyncMock(return_value=None)
 


### PR DESCRIPTION
## TLDR

Problem this solves:

- Config credentials could be replaced through duplicate names

How it solves it:

- Rejects existing credential names with HTTP 409
- Maps database duplicate races to the same HTTP 409 response

## User Flow

Before: a user with credential-route access can replace an admin config credential

1. The admin starts the proxy with `openai-prod` in `credential_list`
2. The user sends `POST https://litellm-domain/credentials` with `credential_name: openai-prod`
3. The proxy returns 200 and replaces the active credential
4. Deployments using `openai-prod` now use the replacement values

After: the same request is rejected and the admin credential remains active

1. The admin starts the proxy with `openai-prod` in `credential_list`
2. The user sends `POST https://litellm-domain/credentials` with `credential_name: openai-prod`
3. The proxy returns 409 and says the credential already exists
4. Deployments using `openai-prod` keep the configured values

## Relevant issues

Fixes #38033

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The test file covering my change passes locally
- [x] My PR passes all required CI/CD checks
- [x] My PR's scope is as isolated as possible
- [x] I have received a Greptile Confidence Score of at least 4/5

## Delays in PR merge?

If delayed, I will follow up in the LiteLLM Slack review channel

## Screenshots / Proof of Fix

The Before result is the issue reporter's live reproduction with PostgreSQL. The After result is a live local proxy request using the same config credential and payload

### Before (f005afa1460385a218be8ef1fdfa49998bf93523)

1. Start the proxy with `openai-prod` defined in config and PostgreSQL enabled
2. Send `POST http://localhost:4200/credentials` with `credential_name: openai-prod`
3. The proxy returns `200 {"success":true,"message":"Credential created successfully"}`
4. `GET http://localhost:4200/credentials` shows the replacement values

### After (881ab975cef10c621adeb70536ab955f0ba42a7f)

1. Start the proxy with `openai-prod` defined in config
2. Send `POST http://127.0.0.1:4017/credentials` with `credential_name: openai-prod`
3. The proxy returns `409` with `Credential with name 'openai-prod' already exists.`
4. The request stops before any database write or in-memory replacement

## Type

Bug Fix

## Caveats (if any)

- Local After proof used the master key because PostgreSQL was unavailable

### Final Attestation

- [x] The tests cover the real config-credential collision regression
