### PR TITLE
fix(ci): raise job-timeout-minutes to 60 for 3 shards to fit pytest's own budget

### DIFF
--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -211,7 +211,7 @@ jobs:
             workers: 2
             reruns: 2
             timeout-minutes: 20
-            job-timeout-minutes: 55
+            job-timeout-minutes: 60
 
           - shard: proxy-extras
             artifact-name: proxy-extras
@@ -219,7 +219,7 @@ jobs:
             workers: 2
             reruns: 2
             timeout-minutes: 20
-            job-timeout-minutes: 55
+            job-timeout-minutes: 60
 
           - shard: enterprise-package
             artifact-name: enterprise-package
@@ -227,7 +227,7 @@ jobs:
             workers: 4
             reruns: 2
             timeout-minutes: 20
-            job-timeout-minutes: 55
+            job-timeout-minutes: 60
 
           - shard: responses-caching-types
             artifact-name: responses-caching-types


### PR DESCRIPTION
`litellm_internal_staging`'s `.github/workflows/test-unit.yml` currently fails the `check_workflow_startup_safety` invariant check on every PR targeting this branch:

```
ERROR: Workflow startup invariants violated:
  - .github/workflows/test-unit.yml: job `unit` gives pytest 20m but caps the job at 55m. Setup can use up to 35m plus 5m of runner overhead, so the job deadline would preempt pytest; raise job-timeout-minutes to at least 60.
```

Three shards (`caching-local`, `proxy-extras`, `enterprise-package`) are still at `job-timeout-minutes: 55`. This is already fixed on `main` (bumped to `60` there), it just hasn't synced down to `litellm_internal_staging` yet. This PR applies only that same minimal change to these three shards -- no other edits.

Ran `tests/code_coverage_tests/check_workflow_startup_safety.py` locally against this branch before and after: fails before, passes after (`Workflow startup invariants hold (setup ceiling 35m)`).

Noticed this while working on an unrelated docs PR (#38039) that kept failing this same pre-existing check.