### PR TITLE
fix(otel): set a body on the GenAI exception event so OTLP can encode it

### DIFF
--- a/litellm/integrations/otel/plumbing/events.py
+++ b/litellm/integrations/otel/plumbing/events.py
@@ -37,6 +37,18 @@ class GenAIEventRecorder:
         self.event_logger.emit(
             Event(
                 name=GenAIEvent.OPERATION_EXCEPTION,
+                # The body MUST be set. ``Event.body`` defaults to ``None``, and
+                # OTLP's ``AnyValue`` has no representation for ``None``: the
+                # exporter's ``_encode_value`` raises ``Invalid type <class
+                # 'NoneType'>``, and ``BatchLogRecordProcessor._export_batch``
+                # swallows that and discards the WHOLE batch — so one such event
+                # silently destroys every log record batched with it. The
+                # encoder grew a ``None`` branch in opentelemetry-exporter-otlp-
+                # proto-common 1.43.0, but litellm pins 1.28.0, so this event is
+                # unexportable as shipped. The message is the natural body for a
+                # WARN record and adds no data the attributes don't already
+                # carry.
+                body=message,
                 timestamp=timestamp_ns,
                 trace_id=span_context.trace_id,
                 span_id=span_context.span_id,

--- a/tests/test_litellm/integrations/otel/test_otel_v2_components.py
+++ b/tests/test_litellm/integrations/otel/test_otel_v2_components.py
@@ -963,7 +963,13 @@ def test_operation_exception_log_event_is_otlp_encodable():
     logs = log_exporter.get_finished_logs()
 
     # Raises "Invalid type <class 'NoneType'> of value None" when body is unset.
-    encode_logs(logs).SerializeToString()
+    request = encode_logs(logs)
+    assert request.SerializeToString()
+
+    (resource_logs,) = request.resource_logs
+    (scope_logs,) = resource_logs.scope_logs
+    (log_record,) = scope_logs.log_records
+    assert log_record.body.string_value == "rate limited"
 
 
 def test_operation_exception_log_event_body_is_never_none():

--- a/tests/test_litellm/integrations/otel/test_otel_v2_components.py
+++ b/tests/test_litellm/integrations/otel/test_otel_v2_components.py
@@ -940,6 +940,51 @@ def test_operation_exception_log_event_always_carries_required_pair():
     assert ExceptionEvent.STACKTRACE not in attributes
 
 
+def test_operation_exception_log_event_is_otlp_encodable():
+    """The event must survive the real OTLP encoder, not just an in-memory exporter.
+
+    ``Event.body`` defaults to ``None`` and OTLP's ``AnyValue`` cannot represent
+    it, so an event emitted without a body raises ``Invalid type <class
+    'NoneType'>`` inside ``encode_logs``. That happens on the exporter's batch
+    thread, where ``BatchLogRecordProcessor._export_batch`` catches it, logs it
+    and drops the WHOLE batch — every record batched alongside is lost silently.
+    Every other test here uses ``InMemoryLogExporter``, which never encodes, so
+    only an explicit encode step can catch this.
+    """
+    encode_logs = pytest.importorskip(
+        "opentelemetry.exporter.otlp.proto.common._internal._log_encoder"
+    ).encode_logs
+
+    engine, _, log_exporter = _engine_with_event_recorder()
+    engine.emit(
+        SpanRole.LLM_CALL,
+        _llm_call_data(SpanError(error_type="RateLimitError", message="rate limited")),
+    )
+    logs = log_exporter.get_finished_logs()
+
+    # Raises "Invalid type <class 'NoneType'> of value None" when body is unset.
+    encode_logs(logs).SerializeToString()
+
+
+def test_operation_exception_log_event_body_is_never_none():
+    """A batch is dropped whole on an unencodable body, so this is asserted for
+    both event shapes: with and without a stacktrace."""
+    engine, _, log_exporter = _engine_with_event_recorder()
+    engine.emit(
+        SpanRole.LLM_CALL,
+        _llm_call_data(SpanError(error_type="APIError", message="boom")),
+    )
+    engine.emit(
+        SpanRole.LLM_CALL,
+        _llm_call_data(
+            SpanError(error_type="APIError", message="boom", stack_trace="Traceback ...")
+        ),
+    )
+
+    bodies = [log.log_record.body for log in log_exporter.get_finished_logs()]
+    assert bodies == ["boom", "boom"]
+
+
 def test_operation_exception_log_event_not_emitted_on_success():
     engine, span_exporter, log_exporter = _engine_with_event_recorder()
     engine.emit(SpanRole.LLM_CALL, _llm_call_data(None))


### PR DESCRIPTION
Fixes #36863.

`Event(body=None)` is rejected by the OTLP log encoder, so no GenAI v2 exception event was ever exported. Set a body on the event so it encodes; adds a test that asserts the emitted event carries a non-None body.

Branch was posted on the issue on 2026-08-14 when PR creation was refused for this account; rebased onto current `litellm_internal_staging`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow OTel logging fix with regression tests; no auth, billing, or request-path behavior changes.
> 
> **Overview**
> **GenAI `gen_ai.client.operation.exception` log events were never successfully exported over OTLP** because `Event` was emitted with a default `body=None`, which the pinned OTLP encoder (`opentelemetry-exporter-otlp-proto-common` 1.28.0) cannot encode. That failure on the batch export thread causes `BatchLogRecordProcessor` to drop the entire log batch, not just the bad record.
> 
> The recorder now sets **`body=message`** on the WARN event (same text already on `exception.message`), restoring encodability without changing attribute semantics.
> 
> Tests add an **`encode_logs`** round-trip so in-memory exporters alone cannot miss this, plus a check that bodies are always set with and without stack traces.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 15cfe744d7da3ff3f738f8929beedc9d4321f7c3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->