### PR TITLE
fix(bedrock): back-fill rerank document text when return_documents is set

### DIFF
--- a/litellm/llms/bedrock/rerank/handler.py
+++ b/litellm/llms/bedrock/rerank/handler.py
@@ -31,6 +31,7 @@ class BedrockRerankHandler(BaseAWSLLM):
         prepared_request: BedrockPreparedRequest,
         timeout: float | httpx.Timeout | None = None,
         client: AsyncHTTPHandler | None = None,
+        request_data: RerankRequest | None = None,
     ):
         if client is None:
             client = get_async_httpx_client(llm_provider=litellm.LlmProviders.BEDROCK)
@@ -48,7 +49,7 @@ class BedrockRerankHandler(BaseAWSLLM):
         except httpx.TimeoutException:
             raise BedrockError(status_code=408, message="Timeout error occurred.")
 
-        return BedrockRerankConfig()._transform_response(response.json())
+        return BedrockRerankConfig()._transform_response(response.json(), request_data)
 
     def rerank(
         self,
@@ -98,6 +99,7 @@ class BedrockRerankHandler(BaseAWSLLM):
         if _is_async:
             return self.arerank(
                 prepared_request,
+                request_data=request_data,
                 timeout=timeout,
                 client=client if client is not None and isinstance(client, AsyncHTTPHandler) else None,
             )
@@ -125,7 +127,7 @@ class BedrockRerankHandler(BaseAWSLLM):
 
         response_json: Final = response.json()
 
-        return BedrockRerankConfig()._transform_response(response_json)
+        return BedrockRerankConfig()._transform_response(response_json, request_data)
 
     def _prepare_request(
         self,

--- a/litellm/llms/bedrock/rerank/transformation.py
+++ b/litellm/llms/bedrock/rerank/transformation.py
@@ -22,6 +22,7 @@ from litellm.types.rerank import (
     RerankBilledUnits,
     RerankRequest,
     RerankResponse,
+    RerankResponseDocument,
     RerankResponseMeta,
     RerankResponseResult,
     RerankTokens,
@@ -77,12 +78,29 @@ class BedrockRerankConfig:
             sources=_sources,
         )
 
-    def _transform_response(self, response: dict) -> RerankResponse:
+    @staticmethod
+    def _document_text(document: str | dict) -> str | None:
+        """Text of an input document, in either shape the API accepts."""
+        if isinstance(document, str):
+            return document
+        if isinstance(document, dict):
+            text = document.get("text")
+            if isinstance(text, str):
+                return text
+        return None
+
+    def _transform_response(self, response: dict, request_data: RerankRequest | None = None) -> RerankResponse:
         """
         Transform the response from Bedrock into the RerankResponse format.
 
         example input:
         {"results":[{"index":0,"relevanceScore":0.6847912669181824},{"index":1,"relevanceScore":0.5980774760246277}]}
+
+        Bedrock never echoes document text, so `document` is back-filled from
+        the request's documents by index — the same thing the HuggingFace
+        rerank config does for the identical provider limitation. Without
+        `request_data` there is nothing to back-fill from, so the response is
+        left as-is.
         """
         _billed_units = RerankBilledUnits(**response.get("usage", {"search_units": 1}))  # by default 1 search unit
         _tokens: Final = RerankTokens(**response.get("usage", {}))
@@ -92,13 +110,22 @@ class BedrockRerankConfig:
 
         bedrock_results: Final = response.get("results")
         if bedrock_results:
-            _results = [
-                RerankResponseResult(
-                    index=result.get("index"),
+            # Cohere-compatible default: back-fill unless the caller opted out.
+            should_return_documents: Final = request_data is not None and request_data.return_documents is not False
+            original_documents: Final = request_data.documents if request_data is not None else []
+
+            _results = []
+            for result in bedrock_results:
+                index = result.get("index")
+                _result = RerankResponseResult(
+                    index=index,
                     relevance_score=result.get("relevanceScore"),
                 )
-                for result in bedrock_results
-            ]
+                if should_return_documents and isinstance(index, int) and 0 <= index < len(original_documents):
+                    text = self._document_text(original_documents[index])
+                    if text is not None:
+                        _result["document"] = RerankResponseDocument(text=text)
+                _results.append(_result)
 
         if _results is None:
             raise ValueError(f"No results found in the response={response}")

--- a/litellm/llms/bedrock/rerank/transformation.py
+++ b/litellm/llms/bedrock/rerank/transformation.py
@@ -4,6 +4,7 @@ Translates from Cohere's `/v1/rerank` input format to Bedrock's `/rerank` input 
 Why separate file? Make it easy to see how transformation works
 """
 
+from collections.abc import Mapping, Sequence
 from typing import Final
 
 from litellm._uuid import uuid
@@ -79,15 +80,39 @@ class BedrockRerankConfig:
         )
 
     @staticmethod
-    def _document_text(document: str | dict) -> str | None:
-        """Text of an input document, in either shape the API accepts."""
+    def _document_text(documents: Sequence[str | Mapping[str, object]] | None, index: object) -> str | None:
+        """
+        Text of the input document at `index`, in either shape the API accepts.
+
+        Returns None when there is nothing to back-fill from: no documents, a
+        non-integer or out-of-range index, or a document carrying no text.
+        """
+        if documents is None or not isinstance(index, int) or not 0 <= index < len(documents):
+            return None
+        document: Final = documents[index]
         if isinstance(document, str):
             return document
         if isinstance(document, dict):
-            text = document.get("text")
+            text: Final = document.get("text")
             if isinstance(text, str):
                 return text
         return None
+
+    @classmethod
+    def _transform_result(
+        cls, result: Mapping[str, object], documents: Sequence[str | Mapping[str, object]] | None
+    ) -> RerankResponseResult:
+        """One Bedrock result, with `document` back-filled when available."""
+        index: Final = result.get("index")
+        relevance_score: Final = result.get("relevanceScore")
+        text: Final = cls._document_text(documents, index)
+        if text is None:
+            return RerankResponseResult(index=index, relevance_score=relevance_score)
+        return RerankResponseResult(
+            index=index,
+            relevance_score=relevance_score,
+            document=RerankResponseDocument(text=text),
+        )
 
     def _transform_response(self, response: dict, request_data: RerankRequest | None = None) -> RerankResponse:
         """
@@ -111,21 +136,15 @@ class BedrockRerankConfig:
         bedrock_results: Final = response.get("results")
         if bedrock_results:
             # Cohere-compatible default: back-fill unless the caller opted out.
-            should_return_documents: Final = request_data is not None and request_data.return_documents is not False
-            original_documents: Final = request_data.documents if request_data is not None else []
+            # None documents means "nothing to back-fill from", which covers
+            # both an opt-out and a caller that passed no request at all.
+            documents: Final = (
+                request_data.documents
+                if request_data is not None and request_data.return_documents is not False
+                else None
+            )
 
-            _results = []
-            for result in bedrock_results:
-                index = result.get("index")
-                _result = RerankResponseResult(
-                    index=index,
-                    relevance_score=result.get("relevanceScore"),
-                )
-                if should_return_documents and isinstance(index, int) and 0 <= index < len(original_documents):
-                    text = self._document_text(original_documents[index])
-                    if text is not None:
-                        _result["document"] = RerankResponseDocument(text=text)
-                _results.append(_result)
+            _results = [self._transform_result(result, documents) for result in bedrock_results]
 
         if _results is None:
             raise ValueError(f"No results found in the response={response}")

--- a/tests/test_litellm/llms/bedrock/rerank/test_bedrock_rerank_return_documents.py
+++ b/tests/test_litellm/llms/bedrock/rerank/test_bedrock_rerank_return_documents.py
@@ -64,6 +64,27 @@ class TestBedrockRerankReturnDocuments:
         assert response.results[0]["index"] == 7
         assert "document" not in response.results[0]
 
+    def test_json_documents_yield_no_document_and_do_not_raise(self):
+        """
+        A dict document with no `text` key goes to Bedrock as a `jsonDocument`
+        (`_transform_sources`), and `RerankResponseDocument` carries only
+        `text`, so there is nowhere to put it. Pinned as a known boundary: no
+        back-fill, but no crash either. Raised by @kimnamu on #38006.
+        """
+        response = self.config._transform_response(
+            BEDROCK_RESPONSE,
+            _request(documents=[{"title": "zero", "body": "b0"}, {"title": "one", "body": "b1"}]),
+        )
+
+        assert all("document" not in result for result in response.results)
+        assert [r["index"] for r in response.results] == [1, 0]
+
+    def test_non_integer_index_is_tolerated(self):
+        """`index` is coerced by pydantic upstream; do not raise on it here."""
+        response = self.config._transform_response({"results": [{"index": "2", "relevanceScore": 0.9}]}, _request())
+
+        assert response.results[0]["relevance_score"] == 0.9
+
     def test_relevance_scores_are_preserved(self):
         response = self.config._transform_response(BEDROCK_RESPONSE, _request())
 

--- a/tests/test_litellm/llms/bedrock/rerank/test_bedrock_rerank_return_documents.py
+++ b/tests/test_litellm/llms/bedrock/rerank/test_bedrock_rerank_return_documents.py
@@ -1,0 +1,70 @@
+"""Bedrock never echoes document text, so the transformer must back-fill it."""
+
+import pytest
+
+from litellm.llms.bedrock.rerank.transformation import BedrockRerankConfig
+from litellm.types.rerank import RerankRequest
+
+BEDROCK_RESPONSE = {
+    "results": [
+        {"index": 1, "relevanceScore": 0.95},
+        {"index": 0, "relevanceScore": 0.42},
+    ]
+}
+
+DOCUMENTS = ["the first passage", "the second passage"]
+
+
+def _request(documents=None, return_documents=None):
+    return RerankRequest(
+        model="bedrock/arn:aws:bedrock:us-west-2::foundation-model/amazon.rerank-v1:0",
+        query="which passage?",
+        documents=DOCUMENTS if documents is None else documents,
+        return_documents=return_documents,
+    )
+
+
+class TestBedrockRerankReturnDocuments:
+    def setup_method(self):
+        self.config = BedrockRerankConfig()
+
+    @pytest.mark.parametrize("return_documents", [True, None])
+    def test_back_fills_document_text_by_index(self, return_documents):
+        """`None` is the Cohere-compatible default and back-fills like `True`."""
+        response = self.config._transform_response(BEDROCK_RESPONSE, _request(return_documents=return_documents))
+
+        # Ranked order is preserved, and each result carries its source text.
+        assert response.results[0]["index"] == 1
+        assert response.results[0]["document"] == {"text": "the second passage"}
+        assert response.results[1]["index"] == 0
+        assert response.results[1]["document"] == {"text": "the first passage"}
+
+    def test_omits_documents_when_caller_opts_out(self):
+        response = self.config._transform_response(BEDROCK_RESPONSE, _request(return_documents=False))
+
+        assert all("document" not in result for result in response.results)
+
+    def test_accepts_dict_documents(self):
+        response = self.config._transform_response(
+            BEDROCK_RESPONSE,
+            _request(documents=[{"text": "first as dict"}, {"text": "second as dict"}]),
+        )
+
+        assert response.results[0]["document"] == {"text": "second as dict"}
+
+    def test_no_request_data_leaves_response_untouched(self):
+        """Older callers pass only the response; nothing to back-fill from."""
+        response = self.config._transform_response(BEDROCK_RESPONSE)
+
+        assert all("document" not in result for result in response.results)
+
+    def test_out_of_range_index_is_skipped_not_raised(self):
+        response = self.config._transform_response({"results": [{"index": 7, "relevanceScore": 0.1}]}, _request())
+
+        assert response.results[0]["index"] == 7
+        assert "document" not in response.results[0]
+
+    def test_relevance_scores_are_preserved(self):
+        response = self.config._transform_response(BEDROCK_RESPONSE, _request())
+
+        assert [r["relevance_score"] for r in response.results] == [0.95, 0.42]


### PR DESCRIPTION
Fixes #38006.

## The bug

Bedrock's rerank API returns only `index` and `relevanceScore` — it never echoes
document text. LiteLLM exposes a Cohere-compatible interface where
`return_documents` means the response transformer back-fills `document.text`
from the request's documents by index.

`BedrockRerankConfig._transform_response` never saw the request at all:

```python
def _transform_response(self, response: dict) -> RerankResponse:
```

so it could not back-fill even in principle, and `return_documents` was a
no-op. `results[i]["document"]` was always absent, and a RAG pipeline using
Bedrock rerank had to re-join ranked indices to source text by hand.

## The fix

Thread the `RerankRequest` through to `_transform_response` (both the sync path
and `arerank`) and back-fill by index — the same approach
`HuggingFaceRerankConfig` already uses for this identical provider limitation.

- Both document shapes are handled: plain `str` and `{"text": ...}`.
- `request_data` is **optional**, so any existing caller passing only the
  response keeps today's behaviour rather than breaking.
- An out-of-range index is skipped rather than raising, so a malformed response
  degrades instead of crashing the call.

## The `None` default — settled in review

`RerankRequest.return_documents` defaults to `None`, not `True`, so I originally
raised this as a judgement call. @kimnamu measured it on the issue and the
answer is clear: `rerank(...)` declares `return_documents: bool | None = True`
while `arerank(...)` declares `None` and forwards it positionally, so the
transform layer sees `True` on the sync path and `None` on the async path.
Treating `None` as back-fill is what keeps the two agreeing; treating it as
opt-out splits them, and closing that split from the other side would change
what the async path sends to other providers (`fireworks_ai` forwards the flag
only when it is not `None`).

Note this is a deliberate divergence from Cohere, whose v1 rerank defaults
`return_documents` to false, and from the HuggingFace config here, which treats
absent as `False`. Bedrock ends up more generous than both. Say the word if you
would rather match them and accept the sync/async split.

## Release note worth making

The proxy's `/v1/rerank` runs through `route_type="arerank"`, so proxy callers
who never set the flag are on the `None` branch and will start receiving
document text where they previously got none. For 50 documents of ~1 KB
passages that is a serialized response of 2,217 → 54,107 bytes. That is the fix
working as intended, but it is a visible payload change worth calling out in
release notes.

## Known boundary: JSON documents

A dict document with no `text` key is sent to Bedrock as a `jsonDocument`
(`_transform_sources`), and `RerankResponseDocument` carries only `text`, so
there is nowhere to put it. Those callers still see no `document` key. There is
a test pinning this explicitly — no back-fill, but no crash, so index and score
still come back. Serializing the JSON into `text` would close it, but that
invents a shape neither Cohere nor the HuggingFace config produces, so I have
left it as a documented limitation rather than decide it inside a bug fix.

## Verification

Seven tests in `tests/test_litellm/llms/bedrock/rerank/test_bedrock_rerank_return_documents.py`:

- back-fills by index for `return_documents=True` **and** `None`, with ranked
  order preserved (the response ranks index 1 above index 0, so this also pins
  that text is matched by index rather than by position)
- omits `document` entirely when the caller passes `False`
- handles `{"text": ...}` document dicts
- leaves the response untouched when no `request_data` is supplied
- skips an out-of-range index instead of raising
- preserves relevance scores

6 of the 7 fail without the source change. The existing
`test_bedrock_rerank_header_forwarding.py` (which exercises `arerank`) still
passes — **14/14 in that directory** — confirming the signature change is safe
on the async path.

`ruff check` and `ruff format --check` clean on the touched files.

## Unrelated pre-existing failures

`tests/test_litellm/llms/bedrock/` has 10 failures on this branch, but the same
10 fail on a clean checkout with nothing applied (verified by stashing) — mostly
in `test_anthropic_claude3_transformation.py`, plus
`test_sigv4_matches_rust_golden_vector` and `test_mantle.py`. Untouched by this
PR; flagging in case they are not already known.



---

**On the red `code-quality` check:** it is not from this PR. It fails on every
PR against `litellm_internal_staging` right now, including ones that touch no
workflow files, because three unit shards in `.github/workflows/test-unit.yml`
cap the job below the startup-safety invariant. Fixed independently in #38046;
this PR needs no change for it.