### PR TITLE
fix(ocr): annotate OCRResponse.tables/keyValuePairs as Any so the model builds

### DIFF
--- a/litellm/llms/base_llm/ocr/transformation.py
+++ b/litellm/llms/base_llm/ocr/transformation.py
@@ -92,8 +92,12 @@ class OCRResponse(LiteLLMPydanticObjectBase):
     document_annotation: Any | None = None
     usage_info: OCRUsageInfo | None = None
     content: str | None = None
-    tables: list[dict[str, object]] | None = None
-    keyValuePairs: list[dict[str, object]] | None = None
+    # `Any`, not `object`: the `object` field below shadows the builtin in this
+    # class namespace, and pydantic resolves the deferred annotations against
+    # that namespace — so `dict[str, object]` resolves to the string "ocr" and
+    # the model can never be built.
+    tables: list[dict[str, Any]] | None = None
+    keyValuePairs: list[dict[str, Any]] | None = None
     object: str = "ocr"
 
     model_config = {"extra": "allow"}

--- a/tests/test_litellm/ocr/test_ocr_response_model_build.py
+++ b/tests/test_litellm/ocr/test_ocr_response_model_build.py
@@ -1,0 +1,32 @@
+"""`OCRResponse` must be constructible.
+
+The model declares a field literally named `object`, which shadows the builtin
+inside the class namespace. Pydantic resolves the deferred annotations against
+that namespace, so any *other* field annotated with the builtin `object`
+resolves to the string "ocr" and pydantic treats it as an unresolved forward
+reference — the model then cannot be built at all.
+"""
+
+from litellm.llms.base_llm.ocr.transformation import OCRPage, OCRResponse
+
+
+def test_ocr_response_can_be_constructed():
+    response = OCRResponse(
+        pages=[OCRPage(index=0, markdown="# hello")],
+        model="mistral-ocr-latest",
+    )
+
+    assert response.object == "ocr"
+    assert response.pages[0].markdown == "# hello"
+
+
+def test_ocr_response_accepts_tables_and_key_value_pairs():
+    response = OCRResponse(
+        pages=[OCRPage(index=0, markdown="# hello")],
+        model="mistral-ocr-latest",
+        tables=[{"rows": [["a", "b"]]}],
+        keyValuePairs=[{"key": "invoice_no", "value": "42"}],
+    )
+
+    assert response.tables == [{"rows": [["a", "b"]]}]
+    assert response.keyValuePairs == [{"key": "invoice_no", "value": "42"}]


### PR DESCRIPTION
No upstream issue exists for this (searched 2026-08-17); reporting it with the fix.

## What

`OCRResponse` cannot be constructed on a clean checkout of `litellm_internal_staging`:

```
PydanticUserError: `OCRResponse` is not fully defined; you should define `ocr`,
then call `OCRResponse.model_rebuild()`.
```

This is not cosmetic: 7 tests in `tests/test_litellm/llms/azure_ai/test_azure_document_intelligence_ocr_transformation.py` fail on the base branch today for this reason and pass with this change (7 failed / 23 passed before, 32 passed after).

## Why

`OCRResponse` declares a field literally named `object` (`object: str = "ocr"`, mirroring Mistral's OCR payload). That name shadows the builtin inside the class namespace, and pydantic resolves the deferred annotations against that namespace — so `list[dict[str, object]]` on `tables` and `keyValuePairs` resolves `object` to the string `"ocr"` and treats it as an unresolved forward reference.

## How

Annotate the two fields as `list[dict[str, Any]] | None` instead of `dict[str, object]`. This breaks the collision without renaming `object`, which is part of the response contract. A comment on the fields records why, so a later cleanup does not put `object` back.

Reproduced on pydantic 2.13.4 / Python 3.14.

## Testing

- New regression test `tests/test_litellm/ocr/test_ocr_response_model_build.py` (2 tests): constructs the model with and without the two fields.
- `uv run pytest tests/test_litellm/ocr/test_ocr_response_model_build.py tests/test_litellm/llms/azure_ai/test_azure_document_intelligence_ocr_transformation.py`: 32 passed (the latter file: 7 failed on base).
- `ruff check` clean on the changed files.
