### PR TITLE
ci: raise the three 55m unit shards to the 60m job-timeout invariant

### DIFF
--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -211,7 +211,7 @@ jobs:
             workers: 2
             reruns: 2
             timeout-minutes: 20
-            job-timeout-minutes: 55
+            job-timeout-minutes: 60
 
           - shard: proxy-extras
             artifact-name: proxy-extras
@@ -219,7 +219,7 @@ jobs:
             workers: 2
             reruns: 2
             timeout-minutes: 20
-            job-timeout-minutes: 55
+            job-timeout-minutes: 60
 
           - shard: enterprise-package
             artifact-name: enterprise-package
@@ -227,7 +227,7 @@ jobs:
             workers: 4
             reruns: 2
             timeout-minutes: 20
-            job-timeout-minutes: 55
+            job-timeout-minutes: 60
 
           - shard: responses-caching-types
             artifact-name: responses-caching-types


### PR DESCRIPTION
## Why `code-quality` is red on every PR

`code-quality` currently fails on PRs that touch no workflow files at all — I
hit it on an unrelated contribution and found it failing on 3 of 4 other
concurrent PRs against `litellm_internal_staging`.

The failing step is `check_workflow_startup_safety.py`:

```
ERROR: Workflow startup invariants violated:
  - .github/workflows/test-unit.yml: job `unit` gives pytest 20m but caps the job at 55m.
    Setup can use up to 35m plus 5m of runner overhead, so the job deadline would
    preempt pytest; raise job-timeout-minutes to at least 60.
```

reported three times, once per offending shard.

## The invariant

```python
required = test_budget + ceiling + JOB_OVERHEAD_MINUTES   # 20 + 35 + 5 = 60
if job_budget < required: ...
```

Three shards in `test-unit.yml` cap the job at **55**:

| shard | job-timeout-minutes |
|---|---|
| `caching-local` | 55 |
| `proxy-extras` | 55 |
| `enterprise-package` | 55 |

## Git history says this is drift, not intent

`afec9b8ab` ("perf(ci): cache the Rust build the unit shards compile from
scratch", Aug 21) raised **every** shard from 55 to 60 in one sweep, and the
long shard from 95 to 100:

```
$ git show afec9b8ab -- .github/workflows/test-unit.yml | grep job-timeout-minutes | sort | uniq -c
     10 +            job-timeout-minutes: 60
      1 +            job-timeout-minutes: 100
     10 -            job-timeout-minutes: 55
      1 -            job-timeout-minutes: 95
```

Each of the three shards still at 55 was added by a *later* commit, from the
pre-`afec9b8ab` template:

| shard | added by |
|---|---|
| `caching-local` | `b31484ed1` — ci: run the keyless caching tests that ran in no job |
| `proxy-extras` | `ae0e8a20d` — fix(ci): run the migration DDL guard |
| `enterprise-package` | `68489f62f` — ci: run the enterprise package suite in GitHub Actions |

So 60 is not a value I picked: it is the value this workflow already settled on
one commit earlier, and these three were copied from a stale template. Happy to
be corrected if a lower cap is deliberate for these particular shards.

## Why it matters beyond the red check

This is not only a noisy gate. As the checker's own docstring explains, the
failure mode it guards against is silent: if the job deadline preempts pytest,
"an entire test suite can silently stop running while the checks list stays
green." A 55m cap against a 20m pytest budget and a 35m setup ceiling leaves no
room for runner overhead, so these three shards are the ones actually exposed to
that.

## The change

Raise the three to 60, matching the other ten shards. Nothing else touched.

## Verification

```
$ python tests/code_coverage_tests/check_workflow_startup_safety.py
Workflow startup invariants hold (setup ceiling 35m)
```

and with the change stashed, the same three violations come back — so the
checker is confirmed to be reacting to exactly this.

## Blast radius

`code-quality` is currently red on every PR against `litellm_internal_staging`,
including ones touching no workflow files. I checked the six most recently
merged PRs on this base and all six had `code-quality` green, so this is recent
breakage rather than a long-standing state.

I have four functional PRs open (#38044, #38047, #38048, #38051) sitting behind
this same red check. This PR is deliberately independent of all of them and
touches only the workflow file, so it can go in on its own.
