### PR TITLE
fix(bedrock): accept tool_choice="any" on the Converse adapter

### DIFF
--- a/litellm/llms/bedrock/chat/converse_transformation.py
+++ b/litellm/llms/bedrock/chat/converse_transformation.py
@@ -591,7 +591,9 @@ class AmazonConverseConfig(BaseConfig):
                     message=f"Bedrock doesn't support tool_choice={tool_choice}. To drop it from the call, set `litellm.drop_params = True.",
                     status_code=400,
                 )
-        elif tool_choice == "required":
+        elif tool_choice in ("required", "any"):
+            # Bedrock's native value for "call some tool" is literally `any`,
+            # so accepting "required" while rejecting "any" was incoherent.
             return ToolChoiceValuesBlock(any={})
         elif tool_choice == "auto":
             return ToolChoiceValuesBlock(auto={})
@@ -603,7 +605,7 @@ class AmazonConverseConfig(BaseConfig):
             return ToolChoiceValuesBlock(tool=specific_tool)
         else:
             raise litellm.utils.UnsupportedParamsError(
-                message=f"Bedrock doesn't support tool_choice={tool_choice}. Supported tool_choice values=['auto', 'required', json object]. To drop it from the call, set `litellm.drop_params = True.",
+                message=f"Bedrock doesn't support tool_choice={tool_choice}. Supported tool_choice values=['auto', 'required', 'any', json object]. To drop it from the call, set `litellm.drop_params = True.",
                 status_code=400,
             )
 

--- a/tests/test_litellm/llms/bedrock/chat/test_bedrock_tool_choice_any.py
+++ b/tests/test_litellm/llms/bedrock/chat/test_bedrock_tool_choice_any.py
@@ -1,0 +1,43 @@
+"""`tool_choice="any"` is Bedrock's own native value and must be accepted."""
+
+import pytest
+
+import litellm
+from litellm.llms.bedrock.chat.converse_transformation import AmazonConverseConfig
+
+MODEL = "anthropic.claude-3-haiku-20240307-v1:0"
+
+
+class TestBedrockToolChoiceAny:
+    def setup_method(self):
+        self.config = AmazonConverseConfig()
+
+    @pytest.mark.parametrize("tool_choice", ["required", "any"])
+    def test_required_and_any_both_map_to_bedrock_any(self, tool_choice):
+        result = self.config.map_tool_choice_values(model=MODEL, tool_choice=tool_choice, drop_params=False)
+
+        assert result == {"any": {}}
+
+    def test_auto_is_unchanged(self):
+        result = self.config.map_tool_choice_values(model=MODEL, tool_choice="auto", drop_params=False)
+
+        assert result == {"auto": {}}
+
+    def test_specific_tool_is_unchanged(self):
+        result = self.config.map_tool_choice_values(
+            model=MODEL,
+            tool_choice={"type": "function", "function": {"name": "get_weather"}},
+            drop_params=False,
+        )
+
+        assert result == {"tool": {"name": "get_weather"}}
+
+    def test_unknown_value_still_raises_and_lists_any(self):
+        with pytest.raises(litellm.utils.UnsupportedParamsError) as exc_info:
+            self.config.map_tool_choice_values(model=MODEL, tool_choice="definitely_not_supported", drop_params=False)
+
+        # The error text is the discoverability surface for these values.
+        assert "'any'" in str(exc_info.value)
+
+    def test_none_still_drops_when_drop_params_is_set(self):
+        assert self.config.map_tool_choice_values(model=MODEL, tool_choice="none", drop_params=True) is None


### PR DESCRIPTION
Fixes #37980.

## The bug

`AmazonConverseConfig.map_tool_choice_values` already maps `"required"` onto
Bedrock's native `{any: {}}`:

```python
elif tool_choice == "required":
    return ToolChoiceValuesBlock(any={})
```

but the literal string `"any"` falls through to the terminal `else` and raises:

```
litellm.UnsupportedParamsError: Bedrock doesn't support tool_choice=any.
Supported tool_choice values=['auto', 'required', json object].
```

So the one name Bedrock itself uses for "call some tool" is the one name the
adapter refuses, while `"required"` — which silently becomes exactly that value
— is accepted. Callers coming from Anthropic's API, where `any` is the spelling,
hit this immediately.

## The fix

Map `"any"` alongside `"required"`, as suggested in the issue, and add it to the
error message — that string is the only place these accepted values are
discoverable at runtime.

```python
elif tool_choice in ("required", "any"):
    return ToolChoiceValuesBlock(any={})
```

## Verification

Six tests in `tests/test_litellm/llms/bedrock/chat/test_bedrock_tool_choice_any.py`:

- `"required"` and `"any"` both map to `{"any": {}}` (parametrized, so the two
  are pinned as equivalent rather than merely both working)
- `"auto"` still maps to `{"auto": {}}`
- a specific-tool dict still maps to `{"tool": {"name": ...}}`
- a genuinely unknown value still raises, and the message now lists `'any'`
- `"none"` with `drop_params=True` still returns `None`

Without the source change the parametrized `"any"` case fails with the issue's
exact error, so the test is confirmed to be reacting to this and nothing else.

- `tests/test_litellm/llms/bedrock/chat/`: **378/378 pass**
- `ruff format --check` clean; `ruff check` on the touched source file reports
  the same 13 pre-existing findings as the base commit, none added
- Type-discipline checker: identical counts to base on every rule (LIT001 132,
  LIT002 92, LIT006 5, LIT010 81, LIT011 43), so no budget delta



---

**On the red `code-quality` check:** it is not from this PR. It fails on every
PR against `litellm_internal_staging` right now, including ones that touch no
workflow files, because three unit shards in `.github/workflows/test-unit.yml`
cap the job below the startup-safety invariant. Fixed independently in #38046;
this PR needs no change for it.