### PR TITLE
fix: keep content: null on an assistant tool-call turn

### DIFF
--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -7702,9 +7702,17 @@ def cleanup_none_field_in_message(message: AllMessageValues):
     Cleans up the message by removing the none field.
 
     remove None fields in the message - e.g. {"function": None} - some providers raise validation errors
+
+    `content` is exempt on an assistant tool-call turn. The OpenAI spec
+    prescribes `content: null` for an assistant message that only calls tools,
+    and providers that require the key to be present reject the request when it
+    is dropped entirely.
     """
     new_message: Final = message.copy()
-    return {k: v for k, v in new_message.items() if v is not None}
+    keeps_null_content: Final = message.get("role") == "assistant" and bool(
+        message.get("tool_calls") or message.get("function_call")
+    )
+    return {k: v for k, v in new_message.items() if v is not None or (k == "content" and keeps_null_content)}
 
 
 def validate_chat_completion_user_messages(messages: list[AllMessageValues]):

--- a/tests/test_litellm/test_cleanup_none_field_in_message.py
+++ b/tests/test_litellm/test_cleanup_none_field_in_message.py
@@ -1,0 +1,68 @@
+"""`content: null` is the OpenAI-prescribed shape for an assistant tool-call turn."""
+
+from litellm.utils import cleanup_none_field_in_message, validate_and_fix_openai_messages
+
+TOOL_CALLS = [{"id": "call_1", "type": "function", "function": {"name": "f", "arguments": "{}"}}]
+
+
+class TestCleanupNoneFieldInMessage:
+    def test_keeps_null_content_on_a_tool_call_turn(self):
+        cleaned = cleanup_none_field_in_message(
+            message={"role": "assistant", "content": None, "tool_calls": TOOL_CALLS}
+        )
+
+        assert "content" in cleaned
+        assert cleaned["content"] is None
+
+    def test_keeps_null_content_on_a_legacy_function_call_turn(self):
+        cleaned = cleanup_none_field_in_message(
+            message={
+                "role": "assistant",
+                "content": None,
+                "function_call": {"name": "f", "arguments": "{}"},
+            }
+        )
+
+        assert "content" in cleaned
+
+    def test_still_strips_other_none_fields_on_that_turn(self):
+        # The original purpose of the helper: providers reject e.g. {"function": None}.
+        cleaned = cleanup_none_field_in_message(
+            message={
+                "role": "assistant",
+                "content": None,
+                "tool_calls": TOOL_CALLS,
+                "function": None,
+                "name": None,
+            }
+        )
+
+        assert "function" not in cleaned
+        assert "name" not in cleaned
+        assert "content" in cleaned
+
+    def test_still_strips_none_content_without_tool_calls(self):
+        cleaned = cleanup_none_field_in_message(message={"role": "assistant", "content": None})
+
+        assert "content" not in cleaned
+
+    def test_user_message_is_unaffected(self):
+        cleaned = cleanup_none_field_in_message(message={"role": "user", "content": None, "name": None})
+
+        assert cleaned == {"role": "user"}
+
+
+class TestValidateAndFixOpenAIMessages:
+    def test_tool_call_turn_survives_the_full_validation_pass(self):
+        """End to end through the caller that strips the field."""
+        messages = [
+            {"role": "user", "content": "hi"},
+            {"role": "assistant", "content": None, "tool_calls": TOOL_CALLS},
+            {"role": "tool", "tool_call_id": "call_1", "content": "ok"},
+        ]
+
+        fixed = validate_and_fix_openai_messages(messages=messages)
+
+        assert "content" in fixed[1]
+        assert fixed[1]["content"] is None
+        assert fixed[1]["tool_calls"] == TOOL_CALLS


### PR DESCRIPTION
Fixes #37711.

## Root cause

I traced the reporter's repro to `cleanup_none_field_in_message` in
`litellm/utils.py`:

```python
new_message: Final = message.copy()
return {k: v for k, v in new_message.items() if v is not None}
```

It drops **every** key whose value is `None`. For an assistant message carrying
`tool_calls`, `content: null` is exactly the shape the OpenAI spec prescribes
for a tool-call-only turn, so the key is removed and providers that require it
to be present reject the request.

The helper's own docstring says the intent is removing stray keys like
`{"function": None}` that trip provider validation — `content` was collateral.

It is reached via `validate_and_fix_openai_messages`, which is why this
reproduces with a plain `litellm.completion()` call: no proxy, no provider, no
API key.

## The fix

Exempt `content` when the assistant message carries `tool_calls` or a legacy
`function_call`. Everything else is stripped exactly as before — including a
`None` `content` on an assistant message that has neither, so the original
behaviour is preserved wherever it was not the bug.

## Verification

Six tests in `tests/test_litellm/test_cleanup_none_field_in_message.py`:

- `content: null` survives on a `tool_calls` turn, and on a legacy
  `function_call` turn
- other `None` fields on that same turn (`function`, `name`) are **still**
  stripped — the helper's original purpose is intact
- `content: null` is still stripped from an assistant message with no tool call
- a user message is unaffected
- an end-to-end case through `validate_and_fix_openai_messages`, the caller
  that was actually dropping the field

4 of the 6 fail without the source change, and the reporter's own repro script
now prints `content key present: True`.

**Regression check.** I ran the provider suites most likely to depend on the old
behaviour — `tests/test_litellm/llms/{openai,anthropic,databricks,mistral}` —
2169 passed. There are 54 failures in that set, but the identical 54 fail on a
clean checkout with nothing applied (verified by stashing and re-running:
`54 failed, 268 passed` on both), so none are caused by this change.

- `ruff format --check` clean on both touched files
- `ruff check litellm/utils.py`: same findings as base, none added
- Type-discipline checker: identical counts to base on every rule



---

**On the red `code-quality` check:** it is not from this PR. It fails on every
PR against `litellm_internal_staging` right now, including ones that touch no
workflow files, because three unit shards in `.github/workflows/test-unit.yml`
cap the job below the startup-safety invariant. Fixed independently in #38046;
this PR needs no change for it.