### PR TITLE
fix(anthropic): drop thinking blocks with empty thinking text, not just missing signature

### DIFF
--- a/litellm/litellm_core_utils/prompt_templates/factory.py
+++ b/litellm/litellm_core_utils/prompt_templates/factory.py
@@ -2302,20 +2302,14 @@ def sanitize_messages_for_tool_calling(
 def _is_unsignable_thinking_block(block: object) -> bool:
     """A thinking block that Anthropic cannot accept on input.
 
-    Anthropic verifies the thinking signature cryptographically, so a block whose
-    signature is null, empty, or missing (e.g. from an open-source reasoning model)
-    is rejected with a 400 and must be dropped rather than blanked or repaired, and
-    so is a block whose signature or data carries another provider's encrypted
-    reasoning. A `redacted_thinking` block Anthropic minted is always kept.
-
-    Anthropic also rejects a `thinking` block whose `thinking` text is empty or
-    whitespace-only ("each thinking block must contain thinking"), regardless of
-    signature. This shape reaches us when a caller replays a `thinking_blocks`
-    history item that originated from a non-Anthropic reasoning provider (e.g. an
-    OpenAI Responses-API turn with no summary text) through this Anthropic-shaped
-    request path (`/v1/chat/completions` -> anthropic/vertex_ai's claude models),
-    which is the same failure the Anthropic Responses-bridge adapter guards
-    against (see PR #36033) for its own separate content-block path.
+    Anthropic verifies the signature cryptographically, so a block with a null,
+    empty, or missing signature (e.g. from an open-source reasoning model) is
+    rejected with a 400, and so is a block whose signature or data carries
+    another provider's encrypted reasoning. It also rejects a `thinking` block
+    whose text is empty or whitespace-only ("each thinking block must contain
+    thinking"), regardless of signature, e.g. when a `thinking_blocks` history
+    item from a non-Anthropic reasoning provider is replayed through this path.
+    `redacted_thinking` blocks carry no signature and are always kept.
     """
     if is_encrypted_reasoning_block(block):
         return True

--- a/litellm/litellm_core_utils/prompt_templates/factory.py
+++ b/litellm/litellm_core_utils/prompt_templates/factory.py
@@ -2307,13 +2307,25 @@ def _is_unsignable_thinking_block(block: object) -> bool:
     is rejected with a 400 and must be dropped rather than blanked or repaired, and
     so is a block whose signature or data carries another provider's encrypted
     reasoning. A `redacted_thinking` block Anthropic minted is always kept.
+
+    Anthropic also rejects a `thinking` block whose `thinking` text is empty or
+    whitespace-only ("each thinking block must contain thinking"), regardless of
+    signature. This shape reaches us when a caller replays a `thinking_blocks`
+    history item that originated from a non-Anthropic reasoning provider (e.g. an
+    OpenAI Responses-API turn with no summary text) through this Anthropic-shaped
+    request path (`/v1/chat/completions` -> anthropic/vertex_ai's claude models),
+    which is the same failure the Anthropic Responses-bridge adapter guards
+    against (see PR #36033) for its own separate content-block path.
     """
     if is_encrypted_reasoning_block(block):
         return True
     if not isinstance(block, dict) or block.get("type") != "thinking":
         return False
     signature: Final = block.get("signature")
-    return not (isinstance(signature, str) and len(signature) > 0)
+    if not (isinstance(signature, str) and len(signature) > 0):
+        return True
+    thinking_text: Final = block.get("thinking")
+    return not (isinstance(thinking_text, str) and len(thinking_text.strip()) > 0)
 
 
 def _drop_unsignable_thinking_blocks(

--- a/tests/test_litellm/litellm_core_utils/prompt_templates/test_litellm_core_utils_prompt_templates_factory.py
+++ b/tests/test_litellm/litellm_core_utils/prompt_templates/test_litellm_core_utils_prompt_templates_factory.py
@@ -3722,14 +3722,7 @@ def test_convert_to_anthropic_tool_invoke_keeps_paired_server_tool_use():
         server_result,
     ]
 def test_anthropic_messages_pt_drops_empty_but_signed_thinking_block():
-    """
-    Anthropic rejects a `thinking` block whose `thinking` text is empty, even
-    when it carries a valid-looking signature, with:
-        400 messages.N.content.M.thinking: each thinking block must contain thinking
-    This shape is reachable via cross-provider replay of a `thinking_blocks`
-    history item (see PR #36033), so `_is_unsignable_thinking_block()` must
-    also check the thinking text, not just the signature.
-    """
+    """An empty-but-signed thinking block must still be dropped."""
     from litellm.litellm_core_utils.prompt_templates.factory import (
         anthropic_messages_pt,
     )
@@ -3762,10 +3755,7 @@ def test_anthropic_messages_pt_drops_empty_but_signed_thinking_block():
 
 
 def test_anthropic_messages_pt_keeps_non_empty_signed_thinking_block():
-    """
-    Regression: a real, non-empty, signed thinking block must still pass
-    through unchanged.
-    """
+    """Regression: a non-empty, signed thinking block passes through unchanged."""
     from litellm.litellm_core_utils.prompt_templates.factory import (
         anthropic_messages_pt,
     )
@@ -3800,11 +3790,7 @@ def test_anthropic_messages_pt_keeps_non_empty_signed_thinking_block():
 
 
 def test_anthropic_messages_pt_keeps_redacted_thinking_block():
-    """
-    Regression: `redacted_thinking` blocks carry no signature and no plaintext
-    `thinking` field by design, and must always be kept regardless of the new
-    emptiness check (which only applies to `type == "thinking"` blocks).
-    """
+    """Regression: redacted_thinking blocks are unaffected by the emptiness check."""
     from litellm.litellm_core_utils.prompt_templates.factory import (
         anthropic_messages_pt,
     )
@@ -3836,11 +3822,7 @@ def test_anthropic_messages_pt_keeps_redacted_thinking_block():
 
 
 def test_anthropic_messages_pt_drops_unsigned_thinking_block():
-    """
-    Regression (pre-existing behaviour): a thinking block with no signature
-    (or an empty/null one) must still be dropped, independent of whether the
-    thinking text is populated.
-    """
+    """Regression: an unsigned thinking block is still dropped, regardless of text."""
     from litellm.litellm_core_utils.prompt_templates.factory import (
         anthropic_messages_pt,
     )
@@ -3873,24 +3855,7 @@ def test_anthropic_messages_pt_drops_unsigned_thinking_block():
 
 
 def test_is_unsignable_thinking_block_treats_whitespace_only_as_empty():
-    """
-    Edge case: a `thinking` field that is present but whitespace-only (e.g.
-    a single trailing newline forwarded from another provider's empty
-    reasoning summary) is functionally empty and Anthropic's API will still
-    reject it with "each thinking block must contain thinking". We treat it
-    the same as a fully empty string and drop the block.
-
-    Note the sibling check ~30 lines below this function's definition
-    (the "don't pass empty text blocks" comment) uses a bare
-    `len(thinking_block) > 0`, which by itself would treat whitespace-only
-    text as non-empty. That sibling check is always combined with
-    `not _is_unsignable_thinking_block(m)` in an `and`, so this function's
-    stricter whitespace-aware check is still the one that decides whether a
-    whitespace-only block survives — the two checks don't disagree in
-    practice, but this function is intentionally the stricter of the two
-    since it is also called standalone (via `_drop_unsignable_thinking_blocks`)
-    without that extra `len(...) > 0` guard.
-    """
+    """Whitespace-only `thinking` text is treated as empty and dropped."""
     from litellm.litellm_core_utils.prompt_templates.factory import (
         _is_unsignable_thinking_block,
     )

--- a/tests/test_litellm/litellm_core_utils/prompt_templates/test_litellm_core_utils_prompt_templates_factory.py
+++ b/tests/test_litellm/litellm_core_utils/prompt_templates/test_litellm_core_utils_prompt_templates_factory.py
@@ -3721,3 +3721,184 @@ def test_convert_to_anthropic_tool_invoke_keeps_paired_server_tool_use():
         },
         server_result,
     ]
+def test_anthropic_messages_pt_drops_empty_but_signed_thinking_block():
+    """
+    Anthropic rejects a `thinking` block whose `thinking` text is empty, even
+    when it carries a valid-looking signature, with:
+        400 messages.N.content.M.thinking: each thinking block must contain thinking
+    This shape is reachable via cross-provider replay of a `thinking_blocks`
+    history item (see PR #36033), so `_is_unsignable_thinking_block()` must
+    also check the thinking text, not just the signature.
+    """
+    from litellm.litellm_core_utils.prompt_templates.factory import (
+        anthropic_messages_pt,
+    )
+
+    messages = [
+        {"role": "user", "content": "What's 2+2?"},
+        {
+            "role": "assistant",
+            "content": "4",
+            "thinking_blocks": [
+                {
+                    "type": "thinking",
+                    "thinking": "",
+                    "signature": "sig_abc123_looks_valid",
+                }
+            ],
+        },
+    ]
+
+    result = anthropic_messages_pt(
+        messages=messages,
+        model="claude-sonnet-4-5-20250929",
+        llm_provider="anthropic",
+    )
+
+    assistant_msg = result[1]
+    assert isinstance(assistant_msg["content"], list)
+    content_types = [block.get("type") for block in assistant_msg["content"]]
+    assert "thinking" not in content_types, "empty-text thinking block must be dropped even though it has a signature"
+
+
+def test_anthropic_messages_pt_keeps_non_empty_signed_thinking_block():
+    """
+    Regression: a real, non-empty, signed thinking block must still pass
+    through unchanged.
+    """
+    from litellm.litellm_core_utils.prompt_templates.factory import (
+        anthropic_messages_pt,
+    )
+
+    messages = [
+        {"role": "user", "content": "What's 2+2?"},
+        {
+            "role": "assistant",
+            "content": "4",
+            "thinking_blocks": [
+                {
+                    "type": "thinking",
+                    "thinking": "Let me add these numbers together.",
+                    "signature": "sig_abc123_looks_valid",
+                }
+            ],
+        },
+    ]
+
+    result = anthropic_messages_pt(
+        messages=messages,
+        model="claude-sonnet-4-5-20250929",
+        llm_provider="anthropic",
+    )
+
+    assistant_msg = result[1]
+    assert isinstance(assistant_msg["content"], list)
+    thinking_block = next((b for b in assistant_msg["content"] if b.get("type") == "thinking"), None)
+    assert thinking_block is not None, "non-empty signed thinking block must be kept"
+    assert thinking_block["thinking"] == "Let me add these numbers together."
+    assert thinking_block["signature"] == "sig_abc123_looks_valid"
+
+
+def test_anthropic_messages_pt_keeps_redacted_thinking_block():
+    """
+    Regression: `redacted_thinking` blocks carry no signature and no plaintext
+    `thinking` field by design, and must always be kept regardless of the new
+    emptiness check (which only applies to `type == "thinking"` blocks).
+    """
+    from litellm.litellm_core_utils.prompt_templates.factory import (
+        anthropic_messages_pt,
+    )
+
+    messages = [
+        {"role": "user", "content": "What's 2+2?"},
+        {
+            "role": "assistant",
+            "content": "4",
+            "thinking_blocks": [
+                {
+                    "type": "redacted_thinking",
+                    "data": "encrypted_opaque_blob",
+                }
+            ],
+        },
+    ]
+
+    result = anthropic_messages_pt(
+        messages=messages,
+        model="claude-sonnet-4-5-20250929",
+        llm_provider="anthropic",
+    )
+
+    assistant_msg = result[1]
+    assert isinstance(assistant_msg["content"], list)
+    content_types = [block.get("type") for block in assistant_msg["content"]]
+    assert "redacted_thinking" in content_types, "redacted_thinking blocks must always be kept"
+
+
+def test_anthropic_messages_pt_drops_unsigned_thinking_block():
+    """
+    Regression (pre-existing behaviour): a thinking block with no signature
+    (or an empty/null one) must still be dropped, independent of whether the
+    thinking text is populated.
+    """
+    from litellm.litellm_core_utils.prompt_templates.factory import (
+        anthropic_messages_pt,
+    )
+
+    messages = [
+        {"role": "user", "content": "What's 2+2?"},
+        {
+            "role": "assistant",
+            "content": "4",
+            "thinking_blocks": [
+                {
+                    "type": "thinking",
+                    "thinking": "Let me add these numbers together.",
+                    "signature": "",
+                }
+            ],
+        },
+    ]
+
+    result = anthropic_messages_pt(
+        messages=messages,
+        model="claude-sonnet-4-5-20250929",
+        llm_provider="anthropic",
+    )
+
+    assistant_msg = result[1]
+    assert isinstance(assistant_msg["content"], list)
+    content_types = [block.get("type") for block in assistant_msg["content"]]
+    assert "thinking" not in content_types, "unsigned thinking block must still be dropped"
+
+
+def test_is_unsignable_thinking_block_treats_whitespace_only_as_empty():
+    """
+    Edge case: a `thinking` field that is present but whitespace-only (e.g.
+    a single trailing newline forwarded from another provider's empty
+    reasoning summary) is functionally empty and Anthropic's API will still
+    reject it with "each thinking block must contain thinking". We treat it
+    the same as a fully empty string and drop the block.
+
+    Note the sibling check ~30 lines below this function's definition
+    (the "don't pass empty text blocks" comment) uses a bare
+    `len(thinking_block) > 0`, which by itself would treat whitespace-only
+    text as non-empty. That sibling check is always combined with
+    `not _is_unsignable_thinking_block(m)` in an `and`, so this function's
+    stricter whitespace-aware check is still the one that decides whether a
+    whitespace-only block survives — the two checks don't disagree in
+    practice, but this function is intentionally the stricter of the two
+    since it is also called standalone (via `_drop_unsignable_thinking_blocks`)
+    without that extra `len(...) > 0` guard.
+    """
+    from litellm.litellm_core_utils.prompt_templates.factory import (
+        _is_unsignable_thinking_block,
+    )
+
+    whitespace_only_block = {
+        "type": "thinking",
+        "thinking": "   \n\t  ",
+        "signature": "sig_abc123_looks_valid",
+    }
+
+    assert _is_unsignable_thinking_block(whitespace_only_block) is True


### PR DESCRIPTION
## TLDR

Problem this solves:

- A `thinking` block with a valid-looking signature but empty `thinking` text is not dropped
- Anthropic rejects it with a 400 even though the signature is present
- This crashes `completion()`/`acompletion()` for `anthropic/*` and `vertex_ai/claude-*`

How it solves it:

- `_is_unsignable_thinking_block()` now also returns `True` when `thinking` is missing, not a string, or empty after `.strip()`
- Signature check runs first and is unchanged; `redacted_thinking` blocks are untouched

The sequential-mode branch of `anthropic_messages_pt()` already guards this case with `len(thinking_block) > 0` and the comment "don't pass empty text blocks. anthropic api raises errors." But `_drop_unsignable_thinking_blocks()`, the filter used to build `thinking_blocks` earlier in the same function and the only guard on the `anthropic_messages_pt()` -> `AnthropicConfig.transform_request()` path, calls `_is_unsignable_thinking_block()` alone. The primary path was left unguarded. #36033 (Responses streaming adapter) and #27850 (Bedrock Converse) fixed the same class of bug elsewhere; this is the same fix on `_is_unsignable_thinking_block()`.

## User Flow

Before: a developer whose app replays assistant history through `anthropic/claude-*` or `vertex_ai/claude-*` gets a 400 whenever that history contains a `thinking_blocks` entry with an empty `thinking` field (for example, forwarded from a non-Anthropic reasoning provider's turn that had no summary text)

1. Client sends a multi-turn `completion()` call where `messages[1]["thinking_blocks"] = [{"type": "thinking", "thinking": "", "signature": "sig_abc123"}]`
2. The block is kept because it has a non-empty signature; only the signature was ever checked
3. The outbound Anthropic request contains `{"type": "thinking", "thinking": "", "signature": "sig_abc123"}`
4. Anthropic returns `400 messages.N.content.M.thinking: each thinking block must contain thinking` and the call raises

After: the same history no longer reaches Anthropic with an empty thinking block

1. Same client call, same history
2. The block is dropped because `thinking` is empty, independent of the signature
3. The outbound request has no thinking block for that turn
4. The call proceeds instead of raising a 400

## Relevant issues

None filed. Found by code reading in `prompt_templates/factory.py` and reproduced with a unit test (below).

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally: `uv run pytest tests/test_litellm/litellm_core_utils/prompt_templates/test_litellm_core_utils_prompt_templates_factory.py -v`, 102 passed (97 pre-existing + 5 new)
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

This is a pure request-transform bug, so the proof is a unit test calling `anthropic_messages_pt()` directly with the malformed history shape and asserting the outbound content list. No live API key and no mocks; the function does no I/O.

### Before (f005afa)

#### Empty-but-signed thinking block

1. `anthropic_messages_pt()` called with `messages[1]["thinking_blocks"] = [{"type": "thinking", "thinking": "", "signature": "sig_abc123_looks_valid"}]`
2. `pytest -k test_anthropic_messages_pt_drops_empty_but_signed_thinking_block` -> FAILED: `assert 'thinking' not in ['thinking', 'text']` (the empty block was kept)

#### Whitespace-only thinking text

1. `_is_unsignable_thinking_block({"type": "thinking", "thinking": "   \n\t  ", "signature": "sig_abc123_looks_valid"})`
2. `pytest -k test_is_unsignable_thinking_block_treats_whitespace_only_as_empty` -> FAILED: `assert False is True` (the function said the block was signable)

### After (9fa8d06)

#### Empty-but-signed thinking block

1. Same call as above
2. `pytest -k test_anthropic_messages_pt_drops_empty_but_signed_thinking_block` -> PASSED, `thinking` type is absent from the outbound content list

#### Whitespace-only thinking text

1. Same call as above
2. `pytest -k test_is_unsignable_thinking_block_treats_whitespace_only_as_empty` -> PASSED, function returns `True`

Full file: `uv run pytest tests/test_litellm/litellm_core_utils/prompt_templates/test_litellm_core_utils_prompt_templates_factory.py -v` -> 102 passed, 0 failed

Also ran `ruff format --check` and `ruff check` on the two changed files. Did not run the full `make test-unit` suite (left to CI per CONTRIBUTING.md) or any live Anthropic/Vertex calls.

## Type

Bug Fix
Test

## Caveats (if any)

### Low

- The emptiness check uses `.strip()`, so whitespace-only text counts as empty. The sibling `len(thinking_block) > 0` check is always combined with `and not _is_unsignable_thinking_block(m)`, so the two agree in practice; this one is the stricter of the two because `_drop_unsignable_thinking_blocks()` calls it standalone.
- Related, not a duplicate: open PR #37624 fixes a 400 with the same error string via `apply_additional_drop_params()`. It does not touch this function.

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
