### PR TITLE
fix: return an iterable stream when interception downgrades stream:true

### DIFF
--- a/litellm/litellm_core_utils/chat_completion_agentic_loop.py
+++ b/litellm/litellm_core_utils/chat_completion_agentic_loop.py
@@ -87,16 +87,36 @@ def _check_agentic_loop_safety(
     return fingerprint
 
 
-def _wrap_response_as_fake_stream(response: object) -> object:
-    if getattr(response, "object", None) == "chat.completion.chunk":
+def _wrap_response_as_fake_stream(
+    response: object,
+    *,
+    model: str,
+    custom_llm_provider: str,
+    logging_obj: object,
+) -> object:
+    """
+    Present a non-streamed response as something the streaming path can consume.
+
+    Interception downgrades `stream: true` to a single non-streamed call so the
+    agentic loop can run, then has to hand a stream back. Returning the bare
+    converted chunk made callers fail with `TypeError: 'async for' requires an
+    object with __aiter__ method, got ModelResponseStream`, and put a
+    `chat.completion.chunk`-shaped object where a full `chat.completion` was
+    expected — which is how a malformed entry reaches the response cache and
+    later raises `KeyError: 'message'`.
+    """
+    if isinstance(response, CustomStreamWrapper):
         return response
     if not hasattr(response, "choices"):
         return response
-    from litellm.llms.base_llm.base_model_iterator import (
-        convert_model_response_to_streaming,
-    )
+    from litellm.llms.base_llm.base_model_iterator import MockResponseIterator
 
-    return convert_model_response_to_streaming(cast(ModelResponse, response))
+    return CustomStreamWrapper(
+        completion_stream=MockResponseIterator(model_response=cast(ModelResponse, response)),
+        model=model,
+        custom_llm_provider=custom_llm_provider,
+        logging_obj=logging_obj,
+    )
 
 
 def _add_agentic_loop_metadata(kwargs_for_followup: dict[str, object]) -> None:
@@ -178,7 +198,12 @@ async def _execute_chat_completion_agentic_plan(
                     str(e),
                 )
         if kwargs.get("_code_interpreter_interception_converted_stream") and not depth:
-            return _wrap_response_as_fake_stream(response_followup)
+            return _wrap_response_as_fake_stream(
+                response_followup,
+                model=model,
+                custom_llm_provider=custom_llm_provider,
+                logging_obj=logging_obj,
+            )
         return response_followup
     finally:
         try:
@@ -305,6 +330,11 @@ async def maybe_run_chat_completion_agentic_loop(
     if kwargs.get("_code_interpreter_interception_converted_stream") and not depth and hasattr(response, "choices"):
         return cast(
             "ModelResponse | CustomStreamWrapper",
-            _wrap_response_as_fake_stream(response),
+            _wrap_response_as_fake_stream(
+                response,
+                model=model,
+                custom_llm_provider=custom_llm_provider,
+                logging_obj=logging_obj,
+            ),
         )
     return None

--- a/tests/test_litellm/litellm_core_utils/test_agentic_loop_fake_stream.py
+++ b/tests/test_litellm/litellm_core_utils/test_agentic_loop_fake_stream.py
@@ -13,9 +13,7 @@ from litellm.utils import CustomStreamWrapper
 def _response() -> ModelResponse:
     return ModelResponse(
         id="chatcmpl-1",
-        choices=[
-            Choices(index=0, finish_reason="stop", message=Message(role="assistant", content="hello"))
-        ],
+        choices=[Choices(index=0, finish_reason="stop", message=Message(role="assistant", content="hello"))],
         model="gpt-4o",
         object="chat.completion",
     )
@@ -60,9 +58,7 @@ class TestWrapResponseAsFakeStream:
 
         assert chunks, "expected at least one chunk"
         assert all(getattr(c, "object", None) == "chat.completion.chunk" for c in chunks)
-        text = "".join(
-            (c.choices[0].delta.content or "") for c in chunks if getattr(c, "choices", None)
-        )
+        text = "".join((c.choices[0].delta.content or "") for c in chunks if getattr(c, "choices", None))
         assert "hello" in text
 
     def test_an_already_wrapped_stream_is_passed_through(self):

--- a/tests/test_litellm/litellm_core_utils/test_agentic_loop_fake_stream.py
+++ b/tests/test_litellm/litellm_core_utils/test_agentic_loop_fake_stream.py
@@ -1,0 +1,76 @@
+"""A downgraded stream must come back as something `async for` can consume."""
+
+import pytest
+
+from litellm.litellm_core_utils.chat_completion_agentic_loop import (
+    _wrap_response_as_fake_stream,
+)
+from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLogging
+from litellm.types.utils import Choices, Message, ModelResponse
+from litellm.utils import CustomStreamWrapper
+
+
+def _response() -> ModelResponse:
+    return ModelResponse(
+        id="chatcmpl-1",
+        choices=[
+            Choices(index=0, finish_reason="stop", message=Message(role="assistant", content="hello"))
+        ],
+        model="gpt-4o",
+        object="chat.completion",
+    )
+
+
+def _logging_obj() -> LiteLLMLogging:
+    return LiteLLMLogging(
+        model="gpt-4o",
+        messages=[{"role": "user", "content": "hi"}],
+        stream=True,
+        call_type="completion",
+        start_time=None,
+        litellm_call_id="test-call-id",
+        function_id="1",
+    )
+
+
+def _wrap(response):
+    return _wrap_response_as_fake_stream(
+        response, model="gpt-4o", custom_llm_provider="openai", logging_obj=_logging_obj()
+    )
+
+
+class TestWrapResponseAsFakeStream:
+    def test_result_is_async_iterable(self):
+        """The reported crash: `async for` got a bare ModelResponseStream."""
+        wrapped = _wrap(_response())
+
+        assert hasattr(wrapped, "__aiter__"), "result must support `async for`"
+        assert isinstance(wrapped, CustomStreamWrapper)
+
+    def test_result_is_sync_iterable_too(self):
+        wrapped = _wrap(_response())
+
+        assert hasattr(wrapped, "__iter__")
+
+    @pytest.mark.asyncio
+    async def test_yields_the_original_content_as_chunks(self):
+        wrapped = _wrap(_response())
+
+        chunks = [chunk async for chunk in wrapped]
+
+        assert chunks, "expected at least one chunk"
+        assert all(getattr(c, "object", None) == "chat.completion.chunk" for c in chunks)
+        text = "".join(
+            (c.choices[0].delta.content or "") for c in chunks if getattr(c, "choices", None)
+        )
+        assert "hello" in text
+
+    def test_an_already_wrapped_stream_is_passed_through(self):
+        wrapped = _wrap(_response())
+
+        assert _wrap(wrapped) is wrapped
+
+    def test_object_without_choices_is_returned_unchanged(self):
+        sentinel = object()
+
+        assert _wrap(sentinel) is sentinel


### PR DESCRIPTION
Fixes #37652.

## Root cause

`_wrap_response_as_fake_stream` (`litellm/litellm_core_utils/chat_completion_agentic_loop.py`)
returned the bare converted chunk:

```python
return convert_model_response_to_streaming(cast(ModelResponse, response))
```

`convert_model_response_to_streaming` returns a single `ModelResponseStream` —
one chunk, not a stream. Measured on a clean checkout:

```
returned type : ModelResponseStream
has __aiter__ : False
object field  : chat.completion.chunk
```

That is both reported symptoms in one line:

1. **The crash.** Interception downgrades `stream: true` to a single
   non-streamed call so the agentic loop can run, then hands this value back to
   the streaming path, which does `async for` over it —
   `TypeError: 'async for' requires an object with __aiter__ method, got ModelResponseStream`.
   No tool call is needed to reach it; a plain assistant reply is enough.
2. **The malformed cache entry.** The same object is `chat.completion.chunk`-shaped
   where a full `chat.completion` is expected, so a cached copy carries `delta`
   instead of `message` and a later read raises `KeyError: 'message'` inside
   `convert_to_model_response_object`. The reporter saw this in production
   without an independent repro; the `object` field above is the mechanism.

The `cast` at one of the call sites already claimed
`"ModelResponse | CustomStreamWrapper"`, which the returned value never
satisfied.

## The fix

Wrap the response in a `CustomStreamWrapper` over a `MockResponseIterator` —
the same construction `litellm/completion_extras/litellm_responses_transformation/handler.py`
already uses to present a non-streamed response as a stream. The result is
genuinely async- and sync-iterable, and the existing `cast` becomes true.

The helper needs `model`, `custom_llm_provider` and `logging_obj` to build the
wrapper; both call sites already have all three, so they are threaded through as
keyword-only arguments.

This takes option (a) from the issue — make the combination work — rather than
(b) reject it with a 4xx, since the downgrade machinery was clearly built to
support it and only the hand-back was wrong.

## Verification

Five tests in `tests/test_litellm/litellm_core_utils/test_agentic_loop_fake_stream.py`:

- the result exposes `__aiter__` and is a `CustomStreamWrapper` — the reported crash
- it is sync-iterable too
- iterating yields `chat.completion.chunk` objects that reassemble the original
  content, so the downgrade is transparent to the client
- an already-wrapped stream passes through unchanged (no double wrapping)
- an object with no `choices` is returned untouched

- `tests/test_litellm/litellm_core_utils`: **10 failures on this branch and the
  identical 10 on a clean checkout** (verified by diffing the failure lists), so
  nothing here regresses; those are pre-existing.
- `ruff format --check` clean on both touched files; `ruff check` reports the
  same 5 pre-existing findings on the source file as base, none added.
- Type-discipline checker: identical counts to base on every rule.

## Note on the cache symptom

I fixed the shape at its source rather than adding a guard in the cache layer.
If you would also like a defensive check where the entry is written — rejecting
a `chat.completion.chunk` where a `chat.completion` is expected — I am happy to
add it, but it seemed better not to paper over the producer inside this fix.



---

**On the red `code-quality` check:** it is not from this PR. It fails on every
PR against `litellm_internal_staging` right now, including ones that touch no
workflow files, because three unit shards in `.github/workflows/test-unit.yml`
cap the job below the startup-safety invariant. Fixed independently in #38046;
this PR needs no change for it.