### PR TITLE
fix(proxy): coordinate shared health database writes

### DIFF
--- a/litellm/proxy/health_check_utils/shared_health_check_manager.py
+++ b/litellm/proxy/health_check_utils/shared_health_check_manager.py
@@ -185,7 +185,7 @@ class SharedHealthCheckManager:
         details: bool = True,
         max_concurrency: int | None = None,
         health_check_skip_disabled_background_models: bool = False,
-    ) -> tuple[list[dict[str, Any]], list[dict[str, Any]], dict[str, Any]]:
+    ) -> tuple[list[dict[str, Any]], list[dict[str, Any]], dict[str, Any], bool]:
         """
         Perform health check with shared state coordination.
 
@@ -203,7 +203,7 @@ class SharedHealthCheckManager:
             health_check_skip_disabled_background_models: Remove models with disable_background_health_check: true
 
         Returns:
-            Tuple of (healthy_endpoints, unhealthy_endpoints)
+            Tuple of (healthy_endpoints, unhealthy_endpoints, exceptions_by_model_id, should_persist)
         """
         # First, try to get cached results
         cached_results = await self.get_cached_health_check_results()
@@ -212,6 +212,7 @@ class SharedHealthCheckManager:
                 cached_results.get("healthy_endpoints", []),
                 cached_results.get("unhealthy_endpoints", []),
                 {},
+                False,
             )
 
         # No recent cache, try to acquire lock
@@ -240,7 +241,7 @@ class SharedHealthCheckManager:
                 # Cache the results
                 await self.cache_health_check_results(healthy_endpoints, unhealthy_endpoints)
 
-                return healthy_endpoints, unhealthy_endpoints, exceptions_by_model_id
+                return healthy_endpoints, unhealthy_endpoints, exceptions_by_model_id, True
 
             finally:
                 # Always release the lock
@@ -249,12 +250,13 @@ class SharedHealthCheckManager:
             # If Redis is not configured, skip polling — there is no cache
             # to wait for.
             if self.redis_cache is None:
-                return await perform_health_check(
+                healthy_endpoints, unhealthy_endpoints, exceptions_by_model_id = await perform_health_check(
                     model_list=model_list,
                     details=details,
                     max_concurrency=max_concurrency,
                     health_check_skip_disabled_background_models=health_check_skip_disabled_background_models,
                 )
+                return healthy_endpoints, unhealthy_endpoints, exceptions_by_model_id, True
 
             # Lock not acquired — poll for cached results until the lock
             # holder finishes or the lock expires, rather than falling back
@@ -280,6 +282,7 @@ class SharedHealthCheckManager:
                         cached_results.get("healthy_endpoints", []),
                         cached_results.get("unhealthy_endpoints", []),
                         {},
+                        False,
                     )
 
                 # Check if the lock is still held — if it was released without
@@ -304,12 +307,13 @@ class SharedHealthCheckManager:
                 elapsed,
             )
 
-            return await perform_health_check(
+            healthy_endpoints, unhealthy_endpoints, exceptions_by_model_id = await perform_health_check(
                 model_list=model_list,
                 details=details,
                 max_concurrency=max_concurrency,
                 health_check_skip_disabled_background_models=health_check_skip_disabled_background_models,
             )
+            return healthy_endpoints, unhealthy_endpoints, exceptions_by_model_id, True
 
     async def is_health_check_in_progress(self) -> bool:
         """

--- a/litellm/proxy/health_endpoints/_health_endpoints.py
+++ b/litellm/proxy/health_endpoints/_health_endpoints.py
@@ -692,18 +692,16 @@ async def _save_health_check_results_if_changed(
                         should_save = False
 
         if should_save:
-            asyncio.create_task(
-                prisma_client.save_health_check_result(
-                    model_name=result["model_name"],
-                    model_id=result["model_id"],
-                    status=new_status,
-                    healthy_count=result["healthy_count"],
-                    unhealthy_count=result["unhealthy_count"],
-                    error_message=result["error_message"],
-                    response_time_ms=(time.time() - start_time) * 1000,
-                    details=None,
-                    checked_by=checked_by,
-                )
+            await prisma_client.save_health_check_result(
+                model_name=result["model_name"],
+                model_id=result["model_id"],
+                status=new_status,
+                healthy_count=result["healthy_count"],
+                unhealthy_count=result["unhealthy_count"],
+                error_message=result["error_message"],
+                response_time_ms=(time.time() - start_time) * 1000,
+                details=None,
+                checked_by=checked_by,
             )
 
 

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -3420,9 +3420,10 @@ def _schedule_background_health_check_db_save(
     model_list: list,
     healthy_endpoints: list,
     unhealthy_endpoints: list,
+    should_persist: bool = True,
 ):
     """Fire-and-forget: persist health check results to DB if prisma is available."""
-    if prisma_client is None:
+    if prisma_client is None or not should_persist:
         return
     import time as time_module
 
@@ -3662,6 +3663,7 @@ async def _run_background_health_check():
                     healthy_endpoints,
                     unhealthy_endpoints,
                     _exceptions_by_model_id,
+                    should_persist_health_check_results,
                 ) = await shared_health_manager.perform_shared_health_check(
                     model_list=_llm_model_list,
                     details=details_bool,
@@ -3683,6 +3685,7 @@ async def _run_background_health_check():
                     health_check_concurrency,
                     instrumentation_context,
                 )
+                should_persist_health_check_results = True
         else:
             (
                 healthy_endpoints,
@@ -3694,6 +3697,7 @@ async def _run_background_health_check():
                 health_check_concurrency,
                 instrumentation_context,
             )
+            should_persist_health_check_results = True
 
         # Update the global variable with the health check results
         health_check_results["healthy_endpoints"] = healthy_endpoints
@@ -3727,6 +3731,7 @@ async def _run_background_health_check():
             _llm_model_list,
             healthy_endpoints,
             unhealthy_endpoints,
+            should_persist=should_persist_health_check_results,
         )
 
         # Write health state to router cache for health-check-driven routing

--- a/tests/test_litellm/proxy/proxy_server/test_background_health.py
+++ b/tests/test_litellm/proxy/proxy_server/test_background_health.py
@@ -220,6 +220,30 @@ def test_schedule_background_health_check_db_save_noop_when_prisma_none():
 
 
 @pytest.mark.asyncio
+async def test_schedule_background_health_check_db_save_noop_for_cached_results(
+    monkeypatch,
+):
+    save = AsyncMock()
+
+    import litellm.proxy.health_endpoints._health_endpoints as he
+
+    monkeypatch.setattr(he, "_save_background_health_checks_to_db", save)
+
+    _schedule_background_health_check_db_save(
+        prisma_client=MagicMock(),
+        shared_health_manager=SimpleNamespace(pod_id="cache-reader"),
+        model_list=[{"model_name": "gpt-4"}],
+        healthy_endpoints=[{"model_id": "h1"}],
+        unhealthy_endpoints=[],
+        should_persist=False,
+    )
+
+    await asyncio.sleep(0)
+
+    save.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_schedule_background_health_check_db_save_invalid_no_event_loop_raises(
     monkeypatch,
 ):

--- a/tests/test_litellm/proxy/test_health_check_functions.py
+++ b/tests/test_litellm/proxy/test_health_check_functions.py
@@ -419,6 +419,43 @@ async def test_save_background_health_checks_to_db():
 
 
 @pytest.mark.asyncio
+async def test_save_background_health_checks_to_db_waits_for_model_writes():
+    write_started = asyncio.Event()
+    release_write = asyncio.Event()
+
+    async def slow_save(**_kwargs):
+        write_started.set()
+        await release_write.wait()
+
+    mock_prisma = MagicMock()
+    mock_prisma.save_health_check_result = AsyncMock(side_effect=slow_save)
+    mock_prisma.get_all_latest_health_checks = AsyncMock(return_value=[])
+    save_task = asyncio.create_task(
+        _save_background_health_checks_to_db(
+            mock_prisma,
+            [
+                {
+                    "model_name": "gpt-3.5-turbo",
+                    "model_info": {"id": "model-123"},
+                    "litellm_params": {"model": "gpt-3.5-turbo"},
+                }
+            ],
+            [{"model": "gpt-3.5-turbo"}],
+            [],
+            time.time(),
+            "background_health_check",
+        )
+    )
+
+    await write_started.wait()
+
+    assert save_task.done() is False
+
+    release_write.set()
+    await save_task
+
+
+@pytest.mark.asyncio
 async def test_save_background_health_checks_to_db_no_prisma():
     """Test graceful handling when no prisma client"""
     result = await _save_background_health_checks_to_db(

--- a/tests/test_litellm/proxy/test_shared_health_check.py
+++ b/tests/test_litellm/proxy/test_shared_health_check.py
@@ -270,7 +270,7 @@ class TestSharedHealthCheckManager:
         with patch(
             "litellm.proxy.health_check_utils.shared_health_check_manager.perform_health_check"
         ) as mock_perform:
-            healthy, unhealthy, _ = (
+            healthy, unhealthy, _, should_persist = (
                 await shared_health_manager.perform_shared_health_check(
                     model_list, details=True
                 )
@@ -279,6 +279,7 @@ class TestSharedHealthCheckManager:
         # Should return cached results, not call perform_health_check
         assert healthy == [{"model": "cached-model"}]
         assert unhealthy == []
+        assert should_persist is False
         mock_perform.assert_not_called()
 
     @pytest.mark.asyncio
@@ -302,7 +303,7 @@ class TestSharedHealthCheckManager:
         ) as mock_perform:
             mock_perform.return_value = (expected_healthy, expected_unhealthy, {})
 
-            healthy, unhealthy, _ = (
+            healthy, unhealthy, _, should_persist = (
                 await shared_health_manager.perform_shared_health_check(
                     model_list, details=True
                 )
@@ -317,6 +318,7 @@ class TestSharedHealthCheckManager:
         )
         assert healthy == expected_healthy
         assert unhealthy == expected_unhealthy
+        assert should_persist is True
 
         # Should cache the results
         assert mock_redis_cache.async_set_cache.call_count >= 2  # Lock + cache
@@ -347,7 +349,7 @@ class TestSharedHealthCheckManager:
         ]
 
         with patch("asyncio.sleep") as mock_sleep:  # Mock sleep to avoid actual delay
-            healthy, unhealthy, _ = (
+            healthy, unhealthy, _, should_persist = (
                 await shared_health_manager.perform_shared_health_check(
                     model_list, details=True
                 )
@@ -357,6 +359,7 @@ class TestSharedHealthCheckManager:
         mock_sleep.assert_called_once_with(5)
         assert healthy == [{"model": "cached-model"}]
         assert unhealthy == []
+        assert should_persist is False
 
     @pytest.mark.asyncio
     async def test_perform_shared_health_check_fallback(self, mock_redis_cache):
@@ -392,7 +395,7 @@ class TestSharedHealthCheckManager:
         ):
             mock_perform.return_value = (expected_healthy, expected_unhealthy, {})
 
-            healthy, unhealthy, _ = await manager.perform_shared_health_check(
+            healthy, unhealthy, _, should_persist = await manager.perform_shared_health_check(
                 model_list, details=True
             )
 
@@ -407,6 +410,7 @@ class TestSharedHealthCheckManager:
         )
         assert healthy == expected_healthy
         assert unhealthy == expected_unhealthy
+        assert should_persist is True
 
     @pytest.mark.asyncio
     async def test_perform_shared_health_check_early_exit_orphaned_lock(
@@ -434,7 +438,7 @@ class TestSharedHealthCheckManager:
         ):
             mock_perform.return_value = (expected_healthy, expected_unhealthy, {})
 
-            healthy, unhealthy, _ = (
+            healthy, unhealthy, _, should_persist = (
                 await shared_health_manager.perform_shared_health_check(
                     model_list, details=True
                 )
@@ -450,6 +454,7 @@ class TestSharedHealthCheckManager:
         )
         assert healthy == expected_healthy
         assert unhealthy == expected_unhealthy
+        assert should_persist is True
 
     @pytest.mark.asyncio
     async def test_perform_shared_health_check_redis_error_during_polling(
@@ -478,7 +483,7 @@ class TestSharedHealthCheckManager:
         ]
 
         with patch("asyncio.sleep") as mock_sleep:
-            healthy, unhealthy, _ = (
+            healthy, unhealthy, _, should_persist = (
                 await shared_health_manager.perform_shared_health_check(
                     model_list, details=True
                 )
@@ -488,6 +493,7 @@ class TestSharedHealthCheckManager:
         assert mock_sleep.call_count == 2
         assert healthy == [{"model": "cached-model"}]
         assert unhealthy == []
+        assert should_persist is False
 
     @pytest.mark.asyncio
     async def test_perform_shared_health_check_no_redis_skips_polling(self):
@@ -508,7 +514,7 @@ class TestSharedHealthCheckManager:
         ):
             mock_perform.return_value = (expected_healthy, expected_unhealthy, {})
 
-            healthy, unhealthy, _ = await manager.perform_shared_health_check(
+            healthy, unhealthy, _, should_persist = await manager.perform_shared_health_check(
                 model_list, details=True
             )
 
@@ -522,6 +528,7 @@ class TestSharedHealthCheckManager:
         )
         assert healthy == expected_healthy
         assert unhealthy == expected_unhealthy
+        assert should_persist is True
 
     @pytest.mark.asyncio
     async def test_is_health_check_in_progress_true(


### PR DESCRIPTION
## TLDR

Problem this solves:

- Cache consumers repeat PostgreSQL health-history reads
- Slow model writes escape their persistence task

How it solves it:

- Only locally executed checks persist results
- Persistence waits for selected model writes

## User Flow

Before: a proxy admin enables shared health checks but database activity still scales with every worker

1. The admin enables `background_health_checks` and `use_shared_health_check`
2. They deploy multiple proxy pods with several workers each
3. They observe one provider check but repeated health-history database reads
4. During database pressure, model writes continue after their scheduling task finishes

After: the same deployment shares both provider checks and persistence ownership

1. The admin enables `background_health_checks` and `use_shared_health_check`
2. They deploy multiple proxy pods with several workers each
3. They observe cache-consuming workers perform no health-history database work
4. The worker that ran the provider check waits for its selected writes

## Relevant issues

Fixes #38057

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

The reproduction is documented in #38057. Live before/after proof requires a multi-worker proxy backed by PostgreSQL

## Type

🐛 Bug Fix

## Caveats (if any)

- Does not change Prisma connection-pool sizing

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR