### PR TITLE
fix(url-utils): run URL validation off the event loop

### DIFF
--- a/litellm/litellm_core_utils/url_utils.py
+++ b/litellm/litellm_core_utils/url_utils.py
@@ -19,6 +19,7 @@ Admins can opt out via two ``litellm`` globals (wired from proxy config):
   check but still resolve DNS and still rewrite HTTP to the resolved IP.
 """
 
+import asyncio
 import socket
 from ipaddress import ip_address, ip_network
 from typing import Any, Final
@@ -413,14 +414,21 @@ def safe_get(client: Any, url: str, **kwargs: Any) -> Any:
 
 
 async def async_safe_get(client: Any, url: str, **kwargs: Any) -> Any:
-    """Async version of safe_get."""
+    """Async version of safe_get.
+
+    ``validate_url`` resolves DNS through the blocking ``socket.getaddrinfo``,
+    and the hostname comes from the caller-supplied URL, so run it in a worker
+    thread. Resolving on the event loop lets one URL pointed at a stalling
+    nameserver pin the loop for the resolver timeout and stall every other
+    in-flight request on the worker.
+    """
     if not getattr(litellm, "user_url_validation", True):
         kwargs.setdefault("follow_redirects", True)
         return await client.get(url, **kwargs)
     kwargs.pop("follow_redirects", None)
     caller_headers: Final = kwargs.pop("headers", {})
     for _ in range(_MAX_REDIRECTS):
-        validated_url, original_host = validate_url(url)
+        validated_url, original_host = await asyncio.to_thread(validate_url, url)
         response = await client.get(
             validated_url,
             headers={**caller_headers, "Host": original_host},

--- a/tests/test_litellm/litellm_core_utils/test_url_utils.py
+++ b/tests/test_litellm/litellm_core_utils/test_url_utils.py
@@ -535,3 +535,77 @@ def test_assert_same_origin_error_message_does_not_leak_hostnames():
     detail = str(exc.value)
     assert "attacker.example.com" not in detail
     assert "api.internal-corp.example" not in detail
+
+
+class TestAsyncSafeGetDoesNotBlockEventLoop:
+    """``validate_url`` calls the blocking ``socket.getaddrinfo``.
+
+    Every ``async_safe_get`` caller fetches a URL that came from the request
+    body (``image_url``/``file_url`` on a chat completion, an A2A agent-card
+    URL, an OpenAPI spec URL for an MCP server, a RAG ingestion file URL), so
+    an unprivileged caller picks the hostname that gets resolved. If that
+    resolution runs on the event loop, one caller pointing at a stalling
+    authoritative nameserver freezes every other in-flight request on the
+    worker for the resolver timeout.
+    """
+
+    @staticmethod
+    def _fake_response():
+        class _Resp:
+            is_redirect = False
+            status_code = 200
+
+        return _Resp()
+
+    class _FakeAsyncClient:
+        async def get(self, url, **kwargs):
+            return TestAsyncSafeGetDoesNotBlockEventLoop._fake_response()
+
+    async def test_event_loop_stays_responsive_during_dns_resolution(
+        self, monkeypatch
+    ):
+        import asyncio
+        import time
+
+        dns_delay = 0.5
+
+        def slow_getaddrinfo(host, port, *args, **kwargs):
+            time.sleep(dns_delay)
+            return [
+                (
+                    socket.AF_INET,
+                    socket.SOCK_STREAM,
+                    6,
+                    "",
+                    ("93.184.216.34", port or 443),
+                )
+            ]
+
+        monkeypatch.setattr(url_utils.socket, "getaddrinfo", slow_getaddrinfo)
+
+        ticks = 0
+        stop = False
+
+        async def heartbeat():
+            nonlocal ticks
+            while not stop:
+                await asyncio.sleep(0.01)
+                ticks += 1
+
+        beat = asyncio.create_task(heartbeat())
+        try:
+            response = await url_utils.async_safe_get(
+                self._FakeAsyncClient(), "https://images.example.com/cat.png"
+            )
+        finally:
+            stop = True
+            await beat
+
+        assert response.status_code == 200
+        # ~50 ticks are due while DNS is in flight; require a fraction of
+        # that so the assertion is not timing-fragile, but 0-1 ticks (the
+        # loop pinned for the whole resolution) still fails.
+        assert ticks >= 10, (
+            f"event loop was blocked during DNS resolution: only {ticks} "
+            "heartbeat ticks fired while validate_url resolved the hostname"
+        )


### PR DESCRIPTION
## TLDR

Problem this solves:

- User-supplied URLs are DNS-resolved on the event loop
- One slow-resolving hostname stalls every concurrent request
- Affects image_url, file_url, A2A cards, MCP specs

How it solves it:

- Run `validate_url` in a worker thread via `asyncio.to_thread`
- Keeps SSRF validation identical; only moves it off-loop

## User Flow

Before: a developer streaming chat completions sees unrelated requests hang for seconds whenever anyone on the same proxy sends an image URL whose hostname is slow to resolve

1. Developer A sends POST https://litellm-domain/v1/chat/completions with an `image_url` content part pointing at `https://images.slow-dns.example/cat.png`, whose authoritative nameserver takes 2s to answer
2. Developer B, at the same moment, sends a plain POST https://litellm-domain/v1/chat/completions with no image and a fast model
3. Developer B gets no bytes back for ~2s: their first SSE chunk, and even the initial response headers, are held until As hostname finishes resolving
4. Repeating step 1 a few times per second makes Bs p99 latency track the slow lookup instead of the model
5. https://litellm-domain/health/readiness is slow to answer for the same window

After: the same slow image URL only delays the request that asked for it

1. Developer A sends the same POST https://litellm-domain/v1/chat/completions with the `image_url` pointing at `https://images.slow-dns.example/cat.png`
2. Developer B, at the same moment, sends the same plain POST https://litellm-domain/v1/chat/completions
3. Developer B gets their response with normal latency; As lookup no longer holds it
4. Developer A still waits ~2s for their own request, which is the real cost of their own URL
5. https://litellm-domain/health/readiness answers normally throughout

## Relevant issues

<!-- none -->

## Linear ticket

<!-- external contributor -->

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PRs scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

## Screenshots / Proof of Fix

Shared setup: a 12-line script that stands in a 2s-slow authoritative nameserver for
`images.slow-dns.example` and drives the real chat-completions image path
(`async_convert_url_to_base64` -> `async_safe_get` -> `validate_url`) while a probe
coroutine measures how often the event loop gets to run.

### Before (f005afa1460385a218be8ef1fdfa49998bf93523)

1. `python loop_lag_demo.py`
2. Observed:
```
image fetch returned      : data:image/png;base64,iV...
wall time for the fetch   : 2.00s (DNS stall = 2.0s)
loop probe iterations     : 0
max event-loop lag        : n/a (loop never ran)
```
The loop did not run once for the whole 2s — every other coroutine on that worker was frozen.

3. `uv run pytest tests/test_litellm/litellm_core_utils/test_url_utils.py -q`
```
E       AssertionError: event loop was blocked during DNS resolution: only 0 heartbeat ticks fired while validate_url resolved the hostname
E       assert 0 >= 10
1 failed, 68 passed in 1.33s
```

### After (staged tip of fix/url-validation-off-event-loop)

1. `python loop_lag_demo.py`
2. Observed:
```
image fetch returned      : data:image/png;base64,iV...
wall time for the fetch   : 2.00s (DNS stall = 2.0s)
loop probe iterations     : 198
max event-loop lag        : 0.8 ms
```
The requesting coroutine still waits its own 2s; the loop stays responsive throughout.

3. `uv run pytest tests/test_litellm/litellm_core_utils/test_url_utils.py -q`
```
69 passed in 1.31s
```

## Type

🐛 Bug Fix

## Caveats (if any)

- Uses the default executor; a large burst can still saturate it
- Sync `safe_get` is unchanged; it has no event loop to block
- `user_url_validation: false` path unchanged (no validation to move)

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
