### PR TITLE
fix: correct typos in helm README and log/docstring text

### DIFF
--- a/helm/litellm-helm/README.md
+++ b/helm/litellm-helm/README.md
@@ -156,7 +156,7 @@ data:
 type: Opaque
 ```
 
-#### Examples for `environmentSecrets` and `environemntConfigMaps`
+#### Examples for `environmentSecrets` and `environmentConfigMaps`
 
 ```yaml
 # Use config map for not-secret configuration data

--- a/litellm/experimental_mcp_client/client.py
+++ b/litellm/experimental_mcp_client/client.py
@@ -1,5 +1,5 @@
 """
-LiteLLM Proxy uses this MCP Client to connnect to other MCP servers.
+LiteLLM Proxy uses this MCP Client to connect to other MCP servers.
 """
 
 import asyncio

--- a/litellm/router_strategy/budget_limiter.py
+++ b/litellm/router_strategy/budget_limiter.py
@@ -772,7 +772,7 @@ class RouterBudgetLimiting(CustomLogger):
                     )
                 )
 
-            verbose_router_logger.debug("Initalized Provider budget config: %s", self.provider_budget_config)
+            verbose_router_logger.debug("Initialized Provider budget config: %s", self.provider_budget_config)
 
     def _init_deployment_budgets(
         self,


### PR DESCRIPTION
Three typo fixes, no behavior change:

- `helm/litellm-helm/README.md`: the examples heading referenced `environemntConfigMaps`. The actual chart value is `environmentConfigMaps` (see `values.yaml` line 81 and `templates/deployment.yaml`), and the same README's values table already spells it correctly — so the heading was the odd one out.
- `litellm/experimental_mcp_client/client.py`: module docstring "connnect" -> "connect".
- `litellm/router_strategy/budget_limiter.py`: debug log message "Initalized" -> "Initialized".

Targeting `litellm_internal_staging` to match the repo's default branch.