### PR TITLE
fix(cost): use deployment model for router aliases

### DIFF
--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -1609,9 +1609,10 @@ class Logging(LiteLLMLoggingBaseClass):
             cache_hit = self.model_call_details.get("cache_hit", False)
 
         try:
+            model_for_cost: Final = litellm_model_name or self.get_deployment_model_for_cost()
             response_cost_calculator_kwargs: Final = {
                 "response_object": result,
-                "model": litellm_model_name or self.model,
+                "model": model_for_cost,
                 "cache_hit": cache_hit,
                 "custom_llm_provider": self.model_call_details.get("custom_llm_provider", None),
                 "base_model": _get_base_model_from_metadata(model_call_details=self.model_call_details),
@@ -1632,7 +1633,7 @@ class Logging(LiteLLMLoggingBaseClass):
                     custom_llm_provider=self.model_call_details.get("custom_llm_provider", None),
                     litellm_params=(self.litellm_params if hasattr(self, "litellm_params") else None),
                     optional_params=self.optional_params,
-                    model=litellm_model_name or self.model,
+                    model=model_for_cost,
                 ),
             }
         except Exception as e:  # error creating kwargs for cost calculation

--- a/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
+++ b/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
@@ -281,6 +281,56 @@ def test_response_cost_calculator_uses_router_model_id_from_litellm_metadata():
         litellm.model_cost.pop(custom_model_id, None)
 
 
+def test_response_cost_calculator_uses_deployment_model_for_router_alias():
+    """A streamed router alias must not hide the provider-qualified deployment model."""
+    from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObj
+
+    alias_model = "vertex/claude-alias-cost-test"
+    deployment_model = "vertex_ai/claude-alias-cost-test"
+    input_cost = 2.0
+    output_cost = 3.0
+
+    litellm.register_model(
+        model_cost={
+            deployment_model: {
+                "input_cost_per_token": input_cost,
+                "output_cost_per_token": output_cost,
+                "max_tokens": 128000,
+                "max_input_tokens": 128000,
+                "max_output_tokens": 16384,
+                "litellm_provider": "vertex_ai",
+            }
+        }
+    )
+
+    try:
+        logging_obj = LiteLLMLoggingObj(
+            model=alias_model,
+            messages=[{"role": "user", "content": "Hi"}],
+            stream=True,
+            call_type="completion",
+            start_time=time.time(),
+            litellm_call_id="test-router-alias-cost",
+            function_id="test-fn",
+        )
+        logging_obj.optional_params = {}
+        logging_obj.model_call_details["model"] = deployment_model
+        logging_obj.model_call_details["custom_llm_provider"] = "vertex_ai"
+
+        response_obj = ModelResponse(
+            id="chatcmpl-router-alias-cost",
+            model=alias_model,
+            choices=[],
+            usage={"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15},
+        )
+
+        cost = logging_obj._response_cost_calculator(result=response_obj)
+
+        assert cost == pytest.approx((10 * input_cost) + (5 * output_cost))
+    finally:
+        litellm.model_cost.pop(deployment_model, None)
+
+
 class TestGetRouterModelId:
     """Tests for the get_router_model_id helper method."""
 


### PR DESCRIPTION
## TLDR

Problem this solves:

- Streamed router aliases can be prefixed twice during cost lookup
- The resulting key misses pricing and records zero spend

How it solves it:

- Use the provider-qualified deployment model when calculating cost
- Add a regression test for a slash-containing router alias

## User Flow

Before: a streamed request through a router alias can show zero spend

1. An administrator configures a model alias such as vertex/claude-opus-5
2. A developer sends a streamed request through that alias
3. The request succeeds and token counts are recorded, but the spend can be shown as $0

After: the same streamed request is priced against its deployment

1. An administrator configures the same model alias
2. A developer sends the same streamed request
3. The request succeeds with the same token counts, and spend uses the provider-qualified deployment pricing

## Relevant issues

Fixes #38069

## Linear ticket


## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The focused regression tests pass locally
- [ ] My PR passes all required CI/CD checks
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile Confidence Score of at least 4/5

## Screenshots / Proof of Fix

### Before (f005afa146)

#### Router alias cost lookup

1. A streamed response carries the router-facing alias vertex/claude-opus-5
2. The cost path receives the same alias as its model input
3. The provider prefix can be added twice, producing a key absent from the pricing map

### After (5a88da02d0)

#### Router alias cost lookup

1. A streamed response still carries the router-facing alias vertex/claude-alias-cost-test
2. The cost path uses vertex_ai/claude-alias-cost-test from the selected deployment
3. uv run pytest tests/test_litellm/litellm_core_utils/test_litellm_logging.py -k response_cost_calculator_uses_deployment_model_for_router_alias -q
4. 1 passed

## Type

🐛 Bug Fix

## Caveats

- The full local logging file run is missing the optional orjson dependency
- The focused regression test and production Ruff check pass locally

### Final Attestation

- [x] The tests cover the router-alias regression described by the issue