### PR TITLE
fix(pricing): correct claude-3-haiku/opus 1-hour cache write prices

### DIFF
--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -12269,7 +12269,7 @@
     },
     "claude-3-haiku-20240307": {
         "cache_creation_input_token_cost": 3e-07,
-        "cache_creation_input_token_cost_above_1hr": 6e-06,
+        "cache_creation_input_token_cost_above_1hr": 5e-07,
         "cache_read_input_token_cost": 3e-08,
         "deprecation_date": "2026-04-20",
         "input_cost_per_token": 2.5e-07,
@@ -12288,7 +12288,7 @@
     },
     "claude-3-opus-20240229": {
         "cache_creation_input_token_cost": 1.875e-05,
-        "cache_creation_input_token_cost_above_1hr": 6e-06,
+        "cache_creation_input_token_cost_above_1hr": 3e-05,
         "cache_read_input_token_cost": 1.5e-06,
         "deprecation_date": "2026-01-05",
         "input_cost_per_token": 1.5e-05,


### PR DESCRIPTION
Fixes #38056

## Summary

`cache_creation_input_token_cost_above_1hr` for `claude-3-haiku-20240307` and `claude-3-opus-20240229` carried the $3/M Sonnet tier's `6e-06`. Per [Anthropic prompt-caching docs](https://platform.claude.com/docs/en/build-with-claude/prompt-caching), 1-hour cache writes are 2x base input price:

| model | input | before | after | ratio after |
| --- | --- | --- | --- | --- |
| claude-3-haiku-20240307 | 2.5e-07 ($0.25/M) | 6e-06 (24.0x, billed 12x too high) | **5e-07** | 2.00x |
| claude-3-opus-20240229 | 1.5e-05 ($15/M) | 6e-06 (0.4x, billed 5x too low) | **3e-05** | 2.00x |

Sanity anchor: `claude-opus-4-1` (also $15/M input) already carries 3e-05.

## Verification

Ran the ratio invariant across all 24 `litellm_provider: anthropic` entries that set this field — all at exactly 2.00x input price after the change (was 22/24 before).

Note: haiku's other cache fields (write 3e-07 = published $0.30/M, read 3e-08 = $0.03/M) follow Anthropic's own rounded Haiku figures and were intentionally left unchanged, as flagged in the issue.