### PR TITLE
fix(anthropic): close abandoned streaming responses

### DIFF
--- a/litellm/llms/anthropic/chat/handler.py
+++ b/litellm/llms/anthropic/chat/handler.py
@@ -183,6 +183,7 @@ def make_sync_call(
         speed=speed,
         tool_name_reverse_map=tool_name_reverse_map,
     )
+    completion_stream.http_response = response
 
     # LOGGING
     logging_obj.post_call(
@@ -635,6 +636,7 @@ class ModelResponseIterator:
     ):
         self.streaming_response = streaming_response
         self.response_iterator = self.streaming_response
+        self.sync_stream = sync_stream
         self.http_response: httpx.Response | None = None
         self.content_blocks: list[ContentBlockDelta] = []
         self.tool_index = -1
@@ -693,6 +695,9 @@ class ModelResponseIterator:
         response: Final = self.http_response
         self.http_response = None
         if response is None:
+            return
+        if self.sync_stream:
+            response.close()
             return
         await response.aclose()
 

--- a/litellm/llms/anthropic/chat/handler.py
+++ b/litellm/llms/anthropic/chat/handler.py
@@ -114,6 +114,7 @@ async def make_call(
         speed=speed,
         tool_name_reverse_map=tool_name_reverse_map,
     )
+    completion_stream.http_response = response
 
     # LOGGING
     logging_obj.post_call(
@@ -634,6 +635,7 @@ class ModelResponseIterator:
     ):
         self.streaming_response = streaming_response
         self.response_iterator = self.streaming_response
+        self.http_response: httpx.Response | None = None
         self.content_blocks: list[ContentBlockDelta] = []
         self.tool_index = -1
         self.json_mode = json_mode
@@ -686,6 +688,13 @@ class ModelResponseIterator:
     @accumulated_json.setter
     def accumulated_json(self, value: str) -> None:
         self._json_buffer.set(value)
+
+    async def aclose(self) -> None:
+        response: Final = self.http_response
+        self.http_response = None
+        if response is None:
+            return
+        await response.aclose()
 
     def check_empty_tool_call_args(self) -> bool:
         """

--- a/tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_handler.py
+++ b/tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_handler.py
@@ -1,18 +1,35 @@
 import json
 import threading
+from collections.abc import AsyncIterator
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from typing import Final
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import anyio
+import httpx
 import pytest
 
 import litellm
 from litellm.constants import RESPONSE_FORMAT_TOOL_NAME
+from litellm.litellm_core_utils.streaming_handler import CustomStreamWrapper
 from litellm.llms.anthropic.chat.handler import ModelResponseIterator, make_call
 from litellm.types.llms.openai import (
     ChatCompletionToolCallChunk,
     ChatCompletionToolCallFunctionChunk,
 )
 from litellm.types.responses.main import OutputCodeInterpreterCall
+
+
+class _RecordingAsyncByteStream(httpx.AsyncByteStream):
+    def __init__(self) -> None:
+        self.aclose_calls: int = 0
+
+    async def __aiter__(self) -> AsyncIterator[bytes]:
+        yield b'data: {"type":"message_start"}\n\n'
+
+    async def aclose(self) -> None:
+        await anyio.sleep(0)
+        self.aclose_calls += 1
 
 
 @pytest.mark.asyncio
@@ -44,6 +61,43 @@ async def test_make_call_passes_logging_obj_to_client_post():
     mock_client.post.assert_called_once()
     call_kwargs = mock_client.post.call_args[1]
     assert call_kwargs.get("logging_obj") is logging_obj
+
+
+@pytest.mark.asyncio
+async def test_make_call_stream_cleanup_closes_http_response_once_under_cancellation():
+    stream: Final = _RecordingAsyncByteStream()
+    response: Final = httpx.Response(200, stream=stream)
+    mock_client: Final = AsyncMock()
+    mock_client.post.return_value = response
+    logging_obj: Final = MagicMock(model_call_details={"litellm_params": {}})
+
+    completion_stream, _ = await make_call(
+        client=mock_client,
+        api_base="https://api.anthropic.com/v1/messages",
+        headers={},
+        data="{}",
+        model="claude-haiku-4-5",
+        messages=[{"role": "user", "content": "Hi"}],
+        logging_obj=logging_obj,
+        timeout=60.0,
+        json_mode=False,
+    )
+    wrapper: Final = CustomStreamWrapper(
+        completion_stream=completion_stream,
+        model="claude-haiku-4-5",
+        custom_llm_provider="anthropic",
+        logging_obj=logging_obj,
+    )
+
+    with anyio.CancelScope() as cancel_scope:
+        cancel_scope.cancel()
+        await wrapper.aclose()
+    await wrapper.aclose()
+    await completion_stream.aclose()
+
+    assert response.is_closed is True
+    assert completion_stream.http_response is None
+    assert stream.aclose_calls == 1
 
 
 def test_redacted_thinking_content_block_delta():

--- a/tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_handler.py
+++ b/tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_handler.py
@@ -1,6 +1,6 @@
 import json
 import threading
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Iterator
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from typing import Final
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -12,7 +12,11 @@ import pytest
 import litellm
 from litellm.constants import RESPONSE_FORMAT_TOOL_NAME
 from litellm.litellm_core_utils.streaming_handler import CustomStreamWrapper
-from litellm.llms.anthropic.chat.handler import ModelResponseIterator, make_call
+from litellm.llms.anthropic.chat.handler import (
+    ModelResponseIterator,
+    make_call,
+    make_sync_call,
+)
 from litellm.types.llms.openai import (
     ChatCompletionToolCallChunk,
     ChatCompletionToolCallFunctionChunk,
@@ -30,6 +34,17 @@ class _RecordingAsyncByteStream(httpx.AsyncByteStream):
     async def aclose(self) -> None:
         await anyio.sleep(0)
         self.aclose_calls += 1
+
+
+class _RecordingSyncByteStream(httpx.SyncByteStream):
+    def __init__(self) -> None:
+        self.close_calls: int = 0
+
+    def __iter__(self) -> Iterator[bytes]:
+        yield b'data: {"type":"message_start"}\n\n'
+
+    def close(self) -> None:
+        self.close_calls += 1
 
 
 @pytest.mark.asyncio
@@ -98,6 +113,41 @@ async def test_make_call_stream_cleanup_closes_http_response_once_under_cancella
     assert response.is_closed is True
     assert completion_stream.http_response is None
     assert stream.aclose_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_make_sync_call_stream_cleanup_closes_http_response_once():
+    stream: Final = _RecordingSyncByteStream()
+    response: Final = httpx.Response(200, stream=stream)
+    mock_client: Final = MagicMock()
+    mock_client.post.return_value = response
+    logging_obj: Final = MagicMock(model_call_details={"litellm_params": {}})
+
+    completion_stream, _ = make_sync_call(
+        client=mock_client,
+        api_base="https://api.anthropic.com/v1/messages",
+        headers={},
+        data="{}",
+        model="claude-haiku-4-5",
+        messages=[{"role": "user", "content": "Hi"}],
+        logging_obj=logging_obj,
+        timeout=60.0,
+        json_mode=False,
+    )
+    wrapper: Final = CustomStreamWrapper(
+        completion_stream=completion_stream,
+        model="claude-haiku-4-5",
+        custom_llm_provider="anthropic",
+        logging_obj=logging_obj,
+    )
+
+    await wrapper.aclose()
+    await wrapper.aclose()
+    await completion_stream.aclose()
+
+    assert response.is_closed is True
+    assert completion_stream.http_response is None
+    assert stream.close_calls == 1
 
 
 def test_redacted_thinking_content_block_delta():


### PR DESCRIPTION
## TLDR

Problem this solves:

- Abandoned synchronous and asynchronous Anthropic streams retain their upstream HTTP response
- Repeated disconnects can exhaust the provider connection pool

How it solves it:

- The Anthropic iterator now owns its raw HTTP response on both request paths
- Existing stream cleanup calls `close()` for synchronous responses and `aclose()` for asynchronous responses exactly once

## User Flow

Before: a developer repeatedly cancels streamed Anthropic chat completions, then new requests time out without producing output

1. They send POST https://litellm-domain/v1/chat/completions with an Anthropic model and `"stream": true`
2. Their client stops reading before the stream finishes
3. They repeat the same request and cancellation pattern
4. A later request returns HTTP 408 with `litellm.Timeout: Connection timed out` after 60 seconds

After: the same canceled streams release their provider connections, so later requests can start normally

1. They send POST https://litellm-domain/v1/chat/completions with an Anthropic model and `"stream": true`
2. Their client stops reading before the stream finishes
3. They repeat the same request and cancellation pattern
4. A later request receives HTTP 200 and begins streaming without waiting for a pool slot

## Relevant issues

Follow-up to #19549, #21213, and #30245

Those changes added the generic disconnect cleanup chain, but the Anthropic chat adapter's local iterator still discarded its raw `httpx.Response`

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally
- [ ] My PR passes all required CI/CD checks
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA)

## Screenshots / Proof of Fix

Shared setup: provider-free harnesses build the real synchronous and asynchronous Anthropic iterators around `httpx.Response` objects, then close them through `CustomStreamWrapper`

### Before (f005afa146)

1. Run either ownership harness against the merge base
2. Observe `response_closed=False stream_close_calls=0`

### After (ddb7409151)

1. Run the same ownership harnesses against this branch
2. Observe `response_closed=True stream_close_calls=1` for both request paths

## Type

Bug Fix

Test

## Caveats (if any)

- Live provider proof requires separate approval for billable credentials
- The deterministic harnesses exercise the complete production close chain

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
