### PR TITLE
fix(guardrails): configure Prompt Security file timeout policy

### DIFF
--- a/litellm/proxy/guardrails/guardrail_hooks/prompt_security/__init__.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/prompt_security/__init__.py
@@ -20,6 +20,7 @@ def initialize_guardrail(litellm_params: "LitellmParams", guardrail: "Guardrail"
         guardrail_name=guardrail.get("guardrail_name", ""),
         event_hook=litellm_params.mode,
         default_on=litellm_params.default_on,
+        file_sanitization_fail_open=getattr(litellm_params, "file_sanitization_fail_open", None),
     )
     litellm.logging_callback_manager.add_litellm_callback(_prompt_security_callback)
 

--- a/litellm/proxy/guardrails/guardrail_hooks/prompt_security/prompt_security.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/prompt_security/prompt_security.py
@@ -92,6 +92,7 @@ class PromptSecurityGuardrail(CustomGuardrail):
         system_prompt: str | None = None,
         check_tool_results: bool | None = None,
         file_sanitization_timeout: float = _SANITIZE_FILE_FAIL_OPEN_TIMEOUT_SECONDS,
+        file_sanitization_fail_open: bool | None = None,
         **kwargs,
     ):
         kwargs.setdefault("supported_event_hooks", list(self.get_supported_event_hooks()))
@@ -122,6 +123,7 @@ class PromptSecurityGuardrail(CustomGuardrail):
         self.max_poll_attempts = 30  # Maximum number of polling attempts
         self.poll_interval = 2  # Seconds between polling attempts
         self.file_sanitization_timeout = file_sanitization_timeout
+        self.file_sanitization_fail_open = file_sanitization_fail_open is not False
 
         super().__init__(**kwargs)
 
@@ -417,6 +419,14 @@ class PromptSecurityGuardrail(CustomGuardrail):
                 timeout=self.file_sanitization_timeout,
             )
         except (asyncio.TimeoutError, httpx.TimeoutException, LiteLLMTimeout) as exc:
+            if not self.file_sanitization_fail_open:
+                verbose_proxy_logger.error(
+                    "Prompt Security Guardrail: file sanitization for %s timed out with %s; failing closed",
+                    filename,
+                    type(exc).__name__,
+                )
+                raise HTTPException(status_code=408, detail="File sanitization timeout") from exc
+
             verbose_proxy_logger.error(
                 "Prompt Security Guardrail: file sanitization for %s timed out with %s; failing open",
                 filename,

--- a/litellm/proxy/guardrails/guardrail_hooks/prompt_security/prompt_security.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/prompt_security/prompt_security.py
@@ -4,10 +4,12 @@ import os
 from collections.abc import Mapping, Sequence
 from typing import TYPE_CHECKING, Final, Literal, Optional
 
+import httpx
 from fastapi import HTTPException
 from typing_extensions import ReadOnly, TypedDict
 
 from litellm._logging import verbose_proxy_logger
+from litellm.exceptions import Timeout as LiteLLMTimeout
 from litellm.integrations.custom_guardrail import (
     CustomGuardrail,
     log_guardrail_information,
@@ -22,6 +24,9 @@ from litellm.types.utils import GenericGuardrailAPIInputs
 if TYPE_CHECKING:
     from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObj
     from litellm.types.proxy.guardrails.guardrail_hooks.base import GuardrailConfigModel
+
+
+_SANITIZE_FILE_FAIL_OPEN_TIMEOUT_SECONDS: Final = 30.0
 
 
 class PromptSecurityGuardrailMissingSecrets(Exception):
@@ -63,6 +68,13 @@ class _SanitizeStatusResponse(TypedDict, total=False):
     metadata: ReadOnly[_SanitizeMetadata]
 
 
+class _SanitizeResult(TypedDict):
+    action: ReadOnly[str]
+    content: ReadOnly[str | None]
+    metadata: ReadOnly[_SanitizeMetadata]
+    violations: ReadOnly[Sequence[str]]
+
+
 class PromptSecurityGuardrail(CustomGuardrail):
     @classmethod
     def get_supported_event_hooks(cls) -> list[GuardrailEventHooks]:
@@ -79,6 +91,7 @@ class PromptSecurityGuardrail(CustomGuardrail):
         user: str | None = None,
         system_prompt: str | None = None,
         check_tool_results: bool | None = None,
+        file_sanitization_timeout: float = _SANITIZE_FILE_FAIL_OPEN_TIMEOUT_SECONDS,
         **kwargs,
     ):
         kwargs.setdefault("supported_event_hooks", list(self.get_supported_event_hooks()))
@@ -108,6 +121,7 @@ class PromptSecurityGuardrail(CustomGuardrail):
         # Configuration for file sanitization
         self.max_poll_attempts = 30  # Maximum number of polling attempts
         self.poll_interval = 2  # Seconds between polling attempts
+        self.file_sanitization_timeout = file_sanitization_timeout
 
         super().__init__(**kwargs)
 
@@ -397,6 +411,31 @@ class PromptSecurityGuardrail(CustomGuardrail):
         Sanitize file content using Prompt Security API.
         Returns: dict with keys 'action', 'content', 'metadata'
         """
+        try:
+            return await asyncio.wait_for(
+                self._sanitize_file_content(file_data, filename, user_api_key_alias),
+                timeout=self.file_sanitization_timeout,
+            )
+        except (asyncio.TimeoutError, httpx.TimeoutException, LiteLLMTimeout) as exc:
+            verbose_proxy_logger.error(
+                "Prompt Security Guardrail: file sanitization for %s timed out with %s; failing open",
+                filename,
+                type(exc).__name__,
+            )
+            fail_open_result: Final[_SanitizeResult] = {
+                "action": "allow",
+                "content": None,
+                "metadata": {},
+                "violations": (),
+            }
+            return fail_open_result
+
+    async def _sanitize_file_content(
+        self,
+        file_data: bytes,
+        filename: str,
+        user_api_key_alias: str | None,
+    ) -> _SanitizeResult:
         headers: Final = {"APP-ID": self.api_key}
         if user_api_key_alias:
             headers["X-LiteLLM-Key-Alias"] = user_api_key_alias

--- a/litellm/types/proxy/guardrails/guardrail_hooks/prompt_security.py
+++ b/litellm/types/proxy/guardrails/guardrail_hooks/prompt_security.py
@@ -12,6 +12,10 @@ class PromptSecurityGuardrailConfigModel(GuardrailConfigModel):
         default=None,
         description="The API base for the Prompt Security guardrail. If not provided, the `PROMPT_SECURITY_API_BASE` environment variable is used.",
     )
+    file_sanitization_fail_open: bool = Field(
+        default=True,
+        description="Whether file sanitization timeouts allow the original file through instead of blocking the request.",
+    )
 
     @staticmethod
     def ui_friendly_name() -> str:

--- a/tests/test_litellm/proxy/guardrails/test_prompt_security_guardrails.py
+++ b/tests/test_litellm/proxy/guardrails/test_prompt_security_guardrails.py
@@ -30,6 +30,7 @@ def test_prompt_security_guard_config(monkeypatch: pytest.MonkeyPatch):
                     "guardrail": "prompt_security",
                     "mode": "during_call",
                     "default_on": True,
+                    "file_sanitization_fail_open": False,
                 },
             }
         ],
@@ -41,6 +42,10 @@ def test_prompt_security_guard_config(monkeypatch: pytest.MonkeyPatch):
     assert registered[0].guardrail_name == "prompt_security"
     assert registered[0].default_on is True
     assert registered[0].event_hook == "during_call"
+    assert registered[0].file_sanitization_fail_open is False
+    config_model = registered[0].get_config_model()
+    assert config_model is not None
+    assert config_model().file_sanitization_fail_open is True
 
 
 def test_prompt_security_guard_config_no_api_key(monkeypatch: pytest.MonkeyPatch):
@@ -390,13 +395,28 @@ async def test_file_sanitization(monkeypatch: pytest.MonkeyPatch):
     ),
     ids=("litellm", "httpx"),
 )
-async def test_file_sanitization_fails_open_on_request_timeout(monkeypatch: pytest.MonkeyPatch, timeout: Exception):
+@pytest.mark.parametrize("fail_open", (True, False), ids=("fail-open", "fail-closed"))
+async def test_file_sanitization_request_timeout_policy(
+    monkeypatch: pytest.MonkeyPatch, timeout: Exception, fail_open: bool
+):
     monkeypatch.setenv("PROMPT_SECURITY_API_KEY", "test-key")
     monkeypatch.setenv("PROMPT_SECURITY_API_BASE", "https://test.prompt.security")
 
-    guardrail = PromptSecurityGuardrail(guardrail_name="test-guard", event_hook="pre_call", default_on=True)
+    guardrail = PromptSecurityGuardrail(
+        guardrail_name="test-guard",
+        event_hook="pre_call",
+        default_on=True,
+        file_sanitization_fail_open=fail_open,
+    )
 
     with patch.object(guardrail.async_handler, "post", AsyncMock(side_effect=timeout)):
+        if not fail_open:
+            with pytest.raises(HTTPException) as exc_info:
+                await guardrail.sanitize_file_content(b"file-content", "document.pdf")
+            assert exc_info.value.status_code == 408
+            assert exc_info.value.detail == "File sanitization timeout"
+            return
+
         result = await guardrail.sanitize_file_content(b"file-content", "document.pdf")
 
     assert result == {
@@ -408,7 +428,8 @@ async def test_file_sanitization_fails_open_on_request_timeout(monkeypatch: pyte
 
 
 @pytest.mark.asyncio
-async def test_file_sanitization_fails_open_on_overall_timeout(monkeypatch: pytest.MonkeyPatch):
+@pytest.mark.parametrize("fail_open", (True, False), ids=("fail-open", "fail-closed"))
+async def test_file_sanitization_overall_timeout_policy(monkeypatch: pytest.MonkeyPatch, fail_open: bool):
     monkeypatch.setenv("PROMPT_SECURITY_API_KEY", "test-key")
     monkeypatch.setenv("PROMPT_SECURITY_API_BASE", "https://test.prompt.security")
 
@@ -417,13 +438,21 @@ async def test_file_sanitization_fails_open_on_overall_timeout(monkeypatch: pyte
         event_hook="pre_call",
         default_on=True,
         file_sanitization_timeout=0.01,
+        file_sanitization_fail_open=fail_open,
     )
 
-    async def hanging_post(*args, **kwargs):
+    async def hanging_post(*_args: object, **_kwargs: object) -> None:
         await asyncio.sleep(60)
         raise AssertionError("sanitization request should have been cancelled")
 
     with patch.object(guardrail.async_handler, "post", side_effect=hanging_post):
+        if not fail_open:
+            with pytest.raises(HTTPException) as exc_info:
+                await guardrail.sanitize_file_content(b"file-content", "document.pdf")
+            assert exc_info.value.status_code == 408
+            assert exc_info.value.detail == "File sanitization timeout"
+            return
+
         result = await guardrail.sanitize_file_content(b"file-content", "document.pdf")
 
     assert result["action"] == "allow"

--- a/tests/test_litellm/proxy/guardrails/test_prompt_security_guardrails.py
+++ b/tests/test_litellm/proxy/guardrails/test_prompt_security_guardrails.py
@@ -1,16 +1,16 @@
-from fastapi.exceptions import HTTPException
-from unittest.mock import patch, AsyncMock
-from httpx import Response, Request
+import asyncio
 import base64
+from unittest.mock import AsyncMock, patch
 
 import pytest
-
-from litellm.proxy.guardrails.guardrail_hooks.prompt_security.prompt_security import (
-    PromptSecurityGuardrailMissingSecrets,
-    PromptSecurityGuardrail,
-)
+from fastapi.exceptions import HTTPException
+from httpx import ReadTimeout, Request, Response
 
 import litellm
+from litellm.proxy.guardrails.guardrail_hooks.prompt_security.prompt_security import (
+    PromptSecurityGuardrail,
+    PromptSecurityGuardrailMissingSecrets,
+)
 from litellm.proxy.guardrails.init_guardrails import init_guardrails_v2
 
 
@@ -375,6 +375,62 @@ async def test_file_sanitization(monkeypatch: pytest.MonkeyPatch):
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "timeout",
+    (
+        litellm.Timeout(
+            message="Prompt Security upload timed out",
+            model="default-model-name",
+            llm_provider="litellm-httpx-handler",
+        ),
+        ReadTimeout(
+            "Prompt Security poll timed out",
+            request=Request(method="GET", url="https://test.prompt.security/api/sanitizeFile"),
+        ),
+    ),
+    ids=("litellm", "httpx"),
+)
+async def test_file_sanitization_fails_open_on_request_timeout(monkeypatch: pytest.MonkeyPatch, timeout: Exception):
+    monkeypatch.setenv("PROMPT_SECURITY_API_KEY", "test-key")
+    monkeypatch.setenv("PROMPT_SECURITY_API_BASE", "https://test.prompt.security")
+
+    guardrail = PromptSecurityGuardrail(guardrail_name="test-guard", event_hook="pre_call", default_on=True)
+
+    with patch.object(guardrail.async_handler, "post", AsyncMock(side_effect=timeout)):
+        result = await guardrail.sanitize_file_content(b"file-content", "document.pdf")
+
+    assert result == {
+        "action": "allow",
+        "content": None,
+        "metadata": {},
+        "violations": (),
+    }
+
+
+@pytest.mark.asyncio
+async def test_file_sanitization_fails_open_on_overall_timeout(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("PROMPT_SECURITY_API_KEY", "test-key")
+    monkeypatch.setenv("PROMPT_SECURITY_API_BASE", "https://test.prompt.security")
+
+    guardrail = PromptSecurityGuardrail(
+        guardrail_name="test-guard",
+        event_hook="pre_call",
+        default_on=True,
+        file_sanitization_timeout=0.01,
+    )
+
+    async def hanging_post(*args, **kwargs):
+        await asyncio.sleep(60)
+        raise AssertionError("sanitization request should have been cancelled")
+
+    with patch.object(guardrail.async_handler, "post", side_effect=hanging_post):
+        result = await guardrail.sanitize_file_content(b"file-content", "document.pdf")
+
+    assert result["action"] == "allow"
+    assert result["content"] is None
+
+
+@pytest.mark.asyncio
 async def test_file_sanitization_block(monkeypatch: pytest.MonkeyPatch):
     """Test that file sanitization blocks malicious files"""
     monkeypatch.setenv("PROMPT_SECURITY_API_KEY", "test-key")
@@ -544,7 +600,7 @@ async def test_role_filtering(monkeypatch: pytest.MonkeyPatch):
         return mock_response
 
     with patch.object(guardrail.async_handler, "post", side_effect=mock_post):
-        result = await guardrail.apply_guardrail(
+        await guardrail.apply_guardrail(
             inputs=inputs,
             request_data=request_data,
             input_type="request",


### PR DESCRIPTION
## TLDR

Problem this solves:

- Slow file sanitization can outage attachment requests

How it solves it:

- `file_sanitization_fail_open: true` allows timed-out files by default
- `file_sanitization_fail_open: false` blocks timeouts with HTTP 408

## User Flow

Before: a developer's attachment request fails when Prompt Security file sanitization times out

1. They send `POST http://localhost:4000/v1/chat/completions` with a base64 attachment and Prompt Security enabled
2. The Prompt Security file request exceeds LiteLLM's HTTP timeout
3. The proxy returns a timeout error and never calls the model

After: the same integration remains available by default and exposes an explicit fail-closed policy

1. They send `POST http://localhost:4000/v1/chat/completions` with the same base64 attachment and Prompt Security enabled
2. The Prompt Security file request exceeds LiteLLM's HTTP timeout
3. Default `file_sanitization_fail_open: true` logs the timeout and forwards the original attachment
4. Setting `file_sanitization_fail_open: false` returns HTTP 408 instead

## Relevant issues

Follow-up: #38204 handles file `modify` verdict policy separately.

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA)

## Screenshots / Proof of Fix

Shared setup: the same synthetic CSV containing an email address, the live Prompt Security test endpoint, and a `0.001s` HTTP timeout with no network mocks

### Before (f005afa146)

1. Ran `PromptSecurityGuardrail.sanitize_file_content(csv_data, "email-addresses.csv")`
2. Observed `{'outcome': 'raised', 'exception_type': 'Timeout', 'elapsed_seconds': 0.01}`

### After (3bba1f66a3)

1. Ran the same call with default `file_sanitization_fail_open: true`
2. Observed `{'outcome': 'returned', 'action': 'allow', 'content_is_none': True, 'elapsed_seconds': 0.007}`
3. Repeated with `file_sanitization_fail_open: false`
4. Observed `{'outcome': 'blocked', 'status_code': 408, 'detail': 'File sanitization timeout', 'elapsed_seconds': 0.012}`

## Type

Bug Fix

## Caveats (if any)

- Timeout fail-open forwards the original unsanitized attachment
- Non-timeout sanitization failures remain fail-closed
- All 49 added production lines are covered locally

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes guardrail behavior on file uploads: default fail-open skips sanitization on timeout (security/availability tradeoff), while fail-closed mode blocks requests; operators must understand the new knob.
> 
> **Overview**
> **Prompt Security file sanitization** now has an explicit timeout and configurable behavior when the sanitize API is slow or times out, so attachment-heavy chat requests are less likely to fail outright.
> 
> `sanitize_file_content` is wrapped in `asyncio.wait_for` (default **30s**, overridable via `file_sanitization_timeout`). On `asyncio.TimeoutError`, `httpx.TimeoutException`, or LiteLLM `Timeout`, behavior depends on **`file_sanitization_fail_open`** (config default **true**): fail-open logs and returns an `allow` result so the request can continue with the original attachment; **`false`** fails closed with **HTTP 408** (`File sanitization timeout`). The option is exposed on `PromptSecurityGuardrailConfigModel` and passed through guardrail initialization.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3bba1f66a3ffa19929c1bc50e8026f2b317af54c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->