### PR TITLE
fix(chatgpt): keep text and accept string input for the Codex backend

### DIFF
--- a/litellm/llms/chatgpt/responses/transformation.py
+++ b/litellm/llms/chatgpt/responses/transformation.py
@@ -69,7 +69,7 @@ class ChatGPTResponsesAPIConfig(OpenAIResponsesAPIConfig):
         # The Responses API accepts a string or a list, but this backend
         # rejects a string with {"detail": "Input must be a list"}.
         if isinstance(input, str):
-            input = [{"role": "user", "content": input}]
+            input = [{"role": "user", "content": input}]  # mutable-ok: the wire payload this backend requires
         request: Final = super().transform_responses_api_request(
             model,
             input,

--- a/litellm/llms/chatgpt/responses/transformation.py
+++ b/litellm/llms/chatgpt/responses/transformation.py
@@ -66,6 +66,10 @@ class ChatGPTResponsesAPIConfig(OpenAIResponsesAPIConfig):
         litellm_params: GenericLiteLLMParams,
         headers: dict,
     ) -> dict:
+        # The Responses API accepts a string or a list, but this backend
+        # rejects a string with {"detail": "Input must be a list"}.
+        if isinstance(input, str):
+            input = [{"role": "user", "content": input}]
         request: Final = super().transform_responses_api_request(
             model,
             input,
@@ -99,6 +103,9 @@ class ChatGPTResponsesAPIConfig(OpenAIResponsesAPIConfig):
             "reasoning",
             "previous_response_id",
             "truncation",
+            # The chat-to-responses bridge translates response_format into
+            # "text"; dropping it here discards strict schemas silently.
+            "text",
         }
 
         return {k: v for k, v in request.items() if k in allowed_keys}

--- a/litellm/llms/chatgpt/responses/transformation.py
+++ b/litellm/llms/chatgpt/responses/transformation.py
@@ -66,13 +66,14 @@ class ChatGPTResponsesAPIConfig(OpenAIResponsesAPIConfig):
         litellm_params: GenericLiteLLMParams,
         headers: dict,
     ) -> dict:
-        # The Responses API accepts a string or a list, but this backend
-        # rejects a string with {"detail": "Input must be a list"}.
-        if isinstance(input, str):
-            input = [{"role": "user", "content": input}]  # mutable-ok: the wire payload this backend requires
+        coerced_input: Final = (
+            [{"role": "user", "content": input}]  # mutable-ok: the wire shape this backend accepts
+            if isinstance(input, str)
+            else input
+        )
         request: Final = super().transform_responses_api_request(
             model,
-            input,
+            coerced_input,
             response_api_optional_request_params,
             litellm_params,
             headers,
@@ -103,8 +104,6 @@ class ChatGPTResponsesAPIConfig(OpenAIResponsesAPIConfig):
             "reasoning",
             "previous_response_id",
             "truncation",
-            # The chat-to-responses bridge translates response_format into
-            # "text"; dropping it here discards strict schemas silently.
             "text",
         }
 

--- a/tests/test_litellm/llms/chatgpt/responses/test_chatgpt_responses_transformation.py
+++ b/tests/test_litellm/llms/chatgpt/responses/test_chatgpt_responses_transformation.py
@@ -156,6 +156,97 @@ class TestChatGPTResponsesAPITransformation:
         }
 
     @pytest.mark.parametrize(
+        "model_name",
+        [
+            "chatgpt/gpt-5.4",
+            "chatgpt/gpt-5.3-codex",
+        ],
+    )
+    def test_chatgpt_preserves_text_for_structured_output(self, model_name):
+        """text carries the schema, so dropping it loses structured output.
+
+        The chat-to-responses bridge turns response_format into text.format,
+        so an allowlist without "text" silently discards strict schemas and
+        the backend answers with prose.
+        """
+        config = ChatGPTResponsesAPIConfig()
+        text_param = {
+            "format": {
+                "type": "json_schema",
+                "name": "ExtractedEntities",
+                "strict": True,
+                "schema": {
+                    "type": "object",
+                    "properties": {"name": {"type": "string"}},
+                    "required": ["name"],
+                    "additionalProperties": False,
+                },
+            }
+        }
+
+        request = config.transform_responses_api_request(
+            model=model_name,
+            input="hi",
+            response_api_optional_request_params={"text": text_param},
+            litellm_params=GenericLiteLLMParams(),
+            headers={},
+        )
+
+        assert request["text"] == text_param
+        assert request["text"]["format"]["type"] == "json_schema"
+        assert request["text"]["format"]["strict"] is True
+
+    @pytest.mark.parametrize(
+        "model_name",
+        [
+            "chatgpt/gpt-5.4",
+            "chatgpt/gpt-5.3-codex",
+        ],
+    )
+    def test_chatgpt_coerces_string_input_to_list(self, model_name):
+        """The backend rejects a string input with "Input must be a list".
+
+        The Responses API itself accepts either, so the string has to be
+        wrapped before it reaches this backend.
+        """
+        config = ChatGPTResponsesAPIConfig()
+
+        request = config.transform_responses_api_request(
+            model=model_name,
+            input="say hi",
+            response_api_optional_request_params={},
+            litellm_params=GenericLiteLLMParams(),
+            headers={},
+        )
+
+        assert isinstance(request["input"], list)
+        assert request["input"] == [{"role": "user", "content": "say hi"}]
+
+    @pytest.mark.parametrize(
+        "model_name",
+        [
+            "chatgpt/gpt-5.4",
+        ],
+    )
+    def test_chatgpt_leaves_list_input_untouched(self, model_name):
+        """Only a bare string needs wrapping; a list must pass through."""
+        config = ChatGPTResponsesAPIConfig()
+        original = [
+            {"role": "system", "content": "be brief"},
+            {"role": "user", "content": "say hi"},
+        ]
+
+        request = config.transform_responses_api_request(
+            model=model_name,
+            input=list(original),
+            response_api_optional_request_params={},
+            litellm_params=GenericLiteLLMParams(),
+            headers={},
+        )
+
+        assert request["input"] == original
+
+    @pytest.mark.parametrize(
         ("model_name", "response_model"),
         [
             ("chatgpt/gpt-5.2-codex", "gpt-5.2-codex"),


### PR DESCRIPTION
## TLDR

Problem this solves:

- `chatgpt/*` answers prose when you ask for a strict JSON schema
- No error and no warning, so it looks like a model failure
- `chatgpt/*` rejects a plain string `input` outright

How it solves it:

- Keep `text` in the outgoing request so the schema survives
- Wrap a string `input` in a list before sending

## User Flow

Before: a developer asking a ChatGPT subscription model for structured output silently gets prose, so their parser fails

1. They send POST https://litellm-domain/v1/responses with a `chatgpt/*` model and a strict `json_schema` in `text.format`, asking for a city and country
2. A 200 comes back, but the body is the sentence `Paris, France` rather than an object
3. Their JSON parse fails, and nothing in the response or logs says the schema was never applied, so they go looking at the model and its prompt
4. They try the simplest possible call instead, POST https://litellm-domain/v1/responses with `"input": "say hi"` as a plain string
5. That returns 400 with `{"detail":"Input must be a list"}`, even though the same string works against OpenAI

After: the same two requests behave the way the API contract says

1. They send the same POST https://litellm-domain/v1/responses with the strict `json_schema`
2. A 200 comes back with `{"city": "Paris", "country": "France"}`, which their parser accepts
3. They send the same POST https://litellm-domain/v1/responses with `"input": "say hi"` as a plain string
4. A 200 comes back with a completed response, matching OpenAI's behaviour for a string input

## Relevant issues

Fixes #38085
Refs #24356, refs #27851

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

Shared setup for both cases, run against the live Codex backend with no mocks. Model `chatgpt/gpt-5.6-sol`, prompt `Paris is the capital of France. Return the city and country.`, schema `{"city": string, "country": string}` with `strict: true` and `additionalProperties: false`.

One thing a reviewer should know about how this was captured. Two other known defects on this provider, the forced streaming flag in #34094 / #34095 and the drained stream in #25429 / #31332, block the same call from the response side. Both arms below have equivalents of those two applied, identically, so the only difference between Before and After is this PR's request-side change. Without that, neither arm returns anything to compare.

### Before (f005afa146)

#### case 1, strict json_schema

1. Send the request above with `text.format` set to the strict schema
2. Observed: `'Paris, France'`, prose rather than JSON, no error and no warning

#### case 2, string input

1. Send `input` as the plain string `say hi`
2. Observed: `litellm.BadRequestError: ChatgptException - {"detail":"Input must be a list"}`

### After (3ee1ccf3fd)

#### case 1, strict json_schema

1. Send the identical request
2. Observed: `{"city": "Paris", "country": "France"}`, parses against the schema

#### case 2, string input

1. Send the identical request
2. Observed: accepted, `status=completed`

Unit tests, and confirmation that they fail without the production change:

1. `uv run pytest tests/test_litellm/llms/chatgpt/responses/test_chatgpt_responses_transformation.py -q` gives `24 passed`
2. Reverting only `litellm/llms/chatgpt/responses/transformation.py` and rerunning gives `4 failed, 20 passed`, the 4 being the new cases across both parametrised models

## Type

🐛 Bug Fix

## Caveats (if any)

- `/v1/chat/completions` needs #31332 or #34095 too, same call
- The `text` half was diagnosed in #24356, closed by the stale bot
- `code-quality` fails on the base branch too, no workflow files touched here
- AI assistance used: Yes
- Used to survey prior reports and draft the tests; fix and results verified by me against the live backend

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
