### PR TITLE
fix(responses): handle unrecognized reasoning_effort values in Responses API 

### DIFF
--- a/litellm/completion_extras/litellm_responses_transformation/transformation.py
+++ b/litellm/completion_extras/litellm_responses_transformation/transformation.py
@@ -1103,6 +1103,12 @@ class LiteLLMResponsesTransformationHandler(CompletionTransformationBridge):
             return (
                 Reasoning(effort="minimal", summary="detailed") if auto_summary_enabled else Reasoning(effort="minimal")
             )
+        elif reasoning_effort:
+            return (
+                Reasoning(effort=reasoning_effort, summary="detailed")
+                if auto_summary_enabled
+                else Reasoning(effort=reasoning_effort)
+            )
         return None
 
     def _add_web_search_tool(

--- a/tests/test_litellm/completion_extras/litellm_responses_transformation/test_completion_extras_litellm_responses_transformation_transformation.py
+++ b/tests/test_litellm/completion_extras/litellm_responses_transformation/test_completion_extras_litellm_responses_transformation_transformation.py
@@ -1523,7 +1523,7 @@ def test_map_reasoning_effort_adds_summary_detailed(monkeypatch):
     handler = LiteLLMResponsesTransformationHandler()
 
     # Test all string effort levels - DEFAULT BEHAVIOR (no summary)
-    effort_levels = ["none", "low", "medium", "high", "xhigh", "minimal"]
+    effort_levels = ["none", "low", "medium", "high", "xhigh", "minimal", "max"]
 
     # Save original flag value
     original_flag = litellm.reasoning_auto_summary
@@ -1585,10 +1585,16 @@ def test_map_reasoning_effort_adds_summary_detailed(monkeypatch):
         assert result_dict["summary"] == "custom_summary"
         print("✓ Dict input is passed through without modification")
 
-        # Test 5: None/unknown values return None
-        result_unknown = handler._map_reasoning_effort("unknown_value")
-        assert result_unknown is None
-        print("✓ Unknown reasoning_effort values return None")
+        # Test 5: Unrecognized but truthy strings pass through (forward-compatible)
+        result_future = handler._map_reasoning_effort("future_level")
+        assert result_future is not None
+        assert result_future["effort"] == "future_level"
+        print("✓ Unrecognized effort values pass through for forward compatibility")
+
+        # Test 6: Empty string returns None
+        result_empty = handler._map_reasoning_effort("")
+        assert result_empty is None
+        print("✓ Empty reasoning_effort returns None")
 
         print(
             "✓ All reasoning_effort behaviors work correctly with flag/env var control"


### PR DESCRIPTION
## TLDR

Problem this solves:

- `reasoning_effort="max"` (and any future effort level) silently dropped when routing through the Responses API

How it solves it:

- Adds a fallthrough branch in `_map_reasoning_effort` that forwards any unrecognized truthy string to a `Reasoning` object

## User Flow

Before: a developer setting `reasoning_effort="max"` gets no reasoning configuration applied

1. They send POST /v1/chat/completions with `"reasoning_effort": "max"` to a model routed through the Responses API
2. `_map_reasoning_effort("max")` matches none of the if/elif branches and returns `None`
3. The request goes out without any reasoning configuration, silently ignoring what the user asked for

After: the same request correctly applies the reasoning effort

1. They send the same POST /v1/chat/completions with `"reasoning_effort": "max"`
2. `_map_reasoning_effort("max")` hits the new fallthrough branch and returns `Reasoning(effort="max")`
3. The Responses API request includes the reasoning configuration as expected

## Relevant issues

Fixes #38084

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

Will provide curl commands against a live proxy after CI passes

## Type

Bug Fix

## Caveats (if any)

The existing test asserting that `_map_reasoning_effort("unknown_value")` returns `None` was updated to reflect the new forward-compatible behavior: any truthy string now passes through. This is intentional, matching the issue's suggested fix of being forward-compatible with new effort levels the API adds