### PR TITLE
fix(responses): preserve max reasoning effort

### DIFF
--- a/litellm/completion_extras/litellm_responses_transformation/transformation.py
+++ b/litellm/completion_extras/litellm_responses_transformation/transformation.py
@@ -1093,6 +1093,17 @@ class LiteLLMResponsesTransformationHandler(CompletionTransformationBridge):
             return Reasoning(effort="high", summary="detailed") if auto_summary_enabled else Reasoning(effort="high")
         elif reasoning_effort == "xhigh":
             return Reasoning(effort="xhigh", summary="detailed") if auto_summary_enabled else Reasoning(effort="xhigh")
+        elif reasoning_effort == "max":
+            return (
+                Reasoning(
+                    effort="max",  # pyright: ignore[reportArgumentType] - OpenAI SDK type omits supported max
+                    summary="detailed",
+                )
+                if auto_summary_enabled
+                else Reasoning(
+                    effort="max"  # pyright: ignore[reportArgumentType] - OpenAI SDK type omits supported max
+                )
+            )
         elif reasoning_effort == "medium":
             return (
                 Reasoning(effort="medium", summary="detailed") if auto_summary_enabled else Reasoning(effort="medium")

--- a/tests/test_litellm/completion_extras/litellm_responses_transformation/test_completion_extras_litellm_responses_transformation_transformation.py
+++ b/tests/test_litellm/completion_extras/litellm_responses_transformation/test_completion_extras_litellm_responses_transformation_transformation.py
@@ -1523,7 +1523,7 @@ def test_map_reasoning_effort_adds_summary_detailed(monkeypatch):
     handler = LiteLLMResponsesTransformationHandler()
 
     # Test all string effort levels - DEFAULT BEHAVIOR (no summary)
-    effort_levels = ["none", "low", "medium", "high", "xhigh", "minimal"]
+    effort_levels = ["none", "low", "medium", "high", "xhigh", "max", "minimal"]
 
     # Save original flag value
     original_flag = litellm.reasoning_auto_summary


### PR DESCRIPTION
## TLDR

Problem this solves:

- Responses conversion silently drops reasoning effort max
- Users receive different reasoning behavior than requested

How it solves it:

- Explicitly maps the documented max effort value
- Preserves existing rejection of unknown effort values

## User Flow

Before: a developer requests maximum reasoning, but the forwarded request omits it

1. They send POST https://litellm-domain/v1/chat/completions with "reasoning_effort": "max"
2. LiteLLM returns the provider response, but max was not forwarded
3. The model may use less reasoning than the developer requested

After: the same request forwards maximum reasoning to the Responses API

1. They send POST https://litellm-domain/v1/chat/completions with "reasoning_effort": "max"
2. LiteLLM forwards a reasoning object whose effort is max
3. The model receives the reasoning level the developer requested

## Relevant issues

Fixes #38084

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. uv run pytest tests/test_litellm/<your_test_file>.py -v. Leave the suites (make test-unit-*, make test-unit) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile Confidence Score of at least 4/5 before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment @greptileai to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Shared setup: no OpenAI API key was available for a paid live-provider call.

### Before (f005afa146)

1. Run the reasoning mapper with reasoning_effort set to max
2. Observe None, which is omitted from the forwarded request

### After (9ed106b52c)

1. Run the same reasoning mapper with reasoning_effort set to max
2. Observe {"effort": "max"}; auto-summary also remains supported

## Type

🐛 Bug Fix
✅ Test

## Caveats (if any)

- Live-provider proof requires an OpenAI API key
- #38089 forwards all unknown values; this preserves rejection

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR