### PR TITLE
fix(ui): use the imported lucide icons in the skill detail copy button

### DIFF
--- a/ui/litellm-dashboard/src/components/claude_code_plugins/skill_detail.tsx
+++ b/ui/litellm-dashboard/src/components/claude_code_plugins/skill_detail.tsx
@@ -343,7 +343,7 @@ const SkillDetail: React.FC<SkillDetailProps> = ({ skill, onBack }) => {
                   padding: 0,
                 }}
               >
-                {copiedKey === "marketplace-cmd" ? <CheckOutlined /> : <CopyOutlined />}
+                {copiedKey === "marketplace-cmd" ? <Check className="size-3" /> : <Copy className="size-3" />}
                 {copiedKey === "marketplace-cmd" ? "Copied" : "Copy"}
               </button>
             </div>


### PR DESCRIPTION
## TLDR

Problem this solves:

- build-ui fails on staging: `Cannot find name 'CheckOutlined'` in skill_detail.tsx
- every open PR inherits the red check through its merge ref
- the skill detail setup tab crashes when rendered in dev

How it solves it:

- render the file's already-imported lucide `Check`/`Copy`, like its two sibling copy buttons

## User Flow

Before: the marketplace setup tab crashes, and no dashboard containing it can be built

1. An admin opens the Skills page of the admin UI, clicks a skill, and opens its How to Use tab
2. They click "See one-time setup" under the plugin instructions
3. The page goes blank: the Copy button beside the marketplace command renders icon components that do not exist
4. Meanwhile every PR and release build of the dashboard fails with `Type error: Cannot find name 'CheckOutlined'`, so no admin UI can ship

After: the setup tab renders and the dashboard builds again

1. The same admin opens the same skill's How to Use tab and clicks "See one-time setup"
2. The setup tab renders, and the marketplace command's Copy button shows the same small copy icon as the install command's button, flipping to a check for two seconds after a click
3. Dashboard builds pass again on every PR

## Relevant issues

Introduced by #33514

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have added meaningful tests
- [ ] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

### Before (28b433a007)

1. `cd ui/litellm-dashboard && npm run build`
2. Observed:

```
Failed to type check.

./src/components/claude_code_plugins/skill_detail.tsx:346:53
Type error: Cannot find name 'CheckOutlined'.

  344 |                 }}
  345 |               >
> 346 |                 {copiedKey === "marketplace-cmd" ? <CheckOutlined /> : <CopyOutlined />}
```

Same failure on staging's own build-ui runs since #33514 merged, e.g. https://github.com/BerriAI/litellm/actions/runs/32756349120/job/97524683403

### After (d2f897848c)

1. `cd ui/litellm-dashboard && npm run build`
2. Observed: `✓ Compiled successfully`, the TypeScript step passes, and the full route table prints

To see it rendered: `npm run dev` in ui/litellm-dashboard, open http://localhost:3000/ui?page=skills, click a skill, open How to Use, click "See one-time setup", and the marketplace command's Copy button shows the copy icon and flips to a check on click

## Type

🐛 Bug Fix

## Caveats (if any)

- no test added: the build's own type check is the regression gate

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line UI icon fix with no auth, data, or API changes; aligns with existing copy buttons in the same file.
> 
> **Overview**
> Fixes a **TypeScript/build break** and **runtime crash** on the skill detail **one-time marketplace setup** tab by swapping undefined `CheckOutlined` / `CopyOutlined` for the **already-imported** lucide `Check` and `Copy` icons (with `className="size-3"`), matching the install and settings copy buttons.
> 
> After this change, the marketplace command **Copy** control renders and toggles to a check on copy again, and `npm run build` for the dashboard passes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d2f897848c341572af26dd17b5b628709f2a3aac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->