### PR TITLE
fix(ci): raise the 55m unit-shard job timeouts to the 60m the startup gate requires

### DIFF
--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -211,7 +211,7 @@ jobs:
             workers: 2
             reruns: 2
             timeout-minutes: 20
-            job-timeout-minutes: 55
+            job-timeout-minutes: 60
 
           - shard: proxy-extras
             artifact-name: proxy-extras
@@ -219,7 +219,7 @@ jobs:
             workers: 2
             reruns: 2
             timeout-minutes: 20
-            job-timeout-minutes: 55
+            job-timeout-minutes: 60
 
           - shard: enterprise-package
             artifact-name: enterprise-package
@@ -227,7 +227,7 @@ jobs:
             workers: 4
             reruns: 2
             timeout-minutes: 20
-            job-timeout-minutes: 55
+            job-timeout-minutes: 60
 
           - shard: responses-caching-types
             artifact-name: responses-caching-types


### PR DESCRIPTION
## TLDR

Problem this solves:

- `code-quality` fails on every PR opened since #37804 landed
- Three unit shards cap the job at 55m while their budgets need 60m

How it solves it:

- Raises the three `job-timeout-minutes: 55` entries to 60
- `check_workflow_startup_safety.py` passes again

## User Flow

Before: every contributor's PR shows a failing required-adjacent check they cannot fix

1. They open any PR against `litellm_internal_staging`
2. Code Quality Checks / code-quality fails after ~1m with "job `unit` gives pytest 20m but caps the job at 55m ... raise job-timeout-minutes to at least 60", three times
3. The failure names `.github/workflows/test-unit.yml`, a file their PR does not touch

After: the same PR runs code-quality green

1. They open any PR against `litellm_internal_staging`
2. Code Quality Checks / code-quality passes

## Relevant issues

Regression from #37804 (the two resized shards, plus `enterprise-package`, kept a 55m cap). Every open PR created after it shows the same red, e.g. #38047, #38048, #38049, #38051, #38053.

## Pre-Submission checklist

- [x] I have added meaningful tests (no new test: the invariant is already enforced by `tests/code_coverage_tests/check_workflow_startup_safety.py`, which this change turns green)
- [x] The check covering this change passes locally: `uv run python ./tests/code_coverage_tests/check_workflow_startup_safety.py` prints "Workflow startup invariants hold (setup ceiling 35m)"
- [ ] My PR passes all required CI/CD checks
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile Confidence Score of at least 4/5 before requesting a maintainer review

## Screenshots / Proof of Fix

CI-only change; the proof is the gate itself.

### Before (d1f3778849, staging HEAD)

```
$ uv run python ./tests/code_coverage_tests/check_workflow_startup_safety.py
ERROR: Workflow startup invariants violated:
  - .github/workflows/test-unit.yml: job `unit` gives pytest 20m but caps the job at 55m. Setup can use up to 35m plus 5m of runner overhead, so the job deadline would preempt pytest; raise job-timeout-minutes to at least 60.
  (x3)
```

### After (this PR)

```
$ uv run python ./tests/code_coverage_tests/check_workflow_startup_safety.py
Workflow startup invariants hold (setup ceiling 35m)
```
