### PR TITLE
fix(ui): use the lucide icons in the marketplace copy button

### DIFF
--- a/ui/litellm-dashboard/src/components/claude_code_plugins/skill_detail.tsx
+++ b/ui/litellm-dashboard/src/components/claude_code_plugins/skill_detail.tsx
@@ -343,7 +343,7 @@ const SkillDetail: React.FC<SkillDetailProps> = ({ skill, onBack }) => {
                   padding: 0,
                 }}
               >
-                {copiedKey === "marketplace-cmd" ? <CheckOutlined /> : <CopyOutlined />}
+                {copiedKey === "marketplace-cmd" ? <Check className="size-3" /> : <Copy className="size-3" />}
                 {copiedKey === "marketplace-cmd" ? "Copied" : "Copy"}
               </button>
             </div>


### PR DESCRIPTION
## TLDR

Problem this solves:

- `build-ui` fails to type check on `litellm_internal_staging`
- The #33514 merge reintroduced two `@ant-design/icons` usages after #37553 removed that import style

How it solves it:

- The marketplace copy button uses the file's existing lucide `Check`/`Copy` icons, like its sibling buttons

## User Flow

Before: a PR based on current staging fails the UI build without touching the UI

1. They open a PR against `litellm_internal_staging`
2. `build-ui` fails after ~1m: `./src/components/claude_code_plugins/skill_detail.tsx:346:53  Type error: Cannot find name 'CheckOutlined'.`
3. The failure names a file their PR does not touch (e.g. #38099)

After: the same PR builds the dashboard green

1. They open a PR against `litellm_internal_staging`
2. `build-ui` passes

## Relevant issues

Regression from the #33514 merge on top of #37553's lucide-react swap. First surfaced on #38099.

## Pre-Submission checklist

- [x] I have added meaningful tests (no new test: the UI build itself is the failing gate this turns green; the change swaps two icons to the pattern the same file already uses two lines above)
- [x] `npm run build` in `ui/litellm-dashboard` compiles successfully locally with this change and fails to type check without it
- [ ] My PR passes all required CI/CD checks
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile Confidence Score of at least 4/5 before requesting a maintainer review

## Screenshots / Proof of Fix

UI-build-only change; the proof is the build.

### Before (staging HEAD 4913b2a3ca)

```
Running TypeScript ...
Failed to type check.
./src/components/claude_code_plugins/skill_detail.tsx:346:53
Type error: Cannot find name 'CheckOutlined'.
```
(from #38099's build-ui run: https://github.com/BerriAI/litellm/actions/runs/32759865129/job/97535915164)

### After (this PR)

```
$ npm run build
... Compiled successfully
```
The button renders identically to its two sibling copy buttons, which already use `<Check className="size-3" />` / `<Copy className="size-3" />`.
