### PR TITLE
fix(passthrough): attribute spend and release budget reservation on router-model /vllm and /azure routes

### DIFF
--- a/litellm/proxy/pass_through_endpoints/llm_passthrough_endpoints.py
+++ b/litellm/proxy/pass_through_endpoints/llm_passthrough_endpoints.py
@@ -9,7 +9,7 @@ Use litellm with Anthropic SDK, Vertex AI SDK, Cohere SDK, etc.
 import json
 import os
 import re
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from types import MappingProxyType
 from typing import TYPE_CHECKING, Annotated, Any, Final, cast
 
@@ -104,6 +104,28 @@ def is_passthrough_request_streaming(request_body: object) -> bool:
     if not isinstance(request_body, dict):
         return False
     return bool(request_body.get("stream", False))
+
+
+def get_passthrough_router_request_metadata(user_api_key_dict: UserAPIKeyAuth) -> Mapping[str, Any]:
+    """
+    Build the request metadata carrying key-level spend attribution and the
+    pre-call budget reservation for a router-model passthrough request.
+
+    Router-model passthrough branches call ``allm_passthrough_route`` directly,
+    bypassing ``add_litellm_data_to_request``. Without this metadata the cost
+    callback cannot attribute spend to the calling key and never releases the
+    budget reservation minted at auth time, so the shared spend counter drifts
+    up until the key falsely trips ``BudgetExceededError``.
+    """
+    from litellm.proxy.litellm_pre_call_utils import LiteLLMProxyRequestSetup
+
+    request_data: Final = {"metadata": {}}  # mutable-ok: attribution builder + litellm mutate this dict in place
+    LiteLLMProxyRequestSetup.add_user_api_key_auth_to_request_metadata(
+        data=request_data,
+        user_api_key_dict=user_api_key_dict,
+        _metadata_variable_name="metadata",
+    )
+    return request_data["metadata"]
 
 
 async def llm_passthrough_factory_proxy_route(
@@ -346,6 +368,7 @@ async def vllm_proxy_route(
                 params=None,
                 headers=None,
                 cookies=None,
+                metadata=get_passthrough_router_request_metadata(user_api_key_dict),
             ),
         )
 
@@ -1475,6 +1498,7 @@ async def azure_proxy_route(
                     params=None,
                     headers=None,
                     cookies=None,
+                    metadata=get_passthrough_router_request_metadata(user_api_key_dict),
                 )
 
                 if is_streaming_request:

--- a/litellm/proxy/pass_through_endpoints/llm_passthrough_endpoints.py
+++ b/litellm/proxy/pass_through_endpoints/llm_passthrough_endpoints.py
@@ -116,16 +116,24 @@ def get_passthrough_router_request_metadata(user_api_key_dict: UserAPIKeyAuth) -
     callback cannot attribute spend to the calling key and never releases the
     budget reservation minted at auth time, so the shared spend counter drifts
     up until the key falsely trips ``BudgetExceededError``.
+
+    The payload rides the ``litellm_metadata`` bucket, not ``metadata``: the
+    router hop ``_ageneric_api_call_with_fallbacks`` canonicalises this call
+    type into ``litellm_metadata``, and the cost callback reads spend
+    attribution from that bucket while only backfilling ``user_api_key*`` keys
+    from ``metadata``. Passing ``metadata=`` would silently drop the secondary
+    attribution fields the helper sets (``agent_id``,
+    ``user_api_end_user_max_budget``) before the callback ever sees them.
     """
     from litellm.proxy.litellm_pre_call_utils import LiteLLMProxyRequestSetup
 
-    request_data: Final = {"metadata": {}}  # mutable-ok: attribution builder + litellm mutate this dict in place
+    request_data: Final = {"litellm_metadata": {}}  # mutable-ok: builder + litellm mutate this in place
     LiteLLMProxyRequestSetup.add_user_api_key_auth_to_request_metadata(
         data=request_data,
         user_api_key_dict=user_api_key_dict,
-        _metadata_variable_name="metadata",
+        _metadata_variable_name="litellm_metadata",
     )
-    return request_data["metadata"]
+    return request_data["litellm_metadata"]
 
 
 async def llm_passthrough_factory_proxy_route(
@@ -368,7 +376,7 @@ async def vllm_proxy_route(
                 params=None,
                 headers=None,
                 cookies=None,
-                metadata=get_passthrough_router_request_metadata(user_api_key_dict),
+                litellm_metadata=get_passthrough_router_request_metadata(user_api_key_dict),
             ),
         )
 
@@ -1498,7 +1506,7 @@ async def azure_proxy_route(
                     params=None,
                     headers=None,
                     cookies=None,
-                    metadata=get_passthrough_router_request_metadata(user_api_key_dict),
+                    litellm_metadata=get_passthrough_router_request_metadata(user_api_key_dict),
                 )
 
                 if is_streaming_request:

--- a/tests/test_litellm/proxy/pass_through_endpoints/test_llm_pass_through_endpoints.py
+++ b/tests/test_litellm/proxy/pass_through_endpoints/test_llm_pass_through_endpoints.py
@@ -4055,3 +4055,87 @@ class TestVertexAILiveWebsocketPassthrough:
         assert "use_in_pass_through" in close_kwargs["reason"]
         assert "default_vertex_config" in close_kwargs["reason"]
         assert len(close_kwargs["reason"].encode("utf-8")) <= 123
+
+
+class TestPassthroughRouterModelBudgetReservation:
+    """
+    Router-model passthrough on /vllm and /azure must thread the calling key's
+    metadata into ``allm_passthrough_route``. Without ``user_api_key`` the spend
+    is attributed to nobody, and without ``user_api_key_budget_reservation`` the
+    pre-call reservation is never released, so the shared spend counter drifts up
+    until the key falsely trips a 429 BudgetExceededError (LIT-5470).
+    """
+
+    def _key_with_reservation(self) -> UserAPIKeyAuth:
+        reservation = {
+            "reserved_cost": 0.5,
+            "entries": [{"counter_key": "spend:key:hashed-token", "reserved_cost": 0.5}],
+        }
+        return UserAPIKeyAuth(
+            api_key="hashed-token",
+            user_id="u1",
+            team_id="t1",
+            budget_reservation=reservation,
+        )
+
+    def _request(self) -> MagicMock:
+        request = MagicMock(spec=Request)
+        request.method = "POST"
+        request.headers = {"content-type": "application/json"}
+        request.query_params = {}
+        return request
+
+    def _install_recording_router(self, monkeypatch, body: dict) -> list[dict]:
+        import litellm.proxy.pass_through_endpoints.llm_passthrough_endpoints as ep
+        import litellm.proxy.proxy_server as proxy_server
+
+        captured: list[dict] = []
+
+        class RecordingRouter:
+            async def allm_passthrough_route(self, **kwargs):
+                captured.append(kwargs)
+                return httpx.Response(200, json={"ok": True})
+
+        async def fake_get_request_body(_request):
+            return body
+
+        monkeypatch.setattr(proxy_server, "llm_router", RecordingRouter())
+        monkeypatch.setattr(ep, "get_request_body", fake_get_request_body)
+        monkeypatch.setattr(ep, "is_passthrough_request_using_router_model", lambda *a, **k: True)
+        return captured
+
+    def _assert_metadata_carries_attribution(self, captured: list[dict], user_api_key_dict: UserAPIKeyAuth) -> None:
+        assert len(captured) == 1, "the router-model branch must dispatch exactly once"
+        metadata = captured[0]["metadata"]
+        assert metadata["user_api_key"] == user_api_key_dict.api_key
+        assert metadata["user_api_key_budget_reservation"] is user_api_key_dict.budget_reservation
+        assert metadata["user_api_key_user_id"] == user_api_key_dict.user_id
+        assert metadata["user_api_key_team_id"] == user_api_key_dict.team_id
+
+    @pytest.mark.asyncio
+    async def test_vllm_router_model_threads_key_metadata(self, monkeypatch):
+        user_api_key_dict = self._key_with_reservation()
+        captured = self._install_recording_router(monkeypatch, {"model": "router-model", "stream": False})
+
+        await vllm_proxy_route(
+            endpoint="/chat/completions",
+            request=self._request(),
+            fastapi_response=MagicMock(spec=Response),
+            user_api_key_dict=user_api_key_dict,
+        )
+
+        self._assert_metadata_carries_attribution(captured, user_api_key_dict)
+
+    @pytest.mark.asyncio
+    async def test_azure_router_model_threads_key_metadata(self, monkeypatch):
+        user_api_key_dict = self._key_with_reservation()
+        captured = self._install_recording_router(monkeypatch, {"model": "gpt-5", "stream": False})
+
+        await azure_proxy_route(
+            endpoint="openai/deployments/gpt-5/chat/completions",
+            request=self._request(),
+            fastapi_response=MagicMock(spec=Response),
+            user_api_key_dict=user_api_key_dict,
+        )
+
+        self._assert_metadata_carries_attribution(captured, user_api_key_dict)

--- a/tests/test_litellm/proxy/pass_through_endpoints/test_llm_pass_through_endpoints.py
+++ b/tests/test_litellm/proxy/pass_through_endpoints/test_llm_pass_through_endpoints.py
@@ -4076,6 +4076,8 @@ class TestPassthroughRouterModelBudgetReservation:
             user_id="u1",
             team_id="t1",
             budget_reservation=reservation,
+            agent_id="agent-xyz",
+            end_user_max_budget=42.0,
         )
 
     def _request(self) -> MagicMock:
@@ -4106,11 +4108,17 @@ class TestPassthroughRouterModelBudgetReservation:
 
     def _assert_metadata_carries_attribution(self, captured: list[dict], user_api_key_dict: UserAPIKeyAuth) -> None:
         assert len(captured) == 1, "the router-model branch must dispatch exactly once"
-        metadata = captured[0]["metadata"]
-        assert metadata["user_api_key"] == user_api_key_dict.api_key
-        assert metadata["user_api_key_budget_reservation"] is user_api_key_dict.budget_reservation
-        assert metadata["user_api_key_user_id"] == user_api_key_dict.user_id
-        assert metadata["user_api_key_team_id"] == user_api_key_dict.team_id
+        assert captured[0].get("metadata") is None, (
+            "attribution must ride the litellm_metadata bucket the router canonicalizes on; "
+            "the plain metadata bucket is dropped for every non-user_api_key field"
+        )
+        litellm_metadata = captured[0]["litellm_metadata"]
+        assert litellm_metadata["user_api_key"] == user_api_key_dict.api_key
+        assert litellm_metadata["user_api_key_budget_reservation"] is user_api_key_dict.budget_reservation
+        assert litellm_metadata["user_api_key_user_id"] == user_api_key_dict.user_id
+        assert litellm_metadata["user_api_key_team_id"] == user_api_key_dict.team_id
+        assert litellm_metadata["agent_id"] == user_api_key_dict.agent_id
+        assert litellm_metadata["user_api_end_user_max_budget"] == user_api_key_dict.end_user_max_budget
 
     @pytest.mark.asyncio
     async def test_vllm_router_model_threads_key_metadata(self, monkeypatch):


### PR DESCRIPTION
## TLDR

Problem this solves:

- Budgeted key's /vllm and /azure router-model calls log $0 spend
- Reserved budget never released, so key falsely 429s

How it solves it:

- Thread the key's attribution metadata into both router calls
- Cost callback now bills the key and reconciles the reservation

## User Flow

Before: a developer with a budgeted virtual key runs inference through the /vllm passthrough to a router-configured model, and their spend reads zero until the key starts refusing requests for no real reason

1. They POST https://litellm-domain/vllm/chat/completions with `Authorization: Bearer sk-budgeted-key` and body `{"model": "my-router-model", "messages": [...]}`
2. The call returns 200 with a normal completion
3. They open https://litellm-domain/ui/?page=logs and see the request logged at $0 spend, and GET https://litellm-domain/key/info?key=sk-budgeted-key still reports spend 0
4. After enough calls the pre-reserved amount piles up unreleased, and the next POST returns a 429 "Budget has been exceeded" error even though real spend is far below the key's max_budget
5. The same happens through https://litellm-domain/azure/openai/deployments/{deployment}/chat/completions for a router model

After: the same requests bill the calling key and release the reservation, so spend shows up and the key keeps serving until it actually hits its budget

1. They POST the same https://litellm-domain/vllm/chat/completions with `sk-budgeted-key` and `{"model": "my-router-model", "messages": [...]}`
2. The call returns 200 with a normal completion
3. https://litellm-domain/ui/?page=logs now shows the request at real non-zero spend, and GET https://litellm-domain/key/info?key=sk-budgeted-key reflects that spend on the key
4. The reservation is reconciled after each call, so the key keeps returning 200 until its real spend reaches max_budget, and only then returns "Budget has been exceeded"
5. If the key carries an `agent_id`, GET https://litellm-domain/spend/logs?api_key=sk-budgeted-key now returns each row with that `agent_id` populated, so agent-level attribution lands too
6. The /azure router-model route behaves the same way

Before this fix a budgeted key could be denied service while its real spend sat well under budget, and its usage went unattributed. After, that usage is billed to the key and the budget only denies once real spend reaches the limit

## Relevant issues

## Linear ticket

Resolves LIT-5470

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Type

🐛 Bug Fix

## Caveats (if any)

- Router-model /vllm and /azure keep their existing direct-passthrough response handling; only the metadata is added
- Streaming router-model passthrough on /vllm and /azure is separately broken both before and after this PR, an unrelated `aiter_bytes` error in the response wrapper downstream of the router call. This fix still threads the attribution metadata successfully on that path; it just does not address that pre-existing streaming failure, which is out of scope here

## Screenshots / Proof of Fix

Live e2e on a realistic multi-pod topology: two proxy pods sharing one Postgres DB and one coordination Redis (`coordination_redis` on, so spend counters are Redis-backed and the leak is cross-pod). The router model `gpt-5` is backed by a real Azure OpenAI deployment (`azure/gpt-4o`), so every completion is a real billed call. Requests alternate between the two pods, and every `/key/info` is read from the OTHER pod than the one that served the request, so the spend numbers also prove cross-pod coordination. Both changed routes, `/vllm` and `/azure`, are driven end to end as a real client would.

The observable surfaces are exactly what an end user sees: the HTTP status of each completion and `GET /key/info?key=...` for the key's spend. No SQL, redis-cli, or log grepping is used as evidence.

### Before the fix (merge base `3122600e`) — bug reproduced on both routes

Mint a budgeted key (`max_budget 0.5`, baseline `/key/info` spend `0.0`), then drive it through the router-model route, reading spend cross-pod after each call:

```bash
# /vllm leg — key qa-before-vllm, alternating pods, /key/info read from the other pod
for i in 1 2 3 4 5; do
  curl -s -w '\nHTTP %{http_code}\n' \
    "http://localhost:$POD/vllm/openai/deployments/gpt-5/chat/completions" \
    -H "Authorization: Bearer $KEY" -H 'Content-Type: application/json' \
    -d '{"model":"gpt-5","messages":[{"role":"user","content":"Say hi in one word"}]}'
  curl -s "http://localhost:$OTHER_POD/key/info?key=$KEY" -H "Authorization: Bearer $MASTER"
done
```

`/vllm/openai/deployments/gpt-5/chat/completions`:

| Req | HTTP | completion | /key/info spend (read cross-pod) |
|-----|------|------------|----------------------------------|
| 1 | 200 | "Hello!" | 0.0 |
| 2 | 200 | "Hello!" | 0.0 |
| 3 | 200 | "Hello!" | 0.0 |
| 4 | 200 | "Hello!" | 0.0 |
| 5 | **429** | `Budget has been exceeded! Key=qa-before-vllm (sk-...PeJw) Current cost: 0.5, Max budget: 0.5` | 0.0 |

`/azure/openai/deployments/gpt-5/chat/completions?api-version=2024-10-21`:

| Req | HTTP | completion | /key/info spend (read cross-pod) |
|-----|------|------------|----------------------------------|
| 1 | 200 | "Hello!" | 0.0 |
| 2 | 200 | "Hello!" | 0.0 |
| 3 | 200 | "Hello!" | 0.0 |
| 4 | 200 | "Hi!" | 0.0 |
| 5 | **429** | `Budget has been exceeded! Key=qa-before-azure (sk-...fHpg) Current cost: 0.5, Max budget: 0.5` | 0.0 |

Both symptoms on both routes: four real billed completions attribute `$0` (`/key/info` spend stuck at `0.0` on both pods), and the never-released pre-call reservation drifts the shared Redis counter to exactly `0.5`, tripping a false HTTP 429 on request 5 while the key's real spend is still `0.0`.

### After the fix — both routes attribute spend and never falsely 429

Spend attribution and reservation release ride the `user_api_key*` keys, which survive regardless of the metadata bucket, so this two-pod result holds unchanged at the current tip.

Same rig, same routes, 6 requests each:

`/vllm/openai/deployments/gpt-5/chat/completions`:

| Req | HTTP | completion | /key/info spend (read cross-pod) |
|-----|------|------------|----------------------------------|
| 1 | 200 | "Hello!" | 0.0 |
| 2 | 200 | "Howdy!" | 0.000066 |
| 3 | 200 | "Hello!" | 0.000132 |
| 4 | 200 | "Hi!" | 0.000198 |
| 5 | 200 | "Hi!" | 0.000198 |
| 6 | 200 | "Hello!" | 0.00033 |

Final settled `/key/info` spend after reconcile: **0.000396 on both pods** (= 6 × ~0.000066 per request).

`/azure/openai/deployments/gpt-5/chat/completions?api-version=2024-10-21`:

| Req | HTTP | completion | /key/info spend (read cross-pod) |
|-----|------|------------|----------------------------------|
| 1 | 200 | "Hello!" | 0.0 |
| 2 | 200 | "Hello!" | 0.000132 |
| 3 | 200 | "Hi!" | 0.000132 |
| 4 | 200 | "Hello!" | 0.000198 |
| 5 | 200 | "Hi!" | 0.000264 |
| 6 | 200 | "Hello!" | 0.00033 |

Final settled `/key/info` spend after reconcile: **0.000396 on both pods**.

All 12 requests (6 per route) return HTTP 200 with real completions, no false 429. `/key/info` spend climbs from `0.0` to the real `~0.000396` per key and agrees across both pods, so the pre-call reservation is released each request and the tiny real spend is the only thing that accrues against the `0.5` budget. Per-request reads occasionally lag one request behind the async cost callback, but every total reconciles within a few seconds. Attribution is restored and the reservation leak is gone on both changed routes.

### New tip `b1035368` (bucket fix) — secondary attribution fields reach the cost callback

The router hop canonicalises this call type onto `litellm_metadata`, and the cost callback reads spend attribution from that bucket while only backfilling `user_api_key*` keys from `metadata`. Building the attribution on `metadata` therefore delivered the `user_api_key*` keys (why the spend and reservation proof above passes) but silently dropped every other field, `agent_id` and `user_api_end_user_max_budget`, before the callback saw them. This commit builds the payload on `litellm_metadata` so those fields survive too.

Single DB-backed proxy at the new tip, real Azure OpenAI behind the `gpt-5` router model. Mint a budgeted key carrying an `agent_id`, drive one real billed request through each changed route, then read the calling key's spend logs, exactly what a user inspecting attribution would do:

```bash
# mint a key that carries an agent_id
curl -s http://localhost:41777/key/generate -H 'Authorization: Bearer sk-lit5470-qa' \
  -H 'Content-Type: application/json' \
  -d '{"max_budget": 5.0, "key_alias": "qa-agentid", "agent_id": "qa-agent-42"}'
# -> key sk-p5ufDbKrw..., agent_id qa-agent-42

# one real billed call on each changed route
curl -s -w '\nHTTP %{http_code}\n' http://localhost:41777/vllm/openai/deployments/gpt-5/chat/completions \
  -H "Authorization: Bearer $KEY" -H 'Content-Type: application/json' \
  -d '{"model":"gpt-5","messages":[{"role":"user","content":"Say hi in one word"}]}'
curl -s -w '\nHTTP %{http_code}\n' "http://localhost:41777/azure/openai/deployments/gpt-5/chat/completions?api-version=2024-10-21" \
  -H "Authorization: Bearer $KEY" -H 'Content-Type: application/json' \
  -d '{"model":"gpt-5","messages":[{"role":"user","content":"Say hi in one word"}]}'

# read the calling key's spend logs and its spend
curl -s "http://localhost:41777/spend/logs?api_key=$KEY" -H 'Authorization: Bearer sk-lit5470-qa'
curl -s "http://localhost:41777/key/info?key=$KEY"        -H 'Authorization: Bearer sk-lit5470-qa'
```

`GET /spend/logs?api_key=<KEY>` returns one row per route, each a real billed request attributed to the calling key with the `agent_id` now populated:

| Route (call_type) | HTTP | completion | spend | spend-log `agent_id` |
|-------------------|------|------------|-------|----------------------|
| /vllm (`allm_passthrough_route`) | 200 | "Hello!" | 0.000066 | `qa-agent-42` |
| /azure (`allm_passthrough_route`) | 200 | "Hello!" | 0.000066 | `qa-agent-42` |

`GET /key/info` reports the key's settled spend at `0.000132` (= 2 × 0.000066), so both real calls billed the key and the reservation released. Before this commit the same rows came back with `agent_id: null` because the field never left the `metadata` bucket. `user_api_end_user_max_budget` rides the identical helper and bucket, so it reaches the callback the same way; its only callback consumer is the customer-spend Slack alert threshold (no HTTP surface), and the mapped unit test asserts it threads through `litellm_metadata` alongside `agent_id`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes budget enforcement and spend attribution on two high-traffic passthrough paths; scope is narrow (metadata only) but incorrect wiring could still affect billing or false budget denials.
> 
> **Overview**
> Fixes **LIT-5470**: budgeted keys on **router-model** `/vllm` and `/azure` passthrough could show **$0 spend**, leak **pre-call budget reservations**, and eventually hit a false **429 BudgetExceededError** while real spend stayed under the limit.
> 
> Router-model branches call `allm_passthrough_route` directly and skipped the usual `add_litellm_data_to_request` path. This PR adds **`get_passthrough_router_request_metadata`**, which uses `LiteLLMProxyRequestSetup.add_user_api_key_auth_to_request_metadata` and puts attribution on **`litellm_metadata`** (not `metadata`), so the router hop and cost callback see `user_api_key*`, **`user_api_key_budget_reservation`**, **`agent_id`**, and **`user_api_end_user_max_budget`**.
> 
> Both router-model call sites now pass `litellm_metadata=get_passthrough_router_request_metadata(user_api_key_dict)` into `allm_passthrough_route`. Unit tests assert vllm and azure routes forward that metadata and leave `metadata` unset for non–`user_api_key*` fields.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b1035368f8983372d05e8158db895a345cc39883. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->