### PR TITLE
fix(passthrough): stop leaking the caller's virtual key on credential-less Vertex passthrough

### DIFF
--- a/litellm/proxy/pass_through_endpoints/llm_passthrough_endpoints.py
+++ b/litellm/proxy/pass_through_endpoints/llm_passthrough_endpoints.py
@@ -1768,6 +1768,8 @@ _VERTEX_CALLER_KEY_HEADER_PRECEDENCE: Final = (
     SpecialHeaders.azure_apim_authorization.value.lower(),
 )
 
+_MAPPED_ROUTE_CALLER_KEY_HEADER: Final = "litellm_user_api_key"
+
 
 def _operator_configured_caller_key_header_names() -> tuple[tuple[str, ...], tuple[str, ...]]:
     """Operator-configured caller-key header names, as (override, pass_through).
@@ -1802,20 +1804,26 @@ def _authenticated_caller_key_values(request: Request) -> frozenset[str]:
     """The value ``user_api_key_auth`` would accept as this caller's LiteLLM key.
 
     The Vertex route authenticates through ``Depends(user_api_key_auth)``, which
-    resolves the key from the first present of the credential headers in
-    ``get_api_key``'s precedence order. That precedence is matched here exactly: an
-    operator ``litellm_key_header_name`` overrides everything so it comes first,
-    then the built-in headers in ``get_api_key`` order, then a
-    ``pass_through_endpoints`` ``litellm_user_api_key`` header which ``get_api_key``
-    checks last. Some of those headers (``Authorization``, ``x-goog-api-key``) are
-    also kept as genuine bring-your-own Google credentials, so returning only the
-    value that actually authenticated lets the filter strip that value wherever it
-    appears while leaving a real Google credential in place. An empty set means no
-    caller key was found, so nothing is value-stripped.
+    resolves the key by precedence, matched here exactly. The ``/vertex_ai`` route
+    is a mapped pass-through route, so a header literally named
+    ``litellm_user_api_key`` overrides every other source (``user_api_key_auth``
+    applies it last), making it highest precedence. Then an operator
+    ``litellm_key_header_name``, then the built-in headers in ``get_api_key`` order,
+    then a ``pass_through_endpoints`` ``litellm_user_api_key`` header which
+    ``get_api_key`` checks last. Some of those headers (``Authorization``,
+    ``x-goog-api-key``) are also kept as genuine bring-your-own Google credentials,
+    so returning only the value that actually authenticated lets the filter strip
+    that value wherever it appears while leaving a real Google credential in place.
+    An empty set means no caller key was found, so nothing is value-stripped.
     """
     incoming: Final = _safe_get_request_headers(request)
     override_headers, pass_through_headers = _operator_configured_caller_key_header_names()
-    ordered_names: Final = override_headers + _VERTEX_CALLER_KEY_HEADER_PRECEDENCE + pass_through_headers
+    ordered_names: Final = (
+        (_MAPPED_ROUTE_CALLER_KEY_HEADER,)
+        + override_headers
+        + _VERTEX_CALLER_KEY_HEADER_PRECEDENCE
+        + pass_through_headers
+    )
     present_values: Final = (incoming[name] for name in ordered_names if incoming.get(name))
     authenticated_key: Final = next(
         (stripped for value in present_values if (stripped := _normalize_credential_value(value))),
@@ -1835,9 +1843,10 @@ def _forwarded_headers_for_credentialless_vertex_passthrough(request: Request) -
     authenticates with an OAuth token in ``Authorization`` or an API key in
     ``x-goog-api-key``. So the proxy-only auth headers Google never consumes
     (everything in that set except those two, e.g. ``x-litellm-api-key`` /
-    ``api-key`` / ``x-api-key`` / ``Ocp-Apim-Subscription-Key``, plus any
-    operator-configured ``litellm_key_header_name`` / ``pass_through_endpoints``
-    key header) are dropped by name. ``Authorization`` and ``x-goog-api-key`` may
+    ``api-key`` / ``x-api-key`` / ``Ocp-Apim-Subscription-Key``, plus the mapped
+    pass-through ``litellm_user_api_key`` header and any operator-configured
+    ``litellm_key_header_name`` / ``pass_through_endpoints`` key header) are dropped
+    by name. ``Authorization`` and ``x-goog-api-key`` may
     instead carry a genuine bring-your-own Google credential, so they are kept
     unless their value is the caller's authenticated LiteLLM key, which is dropped
     by value (normalizing any ``Bearer`` / ``Basic`` / ``AWS4`` auth-scheme prefix
@@ -1852,7 +1861,11 @@ def _forwarded_headers_for_credentialless_vertex_passthrough(request: Request) -
     incoming: Final = _safe_get_request_headers(request)
     caller_key_values: Final = _authenticated_caller_key_values(request)
     override_headers, pass_through_headers = _operator_configured_caller_key_header_names()
-    never_forwarded: Final = _HEADERS_NEVER_FORWARDED_TO_VERTEX.union(override_headers).union(pass_through_headers)
+    never_forwarded: Final = (
+        _HEADERS_NEVER_FORWARDED_TO_VERTEX.union((_MAPPED_ROUTE_CALLER_KEY_HEADER,))
+        .union(override_headers)
+        .union(pass_through_headers)
+    )
     forwarded: Final = MappingProxyType(
         {
             name: value

--- a/litellm/proxy/pass_through_endpoints/llm_passthrough_endpoints.py
+++ b/litellm/proxy/pass_through_endpoints/llm_passthrough_endpoints.py
@@ -1735,26 +1735,35 @@ _CREDENTIALLESS_VERTEX_MISSING_CREDENTIAL_DETAIL: Final = (
 )
 
 
+def _bearer_stripped(value: str) -> str:
+    parts: Final = value.split(None, 1)
+    if len(parts) == 2 and parts[0].lower() == "bearer":
+        return parts[1]
+    return value
+
+
 def _forwarded_headers_for_credentialless_vertex_passthrough(request: Request) -> Mapping[str, str]:
     """
     Header set to forward on the bring-your-own-credentials Vertex passthrough
     branch, used when the proxy has no Vertex credential configured.
 
     The LiteLLM virtual key that authenticated the caller is never forwarded to
-    Google: whichever header carried it (``x-litellm-api-key``, or ``Authorization``
-    when that is what ``get_litellm_virtual_key`` consumed) is dropped. A caller may
-    still bring their own Google credential in the ``Authorization`` (OAuth token) or
-    ``x-goog-api-key`` header; when neither is present the request is rejected so the
-    virtual key cannot leak upstream.
+    Google. LiteLLM accepts that key from several headers (``Authorization``,
+    ``x-litellm-api-key``, ``x-goog-api-key``, ``api-key``, ``x-api-key``), and
+    ``x-goog-api-key`` doubles as a genuine Google credential, so the key is dropped
+    by value across every header rather than by name. A caller may still bring their
+    own Google credential in the ``Authorization`` (OAuth token) or ``x-goog-api-key``
+    header; when neither survives the request is rejected so the virtual key cannot
+    leak upstream.
     """
     incoming: Final = _safe_get_request_headers(request)
-    litellm_virtual_key: Final = get_litellm_virtual_key(request)
+    caller_virtual_key: Final = _bearer_stripped(get_litellm_virtual_key(request))
     forwarded: Final = MappingProxyType(
         {
             name: value
             for name, value in incoming.items()
             if name not in ("content-length", "host", "x-litellm-api-key")
-            and not (name == "authorization" and value == litellm_virtual_key)
+            and not (caller_virtual_key and _bearer_stripped(value) == caller_virtual_key)
         }
     )
     if "authorization" not in forwarded and "x-goog-api-key" not in forwarded:

--- a/litellm/proxy/pass_through_endpoints/llm_passthrough_endpoints.py
+++ b/litellm/proxy/pass_through_endpoints/llm_passthrough_endpoints.py
@@ -1769,26 +1769,46 @@ _VERTEX_CALLER_KEY_HEADER_PRECEDENCE: Final = (
 )
 
 
+def _operator_configured_caller_key_header_names() -> tuple[str, ...]:
+    """Lowercased header names the operator has configured as caller-key sources.
+
+    ``user_api_key_auth`` accepts the caller's key from two runtime-configured
+    headers beyond the built-in ones: ``general_settings.litellm_key_header_name``,
+    and each ``general_settings.pass_through_endpoints`` entry's
+    ``headers.litellm_user_api_key``. Google never consumes either, so they are
+    both dropped by name and treated as top-precedence caller-key sources.
+    """
+    from litellm.proxy.proxy_server import general_settings
+
+    custom_key_header: Final = general_settings.get("litellm_key_header_name")
+    pass_through_endpoints: Final = general_settings.get("pass_through_endpoints")
+    endpoints: Final = pass_through_endpoints if isinstance(pass_through_endpoints, list) else ()
+    pass_through_key_headers: Final = tuple(
+        headers["litellm_user_api_key"]
+        for endpoint in endpoints
+        if isinstance(endpoint, dict)
+        for headers in (endpoint.get("headers"),)
+        if isinstance(headers, dict) and isinstance(headers.get("litellm_user_api_key"), str)
+    )
+    configured: Final = ((custom_key_header,) if isinstance(custom_key_header, str) else ()) + pass_through_key_headers
+    return tuple(dict.fromkeys(name.lower() for name in configured))
+
+
 def _authenticated_caller_key_values(request: Request) -> frozenset[str]:
     """The value ``user_api_key_auth`` would accept as this caller's LiteLLM key.
 
     The Vertex route authenticates through ``Depends(user_api_key_auth)``, which
     resolves the key from the first present of the credential headers in
     ``get_api_key``'s precedence order, with the operator-configured
-    ``general_settings.litellm_key_header_name`` overriding all of them. Some of
-    those headers (``Authorization``, ``x-goog-api-key``) are also kept as genuine
-    bring-your-own Google credentials, so returning only the value that actually
-    authenticated lets the filter strip that value wherever it appears while
-    leaving a real Google credential in place. An empty set means no caller key
-    was found, so nothing is value-stripped.
+    ``litellm_key_header_name`` / ``pass_through_endpoints`` headers overriding all
+    of them. Some of those headers (``Authorization``, ``x-goog-api-key``) are also
+    kept as genuine bring-your-own Google credentials, so returning only the value
+    that actually authenticated lets the filter strip that value wherever it
+    appears while leaving a real Google credential in place. An empty set means no
+    caller key was found, so nothing is value-stripped.
     """
-    from litellm.proxy.proxy_server import general_settings
-
     incoming: Final = _safe_get_request_headers(request)
-    custom_key_header_name: Final = (general_settings.get("litellm_key_header_name") or "").lower()
-    ordered_names: Final = (
-        (custom_key_header_name,) if custom_key_header_name else ()
-    ) + _VERTEX_CALLER_KEY_HEADER_PRECEDENCE
+    ordered_names: Final = _operator_configured_caller_key_header_names() + _VERTEX_CALLER_KEY_HEADER_PRECEDENCE
     present_values: Final = (incoming[name] for name in ordered_names if incoming.get(name))
     authenticated_key: Final = next(
         (stripped for value in present_values if (stripped := _normalize_credential_value(value))),
@@ -1808,26 +1828,28 @@ def _forwarded_headers_for_credentialless_vertex_passthrough(request: Request) -
     authenticates with an OAuth token in ``Authorization`` or an API key in
     ``x-goog-api-key``. So the proxy-only auth headers Google never consumes
     (everything in that set except those two, e.g. ``x-litellm-api-key`` /
-    ``api-key`` / ``x-api-key`` / ``Ocp-Apim-Subscription-Key``) are dropped by
-    name. ``Authorization`` and ``x-goog-api-key`` may instead carry a genuine
-    bring-your-own Google credential, so they are kept unless their value is the
-    caller's authenticated LiteLLM key, which is dropped by value (normalizing any
-    ``Bearer`` / ``Basic`` / ``AWS4`` auth-scheme prefix the same way authentication does). Because the value that authenticated is resolved by the
-    same precedence ``user_api_key_auth`` uses, a virtual key sent only in
-    ``x-goog-api-key`` (or in the operator-configured ``litellm_key_header_name``)
-    is dropped too, while a real Google key in ``x-goog-api-key`` alongside a
-    virtual key in a higher-precedence header is preserved. When neither a
-    surviving ``Authorization`` nor ``x-goog-api-key`` remains the request is
-    rejected so the virtual key cannot leak upstream.
+    ``api-key`` / ``x-api-key`` / ``Ocp-Apim-Subscription-Key``, plus any
+    operator-configured ``litellm_key_header_name`` / ``pass_through_endpoints``
+    key header) are dropped by name. ``Authorization`` and ``x-goog-api-key`` may
+    instead carry a genuine bring-your-own Google credential, so they are kept
+    unless their value is the caller's authenticated LiteLLM key, which is dropped
+    by value (normalizing any ``Bearer`` / ``Basic`` / ``AWS4`` auth-scheme prefix
+    the same way authentication does). Because the value that authenticated is
+    resolved by the same precedence ``user_api_key_auth`` uses, a virtual key sent
+    only in ``x-goog-api-key`` (or in an operator-configured key header) is dropped
+    too, while a real Google key in ``x-goog-api-key`` alongside a virtual key in a
+    higher-precedence header is preserved. When neither a surviving
+    ``Authorization`` nor ``x-goog-api-key`` remains the request is rejected so the
+    virtual key cannot leak upstream.
     """
     incoming: Final = _safe_get_request_headers(request)
     caller_key_values: Final = _authenticated_caller_key_values(request)
+    never_forwarded: Final = _HEADERS_NEVER_FORWARDED_TO_VERTEX.union(_operator_configured_caller_key_header_names())
     forwarded: Final = MappingProxyType(
         {
             name: value
             for name, value in incoming.items()
-            if name not in _HEADERS_NEVER_FORWARDED_TO_VERTEX
-            and _normalize_credential_value(value) not in caller_key_values
+            if name not in never_forwarded and _normalize_credential_value(value) not in caller_key_values
         }
     )
     if "authorization" not in forwarded and "x-goog-api-key" not in forwarded:

--- a/litellm/proxy/pass_through_endpoints/llm_passthrough_endpoints.py
+++ b/litellm/proxy/pass_through_endpoints/llm_passthrough_endpoints.py
@@ -1742,8 +1742,9 @@ def _bearer_stripped(value: str) -> str:
     return value
 
 
-_HEADERS_NEVER_FORWARDED_TO_VERTEX: Final = frozenset(
-    {"content-length", "host", "x-litellm-api-key", "api-key", "x-api-key"}
+_VERTEX_UPSTREAM_CREDENTIAL_HEADERS: Final = frozenset({"authorization", "x-goog-api-key"})
+_HEADERS_NEVER_FORWARDED_TO_VERTEX: Final = frozenset({"content-length", "host"}) | (
+    SpecialHeaders.litellm_credential_header_names() - _VERTEX_UPSTREAM_CREDENTIAL_HEADERS
 )
 
 
@@ -1772,9 +1773,12 @@ def _forwarded_headers_for_credentialless_vertex_passthrough(request: Request) -
     branch, used when the proxy has no Vertex credential configured.
 
     No credential the proxy accepts for caller authentication is forwarded to
-    Google. Vertex only ever authenticates with an OAuth token in ``Authorization``
-    or an API key in ``x-goog-api-key``, so the proxy-only auth headers Google never
-    consumes (``x-litellm-api-key`` / ``api-key`` / ``x-api-key``) are dropped by
+    Google. ``user_api_key_auth`` reads the caller's key from every header in
+    ``SpecialHeaders.litellm_credential_header_names()``, and Vertex only ever
+    authenticates with an OAuth token in ``Authorization`` or an API key in
+    ``x-goog-api-key``. So the proxy-only auth headers Google never consumes
+    (everything in that set except those two, e.g. ``x-litellm-api-key`` /
+    ``api-key`` / ``x-api-key`` / ``Ocp-Apim-Subscription-Key``) are dropped by
     name. ``Authorization`` and ``x-goog-api-key`` may instead carry a genuine
     bring-your-own Google credential, so they are kept unless their value is one of
     the caller's LiteLLM key values, which are dropped by value (normalizing any

--- a/litellm/proxy/pass_through_endpoints/llm_passthrough_endpoints.py
+++ b/litellm/proxy/pass_through_endpoints/llm_passthrough_endpoints.py
@@ -1742,19 +1742,27 @@ def _bearer_stripped(value: str) -> str:
     return value
 
 
+_HEADERS_NEVER_FORWARDED_TO_VERTEX: Final = frozenset(
+    {"content-length", "host", "x-litellm-api-key", "api-key", "x-api-key"}
+)
+
+
 def _forwarded_headers_for_credentialless_vertex_passthrough(request: Request) -> Mapping[str, str]:
     """
     Header set to forward on the bring-your-own-credentials Vertex passthrough
     branch, used when the proxy has no Vertex credential configured.
 
-    The LiteLLM virtual key that authenticated the caller is never forwarded to
-    Google. LiteLLM accepts that key from several headers (``Authorization``,
-    ``x-litellm-api-key``, ``x-goog-api-key``, ``api-key``, ``x-api-key``), and
-    ``x-goog-api-key`` doubles as a genuine Google credential, so the key is dropped
-    by value across every header rather than by name. A caller may still bring their
-    own Google credential in the ``Authorization`` (OAuth token) or ``x-goog-api-key``
-    header; when neither survives the request is rejected so the virtual key cannot
-    leak upstream.
+    No credential the proxy accepts for caller authentication is forwarded to
+    Google. LiteLLM reads the caller's virtual key from ``x-litellm-api-key``,
+    ``api-key``, ``x-api-key``, ``Authorization``, and ``x-goog-api-key``. Vertex
+    only ever authenticates with an OAuth token in ``Authorization`` or an API key
+    in ``x-goog-api-key``, so ``x-litellm-api-key`` / ``api-key`` / ``x-api-key``
+    can only carry caller auth material and are dropped by name. ``Authorization``
+    and ``x-goog-api-key`` may instead carry a genuine bring-your-own Google
+    credential, so they are kept unless their value is the caller's virtual key,
+    which is dropped by value (normalizing any ``Bearer`` prefix). When neither a
+    surviving ``Authorization`` nor ``x-goog-api-key`` remains the request is
+    rejected so the virtual key cannot leak upstream.
     """
     incoming: Final = _safe_get_request_headers(request)
     caller_virtual_key: Final = _bearer_stripped(get_litellm_virtual_key(request))
@@ -1762,7 +1770,7 @@ def _forwarded_headers_for_credentialless_vertex_passthrough(request: Request) -
         {
             name: value
             for name, value in incoming.items()
-            if name not in ("content-length", "host", "x-litellm-api-key")
+            if name not in _HEADERS_NEVER_FORWARDED_TO_VERTEX
             and not (caller_virtual_key and _bearer_stripped(value) == caller_virtual_key)
         }
     )

--- a/litellm/proxy/pass_through_endpoints/llm_passthrough_endpoints.py
+++ b/litellm/proxy/pass_through_endpoints/llm_passthrough_endpoints.py
@@ -29,7 +29,11 @@ from litellm.llms.anthropic.common_utils import AnthropicModelInfo
 from litellm.llms.vertex_ai.vertex_llm_base import VertexBase
 from litellm.proxy._types import *
 from litellm.proxy.auth.route_checks import RouteChecks
-from litellm.proxy.auth.user_api_key_auth import user_api_key_auth, user_api_key_auth_websocket
+from litellm.proxy.auth.user_api_key_auth import (
+    _get_bearer_token,
+    user_api_key_auth,
+    user_api_key_auth_websocket,
+)
 from litellm.proxy.common_utils.http_parsing_utils import (
     _read_request_body,
     _safe_get_request_headers,
@@ -1735,11 +1739,18 @@ _CREDENTIALLESS_VERTEX_MISSING_CREDENTIAL_DETAIL: Final = (
 )
 
 
-def _bearer_stripped(value: str) -> str:
-    parts: Final = value.split(None, 1)
-    if len(parts) == 2 and parts[0].lower() == "bearer":
-        return parts[1]
-    return value
+def _normalize_credential_value(value: str) -> str:
+    """Reduce a header value to the bare token, matching how ``user_api_key_auth``
+    reads a caller's key.
+
+    Reuses the auth module's ``_get_bearer_token`` so the caller-key comparison
+    strips exactly the schemes authentication accepts (``Bearer`` / ``bearer`` /
+    ``Basic`` / ``AWS4-HMAC-SHA256`` credential), rather than re-deriving a
+    narrower normalization here. ``_get_bearer_token`` returns ``""`` for a value
+    with no recognized scheme prefix, so a bare token (or a real Google
+    credential that carries no scheme) falls back to its own value.
+    """
+    return _get_bearer_token(value) or value
 
 
 _VERTEX_UPSTREAM_CREDENTIAL_HEADERS: Final = frozenset({"authorization", "x-goog-api-key"})
@@ -1780,7 +1791,7 @@ def _authenticated_caller_key_values(request: Request) -> frozenset[str]:
     ) + _VERTEX_CALLER_KEY_HEADER_PRECEDENCE
     present_values: Final = (incoming[name] for name in ordered_names if incoming.get(name))
     authenticated_key: Final = next(
-        (stripped for value in present_values if (stripped := _bearer_stripped(value))),
+        (stripped for value in present_values if (stripped := _normalize_credential_value(value))),
         "",
     )
     return frozenset({authenticated_key}) if authenticated_key else frozenset()
@@ -1801,7 +1812,7 @@ def _forwarded_headers_for_credentialless_vertex_passthrough(request: Request) -
     name. ``Authorization`` and ``x-goog-api-key`` may instead carry a genuine
     bring-your-own Google credential, so they are kept unless their value is the
     caller's authenticated LiteLLM key, which is dropped by value (normalizing any
-    ``Bearer`` prefix). Because the value that authenticated is resolved by the
+    ``Bearer`` / ``Basic`` / ``AWS4`` auth-scheme prefix the same way authentication does). Because the value that authenticated is resolved by the
     same precedence ``user_api_key_auth`` uses, a virtual key sent only in
     ``x-goog-api-key`` (or in the operator-configured ``litellm_key_header_name``)
     is dropped too, while a real Google key in ``x-goog-api-key`` alongside a
@@ -1815,7 +1826,8 @@ def _forwarded_headers_for_credentialless_vertex_passthrough(request: Request) -
         {
             name: value
             for name, value in incoming.items()
-            if name not in _HEADERS_NEVER_FORWARDED_TO_VERTEX and _bearer_stripped(value) not in caller_key_values
+            if name not in _HEADERS_NEVER_FORWARDED_TO_VERTEX
+            and _normalize_credential_value(value) not in caller_key_values
         }
     )
     if "authorization" not in forwarded and "x-goog-api-key" not in forwarded:

--- a/litellm/proxy/pass_through_endpoints/llm_passthrough_endpoints.py
+++ b/litellm/proxy/pass_through_endpoints/llm_passthrough_endpoints.py
@@ -1748,23 +1748,42 @@ _HEADERS_NEVER_FORWARDED_TO_VERTEX: Final = frozenset({"content-length", "host"}
 )
 
 
-def _credentialless_caller_key_values(request: Request) -> frozenset[str]:
-    """Every header value the proxy would accept as this caller's LiteLLM key.
+_VERTEX_CALLER_KEY_HEADER_PRECEDENCE: Final = (
+    SpecialHeaders.custom_litellm_api_key.value.lower(),
+    SpecialHeaders.openai_authorization.value.lower(),
+    SpecialHeaders.azure_authorization.value.lower(),
+    SpecialHeaders.anthropic_authorization.value.lower(),
+    SpecialHeaders.google_ai_studio_authorization.value.lower(),
+    SpecialHeaders.azure_apim_authorization.value.lower(),
+)
 
-    Beyond the built-in ``x-litellm-api-key`` / ``Authorization`` that
-    ``get_litellm_virtual_key`` reads, ``user_api_key_auth`` also authenticates a
-    caller from the operator-configured ``general_settings.litellm_key_header_name``
-    when one is set, reading that header straight off the request. Any of those
-    values equals the virtual key and must never be forwarded to Google.
+
+def _authenticated_caller_key_values(request: Request) -> frozenset[str]:
+    """The value ``user_api_key_auth`` would accept as this caller's LiteLLM key.
+
+    The Vertex route authenticates through ``Depends(user_api_key_auth)``, which
+    resolves the key from the first present of the credential headers in
+    ``get_api_key``'s precedence order, with the operator-configured
+    ``general_settings.litellm_key_header_name`` overriding all of them. Some of
+    those headers (``Authorization``, ``x-goog-api-key``) are also kept as genuine
+    bring-your-own Google credentials, so returning only the value that actually
+    authenticated lets the filter strip that value wherever it appears while
+    leaving a real Google credential in place. An empty set means no caller key
+    was found, so nothing is value-stripped.
     """
     from litellm.proxy.proxy_server import general_settings
 
-    custom_key_header_name: Final = general_settings.get("litellm_key_header_name") or ""
-    candidates: Final = (
-        get_litellm_virtual_key(request),
-        request.headers.get(custom_key_header_name, "") if custom_key_header_name else "",
+    incoming: Final = _safe_get_request_headers(request)
+    custom_key_header_name: Final = (general_settings.get("litellm_key_header_name") or "").lower()
+    ordered_names: Final = (
+        (custom_key_header_name,) if custom_key_header_name else ()
+    ) + _VERTEX_CALLER_KEY_HEADER_PRECEDENCE
+    present_values: Final = (incoming[name] for name in ordered_names if incoming.get(name))
+    authenticated_key: Final = next(
+        (stripped for value in present_values if (stripped := _bearer_stripped(value))),
+        "",
     )
-    return frozenset(_bearer_stripped(value) for value in candidates if _bearer_stripped(value))
+    return frozenset({authenticated_key}) if authenticated_key else frozenset()
 
 
 def _forwarded_headers_for_credentialless_vertex_passthrough(request: Request) -> Mapping[str, str]:
@@ -1780,15 +1799,18 @@ def _forwarded_headers_for_credentialless_vertex_passthrough(request: Request) -
     (everything in that set except those two, e.g. ``x-litellm-api-key`` /
     ``api-key`` / ``x-api-key`` / ``Ocp-Apim-Subscription-Key``) are dropped by
     name. ``Authorization`` and ``x-goog-api-key`` may instead carry a genuine
-    bring-your-own Google credential, so they are kept unless their value is one of
-    the caller's LiteLLM key values, which are dropped by value (normalizing any
-    ``Bearer`` prefix). Dropping by value also covers a virtual key sent in the
-    operator-configured ``litellm_key_header_name``, whatever that header is named.
-    When neither a surviving ``Authorization`` nor ``x-goog-api-key`` remains the
-    request is rejected so the virtual key cannot leak upstream.
+    bring-your-own Google credential, so they are kept unless their value is the
+    caller's authenticated LiteLLM key, which is dropped by value (normalizing any
+    ``Bearer`` prefix). Because the value that authenticated is resolved by the
+    same precedence ``user_api_key_auth`` uses, a virtual key sent only in
+    ``x-goog-api-key`` (or in the operator-configured ``litellm_key_header_name``)
+    is dropped too, while a real Google key in ``x-goog-api-key`` alongside a
+    virtual key in a higher-precedence header is preserved. When neither a
+    surviving ``Authorization`` nor ``x-goog-api-key`` remains the request is
+    rejected so the virtual key cannot leak upstream.
     """
     incoming: Final = _safe_get_request_headers(request)
-    caller_key_values: Final = _credentialless_caller_key_values(request)
+    caller_key_values: Final = _authenticated_caller_key_values(request)
     forwarded: Final = MappingProxyType(
         {
             name: value

--- a/litellm/proxy/pass_through_endpoints/llm_passthrough_endpoints.py
+++ b/litellm/proxy/pass_through_endpoints/llm_passthrough_endpoints.py
@@ -9,7 +9,7 @@ Use litellm with Anthropic SDK, Vertex AI SDK, Cohere SDK, etc.
 import json
 import os
 import re
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from types import MappingProxyType
 from typing import TYPE_CHECKING, Annotated, Any, Final, cast
 
@@ -1726,6 +1726,42 @@ def _override_vertex_params_from_router_credentials(
     return vertex_project, vertex_location
 
 
+_CREDENTIALLESS_VERTEX_MISSING_CREDENTIAL_DETAIL: Final = (
+    "No Vertex AI credential is configured on this proxy and the request carried no upstream "
+    "Google credential. The LiteLLM virtual key is not forwarded to Google. Configure a Vertex "
+    "credential (DEFAULT_VERTEXAI_PROJECT / DEFAULT_VERTEXAI_LOCATION / DEFAULT_VERTEXAI_CREDENTIALS, "
+    "or a model with use_in_pass_through: true), or send your own Google OAuth token in the "
+    "Authorization header."
+)
+
+
+def _forwarded_headers_for_credentialless_vertex_passthrough(request: Request) -> Mapping[str, str]:
+    """
+    Header set to forward on the bring-your-own-credentials Vertex passthrough
+    branch, used when the proxy has no Vertex credential configured.
+
+    The LiteLLM virtual key that authenticated the caller is never forwarded to
+    Google: whichever header carried it (``x-litellm-api-key``, or ``Authorization``
+    when that is what ``get_litellm_virtual_key`` consumed) is dropped. A caller may
+    still bring their own Google credential in the ``Authorization`` (OAuth token) or
+    ``x-goog-api-key`` header; when neither is present the request is rejected so the
+    virtual key cannot leak upstream.
+    """
+    incoming: Final = _safe_get_request_headers(request)
+    litellm_virtual_key: Final = get_litellm_virtual_key(request)
+    forwarded: Final = MappingProxyType(
+        {
+            name: value
+            for name, value in incoming.items()
+            if name not in ("content-length", "host", "x-litellm-api-key")
+            and not (name == "authorization" and value == litellm_virtual_key)
+        }
+    )
+    if "authorization" not in forwarded and "x-goog-api-key" not in forwarded:
+        raise HTTPException(status_code=401, detail=_CREDENTIALLESS_VERTEX_MISSING_CREDENTIAL_DETAIL)
+    return forwarded
+
+
 async def _prepare_vertex_auth_headers(
     request: Request,
     vertex_credentials: Any | None,
@@ -1734,7 +1770,7 @@ async def _prepare_vertex_auth_headers(
     vertex_location: str | None,
     base_target_url: str | None,
     get_vertex_pass_through_handler: BaseVertexAIPassThroughHandler,
-) -> tuple[dict, str | None, bool, str | None, str | None]:
+) -> tuple[Mapping[str, str], str | None, bool, str | None, str | None]:
     """
     Prepare authentication headers for Vertex AI pass-through requests.
 
@@ -1760,11 +1796,11 @@ async def _prepare_vertex_auth_headers(
 
     # Use headers from the incoming request if no vertex credentials are found
     if (vertex_credentials is None or vertex_credentials.vertex_project is None) and router_credentials is None:
-        headers = _safe_get_request_headers(request).copy()
+        headers = _forwarded_headers_for_credentialless_vertex_passthrough(request)
         headers_passed_through = True
-        verbose_proxy_logger.debug("default_vertex_config  not set, incoming request headers %s", headers)
-        headers.pop("content-length", None)
-        headers.pop("host", None)
+        verbose_proxy_logger.debug(
+            "default_vertex_config not set, forwarding caller-provided headers %s", tuple(headers.keys())
+        )
     else:
         if router_credentials is not None:
             vertex_credentials_str = None
@@ -1850,7 +1886,7 @@ async def _base_vertex_proxy_route(
 
     encoded_endpoint = httpx.URL(endpoint).path
     verbose_proxy_logger.debug("requested endpoint %s", endpoint)
-    headers: dict = {}
+    headers: Mapping[str, str] = {}
     api_key_to_use = get_litellm_virtual_key(request=request)
     user_api_key_dict = await user_api_key_auth(
         request=request,

--- a/litellm/proxy/pass_through_endpoints/llm_passthrough_endpoints.py
+++ b/litellm/proxy/pass_through_endpoints/llm_passthrough_endpoints.py
@@ -1747,31 +1747,49 @@ _HEADERS_NEVER_FORWARDED_TO_VERTEX: Final = frozenset(
 )
 
 
+def _credentialless_caller_key_values(request: Request) -> frozenset[str]:
+    """Every header value the proxy would accept as this caller's LiteLLM key.
+
+    Beyond the built-in ``x-litellm-api-key`` / ``Authorization`` that
+    ``get_litellm_virtual_key`` reads, ``user_api_key_auth`` also authenticates a
+    caller from the operator-configured ``general_settings.litellm_key_header_name``
+    when one is set, reading that header straight off the request. Any of those
+    values equals the virtual key and must never be forwarded to Google.
+    """
+    from litellm.proxy.proxy_server import general_settings
+
+    custom_key_header_name: Final = general_settings.get("litellm_key_header_name") or ""
+    candidates: Final = (
+        get_litellm_virtual_key(request),
+        request.headers.get(custom_key_header_name, "") if custom_key_header_name else "",
+    )
+    return frozenset(_bearer_stripped(value) for value in candidates if _bearer_stripped(value))
+
+
 def _forwarded_headers_for_credentialless_vertex_passthrough(request: Request) -> Mapping[str, str]:
     """
     Header set to forward on the bring-your-own-credentials Vertex passthrough
     branch, used when the proxy has no Vertex credential configured.
 
     No credential the proxy accepts for caller authentication is forwarded to
-    Google. LiteLLM reads the caller's virtual key from ``x-litellm-api-key``,
-    ``api-key``, ``x-api-key``, ``Authorization``, and ``x-goog-api-key``. Vertex
-    only ever authenticates with an OAuth token in ``Authorization`` or an API key
-    in ``x-goog-api-key``, so ``x-litellm-api-key`` / ``api-key`` / ``x-api-key``
-    can only carry caller auth material and are dropped by name. ``Authorization``
-    and ``x-goog-api-key`` may instead carry a genuine bring-your-own Google
-    credential, so they are kept unless their value is the caller's virtual key,
-    which is dropped by value (normalizing any ``Bearer`` prefix). When neither a
-    surviving ``Authorization`` nor ``x-goog-api-key`` remains the request is
-    rejected so the virtual key cannot leak upstream.
+    Google. Vertex only ever authenticates with an OAuth token in ``Authorization``
+    or an API key in ``x-goog-api-key``, so the proxy-only auth headers Google never
+    consumes (``x-litellm-api-key`` / ``api-key`` / ``x-api-key``) are dropped by
+    name. ``Authorization`` and ``x-goog-api-key`` may instead carry a genuine
+    bring-your-own Google credential, so they are kept unless their value is one of
+    the caller's LiteLLM key values, which are dropped by value (normalizing any
+    ``Bearer`` prefix). Dropping by value also covers a virtual key sent in the
+    operator-configured ``litellm_key_header_name``, whatever that header is named.
+    When neither a surviving ``Authorization`` nor ``x-goog-api-key`` remains the
+    request is rejected so the virtual key cannot leak upstream.
     """
     incoming: Final = _safe_get_request_headers(request)
-    caller_virtual_key: Final = _bearer_stripped(get_litellm_virtual_key(request))
+    caller_key_values: Final = _credentialless_caller_key_values(request)
     forwarded: Final = MappingProxyType(
         {
             name: value
             for name, value in incoming.items()
-            if name not in _HEADERS_NEVER_FORWARDED_TO_VERTEX
-            and not (caller_virtual_key and _bearer_stripped(value) == caller_virtual_key)
+            if name not in _HEADERS_NEVER_FORWARDED_TO_VERTEX and _bearer_stripped(value) not in caller_key_values
         }
     )
     if "authorization" not in forwarded and "x-goog-api-key" not in forwarded:

--- a/litellm/proxy/pass_through_endpoints/llm_passthrough_endpoints.py
+++ b/litellm/proxy/pass_through_endpoints/llm_passthrough_endpoints.py
@@ -1769,29 +1769,33 @@ _VERTEX_CALLER_KEY_HEADER_PRECEDENCE: Final = (
 )
 
 
-def _operator_configured_caller_key_header_names() -> tuple[str, ...]:
-    """Lowercased header names the operator has configured as caller-key sources.
+def _operator_configured_caller_key_header_names() -> tuple[tuple[str, ...], tuple[str, ...]]:
+    """Operator-configured caller-key header names, as (override, pass_through).
 
     ``user_api_key_auth`` accepts the caller's key from two runtime-configured
-    headers beyond the built-in ones: ``general_settings.litellm_key_header_name``,
-    and each ``general_settings.pass_through_endpoints`` entry's
-    ``headers.litellm_user_api_key``. Google never consumes either, so they are
-    both dropped by name and treated as top-precedence caller-key sources.
+    header sources beyond the built-in ones, at opposite ends of its precedence.
+    ``general_settings.litellm_key_header_name`` overrides every built-in source
+    (it replaces the resolved key after ``get_api_key`` runs), so it is highest
+    precedence. Each ``general_settings.pass_through_endpoints`` entry's
+    ``headers.litellm_user_api_key`` is checked last inside ``get_api_key``, so it
+    is lowest. Google never consumes either, so both are also dropped by name.
     """
     from litellm.proxy.proxy_server import general_settings
 
     custom_key_header: Final = general_settings.get("litellm_key_header_name")
+    override: Final = (custom_key_header.lower(),) if isinstance(custom_key_header, str) else ()
     pass_through_endpoints: Final = general_settings.get("pass_through_endpoints")
     endpoints: Final = pass_through_endpoints if isinstance(pass_through_endpoints, list) else ()
-    pass_through_key_headers: Final = tuple(
-        headers["litellm_user_api_key"]
-        for endpoint in endpoints
-        if isinstance(endpoint, dict)
-        for headers in (endpoint.get("headers"),)
-        if isinstance(headers, dict) and isinstance(headers.get("litellm_user_api_key"), str)
+    pass_through: Final = tuple(
+        dict.fromkeys(
+            headers["litellm_user_api_key"].lower()
+            for endpoint in endpoints
+            if isinstance(endpoint, dict)
+            for headers in (endpoint.get("headers"),)
+            if isinstance(headers, dict) and isinstance(headers.get("litellm_user_api_key"), str)
+        )
     )
-    configured: Final = ((custom_key_header,) if isinstance(custom_key_header, str) else ()) + pass_through_key_headers
-    return tuple(dict.fromkeys(name.lower() for name in configured))
+    return override, pass_through
 
 
 def _authenticated_caller_key_values(request: Request) -> frozenset[str]:
@@ -1799,16 +1803,19 @@ def _authenticated_caller_key_values(request: Request) -> frozenset[str]:
 
     The Vertex route authenticates through ``Depends(user_api_key_auth)``, which
     resolves the key from the first present of the credential headers in
-    ``get_api_key``'s precedence order, with the operator-configured
-    ``litellm_key_header_name`` / ``pass_through_endpoints`` headers overriding all
-    of them. Some of those headers (``Authorization``, ``x-goog-api-key``) are also
-    kept as genuine bring-your-own Google credentials, so returning only the value
-    that actually authenticated lets the filter strip that value wherever it
+    ``get_api_key``'s precedence order. That precedence is matched here exactly: an
+    operator ``litellm_key_header_name`` overrides everything so it comes first,
+    then the built-in headers in ``get_api_key`` order, then a
+    ``pass_through_endpoints`` ``litellm_user_api_key`` header which ``get_api_key``
+    checks last. Some of those headers (``Authorization``, ``x-goog-api-key``) are
+    also kept as genuine bring-your-own Google credentials, so returning only the
+    value that actually authenticated lets the filter strip that value wherever it
     appears while leaving a real Google credential in place. An empty set means no
     caller key was found, so nothing is value-stripped.
     """
     incoming: Final = _safe_get_request_headers(request)
-    ordered_names: Final = _operator_configured_caller_key_header_names() + _VERTEX_CALLER_KEY_HEADER_PRECEDENCE
+    override_headers, pass_through_headers = _operator_configured_caller_key_header_names()
+    ordered_names: Final = override_headers + _VERTEX_CALLER_KEY_HEADER_PRECEDENCE + pass_through_headers
     present_values: Final = (incoming[name] for name in ordered_names if incoming.get(name))
     authenticated_key: Final = next(
         (stripped for value in present_values if (stripped := _normalize_credential_value(value))),
@@ -1844,7 +1851,8 @@ def _forwarded_headers_for_credentialless_vertex_passthrough(request: Request) -
     """
     incoming: Final = _safe_get_request_headers(request)
     caller_key_values: Final = _authenticated_caller_key_values(request)
-    never_forwarded: Final = _HEADERS_NEVER_FORWARDED_TO_VERTEX.union(_operator_configured_caller_key_header_names())
+    override_headers, pass_through_headers = _operator_configured_caller_key_header_names()
+    never_forwarded: Final = _HEADERS_NEVER_FORWARDED_TO_VERTEX.union(override_headers).union(pass_through_headers)
     forwarded: Final = MappingProxyType(
         {
             name: value

--- a/tests/test_litellm/proxy/pass_through_endpoints/test_llm_pass_through_endpoints.py
+++ b/tests/test_litellm/proxy/pass_through_endpoints/test_llm_pass_through_endpoints.py
@@ -3450,14 +3450,16 @@ class TestVertexCredentiallessPassthroughVirtualKeyLeak:
 
     With no Vertex credential configured, the passthrough took the
     bring-your-own-credentials branch and forwarded the whole incoming header set
-    to Google, including whichever header carried the caller's LiteLLM virtual key
-    (``Authorization: Bearer <vkey>`` or ``x-litellm-api-key: <vkey>``). That leaked
-    the proxy's own secret to an upstream provider.
+    to Google, including whichever header carried the caller's LiteLLM virtual key.
+    LiteLLM accepts that key from several headers (``Authorization``,
+    ``x-litellm-api-key``, ``x-goog-api-key``, ``api-key``, ``x-api-key``), and
+    ``x-goog-api-key`` doubles as a genuine Google credential, so any of them could
+    leak the proxy's own secret to an upstream provider.
 
     A credential-less request that carries no upstream Google credential must now
     fail with a clean 401 and never reach ``create_pass_through_route``; a genuine
     bring-your-own Google credential must still pass through, with the virtual key
-    stripped from what is forwarded.
+    stripped by value from every forwarded header.
     """
 
     VKEY = "sk-litellm-victim-key"
@@ -3576,6 +3578,26 @@ class TestVertexCredentiallessPassthroughVirtualKeyLeak:
         assert raised is None
         assert forwarded is not None
         assert forwarded.get("x-goog-api-key") == "AIza-google-api-key"
+        assert "x-litellm-api-key" not in forwarded
+        assert self.VKEY not in " ".join(f"{name}:{value}" for name, value in forwarded.items())
+
+    @pytest.mark.asyncio
+    async def test_virtual_key_echoed_in_alternate_auth_headers_is_stripped_by_value(self, monkeypatch):
+        raised, forwarded = await self._run(
+            monkeypatch,
+            [
+                (b"x-litellm-api-key", self.VKEY.encode()),
+                (b"authorization", b"Bearer ya29.google-oauth-token"),
+                (b"api-key", self.VKEY.encode()),
+                (b"x-api-key", self.VKEY.encode()),
+                (b"content-type", b"application/json"),
+            ],
+        )
+        assert raised is None
+        assert forwarded is not None
+        assert forwarded.get("authorization") == "Bearer ya29.google-oauth-token"
+        assert "api-key" not in forwarded
+        assert "x-api-key" not in forwarded
         assert "x-litellm-api-key" not in forwarded
         assert self.VKEY not in " ".join(f"{name}:{value}" for name, value in forwarded.items())
 

--- a/tests/test_litellm/proxy/pass_through_endpoints/test_llm_pass_through_endpoints.py
+++ b/tests/test_litellm/proxy/pass_through_endpoints/test_llm_pass_through_endpoints.py
@@ -3582,6 +3582,20 @@ class TestVertexCredentiallessPassthroughVirtualKeyLeak:
         assert self.VKEY not in " ".join(f"{name}:{value}" for name, value in forwarded.items())
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("scheme", ["Bearer", "bearer", "Basic"])
+    async def test_virtual_key_echoed_in_authorization_with_any_scheme_is_stripped(self, monkeypatch, scheme):
+        raised, forwarded = await self._run(
+            monkeypatch,
+            [
+                (b"x-litellm-api-key", self.VKEY.encode()),
+                (b"authorization", f"{scheme} {self.VKEY}".encode()),
+                (b"content-type", b"application/json"),
+            ],
+        )
+        assert forwarded is None, f"a virtual key echoed as '{scheme} <key>' in Authorization must be stripped, not forwarded"
+        assert raised is not None and raised.status_code == 401
+
+    @pytest.mark.asyncio
     async def test_byo_x_goog_api_key_still_forwards_without_virtual_key(self, monkeypatch):
         raised, forwarded = await self._run(
             monkeypatch,

--- a/tests/test_litellm/proxy/pass_through_endpoints/test_llm_pass_through_endpoints.py
+++ b/tests/test_litellm/proxy/pass_through_endpoints/test_llm_pass_through_endpoints.py
@@ -3736,6 +3736,36 @@ class TestVertexCredentiallessPassthroughVirtualKeyLeak:
         assert "x-company-key" not in forwarded
         assert self.VKEY not in " ".join(f"{name}:{value}" for name, value in forwarded.items())
 
+    @pytest.mark.asyncio
+    async def test_virtual_key_in_mapped_route_litellm_user_api_key_header_is_stripped(self, monkeypatch):
+        raised, forwarded = await self._run(
+            monkeypatch,
+            [
+                (b"litellm_user_api_key", self.VKEY.encode()),
+                (b"authorization", b"Bearer ya29.byo-google-oauth"),
+                (b"x-goog-api-key", b"AIza-real-google-api-key"),
+                (b"content-type", b"application/json"),
+            ],
+        )
+        assert raised is None
+        assert forwarded is not None
+        assert forwarded.get("x-goog-api-key") == "AIza-real-google-api-key"
+        assert forwarded.get("authorization") == "Bearer ya29.byo-google-oauth"
+        assert "litellm_user_api_key" not in forwarded
+        assert self.VKEY not in " ".join(f"{name}:{value}" for name, value in forwarded.items())
+
+    @pytest.mark.asyncio
+    async def test_virtual_key_in_mapped_route_litellm_user_api_key_header_alone_is_rejected(self, monkeypatch):
+        raised, forwarded = await self._run(
+            monkeypatch,
+            [
+                (b"litellm_user_api_key", self.VKEY.encode()),
+                (b"content-type", b"application/json"),
+            ],
+        )
+        assert forwarded is None, "a virtual key in the mapped-route litellm_user_api_key header must be dropped, not forwarded"
+        assert raised is not None and raised.status_code == 401
+
 
 class TestGetAzureAISearchIndexFromEndpoint:
     """The operable index is only the segment right after ``indexes``.

--- a/tests/test_litellm/proxy/pass_through_endpoints/test_llm_pass_through_endpoints.py
+++ b/tests/test_litellm/proxy/pass_through_endpoints/test_llm_pass_through_endpoints.py
@@ -35,7 +35,7 @@ from litellm.proxy.pass_through_endpoints.llm_passthrough_endpoints import (
     vertex_proxy_route,
     vllm_proxy_route,
 )
-from litellm.proxy._types import LitellmUserRoles, UserAPIKeyAuth
+from litellm.proxy._types import LitellmUserRoles, SpecialHeaders, UserAPIKeyAuth
 from litellm.types.passthrough_endpoints.vertex_ai import VertexPassThroughCredentials
 
 
@@ -3607,6 +3607,28 @@ class TestVertexCredentiallessPassthroughVirtualKeyLeak:
         assert self.VKEY not in forwarded_blob
         assert "azure-style-caller-secret" not in forwarded_blob
         assert "anthropic-style-caller-secret" not in forwarded_blob
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "credential_header",
+        sorted(SpecialHeaders.litellm_credential_header_names() - {"authorization", "x-goog-api-key"}),
+    )
+    async def test_every_non_google_credential_header_is_dropped_by_name(self, monkeypatch, credential_header):
+        raised, forwarded = await self._run(
+            monkeypatch,
+            [
+                (b"x-goog-api-key", b"AIza-real-google-api-key"),
+                (credential_header.encode(), b"some-distinct-caller-secret-value"),
+                (b"content-type", b"application/json"),
+            ],
+        )
+        assert raised is None
+        assert forwarded is not None
+        assert forwarded.get("x-goog-api-key") == "AIza-real-google-api-key"
+        assert credential_header not in forwarded
+        assert "some-distinct-caller-secret-value" not in " ".join(
+            f"{name}:{value}" for name, value in forwarded.items()
+        )
 
     @pytest.mark.asyncio
     async def test_virtual_key_in_operator_configured_header_is_stripped(self, monkeypatch):

--- a/tests/test_litellm/proxy/pass_through_endpoints/test_llm_pass_through_endpoints.py
+++ b/tests/test_litellm/proxy/pass_through_endpoints/test_llm_pass_through_endpoints.py
@@ -3535,6 +3535,19 @@ class TestVertexCredentiallessPassthroughVirtualKeyLeak:
         assert raised is not None and raised.status_code == 401
 
     @pytest.mark.asyncio
+    async def test_x_goog_api_key_carrying_virtual_key_is_rejected_not_forwarded(self, monkeypatch):
+        raised, forwarded = await self._run(
+            monkeypatch,
+            [
+                (b"x-litellm-api-key", self.VKEY.encode()),
+                (b"x-goog-api-key", self.VKEY.encode()),
+                (b"content-type", b"application/json"),
+            ],
+        )
+        assert forwarded is None, "the virtual key in x-goog-api-key must not satisfy the gate nor be forwarded"
+        assert raised is not None and raised.status_code == 401
+
+    @pytest.mark.asyncio
     async def test_byo_google_oauth_token_still_forwards_without_virtual_key(self, monkeypatch):
         raised, forwarded = await self._run(
             monkeypatch,

--- a/tests/test_litellm/proxy/pass_through_endpoints/test_llm_pass_through_endpoints.py
+++ b/tests/test_litellm/proxy/pass_through_endpoints/test_llm_pass_through_endpoints.py
@@ -3311,6 +3311,7 @@ class TestVertexRawPredictStreamingClassification:
                 "path": f"/vertex_ai/{endpoint}",
                 "headers": [
                     (b"content-type", b"application/json"),
+                    (b"x-litellm-api-key", b"test-key"),
                     (b"authorization", b"Bearer ya29.byo-google-oauth"),
                 ],
                 "query_string": b"",

--- a/tests/test_litellm/proxy/pass_through_endpoints/test_llm_pass_through_endpoints.py
+++ b/tests/test_litellm/proxy/pass_through_endpoints/test_llm_pass_through_endpoints.py
@@ -3461,7 +3461,9 @@ class TestVertexCredentiallessPassthroughVirtualKeyLeak:
     proxy-only auth headers Google never consumes (``x-litellm-api-key``,
     ``api-key``, ``x-api-key``) are dropped by name, and the virtual key is dropped
     by value from ``Authorization`` / ``x-goog-api-key``, which may instead carry a
-    genuine bring-your-own Google credential that must still pass through.
+    genuine bring-your-own Google credential that must still pass through. The
+    by-value strip also covers a virtual key sent in the operator-configured
+    ``general_settings.litellm_key_header_name``, whatever that header is named.
     """
 
     VKEY = "sk-litellm-victim-key"
@@ -3605,6 +3607,42 @@ class TestVertexCredentiallessPassthroughVirtualKeyLeak:
         assert self.VKEY not in forwarded_blob
         assert "azure-style-caller-secret" not in forwarded_blob
         assert "anthropic-style-caller-secret" not in forwarded_blob
+
+    @pytest.mark.asyncio
+    async def test_virtual_key_in_operator_configured_header_is_stripped(self, monkeypatch):
+        with mock.patch.dict(  # test-quality-ok: general_settings is the real proxy config surface for litellm_key_header_name; no injection seam exists on this route
+            "litellm.proxy.proxy_server.general_settings",
+            {"litellm_key_header_name": "x-company-key"},
+        ):
+            raised, forwarded = await self._run(
+                monkeypatch,
+                [
+                    (b"x-company-key", f"Bearer {self.VKEY}".encode()),
+                    (b"x-goog-api-key", b"AIza-real-google-api-key"),
+                    (b"content-type", b"application/json"),
+                ],
+            )
+        assert raised is None
+        assert forwarded is not None
+        assert forwarded.get("x-goog-api-key") == "AIza-real-google-api-key"
+        assert "x-company-key" not in forwarded
+        assert self.VKEY not in " ".join(f"{name}:{value}" for name, value in forwarded.items())
+
+    @pytest.mark.asyncio
+    async def test_virtual_key_in_operator_configured_header_alone_is_rejected(self, monkeypatch):
+        with mock.patch.dict(  # test-quality-ok: general_settings is the real proxy config surface for litellm_key_header_name; no injection seam exists on this route
+            "litellm.proxy.proxy_server.general_settings",
+            {"litellm_key_header_name": "x-company-key"},
+        ):
+            raised, forwarded = await self._run(
+                monkeypatch,
+                [
+                    (b"x-company-key", f"Bearer {self.VKEY}".encode()),
+                    (b"content-type", b"application/json"),
+                ],
+            )
+        assert forwarded is None, "a virtual key in the custom auth header must not satisfy the gate nor be forwarded"
+        assert raised is not None and raised.status_code == 401
 
 
 class TestGetAzureAISearchIndexFromEndpoint:

--- a/tests/test_litellm/proxy/pass_through_endpoints/test_llm_pass_through_endpoints.py
+++ b/tests/test_litellm/proxy/pass_through_endpoints/test_llm_pass_through_endpoints.py
@@ -553,10 +553,9 @@ class TestVertexAIPassThroughHandler:
     @pytest.mark.asyncio
     async def test_vertex_passthrough_with_no_default_credentials(self, monkeypatch):
         """
-        Test that when no default credentials are set, the request fails
-        """
-        """
-        Test that when passthrough credentials are set, they are correctly used in the request
+        With no Vertex credential matching the request, the only Authorization present
+        is the caller's own virtual key. It must not be forwarded to Google; the
+        request fails with a clean 401 instead (LIT-5997).
         """
         from litellm.proxy.pass_through_endpoints.passthrough_endpoint_router import (
             PassthroughEndpointRouter,
@@ -619,31 +618,25 @@ class TestVertexAIPassThroughHandler:
             mock_get_token.return_value = (test_token, "")
             mock_auth.return_value = MagicMock()
 
-            # Call the route
-            try:
+            with pytest.raises(HTTPException) as exc_info:
                 await vertex_proxy_route(
                     endpoint=endpoint,
                     request=mock_request,
                     fastapi_response=mock_response,
                 )
-            except Exception as e:
-                traceback.print_exc()
-                print(f"Error: {e}")
 
-            # Verify create_pass_through_route was called with correct arguments
-            mock_create_route.assert_called_once_with(
-                endpoint=endpoint,
-                target=f"https://{test_location}-aiplatform.googleapis.com/v1/projects/{test_project}/locations/{test_location}/publishers/google/models/gemini-1.5-flash:generateContent",
-                custom_headers={"authorization": f"Bearer {test_token}"},
-                is_streaming_request=False,
-            )
+            assert exc_info.value.status_code == 401
+            mock_create_route.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_async_vertex_proxy_route_api_key_auth(self):
         """
         Critical
 
-        This is how Vertex AI JS SDK will Auth to Litellm Proxy
+        This is how Vertex AI JS SDK will Auth to Litellm Proxy: the virtual key
+        arrives in x-litellm-api-key and must reach user_api_key_auth. With no Vertex
+        credential configured, that virtual key must not be forwarded to Google, so
+        the request fails with a clean 401 (LIT-5997).
         """
         # Mock dependencies
         mock_request = Mock()
@@ -663,14 +656,15 @@ class TestVertexAIPassThroughHandler:
                     return_value={"status": "success"}
                 )
 
-                # Call the function
-                result = await vertex_proxy_route(
-                    endpoint="v1/projects/test-project/locations/us-central1/publishers/google/models/gemini-1.5-pro:generateContent",
-                    request=mock_request,
-                    fastapi_response=mock_response,
-                )
+                with pytest.raises(HTTPException) as exc_info:
+                    await vertex_proxy_route(
+                        endpoint="v1/projects/test-project/locations/us-central1/publishers/google/models/gemini-1.5-pro:generateContent",
+                        request=mock_request,
+                        fastapi_response=mock_response,
+                    )
 
-                # Verify user_api_key_auth was called with the correct Bearer token
+                assert exc_info.value.status_code == 401
+                mock_pass_through.assert_not_called()
                 mock_auth.assert_called_once()
                 call_args = mock_auth.call_args[1]
                 assert call_args["api_key"] == "Bearer test-key-123"
@@ -1338,7 +1332,9 @@ class TestVertexAIDiscoveryPassThroughHandler:
     @pytest.mark.asyncio
     async def test_vertex_discovery_proxy_route_api_key_auth(self):
         """
-        Test that the route correctly handles API key authentication
+        The virtual key arrives in x-litellm-api-key and must reach user_api_key_auth.
+        With no Vertex credential configured, that virtual key must not be forwarded to
+        Google, so the request fails with a clean 401 (LIT-5997).
         """
         # Mock dependencies
         mock_request = Mock()
@@ -1358,14 +1354,15 @@ class TestVertexAIDiscoveryPassThroughHandler:
                     return_value={"status": "success"}
                 )
 
-                # Call the function
-                result = await vertex_discovery_proxy_route(
-                    endpoint="v1/projects/test-project/locations/us-central1/dataStores/default/servingConfigs/default:search",
-                    request=mock_request,
-                    fastapi_response=mock_response,
-                )
+                with pytest.raises(HTTPException) as exc_info:
+                    await vertex_discovery_proxy_route(
+                        endpoint="v1/projects/test-project/locations/us-central1/dataStores/default/servingConfigs/default:search",
+                        request=mock_request,
+                        fastapi_response=mock_response,
+                    )
 
-                # Verify user_api_key_auth was called with the correct Bearer token
+                assert exc_info.value.status_code == 401
+                mock_pass_through.assert_not_called()
                 mock_auth.assert_called_once()
                 call_args = mock_auth.call_args[1]
                 assert call_args["api_key"] == "Bearer test-key-123"
@@ -3312,7 +3309,10 @@ class TestVertexRawPredictStreamingClassification:
                 "type": "http",
                 "method": "POST",
                 "path": f"/vertex_ai/{endpoint}",
-                "headers": [(b"content-type", b"application/json")],
+                "headers": [
+                    (b"content-type", b"application/json"),
+                    (b"authorization", b"Bearer ya29.byo-google-oauth"),
+                ],
                 "query_string": b"",
             },
             receive=receive,
@@ -3443,6 +3443,128 @@ def test_is_passthrough_request_streaming_tolerates_non_object_bodies(request_bo
     )
 
     assert is_passthrough_request_streaming(request_body) is expected
+
+
+class TestVertexCredentiallessPassthroughVirtualKeyLeak:
+    """Regression coverage for LIT-5997.
+
+    With no Vertex credential configured, the passthrough took the
+    bring-your-own-credentials branch and forwarded the whole incoming header set
+    to Google, including whichever header carried the caller's LiteLLM virtual key
+    (``Authorization: Bearer <vkey>`` or ``x-litellm-api-key: <vkey>``). That leaked
+    the proxy's own secret to an upstream provider.
+
+    A credential-less request that carries no upstream Google credential must now
+    fail with a clean 401 and never reach ``create_pass_through_route``; a genuine
+    bring-your-own Google credential must still pass through, with the virtual key
+    stripped from what is forwarded.
+    """
+
+    VKEY = "sk-litellm-victim-key"
+    ENDPOINT = (
+        "v1/projects/my-proj/locations/us-central1/publishers/google/models/"
+        "gemini-2.5-flash:generateContent"
+    )
+
+    async def _run(
+        self, monkeypatch, headers: list[tuple[bytes, bytes]]
+    ) -> tuple[HTTPException | None, dict | None]:
+        from litellm.proxy.pass_through_endpoints.passthrough_endpoint_router import (
+            PassthroughEndpointRouter,
+        )
+
+        async def receive():
+            return {"type": "http.request", "body": b"{}", "more_body": False}
+
+        request = Request(
+            {
+                "type": "http",
+                "method": "POST",
+                "path": f"/vertex_ai/{self.ENDPOINT}",
+                "headers": headers,
+                "query_string": b"",
+            },
+            receive=receive,
+        )
+
+        captured: dict = {}
+
+        def fake_create_pass_through_route(**kwargs):
+            captured.update(kwargs)
+            return AsyncMock(return_value={"status": "success"})
+
+        mock_handler = Mock()
+        mock_handler.get_default_base_target_url.return_value = "https://us-central1-aiplatform.googleapis.com/"
+
+        module = "litellm.proxy.pass_through_endpoints.llm_passthrough_endpoints"
+        monkeypatch.setattr(f"{module}.passthrough_endpoint_router", PassthroughEndpointRouter())
+        raised: HTTPException | None = None
+        with (
+            mock.patch(f"{module}.create_pass_through_route", side_effect=fake_create_pass_through_route),
+            mock.patch(f"{module}.user_api_key_auth", new=AsyncMock(return_value=UserAPIKeyAuth(token="hashed"))),
+            mock.patch(f"{module}.get_vertex_pass_through_handler", return_value=mock_handler),
+        ):
+            try:
+                await vertex_proxy_route(
+                    endpoint=self.ENDPOINT,
+                    request=request,
+                    fastapi_response=Response(),
+                    user_api_key_dict=UserAPIKeyAuth(token="hashed"),
+                )
+            except HTTPException as exc:
+                raised = exc
+
+        return raised, (captured.get("custom_headers") if captured else None)
+
+    @pytest.mark.asyncio
+    async def test_authorization_bearer_virtual_key_is_rejected_not_forwarded(self, monkeypatch):
+        raised, forwarded = await self._run(
+            monkeypatch,
+            [(b"authorization", f"Bearer {self.VKEY}".encode()), (b"content-type", b"application/json")],
+        )
+        assert forwarded is None, "credential-less request must never reach the upstream forwarder"
+        assert raised is not None and raised.status_code == 401
+
+    @pytest.mark.asyncio
+    async def test_x_litellm_api_key_virtual_key_is_rejected_not_forwarded(self, monkeypatch):
+        raised, forwarded = await self._run(
+            monkeypatch,
+            [(b"x-litellm-api-key", self.VKEY.encode()), (b"content-type", b"application/json")],
+        )
+        assert forwarded is None, "credential-less request must never reach the upstream forwarder"
+        assert raised is not None and raised.status_code == 401
+
+    @pytest.mark.asyncio
+    async def test_byo_google_oauth_token_still_forwards_without_virtual_key(self, monkeypatch):
+        raised, forwarded = await self._run(
+            monkeypatch,
+            [
+                (b"x-litellm-api-key", self.VKEY.encode()),
+                (b"authorization", b"Bearer ya29.google-oauth-token"),
+                (b"content-type", b"application/json"),
+            ],
+        )
+        assert raised is None
+        assert forwarded is not None
+        assert forwarded.get("authorization") == "Bearer ya29.google-oauth-token"
+        assert "x-litellm-api-key" not in forwarded
+        assert self.VKEY not in " ".join(f"{name}:{value}" for name, value in forwarded.items())
+
+    @pytest.mark.asyncio
+    async def test_byo_x_goog_api_key_still_forwards_without_virtual_key(self, monkeypatch):
+        raised, forwarded = await self._run(
+            monkeypatch,
+            [
+                (b"x-litellm-api-key", self.VKEY.encode()),
+                (b"x-goog-api-key", b"AIza-google-api-key"),
+                (b"content-type", b"application/json"),
+            ],
+        )
+        assert raised is None
+        assert forwarded is not None
+        assert forwarded.get("x-goog-api-key") == "AIza-google-api-key"
+        assert "x-litellm-api-key" not in forwarded
+        assert self.VKEY not in " ".join(f"{name}:{value}" for name, value in forwarded.items())
 
 
 class TestGetAzureAISearchIndexFromEndpoint:

--- a/tests/test_litellm/proxy/pass_through_endpoints/test_llm_pass_through_endpoints.py
+++ b/tests/test_litellm/proxy/pass_through_endpoints/test_llm_pass_through_endpoints.py
@@ -3699,7 +3699,7 @@ class TestVertexCredentiallessPassthroughVirtualKeyLeak:
         assert raised is not None and raised.status_code == 401
 
     @pytest.mark.asyncio
-    async def test_virtual_key_in_pass_through_configured_header_is_stripped(self, monkeypatch):
+    async def test_virtual_key_in_pass_through_configured_header_is_dropped_and_rejected(self, monkeypatch):
         with mock.patch.dict(  # test-quality-ok: general_settings is the real proxy config surface for pass_through_endpoints; no injection seam exists on this route
             "litellm.proxy.proxy_server.general_settings",
             {"pass_through_endpoints": [{"headers": {"litellm_user_api_key": "x-company-key"}}]},
@@ -3708,6 +3708,23 @@ class TestVertexCredentiallessPassthroughVirtualKeyLeak:
                 monkeypatch,
                 [
                     (b"x-company-key", f"Bearer {self.VKEY}".encode()),
+                    (b"content-type", b"application/json"),
+                ],
+            )
+        assert forwarded is None, "a virtual key in the pass-through key header must be dropped, not forwarded"
+        assert raised is not None and raised.status_code == 401
+
+    @pytest.mark.asyncio
+    async def test_authenticated_authorization_is_stripped_over_a_lower_precedence_pass_through_header(self, monkeypatch):
+        with mock.patch.dict(  # test-quality-ok: general_settings is the real proxy config surface for pass_through_endpoints; no injection seam exists on this route
+            "litellm.proxy.proxy_server.general_settings",
+            {"pass_through_endpoints": [{"headers": {"litellm_user_api_key": "x-company-key"}}]},
+        ):
+            raised, forwarded = await self._run(
+                monkeypatch,
+                [
+                    (b"authorization", f"Bearer {self.VKEY}".encode()),
+                    (b"x-company-key", b"sk-decoy-lower-precedence-value"),
                     (b"x-goog-api-key", b"AIza-real-google-api-key"),
                     (b"content-type", b"application/json"),
                 ],
@@ -3715,6 +3732,7 @@ class TestVertexCredentiallessPassthroughVirtualKeyLeak:
         assert raised is None
         assert forwarded is not None
         assert forwarded.get("x-goog-api-key") == "AIza-real-google-api-key"
+        assert "authorization" not in forwarded, "Authorization authenticated (higher precedence) so its key must be stripped"
         assert "x-company-key" not in forwarded
         assert self.VKEY not in " ".join(f"{name}:{value}" for name, value in forwarded.items())
 

--- a/tests/test_litellm/proxy/pass_through_endpoints/test_llm_pass_through_endpoints.py
+++ b/tests/test_litellm/proxy/pass_through_endpoints/test_llm_pass_through_endpoints.py
@@ -3554,6 +3554,18 @@ class TestVertexCredentiallessPassthroughVirtualKeyLeak:
         assert raised is not None and raised.status_code == 401
 
     @pytest.mark.asyncio
+    async def test_virtual_key_authenticated_solely_via_x_goog_api_key_is_rejected(self, monkeypatch):
+        raised, forwarded = await self._run(
+            monkeypatch,
+            [
+                (b"x-goog-api-key", self.VKEY.encode()),
+                (b"content-type", b"application/json"),
+            ],
+        )
+        assert forwarded is None, "a virtual key that authenticated via x-goog-api-key must be stripped, not forwarded"
+        assert raised is not None and raised.status_code == 401
+
+    @pytest.mark.asyncio
     async def test_byo_google_oauth_token_still_forwards_without_virtual_key(self, monkeypatch):
         raised, forwarded = await self._run(
             monkeypatch,
@@ -3611,12 +3623,16 @@ class TestVertexCredentiallessPassthroughVirtualKeyLeak:
     @pytest.mark.asyncio
     @pytest.mark.parametrize(
         "credential_header",
-        sorted(SpecialHeaders.litellm_credential_header_names() - {"authorization", "x-goog-api-key"}),
+        sorted(
+            SpecialHeaders.litellm_credential_header_names()
+            - {"authorization", "x-goog-api-key", "x-litellm-api-key"}
+        ),
     )
     async def test_every_non_google_credential_header_is_dropped_by_name(self, monkeypatch, credential_header):
         raised, forwarded = await self._run(
             monkeypatch,
             [
+                (b"x-litellm-api-key", self.VKEY.encode()),
                 (b"x-goog-api-key", b"AIza-real-google-api-key"),
                 (credential_header.encode(), b"some-distinct-caller-secret-value"),
                 (b"content-type", b"application/json"),
@@ -3626,9 +3642,10 @@ class TestVertexCredentiallessPassthroughVirtualKeyLeak:
         assert forwarded is not None
         assert forwarded.get("x-goog-api-key") == "AIza-real-google-api-key"
         assert credential_header not in forwarded
-        assert "some-distinct-caller-secret-value" not in " ".join(
-            f"{name}:{value}" for name, value in forwarded.items()
-        )
+        assert "x-litellm-api-key" not in forwarded
+        forwarded_blob = " ".join(f"{name}:{value}" for name, value in forwarded.items())
+        assert self.VKEY not in forwarded_blob
+        assert "some-distinct-caller-secret-value" not in forwarded_blob
 
     @pytest.mark.asyncio
     async def test_virtual_key_in_operator_configured_header_is_stripped(self, monkeypatch):

--- a/tests/test_litellm/proxy/pass_through_endpoints/test_llm_pass_through_endpoints.py
+++ b/tests/test_litellm/proxy/pass_through_endpoints/test_llm_pass_through_endpoints.py
@@ -3698,6 +3698,26 @@ class TestVertexCredentiallessPassthroughVirtualKeyLeak:
         assert forwarded is None, "a virtual key in the custom auth header must not satisfy the gate nor be forwarded"
         assert raised is not None and raised.status_code == 401
 
+    @pytest.mark.asyncio
+    async def test_virtual_key_in_pass_through_configured_header_is_stripped(self, monkeypatch):
+        with mock.patch.dict(  # test-quality-ok: general_settings is the real proxy config surface for pass_through_endpoints; no injection seam exists on this route
+            "litellm.proxy.proxy_server.general_settings",
+            {"pass_through_endpoints": [{"headers": {"litellm_user_api_key": "x-company-key"}}]},
+        ):
+            raised, forwarded = await self._run(
+                monkeypatch,
+                [
+                    (b"x-company-key", f"Bearer {self.VKEY}".encode()),
+                    (b"x-goog-api-key", b"AIza-real-google-api-key"),
+                    (b"content-type", b"application/json"),
+                ],
+            )
+        assert raised is None
+        assert forwarded is not None
+        assert forwarded.get("x-goog-api-key") == "AIza-real-google-api-key"
+        assert "x-company-key" not in forwarded
+        assert self.VKEY not in " ".join(f"{name}:{value}" for name, value in forwarded.items())
+
 
 class TestGetAzureAISearchIndexFromEndpoint:
     """The operable index is only the segment right after ``indexes``.

--- a/tests/test_litellm/proxy/pass_through_endpoints/test_llm_pass_through_endpoints.py
+++ b/tests/test_litellm/proxy/pass_through_endpoints/test_llm_pass_through_endpoints.py
@@ -3457,9 +3457,11 @@ class TestVertexCredentiallessPassthroughVirtualKeyLeak:
     leak the proxy's own secret to an upstream provider.
 
     A credential-less request that carries no upstream Google credential must now
-    fail with a clean 401 and never reach ``create_pass_through_route``; a genuine
-    bring-your-own Google credential must still pass through, with the virtual key
-    stripped by value from every forwarded header.
+    fail with a clean 401 and never reach ``create_pass_through_route``. The
+    proxy-only auth headers Google never consumes (``x-litellm-api-key``,
+    ``api-key``, ``x-api-key``) are dropped by name, and the virtual key is dropped
+    by value from ``Authorization`` / ``x-goog-api-key``, which may instead carry a
+    genuine bring-your-own Google credential that must still pass through.
     """
 
     VKEY = "sk-litellm-victim-key"
@@ -3582,14 +3584,14 @@ class TestVertexCredentiallessPassthroughVirtualKeyLeak:
         assert self.VKEY not in " ".join(f"{name}:{value}" for name, value in forwarded.items())
 
     @pytest.mark.asyncio
-    async def test_virtual_key_echoed_in_alternate_auth_headers_is_stripped_by_value(self, monkeypatch):
+    async def test_alternate_proxy_auth_headers_are_never_forwarded_to_google(self, monkeypatch):
         raised, forwarded = await self._run(
             monkeypatch,
             [
                 (b"x-litellm-api-key", self.VKEY.encode()),
                 (b"authorization", b"Bearer ya29.google-oauth-token"),
-                (b"api-key", self.VKEY.encode()),
-                (b"x-api-key", self.VKEY.encode()),
+                (b"api-key", b"azure-style-caller-secret"),
+                (b"x-api-key", b"anthropic-style-caller-secret"),
                 (b"content-type", b"application/json"),
             ],
         )
@@ -3599,7 +3601,10 @@ class TestVertexCredentiallessPassthroughVirtualKeyLeak:
         assert "api-key" not in forwarded
         assert "x-api-key" not in forwarded
         assert "x-litellm-api-key" not in forwarded
-        assert self.VKEY not in " ".join(f"{name}:{value}" for name, value in forwarded.items())
+        forwarded_blob = " ".join(f"{name}:{value}" for name, value in forwarded.items())
+        assert self.VKEY not in forwarded_blob
+        assert "azure-style-caller-secret" not in forwarded_blob
+        assert "anthropic-style-caller-secret" not in forwarded_blob
 
 
 class TestGetAzureAISearchIndexFromEndpoint:


### PR DESCRIPTION
## TLDR

Problem this solves:

- Credential-less Vertex passthrough forwarded the caller's proxy auth headers to Google
- Every header the proxy accepts for caller auth leaked upstream: `Authorization`, `x-litellm-api-key`, `x-goog-api-key`, `api-key`, `x-api-key`, `Ocp-Apim-Subscription-Key`, the mapped-route `litellm_user_api_key` header, and the operator-configured `litellm_key_header_name`
- The LiteLLM virtual key, and any other caller secret in those headers, reached a third-party provider

How it solves it:

- Derive the name-drop set from the canonical `SpecialHeaders.litellm_credential_header_names()`, so every proxy-only auth header Google never consumes (`x-litellm-api-key`, `api-key`, `x-api-key`, `Ocp-Apim-Subscription-Key`) is dropped, plus any operator-configured caller-key header (`litellm_key_header_name` and each `pass_through_endpoints` entry's `litellm_user_api_key`), and future additions are covered automatically
- Resolve the caller's key by the same precedence `user_api_key_auth` uses and value-strip exactly that value from `Authorization` / `x-goog-api-key` (which can instead hold a real Google credential) and from the operator-configured custom key header, normalizing the value with the auth module's own `_get_bearer_token` so every scheme it accepts (`Bearer` / `bearer` / `Basic` / `AWS4-HMAC-SHA256`) is matched
- Fail with a clean 401 when no real Google credential is present, so nothing is forwarded

## User Flow

Before: a developer calls Vertex passthrough on a proxy with no Vertex credential configured, and their LiteLLM key is handed to Google

1. They POST `https://litellm-domain/vertex_ai/v1/projects/my-proj/locations/global/publishers/google/models/gemini-2.5-pro:generateContent` with `Authorization: Bearer sk-...` (their LiteLLM virtual key) and a JSON body
2. The proxy authenticates them, finds no Vertex credential, and forwards the request to `https://aiplatform.googleapis.com/v1/projects/my-proj/...:generateContent` with that same `Authorization: Bearer sk-...` still on it
3. Google receives the developer's LiteLLM virtual key; sending the key in `x-litellm-api-key`, `x-goog-api-key`, `api-key`, `x-api-key`, or the operator's configured key header instead leaks it the same way
4. Another party who can read that upstream request now holds a working LiteLLM key and can call the proxy as that developer

After: the same call fails fast with a clean 401, and the key is never forwarded

1. They POST the same URL with `Authorization: Bearer sk-...` and the same body
2. The proxy authenticates them, finds no Vertex credential and no bring-your-own Google credential, and returns `401` saying no Vertex credential is configured and the virtual key is not forwarded
3. Nothing is sent to `https://aiplatform.googleapis.com`; sending the key in `x-litellm-api-key` or `x-goog-api-key` gives the same 401, and any `api-key` / `x-api-key` / configured custom key header is stripped before forwarding
4. A developer who brings their own Google credential (an OAuth token in `Authorization`, or a real Google API key in `x-goog-api-key`) still has it forwarded, now with the LiteLLM key and the other proxy auth headers stripped out
5. No other party can obtain a LiteLLM virtual key from this branch anymore

## Relevant issues

## Linear ticket

Resolves LIT-5997

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Shared setup (no real virtual key is ever sent to real Google: a local sink intercepts every egress and the capture is the proof)

- Proxy config has no Vertex credential: no `DEFAULT_VERTEXAI_*` env vars, and no `use_in_pass_through` model, so the passthrough takes the credential-less branch
- A local mitmproxy sink sits on the proxy's egress. It intercepts every request whose host ends in `googleapis.com`, records the exact headers that would have gone to Google, and returns a synthetic `599` so nothing reaches Google. A leak shows up as the virtual key (or any caller secret) appearing in that capture
- Generate a virtual key against the proxy: `curl -sX POST http://127.0.0.1:PORT/key/generate -H "<auth header>: Bearer $MASTER_KEY" -d '{"duration":"2h"}'` returns `sk-…`
- Payload for every call: `{"contents":[{"role":"user","parts":[{"text":"hi"}]}]}`
- The custom-key-header cases (Case G) run against a second proxy configured with `general_settings.litellm_key_header_name: x-company-key`; every other case runs against a default-config proxy

### Before (28b433a007)

#### Case A: virtual key in Authorization

1. `curl -sX POST http://127.0.0.1:49346/vertex_ai/v1/projects/my-proj/locations/global/publishers/google/models/gemini-2.5-pro:generateContent -H "Authorization: Bearer sk-…" -d '<payload>'`
2. Sink capture of the outbound to `aiplatform.googleapis.com`: `authorization: Bearer sk-…`, the virtual key was on its way to Google

#### Case B: virtual key in x-litellm-api-key

1. `curl -sX POST http://127.0.0.1:49346/vertex_ai/.../gemini-2.5-pro:generateContent -H "x-litellm-api-key: sk-…" -d '<payload>'`
2. Sink capture of the outbound to `aiplatform.googleapis.com`: `x-litellm-api-key: sk-…`, the virtual key was on its way to Google

#### Case D: virtual key in x-goog-api-key

1. `curl -sX POST http://127.0.0.1:49346/vertex_ai/.../gemini-2.5-pro:generateContent -H "x-litellm-api-key: sk-…" -H "x-goog-api-key: sk-…" -d '<payload>'`
2. Sink capture of the outbound to `aiplatform.googleapis.com`: `x-goog-api-key: sk-…` and `x-litellm-api-key: sk-…`. The virtual key was on its way to Google, this time posing as a Google API key

#### Case F: distinct caller secrets in api-key and x-api-key

1. `curl -sX POST http://127.0.0.1:49346/vertex_ai/.../gemini-2.5-pro:generateContent -H "x-litellm-api-key: sk-…" -H "Authorization: Bearer ya29.fake-google-oauth" -H "api-key: azure-secret-abc123" -H "x-api-key: anthropic-secret-def456" -d '<payload>'`
2. Sink capture of the outbound to `aiplatform.googleapis.com`: `authorization: Bearer ya29.fake-google-oauth`, `api-key: azure-secret-abc123`, `x-api-key: anthropic-secret-def456`, and `x-litellm-api-key: sk-…`. Every proxy auth header, including two unrelated caller secrets and the virtual key, went to Google

#### Case G: virtual key in the operator-configured custom key header

Against a merge-base proxy configured with `general_settings.litellm_key_header_name: x-company-key`

1. `curl -sX POST http://127.0.0.1:42826/vertex_ai/.../gemini-2.5-pro:generateContent -H "x-company-key: Bearer sk-…" -H "x-goog-api-key: AIzaSyReal-Google-Api-Key-000" -d '<payload>'`
2. Sink capture of the outbound to `aiplatform.googleapis.com`: `x-company-key: Bearer sk-…` and `x-goog-api-key: AIzaSyReal-Google-Api-Key-000`. The caller authenticated with the custom header, and that same header carrying the virtual key was forwarded to Google alongside the real Google key

#### Case H: caller Azure APIM secret in Ocp-Apim-Subscription-Key

1. `curl -sX POST http://127.0.0.1:49346/vertex_ai/.../gemini-2.5-pro:generateContent -H "x-litellm-api-key: sk-…" -H "Authorization: Bearer ya29.fake-google-oauth" -H "Ocp-Apim-Subscription-Key: azure-apim-secret-xyz789" -d '<payload>'`
2. Sink capture of the outbound to `aiplatform.googleapis.com`: `authorization: Bearer ya29.fake-google-oauth` and `Ocp-Apim-Subscription-Key: azure-apim-secret-xyz789`. The caller's Azure APIM subscription key, an auth header the proxy accepts but Google never consumes, was forwarded to Google

#### Case J: virtual key echoed into Authorization with a Basic scheme

1. `curl -sX POST http://127.0.0.1:49346/vertex_ai/.../gemini-2.5-pro:generateContent -H "x-litellm-api-key: sk-…" -H "Authorization: Basic sk-…" -d '<payload>'`
2. Sink capture of the outbound to `aiplatform.googleapis.com`: `authorization: Basic sk-…`. The caller authenticated with `x-litellm-api-key` and echoed the same virtual key into `Authorization` under a `Basic` scheme, and that header carrying the key was forwarded to Google

### After (16a81c9ceb)

The header-filtering behavior in Cases A-H is stable across the hardening commits and was captured against the default-config proxy on port 41337 and the custom-key-header proxy on port 41779. Case I was run against a fresh default-config proxy on port 40923, and Case J plus the no-regression re-check of Cases C and E against a fresh default-config proxy on port 40611 at this exact tip.

#### Case A: virtual key in Authorization

1. `curl -sw '%{http_code}' -X POST http://127.0.0.1:41337/vertex_ai/.../gemini-2.5-pro:generateContent -H "Authorization: Bearer sk-…" -d '<payload>'`
2. Response: `HTTP 401` with `{"detail":"No Vertex AI credential is configured on this proxy and the request carried no upstream Google credential. The LiteLLM virtual key is not forwarded to Google. ..."}`. The sink recorded nothing new: no request reached `googleapis.com`

#### Case B: virtual key in x-litellm-api-key

1. `curl -sw '%{http_code}' -X POST http://127.0.0.1:41337/vertex_ai/.../gemini-2.5-pro:generateContent -H "x-litellm-api-key: sk-…" -d '<payload>'`
2. Response: `HTTP 401` with the same "no Vertex AI credential is configured" detail. The sink recorded nothing new: no request reached `googleapis.com`

#### Case C: bring-your-own Google token, virtual key in x-litellm-api-key for proxy auth

1. `curl -sw '%{http_code}' -X POST http://127.0.0.1:41337/vertex_ai/.../gemini-2.5-pro:generateContent -H "x-litellm-api-key: sk-…" -H "Authorization: Bearer ya29.fake-google-oauth" -d '<payload>'`
2. Response: `HTTP 599` from the sink (the request was forwarded). Sink capture of the outbound to `aiplatform.googleapis.com`: `authorization: Bearer ya29.fake-google-oauth`, `x-litellm-api-key: <absent>`, and the virtual key is nowhere in the outbound. Real bring-your-own passthrough still works, with the key stripped

#### Case D: virtual key in x-goog-api-key

1. `curl -sw '%{http_code}' -X POST http://127.0.0.1:41337/vertex_ai/.../gemini-2.5-pro:generateContent -H "x-litellm-api-key: sk-…" -H "x-goog-api-key: sk-…" -d '<payload>'`
2. Response: `HTTP 401` with the same "no Vertex AI credential is configured" detail. The sink recorded nothing new: no request reached `googleapis.com`. The key posing as a Google API key no longer satisfies the gate

#### Case E: bring-your-own real Google API key in x-goog-api-key, virtual key in x-litellm-api-key for proxy auth

1. `curl -sw '%{http_code}' -X POST http://127.0.0.1:41337/vertex_ai/.../gemini-2.5-pro:generateContent -H "x-litellm-api-key: sk-…" -H "x-goog-api-key: AIzaSyReal-Google-Api-Key-000" -d '<payload>'`
2. Response: `HTTP 599` from the sink (the request was forwarded). Sink capture of the outbound to `aiplatform.googleapis.com`: `x-goog-api-key: AIzaSyReal-Google-Api-Key-000`, `x-litellm-api-key: <absent>`, and the virtual key is nowhere in the outbound. A real Google API key that differs from the virtual key still forwards, with the key stripped

#### Case F: distinct caller secrets in api-key and x-api-key, bring-your-own Google token for the real credential

1. `curl -sw '%{http_code}' -X POST http://127.0.0.1:41337/vertex_ai/.../gemini-2.5-pro:generateContent -H "x-litellm-api-key: sk-…" -H "Authorization: Bearer ya29.fake-google-oauth" -H "api-key: azure-secret-abc123" -H "x-api-key: anthropic-secret-def456" -d '<payload>'`
2. Response: `HTTP 599` from the sink (the request was forwarded). Sink capture of the outbound to `aiplatform.googleapis.com`: `authorization: Bearer ya29.fake-google-oauth` only. `x-litellm-api-key`, `api-key`, and `x-api-key` are all `<absent>`, and neither `azure-secret-abc123`, `anthropic-secret-def456`, nor the virtual key appears anywhere. The Google token still forwards, every proxy auth header is dropped

#### Case G: virtual key in the operator-configured custom key header

Against the proxy configured with `general_settings.litellm_key_header_name: x-company-key`

1. `curl -sw '%{http_code}' -X POST http://127.0.0.1:41779/vertex_ai/.../gemini-2.5-pro:generateContent -H "x-company-key: Bearer sk-…" -H "x-goog-api-key: AIzaSyReal-Google-Api-Key-000" -d '<payload>'`
2. Response: `HTTP 599` from the sink (the request was forwarded). Sink capture of the outbound to `aiplatform.googleapis.com`: `x-goog-api-key: AIzaSyReal-Google-Api-Key-000` only, `x-company-key: <absent>`, and the virtual key is nowhere in the outbound. The caller still authenticates with the custom header, the real Google key still forwards, and the virtual key is stripped
3. Sending the virtual key in `x-company-key` with no real Google credential returns `HTTP 401` and nothing reaches `googleapis.com`

#### Case H: caller Azure APIM secret in Ocp-Apim-Subscription-Key, legitimate Google header preserved

1. `curl -sw '%{http_code}' -X POST http://127.0.0.1:41337/vertex_ai/.../gemini-2.5-pro:generateContent -H "x-litellm-api-key: sk-…" -H "Authorization: Bearer ya29.fake-google-oauth" -H "Ocp-Apim-Subscription-Key: azure-apim-secret-xyz789" -H "X-Goog-User-Project: my-billing-proj" -d '<payload>'`
2. Response: `HTTP 599` from the sink (the request was forwarded). Sink capture of the outbound to `aiplatform.googleapis.com`: `authorization: Bearer ya29.fake-google-oauth` and `X-Goog-User-Project: my-billing-proj`, while `Ocp-Apim-Subscription-Key` is `<absent>` and `azure-apim-secret-xyz789` appears nowhere. The caller's Azure APIM secret is dropped, and the genuine Google `X-Goog-User-Project` header is preserved so real Vertex requests keep working

#### Case I: virtual key resolved through the full auth precedence, and no regression to real credentials

The route authenticates through `Depends(user_api_key_auth)`, which accepts the caller key from every header in `SpecialHeaders.litellm_credential_header_names()`, `x-goog-api-key` included. The filter now resolves the caller key by that same precedence and value-strips exactly the value that authenticated, so `x-goog-api-key` is stripped when it carried the key and preserved when it carried a real Google key alongside a higher-precedence virtual key. All against the port 40923 proxy at this tip:

1. `curl -sw '%{http_code}' -X POST http://127.0.0.1:40923/vertex_ai/.../gemini-2.5-pro:generateContent -H "x-goog-api-key: sk-…" -d '<payload>'` returns `HTTP 401` and the sink records nothing new (the proxy's own auth rejects a virtual key in `x-goog-api-key` on this route today, and the filter would strip it regardless, closing the boundary that a mocked unit test exercises directly)
2. Case C re-run (`x-litellm-api-key: sk-…` + `Authorization: Bearer ya29.fake-google-oauth`) still returns `HTTP 599` with `authorization: Bearer ya29.fake-google-oauth` forwarded and the virtual key absent
3. Case E re-run (`x-litellm-api-key: sk-…` + `x-goog-api-key: AIzaSyReal-Google-Api-Key-000`) still returns `HTTP 599` with `x-goog-api-key: AIzaSyReal-Google-Api-Key-000` forwarded and the virtual key absent, so resolving by precedence does not strip a genuine Google key

#### Case J: virtual key echoed into Authorization with a Basic scheme, and no regression to real credentials

Against a fresh default-config proxy on port 40611 at this tip:

1. `curl -sw '%{http_code}' -X POST http://127.0.0.1:40611/vertex_ai/.../gemini-2.5-pro:generateContent -H "x-litellm-api-key: sk-…" -H "Authorization: Basic sk-…" -d '<payload>'` returns `HTTP 401` and the sink records nothing new. Normalizing the value with the auth module's own `_get_bearer_token` strips the `Basic` scheme just as authentication does, so the echoed virtual key matches the authenticated key and `Authorization` is dropped, leaving no upstream credential
2. Case C re-run (`x-litellm-api-key: sk-…` + `Authorization: Bearer ya29.fake-google-oauth`) still returns `HTTP 599` with `authorization: Bearer ya29.fake-google-oauth` forwarded and the virtual key absent
3. Case E re-run (`x-litellm-api-key: sk-…` + `x-goog-api-key: AIzaSyReal-Google-Api-Key-000`) still returns `HTTP 599` with `x-goog-api-key: AIzaSyReal-Google-Api-Key-000` forwarded and the virtual key absent

#### Case K: virtual key in the mapped-route litellm_user_api_key header, with real credentials preserved

The `/vertex_ai` prefix is a mapped pass-through route, so `user_api_key_auth` accepts the caller key from a header literally named `litellm_user_api_key` and applies it last, overriding every other source. Against fresh default-config proxies on ports 40611 (before this commit) and 40337 (this tip), same request each side: `litellm_user_api_key: sk-…` (auth) + `Authorization: Bearer ya29.fake-google-oauth` + `x-goog-api-key: AIzaSyReal-Google-Api-Key-000`.

1. Before (port 40611): `HTTP 599`, and the sink capture to `aiplatform.googleapis.com` shows `litellm_user_api_key: sk-…` forwarded with the virtual key, while the real `Authorization` was dropped. The virtual key reached Google and the bring-your-own token was lost
2. After (port 40337): `HTTP 599`, and the sink capture shows `authorization: Bearer ya29.fake-google-oauth` and `x-goog-api-key: AIzaSyReal-Google-Api-Key-000` both forwarded, `litellm_user_api_key` `<absent>`, and the virtual key nowhere. The key that authenticated is stripped, and both real credentials are preserved

## Type

🐛 Bug Fix

## Caveats (if any)

Scope of this PR is the credential-less Vertex passthrough leaking the caller's LiteLLM credential through request headers. One adjacent vector is intentionally left for a separate, focused change: a caller can also send a virtual key in the `?key=` URL query parameter (the Google AI Studio auth convention that `user_api_key_auth` reads on generateContent routes). A client that authenticates only with `?key=` is already rejected with a 401 on this branch (no surviving upstream Google credential), so that common case does not leak. The virtual key does still ride the forwarded URL query when the caller both authenticates with a header and brings a real Google credential, but stripping credential query params belongs in the shared pass-through URL-forwarding path (it affects every provider, not just Vertex) and is being tracked as its own follow-up rather than widening this PR's blast radius.

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR


## Live PR risk

/live-pr-risk CHECKED e6eb6a4a4d: SAFE. The graph is tiny and fully local: `_forwarded_headers_for_credentialless_vertex_passthrough` is called only by `_prepare_vertex_auth_headers`, which is called only by `_base_vertex_proxy_route`, which is reached by the two public routes `vertex_proxy_route` and `vertex_discovery_proxy_route`. The re-signed `_prepare_vertex_auth_headers` now returns `Mapping[str, str]` and its credential-less branch raises `HTTPException(401)`; nothing downstream mutates the returned headers, and `create_pass_through_route` copies them with `dict(...)`, so the immutable `MappingProxyType` is safe on every path. `vertex_proxy_route` was driven live in the proof above; `vertex_discovery_proxy_route` runs the identical credential-less branch and is covered by unit tests. Direct-caller and related passthrough tests pass on the fixed head (160 passed), including `test_vertex_passthrough_load_balancing.py`, which unpacks the new tuple directly.

/live-pr-risk CHECKED 4bc097733f: SAFE. This commit hardens the same branch to strip the virtual key from every forwarded header by value (normalizing any `Bearer` prefix) instead of only from `Authorization` by name, closing the `x-goog-api-key` vector Greptile flagged. Re-walked the graph for the added code: the new `_bearer_stripped` is a pure module-private helper referenced only inside `_forwarded_headers_for_credentialless_vertex_passthrough`, and that function still has exactly one caller, so the blast radius is identical to the commit above. No new dependents, side effects, or raises.

/live-pr-risk CHECKED e7c2ede159: SAFE. This commit additionally drops the proxy-only auth headers Google never consumes (`x-litellm-api-key`, `api-key`, `x-api-key`) by name via a new module-private `_HEADERS_NEVER_FORWARDED_TO_VERTEX` frozenset, keeping the by-value virtual-key strip for `Authorization` / `x-goog-api-key`. The frozenset is referenced only inside `_forwarded_headers_for_credentialless_vertex_passthrough`, which still has exactly one caller, so the blast radius is unchanged; no new dependents, side effects, or raises, and the gate is untouched.

/live-pr-risk CHECKED ee0363249d: SAFE. This commit closes the last vector Greptile flagged: `user_api_key_auth` also authenticates a caller from the operator-configured `general_settings.litellm_key_header_name`, read straight off the request, so a virtual key sent there survived the filter. The new module-private `_credentialless_caller_key_values` reads `general_settings` (read-only, via the same lazy import already used elsewhere in the module) and returns the set of accepted key values; the filter now value-strips any header matching one of them. Blast radius unchanged: both the helper and the filter are called only from the single existing caller, no new raises (the 401 gate is untouched), no mutation, no signature change. Verified live on both sides: at the merge-base with `litellm_key_header_name: x-company-key` set, `x-company-key: Bearer <vkey>` forwarded to `aiplatform.googleapis.com` alongside a real Google key; on this tip the same request forwards only the real Google key with the custom header and the virtual key stripped, and the custom header alone returns 401. Cases A-F re-verified unchanged on this tip.

/live-pr-risk CHECKED ab93636e2c: SAFE. This commit replaces the hand-rolled name-drop set with one derived from the canonical `SpecialHeaders.litellm_credential_header_names()` minus the two headers that double as real Google credentials (`Authorization`, `x-goog-api-key`), which are value-stripped instead. This is the same source `user_api_key_auth` reads the caller's key from, so the drop set now cannot drift out of sync with what authenticates, and it picked up `Ocp-Apim-Subscription-Key`, which the hand-rolled set missed. `SpecialHeaders` is a pure enum already imported into the module via its `_types` star import; the derived frozenset is evaluated once at import with no side effects, and both module-level constants are referenced only inside the single-caller filter, so the blast radius is unchanged. Verified live on both sides: at the merge-base a distinct caller Azure APIM secret in `Ocp-Apim-Subscription-Key` forwarded to `aiplatform.googleapis.com`; on this tip it is dropped while the genuine Google `X-Goog-User-Project` header is preserved, and all of Cases A-G re-verified unchanged.

/live-pr-risk CHECKED f3dc339e07: SAFE. This commit resolves the caller key by the same precedence `get_api_key` uses (custom `litellm_key_header_name`, then `x-litellm-api-key`, `Authorization`, `api-key`, `x-api-key`, `x-goog-api-key`, `Ocp-Apim-Subscription-Key`) and value-strips exactly the one value that authenticated, instead of only the value from `x-litellm-api-key` / `Authorization` / the custom header. This closes the structural gap Greptile flagged: `x-goog-api-key` is an accepted auth source that the old caller-key set omitted while keeping the header, so a virtual key authenticated through it would have been forwarded. The precedence tuple is built once at import from the same `SpecialHeaders` enum; `_authenticated_caller_key_values` reads request headers and `general_settings` read-only and is still called only by the single-caller filter, so the blast radius is unchanged, no new raises, no mutation. Verified live at this tip: a real Google key in `x-goog-api-key` alongside a higher-precedence virtual key in `x-litellm-api-key` is still forwarded (Case E, 599), the bring-your-own OAuth token is still forwarded (Case C, 599), and a virtual key sent only in `x-goog-api-key` is rejected. Note the proxy's own auth currently rejects a virtual key presented in `x-goog-api-key` on this route before the filter runs, so this commit is defense-in-depth on the forwarding boundary, proven directly by the added unit tests.

/live-pr-risk CHECKED 5d8286c963: SAFE. This commit swaps the filter's own `Bearer`-only stripping for the auth module's `_get_bearer_token`, so the caller-key comparison normalizes exactly the schemes authentication accepts (`Bearer` / `bearer` / `Basic` / `AWS4-HMAC-SHA256`), with a raw-value fallback for a bare token. It closes the case Greptile flagged: a virtual key echoed as `Authorization: Basic <key>` alongside a higher-precedence auth header did not match the caller key under the old normalization and was forwarded. `_get_bearer_token` is a pure function in `user_api_key_auth` (already imported into this module for `user_api_key_auth`), with no side effects; the new `_normalize_credential_value` wrapper is referenced only by the single-caller resolver and filter, so the blast radius is unchanged. Verified live on both sides: at the merge-base `Authorization: Basic <vkey>` forwarded to `aiplatform.googleapis.com`; on this tip it returns 401 with nothing forwarded, while the bring-your-own OAuth token (Case C) and a real Google key (Case E) still forward with the virtual key absent.

/live-pr-risk CHECKED 2fe1e7e43f: SAFE. `user_api_key_auth` also accepts the caller key from a `pass_through_endpoints` entry's `headers.litellm_user_api_key`, not only `litellm_key_header_name`. This commit adds `_operator_configured_caller_key_header_names`, which reads both from `general_settings` (read-only), drops every configured caller-key header by name, and feeds them as top-precedence caller-key sources into the resolver. The helper is pure and referenced only by the single-caller resolver and filter, so the blast radius is unchanged, no new raises, no mutation. Config values are read defensively with `isinstance` guards. Covered by unit tests that configure each source through `general_settings` and assert the configured header is dropped while a real Google key in `x-goog-api-key` is preserved; the full passthrough test file (160 tests) passes, including the LIT-4761 streaming-classification suite whose fixture now sends the virtual key in `x-litellm-api-key`, matching a real request.

/live-pr-risk CHECKED fcc047bf8a: SAFE. Corrects the precedence of the operator-configured key headers to match `get_api_key` exactly: `litellm_key_header_name` overrides everything so it resolves first, then the built-in headers in `get_api_key` order, then a `pass_through_endpoints` `litellm_user_api_key` header which `get_api_key` checks last. The prior commit had lumped both configured sources at the top, so a request that authenticated via `Authorization` while also carrying a pass-through header could pick the wrong value and leave the authenticated `Authorization` key forwarded. `_operator_configured_caller_key_header_names` now returns `(override, pass_through)` and both the resolver ordering and the name-drop consume it; still pure, still called only by the single-caller resolver and filter, no new raises or mutation. Covered by a new unit test where `Authorization` holds the authenticated key, a pass-through header holds a decoy, and a real `x-goog-api-key` is present: the `Authorization` key is stripped, the pass-through header dropped, and the real Google key preserved. Full passthrough test file (161 tests) green.

/live-pr-risk CHECKED 16a81c9ceb: SAFE. Closes a high-severity vector Cursor Bugbot flagged: on mapped pass-through routes (of which `/vertex_ai` is one), `user_api_key_auth` accepts the caller key from a header literally named `litellm_user_api_key` via `check_api_key_for_custom_headers_or_pass_through_endpoints`, applied last so it overrides every other source. The filter now drops that header by name and resolves it at highest precedence. Adds a module constant plus a prepend to the resolver order and a union into the name-drop set; still pure, still called only by the single-caller resolver and filter, no new raises or mutation. Verified live on both sides: at the previous tip a virtual key in `litellm_user_api_key` forwarded to `aiplatform.googleapis.com` while the real `Authorization` was wrongly stripped; on this tip the virtual key is dropped and both the bring-your-own OAuth token and a real Google key are preserved. Full passthrough test file (163 tests) green.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Security-sensitive change to Vertex passthrough auth and header forwarding; wrong filtering could break BYO-Google flows or still leak secrets upstream.
> 
> **Overview**
> Fixes **LIT-5997**: when the proxy has no Vertex credential, the bring-your-own-credentials branch no longer forwards the full incoming header set to Google.
> 
> **Credential-less Vertex passthrough** now builds upstream headers via `_forwarded_headers_for_credentialless_vertex_passthrough` instead of copying all request headers. Proxy-only auth headers (from `SpecialHeaders.litellm_credential_header_names()` except `Authorization` / `x-goog-api-key`, plus operator `litellm_key_header_name` and pass-through key headers) are **dropped by name**. The caller key is resolved with the same precedence as `user_api_key_auth` and **stripped by value** from any remaining header (using `_get_bearer_token` for scheme normalization). If neither a surviving `Authorization` nor `x-goog-api-key` remains, the route returns **401** with guidance instead of calling Google.
> 
> Bring-your-own Google OAuth or API keys still forward; LiteLLM virtual keys in `Authorization`, `x-litellm-api-key`, `x-goog-api-key`, or custom headers no longer reach upstream. Tests were updated and expanded (`TestVertexCredentiallessPassthroughVirtualKeyLeak`) for these cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 16a81c9ceb691fbcce492b798d12f45b27646c51. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->