### PR TITLE
fix(runwayml): route every generation endpoint and fix video cost tracking

### DIFF
--- a/litellm/cost_calculator.py
+++ b/litellm/cost_calculator.py
@@ -150,6 +150,7 @@ _VIDEO_CALL_TYPES: Final = frozenset(
     }
 )
 
+
 _SPEECH_CALL_TYPES: Final = frozenset(
     {
         CallTypes.speech.value,
@@ -1372,22 +1373,35 @@ def completion_cost(
                     if custom_pricing and litellm_logging_obj is not None:
                         _litellm_params = getattr(litellm_logging_obj, "litellm_params", None)
                         if _litellm_params is not None:
-                            _metadata = _litellm_params.get("metadata", {}) or {}
-                            _video_model_info = _metadata.get("model_info", None)
+                            _video_model_info = next(
+                                (
+                                    model_info
+                                    for _metadata_key in ("metadata", "litellm_metadata")
+                                    if (model_info := (_litellm_params.get(_metadata_key) or {}).get("model_info"))
+                                    is not None
+                                ),
+                                None,
+                            )
 
                     usage_obj = getattr(completion_response, "usage", None)
                     duration_seconds: float | None = None
                     video_resolution: str | None = None
+                    provider_reported_cost: float | None = None
                     if completion_response is not None and usage_obj:
                         # Handle both dict and Pydantic Usage object
                         if isinstance(usage_obj, dict):
                             duration_seconds = usage_obj.get("duration_seconds", None)
                             _vr = usage_obj.get("video_resolution", None)
+                            provider_reported_cost = usage_obj.get("provider_reported_cost_usd", None)
                         else:
                             duration_seconds = getattr(usage_obj, "duration_seconds", None)
                             _vr = getattr(usage_obj, "video_resolution", None)
+                            provider_reported_cost = getattr(usage_obj, "provider_reported_cost_usd", None)
                         if _vr is not None:
                             video_resolution = str(_vr).strip().lower()
+
+                        if _video_model_info is None and provider_reported_cost is not None:
+                            return float(provider_reported_cost)
 
                         if duration_seconds is not None:
                             # Calculate cost based on video duration using video-specific cost calculation

--- a/litellm/litellm_core_utils/exception_mapping_utils.py
+++ b/litellm/litellm_core_utils/exception_mapping_utils.py
@@ -2301,6 +2301,7 @@ def exception_type(
                 or custom_llm_provider == "custom_openai"
                 or custom_llm_provider in litellm.openai_compatible_providers
                 or custom_llm_provider == "mistral"
+                or custom_llm_provider == "runwayml"
             ):
                 _map_openai_exception(
                     model=model,

--- a/litellm/llms/openai/cost_calculation.py
+++ b/litellm/llms/openai/cost_calculation.py
@@ -134,14 +134,7 @@ def cost_per_second(model: str, custom_llm_provider: str | None, duration: float
 
 
 def _video_resolution_to_cost_field_suffix(resolution: str) -> str | None:
-    """
-    Map usage resolution to a safe suffix for ``output_cost_per_second_<suffix>`` keys.
-
-    Note: Currently only ``output_cost_per_second_1080p`` is explicitly declared in
-    ModelInfo (types/utils.py). Other resolution tiers (e.g., 720p, 4k) can be added
-    to model_prices_and_context_window.json but are not exposed via get_model_info()
-    until added to the ModelInfo TypedDict.
-    """
+    """Map usage resolution to a safe suffix for ``output_cost_per_second_<suffix>`` keys."""
     r: Final = resolution.strip().lower()
     if not r:
         return None

--- a/litellm/llms/runwayml/videos/transformation.py
+++ b/litellm/llms/runwayml/videos/transformation.py
@@ -636,8 +636,9 @@ class RunwayMLVideoConfig(BaseVideoConfig):
         if "completedAt" in response_data:
             video_data["completed_at"] = self._parse_runway_timestamp(response_data.get("completedAt"))
 
-        if "progress" in response_data:
-            video_data["progress"] = _progress_percent(response_data["progress"])
+        progress_value: Final = response_data.get("progress")
+        if progress_value is not None:
+            video_data["progress"] = _progress_percent(progress_value)
 
         if "failureCode" in response_data or "failure" in response_data:
             video_data["error"] = {

--- a/litellm/llms/runwayml/videos/transformation.py
+++ b/litellm/llms/runwayml/videos/transformation.py
@@ -1,5 +1,6 @@
 from collections.abc import Mapping, Sequence
 from datetime import datetime
+from types import MappingProxyType
 from typing import TYPE_CHECKING, Any, Final, Literal
 
 import httpx
@@ -33,6 +34,10 @@ else:
     LiteLLMLoggingObj = Any
 
 
+class RunwayMLError(BaseLLMException):
+    pass
+
+
 class _RunwayTaskResponse(TypedDict, total=False):
     id: ReadOnly[str]
     status: ReadOnly[str]
@@ -41,7 +46,8 @@ class _RunwayTaskResponse(TypedDict, total=False):
     output: ReadOnly[Sequence[str] | str]
     failureCode: ReadOnly[str]
     failure: ReadOnly[str]
-    progress: ReadOnly[int]
+    progress: ReadOnly[float]
+    estimatedCost: ReadOnly[Mapping[str, float]]
 
 
 class _VideoObjectData(TypedDict, extra_items=object):
@@ -56,12 +62,54 @@ def _parse_runway_task_response(raw_response: httpx.Response) -> _RunwayTaskResp
     return response_data
 
 
+_USD_PER_CREDIT: Final = 0.01
+
+_RESOLUTION_AREA_TIERS: Final[tuple[tuple[int, str], ...]] = (
+    (600_000, "480p"),
+    (1_500_000, "720p"),
+    (4_000_000, "1080p"),
+)
+
+
+def _ratio_to_resolution(ratio: object) -> str | None:
+    if not isinstance(ratio, str) or ":" not in ratio:
+        return None
+    width_str, _, height_str = ratio.partition(":")
+    if not (width_str.isdigit() and height_str.isdigit()):
+        return None
+    area: Final = int(width_str) * int(height_str)
+    return next((label for threshold, label in _RESOLUTION_AREA_TIERS if area < threshold), "4k")
+
+
+def _duration_seconds(seconds: str | None) -> float | None:
+    if not seconds:
+        return None
+    try:
+        return float(seconds)
+    except ValueError:
+        return None
+
+
+def _estimated_cost_usd(response_data: _RunwayTaskResponse) -> float | None:
+    estimated_cost: Final = response_data.get("estimatedCost")
+    if not isinstance(estimated_cost, Mapping):
+        return None
+    credits: Final = estimated_cost.get("credits")
+    if not isinstance(credits, (int, float)):
+        return None
+    return float(credits) * _USD_PER_CREDIT
+
+
+def _progress_percent(progress: float) -> int:
+    return min(100, max(0, round(float(progress) * 100)))
+
+
 class RunwayMLVideoConfig(BaseVideoConfig):
     """
     Configuration class for RunwayML video generation.
 
     RunwayML uses a task-based API where:
-    1. POST /v1/image_to_video creates a task
+    1. POST /v1/text_to_video, /v1/image_to_video, or /v1/video_to_video creates a task
     2. The task returns immediately with a task ID
     3. Client must poll or wait for task completion
     """
@@ -195,31 +243,36 @@ class RunwayMLVideoConfig(BaseVideoConfig):
         """
         Transform the video creation request for RunwayML API.
 
-        RunwayML expects:
-        {
-            "model": "gen4_turbo",
-            "promptImage": "https://... or data:image/...",
-            "promptText": "description",
-            "ratio": "1280:720",
-            "duration": 5
-        }
+        RunwayML has three generation endpoints discriminated by which input is
+        present, and each request body rejects unknown fields:
+        - /text_to_video: promptText only (rejects promptImage)
+        - /image_to_video: promptImage (+ optional promptText)
+        - /video_to_video: promptVideo or videoUri (rejects promptImage)
         """
-        # Build the request data
+        merged_params: Final = MappingProxyType(
+            {
+                "model": model,
+                "promptText": prompt,
+                **video_create_optional_request_params,
+            }
+        )
+
+        endpoint: Final = self._select_generation_endpoint(merged_params)
+
         request_data: Final[dict[str, object]] = {
-            "model": model,
-            "promptText": prompt,
+            key: value for key, value in merged_params.items() if endpoint == "image_to_video" or key != "promptImage"
         }
 
-        # Add mapped parameters
-        request_data.update(video_create_optional_request_params)
-
-        # RunwayML uses JSON body, no files multipart
         files_list: Final[RequestFiles] = []
 
-        # Append the specific endpoint for video generation
-        full_api_base: Final = f"{api_base}/image_to_video"
+        return request_data, files_list, f"{api_base}/{endpoint}"
 
-        return request_data, files_list, full_api_base
+    def _select_generation_endpoint(self, request_data: Mapping[str, object]) -> str:
+        if request_data.get("promptVideo") is not None or request_data.get("videoUri") is not None:
+            return "video_to_video"
+        if request_data.get("promptImage") is not None:
+            return "image_to_video"
+        return "text_to_video"
 
     def transform_video_create_response(
         self,
@@ -285,13 +338,15 @@ class RunwayMLVideoConfig(BaseVideoConfig):
             video_obj.id = encode_video_id_with_provider(video_obj.id, custom_llm_provider, model)
 
         # Add usage data for cost tracking
-        usage_data: Final = {}
-        if video_obj and hasattr(video_obj, "seconds") and video_obj.seconds:
-            try:
-                usage_data["duration_seconds"] = float(video_obj.seconds)
-            except (ValueError, TypeError):
-                pass
-        video_obj.usage = usage_data
+        video_obj.usage = {
+            key: value
+            for key, value in (
+                ("duration_seconds", _duration_seconds(video_obj.seconds)),
+                ("video_resolution", _ratio_to_resolution(request_data.get("ratio") if request_data else None)),
+                ("provider_reported_cost_usd", _estimated_cost_usd(response_data)),
+            )
+            if value is not None
+        }
 
         return video_obj
 
@@ -582,7 +637,7 @@ class RunwayMLVideoConfig(BaseVideoConfig):
             video_data["completed_at"] = self._parse_runway_timestamp(response_data.get("completedAt"))
 
         if "progress" in response_data:
-            video_data["progress"] = response_data["progress"]
+            video_data["progress"] = _progress_percent(response_data["progress"])
 
         if "failureCode" in response_data or "failure" in response_data:
             video_data["error"] = {
@@ -646,9 +701,7 @@ class RunwayMLVideoConfig(BaseVideoConfig):
         raise NotImplementedError("video extension is not supported for RunwayML")
 
     def get_error_class(self, error_message: str, status_code: int, headers: dict | httpx.Headers) -> BaseLLMException:
-        from ...base_llm.chat.transformation import BaseLLMException
-
-        raise BaseLLMException(
+        return RunwayMLError(
             status_code=status_code,
             message=error_message,
             headers=headers,

--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -43795,10 +43795,10 @@
             "comment": "5 credits per second @ $0.01 per credit = $0.05 per second"
         }
     },
-    "runwayml/gen4_aleph": {
+    "runwayml/gen4.5": {
         "litellm_provider": "runwayml",
         "mode": "video_generation",
-        "output_cost_per_video_per_second": 0.15,
+        "output_cost_per_second": 0.12,
         "source": "https://docs.dev.runwayml.com/guides/pricing/",
         "supported_modalities": [
             "text",
@@ -43808,13 +43808,136 @@
             "video"
         ],
         "metadata": {
-            "comment": "15 credits per second @ $0.01 per credit = $0.15 per second"
+            "comment": "12 credits per second @ $0.01 per credit = $0.12 per second"
         }
     },
-    "runwayml/gen3a_turbo": {
+    "runwayml/aleph2": {
         "litellm_provider": "runwayml",
         "mode": "video_generation",
-        "output_cost_per_video_per_second": 0.05,
+        "output_cost_per_second": 0.28,
+        "source": "https://docs.dev.runwayml.com/guides/pricing/",
+        "supported_modalities": [
+            "text",
+            "video"
+        ],
+        "supported_output_modalities": [
+            "video"
+        ],
+        "metadata": {
+            "comment": "28 credits per second @ $0.01 per credit = $0.28 per second; 56 credit minimum per task not modeled"
+        }
+    },
+    "runwayml/seedance2": {
+        "litellm_provider": "runwayml",
+        "mode": "video_generation",
+        "output_cost_per_second": 0.36,
+        "output_cost_per_second_1080p": 0.4,
+        "output_cost_per_second_4k": 1.5,
+        "source": "https://docs.dev.runwayml.com/guides/pricing/",
+        "supported_modalities": [
+            "text",
+            "image",
+            "video"
+        ],
+        "supported_output_modalities": [
+            "video"
+        ],
+        "metadata": {
+            "comment": "36 credits per second at 480p/720p, 40 at 1080p, 150 at 4K @ $0.01 per credit"
+        }
+    },
+    "runwayml/seedance2_fast": {
+        "litellm_provider": "runwayml",
+        "mode": "video_generation",
+        "output_cost_per_second": 0.29,
+        "source": "https://docs.dev.runwayml.com/guides/pricing/",
+        "supported_modalities": [
+            "text",
+            "image",
+            "video"
+        ],
+        "supported_output_modalities": [
+            "video"
+        ],
+        "metadata": {
+            "comment": "29 credits per second at 480p/720p @ $0.01 per credit = $0.29 per second"
+        }
+    },
+    "runwayml/seedance2_mini": {
+        "litellm_provider": "runwayml",
+        "mode": "video_generation",
+        "output_cost_per_second": 0.16,
+        "source": "https://docs.dev.runwayml.com/guides/pricing/",
+        "supported_modalities": [
+            "text",
+            "image",
+            "video"
+        ],
+        "supported_output_modalities": [
+            "video"
+        ],
+        "metadata": {
+            "comment": "16 credits per second @ $0.01 per credit = $0.16 per second; 64 credit minimum per task not modeled"
+        }
+    },
+    "runwayml/seedance2_5": {
+        "litellm_provider": "runwayml",
+        "mode": "video_generation",
+        "output_cost_per_second": 0.3,
+        "output_cost_per_second_480p": 0.2,
+        "output_cost_per_second_1080p": 0.68,
+        "source": "https://docs.dev.runwayml.com/guides/pricing/",
+        "supported_modalities": [
+            "text",
+            "image",
+            "video"
+        ],
+        "supported_output_modalities": [
+            "video"
+        ],
+        "metadata": {
+            "comment": "Output: 20/30/68 credits per second at 480p/720p/1080p @ $0.01 per credit; input video billed additionally at 10/15/34 credits per input second and the 80 credit minimum per task are not modeled"
+        }
+    },
+    "runwayml/hailuo3": {
+        "litellm_provider": "runwayml",
+        "mode": "video_generation",
+        "output_cost_per_second": 0.1,
+        "output_cost_per_second_1080p": 0.15,
+        "source": "https://docs.dev.runwayml.com/guides/pricing/",
+        "supported_modalities": [
+            "text",
+            "image",
+            "video"
+        ],
+        "supported_output_modalities": [
+            "video"
+        ],
+        "metadata": {
+            "comment": "10 credits per second at 768P, 15 at 2K (mapped to the 1080p tier) @ $0.01 per credit; 2 credits per reference image not modeled"
+        }
+    },
+    "runwayml/gemini_omni_flash": {
+        "litellm_provider": "runwayml",
+        "mode": "video_generation",
+        "output_cost_per_second": 0.1,
+        "source": "https://docs.dev.runwayml.com/guides/pricing/",
+        "supported_modalities": [
+            "text",
+            "image",
+            "video"
+        ],
+        "supported_output_modalities": [
+            "video"
+        ],
+        "metadata": {
+            "comment": "10 credits per second @ $0.01 per credit = $0.10 per second"
+        }
+    },
+    "runwayml/veo3.1": {
+        "litellm_provider": "runwayml",
+        "mode": "video_generation",
+        "output_cost_per_second": 0.4,
         "source": "https://docs.dev.runwayml.com/guides/pricing/",
         "supported_modalities": [
             "text",
@@ -43824,7 +43947,23 @@
             "video"
         ],
         "metadata": {
-            "comment": "5 credits per second @ $0.01 per credit = $0.05 per second"
+            "comment": "40 credits per second with audio, 20 without @ $0.01 per credit; priced at the with-audio rate"
+        }
+    },
+    "runwayml/veo3.1_fast": {
+        "litellm_provider": "runwayml",
+        "mode": "video_generation",
+        "output_cost_per_second": 0.15,
+        "source": "https://docs.dev.runwayml.com/guides/pricing/",
+        "supported_modalities": [
+            "text",
+            "image"
+        ],
+        "supported_output_modalities": [
+            "video"
+        ],
+        "metadata": {
+            "comment": "15 credits per second with audio, 10 without @ $0.01 per credit; priced at the with-audio rate"
         }
     },
     "runwayml/gen4_image": {

--- a/litellm/types/router.py
+++ b/litellm/types/router.py
@@ -10,7 +10,7 @@ from typing import Any, ClassVar, Final, Generic, Literal, TypeVar, get_type_hin
 
 import httpx
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
-from typing_extensions import Protocol, Required, TypedDict, runtime_checkable
+from typing_extensions import Protocol, ReadOnly, Required, TypedDict, runtime_checkable
 
 from litellm._uuid import uuid
 
@@ -480,7 +480,9 @@ class LiteLLMParamsTypedDict(TypedDict, total=False):
     output_cost_per_token: float | None
     input_cost_per_second: float | None
     output_cost_per_second: float | None
+    output_cost_per_second_480p: ReadOnly[float | None]
     output_cost_per_second_1080p: float | None
+    output_cost_per_second_4k: ReadOnly[float | None]
     num_retries: int | None
     ## MOCK RESPONSES ##
     mock_response: str | ModelResponse | Exception | None

--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -277,6 +277,8 @@ class ModelInfoBase(ProviderSpecificModelInfo, total=False):
     output_cost_per_second_1080p: (
         float | None
     )  # video_generation tier: key output_cost_per_second_<resolution> (e.g. 1080p, 720p)
+    output_cost_per_second_480p: ReadOnly[float | None]
+    output_cost_per_second_4k: ReadOnly[float | None]
     ocr_cost_per_page: float | None  # for OCR models
     ocr_cost_per_credit: float | None  # for OCR models priced by credit
     annotation_cost_per_page: float | None  # for OCR models
@@ -3331,6 +3333,8 @@ class CustomPricingLiteLLMParams(MirroredPricingParams):
     input_cost_per_second: float | None = None
     output_cost_per_second: float | None = None
     output_cost_per_second_1080p: float | None = None
+    output_cost_per_second_480p: float | None = None
+    output_cost_per_second_4k: float | None = None
     input_cost_per_pixel: float | None = None
     output_cost_per_pixel: float | None = None
 

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -5726,6 +5726,8 @@ def _get_model_info_helper(
                 ),
                 output_cost_per_second=_model_info.get("output_cost_per_second", None),
                 output_cost_per_second_1080p=_model_info.get("output_cost_per_second_1080p", None),
+                output_cost_per_second_480p=_model_info.get("output_cost_per_second_480p", None),
+                output_cost_per_second_4k=_model_info.get("output_cost_per_second_4k", None),
                 output_cost_per_video_per_second=_model_info.get("output_cost_per_video_per_second", None),
                 output_cost_per_image=_model_info.get("output_cost_per_image", None),
                 output_cost_per_image_token=_model_info.get("output_cost_per_image_token", None),

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -43795,10 +43795,10 @@
             "comment": "5 credits per second @ $0.01 per credit = $0.05 per second"
         }
     },
-    "runwayml/gen4_aleph": {
+    "runwayml/gen4.5": {
         "litellm_provider": "runwayml",
         "mode": "video_generation",
-        "output_cost_per_video_per_second": 0.15,
+        "output_cost_per_second": 0.12,
         "source": "https://docs.dev.runwayml.com/guides/pricing/",
         "supported_modalities": [
             "text",
@@ -43808,13 +43808,136 @@
             "video"
         ],
         "metadata": {
-            "comment": "15 credits per second @ $0.01 per credit = $0.15 per second"
+            "comment": "12 credits per second @ $0.01 per credit = $0.12 per second"
         }
     },
-    "runwayml/gen3a_turbo": {
+    "runwayml/aleph2": {
         "litellm_provider": "runwayml",
         "mode": "video_generation",
-        "output_cost_per_video_per_second": 0.05,
+        "output_cost_per_second": 0.28,
+        "source": "https://docs.dev.runwayml.com/guides/pricing/",
+        "supported_modalities": [
+            "text",
+            "video"
+        ],
+        "supported_output_modalities": [
+            "video"
+        ],
+        "metadata": {
+            "comment": "28 credits per second @ $0.01 per credit = $0.28 per second; 56 credit minimum per task not modeled"
+        }
+    },
+    "runwayml/seedance2": {
+        "litellm_provider": "runwayml",
+        "mode": "video_generation",
+        "output_cost_per_second": 0.36,
+        "output_cost_per_second_1080p": 0.4,
+        "output_cost_per_second_4k": 1.5,
+        "source": "https://docs.dev.runwayml.com/guides/pricing/",
+        "supported_modalities": [
+            "text",
+            "image",
+            "video"
+        ],
+        "supported_output_modalities": [
+            "video"
+        ],
+        "metadata": {
+            "comment": "36 credits per second at 480p/720p, 40 at 1080p, 150 at 4K @ $0.01 per credit"
+        }
+    },
+    "runwayml/seedance2_fast": {
+        "litellm_provider": "runwayml",
+        "mode": "video_generation",
+        "output_cost_per_second": 0.29,
+        "source": "https://docs.dev.runwayml.com/guides/pricing/",
+        "supported_modalities": [
+            "text",
+            "image",
+            "video"
+        ],
+        "supported_output_modalities": [
+            "video"
+        ],
+        "metadata": {
+            "comment": "29 credits per second at 480p/720p @ $0.01 per credit = $0.29 per second"
+        }
+    },
+    "runwayml/seedance2_mini": {
+        "litellm_provider": "runwayml",
+        "mode": "video_generation",
+        "output_cost_per_second": 0.16,
+        "source": "https://docs.dev.runwayml.com/guides/pricing/",
+        "supported_modalities": [
+            "text",
+            "image",
+            "video"
+        ],
+        "supported_output_modalities": [
+            "video"
+        ],
+        "metadata": {
+            "comment": "16 credits per second @ $0.01 per credit = $0.16 per second; 64 credit minimum per task not modeled"
+        }
+    },
+    "runwayml/seedance2_5": {
+        "litellm_provider": "runwayml",
+        "mode": "video_generation",
+        "output_cost_per_second": 0.3,
+        "output_cost_per_second_480p": 0.2,
+        "output_cost_per_second_1080p": 0.68,
+        "source": "https://docs.dev.runwayml.com/guides/pricing/",
+        "supported_modalities": [
+            "text",
+            "image",
+            "video"
+        ],
+        "supported_output_modalities": [
+            "video"
+        ],
+        "metadata": {
+            "comment": "Output: 20/30/68 credits per second at 480p/720p/1080p @ $0.01 per credit; input video billed additionally at 10/15/34 credits per input second and the 80 credit minimum per task are not modeled"
+        }
+    },
+    "runwayml/hailuo3": {
+        "litellm_provider": "runwayml",
+        "mode": "video_generation",
+        "output_cost_per_second": 0.1,
+        "output_cost_per_second_1080p": 0.15,
+        "source": "https://docs.dev.runwayml.com/guides/pricing/",
+        "supported_modalities": [
+            "text",
+            "image",
+            "video"
+        ],
+        "supported_output_modalities": [
+            "video"
+        ],
+        "metadata": {
+            "comment": "10 credits per second at 768P, 15 at 2K (mapped to the 1080p tier) @ $0.01 per credit; 2 credits per reference image not modeled"
+        }
+    },
+    "runwayml/gemini_omni_flash": {
+        "litellm_provider": "runwayml",
+        "mode": "video_generation",
+        "output_cost_per_second": 0.1,
+        "source": "https://docs.dev.runwayml.com/guides/pricing/",
+        "supported_modalities": [
+            "text",
+            "image",
+            "video"
+        ],
+        "supported_output_modalities": [
+            "video"
+        ],
+        "metadata": {
+            "comment": "10 credits per second @ $0.01 per credit = $0.10 per second"
+        }
+    },
+    "runwayml/veo3.1": {
+        "litellm_provider": "runwayml",
+        "mode": "video_generation",
+        "output_cost_per_second": 0.4,
         "source": "https://docs.dev.runwayml.com/guides/pricing/",
         "supported_modalities": [
             "text",
@@ -43824,7 +43947,23 @@
             "video"
         ],
         "metadata": {
-            "comment": "5 credits per second @ $0.01 per credit = $0.05 per second"
+            "comment": "40 credits per second with audio, 20 without @ $0.01 per credit; priced at the with-audio rate"
+        }
+    },
+    "runwayml/veo3.1_fast": {
+        "litellm_provider": "runwayml",
+        "mode": "video_generation",
+        "output_cost_per_second": 0.15,
+        "source": "https://docs.dev.runwayml.com/guides/pricing/",
+        "supported_modalities": [
+            "text",
+            "image"
+        ],
+        "supported_output_modalities": [
+            "video"
+        ],
+        "metadata": {
+            "comment": "15 credits per second with audio, 10 without @ $0.01 per credit; priced at the with-audio rate"
         }
     },
     "runwayml/gen4_image": {

--- a/model_prices_and_context_window.schema.json
+++ b/model_prices_and_context_window.schema.json
@@ -428,6 +428,14 @@
           "type": "number",
           "minimum": 0
         },
+        "output_cost_per_second_480p": {
+          "type": "number",
+          "minimum": 0
+        },
+        "output_cost_per_second_4k": {
+          "type": "number",
+          "minimum": 0
+        },
         "output_cost_per_token": {
           "type": "number",
           "minimum": 0,

--- a/tests/test_litellm/litellm_core_utils/test_exception_mapping_utils.py
+++ b/tests/test_litellm/litellm_core_utils/test_exception_mapping_utils.py
@@ -867,6 +867,7 @@ PROVIDERS_WITH_A_HANDLER = (
     "openrouter",
     "perplexity",
     "replicate",
+    "runwayml",
     "sagemaker",
     "together_ai",
     "vertex_ai",
@@ -956,6 +957,7 @@ PROVIDERS_THAT_RECOGNISE_A_FULL_CONTEXT_WINDOW = (
     "mistral",
     "openai",
     "perplexity",
+    "runwayml",
     "together_ai",
     "vertex_ai",
     "xai",
@@ -971,6 +973,7 @@ PROVIDERS_THAT_RECOGNISE_A_CONTENT_POLICY_BLOCK = (
     "mistral",
     "openai",
     "perplexity",
+    "runwayml",
     "together_ai",
     "xai",
 )

--- a/tests/test_litellm/llms/runwayml/videos/test_runway_video_transformation.py
+++ b/tests/test_litellm/llms/runwayml/videos/test_runway_video_transformation.py
@@ -119,6 +119,25 @@ class TestRunwayMLVideoTransformation:
         assert result.status == "in_progress"
         assert result.progress == 3
 
+    def test_status_progress_null_leaves_progress_unset(self):
+        """Runway sends an explicit null progress for pending polls; scaling it must not crash."""
+        mock_response = Mock(spec=httpx.Response)
+        mock_response.json.return_value = {
+            "id": "63fd0f13-f29d-4e58-99d3-1cb9efa14a5b",
+            "createdAt": "2025-11-11T21:48:50.448Z",
+            "status": "PENDING",
+            "progress": None,
+        }
+
+        result = self.config.transform_video_status_retrieve_response(
+            raw_response=mock_response,
+            logging_obj=self.mock_logging_obj,
+            custom_llm_provider="runwayml",
+        )
+
+        assert result.status == "queued"
+        assert result.progress is None
+
     def test_get_error_class_returns_exception_instead_of_raising(self):
         error = self.config.get_error_class(
             error_message="Invalid API key",

--- a/tests/test_litellm/llms/runwayml/videos/test_runway_video_transformation.py
+++ b/tests/test_litellm/llms/runwayml/videos/test_runway_video_transformation.py
@@ -7,7 +7,12 @@ from unittest.mock import Mock
 import httpx
 import pytest
 
-from litellm.llms.runwayml.videos.transformation import RunwayMLVideoConfig
+from litellm.llms.base_llm.chat.transformation import BaseLLMException
+from litellm.llms.runwayml.videos.transformation import (
+    RunwayMLError,
+    RunwayMLVideoConfig,
+    _ratio_to_resolution,
+)
 from litellm.types.router import GenericLiteLLMParams
 from litellm.types.videos.main import VideoObject
 
@@ -48,6 +53,139 @@ class TestRunwayMLVideoTransformation:
 
         # Validate URL has correct endpoint
         assert url == "https://api.dev.runwayml.com/v1/image_to_video"
+
+    def test_transform_video_create_request_text_to_video(self):
+        """A prompt-only request must hit /text_to_video, not /image_to_video."""
+        data, files, url = self.config.transform_video_create_request(
+            model="veo3.1",
+            prompt="A serene mountain lake at sunrise",
+            api_base="https://api.dev.runwayml.com/v1",
+            video_create_optional_request_params={"duration": 8, "ratio": "1280:720"},
+            litellm_params=GenericLiteLLMParams(),
+            headers={},
+        )
+
+        assert url == "https://api.dev.runwayml.com/v1/text_to_video"
+        assert "promptImage" not in data
+        assert data["promptText"] == "A serene mountain lake at sunrise"
+
+    def test_transform_video_create_request_video_to_video(self):
+        """A promptVideo request must hit /video_to_video with promptImage stripped."""
+        data, files, url = self.config.transform_video_create_request(
+            model="aleph2",
+            prompt="Make it snow",
+            api_base="https://api.dev.runwayml.com/v1",
+            video_create_optional_request_params={
+                "promptVideo": "https://example.com/source.mp4",
+                "promptImage": "https://example.com/reference.png",
+                "ratio": "1280:720",
+            },
+            litellm_params=GenericLiteLLMParams(),
+            headers={},
+        )
+
+        assert url == "https://api.dev.runwayml.com/v1/video_to_video"
+        assert data["promptVideo"] == "https://example.com/source.mp4"
+        assert "promptImage" not in data
+
+    def test_transform_video_create_request_video_uri_routes_to_video_to_video(self):
+        _, _, url = self.config.transform_video_create_request(
+            model="aleph2",
+            prompt="Make it snow",
+            api_base="https://api.dev.runwayml.com/v1",
+            video_create_optional_request_params={"videoUri": "https://example.com/source.mp4"},
+            litellm_params=GenericLiteLLMParams(),
+            headers={},
+        )
+
+        assert url == "https://api.dev.runwayml.com/v1/video_to_video"
+
+    def test_status_progress_fraction_scales_to_percent(self):
+        """Runway reports progress as a 0..1 float; VideoObject.progress is an int percent."""
+        mock_response = Mock(spec=httpx.Response)
+        mock_response.json.return_value = {
+            "id": "63fd0f13-f29d-4e58-99d3-1cb9efa14a5b",
+            "createdAt": "2025-11-11T21:48:50.448Z",
+            "status": "RUNNING",
+            "progress": 0.027,
+        }
+
+        result = self.config.transform_video_status_retrieve_response(
+            raw_response=mock_response,
+            logging_obj=self.mock_logging_obj,
+            custom_llm_provider="runwayml",
+        )
+
+        assert result.status == "in_progress"
+        assert result.progress == 3
+
+    def test_get_error_class_returns_exception_instead_of_raising(self):
+        error = self.config.get_error_class(
+            error_message="Invalid API key",
+            status_code=401,
+            headers={},
+        )
+
+        assert isinstance(error, RunwayMLError)
+        assert isinstance(error, BaseLLMException)
+        assert error.status_code == 401
+        assert error.message == "Invalid API key"
+
+    def test_create_response_usage_includes_resolution_and_provider_cost(self):
+        mock_response = Mock(spec=httpx.Response)
+        mock_response.json.return_value = {
+            "id": "test-video-id-123",
+            "createdAt": "2025-11-11T21:48:50.448Z",
+            "status": "PENDING",
+            "estimatedCost": {"credits": 25.0},
+        }
+
+        video_obj = self.config.transform_video_create_response(
+            model="gen4_turbo",
+            raw_response=mock_response,
+            logging_obj=self.mock_logging_obj,
+            custom_llm_provider="runwayml",
+            request_data={"model": "gen4_turbo", "ratio": "1280:720", "duration": 5},
+        )
+
+        assert video_obj.usage == {
+            "duration_seconds": 5.0,
+            "video_resolution": "720p",
+            "provider_reported_cost_usd": 0.25,
+        }
+
+    def test_create_response_usage_omits_unknown_fields(self):
+        mock_response = Mock(spec=httpx.Response)
+        mock_response.json.return_value = {
+            "id": "test-video-id-123",
+            "createdAt": "2025-11-11T21:48:50.448Z",
+            "status": "PENDING",
+        }
+
+        video_obj = self.config.transform_video_create_response(
+            model="gen4_turbo",
+            raw_response=mock_response,
+            logging_obj=self.mock_logging_obj,
+            custom_llm_provider="runwayml",
+            request_data={"model": "gen4_turbo"},
+        )
+
+        assert video_obj.usage == {}
+
+    @pytest.mark.parametrize(
+        "ratio,expected",
+        [
+            ("848:480", "480p"),
+            ("1280:720", "720p"),
+            ("1920:1080", "1080p"),
+            ("2560:1440", "1080p"),
+            ("3840:2160", "4k"),
+            (None, None),
+            ("banana", None),
+        ],
+    )
+    def test_ratio_to_resolution_tiers(self, ratio, expected):
+        assert _ratio_to_resolution(ratio) == expected
 
     def test_transform_video_status_with_timestamp_handling(self):
         """Test status retrieval handles RunwayML's ISO 8601 timestamps correctly."""

--- a/tests/test_litellm/test_utils.py
+++ b/tests/test_litellm/test_utils.py
@@ -730,7 +730,9 @@ def validate_model_cost_values(model_data, exceptions=None):
         "output_cost_per_pixel",
         "input_cost_per_second",
         "output_cost_per_second",
+        "output_cost_per_second_480p",
         "output_cost_per_second_1080p",
+        "output_cost_per_second_4k",
         "input_cost_per_query",
         "input_cost_per_request",
         "input_cost_per_audio_token",
@@ -944,7 +946,9 @@ def test_aaamodel_prices_and_context_window_json_is_valid():
                 "output_cost_per_video_token": {"type": "number"},
                 "output_cost_per_pixel": {"type": "number"},
                 "output_cost_per_second": {"type": "number"},
+                "output_cost_per_second_480p": {"type": "number"},
                 "output_cost_per_second_1080p": {"type": "number"},
+                "output_cost_per_second_4k": {"type": "number"},
                 "output_cost_per_token": {"type": "number"},
                 "output_cost_per_token_above_128k_tokens": {"type": "number"},
                 "output_cost_per_token_above_200k_tokens": {"type": "number"},
@@ -1124,6 +1128,7 @@ def test_aaamodel_prices_and_context_window_json_is_valid():
     exceptions = [
         # Add any model IDs that should be exempt from the cost validation
         # Example: "expensive-model-id",
+        "runwayml/seedance2",  # 4K output is 150 credits/second = $1.50/second
     ]
 
     is_valid, violations = validate_model_cost_values(actual_json, exceptions)

--- a/tests/test_litellm/test_video_generation.py
+++ b/tests/test_litellm/test_video_generation.py
@@ -421,6 +421,117 @@ class TestVideoGeneration:
         )
         assert cost == 0.5
 
+    def test_completion_cost_video_custom_pricing_under_litellm_metadata(self):
+        """Video routes store deployment model_info under litellm_metadata, not metadata.
+
+        Regression for https://github.com/BerriAI/litellm/issues/36483: custom video
+        pricing was silently ignored because completion_cost only read metadata.
+        """
+        from litellm.cost_calculator import completion_cost
+
+        mock_response = MagicMock()
+        mock_response.usage = {"duration_seconds": 10.0}
+        type(mock_response)._hidden_params = {}
+
+        mock_logging_obj = MagicMock()
+        mock_logging_obj.litellm_params = {
+            "litellm_metadata": {
+                "model_info": {
+                    "output_cost_per_video_per_second": 0.18,
+                }
+            }
+        }
+
+        cost = completion_cost(
+            completion_response=mock_response,
+            model="runwayml/seedance2",
+            call_type="create_video",
+            custom_llm_provider="runwayml",
+            custom_pricing=True,
+            litellm_logging_obj=mock_logging_obj,
+        )
+        assert abs(cost - 1.8) < 0.001
+
+    def test_completion_cost_video_uses_provider_reported_cost_without_custom_pricing(self):
+        """With no custom pricing, the provider's own reported cost wins over a duration estimate."""
+        from litellm.cost_calculator import completion_cost
+
+        mock_response = MagicMock()
+        mock_response.usage = {
+            "duration_seconds": 5.0,
+            "video_resolution": "720p",
+            "provider_reported_cost_usd": 0.31,
+        }
+        type(mock_response)._hidden_params = {}
+
+        cost = completion_cost(
+            completion_response=mock_response,
+            model="runwayml/gen4_turbo",
+            call_type="create_video",
+            custom_llm_provider="runwayml",
+        )
+        assert cost == 0.31
+
+    def test_completion_cost_video_custom_pricing_beats_provider_reported_cost(self):
+        """Deployment-level custom pricing overrides the provider's reported cost."""
+        from litellm.cost_calculator import completion_cost
+
+        mock_response = MagicMock()
+        mock_response.usage = {
+            "duration_seconds": 10.0,
+            "provider_reported_cost_usd": 0.31,
+        }
+        type(mock_response)._hidden_params = {}
+
+        mock_logging_obj = MagicMock()
+        mock_logging_obj.litellm_params = {
+            "metadata": {
+                "model_info": {
+                    "output_cost_per_video_per_second": 0.18,
+                }
+            }
+        }
+
+        cost = completion_cost(
+            completion_response=mock_response,
+            model="runwayml/seedance2",
+            call_type="create_video",
+            custom_llm_provider="runwayml",
+            custom_pricing=True,
+            litellm_logging_obj=mock_logging_obj,
+        )
+        assert abs(cost - 1.8) < 0.001
+
+    def test_completion_cost_video_resolution_tiers_from_cost_map(self, monkeypatch):
+        """The 480p/1080p/4k tier keys resolve from the shipped runwayml cost map entries."""
+        from litellm.cost_calculator import completion_cost
+
+        local_map_path = os.path.join(
+            os.path.dirname(__file__), "..", "..", "model_prices_and_context_window.json"
+        )
+        with open(local_map_path, "r") as f:
+            monkeypatch.setattr(litellm, "model_cost", json.load(f))
+
+        def cost_for(model: str, resolution: str | None, duration: float) -> float:
+            mock_response = MagicMock()
+            mock_response.usage = {
+                "duration_seconds": duration,
+                **({"video_resolution": resolution} if resolution else {}),
+            }
+            type(mock_response)._hidden_params = {}
+            return completion_cost(
+                completion_response=mock_response,
+                model=model,
+                call_type="create_video",
+                custom_llm_provider="runwayml",
+            )
+
+        assert abs(cost_for("runwayml/seedance2", "4k", 8.0) - 12.0) < 0.001
+        assert abs(cost_for("runwayml/seedance2", "1080p", 8.0) - 3.2) < 0.001
+        assert abs(cost_for("runwayml/seedance2", "720p", 8.0) - 2.88) < 0.001
+        assert abs(cost_for("runwayml/seedance2_5", "480p", 8.0) - 1.6) < 0.001
+        assert abs(cost_for("runwayml/gen4.5", None, 8.0) - 0.96) < 0.001
+
     def test_video_generation_with_files(self):
         """Test video generation with file uploads."""
         config = OpenAIVideoConfig()

--- a/ui/litellm-dashboard/src/lib/http/schema.d.ts
+++ b/ui/litellm-dashboard/src/lib/http/schema.d.ts
@@ -27624,6 +27624,10 @@ export interface components {
             output_cost_per_second?: number | null;
             /** Output Cost Per Second 1080P */
             output_cost_per_second_1080p?: number | null;
+            /** Output Cost Per Second 480P */
+            output_cost_per_second_480p?: number | null;
+            /** Output Cost Per Second 4K */
+            output_cost_per_second_4k?: number | null;
             /** Output Cost Per Token */
             output_cost_per_token?: number | null;
             /** Output Cost Per Token Above 128K Tokens */
@@ -36833,6 +36837,10 @@ export interface components {
             output_cost_per_second?: number | null;
             /** Output Cost Per Second 1080P */
             output_cost_per_second_1080p?: number | null;
+            /** Output Cost Per Second 480P */
+            output_cost_per_second_480p?: number | null;
+            /** Output Cost Per Second 4K */
+            output_cost_per_second_4k?: number | null;
             /** Output Cost Per Token */
             output_cost_per_token?: number | null;
             /** Output Cost Per Token Above 128K Tokens */


### PR DESCRIPTION
## TLDR

Problem this solves:

- Every RunwayML video request was sent to image_to_video
- Text-to-video 400'd; video-to-video was unreachable
- Runway 4xx errors surfaced as proxy 500 APIConnectionError
- Status polling 500'd on Runway's fractional progress mid-render
- Custom per-deployment video pricing was silently ignored
- Cost map carried removed Runway models, missed all current ones

How it solves it:

- Picks text_to_video, image_to_video, or video_to_video from the inputs
- Returns Runway errors with their real status codes
- Scales Runway's 0..1 progress to a whole percent
- Reads deployment pricing from both metadata slots
- Refreshes Runway prices with resolution tiers and Runway-reported cost

## User Flow

Before: a developer generating videos with RunwayML through the gateway cannot reach text-to-video at all, sees 500s in place of provider errors, watches status polling fail mid-render, and gets $0.00 spend

1. They send POST https://litellm-domain/v1/videos with `{"model": "runwayml/seedance2", "prompt": "a golden sunset", "seconds": 4, "size": "1280x720"}` and no image
2. The gateway aims the call at Runway's image-to-video endpoint, Runway rejects it, and the developer gets HTTP 500 `litellm.APIConnectionError` with Runway's own error text buried inside; a wrong API key comes back the same way instead of as a 401, and no request shape reaches text-to-video or video-to-video
3. They work around it by attaching a `promptImage`, and a video id comes back
4. They poll GET https://litellm-domain/v1/videos/{video_id} while the render runs and get HTTP 500 `Input should be a valid integer` because Runway reports progress as `0.027`; the poll only succeeds once the render finishes
5. On https://litellm-domain/ui/?page=logs the finished clip shows $0.00 spend, and the custom price they set on the deployment changes nothing

After: the same developer generates text-to-video, image-to-video, and video-to-video clips, sees Runway's real errors, polls progress mid-render, and gets real spend

1. They send the same POST https://litellm-domain/v1/videos with `{"model": "runwayml/seedance2", "prompt": "a golden sunset", "seconds": 4, "size": "1280x720"}` and no image
2. The call lands on Runway's text-to-video endpoint and a video id comes back with HTTP 200; adding `promptImage` selects image-to-video, `promptVideo` selects video-to-video, and a wrong API key now returns Runway's own 401 and message
3. They poll GET https://litellm-domain/v1/videos/{video_id} mid-render and get HTTP 200 with `"status": "in_progress"` and `"progress": 3`
4. On https://litellm-domain/ui/?page=logs the finished clip shows real spend: the deployment's custom price when one is set, otherwise Runway's own reported cost for the task, otherwise the refreshed price list for current Runway models with 480p/720p/1080p/4K tiers

## Relevant issues

Fixes #36483

## Linear ticket

Resolves LIT-5981

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Shared setup: DB-less proxy from the worktree on a random free port, the issue's own config (`runwayml/seedance2` behind model_name `seedance-2.0`), requests hitting the real https://api.dev.runwayml.com. No valid RunwayML key exists on this machine, so both runs use a deliberately invalid key: Runway authenticates before validating bodies, which still exposes the outbound endpoint choice and the error mapping live. The rendered-video legs (mid-render progress, final spend) need a valid key and are the one pending item

```yaml
model_list:
  - model_name: seedance-2.0
    litellm_params:
      model: runwayml/seedance2
      api_key: os.environ/RUNWAYML_API_KEY
general_settings:
  master_key: sk-lit5981-repro
```

### Before (f005afa146)

#### Text-to-video request is misrouted and the provider 4xx becomes a 500

1. `curl -sS -X POST "http://127.0.0.1:34505/v1/videos" -H "Authorization: Bearer sk-lit5981-repro" -H 'Content-Type: application/json' -d '{"model":"seedance-2.0","prompt":"a golden sunset","seconds":4,"size":"1280x720"}'`
2. HTTP 500: `litellm.APIConnectionError: RunwaymlException - {"error":"The provided API key in the Authorization header is not the correct length. ..."}`
3. Proxy debug log shows the outbound call for this image-less request: `POST https://api.dev.runwayml.com/v1/image_to_video`

### After (3030e974b8)

Same proxy, same config, same invalid key, same three request shapes. Each request now lands on the endpoint its inputs select, and Runway's 4xx comes back as a 401, not a proxy 500

#### Image-less request now routes to text-to-video and the 401 passes through

1. `curl -sS -X POST "http://127.0.0.1:39411/v1/videos" -H "Authorization: Bearer sk-lit5981-repro" -H 'Content-Type: application/json' -d '{"model":"seedance-2.0","prompt":"a golden sunset","seconds":4,"size":"1280x720"}'`
2. HTTP 401: `{"error":{"message":"litellm.AuthenticationError: AuthenticationError: RunwaymlException - {\"error\":\"The provided API key in the Authorization header did not start with `key_`.\",\"docUrl\":\"https://docs.dev.runwayml.com/api\"}. ...","code":"401"}}`
3. Proxy debug log shows the outbound call for this image-less request: `POST https://api.dev.runwayml.com/v1/text_to_video`

#### Endpoint selection: the log shows all three routes hit, one per input shape

- image-less body -> `https://api.dev.runwayml.com/v1/text_to_video`
- body with `input_reference` (mapped to promptImage) -> `https://api.dev.runwayml.com/v1/image_to_video`
- body with `promptVideo` -> `https://api.dev.runwayml.com/v1/video_to_video`

All three return HTTP 401 with Runway's own message, confirming both the routing fix and the error-passthrough fix live

The remaining legs (mid-render `"progress": 3` on a status poll, and real spend on a finished clip) need a valid RunwayML key and are covered by unit tests only; they are the one pending item

## Type

🐛 Bug Fix

## Caveats (if any)

- veo3.1 map entries use the with-audio rate; no-audio renders cost less
- Per-task credit minimums (aleph2, seedance2_mini, seedance2_5) not modeled
- seedance2_5 bills input video per second too; not modeled
- Rendered-video live QA pending: no RunwayML key available

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

- [x] 3030e974b8 passes /live-pr-risk
