### PR TITLE
fix(langsmith): keep root-run ids self-consistent so batch ingest stops rejecting header-tagged requests

### DIFF
--- a/litellm/integrations/langsmith.py
+++ b/litellm/integrations/langsmith.py
@@ -168,17 +168,20 @@ class LangsmithLogger(CustomBatchLogger):
         return outputs
 
     def _ensure_required_ids(self, data: dict, run_id: str | None):
+        resolved_id: Final = run_id or str(uuid.uuid4())
         if "id" not in data or data["id"] is None:
-            run_id = str(uuid.uuid4())
-            data["id"] = run_id
+            data["id"] = resolved_id
 
-        if "trace_id" not in data or data["trace_id"] is None:
-            if run_id is not None and isinstance(run_id, str):
-                data["trace_id"] = run_id
+        # LangSmith rejects the whole ingest batch unless a root run's trace_id
+        # equals the run id embedded in the first segment of dotted_order
+        posts_as_root: Final = ("parent_run_id" not in data or data["parent_run_id"] is None) and (
+            "dotted_order" not in data or data["dotted_order"] is None
+        )
+        if posts_as_root or "trace_id" not in data or data["trace_id"] is None:
+            data["trace_id"] = resolved_id
 
         if "dotted_order" not in data or data["dotted_order"] is None:
-            if run_id is not None and isinstance(run_id, str):
-                data["dotted_order"] = self.make_dot_order(run_id=run_id)
+            data["dotted_order"] = self.make_dot_order(run_id=resolved_id)
 
     def _prepare_log_data(
         self,
@@ -193,6 +196,11 @@ class LangsmithLogger(CustomBatchLogger):
             metadata = _litellm_params.get("metadata", {}) or {}
 
             fields: Final = self._extract_metadata_fields(metadata, credentials)
+            # the proxy header fan-out mirrors one value into both keys, and LangSmith
+            # rejects the whole ingest batch when run-body session_id is not an
+            # existing tracer-session uuid
+            if fields["session_id"] == fields["trace_id"]:
+                fields["session_id"] = None
             verbose_logger.debug(
                 "Langsmith Logging - project_name: %s, run_name %s", fields["project_name"], fields["run_name"]
             )

--- a/tests/test_litellm/integrations/test_langsmith_init.py
+++ b/tests/test_litellm/integrations/test_langsmith_init.py
@@ -432,3 +432,103 @@ class TestLangsmithRedactUserApiKeyInfo:
         )
 
         assert data["inputs"]["metadata"]["user_api_key_hash"] == "abc123"
+
+
+class TestLangsmithRootRunIdConsistency:
+    """Regression tests for LIT-5878 / #37269.
+
+    A request that carries a session/trace header (e.g. x-claude-code-session-id)
+    fans the header value out into litellm metadata as both trace_id and
+    session_id. LangSmith then rejected the whole ingest batch twice over:
+    a root run whose trace_id does not match the run id embedded in dotted_order
+    (400), and a run-body session_id that does not reference an existing tracer
+    session (404, or 422 for non-UUID values).
+    """
+
+    def _prepare(self, request_metadata):
+        payload = {
+            "id": "slp-1",
+            "response": {"choices": []},
+            "metadata": {},
+            "startTime": 1.0,
+            "endTime": 2.0,
+            "request_tags": [],
+            "error_str": None,
+            "status": "success",
+            "response_cost": 0.0,
+            "prompt_tokens": 1,
+            "completion_tokens": 1,
+            "total_tokens": 2,
+        }
+        logger = LangsmithLogger(
+            langsmith_api_key="test-key",
+            langsmith_project="test-project",
+        )
+        return logger._prepare_log_data(
+            kwargs={
+                "litellm_params": {"metadata": request_metadata},
+                "standard_logging_object": payload,
+            },
+            response_obj=None,
+            start_time=1.0,
+            end_time=2.0,
+            credentials={
+                "LANGSMITH_API_KEY": "test-key",
+                "LANGSMITH_PROJECT": "test-project",
+                "LANGSMITH_BASE_URL": "https://api.smith.langchain.com",
+            },
+        )
+
+    def test_header_derived_ids_yield_self_consistent_root_run(self):
+        header_value = "ed29c3bb-44fa-4eec-9b7b-fecaa3e82d64"
+        data = self._prepare({"trace_id": header_value, "session_id": header_value})
+
+        assert data["trace_id"] == data["id"]
+        assert data["trace_id"] != header_value
+        assert data["dotted_order"].endswith(data["id"])
+        assert len(data["dotted_order"]) == 22 + len(data["id"])
+        assert "session_id" not in data
+
+    def test_distinct_session_id_is_still_forwarded(self):
+        data = self._prepare({"session_id": "11111111-2222-3333-4444-555555555555"})
+
+        assert data["session_id"] == "11111111-2222-3333-4444-555555555555"
+
+    def test_trace_id_only_root_run_is_overridden(self):
+        data = self._prepare({"trace_id": "ed29c3bb-44fa-4eec-9b7b-fecaa3e82d64"})
+
+        assert data["trace_id"] == data["id"]
+        assert data["trace_id"] != "ed29c3bb-44fa-4eec-9b7b-fecaa3e82d64"
+        assert data["dotted_order"].endswith(data["id"])
+
+    def test_root_run_without_caller_ids_is_self_consistent(self):
+        data = self._prepare({})
+
+        assert data["trace_id"] == data["id"]
+        assert data["dotted_order"].endswith(data["id"])
+
+    def test_child_run_keeps_caller_trace_id(self):
+        data = self._prepare(
+            {
+                "trace_id": "trace-1",
+                "parent_run_id": "parent-1",
+                "run_id": "child-1",
+            }
+        )
+
+        assert data["trace_id"] == "trace-1"
+        assert data["id"] == "child-1"
+        assert data["parent_run_id"] == "parent-1"
+
+    def test_caller_supplied_dotted_order_and_trace_id_are_untouched(self):
+        dotted = "20260820T000000000000Ztrace-1.20260820T000001000000Zrun-1"
+        data = self._prepare(
+            {
+                "trace_id": "trace-1",
+                "run_id": "run-1",
+                "dotted_order": dotted,
+            }
+        )
+
+        assert data["trace_id"] == "trace-1"
+        assert data["dotted_order"] == dotted


### PR DESCRIPTION
## TLDR

Problem this solves:

- Requests carrying a session/trace header never reach LangSmith
- One inconsistent run makes LangSmith drop the whole ingest batch

How it solves it:

- Root runs always post trace_id matching the id inside dotted_order
- session_id is dropped only when it mirrors the header-derived trace_id

## User Flow

Before: a developer whose requests carry a session header sees no traces in LangSmith at all

1. They send POST https://litellm-domain/v1/chat/completions with header `x-claude-code-session-id: ed29c3bb-...` (any session or trace header behaves the same)
2. The request returns 200 with a normal completion
3. They open their LangSmith project and the run is missing; the proxy log shows LangSmith answering 400 `invalid 'dotted_order': trace_id ed29c3bb-... does not match first part of dotted_order ...` and the entire batch is discarded

After: the same request produces a run in LangSmith

1. They send the same POST with the same header
2. The request returns 200 with a normal completion
3. They open their LangSmith project and the run is there, with trace_id equal to the run id and a consistent dotted_order
4. A caller who sets `metadata.session_id` to a real tracer-session id still sees the run grouped under that session

## Relevant issues

Fixes #37269

## Linear ticket

Resolves LIT-5878

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Shared setup: proxy launched from the tree under test with `python litellm/proxy/proxy_cli.py --config config.yaml --detailed_debug`, config enabling `callbacks: ["langsmith"]` with `langsmith_batch_size: 1` and one `gemini/gemini-2.5-flash` deployment, LangSmith EU SaaS project `litellm-lit5878` as the real destination. Every case is a real curl against the live proxy hitting the real Gemini API, with the outcome read back from LangSmith's own API

End-to-end demo at the PR tip in the real apps: a request sent from the LiteLLM Admin UI Playground, answered by the real Gemini API, and the resulting trace stored and rendered in the LangSmith UI

![e2e demo](https://raw.githubusercontent.com/yucheng-berri/opentelemetry-python-contrib/assets-pr38116/e2e_ui_demo.gif)

Stills: [request](https://raw.githubusercontent.com/yucheng-berri/opentelemetry-python-contrib/assets-pr38116/playground_request.png), [response](https://raw.githubusercontent.com/yucheng-berri/opentelemetry-python-contrib/assets-pr38116/playground_response.png), [trace in LangSmith](https://raw.githubusercontent.com/yucheng-berri/opentelemetry-python-contrib/assets-pr38116/langsmith_trace_ui_request.png). Public LangSmith share links for independent verification: [UI-sent run](https://eu.smith.langchain.com/public/90df3844-9e61-4746-9b0a-e366ac2bdd07/r) and [header-case run](https://eu.smith.langchain.com/public/db91de43-0f43-4c72-becf-0790834fc8db/r)

### Before (f005afa146)

#### session header on /v1/chat/completions

1. `curl http://localhost:4000/v1/chat/completions -H "Authorization: Bearer sk-..." -H "x-claude-code-session-id: ed29c3bb-44fa-4eec-9b7b-fecaa3e82d64" -d '{"model": "gemini-flash", "messages": [{"role": "user", "content": "say REPRO-WITH-HEADER"}]}'` returns 200
2. Proxy log: `Langsmith HTTP Error: 400 - {"error":"Bad request: invalid 'dotted_order': trace_id ed29c3bb-44fa-4eec-9b7b-fecaa3e82d64 does not match first part of dotted_order 0000995f-0e70-41f1-b390-b740793d91c4 for run_id:0000995f-... parent_run_id:<nil>"}`
3. LangSmith runs/query for the project: run absent, whole batch dropped

#### session header on /v1/messages

1. Same header on `curl http://localhost:4000/v1/messages ... -d '{"model": "gemini-flash", "max_tokens": 50, "messages": [{"role": "user", "content": "say BEFORE-ANTHROPIC-HEADER"}]}'` returns 200
2. Proxy log: `Langsmith HTTP Error: 400 ... trace_id ed29c3bb-... does not match first part of dotted_order 7f85052d-9dba-49ee-834f-10c0eeb997f3 ...`, run dropped

#### session header on /v1/responses

1. Same header on `curl http://localhost:4000/v1/responses ... -d '{"model": "gemini-flash", "input": "say BEFORE-RESPONSES-HEADER"}'` returns 200
2. Proxy log: `Langsmith HTTP Error: 400 ... trace_id ed29c3bb-... does not match first part of dotted_order b8b4a196-2725-4d69-aa6b-63a4f817b81c ...`, run dropped

#### x-litellm-session-id header on /v1/chat/completions

1. `curl ... -H "x-litellm-session-id: 22222222-3333-4444-5555-666666666666" -d '{... "say BEFORE-LITELLM-SESSION"}'` returns 200
2. Proxy log: `Langsmith HTTP Error: 400 ... trace_id 22222222-... does not match first part of dotted_order e95cac56-261b-4ff9-a696-65f85056976b ...`, run dropped

#### valid tracer-session id in body metadata

1. `curl ... -d '{... "say BEFORE-VALID-SESSION", "metadata": {"session_id": "9abdcc6f-d54e-449e-84d5-8cc5a033632f"}}'` returns 200
2. Proxy log: `Batch of 1 runs successfully created`, run lands (this case worked and must keep working)

#### control, no header

1. `curl ... -d '{... "say BEFORE-CONTROL"}'` returns 200
2. Proxy log: `Batch of 1 runs successfully created`, run lands

### After (a8c9940632, rebased code-identical onto staging as 534edf380f)

#### session header on /v1/chat/completions

1. Same curl with `x-claude-code-session-id: ed29c3bb-...` and marker `FINAL4-HEADER-UUID` returns 200
2. Proxy log: `Batch of 1 runs successfully created`, zero `Langsmith HTTP Error` lines in the whole run
3. LangSmith API read-back: `FINAL4-HEADER-UUID | id==trace True | dotted_ok True`
4. The same run rendered in the LangSmith UI (public share link above):

![header case trace in LangSmith](https://raw.githubusercontent.com/yucheng-berri/opentelemetry-python-contrib/assets-pr38116/langsmith_trace_header_case.png)

#### session header on /v1/messages

1. Same curl with marker `FINAL4-ANTHROPIC-HEADER` returns 200
2. Read-back: `FINAL4-ANTHROPIC-HEADER | id==trace True | dotted_ok True`

#### session header on /v1/responses

1. Same curl with marker `FINAL4-RESPONSES-HEADER` returns 200
2. Read-back: `FINAL4-RESPONSES-HEADER | id==trace True | dotted_ok True`

#### x-litellm-session-id header on /v1/chat/completions

1. Same curl with marker `FINAL4-LITELLM-SESSION` returns 200
2. Read-back: `FINAL4-LITELLM-SESSION | id==trace True | dotted_ok True`

#### valid tracer-session id in body metadata

1. Same curl with marker `FINAL4-VALID-SESSION` and `"metadata": {"session_id": "9abdcc6f-d54e-449e-84d5-8cc5a033632f"}` returns 200
2. Read-back: `FINAL4-VALID-SESSION | id==trace True | dotted_ok True`, grouped under tracer session `9abdcc6f-...`, so the documented session field keeps working

#### control, no header

1. Same curl with marker `FINAL4-CONTROL` returns 200
2. Read-back: `FINAL4-CONTROL | id==trace True | dotted_ok True`

## Type

🐛 Bug Fix

## Behavior changes

- A caller-supplied `metadata.trace_id` on a run that posts as a root (no `parent_run_id`, no `dotted_order`) is now overridden with the run id. At the current tip that combination never produced a stored run: LangSmith rejected the whole batch with the 400 above, so nothing working is lost. With `parent_run_id` or `dotted_order` supplied, the caller's `trace_id` is honored unchanged
- `metadata.session_id` is dropped only when it mirrors `metadata.trace_id` (the proxy header fan-out writes one header value into both keys). A distinct, deliberately set session id is forwarded exactly as before

## Caveats (if any)

- Child runs supplying `parent_run_id` without `dotted_order` still get a poisoned minted `dotted_order` (pre-existing, #7140)
- A W3C `baggage: session.id=...` header still poisons the batch via run-body session_id; verified pre-existing with identical 404s at the merge base, follow-up alongside #7140
- Overlaps #37677, which fixes only the dotted_order leg; verified live that header runs still drop there via the mirrored session_id
- Docs follow-up: BerriAI/litellm-docs#1009 notes the root-run override and the session_id constraints on the LangSmith page

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
