### PR TITLE
fix(responses): let cache-control injection reach the system prompt from instructions

### DIFF
--- a/litellm/integrations/anthropic_cache_control_hook.py
+++ b/litellm/integrations/anthropic_cache_control_hook.py
@@ -104,6 +104,13 @@ def _accepts_prompt_cache_breakpoint(block: object) -> bool:
     return isinstance(block, dict) and block.get("type") in OPENAI_PROMPT_CACHE_BREAKPOINT_BLOCK_TYPES
 
 
+# Set by a caller whose message list is not the one that goes upstream -- today the
+# Responses API layer, whose `instructions` only becomes a system message further down.
+# Tells this hook to hand role-targeted points to the pass holding the final messages
+# rather than spending them on a list that is still missing some of their targets.
+CARRY_UNMATCHED_MESSAGE_POINTS: Final = "_litellm_carry_unmatched_cache_control_points"
+
+
 class AnthropicCacheControlHook(CustomPromptManagement):
     def get_chat_completion_prompt(
         self,
@@ -128,6 +135,7 @@ class AnthropicCacheControlHook(CustomPromptManagement):
         - non_default_params: dict - params with any global cache controls
         """
         # Extract cache control injection points
+        carry_unmatched: Final = bool(non_default_params.pop(CARRY_UNMATCHED_MESSAGE_POINTS, False))
         injection_points: Final[list[CacheControlInjectionPoint]] = non_default_params.pop(
             "cache_control_injection_points", []
         )
@@ -161,12 +169,25 @@ class AnthropicCacheControlHook(CustomPromptManagement):
                 non_default_params.get("prompt_cache_options"),
             )
         )
+        # A provisional message list defers every role-targeted point to the pass holding
+        # the final one: a role with no message here may have one there, and settling all
+        # of them in one pass is what lets config order decide the shared breakpoint
+        # budget. An ordinal names a different message once a later layer builds its own
+        # list, so it is placed here or not at all.
+        carried_message_points: Final[Sequence[CacheControlMessageInjectionPoint]] = (
+            tuple(point for point in message_points if point.get("index") is None) if carry_unmatched else ()
+        )
+        applied_message_points: Final[Sequence[CacheControlMessageInjectionPoint]] = (
+            tuple(point for point in message_points if point.get("index") is not None)
+            if carry_unmatched
+            else tuple(message_points)
+        )
         reserved_blocks: Final = (
             1 if not openai_dialect and any(p.get("location") == "tool_config" for p in remaining_points) else 0
         )
         breakpoints_before: Final = AnthropicCacheControlHook._count_request_cache_breakpoints(processed_messages)
         processed_messages = self._apply_message_injections(
-            points=message_points,
+            points=applied_message_points,
             messages=processed_messages,
             max_blocks=MAX_CACHE_CONTROL_BLOCKS - reserved_blocks,
             openai_dialect=openai_dialect,
@@ -177,10 +198,15 @@ class AnthropicCacheControlHook(CustomPromptManagement):
         ):
             non_default_params.setdefault("prompt_cache_options", PromptCacheOptions(mode="explicit"))
 
-        # Pass through non-message injection points for provider-specific handling
-        if remaining_points:
+        # Points this pass did not place: non-message ones for the provider transform, and
+        # the deferred role-targeted ones. Deferring is what reaches the Responses API's
+        # `instructions`, which is only a system message once the bridge builds one. The
+        # judged stamp is what makes it safe: the next pass must not re-judge points
+        # against messages this pass already marked (see `_should_stand_down`).
+        carried_points: Final[Sequence[CacheControlInjectionPoint]] = (*remaining_points, *carried_message_points)
+        if carried_points:
             non_default_params["cache_control_injection_points"] = AnthropicCacheControlHook._stamped_as_judged(
-                remaining_points
+                carried_points
             )
 
         return model, processed_messages, non_default_params
@@ -218,7 +244,7 @@ class AnthropicCacheControlHook(CustomPromptManagement):
 
     @staticmethod
     def _apply_message_injections(
-        points: list[CacheControlMessageInjectionPoint],
+        points: Sequence[CacheControlMessageInjectionPoint],
         messages: list[AllMessageValues],
         max_blocks: int,
         openai_dialect: bool = False,

--- a/litellm/responses/main.py
+++ b/litellm/responses/main.py
@@ -1,6 +1,7 @@
 import asyncio
 import contextvars
-from collections.abc import Coroutine, Iterable, Mapping
+from collections.abc import Coroutine, Generator, Iterable, Mapping
+from contextlib import contextmanager
 from functools import partial
 from typing import TYPE_CHECKING, Any, Final, Literal, Optional, cast
 
@@ -13,6 +14,7 @@ from litellm.completion_extras.litellm_responses_transformation.transformation i
     LiteLLMResponsesTransformationHandler,
 )
 from litellm.constants import request_timeout
+from litellm.integrations.anthropic_cache_control_hook import CARRY_UNMATCHED_MESSAGE_POINTS
 from litellm.litellm_core_utils.asyncify import run_async_function
 from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObj
 from litellm.litellm_core_utils.prompt_templates.common_utils import (
@@ -390,6 +392,60 @@ async def aresponses_api_with_mcp(
     return response
 
 
+def _bridges_to_chat_completions(
+    responses_api_provider_config: BaseResponsesAPIConfig | None, use_chat_completions_api: bool
+) -> bool:
+    """Whether the request reaches its provider as a chat completion, not a Responses call."""
+    return responses_api_provider_config is None or use_chat_completions_api is True
+
+
+def _will_bridge_to_chat_completions(
+    model: str, custom_llm_provider: str | None, use_chat_completions_api: bool
+) -> bool:
+    """``_bridges_to_chat_completions`` for callers running before the provider config is resolved.
+
+    Resolving the config is a pure lookup, so this asks the same question the dispatch
+    asks rather than restating its condition. Both callers resolve the provider before
+    this runs, so the only way to be wrong is a prompt manager that moves the model
+    across the bridge boundary, which would leave the deferred points to a pass that
+    never comes.
+    """
+    normalized_model: Final = _normalize_openai_chat_completions_responses_model(model)
+    if custom_llm_provider is None:
+        return True
+    return _bridges_to_chat_completions(
+        ProviderConfigManager.get_provider_responses_api_config(
+            model=normalized_model[0], provider=custom_llm_provider
+        ),
+        use_chat_completions_api or normalized_model[1],
+    )
+
+
+@contextmanager
+def _prompt_management_sees_a_provisional_message_list(
+    kwargs: dict[str, Any],  # mutable-ok: the signal is read and popped out of the caller's own kwargs
+    bridged: bool,
+) -> Generator[None, None]:
+    """Tell the cache-control hook that this layer's messages are not the ones sent upstream.
+
+    A Responses request keeps its system prompt in ``instructions``, which only becomes a
+    system message when the chat-completion bridge builds one, so a role-targeted point
+    is placed by the bridge's pass rather than this one.
+
+    Only raised for a request that will be bridged. A provider serving Responses natively
+    gets no second pass, so this layer is the last one that can place anything and handing
+    a point forward there drops it.
+    """
+    if not bridged:
+        yield
+        return
+    kwargs[CARRY_UNMATCHED_MESSAGE_POINTS] = True
+    try:
+        yield
+    finally:
+        kwargs.pop(CARRY_UNMATCHED_MESSAGE_POINTS, None)
+
+
 @client
 async def aresponses(
     input: str | ResponseInputParam,
@@ -467,19 +523,25 @@ async def aresponses(
                 client_input: list[AllMessageValues] = [{"role": "user", "content": input}]
             else:
                 client_input = [item for item in input if isinstance(item, dict) and "role" in item]
-            (
-                model,
-                merged_input,
-                merged_optional_params,
-            ) = await litellm_logging_obj.async_get_chat_completion_prompt(
-                model=model,
-                messages=client_input,
-                non_default_params=kwargs,
-                prompt_id=prompt_id,
-                prompt_variables=prompt_variables,
-                prompt_label=kwargs.get("prompt_label", None),
-                prompt_version=kwargs.get("prompt_version", None),
-            )
+            with _prompt_management_sees_a_provisional_message_list(
+                kwargs,
+                bridged=_will_bridge_to_chat_completions(
+                    model, custom_llm_provider, bool(kwargs.get("use_chat_completions_api"))
+                ),
+            ):
+                (
+                    model,
+                    merged_input,
+                    merged_optional_params,
+                ) = await litellm_logging_obj.async_get_chat_completion_prompt(
+                    model=model,
+                    messages=client_input,
+                    non_default_params=kwargs,
+                    prompt_id=prompt_id,
+                    prompt_variables=prompt_variables,
+                    prompt_label=kwargs.get("prompt_label", None),
+                    prompt_version=kwargs.get("prompt_version", None),
+                )
             input = cast(
                 str | ResponseInputParam,
                 ResponsesAPIRequestUtils.merge_prompt_management_input(
@@ -566,6 +628,7 @@ def _apply_prompt_management_to_responses_call(
     litellm_logging_obj: LiteLLMLoggingObj | None,
     kwargs: dict[str, Any],
     local_vars: dict[str, object],
+    use_chat_completions_api: bool,
 ) -> tuple[str | ResponseInputParam, str, str | None]:
     async_merged: Final[Mapping[str, object] | None] = kwargs.pop("_async_prompt_merged_params", None)
     if async_merged is not None:
@@ -585,19 +648,23 @@ def _apply_prompt_management_to_responses_call(
     if isinstance(litellm_logging_obj, LiteLLMLoggingObj) and litellm_logging_obj.should_run_prompt_management_hooks(
         prompt_id=prompt_id, non_default_params=kwargs
     ):
-        (
-            model,
-            merged_input,
-            merged_optional_params,
-        ) = litellm_logging_obj.get_chat_completion_prompt(
-            model=model,
-            messages=client_input,
-            non_default_params=kwargs,
-            prompt_id=prompt_id,
-            prompt_variables=prompt_variables,
-            prompt_label=kwargs.get("prompt_label", None),
-            prompt_version=kwargs.get("prompt_version", None),
-        )
+        with _prompt_management_sees_a_provisional_message_list(
+            kwargs,
+            bridged=_will_bridge_to_chat_completions(model, custom_llm_provider, use_chat_completions_api),
+        ):
+            (
+                model,
+                merged_input,
+                merged_optional_params,
+            ) = litellm_logging_obj.get_chat_completion_prompt(
+                model=model,
+                messages=client_input,
+                non_default_params=kwargs,
+                prompt_id=prompt_id,
+                prompt_variables=prompt_variables,
+                prompt_label=kwargs.get("prompt_label", None),
+                prompt_version=kwargs.get("prompt_version", None),
+            )
         input = cast(
             str | ResponseInputParam,
             ResponsesAPIRequestUtils.merge_prompt_management_input(
@@ -961,6 +1028,7 @@ def responses(
             litellm_logging_obj=litellm_logging_obj,
             kwargs=kwargs,
             local_vars=local_vars,
+            use_chat_completions_api=use_chat_completions_api,
         )
 
         #########################################################
@@ -1063,7 +1131,7 @@ def responses(
         if _file_search_dispatch is not None:
             return _file_search_dispatch
 
-        if responses_api_provider_config is None or use_chat_completions_api is True:
+        if _bridges_to_chat_completions(responses_api_provider_config, use_chat_completions_api):
             return litellm_completion_transformation_handler.response_api_handler(
                 model=model,
                 input=input,

--- a/tests/test_litellm/responses/test_responses_api_request_body.py
+++ b/tests/test_litellm/responses/test_responses_api_request_body.py
@@ -41,9 +41,7 @@ def _minimal_responses_api_payload(response_id: str, model: str) -> dict:
                 "id": "msg_1",
                 "status": "completed",
                 "role": "assistant",
-                "content": [
-                    {"type": "output_text", "text": "Done.", "annotations": []}
-                ],
+                "content": [{"type": "output_text", "text": "Done.", "annotations": []}],
             }
         ],
         "parallel_tool_calls": True,
@@ -83,9 +81,9 @@ class MockResponse:
 def _assert_request_body_matches(request_body: dict, expected_body: dict) -> None:
     for key, expected_value in expected_body.items():
         assert key in request_body, f"Missing key in request body: {key}"
-        assert (
-            request_body[key] == expected_value
-        ), f"Mismatch for key {key}: got {request_body[key]!r}, expected {expected_value!r}"
+        assert request_body[key] == expected_value, (
+            f"Mismatch for key {key}: got {request_body[key]!r}, expected {expected_value!r}"
+        )
 
 
 @pytest.mark.asyncio
@@ -100,9 +98,7 @@ async def test_aresponses_context_management_and_shell_request_body_matches_expe
         "litellm.llms.custom_httpx.http_handler.AsyncHTTPHandler.post",
         new_callable=AsyncMock,
     ) as mock_post:
-        mock_post.return_value = MockResponse(
-            _minimal_responses_api_payload("resp_ctx_shell_test", "gpt-4o"), 200
-        )
+        mock_post.return_value = MockResponse(_minimal_responses_api_payload("resp_ctx_shell_test", "gpt-4o"), 200)
 
         await litellm.aresponses(
             model="openai/gpt-4o",
@@ -426,7 +422,18 @@ async def test_aresponses_websocket_strips_responses_routing_prefix_from_openai_
 
 
 _INJECTION_POINT_INPUT = [{"role": "system", "content": "You are terse."}, {"role": "user", "content": "hi"}]
-_SYSTEM_INJECTION_POINT = [{"location": "message", "role": "system"}]
+_SYSTEM_POINT = {"location": "message", "role": "system"}
+_USER_POINT = {"location": "message", "role": "user"}
+_SYSTEM_INJECTION_POINT = [_SYSTEM_POINT]
+_ANTHROPIC_MESSAGES_PAYLOAD = {
+    "id": "msg_1",
+    "type": "message",
+    "role": "assistant",
+    "model": "claude-sonnet-4-5",
+    "content": [{"type": "text", "text": "Done."}],
+    "stop_reason": "end_turn",
+    "usage": {"input_tokens": 10, "output_tokens": 5},
+}
 
 
 def _sent_body(mock_post) -> dict:
@@ -598,3 +605,178 @@ def test_responses_custom_api_base_sends_no_openai_markers():
         body = _sent_body(mock_post)
         assert body["input"] == _INJECTION_POINT_INPUT
         assert "prompt_cache_options" not in body
+
+
+@pytest.mark.asyncio
+async def test_injection_points_still_reach_a_native_responses_provider():
+    """Providers that serve Responses natively never reach the chat-completions bridge,
+    so this layer is their only chance to inject and must keep doing so."""
+    injected_client = AsyncHTTPHandler()
+    mock_post = AsyncMock(return_value=MockResponse(_minimal_responses_api_payload("resp_native", "gpt-5.6"), 200))
+    injected_client.post = mock_post
+
+    await litellm.aresponses(
+        model="openai/gpt-5.6",
+        api_key="fake-api-key",
+        input=copy.deepcopy(_INJECTION_POINT_INPUT),
+        cache_control_injection_points=copy.deepcopy(_SYSTEM_INJECTION_POINT),
+        client=injected_client,
+    )
+
+    body = _sent_body(mock_post)
+    assert body["input"][0]["content"][0]["prompt_cache_breakpoint"] == {"mode": "explicit"}
+    assert "cache_control_injection_points" not in body
+
+
+async def _bridged_body(mock_post, *, points, input, instructions="You are a documentation assistant."):
+    injected_client = AsyncHTTPHandler()
+    injected_client.post = mock_post
+
+    await litellm.aresponses(
+        model="anthropic/claude-sonnet-4-5",
+        api_key="fake-api-key",
+        instructions=instructions,
+        input=copy.deepcopy(input),
+        cache_control_injection_points=copy.deepcopy(points),
+        client=injected_client,
+    )
+    return _sent_body(mock_post)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "content",
+    [
+        pytest.param("hi", id="string-content"),
+        pytest.param([{"type": "input_text", "text": "hi there friend"}], id="list-content"),
+    ],
+)
+@pytest.mark.parametrize(
+    "points",
+    [
+        pytest.param([_SYSTEM_POINT], id="system-only"),
+        pytest.param([_USER_POINT, _SYSTEM_POINT], id="mixed-user-and-system"),
+    ],
+)
+async def test_instructions_are_marked_when_the_bridge_builds_the_system_message(points, content):
+    """The system prompt lives in `instructions`, which is not a message until the bridge
+    builds one, so the point targeting it matches nothing at the Responses layer.
+
+    Carrying it forward is what marks it at all. Carrying it *stamped* is what keeps a
+    second point that did match from stranding it: without the stamp the next pass reads
+    litellm's own marks as client breakpoints and stands the whole configuration down.
+    """
+    mock_post = AsyncMock(return_value=MockResponse(_ANTHROPIC_MESSAGES_PAYLOAD, 200))
+    body = await _bridged_body(mock_post, points=points, input=[{"role": "user", "content": content}])
+
+    assert body["system"][0]["cache_control"] == {"type": "ephemeral"}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("instructions", [None, "You are a documentation assistant."])
+async def test_positional_points_address_the_input_item_the_caller_indexed(instructions):
+    """`index` counts the caller's `input` items, and the Responses layer is where that
+    list still is, so a matched positional point must be spent there and never re-resolved
+    against the bridge's list, where the system message shifts every ordinal by one."""
+    mock_post = AsyncMock(return_value=MockResponse(_ANTHROPIC_MESSAGES_PAYLOAD, 200))
+    body = await _bridged_body(
+        mock_post,
+        points=[{"location": "message", "index": 0}],
+        input=[{"role": "user", "content": [{"type": "input_text", "text": "hi there friend"}]}],
+        instructions=instructions,
+    )
+
+    assert body["messages"][0]["content"][0]["cache_control"] == {"type": "ephemeral"}
+    if instructions:
+        assert "cache_control" not in json.dumps(body["system"])
+
+
+@pytest.mark.asyncio
+async def test_out_of_bounds_positional_points_are_not_revived_by_a_longer_list():
+    """An ordinal addresses the list in front of the pass that reads it.
+
+    Carrying one forward would re-resolve it against the bridge's longer list, where an
+    index that named nothing in the caller's `input` can land on a real message -- the
+    system prompt included. Positional points are resolved where they were written or not
+    at all.
+    """
+    mock_post = AsyncMock(return_value=MockResponse(_ANTHROPIC_MESSAGES_PAYLOAD, 200))
+    body = await _bridged_body(
+        mock_post,
+        points=[{"location": "message", "index": 1}],
+        input=[{"role": "user", "content": [{"type": "input_text", "text": "only item"}]}],
+    )
+
+    assert "cache_control" not in json.dumps(body["system"])
+    assert "cache_control" not in json.dumps(body["messages"])
+
+
+def _four_user_turns() -> list:
+    return [
+        item
+        for i in range(4)
+        for item in (
+            {"role": "user", "content": [{"type": "input_text", "text": f"msg{i}"}]},
+            {"role": "assistant", "content": [{"type": "output_text", "text": f"reply{i}", "annotations": []}]},
+        )
+    ]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "points,instructions,system_marked,marked_messages",
+    [
+        pytest.param([_SYSTEM_POINT, _USER_POINT], "You are terse.", True, [0, 2, 4], id="earlier-point-wins"),
+        pytest.param([_USER_POINT, _SYSTEM_POINT], "You are terse.", False, [0, 2, 4, 6], id="reversed-order-reverses"),
+        pytest.param([_USER_POINT, _SYSTEM_POINT], None, False, [0, 2, 4, 6], id="target-never-built-costs-nothing"),
+    ],
+)
+async def test_config_order_decides_who_wins_the_shared_breakpoint_budget(
+    points, instructions, system_marked, marked_messages
+):
+    """Injection points are honoured in config order, earlier ones winning scarce slots.
+
+    A role-targeted point is placed a pass later than a positional one, so the four
+    breakpoints it competes for are shared across both passes. Every role point being
+    settled in the pass that holds the final list -- rather than the earlier pass holding
+    a slot for one it cannot place -- is what keeps that competition ordered in both
+    directions, and what stops a point whose target is never built from costing anything.
+    """
+    mock_post = AsyncMock(return_value=MockResponse(_ANTHROPIC_MESSAGES_PAYLOAD, 200))
+    body = await _bridged_body(mock_post, points=points, input=_four_user_turns(), instructions=instructions)
+
+    assert ("cache_control" in json.dumps(body.get("system", []))) is system_marked
+    assert [i for i, msg in enumerate(body["messages"]) if "cache_control" in json.dumps(msg)] == marked_messages
+
+
+@pytest.mark.asyncio
+async def test_a_native_responses_provider_places_every_point_itself():
+    """A provider serving Responses natively gets no second pass.
+
+    This layer is the last one that can place anything, so handing a point forward here
+    drops it -- and an unmatchable point must not cost a matching one its slot either.
+    The request has to be known to be bridged before anything is deferred.
+    """
+    input_items = _four_user_turns()
+
+    async def _marked_indices(points):
+        injected_client = AsyncHTTPHandler()
+        mock_post = AsyncMock(return_value=MockResponse(_minimal_responses_api_payload("resp_native", "gpt-5.6"), 200))
+        injected_client.post = mock_post
+        await litellm.aresponses(
+            model="openai/gpt-5.6",
+            api_key="fake-api-key",
+            input=copy.deepcopy(input_items),
+            cache_control_injection_points=copy.deepcopy(points),
+            client=injected_client,
+        )
+        body = _sent_body(mock_post)
+        return [i for i, item in enumerate(body["input"]) if "prompt_cache_breakpoint" in json.dumps(item)]
+
+    user_only = await _marked_indices([_USER_POINT])
+    # The system point can never match here: nothing turns `instructions` into a message
+    # on the native path, so it must not cost the user point a slot.
+    with_unmatchable_system = await _marked_indices([_SYSTEM_POINT, _USER_POINT])
+
+    assert user_only == [0, 2, 4, 6]
+    assert with_unmatchable_system == user_only


### PR DESCRIPTION
## TLDR

Problem this solves:

- Cache-control auto-injection silently does nothing on the Responses API
- Affects every provider without a native Responses API, so no caching discount
- The system prompt lives in `instructions`, which the injection never looked at

How it solves it:

- The Responses layer hands role-targeted points to the pass that builds the system message
- The transformed chat-completion request then marks the system message it builds
- Providers with a native Responses API keep injecting exactly as before

## User Flow

Before: a developer configures prompt caching on an Anthropic deployment, sends Responses API traffic, and never gets a caching discount

1. Their admin configures the deployment with `cache_control_injection_points` targeting the system role
2. They send POST https://litellm-domain/v1/responses with their long system prompt in `instructions` and a short question in `input`
3. The response comes back with `cache_write_tokens: 0` and `cached_tokens: 0`, so nothing was ever cached
4. They repeat the same request and still see `cached_tokens: 0`, paying full price for the system prompt every single time
5. The same content sent to https://litellm-domain/v1/chat/completions as a system message does get cached, so the discount depends on which endpoint they picked

After: the same Responses request caches the system prompt and reads it back

1. Their admin configures the deployment the same way, with no config change
2. They send the same POST https://litellm-domain/v1/responses with the system prompt in `instructions`
3. The first response comes back with `cache_write_tokens: 3390`, so the system prompt was written to cache
4. They repeat the same request and the response now shows `cached_tokens: 3390` with `cache_write_tokens: 0`, charging roughly a tenth for that prefix
5. Both endpoints now behave the same way for the same content

## Relevant issues

## Linear ticket

Resolves LIT-6001

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally
- [x] My PR passes all required CI/CD checks
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5**

## How

`AnthropicCacheControlHook` spends the configured injection points on the first message
list it is shown, and drops the message points that matched nothing. That is right when
the messages it sees are the ones going upstream. On /v1/responses they are not: the
system prompt lives in `instructions` and only becomes a system message once the
chat-completion bridge builds one, so a role-targeted point matched nothing and was
thrown away before the message it wanted existed.

When the caller says its message list is provisional, the hook now hands every
role-targeted point to the pass that holds the final list, stamped as judged. The stamp
is the existing mechanism for this and it is load-bearing: without it the next pass
re-judges the points against messages this pass has already marked, reads litellm's own
marks as client breakpoints, and stands the whole configuration down. Callers holding the
final messages, /chat/completions and /v1/messages, do not raise the signal and behave
exactly as before.

Handing over all of them rather than only the ones that matched nothing is what keeps the
four-breakpoint cap honest. The two passes share one budget, and the second pass counts
the marks the first one made, so settling every role point in a single pass is what lets
config order decide who wins when slots are scarce, in both directions, with nothing
forecast and no slot reserved for a point that may never match.

A positional `index` addresses the list in front of the pass reading it, so it is placed
where it was written and never carried. It keeps counting the caller's own `input` items
and never slides onto the system message the bridge prepends.

## Proof of fix

Live proxy against a real Anthropic-backed deployment configured with `cache_control_injection_points` on the system role. Same payload throughout, system prompt in `instructions`.

Before the change, the request litellm sent upstream carried no `cache_control` at all, and instrumenting the injection counter showed it running once with a delta of 0. The gateway injected nothing.

After the change, the outgoing request carries the marker on the system block:

```
'system': [{'type': 'text', 'text': 'You are a documentation assistant...', 'cache_control': {'type': 'ephemeral'}}]
```

Driving it end to end, first call writes the cache and the repeat reads it:

```bash
curl -sS http://127.0.0.1:4000/v1/responses \
  -H "Authorization: Bearer $KEY" -H 'Content-Type: application/json' \
  --data @responses-with-instructions.json
```

```
responses+instructions call 1: cached=0     write=3390
responses+instructions call 2: cached=3390  write=0
```

For comparison, the equivalent `/v1/chat/completions` request with the same content produces a byte-identical upstream body apart from `max_tokens`, and the same cache behaviour, so this brings the two surfaces to parity.

Tests: 911 passed across the responses suites, the cache-control hook suite, and the
bedrock/openai transformation suites that also read injection points.

Every part of the rule is pinned by a test that fails when only that part is reverted:

```
test_instructions_are_marked_when_the_bridge_builds_the_system_message[system-only|mixed x string|list content]
test_positional_points_address_the_input_item_the_caller_indexed[with|without instructions]
test_out_of_bounds_positional_points_are_not_revived_by_a_longer_list
test_config_order_decides_who_wins_the_shared_breakpoint_budget[earlier-point-wins|reversed-order-reverses|target-never-built-costs-nothing]
test_a_native_responses_provider_places_every_point_itself
test_injection_points_still_reach_a_native_responses_provider
```

The HTTP tests inject an `AsyncHTTPHandler` through `client=` rather than patching a
litellm internal, matching the sibling pattern in this file and the TQ008 gate.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches prompt-management and cache-injection across two request passes; incorrect bridge detection could drop or mis-apply breakpoints, but behavior is gated to bridged Responses and covered by new tests.
> 
> **Overview**
> Fixes **silent failure** of `cache_control_injection_points` on `/v1/responses` when traffic is bridged to chat completions: the system prompt in `instructions` was not in the message list during the first hook pass, so role-targeted points (e.g. `role: system`) never applied.
> 
> **`AnthropicCacheControlHook`** now honors a `CARRY_UNMATCHED_MESSAGE_POINTS` signal: on a provisional message list it applies only **positional** (`index`) points, **defers all role-targeted** points to the next pass via `cache_control_injection_points` (stamped as judged), and keeps the shared four-breakpoint budget consistent across passes.
> 
> **Responses API** sets that signal only when `_will_bridge_to_chat_completions` is true (sync and async prompt-management paths), so native Responses providers still inject in one pass and unmatchable roles do not steal slots.
> 
> Adds HTTP-level tests for bridged Anthropic (`instructions` → `system` `cache_control`), index semantics, config-order budget sharing, and native OpenAI Responses behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b55ea07aebd9833b99f4357ed878686baf6931e4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

