### PR TITLE
docs: fix broken CONTRIBUTING and LICENSE links in proxy client README

### DIFF
--- a/litellm/proxy/client/README.md
+++ b/litellm/proxy/client/README.md
@@ -294,11 +294,11 @@ keys = client.keys.list(
 
 ## Contributing
 
-Contributions are welcome! Please check out our [contributing guidelines](../../CONTRIBUTING.md) for details.
+Contributions are welcome! Please check out our [contributing guidelines](../../../CONTRIBUTING.md) for details.
 
 ## License
 
-This project is licensed under the MIT License - see the [LICENSE](../../LICENSE) file for details.
+This project is licensed under the MIT License - see the [LICENSE](../../../LICENSE) file for details.
 
 ## CLI Authentication Flow
 


### PR DESCRIPTION
`litellm/proxy/client/README.md` links to `../../CONTRIBUTING.md` and `../../LICENSE`. From `litellm/proxy/client/`, `../../` resolves to the `litellm/` package directory, which contains neither file — both live at the repository root, so the links need `../../../`.

Docs only.