### PR TITLE
chore(codeowners): unown ui container plumbing and generated files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,9 @@
 /ui/ @yuneng-berri @ryan-crabbe-berri
 /litellm/proxy/_experimental/out/ @yuneng-berri @ryan-crabbe-berri
+/ui/Dockerfile @yuneng-berri
+/ui/nginx.conf @yuneng-berri
 /ui/litellm-dashboard/src/lib/http/schema.d.ts
+/ui/litellm-dashboard/tsconfig.tsbuildinfo
 /model_prices_and_context_window.json @mateo-berri
 /litellm/model_prices_and_context_window_backup.json @mateo-berri
 /litellm-proxy-extras/litellm_proxy_extras/migrations/ @yuneng-berri @ryan-crabbe-berri

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,7 +1,7 @@
 /ui/ @yuneng-berri @ryan-crabbe-berri
 /litellm/proxy/_experimental/out/ @yuneng-berri @ryan-crabbe-berri
-/ui/Dockerfile @yuneng-berri
-/ui/nginx.conf @yuneng-berri
+/ui/Dockerfile
+/ui/nginx.conf
 /ui/litellm-dashboard/src/lib/http/schema.d.ts
 /ui/litellm-dashboard/tsconfig.tsbuildinfo
 /model_prices_and_context_window.json @mateo-berri


### PR DESCRIPTION
## TLDR

Problem this solves:

- `/ui/` ownership sweeps in container plumbing, not dashboard code
- nginx.conf and the UI Dockerfile pull in dashboard reviewers
- A generated `tsconfig.tsbuildinfo` is checked in and owned

How it solves it:

- Unown `/ui/Dockerfile` and `/ui/nginx.conf` outright
- Exempt the generated tsbuildinfo entirely, like `schema.d.ts` already is

## User Flow

Not applicable: this changes repo review routing, not anything an end user of the gateway can observe

## Relevant issues

## Linear ticket

## Pre-Submission checklist

- [ ] I have added meaningful tests
- [x] The handful of test files covering my change pass locally
- [x] My PR passes all required CI/CD checks
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

### Before (a1134755ca)

1. `gh api "repos/BerriAI/litellm/codeowners/errors?ref=litellm_internal_staging"`

```
{"errors":[]}
```

2. `sed -n '1,3p' .github/CODEOWNERS` shows `/ui/` as the last rule matching `ui/nginx.conf`, `ui/Dockerfile`, and `ui/litellm-dashboard/tsconfig.tsbuildinfo`

```
/ui/ @yuneng-berri @ryan-crabbe-berri
/litellm/proxy/_experimental/out/ @yuneng-berri @ryan-crabbe-berri
/ui/litellm-dashboard/src/lib/http/schema.d.ts
```

### After (5ed83942dc)

1. `gh api "repos/BerriAI/litellm/codeowners/errors?ref=litellm_codeowners_ui_infra_exemptions"`

```
{"errors":[]}
```

2. `sed -n '1,6p' .github/CODEOWNERS` shows more specific rules now winning last-match for those three paths

```
/ui/ @yuneng-berri @ryan-crabbe-berri
/litellm/proxy/_experimental/out/ @yuneng-berri @ryan-crabbe-berri
/ui/Dockerfile
/ui/nginx.conf
/ui/litellm-dashboard/src/lib/http/schema.d.ts
/ui/litellm-dashboard/tsconfig.tsbuildinfo
```

3. Open any follow-up PR touching only `ui/nginx.conf` and the auto-requested reviewer list no longer includes me

## Type

🚄 Infrastructure

## Caveats (if any)

- Nobody owns the UI Dockerfile or nginx.conf now
- Whoever owns deploy infra can claim them in a follow-up

### Final Attestation

- [ ] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
