### PR TITLE
ci: raise three unit shard job timeouts to satisfy the startup safety gate

### DIFF
--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -211,7 +211,7 @@ jobs:
             workers: 2
             reruns: 2
             timeout-minutes: 20
-            job-timeout-minutes: 55
+            job-timeout-minutes: 60
 
           - shard: proxy-extras
             artifact-name: proxy-extras
@@ -219,7 +219,7 @@ jobs:
             workers: 2
             reruns: 2
             timeout-minutes: 20
-            job-timeout-minutes: 55
+            job-timeout-minutes: 60
 
           - shard: enterprise-package
             artifact-name: enterprise-package
@@ -227,7 +227,7 @@ jobs:
             workers: 4
             reruns: 2
             timeout-minutes: 20
-            job-timeout-minutes: 55
+            job-timeout-minutes: 60
 
           - shard: responses-caching-types
             artifact-name: responses-caching-types


### PR DESCRIPTION
## TLDR

Problem this solves:

- The code-quality startup safety gate is red on staging itself
- Three unit shards cap the job at 55m while pytest gets 20m and setup can take 35m plus overhead

How it solves it:

- Raises job-timeout-minutes to 60 on the caching, proxy-extras, and enterprise-package shards

## User Flow

Before: any branch rebased onto litellm_internal_staging fails the code-quality check on a workflow file it never touched

1. They push a rebased branch and open the checks page
2. code-quality fails with "Workflow startup invariants violated" naming test-unit.yml three times
3. The file is byte-identical to the base branch

After: the same push gets a green code-quality check

1. tests/code_coverage_tests/check_workflow_startup_safety.py prints "Workflow startup invariants hold (setup ceiling 35m)"

## Relevant issues

The 55m caps arrived alongside #37804's shard rework; the gate requires at least 60m so setup can never preempt pytest

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

### Before (merge base, current staging)

```
$ uv run python ./tests/code_coverage_tests/check_workflow_startup_safety.py
ERROR: Workflow startup invariants violated:
  - .github/workflows/test-unit.yml: job `unit` gives pytest 20m but caps the job at 55m ... (x3)
```

### After (PR tip d7d6014474)

```
$ uv run python ./tests/code_coverage_tests/check_workflow_startup_safety.py
Workflow startup invariants hold (setup ceiling 35m)
```
