### PR TITLE
fix(auto-router): list configured auto-routers in the usage picker before they have traffic

### DIFF
--- a/litellm/proxy/management_endpoints/auto_router_endpoints.py
+++ b/litellm/proxy/management_endpoints/auto_router_endpoints.py
@@ -36,6 +36,7 @@ from litellm.proxy.litellm_pre_call_utils import LiteLLMProxyRequestSetup
 from litellm.repositories.base_repository import SupportsModelDump
 from litellm.repositories.team_repository import TeamRepository
 from litellm.router_strategy.complexity_router import ComplexityRouter
+from litellm.router_utils.auto_router_model_naming import classify_strategy_router_model
 from litellm.types.management_endpoints.auto_router_endpoints import (
     SHADOW_EVAL_TURN_VALVE,
     AutoRouterBenchmarkGroup,
@@ -510,6 +511,53 @@ def _summed_agg_row(rows: Sequence[_SessionAggRow]) -> _SessionAggRow:
     )
 
 
+def _strategy_router_key(deployment: object) -> tuple[str, str] | None:
+    """``(model_name, kind)`` for a deployment whose routing the session rollup records.
+
+    Kinds come from ``classify_strategy_router_model``, the same rule the Router registers a
+    deployment by, so this arm cannot disagree with the arm that stamped ``router_type`` onto
+    the session rows. Semantic auto-routers return None: they record no routing decision, so
+    they can never own a session row, and ``AutoRouterBenchmarkGroup.router_type`` has no
+    value for them. A permanent zero would read as "no traffic" rather than "not instrumented".
+    """
+    if not isinstance(deployment, Mapping):
+        return None
+    litellm_params: Final = deployment.get("litellm_params")
+    router_name: Final = deployment.get("model_name")
+    if not (isinstance(litellm_params, Mapping) and isinstance(router_name, str) and router_name):
+        return None
+    model: Final = litellm_params.get("model")
+    if not isinstance(model, str):
+        return None
+    kind: Final = classify_strategy_router_model(model)
+    return None if kind is None or kind == "semantic" else (router_name, kind)
+
+
+def _idle_router_groups(
+    llm_router: "Router | None", covered: frozenset[tuple[str, str]]
+) -> tuple[AutoRouterBenchmarkGroup, ...]:
+    """Zeroed groups for configured strategy routers the window's traffic did not cover.
+
+    The dashboard's router picker has to list a router the moment it is created rather than
+    once it has spent something, so the registry drives the list and the rollup only supplies
+    the measures. ``_summed_agg_row`` over no sessions is already the zero element of the
+    fold, so a group with every measure at zero costs one relabel rather than a literal that
+    would go stale the next time the response grows a field.
+    """
+    if llm_router is None:
+        return ()
+    zero: Final = _summed_agg_row(())
+    idle: Final = frozenset(
+        key
+        for key in (_strategy_router_key(deployment) for deployment in llm_router.model_list or ())
+        if key is not None and key not in covered
+    )
+    return tuple(
+        _benchmark_group(zero.model_copy(update=MappingProxyType({"router_name": name, "router_type": kind})))
+        for name, kind in sorted(idle)
+    )
+
+
 @router.get(
     "/auto_router/benchmarks",
     tags=("auto router",),
@@ -532,8 +580,13 @@ async def get_auto_router_benchmarks(
     overlaps it: its last turn is on or after start_date and its first turn is on or before
     end_date. Overall hit rate is over telemetry-bearing turns; each bucket's hit rate is
     over that bucket's turns.
+
+    The rollup supplies the measures, never the list. Which routers appear comes from the
+    model registry, so one shows up as soon as it is configured and reads zero until it
+    serves traffic, and `routers_in_scope` counts those too rather than only the routers the
+    window recorded.
     """
-    from litellm.proxy.proxy_server import prisma_client
+    from litellm.proxy.proxy_server import llm_router, prisma_client
 
     _require_admin_viewer(user_api_key_dict, "view auto-router benchmarks across the deployment")
     if prisma_client is None:
@@ -555,11 +608,14 @@ async def get_auto_router_benchmarks(
         (end_day + timedelta(days=1)).isoformat(),
     )
     rows: Final = _SESSION_AGG_ROWS.validate_python(raw_rows or ())
-    groups: Final = tuple(_benchmark_group(row) for row in rows)
+    groups: Final = (
+        *(_benchmark_group(row) for row in rows),
+        *_idle_router_groups(llm_router, frozenset((row.router_name, row.router_type) for row in rows)),
+    )
     return AutoRouterBenchmarksResponse(
         start_date=start_day.strftime("%Y-%m-%d"),
         end_date=end_day.strftime("%Y-%m-%d"),
-        routers_in_scope=len(rows),
+        routers_in_scope=len(groups),
         totals=_benchmark_totals(_summed_agg_row(rows)),
         groups=groups,
     )

--- a/litellm/types/management_endpoints/auto_router_endpoints.py
+++ b/litellm/types/management_endpoints/auto_router_endpoints.py
@@ -158,9 +158,18 @@ class AutoRouterBenchmarksResponse(BaseModel):
 
     start_date: str = Field(description="Window start day, YYYY-MM-DD UTC, inclusive")
     end_date: str = Field(description="Window end day, YYYY-MM-DD UTC, inclusive")
-    routers_in_scope: int
+    routers_in_scope: int = Field(
+        description="How many groups this response carries. Every auto-router configured on the "
+        "proxy counts, whether or not it served anything in the window. To count only the routers "
+        "that did serve traffic, filter `groups` to the entries whose `sessions` is above zero"
+    )
     totals: AutoRouterBenchmarkTotals
-    groups: tuple[AutoRouterBenchmarkGroup, ...]
+    groups: tuple[AutoRouterBenchmarkGroup, ...] = Field(
+        description="One entry per auto-router, listed from the model registry rather than from "
+        "the rollup, so a router appears as soon as it is configured and reads zero until it "
+        "serves traffic. Semantic auto-routers are absent: they record no routing decision, so no "
+        "session can ever be attributed to them"
+    )
 
 
 ShadowEvalStatus: TypeAlias = Literal["running", "completed", "stopped"]

--- a/tests/test_litellm/proxy/management_endpoints/test_auto_router_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_auto_router_endpoints.py
@@ -2,6 +2,7 @@
 Unit tests for auto router management endpoints
 """
 
+from collections.abc import Mapping, Sequence
 from pathlib import Path
 from typing import Final
 
@@ -22,10 +23,21 @@ from litellm.proxy.management_endpoints.auto_router_endpoints import (
 from litellm.router import Router
 from litellm.types.utils import Choices, Message, ModelResponse
 from litellm.types.management_endpoints.auto_router_endpoints import (
+    AutoRouterBenchmarksResponse,
     AutoRouterRoutingTestRequest,
 )
 
 ADMIN = UserAPIKeyAuth(user_role=LitellmUserRoles.PROXY_ADMIN, api_key="sk-test", user_id="admin")
+
+
+def _deployment(model_name: str, model: str, *, db_model: bool) -> dict[str, object]:
+    """One entry as `Router.model_list` holds it, for either origin."""
+    return {
+        "model_name": model_name,
+        "litellm_params": {"model": model},
+        "model_info": {"id": f"{model_name}-{int(db_model)}", "db_model": db_model},
+    }
+
 
 TIERS = {
     "SIMPLE": ["cheap-model"],
@@ -295,6 +307,34 @@ def test_classifier_plugin_is_not_settable_over_http():
 class TestAutoRouterBenchmarks:
     from litellm.proxy.management_endpoints.auto_router_endpoints import _SessionAggRow
 
+    @pytest.fixture(autouse=True)
+    def _pin_the_router_global(self, monkeypatch: pytest.MonkeyPatch):
+        """Every test here reads proxy_server.llm_router, so no test may inherit a sibling's."""
+        from litellm.proxy import proxy_server
+
+        monkeypatch.setattr(proxy_server, "llm_router", None)
+
+    @staticmethod
+    async def _benchmarks(
+        monkeypatch: pytest.MonkeyPatch,
+        rows: Sequence[Mapping[str, object]],
+        model_list: Sequence[object],
+    ) -> AutoRouterBenchmarksResponse:
+        from litellm.proxy import proxy_server
+        from litellm.proxy.management_endpoints.auto_router_endpoints import get_auto_router_benchmarks
+
+        class _DB:
+            async def query_raw(self, sql: str, *params: object):
+                return rows
+
+        monkeypatch.setattr(proxy_server, "prisma_client", type("P", (), {"db": _DB()})())
+        monkeypatch.setattr(proxy_server, "llm_router", type("R", (), {"model_list": model_list})())
+        return await get_auto_router_benchmarks(
+            user_api_key_dict=ADMIN,
+            start_date="2026-07-01",
+            end_date="2026-08-01",
+        )
+
     ROW = _SessionAggRow(
         router_name="live-auto",
         router_type="complexity",
@@ -470,6 +510,113 @@ class TestAutoRouterBenchmarks:
             end_date="2026-08-01",
         )
         assert response.groups[0].tier_turns == expected
+
+    @pytest.mark.asyncio
+    async def test_the_picker_lists_configured_routers_before_they_have_traffic(self, monkeypatch: pytest.MonkeyPatch):
+        """A router must be selectable the moment it exists, from either origin.
+
+        `live-auto` is the only router the rollup knows about, so before this it was the only
+        thing the dropdown could offer. Both a config.yaml router and a DB-created one now
+        arrive zeroed, and neither moves the totals or duplicates the router that has traffic.
+        """
+        response = await self._benchmarks(
+            monkeypatch,
+            rows=[self.ROW.model_dump()],
+            model_list=[
+                _deployment("live-auto", "auto_router/complexity_router", db_model=False),
+                _deployment("idle-from-config", "auto_router/complexity_router", db_model=False),
+                _deployment("idle-from-db", "auto_router/complexity_router", db_model=True),
+            ],
+        )
+
+        by_name = {group.router_name: group for group in response.groups}
+        assert sorted(by_name) == ["idle-from-config", "idle-from-db", "live-auto"]
+        assert len(response.groups) == 3
+        assert response.routers_in_scope == 3
+        assert by_name["live-auto"].spend == 10.0
+        assert response.totals.spend == 10.0
+        assert response.totals.sessions == 4
+        for name in ("idle-from-config", "idle-from-db"):
+            idle = by_name[name]
+            assert idle.router_type == "complexity"
+            assert (idle.sessions, idle.turns, idle.spend, idle.saved_spend, idle.baseline_spend) == (
+                0,
+                0,
+                0.0,
+                0.0,
+                0.0,
+            )
+            assert (idle.saved_pct, idle.saved_per_session, idle.avg_turns_per_session) == (0.0, 0.0, 0.0)
+            assert (idle.cache.hit_rate_pct, idle.cache.coverage_pct) == (0.0, 0.0)
+            assert idle.cache.same_model.turns == idle.cache.return_to_tier.hits == 0
+            assert idle.tier_turns == {}
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "model, listed_as",
+        [
+            ("auto_router/complexity_router", "complexity"),
+            ("auto_router/adaptive_router", "adaptive"),
+            ("auto_router/quality_router", "quality"),
+            ("auto_router/my-semantic-router", None),
+            ("openai/gpt-5", None),
+        ],
+    )
+    async def test_only_kinds_whose_routing_the_rollup_records_are_listed(
+        self, model: str, listed_as: str | None, monkeypatch: pytest.MonkeyPatch
+    ):
+        """A semantic auto-router records no routing decision, so it can never own a session
+        row; listing it would show $0 forever even while it serves traffic."""
+        response = await self._benchmarks(
+            monkeypatch, rows=[], model_list=[_deployment("candidate", model, db_model=True)]
+        )
+
+        assert [group.router_type for group in response.groups] == ([listed_as] if listed_as else [])
+
+    @pytest.mark.asyncio
+    async def test_a_malformed_deployment_is_skipped_rather_than_failing_the_dashboard(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        response = await self._benchmarks(
+            monkeypatch,
+            rows=[self.ROW.model_dump()],
+            model_list=[
+                "not-a-mapping",
+                {},
+                {"model_name": "no-params"},
+                {"model_name": "", "litellm_params": {"model": "auto_router/complexity_router"}},
+                {"model_name": 7, "litellm_params": {"model": "auto_router/complexity_router"}},
+                {"model_name": "no-model", "litellm_params": {}},
+                {"model_name": "unreadable-model", "litellm_params": {"model": None}},
+            ],
+        )
+
+        assert [group.router_name for group in response.groups] == ["live-auto"]
+
+    @pytest.mark.asyncio
+    async def test_two_deployments_of_one_router_are_listed_once(self, monkeypatch: pytest.MonkeyPatch):
+        """Tagged variants share a model_name, and the picker selects by name and type."""
+        response = await self._benchmarks(
+            monkeypatch,
+            rows=[],
+            model_list=[
+                _deployment("tagged", "auto_router/complexity_router", db_model=True),
+                _deployment("tagged", "auto_router/complexity_router", db_model=True),
+            ],
+        )
+
+        assert [group.router_name for group in response.groups] == ["tagged"]
+
+    def test_the_listed_kinds_match_the_router_types_traffic_can_record(self):
+        """The one reason semantic is excluded, pinned against both declarations: a kind the
+        rollup can record must be listable, and a kind it cannot must not be."""
+        from typing import get_args, get_type_hints
+
+        from litellm.router_utils.auto_router_model_naming import StrategyRouterKind
+        from litellm.types.utils import StandardLoggingRoutingDecision
+
+        recorded = set(get_args(get_type_hints(StandardLoggingRoutingDecision)["router_type"]))
+        assert set(get_args(StrategyRouterKind)) - {"semantic"} == recorded
 
 
 # ---------------------------------------------------------------------------

--- a/ui/litellm-dashboard/src/lib/http/schema.d.ts
+++ b/ui/litellm-dashboard/src/lib/http/schema.d.ts
@@ -777,6 +777,11 @@ export interface paths {
          *     overlaps it: its last turn is on or after start_date and its first turn is on or before
          *     end_date. Overall hit rate is over telemetry-bearing turns; each bucket's hit rate is
          *     over that bucket's turns.
+         *
+         *     The rollup supplies the measures, never the list. Which routers appear comes from the
+         *     model registry, so one shows up as soon as it is configured and reads zero until it
+         *     serves traffic, and `routers_in_scope` counts those too rather than only the routers the
+         *     window recorded.
          */
         get: operations["get_auto_router_benchmarks_auto_router_benchmarks_get"];
         put?: never;
@@ -21965,9 +21970,15 @@ export interface components {
              * @description Window end day, YYYY-MM-DD UTC, inclusive
              */
             end_date: string;
-            /** Groups */
+            /**
+             * Groups
+             * @description One entry per auto-router, listed from the model registry rather than from the rollup, so a router appears as soon as it is configured and reads zero until it serves traffic. Semantic auto-routers are absent: they record no routing decision, so no session can ever be attributed to them
+             */
             groups: components["schemas"]["AutoRouterBenchmarkGroup"][];
-            /** Routers In Scope */
+            /**
+             * Routers In Scope
+             * @description How many groups this response carries. Every auto-router configured on the proxy counts, whether or not it served anything in the window. To count only the routers that did serve traffic, filter `groups` to the entries whose `sessions` is above zero
+             */
             routers_in_scope: number;
             /**
              * Start Date


### PR DESCRIPTION
## TLDR

Problem this solves:

- A new auto-router is missing from the usage picker
- It only appears once it has billed traffic
- The picker was built from spend rows, not the registry

How it solves it:

- The benchmarks endpoint now lists every configured auto-router
- Idle ones come back zeroed instead of absent
- Semantic auto-routers stay out; they record no routing decision

## User Flow

Before: an admin creates an auto-router, opens the cost dashboard to watch it, and cannot find it in the router picker

1. They create an auto-router at https://litellm-domain/ui/?page=llm-model-hub on the Auto-Routers tab, naming it `router-brand-new`
2. The Auto-Routers tab lists `router-brand-new` right away
3. They open https://litellm-domain/ui/?page=cost-optimization, pick the Auto-Router tab, then Usage
4. They open the router picker in the top right and see only routers that have already spent money
5. `router-brand-new` is absent, with nothing on screen saying why, so it reads as the router being broken or the dashboard being stale
6. It appears only after the router serves real traffic and that traffic is billed

After: the same router is selectable the moment it exists, reading zero until it serves something

1. They create an auto-router at https://litellm-domain/ui/?page=llm-model-hub on the Auto-Routers tab, naming it `router-brand-new`
2. The Auto-Routers tab lists `router-brand-new` right away
3. They open https://litellm-domain/ui/?page=cost-optimization, pick the Auto-Router tab, then Usage
4. They open the router picker and see `router-brand-new` alongside the routers that have traffic
5. Selecting it shows total estimated savings of $0.00 across 0 sessions, which is a true statement about a router nobody has called yet
6. The numbers fill in on their own once it serves traffic, with no second visit to the Models page needed

## Relevant issues

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

The picker is rendered straight from the `groups` array of `GET /auto_router/benchmarks`, so that response is what the dropdown can offer. Both legs run against the same proxy on port 4823, real Postgres, and real Anthropic models reached through a gateway upstream, costing real money. Only the code differs between the legs.

Shared setup, a config with one auto-router that gets traffic, one idle auto-router, and one semantic auto-router:

```yaml
model_list:
  - model_name: claude-haiku-real
    litellm_params: {model: openai/anthropic/claude-haiku-4-5, api_base: https://gateway-host/v1, api_key: os.environ/GATEWAY_KEY, input_cost_per_token: 1e-06, output_cost_per_token: 5e-06}
  - model_name: claude-sonnet-real
    litellm_params: {model: openai/anthropic/claude-sonnet-4-5, api_base: https://gateway-host/v1, api_key: os.environ/GATEWAY_KEY, input_cost_per_token: 3e-06, output_cost_per_token: 1.5e-05}
  - model_name: claude-opus-real
    litellm_params: {model: openai/anthropic/claude-opus-4-5, api_base: https://gateway-host/v1, api_key: os.environ/GATEWAY_KEY, input_cost_per_token: 5e-06, output_cost_per_token: 2.5e-05}
  - model_name: router-with-traffic
    litellm_params:
      model: auto_router/complexity_router
      complexity_router_default_model: claude-haiku-real
      complexity_router_config:
        tiers: {SIMPLE: claude-haiku-real, MEDIUM: claude-sonnet-real, COMPLEX: claude-opus-real, REASONING: claude-opus-real}
        classifier_type: llm
        classifier_llm_config: {model: claude-haiku-real, timeout_ms: 10000}
  - model_name: router-idle-config
    litellm_params:
      model: auto_router/complexity_router
      complexity_router_default_model: claude-haiku-real
      complexity_router_config:
        tiers: {SIMPLE: claude-haiku-real, MEDIUM: claude-sonnet-real, COMPLEX: claude-opus-real, REASONING: claude-opus-real}
        classifier_type: llm
        classifier_llm_config: {model: claude-haiku-real, timeout_ms: 10000}
  - model_name: router-semantic-idle
    litellm_params:
      model: auto_router/semantic-probe
      auto_router_default_model: claude-haiku-real
      auto_router_embedding_model: claude-haiku-real
      auto_router_config: '{"encoder_type": "openai", "routes": [{"name": "claude-sonnet-real", "utterances": ["write me a poem"]}]}'
```

Three real turns through the router that gets traffic, one per complexity tier, then a fourth auto-router created the way the dashboard creates one:

```bash
for i in 0 1 2; do
  curl -sS http://127.0.0.1:4823/v1/chat/completions -H "Authorization: Bearer $KEY" -H 'Content-Type: application/json' \
    -d "{\"model\":\"router-with-traffic\",\"messages\":[{\"role\":\"user\",\"content\":\"probe turn $i\"}],\"max_tokens\":64,\"litellm_session_id\":\"dropdown-repro\"}" \
    | python3 -c 'import json,sys; d=json.load(sys.stdin); print(d["model"], d["id"])'
done

curl -sS -X POST http://127.0.0.1:4823/model/new -H "Authorization: Bearer $KEY" -H 'Content-Type: application/json' \
  -d '{"model_name":"router-brand-new","litellm_params":{"model":"auto_router/complexity_router","complexity_router_default_model":"claude-haiku-real","complexity_router_config":{"tiers":{"SIMPLE":"claude-haiku-real","MEDIUM":"claude-sonnet-real","COMPLEX":"claude-opus-real","REASONING":"claude-opus-real"},"classifier_type":"llm","classifier_llm_config":{"model":"claude-haiku-real","timeout_ms":10000}}},"model_info":{"mode":"chat"}}'
```

```
router-with-traffic chatcmpl-792fc01a-acde-4c82-83cb-09c7cd6b1809
router-with-traffic chatcmpl-73ad8296-d9e8-4b86-8a59-835e8f00553b
router-with-traffic chatcmpl-b1e565b0-c2b3-46fe-99a1-fef8a5f896d2
POST /model/new -> 200 {"model_id":"ea477aca-f6f7-4794-aa38-dfe81379a750","model_name":"router-brand-new", ...}
```

### Before (b36f34813a)

#### The Models page lists four auto-routers

1. `curl -sS http://127.0.0.1:4823/v2/model/info -H "Authorization: Bearer $KEY" | python3 -c 'import json,sys; [print(" -", m["model_name"], m["litellm_params"]["model"]) for m in json.load(sys.stdin)["data"] if m["litellm_params"]["model"].startswith("auto_router/")]'`
2. Output:

```
 - router-with-traffic auto_router/complexity_router
 - router-idle-config auto_router/complexity_router
 - router-semantic-idle auto_router/semantic-probe
 - router-brand-new auto_router/complexity_router
```

#### The usage picker can offer only one of them

1. `curl -sS "http://127.0.0.1:4823/auto_router/benchmarks?start_date=2026-07-25&end_date=2026-08-24" -H "Authorization: Bearer $KEY" | python3 -c 'import json,sys; d=json.load(sys.stdin); print("routers_in_scope:", d["routers_in_scope"]); [print(" -", g["router_name"], g["router_type"], round(g["spend"],6), round(g["saved_spend"],6), g["sessions"]) for g in d["groups"]]'`
2. Output, the two idle complexity routers are simply absent:

```
routers_in_scope: 1
 - router-with-traffic complexity 0.002231 0.001184 1
```

### After (26e47aea32)

#### The Models page lists four auto-routers

1. Same command as above
2. Same output, unchanged:

```
 - router-with-traffic auto_router/complexity_router
 - router-idle-config auto_router/complexity_router
 - router-semantic-idle auto_router/semantic-probe
 - router-brand-new auto_router/complexity_router
```

#### The usage picker offers every instrumented auto-router

1. Same command as above
2. Output, both idle routers arrive zeroed, the config-defined one and the one created through `/model/new`, while the router with traffic keeps its real numbers and is listed once:

```
routers_in_scope: 3
 - router-with-traffic complexity 0.002231 0.001184 1
 - router-brand-new complexity 0.0 0.0 0
 - router-idle-config complexity 0.0 0.0 0
```

3. `router-semantic-idle` is deliberately still absent. A semantic auto-router records no routing decision, so it can never own a session row, and listing it would show $0 forever even while it serves traffic

#### Reviewer cross-process re-QA (two proxy processes, two uvicorn workers each)

The run above is single-process. Auto-router listing reads `llm_router.model_list`, per-process in-memory state, so this leg reruns before/after across two proxy processes sharing one Postgres, each booted `--num_workers 2`, and reads the endpoint back through the process that did not create the router. A pared-down config carries two idle strategy routers and no traffic-bearing one, so the before number is a clean zero.

Before (base b36f34813a, two workers), on port 25444:

`curl -sS "http://127.0.0.1:25444/auto_router/benchmarks?start_date=2026-07-25&end_date=2026-08-24" -H "Authorization: Bearer $KEY" | python3 -c 'import json,sys; d=json.load(sys.stdin); print("routers_in_scope:", d["routers_in_scope"]); [print(" -", g["router_name"], g["router_type"], round(g["spend"],6), g["sessions"]) for g in d["groups"]] or print(" (none)")'`

```
routers_in_scope: 0
 (none)
```

After (head 26e47aea32), two processes on ports 25442 and 25443 sharing one Postgres. A third router is created through `/model/new` on the 25442 process only:

`curl -sS -X POST http://127.0.0.1:25442/model/new -H "Authorization: Bearer $KEY" -H 'Content-Type: application/json' -d '{"model_name":"db-idle-complexity","litellm_params":{"model":"auto_router/complexity_router","complexity_router_default_model":"gpt-4o-mini","complexity_router_config":{"tiers":{"SIMPLE":"gpt-4o-mini","MEDIUM":"gpt-4o","COMPLEX":"claude-sonnet-4-20250514","REASONING":"o1-preview"}}},"model_info":{"mode":"chat"}}'`

Same benchmarks command against 25442 (the creating process) and 25443 (the other one) after the DB poll, both agree:

```
# port 25442
routers_in_scope: 3
 - db-idle-complexity complexity 0.0 0
 - idle-adaptive-router adaptive 0.0 0
 - idle-complexity-router complexity 0.0 0
# port 25443 (separate process, never handled the /model/new call)
routers_in_scope: 3
 - db-idle-complexity complexity 0.0 0
 - idle-adaptive-router adaptive 0.0 0
 - idle-complexity-router complexity 0.0 0
```

Both config-defined idle routers and the `/model/new`-created one come back zeroed and identical across the two processes, so the fix holds under the multi-pod topology and a second process reaches the registered routers through DB propagation.


Screenshots of the picker itself to follow, since this needs no dashboard change: the tab already builds its options from `groups`

## Type

🐛 Bug Fix

## Caveats (if any)

- Semantic auto-routers are excluded; they emit no routing telemetry
- Renaming a router leaves its old traffic under the old name
- `routers_in_scope` now counts idle routers too
- No new query; the rollup is still the only table read
- `code-quality` is red across staging; #38128 fixes it

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

- [x] 26e47aea32636c2ffd98e2b34047a06c22fab0b6 passes /live-pr-risk

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-path change to an admin benchmarks endpoint: no new DB queries, totals semantics preserved, and listing logic is defensive against bad `model_list` entries.
> 
> **Overview**
> **Fixes the cost dashboard router picker** showing only auto-routers that already had billed traffic in the selected window.
> 
> `GET /auto_router/benchmarks` now **merges rollup metrics with the proxy model registry** (`llm_router.model_list`): traffic still comes from the session rollup, but **configured strategy routers missing from that query get zeroed `groups` entries** via `_idle_router_groups` / `_strategy_router_key` and `classify_strategy_router_model`. **`routers_in_scope` counts all returned groups**, not just routers with sessions. **Semantic auto-routers stay excluded** (no routable `router_type` in telemetry); malformed or duplicate deployments are skipped/deduped without failing the endpoint. **Aggregate `totals` are unchanged**—still summed from rollup rows only.
> 
> Response/OpenAPI field descriptions and unit tests cover idle config vs DB routers, router kinds, and edge cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 26e47aea32636c2ffd98e2b34047a06c22fab0b6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
