### PR TITLE
refactor(utils)!: delete prompt_token_calculator

### DIFF
--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -6526,13 +6526,6 @@ def acreate(*args, **kwargs):  ## Thin client to handle the acreate langchain ca
     return litellm.acompletion(*args, **kwargs)
 
 
-def prompt_token_calculator(model, messages):
-    text: Final = " ".join(message["content"] for message in messages)
-    if "claude" in model:
-        return token_counter(model=model, text=text)
-    return len(_get_default_encoding().encode(text))
-
-
 def valid_model(model):
     try:
         # for a given model name, check if the user has the right permissions to access the model

--- a/ruff-strict-budget.json
+++ b/ruff-strict-budget.json
@@ -1,6 +1,6 @@
 {
   "ANN001": {
-    "limit": 3020
+    "limit": 3018
   },
   "ANN002": {
     "limit": 71
@@ -9,7 +9,7 @@
     "limit": 827
   },
   "ANN201": {
-    "limit": 2017
+    "limit": 2016
   },
   "ANN202": {
     "limit": 852

--- a/tests/test_litellm/test_utils.py
+++ b/tests/test_litellm/test_utils.py
@@ -1,7 +1,6 @@
 import json
 import logging
 import os
-import sys
 from typing import Final
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -42,7 +41,6 @@ from litellm.utils import (
     get_prompt_cache_min_tokens,
     is_cached_message,
     is_prompt_caching_valid_prompt,
-    prompt_token_calculator,
 )
 
 # Adds the parent directory to the system path
@@ -4976,19 +4974,3 @@ def test_completion_does_not_leak_rust_flag_into_provider_request_body():
     create_kwargs = mock_client.chat.completions.with_raw_response.create.call_args.kwargs
     assert "rust" not in create_kwargs
     assert "rust" not in (create_kwargs.get("extra_body") or {})
-
-
-def test_prompt_token_calculator_counts_claude_without_the_anthropic_sdk():
-    """
-    The claude branch used to call the anthropic SDK's `count_tokens`, which the SDK
-    removed, so every claude call raised AttributeError. Counting must work with
-    `anthropic` unimportable.
-    """
-    messages: Final = [{"role": "user", "content": "the quick brown fox jumps over the lazy dog"}]
-
-    with patch.dict(sys.modules, {"anthropic": None}):
-        claude_tokens = prompt_token_calculator("claude-sonnet-4-5", messages)
-        gpt_tokens = prompt_token_calculator("gpt-4o", messages)
-
-    assert claude_tokens == 9
-    assert gpt_tokens == 9


### PR DESCRIPTION
## TLDR

Problem this solves:

- `prompt_token_calculator` duplicates `token_counter` with no callers
- It hands claude ids straight through, so most get OpenAI tokenization
- Two entry points means the tokenizer question gets asked twice

How it solves it:

- Delete it; `token_counter` is the supported entry point
- Ratchet the strict budget for the annotations that went with it

## User Flow

Before: an SDK user counting claude tokens picks the wrapper and silently gets OpenAI tokenization for most claude ids

1. They call `litellm.utils.prompt_token_calculator("anthropic/claude-sonnet-4-5", messages)`
2. It returns `24` for a string the claude tokenizer counts as `27`, because only bare ids like `claude-sonnet-4-5` reach the claude tokenizer
3. Nothing signals the fallback, so the estimate is quietly wrong and they size their prompts against it

After: the wrapper is gone, so there is one entry point and the tokenizer question is asked in one place

1. They call `litellm.token_counter(model="anthropic/claude-sonnet-4-5", text=...)` and get the same number the rest of the library uses
2. `from litellm.utils import prompt_token_calculator` now raises ImportError, pointing them at the supported call rather than a second path that behaves differently

## Relevant issues

Follow-up to #38130

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

This is SDK surface with no proxy route in front of it, so the reproduction is the call an SDK consumer makes. Shared setup, `probe.py`:

```python
from litellm.utils import _select_tokenizer, token_counter

TEXT = "El zorro marrón rápido saltó sobre el perro perezoso 🦊🐕 tokenización"

for model in ("claude-sonnet-4-5", "claude-3-opus-20240229", "anthropic/claude-sonnet-4-5"):
    sel = _select_tokenizer(model)
    print(f"{model:32} tokenizer={sel['type']:22} count={token_counter(model=model, text=TEXT)}")
```

### Before (fdae9306d8)

#### the wrapper disagrees with itself across claude ids

1. Run the probe

```console
$ python probe.py
claude-sonnet-4-5                tokenizer=huggingface_tokenizer  count=27
claude-3-opus-20240229           tokenizer=openai_tokenizer       count=24
anthropic/claude-sonnet-4-5      tokenizer=openai_tokenizer       count=24
```

2. Two of the three claude ids are counted with the OpenAI tokenizer, and `prompt_token_calculator` hands all three straight through

#### the wrapper is importable

1. Import it

```console
$ python -c "from litellm.utils import prompt_token_calculator; print(prompt_token_calculator)"
<function prompt_token_calculator at 0x10a5a1300>
```

### After (0a1d601e4a)

#### the second entry point is gone

1. Import it

```console
$ python -c "from litellm.utils import prompt_token_calculator; print(prompt_token_calculator)"
ImportError: cannot import name 'prompt_token_calculator' from 'litellm.utils' (/Users/ryan/coding/litellm/litellm/utils.py)
```

#### the supported call is unchanged

1. Count with `token_counter`

```console
$ python -c "from litellm.utils import token_counter; print(token_counter(model='claude-sonnet-4-5', text='the quick brown fox jumps over the lazy dog'))"
9
```

## Type

🧹 Refactoring

## Caveats (if any)

- Breaking: `from litellm.utils import prompt_token_calculator` stops resolving
- `token_counter`'s own claude-id selection gap needs a separate fix

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
