### PR TITLE
fix(terraform): honor configured key on create

### DIFF
--- a/terraform/provider/CHANGELOG.md
+++ b/terraform/provider/CHANGELOG.md
@@ -20,6 +20,7 @@ longer signal it.
 
 ### Fixed
 
+- **key**: Honor caller-supplied write-only key values when creating `litellm_key` resources without overwriting token IDs during updates
 - **team**: Read now decodes the `team_info` envelope `/team/info` actually returns, so team attributes refresh from the proxy instead of always falling back to the prior state
 
 ### Changed

--- a/terraform/provider/litellm/resource_key.go
+++ b/terraform/provider/litellm/resource_key.go
@@ -145,6 +145,12 @@ func resourceKeyCreate(ctx context.Context, d *schema.ResourceData, m interface{
 
 	key := &Key{}
 	mapResourceDataToKey(d, key)
+	if rawConfig := d.GetRawConfig(); !rawConfig.IsNull() {
+		rawKey := rawConfig.GetAttr("key")
+		if rawKey.IsKnown() && !rawKey.IsNull() {
+			key.Key = rawKey.AsString()
+		}
+	}
 
 	createdKey, err := c.CreateKey(key)
 	if err != nil {

--- a/terraform/provider/litellm/resource_key_test.go
+++ b/terraform/provider/litellm/resource_key_test.go
@@ -1,0 +1,65 @@
+package litellm
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/hashicorp/go-cty/cty"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestResourceKeyCreateUsesConfiguredKey(t *testing.T) {
+	var payload Key
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/key/generate":
+			if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+				t.Error(err)
+			}
+		case "/key/info":
+		default:
+			http.NotFound(w, r)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(Key{Key: "sk-customer-managed", TokenID: "token-id"})
+	}))
+	defer server.Close()
+
+	d := resourceDataWithRawKey(t, "sk-customer-managed")
+	diags := resourceKeyCreate(context.Background(), d, NewClient(server.URL, "sk-master", false))
+
+	if diags.HasError() {
+		t.Fatalf("create returned diagnostics: %v", diags)
+	}
+	if payload.Key != "sk-customer-managed" {
+		t.Fatalf("configured key was dropped from create payload: got %q", payload.Key)
+	}
+}
+
+func TestMapResourceDataToKeyPreservesUpdateTokenID(t *testing.T) {
+	d := resourceDataWithRawKey(t, "sk-customer-managed")
+	key := &Key{Key: "token-id"}
+
+	mapResourceDataToKey(d, key)
+
+	if key.Key != "token-id" {
+		t.Fatalf("update token ID was overwritten: got %q", key.Key)
+	}
+}
+
+func resourceDataWithRawKey(t *testing.T, key string) *schema.ResourceData {
+	t.Helper()
+	d, err := schema.InternalMap(resourceKey().Schema).Data(nil, &terraform.InstanceDiff{
+		RawConfig: cty.ObjectVal(map[string]cty.Value{
+			"key": cty.StringVal(key),
+		}),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return d
+}


### PR DESCRIPTION
## TLDR

Problem this solves:

- Terraform silently drops caller-supplied LiteLLM keys
- Generated keys replace the requested credential

How it solves it:

- Reads the write-only value during resource creation
- Preserves token IDs during resource updates
- Adds create and update regression coverage

## User Flow

Before: an operator supplies a predetermined key, but LiteLLM creates a different credential

1. They configure `litellm_key` with a write-only `key` value
2. They run `tofu apply`, which sends POST `http://localhost:4000/key/generate`
3. Apply succeeds, but GET `http://localhost:4000/key/info?key=<configured-key>` returns 404

After: the same configuration creates and manages the requested credential

1. They configure `litellm_key` with the same write-only `key` value
2. They run `tofu apply`, which sends POST `http://localhost:4000/key/generate`
3. Apply succeeds, and GET `http://localhost:4000/key/info?key=<configured-key>` returns 200

## Relevant issues

Fixes BerriAI/terraform-provider-litellm#39

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The provider tests covering my change pass locally
- [ ] My PR passes all required CI/CD checks
- [x] My PR's scope is as isolated as possible
- [ ] I have received a Greptile Confidence Score of at least 4/5

## Screenshots / Proof of Fix

Shared setup: LiteLLM `v1.87.1`, PostgreSQL 16, OpenTofu `v1.12.3`, and one predetermined disposable key

### Before (85d5ac2b5c)

1. Built the provider at `85d5ac2b5c` and ran `tofu apply -auto-approve`
2. Compared state ID with the configured key SHA-256: `before_state_id_matches_sha256=false`
3. Queried the configured key: `before_configured_key_lookup_status=404`

### After (370e6b622b)

1. Built the provider at `370e6b622b` and ran the same `tofu apply -auto-approve`
2. Compared state ID with the configured key SHA-256: `after_state_id_matches_sha256=true`
3. Queried the configured key: `after_api_received_configured_key=true`, `after_key_alias_matches=true`
4. Ran `tofu plan -detailed-exitcode`: `after_noop_plan_exit=0`
5. Ran `tofu destroy` and queried again: `after_destroy_lookup_status=404`

## Type

Bug Fix

Test

## Caveats (if any)

## Final Attestation

- [x] The tests check creation and update token-ID preservation