### PR TITLE
fix(ci): give three unit shards a job deadline that outlasts their pytest budget

### DIFF
--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -211,7 +211,7 @@ jobs:
             workers: 2
             reruns: 2
             timeout-minutes: 20
-            job-timeout-minutes: 55
+            job-timeout-minutes: 60
 
           - shard: proxy-extras
             artifact-name: proxy-extras
@@ -219,7 +219,7 @@ jobs:
             workers: 2
             reruns: 2
             timeout-minutes: 20
-            job-timeout-minutes: 55
+            job-timeout-minutes: 60
 
           - shard: enterprise-package
             artifact-name: enterprise-package
@@ -227,7 +227,7 @@ jobs:
             workers: 4
             reruns: 2
             timeout-minutes: 20
-            job-timeout-minutes: 55
+            job-timeout-minutes: 60
 
           - shard: responses-caching-types
             artifact-name: responses-caching-types


### PR DESCRIPTION
## TLDR

Problem this solves:

- `code-quality` is red on staging, so every open PR inherits the failure
- Three unit shards can be killed mid-run before pytest reports

How it solves it:

- Raises `job-timeout-minutes` from 55 to 60 on those three shards
- Satisfies the checker's 20m pytest + 35m setup + 5m overhead rule

## User Flow

Before: a contributor opens a PR and sees `code-quality` fail with an error naming a workflow file they never touched

1. They open any PR against `litellm_internal_staging`
2. The `code-quality` check fails after about 2m30s
3. The log reads "Workflow startup invariants violated" for `.github/workflows/test-unit.yml`, three times
4. Nothing in their own diff relates to the error, so they cannot clear it from their branch

After: the same PR gets a green `code-quality` check

1. They open any PR against `litellm_internal_staging`
2. The `code-quality` check passes
3. The log reads "Workflow startup invariants hold (setup ceiling 35m)"

## Relevant issues

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally
- [x] My PR passes all required CI/CD checks
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

The invariant already has a dedicated checker in `tests/code_coverage_tests/check_workflow_startup_safety.py`, which is what catches this, so the regression test exists and no new one is warranted.

## Screenshots / Proof of Fix

### Before (ca32321612)

1. Run the checker at the merge base

```
$ uv run --no-sync --with pyyaml --with pydantic python ./tests/code_coverage_tests/check_workflow_startup_safety.py
ERROR: Workflow startup invariants violated:
  - .github/workflows/test-unit.yml: job `unit` gives pytest 20m but caps the job at 55m. Setup can use up to 35m plus 5m of runner overhead, so the job deadline would preempt pytest; raise job-timeout-minutes to at least 60.
  - .github/workflows/test-unit.yml: job `unit` gives pytest 20m but caps the job at 55m. Setup can use up to 35m plus 5m of runner overhead, so the job deadline would preempt pytest; raise job-timeout-minutes to at least 60.
  - .github/workflows/test-unit.yml: job `unit` gives pytest 20m but caps the job at 55m. Setup can use up to 35m plus 5m of runner overhead, so the job deadline would preempt pytest; raise job-timeout-minutes to at least 60.
$ echo $?
1
```

### After (7063c69c19)

1. Run the same checker at the PR tip

```
$ uv run --no-sync --with pyyaml --with pydantic python ./tests/code_coverage_tests/check_workflow_startup_safety.py
Workflow startup invariants hold (setup ceiling 35m)
$ echo $?
0
```

## Type

🚄 Infrastructure

## Caveats (if any)

- Raises only the ceiling, so a healthy shard's runtime is unchanged
