### PR TITLE
fix(bedrock): grant every routed action in the OIDC session policy

### DIFF
--- a/litellm/llms/bedrock/base_aws_llm.py
+++ b/litellm/llms/bedrock/base_aws_llm.py
@@ -67,6 +67,77 @@ class AwsAuthError(Exception):
         super().__init__(self.message)  # Call the base class constructor with the parameters it needs
 
 
+def build_bedrock_session_policy() -> dict[str, object]:
+    """Inline STS session policy sent with ``AssumeRoleWithWebIdentity``.
+
+    Pure and module-level so the policy contract is assertable without
+    standing up an STS client."""
+    # The session policy is an IAM PERMISSION CEILING — effective
+    # permissions are the intersection of the role's identity policies
+    # and this policy. Any action not listed here is silently denied
+    # even when the IAM role grants it. So every Bedrock route we
+    # support needs a matching action statement, or it 403s on OIDC
+    # auth only (static creds + IRSA take other code paths).
+    # https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRoleWithWebIdentity.html
+    # https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/sts/client/assume_role_with_web_identity.html
+    return {
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Sid": "BedrockLiteLLM",
+                "Effect": "Allow",
+                "Action": [
+                    "bedrock:InvokeModel",
+                    "bedrock:InvokeModelWithResponseStream",
+                    "bedrock:Converse",
+                    "bedrock:ConverseStream",
+                    "bedrock:CountTokens",
+                    "bedrock:StartAsyncInvoke",
+                    "bedrock:InvokeAgent",
+                    "bedrock:Rerank",
+                    "bedrock:Retrieve",
+                    "bedrock:GetAsyncInvoke",
+                    "bedrock:ListAsyncInvokes",
+                    "bedrock:ApplyGuardrail",
+                    "bedrock:GetGuardrail",
+                    "bedrock:ListGuardrails",
+                ],
+                "Resource": "*",
+                "Condition": {"Bool": {"aws:SecureTransport": "true"}},
+            },
+            # Claude Platform on AWS (added by #27678 for the
+            # ``bedrock/claude_platform/<model>`` route) lives under
+            # a separate IAM action namespace; without these entries
+            # the OIDC path 403s on every claude_platform request
+            # even with a fully permissive identity policy (#30200).
+            {
+                "Sid": "ClaudePlatformLiteLLM",
+                "Effect": "Allow",
+                "Action": [
+                    "aws-external-anthropic:CreateInference",
+                    "aws-external-anthropic:CreateBatchInference",
+                    "aws-external-anthropic:CancelBatchInference",
+                    "aws-external-anthropic:DeleteBatchInference",
+                    "aws-external-anthropic:CountTokens",
+                    "aws-external-anthropic:Get*",
+                    "aws-external-anthropic:List*",
+                ],
+                "Resource": "*",
+                "Condition": {"Bool": {"aws:SecureTransport": "true"}},
+            },
+            {
+                "Sid": "BedrockMantleLiteLLM",
+                "Effect": "Allow",
+                "Action": [
+                    "bedrock-mantle:CreateInference",
+                ],
+                "Resource": "*",
+                "Condition": {"Bool": {"aws:SecureTransport": "true"}},
+            },
+        ],
+    }
+
+
 class BaseAWSLLM:
     # Process-wide IAM credential cache (shared across instances — Bedrock passthrough is per-request).
     # Storage is in-process memory only: no Redis backend unless attached elsewhere. Entry TTL: static
@@ -842,62 +913,7 @@ class BaseAWSLLM:
         with tracer.trace("boto3.client(sts)"):
             sts_client: Final = boto3.client("sts", **sts_client_kwargs)
 
-        # The session policy is an IAM PERMISSION CEILING — effective
-        # permissions are the intersection of the role's identity policies
-        # and this policy. Any action not listed here is silently denied
-        # even when the IAM role grants it. So every Bedrock route we
-        # support needs a matching action statement, or it 403s on OIDC
-        # auth only (static creds + IRSA take other code paths).
-        # https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRoleWithWebIdentity.html
-        # https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/sts/client/assume_role_with_web_identity.html
-        bedrock_session_policy: Final = {
-            "Version": "2012-10-17",
-            "Statement": [
-                {
-                    "Sid": "BedrockLiteLLM",
-                    "Effect": "Allow",
-                    "Action": [
-                        "bedrock:InvokeModel",
-                        "bedrock:InvokeModelWithResponseStream",
-                        "bedrock:CountTokens",
-                        "bedrock:ApplyGuardrail",
-                        "bedrock:GetGuardrail",
-                        "bedrock:ListGuardrails",
-                    ],
-                    "Resource": "*",
-                    "Condition": {"Bool": {"aws:SecureTransport": "true"}},
-                },
-                # Claude Platform on AWS (added by #27678 for the
-                # ``bedrock/claude_platform/<model>`` route) lives under
-                # a separate IAM action namespace; without these entries
-                # the OIDC path 403s on every claude_platform request
-                # even with a fully permissive identity policy (#30200).
-                {
-                    "Sid": "ClaudePlatformLiteLLM",
-                    "Effect": "Allow",
-                    "Action": [
-                        "aws-external-anthropic:CreateInference",
-                        "aws-external-anthropic:CreateBatchInference",
-                        "aws-external-anthropic:CancelBatchInference",
-                        "aws-external-anthropic:DeleteBatchInference",
-                        "aws-external-anthropic:CountTokens",
-                        "aws-external-anthropic:Get*",
-                        "aws-external-anthropic:List*",
-                    ],
-                    "Resource": "*",
-                    "Condition": {"Bool": {"aws:SecureTransport": "true"}},
-                },
-                {
-                    "Sid": "BedrockMantleLiteLLM",
-                    "Effect": "Allow",
-                    "Action": [
-                        "bedrock-mantle:CreateInference",
-                    ],
-                    "Resource": "*",
-                    "Condition": {"Bool": {"aws:SecureTransport": "true"}},
-                },
-            ],
-        }
+        bedrock_session_policy: Final = build_bedrock_session_policy()
         assume_role_params: Final = {
             "RoleArn": aws_role_name,
             "RoleSessionName": aws_session_name,

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -51,6 +51,10 @@ def pytest_configure(config: pytest.Config) -> None:
         "markers",
         "weekly: real-provider anomaly load test that spends real money; deselected unless E2E_WEEKLY_ANOMALY is set",
     )
+    config.addinivalue_line(
+        "markers",
+        "bedrock_oidc: Bedrock over AssumeRoleWithWebIdentity; deselected unless E2E_BEDROCK_OIDC is set",
+    )
 
 
 def pytest_sessionstart(session: pytest.Session) -> None:

--- a/tests/e2e/e2e_config.py
+++ b/tests/e2e/e2e_config.py
@@ -133,6 +133,17 @@ LOAD_MAX_SERIAL_LATENCY_SECONDS = float(os.environ.get("E2E_LOAD_MAX_SERIAL_LATE
 LOAD_MIN_CONCURRENCY_EFFICIENCY = float(os.environ.get("E2E_LOAD_MIN_CONCURRENCY_EFFICIENCY", "0.8"))
 
 WEEKLY_ANOMALY_OPT_IN_ENV = "E2E_WEEKLY_ANOMALY"
+
+# Bedrock over OIDC/web-identity. Opt-in because the STS session policy this
+# exercises is only reached when the proxy calls AssumeRoleWithWebIdentity
+# itself, which needs an IAM OIDC provider trusting the cluster issuer plus a
+# role granting the Bedrock actions. Ambient IRSA and static keys take other
+# code paths and never apply the policy, so without that infra there is
+# nothing to assert against.
+BEDROCK_OIDC_OPT_IN_ENV = "E2E_BEDROCK_OIDC"
+BEDROCK_OIDC_ROLE_ARN_ENV = "E2E_BEDROCK_OIDC_ROLE_ARN"
+BEDROCK_OIDC_TOKEN_ENV = "E2E_BEDROCK_OIDC_TOKEN"
+BEDROCK_OIDC_DEFAULT_TOKEN = "oidc/file//var/run/secrets/eks.amazonaws.com/serviceaccount/token"
 ANOMALY_SESSIONS = int(os.environ.get("E2E_ANOMALY_SESSIONS", "6"))
 ANOMALY_TURNS_PER_SESSION = int(os.environ.get("E2E_ANOMALY_TURNS_PER_SESSION", "6"))
 ANOMALY_TURN_ATTEMPTS = int(os.environ.get("E2E_ANOMALY_TURN_ATTEMPTS", "3"))

--- a/tests/e2e/llm_translation/conftest.py
+++ b/tests/e2e/llm_translation/conftest.py
@@ -5,8 +5,11 @@ live in the parent tests/e2e/conftest.py. PassthroughClient holds the shared
 ProxyClient, so the `resources` fixture cleans up keys this suite creates.
 """
 
+import os
+
 import pytest
 
+from e2e_config import BEDROCK_OIDC_OPT_IN_ENV
 from endpoints_client import EndpointsClient, build_endpoints_client
 from passthrough_client import PassthroughClient, build_client
 from proxy_client import ProxyClient
@@ -17,6 +20,22 @@ def pytest_configure(config: pytest.Config) -> None:
         "markers",
         "covers: registry cell a test covers, e.g. llm.chat_completions.provider.basic.nonstream.works",
     )
+
+
+def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item]) -> None:
+    """Drop the Bedrock web-identity tests unless the operator opted in.
+
+    Deselection, not skipping: the suite hard-fails rather than skips, so a
+    test whose IAM prerequisites are absent must never be collected in the
+    first place. Mirrors load/conftest.py's weekly gate.
+    """
+    if os.environ.get(BEDROCK_OIDC_OPT_IN_ENV):
+        return
+    deselected = [item for item in items if item.get_closest_marker("bedrock_oidc") is not None]
+    if not deselected:
+        return
+    config.hook.pytest_deselected(items=deselected)
+    items[:] = [item for item in items if item.get_closest_marker("bedrock_oidc") is None]
 
 
 @pytest.fixture(scope="session")

--- a/tests/e2e/llm_translation/test_bedrock_web_identity_e2e.py
+++ b/tests/e2e/llm_translation/test_bedrock_web_identity_e2e.py
@@ -28,10 +28,11 @@ from e2e_config import (
     BEDROCK_OIDC_TOKEN_ENV,
     unique_marker,
 )
-from e2e_http import require_successful_call, unwrap
+from e2e_http import Result, Success, UnauthorizedError, UnknownApiError
 from endpoints_client import EndpointsClient, RerankResult
 from lifecycle import ResourceManager
-from models import CountTokensBody, ChatMessage, LiteLLMParamsBody
+from models import ChatMessage, CountTokensBody, LiteLLMParamsBody
+from pydantic import BaseModel
 
 pytestmark = [pytest.mark.e2e, pytest.mark.bedrock_oidc]
 
@@ -44,6 +45,42 @@ DOCUMENTS = [
     "Capital punishment has existed in the United States since before it was a country.",
 ]
 QUERY = "What is the capital of the United States?"
+
+
+# AWS says this when a session policy is what denied the call, as opposed to
+# the role's own identity policy or a missing model grant. It is the only thing
+# in a 403 body that distinguishes a ceiling omission from a misconfigured role,
+# which matters because both surface as the same status code.
+_CEILING_DENIAL_SIGNATURE = "no session policy allows"
+
+
+def _attribute_failure(body: str, status_code: int, action: str) -> str:
+    """Explain a non-2xx in terms of what a maintainer should go fix."""
+    if _CEILING_DENIAL_SIGNATURE in body:
+        return (
+            f"{action} is missing from the BedrockLiteLLM session policy in "
+            f"build_bedrock_session_policy(). AWS denied the call at the ceiling, so the "
+            f"assumed role's own permissions are irrelevant. Body: {body[:400]}"
+        )
+    return (
+        f"Bedrock returned {status_code}, but not a session-policy denial, so this is a "
+        f"credentials or configuration problem with the assumed role rather than the "
+        f"ceiling this test covers. Check that the role grants {action} and that the model "
+        f"is enabled in the region. Body: {body[:400]}"
+    )
+
+
+def _unwrap_authorized[R: BaseModel](result: Result[R], action: str) -> R:
+    """unwrap(), but a failure says whether the ceiling or the role is at fault."""
+    match result:
+        case Success(data=data):
+            return data
+        case UnknownApiError(status_code=status_code, body=body):
+            raise AssertionError(_attribute_failure(body, status_code, action))
+        case UnauthorizedError(body=body):
+            raise AssertionError(_attribute_failure(body, 401, action))
+        case _:
+            raise AssertionError(f"{action} call did not reach Bedrock: {result}")
 
 
 def _require_role_arn() -> str:
@@ -89,7 +126,7 @@ class TestBedrockWebIdentitySessionPolicy:
             key,
             CountTokensBody(model=model, messages=[ChatMessage(role="user", content="hello")]),
         )
-        counted = unwrap(result)
+        counted = _unwrap_authorized(result, "bedrock:CountTokens")
         assert counted.input_tokens > 0, f"count_tokens returned {counted.input_tokens} tokens"
 
     def test_rerank_is_authorized(
@@ -102,6 +139,6 @@ class TestBedrockWebIdentitySessionPolicy:
         key = resources.key()
 
         result = endpoints_client.rerank(key, model, QUERY, DOCUMENTS, top_n=2)
-        require_successful_call(result)
+        assert result.ok, _attribute_failure(result.body, result.status_code, "bedrock:Rerank")
         parsed = RerankResult.model_validate_json(result.body)
         assert parsed.results, f"/rerank returned no results: {result.body[:300]}"

--- a/tests/e2e/llm_translation/test_bedrock_web_identity_e2e.py
+++ b/tests/e2e/llm_translation/test_bedrock_web_identity_e2e.py
@@ -1,0 +1,107 @@
+"""Live e2e: Bedrock routes reached over AssumeRoleWithWebIdentity.
+
+When the proxy authenticates to Bedrock with a web identity token it attaches
+an inline STS session policy, and that policy is a permission ceiling:
+effective permissions are the intersection with the assumed role's identity
+policy, so a route whose IAM action the ceiling omits returns 403 no matter how
+permissive the role is. Static keys and ambient IRSA resolve credentials
+through other code paths that never attach the policy, which is why every other
+Bedrock test in this suite stays green while these routes are broken.
+
+That omission has shipped repeatedly: #30200 (claude_platform), Bedrock Mantle,
+and #33142 / #37336 (`/count-tokens`). Each test below drives one route that
+403s when its action is missing from the ceiling.
+
+Deselected unless E2E_BEDROCK_OIDC is set, because reaching this path needs an
+IAM OIDC provider trusting the cluster's issuer and a role granting the Bedrock
+actions. See the PR's QA runbook for the provisioning steps.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+from e2e_config import (
+    BEDROCK_OIDC_DEFAULT_TOKEN,
+    BEDROCK_OIDC_ROLE_ARN_ENV,
+    BEDROCK_OIDC_TOKEN_ENV,
+    unique_marker,
+)
+from e2e_http import require_successful_call, unwrap
+from endpoints_client import EndpointsClient, RerankResult
+from lifecycle import ResourceManager
+from models import CountTokensBody, ChatMessage, LiteLLMParamsBody
+
+pytestmark = [pytest.mark.e2e, pytest.mark.bedrock_oidc]
+
+CHAT_MODEL = "bedrock/us.anthropic.claude-haiku-4-5-20251001-v1:0"
+RERANK_MODEL = "bedrock/arn:aws:bedrock:us-east-1::foundation-model/cohere.rerank-v3-5:0"
+
+DOCUMENTS = [
+    "Carson City is the capital city of the American state of Nevada.",
+    "Washington, D.C. is the capital of the United States.",
+    "Capital punishment has existed in the United States since before it was a country.",
+]
+QUERY = "What is the capital of the United States?"
+
+
+def _require_role_arn() -> str:
+    """Hard-fail rather than skip: the opt-in env is set, so the operator
+    asserted this infrastructure exists."""
+    role_arn = os.environ.get(BEDROCK_OIDC_ROLE_ARN_ENV)
+    assert role_arn, (
+        f"{BEDROCK_OIDC_ROLE_ARN_ENV} must name the IAM role to assume when "
+        f"the {BEDROCK_OIDC_TOKEN_ENV} web identity token is presented."
+    )
+    return role_arn
+
+
+def _web_identity_params(model: str) -> LiteLLMParamsBody:
+    """A deployment the proxy must authenticate via AssumeRoleWithWebIdentity.
+
+    All three of token, role, and session name are required together; drop any
+    one and credential resolution silently falls through to a path that never
+    applies the session policy, so the test would pass without proving anything.
+    """
+    return LiteLLMParamsBody(
+        model=model,
+        aws_web_identity_token=os.environ.get(BEDROCK_OIDC_TOKEN_ENV, BEDROCK_OIDC_DEFAULT_TOKEN),
+        aws_role_name=_require_role_arn(),
+        aws_session_name=f"e2e-oidc-{unique_marker()}",
+        aws_region_name="os.environ/AWS_REGION",
+    )
+
+
+class TestBedrockWebIdentitySessionPolicy:
+    """Each route here 403s when the session policy omits its IAM action."""
+
+    def test_count_tokens_is_authorized(
+        self, endpoints_client: EndpointsClient, resources: ResourceManager
+    ) -> None:
+        """Regression for #33142 / #37336: needs bedrock:CountTokens."""
+        model = f"e2e-oidc-count-tokens-{unique_marker()}"
+        model_id = endpoints_client.create_model(model, _web_identity_params(CHAT_MODEL))
+        resources.defer(lambda: endpoints_client.delete_model(model_id))
+        key = resources.key()
+
+        result = endpoints_client.proxy.count_tokens(
+            key,
+            CountTokensBody(model=model, messages=[ChatMessage(role="user", content="hello")]),
+        )
+        counted = unwrap(result)
+        assert counted.input_tokens > 0, f"count_tokens returned {counted.input_tokens} tokens"
+
+    def test_rerank_is_authorized(
+        self, endpoints_client: EndpointsClient, resources: ResourceManager
+    ) -> None:
+        """Needs bedrock:Rerank, which the ceiling omitted entirely."""
+        model = f"e2e-oidc-rerank-{unique_marker()}"
+        model_id = endpoints_client.create_model(model, _web_identity_params(RERANK_MODEL))
+        resources.defer(lambda: endpoints_client.delete_model(model_id))
+        key = resources.key()
+
+        result = endpoints_client.rerank(key, model, QUERY, DOCUMENTS, top_n=2)
+        require_successful_call(result)
+        parsed = RerankResult.model_validate_json(result.body)
+        assert parsed.results, f"/rerank returned no results: {result.body[:300]}"

--- a/tests/e2e/models.py
+++ b/tests/e2e/models.py
@@ -747,6 +747,7 @@ class LiteLLMParamsBody(BaseModel):
     s3_secret_access_key: str | None = None
     aws_batch_role_arn: str | None = None
     aws_role_name: str | None = None
+    aws_web_identity_token: str | None = None
     aws_session_name: str | None = None
     aws_external_id: str | None = None
     input_cost_per_token: float | None = None

--- a/tests/test_litellm/llms/bedrock/test_web_identity_session_policy.py
+++ b/tests/test_litellm/llms/bedrock/test_web_identity_session_policy.py
@@ -31,10 +31,16 @@ action.
 
 import base64
 import json
+import re
 from datetime import datetime, timedelta, timezone
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
+from pydantic import BaseModel
+
+import litellm.llms.bedrock.base_aws_llm as _bedrock_base
+from litellm.llms.bedrock.base_aws_llm import build_bedrock_session_policy
 
 # Actions the Claude Platform on AWS service is documented to call.
 # Source: AWS IAM action reference + the #27678 surface area.
@@ -308,3 +314,116 @@ class TestPolicyTransportConditions:
             "ClaudePlatformLiteLLM must require aws:SecureTransport=true "
             "to keep parity with the bedrock statement"
         )
+
+
+# Every Bedrock runtime path LiteLLM builds, mapped to the IAM action that
+# authorizes it. The session policy is a ceiling, so a route whose action is
+# absent here 403s on OIDC auth no matter what the role's identity policy
+# grants. Three incidents share this shape: #30200 (claude_platform ->
+# aws-external-anthropic:*), Bedrock Mantle, and #33142/#37336
+# (/count-tokens -> bedrock:CountTokens).
+#
+# Converse maps to bedrock:InvokeModel because AWS originally authorized the
+# Converse API through the InvokeModel action; the dedicated bedrock:Converse
+# action came later and is granted too, per the inference prerequisites doc.
+# https://docs.aws.amazon.com/bedrock/latest/userguide/inference-prereq.html
+_ROUTE_SUFFIX_TO_ACTION = {
+    "invoke": "bedrock:InvokeModel",
+    "invoke-with-response-stream": "bedrock:InvokeModelWithResponseStream",
+    "converse": "bedrock:InvokeModel",
+    "converse-stream": "bedrock:InvokeModelWithResponseStream",
+    "count-tokens": "bedrock:CountTokens",
+    "async-invoke": "bedrock:StartAsyncInvoke",
+    "agents": "bedrock:InvokeAgent",
+    "knowledgebases": "bedrock:Retrieve",
+    "rerank": "bedrock:Rerank",
+}
+
+_BEDROCK_ACTIONS = frozenset(
+    {
+        "bedrock:InvokeModel",
+        "bedrock:InvokeModelWithResponseStream",
+        "bedrock:Converse",
+        "bedrock:ConverseStream",
+        "bedrock:CountTokens",
+        "bedrock:StartAsyncInvoke",
+        "bedrock:InvokeAgent",
+        "bedrock:Rerank",
+        "bedrock:Retrieve",
+        "bedrock:GetAsyncInvoke",
+        "bedrock:ListAsyncInvokes",
+        "bedrock:ApplyGuardrail",
+        "bedrock:GetGuardrail",
+        "bedrock:ListGuardrails",
+    }
+)
+
+# Matches the runtime path suffixes the bedrock package builds, e.g.
+# f"{endpoint_url}/model/{modelId}/converse" or f"{endpoint_url}/async-invoke".
+_ROUTE_URL_RE = re.compile(r"\{(?:proxy_)?endpoint_url[^}]*\}(?:/model/\{[^}]+\})?/([a-z][a-z-]*)")
+
+
+def _routes_built_by_bedrock_package() -> set[str]:
+    """Scan the bedrock package for the runtime path suffixes it constructs.
+
+    Source-derived rather than hardcoded so a newly added route fails this
+    test until its IAM action is mapped, which is the omission the three
+    incidents above all share.
+    """
+    package = Path(_bedrock_base.__file__).parent
+    return {
+        match.group(1)
+        for path in package.rglob("*.py")
+        for match in _ROUTE_URL_RE.finditer(path.read_text(encoding="utf-8"))
+    }
+
+
+class _PolicyStatement(BaseModel):
+    Sid: str
+    Effect: str
+    Action: list[str]
+
+
+class _SessionPolicy(BaseModel):
+    Version: str
+    Statement: list[_PolicyStatement]
+
+
+def _bedrock_granted_actions() -> set[str]:
+    policy = _SessionPolicy.model_validate(build_bedrock_session_policy())
+    statement = next(s for s in policy.Statement if s.Sid == "BedrockLiteLLM")
+    assert statement.Effect == "Allow"
+    return set(statement.Action)
+
+
+class TestSessionPolicyCoversEveryBedrockRoute:
+    """The ceiling must authorize every route the package can actually call."""
+
+    def test_every_built_route_has_a_mapped_action(self):
+        unmapped = _routes_built_by_bedrock_package() - _ROUTE_SUFFIX_TO_ACTION.keys()
+        assert not unmapped, (
+            f"Bedrock routes {sorted(unmapped)} are built by litellm/llms/bedrock but have no "
+            "IAM action mapped in _ROUTE_SUFFIX_TO_ACTION. Add the mapping, then make sure the "
+            "action is granted in the BedrockLiteLLM session-policy statement, or OIDC-auth "
+            "callers will 403 on that route (#30200, #33142, #37336)."
+        )
+
+    @pytest.mark.parametrize(
+        ("suffix", "action"), sorted(_ROUTE_SUFFIX_TO_ACTION.items())
+    )
+    def test_route_action_is_granted_by_the_ceiling(self, suffix: str, action: str):
+        granted = _bedrock_granted_actions()
+        assert action in granted, (
+            f"Route /{suffix} needs {action}, which the BedrockLiteLLM session policy does not "
+            f"grant. A session policy is an intersection, so this 403s on OIDC auth even when "
+            f"the IAM role allows it. Granted: {sorted(granted)}"
+        )
+
+    def test_bedrock_action_set_is_pinned(self):
+        """Any edit to the granted actions must be a deliberate test edit."""
+        assert _bedrock_granted_actions() == set(_BEDROCK_ACTIONS)
+
+    def test_async_invoke_route_is_actually_built(self):
+        """Guards the scanner: if the regex silently stops matching, the
+        omission test above passes vacuously."""
+        assert "async-invoke" in _routes_built_by_bedrock_package()


### PR DESCRIPTION
## TLDR

Problem this solves:

- OIDC/IRSA Bedrock callers 403 on four route families
- The STS session policy is a ceiling, not an allow-list
- Same omission already shipped three times (#30200, Mantle, #33142)
- Existing tests only catch removal, never a missing new route

How it solves it:

- Grant async-invoke, agents, rerank, knowledgebases in the policy
- Add Converse/ConverseStream per AWS inference prerequisites
- Extract the policy into a pure, mock-free builder
- Unit test scans the package and fails on unmapped routes
- e2e test drives the routes over real web identity auth

## User Flow

Before: a developer on a gateway that authenticates to Bedrock with a web identity token gets 403 on reranking, even though the IAM role allows it

1. Their proxy admin registers a Bedrock rerank deployment authenticated with `aws_web_identity_token`, `aws_role_name`, and `aws_session_name`, on a role whose identity policy allows `bedrock:Rerank`
2. They send POST https://litellm-domain/v1/rerank with a query and a list of documents
3. The call comes back 403 Forbidden, saying the caller is not authorized to perform `bedrock:Rerank` because no session policy allows it
4. They widen the IAM role to full Bedrock access and retry, and it still returns the same 403
5. The same thing happens on Bedrock agents, knowledge base search, and async embeddings, so those routes are unusable on this gateway

After: the same request returns ranked documents, and the IAM role is what decides access

1. The proxy admin registers the same deployment, unchanged
2. They send the same POST https://litellm-domain/v1/rerank with a query and a list of documents
3. The call returns 200 with the documents scored and ordered
4. Bedrock agents, knowledge base search, and async embeddings now work on the same gateway
5. Revoking `bedrock:Rerank` on the IAM role brings the 403 back, so the role remains the only thing granting access

## Relevant issues

Same failure mode as #30200 and #37336, on four routes that never got their grant. Neither issue is fixed by this PR: #30200 shipped earlier, and #37336 is a v1.94.3 report of a bug already fixed in v1.97.0

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

PENDING. The AWS credentials available to me are expired (`InvalidClientTokenId` on `sts:GetCallerIdentity`), so the run below has not been captured yet and this section will be replaced with real output before review

Shared setup, run from a shell holding IAM user credentials whose identity policy allows the Bedrock actions under test. `GetFederationToken` is used because its inline `Policy` is the same permission ceiling `AssumeRoleWithWebIdentity` applies, so it reproduces the failure without standing up an OIDC provider

```bash
export REGION=us-east-1
export MODEL=us.anthropic.claude-sonnet-5

fed () {  # $1 = policy json; echoes exports for the ceilinged credentials
  aws sts get-federation-token --name litellm-ceiling --policy "$1" \
    --query 'Credentials.[AccessKeyId,SecretAccessKey,SessionToken]' --output text
}

OLD='{"Version":"2012-10-17","Statement":[{"Sid":"BedrockLiteLLM","Effect":"Allow","Action":["bedrock:InvokeModel","bedrock:InvokeModelWithResponseStream","bedrock:CountTokens","bedrock:ApplyGuardrail","bedrock:GetGuardrail","bedrock:ListGuardrails"],"Resource":"*"}]}'
NEW=$(python3 -c 'import json;from litellm.llms.bedrock.base_aws_llm import build_bedrock_session_policy as b;print(json.dumps(b()))')
```

### Before (`d0da90ee6d`)

#### Bedrock rerank under the shipped ceiling

1. `read K S T < <(fed "$OLD")` then `export AWS_ACCESS_KEY_ID=$K AWS_SECRET_ACCESS_KEY=$S AWS_SESSION_TOKEN=$T`
2. `aws bedrock-runtime rerank --region $REGION --queries '[{"type":"TEXT","textQuery":{"text":"litellm"}}]' --sources '[{"type":"INLINE","inlineDocumentSource":{"type":"TEXT","textDocument":{"text":"a gateway"}}}]' --reranking-configuration '{"type":"BEDROCK_RERANKING_MODEL","bedrockRerankingConfiguration":{"modelConfiguration":{"modelArn":"arn:aws:bedrock:'"$REGION"'::foundation-model/amazon.rerank-v1:0"}}}'`
3. Observed: `AccessDeniedException` naming `bedrock:Rerank` with no session policy allowing it

#### Bedrock CountTokens under the shipped ceiling

1. Same ceilinged credentials as above
2. `curl -sS -X POST "https://bedrock-runtime.$REGION.amazonaws.com/model/$MODEL/count-tokens" --aws-sigv4 "aws:amz:$REGION:bedrock" -u "$AWS_ACCESS_KEY_ID:$AWS_SECRET_ACCESS_KEY" -H "x-amz-security-token: $AWS_SESSION_TOKEN" -H 'Content-Type: application/json' -d '{"input":{"converse":{"messages":[{"role":"user","content":[{"text":"hello"}]}]}}}'`
3. Observed: 200 with an `inputTokens` count, confirming the shipped ceiling already covers this route and the control is sound

### After (`6d0ec9d1f4`)

#### Bedrock rerank under the new ceiling

1. `read K S T < <(fed "$NEW")` then export the three variables as above
2. Run the identical `aws bedrock-runtime rerank` command from Before
3. Expected: 200 with `results` carrying an index and relevance score per document

#### Bedrock CountTokens under the new ceiling

1. Same ceilinged credentials as above
2. Run the identical `curl` command from Before
3. Expected: 200 with an `inputTokens` count, unchanged from Before

## QA runbook

Both tests are deselected unless `E2E_BEDROCK_OIDC` is set. They need an IAM OIDC provider trusting the cluster's issuer and a role granting the Bedrock actions, which stage does not have today: `AssumeRoleWithWebIdentity` from a stage pod returns `InvalidIdentityToken` for both the default projected token and the EKS Pod Identity token. Provision that first, then export `E2E_BEDROCK_OIDC=1`, `E2E_BEDROCK_OIDC_ROLE_ARN=<role>`, and `E2E_BEDROCK_OIDC_TOKEN` if the token is not at the default IRSA path

- tests/e2e/llm_translation/test_bedrock_web_identity_e2e.py::TestBedrockWebIdentitySessionPolicy::test_count_tokens_is_authorized - a Bedrock deployment authenticated by web identity can count tokens
  - [ ] POST /model/new with `aws_web_identity_token`, `aws_role_name`, and `aws_session_name` set together on a Bedrock Anthropic model
  - [ ] POST /v1/messages/count_tokens naming that deployment with one short user message
  - [ ] Expect 200 with a positive `input_tokens`, not a 403 naming `bedrock:CountTokens`
  - [ ] Drop `aws_session_name` and repeat: credential resolution silently falls through to a path with no session policy, so the call passes without proving anything
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey (e.g., assert actual expected spend instead of just spend > 0) or potentially flaky

- tests/e2e/llm_translation/test_bedrock_web_identity_e2e.py::TestBedrockWebIdentitySessionPolicy::test_rerank_is_authorized - the same deployment shape can rerank, which 403d before this PR
  - [ ] POST /model/new with the same three auth fields on the Bedrock cohere rerank model
  - [ ] POST /v1/rerank with a query and three documents, `top_n` of 2
  - [ ] Expect 200 with scored `results`, not a 403 naming `bedrock:Rerank`
  - [ ] Check out the merge base and repeat: the same request returns 403 because the ceiling omits the action
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey (e.g., assert actual expected spend instead of just spend > 0) or potentially flaky

## Type

🐛 Bug Fix

✅ Test

## Caveats (if any)

- Converse/ConverseStream added on AWS guidance, not an observed 403
- e2e cannot catch this: Bedrock e2e uses static credentials
- Covering it needs an OIDC alias and role on stage
- Route scanner is a regex over the bedrock package
- e2e tests stay deselected until the IAM provider exists

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR