### PR TITLE
fix(complexity_router): keep both ends of a clipped classifier context turn

### DIFF
--- a/litellm/router_strategy/complexity_router/complexity_router.py
+++ b/litellm/router_strategy/complexity_router/complexity_router.py
@@ -274,6 +274,7 @@ _REMINDER_CLOSE: Final = "</system-reminder>"
 _DEFAULT_REMINDER_MARKERS: Final = ((_REMINDER_OPEN, _REMINDER_CLOSE),)
 
 _TRUNCATION_MARKER: Final = "..."
+_TRUNCATION_HEAD_FRACTION: Final = 0.3
 
 _CJK_CHARACTER: Final = re.compile("[぀-ヿㇰ-ㇿ㐀-䶿一-鿿豈-﫿ｦ-ﾝ\U00020000-\U0003ffff]")
 
@@ -552,8 +553,21 @@ def _matched_plan_mode_sentinel(
 
 
 def _truncate(text: str, limit: int) -> str:
-    """Cap text at limit characters, marking it so the classifier can tell the turn was cut short."""
-    return text if len(text) <= limit else f"{text[:limit]}{_TRUNCATION_MARKER}"
+    """Cap text at limit characters, keeping both ends and eliding the middle.
+
+    A chat turn states its ask at the end, so cutting the tail keeps the preamble and discards the
+    request the turn exists to make: a turn opening with an incident report and closing with "rewrite
+    the retry path and prove it cannot livelock" reached the classifier as the incident report alone.
+    Keeping both ends costs nothing at the same budget and is what the truncation literature finds
+    best for classifying long text, head+tail measuring above both head-only and tail-only in Sun et
+    al. 2019. The marker sits at the cut, so the turn reads as having its middle removed rather than
+    as trailing off mid-thought.
+    """
+    if len(text) <= limit:
+        return text
+    head_chars: Final = max(int(limit * _TRUNCATION_HEAD_FRACTION), 0)
+    tail_chars: Final = max(limit - head_chars, 0)
+    return f"{text[:head_chars]}{_TRUNCATION_MARKER}{text[len(text) - tail_chars :]}"
 
 
 def _iter_context_turns_newest_first(

--- a/tests/test_litellm/router_strategy/test_complexity_router.py
+++ b/tests/test_litellm/router_strategy/test_complexity_router.py
@@ -5989,6 +5989,77 @@ class TestContextAwareClassifier:
         assert _strip_reminder_blocks(text, pairs) == "<<<begin_main>>> why is my tag stripped?"
 
     @pytest.mark.parametrize(
+        "text,limit,expected",
+        [
+            pytest.param("short", 10, "short", id="under-the-limit-is-untouched"),
+            pytest.param("exact", 5, "exact", id="exactly-the-limit-is-untouched"),
+            pytest.param(
+                "Second request with more details and longer text",
+                30,
+                "Second re...tails and longer text",
+                id="over-the-limit-keeps-both-ends",
+            ),
+            pytest.param("abcdefghij", 4, "a...hij", id="tiny-limit-still-splits"),
+            pytest.param("abcdefghij", 1, "...j", id="limit-too-small-for-a-head-keeps-the-tail"),
+            pytest.param("abcdefghij", 0, "...", id="zero-limit-quotes-nothing"),
+            pytest.param("日本語のテキストと最後の質問", 6, "日...最後の質問", id="cjk-slices-by-character"),
+        ],
+    )
+    def test_truncate_keeps_the_end_of_an_over_long_turn(self, text, limit, expected):
+        """A cut turn keeps its tail, because that is where a chat turn puts its ask.
+
+        Head-only truncation was the shipped behavior and it discarded exactly the part that carries
+        the difficulty. The degenerate limits are here because the budget hands this function whatever
+        space is left rather than a configured constant, so it must stay total: a limit too small to
+        hold a head degrades to tail-only rather than raising or slicing with a negative index.
+        """
+        from litellm.router_strategy.complexity_router.complexity_router import _truncate
+
+        assert _truncate(text, limit) == expected
+
+    def test_truncate_holds_its_length_budget(self):
+        """Cutting to N spends N characters plus the marker, at every N including the degenerate ones.
+
+        The marker is the cost of having cut at all, so it is charged uniformly rather than only once
+        the limit is large enough to hold a head; a caller sizing a cut against a remaining budget can
+        therefore price it as limit plus marker without special-casing the small end.
+        """
+        from litellm.router_strategy.complexity_router.complexity_router import _TRUNCATION_MARKER, _truncate
+
+        text = "x" * 500
+
+        assert all(
+            len(_truncate(text, limit)) == limit + len(_TRUNCATION_MARKER) for limit in (0, 1, 2, 4, 30, 200, 499)
+        )
+
+    def test_clipped_prior_turn_still_carries_the_ask_it_closes_on(self):
+        """The reported defect, at the level the classifier sees it.
+
+        A prior turn that opens with an incident report and closes with the request routed to the
+        cheapest tier, because the 200-character cut kept the report and dropped the request. The
+        quoted turn must carry both ends.
+        """
+        from litellm.router_strategy.complexity_router.complexity_router import _extract_prior_turns
+
+        turn = (
+            "We run a multi-region gateway and last night the eu-west pod returned 502s on the "
+            "streaming path only, for thirty minutes, while non-streaming stayed healthy the whole "
+            "window and the cooldown map was mid-failover. " + "Filler sentence to push past the cap. " * 4
+            + "Now rewrite the streaming retry path and prove it cannot livelock."
+        )
+
+        quoted = _extract_prior_turns(
+            [{"role": "user", "content": turn}, {"role": "user", "content": "go ahead"}],
+            "go ahead",
+            3,
+            200,
+            False,
+        )
+
+        assert "multi-region gateway" in quoted[0][1]
+        assert "prove it cannot livelock" in quoted[0][1]
+
+    @pytest.mark.parametrize(
         "messages,current_ask,window,per_turn_chars,include_assistant,expected",
         [
             pytest.param(
@@ -6002,7 +6073,7 @@ class TestContextAwareClassifier:
                 2,
                 30,
                 False,
-                (("user", "First request"), ("user", "Second request with more detai...")),
+                (("user", "First request"), ("user", "Second re...tails and longer text")),
                 id="current-ask-excluded-and-long-turn-marked-as-clipped",
             ),
             pytest.param(
@@ -6111,7 +6182,7 @@ class TestContextAwareClassifier:
                 1,
                 20,
                 True,
-                (("assistant", "a very long plan tha..."),),
+                (("assistant", "a very...l past the cap"),),
                 id="assistant-reply-is-clipped-at-per-turn-chars",
             ),
             pytest.param(
@@ -6134,7 +6205,8 @@ class TestContextAwareClassifier:
 
         The current ask is excluded by matching it rather than by position, since `aclassify` takes
         `prompt` and `messages` separately and a caller may classify other than the newest turn. A turn
-        cut at per_turn_chars is marked so a clip does not read as an abandoned thought.
+        over per_turn_chars keeps both ends with its middle elided, so the ask it closes on survives the
+        cut and the marker does not read as an abandoned thought.
 
         With assistant turns enabled the window is the last N turns of the conversation rather than the
         last N asks, which is what makes a plan the assistant called complex visible under a bare "yes".


### PR DESCRIPTION
## TLDR

Problem this solves:

- Clipped classifier context dropped the end of each turn
- A chat turn states its ask at the end
- The auto-router then classified a follow-up against a preamble

How it solves it:

- Keep the opening and the ending, elide the middle
- Same character budget, marker moves to the cut

## User Flow

Before: someone approving a hard piece of work in a follow-up gets answered by the cheap model, because the router never saw what was approved

1. They send POST https://litellm-domain/v1/chat/completions to an auto-router model, with a long earlier turn that opens with an incident report and closes with "rewrite the streaming retry path and prove it cannot livelock", then a short newest turn saying "go ahead"
2. The response comes back from the mid tier
3. They read the reply and find it answers the incident report rather than the rewrite they approved, so they repeat themselves with the whole request pasted in again

After: the same follow-up reaches a tier that matches the work that was approved

1. They send the same POST https://litellm-domain/v1/chat/completions with the same two turns
2. The response comes back from the top tier
3. The reply addresses the rewrite, so the request is not repeated

## Relevant issues

- The classifier's quoted context kept each turn's opening and dropped its ending
- A follow-up like "go ahead" was therefore classified against a preamble
- Keeping both ends costs the same characters and needs no new configuration

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally
- [x] My PR passes all required CI/CD checks
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

Shared setup. One proxy on port 4581 with an auto-router over four tiers, an LLM classifier at
`classifier_context_window_size: 3` and the shipped `classifier_context_per_turn_chars: 200`. The
classifier and every tier call a real provider through a gateway, so each run below costs real money.
A second router with the per-turn cap raised to 2000 quotes the 785 character turn whole and stands
in for the answer the classifier gives when nothing is clipped; it returned `tier-complex` on 12 of
12 runs at both commits, which is the reference point the two legs below are measured against.

The request is the same in every case: a 785 character user turn opening with an incident report and
closing with "rewrite the streaming retry path, make the cooldown map tolerate a partitioned Redis,
and prove the new design holds under a simulated failover with a formal argument about why it cannot
livelock", then a newest user turn of "go ahead".

```bash
cat > payload.json <<'JSON'
{"model": "router-real", "max_tokens": 20, "messages": [
  {"role": "user", "content": "<the 785 character turn above>"},
  {"role": "assistant", "content": "Understood. I can take that on."},
  {"role": "user", "content": "go ahead"}]}
JSON
```

### Before (85d5ac2b5c)

#### /v1/chat/completions

1. Read back what the classifier actually received for the earlier turn:

```
[1] Here is the full context before I ask. We run a multi-region gateway that fronts four providers.
Last night between 02:10 and 02:40 UTC the eu-west pod started returning 502s on the streaming path onl...
```

The turn is cut at 200 characters, mid word, and the request it closes on is gone

2. Route it twelve times:

```bash
for i in $(seq 1 12); do curl -s http://127.0.0.1:4581/v1/chat/completions \
  -H "Authorization: Bearer sk-rig-1234" -H "Content-Type: application/json" \
  -d @payload.json | jq -r .router_model_name; done | sort | uniq -c
  12 tier-medium
```

#### /v1/messages

1. Same two turns as Anthropic content blocks, three runs:

```
  run 1 routed to: tier-medium
  run 2 routed to: tier-medium
  run 3 routed to: tier-medium
```

#### /v1/responses

1. Same two turns as a responses `input` array, three runs:

```
  run 1 routed to: tier-medium
  run 2 routed to: tier-medium
  run 3 routed to: tier-medium
```

### After (502948c292)

#### /v1/chat/completions

1. The same read back, at the same 200 character budget:

```
[1] Here is the full context before I ask. We run a multi-region...ioned Redis without flapping, and
prove the new design holds under a simulated failover with a formal argument about why it cannot livelock.
```

The marker now sits at the cut and the request the turn closes on survives

2. Route it twelve times:

```bash
for i in $(seq 1 12); do curl -s http://127.0.0.1:4581/v1/chat/completions \
  -H "Authorization: Bearer sk-rig-1234" -H "Content-Type: application/json" \
  -d @payload.json | jq -r .router_model_name; done | sort | uniq -c
  12 tier-reasoning
```

#### /v1/messages

1. Same two turns as Anthropic content blocks, three runs:

```
  run 1 routed to: tier-reasoning
  run 2 routed to: tier-reasoning
  run 3 routed to: tier-reasoning
```

#### /v1/responses

1. Same two turns as a responses `input` array, three runs:

```
  run 1 routed to: tier-reasoning
  run 2 routed to: tier-reasoning
  run 3 routed to: tier-reasoning
```

## Type

🐛 Bug Fix

## Caveats

- Read this as direction of loss, not accuracy
- Unclipped context answers `tier-complex` on this request
- 200 characters cannot represent a 785 character turn
- A follow-up PR makes the whole block the bound
- Head fraction is 0.3, from the truncation literature
- 14 tests in this file fail without the semantic-router extra, on staging too

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized change to classifier context formatting in the complexity router; no auth or API contract changes, with broad test coverage for truncation edge cases.
> 
> **Overview**
> **Fixes LLM classifier context truncation** so over-long prior turns keep the **opening and closing** text with the middle replaced by `...`, instead of keeping only the head and dropping the tail.
> 
> The complexity router’s `_truncate` now splits the per-turn character budget roughly **30% head / 70% tail** (`_TRUNCATION_HEAD_FRACTION`). That matters because classifier context is built from prior turns: users often put the real ask at the end of a long turn, so head-only clipping made short follow-ups like “go ahead” get classified against preamble alone and route to the wrong tier.
> 
> Tests add direct `_truncate` cases (including degenerate limits and CJK), a length-budget check, a regression for `_extract_prior_turns`, and updated expectations in the prior-turn window tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e864310122ea3d4c6a337763508361a333d12a61. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->