### PR TITLE
fix(logging_worker): carry queued tasks across event-loop change instead of dropping them

### DIFF
--- a/litellm/litellm_core_utils/logging_worker.py
+++ b/litellm/litellm_core_utils/logging_worker.py
@@ -5,7 +5,7 @@ import asyncio
 import atexit
 import contextvars
 import logging
-from collections.abc import Coroutine
+from collections.abc import Coroutine, Iterator
 from typing import Final
 
 from typing_extensions import TypedDict
@@ -61,6 +61,19 @@ class LoggingWorker:
         # Register cleanup handler to flush remaining events on exit
         atexit.register(self._flush_on_exit)
 
+    @staticmethod
+    def _drain_pending(queue: "asyncio.Queue[LoggingTask]") -> tuple[LoggingTask, ...]:
+        """Pop every task still queued, without awaiting them, so they can be moved to another queue."""
+
+        def _pop_until_empty() -> Iterator[LoggingTask]:
+            while True:
+                try:
+                    yield queue.get_nowait()
+                except asyncio.QueueEmpty:
+                    return
+
+        return tuple(_pop_until_empty())
+
     def _ensure_queue(self) -> None:
         """Initialize the queue if it doesn't exist or if event loop has changed."""
         try:
@@ -69,14 +82,27 @@ class LoggingWorker:
             # No running loop, can't initialize
             return
 
-        # Check if we need to reinitialize due to event loop change
+        # The queue, semaphore and worker task are all bound to the loop that created them. On a
+        # loop change we hand the still-pending tasks to a fresh queue instead of dropping them,
+        # so queued spend-logging coroutines are not silently discarded (and never left un-awaited).
         if self._queue is not None and self._bound_loop is not current_loop:
-            verbose_logger.debug("LoggingWorker: Event loop changed, reinitializing queue and worker")
-            # Clear old state - these are bound to the old loop
-            self._queue = None
+            carried_over: Final = self._drain_pending(self._queue)
+            new_queue: Final[asyncio.Queue[LoggingTask]] = asyncio.Queue(maxsize=self.max_queue_size)
+            for carried_task in carried_over:
+                new_queue.put_nowait(carried_task)
+            if carried_over:
+                verbose_logger.warning(
+                    "LoggingWorker: event loop changed; carried %d pending logging task(s) onto the new loop",
+                    len(carried_over),
+                )
+            else:
+                verbose_logger.debug("LoggingWorker: Event loop changed, reinitializing queue and worker")
             self._sem = None
             self._worker_task = None
             self._running_tasks.clear()
+            self._queue = new_queue
+            self._bound_loop = current_loop
+            return
 
         if self._queue is None:
             self._queue = asyncio.Queue(maxsize=self.max_queue_size)

--- a/tests/test_litellm/litellm_core_utils/test_logging_worker.py
+++ b/tests/test_litellm/litellm_core_utils/test_logging_worker.py
@@ -413,3 +413,42 @@ class TestLoggingWorker:
         assert worker2._bound_loop is not None
 
         await worker2.stop()
+
+    def test_event_loop_change_carries_pending_tasks_over(self):
+        """Regression (LIT-6028): a loop change must not silently drop queued coroutines.
+
+        Before the fix ``_ensure_queue`` nulled ``self._queue`` on a loop change, discarding
+        every pending ``LoggingTask`` (each an un-awaited spend-logging coroutine). The tasks
+        must instead be moved onto the queue bound to the new loop and still execute there.
+        """
+        worker = LoggingWorker(timeout=1.0, max_queue_size=10)
+        executed: list[int] = []
+
+        async def spend_log(index: int) -> None:
+            executed.append(index)
+
+        async def enqueue_on_first_loop() -> None:
+            worker._ensure_queue()
+            for i in range(5):
+                worker.enqueue(spend_log(i))
+            assert worker._queue is not None
+            assert worker._queue.qsize() == 5
+
+        asyncio.run(enqueue_on_first_loop())
+
+        stale_queue = worker._queue
+        assert stale_queue is not None
+
+        async def rebind_on_second_loop() -> None:
+            worker._ensure_queue()
+            assert worker._queue is not None
+            # A fresh queue bound to the new loop, holding every carried-over task (not dropped).
+            assert worker._queue is not stale_queue
+            assert worker._queue.qsize() == 5
+            while not worker._queue.empty():
+                task = worker._queue.get_nowait()
+                await task["context"].run(asyncio.create_task, task["coroutine"])
+
+        asyncio.run(rebind_on_second_loop())
+
+        assert sorted(executed) == [0, 1, 2, 3, 4]


### PR DESCRIPTION
## TLDR

Problem this solves:

- A loop change silently drops every queued spend-logging coroutine
- Missing spend rows and observability events, no error raised
- `flush()` reports success on a queue whose contents were discarded

How it solves it:

- Drain the stale queue, move pending tasks onto the new loop's queue
- Warn with the carried-over count instead of a silent debug log
- `flush()`/`join()` stay honest since nothing is thrown away

## User Flow

Before: a developer using the LiteLLM Python SDK who runs each request in its own `asyncio.run()` loop loses the background spend/callback logging for earlier requests

1. They make an async LiteLLM completion inside `asyncio.run()` for request A; its success callback is queued for background logging, but the loop closes before the queue drains
2. They make another async LiteLLM completion inside a fresh `asyncio.run()` for request B
3. Python prints `RuntimeWarning: coroutine 'Logging.async_success_handler' was never awaited` to stderr
4. Request A's spend row and observability event never reach their logging backend, and nothing errors, so the loss is invisible

After: the same two requests both log

1. They make the async LiteLLM completion inside `asyncio.run()` for request A; its success callback is queued
2. They make the async LiteLLM completion inside a fresh `asyncio.run()` for request B
3. Instead of the warning they see `LoggingWorker: event loop changed; carried N pending logging task(s) onto the new loop`, and no `never awaited` warning appears
4. Request A's spend row and observability event are delivered; both requests show up in their logging backend

## Relevant issues

## Linear ticket

Resolves LIT-6028

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Shared setup: a standalone script enqueues 5 spend-logging coroutines on one `asyncio.run()` loop, then triggers a second `asyncio.run()` loop (the exact "fresh loop per request" trigger from the ticket) and reports how many survived, how many ran, and how many `never awaited` warnings fired.

```python
# repro_logging_worker.py
import asyncio
import gc
import warnings

from litellm.litellm_core_utils.logging_worker import LoggingWorker

executed: list[int] = []


async def spend_log(i: int) -> None:
    executed.append(i)


worker = LoggingWorker()
N = 5


def enqueue_on_fresh_loop() -> int:
    async def run() -> int:
        worker._ensure_queue()
        for i in range(N):
            worker.enqueue(spend_log(i))
        return worker._queue.qsize()

    return asyncio.run(run())


def rebind_on_fresh_loop_and_drain() -> int:
    async def run() -> int:
        worker._ensure_queue()
        carried = worker._queue.qsize()
        while not worker._queue.empty():
            task = worker._queue.get_nowait()
            await task["context"].run(asyncio.create_task, task["coroutine"])
        return carried

    return asyncio.run(run())


with warnings.catch_warnings(record=True) as caught:
    warnings.simplefilter("always")
    queued = enqueue_on_fresh_loop()
    print(f"queued on loop A: {queued}")
    carried = rebind_on_fresh_loop_and_drain()
    gc.collect()
    print(f"carried onto loop B: {carried}")
    print(f"executed spend-log coroutines: {sorted(executed)}")
    never_awaited = [str(w.message) for w in caught
                     if issubclass(w.category, RuntimeWarning) and "never awaited" in str(w.message)]
    print(f"'never awaited' RuntimeWarnings: {len(never_awaited)}")

lost = N - len(executed)
print("VERDICT:", f"{lost} of {N} queued spend-log coroutines were DROPPED" if lost else "all queued coroutines survived the loop change")
```

### Before (85d5ac2b5c)

1. `python repro_logging_worker.py`
2. Observed output:

```
queued on loop A: 5
carried onto loop B: 0
executed spend-log coroutines: []
'never awaited' RuntimeWarnings: 5
VERDICT: 5 of 5 queued spend-log coroutines were DROPPED
```

All 5 queued spend-logging coroutines are discarded on the loop change and Python reports each as `coroutine 'spend_log' was never awaited`.

### After (12a34a10d8)

1. `python repro_logging_worker.py`
2. Observed output:

```
LiteLLM:WARNING: logging_worker.py:94 - LoggingWorker: event loop changed; carried 5 pending logging task(s) onto the new loop
queued on loop A: 5
carried onto loop B: 5
executed spend-log coroutines: [0, 1, 2, 3, 4]
'never awaited' RuntimeWarnings: 0
VERDICT: all queued coroutines survived the loop change
```

All 5 tasks are carried onto the new loop and execute there, with zero `never awaited` warnings and a single warning-level line reporting the carried-over count.

## Type

🐛 Bug Fix

## Caveats (if any)

- Only the loop-change path changes; steady-state single-loop behavior is unchanged

<!-- live-pr-risk CHECKED at 12a34a10d8: the diff is scoped to the loop-change branch of _ensure_queue; the steady-state single-loop path (first-init and same-loop no-op) is byte-identical to base, so no enqueue caller regresses. A real OpenAI acompletion confirms happy-path spend-logging callbacks still fire, and the before/after repro proves the loop-change path now carries instead of drops. No untested dependent path regresses. -->

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches hot-path queue initialization for background logging; behavior change is scoped to event-loop changes, but incorrect carry-over could affect spend/callback delivery or shutdown semantics.
> 
> **Overview**
> Fixes **silent loss of background spend/observability logging** when the global `LoggingWorker` sees a new `asyncio` event loop (e.g. repeated `asyncio.run()` per request).
> 
> On loop rebind, `_ensure_queue` no longer discards the old queue. It **drains pending `LoggingTask` entries** via new `_drain_pending`, **re-enqueues them on a fresh loop-bound queue**, resets semaphore/worker state, and **logs a warning** with the carried-over count when anything was pending.
> 
> Adds regression test **`test_event_loop_change_carries_pending_tasks_over`** (LIT-6028) so queued coroutines still run after rebind instead of triggering `never awaited` warnings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 12a34a10d8cddfe5d8812ef7eba74911760f940d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
