### PR TITLE
fix(responses): preserve reasoning_effort=max through Responses API conversion

### DIFF
--- a/litellm/completion_extras/litellm_responses_transformation/transformation.py
+++ b/litellm/completion_extras/litellm_responses_transformation/transformation.py
@@ -1120,6 +1120,8 @@ class LiteLLMResponsesTransformationHandler(CompletionTransformationBridge):
             return Reasoning(effort="high", summary="detailed") if auto_summary_enabled else Reasoning(effort="high")
         elif reasoning_effort == "xhigh":
             return Reasoning(effort="xhigh", summary="detailed") if auto_summary_enabled else Reasoning(effort="xhigh")
+        elif reasoning_effort == "max":
+            return Reasoning(effort="max", summary="detailed") if auto_summary_enabled else Reasoning(effort="max")
         elif reasoning_effort == "medium":
             return (
                 Reasoning(effort="medium", summary="detailed") if auto_summary_enabled else Reasoning(effort="medium")

--- a/tests/mcp_tests/test_mcp_logging.py
+++ b/tests/mcp_tests/test_mcp_logging.py
@@ -28,7 +28,17 @@ class TestMCPLogger(CustomLogger):
 
     async def async_log_success_event(self, kwargs, response_obj, start_time, end_time):
         print("success event")
-        self.standard_logging_payload = kwargs.get("standard_logging_object", None)
+        payload = kwargs.get("standard_logging_object", None)
+        # Only capture MCP tool call events. litellm.callbacks is a process-wide
+        # global, so when xdist runs other MCP tests in parallel (e.g.
+        # test_mcp_chat_completions which issues an acompletion call), those
+        # success events are also routed to this logger. Without filtering by
+        # call_type, the acompletion payload (response_cost ~1e-05) overwrites
+        # the MCP payload (response_cost = 1.2) and the cost-tracking assertion
+        # fails non-deterministically.
+        if payload is not None and payload.get("call_type") != "call_mcp_tool":
+            return
+        self.standard_logging_payload = payload
         print(f"Captured standard_logging_payload: {self.standard_logging_payload}")
 
 
@@ -336,7 +346,13 @@ class MCPLoggerHook(CustomLogger):
 
     async def async_log_success_event(self, kwargs, response_obj, start_time, end_time):
         print("success event")
-        self.standard_logging_payload = kwargs.get("standard_logging_object", None)
+        payload = kwargs.get("standard_logging_object", None)
+        # Only capture MCP tool call events; see TestMCPLogger for the rationale.
+        # Without this filter, acompletion events from parallel xdist workers
+        # overwrite the MCP payload and the response_cost assertion fails.
+        if payload is not None and payload.get("call_type") != "call_mcp_tool":
+            return
+        self.standard_logging_payload = payload
         print(f"Captured standard_logging_payload: {self.standard_logging_payload}")
 
     async def async_post_mcp_tool_call_hook(

--- a/tests/test_litellm/completion_extras/litellm_responses_transformation/test_completion_extras_litellm_responses_transformation_transformation.py
+++ b/tests/test_litellm/completion_extras/litellm_responses_transformation/test_completion_extras_litellm_responses_transformation_transformation.py
@@ -1523,7 +1523,10 @@ def test_map_reasoning_effort_adds_summary_detailed(monkeypatch):
     handler = LiteLLMResponsesTransformationHandler()
 
     # Test all string effort levels - DEFAULT BEHAVIOR (no summary)
-    effort_levels = ["none", "low", "medium", "high", "xhigh", "minimal"]
+    # "max" is included because LiteLLM supports it as a reasoning_effort value
+    # (used by Anthropic, OpenRouter, and OpenAI Responses API). It must round-trip
+    # through _map_reasoning_effort instead of being silently dropped (see issue #38084).
+    effort_levels = ["none", "low", "medium", "high", "xhigh", "max", "minimal"]
 
     # Save original flag value
     original_flag = litellm.reasoning_auto_summary
@@ -1596,6 +1599,65 @@ def test_map_reasoning_effort_adds_summary_detailed(monkeypatch):
 
     finally:
         # Restore original values
+        litellm.reasoning_auto_summary = original_flag
+        if original_env is not None:
+            monkeypatch.setenv("LITELLM_REASONING_AUTO_SUMMARY", original_env)
+        elif "LITELLM_REASONING_AUTO_SUMMARY" in os.environ:
+            del os.environ["LITELLM_REASONING_AUTO_SUMMARY"]
+
+
+def test_map_reasoning_effort_max_not_dropped():
+    """
+    Regression test for issue #38084: reasoning_effort="max" was silently dropped
+    when a request was converted to the Responses API.
+
+    LiteLLM supports "max" as a reasoning_effort value (used by Anthropic, OpenRouter,
+    and the OpenAI Responses API surface). _map_reasoning_effort must round-trip it
+    to Reasoning(effort="max") instead of returning None, otherwise the provider runs
+    at its default depth with no error or warning.
+    """
+    import litellm
+    from litellm.completion_extras.litellm_responses_transformation.transformation import (
+        LiteLLMResponsesTransformationHandler,
+    )
+
+    handler = LiteLLMResponsesTransformationHandler()
+
+    original_flag = litellm.reasoning_auto_summary
+    original_env = os.environ.get("LITELLM_REASONING_AUTO_SUMMARY")
+
+    try:
+        # Default behavior: effort=max must produce a Reasoning with effort="max"
+        # and no summary (matching the other effort levels).
+        litellm.reasoning_auto_summary = False
+        if "LITELLM_REASONING_AUTO_SUMMARY" in os.environ:
+            del os.environ["LITELLM_REASONING_AUTO_SUMMARY"]
+
+        result = handler._map_reasoning_effort("max")
+        assert result is not None, (
+            "reasoning_effort='max' must not be silently dropped; "
+            "expected Reasoning(effort='max'), got None (issue #38084)"
+        )
+        assert result["effort"] == "max", f"Expected effort='max', got {result['effort']!r}"
+        assert "summary" not in result, "Summary should NOT be present by default for effort='max'"
+
+        # With auto-summary enabled: summary='detailed' is added, matching other efforts.
+        litellm.reasoning_auto_summary = True
+        result = handler._map_reasoning_effort("max")
+        assert result is not None, "reasoning_effort='max' must not be dropped with auto-summary on"
+        assert result["effort"] == "max"
+        assert result["summary"] == "detailed"
+
+        # Dict input with effort='max' is passed through unchanged.
+        litellm.reasoning_auto_summary = False
+        dict_input = {"effort": "max", "summary": "concise"}
+        result_dict = handler._map_reasoning_effort(dict_input)
+        assert result_dict["effort"] == "max"
+        assert result_dict["summary"] == "concise"
+
+        print("✓ reasoning_effort='max' is preserved through Responses API conversion")
+
+    finally:
         litellm.reasoning_auto_summary = original_flag
         if original_env is not None:
             monkeypatch.setenv("LITELLM_REASONING_AUTO_SUMMARY", original_env)

--- a/tests/test_litellm/completion_extras/litellm_responses_transformation/test_completion_extras_litellm_responses_transformation_transformation.py
+++ b/tests/test_litellm/completion_extras/litellm_responses_transformation/test_completion_extras_litellm_responses_transformation_transformation.py
@@ -1623,46 +1623,34 @@ def test_map_reasoning_effort_max_not_dropped(monkeypatch):
 
     handler = LiteLLMResponsesTransformationHandler()
 
-    original_flag = litellm.reasoning_auto_summary
-    original_env = os.environ.get("LITELLM_REASONING_AUTO_SUMMARY")
+    monkeypatch.delenv("LITELLM_REASONING_AUTO_SUMMARY", raising=False)
 
-    try:
-        # Default behavior: effort=max must produce a Reasoning with effort="max"
-        # and no summary (matching the other effort levels).
-        litellm.reasoning_auto_summary = False
-        if "LITELLM_REASONING_AUTO_SUMMARY" in os.environ:
-            del os.environ["LITELLM_REASONING_AUTO_SUMMARY"]
+    # Default behavior: effort=max must produce a Reasoning with effort="max"
+    # and no summary (matching the other effort levels).
+    monkeypatch.setattr(litellm, "reasoning_auto_summary", False)
+    result = handler._map_reasoning_effort("max")
+    assert result is not None, (
+        "reasoning_effort='max' must not be silently dropped; "
+        "expected Reasoning(effort='max'), got None (issue #38084)"
+    )
+    assert result["effort"] == "max", f"Expected effort='max', got {result['effort']!r}"
+    assert "summary" not in result, "Summary should NOT be present by default for effort='max'"
 
-        result = handler._map_reasoning_effort("max")
-        assert result is not None, (
-            "reasoning_effort='max' must not be silently dropped; "
-            "expected Reasoning(effort='max'), got None (issue #38084)"
-        )
-        assert result["effort"] == "max", f"Expected effort='max', got {result['effort']!r}"
-        assert "summary" not in result, "Summary should NOT be present by default for effort='max'"
+    # With auto-summary enabled: summary='detailed' is added, matching other efforts.
+    monkeypatch.setattr(litellm, "reasoning_auto_summary", True)
+    result = handler._map_reasoning_effort("max")
+    assert result is not None, "reasoning_effort='max' must not be dropped with auto-summary on"
+    assert result["effort"] == "max"
+    assert result["summary"] == "detailed"
 
-        # With auto-summary enabled: summary='detailed' is added, matching other efforts.
-        litellm.reasoning_auto_summary = True
-        result = handler._map_reasoning_effort("max")
-        assert result is not None, "reasoning_effort='max' must not be dropped with auto-summary on"
-        assert result["effort"] == "max"
-        assert result["summary"] == "detailed"
+    # Dict input with effort='max' is passed through unchanged.
+    monkeypatch.setattr(litellm, "reasoning_auto_summary", False)
+    dict_input = {"effort": "max", "summary": "concise"}
+    result_dict = handler._map_reasoning_effort(dict_input)
+    assert result_dict["effort"] == "max"
+    assert result_dict["summary"] == "concise"
 
-        # Dict input with effort='max' is passed through unchanged.
-        litellm.reasoning_auto_summary = False
-        dict_input = {"effort": "max", "summary": "concise"}
-        result_dict = handler._map_reasoning_effort(dict_input)
-        assert result_dict["effort"] == "max"
-        assert result_dict["summary"] == "concise"
-
-        print("✓ reasoning_effort='max' is preserved through Responses API conversion")
-
-    finally:
-        litellm.reasoning_auto_summary = original_flag
-        if original_env is not None:
-            monkeypatch.setenv("LITELLM_REASONING_AUTO_SUMMARY", original_env)
-        elif "LITELLM_REASONING_AUTO_SUMMARY" in os.environ:
-            del os.environ["LITELLM_REASONING_AUTO_SUMMARY"]
+    print("✓ reasoning_effort='max' is preserved through Responses API conversion")
 
 
 def test_transform_response_preserves_annotations():

--- a/tests/test_litellm/completion_extras/litellm_responses_transformation/test_completion_extras_litellm_responses_transformation_transformation.py
+++ b/tests/test_litellm/completion_extras/litellm_responses_transformation/test_completion_extras_litellm_responses_transformation_transformation.py
@@ -1606,7 +1606,7 @@ def test_map_reasoning_effort_adds_summary_detailed(monkeypatch):
             del os.environ["LITELLM_REASONING_AUTO_SUMMARY"]
 
 
-def test_map_reasoning_effort_max_not_dropped():
+def test_map_reasoning_effort_max_not_dropped(monkeypatch):
     """
     Regression test for issue #38084: reasoning_effort="max" was silently dropped
     when a request was converted to the Responses API.


### PR DESCRIPTION
## Summary

`_map_reasoning_effort` had an if/elif chain over `none`/`minimal`/`low`/`medium`/`high`/`xhigh` ending in `return None`, with no `max` branch. When a request carrying `reasoning_effort="max"` was converted to the Responses API (forced by `tools`, or when the value came from `litellm_params` in the config), the effort was silently dropped: the caller set `responses_api_request["reasoning"] = None` and no reasoning field was sent to the provider. The call returned 200 and the model ran at its default depth, with no error or warning, even with `drop_params: false`.

LiteLLM already supports `"max"` as a `reasoning_effort` value elsewhere (Anthropic thinking budgets, OpenRouter mapping, `model_info.supports_max_reasoning_effort`), and the OpenAI Responses API surface accepts `reasoning.effort="max"`. The Responses API conversion was the only path that lost it.

### Fix

Add a `max` branch to `_map_reasoning_effort` that maps to `Reasoning(effort="max")`, with the same auto-summary (`litellm.reasoning_auto_summary` / `LITELLM_REASONING_AUTO_SUMMARY` env var) behavior as the other effort levels.

### Repro (from #38084)

```python
from litellm.completion_extras.litellm_responses_transformation.transformation import (
    LiteLLMResponsesTransformationHandler as H,
)

h = H.__new__(H)
h._map_reasoning_effort("xhigh")  # {'effort': 'xhigh'}
h._map_reasoning_effort("max")    # None   <-- the bug
```

After the fix:

```python
h._map_reasoning_effort("max")    # {'effort': 'max'}
```

### Evidence from the issue

- **Case B** (`/v1/chat/completions`, `reasoning_effort=max`, with tools): no `reasoning` field sent to `/v1/responses`, 200 returned, 200 reasoning tokens.
- **Case D** (`/v1/responses`, effort from `litellm_params: reasoning_effort: max`): no `reasoning` field sent, 200 returned, 286 reasoning tokens.
- **Case E** (`/v1/responses`, client sends `reasoning: {"effort": "max"}`): provider accepts `max` on this surface, 200 returned, 516 reasoning tokens (same model/prompt as D).

Fixes #38084

## Test plan

- [x] `test_map_reasoning_effort_adds_summary_detailed` extended to cover `"max"` (default no-summary and flag-enabled summary='detailed')
- [x] New regression test `test_map_reasoning_effort_max_not_dropped` asserts `max` is no longer dropped (default, auto-summary, and dict pass-through)
- [x] Repro from the issue verified: `_map_reasoning_effort("max")` now returns `{'effort': 'max'}` instead of `None`
- [x] Full test file run: 73 passed (7 pre-existing `acompletion_bridge_normalizes_*` failures on `main` are unrelated to this change, verified by stash)