### PR TITLE
fix(ui): forward OAuth issuer/authorization/token/registration URLs from the MCP server edit form

### DIFF
--- a/ui/litellm-dashboard/src/app/(dashboard)/mcp-servers/_components/mcp_server_edit.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/mcp-servers/_components/mcp_server_edit.test.tsx
@@ -381,6 +381,44 @@ describe("MCPServerEdit (true passthrough warning)", () => {
   });
 });
 
+describe("MCPServerEdit (OAuth authorize temp payload)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("forwards issuer/authorization_url/token_url/registration_url to the temp OAuth session payload", async () => {
+    // Without these fields the ephemeral server the temp OAuth session endpoint builds has no
+    // admin-configured OAuth endpoints on it, discovery falls back to (and fails against) the
+    // plain server url, and Authorize & Fetch Token 400s with "authorization url is not
+    // configured" even though the saved server (and the visible form) has all four fields filled in.
+    render(
+      <MCPServerEdit
+        mcpServer={{
+          ...interactiveOAuthServer,
+          issuer: "https://github.com/login/oauth",
+          authorization_url: "https://github.com/login/oauth/authorize",
+          token_url: "https://github.com/login/oauth/access_token",
+          registration_url: "https://github.com/login/oauth/register",
+        }}
+        accessToken="access-token"
+        onCancel={vi.fn()}
+        onSuccess={vi.fn()}
+        availableAccessGroups={[]}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(mockOauth.getTemporaryPayload).toBeTruthy();
+    });
+    const payload = mockOauth.getTemporaryPayload!();
+    expect(payload).toBeTruthy();
+    expect(payload?.issuer).toBe("https://github.com/login/oauth");
+    expect(payload?.authorization_url).toBe("https://github.com/login/oauth/authorize");
+    expect(payload?.token_url).toBe("https://github.com/login/oauth/access_token");
+    expect(payload?.registration_url).toBe("https://github.com/login/oauth/register");
+  });
+});
+
 describe("MCPServerEdit (auth type switch)", () => {
   beforeEach(() => {
     vi.clearAllMocks();

--- a/ui/litellm-dashboard/src/app/(dashboard)/mcp-servers/_components/mcp_server_edit.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/mcp-servers/_components/mcp_server_edit.tsx
@@ -282,6 +282,10 @@ const MCPServerEdit: React.FC<MCPServerEditProps> = ({
         credentials: isClientForwardedTokenMode(values.auth_type)
           ? preservedAdminCredentials(values.credentials)
           : values.credentials,
+        issuer: values.issuer,
+        authorization_url: values.authorization_url,
+        token_url: values.token_url,
+        registration_url: values.registration_url,
         mcp_access_groups: values.mcp_access_groups || mcpServer.mcp_access_groups,
         static_headers: staticHeaders,
         command: values.command,


### PR DESCRIPTION
## TLDR

Problem this solves:

- Clicking Authorize & Fetch Token on an existing MCP server's edit page can 400 with "authorization url is not configured", even when the server has Authorization URL / Token URL already saved
- The edit form's OAuth session payload silently dropped issuer, authorization_url, token_url, and registration_url before sending it to the backend

How it solves it:

- Forward those four fields from the edit form's OAuth session payload, matching the create form's payload builder

## User Flow

Before: an admin re-authorizing an existing OAuth2 MCP server gets a 400 even though the server already has working endpoints saved

1. They open their proxy's Admin UI at https://your-proxy-domain/ui/mcp-servers, click into an existing OAuth2 server, and go to its Settings tab
2. Authorization URL and Token URL show the values already saved for the server
3. They click "Authorize & Fetch Token"
4. The button shows: "MCP server authorization url is not configured. OAuth endpoint discovery against the configured server url did not resolve it; the url may be misconfigured. ..."

After: the same click starts the real OAuth flow instead

1. They open the same Settings tab on the same server
2. Authorization URL and Token URL still show the values already saved for the server
3. They click "Authorize & Fetch Token"
4. The browser navigates to the identity provider's real authorization endpoint (e.g. `https://github.com/login/oauth/authorize?...`) to complete sign-in, instead of showing the 400

## Relevant issues

<!-- none -->

## Linear ticket

Resolves LIT-6074

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Setup: a proxy running this repo's code with an OAuth2 MCP server configured (`github_mcp`, transport `http`, `auth_type: oauth2`, `oauth2_flow: authorization_code`, url `https://api.githubcopilot.com/mcp/`). Both legs curl the same live proxy's real `/v1/mcp/server/oauth/session` and `/v1/mcp/server/oauth/{server_id}/authorize` endpoints hit by the edit form's "Authorize & Fetch Token" button, with `authorization_url`/`token_url` set to GitHub's real OAuth endpoints and no `issuer` (the correct configuration for a provider like GitHub that has no RFC 8414 discovery document) — reproducing exactly what the edit form's payload builder did/does before and after this fix.

### Before (6147b3ce6ed6a7b675bd9d2f5d2b2c25ad7c80b1)

1. `POST /v1/mcp/server/oauth/session` with the pre-fix payload shape (no `issuer`/`authorization_url`/`token_url`/`registration_url` keys, matching the old edit-form payload):
   ```
   curl -s -X POST http://localhost:4000/v1/mcp/server/oauth/session \
     -H "Authorization: Bearer $LITELLM_MASTER_KEY" -H "Content-Type: application/json" \
     -d '{"server_name":"github_mcp_before","alias":"github_mcp_before","url":"https://api.githubcopilot.com/mcp/","transport":"http","auth_type":"oauth2","credentials":{},"mcp_access_groups":[],"static_headers":{}}'
   ```
   Response: `{"server_id":"e60685c0-4b71-4abf-939c-c7aaec0ee96b", ..., "authorization_url":null, "token_url":null, ...}`
2. `GET /v1/mcp/server/oauth/{server_id}/authorize?redirect_uri=...&client_id=test-client&state=xyz&code_challenge=abc&code_challenge_method=S256&response_type=code`
   Response: `HTTP 400` — `{"detail":"MCP server authorization url is not configured. OAuth endpoint discovery against the configured server url did not resolve it; the url may be misconfigured. Check the proxy logs for 'MCP OAuth' warnings from server load, verify the server url, or set Authorization URL and Token URL manually, or set Issuer to discover them from the identity provider (RFC 8414)."}`
3. Same 400, reproduced live in the Admin UI: opened the `github_mcp` server's Settings tab (Authorization URL / Token URL already showing GitHub's real endpoints) and clicked "Authorize & Fetch Token" — the button surfaced the identical error text inline and as a toast.

### After (177f773e4b9d7e576b6b8ef2e64a79e2529d16d4)

1. `POST /v1/mcp/server/oauth/session` with the fixed payload shape (`authorization_url`/`token_url` forwarded, `issuer` omitted, matching a correctly-configured GitHub server):
   ```
   curl -s -X POST http://localhost:4000/v1/mcp/server/oauth/session \
     -H "Authorization: Bearer $LITELLM_MASTER_KEY" -H "Content-Type: application/json" \
     -d '{"server_name":"github_mcp_after","alias":"github_mcp_after","url":"https://api.githubcopilot.com/mcp/","transport":"http","auth_type":"oauth2","credentials":{},"mcp_access_groups":[],"static_headers":{},"issuer":null,"authorization_url":"https://github.com/login/oauth/authorize","token_url":"https://github.com/login/oauth/access_token","registration_url":null}'
   ```
   Response: `{"server_id":"9491d7ee-705f-4c5e-b2aa-6cfd6e669523", ..., "authorization_url":"https://github.com/login/oauth/authorize", "token_url":"https://github.com/login/oauth/access_token", ...}`
2. `GET /v1/mcp/server/oauth/{server_id}/authorize?redirect_uri=...&client_id=test-client&state=xyz&code_challenge=abc&code_challenge_method=S256&response_type=code`
   Response: `HTTP 307`, `location: https://github.com/login/oauth/authorize?client_id=test-client&redirect_uri=...&state=...&response_type=code&code_challenge=abc&code_challenge_method=S256`
3. Same success, reproduced live in the Admin UI: same server, same Settings tab, clicked "Authorize & Fetch Token" — the browser navigated to GitHub's real `https://github.com/login/oauth/authorize` endpoint with the client's PKCE `state`/`code_challenge` in the query string (GitHub itself returned its own 404, since no real registered OAuth App client_id was used in this test, but the redirect itself is the proof: the gateway's own endpoint resolution succeeded, and the browser reached the identity provider).

## Type

🐛 Bug Fix

## Caveats (if any)

- If an admin sets an Issuer alongside manual Authorization/Token URL, the Issuer takes over as the sole endpoint source (by design, RFC 8414 §3.3 anti-mix-up protection) and the manual endpoints are ignored; providers with no RFC 8414 metadata document (like GitHub) will then still 400 with a different message. That's a separate, pre-existing behavior, unaffected by this fix.

## QA runbook

<!-- N/A: no tests/e2e changes -->

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
