### PR TITLE
fix(videos): forward uploaded source file on /v1/videos/edits to the provider

### DIFF
--- a/litellm/llms/base_llm/videos/transformation.py
+++ b/litellm/llms/base_llm/videos/transformation.py
@@ -1,9 +1,10 @@
 import types
 from abc import ABC, abstractmethod
+from collections.abc import Mapping
 from typing import TYPE_CHECKING, Any
 
 import httpx
-from httpx._types import RequestFiles
+from httpx._types import FileContent, RequestFiles
 
 from litellm.types.responses.main import *
 from litellm.types.router import GenericLiteLLMParams
@@ -340,14 +341,18 @@ class BaseVideoConfig(ABC):
         api_base: str,
         litellm_params: GenericLiteLLMParams,
         headers: dict,
+        video_file: FileContent | None = None,
         extra_body: dict[str, Any] | None = None,
         prefetched_source_data: dict[str, Any] | None = None,
-    ) -> tuple[str, dict]:
+    ) -> tuple[str, Mapping[str, object], RequestFiles | None]:
         """
-        Transform the video edit request into a URL and JSON data.
+        Transform the video edit request into a URL plus either JSON data or
+        multipart form fields and files.
 
         Returns:
-            Tuple[str, Dict]: (url, data) for the POST request
+            tuple[str, Mapping[str, object], RequestFiles | None]: (url, data,
+            files). When files is None the handler sends data as JSON; otherwise
+            data holds the form fields and files holds the uploaded source video.
         """
         raise NotImplementedError("video edit is not supported for this provider")
 

--- a/litellm/llms/custom_httpx/llm_http_handler.py
+++ b/litellm/llms/custom_httpx/llm_http_handler.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING, Any, Final, Literal, Optional, TypedDict, Type
 from urllib.parse import parse_qs, urlencode, urlparse, urlunparse
 
 import httpx
+from httpx._types import FileContent
 from openai.types.file_deleted import FileDeleted
 
 import litellm
@@ -7838,6 +7839,7 @@ class BaseLLMHTTPHandler:
         custom_llm_provider: str,
         litellm_params,
         logging_obj,
+        video_file: FileContent | None = None,
         extra_headers: dict[str, object] | None = None,
         extra_body: dict[str, object] | None = None,
         timeout: float | None = None,
@@ -7849,6 +7851,7 @@ class BaseLLMHTTPHandler:
             return self.async_video_edit_handler(
                 prompt=prompt,
                 video_id=video_id,
+                video_file=video_file,
                 video_provider_config=video_provider_config,
                 custom_llm_provider=custom_llm_provider,
                 litellm_params=litellm_params,
@@ -7902,9 +7905,10 @@ class BaseLLMHTTPHandler:
             prefetched_source_data = prefetch_resp.json()
 
         try:
-            url, data = video_provider_config.transform_video_edit_request(
+            url, data, files = video_provider_config.transform_video_edit_request(
                 prompt=prompt,
                 video_id=video_id,
+                video_file=video_file,
                 api_base=api_base,
                 litellm_params=litellm_params,
                 headers=headers,
@@ -7923,11 +7927,10 @@ class BaseLLMHTTPHandler:
                 },
             )
 
-            response: Final = sync_httpx_client.post(
-                url=url,
-                headers=headers,
-                json=data,
-                timeout=timeout,
+            response: Final = (
+                sync_httpx_client.post(url=url, headers=headers, data=data, files=files, timeout=timeout)
+                if files
+                else sync_httpx_client.post(url=url, headers=headers, json=data, timeout=timeout)
             )
             response.raise_for_status()
             return video_provider_config.transform_video_edit_response(
@@ -7947,6 +7950,7 @@ class BaseLLMHTTPHandler:
         custom_llm_provider: str,
         litellm_params,
         logging_obj,
+        video_file: FileContent | None = None,
         extra_headers: dict[str, object] | None = None,
         extra_body: dict[str, object] | None = None,
         timeout: float | None = None,
@@ -7998,9 +8002,10 @@ class BaseLLMHTTPHandler:
             prefetched_source_data = prefetch_resp.json()
 
         try:
-            url, data = video_provider_config.transform_video_edit_request(
+            url, data, files = video_provider_config.transform_video_edit_request(
                 prompt=prompt,
                 video_id=video_id,
+                video_file=video_file,
                 api_base=api_base,
                 litellm_params=litellm_params,
                 headers=headers,
@@ -8019,11 +8024,10 @@ class BaseLLMHTTPHandler:
                 },
             )
 
-            response: Final = await async_httpx_client.post(
-                url=url,
-                headers=headers,
-                json=data,
-                timeout=timeout,
+            response: Final = await (
+                async_httpx_client.post(url=url, headers=headers, data=data, files=files, timeout=timeout)
+                if files
+                else async_httpx_client.post(url=url, headers=headers, json=data, timeout=timeout)
             )
             response.raise_for_status()
             return video_provider_config.transform_video_edit_response(

--- a/litellm/llms/gemini/videos/transformation.py
+++ b/litellm/llms/gemini/videos/transformation.py
@@ -566,6 +566,7 @@ class GeminiVideoConfig(BaseVideoConfig):
         api_base,
         litellm_params,
         headers,
+        video_file=None,
         extra_body=None,
         prefetched_source_data=None,
     ):

--- a/litellm/llms/openai/videos/transformation.py
+++ b/litellm/llms/openai/videos/transformation.py
@@ -1,5 +1,7 @@
 import mimetypes
+from collections.abc import Mapping
 from io import BufferedReader, BytesIO
+from types import MappingProxyType
 from typing import TYPE_CHECKING, Any, Final, cast
 from urllib.parse import quote
 
@@ -502,15 +504,26 @@ class OpenAIVideoConfig(BaseVideoConfig):
         api_base: str,
         litellm_params: GenericLiteLLMParams,
         headers: dict,
+        video_file: FileContent | None = None,
         extra_body: dict[str, object] | None = None,
         prefetched_source_data: dict[str, object] | None = None,
-    ) -> tuple[str, dict]:
-        original_video_id: Final = extract_original_video_id(video_id)
+    ) -> tuple[str, Mapping[str, object], RequestFiles | None]:
         url: Final = f"{api_base.rstrip('/')}/edits"
+
+        if video_file is not None:
+            files: Final[RequestFiles] = (self._video_file_tuple(video_file, "video"),)
+            form_data: Final = (
+                MappingProxyType({"prompt": prompt, **extra_body})
+                if extra_body
+                else MappingProxyType({"prompt": prompt})
+            )
+            return url, form_data, files
+
+        original_video_id: Final = extract_original_video_id(video_id)
         data: Final[dict[str, object]] = {"prompt": prompt, "video": {"id": original_video_id}}
         if extra_body:
             data.update(extra_body)
-        return url, data
+        return url, data, None
 
     def transform_video_edit_response(
         self,
@@ -570,21 +583,22 @@ class OpenAIVideoConfig(BaseVideoConfig):
         else:
             files_list.append((field_name, ("input_reference.png", image, image_content_type)))
 
+    def _video_file_tuple(self, video: FileContent, field_name: str) -> tuple[str, FileTypes]:
+        """
+        Build a multipart field tuple for a video upload with proper video MIME
+        type detection: these paths must send video/mp4, not image/* content types.
+        """
+        filename: Final = getattr(video, "name", None) or "input_video.mp4"
+        content_type: Final = self._get_video_content_type(video=video, filename=filename)
+        return (field_name, (filename, video, content_type))
+
     def _add_video_to_files(
         self,
         files_list: list[tuple[str, FileTypes]],
         video: FileContent,
         field_name: str,
     ) -> None:
-        """
-        Add a video to files with proper video MIME type detection.
-
-        This path is used by POST /videos/characters and must send video/mp4,
-        not image/* content types.
-        """
-        filename: Final = getattr(video, "name", None) or "input_video.mp4"
-        content_type: Final = self._get_video_content_type(video=video, filename=filename)
-        files_list.append((field_name, (filename, video, content_type)))
+        files_list.append(self._video_file_tuple(video, field_name))
 
     def _get_video_content_type(self, video: FileContent, filename: str) -> str:
         guessed_content_type, _ = mimetypes.guess_type(filename)

--- a/litellm/llms/runwayml/videos/transformation.py
+++ b/litellm/llms/runwayml/videos/transformation.py
@@ -672,6 +672,7 @@ class RunwayMLVideoConfig(BaseVideoConfig):
         api_base,
         litellm_params,
         headers,
+        video_file=None,
         extra_body=None,
         prefetched_source_data=None,
     ):

--- a/litellm/llms/vertex_ai/videos/transformation.py
+++ b/litellm/llms/vertex_ai/videos/transformation.py
@@ -7,11 +7,11 @@ Based on: https://docs.cloud.google.com/vertex-ai/generative-ai/docs/model-refer
 
 import base64
 import time
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from typing import TYPE_CHECKING, Any, Final, TypedDict, cast
 
 import httpx
-from httpx._types import RequestFiles
+from httpx._types import FileContent, RequestFiles
 from typing_extensions import ReadOnly
 
 from litellm.constants import DEFAULT_GOOGLE_VIDEO_DURATION_SECONDS
@@ -677,9 +677,10 @@ class VertexAIVideoConfig(BaseVideoConfig, VertexBase):
         api_base: str,
         litellm_params: GenericLiteLLMParams,
         headers: dict,
+        video_file: FileContent | None = None,
         extra_body: dict[str, object] | None = None,
         prefetched_source_data: dict[str, Any] | None = None,
-    ) -> tuple[str, dict]:
+    ) -> tuple[str, Mapping[str, object], RequestFiles | None]:
         """
         Build a predictLongRunning edit request from the pre-fetched source video.
 
@@ -727,7 +728,7 @@ class VertexAIVideoConfig(BaseVideoConfig, VertexBase):
                 request_data["parameters"] = vertex_params
 
         edit_url: Final = f"{api_base.rstrip('/')}/{model}:predictLongRunning"
-        return edit_url, request_data
+        return edit_url, request_data, None
 
     def transform_video_edit_response(
         self,

--- a/litellm/proxy/image_endpoints/endpoints.py
+++ b/litellm/proxy/image_endpoints/endpoints.py
@@ -1,6 +1,7 @@
 import asyncio
 import io
 import traceback
+from collections.abc import Sequence
 from typing import Final
 
 import orjson
@@ -33,10 +34,10 @@ async def uploadfile_to_bytesio(upload: UploadFile) -> io.BytesIO:
 
 
 async def batch_to_bytesio(
-    uploads: list[UploadFile] | None,
+    uploads: Sequence[UploadFile] | None,
 ) -> list[io.BytesIO] | None:
     """
-    Convert a list of UploadFiles to a list of BytesIO buffers, or None.
+    Convert a sequence of UploadFiles to a list of BytesIO buffers, or None.
     """
     if not uploads:
         return None

--- a/litellm/proxy/video_endpoints/endpoints.py
+++ b/litellm/proxy/video_endpoints/endpoints.py
@@ -4,6 +4,7 @@ from typing import Any, Final
 
 from fastapi import APIRouter, Depends, File, Form, Request, Response, UploadFile
 from fastapi.responses import ORJSONResponse
+from starlette.datastructures import UploadFile as StarletteUploadFile
 
 from litellm.proxy._types import *
 from litellm.proxy.auth.user_api_key_auth import UserAPIKeyAuth, user_api_key_auth
@@ -759,7 +760,14 @@ async def video_edit(
     )
 
     data: Final = await _read_request_body(request=request)
-    data["video_id"] = video_reference_to_id(data.pop("video", None))
+    uploaded_video: Final = data.pop("video", None)
+    if isinstance(uploaded_video, StarletteUploadFile):
+        video_files: Final = await batch_to_bytesio((uploaded_video,))
+        if video_files:
+            data["video"] = video_files[0]
+        data["video_id"] = ""
+    else:
+        data["video_id"] = video_reference_to_id(uploaded_video)
 
     decoded: Final = decode_video_id_with_provider(data["video_id"])
     provider_from_id: Final = decoded.get("custom_llm_provider")

--- a/litellm/videos/main.py
+++ b/litellm/videos/main.py
@@ -1341,12 +1341,13 @@ def video_get_character(
 async def avideo_edit(
     video_id: str,
     prompt: str,
-    video: FileContent | None = None,
     timeout=600,
     custom_llm_provider=None,
     extra_headers: dict[str, object] | None = None,
     extra_query: dict[str, object] | None = None,
     extra_body: dict[str, object] | None = None,
+    *,
+    video: FileContent | None = None,
     **kwargs,
 ) -> VideoObject:
     """
@@ -1395,12 +1396,13 @@ async def avideo_edit(
 def video_edit(
     video_id: str,
     prompt: str,
-    video: FileContent | None = None,
     timeout=600,
     custom_llm_provider=None,
     extra_headers: dict[str, object] | None = None,
     extra_query: dict[str, object] | None = None,
     extra_body: dict[str, object] | None = None,
+    *,
+    video: FileContent | None = None,
     **kwargs,
 ) -> VideoObject | Coroutine[object, object, VideoObject]:
     """

--- a/litellm/videos/main.py
+++ b/litellm/videos/main.py
@@ -5,6 +5,8 @@ from collections.abc import Coroutine
 from functools import partial
 from typing import Final, Literal, overload
 
+from httpx._types import FileContent
+
 import litellm
 from litellm.constants import DEFAULT_VIDEO_ENDPOINT_MODEL
 from litellm.constants import request_timeout as DEFAULT_REQUEST_TIMEOUT
@@ -1339,6 +1341,7 @@ def video_get_character(
 async def avideo_edit(
     video_id: str,
     prompt: str,
+    video: FileContent | None = None,
     timeout=600,
     custom_llm_provider=None,
     extra_headers: dict[str, object] | None = None,
@@ -1359,6 +1362,7 @@ async def avideo_edit(
             video_edit,
             video_id=video_id,
             prompt=prompt,
+            video=video,
             timeout=timeout,
             custom_llm_provider=custom_llm_provider,
             extra_headers=extra_headers,
@@ -1391,6 +1395,7 @@ async def avideo_edit(
 def video_edit(
     video_id: str,
     prompt: str,
+    video: FileContent | None = None,
     timeout=600,
     custom_llm_provider=None,
     extra_headers: dict[str, object] | None = None,
@@ -1444,6 +1449,7 @@ def video_edit(
         return base_llm_http_handler.video_edit_handler(
             prompt=prompt,
             video_id=video_id,
+            video_file=video,
             video_provider_config=provider_config,
             custom_llm_provider=custom_llm_provider,
             litellm_params=litellm_params,

--- a/tests/test_litellm/llms/openai/videos/test_openai_video_transformation.py
+++ b/tests/test_litellm/llms/openai/videos/test_openai_video_transformation.py
@@ -1,3 +1,5 @@
+import io
+
 from litellm.llms.openai.videos.transformation import OpenAIVideoConfig
 from litellm.types.router import GenericLiteLLMParams
 from litellm.types.videos.utils import encode_character_id_with_provider
@@ -68,3 +70,48 @@ def test_wrapped_character_id_is_decoded_then_encoded_as_path_segment():
         == "https://api.openai.com/v1/videos/characters/..%2F..%2Fcharacters%3Fx%3D1%23frag"
     )
     assert params == {}
+
+
+def test_video_edit_request_forwards_uploaded_file_as_multipart():
+    """An uploaded source video must leave as a multipart ``video`` file part,
+    not be dropped in favor of a JSON id reference."""
+    config = OpenAIVideoConfig()
+    source = io.BytesIO(b"\x00\x00\x00\x18ftypmp42\x00\x00\x00\x00mp42isomBODY")
+    source.name = "clip.mp4"
+
+    url, data, files = config.transform_video_edit_request(
+        prompt="make it nighttime",
+        video_id="",
+        api_base="https://api.openai.com/v1/videos",
+        litellm_params=GenericLiteLLMParams(),
+        headers={},
+        video_file=source,
+    )
+
+    assert url == "https://api.openai.com/v1/videos/edits"
+    assert data == {"prompt": "make it nighttime"}
+    assert files is not None
+    field_names = [field for field, _ in files]
+    assert field_names == ["video"]
+    _, (filename, content, content_type) = files[0]
+    assert filename == "clip.mp4"
+    assert content is source
+    assert content_type == "video/mp4"
+
+
+def test_video_edit_request_without_file_sends_json_id_reference():
+    """The id-reference path must stay JSON (files is None) so existing
+    remix/edit-by-id callers keep working."""
+    config = OpenAIVideoConfig()
+
+    url, data, files = config.transform_video_edit_request(
+        prompt="brighter",
+        video_id="video_abc123",
+        api_base="https://api.openai.com/v1/videos",
+        litellm_params=GenericLiteLLMParams(),
+        headers={},
+    )
+
+    assert url == "https://api.openai.com/v1/videos/edits"
+    assert data == {"prompt": "brighter", "video": {"id": "video_abc123"}}
+    assert files is None

--- a/tests/test_litellm/llms/vertex_ai/videos/test_vertex_video_transformation.py
+++ b/tests/test_litellm/llms/vertex_ai/videos/test_vertex_video_transformation.py
@@ -479,7 +479,7 @@ class TestVertexAIVideoConfig:
             },
         }
 
-        url, data = self.config.transform_video_edit_request(
+        url, data, files = self.config.transform_video_edit_request(
             prompt="Make it brighter",
             video_id=operation_name,
             api_base=api_base,
@@ -488,6 +488,7 @@ class TestVertexAIVideoConfig:
             prefetched_source_data=prefetched,
         )
 
+        assert files is None
         assert url.endswith(":predictLongRunning")
         assert "veo-3.1-generate-001" in url
         instance = data["instances"][0]
@@ -507,7 +508,7 @@ class TestVertexAIVideoConfig:
             },
         }
 
-        _, data = self.config.transform_video_edit_request(
+        _, data, _ = self.config.transform_video_edit_request(
             prompt="Make it darker",
             video_id=operation_name,
             api_base=api_base,

--- a/tests/test_litellm/proxy/video_endpoints/test_endpoints.py
+++ b/tests/test_litellm/proxy/video_endpoints/test_endpoints.py
@@ -47,6 +47,7 @@ from litellm.types.videos.utils import (
 )
 
 from fastapi import Response
+from starlette.datastructures import UploadFile as StarletteUploadFile
 
 # --------------------------------------------------------------------------- #
 # A real model-encoded video id: decodes (for real) to provider "azure",
@@ -448,6 +449,31 @@ async def test_edit__json_string_video_reference_from_form_field(harness):
     )
 
     assert harness.processor_data()["video_id"] == "video_plain"
+
+
+@pytest.mark.asyncio
+async def test_edit__uploaded_video_file_is_forwarded_not_dropped(harness):
+    """A multipart-uploaded source video must be converted to bytes and attached
+    under ``video`` so the provider receives the file. Before the fix the upload
+    was popped, coerced to an empty ``video_id``, and silently dropped."""
+    import io
+
+    upload = StarletteUploadFile(file=io.BytesIO(b"rawmp4"), filename="clip.mp4")
+    harness.read_body.return_value = {"prompt": "make it nighttime", "video": upload}
+
+    await endpoints.video_edit(
+        request=FakeRequest(raw_body=b"multipart"),
+        fastapi_response=Response(),
+        user_api_key_dict=_user(),
+    )
+
+    harness.batch_to_bytesio.assert_called_once_with((upload,))
+    assert harness.processor_data() == {
+        "prompt": "make it nighttime",
+        "video": b"filebytes",
+        "video_id": "",
+        "custom_llm_provider": "openai",
+    }
 
 
 # =========================================================================== #

--- a/tests/test_litellm/test_video_generation.py
+++ b/tests/test_litellm/test_video_generation.py
@@ -2109,7 +2109,7 @@ class TestVideoEdit:
         """Verify JSON body with video.id for POST /videos/edits."""
         config = OpenAIVideoConfig()
 
-        url, data = config.transform_video_edit_request(
+        url, data, files = config.transform_video_edit_request(
             prompt="make it brighter",
             video_id="video_abc123",
             api_base="https://api.openai.com/v1/videos",
@@ -2120,12 +2120,13 @@ class TestVideoEdit:
         assert url == "https://api.openai.com/v1/videos/edits"
         assert data["prompt"] == "make it brighter"
         assert data["video"]["id"] == "video_abc123"
+        assert files is None
 
     def test_video_edit_transform_request_with_extra_body(self):
         """Extra body params are merged into request data."""
         config = OpenAIVideoConfig()
 
-        url, data = config.transform_video_edit_request(
+        url, data, files = config.transform_video_edit_request(
             prompt="darken it",
             video_id="video_abc123",
             api_base="https://api.openai.com/v1/videos",
@@ -2135,6 +2136,7 @@ class TestVideoEdit:
         )
 
         assert data["resolution"] == "1080p"
+        assert files is None
 
     def test_video_edit_mock_response(self):
         """video_edit returns VideoObject on mock_response."""
@@ -2160,7 +2162,7 @@ class TestVideoEdit:
         config = OpenAIVideoConfig()
 
         encoded_id = encode_video_id_with_provider("raw_video_id", "openai", None)
-        url, data = config.transform_video_edit_request(
+        url, data, files = config.transform_video_edit_request(
             prompt="test",
             video_id=encoded_id,
             api_base="https://api.openai.com/v1/videos",
@@ -2170,6 +2172,7 @@ class TestVideoEdit:
 
         # The video.id in the request body should be the raw ID, not the encoded one
         assert data["video"]["id"] == "raw_video_id"
+        assert files is None
 
 
 class TestVideoExtension:


### PR DESCRIPTION
## TLDR

Problem this solves:

- `/v1/videos/edits` parsed an uploaded source video, then dropped it
- The provider got JSON with no file, so raw-file edits could never run

How it solves it:

- Forward the uploaded file down to the provider transform
- OpenAI now sends multipart with a `video` file part, like its own SDK
- Edit-by-id keeps sending JSON, unchanged

## User Flow

Before: a developer uploading a raw source video to `/v1/videos/edits` has the file silently dropped, so the provider gets a request with no video and the edit never runs

1. They POST `multipart/form-data` to `https://litellm-domain/v1/videos/edits` with `model`, `prompt`, and a `video` file part holding the raw mp4 bytes
2. The gateway forwards to the provider as `application/json` with no file part, so the source video never leaves the gateway
3. The provider, seeing no source video, rejects the request with a 400 about the missing `prompt`/file, so the edit never runs

After: the same upload reaches the provider as a real multipart file, exactly like the official OpenAI SDK's `client.videos.edit(prompt=..., video=<file>)` sends it

1. They POST `multipart/form-data` to `https://litellm-domain/v1/videos/edits` with `model`, `prompt`, and a `video` file part holding the raw mp4 bytes
2. The gateway forwards to the provider as `multipart/form-data` carrying the same `video` file part, filename and all bytes preserved
3. The provider receives the source video and runs the edit: against an OpenAI-compatible backend a `200` with a video id comes back, and against OpenAI's live endpoint the multipart is accepted and reaches the same handling the official SDK hits

Edit-by-id is untouched: a developer sending `application/json` with `{"video": {"id": "video_..."}}` still has it forwarded as JSON, before and after

## Relevant issues

## Linear ticket

Resolves LIT-6045

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Shared setup (an OpenAI-compatible backend logs exactly what LiteLLM sends it: request content-type, form fields, and file parts with their byte counts):

```yaml
# proxy config (both before and after proxies)
model_list:
  - model_name: my-edit-model
    litellm_params:
      model: openai/my-edit-model
      api_base: http://127.0.0.1:64762/v1   # the logging backend
      api_key: dummy
general_settings:
  master_key: sk-1234
```

`source.mp4` is a 117-byte mp4. Before proxy booted at the merge base on `:51893`, After proxy at the PR tip on `:64763`, both pointing at the same backend on `:64762`.

### Before (6147b3ce6e)

#### uploaded source file

1. Upload the raw file:

```bash
curl -sS -X POST http://127.0.0.1:51893/v1/videos/edits \
  -H "Authorization: Bearer sk-1234" \
  -F "model=my-edit-model" -F "prompt=make it nighttime" \
  -F "video=@source.mp4;type=video/mp4" -w "\nHTTP %{http_code}\n"
# -> HTTP 400 (backend rejects: the provider never saw a source video)
```

2. What the backend actually received (dropped file):

```json
{"method": "POST", "path": "/v1/videos/edits", "content_type": "application/json"}
{"kind": "videos.edit", "fields": {}, "files": {}}
```

#### edit-by-id (regression guard)

1. Reference an existing video by id:

```bash
curl -sS -X POST http://127.0.0.1:51893/v1/videos/edits \
  -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
  -d '{"model":"my-edit-model","prompt":"make it nighttime","video":{"id":"video_abc123"}}'
```

2. What the backend received (JSON, no file):

```json
{"method": "POST", "path": "/v1/videos/edits", "content_type": "application/json"}
{"kind": "videos.edit", "fields": {}, "files": {}}
```

### After (eb00f46c5d, re-verified live at tip)

#### uploaded source file

1. Same upload:

```bash
curl -sS -X POST http://127.0.0.1:64763/v1/videos/edits \
  -H "Authorization: Bearer sk-1234" \
  -F "model=my-edit-model" -F "prompt=make it nighttime" \
  -F "video=@source.mp4;type=video/mp4" -w "\nHTTP %{http_code}\n"
# -> HTTP 200
# {"id":"video_...","object":"video","status":"completed","model":"my-edit-model",...}
```

2. What the backend received (file forwarded intact):

```json
{"method": "POST", "path": "/v1/videos/edits", "content_type": "multipart/form-data; boundary=..."}
{"kind": "videos.edit", "fields": {"prompt": "make it nighttime"}, "files": {"video": {"filename": "source.mp4", "bytes": 117}}}
```

#### edit-by-id (regression guard)

1. Same id reference:

```bash
curl -sS -X POST http://127.0.0.1:64763/v1/videos/edits \
  -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
  -d '{"model":"my-edit-model","prompt":"make it nighttime","video":{"id":"video_abc123"}}'
```

2. What the backend received (JSON, no file: identical to Before, no regression):

```json
{"method": "POST", "path": "/v1/videos/edits", "content_type": "application/json"}
{"kind": "videos.edit", "fields": {}, "files": {}}
```

### Real OpenAI passthrough (parity with the official SDK, at eb00f46c5d)

The uploaded-file multipart LiteLLM emits is byte-for-byte what the official `openai` SDK sends, so both reach OpenAI's live endpoint and hit the same response:

1. Through LiteLLM (`sora-real` -> `openai/sora-2`, real key, `-> https://api.openai.com/v1/videos/edits`):

```bash
curl -sS -X POST http://127.0.0.1:57341/v1/videos/edits \
  -H "Authorization: Bearer sk-1234" \
  -F "model=sora-real" -F "prompt=make it nighttime" \
  -F "video=@source.mp4;type=video/mp4" -w "\nHTTP %{http_code}\n"
# -> HTTP 400  OpenAIException: {"message":"Unknown parameter: 'video'.","type":"invalid_request_error","code":"unknown_parameter"}
```

2. The official SDK 2.33.0, same file, same endpoint:

```python
client.videos.edit(prompt="make it nighttime", video=<same 117-byte mp4>)
# -> 400  {"message":"Unknown parameter: 'video'.","type":"invalid_request_error","code":"unknown_parameter"}
```

Same URL, same multipart field name `video`, same verbatim error. The multipart leaves LiteLLM correctly and matches the reference client; the `video` rejection is OpenAI-side (their `/videos/edits` isn't accepting the source-video param yet) and hits the official SDK identically.

## Type

🐛 Bug Fix

## Caveats

- OpenAI's live `/videos/edits` currently rejects the `video` param; the SDK hits this too
- Only the OpenAI transform emits multipart today; other providers still 3-tuple with `files=None`

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR


- [x] 7d0df4a062648ffb11ad4c9c02af787c28914a17 passes /live-pr-risk


- [x] eb00f46c5d707b1dc9ca37d82d39bd0100e09683 passes /live-pr-risk

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the video-edit request contract and HTTP encoding path end-to-end; behavior for file uploads is new, though JSON edit-by-id is preserved and covered by tests.
> 
> **Overview**
> Fixes a bug where **multipart uploads** to `/v1/videos/edits` were parsed and then **discarded**, so upstream providers only saw JSON with no source video.
> 
> The proxy now detects a `video` **file upload**, converts it to a `BytesIO` (with filename), passes it as `video` into `video_edit` / `avideo_edit`, and sets `video_id` to empty for file-based edits. **Edit-by-id** (JSON `{"video": {"id": "..."}}`) is unchanged.
> 
> `transform_video_edit_request` gains optional `video_file` and returns **`(url, data, files)`** instead of `(url, data)`. Sync/async **video edit handlers** post **multipart** when `files` is set, otherwise **JSON** as before. **OpenAI** builds a `video` multipart part (with `video/mp4` MIME) when a file is present; Vertex and other providers return `files=None`. A small refactor shares `_video_file_tuple` for character and edit uploads.
> 
> Tests cover multipart vs JSON edit transforms and proxy forwarding of uploaded video.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eb00f46c5d707b1dc9ca37d82d39bd0100e09683. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->