### PR TITLE
feat(ui): add error-code drilldown for failed requests on caching page

### DIFF
--- a/litellm/proxy/analytics_endpoints/cache_activity.py
+++ b/litellm/proxy/analytics_endpoints/cache_activity.py
@@ -34,10 +34,18 @@ class CacheActivityFilterOptions(BaseModel):
     models: list[str]
 
 
+class CacheActivityErrorBucket(BaseModel):
+    call_type: str
+    error_code: str
+    error_class: str
+    count: int
+
+
 class CacheActivityResponse(BaseModel):
     groups: list[CacheActivityGroup]
     totals: CacheActivityTotals
     filter_options: CacheActivityFilterOptions
+    error_breakdown: tuple[CacheActivityErrorBucket, ...]
 
 
 GROUPS_SQL: Final = """
@@ -62,6 +70,26 @@ GROUPS_SQL: Final = """
         AND ($4::jsonb = '[]'::jsonb
             OR sl."model" IN (SELECT jsonb_array_elements_text($4::jsonb)))
     GROUP BY 1
+    ORDER BY (COUNT(*)) DESC
+"""
+
+ERROR_BREAKDOWN_SQL: Final = """
+    SELECT
+        CASE WHEN sl."call_type" = '' THEN 'Unknown' ELSE sl."call_type" END AS call_type,
+        COALESCE(NULLIF(sl."metadata"->'error_information'->>'error_code', ''), 'Unknown') AS error_code,
+        COALESCE(NULLIF(sl."metadata"->'error_information'->>'error_class', ''), 'Unknown') AS error_class,
+        COUNT(*)::int AS count
+    FROM "LiteLLM_SpendLogs" sl
+    LEFT JOIN "LiteLLM_VerificationToken" vt ON sl."api_key" = vt."token"
+    WHERE
+        sl."status" = 'failure'
+        AND sl."startTime" >= ($1::timestamptz AT TIME ZONE 'UTC')
+        AND sl."startTime" <  (($2::timestamptz + INTERVAL '1 day') AT TIME ZONE 'UTC')
+        AND ($3::jsonb = '[]'::jsonb
+            OR COALESCE(vt."key_alias", 'Unnamed Key') IN (SELECT jsonb_array_elements_text($3::jsonb)))
+        AND ($4::jsonb = '[]'::jsonb
+            OR sl."model" IN (SELECT jsonb_array_elements_text($4::jsonb)))
+    GROUP BY 1, 2, 3
     ORDER BY (COUNT(*)) DESC
 """
 
@@ -95,6 +123,7 @@ class _ModelRow(BaseModel):
 
 
 _groups_adapter: Final = TypeAdapter(list[CacheActivityGroup])
+_error_buckets_adapter: Final = TypeAdapter(tuple[CacheActivityErrorBucket, ...])
 _key_alias_rows_adapter: Final = TypeAdapter(list[_KeyAliasRow])
 _model_rows_adapter: Final = TypeAdapter(list[_ModelRow])
 
@@ -120,10 +149,11 @@ async def get_cache_activity(
     key_aliases: Sequence[str],
     models: Sequence[str],
 ) -> CacheActivityResponse:
-    group_rows, key_alias_rows, model_rows = await asyncio.gather(
-        prisma_client.db.query_raw(
-            GROUPS_SQL, start_date, end_date, json.dumps(list(key_aliases)), json.dumps(list(models))
-        ),
+    key_aliases_json: Final = json.dumps(list(key_aliases))
+    models_json: Final = json.dumps(list(models))
+    group_rows, error_rows, key_alias_rows, model_rows = await asyncio.gather(
+        prisma_client.db.query_raw(GROUPS_SQL, start_date, end_date, key_aliases_json, models_json),
+        prisma_client.db.query_raw(ERROR_BREAKDOWN_SQL, start_date, end_date, key_aliases_json, models_json),
         prisma_client.db.query_raw(KEY_ALIAS_OPTIONS_SQL, start_date, end_date),
         prisma_client.db.query_raw(MODEL_OPTIONS_SQL, start_date, end_date),
     )
@@ -135,4 +165,5 @@ async def get_cache_activity(
             key_aliases=[row.key_alias for row in _key_alias_rows_adapter.validate_python(key_alias_rows or [])],
             models=[row.model for row in _model_rows_adapter.validate_python(model_rows or [])],
         ),
+        error_breakdown=_error_buckets_adapter.validate_python(error_rows or []),
     )

--- a/tests/test_litellm/proxy/analytics_endpoints/test_analytics_endpoints.py
+++ b/tests/test_litellm/proxy/analytics_endpoints/test_analytics_endpoints.py
@@ -14,6 +14,7 @@ from fastapi import HTTPException
 
 from litellm.proxy.analytics_endpoints.analytics_endpoints import get_global_activity
 from litellm.proxy.analytics_endpoints.cache_activity import (
+    ERROR_BREAKDOWN_SQL,
     GROUPS_SQL,
     CacheActivityGroup,
     compute_totals,
@@ -37,6 +38,11 @@ GROUP_ROWS = [
         "generated_completion_tokens": 0,
     },
 ]
+ERROR_ROWS = [
+    {"call_type": "acompletion", "error_code": "429", "error_class": "RateLimitError", "count": 150},
+    {"call_type": "acompletion", "error_code": "401", "error_class": "AuthenticationError", "count": 50},
+    {"call_type": "Unknown", "error_code": "Unknown", "error_class": "Unknown", "count": 110},
+]
 KEY_ALIAS_ROWS = [{"key_alias": "Unnamed Key"}, {"key_alias": "my-key"}]
 MODEL_ROWS = [{"model": "gpt-5.1"}]
 
@@ -49,6 +55,8 @@ def build_prisma(query_raw: AsyncMock) -> MagicMock:
 
 def dispatching_query_raw() -> AsyncMock:
     async def dispatch(sql: str, *params: object) -> list[dict[str, object]]:
+        if "error_code" in sql:
+            return ERROR_ROWS
         if "GROUP BY" in sql:
             return GROUP_ROWS
         if "key_alias" in sql:
@@ -67,9 +75,7 @@ def mock_prisma(monkeypatch: pytest.MonkeyPatch) -> MagicMock:
 
 @pytest.mark.asyncio
 async def test_returns_groups_totals_and_filter_options(mock_prisma: MagicMock):
-    response = await get_global_activity(
-        start_date="2026-07-01", end_date="2026-07-27", key_aliases=[], models=[]
-    )
+    response = await get_global_activity(start_date="2026-07-01", end_date="2026-07-27", key_aliases=[], models=[])
 
     assert [group.call_type for group in response.groups] == ["acompletion", "Unknown"]
     assert response.groups[0].api_requests == 1000
@@ -81,6 +87,11 @@ async def test_returns_groups_totals_and_filter_options(mock_prisma: MagicMock):
     assert response.totals.cache_hit_ratio == pytest.approx((300 / 1610) * 100)
     assert response.filter_options.key_aliases == ["Unnamed Key", "my-key"]
     assert response.filter_options.models == ["gpt-5.1"]
+    assert [(bucket.error_code, bucket.error_class, bucket.count) for bucket in response.error_breakdown] == [
+        ("429", "RateLimitError", 150),
+        ("401", "AuthenticationError", 50),
+        ("Unknown", "Unknown", 110),
+    ]
 
 
 @pytest.mark.asyncio
@@ -92,11 +103,13 @@ async def test_filters_are_passed_to_sql_as_json_arrays(mock_prisma: MagicMock):
         models=["gpt-5.1", "claude-opus-4-8"],
     )
 
-    groups_call = next(
-        call for call in mock_prisma.db.query_raw.call_args_list if "GROUP BY" in call.args[0]
-    )
-    assert groups_call.args[3] == json.dumps(["my-key"])
-    assert groups_call.args[4] == json.dumps(["gpt-5.1", "claude-opus-4-8"])
+    filtered_calls = [
+        call for call in mock_prisma.db.query_raw.call_args_list if call.args[0] in (GROUPS_SQL, ERROR_BREAKDOWN_SQL)
+    ]
+    assert len(filtered_calls) == 2
+    for call in filtered_calls:
+        assert call.args[3] == json.dumps(["my-key"])
+        assert call.args[4] == json.dumps(["gpt-5.1", "claude-opus-4-8"])
 
 
 @pytest.mark.asyncio
@@ -131,3 +144,10 @@ def test_totals_denominator_includes_failed_requests():
 def test_groups_sql_splits_failures_and_labels_empty_call_type_unknown():
     assert "SUM(CASE WHEN sl.\"status\" = 'failure' THEN 1 ELSE 0 END)" in GROUPS_SQL
     assert "CASE WHEN sl.\"call_type\" = '' THEN 'Unknown' ELSE sl.\"call_type\" END" in GROUPS_SQL
+
+
+def test_error_breakdown_sql_counts_only_failures_bucketed_by_code_and_class():
+    assert "sl.\"status\" = 'failure'" in ERROR_BREAKDOWN_SQL
+    assert "sl.\"metadata\"->'error_information'->>'error_code'" in ERROR_BREAKDOWN_SQL
+    assert "sl.\"metadata\"->'error_information'->>'error_class'" in ERROR_BREAKDOWN_SQL
+    assert "GROUP BY 1, 2, 3" in ERROR_BREAKDOWN_SQL

--- a/ui/litellm-dashboard/src/app/(dashboard)/caching/_components/ErrorDrilldown.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/caching/_components/ErrorDrilldown.test.tsx
@@ -1,0 +1,55 @@
+import React from "react";
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { ErrorCodeTooltip, groupErrorBuckets, type CacheActivityErrorBucket } from "./ErrorDrilldown";
+
+const BUCKETS: CacheActivityErrorBucket[] = [
+  { call_type: "acompletion", error_code: "401", error_class: "AuthenticationError", count: 50 },
+  { call_type: "acompletion", error_code: "429", error_class: "RateLimitError", count: 120 },
+  { call_type: "acompletion", error_code: "429", error_class: "InternalServerError", count: 30 },
+  { call_type: "aembedding", error_code: "500", error_class: "InternalServerError", count: 999 },
+];
+
+describe("groupErrorBuckets", () => {
+  it("keeps only the requested call_type, totals per code, and sorts codes and classes by count desc", () => {
+    expect(groupErrorBuckets(BUCKETS, "acompletion")).toEqual([
+      {
+        error_code: "429",
+        "Failed requests": 150,
+        classes: [
+          { error_class: "RateLimitError", count: 120 },
+          { error_class: "InternalServerError", count: 30 },
+        ],
+      },
+      {
+        error_code: "401",
+        "Failed requests": 50,
+        classes: [{ error_class: "AuthenticationError", count: 50 }],
+      },
+    ]);
+  });
+
+  it("returns no data for a call_type without failures", () => {
+    expect(groupErrorBuckets(BUCKETS, "atranscription")).toEqual([]);
+  });
+});
+
+describe("ErrorCodeTooltip", () => {
+  const datum = groupErrorBuckets(BUCKETS, "acompletion")[0];
+
+  it("shows the code total and one row per error class on hover", () => {
+    render(<ErrorCodeTooltip active label="429" payload={[{ payload: datum, value: 150, graphicalItemId: "bar" }]} />);
+
+    expect(screen.getByText("Error code 429: 150 failed")).toBeInTheDocument();
+    expect(screen.getByText("RateLimitError")).toBeInTheDocument();
+    expect(screen.getByText("120")).toBeInTheDocument();
+    expect(screen.getByText("InternalServerError")).toBeInTheDocument();
+    expect(screen.getByText("30")).toBeInTheDocument();
+  });
+
+  it("renders nothing when inactive", () => {
+    const { container } = render(<ErrorCodeTooltip active={false} label="429" payload={[]} />);
+
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/ui/litellm-dashboard/src/app/(dashboard)/caching/_components/ErrorDrilldown.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/caching/_components/ErrorDrilldown.tsx
@@ -1,0 +1,99 @@
+"use client";
+
+import React from "react";
+import { X } from "lucide-react";
+import { BarChart } from "@/components/shared/charts";
+import type { ChartTooltipProps } from "@/components/shared/charts/chart_tooltip";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import type { components } from "@/lib/http/schema";
+
+export type CacheActivityErrorBucket = components["schemas"]["CacheActivityErrorBucket"];
+
+export const FAILED_REQUESTS_SERIES = "Failed requests";
+
+export type ErrorClassCount = {
+  error_class: string;
+  count: number;
+};
+
+export type ErrorCodeDatum = {
+  error_code: string;
+  [FAILED_REQUESTS_SERIES]: number;
+  classes: ErrorClassCount[];
+};
+
+export const groupErrorBuckets = (buckets: readonly CacheActivityErrorBucket[], callType: string): ErrorCodeDatum[] => {
+  const byCode = new Map<string, Map<string, number>>();
+  for (const bucket of buckets) {
+    if (bucket.call_type !== callType) continue;
+    const classes = byCode.get(bucket.error_code) ?? new Map<string, number>();
+    classes.set(bucket.error_class, (classes.get(bucket.error_class) ?? 0) + bucket.count);
+    byCode.set(bucket.error_code, classes);
+  }
+  return [...byCode.entries()]
+    .map(([errorCode, classes]) => ({
+      error_code: errorCode,
+      [FAILED_REQUESTS_SERIES]: [...classes.values()].reduce((total, count) => total + count, 0),
+      classes: [...classes.entries()]
+        .map(([errorClass, count]) => ({ error_class: errorClass, count }))
+        .sort((a, b) => b.count - a.count),
+    }))
+    .sort((a, b) => b[FAILED_REQUESTS_SERIES] - a[FAILED_REQUESTS_SERIES]);
+};
+
+export const ErrorCodeTooltip = ({ active, payload, label }: ChartTooltipProps) => {
+  if (!active || !payload || payload.length === 0) return null;
+  const datum = payload[0]?.payload as ErrorCodeDatum | undefined;
+  if (!datum) return null;
+
+  return (
+    <div className="min-w-40 rounded-lg border border-border/50 bg-background px-2.5 py-1.5 text-xs shadow-xl">
+      <p className="mb-1.5 font-medium text-foreground">
+        Error code {String(label)}: {datum[FAILED_REQUESTS_SERIES].toLocaleString()} failed
+      </p>
+      <div className="grid gap-1.5">
+        {datum.classes.map((errorClass) => (
+          <div key={errorClass.error_class} className="flex w-full items-center justify-between gap-4">
+            <span className="text-muted-foreground">{errorClass.error_class}</span>
+            <span className="font-mono font-medium tabular-nums text-foreground">
+              {errorClass.count.toLocaleString()}
+            </span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+interface ErrorDrilldownCardProps {
+  callType: string;
+  buckets: readonly CacheActivityErrorBucket[];
+  valueFormatter: (value: number) => string;
+  onClose: () => void;
+}
+
+export const ErrorDrilldownCard = ({ callType, buckets, valueFormatter, onClose }: ErrorDrilldownCardProps) => (
+  <Card className="mt-4">
+    <CardHeader className="flex flex-row items-center justify-between">
+      <CardTitle className="text-base font-semibold">Failed requests by error code: {callType}</CardTitle>
+      <Button variant="outline" size="icon-sm" onClick={onClose} aria-label="Close error breakdown">
+        <X />
+      </Button>
+    </CardHeader>
+    <CardContent>
+      <p className="text-sm text-muted-foreground">Hover a bar to see the error classes behind that code.</p>
+      <BarChart
+        data={groupErrorBuckets(buckets, callType)}
+        index="error_code"
+        categories={[FAILED_REQUESTS_SERIES]}
+        colors={["red"]}
+        valueFormatter={valueFormatter}
+        showLegend={false}
+        customTooltip={ErrorCodeTooltip}
+        yAxisWidth={48}
+        className="mt-2"
+      />
+    </CardContent>
+  </Card>
+);

--- a/ui/litellm-dashboard/src/app/(dashboard)/caching/_components/ErrorDrilldown.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/caching/_components/ErrorDrilldown.tsx
@@ -24,21 +24,18 @@ export type ErrorCodeDatum = {
 };
 
 export const groupErrorBuckets = (buckets: readonly CacheActivityErrorBucket[], callType: string): ErrorCodeDatum[] => {
-  const byCode = new Map<string, Map<string, number>>();
-  for (const bucket of buckets) {
-    if (bucket.call_type !== callType) continue;
-    const classes = byCode.get(bucket.error_code) ?? new Map<string, number>();
-    classes.set(bucket.error_class, (classes.get(bucket.error_class) ?? 0) + bucket.count);
-    byCode.set(bucket.error_code, classes);
-  }
-  return [...byCode.entries()]
-    .map(([errorCode, classes]) => ({
-      error_code: errorCode,
-      [FAILED_REQUESTS_SERIES]: [...classes.values()].reduce((total, count) => total + count, 0),
-      classes: [...classes.entries()]
-        .map(([errorClass, count]) => ({ error_class: errorClass, count }))
-        .sort((a, b) => b.count - a.count),
-    }))
+  const rows = buckets.filter((bucket) => bucket.call_type === callType);
+  return [...new Set(rows.map((row) => row.error_code))]
+    .map((errorCode) => {
+      const codeRows = rows.filter((row) => row.error_code === errorCode);
+      return {
+        error_code: errorCode,
+        [FAILED_REQUESTS_SERIES]: codeRows.reduce((total, row) => total + row.count, 0),
+        classes: codeRows
+          .map((row) => ({ error_class: row.error_class, count: row.count }))
+          .sort((a, b) => b.count - a.count),
+      };
+    })
     .sort((a, b) => b[FAILED_REQUESTS_SERIES] - a[FAILED_REQUESTS_SERIES]);
 };
 

--- a/ui/litellm-dashboard/src/app/(dashboard)/caching/_components/cache_dashboard.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/caching/_components/cache_dashboard.test.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { screen, waitFor, within } from "@testing-library/react";
+import { fireEvent, screen, waitFor, within } from "@testing-library/react";
 import { renderWithProviders } from "../../../../../tests/test-utils";
 import CacheDashboard from "./cache_dashboard";
 
@@ -47,6 +47,11 @@ const cacheActivity = {
     key_aliases: ["my-key", "Unnamed Key"],
     models: ["gpt-5.1", "text-embedding-3-large"],
   },
+  error_breakdown: [
+    { call_type: "acompletion", error_code: "429", error_class: "RateLimitError", count: 150 },
+    { call_type: "acompletion", error_code: "401", error_class: "AuthenticationError", count: 50 },
+    { call_type: "aembedding", error_code: "500", error_class: "InternalServerError", count: 50 },
+  ],
 };
 
 const renderDashboard = () =>
@@ -183,6 +188,27 @@ describe("CacheDashboard cache analytics charts", () => {
       keyAliases: [],
       models: [],
     });
+  });
+
+  it("opens the error-code drilldown for a call_type when its failed segment is clicked, and closes it again", async () => {
+    renderDashboard();
+    const { requestsCard } = await findChartCards();
+
+    const redBar = Array.from(requestsCard.querySelectorAll(".recharts-bar")).find((bar) =>
+      bar.querySelector("path.recharts-rectangle")?.getAttribute("fill")?.includes("red"),
+    );
+    expect(redBar).toBeDefined();
+    expect(screen.queryByText(/Failed requests by error code/)).not.toBeInTheDocument();
+
+    fireEvent.click(redBar!.querySelectorAll("path.recharts-rectangle")[0]);
+
+    const drilldownCard = cardTitled("Failed requests by error code: acompletion");
+    expect(within(drilldownCard).getAllByText("429").length).toBeGreaterThan(0);
+    expect(within(drilldownCard).getAllByText("401").length).toBeGreaterThan(0);
+    expect(within(drilldownCard).queryByText("500")).not.toBeInTheDocument();
+
+    fireEvent.click(within(drilldownCard).getByRole("button", { name: "Close error breakdown" }));
+    expect(screen.queryByText(/Failed requests by error code/)).not.toBeInTheDocument();
   });
 
   it("formats y-axis ticks with compact notation", async () => {

--- a/ui/litellm-dashboard/src/app/(dashboard)/caching/_components/cache_dashboard.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/caching/_components/cache_dashboard.test.tsx
@@ -211,6 +211,31 @@ describe("CacheDashboard cache analytics charts", () => {
     expect(screen.queryByText(/Failed requests by error code/)).not.toBeInTheDocument();
   });
 
+  it("dismisses an open drilldown when refetched data no longer has failures for that call_type", async () => {
+    const { rerender } = renderDashboard();
+    const { requestsCard } = await findChartCards();
+
+    const redBar = Array.from(requestsCard.querySelectorAll(".recharts-bar")).find((bar) =>
+      bar.querySelector("path.recharts-rectangle")?.getAttribute("fill")?.includes("red"),
+    );
+    fireEvent.click(redBar!.querySelectorAll("path.recharts-rectangle")[0]);
+    expect(screen.getByText("Failed requests by error code: acompletion")).toBeInTheDocument();
+
+    useCacheActivity.mockReturnValue({
+      data: {
+        ...cacheActivity,
+        groups: cacheActivity.groups.map((group) =>
+          group.call_type === "acompletion" ? { ...group, failed_requests: 0 } : group,
+        ),
+        error_breakdown: cacheActivity.error_breakdown.filter((bucket) => bucket.call_type !== "acompletion"),
+      },
+      refetch: vi.fn(),
+    });
+    rerender(<CacheDashboard accessToken="sk-test" token="tok" userRole="Admin" userID="u1" premiumUser={false} />);
+
+    expect(screen.queryByText(/Failed requests by error code/)).not.toBeInTheDocument();
+  });
+
   it("formats y-axis ticks with compact notation", async () => {
     renderDashboard();
     const { requestsCard, tokensCard } = await findChartCards();

--- a/ui/litellm-dashboard/src/app/(dashboard)/caching/_components/cache_dashboard.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/caching/_components/cache_dashboard.tsx
@@ -49,6 +49,11 @@ const formatDateWithoutTZ = (date: Date | undefined) => {
   return date.toISOString().split("T")[0];
 };
 
+const resolveDrilldownCallType = (selected: string | null, groups: readonly CacheActivityGroup[]): string | null =>
+  selected !== null && groups.some((group) => group.call_type === selected && group.failed_requests > 0)
+    ? selected
+    : null;
+
 function valueFormatterNumbers(number: number) {
   const formatter = new Intl.NumberFormat("en-US", {
     maximumFractionDigits: 0,
@@ -98,6 +103,7 @@ const CacheDashboard: React.FC<CachePageProps> = ({ accessToken, token, userRole
   const uniqueApiKeys = activity?.filter_options.key_aliases ?? [];
   const uniqueModels = activity?.filter_options.models ?? [];
   const chartData = (activity?.groups ?? []).map(toChartDatum);
+  const activeDrilldownCallType = resolveDrilldownCallType(errorDrilldownCallType, activity?.groups ?? []);
 
   const handleRefreshClick = () => {
     refetch();
@@ -298,9 +304,9 @@ const CacheDashboard: React.FC<CachePageProps> = ({ accessToken, token, userRole
               </CardContent>
             </Card>
 
-            {errorDrilldownCallType !== null && (
+            {activeDrilldownCallType !== null && (
               <ErrorDrilldownCard
-                callType={errorDrilldownCallType}
+                callType={activeDrilldownCallType}
                 buckets={activity?.error_breakdown ?? []}
                 valueFormatter={valueFormatterNumbers}
                 onClose={() => setErrorDrilldownCallType(null)}

--- a/ui/litellm-dashboard/src/app/(dashboard)/caching/_components/cache_dashboard.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/caching/_components/cache_dashboard.tsx
@@ -27,6 +27,7 @@ import { useCacheActivity, type CacheActivityGroup } from "@/app/(dashboard)/hoo
 import { CacheHealthTab } from "./cache_health";
 import CacheSettings from "./cache_settings";
 import CoordinationRedisSettings from "./coordination_redis_settings";
+import { ErrorDrilldownCard } from "./ErrorDrilldown";
 
 const REQUEST_SERIES = {
   apiRequests: "LLM API requests",
@@ -73,6 +74,7 @@ const CacheDashboard: React.FC<CachePageProps> = ({ accessToken, token, userRole
   const anchor2 = useComboboxAnchor();
   const [selectedApiKeys, setSelectedApiKeys] = useState<string[]>([]);
   const [selectedModels, setSelectedModels] = useState<string[]>([]);
+  const [errorDrilldownCallType, setErrorDrilldownCallType] = useState<string | null>(null);
 
   const [dateValue, setDateValue] = useState<DateRangePickerValue>({
     from: new Date(Date.now() - 7 * 24 * 60 * 60 * 1000),
@@ -277,6 +279,9 @@ const CacheDashboard: React.FC<CachePageProps> = ({ accessToken, token, userRole
                 <CardTitle className="text-base font-semibold">Cache Hits vs API Requests</CardTitle>
               </CardHeader>
               <CardContent>
+                <p className="text-sm text-muted-foreground">
+                  Click a red failed-requests segment to see which error codes caused those failures.
+                </p>
                 <BarChart
                   data={chartData}
                   stack={true}
@@ -285,9 +290,22 @@ const CacheDashboard: React.FC<CachePageProps> = ({ accessToken, token, userRole
                   categories={[REQUEST_SERIES.apiRequests, REQUEST_SERIES.cacheHits, REQUEST_SERIES.failed]}
                   colors={["sky", "teal", "red"]}
                   yAxisWidth={48}
+                  className="mt-2"
+                  onValueChange={(item) => {
+                    if (item.categoryClicked === REQUEST_SERIES.failed) setErrorDrilldownCallType(item.name);
+                  }}
                 />
               </CardContent>
             </Card>
+
+            {errorDrilldownCallType !== null && (
+              <ErrorDrilldownCard
+                callType={errorDrilldownCallType}
+                buckets={activity?.error_breakdown ?? []}
+                valueFormatter={valueFormatterNumbers}
+                onClose={() => setErrorDrilldownCallType(null)}
+              />
+            )}
 
             <Card className="mt-6">
               <CardHeader>

--- a/ui/litellm-dashboard/src/lib/http/schema.d.ts
+++ b/ui/litellm-dashboard/src/lib/http/schema.d.ts
@@ -23009,6 +23009,17 @@ export interface components {
             /** Total Requested */
             total_requested: number;
         };
+        /** CacheActivityErrorBucket */
+        CacheActivityErrorBucket: {
+            /** Call Type */
+            call_type: string;
+            /** Count */
+            count: number;
+            /** Error Class */
+            error_class: string;
+            /** Error Code */
+            error_code: string;
+        };
         /** CacheActivityFilterOptions */
         CacheActivityFilterOptions: {
             /** Key Aliases */
@@ -23033,6 +23044,8 @@ export interface components {
         };
         /** CacheActivityResponse */
         CacheActivityResponse: {
+            /** Error Breakdown */
+            error_breakdown: components["schemas"]["CacheActivityErrorBucket"][];
             filter_options: components["schemas"]["CacheActivityFilterOptions"];
             /** Groups */
             groups: components["schemas"]["CacheActivityGroup"][];


### PR DESCRIPTION
## TLDR

Problem this solves:

- Caching page shows failed requests only as a red bar with a count
- A customer asked which error codes are behind those failures, with detail on hover

How it solves it:

- `/global/activity/cache_hits` now also returns failures bucketed by error code and class
- Clicking a red failed-requests segment opens a per-error-code drilldown chart
- Hovering a drilldown bar lists the error classes behind that code

## User Flow

Before: a proxy admin reviewing cache performance sees failures happening but cannot find out why from the UI

1. They open https://litellm-domain/ui/?page=caching and see the Cache Hits vs API Requests chart with a red "Failed requests" segment on the Unknown bar
2. They hover that bar and get only a count, for example "Failed requests: 164"
3. They click the red segment and nothing happens
4. To learn what those errors are (429s, 401s, 500s), they have to ask support or query the database by hand

After: the same admin gets the error-code breakdown in one click

1. They open https://litellm-domain/ui/?page=caching and see the same chart, now captioned "Click a red failed-requests segment to see which error codes caused those failures"
2. They hover that bar and still get the count
3. They click the red segment and a "Failed requests by error code" chart appears below with one bar per code: 403, 401, 429, 400, 500, and so on
4. They hover the 401 bar and see the classes behind it: KeyNotFoundError 42, AuthenticationError 14, ProxyException 4

## Relevant issues

## Linear ticket

Resolves LIT-5906

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Setup shared by both runs: proxy on localhost:4873 with a local response cache and real OpenAI `gpt-5.6` deployments, one deployment with a bad provider key, one with an unreachable `api_base`, and an `rpm_limit: 1` virtual key. Real traffic seeded through `/v1/chat/completions` (real OpenAI calls plus intentional failures):

```
broken-auth attempt 1 -> HTTP 401
unreachable attempt 1 -> HTTP 500
bad-request attempt 1 -> HTTP 400
rpm-limited attempt 2 -> HTTP 429
```

### Before (25ec6827b7)

#### Endpoint payload

1. `curl -s "http://localhost:4873/global/activity/cache_hits?start_date=2026-08-17&end_date=2026-08-24" -H 'Authorization: Bearer sk-1234'` piped to `jq 'keys'`
2. Output: `["filter_options", "groups", "totals"]`, so no error information is available to the UI

#### Caching page drilldown

1. Open http://localhost:4873/ui/?page=caching and hover the Unknown bar: the tooltip shows only "Failed requests: 164"
2. Click the red segment: nothing happens, no drilldown exists

![before: caching page at merge base](https://raw.githubusercontent.com/BerriAI/litellm/litellm_caching_error_drilldown_screenshots/caching-before-merge-base.png)

### After (a5c81e525b)

#### Endpoint payload

1. Same curl piped to `jq 'keys'`
2. Output: `["error_breakdown", "filter_options", "groups", "totals"]`
3. `jq '.error_breakdown[:3]'` shows real buckets from the seeded traffic:

```json
[
  {"call_type": "Unknown", "error_code": "403", "error_class": "ProxyException", "count": 62},
  {"call_type": "Unknown", "error_code": "401", "error_class": "KeyNotFoundError", "count": 42},
  {"call_type": "Unknown", "error_code": "401", "error_class": "AuthenticationError", "count": 14}
]
```

#### Caching page drilldown

1. Open http://localhost:4873/ui/?page=caching: the chart now carries the caption "Click a red failed-requests segment to see which error codes caused those failures"

![after: main chart with caption](https://raw.githubusercontent.com/BerriAI/litellm/litellm_caching_error_drilldown_screenshots/caching-main-chart.png)

2. Click the red segment on the Unknown bar: a "Failed requests by error code: Unknown" chart appears with one bar per code (403, 401, Unknown, 429, 400, unknown_url, 500, invalid_value, 404)
3. Hover the 401 bar: the tooltip reads "Error code 401: 55 failed" with KeyNotFoundError 42 and AuthenticationError 13
4. Click the X on the drilldown card: it closes again
5. With the drilldown open, filter models to one with zero failures (`openai/gpt-5.4-nano`): the drilldown dismisses itself instead of lingering with stale scope

![after: error-code drilldown with hover tooltip](https://raw.githubusercontent.com/BerriAI/litellm/litellm_caching_error_drilldown_screenshots/caching-error-drilldown.png)

## Type

🆕 New Feature

## Caveats (if any)

- Failed spend logs carry no call type today, so failures bucket under "Unknown"
- Error codes are stored as provider strings and can be non numeric, e.g. `unknown_url`

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
