### PR TITLE
fix(bedrock): preserve usage details in fake streams

### DIFF
--- a/litellm/llms/bedrock/chat/invoke_handler.py
+++ b/litellm/llms/bedrock/chat/invoke_handler.py
@@ -824,6 +824,16 @@ class MockResponseIterator:  # for returning ai21 streaming responses
                     prompt_tokens=chunk_usage.prompt_tokens,
                     completion_tokens=chunk_usage.completion_tokens,
                     total_tokens=chunk_usage.total_tokens,
+                    prompt_tokens_details=(
+                        chunk_usage.prompt_tokens_details.model_dump(exclude_none=True)
+                        if chunk_usage.prompt_tokens_details is not None
+                        else None
+                    ),
+                    completion_tokens_details=(
+                        chunk_usage.completion_tokens_details.model_dump(exclude_none=True)
+                        if chunk_usage.completion_tokens_details is not None
+                        else None
+                    ),
                 ),
                 index=0,
             )

--- a/tests/test_litellm/llms/bedrock/chat/test_invoke_handler.py
+++ b/tests/test_litellm/llms/bedrock/chat/test_invoke_handler.py
@@ -9,10 +9,57 @@ from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLogging
 from litellm.litellm_core_utils.streaming_handler import CustomStreamWrapper
 from litellm.llms.bedrock.chat.invoke_handler import (
     AWSEventStreamDecoder,
+    MockResponseIterator,
     make_call,
     make_sync_call,
 )
 from litellm.llms.custom_httpx.http_handler import AsyncHTTPHandler, HTTPHandler
+from litellm.types.utils import (
+    Choices,
+    CompletionTokensDetailsWrapper,
+    Message,
+    ModelResponse,
+    PromptTokensDetailsWrapper,
+    Usage,
+)
+
+
+def test_mock_response_iterator_preserves_usage_details():
+    response = ModelResponse(
+        choices=[
+            Choices(
+                finish_reason="stop",
+                index=0,
+                message=Message(content="done", role="assistant"),
+            )
+        ],
+        usage=Usage(
+            prompt_tokens=500,
+            completion_tokens=25,
+            total_tokens=525,
+            prompt_tokens_details=PromptTokensDetailsWrapper(
+                cached_tokens=321,
+                cache_write_tokens=123,
+            ),
+            completion_tokens_details=CompletionTokensDetailsWrapper(
+                reasoning_tokens=11,
+            ),
+        ),
+    )
+
+    chunk = MockResponseIterator(model_response=response)._chunk_parser(response)
+
+    assert chunk["usage"] == {
+        "prompt_tokens": 500,
+        "completion_tokens": 25,
+        "total_tokens": 525,
+        "prompt_tokens_details": {
+            "cached_tokens": 321,
+            "cache_write_tokens": 123,
+            "cache_creation_tokens": 123,
+        },
+        "completion_tokens_details": {"reasoning_tokens": 11},
+    }
 
 
 def test_transform_thinking_blocks_with_redacted_content():
@@ -203,9 +250,7 @@ def test_bedrock_converse_streaming_consistent_id():
     expected_id = f"chatcmpl-{native_conversation_id}"
 
     for response in parsed_responses:
-        assert (
-            response.id == expected_id
-        ), "All chunk IDs must match the one captured from the messageStart event"
+        assert response.id == expected_id, "All chunk IDs must match the one captured from the messageStart event"
 
 
 @pytest.mark.asyncio
@@ -472,4 +517,3 @@ async def test_async_invoke_streaming_forwards_bedrock_response_headers():
     )
 
     assert stream._hidden_params["additional_headers"]["llm_provider-x-amzn-requestid"] == "req-987"
-

--- a/tests/test_litellm/llms/bedrock/chat/test_invoke_handler.py
+++ b/tests/test_litellm/llms/bedrock/chat/test_invoke_handler.py
@@ -250,7 +250,9 @@ def test_bedrock_converse_streaming_consistent_id():
     expected_id = f"chatcmpl-{native_conversation_id}"
 
     for response in parsed_responses:
-        assert response.id == expected_id, "All chunk IDs must match the one captured from the messageStart event"
+        assert (
+            response.id == expected_id
+        ), "All chunk IDs must match the one captured from the messageStart event"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## TLDR

Problem this solves:

- Bedrock fake streams discard prompt and completion usage details
- Cache token counts disappear from downstream spend logs

How it solves it:

- Copy both detail objects into the generated stream chunk
- Add a regression test with nonzero cache and reasoning tokens

## User Flow

Before: a developer streams a Bedrock chat completion and the cache breakdown disappears

1. They send POST https://litellm-domain/v1/chat/completions with `"stream": true`
2. The final SSE chunk carries aggregate token counts but omits cache and reasoning details
3. They open https://litellm-domain/ui/?page=logs and cannot see the request's cache-token breakdown

After: the same streamed completion preserves the provider's complete usage object

1. They send POST https://litellm-domain/v1/chat/completions with `"stream": true`
2. The final SSE chunk carries aggregate counts plus prompt and completion token details
3. They open https://litellm-domain/ui/?page=logs and see the request's cache-token breakdown

## Relevant issues

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The test file covering my change passes locally
- [ ] My PR passes all required CI/CD checks
- [x] My PR's scope is as isolated as possible
- [ ] I have received a Greptile Confidence Score of at least 4/5

## Screenshots / Proof of Fix

This conversion is internal to the Bedrock fake-stream adapter, so it has no independent live endpoint toggle. The focused regression exercises the exact final chunk consumed by the proxy

### Before (fde307539e)

1. Build a response with `cached_tokens=321`, `cache_write_tokens=123`, and `reasoning_tokens=11`
2. Convert it through the Bedrock fake-stream iterator
3. Observe that the resulting usage contains only prompt, completion, and total tokens

### After (117ea7f907)

1. Build the same response with the same usage details
2. Convert it through the Bedrock fake-stream iterator
3. Observe that all cache and reasoning details remain in the resulting usage

## Type

Bug Fix

## Caveats (if any)

## Final Attestation

- [x] The test checks the real dropped fields and fails without the fix
