### PR TITLE
fix(router): break cost-based-routing ties on cache-read price

### DIFF
--- a/litellm/router_strategy/lowest_cost.py
+++ b/litellm/router_strategy/lowest_cost.py
@@ -265,9 +265,14 @@ class LowestCostLoggingHandler(CustomLogger):
             # if litellm["model"] is not in model_cost map -> use item_cost = $10
 
             item_cost = item_input_cost + item_output_cost
-            # falls back to the input price rather than 0 so a model with no cache-read entry is
-            # never ranked as though its cache reads were free
-            item_cache_read_cost = item_litellm_model_cost_map.get("cache_read_input_token_cost", item_input_cost)
+            # deployment override first, mirroring input/output above, then the cost map. An
+            # absent or explicitly null price falls back to the input price rather than 0, so a
+            # model without one is never ranked as though its cache reads were free
+            item_cache_read_cost = _deployment.get("litellm_params", {}).get("cache_read_input_token_cost")
+            if item_cache_read_cost is None:
+                item_cache_read_cost = item_litellm_model_cost_map.get("cache_read_input_token_cost")
+            if item_cache_read_cost is None:
+                item_cache_read_cost = item_input_cost
 
             item_rpm = item_map.get(precise_minute, {}).get("rpm", 0)
             item_tpm = item_map.get(precise_minute, {}).get("tpm", 0)

--- a/litellm/router_strategy/lowest_cost.py
+++ b/litellm/router_strategy/lowest_cost.py
@@ -265,6 +265,9 @@ class LowestCostLoggingHandler(CustomLogger):
             # if litellm["model"] is not in model_cost map -> use item_cost = $10
 
             item_cost = item_input_cost + item_output_cost
+            # falls back to the input price rather than 0 so a model with no cache-read entry is
+            # never ranked as though its cache reads were free
+            item_cache_read_cost = item_litellm_model_cost_map.get("cache_read_input_token_cost", item_input_cost)
 
             item_rpm = item_map.get(precise_minute, {}).get("rpm", 0)
             item_tpm = item_map.get(precise_minute, {}).get("tpm", 0)
@@ -294,12 +297,12 @@ class LowestCostLoggingHandler(CustomLogger):
             ):  # if user passed in tpm / rpm in the model_list
                 continue
             else:
-                potential_deployments.append((_deployment, item_cost))
+                potential_deployments.append((_deployment, item_cost, item_cache_read_cost))
 
         if len(potential_deployments) == 0:
             return None
 
-        potential_deployments = sorted(potential_deployments, key=lambda x: x[1])
+        potential_deployments = sorted(potential_deployments, key=lambda x: (x[1], x[2]))
 
         selected_deployment: Final = potential_deployments[0][0]
         return selected_deployment

--- a/tests/test_litellm/router_strategy/test_lowest_cost.py
+++ b/tests/test_litellm/router_strategy/test_lowest_cost.py
@@ -59,3 +59,64 @@ async def test_tied_input_output_price_breaks_on_cache_read_not_list_order(order
     selected = await handler.async_get_available_deployments(model_group=MODEL_GROUP, healthy_deployments=healthy)
 
     assert selected["model_info"]["id"] == CHEAP_CACHE
+
+
+@pytest.fixture
+def tied_prices_no_cache_entry():
+    """Same tie, but the cost map carries an explicit null cache-read price."""
+    for name in (PRICEY_CACHE, CHEAP_CACHE):
+        litellm.register_model(
+            {
+                f"openai/{name}": {
+                    "litellm_provider": "openai",
+                    "mode": "chat",
+                    "input_cost_per_token": 1.4e-07,
+                    "output_cost_per_token": 2.8e-07,
+                }
+            }
+        )
+        litellm.model_cost[f"openai/{name}"]["cache_read_input_token_cost"] = None
+    yield
+    for name in (PRICEY_CACHE, CHEAP_CACHE):
+        litellm.model_cost.pop(f"openai/{name}", None)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "order",
+    [[PRICEY_CACHE, CHEAP_CACHE], [CHEAP_CACHE, PRICEY_CACHE]],
+    ids=["pricey-listed-first", "cheap-listed-first"],
+)
+async def test_deployment_level_cache_read_override_breaks_the_tie(order, tied_prices):
+    """A per-deployment cache-read price must win over the shared model-map entry, the same way
+    input and output prices already honour litellm_params."""
+    handler = LowestCostLoggingHandler(router_cache=DualCache())
+    overrides = {PRICEY_CACHE: 9e-07, CHEAP_CACHE: 1e-09}
+    healthy = [
+        {
+            "model_name": MODEL_GROUP,
+            "litellm_params": {
+                "model": f"openai/{PRICEY_CACHE}",
+                "cache_read_input_token_cost": overrides[name],
+            },
+            "model_info": {"id": name},
+        }
+        for name in order
+    ]
+
+    selected = await handler.async_get_available_deployments(model_group=MODEL_GROUP, healthy_deployments=healthy)
+
+    assert selected["model_info"]["id"] == CHEAP_CACHE
+
+
+@pytest.mark.asyncio
+async def test_null_cache_read_price_does_not_break_sorting(tied_prices_no_cache_entry):
+    """An explicitly null cache-read price means unset, not zero, so it must fall back to the
+    input price instead of putting None into the sort key and raising TypeError."""
+    handler = LowestCostLoggingHandler(router_cache=DualCache())
+
+    selected = await handler.async_get_available_deployments(
+        model_group=MODEL_GROUP, healthy_deployments=_deployments([PRICEY_CACHE, CHEAP_CACHE])
+    )
+
+    assert selected["model_info"]["id"] in (PRICEY_CACHE, CHEAP_CACHE)

--- a/tests/test_litellm/router_strategy/test_lowest_cost.py
+++ b/tests/test_litellm/router_strategy/test_lowest_cost.py
@@ -1,0 +1,61 @@
+#### What this tests ####
+#    cost-based-routing scored deployments on input + output price alone, so two
+#    deployments whose input and output prices tie were ordered only by their position
+#    in model_list. cache_read_input_token_cost can differ 10x across such a tie, which
+#    is the price that dominates cache-heavy traffic. Issue #38064.
+
+import pytest
+
+import litellm
+from litellm.caching.caching import DualCache
+from litellm.router_strategy.lowest_cost import LowestCostLoggingHandler
+
+MODEL_GROUP = "test-tied-price-model"
+CHEAP_CACHE = "cheap-cache-read"
+PRICEY_CACHE = "pricey-cache-read"
+
+
+def _deployments(order):
+    return [
+        {
+            "model_name": MODEL_GROUP,
+            "litellm_params": {"model": f"openai/{name}"},
+            "model_info": {"id": name},
+        }
+        for name in order
+    ]
+
+
+@pytest.fixture
+def tied_prices():
+    """Two models with identical input and output prices, cache-read differing 10x."""
+    for name, cache_read in ((PRICEY_CACHE, 2.8e-08), (CHEAP_CACHE, 2.8e-09)):
+        litellm.register_model(
+            {
+                f"openai/{name}": {
+                    "litellm_provider": "openai",
+                    "mode": "chat",
+                    "input_cost_per_token": 1.4e-07,
+                    "output_cost_per_token": 2.8e-07,
+                    "cache_read_input_token_cost": cache_read,
+                }
+            }
+        )
+    yield
+    for name in (PRICEY_CACHE, CHEAP_CACHE):
+        litellm.model_cost.pop(f"openai/{name}", None)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "order",
+    [[PRICEY_CACHE, CHEAP_CACHE], [CHEAP_CACHE, PRICEY_CACHE]],
+    ids=["pricey-listed-first", "cheap-listed-first"],
+)
+async def test_tied_input_output_price_breaks_on_cache_read_not_list_order(order, tied_prices):
+    handler = LowestCostLoggingHandler(router_cache=DualCache())
+    healthy = _deployments(order)
+
+    selected = await handler.async_get_available_deployments(model_group=MODEL_GROUP, healthy_deployments=healthy)
+
+    assert selected["model_info"]["id"] == CHEAP_CACHE


### PR DESCRIPTION
## TLDR

Problem this solves:

- Cost routing scores on input plus output price only
- Cache-read price is never read, though it dominates cached traffic
- Two equal-priced deployments tie, so list order decides
- The cost map already ships such a tie, 10x apart

How it solves it:

- Break an exact tie on the cache-read price
- Fall back to the input price when a model declares none
- Read a deployment's own cache-read override before the map
- Deployments whose input plus output differ are untouched

## User Flow

Before: a team on cost-based-routing with two providers serving the same model pays 10x more per cached token than they need to, and which provider they get depends on the order they happened to type into their config

1. They configure two deployments of the same model under one `model_name`, one from each provider, and set `routing_strategy: cost-based-routing`
2. Both providers publish the same input and output price, and one publishes a cache-read price 10x lower than the other
3. They send POST https://litellm-domain/v1/chat/completions with a long stable system prompt, so most input tokens are cache reads
4. https://litellm-domain/ui/?page=logs shows the request served by whichever deployment sits first in the config, and moving the other one up flips it, at 10x the cache-read price either way

After: the cheaper cache-read deployment wins regardless of config order

1. They configure the same two deployments with the same strategy
2. Both providers publish the same input and output price, one with a 10x lower cache-read price
3. They send the same POST https://litellm-domain/v1/chat/completions with the same long stable system prompt
4. https://litellm-domain/ui/?page=logs shows the cheaper-cache deployment serving it, and reordering the config does not change that

## Relevant issues

Fixes #38064

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

The tie is in the shipped cost map, not synthetic. Both entries carry the same input and output price:

```
fireworks_ai/deepseek-v4-flash   input=1.4e-07  output=2.8e-07  cache_read=2.8e-08
tencent/deepseek-v4-flash        input=1.4e-07  output=2.8e-07  cache_read=2.8e-09
input + output = 4.2e-07 for both
```

Routing the same model group twice, changing only the order of `model_list`, at 432722944c:

Before:

```
list order ['fireworks_ai', 'tencent']  ->  routed to: fireworks_ai
list order ['tencent', 'fireworks_ai']  ->  routed to: tencent
```

After:

```
list order ['fireworks_ai', 'tencent']  ->  routed to: tencent
list order ['tencent', 'fireworks_ai']  ->  routed to: tencent
```

`tencent` is the deployment whose cache reads cost 10x less. To see it end to end, put both deployments under one `model_name` with `routing_strategy: cost-based-routing`, send a request with a long repeated system prompt, and check which deployment served it on /ui/?page=logs before and after reordering the list

## Type

🐛 Bug Fix

## Caveats (if any)

- Only breaks exact ties, it does not weight cache reads
- A model with no cache-read price falls back to its input price
- An explicitly null price is treated as unset, not zero


