### PR TITLE
feat(router): add redis router capability cache

### DIFF
--- a/litellm/router.py
+++ b/litellm/router.py
@@ -6929,14 +6929,15 @@ class Router:
         status_code: Final = getattr(error, "status_code", None)
         if status_code is not None and not litellm._should_retry(status_code):
             # 401/403 are special cases - allow retry if multiple deployments exist (handled below)
-            if status_code not in (401, 403):
+            # 404 means the provider does not serve this model, so the retry loop is
+            # allowed to advance to the next-priority deployment. The
+            # `_num_healthy_deployments <= 0` guard at the end of this method still
+            # raises once nothing else is left to try, and the capability cache in
+            # async_get_healthy_deployments keeps the 404-ing deployment out of the
+            # candidate list on subsequent attempts.
+            if status_code not in (401, 403, 404):
                 raise error
 
-        # HTTP 404 (litellm.NotFoundError) means the provider does not support
-        # this model. We allow the retry loop to continue so that order-based
-        # deployment fallback can advance to the next-priority provider.
-        # The capability cache in async_get_healthy_deployments ensures the
-        # incapable deployment is filtered out on the next attempt.
         # Error we should only retry if there are other deployments
         if isinstance(error, openai.RateLimitError):
             if (

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -3059,6 +3059,17 @@ class Router:
             ):
                 await response.fetch_stream()
 
+            # Record that this deployment successfully served this model.
+            # Stored in Redis (via DualCache) so all router instances share the signal.
+            _dep_id_cap: str | None = (deployment.get("model_info") or {}).get("id") if deployment else None
+            if _dep_id_cap:
+                asyncio.create_task(
+                    self.cache.async_set_cache(
+                        key=f"litellm:cap:{_dep_id_cap}:{model}",
+                        value=True,
+                        ttl=86400,  # 24h — re-confirm capability daily
+                    )
+                )
             self.success_calls[model_name] += 1
             verbose_router_logger.info("litellm.acompletion(model=%s)\x1b[32m 200 OK\x1b[0m", model_name)
             # debug how often this deployment picked
@@ -3096,6 +3107,19 @@ class Router:
             if deployment is not None:
                 self._set_deployment_num_retries_on_exception(e, deployment)
                 self._stamp_failed_deployment_id_with_effective_model_info(e, deployment, kwargs)
+                # 404 → provider does not support this model. Cache this signal in Redis
+                # (via DualCache) so every router instance skips this deployment next time.
+                # TTL of 1h means we re-test after an hour, in case the provider adds support.
+                if isinstance(e, litellm.NotFoundError):
+                    _dep_id_cap: str | None = (deployment.get("model_info") or {}).get("id")
+                    if _dep_id_cap:
+                        asyncio.create_task(
+                            self.cache.async_set_cache(
+                                key=f"litellm:cap:{_dep_id_cap}:{model}",
+                                value=False,
+                                ttl=3600,  # 1h — re-test after TTL
+                            )
+                        )
             raise e
 
     def _update_kwargs_before_fallbacks(
@@ -6908,8 +6932,11 @@ class Router:
             if status_code not in (401, 403):
                 raise error
 
-        if isinstance(error, litellm.NotFoundError):
-            raise error
+        # HTTP 404 (litellm.NotFoundError) means the provider does not support
+        # this model. We allow the retry loop to continue so that order-based
+        # deployment fallback can advance to the next-priority provider.
+        # The capability cache in async_get_healthy_deployments ensures the
+        # incapable deployment is filtered out on the next attempt.
         # Error we should only retry if there are other deployments
         if isinstance(error, openai.RateLimitError):
             if (
@@ -11280,19 +11307,44 @@ class Router:
             request_kwargs=request_kwargs,
         )
 
-        ## ORDER FILTERING ## -> if user set 'order' in deployments, return deployments with lowest order (e.g. order=1 > order=2)
-        _target_order: Final = (request_kwargs or {}).pop("_target_order", None)
-        healthy_deployments = litellm.utils._get_order_filtered_deployments(
-            cast(list[dict], healthy_deployments), target_order=_target_order
-        )
+        ## CAPABILITY CACHE FILTER ## -> skip deployments whose 404 responses have been
+        ## cached, indicating they cannot serve this model at this provider. The cache
+        ## is backed by Redis (via self.cache DualCache) with a TTL so providers that
+        ## later add model support are automatically re-tested after expiry.
+        ## key schema: litellm:cap:<deployment_id>:<model_group>
+        ##   None  → unknown (first request) → allow
+        ##   True  → confirmed capable        → allow
+        ##   False → confirmed incapable (404) → skip
+        _capable_deployments: list[dict] = []
+        for _dep in cast(list[dict], healthy_deployments):
+            _dep_id: str | None = (_dep.get("model_info") or {}).get("id")
+            if _dep_id:
+                _cap_key = f"litellm:cap:{_dep_id}:{model}"
+                _cached_cap = await self.cache.async_get_cache(_cap_key)
+                if _cached_cap is not False:  # None or True → keep
+                    _capable_deployments.append(_dep)
+            else:
+                _capable_deployments.append(_dep)  # no id to look up, allow through
+        if _capable_deployments:  # only narrow if filter leaves at least one candidate
+            healthy_deployments = _capable_deployments
 
-        ## WEIGHTED FAILOVER EXCLUSION ## -> drop deployments already tried in
-        ## this request via weighted-failover. Always honored, regardless of the
-        ## router-level flag, so a stale exclusion key on kwargs cannot escape.
+        ## WEIGHTED FAILOVER EXCLUSION ## -> drop deployments already tried in this
+        ## request via weighted-failover. Runs BEFORE order filter so that excluded
+        ## order-1 deployments don't prevent order-2 from being selected — this was
+        ## the root cause of silent 404 routing failures with order-based fallback.
         _excluded_deployment_ids: Final = (request_kwargs or {}).pop("_excluded_deployment_ids", None)
         healthy_deployments = litellm.utils._get_excluded_filtered_deployments(
             cast(list[dict], healthy_deployments),
             excluded_deployment_ids=_excluded_deployment_ids,
+        )
+
+        ## ORDER FILTERING ## -> if user set 'order' in deployments, return deployments
+        ## with the lowest order value (order=1 preferred over order=2). Runs AFTER
+        ## exclusion so incapable/excluded order-1 deployments correctly fall through
+        ## to order-2 rather than producing an empty deployment list.
+        _target_order: Final = (request_kwargs or {}).pop("_target_order", None)
+        healthy_deployments = litellm.utils._get_order_filtered_deployments(
+            cast(list[dict], healthy_deployments), target_order=_target_order
         )
 
         if len(healthy_deployments) == 0:

--- a/tests/test_litellm/test_router_capability_cache.py
+++ b/tests/test_litellm/test_router_capability_cache.py
@@ -1,0 +1,212 @@
+"""Tests for the router capability cache and the order/exclusion filter ordering.
+
+Covers three behaviours introduced together:
+
+1. A provider answering 404 for a model no longer aborts the request. The retry
+   loop is allowed to advance to the next-priority deployment.
+2. `async_get_healthy_deployments` applies weighted-failover exclusion BEFORE the
+   `model_info.order` filter, so excluded order-1 deployments fall through to
+   order-2 instead of emptying the candidate list.
+3. A DualCache entry per (deployment id, model group) records which providers
+   answered 404, so later requests skip them until the TTL expires.
+"""
+
+import pytest
+
+import litellm
+from litellm import Router
+
+MODEL_GROUP = "universal-group"
+
+
+def _two_tier_router() -> Router:
+    """Two deployments in one group: order 1 and order 2."""
+    return Router(
+        model_list=[
+            {
+                "model_name": MODEL_GROUP,
+                "litellm_params": {"model": "openai/tier-one", "api_key": "sk-tier-one"},
+                "model_info": {"id": "dep-order-1", "order": 1},
+            },
+            {
+                "model_name": MODEL_GROUP,
+                "litellm_params": {"model": "openai/tier-two", "api_key": "sk-tier-two"},
+                "model_info": {"id": "dep-order-2", "order": 2},
+            },
+        ]
+    )
+
+
+def _flat_router() -> Router:
+    """Two deployments in one group, no order set."""
+    return Router(
+        model_list=[
+            {
+                "model_name": MODEL_GROUP,
+                "litellm_params": {"model": "openai/alpha", "api_key": "sk-alpha"},
+                "model_info": {"id": "dep-alpha"},
+            },
+            {
+                "model_name": MODEL_GROUP,
+                "litellm_params": {"model": "openai/beta", "api_key": "sk-beta"},
+                "model_info": {"id": "dep-beta"},
+            },
+        ]
+    )
+
+
+def _not_found() -> litellm.NotFoundError:
+    return litellm.NotFoundError(
+        message="The model 'some-model' does not exist",
+        model=MODEL_GROUP,
+        llm_provider="openai",
+    )
+
+
+def _ids(deployments) -> set:
+    return {d["model_info"]["id"] for d in deployments}
+
+
+# ---------------------------------------------------------------- retry gating
+
+
+def test_404_retries_while_other_deployments_remain():
+    """A 404 returns True so the retry loop moves to the next deployment."""
+    router = _two_tier_router()
+
+    assert (
+        router.should_retry_this_error(
+            error=_not_found(),
+            healthy_deployments=[{"model_info": {"id": "dep-order-2"}}],
+            all_deployments=router.model_list,
+        )
+        is True
+    )
+
+
+def test_404_raises_once_nothing_healthy_is_left():
+    """The last 404 still surfaces to the caller instead of retrying forever."""
+    router = _two_tier_router()
+
+    with pytest.raises(litellm.NotFoundError):
+        router.should_retry_this_error(
+            error=_not_found(),
+            healthy_deployments=[],
+            all_deployments=router.model_list,
+        )
+
+
+@pytest.mark.parametrize(
+    "error",
+    [
+        litellm.BadRequestError(message="bad", model=MODEL_GROUP, llm_provider="openai"),
+        litellm.ContextWindowExceededError(
+            message="too long", model=MODEL_GROUP, llm_provider="openai"
+        ),
+    ],
+    ids=["400", "context-window"],
+)
+def test_other_4xx_errors_still_raise(error):
+    """Only 404 was exempted; other non-retryable 4xx keep aborting the request."""
+    router = _two_tier_router()
+
+    with pytest.raises(type(error)):
+        router.should_retry_this_error(
+            error=error,
+            healthy_deployments=[{"model_info": {"id": "dep-order-2"}}],
+            all_deployments=router.model_list,
+        )
+
+
+# ------------------------------------------------------- exclusion before order
+
+
+@pytest.mark.asyncio
+async def test_excluded_order_1_falls_through_to_order_2():
+    """Regression: excluding every order-1 deployment used to empty the list.
+
+    The order filter narrowed to order-1 first, exclusion then removed all of
+    them, and the caller saw "No deployments available" while a healthy order-2
+    deployment was sitting right there.
+    """
+    router = _two_tier_router()
+
+    deployments = await router.async_get_healthy_deployments(
+        model=MODEL_GROUP,
+        request_kwargs={"_excluded_deployment_ids": ["dep-order-1"]},
+        messages=[{"role": "user", "content": "hi"}],
+    )
+
+    assert _ids(deployments) == {"dep-order-2"}
+
+
+@pytest.mark.asyncio
+async def test_order_1_preferred_when_nothing_is_excluded():
+    """The order filter still wins when exclusion removes nothing."""
+    router = _two_tier_router()
+
+    deployments = await router.async_get_healthy_deployments(
+        model=MODEL_GROUP,
+        request_kwargs={},
+        messages=[{"role": "user", "content": "hi"}],
+    )
+
+    assert _ids(deployments) == {"dep-order-1"}
+
+
+# --------------------------------------------------------------- capability cache
+
+
+@pytest.mark.asyncio
+async def test_incapable_deployment_is_skipped():
+    """A deployment cached as incapable drops out of the candidate list."""
+    router = _flat_router()
+    await router.cache.async_set_cache(
+        key=f"litellm:cap:dep-alpha:{MODEL_GROUP}", value=False, ttl=3600
+    )
+
+    deployments = await router.async_get_healthy_deployments(
+        model=MODEL_GROUP,
+        request_kwargs={},
+        messages=[{"role": "user", "content": "hi"}],
+    )
+
+    assert _ids(deployments) == {"dep-beta"}
+
+
+@pytest.mark.asyncio
+async def test_capable_and_unknown_deployments_are_kept():
+    """True means keep; a missing entry means untested, so also keep."""
+    router = _flat_router()
+    await router.cache.async_set_cache(
+        key=f"litellm:cap:dep-alpha:{MODEL_GROUP}", value=True, ttl=86400
+    )
+
+    deployments = await router.async_get_healthy_deployments(
+        model=MODEL_GROUP,
+        request_kwargs={},
+        messages=[{"role": "user", "content": "hi"}],
+    )
+
+    assert _ids(deployments) == {"dep-alpha", "dep-beta"}
+
+
+@pytest.mark.asyncio
+async def test_all_incapable_falls_back_to_the_full_list():
+    """With every candidate cached incapable the filter is skipped.
+
+    Better to re-probe a stale cache than to refuse a request outright.
+    """
+    router = _flat_router()
+    for dep_id in ("dep-alpha", "dep-beta"):
+        await router.cache.async_set_cache(
+            key=f"litellm:cap:{dep_id}:{MODEL_GROUP}", value=False, ttl=3600
+        )
+
+    deployments = await router.async_get_healthy_deployments(
+        model=MODEL_GROUP,
+        request_kwargs={},
+        messages=[{"role": "user", "content": "hi"}],
+    )
+
+    assert _ids(deployments) == {"dep-alpha", "dep-beta"}


### PR DESCRIPTION
## TLDR

Problem this solves:
- A 404 aborts the request instead of trying the next provider
- Excluded order-1 deployments block order-2 from being picked
- Each request re-probes providers already known to lack the model

How it solves it:
- 404 joins 401/403 as retryable while other deployments remain
- Exclusion filtering now runs ahead of order filtering
- A DualCache entry per deployment+model remembers 404s, TTL-expired

## User Flow

Before: a developer calling a model that only a lower-priority provider serves gets a 404 back.

1. They send `POST https://litellm-domain/v1/chat/completions` with `{"model": "universal:moonshotai/kimi-k2", "messages": [...]}`
2. The top-priority provider answers 404 `The model 'moonshotai/kimi-k2' does not exist`
3. The gateway hands that 404 straight to the caller, although a lower-priority provider serves the model
4. Repeating the request returns the same 404 every time, and each repeat pays the same round trip to the provider that cannot serve it
5. Once failover excludes the top-priority deployments, the same request comes back `400 No deployments available for selected model`, even though lower-priority deployments are healthy

After: the same request is answered by the lower-priority provider.

1. They send the same `POST https://litellm-domain/v1/chat/completions` with `{"model": "universal:moonshotai/kimi-k2", "messages": [...]}`
2. The top-priority provider answers 404, and the gateway advances to the next-priority provider inside the same request
3. The caller receives `200` with a completion from that provider
4. A repeat of the same request skips the 404-ing provider for the next hour, so it is served without the wasted round trip
5. When failover excludes the top-priority deployments, the request is served by the next order tier instead of `400 No deployments available for selected model`

No authorization surface changes: a caller can reach exactly the deployments their key already allowed.

## Relevant issues

<!-- none linked -->

## Linear ticket

<!-- external contributor -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

The same nine tests run against the PR base and against this PR's tip. No live provider is involved: each case drives the router's own deployment-selection path, and the three failures at the base are the reported symptoms verbatim — `NotFoundError` surfacing to the caller, and `No deployments available for selected model` while a healthy order-2 deployment exists.

Shared setup:

```bash
pytest tests/test_litellm/test_router_capability_cache.py -v --tb=line
```

### Before (`ee68813`, PR base `litellm_internal_staging`)

#### All nine cases

1. Run the command above with `litellm/router.py` at the PR base.
2. Observed:

```
============================= test session starts ==============================
collecting ... collected 9 items
tests/test_litellm/test_router_capability_cache.py::test_404_retries_while_other_deployments_remain FAILED [ 11%]
tests/test_litellm/test_router_capability_cache.py::test_404_raises_once_nothing_healthy_is_left PASSED [ 22%]
tests/test_litellm/test_router_capability_cache.py::test_other_4xx_errors_still_raise[400] PASSED [ 33%]
tests/test_litellm/test_router_capability_cache.py::test_other_4xx_errors_still_raise[context-window] PASSED [ 44%]
tests/test_litellm/test_router_capability_cache.py::test_excluded_order_1_falls_through_to_order_2 FAILED [ 55%]
tests/test_litellm/test_router_capability_cache.py::test_order_1_preferred_when_nothing_is_excluded PASSED [ 66%]
tests/test_litellm/test_router_capability_cache.py::test_incapable_deployment_is_skipped FAILED [ 77%]
tests/test_litellm/test_router_capability_cache.py::test_capable_and_unknown_deployments_are_kept PASSED [ 88%]
tests/test_litellm/test_router_capability_cache.py::test_all_incapable_falls_back_to_the_full_list PASSED [100%]
=================================== FAILURES ===================================
E   litellm.exceptions.NotFoundError: litellm.NotFoundError: The model 'some-model' does not exist
E   litellm.types.router.RouterRateLimitError: No deployments available for selected model, Try again in 5 seconds. Passed model=universal-group. pre-call-checks=False, cooldown_list=[]
E   AssertionError: assert {'dep-alpha', 'dep-beta'} == {'dep-beta'}
=========================== short test summary info ============================
FAILED tests/test_litellm/test_router_capability_cache.py::test_404_retries_while_other_deployments_remain - litellm.exceptions.NotFoundError: litellm.NotFoundError: The model 'some-mo...
FAILED tests/test_litellm/test_router_capability_cache.py::test_excluded_order_1_falls_through_to_order_2 - litellm.types.router.RouterRateLimitError: No deployments available for sel...
FAILED tests/test_litellm/test_router_capability_cache.py::test_incapable_deployment_is_skipped - AssertionError: assert {'dep-alpha', 'dep-beta'} == {'dep-beta'}
========================= 3 failed, 6 passed in 4.49s ==========================
```

### After (`940f57b`, PR tip)

#### All nine cases

1. Run the same command with `litellm/router.py` at this PR's tip.
2. Observed:

```
============================= test session starts ==============================
collecting ... collected 9 items
tests/test_litellm/test_router_capability_cache.py::test_404_retries_while_other_deployments_remain PASSED [ 11%]
tests/test_litellm/test_router_capability_cache.py::test_404_raises_once_nothing_healthy_is_left PASSED [ 22%]
tests/test_litellm/test_router_capability_cache.py::test_other_4xx_errors_still_raise[400] PASSED [ 33%]
tests/test_litellm/test_router_capability_cache.py::test_other_4xx_errors_still_raise[context-window] PASSED [ 44%]
tests/test_litellm/test_router_capability_cache.py::test_excluded_order_1_falls_through_to_order_2 PASSED [ 55%]
tests/test_litellm/test_router_capability_cache.py::test_order_1_preferred_when_nothing_is_excluded PASSED [ 66%]
tests/test_litellm/test_router_capability_cache.py::test_incapable_deployment_is_skipped PASSED [ 77%]
tests/test_litellm/test_router_capability_cache.py::test_capable_and_unknown_deployments_are_kept PASSED [ 88%]
tests/test_litellm/test_router_capability_cache.py::test_all_incapable_falls_back_to_the_full_list PASSED [100%]
============================== 9 passed in 3.70s ===============================
```

## Type

🆕 New Feature
🐛 Bug Fix

## Caveats (if any)

- Negative entries live 1h, positive 24h; both are hardcoded TTLs
- Cache key is deployment id plus the requested model string
- Falls back to in-memory DualCache when Redis is absent
- A genuinely missing model now costs one attempt per order tier
- Cache writes are fire-and-forget tasks; a failed write only costs a re-probe
- Filter is skipped when every deployment is cached incapable, so behaviour degrades to the old path
- Coverage is at the router-selection layer; no live-provider e2e run is attached

### Final Attestation

- [ ] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
