### PR TITLE
fix(router): count provider budget spend on every API surface

### DIFF
--- a/litellm/router_strategy/budget_limiter.py
+++ b/litellm/router_strategy/budget_limiter.py
@@ -407,12 +407,14 @@ class RouterBudgetLimiting(CustomLogger):
 
         response_cost: Final[float] = standard_logging_payload.get("response_cost", 0)
         model_id: Final[str] = str(standard_logging_payload.get("model_id", ""))
-        custom_llm_provider: Final[str] = kwargs.get("litellm_params", {}).get("custom_llm_provider", None)
-        if custom_llm_provider is None:
-            raise ValueError("custom_llm_provider is required")
+        # litellm_params only carries the provider on chat completions; the payload carries it on every
+        # surface, so read it from there instead of skipping the budget for responses, messages and embeddings.
+        custom_llm_provider: Final[str | None] = standard_logging_payload.get("custom_llm_provider")
 
-        budget_config: Final = self._get_budget_config_for_provider(custom_llm_provider)
-        if budget_config:
+        budget_config: Final = (
+            self._get_budget_config_for_provider(custom_llm_provider) if custom_llm_provider is not None else None
+        )
+        if custom_llm_provider is not None and budget_config is not None:
             # increment spend for provider
             spend_key: Final = f"provider_spend:{custom_llm_provider}:{budget_config.budget_duration}"
             start_time_key: Final = f"provider_budget_start_time:{custom_llm_provider}"

--- a/tests/test_litellm/router_strategy/test_budget_limiter.py
+++ b/tests/test_litellm/router_strategy/test_budget_limiter.py
@@ -1,0 +1,134 @@
+"""
+Spend tracking in RouterBudgetLimiting.async_log_success_event.
+
+Only chat completions puts custom_llm_provider into litellm_params. The responses,
+anthropic_messages, embedding and rerank surfaces leave it unset, which used to make
+the callback raise before any spend was recorded, so those budgets never moved.
+"""
+
+import pytest
+
+from litellm.caching.caching import DualCache
+from litellm.router_strategy.budget_limiter import RouterBudgetLimiting
+
+
+@pytest.fixture
+def disable_budget_sync(monkeypatch):
+    async def noop(*args, **kwargs):
+        return None
+
+    monkeypatch.setattr(
+        "litellm.router_strategy.budget_limiter.RouterBudgetLimiting.periodic_sync_in_memory_spend_with_redis",
+        noop,
+    )
+
+
+def _success_kwargs(
+    *,
+    provider_in_litellm_params: str | None,
+    provider_in_payload: str | None,
+    call_type: str = "aresponses",
+    response_cost: float = 0.25,
+    model_id: str = "deployment-1",
+) -> dict:
+    litellm_params = {"model": "openai/gpt-4o"}
+    if provider_in_litellm_params is not None:
+        litellm_params["custom_llm_provider"] = provider_in_litellm_params
+
+    return {
+        "call_type": call_type,
+        "litellm_params": litellm_params,
+        "standard_logging_object": {
+            "response_cost": response_cost,
+            "model_id": model_id,
+            "custom_llm_provider": provider_in_payload,
+        },
+    }
+
+
+async def _log_success(limiter: RouterBudgetLimiting, kwargs: dict) -> None:
+    await limiter.async_log_success_event(kwargs=kwargs, response_obj=None, start_time=None, end_time=None)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("call_type", ["aresponses", "anthropic_messages", "aembedding", "arerank"])
+async def test_provider_spend_tracked_when_litellm_params_omits_provider(disable_budget_sync, call_type):
+    """Non-chat surfaces carry the provider only on the standard logging payload."""
+    limiter = RouterBudgetLimiting(
+        dual_cache=DualCache(),
+        provider_budget_config={"openai": {"budget_limit": 10.0, "time_period": "1d"}},
+    )
+
+    await _log_success(
+        limiter,
+        _success_kwargs(
+            provider_in_litellm_params=None,
+            provider_in_payload="openai",
+            call_type=call_type,
+        ),
+    )
+
+    assert await limiter.dual_cache.async_get_cache("provider_spend:openai:1d") == 0.25
+
+
+@pytest.mark.asyncio
+async def test_chat_completions_spend_still_tracked(disable_budget_sync):
+    """Chat completions fills in both sources and must keep accumulating."""
+    limiter = RouterBudgetLimiting(
+        dual_cache=DualCache(),
+        provider_budget_config={"openai": {"budget_limit": 10.0, "time_period": "1d"}},
+    )
+
+    await _log_success(
+        limiter,
+        _success_kwargs(
+            provider_in_litellm_params="openai",
+            provider_in_payload="openai",
+            call_type="acompletion",
+        ),
+    )
+
+    assert await limiter.dual_cache.async_get_cache("provider_spend:openai:1d") == 0.25
+
+
+@pytest.mark.asyncio
+async def test_budget_of_other_provider_is_untouched(disable_budget_sync):
+    """A provider without its own budget must not bleed into a configured one."""
+    limiter = RouterBudgetLimiting(
+        dual_cache=DualCache(),
+        provider_budget_config={"openai": {"budget_limit": 10.0, "time_period": "1d"}},
+    )
+
+    await _log_success(
+        limiter,
+        _success_kwargs(provider_in_litellm_params=None, provider_in_payload="anthropic"),
+    )
+
+    assert await limiter.dual_cache.async_get_cache("provider_spend:openai:1d") in (None, 0.0)
+
+
+@pytest.mark.asyncio
+async def test_deployment_budget_tracked_when_provider_is_unresolvable(disable_budget_sync):
+    """An unresolvable provider must not abort the deployment and tag budgets that follow it."""
+    limiter = RouterBudgetLimiting(
+        dual_cache=DualCache(),
+        provider_budget_config=None,
+        model_list=[
+            {
+                "model_name": "some-model",
+                "litellm_params": {
+                    "model": "openai/gpt-4o",
+                    "max_budget": 10.0,
+                    "budget_duration": "1d",
+                },
+                "model_info": {"id": "deployment-1"},
+            }
+        ],
+    )
+
+    await _log_success(
+        limiter,
+        _success_kwargs(provider_in_litellm_params=None, provider_in_payload=None),
+    )
+
+    assert await limiter.dual_cache.async_get_cache("deployment_spend:deployment-1:1d") == 0.25


### PR DESCRIPTION
## TLDR

Problem this solves:

- Provider budgets never count responses or messages spend
- The budget callback raises on every non-chat request
- One missing field also skips deployment and tag budgets

How it solves it:

- Read the provider from the standard logging payload
- That field is populated on every API surface

## User Flow

Before: an admin caps OpenAI at $50 a day, but everything an agent client sends through the Responses API is free of charge as far as the cap is concerned

1. The admin sets a $50/day OpenAI provider budget in `router_settings.provider_budget_config` and restarts the proxy
2. The admin sends GET `http://localhost:4000/provider/budgets` and sees `"spend": 0.009408`
3. A developer sends POST `http://localhost:4000/v1/responses` with model `gpt-5.6-sol` and gets `200` with a completed response
4. The admin sends GET `http://localhost:4000/provider/budgets` again and still sees `"spend": 0.009408`, unchanged
5. The same thing happens for POST `http://localhost:4000/v1/messages`, while POST `http://localhost:4000/v1/chat/completions` does move the number
6. The proxy log carries `ValueError: custom_llm_provider is required` for each of those requests, marked non-blocking
7. A workload made mostly of Responses API traffic never reaches the $50 ceiling, so the cap the admin set never fires

After: the same cap counts every route, so the ceiling means what it says

1. The admin sets the same $50/day OpenAI provider budget and restarts the proxy
2. The admin sends GET `http://localhost:4000/provider/budgets` and sees `"spend": 0.018816`
3. A developer sends POST `http://localhost:4000/v1/responses` with model `gpt-5.6-sol` and gets `200` with a completed response
4. The admin sends GET `http://localhost:4000/provider/budgets` again and sees `"spend": 0.02016`, up by the cost of that call
5. POST `http://localhost:4000/v1/messages` and POST `http://localhost:4000/v1/chat/completions` each move the number by the same amount
6. The proxy log carries no `custom_llm_provider is required` entries
7. Responses API traffic now counts toward the $50 ceiling, so the cap fires when it should

## Relevant issues

Fixes #38176
Fixes #26701
Fixes #30276
Fixes #37877

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Shared setup, identical for both runs. The proxy runs the pinned `litellm/litellm:v1.97.0` image with `router_strategy/budget_limiter.py` mounted over: the merge base copy of that file for Before, this PR's copy for After. Every other file is untouched, and `budget_limiter.py` at the merge base is byte-identical to the one in the image. Calls hit the real OpenAI API and cost real money.

```yaml
model_list:
  - model_name: gpt-5.6-sol
    litellm_params:
      model: openai/gpt-5.6-sol
      api_key: os.environ/OPENAI_API_KEY
    model_info:
      input_cost_per_token: 0.000004
      output_cost_per_token: 0.000024

router_settings:
  provider_budget_config:
    openai:
      budget_limit: 50.0
      time_period: 1d
```

Each case reads the budget, sends one request, waits 6 seconds for the spend to sync, then reads the budget again.

### Before (da91d4b6c9)

#### /v1/responses

1. `curl -sS http://localhost:4000/provider/budgets -H "Authorization: Bearer $LITELLM_MASTER_KEY"` returns `{"budget_limit": 50.0, "time_period": "1d", "spend": 0.009408}`
2. `curl -sS http://localhost:4000/v1/responses -H "Authorization: Bearer $LITELLM_MASTER_KEY" -H "content-type: application/json" -d '{"model":"gpt-5.6-sol","input":"Reply only with OK","max_output_tokens":16}'` returns `200` with `"status": "completed"` and `"total_tokens": 311`
3. `curl -sS http://localhost:4000/provider/budgets -H "Authorization: Bearer $LITELLM_MASTER_KEY"` returns `{"budget_limit": 50.0, "time_period": "1d", "spend": 0.009408}`, unchanged

#### /v1/messages

1. `curl -sS http://localhost:4000/provider/budgets -H "Authorization: Bearer $LITELLM_MASTER_KEY"` returns `{"budget_limit": 50.0, "time_period": "1d", "spend": 0.009408}`
2. `curl -sS http://localhost:4000/v1/messages -H "Authorization: Bearer $LITELLM_MASTER_KEY" -H "content-type: application/json" -d '{"model":"gpt-5.6-sol","max_tokens":16,"messages":[{"role":"user","content":"Reply only with OK"}]}'` returns `200` with `"stop_reason": "end_turn"`
3. `curl -sS http://localhost:4000/provider/budgets -H "Authorization: Bearer $LITELLM_MASTER_KEY"` returns `{"budget_limit": 50.0, "time_period": "1d", "spend": 0.009408}`, unchanged

#### /v1/chat/completions

1. `curl -sS http://localhost:4000/provider/budgets -H "Authorization: Bearer $LITELLM_MASTER_KEY"` returns `{"budget_limit": 50.0, "time_period": "1d", "spend": 0.009408}`
2. `curl -sS http://localhost:4000/v1/chat/completions -H "Authorization: Bearer $LITELLM_MASTER_KEY" -H "content-type: application/json" -d '{"model":"gpt-5.6-sol","messages":[{"role":"user","content":"Reply only with OK"}],"max_tokens":5}'` returns `200`
3. `curl -sS http://localhost:4000/provider/budgets -H "Authorization: Bearer $LITELLM_MASTER_KEY"` returns `{"budget_limit": 50.0, "time_period": "1d", "spend": 0.010752}`, up by 0.001344

#### proxy log during the three cases above

1. `docker logs -t litellm --since <start of run> | grep -c "custom_llm_provider is required"` returns `6`

### After (988ebe5bce)

#### /v1/responses

1. `curl -sS http://localhost:4000/provider/budgets -H "Authorization: Bearer $LITELLM_MASTER_KEY"` returns `{"budget_limit": 50.0, "time_period": "1d", "spend": 0.018816}`
2. `curl -sS http://localhost:4000/v1/responses -H "Authorization: Bearer $LITELLM_MASTER_KEY" -H "content-type: application/json" -d '{"model":"gpt-5.6-sol","input":"Reply only with OK","max_output_tokens":16}'` returns `200` with `"status": "completed"` and `"total_tokens": 311`
3. `curl -sS http://localhost:4000/provider/budgets -H "Authorization: Bearer $LITELLM_MASTER_KEY"` returns `{"budget_limit": 50.0, "time_period": "1d", "spend": 0.02016}`, up by 0.001344

#### /v1/messages

1. `curl -sS http://localhost:4000/provider/budgets -H "Authorization: Bearer $LITELLM_MASTER_KEY"` returns `{"budget_limit": 50.0, "time_period": "1d", "spend": 0.02016}`
2. `curl -sS http://localhost:4000/v1/messages -H "Authorization: Bearer $LITELLM_MASTER_KEY" -H "content-type: application/json" -d '{"model":"gpt-5.6-sol","max_tokens":16,"messages":[{"role":"user","content":"Reply only with OK"}]}'` returns `200` with `"stop_reason": "end_turn"`
3. `curl -sS http://localhost:4000/provider/budgets -H "Authorization: Bearer $LITELLM_MASTER_KEY"` returns `{"budget_limit": 50.0, "time_period": "1d", "spend": 0.021504}`, up by 0.001344

#### /v1/chat/completions

1. `curl -sS http://localhost:4000/provider/budgets -H "Authorization: Bearer $LITELLM_MASTER_KEY"` returns `{"budget_limit": 50.0, "time_period": "1d", "spend": 0.021504}`
2. `curl -sS http://localhost:4000/v1/chat/completions -H "Authorization: Bearer $LITELLM_MASTER_KEY" -H "content-type: application/json" -d '{"model":"gpt-5.6-sol","messages":[{"role":"user","content":"Reply only with OK"}],"max_tokens":5}'` returns `200`
3. `curl -sS http://localhost:4000/provider/budgets -H "Authorization: Bearer $LITELLM_MASTER_KEY"` returns `{"budget_limit": 50.0, "time_period": "1d", "spend": 0.022848}`, up by 0.001344

#### proxy log during the three cases above

1. `docker logs litellm --since <start of run> | grep -c "custom_llm_provider is required"` returns `0`

## Type

🐛 Bug Fix

## Caveats

- Embedding and rerank are covered by unit test, not by the live run
- PRs #30294, #32180, #32276 and #37896 target the same root cause

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
