### PR TITLE
fix(bedrock): map tool_choice='any' to native any block (same as 'required')

### DIFF
--- a/litellm/llms/bedrock/chat/converse_transformation.py
+++ b/litellm/llms/bedrock/chat/converse_transformation.py
@@ -591,7 +591,7 @@ class AmazonConverseConfig(BaseConfig):
                     message=f"Bedrock doesn't support tool_choice={tool_choice}. To drop it from the call, set `litellm.drop_params = True.",
                     status_code=400,
                 )
-        elif tool_choice == "required":
+        elif tool_choice == "required" or tool_choice == "any":
             return ToolChoiceValuesBlock(any={})
         elif tool_choice == "auto":
             return ToolChoiceValuesBlock(auto={})
@@ -603,7 +603,7 @@ class AmazonConverseConfig(BaseConfig):
             return ToolChoiceValuesBlock(tool=specific_tool)
         else:
             raise litellm.utils.UnsupportedParamsError(
-                message=f"Bedrock doesn't support tool_choice={tool_choice}. Supported tool_choice values=['auto', 'required', json object]. To drop it from the call, set `litellm.drop_params = True.",
+                message=f"Bedrock doesn't support tool_choice={tool_choice}. Supported tool_choice values=['auto', 'required', 'any', json object]. To drop it from the call, set `litellm.drop_params = True.",
                 status_code=400,
             )
 

--- a/tests/test_litellm/llms/bedrock/chat/test_converse_transformation.py
+++ b/tests/test_litellm/llms/bedrock/chat/test_converse_transformation.py
@@ -284,6 +284,82 @@ def test_reasoning_with_forced_tool_choice_switches_to_auto():
     assert optional_params["tool_choice"] == {"auto": {}}
 
 
+def test_tool_choice_any_maps_to_any_block():
+    """`tool_choice="any"` should map to Bedrock's ToolChoiceValuesBlock(any={}), same as "required".
+
+    Regression test for https://github.com/BerriAI/litellm/issues/37980: "any" previously
+    fell through to the UnsupportedParamsError branch even though Bedrock's Converse API
+    natively supports the any block.
+    """
+    config = AmazonConverseConfig()
+
+    non_default_params = {
+        "tools": [
+            {
+                "type": "function",
+                "function": {"name": "get_current_weather", "parameters": {}},
+            }
+        ],
+        "tool_choice": "any",
+    }
+
+    optional_params = config.map_openai_params(
+        model="bedrock/converse/us.anthropic.claude-sonnet-4-5-20250929-v1:0",
+        non_default_params=non_default_params,
+        optional_params={},
+        drop_params=False,
+    )
+
+    assert optional_params["tool_choice"] == {"any": {}}
+
+
+def test_tool_choice_required_maps_to_any_block():
+    """`tool_choice="required"` (and now "any") both map to Bedrock's native {any:{}} block."""
+    config = AmazonConverseConfig()
+
+    non_default_params = {
+        "tools": [
+            {
+                "type": "function",
+                "function": {"name": "get_current_weather", "parameters": {}},
+            }
+        ],
+        "tool_choice": "required",
+    }
+
+    optional_params = config.map_openai_params(
+        model="bedrock/converse/us.anthropic.claude-sonnet-4-5-20250929-v1:0",
+        non_default_params=non_default_params,
+        optional_params={},
+        drop_params=False,
+    )
+
+    assert optional_params["tool_choice"] == {"any": {}}
+
+
+def test_tool_choice_none_still_raises():
+    """Values outside auto/required/any/json-object must still raise UnsupportedParamsError."""
+    config = AmazonConverseConfig()
+
+    non_default_params = {
+        "tools": [
+            {
+                "type": "function",
+                "function": {"name": "get_current_weather", "parameters": {}},
+            }
+        ],
+        "tool_choice": "none",
+    }
+
+    with pytest.raises(litellm.UnsupportedParamsError):
+        config.map_openai_params(
+            model="bedrock/converse/us.anthropic.claude-sonnet-4-5-20250929-v1:0",
+            non_default_params=non_default_params,
+            optional_params={},
+            drop_params=False,
+        )
+
+
 @pytest.mark.parametrize(
     "model",
     [


### PR DESCRIPTION
## 🐛 Fix: Bedrock adapter rejects `tool_choice="any"` despite Converse API support

## Relevant issues

Fixes #37980

## Pre-Submission checklist

- [x] I have Added a Brief description of the fix
- [x] I have added a test to cover this fix
- [x] My PR passes all linting/CI checks

## Brief description of the fix

Bedrock's Converse API natively supports the `any` tool-choice block, and LiteLLM already maps `"required"` → `ToolChoiceValuesBlock(any={})` because both express "force the model to call a tool". But `"any"` itself fell through to the `UnsupportedParamsError` branch:

```
litellm.UnsupportedParamsError: Bedrock doesn't support tool_choice=any. Supported tool_choice values=['auto', 'required', json object].
```

This PR maps `"any"` the same way as `"required"`:

```python
elif tool_choice == "required" or tool_choice == "any":
    return ToolChoiceValuesBlock(any={})
```

and includes `'any'` in the supported-values error message.

This aligns Bedrock with other providers that accept both spellings (the OpenAI-compatible surface treats `required`/`any` as synonyms), so OpenAI-style clients sending `tool_choice: "any"` no longer need provider-specific branching.

## How to verify

New regression tests in `tests/test_litellm/llms/bedrock/chat/test_converse_transformation.py`:

- `test_tool_choice_any_maps_to_any_block` — `"any"` now maps to `{"any": {}}` (previously raised)
- `test_tool_choice_required_maps_to_any_block` — pins the existing `"required"` → `{"any": {}}` mapping so the two stay in sync
- `test_tool_choice_none_still_raises` — genuinely unsupported values still raise `UnsupportedParamsError`

```
pytest tests/test_litellm/llms/bedrock/chat/test_converse_transformation.py -k tool_choice
# 12 passed (9 pre-existing + 3 new)
```

## Notes

`tool_choice == "any"` is not currently part of the OpenAI API surface (it uses `required`), but it appears in several OpenAI-compatible clients and is accepted by other LiteLLM providers, which is what triggered the original report.
