### PR TITLE
fix(logging): redact tool call arguments to valid JSON and preserve null content

### DIFF
--- a/litellm/constants.py
+++ b/litellm/constants.py
@@ -49,8 +49,8 @@ LITELLM_MAX_STREAMING_DURATION_SECONDS: Final = (
 # Set to 0 to disable truncation.
 MAX_BASE64_LENGTH_FOR_LOGGING: Final = int(os.getenv("MAX_BASE64_LENGTH_FOR_LOGGING", 64))
 REDACTED_BY_LITELLM: Final = "redacted-by-litellm"
-# arguments fields contractually hold JSON (consumers json.loads them), so redact to valid JSON
-REDACTED_TOOL_CALL_ARGUMENTS: Final = "{}"
+# in-memory stand-in handed to provider converters for redacted arguments; never stored
+REDACTED_TOOL_CALL_ARGUMENTS_PLACEHOLDER: Final = "{}"
 
 MAX_STRING_LENGTH_STDOUT_LOG: Final = get_env_int("MAX_STRING_LENGTH_STDOUT_LOG", 4096)
 

--- a/litellm/constants.py
+++ b/litellm/constants.py
@@ -49,6 +49,8 @@ LITELLM_MAX_STREAMING_DURATION_SECONDS: Final = (
 # Set to 0 to disable truncation.
 MAX_BASE64_LENGTH_FOR_LOGGING: Final = int(os.getenv("MAX_BASE64_LENGTH_FOR_LOGGING", 64))
 REDACTED_BY_LITELLM: Final = "redacted-by-litellm"
+# arguments fields contractually hold JSON (consumers json.loads them), so redact to valid JSON
+REDACTED_TOOL_CALL_ARGUMENTS: Final = "{}"
 
 MAX_STRING_LENGTH_STDOUT_LOG: Final = get_env_int("MAX_STRING_LENGTH_STDOUT_LOG", 4096)
 

--- a/litellm/integrations/langfuse/langfuse_otel.py
+++ b/litellm/integrations/langfuse/langfuse_otel.py
@@ -10,6 +10,7 @@ from litellm.integrations.langfuse.langfuse_otel_attributes import (
     LangfuseLLMObsOTELAttributes,
 )
 from litellm.integrations.opentelemetry import OpenTelemetry, OpenTelemetryConfig
+from litellm.litellm_core_utils.safe_json_loads import safe_json_loads
 from litellm.types.integrations.langfuse_otel import (
     LangfuseSpanAttributes,
 )
@@ -197,7 +198,11 @@ class LangfuseOtelLogger(OpenTelemetry):
                         )
                     elif item_type == "function_call":
                         arguments_str = getattr(item, "arguments", "{}")
-                        arguments_obj = json.loads(arguments_str) if isinstance(arguments_str, str) else arguments_str
+                        arguments_obj = (
+                            safe_json_loads(arguments_str, default={})
+                            if isinstance(arguments_str, str)
+                            else arguments_str
+                        )
                         langfuse_tool_call = {
                             "id": getattr(item, "id", ""),
                             "name": getattr(item, "name", ""),

--- a/litellm/litellm_core_utils/redact_messages.py
+++ b/litellm/litellm_core_utils/redact_messages.py
@@ -13,7 +13,7 @@ import inspect
 from typing import TYPE_CHECKING, Any, Final
 
 import litellm
-from litellm.constants import REDACTED_BY_LITELLM
+from litellm.constants import REDACTED_BY_LITELLM, REDACTED_TOOL_CALL_ARGUMENTS
 from litellm.integrations.custom_logger import CustomLogger
 from litellm.litellm_core_utils.core_helpers import (
     get_metadata_variable_name_from_kwargs,
@@ -33,9 +33,6 @@ if TYPE_CHECKING:
     LiteLLMLoggingObject = _LiteLLMLoggingObject
 else:
     LiteLLMLoggingObject = Any
-
-# arguments fields contractually hold JSON (consumers json.loads them), so redact to valid JSON
-_REDACTED_TOOL_ARGUMENTS: Final = "{}"
 
 
 def redact_message_input_output_from_custom_logger(
@@ -88,13 +85,13 @@ def _redact_tool_calls(tool_calls) -> None:
     for tool_call in tool_calls:
         function = getattr(tool_call, "function", None)
         if function is not None and hasattr(function, "arguments"):
-            function.arguments = _REDACTED_TOOL_ARGUMENTS
+            function.arguments = REDACTED_TOOL_CALL_ARGUMENTS
 
 
 def _redact_function_call(function_call) -> None:
     """Redact legacy assistant function_call arguments."""
     if function_call is not None and hasattr(function_call, "arguments"):
-        function_call.arguments = _REDACTED_TOOL_ARGUMENTS
+        function_call.arguments = REDACTED_TOOL_CALL_ARGUMENTS
 
 
 def _redact_choice_content(choice):
@@ -138,7 +135,7 @@ def _redact_responses_api_output(output_items):
                         summary_item.text = REDACTED_BY_LITELLM
 
         if hasattr(output_item, "type") and output_item.type == "function_call" and hasattr(output_item, "arguments"):
-            output_item.arguments = _REDACTED_TOOL_ARGUMENTS
+            output_item.arguments = REDACTED_TOOL_CALL_ARGUMENTS
 
 
 def _redact_responses_api_output_dict(output_items, redacted_str: str):
@@ -161,7 +158,7 @@ def _redact_responses_api_output_dict(output_items, redacted_str: str):
                     summary_item["text"] = redacted_str
 
         if output_item.get("type") == "function_call" and "arguments" in output_item:
-            output_item["arguments"] = _REDACTED_TOOL_ARGUMENTS
+            output_item["arguments"] = REDACTED_TOOL_CALL_ARGUMENTS
 
 
 def _redact_standard_logging_object(model_call_details: dict):
@@ -200,11 +197,11 @@ def _redact_tool_calls_dict(message: dict) -> None:
     if isinstance(tool_calls, list):
         for tool_call in tool_calls:
             if isinstance(tool_call, dict) and isinstance(tool_call.get("function"), dict):
-                tool_call["function"]["arguments"] = _REDACTED_TOOL_ARGUMENTS
+                tool_call["function"]["arguments"] = REDACTED_TOOL_CALL_ARGUMENTS
 
     function_call: Final = message.get("function_call")
     if isinstance(function_call, dict) and "arguments" in function_call:
-        function_call["arguments"] = _REDACTED_TOOL_ARGUMENTS
+        function_call["arguments"] = REDACTED_TOOL_CALL_ARGUMENTS
 
 
 def _redact_model_response_dict_choices(choices, redacted_str: str):

--- a/litellm/litellm_core_utils/redact_messages.py
+++ b/litellm/litellm_core_utils/redact_messages.py
@@ -13,7 +13,7 @@ import inspect
 from typing import TYPE_CHECKING, Any, Final
 
 import litellm
-from litellm.constants import REDACTED_BY_LITELLM, REDACTED_TOOL_CALL_ARGUMENTS
+from litellm.constants import REDACTED_BY_LITELLM
 from litellm.integrations.custom_logger import CustomLogger
 from litellm.litellm_core_utils.core_helpers import (
     get_metadata_variable_name_from_kwargs,
@@ -85,13 +85,13 @@ def _redact_tool_calls(tool_calls) -> None:
     for tool_call in tool_calls:
         function = getattr(tool_call, "function", None)
         if function is not None and hasattr(function, "arguments"):
-            function.arguments = REDACTED_TOOL_CALL_ARGUMENTS
+            function.arguments = REDACTED_BY_LITELLM
 
 
 def _redact_function_call(function_call) -> None:
     """Redact legacy assistant function_call arguments."""
     if function_call is not None and hasattr(function_call, "arguments"):
-        function_call.arguments = REDACTED_TOOL_CALL_ARGUMENTS
+        function_call.arguments = REDACTED_BY_LITELLM
 
 
 def _redact_choice_content(choice):
@@ -119,23 +119,23 @@ def _redact_choice_content(choice):
 def _redact_responses_api_output(output_items):
     """Helper to redact ResponsesAPIResponse output items."""
     for output_item in output_items:
-        if hasattr(output_item, "text"):
+        if getattr(output_item, "text", None) is not None:
             output_item.text = REDACTED_BY_LITELLM
 
         if hasattr(output_item, "content") and isinstance(output_item.content, list):
             for content_part in output_item.content:
-                if hasattr(content_part, "text"):
+                if getattr(content_part, "text", None) is not None:
                     content_part.text = REDACTED_BY_LITELLM
 
         # Redact reasoning items in output array
         if hasattr(output_item, "type") and output_item.type == "reasoning":
             if hasattr(output_item, "summary") and isinstance(output_item.summary, list):
                 for summary_item in output_item.summary:
-                    if hasattr(summary_item, "text"):
+                    if getattr(summary_item, "text", None) is not None:
                         summary_item.text = REDACTED_BY_LITELLM
 
         if hasattr(output_item, "type") and output_item.type == "function_call" and hasattr(output_item, "arguments"):
-            output_item.arguments = REDACTED_TOOL_CALL_ARGUMENTS
+            output_item.arguments = REDACTED_BY_LITELLM
 
 
 def _redact_responses_api_output_dict(output_items, redacted_str: str):
@@ -144,21 +144,21 @@ def _redact_responses_api_output_dict(output_items, redacted_str: str):
         if not isinstance(output_item, dict):
             continue
 
-        if "text" in output_item:
+        if output_item.get("text") is not None:
             output_item["text"] = redacted_str
 
         if isinstance(output_item.get("content"), list):
             for content_item in output_item["content"]:
-                if isinstance(content_item, dict) and "text" in content_item:
+                if isinstance(content_item, dict) and content_item.get("text") is not None:
                     content_item["text"] = redacted_str
 
         if output_item.get("type") == "reasoning" and isinstance(output_item.get("summary"), list):
             for summary_item in output_item["summary"]:
-                if isinstance(summary_item, dict) and "text" in summary_item:
+                if isinstance(summary_item, dict) and summary_item.get("text") is not None:
                     summary_item["text"] = redacted_str
 
         if output_item.get("type") == "function_call" and "arguments" in output_item:
-            output_item["arguments"] = REDACTED_TOOL_CALL_ARGUMENTS
+            output_item["arguments"] = redacted_str
 
 
 def _redact_standard_logging_object(model_call_details: dict):
@@ -197,11 +197,11 @@ def _redact_tool_calls_dict(message: dict) -> None:
     if isinstance(tool_calls, list):
         for tool_call in tool_calls:
             if isinstance(tool_call, dict) and isinstance(tool_call.get("function"), dict):
-                tool_call["function"]["arguments"] = REDACTED_TOOL_CALL_ARGUMENTS
+                tool_call["function"]["arguments"] = REDACTED_BY_LITELLM
 
     function_call: Final = message.get("function_call")
     if isinstance(function_call, dict) and "arguments" in function_call:
-        function_call["arguments"] = REDACTED_TOOL_CALL_ARGUMENTS
+        function_call["arguments"] = REDACTED_BY_LITELLM
 
 
 def _redact_model_response_dict_choices(choices, redacted_str: str):
@@ -267,7 +267,7 @@ def perform_redaction(model_call_details: dict, result, redact_streaming_respons
             isinstance(result, (litellm.ModelResponse, litellm.ResponsesAPIResponse, litellm.EmbeddingResponse))
             or (isinstance(result, dict) and ("choices" in result or "output" in result))
         ):
-            return {"text": "redacted-by-litellm"}
+            return {"text": REDACTED_BY_LITELLM}
 
         _result: Final = copy.deepcopy(result)
         if isinstance(_result, litellm.ModelResponse):

--- a/litellm/litellm_core_utils/redact_messages.py
+++ b/litellm/litellm_core_utils/redact_messages.py
@@ -34,6 +34,9 @@ if TYPE_CHECKING:
 else:
     LiteLLMLoggingObject = Any
 
+# arguments fields contractually hold JSON (consumers json.loads them), so redact to valid JSON
+_REDACTED_TOOL_ARGUMENTS: Final = "{}"
+
 
 def redact_message_input_output_from_custom_logger(
     litellm_logging_obj: LiteLLMLoggingObject, result, custom_logger: CustomLogger
@@ -85,28 +88,30 @@ def _redact_tool_calls(tool_calls) -> None:
     for tool_call in tool_calls:
         function = getattr(tool_call, "function", None)
         if function is not None and hasattr(function, "arguments"):
-            function.arguments = REDACTED_BY_LITELLM
+            function.arguments = _REDACTED_TOOL_ARGUMENTS
 
 
 def _redact_function_call(function_call) -> None:
     """Redact legacy assistant function_call arguments."""
     if function_call is not None and hasattr(function_call, "arguments"):
-        function_call.arguments = REDACTED_BY_LITELLM
+        function_call.arguments = _REDACTED_TOOL_ARGUMENTS
 
 
 def _redact_choice_content(choice):
     """Helper to redact content in a choice (message or delta)."""
     if isinstance(choice, litellm.Choices):
-        choice.message.content = REDACTED_BY_LITELLM
-        if hasattr(choice.message, "reasoning_content"):
+        if choice.message.content is not None:
+            choice.message.content = REDACTED_BY_LITELLM
+        if getattr(choice.message, "reasoning_content", None) is not None:
             choice.message.reasoning_content = REDACTED_BY_LITELLM
         if hasattr(choice.message, "thinking_blocks"):
             choice.message.thinking_blocks = None
         _redact_tool_calls(getattr(choice.message, "tool_calls", None))
         _redact_function_call(getattr(choice.message, "function_call", None))
     elif isinstance(choice, litellm.utils.StreamingChoices):
-        choice.delta.content = REDACTED_BY_LITELLM
-        if hasattr(choice.delta, "reasoning_content"):
+        if choice.delta.content is not None:
+            choice.delta.content = REDACTED_BY_LITELLM
+        if getattr(choice.delta, "reasoning_content", None) is not None:
             choice.delta.reasoning_content = REDACTED_BY_LITELLM
         if hasattr(choice.delta, "thinking_blocks"):
             choice.delta.thinking_blocks = None
@@ -133,7 +138,7 @@ def _redact_responses_api_output(output_items):
                         summary_item.text = REDACTED_BY_LITELLM
 
         if hasattr(output_item, "type") and output_item.type == "function_call" and hasattr(output_item, "arguments"):
-            output_item.arguments = REDACTED_BY_LITELLM
+            output_item.arguments = _REDACTED_TOOL_ARGUMENTS
 
 
 def _redact_responses_api_output_dict(output_items, redacted_str: str):
@@ -156,7 +161,7 @@ def _redact_responses_api_output_dict(output_items, redacted_str: str):
                     summary_item["text"] = redacted_str
 
         if output_item.get("type") == "function_call" and "arguments" in output_item:
-            output_item["arguments"] = redacted_str
+            output_item["arguments"] = _REDACTED_TOOL_ARGUMENTS
 
 
 def _redact_standard_logging_object(model_call_details: dict):
@@ -189,40 +194,42 @@ def _redact_standard_logging_object(model_call_details: dict):
             standard_logging_object["response"] = {"text": redacted_str}
 
 
-def _redact_tool_calls_dict(message: dict, redacted_str: str) -> None:
+def _redact_tool_calls_dict(message: dict) -> None:
     """Redact tool call / function_call arguments in a dict-form message or delta."""
     tool_calls: Final = message.get("tool_calls")
     if isinstance(tool_calls, list):
         for tool_call in tool_calls:
             if isinstance(tool_call, dict) and isinstance(tool_call.get("function"), dict):
-                tool_call["function"]["arguments"] = redacted_str
+                tool_call["function"]["arguments"] = _REDACTED_TOOL_ARGUMENTS
 
     function_call: Final = message.get("function_call")
     if isinstance(function_call, dict) and "arguments" in function_call:
-        function_call["arguments"] = redacted_str
+        function_call["arguments"] = _REDACTED_TOOL_ARGUMENTS
 
 
 def _redact_model_response_dict_choices(choices, redacted_str: str):
     for choice in choices:
         if isinstance(choice, dict):
             if "message" in choice and isinstance(choice["message"], dict):
-                choice["message"]["content"] = redacted_str
-                if "reasoning_content" in choice["message"]:
+                if choice["message"].get("content") is not None:
+                    choice["message"]["content"] = redacted_str
+                if choice["message"].get("reasoning_content") is not None:
                     choice["message"]["reasoning_content"] = redacted_str
                 if "thinking_blocks" in choice["message"]:
                     choice["message"]["thinking_blocks"] = None
                 if "audio" in choice["message"]:
                     choice["message"]["audio"] = None
-                _redact_tool_calls_dict(choice["message"], redacted_str)
+                _redact_tool_calls_dict(choice["message"])
             elif "delta" in choice and isinstance(choice["delta"], dict):
-                choice["delta"]["content"] = redacted_str
-                if "reasoning_content" in choice["delta"]:
+                if choice["delta"].get("content") is not None:
+                    choice["delta"]["content"] = redacted_str
+                if choice["delta"].get("reasoning_content") is not None:
                     choice["delta"]["reasoning_content"] = redacted_str
                 if "thinking_blocks" in choice["delta"]:
                     choice["delta"]["thinking_blocks"] = None
                 if "audio" in choice["delta"]:
                     choice["delta"]["audio"] = None
-                _redact_tool_calls_dict(choice["delta"], redacted_str)
+                _redact_tool_calls_dict(choice["delta"])
         else:
             _redact_choice_content(choice)
 

--- a/litellm/responses/litellm_completion_transformation/session_handler.py
+++ b/litellm/responses/litellm_completion_transformation/session_handler.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING, Any, Final, cast
 
 import litellm
 from litellm._logging import verbose_proxy_logger
-from litellm.constants import REDACTED_BY_LITELLM, REDACTED_TOOL_CALL_ARGUMENTS
+from litellm.constants import REDACTED_BY_LITELLM, REDACTED_TOOL_CALL_ARGUMENTS_PLACEHOLDER
 from litellm.proxy._types import SpendLogsPayload
 from litellm.proxy.spend_tracking.cold_storage_handler import ColdStorageHandler
 from litellm.responses.utils import ResponsesAPIRequestUtils
@@ -31,14 +31,14 @@ COLD_STORAGE_HANDLER: Final = ColdStorageHandler()
 
 
 def _normalize_redacted_tool_call_arguments(message: Message) -> None:
-    """Older releases redacted tool-call arguments to the bare sentinel (invalid JSON);
+    """Redaction stores the bare sentinel (invalid JSON) in tool-call arguments;
     normalize replayed history to "{}" so provider converters can parse it."""
     for tool_call in message.tool_calls or []:
         if (function := getattr(tool_call, "function", None)) is not None and function.arguments == REDACTED_BY_LITELLM:
-            function.arguments = REDACTED_TOOL_CALL_ARGUMENTS
+            function.arguments = REDACTED_TOOL_CALL_ARGUMENTS_PLACEHOLDER
     function_call: Final = message.function_call
     if function_call is not None and function_call.arguments == REDACTED_BY_LITELLM:
-        function_call.arguments = REDACTED_TOOL_CALL_ARGUMENTS
+        function_call.arguments = REDACTED_TOOL_CALL_ARGUMENTS_PLACEHOLDER
 
 
 class ResponsesSessionHandler:

--- a/litellm/responses/litellm_completion_transformation/session_handler.py
+++ b/litellm/responses/litellm_completion_transformation/session_handler.py
@@ -34,9 +34,8 @@ def _normalize_redacted_tool_call_arguments(message: Message) -> None:
     """Older releases redacted tool-call arguments to the bare sentinel (invalid JSON);
     normalize replayed history to "{}" so provider converters can parse it."""
     for tool_call in message.tool_calls or []:
-        function: Final = tool_call.function
-        if function.arguments == REDACTED_BY_LITELLM:
-            function.arguments = REDACTED_TOOL_CALL_ARGUMENTS
+        if tool_call.function.arguments == REDACTED_BY_LITELLM:
+            tool_call.function.arguments = REDACTED_TOOL_CALL_ARGUMENTS
     function_call: Final = message.function_call
     if function_call is not None and function_call.arguments == REDACTED_BY_LITELLM:
         function_call.arguments = REDACTED_TOOL_CALL_ARGUMENTS
@@ -156,8 +155,7 @@ class ResponsesSessionHandler:
             model_response: Final = ModelResponse(**_response_output)
             for choice in model_response.choices:
                 if hasattr(choice, "message"):
-                    message: Final = getattr(choice, "message")
-                    _normalize_redacted_tool_call_arguments(message)
+                    _normalize_redacted_tool_call_arguments(message := getattr(choice, "message"))
                     chat_completion_message_history.append(message)
         return chat_completion_message_history
 

--- a/litellm/responses/litellm_completion_transformation/session_handler.py
+++ b/litellm/responses/litellm_completion_transformation/session_handler.py
@@ -34,8 +34,8 @@ def _normalize_redacted_tool_call_arguments(message: Message) -> None:
     """Older releases redacted tool-call arguments to the bare sentinel (invalid JSON);
     normalize replayed history to "{}" so provider converters can parse it."""
     for tool_call in message.tool_calls or []:
-        if tool_call.function.arguments == REDACTED_BY_LITELLM:
-            tool_call.function.arguments = REDACTED_TOOL_CALL_ARGUMENTS
+        if (function := getattr(tool_call, "function", None)) is not None and function.arguments == REDACTED_BY_LITELLM:
+            function.arguments = REDACTED_TOOL_CALL_ARGUMENTS
     function_call: Final = message.function_call
     if function_call is not None and function_call.arguments == REDACTED_BY_LITELLM:
         function_call.arguments = REDACTED_TOOL_CALL_ARGUMENTS

--- a/litellm/responses/litellm_completion_transformation/session_handler.py
+++ b/litellm/responses/litellm_completion_transformation/session_handler.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING, Any, Final, cast
 
 import litellm
 from litellm._logging import verbose_proxy_logger
-from litellm.constants import REDACTED_BY_LITELLM
+from litellm.constants import REDACTED_BY_LITELLM, REDACTED_TOOL_CALL_ARGUMENTS
 from litellm.proxy._types import SpendLogsPayload
 from litellm.proxy.spend_tracking.cold_storage_handler import ColdStorageHandler
 from litellm.responses.utils import ResponsesAPIRequestUtils
@@ -36,10 +36,10 @@ def _normalize_redacted_tool_call_arguments(message: Message) -> None:
     for tool_call in message.tool_calls or []:
         function: Final = tool_call.function
         if function.arguments == REDACTED_BY_LITELLM:
-            function.arguments = "{}"
+            function.arguments = REDACTED_TOOL_CALL_ARGUMENTS
     function_call: Final = message.function_call
     if function_call is not None and function_call.arguments == REDACTED_BY_LITELLM:
-        function_call.arguments = "{}"
+        function_call.arguments = REDACTED_TOOL_CALL_ARGUMENTS
 
 
 class ResponsesSessionHandler:

--- a/litellm/responses/litellm_completion_transformation/session_handler.py
+++ b/litellm/responses/litellm_completion_transformation/session_handler.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING, Any, Final, cast
 
 import litellm
 from litellm._logging import verbose_proxy_logger
+from litellm.constants import REDACTED_BY_LITELLM
 from litellm.proxy._types import SpendLogsPayload
 from litellm.proxy.spend_tracking.cold_storage_handler import ColdStorageHandler
 from litellm.responses.utils import ResponsesAPIRequestUtils
@@ -27,6 +28,18 @@ else:
 ########################################################
 COLD_STORAGE_HANDLER: Final = ColdStorageHandler()
 ########################################################
+
+
+def _normalize_redacted_tool_call_arguments(message: Message) -> None:
+    """Older releases redacted tool-call arguments to the bare sentinel (invalid JSON);
+    normalize replayed history to "{}" so provider converters can parse it."""
+    for tool_call in message.tool_calls or []:
+        function: Final = tool_call.function
+        if function.arguments == REDACTED_BY_LITELLM:
+            function.arguments = "{}"
+    function_call: Final = message.function_call
+    if function_call is not None and function_call.arguments == REDACTED_BY_LITELLM:
+        function_call.arguments = "{}"
 
 
 class ResponsesSessionHandler:
@@ -143,7 +156,9 @@ class ResponsesSessionHandler:
             model_response: Final = ModelResponse(**_response_output)
             for choice in model_response.choices:
                 if hasattr(choice, "message"):
-                    chat_completion_message_history.append(getattr(choice, "message"))
+                    message: Final = getattr(choice, "message")
+                    _normalize_redacted_tool_call_arguments(message)
+                    chat_completion_message_history.append(message)
         return chat_completion_message_history
 
     @staticmethod

--- a/litellm/responses/litellm_completion_transformation/transformation.py
+++ b/litellm/responses/litellm_completion_transformation/transformation.py
@@ -32,7 +32,7 @@ from typing_extensions import TypedDict
 
 from litellm._logging import verbose_logger
 from litellm.caching import InMemoryCache
-from litellm.constants import REDACTED_BY_LITELLM
+from litellm.constants import REDACTED_BY_LITELLM, REDACTED_TOOL_CALL_ARGUMENTS
 from litellm.litellm_core_utils.get_supported_openai_params import (
     get_supported_openai_params,
 )
@@ -1554,7 +1554,7 @@ class LiteLLMCompletionResponsesConfig:
         raw_arguments = function_call.get("arguments")
         if raw_arguments == REDACTED_BY_LITELLM:
             # older releases stored the bare sentinel (invalid JSON) in arguments
-            raw_arguments = "{}"
+            raw_arguments = REDACTED_TOOL_CALL_ARGUMENTS
         if not raw_arguments and function_call.get("type") == "custom_tool_call":
             raw_input: Final = function_call.get("input") or ""
             raw_arguments = json.dumps({"content": raw_input}) if raw_input else ""

--- a/litellm/responses/litellm_completion_transformation/transformation.py
+++ b/litellm/responses/litellm_completion_transformation/transformation.py
@@ -32,7 +32,7 @@ from typing_extensions import TypedDict
 
 from litellm._logging import verbose_logger
 from litellm.caching import InMemoryCache
-from litellm.constants import REDACTED_BY_LITELLM, REDACTED_TOOL_CALL_ARGUMENTS
+from litellm.constants import REDACTED_BY_LITELLM, REDACTED_TOOL_CALL_ARGUMENTS_PLACEHOLDER
 from litellm.litellm_core_utils.get_supported_openai_params import (
     get_supported_openai_params,
 )
@@ -1553,8 +1553,8 @@ class LiteLLMCompletionResponsesConfig:
         # "arguments" (JSON string), so normalize to arguments here.
         raw_arguments = function_call.get("arguments")
         if raw_arguments == REDACTED_BY_LITELLM:
-            # older releases stored the bare sentinel (invalid JSON) in arguments
-            raw_arguments = REDACTED_TOOL_CALL_ARGUMENTS
+            # redaction stores the bare sentinel (invalid JSON) in arguments
+            raw_arguments = REDACTED_TOOL_CALL_ARGUMENTS_PLACEHOLDER
         if not raw_arguments and function_call.get("type") == "custom_tool_call":
             raw_input: Final = function_call.get("input") or ""
             raw_arguments = json.dumps({"content": raw_input}) if raw_input else ""

--- a/litellm/responses/litellm_completion_transformation/transformation.py
+++ b/litellm/responses/litellm_completion_transformation/transformation.py
@@ -32,6 +32,7 @@ from typing_extensions import TypedDict
 
 from litellm._logging import verbose_logger
 from litellm.caching import InMemoryCache
+from litellm.constants import REDACTED_BY_LITELLM
 from litellm.litellm_core_utils.get_supported_openai_params import (
     get_supported_openai_params,
 )
@@ -1551,6 +1552,9 @@ class LiteLLMCompletionResponsesConfig:
         # store their payload in "input" (raw string) rather than
         # "arguments" (JSON string), so normalize to arguments here.
         raw_arguments = function_call.get("arguments")
+        if raw_arguments == REDACTED_BY_LITELLM:
+            # older releases stored the bare sentinel (invalid JSON) in arguments
+            raw_arguments = "{}"
         if not raw_arguments and function_call.get("type") == "custom_tool_call":
             raw_input: Final = function_call.get("input") or ""
             raw_arguments = json.dumps({"content": raw_input}) if raw_input else ""

--- a/tests/test_litellm/integrations/test_langfuse_otel.py
+++ b/tests/test_litellm/integrations/test_langfuse_otel.py
@@ -933,6 +933,49 @@ class TestLangfuseOtelResponsesAPI:
             assert output_data[0]["arguments"]["location"] == "San Francisco"
             assert output_data[0]["arguments"]["unit"] == "celsius"
 
+    def test_responses_api_function_call_with_redacted_arguments(self):
+        """Sentinel arguments (invalid JSON) must not kill the whole observation output."""
+        from litellm.types.integrations.langfuse_otel import LangfuseSpanAttributes
+        from openai.types.responses import ResponseFunctionToolCall
+
+        response_obj = ResponsesAPIResponse(
+            id="response-redacted",
+            created_at=1625247700,
+            output=[
+                ResponseFunctionToolCall(
+                    id="fc-redacted",
+                    type="function_call",
+                    name="get_weather",
+                    call_id="call-redacted",
+                    arguments="redacted-by-litellm",
+                    status="completed",
+                )
+            ],
+        )
+
+        kwargs = {
+            "call_type": "responses",
+            "messages": [{"role": "user", "content": "What's the weather?"}],
+            "model": "gpt-4o",
+            "optional_params": {},
+        }
+
+        mock_span = MagicMock()
+
+        with patch("litellm.integrations.arize._utils.safe_set_attribute") as mock_safe_set_attribute:
+            LangfuseOtelLogger._set_langfuse_specific_attributes(mock_span, kwargs, response_obj)
+
+            output_calls = [
+                call
+                for call in mock_safe_set_attribute.call_args_list
+                if call.args[1] == LangfuseSpanAttributes.OBSERVATION_OUTPUT.value
+            ]
+
+            assert len(output_calls) > 0, "observation.output should still be set"
+            output_data = json.loads(output_calls[0].args[2])
+            assert output_data[0]["name"] == "get_weather"
+            assert output_data[0]["arguments"] == {}
+
 
 if __name__ == "__main__":
     pytest.main([__file__])

--- a/tests/test_litellm/integrations/test_langfuse_otel.py
+++ b/tests/test_litellm/integrations/test_langfuse_otel.py
@@ -935,8 +935,9 @@ class TestLangfuseOtelResponsesAPI:
 
     def test_responses_api_function_call_with_redacted_arguments(self):
         """Sentinel arguments (invalid JSON) must not kill the whole observation output."""
-        from litellm.types.integrations.langfuse_otel import LangfuseSpanAttributes
         from openai.types.responses import ResponseFunctionToolCall
+
+        from litellm.types.integrations.langfuse_otel import LangfuseSpanAttributes
 
         response_obj = ResponsesAPIResponse(
             id="response-redacted",
@@ -962,7 +963,9 @@ class TestLangfuseOtelResponsesAPI:
 
         mock_span = MagicMock()
 
-        with patch("litellm.integrations.arize._utils.safe_set_attribute") as mock_safe_set_attribute:
+        with patch(  # test-quality-ok: the span attribute sink is the observable boundary; sibling tests in this class stub the same seam
+            "litellm.integrations.arize._utils.safe_set_attribute"
+        ) as mock_safe_set_attribute:
             LangfuseOtelLogger._set_langfuse_specific_attributes(mock_span, kwargs, response_obj)
 
             output_calls = [

--- a/tests/test_litellm/litellm_core_utils/test_redact_messages.py
+++ b/tests/test_litellm/litellm_core_utils/test_redact_messages.py
@@ -352,9 +352,9 @@ class TestPerformRedaction:
         message = redacted["choices"][0]["message"]
         assert message["content"] is None
         tool_call = message["tool_calls"][0]
-        assert tool_call["function"]["arguments"] == "{}"
+        assert tool_call["function"]["arguments"] == "redacted-by-litellm"
         assert tool_call["function"]["name"] == "get_weather"
-        assert message["function_call"]["arguments"] == "{}"
+        assert message["function_call"]["arguments"] == "redacted-by-litellm"
 
     def test_redacts_tool_call_arguments_in_streaming_delta_dict(self):
         result = {
@@ -379,7 +379,7 @@ class TestPerformRedaction:
         redacted = perform_redaction({}, result)
 
         delta = redacted["choices"][0]["delta"]
-        assert delta["tool_calls"][0]["function"]["arguments"] == "{}"
+        assert delta["tool_calls"][0]["function"]["arguments"] == "redacted-by-litellm"
 
     def test_redacts_tool_call_arguments_on_model_response_object(self):
         result = litellm.ModelResponse(
@@ -408,7 +408,7 @@ class TestPerformRedaction:
         redacted = perform_redaction({}, result)
 
         tool_call = redacted.choices[0].message.tool_calls[0]
-        assert tool_call.function.arguments == "{}"
+        assert tool_call.function.arguments == "redacted-by-litellm"
         assert tool_call.function.name == "get_weather"
         assert result.choices[0].message.tool_calls[0].function.arguments == (
             '{"city": "sensitive-city"}'
@@ -442,7 +442,7 @@ class TestPerformRedaction:
         perform_redaction(details, None)
 
         tool_call = streaming_response.choices[0].delta.tool_calls[0]
-        assert tool_call.function.arguments == "{}"
+        assert tool_call.function.arguments == "redacted-by-litellm"
 
     def test_redacts_tool_call_arguments_in_standard_logging_object(self):
         details = {
@@ -472,7 +472,7 @@ class TestPerformRedaction:
         perform_redaction(details, None)
 
         message = details["standard_logging_object"]["response"]["choices"][0]["message"]
-        assert message["tool_calls"][0]["function"]["arguments"] == "{}"
+        assert message["tool_calls"][0]["function"]["arguments"] == "redacted-by-litellm"
 
     def test_redacts_responses_api_function_call_arguments_dict(self):
         result = {
@@ -488,7 +488,7 @@ class TestPerformRedaction:
 
         redacted = perform_redaction({}, result)
 
-        assert redacted["output"][0]["arguments"] == "{}"
+        assert redacted["output"][0]["arguments"] == "redacted-by-litellm"
         assert redacted["output"][0]["name"] == "get_weather"
 
     def test_redacts_every_tool_call_in_multi_element_list(self):
@@ -520,8 +520,8 @@ class TestPerformRedaction:
         redacted = perform_redaction({}, result)
 
         tool_calls = redacted.choices[0].message.tool_calls
-        assert tool_calls[0].function.arguments == "{}"
-        assert tool_calls[1].function.arguments == "{}"
+        assert tool_calls[0].function.arguments == "redacted-by-litellm"
+        assert tool_calls[1].function.arguments == "redacted-by-litellm"
 
     def test_preserves_none_content_on_tool_call_only_message(self):
         result = litellm.ModelResponse(
@@ -558,7 +558,7 @@ class TestPerformRedaction:
 
         _redact_responses_api_output([output_item])
 
-        assert output_item.arguments == "{}"
+        assert output_item.arguments == "redacted-by-litellm"
         assert output_item.name == "get_weather"
 
     def test_redacts_response_output_objects_with_top_level_text(self):
@@ -571,6 +571,29 @@ class TestPerformRedaction:
 
         assert output_items[0].text == "redacted-by-litellm"
         assert output_items[1] == "non-dict output item"
+
+    def test_preserves_none_text_in_responses_output(self):
+        from litellm.litellm_core_utils.redact_messages import _redact_responses_api_output_dict
+
+        none_item = SimpleNamespace(type="output_text", text=None, content=[SimpleNamespace(text=None)])
+        real_item = SimpleNamespace(type="output_text", text="real answer", content=[SimpleNamespace(text="real part")])
+
+        _redact_responses_api_output([none_item, real_item])
+
+        assert none_item.text is None
+        assert none_item.content[0].text is None
+        assert real_item.text == "redacted-by-litellm"
+        assert real_item.content[0].text == "redacted-by-litellm"
+
+        none_dict = {"type": "output_text", "text": None, "content": [{"text": None}]}
+        real_dict = {"type": "output_text", "text": "real answer", "content": [{"text": "real part"}]}
+
+        _redact_responses_api_output_dict([none_dict, real_dict], "redacted-by-litellm")
+
+        assert none_dict["text"] is None
+        assert none_dict["content"][0]["text"] is None
+        assert real_dict["text"] == "redacted-by-litellm"
+        assert real_dict["content"][0]["text"] == "redacted-by-litellm"
 
     def test_skips_non_dict_response_output_items(self):
         result = {

--- a/tests/test_litellm/litellm_core_utils/test_redact_messages.py
+++ b/tests/test_litellm/litellm_core_utils/test_redact_messages.py
@@ -350,11 +350,11 @@ class TestPerformRedaction:
         redacted = perform_redaction({}, result)
 
         message = redacted["choices"][0]["message"]
-        assert message["content"] == "redacted-by-litellm"
+        assert message["content"] is None
         tool_call = message["tool_calls"][0]
-        assert tool_call["function"]["arguments"] == "redacted-by-litellm"
+        assert tool_call["function"]["arguments"] == "{}"
         assert tool_call["function"]["name"] == "get_weather"
-        assert message["function_call"]["arguments"] == "redacted-by-litellm"
+        assert message["function_call"]["arguments"] == "{}"
 
     def test_redacts_tool_call_arguments_in_streaming_delta_dict(self):
         result = {
@@ -379,7 +379,7 @@ class TestPerformRedaction:
         redacted = perform_redaction({}, result)
 
         delta = redacted["choices"][0]["delta"]
-        assert delta["tool_calls"][0]["function"]["arguments"] == "redacted-by-litellm"
+        assert delta["tool_calls"][0]["function"]["arguments"] == "{}"
 
     def test_redacts_tool_call_arguments_on_model_response_object(self):
         result = litellm.ModelResponse(
@@ -408,7 +408,7 @@ class TestPerformRedaction:
         redacted = perform_redaction({}, result)
 
         tool_call = redacted.choices[0].message.tool_calls[0]
-        assert tool_call.function.arguments == "redacted-by-litellm"
+        assert tool_call.function.arguments == "{}"
         assert tool_call.function.name == "get_weather"
         assert result.choices[0].message.tool_calls[0].function.arguments == (
             '{"city": "sensitive-city"}'
@@ -442,7 +442,7 @@ class TestPerformRedaction:
         perform_redaction(details, None)
 
         tool_call = streaming_response.choices[0].delta.tool_calls[0]
-        assert tool_call.function.arguments == "redacted-by-litellm"
+        assert tool_call.function.arguments == "{}"
 
     def test_redacts_tool_call_arguments_in_standard_logging_object(self):
         details = {
@@ -472,7 +472,7 @@ class TestPerformRedaction:
         perform_redaction(details, None)
 
         message = details["standard_logging_object"]["response"]["choices"][0]["message"]
-        assert message["tool_calls"][0]["function"]["arguments"] == "redacted-by-litellm"
+        assert message["tool_calls"][0]["function"]["arguments"] == "{}"
 
     def test_redacts_responses_api_function_call_arguments_dict(self):
         result = {
@@ -488,8 +488,78 @@ class TestPerformRedaction:
 
         redacted = perform_redaction({}, result)
 
-        assert redacted["output"][0]["arguments"] == "redacted-by-litellm"
+        assert redacted["output"][0]["arguments"] == "{}"
         assert redacted["output"][0]["name"] == "get_weather"
+
+    def test_redacts_every_tool_call_in_multi_element_list(self):
+        result = litellm.ModelResponse(
+            id="resp-multi",
+            choices=[
+                litellm.Choices(
+                    message=litellm.Message(
+                        content=None,
+                        role="assistant",
+                        tool_calls=[
+                            {
+                                "id": "call_1",
+                                "type": "function",
+                                "function": {"name": "get_weather", "arguments": '{"city": "a"}'},
+                            },
+                            {
+                                "id": "call_2",
+                                "type": "function",
+                                "function": {"name": "get_time", "arguments": '{"tz": "b"}'},
+                            },
+                        ],
+                    )
+                )
+            ],
+            model="gpt-4o",
+        )
+
+        redacted = perform_redaction({}, result)
+
+        tool_calls = redacted.choices[0].message.tool_calls
+        assert tool_calls[0].function.arguments == "{}"
+        assert tool_calls[1].function.arguments == "{}"
+
+    def test_preserves_none_content_on_tool_call_only_message(self):
+        result = litellm.ModelResponse(
+            id="resp-none",
+            choices=[
+                litellm.Choices(
+                    message=litellm.Message(
+                        content=None,
+                        role="assistant",
+                        tool_calls=[
+                            {
+                                "id": "call_1",
+                                "type": "function",
+                                "function": {"name": "get_weather", "arguments": '{"city": "a"}'},
+                            }
+                        ],
+                    )
+                )
+            ],
+            model="gpt-4o",
+        )
+
+        redacted = perform_redaction({}, result)
+
+        assert redacted.choices[0].message.content is None
+
+    def test_redacts_responses_api_function_call_arguments_object(self):
+        output_item = SimpleNamespace(
+            type="function_call",
+            name="get_weather",
+            arguments='{"city": "sensitive-city"}',
+            call_id="call_1",
+        )
+
+        _redact_responses_api_output([output_item])
+
+        assert output_item.arguments == "{}"
+        assert output_item.name == "get_weather"
 
     def test_redacts_response_output_objects_with_top_level_text(self):
         output_items = [

--- a/tests/test_litellm/responses/litellm_completion_transformation/test_litellm_completion_responses.py
+++ b/tests/test_litellm/responses/litellm_completion_transformation/test_litellm_completion_responses.py
@@ -953,6 +953,19 @@ class TestFunctionCallTransformation:
         assert function.get("name") == "get_weather"
         assert function.get("arguments") == '{"location": "São Paulo, Brazil"}'
 
+    def test_function_call_transformation_normalizes_redacted_arguments(self):
+        """Rows stored before the redaction fix hold the bare sentinel, which is invalid JSON."""
+        result = LiteLLMCompletionResponsesConfig._transform_responses_api_function_call_to_chat_completion_message(
+            function_call={
+                "type": "function_call",
+                "name": "get_weather",
+                "arguments": "redacted-by-litellm",
+                "call_id": "call_123",
+            }
+        )
+
+        assert result[0]["tool_calls"][0]["function"]["arguments"] == "{}"
+
     def test_complete_input_transformation_with_function_calls(self):
         """Test the complete transformation with the exact input from the issue"""
         test_input = [

--- a/tests/test_litellm/responses/litellm_completion_transformation/test_litellm_completion_responses.py
+++ b/tests/test_litellm/responses/litellm_completion_transformation/test_litellm_completion_responses.py
@@ -954,7 +954,7 @@ class TestFunctionCallTransformation:
         assert function.get("arguments") == '{"location": "São Paulo, Brazil"}'
 
     def test_function_call_transformation_normalizes_redacted_arguments(self):
-        """Rows stored before the redaction fix hold the bare sentinel, which is invalid JSON."""
+        """Redacted rows hold the bare sentinel in arguments, which is invalid JSON."""
         result = LiteLLMCompletionResponsesConfig._transform_responses_api_function_call_to_chat_completion_message(
             function_call={
                 "type": "function_call",

--- a/tests/test_litellm/responses/litellm_completion_transformation/test_session_handler.py
+++ b/tests/test_litellm/responses/litellm_completion_transformation/test_session_handler.py
@@ -9,8 +9,10 @@ import litellm
 from litellm.responses.litellm_completion_transformation import session_handler
 from litellm.responses.litellm_completion_transformation.session_handler import (
     ResponsesSessionHandler,
+    _normalize_redacted_tool_call_arguments,
 )
 from litellm.responses.utils import ResponsesAPIRequestUtils
+from litellm.types.utils import Message
 
 
 @pytest.mark.asyncio
@@ -638,6 +640,22 @@ async def test_session_lookup_does_not_retry_when_spend_logs_are_disabled(
 
     assert spend_logs == []
     assert fake_prisma_client.db.calls == [("chatcmpl-does-not-exist",)]
+
+
+def test_normalize_redacted_arguments_skips_custom_tool_calls():
+    """Custom tool calls have no .function; the normalizer must skip them, not crash (session replay path)."""
+    message = Message(
+        content=None,
+        tool_calls=[
+            {"id": "call_c", "type": "custom", "custom": {"name": "run_code", "input": "print(1)"}},
+            {"id": "call_f", "type": "function", "function": {"name": "get_weather", "arguments": "redacted-by-litellm"}},
+        ],
+    )
+
+    _normalize_redacted_tool_call_arguments(message)
+
+    assert message.tool_calls[0].custom.input == "print(1)"
+    assert message.tool_calls[1].function.arguments == "{}"
 
 
 @pytest.mark.asyncio

--- a/tests/test_litellm/responses/litellm_completion_transformation/test_session_handler.py
+++ b/tests/test_litellm/responses/litellm_completion_transformation/test_session_handler.py
@@ -638,3 +638,65 @@ async def test_session_lookup_does_not_retry_when_spend_logs_are_disabled(
 
     assert spend_logs == []
     assert fake_prisma_client.db.calls == [("chatcmpl-does-not-exist",)]
+
+
+@pytest.mark.asyncio
+async def test_message_history_normalizes_redacted_tool_call_arguments():
+    """Sessions stored with turn_off_message_logging before the fix hold the bare
+    sentinel in tool-call arguments; replay must normalize it to valid JSON."""
+    mock_spend_logs = [
+        {
+            "request_id": "chatcmpl-redacted-1",
+            "call_type": "aresponses",
+            "session_id": "sess-redacted",
+            "proxy_server_request": {
+                "input": "what is the weather in sf",
+                "model": "gpt-4o",
+            },
+            "response": {
+                "id": "chatcmpl-redacted-1",
+                "model": "gpt-4o",
+                "object": "chat.completion",
+                "choices": [
+                    {
+                        "index": 0,
+                        "message": {
+                            "role": "assistant",
+                            "content": None,
+                            "tool_calls": [
+                                {
+                                    "id": "call_1",
+                                    "type": "function",
+                                    "function": {
+                                        "name": "get_weather",
+                                        "arguments": "redacted-by-litellm",
+                                    },
+                                }
+                            ],
+                            "function_call": None,
+                        },
+                        "finish_reason": "tool_calls",
+                    }
+                ],
+                "created": 1748575031,
+                "usage": {"total_tokens": 10, "prompt_tokens": 5, "completion_tokens": 5},
+            },
+            "status": "success",
+        }
+    ]
+
+    with patch.object(
+        ResponsesSessionHandler,
+        "get_all_spend_logs_for_previous_response_id",
+        new_callable=AsyncMock,
+    ) as mock_get_spend_logs:
+        mock_get_spend_logs.return_value = mock_spend_logs
+
+        result = await ResponsesSessionHandler.get_chat_completion_message_history_for_previous_response_id(
+            "chatcmpl-redacted-1"
+        )
+
+    assistant_message = result["messages"][-1]
+    tool_call = assistant_message.tool_calls[0]
+    assert tool_call.function.arguments == "{}"
+    assert json.loads(tool_call.function.arguments) == {}

--- a/tests/test_litellm/responses/litellm_completion_transformation/test_session_handler.py
+++ b/tests/test_litellm/responses/litellm_completion_transformation/test_session_handler.py
@@ -685,7 +685,7 @@ async def test_message_history_normalizes_redacted_tool_call_arguments():
         }
     ]
 
-    with patch.object(
+    with patch.object(  # test-quality-ok: the handler has no DI seam for the spend-log fetch; every test in this file stubs this same boundary
         ResponsesSessionHandler,
         "get_all_spend_logs_for_previous_response_id",
         new_callable=AsyncMock,

--- a/tests/test_litellm/responses/litellm_completion_transformation/test_session_handler.py
+++ b/tests/test_litellm/responses/litellm_completion_transformation/test_session_handler.py
@@ -660,8 +660,8 @@ def test_normalize_redacted_arguments_skips_custom_tool_calls():
 
 @pytest.mark.asyncio
 async def test_message_history_normalizes_redacted_tool_call_arguments():
-    """Sessions stored with turn_off_message_logging before the fix hold the bare
-    sentinel in tool-call arguments; replay must normalize it to valid JSON."""
+    """Sessions stored with turn_off_message_logging hold the bare sentinel
+    in tool-call arguments; replay must normalize it to valid JSON."""
     mock_spend_logs = [
         {
             "request_id": "chatcmpl-redacted-1",


### PR DESCRIPTION
## TLDR

Problem this solves:

- `turn_off_message_logging` stores tool call arguments as invalid JSON
- it also invents `redacted-by-litellm` content for tool-only turns
- replaying such a session via `previous_response_id` fails with 500

How it solves it:

- keep storing the explicit `redacted-by-litellm` marker in `arguments`, so a redacted call stays distinguishable in the logs
- swap that marker for `{}` in memory while rebuilding the provider request during session replay, so converters can parse it
- keep `null` assistant content `null` instead of inventing text, on chat choices and on Responses API output items alike
- guard Langfuse observation output against unparseable arguments

## User Flow

Before: a developer whose proxy has `turn_off_message_logging: true` cannot continue any Responses API session that contains a tool call

1. They send POST https://litellm-domain/v1/responses with `tools` and get back a `function_call` with real arguments
2. They follow up with POST https://litellm-domain/v1/responses carrying `previous_response_id` and a new question
3. The follow-up fails with HTTP 500, `Unable to convert openai tool calls ... Expecting value: line 1 column 1`, because the stored turn now holds `"arguments": "redacted-by-litellm"`
4. On https://litellm-domain/ui/?page=logs the assistant turn of that request shows invented `redacted-by-litellm` content where the model actually sent none, and the stored tool call arguments are unparseable for anything reading the log

After: the same follow-up works and the stored log stays redacted

1. They send the same POST https://litellm-domain/v1/responses with `tools` and get back the same `function_call` with real arguments
2. The follow-up with `previous_response_id` returns HTTP 200 with the model's answer: the marker is swapped for `{}` only in memory while building the provider request
3. Sessions stored before the upgrade replay the same way, since old and new rows hold the same marker
4. On https://litellm-domain/ui/?page=logs the assistant turn shows the tool call with no invented content, matching what the model really sent, and the stored arguments keep the explicit redaction marker

## Relevant issues

## Linear ticket

Resolves LIT-6102

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Shared setup: proxy with `turn_off_message_logging: true`, `store_prompts_in_spend_logs: true`, a `langfuse_otel` callback, Postgres attached, real Gemini and Anthropic upstreams. `TOOLS` is one `get_weather` function tool in the endpoint's native shape

### Before (a9c7b848f2)

#### case 1: /v1/chat/completions tool call, live response untouched

1. `curl -s $PROXY/v1/chat/completions -d '{"model":"gemini-flash","messages":[{"role":"user","content":"Weather in Berlin? You must use the get_weather tool."}],"tools":TOOLS}'`
2. Client sees real arguments: `"content": null, "tool_calls": [{"function": {"arguments": "{\"city\": \"Berlin\"}", "name": "get_weather"}}]`

#### case 2: /v1/chat/completions stream=true tool call, live stream untouched

1. Same call with `"stream": true`
2. Streamed chunks carry `"function":{"arguments":"{\"city\": \"Tokyo\"}","name":"get_weather"}`

#### case 3: /v1/responses tool call, live response untouched

1. `curl -s $PROXY/v1/responses -d '{"model":"gemini-flash","input":"Weather in Berlin? You must use the get_weather tool.","tools":TOOLS}'`
2. Client sees `"function_call": {"name": "get_weather", "arguments": "{\"city\": \"Berlin\"}"}`

#### case 4: what the spend log stored

1. `SELECT response FROM "LiteLLM_SpendLogs" ORDER BY "startTime" DESC LIMIT 3;` then count the redacted fields
2. Output: `3 "arguments": "redacted-by-litellm"` and `3 "content": "redacted-by-litellm"`; the arguments are invalid JSON and the content is invented (the model sent none)
3. The logs page renders the fabricated assistant content and the raw sentinel:

![before: fabricated assistant content and raw sentinel arguments](https://raw.githubusercontent.com/BerriAI/litellm/assets-pr38182/ui_before_messages.png)

#### case 5: replay the session to the same model

1. `curl -s $PROXY/v1/responses -d '{"model":"gemini-flash","previous_response_id":"<id from case 3>","input":"and tomorrow?"}'`
2. HTTP 500: `litellm.APIConnectionError: Unable to convert openai tool calls={'content': 'redacted-by-litellm', ... 'arguments': 'redacted-by-litellm' ...}`

#### case 6: replay the session cross-provider

1. Same call with `"model": "claude-haiku"`
2. HTTP 400: `AnthropicException - Failed to parse tool call arguments for tool 'get_weather' ... Expecting value: line 1 column 1 (char 0). Arguments: redacted-by-litellm`

#### case 7: replay a session stored by the old release

1. On this side every stored session is an old-format row, so this is case 5: any replay of stored history fails the same way

### After (92ee7e3b57)

#### case 1: /v1/chat/completions tool call, live response untouched

1. Same call as before
2. Client sees the same real arguments: `"content": null, "tool_calls": [{"function": {"arguments": "{\"city\": \"Berlin\"}", "name": "get_weather"}}]`

#### case 2: /v1/chat/completions stream=true tool call, live stream untouched

1. Same call as before
2. Streamed chunks carry `"function":{"arguments":"{\"city\": \"Tokyo\"}","name":"get_weather"}`

#### case 3: /v1/responses tool call, live response untouched

1. Same call as before
2. Client sees `"function_call": {"name": "get_weather", "arguments": "{\"city\": \"Berlin\"}"}`

#### case 4: what the spend log stored

1. Same query
2. Output: `3 "arguments": "redacted-by-litellm"` and `3 "content": null`; the stored row keeps the explicit redaction marker and no content is invented
3. The logs page shows the tool call with no invented content and the marker visible in the arguments:

![after: tool call with no invented content and the marker kept in arguments](https://raw.githubusercontent.com/BerriAI/litellm/assets-pr38182/ui_after_messages.png)

#### case 5: replay the session to the same model

1. Same call as before
2. HTTP 200, the model answers the follow-up: the stored marker is swapped for `{}` in memory while building the provider request, so the converter parses it

![after: tool call, stored row, replay end to end](https://raw.githubusercontent.com/BerriAI/litellm/assets-pr38182/demo.gif)

#### case 6: replay the session cross-provider

1. Same call as before
2. The request now clears argument parsing and reaches Anthropic; this rig's Anthropic key is routed through a sandbox gateway so the upstream answers with an auth error, proving the converter no longer crashes

#### case 7: replay a session stored by the old release

1. Same call with the `previous_response_id` of a session written by the unfixed build
2. HTTP 200: old rows and new rows hold the same marker, so the same in-memory normalization covers both and the session continues

### Langfuse destination A/B (real cloud.langfuse.com, base a9c7b848f2 vs head 2e986da02e)

Same two proxies with a `langfuse_otel` callback exporting to `https://cloud.langfuse.com`; every value below was read back through the Langfuse public API, no local collector

#### case 8: /v1/chat/completions tool call reaches Langfuse on both sides

1. Same gemini-flash `get_weather` call on each proxy
2. Both traces show the redacted input and a parsed observation output, since this branch already guarded the marker before this PR:

```json
"input": [{"role": "user", "content": "redacted-by-litellm"}]
"output": [{"name": "get_weather", "type": "function_call", "arguments": {}}]
```

#### case 9: native /v1/responses tool call, the branch this PR guards

1. `curl -s $PROXY/v1/responses -d '{"model":"gpt-4o-mini","input":"Weather in Berlin? You must use the get_weather tool.","tools":TOOLS,"tool_choice":"required"}'` on each proxy
2. Before (trace `89bd360f...`): the observation has `"output": null` and the proxy log shows the crash that ate it:

```
File ".../langfuse_otel.py", line 200, in _set_observation_output
json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
```

3. After (trace `2b0f5d14...`): the observation output arrives intact, and its `id` matches the `function_call` id the client received, proving it is the same call:

```json
"output": [{"id": "fc_01e481945093009c006a8e259c3ecc87d08b19d495c968d940",
            "name": "get_weather", "call_id": "call_iDyZKYqmqvcKrej2v7rN4MGc",
            "type": "function_call", "arguments": {}}]
```

4. The spend rows stayed identical on both sides (`"arguments": "redacted-by-litellm"`, no invented text), confirming the stored format is untouched and this run also exercised the Responses-shape redaction writer live

## Type

🐛 Bug Fix

## Caveats (if any)

- stored `arguments` keep the `redacted-by-litellm` marker, which is not valid JSON; readers that `json.loads` stored arguments must keep handling that, as they did before this PR
- custom tool calls carry no `function` field, so the replay normalizer skips them via a `getattr` guard
- Gemini may still reject a replayed redacted turn that carries a thought signature (provider 400 instead of the old proxy 500), since the real arguments are unrecoverable by design

## Behavior changes

- stored spend-log values are unchanged: redacted tool call arguments keep the `redacted-by-litellm` marker, so log readers can still tell a redacted call from a genuinely empty one
- redacted assistant turns with no content now keep `content: null` instead of the sentinel string, and Responses API output items with `text: null` keep it too; Langfuse and OTEL payloads omit those fields for such turns
- session replay swaps the `redacted-by-litellm` arguments for `{}` in memory while building the provider request; the stored row is untouched
- earlier revisions of this PR stored `{}` instead of the marker; that never shipped, and external log readers keep seeing the marker exactly as before
