### PR TITLE
fix(pricing): add missing Azure gpt-5.6 cache-write rates

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -6592,6 +6592,9 @@
         "supports_web_search": true
     },
     "azure/gpt-5.6": {
+        "cache_creation_input_token_cost": 6.25e-06,
+        "cache_creation_input_token_cost_above_272k_tokens": 1.25e-05,
+        "cache_creation_input_token_cost_priority": 1.25e-05,
         "cache_read_input_token_cost": 5e-07,
         "cache_read_input_token_cost_above_272k_tokens": 1e-06,
         "cache_read_input_token_cost_priority": 1e-06,
@@ -6642,6 +6645,9 @@
         "supports_minimal_reasoning_effort": false
     },
     "azure/gpt-5.6-sol": {
+        "cache_creation_input_token_cost": 6.25e-06,
+        "cache_creation_input_token_cost_above_272k_tokens": 1.25e-05,
+        "cache_creation_input_token_cost_priority": 1.25e-05,
         "cache_read_input_token_cost": 5e-07,
         "cache_read_input_token_cost_above_272k_tokens": 1e-06,
         "cache_read_input_token_cost_priority": 1e-06,
@@ -6693,6 +6699,9 @@
         "supports_minimal_reasoning_effort": false
     },
     "azure/gpt-5.6-terra": {
+        "cache_creation_input_token_cost": 2.5e-06,
+        "cache_creation_input_token_cost_above_272k_tokens": 5e-06,
+        "cache_creation_input_token_cost_priority": 5e-06,
         "cache_read_input_token_cost": 2e-07,
         "cache_read_input_token_cost_above_272k_tokens": 4e-07,
         "cache_read_input_token_cost_priority": 4e-07,
@@ -6744,6 +6753,9 @@
         "supports_minimal_reasoning_effort": false
     },
     "azure/gpt-5.6-luna": {
+        "cache_creation_input_token_cost": 2.5e-07,
+        "cache_creation_input_token_cost_above_272k_tokens": 5e-07,
+        "cache_creation_input_token_cost_priority": 5e-07,
         "cache_read_input_token_cost": 2e-08,
         "cache_read_input_token_cost_above_272k_tokens": 4e-08,
         "cache_read_input_token_cost_priority": 4e-08,
@@ -6795,6 +6807,9 @@
         "supports_minimal_reasoning_effort": false
     },
     "azure/us/gpt-5.6": {
+        "cache_creation_input_token_cost": 6.875e-06,
+        "cache_creation_input_token_cost_above_272k_tokens": 1.375e-05,
+        "cache_creation_input_token_cost_priority": 1.71875e-05,
         "cache_read_input_token_cost": 5.5e-07,
         "cache_read_input_token_cost_above_272k_tokens": 1.1e-06,
         "cache_read_input_token_cost_priority": 1.375e-06,
@@ -6842,6 +6857,9 @@
         "supports_minimal_reasoning_effort": false
     },
     "azure/us/gpt-5.6-sol": {
+        "cache_creation_input_token_cost": 6.875e-06,
+        "cache_creation_input_token_cost_above_272k_tokens": 1.375e-05,
+        "cache_creation_input_token_cost_priority": 1.71875e-05,
         "cache_read_input_token_cost": 5.5e-07,
         "cache_read_input_token_cost_above_272k_tokens": 1.1e-06,
         "cache_read_input_token_cost_priority": 1.375e-06,
@@ -6890,6 +6908,9 @@
         "supports_minimal_reasoning_effort": false
     },
     "azure/us/gpt-5.6-terra": {
+        "cache_creation_input_token_cost": 2.75e-06,
+        "cache_creation_input_token_cost_above_272k_tokens": 5.5e-06,
+        "cache_creation_input_token_cost_priority": 6.875e-06,
         "cache_read_input_token_cost": 2.2e-07,
         "cache_read_input_token_cost_above_272k_tokens": 4.4e-07,
         "cache_read_input_token_cost_priority": 5.5e-07,
@@ -6938,6 +6959,9 @@
         "supports_minimal_reasoning_effort": false
     },
     "azure/us/gpt-5.6-luna": {
+        "cache_creation_input_token_cost": 2.75e-07,
+        "cache_creation_input_token_cost_above_272k_tokens": 5.5e-07,
+        "cache_creation_input_token_cost_priority": 6.875e-07,
         "cache_read_input_token_cost": 2.2e-08,
         "cache_read_input_token_cost_above_272k_tokens": 4.4e-08,
         "cache_read_input_token_cost_priority": 5.5e-08,
@@ -6986,6 +7010,9 @@
         "supports_minimal_reasoning_effort": false
     },
     "azure/eu/gpt-5.6": {
+        "cache_creation_input_token_cost": 6.875e-06,
+        "cache_creation_input_token_cost_above_272k_tokens": 1.375e-05,
+        "cache_creation_input_token_cost_priority": 1.71875e-05,
         "cache_read_input_token_cost": 5.5e-07,
         "cache_read_input_token_cost_above_272k_tokens": 1.1e-06,
         "cache_read_input_token_cost_priority": 1.375e-06,
@@ -7033,6 +7060,9 @@
         "supports_minimal_reasoning_effort": false
     },
     "azure/eu/gpt-5.6-sol": {
+        "cache_creation_input_token_cost": 6.875e-06,
+        "cache_creation_input_token_cost_above_272k_tokens": 1.375e-05,
+        "cache_creation_input_token_cost_priority": 1.71875e-05,
         "cache_read_input_token_cost": 5.5e-07,
         "cache_read_input_token_cost_above_272k_tokens": 1.1e-06,
         "cache_read_input_token_cost_priority": 1.375e-06,
@@ -7081,6 +7111,9 @@
         "supports_minimal_reasoning_effort": false
     },
     "azure/eu/gpt-5.6-terra": {
+        "cache_creation_input_token_cost": 2.75e-06,
+        "cache_creation_input_token_cost_above_272k_tokens": 5.5e-06,
+        "cache_creation_input_token_cost_priority": 6.875e-06,
         "cache_read_input_token_cost": 2.2e-07,
         "cache_read_input_token_cost_above_272k_tokens": 4.4e-07,
         "cache_read_input_token_cost_priority": 5.5e-07,
@@ -7129,6 +7162,9 @@
         "supports_minimal_reasoning_effort": false
     },
     "azure/eu/gpt-5.6-luna": {
+        "cache_creation_input_token_cost": 2.75e-07,
+        "cache_creation_input_token_cost_above_272k_tokens": 5.5e-07,
+        "cache_creation_input_token_cost_priority": 6.875e-07,
         "cache_read_input_token_cost": 2.2e-08,
         "cache_read_input_token_cost_above_272k_tokens": 4.4e-08,
         "cache_read_input_token_cost_priority": 5.5e-08,

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -6592,6 +6592,9 @@
         "supports_web_search": true
     },
     "azure/gpt-5.6": {
+        "cache_creation_input_token_cost": 6.25e-06,
+        "cache_creation_input_token_cost_above_272k_tokens": 1.25e-05,
+        "cache_creation_input_token_cost_priority": 1.25e-05,
         "cache_read_input_token_cost": 5e-07,
         "cache_read_input_token_cost_above_272k_tokens": 1e-06,
         "cache_read_input_token_cost_priority": 1e-06,
@@ -6642,6 +6645,9 @@
         "supports_minimal_reasoning_effort": false
     },
     "azure/gpt-5.6-sol": {
+        "cache_creation_input_token_cost": 6.25e-06,
+        "cache_creation_input_token_cost_above_272k_tokens": 1.25e-05,
+        "cache_creation_input_token_cost_priority": 1.25e-05,
         "cache_read_input_token_cost": 5e-07,
         "cache_read_input_token_cost_above_272k_tokens": 1e-06,
         "cache_read_input_token_cost_priority": 1e-06,
@@ -6693,6 +6699,9 @@
         "supports_minimal_reasoning_effort": false
     },
     "azure/gpt-5.6-terra": {
+        "cache_creation_input_token_cost": 2.5e-06,
+        "cache_creation_input_token_cost_above_272k_tokens": 5e-06,
+        "cache_creation_input_token_cost_priority": 5e-06,
         "cache_read_input_token_cost": 2e-07,
         "cache_read_input_token_cost_above_272k_tokens": 4e-07,
         "cache_read_input_token_cost_priority": 4e-07,
@@ -6744,6 +6753,9 @@
         "supports_minimal_reasoning_effort": false
     },
     "azure/gpt-5.6-luna": {
+        "cache_creation_input_token_cost": 2.5e-07,
+        "cache_creation_input_token_cost_above_272k_tokens": 5e-07,
+        "cache_creation_input_token_cost_priority": 5e-07,
         "cache_read_input_token_cost": 2e-08,
         "cache_read_input_token_cost_above_272k_tokens": 4e-08,
         "cache_read_input_token_cost_priority": 4e-08,
@@ -6795,6 +6807,9 @@
         "supports_minimal_reasoning_effort": false
     },
     "azure/us/gpt-5.6": {
+        "cache_creation_input_token_cost": 6.875e-06,
+        "cache_creation_input_token_cost_above_272k_tokens": 1.375e-05,
+        "cache_creation_input_token_cost_priority": 1.71875e-05,
         "cache_read_input_token_cost": 5.5e-07,
         "cache_read_input_token_cost_above_272k_tokens": 1.1e-06,
         "cache_read_input_token_cost_priority": 1.375e-06,
@@ -6842,6 +6857,9 @@
         "supports_minimal_reasoning_effort": false
     },
     "azure/us/gpt-5.6-sol": {
+        "cache_creation_input_token_cost": 6.875e-06,
+        "cache_creation_input_token_cost_above_272k_tokens": 1.375e-05,
+        "cache_creation_input_token_cost_priority": 1.71875e-05,
         "cache_read_input_token_cost": 5.5e-07,
         "cache_read_input_token_cost_above_272k_tokens": 1.1e-06,
         "cache_read_input_token_cost_priority": 1.375e-06,
@@ -6890,6 +6908,9 @@
         "supports_minimal_reasoning_effort": false
     },
     "azure/us/gpt-5.6-terra": {
+        "cache_creation_input_token_cost": 2.75e-06,
+        "cache_creation_input_token_cost_above_272k_tokens": 5.5e-06,
+        "cache_creation_input_token_cost_priority": 6.875e-06,
         "cache_read_input_token_cost": 2.2e-07,
         "cache_read_input_token_cost_above_272k_tokens": 4.4e-07,
         "cache_read_input_token_cost_priority": 5.5e-07,
@@ -6938,6 +6959,9 @@
         "supports_minimal_reasoning_effort": false
     },
     "azure/us/gpt-5.6-luna": {
+        "cache_creation_input_token_cost": 2.75e-07,
+        "cache_creation_input_token_cost_above_272k_tokens": 5.5e-07,
+        "cache_creation_input_token_cost_priority": 6.875e-07,
         "cache_read_input_token_cost": 2.2e-08,
         "cache_read_input_token_cost_above_272k_tokens": 4.4e-08,
         "cache_read_input_token_cost_priority": 5.5e-08,
@@ -6986,6 +7010,9 @@
         "supports_minimal_reasoning_effort": false
     },
     "azure/eu/gpt-5.6": {
+        "cache_creation_input_token_cost": 6.875e-06,
+        "cache_creation_input_token_cost_above_272k_tokens": 1.375e-05,
+        "cache_creation_input_token_cost_priority": 1.71875e-05,
         "cache_read_input_token_cost": 5.5e-07,
         "cache_read_input_token_cost_above_272k_tokens": 1.1e-06,
         "cache_read_input_token_cost_priority": 1.375e-06,
@@ -7033,6 +7060,9 @@
         "supports_minimal_reasoning_effort": false
     },
     "azure/eu/gpt-5.6-sol": {
+        "cache_creation_input_token_cost": 6.875e-06,
+        "cache_creation_input_token_cost_above_272k_tokens": 1.375e-05,
+        "cache_creation_input_token_cost_priority": 1.71875e-05,
         "cache_read_input_token_cost": 5.5e-07,
         "cache_read_input_token_cost_above_272k_tokens": 1.1e-06,
         "cache_read_input_token_cost_priority": 1.375e-06,
@@ -7081,6 +7111,9 @@
         "supports_minimal_reasoning_effort": false
     },
     "azure/eu/gpt-5.6-terra": {
+        "cache_creation_input_token_cost": 2.75e-06,
+        "cache_creation_input_token_cost_above_272k_tokens": 5.5e-06,
+        "cache_creation_input_token_cost_priority": 6.875e-06,
         "cache_read_input_token_cost": 2.2e-07,
         "cache_read_input_token_cost_above_272k_tokens": 4.4e-07,
         "cache_read_input_token_cost_priority": 5.5e-07,
@@ -7129,6 +7162,9 @@
         "supports_minimal_reasoning_effort": false
     },
     "azure/eu/gpt-5.6-luna": {
+        "cache_creation_input_token_cost": 2.75e-07,
+        "cache_creation_input_token_cost_above_272k_tokens": 5.5e-07,
+        "cache_creation_input_token_cost_priority": 6.875e-07,
         "cache_read_input_token_cost": 2.2e-08,
         "cache_read_input_token_cost_above_272k_tokens": 4.4e-08,
         "cache_read_input_token_cost_priority": 5.5e-08,

--- a/tests/test_litellm/test_cost_calculator.py
+++ b/tests/test_litellm/test_cost_calculator.py
@@ -1,4 +1,6 @@
 
+from typing import Final
+
 import pytest
 
 
@@ -3781,3 +3783,52 @@ def test_completion_cost_prices_anthropic_shaped_cache_read_tokens(_local_model_
     )
 
     assert cost == pytest.approx(3 * 4e-6 + 4014 * 4e-7 + 5 * 2e-5, rel=1e-9)
+
+
+@pytest.mark.parametrize(
+    "model",
+    tuple(
+        f"azure/{region}gpt-5.6{variant}"
+        for region in ("", "eu/", "us/")
+        for variant in ("", "-sol", "-terra", "-luna")
+    ),
+)
+@pytest.mark.parametrize("tier", ("", "_above_272k_tokens", "_priority"))
+def test_azure_gpt_5_6_cache_write_rate_matches_openai_ratio(_local_model_cost_map, model: str, tier: str):
+    """Regression for #37631: the azure/* gpt-5.6 entries carried no
+    cache_creation_input_token_cost at all, so cache writes fell back to $0. Azure
+    charges 1.25x the input rate for them, matching the OpenAI-hosted twins."""
+    info: Final = litellm.model_cost[model]
+    twin: Final = litellm.model_cost[model.split("/")[-1]]
+    twin_ratio: Final = twin[f"cache_creation_input_token_cost{tier}"] / twin[f"input_cost_per_token{tier}"]
+
+    assert twin_ratio == pytest.approx(1.25, rel=1e-12)
+    assert info[f"cache_creation_input_token_cost{tier}"] == pytest.approx(
+        twin_ratio * info[f"input_cost_per_token{tier}"], rel=1e-12
+    )
+
+
+def test_azure_gpt_5_6_bills_cache_write_tokens_at_cache_creation_rate(_local_model_cost_map):
+    """Regression for #37631: Azure reports cache writes as
+    prompt_tokens_details.cache_write_tokens, which LiteLLM classifies as cache-creation
+    tokens. Without a cache-creation rate on the azure/* entries the lookup yielded $0,
+    under-billing a write-heavy prompt by ~98%."""
+    from litellm.litellm_core_utils.llm_cost_calc.utils import generic_cost_per_token
+
+    def _input_cost(model: str) -> float:
+        usage: Final = Usage(
+            completion_tokens=0,
+            prompt_tokens=10_000,
+            total_tokens=10_000,
+            prompt_tokens_details=PromptTokensDetailsWrapper(
+                cached_tokens=0, text_tokens=0, cache_write_tokens=10_000
+            ),
+        )
+        return generic_cost_per_token(model=model, usage=usage, custom_llm_provider="azure")[0]
+
+    global_cost: Final = _input_cost("azure/gpt-5.6-sol")
+    eu_cost: Final = _input_cost("azure/eu/gpt-5.6-sol")
+
+    assert global_cost == pytest.approx(10_000 * 6.25e-06, rel=1e-9)
+    assert global_cost > 10_000 * litellm.model_cost["azure/gpt-5.6-sol"]["input_cost_per_token"]
+    assert eu_cost == pytest.approx(1.1 * global_cost, rel=1e-9)


### PR DESCRIPTION
## TLDR

Problem this solves:

- Azure gpt-5.6 cache-write tokens are billed at zero
- Spend under-reported by ~98% on cache-heavy prompts

How it solves it:

- Adds the missing cache-write rate to 12 azure gpt-5.6 entries
- Derives each from the OpenAI twin's cache-to-input ratio

## User Flow

Before: a platform team charging back Azure OpenAI spend sees almost nothing billed for their RAG service, whose requests carry a large cached system prompt

1. Their RAG service sends POST https://litellm-domain/v1/chat/completions with `"model": "azure-gpt-5.6-sol"` and a ~2,200-token system prompt
2. The response comes back 200 with `"usage": {"prompt_tokens": 2219, "completion_tokens": 5, "prompt_tokens_details": {"cached_tokens": 0, "cache_write_tokens": 2216}}`
3. They open https://litellm-domain/ui/?page=logs and the request shows $0.000165 spend, as if the 2,216 cache-write tokens were free
4. Their monthly Azure invoice for that traffic is roughly 85x the total the gateway reports, so per-team chargeback is unusable

After: the same request is billed at the cache-write rate, and the gateway total lines up with the invoice

1. Their RAG service sends the same POST https://litellm-domain/v1/chat/completions with `"model": "azure-gpt-5.6-sol"` and the same ~2,200-token system prompt
2. The response comes back 200 with the same usage object
3. https://litellm-domain/ui/?page=logs now shows that request at $0.014015 spend
4. The monthly total tracks the Azure invoice, so chargeback per team is accurate

## Relevant issues

Fixes #37631

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Shared setup, a live Azure OpenAI `gpt-5.6-sol` deployment behind the proxy:

```yaml
model_list:
  - model_name: azure-gpt-5.6-sol
    litellm_params:
      model: azure/gpt-5.6-sol
      api_base: os.environ/AZURE_OPENAI_ENDPOINT
      api_version: "2025-04-01-preview"

general_settings:
  master_key: os.environ/LITELLM_MASTER_KEY
  database_url: os.environ/DATABASE_URL
```

The request body, sized so the prompt is large enough for Azure to write it to cache:

```bash
python - <<'EOF'
import json
prefix = 'You are a documentation assistant. ' + (
    'The following is reference material about cloud architecture patterns. ' * 220)
json.dump({"model": "azure-gpt-5.6-sol",
           "messages": [{"role": "system", "content": prefix},
                        {"role": "user", "content": "say ok"}],
           "max_tokens": 10}, open("req.json", "w"))
EOF
```

### Before (31a67561ab)

1. Start the proxy at the merge base and send the request, confirming the provider reports cache writes:

```bash
curl -s http://localhost:4000/v1/chat/completions \
  -H "Authorization: Bearer $LITELLM_MASTER_KEY" \
  -H "Content-Type: application/json" --data @req.json | jq .usage
```

2. Read back what the gateway recorded for it:

```bash
curl -s "http://localhost:4000/spend/logs" \
  -H "Authorization: Bearer $LITELLM_MASTER_KEY" | jq '.[-1] | {model, spend, prompt_tokens}'
```

Expected to show the cache-write tokens costing nothing, around $0.000165 against a correct $0.014015

### After (0400f0b739)

1. Restart the proxy at this PR's tip and send the identical request:

```bash
curl -s http://localhost:4000/v1/chat/completions \
  -H "Authorization: Bearer $LITELLM_MASTER_KEY" \
  -H "Content-Type: application/json" --data @req.json | jq .usage
```

2. Read back the recorded spend:

```bash
curl -s "http://localhost:4000/spend/logs" \
  -H "Authorization: Bearer $LITELLM_MASTER_KEY" | jq '.[-1] | {model, spend, prompt_tokens}'
```

Expected to show the same usage object now billed at the cache-write rate, around $0.014015

Both runs are pending: no Azure gpt-5.6 deployment was available to whoever prepared this branch, so the output above is stated as an expectation rather than a captured run. The commands are ready to paste and this section will be replaced with the real output before review. In the meantime the regression test in `tests/test_litellm/test_cost_calculator.py` covers the same billing path, and every one of its 37 cases fails at the merge base and passes here

## Type

🐛 Bug Fix

✅ Test

## Caveats (if any)

- Purely additive: no existing price is modified
- Azure priority input rates look wrong, but that is separate
- Also fixes the azure/eu entries, which the issue omits
