### PR TITLE
fix(proxy): fail fast when general_settings is not a mapping (#38190)

### DIFF
--- a/litellm/proxy/proxy_cli.py
+++ b/litellm/proxy/proxy_cli.py
@@ -1152,6 +1152,16 @@ def run_server(
             general_settings = _config.get("general_settings", {})
             if general_settings is None:
                 general_settings = {}
+            elif not isinstance(general_settings, dict):
+                # A non-dict `general_settings` (e.g. a bare string from a
+                # malformed YAML block) otherwise surfaces as a cryptic
+                # `AttributeError: 'str' object has no attribute 'get'` deep in
+                # startup. Fail fast with a message that points at the config.
+                raise ValueError(
+                    "`general_settings` in the proxy config must be a mapping "
+                    f"(got {type(general_settings).__name__}). Check the "
+                    "`general_settings:` block in your config file."
+                )
             ### LOAD KEY MANAGEMENT SETTINGS FIRST (needed for custom secret manager) ###
             key_management_settings: Final = general_settings.get("key_management_settings", None)
             if key_management_settings is not None:

--- a/litellm/proxy/proxy_cli.py
+++ b/litellm/proxy/proxy_cli.py
@@ -1153,10 +1153,6 @@ def run_server(
             if general_settings is None:
                 general_settings = {}
             elif not isinstance(general_settings, dict):
-                # A non-dict `general_settings` (e.g. a bare string from a
-                # malformed YAML block) otherwise surfaces as a cryptic
-                # `AttributeError: 'str' object has no attribute 'get'` deep in
-                # startup. Fail fast with a message that points at the config.
                 raise ValueError(
                     "`general_settings` in the proxy config must be a mapping "
                     f"(got {type(general_settings).__name__}). Check the "

--- a/tests/test_litellm/proxy/test_proxy_cli.py
+++ b/tests/test_litellm/proxy/test_proxy_cli.py
@@ -2677,3 +2677,31 @@ class TestLibpqSslParamTranslation:
         assert query["sslmode"] == ["require"]
         assert query["sslcert"] == ["/certs/rds-bundle.pem"]
         assert query["sslaccept"] == ["strict"]
+
+
+@pytest.mark.xdist_group("proxy_cli")
+class TestGeneralSettingsShape:
+    """`general_settings` is read straight from user YAML. A non-mapping value
+    (a bare string when the block is malformed, or `null` from an empty block)
+    used to reach `general_settings.get(...)` and blow up at startup with an
+    opaque `AttributeError: 'str' object has no attribute 'get'`. Startup must
+    either tolerate it (None -> {}) or fail with a message pointing at the config.
+    """
+
+    def test_null_general_settings_is_tolerated(self, tmp_path):
+        """An empty `general_settings:` block parses as None and must not crash."""
+        config_path = tmp_path / "config.yaml"
+        config_path.write_text(yaml.dump({"model_list": [], "general_settings": None}))
+
+        captured = _run_server_and_capture_urls(str(config_path))
+        assert captured["DATABASE_URL"].startswith("postgresql://t:t@localhost:5432/t")
+
+    def test_string_general_settings_fails_with_actionable_error(self, tmp_path):
+        """A non-mapping value must fail fast, not as a cryptic AttributeError."""
+        config_path = tmp_path / "config.yaml"
+        config_path.write_text(
+            yaml.dump({"model_list": [], "general_settings": "database_url"})
+        )
+
+        with pytest.raises(ValueError, match=r"general_settings.*must be a mapping"):
+            _run_server_and_capture_urls(str(config_path))


### PR DESCRIPTION
## Summary

Fixes #38190.

When the proxy config's `general_settings` block is a non-mapping value (e.g. a bare string from a malformed YAML block), `run_server` reached `general_settings.get("key_management_settings", None)` and crashed at startup with an opaque error:

```
AttributeError: 'str' object has no attribute 'get'
  File ".../litellm/proxy/proxy_cli.py", line 1152, in run_server
    key_management_settings: Final = general_settings.get("key_management_settings", None)
```

The existing guard only handled the `None` case. This PR extends it so that:
- `general_settings: null` (empty block) still coerces to `{}` (unchanged behavior).
- Any other non-mapping value now raises a `ValueError` that names the offending type and points at the `general_settings:` block, instead of a cryptic `AttributeError` deep in startup.

## Changes

- `litellm/proxy/proxy_cli.py`: type-aware guard on `general_settings`.
- `tests/test_litellm/proxy/test_proxy_cli.py`: new `TestGeneralSettingsShape` covering the tolerated (`None`) and fail-fast (`str`) cases.

## Testing

```
pytest tests/test_litellm/proxy/test_proxy_cli.py::TestGeneralSettingsShape        # 2 passed
pytest tests/test_litellm/proxy/test_proxy_cli.py::TestPostgresStatementTimeoutOptions  # 15 passed (no regression)
```

## Type

- [x] Bug Fix 🐛