### PR TITLE
fix: preserve content:null on assistant tool-call turns (#37711)

### DIFF
--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -7875,9 +7875,22 @@ def cleanup_none_field_in_message(message: AllMessageValues):
     Cleans up the message by removing the none field.
 
     remove None fields in the message - e.g. {"function": None} - some providers raise validation errors
+
+    Exception: an assistant message that carries `tool_calls` may legitimately set
+    `content: null` (the shape the OpenAI spec prescribes for a tool-call-only
+    turn). Dropping the key entirely breaks providers whose deserializers require
+    it to be present, so `content` is preserved verbatim in that case.
     """
     new_message: Final = message.copy()
-    return {k: v for k, v in new_message.items() if v is not None}
+    preserve_null_content: Final = (
+        new_message.get("role") == "assistant"
+        and new_message.get("content", "not-null") is None
+        and bool(new_message.get("tool_calls"))
+    )
+    cleaned = {k: v for k, v in new_message.items() if v is not None}
+    if preserve_null_content:
+        return {**cleaned, "content": None}
+    return cleaned
 
 
 def validate_chat_completion_user_messages(messages: list[AllMessageValues]):

--- a/tests/test_litellm/test_utils.py
+++ b/tests/test_litellm/test_utils.py
@@ -5689,3 +5689,84 @@ class TestDefaultReasoningEffortHydration:
 
         model_info = dict(_get_model_info_helper(model="gpt-5.6-terra", custom_llm_provider="openai"))
         assert model_info.get("default_reasoning_effort") is None
+
+
+class TestCleanupNoneFieldInMessage:
+    """`content: null` on an assistant tool-call turn is the shape the OpenAI
+    spec prescribes, and strict provider deserializers reject the request when
+    the key is dropped entirely (see #37711). It must survive message cleanup,
+    while genuinely irrelevant None fields are still stripped.
+    """
+
+    def test_null_content_preserved_on_assistant_tool_call(self):
+        from litellm.utils import cleanup_none_field_in_message
+
+        message = {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [
+                {"id": "call_1", "type": "function", "function": {"name": "f", "arguments": "{}"}}
+            ],
+        }
+        cleaned = cleanup_none_field_in_message(message)
+        assert "content" in cleaned
+        assert cleaned["content"] is None
+        assert cleaned["tool_calls"] == message["tool_calls"]
+
+    def test_null_content_still_dropped_without_tool_calls(self):
+        from litellm.utils import cleanup_none_field_in_message
+
+        cleaned = cleanup_none_field_in_message({"role": "assistant", "content": None})
+        assert "content" not in cleaned
+
+    def test_other_none_fields_still_stripped(self):
+        from litellm.utils import cleanup_none_field_in_message
+
+        message = {
+            "role": "assistant",
+            "content": None,
+            "function_call": None,
+            "tool_calls": [
+                {"id": "call_1", "type": "function", "function": {"name": "f", "arguments": "{}"}}
+            ],
+        }
+        cleaned = cleanup_none_field_in_message(message)
+        assert "content" in cleaned
+        assert "function_call" not in cleaned
+
+    def test_end_to_end_null_content_reaches_openai_sdk(self, monkeypatch):
+        import litellm
+        from openai.resources.chat.completions import Completions
+
+        captured = {}
+
+        def spy(self, *args, **kwargs):
+            captured["messages"] = kwargs.get("messages")
+            raise RuntimeError("stop")
+
+        monkeypatch.setattr(Completions, "create", spy)
+        messages = [
+            {"role": "user", "content": "hi"},
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {"id": "call_1", "type": "function", "function": {"name": "f", "arguments": "{}"}}
+                ],
+            },
+            {"role": "tool", "tool_call_id": "call_1", "content": "ok"},
+        ]
+        with pytest.raises(litellm.InternalServerError, match="stop"):
+            litellm.completion(
+                model="openai/some-model",
+                messages=messages,
+                max_tokens=1,
+                api_base="http://127.0.0.1:1/v1",
+                api_key="x",
+                timeout=3,
+            )
+
+        assert captured.get("messages") is not None
+        assistant_msg = captured["messages"][1]
+        assert "content" in assistant_msg
+        assert assistant_msg["content"] is None


### PR DESCRIPTION
## Summary

Fixes #37711.

For an assistant message carrying `tool_calls` and `content: null` — the shape the OpenAI spec prescribes for a tool-call-only turn — litellm removed the `content` key entirely before handing the request to the provider SDK. Providers whose deserializers require the key to be present then reject the request:

```
litellm.BadRequestError: OpenAIException - Failed to deserialize the JSON body
into the target type: messages[1]: missing field `content` at line 1 column 165.
```

The identical body sent directly to the same provider (or with `content: ""`) returns 200 — only the key-absent form fails, which is what litellm produced. This breaks every multi-turn tool-calling conversation against such providers.

## Root cause

`cleanup_none_field_in_message()` in `litellm/utils.py` drops **all** None-valued keys:

```python
return {k: v for k, v in new_message.items() if v is not None}
```

That is correct for genuinely-irrelevant fields (e.g. `function_call: None`), but `content: null` on an assistant tool-call turn is meaningful and must be forwarded verbatim.

## Fix

Preserve `content` when the message is an assistant turn that carries `tool_calls` and `content is None`. All other None fields are still stripped, and `content: null` **without** `tool_calls` keeps the previous behavior.

## Testing

New `TestCleanupNoneFieldInMessage` in `tests/test_litellm/test_utils.py`:
- unit: null content preserved with tool_calls; still dropped without; other None fields still stripped
- end-to-end: `content: null` is present at the litellm -> OpenAI SDK boundary (reproduces the issue's script)

```
pytest tests/test_litellm/test_utils.py::TestCleanupNoneFieldInMessage   # 4 passed
```

## Type

- [x] Bug Fix 🐛