### PR TITLE
fix(proxy): log warning instead of silently swallowing enterprise hoo…

### DIFF
--- a/litellm/proxy/hooks/__init__.py
+++ b/litellm/proxy/hooks/__init__.py
@@ -11,6 +11,7 @@ from .parallel_request_limiter import _PROXY_MaxParallelRequestsHandler
 from .parallel_request_limiter_v3 import _PROXY_MaxParallelRequestsHandler_v3
 from .responses_id_security import ResponsesIDSecurity
 from .sensitive_data_routing import _PROXY_SensitiveDataRoutingHandler
+from litellm._logging import verbose_proxy_logger
 
 # List of all available hooks that can be enabled.
 # Defined before the enterprise import below so that any module re-imported
@@ -47,10 +48,8 @@ def get_proxy_hook(
 
 try:
     from enterprise.enterprise_hooks import ENTERPRISE_PROXY_HOOKS
-except ImportError:
-    ENTERPRISE_PROXY_HOOKS = {}
-
-
-### update PROXY_HOOKS with ENTERPRISE_PROXY_HOOKS ###
-
-PROXY_HOOKS.update(ENTERPRISE_PROXY_HOOKS)
+    PROXY_HOOKS.update(ENTERPRISE_PROXY_HOOKS)
+except ImportError as e:
+    verbose_proxy_logger.warning(
+        f"Could not import enterprise hooks — enterprise features disabled: {e}"
+    )

--- a/litellm/proxy/hooks/__init__.py
+++ b/litellm/proxy/hooks/__init__.py
@@ -48,8 +48,7 @@ def get_proxy_hook(
 
 try:
     from enterprise.enterprise_hooks import ENTERPRISE_PROXY_HOOKS
+
     PROXY_HOOKS.update(ENTERPRISE_PROXY_HOOKS)
 except ImportError as e:
-    verbose_proxy_logger.warning(
-        f"Could not import enterprise hooks — enterprise features disabled: {e}"
-    )
+    verbose_proxy_logger.warning(f"Could not import enterprise hooks — enterprise features disabled: {e}")

--- a/litellm/proxy/hooks/__init__.py
+++ b/litellm/proxy/hooks/__init__.py
@@ -1,6 +1,8 @@
 import os
 from typing import Final, Literal
 
+from litellm._logging import verbose_proxy_logger
+
 from . import *
 from .cache_control_check import _PROXY_CacheControlCheck
 from .litellm_skills import SkillsInjectionHook
@@ -11,7 +13,6 @@ from .parallel_request_limiter import _PROXY_MaxParallelRequestsHandler
 from .parallel_request_limiter_v3 import _PROXY_MaxParallelRequestsHandler_v3
 from .responses_id_security import ResponsesIDSecurity
 from .sensitive_data_routing import _PROXY_SensitiveDataRoutingHandler
-from litellm._logging import verbose_proxy_logger
 
 # List of all available hooks that can be enabled.
 # Defined before the enterprise import below so that any module re-imported

--- a/litellm/proxy/hooks/__init__.py
+++ b/litellm/proxy/hooks/__init__.py
@@ -52,4 +52,4 @@ try:
 
     PROXY_HOOKS.update(ENTERPRISE_PROXY_HOOKS)
 except ImportError as e:
-    verbose_proxy_logger.warning(f"Could not import enterprise hooks — enterprise features disabled: {e}")
+    verbose_proxy_logger.warning("Could not import enterprise hooks — enterprise features disabled: %s", e)

--- a/tests/test_litellm/proxy/hooks/test_proxy_hooks_init.py
+++ b/tests/test_litellm/proxy/hooks/test_proxy_hooks_init.py
@@ -49,3 +49,38 @@ def test_isolation_module_does_not_pull_in_proxy_utils():
     importlib.import_module("litellm.llms.base_llm.managed_resources.isolation")
     assert "litellm.proxy.utils" not in sys.modules
     assert "litellm.proxy.management_endpoints.common_utils" not in sys.modules
+
+def test_enterprise_hooks_import_failure_logs_warning(monkeypatch, caplog):
+    """
+    If the `enterprise` / `litellm_enterprise` package is unavailable
+    (e.g. missing from a hardened non_root Docker image), hooks/__init__.py
+    should log a warning and continue, instead of letting the ImportError
+    propagate and crash the whole proxy at import time.
+    """
+    import builtins
+    import importlib
+    import logging
+    import sys
+
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "enterprise" or name.startswith("enterprise."):
+            raise ImportError("No module named 'enterprise'")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    sys.modules.pop("litellm.proxy.hooks", None)
+
+    with caplog.at_level(logging.WARNING):
+        import litellm.proxy.hooks as hooks_module
+        importlib.reload(hooks_module)
+
+    assert any(
+        "enterprise hooks" in record.message.lower()
+        for record in caplog.records
+    ), "Expected a warning to be logged when enterprise hooks import fails"
+
+    monkeypatch.undo()
+    sys.modules.pop("litellm.proxy.hooks", None)
+    importlib.import_module("litellm.proxy.hooks")

--- a/tests/test_litellm/proxy/hooks/test_proxy_hooks_init.py
+++ b/tests/test_litellm/proxy/hooks/test_proxy_hooks_init.py
@@ -81,6 +81,6 @@ def test_enterprise_hooks_import_failure_logs_warning(monkeypatch, caplog):
         for record in caplog.records
     ), "Expected a warning to be logged when enterprise hooks import fails"
 
-    monkeypatch.undo()
+    monkeypatch.setattr(builtins, "__import__", real_import)
     sys.modules.pop("litellm.proxy.hooks", None)
     importlib.import_module("litellm.proxy.hooks")


### PR DESCRIPTION

## TLDR

<!-- Fill in the bullets below and keep each one short and concrete: one line per bullet, roughly 10 words max
     This section must be extremely human parsable, comprehensible, and readable: its target audience is humans, not AI agents -->

Problem this solves:

- Missing enterprise package silently disables hooks with no signal
- Proxy admins get a 500 with no clue why managed-file uploads fail

How it solves it:

- Logs a clear warning when the enterprise hooks import fails
- Adds a regression test asserting the warning fires

## User Flow

Before: an operator running a hardened non_root image gets silent, unexplained 500s on file uploads

1. They send POST https://litellm-domain/v1/files as multipart with file=@video.mp4, purpose=user_data
2. The response is HTTP 500 with body {"error":{"message":"Managed files hook not found",...}}
3. They check the proxy startup logs and see nothing about enterprise hooks being unavailable - no indication of what's wrong
4. They have to read the LiteLLM source to discover the enterprise hooks import silently failed at startup

After: the same silent failure now announces itself at startup

1. The proxy starts on an image or environment missing the enterprise package
2. The startup log now shows a warning: "Could not import enterprise hooks - enterprise features disabled: No module named 'enterprise'"
3. An operator seeing that warning immediately knows why /v1/files returns 500, instead of debugging blind

## Relevant issues

Relates to #38183

## Linear ticket

<!-- if you are an internal contributor, add "Resolves " followed by the Linear ticket e.g., "Resolves LIT-1234" to link the Linear ticket to the GitHub PR. If you don't have one, leave the section blank rather than guessing -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

### Before (31a67561ab)

1. Comment out `COPY --from=builder /app/enterprise /app/enterprise` in docker/Dockerfile.non_root, then `docker build -t litellm-non-root-test -f docker/Dockerfile.non_root .`
2. `docker run --rm -p 4000:4000 litellm-non-root-test --port 4000`
3. Traceback: `ModuleNotFoundError: No module named 'enterprise'` - proxy crashes on startup with no clean warning

<img width="1260" height="142" alt="Screenshot 2026-08-25 161112" src="https://github.com/user-attachments/assets/dd957c1f-192c-40de-a3f3-ddc912346d3d" />

### After (8242f5bd19)

1. Same Dockerfile change (enterprise/ still absent at runtime), same build and run commands
2. Startup log shows: `WARNING: __init__.py:53 - Could not import enterprise hooks - enterprise features disabled: No module named 'enterprise'`
3. Proxy starts cleanly and serves on port 4000 instead of crashing
4. `python -m pytest tests/test_litellm/proxy/hooks/test_proxy_hooks_init.py -v` - all 4 tests pass, including the new `test_enterprise_hooks_import_failure_logs_warning`

<img width="1452" height="368" alt="Screenshot 2026-08-25 151146" src="https://github.com/user-attachments/assets/1d61877b-fedc-4bb0-971f-a946760a8065" />

## Type
🐛 Bug Fix
✅ Test

## Caveats (if any)

- Does not fix the underlying 500; the Dockerfile COPY fix is already on main
- Stable `non_root` images still need a maintainer rebuild to pick that up


### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability-only change at import time; behavior without enterprise remains non-fatal and is covered by a new unit test.
> 
> **Overview**
> When the `enterprise` package is missing, proxy hook registration no longer fails **silently**: a startup **warning** is emitted via `verbose_proxy_logger` with the underlying `ImportError`, so operators can see that enterprise features (e.g. managed files) are disabled.
> 
> The enterprise merge into `PROXY_HOOKS` now runs only inside the successful import path (equivalent to updating with an empty map on failure). A regression test fakes a missing `enterprise` module, reloads `litellm.proxy.hooks`, and asserts the warning appears in logs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 962acf4186b5db9ac7308e70df80d219db5a3b00. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->