### PR TITLE
fix: update Scaleway models list

### DIFF
--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -46383,6 +46383,30 @@
         "supports_tool_choice": true,
         "supports_vision": true
     },
+    "scaleway/zai/glm-5.2": {
+        "input_cost_per_token": 1.8e-06,
+        "litellm_provider": "scaleway",
+        "max_input_tokens": 256000,
+        "max_output_tokens": 16384,
+        "max_tokens": 16384,
+        "mode": "chat",
+        "output_cost_per_token": 5.5e-06,
+        "supports_function_calling": true,
+        "supports_reasoning": true
+    },
+    "scaleway/deepseek/deepseek-v4-flash-0731": {
+        "input_cost_per_token": 4e-07,
+        "cache_read_input_token_cost": 8e-08,
+        "litellm_provider": "scaleway",
+        "max_input_tokens": 256000,
+        "max_output_tokens": 32768,
+        "max_tokens": 32768,
+        "mode": "chat",
+        "output_cost_per_token": 8e-07,
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_prompt_caching": true
+    },
     "scaleway/qwen/qwen3.5-397b-a17b": {
         "input_cost_per_token": 6e-07,
         "litellm_provider": "scaleway",
@@ -46461,28 +46485,6 @@
         "supports_reasoning": true,
         "supports_vision": true
     },
-    "scaleway/google/gemma-3-27b-it": {
-        "input_cost_per_token": 2.5e-07,
-        "litellm_provider": "scaleway",
-        "max_input_tokens": 40000,
-        "max_output_tokens": 8192,
-        "max_tokens": 8192,
-        "mode": "chat",
-        "output_cost_per_token": 5e-07,
-        "supports_function_calling": true,
-        "supports_vision": true
-    },
-    "scaleway/hcompany/holo2-30b-a3b": {
-        "input_cost_per_token": 3e-07,
-        "litellm_provider": "scaleway",
-        "max_input_tokens": 22000,
-        "max_output_tokens": 16384,
-        "max_tokens": 16384,
-        "mode": "chat",
-        "output_cost_per_token": 7e-07,
-        "supports_reasoning": true,
-        "supports_vision": true
-    },
     "scaleway/mistralai/mistral-medium-3.5-128b": {
         "input_cost_per_token": 1.5e-06,
         "litellm_provider": "scaleway",
@@ -46495,27 +46497,6 @@
         "supports_function_calling": true,
         "supports_vision": true,
         "supports_tool_choice": true
-    },
-    "scaleway/mistralai/devstral-2-123b-instruct-2512": {
-        "input_cost_per_token": 4e-07,
-        "litellm_provider": "scaleway",
-        "max_input_tokens": 200000,
-        "max_output_tokens": 16384,
-        "max_tokens": 16384,
-        "mode": "chat",
-        "output_cost_per_token": 2e-06,
-        "supports_function_calling": true
-    },
-    "scaleway/mistralai/voxtral-small-24b-2507": {
-        "input_cost_per_audio_token": 1.5e-07,
-        "input_cost_per_token": 1.5e-07,
-        "litellm_provider": "scaleway",
-        "max_input_tokens": 32000,
-        "max_output_tokens": 16384,
-        "max_tokens": 16384,
-        "mode": "chat",
-        "output_cost_per_token": 3.5e-07,
-        "supports_audio_input": true
     },
     "scaleway/mistralai/mistral-small-3.2-24b-instruct-2506": {
         "input_cost_per_token": 1.5e-07,


### PR DESCRIPTION
## TLDR

<!-- Fill in the bullets below and keep each one short and concrete: one line per bullet, roughly 10 words max
     This section must be extremely human parsable, comprehensible, and readable: its target audience is humans, not AI agents -->

Problem this solves:

- Current model list is not synchronized with available models

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- x ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).


## Screenshots / Proof of Fix

<!-- Include screenshots, screen recordings, or command (e.g., curl) + output demonstrating that your changes work as expected
     The proof must be completely e2e with no mocks, using actual LLM calls costing real $$$ if applicable. `pytest` commands are not enough
     Show ONLY the latest run: capture Before at the merge base and After at the PR's current tip, and when new commits change behavior, replace this whole section with the fresh run instead of stacking it on top of older ones. The run must be up to date. As soon as a new commit is made and it makes this PR description's after sha stale (it's no longer tip of PR), you must re-run the QA
     Structure the section exactly as below: Before and After one heading level below this section, each naming the commit hash it was captured at, one lower-level heading per case inside each, the same case names in the same order on both sides, and numbered steps (command, observed output) under every case, never loose prose; shared setup (config, payloads) goes above Before, and with a single case, drop the case headings and number the steps directly


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
🐛 Bug Fix
🧹 Refactoring
📖 Documentation
🚄 Infrastructure
✅ Test

## Caveats (if any)

<!-- Short bullet points, just like the TLDR: one line per bullet, roughly 10 words max
     Call out known limitations, follow-up work, or anything a reviewer should watch out for
     Leave this section empty if there are none -->

## QA runbook

<!-- Only needed when your PR edits tests/e2e; delete this section otherwise

For each e2e test you added or changed, list the manual steps a reviewer can follow to reproduce it by hand against a live proxy, mapping 1:1 to what the test asserts: one top-level bullet per test giving its pytest node id followed by what it proves in plain words, then a nested "- [ ]" checklist where each item is a concrete action (route, request body, expected response) and the final item is the sanity-check step shown in the examples. Note environment prerequisites (provider credentials, config flags) and any nuances a manual run will hit. See PRs #32914 and #32963 for full examples

Example checklists:

- tests/e2e/quota_management/ratelimit/test_rate_limit_e2e.py::TestKeyRateLimits::test_rpm_limit_blocks_over_limit - a key allowed 2 requests a minute serves exactly 2 and refuses the 3rd
  - [ ] Generate a limited key: curl -X POST http://localhost:4000/key/generate -H "Authorization: Bearer sk-1234" -d '{"rpm_limit": 2}'
  - [ ] Send three /v1/chat/completions requests with that key inside one minute
  - [ ] Expect the first two to return 200 and the third to return 429 naming the rpm limit
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey (e.g., assert actual expected spend instead of just spend > 0) or potentially flaky

- tests/e2e/management/test_management_e2e.py::TestModelRoutes::test_model_create_appears_in_ui - a deployment created through the API shows up on the Admin UI models page
  - [ ] POST /model/new with the master key, a bedrock model, and aws_region_name (needs STORE_MODEL_IN_DB=True and AWS credentials)
  - [ ] Open http://localhost:4000/ui/?page=models and expect a deployment row showing the returned model id
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey (e.g., assert actual expected spend instead of just spend > 0) or potentially flaky
-->

### Final Attestation

- [ ] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
