### PR TITLE
fix(anthropic-responses): preserve structured output strictness

### DIFF
--- a/litellm/llms/anthropic/experimental_pass_through/responses_adapters/transformation.py
+++ b/litellm/llms/anthropic/experimental_pass_through/responses_adapters/transformation.py
@@ -520,7 +520,7 @@ class LiteLLMAnthropicToResponsesAPIAdapter:
                         "type": "json_schema",
                         "name": "structured_output",
                         "schema": schema,
-                        "strict": True,
+                        "strict": bool(output_format.get("strict")),
                     }
                 }
 

--- a/litellm/llms/anthropic/experimental_pass_through/responses_adapters/transformation.py
+++ b/litellm/llms/anthropic/experimental_pass_through/responses_adapters/transformation.py
@@ -520,7 +520,7 @@ class LiteLLMAnthropicToResponsesAPIAdapter:
                         "type": "json_schema",
                         "name": "structured_output",
                         "schema": schema,
-                        "strict": bool(output_format.get("strict")),
+                        "strict": output_format.get("strict", False),
                     }
                 }
 

--- a/litellm/types/llms/anthropic.py
+++ b/litellm/types/llms/anthropic.py
@@ -36,6 +36,7 @@ AnthropicInputSchema = TypedDict(
 class AnthropicOutputSchema(TypedDict, total=False):
     type: Required[Literal["json_schema"]]
     schema: Required[dict]
+    strict: ReadOnly[bool]
 
 
 class AnthropicOutputConfig(TypedDict, total=False):

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/responses_adapters/test_responses_adapters_transformation.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/responses_adapters/test_responses_adapters_transformation.py
@@ -132,14 +132,14 @@ class TestOutputConfigStructuredOutput:
     }
 
     def test_output_config_format_json_schema_converted(self):
-        """output_config.format.json_schema is converted to OpenAI text.format."""
+        """output_config.format.json_schema is converted to OpenAI text.format, defaulting strict to False."""
         req = _make_request(output_config={"format": {"type": "json_schema", "schema": self._SCHEMA}})
         kwargs = _ADAPTER.translate_request(req)
         assert "text" in kwargs
         fmt = kwargs["text"]["format"]
         assert fmt["type"] == "json_schema"
         assert fmt["schema"] == self._SCHEMA
-        assert fmt["strict"] is True
+        assert fmt["strict"] is False
         assert fmt["name"] == "structured_output"
 
     def test_output_config_without_format_does_not_set_text(self):
@@ -149,21 +149,65 @@ class TestOutputConfigStructuredOutput:
         assert "text" not in kwargs
 
     def test_output_format_still_works(self):
-        """The original output_format field still takes precedence when present."""
+        """The original output_format field still takes precedence when present, defaulting strict to False."""
         req = _make_request(output_format={"type": "json_schema", "schema": self._SCHEMA})
         kwargs = _ADAPTER.translate_request(req)
         assert "text" in kwargs
         assert kwargs["text"]["format"]["type"] == "json_schema"
+        assert kwargs["text"]["format"]["strict"] is False
+
+    def test_output_format_explicit_strict_false_is_preserved(self):
+        """output_format with an explicit strict=False is preserved as False."""
+        req = _make_request(output_format={"type": "json_schema", "schema": self._SCHEMA, "strict": False})
+        kwargs = _ADAPTER.translate_request(req)
+        assert kwargs["text"]["format"]["strict"] is False
+
+    def test_output_format_explicit_strict_true_is_preserved(self):
+        """output_format with an explicit strict=True is preserved as True."""
+        req = _make_request(output_format={"type": "json_schema", "schema": self._SCHEMA, "strict": True})
+        kwargs = _ADAPTER.translate_request(req)
+        assert kwargs["text"]["format"]["strict"] is True
 
     def test_output_format_takes_precedence_over_output_config(self):
-        """output_format takes precedence over output_config.format."""
+        """output_format takes precedence over output_config.format, for both schema and strict."""
         other_schema = {"type": "object", "properties": {"id": {"type": "integer"}}}
         req = _make_request(
-            output_format={"type": "json_schema", "schema": self._SCHEMA},
-            output_config={"format": {"type": "json_schema", "schema": other_schema}},
+            output_format={"type": "json_schema", "schema": self._SCHEMA, "strict": False},
+            output_config={"format": {"type": "json_schema", "schema": other_schema, "strict": True}},
         )
         kwargs = _ADAPTER.translate_request(req)
         assert kwargs["text"]["format"]["schema"] == self._SCHEMA
+        assert kwargs["text"]["format"]["strict"] is False
+
+    def test_optional_property_stays_out_of_required_list(self):
+        """A property absent from required must stay absent from required in the translated schema."""
+        schema = {
+            "type": "object",
+            "properties": {
+                "name": {"type": "string"},
+                "nickname": {"type": "string"},
+            },
+            "required": ["name"],
+            "additionalProperties": False,
+        }
+        req = _make_request(output_format={"type": "json_schema", "schema": schema})
+        kwargs = _ADAPTER.translate_request(req)
+        fmt_schema = kwargs["text"]["format"]["schema"]
+        assert fmt_schema["required"] == ["name"]
+        assert "nickname" not in fmt_schema["required"]
+        assert fmt_schema["additionalProperties"] is False
+
+    def test_translate_request_does_not_mutate_input_schema(self):
+        """translate_request must not mutate the caller's output_format or schema dicts."""
+        schema = {"type": "object", "properties": {"x": {"type": "number"}}, "required": ["x"]}
+        output_format = {"type": "json_schema", "schema": schema, "strict": False}
+        req = _make_request(output_format=output_format)
+        snapshot = json.loads(json.dumps(output_format))
+
+        _ADAPTER.translate_request(req)
+
+        assert output_format == snapshot
+        assert req["output_format"] == snapshot
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/responses_adapters/test_responses_adapters_transformation.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/responses_adapters/test_responses_adapters_transformation.py
@@ -142,6 +142,14 @@ class TestOutputConfigStructuredOutput:
         assert fmt["strict"] is False
         assert fmt["name"] == "structured_output"
 
+    def test_output_config_format_explicit_strict_true_is_preserved(self):
+        """Nested output_config.format with explicit strict=True is preserved."""
+        req = _make_request(
+            output_config={"format": {"type": "json_schema", "schema": self._SCHEMA, "strict": True}}
+        )
+        kwargs = _ADAPTER.translate_request(req)
+        assert kwargs["text"]["format"]["strict"] is True
+
     def test_output_config_without_format_does_not_set_text(self):
         """output_config with only non-format keys doesn't produce text.format."""
         req = _make_request(output_config={"effort": "high"})


### PR DESCRIPTION
## TLDR

Problem this solves:

- Optional schema properties fail strict validation downstream
- Omitted strictness becomes strict unexpectedly

How it solves it:

- Default translated structured output schemas to non-strict
- Preserve explicit strict values and schema requirements

## User Flow

Before: a developer extracting structured data through the gateway with an Anthropic-shaped request against an OpenAI model gets a 400 the moment their schema has an optional property, before the model ever runs

1. They send POST https://litellm-domain/v1/messages with `"model": "gpt-5.6-sol"` and `"output_format": {"type": "json_schema", "schema": {...}}` where the schema lists `name` and `nickname` under `properties` but only `name` under `required` (same thing with `output_config.format` from the Anthropic Python SDK, and with `"stream": true`)
2. They get HTTP 400 with `Invalid schema for response_format 'structured_output': In context=(), 'required' is required to be supplied and to be an array including every key in properties. Missing 'nickname'.` and no model output
3. The only way through is to rewrite the schema so every property is required, which forces the model to invent a value for fields the source text does not contain

After: the same request returns the model's JSON, and the optional property stays optional

1. They send the same POST https://litellm-domain/v1/messages with the same schema
2. They get HTTP 200 with `content[0].text` = `{"name":"Samantha","nickname":"Sam"}` (streaming returns the same text through `content_block_delta` events, and the Anthropic Python SDK's `output_config` form works the same way)
3. A caller that wants OpenAI's strict mode adds `"strict": true` next to `schema` inside `output_format` (or `output_config.format`) and gets the old behavior, including the 400 above when the schema is not strict-compatible

## Relevant issues

## Linear ticket

Resolves LIT-6131

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Both legs boot a proxy with `--num_workers 2` and no database, from the exact commit named in each heading (the before leg is the PR's merge base against `litellm_internal_staging`), and hit real OpenAI and Anthropic APIs. Same config, same payloads, same case order on both sides

Config:

```yaml
model_list:
  - model_name: gpt-5.6-sol
    litellm_params:
      model: openai/gpt-5.6-sol
      api_key: os.environ/OPENAI_API_KEY
  - model_name: claude-sonnet-5
    litellm_params:
      model: anthropic/claude-sonnet-5
      api_key: os.environ/ANTHROPIC_API_KEY
general_settings:
  master_key: sk-lit6131-qa
```

Shared pieces (`$PORT` is the leg's proxy port):

```bash
URL="http://127.0.0.1:$PORT/v1/messages"
hdr=(-H "x-api-key: sk-lit6131-qa" -H "anthropic-version: 2023-06-01" -H "content-type: application/json")
OPT='{"type":"object","properties":{"name":{"type":"string"},"nickname":{"type":"string"}},"required":["name"],"additionalProperties":false}'
ALL='{"type":"object","properties":{"name":{"type":"string"}},"required":["name"],"additionalProperties":false}'
MSG='Extract the person. Text: \"Samantha, who friends call Sam, joined in 2019.\"'
```

The Anthropic Python SDK case (`anthropic` 0.84.0):

```python
import anthropic

client = anthropic.Anthropic(base_url="http://127.0.0.1:$PORT", api_key="sk-lit6131-qa")
schema = {
    "type": "object",
    "properties": {"name": {"type": "string"}, "nickname": {"type": "string"}},
    "required": ["name"],
    "additionalProperties": False,
}
try:
    resp = client.messages.create(
        model="gpt-5.6-sol",
        max_tokens=200,
        messages=[{"role": "user", "content": 'Extract the person. Text: "Samantha, who friends call Sam, joined in 2019."'}],
        output_config={"format": {"type": "json_schema", "schema": schema}},
    )
    print("OK:", resp.content[0].text)
except anthropic.APIStatusError as e:
    print("ERROR:", e.status_code, e.message)
```

### Before (bb27bfd9a7)

#### Optional property, output_format, curl

1. `curl -s -w '\n%{http_code}' "${hdr[@]}" "$URL" -d "{\"model\":\"gpt-5.6-sol\",\"max_tokens\":200,\"messages\":[{\"role\":\"user\",\"content\":\"$MSG\"}],\"output_format\":{\"type\":\"json_schema\",\"schema\":$OPT}}"`
2. HTTP 400
   ```
   {"error":{"message":"litellm.BadRequestError: OpenAIException - {\n  \"error\": {\n    \"message\": \"Invalid schema for response_format 'structured_output': In context=(), 'required' is required to be supplied and to be an array including every key in properties. Missing 'nickname'.\",\n    \"type\": \"invalid_request_error\",\n    \"param\": \"text.format.schema\",\n    \"code\": \"invalid_json_schema\"\n  }\n}. Received Model Group=gpt-5.6-sol\nAvailable Model Group Fallbacks=None","type":null,"param":null,"code":"400"}}
   ```

#### Optional property, output_config.format, Anthropic Python SDK

1. `python case2.py` (script above)
2. `ERROR: 400 Error code: 400 - {'error': {'message': 'litellm.BadRequestError: OpenAIException - {\n  "error": {\n    "message": "Invalid schema for response_format \'structured_output\': In context=(), \'required\' is required to be supplied and to be an array including every key in properties. Missing \'nickname\'.",\n    "type": "invalid_request_error",\n    "param": "text.format.schema",\n    "code": "invalid_json_schema"\n  }\n}. Received Model Group=gpt-5.6-sol\nAvailable Model Group Fallbacks=None', 'type': None, 'param': None, 'code': '400'}}`

#### Optional property, output_format, streaming, curl

1. Same curl as the first case with `"stream":true` added to the body
2. HTTP 400, no SSE events, same `Missing 'nickname'` error body as the first case

#### Explicit strict true, optional property, curl

1. Same curl as the first case with `,\"strict\":true` added inside `output_format`
2. HTTP 400, same `Missing 'nickname'` error body as the first case

#### Explicit strict true, all-required schema, curl

1. `curl -s -w '\n%{http_code}' "${hdr[@]}" "$URL" -d "{\"model\":\"gpt-5.6-sol\",\"max_tokens\":200,\"messages\":[{\"role\":\"user\",\"content\":\"$MSG\"}],\"output_format\":{\"type\":\"json_schema\",\"schema\":$ALL,\"strict\":true}}"`
2. HTTP 200, `content[0].text` = `{"name":"Samantha"}`, `stop_reason` = `end_turn`

#### Optional property, output_format, Anthropic model control, curl

1. Same curl as the first case with `"model":"claude-sonnet-5"`
2. HTTP 200, `content[0].text` = `{"name":"Samantha","nickname":"Sam"}`, `stop_reason` = `end_turn`

### After (482e712da183d9d75c2d9a4caa7bfdbae248be59)

#### Optional property, output_format, curl

1. `curl -s -w '\n%{http_code}' "${hdr[@]}" "$URL" -d "{\"model\":\"gpt-5.6-sol\",\"max_tokens\":200,\"messages\":[{\"role\":\"user\",\"content\":\"$MSG\"}],\"output_format\":{\"type\":\"json_schema\",\"schema\":$OPT}}"`
2. HTTP 200
   ```
   {"content":[{"type":"text","text":"{\"name\":\"Samantha\",\"nickname\":\"Sam\"}"}],"stop_reason":"end_turn"}
   ```

#### Optional property, output_config.format, Anthropic Python SDK

1. `python case2.py` (script above)
2. `OK: {"name":"Samantha","nickname":"Sam"}`

#### Optional property, output_format, streaming, curl

1. Same curl as the first case with `"stream":true` added to the body
2. HTTP 200, 15 SSE events, no `error` event, concatenated `content_block_delta` text = `{"name":"Samantha","nickname":"Sam"}`

#### Explicit strict true, optional property, curl

1. Same curl as the first case with `,\"strict\":true` added inside `output_format`
2. HTTP 400, same `Missing 'nickname'` error body as the before leg (an explicit `strict: true` still reaches OpenAI unchanged)

#### Explicit strict true, all-required schema, curl

1. `curl -s -w '\n%{http_code}' "${hdr[@]}" "$URL" -d "{\"model\":\"gpt-5.6-sol\",\"max_tokens\":200,\"messages\":[{\"role\":\"user\",\"content\":\"$MSG\"}],\"output_format\":{\"type\":\"json_schema\",\"schema\":$ALL,\"strict\":true}}"`
2. HTTP 200, `content[0].text` = `{"name":"Samantha"}`, `stop_reason` = `end_turn`

#### Optional property, output_format, Anthropic model control, curl

1. Same curl as the first case with `"model":"claude-sonnet-5"`
2. HTTP 200, `content[0].text` = `{"name":"Samantha","nickname":"Sam"}`, `stop_reason` = `end_turn`

The same six cases were re-run on this tip merged into current `litellm_internal_staging` (local merge commit 92edc58137) with identical results

Observations from the run:

- Every 200 response parsed as JSON matching its schema, no extra keys
- Streaming and non-streaming fail and succeed identically, before and after
- Native Anthropic models were unaffected on both legs

## Type

🐛 Bug Fix

## Caveats (if any)

### Medium

- Default flips from implicit strict to non-strict for OpenAI-routed `/v1/messages` structured output
  - Callers whose all-required schemas silently got strict mode now need `strict: true` to keep it
  - Callers with optional properties never worked before, so nothing regresses for them
  - Mirrors OpenAI's own `text.format.strict` default and this bridge's existing tool `strict` handling

### Low

- `strict` inside `output_format` is a gateway extension, not an Anthropic API field; it only affects OpenAI-routed models
- The docs table for the messages-to-responses mapping still says `"strict": true` and needs a follow-up docs PR
- The chat-completions bridge (Azure, other providers) still forces strict and rewrites every property into `required`; out of scope here, unchanged by this PR

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

- [x] 482e712da183d9d75c2d9a4caa7bfdbae248be59 passes /live-pr-risk
