### PR TITLE
fix(model_prices): correct cache read pricing for Gemini flash latest and preview aliases

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -20237,7 +20237,7 @@
         "supports_image_size": false
     },
     "gemini-2.5-flash-preview-09-2025": {
-        "cache_read_input_token_cost": 7.5e-08,
+        "cache_read_input_token_cost": 3e-08,
         "input_cost_per_audio_token": 1e-06,
         "input_cost_per_token": 3e-07,
         "litellm_provider": "vertex_ai-language-models",
@@ -20373,7 +20373,7 @@
     },
     "gemini-2.5-flash-lite-preview-06-17": {
         "deprecation_date": "2025-11-18",
-        "cache_read_input_token_cost": 2.5e-08,
+        "cache_read_input_token_cost": 1e-08,
         "input_cost_per_audio_token": 5e-07,
         "input_cost_per_token": 1e-07,
         "litellm_provider": "vertex_ai-language-models",
@@ -21953,7 +21953,7 @@
         "supports_image_size": false
     },
     "gemini/gemini-2.5-flash-preview-09-2025": {
-        "cache_read_input_token_cost": 7.5e-08,
+        "cache_read_input_token_cost": 3e-08,
         "deprecation_date": "2026-02-17",
         "input_cost_per_audio_token": 1e-06,
         "input_cost_per_token": 3e-07,
@@ -22001,7 +22001,7 @@
         "supports_image_size": false
     },
     "gemini/gemini-flash-latest": {
-        "cache_read_input_token_cost": 7.5e-08,
+        "cache_read_input_token_cost": 3e-08,
         "input_cost_per_audio_token": 1e-06,
         "input_cost_per_token": 3e-07,
         "litellm_provider": "gemini",
@@ -22047,7 +22047,7 @@
         }
     },
     "gemini/gemini-flash-lite-latest": {
-        "cache_read_input_token_cost": 2.5e-08,
+        "cache_read_input_token_cost": 1e-08,
         "input_cost_per_audio_token": 3e-07,
         "input_cost_per_token": 1e-07,
         "litellm_provider": "gemini",
@@ -22094,7 +22094,7 @@
     },
     "gemini/gemini-2.5-flash-lite-preview-06-17": {
         "deprecation_date": "2025-11-18",
-        "cache_read_input_token_cost": 2.5e-08,
+        "cache_read_input_token_cost": 1e-08,
         "input_cost_per_audio_token": 5e-07,
         "input_cost_per_token": 1e-07,
         "litellm_provider": "gemini",

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -20237,7 +20237,7 @@
         "supports_image_size": false
     },
     "gemini-2.5-flash-preview-09-2025": {
-        "cache_read_input_token_cost": 7.5e-08,
+        "cache_read_input_token_cost": 3e-08,
         "input_cost_per_audio_token": 1e-06,
         "input_cost_per_token": 3e-07,
         "litellm_provider": "vertex_ai-language-models",
@@ -20373,7 +20373,7 @@
     },
     "gemini-2.5-flash-lite-preview-06-17": {
         "deprecation_date": "2025-11-18",
-        "cache_read_input_token_cost": 2.5e-08,
+        "cache_read_input_token_cost": 1e-08,
         "input_cost_per_audio_token": 5e-07,
         "input_cost_per_token": 1e-07,
         "litellm_provider": "vertex_ai-language-models",
@@ -21953,7 +21953,7 @@
         "supports_image_size": false
     },
     "gemini/gemini-2.5-flash-preview-09-2025": {
-        "cache_read_input_token_cost": 7.5e-08,
+        "cache_read_input_token_cost": 3e-08,
         "deprecation_date": "2026-02-17",
         "input_cost_per_audio_token": 1e-06,
         "input_cost_per_token": 3e-07,
@@ -22001,7 +22001,7 @@
         "supports_image_size": false
     },
     "gemini/gemini-flash-latest": {
-        "cache_read_input_token_cost": 7.5e-08,
+        "cache_read_input_token_cost": 3e-08,
         "input_cost_per_audio_token": 1e-06,
         "input_cost_per_token": 3e-07,
         "litellm_provider": "gemini",
@@ -22047,7 +22047,7 @@
         }
     },
     "gemini/gemini-flash-lite-latest": {
-        "cache_read_input_token_cost": 2.5e-08,
+        "cache_read_input_token_cost": 1e-08,
         "input_cost_per_audio_token": 3e-07,
         "input_cost_per_token": 1e-07,
         "litellm_provider": "gemini",
@@ -22094,7 +22094,7 @@
     },
     "gemini/gemini-2.5-flash-lite-preview-06-17": {
         "deprecation_date": "2025-11-18",
-        "cache_read_input_token_cost": 2.5e-08,
+        "cache_read_input_token_cost": 1e-08,
         "input_cost_per_audio_token": 5e-07,
         "input_cost_per_token": 1e-07,
         "litellm_provider": "gemini",

--- a/tests/test_litellm/llms/gemini/test_cost_calculator.py
+++ b/tests/test_litellm/llms/gemini/test_cost_calculator.py
@@ -301,3 +301,29 @@ def test_gemini_image_generation_cost_no_web_search_when_absent(monkeypatch):
     )
 
     assert cost_zero == cost_none
+
+
+@pytest.mark.parametrize(
+    ("model", "expected_cache_rate"),
+    [
+        ("gemini-flash-latest", 3e-08),
+        ("gemini/gemini-flash-latest", 3e-08),
+        ("gemini-flash-lite-latest", 1e-08),
+        ("gemini/gemini-flash-lite-latest", 1e-08),
+        ("gemini/gemini-2.5-flash-preview-09-2025", 3e-08),
+        ("gemini-2.5-flash-preview-09-2025", 3e-08),
+        ("gemini/gemini-2.5-flash-lite-preview-06-17", 1e-08),
+        ("gemini-2.5-flash-lite-preview-06-17", 1e-08),
+    ],
+)
+def test_gemini_flash_cache_read_pricing(monkeypatch, model: str, expected_cache_rate: float):
+    """Regression: Gemini 2.5/flash aliases price cache reads at 10% of input cost."""
+    monkeypatch.setenv("LITELLM_LOCAL_MODEL_COST_MAP", "True")
+    litellm.model_cost = litellm.get_model_cost_map(url="")
+    model_info = litellm.get_model_info(model=model)
+    assert model_info.get("cache_read_input_token_cost") == expected_cache_rate
+    assert model_info.get("cache_read_input_token_cost") == pytest.approx(
+        0.10 * model_info.get("input_cost_per_token")
+    )
+
+


### PR DESCRIPTION
Fixes #38062

## Root Cause
Several Gemini 2.5 / Flash aliases in `model_prices_and_context_window.json` (and its backup) still billed cache reads at 25% of input cost (`7.5e-08` / `2.5e-08`), which was the legacy Gemini 2.0 rate, instead of the 10% rate (`3e-08` / `1e-08`) matching Google's official Gemini 2.5 Flash pricing:
- `gemini/gemini-flash-latest` (`7.5e-08` -> `3e-08`)
- `gemini/gemini-flash-lite-latest` (`2.5e-08` -> `1e-08`)
- `gemini/gemini-2.5-flash-preview-09-2025` (`7.5e-08` -> `3e-08`)
- `gemini-2.5-flash-preview-09-2025` (`7.5e-08` -> `3e-08`)
- `gemini/gemini-2.5-flash-lite-preview-06-17` (`2.5e-08` -> `1e-08`)
- `gemini-2.5-flash-lite-preview-06-17` (`2.5e-08` -> `1e-08`)

## Changes
- Updated `cache_read_input_token_cost` in `model_prices_and_context_window.json` and `litellm/model_prices_and_context_window_backup.json` to 10% of `input_cost_per_token`.
- Added unit test in `tests/test_litellm/llms/gemini/test_cost_calculator.py` covering all corrected model aliases.

## Verification & Test Evidence
- `pytest tests/test_litellm/llms/gemini/test_cost_calculator.py` -> Passed (19 passed, exit code 0)
- `pytest tests/test_litellm/test_model_prices_schema.py` -> Passed (21 passed, exit code 0)
- `python ci_cd/check_files_match.py` -> Passed (exit code 0)
- `python ci_cd/generate_model_prices_schema.py --check` -> Passed (exit code 0)
- `ruff check --config ruff-tests.toml tests/test_litellm/llms/gemini/test_cost_calculator.py` -> Passed (exit code 0)