### PR TITLE
fix(completion_extras): forward reasoning_effort=max through the Responses API bridge

### DIFF
--- a/litellm/completion_extras/litellm_responses_transformation/transformation.py
+++ b/litellm/completion_extras/litellm_responses_transformation/transformation.py
@@ -5,7 +5,7 @@ Handler for transforming /chat/completions api requests to litellm.responses req
 import json
 import os
 from collections.abc import AsyncIterator, Callable, Iterable, Iterator, Mapping, Sequence
-from typing import TYPE_CHECKING, Any, Final, Literal, TypedDict, Union, cast
+from typing import TYPE_CHECKING, Any, Final, Literal, TypedDict, Union, cast, get_args
 
 from openai.types.responses.custom_tool_param import CustomToolParam
 from openai.types.responses.response_input_param import (
@@ -35,6 +35,7 @@ from litellm.responses.sse_output_recovery import (
 )
 from litellm.responses.utils import normalize_responses_api_stream_options
 from litellm.types.llms.openai import (
+    REASONING_EFFORT,
     ChatCompletionAnnotation,
     ChatCompletionReasoningItem,
     ChatCompletionToolCallChunk,
@@ -1113,22 +1114,11 @@ class LiteLLMResponsesTransformationHandler(CompletionTransformationBridge):
             litellm.reasoning_auto_summary or os.getenv("LITELLM_REASONING_AUTO_SUMMARY", "false").lower() == "true"
         )
 
-        # If string is passed, map with optional summary based on flag/env var
-        if reasoning_effort == "none":
-            return Reasoning(effort="none", summary="detailed") if auto_summary_enabled else Reasoning(effort="none")
-        elif reasoning_effort == "high":
-            return Reasoning(effort="high", summary="detailed") if auto_summary_enabled else Reasoning(effort="high")
-        elif reasoning_effort == "xhigh":
-            return Reasoning(effort="xhigh", summary="detailed") if auto_summary_enabled else Reasoning(effort="xhigh")
-        elif reasoning_effort == "medium":
+        if reasoning_effort in get_args(REASONING_EFFORT):
             return (
-                Reasoning(effort="medium", summary="detailed") if auto_summary_enabled else Reasoning(effort="medium")
-            )
-        elif reasoning_effort == "low":
-            return Reasoning(effort="low", summary="detailed") if auto_summary_enabled else Reasoning(effort="low")
-        elif reasoning_effort == "minimal":
-            return (
-                Reasoning(effort="minimal", summary="detailed") if auto_summary_enabled else Reasoning(effort="minimal")
+                Reasoning(effort=reasoning_effort, summary="detailed")
+                if auto_summary_enabled
+                else Reasoning(effort=reasoning_effort)
             )
         return None
 

--- a/litellm/types/llms/openai.py
+++ b/litellm/types/llms/openai.py
@@ -1840,7 +1840,7 @@ ResponsesAPIStreamingResponse = Annotated[
 ]
 
 
-REASONING_EFFORT = Literal["none", "minimal", "low", "medium", "high", "xhigh"]
+REASONING_EFFORT = Literal["none", "minimal", "low", "medium", "high", "xhigh", "max"]
 
 
 class OpenAIRealtimeStreamSession(TypedDict, total=False):

--- a/tests/test_litellm/completion_extras/litellm_responses_transformation/test_completion_extras_litellm_responses_transformation_transformation.py
+++ b/tests/test_litellm/completion_extras/litellm_responses_transformation/test_completion_extras_litellm_responses_transformation_transformation.py
@@ -2,7 +2,7 @@ import datetime
 import json
 import os
 import unittest
-from typing import TYPE_CHECKING, List, Literal, Optional, Tuple
+from typing import TYPE_CHECKING, Final, List, Literal, Optional, Tuple
 from unittest.mock import ANY, MagicMock, Mock, patch
 
 import httpx
@@ -1585,10 +1585,16 @@ def test_map_reasoning_effort_adds_summary_detailed(monkeypatch):
         assert result_dict["summary"] == "custom_summary"
         print("✓ Dict input is passed through without modification")
 
-        # Test 5: None/unknown values return None
-        result_unknown = handler._map_reasoning_effort("unknown_value")
-        assert result_unknown is None
-        print("✓ Unknown reasoning_effort values return None")
+        # Test 5: every REASONING_EFFORT level reaches the provider, and anything else (a typo, an
+        # unshipped level, "default") is dropped so the request still succeeds at the provider default
+        from litellm.types.llms.openai import Reasoning
+
+        for effort in ("max", "xhigh", "none"):
+            result_passthrough = handler._map_reasoning_effort(effort)
+            assert result_passthrough == Reasoning(effort=effort)
+        for dropped in ("ultra", "hgih", "unknown_value", "", "default"):
+            assert handler._map_reasoning_effort(dropped) is None
+        print("✓ Enumerated levels pass through and unknown ones are dropped")
 
         print(
             "✓ All reasoning_effort behaviors work correctly with flag/env var control"
@@ -2436,6 +2442,32 @@ def test_map_optional_params_preserves_reasoning_summary():
     }
     assert responses_api_request["reasoning"]["effort"] == "high"
     assert responses_api_request["reasoning"]["summary"] == "detailed"
+
+
+@pytest.mark.parametrize("reasoning_effort", ["max", "high"])
+def test_transform_request_bedrock_mantle_tools_keeps_reasoning_effort(monkeypatch, reasoning_effort):
+    """Regression for reasoning_effort=max being dropped on the chat -> Responses bridge (issue #38084)."""
+    from litellm.completion_extras.litellm_responses_transformation.transformation import (
+        LiteLLMResponsesTransformationHandler,
+    )
+
+    monkeypatch.setattr(litellm, "reasoning_auto_summary", False)
+    monkeypatch.delenv("LITELLM_REASONING_AUTO_SUMMARY", raising=False)
+    handler: Final = LiteLLMResponsesTransformationHandler()
+
+    result: Final = handler.transform_request(
+        model="openai.gpt-5.6-sol",
+        messages=[{"role": "user", "content": "Say pong"}],
+        optional_params={
+            "reasoning_effort": reasoning_effort,
+            "tools": [{"type": "function", "function": {"name": "get_weather", "parameters": {"type": "object"}}}],
+        },
+        litellm_params={"custom_llm_provider": "bedrock_mantle"},
+        headers={},
+        litellm_logging_obj=Mock(),
+    )
+
+    assert result["reasoning"] == {"effort": reasoning_effort}
 
 
 def test_map_optional_params_tool_choice_chat_nested_to_responses_api():

--- a/tests/test_litellm/proxy/response_api_endpoints/test_endpoints.py
+++ b/tests/test_litellm/proxy/response_api_endpoints/test_endpoints.py
@@ -1353,6 +1353,8 @@ class TestParseCursorModelVariant:
             ("claude-opus-5-fast", "claude-opus-5", None),
             ("gpt-5.6-sol", "gpt-5.6-sol", None),
             ("foo-thinking-ultra-fast", "foo-thinking-ultra", None),
+            ("gpt-5.6-thinking-max", "gpt-5.6", "max"),
+            ("foo-thinking-mega-fast", "foo-thinking-mega", None),
             ("-thinking-high", "-thinking-high", None),
         ],
     )


### PR DESCRIPTION
## TLDR

Problem this solves:

- `reasoning_effort: "max"` is silently dropped on conversion to the Responses API
- Bedrock Mantle gpt-5.6 models accept `max` but ran at their default depth
- Affects /v1/chat/completions with tools and `reasoning_effort` on /v1/responses (client-sent or config-level)

How it solves it:

- adds `max` to `REASONING_EFFORT` and forwards every enumerated level
- unknown values still drop, so typo'd requests keep succeeding
- shares byte-identical hunks with #37897, so either merge order composes

## User Flow

Before: a developer whose gateway serves Bedrock Mantle asks for reasoning effort max and silently gets the model's default depth

1. They send POST https://litellm-domain/v1/chat/completions with `"model": "gpt-5.6-sol"`, `"reasoning_effort": "max"`, and their function tools
2. HTTP 200 comes back, but the model ran at its default depth; even a gpt-5.5 deployment, whose model rejects `max` outright when called directly, answers 200 as if nothing had been asked
3. They try the operator route: the admin configures `reasoning_effort: max` on the deployment, and they send POST https://litellm-domain/v1/responses with a plain `"input"`
4. The response echoes `"reasoning": {"effort": "medium"}`, the provider default, not what was configured

After: the same requests reach Bedrock Mantle with effort max applied

1. They send POST https://litellm-domain/v1/chat/completions with `"model": "gpt-5.6-sol"`, `"reasoning_effort": "max"`, and their function tools
2. HTTP 200 comes back with the effort applied, and the gpt-5.5 deployment now answers with Bedrock Mantle's own 400 `Unsupported value: 'max'`, exactly what the provider says when called directly
3. The admin configures `reasoning_effort: max` on the deployment, and they send POST https://litellm-domain/v1/responses with a plain `"input"`
4. The response echoes `"reasoning": {"effort": "max"}`

## Relevant issues

Fixes #38084

## Linear ticket

Resolves LIT-6095

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Live run against real Bedrock Mantle (us-east-1, real $$$). Each leg boots its own proxy from its own worktree with 2 uvicorn workers (`--num_workers 2`), before on port 28413, after on port 29617, same config:

```yaml
model_list:
  - model_name: gpt-5.6-sol
    litellm_params:
      model: bedrock_mantle/openai.gpt-5.6-sol
      aws_region_name: us-east-1
      drop_params: false
  - model_name: gpt-5.6-sol-cfg-max
    litellm_params:
      model: bedrock_mantle/openai.gpt-5.6-sol
      aws_region_name: us-east-1
      drop_params: false
      reasoning_effort: max
  - model_name: gpt-5.5
    litellm_params:
      model: bedrock_mantle/openai.gpt-5.5
      aws_region_name: us-east-1
      drop_params: false
general_settings:
  master_key: sk-1234
router_settings:
  num_retries: 0
```

Control, straight to the provider (what Mantle itself does with `effort: max`, no LiteLLM involved):

1. `curl -sS https://bedrock-mantle.us-east-1.api.aws/openai/v1/responses -H "Authorization: Bearer $AWS_BEARER_TOKEN_BEDROCK" -H 'Content-Type: application/json' -d '{"model":"openai.gpt-5.5","max_output_tokens":64,"reasoning":{"effort":"max"},"input":"Say pong"}'`
2. HTTP 400: `Unsupported value: 'max' is not supported with the 'openai.gpt-5.5' model. Supported values are: 'none', 'low', 'medium', 'high', and 'xhigh'`
3. Same request with `"model":"openai.gpt-5.6-sol"`: HTTP 200, response carries `"reasoning": {"summary": null, "effort": "max", "context": "all_turns"}`

### Before (bb27bfd9a7)

#### /v1/chat/completions with tools, gpt-5.5, reasoning_effort max

1. `curl -sS http://localhost:28413/v1/chat/completions -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' -d '{"model":"gpt-5.5","reasoning_effort":"max","max_completion_tokens":4096,"tools":[{"type":"function","function":{"name":"get_weather","description":"Get the weather for a city","parameters":{"type":"object","properties":{"city":{"type":"string"}},"required":["city"]}}}],"messages":[{"role":"user","content":"What is the 10th prime number after 1000? Reply with just the number."}]}'`
2. HTTP 200 with `"reasoning_tokens": 86`: the effort a model of this family rejects outright was silently discarded before reaching the provider

#### /v1/chat/completions with tools, gpt-5.6-sol, reasoning_effort max

1. Same request with `"model":"gpt-5.6-sol"`
2. HTTP 200 with `"reasoning_tokens": 64`, indistinguishable from a request that asked for nothing

#### /v1/responses, client-sent reasoning_effort max

1. `curl -sS http://localhost:28413/v1/responses -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' -d '{"model":"gpt-5.6-sol","max_output_tokens":4096,"reasoning_effort":"max","input":"What is the 10th prime number after 1000? Reply with just the number."}'`
2. HTTP 200, response echoes `"reasoning": {"effort": "medium"}`: the provider default, not what was asked

#### /v1/responses, deployment configured with reasoning_effort max

1. `curl -sS http://localhost:28413/v1/responses -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' -d '{"model":"gpt-5.6-sol-cfg-max","max_output_tokens":4096,"input":"What is the 10th prime number after 1000? Reply with just the number."}'`
2. HTTP 200, response echoes `"reasoning": {"effort": "medium"}`: the configured `max` never left the gateway

### After (a73f11ae9c)

#### /v1/chat/completions with tools, gpt-5.5, reasoning_effort max

1. `curl -sS http://localhost:29617/v1/chat/completions -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' -d '{"model":"gpt-5.5","reasoning_effort":"max","max_completion_tokens":4096,"tools":[{"type":"function","function":{"name":"get_weather","description":"Get the weather for a city","parameters":{"type":"object","properties":{"city":{"type":"string"}},"required":["city"]}}}],"messages":[{"role":"user","content":"What is the 10th prime number after 1000? Reply with just the number."}]}'`
2. HTTP 400: `litellm.BadRequestError: BedrockException - {"error":{"code":"unsupported_value","message":"Unsupported value: 'max' is not supported with the 'openai.gpt-5.5' ...` The effort now reaches Mantle, whose answer matches the direct control call

#### /v1/chat/completions with tools, gpt-5.6-sol, reasoning_effort max

1. Same request with `"model":"gpt-5.6-sol"`
2. HTTP 200 with `"reasoning_tokens": 183` on a model that supports `max`

#### /v1/responses, client-sent reasoning_effort max

1. `curl -sS http://localhost:29617/v1/responses -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' -d '{"model":"gpt-5.6-sol","max_output_tokens":4096,"reasoning_effort":"max","input":"What is the 10th prime number after 1000? Reply with just the number."}'`
2. HTTP 200, response echoes `"reasoning": {"effort": "max"}`

#### /v1/responses, deployment configured with reasoning_effort max

1. `curl -sS http://localhost:29617/v1/responses -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' -d '{"model":"gpt-5.6-sol-cfg-max","max_output_tokens":4096,"input":"What is the 10th prime number after 1000? Reply with just the number."}'`
2. HTTP 200, response echoes `"reasoning": {"effort": "max"}`

Observations from the run:

- reasoning token counts barely scale with effort on gpt-5.6-sol (64 to 183)
- Mantle accepts `summary: "detailed"` yet returns zero summary items
- /v1/messages never forwards `reasoning_effort` to Mantle on either leg; this PR leaves that alone

## Type

🐛 Bug Fix

## Caveats (if any)

- shares hunks with #37897; whichever lands second auto-merges
- `max` also becomes a valid Cursor `-thinking-max` suffix level
- models rejecting `max` now surface the provider's 400, matching direct calls
- /v1/messages drops `reasoning_effort` before this mapping; unchanged by this PR

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
- [x] a73f11ae9c736059299c2078ee602bc05e43559d passes /live-pr-risk

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small mapping refactor in the chat→Responses bridge with clear tests; models that reject `max` will surface provider errors instead of silently ignoring the parameter.
> 
> **Overview**
> Fixes **`reasoning_effort: "max"`** being dropped when chat completions (especially with tools) are bridged to the Responses API—e.g. Bedrock Mantle gpt-5.6 models that accept `max` but were running at default depth.
> 
> **`REASONING_EFFORT`** now includes **`max`**. **`_map_reasoning_effort`** no longer hard-codes each level; it passes through any value in that enum (still honoring auto-summary when enabled) and returns **`None`** for unknown strings so typo’d requests keep working. Proxy Cursor model names pick up **`thinking-max`** automatically because thinking levels are derived from the same type.
> 
> Tests cover enum passthrough/drop behavior, a Bedrock Mantle **`transform_request`** regression, and **`_parse_cursor_model_variant`** for **`gpt-5.6-thinking-max`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a73f11ae9c736059299c2078ee602bc05e43559d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->