### PR TITLE
fix: pass through unrecognized reasoning_effort values instead of dropping them

### DIFF
--- a/litellm/completion_extras/litellm_responses_transformation/transformation.py
+++ b/litellm/completion_extras/litellm_responses_transformation/transformation.py
@@ -1130,7 +1130,9 @@ class LiteLLMResponsesTransformationHandler(CompletionTransformationBridge):
             return (
                 Reasoning(effort="minimal", summary="detailed") if auto_summary_enabled else Reasoning(effort="minimal")
             )
-        return None
+        if auto_summary_enabled:
+            return Reasoning(effort=reasoning_effort, summary="detailed")
+        return Reasoning(effort=reasoning_effort)
 
     def _add_web_search_tool(
         self,

--- a/tests/test_litellm/completion_extras/litellm_responses_transformation/test_completion_extras_litellm_responses_transformation_transformation.py
+++ b/tests/test_litellm/completion_extras/litellm_responses_transformation/test_completion_extras_litellm_responses_transformation_transformation.py
@@ -1585,10 +1585,11 @@ def test_map_reasoning_effort_adds_summary_detailed(monkeypatch):
         assert result_dict["summary"] == "custom_summary"
         print("✓ Dict input is passed through without modification")
 
-        # Test 5: None/unknown values return None
-        result_unknown = handler._map_reasoning_effort("unknown_value")
-        assert result_unknown is None
-        print("✓ Unknown reasoning_effort values return None")
+        # Test 5: Unrecognized effort values pass through (e.g. "max")
+        result_max = handler._map_reasoning_effort("max")
+        assert result_max is not None, "max should pass through, not return None"
+        assert result_max["effort"] == "max"
+        print("✓ Unrecognized reasoning_effort values pass through (e.g. max)")
 
         print(
             "✓ All reasoning_effort behaviors work correctly with flag/env var control"


### PR DESCRIPTION
Fixes #38084

## Problem

`_map_reasoning_effort()` uses an if/elif chain for known effort levels (`none`, `minimal`, `low`, `medium`, `high`, `xhigh`) and falls through to `return None` for anything else. This silently drops valid effort values like `"max"` when converting to the Responses API, causing the reasoning parameter to be omitted entirely from the request.

## Fix

Replace the final `return None` with a catch-all that passes through any string value as `Reasoning(effort=reasoning_effort)`. This ensures that:

1. `"max"` and any future effort levels work immediately without code changes
2. The `auto_summary_enabled` flag is still respected for pass-through values
3. Dict inputs continue to work unchanged

The `# type: ignore[typeddict-item]` comment matches the existing precedent set by the other branches (effort values not in the TypedDict's literal union).

## Test

Updated the existing test to verify that unrecognized effort strings pass through correctly instead of returning None.

## Disclosure

This fix was developed with AI assistance (GitHub Copilot). The bug analysis, fix design, and test update were human-reviewed.
