### PR TITLE
fix(model_prices): raise bedrock_mantle gpt-5.6 max_input_tokens to Mantle's enforced 1050000

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -49016,12 +49016,13 @@
         "output_cost_per_token": 3.3e-05,
         "output_cost_per_token_above_272k_tokens": 4.95e-05,
         "litellm_provider": "bedrock_mantle",
-        "max_input_tokens": 1000000,
+        "max_input_tokens": 1050000,
         "max_output_tokens": 128000,
         "max_tokens": 128000,
         "mode": "responses",
         "use_openai_responses_path": true,
         "supported_endpoints": [
+            "/v1/chat/completions",
             "/v1/responses"
         ],
         "supported_modalities": [
@@ -49048,12 +49049,13 @@
         "output_cost_per_token": 1.32e-05,
         "output_cost_per_token_above_272k_tokens": 1.98e-05,
         "litellm_provider": "bedrock_mantle",
-        "max_input_tokens": 1000000,
+        "max_input_tokens": 1050000,
         "max_output_tokens": 128000,
         "max_tokens": 128000,
         "mode": "responses",
         "use_openai_responses_path": true,
         "supported_endpoints": [
+            "/v1/chat/completions",
             "/v1/responses"
         ],
         "supported_modalities": [
@@ -49080,12 +49082,13 @@
         "output_cost_per_token": 1.32e-06,
         "output_cost_per_token_above_272k_tokens": 1.98e-06,
         "litellm_provider": "bedrock_mantle",
-        "max_input_tokens": 1000000,
+        "max_input_tokens": 1050000,
         "max_output_tokens": 128000,
         "max_tokens": 128000,
         "mode": "responses",
         "use_openai_responses_path": true,
         "supported_endpoints": [
+            "/v1/chat/completions",
             "/v1/responses"
         ],
         "supported_modalities": [

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -49016,12 +49016,13 @@
         "output_cost_per_token": 3.3e-05,
         "output_cost_per_token_above_272k_tokens": 4.95e-05,
         "litellm_provider": "bedrock_mantle",
-        "max_input_tokens": 1000000,
+        "max_input_tokens": 1050000,
         "max_output_tokens": 128000,
         "max_tokens": 128000,
         "mode": "responses",
         "use_openai_responses_path": true,
         "supported_endpoints": [
+            "/v1/chat/completions",
             "/v1/responses"
         ],
         "supported_modalities": [
@@ -49048,12 +49049,13 @@
         "output_cost_per_token": 1.32e-05,
         "output_cost_per_token_above_272k_tokens": 1.98e-05,
         "litellm_provider": "bedrock_mantle",
-        "max_input_tokens": 1000000,
+        "max_input_tokens": 1050000,
         "max_output_tokens": 128000,
         "max_tokens": 128000,
         "mode": "responses",
         "use_openai_responses_path": true,
         "supported_endpoints": [
+            "/v1/chat/completions",
             "/v1/responses"
         ],
         "supported_modalities": [
@@ -49080,12 +49082,13 @@
         "output_cost_per_token": 1.32e-06,
         "output_cost_per_token_above_272k_tokens": 1.98e-06,
         "litellm_provider": "bedrock_mantle",
-        "max_input_tokens": 1000000,
+        "max_input_tokens": 1050000,
         "max_output_tokens": 128000,
         "max_tokens": 128000,
         "mode": "responses",
         "use_openai_responses_path": true,
         "supported_endpoints": [
+            "/v1/chat/completions",
             "/v1/responses"
         ],
         "supported_modalities": [

--- a/tests/test_litellm/litellm_core_utils/llm_cost_calc/test_llm_cost_calc_utils.py
+++ b/tests/test_litellm/litellm_core_utils/llm_cost_calc/test_llm_cost_calc_utils.py
@@ -478,10 +478,10 @@ def test_generic_cost_per_token_minimax_m3_above_512k_tokens(_local_model_cost_m
     ],
 )
 def test_generic_cost_per_token_bedrock_mantle_gpt56_long_context(_local_model_cost_map, model):
-    """Bedrock GPT-5.6 supports a 1M context window, billed at the long-context rates above 272K."""
+    """Bedrock GPT-5.6 enforces a 1,050,000-token context window, billed at the long-context rates above 272K."""
 
     model_cost_map = litellm.model_cost[model]
-    assert model_cost_map["max_input_tokens"] == 1000000
+    assert model_cost_map["max_input_tokens"] == 1050000
 
     cached_tokens = 100000
     completion_tokens = 1000

--- a/tests/test_litellm/llms/bedrock_mantle/test_bedrock_mantle_responses_transformation.py
+++ b/tests/test_litellm/llms/bedrock_mantle/test_bedrock_mantle_responses_transformation.py
@@ -1568,7 +1568,7 @@ class TestBedrockMantleResponsesPricing:
         assert "bedrock_mantle/openai.gpt-5.4" in litellm.bedrock_mantle_models
 
 
-def _repo_cost_map(map_name: str) -> dict:
+def _repo_cost_map(map_name: str) -> dict[str, dict[str, object]]:
     repo_root = Path(__file__).resolve().parents[4]
     paths = {
         "root": repo_root / "model_prices_and_context_window.json",

--- a/tests/test_litellm/llms/bedrock_mantle/test_bedrock_mantle_responses_transformation.py
+++ b/tests/test_litellm/llms/bedrock_mantle/test_bedrock_mantle_responses_transformation.py
@@ -8,7 +8,8 @@ gate, the URL construction for both paths, and the shared Bearer auth.
 """
 
 import copy
-
+import json
+from pathlib import Path
 
 import pytest
 from botocore.exceptions import (
@@ -1523,7 +1524,7 @@ class TestBedrockMantleResponsesPricing:
         assert info["cache_creation_input_token_cost"] == pytest.approx(cache_creation_cost)
         assert info["cache_read_input_token_cost"] == pytest.approx(cache_read_cost)
         assert info["output_cost_per_token"] == pytest.approx(output_cost)
-        assert info["max_input_tokens"] == 1000000
+        assert info["max_input_tokens"] == 1050000
         assert info["input_cost_per_token_above_272k_tokens"] == pytest.approx(input_cost * 2)
         assert info["cache_creation_input_token_cost_above_272k_tokens"] == pytest.approx(cache_creation_cost * 2)
         assert info["cache_read_input_token_cost_above_272k_tokens"] == pytest.approx(cache_read_cost * 2)
@@ -1565,3 +1566,42 @@ class TestBedrockMantleResponsesPricing:
     def test_models_registered(self, local_cost_map):
         assert "bedrock_mantle/openai.gpt-5.5" in litellm.bedrock_mantle_models
         assert "bedrock_mantle/openai.gpt-5.4" in litellm.bedrock_mantle_models
+
+
+def _repo_cost_map(map_name: str) -> dict:
+    repo_root = Path(__file__).resolve().parents[4]
+    paths = {
+        "root": repo_root / "model_prices_and_context_window.json",
+        "bundled_backup": repo_root / "litellm" / "model_prices_and_context_window_backup.json",
+    }
+    return json.loads(paths[map_name].read_text())
+
+
+class TestGpt56MantleRegistryEntries:
+    """Locks the gpt-5.6 frontier entries to Bedrock Mantle's live behavior.
+
+    Mantle enforces a 1,050,000-token prompt maximum for gpt-5.6 sol/terra/luna
+    (oversize requests 400 with "prompt tokens (N) exceed model maximum
+    (1050000)", and a 1,030,590-token request completes), matching the OpenAI
+    Bedrock guide. mode must stay "responses": Mantle's native
+    /v1/chat/completions rejects function tools unless reasoning_effort is
+    "none", so chat traffic has to keep bridging to the Responses API
+    (see the responses_api_bridge tests above).
+    """
+
+    @pytest.mark.parametrize("map_name", ("root", "bundled_backup"))
+    @pytest.mark.parametrize(
+        "key",
+        (
+            "bedrock_mantle/openai.gpt-5.6-sol",
+            "bedrock_mantle/openai.gpt-5.6-terra",
+            "bedrock_mantle/openai.gpt-5.6-luna",
+        ),
+    )
+    def test_entry_matches_mantle_enforced_limits(self, map_name, key):
+        entry = _repo_cost_map(map_name)[key]
+        assert entry["max_input_tokens"] == 1050000
+        assert entry["max_output_tokens"] == 128000
+        assert entry["mode"] == "responses"
+        assert entry["use_openai_responses_path"] is True
+        assert entry["supported_endpoints"] == ["/v1/chat/completions", "/v1/responses"]


### PR DESCRIPTION
## TLDR

Problem this solves:

- Mantle GPT-5.6 entries advertise 1,000,000 max input tokens
- Bedrock Mantle actually enforces 1,050,000 for sol, terra, and luna
- With pre-call checks on, the proxy rejects requests Mantle serves

How it solves it:

- Raise the three entries to 1,050,000 in both cost maps
- List /v1/chat/completions next to /v1/responses in supported_endpoints
- Regression test locks the entries to Mantle's enforced limits

## User Flow

Before: a developer running Codex against a Bedrock Mantle GPT-5.6 deployment has their long session refused by the gateway even though Bedrock would serve it

1. They point Codex at the gateway's `openai.gpt-5.6-luna` deployment and work until the session grows past a million tokens; Codex sends POST https://litellm-domain/v1/responses with a 1,030,590-token prompt
2. The gateway answers 400 `ContextWindowExceededError ... Max Input Tokens=1000000, Got=1034742` and Codex surfaces the failure
3. Sending the identical body straight to POST https://bedrock-mantle.us-east-1.api.aws/openai/v1/responses returns 200 with output "pong", so the refusal is the gateway's alone
4. GET https://litellm-domain/v1/model/info shows `max_input_tokens: 1000000` while Bedrock's own oversize error names "model maximum (1050000)"

After: the same session sails through, and the gateway's ceiling matches Bedrock's

1. They point Codex at the gateway's `openai.gpt-5.6-luna` deployment and work until the session grows past a million tokens; Codex sends POST https://litellm-domain/v1/responses with a 1,030,590-token prompt
2. The gateway answers 200, status completed, `usage.input_tokens: 1030590`, output "pong"
3. Only a genuinely oversize request (1,074,439 tokens) gets 400, now naming `Max Input Tokens=1050000`, the same ceiling Bedrock itself enforces
4. GET https://litellm-domain/v1/model/info shows `max_input_tokens: 1050000`

## Relevant issues

Fixes #36016

## Linear ticket

Resolves LIT-6096

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Setup: proxy on localhost:44900 (localhost:41873 for Before) with `mantle-luna` -> `bedrock_mantle/openai.gpt-5.6-luna` (us-east-1, bearer token auth) and `router_settings: enable_pre_call_checks: true`. Long-prompt bodies are plain filler text generated to a target o200k_base token count, asking the model to reply exactly "pong"; `proxy_body1030k_luna.json` carries a 1,030,590-token prompt (Mantle's own usage count), `proxy_body1070k_luna.json` 1,074,439 tokens. Direct-to-Bedrock controls hit `https://bedrock-mantle.us-east-1.api.aws/openai/v1` with the same bodies and the account's bearer token

### Before (bb27bfd9a7)

#### 1,030K-token request on /v1/responses

1. `curl -sS http://localhost:41873/v1/responses -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' --data-binary @proxy_body1030k_luna.json`
2. `{"error":{"message":"litellm.ContextWindowExceededError: litellm.BadRequestError: litellm._pre_call_checks: Context Window exceeded for given call. No models have context window large enough for this call.\nModel=bedrock_mantle/openai.gpt-5.6-luna, Max Input Tokens=1000000, Got=1034742\nmodel=mantle-luna. ...","code":"400"}}`
3. Control, same body straight to Bedrock: `curl -sS https://bedrock-mantle.us-east-1.api.aws/openai/v1/responses -H "Authorization: Bearer $AWS_BEARER_TOKEN_BEDROCK" -H 'Content-Type: application/json' --data-binary @body1030k.json` returns HTTP 200, `"usage": {"input_tokens": 1030590, ...}`, output text "pong"

#### Bedrock's real ceiling (control)

1. `curl -sS https://bedrock-mantle.us-east-1.api.aws/openai/v1/responses ... --data-binary @body1070k.json` (1,070,126 tokens)
2. HTTP 400: `{"error":{"code":"validation_error","message":"prompt tokens (1070126) exceed model maximum (1050000) for openai.gpt-5.6-luna"}}`, and the same "model maximum (1050000)" comes back for openai.gpt-5.6-sol and openai.gpt-5.6-terra

#### Tool calling on /v1/chat/completions

1. `curl -sS http://localhost:41873/v1/chat/completions -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' -d '{"model":"mantle-luna","messages":[{"role":"user","content":"What is the weather in Paris? Use the tool."}],"tools":[{"type":"function","function":{"name":"get_weather","description":"Get weather for a city","parameters":{"type":"object","properties":{"city":{"type":"string"}},"required":["city"]}}}]}'`
2. HTTP 200, `finish_reason: "tool_calls"`, `get_weather` with `{"city":"Paris"}`

### After (f583151a5b, all three legs re-run at tip 6be000f1f3 with identical results)

#### 1,030K-token request on /v1/responses

1. `curl -sS http://localhost:44900/v1/responses -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' --data-binary @proxy_body1030k_luna.json`
2. HTTP 200, status completed, `"usage": {"input_tokens": 1030590, ..., "output_tokens": 5, "total_tokens": 1030595}`, output text "pong"

#### Bedrock's real ceiling (now mirrored by the proxy)

1. `curl -sS http://localhost:44900/v1/responses -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' --data-binary @proxy_body1070k_luna.json`
2. HTTP 400: `litellm.ContextWindowExceededError: ... Max Input Tokens=1050000, Got=1074439`, matching Bedrock's own enforcement, so genuinely oversize requests are still caught before spending tokens

#### Tool calling on /v1/chat/completions

1. Same curl as Before against localhost:44900
2. HTTP 200, `finish_reason: "tool_calls"`, `get_weather` with `{"city":"Paris"}`: the chat -> Responses bridge is untouched

## Type

🐛 Bug Fix

## Caveats (if any)

- `mode` stays `responses` on purpose: Mantle's native chat endpoint rejects function tools unless `reasoning_effort` is "none", so the bridge is load-bearing
- Adding `/v1/chat/completions` to `supported_endpoints` changes no routing; it documents what the deployment already serves through the bridge
- GPT-5.5/5.4 keep 272,000: AWS docs say 272K yet Mantle validated a 300K request, contradictory evidence tracked separately
- `bedrock/` Converse GPT-5.6 profile entries are untouched

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

- [x] f583151a5b8928361237e715abe75b305fc4b3a5 passes /live-pr-risk

- [x] 6be000f1f35091cbbdfedb7df4e0dd8d494c0eaf passes /live-pr-risk

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only changes to the model cost map and tests; no runtime routing or auth logic is modified.
> 
> **Overview**
> **Bedrock Mantle GPT-5.6 (sol, terra, luna)** model registry entries are updated so LiteLLM’s context limits match what AWS actually enforces.
> 
> For all three variants in `model_prices_and_context_window.json` and the bundled backup, **`max_input_tokens` rises from 1,000,000 to 1,050,000**, fixing false `ContextWindowExceededError` rejections on the proxy when `enable_pre_call_checks` is on for prompts Bedrock would accept (e.g. ~1.03M tokens). **`supported_endpoints`** now lists **`/v1/chat/completions`** alongside **`/v1/responses`** to reflect chat traffic served via the Responses bridge; routing behavior is unchanged.
> 
> Tests assert the new limit in cost-calc and mantle transformation suites, and **`TestGpt56MantleRegistryEntries`** reads both JSON maps to lock `max_input_tokens`, `mode`, `use_openai_responses_path`, and `supported_endpoints`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6be000f1f35091cbbdfedb7df4e0dd8d494c0eaf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
