### PR TITLE
test(mcp): drain the logging worker after each test so queued callbacks cannot leak into the next test

### DIFF
--- a/tests/mcp_tests/conftest.py
+++ b/tests/mcp_tests/conftest.py
@@ -7,6 +7,7 @@ import pytest
 
 import litellm
 import asyncio
+from litellm.litellm_core_utils.logging_worker import GLOBAL_LOGGING_WORKER
 
 
 @pytest.fixture(scope="session")
@@ -38,6 +39,8 @@ def setup_and_teardown():
     yield
 
     # Teardown code (executes after the yield point)
+    # LoggingWorker carries still-queued coroutines onto the next test's loop, where they'd log into that test's callbacks
+    asyncio.run(GLOBAL_LOGGING_WORKER.clear_queue())
     loop.close()  # Close the loop created earlier
     asyncio.set_event_loop(None)  # Remove the reference to the loop
 

--- a/tests/mcp_tests/test_mcp_logging.py
+++ b/tests/mcp_tests/test_mcp_logging.py
@@ -1,6 +1,9 @@
 import os
 import pytest
 import asyncio
+import subprocess
+import sys
+from pathlib import Path
 from typing import Optional
 from unittest.mock import AsyncMock, patch
 
@@ -442,3 +445,45 @@ async def test_mcp_tool_call_hook():
                 logged_standard_logging_payload is not None
             ), "Standard logging payload should not be None"
             assert logged_standard_logging_payload["response_cost"] == 1.42
+
+
+_QUEUED_LOGGING_OUTLIVES_TEST = '''
+import time
+
+from litellm.litellm_core_utils.logging_worker import GLOBAL_LOGGING_WORKER
+
+ran_at = []
+
+
+async def _record_run():
+    ran_at.append(time.monotonic())
+
+
+async def test_1_leaves_logging_queued_behind_a_stopped_worker():
+    GLOBAL_LOGGING_WORKER.ensure_initialized_and_enqueue(_record_run())
+    await GLOBAL_LOGGING_WORKER.stop()
+    assert ran_at == []
+
+
+async def test_2_starts_after_the_previous_tests_logging_ran():
+    started_at = time.monotonic()
+    GLOBAL_LOGGING_WORKER.ensure_initialized_and_enqueue(_record_run())
+    await GLOBAL_LOGGING_WORKER.flush()
+    assert [t < started_at for t in ran_at] == [True, False]
+'''
+
+
+def test_logging_queued_by_one_test_is_drained_before_the_next(tmp_path: Path):
+    """Regression: a logging coroutine queued by one test must not run inside a later test (it would log into that
+    test's callbacks, which is how test_mcp_tool_call_hook captured a gpt-4o-mini payload under xdist)."""
+    (tmp_path / "conftest.py").write_text((Path(__file__).parent / "conftest.py").read_text())
+    (tmp_path / "pyproject.toml").write_text('[tool.pytest.ini_options]\nasyncio_mode = "auto"\n')
+    (tmp_path / "test_queued_logging.py").write_text(_QUEUED_LOGGING_OUTLIVES_TEST)
+    result = subprocess.run(
+        [sys.executable, "-m", "pytest", "-q", "-p", "no:cacheprovider", "test_queued_logging.py"],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr


### PR DESCRIPTION
## TLDR

Problem this solves:

- `tests/mcp_tests/test_mcp_logging.py` flakes under xdist: `assert 1.35e-05 == 1.42`
- A previous test's queued logging coroutine runs inside the next test on the same worker
- It resolves `litellm.callbacks` at run time and overwrites the next test's captured payload

How it solves it:

- The suite's autouse teardown drains `GLOBAL_LOGGING_WORKER` before the next test starts
- A regression test runs the real conftest in a subprocess against a stopped worker with queued work

## User Flow

Before: a contributor's PR goes red on the MCP test job for a test their change never touched

1. They push a branch and open a PR; the "LiteLLM MCP Tests" job runs `pytest tests/mcp_tests -n 4`
2. The job fails with `FAILED tests/mcp_tests/test_mcp_logging.py::test_mcp_tool_call_hook - assert 1.35e-05 == 1.42`
3. The captured stdout shows the MCP logger first recording its own `MCP: zapier_gmail_server-add_tools` payload at `1.42`, then a `gpt-4o-mini` `acompletion` payload at `1.35e-05` from a test that finished nine seconds earlier on the same worker
4. They rerun the job and it passes, because the worker assignment changed

After: the same PR's MCP test job is green on the first run

1. They push a branch and open a PR; the "LiteLLM MCP Tests" job runs `pytest tests/mcp_tests -n 4`
2. Every logging coroutine a test queued has already run by the time the next test on that worker starts, so `test_mcp_tool_call_hook` only ever sees its own `1.42` payload
3. The job passes without a rerun

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

This PR only changes test infrastructure, so there is no proxy route or LLM call to show; the proof is the leak reproduced against the merge-base conftest and gone against this branch's conftest, using the same two-test scenario the new regression test runs

Root cause: `12a34a10d8` made `LoggingWorker` carry still-queued coroutines onto the next event loop instead of dropping them. A pytest-asyncio test gets a fresh loop, so a coroutine one test enqueued but never ran is carried into the next test on that xdist worker and executes there, against whatever `litellm.callbacks` that test registered. The CI log for the failing run carries the smoking gun: `LoggingWorker: event loop changed; carried 2 pending logging task(s) onto the new loop`

### Before (891b23d680)

1. Copy `tests/mcp_tests/conftest.py` (merge-base version) next to the regression scenario and run it: `python -m pytest -q -p no:cacheprovider test_queued_logging.py`
2. Output:

```
.F                                                                       [100%]
______________ test_2_starts_after_the_previous_tests_logging_ran ______________
>       assert [t < started_at for t in ran_at] == [True, False]
E       assert [False, False] == [True, False]
WARNING  LiteLLM:logging_worker.py:94 LoggingWorker: event loop changed; carried 1 pending logging task(s) onto the new loop
1 failed, 1 passed in 0.21s
```

### After (691d434366)

1. Run the regression test, which copies this branch's `tests/mcp_tests/conftest.py` and runs the same scenario in a subprocess: `python -m pytest -q -p no:cacheprovider tests/mcp_tests/test_mcp_logging.py`
2. Output:

```
4 passed in 13.92s
```

3. Run the whole suite the way CI does: `python -m pytest tests/mcp_tests -q -n 4`
4. Output (the three failures are `test_proxy_mcp_e2e.py` stdio tests whose spawned MCP server can't import `mcp` on this machine, `ModuleNotFoundError: No module named 'mcp'`, unrelated to this change):

```
FAILED tests/mcp_tests/test_proxy_mcp_e2e.py::TestProxyMcpStatelessBehavior::test_independent_clients_no_shared_session
FAILED tests/mcp_tests/test_proxy_mcp_e2e.py::TestProxyMcpSimpleConnections::test_proxy_mcp_lists_all_servers_without_header
FAILED tests/mcp_tests/test_proxy_mcp_e2e.py::TestProxyMcpSimpleConnections::test_proxy_mcp_stdio_roundtrip
3 failed, 144 passed, 4 skipped, 24 warnings in 53.91s
```

## Type

✅ Test

## Caveats (if any)

- Only `tests/mcp_tests` is covered; other suites set `litellm.callbacks` globally too and could leak the same way
- A coroutine enqueued from a background thread after teardown could still land in the next test's queue

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
