### PR TITLE
feat(models): add missing Together AI serverless models to the cost map

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -37886,6 +37886,7 @@
         "output_cost_per_token": 1e-07
     },
     "together_ai/Qwen/Qwen2.5-72B-Instruct-Turbo": {
+        "deprecation_date": "2026-02-06",
         "litellm_provider": "together_ai",
         "mode": "chat",
         "supports_function_calling": true,
@@ -37902,6 +37903,7 @@
         "supports_tool_choice": true
     },
     "together_ai/Qwen/Qwen3-235B-A22B-Instruct-2507-tput": {
+        "deprecation_date": "2026-07-10",
         "input_cost_per_token": 2e-07,
         "litellm_provider": "together_ai",
         "max_input_tokens": 262000,
@@ -37914,6 +37916,7 @@
         "supports_tool_choice": true
     },
     "together_ai/Qwen/Qwen3-235B-A22B-Thinking-2507": {
+        "deprecation_date": "2026-04-16",
         "input_cost_per_token": 6.5e-07,
         "litellm_provider": "together_ai",
         "max_input_tokens": 256000,
@@ -37926,6 +37929,7 @@
         "supports_tool_choice": true
     },
     "together_ai/Qwen/Qwen3-235B-A22B-fp8-tput": {
+        "deprecation_date": "2026-02-06",
         "input_cost_per_token": 2e-07,
         "litellm_provider": "together_ai",
         "max_input_tokens": 40000,
@@ -37937,6 +37941,7 @@
         "supports_tool_choice": false
     },
     "together_ai/Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8": {
+        "deprecation_date": "2026-06-04",
         "input_cost_per_token": 2e-06,
         "litellm_provider": "together_ai",
         "max_input_tokens": 256000,
@@ -37949,11 +37954,15 @@
         "supports_tool_choice": true
     },
     "together_ai/deepseek-ai/DeepSeek-R1": {
+        "deprecation_date": "2026-05-14",
         "input_cost_per_token": 3e-06,
         "litellm_provider": "together_ai",
         "max_input_tokens": 128000,
         "max_output_tokens": 20480,
         "max_tokens": 20480,
+        "metadata": {
+            "successor": "together_ai/deepseek-ai/DeepSeek-V4-Pro"
+        },
         "mode": "chat",
         "output_cost_per_token": 7e-06,
         "supports_function_calling": true,
@@ -37962,6 +37971,7 @@
         "supports_tool_choice": true
     },
     "together_ai/deepseek-ai/DeepSeek-R1-0528-tput": {
+        "deprecation_date": "2026-02-03",
         "input_cost_per_token": 5.5e-07,
         "litellm_provider": "together_ai",
         "max_input_tokens": 128000,
@@ -37979,6 +37989,9 @@
         "max_input_tokens": 65536,
         "max_output_tokens": 8192,
         "max_tokens": 8192,
+        "metadata": {
+            "successor": "together_ai/deepseek-ai/DeepSeek-V4-Pro"
+        },
         "mode": "chat",
         "output_cost_per_token": 1.25e-06,
         "supports_function_calling": true,
@@ -37987,9 +38000,13 @@
         "supports_tool_choice": true
     },
     "together_ai/deepseek-ai/DeepSeek-V3.1": {
+        "deprecation_date": "2026-05-14",
         "input_cost_per_token": 6e-07,
         "litellm_provider": "together_ai",
         "max_tokens": 16384,
+        "metadata": {
+            "successor": "together_ai/deepseek-ai/DeepSeek-V4-Pro"
+        },
         "mode": "chat",
         "output_cost_per_token": 1.7e-06,
         "source": "https://www.together.ai/models/deepseek-v3-1",
@@ -38001,6 +38018,7 @@
         "max_output_tokens": 16384
     },
     "together_ai/meta-llama/Llama-3.2-3B-Instruct-Turbo": {
+        "deprecation_date": "2026-03-06",
         "litellm_provider": "together_ai",
         "mode": "chat",
         "supports_function_calling": true,
@@ -38009,16 +38027,21 @@
         "supports_tool_choice": true
     },
     "together_ai/meta-llama/Llama-3.3-70B-Instruct-Turbo": {
-        "input_cost_per_token": 8.8e-07,
+        "input_cost_per_token": 1.04e-06,
         "litellm_provider": "together_ai",
+        "max_input_tokens": 131072,
+        "max_output_tokens": 131072,
+        "max_tokens": 131072,
         "mode": "chat",
-        "output_cost_per_token": 8.8e-07,
+        "output_cost_per_token": 1.04e-06,
+        "source": "https://docs.together.ai/docs/serverless-models",
         "supports_function_calling": true,
         "supports_parallel_function_calling": true,
         "supports_response_schema": true,
         "supports_tool_choice": true
     },
     "together_ai/meta-llama/Llama-3.3-70B-Instruct-Turbo-Free": {
+        "deprecation_date": "2025-11-13",
         "input_cost_per_token": 0,
         "litellm_provider": "together_ai",
         "mode": "chat",
@@ -38029,6 +38052,7 @@
         "supports_tool_choice": true
     },
     "together_ai/meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8": {
+        "deprecation_date": "2026-03-31",
         "input_cost_per_token": 2.7e-07,
         "litellm_provider": "together_ai",
         "mode": "chat",
@@ -38039,6 +38063,7 @@
         "supports_tool_choice": true
     },
     "together_ai/meta-llama/Llama-4-Scout-17B-16E-Instruct": {
+        "deprecation_date": "2026-02-06",
         "input_cost_per_token": 1.8e-07,
         "litellm_provider": "together_ai",
         "mode": "chat",
@@ -38049,6 +38074,7 @@
         "supports_tool_choice": true
     },
     "together_ai/meta-llama/Meta-Llama-3.1-405B-Instruct-Turbo": {
+        "deprecation_date": "2026-02-06",
         "input_cost_per_token": 3.5e-06,
         "litellm_provider": "together_ai",
         "mode": "chat",
@@ -38059,6 +38085,7 @@
         "supports_tool_choice": true
     },
     "together_ai/meta-llama/Meta-Llama-3.1-70B-Instruct-Turbo": {
+        "deprecation_date": "2026-02-25",
         "input_cost_per_token": 8.8e-07,
         "litellm_provider": "together_ai",
         "mode": "chat",
@@ -38069,6 +38096,7 @@
         "supports_tool_choice": true
     },
     "together_ai/meta-llama/Meta-Llama-3.1-8B-Instruct-Turbo": {
+        "deprecation_date": "2026-03-06",
         "input_cost_per_token": 1.8e-07,
         "litellm_provider": "together_ai",
         "mode": "chat",
@@ -38079,6 +38107,7 @@
         "supports_tool_choice": true
     },
     "together_ai/mistralai/Mistral-7B-Instruct-v0.1": {
+        "deprecation_date": "2025-11-13",
         "litellm_provider": "together_ai",
         "mode": "chat",
         "supports_function_calling": true,
@@ -38087,6 +38116,7 @@
         "supports_tool_choice": true
     },
     "together_ai/mistralai/Mistral-Small-24B-Instruct-2501": {
+        "deprecation_date": "2026-04-02",
         "litellm_provider": "together_ai",
         "mode": "chat",
         "supports_function_calling": true,
@@ -38094,6 +38124,7 @@
         "supports_tool_choice": true
     },
     "together_ai/mistralai/Mixtral-8x7B-Instruct-v0.1": {
+        "deprecation_date": "2026-04-16",
         "input_cost_per_token": 6e-07,
         "litellm_provider": "together_ai",
         "mode": "chat",
@@ -38106,6 +38137,9 @@
     "together_ai/moonshotai/Kimi-K2-Instruct": {
         "input_cost_per_token": 1e-06,
         "litellm_provider": "together_ai",
+        "metadata": {
+            "successor": "together_ai/moonshotai/Kimi-K3"
+        },
         "mode": "chat",
         "output_cost_per_token": 3e-06,
         "source": "https://www.together.ai/models/kimi-k2-instruct",
@@ -38149,6 +38183,7 @@
         "supports_tool_choice": true
     },
     "together_ai/zai-org/GLM-4.5-Air-FP8": {
+        "deprecation_date": "2026-04-02",
         "input_cost_per_token": 2e-07,
         "litellm_provider": "together_ai",
         "max_input_tokens": 128000,
@@ -38166,6 +38201,9 @@
         "max_input_tokens": 200000,
         "max_output_tokens": 200000,
         "max_tokens": 200000,
+        "metadata": {
+            "successor": "together_ai/zai-org/GLM-5.2"
+        },
         "mode": "chat",
         "output_cost_per_token": 2.2e-06,
         "source": "https://www.together.ai/models/glm-4-6",
@@ -38175,11 +38213,15 @@
         "supports_tool_choice": true
     },
     "together_ai/zai-org/GLM-4.7": {
+        "deprecation_date": "2026-04-02",
         "input_cost_per_token": 4.5e-07,
         "litellm_provider": "together_ai",
         "max_input_tokens": 200000,
         "max_output_tokens": 200000,
         "max_tokens": 200000,
+        "metadata": {
+            "successor": "together_ai/zai-org/GLM-5.2"
+        },
         "mode": "chat",
         "output_cost_per_token": 2e-06,
         "source": "https://www.together.ai/models/glm-4-7",
@@ -38189,11 +38231,15 @@
         "supports_tool_choice": true
     },
     "together_ai/moonshotai/Kimi-K2.5": {
+        "deprecation_date": "2026-05-21",
         "input_cost_per_token": 5e-07,
         "litellm_provider": "together_ai",
         "max_input_tokens": 256000,
         "max_output_tokens": 256000,
         "max_tokens": 256000,
+        "metadata": {
+            "successor": "together_ai/moonshotai/Kimi-K3"
+        },
         "mode": "chat",
         "output_cost_per_token": 2.8e-06,
         "source": "https://www.together.ai/models/kimi-k2-5",
@@ -38203,9 +38249,13 @@
         "supports_reasoning": true
     },
     "together_ai/moonshotai/Kimi-K2-Instruct-0905": {
+        "deprecation_date": "2026-03-06",
         "input_cost_per_token": 1e-06,
         "litellm_provider": "together_ai",
         "max_input_tokens": 262144,
+        "metadata": {
+            "successor": "together_ai/moonshotai/Kimi-K3"
+        },
         "mode": "chat",
         "output_cost_per_token": 3e-06,
         "source": "https://www.together.ai/models/kimi-k2-0905",
@@ -38214,9 +38264,13 @@
         "supports_tool_choice": true
     },
     "together_ai/Qwen/Qwen3-Next-80B-A3B-Instruct": {
+        "deprecation_date": "2026-04-02",
         "input_cost_per_token": 1.5e-07,
         "litellm_provider": "together_ai",
         "max_input_tokens": 262144,
+        "metadata": {
+            "successor": "together_ai/Qwen/Qwen3.7-Plus"
+        },
         "mode": "chat",
         "output_cost_per_token": 1.5e-06,
         "source": "https://www.together.ai/models/qwen3-next-80b-a3b-instruct",
@@ -38226,9 +38280,13 @@
         "supports_tool_choice": true
     },
     "together_ai/Qwen/Qwen3-Next-80B-A3B-Thinking": {
+        "deprecation_date": "2026-02-25",
         "input_cost_per_token": 1.5e-07,
         "litellm_provider": "together_ai",
         "max_input_tokens": 262144,
+        "metadata": {
+            "successor": "together_ai/Qwen/Qwen3.6-Plus"
+        },
         "mode": "chat",
         "output_cost_per_token": 1.5e-06,
         "source": "https://www.together.ai/models/qwen3-next-80b-a3b-thinking",
@@ -38238,6 +38296,7 @@
         "supports_tool_choice": true
     },
     "together_ai/Qwen/Qwen3.5-397B-A17B": {
+        "deprecation_date": "2026-06-29",
         "input_cost_per_token": 6e-07,
         "litellm_provider": "together_ai",
         "max_input_tokens": 262144,
@@ -38246,6 +38305,292 @@
         "source": "https://www.together.ai/models/Qwen/Qwen3.5-397B-A17B",
         "supports_function_calling": true,
         "supports_parallel_function_calling": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true
+    },
+    "together_ai/MiniMaxAI/MiniMax-M3": {
+        "input_cost_per_token": 3e-07,
+        "litellm_provider": "together_ai",
+        "max_input_tokens": 524288,
+        "max_output_tokens": 524288,
+        "max_tokens": 524288,
+        "mode": "chat",
+        "output_cost_per_token": 1.2e-06,
+        "source": "https://docs.together.ai/docs/serverless-models",
+        "supports_function_calling": true,
+        "supports_parallel_function_calling": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true,
+        "supports_vision": true
+    },
+    "together_ai/Prism-ML/Ternary-Bonsai-27B": {
+        "input_cost_per_token": 0.0,
+        "litellm_provider": "together_ai",
+        "max_input_tokens": 262144,
+        "max_output_tokens": 262144,
+        "max_tokens": 262144,
+        "mode": "chat",
+        "output_cost_per_token": 0.0,
+        "source": "https://docs.together.ai/docs/serverless-models"
+    },
+    "together_ai/Qwen/Qwen3.5-9B": {
+        "input_cost_per_token": 1.7e-07,
+        "litellm_provider": "together_ai",
+        "max_input_tokens": 262144,
+        "max_output_tokens": 262144,
+        "max_tokens": 262144,
+        "mode": "chat",
+        "output_cost_per_token": 2.5e-07,
+        "source": "https://docs.together.ai/docs/serverless-models",
+        "supports_function_calling": true,
+        "supports_parallel_function_calling": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true,
+        "supports_vision": true
+    },
+    "together_ai/Qwen/Qwen3.6-Plus": {
+        "input_cost_per_token": 5e-07,
+        "litellm_provider": "together_ai",
+        "max_input_tokens": 1000000,
+        "max_output_tokens": 1000000,
+        "max_tokens": 1000000,
+        "mode": "chat",
+        "output_cost_per_token": 3e-06,
+        "source": "https://docs.together.ai/docs/serverless-models",
+        "supports_reasoning": true
+    },
+    "together_ai/Qwen/Qwen3.7-Max": {
+        "input_cost_per_token": 1.25e-06,
+        "litellm_provider": "together_ai",
+        "max_input_tokens": 1000000,
+        "max_output_tokens": 1000000,
+        "max_tokens": 1000000,
+        "mode": "chat",
+        "output_cost_per_token": 3.75e-06,
+        "source": "https://docs.together.ai/docs/serverless-models"
+    },
+    "together_ai/Qwen/Qwen3.7-Plus": {
+        "input_cost_per_token": 3.2e-07,
+        "litellm_provider": "together_ai",
+        "max_input_tokens": 1000000,
+        "max_output_tokens": 1000000,
+        "max_tokens": 1000000,
+        "mode": "chat",
+        "output_cost_per_token": 1.28e-06,
+        "source": "https://docs.together.ai/docs/serverless-models"
+    },
+    "together_ai/Qwen/Qwen3.8-2.4T-A95B": {
+        "input_cost_per_token": 2.5e-06,
+        "litellm_provider": "together_ai",
+        "max_input_tokens": 1010000,
+        "max_output_tokens": 1010000,
+        "max_tokens": 1010000,
+        "mode": "chat",
+        "output_cost_per_token": 6.25e-06,
+        "source": "https://docs.together.ai/docs/serverless-models"
+    },
+    "together_ai/arize-ai/qwen-2-1.5b-instruct": {
+        "input_cost_per_token": 1e-07,
+        "litellm_provider": "together_ai",
+        "max_input_tokens": 32768,
+        "max_output_tokens": 32768,
+        "max_tokens": 32768,
+        "mode": "chat",
+        "output_cost_per_token": 1e-07,
+        "source": "https://docs.together.ai/docs/serverless-models"
+    },
+    "together_ai/deepseek-ai/DeepSeek-V4-Flash-0731": {
+        "input_cost_per_token": 1.4e-07,
+        "litellm_provider": "together_ai",
+        "max_input_tokens": 1048576,
+        "max_output_tokens": 1048576,
+        "max_tokens": 1048576,
+        "mode": "chat",
+        "output_cost_per_token": 2.8e-07,
+        "source": "https://docs.together.ai/docs/serverless-models",
+        "supports_function_calling": true,
+        "supports_parallel_function_calling": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true
+    },
+    "together_ai/deepseek-ai/DeepSeek-V4-Pro": {
+        "input_cost_per_token": 1.74e-06,
+        "litellm_provider": "together_ai",
+        "max_input_tokens": 512000,
+        "max_output_tokens": 512000,
+        "max_tokens": 512000,
+        "mode": "chat",
+        "output_cost_per_token": 3.48e-06,
+        "source": "https://docs.together.ai/docs/serverless-models",
+        "supports_function_calling": true,
+        "supports_parallel_function_calling": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true
+    },
+    "together_ai/deepseek-ai/DeepSeek-V4-Pro-0813": {
+        "input_cost_per_token": 1.32e-06,
+        "litellm_provider": "together_ai",
+        "max_input_tokens": 1048576,
+        "max_output_tokens": 1048576,
+        "max_tokens": 1048576,
+        "mode": "chat",
+        "output_cost_per_token": 3.96e-06,
+        "source": "https://docs.together.ai/docs/serverless-models",
+        "supports_function_calling": true,
+        "supports_parallel_function_calling": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true
+    },
+    "together_ai/google/gemma-3n-E4B-it": {
+        "input_cost_per_token": 6e-08,
+        "litellm_provider": "together_ai",
+        "max_input_tokens": 32768,
+        "max_output_tokens": 32768,
+        "max_tokens": 32768,
+        "mode": "chat",
+        "output_cost_per_token": 1.2e-07,
+        "source": "https://docs.together.ai/docs/serverless-models"
+    },
+    "together_ai/google/gemma-4-31B-it": {
+        "input_cost_per_token": 3.9e-07,
+        "litellm_provider": "together_ai",
+        "max_input_tokens": 262144,
+        "max_output_tokens": 262144,
+        "max_tokens": 262144,
+        "mode": "chat",
+        "output_cost_per_token": 9.7e-07,
+        "source": "https://docs.together.ai/docs/serverless-models",
+        "supports_function_calling": true,
+        "supports_parallel_function_calling": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true,
+        "supports_vision": true
+    },
+    "together_ai/intfloat/multilingual-e5-large-instruct": {
+        "input_cost_per_token": 2e-08,
+        "litellm_provider": "together_ai",
+        "max_input_tokens": 514,
+        "max_tokens": 514,
+        "mode": "embedding",
+        "output_cost_per_token": 2e-08,
+        "output_vector_size": 1024,
+        "source": "https://docs.together.ai/docs/serverless-models"
+    },
+    "together_ai/meta-llama/Llama-Guard-4-12B": {
+        "input_cost_per_token": 2e-07,
+        "litellm_provider": "together_ai",
+        "max_input_tokens": 1048576,
+        "max_output_tokens": 1048576,
+        "max_tokens": 1048576,
+        "mode": "chat",
+        "output_cost_per_token": 2e-07,
+        "source": "https://docs.together.ai/docs/serverless-models"
+    },
+    "together_ai/meta-models/Muse-Glimmer-30B": {
+        "input_cost_per_token": 3.5e-07,
+        "litellm_provider": "together_ai",
+        "max_input_tokens": 131072,
+        "max_output_tokens": 131072,
+        "max_tokens": 131072,
+        "mode": "chat",
+        "output_cost_per_token": 1.5e-06,
+        "source": "https://docs.together.ai/docs/serverless-models"
+    },
+    "together_ai/moonshotai/Kimi-K2.7-Code": {
+        "input_cost_per_token": 9.5e-07,
+        "litellm_provider": "together_ai",
+        "max_input_tokens": 262144,
+        "max_output_tokens": 262144,
+        "max_tokens": 262144,
+        "mode": "chat",
+        "output_cost_per_token": 4e-06,
+        "source": "https://docs.together.ai/docs/serverless-models",
+        "supports_function_calling": true,
+        "supports_parallel_function_calling": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true,
+        "supports_vision": true
+    },
+    "together_ai/moonshotai/Kimi-K3": {
+        "input_cost_per_token": 3e-06,
+        "litellm_provider": "together_ai",
+        "max_input_tokens": 1048576,
+        "max_output_tokens": 1048576,
+        "max_tokens": 1048576,
+        "mode": "chat",
+        "output_cost_per_token": 1.5e-05,
+        "source": "https://docs.together.ai/docs/serverless-models",
+        "supports_function_calling": true,
+        "supports_parallel_function_calling": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true,
+        "supports_vision": true
+    },
+    "together_ai/nvidia/nemotron-3-ultra-550b-a55b": {
+        "input_cost_per_token": 6e-07,
+        "litellm_provider": "together_ai",
+        "max_input_tokens": 512288,
+        "max_output_tokens": 512288,
+        "max_tokens": 512288,
+        "mode": "chat",
+        "output_cost_per_token": 3.6e-06,
+        "source": "https://docs.together.ai/docs/serverless-models",
+        "supports_function_calling": true,
+        "supports_parallel_function_calling": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true
+    },
+    "together_ai/pearl-ai/gemma-4-31b-it": {
+        "input_cost_per_token": 2.8e-07,
+        "litellm_provider": "together_ai",
+        "max_input_tokens": 262144,
+        "max_output_tokens": 262144,
+        "max_tokens": 262144,
+        "mode": "chat",
+        "output_cost_per_token": 8.6e-07,
+        "source": "https://docs.together.ai/docs/serverless-models"
+    },
+    "together_ai/thinkingmachines/Inkling": {
+        "input_cost_per_token": 1e-06,
+        "litellm_provider": "together_ai",
+        "max_input_tokens": 524288,
+        "max_output_tokens": 524288,
+        "max_tokens": 524288,
+        "mode": "chat",
+        "output_cost_per_token": 4.05e-06,
+        "source": "https://docs.together.ai/docs/serverless-models",
+        "supports_function_calling": true,
+        "supports_parallel_function_calling": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true
+    },
+    "together_ai/thinkingmachines/Inkling-Small": {
+        "input_cost_per_token": 5e-07,
+        "litellm_provider": "together_ai",
+        "max_input_tokens": 524288,
+        "max_output_tokens": 524288,
+        "max_tokens": 524288,
+        "mode": "chat",
+        "output_cost_per_token": 1.2e-06,
+        "source": "https://docs.together.ai/docs/serverless-models"
+    },
+    "together_ai/zai-org/GLM-5.2": {
+        "input_cost_per_token": 1.4e-06,
+        "litellm_provider": "together_ai",
+        "max_input_tokens": 1048575,
+        "max_output_tokens": 1048575,
+        "max_tokens": 1048575,
+        "mode": "chat",
+        "output_cost_per_token": 4.4e-06,
+        "source": "https://docs.together.ai/docs/serverless-models",
+        "supports_function_calling": true,
+        "supports_parallel_function_calling": true,
+        "supports_reasoning": true,
         "supports_response_schema": true,
         "supports_tool_choice": true
     },

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -37886,6 +37886,7 @@
         "output_cost_per_token": 1e-07
     },
     "together_ai/Qwen/Qwen2.5-72B-Instruct-Turbo": {
+        "deprecation_date": "2026-02-06",
         "litellm_provider": "together_ai",
         "mode": "chat",
         "supports_function_calling": true,
@@ -37902,6 +37903,7 @@
         "supports_tool_choice": true
     },
     "together_ai/Qwen/Qwen3-235B-A22B-Instruct-2507-tput": {
+        "deprecation_date": "2026-07-10",
         "input_cost_per_token": 2e-07,
         "litellm_provider": "together_ai",
         "max_input_tokens": 262000,
@@ -37914,6 +37916,7 @@
         "supports_tool_choice": true
     },
     "together_ai/Qwen/Qwen3-235B-A22B-Thinking-2507": {
+        "deprecation_date": "2026-04-16",
         "input_cost_per_token": 6.5e-07,
         "litellm_provider": "together_ai",
         "max_input_tokens": 256000,
@@ -37926,6 +37929,7 @@
         "supports_tool_choice": true
     },
     "together_ai/Qwen/Qwen3-235B-A22B-fp8-tput": {
+        "deprecation_date": "2026-02-06",
         "input_cost_per_token": 2e-07,
         "litellm_provider": "together_ai",
         "max_input_tokens": 40000,
@@ -37937,6 +37941,7 @@
         "supports_tool_choice": false
     },
     "together_ai/Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8": {
+        "deprecation_date": "2026-06-04",
         "input_cost_per_token": 2e-06,
         "litellm_provider": "together_ai",
         "max_input_tokens": 256000,
@@ -37949,11 +37954,15 @@
         "supports_tool_choice": true
     },
     "together_ai/deepseek-ai/DeepSeek-R1": {
+        "deprecation_date": "2026-05-14",
         "input_cost_per_token": 3e-06,
         "litellm_provider": "together_ai",
         "max_input_tokens": 128000,
         "max_output_tokens": 20480,
         "max_tokens": 20480,
+        "metadata": {
+            "successor": "together_ai/deepseek-ai/DeepSeek-V4-Pro"
+        },
         "mode": "chat",
         "output_cost_per_token": 7e-06,
         "supports_function_calling": true,
@@ -37962,6 +37971,7 @@
         "supports_tool_choice": true
     },
     "together_ai/deepseek-ai/DeepSeek-R1-0528-tput": {
+        "deprecation_date": "2026-02-03",
         "input_cost_per_token": 5.5e-07,
         "litellm_provider": "together_ai",
         "max_input_tokens": 128000,
@@ -37979,6 +37989,9 @@
         "max_input_tokens": 65536,
         "max_output_tokens": 8192,
         "max_tokens": 8192,
+        "metadata": {
+            "successor": "together_ai/deepseek-ai/DeepSeek-V4-Pro"
+        },
         "mode": "chat",
         "output_cost_per_token": 1.25e-06,
         "supports_function_calling": true,
@@ -37987,9 +38000,13 @@
         "supports_tool_choice": true
     },
     "together_ai/deepseek-ai/DeepSeek-V3.1": {
+        "deprecation_date": "2026-05-14",
         "input_cost_per_token": 6e-07,
         "litellm_provider": "together_ai",
         "max_tokens": 16384,
+        "metadata": {
+            "successor": "together_ai/deepseek-ai/DeepSeek-V4-Pro"
+        },
         "mode": "chat",
         "output_cost_per_token": 1.7e-06,
         "source": "https://www.together.ai/models/deepseek-v3-1",
@@ -38001,6 +38018,7 @@
         "max_output_tokens": 16384
     },
     "together_ai/meta-llama/Llama-3.2-3B-Instruct-Turbo": {
+        "deprecation_date": "2026-03-06",
         "litellm_provider": "together_ai",
         "mode": "chat",
         "supports_function_calling": true,
@@ -38009,16 +38027,21 @@
         "supports_tool_choice": true
     },
     "together_ai/meta-llama/Llama-3.3-70B-Instruct-Turbo": {
-        "input_cost_per_token": 8.8e-07,
+        "input_cost_per_token": 1.04e-06,
         "litellm_provider": "together_ai",
+        "max_input_tokens": 131072,
+        "max_output_tokens": 131072,
+        "max_tokens": 131072,
         "mode": "chat",
-        "output_cost_per_token": 8.8e-07,
+        "output_cost_per_token": 1.04e-06,
+        "source": "https://docs.together.ai/docs/serverless-models",
         "supports_function_calling": true,
         "supports_parallel_function_calling": true,
         "supports_response_schema": true,
         "supports_tool_choice": true
     },
     "together_ai/meta-llama/Llama-3.3-70B-Instruct-Turbo-Free": {
+        "deprecation_date": "2025-11-13",
         "input_cost_per_token": 0,
         "litellm_provider": "together_ai",
         "mode": "chat",
@@ -38029,6 +38052,7 @@
         "supports_tool_choice": true
     },
     "together_ai/meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8": {
+        "deprecation_date": "2026-03-31",
         "input_cost_per_token": 2.7e-07,
         "litellm_provider": "together_ai",
         "mode": "chat",
@@ -38039,6 +38063,7 @@
         "supports_tool_choice": true
     },
     "together_ai/meta-llama/Llama-4-Scout-17B-16E-Instruct": {
+        "deprecation_date": "2026-02-06",
         "input_cost_per_token": 1.8e-07,
         "litellm_provider": "together_ai",
         "mode": "chat",
@@ -38049,6 +38074,7 @@
         "supports_tool_choice": true
     },
     "together_ai/meta-llama/Meta-Llama-3.1-405B-Instruct-Turbo": {
+        "deprecation_date": "2026-02-06",
         "input_cost_per_token": 3.5e-06,
         "litellm_provider": "together_ai",
         "mode": "chat",
@@ -38059,6 +38085,7 @@
         "supports_tool_choice": true
     },
     "together_ai/meta-llama/Meta-Llama-3.1-70B-Instruct-Turbo": {
+        "deprecation_date": "2026-02-25",
         "input_cost_per_token": 8.8e-07,
         "litellm_provider": "together_ai",
         "mode": "chat",
@@ -38069,6 +38096,7 @@
         "supports_tool_choice": true
     },
     "together_ai/meta-llama/Meta-Llama-3.1-8B-Instruct-Turbo": {
+        "deprecation_date": "2026-03-06",
         "input_cost_per_token": 1.8e-07,
         "litellm_provider": "together_ai",
         "mode": "chat",
@@ -38079,6 +38107,7 @@
         "supports_tool_choice": true
     },
     "together_ai/mistralai/Mistral-7B-Instruct-v0.1": {
+        "deprecation_date": "2025-11-13",
         "litellm_provider": "together_ai",
         "mode": "chat",
         "supports_function_calling": true,
@@ -38087,6 +38116,7 @@
         "supports_tool_choice": true
     },
     "together_ai/mistralai/Mistral-Small-24B-Instruct-2501": {
+        "deprecation_date": "2026-04-02",
         "litellm_provider": "together_ai",
         "mode": "chat",
         "supports_function_calling": true,
@@ -38094,6 +38124,7 @@
         "supports_tool_choice": true
     },
     "together_ai/mistralai/Mixtral-8x7B-Instruct-v0.1": {
+        "deprecation_date": "2026-04-16",
         "input_cost_per_token": 6e-07,
         "litellm_provider": "together_ai",
         "mode": "chat",
@@ -38106,6 +38137,9 @@
     "together_ai/moonshotai/Kimi-K2-Instruct": {
         "input_cost_per_token": 1e-06,
         "litellm_provider": "together_ai",
+        "metadata": {
+            "successor": "together_ai/moonshotai/Kimi-K3"
+        },
         "mode": "chat",
         "output_cost_per_token": 3e-06,
         "source": "https://www.together.ai/models/kimi-k2-instruct",
@@ -38149,6 +38183,7 @@
         "supports_tool_choice": true
     },
     "together_ai/zai-org/GLM-4.5-Air-FP8": {
+        "deprecation_date": "2026-04-02",
         "input_cost_per_token": 2e-07,
         "litellm_provider": "together_ai",
         "max_input_tokens": 128000,
@@ -38166,6 +38201,9 @@
         "max_input_tokens": 200000,
         "max_output_tokens": 200000,
         "max_tokens": 200000,
+        "metadata": {
+            "successor": "together_ai/zai-org/GLM-5.2"
+        },
         "mode": "chat",
         "output_cost_per_token": 2.2e-06,
         "source": "https://www.together.ai/models/glm-4-6",
@@ -38175,11 +38213,15 @@
         "supports_tool_choice": true
     },
     "together_ai/zai-org/GLM-4.7": {
+        "deprecation_date": "2026-04-02",
         "input_cost_per_token": 4.5e-07,
         "litellm_provider": "together_ai",
         "max_input_tokens": 200000,
         "max_output_tokens": 200000,
         "max_tokens": 200000,
+        "metadata": {
+            "successor": "together_ai/zai-org/GLM-5.2"
+        },
         "mode": "chat",
         "output_cost_per_token": 2e-06,
         "source": "https://www.together.ai/models/glm-4-7",
@@ -38189,11 +38231,15 @@
         "supports_tool_choice": true
     },
     "together_ai/moonshotai/Kimi-K2.5": {
+        "deprecation_date": "2026-05-21",
         "input_cost_per_token": 5e-07,
         "litellm_provider": "together_ai",
         "max_input_tokens": 256000,
         "max_output_tokens": 256000,
         "max_tokens": 256000,
+        "metadata": {
+            "successor": "together_ai/moonshotai/Kimi-K3"
+        },
         "mode": "chat",
         "output_cost_per_token": 2.8e-06,
         "source": "https://www.together.ai/models/kimi-k2-5",
@@ -38203,9 +38249,13 @@
         "supports_reasoning": true
     },
     "together_ai/moonshotai/Kimi-K2-Instruct-0905": {
+        "deprecation_date": "2026-03-06",
         "input_cost_per_token": 1e-06,
         "litellm_provider": "together_ai",
         "max_input_tokens": 262144,
+        "metadata": {
+            "successor": "together_ai/moonshotai/Kimi-K3"
+        },
         "mode": "chat",
         "output_cost_per_token": 3e-06,
         "source": "https://www.together.ai/models/kimi-k2-0905",
@@ -38214,9 +38264,13 @@
         "supports_tool_choice": true
     },
     "together_ai/Qwen/Qwen3-Next-80B-A3B-Instruct": {
+        "deprecation_date": "2026-04-02",
         "input_cost_per_token": 1.5e-07,
         "litellm_provider": "together_ai",
         "max_input_tokens": 262144,
+        "metadata": {
+            "successor": "together_ai/Qwen/Qwen3.7-Plus"
+        },
         "mode": "chat",
         "output_cost_per_token": 1.5e-06,
         "source": "https://www.together.ai/models/qwen3-next-80b-a3b-instruct",
@@ -38226,9 +38280,13 @@
         "supports_tool_choice": true
     },
     "together_ai/Qwen/Qwen3-Next-80B-A3B-Thinking": {
+        "deprecation_date": "2026-02-25",
         "input_cost_per_token": 1.5e-07,
         "litellm_provider": "together_ai",
         "max_input_tokens": 262144,
+        "metadata": {
+            "successor": "together_ai/Qwen/Qwen3.6-Plus"
+        },
         "mode": "chat",
         "output_cost_per_token": 1.5e-06,
         "source": "https://www.together.ai/models/qwen3-next-80b-a3b-thinking",
@@ -38238,6 +38296,7 @@
         "supports_tool_choice": true
     },
     "together_ai/Qwen/Qwen3.5-397B-A17B": {
+        "deprecation_date": "2026-06-29",
         "input_cost_per_token": 6e-07,
         "litellm_provider": "together_ai",
         "max_input_tokens": 262144,
@@ -38246,6 +38305,292 @@
         "source": "https://www.together.ai/models/Qwen/Qwen3.5-397B-A17B",
         "supports_function_calling": true,
         "supports_parallel_function_calling": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true
+    },
+    "together_ai/MiniMaxAI/MiniMax-M3": {
+        "input_cost_per_token": 3e-07,
+        "litellm_provider": "together_ai",
+        "max_input_tokens": 524288,
+        "max_output_tokens": 524288,
+        "max_tokens": 524288,
+        "mode": "chat",
+        "output_cost_per_token": 1.2e-06,
+        "source": "https://docs.together.ai/docs/serverless-models",
+        "supports_function_calling": true,
+        "supports_parallel_function_calling": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true,
+        "supports_vision": true
+    },
+    "together_ai/Prism-ML/Ternary-Bonsai-27B": {
+        "input_cost_per_token": 0.0,
+        "litellm_provider": "together_ai",
+        "max_input_tokens": 262144,
+        "max_output_tokens": 262144,
+        "max_tokens": 262144,
+        "mode": "chat",
+        "output_cost_per_token": 0.0,
+        "source": "https://docs.together.ai/docs/serverless-models"
+    },
+    "together_ai/Qwen/Qwen3.5-9B": {
+        "input_cost_per_token": 1.7e-07,
+        "litellm_provider": "together_ai",
+        "max_input_tokens": 262144,
+        "max_output_tokens": 262144,
+        "max_tokens": 262144,
+        "mode": "chat",
+        "output_cost_per_token": 2.5e-07,
+        "source": "https://docs.together.ai/docs/serverless-models",
+        "supports_function_calling": true,
+        "supports_parallel_function_calling": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true,
+        "supports_vision": true
+    },
+    "together_ai/Qwen/Qwen3.6-Plus": {
+        "input_cost_per_token": 5e-07,
+        "litellm_provider": "together_ai",
+        "max_input_tokens": 1000000,
+        "max_output_tokens": 1000000,
+        "max_tokens": 1000000,
+        "mode": "chat",
+        "output_cost_per_token": 3e-06,
+        "source": "https://docs.together.ai/docs/serverless-models",
+        "supports_reasoning": true
+    },
+    "together_ai/Qwen/Qwen3.7-Max": {
+        "input_cost_per_token": 1.25e-06,
+        "litellm_provider": "together_ai",
+        "max_input_tokens": 1000000,
+        "max_output_tokens": 1000000,
+        "max_tokens": 1000000,
+        "mode": "chat",
+        "output_cost_per_token": 3.75e-06,
+        "source": "https://docs.together.ai/docs/serverless-models"
+    },
+    "together_ai/Qwen/Qwen3.7-Plus": {
+        "input_cost_per_token": 3.2e-07,
+        "litellm_provider": "together_ai",
+        "max_input_tokens": 1000000,
+        "max_output_tokens": 1000000,
+        "max_tokens": 1000000,
+        "mode": "chat",
+        "output_cost_per_token": 1.28e-06,
+        "source": "https://docs.together.ai/docs/serverless-models"
+    },
+    "together_ai/Qwen/Qwen3.8-2.4T-A95B": {
+        "input_cost_per_token": 2.5e-06,
+        "litellm_provider": "together_ai",
+        "max_input_tokens": 1010000,
+        "max_output_tokens": 1010000,
+        "max_tokens": 1010000,
+        "mode": "chat",
+        "output_cost_per_token": 6.25e-06,
+        "source": "https://docs.together.ai/docs/serverless-models"
+    },
+    "together_ai/arize-ai/qwen-2-1.5b-instruct": {
+        "input_cost_per_token": 1e-07,
+        "litellm_provider": "together_ai",
+        "max_input_tokens": 32768,
+        "max_output_tokens": 32768,
+        "max_tokens": 32768,
+        "mode": "chat",
+        "output_cost_per_token": 1e-07,
+        "source": "https://docs.together.ai/docs/serverless-models"
+    },
+    "together_ai/deepseek-ai/DeepSeek-V4-Flash-0731": {
+        "input_cost_per_token": 1.4e-07,
+        "litellm_provider": "together_ai",
+        "max_input_tokens": 1048576,
+        "max_output_tokens": 1048576,
+        "max_tokens": 1048576,
+        "mode": "chat",
+        "output_cost_per_token": 2.8e-07,
+        "source": "https://docs.together.ai/docs/serverless-models",
+        "supports_function_calling": true,
+        "supports_parallel_function_calling": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true
+    },
+    "together_ai/deepseek-ai/DeepSeek-V4-Pro": {
+        "input_cost_per_token": 1.74e-06,
+        "litellm_provider": "together_ai",
+        "max_input_tokens": 512000,
+        "max_output_tokens": 512000,
+        "max_tokens": 512000,
+        "mode": "chat",
+        "output_cost_per_token": 3.48e-06,
+        "source": "https://docs.together.ai/docs/serverless-models",
+        "supports_function_calling": true,
+        "supports_parallel_function_calling": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true
+    },
+    "together_ai/deepseek-ai/DeepSeek-V4-Pro-0813": {
+        "input_cost_per_token": 1.32e-06,
+        "litellm_provider": "together_ai",
+        "max_input_tokens": 1048576,
+        "max_output_tokens": 1048576,
+        "max_tokens": 1048576,
+        "mode": "chat",
+        "output_cost_per_token": 3.96e-06,
+        "source": "https://docs.together.ai/docs/serverless-models",
+        "supports_function_calling": true,
+        "supports_parallel_function_calling": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true
+    },
+    "together_ai/google/gemma-3n-E4B-it": {
+        "input_cost_per_token": 6e-08,
+        "litellm_provider": "together_ai",
+        "max_input_tokens": 32768,
+        "max_output_tokens": 32768,
+        "max_tokens": 32768,
+        "mode": "chat",
+        "output_cost_per_token": 1.2e-07,
+        "source": "https://docs.together.ai/docs/serverless-models"
+    },
+    "together_ai/google/gemma-4-31B-it": {
+        "input_cost_per_token": 3.9e-07,
+        "litellm_provider": "together_ai",
+        "max_input_tokens": 262144,
+        "max_output_tokens": 262144,
+        "max_tokens": 262144,
+        "mode": "chat",
+        "output_cost_per_token": 9.7e-07,
+        "source": "https://docs.together.ai/docs/serverless-models",
+        "supports_function_calling": true,
+        "supports_parallel_function_calling": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true,
+        "supports_vision": true
+    },
+    "together_ai/intfloat/multilingual-e5-large-instruct": {
+        "input_cost_per_token": 2e-08,
+        "litellm_provider": "together_ai",
+        "max_input_tokens": 514,
+        "max_tokens": 514,
+        "mode": "embedding",
+        "output_cost_per_token": 2e-08,
+        "output_vector_size": 1024,
+        "source": "https://docs.together.ai/docs/serverless-models"
+    },
+    "together_ai/meta-llama/Llama-Guard-4-12B": {
+        "input_cost_per_token": 2e-07,
+        "litellm_provider": "together_ai",
+        "max_input_tokens": 1048576,
+        "max_output_tokens": 1048576,
+        "max_tokens": 1048576,
+        "mode": "chat",
+        "output_cost_per_token": 2e-07,
+        "source": "https://docs.together.ai/docs/serverless-models"
+    },
+    "together_ai/meta-models/Muse-Glimmer-30B": {
+        "input_cost_per_token": 3.5e-07,
+        "litellm_provider": "together_ai",
+        "max_input_tokens": 131072,
+        "max_output_tokens": 131072,
+        "max_tokens": 131072,
+        "mode": "chat",
+        "output_cost_per_token": 1.5e-06,
+        "source": "https://docs.together.ai/docs/serverless-models"
+    },
+    "together_ai/moonshotai/Kimi-K2.7-Code": {
+        "input_cost_per_token": 9.5e-07,
+        "litellm_provider": "together_ai",
+        "max_input_tokens": 262144,
+        "max_output_tokens": 262144,
+        "max_tokens": 262144,
+        "mode": "chat",
+        "output_cost_per_token": 4e-06,
+        "source": "https://docs.together.ai/docs/serverless-models",
+        "supports_function_calling": true,
+        "supports_parallel_function_calling": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true,
+        "supports_vision": true
+    },
+    "together_ai/moonshotai/Kimi-K3": {
+        "input_cost_per_token": 3e-06,
+        "litellm_provider": "together_ai",
+        "max_input_tokens": 1048576,
+        "max_output_tokens": 1048576,
+        "max_tokens": 1048576,
+        "mode": "chat",
+        "output_cost_per_token": 1.5e-05,
+        "source": "https://docs.together.ai/docs/serverless-models",
+        "supports_function_calling": true,
+        "supports_parallel_function_calling": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true,
+        "supports_vision": true
+    },
+    "together_ai/nvidia/nemotron-3-ultra-550b-a55b": {
+        "input_cost_per_token": 6e-07,
+        "litellm_provider": "together_ai",
+        "max_input_tokens": 512288,
+        "max_output_tokens": 512288,
+        "max_tokens": 512288,
+        "mode": "chat",
+        "output_cost_per_token": 3.6e-06,
+        "source": "https://docs.together.ai/docs/serverless-models",
+        "supports_function_calling": true,
+        "supports_parallel_function_calling": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true
+    },
+    "together_ai/pearl-ai/gemma-4-31b-it": {
+        "input_cost_per_token": 2.8e-07,
+        "litellm_provider": "together_ai",
+        "max_input_tokens": 262144,
+        "max_output_tokens": 262144,
+        "max_tokens": 262144,
+        "mode": "chat",
+        "output_cost_per_token": 8.6e-07,
+        "source": "https://docs.together.ai/docs/serverless-models"
+    },
+    "together_ai/thinkingmachines/Inkling": {
+        "input_cost_per_token": 1e-06,
+        "litellm_provider": "together_ai",
+        "max_input_tokens": 524288,
+        "max_output_tokens": 524288,
+        "max_tokens": 524288,
+        "mode": "chat",
+        "output_cost_per_token": 4.05e-06,
+        "source": "https://docs.together.ai/docs/serverless-models",
+        "supports_function_calling": true,
+        "supports_parallel_function_calling": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true
+    },
+    "together_ai/thinkingmachines/Inkling-Small": {
+        "input_cost_per_token": 5e-07,
+        "litellm_provider": "together_ai",
+        "max_input_tokens": 524288,
+        "max_output_tokens": 524288,
+        "max_tokens": 524288,
+        "mode": "chat",
+        "output_cost_per_token": 1.2e-06,
+        "source": "https://docs.together.ai/docs/serverless-models"
+    },
+    "together_ai/zai-org/GLM-5.2": {
+        "input_cost_per_token": 1.4e-06,
+        "litellm_provider": "together_ai",
+        "max_input_tokens": 1048575,
+        "max_output_tokens": 1048575,
+        "max_tokens": 1048575,
+        "mode": "chat",
+        "output_cost_per_token": 4.4e-06,
+        "source": "https://docs.together.ai/docs/serverless-models",
+        "supports_function_calling": true,
+        "supports_parallel_function_calling": true,
+        "supports_reasoning": true,
         "supports_response_schema": true,
         "supports_tool_choice": true
     },

--- a/tests/test_litellm/test_together_ai_model_metadata.py
+++ b/tests/test_litellm/test_together_ai_model_metadata.py
@@ -3,10 +3,14 @@ from pathlib import Path
 from typing import Final
 
 import pytest
+from pydantic import TypeAdapter
 
 from litellm.litellm_core_utils.get_llm_provider_logic import get_llm_provider
 
 REPO_ROOT: Final = Path(__file__).parents[2]
+
+CostMap = dict[str, dict[str, object]]
+COST_MAP_ADAPTER: Final = TypeAdapter(CostMap)
 
 SERVERLESS_CHAT_MODELS: Final = (
     "together_ai/moonshotai/Kimi-K3",
@@ -66,13 +70,13 @@ DEPRECATED_MODELS: Final = {
 
 
 @pytest.fixture(scope="module")
-def cost_map() -> dict:
+def cost_map() -> CostMap:
     with open(REPO_ROOT / "model_prices_and_context_window.json") as f:
-        return json.load(f)
+        return COST_MAP_ADAPTER.validate_python(json.load(f))
 
 
 @pytest.mark.parametrize("model", SERVERLESS_CHAT_MODELS)
-def test_together_serverless_chat_model_is_mapped(cost_map: dict, model: str):
+def test_together_serverless_chat_model_is_mapped(cost_map: CostMap, model: str):
     info = cost_map.get(model)
     assert info is not None, f"{model} missing from model_prices_and_context_window.json"
     assert info["litellm_provider"] == "together_ai"
@@ -86,7 +90,7 @@ def test_together_serverless_chat_model_is_mapped(cost_map: dict, model: str):
     assert provider == "together_ai"
 
 
-def test_together_kimi_k3_pricing_and_capabilities(cost_map: dict):
+def test_together_kimi_k3_pricing_and_capabilities(cost_map: CostMap):
     info = cost_map["together_ai/moonshotai/Kimi-K3"]
     assert info["input_cost_per_token"] == 3e-06
     assert info["output_cost_per_token"] == 1.5e-05
@@ -98,7 +102,7 @@ def test_together_kimi_k3_pricing_and_capabilities(cost_map: dict):
     assert info["supports_reasoning"] is True
 
 
-def test_together_glm_52_pricing(cost_map: dict):
+def test_together_glm_52_pricing(cost_map: CostMap):
     info = cost_map["together_ai/zai-org/GLM-5.2"]
     assert info["input_cost_per_token"] == 1.4e-06
     assert info["output_cost_per_token"] == 4.4e-06
@@ -106,7 +110,7 @@ def test_together_glm_52_pricing(cost_map: dict):
     assert info["supports_reasoning"] is True
 
 
-def test_together_multilingual_e5_embedding_entry(cost_map: dict):
+def test_together_multilingual_e5_embedding_entry(cost_map: CostMap):
     info = cost_map["together_ai/intfloat/multilingual-e5-large-instruct"]
     assert info["mode"] == "embedding"
     assert info["input_cost_per_token"] == 2e-08
@@ -114,7 +118,7 @@ def test_together_multilingual_e5_embedding_entry(cost_map: dict):
     assert info["output_vector_size"] == 1024
 
 
-def test_together_llama_33_70b_repriced_to_current_together_rate(cost_map: dict):
+def test_together_llama_33_70b_repriced_to_current_together_rate(cost_map: CostMap):
     info = cost_map["together_ai/meta-llama/Llama-3.3-70B-Instruct-Turbo"]
     assert info["input_cost_per_token"] == 1.04e-06
     assert info["output_cost_per_token"] == 1.04e-06
@@ -122,17 +126,25 @@ def test_together_llama_33_70b_repriced_to_current_together_rate(cost_map: dict)
 
 
 @pytest.mark.parametrize("model", sorted(DEPRECATED_MODELS))
-def test_together_deprecated_model_carries_deprecation_date(cost_map: dict, model: str):
+def test_together_deprecated_model_carries_deprecation_date(cost_map: CostMap, model: str):
     info = cost_map.get(model)
     assert info is not None, f"{model} missing from model_prices_and_context_window.json"
     assert info.get("deprecation_date") == DEPRECATED_MODELS[model]
 
 
-def test_together_successor_metadata_points_at_live_models(cost_map: dict):
+def _successor(info: dict[str, object]) -> str | None:
+    metadata = info.get("metadata")
+    if not isinstance(metadata, dict):
+        return None
+    successor = metadata.get("successor")
+    return successor if isinstance(successor, str) else None
+
+
+def test_together_successor_metadata_points_at_live_models(cost_map: CostMap):
     successors = {
-        model: info["metadata"]["successor"]
+        model: successor
         for model, info in cost_map.items()
-        if model.startswith("together_ai/") and "successor" in info.get("metadata", {})
+        if model.startswith("together_ai/") and (successor := _successor(info)) is not None
     }
     assert len(successors) >= 10
     for model, successor in successors.items():
@@ -141,9 +153,9 @@ def test_together_successor_metadata_points_at_live_models(cost_map: dict):
         assert "deprecation_date" not in target, f"{model} names deprecated successor {successor}"
 
 
-def test_together_backup_cost_map_in_sync(cost_map: dict):
+def test_together_backup_cost_map_in_sync(cost_map: CostMap):
     with open(REPO_ROOT / "litellm" / "model_prices_and_context_window_backup.json") as f:
-        backup = json.load(f)
+        backup = COST_MAP_ADAPTER.validate_python(json.load(f))
     together_main = {k: v for k, v in cost_map.items() if k.startswith("together_ai/")}
     together_backup = {k: v for k, v in backup.items() if k.startswith("together_ai/")}
     assert together_backup == together_main

--- a/tests/test_litellm/test_together_ai_model_metadata.py
+++ b/tests/test_litellm/test_together_ai_model_metadata.py
@@ -1,0 +1,149 @@
+import json
+from pathlib import Path
+from typing import Final
+
+import pytest
+
+from litellm.litellm_core_utils.get_llm_provider_logic import get_llm_provider
+
+REPO_ROOT: Final = Path(__file__).parents[2]
+
+SERVERLESS_CHAT_MODELS: Final = (
+    "together_ai/moonshotai/Kimi-K3",
+    "together_ai/zai-org/GLM-5.2",
+    "together_ai/deepseek-ai/DeepSeek-V4-Pro",
+    "together_ai/deepseek-ai/DeepSeek-V4-Pro-0813",
+    "together_ai/deepseek-ai/DeepSeek-V4-Flash-0731",
+    "together_ai/moonshotai/Kimi-K2.7-Code",
+    "together_ai/MiniMaxAI/MiniMax-M3",
+    "together_ai/thinkingmachines/Inkling",
+    "together_ai/thinkingmachines/Inkling-Small",
+    "together_ai/Qwen/Qwen3.8-2.4T-A95B",
+    "together_ai/Qwen/Qwen3.7-Max",
+    "together_ai/Qwen/Qwen3.7-Plus",
+    "together_ai/Qwen/Qwen3.6-Plus",
+    "together_ai/Qwen/Qwen3.5-9B",
+    "together_ai/nvidia/nemotron-3-ultra-550b-a55b",
+    "together_ai/meta-models/Muse-Glimmer-30B",
+    "together_ai/google/gemma-4-31B-it",
+    "together_ai/pearl-ai/gemma-4-31b-it",
+    "together_ai/google/gemma-3n-E4B-it",
+    "together_ai/arize-ai/qwen-2-1.5b-instruct",
+    "together_ai/Prism-ML/Ternary-Bonsai-27B",
+    "together_ai/meta-llama/Llama-Guard-4-12B",
+    "together_ai/openai/gpt-oss-120b",
+    "together_ai/openai/gpt-oss-20b",
+    "together_ai/meta-llama/Llama-3.3-70B-Instruct-Turbo",
+)
+
+DEPRECATED_MODELS: Final = {
+    "together_ai/Qwen/Qwen3-235B-A22B-Instruct-2507-tput": "2026-07-10",
+    "together_ai/Qwen/Qwen3.5-397B-A17B": "2026-06-29",
+    "together_ai/Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8": "2026-06-04",
+    "together_ai/moonshotai/Kimi-K2.5": "2026-05-21",
+    "together_ai/deepseek-ai/DeepSeek-R1": "2026-05-14",
+    "together_ai/deepseek-ai/DeepSeek-V3.1": "2026-05-14",
+    "together_ai/Qwen/Qwen3-235B-A22B-Thinking-2507": "2026-04-16",
+    "together_ai/mistralai/Mixtral-8x7B-Instruct-v0.1": "2026-04-16",
+    "together_ai/zai-org/GLM-4.5-Air-FP8": "2026-04-02",
+    "together_ai/zai-org/GLM-4.7": "2026-04-02",
+    "together_ai/mistralai/Mistral-Small-24B-Instruct-2501": "2026-04-02",
+    "together_ai/Qwen/Qwen3-Next-80B-A3B-Instruct": "2026-04-02",
+    "together_ai/meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8": "2026-03-31",
+    "together_ai/meta-llama/Meta-Llama-3.1-8B-Instruct-Turbo": "2026-03-06",
+    "together_ai/moonshotai/Kimi-K2-Instruct-0905": "2026-03-06",
+    "together_ai/meta-llama/Llama-3.2-3B-Instruct-Turbo": "2026-03-06",
+    "together_ai/Qwen/Qwen3-Next-80B-A3B-Thinking": "2026-02-25",
+    "together_ai/meta-llama/Meta-Llama-3.1-70B-Instruct-Turbo": "2026-02-25",
+    "together_ai/Qwen/Qwen3-235B-A22B-fp8-tput": "2026-02-06",
+    "together_ai/meta-llama/Llama-4-Scout-17B-16E-Instruct": "2026-02-06",
+    "together_ai/Qwen/Qwen2.5-72B-Instruct-Turbo": "2026-02-06",
+    "together_ai/meta-llama/Meta-Llama-3.1-405B-Instruct-Turbo": "2026-02-06",
+    "together_ai/deepseek-ai/DeepSeek-R1-0528-tput": "2026-02-03",
+    "together_ai/mistralai/Mistral-7B-Instruct-v0.1": "2025-11-13",
+    "together_ai/meta-llama/Llama-3.3-70B-Instruct-Turbo-Free": "2025-11-13",
+}
+
+
+@pytest.fixture(scope="module")
+def cost_map() -> dict:
+    with open(REPO_ROOT / "model_prices_and_context_window.json") as f:
+        return json.load(f)
+
+
+@pytest.mark.parametrize("model", SERVERLESS_CHAT_MODELS)
+def test_together_serverless_chat_model_is_mapped(cost_map: dict, model: str):
+    info = cost_map.get(model)
+    assert info is not None, f"{model} missing from model_prices_and_context_window.json"
+    assert info["litellm_provider"] == "together_ai"
+    assert info["mode"] == "chat"
+    assert info["input_cost_per_token"] >= 0
+    assert info["output_cost_per_token"] >= info["input_cost_per_token"]
+    assert "deprecation_date" not in info
+
+    routed_model, provider, _, _ = get_llm_provider(model=model)
+    assert routed_model == model.removeprefix("together_ai/")
+    assert provider == "together_ai"
+
+
+def test_together_kimi_k3_pricing_and_capabilities(cost_map: dict):
+    info = cost_map["together_ai/moonshotai/Kimi-K3"]
+    assert info["input_cost_per_token"] == 3e-06
+    assert info["output_cost_per_token"] == 1.5e-05
+    assert info["max_input_tokens"] == 1048576
+    assert info["supports_function_calling"] is True
+    assert info["supports_tool_choice"] is True
+    assert info["supports_response_schema"] is True
+    assert info["supports_vision"] is True
+    assert info["supports_reasoning"] is True
+
+
+def test_together_glm_52_pricing(cost_map: dict):
+    info = cost_map["together_ai/zai-org/GLM-5.2"]
+    assert info["input_cost_per_token"] == 1.4e-06
+    assert info["output_cost_per_token"] == 4.4e-06
+    assert info["supports_function_calling"] is True
+    assert info["supports_reasoning"] is True
+
+
+def test_together_multilingual_e5_embedding_entry(cost_map: dict):
+    info = cost_map["together_ai/intfloat/multilingual-e5-large-instruct"]
+    assert info["mode"] == "embedding"
+    assert info["input_cost_per_token"] == 2e-08
+    assert info["max_input_tokens"] == 514
+    assert info["output_vector_size"] == 1024
+
+
+def test_together_llama_33_70b_repriced_to_current_together_rate(cost_map: dict):
+    info = cost_map["together_ai/meta-llama/Llama-3.3-70B-Instruct-Turbo"]
+    assert info["input_cost_per_token"] == 1.04e-06
+    assert info["output_cost_per_token"] == 1.04e-06
+    assert info["max_input_tokens"] == 131072
+
+
+@pytest.mark.parametrize("model", sorted(DEPRECATED_MODELS))
+def test_together_deprecated_model_carries_deprecation_date(cost_map: dict, model: str):
+    info = cost_map.get(model)
+    assert info is not None, f"{model} missing from model_prices_and_context_window.json"
+    assert info.get("deprecation_date") == DEPRECATED_MODELS[model]
+
+
+def test_together_successor_metadata_points_at_live_models(cost_map: dict):
+    successors = {
+        model: info["metadata"]["successor"]
+        for model, info in cost_map.items()
+        if model.startswith("together_ai/") and "successor" in info.get("metadata", {})
+    }
+    assert len(successors) >= 10
+    for model, successor in successors.items():
+        target = cost_map.get(successor)
+        assert target is not None, f"{model} names successor {successor} that is not in the map"
+        assert "deprecation_date" not in target, f"{model} names deprecated successor {successor}"
+
+
+def test_together_backup_cost_map_in_sync(cost_map: dict):
+    with open(REPO_ROOT / "litellm" / "model_prices_and_context_window_backup.json") as f:
+        backup = json.load(f)
+    together_main = {k: v for k, v in cost_map.items() if k.startswith("together_ai/")}
+    together_backup = {k: v for k, v in backup.items() if k.startswith("together_ai/")}
+    assert together_backup == together_main


### PR DESCRIPTION
## TLDR

Problem this solves:

- 21 live Together serverless chat models are missing from the cost map
- Calls to them succeed but track $0 spend and strip tools
- 25 delisted together_ai entries still look active

How it solves it:

- Backfills pricing, context windows, and capability flags from the live catalog
- Adds the multilingual-e5 embedding and Llama-Guard-4-12B entries
- Marks delisted entries with their documented `deprecation_date`
- Points superseded models at a live successor via `metadata`
- Reprices Llama-3.3-70B-Instruct-Turbo to Together's current rate

## User Flow

Before: a developer routing Kimi-K3 through the gateway gets real completions but the gateway tracks zero spend

1. The proxy admin adds `kimi-k3 -> together_ai/moonshotai/Kimi-K3` to the config and boots the proxy
2. The developer sends POST https://litellm-domain/v1/chat/completions with model `kimi-k3` and gets a 200 with a real Together completion (192 tokens billed by Together)
3. The response headers show `x-litellm-response-cost-input: 0.0` and `x-litellm-response-cost-output: 0`, with no `x-litellm-response-cost` header at all, so every spend surface records $0 for the call
4. The same request with `tools` fails with a 400 `litellm.UnsupportedParamsError: together_ai does not support parameters: ['tools']` because the capability lookup finds no entry for the model
5. GET https://litellm-domain/v1/model/info shows the deployment with no pricing and no capability flags

After: the same request comes back with a real cost and tools pass through

1. The proxy admin adds `kimi-k3 -> together_ai/moonshotai/Kimi-K3` to the config and boots the proxy
2. The developer sends the same POST https://litellm-domain/v1/chat/completions and gets a 200 with a real Together completion
3. The response headers now carry `x-litellm-response-cost` with the real dollar amount
4. The same request with `tools` reaches Together intact and the model can call them
5. GET https://litellm-domain/v1/model/info shows the deployment's pricing, context window, and capability flags

## Relevant issues

## Linear ticket

Resolves LIT-5968

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Both legs run the same live no-DB proxy recipe from a fresh bootstrapped worktree, hitting the real Together API: `LITELLM_LOCAL_MODEL_COST_MAP=True .venv/bin/python litellm/proxy/proxy_cli.py --config qa_config.yaml --port <port> --num_workers 2`, 2 uvicorn workers per leg, with this config (Before on port 40760, After on port 31581)

```yaml
model_list:
  - model_name: kimi-k3
    litellm_params:
      model: together_ai/moonshotai/Kimi-K3
      api_key: os.environ/TOGETHER_API_KEY
  - model_name: glm-5-2
    litellm_params:
      model: together_ai/zai-org/GLM-5.2
      api_key: os.environ/TOGETHER_API_KEY
  - model_name: e5-embed
    litellm_params:
      model: together_ai/intfloat/multilingual-e5-large-instruct
      api_key: os.environ/TOGETHER_API_KEY

general_settings:
  master_key: sk-lit5968-qa
```

### Before (9dff9cdd9a)

Completions succeed but every cost header is 0.0 with no top-level `x-litellm-response-cost` at all, tool calls are rejected with a 400, and model info has no pricing or capability flags

#### kimi-k3 chat completion + cost headers

1. Command and observed output:

    ```
    $ curl -sS -D /tmp/h1_40760.txt http://localhost:40760/v1/chat/completions -H 'Authorization: Bearer sk-lit5968-qa' -H 'Content-Type: application/json' -d '{"model": "kimi-k3", "messages": [{"role": "user", "content": "Say hello in exactly three words."}], "max_tokens": 100}' | head -c 400; echo; grep -i 'x-litellm-response-cost\|x-litellm-model-name' /tmp/h1_40760.txt
    {"id":"chatcmpl-01a039edf96379009b918c4c","created":1787678292,"model":"kimi-k3","object":"chat.completion","system_fingerprint":"default","choices":[{"finish_reason":"length","index":0,"message":{"content":"response","role":"assistant","reasoning_content":"The user wants me to say hello in exactly three words. Let me think of a greeting that is exactly three words.\n\nOptions:\n- \"Hello there, f
    x-litellm-model-name: together_ai/moonshotai/Kimi-K3
    x-litellm-response-cost-original: 0.0
    x-litellm-response-cost-discount-amount: 0.0
    x-litellm-response-cost-margin-amount: 0.0
    x-litellm-response-cost-margin-percent: 0.0
    x-litellm-response-cost-input: 0.0
    x-litellm-response-cost-output: 0
    x-litellm-response-cost-tool-usage: 0.0
    ```

#### glm-5-2 chat completion + cost headers

1. Command and observed output:

    ```
    $ curl -sS -D /tmp/h2_40760.txt http://localhost:40760/v1/chat/completions -H 'Authorization: Bearer sk-lit5968-qa' -H 'Content-Type: application/json' -d '{"model": "glm-5-2", "messages": [{"role": "user", "content": "Say hello in exactly three words."}], "max_tokens": 100}' | head -c 400; echo; grep -i 'x-litellm-response-cost\|x-litellm-model-name' /tmp/h2_40760.txt
    {"id":"edb73fbf-aws_uw1","created":1787678296,"model":"glm-5-2","object":"chat.completion","system_fingerprint":"default","choices":[{"finish_reason":"length","index":0,"message":{"role":"assistant","reasoning_content":"1.  **Analyze the Request:**\n    *   Task: Say hello.\n    *   Constraint: Exactly three words.\n\n2.  **Determine the appropriate response:**\n    *   Needs to be a greeting (\"h
    x-litellm-model-name: together_ai/zai-org/GLM-5.2
    x-litellm-response-cost-original: 0.0
    x-litellm-response-cost-discount-amount: 0.0
    x-litellm-response-cost-margin-amount: 0.0
    x-litellm-response-cost-margin-percent: 0.0
    x-litellm-response-cost-input: 0.0
    x-litellm-response-cost-output: 0
    x-litellm-response-cost-tool-usage: 0.0
    ```

#### kimi-k3 tool calling

1. Command and observed output:

    ```
    $ curl -sS http://localhost:40760/v1/chat/completions -H 'Authorization: Bearer sk-lit5968-qa' -H 'Content-Type: application/json' -d '{"model": "kimi-k3", "messages": [{"role": "user", "content": "What is the weather in San Francisco right now? Use the get_weather tool."}], "tools": [{"type": "function", "function": {"name": "get_weather", "description": "Get current weather for a city", "parameters": {"type": "object", "properties": {"city": {"type": "string"}}, "required": ["city"]}}}], "max_tokens": 2000}' | head -c 700
    {"error":{"message":"litellm.UnsupportedParamsError: together_ai does not support parameters: ['tools'], for model=moonshotai/Kimi-K3. To drop these, set `litellm.drop_params=True` or for proxy:\n\n`litellm_settings:\n drop_params: true`\n. \n If you want to use these params dynamically send allowed_openai_params=['tools'] in your request.. Received Model Group=kimi-k3\nAvailable Model Group Fallbacks=None","type":"None","param":null,"code":"400"}}
    ```

#### model info pricing for kimi-k3

1. Command and observed output:

    ```
    $ curl -sS 'http://localhost:40760/v1/model/info' -H 'Authorization: Bearer sk-lit5968-qa' | python3 -c 'import json, sys; models = json.load(sys.stdin)["data"]; info = next(model for model in models if model["model_name"] == "kimi-k3")["model_info"]; print(json.dumps({key: info.get(key) for key in ("input_cost_per_token", "output_cost_per_token", "max_input_tokens", "supports_function_calling", "supports_vision", "supports_reasoning")}, indent=2))'
    {
      "input_cost_per_token": 0,
      "output_cost_per_token": 0,
      "max_input_tokens": null,
      "supports_function_calling": null,
      "supports_vision": null,
      "supports_reasoning": null
    }
    ```

#### e5 embedding + cost headers

1. Command and observed output:

    ```
    $ curl -sS -D /tmp/h3_40760.txt http://localhost:40760/v1/embeddings -H 'Authorization: Bearer sk-lit5968-qa' -H 'Content-Type: application/json' -d '{"model": "e5-embed", "input": "hello world"}' | python3 -c 'import json, sys; r = json.load(sys.stdin); print("embedding dims:", len(r["data"][0]["embedding"]), "usage:", json.dumps(r["usage"]))'; grep -i 'x-litellm-response-cost\|x-litellm-model-name' /tmp/h3_40760.txt
    embedding dims: 1024 usage: {"completion_tokens": 0, "prompt_tokens": 5, "total_tokens": 5, "completion_tokens_details": null, "prompt_tokens_details": null}
    x-litellm-model-name: together_ai/intfloat/multilingual-e5-large-instruct
    x-litellm-response-cost-original: 0.0
    x-litellm-response-cost-discount-amount: 0.0
    x-litellm-response-cost-margin-amount: 0.0
    x-litellm-response-cost-margin-percent: 0.0
    x-litellm-response-cost-input: 0.0
    x-litellm-response-cost-output: 0
    x-litellm-response-cost-tool-usage: 0.0
    ```

### After (db8c49305e)

The same requests now return real costs (kimi-k3: 28 input tokens x $3/M + 100 output tokens x $15/M = $0.001584), tools pass through and the model calls them, model info shows the full entry, and the embedding call is priced

#### kimi-k3 chat completion + cost headers

1. Command and observed output:

    ```
    $ curl -sS -D /tmp/h1_31581.txt http://localhost:31581/v1/chat/completions -H 'Authorization: Bearer sk-lit5968-qa' -H 'Content-Type: application/json' -d '{"model": "kimi-k3", "messages": [{"role": "user", "content": "Say hello in exactly three words."}], "max_tokens": 100}' | head -c 400; echo; grep -i 'x-litellm-response-cost\|x-litellm-model-name' /tmp/h1_31581.txt
    {"id":"chatcmpl-01a039f421e97e708f54fcc9","created":1787678695,"model":"kimi-k3","object":"chat.completion","system_fingerprint":"default","choices":[{"finish_reason":"length","index":0,"message":{"role":"assistant","reasoning_content":"The user wants me to say hello in exactly three words. Let me think of a greeting that is exactly three words.\n\nOptions:\n- \"Hello there, friend!\" - 3 words\n-
    x-litellm-model-name: together_ai/moonshotai/Kimi-K3
    x-litellm-response-cost: 0.0015840000000000001
    x-litellm-response-cost-original: 0.0015840000000000001
    x-litellm-response-cost-discount-amount: 0.0
    x-litellm-response-cost-margin-amount: 0.0
    x-litellm-response-cost-margin-percent: 0.0
    x-litellm-response-cost-input: 8.400000000000001e-05
    x-litellm-response-cost-output: 0.0015
    x-litellm-response-cost-reasoning: 0.0015
    x-litellm-response-cost-tool-usage: 0.0
    ```

#### glm-5-2 chat completion + cost headers

1. Command and observed output:

    ```
    $ curl -sS -D /tmp/h2_31581.txt http://localhost:31581/v1/chat/completions -H 'Authorization: Bearer sk-lit5968-qa' -H 'Content-Type: application/json' -d '{"model": "glm-5-2", "messages": [{"role": "user", "content": "Say hello in exactly three words."}], "max_tokens": 100}' | head -c 400; echo; grep -i 'x-litellm-response-cost\|x-litellm-model-name' /tmp/h2_31581.txt
    {"id":"b28c5c4e-aws_uw1","created":1787678701,"model":"glm-5-2","object":"chat.completion","system_fingerprint":"default","choices":[{"finish_reason":"length","index":0,"message":{"role":"assistant","reasoning_content":"1.  **Analyze the Request:**\n    *   Task: Say hello.\n    *   Constraint: Exactly three words.\n\n2.  **Evaluate Options:**\n    *   \"Hello to you.\" (3 words)\n    *   \"I say 
    x-litellm-model-name: together_ai/zai-org/GLM-5.2
    x-litellm-response-cost: 0.0004666
    x-litellm-response-cost-original: 0.0004666
    x-litellm-response-cost-discount-amount: 0.0
    x-litellm-response-cost-margin-amount: 0.0
    x-litellm-response-cost-margin-percent: 0.0
    x-litellm-response-cost-input: 2.66e-05
    x-litellm-response-cost-output: 0.00044
    x-litellm-response-cost-reasoning: 0.0004356
    x-litellm-response-cost-tool-usage: 0.0
    ```

#### kimi-k3 tool calling

1. Command and observed output:

    ```
    $ curl -sS http://localhost:31581/v1/chat/completions -H 'Authorization: Bearer sk-lit5968-qa' -H 'Content-Type: application/json' -d '{"model": "kimi-k3", "messages": [{"role": "user", "content": "What is the weather in San Francisco right now? Use the get_weather tool."}], "tools": [{"type": "function", "function": {"name": "get_weather", "description": "Get current weather for a city", "parameters": {"type": "object", "properties": {"city": {"type": "string"}}, "required": ["city"]}}}], "max_tokens": 2000}' | python3 -c 'import json, sys; c = json.load(sys.stdin)["choices"][0]; print("finish_reason:", c["finish_reason"]); print("tool_calls:", json.dumps(c["message"].get("tool_calls"))[:300])'
    finish_reason: tool_calls
    tool_calls: [{"function": {"arguments": "{\"city\":\"San Francisco\"}", "name": "get_weather"}, "id": "get_weather_0", "type": "function"}]
    ```

#### model info pricing for kimi-k3

1. Command and observed output:

    ```
    $ curl -sS 'http://localhost:31581/v1/model/info' -H 'Authorization: Bearer sk-lit5968-qa' | python3 -c 'import json, sys; models = json.load(sys.stdin)["data"]; info = next(model for model in models if model["model_name"] == "kimi-k3")["model_info"]; print(json.dumps({key: info.get(key) for key in ("input_cost_per_token", "output_cost_per_token", "max_input_tokens", "supports_function_calling", "supports_vision", "supports_reasoning")}, indent=2))'
    {
      "input_cost_per_token": 3e-06,
      "output_cost_per_token": 1.5e-05,
      "max_input_tokens": 1048576,
      "supports_function_calling": true,
      "supports_vision": true,
      "supports_reasoning": true
    }
    ```

#### e5 embedding + cost headers

1. Command and observed output:

    ```
    $ curl -sS -D /tmp/h3_31581.txt http://localhost:31581/v1/embeddings -H 'Authorization: Bearer sk-lit5968-qa' -H 'Content-Type: application/json' -d '{"model": "e5-embed", "input": "hello world"}' | python3 -c 'import json, sys; r = json.load(sys.stdin); print("embedding dims:", len(r["data"][0]["embedding"]), "usage:", json.dumps(r["usage"]))'; grep -i 'x-litellm-response-cost\|x-litellm-model-name' /tmp/h3_31581.txt
    embedding dims: 1024 usage: {"completion_tokens": 0, "prompt_tokens": 5, "total_tokens": 5, "completion_tokens_details": null, "prompt_tokens_details": null}
    x-litellm-model-name: together_ai/intfloat/multilingual-e5-large-instruct
    x-litellm-response-cost: 1e-07
    x-litellm-response-cost-original: 1e-07
    x-litellm-response-cost-discount-amount: 0.0
    x-litellm-response-cost-margin-amount: 0.0
    x-litellm-response-cost-margin-percent: 0.0
    x-litellm-response-cost-input: 1e-07
    x-litellm-response-cost-output: 0.0
    x-litellm-response-cost-tool-usage: 0.0
    ```

## Type

🆕 New Feature

## Caveats (if any)

- `google/gemma-3n-E4B-it`: docs list it removed 2026-08-04, the live API still serves it, so it stays mapped
- Cache pricing fields (`cache_read_input_token_cost`) land separately in LIT-5972
- 7 delisted entries have no documented removal date, so they stay undated
- Successor metadata resolves the docs' replacement chains to models Together still serves
- Image, video, audio, and transcribe catalogs use a different pricing schema; out of scope
- Context windows follow Together's live API where docs disagree: GLM-5.2 is mapped at 1048575, verified by serving a real 600,022-token prompt (docs still say 512000)

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

- [x] db8c49305e passes /live-pr-risk

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Catalog-only JSON and tests; incorrect rates could skew billing, but changes align entries with Together’s documented serverless pricing and fix prior $0-cost and missing-capability behavior.
> 
> **Overview**
> Updates **`model_prices_and_context_window.json`** and its backup with Together AI’s current serverless catalog so routing, spend tracking, and capability checks work for models that were missing or stale.
> 
> **Adds** many new `together_ai/` entries (e.g. Kimi-K3, GLM-5.2, DeepSeek-V4-Pro/Flash, Qwen 3.6–3.8 tiers, MiniMax-M3, Nemotron, Gemma 4, Inkling, embedding `multilingual-e5-large-instruct`) with token costs, context limits, and flags such as tools, vision, and reasoning.
> 
> **Marks 25 delisted models** with **`deprecation_date`** and sets **`metadata.successor`** on superseded lines (DeepSeek → V4-Pro, Kimi K2 → K3, GLM 4.x → 5.2, etc.). **Re-prices** `Llama-3.3-70B-Instruct-Turbo` and adds its 131k token limits plus a docs source URL.
> 
> **New tests** in `test_together_ai_model_metadata.py` assert serverless mappings, deprecation dates, successor chains, repricing, and that both JSON cost maps stay in sync for `together_ai/` keys.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit db8c49305ead5151c2c9b7d9bdfb5cf388b1c140. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->