### PR TITLE
fix(bedrock_mantle): register a Bedrock runtime passthrough config so /bedrock/model/<deployment>/invoke works

### DIFF
--- a/litellm/llms/bedrock/passthrough/transformation.py
+++ b/litellm/llms/bedrock/passthrough/transformation.py
@@ -1,4 +1,5 @@
 import json
+from collections.abc import Mapping
 from typing import TYPE_CHECKING, Final, Optional, cast
 
 from httpx import Response
@@ -93,6 +94,9 @@ class BedrockPassthroughConfig(BaseAWSLLM, BedrockModelInfo, BedrockEventStreamD
             endpoint_url,
         )
 
+    def get_bedrock_bearer_token(self, litellm_params: Mapping[str, object]) -> str | None:
+        return None
+
     def sign_request(
         self,
         headers: dict,
@@ -109,6 +113,7 @@ class BedrockPassthroughConfig(BaseAWSLLM, BedrockModelInfo, BedrockEventStreamD
             request_data=request_data or {},
             api_base=api_base,
             model=model,
+            api_key=self.get_bedrock_bearer_token(optional_params),
         )
 
     def logging_non_streaming_response(

--- a/litellm/llms/bedrock_mantle/common_utils.py
+++ b/litellm/llms/bedrock_mantle/common_utils.py
@@ -13,6 +13,7 @@ global state.
 """
 
 import re
+from collections.abc import Mapping
 from typing import Final
 
 from botocore.exceptions import (
@@ -31,30 +32,39 @@ BEDROCK_MANTLE_DEFAULT_REGION: Final = "us-east-1"
 MANTLE_HOST_RE: Final = re.compile(r"^https?://bedrock-mantle\.([^/.]+)\.api\.aws", re.IGNORECASE)
 
 
+def resolve_mantle_bearer_token(api_key: str | None) -> str | None:
+    return api_key or get_secret_str("BEDROCK_MANTLE_API_KEY") or get_secret_str("AWS_BEARER_TOKEN_BEDROCK")
+
+
+def resolve_mantle_region(params: Mapping[str, object]) -> str:
+    region: Final = params.get("aws_region_name")
+    if isinstance(region, str) and region:
+        BaseAWSLLM._validate_aws_region_name(region)
+        return region
+    api_base: Final = params.get("api_base")
+    base: Final = (api_base if isinstance(api_base, str) else None) or get_secret_str("BEDROCK_MANTLE_API_BASE")
+    if base:
+        match: Final = MANTLE_HOST_RE.match(base.rstrip("/"))
+        if match:
+            return match.group(1)
+    return (
+        get_secret_str("BEDROCK_MANTLE_REGION")
+        or get_secret_str("AWS_REGION_NAME")
+        or get_secret_str("AWS_REGION")
+        or BEDROCK_MANTLE_DEFAULT_REGION
+    )
+
+
 class BedrockMantleAuthMixin:
     _aws_signer: BaseAWSLLM
 
     @staticmethod
     def _resolve_bearer_token(api_key: str | None) -> str | None:
-        return api_key or get_secret_str("BEDROCK_MANTLE_API_KEY") or get_secret_str("AWS_BEARER_TOKEN_BEDROCK")
+        return resolve_mantle_bearer_token(api_key)
 
     @staticmethod
     def _resolve_region(params: dict) -> str:
-        region: Final = params.get("aws_region_name")
-        if region:
-            BaseAWSLLM._validate_aws_region_name(region)
-            return region
-        base: Final = params.get("api_base") or get_secret_str("BEDROCK_MANTLE_API_BASE")
-        if base:
-            match: Final = MANTLE_HOST_RE.match(base.rstrip("/"))
-            if match:
-                return match.group(1)
-        return (
-            get_secret_str("BEDROCK_MANTLE_REGION")
-            or get_secret_str("AWS_REGION_NAME")
-            or get_secret_str("AWS_REGION")
-            or BEDROCK_MANTLE_DEFAULT_REGION
-        )
+        return resolve_mantle_region(params)
 
     def sign_request(
         self,

--- a/litellm/llms/bedrock_mantle/passthrough/transformation.py
+++ b/litellm/llms/bedrock_mantle/passthrough/transformation.py
@@ -1,12 +1,19 @@
 from collections.abc import Mapping
-from typing import Final, Literal
+from typing import TYPE_CHECKING, Final, Literal, Optional
 
+from httpx import Response
+
+from litellm.litellm_core_utils.litellm_logging import Logging
 from litellm.llms.bedrock.passthrough.transformation import BedrockPassthroughConfig
 from litellm.llms.bedrock_mantle.common_utils import (
     MANTLE_HOST_RE,
     resolve_mantle_bearer_token,
     resolve_mantle_region,
 )
+from litellm.types.utils import LlmProviders
+
+if TYPE_CHECKING:
+    from litellm.types.utils import CostResponseTypes
 
 
 class BedrockMantlePassthroughConfig(BedrockPassthroughConfig):
@@ -42,3 +49,23 @@ class BedrockMantlePassthroughConfig(BedrockPassthroughConfig):
     def get_bedrock_bearer_token(self, litellm_params: Mapping[str, object]) -> str | None:
         api_key: Final = litellm_params.get("api_key")
         return resolve_mantle_bearer_token(api_key if isinstance(api_key, str) else None)
+
+    def logging_non_streaming_response(
+        self,
+        model: str,
+        custom_llm_provider: str,
+        httpx_response: Response,
+        request_data: dict,  # mutable-ok: mirrors the inherited BedrockPassthroughConfig signature
+        logging_obj: Logging,
+        endpoint: str,
+    ) -> Optional["CostResponseTypes"]:
+        is_converse: Final = "invoke" not in endpoint and "converse" in endpoint
+        shape_provider: Final = LlmProviders.BEDROCK.value if is_converse else custom_llm_provider
+        return super().logging_non_streaming_response(
+            model=model,
+            custom_llm_provider=shape_provider,
+            httpx_response=httpx_response,
+            request_data=request_data,
+            logging_obj=logging_obj,
+            endpoint=endpoint,
+        )

--- a/litellm/llms/bedrock_mantle/passthrough/transformation.py
+++ b/litellm/llms/bedrock_mantle/passthrough/transformation.py
@@ -1,0 +1,44 @@
+from collections.abc import Mapping
+from typing import Final, Literal
+
+from litellm.llms.bedrock.passthrough.transformation import BedrockPassthroughConfig
+from litellm.llms.bedrock_mantle.common_utils import (
+    MANTLE_HOST_RE,
+    resolve_mantle_bearer_token,
+    resolve_mantle_region,
+)
+
+
+class BedrockMantlePassthroughConfig(BedrockPassthroughConfig):
+    """Native Bedrock runtime passthrough (InvokeModel, Converse) for deployments declared as bedrock_mantle.
+
+    The Mantle host only serves the OpenAI-compatible surface, so a Mantle api_base lends its region and the
+    request itself goes to bedrock-runtime, signed with the deployment's Bearer token or SigV4 credentials.
+    """
+
+    def _get_aws_region_name(
+        self,
+        optional_params: Mapping[str, object],
+        model: str | None = None,
+        model_id: str | None = None,
+    ) -> str:
+        return resolve_mantle_region(optional_params)
+
+    def get_runtime_endpoint(
+        self,
+        api_base: str | None,
+        aws_bedrock_runtime_endpoint: str | None,
+        aws_region_name: str,
+        endpoint_type: Literal["runtime", "agent", "agentcore"] | None = "runtime",
+    ) -> tuple[str, str]:
+        is_mantle_host: Final = api_base is not None and MANTLE_HOST_RE.match(api_base.rstrip("/")) is not None
+        return super().get_runtime_endpoint(
+            api_base=None if is_mantle_host else api_base,
+            aws_bedrock_runtime_endpoint=aws_bedrock_runtime_endpoint,
+            aws_region_name=aws_region_name,
+            endpoint_type=endpoint_type,
+        )
+
+    def get_bedrock_bearer_token(self, litellm_params: Mapping[str, object]) -> str | None:
+        api_key: Final = litellm_params.get("api_key")
+        return resolve_mantle_bearer_token(api_key if isinstance(api_key, str) else None)

--- a/litellm/passthrough/main.py
+++ b/litellm/passthrough/main.py
@@ -199,7 +199,7 @@ def llm_passthrough_route(
         api_key=api_key,
     )
 
-    litellm_params_dict: Final = get_litellm_params(**kwargs)
+    litellm_params_dict: Final = get_litellm_params(api_key=api_key, api_base=api_base, **kwargs)
 
     if client is None:
         from litellm.llms.custom_httpx.http_handler import (

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -8610,6 +8610,12 @@ class ProviderConfigManager:
             )
 
             return BedrockPassthroughConfig()
+        elif LlmProviders.BEDROCK_MANTLE == provider:
+            from litellm.llms.bedrock_mantle.passthrough.transformation import (
+                BedrockMantlePassthroughConfig,
+            )
+
+            return BedrockMantlePassthroughConfig()
         elif LlmProviders.VLLM == provider or LlmProviders.HOSTED_VLLM == provider:
             from litellm.llms.vllm.passthrough.transformation import (
                 VLLMPassthroughConfig,

--- a/tests/test_litellm/llms/bedrock_mantle/passthrough/test_bedrock_mantle_passthrough_transformation.py
+++ b/tests/test_litellm/llms/bedrock_mantle/passthrough/test_bedrock_mantle_passthrough_transformation.py
@@ -14,6 +14,7 @@ from litellm.utils import ProviderConfigManager
 
 MANTLE_API_BASE = "https://bedrock-mantle.us-east-2.api.aws"
 INVOKE_ENDPOINT = "model/us.openai.gpt-5.6-sol/invoke"
+CONVERSE_ENDPOINT = "model/us.openai.gpt-5.6-sol/converse"
 REQUEST_BODY = {"messages": [{"role": "user", "content": "say pong"}], "max_completion_tokens": 64}
 
 
@@ -150,3 +151,47 @@ def test_invoke_passthrough_route_reaches_bedrock_runtime_for_a_mantle_deploymen
     assert str(sent["url"]) == f"https://bedrock-runtime.us-east-2.amazonaws.com/{INVOKE_ENDPOINT}"
     assert sent["headers"]["Authorization"] == f"Bearer {expected_bearer}"
     assert json.loads(sent["content"]) == REQUEST_BODY
+
+
+def _logged_model_response(endpoint, body):
+    request = httpx.Request("POST", f"https://bedrock-runtime.us-east-1.amazonaws.com/{endpoint}")
+    return BedrockMantlePassthroughConfig().logging_non_streaming_response(
+        model="us.openai.gpt-5.6-sol",
+        custom_llm_provider="bedrock_mantle",
+        httpx_response=httpx.Response(200, json=body, request=request),
+        request_data={"messages": [{"role": "user", "content": [{"text": "say pong"}]}]},
+        logging_obj=MagicMock(),
+        endpoint=endpoint,
+    )
+
+
+def test_converse_logging_parses_the_converse_response_shape():
+    result = _logged_model_response(
+        CONVERSE_ENDPOINT,
+        {
+            "metrics": {"latencyMs": 800.0},
+            "output": {"message": {"content": [{"text": "pong"}], "role": "assistant"}},
+            "stopReason": "end_turn",
+            "usage": {"inputTokens": 8, "outputTokens": 5, "totalTokens": 13},
+        },
+    )
+    assert result.choices[0].message.content == "pong"
+    assert result.usage.prompt_tokens == 8
+    assert result.usage.completion_tokens == 5
+
+
+def test_invoke_logging_parses_the_openai_chat_response_shape():
+    result = _logged_model_response(
+        INVOKE_ENDPOINT,
+        {
+            "choices": [{"finish_reason": "stop", "index": 0, "message": {"content": "pong", "role": "assistant"}}],
+            "created": 1787677792,
+            "id": "chatcmpl-regression",
+            "model": "us.openai.gpt-5.6-sol",
+            "object": "chat.completion",
+            "usage": {"completion_tokens": 5, "prompt_tokens": 8, "total_tokens": 13},
+        },
+    )
+    assert result.choices[0].message.content == "pong"
+    assert result.usage.prompt_tokens == 8
+    assert result.usage.completion_tokens == 5

--- a/tests/test_litellm/llms/bedrock_mantle/passthrough/test_bedrock_mantle_passthrough_transformation.py
+++ b/tests/test_litellm/llms/bedrock_mantle/passthrough/test_bedrock_mantle_passthrough_transformation.py
@@ -1,0 +1,152 @@
+import json
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+from botocore.credentials import Credentials
+
+from litellm.llms.bedrock.passthrough.transformation import BedrockPassthroughConfig
+from litellm.llms.bedrock_mantle.passthrough.transformation import BedrockMantlePassthroughConfig
+from litellm.llms.custom_httpx.http_handler import HTTPHandler
+from litellm.passthrough.main import llm_passthrough_route
+from litellm.types.utils import LlmProviders
+from litellm.utils import ProviderConfigManager
+
+MANTLE_API_BASE = "https://bedrock-mantle.us-east-2.api.aws"
+INVOKE_ENDPOINT = "model/us.openai.gpt-5.6-sol/invoke"
+REQUEST_BODY = {"messages": [{"role": "user", "content": "say pong"}], "max_completion_tokens": 64}
+
+
+@pytest.fixture
+def no_ambient_aws(monkeypatch):
+    for name in (
+        "AWS_BEARER_TOKEN_BEDROCK",
+        "BEDROCK_MANTLE_API_KEY",
+        "BEDROCK_MANTLE_API_BASE",
+        "BEDROCK_MANTLE_REGION",
+        "AWS_BEDROCK_RUNTIME_ENDPOINT",
+        "AWS_REGION_NAME",
+        "AWS_REGION",
+        "AWS_DEFAULT_REGION",
+    ):
+        monkeypatch.delenv(name, raising=False)
+
+
+def test_bedrock_mantle_registers_its_own_bedrock_passthrough_config():
+    config = ProviderConfigManager.get_provider_passthrough_config(
+        model="us.openai.gpt-5.6-sol", provider=LlmProviders.BEDROCK_MANTLE
+    )
+    assert isinstance(config, BedrockMantlePassthroughConfig)
+    assert isinstance(config, BedrockPassthroughConfig)
+
+
+def test_mantle_api_base_only_lends_its_region_to_the_runtime_url(no_ambient_aws):
+    url, base_url = BedrockMantlePassthroughConfig().get_complete_url(
+        api_base=MANTLE_API_BASE,
+        api_key=None,
+        model="us.openai.gpt-5.6-sol",
+        endpoint=INVOKE_ENDPOINT,
+        request_query_params=None,
+        litellm_params={"api_base": MANTLE_API_BASE},
+    )
+    assert str(url) == f"https://bedrock-runtime.us-east-2.amazonaws.com/{INVOKE_ENDPOINT}"
+    assert base_url == "https://bedrock-runtime.us-east-2.amazonaws.com"
+
+
+def test_explicit_region_and_non_mantle_api_base_are_kept(no_ambient_aws):
+    vpc_endpoint = "https://vpce-0123.bedrock-runtime.us-east-1.vpce.amazonaws.com"
+    url, base_url = BedrockMantlePassthroughConfig().get_complete_url(
+        api_base=vpc_endpoint,
+        api_key=None,
+        model="us.openai.gpt-5.6-sol",
+        endpoint=INVOKE_ENDPOINT,
+        request_query_params=None,
+        litellm_params={"api_base": vpc_endpoint, "aws_region_name": "us-east-1"},
+    )
+    assert str(url) == f"{vpc_endpoint}/{INVOKE_ENDPOINT}"
+    assert base_url == vpc_endpoint
+
+
+def test_region_falls_back_to_the_mantle_default_without_any_hint(no_ambient_aws):
+    url, _ = BedrockMantlePassthroughConfig().get_complete_url(
+        api_base=None,
+        api_key=None,
+        model="us.openai.gpt-5.6-sol",
+        endpoint=INVOKE_ENDPOINT,
+        request_query_params=None,
+        litellm_params={},
+    )
+    assert str(url) == f"https://bedrock-runtime.us-east-1.amazonaws.com/{INVOKE_ENDPOINT}"
+
+
+@pytest.mark.parametrize(
+    ("litellm_params", "env", "expected_bearer"),
+    [
+        ({"api_key": "deployment-bedrock-api-key"}, {}, "deployment-bedrock-api-key"),
+        ({}, {"BEDROCK_MANTLE_API_KEY": "mantle-env-key"}, "mantle-env-key"),
+        ({}, {"AWS_BEARER_TOKEN_BEDROCK": "aws-env-key"}, "aws-env-key"),
+    ],
+)
+def test_sign_request_uses_the_deployment_bearer_token(no_ambient_aws, monkeypatch, litellm_params, env, expected_bearer):
+    for name, value in env.items():
+        monkeypatch.setenv(name, value)
+    headers, body = BedrockMantlePassthroughConfig().sign_request(
+        headers={},
+        litellm_params=litellm_params,
+        request_data=REQUEST_BODY,
+        api_base=f"https://bedrock-runtime.us-east-1.amazonaws.com/{INVOKE_ENDPOINT}",
+        model="us.openai.gpt-5.6-sol",
+    )
+    assert headers["Authorization"] == f"Bearer {expected_bearer}"
+    assert body is not None
+    assert json.loads(body) == REQUEST_BODY
+
+
+def test_sign_request_falls_back_to_sigv4_scoped_to_the_mantle_region(no_ambient_aws):
+    config = BedrockMantlePassthroughConfig()
+    with patch.object(config, "get_credentials", return_value=Credentials("AKIA", "secret")):
+        headers, body = config.sign_request(
+            headers={},
+            litellm_params={"api_base": MANTLE_API_BASE},
+            request_data=REQUEST_BODY,
+            api_base=f"https://bedrock-runtime.us-east-2.amazonaws.com/{INVOKE_ENDPOINT}",
+            model="us.openai.gpt-5.6-sol",
+        )
+    assert headers["Authorization"].startswith("AWS4-HMAC-SHA256 Credential=AKIA/")
+    assert "/us-east-2/bedrock/aws4_request" in headers["Authorization"]
+    assert body is not None
+    assert json.loads(body) == REQUEST_BODY
+
+
+@pytest.mark.parametrize(
+    ("route_kwargs", "env", "expected_bearer"),
+    [
+        ({"api_key": "deployment-bedrock-api-key"}, {}, "deployment-bedrock-api-key"),
+        ({}, {"BEDROCK_MANTLE_API_KEY": "mantle-env-key"}, "mantle-env-key"),
+    ],
+)
+def test_invoke_passthrough_route_reaches_bedrock_runtime_for_a_mantle_deployment(
+    no_ambient_aws, monkeypatch, route_kwargs, env, expected_bearer
+):
+    for name, value in env.items():
+        monkeypatch.setenv(name, value)
+    client = HTTPHandler()
+    with (
+        patch.object(client.client, "send", return_value=MagicMock(status_code=200)),
+        patch.object(client.client, "build_request", wraps=client.client.build_request) as build_request,
+    ):
+        response = llm_passthrough_route(
+            model="bedrock_mantle/us.openai.gpt-5.6-sol",
+            endpoint=INVOKE_ENDPOINT,
+            method="POST",
+            api_base=MANTLE_API_BASE,
+            json=dict(REQUEST_BODY),
+            client=client,
+            litellm_logging_obj=MagicMock(),
+            **route_kwargs,
+        )
+    assert response.status_code == 200
+    sent = build_request.call_args.kwargs
+    assert str(sent["url"]) == f"https://bedrock-runtime.us-east-2.amazonaws.com/{INVOKE_ENDPOINT}"
+    assert sent["headers"]["Authorization"] == f"Bearer {expected_bearer}"
+    assert json.loads(sent["content"]) == REQUEST_BODY


### PR DESCRIPTION
## TLDR

Problem this solves:

- `/bedrock/model/<deployment>/invoke` 500s for `bedrock_mantle` deployments
- Error: `Provider bedrock_mantle not found`, so native InvokeModel, streaming, and Converse are unusable

How it solves it:

- Registers a Bedrock runtime passthrough config for `bedrock_mantle`
- Requests go to `bedrock-runtime.<region>.amazonaws.com` with the deployment's Bearer token or SigV4
- A Mantle `api_base` only lends its region (that host serves no InvokeModel)
- The passthrough route now forwards the deployment's `api_key` and `api_base` to provider configs
- Converse responses are parsed with the Converse shape config for success logging, so spend tracks on `/converse` too

## User Flow

Before: a developer whose gateway routes GPT-OSS and GPT-5.6 through Bedrock Mantle calls the native Bedrock passthrough routes and every one of them 500s

1. They send POST https://litellm-domain/v1/chat/completions with `"model": "gpt-5.6-sol"` and get 200 with the model's reply, so the deployment itself works
2. They send POST https://litellm-domain/bedrock/model/gpt-5.6-sol/invoke with the same messages body
3. The response is HTTP 500 with `{"error":{"message":"Provider bedrock_mantle not found","code":"500"}}`
4. POST https://litellm-domain/bedrock/model/gpt-5.6-sol/invoke-with-response-stream and POST https://litellm-domain/bedrock/model/gpt-5.6-sol/converse return the same 500

After: the same requests reach Bedrock and come back 200

1. They send POST https://litellm-domain/v1/chat/completions with `"model": "gpt-5.6-sol"` and get 200 with the model's reply, so the deployment itself works
2. They send POST https://litellm-domain/bedrock/model/gpt-5.6-sol/invoke with the same messages body
3. The response is HTTP 200 with the model's chat completion, token usage included
4. POST https://litellm-domain/bedrock/model/gpt-5.6-sol/invoke-with-response-stream returns 200 with an AWS event stream carrying the reply chunks, and POST https://litellm-domain/bedrock/model/gpt-5.6-sol/converse returns 200 with the Converse output message and its token usage counted toward spend

## Relevant issues

Fixes #38054

## Linear ticket

Resolves LIT-6094

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Shared setup: both proxies boot from the same config with `--num_workers 2` and no database, real AWS Bedrock credentials from the environment (`AWS_BEARER_TOKEN_BEDROCK`), real $$$ spent. Before runs the merge base on port 30412, After runs this PR's tip on port 30411

```yaml
model_list:
  - model_name: gpt-5.6-sol
    litellm_params:
      model: bedrock_mantle/openai.gpt-5.6-sol
      aws_region_name: us-east-1
  - model_name: gpt-5.6-sol-profile
    litellm_params:
      model: bedrock_mantle/us.openai.gpt-5.6-sol
      aws_region_name: us-east-1
  - model_name: bedrock-control
    litellm_params:
      model: bedrock/us.openai.gpt-5.6-sol
      aws_region_name: us-east-1
general_settings:
  master_key: sk-1234
```

Shared request body: `{"messages":[{"role":"user","content":"say pong"}],"max_completion_tokens":64}`

### Before (9dff9cdd9a)

#### invoke (mantle deployment)

1. `curl -s -w '\nHTTP %{http_code}\n' -X POST "http://localhost:30412/bedrock/model/gpt-5.6-sol-profile/invoke" -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' -d "$body"`
2. Observed:

```
{"error":{"message":"Provider bedrock_mantle not found","type":"None","param":"None","code":"500"}}
HTTP 500
```

#### invoke-with-response-stream (mantle deployment)

1. `curl -s -X POST "http://localhost:30412/bedrock/model/gpt-5.6-sol-profile/invoke-with-response-stream" -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' -d "$body"`
2. Observed:

```
HTTP 500, 99 bytes
{"error":{"message":"Provider bedrock_mantle not found","type":"None","param":"None","code":"500"}}
```

#### converse (mantle deployment)

1. `curl -s -w '\nHTTP %{http_code}\n' -X POST "http://localhost:30412/bedrock/model/gpt-5.6-sol-profile/converse" -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' -d '{"messages":[{"role":"user","content":[{"text":"say pong"}]}],"inferenceConfig":{"maxTokens":64}}'`
2. Observed:

```
{"error":{"message":"Provider bedrock_mantle not found","type":"None","param":"None","code":"500"}}
HTTP 500
```

#### invoke (plain bedrock control deployment)

1. `curl -s -w '\nHTTP %{http_code}\n' -X POST "http://localhost:30412/bedrock/model/bedrock-control/invoke" -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' -d "$body"`
2. Observed:

```
{"choices":[{"finish_reason":"stop","index":0,"message":{"annotations":[],"content":"pong","refusal":null,"role":"assistant"}}],"created":1787677763,"id":"chatcmpl-yk7x7bolwxf6nobr32decjo2ox2dpnovydxwqc5gq74xcuz7mksq","model":"us.openai.gpt-5.6-sol","object":"chat.completion","service_tier":"default","usage":{"completion_tokens":5,...,"total_tokens":13},"system_fingerprint":null}
HTTP 200
```

### After (e8bdbcd1cf)

#### invoke (mantle deployment)

1. `curl -s -w '\nHTTP %{http_code}\n' -X POST "http://localhost:30411/bedrock/model/gpt-5.6-sol-profile/invoke" -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' -d "$body"`
2. Observed:

```
{"choices":[{"finish_reason":"stop","index":0,"message":{"annotations":[],"content":"pong","refusal":null,"role":"assistant"}}],"created":1787680664,"id":"chatcmpl-tceo3dodohpgviz7gsdyccb6k2o6veyiybqhqkbwvyk36y3zhkhq","model":"us.openai.gpt-5.6-sol","object":"chat.completion","service_tier":"default","usage":{"completion_tokens":5,...,"total_tokens":13},"system_fingerprint":null}
HTTP 200
```

3. Proxy debug log for this call shows the spend normalized from the OpenAI-shaped body: `response_cost: 0.00020899999999999998`

#### invoke-with-response-stream (mantle deployment)

1. `curl -s -X POST "http://localhost:30411/bedrock/model/gpt-5.6-sol-profile/invoke-with-response-stream" -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' -d "$body"`
2. Observed: HTTP 200, 2161 bytes of AWS event stream; a decoded chunk carries the reply:

```
{"choices":[{"delta":{"content":"pong"},"finish_reason":null,"index":0}],"created":1787680677,"id":"chatcmpl-uc46q6epje7zokw6ibw4jqlloebgqt5m4ijb2phstae2vabxlvwq","model":"us.openai.gpt-5.6-sol","object":"chat.completion
```

#### converse (mantle deployment)

1. `curl -s -w '\nHTTP %{http_code}\n' -X POST "http://localhost:30411/bedrock/model/gpt-5.6-sol-profile/converse" -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' -d '{"messages":[{"role":"user","content":[{"text":"say pong"}]}],"inferenceConfig":{"maxTokens":64}}'`
2. Observed:

```
{"metrics":{"latencyMs":17221},"output":{"message":{"content":[{"text":"pong"}],"role":"assistant"}},"stopReason":"end_turn","usage":{"cacheReadInputTokenCount":0,"cacheReadInputTokens":0,"inputTokens":8,"outputTokens":5,"serverToolUsage":{},"totalTokens":13}}
HTTP 200
```

3. Proxy debug log for this call shows the Converse usage normalized for spend: `response_cost: 0.00020899999999999998` (it logged `response_cost: 0.0` before the second commit, since the Converse body went through the OpenAI shape parser)

#### invoke (plain bedrock control deployment)

1. `curl -s -w '\nHTTP %{http_code}\n' -X POST "http://localhost:30411/bedrock/model/bedrock-control/invoke" -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' -d "$body"`
2. Observed:

```
{"choices":[{"finish_reason":"stop","index":0,"message":{"annotations":[],"content":"pong","refusal":null,"role":"assistant"}}],"created":1787680706,"id":"chatcmpl-ublpoy4etygfrkuvds7bg24kzlnrbm3zu7h6vtjqgicwdsdfgjfq","model":"us.openai.gpt-5.6-sol","object":"chat.completion","service_tier":"default","usage":{"completion_tokens":5,...,"total_tokens":13},"system_fingerprint":null}
HTTP 200
```

## Type

🐛 Bug Fix

## Caveats (if any)

- `x-litellm-response-cost` headers read 0.0 on bedrock passthrough; pre-existing, both providers, left alone
- Bare `openai.gpt-5.6-sol` gets AWS's own 400; InvokeModel needs the `us.` profile id
- Streaming passthrough spend still logs 0.0 (no usage extraction from the event stream); pre-existing, both providers
- The plain `bedrock` control's invoke success logging raises a non-blocking error on this model family's OpenAI-shaped body; pre-existing, untouched

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR


- [x] e8bdbcd1cf passes /live-pr-risk

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> Unable to generate summary.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e8bdbcd1cf176914a2b110f95e8fc9d87c574436. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

