### PR TITLE
fix(router): resolve provider from api_base in deployment validation and acompletion

### DIFF
--- a/litellm/main.py
+++ b/litellm/main.py
@@ -602,7 +602,7 @@ async def acompletion(
         _, custom_llm_provider, _, _ = get_llm_provider(
             model=model,
             custom_llm_provider=custom_llm_provider,
-            api_base=base_url,
+            api_base=kwargs.get("api_base") or base_url,
         )
 
     fallbacks = fallbacks or litellm.model_fallbacks

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -8341,6 +8341,7 @@ class Router:
             ) = litellm.get_llm_provider(
                 model=deployment.litellm_params.model,
                 custom_llm_provider=deployment.litellm_params.get("custom_llm_provider", None),
+                api_base=deployment.litellm_params.api_base,
             )
             # done reading model["litellm_params"]
             # Check if provider is supported: either in enum or JSON-configured

--- a/tests/test_litellm/test_main.py
+++ b/tests/test_litellm/test_main.py
@@ -2944,3 +2944,16 @@ def test_a_stream_that_reported_no_usage_is_still_billed(local_cost_map):
     assert cost == pytest.approx(
         _priced_at(rebuilt.usage.prompt_tokens, rebuilt.usage.completion_tokens)
     )
+
+
+@pytest.mark.asyncio
+async def test_acompletion_resolves_provider_from_api_base():
+    response = await litellm.acompletion(
+        model="deepseek-chat",
+        api_base="https://api.deepseek.com/v1",
+        api_key="fake-key",
+        messages=[{"role": "user", "content": "hi"}],
+        mock_response="resolved",
+    )
+
+    assert response.choices[0].message.content == "resolved"

--- a/tests/test_litellm/test_router.py
+++ b/tests/test_litellm/test_router.py
@@ -8921,3 +8921,65 @@ class TestAzureBaseModelFallbackLogging:
             deployment=None, received_model_name="my-group", id="azure-base-model-test-id"
         )
         assert model_info["max_input_tokens"] == litellm.model_cost["azure/gpt-4o-mini"]["max_input_tokens"]
+
+
+class TestAddDeploymentApiBaseProviderResolution:
+    def test_bare_model_with_known_api_base_initializes(self):
+        router = litellm.Router(
+            model_list=[
+                {
+                    "model_name": "groq-pinned",
+                    "litellm_params": {
+                        "model": "llama-3.3-70b-versatile",
+                        "api_base": "https://api.groq.com/openai/v1",
+                        "api_key": "fake-key",
+                    },
+                },
+                {
+                    "model_name": "deepseek-pinned",
+                    "litellm_params": {
+                        "model": "deepseek-chat",
+                        "api_base": "https://api.deepseek.com/v1",
+                        "api_key": "fake-key",
+                    },
+                },
+            ]
+        )
+
+        model_list = router.get_model_list()
+        assert model_list is not None
+        assert {m["model_name"] for m in model_list} == {"groq-pinned", "deepseek-pinned"}
+
+    def test_bare_model_with_unknown_api_base_still_raises(self):
+        with pytest.raises(litellm.BadRequestError, match="LLM Provider NOT provided"):
+            litellm.Router(
+                model_list=[
+                    {
+                        "model_name": "mystery",
+                        "litellm_params": {
+                            "model": "some-unknown-model",
+                            "api_base": "https://llm.internal.example.com/v1",
+                            "api_key": "fake-key",
+                        },
+                    }
+                ]
+            )
+
+    def test_explicit_custom_llm_provider_beats_api_base_endpoint_match(self):
+        router = litellm.Router(
+            model_list=[
+                {
+                    "model_name": "openai-via-gateway",
+                    "litellm_params": {
+                        "model": "gpt-3.5-turbo",
+                        "custom_llm_provider": "openai",
+                        "api_base": "https://api.groq.com/openai/v1",
+                        "api_key": "fake-key",
+                    },
+                }
+            ]
+        )
+
+        deployment = router.get_deployment_by_model_group_name("openai-via-gateway")
+        assert deployment is not None
+        assert deployment.litellm_params.custom_llm_provider == "openai"


### PR DESCRIPTION
## TLDR

Problem this solves:

- Config entry with bare model + known api_base fails startup validation
- Proxy then returns 400 no healthy deployments for that model group
- Same model + api_base works through the sync SDK, so behavior diverges

How it solves it:

- Deployment validation now passes the deployment's api_base into provider resolution
- acompletion forwards the api_base kwarg too, matching sync completion
- Endpoint matching (api.groq.com, api.deepseek.com, etc.) now fires on both paths

## User Flow

Before: a proxy admin pins a model to a known OpenAI-compatible endpoint via api_base, and every request to it dies with 400

1. The admin adds a config entry: `model_name: deepseek-pinned` with `model: deepseek-chat`, `api_base: https://api.deepseek.com/v1`, and their API key
2. They start the proxy and the startup log prints `Error creating deployment: litellm.BadRequestError: LLM Provider NOT provided. ... You passed model=deepseek-chat`
3. A developer sends POST https://litellm-domain/v1/chat/completions with `{"model": "deepseek-pinned", "messages": [...]}` and gets HTTP 400 `You passed in model=deepseek-pinned. There are no healthy deployments for this model`
4. The same bare model plus api_base completes fine when called through `litellm.completion` directly, so only the proxy config path rejects it

After: the same config entry loads at startup and serves completions

1. The admin adds the identical config entry: `model_name: deepseek-pinned` with `model: deepseek-chat`, `api_base: https://api.deepseek.com/v1`, and their API key
2. They start the proxy and the startup log shows no deployment errors
3. The developer sends the same POST https://litellm-domain/v1/chat/completions and gets HTTP 200 with the assistant's reply, `x-litellm-model-name: deepseek-chat`, and a real non-zero `x-litellm-response-cost` header
4. The same request with `"stream": true` streams chunks back normally

## Relevant issues

## Linear ticket

Resolves LIT-6120

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Shared setup: worktree proxy on port 27260 with this config (`DEEPSEEK_API_KEY` set in the environment):

```yaml
model_list:
  - model_name: deepseek-pinned
    litellm_params:
      model: deepseek-chat
      api_base: https://api.deepseek.com/v1
      api_key: os.environ/DEEPSEEK_API_KEY

general_settings:
  master_key: sk-lit6120-test
```

Started with `python litellm/proxy/proxy_cli.py --config lit6120_config.yaml --port 27260 --detailed_debug`

### Before (92fe35854b)

#### Deployment validation at startup

1. Start the proxy with the config above
2. Startup log: `LiteLLM Router:ERROR: router.py:7808 - Error creating deployment: litellm.BadRequestError: LLM Provider NOT provided. Pass in the LLM provider you are trying to call. You passed model=deepseek-chat`

#### POST /v1/chat/completions

1. `curl -sS http://localhost:27260/v1/chat/completions -H "Authorization: Bearer sk-lit6120-test" -H "Content-Type: application/json" -d '{"model": "deepseek-pinned", "messages": [{"role": "user", "content": "Say OK"}], "max_tokens": 5}'`
2. HTTP 400: `{"error":{"message":"litellm.BadRequestError: You passed in model=deepseek-pinned. There are no healthy deployments for this model. Received Model Group=deepseek-pinned\nAvailable Model Group Fallbacks=None","type":null,"param":null,"code":"400"}}`
3. Control, same model + api_base through the sync SDK against the real provider: `litellm.completion(model='deepseek-chat', api_base='https://api.deepseek.com/v1', api_key=..., messages=[{'role':'user','content':'Say OK'}], max_tokens=5)` returns `OK` (served by `deepseek-v4-flash`), so the SDK resolves what the proxy config rejects

### After (0bd4d323da)

#### Deployment validation at startup

1. Start the proxy with the identical config
2. `grep -c "Error creating deployment" litellm.log` prints `0`

#### POST /v1/chat/completions

1. Same curl: `curl -sS http://localhost:27260/v1/chat/completions -H "Authorization: Bearer sk-lit6120-test" -H "Content-Type: application/json" -d '{"model": "deepseek-pinned", "messages": [{"role": "user", "content": "Say OK"}], "max_tokens": 5}'`
2. HTTP 200: `{"id": "e690ed1e-156c-418d-9b2a-3f7c8bdd7cf9", "model": "deepseek-pinned", "object": "chat.completion", "choices": [{"finish_reason": "stop", "index": 0, "message": {"content": "OK", "role": "assistant"}}], "usage": {"completion_tokens": 1, "prompt_tokens": 6, "total_tokens": 7}}`
3. Response headers show correct provider resolution and real spend: `x-litellm-model-name: deepseek-chat`, `x-litellm-model-api-base: https://api.deepseek.com/v1`, `x-litellm-response-cost: 3.96e-06`
4. Same request with `"stream": true` streams `chat.completion.chunk` frames ending in the full `OK` reply

## Type

🐛 Bug Fix

## Caveats (if any)

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to provider-resolution inputs on router init and async completion; explicit `custom_llm_provider` still wins, with regression tests for known and unknown endpoints.
> 
> **Overview**
> **Fixes provider resolution when only a bare model name and a known `api_base` are configured**, so proxy deployments and async completions behave like the sync SDK.
> 
> Router deployment validation now passes each deployment’s `api_base` into `get_llm_provider`, so entries such as `deepseek-chat` with `https://api.deepseek.com/v1` (or Groq-style bases) resolve at startup instead of failing with “LLM Provider NOT provided” and leaving the model group with no healthy deployments.
> 
> `acompletion` now forwards `kwargs["api_base"]` (falling back to `base_url`) into the same provider lookup, aligning async calls with sync completion when callers pin an endpoint without a `provider/model` prefix.
> 
> Tests cover async resolution from `api_base`, successful router init for known bases, unchanged failure for unknown bases, and precedence of explicit `custom_llm_provider` over endpoint matching.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0bd4d323da3a5969a7a3940faef03ecd239d2a98. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->