### PR TITLE
fix: never drop tool_result messages with unknown or empty content in anthropic adapter

### DIFF
--- a/litellm/llms/anthropic/experimental_pass_through/adapters/transformation.py
+++ b/litellm/llms/anthropic/experimental_pass_through/adapters/transformation.py
@@ -1,7 +1,7 @@
 import copy
 import hashlib
 import json
-from collections.abc import AsyncIterator, Iterator, Mapping
+from collections.abc import AsyncIterator, Iterator, Mapping, Sequence
 from typing import TYPE_CHECKING, Any, Final, Literal, TypeVar, cast
 
 import litellm
@@ -73,6 +73,7 @@ from litellm.litellm_core_utils.prompt_templates.factory import (
 from litellm.litellm_core_utils.reasoning_effort_utils import (
     reasoning_effort_from_thinking_budget,
 )
+from litellm.litellm_core_utils.safe_json_dumps import safe_dumps
 from litellm.llms.anthropic.common_utils import normalize_anthropic_tool_use_id
 from litellm.llms.anthropic.experimental_pass_through.context_management import (
     PolyfillResult,
@@ -437,34 +438,30 @@ class LiteLLMAnthropicMessagesAdapter:
                                 # image becomes a structured image_url part
                                 if len(content_items) == 1:
                                     c = content_items[0]
+                                    single_content: str | Sequence[ChatCompletionImageObject]
                                     if isinstance(c, str):
-                                        tool_result = ChatCompletionToolMessage(
-                                            role="tool",
-                                            tool_call_id=content.get("tool_use_id", ""),
-                                            content=c,
-                                        )
-                                        self._add_cache_control_if_applicable(content, tool_result, model)
-                                        tool_message_list.append(tool_result)
+                                        single_content = c
                                     elif isinstance(c, dict):
                                         if c.get("type") == "text":
-                                            tool_result = ChatCompletionToolMessage(
-                                                role="tool",
-                                                tool_call_id=content.get("tool_use_id", ""),
-                                                content=c.get("text", ""),
-                                            )
-                                            self._add_cache_control_if_applicable(content, tool_result, model)
-                                            tool_message_list.append(tool_result)
+                                            single_content = c.get("text", "")
                                         elif c.get("type") == "image":
                                             image_part = self._tool_result_image_part(c.get("source"))
-                                            tool_result = ChatCompletionToolMessage(
-                                                role="tool",
-                                                tool_call_id=content.get("tool_use_id", ""),
-                                                content=[image_part]  # mutable-ok: content must be a json list
+                                            single_content = (
+                                                [image_part]  # mutable-ok: content must be a json list
                                                 if image_part
-                                                else "",
+                                                else ""
                                             )
-                                            self._add_cache_control_if_applicable(content, tool_result, model)
-                                            tool_message_list.append(tool_result)
+                                        else:
+                                            single_content = safe_dumps(c)
+                                    else:
+                                        single_content = safe_dumps(c)
+                                    tool_result = ChatCompletionToolMessage(
+                                        role="tool",
+                                        tool_call_id=content.get("tool_use_id", ""),
+                                        content=single_content,
+                                    )
+                                    self._add_cache_control_if_applicable(content, tool_result, model)
+                                    tool_message_list.append(tool_result)
                                 else:
                                     # For multiple content items, combine into a single tool message
                                     # with list content to preserve all items while having one tool_use_id
@@ -486,15 +483,33 @@ class LiteLLMAnthropicMessagesAdapter:
                                                 image_part = self._tool_result_image_part(c.get("source"))
                                                 if image_part:
                                                     combined_content_parts.append(image_part)
+                                            else:
+                                                combined_content_parts.append(
+                                                    ChatCompletionTextObject(type="text", text=safe_dumps(c))
+                                                )
+                                        else:
+                                            combined_content_parts.append(
+                                                ChatCompletionTextObject(type="text", text=safe_dumps(c))
+                                            )
                                     # Create a single tool message with combined content
-                                    if combined_content_parts:
-                                        tool_result = ChatCompletionToolMessage(
-                                            role="tool",
-                                            tool_call_id=content.get("tool_use_id", ""),
-                                            content=combined_content_parts,
-                                        )
-                                        self._add_cache_control_if_applicable(content, tool_result, model)
-                                        tool_message_list.append(tool_result)
+                                    tool_result = ChatCompletionToolMessage(
+                                        role="tool",
+                                        tool_call_id=content.get("tool_use_id", ""),
+                                        content=combined_content_parts if combined_content_parts else "",
+                                    )
+                                    self._add_cache_control_if_applicable(content, tool_result, model)
+                                    tool_message_list.append(tool_result)
+                            else:
+                                raw_tool_result_content = content.get("content")
+                                tool_result = ChatCompletionToolMessage(
+                                    role="tool",
+                                    tool_call_id=content.get("tool_use_id", ""),
+                                    content=""
+                                    if raw_tool_result_content is None
+                                    else safe_dumps(raw_tool_result_content),
+                                )
+                                self._add_cache_control_if_applicable(content, tool_result, model)
+                                tool_message_list.append(tool_result)
 
             if len(tool_message_list) > 0:
                 new_messages.extend(tool_message_list)

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_anthropic_experimental_pass_through_adapters_transformation.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_anthropic_experimental_pass_through_adapters_transformation.py
@@ -3930,9 +3930,7 @@ def test_translate_anthropic_messages_to_openai_carries_midturn_system_prompt_ca
 
 
 def test_translate_anthropic_messages_to_openai_tool_result_with_tool_reference():
-    """Regression test for LIT-6103: a tool_result whose content is a single unknown
-    block type (e.g. tool_reference from Claude Code's ENABLE_TOOL_SEARCH) must still
-    emit a role:"tool" message instead of being silently dropped."""
+    """LIT-6103: a single unknown block type must still emit the tool message."""
 
     tool_reference_block = {"type": "tool_reference", "tool_name": "WebFetch"}
     anthropic_messages = [
@@ -3970,10 +3968,7 @@ def test_translate_anthropic_messages_to_openai_tool_result_with_tool_reference(
 
 
 def test_translate_anthropic_messages_to_openai_tool_result_tool_reference_with_sibling_text():
-    """Regression test for LIT-6103: with a sibling text part next to the tool_result,
-    dropping the tool_result leaves an assistant tool_use answered only by a user text
-    message, which Anthropic rejects with a 400. The tool message must be emitted and
-    placed before the user message."""
+    """LIT-6103: the tool message must be emitted before the sibling text user message."""
 
     anthropic_messages = [
         AnthropicMessagesUserMessageParam(role="user", content=[{"type": "text", "text": "Load the WebFetch tool"}]),
@@ -4020,8 +4015,7 @@ def test_translate_anthropic_messages_to_openai_tool_result_tool_reference_with_
 
 
 def test_translate_anthropic_messages_to_openai_tool_result_mixed_unknown_and_text():
-    """Regression test for LIT-6103: unknown block types mixed with text in a multi-item
-    tool_result content list must be JSON-serialized into text parts, not dropped."""
+    """LIT-6103: unknown blocks mixed with text become serialized text parts."""
 
     tool_reference_block = {"type": "tool_reference", "tool_name": "WebFetch"}
     search_result_block = {"type": "search_result", "title": "docs", "source": "https://example.com"}
@@ -4071,8 +4065,7 @@ def test_translate_anthropic_messages_to_openai_tool_result_mixed_unknown_and_te
 
 
 def test_translate_anthropic_messages_to_openai_tool_result_empty_content_list():
-    """Regression test for LIT-6103: a tool_result with an empty content list must still
-    emit a role:"tool" message so the tool_use stays answered."""
+    """LIT-6103: an empty content list must still emit the tool message."""
 
     anthropic_messages = [
         AnthropicMessagesUserMessageParam(role="user", content=[{"type": "text", "text": "Run the tool"}]),
@@ -4119,8 +4112,7 @@ def test_translate_anthropic_messages_to_openai_tool_result_empty_content_list()
 def test_translate_anthropic_messages_to_openai_tool_result_odd_content_shapes(
     tool_result_content, expected_tool_content
 ):
-    """Regression test for LIT-6103: tool_result content that is a non-str non-dict item,
-    an explicit null, or a bare dict must still emit a role:"tool" message."""
+    """LIT-6103: off-contract content shapes must still emit the tool message."""
 
     anthropic_messages = [
         AnthropicMessagesUserMessageParam(role="user", content=[{"type": "text", "text": "Run the tool"}]),
@@ -4144,8 +4136,7 @@ def test_translate_anthropic_messages_to_openai_tool_result_odd_content_shapes(
 
 
 def test_translate_anthropic_messages_to_openai_tool_result_multi_item_non_dict_items():
-    """Regression test for LIT-6103: non-str non-dict items in a multi-item tool_result
-    content list must be JSON-serialized into text parts, not silently discarded."""
+    """LIT-6103: non-dict items in a multi-item list become serialized text parts."""
 
     anthropic_messages = [
         AnthropicMessagesUserMessageParam(role="user", content=[{"type": "text", "text": "Run the tool"}]),
@@ -4179,8 +4170,7 @@ def test_translate_anthropic_messages_to_openai_tool_result_multi_item_non_dict_
 
 
 def test_translate_anthropic_messages_to_openai_tool_result_null_content_preserves_cache_control():
-    """Regression test for LIT-6103: the fallthrough emit sites must carry cache_control
-    through for Claude models the same way the pre-existing branches do."""
+    """LIT-6103: the fallthrough emit sites carry cache_control through."""
 
     anthropic_messages = [
         AnthropicMessagesUserMessageParam(role="user", content=[{"type": "text", "text": "Run the tool"}]),
@@ -4213,8 +4203,7 @@ def test_translate_anthropic_messages_to_openai_tool_result_null_content_preserv
 
 
 def test_translate_anthropic_messages_to_openai_tool_result_all_image_parts_unconvertible():
-    """Regression test for LIT-6103: a multi-item tool_result whose parts all fail to
-    convert must still emit the tool message with empty content, never drop it."""
+    """LIT-6103: a tool_result whose parts all fail to convert must still emit the tool message."""
 
     anthropic_messages = [
         AnthropicMessagesUserMessageParam(role="user", content=[{"type": "text", "text": "Screenshot twice"}]),

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_anthropic_experimental_pass_through_adapters_transformation.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_anthropic_experimental_pass_through_adapters_transformation.py
@@ -4110,7 +4110,7 @@ def test_translate_anthropic_messages_to_openai_tool_result_empty_content_list()
     ],
 )
 def test_translate_anthropic_messages_to_openai_tool_result_odd_content_shapes(
-    tool_result_content, expected_tool_content
+    tool_result_content: object, expected_tool_content: str
 ):
     """LIT-6103: off-contract content shapes must still emit the tool message."""
 
@@ -4233,3 +4233,38 @@ def test_translate_anthropic_messages_to_openai_tool_result_all_image_parts_unco
     assert len(tool_messages) == 1, "Tool message must be emitted even when no parts convert"
     assert tool_messages[0]["tool_call_id"] == "toolu_img01"
     assert tool_messages[0]["content"] == ""
+
+
+def test_translate_anthropic_messages_to_openai_tool_result_bare_string_items():
+    """LIT-6103: bare string items keep their pre-fix behavior through the restructured dispatch."""
+
+    anthropic_messages = [
+        AnthropicMessagesUserMessageParam(role="user", content=[{"type": "text", "text": "Run the tool"}]),
+        AnthopicMessagesAssistantMessageParam(
+            role="assistant",
+            content=[{"type": "tool_use", "id": "toolu_str01", "name": "str_tool", "input": {}}],
+        ),
+        AnthropicMessagesUserMessageParam(
+            role="user",
+            content=[{"type": "tool_result", "tool_use_id": "toolu_str01", "content": ["bare result"]}],
+        ),
+        AnthopicMessagesAssistantMessageParam(
+            role="assistant",
+            content=[{"type": "tool_use", "id": "toolu_str02", "name": "str_tool", "input": {}}],
+        ),
+        AnthropicMessagesUserMessageParam(
+            role="user",
+            content=[{"type": "tool_result", "tool_use_id": "toolu_str02", "content": ["part one", "part two"]}],
+        ),
+    ]
+
+    adapter = LiteLLMAnthropicMessagesAdapter()
+    result = adapter.translate_anthropic_messages_to_openai(messages=anthropic_messages)
+
+    tool_messages = [msg for msg in result if isinstance(msg, dict) and msg.get("role") == "tool"]
+    assert len(tool_messages) == 2
+    assert tool_messages[0]["content"] == "bare result"
+    assert tool_messages[1]["content"] == [
+        {"type": "text", "text": "part one"},
+        {"type": "text", "text": "part two"},
+    ]

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_anthropic_experimental_pass_through_adapters_transformation.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_anthropic_experimental_pass_through_adapters_transformation.py
@@ -6,6 +6,7 @@ import litellm
 
 
 
+from litellm.litellm_core_utils.safe_json_dumps import safe_dumps
 from litellm.litellm_core_utils.prompt_templates.common_utils import (
     TOOL_RESULT_IMAGE_PLACEHOLDER,
 )
@@ -3926,3 +3927,320 @@ def test_translate_anthropic_messages_to_openai_carries_midturn_system_prompt_ca
     assert result == [
         {"role": "system", "content": [{"type": "text", "text": "fix", "prompt_cache_breakpoint": explicit}]}
     ]
+
+
+def test_translate_anthropic_messages_to_openai_tool_result_with_tool_reference():
+    """Regression test for LIT-6103: a tool_result whose content is a single unknown
+    block type (e.g. tool_reference from Claude Code's ENABLE_TOOL_SEARCH) must still
+    emit a role:"tool" message instead of being silently dropped."""
+
+    tool_reference_block = {"type": "tool_reference", "tool_name": "WebFetch"}
+    anthropic_messages = [
+        AnthropicMessagesUserMessageParam(role="user", content=[{"type": "text", "text": "Load the WebFetch tool"}]),
+        AnthopicMessagesAssistantMessageParam(
+            role="assistant",
+            content=[
+                {
+                    "type": "tool_use",
+                    "id": "toolu_01PV7TQswAGFPMWK6Cbfkxtn",
+                    "name": "tool_search",
+                    "input": {"query": "select:WebFetch"},
+                }
+            ],
+        ),
+        AnthropicMessagesUserMessageParam(
+            role="user",
+            content=[
+                {
+                    "type": "tool_result",
+                    "tool_use_id": "toolu_01PV7TQswAGFPMWK6Cbfkxtn",
+                    "content": [tool_reference_block],
+                }
+            ],
+        ),
+    ]
+
+    adapter = LiteLLMAnthropicMessagesAdapter()
+    result = adapter.translate_anthropic_messages_to_openai(messages=anthropic_messages)
+
+    tool_messages = [msg for msg in result if isinstance(msg, dict) and msg.get("role") == "tool"]
+    assert len(tool_messages) == 1, "Tool message was dropped for tool_reference content"
+    assert tool_messages[0]["tool_call_id"] == "toolu_01PV7TQswAGFPMWK6Cbfkxtn"
+    assert tool_messages[0]["content"] == safe_dumps({"type": "tool_reference", "tool_name": "WebFetch"})
+
+
+def test_translate_anthropic_messages_to_openai_tool_result_tool_reference_with_sibling_text():
+    """Regression test for LIT-6103: with a sibling text part next to the tool_result,
+    dropping the tool_result leaves an assistant tool_use answered only by a user text
+    message, which Anthropic rejects with a 400. The tool message must be emitted and
+    placed before the user message."""
+
+    anthropic_messages = [
+        AnthropicMessagesUserMessageParam(role="user", content=[{"type": "text", "text": "Load the WebFetch tool"}]),
+        AnthopicMessagesAssistantMessageParam(
+            role="assistant",
+            content=[
+                {
+                    "type": "tool_use",
+                    "id": "toolu_01PV7TQswAGFPMWK6Cbfkxtn",
+                    "name": "tool_search",
+                    "input": {"query": "select:WebFetch"},
+                }
+            ],
+        ),
+        AnthropicMessagesUserMessageParam(
+            role="user",
+            content=[
+                {
+                    "type": "tool_result",
+                    "tool_use_id": "toolu_01PV7TQswAGFPMWK6Cbfkxtn",
+                    "content": [{"type": "tool_reference", "tool_name": "WebFetch"}],
+                },
+                {"type": "text", "text": "Now fetch the page"},
+            ],
+        ),
+    ]
+
+    adapter = LiteLLMAnthropicMessagesAdapter()
+    result = adapter.translate_anthropic_messages_to_openai(messages=anthropic_messages)
+
+    tool_message_idx = None
+    user_message_idx = None
+    for i, msg in enumerate(result):
+        if isinstance(msg, dict) and msg.get("role") == "tool":
+            tool_message_idx = i
+        elif (
+            isinstance(msg, dict) and msg.get("role") == "user" and "Now fetch the page" in str(msg.get("content", ""))
+        ):
+            user_message_idx = i
+
+    assert tool_message_idx is not None, "Tool message was dropped, orphaning the tool_use"
+    assert user_message_idx is not None, "Sibling text user message not found"
+    assert tool_message_idx < user_message_idx, "Tool message must precede the user message"
+
+
+def test_translate_anthropic_messages_to_openai_tool_result_mixed_unknown_and_text():
+    """Regression test for LIT-6103: unknown block types mixed with text in a multi-item
+    tool_result content list must be JSON-serialized into text parts, not dropped."""
+
+    tool_reference_block = {"type": "tool_reference", "tool_name": "WebFetch"}
+    search_result_block = {"type": "search_result", "title": "docs", "source": "https://example.com"}
+    anthropic_messages = [
+        AnthropicMessagesUserMessageParam(role="user", content=[{"type": "text", "text": "Search and load tools"}]),
+        AnthopicMessagesAssistantMessageParam(
+            role="assistant",
+            content=[
+                {
+                    "type": "tool_use",
+                    "id": "toolu_mixed01",
+                    "name": "tool_search",
+                    "input": {"query": "web"},
+                }
+            ],
+        ),
+        AnthropicMessagesUserMessageParam(
+            role="user",
+            content=[
+                {
+                    "type": "tool_result",
+                    "tool_use_id": "toolu_mixed01",
+                    "content": [
+                        {"type": "text", "text": "Found 2 tools"},
+                        tool_reference_block,
+                        search_result_block,
+                    ],
+                }
+            ],
+        ),
+    ]
+
+    adapter = LiteLLMAnthropicMessagesAdapter()
+    result = adapter.translate_anthropic_messages_to_openai(messages=anthropic_messages)
+
+    tool_messages = [msg for msg in result if isinstance(msg, dict) and msg.get("role") == "tool"]
+    assert len(tool_messages) == 1, "Exactly one tool message expected for one tool_use_id"
+    content = tool_messages[0]["content"]
+    assert isinstance(content, list)
+    assert len(content) == 3, "Unknown block types must not be dropped from the content list"
+    assert content[0] == {"type": "text", "text": "Found 2 tools"}
+    assert content[1] == {"type": "text", "text": safe_dumps({"type": "tool_reference", "tool_name": "WebFetch"})}
+    assert content[2] == {
+        "type": "text",
+        "text": safe_dumps({"type": "search_result", "title": "docs", "source": "https://example.com"}),
+    }
+
+
+def test_translate_anthropic_messages_to_openai_tool_result_empty_content_list():
+    """Regression test for LIT-6103: a tool_result with an empty content list must still
+    emit a role:"tool" message so the tool_use stays answered."""
+
+    anthropic_messages = [
+        AnthropicMessagesUserMessageParam(role="user", content=[{"type": "text", "text": "Run the tool"}]),
+        AnthopicMessagesAssistantMessageParam(
+            role="assistant",
+            content=[
+                {
+                    "type": "tool_use",
+                    "id": "toolu_empty01",
+                    "name": "noop_tool",
+                    "input": {},
+                }
+            ],
+        ),
+        AnthropicMessagesUserMessageParam(
+            role="user",
+            content=[
+                {
+                    "type": "tool_result",
+                    "tool_use_id": "toolu_empty01",
+                    "content": [],
+                }
+            ],
+        ),
+    ]
+
+    adapter = LiteLLMAnthropicMessagesAdapter()
+    result = adapter.translate_anthropic_messages_to_openai(messages=anthropic_messages)
+
+    tool_messages = [msg for msg in result if isinstance(msg, dict) and msg.get("role") == "tool"]
+    assert len(tool_messages) == 1, "Tool message was dropped for empty content list"
+    assert tool_messages[0]["tool_call_id"] == "toolu_empty01"
+    assert tool_messages[0]["content"] == ""
+
+
+@pytest.mark.parametrize(
+    ("tool_result_content", "expected_tool_content"),
+    [
+        ([42], safe_dumps(42)),
+        (None, ""),
+        ({"type": "text", "text": "bare dict"}, safe_dumps({"type": "text", "text": "bare dict"})),
+    ],
+)
+def test_translate_anthropic_messages_to_openai_tool_result_odd_content_shapes(
+    tool_result_content, expected_tool_content
+):
+    """Regression test for LIT-6103: tool_result content that is a non-str non-dict item,
+    an explicit null, or a bare dict must still emit a role:"tool" message."""
+
+    anthropic_messages = [
+        AnthropicMessagesUserMessageParam(role="user", content=[{"type": "text", "text": "Run the tool"}]),
+        AnthopicMessagesAssistantMessageParam(
+            role="assistant",
+            content=[{"type": "tool_use", "id": "toolu_odd01", "name": "odd_tool", "input": {}}],
+        ),
+        AnthropicMessagesUserMessageParam(
+            role="user",
+            content=[{"type": "tool_result", "tool_use_id": "toolu_odd01", "content": tool_result_content}],
+        ),
+    ]
+
+    adapter = LiteLLMAnthropicMessagesAdapter()
+    result = adapter.translate_anthropic_messages_to_openai(messages=anthropic_messages)
+
+    tool_messages = [msg for msg in result if isinstance(msg, dict) and msg.get("role") == "tool"]
+    assert len(tool_messages) == 1, f"Tool message was dropped for content {tool_result_content!r}"
+    assert tool_messages[0]["tool_call_id"] == "toolu_odd01"
+    assert tool_messages[0]["content"] == expected_tool_content
+
+
+def test_translate_anthropic_messages_to_openai_tool_result_multi_item_non_dict_items():
+    """Regression test for LIT-6103: non-str non-dict items in a multi-item tool_result
+    content list must be JSON-serialized into text parts, not silently discarded."""
+
+    anthropic_messages = [
+        AnthropicMessagesUserMessageParam(role="user", content=[{"type": "text", "text": "Run the tool"}]),
+        AnthopicMessagesAssistantMessageParam(
+            role="assistant",
+            content=[{"type": "tool_use", "id": "toolu_odd02", "name": "odd_tool", "input": {}}],
+        ),
+        AnthropicMessagesUserMessageParam(
+            role="user",
+            content=[
+                {
+                    "type": "tool_result",
+                    "tool_use_id": "toolu_odd02",
+                    "content": [{"type": "text", "text": "a"}, None, 42],
+                }
+            ],
+        ),
+    ]
+
+    adapter = LiteLLMAnthropicMessagesAdapter()
+    result = adapter.translate_anthropic_messages_to_openai(messages=anthropic_messages)
+
+    tool_messages = [msg for msg in result if isinstance(msg, dict) and msg.get("role") == "tool"]
+    assert len(tool_messages) == 1
+    content = tool_messages[0]["content"]
+    assert isinstance(content, list)
+    assert len(content) == 3, "Non-dict items must not be discarded from the content list"
+    assert content[0] == {"type": "text", "text": "a"}
+    assert content[1] == {"type": "text", "text": safe_dumps(None)}
+    assert content[2] == {"type": "text", "text": safe_dumps(42)}
+
+
+def test_translate_anthropic_messages_to_openai_tool_result_null_content_preserves_cache_control():
+    """Regression test for LIT-6103: the fallthrough emit sites must carry cache_control
+    through for Claude models the same way the pre-existing branches do."""
+
+    anthropic_messages = [
+        AnthropicMessagesUserMessageParam(role="user", content=[{"type": "text", "text": "Run the tool"}]),
+        AnthopicMessagesAssistantMessageParam(
+            role="assistant",
+            content=[{"type": "tool_use", "id": "toolu_cc01", "name": "odd_tool", "input": {}}],
+        ),
+        AnthropicMessagesUserMessageParam(
+            role="user",
+            content=[
+                {
+                    "type": "tool_result",
+                    "tool_use_id": "toolu_cc01",
+                    "content": None,
+                    "cache_control": {"type": "ephemeral"},
+                }
+            ],
+        ),
+    ]
+
+    adapter = LiteLLMAnthropicMessagesAdapter()
+    result = adapter.translate_anthropic_messages_to_openai(
+        messages=anthropic_messages, model="claude-sonnet-5"
+    )
+
+    tool_messages = [msg for msg in result if isinstance(msg, dict) and msg.get("role") == "tool"]
+    assert len(tool_messages) == 1
+    assert tool_messages[0]["content"] == ""
+    assert tool_messages[0].get("cache_control") == {"type": "ephemeral"}
+
+
+def test_translate_anthropic_messages_to_openai_tool_result_all_image_parts_unconvertible():
+    """Regression test for LIT-6103: a multi-item tool_result whose parts all fail to
+    convert must still emit the tool message with empty content, never drop it."""
+
+    anthropic_messages = [
+        AnthropicMessagesUserMessageParam(role="user", content=[{"type": "text", "text": "Screenshot twice"}]),
+        AnthopicMessagesAssistantMessageParam(
+            role="assistant",
+            content=[{"type": "tool_use", "id": "toolu_img01", "name": "shot_tool", "input": {}}],
+        ),
+        AnthropicMessagesUserMessageParam(
+            role="user",
+            content=[
+                {
+                    "type": "tool_result",
+                    "tool_use_id": "toolu_img01",
+                    "content": [
+                        {"type": "image", "source": {"type": "weird"}},
+                        {"type": "image", "source": None},
+                    ],
+                }
+            ],
+        ),
+    ]
+
+    adapter = LiteLLMAnthropicMessagesAdapter()
+    result = adapter.translate_anthropic_messages_to_openai(messages=anthropic_messages)
+
+    tool_messages = [msg for msg in result if isinstance(msg, dict) and msg.get("role") == "tool"]
+    assert len(tool_messages) == 1, "Tool message must be emitted even when no parts convert"
+    assert tool_messages[0]["tool_call_id"] == "toolu_img01"
+    assert tool_messages[0]["content"] == ""


### PR DESCRIPTION
## TLDR

Problem this solves:

- `LiteLLMAnthropicMessagesAdapter.translate_anthropic_messages_to_openai` converts `tool_result` list content with a text/image-only whitelist and no fallthrough, so any other block type (`tool_reference` from Claude Code's tool search, `search_result`, `document`, future beta blocks) produces no `role:"tool"` message at all. The multi-item branch also skips the tool message entirely when no parts survive, including an empty content list
- Through any message-editing guardrail on `/v1/messages`, the write-back then rebuilds the conversation with the assistant `tool_use` orphaned, and Anthropic rejects it with `messages.N: tool_use ids were found without tool_result blocks immediately after`. Claude Code surfaces that as "API Error: 400 due to tool use concurrency issues" and the session stays bricked until the user rewinds past the tool-search call. The same drop reaches `/v1/messages` requests served by non-Anthropic chat models, which fail with `No tool output found for function call`

How it solves it:

- Unknown block types in `tool_result` content now fall through to JSON serialization (via the house `safe_dumps` helper, which cannot raise on non-JSON-serializable values) instead of being dropped: a single unknown block becomes the tool message's string content, an unknown block mixed into a multi-item list becomes a text part
- The multi-item branch always emits the tool message, with `""` content when nothing survives, and a terminal branch covers content shapes outside the absent/str/list contract (explicit null, bare dict, scalar), so a `tool_result` can never be dropped and the `tool_use`/`tool_result` pairing invariant holds

## Relevant issues

## Linear ticket

Resolves LIT-6103

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Live proxy on localhost with a message-editing guardrail (headroom compression) attached and a real Anthropic-format upstream. The request is the exact shape Claude Code sends after a tool-search call: assistant `tool_use` answered by a `tool_result` whose content is `[{"type": "tool_reference", ...}]`, with a sibling text part

```bash
curl -s -w "\nHTTP:%{http_code}\n" http://127.0.0.1:20103/v1/messages \
  -H "Authorization: Bearer sk-..." -H "content-type: application/json" \
  -d @repro.json
```

Before (base, same request):

```text
"message": "messages.2: `tool_use` ids were found without `tool_result` blocks immediately after:
toolu_01PV7TQswAGFPMWK6Cbfkxtn. Each `tool_use` block must have a corresponding `tool_result`
block in the next message."
HTTP:400
```

After (this PR, same request):

```text
x-litellm-applied-guardrails: headrooom-compression
content text: "ok"
HTTP:200
```

Three content shapes were driven on both sides, on two dependent paths (guardrail write-back to an Anthropic upstream, and the `/v1/messages` chat-adapter path to an OpenAI upstream):

```text
shape                                   base            this PR
[tool_reference] + sibling text         400             200
[text, tool_reference]                  200 (dropped)   200 (preserved)
[] empty content list                   400             200
null content (explicit)                 400             200
[42] non-dict item                      400             200
```

On the OpenAI-upstream leg the base failure reads `No tool output found for function call toolu_...`, same root cause, same fix

## Type

🐛 Bug Fix

## Changes

- `litellm/llms/anthropic/experimental_pass_through/adapters/transformation.py`: the `tool_result` conversion in `translate_anthropic_messages_to_openai` gains fallthrough branches. The single-item dispatch emits `safe_dumps(block)` for unknown dict types and non-str non-dict items, the multi-item loop appends unknown items as serialized text parts, the multi-item emit is no longer conditional on `combined_content_parts` being non-empty, and a terminal branch handles content that is neither absent, str, nor list (null becomes `""`, anything else is serialized)
- `tests/test_litellm/.../test_anthropic_experimental_pass_through_adapters_transformation.py`: ten regression cases (single `tool_reference`, `tool_reference` with sibling text asserting tool-message placement, mixed text plus unknown blocks, empty content list, null/scalar/bare-dict content, non-dict items in a multi-item list, cache_control carried through the new emit sites, all-unconvertible image parts). All ten fail on the unfixed adapter

## Behavior changes

- Requests that previously 400'd (or silently lost tool results) through guardrail translation now succeed; downstream consumers of the OpenAI-format list (guardrail scanning, complexity routing, compaction token counting) now see tool results that were previously invisible to them
- Known tradeoff, unchanged by this PR: `convert_to_anthropic_tool_result` on the write-back side has the mirror-image whitelist, so an unknown block round-trips as JSON text rather than as its original block type. The pairing and the payload survive; the block-type fidelity gap is tracked on the ticket
- Known open item, under discussion on the ticket: the Bedrock guardrail's raw-vs-structured text-count alignment does not account for the newly-emitted tool messages, so its ANONYMIZE masking write-back skips (fails open) on requests containing these shapes; blocking is unaffected. The misalignment class pre-exists on the base branch for tool_results with no content key, and before this PR the affected requests could not reach the provider at all because they died with the 400 this PR fixes. The proper fix is in the count-alignment contract of the guardrail translation layer

## QA runbook

1. Run a proxy with any message-editing guardrail (e.g. headroom compression) attached to an Anthropic model
2. Send a `/v1/messages` request containing an assistant `tool_use` answered by a `tool_result` whose content is `[{"type": "tool_reference", "tool_name": "WebFetch"}]` plus a sibling text part (this is what Claude Code sends when `ENABLE_TOOL_SEARCH=true`)
3. Expect 200 with the guardrail applied; before this PR the same request 400s with the orphaned `tool_use` error

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/berriai/litellm/pull/38237" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the Anthropic→OpenAI message translation path used by `/v1/messages` and guardrails; impact is limited to edge-case `tool_result` shapes but tool pairing is conversation-critical.
> 
> **Overview**
> Fixes **LIT-6103**: `translate_anthropic_messages_to_openai` no longer omits `role: "tool"` messages when `tool_result` content is empty, unknown, or off-schema—cases that previously left assistant `tool_use` blocks without a matching result (400s on `/v1/messages`, including Claude Code tool-search `tool_reference` payloads).
> 
> **Adapter behavior:** Unknown dict blocks in list content are serialized with `safe_dumps` (single-item → string content; multi-item → extra text parts). The multi-item path **always** appends one tool message (`""` if nothing converted). A new **else** branch handles non-string, non-list `content` (e.g. `null`, scalars, bare dicts). Single-item text/image/string handling is refactored but kept backward compatible.
> 
> **Tests:** Ten regression tests cover `tool_reference`, mixed unknown blocks, empty lists, odd shapes, `cache_control`, and unconvertible images.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ff6c3dc7c26d7ff0effdf5f247a64303dae68b4a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->