### PR TITLE
fix: make OpenRouter usage-accounting injection opt-out

### DIFF
--- a/litellm/llms/openrouter/chat/transformation.py
+++ b/litellm/llms/openrouter/chat/transformation.py
@@ -160,14 +160,15 @@ class OpenrouterConfig(OpenAIGPTConfig):
         response: Final = super().transform_request(model, messages, optional_params, litellm_params, headers)
         response.update(extra_body)
 
-        # Add OpenRouter usage accounting for cost data. Opt-out for endpoints
-        # that reject the param (e.g. an OpenAI-compatible gateway that does not
-        # accept `usage`) via per-route `model_info: {openrouter_include_usage:
-        # false}` or global `litellm.openrouter_include_usage`.
-        model_info = litellm_params.get("model_info")
-        include_usage = model_info.get("openrouter_include_usage") if model_info else None
-        if include_usage is None:
-            include_usage = getattr(litellm, "openrouter_include_usage", True)
+        model_info: Final = litellm_params.get("model_info")
+        model_include_usage: Final = (
+            model_info.get("openrouter_include_usage") if model_info else None
+        )
+        include_usage: Final = (
+            model_include_usage
+            if model_include_usage is not None
+            else getattr(litellm, "openrouter_include_usage", True)
+        )
         if include_usage and "usage" not in response:
             response["usage"] = {"include": True}
 

--- a/litellm/llms/openrouter/chat/transformation.py
+++ b/litellm/llms/openrouter/chat/transformation.py
@@ -160,9 +160,15 @@ class OpenrouterConfig(OpenAIGPTConfig):
         response: Final = super().transform_request(model, messages, optional_params, litellm_params, headers)
         response.update(extra_body)
 
-        # ALWAYS add usage parameter to get cost data from OpenRouter
-        # This ensures cost tracking works for all OpenRouter models
-        if "usage" not in response:
+        # Add OpenRouter usage accounting for cost data. Opt-out for endpoints
+        # that reject the param (e.g. an OpenAI-compatible gateway that does not
+        # accept `usage`) via per-route `model_info: {openrouter_include_usage:
+        # false}` or global `litellm.openrouter_include_usage`.
+        model_info = litellm_params.get("model_info")
+        include_usage = model_info.get("openrouter_include_usage") if model_info else None
+        if include_usage is None:
+            include_usage = getattr(litellm, "openrouter_include_usage", True)
+        if include_usage and "usage" not in response:
             response["usage"] = {"include": True}
 
         return response

--- a/tests/test_litellm/llms/openrouter/chat/test_openrouter_chat_transformation.py
+++ b/tests/test_litellm/llms/openrouter/chat/test_openrouter_chat_transformation.py
@@ -613,3 +613,28 @@ def test_openrouter_reasoning_effort_high_passes_through():
     )
 
     assert result["reasoning_effort"] == "high"
+
+
+def test_openrouter_usage_injection_default():
+    """By default OpenRouter usage accounting is injected for cost data."""
+    transformed = OpenrouterConfig().transform_request(
+        model="openrouter/openai/gpt-4o",
+        messages=[{"role": "user", "content": "hi"}],
+        optional_params={},
+        litellm_params={},
+        headers={},
+    )
+    assert transformed["usage"] == {"include": True}
+
+
+def test_openrouter_usage_injection_opt_out_via_model_info():
+    """Per-route model_info.openrouter_include_usage=False suppresses the usage
+    param for endpoints that reject it."""
+    transformed = OpenrouterConfig().transform_request(
+        model="openrouter/openai/gpt-4o",
+        messages=[{"role": "user", "content": "hi"}],
+        optional_params={},
+        litellm_params={"model_info": {"openrouter_include_usage": False}},
+        headers={},
+    )
+    assert "usage" not in transformed


### PR DESCRIPTION
## What

Make OpenRouter's `usage: {include: true}` injection **opt-out** instead of unconditional.

`OpenrouterConfig.transform_request` always adds `usage: {include: true}` to capture cost data from OpenRouter. Some OpenAI-compatible gateways/endpoints that a request can be routed through do **not** accept that parameter and reject the call with `Unknown parameter: 'usage'` (HTTP 400). This gates the injection, **default `True` so existing behavior is unchanged**:

- **per-route:** `model_info: { openrouter_include_usage: false }` on the model
- **global:** `litellm.openrouter_include_usage = False`

The opt-out is read from `model_info` (not a raw `litellm_params` key) because `get_litellm_params` only preserves a fixed allowlist of kwargs — `model_info` is always carried through to `transform_request`, so the per-route flag reliably reaches it.

## Why

Lets deployments route `openrouter/*` through an endpoint that rejects `usage` (e.g. an OpenAI-compatible proxy) while every other OpenRouter route keeps cost accounting on by default.

## Test

`tests/test_litellm/llms/openrouter/chat/test_openrouter_chat_transformation.py`: `usage` is injected by default and omitted when `model_info.openrouter_include_usage` is `false`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
