### PR TITLE
chore: bump litellm-enterprise 0.1.59 -> 0.1.60, litellm 1.99.0 -> 1.100.0

### DIFF
--- a/enterprise/pyproject.toml
+++ b/enterprise/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "litellm-enterprise"
-version = "0.1.59"
+version = "0.1.60"
 description = "Package for LiteLLM Enterprise features"
 readme = "README.md"
 requires-python = ">=3.9"
@@ -26,7 +26,7 @@ required-version = ">=0.10.9"
 module-root = ""
 
 [tool.commitizen]
-version = "0.1.59"
+version = "0.1.60"
 version_files = [
     "pyproject.toml:^version",
     "../pyproject.toml:litellm-enterprise==",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "litellm"
-version = "1.99.0"
+version = "1.100.0"
 description = "Library to easily interface with LLM API providers"
 readme = "README.md"
 requires-python = ">=3.10, <3.15"
@@ -68,7 +68,7 @@ proxy = [
     "azure-storage-blob>=12.28.0,<13.0",
     "mcp>=1.28.1,<2.0",
     "litellm-proxy-extras==0.4.89",
-    "litellm-enterprise==0.1.59",
+    "litellm-enterprise==0.1.60",
     "RestrictedPython>=8.1,<9.0",
     "rich>=13.9.4,<14.0",
     "InquirerPy>=0.3.4,<1.0",
@@ -310,7 +310,7 @@ members = ["enterprise", "litellm-proxy-extras"]
 profile = "black"
 
 [tool.commitizen]
-version = "1.99.0"
+version = "1.100.0"
 version_files = [
     "pyproject.toml:^version",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -10,7 +10,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-08-19T15:53:37.294198Z"
+exclude-newer = "2026-08-23T02:27:57.028643Z"
 exclude-newer-span = "P3D"
 
 [manifest]
@@ -4266,7 +4266,7 @@ wheels = [
 
 [[package]]
 name = "litellm"
-version = "1.99.0"
+version = "1.100.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },
@@ -4661,7 +4661,7 @@ proxy-dev = [
 
 [[package]]
 name = "litellm-enterprise"
-version = "0.1.59"
+version = "0.1.60"
 source = { editable = "enterprise" }
 
 [[package]]


### PR DESCRIPTION
## TLDR

Problem this solves:

- 1.99.0 line graduated (v1.99.0-rc.1 tagged); next promotion opens a new line
- enterprise/ changed since main but still publishes as 0.1.59
- Without bumps, the next release ships stale versions

How it solves it:

- Bumps root litellm 1.99.0 -> 1.100.0 (weekly MINOR, per release scheme)
- Bumps litellm-enterprise 0.1.59 -> 0.1.60 (PATCH) plus the root pin
- Refreshes uv.lock against the new versions

## User Flow

Not applicable: this is a version metadata change only, no behavior changes. The next nightly and rc cut from staging will publish as 1.100.0.x instead of continuing the graduated 1.99.0 line

## Relevant issues

None

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests (not applicable: version bump only, no behavior to test)
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

There is no meaningful proof of fix for a version bump. The diff is the version lines in pyproject.toml and enterprise/pyproject.toml plus the matching uv.lock refresh; the lock's only other movement is the rolling exclude-newer timestamp, with no third-party package changes

## Type

🚄 Infrastructure

## Caveats (if any)

- litellm-proxy-extras (0.4.89) is unchanged since main, so no bump for it

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
