### PR TITLE
fix(utils): stop shorten_message_to_fit_limit growing the message when half_length is 0

### DIFF
--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -7161,7 +7161,10 @@ def shorten_message_to_fit_limit(message, tokens_needed, model: str | None, rais
 
         half_length = new_length // 2
         left_half = content[:half_length]
-        right_half = content[-half_length:]
+        # content[-0:] is content[0:], i.e. the whole string, so a zero half has to be
+        # spelled out. Otherwise every further attempt prepends ".." to the full content
+        # and the message grows by two characters instead of shrinking.
+        right_half = content[-half_length:] if half_length else ""
 
         trimmed_content = left_half + ".." + right_half
         message["content"] = trimmed_content

--- a/tests/test_litellm/test_utils.py
+++ b/tests/test_litellm/test_utils.py
@@ -6136,3 +6136,20 @@ def test_load_credentials_from_list_fills_kwargs_from_the_loaded_credential_with
         "api_key": "sk-from-db",
     }
     assert _credential_warnings(caplog) == []
+
+def test_shorten_message_to_fit_limit_never_grows_content():
+    """A zero half_length must not turn the trim into a two-character prefix.
+
+    `content[-0:]` is `content[0:]`, so with half_length == 0 the "right half" is the
+    whole string and each attempt returns `".." + content`. The loop then runs its full
+    attempt budget growing the message two characters at a time.
+    """
+    from litellm.utils import shorten_message_to_fit_limit
+
+    content = "hello world " * 40
+    message = {"role": "user", "content": content}
+
+    result = shorten_message_to_fit_limit(message, tokens_needed=1, model="claude-3-5-sonnet-20240620")
+
+    assert len(result["content"]) < len(content)
+    assert not result["content"].startswith("....")


### PR DESCRIPTION
## Relevant issues

Reported before in #28128. That issue and its PR #28129 were both closed by the stale bot (the PR never cleared the CLA check), and the defect is still on `litellm_internal_staging` today, so this reopens the fix with a trace of the loop and a regression test. Credit to @DSurya11 for the original report.

## What happens

`shorten_message_to_fit_limit` keeps the first and last `new_length // 2` characters:

```python
half_length = new_length // 2
left_half = content[:half_length]
right_half = content[-half_length:]
trimmed_content = left_half + ".." + right_half
```

`new_length = int(len(content) * tokens_needed / total_tokens) - 1`, so a small budget next to a large message drives `new_length` to 0 or 1 and `half_length` to 0. `content[-0:]` is `content[0:]`, the whole string, so `trimmed_content` becomes `".." + content`: two characters longer than the input. The loop then repeats that until `MAX_TOKEN_TRIMMING_ATTEMPTS` runs out, calling `get_token_count` each time on a message it is making bigger.

Loop trace on staging, `tokens_needed=1`, content `"hello world " * 40`:

```
attempt 0: tokens=88 len=480 new_length=4 half_length=2 right_half_len=2  -> len 6
attempt 1: tokens=11 len=6   new_length=0 half_length=0 right_half_len=6  -> len 8
attempt 2: tokens=12 len=8   new_length=0 half_length=0 right_half_len=8  -> len 10
attempt 3: tokens=12 len=10  new_length=0 half_length=0 right_half_len=10 -> len 12
...
attempt 9: tokens=12 len=22  new_length=0 half_length=0 right_half_len=22 -> len 24
final tokens: 13   needed: 1     content: '..................he..d '
```

From attempt 1 on, the "right half" is the entire string. The message grows monotonically and the function returns content that is four times longer than at attempt 1 and still 13x over budget. `trim_messages` reaches this through `process_messages` -> `shorten_message_to_fit_limit`.

The `tokens_needed <= 10` early return above only covers models whose name contains `gpt`.

## Fix

One line: spell out the empty right half, since `-0` cannot express it.

```python
right_half = content[-half_length:] if half_length else ""
```

The trim then converges on `".."` rather than walking away from the target.

## Testing

`tests/test_litellm/test_utils.py::test_shorten_message_to_fit_limit_never_grows_content`, which fails on the current code and passes with the fix:

```
# before
E  AssertionError: assert not True
E   +  where True = '..................he..d '.startswith('....')
1 failed

# after
1 passed
```

Same input after the fix: 480 chars / 88 tokens in, `'..'` / 8 tokens out (8 is the per-message overhead, the floor for any content).

The existing trimming tests are unchanged either way, run as a control:

```
pytest tests/litellm_utils_tests/test_utils.py -k "trim or shorten"
13 passed        # on current staging
13 passed        # with this patch
```

To be explicit about the repo's proof-of-fix bar: this is pytest evidence only. I have not run a live proxy with real provider calls, because this function is pure string and token arithmetic with no network path, so a live call would exercise nothing the tests above do not.

## Type

🐛 Bug Fix

## Pre-Submission checklist

- [x] I have Added testing in the `tests/test_litellm/` directory
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
