### PR TITLE
fix(anthropic): translate tool_result document blocks in the /v1/messages bridge

### DIFF
--- a/litellm/llms/anthropic/experimental_pass_through/adapters/transformation.py
+++ b/litellm/llms/anthropic/experimental_pass_through/adapters/transformation.py
@@ -434,7 +434,7 @@ class LiteLLMAnthropicMessagesAdapter:
                                 content_items = list(content.get("content", []))
 
                                 # Single-item text keeps the backward-compatible string format; a single
-                                # image becomes a structured image_url part
+                                # image or document becomes a structured image_url part
                                 if len(content_items) == 1:
                                     c = content_items[0]
                                     if isinstance(c, str):
@@ -454,7 +454,7 @@ class LiteLLMAnthropicMessagesAdapter:
                                             )
                                             self._add_cache_control_if_applicable(content, tool_result, model)
                                             tool_message_list.append(tool_result)
-                                        elif c.get("type") == "image":
+                                        elif c.get("type") in ("image", "document"):
                                             image_part = self._tool_result_image_part(c.get("source"))
                                             tool_result = ChatCompletionToolMessage(
                                                 role="tool",
@@ -482,7 +482,7 @@ class LiteLLMAnthropicMessagesAdapter:
                                                         text=c.get("text", ""),
                                                     )
                                                 )
-                                            elif c.get("type") == "image":
+                                            elif c.get("type") in ("image", "document"):
                                                 image_part = self._tool_result_image_part(c.get("source"))
                                                 if image_part:
                                                     combined_content_parts.append(image_part)

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_anthropic_experimental_pass_through_adapters_transformation.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_anthropic_experimental_pass_through_adapters_transformation.py
@@ -1,3 +1,4 @@
+import base64
 from typing import Any, cast
 
 import pytest
@@ -11,6 +12,7 @@ from litellm.litellm_core_utils.prompt_templates.common_utils import (
 )
 from litellm.litellm_core_utils.prompt_templates.factory import (
     THOUGHT_SIGNATURE_SEPARATOR,
+    _bedrock_converse_messages_pt,
 )
 from litellm.llms.anthropic.experimental_pass_through.adapters.transformation import (
     OPENAI_MAX_TOOL_NAME_LENGTH,
@@ -3870,6 +3872,75 @@ def test_tool_result_plain_text_unchanged_by_openai_transform():
     assert len(tool_messages) == 1
     assert tool_messages[0]["content"] == "42 files found"
     assert _image_urls_in_user_messages(result) == []
+
+
+TOOL_RESULT_PDF_B64 = base64.b64encode(b"%PDF-1.4 minimal regression fixture").decode()
+
+
+def _base64_pdf_block():
+    return {
+        "type": "document",
+        "source": {"type": "base64", "media_type": "application/pdf", "data": TOOL_RESULT_PDF_B64},
+    }
+
+
+def test_tool_result_single_document_kept_as_pdf_data_url():
+    adapter = LiteLLMAnthropicMessagesAdapter()
+    translated = adapter.translate_anthropic_messages_to_openai(
+        messages=[
+            _anthropic_tool_use_turn("toolu_01"),
+            _anthropic_tool_result_turn({"toolu_01": [_base64_pdf_block()]}),
+        ]
+    )
+
+    tool_messages = [m for m in translated if m.get("role") == "tool"]
+    assert len(tool_messages) == 1
+    assert tool_messages[0]["content"] == [
+        {
+            "type": "image_url",
+            "image_url": {"url": f"data:application/pdf;base64,{TOOL_RESULT_PDF_B64}"},
+        }
+    ]
+
+
+def test_tool_result_text_and_document_reach_bedrock_converse_tool_result():
+    """Claude Code >= 2.1.245 sends Read-tool PDF output as a document block inside
+    tool_result; dropping it left bedrock converse models blind to the PDF content."""
+    adapter = LiteLLMAnthropicMessagesAdapter()
+    translated = adapter.translate_anthropic_messages_to_openai(
+        messages=[
+            AnthropicMessagesUserMessageParam(role="user", content="Read pong.pdf"),
+            _anthropic_tool_use_turn("toolu_01"),
+            _anthropic_tool_result_turn(
+                {
+                    "toolu_01": [
+                        {"type": "text", "text": "PDF file read: pong.pdf (579 bytes)"},
+                        _base64_pdf_block(),
+                    ]
+                }
+            ),
+        ]
+    )
+
+    converse_messages = _bedrock_converse_messages_pt(
+        messages=translated,
+        model="anthropic.claude-haiku-4-5-20251001-v1:0",
+        llm_provider="bedrock_converse",
+    )
+
+    tool_results = [
+        block["toolResult"]
+        for message in converse_messages
+        for block in message["content"]
+        if "toolResult" in block
+    ]
+    assert len(tool_results) == 1
+    documents = [part["document"] for part in tool_results[0]["content"] if "document" in part]
+    assert len(documents) == 1
+    assert documents[0]["format"] == "pdf"
+    assert documents[0]["source"]["bytes"] == TOOL_RESULT_PDF_B64
+    texts = [part["text"] for part in tool_results[0]["content"] if "text" in part]
+    assert texts == ["PDF file read: pong.pdf (579 bytes)"]
 
 
 def test_translate_anthropic_to_openai_carries_prompt_cache_breakpoint_on_system_and_user_blocks():


### PR DESCRIPTION
## TLDR

Problem this solves:

- Claude Code >= 2.1.245 puts Read-tool PDF output in a `document` block inside `tool_result`
- The /v1/messages bridge dropped those blocks, so chat-bridged models (e.g. Bedrock Converse) never saw the PDF
- This turned the e2e `pdf_input` bedrock_converse cell red for unrelated PRs

How it solves it:

- Translate `document` blocks in `tool_result` content like `image` blocks (data URL part)
- Bedrock Converse then rebuilds them as native `toolResult` document blocks

## User Flow

Before: a Claude Code user on a LiteLLM gateway with a Bedrock Converse Claude model asks about a PDF and the model answers as if the file were empty

1. They point Claude Code (2.1.245 or newer) at the gateway: `ANTHROPIC_BASE_URL=https://litellm-domain`, `ANTHROPIC_AUTH_TOKEN=sk-...`
2. They run `claude --print --model claude-haiku-4-5-bedrock-converse --allowed-tools Read -- "Use the Read tool to read the file at ./pong.pdf. Report the single word that appears in the document."`
3. The CLI sends `POST https://litellm-domain/v1/messages`, the model calls Read, and the CLI sends a follow-up `POST /v1/messages` whose tool result carries a text stub plus the PDF as a document attachment
4. The answer comes back: "I read the PDF file, but the result shows it was successfully read (579 bytes) without displaying the extracted text content", and the word PONG never appears

After: the same run answers with the PDF's content

1. They point Claude Code (2.1.245 or newer) at the gateway: `ANTHROPIC_BASE_URL=https://litellm-domain`, `ANTHROPIC_AUTH_TOKEN=sk-...`
2. They run `claude --print --model claude-haiku-4-5-bedrock-converse --allowed-tools Read -- "Use the Read tool to read the file at ./pong.pdf. Report the single word that appears in the document."`
3. The CLI sends the same two `POST https://litellm-domain/v1/messages` requests with the same tool result
4. The answer comes back: "The single word that appears in the document is **PONG**."

## Relevant issues

## Linear ticket

Resolves LIT-6127

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Setup shared by both legs: a DB-less proxy on port 27248 with this config (AWS creds from env, us-east-1)

```yaml
model_list:
  - model_name: claude-haiku-4-5-bedrock-converse
    litellm_params:
      model: bedrock/converse/us.anthropic.claude-haiku-4-5-20251001-v1:0
      aws_region_name: us-east-1

general_settings:
  master_key: sk-lit6127-repro
```

`pong.pdf` is a single-page PDF whose only visible text is PONG, built by the same generator as `tests/e2e/claude_code/pdf_input/test_bedrock_converse.py`. The client is the real Claude Code CLI at 2.1.245 (the version the e2e runner image picked up when the cell went red), run with a PATH that has no poppler-utils to match the CI image. Real Bedrock haiku calls, real $

### Before (a9f42f0ccf)

1. Boot the proxy at the merge base: `python litellm/proxy/proxy_cli.py --config proxy_config.yaml --port 27248 --detailed_debug` (no `DATABASE_URL` set)
2. Run the CLI:
   ```
   env -i HOME="$(mktemp -d)" PATH=/usr/bin:/bin:/usr/sbin:/sbin \
     ANTHROPIC_BASE_URL=http://127.0.0.1:27248 ANTHROPIC_AUTH_TOKEN=sk-lit6127-repro \
     claude --print --output-format stream-json --verbose \
     --model claude-haiku-4-5-bedrock-converse --allowed-tools Read -- \
     "Use the Read tool to read the file at ./pong.pdf. Report the single word that appears in the document."
   ```
3. The CLI's follow-up request carries `tool_result.content = [{"type": "text", ...}, {"type": "document", "source": {"type": "base64", "media_type": "application/pdf", ...}}]`, but the proxy's Converse request drops the document:
   ```
   "toolResult": {"content": [{"text": "PDF file read: .../pong.pdf (579 bytes)"}], "toolUseId": "tooluse_iD6bmyhbSBekBN6HIkBF6K"}
   ```
4. Final result line, no PONG:
   ```
   I read the PDF file, but the tool result shows only that the file was successfully read (579 bytes) without displaying the extracted text content. ...
   ```

### After (17845b4fb0)

1. Boot the same proxy at the PR tip, same config
2. Run the identical CLI command with the identical `pong.pdf`
3. The proxy's Converse request now keeps the PDF as a native document block:
   ```
   "toolResult": {"content": [{"text": "PDF file read: .../pong.pdf (579 bytes)"}, {"document": {"source": {"bytes": "JVBERi0xLjQKMSAwIG9iag..."}, "format": "pdf", "name": "DocumentPDFmessages_..."}}], ...}
   ```
4. Final result line:
   ```
   The single word that appears in the document is **PONG**.
   ```

Sanity leg: Claude Code 2.1.237 (which sends the PDF as a sibling user-content document block instead) passes against both the merge base and the PR tip, which is why the e2e cell only went red when the unpinned CI image moved from 2.1.237 to 2.1.245

### Fresh e2e run at this tip

[litellm-e2e-pr build 130](https://buildkite.com/berriai-1/litellm-e2e-pr/builds/130) (LITELLM_SHA=17845b4fb0, E2E_PATHS=claude_code/pdf_input) is green: all 5 pdf_input cells pass, including the previously red `test_bedrock_converse.py::test_pdf_input_bedrock_converse`, with all 15 model legs passing (bedrock_converse pass=3). The same selection failed this cell on all 3 converse models in [builds 126-128](https://buildkite.com/berriai-1/litellm-e2e-pr/builds/128) before the fix

## Type

🐛 Bug Fix

## Caveats (if any)

- Anthropic-native providers (anthropic, bedrock invoke, vertex) were never affected; they bypass this bridge

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

CHECKED: live-pr-risk at 17845b4fb0, verdict safe. Every downstream consumer of tool-message image_url parts was driven live on real providers, base vs head: Bedrock Converse rebuilds the pdf as a native toolResult document block, Gemini receives it as inline_data and answers from it, and OpenAI routes through the Responses bridge, which drops the part identically on both sides (pre-existing gap, filed separately). The openai/azure chat hoist path is unreachable through the /v1/messages bridge, and if reached it produces the same wire shape the long-standing user-content document path already produces. No subclasses, no renames, no config or wire-field changes; staging drift since the merge base does not touch the changed or consumer files

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow adapter change mirroring existing image tool_result handling; tests lock PDF→Converse document behavior with no auth or config changes.
> 
> **Overview**
> Fixes a regression where **Claude Code ≥ 2.1.245** puts Read-tool PDFs in `tool_result` as **`document`** blocks and the `/v1/messages` adapter only handled **`image`**, so bridged backends (notably **Bedrock Converse**) saw text stubs without the PDF.
> 
> The adapter now treats **`document`** like **`image`** in `tool_result` (single-item and combined multi-part paths), emitting the same **`image_url`** data-URL shape via `_tool_result_image_part`, which downstream Converse formatting turns into native **`toolResult` document** blocks.
> 
> Tests cover a lone PDF document in a tool message and a mixed text+document result through `_bedrock_converse_messages_pt`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 17845b4fb01b8ec3d0c90254bece1b802807f77c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->