### PR TITLE
fix(anthropic): carry tool_result document blocks through the /v1/messages responses bridge

### DIFF
--- a/litellm/llms/anthropic/experimental_pass_through/responses_adapters/transformation.py
+++ b/litellm/llms/anthropic/experimental_pass_through/responses_adapters/transformation.py
@@ -271,7 +271,16 @@ class LiteLLMAnthropicToResponsesAPIAdapter:
                         elif btype == "tool_result":
                             tool_use_id = block.get("tool_use_id", "")
                             inner = block.get("content")
-                            tool_file_parts: tuple[dict[str, str], ...] = ()  # mutable-ok: json content parts
+                            document_candidates = (
+                                tuple(
+                                    self._translate_anthropic_document_block_to_file_part(c)
+                                    for c in inner
+                                    if isinstance(c, dict) and c.get("type") == "document"
+                                )
+                                if isinstance(inner, list)
+                                else ()
+                            )
+                            tool_file_parts = tuple(part for part in document_candidates if part is not None)
                             if inner is None:
                                 output_text = ""
                             elif isinstance(inner, str):
@@ -297,12 +306,6 @@ class LiteLLMAnthropicToResponsesAPIAdapter:
                                         {"type": "input_image", "image_url": url}  # mutable-ok: json content part
                                         for url in image_urls
                                     )
-                                document_candidates = tuple(
-                                    self._translate_anthropic_document_block_to_file_part(c)
-                                    for c in inner
-                                    if isinstance(c, dict) and c.get("type") == "document"
-                                )
-                                tool_file_parts = tuple(part for part in document_candidates if part is not None)
                             else:
                                 output_text = str(inner)
                             # tool_result is a top-level item, not inside the message

--- a/litellm/llms/anthropic/experimental_pass_through/responses_adapters/transformation.py
+++ b/litellm/llms/anthropic/experimental_pass_through/responses_adapters/transformation.py
@@ -88,6 +88,51 @@ class LiteLLMAnthropicToResponsesAPIAdapter:
         return None
 
     @staticmethod
+    def _translate_anthropic_document_block_to_file_part(
+        block: Mapping[str, object],
+    ) -> dict[str, str] | None:  # mutable-ok: API message payload
+        """Convert an Anthropic document block to a Responses input_file part."""
+        raw_source: Final = block.get("source")
+        if not isinstance(raw_source, Mapping):
+            return None
+        source: Final = cast(Mapping[str, object], raw_source)  # cast-ok: untrusted client payload
+        source_type: Final = source.get("type")
+        if source_type == "base64":
+            data: Final = source.get("data")
+            if not isinstance(data, str) or not data:
+                return None
+            raw_media_type: Final = source.get("media_type")
+            media_type: Final = (
+                raw_media_type if isinstance(raw_media_type, str) and raw_media_type else "application/pdf"
+            )
+            raw_title: Final = block.get("title")
+            filename: Final = raw_title if isinstance(raw_title, str) and raw_title else "document.pdf"
+            return {  # mutable-ok: API message payload
+                "type": "input_file",
+                "filename": filename,
+                "file_data": f"data:{media_type};base64,{data}",
+            }
+        if source_type == "url":
+            url: Final = source.get("url")
+            if not isinstance(url, str) or not url:
+                return None
+            return {"type": "input_file", "file_url": url}  # mutable-ok: API message payload
+        return None
+
+    @staticmethod
+    def _tool_result_output_value(
+        output_text: str,
+        file_parts: tuple[dict[str, str], ...],  # mutable-ok: json content parts
+    ) -> str | list[dict[str, str]]:  # mutable-ok: API message payload
+        """Plain string output, or a part list when document file parts are present."""
+        if not file_parts:
+            return output_text
+        text_parts: Final = (
+            [{"type": "input_text", "text": output_text}] if output_text else []  # mutable-ok: API message payload
+        )
+        return [*text_parts, *file_parts]  # mutable-ok: API message payload
+
+    @staticmethod
     def _translate_midturn_system_content_to_responses(
         content: str | Iterable[AnthropicSystemMessageContent],
     ) -> list[dict[str, object]]:  # mutable-ok: API message payload
@@ -226,6 +271,7 @@ class LiteLLMAnthropicToResponsesAPIAdapter:
                         elif btype == "tool_result":
                             tool_use_id = block.get("tool_use_id", "")
                             inner = block.get("content")
+                            tool_file_parts: tuple[dict[str, str], ...] = ()  # mutable-ok: json content parts
                             if inner is None:
                                 output_text = ""
                             elif isinstance(inner, str):
@@ -251,6 +297,12 @@ class LiteLLMAnthropicToResponsesAPIAdapter:
                                         {"type": "input_image", "image_url": url}  # mutable-ok: json content part
                                         for url in image_urls
                                     )
+                                document_candidates = tuple(
+                                    self._translate_anthropic_document_block_to_file_part(c)
+                                    for c in inner
+                                    if isinstance(c, dict) and c.get("type") == "document"
+                                )
+                                tool_file_parts = tuple(part for part in document_candidates if part is not None)
                             else:
                                 output_text = str(inner)
                             # tool_result is a top-level item, not inside the message
@@ -258,7 +310,7 @@ class LiteLLMAnthropicToResponsesAPIAdapter:
                                 {
                                     "type": "function_call_output",
                                     "call_id": tool_use_id,
-                                    "output": output_text,
+                                    "output": self._tool_result_output_value(output_text, tool_file_parts),
                                 }
                             )
                     if tool_image_parts:

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/responses_adapters/test_responses_adapters_transformation.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/responses_adapters/test_responses_adapters_transformation.py
@@ -16,7 +16,10 @@ from litellm.constants import (
     DEFAULT_REASONING_EFFORT_LOW_THINKING_BUDGET,
     DEFAULT_REASONING_EFFORT_MEDIUM_THINKING_BUDGET,
 )
-from litellm.litellm_core_utils.prompt_templates.common_utils import TOOL_RESULT_IMAGE_BOUNDARY
+from litellm.litellm_core_utils.prompt_templates.common_utils import (
+    TOOL_RESULT_IMAGE_BOUNDARY,
+    TOOL_RESULT_IMAGE_PLACEHOLDER,
+)
 from litellm.llms.anthropic.experimental_pass_through.responses_adapters.transformation import (
     LiteLLMAnthropicToResponsesAPIAdapter,
 )
@@ -1553,6 +1556,119 @@ class TestToolResultImages:
         outputs = [item for item in items if item.get("type") == "function_call_output"]
         assert outputs[0]["output"] == "screenshot saved"
         assert self._input_images(items) == []
+
+
+class TestToolResultDocuments:
+    """Documents inside tool_result blocks must survive translation (LIT-6135):
+    the function_call_output output becomes a list of parts carrying the joined
+    text as input_text and each document as an input_file. Without documents the
+    output stays the plain string it always was."""
+
+    PDF_B64 = "JVBERi0xLjQKJSBQT05H"
+    PDF_DATA_URI = "data:application/pdf;base64,JVBERi0xLjQKJSBQT05H"
+    PDF_URL = "https://example.com/report.pdf"
+    PNG_B64 = "iVBORw0KGgoAAAANSUhEUg=="
+
+    def _messages(self, tool_result_content):
+        return [
+            {"role": "user", "content": "read the pdf"},
+            {
+                "role": "assistant",
+                "content": [{"type": "tool_use", "id": "toolu_01", "name": "read", "input": {}}],
+            },
+            {
+                "role": "user",
+                "content": [
+                    {"type": "tool_result", "tool_use_id": "toolu_01", "content": tool_result_content}
+                ],
+            },
+        ]
+
+    def _translate(self, tool_result_content):
+        return _ADAPTER.translate_messages_to_responses_input(self._messages(tool_result_content))
+
+    @staticmethod
+    def _tool_output(items):
+        return next(item for item in items if item.get("type") == "function_call_output")["output"]
+
+    def _base64_document(self, **extra):
+        return {
+            "type": "document",
+            "source": {"type": "base64", "media_type": "application/pdf", "data": self.PDF_B64},
+            **extra,
+        }
+
+    def test_text_and_base64_document_produce_part_list(self):
+        output = self._tool_output(
+            self._translate([{"type": "text", "text": "PDF file read: mystery.pdf"}, self._base64_document()])
+        )
+        assert output == [
+            {"type": "input_text", "text": "PDF file read: mystery.pdf"},
+            {"type": "input_file", "filename": "document.pdf", "file_data": self.PDF_DATA_URI},
+        ]
+
+    def test_document_only_produces_single_file_part(self):
+        output = self._tool_output(self._translate([self._base64_document()]))
+        assert output == [{"type": "input_file", "filename": "document.pdf", "file_data": self.PDF_DATA_URI}]
+
+    def test_document_title_becomes_filename(self):
+        output = self._tool_output(self._translate([self._base64_document(title="quarterly-report.pdf")]))
+        assert output == [
+            {"type": "input_file", "filename": "quarterly-report.pdf", "file_data": self.PDF_DATA_URI}
+        ]
+
+    def test_url_document_becomes_file_url_part(self):
+        output = self._tool_output(
+            self._translate([{"type": "document", "source": {"type": "url", "url": self.PDF_URL}}])
+        )
+        assert output == [{"type": "input_file", "file_url": self.PDF_URL}]
+
+    def test_document_with_empty_data_falls_back_to_string_output(self):
+        output = self._tool_output(
+            self._translate(
+                [
+                    {"type": "text", "text": "PDF file read"},
+                    {"type": "document", "source": {"type": "base64", "media_type": "application/pdf", "data": ""}},
+                ]
+            )
+        )
+        assert output == "PDF file read"
+
+    def test_document_without_source_dict_keeps_string_output(self):
+        output = self._tool_output(
+            self._translate([{"type": "text", "text": "stub"}, {"type": "document", "source": self.PDF_URL}])
+        )
+        assert output == "stub"
+
+    def test_text_only_tool_result_keeps_plain_string_output(self):
+        output = self._tool_output(self._translate([{"type": "text", "text": "plain result"}]))
+        assert output == "plain result"
+
+    def test_text_image_and_document_mix(self):
+        items = self._translate(
+            [
+                {"type": "text", "text": "captured"},
+                {"type": "image", "source": {"type": "base64", "media_type": "image/png", "data": self.PNG_B64}},
+                self._base64_document(),
+            ]
+        )
+
+        output = self._tool_output(items)
+        assert output == [
+            {"type": "input_text", "text": f"captured\n{TOOL_RESULT_IMAGE_PLACEHOLDER}"},
+            {"type": "input_file", "filename": "document.pdf", "file_data": self.PDF_DATA_URI},
+        ]
+
+        image_message = next(
+            item
+            for item in items
+            if item.get("type") == "message"
+            and any(part.get("type") == "input_image" for part in item.get("content", []))
+        )
+        assert image_message["content"] == [
+            {"type": "input_text", "text": TOOL_RESULT_IMAGE_BOUNDARY},
+            {"type": "input_image", "image_url": f"data:image/png;base64,{self.PNG_B64}"},
+        ]
 
 
 def _contains_key(value, key) -> bool:

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/responses_adapters/test_responses_adapters_transformation.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/responses_adapters/test_responses_adapters_transformation.py
@@ -1644,6 +1644,23 @@ class TestToolResultDocuments:
         output = self._tool_output(self._translate([{"type": "text", "text": "plain result"}]))
         assert output == "plain result"
 
+    def test_file_id_source_document_keeps_string_output(self):
+        output = self._tool_output(
+            self._translate(
+                [
+                    {"type": "text", "text": "stub"},
+                    {"type": "document", "source": {"type": "file", "file_id": "file_abc123"}},
+                ]
+            )
+        )
+        assert output == "stub"
+
+    def test_url_source_without_url_keeps_string_output(self):
+        output = self._tool_output(
+            self._translate([{"type": "text", "text": "stub"}, {"type": "document", "source": {"type": "url"}}])
+        )
+        assert output == "stub"
+
     def test_text_image_and_document_mix(self):
         items = self._translate(
             [


### PR DESCRIPTION
## TLDR

Problem this solves:

- /v1/messages tool_result document blocks never reach OpenAI models
- Claude Code PDF reads through the gateway lose the PDF bytes
- the model only receives a one-line text stub

How it solves it:

- translate each document block to a Responses input_file part
- function_call_output output becomes a part list when documents are present
- text-only and image-only tool results keep today's exact wire shape

## User Flow

Before: a Claude Code user on a LiteLLM gateway asks gpt-5.6 for the single word inside a local PDF, and the answer never contains it

1. They set ANTHROPIC_BASE_URL to https://litellm-domain, start Claude Code 2.1.245 with --model gpt-5.6, and prompt: use the Read tool to read ./mystery.pdf (no pages) and report the single word in the document
2. Claude Code reads the file and sends POST https://litellm-domain/v1/messages with a tool_result carrying the text stub "PDF file read: mystery.pdf (579 bytes)" plus the PDF as a base64 document block
3. The request returns 200, but the model answers that it could not extract the word because the tool returned only PDF metadata, and PONG, the word printed inside the PDF, never appears

After: the same prompt ends with the model reporting the word inside the PDF

1. They set ANTHROPIC_BASE_URL to https://litellm-domain, start Claude Code 2.1.245 with --model gpt-5.6, and prompt: use the Read tool to read ./mystery.pdf (no pages) and report the single word in the document
2. Claude Code reads the file and sends POST https://litellm-domain/v1/messages with a tool_result carrying the text stub "PDF file read: mystery.pdf (579 bytes)" plus the PDF as a base64 document block
3. The request returns 200 and the model's answer names PONG, the single word printed inside the PDF

## Relevant issues

## Linear ticket

Resolves LIT-6135

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

QA run against real gpt-5.6 (real spend): the before leg on a proxy at the merge base 104fe73113, the after leg on a proxy at this PR's tip 5998c0d1d2. Each leg is a DB-less proxy with 2 uvicorn workers plus Claude Code 2.1.245 driven interactively in its TUI, with pdftotext absent from PATH so the Read tool attaches the PDF as a document block instead of extracting text locally. mystery.pdf is a 579-byte PDF whose only content word is PONG, and the filename deliberately does not leak the marker

Proxy (lit6135_config.yaml below; before leg on port 42544, after leg on port 50777):

```bash
python litellm/proxy/proxy_cli.py --config lit6135_config.yaml --port <port> --num_workers 2 --detailed_debug
```

```yaml
model_list:
  - model_name: gpt-5.6
    litellm_params:
      model: openai/gpt-5.6
      api_key: os.environ/OPENAI_API_KEY

general_settings:
  master_key: sk-lit6135-repro
```

Client, identical for both legs apart from the port:

```bash
tmux new-session -d -s lit6135 -x 220 -y 50 -c "$scratch" \
  "env -i HOME=$fresh_home PATH=$scratch/bin:/usr/bin:/bin:/usr/sbin:/sbin TERM=xterm-256color \
   ANTHROPIC_BASE_URL=http://127.0.0.1:<port> ANTHROPIC_AUTH_TOKEN=sk-lit6135-repro \
   claude --model gpt-5.6 --allowed-tools Read"
```

then, in the TUI: "Use the Read tool to read the file at ./mystery.pdf, passing only the file_path parameter (no pages). Report the single word that appears in the document."

### Before (proxy at merge base 104fe73113, port 42544): the model never sees the PDF

```
❯ Use the Read tool to read the file at ./mystery.pdf, passing only the file_path parameter (no pages). Report the single word that appears in the document.

  Read 1 file (ctrl+o to expand)

⏺ Bash(python3 -c "from pathlib import Path; print(Path('/…/scratchpad/lit61…)
  ⎿  Interrupted · What should Claude do instead?

❯ Do not run any more tools. Based only on what the Read tool already returned, report the single word that appears in the document.

⏺ The Read result contained no visible document text, so I can't determine the word without guessing.
```

PONG appears nowhere in the answer, and the model even tried to escape its blindness by cat'ing the file with Bash (denied to keep the run Read-only). Supporting color from the proxy log: the outgoing POST https://api.openai.com/v1/responses carried only `'output': 'PDF file read: .../mystery.pdf (579 bytes)'`, and `grep -c JVBERi` over the complete outgoing request body found zero hits, so the PDF bytes never left the gateway

### After (proxy at e1a0920445, port 30071): same client, same PDF, same prompt

The current tip c3c9e3a919 adds only test cases on top of e1a0920445: `git diff e1a0920445 c3c9e3a919 --stat -- ':!tests'` is empty, so the proxy code under test is identical to the tip

```
❯ Use the Read tool to read the file at ./mystery.pdf, passing only the file_path parameter (no pages). Report the single word that appears in the document.

  Read 1 file (ctrl+o to expand)

⏺ PONG
```

Supporting color from the proxy log: the outgoing function_call_output output is now a part list ending in `{'type': 'input_file', 'filename': 'document.pdf', 'file_data': 'data:application/pdf;base64,JVBERi...'}`, and a direct probe of api.openai.com/v1/responses with a file-only output list (no input_text part) also returns HTTP 200 with the model reading the PDF

Run observations, neither caused by this PR:

- repeated Reads of one PDF return raw text client-side; unrelated
- Claude Code shows an unknown-model banner for gpt-5.6; cosmetic

## Type

🐛 Bug Fix

## Caveats (if any)

- Low: file, text, and content document sources still drop, like image sources
- Low: user-content document blocks still drop, a pre-existing gap
- Low: tool_result images keep their #34462 sidecar, untouched here

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

live-pr-risk evidence: the changed adapter is consumed only by responses_adapters/handler.py (no subclasses, no string dispatch, no wire-contract change on LiteLLM's own responses), and OpenAI accepts both mixed and file-only output part lists, verified with live probes

- [x] c3c9e3a919 passes /live-pr-risk
