### PR TITLE
fix(guardrails)!: type guardrail responses with LitellmParams and serialize only stored params

### DIFF
--- a/basedpyright-code-budget.json
+++ b/basedpyright-code-budget.json
@@ -99,7 +99,7 @@
     "limit": 0
   },
   "reportUnknownArgumentType": {
-    "limit": 44655
+    "limit": 44526
   },
   "reportUnknownLambdaType": {
     "limit": 109

--- a/litellm/proxy/_lazy_openapi_snapshot.json
+++ b/litellm/proxy/_lazy_openapi_snapshot.json
@@ -13119,7 +13119,9 @@
             "200": {
               "content": {
                 "application/json": {
-                  "schema": {}
+                  "schema": {
+                    "$ref": "#/components/schemas/GuardrailInfoResponse"
+                  }
                 }
               },
               "description": "Successful Response"
@@ -13273,7 +13275,9 @@
             "200": {
               "content": {
                 "application/json": {
-                  "schema": {}
+                  "schema": {
+                    "$ref": "#/components/schemas/GuardrailInfoResponse"
+                  }
                 }
               },
               "description": "Successful Response"

--- a/litellm/proxy/_lazy_openapi_snapshot.json
+++ b/litellm/proxy/_lazy_openapi_snapshot.json
@@ -7917,7 +7917,7 @@
           "title": "ApplyGuardrailResponse",
           "type": "object"
         },
-        "BaseLitellmParams-Input": {
+        "BaseLitellmParams": {
           "additionalProperties": true,
           "properties": {
             "additional_provider_specific_params": {
@@ -8121,7 +8121,7 @@
                 }
               ],
               "default": true,
-              "description": "Whether to fail the request if Model Armor encounters an error",
+              "description": "Whether to fail the request if the guardrail encounters an error. Implemented by guardrail='model_armor' and 'generic_guardrail_api'. True (default) raises the error. False logs a critical error and lets the request proceed, so only a valid guardrail response can block or modify it.",
               "title": "Fail On Error"
             },
             "guard_name": {
@@ -8196,6 +8196,22 @@
               "description": "Optional field if guardrail requires a 'model' parameter",
               "title": "Model"
             },
+            "on_sensitive_data": {
+              "anyOf": [
+                {
+                  "enum": [
+                    "block",
+                    "route"
+                  ],
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Action to take when sensitive data is detected. 'block' raises an exception (default behavior). 'route' reroutes the request to the model specified in sensitive_data_route_to_model.",
+              "title": "On Sensitive Data"
+            },
             "on_violation": {
               "anyOf": [
                 {
@@ -8211,6 +8227,19 @@
               ],
               "description": "For /v1/realtime sessions: 'warn' speaks the violation message and continues; 'end_session' speaks the message and closes the connection.",
               "title": "On Violation"
+            },
+            "only_scan_new_messages": {
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": false,
+              "description": "When True, the guardrail only scans messages that have not already been scanned earlier in the same session (identified by litellm_session_id / session_id). Message content is hashed per session and cached; only the diff (new or edited messages) is sent to the guardrail provider on follow-up calls. Falls back to a full scan when the request has no session id or the cache is unavailable. Intended for blocking/detection guardrails; not applied when mask_request_content is set.",
+              "title": "Only Scan New Messages"
             },
             "pangea_input_recipe": {
               "anyOf": [
@@ -8275,6 +8304,55 @@
               "description": "The message the bot speaks aloud when a /v1/realtime guardrail fires. Falls back to violation_message_template if not set.",
               "title": "Realtime Violation Message"
             },
+            "run_in_parallel": {
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "When True, this pre_call or post_call guardrail runs concurrently with other opted-in guardrails of the same hook, after the sequential guardrails have run. Use only for block-only guardrails that inspect and reject; do not enable it for guardrails that modify the request or response (e.g. PII masking or sensitive-data routing), since parallel runs share one snapshot and their mutations would race.",
+              "title": "Run In Parallel"
+            },
+            "sanitize_error_detail": {
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": true,
+              "description": "For guardrail='model_armor': omit the raw Model Armor response from caller-facing errors and logs by default. Set False to restore verbose output.",
+              "title": "Sanitize Error Detail"
+            },
+            "scan_only_tool_results": {
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "When True, unified guardrails only evaluate tool results, the untrusted data an agent feeds back into the model, and skip system, user, and assistant content. Intended for agent harnesses whose own prompt scaffolding is trusted but often trips prompt-attack detectors.",
+              "title": "Scan Only Tool Results"
+            },
+            "sensitive_data_route_to_model": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Model to route requests to when sensitive data is detected and on_sensitive_data='route'. This is typically an on-premise model for data privacy. The routing decision persists for the entire session.",
+              "title": "Sensitive Data Route To Model"
+            },
             "severity_threshold": {
               "anyOf": [
                 {
@@ -8296,8 +8374,46 @@
                   "type": "null"
                 }
               ],
-              "description": "When True, unified guardrails skip system-role messages when building evaluation inputs (texts and structured_messages). When False, system messages are included even if litellm_settings sets a global skip. When None, use the global litellm.skip_system_message_in_guardrail setting.",
+              "description": "When True, unified guardrails skip system-role messages when building evaluation inputs (texts and structured_messages). When False, system messages are included even if litellm_settings sets a global skip. When None, use the global litellm.skip_system_message_in_guardrail setting. For Anthropic /v1/messages, the flag applies only to the trusted top-level system prompt. In-sequence system entries are untrusted client input and remain in texts and structured_messages.",
               "title": "Skip System Message In Guardrail"
+            },
+            "skip_tool_message_in_guardrail": {
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "When True, unified guardrails skip tool-role messages when building evaluation inputs (texts and structured_messages). When False, tool messages are included even if litellm_settings sets a global skip. When None, use the global litellm.skip_tool_message_in_guardrail setting.",
+              "title": "Skip Tool Message In Guardrail"
+            },
+            "skip_unscannable_attachments": {
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": false,
+              "description": "Implemented by guardrail='model_armor'. When True, attachment references that carry no inline bytes (file_id, gs://, or http(s) URLs) pass through unscanned instead of blocking, while fail_on_error still governs real Model Armor API errors. Default False blocks them.",
+              "title": "Skip Unscannable Attachments"
+            },
+            "sticky_session_routing": {
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": true,
+              "description": "When True (default), after sensitive data is detected and routed, all subsequent requests in the same session will continue routing to the same model.",
+              "title": "Sticky Session Routing"
             },
             "template_id": {
               "anyOf": [
@@ -8311,9 +8427,21 @@
               "description": "The ID of your Model Armor template",
               "title": "Template Id"
             },
+            "timeout": {
+              "anyOf": [
+                {
+                  "type": "number"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Per-request timeout for the guardrail provider API call (seconds). Accepts int, float, or numeric string; coerced to float on load. Each guardrail handler chooses its own default when unset.",
+              "title": "Timeout"
+            },
             "unreachable_fallback": {
               "default": "fail_closed",
-              "description": "Behavior when a guardrail endpoint is unreachable due to network errors. NOTE: This is currently only implemented by guardrail='generic_guardrail_api'. 'fail_closed' raises an error (default). 'fail_open' logs a critical error and allows the request to proceed.",
+              "description": "Behavior when a guardrail endpoint is unreachable due to network errors. Implemented by guardrail='generic_guardrail_api', 'akto', 'vigil_guard', 'repelloai', 'headroom', and 'compresr'. 'fail_closed' raises an error (default). 'fail_open' logs a critical error and allows the request to proceed.",
               "enum": [
                 "fail_closed",
                 "fail_open"
@@ -8337,424 +8465,173 @@
           "title": "BaseLitellmParams",
           "type": "object"
         },
-        "BaseLitellmParams-Output": {
-          "additionalProperties": true,
+        "BedrockChecksConfigModel": {
+          "description": "Inline `checks` config for the resource-less Bedrock InvokeGuardrailChecks API.\n\nInclude only the checks you want to run; at least one must be set.",
           "properties": {
-            "additional_provider_specific_params": {
+            "contentFilter": {
               "anyOf": [
                 {
-                  "additionalProperties": true,
-                  "type": "object"
+                  "$ref": "#/components/schemas/BedrockChecksContentFilterModel"
                 },
                 {
                   "type": "null"
                 }
-              ],
-              "description": "Additional provider-specific parameters for generic guardrail APIs",
-              "title": "Additional Provider Specific Params"
+              ]
             },
-            "api_base": {
+            "promptAttack": {
               "anyOf": [
                 {
-                  "type": "string"
+                  "$ref": "#/components/schemas/BedrockChecksPromptAttackModel"
                 },
                 {
                   "type": "null"
                 }
-              ],
-              "description": "Base URL for the guardrail service API",
-              "title": "Api Base"
+              ]
             },
-            "api_endpoint": {
+            "sensitiveInformation": {
               "anyOf": [
                 {
-                  "type": "string"
+                  "$ref": "#/components/schemas/BedrockChecksSensitiveInformationModel"
                 },
                 {
                   "type": "null"
                 }
-              ],
-              "description": "Optional custom API endpoint for Model Armor",
-              "title": "Api Endpoint"
-            },
-            "api_key": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "API key for the guardrail service",
-              "title": "Api Key"
-            },
-            "blocked_words": {
-              "anyOf": [
-                {
-                  "items": {
-                    "$ref": "#/components/schemas/BlockedWord"
-                  },
-                  "type": "array"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "List of blocked words with individual actions",
-              "title": "Blocked Words"
-            },
-            "blocked_words_file": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "Path to YAML file containing blocked_words list",
-              "title": "Blocked Words File"
-            },
-            "categories": {
-              "anyOf": [
-                {
-                  "items": {
-                    "$ref": "#/components/schemas/ContentFilterCategoryConfig"
-                  },
-                  "type": "array"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "List of prebuilt categories to enable (harmful_*, bias_*)",
-              "title": "Categories"
-            },
-            "category_thresholds": {
-              "anyOf": [
-                {
-                  "$ref": "#/components/schemas/LakeraCategoryThresholds"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "Threshold configuration for Lakera guardrail categories"
-            },
-            "credentials": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "Path to Google Cloud credentials JSON file or JSON string",
-              "title": "Credentials"
-            },
-            "custom_code": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "Python-like code containing the apply_guardrail function for custom guardrail logic",
-              "title": "Custom Code"
-            },
-            "default_on": {
-              "anyOf": [
-                {
-                  "type": "boolean"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "Whether the guardrail is enabled by default",
-              "title": "Default On"
-            },
-            "detect_secrets_config": {
-              "anyOf": [
-                {
-                  "additionalProperties": true,
-                  "type": "object"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "Configuration for detect-secrets guardrail",
-              "title": "Detect Secrets Config"
-            },
-            "end_session_after_n_fails": {
-              "anyOf": [
-                {
-                  "type": "integer"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "For /v1/realtime sessions: automatically close the session after this many guardrail violations.",
-              "title": "End Session After N Fails"
-            },
-            "experimental_use_latest_role_message_only": {
-              "anyOf": [
-                {
-                  "type": "boolean"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "default": false,
-              "description": "When True, guardrails only receive the latest message for the relevant role (e.g., newest user input pre-call, newest assistant output post-call)",
-              "title": "Experimental Use Latest Role Message Only"
-            },
-            "extra_headers": {
-              "anyOf": [
-                {
-                  "items": {
-                    "type": "string"
-                  },
-                  "type": "array"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "Header names to forward from the client request to the guardrail (e.g. x-request-id). Only these headers' values are sent; others may be omitted or sent as [present]. Used by generic_guardrail_api (similar to MCP extra_headers).",
-              "title": "Extra Headers"
-            },
-            "fail_on_error": {
-              "anyOf": [
-                {
-                  "type": "boolean"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "default": true,
-              "description": "Whether to fail the request if Model Armor encounters an error",
-              "title": "Fail On Error"
-            },
-            "guard_name": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "Name of the guardrail in guardrails.ai",
-              "title": "Guard Name"
-            },
-            "keyword_redaction_tag": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "Tag to use for keyword redaction",
-              "title": "Keyword Redaction Tag"
-            },
-            "location": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "Google Cloud location/region (e.g., us-central1)",
-              "title": "Location"
-            },
-            "mask_request_content": {
-              "anyOf": [
-                {
-                  "type": "boolean"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "Will mask request content if guardrail makes any changes",
-              "title": "Mask Request Content"
-            },
-            "mask_response_content": {
-              "anyOf": [
-                {
-                  "type": "boolean"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "Will mask response content if guardrail makes any changes",
-              "title": "Mask Response Content"
-            },
-            "model": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "Optional field if guardrail requires a 'model' parameter",
-              "title": "Model"
-            },
-            "on_violation": {
-              "anyOf": [
-                {
-                  "enum": [
-                    "warn",
-                    "end_session"
-                  ],
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "For /v1/realtime sessions: 'warn' speaks the violation message and continues; 'end_session' speaks the message and closes the connection.",
-              "title": "On Violation"
-            },
-            "pangea_input_recipe": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "Recipe for input (LLM request)",
-              "title": "Pangea Input Recipe"
-            },
-            "pangea_output_recipe": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "Recipe for output (LLM response)",
-              "title": "Pangea Output Recipe"
-            },
-            "pattern_redaction_format": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "Format string for pattern redaction (use {pattern_name} placeholder)",
-              "title": "Pattern Redaction Format"
-            },
-            "patterns": {
-              "anyOf": [
-                {
-                  "items": {
-                    "$ref": "#/components/schemas/ContentFilterPattern"
-                  },
-                  "type": "array"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "List of patterns (prebuilt or custom regex) to detect",
-              "title": "Patterns"
-            },
-            "realtime_violation_message": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "The message the bot speaks aloud when a /v1/realtime guardrail fires. Falls back to violation_message_template if not set.",
-              "title": "Realtime Violation Message"
-            },
-            "severity_threshold": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "Minimum severity to block (high, medium, low)",
-              "title": "Severity Threshold"
-            },
-            "skip_system_message_in_guardrail": {
-              "anyOf": [
-                {
-                  "type": "boolean"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "When True, unified guardrails skip system-role messages when building evaluation inputs (texts and structured_messages). When False, system messages are included even if litellm_settings sets a global skip. When None, use the global litellm.skip_system_message_in_guardrail setting.",
-              "title": "Skip System Message In Guardrail"
-            },
-            "template_id": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "The ID of your Model Armor template",
-              "title": "Template Id"
-            },
-            "unreachable_fallback": {
-              "default": "fail_closed",
-              "description": "Behavior when a guardrail endpoint is unreachable due to network errors. NOTE: This is currently only implemented by guardrail='generic_guardrail_api'. 'fail_closed' raises an error (default). 'fail_open' logs a critical error and allows the request to proceed.",
-              "enum": [
-                "fail_closed",
-                "fail_open"
-              ],
-              "title": "Unreachable Fallback",
-              "type": "string"
-            },
-            "violation_message_template": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "Custom message when a guardrail blocks an action. Supports placeholders like {tool_name}, {rule_id}, and {default_message}.",
-              "title": "Violation Message Template"
+              ]
             }
           },
-          "title": "BaseLitellmParams",
+          "title": "BedrockChecksConfigModel",
+          "type": "object"
+        },
+        "BedrockChecksContentFilterCategoryItem": {
+          "properties": {
+            "category": {
+              "enum": [
+                "VIOLENCE",
+                "HATE",
+                "SEXUAL",
+                "MISCONDUCT",
+                "INSULTS"
+              ],
+              "title": "Category",
+              "type": "string"
+            }
+          },
+          "required": [
+            "category"
+          ],
+          "title": "BedrockChecksContentFilterCategoryItem",
+          "type": "object"
+        },
+        "BedrockChecksContentFilterModel": {
+          "properties": {
+            "categories": {
+              "items": {
+                "$ref": "#/components/schemas/BedrockChecksContentFilterCategoryItem"
+              },
+              "title": "Categories",
+              "type": "array"
+            }
+          },
+          "required": [
+            "categories"
+          ],
+          "title": "BedrockChecksContentFilterModel",
+          "type": "object"
+        },
+        "BedrockChecksPromptAttackCategoryItem": {
+          "properties": {
+            "category": {
+              "enum": [
+                "JAILBREAK",
+                "PROMPT_INJECTION",
+                "PROMPT_LEAKAGE"
+              ],
+              "title": "Category",
+              "type": "string"
+            }
+          },
+          "required": [
+            "category"
+          ],
+          "title": "BedrockChecksPromptAttackCategoryItem",
+          "type": "object"
+        },
+        "BedrockChecksPromptAttackModel": {
+          "properties": {
+            "categories": {
+              "items": {
+                "$ref": "#/components/schemas/BedrockChecksPromptAttackCategoryItem"
+              },
+              "title": "Categories",
+              "type": "array"
+            }
+          },
+          "required": [
+            "categories"
+          ],
+          "title": "BedrockChecksPromptAttackModel",
+          "type": "object"
+        },
+        "BedrockChecksSensitiveInformationEntityItem": {
+          "properties": {
+            "type": {
+              "enum": [
+                "ADDRESS",
+                "AGE",
+                "AWS_ACCESS_KEY",
+                "AWS_SECRET_KEY",
+                "CA_HEALTH_NUMBER",
+                "CA_SOCIAL_INSURANCE_NUMBER",
+                "CREDIT_DEBIT_CARD_CVV",
+                "CREDIT_DEBIT_CARD_EXPIRY",
+                "CREDIT_DEBIT_CARD_NUMBER",
+                "DRIVER_ID",
+                "EMAIL",
+                "INTERNATIONAL_BANK_ACCOUNT_NUMBER",
+                "IP_ADDRESS",
+                "LICENSE_PLATE",
+                "MAC_ADDRESS",
+                "NAME",
+                "PASSWORD",
+                "PHONE",
+                "PIN",
+                "SWIFT_CODE",
+                "UK_NATIONAL_HEALTH_SERVICE_NUMBER",
+                "UK_NATIONAL_INSURANCE_NUMBER",
+                "UK_UNIQUE_TAXPAYER_REFERENCE_NUMBER",
+                "URL",
+                "USERNAME",
+                "US_BANK_ACCOUNT_NUMBER",
+                "US_BANK_ROUTING_NUMBER",
+                "US_INDIVIDUAL_TAX_IDENTIFICATION_NUMBER",
+                "US_PASSPORT_NUMBER",
+                "US_SOCIAL_SECURITY_NUMBER",
+                "VEHICLE_IDENTIFICATION_NUMBER"
+              ],
+              "title": "Type",
+              "type": "string"
+            }
+          },
+          "required": [
+            "type"
+          ],
+          "title": "BedrockChecksSensitiveInformationEntityItem",
+          "type": "object"
+        },
+        "BedrockChecksSensitiveInformationModel": {
+          "properties": {
+            "entities": {
+              "items": {
+                "$ref": "#/components/schemas/BedrockChecksSensitiveInformationEntityItem"
+              },
+              "title": "Entities",
+              "type": "array"
+            }
+          },
+          "required": [
+            "entities"
+          ],
+          "title": "BedrockChecksSensitiveInformationModel",
           "type": "object"
         },
         "BlockedWord": {
@@ -8787,6 +8664,187 @@
             "action"
           ],
           "title": "BlockedWord",
+          "type": "object"
+        },
+        "CiscoAIDefenseGuardrailConfigModelOptionalParams": {
+          "additionalProperties": true,
+          "description": "Optional parameters for the Cisco AI Defense guardrail.",
+          "properties": {
+            "enabled_rules": {
+              "anyOf": [
+                {
+                  "items": {
+                    "$ref": "#/components/schemas/CiscoAIDefenseRule"
+                  },
+                  "type": "array"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Explicit list of Cisco AI Defense rules to evaluate. If omitted, the policies configured for the API key in the Cisco AI Defense UI are used.",
+              "title": "Enabled Rules"
+            },
+            "fallback_on_error": {
+              "anyOf": [
+                {
+                  "enum": [
+                    "allow",
+                    "block"
+                  ],
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": "block",
+              "description": "Behaviour when the Cisco AI Defense API is unavailable: 'allow' proceeds without scanning (high availability), 'block' rejects the request (maximum security).",
+              "title": "Fallback On Error"
+            },
+            "inspect_path": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Override for the inspection endpoint path. Defaults to /api/v1/inspect/chat when inspection_type='chat' and /api/v1/inspect/mcp when inspection_type='mcp'.",
+              "title": "Inspect Path"
+            },
+            "inspection_type": {
+              "default": "chat",
+              "description": "Which Cisco AI Defense inspection surface to use. 'chat' scans LLM model conversations via /api/v1/inspect/chat. 'mcp' scans MCP tool calls via /api/v1/inspect/mcp. Each guardrail instance targets exactly one surface; configure two guardrails to scan both chat and MCP traffic.",
+              "enum": [
+                "chat",
+                "mcp"
+              ],
+              "title": "Inspection Type",
+              "type": "string"
+            },
+            "integration_profile_id": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Integration profile id to apply (advanced).",
+              "title": "Integration Profile Id"
+            },
+            "integration_profile_version": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Integration profile version to apply (advanced).",
+              "title": "Integration Profile Version"
+            },
+            "integration_tenant_id": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Integration tenant id to apply (advanced).",
+              "title": "Integration Tenant Id"
+            },
+            "integration_type": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Integration type to apply (advanced).",
+              "title": "Integration Type"
+            },
+            "on_flagged_action": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": "block",
+              "description": "Action to take when Cisco AI Defense flags content. 'block' raises an HTTPException; 'monitor' logs the detection and lets the request continue.",
+              "title": "On Flagged Action"
+            },
+            "timeout": {
+              "anyOf": [
+                {
+                  "maximum": 60.0,
+                  "minimum": 1.0,
+                  "type": "number"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": 10.0,
+              "description": "Timeout (seconds) for Cisco AI Defense API calls (1-60).",
+              "title": "Timeout"
+            }
+          },
+          "title": "CiscoAIDefenseGuardrailConfigModelOptionalParams",
+          "type": "object"
+        },
+        "CiscoAIDefenseRule": {
+          "description": "A single rule to enable for Cisco AI Defense inspection.",
+          "properties": {
+            "entity_types": {
+              "anyOf": [
+                {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Optional list of entity types for the rule (e.g. 'Email Address', 'Phone Number'). Applies to rules such as PII, PCI, and PHI.",
+              "title": "Entity Types"
+            },
+            "rule_name": {
+              "description": "The canonical Cisco AI Defense rule name to evaluate.",
+              "enum": [
+                "Code Detection",
+                "Harassment",
+                "Hate Speech",
+                "PCI",
+                "PHI",
+                "PII",
+                "Prompt Injection",
+                "Profanity",
+                "Sexual Content & Exploitation",
+                "Social Division & Polarization",
+                "Violence & Public Safety Threats"
+              ],
+              "title": "Rule Name",
+              "type": "string"
+            }
+          },
+          "required": [
+            "rule_name"
+          ],
+          "title": "CiscoAIDefenseRule",
           "type": "object"
         },
         "ContentFilterAction": {
@@ -8933,106 +8991,6 @@
           "title": "GUARDRAIL_DEFINITION_LOCATION",
           "type": "string"
         },
-        "GraySwanGuardrailConfigModelOptionalParams": {
-          "description": "Optional parameters for the Gray Swan guardrail.",
-          "properties": {
-            "categories": {
-              "anyOf": [
-                {
-                  "additionalProperties": {
-                    "type": "string"
-                  },
-                  "type": "object"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "Default Gray Swan category definitions to send with each request.",
-              "title": "Categories"
-            },
-            "fail_open": {
-              "anyOf": [
-                {
-                  "type": "boolean"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "default": true,
-              "description": "If true (default), errors contacting Gray Swan are logged and the request proceeds. If false, errors propagate and block the request.",
-              "title": "Fail Open"
-            },
-            "guardrail_timeout": {
-              "anyOf": [
-                {
-                  "type": "number"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "default": 30.0,
-              "description": "Timeout in seconds for calling the Gray Swan guardrail service.",
-              "title": "Guardrail Timeout"
-            },
-            "on_flagged_action": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "default": "passthrough",
-              "description": "Action when a violation is detected: 'block' rejects the call (400 error), 'monitor' logs only, 'passthrough' replaces response content with violation message (200 status).",
-              "title": "On Flagged Action"
-            },
-            "policy_id": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "Gray Swan policy identifier to apply during monitoring.",
-              "title": "Policy Id"
-            },
-            "reasoning_mode": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "Gray Swan reasoning mode override. Accepted values: 'off', 'hybrid', 'thinking'.",
-              "title": "Reasoning Mode"
-            },
-            "violation_threshold": {
-              "anyOf": [
-                {
-                  "maximum": 1.0,
-                  "minimum": 0.0,
-                  "type": "number"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "default": 0.5,
-              "description": "Threshold between 0 and 1 at which Gray Swan violations trigger the configured action.",
-              "title": "Violation Threshold"
-            }
-          },
-          "title": "GraySwanGuardrailConfigModelOptionalParams",
-          "type": "object"
-        },
         "Guardrail": {
           "properties": {
             "created_at": {
@@ -9156,7 +9114,7 @@
             "litellm_params": {
               "anyOf": [
                 {
-                  "$ref": "#/components/schemas/BaseLitellmParams-Output"
+                  "$ref": "#/components/schemas/LitellmParams"
                 },
                 {
                   "type": "null"
@@ -9506,7 +9464,7 @@
                   "type": "null"
                 }
               ],
-              "description": "Base URL for the Lakera AI API",
+              "description": "Regional base URL for the Cisco AI Defense Inspection API. Defaults to https://us.api.inspect.aidefense.security.cisco.com. Supported regions: us (us-west-2), ap (ap-ne-1), eu (eu-central-1). The environment variable `CISCO_AI_DEFENSE_API_BASE` is consulted as a fallback. The endpoint path is derived from inspection_type (/api/v1/inspect/chat for 'chat', /api/v1/inspect/mcp for 'mcp').",
               "title": "Api Base"
             },
             "api_endpoint": {
@@ -9542,7 +9500,7 @@
                   "type": "null"
                 }
               ],
-              "description": "API key for the Lakera AI service",
+              "description": "API key for the Cisco AI Defense inspection endpoint. If not provided, the `CISCO_AI_DEFENSE_API_KEY` environment variable is used. Sent in the `X-Cisco-AI-Defense-API-Key` header. Both the chat and MCP endpoints use this key.",
               "title": "Api Key"
             },
             "api_version": {
@@ -9596,6 +9554,18 @@
               ],
               "description": "Custom assertions to validate against the output. Each assertion is a string describing a condition.",
               "title": "Assertions"
+            },
+            "asset_id": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Repello asset ID whose dashboard policies are enforced. Required; the guardrail raises at init if it is missing.",
+              "title": "Asset Id"
             },
             "async_mode": {
               "anyOf": [
@@ -9887,6 +9857,24 @@
               ],
               "description": "Threshold configuration for Lakera guardrail categories"
             },
+            "checks": {
+              "anyOf": [
+                {
+                  "$ref": "#/components/schemas/BedrockChecksConfigModel"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Inline safeguards for the resource-less InvokeGuardrailChecks API (contentFilter / promptAttack / sensitiveInformation). When set, the guardrail calls InvokeGuardrailChecks instead of ApplyGuardrail and no guardrailIdentifier is required. Mutually exclusive with guardrailIdentifier."
+            },
+            "chunk_budget_chars": {
+              "default": 25000,
+              "description": "ApplyGuardrail: batch size, in characters, used to re-send content after AWS has rejected a request as too large. Requests AWS accepts are always sent in a single call, so this has no effect until a rejection happens. Defaults to 25,000; a batch AWS still rejects is bisected automatically, so this value only trades round trips against batch size and cannot fail a request on its own.",
+              "exclusiveMinimum": 0.0,
+              "title": "Chunk Budget Chars",
+              "type": "integer"
+            },
             "confidence_threshold": {
               "default": 0.5,
               "default_value": 0.5,
@@ -9912,6 +9900,21 @@
               ],
               "description": "Additional configuration for the guardrail",
               "title": "Config"
+            },
+            "content_filter_threshold": {
+              "anyOf": [
+                {
+                  "maximum": 1.0,
+                  "minimum": 0.0,
+                  "type": "number"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": 0.5,
+              "description": "InvokeGuardrailChecks: block when any contentFilter severityScore >= this value (scores are in [0,1]). Set to null to make the content filter detect-only (logged, never blocks).",
+              "title": "Content Filter Threshold"
             },
             "content_moderation_check": {
               "anyOf": [
@@ -9948,6 +9951,18 @@
               ],
               "description": "Python-like code containing the apply_guardrail function for custom guardrail logic",
               "title": "Custom Code"
+            },
+            "deepkeep_firewall_id": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "The DeepKeep Firewall ID to use for guardrail evaluation. If not provided, the `DEEPKEEP_FIREWALL_ID` environment variable is checked.",
+              "title": "Deepkeep Firewall Id"
             },
             "default_action": {
               "default": "deny",
@@ -10115,7 +10130,7 @@
                 }
               ],
               "default": true,
-              "description": "Whether to fail the request if Model Armor encounters an error",
+              "description": "Whether to fail the request if the guardrail encounters an error. Implemented by guardrail='model_armor' and 'generic_guardrail_api'. True (default) raises the error. False logs a critical error and lets the request proceed, so only a valid guardrail response can block or modify it.",
               "title": "Fail On Error"
             },
             "grounding_check": {
@@ -10388,7 +10403,7 @@
                   "type": "null"
                 }
               ],
-              "description": "Optional field if guardrail requires a 'model' parameter",
+              "description": "Model name forwarded to the headroom /v1/compress endpoint.",
               "title": "Model"
             },
             "monitor_mode": {
@@ -10443,6 +10458,22 @@
               "description": "Action to take when content is flagged: 'block' (raise exception) or 'monitor' (log only)",
               "title": "On Flagged Action"
             },
+            "on_sensitive_data": {
+              "anyOf": [
+                {
+                  "enum": [
+                    "block",
+                    "route"
+                  ],
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Action to take when sensitive data is detected. 'block' raises an exception (default behavior). 'route' reroutes the request to the model specified in sensitive_data_route_to_model.",
+              "title": "On Sensitive Data"
+            },
             "on_violation": {
               "anyOf": [
                 {
@@ -10459,10 +10490,23 @@
               "description": "For /v1/realtime sessions: 'warn' speaks the violation message and continues; 'end_session' speaks the message and closes the connection.",
               "title": "On Violation"
             },
+            "only_scan_new_messages": {
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": false,
+              "description": "When True, the guardrail only scans messages that have not already been scanned earlier in the same session (identified by litellm_session_id / session_id). Message content is hashed per session and cached; only the diff (new or edited messages) is sent to the guardrail provider on follow-up calls. Falls back to a full scan when the request has no session id or the cache is unavailable. Intended for blocking/detection guardrails; not applied when mask_request_content is set.",
+              "title": "Only Scan New Messages"
+            },
             "optional_params": {
               "anyOf": [
                 {
-                  "$ref": "#/components/schemas/GraySwanGuardrailConfigModelOptionalParams"
+                  "$ref": "#/components/schemas/CiscoAIDefenseGuardrailConfigModelOptionalParams"
                 },
                 {
                   "type": "null"
@@ -10571,6 +10615,21 @@
               "description": "Enable PII (Personally Identifiable Information) detection.",
               "title": "Pii Check"
             },
+            "pii_confidence_threshold": {
+              "anyOf": [
+                {
+                  "maximum": 1.0,
+                  "minimum": 0.0,
+                  "type": "number"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": 0.5,
+              "description": "InvokeGuardrailChecks: block when any sensitiveInformation confidenceScore >= this value (scores are in [0,1]). Set to null to make PII detection detect-only.",
+              "title": "Pii Confidence Threshold"
+            },
             "pii_entities_config": {
               "anyOf": [
                 {
@@ -10633,6 +10692,30 @@
               ],
               "title": "Policy Names",
               "ui_type": "multiselect"
+            },
+            "post_checkpoint_id": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Post-checkpoint ID for the Ovalix Tracker service.",
+              "title": "Post Checkpoint Id"
+            },
+            "pre_checkpoint_id": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Pre-checkpoint ID for the Ovalix Tracker service.",
+              "title": "Pre Checkpoint Id"
             },
             "presidio_ad_hoc_recognizers": {
               "anyOf": [
@@ -10766,6 +10849,21 @@
               "description": "Project ID for the Lakera AI project",
               "title": "Project Id"
             },
+            "prompt_attack_threshold": {
+              "anyOf": [
+                {
+                  "maximum": 1.0,
+                  "minimum": 0.0,
+                  "type": "number"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": 0.5,
+              "description": "InvokeGuardrailChecks: block when any promptAttack severityScore >= this value (scores are in [0,1]). Set to null to make prompt-attack detection detect-only.",
+              "title": "Prompt Attack Threshold"
+            },
             "prompt_injections": {
               "anyOf": [
                 {
@@ -10804,6 +10902,43 @@
               ],
               "description": "Ordered allow/deny rules. Patterns use regex for tool names/types and optional regex constraints on tool arguments.",
               "title": "Rules"
+            },
+            "run_in_parallel": {
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "When True, this pre_call or post_call guardrail runs concurrently with other opted-in guardrails of the same hook, after the sequential guardrails have run. Use only for block-only guardrails that inspect and reject; do not enable it for guardrails that modify the request or response (e.g. PII masking or sensitive-data routing), since parallel runs share one snapshot and their mutations would race.",
+              "title": "Run In Parallel"
+            },
+            "sanitize_error_detail": {
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": true,
+              "description": "For guardrail='model_armor': omit the raw Model Armor response from caller-facing errors and logs by default. Set False to restore verbose output.",
+              "title": "Sanitize Error Detail"
+            },
+            "scan_only_tool_results": {
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "When True, unified guardrails only evaluate tool results, the untrusted data an agent feeds back into the model, and skip system, user, and assistant content. Intended for agent harnesses whose own prompt scaffolding is trusted but often trips prompt-attack detectors.",
+              "title": "Scan Only Tool Results"
             },
             "send_user_api_key_alias": {
               "anyOf": [
@@ -10844,6 +10979,18 @@
               "description": "Whether to send user_API_key_user_id in headers",
               "title": "Send User Api Key User Id"
             },
+            "sensitive_data_route_to_model": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Model to route requests to when sensitive data is detected and on_sensitive_data='route'. This is typically an on-premise model for data privacy. The routing decision persists for the entire session.",
+              "title": "Sensitive Data Route To Model"
+            },
             "severity_threshold": {
               "anyOf": [
                 {
@@ -10856,6 +11003,54 @@
               "description": "Minimum severity to block (high, medium, low)",
               "title": "Severity Threshold"
             },
+            "singulr_api_base": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "The Singulr API base URL. Get base URL from Singulr Platform.",
+              "title": "Singulr Api Base"
+            },
+            "singulr_api_key": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "The Singulr API key. Generate API key from Singulr Platform.",
+              "title": "Singulr Api Key"
+            },
+            "singulr_application_id": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "The Singulr application ID. Get application ID from Singulr Platform.",
+              "title": "Singulr Application Id"
+            },
+            "singulr_guardrail_id": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "The Singulr Guardrail ID. Get guardrail ID from Singulr Platform.",
+              "title": "Singulr Guardrail Id"
+            },
             "skip_system_message_in_guardrail": {
               "anyOf": [
                 {
@@ -10865,8 +11060,46 @@
                   "type": "null"
                 }
               ],
-              "description": "When True, unified guardrails skip system-role messages when building evaluation inputs (texts and structured_messages). When False, system messages are included even if litellm_settings sets a global skip. When None, use the global litellm.skip_system_message_in_guardrail setting.",
+              "description": "When True, unified guardrails skip system-role messages when building evaluation inputs (texts and structured_messages). When False, system messages are included even if litellm_settings sets a global skip. When None, use the global litellm.skip_system_message_in_guardrail setting. For Anthropic /v1/messages, the flag applies only to the trusted top-level system prompt. In-sequence system entries are untrusted client input and remain in texts and structured_messages.",
               "title": "Skip System Message In Guardrail"
+            },
+            "skip_tool_message_in_guardrail": {
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "When True, unified guardrails skip tool-role messages when building evaluation inputs (texts and structured_messages). When False, tool messages are included even if litellm_settings sets a global skip. When None, use the global litellm.skip_tool_message_in_guardrail setting.",
+              "title": "Skip Tool Message In Guardrail"
+            },
+            "skip_unscannable_attachments": {
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": false,
+              "description": "Implemented by guardrail='model_armor'. When True, attachment references that carry no inline bytes (file_id, gs://, or http(s) URLs) pass through unscanned instead of blocking, while fail_on_error still governs real Model Armor API errors. Default False blocks them.",
+              "title": "Skip Unscannable Attachments"
+            },
+            "sticky_session_routing": {
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": true,
+              "description": "When True (default), after sensitive data is detected and routed, all subsequent requests in the same session will continue routing to the same model.",
+              "title": "Sticky Session Routing"
             },
             "template_id": {
               "anyOf": [
@@ -10880,6 +11113,18 @@
               "description": "The ID of your Model Armor template",
               "title": "Template Id"
             },
+            "timeout": {
+              "anyOf": [
+                {
+                  "type": "number"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Per-request timeout for the guardrail provider API call (seconds). Accepts int, float, or numeric string; coerced to float on load. Each guardrail handler chooses its own default when unset.",
+              "title": "Timeout"
+            },
             "tool_selection_quality_check": {
               "anyOf": [
                 {
@@ -10892,9 +11137,33 @@
               "description": "Enable tool selection quality check to evaluate quality of tool/function calls.",
               "title": "Tool Selection Quality Check"
             },
+            "tracker_api_base": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Base URL for the Ovalix Tracker service.",
+              "title": "Tracker Api Base"
+            },
+            "tracker_api_key": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "API key for the Ovalix Tracker service.",
+              "title": "Tracker Api Key"
+            },
             "unreachable_fallback": {
               "default": "fail_closed",
-              "description": "What to do when Akto is unreachable. 'fail_open' = allow, 'fail_closed' = block.",
+              "description": "Behavior when the headroom compression service is unreachable or errors. 'fail_closed' raises an error (default). 'fail_open' logs a critical error and forwards the request uncompressed instead of blocking it.",
               "enum": [
                 "fail_closed",
                 "fail_open"
@@ -11046,7 +11315,7 @@
             "litellm_params": {
               "anyOf": [
                 {
-                  "$ref": "#/components/schemas/BaseLitellmParams-Input"
+                  "$ref": "#/components/schemas/BaseLitellmParams"
                 },
                 {
                   "type": "null"
@@ -11086,6 +11355,9 @@
             "US_SSN",
             "UK_NHS",
             "UK_NINO",
+            "UK_PASSPORT",
+            "UK_POSTCODE",
+            "UK_VEHICLE_REGISTRATION",
             "ES_NIF",
             "ES_NIE",
             "IT_FISCAL_CODE",
@@ -11789,6 +12061,13 @@
         },
         "ValidationError": {
           "properties": {
+            "ctx": {
+              "title": "Context",
+              "type": "object"
+            },
+            "input": {
+              "title": "Input"
+            },
             "loc": {
               "items": {
                 "anyOf": [

--- a/litellm/proxy/guardrails/guardrail_endpoints.py
+++ b/litellm/proxy/guardrails/guardrail_endpoints.py
@@ -264,7 +264,7 @@ async def list_guardrails_v2(
                 if isinstance(litellm_params, LitellmParams)
                 else litellm_params
             ) or {}
-            masked_litellm_params_dict = _get_masked_values(
+            masked_litellm_params_dict: dict[str, object] = _get_masked_values(
                 litellm_params_dict,
                 unmasked_length=4,
                 number_of_asterisks=4,
@@ -303,7 +303,7 @@ async def list_guardrails_v2(
                 if isinstance(in_memory_litellm_params_raw, LitellmParams)
                 else in_memory_litellm_params_raw
             ) or {}
-            masked_in_memory_litellm_params = _get_masked_values(
+            masked_in_memory_litellm_params: dict[str, object] = _get_masked_values(
                 in_memory_litellm_params_dict,
                 unmasked_length=4,
                 number_of_asterisks=4,
@@ -1320,7 +1320,7 @@ async def get_guardrail_info(guardrail_id: str):
             if isinstance(litellm_params, LitellmParams)
             else litellm_params
         ) or {}
-        masked_litellm_params_dict: Final = _get_masked_values(
+        masked_litellm_params_dict: Final[dict[str, object]] = _get_masked_values(
             result_litellm_params_dict,
             unmasked_length=4,
             number_of_asterisks=4,

--- a/litellm/proxy/guardrails/guardrail_endpoints.py
+++ b/litellm/proxy/guardrails/guardrail_endpoints.py
@@ -34,7 +34,6 @@ from litellm.types.guardrails import (
     PII_ENTITY_CATEGORIES_MAP,
     ApplyGuardrailRequest,
     ApplyGuardrailResponse,
-    BaseLitellmParams,
     BedrockGuardrailConfigModel,
     Guardrail,
     GuardrailEventHooks,
@@ -270,9 +269,7 @@ async def list_guardrails_v2(
                 unmasked_length=4,
                 number_of_asterisks=4,
             )
-            masked_litellm_params = (
-                BaseLitellmParams(**masked_litellm_params_dict) if masked_litellm_params_dict else None
-            )
+            masked_litellm_params = LitellmParams(**masked_litellm_params_dict) if masked_litellm_params_dict else None
             guardrail_configs.append(
                 GuardrailInfoResponse(
                     guardrail_id=guardrail.get("guardrail_id"),
@@ -312,7 +309,7 @@ async def list_guardrails_v2(
                 number_of_asterisks=4,
             )
             masked_in_memory_litellm_params_typed = (
-                BaseLitellmParams(**masked_in_memory_litellm_params) if masked_in_memory_litellm_params else None
+                LitellmParams(**masked_in_memory_litellm_params) if masked_in_memory_litellm_params else None
             )
             guardrail_configs.append(
                 GuardrailInfoResponse(
@@ -1328,7 +1325,7 @@ async def get_guardrail_info(guardrail_id: str):
             unmasked_length=4,
             number_of_asterisks=4,
         )
-        masked_litellm_params = BaseLitellmParams(**masked_litellm_params_dict) if masked_litellm_params_dict else None
+        masked_litellm_params = LitellmParams(**masked_litellm_params_dict) if masked_litellm_params_dict else None
 
         return GuardrailInfoResponse(
             guardrail_id=result.get("guardrail_id"),

--- a/litellm/proxy/guardrails/guardrail_endpoints.py
+++ b/litellm/proxy/guardrails/guardrail_endpoints.py
@@ -13,7 +13,7 @@ from typing import TYPE_CHECKING, Any, Final, Literal, Protocol, TypeVar, Union,
 from urllib.parse import urlparse
 
 from fastapi import APIRouter, Depends, HTTPException, Request
-from pydantic import BaseModel
+from pydantic import BaseModel, ValidationError
 
 from litellm._logging import verbose_proxy_logger
 from litellm.constants import DEFAULT_MAX_RECURSE_DEPTH
@@ -31,6 +31,7 @@ from litellm.proxy.guardrails.usage_endpoints import router as guardrails_usage_
 from litellm.proxy.management_endpoints.common_utils import _user_has_admin_view
 from litellm.repositories.table_repositories import GuardrailsRepository
 from litellm.types.guardrails import (
+    GUARDRAIL_DEFINITION_LOCATION,
     PII_ENTITY_CATEGORIES_MAP,
     ApplyGuardrailRequest,
     ApplyGuardrailResponse,
@@ -108,6 +109,18 @@ async def _find_team_guardrail_rows(
     return rows
 
 
+def _typed_masked_params(masked_params: dict[str, object]) -> LitellmParams | None:
+    if not masked_params:
+        return None
+    try:
+        return LitellmParams(**masked_params)
+    except ValidationError as e:
+        verbose_proxy_logger.warning(
+            "Stored litellm_params failed LitellmParams validation; omitting them from the response: %s", e
+        )
+        return None
+
+
 def _get_guardrails_list_response(
     guardrails_config: list[dict],
 ) -> ListGuardrailsResponse:
@@ -119,7 +132,7 @@ def _get_guardrails_list_response(
     guardrail_configs: Final[list[GuardrailInfoResponse]] = []
     for guardrail in guardrails_config:
         litellm_params = guardrail.get("litellm_params") or {}
-        masked_params = _get_masked_values(
+        masked_params: dict[str, object] = _get_masked_values(
             litellm_params,
             unmasked_length=4,
             number_of_asterisks=4,
@@ -128,8 +141,9 @@ def _get_guardrails_list_response(
             GuardrailInfoResponse(
                 guardrail_id=guardrail.get("guardrail_id"),
                 guardrail_name=guardrail.get("guardrail_name"),
-                litellm_params=masked_params,
+                litellm_params=_typed_masked_params(masked_params),
                 guardrail_info=guardrail.get("guardrail_info"),
+                guardrail_definition_location=GUARDRAIL_DEFINITION_LOCATION.CONFIG,
             )
         )
     return ListGuardrailsResponse(guardrails=guardrail_configs)
@@ -140,6 +154,7 @@ def _get_guardrails_list_response(
     tags=["Guardrails"],
     dependencies=[Depends(user_api_key_auth)],
     response_model=ListGuardrailsResponse,
+    response_model_exclude_unset=True,
 )
 async def list_guardrails():
     """
@@ -192,6 +207,7 @@ async def list_guardrails():
     "/v2/guardrails/list",
     tags=["Guardrails"],
     response_model=ListGuardrailsResponse,
+    response_model_exclude_unset=True,
 )
 async def list_guardrails_v2(
     user_api_key_dict: UserAPIKeyAuth = Depends(user_api_key_auth),
@@ -260,7 +276,7 @@ async def list_guardrails_v2(
         for guardrail in guardrails:
             litellm_params: LitellmParams | dict | None = guardrail.get("litellm_params")
             litellm_params_dict = (
-                litellm_params.model_dump(exclude_none=True)
+                litellm_params.model_dump(exclude_unset=True)
                 if isinstance(litellm_params, LitellmParams)
                 else litellm_params
             ) or {}
@@ -269,7 +285,7 @@ async def list_guardrails_v2(
                 unmasked_length=4,
                 number_of_asterisks=4,
             )
-            masked_litellm_params = LitellmParams(**masked_litellm_params_dict) if masked_litellm_params_dict else None
+            masked_litellm_params = _typed_masked_params(masked_litellm_params_dict)
             guardrail_configs.append(
                 GuardrailInfoResponse(
                     guardrail_id=guardrail.get("guardrail_id"),
@@ -299,7 +315,7 @@ async def list_guardrails_v2(
                     continue
             in_memory_litellm_params_raw = guardrail.get("litellm_params")
             in_memory_litellm_params_dict = (
-                in_memory_litellm_params_raw.model_dump(exclude_none=True)
+                in_memory_litellm_params_raw.model_dump(exclude_unset=True)
                 if isinstance(in_memory_litellm_params_raw, LitellmParams)
                 else in_memory_litellm_params_raw
             ) or {}
@@ -308,9 +324,7 @@ async def list_guardrails_v2(
                 unmasked_length=4,
                 number_of_asterisks=4,
             )
-            masked_in_memory_litellm_params_typed = (
-                LitellmParams(**masked_in_memory_litellm_params) if masked_in_memory_litellm_params else None
-            )
+            masked_in_memory_litellm_params_typed = _typed_masked_params(masked_in_memory_litellm_params)
             guardrail_configs.append(
                 GuardrailInfoResponse(
                     guardrail_id=guardrail.get("guardrail_id"),
@@ -1251,11 +1265,15 @@ async def patch_guardrail(
     "/guardrails/{guardrail_id}",
     tags=["Guardrails"],
     dependencies=[Depends(user_api_key_auth)],
+    response_model=GuardrailInfoResponse,
+    response_model_exclude_unset=True,
 )
 @router.get(
     "/guardrails/{guardrail_id}/info",
     tags=["Guardrails"],
     dependencies=[Depends(user_api_key_auth)],
+    response_model=GuardrailInfoResponse,
+    response_model_exclude_unset=True,
 )
 async def get_guardrail_info(guardrail_id: str):
     """
@@ -1293,7 +1311,6 @@ async def get_guardrail_info(guardrail_id: str):
     from litellm.litellm_core_utils.litellm_logging import _get_masked_values
     from litellm.proxy.guardrails.guardrail_registry import IN_MEMORY_GUARDRAIL_HANDLER
     from litellm.proxy.proxy_server import prisma_client
-    from litellm.types.guardrails import GUARDRAIL_DEFINITION_LOCATION
 
     try:
         guardrail_definition_location: GUARDRAIL_DEFINITION_LOCATION = GUARDRAIL_DEFINITION_LOCATION.DB
@@ -1316,7 +1333,7 @@ async def get_guardrail_info(guardrail_id: str):
 
         litellm_params: Final[LitellmParams | dict | None] = result.get("litellm_params")
         result_litellm_params_dict: Final = (
-            litellm_params.model_dump(exclude_none=True)
+            litellm_params.model_dump(exclude_unset=True)
             if isinstance(litellm_params, LitellmParams)
             else litellm_params
         ) or {}
@@ -1325,7 +1342,7 @@ async def get_guardrail_info(guardrail_id: str):
             unmasked_length=4,
             number_of_asterisks=4,
         )
-        masked_litellm_params = LitellmParams(**masked_litellm_params_dict) if masked_litellm_params_dict else None
+        masked_litellm_params = _typed_masked_params(masked_litellm_params_dict)
 
         return GuardrailInfoResponse(
             guardrail_id=result.get("guardrail_id"),

--- a/litellm/proxy/guardrails/guardrail_registry.py
+++ b/litellm/proxy/guardrails/guardrail_registry.py
@@ -294,7 +294,7 @@ class GuardrailRegistry:
             # Properly serialize LitellmParams Pydantic model to dict
             litellm_params_obj: Final = guardrail.get("litellm_params", {})
             if hasattr(litellm_params_obj, "model_dump"):
-                litellm_params_dict = litellm_params_obj.model_dump()
+                litellm_params_dict = litellm_params_obj.model_dump(exclude_unset=True)
             else:
                 litellm_params_dict = dict(litellm_params_obj) if litellm_params_obj else {}
             litellm_params: Final[str] = safe_dumps(litellm_params_dict)
@@ -340,7 +340,7 @@ class GuardrailRegistry:
             # Properly serialize LitellmParams Pydantic model to dict
             litellm_params_obj: Final = guardrail.get("litellm_params", {})
             if hasattr(litellm_params_obj, "model_dump"):
-                litellm_params_dict = litellm_params_obj.model_dump()
+                litellm_params_dict = litellm_params_obj.model_dump(exclude_unset=True)
             else:
                 litellm_params_dict = dict(litellm_params_obj) if litellm_params_obj else {}
             litellm_params: Final[str] = safe_dumps(litellm_params_dict)

--- a/litellm/types/guardrails.py
+++ b/litellm/types/guardrails.py
@@ -1076,7 +1076,7 @@ class GUARDRAIL_DEFINITION_LOCATION(str, Enum):
 class GuardrailInfoResponse(BaseModel):
     guardrail_id: str | None = None
     guardrail_name: str
-    litellm_params: BaseLitellmParams | None = None
+    litellm_params: LitellmParams | None = None
     guardrail_info: dict | None = None
     created_at: datetime | None = None
     updated_at: datetime | None = None

--- a/tests/test_litellm/proxy/guardrails/test_guardrail_endpoints.py
+++ b/tests/test_litellm/proxy/guardrails/test_guardrail_endpoints.py
@@ -36,10 +36,10 @@ from litellm.proxy.guardrails.guardrail_registry import (
 )
 from litellm.types.guardrails import (
     ApplyGuardrailRequest,
-    BaseLitellmParams,
     Guardrail,
     GuardrailInfoResponse,
     LitellmParams,
+    Mode,
 )
 
 # Mock data for testing
@@ -149,7 +149,7 @@ async def test_list_guardrails_v2_with_db_and_config(
     )
     assert db_guardrail.guardrail_name == "Test DB Guardrail"
     assert db_guardrail.guardrail_definition_location == "db"
-    assert isinstance(db_guardrail.litellm_params, BaseLitellmParams)
+    assert isinstance(db_guardrail.litellm_params, LitellmParams)
 
     # Check config guardrail
     config_guardrail = next(
@@ -157,7 +157,7 @@ async def test_list_guardrails_v2_with_db_and_config(
     )
     assert config_guardrail.guardrail_name == "Test Config Guardrail"
     assert config_guardrail.guardrail_definition_location == "config"
-    assert isinstance(config_guardrail.litellm_params, BaseLitellmParams)
+    assert isinstance(config_guardrail.litellm_params, LitellmParams)
 
 
 @pytest.mark.asyncio
@@ -446,8 +446,31 @@ async def test_get_guardrail_info_from_db(mocker, mock_prisma_client):
 
     assert response.guardrail_id == "test-db-guardrail"
     assert response.guardrail_name == "Test DB Guardrail"
-    assert isinstance(response.litellm_params, BaseLitellmParams)
+    assert isinstance(response.litellm_params, LitellmParams)
     assert response.guardrail_info == {"description": "Test guardrail from DB"}
+
+
+@pytest.mark.asyncio
+async def test_guardrail_info_response_keeps_tag_based_mode(mocker, mock_prisma_client):
+    """The response model must carry `guardrail` and the full `mode` union, tag-based mode included."""
+    tag_mode_guardrail = {
+        **MOCK_DB_GUARDRAIL,
+        "litellm_params": {
+            "guardrail": "bedrock",
+            "mode": {"tags": {"Service-Type: internal-service": "post_call"}, "default": ["pre_call", "post_call"]},
+        },
+    }
+    mock_prisma_client.db.litellm_guardrailstable.find_unique = AsyncMock(return_value=tag_mode_guardrail)
+    mocker.patch("litellm.proxy.proxy_server.prisma_client", mock_prisma_client)
+
+    response = await get_guardrail_info("test-db-guardrail")
+
+    assert isinstance(response.litellm_params, LitellmParams)
+    assert response.litellm_params.guardrail == "bedrock"
+    assert isinstance(response.litellm_params.mode, Mode)
+    assert response.litellm_params.mode.tags == {"Service-Type: internal-service": "post_call"}
+    assert response.litellm_params.mode.default == ["pre_call", "post_call"]
+    assert response.model_dump()["litellm_params"]["mode"] == tag_mode_guardrail["litellm_params"]["mode"]
 
 
 @pytest.mark.asyncio
@@ -470,7 +493,7 @@ async def test_get_guardrail_info_from_config(
 
     assert response.guardrail_id == "test-config-guardrail"
     assert response.guardrail_name == "Test Config Guardrail"
-    assert isinstance(response.litellm_params, BaseLitellmParams)
+    assert isinstance(response.litellm_params, LitellmParams)
     assert response.guardrail_info == {"description": "Test guardrail from config"}
 
 

--- a/tests/test_litellm/proxy/guardrails/test_guardrail_endpoints.py
+++ b/tests/test_litellm/proxy/guardrails/test_guardrail_endpoints.py
@@ -6,7 +6,8 @@ from unittest.mock import AsyncMock
 import pytest
 
 
-from fastapi import HTTPException
+from fastapi import FastAPI, HTTPException
+from fastapi.testclient import TestClient
 
 from litellm.proxy._types import LitellmUserRoles, UserAPIKeyAuth
 from litellm.proxy.guardrails.guardrail_endpoints import (
@@ -30,6 +31,9 @@ from litellm.proxy.guardrails.guardrail_endpoints import (
 )
 
 MOCK_ADMIN_USER = UserAPIKeyAuth(user_role=LitellmUserRoles.PROXY_ADMIN)
+from litellm.proxy.auth.user_api_key_auth import user_api_key_auth
+from litellm.proxy.guardrails.guardrail_endpoints import _get_guardrails_list_response
+from litellm.proxy.guardrails.guardrail_endpoints import router as guardrails_router
 from litellm.proxy.guardrails.guardrail_registry import (
     IN_MEMORY_GUARDRAIL_HANDLER,
     InMemoryGuardrailHandler,
@@ -158,6 +162,80 @@ async def test_list_guardrails_v2_with_db_and_config(
     assert config_guardrail.guardrail_name == "Test Config Guardrail"
     assert config_guardrail.guardrail_definition_location == "config"
     assert isinstance(config_guardrail.litellm_params, LitellmParams)
+
+
+def _guardrails_test_client() -> TestClient:
+    app = FastAPI()
+    app.include_router(guardrails_router)
+    app.dependency_overrides[user_api_key_auth] = lambda: MOCK_ADMIN_USER
+    return TestClient(app)
+
+
+def test_list_guardrails_v2_wire_response_has_only_stored_params(
+    mocker, mock_prisma_client, mock_in_memory_handler
+):
+    """exclude_unset regression: unset mixin defaults (chunk_budget_chars etc.) must not serialize."""
+    mock_in_memory_handler.list_in_memory_guardrails.return_value = []
+    mocker.patch("litellm.proxy.proxy_server.prisma_client", mock_prisma_client)
+    mocker.patch(
+        "litellm.proxy.guardrails.guardrail_registry.IN_MEMORY_GUARDRAIL_HANDLER",
+        mock_in_memory_handler,
+    )
+
+    response = _guardrails_test_client().get("/v2/guardrails/list")
+
+    assert response.status_code == 200
+    (guardrail,) = response.json()["guardrails"]
+    assert set(guardrail["litellm_params"]) == {"guardrail", "mode", "default_on"}
+    assert guardrail["guardrail_definition_location"] == "db"
+
+
+def test_get_guardrail_info_wire_response_has_only_stored_params(mocker, mock_prisma_client):
+    """exclude_unset regression for GET /guardrails/{id}."""
+    mocker.patch("litellm.proxy.proxy_server.prisma_client", mock_prisma_client)
+
+    response = _guardrails_test_client().get("/guardrails/test-db-guardrail")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["guardrail_name"] == "Test DB Guardrail"
+    assert set(body["litellm_params"]) == {"guardrail", "mode", "default_on"}
+
+
+@pytest.mark.asyncio
+async def test_list_guardrails_v2_keeps_serving_when_one_row_is_invalid(
+    mocker, mock_prisma_client, mock_in_memory_handler
+):
+    """A row failing LitellmParams validation must yield litellm_params=None, not a 500 for the whole list."""
+    bad_row = {
+        **MOCK_DB_GUARDRAIL,
+        "guardrail_id": "bad-db-guardrail",
+        "litellm_params": {"guardrail": "test.guardrail"},
+    }
+    mock_prisma_client.db.litellm_guardrailstable.find_many = AsyncMock(
+        return_value=[MOCK_DB_GUARDRAIL, bad_row]
+    )
+    mocker.patch("litellm.proxy.proxy_server.prisma_client", mock_prisma_client)
+    mocker.patch(
+        "litellm.proxy.guardrails.guardrail_registry.IN_MEMORY_GUARDRAIL_HANDLER",
+        mock_in_memory_handler,
+    )
+
+    response = await list_guardrails_v2(user_api_key_dict=MOCK_ADMIN_USER)
+
+    by_id = {g.guardrail_id: g for g in response.guardrails}
+    assert isinstance(by_id["test-db-guardrail"].litellm_params, LitellmParams)
+    assert by_id["bad-db-guardrail"].litellm_params is None
+
+
+def test_config_guardrails_list_sets_location_explicitly():
+    """guardrail_definition_location must stay on the wire under exclude_unset."""
+    response = _get_guardrails_list_response([MOCK_CONFIG_GUARDRAIL])
+
+    (guardrail,) = response.guardrails
+    assert guardrail.guardrail_definition_location == "config"
+    assert "guardrail_definition_location" in guardrail.model_fields_set
+    assert isinstance(guardrail.litellm_params, LitellmParams)
 
 
 @pytest.mark.asyncio

--- a/tests/test_litellm/proxy/guardrails/test_guardrail_registry.py
+++ b/tests/test_litellm/proxy/guardrails/test_guardrail_registry.py
@@ -657,3 +657,27 @@ class TestScanOnlyToolResultsInitRefusal:
                     "scan_only_tool_results": True,
                 },
             )
+
+
+@pytest.mark.asyncio
+async def test_add_guardrail_to_db_stores_only_set_params():
+    """Sparse-storage regression: unset mixin defaults must not be persisted to the DB row."""
+    import json
+    from unittest.mock import AsyncMock, MagicMock
+
+    from litellm.proxy.guardrails.guardrail_registry import GuardrailRegistry
+
+    prisma_client = MagicMock()
+    created_row = MagicMock()
+    created_row.guardrail_id = "new-id"
+    prisma_client.db.litellm_guardrailstable.create = AsyncMock(return_value=created_row)
+
+    guardrail = Guardrail(
+        guardrail_name="sparse-guard",
+        litellm_params=LitellmParams(guardrail="custom_code", mode="pre_call", custom_code="def f(): ..."),
+        guardrail_info={},
+    )
+    await GuardrailRegistry().add_guardrail_to_db(guardrail=guardrail, prisma_client=prisma_client)
+
+    stored = json.loads(prisma_client.db.litellm_guardrailstable.create.call_args.kwargs["data"]["litellm_params"])
+    assert set(stored) == {"guardrail", "mode", "custom_code", "default_on"}

--- a/ui/litellm-dashboard/src/app/(dashboard)/guardrails/_components/GuardrailTestPlayground.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/guardrails/_components/GuardrailTestPlayground.test.tsx
@@ -2,7 +2,7 @@ import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import GuardrailTestPlayground from "./GuardrailTestPlayground";
-import type { Guardrail, GuardrailLitellmParams } from "@/components/guardrails/types";
+import type { Guardrail } from "@/components/guardrails/types";
 
 vi.mock("@/components/networking");
 
@@ -30,7 +30,7 @@ describe("GuardrailTestPlayground", () => {
         guardrail: "presidio",
         mode: "pre_call",
         default_on: false,
-      } as GuardrailLitellmParams,
+      },
       guardrail_info: {},
       guardrail_definition_location: "db",
     },

--- a/ui/litellm-dashboard/src/app/(dashboard)/guardrails/_components/GuardrailTestPlayground.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/guardrails/_components/GuardrailTestPlayground.test.tsx
@@ -2,6 +2,7 @@ import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import GuardrailTestPlayground from "./GuardrailTestPlayground";
+import type { Guardrail, GuardrailLitellmParams } from "@/components/guardrails/types";
 
 vi.mock("@/components/networking");
 
@@ -21,7 +22,7 @@ Object.defineProperty(window, "matchMedia", {
 
 describe("GuardrailTestPlayground", () => {
   const mockAccessToken = "test-token";
-  const mockGuardrails = [
+  const mockGuardrails: Guardrail[] = [
     {
       guardrail_id: "guard-1",
       guardrail_name: "test-guardrail",
@@ -29,8 +30,9 @@ describe("GuardrailTestPlayground", () => {
         guardrail: "presidio",
         mode: "pre_call",
         default_on: false,
-      },
+      } as GuardrailLitellmParams,
       guardrail_info: {},
+      guardrail_definition_location: "db",
     },
   ];
 

--- a/ui/litellm-dashboard/src/app/(dashboard)/guardrails/_components/GuardrailTestPlayground.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/guardrails/_components/GuardrailTestPlayground.tsx
@@ -6,24 +6,11 @@ import { toast } from "@/lib/toast";
 import { Card, CardContent } from "@/components/ui/card";
 import { InputGroup, InputGroupAddon, InputGroupInput } from "@/components/ui/input-group";
 import { UiLoadingSpinner } from "@/components/ui/ui-loading-spinner";
-import { GuardrailMode } from "@/components/guardrails/types";
+import type { Guardrail } from "@/components/guardrails/types";
 import { formatGuardrailMode } from "./guardrail_info_helpers";
 
-interface GuardrailItem {
-  guardrail_id?: string;
-  guardrail_name: string | null;
-  litellm_params: {
-    guardrail: string;
-    mode: GuardrailMode;
-    default_on: boolean;
-  };
-  guardrail_info: Record<string, any> | null;
-  created_at?: string;
-  updated_at?: string;
-}
-
 interface GuardrailTestPlaygroundProps {
-  guardrailsList: GuardrailItem[];
+  guardrailsList: Guardrail[];
   isLoading: boolean;
   accessToken: string | null;
   onClose: () => void;
@@ -169,12 +156,12 @@ const GuardrailTestPlayground: React.FC<GuardrailTestPlaygroundProps> = ({
                         <div className="mt-1 space-y-1 text-xs">
                           <div>
                             <span className="font-medium">Type: </span>
-                            <span className="text-muted-foreground">{guardrail.litellm_params.guardrail}</span>
+                            <span className="text-muted-foreground">{guardrail.litellm_params?.guardrail}</span>
                           </div>
                           <div>
                             <span className="font-medium">Mode: </span>
                             <span className="text-muted-foreground">
-                              {formatGuardrailMode(guardrail.litellm_params.mode)}
+                              {formatGuardrailMode(guardrail.litellm_params?.mode)}
                             </span>
                           </div>
                         </div>

--- a/ui/litellm-dashboard/src/app/(dashboard)/guardrails/_components/GuardrailsPanel.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/guardrails/_components/GuardrailsPanel.tsx
@@ -118,10 +118,9 @@ const GuardrailsPanel: React.FC<GuardrailsPanelProps> = ({ accessToken, userRole
     setGuardrailToDelete(null);
   };
 
-  const providerDisplayName =
-    guardrailToDelete && guardrailToDelete.litellm_params
-      ? getGuardrailLogoAndName(guardrailToDelete.litellm_params.guardrail).displayName
-      : undefined;
+  const providerDisplayName = guardrailToDelete?.litellm_params?.guardrail
+    ? getGuardrailLogoAndName(guardrailToDelete.litellm_params.guardrail).displayName
+    : undefined;
 
   return (
     <div className="w-full mx-auto flex-auto overflow-y-auto m-8 p-2">

--- a/ui/litellm-dashboard/src/app/(dashboard)/guardrails/_components/GuardrailsPanel.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/guardrails/_components/GuardrailsPanel.tsx
@@ -96,7 +96,7 @@ const GuardrailsPanel: React.FC<GuardrailsPanelProps> = ({ accessToken, userRole
   };
 
   const handleDeleteConfirm = async () => {
-    if (!guardrailToDelete || !accessToken) return;
+    if (!guardrailToDelete?.guardrail_id || !accessToken) return;
 
     setIsDeleting(true);
     try {
@@ -211,10 +211,10 @@ const GuardrailsPanel: React.FC<GuardrailsPanelProps> = ({ accessToken, userRole
                   { label: "Name", value: guardrailToDelete?.guardrail_name },
                   { label: "ID", value: guardrailToDelete?.guardrail_id, code: true },
                   { label: "Provider", value: providerDisplayName },
-                  { label: "Mode", value: formatGuardrailMode(guardrailToDelete?.litellm_params.mode) },
+                  { label: "Mode", value: formatGuardrailMode(guardrailToDelete?.litellm_params?.mode) },
                   {
                     label: "Default On",
-                    value: guardrailToDelete?.litellm_params.default_on ? "Yes" : "No",
+                    value: guardrailToDelete?.litellm_params?.default_on ? "Yes" : "No",
                   },
                 ]}
                 onCancel={handleDeleteCancel}

--- a/ui/litellm-dashboard/src/app/(dashboard)/guardrails/_components/custom_code/CustomCodeModal.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/guardrails/_components/custom_code/CustomCodeModal.test.tsx
@@ -14,6 +14,8 @@ const mockCreate = vi.mocked(createGuardrailCall);
 const mockUpdate = vi.mocked(updateGuardrailCall);
 const mockTest = vi.mocked(testCustomCodeGuardrail);
 
+const TAG_BASED_MODE_HINT = "Tag-based mode is managed in config and can't be edited here";
+
 describe("CustomCodeModal", () => {
   const onClose = vi.fn();
   const onSuccess = vi.fn();
@@ -92,6 +94,39 @@ describe("CustomCodeModal", () => {
     });
     const [, , payload] = mockUpdate.mock.calls[0] as [string, string, { litellm_params: Record<string, unknown> }];
     expect(payload.litellm_params).not.toHaveProperty("mode");
+  });
+
+  it("should lock the mode chips when editing a tag-based mode", async () => {
+    renderModal({
+      editData: {
+        guardrail_id: "g-1",
+        guardrail_name: "tagged-guardrail",
+        litellm_params: {
+          mode: { tags: { "team:internal": "post_call" }, default: ["pre_call"] },
+          default_on: false,
+          custom_code: "def apply_guardrail(): pass",
+        },
+      },
+    });
+
+    expect(await screen.findByLabelText("pre_call (Request)")).toBeInTheDocument();
+    expect(screen.getByLabelText("post_call (Response)")).toBeInTheDocument();
+    expect(screen.getAllByRole("combobox")[0]).toBeDisabled();
+    expect(screen.getByText(TAG_BASED_MODE_HINT)).toBeInTheDocument();
+  });
+
+  it("should leave the mode chips editable when editing a plain mode", async () => {
+    renderModal({
+      editData: {
+        guardrail_id: "g-1",
+        guardrail_name: "plain-guardrail",
+        litellm_params: { mode: ["pre_call"], default_on: false, custom_code: "def apply_guardrail(): pass" },
+      },
+    });
+
+    expect(await screen.findByLabelText("pre_call (Request)")).toBeInTheDocument();
+    expect(screen.getAllByRole("combobox")[0]).toBeEnabled();
+    expect(screen.queryByText(TAG_BASED_MODE_HINT)).not.toBeInTheDocument();
   });
 
   it("should keep save disabled until a guardrail name is entered", async () => {

--- a/ui/litellm-dashboard/src/app/(dashboard)/guardrails/_components/custom_code/CustomCodeModal.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/guardrails/_components/custom_code/CustomCodeModal.test.tsx
@@ -68,6 +68,32 @@ describe("CustomCodeModal", () => {
     expect(screen.getByRole("button", { name: /update guardrail/i })).toBeInTheDocument();
   });
 
+  it("should seed the mode chips from a tag-based mode and leave it untouched on update", async () => {
+    const user = userEvent.setup();
+    renderModal({
+      editData: {
+        guardrail_id: "g-1",
+        guardrail_name: "tagged-guardrail",
+        litellm_params: {
+          mode: { tags: { "Service-Type: internal-service": "post_call" }, default: ["pre_call"] },
+          default_on: true,
+          custom_code: "def apply_guardrail(): pass",
+        },
+      },
+    });
+
+    expect(await screen.findByLabelText("pre_call (Request)")).toBeInTheDocument();
+    expect(screen.getByLabelText("post_call (Response)")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /update guardrail/i }));
+
+    await waitFor(() => {
+      expect(mockUpdate).toHaveBeenCalledTimes(1);
+    });
+    const [, , payload] = mockUpdate.mock.calls[0] as [string, string, { litellm_params: Record<string, unknown> }];
+    expect(payload.litellm_params).not.toHaveProperty("mode");
+  });
+
   it("should keep save disabled until a guardrail name is entered", async () => {
     const user = userEvent.setup();
     renderModal();

--- a/ui/litellm-dashboard/src/app/(dashboard)/guardrails/_components/custom_code/CustomCodeModal.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/guardrails/_components/custom_code/CustomCodeModal.tsx
@@ -31,7 +31,7 @@ import { Switch } from "@/components/ui/switch";
 import { Textarea } from "@/components/ui/textarea";
 import { UiLoadingSpinner } from "@/components/ui/ui-loading-spinner";
 import type { GuardrailLitellmParams, GuardrailMode } from "@/components/guardrails/types";
-import { guardrailModeList } from "../guardrail_info_helpers";
+import { guardrailModeList, isTagBasedMode } from "../guardrail_info_helpers";
 
 // Code templates
 const CODE_TEMPLATES = {
@@ -190,6 +190,7 @@ interface CustomCodeModalProps {
 const CustomCodeModal: React.FC<CustomCodeModalProps> = ({ visible, onClose, onSuccess, accessToken, editData }) => {
   const anchor = useComboboxAnchor();
   const isEditMode = !!editData;
+  const tagBasedMode = isEditMode && isTagBasedMode(editData?.litellm_params?.mode);
   const [guardrailName, setGuardrailName] = useState("");
   const [mode, setMode] = useState<string[]>(["pre_call"]);
   const [defaultOn, setDefaultOn] = useState(false);
@@ -519,6 +520,7 @@ const CustomCodeModal: React.FC<CustomCodeModalProps> = ({ visible, onClose, onS
               items={MODE_OPTIONS}
               value={selectedModeOptions}
               onValueChange={(options: ModeOption[]) => setMode(options.map((option) => option.value))}
+              disabled={tagBasedMode}
               multiple
             >
               <ComboboxChips render={<div ref={anchor} />} className="w-full">
@@ -540,6 +542,11 @@ const CustomCodeModal: React.FC<CustomCodeModalProps> = ({ visible, onClose, onS
                 </ComboboxList>
               </ComboboxContent>
             </Combobox>
+            {tagBasedMode && (
+              <p className="mt-1 text-xs text-muted-foreground">
+                Tag-based mode is managed in config and can&apos;t be edited here
+              </p>
+            )}
           </div>
           <div className="w-[180px]">
             <label className="mb-1 block text-xs font-medium text-muted-foreground">Template</label>

--- a/ui/litellm-dashboard/src/app/(dashboard)/guardrails/_components/custom_code/CustomCodeModal.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/guardrails/_components/custom_code/CustomCodeModal.tsx
@@ -30,6 +30,8 @@ import {
 import { Switch } from "@/components/ui/switch";
 import { Textarea } from "@/components/ui/textarea";
 import { UiLoadingSpinner } from "@/components/ui/ui-loading-spinner";
+import type { GuardrailLitellmParams, GuardrailMode } from "@/components/guardrails/types";
+import { guardrailModeList } from "../guardrail_info_helpers";
 
 // Code templates
 const CODE_TEMPLATES = {
@@ -173,12 +175,7 @@ const MODE_OPTION_BY_VALUE: Record<string, ModeOption> = Object.fromEntries(
 export interface EditGuardrailData {
   guardrail_id: string;
   guardrail_name: string;
-  litellm_params: {
-    mode?: string | string[];
-    default_on?: boolean;
-    custom_code?: string;
-    [key: string]: any;
-  };
+  litellm_params: Partial<Pick<GuardrailLitellmParams, "mode" | "default_on" | "custom_code">>;
 }
 
 interface CustomCodeModalProps {
@@ -305,11 +302,9 @@ const CustomCodeModal: React.FC<CustomCodeModalProps> = ({ visible, onClose, onS
     setCode(CODE_TEMPLATES[templateKey as keyof typeof CODE_TEMPLATES].code);
   };
 
-  // Normalize mode from API (string or string[]) to string[]
-  const normalizeMode = (m: string | string[] | undefined): string[] => {
-    if (m === undefined || m === null) return ["pre_call"];
-    if (Array.isArray(m)) return m.length ? m : ["pre_call"];
-    return [m];
+  const normalizeMode = (m: GuardrailMode | undefined): string[] => {
+    const modes = guardrailModeList(m);
+    return modes.length ? modes : ["pre_call"];
   };
 
   // Reset form when modal opens or editData changes

--- a/ui/litellm-dashboard/src/app/(dashboard)/guardrails/_components/guardrailTableColumns.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/guardrails/_components/guardrailTableColumns.tsx
@@ -50,10 +50,13 @@ function GuardrailRowActions({ guardrail, onDeleteClick }: GuardrailRowActionsPr
       <DropdownMenuContent align="end" className="w-52">
         <DropdownMenuItem
           variant="destructive"
-          disabled={isConfigGuardrail}
+          disabled={isConfigGuardrail || !guardrail.guardrail_id}
           data-testid="guardrail-action-delete"
           title={isConfigGuardrail ? CONFIG_DELETE_HINT : undefined}
-          onClick={() => onDeleteClick(guardrail.guardrail_id, guardrail.guardrail_name || "Unnamed Guardrail")}
+          onClick={() =>
+            guardrail.guardrail_id &&
+            onDeleteClick(guardrail.guardrail_id, guardrail.guardrail_name || "Unnamed Guardrail")
+          }
         >
           <Trash2 />
           Delete
@@ -81,9 +84,9 @@ export const getGuardrailTableColumns = ({
     enableSorting: true,
     cell: ({ row }) => (
       <IdentityCell
-        title={row.original.guardrail_id}
+        title={row.original.guardrail_id ?? "-"}
         titleClassName="font-mono text-xs font-normal"
-        onClick={() => onGuardrailClick(row.original.guardrail_id)}
+        onClick={() => row.original.guardrail_id && onGuardrailClick(row.original.guardrail_id)}
       />
     ),
   },
@@ -109,7 +112,7 @@ export const getGuardrailTableColumns = ({
     header: "Provider",
     size: 180,
     enableSorting: false,
-    cell: ({ row }) => <GuardrailProviderCell provider={row.original.litellm_params.guardrail} />,
+    cell: ({ row }) => <GuardrailProviderCell provider={row.original.litellm_params?.guardrail ?? ""} />,
   },
   {
     id: "mode",
@@ -118,7 +121,7 @@ export const getGuardrailTableColumns = ({
     size: 130,
     enableSorting: false,
     cell: ({ row }) => {
-      const mode = formatGuardrailMode(row.original.litellm_params.mode);
+      const mode = formatGuardrailMode(row.original.litellm_params?.mode);
       return (
         <span className="font-mono text-xs text-muted-foreground" title={mode || undefined}>
           {mode || "-"}

--- a/ui/litellm-dashboard/src/app/(dashboard)/guardrails/_components/guardrail_info.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/guardrails/_components/guardrail_info.tsx
@@ -32,6 +32,7 @@ import {
 } from "./GuardrailFormField";
 import ContentFilterManager, { formatContentFilterDataForAPI } from "./content_filter/ContentFilterManager";
 import CustomCodeModal, { EditGuardrailData } from "./custom_code/CustomCodeModal";
+import type { Guardrail } from "@/components/guardrails/types";
 import {
   formatGuardrailMode,
   getGuardrailLogoAndName,
@@ -66,7 +67,7 @@ export interface GuardrailInfoProps {
 }
 
 const GuardrailInfoView: React.FC<GuardrailInfoProps> = ({ guardrailId, onClose, accessToken, isAdmin }) => {
-  const [guardrailData, setGuardrailData] = useState<any>(null);
+  const [guardrailData, setGuardrailData] = useState<Guardrail | null>(null);
   const [guardrailProviderSpecificParams, setGuardrailProviderSpecificParams] = useState<any>(null);
   const [loading, setLoading] = useState(true);
   const [isEditing, setIsEditing] = useState(false);
@@ -278,7 +279,7 @@ const GuardrailInfoView: React.FC<GuardrailInfoProps> = ({ guardrailId, onClose,
 
   const handleGuardrailUpdate = async (values: GuardrailFormValues) => {
     try {
-      if (!accessToken) return;
+      if (!accessToken || !guardrailData) return;
 
       // Prepare update data object - only include changed fields
       const updateData: any = {
@@ -572,8 +573,8 @@ const GuardrailInfoView: React.FC<GuardrailInfoProps> = ({ guardrailId, onClose,
               <Card className="block p-6">
                 <p>Created At</p>
                 <div className="mt-2">
-                  <h3 className="text-lg font-medium">{formatDate(guardrailData.created_at)}</h3>
-                  <p>Last Updated: {formatDate(guardrailData.updated_at)}</p>
+                  <h3 className="text-lg font-medium">{formatDate(guardrailData.created_at ?? undefined)}</h3>
+                  <p>Last Updated: {formatDate(guardrailData.updated_at ?? undefined)}</p>
                 </div>
               </Card>
             </div>
@@ -812,7 +813,7 @@ const GuardrailInfoView: React.FC<GuardrailInfoProps> = ({ guardrailId, onClose,
                                     optionalParams={providerFields.optional_params}
                                     parentFieldKey="optional_params"
                                     control={form.control}
-                                    values={guardrailData.litellm_params}
+                                    values={guardrailData.litellm_params ?? undefined}
                                   />
                                 );
                               })()}
@@ -883,11 +884,11 @@ const GuardrailInfoView: React.FC<GuardrailInfoProps> = ({ guardrailId, onClose,
 
                     <div>
                       <p className="font-medium">Created At</p>
-                      <div>{formatDate(guardrailData.created_at)}</div>
+                      <div>{formatDate(guardrailData.created_at ?? undefined)}</div>
                     </div>
                     <div>
                       <p className="font-medium">Last Updated</p>
-                      <div>{formatDate(guardrailData.updated_at)}</div>
+                      <div>{formatDate(guardrailData.updated_at ?? undefined)}</div>
                     </div>
 
                     {guardrailData.litellm_params?.guardrail === "tool_permission" && (

--- a/ui/litellm-dashboard/src/app/(dashboard)/guardrails/_components/guardrail_info_helpers.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/guardrails/_components/guardrail_info_helpers.test.tsx
@@ -15,6 +15,7 @@ import {
   skipToolMessageToChoice,
   choiceToSkipToolForCreate,
   formatGuardrailMode,
+  guardrailModeList,
 } from "./guardrail_info_helpers";
 
 describe("guardrail_info_helpers", () => {
@@ -208,6 +209,29 @@ describe("guardrail_info_helpers", () => {
 
       expect(result.displayName).toBe("RepelloAI Argus");
       expect(result.logo).toContain("repelloai.png");
+    });
+  });
+
+  describe("guardrailModeList", () => {
+    it("wraps a single mode and passes a list through", () => {
+      expect(guardrailModeList("pre_call")).toEqual(["pre_call"]);
+      expect(guardrailModeList(["pre_call", "post_call"])).toEqual(["pre_call", "post_call"]);
+    });
+
+    it("flattens a tag-based mode into a deduped list, default modes first", () => {
+      const mode = {
+        tags: { "Service-Type: internal-service": "post_call", "Service-Type: batch": ["during_call", "post_call"] },
+        default: ["pre_call", "post_call"],
+      };
+
+      expect(guardrailModeList(mode)).toEqual(["pre_call", "post_call", "during_call"]);
+    });
+
+    it("returns an empty list for missing or unusable modes", () => {
+      expect(guardrailModeList(undefined)).toEqual([]);
+      expect(guardrailModeList(null)).toEqual([]);
+      expect(guardrailModeList({})).toEqual([]);
+      expect(guardrailModeList({ tags: {}, default: null })).toEqual([]);
     });
   });
 

--- a/ui/litellm-dashboard/src/app/(dashboard)/guardrails/_components/guardrail_info_helpers.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/guardrails/_components/guardrail_info_helpers.tsx
@@ -110,15 +110,20 @@ export const toModeArray = (raw: unknown): string[] => {
   return [];
 };
 
-export const formatGuardrailMode = (raw: unknown): string => {
-  const flat: string[] = toModeArray(raw);
-  if (flat.length > 0) return flat.join(", ");
-  if (raw === null || typeof raw !== "object") return "";
+export const isTagBasedMode = (raw: unknown): raw is { tags?: Record<string, unknown>; default?: unknown } =>
+  raw !== null && typeof raw === "object" && !Array.isArray(raw);
 
-  const { tags, default: fallback } = raw as { tags?: Record<string, unknown>; default?: unknown };
-  const tagged: string[] = tags && typeof tags === "object" ? Object.values(tags).flatMap(toModeArray) : [];
-  const modes: string[] = Array.from(new Set([...toModeArray(fallback), ...tagged]));
-  return modes.length > 0 ? `${modes.join(", ")} (tag-based)` : "";
+// Every mode a guardrail can run in, with a tag-based mode's per-tag and default modes flattened and deduped
+export const guardrailModeList = (raw: unknown): string[] => {
+  if (!isTagBasedMode(raw)) return toModeArray(raw);
+  const tagged: string[] = raw.tags && typeof raw.tags === "object" ? Object.values(raw.tags).flatMap(toModeArray) : [];
+  return Array.from(new Set([...toModeArray(raw.default), ...tagged]));
+};
+
+export const formatGuardrailMode = (raw: unknown): string => {
+  const modes: string[] = guardrailModeList(raw);
+  if (modes.length === 0) return "";
+  return isTagBasedMode(raw) ? `${modes.join(", ")} (tag-based)` : modes.join(", ");
 };
 
 // Resolves the supported modes for the selected provider, falling back to the global list

--- a/ui/litellm-dashboard/src/app/(dashboard)/guardrails/_components/guardrail_info_helpers.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/guardrails/_components/guardrail_info_helpers.tsx
@@ -103,7 +103,6 @@ export const populateGuardrailProviderMap = (providerParamsResponse: Record<stri
   });
 };
 
-// Normalizes a form "mode" value (string, string[], or empty) into a string array
 export const toModeArray = (raw: unknown): string[] => {
   if (Array.isArray(raw)) return raw.filter((m): m is string => typeof m === "string");
   if (typeof raw === "string") return [raw];
@@ -113,7 +112,6 @@ export const toModeArray = (raw: unknown): string[] => {
 export const isTagBasedMode = (raw: unknown): raw is { tags?: Record<string, unknown>; default?: unknown } =>
   raw !== null && typeof raw === "object" && !Array.isArray(raw);
 
-// Every mode a guardrail can run in, with a tag-based mode's per-tag and default modes flattened and deduped
 export const guardrailModeList = (raw: unknown): string[] => {
   if (!isTagBasedMode(raw)) return toModeArray(raw);
   const tagged: string[] = raw.tags && typeof raw.tags === "object" ? Object.values(raw.tags).flatMap(toModeArray) : [];

--- a/ui/litellm-dashboard/src/app/(dashboard)/guardrails/_components/guardrail_table.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/guardrails/_components/guardrail_table.test.tsx
@@ -3,7 +3,7 @@ import userEvent from "@testing-library/user-event";
 import { describe, it, expect, vi } from "vitest";
 
 import GuardrailTable from "./guardrail_table";
-import { Guardrail, GuardrailDefinitionLocation } from "@/components/guardrails/types";
+import { Guardrail, GuardrailDefinitionLocation, GuardrailLitellmParams } from "@/components/guardrails/types";
 
 const baseProps = {
   isLoading: false,
@@ -11,10 +11,19 @@ const baseProps = {
   onGuardrailClick: vi.fn(),
 };
 
-const makeGuardrail = (overrides: Partial<Guardrail> = {}): Guardrail => ({
+type GuardrailOverrides = Partial<Omit<Guardrail, "litellm_params">> & {
+  litellm_params?: Partial<GuardrailLitellmParams>;
+};
+
+const makeGuardrail = ({ litellm_params, ...overrides }: GuardrailOverrides = {}): Guardrail => ({
   guardrail_id: "gr-1",
   guardrail_name: "PII Redaction",
-  litellm_params: { guardrail: "presidio", mode: "pre_call", default_on: true },
+  litellm_params: {
+    guardrail: "presidio",
+    mode: "pre_call",
+    default_on: true,
+    ...litellm_params,
+  } as GuardrailLitellmParams,
   guardrail_info: null,
   created_at: "2021-01-01",
   updated_at: "2021-01-02",

--- a/ui/litellm-dashboard/src/app/(dashboard)/guardrails/_components/guardrail_table.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/guardrails/_components/guardrail_table.test.tsx
@@ -12,7 +12,7 @@ const baseProps = {
 };
 
 type GuardrailOverrides = Partial<Omit<Guardrail, "litellm_params">> & {
-  litellm_params?: Partial<GuardrailLitellmParams>;
+  litellm_params?: GuardrailLitellmParams;
 };
 
 const makeGuardrail = ({ litellm_params, ...overrides }: GuardrailOverrides = {}): Guardrail => ({
@@ -23,7 +23,7 @@ const makeGuardrail = ({ litellm_params, ...overrides }: GuardrailOverrides = {}
     mode: "pre_call",
     default_on: true,
     ...litellm_params,
-  } as GuardrailLitellmParams,
+  },
   guardrail_info: null,
   created_at: "2021-01-01",
   updated_at: "2021-01-02",

--- a/ui/litellm-dashboard/src/app/(dashboard)/policies/_components/add_policy_form.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/policies/_components/add_policy_form.tsx
@@ -318,10 +318,10 @@ const AddPolicyForm: React.FC<AddPolicyFormProps> = ({
     }
   };
 
-  const guardrailOptions = availableGuardrails.map((g) => ({
-    label: g.guardrail_name || g.guardrail_id,
-    value: g.guardrail_name || g.guardrail_id,
-  }));
+  const guardrailOptions = availableGuardrails.flatMap((g) => {
+    const key = g.guardrail_name || g.guardrail_id;
+    return key ? [{ label: key, value: key }] : [];
+  });
 
   const policyOptions = existingPolicies
     .filter((p) => !editingPolicy || p.policy_id !== editingPolicy.policy_id)

--- a/ui/litellm-dashboard/src/app/(dashboard)/policies/_components/pipeline_flow_builder.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/policies/_components/pipeline_flow_builder.tsx
@@ -275,10 +275,10 @@ const StepCard: React.FC<StepCardProps> = ({
   onDelete,
   availableGuardrails,
 }) => {
-  const guardrailOptions = availableGuardrails.map((g) => ({
-    label: g.guardrail_name || g.guardrail_id,
-    value: g.guardrail_name || g.guardrail_id,
-  }));
+  const guardrailOptions = availableGuardrails.flatMap((g) => {
+    const key = g.guardrail_name || g.guardrail_id;
+    return key ? [{ label: key, value: key }] : [];
+  });
 
   return (
     <div

--- a/ui/litellm-dashboard/src/components/guardrails/types.ts
+++ b/ui/litellm-dashboard/src/components/guardrails/types.ts
@@ -20,9 +20,12 @@ export interface PiiConfigurationProps {
   entityCategories?: PiiEntityCategory[];
 }
 
-export type Guardrail = components["schemas"]["GuardrailInfoResponse"];
-export type GuardrailLitellmParams = components["schemas"]["LitellmParams"];
-export type GuardrailMode = GuardrailLitellmParams["mode"];
+// Partial because the read endpoints serialize with response_model_exclude_unset: only stored keys reach the wire
+export type GuardrailLitellmParams = Partial<components["schemas"]["LitellmParams"]>;
+export type Guardrail = Omit<components["schemas"]["GuardrailInfoResponse"], "litellm_params"> & {
+  litellm_params?: GuardrailLitellmParams | null;
+};
+export type GuardrailMode = components["schemas"]["LitellmParams"]["mode"];
 export type GuardrailDefinitionLocation = components["schemas"]["GUARDRAIL_DEFINITION_LOCATION"];
 
 export const GuardrailDefinitionLocation = {

--- a/ui/litellm-dashboard/src/components/guardrails/types.ts
+++ b/ui/litellm-dashboard/src/components/guardrails/types.ts
@@ -1,3 +1,5 @@
+import type { components } from "@/lib/http/schema";
+
 export interface PiiEntity {
   name: string;
   category: string;
@@ -18,28 +20,12 @@ export interface PiiConfigurationProps {
   entityCategories?: PiiEntityCategory[];
 }
 
-export type GuardrailMode =
-  | string
-  | string[]
-  | { tags?: Record<string, string | string[]>; default?: string | string[] | null };
+export type Guardrail = components["schemas"]["GuardrailInfoResponse"];
+export type GuardrailLitellmParams = components["schemas"]["LitellmParams"];
+export type GuardrailMode = GuardrailLitellmParams["mode"];
+export type GuardrailDefinitionLocation = components["schemas"]["GUARDRAIL_DEFINITION_LOCATION"];
 
-export interface Guardrail {
-  guardrail_id: string;
-  guardrail_name: string | null;
-  litellm_params: {
-    guardrail: string;
-    mode: GuardrailMode;
-    default_on: boolean;
-    pii_entities_config?: { [key: string]: string };
-    [key: string]: any;
-  };
-  guardrail_info: Record<string, any> | null;
-  created_at?: string;
-  updated_at?: string;
-  guardrail_definition_location: GuardrailDefinitionLocation;
-}
-
-export enum GuardrailDefinitionLocation {
-  DB = "db",
-  CONFIG = "config",
-}
+export const GuardrailDefinitionLocation = {
+  DB: "db",
+  CONFIG: "config",
+} as const satisfies Record<string, GuardrailDefinitionLocation>;

--- a/ui/litellm-dashboard/src/lib/http/schema.d.ts
+++ b/ui/litellm-dashboard/src/lib/http/schema.d.ts
@@ -22147,7 +22147,7 @@ export interface components {
             routing_decision: components["schemas"]["StandardLoggingRoutingDecision"];
         };
         /** BaseLitellmParams */
-        "BaseLitellmParams-Input": {
+        BaseLitellmParams: {
             /**
              * Additional Provider Specific Params
              * @description Additional provider-specific parameters for generic guardrail APIs
@@ -22227,7 +22227,7 @@ export interface components {
             extra_headers?: string[] | null;
             /**
              * Fail On Error
-             * @description Whether to fail the request if Model Armor encounters an error
+             * @description Whether to fail the request if the guardrail encounters an error. Implemented by guardrail='model_armor' and 'generic_guardrail_api'. True (default) raises the error. False logs a critical error and lets the request proceed, so only a valid guardrail response can block or modify it.
              * @default true
              */
             fail_on_error: boolean | null;
@@ -22262,185 +22262,21 @@ export interface components {
              */
             model?: string | null;
             /**
+             * On Sensitive Data
+             * @description Action to take when sensitive data is detected. 'block' raises an exception (default behavior). 'route' reroutes the request to the model specified in sensitive_data_route_to_model.
+             */
+            on_sensitive_data?: ("block" | "route") | null;
+            /**
              * On Violation
              * @description For /v1/realtime sessions: 'warn' speaks the violation message and continues; 'end_session' speaks the message and closes the connection.
              */
             on_violation?: ("warn" | "end_session") | null;
             /**
-             * Pangea Input Recipe
-             * @description Recipe for input (LLM request)
-             */
-            pangea_input_recipe?: string | null;
-            /**
-             * Pangea Output Recipe
-             * @description Recipe for output (LLM response)
-             */
-            pangea_output_recipe?: string | null;
-            /**
-             * Pattern Redaction Format
-             * @description Format string for pattern redaction (use {pattern_name} placeholder)
-             */
-            pattern_redaction_format?: string | null;
-            /**
-             * Patterns
-             * @description List of patterns (prebuilt or custom regex) to detect
-             */
-            patterns?: components["schemas"]["ContentFilterPattern"][] | null;
-            /**
-             * Realtime Violation Message
-             * @description The message the bot speaks aloud when a /v1/realtime guardrail fires. Falls back to violation_message_template if not set.
-             */
-            realtime_violation_message?: string | null;
-            /**
-             * Severity Threshold
-             * @description Minimum severity to block (high, medium, low)
-             */
-            severity_threshold?: string | null;
-            /**
-             * Skip System Message In Guardrail
-             * @description When True, unified guardrails skip system-role messages when building evaluation inputs (texts and structured_messages). When False, system messages are included even if litellm_settings sets a global skip. When None, use the global litellm.skip_system_message_in_guardrail setting.
-             */
-            skip_system_message_in_guardrail?: boolean | null;
-            /**
-             * Template Id
-             * @description The ID of your Model Armor template
-             */
-            template_id?: string | null;
-            /**
-             * Unreachable Fallback
-             * @description Behavior when a guardrail endpoint is unreachable due to network errors. NOTE: This is currently only implemented by guardrail='generic_guardrail_api'. 'fail_closed' raises an error (default). 'fail_open' logs a critical error and allows the request to proceed.
-             * @default fail_closed
-             * @enum {string}
-             */
-            unreachable_fallback: "fail_closed" | "fail_open";
-            /**
-             * Violation Message Template
-             * @description Custom message when a guardrail blocks an action. Supports placeholders like {tool_name}, {rule_id}, and {default_message}.
-             */
-            violation_message_template?: string | null;
-        } & {
-            [key: string]: unknown;
-        };
-        /** BaseLitellmParams */
-        "BaseLitellmParams-Output": {
-            /**
-             * Additional Provider Specific Params
-             * @description Additional provider-specific parameters for generic guardrail APIs
-             */
-            additional_provider_specific_params?: {
-                [key: string]: unknown;
-            } | null;
-            /**
-             * Api Base
-             * @description Base URL for the guardrail service API
-             */
-            api_base?: string | null;
-            /**
-             * Api Endpoint
-             * @description Optional custom API endpoint for Model Armor
-             */
-            api_endpoint?: string | null;
-            /**
-             * Api Key
-             * @description API key for the guardrail service
-             */
-            api_key?: string | null;
-            /**
-             * Blocked Words
-             * @description List of blocked words with individual actions
-             */
-            blocked_words?: components["schemas"]["BlockedWord"][] | null;
-            /**
-             * Blocked Words File
-             * @description Path to YAML file containing blocked_words list
-             */
-            blocked_words_file?: string | null;
-            /**
-             * Categories
-             * @description List of prebuilt categories to enable (harmful_*, bias_*)
-             */
-            categories?: components["schemas"]["ContentFilterCategoryConfig"][] | null;
-            /** @description Threshold configuration for Lakera guardrail categories */
-            category_thresholds?: components["schemas"]["LakeraCategoryThresholds"] | null;
-            /**
-             * Credentials
-             * @description Path to Google Cloud credentials JSON file or JSON string
-             */
-            credentials?: string | null;
-            /**
-             * Custom Code
-             * @description Python-like code containing the apply_guardrail function for custom guardrail logic
-             */
-            custom_code?: string | null;
-            /**
-             * Default On
-             * @description Whether the guardrail is enabled by default
-             */
-            default_on?: boolean | null;
-            /**
-             * Detect Secrets Config
-             * @description Configuration for detect-secrets guardrail
-             */
-            detect_secrets_config?: {
-                [key: string]: unknown;
-            } | null;
-            /**
-             * End Session After N Fails
-             * @description For /v1/realtime sessions: automatically close the session after this many guardrail violations.
-             */
-            end_session_after_n_fails?: number | null;
-            /**
-             * Experimental Use Latest Role Message Only
-             * @description When True, guardrails only receive the latest message for the relevant role (e.g., newest user input pre-call, newest assistant output post-call)
+             * Only Scan New Messages
+             * @description When True, the guardrail only scans messages that have not already been scanned earlier in the same session (identified by litellm_session_id / session_id). Message content is hashed per session and cached; only the diff (new or edited messages) is sent to the guardrail provider on follow-up calls. Falls back to a full scan when the request has no session id or the cache is unavailable. Intended for blocking/detection guardrails; not applied when mask_request_content is set.
              * @default false
              */
-            experimental_use_latest_role_message_only: boolean | null;
-            /**
-             * Extra Headers
-             * @description Header names to forward from the client request to the guardrail (e.g. x-request-id). Only these headers' values are sent; others may be omitted or sent as [present]. Used by generic_guardrail_api (similar to MCP extra_headers).
-             */
-            extra_headers?: string[] | null;
-            /**
-             * Fail On Error
-             * @description Whether to fail the request if Model Armor encounters an error
-             * @default true
-             */
-            fail_on_error: boolean | null;
-            /**
-             * Guard Name
-             * @description Name of the guardrail in guardrails.ai
-             */
-            guard_name?: string | null;
-            /**
-             * Keyword Redaction Tag
-             * @description Tag to use for keyword redaction
-             */
-            keyword_redaction_tag?: string | null;
-            /**
-             * Location
-             * @description Google Cloud location/region (e.g., us-central1)
-             */
-            location?: string | null;
-            /**
-             * Mask Request Content
-             * @description Will mask request content if guardrail makes any changes
-             */
-            mask_request_content?: boolean | null;
-            /**
-             * Mask Response Content
-             * @description Will mask response content if guardrail makes any changes
-             */
-            mask_response_content?: boolean | null;
-            /**
-             * Model
-             * @description Optional field if guardrail requires a 'model' parameter
-             */
-            model?: string | null;
-            /**
-             * On Violation
-             * @description For /v1/realtime sessions: 'warn' speaks the violation message and continues; 'end_session' speaks the message and closes the connection.
-             */
-            on_violation?: ("warn" | "end_session") | null;
+            only_scan_new_messages: boolean | null;
             /**
              * Pangea Input Recipe
              * @description Recipe for input (LLM request)
@@ -22467,23 +22303,66 @@ export interface components {
              */
             realtime_violation_message?: string | null;
             /**
+             * Run In Parallel
+             * @description When True, this pre_call or post_call guardrail runs concurrently with other opted-in guardrails of the same hook, after the sequential guardrails have run. Use only for block-only guardrails that inspect and reject; do not enable it for guardrails that modify the request or response (e.g. PII masking or sensitive-data routing), since parallel runs share one snapshot and their mutations would race.
+             */
+            run_in_parallel?: boolean | null;
+            /**
+             * Sanitize Error Detail
+             * @description For guardrail='model_armor': omit the raw Model Armor response from caller-facing errors and logs by default. Set False to restore verbose output.
+             * @default true
+             */
+            sanitize_error_detail: boolean | null;
+            /**
+             * Scan Only Tool Results
+             * @description When True, unified guardrails only evaluate tool results, the untrusted data an agent feeds back into the model, and skip system, user, and assistant content. Intended for agent harnesses whose own prompt scaffolding is trusted but often trips prompt-attack detectors.
+             */
+            scan_only_tool_results?: boolean | null;
+            /**
+             * Sensitive Data Route To Model
+             * @description Model to route requests to when sensitive data is detected and on_sensitive_data='route'. This is typically an on-premise model for data privacy. The routing decision persists for the entire session.
+             */
+            sensitive_data_route_to_model?: string | null;
+            /**
              * Severity Threshold
              * @description Minimum severity to block (high, medium, low)
              */
             severity_threshold?: string | null;
             /**
              * Skip System Message In Guardrail
-             * @description When True, unified guardrails skip system-role messages when building evaluation inputs (texts and structured_messages). When False, system messages are included even if litellm_settings sets a global skip. When None, use the global litellm.skip_system_message_in_guardrail setting.
+             * @description When True, unified guardrails skip system-role messages when building evaluation inputs (texts and structured_messages). When False, system messages are included even if litellm_settings sets a global skip. When None, use the global litellm.skip_system_message_in_guardrail setting. For Anthropic /v1/messages, the flag applies only to the trusted top-level system prompt. In-sequence system entries are untrusted client input and remain in texts and structured_messages.
              */
             skip_system_message_in_guardrail?: boolean | null;
+            /**
+             * Skip Tool Message In Guardrail
+             * @description When True, unified guardrails skip tool-role messages when building evaluation inputs (texts and structured_messages). When False, tool messages are included even if litellm_settings sets a global skip. When None, use the global litellm.skip_tool_message_in_guardrail setting.
+             */
+            skip_tool_message_in_guardrail?: boolean | null;
+            /**
+             * Skip Unscannable Attachments
+             * @description Implemented by guardrail='model_armor'. When True, attachment references that carry no inline bytes (file_id, gs://, or http(s) URLs) pass through unscanned instead of blocking, while fail_on_error still governs real Model Armor API errors. Default False blocks them.
+             * @default false
+             */
+            skip_unscannable_attachments: boolean | null;
+            /**
+             * Sticky Session Routing
+             * @description When True (default), after sensitive data is detected and routed, all subsequent requests in the same session will continue routing to the same model.
+             * @default true
+             */
+            sticky_session_routing: boolean | null;
             /**
              * Template Id
              * @description The ID of your Model Armor template
              */
             template_id?: string | null;
             /**
+             * Timeout
+             * @description Per-request timeout for the guardrail provider API call (seconds). Accepts int, float, or numeric string; coerced to float on load. Each guardrail handler chooses its own default when unset.
+             */
+            timeout?: number | null;
+            /**
              * Unreachable Fallback
-             * @description Behavior when a guardrail endpoint is unreachable due to network errors. NOTE: This is currently only implemented by guardrail='generic_guardrail_api'. 'fail_closed' raises an error (default). 'fail_open' logs a critical error and allows the request to proceed.
+             * @description Behavior when a guardrail endpoint is unreachable due to network errors. Implemented by guardrail='generic_guardrail_api', 'akto', 'vigil_guard', 'repelloai', 'headroom', and 'compresr'. 'fail_closed' raises an error (default). 'fail_open' logs a critical error and allows the request to proceed.
              * @default fail_closed
              * @enum {string}
              */
@@ -22498,6 +22377,56 @@ export interface components {
         };
         /** BaseModel */
         BaseModel: Record<string, never>;
+        /**
+         * BedrockChecksConfigModel
+         * @description Inline `checks` config for the resource-less Bedrock InvokeGuardrailChecks API.
+         *
+         *     Include only the checks you want to run; at least one must be set.
+         */
+        BedrockChecksConfigModel: {
+            contentFilter?: components["schemas"]["BedrockChecksContentFilterModel"] | null;
+            promptAttack?: components["schemas"]["BedrockChecksPromptAttackModel"] | null;
+            sensitiveInformation?: components["schemas"]["BedrockChecksSensitiveInformationModel"] | null;
+        };
+        /** BedrockChecksContentFilterCategoryItem */
+        BedrockChecksContentFilterCategoryItem: {
+            /**
+             * Category
+             * @enum {string}
+             */
+            category: "VIOLENCE" | "HATE" | "SEXUAL" | "MISCONDUCT" | "INSULTS";
+        };
+        /** BedrockChecksContentFilterModel */
+        BedrockChecksContentFilterModel: {
+            /** Categories */
+            categories: components["schemas"]["BedrockChecksContentFilterCategoryItem"][];
+        };
+        /** BedrockChecksPromptAttackCategoryItem */
+        BedrockChecksPromptAttackCategoryItem: {
+            /**
+             * Category
+             * @enum {string}
+             */
+            category: "JAILBREAK" | "PROMPT_INJECTION" | "PROMPT_LEAKAGE";
+        };
+        /** BedrockChecksPromptAttackModel */
+        BedrockChecksPromptAttackModel: {
+            /** Categories */
+            categories: components["schemas"]["BedrockChecksPromptAttackCategoryItem"][];
+        };
+        /** BedrockChecksSensitiveInformationEntityItem */
+        BedrockChecksSensitiveInformationEntityItem: {
+            /**
+             * Type
+             * @enum {string}
+             */
+            type: "ADDRESS" | "AGE" | "AWS_ACCESS_KEY" | "AWS_SECRET_KEY" | "CA_HEALTH_NUMBER" | "CA_SOCIAL_INSURANCE_NUMBER" | "CREDIT_DEBIT_CARD_CVV" | "CREDIT_DEBIT_CARD_EXPIRY" | "CREDIT_DEBIT_CARD_NUMBER" | "DRIVER_ID" | "EMAIL" | "INTERNATIONAL_BANK_ACCOUNT_NUMBER" | "IP_ADDRESS" | "LICENSE_PLATE" | "MAC_ADDRESS" | "NAME" | "PASSWORD" | "PHONE" | "PIN" | "SWIFT_CODE" | "UK_NATIONAL_HEALTH_SERVICE_NUMBER" | "UK_NATIONAL_INSURANCE_NUMBER" | "UK_UNIQUE_TAXPAYER_REFERENCE_NUMBER" | "URL" | "USERNAME" | "US_BANK_ACCOUNT_NUMBER" | "US_BANK_ROUTING_NUMBER" | "US_INDIVIDUAL_TAX_IDENTIFICATION_NUMBER" | "US_PASSPORT_NUMBER" | "US_SOCIAL_SECURITY_NUMBER" | "VEHICLE_IDENTIFICATION_NUMBER";
+        };
+        /** BedrockChecksSensitiveInformationModel */
+        BedrockChecksSensitiveInformationModel: {
+            /** Entities */
+            entities: components["schemas"]["BedrockChecksSensitiveInformationEntityItem"][];
+        };
         /** BlockKeyRequest */
         BlockKeyRequest: {
             /** Key */
@@ -23710,6 +23639,86 @@ export interface components {
             } | null;
         } & {
             [key: string]: unknown;
+        };
+        /**
+         * CiscoAIDefenseGuardrailConfigModelOptionalParams
+         * @description Optional parameters for the Cisco AI Defense guardrail.
+         */
+        CiscoAIDefenseGuardrailConfigModelOptionalParams: {
+            /**
+             * Enabled Rules
+             * @description Explicit list of Cisco AI Defense rules to evaluate. If omitted, the policies configured for the API key in the Cisco AI Defense UI are used.
+             */
+            enabled_rules?: components["schemas"]["CiscoAIDefenseRule"][] | null;
+            /**
+             * Fallback On Error
+             * @description Behaviour when the Cisco AI Defense API is unavailable: 'allow' proceeds without scanning (high availability), 'block' rejects the request (maximum security).
+             * @default block
+             */
+            fallback_on_error: ("allow" | "block") | null;
+            /**
+             * Inspect Path
+             * @description Override for the inspection endpoint path. Defaults to /api/v1/inspect/chat when inspection_type='chat' and /api/v1/inspect/mcp when inspection_type='mcp'.
+             */
+            inspect_path?: string | null;
+            /**
+             * Inspection Type
+             * @description Which Cisco AI Defense inspection surface to use. 'chat' scans LLM model conversations via /api/v1/inspect/chat. 'mcp' scans MCP tool calls via /api/v1/inspect/mcp. Each guardrail instance targets exactly one surface; configure two guardrails to scan both chat and MCP traffic.
+             * @default chat
+             * @enum {string}
+             */
+            inspection_type: "chat" | "mcp";
+            /**
+             * Integration Profile Id
+             * @description Integration profile id to apply (advanced).
+             */
+            integration_profile_id?: string | null;
+            /**
+             * Integration Profile Version
+             * @description Integration profile version to apply (advanced).
+             */
+            integration_profile_version?: string | null;
+            /**
+             * Integration Tenant Id
+             * @description Integration tenant id to apply (advanced).
+             */
+            integration_tenant_id?: string | null;
+            /**
+             * Integration Type
+             * @description Integration type to apply (advanced).
+             */
+            integration_type?: string | null;
+            /**
+             * On Flagged Action
+             * @description Action to take when Cisco AI Defense flags content. 'block' raises an HTTPException; 'monitor' logs the detection and lets the request continue.
+             * @default block
+             */
+            on_flagged_action: string | null;
+            /**
+             * Timeout
+             * @description Timeout (seconds) for Cisco AI Defense API calls (1-60).
+             * @default 10
+             */
+            timeout: number | null;
+        } & {
+            [key: string]: unknown;
+        };
+        /**
+         * CiscoAIDefenseRule
+         * @description A single rule to enable for Cisco AI Defense inspection.
+         */
+        CiscoAIDefenseRule: {
+            /**
+             * Entity Types
+             * @description Optional list of entity types for the rule (e.g. 'Email Address', 'Phone Number'). Applies to rules such as PII, PCI, and PHI.
+             */
+            entity_types?: string[] | null;
+            /**
+             * Rule Name
+             * @description The canonical Cisco AI Defense rule name to evaluate.
+             * @enum {string}
+             */
+            rule_name: "Code Detection" | "Harassment" | "Hate Speech" | "PCI" | "PHI" | "PII" | "Prompt Injection" | "Profanity" | "Sexual Content & Exploitation" | "Social Division & Polarization" | "Violence & Public Safety Threats";
         };
         /** CitationsObject */
         CitationsObject: {
@@ -25962,53 +25971,6 @@ export interface components {
             /** Starttime */
             startTime?: string | null;
         };
-        /**
-         * GraySwanGuardrailConfigModelOptionalParams
-         * @description Optional parameters for the Gray Swan guardrail.
-         */
-        GraySwanGuardrailConfigModelOptionalParams: {
-            /**
-             * Categories
-             * @description Default Gray Swan category definitions to send with each request.
-             */
-            categories?: {
-                [key: string]: string;
-            } | null;
-            /**
-             * Fail Open
-             * @description If true (default), errors contacting Gray Swan are logged and the request proceeds. If false, errors propagate and block the request.
-             * @default true
-             */
-            fail_open: boolean | null;
-            /**
-             * Guardrail Timeout
-             * @description Timeout in seconds for calling the Gray Swan guardrail service.
-             * @default 30
-             */
-            guardrail_timeout: number | null;
-            /**
-             * On Flagged Action
-             * @description Action when a violation is detected: 'block' rejects the call (400 error), 'monitor' logs only, 'passthrough' replaces response content with violation message (200 status).
-             * @default passthrough
-             */
-            on_flagged_action: string | null;
-            /**
-             * Policy Id
-             * @description Gray Swan policy identifier to apply during monitoring.
-             */
-            policy_id?: string | null;
-            /**
-             * Reasoning Mode
-             * @description Gray Swan reasoning mode override. Accepted values: 'off', 'hybrid', 'thinking'.
-             */
-            reasoning_mode?: string | null;
-            /**
-             * Violation Threshold
-             * @description Threshold between 0 and 1 at which Gray Swan violations trigger the configured action.
-             * @default 0.5
-             */
-            violation_threshold: number | null;
-        };
         /** Guardrail */
         Guardrail: {
             /** Created At */
@@ -26041,7 +26003,7 @@ export interface components {
             } | null;
             /** Guardrail Name */
             guardrail_name: string;
-            litellm_params?: components["schemas"]["BaseLitellmParams-Output"] | null;
+            litellm_params?: components["schemas"]["LitellmParams"] | null;
             /** Updated At */
             updated_at?: string | null;
         };
@@ -28502,7 +28464,7 @@ export interface components {
             anonymize_input?: boolean | null;
             /**
              * Api Base
-             * @description Base URL for the Lakera AI API
+             * @description Regional base URL for the Cisco AI Defense Inspection API. Defaults to https://us.api.inspect.aidefense.security.cisco.com. Supported regions: us (us-west-2), ap (ap-ne-1), eu (eu-central-1). The environment variable `CISCO_AI_DEFENSE_API_BASE` is consulted as a fallback. The endpoint path is derived from inspection_type (/api/v1/inspect/chat for 'chat', /api/v1/inspect/mcp for 'mcp').
              */
             api_base?: string | null;
             /**
@@ -28517,7 +28479,7 @@ export interface components {
             api_id?: string | null;
             /**
              * Api Key
-             * @description API key for the Lakera AI service
+             * @description API key for the Cisco AI Defense inspection endpoint. If not provided, the `CISCO_AI_DEFENSE_API_KEY` environment variable is used. Sent in the `X-Cisco-AI-Defense-API-Key` header. Both the chat and MCP endpoints use this key.
              */
             api_key?: string | null;
             /**
@@ -28541,6 +28503,11 @@ export interface components {
              * @description Custom assertions to validate against the output. Each assertion is a string describing a condition.
              */
             assertions?: string[] | null;
+            /**
+             * Asset Id
+             * @description Repello asset ID whose dashboard policies are enforced. Required; the guardrail raises at init if it is missing.
+             */
+            asset_id?: string | null;
             /**
              * Async Mode
              * @description Set to True to request asynchronous analysis (sets `plr_async` header). Defaults to provider behaviour when omitted.
@@ -28650,6 +28617,14 @@ export interface components {
             categories?: components["schemas"]["ContentFilterCategoryConfig"][] | null;
             /** @description Threshold configuration for Lakera guardrail categories */
             category_thresholds?: components["schemas"]["LakeraCategoryThresholds"] | null;
+            /** @description Inline safeguards for the resource-less InvokeGuardrailChecks API (contentFilter / promptAttack / sensitiveInformation). When set, the guardrail calls InvokeGuardrailChecks instead of ApplyGuardrail and no guardrailIdentifier is required. Mutually exclusive with guardrailIdentifier. */
+            checks?: components["schemas"]["BedrockChecksConfigModel"] | null;
+            /**
+             * Chunk Budget Chars
+             * @description ApplyGuardrail: batch size, in characters, used to re-send content after AWS has rejected a request as too large. Requests AWS accepts are always sent in a single call, so this has no effect until a rejection happens. Defaults to 25,000; a batch AWS still rejects is bisected automatically, so this value only trades round trips against batch size and cannot fail a request on its own.
+             * @default 25000
+             */
+            chunk_budget_chars: number;
             /**
              * Confidence Threshold
              * @description Only block or mask when detection confidence >= this value; below threshold, allow or log_only.
@@ -28663,6 +28638,12 @@ export interface components {
             config?: {
                 [key: string]: unknown;
             } | null;
+            /**
+             * Content Filter Threshold
+             * @description InvokeGuardrailChecks: block when any contentFilter severityScore >= this value (scores are in [0,1]). Set to null to make the content filter detect-only (logged, never blocks).
+             * @default 0.5
+             */
+            content_filter_threshold: number | null;
             /**
              * Content Moderation Check
              * @description Enable content moderation to check for harmful content (harassment, hate speech, etc.).
@@ -28678,6 +28659,11 @@ export interface components {
              * @description Python-like code containing the apply_guardrail function for custom guardrail logic
              */
             custom_code?: string | null;
+            /**
+             * Deepkeep Firewall Id
+             * @description The DeepKeep Firewall ID to use for guardrail evaluation. If not provided, the `DEEPKEEP_FIREWALL_ID` environment variable is checked.
+             */
+            deepkeep_firewall_id?: string | null;
             /**
              * Default Action
              * @description Fallback decision when no rule matches
@@ -28755,7 +28741,7 @@ export interface components {
             extra_headers?: string[] | null;
             /**
              * Fail On Error
-             * @description Whether to fail the request if Model Armor encounters an error
+             * @description Whether to fail the request if the guardrail encounters an error. Implemented by guardrail='model_armor' and 'generic_guardrail_api'. True (default) raises the error. False logs a critical error and lets the request proceed, so only a valid guardrail response can block or modify it.
              * @default true
              */
             fail_on_error: boolean | null;
@@ -28874,7 +28860,7 @@ export interface components {
             mode: string | string[] | components["schemas"]["Mode"];
             /**
              * Model
-             * @description Optional field if guardrail requires a 'model' parameter
+             * @description Model name forwarded to the headroom /v1/compress endpoint.
              */
             model?: string | null;
             /**
@@ -28902,12 +28888,23 @@ export interface components {
              */
             on_flagged_action: string | null;
             /**
+             * On Sensitive Data
+             * @description Action to take when sensitive data is detected. 'block' raises an exception (default behavior). 'route' reroutes the request to the model specified in sensitive_data_route_to_model.
+             */
+            on_sensitive_data?: ("block" | "route") | null;
+            /**
              * On Violation
              * @description For /v1/realtime sessions: 'warn' speaks the violation message and continues; 'end_session' speaks the message and closes the connection.
              */
             on_violation?: ("warn" | "end_session") | null;
+            /**
+             * Only Scan New Messages
+             * @description When True, the guardrail only scans messages that have not already been scanned earlier in the same session (identified by litellm_session_id / session_id). Message content is hashed per session and cached; only the diff (new or edited messages) is sent to the guardrail provider on follow-up calls. Falls back to a full scan when the request has no session id or the cache is unavailable. Intended for blocking/detection guardrails; not applied when mask_request_content is set.
+             * @default false
+             */
+            only_scan_new_messages: boolean | null;
             /** @description Optional parameters for the guardrail */
-            optional_params?: components["schemas"]["GraySwanGuardrailConfigModelOptionalParams"] | null;
+            optional_params?: components["schemas"]["CiscoAIDefenseGuardrailConfigModelOptionalParams"] | null;
             /**
              * Output Parse Pii
              * @description When True, LiteLLM will replace the masked text with the original text in the response
@@ -28950,6 +28947,12 @@ export interface components {
              */
             pii_check?: boolean | null;
             /**
+             * Pii Confidence Threshold
+             * @description InvokeGuardrailChecks: block when any sensitiveInformation confidenceScore >= this value (scores are in [0,1]). Set to null to make PII detection detect-only.
+             * @default 0.5
+             */
+            pii_confidence_threshold: number | null;
+            /**
              * Pii Entities Config
              * @description Configuration for PII entity types and actions
              */
@@ -28971,6 +28974,16 @@ export interface components {
              * @description XecGuard policies to apply on each scan. Select one or more of the built-in default policies; if none are selected, the guardrail defaults to System Prompt Enforcement + Harmful Content Protection.
              */
             policy_names?: string[] | null;
+            /**
+             * Post Checkpoint Id
+             * @description Post-checkpoint ID for the Ovalix Tracker service.
+             */
+            post_checkpoint_id?: string | null;
+            /**
+             * Pre Checkpoint Id
+             * @description Pre-checkpoint ID for the Ovalix Tracker service.
+             */
+            pre_checkpoint_id?: string | null;
             /**
              * Presidio Ad Hoc Recognizers
              * @description Path to a JSON file containing ad-hoc recognizers for Presidio
@@ -29020,6 +29033,12 @@ export interface components {
              */
             project_id?: string | null;
             /**
+             * Prompt Attack Threshold
+             * @description InvokeGuardrailChecks: block when any promptAttack severityScore >= this value (scores are in [0,1]). Set to null to make prompt-attack detection detect-only.
+             * @default 0.5
+             */
+            prompt_attack_threshold: number | null;
+            /**
              * Prompt Injections
              * @description Enable prompt injection detection. Default check if no evaluation_id and no other checks are specified.
              */
@@ -29034,6 +29053,22 @@ export interface components {
              * @description Ordered allow/deny rules. Patterns use regex for tool names/types and optional regex constraints on tool arguments.
              */
             rules?: components["schemas"]["ToolPermissionRule"][] | null;
+            /**
+             * Run In Parallel
+             * @description When True, this pre_call or post_call guardrail runs concurrently with other opted-in guardrails of the same hook, after the sequential guardrails have run. Use only for block-only guardrails that inspect and reject; do not enable it for guardrails that modify the request or response (e.g. PII masking or sensitive-data routing), since parallel runs share one snapshot and their mutations would race.
+             */
+            run_in_parallel?: boolean | null;
+            /**
+             * Sanitize Error Detail
+             * @description For guardrail='model_armor': omit the raw Model Armor response from caller-facing errors and logs by default. Set False to restore verbose output.
+             * @default true
+             */
+            sanitize_error_detail: boolean | null;
+            /**
+             * Scan Only Tool Results
+             * @description When True, unified guardrails only evaluate tool results, the untrusted data an agent feeds back into the model, and skip system, user, and assistant content. Intended for agent harnesses whose own prompt scaffolding is trusted but often trips prompt-attack detectors.
+             */
+            scan_only_tool_results?: boolean | null;
             /**
              * Send User Api Key Alias
              * @description Whether to send user_API_key_alias in headers
@@ -29053,28 +29088,85 @@ export interface components {
              */
             send_user_api_key_user_id: boolean | null;
             /**
+             * Sensitive Data Route To Model
+             * @description Model to route requests to when sensitive data is detected and on_sensitive_data='route'. This is typically an on-premise model for data privacy. The routing decision persists for the entire session.
+             */
+            sensitive_data_route_to_model?: string | null;
+            /**
              * Severity Threshold
              * @description Minimum severity to block (high, medium, low)
              */
             severity_threshold?: string | null;
             /**
+             * Singulr Api Base
+             * @description The Singulr API base URL. Get base URL from Singulr Platform.
+             */
+            singulr_api_base?: string | null;
+            /**
+             * Singulr Api Key
+             * @description The Singulr API key. Generate API key from Singulr Platform.
+             */
+            singulr_api_key?: string | null;
+            /**
+             * Singulr Application Id
+             * @description The Singulr application ID. Get application ID from Singulr Platform.
+             */
+            singulr_application_id?: string | null;
+            /**
+             * Singulr Guardrail Id
+             * @description The Singulr Guardrail ID. Get guardrail ID from Singulr Platform.
+             */
+            singulr_guardrail_id?: string | null;
+            /**
              * Skip System Message In Guardrail
-             * @description When True, unified guardrails skip system-role messages when building evaluation inputs (texts and structured_messages). When False, system messages are included even if litellm_settings sets a global skip. When None, use the global litellm.skip_system_message_in_guardrail setting.
+             * @description When True, unified guardrails skip system-role messages when building evaluation inputs (texts and structured_messages). When False, system messages are included even if litellm_settings sets a global skip. When None, use the global litellm.skip_system_message_in_guardrail setting. For Anthropic /v1/messages, the flag applies only to the trusted top-level system prompt. In-sequence system entries are untrusted client input and remain in texts and structured_messages.
              */
             skip_system_message_in_guardrail?: boolean | null;
+            /**
+             * Skip Tool Message In Guardrail
+             * @description When True, unified guardrails skip tool-role messages when building evaluation inputs (texts and structured_messages). When False, tool messages are included even if litellm_settings sets a global skip. When None, use the global litellm.skip_tool_message_in_guardrail setting.
+             */
+            skip_tool_message_in_guardrail?: boolean | null;
+            /**
+             * Skip Unscannable Attachments
+             * @description Implemented by guardrail='model_armor'. When True, attachment references that carry no inline bytes (file_id, gs://, or http(s) URLs) pass through unscanned instead of blocking, while fail_on_error still governs real Model Armor API errors. Default False blocks them.
+             * @default false
+             */
+            skip_unscannable_attachments: boolean | null;
+            /**
+             * Sticky Session Routing
+             * @description When True (default), after sensitive data is detected and routed, all subsequent requests in the same session will continue routing to the same model.
+             * @default true
+             */
+            sticky_session_routing: boolean | null;
             /**
              * Template Id
              * @description The ID of your Model Armor template
              */
             template_id?: string | null;
             /**
+             * Timeout
+             * @description Per-request timeout for the guardrail provider API call (seconds). Accepts int, float, or numeric string; coerced to float on load. Each guardrail handler chooses its own default when unset.
+             */
+            timeout?: number | null;
+            /**
              * Tool Selection Quality Check
              * @description Enable tool selection quality check to evaluate quality of tool/function calls.
              */
             tool_selection_quality_check?: boolean | null;
             /**
+             * Tracker Api Base
+             * @description Base URL for the Ovalix Tracker service.
+             */
+            tracker_api_base?: string | null;
+            /**
+             * Tracker Api Key
+             * @description API key for the Ovalix Tracker service.
+             */
+            tracker_api_key?: string | null;
+            /**
              * Unreachable Fallback
-             * @description What to do when Akto is unreachable. 'fail_open' = allow, 'fail_closed' = block.
+             * @description Behavior when the headroom compression service is unreachable or errors. 'fail_closed' raises an error (default). 'fail_open' logs a critical error and forwards the request uncompressed instead of blocking it.
              * @default fail_closed
              * @enum {string}
              */
@@ -30847,7 +30939,7 @@ export interface components {
             } | null;
             /** Guardrail Name */
             guardrail_name?: string | null;
-            litellm_params?: components["schemas"]["BaseLitellmParams-Input"] | null;
+            litellm_params?: components["schemas"]["BaseLitellmParams"] | null;
         };
         /** PatchPromptRequest */
         PatchPromptRequest: {
@@ -31029,7 +31121,7 @@ export interface components {
          * PiiEntityType
          * @enum {string}
          */
-        PiiEntityType: "CREDIT_CARD" | "CRYPTO" | "DATE_TIME" | "EMAIL_ADDRESS" | "IBAN_CODE" | "IP_ADDRESS" | "NRP" | "LOCATION" | "PERSON" | "PHONE_NUMBER" | "MEDICAL_LICENSE" | "URL" | "US_BANK_NUMBER" | "US_DRIVER_LICENSE" | "US_ITIN" | "US_PASSPORT" | "US_SSN" | "UK_NHS" | "UK_NINO" | "ES_NIF" | "ES_NIE" | "IT_FISCAL_CODE" | "IT_DRIVER_LICENSE" | "IT_VAT_CODE" | "IT_PASSPORT" | "IT_IDENTITY_CARD" | "PL_PESEL" | "SG_NRIC_FIN" | "SG_UEN" | "AU_ABN" | "AU_ACN" | "AU_TFN" | "AU_MEDICARE" | "IN_PAN" | "IN_AADHAAR" | "IN_VEHICLE_REGISTRATION" | "IN_VOTER" | "IN_PASSPORT" | "FI_PERSONAL_IDENTITY_CODE";
+        PiiEntityType: "CREDIT_CARD" | "CRYPTO" | "DATE_TIME" | "EMAIL_ADDRESS" | "IBAN_CODE" | "IP_ADDRESS" | "NRP" | "LOCATION" | "PERSON" | "PHONE_NUMBER" | "MEDICAL_LICENSE" | "URL" | "US_BANK_NUMBER" | "US_DRIVER_LICENSE" | "US_ITIN" | "US_PASSPORT" | "US_SSN" | "UK_NHS" | "UK_NINO" | "UK_PASSPORT" | "UK_POSTCODE" | "UK_VEHICLE_REGISTRATION" | "ES_NIF" | "ES_NIE" | "IT_FISCAL_CODE" | "IT_DRIVER_LICENSE" | "IT_VAT_CODE" | "IT_PASSPORT" | "IT_IDENTITY_CARD" | "PL_PESEL" | "SG_NRIC_FIN" | "SG_UEN" | "AU_ABN" | "AU_ACN" | "AU_TFN" | "AU_MEDICARE" | "IN_PAN" | "IN_AADHAAR" | "IN_VEHICLE_REGISTRATION" | "IN_VOTER" | "IN_PASSPORT" | "FI_PERSONAL_IDENTITY_CODE";
         /**
          * PipelineTestRequest
          * @description Request body for testing a guardrail pipeline with sample messages.

--- a/ui/litellm-dashboard/src/lib/http/schema.d.ts
+++ b/ui/litellm-dashboard/src/lib/http/schema.d.ts
@@ -45104,7 +45104,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": unknown;
+                    "application/json": components["schemas"]["GuardrailInfoResponse"];
                 };
             };
             /** @description Validation Error */
@@ -45236,7 +45236,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": unknown;
+                    "application/json": components["schemas"]["GuardrailInfoResponse"];
                 };
             };
             /** @description Validation Error */


### PR DESCRIPTION
## TLDR

Problem this solves:

- Guardrail API responses were typed looser than what the proxy actually returns
- The dashboard hand-copied those types and used `any`, so tag-based modes crashed pages
- Edit Code modal still showed empty mode chips for a tag-based guardrail
- List and detail responses inflated every guardrail with ~150 unset provider fields
- Editing a tag-based guardrail's chips could silently flatten its tag routing

How it solves it:

- `GuardrailInfoResponse.litellm_params` is now the full `LitellmParams` model
- The three read endpoints serialize only stored keys via `response_model_exclude_unset`
- DB writes persist only client-set params, not the full default dump
- A row failing validation returns `litellm_params: null` instead of a 500
- `GET /guardrails/{id}` gains a typed response schema
- Dashboard guardrail types alias the generated schema, `any` removed
- One shared helper flattens string, list, and tag-based modes
- CustomCodeModal locks its mode chips when the stored mode is tag-based

## User Flow

Before: an admin editing the code of a tag-based guardrail sees no mode selected, and every guardrail response claims settings for providers they never configured

1. They add a guardrail to the config with `mode: {tags: {"Service-Type: internal-service": post_call}, default: [pre_call]}` and restart the proxy
2. They open https://litellm-domain/ui/?page=guardrails and see the row render `pre_call, post_call (tag-based)` in the Mode column
3. They click the guardrail, then Edit Code, and the Mode chips are empty even though the guardrail runs in `pre_call` and `post_call`
4. GET https://litellm-domain/openapi.json describes `GuardrailInfoResponse.litellm_params` as `BaseLitellmParams`, which has neither `mode` nor `guardrail`, so generated clients cannot see either field
5. GET https://litellm-domain/v2/guardrails/list returns ~150 fields for their four-line guardrail, including concrete values like a Bedrock batching size of 25000, so it looks configured for providers they never touched

After: the same modal opens with the guardrail's real modes shown, the schema matches the real response, and responses carry only what was configured

1. They add the same guardrail to the config and restart the proxy
2. They open https://litellm-domain/ui/?page=guardrails and see the same `pre_call, post_call (tag-based)` row
3. They click the guardrail, then Edit Code, and the Mode chips show `pre_call` and `post_call`, locked with a note that tag-based mode is managed in config, so saving cannot flatten the tag routing
4. GET https://litellm-domain/openapi.json describes `GuardrailInfoResponse.litellm_params` as `LitellmParams`, whose `mode` is `string | string[] | Mode`, so generated clients see the tag-based shape
5. GET https://litellm-domain/v2/guardrails/list returns exactly the four fields they configured

## Relevant issues

Follow-up to #37493

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Shared setup: proxy config with a tag-based custom_code guardrail, plus one DB guardrail with the same mode created through the API

```yaml
model_list:
  - model_name: gpt-5-mini
    litellm_params:
      model: openai/gpt-5-mini
      api_key: os.environ/OPENAI_API_KEY

guardrails:
  - guardrail_name: tagged-custom-guard
    litellm_params:
      guardrail: custom_code
      mode:
        tags:
          "Service-Type: internal-service": post_call
        default: [pre_call]
      default_on: false
      custom_code: |
        async def apply_guardrail(inputs, request_data, input_type):
            return inputs

general_settings:
  store_model_in_db: true
```

```bash
curl -s http://localhost:4000/guardrails -H "Authorization: Bearer $LITELLM_MASTER_KEY" -H 'Content-Type: application/json' -d '{"guardrail": {"guardrail_name": "tagged-custom-guard-db", "litellm_params": {"guardrail": "custom_code", "mode": {"tags": {"Service-Type: internal-service": "post_call"}, "default": ["pre_call"]}, "default_on": false, "custom_code": "async def apply_guardrail(inputs, request_data, input_type):\n    return inputs\n"}, "guardrail_info": {}}}'
```

Both proxies were started with `python litellm/proxy/proxy_cli.py --config guardrail_types_config.yaml` and the dashboard dev server with `npm run dev` in `ui/litellm-dashboard`

### Before (e5adf7d926)

#### OpenAPI schema for the guardrail response

1. `curl -s http://localhost:4000/openapi.json | jq -c '.components.schemas.GuardrailInfoResponse.properties.litellm_params'`
2. Output: `{"anyOf":[{"$ref":"#/components/schemas/BaseLitellmParams-Output"},{"type":"null"}]}`
3. `curl -s http://localhost:4000/openapi.json | jq -c '.components.schemas["BaseLitellmParams-Output"].properties | has("mode"), has("guardrail")'`
4. Output: `false` and `false`, so the schema promises a response without the two fields the UI reads most

#### Keys on the wire for a freshly created guardrail

1. Create the DB guardrail with the shared-setup curl above
2. `curl -s http://localhost:4000/v2/guardrails/list -H "Authorization: Bearer $LITELLM_MASTER_KEY" | jq -c '.guardrails[] | {name: .guardrail_name, key_count: (.litellm_params | length), chunk_budget_chars: .litellm_params.chunk_budget_chars, unreachable_fallback: .litellm_params.unreachable_fallback, sticky_session_routing: .litellm_params.sticky_session_routing}'`
3. Output: `{"name":"tagged-custom-guard-db","key_count":146,"chunk_budget_chars":25000,"unreachable_fallback":"fail_closed","sticky_session_routing":true}` and `{"name":"tagged-custom-guard","key_count":73,"chunk_budget_chars":25000,"unreachable_fallback":"fail_closed","sticky_session_routing":true}`
4. A four-key custom_code guardrail answers with 146 fields, and Bedrock batching, network fallback, and session routing settings the admin never set carry concrete values

#### Guardrail list and info keep the tag-based mode

1. `curl -s http://localhost:4000/v2/guardrails/list -H "Authorization: Bearer $LITELLM_MASTER_KEY" | jq -c '.guardrails[] | {guardrail_name, guardrail_definition_location, mode: .litellm_params.mode}'`
2. Output: `{"guardrail_name":"tagged-custom-guard-db","guardrail_definition_location":"db","mode":{"tags":{"Service-Type: internal-service":"post_call"},"default":["pre_call"]}}` and `{"guardrail_name":"tagged-custom-guard","guardrail_definition_location":"config","mode":{"tags":{"Service-Type: internal-service":"post_call"},"default":["pre_call"]}}`
3. `curl -s http://localhost:4000/guardrails/<id> -H "Authorization: Bearer $LITELLM_MASTER_KEY" | jq -c '{guardrail_id, guardrail_definition_location, guardrail: .litellm_params.guardrail, mode: .litellm_params.mode}'`
4. Output: `{"guardrail_id":"<id>","guardrail_definition_location":"db","guardrail":"custom_code","mode":{"tags":{"Service-Type: internal-service":"post_call"},"default":["pre_call"]}}`

#### Edit Code modal for a tag-based guardrail

1. Open http://localhost:3000/?page=guardrails and click `tagged-custom-guard-db`
2. Click Edit Code
3. The Mode chips are empty, and picking any chip then saving replaces the tag-based mode with a flat list (screenshot to follow)

### After (b2d831745d)

#### OpenAPI schema for the guardrail response

1. `curl -s http://localhost:4000/openapi.json | jq -c '.components.schemas.GuardrailInfoResponse.properties.litellm_params'`
2. Output: `{"anyOf":[{"$ref":"#/components/schemas/LitellmParams"},{"type":"null"}]}`
3. `curl -s http://localhost:4000/openapi.json | jq -c '.components.schemas.LitellmParams.properties | has("mode"), has("guardrail"), .mode.anyOf'`
4. Output: `true`, `true`, and `[{"type":"string"},{"items":{"type":"string"},"type":"array"},{"$ref":"#/components/schemas/Mode"}]`
5. `curl -s http://localhost:4000/openapi.json | jq -c '.paths."/guardrails/{guardrail_id}".get.responses."200".content."application/json".schema'` now returns `{"$ref":"#/components/schemas/GuardrailInfoResponse"}` where it was `{}` before

#### Keys on the wire for a freshly created guardrail

1. Create the DB guardrail with the shared-setup curl above
2. Same `curl -s http://localhost:4000/v2/guardrails/list ... | jq -c ...` as Before
3. Output: `{"name":"tagged-custom-guard-db","key_count":4,"chunk_budget_chars":null,"unreachable_fallback":null,"sticky_session_routing":null}` and `{"name":"tagged-custom-guard","key_count":4,"chunk_budget_chars":null,"unreachable_fallback":null,"sticky_session_routing":null}`
4. `curl -s http://localhost:4000/v2/guardrails/list -H "Authorization: Bearer $LITELLM_MASTER_KEY" | jq -c '.guardrails[] | .litellm_params | keys'`
5. Output: `["custom_code","default_on","guardrail","mode"]` twice, so both rows answer with exactly what was configured

#### Guardrail list and info keep the tag-based mode

1. Same `curl -s http://localhost:4000/v2/guardrails/list ...` as Before
2. Output: `{"guardrail_name":"tagged-custom-guard-db","guardrail_definition_location":"db","mode":{"tags":{"Service-Type: internal-service":"post_call"},"default":["pre_call"]}}` and `{"guardrail_name":"tagged-custom-guard","guardrail_definition_location":"config","mode":{"tags":{"Service-Type: internal-service":"post_call"},"default":["pre_call"]}}`, identical to Before
3. Same `curl -s http://localhost:4000/guardrails/<id> ...` as Before
4. Output: `{"guardrail_id":"<id>","guardrail_definition_location":"db","guardrail":"custom_code","mode":{"tags":{"Service-Type: internal-service":"post_call"},"default":["pre_call"]}}`, unchanged, so the sparse response drops nothing that was stored

#### Edit Code modal for a tag-based guardrail

1. Open http://localhost:3000/?page=guardrails and click `tagged-custom-guard-db`
2. Click Edit Code
3. The Mode chips show `pre_call` and `post_call`, the picker is disabled, and a note reads "Tag-based mode is managed in config and can't be edited here" (screenshot to follow)

## Type

🐛 Bug Fix

## Caveats (if any)

- Breaking: read responses no longer emit unset params (null padding, provider defaults)
- Legacy DB rows keep their previously stored full dumps until next update
- `default_on` always serializes; the model forces it during construction
- `_lazy_openapi_snapshot.json` refreshed for the `guardrails` fragment only; the rest was already stale
- Plain string or list modes stay editable in the modal, tag-based is read-only

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking change for API clients that relied on unset guardrail fields appearing in list/detail responses; behavior is limited to read serialization and typing, not runtime guardrail enforcement.
> 
> **Overview**
> Guardrail **list/detail APIs** now type `litellm_params` as full **`LitellmParams`** (including `guardrail`, `mode`, and tag-based `Mode`) instead of **`BaseLitellmParams`**, and use **`response_model_exclude_unset`** so JSON only includes keys that were actually set—not hundreds of provider defaults. **DB create/update** persists params with **`exclude_unset`** for the same sparse storage.
> 
> Invalid stored params on a row are **validated** on read; failures yield **`litellm_params: null`** with a warning instead of failing the whole list. **`GET /guardrails/{id}`** is documented with **`GuardrailInfoResponse`** in OpenAPI.
> 
> The **dashboard** aliases guardrail types from the generated schema, handles optional `litellm_params`, and uses shared helpers for **tag-based modes** in tables and the **Custom Code** modal (chips seeded and **locked** so saves cannot overwrite tag routing).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b2d831745dc7730bfc1d0117404cc1365545ab5d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->