### PR TITLE
fix(together_ai): pass tools through for models missing from the registry

### DIFF
--- a/litellm/llms/together_ai/chat/transformation.py
+++ b/litellm/llms/together_ai/chat/transformation.py
@@ -4,34 +4,74 @@ Translates from OpenAI's `/v1/chat/completions` to Together AI's `/v1/chat/compl
 Docs: https://docs.together.ai/docs/chat-overview
 """
 
+from collections.abc import Container
 from types import MappingProxyType
 from typing import Final
 
+import litellm
 from litellm._logging import verbose_logger
+from litellm.exceptions import UnsupportedParamsError
 from litellm.utils import supports_function_calling
 
 from ...openai.chat.gpt_transformation import OpenAIGPTConfig
 
-FUNCTION_CALLING_ONLY_PARAMS: Final = ("tools", "tool_choice", "function_call", "response_format")
+TOOL_CALLING_PARAMS: Final = ("tools", "tool_choice", "function_call")
 PLAIN_TEXT_RESPONSE_FORMAT: Final = MappingProxyType({"type": "text"})
+FUNCTION_CALLING_DOCS_URL: Final = "https://docs.together.ai/docs/function-calling"
+
+
+def _function_calling_verdict(model: str) -> bool | None:
+    try:
+        if supports_function_calling(model, custom_llm_provider="together_ai"):
+            return True
+    except Exception as e:
+        verbose_logger.debug("Error checking together_ai function calling support for %s: %s", model, e)
+    registry_entry: Final = litellm.model_cost.get(f"together_ai/{model}")
+    if isinstance(registry_entry, dict) and registry_entry.get("supports_function_calling") is False:
+        return False
+    return None
+
+
+def _tool_params_to_drop(passed_params: Container[str], model: str, drop_params: bool) -> tuple[str, ...]:
+    passed_tool_params: Final = tuple(param for param in TOOL_CALLING_PARAMS if param in passed_params)
+    if not passed_tool_params:
+        return ()
+    verdict: Final = _function_calling_verdict(model)
+    if verdict is True:
+        return ()
+    if verdict is None:
+        verbose_logger.warning(
+            "together_ai model %s has no function calling entry in the model registry; passing %s through for Together to validate. Docs - %s",
+            model,
+            ", ".join(passed_tool_params),
+            FUNCTION_CALLING_DOCS_URL,
+        )
+        return ()
+    if drop_params or litellm.drop_params:
+        verbose_logger.warning(
+            "together_ai model %s does not support function calling per the model registry; dropping %s. Docs - %s",
+            model,
+            ", ".join(passed_tool_params),
+            FUNCTION_CALLING_DOCS_URL,
+        )
+        return passed_tool_params
+    raise UnsupportedParamsError(
+        status_code=500,
+        message=f"together_ai does not support parameters: {', '.join(passed_tool_params)}, for model={model}. To drop it from the call, set `litellm.drop_params = True`.",
+    )
 
 
 class TogetherAIChatConfig(OpenAIGPTConfig):
     def get_supported_openai_params(self, model: str) -> list:
-        supports_fc: bool | None = None
-        try:
-            supports_fc = supports_function_calling(model, custom_llm_provider="together_ai")
-        except Exception as e:
-            verbose_logger.debug("Error getting supported openai params: %s", e)
-
+        supports_fc: Final = _function_calling_verdict(model)
         supported_params: Final = super().get_supported_openai_params(model)
         if supports_fc is True:
             return supported_params
         verbose_logger.debug(
-            "Only some together models support function calling/response_format. Docs - https://docs.together.ai/docs/function-calling"
+            "Only some together models support response_format. Docs - https://docs.together.ai/docs/function-calling"
         )
         return [  # mutable-ok: the inherited contract returns a plain list; building fresh avoids mutating the base class's value
-            param for param in supported_params if param not in FUNCTION_CALLING_ONLY_PARAMS
+            param for param in supported_params if param != "response_format"
         ]
 
     def map_openai_params(
@@ -42,7 +82,8 @@ class TogetherAIChatConfig(OpenAIGPTConfig):
         drop_params: bool,
     ) -> dict:
         mapped_openai_params: Final = super().map_openai_params(non_default_params, optional_params, model, drop_params)
-
+        for param in _tool_params_to_drop(mapped_openai_params, model, drop_params):
+            mapped_openai_params.pop(param)
         if mapped_openai_params.get("response_format") == PLAIN_TEXT_RESPONSE_FORMAT:
             mapped_openai_params.pop("response_format")
         return mapped_openai_params

--- a/tests/test_litellm/llms/together_ai/chat/test_together_ai_chat_transformation.py
+++ b/tests/test_litellm/llms/together_ai/chat/test_together_ai_chat_transformation.py
@@ -1,10 +1,12 @@
 import json
+import logging
 from unittest.mock import MagicMock
 
 import httpx
 import pytest
 
 import litellm
+from litellm.exceptions import UnsupportedParamsError
 from litellm.llms.base_llm.chat.transformation import LiteLLMLoggingObj
 from litellm.llms.openai.chat.gpt_transformation import (
     OpenAIChatCompletionStreamingHandler,
@@ -14,10 +16,12 @@ from litellm.types.utils import LlmProviders, ModelResponse
 
 TOOL_CALLING_MODEL = "openai/gpt-oss-20b"
 REASONING_MODEL = "deepseek-ai/DeepSeek-V3.1"
-PLAIN_MODEL = "Qwen/Qwen3-235B-A22B-fp8-tput"
-UNMAPPED_MODEL = "MiniMaxAI/MiniMax-M3"
+UNMAPPED_MODEL = "example-org/brand-new-model"
+NO_TOOLS_MODEL = "example-org/no-tools-model"
 
-FUNCTION_CALLING_PARAMS = ("tools", "tool_choice", "function_call", "response_format")
+TOOL_PARAMS = ("tools", "tool_choice", "function_call")
+
+WEATHER_TOOLS = [{"type": "function", "function": {"name": "get_weather", "parameters": {}}}]
 
 
 @pytest.fixture(autouse=True)
@@ -28,42 +32,101 @@ def force_local_model_cost(monkeypatch):
     monkeypatch.setattr(litellm, "model_cost", get_model_cost_map(url=litellm.model_cost_map_url))
 
 
+@pytest.fixture
+def registry_disables_function_calling(monkeypatch):
+    monkeypatch.setitem(
+        litellm.model_cost,
+        f"together_ai/{NO_TOOLS_MODEL}",
+        {"litellm_provider": "together_ai", "mode": "chat", "supports_function_calling": False},
+    )
+
+
+@pytest.fixture
+def together_warning_log(caplog):
+    from litellm._logging import verbose_logger
+
+    verbose_logger.addHandler(caplog.handler)
+    with caplog.at_level(logging.WARNING, logger="LiteLLM"):
+        yield caplog
+    verbose_logger.removeHandler(caplog.handler)
+
+
 def test_supported_params_tool_calling_model():
     supported = TogetherAIChatConfig().get_supported_openai_params(model=TOOL_CALLING_MODEL)
 
-    for param in FUNCTION_CALLING_PARAMS:
+    for param in (*TOOL_PARAMS, "response_format"):
         assert param in supported
 
 
-def test_supported_params_plain_model():
-    supported = TogetherAIChatConfig().get_supported_openai_params(model=PLAIN_MODEL)
-
-    for param in FUNCTION_CALLING_PARAMS:
-        assert param not in supported
-    assert "temperature" in supported
-    assert "max_tokens" in supported
-
-
-def test_supported_params_unmapped_model_treated_as_plain():
+def test_supported_params_unmapped_model_keeps_tool_params():
     supported = TogetherAIChatConfig().get_supported_openai_params(model=UNMAPPED_MODEL)
 
-    for param in FUNCTION_CALLING_PARAMS:
-        assert param not in supported
+    for param in TOOL_PARAMS:
+        assert param in supported
+    assert "response_format" not in supported
     assert "stream" in supported
+    assert "temperature" in supported
+
+
+def test_supported_params_no_tools_model_keeps_tool_params(registry_disables_function_calling):
+    supported = TogetherAIChatConfig().get_supported_openai_params(model=NO_TOOLS_MODEL)
+
+    for param in TOOL_PARAMS:
+        assert param in supported
+    assert "response_format" not in supported
 
 
 def test_map_openai_params_tool_calling_model_passes_tools():
-    tools = [{"type": "function", "function": {"name": "get_weather", "parameters": {}}}]
-
     mapped = TogetherAIChatConfig().map_openai_params(
-        non_default_params={"tools": tools, "tool_choice": "auto"},
+        non_default_params={"tools": WEATHER_TOOLS, "tool_choice": "auto"},
         optional_params={},
         model=TOOL_CALLING_MODEL,
         drop_params=False,
     )
 
-    assert mapped["tools"] == tools
+    assert mapped["tools"] == WEATHER_TOOLS
     assert mapped["tool_choice"] == "auto"
+
+
+@pytest.mark.parametrize("drop_params", [False, True])
+def test_map_openai_params_unmapped_model_passes_tools_through(drop_params, together_warning_log):
+    mapped = TogetherAIChatConfig().map_openai_params(
+        non_default_params={"tools": WEATHER_TOOLS, "tool_choice": "required"},
+        optional_params={},
+        model=UNMAPPED_MODEL,
+        drop_params=drop_params,
+    )
+
+    assert mapped["tools"] == WEATHER_TOOLS
+    assert mapped["tool_choice"] == "required"
+    assert UNMAPPED_MODEL in together_warning_log.text
+    assert "passing tools, tool_choice through" in together_warning_log.text
+
+
+def test_map_openai_params_no_tools_model_drops_tools_with_warning(
+    registry_disables_function_calling, together_warning_log
+):
+    mapped = TogetherAIChatConfig().map_openai_params(
+        non_default_params={"tools": WEATHER_TOOLS, "temperature": 0.5},
+        optional_params={},
+        model=NO_TOOLS_MODEL,
+        drop_params=True,
+    )
+
+    assert "tools" not in mapped
+    assert mapped["temperature"] == 0.5
+    assert NO_TOOLS_MODEL in together_warning_log.text
+    assert "dropping tools" in together_warning_log.text
+
+
+def test_map_openai_params_no_tools_model_raises_without_drop_params(registry_disables_function_calling):
+    with pytest.raises(UnsupportedParamsError, match="does not support parameters"):
+        TogetherAIChatConfig().map_openai_params(
+            non_default_params={"tools": WEATHER_TOOLS},
+            optional_params={},
+            model=NO_TOOLS_MODEL,
+            drop_params=False,
+        )
 
 
 def test_map_openai_params_reasoning_model_passes_sampling_params():
@@ -170,6 +233,41 @@ def test_streaming_chunk_maps_delta_reasoning_to_reasoning_content():
     assert parsed.choices[0]["delta"]["reasoning_content"] == "thinking about 2+2"
 
 
+def test_streaming_chunk_preserves_tool_call_index_and_id():
+    iterator = TogetherAIChatConfig().get_model_response_iterator(
+        streaming_response=iter(()), sync_stream=True
+    )
+
+    def parse_tool_call_chunk(tool_call: dict):
+        parsed = iterator.chunk_parser(
+            {
+                "id": "chunk-1",
+                "created": 1234567890,
+                "model": TOOL_CALLING_MODEL,
+                "choices": [{"index": 0, "delta": {"role": "assistant", "content": "", "tool_calls": [tool_call]}}],
+            }
+        )
+        return parsed.choices[0]["delta"]["tool_calls"][0]
+
+    opener = parse_tool_call_chunk(
+        {
+            "index": 1,
+            "id": "call_abc123",
+            "type": "function",
+            "function": {"name": "get_weather", "arguments": ""},
+        }
+    )
+    continuation = parse_tool_call_chunk(
+        {"index": 1, "id": "", "type": "function", "function": {"arguments": '{"city": "San'}}
+    )
+
+    assert opener["index"] == 1
+    assert opener["id"] == "call_abc123"
+    assert opener["function"]["name"] == "get_weather"
+    assert continuation["index"] == 1
+    assert continuation["function"]["arguments"] == '{"city": "San'
+
+
 def test_together_ai_config_alias_points_at_chat_config():
     assert litellm.TogetherAIConfig is litellm.TogetherAIChatConfig
     config = litellm.TogetherAIConfig(max_tokens=10)
@@ -230,3 +328,60 @@ def test_completion_routes_through_together_chat_config():
     assert json.loads(request.content)["model"] == REASONING_MODEL
     assert response.choices[0].message.content == "4"
     assert response.choices[0].message.reasoning_content == "2+2 equals 4"
+
+
+def test_completion_unmapped_model_sends_tools_to_together():
+    from litellm.llms.custom_httpx.http_handler import HTTPHandler
+
+    captured_requests = []
+
+    def respond(request: httpx.Request) -> httpx.Response:
+        captured_requests.append(request)
+        return httpx.Response(
+            200,
+            json={
+                "id": "chatcmpl-together-tools",
+                "object": "chat.completion",
+                "created": 1234567890,
+                "model": UNMAPPED_MODEL,
+                "choices": [
+                    {
+                        "index": 0,
+                        "message": {
+                            "role": "assistant",
+                            "content": None,
+                            "tool_calls": [
+                                {
+                                    "id": "call_abc123",
+                                    "type": "function",
+                                    "function": {
+                                        "name": "get_weather",
+                                        "arguments": '{"city": "San Francisco"}',
+                                    },
+                                }
+                            ],
+                        },
+                        "finish_reason": "tool_calls",
+                    }
+                ],
+                "usage": {"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15},
+            },
+        )
+
+    client = HTTPHandler(client=httpx.Client(transport=httpx.MockTransport(respond)))
+
+    response = litellm.completion(
+        model=f"together_ai/{UNMAPPED_MODEL}",
+        messages=[{"role": "user", "content": "What is the weather in San Francisco?"}],
+        tools=WEATHER_TOOLS,
+        tool_choice="auto",
+        api_key="fake-key",
+        client=client,
+    )
+
+    request_body = json.loads(captured_requests[0].content)
+    assert request_body["tools"] == WEATHER_TOOLS
+    assert request_body["tool_choice"] == "auto"
+    tool_call = response.choices[0].message.tool_calls[0]
+    assert tool_call.function.name == "get_weather"
+    assert json.loads(tool_call.function.arguments) == {"city": "San Francisco"}


### PR DESCRIPTION
## TLDR

Problem this solves:

- Tools for registry-unknown Together models got a 400 by default
- Under drop_params they were silently stripped
- The model then emitted its tool call as plain text

How it solves it:

- Fail open: pass tool params through with a warning
- Together validates them itself, with clear errors when unsupported
- Models the registry marks as no-tools keep the loud contract

## User Flow

Before: a developer pointing their app at a newly launched Together model gets their tool calls rejected, and turning on drop_params makes the model answer with the tool call as plain text

1. They send POST http://litellm-domain/v1/chat/completions with `"model": "together_ai/Qwen/Qwen3.7-Max"`, `"stream": true`, a `tools` array with one `get_weather` function, and a prompt asking for the weather in San Francisco
2. The request fails with HTTP 400: `litellm.UnsupportedParamsError: together_ai does not support parameters: ['tools'], for model=Qwen/Qwen3.7-Max`, even though the same request sent straight to https://api.together.ai/v1/chat/completions streams back a proper `get_weather` tool call
3. Following the error's advice, they retry on a deployment with `drop_params: true`
4. The request now returns 200, but the stream carries zero `tool_calls` chunks; instead the answer arrives as plain text content reading `{"name": "get_weather", "arguments": {"location": "San Francisco"}}`, which their app renders to the end user as gibberish instead of running the tool

After: the same request streams structured tool calls, with or without drop_params

1. They send the same POST http://litellm-domain/v1/chat/completions with `"model": "together_ai/Qwen/Qwen3.7-Max"`, `"stream": true`, and the same `tools` array
2. The stream opens with a delta carrying `tool_calls` with `"id": "call_..."`, `"function": {"name": "get_weather"}`, and the argument fragments assemble to `{"city": "San Francisco"}`, finishing with `"finish_reason": "tool_calls"`, so their app runs the tool
3. The `drop_params: true` deployment behaves identically: same structured tool call, no tool-call-as-text
4. A model the registry explicitly marks as not supporting tools still answers the old way: HTTP 400 by default, tools dropped with a logged warning under drop_params

## Relevant issues

## Linear ticket

Resolves LIT-5964

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Live proxy on port 20536 (no DB), config with a wildcard `together_ai/*` deployment plus an alias `qwen37max-dropparams` = `together_ai/Qwen/Qwen3.7-Max` with `drop_params: true`, real `TOGETHER_API_KEY`, every call billed by api.together.ai. `Qwen/Qwen3.7-Max` is live on Together serverless but has no `supports_function_calling` entry in the registry; `MiniMaxAI/MiniMax-M3` is flagged `supports_function_calling: true`. Together itself serves streamed tool calls for the exact Before request when called directly (control run)

Shared request (the "same curl" below), with only the `model` value and `stream` flag varying per case:

```
curl -sS http://localhost:20536/v1/chat/completions \
  -H "Authorization: Bearer sk-qa-1234" -H "Content-Type: application/json" \
  -d '{"model":"together_ai/Qwen/Qwen3.7-Max","stream":true,"messages":[{"role":"user","content":"What is the weather in San Francisco? Use the tool."}],"tools":[{"type":"function","function":{"name":"get_weather","description":"Get current weather for a city","parameters":{"type":"object","properties":{"city":{"type":"string"}},"required":["city"]}}}]}'
```

### Before (75c4565dde)

#### Registry-unknown model, default settings

1. Run the shared curl
2. HTTP 400: `litellm.UnsupportedParamsError: together_ai does not support parameters: ['tools'], for model=Qwen/Qwen3.7-Max. To drop it from the call, set litellm.drop_params = True.`

#### Registry-unknown model, drop_params alias

1. Same request with `"model":"qwen37max-dropparams"`
2. 200, but zero `tool_calls` chunks; the tool call arrives as plain text content: `{"name": "get_weather", "arguments": {"location": "San Francisco"}}`

#### Registry-unknown model via /v1/responses and /v1/messages

1. Same model, tools, and prompt through POST /v1/responses and POST /v1/messages (the shared params layer serves all three endpoints)
2. Both return HTTP 400 with the same `litellm.UnsupportedParamsError: together_ai does not support parameters: ['tools']` error

#### Flagged model (MiniMaxAI/MiniMax-M3), non-streaming / parallel / forced / streaming

1. Non-streaming single tool call, `parallel_tool_calls` with two cities, `tool_choice` forced named and `"required"`, and streaming parallel all return proper structured `tool_calls` (verification legs; nothing to fix here)

### After (ec365a3c12)

#### Registry-unknown model, default settings

1. Run the shared curl
2. Structured streamed tool calls: opener `{"id":"call_089b124eef984242b4e84ecc","function":{"arguments":"","name":"get_weather"},"type":"function","index":0}`, argument fragments assemble to `{"city": "San Francisco"}`, `finish_reason: tool_calls`; proxy log carries the new warning naming the model and the passed-through params

#### Registry-unknown model, drop_params alias

1. Same request with `"model":"qwen37max-dropparams"`
2. Structured tool calls too: opener `{"id":"call_8b79026a44d9481d89fe679e","function":{"arguments":"","name":"get_weather"},...}`, no tool-call-as-text content

#### Registry-unknown model via /v1/responses and /v1/messages

1. Same model, tools, and prompt through POST /v1/responses and POST /v1/messages
2. /v1/responses finishes with a `function_call` output item: `{"arguments":"{\"city\": \"San Francisco\"}","call_id":"call_6ebb7e0928504f2ca62655c5","name":"get_weather","type":"function_call","status":"completed"}`
3. /v1/messages streams a `tool_use` content block named `get_weather` and ends with `"stop_reason": "tool_use"`

#### Flagged model (MiniMaxAI/MiniMax-M3), non-streaming / parallel / forced / streaming

1. Non-streaming: `finish_reason=tool_calls`, `get_weather {"city":"San Francisco"}`
2. Parallel: 2 calls, `[('get_weather', '{"city":"San Francisco"}'), ('get_weather', '{"city":"Tokyo"}')]`
3. Forced named `get_time`: returns exactly `get_time`; `tool_choice: "required"` on a chit-chat prompt returns a tool call
4. Streaming parallel: deltas carry `index` 0 and 1, each call's `id` exactly once on its opener chunk, fragments assemble per index, `finish_reason: tool_calls`

## Type

🐛 Bug Fix

## Caveats (if any)

- Ticket's `optional_params.remove()` brittleness is already gone (PR #38248)
- Tool-calls-as-text was caused by our own drop; no text parsing added
- Parallel, forced, and streaming tool calls verified working at base; regression tests added

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
- [x] ec365a3c12 passes /live-pr-risk

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes request shaping for all Together AI chat completions with tools; behavior shifts for registry-unknown models but preserves strict handling when the registry explicitly disables function calling.
> 
> **Overview**
> Fixes Together AI tool calling for models that aren't in LiteLLM's registry (or lack a `supports_function_calling` flag). **Previously**, unknown models were treated like non-tool models: `tools`/`tool_choice`/`function_call` were removed from supported params and dropped or rejected in `map_openai_params`, which caused HTTP 400s or silent stripping under `drop_params` (leading to tool calls as plain text).
> 
> **Now** a three-way verdict drives behavior: registry-confirmed support keeps tools; explicit `supports_function_calling: false` still raises or drops per `drop_params`; **unknown/missing registry entries fail open**—tool params are forwarded to Together with a warning so the API can validate. `response_format` is still filtered separately from tool params in `get_supported_openai_params` (only `response_format` is removed when FC isn't confirmed true).
> 
> Tests cover unmapped pass-through, registry no-tools drop/raise, end-to-end `litellm.completion` with tools, and streaming chunks preserving tool call `index`/`id`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ec365a3c12991b924bfa2f85cd62e69e39569c42. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->