### PR TITLE
fix(anthropic): carry user-content document blocks through the /v1/messages responses bridge

### DIFF
--- a/litellm/llms/anthropic/experimental_pass_through/responses_adapters/transformation.py
+++ b/litellm/llms/anthropic/experimental_pass_through/responses_adapters/transformation.py
@@ -214,6 +214,7 @@ class LiteLLMAnthropicToResponsesAPIAdapter:
           system text        -> message(role=system, input_text)
           user text          -> message(role=user, input_text)
           user image         -> message(role=user, input_image)
+          user document      -> message(role=user, input_file)
           user tool_result   -> function_call_output
           assistant text     -> message(role=assistant, output_text)
           assistant thinking -> reasoning
@@ -267,6 +268,12 @@ class LiteLLMAnthropicToResponsesAPIAdapter:
                                     with_prompt_cache_breakpoint(
                                         {"type": "input_image", "image_url": url}, block.get("prompt_cache_breakpoint")
                                     )
+                                )
+                        elif btype == "document":
+                            file_part = self._translate_anthropic_document_block_to_file_part(block)
+                            if file_part:
+                                user_parts.append(
+                                    with_prompt_cache_breakpoint(file_part, block.get("prompt_cache_breakpoint"))
                                 )
                         elif btype == "tool_result":
                             tool_use_id = block.get("tool_use_id", "")

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/responses_adapters/test_responses_adapters_transformation.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/responses_adapters/test_responses_adapters_transformation.py
@@ -1688,6 +1688,87 @@ class TestToolResultDocuments:
         ]
 
 
+class TestUserContentDocuments:
+    """Documents in plain user content must survive translation (LIT-6144): each
+    document block becomes an input_file part of the user message, in block order,
+    exactly like image blocks become input_image parts. Untranslatable documents
+    are dropped without disturbing the surrounding parts."""
+
+    PDF_B64 = "JVBERi0xLjQKJSBQT05H"
+    PDF_DATA_URI = "data:application/pdf;base64,JVBERi0xLjQKJSBQT05H"
+    PDF_URL = "https://example.com/report.pdf"
+    EXPLICIT = {"mode": "explicit"}
+
+    def _translate(self, user_content):
+        return _ADAPTER.translate_messages_to_responses_input([{"role": "user", "content": user_content}])
+
+    @staticmethod
+    def _user_content(items):
+        return next(item for item in items if item.get("type") == "message" and item.get("role") == "user")["content"]
+
+    def _base64_document(self, **extra):
+        return {
+            "type": "document",
+            "source": {"type": "base64", "media_type": "application/pdf", "data": self.PDF_B64},
+            **extra,
+        }
+
+    def test_document_then_text_keeps_block_order(self):
+        content = self._user_content(
+            self._translate([self._base64_document(), {"type": "text", "text": "what does the pdf say?"}])
+        )
+        assert content == [
+            {"type": "input_file", "filename": "document.pdf", "file_data": self.PDF_DATA_URI},
+            {"type": "input_text", "text": "what does the pdf say?"},
+        ]
+
+    def test_document_title_becomes_filename(self):
+        content = self._user_content(self._translate([self._base64_document(title="quarterly-report.pdf")]))
+        assert content == [
+            {"type": "input_file", "filename": "quarterly-report.pdf", "file_data": self.PDF_DATA_URI}
+        ]
+
+    def test_url_document_becomes_file_url_part(self):
+        content = self._user_content(
+            self._translate([{"type": "document", "source": {"type": "url", "url": self.PDF_URL}}])
+        )
+        assert content == [{"type": "input_file", "file_url": self.PDF_URL}]
+
+    def test_document_only_content_still_produces_user_message(self):
+        content = self._user_content(self._translate([self._base64_document()]))
+        assert content == [{"type": "input_file", "filename": "document.pdf", "file_data": self.PDF_DATA_URI}]
+
+    def test_empty_base64_data_drops_only_the_document_part(self):
+        content = self._user_content(
+            self._translate(
+                [
+                    {"type": "text", "text": "still here"},
+                    {"type": "document", "source": {"type": "base64", "media_type": "application/pdf", "data": ""}},
+                ]
+            )
+        )
+        assert content == [{"type": "input_text", "text": "still here"}]
+
+    def test_non_dict_source_drops_only_the_document_part(self):
+        content = self._user_content(
+            self._translate([{"type": "text", "text": "still here"}, {"type": "document", "source": self.PDF_URL}])
+        )
+        assert content == [{"type": "input_text", "text": "still here"}]
+
+    def test_document_breakpoint_rides_on_the_file_part(self):
+        content = self._user_content(
+            self._translate([self._base64_document(prompt_cache_breakpoint=self.EXPLICIT)])
+        )
+        assert content == [
+            {
+                "type": "input_file",
+                "filename": "document.pdf",
+                "file_data": self.PDF_DATA_URI,
+                "prompt_cache_breakpoint": self.EXPLICIT,
+            }
+        ]
+
+
 def _contains_key(value, key) -> bool:
     if isinstance(value, dict):
         return key in value or any(_contains_key(v, key) for v in value.values())


### PR DESCRIPTION
## TLDR

Problem this solves:

- /v1/messages user-content document blocks vanish for OpenAI models
- The bridge forwards only text and image user blocks
- Requests return 200 with the model blind to the PDF

How it solves it:

- Translates user document blocks to Responses input_file parts
- Reuses the tool_result document translation from #38261
- Base64 sources become file_data data-URLs, url sources file_url

## User Flow

Before: an Anthropic-SDK user on a LiteLLM gateway attaches a PDF to a /v1/messages request for an OpenAI model and gets an answer written as if no PDF existed

1. They send POST https://litellm-domain/v1/messages with model `gpt-5.6` and a user content list holding a document block (base64 `application/pdf`, title `secret.pdf`) followed by the text "What is the secret codeword in the attached PDF? Reply with just the codeword."
2. The request returns 200 with an ordinary `end_turn` answer, but the text asks them to attach the PDF they already attached
3. The response usage shows `input_tokens: 24`, the question text alone, yet the call is still billed

After: the same request comes back answering from the PDF's content

1. They send the same POST https://litellm-domain/v1/messages with the same document-plus-text content list
2. The request returns 200 and the answer text is "PELICAN-7741", the codeword that only exists inside the attached PDF
3. The response usage now counts the document's tokens alongside the question's

## Relevant issues

## Linear ticket

Resolves LIT-6144

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Shared setup, both legs: DB-less proxy booted from a fresh worktree with `--num_workers 2`, config maps `gpt-5.6` to `openai/gpt-5.6`, master key `sk-lit6144-qa`. The payload `lit6144_messages_payload.json` is an Anthropic Messages body for `gpt-5.6`: the user content list holds a document block (base64 `application/pdf`, title `secret.pdf`, a 611-byte PDF whose only text is "The secret codeword is PELICAN-7741.") followed by a text block "What is the secret codeword in the attached PDF? Reply with just the codeword." Real OpenAI spend, no mocks; the two legs differ only in the commit the proxy was booted from

### Before (c3c9e3a)

1. `curl -sS http://127.0.0.1:34403/v1/messages -H 'Authorization: Bearer sk-lit6144-qa' -H 'Content-Type: application/json' -d @lit6144_messages_payload.json`
2. HTTP 200, `stop_reason: end_turn`, answer text: `Please attach the PDF.`
3. `"usage": {"input_tokens": 24, "output_tokens": 160}`: the question text alone reached the model, the attached PDF never did

### After (61ee2f5)

1. `curl -sS http://127.0.0.1:26181/v1/messages -H 'Authorization: Bearer sk-lit6144-qa' -H 'Content-Type: application/json' -d @lit6144_messages_payload.json`
2. HTTP 200, `stop_reason: end_turn`, answer text: `PELICAN-7741`, the codeword that exists only inside the attached PDF
3. `"usage": {"input_tokens": 59, "output_tokens": 10}`: the document's tokens now reach the model

Control run (provider-direct, proves the emitted shape): the same PDF sent straight to `POST https://api.openai.com/v1/responses` as an `input_file` part with a `file_data` data-URL returns `PELICAN-7741`, so the translation target is exactly what OpenAI expects

QA observations:

- Blind-answer wording varies run to run; facts identical
- 200-plus-billed-blind-call symptom matches the ticket exactly

## Type

🐛 Bug Fix

## Caveats (if any)

- Reuses the shared document translation helper that landed in #38261
- file/text/content document sources still dropped, as before this PR
- Unsupported media types now surface provider errors, not silent blindness

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

CHECKED: live-pr-risk at 61ee2f5: base/head A/B on live 2-worker proxies covering marked documents (both marker styles), url-source documents, and marked-text parity; no marker leak upstream, no breaking or backward-incompatible path found; clean merge-tree vs current litellm_internal_staging; Azure Responses leg not driven live (part shape shared with #38261)
