### PR TITLE
fix(router): resolve hidden aliases for explicit lookup

### DIFF
--- a/litellm/router.py
+++ b/litellm/router.py
@@ -10644,10 +10644,9 @@ class Router:
                 _router_model_name: str = model_value
             elif isinstance(model_value, dict):
                 _model_value = RouterModelGroupAliasItem(**model_value)
-                if _model_value["hidden"] is True:
+                if _model_value["hidden"] is True and model_name is None:
                     continue
-                else:
-                    _router_model_name = _model_value["model"]
+                _router_model_name = _model_value["model"]
             else:
                 continue
 

--- a/tests/test_litellm/test_router_order_fallback.py
+++ b/tests/test_litellm/test_router_order_fallback.py
@@ -367,6 +367,45 @@ async def test_router_order_fallback_with_wildcard_model_group():
     assert response._hidden_params["model_id"] == "2"
 
 
+@pytest.mark.asyncio
+async def test_router_order_fallback_with_hidden_model_group_alias():
+    router = Router(
+        model_list=[
+            {
+                "model_name": "canonical-model",
+                "litellm_params": {
+                    "model": "gpt-4o",
+                    "api_key": "bad",
+                    "mock_response": Exception("fail order 1"),
+                    "order": 1,
+                },
+                "model_info": {"id": "1"},
+            },
+            {
+                "model_name": "canonical-model",
+                "litellm_params": {
+                    "model": "gpt-4o",
+                    "api_key": "good",
+                    "mock_response": "success from order 2",
+                    "order": 2,
+                },
+                "model_info": {"id": "2"},
+            },
+        ],
+        model_group_alias={"hidden-alias": {"model": "canonical-model", "hidden": True}},
+        num_retries=0,
+    )
+
+    assert "hidden-alias" not in {deployment["model_name"] for deployment in router.get_model_list() or []}
+
+    response = await router.acompletion(
+        model="hidden-alias",
+        messages=[{"role": "user", "content": "hi"}],
+    )
+
+    assert response._hidden_params["model_id"] == "2"
+
+
 def test_check_non_standard_fallback_format():
     from litellm.router_utils.fallback_event_handlers import (
         _check_non_standard_fallback_format,


### PR DESCRIPTION
## TLDR

Problem this solves:

- Hidden aliases disappear during explicit deployment lookup
- Ordered fallback cannot discover the alias's later deployments
- Requests fail even when a healthy fallback is configured

How it solves it:

- Skip hidden aliases only during discovery enumeration
- Resolve hidden aliases when the caller explicitly names one
- Preserve existing routing and discovery behavior

## User Flow

Before: a Claude Code request using a hidden model alias fails after its primary deployment fails, even though the canonical model group has a healthy higher-order fallback

1. The proxy admin maps `hidden-alias` to `canonical-model` with `hidden: true`
2. They configure an order-1 and order-2 deployment for `canonical-model`
3. Claude Code sends `POST https://litellm-domain/v1/messages` with `"model": "hidden-alias"`
4. The order-1 deployment fails
5. The response is the order-1 error (for a bad key, `401` with `Available Model Group Fallbacks=None`), and Claude Code sits in its retry loop instead of answering
6. `GET https://litellm-domain/v1/models` does not list `hidden-alias`

After: the same request reaches the healthy higher-order fallback while the alias remains hidden from discovery

1. The proxy admin keeps the same hidden alias mapping
2. They keep the same order-1 and order-2 deployments
3. Claude Code sends the same `POST https://litellm-domain/v1/messages` request
4. The order-1 deployment fails
5. The response is `200` from the order-2 deployment, and Claude Code answers normally
6. `GET https://litellm-domain/v1/models` still does not list `hidden-alias`

## Relevant issues

Related to, but distinct from, #10317 and #29378. Those address aliases in configured fallback maps; this change addresses hidden aliases during ordered deployment lookup

## Linear ticket

Resolves LIT-6169

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Shared setup: one proxy per commit, each booted with `--num_workers 2` and no database, same config on both. The order-1 deployment carries a deliberately invalid Anthropic key so it always fails with a 401, the order-2 deployment carries a real key, and cooldowns are disabled so the 401 cannot hide the order-1 attempt. `claude-code-haiku` is the hidden alias, `visible-haiku` the control

```yaml
model_list:
  - model_name: canonical-haiku
    litellm_params:
      model: anthropic/claude-haiku-4-5
      api_key: sk-ant-api03-order-1-invalid-key
      order: 1
    model_info:
      id: order-1-bad-key
  - model_name: canonical-haiku
    litellm_params:
      model: anthropic/claude-haiku-4-5
      api_key: os.environ/ANTHROPIC_API_KEY
      order: 2
    model_info:
      id: order-2-good-key
router_settings:
  num_retries: 0
  disable_cooldowns: true
  model_group_alias:
    claude-code-haiku:
      model: canonical-haiku
      hidden: true
    visible-haiku: canonical-haiku
general_settings:
  master_key: sk-1234
```

Every curl below is `curl -s -D - http://127.0.0.1:$PORT<route> -H 'Authorization: Bearer sk-1234' -H 'content-type: application/json' -d '{"model":"<model>","max_tokens":20,"messages":[{"role":"user","content":"Reply with exactly: pong"}]}'` (plus `-H 'anthropic-version: 2023-06-01'` on `/v1/messages`; `/v1/responses` sends `{"model":"<model>","max_output_tokens":20,"input":"Reply with exactly: pong"}`), shown with only the status line, the `x-litellm-model-id` header, and the start of the body. Claude Code is `env -u ANTHROPIC_API_KEY ANTHROPIC_BASE_URL=http://127.0.0.1:$PORT ANTHROPIC_AUTH_TOKEN=sk-1234 ANTHROPIC_MODEL=claude-code-haiku claude` (Claude Code v2.1.246), then the prompt `Reply with exactly the word pong and nothing else`

### Before (04818a3554)

#### /v1/models hides the alias

1. `GET /v1/models`
2. `['canonical-haiku', 'visible-haiku']`, no `claude-code-haiku`

#### /v1/messages with the hidden alias

1. `POST /v1/messages` with `"model": "claude-code-haiku"`
2. `HTTP/1.1 401 Unauthorized`, `x-litellm-model-id: order-1-bad-key`, body `{"error":{"message":"{\"type\":\"error\",\"error\":{\"type\":\"authentication_error\",\"message\":\"API key is invalid.\"},\"request_id\":null}. Received Model Group=claude-code-haiku\nAvailable Model Group Fallbacks=None", ...}}`

#### /v1/chat/completions with the hidden alias

1. `POST /v1/chat/completions` with `"model": "claude-code-haiku"`
2. `HTTP/1.1 401 Unauthorized`, body `{"error":{"message":"litellm.AuthenticationError: AnthropicException - {\"type\":\"error\",\"error\":{\"type\":\"authentication_error\",\"message\":\"API key is invalid.\"},\"request_id\":null}. Received Model Group=claude-code-haiku\nAvailable Model Group Fallbacks=None", ...}}`

#### /v1/responses with the hidden alias

1. `POST /v1/responses` with `"model": "claude-code-haiku"`
2. `HTTP/1.1 401 Unauthorized`, `x-litellm-model-id: order-1-bad-key`, body `{"error":{"message":"litellm.AuthenticationError: AnthropicException - {\"type\":\"error\",\"error\":{\"type\":\"authentication_error\",\"message\":\"API key is invalid.\"},\"request_id\":null}. Received Model Group=claude-code-haiku\nAvailable Model Group Fallbacks=None", ...}}`

#### /v1/messages with the visible alias (control)

1. `POST /v1/messages` with `"model": "visible-haiku"`
2. `HTTP/1.1 200 OK`, body `{"model":"claude-haiku-4-5-20251001", ..., "content":[{"type":"text","text":"pong"}], ...}`

#### Claude Code with the hidden alias

1. Start Claude Code against the proxy and send the prompt
2. Claude Code never answers and loops on `✻ 401 {"type":"error","error":{"type":"authentication_error","message":"API key is invalid."},"request_id":null}. Received Mo… · Retrying in 2s · attempt 5/10`

### After (31f7b9409a)

#### /v1/models hides the alias

1. `GET /v1/models`
2. `['canonical-haiku', 'visible-haiku']`, still no `claude-code-haiku`

#### /v1/messages with the hidden alias

1. `POST /v1/messages` with `"model": "claude-code-haiku"`
2. `HTTP/1.1 200 OK`, body `{"model":"claude-haiku-4-5-20251001","id":"msg_011CeRmYMT3JW3stVvcKNxwY","type":"message","role":"assistant","content":[{"type":"text","text":"pong"}],"stop_reason":"end_turn", ...}`

#### /v1/chat/completions with the hidden alias

1. `POST /v1/chat/completions` with `"model": "claude-code-haiku"`
2. `HTTP/1.1 200 OK`, `x-litellm-model-id: order-2-good-key`, body `{"id":"chatcmpl-e37e0dfd-a949-4b2c-8b8f-0cdfb0ff8a08", ..., "choices":[{"finish_reason":"stop","index":0,"message":{"content":"pong","role":"assistant", ...}}], ...}`

#### /v1/responses with the hidden alias

1. `POST /v1/responses` with `"model": "claude-code-haiku"`
2. `HTTP/1.1 200 OK`, `x-litellm-model-id: order-2-good-key`, body `{"id":"resp_4L-bQKqfZyP9XEaVRzr2RAApEDDdI98tClxfkLHAZrUdMCgFqO01Vw7vfobh_356oDO-Pb1ewqkkzLgtyfnvurJjUPNhsMQQh7guxNtOkZwUngwM9wZZGu_wCu8z7ARMB-rADiY8Udvfz4EuXmfWBmJap6A0OQMo3luO8DrKkP9FHPB1JFbpfNCDTVBpNZzD7uvP1AyD5jF89ZTfWy9q_Idsy7...", ...}`

#### /v1/messages with the visible alias (control)

1. `POST /v1/messages` with `"model": "visible-haiku"`
2. `HTTP/1.1 200 OK`, body `{"model":"claude-haiku-4-5-20251001", ..., "content":[{"type":"text","text":"pong"}], ...}`, unchanged

#### Claude Code with the hidden alias

1. Start Claude Code against the proxy and send the prompt
2. Claude Code answers `⏺ pong` (`✻ Crunched for 14s · done 10:40 AM`)

## Type

🐛 Bug Fix

## Design rationale

The `hidden` flag controls whether an alias appears during model discovery. It should not prevent routing when a caller already knows and explicitly supplies that alias

Enumeration calls this lookup without a model name, so hidden aliases remain excluded from discovery. Explicit routing supplies the requested model name, so the same alias can safely resolve to its canonical deployment group and participate in ordered fallback

This keeps visibility and callability separate without changing team routing, wildcard routing, cooldown handling, external fallback maps, or the original client model spelling

## Caveats (if any)

### Low

- Hidden aliases remain absent from model discovery, and `hidden` is not an authorization boundary
- Configured fallback-map alias behavior is unchanged
- Hidden aliases now resolve in every explicit-lookup consumer (model-level limits, blocked-model checks), matching how visible aliases already behave
- `x-litellm-model-id` on `/v1/messages` still names the order-1 deployment after a fallback (pre-existing, `/v1/chat/completions` names order 2)
- `/health?model=<hidden alias>` returns no endpoints before and after this PR (pre-existing, the health path resolves only visible aliases)

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

- [x] 31f7b9409a passes /live-pr-risk
