### PR TITLE
test: gate the test tree on B003 so a test cannot swap os.environ for a plain dict

### DIFF
--- a/ruff-tests.toml
+++ b/ruff-tests.toml
@@ -51,6 +51,10 @@
 # F632    `is` against a literal. It compares identity, so it passes only where CPython
 #         happens to intern the value and stops meaning what it says the moment the
 #         value is built at runtime
+# B003    `os.environ = {...}` rebinds the mapping instead of mutating it, so `putenv`
+#         never fires and a subprocess still reads the real keys the test believes it
+#         cleared. The manual restore underneath is skipped whenever the body raises,
+#         so every later test in that worker inherits a plain dict for an environment
 #
 # No target-version here on purpose: it resolves from requires-python (>=3.10), so
 # 3.11-only builtins like BaseExceptionGroup are correctly flagged in a tree that
@@ -78,4 +82,5 @@ lint.select = [
     "B023",
     "B025",
     "F632",
+    "B003",
 ]

--- a/tests/litellm_utils_tests/test_utils.py
+++ b/tests/litellm_utils_tests/test_utils.py
@@ -328,34 +328,23 @@ def test_trimming_with_untokenizable_field(caplog: pytest.LogCaptureFixture) -> 
 
 
 def test_aget_valid_models():
-    old_environ = os.environ
-    os.environ = {"OPENAI_API_KEY": "temp"}  # mock set only openai key in environ
+    with mock.patch.dict(os.environ, {"OPENAI_API_KEY": "temp"}, clear=True):
+        valid_models = get_valid_models()
+        print(valid_models)
 
-    valid_models = get_valid_models()
-    print(valid_models)
+        # list of openai supported llms on litellm
+        expected_models = (
+            litellm.open_ai_chat_completion_models | litellm.open_ai_text_completion_models
+        )
 
-    # list of openai supported llms on litellm
-    expected_models = (
-        litellm.open_ai_chat_completion_models | litellm.open_ai_text_completion_models
-    )
-
-    assert set(valid_models) == set(expected_models)
-
-    # reset replicate env key
-    os.environ = old_environ
+        assert set(valid_models) == set(expected_models)
 
     # GEMINI
-    expected_models = litellm.gemini_models
-    old_environ = os.environ
-    os.environ = {"GEMINI_API_KEY": "temp"}  # mock set only openai key in environ
+    with mock.patch.dict(os.environ, {"GEMINI_API_KEY": "temp"}, clear=True):
+        valid_models = get_valid_models()
 
-    valid_models = get_valid_models()
-
-    print(valid_models)
-    assert set(valid_models) == set(expected_models)
-
-    # reset replicate env key
-    os.environ = old_environ
+        print(valid_models)
+        assert set(valid_models) == set(litellm.gemini_models)
 
 
 @pytest.mark.parametrize("custom_llm_provider", ["anthropic", "xai"])


### PR DESCRIPTION
## TLDR

Problem this solves:

- `os.environ = {...}` swaps the mapping instead of mutating it
- The keys the test meant to hide are still there for subprocesses
- One failed assertion leaves the whole worker without an environment
- Nothing in lint or the in-house gate catches the rebind

How it solves it:

- Rewrite the one such test to use `mock.patch.dict(..., clear=True)`
- Gate the test tree on ruff B003, already wired to CI

## User Flow

This one is test-only, so there is no proxy route that behaves differently. The person it affects is whoever runs the suite

Before: a contributor breaks `get_valid_models` and gets a wall of unrelated red

1. They change model discovery and run `pytest tests/litellm_utils_tests/test_utils.py`
2. `test_aget_valid_models` fails, which is the honest signal
3. Because it failed, the line that puts the real environment back never runs, so every test after it in that worker reads an environment holding one key
4. Tests that have nothing to do with the change start failing on missing credentials, and the run reports a dozen failures instead of one
5. They spend the next hour deciding which failures are theirs

After: the same break reports exactly one failure

1. They make the same change and run the same command
2. `test_aget_valid_models` fails
3. Every later test still sees the real environment, so nothing else changes colour
4. The one red test is the one they broke

## Relevant issues

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

This PR changes lint config and one test, so there is no proxy route to curl. What matters is whether the pattern the rule bans actually misbehaves, so both shapes are run side by side.

Shared setup. Two throwaway modules holding the same test twice, one written the way the tree had it and one the way this PR writes it. Each has a stand-in failure where the real assertion sits, plus a second, unrelated test that only reads an environment variable the shell set:

`test_before.py`

```python
import os


def test_only_openai_key_is_visible():
    old_environ = os.environ
    os.environ = {"OPENAI_API_KEY": "temp"}

    assert os.getenv("OPENAI_API_KEY") == "temp"
    assert False, "stand-in for the assertion under test going red"

    os.environ = old_environ


def test_a_later_test_still_sees_the_real_environment():
    assert os.getenv("PROOF_MARKER") == "set-by-the-shell"
```

`test_after.py`

```python
import os
from unittest import mock


def test_only_openai_key_is_visible():
    with mock.patch.dict(os.environ, {"OPENAI_API_KEY": "temp"}, clear=True):
        assert os.getenv("OPENAI_API_KEY") == "temp"
        assert False, "stand-in for the assertion under test going red"


def test_a_later_test_still_sees_the_real_environment():
    assert os.getenv("PROOF_MARKER") == "set-by-the-shell"
```

And `env_isolation.py`, which runs both shapes in one process and asks a child process what it can see:

```python
import os
import subprocess
import sys

CHILD = "import os; print('  child sees OPENAI_API_KEY:', os.getenv('OPENAI_API_KEY'), '| REAL_MARKER:', os.getenv('REAL_MARKER'))"


def show(label):
    print(label)
    print("  parent sees OPENAI_API_KEY:", os.getenv("OPENAI_API_KEY"), "| REAL_MARKER:", os.getenv("REAL_MARKER"))
    print(subprocess.run([sys.executable, "-c", CHILD], capture_output=True, text=True).stdout.rstrip())


os.environ["REAL_MARKER"] = "a-key-the-test-meant-to-hide"
os.environ["OPENAI_API_KEY"] = "the-operators-real-key"

old_environ = os.environ
os.environ = {"OPENAI_API_KEY": "temp"}
show("rebinding os.environ:")
os.environ = old_environ

from unittest import mock

with mock.patch.dict(os.environ, {"OPENAI_API_KEY": "temp"}, clear=True):
    show("patch.dict(clear=True):")
```

### Before (04818a3554)

#### one failed test takes the rest of the worker with it

1. Run the suite with a marker in the environment

```console
$ PROOF_MARKER=set-by-the-shell pytest test_before.py -p no:randomly -q
```

2. Output. Two failures, and the second test never touched an environment variable this run

```console
    def test_a_later_test_still_sees_the_real_environment():
>       assert os.getenv("PROOF_MARKER") == "set-by-the-shell"
E       AssertionError: assert None == 'set-by-the-shell'

FAILED test_before.py::test_only_openai_key_is_visible
FAILED test_before.py::test_a_later_test_still_sees_the_real_environment
2 failed in 0.03s
```

#### the isolation does not reach a child process

1. Run

```console
$ python env_isolation.py
```

2. Output. Under the rebind, a subprocess still reads the real key the test believed it had cleared

```console
rebinding os.environ:
  parent sees OPENAI_API_KEY: temp | REAL_MARKER: None
  child sees OPENAI_API_KEY: the-operators-real-key | REAL_MARKER: a-key-the-test-meant-to-hide
patch.dict(clear=True):
  parent sees OPENAI_API_KEY: temp | REAL_MARKER: None
  child sees OPENAI_API_KEY: temp | REAL_MARKER: None
```

#### lint says nothing

1. Run

```console
$ ruff check --config ruff-tests.toml tests
```

2. Output

```console
All checks passed!
```

### After (8298cbe1f7)

#### one failed test takes the rest of the worker with it

1. Run the same suite against the shape this PR adopts

```console
$ PROOF_MARKER=set-by-the-shell pytest test_after.py -p no:randomly -q
```

2. Output. The blast radius is one test

```console
E           assert False

FAILED test_after.py::test_only_openai_key_is_visible
1 failed, 1 passed in 0.03s
```

#### the isolation does not reach a child process

1. Same script, same output. The second half of it is what this PR now uses everywhere

```console
patch.dict(clear=True):
  parent sees OPENAI_API_KEY: temp | REAL_MARKER: None
  child sees OPENAI_API_KEY: temp | REAL_MARKER: None
```

#### lint says nothing

1. Run

```console
$ ruff check --config ruff-tests.toml tests
```

2. Output, with B003 now selected and the four sites gone

```console
All checks passed!
```

### Rule and regression numbers

Four B003 findings across the tree, all four in `test_aget_valid_models`, now zero. The test itself passes on both sides. Running the whole `get_valid_models` family gives the same tally before and after, 5 passed and 4 failed, and those four fail identically on a pristine checkout because this machine has no Fireworks or xAI credentials.

Worth noting where this sits next to what we already have: `scripts/check_test_quality.py` ratchets TQ004 for a raw `os.environ["X"] = ...` write, and it looks at subscript targets only, so a whole-mapping rebind walked straight past it. B003 closes that half.

I looked at the rest of the test tree for the next rule worth turning on and B003 was the only candidate whose existing sites are wrong today. B905 has the most hits at 37, but every one is either equal by construction or a deliberate `zip(x, x[1:])` that wants `strict=False`, so it would be prevention only. ASYNC251, PLW1510, F402 and B005 are all latent in the same way.

## Type

🧹 Refactoring
🚄 Infrastructure
✅ Test

## Caveats (if any)

### Low

- `clear=True` unsets everything for the block, same as before
- The two halves now assert inside their own `with`, so scope shifted

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
