### PR TITLE
fix(together_ai): strip internal thinking fields from outbound messages, keep reasoning_content

### DIFF
--- a/litellm/llms/together_ai/chat/transformation.py
+++ b/litellm/llms/together_ai/chat/transformation.py
@@ -4,18 +4,25 @@ Translates from OpenAI's `/v1/chat/completions` to Together AI's `/v1/chat/compl
 Docs: https://docs.together.ai/docs/chat-overview
 """
 
-from collections.abc import Container
+from collections.abc import Container, Coroutine
 from types import MappingProxyType
-from typing import Final
+from typing import (
+    Final,
+    Literal,
+    cast,  # noqa: TID251  # rebuilding a TypedDict minus keys has no checked spelling
+    overload,
+)
 
 import litellm
 from litellm._logging import verbose_logger
 from litellm.exceptions import UnsupportedParamsError
+from litellm.types.llms.openai import AllMessageValues
 from litellm.utils import supports_function_calling
 
 from ...openai.chat.gpt_transformation import OpenAIGPTConfig
 
 TOOL_CALLING_PARAMS: Final = ("tools", "tool_choice", "function_call")
+LITELLM_INTERNAL_ASSISTANT_FIELDS: Final = frozenset({"thinking_blocks", "provider_specific_fields"})
 PLAIN_TEXT_RESPONSE_FORMAT: Final = MappingProxyType({"type": "text"})
 FUNCTION_CALLING_DOCS_URL: Final = "https://docs.together.ai/docs/function-calling"
 
@@ -61,7 +68,50 @@ def _tool_params_to_drop(passed_params: Container[str], model: str, drop_params:
     )
 
 
+def _without_litellm_internal_fields(message: AllMessageValues) -> AllMessageValues:
+    if message["role"] != "assistant" or LITELLM_INTERNAL_ASSISTANT_FIELDS.isdisjoint(message):
+        return message
+    return cast(  # cast-ok: rebuilding the same TypedDict minus internal keys loses the narrowed type
+        "AllMessageValues",
+        {  # mutable-ok: TypedDict rebuild minus internal keys
+            key: value for key, value in message.items() if key not in LITELLM_INTERNAL_ASSISTANT_FIELDS
+        },
+    )
+
+
 class TogetherAIChatConfig(OpenAIGPTConfig):
+    @overload
+    def _transform_messages(
+        self,
+        messages: list[AllMessageValues],  # mutable-ok: inherited contract
+        model: str,
+        is_async: Literal[True],
+    ) -> Coroutine[object, object, list[AllMessageValues]]: ...  # mutable-ok: inherited contract
+
+    @overload
+    def _transform_messages(
+        self,
+        messages: list[AllMessageValues],  # mutable-ok: inherited contract
+        model: str,
+        is_async: Literal[False] = False,
+    ) -> list[AllMessageValues]: ...  # mutable-ok: inherited contract
+
+    def _transform_messages(
+        self,
+        messages: list[AllMessageValues],  # mutable-ok: inherited contract
+        model: str,
+        is_async: bool = False,
+    ) -> list[AllMessageValues] | Coroutine[object, object, list[AllMessageValues]]:  # mutable-ok: inherited contract
+        """Together consumes replayed assistant `reasoning_content` (preserved thinking via
+        `chat_template_kwargs: {"clear_thinking": false}`), so it must stay in the payload;
+        only litellm-internal fields are stripped before sending."""
+        stripped: Final = [  # mutable-ok: super() requires a list
+            _without_litellm_internal_fields(message) for message in messages
+        ]
+        if is_async:
+            return super()._transform_messages(stripped, model, is_async=True)
+        return super()._transform_messages(stripped, model, is_async=False)
+
     def get_supported_openai_params(self, model: str) -> list:
         supports_fc: Final = _function_calling_verdict(model)
         supported_params: Final = super().get_supported_openai_params(model)

--- a/tests/test_litellm/llms/together_ai/chat/test_together_ai_chat_transformation.py
+++ b/tests/test_litellm/llms/together_ai/chat/test_together_ai_chat_transformation.py
@@ -1,5 +1,6 @@
 import json
 import logging
+from collections.abc import Mapping, Sequence
 from unittest.mock import MagicMock
 
 import httpx
@@ -283,7 +284,7 @@ PRESERVED_THINKING_MESSAGES = [
 ]
 
 
-def _assert_internal_fields_stripped_reasoning_kept(transformed_messages: list):
+def _assert_internal_fields_stripped_reasoning_kept(transformed_messages: Sequence[Mapping[str, object]]):
     assistant_message = transformed_messages[1]
     assert assistant_message["reasoning_content"] == REPLAYED_ASSISTANT_MESSAGE["reasoning_content"]
     assert "thinking_blocks" not in assistant_message
@@ -320,7 +321,7 @@ async def test_async_transform_request_keeps_reasoning_content_strips_internal_f
 def test_completion_sends_chat_template_kwargs_and_preserved_reasoning():
     from litellm.llms.custom_httpx.http_handler import HTTPHandler
 
-    captured_requests = []
+    captured_requests: list[httpx.Request] = []
 
     def respond(request: httpx.Request) -> httpx.Response:
         captured_requests.append(request)

--- a/tests/test_litellm/llms/together_ai/chat/test_together_ai_chat_transformation.py
+++ b/tests/test_litellm/llms/together_ai/chat/test_together_ai_chat_transformation.py
@@ -268,6 +268,96 @@ def test_streaming_chunk_preserves_tool_call_index_and_id():
     assert continuation["function"]["arguments"] == '{"city": "San'
 
 
+REPLAYED_ASSISTANT_MESSAGE = {
+    "role": "assistant",
+    "content": "The digit sum is 11.",
+    "reasoning_content": "The secret number is 47. 4 + 7 = 11.",
+    "thinking_blocks": [{"type": "thinking", "thinking": "The secret number is 47.", "signature": ""}],
+    "provider_specific_fields": {"thinking_blocks": [{"type": "thinking", "thinking": "The secret number is 47."}]},
+}
+
+PRESERVED_THINKING_MESSAGES = [
+    {"role": "user", "content": "Pick a secret two-digit number and tell me only its digit sum."},
+    REPLAYED_ASSISTANT_MESSAGE,
+    {"role": "user", "content": "What was the secret number?"},
+]
+
+
+def _assert_internal_fields_stripped_reasoning_kept(transformed_messages: list):
+    assistant_message = transformed_messages[1]
+    assert assistant_message["reasoning_content"] == REPLAYED_ASSISTANT_MESSAGE["reasoning_content"]
+    assert "thinking_blocks" not in assistant_message
+    assert "provider_specific_fields" not in assistant_message
+    assert assistant_message["content"] == REPLAYED_ASSISTANT_MESSAGE["content"]
+    assert transformed_messages[0] == PRESERVED_THINKING_MESSAGES[0]
+    assert transformed_messages[2] == PRESERVED_THINKING_MESSAGES[2]
+
+
+def test_transform_request_keeps_reasoning_content_strips_internal_fields():
+    request = TogetherAIChatConfig().transform_request(
+        model=REASONING_MODEL,
+        messages=[dict(message) for message in PRESERVED_THINKING_MESSAGES],
+        optional_params={},
+        litellm_params={"custom_llm_provider": "together_ai"},
+        headers={},
+    )
+
+    _assert_internal_fields_stripped_reasoning_kept(request["messages"])
+
+
+async def test_async_transform_request_keeps_reasoning_content_strips_internal_fields():
+    request = await TogetherAIChatConfig().async_transform_request(
+        model=REASONING_MODEL,
+        messages=[dict(message) for message in PRESERVED_THINKING_MESSAGES],
+        optional_params={},
+        litellm_params={"custom_llm_provider": "together_ai"},
+        headers={},
+    )
+
+    _assert_internal_fields_stripped_reasoning_kept(request["messages"])
+
+
+def test_completion_sends_chat_template_kwargs_and_preserved_reasoning():
+    from litellm.llms.custom_httpx.http_handler import HTTPHandler
+
+    captured_requests = []
+
+    def respond(request: httpx.Request) -> httpx.Response:
+        captured_requests.append(request)
+        return httpx.Response(
+            200,
+            json={
+                "id": "chatcmpl-together-preserved",
+                "object": "chat.completion",
+                "created": 1234567890,
+                "model": REASONING_MODEL,
+                "choices": [
+                    {
+                        "index": 0,
+                        "message": {"role": "assistant", "content": "47"},
+                        "finish_reason": "stop",
+                    }
+                ],
+                "usage": {"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15},
+            },
+        )
+
+    client = HTTPHandler(client=httpx.Client(transport=httpx.MockTransport(respond)))
+
+    litellm.completion(
+        model=f"together_ai/{REASONING_MODEL}",
+        messages=[dict(message) for message in PRESERVED_THINKING_MESSAGES],
+        chat_template_kwargs={"clear_thinking": False},
+        api_key="fake-key",
+        client=client,
+    )
+
+    request_body = json.loads(captured_requests[0].content)
+    assert request_body["chat_template_kwargs"] == {"clear_thinking": False}
+    assert "extra_body" not in request_body
+    _assert_internal_fields_stripped_reasoning_kept(request_body["messages"])
+
+
 def test_together_ai_config_alias_points_at_chat_config():
     assert litellm.TogetherAIConfig is litellm.TogetherAIChatConfig
     config = litellm.TogetherAIConfig(max_tokens=10)


### PR DESCRIPTION
## TLDR

Problem this solves:

- Outbound Together requests leak litellm-internal `thinking_blocks` and `provider_specific_fields`
- Nothing pins `chat_template_kwargs` passthrough or preserved-thinking replay

How it solves it:

- Strips internal fields from assistant messages before sending
- Keeps `reasoning_content`: Together consumes it for preserved thinking
- Regression tests pin passthrough, stripping, and reasoning replay

## User Flow

Before: a developer chats with Together's GLM-5.2 in preserved-thinking mode through the proxy, and the request forwarded to Together carries litellm-internal junk fields

1. Their Anthropic-SDK app sends POST http://localhost:4000/v1/messages with a prior assistant turn (thinking + text blocks) and `chat_template_kwargs: {"clear_thinking": false}`
2. The reply is correct: the model recalls a secret that only existed in the replayed thinking
3. But the proxy's debug log shows the request sent to https://api.together.ai/v1/chat/completions carrying `thinking_blocks` on the assistant message (plus `provider_specific_fields` when an OpenAI-SDK client replays a LiteLLM response verbatim), undocumented fields Together happens to ignore today

After: the same chat works and the request Together receives is clean

1. Their Anthropic-SDK app sends the same POST http://localhost:4000/v1/messages with the replayed thinking and `chat_template_kwargs: {"clear_thinking": false}`
2. The reply is correct: the model still recalls the secret, proving `reasoning_content` still reaches Together
3. The proxy's debug log shows the assistant message sent to https://api.together.ai/v1/chat/completions with only `content` and `reasoning_content`, no litellm-internal fields

## Relevant issues

## Linear ticket

Resolves LIT-5967

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Both legs booted a live proxy with 2 uvicorn workers (no DB) hitting the real Together API, with `qwen-hybrid = together_ai/Qwen/Qwen3.5-9B` and `glm-52 = together_ai/zai-org/GLM-5.2`. Same five cases per leg; only the checked-out commit differs. The one commit since the proven tip, 8a61b286d1, only annotates test helpers, so it cannot change behavior and the proof stands

### Before (merge base e4ff44f623, port 39605)

**Case 1: /v1/chat/completions kwargs passthrough (non-streaming)**

```bash
curl -s http://localhost:39605/v1/chat/completions -H 'Authorization: Bearer sk-lit5967-qa' -H 'Content-Type: application/json' \
  -d '{"model":"qwen-hybrid","messages":[{"role":"user","content":"What is 17*23? Answer with just the number."}],"chat_template_kwargs":{"thinking":false}}'
```

With kwargs: content `"391"`, message keys `['content','role']`, no `reasoning_content`. Control (same body minus `chat_template_kwargs`): content `"391"` with `reasoning_content` present. Passthrough already worked here

**Case 2: same, streaming**

```bash
curl -s -N http://localhost:39605/v1/chat/completions -H 'Authorization: Bearer sk-lit5967-qa' -H 'Content-Type: application/json' \
  -d '{"model":"qwen-hybrid","messages":[{"role":"user","content":"What is 17*23? Answer with just the number."}],"chat_template_kwargs":{"thinking":false},"stream":true,"stream_options":{"include_usage":true}}'
```

With kwargs: 0 delta chunks carrying `reasoning_content`, answer `"401"` (thinking-off model artifact). Control: 359 reasoning deltas, answer `"391"`

**Case 3: /v1/responses kwargs passthrough**

```bash
curl -s http://localhost:39605/v1/responses -H 'Authorization: Bearer sk-lit5967-qa' -H 'Content-Type: application/json' \
  -d '{"model":"qwen-hybrid","input":"What is 17*23? Answer with just the number.","chat_template_kwargs":{"thinking":false}}'
```

With kwargs: output item types `['message']`. Control: `['reasoning','message']`

**Case 4: /v1/messages preserved thinking (GLM-5.2)**

```bash
curl -s http://localhost:39605/v1/messages -H 'Authorization: Bearer sk-lit5967-qa' -H 'Content-Type: application/json' \
  -d '{"model":"glm-52","max_tokens":2048,"messages":[{"role":"user","content":"Pick a secret two-digit number. Reply with ONLY the sum of its digits, nothing else."}]}'
# turn 2 replays the full assistant content array (thinking + text blocks) verbatim, adds the question and chat_template_kwargs
curl -s http://localhost:39605/v1/messages -H 'Authorization: Bearer sk-lit5967-qa' -H 'Content-Type: application/json' -d @case4_turn2_req.json
```

Turn 1 thinking picked secret 42, text `"6"`. Turn 2 replied `"42"`: the replayed thinking reached the model. But the proxy debug log's "POST Request Sent from LiteLLM" to https://api.together.ai/v1/chat/completions shows the outbound assistant message keys as `['content','reasoning_content','role','thinking_blocks']`: **`thinking_blocks` leaked**

**Case 5: /v1/chat/completions verbatim-history replay (GLM-5.2)**

Turn 1 (same secret prompt) answered `"11"` with reasoning settling on 47. Turn 2 replayed the assistant message with `reasoning_content`, `thinking_blocks`, and `provider_specific_fields` exactly as a LiteLLM response carries them, plus `"chat_template_kwargs":{"clear_thinking":false}`:

```bash
curl -s http://localhost:39605/v1/chat/completions -H 'Authorization: Bearer sk-lit5967-qa' -H 'Content-Type: application/json' -d @case5_turn2_req.json
```

Reply `"47"`, the correct secret. Outbound assistant message keys: `['content','provider_specific_fields','reasoning_content','role','thinking_blocks']` with `provider_specific_fields: {'thinking_blocks': []}`: **all three litellm-internal keys leaked to Together**

### After (tip 1ba66b1555, port 37398)

**Case 1: /v1/chat/completions kwargs passthrough (non-streaming)**

Same command on port 37398. With kwargs: content `"391"`, keys `['content','role']`. Control: `"391"` with `reasoning_content`. Unchanged

**Case 2: same, streaming**

With kwargs: 0 reasoning deltas, content `"391"`. Control: 346 reasoning deltas. Unchanged

**Case 3: /v1/responses kwargs passthrough**

With kwargs: output item types `['message']`, text `"391"`. Control: `['reasoning','message']`. Unchanged

**Case 4: /v1/messages preserved thinking (GLM-5.2)**

Turn 1 thinking picked 42, text `"6"`. Turn 2 (same verbatim replay + `{"clear_thinking": false}`) replied `"42"`, and the outbound body now shows the assistant message as

```
{'role': 'assistant', 'content': '6', 'reasoning_content': '1.  **Analyze the Request:** ... Let\'s pick 42. ...'}
```

`thinking_blocks` absent, `provider_specific_fields` absent, `reasoning_content` present and still consumed (the recall proves it)

**Case 5: /v1/chat/completions verbatim-history replay (GLM-5.2)**

Turn 1 picked 73, answered `"10"`. Turn 2 with all three internal fields replayed replied `"73"`, and the outbound assistant message carries only `role`, `content`, and `reasoning_content` alongside `'chat_template_kwargs': {'clear_thinking': False}` in the body

Closing notes from the legs:

- Case 4 before-leg leak lacked `provider_specific_fields`; this PR leaves that path equally clean
- Qwen answers 401 with thinking disabled; model artifact, both legs' controls got 391
- Control streams carry hundreds of reasoning deltas; unrelated to this PR
- Functional passthrough already worked at the merge base; this PR fixes the leak and pins both behaviors

## Type

🐛 Bug Fix
✅ Test

## Caveats (if any)

### Low

- Together silently ignores unknown `chat_template_kwargs` keys server-side
- LiteLLM passes them through for Together to validate, like tools in #38265

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

- [x] 1ba66b1555 passes /live-pr-risk
