### PR TITLE
fix(bedrock): map reasoning_effort to reasoning.effort for OpenAI GPT-5.x on Converse

### DIFF
--- a/litellm/llms/bedrock/chat/converse_transformation.py
+++ b/litellm/llms/bedrock/chat/converse_transformation.py
@@ -426,8 +426,8 @@ class AmazonConverseConfig(BaseConfig):
         if "gpt-oss" in model:
             optional_params["reasoning_effort"] = reasoning_effort
         elif "openai.gpt-5" in model:
-            optional_params.pop("thinking", None)
-            optional_params["reasoning"] = {"effort": reasoning_effort}
+            reasoning: Final[BedrockConverseGptReasoningEffortBlock] = {"effort": reasoning_effort}
+            optional_params["reasoning"] = reasoning
         elif self._is_nova_2_model(model):
             reasoning_config: Final = self._transform_reasoning_effort_to_reasoning_config(reasoning_effort)
             optional_params.update(reasoning_config)

--- a/litellm/llms/bedrock/chat/converse_transformation.py
+++ b/litellm/llms/bedrock/chat/converse_transformation.py
@@ -426,8 +426,6 @@ class AmazonConverseConfig(BaseConfig):
         if "gpt-oss" in model:
             optional_params["reasoning_effort"] = reasoning_effort
         elif "openai.gpt-5" in model:
-            # Converse rejects Anthropic's `thinking` for OpenAI GPT-5.x; effort goes
-            # under additionalModelRequestFields as {"reasoning": {"effort": ...}}.
             optional_params.pop("thinking", None)
             optional_params["reasoning"] = {"effort": reasoning_effort}
         elif self._is_nova_2_model(model):
@@ -561,7 +559,7 @@ class AmazonConverseConfig(BaseConfig):
             # only anthropic and mistral support tool choice config. otherwise (E.g. cohere) will fail the call - https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_ToolChoice.html
             supported_params.append("tool_choice")
 
-        if "gpt-oss" in model:
+        if "gpt-oss" in model or "openai.gpt-5" in model or "openai.gpt-5" in base_model:
             supported_params.append("reasoning_effort")
         elif self._is_nova_2_model(model):
             # Nova 2 models support reasoning_effort (transformed to reasoningConfig)
@@ -909,7 +907,7 @@ class AmazonConverseConfig(BaseConfig):
                 optional_params["_parallel_tool_use_config"] = {
                     "tool_choice": {"type": "auto", "disable_parallel_tool_use": not value}
                 }
-            if param == "thinking":
+            if param == "thinking" and "openai.gpt-5" not in model:
                 if (
                     isinstance(value, dict)
                     and value.get("type") == "adaptive"

--- a/litellm/llms/bedrock/chat/converse_transformation.py
+++ b/litellm/llms/bedrock/chat/converse_transformation.py
@@ -418,12 +418,18 @@ class AmazonConverseConfig(BaseConfig):
         Handle the reasoning_effort parameter based on the model type.
 
         - GPT-OSS models: passed through unchanged via additionalModelRequestFields.
+        - OpenAI GPT-5.x models: mapped to ``reasoning.effort`` via additionalModelRequestFields.
         - Nova 2 models: transformed to reasoningConfig.
         - Anthropic models: mapped to ``thinking`` (and ``output_config.effort`` on
           adaptive Claude 4.6 / 4.7).
         """
         if "gpt-oss" in model:
             optional_params["reasoning_effort"] = reasoning_effort
+        elif "openai.gpt-5" in model:
+            # Converse rejects Anthropic's `thinking` for OpenAI GPT-5.x; effort goes
+            # under additionalModelRequestFields as {"reasoning": {"effort": ...}}.
+            optional_params.pop("thinking", None)
+            optional_params["reasoning"] = {"effort": reasoning_effort}
         elif self._is_nova_2_model(model):
             reasoning_config: Final = self._transform_reasoning_effort_to_reasoning_config(reasoning_effort)
             optional_params.update(reasoning_config)

--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -49473,6 +49473,7 @@
         ],
         "supports_function_calling": true,
         "supports_tool_choice": true,
+        "supports_reasoning": true,
         "supports_vision": true
     },
     "global.openai.gpt-5.6-sol": {
@@ -49498,6 +49499,7 @@
         ],
         "supports_function_calling": true,
         "supports_tool_choice": true,
+        "supports_reasoning": true,
         "supports_vision": true
     },
     "us.openai.gpt-5.6-terra": {
@@ -49523,6 +49525,7 @@
         ],
         "supports_function_calling": true,
         "supports_tool_choice": true,
+        "supports_reasoning": true,
         "supports_vision": true
     },
     "global.openai.gpt-5.6-terra": {
@@ -49548,6 +49551,7 @@
         ],
         "supports_function_calling": true,
         "supports_tool_choice": true,
+        "supports_reasoning": true,
         "supports_vision": true
     },
     "us.openai.gpt-5.6-luna": {
@@ -49573,6 +49577,7 @@
         ],
         "supports_function_calling": true,
         "supports_tool_choice": true,
+        "supports_reasoning": true,
         "supports_vision": true
     },
     "global.openai.gpt-5.6-luna": {
@@ -49598,6 +49603,7 @@
         ],
         "supports_function_calling": true,
         "supports_tool_choice": true,
+        "supports_reasoning": true,
         "supports_vision": true
     },
     "bedrock_mantle/openai.gpt-5.5": {

--- a/litellm/types/llms/bedrock.py
+++ b/litellm/types/llms/bedrock.py
@@ -3,7 +3,7 @@ from collections.abc import Sequence
 from enum import Enum
 from typing import TYPE_CHECKING, Any, Final, Literal
 
-from typing_extensions import Required, TypedDict, override
+from typing_extensions import ReadOnly, Required, TypedDict, override
 
 from .openai import ChatCompletionToolCallChunk
 
@@ -95,6 +95,10 @@ class BedrockConverseReasoningContentBlockDelta(TypedDict, total=False):
     signature: str
     redactedContent: str
     text: str
+
+
+class BedrockConverseGptReasoningEffortBlock(TypedDict):
+    effort: ReadOnly[str]
 
 
 class GuardrailConverseTextBlock(TypedDict, total=False):

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -49473,6 +49473,7 @@
         ],
         "supports_function_calling": true,
         "supports_tool_choice": true,
+        "supports_reasoning": true,
         "supports_vision": true
     },
     "global.openai.gpt-5.6-sol": {
@@ -49498,6 +49499,7 @@
         ],
         "supports_function_calling": true,
         "supports_tool_choice": true,
+        "supports_reasoning": true,
         "supports_vision": true
     },
     "us.openai.gpt-5.6-terra": {
@@ -49523,6 +49525,7 @@
         ],
         "supports_function_calling": true,
         "supports_tool_choice": true,
+        "supports_reasoning": true,
         "supports_vision": true
     },
     "global.openai.gpt-5.6-terra": {
@@ -49548,6 +49551,7 @@
         ],
         "supports_function_calling": true,
         "supports_tool_choice": true,
+        "supports_reasoning": true,
         "supports_vision": true
     },
     "us.openai.gpt-5.6-luna": {
@@ -49573,6 +49577,7 @@
         ],
         "supports_function_calling": true,
         "supports_tool_choice": true,
+        "supports_reasoning": true,
         "supports_vision": true
     },
     "global.openai.gpt-5.6-luna": {
@@ -49598,6 +49603,7 @@
         ],
         "supports_function_calling": true,
         "supports_tool_choice": true,
+        "supports_reasoning": true,
         "supports_vision": true
     },
     "bedrock_mantle/openai.gpt-5.5": {

--- a/tests/test_litellm/llms/bedrock/chat/test_converse_transformation.py
+++ b/tests/test_litellm/llms/bedrock/chat/test_converse_transformation.py
@@ -318,6 +318,40 @@ def test_reasoning_effort_maps_to_reasoning_effort_for_openai_gpt5_converse(mode
 @pytest.mark.parametrize(
     "model",
     [
+        "us.openai.gpt-5.6-sol",
+        "bedrock/converse/global.openai.gpt-5.6-luna",
+    ],
+)
+def test_openai_gpt5_converse_never_forwards_thinking(model, local_model_cost_map):
+    """GPT-5.x on Converse must never send Anthropic ``thinking``/``output_config`` (Bedrock rejects them).
+
+    Regression: ``thinking`` is not advertised as supported, and even when supplied alongside
+    ``reasoning_effort`` in either order it never survives into the request."""
+    config = AmazonConverseConfig()
+
+    supported = config.get_supported_openai_params(model=model)
+    assert "thinking" not in supported
+    assert "output_config" not in supported
+
+    thinking_block = {"type": "enabled", "budget_tokens": 2048}
+    for non_default_params in (
+        {"reasoning_effort": "high", "thinking": thinking_block},
+        {"thinking": thinking_block, "reasoning_effort": "high"},
+    ):
+        optional_params = config.map_openai_params(
+            non_default_params=dict(non_default_params),
+            optional_params={},
+            model=model,
+            drop_params=False,
+        )
+        _, additional_request_params, _, _ = config._prepare_request_params(optional_params, model)
+        assert additional_request_params["reasoning"] == {"effort": "high"}
+        assert "thinking" not in additional_request_params
+
+
+@pytest.mark.parametrize(
+    "model",
+    [
         "bedrock/converse/us.anthropic.claude-opus-4-5-20251101-v1:0",
         "bedrock/converse/us.anthropic.claude-opus-4-6-v1",
         "bedrock/converse/us.anthropic.claude-opus-4-7",

--- a/tests/test_litellm/llms/bedrock/chat/test_converse_transformation.py
+++ b/tests/test_litellm/llms/bedrock/chat/test_converse_transformation.py
@@ -287,6 +287,37 @@ def test_reasoning_with_forced_tool_choice_switches_to_auto():
 @pytest.mark.parametrize(
     "model",
     [
+        "us.openai.gpt-5.6-sol",
+        "global.openai.gpt-5.6-terra",
+        "bedrock/converse/us.openai.gpt-5.6-luna",
+    ],
+)
+def test_reasoning_effort_maps_to_reasoning_effort_for_openai_gpt5_converse(model, local_model_cost_map):
+    """OpenAI GPT-5.x on Bedrock Converse routes reasoning_effort to
+    ``additionalModelRequestFields.reasoning.effort`` rather than Anthropic ``thinking``."""
+    config = AmazonConverseConfig()
+
+    assert "reasoning_effort" in config.get_supported_openai_params(model=model)
+
+    optional_params = config.map_openai_params(
+        non_default_params={"reasoning_effort": "high"},
+        optional_params={},
+        model=model,
+        drop_params=False,
+    )
+
+    assert optional_params["reasoning"] == {"effort": "high"}
+    assert "thinking" not in optional_params
+    assert "reasoning_effort" not in optional_params
+
+    _, additional_request_params, _, _ = config._prepare_request_params(optional_params, model)
+    assert additional_request_params["reasoning"] == {"effort": "high"}
+    assert "thinking" not in additional_request_params
+
+
+@pytest.mark.parametrize(
+    "model",
+    [
         "bedrock/converse/us.anthropic.claude-opus-4-5-20251101-v1:0",
         "bedrock/converse/us.anthropic.claude-opus-4-6-v1",
         "bedrock/converse/us.anthropic.claude-opus-4-7",

--- a/tests/test_litellm/llms/bedrock/test_cross_region_inference_profile_mapping.py
+++ b/tests/test_litellm/llms/bedrock/test_cross_region_inference_profile_mapping.py
@@ -293,15 +293,16 @@ def test_bedrock_gpt_5_6_advertises_only_converse_supported_features(
 
 
 @pytest.mark.parametrize("profile", GPT_5_6_PROFILES, ids=lambda p: p.model_id)
-def test_bedrock_gpt_5_6_offers_tools_but_not_reasoning(profile, local_model_cost_map):
-    """Converse rejects the Anthropic-shaped thinking block LiteLLM emits for
-    reasoning_effort, so neither reasoning param may be offered yet, while the tool
-    params these models do accept must be."""
+def test_bedrock_gpt_5_6_offers_tools_and_reasoning_effort_but_not_thinking(profile, local_model_cost_map):
+    """GPT-5.x on Converse maps reasoning_effort to reasoning.effort, so reasoning_effort
+    is offered while the Anthropic-only thinking/output_config are not, alongside the tool
+    params these models accept."""
     supported = AmazonConverseConfig().get_supported_openai_params(
         model=f"bedrock/{profile.model_id}"
     )
 
     assert "tools" in supported
     assert "tool_choice" in supported
-    assert "reasoning_effort" not in supported
+    assert "reasoning_effort" in supported
     assert "thinking" not in supported
+    assert "output_config" not in supported


### PR DESCRIPTION
## TLDR

Problem this solves:

- OpenAI GPT-5.x on Bedrock Converse silently loses `reasoning_effort`
- Sent as Anthropic `thinking`, Converse 400s with unknown_parameter

How it solves it:

- Map effort to `additionalModelRequestFields.reasoning.effort` for GPT-5.x
- Set `supports_reasoning` on the six bedrock_converse gpt-5.6 entries

## User Flow

Before: a developer calling a GPT-5.6 Bedrock Converse model with reasoning effort gets a hard 400 and no reasoning

1. They POST https://litellm-domain/v1/chat/completions with `"model": "gpt-5.6-sol-bedrock"` and `"reasoning_effort": "high"`
2. The response is `400` with `bedrock does not support parameters: ['reasoning_effort']`
3. If they set `drop_params: true` to get past the 400, the answer comes back but the model ran with no reasoning applied

After: the same request returns 200 and the model runs at the requested effort

1. They POST https://litellm-domain/v1/chat/completions with the same `"model": "gpt-5.6-sol-bedrock"` and `"reasoning_effort": "high"`
2. The response is `200` with the assistant answer
3. No `drop_params` workaround is needed and the effort reaches Bedrock

## Relevant issues

Related to #34105 (same root cause: the Converse reasoning-effort handler assumes any non gpt-oss / non Nova-2 model is Anthropic and discards the value). This PR fixes the GPT-5.x case; Qwen3 and other providers in that issue are out of scope here

## Linear ticket

Resolves LIT-5984

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Real Bedrock Converse calls against `us.openai.gpt-5.6-sol`, no mocks, billed to a live AWS account. Both legs run the identical config and requests and differ only in the commit the proxy was booted from: Before at the merge base `1ff615c335`, After at the PR tip `418012aac5`. Each leg is one proxy with `--num_workers 2` (Before on port 18342, After on port 27519)

Config (`qa_config.yaml`):

```yaml
model_list:
  - model_name: gpt-5.6-sol-bedrock
    litellm_params:
      model: bedrock/converse/us.openai.gpt-5.6-sol
      aws_region_name: us-east-1
litellm_settings:
  drop_params: false
```

Proxy launched with `AWS_BEARER_TOKEN_BEDROCK=... LITELLM_MASTER_KEY=sk-qa5984 litellm --config qa_config.yaml --port <port> --num_workers 2`

### Before (1ff615c335)

#### /v1/chat/completions with reasoning_effort

1. Send the request:

```bash
curl -s http://localhost:18342/v1/chat/completions \
  -H "Authorization: Bearer sk-qa5984" -H "Content-Type: application/json" \
  -d '{"model":"gpt-5.6-sol-bedrock","messages":[{"role":"user","content":"In one sentence, what is 17 * 23? Show the number."}],"reasoning_effort":"high"}'
```

2. Observed 400:

```json
{"error":{"message":"litellm.UnsupportedParamsError: bedrock does not support parameters: ['reasoning_effort'], for model=converse/us.openai.gpt-5.6-sol. To drop these, set `litellm.drop_params=True` ...","type":"None","param":null,"code":"400"}}
```

#### /v1/responses with reasoning.effort

1. Send the request:

```bash
curl -s http://localhost:18342/v1/responses \
  -H "Authorization: Bearer sk-qa5984" -H "Content-Type: application/json" \
  -d '{"model":"gpt-5.6-sol-bedrock","input":"In one sentence, what is 19 * 21? Show the number.","reasoning":{"effort":"high"}}'
```

2. Observed the same 400 UnsupportedParamsError naming `reasoning_effort`

#### /v1/messages with reasoning_effort

1. Send the request:

```bash
curl -s http://localhost:18342/v1/messages \
  -H "Authorization: Bearer sk-qa5984" -H "Content-Type: application/json" \
  -d '{"model":"gpt-5.6-sol-bedrock","max_tokens":512,"messages":[{"role":"user","content":"In one sentence, what is 13 * 29? Show the number."}],"reasoning_effort":"high"}'
```

2. Observed the same 400 UnsupportedParamsError naming `reasoning_effort`

### After (418012aac5)

#### /v1/chat/completions with reasoning_effort

1. Send the identical request against the tip proxy on port 27519
2. Observed 200:

```json
{"model":"gpt-5.6-sol-bedrock","object":"chat.completion","choices":[{"finish_reason":"stop","index":0,"message":{"content":"17 × 23 = 391.","role":"assistant"}}],"usage":{"completion_tokens":12,"prompt_tokens":22,"total_tokens":34}}
```

#### /v1/responses with reasoning.effort

1. Send the identical request against the tip proxy
2. Observed 200 with `"status": "completed"` and output text `19 × 21 = 399.`

#### /v1/messages with reasoning_effort

1. Send the identical request against the tip proxy
2. Observed 200 with content text `13 × 29 = 377.`

Notes:

- Before 400 with `drop_params: false` proves refusal, never silent drop
- So After 200 means Bedrock accepted `additionalModelRequestFields.reasoning.effort`
- Direct boto3: `thinking` shape gets `ValidationException`, `reasoning.effort` shape accepted
- Harder prompt billed 36 completion tokens, 5 visible: hidden reasoning real
- Usage lacks separate reasoning token counts here; pre-existing, unchanged

## Type

🐛 Bug Fix

## Caveats (if any)

### Low

- Scoped to OpenAI GPT-5.x; other Converse providers in #34105 still drop effort
- `thinking` and `output_config` stay rejected for GPT-5.x, as before this PR
- Opaque inference-profile ARN aliases still misroute effort; pre-existing, every model family
- Verified live on `us.openai.gpt-5.6-sol`; `terra` and `luna` share the same code path

## Changes

`_handle_reasoning_effort_parameter` gains a branch for `openai.gpt-5` models that maps `reasoning_effort` to `{"reasoning": {"effort": ...}}` under `additionalModelRequestFields`. The six `bedrock_converse` gpt-5.6 entries (`us.` and `global.` for sol, terra, luna) gain `supports_reasoning: true` as correct capability metadata

`get_supported_openai_params` advertises only `reasoning_effort` for GPT-5.x (not the Anthropic-only `thinking` / `output_config`), and `map_openai_params` skips the `thinking` mapping for these models. Together this closes an order-dependent leak where a request combining `thinking` with `reasoning_effort` could still serialize a `thinking` block that Bedrock rejects, and it makes such a request fail fast with a clear client-side error instead. Parametrized regression tests cover the supported-param gate, the mapped shape, and that `thinking` never survives regardless of parameter order

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shared Bedrock Converse parameter routing for reasoning; wrong model-id matching could affect non–GPT-5 models, but scope is narrow and covered by regression tests.
> 
> **Overview**
> Fixes **OpenAI GPT-5.x on Bedrock Converse** so `reasoning_effort` is honored instead of rejected or misrouted to Anthropic `thinking` (which Bedrock returns as an unknown parameter).
> 
> **Bedrock Converse mapping** adds a GPT-5 branch in `_handle_reasoning_effort_parameter` that sets `additionalModelRequestFields.reasoning` to `{"effort": <value>}`. `get_supported_openai_params` now advertises `reasoning_effort` for these models, and `map_openai_params` no longer applies the `thinking` mapper when the model id contains `openai.gpt-5`.
> 
> **Model metadata** sets `supports_reasoning: true` on the six `bedrock_converse` GPT-5.6 variants in the cost/context JSON files. A **`BedrockConverseGptReasoningEffortBlock`** TypedDict documents the effort shape.
> 
> **Tests** assert the mapped request shape, that `thinking`/`output_config` are not offered or forwarded (including when combined with `reasoning_effort`), and update cross-region profile expectations accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 418012aac5e1f4959e91deb574c7a88629f22d17. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR



- [x] 418012aac5e1f4959e91deb574c7a88629f22d17 passes /live-pr-risk

