### PR TITLE
test(together_ai): regression suite across chat, responses, and messages surfaces

### DIFF
--- a/tests/test_litellm/llms/together_ai/chat/test_together_ai_chat_transformation.py
+++ b/tests/test_litellm/llms/together_ai/chat/test_together_ai_chat_transformation.py
@@ -535,12 +535,13 @@ def _sync_client(captured_requests: list[httpx.Request], response: httpx.Respons
     return HTTPHandler(client=httpx.Client(transport=httpx.MockTransport(respond)))
 
 
-def _async_client(captured_requests: list[httpx.Request], response: httpx.Response) -> AsyncHTTPHandler:
+async def _async_client(captured_requests: list[httpx.Request], response: httpx.Response) -> AsyncHTTPHandler:
     def respond(request: httpx.Request) -> httpx.Response:
         captured_requests.append(request)
         return response
 
     handler = AsyncHTTPHandler()
+    await handler.close()
     handler.client = httpx.AsyncClient(transport=httpx.MockTransport(respond))
     return handler
 
@@ -600,7 +601,7 @@ def test_streaming_completion_rebuilds_reasoning_and_parallel_tool_calls():
 
 async def test_async_streaming_completion_strips_internal_fields_and_streams_reasoning():
     captured_requests: list[httpx.Request] = []
-    client = _async_client(
+    client = await _async_client(
         captured_requests,
         _sse_response(
             _chunk({"role": "assistant", "reasoning": "Recalling 47."}),
@@ -608,15 +609,18 @@ async def test_async_streaming_completion_strips_internal_fields_and_streams_rea
         ),
     )
 
-    stream = await litellm.acompletion(
-        model=f"together_ai/{REASONING_MODEL}",
-        messages=[dict(message) for message in PRESERVED_THINKING_MESSAGES],
-        chat_template_kwargs={"clear_thinking": False},
-        stream=True,
-        api_key="fake-key",
-        client=client,
-    )
-    chunks = [chunk async for chunk in stream]
+    try:
+        stream = await litellm.acompletion(
+            model=f"together_ai/{REASONING_MODEL}",
+            messages=[dict(message) for message in PRESERVED_THINKING_MESSAGES],
+            chat_template_kwargs={"clear_thinking": False},
+            stream=True,
+            api_key="fake-key",
+            client=client,
+        )
+        chunks = [chunk async for chunk in stream]
+    finally:
+        await client.client.aclose()
 
     request_body = json.loads(captured_requests[0].content)
     assert str(captured_requests[0].url) == TOGETHER_CHAT_URL

--- a/tests/test_litellm/llms/together_ai/chat/test_together_ai_chat_transformation.py
+++ b/tests/test_litellm/llms/together_ai/chat/test_together_ai_chat_transformation.py
@@ -1,6 +1,6 @@
 import json
 import logging
-from collections.abc import Mapping, Sequence
+from collections.abc import Iterator, Mapping, Sequence
 from unittest.mock import MagicMock
 
 import httpx
@@ -9,6 +9,7 @@ import pytest
 import litellm
 from litellm.exceptions import UnsupportedParamsError
 from litellm.llms.base_llm.chat.transformation import LiteLLMLoggingObj
+from litellm.llms.custom_httpx.http_handler import AsyncHTTPHandler, HTTPHandler
 from litellm.llms.openai.chat.gpt_transformation import (
     OpenAIChatCompletionStreamingHandler,
 )
@@ -31,6 +32,11 @@ def force_local_model_cost(monkeypatch):
     from litellm.litellm_core_utils.get_model_cost_map import get_model_cost_map
 
     monkeypatch.setattr(litellm, "model_cost", get_model_cost_map(url=litellm.model_cost_map_url))
+
+
+@pytest.fixture(autouse=True)
+def isolate_together_api_base_env(monkeypatch):
+    monkeypatch.delenv("TOGETHER_AI_API_BASE", raising=False)
 
 
 @pytest.fixture
@@ -476,3 +482,334 @@ def test_completion_unmapped_model_sends_tools_to_together():
     tool_call = response.choices[0].message.tool_calls[0]
     assert tool_call.function.name == "get_weather"
     assert json.loads(tool_call.function.arguments) == {"city": "San Francisco"}
+
+
+TOGETHER_CHAT_URL = "https://api.together.ai/v1/chat/completions"
+
+WEATHER_AND_TIME_TOOLS = [
+    *WEATHER_TOOLS,
+    {"type": "function", "function": {"name": "get_time", "parameters": {}}},
+]
+
+ANTHROPIC_WEATHER_TOOL = {
+    "name": "get_weather",
+    "description": "Get the weather",
+    "input_schema": {"type": "object", "properties": {"city": {"type": "string"}}},
+}
+
+
+def _chat_completion(message: Mapping[str, object], finish_reason: str = "stop") -> dict:
+    return {
+        "id": "chatcmpl-together",
+        "object": "chat.completion",
+        "created": 1234567890,
+        "model": UNMAPPED_MODEL,
+        "choices": [{"index": 0, "message": dict(message), "finish_reason": finish_reason}],
+        "usage": {"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15},
+    }
+
+
+def _chunk(delta: Mapping[str, object], finish_reason: str | None = None) -> dict:
+    return {
+        "id": "chatcmpl-together-stream",
+        "object": "chat.completion.chunk",
+        "created": 1234567890,
+        "model": UNMAPPED_MODEL,
+        "choices": [{"index": 0, "delta": dict(delta), "finish_reason": finish_reason}],
+    }
+
+
+def _sse(*events: Mapping[str, object]) -> bytes:
+    return b"".join(f"data: {json.dumps(event)}\n\n".encode() for event in events) + b"data: [DONE]\n\n"
+
+
+def _sse_response(*events: Mapping[str, object]) -> httpx.Response:
+    return httpx.Response(200, content=_sse(*events), headers={"Content-Type": "text/event-stream"})
+
+
+def _sync_client(captured_requests: list[httpx.Request], response: httpx.Response) -> HTTPHandler:
+    def respond(request: httpx.Request) -> httpx.Response:
+        captured_requests.append(request)
+        return response
+
+    return HTTPHandler(client=httpx.Client(transport=httpx.MockTransport(respond)))
+
+
+def _async_client(captured_requests: list[httpx.Request], response: httpx.Response) -> AsyncHTTPHandler:
+    def respond(request: httpx.Request) -> httpx.Response:
+        captured_requests.append(request)
+        return response
+
+    handler = AsyncHTTPHandler()
+    handler.client = httpx.AsyncClient(transport=httpx.MockTransport(respond))
+    return handler
+
+
+PARALLEL_TOOL_CALL_STREAM = (
+    _chunk({"role": "assistant", "reasoning": "Need weather "}),
+    _chunk({"reasoning": "and time."}),
+    _chunk(
+        {
+            "tool_calls": [
+                {"index": 0, "id": "call_weather", "type": "function", "function": {"name": "get_weather", "arguments": ""}}
+            ]
+        }
+    ),
+    _chunk({"tool_calls": [{"index": 0, "function": {"arguments": '{"city": "San'}}]}),
+    _chunk({"tool_calls": [{"index": 0, "function": {"arguments": ' Francisco"}'}}]}),
+    _chunk(
+        {"tool_calls": [{"index": 1, "id": "call_time", "type": "function", "function": {"name": "get_time", "arguments": ""}}]}
+    ),
+    _chunk({"tool_calls": [{"index": 1, "function": {"arguments": '{"tz": "PST"}'}}]}, finish_reason="tool_calls"),
+)
+
+
+def test_streaming_completion_rebuilds_reasoning_and_parallel_tool_calls():
+    captured_requests: list[httpx.Request] = []
+    client = _sync_client(captured_requests, _sse_response(*PARALLEL_TOOL_CALL_STREAM))
+
+    chunks = list(
+        litellm.completion(
+            model=f"together_ai/{UNMAPPED_MODEL}",
+            messages=[{"role": "user", "content": "Weather and time in San Francisco?"}],
+            tools=WEATHER_AND_TIME_TOOLS,
+            stream=True,
+            api_key="fake-key",
+            client=client,
+        )
+    )
+
+    request_body = json.loads(captured_requests[0].content)
+    assert str(captured_requests[0].url) == TOGETHER_CHAT_URL
+    assert request_body["stream"] is True
+    assert request_body["tools"] == WEATHER_AND_TIME_TOOLS
+
+    streamed_reasoning = "".join(getattr(chunk.choices[0].delta, "reasoning_content", None) or "" for chunk in chunks)
+    assert streamed_reasoning == "Need weather and time."
+
+    rebuilt = litellm.stream_chunk_builder(chunks)
+    message = rebuilt.choices[0].message
+    assert message.reasoning_content == "Need weather and time."
+    assert rebuilt.choices[0].finish_reason == "tool_calls"
+    calls = {call.id: call for call in message.tool_calls}
+    assert calls["call_weather"].function.name == "get_weather"
+    assert json.loads(calls["call_weather"].function.arguments) == {"city": "San Francisco"}
+    assert calls["call_time"].function.name == "get_time"
+    assert json.loads(calls["call_time"].function.arguments) == {"tz": "PST"}
+
+
+async def test_async_streaming_completion_strips_internal_fields_and_streams_reasoning():
+    captured_requests: list[httpx.Request] = []
+    client = _async_client(
+        captured_requests,
+        _sse_response(
+            _chunk({"role": "assistant", "reasoning": "Recalling 47."}),
+            _chunk({"content": "47"}, finish_reason="stop"),
+        ),
+    )
+
+    stream = await litellm.acompletion(
+        model=f"together_ai/{REASONING_MODEL}",
+        messages=[dict(message) for message in PRESERVED_THINKING_MESSAGES],
+        chat_template_kwargs={"clear_thinking": False},
+        stream=True,
+        api_key="fake-key",
+        client=client,
+    )
+    chunks = [chunk async for chunk in stream]
+
+    request_body = json.loads(captured_requests[0].content)
+    assert str(captured_requests[0].url) == TOGETHER_CHAT_URL
+    assert request_body["chat_template_kwargs"] == {"clear_thinking": False}
+    _assert_internal_fields_stripped_reasoning_kept(request_body["messages"])
+
+    rebuilt = litellm.stream_chunk_builder(chunks)
+    assert rebuilt.choices[0].message.reasoning_content == "Recalling 47."
+    assert rebuilt.choices[0].message.content == "47"
+
+
+@pytest.mark.parametrize("api_base", ["https://api.together.ai/v1", "https://api.together.xyz/v1"])
+def test_completion_bare_model_with_together_api_base_uses_together_config(api_base):
+    captured_requests: list[httpx.Request] = []
+    client = _sync_client(
+        captured_requests,
+        httpx.Response(200, json=_chat_completion({"role": "assistant", "content": "4", "reasoning": "2+2"})),
+    )
+
+    response = litellm.completion(
+        model=UNMAPPED_MODEL,
+        messages=[{"role": "user", "content": "What is 2+2?"}],
+        api_base=api_base,
+        api_key="fake-key",
+        client=client,
+    )
+
+    assert str(captured_requests[0].url) == f"{api_base}/chat/completions"
+    assert captured_requests[0].headers["authorization"] == "Bearer fake-key"
+    assert response._hidden_params["custom_llm_provider"] == "together_ai"
+    assert response.choices[0].message.reasoning_content == "2+2"
+
+
+def test_completion_honors_together_ai_api_base_env(monkeypatch):
+    monkeypatch.setenv("TOGETHER_AI_API_BASE", "https://together.internal.example/v1")
+    captured_requests: list[httpx.Request] = []
+    client = _sync_client(
+        captured_requests,
+        httpx.Response(200, json=_chat_completion({"role": "assistant", "content": "4"})),
+    )
+
+    litellm.completion(
+        model=f"together_ai/{REASONING_MODEL}",
+        messages=[{"role": "user", "content": "What is 2+2?"}],
+        api_key="fake-key",
+        client=client,
+    )
+
+    assert str(captured_requests[0].url) == "https://together.internal.example/v1/chat/completions"
+
+
+def test_responses_api_sends_tools_and_maps_reasoning_and_function_call():
+    captured_requests: list[httpx.Request] = []
+    client = _sync_client(
+        captured_requests,
+        httpx.Response(
+            200,
+            json=_chat_completion(
+                {
+                    "role": "assistant",
+                    "content": None,
+                    "reasoning": "Need the weather tool.",
+                    "tool_calls": [
+                        {
+                            "id": "call_abc123",
+                            "type": "function",
+                            "function": {"name": "get_weather", "arguments": '{"city": "San Francisco"}'},
+                        }
+                    ],
+                },
+                finish_reason="tool_calls",
+            ),
+        ),
+    )
+
+    response = litellm.responses(
+        model=f"together_ai/{UNMAPPED_MODEL}",
+        input="What is the weather in San Francisco?",
+        tools=[{"type": "function", "name": "get_weather", "parameters": {}}],
+        api_key="fake-key",
+        client=client,
+    )
+
+    request_body = json.loads(captured_requests[0].content)
+    assert str(captured_requests[0].url) == TOGETHER_CHAT_URL
+    assert [tool["function"]["name"] for tool in request_body["tools"]] == ["get_weather"]
+    outputs = {item.type: item for item in response.output}
+    assert outputs["reasoning"].content[0].text == "Need the weather tool."
+    assert outputs["function_call"].name == "get_weather"
+    assert json.loads(outputs["function_call"].arguments) == {"city": "San Francisco"}
+
+
+ANTHROPIC_TOOL_LOOP_MESSAGES = [
+    {"role": "user", "content": "What is the weather in San Francisco?"},
+    {
+        "role": "assistant",
+        "content": [
+            {"type": "thinking", "thinking": "I should call get_weather.", "signature": ""},
+            {"type": "tool_use", "id": "toolu_01", "name": "get_weather", "input": {"city": "San Francisco"}},
+        ],
+    },
+    {
+        "role": "user",
+        "content": [{"type": "tool_result", "tool_use_id": "toolu_01", "content": "Sunny, 18C"}],
+    },
+]
+
+
+def test_anthropic_messages_replays_tool_loop_and_maps_reasoning_to_thinking_block():
+    captured_requests: list[httpx.Request] = []
+    client = _sync_client(
+        captured_requests,
+        httpx.Response(
+            200,
+            json=_chat_completion({"role": "assistant", "content": "Sunny in SF.", "reasoning": "Tool said sunny."}),
+        ),
+    )
+
+    response = litellm.anthropic.messages.create(
+        model=f"together_ai/{UNMAPPED_MODEL}",
+        max_tokens=100,
+        messages=[dict(message) for message in ANTHROPIC_TOOL_LOOP_MESSAGES],
+        tools=[ANTHROPIC_WEATHER_TOOL],
+        api_key="fake-key",
+        client=client,
+    )
+
+    request_body = json.loads(captured_requests[0].content)
+    assert str(captured_requests[0].url) == TOGETHER_CHAT_URL
+    assert [tool["function"]["name"] for tool in request_body["tools"]] == ["get_weather"]
+    assistant_turn = request_body["messages"][1]
+    assert assistant_turn["role"] == "assistant"
+    assert assistant_turn["reasoning_content"] == "I should call get_weather."
+    assert "thinking_blocks" not in assistant_turn
+    replayed_call = assistant_turn["tool_calls"][0]
+    assert replayed_call["id"] == "toolu_01"
+    assert replayed_call["function"]["name"] == "get_weather"
+    assert json.loads(replayed_call["function"]["arguments"]) == {"city": "San Francisco"}
+    tool_turn = request_body["messages"][2]
+    assert tool_turn["role"] == "tool"
+    assert tool_turn["tool_call_id"] == "toolu_01"
+    assert tool_turn["content"] == "Sunny, 18C"
+
+    blocks = {block["type"]: block for block in response["content"]}
+    assert blocks["thinking"]["thinking"] == "Tool said sunny."
+    assert blocks["text"]["text"] == "Sunny in SF."
+    assert response["stop_reason"] == "end_turn"
+
+
+def _anthropic_sse_events(stream: Iterator[bytes]) -> list[dict]:
+    return [
+        json.loads(line.removeprefix("data: "))
+        for raw in stream
+        for line in raw.decode().splitlines()
+        if line.startswith("data: ")
+    ]
+
+
+def test_anthropic_messages_streams_together_tool_call_as_input_json_delta():
+    captured_requests: list[httpx.Request] = []
+    client = _sync_client(captured_requests, _sse_response(*PARALLEL_TOOL_CALL_STREAM))
+
+    events = _anthropic_sse_events(
+        litellm.anthropic.messages.create(
+            model=f"together_ai/{UNMAPPED_MODEL}",
+            max_tokens=100,
+            messages=[{"role": "user", "content": "Weather and time in San Francisco?"}],
+            tools=[ANTHROPIC_WEATHER_TOOL, {"name": "get_time", "input_schema": {"type": "object"}}],
+            stream=True,
+            api_key="fake-key",
+            client=client,
+        )
+    )
+
+    assert json.loads(captured_requests[0].content)["stream"] is True
+    tool_starts = {
+        event["index"]: event["content_block"]
+        for event in events
+        if event["type"] == "content_block_start" and event["content_block"]["type"] == "tool_use"
+    }
+    input_json_deltas = [
+        event for event in events if event["type"] == "content_block_delta" and event["delta"]["type"] == "input_json_delta"
+    ]
+    tool_inputs = {
+        block["name"]: json.loads("".join(delta["delta"]["partial_json"] for delta in input_json_deltas if delta["index"] == index))
+        for index, block in tool_starts.items()
+    }
+    assert {block["id"] for block in tool_starts.values()} == {"call_weather", "call_time"}
+    assert tool_inputs == {"get_weather": {"city": "San Francisco"}, "get_time": {"tz": "PST"}}
+    thinking_text = "".join(
+        event["delta"]["thinking"]
+        for event in events
+        if event["type"] == "content_block_delta" and event["delta"]["type"] == "thinking_delta"
+    )
+    assert thinking_text == "Need weather and time."
+    assert [event["delta"]["stop_reason"] for event in events if event["type"] == "message_delta"] == ["tool_use"]


### PR DESCRIPTION
## TLDR

Problem this solves:

- The Together overhaul (#38233, #38248, #38230, #38265, #38275) had unit tests but no cross-surface ones
- Legacy `api.together.xyz` routing and `TOGETHER_AI_API_BASE` had no test through `litellm.completion`
- Streaming, async, `/v1/responses`, and `/v1/messages` never reached the Together transformation in a test

How it solves it:

- Adds 7 tests (8 cases) to the existing Together test file, no runtime code change
- Each new test fails under a one-line mutation of the merged code (proof below)
- A live two-worker proxy run confirms the mocked wire shapes match Together today

## User Flow

Before: a developer running an agent loop against Together through the gateway is the first to notice a regression, because nothing in CI covered these paths

1. A contributor refactors the Together integration and their PR passes CI, since the streaming, async, `/v1/responses`, `/v1/messages`, legacy-host, and env api_base paths have no tests
2. The developer sends POST https://litellm-domain/v1/messages with a replayed assistant turn (thinking block plus `tool_use`) and a `tool_result`, the way Claude Code and the Anthropic SDK do on every tool loop
3. Together answers 400 because the replayed assistant message now carries gateway-internal fields, or the tool call never reaches Together at all, and the loop dies on turn two
4. The same happens on POST https://litellm-domain/v1/responses (no `function_call` item comes back) and on POST https://litellm-domain/v1/chat/completions with `"stream": true` (no `reasoning_content` deltas, tool call arguments never reassemble)
5. A deployment pointed at `api_base: https://api.together.xyz/v1` boots with "LLM Provider NOT provided" again

After: the same regression is caught by CI on the contributor's PR, so the developer never sees it

1. A contributor refactors the Together integration and their PR fails `tests/test_litellm/llms/together_ai/chat/test_together_ai_chat_transformation.py` in CI, naming the exact surface that broke
2. The developer's POST https://litellm-domain/v1/messages tool loop keeps returning 200 with `stop_reason: "end_turn"` on turn two
3. POST https://litellm-domain/v1/responses keeps returning a `reasoning` item and a `function_call` item with the tool name and JSON arguments
4. POST https://litellm-domain/v1/chat/completions with `"stream": true` keeps streaming `reasoning_content` deltas and indexed `tool_calls` deltas that reassemble into complete calls
5. A deployment pointed at `api_base: https://api.together.xyz/v1` or at `TOGETHER_AI_API_BASE` keeps routing to that host

## Relevant issues

## Linear ticket

Resolves LIT-5970

## What was already covered and what this adds

| Behavior | Already covered by | Added here |
| --- | --- | --- |
| `api.together.ai` / `api.together.xyz` resolve in `get_llm_provider` | test_get_llm_provider_endpoint_match.py | bare model + `api_base` through `litellm.completion` |
| `TOGETHER_AI_API_BASE` env | rerank only (rerank_api/test_main.py) | chat completions honor it |
| Tools pass through / drop / raise per registry | together test file, `map_openai_params` level | passthrough through streaming, `/v1/responses`, `/v1/messages` |
| `reasoning` -> `reasoning_content` | non-streaming response, `chunk_parser` level | full `stream=True` run, async stream, `stream_chunk_builder` |
| Tool call index and id in chunks | `chunk_parser` level | two tool calls reassembled end to end, sync and via `/v1/messages` |
| Internal fields stripped from replayed assistant messages | sync/async `transform_request`, sync `completion` | async streaming `acompletion`, `/v1/messages` tool loop replay |
| `/v1/responses` bridge to Together | none | tools sent, `reasoning` and `function_call` output items |
| `/v1/messages` adapter to Together | none | tool loop replay body, thinking block, `input_json_delta` streaming |
| Registry pricing, deprecation dates, successors | test_together_ai_model_metadata.py | nothing (registry-wide capability test waits on #38257) |

Deferred on purpose until the sibling PRs land: cost calculation (#38280), registry-wide capability fields (#38257), `reasoning_effort` (#38263), and `response_format` json_schema (#38269). Testing them now would pin unmerged behavior

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

This PR ships no runtime code, so the proof is that the new tests have teeth: four one-line mutations of the merged Together code, run against the test file at the merge base (Before) and at this PR's tip (After), plus a live proxy run showing the mocked wire shapes are what Together returns today. Mutation runner: each mutation is applied, the file is run, and the source is restored (`git status litellm` is clean afterwards)

Mutations (all in code merged by #38233, #38248, #38265, #38275):

- M1 `litellm/llms/together_ai/chat/transformation.py`: `if message["role"] != "assistant" or LITELLM_INTERNAL_ASSISTANT_FIELDS.isdisjoint(message):` -> `if True:` (stop stripping `thinking_blocks` / `provider_specific_fields`)
- M2 `litellm/litellm_core_utils/get_llm_provider_logic.py`: `elif endpoint == "api.together.ai/v1" or endpoint == "api.together.xyz/v1":` -> `elif endpoint == "api.together.ai/v1":` (drop the legacy host)
- M3 `litellm/llms/together_ai/chat/transformation.py`: in `_tool_params_to_drop`, the no-registry-verdict branch `return ()` -> `return passed_tool_params` (fail closed instead of passing tools through)
- M4 `litellm/litellm_core_utils/get_llm_provider_logic.py`: `api_base or get_secret_str("TOGETHER_AI_API_BASE") or "https://api.together.ai/v1"` -> `api_base or "https://api.together.ai/v1"` (ignore the env var)

### Before (99e1eaaca0)

#### Mutations against the existing test file

1. `.venv/bin/python -m pytest tests/test_litellm/llms/together_ai/chat/test_together_ai_chat_transformation.py -q` with each mutation applied in turn, the merge-base version of the file run from a snapshot copy so nothing in this PR was on disk

```
=== M1 stop stripping litellm-internal fields from replayed assistant messages ===
FAILED tests/test_litellm/llms/together_ai/chat/test_together_ai_chat_transformation.py::test_async_transform_request_keeps_reasoning_content_strips_internal_fields
FAILED tests/test_litellm/llms/together_ai/chat/test_together_ai_chat_transformation.py::test_completion_sends_chat_template_kwargs_and_preserved_reasoning
FAILED tests/test_litellm/llms/together_ai/chat/test_together_ai_chat_transformation.py::test_transform_request_keeps_reasoning_content_strips_internal_fields
3 failed, 19 passed in 0.36s
=== M2 drop the legacy api.together.xyz host from the provider match ===
22 passed in 0.32s
=== M3 fail closed: drop tools for models with no registry verdict ===
FAILED tests/test_litellm/llms/together_ai/chat/test_together_ai_chat_transformation.py::test_completion_unmapped_model_sends_tools_to_together
FAILED tests/test_litellm/llms/together_ai/chat/test_together_ai_chat_transformation.py::test_map_openai_params_unmapped_model_passes_tools_through[False]
FAILED tests/test_litellm/llms/together_ai/chat/test_together_ai_chat_transformation.py::test_map_openai_params_unmapped_model_passes_tools_through[True]
3 failed, 19 passed in 0.30s
=== M4 ignore TOGETHER_AI_API_BASE ===
22 passed in 0.37s
=== unmutated ===
22 passed in 0.49s
litellm/ tree clean
```

M2 and M4 pass every existing test, so a PR shipping either regression would be green in CI. M1 and M3 are caught only at the `transform_request` / `map_openai_params` unit level, not through streaming, `/v1/responses`, or `/v1/messages`

#### Live proxy, two workers, real Together calls

Runtime code is identical at both hashes (this PR only adds tests), so the run under After stands for Before too

### After (602bf1c0ac)

#### Mutations against the test file in this PR

1. Same command with each mutation applied in turn

```
=== M1 stop stripping litellm-internal fields from replayed assistant messages ===
FAILED tests/test_litellm/llms/together_ai/chat/test_together_ai_chat_transformation.py::test_anthropic_messages_replays_tool_loop_and_maps_reasoning_to_thinking_block
FAILED tests/test_litellm/llms/together_ai/chat/test_together_ai_chat_transformation.py::test_async_streaming_completion_strips_internal_fields_and_streams_reasoning
FAILED tests/test_litellm/llms/together_ai/chat/test_together_ai_chat_transformation.py::test_async_transform_request_keeps_reasoning_content_strips_internal_fields
FAILED tests/test_litellm/llms/together_ai/chat/test_together_ai_chat_transformation.py::test_completion_sends_chat_template_kwargs_and_preserved_reasoning
FAILED tests/test_litellm/llms/together_ai/chat/test_together_ai_chat_transformation.py::test_transform_request_keeps_reasoning_content_strips_internal_fields
5 failed, 25 passed in 0.49s
=== M2 drop the legacy api.together.xyz host from the provider match ===
FAILED tests/test_litellm/llms/together_ai/chat/test_together_ai_chat_transformation.py::test_completion_bare_model_with_together_api_base_uses_together_config[https://api.together.xyz/v1]
1 failed, 29 passed in 0.60s
=== M3 fail closed: drop tools for models with no registry verdict ===
FAILED tests/test_litellm/llms/together_ai/chat/test_together_ai_chat_transformation.py::test_anthropic_messages_replays_tool_loop_and_maps_reasoning_to_thinking_block
FAILED tests/test_litellm/llms/together_ai/chat/test_together_ai_chat_transformation.py::test_completion_unmapped_model_sends_tools_to_together
FAILED tests/test_litellm/llms/together_ai/chat/test_together_ai_chat_transformation.py::test_map_openai_params_unmapped_model_passes_tools_through[False]
FAILED tests/test_litellm/llms/together_ai/chat/test_together_ai_chat_transformation.py::test_map_openai_params_unmapped_model_passes_tools_through[True]
FAILED tests/test_litellm/llms/together_ai/chat/test_together_ai_chat_transformation.py::test_responses_api_sends_tools_and_maps_reasoning_and_function_call
FAILED tests/test_litellm/llms/together_ai/chat/test_together_ai_chat_transformation.py::test_streaming_completion_rebuilds_reasoning_and_parallel_tool_calls
6 failed, 24 passed in 0.48s
=== M4 ignore TOGETHER_AI_API_BASE ===
FAILED tests/test_litellm/llms/together_ai/chat/test_together_ai_chat_transformation.py::test_completion_honors_together_ai_api_base_env
1 failed, 29 passed in 0.44s
=== unmutated ===
30 passed in 0.36s
litellm/ tree clean
```

2. Full run of the file at the tip, unmutated

```
============================= test session starts ==============================
collecting ... collected 30 items
tests/test_litellm/llms/together_ai/chat/test_together_ai_chat_transformation.py::test_anthropic_messages_replays_tool_loop_and_maps_reasoning_to_thinking_block PASSED [  3%]
tests/test_litellm/llms/together_ai/chat/test_together_ai_chat_transformation.py::test_anthropic_messages_streams_together_tool_call_as_input_json_delta PASSED [  6%]
tests/test_litellm/llms/together_ai/chat/test_together_ai_chat_transformation.py::test_async_streaming_completion_strips_internal_fields_and_streams_reasoning PASSED [ 10%]
tests/test_litellm/llms/together_ai/chat/test_together_ai_chat_transformation.py::test_async_transform_request_keeps_reasoning_content_strips_internal_fields PASSED [ 13%]
tests/test_litellm/llms/together_ai/chat/test_together_ai_chat_transformation.py::test_completion_bare_model_with_together_api_base_uses_together_config[https://api.together.ai/v1] PASSED [ 16%]
tests/test_litellm/llms/together_ai/chat/test_together_ai_chat_transformation.py::test_completion_bare_model_with_together_api_base_uses_together_config[https://api.together.xyz/v1] PASSED [ 20%]
tests/test_litellm/llms/together_ai/chat/test_together_ai_chat_transformation.py::test_completion_honors_together_ai_api_base_env PASSED [ 23%]
tests/test_litellm/llms/together_ai/chat/test_together_ai_chat_transformation.py::test_completion_routes_through_together_chat_config PASSED [ 26%]
tests/test_litellm/llms/together_ai/chat/test_together_ai_chat_transformation.py::test_completion_sends_chat_template_kwargs_and_preserved_reasoning PASSED [ 30%]
tests/test_litellm/llms/together_ai/chat/test_together_ai_chat_transformation.py::test_completion_unmapped_model_sends_tools_to_together PASSED [ 33%]
tests/test_litellm/llms/together_ai/chat/test_together_ai_chat_transformation.py::test_map_openai_params_drops_text_response_format PASSED [ 36%]
tests/test_litellm/llms/together_ai/chat/test_together_ai_chat_transformation.py::test_map_openai_params_keeps_json_response_format PASSED [ 40%]
tests/test_litellm/llms/together_ai/chat/test_together_ai_chat_transformation.py::test_map_openai_params_no_tools_model_drops_tools_with_warning PASSED [ 43%]
tests/test_litellm/llms/together_ai/chat/test_together_ai_chat_transformation.py::test_map_openai_params_no_tools_model_raises_without_drop_params PASSED [ 46%]
tests/test_litellm/llms/together_ai/chat/test_together_ai_chat_transformation.py::test_map_openai_params_reasoning_model_passes_sampling_params PASSED [ 50%]
tests/test_litellm/llms/together_ai/chat/test_together_ai_chat_transformation.py::test_map_openai_params_tool_calling_model_passes_tools PASSED [ 53%]
tests/test_litellm/llms/together_ai/chat/test_together_ai_chat_transformation.py::test_map_openai_params_unmapped_model_passes_tools_through[False] PASSED [ 56%]
tests/test_litellm/llms/together_ai/chat/test_together_ai_chat_transformation.py::test_map_openai_params_unmapped_model_passes_tools_through[True] PASSED [ 60%]
tests/test_litellm/llms/together_ai/chat/test_together_ai_chat_transformation.py::test_provider_config_manager_returns_together_chat_config PASSED [ 63%]
tests/test_litellm/llms/together_ai/chat/test_together_ai_chat_transformation.py::test_responses_api_sends_tools_and_maps_reasoning_and_function_call PASSED [ 66%]
tests/test_litellm/llms/together_ai/chat/test_together_ai_chat_transformation.py::test_streaming_chunk_maps_delta_reasoning_to_reasoning_content PASSED [ 70%]
tests/test_litellm/llms/together_ai/chat/test_together_ai_chat_transformation.py::test_streaming_chunk_preserves_tool_call_index_and_id PASSED [ 73%]
tests/test_litellm/llms/together_ai/chat/test_together_ai_chat_transformation.py::test_streaming_completion_rebuilds_reasoning_and_parallel_tool_calls PASSED [ 76%]
tests/test_litellm/llms/together_ai/chat/test_together_ai_chat_transformation.py::test_supported_params_no_tools_model_keeps_tool_params PASSED [ 80%]
tests/test_litellm/llms/together_ai/chat/test_together_ai_chat_transformation.py::test_supported_params_tool_calling_model PASSED [ 83%]
tests/test_litellm/llms/together_ai/chat/test_together_ai_chat_transformation.py::test_supported_params_unmapped_model_keeps_tool_params PASSED [ 86%]
tests/test_litellm/llms/together_ai/chat/test_together_ai_chat_transformation.py::test_together_ai_config_alias_points_at_chat_config PASSED [ 90%]
tests/test_litellm/llms/together_ai/chat/test_together_ai_chat_transformation.py::test_transform_request_keeps_reasoning_content_strips_internal_fields PASSED [ 93%]
tests/test_litellm/llms/together_ai/chat/test_together_ai_chat_transformation.py::test_transform_response_maps_reasoning_to_reasoning_content PASSED [ 96%]
tests/test_litellm/llms/together_ai/chat/test_together_ai_chat_transformation.py::test_transform_response_preserves_reasoning_content_field PASSED [100%]/Users/mateo/Development/litellm_together_regression_tests/.venv/lib/python3.12/site-packages/_pytest/unraisableexception.py:67: PytestUnraisableExceptionWarning: Exception ignored in: <socket.socket fd=16, family=1, type=1, proto=0>
Traceback (most recent call last):
  File "/Users/mateo/Development/litellm_together_regression_tests/.venv/lib/python3.12/site-packages/_pytest/unraisableexception.py", line 33, in gc_collect_harder
    gc.collect()
ResourceWarning: unclosed <socket.socket fd=16, family=1, type=1, proto=0>
Enable tracemalloc to get traceback where the object was allocated.
See https://docs.pytest.org/en/stable/how-to/capture-warnings.html#resource-warnings for more info.
  warnings.warn(pytest.PytestUnraisableExceptionWarning(msg))
/Users/mateo/Development/litellm_together_regression_tests/.venv/lib/python3.12/site-packages/_pytest/unraisableexception.py:67: PytestUnraisableExceptionWarning: Exception ignored in: <socket.socket fd=15, family=1, type=1, proto=0>
Traceback (most recent call last):
  File "/Users/mateo/Development/litellm_together_regression_tests/.venv/lib/python3.12/site-packages/_pytest/unraisableexception.py", line 33, in gc_collect_harder
    gc.collect()
ResourceWarning: unclosed <socket.socket fd=15, family=1, type=1, proto=0>
Enable tracemalloc to get traceback where the object was allocated.
See https://docs.pytest.org/en/stable/how-to/capture-warnings.html#resource-warnings for more info.
  warnings.warn(pytest.PytestUnraisableExceptionWarning(msg))
/Users/mateo/Development/litellm_together_regression_tests/.venv/lib/python3.12/site-packages/_pytest/unraisableexception.py:67: PytestUnraisableExceptionWarning: Exception ignored in: <function BaseEventLoop.__del__ at 0x10b819a80>
Traceback (most recent call last):
  File "/Users/mateo/.local/share/uv/python/cpython-3.12.13-macos-aarch64-none/lib/python3.12/asyncio/base_events.py", line 730, in __del__
    _warn(f"unclosed event loop {self!r}", ResourceWarning, source=self)
ResourceWarning: unclosed event loop <_UnixSelectorEventLoop running=False closed=False debug=False>
Enable tracemalloc to get traceback where the object was allocated.
See https://docs.pytest.org/en/stable/how-to/capture-warnings.html#resource-warnings for more info.
  warnings.warn(pytest.PytestUnraisableExceptionWarning(msg))
============================== 30 passed in 0.49s ==============================
```

#### Live proxy, two workers, real Together calls

Proxy: `python litellm/proxy/proxy_cli.py --config lit5970_proxy.yaml --port 41873 --num_workers 2` (`BASE=http://localhost:41873`, `KEY=sk-lit5970-qa`), no database. Config: `together-glm` = `together_ai/zai-org/GLM-5.2` (registry says function calling supported), `together-qwen` = `together_ai/Qwen/Qwen3.6-Plus` (no function calling verdict in the registry, so tools pass through with a warning), `together-xyz-host` = bare `zai-org/GLM-5.2` with `api_base: https://api.together.xyz/v1`. Master key `sk-lit5970-qa`

1. Streaming chat completion with tools on the no-verdict model

```
$ curl -sN "$BASE/v1/chat/completions" -H "Authorization: Bearer $KEY" -H 'Content-Type: application/json' \
  -d '{"model":"together-qwen","stream":true,"messages":[{"role":"user","content":"What is the weather in San Francisco? Call get_weather."}],"tools":[{"type":"function","function":{"name":"get_weather","parameters":{"type":"object","properties":{"city":{"type":"string"}},"required":["city"]}}}]}' > case1.sse
grep -c reasoning_content case1.sse; grep -m1 reasoning_content case1.sse | cut -c1-260
grep tool_calls case1.sse | grep -v '"tool_calls":null' | head -4 | cut -c1-320
grep -o '"finish_reason":"[a-z_]*"' case1.sse | grep -v null | sort -u

chunks with reasoning_content: 32
first reasoning chunk:
data: {"id":"chatcmpl-77139c70-e3f6-9306-a270-a3411de8bd18","created":1787704509,"model":"together-qwen","object":"chat.completion.chunk","choices":[{"text":"","index":0,"delta":{"reasoning_content":"Thinking","content":"","role":"assistant"}}]}
tool_calls chunks:
data: {"id":"chatcmpl-77139c70-e3f6-9306-a270-a3411de8bd18","created":1787704509,"model":"together-qwen","object":"chat.completion.chunk","choices":[{"text":"","index":0,"delta":{"content":"","tool_calls":[{"id":"call_30441e968ec547798dc10ded","function":{"arguments":"","name":"get_weather"},"type":"function","index":0
data: {"id":"chatcmpl-77139c70-e3f6-9306-a270-a3411de8bd18","created":1787704509,"model":"together-qwen","object":"chat.completion.chunk","choices":[{"text":"","index":0,"delta":{"content":"","tool_calls":[{"id":"","function":{"arguments":"{\"city\": "},"type":"function","index":0}]}}]}
data: {"id":"chatcmpl-77139c70-e3f6-9306-a270-a3411de8bd18","created":1787704509,"model":"together-qwen","object":"chat.completion.chunk","choices":[{"text":"","index":0,"delta":{"content":"","tool_calls":[{"id":"","function":{"arguments":"\"San Francisco"},"type":"function","index":0}]}}]}
data: {"id":"chatcmpl-77139c70-e3f6-9306-a270-a3411de8bd18","created":1787704509,"model":"together-qwen","object":"chat.completion.chunk","choices":[{"text":"","index":0,"delta":{"content":"","tool_calls":[{"id":"","function":{"arguments":"\""},"type":"function","index":0}]}}]}
finish:
"finish_reason":"tool_calls"
```

2. `/v1/responses` with tools

```
$ curl -s "$BASE/v1/responses" -H "Authorization: Bearer $KEY" -H 'Content-Type: application/json' \
  -d '{"model":"together-glm","input":"What is the weather in San Francisco? Call get_weather.","tools":[{"type":"function","name":"get_weather","parameters":{"type":"object","properties":{"city":{"type":"string"}},"required":["city"]}}]}' \
  | jq -c '{status, output: [.output[] | {type, name, arguments, summary_text: (.content[0].text // null | tostring | .[0:80])}]}'

{"status":"completed","output":[{"type":"reasoning","name":null,"arguments":null,"summary_text":"The user wants to know the weather in San Francisco. I'll call the get_weather f"},{"type":"message","name":null,"arguments":null,"summary_text":"null"},{"type":"function_call","name":"get_weather","arguments":"{\"city\":\"San Francisco\"}","summary_text":"null"}]}
```

3. `/v1/messages` tool loop: turn one returns thinking plus `tool_use`, turn two replays that assistant content plus a `tool_result`

```
$ TOOLS='[{"name":"get_weather","description":"Get the weather","input_schema":{"type":"object","properties":{"city":{"type":"string"}},"required":["city"]}}]'
curl -s "$BASE/v1/messages" -H "Authorization: Bearer $KEY" -H 'Content-Type: application/json' \
  -d "{\"model\":\"together-glm\",\"max_tokens\":400,\"messages\":[{\"role\":\"user\",\"content\":\"What is the weather in San Francisco? Call get_weather.\"}],\"tools\":$TOOLS}" > turn1.json
jq -c '{stop_reason, content: [.content[] | {type, name, input, thinking: (.thinking // null | tostring | .[0:60]), text: (.text // null | tostring | .[0:60])}]}' turn1.json
ASSISTANT_CONTENT=$(jq -c '.content' turn1.json); TOOL_USE_ID=$(jq -r '[.content[] | select(.type=="tool_use")][0].id' turn1.json)
curl -s "$BASE/v1/messages" -H "Authorization: Bearer $KEY" -H 'Content-Type: application/json' \
  -d "{\"model\":\"together-glm\",\"max_tokens\":400,\"messages\":[{\"role\":\"user\",\"content\":\"What is the weather in San Francisco? Call get_weather.\"},{\"role\":\"assistant\",\"content\":$ASSISTANT_CONTENT},{\"role\":\"user\",\"content\":[{\"type\":\"tool_result\",\"tool_use_id\":\"$TOOL_USE_ID\",\"content\":\"Sunny, 18C\"}]}],\"tools\":$TOOLS}" \
  | jq -c '{stop_reason, content: [.content[] | {type, text: (.text // null | tostring | .[0:120])}], error: (.error // null)}'

turn 1:
{"stop_reason":"tool_use","content":[{"type":"thinking","name":null,"input":null,"thinking":"The user wants to know the weather in San Francisco. I'll ca","text":"null"},{"type":"tool_use","name":"get_weather","input":{"city":"San Francisco"},"thinking":"null","text":"null"}]}
turn 2 (assistant thinking + tool_use replayed, then tool_result):
{"stop_reason":"end_turn","content":[{"type":"thinking","text":"null"},{"type":"text","text":"The weather in San Francisco is currently **sunny** with a temperature of **18°C** (about 64°F). It looks like a lovely "}],"error":null}
```

4. Bare model plus legacy `api.together.xyz` api_base

```
$ curl -s -D headers.txt "$BASE/v1/chat/completions" -H "Authorization: Bearer $KEY" -H 'Content-Type: application/json' \
  -d '{"model":"together-xyz-host","messages":[{"role":"user","content":"What is 2+2? Answer with just the number."}]}' > case4.json
grep -i "^HTTP\|x-litellm-model-api-base\|x-litellm-model-id" headers.txt | tr -d '\r'
jq -c '{model, content: .choices[0].message.content, reasoning_content: (.choices[0].message.reasoning_content // null | tostring | .[0:80]), usage}' case4.json

HTTP/1.1 200 OK
x-litellm-model-id: 3429e0c4d074c642ddd55527daf3a017581c9432d37d8cc39d30da361d666d61
x-litellm-model-api-base: https://api.together.xyz/v1
{"model":"together-xyz-host","content":"4","reasoning_content":"1.  **Analyze the Request:** The user is asking for the result of 2+2 and specif","usage":{"completion_tokens":101,"prompt_tokens":25,"total_tokens":126,"completion_tokens_details":{"reasoning_tokens":98},"prompt_tokens_details":{"cached_tokens":0}}}
```

Observations from the live run (none caused by this PR, all left alone):

- `/v1/responses` output carries an empty `message` item between `reasoning` and `function_call`
- `/v1/messages` turn two returns a `thinking` block with no text field alongside the answer

## Type

✅ Test

## Caveats (if any)

### Low

- Tool-call deltas in the test streams arrive one call at a time, matching what Together sends; interleaved deltas across two calls are not pinned
- Registry-wide capability and cost tests wait on #38257 and #38280, then land as a follow-up commit here or a sibling PR

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

- [x] 7c3da429c7 passes /live-pr-risk
- [x] 602bf1c0ac passes /live-pr-risk
