### PR TITLE
fix(azure_ai): preserve OpenAI model provider identity

### DIFF
--- a/litellm/llms/azure_ai/chat/transformation.py
+++ b/litellm/llms/azure_ai/chat/transformation.py
@@ -8,7 +8,6 @@ import httpx
 from httpx import Response
 
 import litellm
-from litellm._logging import verbose_logger
 from litellm.litellm_core_utils.prompt_templates.common_utils import (
     _audio_or_image_in_message_content,
     convert_content_list_to_str,
@@ -204,21 +203,6 @@ class AzureAIStudioConfig(OpenAIConfig):
                 message["content"] = texts
         return stripped_messages
 
-    def _is_azure_openai_model(self, model: str, api_base: str | None) -> bool:
-        try:
-            if "/" in model:
-                model = model.split("/", 1)[1]
-            if (
-                model in litellm.open_ai_chat_completion_models
-                or model in litellm.open_ai_text_completion_models
-                or model in litellm.open_ai_embedding_models
-            ):
-                return True
-
-        except Exception:
-            return False
-        return False
-
     def _get_openai_compatible_provider_info(
         self,
         model: str,
@@ -228,10 +212,6 @@ class AzureAIStudioConfig(OpenAIConfig):
     ) -> tuple[str | None, str | None, str]:
         api_base = api_base or get_secret_str("AZURE_AI_API_BASE")
         dynamic_api_key: Final = api_key or get_secret_str("AZURE_AI_API_KEY")
-
-        if self._is_azure_openai_model(model=model, api_base=api_base):
-            verbose_logger.debug("Model=%s is Azure OpenAI model. Setting custom_llm_provider='azure'.", model)
-            custom_llm_provider = "azure"
         return api_base, dynamic_api_key, custom_llm_provider
 
     def transform_request(

--- a/tests/test_litellm/llms/azure_ai/chat/test_azure_ai_transformation.py
+++ b/tests/test_litellm/llms/azure_ai/chat/test_azure_ai_transformation.py
@@ -10,11 +10,8 @@ from litellm.llms.azure_ai.chat.transformation import AzureAIStudioConfig
 
 
 @pytest.mark.asyncio
-async def test_get_openai_compatible_provider_info():
-    """
-    Test that Azure AI requests are formatted correctly with the proper endpoint and parameters
-    for both synchronous and asynchronous calls
-    """
+async def test_azure_ai_openai_model_keeps_azure_ai_provider():
+    """OpenAI-named Azure AI deployments must retain Azure AI pricing identity."""
     config = AzureAIStudioConfig()
 
     (
@@ -22,13 +19,13 @@ async def test_get_openai_compatible_provider_info():
         dynamic_api_key,
         custom_llm_provider,
     ) = config._get_openai_compatible_provider_info(
-        model="azure_ai/gpt-4o-mini",
+        model="azure_ai/gpt-5.4-nano",
         api_base="https://my-base",
         api_key="my-key",
         custom_llm_provider="azure_ai",
     )
 
-    assert custom_llm_provider == "azure"
+    assert custom_llm_provider == "azure_ai"
 
 
 def test_azure_ai_validate_environment():


### PR DESCRIPTION
## TLDR

Problem this solves:

- Azure AI OpenAI-named deployments lose their configured provider
- Router pricing can resolve through the Azure OpenAI path

How it solves it:

- Keep the explicit `azure_ai` provider through provider resolution
- Add regression coverage for `azure_ai/gpt-5.4-nano`

## User Flow

Before: a proxy operator adds an Azure AI Foundry deployment, and requests can log an Azure OpenAI base-model error

1. They configure `azure_ai/gpt-5.4-nano` with `custom_llm_provider: azure_ai`
2. Their application sends POST `https://litellm-domain/v1/chat/completions` using that deployment
3. The proxy can identify it as Azure OpenAI and resolve Azure OpenAI metadata

After: the same deployment keeps its Azure AI Foundry identity for metadata and pricing

1. They configure `azure_ai/gpt-5.4-nano` with `custom_llm_provider: azure_ai`
2. Their application sends the same POST `https://litellm-domain/v1/chat/completions`
3. The proxy resolves the deployment as `azure_ai/gpt-5.4-nano`

## Relevant issues

Fixes #38276

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The focused Azure AI transformation test file passes locally
- [x] My PR passes all required CI/CD checks locally with `make check`
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile Confidence Score of at least 4/5 before requesting a maintainer review

## Screenshots / Proof of Fix

No live Azure AI Foundry credentials are configured in this workspace. The draft is backed by a provider-free regression test and a local Router readback that resolves `azure_ai/gpt-5.4-nano` as `azure_ai` with its 272000 input-token limit and `2e-07` input-token cost

## Type

🐛 Bug Fix

## Final Attestation

- [x] The regression test fails when Azure AI OpenAI-named models are rewritten to `azure`, and passes when their configured provider remains authoritative
