### PR TITLE
fix(openai): preserve streaming service tier

### DIFF
--- a/litellm/llms/openai/chat/gpt_transformation.py
+++ b/litellm/llms/openai/chat/gpt_transformation.py
@@ -807,6 +807,8 @@ class OpenAIChatCompletionStreamingHandler(BaseModelResponseIterator):
             }
             if "usage" in chunk and chunk["usage"] is not None:
                 kwargs["usage"] = chunk["usage"]
+            if "service_tier" in chunk and chunk["service_tier"] is not None:
+                kwargs["service_tier"] = chunk["service_tier"]
             return ModelResponseStream(**kwargs)
         except Exception as e:
             raise e

--- a/tests/test_litellm/llms/openai/chat/test_openai_gpt_transformation.py
+++ b/tests/test_litellm/llms/openai/chat/test_openai_gpt_transformation.py
@@ -5,7 +5,6 @@ Tests for OpenAI GPT transformation (litellm/llms/openai/chat/gpt_transformation
 
 import pytest
 
-
 import litellm
 from litellm.litellm_core_utils.prompt_templates.common_utils import TOOL_RESULT_IMAGE_BOUNDARY
 from litellm.llms.openai.chat.gpt_5_transformation import OpenAIGPT5Config
@@ -183,6 +182,24 @@ class TestOpenAIChatCompletionStreamingHandler:
         assert result.usage.prompt_tokens == 13797
         assert result.usage.completion_tokens == 350
         assert result.usage.total_tokens == 14147
+
+    def test_chunk_parser_preserves_service_tier(self):
+        """Provider service-tier responses must survive chunk normalization."""
+        handler = OpenAIChatCompletionStreamingHandler(
+            streaming_response=None, sync_stream=True
+        )
+
+        result = handler.chunk_parser(
+            {
+                "id": "gen-123",
+                "created": 1234567890,
+                "model": "xai/grok-4.6",
+                "choices": [],
+                "service_tier": "priority",
+            }
+        )
+
+        assert result.service_tier == "priority"
 
     def test_chunk_parser_raises_on_in_body_error_payload(self):
         """vLLM/sglang return HTTP 200 streams whose body carries the error,


### PR DESCRIPTION
## Problem
OpenAI-compatible streaming responses can include a provider-served `service_tier` such as `priority`, but LiteLLM's `OpenAIChatCompletionStreamingHandler.chunk_parser` rebuilds each chunk from a fixed field set and drops that metadata. This prevents downstream hooks, assembled streaming responses, and billing diagnostics from verifying the tier actually served.

## Root Cause
The parser copied `id`, `object`, `created`, `model`, `choices`, and optional `usage`, but never copied a non-null `service_tier` field from the raw provider chunk.

## Solution
Preserve a non-null `service_tier` in the normalized `ModelResponseStream`, matching the existing optional `usage` pass-through pattern.

## Changes
- Add `service_tier` pass-through in `OpenAIChatCompletionStreamingHandler.chunk_parser`.
- Add a mocked regression test for a priority-tier streaming chunk.
- Remove one pre-existing extra blank line in the touched test import block so Ruff check is clean.

## Testing
- Latest-base baseline: `tests/test_litellm/llms/openai/chat/test_openai_gpt_transformation.py` — 49 passed.
- Final focused suite: same file — 50 passed.
- `.venv\Scripts\ruff.exe check` on both changed files — passed.
- `.venv\Scripts\python.exe -m compileall` on both changed files — passed.
- `git diff --check` — passed.
- `ruff format --check` was attempted; the Windows checkout has mixed CRLF/LF normalization and the formatter reports existing formatting differences in these files. The repository HEAD passed the formatter through normalized stdin; no unrelated format rewrite was included.
- `basedpyright` was attempted; it reports 333 repository-existing diagnostics across the touched module/test and is not a clean typecheck signal for this two-line behavior change. No typecheck pass is claimed.
- Full suite was not run; no live provider or external API was used.

## Compatibility/Risk
Low-risk parser-only metadata preservation. Providers that do not send `service_tier` are unchanged. The field is optional and already supported by LiteLLM response models and downstream service-tier utilities.

## Notes for Reviewer
The regression uses a mocked raw chunk and verifies the normalized response exposes `priority`. The existing xAI handler inherits this parser, so no provider-specific branch is needed. The fork may still require the repository CLA gate before merge.

## Linked Issue
Fixes #38247

## Repository Gates
- [x] Focused tests and mocked-only validation completed.
- [x] Issue, assignee, claim comments, matching open PRs, and latest staging base rechecked before commit.
- [ ] CLA gate — external contributor gate may require maintainer action.
- [ ] Full repository typecheck/format baseline — existing Windows/environment diagnostics recorded above.