### PR TITLE
fix(logging): keep tracebacks for provider-originated 4xx errors

### DIFF
--- a/litellm/litellm_core_utils/core_helpers.py
+++ b/litellm/litellm_core_utils/core_helpers.py
@@ -58,7 +58,17 @@ def safe_divide(
     return numerator / denominator
 
 
+def _is_proxy_rejection(exception: BaseException) -> bool:
+    try:
+        from starlette.exceptions import HTTPException
+    except ImportError:
+        return False
+    return isinstance(exception, HTTPException)
+
+
 def _is_provider_originated(exception: BaseException) -> bool:
+    if _is_proxy_rejection(exception):
+        return False
     if getattr(exception, "llm_provider", None):
         return True
     from litellm.llms.base_llm.chat.transformation import BaseLLMException
@@ -74,6 +84,8 @@ def is_expected_client_error(exception: BaseException | None) -> bool:
     client error and keeps its traceback: a mapped litellm exception carries
     ``llm_provider``, and the raw ``BaseLLMException`` that provider handlers
     raise before mapping (the /v1/messages route surfaces it as-is) is one too.
+    The proxy's own limiters raise ``HTTPException`` subclasses that also carry
+    an ``llm_provider``, so any ``HTTPException`` stays a proxy rejection.
 
     ProxyException stores the status on .code (as a str), HTTPException and
     litellm exceptions on .status_code.

--- a/litellm/litellm_core_utils/core_helpers.py
+++ b/litellm/litellm_core_utils/core_helpers.py
@@ -60,12 +60,18 @@ def safe_divide(
 
 def is_expected_client_error(exception: BaseException | None) -> bool:
     """
-    True when the exception maps to an HTTP 4xx status.
+    True when the proxy itself rejected the request with an HTTP 4xx before any
+    provider call (bad key, budget, unknown model, guardrail). A 4xx returned by
+    a provider (the exception carries ``llm_provider``) is an upstream or
+    deployment problem, so it is never an expected client error and keeps its
+    traceback.
 
     ProxyException stores the status on .code (as a str), HTTPException and
     litellm exceptions on .status_code.
     """
     if exception is None:
+        return False
+    if getattr(exception, "llm_provider", None):
         return False
     code: Final[object] = getattr(exception, "code", None)
     status_code: Final[object] = code if code is not None else getattr(exception, "status_code", None)

--- a/litellm/litellm_core_utils/core_helpers.py
+++ b/litellm/litellm_core_utils/core_helpers.py
@@ -58,7 +58,18 @@ def safe_divide(
     return numerator / denominator
 
 
+def _is_litellm_limit_rejection(exception: BaseException) -> bool:
+    from litellm.exceptions import RateLimitErrorCategory
+
+    litellm_limit_categories: Final = frozenset(
+        (RateLimitErrorCategory.LITELLM_RATE_LIMIT.value, RateLimitErrorCategory.LITELLM_BATCH_RATE_LIMIT.value)
+    )
+    return getattr(exception, "category", None) in litellm_limit_categories
+
+
 def _is_proxy_rejection(exception: BaseException) -> bool:
+    if _is_litellm_limit_rejection(exception):
+        return True
     try:
         from starlette.exceptions import HTTPException
     except ImportError:
@@ -85,7 +96,10 @@ def is_expected_client_error(exception: BaseException | None) -> bool:
     ``llm_provider``, and the raw ``BaseLLMException`` that provider handlers
     raise before mapping (the /v1/messages route surfaces it as-is) is one too.
     The proxy's own limiters raise ``HTTPException`` subclasses that also carry
-    an ``llm_provider``, so any ``HTTPException`` stays a proxy rejection.
+    an ``llm_provider``, so any ``HTTPException`` stays a proxy rejection, and
+    so does any exception whose unified rate-limit ``category`` names litellm's
+    own limiter (``BudgetExceededError`` is a plain ``Exception`` that the auth
+    handler decorates with the requested model's provider).
 
     ProxyException stores the status on .code (as a str), HTTPException and
     litellm exceptions on .status_code.

--- a/litellm/litellm_core_utils/core_helpers.py
+++ b/litellm/litellm_core_utils/core_helpers.py
@@ -58,20 +58,29 @@ def safe_divide(
     return numerator / denominator
 
 
+def _is_provider_originated(exception: BaseException) -> bool:
+    if getattr(exception, "llm_provider", None):
+        return True
+    from litellm.llms.base_llm.chat.transformation import BaseLLMException
+
+    return isinstance(exception, BaseLLMException)
+
+
 def is_expected_client_error(exception: BaseException | None) -> bool:
     """
     True when the proxy itself rejected the request with an HTTP 4xx before any
     provider call (bad key, budget, unknown model, guardrail). A 4xx returned by
-    a provider (the exception carries ``llm_provider``) is an upstream or
-    deployment problem, so it is never an expected client error and keeps its
-    traceback.
+    a provider is an upstream or deployment problem, so it is never an expected
+    client error and keeps its traceback: a mapped litellm exception carries
+    ``llm_provider``, and the raw ``BaseLLMException`` that provider handlers
+    raise before mapping (the /v1/messages route surfaces it as-is) is one too.
 
     ProxyException stores the status on .code (as a str), HTTPException and
     litellm exceptions on .status_code.
     """
     if exception is None:
         return False
-    if getattr(exception, "llm_provider", None):
+    if _is_provider_originated(exception):
         return False
     code: Final[object] = getattr(exception, "code", None)
     status_code: Final[object] = code if code is not None else getattr(exception, "status_code", None)

--- a/tests/test_litellm/integrations/otel/test_otel_v2_logger.py
+++ b/tests/test_litellm/integrations/otel/test_otel_v2_logger.py
@@ -330,6 +330,30 @@ def test_real_llm_failure_still_emitted():
     assert span.status.status_code is StatusCode.ERROR
 
 
+def test_provider_auth_failure_span_carries_stack_trace():
+    """Regression for LIT-6163: a 401 the provider returned is not an expected
+    client error, so the error span built from the real failure payload keeps
+    ``litellm.provider.error.stack_trace`` alongside code and llm_provider."""
+    from litellm.exceptions import AuthenticationError
+    from litellm.litellm_core_utils.litellm_logging import StandardLoggingPayloadSetup
+
+    try:
+        raise AuthenticationError(
+            message="AnthropicException - API key is invalid.", llm_provider="anthropic", model="claude-haiku-4-5"
+        )
+    except AuthenticationError as caught:
+        error_information = StandardLoggingPayloadSetup.get_error_information(caught)
+    logger, exporter = _logger()
+    payload = _payload(status="failure", custom_llm_provider="anthropic", error_information=error_information)
+    _emit_llm(logger, _kwargs(payload=payload), fail=True)
+    (span,) = exporter.get_finished_spans()
+    assert span.status.status_code is StatusCode.ERROR
+    assert span.attributes["error.type"] == "AuthenticationError"
+    assert span.attributes["litellm.provider.error.code"] == "401"
+    assert span.attributes["litellm.provider.error.llm_provider"] == "anthropic"
+    assert "test_otel_v2_logger" in span.attributes["litellm.provider.error.stack_trace"]
+
+
 def test_idempotent_on_repeat_callback():
     """The carrier is the dedup: once the async callback closes the span and
     clears the carrier, a second callback firing emits nothing."""

--- a/tests/test_litellm/integrations/otel/test_otel_v2_logger.py
+++ b/tests/test_litellm/integrations/otel/test_otel_v2_logger.py
@@ -354,6 +354,26 @@ def test_provider_auth_failure_span_carries_stack_trace():
     assert "test_otel_v2_logger" in span.attributes["litellm.provider.error.stack_trace"]
 
 
+def test_unmapped_provider_auth_failure_span_carries_stack_trace():
+    """Regression for LIT-6163 on /v1/messages: that route logs the provider's
+    raw exception (no llm_provider), and its error span keeps the stack trace."""
+    from litellm.litellm_core_utils.litellm_logging import StandardLoggingPayloadSetup
+    from litellm.llms.anthropic.common_utils import AnthropicError
+
+    try:
+        raise AnthropicError(status_code=401, message='{"type":"authentication_error","message":"API key is invalid."}')
+    except AnthropicError as caught:
+        error_information = StandardLoggingPayloadSetup.get_error_information(caught)
+    logger, exporter = _logger()
+    payload = _payload(status="failure", custom_llm_provider="anthropic", error_information=error_information)
+    _emit_llm(logger, _kwargs(payload=payload), fail=True)
+    (span,) = exporter.get_finished_spans()
+    assert span.status.status_code is StatusCode.ERROR
+    assert span.attributes["error.type"] == "AnthropicError"
+    assert span.attributes["litellm.provider.error.code"] == "401"
+    assert "test_otel_v2_logger" in span.attributes["litellm.provider.error.stack_trace"]
+
+
 def test_idempotent_on_repeat_callback():
     """The carrier is the dedup: once the async callback closes the span and
     clears the carrier, a second callback firing emits nothing."""

--- a/tests/test_litellm/litellm_core_utils/test_core_helpers.py
+++ b/tests/test_litellm/litellm_core_utils/test_core_helpers.py
@@ -286,6 +286,7 @@ class TestIsExpectedClientError:
         from litellm.exceptions import AuthenticationError, RateLimitError
         from litellm.litellm_core_utils.core_helpers import is_expected_client_error
         from litellm.llms.anthropic.common_utils import AnthropicError
+        from litellm.proxy.common_utils.proxy_rate_limit_error import ProxyRateLimitError
 
         provider_auth_failure = AuthenticationError(
             message="AnthropicException - API key is invalid.", llm_provider="anthropic", model="claude-haiku-4-5"
@@ -297,6 +298,12 @@ class TestIsExpectedClientError:
 
         unmapped_provider_failure = AnthropicError(status_code=401, message='{"type":"authentication_error"}')
         assert is_expected_client_error(unmapped_provider_failure) is False
+
+        proxy_rate_limit = ProxyRateLimitError(
+            detail={"error": "Max parallel requests reached"}, model="claude-haiku-4-5", llm_provider="anthropic"
+        )
+        assert proxy_rate_limit.llm_provider == "anthropic"
+        assert is_expected_client_error(proxy_rate_limit) is True
 
         class RouterRejection(Exception):
             def __init__(self):

--- a/tests/test_litellm/litellm_core_utils/test_core_helpers.py
+++ b/tests/test_litellm/litellm_core_utils/test_core_helpers.py
@@ -285,6 +285,7 @@ class TestIsExpectedClientError:
         pre-call rejections (no llm_provider) are expected client errors."""
         from litellm.exceptions import AuthenticationError, RateLimitError
         from litellm.litellm_core_utils.core_helpers import is_expected_client_error
+        from litellm.llms.anthropic.common_utils import AnthropicError
 
         provider_auth_failure = AuthenticationError(
             message="AnthropicException - API key is invalid.", llm_provider="anthropic", model="claude-haiku-4-5"
@@ -293,6 +294,9 @@ class TestIsExpectedClientError:
 
         provider_rate_limit = RateLimitError(message="rate limited upstream", llm_provider="openai", model="gpt-4o")
         assert is_expected_client_error(provider_rate_limit) is False
+
+        unmapped_provider_failure = AnthropicError(status_code=401, message='{"type":"authentication_error"}')
+        assert is_expected_client_error(unmapped_provider_failure) is False
 
         class RouterRejection(Exception):
             def __init__(self):

--- a/tests/test_litellm/litellm_core_utils/test_core_helpers.py
+++ b/tests/test_litellm/litellm_core_utils/test_core_helpers.py
@@ -311,3 +311,26 @@ class TestIsExpectedClientError:
                 self.llm_provider = ""
 
         assert is_expected_client_error(RouterRejection()) is True
+
+    def test_budget_rejection_decorated_with_provider_is_expected(self):
+        """The auth handler stamps the requested model's provider onto the proxy's
+        own BudgetExceededError before logging it, which must not turn a key-over-budget
+        429 into a provider error that keeps its traceback."""
+        from litellm.exceptions import BudgetExceededError, RateLimitError, RateLimitErrorCategory
+        from litellm.litellm_core_utils.core_helpers import is_expected_client_error
+
+        over_budget = BudgetExceededError(current_cost=0.01, max_budget=0.0, llm_provider="anthropic")
+        assert over_budget.llm_provider == "anthropic"
+        assert is_expected_client_error(over_budget) is True
+
+        litellm_limit = RateLimitError(
+            message="key over rpm", llm_provider="anthropic", model="claude-haiku-4-5",
+            category=RateLimitErrorCategory.LITELLM_RATE_LIMIT,
+        )
+        assert is_expected_client_error(litellm_limit) is True
+
+        vendor_limit = RateLimitError(
+            message="rate limited upstream", llm_provider="anthropic", model="claude-haiku-4-5",
+            category=RateLimitErrorCategory.VENDOR_RATE_LIMIT,
+        )
+        assert is_expected_client_error(vendor_limit) is False

--- a/tests/test_litellm/litellm_core_utils/test_core_helpers.py
+++ b/tests/test_litellm/litellm_core_utils/test_core_helpers.py
@@ -278,3 +278,25 @@ class TestIsExpectedClientError:
         assert is_expected_client_error(WithCode("invalid_request_error")) is False
         assert is_expected_client_error(Exception("no status")) is False
         assert is_expected_client_error(None) is False
+
+    def test_provider_originated_4xx_is_not_expected(self):
+        """Regression for LIT-6163: a 4xx the provider returned is an upstream or
+        deployment problem, so it keeps its traceback; only the proxy's own
+        pre-call rejections (no llm_provider) are expected client errors."""
+        from litellm.exceptions import AuthenticationError, RateLimitError
+        from litellm.litellm_core_utils.core_helpers import is_expected_client_error
+
+        provider_auth_failure = AuthenticationError(
+            message="AnthropicException - API key is invalid.", llm_provider="anthropic", model="claude-haiku-4-5"
+        )
+        assert is_expected_client_error(provider_auth_failure) is False
+
+        provider_rate_limit = RateLimitError(message="rate limited upstream", llm_provider="openai", model="gpt-4o")
+        assert is_expected_client_error(provider_rate_limit) is False
+
+        class RouterRejection(Exception):
+            def __init__(self):
+                self.status_code = 429
+                self.llm_provider = ""
+
+        assert is_expected_client_error(RouterRejection()) is True

--- a/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
+++ b/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
@@ -5746,6 +5746,19 @@ def test_get_error_information_keeps_traceback_for_unmapped_provider_4xx():
     assert "test_litellm_logging" in result["traceback"]
 
 
+def test_get_error_information_skips_traceback_for_budget_rejection_with_provider():
+    """A key-over-budget 429 is the proxy's own rejection even after the auth
+    handler stamps the requested model's provider onto it, so it stays cheap."""
+    from litellm.litellm_core_utils.litellm_logging import StandardLoggingPayloadSetup
+
+    assert litellm.log_client_error_tracebacks is False
+    over_budget = _raise_and_catch(litellm.BudgetExceededError(current_cost=0.01, max_budget=0.0, llm_provider="anthropic"))
+    result = StandardLoggingPayloadSetup.get_error_information(over_budget)
+    assert result["error_code"] == "429"
+    assert result["llm_provider"] == "anthropic"
+    assert result["traceback"] == ""
+
+
 def test_failure_handler_helper_fn_builds_payload_once_per_exception():
     """Regression for LIT-6043: async and sync failure handlers both call
     _failure_handler_helper_fn for the same failed request; the standardized

--- a/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
+++ b/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
@@ -5732,6 +5732,20 @@ def test_get_error_information_keeps_traceback_for_provider_4xx():
     assert "test_litellm_logging" in result["traceback"]
 
 
+def test_get_error_information_keeps_traceback_for_unmapped_provider_4xx():
+    """Regression for LIT-6163 on /v1/messages: that route logs the provider's
+    raw BaseLLMException (no llm_provider), which still keeps its traceback."""
+    from litellm.litellm_core_utils.litellm_logging import StandardLoggingPayloadSetup
+    from litellm.llms.anthropic.common_utils import AnthropicError
+
+    assert litellm.log_client_error_tracebacks is False
+    raw_provider_exc = _raise_and_catch(AnthropicError(status_code=401, message='{"type":"authentication_error"}'))
+    result = StandardLoggingPayloadSetup.get_error_information(raw_provider_exc)
+    assert result["error_code"] == "401"
+    assert result["error_class"] == "AnthropicError"
+    assert "test_litellm_logging" in result["traceback"]
+
+
 def test_failure_handler_helper_fn_builds_payload_once_per_exception():
     """Regression for LIT-6043: async and sync failure handlers both call
     _failure_handler_helper_fn for the same failed request; the standardized

--- a/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
+++ b/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
@@ -5714,6 +5714,24 @@ def test_get_error_information_skips_traceback_for_expected_4xx(monkeypatch):
     assert "test_litellm_logging" in result["traceback"]
 
 
+def test_get_error_information_keeps_traceback_for_provider_4xx():
+    """Regression for LIT-6163: a 4xx the provider returned (invalid deployment
+    key, upstream validation) is an operator problem, so its traceback must
+    survive the expected-client-error gate and reach every payload consumer."""
+    from litellm.litellm_core_utils.litellm_logging import StandardLoggingPayloadSetup
+
+    assert litellm.log_client_error_tracebacks is False
+    provider_exc = _raise_and_catch(
+        litellm.AuthenticationError(
+            message="AnthropicException - API key is invalid.", llm_provider="anthropic", model="claude-haiku-4-5"
+        )
+    )
+    result = StandardLoggingPayloadSetup.get_error_information(provider_exc)
+    assert result["error_code"] == "401"
+    assert result["llm_provider"] == "anthropic"
+    assert "test_litellm_logging" in result["traceback"]
+
+
 def test_failure_handler_helper_fn_builds_payload_once_per_exception():
     """Regression for LIT-6043: async and sync failure handlers both call
     _failure_handler_helper_fn for the same failed request; the standardized


### PR DESCRIPTION
## TLDR

Problem this solves:

- Provider 4xx failures (bad deployment key) lost their traceback since #38102
- OTel error spans dropped `litellm.provider.error.stack_trace` on `/v1/chat/completions`, `/v1/responses`, and `/v1/messages`
- Scheduled e2e suite red on `test_failed_chat_completions_error_span_attributes` (litellm-e2e builds 68 to 70)

How it solves it:

- A 4xx that came back from a provider is never an expected client error: a mapped litellm exception carrying `llm_provider`, or the raw provider exception `/v1/messages` logs as-is
- The proxy's own pre-call 4xx rejections still skip the traceback, keeping #38102's CPU win, including the proxy's own rate limiters and the key-over-budget 429 even though the auth handler stamps an `llm_provider` on them
- Regression tests at the helper, standard logging payload, and OTel span levels

## User Flow

Before: an operator tracing LiteLLM into their OTel backend sees a provider auth failure span with no stack trace, so they cannot tell where in the gateway the call died

1. They register a deployment whose upstream key is wrong: POST https://litellm-domain/model/new with `{"model_name":"otel-err","litellm_params":{"model":"anthropic/claude-haiku-4-5","api_key":"<invalid>"}}` and get 200 with a model id
2. Their app sends POST https://litellm-domain/v1/chat/completions with `{"model":"otel-err","messages":[...]}` and gets 401 `litellm.AuthenticationError: AnthropicException - {"type":"error","error":{"type":"authentication_error","message":"API key is invalid."}}` plus an `x-litellm-call-id` header (POST https://litellm-domain/v1/responses and POST https://litellm-domain/v1/messages fail the same way)
3. They open that call id's trace in their OTel backend (e.g. http://jaeger-domain/search, service `litellm`): the `chat otel-err` span carries `error.type=AuthenticationError`, `litellm.provider.error.code=401`, and `litellm.provider.error.llm_provider=anthropic`, but no `litellm.provider.error.stack_trace` tag, so the trace ends at "the provider said no" with nothing about where the gateway was when it failed

After: the same span carries the stack trace, so the operator sees the gateway frames the failing provider call went through

1. They register a deployment whose upstream key is wrong: POST https://litellm-domain/model/new with `{"model_name":"otel-err","litellm_params":{"model":"anthropic/claude-haiku-4-5","api_key":"<invalid>"}}` and get 200 with a model id
2. Their app sends POST https://litellm-domain/v1/chat/completions with `{"model":"otel-err","messages":[...]}` and gets 401 `litellm.AuthenticationError: AnthropicException - {"type":"error","error":{"type":"authentication_error","message":"API key is invalid."}}` plus an `x-litellm-call-id` header (POST https://litellm-domain/v1/responses and POST https://litellm-domain/v1/messages fail the same way)
3. They open that call id's trace in their OTel backend: the `chat otel-err` span carries the same `error.type`, `litellm.provider.error.code`, and `litellm.provider.error.llm_provider` tags and now also `litellm.provider.error.stack_trace` with the gateway frames of the failed call, on all three routes

## Relevant issues

Regression from #38102

## Linear ticket

Resolves LIT-6163

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Shared setup for both legs: a local Jaeger (`docker run -d --name lit6163-jaeger -p 37398:16686 -p 49068:4318 jaegertracing/all-in-one`), a local Postgres with the schema pushed, and the proxy started with `--num_workers 2` and `LITELLM_OTEL_V2=1 PHOENIX_COLLECTOR_HTTP_ENDPOINT=http://localhost:49068/v1/traces` on this config (the deployment under test is registered through the API, not the config):

```yaml
model_list:
  - model_name: claude-haiku-4-5
    litellm_params:
      model: anthropic/claude-haiku-4-5
      api_key: os.environ/ANTHROPIC_API_KEY

litellm_settings:
  callbacks: ["arize_phoenix"]

general_settings:
  master_key: sk-1234
  store_model_in_db: true
```

Each leg registers one deployment with an invalid Anthropic key, sends it one request on each of `/v1/chat/completions`, `/v1/responses`, and `/v1/messages`, and reads every error span of that call id back from Jaeger's query API. The last case runs `tests/e2e/logging/test_otel_trace_e2e.py::TestOtelTraceCompleteness::test_failed_chat_completions_error_span_attributes` against the same proxy with `LITELLM_PROXY_URL=http://localhost:<port> E2E_OTEL_QUERY_URL=http://localhost:37398`, exactly what the scheduled suite runs

### Before (72b8b47ee8)

#### Register a deployment with an invalid Anthropic key

1. Register it

   ```
   curl -s http://localhost:45575/model/new -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' -d '{"model_name":"otel-err-before-20295","litellm_params":{"model":"anthropic/claude-haiku-4-5","api_key":"sk-upstream-invalid-for-langfuse-e2e-only"}}'
   ```

   ```
   {"model_name": "otel-err-before-20295", "model_id": "3b7c2127-8ffe-46b1-97b2-25b654dc525a"}
   ```

#### Chat completion through it

1. Send the request

   ```
   curl -s -D - http://localhost:45575/v1/chat/completions -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' -d '{"model":"otel-err-before-20295","messages":[{"role":"user","content":"trigger an upstream auth failure"}],"max_tokens":16}'
   ```

   ```
   HTTP/1.1 401 Unauthorized
   x-litellm-call-id: 1c27cdad-f558-42c2-9c16-0bc28bfceab9
   {"error":{"message":"litellm.AuthenticationError: AnthropicException - {\"type\":\"error\",\"error\":{\"type\":\"authentication_error\",\"message\":\"API key is invalid.\"},\"request_id\":null}. Received Model Group=otel
   ```

2. Read the error spans back from Jaeger

   ```
   curl -s 'http://localhost:37398/api/traces?service=litellm&tags=%7B%22litellm.call_id%22%3A%221c27cdad-f558-42c2-9c16-0bc28bfceab9%22%7D' | python3 -c '...print every litellm.provider.error.* and error.* tag of every span that carries error.type...'
   ```

   ```
   traces: 1 spans: ['auth /v1/chat/completions', 'chat otel-err-before-20295', 'postgres get_data', 'POST /v1/chat/completions']
     span: chat otel-err-before-20295
       error.type = 'AuthenticationError'
       litellm.provider.error.code = '401'
       litellm.provider.error.llm_provider = 'anthropic'
       litellm.provider.error.stack_trace present: False
     span: POST /v1/chat/completions
       error.type = 'ProxyException'
       litellm.provider.error.code = '401'
       litellm.provider.error.llm_provider = 'anthropic'
       litellm.provider.error.stack_trace present: False
   ```

#### Responses API through it

1. Send the request

   ```
   curl -s -D - http://localhost:45575/v1/responses -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' -d '{"model":"otel-err-before-20295","input":"trigger an upstream auth failure","max_output_tokens":16}'
   ```

   ```
   HTTP/1.1 401 Unauthorized
   x-litellm-call-id: 3c96d60c-96d6-4c0c-bbec-2f52340400e3
   {"error":{"message":"litellm.AuthenticationError: AnthropicException - {\"type\":\"error\",\"error\":{\"type\":\"authentication_error\",\"message\":\"API key is invalid.\"},\"request_id\":null}. Received Model Group=otel
   ```

2. Read the error spans back from Jaeger

   ```
   curl -s 'http://localhost:37398/api/traces?service=litellm&tags=%7B%22litellm.call_id%22%3A%223c96d60c-96d6-4c0c-bbec-2f52340400e3%22%7D' | python3 -c '...print every litellm.provider.error.* and error.* tag of every span that carries error.type...'
   ```

   ```
   traces: 1 spans: ['auth /v1/responses', 'chat otel-err-before-20295', 'postgres get_data', 'POST /v1/responses']
     span: chat otel-err-before-20295
       error.type = 'AuthenticationError'
       litellm.provider.error.code = '401'
       litellm.provider.error.llm_provider = 'anthropic'
       litellm.provider.error.stack_trace present: False
     span: POST /v1/responses
       error.type = 'ProxyException'
       litellm.provider.error.code = '401'
       litellm.provider.error.llm_provider = 'anthropic'
       litellm.provider.error.stack_trace present: False
   ```

#### Anthropic Messages API through it

1. Send the request

   ```
   curl -s -D - http://localhost:45575/v1/messages -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' -d '{"model":"otel-err-before-20295","messages":[{"role":"user","content":"trigger an upstream auth failure"}],"max_tokens":16}'
   ```

   ```
   HTTP/1.1 401 Unauthorized
   x-litellm-call-id: f1f91484-6082-4cb6-a7aa-1e30641462e2
   {"error":{"message":"{\"type\":\"error\",\"error\":{\"type\":\"authentication_error\",\"message\":\"API key is invalid.\"},\"request_id\":null}. Received Model Group=otel-err-before-20295\nAvailable Model Group Fallbacks
   ```

2. Read the error spans back from Jaeger

   ```
   curl -s 'http://localhost:37398/api/traces?service=litellm&tags=%7B%22litellm.call_id%22%3A%22f1f91484-6082-4cb6-a7aa-1e30641462e2%22%7D' | python3 -c '...print every litellm.provider.error.* and error.* tag of every span that carries error.type...'
   ```

   ```
   traces: 1 spans: ['postgres get_data', 'POST /v1/messages', 'auth /v1/messages', 'chat otel-err-before-20295']
     span: POST /v1/messages
       error.type = 'ProxyException'
       litellm.provider.error.code = '401'
       litellm.provider.error.stack_trace present: False
     span: chat otel-err-before-20295
       error.type = 'BaseLLMException'
       litellm.provider.error.code = '401'
       litellm.provider.error.stack_trace present: False
   ```

#### The scheduled e2e test against the same proxy

1. Run the test

   ```
   LITELLM_PROXY_URL=http://localhost:45575 LITELLM_MASTER_KEY=sk-1234 E2E_OTEL_QUERY_URL=http://localhost:37398 .venv/bin/python -m pytest "tests/e2e/logging/test_otel_trace_e2e.py::TestOtelTraceCompleteness::test_failed_chat_completions_error_span_attributes" -p no:cacheprovider -q
   ```

   ```
           stack = _tag(span, "litellm.provider.error.stack_trace")
   >       assert isinstance(stack, str) and stack, (
               "the error span must carry a non-empty litellm.provider.error.stack_trace"
           )
   E       AssertionError: the error span must carry a non-empty litellm.provider.error.stack_trace
   E       assert (False)
   E        +  where False = isinstance(None, str)
   tests/e2e/logging/test_otel_trace_e2e.py:283: AssertionError
   1 failed in 21.03s
   ```

### After (514cae1b3d)

#### Register a deployment with an invalid Anthropic key

1. Register it

   ```
   curl -s http://localhost:57641/model/new -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' -d '{"model_name":"otel-err-after5-12755","litellm_params":{"model":"anthropic/claude-haiku-4-5","api_key":"sk-upstream-invalid-for-langfuse-e2e-only"}}'
   ```

   ```
   {"model_name": "otel-err-after5-12755", "model_id": "d7d9404d-594a-43f8-ae6e-68dc62e29d8b"}
   ```

#### Chat completion through it

1. Send the request

   ```
   curl -s -D - http://localhost:57641/v1/chat/completions -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' -d '{"model":"otel-err-after5-12755","messages":[{"role":"user","content":"trigger an upstream auth failure"}],"max_tokens":16}'
   ```

   ```
   HTTP/1.1 401 Unauthorized
   x-litellm-call-id: 02be2ff7-293f-4231-811b-cf2c53338d10
   {"error":{"message":"litellm.AuthenticationError: AnthropicException - {\"type\":\"error\",\"error\":{\"type\":\"authentication_error\",\"message\":\"API key is invalid.\"},\"request_id\":null}. Received Model Group=otel
   ```

2. Read the error spans back from Jaeger

   ```
   curl -s 'http://localhost:37398/api/traces?service=litellm&tags=%7B%22litellm.call_id%22%3A%2202be2ff7-293f-4231-811b-cf2c53338d10%22%7D' | python3 -c '...print every litellm.provider.error.* and error.* tag of every span that carries error.type...'
   ```

   ```
   traces: 1 spans: ['auth /v1/chat/completions', 'chat otel-err-after5-12755', 'postgres get_data', 'POST /v1/chat/completions']
     span: chat otel-err-after5-12755
       error.type = 'AuthenticationError'
       litellm.provider.error.code = '401'
       litellm.provider.error.llm_provider = 'anthropic'
       litellm.provider.error.stack_trace = '  File "/Users/mateo/Development/litellm_fix_otel_provider_error_stack_trace/litellm/utils.py", line 1856, in wrapper_async\n    result = awa' ... (1007 chars)
       litellm.provider.error.stack_trace present: True
     span: POST /v1/chat/completions
       error.type = 'ProxyException'
       litellm.provider.error.code = '401'
       litellm.provider.error.llm_provider = 'anthropic'
       litellm.provider.error.stack_trace = '  File "/Users/mateo/Development/litellm_fix_otel_provider_error_stack_trace/litellm/proxy/proxy_server.py", line 10107, in chat_completion\n' ... (4429 chars)
       litellm.provider.error.stack_trace present: True
   ```

#### Responses API through it

1. Send the request

   ```
   curl -s -D - http://localhost:57641/v1/responses -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' -d '{"model":"otel-err-after5-12755","input":"trigger an upstream auth failure","max_output_tokens":16}'
   ```

   ```
   HTTP/1.1 401 Unauthorized
   x-litellm-call-id: 8da5a7f5-69b1-47c5-8187-85af5c7cd0c1
   {"error":{"message":"litellm.AuthenticationError: AnthropicException - {\"type\":\"error\",\"error\":{\"type\":\"authentication_error\",\"message\":\"API key is invalid.\"},\"request_id\":null}. Received Model Group=otel
   ```

2. Read the error spans back from Jaeger

   ```
   curl -s 'http://localhost:37398/api/traces?service=litellm&tags=%7B%22litellm.call_id%22%3A%228da5a7f5-69b1-47c5-8187-85af5c7cd0c1%22%7D' | python3 -c '...print every litellm.provider.error.* and error.* tag of every span that carries error.type...'
   ```

   ```
   traces: 1 spans: ['auth /v1/responses', 'chat otel-err-after5-12755', 'postgres get_data', 'POST /v1/responses']
     span: chat otel-err-after5-12755
       error.type = 'AuthenticationError'
       litellm.provider.error.code = '401'
       litellm.provider.error.llm_provider = 'anthropic'
       litellm.provider.error.stack_trace = '  File "/Users/mateo/Development/litellm_fix_otel_provider_error_stack_trace/litellm/utils.py", line 1856, in wrapper_async\n    result = awa' ... (1007 chars)
       litellm.provider.error.stack_trace present: True
     span: POST /v1/responses
       error.type = 'ProxyException'
       litellm.provider.error.code = '401'
       litellm.provider.error.llm_provider = 'anthropic'
       litellm.provider.error.stack_trace = '  File "/Users/mateo/Development/litellm_fix_otel_provider_error_stack_trace/litellm/proxy/response_api_endpoints/endpoints.py", line 340, i' ... (6284 chars)
       litellm.provider.error.stack_trace present: True
   ```

#### Anthropic Messages API through it

1. Send the request

   ```
   curl -s -D - http://localhost:57641/v1/messages -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' -d '{"model":"otel-err-after5-12755","messages":[{"role":"user","content":"trigger an upstream auth failure"}],"max_tokens":16}'
   ```

   ```
   HTTP/1.1 401 Unauthorized
   x-litellm-call-id: 2c781610-d163-4562-901d-0a1c58408839
   {"error":{"message":"{\"type\":\"error\",\"error\":{\"type\":\"authentication_error\",\"message\":\"API key is invalid.\"},\"request_id\":null}. Received Model Group=otel-err-after5-12755\nAvailable Model Group Fallbacks=
   ```

2. Read the error spans back from Jaeger

   ```
   curl -s 'http://localhost:37398/api/traces?service=litellm&tags=%7B%22litellm.call_id%22%3A%222c781610-d163-4562-901d-0a1c58408839%22%7D' | python3 -c '...print every litellm.provider.error.* and error.* tag of every span that carries error.type...'
   ```

   ```
   traces: 1 spans: ['auth /v1/messages', 'chat otel-err-after5-12755', 'postgres get_data', 'POST /v1/messages']
     span: chat otel-err-after5-12755
       error.type = 'BaseLLMException'
       litellm.provider.error.code = '401'
       litellm.provider.error.stack_trace = '  File "/Users/mateo/Development/litellm_fix_otel_provider_error_stack_trace/litellm/utils.py", line 1856, in wrapper_async\n    result = awa' ... (1350 chars)
       litellm.provider.error.stack_trace present: True
     span: POST /v1/messages
       error.type = 'ProxyException'
       litellm.provider.error.code = '401'
       litellm.provider.error.stack_trace = '  File "/Users/mateo/Development/litellm_fix_otel_provider_error_stack_trace/litellm/proxy/anthropic_endpoints/endpoints.py", line 97, in an' ... (5754 chars)
       litellm.provider.error.stack_trace present: True
   ```

#### The scheduled e2e test against the same proxy

1. Run the test

   ```
   LITELLM_PROXY_URL=http://localhost:57641 LITELLM_MASTER_KEY=sk-1234 E2E_OTEL_QUERY_URL=http://localhost:37398 .venv/bin/python -m pytest "tests/e2e/logging/test_otel_trace_e2e.py::TestOtelTraceCompleteness::test_failed_chat_completions_error_span_attributes" -p no:cacheprovider -q
   ```

   ```
   .                                                                        [100%]
   1 passed in 20.37s
   ```

QA observations:

- `/v1/messages` error spans report `error.type=BaseLLMException`, no `llm_provider` tag; pre-existing, left alone
- `/v1/messages` 401 body lacks the `litellm.AuthenticationError` prefix; pre-existing, left alone

#### Neighbouring paths, live A/B (base 72b8b47ee8 vs 514cae1b3d, 2 workers each, spans read from Jaeger)

| Scenario | Status | Base stack_trace | Tip stack_trace |
|---|---|---|---|
| Valid key, valid model | 200 | n/a | n/a |
| Invalid virtual key | 401 | absent | absent |
| Unknown model (#38102 flow) | 400 | absent | absent |
| Key over budget | 429 | absent | absent |
| Key rpm_limit=1 hit | 429 | absent | absent |
| Provider 401, non-streaming | 401 | absent | present |
| Provider 401, streaming | 401 | absent | present |
| Provider 400 (temperature 5) | 400 | absent | present |

Response bodies and statuses were identical on both sides for every row. The key-over-budget row carried a stack trace at a6e1708e6c because the auth handler stamps the model's provider onto the budget error; 514cae1b3d closes that

## Type

🐛 Bug Fix

## Caveats (if any)

### Low

- Provider 429s and 4xx validation errors regain their traceback too, as intended
  - Bounded by upstream round trips, so they cannot saturate a worker the way local rejections could
- Router "no deployments available" errors carry an empty `llm_provider`, so they still count as expected client errors
- The proxy's own rate limiters raise an `HTTPException` subclass that carries an `llm_provider`, and the auth handler stamps one onto `BudgetExceededError`, so the `HTTPException` check and litellm's own rate-limit `category` both run before the `llm_provider` carve-out and keep them expected

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
- [x] 514cae1b3dc1ff72fdf5b10aa440e75b523c207d passes /live-pr-risk

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes classification of exceptions on the hot logging path; misclassification could either leak tracebacks for cheap local 4xx or drop them for operator-critical upstream failures, but behavior is heavily regression-tested.
> 
> **Overview**
> Fixes a regression where **upstream provider 4xx** (bad deployment key, invalid upstream auth) were treated like local proxy rejections, so standard logging and OTel v2 dropped stack traces from error payloads and `litellm.provider.error.stack_trace` on LLM error spans.
> 
> **`is_expected_client_error`** in `core_helpers.py` is narrowed: only **proxy-side** rejections before a provider call stay “expected” (no traceback when `log_client_error_tracebacks` is off). New helpers distinguish proxy vs provider via **`HTTPException`**, LiteLLM rate-limit **`category`**, **`llm_provider`**, and **`BaseLLMException`**. Proxy budget and LiteLLM limiter 429s remain expected even when auth decorates them with a model provider.
> 
> Regression tests cover the helper, **`StandardLoggingPayloadSetup.get_error_information`**, and OTel v2 failure spans (mapped and unmapped provider errors on `/v1/messages`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 514cae1b3dc1ff72fdf5b10aa440e75b523c207d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->