### PR TITLE
test(together_ai): expect tools to pass through for models without a function calling entry

### DIFF
--- a/tests/llm_translation/test_together_ai.py
+++ b/tests/llm_translation/test_together_ai.py
@@ -23,26 +23,20 @@ class TestTogetherAI(BaseLLMChatTest):
         pass
 
     @pytest.mark.parametrize(
-        "model, expected_bool",
+        "model, supports_response_format",
         [
             ("meta-llama/Meta-Llama-3.1-8B-Instruct-Turbo", True),
             ("nvidia/Llama-3.1-Nemotron-70B-Instruct-HF", False),
         ],
     )
     def test_get_supported_response_format_together_ai(
-        self, model: str, expected_bool: bool
+        self, model: str, supports_response_format: bool
     ) -> None:
         os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = "True"
         litellm.model_cost = litellm.get_model_cost_map(url="")
         optional_params = litellm.get_supported_openai_params(
             model, custom_llm_provider="together_ai"
         )
-        # Mapped provider
         assert isinstance(optional_params, list)
-
-        if expected_bool:
-            assert "response_format" in optional_params
-            assert "tools" in optional_params
-        else:
-            assert "response_format" not in optional_params
-            assert "tools" not in optional_params
+        assert ("response_format" in optional_params) is supports_response_format
+        assert "tools" in optional_params


### PR DESCRIPTION
## TLDR

Problem this solves:

- CI on litellm_internal_staging fails in `llm_translation_testing` since #38265 merged
- `test_get_supported_response_format_together_ai` still asserts `tools` is dropped for Nemotron
- #38265 deliberately passes `tools` through for models without a function-calling entry

How it solves it:

- The test now expects `tools` in the supported params for both models
- `response_format` stays gated on the registry, so that assertion is unchanged

## User Flow

Before: a maintainer watching CI on litellm_internal_staging sees the together_ai test job red on every push

1. They open https://app.circleci.com/pipelines/github/BerriAI/litellm/88669/workflows/7e7cff9b-5f81-47bc-9377-555351c9a8f1/jobs/2137086/tests
2. `llm_translation_testing` shows one failure: `test_get_supported_response_format_together_ai[nvidia/Llama-3.1-Nemotron-70B-Instruct-HF-False]`
3. The assertion reads `assert 'tools' not in [...]`, even though sending `tools` for that model to POST https://litellm-domain/v1/chat/completions works as intended since #38265

After: the same job goes green and the together_ai test agrees with what the gateway does

1. They open the `llm_translation_testing` job for the next push to litellm_internal_staging
2. `test_get_supported_response_format_together_ai` passes for both parametrized models
3. Sending `tools` for `together_ai/nvidia/Llama-3.1-Nemotron-70B-Instruct-HF` to POST https://litellm-domain/v1/chat/completions still passes them through, unchanged from #38265

## Relevant issues

Follow-up to #38265

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

This PR only changes a test, so the proof is the test run itself at the merge base and at the tip, with the CircleCI job that first went red as the Before

### Before (273b01af6c)

1. CI: https://app.circleci.com/pipelines/github/BerriAI/litellm/88669/workflows/7e7cff9b-5f81-47bc-9377-555351c9a8f1/jobs/2137086/tests fails with `AssertionError: assert 'tools' not in ['frequency_penalty', 'logit_bias', ...]`
2. `uv run pytest tests/llm_translation/test_together_ai.py -k test_get_supported_response_format_together_ai -q`
3. `FAILED tests/llm_translation/test_together_ai.py::TestTogetherAI::test_get_supported_response_format_together_ai[nvidia/Llama-3.1-Nemotron-70B-Instruct-HF-False]` and `1 failed, 1 passed`

### After (86091a9ec3)

1. `uv run pytest tests/llm_translation/test_together_ai.py -k test_get_supported_response_format_together_ai -q`
2. `2 passed, 39 deselected`
3. The same test at the commit before #38265 (dc40377959) fails on `assert "tools" in optional_params`, so it now guards the pass-through behavior instead of the old drop

## Type

✅ Test

## Caveats (if any)

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR


- [x] 86091a9ec3 passes /live-pr-risk
