### PR TITLE
refactor(ui): install the shadcn alert primitive

### DIFF
--- a/ui/litellm-dashboard/eslint-suppressions.json
+++ b/ui/litellm-dashboard/eslint-suppressions.json
@@ -2133,6 +2133,11 @@
       "count": 1
     }
   },
+  "src/components/ui/alert.tsx": {
+    "local/filename-pascal-case": {
+      "count": 1
+    }
+  },
   "src/components/ui/avatar.tsx": {
     "local/filename-pascal-case": {
       "count": 1

--- a/ui/litellm-dashboard/src/components/shared/Alert.tsx
+++ b/ui/litellm-dashboard/src/components/shared/Alert.tsx
@@ -1,75 +1,32 @@
-import * as React from "react";
+import type * as React from "react";
 
-import { cva, type VariantProps } from "class-variance-authority";
-
+import { Alert as AlertPrimitive, AlertAction, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { cn } from "@/lib/cva.config";
 
-const alertVariants = cva(
-  "group/alert relative grid w-full gap-0.5 rounded-lg border px-4 py-3 text-left text-sm has-data-[slot=alert-action]:relative has-data-[slot=alert-action]:pr-18 has-[>svg]:grid-cols-[auto_1fr] has-[>svg]:gap-x-2.5 *:[svg]:row-span-2 *:[svg]:translate-y-0.5 *:[svg]:text-current *:[svg:not([class*='size-'])]:size-4",
-  {
-    variants: {
-      variant: {
-        default: "bg-card text-card-foreground",
-        destructive:
-          "bg-card text-destructive *:data-[slot=alert-description]:text-destructive/90 *:[svg]:text-current",
-        info: "border-info/20 bg-info/5 text-info *:[svg]:text-current",
-        success: "border-success/20 bg-success/5 text-success *:[svg]:text-current",
-        warning: "border-warning/20 bg-warning/5 text-warning *:[svg]:text-current",
-        error:
-          "border-destructive/20 bg-destructive/10 text-destructive *:data-[slot=alert-description]:text-destructive/90 *:[svg]:text-destructive",
-      },
-    },
-    defaultVariants: {
-      variant: "default",
-    },
-  },
-);
+const STATUS_VARIANT_CLASSES = {
+  info: "border-info/20 bg-info/5 text-info *:[svg]:text-current",
+  success: "border-success/20 bg-success/5 text-success *:[svg]:text-current",
+  warning: "border-warning/20 bg-warning/5 text-warning *:[svg]:text-current",
+  error:
+    "border-destructive/20 bg-destructive/10 text-destructive *:data-[slot=alert-description]:text-destructive/90 *:[svg]:text-destructive",
+} as const;
 
-type AlertProps = React.ComponentProps<"div"> & VariantProps<typeof alertVariants>;
+type StatusVariant = keyof typeof STATUS_VARIANT_CLASSES;
+type AlertVariant = NonNullable<React.ComponentProps<typeof AlertPrimitive>["variant"]> | StatusVariant;
 
-const Alert = React.forwardRef<HTMLDivElement, AlertProps>(({ className, variant = "default", ...props }, ref) => (
-  <div
-    ref={ref}
-    data-slot="alert"
+type AlertProps = Omit<React.ComponentProps<typeof AlertPrimitive>, "variant"> & {
+  variant?: AlertVariant;
+};
+
+const isStatusVariant = (variant: AlertVariant): variant is StatusVariant => variant in STATUS_VARIANT_CLASSES;
+
+const Alert = ({ variant = "default", className, ...props }: AlertProps) => (
+  <AlertPrimitive
     data-variant={variant}
-    role="alert"
-    className={cn(alertVariants({ variant }), className)}
+    variant={variant === "destructive" ? "destructive" : "default"}
+    className={cn(isStatusVariant(variant) ? STATUS_VARIANT_CLASSES[variant] : undefined, className)}
     {...props}
   />
-));
-Alert.displayName = "Alert";
-
-const AlertTitle = React.forwardRef<HTMLDivElement, React.ComponentProps<"div">>(({ className, ...props }, ref) => (
-  <div
-    ref={ref}
-    data-slot="alert-title"
-    className={cn(
-      "font-medium group-has-[>svg]/alert:col-start-2 [&_a]:underline [&_a]:underline-offset-3 [&_a]:hover:text-foreground",
-      className,
-    )}
-    {...props}
-  />
-));
-AlertTitle.displayName = "AlertTitle";
-
-const AlertDescription = React.forwardRef<HTMLDivElement, React.ComponentProps<"div">>(
-  ({ className, ...props }, ref) => (
-    <div
-      ref={ref}
-      data-slot="alert-description"
-      className={cn(
-        "text-sm text-balance text-muted-foreground md:text-pretty [&_a]:underline [&_a]:underline-offset-3 [&_a]:hover:text-foreground [&_p:not(:last-child)]:mb-4",
-        className,
-      )}
-      {...props}
-    />
-  ),
 );
-AlertDescription.displayName = "AlertDescription";
-
-const AlertAction = React.forwardRef<HTMLDivElement, React.ComponentProps<"div">>(({ className, ...props }, ref) => (
-  <div ref={ref} data-slot="alert-action" className={cn("absolute top-2.5 right-3", className)} {...props} />
-));
-AlertAction.displayName = "AlertAction";
 
 export { Alert, AlertTitle, AlertDescription, AlertAction };

--- a/ui/litellm-dashboard/src/components/ui/alert.tsx
+++ b/ui/litellm-dashboard/src/components/ui/alert.tsx
@@ -1,0 +1,56 @@
+import * as React from "react";
+import { cva, type VariantProps } from "class-variance-authority";
+
+import { cn } from "@/lib/cva.config";
+
+const alertVariants = cva(
+  "group/alert relative grid w-full gap-0.5 rounded-lg border px-4 py-3 text-left text-sm has-data-[slot=alert-action]:relative has-data-[slot=alert-action]:pr-18 has-[>svg]:grid-cols-[auto_1fr] has-[>svg]:gap-x-2.5 *:[svg]:row-span-2 *:[svg]:translate-y-0.5 *:[svg]:text-current *:[svg:not([class*='size-'])]:size-4",
+  {
+    variants: {
+      variant: {
+        default: "bg-card text-card-foreground",
+        destructive:
+          "bg-card text-destructive *:data-[slot=alert-description]:text-destructive/90 *:[svg]:text-current",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  },
+);
+
+function Alert({ className, variant, ...props }: React.ComponentProps<"div"> & VariantProps<typeof alertVariants>) {
+  return <div data-slot="alert" role="alert" className={cn(alertVariants({ variant }), className)} {...props} />;
+}
+
+function AlertTitle({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-title"
+      className={cn(
+        "font-medium group-has-[>svg]/alert:col-start-2 [&_a]:underline [&_a]:underline-offset-3 [&_a]:hover:text-foreground",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function AlertDescription({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-description"
+      className={cn(
+        "text-sm text-balance text-muted-foreground md:text-pretty [&_a]:underline [&_a]:underline-offset-3 [&_a]:hover:text-foreground [&_p:not(:last-child)]:mb-4",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function AlertAction({ className, ...props }: React.ComponentProps<"div">) {
+  return <div data-slot="alert-action" className={cn("absolute top-2.5 right-3", className)} {...props} />;
+}
+
+export { Alert, AlertTitle, AlertDescription, AlertAction };


### PR DESCRIPTION
## TLDR

Problem this solves:

- `shared/Alert.tsx` is base-vega's `alert.tsx` copied in by hand
- `npx shadcn add` cannot reach it, so it drifts from upstream
- It still wraps every part in `forwardRef`, which React 19 dropped the need for

How it solves it:

- Install the primitive into `components/ui/` where the CLI owns it
- Reduce the shared file to a wrapper adding four status variants
- Rendered classes stay byte-identical, so no call site moves

## User Flow

This is a no-op refactor, so the two lists are identical by design. An admin sees the same alerts, in the same colours, on the same routes, before and after

Before: an admin loads the dashboard and sees the standard alerts

1. They open http://localhost:4000/ui/?page=api-keys with the proxy started under `--detailed_debug` and see an amber "Performance Warning: Detailed Debug Mode Active" banner across the top
2. They switch the theme toggle to dark and the banner stays amber on the dark surface
3. They open http://localhost:4000/ui/?page=admin-settings, pick SCIM, and see a blue "Using SCIM" notice

After: the same admin sees exactly the same three things

1. They open http://localhost:4000/ui/?page=api-keys with the proxy started under `--detailed_debug` and see an amber "Performance Warning: Detailed Debug Mode Active" banner across the top
2. They switch the theme toggle to dark and the banner stays amber on the dark surface
3. They open http://localhost:4000/ui/?page=admin-settings, pick SCIM, and see a blue "Using SCIM" notice

## Relevant issues

## Linear ticket

## Pre-Submission checklist

- [ ] I have added meaningful tests
- [x] The handful of test files covering my change pass locally
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

Setup: start the proxy with `python litellm/proxy/proxy_cli.py --config litellm/proxy/dev_config.yaml --detailed_debug --reload`, then run `npm run dev` in `ui/litellm-dashboard` and sign in at http://localhost:3000

### Before (3e2927de9a)

#### Warning alert, both themes

1. Open http://localhost:3000/?page=api-keys and screenshot the amber debug banner at the top of the page
2. Click the theme toggle in the top bar to switch to dark, and screenshot the same banner

#### Info alert, both themes

1. Open http://localhost:3000/?page=admin-settings, select SCIM, and screenshot the blue "Using SCIM" notice
2. Switch the theme toggle to dark and screenshot the same notice

### After (a5b6f31585)

#### Warning alert, both themes

1. Open http://localhost:3000/?page=api-keys and screenshot the amber debug banner at the top of the page
2. Click the theme toggle in the top bar to switch to dark, and screenshot the same banner

#### Info alert, both themes

1. Open http://localhost:3000/?page=admin-settings, select SCIM, and screenshot the blue "Using SCIM" notice
2. Switch the theme toggle to dark and screenshot the same notice

## Type

🧹 Refactoring

## Caveats (if any)

### Low

- Upstream's `alertVariants` is not exported, so the wrapper appends its status classes and leans on twMerge to settle the overlap
- `ui/alert.tsx` takes the same `filename-pascal-case` suppression every other CLI-managed primitive carries
- No new test: `shared/Alert.test.tsx` already covers all six variants and is the gate here, kept unedited. It fails when a status variant loses its token colour, checked by mutating the info variant and watching it go red

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
