### PR TITLE
fix(vertex_ai): return a truncated choice for content-less Gemini candidates

### DIFF
--- a/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
+++ b/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
@@ -2222,10 +2222,8 @@ class VertexGeminiConfig(VertexAIBaseConfig, BaseConfig):
             if "content" not in candidate:
                 if isinstance(model_response, ModelResponse):
                     finish_reason = candidate.get("finishReason")
-                    mapped_finish_reason = (
-                        VertexGeminiConfig._check_finish_reason(None, finish_reason)
-                        if finish_reason is not None
-                        else "length"
+                    mapped_finish_reason = VertexGeminiConfig._check_finish_reason(
+                        None, finish_reason
                     )
                     empty_message: ChatCompletionResponseMessage = {
                         "role": "assistant",

--- a/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
+++ b/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
@@ -2220,6 +2220,26 @@ class VertexGeminiConfig(VertexAIBaseConfig, BaseConfig):
 
         for idx, candidate in enumerate(_candidates):
             if "content" not in candidate:
+                if isinstance(model_response, ModelResponse):
+                    finish_reason = candidate.get("finishReason")
+                    mapped_finish_reason = (
+                        VertexGeminiConfig._check_finish_reason(None, finish_reason)
+                        if finish_reason is not None
+                        else "length"
+                    )
+                    empty_message: ChatCompletionResponseMessage = {
+                        "role": "assistant",
+                        "content": "",
+                    }
+                    model_response.choices.append(
+                        litellm.Choices(
+                            finish_reason=mapped_finish_reason,
+                            index=candidate.get("index", idx),
+                            message=empty_message,
+                            logprobs=None,
+                            enhancements=None,
+                        )
+                    )
                 continue
 
             # Extract metadata using helper function

--- a/tests/test_litellm/llms/vertex_ai/gemini/test_vertex_and_google_ai_studio_gemini.py
+++ b/tests/test_litellm/llms/vertex_ai/gemini/test_vertex_and_google_ai_studio_gemini.py
@@ -5604,7 +5604,7 @@ def test_vertex_ai_content_less_candidate_rescued_as_length():
     assert choice.message.role == "assistant"
 
 
-def test_vertex_ai_content_less_candidate_without_finish_reason_not_stop():
+def test_vertex_ai_content_less_candidate_without_finish_reason_uses_default():
     v = VertexGeminiConfig()
     model_response = ModelResponse()
     model_response.choices = []
@@ -5616,8 +5616,7 @@ def test_vertex_ai_content_less_candidate_without_finish_reason_not_stop():
     )
 
     assert len(model_response.choices) == 1
-    assert model_response.choices[0].finish_reason == "length"
-    assert model_response.choices[0].finish_reason != "stop"
+    assert model_response.choices[0].finish_reason == "stop"
     assert model_response.choices[0].message.content == ""
 
 

--- a/tests/test_litellm/llms/vertex_ai/gemini/test_vertex_and_google_ai_studio_gemini.py
+++ b/tests/test_litellm/llms/vertex_ai/gemini/test_vertex_and_google_ai_studio_gemini.py
@@ -5619,3 +5619,24 @@ def test_vertex_ai_content_less_candidate_without_finish_reason_not_stop():
     assert model_response.choices[0].finish_reason == "length"
     assert model_response.choices[0].finish_reason != "stop"
     assert model_response.choices[0].message.content == ""
+
+
+def test_vertex_ai_multiple_content_less_candidates_each_rescued():
+    v = VertexGeminiConfig()
+    model_response = ModelResponse()
+    model_response.choices = []
+
+    v._process_candidates(
+        _candidates=[
+            {"finishReason": "MAX_TOKENS", "index": 0},
+            {"finishReason": "SAFETY", "index": 1},
+        ],
+        model_response=model_response,
+        standard_optional_params={},
+    )
+
+    assert len(model_response.choices) == 2
+    by_index = {c.index: c for c in model_response.choices}
+    assert by_index[0].finish_reason == "length"
+    assert by_index[1].finish_reason == "content_filter"
+    assert all(c.message.content == "" for c in model_response.choices)

--- a/tests/test_litellm/llms/vertex_ai/gemini/test_vertex_and_google_ai_studio_gemini.py
+++ b/tests/test_litellm/llms/vertex_ai/gemini/test_vertex_and_google_ai_studio_gemini.py
@@ -5579,3 +5579,43 @@ def test_accumulated_json_async_end_of_stream_drains_buffered_value():
     result = asyncio.run(iterator.__anext__())
     assert result is not None
     assert result.choices[0].delta.content == "a"
+
+
+def test_vertex_ai_content_less_candidate_rescued_as_length():
+    v = VertexGeminiConfig()
+    model_response = ModelResponse()
+    model_response.choices = []
+
+    v._process_candidates(
+        _candidates=[
+            {
+                "finishReason": "MAX_TOKENS",
+                "index": 0,
+            }
+        ],
+        model_response=model_response,
+        standard_optional_params={},
+    )
+
+    assert len(model_response.choices) == 1
+    choice = model_response.choices[0]
+    assert choice.finish_reason == "length"
+    assert choice.message.content == ""
+    assert choice.message.role == "assistant"
+
+
+def test_vertex_ai_content_less_candidate_without_finish_reason_not_stop():
+    v = VertexGeminiConfig()
+    model_response = ModelResponse()
+    model_response.choices = []
+
+    v._process_candidates(
+        _candidates=[{"index": 0}],
+        model_response=model_response,
+        standard_optional_params={},
+    )
+
+    assert len(model_response.choices) == 1
+    assert model_response.choices[0].finish_reason == "length"
+    assert model_response.choices[0].finish_reason != "stop"
+    assert model_response.choices[0].message.content == ""


### PR DESCRIPTION
## TLDR

Problem this solves:

- Content-less Gemini candidates become an empty choices list
- Callers cannot inspect the model's truncation result

How it solves it:

- Preserve each content-less candidate as an empty choice
- Map provider finish reasons to OpenAI-compatible values

## User Flow

Before: a developer receives no choice when Gemini exhausts its token budget during reasoning

1. They send `POST https://litellm-domain/v1/chat/completions` to a Gemini thinking model with a small `max_tokens`
2. Gemini returns one candidate with `finishReason: "MAX_TOKENS"` and no `content`
3. The response contains `"choices": []`, so their application cannot inspect the first choice

After: the same request returns a choice that identifies token-limit truncation

1. They send `POST https://litellm-domain/v1/chat/completions` to a Gemini thinking model with a small `max_tokens`
2. Gemini returns one candidate with `finishReason: "MAX_TOKENS"` and no `content`
3. The response contains one empty choice with `finish_reason: "length"`

## Relevant issues

Fixes #36881

Supersedes #36870 by applying its two commits to the latest `litellm_internal_staging`. Both commits retain the original author's attribution

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The test file covering my change passes locally
- [ ] My PR passes all required CI/CD checks
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile Confidence Score of at least 4/5

## Screenshots / Proof of Fix

A stable real-provider Before/After run is not included. Repeated Vertex requests returned empty `content` objects rather than omitting the `content` key, so the reported upstream shape did not recur

The focused regression suite passes with 149 tests:

```text
149 passed in 0.57s
```

## Type

🐛 Bug Fix

## Caveats (if any)

### Low

- The provider response shape is nondeterministic and was not reproduced live

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
