### PR TITLE
refactor(ui): re-pull label, textarea, separator and skeleton from the registry

### DIFF
--- a/ui/litellm-dashboard/src/components/ui/label.tsx
+++ b/ui/litellm-dashboard/src/components/ui/label.tsx
@@ -4,10 +4,9 @@ import * as React from "react";
 
 import { cn } from "@/lib/cva.config";
 
-const Label = React.forwardRef<HTMLLabelElement, React.ComponentPropsWithoutRef<"label">>(
-  ({ className, ...props }, ref) => (
+function Label({ className, ...props }: React.ComponentProps<"label">) {
+  return (
     <label
-      ref={ref}
       data-slot="label"
       className={cn(
         "flex items-center gap-2 text-sm leading-none font-medium select-none group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 peer-disabled:cursor-not-allowed peer-disabled:opacity-50",
@@ -15,8 +14,7 @@ const Label = React.forwardRef<HTMLLabelElement, React.ComponentPropsWithoutRef<
       )}
       {...props}
     />
-  ),
-);
-Label.displayName = "Label";
+  );
+}
 
 export { Label };

--- a/ui/litellm-dashboard/src/components/ui/ref-forwarding.test.tsx
+++ b/ui/litellm-dashboard/src/components/ui/ref-forwarding.test.tsx
@@ -11,6 +11,7 @@ import { Label } from "./label";
 import { Separator } from "./separator";
 import { Skeleton } from "./skeleton";
 import { Table, TableBody, TableCaption, TableCell, TableFooter, TableHead, TableHeader, TableRow } from "./table";
+import { Textarea } from "./textarea";
 import { UiLoadingSpinner } from "./ui-loading-spinner";
 
 describe("ui primitives forward refs to their DOM node", () => {
@@ -48,6 +49,12 @@ describe("ui primitives forward refs to their DOM node", () => {
     const ref = React.createRef<HTMLDivElement>();
     render(<Skeleton ref={ref} />);
     expect(ref.current).toBeInstanceOf(HTMLDivElement);
+  });
+
+  it("Textarea", () => {
+    const ref = React.createRef<HTMLTextAreaElement>();
+    render(<Textarea ref={ref} />);
+    expect(ref.current).toBeInstanceOf(HTMLTextAreaElement);
   });
 
   it("UiLoadingSpinner", () => {

--- a/ui/litellm-dashboard/src/components/ui/separator.tsx
+++ b/ui/litellm-dashboard/src/components/ui/separator.tsx
@@ -1,14 +1,12 @@
 "use client";
 
 import { Separator as SeparatorPrimitive } from "@base-ui/react/separator";
-import * as React from "react";
 
 import { cn } from "@/lib/cva.config";
 
-const Separator = React.forwardRef<React.ComponentRef<typeof SeparatorPrimitive>, SeparatorPrimitive.Props>(
-  ({ className, orientation = "horizontal", ...props }, ref) => (
+function Separator({ className, orientation = "horizontal", ...props }: SeparatorPrimitive.Props) {
+  return (
     <SeparatorPrimitive
-      ref={ref}
       data-slot="separator"
       orientation={orientation}
       className={cn(
@@ -17,8 +15,7 @@ const Separator = React.forwardRef<React.ComponentRef<typeof SeparatorPrimitive>
       )}
       {...props}
     />
-  ),
-);
-Separator.displayName = "Separator";
+  );
+}
 
 export { Separator };

--- a/ui/litellm-dashboard/src/components/ui/skeleton.tsx
+++ b/ui/litellm-dashboard/src/components/ui/skeleton.tsx
@@ -1,12 +1,7 @@
-import * as React from "react";
-
 import { cn } from "@/lib/cva.config";
 
-const Skeleton = React.forwardRef<HTMLDivElement, React.ComponentPropsWithoutRef<"div">>(
-  ({ className, ...props }, ref) => (
-    <div ref={ref} data-slot="skeleton" className={cn("animate-pulse rounded-md bg-muted", className)} {...props} />
-  ),
-);
-Skeleton.displayName = "Skeleton";
+function Skeleton({ className, ...props }: React.ComponentProps<"div">) {
+  return <div data-slot="skeleton" className={cn("animate-pulse rounded-md bg-muted", className)} {...props} />;
+}
 
 export { Skeleton };

--- a/ui/litellm-dashboard/src/components/ui/textarea.tsx
+++ b/ui/litellm-dashboard/src/components/ui/textarea.tsx
@@ -2,10 +2,9 @@ import * as React from "react";
 
 import { cn } from "@/lib/cva.config";
 
-const Textarea = React.forwardRef<HTMLTextAreaElement, React.ComponentProps<"textarea">>(
-  ({ className, ...props }, ref) => (
+function Textarea({ className, ...props }: React.ComponentProps<"textarea">) {
+  return (
     <textarea
-      ref={ref}
       data-slot="textarea"
       className={cn(
         "flex field-sizing-content min-h-16 w-full rounded-md border border-input bg-transparent px-2.5 py-2 text-base shadow-xs transition-[color,box-shadow] outline-none placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 md:text-sm dark:bg-input/30 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40",
@@ -13,8 +12,7 @@ const Textarea = React.forwardRef<HTMLTextAreaElement, React.ComponentProps<"tex
       )}
       {...props}
     />
-  ),
-);
-Textarea.displayName = "Textarea";
+  );
+}
 
 export { Textarea };


### PR DESCRIPTION
## TLDR

Problem this solves:

- Four primitives still wrap their body in `React.forwardRef`
- The dashboard has been on React 19 since #37411, which does not need it
- `ref-forwarding.test.tsx` never covered `Textarea`, the one with real ref call sites

How it solves it:

- Re-pull each from base-vega, which drops the wrapper and its `displayName`
- Picked these four because ref plumbing is their only divergence from upstream
- Add the missing `Textarea` case to the existing ref test

## User Flow

This is a no-op refactor, so the two lists are identical by design. The primitives render the same markup and still hand their ref to the DOM node, so react-hook-form keeps focusing the right field

Before: an admin fills in a form that has a required textarea and leaves it blank

1. They open http://localhost:4000/ui/?page=vector-stores and click Create Vector Store
2. They submit with the description empty and the form scrolls to and focuses that textarea
3. They fill it in and the store is created

After: the same admin sees exactly the same three things

1. They open http://localhost:4000/ui/?page=vector-stores and click Create Vector Store
2. They submit with the description empty and the form scrolls to and focuses that textarea
3. They fill it in and the store is created

## Relevant issues

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

Setup: start the proxy with `python litellm/proxy/proxy_cli.py --config litellm/proxy/dev_config.yaml --detailed_debug --reload`, then run `npm run dev` in `ui/litellm-dashboard` and sign in at http://localhost:3000

### Before (e300822483)

#### Textarea keeps its ref, so a blank required field still gets focused

1. Open http://localhost:3000/?page=vector-stores and click Create Vector Store
2. Submit with the description left empty, and screenshot the textarea taking focus with its error
3. Switch the theme toggle to dark and screenshot the same field

#### Label, Separator and Skeleton render unchanged

1. Open http://localhost:3000/?page=api-keys and screenshot the table while its skeleton rows are still showing
2. Open any key's detail drawer and screenshot the labels and divider lines

### After (d2aea2d4e7)

#### Textarea keeps its ref, so a blank required field still gets focused

1. Open http://localhost:3000/?page=vector-stores and click Create Vector Store
2. Submit with the description left empty, and screenshot the textarea taking focus with its error
3. Switch the theme toggle to dark and screenshot the same field

#### Label, Separator and Skeleton render unchanged

1. Open http://localhost:3000/?page=api-keys and screenshot the table while its skeleton rows are still showing
2. Open any key's detail drawer and screenshot the labels and divider lines

## Type

🧹 Refactoring

## Caveats (if any)

### Low

- Seven other primitives still carry `forwardRef`: `avatar`, `breadcrumb`, `card`, `chart`, `combobox`, `input`, `table`. Each has also drifted from upstream on its class strings, so re-pulling them is a visual change and belongs in its own PR
- `ui/ui-loading-spinner.tsx` has one too, but it is not a registry item and is already slated for replacement by a much smaller local Spinner

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
