### PR TITLE
fix(proxy): stop cache eviction errors from failing /key/update

### DIFF
--- a/litellm/proxy/auth/auth_checks.py
+++ b/litellm/proxy/auth/auth_checks.py
@@ -2588,13 +2588,29 @@ async def _delete_cache_key_object(
     user_api_key_cache: UserApiKeyCache,
     proxy_logging_obj: ProxyLogging | None,
 ):
+    """
+    Evict one key object, best-effort, matching `delete_cache_team_object` and
+    `delete_cache_key_objects`.
+
+    Every caller runs this after its own write has already committed, and the in-memory entry is
+    dropped before the Redis round trip. Letting a cache-backend error raise here therefore reports
+    failure for work that succeeded without making the cache any less stale; the leftover Redis
+    entry expires at its TTL either way.
+    """
     key: Final = hashed_token
 
-    user_api_key_cache.delete_cache(key=key)
+    try:
+        user_api_key_cache.delete_cache(key=key)
 
-    ## UPDATE REDIS CACHE ##
-    if proxy_logging_obj is not None:
-        await proxy_logging_obj.internal_usage_cache.dual_cache.async_delete_cache(key=key)
+        ## UPDATE REDIS CACHE ##
+        if proxy_logging_obj is not None:
+            await proxy_logging_obj.internal_usage_cache.dual_cache.async_delete_cache(key=key)
+    except Exception as e:  # noqa: BLE001  # best-effort: a cache error must not fail a committed write
+        verbose_proxy_logger.warning(
+            "Failed to invalidate cached key entry %s; a stale key object may be served until its TTL expires: %s",
+            key,
+            e,
+        )
 
 
 async def delete_cache_key_objects(

--- a/tests/test_litellm/proxy/auth/test_auth_checks.py
+++ b/tests/test_litellm/proxy/auth/test_auth_checks.py
@@ -7394,3 +7394,57 @@ async def test_invalidate_team_member_spend_state_self_delivered_broadcast_does_
     assert (
         local_spend_counter_cache.in_memory_cache.get_cache("spend_db_floor:spend:team_member:user-1:team-1") == 0.0
     ), "the handler's self-delivered broadcast erased the post-reset floor marker, reopening the stale-floor race"
+
+
+@pytest.mark.asyncio
+async def test_delete_cache_key_object_is_best_effort_when_the_cache_backend_fails(caplog):
+    """
+    LIT-5898: `_delete_cache_key_object` must not propagate a cache-backend error.
+
+    Every caller runs it after its own write has committed, so a raise here turned a persisted
+    `/key/update` into `400 Authentication Error` (and `/key/block`, `/key/regenerate` into 500s)
+    for operators whose Redis ACL denies `DEL` on LiteLLM's unprefixed token-hash keys. The
+    in-memory entry is already dropped by then, so raising never made the cache less stale.
+    """
+    import logging
+    from unittest.mock import AsyncMock, MagicMock
+
+    from litellm.proxy.auth.auth_checks import _delete_cache_key_object
+
+    hashed_token = "a" * 64
+    caplog.set_level(logging.WARNING, logger="LiteLLM Proxy")
+
+    failing_cache = MagicMock()
+    failing_cache.delete_cache = MagicMock()
+    failing_logging_obj = MagicMock()
+    failing_logging_obj.internal_usage_cache.dual_cache.async_delete_cache = AsyncMock(
+        side_effect=Exception("No permissions to access a key")
+    )
+
+    await _delete_cache_key_object(
+        hashed_token=hashed_token,
+        user_api_key_cache=failing_cache,
+        proxy_logging_obj=failing_logging_obj,
+    )
+
+    failing_cache.delete_cache.assert_called_once_with(key=hashed_token)
+    failing_logging_obj.internal_usage_cache.dual_cache.async_delete_cache.assert_awaited_once_with(key=hashed_token)
+    assert any("Failed to invalidate cached key entry" in record.getMessage() for record in caplog.records), (
+        "a swallowed cache-eviction failure must still be logged, or a stale auth entry goes unnoticed"
+    )
+
+    caplog.clear()
+    healthy_cache = MagicMock()
+    healthy_cache.delete_cache = MagicMock()
+    healthy_logging_obj = MagicMock()
+    healthy_logging_obj.internal_usage_cache.dual_cache.async_delete_cache = AsyncMock()
+
+    await _delete_cache_key_object(
+        hashed_token=hashed_token,
+        user_api_key_cache=healthy_cache,
+        proxy_logging_obj=healthy_logging_obj,
+    )
+
+    healthy_cache.delete_cache.assert_called_once_with(key=hashed_token)
+    healthy_logging_obj.internal_usage_cache.dual_cache.async_delete_cache.assert_awaited_once_with(key=hashed_token)
+    assert caplog.records == [], "a healthy eviction must stay silent, and must still reach both caches"


### PR DESCRIPTION
## TLDR

Problem this solves:

- `/key/update` returned 400 after the DB write already committed
- The error read "Authentication Error", so operators debugged auth
- Same crash hit `/key/block` and `/key/regenerate` as 500s
- Trigger: a Redis ACL that denies DEL on cache keys

How it solves it:

- Cache eviction for a key is now best-effort, not fatal
- A failed eviction logs a warning and the request succeeds
- Matches the two sibling helpers on either side of it
- One helper, so every caller is covered at once

## User Flow

Before: a proxy admin whose Redis user has a key-pattern ACL cannot edit any virtual key, and the error tells them their auth is broken when it is not

1. They open https://litellm-domain/ui/?page=api-keys, pick a key, and go to Settings, Edit Settings
2. They change Max Budget to 42 and hit Save Changes
3. A red banner comes back reading "Authentication Error, No permissions to access a key"
4. They reload the page and the budget shows 42 anyway, because the save actually went through
5. Hitting `POST https://litellm-domain/key/update` directly returns the same 400 with `"type": "auth_error"`, so they go looking at their master key and their permissions instead of at Redis
6. Blocking or regenerating a key from the same page fails too, with a bare 500

After: the same admin edits keys normally, and a Redis that refuses the eviction only shows up as a warning in the proxy logs

1. They open https://litellm-domain/ui/?page=api-keys, pick a key, and go to Settings, Edit Settings
2. They change Max Budget to 42 and hit Save Changes
3. The save reports success and the budget shows 42
4. `POST https://litellm-domain/key/update` returns 200 with the updated key object
5. Blocking and regenerating a key from the same page both succeed
6. The proxy log carries one warning per denied eviction, naming the key entry that could not be invalidated and that it will be served until its TTL expires

## Relevant issues

## Linear ticket

Resolves LIT-5898

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Shared setup, identical for both runs. A Redis whose LiteLLM user may only touch `allowed:*`, which is what a key-pattern-scoped ACL looks like in practice. LiteLLM caches key objects under the bare sha256 token hash, so the eviction `DEL` lands outside the allowed pattern:

```bash
docker run -d --name litfix-redis -p 6380:6379 redis:7.4.1
docker exec litfix-redis redis-cli ACL SETUSER litellm_user on '>litellmpass' '~allowed:*' +@all
```

Proxy config used for both runs:

```yaml
general_settings:
  master_key: sk-1234
  database_url: postgresql://litellm:litellm@localhost:5433/litellm
litellm_settings:
  cache: true
  cache_params:
    type: redis
    host: localhost
    port: 6380
    username: litellm_user
    password: litellmpass
```

Each case first mints a key with `curl -s http://localhost:4001/key/generate -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' -d '{"key_alias":"..."}'`, then runs the command shown.

### Before (e52f05566d)

#### /key/update

1. Command:

```bash
curl -s -w '\nHTTP %{http_code}\n' -X POST http://localhost:4001/key/update \
  -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' \
  -d '{"key": "sk-SzcGDYvoi4e65c_EP3LLHA", "max_budget": 42}'
```

2. Output:

```
{"error":{"message":"Authentication Error, No permissions to access a key","type":"auth_error","param":"None","code":"400"}}
HTTP 400
```

3. The write landed anyway, which is what makes the 400 a lie:

```bash
curl -s -G http://localhost:4001/key/info --data-urlencode 'key=sk-SzcGDYvoi4e65c_EP3LLHA' \
  -H 'Authorization: Bearer sk-1234'
```

```
max_budget in DB: 42.0
```

#### /key/block

1. Command:

```bash
curl -s -w '\nHTTP %{http_code}\n' -X POST http://localhost:4001/key/block \
  -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' \
  -d '{"key": "sk-kS8HJzjG0x__VTHINul6Wg"}'
```

2. Output:

```
{"error":{"message":"Internal server error","type":"internal_server_error"}}
HTTP 500
```

#### /key/regenerate

1. Command:

```bash
curl -s -w '\nHTTP %{http_code}\n' -X POST http://localhost:4001/key/regenerate \
  -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' \
  -d '{"key": "sk-YXoi3I12AL0BL9Q6i6lmsQ"}'
```

2. Output:

```
{"error":{"message":"No permissions to access a key","type":"internal_server_error","param":"None","code":"500"}}
HTTP 500
```

### After (d8ad578045)

#### /key/update

1. Command:

```bash
curl -s -w '\nHTTP %{http_code}\n' -X POST http://localhost:4001/key/update \
  -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' \
  -d '{"key": "sk-XyakQzTACDBGfsCPL-Fv_g", "max_budget": 42}'
```

2. Output, response body trimmed to the fields that matter:

```
{"key":"sk-XyakQzTACDBGfsCPL-Fv_g","key_name":"sk-...Fv_g","key_alias":"lit5898-update-AFTER","spend":0.0,"max_budget":42.0,"blocked":null,"updated_at":"2026-08-26T06:29:44.001000+00:00", ...}
HTTP 200
```

3. And the DB agrees, as it did before:

```bash
curl -s -G http://localhost:4001/key/info --data-urlencode 'key=sk-XyakQzTACDBGfsCPL-Fv_g' \
  -H 'Authorization: Bearer sk-1234'
```

```
max_budget in DB: 42.0
```

4. The denied eviction is now a log line rather than a failed request:

```
23:18:24 - LiteLLM Proxy:WARNING: auth_checks.py:2609 - Failed to invalidate cached key entry
1e3d65f3...; a stale key object may be served until its TTL expires: No permissions to access a key
```

#### /key/block

1. Command:

```bash
curl -s -w '\nHTTP %{http_code}\n' -X POST http://localhost:4001/key/block \
  -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' \
  -d '{"key": "sk-PkesalVpqDP-a4dKCQ9k-Q"}'
```

2. Output, trimmed:

```
{"token":"c10964f5...","key_name":"sk-...9k-Q","key_alias":"lit5898-block-AFTER","blocked":true, ...}
HTTP 200
```

#### /key/regenerate

1. Command:

```bash
curl -s -w '\nHTTP %{http_code}\n' -X POST http://localhost:4001/key/regenerate \
  -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' \
  -d '{"key": "sk-ILdPaJm9JPEHvr3XCbW0Zg"}'
```

2. Output, trimmed:

```
{"key_alias":"lit5898-regen-AFTER","key":"sk-FegM1ppcy8YnoxMEI5Y2Kg","key_name":"sk-...Y2Kg","token_id":"3b2200c4...", ...}
HTTP 200
```

#### Eviction still happens when Redis allows it

Guards against the fix quietly turning invalidation into a no-op. With `ACL SETUSER litellm_user on '>litellmpass' '~*' +@all`, seed the key's cache entry by hand and watch `/key/update` remove it:

1. Commands:

```bash
docker exec litfix-redis redis-cli --user litellm_user --pass litellmpass SET "$HASH" seeded
docker exec litfix-redis redis-cli --user litellm_user --pass litellmpass EXISTS "$HASH"
curl -s -o /dev/null -w '%{http_code}\n' -X POST http://localhost:4001/key/update \
  -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' \
  -d '{"key": "'"$KEY"'", "max_budget": 7}'
docker exec litfix-redis redis-cli --user litellm_user --pass litellmpass EXISTS "$HASH"
```

2. Output:

```
OK
(integer) 1
200
(integer) 0
```

## Type

🐛 Bug Fix

## Caveats (if any)

### Medium

- `update_key_fn`'s catch-all still labels every failure `auth_error`
- That mislabeling is what misdirected debugging; unchanged here
- Fixing it moves other failures from 400 to 500, so separate PR

### Low

- A denied eviction is now only visible as a WARNING log line
- Staleness is unchanged: the raise never rolled anything back

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
