### PR TITLE
test(azure-ai): pin the 422 retry that drops the field the provider rejected

### DIFF
--- a/tests/test_litellm/llms/custom_httpx/test_llm_http_handler.py
+++ b/tests/test_litellm/llms/custom_httpx/test_llm_http_handler.py
@@ -2762,11 +2762,12 @@ def test_video_generation_with_input_reference_keeps_file_multipart():
 AZURE_AI_HOST = "myfoundry.services.ai.azure.com"
 AZURE_AI_BASE = f"https://{AZURE_AI_HOST}"
 
-TOOL_WITH_AN_UNSUPPORTED_FIELD = {
-    "type": "function",
-    "function": {"name": "lookup", "parameters": {"type": "object", "properties": {}}},
-    "strict": True,
-}
+def _a_tool_with_an_unsupported_field() -> dict:
+    return {
+        "type": "function",
+        "function": {"name": "lookup", "parameters": {"type": "object", "properties": {}}},
+        "strict": True,
+    }
 
 A_COMPLETION = {
     "id": "chatcmpl-1",
@@ -2811,7 +2812,7 @@ def _call_azure_ai(recorder: _RecordedAzureAI, **overrides):
         return litellm.completion(
             model="azure_ai/grok-3",
             messages=[{"role": "user", "content": "hi"}],
-            tools=[TOOL_WITH_AN_UNSUPPORTED_FIELD],
+            tools=[_a_tool_with_an_unsupported_field()],
             api_base=AZURE_AI_BASE,
             api_key="fake-key",
             **overrides,
@@ -2898,7 +2899,7 @@ async def test_a_tool_field_the_provider_rejects_is_dropped_and_retried_on_the_a
         response = await litellm.acompletion(
             model="azure_ai/grok-3",
             messages=[{"role": "user", "content": "hi"}],
-            tools=[TOOL_WITH_AN_UNSUPPORTED_FIELD],
+            tools=[_a_tool_with_an_unsupported_field()],
             api_base=AZURE_AI_BASE,
             api_key="fake-key",
         )
@@ -2923,7 +2924,7 @@ async def test_a_provider_that_keeps_rejecting_is_not_retried_forever_on_the_asy
             await litellm.acompletion(
                 model="azure_ai/grok-3",
                 messages=[{"role": "user", "content": "hi"}],
-                tools=[TOOL_WITH_AN_UNSUPPORTED_FIELD],
+                tools=[_a_tool_with_an_unsupported_field()],
                 api_base=AZURE_AI_BASE,
                 api_key="fake-key",
             )

--- a/tests/test_litellm/llms/custom_httpx/test_llm_http_handler.py
+++ b/tests/test_litellm/llms/custom_httpx/test_llm_http_handler.py
@@ -2757,3 +2757,175 @@ def test_video_generation_with_input_reference_keeps_file_multipart():
         "seconds": "4",
     }
     assert result.status == "queued"
+
+
+AZURE_AI_HOST = "myfoundry.services.ai.azure.com"
+AZURE_AI_BASE = f"https://{AZURE_AI_HOST}"
+
+TOOL_WITH_AN_UNSUPPORTED_FIELD = {
+    "type": "function",
+    "function": {"name": "lookup", "parameters": {"type": "object", "properties": {}}},
+    "strict": True,
+}
+
+A_COMPLETION = {
+    "id": "chatcmpl-1",
+    "object": "chat.completion",
+    "created": 1,
+    "model": "grok-3",
+    "choices": [
+        {"index": 0, "message": {"role": "assistant", "content": "sent"}, "finish_reason": "stop"}
+    ],
+    "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+}
+
+TOOL_LEVEL_REJECTION = "Extra inputs are not permitted: tools[0].strict"
+UNRELATED_REJECTION = "Extra inputs are not permitted: temperature"
+A_REJECTION_THE_PROVIDER_CANNOT_FIX = "The model is not available in this region"
+
+
+class _RecordedAzureAI:
+    def __init__(self, responses: list[httpx.Response]) -> None:
+        self._responses = responses
+        self.bodies: list[dict] = []
+
+    def __call__(self, request: httpx.Request) -> httpx.Response:
+        self.bodies.append(json.loads(request.content))
+        return self._responses[min(len(self.bodies) - 1, len(self._responses) - 1)]
+
+
+@pytest.fixture
+def httpx_transport(monkeypatch):
+    monkeypatch.setattr(litellm, "disable_aiohttp_transport", True)
+
+
+def _rejection(message: str) -> httpx.Response:
+    return httpx.Response(422, json={"error": {"message": message}})
+
+
+def _call_azure_ai(recorder: _RecordedAzureAI, **overrides):
+    import respx
+
+    with respx.mock:
+        respx.route(host=AZURE_AI_HOST).mock(side_effect=recorder)
+        return litellm.completion(
+            model="azure_ai/grok-3",
+            messages=[{"role": "user", "content": "hi"}],
+            tools=[TOOL_WITH_AN_UNSUPPORTED_FIELD],
+            api_base=AZURE_AI_BASE,
+            api_key="fake-key",
+            **overrides,
+        )
+
+
+def test_a_tool_field_the_provider_rejects_is_dropped_and_the_call_retried():
+    recorder = _RecordedAzureAI(
+        [_rejection(TOOL_LEVEL_REJECTION), httpx.Response(200, json=A_COMPLETION)]
+    )
+
+    response = _call_azure_ai(recorder)
+
+    assert len(recorder.bodies) == 2
+    assert recorder.bodies[0]["tools"][0]["strict"] is True
+    assert "strict" not in recorder.bodies[1]["tools"][0]
+    assert response.choices[0].message.content == "sent"
+
+
+def test_the_retry_changes_only_the_field_the_provider_named():
+    recorder = _RecordedAzureAI(
+        [_rejection(TOOL_LEVEL_REJECTION), httpx.Response(200, json=A_COMPLETION)]
+    )
+
+    _call_azure_ai(recorder)
+
+    first, second = recorder.bodies
+    assert second["messages"] == first["messages"]
+    assert second["model"] == first["model"]
+    assert second["tools"][0]["function"] == first["tools"][0]["function"]
+
+
+def test_a_provider_that_keeps_rejecting_is_not_retried_forever():
+    recorder = _RecordedAzureAI([_rejection(TOOL_LEVEL_REJECTION)])
+
+    with pytest.raises(litellm.BadRequestError) as raised:
+        _call_azure_ai(recorder)
+
+    assert len(recorder.bodies) == 2
+    assert raised.value.status_code == 422
+
+
+def test_a_rejection_the_provider_cannot_fix_is_not_retried_at_all():
+    recorder = _RecordedAzureAI([_rejection(A_REJECTION_THE_PROVIDER_CANNOT_FIX)])
+
+    with pytest.raises(litellm.BadRequestError):
+        _call_azure_ai(recorder)
+
+    assert len(recorder.bodies) == 1
+
+
+def test_an_extra_input_outside_a_tool_is_not_retried_unless_dropping_params_was_asked_for():
+    recorder = _RecordedAzureAI([_rejection(UNRELATED_REJECTION)])
+
+    with pytest.raises(litellm.BadRequestError):
+        _call_azure_ai(recorder)
+
+    assert len(recorder.bodies) == 1
+
+
+def test_an_extra_input_outside_a_tool_is_retried_when_dropping_params_was_asked_for():
+    recorder = _RecordedAzureAI(
+        [_rejection(UNRELATED_REJECTION), httpx.Response(200, json=A_COMPLETION)]
+    )
+
+    response = _call_azure_ai(recorder, drop_params=True)
+
+    assert len(recorder.bodies) == 2
+    assert response.choices[0].message.content == "sent"
+
+
+@pytest.mark.asyncio
+async def test_a_tool_field_the_provider_rejects_is_dropped_and_retried_on_the_async_path(
+    httpx_transport,
+):
+    import respx
+
+    recorder = _RecordedAzureAI(
+        [_rejection(TOOL_LEVEL_REJECTION), httpx.Response(200, json=A_COMPLETION)]
+    )
+
+    with respx.mock:
+        respx.route(host=AZURE_AI_HOST).mock(side_effect=recorder)
+        response = await litellm.acompletion(
+            model="azure_ai/grok-3",
+            messages=[{"role": "user", "content": "hi"}],
+            tools=[TOOL_WITH_AN_UNSUPPORTED_FIELD],
+            api_base=AZURE_AI_BASE,
+            api_key="fake-key",
+        )
+
+    assert len(recorder.bodies) == 2
+    assert recorder.bodies[0]["tools"][0]["strict"] is True
+    assert "strict" not in recorder.bodies[1]["tools"][0]
+    assert response.choices[0].message.content == "sent"
+
+
+@pytest.mark.asyncio
+async def test_a_provider_that_keeps_rejecting_is_not_retried_forever_on_the_async_path(
+    httpx_transport,
+):
+    import respx
+
+    recorder = _RecordedAzureAI([_rejection(TOOL_LEVEL_REJECTION)])
+
+    with respx.mock:
+        respx.route(host=AZURE_AI_HOST).mock(side_effect=recorder)
+        with pytest.raises(litellm.BadRequestError):
+            await litellm.acompletion(
+                model="azure_ai/grok-3",
+                messages=[{"role": "user", "content": "hi"}],
+                tools=[TOOL_WITH_AN_UNSUPPORTED_FIELD],
+                api_base=AZURE_AI_BASE,
+                api_key="fake-key",
+            )
+
+    assert len(recorder.bodies) == 2

--- a/tests/test_litellm/llms/custom_httpx/test_llm_http_handler.py
+++ b/tests/test_litellm/llms/custom_httpx/test_llm_http_handler.py
@@ -2759,8 +2759,8 @@ def test_video_generation_with_input_reference_keeps_file_multipart():
     assert result.status == "queued"
 
 
-AZURE_AI_HOST = "myfoundry.services.ai.azure.com"
-AZURE_AI_BASE = f"https://{AZURE_AI_HOST}"
+AZURE_AI_BASE = "https://myfoundry.services.ai.azure.com"
+AZURE_AI_CHAT_COMPLETIONS_URL = f"{AZURE_AI_BASE}/models/chat/completions"
 
 def _a_tool_with_an_unsupported_field() -> dict:
     return {
@@ -2807,8 +2807,8 @@ def _rejection(message: str) -> httpx.Response:
 def _call_azure_ai(recorder: _RecordedAzureAI, **overrides):
     import respx
 
-    with respx.mock:
-        respx.route(host=AZURE_AI_HOST).mock(side_effect=recorder)
+    with respx.mock(assert_all_called=True) as router:
+        router.post(AZURE_AI_CHAT_COMPLETIONS_URL).mock(side_effect=recorder)
         return litellm.completion(
             model="azure_ai/grok-3",
             messages=[{"role": "user", "content": "hi"}],
@@ -2894,8 +2894,8 @@ async def test_a_tool_field_the_provider_rejects_is_dropped_and_retried_on_the_a
         [_rejection(TOOL_LEVEL_REJECTION), httpx.Response(200, json=A_COMPLETION)]
     )
 
-    with respx.mock:
-        respx.route(host=AZURE_AI_HOST).mock(side_effect=recorder)
+    with respx.mock(assert_all_called=True) as router:
+        router.post(AZURE_AI_CHAT_COMPLETIONS_URL).mock(side_effect=recorder)
         response = await litellm.acompletion(
             model="azure_ai/grok-3",
             messages=[{"role": "user", "content": "hi"}],
@@ -2918,8 +2918,8 @@ async def test_a_provider_that_keeps_rejecting_is_not_retried_forever_on_the_asy
 
     recorder = _RecordedAzureAI([_rejection(TOOL_LEVEL_REJECTION)])
 
-    with respx.mock:
-        respx.route(host=AZURE_AI_HOST).mock(side_effect=recorder)
+    with respx.mock(assert_all_called=True) as router:
+        router.post(AZURE_AI_CHAT_COMPLETIONS_URL).mock(side_effect=recorder)
         with pytest.raises(litellm.BadRequestError):
             await litellm.acompletion(
                 model="azure_ai/grok-3",


### PR DESCRIPTION
## TLDR

Problem this solves:

- Azure AI retries a 422 by dropping the field the endpoint rejected
- That retry is what makes a customer's tool call work instead of 400
- Nothing covered it; the handler sits at 0.20 test-to-source

How it solves it:

- Drive real completion calls against a recorded Azure AI endpoint
- Assert the bytes that actually went over the wire, patch nothing internal

## User Flow

This PR adds tests and changes no behavior, so the flow below is what the tests hold in place rather than something that changes between Before and After.

Before: nothing stops a refactor from quietly dropping the retry that makes tool calls work on Azure AI

1. A developer sends POST https://litellm-domain/v1/chat/completions with `"model": "azure_ai/grok-3"` and a tool carrying `"strict": true`
2. Azure AI answers 422 saying `tools[0].strict` is not permitted
3. LiteLLM removes `strict` and sends the request again, and the developer gets a normal completion back
4. Nothing in CI would notice if a later change surfaced that 422 to the developer instead, or retried a rejection that can never succeed

After: each of those steps is pinned, so losing them turns the suite red before it ships

1. The same POST with the same tool
2. Azure AI answers the same 422
3. The developer still gets a normal completion back
4. A change that stopped the retry, retried the wrong kind of rejection, or retried more than twice now fails CI

## Relevant issues

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## What is pinned

- A tool field the endpoint rejects is dropped and the call retried, and the caller gets a normal completion
- The retry changes only the field the provider named, leaving messages, model and the rest of the tool alone
- A provider that keeps rejecting stops after exactly two attempts rather than retrying forever
- A rejection the provider cannot fix is not retried at all, so a dead request does not cost a second call
- An extra input outside a tool is retried only when `drop_params` was asked for
- The first two also run on the async path

## Screenshots / Proof of Fix

Tests only, so the proof is that they fail when the behaviour they pin is broken. The requests below are the ones the tests record; the endpoint is faked at the HTTP boundary, so this costs no provider spend and needs no key.

### Before (`be4a79710d^`, the merge base)

#### Nothing covers the retry

1. Search the handler's mapped test file for the retry it owns:

```bash
grep -c "max_retry_on_unprocessable\|_make_common" tests/test_litellm/llms/custom_httpx/test_llm_http_handler.py
```

2. Output: `0`

### After (`be4a79710d`)

#### The suite passes

1. Run the file:

```bash
uv run pytest tests/test_litellm/llms/custom_httpx/test_llm_http_handler.py -q
```

2. Output: `94 passed` in 0.54s, with no network egress

#### The recorded exchange

1. First request body carries the field Azure AI will reject:

```json
{"tools": [{"type": "function", "function": {"name": "f", "parameters": {"type": "object", "properties": {}}}, "strict": true}]}
```

2. Endpoint answers `422` with `Extra inputs are not permitted: tools[0].strict`
3. Second request body has it removed:

```json
{"tools": [{"type": "function", "function": {"name": "f", "parameters": {"type": "object", "properties": {}}}}]}
```

4. Endpoint answers `200`, and the call returns the assistant message

#### Each pinned behavior fails when its source is mutated

Applied one at a time, reverting between each, running `uv run pytest tests/test_litellm/llms/custom_httpx/test_llm_http_handler.py -q -k "reject or retri or extra_input or tool_field"` after each:

1. Retry cap raised from 2 to 3 in `AzureAIStudioConfig.max_retry_on_unprocessable_entity_error`: `2 failed, 9 passed`
2. `_error_has_tool_level_extra_fields` always returns False: `4 failed, 7 passed`

The recorded route matches POST on the exact Foundry path, so it pins the routing too: the first attempt at this used `/chat/completions` and seven tests went red, because the real path carries a `/models` prefix.

Both revert cleanly; `git status litellm/` is empty at the tip.

## Type

✅ Test

## Caveats (if any)

### Low

- The async cases pin the transport to httpx via monkeypatch
- The aiohttp default carries its own transport an httpx-level fake cannot intercept, and without the pin those two tests reached the real Azure endpoint and failed on a 401
- The retry loop under test is shared, but only Azure AI opts into it today, so that is the only provider these drive
- The mapped test file is now just over 2,900 lines, which the testing audit counts as oversized; splitting it is its own change
- Review flagged the shared tool payload as cross-test contamination; it does not reproduce, because the request is copied before the transform runs
- Each case builds its own payload anyway, so the point stays moot if that copy ever goes
