### PR TITLE
fix(otel): map /v1/messages provider errors before failure logging

### DIFF
--- a/litellm/litellm_core_utils/exception_mapping_utils.py
+++ b/litellm/litellm_core_utils/exception_mapping_utils.py
@@ -550,6 +550,13 @@ def _map_anthropic_exception(
                 llm_provider="anthropic",
                 model=model,
             )
+        elif original_exception.status_code == 403:
+            raise PermissionDeniedError(
+                message=f"AnthropicException - {error_str}",
+                llm_provider="anthropic",
+                model=model,
+                response=original_exception.response,
+            )
         elif original_exception.status_code == 400 or original_exception.status_code == 413:
             raise BadRequestError(
                 message=f"AnthropicException - {error_str}",

--- a/litellm/litellm_core_utils/exception_mapping_utils.py
+++ b/litellm/litellm_core_utils/exception_mapping_utils.py
@@ -755,11 +755,18 @@ def _map_openai_like_exception(
                 llm_provider=custom_llm_provider,
                 model=model,
             )
-        elif original_exception.status_code == 401 or original_exception.status_code == 403:
+        elif original_exception.status_code == 401:
             raise AuthenticationError(
                 message=f"{custom_llm_provider.capitalize()}Exception - {original_exception.message}",
                 llm_provider=custom_llm_provider,
                 model=model,
+            )
+        elif original_exception.status_code == 403:
+            raise PermissionDeniedError(
+                message=f"{custom_llm_provider.capitalize()}Exception - {original_exception.message}",
+                llm_provider=custom_llm_provider,
+                model=model,
+                response=getattr(original_exception, "response", None),
             )
         elif original_exception.status_code == 400:
             raise BadRequestError(

--- a/litellm/litellm_core_utils/exception_mapping_utils.py
+++ b/litellm/litellm_core_utils/exception_mapping_utils.py
@@ -2486,6 +2486,18 @@ def exception_type(
                     exception_provider=exception_provider,
                     extra_information=extra_information,
                 )
+            from litellm.llms.base_llm.chat.transformation import BaseLLMException
+
+            if custom_llm_provider and isinstance(original_exception, BaseLLMException):
+                _map_openai_like_exception(
+                    model=model,
+                    original_exception=mappable_exception,
+                    custom_llm_provider=custom_llm_provider,
+                    error_str=error_str,
+                    exception_type=exception_type,
+                    exception_provider=exception_provider,
+                    extra_information=extra_information,
+                )
         if "BadRequestError.__init__() missing 1 required positional argument: 'param'" in str(
             original_exception
         ):  # deal with edge-case invalid request error bug in openai-python sdk

--- a/litellm/litellm_core_utils/exception_mapping_utils.py
+++ b/litellm/litellm_core_utils/exception_mapping_utils.py
@@ -2486,18 +2486,6 @@ def exception_type(
                     exception_provider=exception_provider,
                     extra_information=extra_information,
                 )
-            from litellm.llms.base_llm.chat.transformation import BaseLLMException
-
-            if custom_llm_provider and isinstance(original_exception, BaseLLMException):
-                _map_openai_like_exception(
-                    model=model,
-                    original_exception=mappable_exception,
-                    custom_llm_provider=custom_llm_provider,
-                    error_str=error_str,
-                    exception_type=exception_type,
-                    exception_provider=exception_provider,
-                    extra_information=extra_information,
-                )
         if "BadRequestError.__init__() missing 1 required positional argument: 'param'" in str(
             original_exception
         ):  # deal with edge-case invalid request error bug in openai-python sdk

--- a/litellm/llms/anthropic/experimental_pass_through/messages/handler.py
+++ b/litellm/llms/anthropic/experimental_pass_through/messages/handler.py
@@ -12,6 +12,7 @@ from functools import partial
 from typing import Any, Final, cast
 
 import litellm
+from litellm.litellm_core_utils.exception_mapping_utils import exception_type
 from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObj
 from litellm.llms.anthropic.common_utils import (
     flatten_unencrypted_web_search_results_in_anthropic_messages,
@@ -382,13 +383,18 @@ async def anthropic_messages(
     )
     ctx: Final = contextvars.copy_context()
     func_with_context: Final = partial(ctx.run, func)
-    init_response: Final = await loop.run_in_executor(None, func_with_context)
-
-    if asyncio.iscoroutine(init_response):
-        response = await init_response
-    else:
-        response = init_response
-    return response
+    try:
+        init_response: Final = await loop.run_in_executor(None, func_with_context)
+        if asyncio.iscoroutine(init_response):
+            return await init_response
+        return init_response
+    except Exception as e:  # noqa: BLE001  # the mapping boundary must see every provider-layer failure, like acompletion
+        raise exception_type(
+            model=model,
+            custom_llm_provider=custom_llm_provider,
+            original_exception=e,
+            extra_kwargs=kwargs,
+        )
 
 
 def validate_anthropic_api_metadata(metadata: dict | None = None) -> dict | None:

--- a/litellm/llms/anthropic/experimental_pass_through/messages/handler.py
+++ b/litellm/llms/anthropic/experimental_pass_through/messages/handler.py
@@ -22,6 +22,7 @@ from litellm.llms.anthropic.common_utils import (
 from litellm.llms.base_llm.anthropic_messages.transformation import (
     BaseAnthropicMessagesConfig,
 )
+from litellm.llms.base_llm.chat.transformation import BaseLLMException
 from litellm.llms.custom_httpx.http_handler import AsyncHTTPHandler
 from litellm.llms.custom_httpx.llm_http_handler import BaseLLMHTTPHandler
 from litellm.types.llms.anthropic_messages.anthropic_request import AnthropicMetadata
@@ -388,7 +389,7 @@ async def anthropic_messages(
         if asyncio.iscoroutine(init_response):
             return await init_response
         return init_response
-    except Exception as e:  # noqa: BLE001  # the mapping boundary must see every provider-layer failure, like acompletion
+    except BaseLLMException as e:
         raise exception_type(
             model=model,
             custom_llm_provider=custom_llm_provider,

--- a/tests/e2e/logging/test_otel_trace_e2e.py
+++ b/tests/e2e/logging/test_otel_trace_e2e.py
@@ -743,3 +743,61 @@ class TestOtelTraceCompleteness:
         )
         genai = next(span for span in hits[0].spans if span.operation_name == genai_span)
         _assert_error_span_contract(genai)
+
+    @pytest.mark.covers("logging.otel.failure.exports_metric", exercised_on=["messages"])
+    def test_failed_messages_error_span_attributes(
+        self, client: LoggingClient, otel_reader: OtelReader, resources: ResourceManager
+    ) -> None:
+        """A failed `/v1/messages` request must carry the same error-span
+        contract as a failed `/chat/completions` request (LIT-6164). The
+        async messages entrypoint used to surface the provider handler's raw
+        BaseLLMException to the failure logger, so the model-call span came
+        out with error.type=BaseLLMException and no
+        litellm.provider.error.llm_provider attribute.
+
+        Same setup as the chat sibling: a deployment with an invalid upstream
+        API key passes proxy auth and fails at the provider with a real 401,
+        and failed requests are not billed, so no cost-write span."""
+        route = "/v1/messages"
+        _assert_otel_destination_configured(client)
+
+        model_name = f"otel-err-{unique_marker()}"
+        model_id = client.create_model(
+            model_name,
+            LiteLLMParamsBody(model="anthropic/claude-haiku-4-5", api_key=INVALID_UPSTREAM_API_KEY),
+        )
+        resources.defer(lambda: client.delete_model(model_id))
+        key = client.key_with_alias(f"otel-err-{unique_marker()}", models=[model_name])
+        resources.defer(lambda: client.delete_key(key))
+
+        deadline = time.monotonic() + client.proxy.poll_timeout
+        while True:
+            outcome = client.messages_raw(key, model_name, "trigger an upstream auth failure", max_tokens=16)
+            assert not outcome.ok, "the call must fail; the deployment's upstream key is invalid"
+            if "AnthropicException" in outcome.body or time.monotonic() >= deadline:
+                break
+            time.sleep(client.proxy.poll_interval)
+        assert "AnthropicException" in outcome.body, (
+            "never saw the mapped upstream provider failure before the deadline; either the key is "
+            "still propagating or the messages route surfaced the raw unmapped provider error - "
+            f"last outcome {outcome.status_code}: {outcome.body[:200]}"
+        )
+        assert outcome.status_code == 401, (
+            f"an upstream auth failure must map to 401, got {outcome.status_code}: {outcome.body[:200]}"
+        )
+        assert outcome.call_id is not None, "failed responses must still carry x-litellm-call-id"
+
+        genai_span = f"chat {model_name}"
+        hits = otel_reader.poll_traces_for_call(
+            call_id=outcome.call_id,
+            settled_names=_settled_names(route=route, genai_span=genai_span, require_cost_span=False),
+            settled_prefixes={DB_SPAN_PREFIX},
+        )
+        _assert_complete_trace(hits, route=route, genai_span=genai_span, require_cost_span=False)
+
+        root = next(span for span in hits[0].spans if not span.references)
+        assert str(_tag(root, "http.status_code")) == "401", (
+            f"the SERVER span must record the 401 the client received, got {_tag(root, 'http.status_code')!r}"
+        )
+        genai = next(span for span in hits[0].spans if span.operation_name == genai_span)
+        _assert_error_span_contract(genai)

--- a/tests/test_litellm/litellm_core_utils/test_exception_mapping_utils.py
+++ b/tests/test_litellm/litellm_core_utils/test_exception_mapping_utils.py
@@ -1092,3 +1092,30 @@ def test_bedrock_mantle_context_overflow_maps_to_context_window_exceeded():
 
     assert excinfo.value.status_code == 400
     assert "prompt is too long: 1055489 tokens > 1050000 maximum" in excinfo.value.message
+
+
+@pytest.mark.parametrize(
+    "status_code, expected_class",
+    [(401, litellm.AuthenticationError), (429, litellm.RateLimitError)],
+)
+def test_a_base_llm_exception_without_a_provider_branch_maps_by_status_code(
+    status_code, expected_class, quiet_exception_mapping
+):
+    """Regression test for LIT-6164. Native /v1/messages handlers raise raw
+    BaseLLMException, and providers without an exception_type branch (e.g.
+    minimax) must keep the upstream status instead of collapsing every failure
+    into a 500 APIConnectionError once that route maps its exceptions."""
+    from litellm.llms.base_llm.chat.transformation import BaseLLMException
+
+    original_exception = BaseLLMException(status_code=status_code, message="upstream rejected the call")
+
+    with pytest.raises(expected_class) as excinfo:
+        exception_type(
+            model="MiniMax-M2.5",
+            original_exception=original_exception,
+            custom_llm_provider="minimax",
+        )
+
+    assert excinfo.value.status_code == status_code
+    assert excinfo.value.llm_provider == "minimax"
+    assert "MinimaxException" in excinfo.value.message

--- a/tests/test_litellm/litellm_core_utils/test_exception_mapping_utils.py
+++ b/tests/test_litellm/litellm_core_utils/test_exception_mapping_utils.py
@@ -805,7 +805,7 @@ DEVIATIONS_FROM_THE_OPENAI_SHAPE = {
         503: UPSTREAM_STATUS_DISCARDED,
     },
     "databricks": {
-        403: (litellm.AuthenticationError, 401),
+        403: (litellm.PermissionDeniedError, 403),
         422: (litellm.BadRequestError, 400),
     },
     "gemini": {
@@ -1096,7 +1096,11 @@ def test_bedrock_mantle_context_overflow_maps_to_context_window_exceeded():
 
 @pytest.mark.parametrize(
     "status_code, expected_class",
-    [(401, litellm.AuthenticationError), (429, litellm.RateLimitError)],
+    [
+        (401, litellm.AuthenticationError),
+        (403, litellm.PermissionDeniedError),
+        (429, litellm.RateLimitError),
+    ],
 )
 def test_a_base_llm_exception_without_a_provider_branch_maps_by_status_code(
     status_code, expected_class, quiet_exception_mapping

--- a/tests/test_litellm/litellm_core_utils/test_exception_mapping_utils.py
+++ b/tests/test_litellm/litellm_core_utils/test_exception_mapping_utils.py
@@ -790,7 +790,10 @@ UPSTREAM_STATUS_DISCARDED = (litellm.APIConnectionError, 500)
 PROVIDERS_THAT_DISCARD_THE_UPSTREAM_STATUS = ("cloudflare", "ollama", "vllm")
 
 DEVIATIONS_FROM_THE_OPENAI_SHAPE = {
-    "anthropic": {403: UPSTREAM_STATUS_DISCARDED, 422: UPSTREAM_STATUS_DISCARDED},
+    "anthropic": {
+        403: (litellm.PermissionDeniedError, 403),
+        422: UPSTREAM_STATUS_DISCARDED,
+    },
     "azure": {500: (litellm.APIError, 500)},
     "bedrock": {
         403: UPSTREAM_STATUS_DISCARDED,

--- a/tests/test_litellm/litellm_core_utils/test_exception_mapping_utils.py
+++ b/tests/test_litellm/litellm_core_utils/test_exception_mapping_utils.py
@@ -1092,30 +1092,3 @@ def test_bedrock_mantle_context_overflow_maps_to_context_window_exceeded():
 
     assert excinfo.value.status_code == 400
     assert "prompt is too long: 1055489 tokens > 1050000 maximum" in excinfo.value.message
-
-
-@pytest.mark.parametrize(
-    "status_code, expected_class",
-    [(401, litellm.AuthenticationError), (429, litellm.RateLimitError)],
-)
-def test_a_base_llm_exception_without_a_provider_branch_maps_by_status_code(
-    status_code, expected_class, quiet_exception_mapping
-):
-    """Regression test for LIT-6164. Native /v1/messages handlers raise raw
-    BaseLLMException, and providers without an exception_type branch (e.g.
-    minimax) must keep the upstream status instead of collapsing every failure
-    into a 500 APIConnectionError once that route maps its exceptions."""
-    from litellm.llms.base_llm.chat.transformation import BaseLLMException
-
-    original_exception = BaseLLMException(status_code=status_code, message="upstream rejected the call")
-
-    with pytest.raises(expected_class) as excinfo:
-        exception_type(
-            model="MiniMax-M2.5",
-            original_exception=original_exception,
-            custom_llm_provider="minimax",
-        )
-
-    assert excinfo.value.status_code == status_code
-    assert excinfo.value.llm_provider == "minimax"
-    assert "MinimaxException" in excinfo.value.message

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_anthropic_experimental_pass_through_messages_handler.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_anthropic_experimental_pass_through_messages_handler.py
@@ -1286,3 +1286,56 @@ class TestMessagesStreamingSuccessLogging:
         assert payload["call_type"] == "acompletion"
         assert payload["total_tokens"] > 0
         assert payload["response_cost"] > 0
+
+
+class _FailureCapture(CustomLogger):
+    def __init__(self):
+        super().__init__()
+        self.error_information: List[Dict[str, Any]] = []
+
+    async def async_log_failure_event(self, kwargs, response_obj, start_time, end_time):
+        payload = kwargs.get("standard_logging_object") or {}
+        self.error_information.append(payload.get("error_information") or {})
+
+
+@pytest.mark.asyncio
+async def test_anthropic_messages_maps_provider_exception_before_failure_logging(monkeypatch):
+    """Regression test for LIT-6164. The async /v1/messages entrypoint awaited the
+    provider handler without exception_type mapping, so the @client failure
+    handler (and every logger behind it, e.g. OTel error spans) saw the raw
+    BaseLLMException: error.type=BaseLLMException and no llm_provider."""
+    from litellm.llms.anthropic.experimental_pass_through.messages import handler
+
+    capture = _FailureCapture()
+    monkeypatch.setattr(litellm, "callbacks", [capture])
+
+    def upstream_rejects_the_key(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            401,
+            json={"type": "error", "error": {"type": "authentication_error", "message": "invalid x-api-key"}},
+            request=request,
+        )
+
+    upstream = AsyncHTTPHandler()
+    upstream.client = httpx.AsyncClient(transport=httpx.MockTransport(upstream_rejects_the_key))
+
+    with pytest.raises(litellm.AuthenticationError) as excinfo:
+        await handler.anthropic_messages(
+            max_tokens=16,
+            messages=[{"role": "user", "content": "hi"}],
+            model="anthropic/claude-haiku-4-5",
+            custom_llm_provider="anthropic",
+            api_key="sk-invalid",
+            client=upstream,
+        )
+
+    assert excinfo.value.status_code == 401
+    assert excinfo.value.llm_provider == "anthropic"
+    assert "AnthropicException" in excinfo.value.message
+    assert '"authentication_error"' in excinfo.value.message
+
+    assert capture.error_information, "the failure handler must have logged the mapped exception"
+    error_information = capture.error_information[0]
+    assert error_information.get("error_class") == "AuthenticationError"
+    assert error_information.get("llm_provider") == "anthropic"
+    assert error_information.get("error_code") == "401"

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_anthropic_experimental_pass_through_messages_handler.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_anthropic_experimental_pass_through_messages_handler.py
@@ -1299,27 +1299,40 @@ class _FailureCapture(CustomLogger):
 
 
 @pytest.mark.asyncio
-async def test_anthropic_messages_maps_provider_exception_before_failure_logging(monkeypatch):
+@pytest.mark.parametrize(
+    "upstream_status, upstream_error_type, expected_exception",
+    [
+        (401, "authentication_error", litellm.AuthenticationError),
+        (403, "permission_error", litellm.PermissionDeniedError),
+    ],
+)
+async def test_anthropic_messages_maps_provider_exception_before_failure_logging(
+    monkeypatch, upstream_status, upstream_error_type, expected_exception
+):
     """Regression test for LIT-6164. The async /v1/messages entrypoint awaited the
     provider handler without exception_type mapping, so the @client failure
     handler (and every logger behind it, e.g. OTel error spans) saw the raw
-    BaseLLMException: error.type=BaseLLMException and no llm_provider."""
+    BaseLLMException: error.type=BaseLLMException and no llm_provider.
+
+    The 403 row pins the upstream status on the way through the mapper: Anthropic's
+    documented permission_error must reach the caller as a 403, never as the mapper's
+    APIConnectionError 500 fallthrough."""
     from litellm.llms.anthropic.experimental_pass_through.messages import handler
 
     capture = _FailureCapture()
     monkeypatch.setattr(litellm, "callbacks", [capture])
 
-    def upstream_rejects_the_key(request: httpx.Request) -> httpx.Response:
+    def upstream_rejects_the_request(request: httpx.Request) -> httpx.Response:
         return httpx.Response(
-            401,
-            json={"type": "error", "error": {"type": "authentication_error", "message": "invalid x-api-key"}},
+            upstream_status,
+            json={"type": "error", "error": {"type": upstream_error_type, "message": "rejected upstream"}},
             request=request,
         )
 
     upstream = AsyncHTTPHandler()
-    upstream.client = httpx.AsyncClient(transport=httpx.MockTransport(upstream_rejects_the_key))
+    upstream.client = httpx.AsyncClient(transport=httpx.MockTransport(upstream_rejects_the_request))
 
-    with pytest.raises(litellm.AuthenticationError) as excinfo:
+    with pytest.raises(expected_exception) as excinfo:
         await handler.anthropic_messages(
             max_tokens=16,
             messages=[{"role": "user", "content": "hi"}],
@@ -1329,13 +1342,13 @@ async def test_anthropic_messages_maps_provider_exception_before_failure_logging
             client=upstream,
         )
 
-    assert excinfo.value.status_code == 401
+    assert excinfo.value.status_code == upstream_status
     assert excinfo.value.llm_provider == "anthropic"
     assert "AnthropicException" in excinfo.value.message
-    assert '"authentication_error"' in excinfo.value.message
+    assert f'"{upstream_error_type}"' in excinfo.value.message
 
     assert capture.error_information, "the failure handler must have logged the mapped exception"
     error_information = capture.error_information[0]
-    assert error_information.get("error_class") == "AuthenticationError"
+    assert error_information.get("error_class") == expected_exception.__name__
     assert error_information.get("llm_provider") == "anthropic"
-    assert error_information.get("error_code") == "401"
+    assert error_information.get("error_code") == str(upstream_status)

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_anthropic_experimental_pass_through_messages_handler.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_anthropic_experimental_pass_through_messages_handler.py
@@ -7,6 +7,7 @@ from typing import Any, Dict, List
 import httpx
 import pytest
 from fastapi.testclient import TestClient
+from pydantic import ValidationError
 
 
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -1352,3 +1353,30 @@ async def test_anthropic_messages_maps_provider_exception_before_failure_logging
     assert error_information.get("error_class") == expected_exception.__name__
     assert error_information.get("llm_provider") == "anthropic"
     assert error_information.get("error_code") == str(upstream_status)
+
+
+@pytest.mark.asyncio
+async def test_anthropic_messages_leaves_non_provider_failures_unmapped():
+    """The mapping boundary is for provider failures only. A request rejected before
+    the provider call (here invalid metadata) must surface as the original exception,
+    not as the mapper's APIConnectionError, whose message embeds a server traceback."""
+    from litellm.llms.anthropic.experimental_pass_through.messages import handler
+
+    def upstream_must_not_be_called(request: httpx.Request) -> httpx.Response:
+        raise AssertionError("the provider must not be called for a request rejected locally")
+
+    upstream = AsyncHTTPHandler()
+    upstream.client = httpx.AsyncClient(transport=httpx.MockTransport(upstream_must_not_be_called))
+
+    with pytest.raises(ValidationError) as excinfo:
+        await handler.anthropic_messages(
+            max_tokens=16,
+            messages=[{"role": "user", "content": "hi"}],
+            model="anthropic/claude-haiku-4-5",
+            custom_llm_provider="anthropic",
+            api_key="sk-invalid",
+            client=upstream,
+            metadata={"user_id": 123},
+        )
+
+    assert "Traceback" not in str(excinfo.value)


### PR DESCRIPTION
## TLDR

Problem this solves:

- `/v1/messages` upstream errors logged as `BaseLLMException` with no provider
- OTel error spans for that route lack `litellm.provider.error.llm_provider`
- Same failure on `/v1/chat/completions` logs `AuthenticationError` + `anthropic`
- Error dashboards split one outage into two unrelated buckets

How it solves it:

- `/v1/messages` runs provider errors through the same exception mapping `acompletion` uses before failure logging
- Error body on `/v1/messages` now matches `/v1/chat/completions`
- e2e OTel test now covers the `/v1/messages` failure span
- Anthropic 403 `permission_error` maps to `PermissionDeniedError` (403) instead of falling through to `APIConnectionError` 500, so the upstream status survives now that `/v1/messages` rides the mapper
- The boundary maps provider failures only (`BaseLLMException`); a request rejected before the provider call, such as invalid `metadata`, keeps its original exception and error body exactly as before, with no server traceback added

## User Flow

Before: a team tracing their gateway in Jaeger sees a broken Anthropic key show up as `AuthenticationError` from `anthropic` on `/v1/chat/completions` but as a nameless `BaseLLMException` with no provider on `/v1/messages`, so the same outage lands in two different error buckets

1. They register a deployment with `POST https://litellm-domain/model/new` and body `{"model_name":"otel-err","litellm_params":{"model":"anthropic/claude-haiku-4-5","api_key":"<a revoked key>"}}` and get back `{"model_name": "otel-err", "model_id": "64a6fbd2-..."}`
2. They send `POST https://litellm-domain/v1/chat/completions` with `{"model":"otel-err","messages":[{"role":"user","content":"hi"}],"max_tokens":16}` and get HTTP 401 with `litellm.AuthenticationError: AnthropicException - {"type":"error","error":{"type":"authentication_error","message":"API key is invalid."}}` and an `x-litellm-call-id` header
3. They open that call id in Jaeger (`GET http://jaeger/api/traces?service=litellm&tags={"litellm.call_id":"<id>"}`) and the `chat otel-err` span shows `error.type = AuthenticationError`, `litellm.provider.error.code = 401`, `litellm.provider.error.llm_provider = anthropic`
4. They send `POST https://litellm-domain/v1/messages` with `{"model":"otel-err","messages":[{"role":"user","content":"hi"}],"max_tokens":16}` and get HTTP 401 whose body is only the raw upstream JSON, `{"type":"error","error":{"type":"authentication_error","message":"API key is invalid."}}. Received Model Group=otel-err`, with no `AuthenticationError` or `AnthropicException` label
5. They open that call id in Jaeger and both the `chat otel-err` span and the `POST /v1/messages` root span show `error.type = BaseLLMException`, `litellm.provider.error.code = 401`, and no `litellm.provider.error.llm_provider` at all, so a dashboard grouped by error type or provider never puts this call next to the one from step 3

After: the same `/v1/messages` failure is labeled exactly like the chat completions one, so both routes land in the same `AuthenticationError` / `anthropic` bucket

1. They register a deployment with `POST https://litellm-domain/model/new` and body `{"model_name":"otel-err","litellm_params":{"model":"anthropic/claude-haiku-4-5","api_key":"<a revoked key>"}}` and get back `{"model_name": "otel-err", "model_id": "64a6fbd2-..."}`
2. They send `POST https://litellm-domain/v1/chat/completions` with `{"model":"otel-err","messages":[{"role":"user","content":"hi"}],"max_tokens":16}` and get HTTP 401 with `litellm.AuthenticationError: AnthropicException - {"type":"error","error":{"type":"authentication_error","message":"API key is invalid."}}` and an `x-litellm-call-id` header
3. They open that call id in Jaeger (`GET http://jaeger/api/traces?service=litellm&tags={"litellm.call_id":"<id>"}`) and the `chat otel-err` span shows `error.type = AuthenticationError`, `litellm.provider.error.code = 401`, `litellm.provider.error.llm_provider = anthropic`
4. They send `POST https://litellm-domain/v1/messages` with `{"model":"otel-err","messages":[{"role":"user","content":"hi"}],"max_tokens":16}` and get HTTP 401 with the same `litellm.AuthenticationError: AnthropicException - {"type":"error","error":{"type":"authentication_error","message":"API key is invalid."}}` body as step 2
5. They open that call id in Jaeger and both the `chat otel-err` span and the `POST /v1/messages` root span show `error.type = AuthenticationError`, `litellm.provider.error.code = 401`, `litellm.provider.error.llm_provider = anthropic`, so the call sits in the same bucket as step 3

## Relevant issues

## Linear ticket

Resolves LIT-6164

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Shared setup: one Postgres and one Jaeger (`jaegertracing/all-in-one`, OTLP on 56785, query UI on 22396) in Docker, `LITELLM_OTEL_V2=1` and `PHOENIX_COLLECTOR_HTTP_ENDPOINT=http://localhost:56785/v1/traces` in the proxy env, and this config for both proxies (Before on 45477 at the merge base, After on 42602 at the PR tip)

```yaml
model_list:
  - model_name: claude-haiku-4-5
    litellm_params:
      model: anthropic/claude-haiku-4-5
      api_key: os.environ/ANTHROPIC_API_KEY

litellm_settings:
  callbacks: ["arize_phoenix"]

general_settings:
  master_key: sk-1234
  store_model_in_db: true
```

Each leg registers a deployment whose upstream Anthropic key is invalid, so every call really reaches `api.anthropic.com` and comes back 401

```bash
curl -s http://localhost:$PORT/model/new -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' \
  -d '{"model_name":"otel-err","litellm_params":{"model":"anthropic/claude-haiku-4-5","api_key":"sk-ant-upstream-invalid-for-otel-e2e-only"}}'
```

The span reader used in every case is the same `curl` against the Jaeger query API, printing every `error.*` and `litellm.provider.error.*` tag of every span carrying `error.type`

```bash
curl -s "http://localhost:22396/api/traces?service=litellm&tags=%7B%22litellm.call_id%22%3A%22$CALL_ID%22%7D" | python3 spans.py
```

### Before (3e2927de9a)

#### /v1/chat/completions

1. `curl -s -D - http://localhost:45477/v1/chat/completions -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' -d '{"model":"otel-err-before-1052","messages":[{"role":"user","content":"trigger an upstream auth failure"}],"max_tokens":16}'`
   ```
   HTTP/1.1 401 Unauthorized
   x-litellm-call-id: ec4b824c-7875-4877-9dbe-630ebe7ffe0c
   {"error":{"message":"litellm.AuthenticationError: AnthropicException - {\"type\":\"error\",\"error\":{\"type\":\"authentication_error\",\"message\":\"API key is invalid.\"},\"request_id\":null}. Received Model Group=otel
   ```
2. Read the trace for `ec4b824c-7875-4877-9dbe-630ebe7ffe0c`
   ```
   traces: 1 spans: ['auth /v1/chat/completions', 'chat otel-err-before-1052', 'postgres get_data', 'POST /v1/chat/completions']
     span: chat otel-err-before-1052
       error = 'True'
       error.type = 'AuthenticationError'
       litellm.provider.error.code = '401'
       litellm.provider.error.llm_provider = 'anthropic'
       litellm.provider.error.stack_trace present: True
     span: POST /v1/chat/completions
       error.type = 'ProxyException'
       litellm.provider.error.code = '401'
       litellm.provider.error.llm_provider = 'anthropic'
   ```

#### /v1/responses

1. `curl -s -D - http://localhost:45477/v1/responses -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' -d '{"model":"otel-err-before-1052","input":"trigger an upstream auth failure","max_output_tokens":16}'`
   ```
   HTTP/1.1 401 Unauthorized
   x-litellm-call-id: e4a152cc-f50b-467b-b752-c4f332abc7b3
   {"error":{"message":"litellm.AuthenticationError: AnthropicException - {\"type\":\"error\",\"error\":{\"type\":\"authentication_error\",\"message\":\"API key is invalid.\"},\"request_id\":null}. Received Model Group=otel
   ```
2. Read the trace for `e4a152cc-f50b-467b-b752-c4f332abc7b3`
   ```
   traces: 1 spans: ['auth /v1/responses', 'chat otel-err-before-1052', 'postgres get_data', 'POST /v1/responses']
     span: chat otel-err-before-1052
       error = 'True'
       error.type = 'AuthenticationError'
       litellm.provider.error.code = '401'
       litellm.provider.error.llm_provider = 'anthropic'
       litellm.provider.error.stack_trace present: True
     span: POST /v1/responses
       error.type = 'ProxyException'
       litellm.provider.error.code = '401'
       litellm.provider.error.llm_provider = 'anthropic'
   ```

#### /v1/messages

1. `curl -s -D - http://localhost:45477/v1/messages -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' -d '{"model":"otel-err-before-1052","messages":[{"role":"user","content":"trigger an upstream auth failure"}],"max_tokens":16}'`
   ```
   HTTP/1.1 401 Unauthorized
   x-litellm-call-id: 3e9f7586-ba6e-445f-9248-12db7b96a755
   {"error":{"message":"{\"type\":\"error\",\"error\":{\"type\":\"authentication_error\",\"message\":\"API key is invalid.\"},\"request_id\":null}. Received Model Group=otel-err-before-1052\nAvailable Model Group Fallbacks=
   ```
   The body is the raw upstream JSON with no `AuthenticationError` / `AnthropicException` label
2. Read the trace for `3e9f7586-ba6e-445f-9248-12db7b96a755`
   ```
   traces: 1 spans: ['auth /v1/messages', 'chat otel-err-before-1052', 'postgres get_data', 'POST /v1/messages']
     span: chat otel-err-before-1052
       error = 'True'
       error.message = '{"type":"error","error":{"type":"authentication_error","message":"API key is invalid."},"request_id":null}'
       error.type = 'BaseLLMException'
       litellm.provider.error.code = '401'
       litellm.provider.error.stack_trace present: True
     span: POST /v1/messages
       error.type = 'ProxyException'
       litellm.provider.error.code = '401'
       litellm.provider.error.stack_trace present: True
   ```
   `error.type` is `BaseLLMException` and neither span carries `litellm.provider.error.llm_provider`

### After (5cfc1608f9)

#### /v1/chat/completions

1. `curl -s -D - http://localhost:42602/v1/chat/completions -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' -d '{"model":"otel-err-after-23312","messages":[{"role":"user","content":"trigger an upstream auth failure"}],"max_tokens":16}'`
   ```
   HTTP/1.1 401 Unauthorized
   x-litellm-call-id: 49d376ca-6b27-46e7-aa06-539018c9646e
   {"error":{"message":"litellm.AuthenticationError: AnthropicException - {\"type\":\"error\",\"error\":{\"type\":\"authentication_error\",\"message\":\"API key is invalid.\"},\"request_id\":null}. Received Model Group=otel
   ```
2. Read the trace for `49d376ca-6b27-46e7-aa06-539018c9646e`
   ```
   traces: 1 spans: ['postgres get_data', 'POST /v1/chat/completions', 'auth /v1/chat/completions', 'chat otel-err-after-23312']
     span: chat otel-err-after-23312
       error = 'True'
       error.type = 'AuthenticationError'
       litellm.provider.error.code = '401'
       litellm.provider.error.llm_provider = 'anthropic'
       litellm.provider.error.stack_trace present: True
     span: POST /v1/chat/completions
       error = 'True'
       error.type = 'ProxyException'
       litellm.provider.error.code = '401'
       litellm.provider.error.llm_provider = 'anthropic'
       litellm.provider.error.stack_trace present: True
   ```

#### /v1/responses

1. `curl -s -D - http://localhost:42602/v1/responses -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' -d '{"model":"otel-err-after-23312","input":"trigger an upstream auth failure","max_output_tokens":16}'`
   ```
   HTTP/1.1 401 Unauthorized
   x-litellm-call-id: 841fb8df-6c40-4717-ba5d-665a299b8b37
   {"error":{"message":"litellm.AuthenticationError: AnthropicException - {\"type\":\"error\",\"error\":{\"type\":\"authentication_error\",\"message\":\"API key is invalid.\"},\"request_id\":null}. Received Model Group=otel
   ```
2. Read the trace for `841fb8df-6c40-4717-ba5d-665a299b8b37`
   ```
   traces: 1 spans: ['postgres get_data', 'POST /v1/responses', 'auth /v1/responses', 'chat otel-err-after-23312']
     span: chat otel-err-after-23312
       error = 'True'
       error.type = 'AuthenticationError'
       litellm.provider.error.code = '401'
       litellm.provider.error.llm_provider = 'anthropic'
       litellm.provider.error.stack_trace present: True
     span: POST /v1/responses
       error = 'True'
       error.type = 'ProxyException'
       litellm.provider.error.code = '401'
       litellm.provider.error.llm_provider = 'anthropic'
       litellm.provider.error.stack_trace present: True
   ```

#### /v1/messages

1. `curl -s -D - http://localhost:42602/v1/messages -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' -d '{"model":"otel-err-after-23312","messages":[{"role":"user","content":"trigger an upstream auth failure"}],"max_tokens":16}'`
   ```
   HTTP/1.1 401 Unauthorized
   x-litellm-call-id: 16ee3ce3-2620-4d94-bb10-2e50818359ce
   {"error":{"message":"litellm.AuthenticationError: AnthropicException - {\"type\":\"error\",\"error\":{\"type\":\"authentication_error\",\"message\":\"API key is invalid.\"},\"request_id\":null}. Received Model Group=otel
   ```
   The body carries the same `litellm.AuthenticationError: AnthropicException` label as the other two routes
2. Read the trace for `16ee3ce3-2620-4d94-bb10-2e50818359ce`
   ```
   traces: 1 spans: ['POST /v1/messages', 'auth /v1/messages', 'chat otel-err-after-23312', 'postgres get_data']
     span: chat otel-err-after-23312
       error = 'True'
       error.type = 'AuthenticationError'
       litellm.provider.error.code = '401'
       litellm.provider.error.llm_provider = 'anthropic'
       litellm.provider.error.stack_trace present: True
     span: POST /v1/messages
       error = 'True'
       error.type = 'ProxyException'
       litellm.provider.error.code = '401'
       litellm.provider.error.llm_provider = 'anthropic'
       litellm.provider.error.stack_trace present: True
   ```

## Type

🐛 Bug Fix

## Caveats (if any)

### Low

- `/v1/messages` error bodies now carry the `litellm.AuthenticationError: AnthropicException -` prefix like the other routes
- Providers with no exception-mapping branch still surface as `APIConnectionError` 500 on `/v1/messages`, exactly as they do on `/v1/chat/completions` today
- The sync `litellm.anthropic.messages.create` path still raises the raw provider exception
- An Anthropic 403 on `/v1/chat/completions` was `APIConnectionError` 500 and is now `PermissionDeniedError` 403, so the router stops retrying it as a 5xx
- A `/v1/messages` request rejected before the provider call (for example a non-string `metadata.user_id`) still answers 500 with the raw validation message, unchanged from before this PR

## QA runbook

- tests/e2e/logging/test_otel_trace_e2e.py::TestOtelTraceCompleteness::test_failed_messages_error_span_attributes - a `/v1/messages` call that fails upstream with a bad Anthropic key exports a complete trace whose gen-AI span carries the typed error contract (`AuthenticationError`, code 401, provider `anthropic`, stack trace) exactly like the existing `/v1/chat/completions` failure test
  - [ ] Run the proxy with `LITELLM_OTEL_V2=1`, `callbacks: ["arize_phoenix"]`, `store_model_in_db: true`, and `PHOENIX_COLLECTOR_HTTP_ENDPOINT` pointing at a Jaeger OTLP HTTP endpoint (the harness brings its own Jaeger)
  - [ ] `POST /model/new` with `{"model_name":"otel-err","litellm_params":{"model":"anthropic/claude-haiku-4-5","api_key":"sk-ant-upstream-invalid-for-otel-e2e-only"}}` and a master key, expect a `model_id` back
  - [ ] `POST /v1/messages` with `{"model":"otel-err","messages":[{"role":"user","content":"trigger an upstream auth failure"}],"max_tokens":16}` and expect HTTP 401, an `x-litellm-call-id` header, and a body containing `AnthropicException`
  - [ ] Query Jaeger for that call id and expect a single trace with an `auth /v1/messages` span, a `chat otel-err` span, and a `POST /v1/messages` root span whose `http.status_code` is 401
  - [ ] On the `chat otel-err` span expect `error = True`, `error.type = AuthenticationError`, `otel.status_code = ERROR`, `litellm.provider.error.code = 401`, `litellm.provider.error.llm_provider = anthropic`, a non-empty `litellm.provider.error.stack_trace`, and an `error.message` containing `AnthropicException` whose embedded provider JSON still parses
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey (e.g., assert actual expected spend instead of just spend > 0) or potentially flaky

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

- [x] 3fe65029bf passes /live-pr-risk
- [x] 5cfc1608f9 passes /live-pr-risk

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes client-visible errors and OTel attributes on `/v1/messages`, and Anthropic 403 now surfaces as 403 (affecting router retry behavior vs prior 500 fallthrough).
> 
> **Overview**
> **Fixes `/v1/messages` surfacing raw `BaseLLMException` to failure loggers and OTel**, so upstream Anthropic failures match `/v1/chat/completions` (`AuthenticationError`, provider `anthropic`, typed error spans).
> 
> The async `anthropic_messages` executor path now catches **`BaseLLMException`** and re-raises through **`exception_type`**, limiting mapping to provider HTTP failures; local validation errors (e.g. bad `metadata`) are unchanged.
> 
> **Anthropic HTTP 403** is mapped to **`PermissionDeniedError` (403)** instead of falling through to **`APIConnectionError` (500)**.
> 
> Adds **e2e OTel** coverage for failed `/v1/messages` and **unit/regression tests** for mapped 401/403 and failure-logging payloads.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5cfc1608f95d6853dae7c0207ac0d5d375b32f21. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->