### PR TITLE
test(streaming): pin the chain from a streamed reply to what it costs

### DIFF
--- a/tests/test_litellm/test_main.py
+++ b/tests/test_litellm/test_main.py
@@ -10,6 +10,7 @@ from fastapi.testclient import TestClient
 
 
 import urllib.parse
+from typing_extensions import ReadOnly, TypedDict
 from unittest.mock import MagicMock, patch
 
 import litellm
@@ -2959,15 +2960,40 @@ async def test_acompletion_resolves_provider_from_api_base():
     assert response.choices[0].message.content == "resolved"
 
 
-OPENAI_HOST = "api.openai.com"
+OPENAI_CHAT_COMPLETIONS_URL = "https://api.openai.com/v1/chat/completions"
 A_STREAMED_MODEL = "gpt-4o"
 
 
-def _sse(chunks: list[dict]) -> str:
+class _StreamedDelta(TypedDict, total=False):
+    content: ReadOnly[str]
+
+
+class _StreamedChoice(TypedDict):
+    index: ReadOnly[int]
+    delta: ReadOnly[_StreamedDelta]
+    finish_reason: ReadOnly[str | None]
+
+
+class _StreamedUsage(TypedDict):
+    prompt_tokens: ReadOnly[int]
+    completion_tokens: ReadOnly[int]
+    total_tokens: ReadOnly[int]
+
+
+class _StreamedChunk(TypedDict, total=False):
+    id: ReadOnly[str]
+    object: ReadOnly[str]
+    created: ReadOnly[int]
+    model: ReadOnly[str]
+    choices: ReadOnly[list[_StreamedChoice]]
+    usage: ReadOnly[_StreamedUsage]
+
+
+def _sse(chunks: list[_StreamedChunk]) -> str:
     return "".join(f"data: {json.dumps(chunk)}\n\n" for chunk in chunks) + "data: [DONE]\n\n"
 
 
-def _content_chunk(text: str, finish_reason: str | None = None) -> dict:
+def _content_chunk(text: str, finish_reason: str | None = None) -> _StreamedChunk:
     return {
         "id": "chatcmpl-stream",
         "object": "chat.completion.chunk",
@@ -2977,7 +3003,7 @@ def _content_chunk(text: str, finish_reason: str | None = None) -> dict:
     }
 
 
-def _usage_chunk(prompt_tokens: int, completion_tokens: int) -> dict:
+def _usage_chunk(prompt_tokens: int, completion_tokens: int) -> _StreamedChunk:
     return {
         "id": "chatcmpl-stream",
         "object": "chat.completion.chunk",
@@ -2993,7 +3019,7 @@ def _usage_chunk(prompt_tokens: int, completion_tokens: int) -> dict:
 
 
 def _a_stream(deltas: tuple[str, ...], prompt_tokens: int, completion_tokens: int) -> str:
-    body = [_content_chunk(delta) for delta in deltas[:-1]]
+    body: list[_StreamedChunk] = [_content_chunk(delta) for delta in deltas[:-1]]
     body.append(_content_chunk(deltas[-1], finish_reason="stop"))
     body.append(_usage_chunk(prompt_tokens, completion_tokens))
     return _sse(body)
@@ -3001,8 +3027,8 @@ def _a_stream(deltas: tuple[str, ...], prompt_tokens: int, completion_tokens: in
 
 @contextlib.contextmanager
 def _openai_streaming(body: str):
-    with respx.mock:
-        respx.route(host=OPENAI_HOST).mock(
+    with respx.mock(assert_all_called=True) as router:
+        router.post(OPENAI_CHAT_COMPLETIONS_URL).mock(
             return_value=httpx.Response(
                 200, text=body, headers={"content-type": "text/event-stream"}
             )

--- a/tests/test_litellm/test_main.py
+++ b/tests/test_litellm/test_main.py
@@ -2957,3 +2957,161 @@ async def test_acompletion_resolves_provider_from_api_base():
     )
 
     assert response.choices[0].message.content == "resolved"
+
+
+OPENAI_HOST = "api.openai.com"
+A_STREAMED_MODEL = "gpt-4o"
+
+
+def _sse(chunks: list[dict]) -> str:
+    return "".join(f"data: {json.dumps(chunk)}\n\n" for chunk in chunks) + "data: [DONE]\n\n"
+
+
+def _content_chunk(text: str, finish_reason: str | None = None) -> dict:
+    return {
+        "id": "chatcmpl-stream",
+        "object": "chat.completion.chunk",
+        "created": 1,
+        "model": A_STREAMED_MODEL,
+        "choices": [{"index": 0, "delta": {"content": text}, "finish_reason": finish_reason}],
+    }
+
+
+def _usage_chunk(prompt_tokens: int, completion_tokens: int) -> dict:
+    return {
+        "id": "chatcmpl-stream",
+        "object": "chat.completion.chunk",
+        "created": 1,
+        "model": A_STREAMED_MODEL,
+        "choices": [],
+        "usage": {
+            "prompt_tokens": prompt_tokens,
+            "completion_tokens": completion_tokens,
+            "total_tokens": prompt_tokens + completion_tokens,
+        },
+    }
+
+
+def _a_stream(deltas: tuple[str, ...], prompt_tokens: int, completion_tokens: int) -> str:
+    body = [_content_chunk(delta) for delta in deltas[:-1]]
+    body.append(_content_chunk(deltas[-1], finish_reason="stop"))
+    body.append(_usage_chunk(prompt_tokens, completion_tokens))
+    return _sse(body)
+
+
+@contextlib.contextmanager
+def _openai_streaming(body: str):
+    with respx.mock:
+        respx.route(host=OPENAI_HOST).mock(
+            return_value=httpx.Response(
+                200, text=body, headers={"content-type": "text/event-stream"}
+            )
+        )
+        yield
+
+
+def _collect(deltas: tuple[str, ...], prompt_tokens: int, completion_tokens: int):
+    with _openai_streaming(_a_stream(deltas, prompt_tokens, completion_tokens)):
+        stream = litellm.completion(
+            model=A_STREAMED_MODEL,
+            messages=[{"role": "user", "content": "hi"}],
+            api_key="fake-key",
+            stream=True,
+            stream_options={"include_usage": True},
+        )
+        return list(stream)
+
+
+def _expected_cost(prompt_tokens: int, completion_tokens: int) -> float:
+    rates = litellm.model_cost[A_STREAMED_MODEL]
+    return (
+        prompt_tokens * rates["input_cost_per_token"]
+        + completion_tokens * rates["output_cost_per_token"]
+    )
+
+
+def test_a_streamed_reply_rebuilds_into_the_text_the_provider_sent():
+    chunks = _collect(("Hel", "lo th", "ere"), prompt_tokens=11, completion_tokens=7)
+
+    rebuilt = litellm.stream_chunk_builder(chunks, messages=[{"role": "user", "content": "hi"}])
+
+    assert rebuilt.choices[0].message.content == "Hello there"
+    assert rebuilt.choices[0].finish_reason == "stop"
+
+
+def test_a_streamed_reply_keeps_the_token_counts_the_provider_reported():
+    chunks = _collect(("Hel", "lo th", "ere"), prompt_tokens=11, completion_tokens=7)
+
+    rebuilt = litellm.stream_chunk_builder(chunks, messages=[{"role": "user", "content": "hi"}])
+
+    assert rebuilt.usage.prompt_tokens == 11
+    assert rebuilt.usage.completion_tokens == 7
+    assert rebuilt.usage.total_tokens == 18
+
+
+def test_a_streamed_reply_is_billed_on_the_counts_the_provider_reported():
+    chunks = _collect(("Hel", "lo th", "ere"), prompt_tokens=11, completion_tokens=7)
+    rebuilt = litellm.stream_chunk_builder(chunks, messages=[{"role": "user", "content": "hi"}])
+
+    cost = litellm.completion_cost(completion_response=rebuilt, model=A_STREAMED_MODEL)
+
+    assert cost == _expected_cost(11, 7)
+
+
+def test_the_bill_follows_the_provider_counts_not_the_length_of_the_text():
+    same_text = ("Hel", "lo th", "ere")
+
+    cheap = litellm.stream_chunk_builder(
+        _collect(same_text, prompt_tokens=11, completion_tokens=7),
+        messages=[{"role": "user", "content": "hi"}],
+    )
+    expensive = litellm.stream_chunk_builder(
+        _collect(same_text, prompt_tokens=1100, completion_tokens=700),
+        messages=[{"role": "user", "content": "hi"}],
+    )
+
+    assert litellm.completion_cost(completion_response=cheap, model=A_STREAMED_MODEL) == _expected_cost(11, 7)
+    assert litellm.completion_cost(
+        completion_response=expensive, model=A_STREAMED_MODEL
+    ) == _expected_cost(1100, 700)
+
+
+def test_prompt_and_completion_tokens_are_billed_at_their_own_rates():
+    rates = litellm.model_cost[A_STREAMED_MODEL]
+    assert rates["input_cost_per_token"] != rates["output_cost_per_token"]
+
+    prompt_heavy = litellm.stream_chunk_builder(
+        _collect(("Hel", "lo"), prompt_tokens=100, completion_tokens=10),
+        messages=[{"role": "user", "content": "hi"}],
+    )
+    completion_heavy = litellm.stream_chunk_builder(
+        _collect(("Hel", "lo"), prompt_tokens=10, completion_tokens=100),
+        messages=[{"role": "user", "content": "hi"}],
+    )
+
+    assert litellm.completion_cost(
+        completion_response=prompt_heavy, model=A_STREAMED_MODEL
+    ) == _expected_cost(100, 10)
+    assert litellm.completion_cost(
+        completion_response=completion_heavy, model=A_STREAMED_MODEL
+    ) == _expected_cost(10, 100)
+
+
+@pytest.mark.asyncio
+async def test_a_streamed_reply_keeps_the_provider_counts_on_the_async_path(monkeypatch):
+    monkeypatch.setattr(litellm, "disable_aiohttp_transport", True)
+
+    with _openai_streaming(_a_stream(("Hel", "lo"), prompt_tokens=11, completion_tokens=7)):
+        stream = await litellm.acompletion(
+            model=A_STREAMED_MODEL,
+            messages=[{"role": "user", "content": "hi"}],
+            api_key="fake-key",
+            stream=True,
+            stream_options={"include_usage": True},
+        )
+        chunks = [chunk async for chunk in stream]
+
+    rebuilt = litellm.stream_chunk_builder(chunks, messages=[{"role": "user", "content": "hi"}])
+    assert rebuilt.choices[0].message.content == "Hello"
+    assert rebuilt.usage.prompt_tokens == 11
+    assert rebuilt.usage.completion_tokens == 7


### PR DESCRIPTION
## TLDR

Problem this solves:

- Streamed chunks, the rebuilt reply, and the cost each have tests
- The chain joining them does not, and that chain is what customers see
- A break anywhere in it reads as spend that misses their provider bill

How it solves it:

- Drive a real streamed completion against a recorded SSE endpoint
- Assert the provider's own token counts survive, and price them

## User Flow

This PR adds tests and changes no behavior, so the flow below is what the tests hold in place rather than something that changes between Before and After.

Before: nothing stops a change from quietly billing a streamed request on estimated tokens instead of the provider's own

1. A developer sends POST https://litellm-domain/v1/chat/completions with `"stream": true` and `"stream_options": {"include_usage": true}`
2. The last SSE chunk carries the provider's counts, 11 prompt and 7 completion tokens
3. They open https://litellm-domain/ui/?page=logs and see the request billed on those counts
4. Nothing in CI would notice if a later change billed it on locally counted tokens instead, so the logged spend would drift from the provider's bill

After: each step is pinned, so that drift turns the suite red before it ships

1. The same streamed POST
2. The same counts arrive and are kept unchanged
3. The spend is still those counts at the model's rates
4. A change that estimated the tokens, or billed output at the input rate, now fails CI

## Relevant issues

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## What is pinned

- The deltas rebuild into the text the provider sent, with its finish reason
- The token counts the provider reported survive the stream unchanged
- The bill is those counts at the model registry's rates
- The bill follows the reported counts rather than the length of the text, so a fallback to locally estimated tokens is caught
- Prompt and completion tokens are billed at their own separate rates
- The counts survive on the async path too

## Screenshots / Proof of Fix

Tests only, so the proof is that they fail when the behaviour they pin is broken. The endpoint is faked at the HTTP boundary, so this costs no provider spend and needs no key.

### Before (`41c920de7f^`, the merge base)

#### The chain is untested end to end

1. `stream_chunk_builder` and `completion_cost` are each well covered, but no test starts from SSE bytes and ends at a cost. Ask for one:

```bash
grep -l "text/event-stream" $(grep -rl "completion_cost" tests/test_litellm/) | wc -l
```

2. Output: `0`

### After (`41c920de7f`)

#### The suite passes

1. Run the file:

```bash
uv run pytest tests/test_litellm/test_main.py -q
```

2. Output: `102 passed` in 1.42s, with no network egress

#### The recorded exchange

1. The endpoint streams three content chunks then the provider's usage chunk:

```
data: {"choices":[{"index":0,"delta":{"content":"Hel"},"finish_reason":null}], ...}
data: {"choices":[{"index":0,"delta":{"content":"lo th"},"finish_reason":null}], ...}
data: {"choices":[{"index":0,"delta":{"content":"ere"},"finish_reason":"stop"}], ...}
data: {"choices":[],"usage":{"prompt_tokens":11,"completion_tokens":7,"total_tokens":18}, ...}
data: [DONE]
```

2. The rebuilt reply reads `Hello there`, `finish_reason` `stop`, usage `11 / 7 / 18`
3. The cost is `11 * input_cost_per_token + 7 * output_cost_per_token` for the model, taken from `litellm.model_cost`

#### Each pinned behavior fails when its source is mutated

Applied one at a time to `litellm/litellm_core_utils/llm_cost_calc/utils.py`, reverting between each, running `uv run pytest tests/test_litellm/test_main.py -q -k "streamed or billed or bill_follows or own_rates"` after each:

1. Prompt tokens billed at half rate (line 658, `* prompt_base_cost` -> `* prompt_base_cost * 0.5`): `5 failed, 3 passed`
2. Completion tokens billed at the prompt rate (line 954, `* completion_base_cost` -> `* prompt_base_cost`): `5 failed, 3 passed`
3. The recorded route pointed at a wrong path (`/v1/chat/completions` -> `/v1/WRONG`): `5 failed, 2 passed`, so the route match is load-bearing rather than decorative

Both revert cleanly; `git status litellm/` is empty at the tip.

## Type

✅ Test

## Caveats (if any)

### Low

- Expected costs are derived from `litellm.model_cost`, not hardcoded, so a price change will not turn these red while the arithmetic stays pinned
- The async case pins the transport to httpx, since the aiohttp default carries a transport an httpx-level fake cannot intercept
- The chain stops at the cost number; the spend write itself needs a database and belongs in a tier above this one
- A provider that reports zero completion tokens alongside real content gets a locally counted 1 instead, so that combination is deliberately not asserted here
- `ReadOnly` and `TypedDict` come from `typing_extensions`, since the unit shards run Python 3.12 and `typing.ReadOnly` landed in 3.13
