### PR TITLE
feat(proxy): hide unhealthy models from model listings, opt-in

### DIFF
--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -2507,6 +2507,17 @@ class ConfigGeneralSettings(LiteLLMPydanticObjectBase):
             "are skipped for on-demand GET /health as well as the background health loop."
         ),
     )
+    model_list_healthy_only: bool | None = Field(
+        None,
+        description=(
+            "When true, `/models`, `/v1/models/{id}` and `/model/info` hide models whose backing "
+            "deployments are all unhealthy, for every caller, without needing `healthy_only=true` "
+            "per request. Requires `background_health_checks: true`, and keeps deployment health "
+            "state cached without turning on `enable_health_check_routing`, so routing is "
+            "unaffected. With no health state nothing is hidden. Hiding is presentation-only, a "
+            "hidden model can still be called."
+        ),
+    )
     alerting: list | None = Field(
         None,
         description="List of alerting integrations. Today, just slack - `alerting: ['slack']`",

--- a/litellm/proxy/common_utils/healthy_model_filter.py
+++ b/litellm/proxy/common_utils/healthy_model_filter.py
@@ -1,0 +1,79 @@
+"""Opt-in health filtering shared by the model listing endpoints.
+
+`/v1/models`, `GET /v1/models/{id}` and `/v1/model/info` hide models whose
+backing deployments are all marked unhealthy by background health checks, either
+per request via `healthy_only=true` or proxy-wide via
+`general_settings.model_list_healthy_only: true`. Both are opt-in: with neither
+set the listings are returned unfiltered and no health lookup runs at all.
+
+The proxy-wide setting is what an operator turns on so every client (UI, SDK,
+raw API) sees only reachable models without having to pass the query parameter.
+It also makes the background health check loop keep the deployment health cache
+populated, so `background_health_checks: true` is the only other setting needed.
+The per-request parameter reads that same cache, so on its own it needs the
+cache to be filled by either this setting or `enable_health_check_routing`.
+
+Filtering is presentation-only and always fails open: it answers "should this
+model be advertised?", never "should a request for it be attempted?". A hidden
+model stays callable, and an absent, stale or empty health state hides nothing.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Final
+
+from litellm._logging import verbose_proxy_logger
+
+if TYPE_CHECKING:
+    from litellm.router import Router
+
+MODEL_LIST_HEALTHY_ONLY_SETTING: Final = "model_list_healthy_only"
+
+
+def is_healthy_only_listing_default(general_settings: Mapping[str, object]) -> bool:
+    """Whether `model_list_healthy_only` filters every listing on this proxy.
+
+    Only a real `true` counts, so a quoted YAML value never silently starts
+    hiding models. This also tells the background health check loop to keep the
+    deployment health cache populated, which is the state the filter reads.
+    """
+    return general_settings.get(MODEL_LIST_HEALTHY_ONLY_SETTING, False) is True
+
+
+def is_healthy_only_enabled(
+    healthy_only: bool | None,
+    general_settings: Mapping[str, object],
+) -> bool:
+    """Whether the health filter applies to this request.
+
+    The per-request `healthy_only=true` and the proxy-wide
+    `model_list_healthy_only` setting are independent opt-ins: either one turns
+    the filter on, and a request cannot turn the proxy-wide setting back off
+    (`healthy_only=false` is the unset default, indistinguishable from absent).
+    """
+    if healthy_only:
+        return True
+    return is_healthy_only_listing_default(general_settings)
+
+
+async def get_hidden_unhealthy_model_names(
+    healthy_only: bool | None,
+    general_settings: Mapping[str, object],
+    llm_router: Router | None,
+) -> set[str]:
+    """Model names to hide from a listing, empty when the filter is off.
+
+    Empty is also the fail-open answer whenever the router cannot report health
+    (no router, no background health checks, stale state, `allowed_fails_policy`
+    configured), so callers apply it unconditionally and simply hide nothing.
+    """
+    if llm_router is None or not is_healthy_only_enabled(healthy_only, general_settings):
+        return set()
+    unhealthy_names: Final = await llm_router.async_get_fully_unhealthy_model_names()
+    if not unhealthy_names:
+        verbose_proxy_logger.debug(
+            "healthy-only model listing is enabled but no unhealthy deployment state is "
+            "available (requires background_health_checks); returning unfiltered model list"
+        )
+    return unhealthy_names

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -329,6 +329,10 @@ from litellm.proxy.common_utils.encrypt_decrypt_utils import (
     decrypt_value_helper,
     encrypt_value_helper,
 )
+from litellm.proxy.common_utils.healthy_model_filter import (
+    get_hidden_unhealthy_model_names,
+    is_healthy_only_listing_default,
+)
 from litellm.proxy.common_utils.html_forms.ui_login import build_ui_login_form
 from litellm.proxy.common_utils.http_parsing_utils import (
     _read_request_body,
@@ -3483,6 +3487,13 @@ def _write_health_state_to_router_cache(
     """
     Write deployment health states to the router's health state cache
     for health-check-driven routing. No-op if the feature is disabled.
+
+    `model_list_healthy_only` reads the same cache to hide unhealthy models from
+    the listing endpoints, so it also keeps the cache populated. That is a pure
+    write: every routing-time reader is itself gated on
+    `enable_health_check_routing`, and the cooldown/failure bookkeeping below
+    stays behind that flag, so routing is untouched when only the listing filter
+    is on.
     """
     from litellm.proxy.health_check import build_deployment_health_states
     from litellm.router_utils.cooldown_handlers import _set_cooldown_deployments
@@ -3493,7 +3504,10 @@ def _write_health_state_to_router_cache(
     _exceptions: Final[dict] = exceptions_by_model_id or {}
 
     try:
-        if llm_router is None or not llm_router.enable_health_check_routing:
+        if llm_router is None:
+            return
+        health_check_routing_enabled: Final = llm_router.enable_health_check_routing
+        if not health_check_routing_enabled and not is_healthy_only_listing_default(general_settings):
             return
 
         # When health_check_ignore_transient_errors is set, treat 429/408
@@ -3515,6 +3529,9 @@ def _write_health_state_to_router_cache(
                 sum(1 for s in states.values() if s.get("is_healthy")),
                 sum(1 for s in states.values() if not s.get("is_healthy")),
             )
+
+        if not health_check_routing_enabled:
+            return
 
         for endpoint in unhealthy_endpoints:
             model_id = endpoint.get("model_id")
@@ -9760,9 +9777,13 @@ async def model_list(
              When scope=expand is passed, proxy admins, team admins, and org admins
              will receive all proxy models as if they are a proxy admin.
     - healthy_only: When true, hide models whose backing deployments are all marked
-                    unhealthy by background health checks. Requires
-                    `background_health_checks: true` in general_settings; without
-                    health state the listing is returned unfiltered (fail open).
+                    unhealthy by background health checks. Set
+                    `general_settings.model_list_healthy_only: true` to apply this
+                    to every caller without the query parameter. Requires
+                    `background_health_checks: true` in general_settings, plus
+                    either `model_list_healthy_only` or `enable_health_check_routing`
+                    to keep deployment health state cached; without health state
+                    the listing is returned unfiltered (fail open).
                     Models expanded from wildcard routes (e.g. `openai/*`) are not
                     filtered, and nothing is hidden when `allowed_fails_policy` is
                     configured (cooldown remains the sole exclusion mechanism).
@@ -9812,14 +9833,11 @@ async def model_list(
 
     # Opt-in: also hide models whose deployments are all unhealthy per background
     # health checks. Empty when health state is unavailable or stale (fail open).
-    unhealthy_names: set[str] = set()
-    if healthy_only and llm_router is not None:
-        unhealthy_names = await llm_router.async_get_fully_unhealthy_model_names()
-        if not unhealthy_names:
-            verbose_proxy_logger.debug(
-                "healthy_only=true but no unhealthy deployment state is available "
-                "(requires background_health_checks); returning unfiltered model list"
-            )
+    unhealthy_names: Final = await get_hidden_unhealthy_model_names(
+        healthy_only=healthy_only,
+        general_settings=settings,
+        llm_router=llm_router,
+    )
 
     hidden_names: Final = blocked_names | unhealthy_names
 
@@ -9982,9 +10000,11 @@ async def model_info(
     # Mirror /v1/models' visibility filter so first-occurrence resolution
     # cannot land on a deployment the listing had hidden.
     blocked_names: Final = llm_router.get_fully_blocked_model_names() if llm_router is not None else set()
-    unhealthy_names: set[str] = set()
-    if healthy_only and llm_router is not None:
-        unhealthy_names = await llm_router.async_get_fully_unhealthy_model_names()
+    unhealthy_names: Final = await get_hidden_unhealthy_model_names(
+        healthy_only=healthy_only,
+        general_settings=settings,
+        llm_router=llm_router,
+    )
     hidden_names: Final = blocked_names | unhealthy_names
     if hidden_names:
         all_models = [m for m in all_models if m not in hidden_names]
@@ -14009,6 +14029,7 @@ async def model_info_v1(
         None,
         description="Filter models by team ID. Returns models with direct_access=True or teamId in access_via_team_ids",
     ),
+    healthy_only: bool | None = False,
 ):
     """
     Provides more info about each model in /models, including config.yaml descriptions (except api key and api base)
@@ -14020,6 +14041,15 @@ async def model_info_v1(
         - When litellm_model_id is not passed, it will return the info for all models
         - include_team_models: When true, filter to deployments the caller can use (same as /v2/model/info).
         - teamId: Filter to models accessible by the given team.
+        - healthy_only: When true, hide models whose backing deployments are all marked
+          unhealthy by background health checks, matching `/v1/models?healthy_only=true`.
+          Set `general_settings.model_list_healthy_only: true` to apply this to every
+          caller without the query parameter. Requires `background_health_checks: true`,
+          plus either `model_list_healthy_only` or `enable_health_check_routing` to keep
+          deployment health state cached; without health state the listing is returned
+          unfiltered (fail open). Ignored when `litellm_model_id` is passed, since that
+          is a direct lookup of one deployment rather than a listing. Hiding is
+          presentation-only: a hidden model can still be called directly.
 
     Each model in the list response includes `model_info.access_via_team_ids` and
     `model_info.direct_access` when the proxy database is connected.
@@ -14184,8 +14214,17 @@ async def model_info_v1(
             user_api_key_dict=user_api_key_dict,
         )
 
-    verbose_proxy_logger.debug("all_models: %s", all_models)
-    return {"data": all_models}
+    hidden_names: Final = await get_hidden_unhealthy_model_names(
+        healthy_only=healthy_only,
+        general_settings=general_settings,
+        llm_router=llm_router,
+    )
+    visible_models: Final = (
+        [model for model in all_models if model.get("model_name") not in hidden_names] if hidden_names else all_models
+    )
+
+    verbose_proxy_logger.debug("all_models: %s", visible_models)
+    return {"data": visible_models}
 
 
 @router.get(

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -14219,9 +14219,7 @@ async def model_info_v1(
         general_settings=general_settings,
         llm_router=llm_router,
     )
-    visible_models: Final = (
-        [model for model in all_models if model.get("model_name") not in hidden_names] if hidden_names else all_models
-    )
+    visible_models: Final = [model for model in all_models if model.get("model_name") not in hidden_names]
 
     verbose_proxy_logger.debug("all_models: %s", visible_models)
     return {"data": visible_models}

--- a/tests/test_litellm/proxy/proxy_server/test_background_health.py
+++ b/tests/test_litellm/proxy/proxy_server/test_background_health.py
@@ -344,6 +344,72 @@ def test_write_health_state_to_router_cache_noop_when_router_none(monkeypatch):
     _write_health_state_to_router_cache([], [], {})
 
 
+def test_write_health_state_to_router_cache_noop_when_nothing_opted_in(monkeypatch):
+    """Neither health-check routing nor the listing filter: write nothing."""
+    fake_router = MagicMock()
+    fake_router.enable_health_check_routing = False
+    fake_router.health_check_ignore_transient_errors = False
+
+    monkeypatch.setattr(proxy_server, "llm_router", fake_router)
+    monkeypatch.setattr(proxy_server, "general_settings", {})
+
+    _write_health_state_to_router_cache([{"model_id": "m1"}], [{"model_id": "m2"}], {})
+
+    fake_router.health_state_cache.set_deployment_health_states.assert_not_called()
+
+
+def test_write_health_state_to_router_cache_populates_for_listing_filter(monkeypatch):
+    """`model_list_healthy_only` needs the health cache, but must not start
+    cooling deployments down: that stays behind enable_health_check_routing."""
+    fake_router = MagicMock()
+    fake_router.enable_health_check_routing = False
+    fake_router.health_check_ignore_transient_errors = False
+    fake_router.cooldown_time = 30
+
+    monkeypatch.setattr(proxy_server, "llm_router", fake_router)
+    monkeypatch.setattr(
+        proxy_server, "general_settings", {"model_list_healthy_only": True}
+    )
+
+    fake_states = {"m1": {"is_healthy": True}, "m2": {"is_healthy": False}}
+
+    import litellm.proxy.health_check as hc
+
+    monkeypatch.setattr(hc, "build_deployment_health_states", lambda **_kw: fake_states)
+
+    cooldowns: list[str] = []
+
+    import litellm.router_utils.cooldown_handlers as cd
+
+    monkeypatch.setattr(
+        cd,
+        "_set_cooldown_deployments",
+        lambda **kw: cooldowns.append(kw.get("deployment")),
+    )
+
+    failures: list[str] = []
+
+    import litellm.router_utils.router_callbacks.track_deployment_metrics as tdm
+
+    monkeypatch.setattr(
+        tdm,
+        "increment_deployment_failures_for_current_minute",
+        lambda **kw: failures.append(kw.get("deployment_id")),
+    )
+
+    _write_health_state_to_router_cache(
+        [{"model_id": "m1"}],
+        [{"model_id": "m2"}],
+        {"m2": SimpleNamespace(status_code=500)},
+    )
+
+    fake_router.health_state_cache.set_deployment_health_states.assert_called_once_with(
+        fake_states
+    )
+    assert cooldowns == []
+    assert failures == []
+
+
 def test_write_health_state_to_router_cache_swallows_internal_failures(monkeypatch):
     """The function logs and swallows exceptions so a bad cache call never crashes the loop."""
     fake_router = MagicMock()

--- a/tests/test_litellm/proxy/test_model_list_healthy_only.py
+++ b/tests/test_litellm/proxy/test_model_list_healthy_only.py
@@ -1,13 +1,20 @@
 """
-Tests for the opt-in `healthy_only` filter on GET /v1/models (`model_list`).
+Tests for the opt-in health filter on the model listing endpoints: the
+per-request `healthy_only` query parameter and the proxy-wide
+`general_settings.model_list_healthy_only` setting, across GET /v1/models
+(`model_list`), GET /v1/models/{id} (`model_info`) and GET /v1/model/info
+(`model_info_v1`).
 """
 
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from fastapi import HTTPException
 
 from litellm.proxy import proxy_server
-from litellm.proxy._types import UserAPIKeyAuth
+from litellm.proxy._types import LitellmUserRoles, UserAPIKeyAuth
+
+HEALTHY_ONLY_SETTING = {"model_list_healthy_only": True}
 
 
 @pytest.fixture
@@ -23,6 +30,7 @@ def patched_model_list(monkeypatch):
 
     monkeypatch.setattr(proxy_server, "llm_router", router)
     monkeypatch.setattr(proxy_server, "user_model", None)
+    monkeypatch.setattr(proxy_server, "general_settings", {})
 
     async def _fake_get_available_models_for_user(**kwargs):
         return ["gpt-4", "claude-sonnet"]
@@ -41,6 +49,44 @@ def patched_model_list(monkeypatch):
     )
 
     return router
+
+
+@pytest.fixture
+def patched_model_info_v1(monkeypatch):
+    """Stub router + globals used by the `/v1/model/info` list path."""
+    healthy_row = {
+        "model_name": "gpt-4",
+        "litellm_params": {"model": "gpt-4"},
+        "model_info": {"id": "healthy-id", "db_model": False},
+    }
+    unhealthy_row = {
+        "model_name": "claude-sonnet",
+        "litellm_params": {"model": "anthropic/claude-sonnet"},
+        "model_info": {"id": "unhealthy-id", "db_model": False},
+    }
+    router = MagicMock()
+    router.model_list = [healthy_row, unhealthy_row]
+    router.get_model_list_from_model_alias.return_value = []
+    router.get_model_names.return_value = ["gpt-4", "claude-sonnet"]
+    router.get_model_access_groups.return_value = {}
+    router.async_get_fully_unhealthy_model_names = AsyncMock(return_value={"claude-sonnet"})
+
+    monkeypatch.setattr(proxy_server, "user_model", None)
+    monkeypatch.setattr(proxy_server, "llm_model_list", router.model_list)
+    monkeypatch.setattr(proxy_server, "llm_router", router)
+    monkeypatch.setattr(proxy_server, "prisma_client", None)
+    monkeypatch.setattr(proxy_server, "general_settings", {})
+    monkeypatch.setattr(proxy_server, "_enrich_model_info_with_litellm_data", lambda model, **kw: model)
+    return router
+
+
+def _admin_key() -> UserAPIKeyAuth:
+    return UserAPIKeyAuth(
+        api_key="sk-test",
+        user_id="u",
+        user_role=LitellmUserRoles.PROXY_ADMIN,
+        team_models=[],
+    )
 
 
 @pytest.mark.asyncio
@@ -90,3 +136,186 @@ async def test_model_list_healthy_only_applies_to_scope_expand(
         healthy_only=True,
     )
     assert [m["id"] for m in response["data"]] == ["gpt-4"]
+
+
+@pytest.mark.asyncio
+async def test_model_list_general_setting_hides_unhealthy_models(patched_model_list, monkeypatch):
+    """`model_list_healthy_only: true` filters callers that pass no query param."""
+    monkeypatch.setattr(proxy_server, "general_settings", HEALTHY_ONLY_SETTING)
+
+    response = await proxy_server.model_list(
+        user_api_key_dict=UserAPIKeyAuth(api_key="sk-test"),
+    )
+    assert [m["id"] for m in response["data"]] == ["gpt-4"]
+
+
+@pytest.mark.asyncio
+async def test_model_list_general_setting_applies_to_scope_expand(patched_model_list, monkeypatch):
+    from litellm.proxy.auth import model_checks
+    from litellm.proxy.management_endpoints import common_utils
+
+    async def _fake_admin(**kwargs):
+        return True
+
+    monkeypatch.setattr(common_utils, "_user_has_admin_privileges", _fake_admin)
+    monkeypatch.setattr(
+        model_checks,
+        "get_complete_model_list",
+        lambda **kwargs: ["gpt-4", "claude-sonnet"],
+    )
+    monkeypatch.setattr(proxy_server, "general_settings", HEALTHY_ONLY_SETTING)
+    patched_model_list.get_model_names = MagicMock(return_value=["gpt-4", "claude-sonnet"])
+    patched_model_list.get_model_access_groups = MagicMock(return_value={})
+
+    response = await proxy_server.model_list(
+        user_api_key_dict=UserAPIKeyAuth(api_key="sk-test"),
+        scope="expand",
+    )
+    assert [m["id"] for m in response["data"]] == ["gpt-4"]
+
+
+@pytest.mark.asyncio
+async def test_model_list_general_setting_false_keeps_unhealthy_models(patched_model_list, monkeypatch):
+    """Explicit `false` must behave exactly like the unset default."""
+    monkeypatch.setattr(proxy_server, "general_settings", {"model_list_healthy_only": False})
+
+    response = await proxy_server.model_list(
+        user_api_key_dict=UserAPIKeyAuth(api_key="sk-test"),
+    )
+    assert [m["id"] for m in response["data"]] == ["gpt-4", "claude-sonnet"]
+    patched_model_list.async_get_fully_unhealthy_model_names.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_model_list_non_boolean_general_setting_does_not_filter(patched_model_list, monkeypatch):
+    """A quoted YAML value is not a bool; never filter on an ambiguous value."""
+    monkeypatch.setattr(proxy_server, "general_settings", {"model_list_healthy_only": "true"})
+
+    response = await proxy_server.model_list(
+        user_api_key_dict=UserAPIKeyAuth(api_key="sk-test"),
+    )
+    assert [m["id"] for m in response["data"]] == ["gpt-4", "claude-sonnet"]
+    patched_model_list.async_get_fully_unhealthy_model_names.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_model_list_blocked_models_hidden_without_health_filter(
+    patched_model_list,
+):
+    """Blocked-model hiding is independent of the health filter."""
+    patched_model_list.get_fully_blocked_model_names = MagicMock(return_value={"gpt-4"})
+
+    response = await proxy_server.model_list(
+        user_api_key_dict=UserAPIKeyAuth(api_key="sk-test"),
+    )
+    assert [m["id"] for m in response["data"]] == ["claude-sonnet"]
+
+
+@pytest.mark.asyncio
+async def test_model_list_no_router_does_not_filter(patched_model_list, monkeypatch):
+    """No router means no health state; fail open rather than hiding everything."""
+    monkeypatch.setattr(proxy_server, "llm_router", None)
+    monkeypatch.setattr(proxy_server, "general_settings", HEALTHY_ONLY_SETTING)
+
+    response = await proxy_server.model_list(
+        user_api_key_dict=UserAPIKeyAuth(api_key="sk-test"),
+    )
+    assert [m["id"] for m in response["data"]] == ["gpt-4", "claude-sonnet"]
+
+
+@pytest.mark.asyncio
+async def test_model_list_general_setting_no_health_state_keeps_all_models(patched_model_list, monkeypatch):
+    """Setting on but no background health checks running: hide nothing."""
+    monkeypatch.setattr(proxy_server, "general_settings", HEALTHY_ONLY_SETTING)
+    patched_model_list.async_get_fully_unhealthy_model_names = AsyncMock(return_value=set())
+
+    response = await proxy_server.model_list(
+        user_api_key_dict=UserAPIKeyAuth(api_key="sk-test"),
+    )
+    assert [m["id"] for m in response["data"]] == ["gpt-4", "claude-sonnet"]
+
+
+@pytest.mark.asyncio
+async def test_retrieve_model_general_setting_hides_unhealthy_model(patched_model_list, monkeypatch):
+    """GET /v1/models/{id} must not serve a model the listing hides."""
+    monkeypatch.setattr(proxy_server, "general_settings", HEALTHY_ONLY_SETTING)
+
+    with pytest.raises(HTTPException) as exc_info:
+        await proxy_server.model_info(
+            model_id="claude-sonnet",
+            user_api_key_dict=UserAPIKeyAuth(api_key="sk-test"),
+        )
+    assert exc_info.value.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_retrieve_model_default_serves_unhealthy_model(patched_model_list, monkeypatch):
+    """Without the opt-in, retrieve keeps serving unhealthy models."""
+    import litellm
+
+    deployment = MagicMock()
+    deployment.litellm_params.model = "anthropic/claude-sonnet"
+    patched_model_list.get_deployment_by_model_group_name.return_value = deployment
+    monkeypatch.setattr(litellm, "get_llm_provider", lambda model: (model, "anthropic", None, None))
+
+    response = await proxy_server.model_info(
+        model_id="claude-sonnet",
+        user_api_key_dict=UserAPIKeyAuth(api_key="sk-test"),
+    )
+    assert response["id"] == "claude-sonnet"
+    patched_model_list.async_get_fully_unhealthy_model_names.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_model_info_v1_healthy_only_hides_unhealthy_deployments(
+    patched_model_info_v1,
+):
+    response = await proxy_server.model_info_v1(
+        user_api_key_dict=_admin_key(),
+        litellm_model_id=None,
+        healthy_only=True,
+    )
+    assert [m["model_name"] for m in response["data"]] == ["gpt-4"]
+
+
+@pytest.mark.asyncio
+async def test_model_info_v1_general_setting_hides_unhealthy_deployments(patched_model_info_v1, monkeypatch):
+    monkeypatch.setattr(proxy_server, "general_settings", HEALTHY_ONLY_SETTING)
+
+    response = await proxy_server.model_info_v1(
+        user_api_key_dict=_admin_key(),
+        litellm_model_id=None,
+    )
+    assert [m["model_name"] for m in response["data"]] == ["gpt-4"]
+
+
+@pytest.mark.asyncio
+async def test_model_info_v1_default_keeps_unhealthy_deployments(
+    patched_model_info_v1,
+):
+    response = await proxy_server.model_info_v1(
+        user_api_key_dict=_admin_key(),
+        litellm_model_id=None,
+    )
+    assert [m["model_name"] for m in response["data"]] == ["gpt-4", "claude-sonnet"]
+    patched_model_info_v1.async_get_fully_unhealthy_model_names.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_model_info_v1_litellm_model_id_lookup_ignores_health_filter(patched_model_info_v1, monkeypatch):
+    """The by-id lookup backs the dashboard's model detail view; turning the
+    proxy-wide filter on must not make an unhealthy model unopenable there."""
+    monkeypatch.setattr(proxy_server, "general_settings", HEALTHY_ONLY_SETTING)
+    deployment = MagicMock()
+    deployment.model_dump.return_value = {
+        "model_name": "claude-sonnet",
+        "litellm_params": {"model": "anthropic/claude-sonnet"},
+        "model_info": {"id": "unhealthy-id"},
+    }
+    patched_model_info_v1.get_deployment.return_value = deployment
+
+    response = await proxy_server.model_info_v1(
+        user_api_key_dict=_admin_key(),
+        litellm_model_id="unhealthy-id",
+    )
+    assert [m["model_name"] for m in response["data"]] == ["claude-sonnet"]

--- a/ui/litellm-dashboard/src/lib/http/schema.d.ts
+++ b/ui/litellm-dashboard/src/lib/http/schema.d.ts
@@ -8152,6 +8152,15 @@ export interface paths {
          *         - When litellm_model_id is not passed, it will return the info for all models
          *         - include_team_models: When true, filter to deployments the caller can use (same as /v2/model/info).
          *         - teamId: Filter to models accessible by the given team.
+         *         - healthy_only: When true, hide models whose backing deployments are all marked
+         *           unhealthy by background health checks, matching `/v1/models?healthy_only=true`.
+         *           Set `general_settings.model_list_healthy_only: true` to apply this to every
+         *           caller without the query parameter. Requires `background_health_checks: true`,
+         *           plus either `model_list_healthy_only` or `enable_health_check_routing` to keep
+         *           deployment health state cached; without health state the listing is returned
+         *           unfiltered (fail open). Ignored when `litellm_model_id` is passed, since that
+         *           is a direct lookup of one deployment rather than a listing. Hiding is
+         *           presentation-only: a hidden model can still be called directly.
          *
          *     Each model in the list response includes `model_info.access_via_team_ids` and
          *     `model_info.direct_access` when the proxy database is connected.
@@ -8605,9 +8614,13 @@ export interface paths {
          *              When scope=expand is passed, proxy admins, team admins, and org admins
          *              will receive all proxy models as if they are a proxy admin.
          *     - healthy_only: When true, hide models whose backing deployments are all marked
-         *                     unhealthy by background health checks. Requires
-         *                     `background_health_checks: true` in general_settings; without
-         *                     health state the listing is returned unfiltered (fail open).
+         *                     unhealthy by background health checks. Set
+         *                     `general_settings.model_list_healthy_only: true` to apply this
+         *                     to every caller without the query parameter. Requires
+         *                     `background_health_checks: true` in general_settings, plus
+         *                     either `model_list_healthy_only` or `enable_health_check_routing`
+         *                     to keep deployment health state cached; without health state
+         *                     the listing is returned unfiltered (fail open).
          *                     Models expanded from wildcard routes (e.g. `openai/*`) are not
          *                     filtered, and nothing is hidden when `allowed_fails_policy` is
          *                     configured (cooldown remains the sole exclusion mechanism).
@@ -17936,6 +17949,15 @@ export interface paths {
          *         - When litellm_model_id is not passed, it will return the info for all models
          *         - include_team_models: When true, filter to deployments the caller can use (same as /v2/model/info).
          *         - teamId: Filter to models accessible by the given team.
+         *         - healthy_only: When true, hide models whose backing deployments are all marked
+         *           unhealthy by background health checks, matching `/v1/models?healthy_only=true`.
+         *           Set `general_settings.model_list_healthy_only: true` to apply this to every
+         *           caller without the query parameter. Requires `background_health_checks: true`,
+         *           plus either `model_list_healthy_only` or `enable_health_check_routing` to keep
+         *           deployment health state cached; without health state the listing is returned
+         *           unfiltered (fail open). Ignored when `litellm_model_id` is passed, since that
+         *           is a direct lookup of one deployment rather than a listing. Hiding is
+         *           presentation-only: a hidden model can still be called directly.
          *
          *     Each model in the list response includes `model_info.access_via_team_ids` and
          *     `model_info.direct_access` when the proxy database is connected.
@@ -17993,9 +18015,13 @@ export interface paths {
          *              When scope=expand is passed, proxy admins, team admins, and org admins
          *              will receive all proxy models as if they are a proxy admin.
          *     - healthy_only: When true, hide models whose backing deployments are all marked
-         *                     unhealthy by background health checks. Requires
-         *                     `background_health_checks: true` in general_settings; without
-         *                     health state the listing is returned unfiltered (fail open).
+         *                     unhealthy by background health checks. Set
+         *                     `general_settings.model_list_healthy_only: true` to apply this
+         *                     to every caller without the query parameter. Requires
+         *                     `background_health_checks: true` in general_settings, plus
+         *                     either `model_list_healthy_only` or `enable_health_check_routing`
+         *                     to keep deployment health state cached; without health state
+         *                     the listing is returned unfiltered (fail open).
          *                     Models expanded from wildcard routes (e.g. `openai/*`) are not
          *                     filtered, and nothing is hidden when `allowed_fails_policy` is
          *                     configured (cooldown remains the sole exclusion mechanism).
@@ -24264,6 +24290,11 @@ export interface components {
              * @description Number of trusted reverse proxies/load balancers in front of the gateway that append to X-Forwarded-For. When set (and mcp_trusted_proxy_ranges validates the direct peer), the client IP for MCP access control is read this many entries from the right of the chain instead of the spoofable leftmost value, defeating append-style X-Forwarded-For forgery.
              */
             mcp_xff_num_trusted_hops?: number | null;
+            /**
+             * Model List Healthy Only
+             * @description When true, `/models`, `/v1/models/{id}` and `/model/info` hide models whose backing deployments are all unhealthy, for every caller, without needing `healthy_only=true` per request. Requires `background_health_checks: true`, and keeps deployment health state cached without turning on `enable_health_check_routing`, so routing is unaffected. With no health state nothing is hidden. Hiding is presentation-only, a hidden model can still be called.
+             */
+            model_list_healthy_only?: boolean | null;
             /**
              * Otel
              * @description [BETA] OpenTelemetry support - this might change, use with caution.
@@ -47638,6 +47669,7 @@ export interface operations {
                 include_team_models?: boolean | null;
                 /** @description Filter models by team ID. Returns models with direct_access=True or teamId in access_via_team_ids */
                 teamId?: string | null;
+                healthy_only?: boolean | null;
             };
             header?: never;
             path?: never;
@@ -59618,6 +59650,7 @@ export interface operations {
                 include_team_models?: boolean | null;
                 /** @description Filter models by team ID. Returns models with direct_access=True or teamId in access_via_team_ids */
                 teamId?: string | null;
+                healthy_only?: boolean | null;
             };
             header?: never;
             path?: never;


### PR DESCRIPTION
## TLDR

Problem this solves:

- Users listing models see ones that are currently unreachable
- Their next call fails, so they file a ticket
- `healthy_only=true` did nothing in a normal health-check setup

How it solves it:

- New `general_settings.model_list_healthy_only`, off by default
- Applies to `/models`, `/v1/models/{id}` and `/model/info`
- `/model/info` also gains the `healthy_only` query parameter
- The setting keeps deployment health state cached, routing untouched

## User Flow

Before: a developer with a virtual key lists models, picks one the gateway cannot reach, and their first call fails

1. The proxy admin sets `background_health_checks: true` and `model_list_healthy_only: true`, then restarts the proxy
2. The developer sends GET https://litellm-domain/v1/models with their virtual key
3. The response lists every model on the key, including `broken-deployment`, whose endpoint has been unreachable for minutes
4. GET https://litellm-domain/model/info lists the same three models
5. They send POST https://litellm-domain/v1/chat/completions with `"model": "broken-deployment"` and get a connection error back

After: the same listing only shows models the gateway can actually reach

1. The proxy admin sets `background_health_checks: true` and `model_list_healthy_only: true`, then restarts the proxy
2. The developer sends GET https://litellm-domain/v1/models with their virtual key
3. The response lists only `gpt-5.6` and `claude-opus-5`; `broken-deployment` is gone
4. GET https://litellm-domain/model/info lists the same two models
5. They pick `gpt-5.6` and their POST https://litellm-domain/v1/chat/completions returns a normal completion

Nothing changes for a proxy that does not set the new option: with it absent, both listings return exactly what they return today.

## Relevant issues

## Linear ticket

Resolves LIT-5557

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Same proxy config on both sides, one healthy OpenAI deployment, one healthy Anthropic deployment, and one deployment pointed at a dead port so the background health check marks it unhealthy:

```yaml
model_list:
  - model_name: gpt-5.6
    litellm_params:
      model: openai/gpt-5.6
      api_key: os.environ/OPENAI_API_KEY
  - model_name: claude-opus-5
    litellm_params:
      model: anthropic/claude-opus-5
      api_key: os.environ/ANTHROPIC_API_KEY
  - model_name: broken-deployment
    litellm_params:
      model: openai/gpt-5.6
      api_key: sk-this-key-is-not-valid
      api_base: http://127.0.0.1:9/v1

general_settings:
  master_key: sk-1234
  background_health_checks: true
  health_check_interval: 15
  model_list_healthy_only: true
```

Both sides use the same virtual key, scoped to all three models:

```bash
curl -s -X POST http://localhost:4000/key/generate -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" -d '{"models": ["gpt-5.6", "claude-opus-5", "broken-deployment"], "key_alias": "lit5557-qa"}'
```

and both sides confirm the health check really did mark one deployment unhealthy before the listings are read:

```bash
curl -s http://localhost:4000/health -H "Authorization: Bearer sk-1234" | jq -c '{healthy_count, unhealthy_count, unhealthy: [.unhealthy_endpoints[].api_base]}'
{"healthy_count":2,"unhealthy_count":1,"unhealthy":["http://127.0.0.1:9/v1"]}
```

### Before (e52f05566d)

#### GET /v1/models

1. Run the listing with the virtual key

   ```bash
   curl -s http://localhost:4000/v1/models -H "Authorization: Bearer $VIRTUAL_KEY" | jq -c '[.data[].id]'
   ```

2. The unreachable deployment is listed; `model_list_healthy_only` is not a setting this build knows

   ```
   ["gpt-5.6","claude-opus-5","broken-deployment"]
   ```

#### GET /model/info

1. Run the listing with the same key

   ```bash
   curl -s http://localhost:4000/model/info -H "Authorization: Bearer $VIRTUAL_KEY" | jq -c '[.data[].model_name]'
   ```

2. Same three models

   ```
   ["gpt-5.6","claude-opus-5","broken-deployment"]
   ```

### After (b989f65b11)

#### GET /v1/models

1. Run the same listing with the same key

   ```bash
   curl -s http://localhost:4000/v1/models -H "Authorization: Bearer $VIRTUAL_KEY" | jq -c '[.data[].id]'
   ```

2. The unreachable deployment is gone

   ```
   ["gpt-5.6","claude-opus-5"]
   ```

#### GET /model/info

1. Run the same listing with the same key

   ```bash
   curl -s http://localhost:4000/model/info -H "Authorization: Bearer $VIRTUAL_KEY" | jq -c '[.data[].model_name]'
   ```

2. Same two models

   ```
   ["gpt-5.6","claude-opus-5"]
   ```

#### The models that survive the filter still serve traffic

1. Call one of them with the same virtual key

   ```bash
   curl -s -X POST http://localhost:4000/v1/chat/completions -H "Authorization: Bearer $VIRTUAL_KEY" -H "Content-Type: application/json" -d '{"model": "gpt-5.6", "messages": [{"role": "user", "content": "Reply with the single word: ok"}], "max_tokens": 16}' | jq -c '.model, .choices[0].message.content'
   ```

2. A real completion comes back from OpenAI

   ```
   "gpt-5.6"
   "ok"
   ```

## Type

🆕 New Feature

## Caveats (if any)

### Medium

- `/v2/model/info` is not filtered, so the Admin UI models page keeps showing unhealthy models
  - That page is where an admin goes to fix a broken deployment, so hiding it there would work against them
  - It also has its own health column already
- Models expanded from a wildcard route are never hidden

### Low

- `healthy_only=true` on its own still needs health state cached
  - Either `model_list_healthy_only` or `enable_health_check_routing` fills it
  - Documented on both endpoints now; before this PR it silently did nothing
- `/model/info?litellm_model_id=<id>` is a direct lookup and stays unfiltered
- Docs for the new setting still need a follow-up in the docs repo

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
