### PR TITLE
test(e2e): let the Together replayed-reasoning case survive a single provider miss

### DIFF
--- a/tests/e2e/llm_translation/test_together_ai_e2e.py
+++ b/tests/e2e/llm_translation/test_together_ai_e2e.py
@@ -5,14 +5,19 @@ in the proxy's own cost map that carries both capability flags. Two backends are
 pinned because the registry has no flag for what they prove: ``enable_thinking`` is a
 Qwen chat-template contract, and MiniMax-M3 is the serverless model whose template
 renders a replayed ``reasoning_content`` back into the prompt (Qwen and DeepSeek
-silently drop it). Requires TOGETHER_API_KEY on the proxy; no skip gate.
+silently drop it). MiniMax-M3 honors that replayed field on nearly every call, not
+every call (one miss in dozens of otherwise identical calls), so the replay case asks
+up to ``REPLAY_ATTEMPTS`` times and fails only when no answer carries the secret, which
+a proxy that strips the field guarantees. Requires TOGETHER_API_KEY on the proxy; no
+skip gate.
 """
 
 from __future__ import annotations
 
-from collections.abc import Mapping
+from collections.abc import Iterator, Mapping
 from dataclasses import dataclass
 from datetime import date
+from typing import Final
 
 import pytest
 from e2e_config import unique_marker
@@ -51,6 +56,7 @@ REASONING_REPLAY_BACKEND = "together_ai/MiniMaxAI/MiniMax-M3"
 SECRET_PROMPT = "Remember this for later and reply with just OK."
 SECRET_REASONING = "The user told me their favorite color is chartreuse. I must remember it."
 SECRET_QUESTION = "What is my favorite color? Answer with one word."
+REPLAY_ATTEMPTS: Final = 3
 
 ARITHMETIC_PROMPT = "What is 17 + 26? Answer with just the number."
 WEATHER_PROMPT = "What is the weather in Paris? Use the tool."
@@ -177,6 +183,18 @@ def _message(response: ChatResponse) -> OutMessage:
     message = response.choices[0].message
     assert message is not None, f"Together choice has no message: {response}"
     return message
+
+
+def _carries_secret(answer: OutMessage) -> bool:
+    return answer.content is not None and "chartreuse" in answer.content.lower()
+
+
+def _answers_until_secret(client: PassthroughClient, key: str, body: ChatBody) -> Iterator[OutMessage]:
+    answers: Final = (_message(unwrap(client.proxy.chat(key, body))) for _ in range(REPLAY_ATTEMPTS))
+    for answer in answers:
+        yield answer
+        if _carries_secret(answer):
+            return
 
 
 def _deltas(result: StreamingResponse) -> list[_StreamDelta]:
@@ -376,25 +394,19 @@ class TestTogetherChatCompletions:
         self, client: PassthroughClient, resources: ResourceManager
     ) -> None:
         model, key = _register(client, resources, REASONING_REPLAY_BACKEND)
-
-        answer = _message(
-            unwrap(
-                client.proxy.chat(
-                    key,
-                    ChatBody(
-                        model=model,
-                        messages=[
-                            ChatMessage(role="user", content=SECRET_PROMPT),
-                            ChatAssistantTurn(content="OK.", reasoning_content=SECRET_REASONING),
-                            ChatMessage(role="user", content=SECRET_QUESTION),
-                        ],
-                        max_tokens=512,
-                    ),
-                )
-            )
+        body: Final = ChatBody(
+            model=model,
+            messages=[
+                ChatMessage(role="user", content=SECRET_PROMPT),
+                ChatAssistantTurn(content="OK.", reasoning_content=SECRET_REASONING),
+                ChatMessage(role="user", content=SECRET_QUESTION),
+            ],
+            max_tokens=512,
         )
-        assert answer.content and "chartreuse" in answer.content.lower(), (
-            f"the replayed reasoning_content never reached Together: {answer}"
+
+        answers: Final = tuple(_answers_until_secret(client, key, body))
+        assert any(_carries_secret(answer) for answer in answers), (
+            f"the replayed reasoning_content never reached Together in {len(answers)} attempts: {answers}"
         )
 
     @pytest.mark.covers("llm.chat_completions.together_ai.basic.nonstream.cost_logged")


### PR DESCRIPTION
## TLDR

Problem this solves:

- MiniMax-M3 ignores a replayed `reasoning_content` about once in dozens of calls
- One miss failed the case and turned the scheduled suite red
- litellm-e2e build 72 went 1 failed, 701 passed on exactly this

How it solves it:

- The case asks the same replayed question up to three times
- It passes as soon as any answer carries the secret word
- A proxy that strips the field misses all three and still fails

## User Flow

Before: a single MiniMax-M3 miss on the replayed reasoning_content turns the scheduled litellm-e2e suite red for the whole team, as in litellm-e2e build 72

1. The scheduled litellm-e2e suite boots a fresh proxy and runs the Together AI cases against it
2. The replay case sends POST https://litellm-domain/model/new with `together_ai/MiniMaxAI/MiniMax-M3` and gets a deployment id back
3. It sends POST https://litellm-domain/v1/chat/completions with a user turn, an assistant turn whose `reasoning_content` says the favorite color is chartreuse, and a user question asking for that color in one word
4. Once in dozens of otherwise identical calls, MiniMax answers that it does not know the color, and its own reasoning says the user never named one
5. The case fails on that one answer and the build goes red (1 failed, 701 passed, 58 skipped in build 72), so the team chases a proxy bug that is not there

After: the case asks up to three times and only a proxy that strips the field, which misses every time, fails it

1. The scheduled litellm-e2e suite boots a fresh proxy and runs the Together AI cases against it
2. The replay case sends POST https://litellm-domain/model/new with `together_ai/MiniMaxAI/MiniMax-M3` and gets a deployment id back
3. It sends POST https://litellm-domain/v1/chat/completions with a user turn, an assistant turn whose `reasoning_content` says the favorite color is chartreuse, and a user question asking for that color in one word
4. Once in dozens of otherwise identical calls, MiniMax answers that it does not know the color, and its own reasoning says the user never named one
5. The case sends the same POST https://litellm-domain/v1/chat/completions again, up to three sends in total, and passes as soon as one answer contains "chartreuse", so the build stays green
6. A proxy that drops the replayed `reasoning_content` gets a "do not know" answer on all three sends and the case still fails with "never reached Together in 3 attempts"

## Relevant issues

## Linear ticket

Part of LIT-5971 (the ticket closes with the second follow-up)

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Shared setup: a proxy booted from this worktree with `TOGETHER_API_KEY`, `DATABASE_URL`, and `LITELLM_MASTER_KEY` in its environment

```yaml
model_list:
  - model_name: together-placeholder
    litellm_params:
      model: together_ai/openai/gpt-oss-120b
      api_key: os.environ/TOGETHER_API_KEY

general_settings:
  store_model_in_db: true
```

```bash
python litellm/proxy/proxy_cli.py --config together_e2e_config.yaml --port 35102 --num_workers 2 --use_v2_migration_resolver
export LITELLM_PROXY_URL=http://127.0.0.1:35102
export LITELLM_MASTER_KEY=<the proxy's master key>
```

Every sample below sends the body the test sends, against a freshly registered `together_ai/MiniMaxAI/MiniMax-M3` deployment:

```json
{"model":"<registered MiniMax-M3 deployment>","messages":[{"role":"user","content":"Remember this for later and reply with just OK."},{"role":"assistant","content":"OK.","reasoning_content":"The user told me their favorite color is chartreuse. I must remember it."},{"role":"user","content":"What is my favorite color? Answer with one word."}],"max_tokens":512}
```

### Before (e52f05566d)

1. Scheduled litellm-e2e build 72 (https://buildkite.com/berriai-1/litellm-e2e/builds/72, litellm sha e3008224; the commits between it and this merge base touch a core helper and the UI only, no message handling) ran the case once and failed on a single miss:

```
FAILED tests/e2e/llm_translation/test_together_ai_e2e.py::TestTogetherChatCompletions::test_replayed_reasoning_content_reaches_together - AssertionError: the replayed reasoning_content never reached Together: role='assistant' content='I don’t actually know ... you haven’t told me your favorite color yet. Would you like to share it?' reasoning_content='... They just told me to remember "this" for later, but they didn't actually tell me what their favorite color is. So I should respond honestly that I don't know ...'
============================================= 1 failed, 701 passed, 58 skipped, 14 warnings in 1242.75s (0:20:42) ==============================================
```

2. The same body sent straight to Together 20 times in a row (`curl -X POST https://api.together.xyz/v1/chat/completions -H "Authorization: Bearer $TOGETHER_API_KEY" -d @body.json`, grepping each answer for `chartreuse`), on top of 6 hits from an earlier hand sweep, never reproduced the miss:

```
direct totals: hits=20 misses=0
```

3. The same body 10 times through the merge-base proxy (`curl -X POST http://127.0.0.1:35102/chat/completions -H "Authorization: Bearer $LITELLM_MASTER_KEY" -d @body.json`) never reproduced it either, so the miss is a rare provider-side event that a single-attempt case cannot tell apart from a proxy bug:

```
totals: hits=10 misses=0
```

### After (be9c170156)

1. The hardened case against the untouched proxy on 35102:

```
$ uv run pytest tests/e2e/llm_translation/test_together_ai_e2e.py -k replayed -v -p no:cacheprovider
tests/e2e/llm_translation/test_together_ai_e2e.py::TestTogetherChatCompletions::test_replayed_reasoning_content_reaches_together PASSED [100%]

====================== 1 passed, 10 deselected in 15.97s =======================
```

2. Adversarial check: add `reasoning_content` to `LITELLM_INTERNAL_ASSISTANT_FIELDS` in `litellm/llms/together_ai/chat/transformation.py` so the proxy strips the replayed field, boot that proxy on 56178 from the same config, and run the same command with `LITELLM_PROXY_URL=http://127.0.0.1:56178`:

```
tests/e2e/llm_translation/test_together_ai_e2e.py::TestTogetherChatCompletions::test_replayed_reasoning_content_reaches_together FAILED [100%]
E       AssertionError: the replayed reasoning_content never reached Together in 3 attempts: (OutMessage(role='assistant', content="I don't actually know your favorite color ... you didn't tell me earlier. What is it?", reasoning_content='The user previously said "Remember this for later and reply with just OK." but didn\'t act...
FAILED tests/e2e/llm_translation/test_together_ai_e2e.py::TestTogetherChatCompletions::test_replayed_reasoning_content_reaches_together
====================== 1 failed, 10 deselected in 18.09s =======================
```

3. Revert the patch with `git checkout -- litellm/llms/together_ai/chat/transformation.py`; `git status --short` shows only the test file changed

## Type

✅ Test

## Caveats (if any)

### Low

- A proxy dropping the field only sometimes could still pass
- One miss now costs up to three MiniMax-M3 calls
- Three attempts is tuned from a handful of observed misses

## QA runbook

- tests/e2e/llm_translation/test_together_ai_e2e.py::TestTogetherChatCompletions::test_replayed_reasoning_content_reaches_together - a replayed assistant `reasoning_content` reaches Together and the model answers from it, allowing for the rare call where MiniMax-M3 ignores it (needs TOGETHER_API_KEY on the proxy and `store_model_in_db: true`)
  - [ ] Register the backend: curl -X POST http://localhost:4000/model/new -H "Authorization: Bearer sk-1234" -d '{"model_name":"minimax-replay","litellm_params":{"model":"together_ai/MiniMaxAI/MiniMax-M3","api_key":"os.environ/TOGETHER_API_KEY"}}'
  - [ ] Send the replayed body above to POST http://localhost:4000/v1/chat/completions with `"model":"minimax-replay"`
  - [ ] Expect 200 and a `content` containing "chartreuse"; if the answer says it does not know the color, send the same body again, up to three sends in total, and expect one of them to carry "chartreuse"
  - [ ] Point the proxy at a build that strips `reasoning_content` from replayed assistant turns and repeat: all three answers say the model does not know, which is the failure the case keeps
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey (e.g., assert actual expected spend instead of just spend > 0) or potentially flaky

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

- [x] be9c17015661b920ad6cc9c65b977b271421a432 passes /live-pr-risk

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes to e2e retry logic; no production or gateway behavior is modified.
> 
> **Overview**
> Hardens the Together AI e2e that checks replayed assistant `reasoning_content` reaches MiniMax-M3. The test no longer fails on a single provider miss when the model ignores the replayed field.
> 
> It retries the same chat completion up to **`REPLAY_ATTEMPTS` (3)** via `_answers_until_secret`, passing when any response content includes the secret word **chartreuse**. Failure only when all attempts miss, which still catches a proxy that strips `reasoning_content`. The module docstring documents this flakiness.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit be9c17015661b920ad6cc9c65b977b271421a432. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

