### PR TITLE
test(cost-estimate): pin the prices and period totals /cost/estimate returns

### DIFF
--- a/tests/test_litellm/proxy/management_endpoints/test_cost_tracking_settings.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_cost_tracking_settings.py
@@ -780,3 +780,133 @@ class TestBlockRequestsForModelsWithoutPricing:
 
         assert response.status_code == 500
         assert "error" in response.json()["detail"]
+
+
+AN_ALIAS = "onprem/alias"
+AN_UNDERLYING_MODEL = "vendor/model"
+A_MAPPED_MODEL = "openai/mapped-only-model"
+INPUT_TOKENS = 1000
+OUTPUT_TOKENS = 500
+
+
+def _router_pricing(**pricing: float) -> MagicMock:
+    mock_router = MagicMock()
+    mock_router.get_model_list.return_value = [
+        {
+            "model_name": AN_ALIAS,
+            "litellm_params": {
+                "model": AN_UNDERLYING_MODEL,
+                "custom_llm_provider": "openai",
+                **pricing,
+            },
+            "model_info": {},
+        }
+    ]
+    return mock_router
+
+
+async def _estimate(mock_router: MagicMock | None, model: str = AN_ALIAS, **overrides: int):
+    from litellm.proxy._types import CostEstimateRequest
+    from litellm.proxy.management_endpoints.cost_tracking_settings import estimate_cost
+
+    request = CostEstimateRequest(
+        model=model,
+        input_tokens=INPUT_TOKENS,
+        output_tokens=OUTPUT_TOKENS,
+        **overrides,
+    )
+    with patch("litellm.proxy.proxy_server.llm_router", mock_router):
+        return await estimate_cost(request=request, user_api_key_dict=MagicMock())
+
+
+class TestEstimateCostPartiallyPricedDeployments:
+    @pytest.mark.asyncio
+    async def test_a_deployment_that_prices_only_input_bills_output_at_zero(self):
+        response = await _estimate(_router_pricing(input_cost_per_token=0.000001))
+
+        assert response.input_cost_per_token == pytest.approx(0.000001)
+        assert response.output_cost_per_token == 0.0
+        assert response.cost_per_request == pytest.approx(0.001)
+
+    @pytest.mark.asyncio
+    async def test_a_deployment_that_prices_only_output_bills_input_at_zero(self):
+        response = await _estimate(_router_pricing(output_cost_per_token=0.000002))
+
+        assert response.input_cost_per_token == 0.0
+        assert response.output_cost_per_token == pytest.approx(0.000002)
+        assert response.cost_per_request == pytest.approx(0.001)
+
+    @pytest.mark.asyncio
+    async def test_a_model_priced_only_by_the_cost_map_reports_that_price_and_provider(self):
+        saved_model_cost = dict(litellm.model_cost)
+        litellm.register_model(
+            {
+                A_MAPPED_MODEL: {
+                    "input_cost_per_token": 0.000005,
+                    "output_cost_per_token": 0.000006,
+                    "litellm_provider": "openai",
+                    "mode": "chat",
+                }
+            }
+        )
+        try:
+            response = await _estimate(None, model=A_MAPPED_MODEL)
+        finally:
+            litellm.model_cost = saved_model_cost
+
+        assert response.input_cost_per_token == pytest.approx(0.000005)
+        assert response.output_cost_per_token == pytest.approx(0.000006)
+        assert response.provider == "openai"
+
+
+class TestEstimateCostPeriodTotals:
+    @pytest.mark.asyncio
+    async def test_zero_requests_a_day_reports_no_daily_cost_rather_than_zero(self):
+        response = await _estimate(
+            _router_pricing(input_cost_per_token=0.000001, output_cost_per_token=0.000002),
+            num_requests_per_day=0,
+        )
+
+        assert response.daily_cost is None
+        assert response.daily_input_cost is None
+        assert response.daily_output_cost is None
+
+    @pytest.mark.asyncio
+    async def test_daily_totals_scale_every_component_by_the_request_count(self):
+        response = await _estimate(
+            _router_pricing(input_cost_per_token=0.000001, output_cost_per_token=0.000002),
+            num_requests_per_day=100,
+        )
+
+        assert response.input_cost_per_request == pytest.approx(0.001)
+        assert response.output_cost_per_request == pytest.approx(0.001)
+        assert response.daily_input_cost == pytest.approx(0.1)
+        assert response.daily_output_cost == pytest.approx(0.1)
+        assert response.daily_cost == pytest.approx(0.2)
+
+    @pytest.mark.asyncio
+    async def test_a_month_and_a_day_are_totalled_from_their_own_request_counts(self):
+        response = await _estimate(
+            _router_pricing(input_cost_per_token=0.000001, output_cost_per_token=0.000002),
+            num_requests_per_day=100,
+            num_requests_per_month=3000,
+        )
+
+        assert response.daily_cost == pytest.approx(0.2)
+        assert response.monthly_cost == pytest.approx(6.0)
+        assert response.monthly_input_cost == pytest.approx(3.0)
+        assert response.monthly_output_cost == pytest.approx(3.0)
+
+    @pytest.mark.asyncio
+    async def test_a_configured_margin_is_totalled_per_period_like_the_other_components(self, monkeypatch):
+        monkeypatch.setattr(litellm, "cost_margin_config", {"openai": 0.10})
+
+        response = await _estimate(
+            _router_pricing(input_cost_per_token=0.000001, output_cost_per_token=0.000002),
+            num_requests_per_day=100,
+        )
+
+        assert response.margin_cost_per_request == pytest.approx(0.0002)
+        assert response.cost_per_request == pytest.approx(0.0022)
+        assert response.daily_margin_cost == pytest.approx(0.02)
+        assert response.daily_cost == pytest.approx(0.22)

--- a/tests/test_litellm/proxy/management_endpoints/test_cost_tracking_settings.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_cost_tracking_settings.py
@@ -815,7 +815,9 @@ async def _estimate(mock_router: MagicMock | None, model: str = AN_ALIAS, **over
         output_tokens=OUTPUT_TOKENS,
         **overrides,
     )
-    with patch("litellm.proxy.proxy_server.llm_router", mock_router):
+    with patch(  # test-quality-ok: proxy_server module global is the endpoint's only injection point
+        "litellm.proxy.proxy_server.llm_router", mock_router
+    ):
         return await estimate_cost(request=request, user_api_key_dict=MagicMock())
 
 
@@ -837,22 +839,19 @@ class TestEstimateCostPartiallyPricedDeployments:
         assert response.cost_per_request == pytest.approx(0.001)
 
     @pytest.mark.asyncio
-    async def test_a_model_priced_only_by_the_cost_map_reports_that_price_and_provider(self):
-        saved_model_cost = dict(litellm.model_cost)
-        litellm.register_model(
+    async def test_a_model_priced_only_by_the_cost_map_reports_that_price_and_provider(self, monkeypatch):
+        monkeypatch.setitem(
+            litellm.model_cost,
+            A_MAPPED_MODEL,
             {
-                A_MAPPED_MODEL: {
-                    "input_cost_per_token": 0.000005,
-                    "output_cost_per_token": 0.000006,
-                    "litellm_provider": "openai",
-                    "mode": "chat",
-                }
-            }
+                "input_cost_per_token": 0.000005,
+                "output_cost_per_token": 0.000006,
+                "litellm_provider": "openai",
+                "mode": "chat",
+            },
         )
-        try:
-            response = await _estimate(None, model=A_MAPPED_MODEL)
-        finally:
-            litellm.model_cost = saved_model_cost
+
+        response = await _estimate(None, model=A_MAPPED_MODEL)
 
         assert response.input_cost_per_token == pytest.approx(0.000005)
         assert response.output_cost_per_token == pytest.approx(0.000006)


### PR DESCRIPTION
## TLDR

Problem this solves:

- The cost estimate endpoint prices a model before anyone spends on it
- Its tests only cover deployments that set both prices
- Half-priced deployments and the per-period totals are untested

How it solves it:

- Estimate against deployments that price only one of the two sides
- Pin the daily and monthly totals, zero requests included

## User Flow

This PR adds tests and changes no behavior, so the flow below is what the tests hold in place rather than something that changes between Before and After.

Before: nothing stops a change from quietly mispricing a deployment that sets only one of its two prices

1. An admin adds a self-hosted model and fills in an input price per token, leaving the output price blank
2. They send POST https://litellm-domain/cost/estimate for that model with 1000 input and 500 output tokens
3. The reply prices input at their rate, output at zero, and multiplies the per-request cost by the request count for the daily and monthly totals
4. Nothing in CI would notice if a later change ignored a one-sided price and fell back to the public price list, billed the blank side at some other rate, or scaled a daily total by one request instead of the real count

After: each of those steps is pinned, so that drift turns the suite red before it ships

1. The same model, priced on one side only
2. The same POST https://litellm-domain/cost/estimate
3. The same reply: their rate on the priced side, zero on the blank side, totals scaled by the real request count
4. A change that drops one-sided pricing, misprices the blank side, or mis-scales a total now fails CI

## Relevant issues

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## What is pinned

- A deployment priced only on input bills output at zero, and the reverse
- A model priced only by the public cost map reports that price and that provider
- Zero requests a day reports no daily cost, rather than a cost of zero
- Daily and monthly totals scale every component by their own request count
- A configured margin is totalled per period like the other components

## Screenshots / Proof of Fix

Tests only, so the proof is that they fail when the behaviour they pin is broken. The cost math runs for real and only the router is faked, so this costs no provider spend and needs no key.

Shared setup: each case is one line changed in `litellm/proxy/management_endpoints/cost_tracking_settings.py`, with the mapped test file run against it. "survived" means the suite passed with the behaviour broken, so nothing was checking it.

```bash
F=litellm/proxy/management_endpoints/cost_tracking_settings.py
T=tests/test_litellm/proxy/management_endpoints/test_cost_tracking_settings.py
cp "$F" /tmp/cts.orig
while IFS='|' read -r name old new; do
  cp /tmp/cts.orig "$F"
  OLD="$old" NEW="$new" python3 -c "
import os,pathlib
p=pathlib.Path('$F'); s=p.read_text()
p.write_text(s.replace(os.environ['OLD'], os.environ['NEW']))"
  uv run pytest "$T" -q -p no:randomly -n 4 >/dev/null 2>&1 \
    && printf '%-16s survived\n' "$name" || printf '%-16s killed\n' "$name"
done < /tmp/cases.txt
cp /tmp/cts.orig "$F"
```

`/tmp/cases.txt`, one `name|before|after` per line:

```
and_or|if input_price is None and output_price is None:|if input_price is None or output_price is None:
input_default|input_cost_per_token=input_price or 0.0|input_cost_per_token=input_price or 1.0
output_default|output_cost_per_token=output_price or 0.0|output_cost_per_token=output_price or 1.0
lookup_swallow|return litellm.get_model_info(model=model)|return None
zero_requests|if not num_requests:|if num_requests is None:
period_total|cost_per_request * num_requests|cost_per_request * 1
period_input|input_cost * num_requests|input_cost * 1
period_output|output_cost * num_requests|output_cost * 1
period_margin|margin_cost * num_requests|margin_cost * 1
provider_pref|mapped_provider if mapped_provider is not None else resolved_provider|resolved_provider
precedence|sources: Final = (litellm_params, model_info)|sources: Final = (model_info, litellm_params)
```

### Before (`e52f05566d`, the merge base)

#### Nine of the eleven go unnoticed

1. Run the loop above against the 24 tests already in the file
2. Output:

```
and_or           survived
input_default    survived
output_default   survived
lookup_swallow   survived
zero_requests    survived
period_total     killed
period_input     survived
period_output    survived
period_margin    survived
provider_pref    survived
precedence       killed
```

### After (`0c87bf5de9`)

#### All eleven are caught

1. Run the same loop against the 31 tests in the file with this PR
2. Output:

```
and_or           killed
input_default    killed
output_default   killed
lookup_swallow   killed
zero_requests    killed
period_total     killed
period_input     killed
period_output    killed
period_margin    killed
provider_pref    killed
precedence       killed
```

#### The suite passes unmutated

1. Run the file:

```bash
uv run pytest tests/test_litellm/proxy/management_endpoints/test_cost_tracking_settings.py -q
```

2. Output: `31 passed`

## Type

✅ Test

## Caveats (if any)

### Low

- The margin case sets `litellm.cost_margin_config`, which has no injection seam
- The shared helper carries a `test-quality-ok` for the router patch, matching the rest of the file
- Only this module's helpers are covered; the wider cost map is out of scope

## Final Attestation

- [ ] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
