### PR TITLE
fix(exceptions): map upstream status codes for providers with no exception_type branch

### DIFF
--- a/litellm/litellm_core_utils/exception_mapping_utils.py
+++ b/litellm/litellm_core_utils/exception_mapping_utils.py
@@ -755,11 +755,18 @@ def _map_openai_like_exception(
                 llm_provider=custom_llm_provider,
                 model=model,
             )
-        elif original_exception.status_code == 401 or original_exception.status_code == 403:
+        elif original_exception.status_code == 401:
             raise AuthenticationError(
                 message=f"{custom_llm_provider.capitalize()}Exception - {original_exception.message}",
                 llm_provider=custom_llm_provider,
                 model=model,
+            )
+        elif original_exception.status_code == 403:
+            raise PermissionDeniedError(
+                message=f"{custom_llm_provider.capitalize()}Exception - {original_exception.message}",
+                llm_provider=custom_llm_provider,
+                model=model,
+                response=_response_or_stub(original_exception, status_code=403),
             )
         elif original_exception.status_code == 400:
             raise BadRequestError(
@@ -2187,6 +2194,120 @@ def _map_openrouter_exception(
         )
 
 
+def _response_or_stub(original_exception: _ProviderHTTPException, status_code: int) -> httpx.Response:
+    response: Final = original_exception.response if hasattr(original_exception, "response") else None
+    if response is not None:
+        return response
+    return httpx.Response(
+        status_code=status_code, request=httpx.Request(method="POST", url="https://docs.litellm.ai/docs")
+    )
+
+
+def _map_exception_by_status(
+    *,
+    model: str,
+    original_exception: _ProviderHTTPException,
+    custom_llm_provider: str,
+    error_str: str,
+    exception_provider: str,
+    extra_information: str,
+) -> None:
+    status_code: Final = original_exception.status_code if hasattr(original_exception, "status_code") else None
+    if not isinstance(status_code, int) or status_code < 400:
+        return
+    message: Final = f"{exception_provider} - {error_str}"
+    response: Final = original_exception.response if hasattr(original_exception, "response") else None
+    match status_code:
+        case 401:
+            raise AuthenticationError(
+                message=message,
+                llm_provider=custom_llm_provider,
+                model=model,
+                response=response,
+                litellm_debug_info=extra_information,
+            )
+        case 403:
+            raise PermissionDeniedError(
+                message=message,
+                llm_provider=custom_llm_provider,
+                model=model,
+                response=_response_or_stub(original_exception, status_code=status_code),
+                litellm_debug_info=extra_information,
+            )
+        case 404:
+            raise NotFoundError(
+                message=message,
+                model=model,
+                llm_provider=custom_llm_provider,
+                response=response,
+                litellm_debug_info=extra_information,
+            )
+        case 408:
+            raise Timeout(
+                message=message,
+                model=model,
+                llm_provider=custom_llm_provider,
+                litellm_debug_info=extra_information,
+            )
+        case 429:
+            raise RateLimitError(
+                message=message,
+                model=model,
+                llm_provider=custom_llm_provider,
+                response=response,
+                litellm_debug_info=extra_information,
+            )
+        case 500:
+            raise InternalServerError(
+                message=message,
+                llm_provider=custom_llm_provider,
+                model=model,
+                response=response,
+                litellm_debug_info=extra_information,
+            )
+        case 502:
+            raise BadGatewayError(
+                message=message,
+                llm_provider=custom_llm_provider,
+                model=model,
+                response=response,
+                litellm_debug_info=extra_information,
+            )
+        case 503:
+            raise ServiceUnavailableError(
+                message=message,
+                llm_provider=custom_llm_provider,
+                model=model,
+                response=response,
+                litellm_debug_info=extra_information,
+            )
+        case 504:
+            raise Timeout(
+                message=message,
+                model=model,
+                llm_provider=custom_llm_provider,
+                litellm_debug_info=extra_information,
+                exception_status_code=status_code,
+            )
+        case _ if status_code < 500:
+            raise BadRequestError(
+                message=message,
+                model=model,
+                llm_provider=custom_llm_provider,
+                response=response,
+                litellm_debug_info=extra_information,
+            )
+        case _:
+            raise APIError(
+                status_code=status_code,
+                message=message,
+                llm_provider=custom_llm_provider,
+                model=model,
+                request=original_exception.request if hasattr(original_exception, "request") else None,
+                litellm_debug_info=extra_information,
+            )
+
+
 def exception_type(
     model,
     original_exception,
@@ -2501,6 +2622,14 @@ def exception_type(
             For unmapped exceptions - raise the exception with traceback - https://github.com/BerriAI/litellm/issues/4201
             """
             exception_mapping_worked = True
+            _map_exception_by_status(
+                model=model,
+                original_exception=mappable_exception,
+                custom_llm_provider=custom_llm_provider,
+                error_str=error_str,
+                exception_provider=exception_provider,
+                extra_information=extra_information,
+            )
             if hasattr(original_exception, "request"):
                 raise APIConnectionError(
                     message=f"{exception_provider} - {error_str}",

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -7344,7 +7344,7 @@ class Router:
             ):
                 raise error  # then raise the error
 
-        if isinstance(error, openai.AuthenticationError):
+        if isinstance(error, (openai.AuthenticationError, openai.PermissionDeniedError)):
             """
             - if other deployments available -> retry
             - else -> raise error

--- a/tests/test_litellm/litellm_core_utils/test_exception_mapping_utils.py
+++ b/tests/test_litellm/litellm_core_utils/test_exception_mapping_utils.py
@@ -13,6 +13,7 @@ from litellm.litellm_core_utils.exception_mapping_utils import (
     extract_and_raise_litellm_exception,
 )
 from litellm.llms.openai.common_utils import OpenAIError
+from litellm.types.utils import LlmProviders
 
 # Test cases for is_error_str_context_window_exceeded
 # Tuple format: (error_message, expected_result)
@@ -785,33 +786,24 @@ OPENAI_SHAPED = {
     503: (litellm.ServiceUnavailableError, 503),
 }
 
-UPSTREAM_STATUS_DISCARDED = (litellm.APIConnectionError, 500)
+PERMISSION_DENIED = (litellm.PermissionDeniedError, 403)
 
-PROVIDERS_THAT_DISCARD_THE_UPSTREAM_STATUS = ("cloudflare", "ollama", "vllm")
+STATUS_KEYED = {**OPENAI_SHAPED, 403: PERMISSION_DENIED}
 
 DEVIATIONS_FROM_THE_OPENAI_SHAPE = {
-    "anthropic": {403: UPSTREAM_STATUS_DISCARDED, 422: UPSTREAM_STATUS_DISCARDED},
+    "anthropic": {403: PERMISSION_DENIED},
     "azure": {500: (litellm.APIError, 500)},
     "bedrock": {
-        403: UPSTREAM_STATUS_DISCARDED,
+        403: PERMISSION_DENIED,
         500: (litellm.ServiceUnavailableError, 503),
     },
-    "cohere": {
-        401: UPSTREAM_STATUS_DISCARDED,
-        403: UPSTREAM_STATUS_DISCARDED,
-        404: UPSTREAM_STATUS_DISCARDED,
-        422: UPSTREAM_STATUS_DISCARDED,
-        429: UPSTREAM_STATUS_DISCARDED,
-        503: UPSTREAM_STATUS_DISCARDED,
-    },
+    "cloudflare": {403: PERMISSION_DENIED},
+    "cohere": {403: PERMISSION_DENIED},
     "databricks": {
-        403: (litellm.AuthenticationError, 401),
+        403: PERMISSION_DENIED,
         422: (litellm.BadRequestError, 400),
     },
-    "gemini": {
-        403: (litellm.PermissionDeniedError, 403),
-        422: UPSTREAM_STATUS_DISCARDED,
-    },
+    "gemini": {403: PERMISSION_DENIED},
     "huggingface": {
         404: (litellm.APIError, 404),
         422: (litellm.APIError, 422),
@@ -824,6 +816,7 @@ DEVIATIONS_FROM_THE_OPENAI_SHAPE = {
         500: (litellm.APIError, 500),
         503: (litellm.APIError, 503),
     },
+    "ollama": {403: PERMISSION_DENIED},
     "openrouter": {500: (litellm.APIError, 500)},
     "replicate": {
         403: (litellm.APIError, 500),
@@ -833,17 +826,11 @@ DEVIATIONS_FROM_THE_OPENAI_SHAPE = {
         503: (litellm.APIError, 500),
     },
     "sagemaker": {
-        403: UPSTREAM_STATUS_DISCARDED,
+        403: PERMISSION_DENIED,
         500: (litellm.ServiceUnavailableError, 503),
     },
-    "vertex_ai": {
-        403: (litellm.PermissionDeniedError, 403),
-        422: UPSTREAM_STATUS_DISCARDED,
-    },
-    **{
-        provider: dict.fromkeys(UPSTREAM_STATUS_CODES, UPSTREAM_STATUS_DISCARDED)
-        for provider in PROVIDERS_THAT_DISCARD_THE_UPSTREAM_STATUS
-    },
+    "vertex_ai": {403: PERMISSION_DENIED},
+    "vllm": {403: PERMISSION_DENIED},
 }
 
 PROVIDERS_WITH_A_HANDLER = (
@@ -873,6 +860,38 @@ PROVIDERS_WITH_A_HANDLER = (
     "vertex_ai",
     "vllm",
     "xai",
+)
+
+PROVIDER_ALIASES_WITH_A_HANDLER = (
+    "aleph_alpha",
+    "anthropic_text",
+    "azure_text",
+    "bedrock_mantle",
+    "cohere_chat",
+    "custom_openai",
+    "lemonade",
+    "litellm_proxy",
+    "ollama_chat",
+    "predibase",
+    "sagemaker_chat",
+    "text-completion-openai",
+    "vertex_ai_beta",
+    "watsonx",
+)
+
+PROVIDERS_WITHOUT_A_HANDLER = tuple(
+    sorted(
+        frozenset(provider.value for provider in LlmProviders)
+        - frozenset(PROVIDERS_WITH_A_HANDLER)
+        - frozenset(PROVIDER_ALIASES_WITH_A_HANDLER)
+        - frozenset(litellm.openai_compatible_providers)
+    )
+)
+
+MINIMAX_401_BODY = (
+    '{"type":"error","error":{"type":"authorized_error","message":"login fail: Please carry the API secret key '
+    "in the 'Authorization' field of the request header (1004)\",\"http_code\":\"401\"},"
+    '"request_id":"06ddc9ba97ee6340e38f10e09787f547"}'
 )
 
 
@@ -938,6 +957,51 @@ def test_an_already_mapped_litellm_exception_passes_through_untouched(
     assert returned is already_mapped
 
 
+@pytest.mark.parametrize("status_code", UPSTREAM_STATUS_CODES)
+@pytest.mark.parametrize("provider", PROVIDERS_WITHOUT_A_HANDLER)
+def test_a_provider_without_a_handler_maps_by_the_upstream_status(
+    provider, status_code, quiet_exception_mapping
+):
+    expected_class, expected_status = STATUS_KEYED[status_code]
+
+    with pytest.raises(openai.APIError) as raised:
+        exception_type(
+            model="test-model",
+            original_exception=_UpstreamHTTPError(status_code=status_code),
+            custom_llm_provider=provider,
+        )
+
+    assert type(raised.value) is expected_class
+    assert raised.value.status_code == expected_status
+    assert raised.value.llm_provider == provider
+    assert raised.value.model == "test-model"
+
+
+def test_a_minimax_bad_key_is_an_authentication_error(quiet_exception_mapping):
+    from litellm.llms.base_llm.chat.transformation import BaseLLMException
+
+    with pytest.raises(litellm.AuthenticationError) as raised:
+        exception_type(
+            model="MiniMax-M2.5",
+            original_exception=BaseLLMException(status_code=401, message=MINIMAX_401_BODY),
+            custom_llm_provider="minimax",
+        )
+
+    assert raised.value.status_code == 401
+    assert raised.value.llm_provider == "minimax"
+    assert raised.value.message.startswith("litellm.AuthenticationError: MinimaxException - ")
+    assert "login fail" in raised.value.message
+
+
+def test_an_exception_without_a_status_is_still_a_connection_error(quiet_exception_mapping):
+    with pytest.raises(litellm.APIConnectionError):
+        exception_type(
+            model="MiniMax-M2.5",
+            original_exception=RuntimeError("socket hung up"),
+            custom_llm_provider="minimax",
+        )
+
+
 CONTEXT_WINDOW_MESSAGE = "This model's maximum context length is 4096 tokens."
 CONTENT_POLICY_MESSAGE = (
     '{"error": {"type": "invalid_request_error", "code": "content_policy_violation"}}'
@@ -993,9 +1057,7 @@ class _UpstreamErrorWithMessage(_UpstreamHTTPError):
 def test_a_full_context_window_reaches_the_caller_as_the_router_needs_it(
     provider, quiet_exception_mapping
 ):
-    if provider in PROVIDERS_THAT_DISCARD_THE_UPSTREAM_STATUS:
-        expected_class, expected_status = UPSTREAM_STATUS_DISCARDED
-    elif provider in PROVIDERS_THAT_RECOGNISE_A_FULL_CONTEXT_WINDOW:
+    if provider in PROVIDERS_THAT_RECOGNISE_A_FULL_CONTEXT_WINDOW:
         expected_class, expected_status = litellm.ContextWindowExceededError, 400
     else:
         expected_class, expected_status = litellm.BadRequestError, 400
@@ -1015,9 +1077,7 @@ def test_a_full_context_window_reaches_the_caller_as_the_router_needs_it(
 def test_a_content_policy_block_reaches_the_caller_as_the_router_needs_it(
     provider, quiet_exception_mapping
 ):
-    if provider in PROVIDERS_THAT_DISCARD_THE_UPSTREAM_STATUS:
-        expected_class, expected_status = UPSTREAM_STATUS_DISCARDED
-    elif provider in PROVIDERS_THAT_RECOGNISE_A_CONTENT_POLICY_BLOCK:
+    if provider in PROVIDERS_THAT_RECOGNISE_A_CONTENT_POLICY_BLOCK:
         expected_class, expected_status = litellm.ContentPolicyViolationError, 400
     else:
         expected_class, expected_status = litellm.BadRequestError, 400

--- a/tests/test_litellm/llms/base_llm/search/test_base_search_transformation.py
+++ b/tests/test_litellm/llms/base_llm/search/test_base_search_transformation.py
@@ -322,7 +322,7 @@ async def test_query_param_key_not_leaked_with_dummy_caller_key(
         "litellm.llms.custom_httpx.http_handler.AsyncHTTPHandler.get",
         fake_get,
     ):
-        with pytest.raises(litellm.APIConnectionError):
+        with pytest.raises(litellm.InternalServerError):
             await litellm.asearch(
                 query="secrets",
                 search_provider=provider,

--- a/tests/test_litellm/llms/compactifai/test_compactifai.py
+++ b/tests/test_litellm/llms/compactifai/test_compactifai.py
@@ -172,7 +172,7 @@ def test_compactifai_authentication_error(respx_mock):
         json=mock_error, status_code=401
     )
 
-    with pytest.raises(litellm.APIConnectionError) as exc_info:
+    with pytest.raises(litellm.AuthenticationError) as exc_info:
         litellm.completion(
             model="compactifai/cai-llama-3-1-8b-slim",
             messages=[{"role": "user", "content": "test"}],

--- a/tests/test_litellm/llms/langflow/chat/test_langflow_chat_transformation.py
+++ b/tests/test_litellm/llms/langflow/chat/test_langflow_chat_transformation.py
@@ -233,7 +233,7 @@ def test_langflow_extra_body_cannot_inject_tweaks_into_run_payload():
         return resp
 
     with patch.object(HTTPHandler, "post", side_effect=fake_post):
-        with pytest.raises(litellm.APIConnectionError):
+        with pytest.raises(litellm.BadRequestError):
             litellm.completion(
                 model="langflow/my-flow",
                 messages=[{"role": "user", "content": "hello"}],

--- a/tests/test_litellm/llms/vertex_ai/vertex_gemma_models/test_vertex_gemma_transformation.py
+++ b/tests/test_litellm/llms/vertex_ai/vertex_gemma_models/test_vertex_gemma_transformation.py
@@ -238,7 +238,7 @@ class TestVertexGemmaCompletion:
 
         Expected: Proper error handling when 'predictions' field is missing
         """
-        from litellm.exceptions import APIConnectionError
+        from litellm.exceptions import BadRequestError
 
         # Invalid response without predictions field
         invalid_response = {
@@ -260,8 +260,8 @@ class TestVertexGemmaCompletion:
             mock_client.post = AsyncMock(return_value=mock_response)
             mock_get_client.return_value = mock_client
 
-            # Should raise exception (wrapped as APIConnectionError by LiteLLM)
-            with pytest.raises(APIConnectionError) as exc_info:
+            # Should raise exception (wrapped as BadRequestError by LiteLLM)
+            with pytest.raises(BadRequestError) as exc_info:
                 await litellm.acompletion(
                     model="vertex_ai/gemma/gemma-3-12b-it",
                     messages=[{"role": "user", "content": "Test"}],

--- a/tests/test_litellm/test_router.py
+++ b/tests/test_litellm/test_router.py
@@ -10607,3 +10607,45 @@ async def test_async_function_with_fallbacks_scrubs_spoofed_values_from_sibling_
     assert litellm_metadata["client_key"] == "client_value"
     assert metadata["attempted_fallbacks"] == 0
     assert metadata["original_model_group"] == "gpt-3.5-turbo"
+
+
+def _permission_denied_error() -> litellm.PermissionDeniedError:
+    return litellm.PermissionDeniedError(
+        message="OpenrouterException - this key has no access to the model",
+        llm_provider="openrouter",
+        model="openrouter/openai/gpt-4o",
+        response=httpx.Response(status_code=403, request=httpx.Request(method="POST", url="https://openrouter.ai")),
+    )
+
+
+def test_permission_denied_error_is_not_retried_against_a_single_deployment():
+    router = litellm.Router(
+        model_list=[
+            {"model_name": "gpt-4o", "litellm_params": {"model": "openrouter/openai/gpt-4o", "api_key": "sk-test"}},
+        ]
+    )
+
+    with pytest.raises(litellm.PermissionDeniedError):
+        router.should_retry_this_error(
+            error=_permission_denied_error(),
+            healthy_deployments=router.model_list,
+            all_deployments=router.model_list,
+        )
+
+
+def test_permission_denied_error_is_retried_when_other_deployments_exist():
+    router = litellm.Router(
+        model_list=[
+            {"model_name": "gpt-4o", "litellm_params": {"model": "openrouter/openai/gpt-4o", "api_key": "sk-test"}},
+            {"model_name": "gpt-4o", "litellm_params": {"model": "openai/gpt-4o", "api_key": "sk-test"}},
+        ]
+    )
+
+    assert (
+        router.should_retry_this_error(
+            error=_permission_denied_error(),
+            healthy_deployments=router.model_list,
+            all_deployments=router.model_list,
+        )
+        is True
+    )


### PR DESCRIPTION
## TLDR

Problem this solves:

- Providers with no `exception_type` branch answered every upstream error as a 500
- A bad MiniMax key came back as `APIConnectionError`, code 500, so clients kept retrying
- OpenAI-like providers (databricks, watsonx, ...) raised `AuthenticationError` for an upstream 403

How it solves it:

- The status-blind fallback now maps by upstream status like the typed providers do
- 401, 403, 404, 408, 429, 5xx get their typed class; any other 4xx is `BadRequestError`
- `APIConnectionError` is only raised when the exception carries no status at all
- OpenAI-like 403 now raises `PermissionDeniedError`
- The router's single-deployment fail-fast now covers `PermissionDeniedError` like it does `AuthenticationError`

## User Flow

Before: a developer with an invalid MiniMax key gets a 500 from the gateway, so their client keeps retrying a request that can never succeed

1. They send POST https://litellm-domain/v1/chat/completions with `"model": "minimax-m2.5"`
2. The gateway answers HTTP 500 with `litellm.APIConnectionError: MinimaxException - {... "http_code":"401" ...}` and `"code":"500"`
3. They send POST https://litellm-domain/v1/responses with the same model and get the same HTTP 500
4. Their SDK treats the 500 as transient and retries, and every retry gets the same 500

After: the same requests come back as 401 authentication errors, so the client stops retrying and the developer fixes the key

1. They send POST https://litellm-domain/v1/chat/completions with `"model": "minimax-m2.5"`
2. The gateway answers HTTP 401 with `litellm.AuthenticationError: MinimaxException - {... "http_code":"401" ...}` and `"code":"401"`
3. They send POST https://litellm-domain/v1/responses with the same model and get the same HTTP 401
4. Their SDK raises an authentication error right away and does not retry

## Relevant issues

## Linear ticket

Resolves LIT-6166

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Shared setup for both legs: a proxy booted with `python litellm/proxy/proxy_cli.py --config proxy_config.yaml --port <port> --num_workers 2`, no database, against the real MiniMax and Anthropic APIs. `minimax-m2.5` carries an invalid key on purpose (MiniMax answers 401 to any invalid key, no account needed). `claude-haiku-4-5` is the paid control, `claude-haiku-4-5-badkey` is the typed-provider control for the same 401

```yaml
model_list:
  - model_name: minimax-m2.5
    litellm_params:
      model: minimax/MiniMax-M2.5
      api_key: minimax-invalid-key-lit6166
  - model_name: claude-haiku-4-5
    litellm_params:
      model: anthropic/claude-haiku-4-5
      api_key: os.environ/ANTHROPIC_API_KEY
  - model_name: claude-haiku-4-5-badkey
    litellm_params:
      model: anthropic/claude-haiku-4-5
      api_key: sk-ant-invalid-key-lit6166

general_settings:
  master_key: sk-1234
```

### Before (e52f05566d)

#### /v1/chat/completions with an invalid MiniMax key

1. Run
   ```
   curl -s -w '\nHTTP %{http_code}\n' http://localhost:40712/v1/chat/completions -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' -d '{"model":"minimax-m2.5","messages":[{"role":"user","content":"hi"}],"max_tokens":16}'
   ```
2. Observed: the upstream 401 comes back as a 500
   ```
   {"error":{"message":"litellm.APIConnectionError: MinimaxException - {\"type\":\"error\",\"error\":{\"type\":\"authorized_error\",\"message\":\"login fail: Please carry the API secret key in the 'Authorization' field of the request header (1004)\",\"http_code\":\"401\"},\"request_id\":\"06ddc9ba97ee6340e38f10e09787f547\"}. Received Model Group=minimax-m2.5\nAvailable Model Group Fallbacks=None","type":null,"param":null,"code":"500"}}
   HTTP 500
   ```

#### /v1/responses with an invalid MiniMax key

1. Run
   ```
   curl -s -w '\nHTTP %{http_code}\n' http://localhost:40712/v1/responses -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' -d '{"model":"minimax-m2.5","input":"hi","max_output_tokens":16}'
   ```
2. Observed: same 500
   ```
   {"error":{"message":"litellm.APIConnectionError: MinimaxException - {\"type\":\"error\",\"error\":{\"type\":\"authorized_error\",\"message\":\"login fail: Please carry the API secret key in the 'Authorization' field of the request header (1004)\",\"http_code\":\"401\"},\"request_id\":\"06ddc9bfe4176d9ac7214a1db123680f\"}. Received Model Group=minimax-m2.5\nAvailable Model Group Fallbacks=None","type":null,"param":null,"code":"500"}}
   HTTP 500
   ```

#### /v1/messages with an invalid MiniMax key

1. Run
   ```
   curl -s -w '\nHTTP %{http_code}\n' http://localhost:40712/v1/messages -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' -d '{"model":"minimax-m2.5","messages":[{"role":"user","content":"hi"}],"max_tokens":16}'
   ```
2. Observed: this route already answered 401 (it does not go through the shared mapper), with the raw upstream JSON as the message
   ```
   {"error":{"message":"{\"type\":\"error\",\"error\":{\"type\":\"authentication_error\",\"message\":\"login fail: Please carry the API secret key in the 'X-Api-Key' field of the request header\"},\"request_id\":\"06ddc9c2ea273bfc212258b20f5f8991\"}. Received Model Group=minimax-m2.5\nAvailable Model Group Fallbacks=None","type":"None","param":"None","code":"401"}}
   HTTP 401
   ```

#### Control: /v1/chat/completions with an invalid Anthropic key (typed provider)

1. Run
   ```
   curl -s -w '\nHTTP %{http_code}\n' http://localhost:40712/v1/chat/completions -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' -d '{"model":"claude-haiku-4-5-badkey","messages":[{"role":"user","content":"hi"}],"max_tokens":16}'
   ```
2. Observed: a typed provider already maps the 401
   ```
   {"error":{"message":"litellm.AuthenticationError: AnthropicException - {\"type\":\"error\",\"error\":{\"type\":\"authentication_error\",\"message\":\"API key is invalid.\"},\"request_id\":null}. Received Model Group=claude-haiku-4-5-badkey\nAvailable Model Group Fallbacks=None","type":null,"param":null,"code":"401"}}
   HTTP 401
   ```

#### Control: valid Anthropic key on all three endpoints

1. Run
   ```
   curl -s -w '\nHTTP %{http_code}\n' http://localhost:40712/v1/chat/completions -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' -d '{"model":"claude-haiku-4-5","messages":[{"role":"user","content":"Reply with the single word ok"}],"max_tokens":16}'
   ```
2. Observed
   ```
   {"id":"chatcmpl-34327872-1344-49ce-a626-3ba57c88794b","created":1787729603,"model":"claude-haiku-4-5","object":"chat.completion","choices":[{"finish_reason":"stop","index":0,"message":{"content":"ok","role":"assistant",...}}],"usage":{"completion_tokens":4,"prompt_tokens":13,"total_tokens":17,...}}
   HTTP 200
   ```
3. Run
   ```
   curl -s -w '\nHTTP %{http_code}\n' http://localhost:40712/v1/responses -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' -d '{"model":"claude-haiku-4-5","input":"Reply with the single word ok","max_output_tokens":16}'
   ```
4. Observed
   ```
   {"id":"resp_lNzEEKpwd752_9UJX0miTE56...","created_at":1787729603,"error":null,"incomplete_details":null,"instructions":null,"metadata":{},"model":"claude-haiku-4-5","object":"response","output":[{"type":"message","id":"msg_87ab1023-9543-410c-b2f7-276b19a762ce",...}],...}
   HTTP 200
   ```
5. Run
   ```
   curl -s -w '\nHTTP %{http_code}\n' http://localhost:40712/v1/messages -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' -d '{"model":"claude-haiku-4-5","messages":[{"role":"user","content":"Reply with the single word ok"}],"max_tokens":16}'
   ```
6. Observed
   ```
   {"model":"claude-haiku-4-5","id":"msg_011CeQyLWvNN576g5jzX3sF3","type":"message","role":"assistant","content":[{"type":"text","text":"ok"}],"stop_reason":"end_turn","stop_sequence":null,"stop_details":null,"usage":{"input_tokens":13,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,...,"output_tokens":4,"service_tier":"standard","inference_geo":"not_available"}}
   HTTP 200
   ```

### After (6386a68c9c)

#### /v1/chat/completions with an invalid MiniMax key

1. Run
   ```
   curl -s -w '\nHTTP %{http_code}\n' http://localhost:34566/v1/chat/completions -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' -d '{"model":"minimax-m2.5","messages":[{"role":"user","content":"hi"}],"max_tokens":16}'
   ```
2. Observed: the upstream 401 is now a 401 `AuthenticationError`
   ```
   {"error":{"message":"litellm.AuthenticationError: MinimaxException - {\"type\":\"error\",\"error\":{\"type\":\"authorized_error\",\"message\":\"login fail: Please carry the API secret key in the 'Authorization' field of the request header (1004)\",\"http_code\":\"401\"},\"request_id\":\"06ddd2520c26c72df2739c8dcad1c6de\"}. Received Model Group=minimax-m2.5\nAvailable Model Group Fallbacks=None","type":null,"param":null,"code":"401"}}
   HTTP 401
   ```

#### /v1/responses with an invalid MiniMax key

1. Run
   ```
   curl -s -w '\nHTTP %{http_code}\n' http://localhost:34566/v1/responses -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' -d '{"model":"minimax-m2.5","input":"hi","max_output_tokens":16}'
   ```
2. Observed: same 401 `AuthenticationError`
   ```
   {"error":{"message":"litellm.AuthenticationError: MinimaxException - {\"type\":\"error\",\"error\":{\"type\":\"authorized_error\",\"message\":\"login fail: Please carry the API secret key in the 'Authorization' field of the request header (1004)\",\"http_code\":\"401\"},\"request_id\":\"06ddd258ae4bbffd1e6667a5f66006c6\"}. Received Model Group=minimax-m2.5\nAvailable Model Group Fallbacks=None","type":null,"param":null,"code":"401"}}
   HTTP 401
   ```

#### /v1/messages with an invalid MiniMax key

1. Run
   ```
   curl -s -w '\nHTTP %{http_code}\n' http://localhost:34566/v1/messages -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' -d '{"model":"minimax-m2.5","messages":[{"role":"user","content":"hi"}],"max_tokens":16}'
   ```
2. Observed: still 401; the `litellm.AuthenticationError` prefix here comes from #38310, which landed on the base and is part of this tip
   ```
   {"error":{"message":"litellm.AuthenticationError: MinimaxException - {\"type\":\"error\",\"error\":{\"type\":\"authentication_error\",\"message\":\"login fail: Please carry the API secret key in the 'X-Api-Key' field of the request header\"},\"request_id\":\"06ddd25fd2c7c39b870f7702696c2a8f\"}. Received Model Group=minimax-m2.5\nAvailable Model Group Fallbacks=None","type":null,"param":null,"code":"401"}}
   HTTP 401
   ```

#### Control: /v1/chat/completions with an invalid Anthropic key (typed provider)

1. Run
   ```
   curl -s -w '\nHTTP %{http_code}\n' http://localhost:34566/v1/chat/completions -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' -d '{"model":"claude-haiku-4-5-badkey","messages":[{"role":"user","content":"hi"}],"max_tokens":16}'
   ```
2. Observed: unchanged
   ```
   {"error":{"message":"litellm.AuthenticationError: AnthropicException - {\"type\":\"error\",\"error\":{\"type\":\"authentication_error\",\"message\":\"API key is invalid.\"},\"request_id\":null}. Received Model Group=claude-haiku-4-5-badkey\nAvailable Model Group Fallbacks=None","type":null,"param":null,"code":"401"}}
   HTTP 401
   ```

#### Control: valid Anthropic key on all three endpoints

1. Run
   ```
   curl -s -w '\nHTTP %{http_code}\n' http://localhost:34566/v1/chat/completions -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' -d '{"model":"claude-haiku-4-5","messages":[{"role":"user","content":"Reply with the single word ok"}],"max_tokens":16}'
   ```
2. Observed
   ```
   {"id":"chatcmpl-60f10bda-5290-408c-8231-1913fb74286c","created":1787731820,"model":"claude-haiku-4-5","object":"chat.completion","choices":[{"finish_reason":"stop","index":0,"message":{"content":"ok","role":"assistant",...}}],"usage":{"completion_tokens":4,"prompt_tokens":13,"total_tokens":17,...}}
   HTTP 200
   ```
3. Run
   ```
   curl -s -w '\nHTTP %{http_code}\n' http://localhost:34566/v1/responses -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' -d '{"model":"claude-haiku-4-5","input":"Reply with the single word ok","max_output_tokens":16}'
   ```
4. Observed
   ```
   {"id":"resp__QWfhwXW_eRlC7OmxZ2ejr56RRCwXwHgqQ...","created_at":1787731829,"error":null,"incomplete_details":null,"instructions":null,"metadata":{},"model":"claude-haiku-4-5","object":"response","output":[{"type":"message","id":"msg_f46089ef-8447-4374-a792-be5e8d008c6f",...}],...}
   HTTP 200
   ```
5. Run
   ```
   curl -s -w '\nHTTP %{http_code}\n' http://localhost:34566/v1/messages -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' -d '{"model":"claude-haiku-4-5","messages":[{"role":"user","content":"Reply with the single word ok"}],"max_tokens":16}'
   ```
6. Observed
   ```
   {"model":"claude-haiku-4-5","id":"msg_011CeR2Ayuexj7fJf1rDLeSN","type":"message","role":"assistant","content":[{"type":"text","text":"ok"}],"stop_reason":"end_turn","stop_sequence":null,"stop_details":null,"usage":{"input_tokens":13,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,...,"output_tokens":4,"service_tier":"standard","inference_geo":"not_available"}}
   HTTP 200
   ```

Observations from the run:

- After leg: the 401 cools the MiniMax deployment down for 5s, so back-to-back calls got a 429 until it expired; cases were spaced 6s apart
- Before leg never cooled it down: the router skips cooldown on `APIConnectionError`
- /v1/messages answered 401 on both legs; its `litellm.AuthenticationError` prefix on the after leg comes from #38310 on the base, not this PR

## Type

🐛 Bug Fix

## Caveats (if any)

### Low

- A branchless provider's 401, 429, or 5xx now cools the deployment down like typed providers do
- A 403 on a model group with a single deployment now fails immediately instead of being retried against it
- With multiple deployments a 403 is still retried across them, but it never cools the failing deployment down, same as typed providers today
- Unlisted 5xx map to `APIError` with the upstream status, matching the OpenAI branch
- 422 maps to `BadRequestError` carrying status 422, matching the OpenAI branch
- The OpenAI branch's own 403 still raises `APIError`; left alone, out of scope

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

- [x] 6386a68c9c37d6ccb2983e99854da0b1b0b7b84a passes /live-pr-risk

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes global error mapping and HTTP codes returned to clients for many providers; behavior shifts from generic 500s to typed 4xx/5xx, which affects retries, cooldowns, and SDK handling but is intentional bug-fix scope.
> 
> **Overview**
> Providers without a dedicated `exception_type` branch used to surface most HTTP errors as **`APIConnectionError` with code 500**, so invalid keys (e.g. MiniMax 401) looked transient and clients kept retrying.
> 
> This PR adds **`_map_exception_by_status`** on the generic fallback path so upstream **401, 403, 404, 408, 429, and 5xx** map to the same typed LiteLLM exceptions as handled providers; **`APIConnectionError`** is only used when the exception has **no status**. OpenAI-like providers now raise **`PermissionDeniedError`** for **403** instead of **`AuthenticationError`**.
> 
> The router **`should_retry_this_error`** logic treats **`PermissionDeniedError`** like **`AuthenticationError`** (fail fast when only one deployment exists). Tests are updated across exception mapping, router retry, and several provider tests that now expect the correct typed errors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6386a68c9c37d6ccb2983e99854da0b1b0b7b84a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->