### PR TITLE
fix(passthrough): record ownership of streamed responses under managed ids

### DIFF
--- a/litellm/proxy/common_utils/sse_keepalive.py
+++ b/litellm/proxy/common_utils/sse_keepalive.py
@@ -91,6 +91,18 @@ def is_sse_content_type(content_type: str | None) -> bool:
     return content_type is not None and content_type.split(";", 1)[0].strip().lower() == _SSE_MEDIA_TYPE
 
 
+def split_complete_sse_frames(pending: bytes) -> tuple[bytes, bytes]:
+    """Split buffered SSE bytes into ``(complete_frames, unterminated_tail)``."""
+    lf_boundary_end: Final = pending.rfind(b"\n\n") + 2
+    crlf_boundary_end: Final = pending.rfind(b"\r\n\r\n") + 4
+    boundary_end: Final = max(
+        lf_boundary_end if lf_boundary_end >= 2 else 0, crlf_boundary_end if crlf_boundary_end >= 4 else 0
+    )
+    if boundary_end == 0:
+        return b"", pending
+    return pending[:boundary_end], pending[boundary_end:]
+
+
 def wrap_passthrough_sse_bytes_with_keepalive_pings(
     stream: AsyncGenerator[bytes, None],
     ping_interval_seconds: float | str | None,

--- a/litellm/proxy/common_utils/sse_keepalive.py
+++ b/litellm/proxy/common_utils/sse_keepalive.py
@@ -93,10 +93,9 @@ def is_sse_content_type(content_type: str | None) -> bool:
 
 def split_complete_sse_frames(pending: bytes) -> tuple[bytes, bytes]:
     """Split buffered SSE bytes into ``(complete_frames, unterminated_tail)``."""
-    lf_boundary_end: Final = pending.rfind(b"\n\n") + 2
-    crlf_boundary_end: Final = pending.rfind(b"\r\n\r\n") + 4
     boundary_end: Final = max(
-        lf_boundary_end if lf_boundary_end >= 2 else 0, crlf_boundary_end if crlf_boundary_end >= 4 else 0
+        (pending.rfind(delimiter) + len(delimiter) for delimiter in _SSE_FRAME_DELIMITERS if delimiter in pending),
+        default=0,
     )
     if boundary_end == 0:
         return b"", pending

--- a/litellm/proxy/pass_through_endpoints/managed_id_rewriter.py
+++ b/litellm/proxy/pass_through_endpoints/managed_id_rewriter.py
@@ -821,10 +821,6 @@ async def rewrite_response_ids(
     return mutated if changed else body
 
 
-# ---------------------------------------------------------------------------
-# OUTPUT path — streamed Responses API bodies
-# ---------------------------------------------------------------------------
-
 _RESPONSE_ID_PREFIX: Final = "resp_"
 _STREAMED_RESPONSE_ID_SPEC: Final[_FieldSpec] = ("id", _RESPONSE_ID_PREFIX)
 _SSE_DATA_PREFIX: Final = "data:"

--- a/litellm/proxy/pass_through_endpoints/managed_id_rewriter.py
+++ b/litellm/proxy/pass_through_endpoints/managed_id_rewriter.py
@@ -32,7 +32,7 @@ from __future__ import annotations
 
 import json
 import re
-from collections.abc import Callable, Mapping, Sequence
+from collections.abc import AsyncGenerator, Callable, Mapping, Sequence
 from typing import (
     TYPE_CHECKING,
     Final,
@@ -43,7 +43,7 @@ from typing import (
 from urllib.parse import quote, unquote
 
 from fastapi import HTTPException
-from pydantic import JsonValue
+from pydantic import JsonValue, TypeAdapter, ValidationError
 
 from litellm._logging import verbose_proxy_logger
 from litellm.llms.base_llm.managed_resources.isolation import (
@@ -52,6 +52,7 @@ from litellm.llms.base_llm.managed_resources.isolation import (
 )
 from litellm.proxy._types import UserAPIKeyAuth
 from litellm.proxy.batches_endpoints.common_utils import validate_batch_list_limit
+from litellm.proxy.common_utils.sse_keepalive import split_complete_sse_frames
 from litellm.repositories.table_repositories import (
     ManagedFileRepository,
     ManagedObjectRepository,
@@ -818,6 +819,125 @@ async def rewrite_response_ids(
         canonical,
     )
     return mutated if changed else body
+
+
+# ---------------------------------------------------------------------------
+# OUTPUT path — streamed Responses API bodies
+# ---------------------------------------------------------------------------
+
+_RESPONSE_ID_PREFIX: Final = "resp_"
+_STREAMED_RESPONSE_ID_SPEC: Final[_FieldSpec] = ("id", _RESPONSE_ID_PREFIX)
+_SSE_DATA_PREFIX: Final = "data:"
+_SSE_EVENT_ADAPTER: Final = TypeAdapter(Mapping[str, JsonValue])
+
+
+def _first_streamed_response(frames: bytes) -> tuple[str, Mapping[str, JsonValue]] | None:
+    for line in frames.decode("utf-8", errors="replace").splitlines():
+        if not line.startswith(_SSE_DATA_PREFIX):
+            continue
+        try:
+            event = _SSE_EVENT_ADAPTER.validate_json(line[len(_SSE_DATA_PREFIX) :])
+        except ValidationError:
+            continue
+        response = event.get("response")
+        if not isinstance(response, dict):
+            continue
+        raw_id = response.get("id")
+        if isinstance(raw_id, str) and raw_id.startswith(_RESPONSE_ID_PREFIX):
+            return raw_id, response
+    return None
+
+
+class _StreamedResponseIdRewriter:
+    __slots__ = ("_is_create_route", "_pending", "_prisma_client", "_provider", "_replacement", "_user_api_key_dict")
+
+    def __init__(
+        self,
+        provider: str,
+        user_api_key_dict: UserAPIKeyAuth,
+        prisma_client: PrismaClient,
+        is_create_route: bool,
+    ) -> None:
+        self._provider: Final = provider
+        self._user_api_key_dict: Final = user_api_key_dict
+        self._prisma_client: Final = prisma_client
+        self._is_create_route: Final = is_create_route
+        self._pending = b""
+        self._replacement: tuple[bytes, bytes] | None = None
+
+    async def feed(self, chunk: bytes) -> bytes:
+        complete_frames, self._pending = split_complete_sse_frames(self._pending + chunk)
+        if not complete_frames:
+            return b""
+        if self._replacement is None:
+            self._replacement = await self._mint(complete_frames)
+        return self._rewrite(complete_frames)
+
+    def flush(self) -> bytes:
+        tail: Final = self._pending
+        self._pending = b""
+        return self._rewrite(tail)
+
+    async def _mint(self, frames: bytes) -> tuple[bytes, bytes] | None:
+        first: Final = _first_streamed_response(frames)
+        if first is None:
+            return None
+        raw_id, snapshot = first
+        managed_id: Final = await _mint_or_reuse_object(
+            raw_id,
+            self._provider,
+            "response",
+            snapshot,
+            self._user_api_key_dict,
+            self._prisma_client,
+            self._is_create_route,
+        )
+        return raw_id.encode(), managed_id.encode()
+
+    def _rewrite(self, frames: bytes) -> bytes:
+        if self._replacement is None:
+            return frames
+        raw_id, managed_id = self._replacement
+        return frames.replace(raw_id, managed_id)
+
+
+async def rewrite_streamed_response_ids(
+    stream: AsyncGenerator[bytes, None],
+    provider: str,
+    method: str,
+    route: str,
+    user_api_key_dict: UserAPIKeyAuth,
+    prisma_client: PrismaClient,
+) -> AsyncGenerator[bytes, None]:
+    """
+    Record ownership of the response object streamed back by a Responses API
+    passthrough and swap its managed id into every SSE frame, so a streamed
+    response is owned and resolved exactly like a non-streamed one.
+
+    Streams for any other ``(provider, method, route)`` are relayed untouched.
+    """
+    from litellm.proxy.auth.auth_utils import normalize_request_route
+
+    canonical: Final = normalize_request_route(_canonical_path(route))
+    field_specs: Final = BUILTIN_OUTPUT_ID_FIELD_MAP.get((provider, method, canonical), ())
+    if _STREAMED_RESPONSE_ID_SPEC not in field_specs:
+        async for chunk in stream:
+            yield chunk
+        return
+
+    rewriter: Final = _StreamedResponseIdRewriter(
+        provider=provider,
+        user_api_key_dict=user_api_key_dict,
+        prisma_client=prisma_client,
+        is_create_route="{" not in canonical,
+    )
+    async for chunk in stream:
+        rewritten_frames = await rewriter.feed(chunk)
+        if rewritten_frames:
+            yield rewritten_frames
+    tail: Final = rewriter.flush()
+    if tail:
+        yield tail
 
 
 # ---------------------------------------------------------------------------

--- a/litellm/proxy/pass_through_endpoints/pass_through_endpoints.py
+++ b/litellm/proxy/pass_through_endpoints/pass_through_endpoints.py
@@ -1209,14 +1209,19 @@ async def pass_through_request(
 
             return StreamingResponse(
                 wrap_passthrough_sse_bytes_with_keepalive_pings(
-                    stream=PassThroughStreamingHandler.chunk_processor(
-                        response=response,
-                        request_body=_parsed_body,
-                        litellm_logging_obj=logging_obj,
-                        endpoint_type=endpoint_type,
-                        start_time=start_time,
-                        passthrough_success_handler_obj=pass_through_endpoint_logging,
-                        url_route=str(url),
+                    stream=_own_streamed_managed_ids(
+                        stream=PassThroughStreamingHandler.chunk_processor(
+                            response=response,
+                            request_body=_parsed_body,
+                            litellm_logging_obj=logging_obj,
+                            endpoint_type=endpoint_type,
+                            start_time=start_time,
+                            passthrough_success_handler_obj=pass_through_endpoint_logging,
+                            url_route=str(url),
+                        ),
+                        managed_id_provider=_managed_id_provider,
+                        request=request,
+                        user_api_key_dict=user_api_key_dict,
                     ),
                     ping_interval_seconds=litellm.sse_keepalive_ping_interval_seconds,
                     upstream_headers=response.headers,
@@ -1285,14 +1290,19 @@ async def pass_through_request(
 
             return StreamingResponse(
                 wrap_passthrough_sse_bytes_with_keepalive_pings(
-                    stream=PassThroughStreamingHandler.chunk_processor(
-                        response=response,
-                        request_body=_parsed_body,
-                        litellm_logging_obj=logging_obj,
-                        endpoint_type=endpoint_type,
-                        start_time=start_time,
-                        passthrough_success_handler_obj=pass_through_endpoint_logging,
-                        url_route=str(url),
+                    stream=_own_streamed_managed_ids(
+                        stream=PassThroughStreamingHandler.chunk_processor(
+                            response=response,
+                            request_body=_parsed_body,
+                            litellm_logging_obj=logging_obj,
+                            endpoint_type=endpoint_type,
+                            start_time=start_time,
+                            passthrough_success_handler_obj=pass_through_endpoint_logging,
+                            url_route=str(url),
+                        ),
+                        managed_id_provider=_managed_id_provider,
+                        request=request,
+                        user_api_key_dict=user_api_key_dict,
                     ),
                     ping_interval_seconds=litellm.sse_keepalive_ping_interval_seconds,
                     upstream_headers=response.headers,
@@ -2439,6 +2449,36 @@ def _is_streaming_response(response: httpx.Response) -> bool:
     if _content_type is not None and "text/event-stream" in _content_type:
         return True
     return False
+
+
+def _own_streamed_managed_ids(
+    stream: AsyncGenerator[bytes, None],
+    managed_id_provider: str | None,
+    request: Request,
+    user_api_key_dict: UserAPIKeyAuth,
+) -> AsyncGenerator[bytes, None]:
+    from litellm.proxy.proxy_server import general_settings, prisma_client, proxy_logging_obj
+
+    if (
+        managed_id_provider is None
+        or not general_settings.get("passthrough_managed_object_ids", False)
+        or prisma_client is None
+        or proxy_logging_obj.get_proxy_hook("managed_files") is None
+    ):
+        return stream
+    from litellm.proxy.auth.auth_utils import get_request_route
+    from litellm.proxy.pass_through_endpoints.managed_id_rewriter import (
+        rewrite_streamed_response_ids,
+    )
+
+    return rewrite_streamed_response_ids(
+        stream=stream,
+        provider=managed_id_provider,
+        method=request.method,
+        route=get_request_route(request),
+        user_api_key_dict=user_api_key_dict,
+        prisma_client=prisma_client,
+    )
 
 
 def _should_buffer_passthrough_response(response: httpx.Response) -> bool:

--- a/litellm/proxy/pass_through_endpoints/streaming_handler.py
+++ b/litellm/proxy/pass_through_endpoints/streaming_handler.py
@@ -10,6 +10,7 @@ from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLogging
 from litellm.litellm_core_utils.logging_worker import GLOBAL_LOGGING_WORKER
 from litellm.proxy._types import PassThroughEndpointLoggingResultValues
 from litellm.proxy.common_request_processing import ProxyBaseLLMRequestProcessing
+from litellm.proxy.common_utils.sse_keepalive import split_complete_sse_frames
 from litellm.types.passthrough_endpoints.pass_through_endpoints import EndpointType
 from litellm.types.utils import StandardPassThroughResponseObject
 
@@ -101,7 +102,7 @@ class PassThroughStreamingHandler:
                 async for chunk in response.aiter_bytes():
                     raw_bytes.append(chunk)
                     PassThroughStreamingHandler._stamp_first_chunk_if_needed(litellm_logging_obj)
-                    complete_frames, pending = PassThroughStreamingHandler._split_complete_sse_frames(
+                    complete_frames, pending = split_complete_sse_frames(
                         pending + chunk
                     )  # rebind-ok: SSE frame reassembly buffer across transport chunks
                     if complete_frames:
@@ -138,17 +139,6 @@ class PassThroughStreamingHandler:
                     )
                 except Exception as e:
                     verbose_proxy_logger.error("Error scheduling chunk_processor logging: %s", e)
-
-    @staticmethod
-    def _split_complete_sse_frames(pending: bytes) -> tuple[bytes, bytes]:
-        lf_boundary_end: Final = pending.rfind(b"\n\n") + 2
-        crlf_boundary_end: Final = pending.rfind(b"\r\n\r\n") + 4
-        boundary_end: Final = max(
-            lf_boundary_end if lf_boundary_end >= 2 else 0, crlf_boundary_end if crlf_boundary_end >= 4 else 0
-        )
-        if boundary_end == 0:
-            return b"", pending
-        return pending[:boundary_end], pending[boundary_end:]
 
     @staticmethod
     async def _route_streaming_logging_to_handler(

--- a/tests/test_litellm/proxy/common_utils/test_sse_keepalive.py
+++ b/tests/test_litellm/proxy/common_utils/test_sse_keepalive.py
@@ -10,12 +10,26 @@ from litellm.proxy.common_utils.sse_keepalive import (
     ANTHROPIC_PING_SSE_CHUNK,
     SSE_COMMENT_PING_BYTES,
     resolve_ttft_keepalive_interval,
+    split_complete_sse_frames,
     wrap_passthrough_sse_bytes_with_keepalive_pings,
     wrap_sse_stream_with_keepalive_pings,
 )
 
 MESSAGE_START_CHUNK: Final = 'data: {"type": "message_start"}\n\n'
 TEXT_DELTA_CHUNK: Final = 'data: {"type": "content_block_delta"}\n\n'
+
+
+@pytest.mark.parametrize("delimiter", [b"\n\n", b"\r\n\r\n", b"\r\r"])
+def test_split_complete_sse_frames_recognizes_every_sse_frame_delimiter(delimiter: bytes):
+    newline: Final = delimiter[: len(delimiter) // 2]
+    frame: Final = b"event: response.created" + newline + b"data: {}" + delimiter
+    tail: Final = b"data: partial"
+
+    assert split_complete_sse_frames(frame + tail) == (frame, tail)
+
+
+def test_split_complete_sse_frames_holds_bytes_with_no_complete_frame():
+    assert split_complete_sse_frames(b"data: unterminated") == (b"", b"data: unterminated")
 
 
 @pytest.mark.asyncio

--- a/tests/test_litellm/proxy/pass_through_endpoints/test_managed_id_rewriter.py
+++ b/tests/test_litellm/proxy/pass_through_endpoints/test_managed_id_rewriter.py
@@ -212,6 +212,29 @@ async def test_streamed_response_is_owned_and_rewritten_across_chunk_boundaries(
 
 
 @pytest.mark.asyncio
+async def test_streamed_response_with_cr_only_frame_delimiters_is_still_owned_and_rewritten():
+    """SSE also terminates lines with a lone CR; those frames must mint and rewrite too."""
+    pc = _prisma_client()
+    payload = _response_stream_bytes().replace(b"\n", b"\r")
+
+    output = await _collect(
+        rewrite_streamed_response_ids(
+            stream=_chunks(payload, 7),
+            provider="openai",
+            method="POST",
+            route="/openai_passthrough/v1/responses",
+            user_api_key_dict=_user(),
+            prisma_client=pc,
+        )
+    )
+
+    pc.db.litellm_managedobjecttable.upsert.assert_awaited_once()
+    managed_id = pc.db.litellm_managedobjecttable.upsert.await_args.kwargs["data"]["create"]["unified_object_id"]
+    assert RAW_RESPONSE_ID.encode() not in output
+    assert output == _response_stream_bytes(managed_id).replace(b"\n", b"\r")
+
+
+@pytest.mark.asyncio
 async def test_streamed_bytes_untouched_on_routes_without_a_response_id():
     pc = _prisma_client()
     payload = _response_stream_bytes()

--- a/tests/test_litellm/proxy/pass_through_endpoints/test_managed_id_rewriter.py
+++ b/tests/test_litellm/proxy/pass_through_endpoints/test_managed_id_rewriter.py
@@ -1,12 +1,15 @@
 import datetime
+import json
+from collections.abc import AsyncIterator, Iterable
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
 from litellm.proxy._types import ProxyException, UserAPIKeyAuth
-from litellm.proxy.pass_through_endpoints.managed_id_codec import new_managed_id
+from litellm.proxy.pass_through_endpoints.managed_id_codec import decode, new_managed_id
 from litellm.proxy.pass_through_endpoints.managed_id_rewriter import (
     list_passthrough_ids_from_db,
+    rewrite_streamed_response_ids,
 )
 
 
@@ -27,7 +30,37 @@ def _prisma_client(file_rows=None, batch_rows=None) -> MagicMock:
     pc.db.litellm_managedobjecttable.find_many = AsyncMock(
         side_effect=lambda *args, take=None, **kwargs: list(batch_rows or [])[:take]
     )
+    pc.db.litellm_managedobjecttable.upsert = AsyncMock(return_value=None)
     return pc
+
+
+RAW_RESPONSE_ID = "resp_0123456789abcdef"
+
+
+def _response_stream_bytes(raw_id: str = RAW_RESPONSE_ID) -> bytes:
+    events = (
+        ("response.created", {"type": "response.created", "response": {"id": raw_id, "status": "in_progress"}}),
+        ("response.output_text.delta", {"type": "response.output_text.delta", "delta": "mango"}),
+        ("response.completed", {"type": "response.completed", "response": {"id": raw_id, "status": "completed"}}),
+    )
+    return b"".join(f"event: {name}\ndata: {json.dumps(payload)}\n\n".encode() for name, payload in events)
+
+
+async def _chunks(payload: bytes, size: int) -> AsyncIterator[bytes]:
+    for start in range(0, len(payload), size):
+        yield payload[start : start + size]
+
+
+async def _collect(stream: AsyncIterator[bytes]) -> bytes:
+    return b"".join([chunk async for chunk in stream])
+
+
+def _response_ids(sse: bytes) -> Iterable[str]:
+    for line in sse.decode().splitlines():
+        if line.startswith("data:"):
+            event = json.loads(line[len("data:") :])
+            if "response" in event:
+                yield event["response"]["id"]
 
 
 def _file_row(unified_id: str) -> MagicMock:
@@ -67,9 +100,7 @@ def _batch_row(unified_id: str) -> MagicMock:
         ),
     ],
 )
-async def test_list_batches_out_of_range_limit_raises_400(
-    limit, expected_message, expected_openai_code
-):
+async def test_list_batches_out_of_range_limit_raises_400(limit, expected_message, expected_openai_code):
     pc = _prisma_client(batch_rows=[_batch_row(new_managed_id("openai", "batch_abc"))])
 
     with pytest.raises(ProxyException) as exc:
@@ -147,3 +178,75 @@ async def test_list_files_drops_batch_guardrail_key_persisted_by_an_older_proxy(
     assert result is not None
     assert "litellm_batch_guardrail" not in result["data"][0]
     assert result["data"][0]["filename"] == "test.jsonl"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("chunk_size", [1, 7, 4096])
+async def test_streamed_response_is_owned_and_rewritten_across_chunk_boundaries(chunk_size: int):
+    """A streamed POST /v1/responses records the caller as owner once and returns
+    the minted id in every event, no matter how the transport splits the SSE bytes."""
+    pc = _prisma_client()
+
+    output = await _collect(
+        rewrite_streamed_response_ids(
+            stream=_chunks(_response_stream_bytes(), chunk_size),
+            provider="openai",
+            method="POST",
+            route="/openai_passthrough/v1/responses",
+            user_api_key_dict=_user(),
+            prisma_client=pc,
+        )
+    )
+
+    pc.db.litellm_managedobjecttable.upsert.assert_awaited_once()
+    created = pc.db.litellm_managedobjecttable.upsert.await_args.kwargs["data"]["create"]
+    assert created["created_by"] == "user-1"
+    assert created["team_id"] == "team-1"
+    assert created["file_purpose"] == "response"
+    assert created["model_object_id"] == f"passthrough:openai:{RAW_RESPONSE_ID}"
+    managed_id = created["unified_object_id"]
+    assert decode(managed_id).raw_provider_id == RAW_RESPONSE_ID
+    assert list(_response_ids(output)) == [managed_id, managed_id]
+    assert RAW_RESPONSE_ID.encode() not in output
+    assert output == _response_stream_bytes(managed_id)
+
+
+@pytest.mark.asyncio
+async def test_streamed_bytes_untouched_on_routes_without_a_response_id():
+    pc = _prisma_client()
+    payload = _response_stream_bytes()
+
+    output = await _collect(
+        rewrite_streamed_response_ids(
+            stream=_chunks(payload, 5),
+            provider="openai",
+            method="POST",
+            route="/openai_passthrough/v1/chat/completions",
+            user_api_key_dict=_user(),
+            prisma_client=pc,
+        )
+    )
+
+    assert output == payload
+    pc.db.litellm_managedobjecttable.upsert.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_streamed_response_stays_raw_and_intact_when_the_row_cannot_be_persisted():
+    pc = _prisma_client()
+    pc.db.litellm_managedobjecttable.upsert = AsyncMock(side_effect=RuntimeError("db down"))
+    payload = _response_stream_bytes()
+
+    output = await _collect(
+        rewrite_streamed_response_ids(
+            stream=_chunks(payload, 3),
+            provider="openai",
+            method="POST",
+            route="/openai_passthrough/v1/responses",
+            user_api_key_dict=_user(),
+            prisma_client=pc,
+        )
+    )
+
+    assert output == payload
+    pc.db.litellm_managedobjecttable.upsert.assert_awaited_once()

--- a/tests/test_litellm/proxy/pass_through_endpoints/test_pass_through_endpoints.py
+++ b/tests/test_litellm/proxy/pass_through_endpoints/test_pass_through_endpoints.py
@@ -1494,6 +1494,86 @@ async def test_pass_through_request_sse_response_marks_logging_obj_as_stream():
 
 
 @pytest.mark.asyncio
+async def test_pass_through_request_streamed_response_is_owned_by_the_caller():
+    """
+    Regression: with passthrough_managed_object_ids on, a streamed
+    POST /openai_passthrough/v1/responses left the raw resp_ id in the stream and
+    recorded no owner, so any other key could read, continue, and delete it.
+    """
+    import litellm
+    from litellm.llms.custom_httpx.http_handler import get_async_httpx_client
+    from litellm.types.llms.custom_http import httpxSpecialProvider
+
+    raw_id = "resp_0123456789abcdef"
+    upstream_body = (
+        b'event: response.created\ndata: {"type": "response.created", "response": {"id": "%s"}}\n\n'
+        b'event: response.completed\ndata: {"type": "response.completed", "response": {"id": "%s"}}\n\n'
+    ) % (raw_id.encode(), raw_id.encode())
+    prisma_client = MagicMock()
+    prisma_client.db.litellm_managedobjecttable.find_first = AsyncMock(return_value=None)
+    prisma_client.db.litellm_managedobjecttable.upsert = AsyncMock(return_value=None)
+    prisma_client.db.litellm_managedfiletable.find_first = AsyncMock(return_value=None)
+
+    def transport_handler(upstream_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, content=upstream_body, headers={"content-type": "text/event-stream"})
+
+    real_handler = get_async_httpx_client(
+        llm_provider=httpxSpecialProvider.PassThroughEndpoint,
+        params={"timeout": resolve_pass_through_request_timeout(None)},
+    )
+    cache_dict = litellm.in_memory_llm_clients_cache.cache_dict
+    cache_key = next(key for key, cached in cache_dict.items() if cached is real_handler)
+    cache_dict[cache_key] = SimpleNamespace(client=httpx.AsyncClient(transport=httpx.MockTransport(transport_handler)))
+
+    mock_proxy_logging = MagicMock()
+    mock_proxy_logging.pre_call_hook = AsyncMock(side_effect=lambda user_api_key_dict, data, call_type: data)
+    mock_proxy_logging.post_call_failure_hook = AsyncMock()
+    mock_proxy_logging.post_call_response_headers_hook = AsyncMock(return_value={})
+    mock_proxy_logging.get_proxy_hook = MagicMock(return_value=MagicMock())
+
+    mock_request = MagicMock(spec=Request)
+    mock_request.method = "POST"
+    mock_request.scope = {"path": "/openai_passthrough/v1/responses"}
+    mock_request.url = MagicMock()
+    mock_request.url.path = "/openai_passthrough/v1/responses"
+    mock_request.body = AsyncMock(return_value=b'{"model": "gpt-5.1", "input": "hi", "stream": true}')
+    mock_request.headers = Headers({"content-type": "application/json"})
+    mock_request.query_params = QueryParams({})
+
+    flag_on = {"passthrough_managed_object_ids": True}
+    proxy_server_globals = (
+        patch("litellm.proxy.proxy_server.proxy_logging_obj", mock_proxy_logging),  # test-quality-ok: read at call time
+        patch("litellm.proxy.proxy_server.general_settings", flag_on),  # test-quality-ok: read at call time
+        patch("litellm.proxy.proxy_server.prisma_client", prisma_client),  # test-quality-ok: read at call time
+    )
+
+    try:
+        with ExitStack() as stack:
+            for patched_global in proxy_server_globals:
+                stack.enter_context(patched_global)
+            response = await pass_through_request(
+                request=mock_request,
+                target="https://api.openai.com/v1/responses",
+                custom_headers={},
+                user_api_key_dict=UserAPIKeyAuth(user_id="user-a", team_id="team-a"),
+                custom_llm_provider="openai",
+            )
+            streamed = b"".join([chunk async for chunk in response.body_iterator])
+    finally:
+        cache_dict[cache_key] = real_handler
+
+    assert response.status_code == 200
+    prisma_client.db.litellm_managedobjecttable.upsert.assert_awaited_once()
+    created = prisma_client.db.litellm_managedobjecttable.upsert.await_args.kwargs["data"]["create"]
+    assert created["created_by"] == "user-a"
+    assert created["team_id"] == "team-a"
+    assert created["model_object_id"] == f"passthrough:openai:{raw_id}"
+    managed_id = created["unified_object_id"]
+    assert raw_id.encode() not in streamed
+    assert streamed == upstream_body.replace(raw_id.encode(), managed_id.encode())
+
+
+@pytest.mark.asyncio
 async def test_create_pass_through_endpoint():
     """
     Test creating a new pass-through endpoint


### PR DESCRIPTION
## TLDR

Problem this solves:

- Streamed passthrough responses came back with OpenAI's raw `resp_` id
- Any key could then read, continue from, or delete that response by id
- The first key to read it became its owner and locked the creator out

How it solves it:

- Mint the managed id from the first `response.created` event
- Rewrite `response.id` inside every SSE frame as it is relayed
- Record the response under the caller, so later reads are checked by id

## User Flow

Before: a developer on key A streams a response through the OpenAI passthrough and gets OpenAI's own `resp_...` id back, so any other key on the gateway can read and delete it, and the first one to read it becomes its owner

1. Key A sends POST https://litellm-domain/openai_passthrough/v1/responses with `{"model": "gpt-5.1", "input": "Reply with the single word mango.", "stream": true, "store": true}`
2. The SSE events come back with `"id": "resp_04bd26a8..."`, OpenAI's raw id, instead of the long scrambled id the same call returns without `stream: true`
3. Key B sends GET https://litellm-domain/openai_passthrough/v1/responses/resp_04bd26a8... and gets 200 with key A's full response text; the body now carries a scrambled id that belongs to key B
4. Key B sends DELETE https://litellm-domain/openai_passthrough/v1/responses/resp_04bd26a8... and gets 200 `"deleted": true`
5. Key A sends DELETE on its own response and gets 404 `Managed resource not found.`
6. Any key on the gateway could read, continue from, and delete another key's streamed response, and by reading it first could lock the creator out of it

After: the same streamed response comes back under a scrambled gateway id owned by key A, so other keys are refused

1. Key A sends POST https://litellm-domain/openai_passthrough/v1/responses with `{"model": "gpt-5.1", "input": "Reply with the single word mango.", "stream": true, "store": true}`
2. Every SSE event carries the long scrambled gateway id (`bGl0ZWxsbV9wcm94eTpwYXNz...`), the same shape as a non-streamed response
3. Key B sends GET https://litellm-domain/openai_passthrough/v1/responses/bGl0ZWxsbV9wcm94eTpwYXNz... and gets 403 `Access denied to managed resource.`
4. Key B sends DELETE https://litellm-domain/openai_passthrough/v1/responses/bGl0ZWxsbV9wcm94eTpwYXNz... and gets 403 `Access denied to managed resource.`
5. Key A sends DELETE on its own response and gets 200 `"deleted": true`
6. Another key can no longer read, continue from, or delete a streamed response it did not create

## Relevant issues

## Linear ticket

Resolves LIT-6165

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Each leg ran two separate proxy processes, each with `--num_workers 2`, on random ports sharing one Postgres. Both virtual keys were minted through instance 1, key A creates through instance 1, and key B's requests plus key A's own-read go through instance 2, so every ownership check crossed processes. Config (`passthrough_managed_object_ids` on, real OpenAI key); `KEY_A` has `user_id: user-a`, `KEY_B` has `user_id: user-b`. Long managed ids are shortened to `bGl0ZWxsbV9wcm94eTpwYXNz...` below; full ids and untruncated bodies are in the QA logs (`lit6165_qa_before.out` / `lit6165_qa_after.out`)

```yaml
model_list:
  - model_name: gpt-5.1
    litellm_params:
      model: openai/gpt-5.1
      api_key: os.environ/OPENAI_API_KEY

files_settings:
  - custom_llm_provider: openai
    api_key: os.environ/OPENAI_API_KEY

general_settings:
  master_key: os.environ/LITELLM_MASTER_KEY
  database_url: os.environ/DATABASE_URL
  passthrough_managed_object_ids: true
```

```
python litellm/proxy/proxy_cli.py --config lit6165.yaml --port $P1 --num_workers 2 --use_v2_migration_resolver
python litellm/proxy/proxy_cli.py --config lit6165.yaml --port $P2 --num_workers 2 --use_v2_migration_resolver
curl -s -X POST http://127.0.0.1:$P1/key/generate -H "Authorization: Bearer $LITELLM_MASTER_KEY" -H 'Content-Type: application/json' -d '{"user_id": "user-a"}'
curl -s -X POST http://127.0.0.1:$P1/key/generate -H "Authorization: Bearer $LITELLM_MASTER_KEY" -H 'Content-Type: application/json' -d '{"user_id": "user-b"}'
```

### Before (e52f05566d, instances on P1=46566 and P2=47062)

#### Streamed response: key B reads, continues from, and deletes key A's response through the other instance

1. Key A streams a response through instance 1; every event carries OpenAI's raw id

```
$ curl -s -N -H "Authorization: Bearer $KEY_A" -H 'Content-Type: application/json' -d '{"model": "gpt-5.1", "input": "Reply with the single word mango.", "stream": true, "store": true}' http://127.0.0.1:46566/openai_passthrough/v1/responses
event: response.created
data: {"type":"response.created","response":{"id":"resp_0a9c3df86361cf7b006a8ea0e903b887d0afdc5375bce05a79","object":"response","created_at":1787732201,"status":"in_progress",...
```

2. Key B reads it by that id through instance 2 and gets the full response, now stamped with a managed id that belongs to key B

```
$ curl -s -w '\nHTTP %{http_code}' -H "Authorization: Bearer $KEY_B" http://127.0.0.1:47062/openai_passthrough/v1/responses/resp_0a9c3df86361cf7b006a8ea0e903b887d0afdc5375bce05a79
{"id": "bGl0ZWxsbV9wcm94eTpwYXNz...", "object": "response", "created_at": 1787732201, "status": "completed", ...
HTTP 200
```

3. Key B continues the conversation from key A's response

```
$ curl -s -w '\nHTTP %{http_code}' -H "Authorization: Bearer $KEY_B" -X POST -H 'Content-Type: application/json' -d '{"model": "gpt-5.1", "previous_response_id": "resp_0a9c3df86361cf7b006a8ea0e903b887d0afdc5375bce05a79", "input": "What word did you just say?"}' http://127.0.0.1:47062/openai_passthrough/v1/responses
{"id": "bGl0ZWxsbV9wcm94eTpwYXNz...", "object": "response", "created_at": 1787732202, "status": "completed", ...
HTTP 200
```

4. Key B deletes it

```
$ curl -s -w '\nHTTP %{http_code}' -H "Authorization: Bearer $KEY_B" -X DELETE http://127.0.0.1:47062/openai_passthrough/v1/responses/resp_0a9c3df86361cf7b006a8ea0e903b887d0afdc5375bce05a79
{"id": "bGl0ZWxsbV9wcm94eTpwYXNz...", "object": "response.deleted", "deleted": true}
HTTP 200
```

5. Key A, the creator, is now locked out of its own response on both instances

```
$ curl -s -w '\nHTTP %{http_code}' -H "Authorization: Bearer $KEY_A" http://127.0.0.1:47062/openai_passthrough/v1/responses/resp_0a9c3df86361cf7b006a8ea0e903b887d0afdc5375bce05a79
{"error":{"message":"Managed resource not found.","type":"None","param":"None","code":"404"}}
HTTP 404
$ curl -s -w '\nHTTP %{http_code}' -H "Authorization: Bearer $KEY_A" -X DELETE http://127.0.0.1:46566/openai_passthrough/v1/responses/resp_0a9c3df86361cf7b006a8ea0e903b887d0afdc5375bce05a79
{"error":{"message":"Managed resource not found.","type":"None","param":"None","code":"404"}}
HTTP 404
```

#### Non-streamed response (control, already protected)

1. Key A creates a response without `stream` through instance 1; the id is already a managed id

```
$ curl -s -H "Authorization: Bearer $KEY_A" -H 'Content-Type: application/json' -d '{"model": "gpt-5.1", "input": "Reply with the single word pineapple.", "store": true}' http://127.0.0.1:46566/openai_passthrough/v1/responses
{"id": "bGl0ZWxsbV9wcm94eTpwYXNz...", "object": "response", "created_at": 1787732203, ...
```

2. Key B is refused on read and delete through instance 2, and key A deletes its own

```
$ curl -s -w '\nHTTP %{http_code}' -H "Authorization: Bearer $KEY_B" http://127.0.0.1:47062/openai_passthrough/v1/responses/bGl0ZWxsbV9wcm94eTpwYXNz...
{"error":{"message":"Access denied to managed resource.","type":"None","param":"None","code":"403"}}
HTTP 403
$ curl -s -w '\nHTTP %{http_code}' -H "Authorization: Bearer $KEY_B" -X DELETE http://127.0.0.1:47062/openai_passthrough/v1/responses/bGl0ZWxsbV9wcm94eTpwYXNz...
{"error":{"message":"Access denied to managed resource.","type":"None","param":"None","code":"403"}}
HTTP 403
$ curl -s -w '\nHTTP %{http_code}' -H "Authorization: Bearer $KEY_A" -X DELETE http://127.0.0.1:46566/openai_passthrough/v1/responses/bGl0ZWxsbV9wcm94eTpwYXNz...
{"id": "bGl0ZWxsbV9wcm94eTpwYXNz...", "object": "response.deleted", "deleted": true}
HTTP 200
```

### After (6a9662a5a8, instances on P1=38401 and P2=52717)

#### Streamed response: key B is refused through the other instance

1. Key A streams a response through instance 1; every event carries the managed id from `response.created` on (10 data lines, 1 distinct id, 0 lines with a raw `resp_` id)

```
$ curl -s -N -H "Authorization: Bearer $KEY_A" -H 'Content-Type: application/json' -d '{"model": "gpt-5.1", "input": "Reply with the single word mango.", "stream": true, "store": true}' http://127.0.0.1:38401/openai_passthrough/v1/responses
event: response.created
data: {"type":"response.created","response":{"id":"bGl0ZWxsbV9wcm94eTpwYXNzdGhyb3VnaDtwcm92aWRlcjpvcGVuYWk7dW5pZmllZF9pZCw2YTk2NTczNC02NzU0LTQ3OTYtOGE4ZS01YzZmZGZiZDkzNjE7cmF3X2lkLHJlc3BfMDg3ZWEwYWZkZWEzMDNkYjAwNmE4ZWE1YWRlOGYwODdkMDkyNGY4ODc3ODZhNTE2ZWI","object":"response","created_at":1787733421,"status":"in_progress",...
```

2. Key B reads it by that id through instance 2 and is refused

```
$ curl -s -w '\nHTTP %{http_code}' -H "Authorization: Bearer $KEY_B" http://127.0.0.1:52717/openai_passthrough/v1/responses/bGl0ZWxsbV9wcm94eTpwYXNz...
{"error":{"message":"Access denied to managed resource.","type":"None","param":"None","code":"403"}}
HTTP 403
```

3. Key B tries to continue from it and is refused

```
$ curl -s -w '\nHTTP %{http_code}' -H "Authorization: Bearer $KEY_B" -X POST -H 'Content-Type: application/json' -d '{"model": "gpt-5.1", "previous_response_id": "bGl0ZWxsbV9wcm94eTpwYXNz...", "input": "What word did you just say?"}' http://127.0.0.1:52717/openai_passthrough/v1/responses
{"error":{"message":"Access denied to managed resource.","type":"None","param":"None","code":"403"}}
HTTP 403
```

4. Key B tries to delete it and is refused

```
$ curl -s -w '\nHTTP %{http_code}' -H "Authorization: Bearer $KEY_B" -X DELETE http://127.0.0.1:52717/openai_passthrough/v1/responses/bGl0ZWxsbV9wcm94eTpwYXNz...
{"error":{"message":"Access denied to managed resource.","type":"None","param":"None","code":"403"}}
HTTP 403
```

5. Key A reads its own streamed response through the OTHER instance, then deletes it

```
$ curl -s -w '\nHTTP %{http_code}' -H "Authorization: Bearer $KEY_A" http://127.0.0.1:52717/openai_passthrough/v1/responses/bGl0ZWxsbV9wcm94eTpwYXNz...
{"id": "bGl0ZWxsbV9wcm94eTpwYXNz...", "object": "response", "created_at": 1787733421, "status": "completed", ...
HTTP 200
$ curl -s -w '\nHTTP %{http_code}' -H "Authorization: Bearer $KEY_A" -X DELETE http://127.0.0.1:38401/openai_passthrough/v1/responses/bGl0ZWxsbV9wcm94eTpwYXNz...
{"id": "bGl0ZWxsbV9wcm94eTpwYXNz...", "object": "response.deleted", "deleted": true}
HTTP 200
```

#### Non-streamed response (control, unchanged)

```
$ curl -s -H "Authorization: Bearer $KEY_A" -H 'Content-Type: application/json' -d '{"model": "gpt-5.1", "input": "Reply with the single word pineapple.", "store": true}' http://127.0.0.1:38401/openai_passthrough/v1/responses
{"id": "bGl0ZWxsbV9wcm94eTpwYXNz...", "object": "response", "created_at": 1787733423, ...
$ curl -s -w '\nHTTP %{http_code}' -H "Authorization: Bearer $KEY_B" http://127.0.0.1:52717/openai_passthrough/v1/responses/bGl0ZWxsbV9wcm94eTpwYXNz...
{"error":{"message":"Access denied to managed resource.","type":"None","param":"None","code":"403"}}
HTTP 403
$ curl -s -w '\nHTTP %{http_code}' -H "Authorization: Bearer $KEY_B" -X DELETE http://127.0.0.1:52717/openai_passthrough/v1/responses/bGl0ZWxsbV9wcm94eTpwYXNz...
{"error":{"message":"Access denied to managed resource.","type":"None","param":"None","code":"403"}}
HTTP 403
$ curl -s -w '\nHTTP %{http_code}' -H "Authorization: Bearer $KEY_A" -X DELETE http://127.0.0.1:38401/openai_passthrough/v1/responses/bGl0ZWxsbV9wcm94eTpwYXNz...
{"id": "bGl0ZWxsbV9wcm94eTpwYXNz...", "object": "response.deleted", "deleted": true}
HTTP 200
```

Closing observations from the run:

- Streamed chat completions relay intact, `[DONE]` preserved: unaffected
- Files and batches enforcement unchanged across instances: left alone
- Ownership rows written on one process, enforced on another
- Error bodies say `"type": "None"`: pre-existing, left alone
- Key B's file list is an empty 200: left alone

## Type

🐛 Bug Fix

## Caveats (if any)

### Medium

- Only the `/openai_passthrough/*` and `/azure/openai/*` prefixes are covered
  - `/openai/v1/responses` is the native Responses route, and streams there still skip the ownership check (separate ticket)
- Objects created before the flag was on stay unowned by design
  - Per-team provider credentials are the strict option; BerriAI/litellm-docs#1022 spells both out

### Low

- Still opt-in behind `passthrough_managed_object_ids: true`

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

- [x] 6a9662a5a8863976481dea0460027806608fbd79 passes /live-pr-risk

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes authorization and multi-tenant isolation for streamed Responses passthrough (auth/access control on a security-sensitive path), though behavior is gated behind `passthrough_managed_object_ids` and limited to Responses SSE routes.
> 
> **Overview**
> **Fixes a cross-tenant gap for streamed OpenAI Responses passthrough:** SSE bodies used upstream raw `resp_` ids with no ownership row, so other API keys could read, continue, or delete those responses (and sometimes become the owner on first read).
> 
> **Streaming path now mirrors non-streamed managed-id behavior.** When `passthrough_managed_object_ids` is on and the route is POST `/v1/responses`, the proxy reassembles complete SSE frames (shared `split_complete_sse_frames`, including CR-only delimiters), mints or reuses a managed object id from the first `response.created` event, persists the caller as owner, and byte-replaces the raw id in every relayed frame. Other routes and disabled flags pass the stream through unchanged; if persistence fails, the stream stays raw.
> 
> **Passthrough streaming responses** wire this via `_own_streamed_managed_ids` ahead of SSE keepalive wrapping; cost-injection streaming reuses the same frame splitter instead of a local duplicate.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6a9662a5a8863976481dea0460027806608fbd79. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->