### PR TITLE
fix(proxy): encrypt streamed responses ids on /openai/v1/responses and /responses aliases

### DIFF
--- a/litellm/proxy/hooks/responses_id_security.py
+++ b/litellm/proxy/hooks/responses_id_security.py
@@ -28,6 +28,21 @@ if TYPE_CHECKING:
     from litellm.proxy._types import UserAPIKeyAuth
 
 
+_RESPONSES_API_PROVIDER_PREFIX: Final = "/openai"
+_RESPONSES_API_CREATE_ROUTES: Final = frozenset({"/v1/responses", "/responses"})
+
+
+def _is_responses_api_create_route(request_route: str | None) -> bool:
+    if request_route is None:
+        return False
+    canonical: Final = (
+        request_route[len(_RESPONSES_API_PROVIDER_PREFIX) :]
+        if request_route.startswith(_RESPONSES_API_PROVIDER_PREFIX + "/")
+        else request_route
+    )
+    return canonical in _RESPONSES_API_CREATE_ROUTES
+
+
 class ResponsesIDSecurity(CustomLogger):
     def __init__(self):
         pass
@@ -267,8 +282,7 @@ class ResponsesIDSecurity(CustomLogger):
         async for chunk in response:
             if (
                 isinstance(chunk, BaseLiteLLMOpenAIResponseObject)
-                and user_api_key_dict.request_route
-                == "/v1/responses"  # only encrypt the response id for the responses api
+                and _is_responses_api_create_route(user_api_key_dict.request_route)
                 and not general_settings.get("disable_responses_id_security", False)
             ):
                 chunk = self._encrypt_response_id(chunk, user_api_key_dict, request_encryption_cache)

--- a/tests/test_litellm/test_responses_id_security.py
+++ b/tests/test_litellm/test_responses_id_security.py
@@ -13,8 +13,11 @@ from litellm.proxy.hooks.responses_id_security import (
     ResponsesIDSecurity,
     _is_responses_api_create_route,
 )
-from litellm.types.llms.base import BaseLiteLLMOpenAIResponseObject
-from litellm.types.llms.openai import ResponsesAPIResponse
+from litellm.types.llms.openai import (
+    ResponseCompletedEvent,
+    ResponsesAPIResponse,
+    ResponsesAPIStreamEvents,
+)
 from litellm.types.utils import SpecialEnums
 
 
@@ -612,18 +615,36 @@ class TestIsResponsesApiCreateRoute:
 class TestAsyncPostCallStreamingIteratorHook:
     """Regression test for LIT-6167: streamed responses on /openai/v1/responses and
     /responses must have their ids security-encrypted, not just on the exact
-    /v1/responses path. Uses real encryption so the id must round-trip back to the
-    raw provider id plus the caller's user/team, which is the access-control wrapper
-    the aliases were leaking without."""
+    /v1/responses path. A streamed create emits ResponseCompletedEvent, whose
+    client-visible id lives on event.response.id, so the test drives that production
+    event shape (not a top-level id) and uses real encryption, asserting the id
+    round-trips back to the raw provider id plus the caller's user/team, which is the
+    access-control wrapper the aliases were leaking without."""
 
     @staticmethod
     async def _agen(chunks):
         for chunk in chunks:
             yield chunk
 
+    @staticmethod
+    def _completed_event(response_id):
+        return ResponseCompletedEvent(
+            type=ResponsesAPIStreamEvents.RESPONSE_COMPLETED,
+            response=ResponsesAPIResponse(
+                id=response_id,
+                created_at=0,
+                model="gpt-5.1",
+                object="response",
+                output=[],
+                parallel_tool_calls=False,
+                tool_choice="auto",
+                tools=[],
+            ),
+        )
+
     async def _drain_streamed_id(self, responses_id_security, route, monkeypatch):
         monkeypatch.setenv("LITELLM_SALT_KEY", "sk-test-salt-key-abcdefghij")
-        chunk = BaseLiteLLMOpenAIResponseObject(id="resp_rawprovider123")
+        event = self._completed_event("resp_rawprovider123")
 
         mock_auth = MagicMock()
         mock_auth.user_id = "user-a"
@@ -634,11 +655,11 @@ class TestAsyncPostCallStreamingIteratorHook:
             out
             async for out in responses_id_security.async_post_call_streaming_iterator_hook(
                 user_api_key_dict=mock_auth,
-                response=self._agen([chunk]),
+                response=self._agen([event]),
                 request_data={},
             )
         ]
-        return collected[0].id
+        return collected[0].response.id
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize(

--- a/tests/test_litellm/test_responses_id_security.py
+++ b/tests/test_litellm/test_responses_id_security.py
@@ -9,7 +9,11 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from fastapi import HTTPException
 
-from litellm.proxy.hooks.responses_id_security import ResponsesIDSecurity
+from litellm.proxy.hooks.responses_id_security import (
+    ResponsesIDSecurity,
+    _is_responses_api_create_route,
+)
+from litellm.types.llms.base import BaseLiteLLMOpenAIResponseObject
 from litellm.types.llms.openai import ResponsesAPIResponse
 from litellm.types.utils import SpecialEnums
 
@@ -573,6 +577,97 @@ class TestAsyncPreCallHook:
 
                     assert exc_info.value.status_code == 403
                     assert "team" in exc_info.value.detail.lower()
+
+
+class TestIsResponsesApiCreateRoute:
+    """Test the route gate that decides whether a streamed response id is encrypted."""
+
+    @pytest.mark.parametrize(
+        "route",
+        [
+            "/v1/responses",
+            "/responses",
+            "/openai/v1/responses",
+        ],
+    )
+    def test_create_routes_match(self, route):
+        assert _is_responses_api_create_route(route) is True
+
+    @pytest.mark.parametrize(
+        "route",
+        [
+            None,
+            "/chat/completions",
+            "/openai/v1/chat/completions",
+            "/v1/responses/{response_id}",
+            "/openai/v1/responses/{response_id}",
+            "/v1/responsesX",
+            "/responsesX",
+        ],
+    )
+    def test_non_create_routes_do_not_match(self, route):
+        assert _is_responses_api_create_route(route) is False
+
+
+class TestAsyncPostCallStreamingIteratorHook:
+    """Regression test for LIT-6167: streamed responses on /openai/v1/responses and
+    /responses must have their ids security-encrypted, not just on the exact
+    /v1/responses path. Uses real encryption so the id must round-trip back to the
+    raw provider id plus the caller's user/team, which is the access-control wrapper
+    the aliases were leaking without."""
+
+    @staticmethod
+    async def _agen(chunks):
+        for chunk in chunks:
+            yield chunk
+
+    async def _drain_streamed_id(self, responses_id_security, route, monkeypatch):
+        monkeypatch.setenv("LITELLM_SALT_KEY", "sk-test-salt-key-abcdefghij")
+        chunk = BaseLiteLLMOpenAIResponseObject(id="resp_rawprovider123")
+
+        mock_auth = MagicMock()
+        mock_auth.user_id = "user-a"
+        mock_auth.team_id = "team-a"
+        mock_auth.request_route = route
+
+        collected = [
+            out
+            async for out in responses_id_security.async_post_call_streaming_iterator_hook(
+                user_api_key_dict=mock_auth,
+                response=self._agen([chunk]),
+                request_data={},
+            )
+        ]
+        return collected[0].id
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "route",
+        ["/v1/responses", "/responses", "/openai/v1/responses"],
+    )
+    async def test_streamed_id_encrypted_on_all_responses_routes(
+        self, responses_id_security, route, monkeypatch
+    ):
+        streamed_id = await self._drain_streamed_id(responses_id_security, route, monkeypatch)
+
+        assert streamed_id != "resp_rawprovider123"
+        assert responses_id_security._is_encrypted_response_id(streamed_id)
+        assert responses_id_security._decrypt_response_id(streamed_id) == (
+            "resp_rawprovider123",
+            "user-a",
+            "team-a",
+        )
+
+    @pytest.mark.asyncio
+    async def test_streamed_id_untouched_on_non_responses_route(
+        self, responses_id_security, monkeypatch
+    ):
+        streamed_id = await self._drain_streamed_id(
+            responses_id_security, "/chat/completions", monkeypatch
+        )
+
+        assert streamed_id == "resp_rawprovider123"
+        assert not responses_id_security._is_encrypted_response_id(streamed_id)
 
 
 class TestAsyncPostCallSuccessHook:


### PR DESCRIPTION
## TLDR

Problem this solves:

- Streamed Responses ids on `/openai/v1/responses` and `/responses` leaked
- Another virtual key could read, continue, and delete them
- Only the exact `/v1/responses` path was protected

How it solves it:

- Normalize the request route before gating id encryption
- Strip the `/openai` provider prefix, accept the `/responses` alias
- Streamed ids now encrypted on every Responses create route

## User Flow

Before: two developers share a proxy with separate virtual keys, and key B can take over key A's streamed response created on the alias routes

1. Key A sends `POST https://litellm-domain/openai/v1/responses` with `"stream": true` and `"store": true`, and the final `response.completed` event returns an id like `resp_bGl0ZWxsbTpjdXN0b21...` (base64 that decodes to a readable `litellm:custom_llm_provider:openai;...` string)
2. Key B sends `GET https://litellm-domain/openai/v1/responses/{that_id}` and gets `200` with the full text of key A's response
3. Key B sends `POST https://litellm-domain/openai/v1/responses` with `"previous_response_id": "{that_id}"` and gets `200`, continuing key A's conversation
4. Key B sends `DELETE https://litellm-domain/openai/v1/responses/{that_id}` and gets `200`, deleting key A's stored response
5. Key A then sends `DELETE .../{that_id}` for its own response and gets `404`, because key B already deleted it
6. Same leak on `POST https://litellm-domain/responses`. Only `POST https://litellm-domain/v1/responses` was safe: its streamed id came back opaque and every cross-key call got `403`
7. Net: any second key could read, hijack, and delete another key's streamed response on the alias routes

After: the streamed id is encrypted on all three routes, so only the owning key can use it

1. Key A sends `POST https://litellm-domain/openai/v1/responses` with `"stream": true` and `"store": true`, and the final event returns an opaque id like `resp__EZx9meEABffoiiNs6T...` that carries no readable content
2. Key B sends `GET https://litellm-domain/openai/v1/responses/{that_id}` and gets `403` "the response id is not associated with the user"
3. Key B sends `POST https://litellm-domain/openai/v1/responses` with `"previous_response_id": "{that_id}"` and gets `403`
4. Key B sends `DELETE https://litellm-domain/openai/v1/responses/{that_id}` and gets `403`
5. Key A then sends `DELETE .../{that_id}` for its own response and gets `200`, since nobody else could touch it
6. Same protection on `POST https://litellm-domain/responses` and `POST https://litellm-domain/v1/responses`
7. Net: a second key can no longer read, continue, or delete another key's streamed response on any Responses create route

## Relevant issues

## Linear ticket

Resolves LIT-6167

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Real OpenAI `gpt-5.1`, real spend, no mocks. One proxy with Responses id security on by default, two virtual keys with different `user_id`s (key A, key B). For each route, key A creates a streaming response (`stream: true`, `store: true`) and key B tries `GET`, continue (`previous_response_id`), and `DELETE` on the returned id, then key A deletes its own.

The After leg below was re-run at the current tip `95f8373e3c` against a live proxy booted from that commit. The only change after `498ba9dd62` was strengthening the regression test, so `responses_id_security.py` is byte-identical. Each After route also confirms the owner is not locked out: after key B is refused, key A `DELETE`s its own streamed id and gets `200`.

### Before (137311ffd6)

#### /openai/v1/responses (streaming)

1. Key A creates. Returned id: `resp_bGl0ZWxsbTpjdXN0b21...` (base64 decodes to plaintext `litellm:custom_llm_provider:openai;model_id:...;response_id:...`)
2. Key B `GET` -> `HTTP 200` (reads key A's full response)
3. Key B continue `POST` with `previous_response_id` -> `HTTP 200`
4. Key B `DELETE` -> `HTTP 200` (deletes key A's response)
5. Key A `DELETE` its own -> `HTTP 404` (key B already deleted it)

#### /responses (streaming)

1. Key A creates. Returned id decodes to the same readable `litellm:custom_llm_provider:...` plaintext
2. Key B `GET` -> `HTTP 200`
3. Key B continue `POST` -> `HTTP 200`
4. Key B `DELETE` -> `HTTP 200`
5. Key A `DELETE` its own -> `HTTP 404`

#### /v1/responses (streaming, control)

1. Key A creates. Returned id is opaque (no readable content)
2. Key B `GET` -> `HTTP 403`
3. Key B continue `POST` -> `HTTP 403`
4. Key B `DELETE` -> `HTTP 403`
5. Key A `DELETE` its own -> `HTTP 200`

### After (95f8373e3c)

#### /openai/v1/responses (streaming)

1. Key A creates. Returned id: `resp_JYnjk3O-VwSgo9zRSuj...` (opaque, no readable content)
2. Key B `GET` -> `HTTP 403` "Forbidden. The response id is not associated with the user..."
3. Key B continue `POST` with `previous_response_id` -> `HTTP 403`
4. Key B `DELETE` -> `HTTP 403`
5. Key A `DELETE` its own -> `HTTP 200`

#### /responses (streaming)

1. Key A creates. Returned id: `resp_iaCJo6RqeMydn_cBFMt...` (opaque)
2. Key B `GET` -> `HTTP 403`
3. Key B continue `POST` -> `HTTP 403`
4. Key B `DELETE` -> `HTTP 403`
5. Key A `DELETE` its own -> `HTTP 200`

#### /v1/responses (streaming, control)

1. Key A creates. Returned id: `resp_3YhCtiFz9LeFLdNVlZe...` (opaque, unchanged behavior)
2. Key B `GET` -> `HTTP 403`
3. Key B continue `POST` -> `HTTP 403`
4. Key B `DELETE` -> `HTTP 403`
5. Key A `DELETE` its own -> `HTTP 200`

## Type

🐛 Bug Fix

## Caveats (if any)

### Low

- Non-streaming create was already protected; this only closes the streaming path
- The streaming hook's `disable_responses_id_security` skip branch has no dedicated unit test; it mirrors the success hook's skip, which is covered, and the route-mismatch test exercises the same "leave the id untouched" path

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

- [x] 95f8373e3cf202f93f132b375b0b4ef537f94b8b passes /live-pr-risk

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> This closes an authorization bypass on alias routes where another virtual key could read, continue, or delete another user's streamed stored responses; the change is narrow but security-critical.
> 
> **Overview**
> Fixes a **cross-tenant leak** where streamed Responses create calls on `/openai/v1/responses` and `/responses` returned **plaintext provider ids** because id encryption in the streaming post-call hook only ran when `request_route` was exactly `/v1/responses`.
> 
> The hook now uses **`_is_responses_api_create_route`**, which strips an optional `/openai` prefix and treats **`/v1/responses`** and **`/responses`** as create routes, so streamed chunks (including `ResponseCompletedEvent.response.id`) get the same user/team-bound encrypted ids as the canonical path.
> 
> Tests cover the route matcher (positive and negative cases) and a **LIT-6167** regression that drives real encryption on all three create routes and leaves ids unchanged on non-Responses routes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 95f8373e3cf202f93f132b375b0b4ef537f94b8b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->