### PR TITLE
fix(mcp): handle DCR bridge envelope with explicit LiteLLM key

### DIFF
--- a/litellm/proxy/_experimental/mcp_server/auth/user_api_key_auth_mcp.py
+++ b/litellm/proxy/_experimental/mcp_server/auth/user_api_key_auth_mcp.py
@@ -429,7 +429,10 @@ class MCPRequestHandler:
                 and oauth2_headers
                 and is_bridge_envelope_shaped(oauth2_headers["Authorization"])
             ):
-                validated_user_api_key_auth, mcp_server_auth_headers = await MCPRequestHandler._admit_dcr_bridge_delegate(
+                (
+                    validated_user_api_key_auth,
+                    mcp_server_auth_headers,
+                ) = await MCPRequestHandler._admit_dcr_bridge_delegate(
                     server=bridge_delegate_target,
                     authorization_value=oauth2_headers["Authorization"],
                     mcp_server_auth_headers=mcp_server_auth_headers,
@@ -828,7 +831,9 @@ class MCPRequestHandler:
                     else await MCPRequestHandler._reload_admitted_principal(result.identity)
                 )
                 if validated_user_api_key_auth is None:
-                    await MCPRequestHandler._enforce_admitted_live_policy(admitted=admitted, request=request, route=route)
+                    await MCPRequestHandler._enforce_admitted_live_policy(
+                        admitted=admitted, request=request, route=route
+                    )
                 injected: Final = {header_key: {"Authorization": result.upstream_authorization.get_secret_value()}}
                 new_headers: Final = {**(mcp_server_auth_headers or {}), **injected}
                 return admitted, new_headers

--- a/litellm/proxy/_experimental/mcp_server/auth/user_api_key_auth_mcp.py
+++ b/litellm/proxy/_experimental/mcp_server/auth/user_api_key_auth_mcp.py
@@ -417,6 +417,26 @@ class MCPRequestHandler:
             # for a delegated server, so validate it: identity / spend / rate
             # limits resolve and any stored upstream token can be forwarded.
             validated_user_api_key_auth = await user_api_key_auth(api_key=litellm_api_key, request=request)
+            if (
+                (
+                    bridge_delegate_target := MCPRequestHandler._single_dcr_bridge_delegate_target(
+                        path=request_route,
+                        mcp_servers=mcp_servers,
+                        client_ip=IPAddressUtils.get_mcp_client_ip(request),
+                    )
+                )
+                is not None
+                and oauth2_headers
+                and is_bridge_envelope_shaped(oauth2_headers["Authorization"])
+            ):
+                validated_user_api_key_auth, mcp_server_auth_headers = await MCPRequestHandler._admit_dcr_bridge_delegate(
+                    server=bridge_delegate_target,
+                    authorization_value=oauth2_headers["Authorization"],
+                    mcp_server_auth_headers=mcp_server_auth_headers,
+                    request=request,
+                    route=request_route,
+                    validated_user_api_key_auth=validated_user_api_key_auth,
+                )
         elif MCPRequestHandler._target_servers_delegate_auth_to_upstream(
             path=request_route,
             mcp_servers=mcp_servers,
@@ -755,15 +775,16 @@ class MCPRequestHandler:
         mcp_server_auth_headers: dict[str, dict[str, str]] | None,
         request: Request,
         route: str,
+        validated_user_api_key_auth: UserAPIKeyAuth | None = None,
     ) -> tuple[UserAPIKeyAuth, dict[str, dict[str, str]] | None]:
         """Open the bridge envelope and admit the caller under the live key it references.
 
         The envelope's signature proves the user authenticated when it was minted, but
-        authorization is resolved fresh here rather than trusted from the envelope: the
-        sealed ``key_hash`` reloads the current ``UserAPIKeyAuth`` record, and the admitted
-        identity then runs through the standard pipeline's centralized policy gate, so the
-        key's present restrictions and revocation state gate the request instead of a
-        snapshot frozen at mint time. The inner upstream token is injected under the
+        authorization is resolved fresh here rather than trusted from the envelope. When
+        the request already supplied a validated LiteLLM key, the envelope identity must
+        match that principal; otherwise the sealed identity reloads the current
+        ``UserAPIKeyAuth`` record and runs through the standard pipeline's centralized
+        policy gate. The inner upstream token is injected under the
         server's per-server auth-header key so egress forwards it via the
         ``PassthroughConfig`` override; the envelope ``Authorization`` the leak-defense
         strips never reaches the upstream. A new headers dict is returned rather than
@@ -783,7 +804,8 @@ class MCPRequestHandler:
         if not master_key:
             raise HTTPException(status_code=500, detail="Server misconfigured: master_key is not set")
 
-        await MCPRequestHandler._run_pre_db_read_auth_checks(request=request, route=route)
+        if validated_user_api_key_auth is None:
+            await MCPRequestHandler._run_pre_db_read_auth_checks(request=request, route=route)
 
         keys: Final = envelope_keys_from_master_key(master_key)
         result: Final = resolve_bridge_envelope(authorization_value, keys, datetime.now(timezone.utc), server.server_id)
@@ -792,8 +814,21 @@ class MCPRequestHandler:
                 header_key: Final = server.alias or server.server_name
                 if header_key is None:
                     raise HTTPException(status_code=500, detail="Server misconfigured: MCP server has no routable name")
-                admitted: Final = await MCPRequestHandler._reload_admitted_principal(result.identity)
-                await MCPRequestHandler._enforce_admitted_live_policy(admitted=admitted, request=request, route=route)
+                if (
+                    validated_user_api_key_auth is not None
+                    and not MCPRequestHandler._bridge_identity_matches_admitted_principal(
+                        identity=result.identity,
+                        admitted=validated_user_api_key_auth,
+                    )
+                ):
+                    raise HTTPException(status_code=401, detail="Invalid or expired credential")
+                admitted: Final = (
+                    validated_user_api_key_auth
+                    if validated_user_api_key_auth is not None
+                    else await MCPRequestHandler._reload_admitted_principal(result.identity)
+                )
+                if validated_user_api_key_auth is None:
+                    await MCPRequestHandler._enforce_admitted_live_policy(admitted=admitted, request=request, route=route)
                 injected: Final = {header_key: {"Authorization": result.upstream_authorization.get_secret_value()}}
                 new_headers: Final = {**(mcp_server_auth_headers or {}), **injected}
                 return admitted, new_headers
@@ -801,6 +836,16 @@ class MCPRequestHandler:
                 raise HTTPException(status_code=401, detail="Invalid or expired credential")
             case _:
                 assert_never(result)
+
+    @staticmethod
+    def _bridge_identity_matches_admitted_principal(identity: EnvelopeIdentity, admitted: UserAPIKeyAuth) -> bool:
+        match identity.subject_type:
+            case "key_hash":
+                return admitted.api_key == identity.subject
+            case "user_id":
+                return admitted.user_id == identity.subject
+            case _:
+                assert_never(identity.subject_type)
 
     @staticmethod
     async def _admit_gateway_session(

--- a/litellm/proxy/_experimental/mcp_server/auth/user_api_key_auth_mcp.py
+++ b/litellm/proxy/_experimental/mcp_server/auth/user_api_key_auth_mcp.py
@@ -430,8 +430,8 @@ class MCPRequestHandler:
                 and is_bridge_envelope_shaped(oauth2_headers["Authorization"])
             ):
                 (
-                    validated_user_api_key_auth,
-                    mcp_server_auth_headers,
+                    validated_user_api_key_auth,  # rebind-ok: envelope replaces the matching explicit-key admission
+                    mcp_server_auth_headers,  # rebind-ok: envelope supplies the upstream authorization header
                 ) = await MCPRequestHandler._admit_dcr_bridge_delegate(
                     server=bridge_delegate_target,
                     authorization_value=oauth2_headers["Authorization"],

--- a/tests/test_litellm/proxy/_experimental/mcp_server/auth/test_user_api_key_auth_mcp.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/auth/test_user_api_key_auth_mcp.py
@@ -6000,15 +6000,18 @@ class TestMCPDcrBridgeDelegateAdmission:
         mock_auth.assert_called_once()
 
     @pytest.mark.parametrize(
-        "envelope_identity",
+        ("envelope_identity", "expected_status"),
         [
-            {"key_hash": _KEY_HASH},
-            {"user_id": "litellm-key-user"},
+            ({"key_hash": _KEY_HASH}, None),
+            ({"user_id": "litellm-key-user"}, None),
+            ({"key_hash": "different-key-hash"}, 401),
         ],
     )
-    async def test_explicit_litellm_key_with_matching_envelope_forwards_inner_token(self, envelope_identity):
-        """The explicit key authenticates the gateway request while its matching envelope supplies
-        the upstream OAuth token for the DCR bridge."""
+    async def test_explicit_litellm_key_requires_matching_envelope_principal(
+        self, envelope_identity, expected_status
+    ):
+        """The explicit key authenticates the gateway request while only an envelope for the same
+        principal can supply the upstream OAuth token for the DCR bridge."""
         envelope = self._mint_bridge_envelope(**envelope_identity)
         scope = {
             "type": "http",
@@ -6032,6 +6035,13 @@ class TestMCPDcrBridgeDelegateAdmission:
             patch("litellm.proxy.proxy_server.master_key", self._MASTER_KEY),
         ):
             mock_mgr.get_mcp_server_by_name.return_value = self._bridge_delegate_server()
+            if expected_status is not None:
+                with pytest.raises(HTTPException) as exc_info:
+                    await MCPRequestHandler.process_mcp_request(scope)
+
+                assert exc_info.value.status_code == expected_status
+                mock_auth.assert_called_once()
+                return
             (
                 auth_result,
                 _mcp_auth_header,
@@ -6047,35 +6057,6 @@ class TestMCPDcrBridgeDelegateAdmission:
         assert mcp_server_auth_headers == {
             "bridge_delegate_server": {"Authorization": "Bearer inner-upstream-access-token"}
         }
-
-    async def test_explicit_litellm_key_rejects_envelope_for_different_principal(self):
-        envelope = self._mint_bridge_envelope(key_hash="different-key-hash")
-        scope = {
-            "type": "http",
-            "method": "POST",
-            "path": "/mcp/bridge_delegate_server",
-            "headers": [
-                (b"x-litellm-api-key", b"sk-explicit-litellm-key"),
-                (b"authorization", f"Bearer {envelope}".encode("latin-1")),
-            ],
-        }
-
-        async def mock_user_api_key_auth(api_key, request):
-            return UserAPIKeyAuth(api_key=self._KEY_HASH, user_id="litellm-key-user")
-
-        with (
-            patch(
-                "litellm.proxy._experimental.mcp_server.auth.user_api_key_auth_mcp.user_api_key_auth",
-                side_effect=mock_user_api_key_auth,
-            ),
-            patch("litellm.proxy._experimental.mcp_server.mcp_server_manager.global_mcp_server_manager") as mock_mgr,
-            patch("litellm.proxy.proxy_server.master_key", self._MASTER_KEY),
-        ):
-            mock_mgr.get_mcp_server_by_name.return_value = self._bridge_delegate_server()
-            with pytest.raises(HTTPException) as exc_info:
-                await MCPRequestHandler.process_mcp_request(scope)
-
-        assert exc_info.value.status_code == 401
 
     async def test_non_bridge_oauth_delegate_server_does_not_take_envelope_arm(self):
         """An oauth_delegate server that is NOT a DCR bridge (``dcr_bridge`` unset) must not take the

--- a/tests/test_litellm/proxy/_experimental/mcp_server/auth/test_user_api_key_auth_mcp.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/auth/test_user_api_key_auth_mcp.py
@@ -5999,11 +5999,17 @@ class TestMCPDcrBridgeDelegateAdmission:
         # The envelope arm was skipped, so the oauth2 arm ran and validated the bearer.
         mock_auth.assert_called_once()
 
-    async def test_explicit_litellm_key_wins_over_envelope_arm(self):
-        """An explicit x-litellm-api-key is always a LiteLLM credential and its arm precedes the
-        envelope arm: user_api_key_auth validates the key and NO inner token is injected, even
-        though the Authorization header carries a valid envelope."""
-        envelope = self._mint_bridge_envelope()
+    @pytest.mark.parametrize(
+        "envelope_identity",
+        [
+            {"key_hash": _KEY_HASH},
+            {"user_id": "litellm-key-user"},
+        ],
+    )
+    async def test_explicit_litellm_key_with_matching_envelope_forwards_inner_token(self, envelope_identity):
+        """The explicit key authenticates the gateway request while its matching envelope supplies
+        the upstream OAuth token for the DCR bridge."""
+        envelope = self._mint_bridge_envelope(**envelope_identity)
         scope = {
             "type": "http",
             "method": "POST",
@@ -6015,7 +6021,7 @@ class TestMCPDcrBridgeDelegateAdmission:
         }
 
         async def mock_user_api_key_auth(api_key, request):
-            return UserAPIKeyAuth(api_key=api_key, user_id="litellm-key-user")
+            return UserAPIKeyAuth(api_key=self._KEY_HASH, user_id="litellm-key-user")
 
         with (
             patch(
@@ -6037,9 +6043,39 @@ class TestMCPDcrBridgeDelegateAdmission:
 
         mock_auth.assert_called_once()
         assert mock_auth.call_args.kwargs["api_key"] == "sk-explicit-litellm-key"
-        # The explicit-key arm admitted; the envelope arm never ran, so no inner token is injected.
         assert auth_result.user_id == "litellm-key-user"
-        assert mcp_server_auth_headers == {}
+        assert mcp_server_auth_headers == {
+            "bridge_delegate_server": {"Authorization": "Bearer inner-upstream-access-token"}
+        }
+
+    async def test_explicit_litellm_key_rejects_envelope_for_different_principal(self):
+        envelope = self._mint_bridge_envelope(key_hash="different-key-hash")
+        scope = {
+            "type": "http",
+            "method": "POST",
+            "path": "/mcp/bridge_delegate_server",
+            "headers": [
+                (b"x-litellm-api-key", b"sk-explicit-litellm-key"),
+                (b"authorization", f"Bearer {envelope}".encode("latin-1")),
+            ],
+        }
+
+        async def mock_user_api_key_auth(api_key, request):
+            return UserAPIKeyAuth(api_key=self._KEY_HASH, user_id="litellm-key-user")
+
+        with (
+            patch(
+                "litellm.proxy._experimental.mcp_server.auth.user_api_key_auth_mcp.user_api_key_auth",
+                side_effect=mock_user_api_key_auth,
+            ),
+            patch("litellm.proxy._experimental.mcp_server.mcp_server_manager.global_mcp_server_manager") as mock_mgr,
+            patch("litellm.proxy.proxy_server.master_key", self._MASTER_KEY),
+        ):
+            mock_mgr.get_mcp_server_by_name.return_value = self._bridge_delegate_server()
+            with pytest.raises(HTTPException) as exc_info:
+                await MCPRequestHandler.process_mcp_request(scope)
+
+        assert exc_info.value.status_code == 401
 
     async def test_non_bridge_oauth_delegate_server_does_not_take_envelope_arm(self):
         """An oauth_delegate server that is NOT a DCR bridge (``dcr_bridge`` unset) must not take the


### PR DESCRIPTION
## TLDR

Problem this solves:

- DCR bridge returns no tools with both credentials
- Upstream OAuth token is not forwarded

How it solves it:

- Validates the explicit LiteLLM key
- Opens the matching bridge envelope
- Rejects credentials belonging to different principals

## User Flow

Before: Claude Desktop receives an empty tool list when it sends both required headers

1. The user completes the browser OAuth sign-in
2. The client receives a token beginning with `llm_env_`
3. The client sends `POST https://gateway.example.com/demo/mcp` with the envelope and `x-litellm-api-key`
4. The request returns 200 with `"tools": []`
5. Claude Desktop reports that the server offered no tools

After: the same request forwards the user's OAuth token and returns the tools

1. The user completes the same browser OAuth sign-in
2. The client receives the same kind of `llm_env_` token
3. The client sends the same `POST https://gateway.example.com/demo/mcp` request with both headers
4. The request returns 200 with the upstream tools listed
5. Claude Desktop shows the server as connected

Credentials from different principals are rejected with 401.

## Relevant issues

Fixes #38208

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The targeted test class passes locally
- [ ] My PR passes all required CI/CD checks
- [x] My PR's scope is as isolated as possible
- [ ] I have received a Greptile Confidence Score of at least 4/5

## Screenshots / Proof of Fix

The live Before reproduction is documented in #38208. A current After run against a real OAuth-protected upstream is pending before this draft is marked ready for review.

## Type

🐛 Bug Fix
✅ Test

## Caveats (if any)

### Low

- Live OAuth After proof is still pending

## Final Attestation

- [ ] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
