### PR TITLE
test(cost-calc): pin the rate fallbacks inside a tiered-pricing tier

### DIFF
--- a/tests/test_litellm/litellm_core_utils/llm_cost_calc/test_llm_cost_calc_utils.py
+++ b/tests/test_litellm/litellm_core_utils/llm_cost_calc/test_llm_cost_calc_utils.py
@@ -716,6 +716,136 @@ def test_generic_cost_per_token_tier_without_an_output_rate_bills_the_model_rate
         litellm.model_cost.pop(model, None)
 
 
+def test_generic_cost_per_token_tier_without_cache_rates_bills_cache_at_the_tier_input_rate():
+    model = "litellm-test-tiered-no-cache-rates"
+    custom_llm_provider = "openrouter"
+    litellm.register_model(
+        {
+            model: {
+                "litellm_provider": custom_llm_provider,
+                "mode": "chat",
+                "cache_read_input_token_cost": 9e-09,
+                "cache_creation_input_token_cost": 9e-06,
+                "tiered_pricing": [
+                    {
+                        "range": [0, 32000],
+                        "input_cost_per_token": 4.6e-07,
+                        "output_cost_per_token": 2.3e-06,
+                    },
+                    {
+                        "range": [32000, 128000],
+                        "input_cost_per_token": 7e-07,
+                        "output_cost_per_token": 3.5e-06,
+                    },
+                ],
+            }
+        }
+    )
+
+    try:
+        uncached = Usage(prompt_tokens=40000, completion_tokens=100, total_tokens=40100)
+        cached = Usage(
+            prompt_tokens=40000,
+            completion_tokens=100,
+            total_tokens=40100,
+            prompt_tokens_details=PromptTokensDetailsWrapper(
+                cached_tokens=5000, cache_creation_tokens=15000
+            ),
+        )
+        uncached_prompt_cost, _ = generic_cost_per_token(
+            model=model,
+            usage=uncached,
+            custom_llm_provider=custom_llm_provider,
+        )
+        cached_prompt_cost, cached_completion_cost = generic_cost_per_token(
+            model=model,
+            usage=cached,
+            custom_llm_provider=custom_llm_provider,
+        )
+
+        tier_input_rate = 7e-07
+        assert round(cached_prompt_cost, 12) == round(40000 * tier_input_rate, 12)
+        assert round(cached_prompt_cost, 12) == round(uncached_prompt_cost, 12)
+        assert round(cached_completion_cost, 12) == round(100 * 3.5e-06, 12)
+    finally:
+        litellm.model_cost.pop(model, None)
+
+
+def test_generic_cost_per_token_tier_without_a_1hr_cache_rate_bills_the_tier_cache_creation_rate():
+    model = "litellm-test-tiered-no-1hr-cache-rate"
+    custom_llm_provider = "openrouter"
+    litellm.register_model(
+        {
+            model: {
+                "litellm_provider": custom_llm_provider,
+                "mode": "chat",
+                "cache_creation_input_token_cost_above_1hr": 9e-05,
+                "tiered_pricing": [
+                    {
+                        "range": [0, 128000],
+                        "input_cost_per_token": 7e-07,
+                        "output_cost_per_token": 3.5e-06,
+                        "cache_creation_input_token_cost": 8.75e-07,
+                    }
+                ],
+            }
+        }
+    )
+
+    try:
+        usage = Usage(
+            prompt_tokens=1000,
+            completion_tokens=10,
+            total_tokens=1010,
+            prompt_tokens_details=PromptTokensDetailsWrapper(
+                cache_creation_tokens=800,
+                cache_creation_token_details=CacheCreationTokenDetails(
+                    ephemeral_5m_input_tokens=300, ephemeral_1h_input_tokens=500
+                ),
+            ),
+        )
+        prompt_cost, completion_cost = generic_cost_per_token(
+            model=model,
+            usage=usage,
+            custom_llm_provider=custom_llm_provider,
+        )
+
+        tier_cache_creation_rate = 8.75e-07
+        expected_prompt = (200 * 7e-07) + (800 * tier_cache_creation_rate)
+        assert round(prompt_cost, 12) == round(expected_prompt, 12)
+        assert round(completion_cost, 12) == round(10 * 3.5e-06, 12)
+    finally:
+        litellm.model_cost.pop(model, None)
+
+
+def test_generic_cost_per_token_tier_without_an_input_rate_is_not_a_priced_tier():
+    model = "litellm-test-tiered-no-input-rate"
+    custom_llm_provider = "openrouter"
+    litellm.register_model(
+        {
+            model: {
+                "litellm_provider": custom_llm_provider,
+                "mode": "chat",
+                "input_cost_per_token": 1e-06,
+                "output_cost_per_token": 2e-06,
+                "tiered_pricing": [{"range": [0, 128000], "output_cost_per_token": 3.5e-06}],
+            }
+        }
+    )
+
+    try:
+        usage = Usage(prompt_tokens=1000, completion_tokens=100, total_tokens=1100)
+        prompt_cost, completion_cost = generic_cost_per_token(
+            model=model,
+            usage=usage,
+            custom_llm_provider=custom_llm_provider,
+        )
+        assert round(prompt_cost, 12) == round(1000 * 1e-06, 12)
+        assert round(completion_cost, 12) == round(100 * 2e-06, 12)
+    finally:
+        litellm.model_cost.pop(model, None)
+
+
 def test_router_deployment_with_input_only_tiers_bills_completions_at_the_backend_rate():
     """Regression: the router registers a deployment's custom pricing as a standalone
     model_cost entry holding only the supplied fields, so an input-only tier table left


### PR DESCRIPTION
## TLDR

Problem this solves:

- Tier rate fallbacks decide real prices, nothing tested them
- Deleting a fallback from the source left the suite green
- 54 of 66 shipped tiers rely on the cache fallback

How it solves it:

- Three tests on tiers that omit a rate
- Each one fails if its fallback is removed
- Test-only, no source touched

## User Flow

This is a test-only change, so nothing an end user does changes today. What changes is whether a future pricing regression reaches them.

Before: a regression in the tier fallbacks ships green, and an admin on a tiered model with prompt caching is billed wrong

1. A tiered model, say `volcengine/doubao-seed-2-0-pro-260215`, declares per-range input and output rates and no cache rates, which is the normal shape
2. Someone changes how a tier resolves a rate it does not declare
3. Every test still passes, so the change merges
4. The admin sends chat completions that reuse a cached prompt and opens https://litellm-domain/ui/?page=logs
5. The cached part of each request is now billed at $0, so the spend they see is lower than what the provider actually charges them

After: the same regression fails CI before it can merge

1. Same model, same shape
2. Someone makes the same change
3. CI fails on the three new tests, naming the tier rate that stopped falling back
4. The change does not merge, and the admin's logs keep showing the real spend

## Relevant issues

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally
- [x] My PR passes all required CI/CD checks
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

This PR adds no source change, so there is no runtime behavior to curl. What it can show is that the tests actually hold the behavior down: each one is run against a source tree with its fallback removed, and it has to fail there and pass on the real tree.

Setup, run from the repo root:

```bash
export PYTHONPATH=$PWD
K="tier_without_cache_rates or tier_without_a_1hr or tier_without_an_input_rate"
T=tests/test_litellm/litellm_core_utils/llm_cost_calc/test_llm_cost_calc_utils.py
U=litellm/litellm_core_utils/llm_cost_calc/utils.py
cp $U /tmp/utils.orig
```

### Before (137311ffd6)

#### the fallbacks are unheld: remove each one, suite stays green

1. Remove the cache-read fallback and run the whole cost-calc suite

```bash
sed -i '' '265s|, "input_cost_per_token"||' $U
python -m pytest -q tests/test_litellm/litellm_core_utils/llm_cost_calc/ ; cp /tmp/utils.orig $U
```

```
257 passed, 1 warning in 1.70s
```

2. Same for the cache-creation fallback

```bash
sed -i '' '253s|, "input_cost_per_token"||' $U
python -m pytest -q tests/test_litellm/litellm_core_utils/llm_cost_calc/ ; cp /tmp/utils.orig $U
```

```
257 passed, 1 warning in 1.70s
```

### After (54cbc44705)

#### the same removals now fail

1. Baseline, real source

```bash
python -m pytest -q $T -k "$K"
```

```
3 passed, 176 deselected, 1 warning in 0.19s
```

2. Remove the cache-read fallback

```bash
sed -i '' '265s|, "input_cost_per_token"||' $U; python -m pytest -q $T -k "$K"; cp /tmp/utils.orig $U
```

```
1 failed, 2 passed, 176 deselected, 1 warning in 0.25s
```

3. Remove the cache-creation fallback

```bash
sed -i '' '253s|, "input_cost_per_token"||' $U; python -m pytest -q $T -k "$K"; cp /tmp/utils.orig $U
```

```
1 failed, 2 passed, 176 deselected, 1 warning in 0.24s
```

4. Point the above-1hr rate at the tier input rate instead of its cache-creation rate

```bash
sed -i '' '263s|"cache_creation_input_token_cost")|"input_cost_per_token")|' $U; python -m pytest -q $T -k "$K"; cp /tmp/utils.orig $U
```

```
1 failed, 2 passed, 176 deselected, 1 warning in 0.26s
```

5. Drop the guard that keeps a tier with no input rate from being priced

```bash
sed -i '' '224s|.*|    if tier is None:|' $U; python -m pytest -q $T -k "$K"; cp /tmp/utils.orig $U
```

```
1 failed, 2 passed, 176 deselected, 1 warning in 0.23s
```

6. Full cost-calc suite plus every other suite that touches tiered pricing or data residency, on the real source

```bash
python -m pytest -q tests/test_litellm/litellm_core_utils/llm_cost_calc/ tests/test_litellm/litellm_core_utils/test_ptu_pricing.py tests/test_litellm/test_cost_calculator.py tests/test_litellm/llms/dashscope/test_dashscope_cost_calculator.py tests/test_litellm/llms/xai/test_xai_cost_calculator.py tests/test_litellm/llms/openai/test_data_residency.py tests/test_litellm/llms/openai/responses/test_openai_responses_data_residency.py tests/test_litellm/proxy/test_budget_reservation.py
```

```
528 passed, 319 warnings in 49.67s
```

(525 on the merge base, 528 here: the three new tests.)

## Type

✅ Test

## Caveats (if any)

### Low

- One nearby mutation stays alive, and it is equivalent
  - Dropping the above-1hr fallback key alone changes nothing
  - A trailing `or cache_creation_cost` already supplies the same value
- The no-input-rate tier guard is defensive, not observed
  - No model in the shipped cost map has that tier shape
  - The other two fallbacks do fire on shipped data

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
