### PR TITLE
fix(mcp): preserve bridge token with gateway key

### DIFF
--- a/litellm/proxy/_experimental/mcp_server/auth/user_api_key_auth_mcp.py
+++ b/litellm/proxy/_experimental/mcp_server/auth/user_api_key_auth_mcp.py
@@ -412,6 +412,28 @@ class MCPRequestHandler:
         # Only OAuth metadata routes registered under /.well-known/ are public.
         if request_route.startswith("/.well-known/"):
             validated_user_api_key_auth = UserAPIKeyAuth()
+        elif (
+            (
+                bridge_delegate_target := MCPRequestHandler._single_dcr_bridge_delegate_target(
+                    path=request_route,
+                    mcp_servers=mcp_servers,
+                    client_ip=IPAddressUtils.get_mcp_client_ip(request),
+                )
+            )
+            is not None
+            and oauth2_headers
+            and is_bridge_envelope_shaped(oauth2_headers["Authorization"])
+        ):
+            # A bridge envelope is the delegated user's credential. Some MCP clients retain the
+            # LiteLLM key needed during token exchange on every request, so it must not displace
+            # the sealed upstream token during tool discovery.
+            validated_user_api_key_auth, mcp_server_auth_headers = await MCPRequestHandler._admit_dcr_bridge_delegate(
+                server=bridge_delegate_target,
+                authorization_value=oauth2_headers["Authorization"],
+                mcp_server_auth_headers=mcp_server_auth_headers,
+                request=request,
+                route=request_route,
+            )
         elif has_explicit_litellm_key:
             # An explicit x-litellm-api-key is always a LiteLLM credential, even
             # for a delegated server, so validate it: identity / spend / rate
@@ -439,29 +461,7 @@ class MCPRequestHandler:
             client_ip=IPAddressUtils.get_mcp_client_ip(request),
         ):
             validated_user_api_key_auth = UserAPIKeyAuth()
-        elif (
-            (
-                bridge_delegate_target := MCPRequestHandler._single_dcr_bridge_delegate_target(
-                    path=request_route,
-                    mcp_servers=mcp_servers,
-                    client_ip=IPAddressUtils.get_mcp_client_ip(request),
-                )
-            )
-            is not None
-            and oauth2_headers
-            and is_bridge_envelope_shaped(oauth2_headers["Authorization"])
-        ):
-            # A single DCR-bridge oauth_delegate target carrying an envelope-shaped
-            # Authorization: open the envelope, admit under its recovered identity, and
-            # inject the inner upstream token for egress. A non-envelope bearer on the same
-            # server is NOT admitted here — it falls through to the oauth2 arm, which 401s.
-            validated_user_api_key_auth, mcp_server_auth_headers = await MCPRequestHandler._admit_dcr_bridge_delegate(
-                server=bridge_delegate_target,
-                authorization_value=oauth2_headers["Authorization"],
-                mcp_server_auth_headers=mcp_server_auth_headers,
-                request=request,
-                route=request_route,
-            )
+
         elif oauth2_headers and is_session_bearer_shaped(oauth2_headers["Authorization"]):
             # A gateway DCR session bearer at any MCP scope: open the identity-only session
             # token and admit under the live litellm user; downstream grant resolution

--- a/tests/test_litellm/proxy/_experimental/mcp_server/auth/test_user_api_key_auth_mcp.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/auth/test_user_api_key_auth_mcp.py
@@ -5999,10 +5999,9 @@ class TestMCPDcrBridgeDelegateAdmission:
         # The envelope arm was skipped, so the oauth2 arm ran and validated the bearer.
         mock_auth.assert_called_once()
 
-    async def test_explicit_litellm_key_wins_over_envelope_arm(self):
-        """An explicit x-litellm-api-key is always a LiteLLM credential and its arm precedes the
-        envelope arm: user_api_key_auth validates the key and NO inner token is injected, even
-        though the Authorization header carries a valid envelope."""
+    async def test_bridge_envelope_preserves_delegated_token_with_litellm_key_header(self):
+        """A DCR client's configured LiteLLM key can accompany every request without replacing the
+        bridge envelope's sealed upstream token at egress."""
         envelope = self._mint_bridge_envelope()
         scope = {
             "type": "http",
@@ -6014,16 +6013,14 @@ class TestMCPDcrBridgeDelegateAdmission:
             ],
         }
 
-        async def mock_user_api_key_auth(api_key, request):
-            return UserAPIKeyAuth(api_key=api_key, user_id="litellm-key-user")
-
         with (
             patch(
                 "litellm.proxy._experimental.mcp_server.auth.user_api_key_auth_mcp.user_api_key_auth",
-                side_effect=mock_user_api_key_auth,
+                new_callable=AsyncMock,
             ) as mock_auth,
             patch("litellm.proxy._experimental.mcp_server.mcp_server_manager.global_mcp_server_manager") as mock_mgr,
             patch("litellm.proxy.proxy_server.master_key", self._MASTER_KEY),
+            self._patch_key_reload(return_value=self._reloaded_key(user_id="envelope-user")),
         ):
             mock_mgr.get_mcp_server_by_name.return_value = self._bridge_delegate_server()
             (
@@ -6035,11 +6032,11 @@ class TestMCPDcrBridgeDelegateAdmission:
                 _raw_headers,
             ) = await MCPRequestHandler.process_mcp_request(scope)
 
-        mock_auth.assert_called_once()
-        assert mock_auth.call_args.kwargs["api_key"] == "sk-explicit-litellm-key"
-        # The explicit-key arm admitted; the envelope arm never ran, so no inner token is injected.
-        assert auth_result.user_id == "litellm-key-user"
-        assert mcp_server_auth_headers == {}
+        mock_auth.assert_not_called()
+        assert auth_result.user_id == "envelope-user"
+        assert mcp_server_auth_headers == {
+            "bridge_delegate_server": {"Authorization": "Bearer inner-upstream-access-token"}
+        }
 
     async def test_non_bridge_oauth_delegate_server_does_not_take_envelope_arm(self):
         """An oauth_delegate server that is NOT a DCR bridge (``dcr_bridge`` unset) must not take the


### PR DESCRIPTION
## TLDR

Problem this solves:

- Gateway key header hides delegated upstream credentials
- MCP clients receive an empty tool list

How it solves it:

- Prefer a valid DCR bridge envelope for its target
- Preserve its sealed upstream bearer for tool discovery

## User Flow

Before: a client that keeps its configured gateway key on every request cannot discover tools after completing delegated sign-in

1. A user configures a DCR bridge `oauth_delegate` MCP server in their client
2. The client completes browser sign-in and receives the gateway-issued bearer
3. The client sends `POST https://gateway.example.com/demo/mcp` with that bearer and `x-litellm-api-key`
4. The response returns 200 with an empty `tools` array

After: the same request preserves the delegated bearer and lists the upstream tools

1. A user configures the same DCR bridge `oauth_delegate` MCP server
2. The client completes the same browser sign-in and receives the gateway-issued bearer
3. The client sends the same `POST https://gateway.example.com/demo/mcp` with the bearer and `x-litellm-api-key`
4. The response returns the authorized upstream tools

## Relevant issues

Fixes #38208

## Linear ticket


## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The focused MCP admission test class passes locally
- [ ] My PR passes all required CI/CD checks
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile Confidence Score of at least 4/5 before requesting a maintainer review

## Screenshots / Proof of Fix

Live proxy proof was not run because this workspace has no configured delegated OAuth upstream

## Type

🐛 Bug Fix

## Caveats (if any)

### Medium

- Live upstream OAuth verification still needs maintainer environment access

## Final Attestation

- [x] The regression test covers the two-header admission path and preserves existing invalid-envelope controls
