### PR TITLE
fix(batches): skip discarded tokenization on allowlist-only batch input file reads

### DIFF
--- a/litellm/__init__.py
+++ b/litellm/__init__.py
@@ -464,6 +464,11 @@ prometheus_metrics_config: Optional[List] = None
 prometheus_exclude_metrics: Optional[List[str]] = None
 prometheus_exclude_labels: Optional[List[str]] = None
 prometheus_emit_stream_label: bool = False
+prometheus_deployment_and_latency_caller_identity: Literal[
+    "api_key_alias",
+    "user_email",
+    "both",
+] = "api_key_alias"
 # Opt-in: emit `rate_limit_category` and `rate_limit_type` labels on
 # `litellm_proxy_failed_requests_metric`. Off by default to preserve the
 # pre-unification label set so existing dashboards / recording rules keyed on

--- a/litellm/integrations/prometheus.py
+++ b/litellm/integrations/prometheus.py
@@ -49,6 +49,7 @@ from litellm.types.integrations.prometheus import *
 from litellm.types.integrations.prometheus import (
     _sanitize_prometheus_label_name,
     _sanitize_prometheus_label_value,
+    validate_prometheus_deployment_and_latency_caller_identity,
 )
 from litellm.types.utils import (
     StandardLoggingGuardrailInformation,
@@ -174,6 +175,11 @@ class PrometheusLogger(CustomLogger):
     ):
         try:
             from prometheus_client import Counter, Gauge, Histogram
+
+            # Validate the caller-identity mode before any collector registers so an
+            # invalid value cannot leave partially-registered metrics behind in the
+            # process-global registry.
+            validate_prometheus_deployment_and_latency_caller_identity()
 
             # Always initialize label_filters, even for non-premium users
             self.label_filters = self._parse_prometheus_config()
@@ -2465,6 +2471,7 @@ class PrometheusLogger(CustomLogger):
         else:
             _metadata = {
                 "user_api_key_alias": getattr(_metadata_raw, "user_api_key_alias", None),
+                "user_api_key_user_email": getattr(_metadata_raw, "user_api_key_user_email", None),
                 "user_api_key_team_id": getattr(_metadata_raw, "user_api_key_team_id", None),
                 "user_api_key_team_alias": getattr(_metadata_raw, "user_api_key_team_alias", None),
                 "user_api_key_hash": getattr(_metadata_raw, "user_api_key_hash", None),
@@ -2485,6 +2492,17 @@ class PrometheusLogger(CustomLogger):
                 return val
             if user_api_key_auth is not None:
                 return getattr(user_api_key_auth, "key_alias", None)
+            return None
+
+        def _get_user_email() -> str | None:
+            val = _metadata.get("user_api_key_user_email")
+            if val is not None:
+                return val
+            val = _litellm_params_metadata.get("user_api_key_user_email")
+            if val is not None:
+                return val
+            if user_api_key_auth is not None:
+                return self._safe_get(user_api_key_auth, "user_email")
             return None
 
         def _get_team_id() -> str | None:
@@ -2522,6 +2540,7 @@ class PrometheusLogger(CustomLogger):
 
         return {
             "api_key_alias": _get_api_key_alias(),
+            "user_email": _get_user_email(),
             "team": _get_team_id(),
             "team_alias": _get_team_alias(),
             "hashed_api_key": _get_hashed_api_key(),
@@ -2579,6 +2598,7 @@ class PrometheusLogger(CustomLogger):
             _metadata: Final = standard_logging_payload.get("metadata", {}) or {}
             hashed_api_key: Final = fallback_values.get("hashed_api_key") or _metadata.get("user_api_key_hash")
             api_key_alias: Final = fallback_values.get("api_key_alias") or _metadata.get("user_api_key_alias")
+            user_email: Final = fallback_values.get("user_email")
             team: Final = fallback_values.get("team") or _metadata.get("user_api_key_team_id")
             team_alias: Final = fallback_values.get("team_alias") or _metadata.get("user_api_key_team_alias")
             client_ip: Final = fallback_values.get("client_ip") or _metadata.get("requester_ip_address")
@@ -2619,6 +2639,7 @@ class PrometheusLogger(CustomLogger):
                 requested_model=label_requested_model,
                 hashed_api_key=hashed_api_key,
                 api_key_alias=api_key_alias,
+                user_email=user_email,
                 team=team,
                 team_alias=team_alias,
                 tags=standard_logging_payload.get("request_tags", []),

--- a/litellm/litellm_core_utils/exception_mapping_utils.py
+++ b/litellm/litellm_core_utils/exception_mapping_utils.py
@@ -550,6 +550,13 @@ def _map_anthropic_exception(
                 llm_provider="anthropic",
                 model=model,
             )
+        elif original_exception.status_code == 403:
+            raise PermissionDeniedError(
+                message=f"AnthropicException - {error_str}",
+                llm_provider="anthropic",
+                model=model,
+                response=original_exception.response,
+            )
         elif original_exception.status_code == 400 or original_exception.status_code == 413:
             raise BadRequestError(
                 message=f"AnthropicException - {error_str}",

--- a/litellm/litellm_core_utils/exception_mapping_utils.py
+++ b/litellm/litellm_core_utils/exception_mapping_utils.py
@@ -755,11 +755,18 @@ def _map_openai_like_exception(
                 llm_provider=custom_llm_provider,
                 model=model,
             )
-        elif original_exception.status_code == 401 or original_exception.status_code == 403:
+        elif original_exception.status_code == 401:
             raise AuthenticationError(
                 message=f"{custom_llm_provider.capitalize()}Exception - {original_exception.message}",
                 llm_provider=custom_llm_provider,
                 model=model,
+            )
+        elif original_exception.status_code == 403:
+            raise PermissionDeniedError(
+                message=f"{custom_llm_provider.capitalize()}Exception - {original_exception.message}",
+                llm_provider=custom_llm_provider,
+                model=model,
+                response=getattr(original_exception, "response", None),
             )
         elif original_exception.status_code == 400:
             raise BadRequestError(

--- a/litellm/litellm_core_utils/exception_mapping_utils.py
+++ b/litellm/litellm_core_utils/exception_mapping_utils.py
@@ -2486,6 +2486,18 @@ def exception_type(
                     exception_provider=exception_provider,
                     extra_information=extra_information,
                 )
+            from litellm.llms.base_llm.chat.transformation import BaseLLMException
+
+            if custom_llm_provider and isinstance(original_exception, BaseLLMException):
+                _map_openai_like_exception(
+                    model=model,
+                    original_exception=mappable_exception,
+                    custom_llm_provider=custom_llm_provider,
+                    error_str=error_str,
+                    exception_type=exception_type,
+                    exception_provider=exception_provider,
+                    extra_information=extra_information,
+                )
         if "BadRequestError.__init__() missing 1 required positional argument: 'param'" in str(
             original_exception
         ):  # deal with edge-case invalid request error bug in openai-python sdk

--- a/litellm/litellm_core_utils/exception_mapping_utils.py
+++ b/litellm/litellm_core_utils/exception_mapping_utils.py
@@ -2486,18 +2486,6 @@ def exception_type(
                     exception_provider=exception_provider,
                     extra_information=extra_information,
                 )
-            from litellm.llms.base_llm.chat.transformation import BaseLLMException
-
-            if custom_llm_provider and isinstance(original_exception, BaseLLMException):
-                _map_openai_like_exception(
-                    model=model,
-                    original_exception=mappable_exception,
-                    custom_llm_provider=custom_llm_provider,
-                    error_str=error_str,
-                    exception_type=exception_type,
-                    exception_provider=exception_provider,
-                    extra_information=extra_information,
-                )
         if "BadRequestError.__init__() missing 1 required positional argument: 'param'" in str(
             original_exception
         ):  # deal with edge-case invalid request error bug in openai-python sdk

--- a/litellm/litellm_core_utils/exception_mapping_utils.py
+++ b/litellm/litellm_core_utils/exception_mapping_utils.py
@@ -755,11 +755,18 @@ def _map_openai_like_exception(
                 llm_provider=custom_llm_provider,
                 model=model,
             )
-        elif original_exception.status_code == 401 or original_exception.status_code == 403:
+        elif original_exception.status_code == 401:
             raise AuthenticationError(
                 message=f"{custom_llm_provider.capitalize()}Exception - {original_exception.message}",
                 llm_provider=custom_llm_provider,
                 model=model,
+            )
+        elif original_exception.status_code == 403:
+            raise PermissionDeniedError(
+                message=f"{custom_llm_provider.capitalize()}Exception - {original_exception.message}",
+                llm_provider=custom_llm_provider,
+                model=model,
+                response=_response_or_stub(original_exception, status_code=403),
             )
         elif original_exception.status_code == 400:
             raise BadRequestError(
@@ -2187,6 +2194,120 @@ def _map_openrouter_exception(
         )
 
 
+def _response_or_stub(original_exception: _ProviderHTTPException, status_code: int) -> httpx.Response:
+    response: Final = original_exception.response if hasattr(original_exception, "response") else None
+    if response is not None:
+        return response
+    return httpx.Response(
+        status_code=status_code, request=httpx.Request(method="POST", url="https://docs.litellm.ai/docs")
+    )
+
+
+def _map_exception_by_status(
+    *,
+    model: str,
+    original_exception: _ProviderHTTPException,
+    custom_llm_provider: str,
+    error_str: str,
+    exception_provider: str,
+    extra_information: str,
+) -> None:
+    status_code: Final = original_exception.status_code if hasattr(original_exception, "status_code") else None
+    if not isinstance(status_code, int) or status_code < 400:
+        return
+    message: Final = f"{exception_provider} - {error_str}"
+    response: Final = original_exception.response if hasattr(original_exception, "response") else None
+    match status_code:
+        case 401:
+            raise AuthenticationError(
+                message=message,
+                llm_provider=custom_llm_provider,
+                model=model,
+                response=response,
+                litellm_debug_info=extra_information,
+            )
+        case 403:
+            raise PermissionDeniedError(
+                message=message,
+                llm_provider=custom_llm_provider,
+                model=model,
+                response=_response_or_stub(original_exception, status_code=status_code),
+                litellm_debug_info=extra_information,
+            )
+        case 404:
+            raise NotFoundError(
+                message=message,
+                model=model,
+                llm_provider=custom_llm_provider,
+                response=response,
+                litellm_debug_info=extra_information,
+            )
+        case 408:
+            raise Timeout(
+                message=message,
+                model=model,
+                llm_provider=custom_llm_provider,
+                litellm_debug_info=extra_information,
+            )
+        case 429:
+            raise RateLimitError(
+                message=message,
+                model=model,
+                llm_provider=custom_llm_provider,
+                response=response,
+                litellm_debug_info=extra_information,
+            )
+        case 500:
+            raise InternalServerError(
+                message=message,
+                llm_provider=custom_llm_provider,
+                model=model,
+                response=response,
+                litellm_debug_info=extra_information,
+            )
+        case 502:
+            raise BadGatewayError(
+                message=message,
+                llm_provider=custom_llm_provider,
+                model=model,
+                response=response,
+                litellm_debug_info=extra_information,
+            )
+        case 503:
+            raise ServiceUnavailableError(
+                message=message,
+                llm_provider=custom_llm_provider,
+                model=model,
+                response=response,
+                litellm_debug_info=extra_information,
+            )
+        case 504:
+            raise Timeout(
+                message=message,
+                model=model,
+                llm_provider=custom_llm_provider,
+                litellm_debug_info=extra_information,
+                exception_status_code=status_code,
+            )
+        case _ if status_code < 500:
+            raise BadRequestError(
+                message=message,
+                model=model,
+                llm_provider=custom_llm_provider,
+                response=response,
+                litellm_debug_info=extra_information,
+            )
+        case _:
+            raise APIError(
+                status_code=status_code,
+                message=message,
+                llm_provider=custom_llm_provider,
+                model=model,
+                request=original_exception.request if hasattr(original_exception, "request") else None,
+                litellm_debug_info=extra_information,
+            )
+
+
 def exception_type(
     model,
     original_exception,
@@ -2501,6 +2622,14 @@ def exception_type(
             For unmapped exceptions - raise the exception with traceback - https://github.com/BerriAI/litellm/issues/4201
             """
             exception_mapping_worked = True
+            _map_exception_by_status(
+                model=model,
+                original_exception=mappable_exception,
+                custom_llm_provider=custom_llm_provider,
+                error_str=error_str,
+                exception_provider=exception_provider,
+                extra_information=extra_information,
+            )
             if hasattr(original_exception, "request"):
                 raise APIConnectionError(
                     message=f"{exception_provider} - {error_str}",

--- a/litellm/llms/anthropic/experimental_pass_through/messages/handler.py
+++ b/litellm/llms/anthropic/experimental_pass_through/messages/handler.py
@@ -12,6 +12,7 @@ from functools import partial
 from typing import Any, Final, cast
 
 import litellm
+from litellm.litellm_core_utils.exception_mapping_utils import exception_type
 from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObj
 from litellm.llms.anthropic.common_utils import (
     flatten_unencrypted_web_search_results_in_anthropic_messages,
@@ -382,13 +383,18 @@ async def anthropic_messages(
     )
     ctx: Final = contextvars.copy_context()
     func_with_context: Final = partial(ctx.run, func)
-    init_response: Final = await loop.run_in_executor(None, func_with_context)
-
-    if asyncio.iscoroutine(init_response):
-        response = await init_response
-    else:
-        response = init_response
-    return response
+    try:
+        init_response: Final = await loop.run_in_executor(None, func_with_context)
+        if asyncio.iscoroutine(init_response):
+            return await init_response
+        return init_response
+    except Exception as e:  # noqa: BLE001  # the mapping boundary must see every provider-layer failure, like acompletion
+        raise exception_type(
+            model=model,
+            custom_llm_provider=custom_llm_provider,
+            original_exception=e,
+            extra_kwargs=kwargs,
+        )
 
 
 def validate_anthropic_api_metadata(metadata: dict | None = None) -> dict | None:

--- a/litellm/llms/anthropic/experimental_pass_through/messages/handler.py
+++ b/litellm/llms/anthropic/experimental_pass_through/messages/handler.py
@@ -22,6 +22,7 @@ from litellm.llms.anthropic.common_utils import (
 from litellm.llms.base_llm.anthropic_messages.transformation import (
     BaseAnthropicMessagesConfig,
 )
+from litellm.llms.base_llm.chat.transformation import BaseLLMException
 from litellm.llms.custom_httpx.http_handler import AsyncHTTPHandler
 from litellm.llms.custom_httpx.llm_http_handler import BaseLLMHTTPHandler
 from litellm.types.llms.anthropic_messages.anthropic_request import AnthropicMetadata
@@ -388,7 +389,7 @@ async def anthropic_messages(
         if asyncio.iscoroutine(init_response):
             return await init_response
         return init_response
-    except Exception as e:  # noqa: BLE001  # the mapping boundary must see every provider-layer failure, like acompletion
+    except BaseLLMException as e:
         raise exception_type(
             model=model,
             custom_llm_provider=custom_llm_provider,

--- a/litellm/proxy/common_utils/sse_keepalive.py
+++ b/litellm/proxy/common_utils/sse_keepalive.py
@@ -91,6 +91,18 @@ def is_sse_content_type(content_type: str | None) -> bool:
     return content_type is not None and content_type.split(";", 1)[0].strip().lower() == _SSE_MEDIA_TYPE
 
 
+def split_complete_sse_frames(pending: bytes) -> tuple[bytes, bytes]:
+    """Split buffered SSE bytes into ``(complete_frames, unterminated_tail)``."""
+    lf_boundary_end: Final = pending.rfind(b"\n\n") + 2
+    crlf_boundary_end: Final = pending.rfind(b"\r\n\r\n") + 4
+    boundary_end: Final = max(
+        lf_boundary_end if lf_boundary_end >= 2 else 0, crlf_boundary_end if crlf_boundary_end >= 4 else 0
+    )
+    if boundary_end == 0:
+        return b"", pending
+    return pending[:boundary_end], pending[boundary_end:]
+
+
 def wrap_passthrough_sse_bytes_with_keepalive_pings(
     stream: AsyncGenerator[bytes, None],
     ping_interval_seconds: float | str | None,

--- a/litellm/proxy/common_utils/sse_keepalive.py
+++ b/litellm/proxy/common_utils/sse_keepalive.py
@@ -93,10 +93,9 @@ def is_sse_content_type(content_type: str | None) -> bool:
 
 def split_complete_sse_frames(pending: bytes) -> tuple[bytes, bytes]:
     """Split buffered SSE bytes into ``(complete_frames, unterminated_tail)``."""
-    lf_boundary_end: Final = pending.rfind(b"\n\n") + 2
-    crlf_boundary_end: Final = pending.rfind(b"\r\n\r\n") + 4
     boundary_end: Final = max(
-        lf_boundary_end if lf_boundary_end >= 2 else 0, crlf_boundary_end if crlf_boundary_end >= 4 else 0
+        (pending.rfind(delimiter) + len(delimiter) for delimiter in _SSE_FRAME_DELIMITERS if delimiter in pending),
+        default=0,
     )
     if boundary_end == 0:
         return b"", pending

--- a/litellm/proxy/hooks/batch_rate_limiter.py
+++ b/litellm/proxy/hooks/batch_rate_limiter.py
@@ -361,6 +361,47 @@ class _PROXY_BatchRateLimiter(CustomLogger):
 
         return False, descriptors
 
+    def _batch_input_file_models_only(
+        self,
+        data: dict,
+        user_api_key_dict: UserAPIKeyAuth,
+        has_enqueued_scopes: bool = False,
+    ) -> bool:
+        """True when the JSONL is read only to validate ``body.model``.
+
+        ``_should_skip_batch_input_file_processing`` returns on the model
+        allowlist check before it consults the operator opt-outs, so a key with a
+        restricted ``models`` list always takes the full path even when batch
+        input-file rate limiting is disabled. The download itself is still
+        required -- the allowlist can only be enforced by inspecting every row --
+        but the per-row token counting it also performs is then discarded by the
+        caller.
+
+        Reporting that case lets the read collect ``body.model`` without
+        tokenizing each row. Enforcement is unchanged: this returns False
+        whenever anything still needs the totals, including enqueued-token
+        scopes, whose reservation is priced from them.
+        """
+        from litellm.proxy.proxy_server import general_settings
+
+        if has_enqueued_scopes:
+            return False
+
+        if not self._key_requires_batch_model_access_check(user_api_key_dict):
+            # An unrestricted key is already covered by the full-skip paths.
+            return False
+
+        if general_settings.get("disable_batch_input_file_rate_limiting") is True:
+            return True
+
+        skip_providers: Final = general_settings.get("skip_batch_input_file_rate_limiting_for_providers") or []
+        if skip_providers:
+            batch_provider: Final = self._resolve_batch_provider(self._get_batch_routing_model(data))
+            if batch_provider and batch_provider in skip_providers:
+                return True
+
+        return False
+
     def _warn_if_unsupported_model_skip_configured(self, general_settings: dict) -> None:
         """Warn once that ``skip_batch_input_file_rate_limiting_for_models`` is a no-op.
 
@@ -729,6 +770,7 @@ class _PROXY_BatchRateLimiter(CustomLogger):
         user_api_key_dict: UserAPIKeyAuth | None = None,
         data: dict | None = None,
         descriptors: Sequence["RateLimitDescriptor"] | None = None,
+        models_only: bool = False,
     ) -> BatchFileUsage:
         """
         Count number of requests and tokens in a batch input file.
@@ -739,6 +781,10 @@ class _PROXY_BatchRateLimiter(CustomLogger):
             user_api_key_dict: User authentication information for file access (required for managed files)
             descriptors: Rate limit descriptors already computed for this batch, so the
                 configured project OTPM limit can scale the no-``max_tokens`` output floor
+            models_only: Collect and validate every row's ``body.model`` but skip
+                per-row token counting. Set when the file is read solely for
+                allowlist enforcement, so the token fields come back 0 and the
+                caller must not charge them.
 
         Returns:
             BatchFileUsage with total_tokens, output_tokens, request_count, and
@@ -831,6 +877,10 @@ class _PROXY_BatchRateLimiter(CustomLogger):
                 try:
                     entry = json.loads(raw_line)
                 except Exception:
+                    if models_only:
+                        # A malformed row names no model, so skipping its size
+                        # estimate cannot weaken the allowlist check below.
+                        continue
                     entry_total_tokens = _estimate_batch_entry_tokens(raw_line)
                     entry_output_tokens = self.parallel_request_limiter.no_max_tokens_output_floor(
                         min_configured_otpm_limit
@@ -842,6 +892,12 @@ class _PROXY_BatchRateLimiter(CustomLogger):
                 model: str | None = (entry.get("body") or {}).get("model") if isinstance(entry, dict) else None
                 if model:
                     models.add(model)
+
+                if models_only:
+                    # Every row's `body.model` is collected above, which is all
+                    # `_enforce_batch_file_model_access` needs. Tokenizing here
+                    # would be work the caller throws away.
+                    continue
 
                 if isinstance(entry, dict):
                     entry_output_tokens = self._estimate_entry_output_tokens(entry, min_configured_otpm_limit)
@@ -1109,6 +1165,12 @@ class _PROXY_BatchRateLimiter(CustomLogger):
             if should_skip:
                 return data
 
+            models_only: Final = self._batch_input_file_models_only(
+                data=data,
+                user_api_key_dict=user_api_key_dict,
+                has_enqueued_scopes=bool(enqueued_scopes),
+            )
+
             # Get custom_llm_provider for token counting
             custom_llm_provider: Final = data.get("custom_llm_provider", "openai")
 
@@ -1120,7 +1182,18 @@ class _PROXY_BatchRateLimiter(CustomLogger):
                 user_api_key_dict=user_api_key_dict,
                 data=data,
                 descriptors=batch_rate_limit_descriptors,
+                models_only=models_only,
             )
+
+            if models_only:
+                # The allowlist was enforced inside count_input_file_usage and
+                # nothing charges this batch, so there are no counters to check.
+                # Returning here keeps the zeroed totals out of `data`, matching
+                # the full-skip path above which also leaves them unset.
+                verbose_proxy_logger.debug(
+                    "Batch model-access validation passed; batch input file rate limiting disabled"
+                )
+                return data
 
             verbose_proxy_logger.debug(
                 "Batch input file usage - Tokens: %s, Requests: %s", batch_usage.total_tokens, batch_usage.request_count

--- a/litellm/proxy/pass_through_endpoints/managed_id_rewriter.py
+++ b/litellm/proxy/pass_through_endpoints/managed_id_rewriter.py
@@ -821,10 +821,6 @@ async def rewrite_response_ids(
     return mutated if changed else body
 
 
-# ---------------------------------------------------------------------------
-# OUTPUT path — streamed Responses API bodies
-# ---------------------------------------------------------------------------
-
 _RESPONSE_ID_PREFIX: Final = "resp_"
 _STREAMED_RESPONSE_ID_SPEC: Final[_FieldSpec] = ("id", _RESPONSE_ID_PREFIX)
 _SSE_DATA_PREFIX: Final = "data:"

--- a/litellm/proxy/pass_through_endpoints/managed_id_rewriter.py
+++ b/litellm/proxy/pass_through_endpoints/managed_id_rewriter.py
@@ -32,7 +32,7 @@ from __future__ import annotations
 
 import json
 import re
-from collections.abc import Callable, Mapping, Sequence
+from collections.abc import AsyncGenerator, Callable, Mapping, Sequence
 from typing import (
     TYPE_CHECKING,
     Final,
@@ -43,7 +43,7 @@ from typing import (
 from urllib.parse import quote, unquote
 
 from fastapi import HTTPException
-from pydantic import JsonValue
+from pydantic import JsonValue, TypeAdapter, ValidationError
 
 from litellm._logging import verbose_proxy_logger
 from litellm.llms.base_llm.managed_resources.isolation import (
@@ -52,6 +52,7 @@ from litellm.llms.base_llm.managed_resources.isolation import (
 )
 from litellm.proxy._types import UserAPIKeyAuth
 from litellm.proxy.batches_endpoints.common_utils import validate_batch_list_limit
+from litellm.proxy.common_utils.sse_keepalive import split_complete_sse_frames
 from litellm.repositories.table_repositories import (
     ManagedFileRepository,
     ManagedObjectRepository,
@@ -818,6 +819,125 @@ async def rewrite_response_ids(
         canonical,
     )
     return mutated if changed else body
+
+
+# ---------------------------------------------------------------------------
+# OUTPUT path — streamed Responses API bodies
+# ---------------------------------------------------------------------------
+
+_RESPONSE_ID_PREFIX: Final = "resp_"
+_STREAMED_RESPONSE_ID_SPEC: Final[_FieldSpec] = ("id", _RESPONSE_ID_PREFIX)
+_SSE_DATA_PREFIX: Final = "data:"
+_SSE_EVENT_ADAPTER: Final = TypeAdapter(Mapping[str, JsonValue])
+
+
+def _first_streamed_response(frames: bytes) -> tuple[str, Mapping[str, JsonValue]] | None:
+    for line in frames.decode("utf-8", errors="replace").splitlines():
+        if not line.startswith(_SSE_DATA_PREFIX):
+            continue
+        try:
+            event = _SSE_EVENT_ADAPTER.validate_json(line[len(_SSE_DATA_PREFIX) :])
+        except ValidationError:
+            continue
+        response = event.get("response")
+        if not isinstance(response, dict):
+            continue
+        raw_id = response.get("id")
+        if isinstance(raw_id, str) and raw_id.startswith(_RESPONSE_ID_PREFIX):
+            return raw_id, response
+    return None
+
+
+class _StreamedResponseIdRewriter:
+    __slots__ = ("_is_create_route", "_pending", "_prisma_client", "_provider", "_replacement", "_user_api_key_dict")
+
+    def __init__(
+        self,
+        provider: str,
+        user_api_key_dict: UserAPIKeyAuth,
+        prisma_client: PrismaClient,
+        is_create_route: bool,
+    ) -> None:
+        self._provider: Final = provider
+        self._user_api_key_dict: Final = user_api_key_dict
+        self._prisma_client: Final = prisma_client
+        self._is_create_route: Final = is_create_route
+        self._pending = b""
+        self._replacement: tuple[bytes, bytes] | None = None
+
+    async def feed(self, chunk: bytes) -> bytes:
+        complete_frames, self._pending = split_complete_sse_frames(self._pending + chunk)
+        if not complete_frames:
+            return b""
+        if self._replacement is None:
+            self._replacement = await self._mint(complete_frames)
+        return self._rewrite(complete_frames)
+
+    def flush(self) -> bytes:
+        tail: Final = self._pending
+        self._pending = b""
+        return self._rewrite(tail)
+
+    async def _mint(self, frames: bytes) -> tuple[bytes, bytes] | None:
+        first: Final = _first_streamed_response(frames)
+        if first is None:
+            return None
+        raw_id, snapshot = first
+        managed_id: Final = await _mint_or_reuse_object(
+            raw_id,
+            self._provider,
+            "response",
+            snapshot,
+            self._user_api_key_dict,
+            self._prisma_client,
+            self._is_create_route,
+        )
+        return raw_id.encode(), managed_id.encode()
+
+    def _rewrite(self, frames: bytes) -> bytes:
+        if self._replacement is None:
+            return frames
+        raw_id, managed_id = self._replacement
+        return frames.replace(raw_id, managed_id)
+
+
+async def rewrite_streamed_response_ids(
+    stream: AsyncGenerator[bytes, None],
+    provider: str,
+    method: str,
+    route: str,
+    user_api_key_dict: UserAPIKeyAuth,
+    prisma_client: PrismaClient,
+) -> AsyncGenerator[bytes, None]:
+    """
+    Record ownership of the response object streamed back by a Responses API
+    passthrough and swap its managed id into every SSE frame, so a streamed
+    response is owned and resolved exactly like a non-streamed one.
+
+    Streams for any other ``(provider, method, route)`` are relayed untouched.
+    """
+    from litellm.proxy.auth.auth_utils import normalize_request_route
+
+    canonical: Final = normalize_request_route(_canonical_path(route))
+    field_specs: Final = BUILTIN_OUTPUT_ID_FIELD_MAP.get((provider, method, canonical), ())
+    if _STREAMED_RESPONSE_ID_SPEC not in field_specs:
+        async for chunk in stream:
+            yield chunk
+        return
+
+    rewriter: Final = _StreamedResponseIdRewriter(
+        provider=provider,
+        user_api_key_dict=user_api_key_dict,
+        prisma_client=prisma_client,
+        is_create_route="{" not in canonical,
+    )
+    async for chunk in stream:
+        rewritten_frames = await rewriter.feed(chunk)
+        if rewritten_frames:
+            yield rewritten_frames
+    tail: Final = rewriter.flush()
+    if tail:
+        yield tail
 
 
 # ---------------------------------------------------------------------------

--- a/litellm/proxy/pass_through_endpoints/pass_through_endpoints.py
+++ b/litellm/proxy/pass_through_endpoints/pass_through_endpoints.py
@@ -1209,14 +1209,19 @@ async def pass_through_request(
 
             return StreamingResponse(
                 wrap_passthrough_sse_bytes_with_keepalive_pings(
-                    stream=PassThroughStreamingHandler.chunk_processor(
-                        response=response,
-                        request_body=_parsed_body,
-                        litellm_logging_obj=logging_obj,
-                        endpoint_type=endpoint_type,
-                        start_time=start_time,
-                        passthrough_success_handler_obj=pass_through_endpoint_logging,
-                        url_route=str(url),
+                    stream=_own_streamed_managed_ids(
+                        stream=PassThroughStreamingHandler.chunk_processor(
+                            response=response,
+                            request_body=_parsed_body,
+                            litellm_logging_obj=logging_obj,
+                            endpoint_type=endpoint_type,
+                            start_time=start_time,
+                            passthrough_success_handler_obj=pass_through_endpoint_logging,
+                            url_route=str(url),
+                        ),
+                        managed_id_provider=_managed_id_provider,
+                        request=request,
+                        user_api_key_dict=user_api_key_dict,
                     ),
                     ping_interval_seconds=litellm.sse_keepalive_ping_interval_seconds,
                     upstream_headers=response.headers,
@@ -1285,14 +1290,19 @@ async def pass_through_request(
 
             return StreamingResponse(
                 wrap_passthrough_sse_bytes_with_keepalive_pings(
-                    stream=PassThroughStreamingHandler.chunk_processor(
-                        response=response,
-                        request_body=_parsed_body,
-                        litellm_logging_obj=logging_obj,
-                        endpoint_type=endpoint_type,
-                        start_time=start_time,
-                        passthrough_success_handler_obj=pass_through_endpoint_logging,
-                        url_route=str(url),
+                    stream=_own_streamed_managed_ids(
+                        stream=PassThroughStreamingHandler.chunk_processor(
+                            response=response,
+                            request_body=_parsed_body,
+                            litellm_logging_obj=logging_obj,
+                            endpoint_type=endpoint_type,
+                            start_time=start_time,
+                            passthrough_success_handler_obj=pass_through_endpoint_logging,
+                            url_route=str(url),
+                        ),
+                        managed_id_provider=_managed_id_provider,
+                        request=request,
+                        user_api_key_dict=user_api_key_dict,
                     ),
                     ping_interval_seconds=litellm.sse_keepalive_ping_interval_seconds,
                     upstream_headers=response.headers,
@@ -2439,6 +2449,36 @@ def _is_streaming_response(response: httpx.Response) -> bool:
     if _content_type is not None and "text/event-stream" in _content_type:
         return True
     return False
+
+
+def _own_streamed_managed_ids(
+    stream: AsyncGenerator[bytes, None],
+    managed_id_provider: str | None,
+    request: Request,
+    user_api_key_dict: UserAPIKeyAuth,
+) -> AsyncGenerator[bytes, None]:
+    from litellm.proxy.proxy_server import general_settings, prisma_client, proxy_logging_obj
+
+    if (
+        managed_id_provider is None
+        or not general_settings.get("passthrough_managed_object_ids", False)
+        or prisma_client is None
+        or proxy_logging_obj.get_proxy_hook("managed_files") is None
+    ):
+        return stream
+    from litellm.proxy.auth.auth_utils import get_request_route
+    from litellm.proxy.pass_through_endpoints.managed_id_rewriter import (
+        rewrite_streamed_response_ids,
+    )
+
+    return rewrite_streamed_response_ids(
+        stream=stream,
+        provider=managed_id_provider,
+        method=request.method,
+        route=get_request_route(request),
+        user_api_key_dict=user_api_key_dict,
+        prisma_client=prisma_client,
+    )
 
 
 def _should_buffer_passthrough_response(response: httpx.Response) -> bool:

--- a/litellm/proxy/pass_through_endpoints/streaming_handler.py
+++ b/litellm/proxy/pass_through_endpoints/streaming_handler.py
@@ -10,6 +10,7 @@ from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLogging
 from litellm.litellm_core_utils.logging_worker import GLOBAL_LOGGING_WORKER
 from litellm.proxy._types import PassThroughEndpointLoggingResultValues
 from litellm.proxy.common_request_processing import ProxyBaseLLMRequestProcessing
+from litellm.proxy.common_utils.sse_keepalive import split_complete_sse_frames
 from litellm.types.passthrough_endpoints.pass_through_endpoints import EndpointType
 from litellm.types.utils import StandardPassThroughResponseObject
 
@@ -101,7 +102,7 @@ class PassThroughStreamingHandler:
                 async for chunk in response.aiter_bytes():
                     raw_bytes.append(chunk)
                     PassThroughStreamingHandler._stamp_first_chunk_if_needed(litellm_logging_obj)
-                    complete_frames, pending = PassThroughStreamingHandler._split_complete_sse_frames(
+                    complete_frames, pending = split_complete_sse_frames(
                         pending + chunk
                     )  # rebind-ok: SSE frame reassembly buffer across transport chunks
                     if complete_frames:
@@ -138,17 +139,6 @@ class PassThroughStreamingHandler:
                     )
                 except Exception as e:
                     verbose_proxy_logger.error("Error scheduling chunk_processor logging: %s", e)
-
-    @staticmethod
-    def _split_complete_sse_frames(pending: bytes) -> tuple[bytes, bytes]:
-        lf_boundary_end: Final = pending.rfind(b"\n\n") + 2
-        crlf_boundary_end: Final = pending.rfind(b"\r\n\r\n") + 4
-        boundary_end: Final = max(
-            lf_boundary_end if lf_boundary_end >= 2 else 0, crlf_boundary_end if crlf_boundary_end >= 4 else 0
-        )
-        if boundary_end == 0:
-            return b"", pending
-        return pending[:boundary_end], pending[boundary_end:]
 
     @staticmethod
     async def _route_streaming_logging_to_handler(

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -4869,6 +4869,14 @@ class ProxyConfig:
         if litellm_settings is None:
             litellm_settings = {}
         if litellm_settings:
+            # Prometheus collectors have fixed label schemas. Load and validate this
+            # setting before processing callbacks so YAML key order cannot construct
+            # the collectors with the default caller-identity mode, and so an invalid
+            # value fails the boot instead of being swallowed by callback init.
+            from litellm.types.integrations.prometheus import validate_caller_identity_settings
+
+            validate_caller_identity_settings(litellm_settings)
+
             # ANSI escape code for blue text
             blue_color_code: Final = "\033[94m"
             reset_color_code: Final = "\033[0m"

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -7344,7 +7344,7 @@ class Router:
             ):
                 raise error  # then raise the error
 
-        if isinstance(error, openai.AuthenticationError):
+        if isinstance(error, (openai.AuthenticationError, openai.PermissionDeniedError)):
             """
             - if other deployments available -> retry
             - else -> raise error

--- a/litellm/types/integrations/prometheus.py
+++ b/litellm/types/integrations/prometheus.py
@@ -1,5 +1,5 @@
 import re
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 from dataclasses import MISSING, dataclass, field, fields
 from enum import Enum
 from types import MappingProxyType
@@ -92,7 +92,20 @@ class LabelValidationError:
 
     @property
     def message(self) -> str:
-        return f"Invalid labels for metric '{self.metric_name}': {self.invalid_labels}"
+        base_message: Final = f"Invalid labels for metric '{self.metric_name}': {self.invalid_labels}"
+        if self.metric_name in PROMETHEUS_DEPLOYMENT_AND_LATENCY_CALLER_IDENTITY_METRICS and any(
+            label in ("api_key_alias", "user_email") for label in self.invalid_labels
+        ):
+            mode: Final[object] = getattr(
+                litellm,
+                "prometheus_deployment_and_latency_caller_identity",
+                "api_key_alias",
+            )
+            return (
+                f"{base_message} (the caller-identity label on this metric is set by "
+                f"prometheus_deployment_and_latency_caller_identity={mode!r})"
+            )
+        return base_message
 
 
 @dataclass
@@ -274,6 +287,94 @@ DEFINED_PROMETHEUS_METRICS = Literal[
     "litellm_mcp_tool_calls_total",
     "litellm_mcp_tool_call_spend_metric",
 ]
+
+
+PROMETHEUS_DEPLOYMENT_AND_LATENCY_CALLER_IDENTITY_METRICS: Final[frozenset[str]] = frozenset(
+    {
+        "litellm_deployment_total_requests",
+        "litellm_deployment_success_responses",
+        "litellm_deployment_failure_responses",
+        "litellm_request_total_latency_metric",
+        "litellm_llm_api_latency_metric",
+        "litellm_llm_api_time_to_first_token_metric",
+        "litellm_request_queue_time_seconds",
+        "litellm_overhead_latency_metric",
+        "litellm_deployment_latency_per_output_token",
+    }
+)
+
+PROMETHEUS_DEPLOYMENT_AND_LATENCY_CALLER_IDENTITY_VALUES: Final[tuple[str, ...]] = (
+    "api_key_alias",
+    "user_email",
+    "both",
+)
+
+
+def validate_prometheus_deployment_and_latency_caller_identity() -> str:
+    """Return the configured caller-identity mode, raising on an invalid value."""
+    caller_identity: Final[object] = getattr(
+        litellm,
+        "prometheus_deployment_and_latency_caller_identity",
+        "api_key_alias",
+    )
+    if isinstance(caller_identity, str) and caller_identity in PROMETHEUS_DEPLOYMENT_AND_LATENCY_CALLER_IDENTITY_VALUES:
+        return caller_identity
+    accepted_values: Final = ", ".join(PROMETHEUS_DEPLOYMENT_AND_LATENCY_CALLER_IDENTITY_VALUES)
+    raise ValueError(
+        "Invalid prometheus_deployment_and_latency_caller_identity="
+        f"{caller_identity!r}. Accepted values: {accepted_values}."
+    )
+
+
+def validate_caller_identity_settings(litellm_settings: Mapping[str, Any]) -> None:
+    """Store the caller-identity mode from litellm_settings and validate it together
+    with prometheus_metrics_config, raising on an invalid value or on include_labels
+    that request a label the selected mode removes."""
+    if "prometheus_deployment_and_latency_caller_identity" not in litellm_settings:
+        return
+    litellm.prometheus_deployment_and_latency_caller_identity = litellm_settings[
+        "prometheus_deployment_and_latency_caller_identity"
+    ]
+    caller_identity_mode: Final = validate_prometheus_deployment_and_latency_caller_identity()
+    if caller_identity_mode != "user_email":
+        return
+    conflicting_metrics: Final = tuple(
+        metric_name
+        for metric_config in (litellm_settings.get("prometheus_metrics_config") or ())
+        if isinstance(metric_config, dict) and "api_key_alias" in (metric_config.get("include_labels") or ())
+        for metric_name in (metric_config.get("metrics") or ())
+        if metric_name in PROMETHEUS_DEPLOYMENT_AND_LATENCY_CALLER_IDENTITY_METRICS
+    )
+    if conflicting_metrics:
+        conflicting_names: Final = ", ".join(conflicting_metrics)
+        raise ValueError(
+            "prometheus_metrics_config include_labels contains 'api_key_alias' for "
+            f"{conflicting_names}, but prometheus_deployment_and_latency_caller_identity="
+            "'user_email' replaces that label on these metrics. Use 'user_email' in "
+            "include_labels or change the mode."
+        )
+
+
+def _resolve_deployment_and_latency_caller_identity_labels(
+    metric_name: str,
+    labels: Sequence[object],
+) -> list[str]:  # mutable-ok: every caller must receive an independently mutable label list
+    """Return a fresh label list with the configured caller identity schema."""
+    if not all(isinstance(label, str) for label in labels):
+        raise TypeError(f"Prometheus labels for {metric_name} must be strings")
+    resolved_labels: Final = [label for label in labels if isinstance(label, str)]
+    if metric_name not in PROMETHEUS_DEPLOYMENT_AND_LATENCY_CALLER_IDENTITY_METRICS:
+        return resolved_labels
+
+    caller_identity: Final = validate_prometheus_deployment_and_latency_caller_identity()
+
+    alias_index: Final = resolved_labels.index(UserAPIKeyLabelNames.API_KEY_ALIAS.value)
+    if caller_identity == "user_email":
+        resolved_labels[alias_index] = UserAPIKeyLabelNames.USER_EMAIL.value
+    elif caller_identity == "both":
+        resolved_labels.insert(alias_index + 1, UserAPIKeyLabelNames.USER_EMAIL.value)
+
+    return resolved_labels
 
 
 class PrometheusMetricLabels:
@@ -781,7 +882,10 @@ class PrometheusMetricLabels:
 
     @staticmethod
     def get_labels(label_name: DEFINED_PROMETHEUS_METRICS) -> list[str]:
-        default_labels: Final = getattr(PrometheusMetricLabels, label_name)
+        default_labels: Final = _resolve_deployment_and_latency_caller_identity_labels(
+            metric_name=label_name,
+            labels=getattr(PrometheusMetricLabels, label_name),
+        )
         custom_labels: Final = []
 
         # Add custom metadata labels

--- a/tests/e2e/llm_translation/test_together_ai_e2e.py
+++ b/tests/e2e/llm_translation/test_together_ai_e2e.py
@@ -5,14 +5,19 @@ in the proxy's own cost map that carries both capability flags. Two backends are
 pinned because the registry has no flag for what they prove: ``enable_thinking`` is a
 Qwen chat-template contract, and MiniMax-M3 is the serverless model whose template
 renders a replayed ``reasoning_content`` back into the prompt (Qwen and DeepSeek
-silently drop it). Requires TOGETHER_API_KEY on the proxy; no skip gate.
+silently drop it). MiniMax-M3 honors that replayed field on nearly every call, not
+every call (one miss in dozens of otherwise identical calls), so the replay case asks
+up to ``REPLAY_ATTEMPTS`` times and fails only when no answer carries the secret, which
+a proxy that strips the field guarantees. Requires TOGETHER_API_KEY on the proxy; no
+skip gate.
 """
 
 from __future__ import annotations
 
-from collections.abc import Mapping
+from collections.abc import Iterator, Mapping
 from dataclasses import dataclass
 from datetime import date
+from typing import Final
 
 import pytest
 from e2e_config import unique_marker
@@ -51,6 +56,7 @@ REASONING_REPLAY_BACKEND = "together_ai/MiniMaxAI/MiniMax-M3"
 SECRET_PROMPT = "Remember this for later and reply with just OK."
 SECRET_REASONING = "The user told me their favorite color is chartreuse. I must remember it."
 SECRET_QUESTION = "What is my favorite color? Answer with one word."
+REPLAY_ATTEMPTS: Final = 3
 
 ARITHMETIC_PROMPT = "What is 17 + 26? Answer with just the number."
 WEATHER_PROMPT = "What is the weather in Paris? Use the tool."
@@ -177,6 +183,18 @@ def _message(response: ChatResponse) -> OutMessage:
     message = response.choices[0].message
     assert message is not None, f"Together choice has no message: {response}"
     return message
+
+
+def _carries_secret(answer: OutMessage) -> bool:
+    return answer.content is not None and "chartreuse" in answer.content.lower()
+
+
+def _answers_until_secret(client: PassthroughClient, key: str, body: ChatBody) -> Iterator[OutMessage]:
+    answers: Final = (_message(unwrap(client.proxy.chat(key, body))) for _ in range(REPLAY_ATTEMPTS))
+    for answer in answers:
+        yield answer
+        if _carries_secret(answer):
+            return
 
 
 def _deltas(result: StreamingResponse) -> list[_StreamDelta]:
@@ -376,25 +394,19 @@ class TestTogetherChatCompletions:
         self, client: PassthroughClient, resources: ResourceManager
     ) -> None:
         model, key = _register(client, resources, REASONING_REPLAY_BACKEND)
-
-        answer = _message(
-            unwrap(
-                client.proxy.chat(
-                    key,
-                    ChatBody(
-                        model=model,
-                        messages=[
-                            ChatMessage(role="user", content=SECRET_PROMPT),
-                            ChatAssistantTurn(content="OK.", reasoning_content=SECRET_REASONING),
-                            ChatMessage(role="user", content=SECRET_QUESTION),
-                        ],
-                        max_tokens=512,
-                    ),
-                )
-            )
+        body: Final = ChatBody(
+            model=model,
+            messages=[
+                ChatMessage(role="user", content=SECRET_PROMPT),
+                ChatAssistantTurn(content="OK.", reasoning_content=SECRET_REASONING),
+                ChatMessage(role="user", content=SECRET_QUESTION),
+            ],
+            max_tokens=512,
         )
-        assert answer.content and "chartreuse" in answer.content.lower(), (
-            f"the replayed reasoning_content never reached Together: {answer}"
+
+        answers: Final = tuple(_answers_until_secret(client, key, body))
+        assert any(_carries_secret(answer) for answer in answers), (
+            f"the replayed reasoning_content never reached Together in {len(answers)} attempts: {answers}"
         )
 
     @pytest.mark.covers("llm.chat_completions.together_ai.basic.nonstream.cost_logged")

--- a/tests/e2e/logging/test_otel_trace_e2e.py
+++ b/tests/e2e/logging/test_otel_trace_e2e.py
@@ -743,3 +743,61 @@ class TestOtelTraceCompleteness:
         )
         genai = next(span for span in hits[0].spans if span.operation_name == genai_span)
         _assert_error_span_contract(genai)
+
+    @pytest.mark.covers("logging.otel.failure.exports_metric", exercised_on=["messages"])
+    def test_failed_messages_error_span_attributes(
+        self, client: LoggingClient, otel_reader: OtelReader, resources: ResourceManager
+    ) -> None:
+        """A failed `/v1/messages` request must carry the same error-span
+        contract as a failed `/chat/completions` request (LIT-6164). The
+        async messages entrypoint used to surface the provider handler's raw
+        BaseLLMException to the failure logger, so the model-call span came
+        out with error.type=BaseLLMException and no
+        litellm.provider.error.llm_provider attribute.
+
+        Same setup as the chat sibling: a deployment with an invalid upstream
+        API key passes proxy auth and fails at the provider with a real 401,
+        and failed requests are not billed, so no cost-write span."""
+        route = "/v1/messages"
+        _assert_otel_destination_configured(client)
+
+        model_name = f"otel-err-{unique_marker()}"
+        model_id = client.create_model(
+            model_name,
+            LiteLLMParamsBody(model="anthropic/claude-haiku-4-5", api_key=INVALID_UPSTREAM_API_KEY),
+        )
+        resources.defer(lambda: client.delete_model(model_id))
+        key = client.key_with_alias(f"otel-err-{unique_marker()}", models=[model_name])
+        resources.defer(lambda: client.delete_key(key))
+
+        deadline = time.monotonic() + client.proxy.poll_timeout
+        while True:
+            outcome = client.messages_raw(key, model_name, "trigger an upstream auth failure", max_tokens=16)
+            assert not outcome.ok, "the call must fail; the deployment's upstream key is invalid"
+            if "AnthropicException" in outcome.body or time.monotonic() >= deadline:
+                break
+            time.sleep(client.proxy.poll_interval)
+        assert "AnthropicException" in outcome.body, (
+            "never saw the mapped upstream provider failure before the deadline; either the key is "
+            "still propagating or the messages route surfaced the raw unmapped provider error - "
+            f"last outcome {outcome.status_code}: {outcome.body[:200]}"
+        )
+        assert outcome.status_code == 401, (
+            f"an upstream auth failure must map to 401, got {outcome.status_code}: {outcome.body[:200]}"
+        )
+        assert outcome.call_id is not None, "failed responses must still carry x-litellm-call-id"
+
+        genai_span = f"chat {model_name}"
+        hits = otel_reader.poll_traces_for_call(
+            call_id=outcome.call_id,
+            settled_names=_settled_names(route=route, genai_span=genai_span, require_cost_span=False),
+            settled_prefixes={DB_SPAN_PREFIX},
+        )
+        _assert_complete_trace(hits, route=route, genai_span=genai_span, require_cost_span=False)
+
+        root = next(span for span in hits[0].spans if not span.references)
+        assert str(_tag(root, "http.status_code")) == "401", (
+            f"the SERVER span must record the 401 the client received, got {_tag(root, 'http.status_code')!r}"
+        )
+        genai = next(span for span in hits[0].spans if span.operation_name == genai_span)
+        _assert_error_span_contract(genai)

--- a/tests/test_litellm/integrations/test_prometheus_caller_identity.py
+++ b/tests/test_litellm/integrations/test_prometheus_caller_identity.py
@@ -1,0 +1,411 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import Final, cast
+from unittest.mock import patch
+
+import pytest
+import yaml
+from prometheus_client import REGISTRY, generate_latest
+from prometheus_client.parser import text_string_to_metric_families
+
+import litellm
+from litellm.integrations.prometheus import PrometheusLogger
+from litellm.proxy._types import UserAPIKeyAuth
+from litellm.types.integrations.prometheus import (
+    DEFINED_PROMETHEUS_METRICS,
+    PROMETHEUS_DEPLOYMENT_AND_LATENCY_CALLER_IDENTITY_METRICS,
+    PrometheusMetricLabels,
+    UserAPIKeyLabelNames,
+    UserAPIKeyLabelValues,
+)
+from litellm.types.utils import StandardLoggingPayload
+
+TARGET_METRICS: Final[tuple[DEFINED_PROMETHEUS_METRICS, ...]] = cast(
+    tuple[DEFINED_PROMETHEUS_METRICS, ...],
+    tuple(sorted(PROMETHEUS_DEPLOYMENT_AND_LATENCY_CALLER_IDENTITY_METRICS)),
+)
+IDENTITY_MODES: Final = ("api_key_alias", "user_email", "both")
+
+
+def _clear_prometheus_registry() -> None:
+    for collector in list(REGISTRY._collector_to_names):  # pyright: ignore[reportPrivateUsage]
+        REGISTRY.unregister(collector)
+
+
+@pytest.fixture(autouse=True)
+def reset_prometheus_settings(monkeypatch: pytest.MonkeyPatch):
+    _clear_prometheus_registry()
+    monkeypatch.setattr(litellm, "prometheus_deployment_and_latency_caller_identity", "api_key_alias")
+    monkeypatch.setattr(litellm, "prometheus_metrics_config", None)
+    monkeypatch.setattr(litellm, "prometheus_exclude_metrics", None)
+    monkeypatch.setattr(litellm, "prometheus_exclude_labels", None)
+    monkeypatch.setattr(litellm, "custom_prometheus_metadata_labels", [])
+    monkeypatch.setattr(litellm, "custom_prometheus_tags", [])
+    yield
+    _clear_prometheus_registry()
+
+
+def _expected_identity_labels(baseline: list[str], mode: str) -> list[str]:
+    expected = list(baseline)
+    alias_index = expected.index(UserAPIKeyLabelNames.API_KEY_ALIAS.value)
+    if mode == "user_email":
+        expected[alias_index] = UserAPIKeyLabelNames.USER_EMAIL.value
+    elif mode == "both":
+        expected.insert(alias_index + 1, UserAPIKeyLabelNames.USER_EMAIL.value)
+    return expected
+
+
+def _set_caller_identity(monkeypatch: pytest.MonkeyPatch, mode: str) -> None:
+    monkeypatch.setattr(litellm, "prometheus_deployment_and_latency_caller_identity", mode)
+
+
+@pytest.mark.parametrize("metric_name", TARGET_METRICS)
+@pytest.mark.parametrize("mode", IDENTITY_MODES)
+def test_target_metric_label_schema_for_each_caller_identity_mode(
+    monkeypatch: pytest.MonkeyPatch,
+    metric_name: DEFINED_PROMETHEUS_METRICS,
+    mode: str,
+):
+    _set_caller_identity(monkeypatch, "api_key_alias")
+    baseline = PrometheusMetricLabels.get_labels(metric_name)
+
+    _set_caller_identity(monkeypatch, mode)
+    actual = PrometheusMetricLabels.get_labels(metric_name)
+
+    assert actual == _expected_identity_labels(baseline, mode)
+
+
+def test_repeated_label_resolution_does_not_mutate_class_level_or_shared_lists(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    total_request_labels = PrometheusMetricLabels.litellm_deployment_total_requests
+    success_labels = PrometheusMetricLabels.litellm_deployment_success_responses
+    original = tuple(total_request_labels)
+
+    assert success_labels is total_request_labels
+    for mode in (*IDENTITY_MODES, *reversed(IDENTITY_MODES)):
+        _set_caller_identity(monkeypatch, mode)
+        for metric_name in TARGET_METRICS:
+            resolved = PrometheusMetricLabels.get_labels(metric_name)
+            assert resolved is not getattr(PrometheusMetricLabels, metric_name)
+
+    assert PrometheusMetricLabels.litellm_deployment_total_requests is total_request_labels
+    assert PrometheusMetricLabels.litellm_deployment_success_responses is success_labels
+    assert success_labels is total_request_labels
+    assert tuple(total_request_labels) == original
+
+
+def test_invalid_caller_identity_mode_fails_during_prometheus_initialization(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    _set_caller_identity(monkeypatch, "invalid")
+
+    with pytest.raises(
+        ValueError,
+        match="prometheus_deployment_and_latency_caller_identity",
+    ) as exc_info:
+        PrometheusLogger()
+
+    message = str(exc_info.value)
+    assert "prometheus_deployment_and_latency_caller_identity" in message
+    for accepted_value in IDENTITY_MODES:
+        assert accepted_value in message
+
+
+def test_label_resolution_rejects_non_string_class_labels(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(
+        PrometheusMetricLabels,
+        "litellm_deployment_total_requests",
+        ["api_key_alias", 1],
+    )
+
+    with pytest.raises(TypeError, match=r"Prometheus labels .* must be strings"):
+        PrometheusMetricLabels.get_labels("litellm_deployment_total_requests")
+
+
+@pytest.mark.parametrize(
+    ("mode", "include_labels", "is_valid"),
+    (
+        ("api_key_alias", ["api_key_alias"], True),
+        ("api_key_alias", ["user_email"], False),
+        ("user_email", ["user_email"], True),
+        ("user_email", ["api_key_alias"], False),
+        ("both", ["api_key_alias"], True),
+        ("both", ["user_email"], True),
+        ("both", ["api_key_alias", "user_email"], True),
+    ),
+)
+def test_include_labels_validation_matches_caller_identity_mode(
+    monkeypatch: pytest.MonkeyPatch,
+    mode: str,
+    include_labels: list[str],
+    is_valid: bool,
+):
+    _set_caller_identity(monkeypatch, mode)
+    monkeypatch.setattr(
+        litellm,
+        "prometheus_metrics_config",
+        [
+            {
+                "group": "caller_identity",
+                "metrics": ["litellm_deployment_total_requests"],
+                "include_labels": include_labels,
+            }
+        ],
+    )
+
+    if not is_valid:
+        with pytest.raises(ValueError, match="Configuration validation failed"):
+            PrometheusLogger()
+        return
+
+    logger = PrometheusLogger()
+    assert logger.get_labels_for_metric("litellm_deployment_total_requests") == include_labels
+
+
+@pytest.mark.parametrize(
+    ("mode", "exclude_labels", "remaining_identity_labels"),
+    (
+        ("api_key_alias", ["api_key_alias"], set[str]()),
+        ("api_key_alias", ["user_email"], {"api_key_alias"}),
+        ("user_email", ["user_email"], set[str]()),
+        ("user_email", ["api_key_alias"], {"user_email"}),
+        ("both", ["api_key_alias"], {"user_email"}),
+        ("both", ["user_email"], {"api_key_alias"}),
+        ("both", ["api_key_alias", "user_email"], set[str]()),
+    ),
+)
+def test_exclude_labels_can_remove_supported_identity_labels(
+    monkeypatch: pytest.MonkeyPatch,
+    mode: str,
+    exclude_labels: list[str],
+    remaining_identity_labels: set[str],
+):
+    _set_caller_identity(monkeypatch, mode)
+    monkeypatch.setattr(litellm, "prometheus_exclude_labels", exclude_labels)
+
+    logger = PrometheusLogger()
+    labels = logger.get_labels_for_metric("litellm_deployment_total_requests")
+
+    assert set(labels) & {"api_key_alias", "user_email"} == remaining_identity_labels
+
+
+@pytest.mark.parametrize("mode", IDENTITY_MODES)
+def test_non_target_metric_label_schema_is_unchanged(monkeypatch: pytest.MonkeyPatch, mode: str):
+    baseline = list(PrometheusMetricLabels.litellm_overhead_with_guardrails_latency_metric)
+    _set_caller_identity(monkeypatch, mode)
+
+    actual = PrometheusMetricLabels.get_labels("litellm_overhead_with_guardrails_latency_metric")
+
+    assert actual == baseline
+    assert "api_key_alias" in actual
+    assert "user_email" not in actual
+
+
+def _standard_logging_payload(user_email: str | None = "alice@example.com") -> StandardLoggingPayload:
+    return cast(
+        StandardLoggingPayload,
+        {
+            "api_base": "https://api.example.com",
+            "model_group": "requested-model",
+            "model_id": "deployment-id",
+            "request_tags": [],
+            "metadata": {
+                "user_api_key_hash": "hashed-key",
+                "user_api_key_alias": "alias-a",
+                "user_api_key_user_email": user_email,
+                "user_api_key_team_id": "team-id",
+                "user_api_key_team_alias": "team-alias",
+                "requester_ip_address": "192.0.2.10",
+                "user_agent": "caller-identity-test",
+            },
+            "hidden_params": {
+                "additional_headers": None,
+                "litellm_overhead_time_ms": 125,
+            },
+        },
+    )
+
+
+def _sample_labels(scrape: str, sample_name: str) -> list[dict[str, str]]:
+    return [
+        sample.labels
+        for family in text_string_to_metric_families(scrape)
+        for sample in family.samples
+        if sample.name == sample_name
+    ]
+
+
+@pytest.mark.parametrize("mode", IDENTITY_MODES)
+def test_successful_request_emits_configured_identity_on_real_counter_and_histogram_samples(
+    monkeypatch: pytest.MonkeyPatch,
+    mode: str,
+):
+    _set_caller_identity(monkeypatch, mode)
+    logger = PrometheusLogger()
+    payload = _standard_logging_payload()
+    enum_values = UserAPIKeyLabelValues(
+        end_user="end-user",
+        user="user-id",
+        user_email="alice@example.com",
+        hashed_api_key="hashed-key",
+        api_key_alias="alias-a",
+        requested_model="requested-model",
+        model_group="requested-model",
+        team="team-id",
+        team_alias="team-alias",
+        model="provider-model",
+        litellm_model_name="deployment-model",
+        model_id="deployment-id",
+        api_base="https://api.example.com",
+        api_provider="openai",
+        client_ip="192.0.2.10",
+        user_agent="caller-identity-test",
+    )
+    start_time = datetime.now()
+    api_call_start_time = start_time + timedelta(milliseconds=100)
+    completion_start_time = api_call_start_time + timedelta(milliseconds=200)
+    end_time = start_time + timedelta(seconds=1)
+    request_kwargs = {
+        "model": "deployment-model",
+        "stream": True,
+        "start_time": start_time,
+        "api_call_start_time": api_call_start_time,
+        "completion_start_time": completion_start_time,
+        "end_time": end_time,
+        "litellm_params": {
+            "custom_llm_provider": "openai",
+            "metadata": {
+                "model_info": {"id": "deployment-id"},
+                "queue_time_seconds": 0.05,
+            },
+        },
+        "standard_logging_object": payload,
+    }
+
+    logger._set_latency_metrics(  # pyright: ignore[reportPrivateUsage, reportUnknownMemberType]
+        kwargs=request_kwargs,
+        model="deployment-model",
+        user_api_key="hashed-key",
+        user_api_key_alias="alias-a",
+        user_api_team="team-id",
+        user_api_team_alias="team-alias",
+        enum_values=enum_values,
+    )
+    logger.set_llm_deployment_success_metrics(  # pyright: ignore[reportUnknownMemberType]
+        request_kwargs=request_kwargs,
+        start_time=start_time,
+        end_time=end_time,
+        enum_values=enum_values,
+        output_tokens=10,
+    )
+
+    scrape = generate_latest(REGISTRY).decode()
+    sample_names = (
+        "litellm_deployment_total_requests_total",
+        "litellm_deployment_success_responses_total",
+        "litellm_request_total_latency_metric_count",
+        "litellm_llm_api_latency_metric_count",
+        "litellm_llm_api_time_to_first_token_metric_count",
+        "litellm_request_queue_time_seconds_count",
+        "litellm_overhead_latency_metric_count",
+        "litellm_deployment_latency_per_output_token_count",
+    )
+    for sample_name in sample_names:
+        samples = _sample_labels(scrape, sample_name)
+        assert len(samples) == 1, sample_name
+        labels = samples[0]
+        if mode == "api_key_alias":
+            assert labels["api_key_alias"] == "alias-a"
+            assert "user_email" not in labels
+        elif mode == "user_email":
+            assert labels["user_email"] == "alice@example.com"
+            assert "api_key_alias" not in labels
+        else:
+            assert labels["api_key_alias"] == "alias-a"
+            assert labels["user_email"] == "alice@example.com"
+
+
+@pytest.mark.parametrize(
+    ("standard_email", "metadata_email", "auth_email", "expected_email"),
+    (
+        ("standard@example.com", "metadata@example.com", "auth@example.com", "standard@example.com"),
+        (None, "metadata@example.com", "auth@example.com", "metadata@example.com"),
+        (None, None, "auth@example.com", "auth@example.com"),
+        (None, None, None, "None"),
+    ),
+)
+def test_deployment_failure_email_fallbacks_reach_both_real_counters(
+    monkeypatch: pytest.MonkeyPatch,
+    standard_email: str | None,
+    metadata_email: str | None,
+    auth_email: str | None,
+    expected_email: str,
+):
+    _set_caller_identity(monkeypatch, "both")
+    logger = PrometheusLogger()
+    payload = _standard_logging_payload(user_email=standard_email)
+    metadata = {
+        "model_info": {"id": "deployment-id"},
+        "user_api_key_user_email": metadata_email,
+        "user_api_key_auth": UserAPIKeyAuth(user_email=auth_email),
+    }
+    request_kwargs = {
+        "model": "deployment-model",
+        "litellm_params": {
+            "custom_llm_provider": "openai",
+            "metadata": metadata,
+        },
+        "standard_logging_object": payload,
+        "exception": RuntimeError("provider failed"),
+    }
+
+    logger.set_llm_deployment_failure_metrics(request_kwargs)  # pyright: ignore[reportUnknownMemberType]
+
+    scrape = generate_latest(REGISTRY).decode()
+    for sample_name in (
+        "litellm_deployment_failure_responses_total",
+        "litellm_deployment_total_requests_total",
+    ):
+        samples = _sample_labels(scrape, sample_name)
+        assert len(samples) == 1, sample_name
+        assert samples[0]["api_key_alias"] == "alias-a"
+        assert samples[0]["user_email"] == expected_email
+
+
+@pytest.mark.asyncio
+async def test_proxy_config_loads_caller_identity_before_initializing_callbacks(tmp_path: Path):
+    from litellm.proxy.proxy_server import ProxyConfig
+
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(
+        yaml.safe_dump(
+            {
+                "model_list": [
+                    {
+                        "model_name": "test-model",
+                        "litellm_params": {"model": "openai/gpt-4", "api_key": "test-key"},
+                    }
+                ],
+                "litellm_settings": {
+                    "callbacks": ["prometheus"],
+                    "prometheus_deployment_and_latency_caller_identity": "both",
+                },
+            },
+            sort_keys=False,
+        )
+    )
+    observed_modes: list[str] = []
+
+    def capture_mode(*args: object, **kwargs: object) -> None:
+        observed_modes.append(litellm.prometheus_deployment_and_latency_caller_identity)
+
+    with patch(  # test-quality-ok: callback interception verifies schema selection before construction
+        "litellm.proxy.proxy_server.initialize_callbacks_on_proxy", side_effect=capture_mode
+    ):
+        await ProxyConfig().load_config(router=None, config_file_path=str(config_path))
+
+    assert observed_modes == ["both"]
+    assert litellm.prometheus_deployment_and_latency_caller_identity == "both"

--- a/tests/test_litellm/litellm_core_utils/test_exception_mapping_utils.py
+++ b/tests/test_litellm/litellm_core_utils/test_exception_mapping_utils.py
@@ -1092,3 +1092,30 @@ def test_bedrock_mantle_context_overflow_maps_to_context_window_exceeded():
 
     assert excinfo.value.status_code == 400
     assert "prompt is too long: 1055489 tokens > 1050000 maximum" in excinfo.value.message
+
+
+@pytest.mark.parametrize(
+    "status_code, expected_class",
+    [(401, litellm.AuthenticationError), (429, litellm.RateLimitError)],
+)
+def test_a_base_llm_exception_without_a_provider_branch_maps_by_status_code(
+    status_code, expected_class, quiet_exception_mapping
+):
+    """Regression test for LIT-6164. Native /v1/messages handlers raise raw
+    BaseLLMException, and providers without an exception_type branch (e.g.
+    minimax) must keep the upstream status instead of collapsing every failure
+    into a 500 APIConnectionError once that route maps its exceptions."""
+    from litellm.llms.base_llm.chat.transformation import BaseLLMException
+
+    original_exception = BaseLLMException(status_code=status_code, message="upstream rejected the call")
+
+    with pytest.raises(expected_class) as excinfo:
+        exception_type(
+            model="MiniMax-M2.5",
+            original_exception=original_exception,
+            custom_llm_provider="minimax",
+        )
+
+    assert excinfo.value.status_code == status_code
+    assert excinfo.value.llm_provider == "minimax"
+    assert "MinimaxException" in excinfo.value.message

--- a/tests/test_litellm/litellm_core_utils/test_exception_mapping_utils.py
+++ b/tests/test_litellm/litellm_core_utils/test_exception_mapping_utils.py
@@ -805,7 +805,7 @@ DEVIATIONS_FROM_THE_OPENAI_SHAPE = {
         503: UPSTREAM_STATUS_DISCARDED,
     },
     "databricks": {
-        403: (litellm.AuthenticationError, 401),
+        403: (litellm.PermissionDeniedError, 403),
         422: (litellm.BadRequestError, 400),
     },
     "gemini": {
@@ -1096,7 +1096,11 @@ def test_bedrock_mantle_context_overflow_maps_to_context_window_exceeded():
 
 @pytest.mark.parametrize(
     "status_code, expected_class",
-    [(401, litellm.AuthenticationError), (429, litellm.RateLimitError)],
+    [
+        (401, litellm.AuthenticationError),
+        (403, litellm.PermissionDeniedError),
+        (429, litellm.RateLimitError),
+    ],
 )
 def test_a_base_llm_exception_without_a_provider_branch_maps_by_status_code(
     status_code, expected_class, quiet_exception_mapping

--- a/tests/test_litellm/litellm_core_utils/test_exception_mapping_utils.py
+++ b/tests/test_litellm/litellm_core_utils/test_exception_mapping_utils.py
@@ -790,7 +790,10 @@ UPSTREAM_STATUS_DISCARDED = (litellm.APIConnectionError, 500)
 PROVIDERS_THAT_DISCARD_THE_UPSTREAM_STATUS = ("cloudflare", "ollama", "vllm")
 
 DEVIATIONS_FROM_THE_OPENAI_SHAPE = {
-    "anthropic": {403: UPSTREAM_STATUS_DISCARDED, 422: UPSTREAM_STATUS_DISCARDED},
+    "anthropic": {
+        403: (litellm.PermissionDeniedError, 403),
+        422: UPSTREAM_STATUS_DISCARDED,
+    },
     "azure": {500: (litellm.APIError, 500)},
     "bedrock": {
         403: UPSTREAM_STATUS_DISCARDED,

--- a/tests/test_litellm/litellm_core_utils/test_exception_mapping_utils.py
+++ b/tests/test_litellm/litellm_core_utils/test_exception_mapping_utils.py
@@ -1092,30 +1092,3 @@ def test_bedrock_mantle_context_overflow_maps_to_context_window_exceeded():
 
     assert excinfo.value.status_code == 400
     assert "prompt is too long: 1055489 tokens > 1050000 maximum" in excinfo.value.message
-
-
-@pytest.mark.parametrize(
-    "status_code, expected_class",
-    [(401, litellm.AuthenticationError), (429, litellm.RateLimitError)],
-)
-def test_a_base_llm_exception_without_a_provider_branch_maps_by_status_code(
-    status_code, expected_class, quiet_exception_mapping
-):
-    """Regression test for LIT-6164. Native /v1/messages handlers raise raw
-    BaseLLMException, and providers without an exception_type branch (e.g.
-    minimax) must keep the upstream status instead of collapsing every failure
-    into a 500 APIConnectionError once that route maps its exceptions."""
-    from litellm.llms.base_llm.chat.transformation import BaseLLMException
-
-    original_exception = BaseLLMException(status_code=status_code, message="upstream rejected the call")
-
-    with pytest.raises(expected_class) as excinfo:
-        exception_type(
-            model="MiniMax-M2.5",
-            original_exception=original_exception,
-            custom_llm_provider="minimax",
-        )
-
-    assert excinfo.value.status_code == status_code
-    assert excinfo.value.llm_provider == "minimax"
-    assert "MinimaxException" in excinfo.value.message

--- a/tests/test_litellm/litellm_core_utils/test_exception_mapping_utils.py
+++ b/tests/test_litellm/litellm_core_utils/test_exception_mapping_utils.py
@@ -13,6 +13,7 @@ from litellm.litellm_core_utils.exception_mapping_utils import (
     extract_and_raise_litellm_exception,
 )
 from litellm.llms.openai.common_utils import OpenAIError
+from litellm.types.utils import LlmProviders
 
 # Test cases for is_error_str_context_window_exceeded
 # Tuple format: (error_message, expected_result)
@@ -785,33 +786,24 @@ OPENAI_SHAPED = {
     503: (litellm.ServiceUnavailableError, 503),
 }
 
-UPSTREAM_STATUS_DISCARDED = (litellm.APIConnectionError, 500)
+PERMISSION_DENIED = (litellm.PermissionDeniedError, 403)
 
-PROVIDERS_THAT_DISCARD_THE_UPSTREAM_STATUS = ("cloudflare", "ollama", "vllm")
+STATUS_KEYED = {**OPENAI_SHAPED, 403: PERMISSION_DENIED}
 
 DEVIATIONS_FROM_THE_OPENAI_SHAPE = {
-    "anthropic": {403: UPSTREAM_STATUS_DISCARDED, 422: UPSTREAM_STATUS_DISCARDED},
+    "anthropic": {403: PERMISSION_DENIED},
     "azure": {500: (litellm.APIError, 500)},
     "bedrock": {
-        403: UPSTREAM_STATUS_DISCARDED,
+        403: PERMISSION_DENIED,
         500: (litellm.ServiceUnavailableError, 503),
     },
-    "cohere": {
-        401: UPSTREAM_STATUS_DISCARDED,
-        403: UPSTREAM_STATUS_DISCARDED,
-        404: UPSTREAM_STATUS_DISCARDED,
-        422: UPSTREAM_STATUS_DISCARDED,
-        429: UPSTREAM_STATUS_DISCARDED,
-        503: UPSTREAM_STATUS_DISCARDED,
-    },
+    "cloudflare": {403: PERMISSION_DENIED},
+    "cohere": {403: PERMISSION_DENIED},
     "databricks": {
-        403: (litellm.AuthenticationError, 401),
+        403: PERMISSION_DENIED,
         422: (litellm.BadRequestError, 400),
     },
-    "gemini": {
-        403: (litellm.PermissionDeniedError, 403),
-        422: UPSTREAM_STATUS_DISCARDED,
-    },
+    "gemini": {403: PERMISSION_DENIED},
     "huggingface": {
         404: (litellm.APIError, 404),
         422: (litellm.APIError, 422),
@@ -824,6 +816,7 @@ DEVIATIONS_FROM_THE_OPENAI_SHAPE = {
         500: (litellm.APIError, 500),
         503: (litellm.APIError, 503),
     },
+    "ollama": {403: PERMISSION_DENIED},
     "openrouter": {500: (litellm.APIError, 500)},
     "replicate": {
         403: (litellm.APIError, 500),
@@ -833,17 +826,11 @@ DEVIATIONS_FROM_THE_OPENAI_SHAPE = {
         503: (litellm.APIError, 500),
     },
     "sagemaker": {
-        403: UPSTREAM_STATUS_DISCARDED,
+        403: PERMISSION_DENIED,
         500: (litellm.ServiceUnavailableError, 503),
     },
-    "vertex_ai": {
-        403: (litellm.PermissionDeniedError, 403),
-        422: UPSTREAM_STATUS_DISCARDED,
-    },
-    **{
-        provider: dict.fromkeys(UPSTREAM_STATUS_CODES, UPSTREAM_STATUS_DISCARDED)
-        for provider in PROVIDERS_THAT_DISCARD_THE_UPSTREAM_STATUS
-    },
+    "vertex_ai": {403: PERMISSION_DENIED},
+    "vllm": {403: PERMISSION_DENIED},
 }
 
 PROVIDERS_WITH_A_HANDLER = (
@@ -873,6 +860,38 @@ PROVIDERS_WITH_A_HANDLER = (
     "vertex_ai",
     "vllm",
     "xai",
+)
+
+PROVIDER_ALIASES_WITH_A_HANDLER = (
+    "aleph_alpha",
+    "anthropic_text",
+    "azure_text",
+    "bedrock_mantle",
+    "cohere_chat",
+    "custom_openai",
+    "lemonade",
+    "litellm_proxy",
+    "ollama_chat",
+    "predibase",
+    "sagemaker_chat",
+    "text-completion-openai",
+    "vertex_ai_beta",
+    "watsonx",
+)
+
+PROVIDERS_WITHOUT_A_HANDLER = tuple(
+    sorted(
+        frozenset(provider.value for provider in LlmProviders)
+        - frozenset(PROVIDERS_WITH_A_HANDLER)
+        - frozenset(PROVIDER_ALIASES_WITH_A_HANDLER)
+        - frozenset(litellm.openai_compatible_providers)
+    )
+)
+
+MINIMAX_401_BODY = (
+    '{"type":"error","error":{"type":"authorized_error","message":"login fail: Please carry the API secret key '
+    "in the 'Authorization' field of the request header (1004)\",\"http_code\":\"401\"},"
+    '"request_id":"06ddc9ba97ee6340e38f10e09787f547"}'
 )
 
 
@@ -938,6 +957,51 @@ def test_an_already_mapped_litellm_exception_passes_through_untouched(
     assert returned is already_mapped
 
 
+@pytest.mark.parametrize("status_code", UPSTREAM_STATUS_CODES)
+@pytest.mark.parametrize("provider", PROVIDERS_WITHOUT_A_HANDLER)
+def test_a_provider_without_a_handler_maps_by_the_upstream_status(
+    provider, status_code, quiet_exception_mapping
+):
+    expected_class, expected_status = STATUS_KEYED[status_code]
+
+    with pytest.raises(openai.APIError) as raised:
+        exception_type(
+            model="test-model",
+            original_exception=_UpstreamHTTPError(status_code=status_code),
+            custom_llm_provider=provider,
+        )
+
+    assert type(raised.value) is expected_class
+    assert raised.value.status_code == expected_status
+    assert raised.value.llm_provider == provider
+    assert raised.value.model == "test-model"
+
+
+def test_a_minimax_bad_key_is_an_authentication_error(quiet_exception_mapping):
+    from litellm.llms.base_llm.chat.transformation import BaseLLMException
+
+    with pytest.raises(litellm.AuthenticationError) as raised:
+        exception_type(
+            model="MiniMax-M2.5",
+            original_exception=BaseLLMException(status_code=401, message=MINIMAX_401_BODY),
+            custom_llm_provider="minimax",
+        )
+
+    assert raised.value.status_code == 401
+    assert raised.value.llm_provider == "minimax"
+    assert raised.value.message.startswith("litellm.AuthenticationError: MinimaxException - ")
+    assert "login fail" in raised.value.message
+
+
+def test_an_exception_without_a_status_is_still_a_connection_error(quiet_exception_mapping):
+    with pytest.raises(litellm.APIConnectionError):
+        exception_type(
+            model="MiniMax-M2.5",
+            original_exception=RuntimeError("socket hung up"),
+            custom_llm_provider="minimax",
+        )
+
+
 CONTEXT_WINDOW_MESSAGE = "This model's maximum context length is 4096 tokens."
 CONTENT_POLICY_MESSAGE = (
     '{"error": {"type": "invalid_request_error", "code": "content_policy_violation"}}'
@@ -993,9 +1057,7 @@ class _UpstreamErrorWithMessage(_UpstreamHTTPError):
 def test_a_full_context_window_reaches_the_caller_as_the_router_needs_it(
     provider, quiet_exception_mapping
 ):
-    if provider in PROVIDERS_THAT_DISCARD_THE_UPSTREAM_STATUS:
-        expected_class, expected_status = UPSTREAM_STATUS_DISCARDED
-    elif provider in PROVIDERS_THAT_RECOGNISE_A_FULL_CONTEXT_WINDOW:
+    if provider in PROVIDERS_THAT_RECOGNISE_A_FULL_CONTEXT_WINDOW:
         expected_class, expected_status = litellm.ContextWindowExceededError, 400
     else:
         expected_class, expected_status = litellm.BadRequestError, 400
@@ -1015,9 +1077,7 @@ def test_a_full_context_window_reaches_the_caller_as_the_router_needs_it(
 def test_a_content_policy_block_reaches_the_caller_as_the_router_needs_it(
     provider, quiet_exception_mapping
 ):
-    if provider in PROVIDERS_THAT_DISCARD_THE_UPSTREAM_STATUS:
-        expected_class, expected_status = UPSTREAM_STATUS_DISCARDED
-    elif provider in PROVIDERS_THAT_RECOGNISE_A_CONTENT_POLICY_BLOCK:
+    if provider in PROVIDERS_THAT_RECOGNISE_A_CONTENT_POLICY_BLOCK:
         expected_class, expected_status = litellm.ContentPolicyViolationError, 400
     else:
         expected_class, expected_status = litellm.BadRequestError, 400

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_anthropic_experimental_pass_through_messages_handler.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_anthropic_experimental_pass_through_messages_handler.py
@@ -1286,3 +1286,56 @@ class TestMessagesStreamingSuccessLogging:
         assert payload["call_type"] == "acompletion"
         assert payload["total_tokens"] > 0
         assert payload["response_cost"] > 0
+
+
+class _FailureCapture(CustomLogger):
+    def __init__(self):
+        super().__init__()
+        self.error_information: List[Dict[str, Any]] = []
+
+    async def async_log_failure_event(self, kwargs, response_obj, start_time, end_time):
+        payload = kwargs.get("standard_logging_object") or {}
+        self.error_information.append(payload.get("error_information") or {})
+
+
+@pytest.mark.asyncio
+async def test_anthropic_messages_maps_provider_exception_before_failure_logging(monkeypatch):
+    """Regression test for LIT-6164. The async /v1/messages entrypoint awaited the
+    provider handler without exception_type mapping, so the @client failure
+    handler (and every logger behind it, e.g. OTel error spans) saw the raw
+    BaseLLMException: error.type=BaseLLMException and no llm_provider."""
+    from litellm.llms.anthropic.experimental_pass_through.messages import handler
+
+    capture = _FailureCapture()
+    monkeypatch.setattr(litellm, "callbacks", [capture])
+
+    def upstream_rejects_the_key(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            401,
+            json={"type": "error", "error": {"type": "authentication_error", "message": "invalid x-api-key"}},
+            request=request,
+        )
+
+    upstream = AsyncHTTPHandler()
+    upstream.client = httpx.AsyncClient(transport=httpx.MockTransport(upstream_rejects_the_key))
+
+    with pytest.raises(litellm.AuthenticationError) as excinfo:
+        await handler.anthropic_messages(
+            max_tokens=16,
+            messages=[{"role": "user", "content": "hi"}],
+            model="anthropic/claude-haiku-4-5",
+            custom_llm_provider="anthropic",
+            api_key="sk-invalid",
+            client=upstream,
+        )
+
+    assert excinfo.value.status_code == 401
+    assert excinfo.value.llm_provider == "anthropic"
+    assert "AnthropicException" in excinfo.value.message
+    assert '"authentication_error"' in excinfo.value.message
+
+    assert capture.error_information, "the failure handler must have logged the mapped exception"
+    error_information = capture.error_information[0]
+    assert error_information.get("error_class") == "AuthenticationError"
+    assert error_information.get("llm_provider") == "anthropic"
+    assert error_information.get("error_code") == "401"

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_anthropic_experimental_pass_through_messages_handler.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_anthropic_experimental_pass_through_messages_handler.py
@@ -1299,27 +1299,40 @@ class _FailureCapture(CustomLogger):
 
 
 @pytest.mark.asyncio
-async def test_anthropic_messages_maps_provider_exception_before_failure_logging(monkeypatch):
+@pytest.mark.parametrize(
+    "upstream_status, upstream_error_type, expected_exception",
+    [
+        (401, "authentication_error", litellm.AuthenticationError),
+        (403, "permission_error", litellm.PermissionDeniedError),
+    ],
+)
+async def test_anthropic_messages_maps_provider_exception_before_failure_logging(
+    monkeypatch, upstream_status, upstream_error_type, expected_exception
+):
     """Regression test for LIT-6164. The async /v1/messages entrypoint awaited the
     provider handler without exception_type mapping, so the @client failure
     handler (and every logger behind it, e.g. OTel error spans) saw the raw
-    BaseLLMException: error.type=BaseLLMException and no llm_provider."""
+    BaseLLMException: error.type=BaseLLMException and no llm_provider.
+
+    The 403 row pins the upstream status on the way through the mapper: Anthropic's
+    documented permission_error must reach the caller as a 403, never as the mapper's
+    APIConnectionError 500 fallthrough."""
     from litellm.llms.anthropic.experimental_pass_through.messages import handler
 
     capture = _FailureCapture()
     monkeypatch.setattr(litellm, "callbacks", [capture])
 
-    def upstream_rejects_the_key(request: httpx.Request) -> httpx.Response:
+    def upstream_rejects_the_request(request: httpx.Request) -> httpx.Response:
         return httpx.Response(
-            401,
-            json={"type": "error", "error": {"type": "authentication_error", "message": "invalid x-api-key"}},
+            upstream_status,
+            json={"type": "error", "error": {"type": upstream_error_type, "message": "rejected upstream"}},
             request=request,
         )
 
     upstream = AsyncHTTPHandler()
-    upstream.client = httpx.AsyncClient(transport=httpx.MockTransport(upstream_rejects_the_key))
+    upstream.client = httpx.AsyncClient(transport=httpx.MockTransport(upstream_rejects_the_request))
 
-    with pytest.raises(litellm.AuthenticationError) as excinfo:
+    with pytest.raises(expected_exception) as excinfo:
         await handler.anthropic_messages(
             max_tokens=16,
             messages=[{"role": "user", "content": "hi"}],
@@ -1329,13 +1342,13 @@ async def test_anthropic_messages_maps_provider_exception_before_failure_logging
             client=upstream,
         )
 
-    assert excinfo.value.status_code == 401
+    assert excinfo.value.status_code == upstream_status
     assert excinfo.value.llm_provider == "anthropic"
     assert "AnthropicException" in excinfo.value.message
-    assert '"authentication_error"' in excinfo.value.message
+    assert f'"{upstream_error_type}"' in excinfo.value.message
 
     assert capture.error_information, "the failure handler must have logged the mapped exception"
     error_information = capture.error_information[0]
-    assert error_information.get("error_class") == "AuthenticationError"
+    assert error_information.get("error_class") == expected_exception.__name__
     assert error_information.get("llm_provider") == "anthropic"
-    assert error_information.get("error_code") == "401"
+    assert error_information.get("error_code") == str(upstream_status)

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_anthropic_experimental_pass_through_messages_handler.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_anthropic_experimental_pass_through_messages_handler.py
@@ -7,6 +7,7 @@ from typing import Any, Dict, List
 import httpx
 import pytest
 from fastapi.testclient import TestClient
+from pydantic import ValidationError
 
 
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -1352,3 +1353,30 @@ async def test_anthropic_messages_maps_provider_exception_before_failure_logging
     assert error_information.get("error_class") == expected_exception.__name__
     assert error_information.get("llm_provider") == "anthropic"
     assert error_information.get("error_code") == str(upstream_status)
+
+
+@pytest.mark.asyncio
+async def test_anthropic_messages_leaves_non_provider_failures_unmapped():
+    """The mapping boundary is for provider failures only. A request rejected before
+    the provider call (here invalid metadata) must surface as the original exception,
+    not as the mapper's APIConnectionError, whose message embeds a server traceback."""
+    from litellm.llms.anthropic.experimental_pass_through.messages import handler
+
+    def upstream_must_not_be_called(request: httpx.Request) -> httpx.Response:
+        raise AssertionError("the provider must not be called for a request rejected locally")
+
+    upstream = AsyncHTTPHandler()
+    upstream.client = httpx.AsyncClient(transport=httpx.MockTransport(upstream_must_not_be_called))
+
+    with pytest.raises(ValidationError) as excinfo:
+        await handler.anthropic_messages(
+            max_tokens=16,
+            messages=[{"role": "user", "content": "hi"}],
+            model="anthropic/claude-haiku-4-5",
+            custom_llm_provider="anthropic",
+            api_key="sk-invalid",
+            client=upstream,
+            metadata={"user_id": 123},
+        )
+
+    assert "Traceback" not in str(excinfo.value)

--- a/tests/test_litellm/llms/base_llm/search/test_base_search_transformation.py
+++ b/tests/test_litellm/llms/base_llm/search/test_base_search_transformation.py
@@ -322,7 +322,7 @@ async def test_query_param_key_not_leaked_with_dummy_caller_key(
         "litellm.llms.custom_httpx.http_handler.AsyncHTTPHandler.get",
         fake_get,
     ):
-        with pytest.raises(litellm.APIConnectionError):
+        with pytest.raises(litellm.InternalServerError):
             await litellm.asearch(
                 query="secrets",
                 search_provider=provider,

--- a/tests/test_litellm/llms/compactifai/test_compactifai.py
+++ b/tests/test_litellm/llms/compactifai/test_compactifai.py
@@ -172,7 +172,7 @@ def test_compactifai_authentication_error(respx_mock):
         json=mock_error, status_code=401
     )
 
-    with pytest.raises(litellm.APIConnectionError) as exc_info:
+    with pytest.raises(litellm.AuthenticationError) as exc_info:
         litellm.completion(
             model="compactifai/cai-llama-3-1-8b-slim",
             messages=[{"role": "user", "content": "test"}],

--- a/tests/test_litellm/llms/langflow/chat/test_langflow_chat_transformation.py
+++ b/tests/test_litellm/llms/langflow/chat/test_langflow_chat_transformation.py
@@ -233,7 +233,7 @@ def test_langflow_extra_body_cannot_inject_tweaks_into_run_payload():
         return resp
 
     with patch.object(HTTPHandler, "post", side_effect=fake_post):
-        with pytest.raises(litellm.APIConnectionError):
+        with pytest.raises(litellm.BadRequestError):
             litellm.completion(
                 model="langflow/my-flow",
                 messages=[{"role": "user", "content": "hello"}],

--- a/tests/test_litellm/llms/vertex_ai/vertex_gemma_models/test_vertex_gemma_transformation.py
+++ b/tests/test_litellm/llms/vertex_ai/vertex_gemma_models/test_vertex_gemma_transformation.py
@@ -238,7 +238,7 @@ class TestVertexGemmaCompletion:
 
         Expected: Proper error handling when 'predictions' field is missing
         """
-        from litellm.exceptions import APIConnectionError
+        from litellm.exceptions import BadRequestError
 
         # Invalid response without predictions field
         invalid_response = {
@@ -260,8 +260,8 @@ class TestVertexGemmaCompletion:
             mock_client.post = AsyncMock(return_value=mock_response)
             mock_get_client.return_value = mock_client
 
-            # Should raise exception (wrapped as APIConnectionError by LiteLLM)
-            with pytest.raises(APIConnectionError) as exc_info:
+            # Should raise exception (wrapped as BadRequestError by LiteLLM)
+            with pytest.raises(BadRequestError) as exc_info:
                 await litellm.acompletion(
                     model="vertex_ai/gemma/gemma-3-12b-it",
                     messages=[{"role": "user", "content": "Test"}],

--- a/tests/test_litellm/proxy/common_utils/test_sse_keepalive.py
+++ b/tests/test_litellm/proxy/common_utils/test_sse_keepalive.py
@@ -10,12 +10,26 @@ from litellm.proxy.common_utils.sse_keepalive import (
     ANTHROPIC_PING_SSE_CHUNK,
     SSE_COMMENT_PING_BYTES,
     resolve_ttft_keepalive_interval,
+    split_complete_sse_frames,
     wrap_passthrough_sse_bytes_with_keepalive_pings,
     wrap_sse_stream_with_keepalive_pings,
 )
 
 MESSAGE_START_CHUNK: Final = 'data: {"type": "message_start"}\n\n'
 TEXT_DELTA_CHUNK: Final = 'data: {"type": "content_block_delta"}\n\n'
+
+
+@pytest.mark.parametrize("delimiter", [b"\n\n", b"\r\n\r\n", b"\r\r"])
+def test_split_complete_sse_frames_recognizes_every_sse_frame_delimiter(delimiter: bytes):
+    newline: Final = delimiter[: len(delimiter) // 2]
+    frame: Final = b"event: response.created" + newline + b"data: {}" + delimiter
+    tail: Final = b"data: partial"
+
+    assert split_complete_sse_frames(frame + tail) == (frame, tail)
+
+
+def test_split_complete_sse_frames_holds_bytes_with_no_complete_frame():
+    assert split_complete_sse_frames(b"data: unterminated") == (b"", b"data: unterminated")
 
 
 @pytest.mark.asyncio

--- a/tests/test_litellm/proxy/hooks/test_batch_file_validation.py
+++ b/tests/test_litellm/proxy/hooks/test_batch_file_validation.py
@@ -2286,3 +2286,178 @@ async def test_disable_flag_still_skips_batch_processing_with_enqueued_limits():
 
     assert result is data
     afile_content_mock.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# Models-only read: the allowlist forces the download, nothing charges the
+# tokens, so the per-row tokenization is skipped.
+# ---------------------------------------------------------------------------
+
+_MODELS_ONLY_ALLOWED = "gpt-4o-mini"
+_MODELS_ONLY_DENIED = "gpt-4o"
+
+
+def _models_only_file(models):
+    """A JSONL batch file naming ``models``, one chat row each."""
+    import json as _json
+
+    body = "\n".join(
+        _json.dumps({"body": {"model": m, "messages": [{"role": "user", "content": "x" * 64}]}})
+        for m in models
+    )
+    content = MagicMock()
+    content.content = body.encode("utf-8")
+    return content
+
+
+def _restricted_user(**kwargs):
+    return UserAPIKeyAuth(
+        api_key="sk-restricted-models-only",
+        user_id="alice",
+        models=[_MODELS_ONLY_ALLOWED],
+        user_role=LitellmUserRoles.INTERNAL_USER.value,
+        **kwargs,
+    )
+
+
+@pytest.mark.asyncio
+async def test_models_only_read_skips_tokenization_for_restricted_key():
+    """Opt-out set + model allowlist: read the file, validate it, don't tokenize.
+
+    ``async_pre_call_hook`` swallows unexpected exceptions and returns ``data``,
+    so the returned value alone proves nothing — assert on the calls that
+    separate the intended path from error recovery.
+    """
+    rate_limiter = _make_rate_limiter()
+    data = {"input_file_id": "file-abc123"}
+    afile_content = AsyncMock(return_value=_models_only_file([_MODELS_ONLY_ALLOWED] * 2))
+
+    with (
+        patch(
+            "litellm.proxy.proxy_server.general_settings",
+            {"disable_batch_input_file_rate_limiting": True},
+        ),
+        patch("litellm.proxy.proxy_server.llm_router", None),
+        patch("litellm.afile_content", new=afile_content),
+        patch("litellm.proxy.hooks.batch_rate_limiter._count_entry_tokens") as count_entry_tokens,
+        patch.object(rate_limiter, "_enforce_batch_file_model_access", new=AsyncMock()) as enforce,
+        patch.object(rate_limiter, "_check_and_increment_batch_counters", new=AsyncMock()) as counters,
+    ):
+        result = await rate_limiter.async_pre_call_hook(
+            user_api_key_dict=_restricted_user(),
+            cache=MagicMock(),
+            data=data,
+            call_type="acreate_batch",
+        )
+
+    assert result == data
+    # Not the full-skip path: the file really was downloaded...
+    afile_content.assert_awaited_once()
+    # ...and every model in it was still checked against the allowlist.
+    enforce.assert_awaited_once()
+    assert set(enforce.await_args.kwargs["models"]) == {_MODELS_ONLY_ALLOWED}
+    # Nothing charges this batch, so the discarded tokenization is skipped.
+    count_entry_tokens.assert_not_called()
+    counters.assert_not_awaited()
+    assert "_batch_token_count" not in data
+
+
+@pytest.mark.asyncio
+async def test_models_only_read_still_rejects_unauthorized_model():
+    """The opt-out must not turn into an authorization bypass."""
+    rate_limiter = _make_rate_limiter()
+    afile_content = AsyncMock(return_value=_models_only_file([_MODELS_ONLY_DENIED]))
+
+    async def _raise_unauthorized(**kwargs):
+        raise Exception(
+            f"Key not allowed to access model. This key only has access to "
+            f"models={kwargs['valid_token'].models}"
+        )
+
+    with (
+        patch(
+            "litellm.proxy.proxy_server.general_settings",
+            {"disable_batch_input_file_rate_limiting": True},
+        ),
+        patch("litellm.proxy.proxy_server.llm_router", None),
+        patch("litellm.afile_content", new=afile_content),
+        patch(
+            "litellm.proxy.auth.auth_checks.can_key_call_model",
+            new=AsyncMock(side_effect=_raise_unauthorized),
+        ),
+    ):
+        with pytest.raises(HTTPException) as exc:
+            await rate_limiter.async_pre_call_hook(
+                user_api_key_dict=_restricted_user(),
+                cache=MagicMock(),
+                data={"input_file_id": "file-abc123"},
+                call_type="acreate_batch",
+            )
+
+    assert exc.value.status_code == 403
+    assert _MODELS_ONLY_DENIED in str(exc.value.detail)
+    afile_content.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_restricted_key_without_opt_out_still_counts_tokens():
+    """No opt-out configured: the pre-existing path is untouched."""
+    rate_limiter = _make_rate_limiter()
+    afile_content = AsyncMock(return_value=_models_only_file([_MODELS_ONLY_ALLOWED] * 2))
+    data = {"input_file_id": "file-abc123"}
+
+    with (
+        patch("litellm.proxy.proxy_server.general_settings", {}),
+        patch("litellm.proxy.proxy_server.llm_router", None),
+        patch("litellm.afile_content", new=afile_content),
+        patch(
+            "litellm.proxy.hooks.batch_rate_limiter._count_entry_tokens", return_value=7
+        ) as count_entry_tokens,
+        patch.object(rate_limiter, "_enforce_batch_file_model_access", new=AsyncMock()),
+        patch.object(rate_limiter, "_check_and_increment_batch_counters", new=AsyncMock()) as counters,
+    ):
+        result = await rate_limiter.async_pre_call_hook(
+            user_api_key_dict=_restricted_user(),
+            cache=MagicMock(),
+            data=data,
+            call_type="acreate_batch",
+        )
+
+    assert result == data
+    afile_content.assert_awaited_once()
+    assert count_entry_tokens.call_count == 2
+    counters.assert_awaited_once()
+    assert data["_batch_token_count"] == 14
+    assert data["_batch_request_count"] == 2
+
+
+@pytest.mark.asyncio
+async def test_models_only_read_disabled_when_enqueued_scopes_apply():
+    """Enqueued-token reservations are priced from the totals, so keep counting."""
+    rate_limiter = _make_rate_limiter()
+    afile_content = AsyncMock(return_value=_models_only_file([_MODELS_ONLY_ALLOWED] * 2))
+
+    with (
+        patch(
+            "litellm.proxy.proxy_server.general_settings",
+            {"disable_batch_input_file_rate_limiting": True},
+        ),
+        patch("litellm.proxy.proxy_server.llm_router", None),
+        patch("litellm.afile_content", new=afile_content),
+        patch(
+            "litellm.proxy.hooks.batch_rate_limiter._count_entry_tokens", return_value=7
+        ) as count_entry_tokens,
+        patch.object(rate_limiter, "_enforce_batch_file_model_access", new=AsyncMock()),
+        patch.object(rate_limiter, "_reserve_batch_enqueued_tokens", new=AsyncMock()) as reserve,
+    ):
+        data = {"input_file_id": "file-abc123"}
+        await rate_limiter.async_pre_call_hook(
+            user_api_key_dict=_restricted_user(metadata={"batch_enqueued_token_limit": 10}),
+            cache=MagicMock(),
+            data=data,
+            call_type="acreate_batch",
+        )
+
+    assert count_entry_tokens.call_count == 2
+    reserve.assert_awaited_once()
+    assert data["_batch_token_count"] == 14

--- a/tests/test_litellm/proxy/pass_through_endpoints/test_managed_id_rewriter.py
+++ b/tests/test_litellm/proxy/pass_through_endpoints/test_managed_id_rewriter.py
@@ -212,6 +212,29 @@ async def test_streamed_response_is_owned_and_rewritten_across_chunk_boundaries(
 
 
 @pytest.mark.asyncio
+async def test_streamed_response_with_cr_only_frame_delimiters_is_still_owned_and_rewritten():
+    """SSE also terminates lines with a lone CR; those frames must mint and rewrite too."""
+    pc = _prisma_client()
+    payload = _response_stream_bytes().replace(b"\n", b"\r")
+
+    output = await _collect(
+        rewrite_streamed_response_ids(
+            stream=_chunks(payload, 7),
+            provider="openai",
+            method="POST",
+            route="/openai_passthrough/v1/responses",
+            user_api_key_dict=_user(),
+            prisma_client=pc,
+        )
+    )
+
+    pc.db.litellm_managedobjecttable.upsert.assert_awaited_once()
+    managed_id = pc.db.litellm_managedobjecttable.upsert.await_args.kwargs["data"]["create"]["unified_object_id"]
+    assert RAW_RESPONSE_ID.encode() not in output
+    assert output == _response_stream_bytes(managed_id).replace(b"\n", b"\r")
+
+
+@pytest.mark.asyncio
 async def test_streamed_bytes_untouched_on_routes_without_a_response_id():
     pc = _prisma_client()
     payload = _response_stream_bytes()

--- a/tests/test_litellm/proxy/pass_through_endpoints/test_managed_id_rewriter.py
+++ b/tests/test_litellm/proxy/pass_through_endpoints/test_managed_id_rewriter.py
@@ -1,12 +1,15 @@
 import datetime
+import json
+from collections.abc import AsyncIterator, Iterable
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
 from litellm.proxy._types import ProxyException, UserAPIKeyAuth
-from litellm.proxy.pass_through_endpoints.managed_id_codec import new_managed_id
+from litellm.proxy.pass_through_endpoints.managed_id_codec import decode, new_managed_id
 from litellm.proxy.pass_through_endpoints.managed_id_rewriter import (
     list_passthrough_ids_from_db,
+    rewrite_streamed_response_ids,
 )
 
 
@@ -27,7 +30,37 @@ def _prisma_client(file_rows=None, batch_rows=None) -> MagicMock:
     pc.db.litellm_managedobjecttable.find_many = AsyncMock(
         side_effect=lambda *args, take=None, **kwargs: list(batch_rows or [])[:take]
     )
+    pc.db.litellm_managedobjecttable.upsert = AsyncMock(return_value=None)
     return pc
+
+
+RAW_RESPONSE_ID = "resp_0123456789abcdef"
+
+
+def _response_stream_bytes(raw_id: str = RAW_RESPONSE_ID) -> bytes:
+    events = (
+        ("response.created", {"type": "response.created", "response": {"id": raw_id, "status": "in_progress"}}),
+        ("response.output_text.delta", {"type": "response.output_text.delta", "delta": "mango"}),
+        ("response.completed", {"type": "response.completed", "response": {"id": raw_id, "status": "completed"}}),
+    )
+    return b"".join(f"event: {name}\ndata: {json.dumps(payload)}\n\n".encode() for name, payload in events)
+
+
+async def _chunks(payload: bytes, size: int) -> AsyncIterator[bytes]:
+    for start in range(0, len(payload), size):
+        yield payload[start : start + size]
+
+
+async def _collect(stream: AsyncIterator[bytes]) -> bytes:
+    return b"".join([chunk async for chunk in stream])
+
+
+def _response_ids(sse: bytes) -> Iterable[str]:
+    for line in sse.decode().splitlines():
+        if line.startswith("data:"):
+            event = json.loads(line[len("data:") :])
+            if "response" in event:
+                yield event["response"]["id"]
 
 
 def _file_row(unified_id: str) -> MagicMock:
@@ -67,9 +100,7 @@ def _batch_row(unified_id: str) -> MagicMock:
         ),
     ],
 )
-async def test_list_batches_out_of_range_limit_raises_400(
-    limit, expected_message, expected_openai_code
-):
+async def test_list_batches_out_of_range_limit_raises_400(limit, expected_message, expected_openai_code):
     pc = _prisma_client(batch_rows=[_batch_row(new_managed_id("openai", "batch_abc"))])
 
     with pytest.raises(ProxyException) as exc:
@@ -147,3 +178,75 @@ async def test_list_files_drops_batch_guardrail_key_persisted_by_an_older_proxy(
     assert result is not None
     assert "litellm_batch_guardrail" not in result["data"][0]
     assert result["data"][0]["filename"] == "test.jsonl"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("chunk_size", [1, 7, 4096])
+async def test_streamed_response_is_owned_and_rewritten_across_chunk_boundaries(chunk_size: int):
+    """A streamed POST /v1/responses records the caller as owner once and returns
+    the minted id in every event, no matter how the transport splits the SSE bytes."""
+    pc = _prisma_client()
+
+    output = await _collect(
+        rewrite_streamed_response_ids(
+            stream=_chunks(_response_stream_bytes(), chunk_size),
+            provider="openai",
+            method="POST",
+            route="/openai_passthrough/v1/responses",
+            user_api_key_dict=_user(),
+            prisma_client=pc,
+        )
+    )
+
+    pc.db.litellm_managedobjecttable.upsert.assert_awaited_once()
+    created = pc.db.litellm_managedobjecttable.upsert.await_args.kwargs["data"]["create"]
+    assert created["created_by"] == "user-1"
+    assert created["team_id"] == "team-1"
+    assert created["file_purpose"] == "response"
+    assert created["model_object_id"] == f"passthrough:openai:{RAW_RESPONSE_ID}"
+    managed_id = created["unified_object_id"]
+    assert decode(managed_id).raw_provider_id == RAW_RESPONSE_ID
+    assert list(_response_ids(output)) == [managed_id, managed_id]
+    assert RAW_RESPONSE_ID.encode() not in output
+    assert output == _response_stream_bytes(managed_id)
+
+
+@pytest.mark.asyncio
+async def test_streamed_bytes_untouched_on_routes_without_a_response_id():
+    pc = _prisma_client()
+    payload = _response_stream_bytes()
+
+    output = await _collect(
+        rewrite_streamed_response_ids(
+            stream=_chunks(payload, 5),
+            provider="openai",
+            method="POST",
+            route="/openai_passthrough/v1/chat/completions",
+            user_api_key_dict=_user(),
+            prisma_client=pc,
+        )
+    )
+
+    assert output == payload
+    pc.db.litellm_managedobjecttable.upsert.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_streamed_response_stays_raw_and_intact_when_the_row_cannot_be_persisted():
+    pc = _prisma_client()
+    pc.db.litellm_managedobjecttable.upsert = AsyncMock(side_effect=RuntimeError("db down"))
+    payload = _response_stream_bytes()
+
+    output = await _collect(
+        rewrite_streamed_response_ids(
+            stream=_chunks(payload, 3),
+            provider="openai",
+            method="POST",
+            route="/openai_passthrough/v1/responses",
+            user_api_key_dict=_user(),
+            prisma_client=pc,
+        )
+    )
+
+    assert output == payload
+    pc.db.litellm_managedobjecttable.upsert.assert_awaited_once()

--- a/tests/test_litellm/proxy/pass_through_endpoints/test_pass_through_endpoints.py
+++ b/tests/test_litellm/proxy/pass_through_endpoints/test_pass_through_endpoints.py
@@ -1494,6 +1494,86 @@ async def test_pass_through_request_sse_response_marks_logging_obj_as_stream():
 
 
 @pytest.mark.asyncio
+async def test_pass_through_request_streamed_response_is_owned_by_the_caller():
+    """
+    Regression: with passthrough_managed_object_ids on, a streamed
+    POST /openai_passthrough/v1/responses left the raw resp_ id in the stream and
+    recorded no owner, so any other key could read, continue, and delete it.
+    """
+    import litellm
+    from litellm.llms.custom_httpx.http_handler import get_async_httpx_client
+    from litellm.types.llms.custom_http import httpxSpecialProvider
+
+    raw_id = "resp_0123456789abcdef"
+    upstream_body = (
+        b'event: response.created\ndata: {"type": "response.created", "response": {"id": "%s"}}\n\n'
+        b'event: response.completed\ndata: {"type": "response.completed", "response": {"id": "%s"}}\n\n'
+    ) % (raw_id.encode(), raw_id.encode())
+    prisma_client = MagicMock()
+    prisma_client.db.litellm_managedobjecttable.find_first = AsyncMock(return_value=None)
+    prisma_client.db.litellm_managedobjecttable.upsert = AsyncMock(return_value=None)
+    prisma_client.db.litellm_managedfiletable.find_first = AsyncMock(return_value=None)
+
+    def transport_handler(upstream_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, content=upstream_body, headers={"content-type": "text/event-stream"})
+
+    real_handler = get_async_httpx_client(
+        llm_provider=httpxSpecialProvider.PassThroughEndpoint,
+        params={"timeout": resolve_pass_through_request_timeout(None)},
+    )
+    cache_dict = litellm.in_memory_llm_clients_cache.cache_dict
+    cache_key = next(key for key, cached in cache_dict.items() if cached is real_handler)
+    cache_dict[cache_key] = SimpleNamespace(client=httpx.AsyncClient(transport=httpx.MockTransport(transport_handler)))
+
+    mock_proxy_logging = MagicMock()
+    mock_proxy_logging.pre_call_hook = AsyncMock(side_effect=lambda user_api_key_dict, data, call_type: data)
+    mock_proxy_logging.post_call_failure_hook = AsyncMock()
+    mock_proxy_logging.post_call_response_headers_hook = AsyncMock(return_value={})
+    mock_proxy_logging.get_proxy_hook = MagicMock(return_value=MagicMock())
+
+    mock_request = MagicMock(spec=Request)
+    mock_request.method = "POST"
+    mock_request.scope = {"path": "/openai_passthrough/v1/responses"}
+    mock_request.url = MagicMock()
+    mock_request.url.path = "/openai_passthrough/v1/responses"
+    mock_request.body = AsyncMock(return_value=b'{"model": "gpt-5.1", "input": "hi", "stream": true}')
+    mock_request.headers = Headers({"content-type": "application/json"})
+    mock_request.query_params = QueryParams({})
+
+    flag_on = {"passthrough_managed_object_ids": True}
+    proxy_server_globals = (
+        patch("litellm.proxy.proxy_server.proxy_logging_obj", mock_proxy_logging),  # test-quality-ok: read at call time
+        patch("litellm.proxy.proxy_server.general_settings", flag_on),  # test-quality-ok: read at call time
+        patch("litellm.proxy.proxy_server.prisma_client", prisma_client),  # test-quality-ok: read at call time
+    )
+
+    try:
+        with ExitStack() as stack:
+            for patched_global in proxy_server_globals:
+                stack.enter_context(patched_global)
+            response = await pass_through_request(
+                request=mock_request,
+                target="https://api.openai.com/v1/responses",
+                custom_headers={},
+                user_api_key_dict=UserAPIKeyAuth(user_id="user-a", team_id="team-a"),
+                custom_llm_provider="openai",
+            )
+            streamed = b"".join([chunk async for chunk in response.body_iterator])
+    finally:
+        cache_dict[cache_key] = real_handler
+
+    assert response.status_code == 200
+    prisma_client.db.litellm_managedobjecttable.upsert.assert_awaited_once()
+    created = prisma_client.db.litellm_managedobjecttable.upsert.await_args.kwargs["data"]["create"]
+    assert created["created_by"] == "user-a"
+    assert created["team_id"] == "team-a"
+    assert created["model_object_id"] == f"passthrough:openai:{raw_id}"
+    managed_id = created["unified_object_id"]
+    assert raw_id.encode() not in streamed
+    assert streamed == upstream_body.replace(raw_id.encode(), managed_id.encode())
+
+
+@pytest.mark.asyncio
 async def test_create_pass_through_endpoint():
     """
     Test creating a new pass-through endpoint

--- a/tests/test_litellm/test_router.py
+++ b/tests/test_litellm/test_router.py
@@ -10607,3 +10607,45 @@ async def test_async_function_with_fallbacks_scrubs_spoofed_values_from_sibling_
     assert litellm_metadata["client_key"] == "client_value"
     assert metadata["attempted_fallbacks"] == 0
     assert metadata["original_model_group"] == "gpt-3.5-turbo"
+
+
+def _permission_denied_error() -> litellm.PermissionDeniedError:
+    return litellm.PermissionDeniedError(
+        message="OpenrouterException - this key has no access to the model",
+        llm_provider="openrouter",
+        model="openrouter/openai/gpt-4o",
+        response=httpx.Response(status_code=403, request=httpx.Request(method="POST", url="https://openrouter.ai")),
+    )
+
+
+def test_permission_denied_error_is_not_retried_against_a_single_deployment():
+    router = litellm.Router(
+        model_list=[
+            {"model_name": "gpt-4o", "litellm_params": {"model": "openrouter/openai/gpt-4o", "api_key": "sk-test"}},
+        ]
+    )
+
+    with pytest.raises(litellm.PermissionDeniedError):
+        router.should_retry_this_error(
+            error=_permission_denied_error(),
+            healthy_deployments=router.model_list,
+            all_deployments=router.model_list,
+        )
+
+
+def test_permission_denied_error_is_retried_when_other_deployments_exist():
+    router = litellm.Router(
+        model_list=[
+            {"model_name": "gpt-4o", "litellm_params": {"model": "openrouter/openai/gpt-4o", "api_key": "sk-test"}},
+            {"model_name": "gpt-4o", "litellm_params": {"model": "openai/gpt-4o", "api_key": "sk-test"}},
+        ]
+    )
+
+    assert (
+        router.should_retry_this_error(
+            error=_permission_denied_error(),
+            healthy_deployments=router.model_list,
+            all_deployments=router.model_list,
+        )
+        is True
+    )

--- a/ui/litellm-dashboard/eslint-suppressions.json
+++ b/ui/litellm-dashboard/eslint-suppressions.json
@@ -2133,6 +2133,11 @@
       "count": 1
     }
   },
+  "src/components/ui/alert.tsx": {
+    "local/filename-pascal-case": {
+      "count": 1
+    }
+  },
   "src/components/ui/avatar.tsx": {
     "local/filename-pascal-case": {
       "count": 1

--- a/ui/litellm-dashboard/src/components/shared/Alert.tsx
+++ b/ui/litellm-dashboard/src/components/shared/Alert.tsx
@@ -1,75 +1,32 @@
-import * as React from "react";
+import type * as React from "react";
 
-import { cva, type VariantProps } from "class-variance-authority";
-
+import { Alert as AlertPrimitive, AlertAction, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { cn } from "@/lib/cva.config";
 
-const alertVariants = cva(
-  "group/alert relative grid w-full gap-0.5 rounded-lg border px-4 py-3 text-left text-sm has-data-[slot=alert-action]:relative has-data-[slot=alert-action]:pr-18 has-[>svg]:grid-cols-[auto_1fr] has-[>svg]:gap-x-2.5 *:[svg]:row-span-2 *:[svg]:translate-y-0.5 *:[svg]:text-current *:[svg:not([class*='size-'])]:size-4",
-  {
-    variants: {
-      variant: {
-        default: "bg-card text-card-foreground",
-        destructive:
-          "bg-card text-destructive *:data-[slot=alert-description]:text-destructive/90 *:[svg]:text-current",
-        info: "border-info/20 bg-info/5 text-info *:[svg]:text-current",
-        success: "border-success/20 bg-success/5 text-success *:[svg]:text-current",
-        warning: "border-warning/20 bg-warning/5 text-warning *:[svg]:text-current",
-        error:
-          "border-destructive/20 bg-destructive/10 text-destructive *:data-[slot=alert-description]:text-destructive/90 *:[svg]:text-destructive",
-      },
-    },
-    defaultVariants: {
-      variant: "default",
-    },
-  },
-);
+const STATUS_VARIANT_CLASSES = {
+  info: "border-info/20 bg-info/5 text-info *:[svg]:text-current",
+  success: "border-success/20 bg-success/5 text-success *:[svg]:text-current",
+  warning: "border-warning/20 bg-warning/5 text-warning *:[svg]:text-current",
+  error:
+    "border-destructive/20 bg-destructive/10 text-destructive *:data-[slot=alert-description]:text-destructive/90 *:[svg]:text-destructive",
+} as const;
 
-type AlertProps = React.ComponentProps<"div"> & VariantProps<typeof alertVariants>;
+type StatusVariant = keyof typeof STATUS_VARIANT_CLASSES;
+type AlertVariant = NonNullable<React.ComponentProps<typeof AlertPrimitive>["variant"]> | StatusVariant;
 
-const Alert = React.forwardRef<HTMLDivElement, AlertProps>(({ className, variant = "default", ...props }, ref) => (
-  <div
-    ref={ref}
-    data-slot="alert"
+type AlertProps = Omit<React.ComponentProps<typeof AlertPrimitive>, "variant"> & {
+  variant?: AlertVariant;
+};
+
+const isStatusVariant = (variant: AlertVariant): variant is StatusVariant => variant in STATUS_VARIANT_CLASSES;
+
+const Alert = ({ variant = "default", className, ...props }: AlertProps) => (
+  <AlertPrimitive
     data-variant={variant}
-    role="alert"
-    className={cn(alertVariants({ variant }), className)}
+    variant={variant === "destructive" ? "destructive" : "default"}
+    className={cn(isStatusVariant(variant) ? STATUS_VARIANT_CLASSES[variant] : undefined, className)}
     {...props}
   />
-));
-Alert.displayName = "Alert";
-
-const AlertTitle = React.forwardRef<HTMLDivElement, React.ComponentProps<"div">>(({ className, ...props }, ref) => (
-  <div
-    ref={ref}
-    data-slot="alert-title"
-    className={cn(
-      "font-medium group-has-[>svg]/alert:col-start-2 [&_a]:underline [&_a]:underline-offset-3 [&_a]:hover:text-foreground",
-      className,
-    )}
-    {...props}
-  />
-));
-AlertTitle.displayName = "AlertTitle";
-
-const AlertDescription = React.forwardRef<HTMLDivElement, React.ComponentProps<"div">>(
-  ({ className, ...props }, ref) => (
-    <div
-      ref={ref}
-      data-slot="alert-description"
-      className={cn(
-        "text-sm text-balance text-muted-foreground md:text-pretty [&_a]:underline [&_a]:underline-offset-3 [&_a]:hover:text-foreground [&_p:not(:last-child)]:mb-4",
-        className,
-      )}
-      {...props}
-    />
-  ),
 );
-AlertDescription.displayName = "AlertDescription";
-
-const AlertAction = React.forwardRef<HTMLDivElement, React.ComponentProps<"div">>(({ className, ...props }, ref) => (
-  <div ref={ref} data-slot="alert-action" className={cn("absolute top-2.5 right-3", className)} {...props} />
-));
-AlertAction.displayName = "AlertAction";
 
 export { Alert, AlertTitle, AlertDescription, AlertAction };

--- a/ui/litellm-dashboard/src/components/ui/alert.tsx
+++ b/ui/litellm-dashboard/src/components/ui/alert.tsx
@@ -1,0 +1,56 @@
+import * as React from "react";
+import { cva, type VariantProps } from "class-variance-authority";
+
+import { cn } from "@/lib/cva.config";
+
+const alertVariants = cva(
+  "group/alert relative grid w-full gap-0.5 rounded-lg border px-4 py-3 text-left text-sm has-data-[slot=alert-action]:relative has-data-[slot=alert-action]:pr-18 has-[>svg]:grid-cols-[auto_1fr] has-[>svg]:gap-x-2.5 *:[svg]:row-span-2 *:[svg]:translate-y-0.5 *:[svg]:text-current *:[svg:not([class*='size-'])]:size-4",
+  {
+    variants: {
+      variant: {
+        default: "bg-card text-card-foreground",
+        destructive:
+          "bg-card text-destructive *:data-[slot=alert-description]:text-destructive/90 *:[svg]:text-current",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  },
+);
+
+function Alert({ className, variant, ...props }: React.ComponentProps<"div"> & VariantProps<typeof alertVariants>) {
+  return <div data-slot="alert" role="alert" className={cn(alertVariants({ variant }), className)} {...props} />;
+}
+
+function AlertTitle({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-title"
+      className={cn(
+        "font-medium group-has-[>svg]/alert:col-start-2 [&_a]:underline [&_a]:underline-offset-3 [&_a]:hover:text-foreground",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function AlertDescription({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-description"
+      className={cn(
+        "text-sm text-balance text-muted-foreground md:text-pretty [&_a]:underline [&_a]:underline-offset-3 [&_a]:hover:text-foreground [&_p:not(:last-child)]:mb-4",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function AlertAction({ className, ...props }: React.ComponentProps<"div">) {
+  return <div data-slot="alert-action" className={cn("absolute top-2.5 right-3", className)} {...props} />;
+}
+
+export { Alert, AlertTitle, AlertDescription, AlertAction };

--- a/ui/litellm-dashboard/src/components/ui/label.tsx
+++ b/ui/litellm-dashboard/src/components/ui/label.tsx
@@ -4,10 +4,9 @@ import * as React from "react";
 
 import { cn } from "@/lib/cva.config";
 
-const Label = React.forwardRef<HTMLLabelElement, React.ComponentPropsWithoutRef<"label">>(
-  ({ className, ...props }, ref) => (
+function Label({ className, ...props }: React.ComponentProps<"label">) {
+  return (
     <label
-      ref={ref}
       data-slot="label"
       className={cn(
         "flex items-center gap-2 text-sm leading-none font-medium select-none group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 peer-disabled:cursor-not-allowed peer-disabled:opacity-50",
@@ -15,8 +14,7 @@ const Label = React.forwardRef<HTMLLabelElement, React.ComponentPropsWithoutRef<
       )}
       {...props}
     />
-  ),
-);
-Label.displayName = "Label";
+  );
+}
 
 export { Label };

--- a/ui/litellm-dashboard/src/components/ui/ref-forwarding.test.tsx
+++ b/ui/litellm-dashboard/src/components/ui/ref-forwarding.test.tsx
@@ -11,6 +11,7 @@ import { Label } from "./label";
 import { Separator } from "./separator";
 import { Skeleton } from "./skeleton";
 import { Table, TableBody, TableCaption, TableCell, TableFooter, TableHead, TableHeader, TableRow } from "./table";
+import { Textarea } from "./textarea";
 import { UiLoadingSpinner } from "./ui-loading-spinner";
 
 describe("ui primitives forward refs to their DOM node", () => {
@@ -48,6 +49,12 @@ describe("ui primitives forward refs to their DOM node", () => {
     const ref = React.createRef<HTMLDivElement>();
     render(<Skeleton ref={ref} />);
     expect(ref.current).toBeInstanceOf(HTMLDivElement);
+  });
+
+  it("Textarea", () => {
+    const ref = React.createRef<HTMLTextAreaElement>();
+    render(<Textarea ref={ref} />);
+    expect(ref.current).toBeInstanceOf(HTMLTextAreaElement);
   });
 
   it("UiLoadingSpinner", () => {

--- a/ui/litellm-dashboard/src/components/ui/separator.tsx
+++ b/ui/litellm-dashboard/src/components/ui/separator.tsx
@@ -1,14 +1,12 @@
 "use client";
 
 import { Separator as SeparatorPrimitive } from "@base-ui/react/separator";
-import * as React from "react";
 
 import { cn } from "@/lib/cva.config";
 
-const Separator = React.forwardRef<React.ComponentRef<typeof SeparatorPrimitive>, SeparatorPrimitive.Props>(
-  ({ className, orientation = "horizontal", ...props }, ref) => (
+function Separator({ className, orientation = "horizontal", ...props }: SeparatorPrimitive.Props) {
+  return (
     <SeparatorPrimitive
-      ref={ref}
       data-slot="separator"
       orientation={orientation}
       className={cn(
@@ -17,8 +15,7 @@ const Separator = React.forwardRef<React.ComponentRef<typeof SeparatorPrimitive>
       )}
       {...props}
     />
-  ),
-);
-Separator.displayName = "Separator";
+  );
+}
 
 export { Separator };

--- a/ui/litellm-dashboard/src/components/ui/skeleton.tsx
+++ b/ui/litellm-dashboard/src/components/ui/skeleton.tsx
@@ -1,12 +1,7 @@
-import * as React from "react";
-
 import { cn } from "@/lib/cva.config";
 
-const Skeleton = React.forwardRef<HTMLDivElement, React.ComponentPropsWithoutRef<"div">>(
-  ({ className, ...props }, ref) => (
-    <div ref={ref} data-slot="skeleton" className={cn("animate-pulse rounded-md bg-muted", className)} {...props} />
-  ),
-);
-Skeleton.displayName = "Skeleton";
+function Skeleton({ className, ...props }: React.ComponentProps<"div">) {
+  return <div data-slot="skeleton" className={cn("animate-pulse rounded-md bg-muted", className)} {...props} />;
+}
 
 export { Skeleton };

--- a/ui/litellm-dashboard/src/components/ui/textarea.tsx
+++ b/ui/litellm-dashboard/src/components/ui/textarea.tsx
@@ -2,10 +2,9 @@ import * as React from "react";
 
 import { cn } from "@/lib/cva.config";
 
-const Textarea = React.forwardRef<HTMLTextAreaElement, React.ComponentProps<"textarea">>(
-  ({ className, ...props }, ref) => (
+function Textarea({ className, ...props }: React.ComponentProps<"textarea">) {
+  return (
     <textarea
-      ref={ref}
       data-slot="textarea"
       className={cn(
         "flex field-sizing-content min-h-16 w-full rounded-md border border-input bg-transparent px-2.5 py-2 text-base shadow-xs transition-[color,box-shadow] outline-none placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 md:text-sm dark:bg-input/30 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40",
@@ -13,8 +12,7 @@ const Textarea = React.forwardRef<HTMLTextAreaElement, React.ComponentProps<"tex
       )}
       {...props}
     />
-  ),
-);
-Textarea.displayName = "Textarea";
+  );
+}
 
 export { Textarea };


### PR DESCRIPTION
## TLDR

**Problem this solves:**

- `POST /v1/batches` spends ~10s per 652-row file tokenizing rows whose token totals are then thrown away
- It happens whenever a key has a restricted `models` list, *even with `disable_batch_input_file_rate_limiting: true`*
- The opt-out is unreachable for those keys: `_should_skip_batch_input_file_processing` returns on the allowlist check first

**How it solves it:**

- Adds a models-only read: collect each row's `body.model`, skip `_count_entry_tokens`
- Allowlist enforcement unchanged — file still downloaded, every `body.model` still validated
- Purely additive; no existing signature or return shape changes

## The problem

`_should_skip_batch_input_file_processing` consults the operator opt-outs *after* the model-allowlist check:

```python
if self._key_requires_batch_model_access_check(user_api_key_dict):
    return False, None                      # restricted `models` -> full path, always

if general_settings.get("disable_batch_input_file_rate_limiting") is True:
    return True, None                       # never reached for such keys
```

The download itself is genuinely required — the allowlist can only be enforced by inspecting every row. But `count_input_file_usage` also runs `_count_entry_tokens` (a real tokenizer) per row, and `async_pre_call_hook` then discards the totals because nothing charges them.

That tokenization is the expensive half, and it is **synchronous CPU work inside the async pre-call hook**.

### Production measurements

Observed on a proxy running v1.96.2, during a nightly backfill submitting 652-row batches to `vertex_ai/gemini-2.5-flash`:

| | latency |
|---|---|
| `POST /v1/batches` (652 rows) | **10~12s** |
| batch status polling, same key | 0.55~0.64s |
| interactive calls, same deployment | 0.5~0.7s |

This held a proxy-wide average-latency monitor above its threshold for as long as a batch was running. Reproduced with **zero 429s**, so it is not retry-driven — it is the cost of the read itself.

## The fix

- `_batch_input_file_models_only()` reports when the JSONL is needed solely for the allowlist
- `count_input_file_usage(models_only=...)` then collects `body.model` without tokenizing
- `async_pre_call_hook` returns before counter enforcement in that mode, leaving `_batch_*_count` unset — matching the existing full-skip path rather than recording zeroes

Deliberately conservative — it returns `False` whenever anything still needs the totals:

- unrestricted keys (already covered by the existing full-skip paths)
- **enqueued-token scopes**, whose reservation is priced from the totals
- no opt-out configured

## Tests

4 added to `tests/test_litellm/proxy/hooks/test_batch_file_validation.py`; suite goes **79 → 83 passing**.

| test | asserts |
|---|---|
| `..._skips_tokenization_for_restricted_key` | file *is* downloaded and allowlist *is* enforced, but `_count_entry_tokens` is never called and no counters are charged |
| `..._still_rejects_unauthorized_model` | a disallowed model in the JSONL still raises 403 — the opt-out must not become an authz bypass |
| `test_restricted_key_without_opt_out_still_counts_tokens` | the pre-existing path is untouched |
| `..._disabled_when_enqueued_scopes_apply` | enqueued reservations still get real totals |

`async_pre_call_hook` swallows unexpected exceptions and returns `data`, so the returned value alone proves nothing — each test also asserts on the calls that separate the intended path from error recovery.

**Control:** reverting only the source change (tests kept) fails the first test with

```
AssertionError: Expected '_count_entry_tokens' to not have been called. Called 2 times.
```

confirming the test is load-bearing rather than vacuous.

## Relevant issues

I could not find an existing issue for this. Note that **#35408** and **#35813** touch the same function (bounding the input-file read with a deadline) — this change is orthogonal (it reduces work *within* the read) but will likely need a trivial rebase against whichever lands first.

## Linear ticket

n/a — external contribution.

## Pre-Submission checklist

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (not yet run)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5**

## Screenshots / Proof of Fix

Run against `main` in a container, with the import origin printed so it is unambiguous which tree is under test:

```
IMPORTED FROM: /oss/litellm
helper present: True
83 passed, 1 warning in 9.13s
```

Control, same command against an otherwise identical tree with only the source change reverted:

```
IMPORTED FROM: /ctrl/litellm
helper present: False
FAILED tests/.../test_batch_file_validation.py::test_models_only_read_skips_tokenization_for_restricted_key
1 failed, 3 passed
```