### PR TITLE
fix(cost_calculator): don't double-prefix aliased model_name in cost lookup

### DIFF
--- a/litellm/cost_calculator.py
+++ b/litellm/cost_calculator.py
@@ -795,9 +795,29 @@ def _select_model_name_for_cost_calc(
         and not _model_contains_known_llm_provider(return_model)
     ):  # add provider prefix if not already present, to match model_cost
         if region_name is not None:
-            return_model = f"{custom_llm_provider}/{region_name}/{return_model}"
+            prefixed = f"{custom_llm_provider}/{region_name}/{return_model}"
         else:
-            return_model = f"{custom_llm_provider}/{return_model}"
+            prefixed = f"{custom_llm_provider}/{return_model}"
+
+        # If `return_model` already contains a "/" whose leading segment is
+        # not a registered provider (i.e. it's an aliased public name like
+        # "vertex/claude-opus-5"), the naive prefix produces a double-prefixed
+        # key ("vertex_ai/vertex/claude-opus-5") that isn't in
+        # `litellm.model_cost`, silently pricing the request at $0. In that
+        # case, prefer the tail-only form ("vertex_ai/claude-opus-5") when it
+        # resolves against the model cost. See issue #38069.
+        if "/" in return_model and prefixed not in litellm.model_cost:
+            tail: Final = return_model.split("/", 1)[1]
+            if region_name is not None:
+                tail_prefixed: Final = f"{custom_llm_provider}/{region_name}/{tail}"
+            else:
+                tail_prefixed = f"{custom_llm_provider}/{tail}"
+            if tail_prefixed in litellm.model_cost:
+                return_model = tail_prefixed
+            else:
+                return_model = prefixed
+        else:
+            return_model = prefixed
 
     return return_model
 

--- a/litellm/cost_calculator.py
+++ b/litellm/cost_calculator.py
@@ -794,32 +794,42 @@ def _select_model_name_for_cost_calc(
         and custom_llm_provider is not None
         and not _model_contains_known_llm_provider(return_model)
     ):  # add provider prefix if not already present, to match model_cost
-        if region_name is not None:
-            prefixed = f"{custom_llm_provider}/{region_name}/{return_model}"
-        else:
-            prefixed = f"{custom_llm_provider}/{return_model}"
-
-        # If `return_model` already contains a "/" whose leading segment is
-        # not a registered provider (i.e. it's an aliased public name like
-        # "vertex/claude-opus-5"), the naive prefix produces a double-prefixed
-        # key ("vertex_ai/vertex/claude-opus-5") that isn't in
-        # `litellm.model_cost`, silently pricing the request at $0. In that
-        # case, prefer the tail-only form ("vertex_ai/claude-opus-5") when it
-        # resolves against the model cost. See issue #38069.
-        if "/" in return_model and prefixed not in litellm.model_cost:
-            tail: Final = return_model.split("/", 1)[1]
-            if region_name is not None:
-                tail_prefixed: Final = f"{custom_llm_provider}/{region_name}/{tail}"
-            else:
-                tail_prefixed = f"{custom_llm_provider}/{tail}"
-            if tail_prefixed in litellm.model_cost:
-                return_model = tail_prefixed
-            else:
-                return_model = prefixed
-        else:
-            return_model = prefixed
+        return_model = _apply_provider_prefix_for_cost_lookup(
+            return_model=return_model,
+            custom_llm_provider=custom_llm_provider,
+            region_name=region_name,
+        )
 
     return return_model
+
+
+def _apply_provider_prefix_for_cost_lookup(
+    return_model: str,
+    custom_llm_provider: str,
+    region_name: str | None,
+) -> str:
+    """Prepend the real provider prefix to a model name for `model_cost` lookup.
+
+    If `return_model` already contains a "/" whose leading segment isn't a
+    registered provider (i.e. it's an aliased public name like
+    ``vertex/claude-opus-5``), the naive prefix produces a double-prefixed key
+    (``vertex_ai/vertex/claude-opus-5``) that isn't in ``litellm.model_cost``,
+    silently pricing the request at $0. In that case, prefer the tail-only form
+    (``vertex_ai/claude-opus-5``) when it resolves against the model cost.
+    See issue #38069.
+    """
+    prefixed: Final = (
+        f"{custom_llm_provider}/{region_name}/{return_model}"
+        if region_name is not None
+        else f"{custom_llm_provider}/{return_model}"
+    )
+    if "/" not in return_model or prefixed in litellm.model_cost:
+        return prefixed
+    tail: Final = return_model.split("/", 1)[1]
+    tail_prefixed: Final = (
+        f"{custom_llm_provider}/{region_name}/{tail}" if region_name is not None else f"{custom_llm_provider}/{tail}"
+    )
+    return tail_prefixed if tail_prefixed in litellm.model_cost else prefixed
 
 
 @lru_cache(maxsize=DEFAULT_MAX_LRU_CACHE_SIZE)

--- a/tests/test_litellm/test_cost_calculator.py
+++ b/tests/test_litellm/test_cost_calculator.py
@@ -3799,6 +3799,34 @@ def test_select_model_name_avoids_double_prefix_for_aliased_public_name(
     assert selected in litellm.model_cost
 
 
+def test_select_model_name_uses_region_when_stripping_alias_prefix(
+    _local_model_cost_map,
+):
+    """The alias-tail fallback must keep any ``region_name`` uplift key that the
+    naive prefix would have used. Regression test for the region branch of
+    ``_apply_provider_prefix_for_cost_lookup``."""
+    from litellm.cost_calculator import _apply_provider_prefix_for_cost_lookup
+
+    litellm.register_model(
+        {
+            "vertex_ai/us-east5/claude-3-5-sonnet": {
+                "input_cost_per_token": 3e-6,
+                "output_cost_per_token": 1.5e-5,
+                "litellm_provider": "vertex_ai",
+            }
+        }
+    )
+
+    resolved = _apply_provider_prefix_for_cost_lookup(
+        return_model="vertex/claude-3-5-sonnet",
+        custom_llm_provider="vertex_ai",
+        region_name="us-east5",
+    )
+
+    assert resolved == "vertex_ai/us-east5/claude-3-5-sonnet"
+    assert resolved in litellm.model_cost
+
+
 def test_select_model_name_keeps_prefix_when_alias_has_no_resolvable_tail(
     _local_model_cost_map,
 ):

--- a/tests/test_litellm/test_cost_calculator.py
+++ b/tests/test_litellm/test_cost_calculator.py
@@ -3758,6 +3758,77 @@ def test_combine_usage_objects_sums_mirrored_cache_write_fields_once():
     assert combined_pair.prompt_tokens_details.cache_creation_tokens == 100
 
 
+def test_select_model_name_avoids_double_prefix_for_aliased_public_name(
+    _local_model_cost_map,
+):
+    """A ``model_list`` entry may expose a public alias whose name contains a
+    ``/`` whose leading segment is not a registered provider, e.g.
+
+        model_name: vertex/claude-3-5-sonnet
+        litellm_params:
+          model: vertex_ai/claude-3-5-sonnet
+
+    On streamed responses the assembled ``completion_response.model`` carries
+    the alias rather than the real deployment name. Naively prepending the
+    real provider prefix produced ``vertex_ai/vertex/claude-3-5-sonnet``,
+    which is not a key in ``litellm.model_cost``, so cost lookup silently
+    returned $0. Regression test for #38069.
+    """
+    from litellm.cost_calculator import _select_model_name_for_cost_calc
+
+    resp = litellm.ModelResponse(
+        id="x",
+        choices=[
+            {
+                "index": 0,
+                "message": {"role": "assistant", "content": "hi"},
+                "finish_reason": "stop",
+            }
+        ],
+        model="vertex/claude-3-5-sonnet",
+    )
+    resp._hidden_params = {}
+
+    selected = _select_model_name_for_cost_calc(
+        model=None,
+        completion_response=resp,
+        custom_llm_provider="vertex_ai",
+    )
+
+    assert selected == "vertex_ai/claude-3-5-sonnet"
+    assert selected in litellm.model_cost
+
+
+def test_select_model_name_keeps_prefix_when_alias_has_no_resolvable_tail(
+    _local_model_cost_map,
+):
+    """If neither the double-prefixed nor the tail-only form is in
+    ``litellm.model_cost``, fall back to the original prefixed name so
+    downstream callers see the same string they did before #38069."""
+    from litellm.cost_calculator import _select_model_name_for_cost_calc
+
+    resp = litellm.ModelResponse(
+        id="x",
+        choices=[
+            {
+                "index": 0,
+                "message": {"role": "assistant", "content": "hi"},
+                "finish_reason": "stop",
+            }
+        ],
+        model="alias/model-that-does-not-exist",
+    )
+    resp._hidden_params = {}
+
+    selected = _select_model_name_for_cost_calc(
+        model=None,
+        completion_response=resp,
+        custom_llm_provider="vertex_ai",
+    )
+
+    assert selected == "vertex_ai/alias/model-that-does-not-exist"
+
+
 def test_completion_cost_prices_anthropic_shaped_cache_read_tokens(_local_model_cost_map):
     """Regression: an Anthropic /v1/messages response reports cache reads as top-level
     cache_read_input_tokens with input_tokens excluding them. Reading that usage as


### PR DESCRIPTION
## TLDR

Problem this solves:

- Streamed requests through a Router alias like `vertex/claude-opus-5` price at $0
- Non-streamed path priced correctly, so budgets and spend silently disagreed
- Any `model_name` containing `/` whose leading segment isn't a registered provider hit this

How it solves it:

- Detect the aliased-name case and try the tail-only prefix (`{provider}/{alias_tail}`)
- Use it when it exists in `litellm.model_cost`; keep the naive prefix otherwise
- Same output as before when the alias resolves or when the assembled name is unknown

## User Flow

Before: an admin using a `model_list` alias containing `/` sees streamed spend silently drop to $0, so budget caps never trip

1. The admin configures the proxy with `model_list: [{ model_name: vertex/claude-3-5-sonnet, litellm_params: { model: vertex_ai/claude-3-5-sonnet, ... } }]` and restarts.
2. A developer's editor integration sends `POST https://litellm-domain/v1/chat/completions` with `"model": "vertex/claude-3-5-sonnet"` and `"stream": true`.
3. The response streams back normally with real token counts.
4. The admin opens `https://litellm-domain/ui/?page=logs` and sees the request logged with full tokens but `$0.00` spend.
5. The same request repeated hundreds of times keeps recording `$0.00`, so any team/key budget cap on that alias never trips.

After: the same request lands on the same alias-key in `litellm.model_cost` and prices correctly, so streamed spend matches non-streamed

1. The admin keeps the same `model_list` and restarts on this build.
2. The developer sends the same `POST https://litellm-domain/v1/chat/completions` with `"model": "vertex/claude-3-5-sonnet"` and `"stream": true`.
3. The response streams back normally with real token counts.
4. `https://litellm-domain/ui/?page=logs` now shows the request at non-zero spend, matching the identical non-streamed call.
5. Budget caps on that alias trip on the same accumulated spend as before the streaming path diverged.

## Relevant issues

Fixes #38069

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile will review once opened)

## Screenshots / Proof of Fix

### Before (b48ee38-equivalent, i.e. `litellm_internal_staging` tip prior to this PR)

#### `_select_model_name_for_cost_calc` with an aliased public name

1. Command:

    ```python
    import litellm
    from litellm.cost_calculator import _select_model_name_for_cost_calc

    resp = litellm.ModelResponse(
        id="x",
        choices=[{"index": 0, "message": {"role": "assistant", "content": "hi"}, "finish_reason": "stop"}],
        model="vertex/claude-3-5-sonnet",
    )
    resp._hidden_params = {}
    print(_select_model_name_for_cost_calc(model=None, completion_response=resp, custom_llm_provider="vertex_ai"))
    ```

2. Output:

    ```
    vertex_ai/vertex/claude-3-5-sonnet
    ```

    Not a key in `litellm.model_cost`, so `completion_cost()` returns `0.0`.

### After (6b707ca)

#### `_select_model_name_for_cost_calc` with an aliased public name

1. Same command as Before.
2. Output:

    ```
    vertex_ai/claude-3-5-sonnet
    ```

    Present in `litellm.model_cost`, so `completion_cost()` returns the expected non-zero value.

#### Targeted regression tests

1. Command (from the repo root, `PYTHONPATH=.` so the local source is loaded):

    ```
    pytest tests/test_litellm/test_cost_calculator.py \
        -k "select_model_name or router_model_id or duplicate_openai_prefix or completion_cost_uses_response_model" -v
    ```

2. Output:

    ```
    tests/test_litellm/test_cost_calculator.py::test_completion_cost_uses_response_model_for_dynamic_routing PASSED
    tests/test_litellm/test_cost_calculator.py::test_cost_per_token_duplicate_openai_prefix_matches_model_cost PASSED
    tests/test_litellm/test_cost_calculator.py::test_custom_pricing_cost_calc_uses_router_model_id_from_litellm_metadata PASSED
    tests/test_litellm/test_cost_calculator.py::test_select_model_name_avoids_double_prefix_for_aliased_public_name PASSED
    tests/test_litellm/test_cost_calculator.py::test_select_model_name_keeps_prefix_when_alias_has_no_resolvable_tail PASSED
    tests/test_litellm/test_cost_calculator.py::test_tiered_pricing_only_deployment_selects_router_model_id PASSED
    6 passed
    ```

## Type

🐛 Bug Fix

## Caveats

### Low

- Behavior only changes when the naive prefix would produce a key that is **not** in `litellm.model_cost`. If that key is already present (existing coverage), the output is identical to before.
- The fallback strips only the alias's leading `/`-segment. Aliases with more than one leading segment (e.g. `region/team/model`) that don't resolve either way still land on the previous behavior.

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
