### PR TITLE
fix(batches): skip discarded tokenization on allowlist-only batch input file reads

### DIFF
--- a/litellm/proxy/hooks/batch_rate_limiter.py
+++ b/litellm/proxy/hooks/batch_rate_limiter.py
@@ -361,6 +361,47 @@ class _PROXY_BatchRateLimiter(CustomLogger):
 
         return False, descriptors
 
+    def _batch_input_file_models_only(
+        self,
+        data: dict,  # mutable-ok: read only here, and mirrors the sibling skip helper's signature
+        user_api_key_dict: UserAPIKeyAuth,
+        has_enqueued_scopes: bool = False,
+    ) -> bool:
+        """True when the JSONL is read only to validate ``body.model``.
+
+        ``_should_skip_batch_input_file_processing`` returns on the model
+        allowlist check before it consults the operator opt-outs, so a key with a
+        restricted ``models`` list always takes the full path even when batch
+        input-file rate limiting is disabled. The download itself is still
+        required -- the allowlist can only be enforced by inspecting every row --
+        but the per-row token counting it also performs is then discarded by the
+        caller.
+
+        Reporting that case lets the read collect ``body.model`` without
+        tokenizing each row. Enforcement is unchanged: this returns False
+        whenever anything still needs the totals, including enqueued-token
+        scopes, whose reservation is priced from them.
+        """
+        from litellm.proxy.proxy_server import general_settings
+
+        if has_enqueued_scopes:
+            return False
+
+        if not self._key_requires_batch_model_access_check(user_api_key_dict):
+            # An unrestricted key is already covered by the full-skip paths.
+            return False
+
+        if general_settings.get("disable_batch_input_file_rate_limiting") is True:
+            return True
+
+        skip_providers: Final = tuple(general_settings.get("skip_batch_input_file_rate_limiting_for_providers") or ())
+        if skip_providers:
+            batch_provider: Final = self._resolve_batch_provider(self._get_batch_routing_model(data))
+            if batch_provider and batch_provider in skip_providers:
+                return True
+
+        return False
+
     def _warn_if_unsupported_model_skip_configured(self, general_settings: dict) -> None:
         """Warn once that ``skip_batch_input_file_rate_limiting_for_models`` is a no-op.
 
@@ -729,6 +770,7 @@ class _PROXY_BatchRateLimiter(CustomLogger):
         user_api_key_dict: UserAPIKeyAuth | None = None,
         data: dict | None = None,
         descriptors: Sequence["RateLimitDescriptor"] | None = None,
+        models_only: bool = False,
     ) -> BatchFileUsage:
         """
         Count number of requests and tokens in a batch input file.
@@ -739,6 +781,10 @@ class _PROXY_BatchRateLimiter(CustomLogger):
             user_api_key_dict: User authentication information for file access (required for managed files)
             descriptors: Rate limit descriptors already computed for this batch, so the
                 configured project OTPM limit can scale the no-``max_tokens`` output floor
+            models_only: Collect and validate every row's ``body.model`` but skip
+                per-row token counting. Set when the file is read solely for
+                allowlist enforcement, so the token fields come back 0 and the
+                caller must not charge them.
 
         Returns:
             BatchFileUsage with total_tokens, output_tokens, request_count, and
@@ -831,6 +877,10 @@ class _PROXY_BatchRateLimiter(CustomLogger):
                 try:
                     entry = json.loads(raw_line)
                 except Exception:
+                    if models_only:
+                        # A malformed row names no model, so skipping its size
+                        # estimate cannot weaken the allowlist check below.
+                        continue
                     entry_total_tokens = _estimate_batch_entry_tokens(raw_line)
                     entry_output_tokens = self.parallel_request_limiter.no_max_tokens_output_floor(
                         min_configured_otpm_limit
@@ -842,6 +892,12 @@ class _PROXY_BatchRateLimiter(CustomLogger):
                 model: str | None = (entry.get("body") or {}).get("model") if isinstance(entry, dict) else None
                 if model:
                     models.add(model)
+
+                if models_only:
+                    # Every row's `body.model` is collected above, which is all
+                    # `_enforce_batch_file_model_access` needs. Tokenizing here
+                    # would be work the caller throws away.
+                    continue
 
                 if isinstance(entry, dict):
                     entry_output_tokens = self._estimate_entry_output_tokens(entry, min_configured_otpm_limit)
@@ -1109,6 +1165,12 @@ class _PROXY_BatchRateLimiter(CustomLogger):
             if should_skip:
                 return data
 
+            models_only: Final = self._batch_input_file_models_only(
+                data=data,
+                user_api_key_dict=user_api_key_dict,
+                has_enqueued_scopes=bool(enqueued_scopes),
+            )
+
             # Get custom_llm_provider for token counting
             custom_llm_provider: Final = data.get("custom_llm_provider", "openai")
 
@@ -1120,7 +1182,18 @@ class _PROXY_BatchRateLimiter(CustomLogger):
                 user_api_key_dict=user_api_key_dict,
                 data=data,
                 descriptors=batch_rate_limit_descriptors,
+                models_only=models_only,
             )
+
+            if models_only:
+                # The allowlist was enforced inside count_input_file_usage and
+                # nothing charges this batch, so there are no counters to check.
+                # Returning here keeps the zeroed totals out of `data`, matching
+                # the full-skip path above which also leaves them unset.
+                verbose_proxy_logger.debug(
+                    "Batch model-access validation passed; batch input file rate limiting disabled"
+                )
+                return data
 
             verbose_proxy_logger.debug(
                 "Batch input file usage - Tokens: %s, Requests: %s", batch_usage.total_tokens, batch_usage.request_count

--- a/tests/test_litellm/proxy/hooks/test_batch_file_validation.py
+++ b/tests/test_litellm/proxy/hooks/test_batch_file_validation.py
@@ -2286,3 +2286,268 @@ async def test_disable_flag_still_skips_batch_processing_with_enqueued_limits():
 
     assert result is data
     afile_content_mock.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# Models-only read: the allowlist forces the download, nothing charges the
+# tokens, so the per-row tokenization is skipped.
+# ---------------------------------------------------------------------------
+
+_MODELS_ONLY_ALLOWED = "gpt-4o-mini"
+_MODELS_ONLY_DENIED = "gpt-4o"
+
+
+def _models_only_file(models):
+    """A JSONL batch file naming ``models``, one chat row each."""
+    import json as _json
+
+    body = "\n".join(
+        _json.dumps({"body": {"model": m, "messages": [{"role": "user", "content": "x" * 64}]}})
+        for m in models
+    )
+    content = MagicMock()
+    content.content = body.encode("utf-8")
+    return content
+
+
+def _restricted_user(**kwargs):
+    return UserAPIKeyAuth(
+        api_key="sk-restricted-models-only",
+        user_id="alice",
+        models=[_MODELS_ONLY_ALLOWED],
+        user_role=LitellmUserRoles.INTERNAL_USER.value,
+        **kwargs,
+    )
+
+
+@pytest.mark.asyncio
+async def test_models_only_read_skips_tokenization_for_restricted_key():
+    """Opt-out set + model allowlist: read the file, validate it, don't tokenize.
+
+    ``async_pre_call_hook`` swallows unexpected exceptions and returns ``data``,
+    so the returned value alone proves nothing — assert on the calls that
+    separate the intended path from error recovery.
+    """
+    rate_limiter = _make_rate_limiter()
+    data = {"input_file_id": "file-abc123"}
+    afile_content = AsyncMock(return_value=_models_only_file([_MODELS_ONLY_ALLOWED] * 2))
+
+    with (
+        patch(  # test-quality-ok: operator config is a module global read at call time; the hook exposes no injection point
+            "litellm.proxy.proxy_server.general_settings",
+            {"disable_batch_input_file_rate_limiting": True},
+        ),
+        patch("litellm.proxy.proxy_server.llm_router", None),  # test-quality-ok: module global; None selects the no-router provider-resolution path
+        patch("litellm.afile_content", new=afile_content),  # test-quality-ok: this is the file-read boundary the test fakes; nothing HTTP sits below it here
+        patch("litellm.proxy.hooks.batch_rate_limiter._count_entry_tokens") as count_entry_tokens,  # test-quality-ok: the call under assertion -- the test's subject is whether it runs
+        patch.object(rate_limiter, "_enforce_batch_file_model_access", new=AsyncMock()) as enforce,
+        patch.object(rate_limiter, "_check_and_increment_batch_counters", new=AsyncMock()) as counters,
+    ):
+        result = await rate_limiter.async_pre_call_hook(
+            user_api_key_dict=_restricted_user(),
+            cache=MagicMock(),
+            data=data,
+            call_type="acreate_batch",
+        )
+
+    assert result == data
+    # Not the full-skip path: the file really was downloaded...
+    afile_content.assert_awaited_once()
+    # ...and every model in it was still checked against the allowlist.
+    enforce.assert_awaited_once()
+    assert set(enforce.await_args.kwargs["models"]) == {_MODELS_ONLY_ALLOWED}
+    # Nothing charges this batch, so the discarded tokenization is skipped.
+    count_entry_tokens.assert_not_called()
+    counters.assert_not_awaited()
+    assert "_batch_token_count" not in data
+
+
+@pytest.mark.asyncio
+async def test_models_only_read_still_rejects_unauthorized_model():
+    """The opt-out must not turn into an authorization bypass."""
+    rate_limiter = _make_rate_limiter()
+    afile_content = AsyncMock(return_value=_models_only_file([_MODELS_ONLY_DENIED]))
+
+    async def _raise_unauthorized(**kwargs):
+        raise Exception(
+            f"Key not allowed to access model. This key only has access to "
+            f"models={kwargs['valid_token'].models}"
+        )
+
+    with (
+        patch(  # test-quality-ok: operator config is a module global read at call time; the hook exposes no injection point
+            "litellm.proxy.proxy_server.general_settings",
+            {"disable_batch_input_file_rate_limiting": True},
+        ),
+        patch("litellm.proxy.proxy_server.llm_router", None),  # test-quality-ok: module global; None selects the no-router provider-resolution path
+        patch("litellm.afile_content", new=afile_content),  # test-quality-ok: this is the file-read boundary the test fakes; nothing HTTP sits below it here
+        patch(  # test-quality-ok: stands in for the authorization decision being simulated
+            "litellm.proxy.auth.auth_checks.can_key_call_model",
+            new=AsyncMock(side_effect=_raise_unauthorized),
+        ),
+    ):
+        with pytest.raises(HTTPException) as exc:
+            await rate_limiter.async_pre_call_hook(
+                user_api_key_dict=_restricted_user(),
+                cache=MagicMock(),
+                data={"input_file_id": "file-abc123"},
+                call_type="acreate_batch",
+            )
+
+    assert exc.value.status_code == 403
+    assert _MODELS_ONLY_DENIED in str(exc.value.detail)
+    afile_content.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_restricted_key_without_opt_out_still_counts_tokens():
+    """No opt-out configured: the pre-existing path is untouched."""
+    rate_limiter = _make_rate_limiter()
+    afile_content = AsyncMock(return_value=_models_only_file([_MODELS_ONLY_ALLOWED] * 2))
+    data = {"input_file_id": "file-abc123"}
+
+    with (
+        patch("litellm.proxy.proxy_server.general_settings", {}),  # test-quality-ok: operator config is a module global read at call time; the hook exposes no injection point
+        patch("litellm.proxy.proxy_server.llm_router", None),  # test-quality-ok: module global; None selects the no-router provider-resolution path
+        patch("litellm.afile_content", new=afile_content),  # test-quality-ok: this is the file-read boundary the test fakes; nothing HTTP sits below it here
+        patch(  # test-quality-ok: the call under assertion -- the test's subject is whether it runs
+            "litellm.proxy.hooks.batch_rate_limiter._count_entry_tokens", return_value=7
+        ) as count_entry_tokens,
+        patch.object(rate_limiter, "_enforce_batch_file_model_access", new=AsyncMock()),
+        patch.object(rate_limiter, "_check_and_increment_batch_counters", new=AsyncMock()) as counters,
+    ):
+        result = await rate_limiter.async_pre_call_hook(
+            user_api_key_dict=_restricted_user(),
+            cache=MagicMock(),
+            data=data,
+            call_type="acreate_batch",
+        )
+
+    assert result == data
+    afile_content.assert_awaited_once()
+    assert count_entry_tokens.call_count == 2
+    counters.assert_awaited_once()
+    assert data["_batch_token_count"] == 14
+    assert data["_batch_request_count"] == 2
+
+
+@pytest.mark.asyncio
+async def test_models_only_read_disabled_when_enqueued_scopes_apply():
+    """Enqueued-token reservations are priced from the totals, so keep counting."""
+    rate_limiter = _make_rate_limiter()
+    afile_content = AsyncMock(return_value=_models_only_file([_MODELS_ONLY_ALLOWED] * 2))
+
+    with (
+        patch(  # test-quality-ok: operator config is a module global read at call time; the hook exposes no injection point
+            "litellm.proxy.proxy_server.general_settings",
+            {"disable_batch_input_file_rate_limiting": True},
+        ),
+        patch("litellm.proxy.proxy_server.llm_router", None),  # test-quality-ok: module global; None selects the no-router provider-resolution path
+        patch("litellm.afile_content", new=afile_content),  # test-quality-ok: this is the file-read boundary the test fakes; nothing HTTP sits below it here
+        patch(  # test-quality-ok: the call under assertion -- the test's subject is whether it runs
+            "litellm.proxy.hooks.batch_rate_limiter._count_entry_tokens", return_value=7
+        ) as count_entry_tokens,
+        patch.object(rate_limiter, "_enforce_batch_file_model_access", new=AsyncMock()),
+        patch.object(rate_limiter, "_reserve_batch_enqueued_tokens", new=AsyncMock()) as reserve,
+    ):
+        data = {"input_file_id": "file-abc123"}
+        await rate_limiter.async_pre_call_hook(
+            user_api_key_dict=_restricted_user(metadata={"batch_enqueued_token_limit": 10}),
+            cache=MagicMock(),
+            data=data,
+            call_type="acreate_batch",
+        )
+
+    assert count_entry_tokens.call_count == 2
+    reserve.assert_awaited_once()
+    assert data["_batch_token_count"] == 14
+
+
+def _models_only_file_with_malformed_row(model):
+    """One valid row plus a line that is not JSON at all."""
+    import json as _json
+
+    body = "\n".join(
+        [
+            _json.dumps({"body": {"model": model, "messages": [{"role": "user", "content": "x" * 64}]}}),
+            "{ this is not json",
+        ]
+    )
+    content = MagicMock()
+    content.content = body.encode("utf-8")
+    return content
+
+
+@pytest.mark.asyncio
+async def test_models_only_read_applies_to_skip_listed_provider():
+    """The provider skip list reaches the models-only path too, not just the global flag."""
+    rate_limiter = _make_rate_limiter()
+    data = {"input_file_id": "file-abc123", "model": "my-vllm-model"}
+    afile_content = AsyncMock(return_value=_models_only_file([_MODELS_ONLY_ALLOWED]))
+
+    with (
+        patch(  # test-quality-ok: operator config is a module global read at call time; the hook exposes no injection point
+            "litellm.proxy.proxy_server.general_settings",
+            {"skip_batch_input_file_rate_limiting_for_providers": ["hosted_vllm"]},
+        ),
+        patch("litellm.proxy.proxy_server.llm_router", MagicMock()),  # test-quality-ok: module global; a router must exist for provider resolution
+        patch(  # test-quality-ok: stands in for the deployment credentials the provider is resolved from
+            "litellm.proxy.openai_files_endpoints.common_utils.get_credentials_for_model",
+            return_value={"custom_llm_provider": "hosted_vllm"},
+        ),
+        patch("litellm.afile_content", new=afile_content),  # test-quality-ok: this is the file-read boundary the test fakes; nothing HTTP sits below it here
+        patch("litellm.proxy.hooks.batch_rate_limiter._count_entry_tokens") as count_entry_tokens,  # test-quality-ok: the call under assertion -- the test's subject is whether it runs
+        patch.object(rate_limiter, "_enforce_batch_file_model_access", new=AsyncMock()) as enforce,
+    ):
+        result = await rate_limiter.async_pre_call_hook(
+            user_api_key_dict=_restricted_user(),
+            cache=MagicMock(),
+            data=data,
+            call_type="acreate_batch",
+        )
+
+    assert result == data
+    # A restricted key still forces the download, so this is the models-only path
+    # rather than the full skip that an unrestricted key would take.
+    afile_content.assert_awaited_once()
+    enforce.assert_awaited_once()
+    count_entry_tokens.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_models_only_read_skips_size_estimate_for_malformed_row():
+    """A row that is not JSON names no model, so it needs no size estimate either."""
+    rate_limiter = _make_rate_limiter()
+    afile_content = AsyncMock(return_value=_models_only_file_with_malformed_row(_MODELS_ONLY_ALLOWED))
+
+    with (
+        patch(  # test-quality-ok: operator config is a module global read at call time; the hook exposes no injection point
+            "litellm.proxy.proxy_server.general_settings",
+            {"disable_batch_input_file_rate_limiting": True},
+        ),
+        patch("litellm.proxy.proxy_server.llm_router", None),  # test-quality-ok: module global; None selects the no-router provider-resolution path
+        patch("litellm.afile_content", new=afile_content),  # test-quality-ok: this is the file-read boundary the test fakes; nothing HTTP sits below it here
+        patch("litellm.proxy.hooks.batch_rate_limiter._count_entry_tokens") as count_entry_tokens,  # test-quality-ok: the call under assertion -- the test's subject is whether it runs
+        patch("litellm.proxy.hooks.batch_rate_limiter._estimate_batch_entry_tokens") as estimate_tokens,  # test-quality-ok: the malformed-row fallback under assertion
+        patch.object(rate_limiter, "_enforce_batch_file_model_access", new=AsyncMock()) as enforce,
+    ):
+        data = {"input_file_id": "file-abc123"}
+        result = await rate_limiter.async_pre_call_hook(
+            user_api_key_dict=_restricted_user(),
+            cache=MagicMock(),
+            data=data,
+            call_type="acreate_batch",
+        )
+
+    # What the caller observes: the batch is admitted and nothing is charged for
+    # it, malformed row included.
+    assert result == data
+    assert "_batch_token_count" not in data
+    assert "_batch_request_count" not in data
+    afile_content.assert_awaited_once()
+    # The malformed row cannot smuggle a model past the allowlist, and neither
+    # counter runs for it.
+    enforce.assert_awaited_once()
+    assert set(enforce.await_args.kwargs["models"]) == {_MODELS_ONLY_ALLOWED}
+    count_entry_tokens.assert_not_called()
+    estimate_tokens.assert_not_called()


### PR DESCRIPTION
## TLDR

**Problem this solves:**

- `POST /v1/batches` spends ~10s per 652-row file tokenizing rows whose token totals are then thrown away
- It happens whenever a key has a restricted `models` list, *even with `disable_batch_input_file_rate_limiting: true`*
- The opt-out is unreachable for those keys: `_should_skip_batch_input_file_processing` returns on the allowlist check first

**How it solves it:**

- Adds a models-only read: collect each row's `body.model`, skip `_count_entry_tokens`
- Allowlist enforcement unchanged — file still downloaded, every `body.model` still validated
- Purely additive; no existing signature or return shape changes

## The problem

`_should_skip_batch_input_file_processing` consults the operator opt-outs *after* the model-allowlist check:

```python
if self._key_requires_batch_model_access_check(user_api_key_dict):
    return False, None                      # restricted `models` -> full path, always

if general_settings.get("disable_batch_input_file_rate_limiting") is True:
    return True, None                       # never reached for such keys
```

The download itself is genuinely required — the allowlist can only be enforced by inspecting every row. But `count_input_file_usage` also runs `_count_entry_tokens` (a real tokenizer) per row, and `async_pre_call_hook` then discards the totals because nothing charges them.

That tokenization is the expensive half, and it is **synchronous CPU work inside the async pre-call hook**.

### Production measurements

Observed on a proxy running v1.96.2, during a nightly backfill submitting 652-row batches to `vertex_ai/gemini-2.5-flash`:

| | latency |
|---|---|
| `POST /v1/batches` (652 rows) | **10~12s** |
| batch status polling, same key | 0.55~0.64s |
| interactive calls, same deployment | 0.5~0.7s |

This held a proxy-wide average-latency monitor above its threshold for as long as a batch was running. Reproduced with **zero 429s**, so it is not retry-driven — it is the cost of the read itself.

## The fix

- `_batch_input_file_models_only()` reports when the JSONL is needed solely for the allowlist
- `count_input_file_usage(models_only=...)` then collects `body.model` without tokenizing
- `async_pre_call_hook` returns before counter enforcement in that mode, leaving `_batch_*_count` unset — matching the existing full-skip path rather than recording zeroes

Deliberately conservative — it returns `False` whenever anything still needs the totals:

- unrestricted keys (already covered by the existing full-skip paths)
- **enqueued-token scopes**, whose reservation is priced from the totals
- no opt-out configured

## Tests

4 added to `tests/test_litellm/proxy/hooks/test_batch_file_validation.py`; suite goes **79 → 83 passing**.

| test | asserts |
|---|---|
| `..._skips_tokenization_for_restricted_key` | file *is* downloaded and allowlist *is* enforced, but `_count_entry_tokens` is never called and no counters are charged |
| `..._still_rejects_unauthorized_model` | a disallowed model in the JSONL still raises 403 — the opt-out must not become an authz bypass |
| `test_restricted_key_without_opt_out_still_counts_tokens` | the pre-existing path is untouched |
| `..._disabled_when_enqueued_scopes_apply` | enqueued reservations still get real totals |

`async_pre_call_hook` swallows unexpected exceptions and returns `data`, so the returned value alone proves nothing — each test also asserts on the calls that separate the intended path from error recovery.

**Control:** reverting only the source change (tests kept) fails the first test with

```
AssertionError: Expected '_count_entry_tokens' to not have been called. Called 2 times.
```

confirming the test is load-bearing rather than vacuous.

## Relevant issues

I could not find an existing issue for this. Note that **#35408** and **#35813** touch the same function (bounding the input-file read with a deadline) — this change is orthogonal (it reduces work *within* the read) but will likely need a trivial rebase against whichever lands first.

## Linear ticket

n/a — external contribution.

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (not yet run)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5**

## Screenshots / Proof of Fix

Run against this branch in a container, with the import origin printed so it is unambiguous which tree is under test:

```
IMPORTED FROM: /oss/litellm
helper present: True
83 passed, 1 warning in 9.13s
```

Control, same command against an otherwise identical tree with only the source change reverted:

```
IMPORTED FROM: /ctrl/litellm
helper present: False
FAILED tests/.../test_batch_file_validation.py::test_models_only_read_skips_tokenization_for_restricted_key
1 failed, 3 passed
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes batch pre-call auth/rate-limit flow for restricted keys; behavior is narrowed (allowlist unchanged, counting preserved when reservations apply) but mistakes could weaken enforcement or skip needed token totals.
> 
> **Overview**
> Restricted API keys with a `models` allowlist could not use `disable_batch_input_file_rate_limiting` or provider skip settings: `_should_skip_batch_input_file_processing` always forces a full JSONL read for allowlist checks, then **tokenized every row** even when no counters or enqueued reservations apply.
> 
> This PR adds a **models-only** path: `_batch_input_file_models_only()` mirrors the opt-out rules for restricted keys, `count_input_file_usage(..., models_only=True)` still downloads the file and collects each row's `body.model` for `_enforce_batch_file_model_access` but skips `_count_entry_tokens` and related estimates. `async_pre_call_hook` returns early without setting `_batch_*_count`, matching the full-skip behavior. Token counting stays on when enqueued-token scopes need totals or when no opt-out applies.
> 
> Six new tests in `test_batch_file_validation.py` cover happy path, 403 on disallowed models, regression without opt-out, enqueued scopes, provider skip list, and malformed JSONL rows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 239b7d60f4c85a784798a4a1d13b3be025a21f76. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->