### PR TITLE
fix(proxy): drop leftover fallbacks when a model group is deleted

### DIFF
--- a/litellm/proxy/management_endpoints/fallback_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/fallback_management_endpoints.py
@@ -30,7 +30,10 @@ else:
         # fastapi is only required for proxy, not for SDK usage
         pass
 
-from litellm.repositories.config_repository import ConfigRepository
+from litellm.repositories.config_repository import (
+    ROUTER_FALLBACK_SETTING_KEYS,
+    ConfigRepository,
+)
 from litellm.types.management_endpoints.router_settings_endpoints import (
     FallbackCreateRequest,
     FallbackDeleteResponse,
@@ -39,12 +42,6 @@ from litellm.types.management_endpoints.router_settings_endpoints import (
 )
 
 router: Final = APIRouter()
-
-FALLBACK_SETTING_KEYS: Final[tuple[str, ...]] = (
-    "fallbacks",
-    "context_window_fallbacks",
-    "content_policy_fallbacks",
-)
 
 
 def _as_target_list(targets: object) -> list[str]:
@@ -77,7 +74,6 @@ def scrub_model_from_fallback_entries(
     existing: object,
     model_name: str,
 ) -> list[dict[str, list[str]]]:
-    """Drop mappings from ``model_name`` and leftover references to it as a target."""
     return [
         remaining
         for remaining in (
@@ -107,33 +103,27 @@ async def remove_deleted_model_from_router_fallbacks(
     prisma_client: "PrismaClient",
     llm_router: "Router | None",
 ) -> None:
-    """Persist fallback lists with ``model_name`` removed after its last deployment is deleted."""
     from litellm.proxy.proxy_server import proxy_config
+    from litellm.proxy.utils import invalidate_config_param
 
     config: Final = await proxy_config.get_config()
     raw_settings: Final = config.get("router_settings", {}) if isinstance(config, dict) else {}
     router_settings: Final[dict[str, object]] = dict(raw_settings) if isinstance(raw_settings, dict) else {}
-    original_by_key: Final = {key: _fallback_entries(router_settings.get(key)) for key in FALLBACK_SETTING_KEYS}
+    original_by_key: Final = {
+        key: _fallback_entries(router_settings.get(key)) for key in ROUTER_FALLBACK_SETTING_KEYS
+    }
     cleaned_by_key: Final = {
-        key: scrub_model_from_fallback_entries(router_settings.get(key), model_name) for key in FALLBACK_SETTING_KEYS
+        key: scrub_model_from_fallback_entries(router_settings.get(key), model_name)
+        for key in ROUTER_FALLBACK_SETTING_KEYS
     }
     if cleaned_by_key == original_by_key:
         return
 
     updated_settings: Final = {**router_settings, **cleaned_by_key}
-    router_settings_json: Final = json.dumps(updated_settings)
-    await ConfigRepository(prisma_client).table.upsert(
-        where={"param_name": "router_settings"},
-        data={
-            "create": {
-                "param_name": "router_settings",
-                "param_value": router_settings_json,
-            },
-            "update": {"param_value": router_settings_json},
-        },
-    )
+    await ConfigRepository(prisma_client).set_param("router_settings", updated_settings)
+    await invalidate_config_param("router_settings")
     if llm_router is not None:
-        for key in FALLBACK_SETTING_KEYS:
+        for key in ROUTER_FALLBACK_SETTING_KEYS:
             setattr(llm_router, key, cleaned_by_key[key])
     verbose_proxy_logger.info("Removed deleted model %s from router fallbacks", model_name)
 

--- a/litellm/proxy/management_endpoints/fallback_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/fallback_management_endpoints.py
@@ -20,6 +20,9 @@ from litellm.proxy.auth.user_api_key_auth import user_api_key_auth
 
 if TYPE_CHECKING:
     from fastapi import APIRouter, Depends, HTTPException, status
+
+    from litellm.proxy.utils import PrismaClient
+    from litellm.router import Router
 else:
     try:
         from fastapi import APIRouter, Depends, HTTPException, status
@@ -36,6 +39,103 @@ from litellm.types.management_endpoints.router_settings_endpoints import (
 )
 
 router: Final = APIRouter()
+
+FALLBACK_SETTING_KEYS: Final[tuple[str, ...]] = (
+    "fallbacks",
+    "context_window_fallbacks",
+    "content_policy_fallbacks",
+)
+
+
+def _as_target_list(targets: object) -> list[str]:
+    if isinstance(targets, str):
+        return [targets]
+    if isinstance(targets, list):
+        return [target for target in targets if isinstance(target, str)]
+    return []
+
+
+def _as_fallback_entry(entry: object) -> dict[str, list[str]]:
+    if not isinstance(entry, dict):
+        return {}
+    return {
+        primary: kept
+        for primary, targets in entry.items()
+        if isinstance(primary, str)
+        for kept in (_as_target_list(targets),)
+        if kept
+    }
+
+
+def _fallback_entries(value: object) -> list[dict[str, list[str]]]:
+    if not isinstance(value, list):
+        return []
+    return [cleaned for entry in value if (cleaned := _as_fallback_entry(entry))]
+
+
+def scrub_model_from_fallback_entries(
+    existing: object,
+    model_name: str,
+) -> list[dict[str, list[str]]]:
+    """Drop mappings from ``model_name`` and leftover references to it as a target."""
+    return [
+        remaining
+        for remaining in (
+            {
+                primary: kept
+                for primary, targets in entry.items()
+                if primary != model_name
+                for kept in ([target for target in targets if target != model_name],)
+                if kept
+            }
+            for entry in _fallback_entries(existing)
+        )
+        if remaining
+    ]
+
+
+def router_lost_last_deployment_for_model(llm_router: object, model_name: str) -> bool:
+    model_names: Final = getattr(llm_router, "model_names", None)
+    if not isinstance(model_names, (set, frozenset, list, tuple)):
+        return False
+    return model_name not in model_names
+
+
+async def remove_deleted_model_from_router_fallbacks(
+    *,
+    model_name: str,
+    prisma_client: "PrismaClient",
+    llm_router: "Router | None",
+) -> None:
+    """Persist fallback lists with ``model_name`` removed after its last deployment is deleted."""
+    from litellm.proxy.proxy_server import proxy_config
+
+    config: Final = await proxy_config.get_config()
+    raw_settings: Final = config.get("router_settings", {}) if isinstance(config, dict) else {}
+    router_settings: Final[dict[str, object]] = dict(raw_settings) if isinstance(raw_settings, dict) else {}
+    original_by_key: Final = {key: _fallback_entries(router_settings.get(key)) for key in FALLBACK_SETTING_KEYS}
+    cleaned_by_key: Final = {
+        key: scrub_model_from_fallback_entries(router_settings.get(key), model_name) for key in FALLBACK_SETTING_KEYS
+    }
+    if cleaned_by_key == original_by_key:
+        return
+
+    updated_settings: Final = {**router_settings, **cleaned_by_key}
+    router_settings_json: Final = json.dumps(updated_settings)
+    await ConfigRepository(prisma_client).table.upsert(
+        where={"param_name": "router_settings"},
+        data={
+            "create": {
+                "param_name": "router_settings",
+                "param_value": router_settings_json,
+            },
+            "update": {"param_value": router_settings_json},
+        },
+    )
+    if llm_router is not None:
+        for key in FALLBACK_SETTING_KEYS:
+            setattr(llm_router, key, cleaned_by_key[key])
+    verbose_proxy_logger.info("Removed deleted model %s from router fallbacks", model_name)
 
 
 @router.post(

--- a/litellm/proxy/management_endpoints/model_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/model_management_endpoints.py
@@ -1526,6 +1526,10 @@ async def delete_model(
         - Delete
         """
 
+        from litellm.proxy.management_endpoints.fallback_management_endpoints import (
+            remove_deleted_model_from_router_fallbacks,
+            router_lost_last_deployment_for_model,
+        )
         from litellm.proxy.proxy_server import (
             MODEL_RECONCILE_LOCK,
             llm_router,
@@ -1585,6 +1589,12 @@ async def delete_model(
             if llm_router is not None:
                 async with MODEL_RECONCILE_LOCK:
                     llm_router.delete_deployment(id=model_info.id)
+                    if router_lost_last_deployment_for_model(llm_router, model_params.model_name):
+                        await remove_deleted_model_from_router_fallbacks(
+                            model_name=model_params.model_name,
+                            prisma_client=prisma_client,
+                            llm_router=llm_router,
+                        )
 
             # Runs after the row delete so the sibling check sees post-delete state.
             if model_params.model_info.team_id is not None:

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -6628,6 +6628,10 @@ class ProxyConfig:
         # For dictionary values, update only non-none values
         if isinstance(current_config[param_name], dict) and isinstance(db_param_value, dict):
             _deep_merge_dicts(current_config[param_name], db_param_value)
+            if param_name == "router_settings":
+                from litellm.repositories.config_repository import apply_empty_router_fallback_lists
+
+                apply_empty_router_fallback_lists(current_config[param_name], db_param_value)
         else:
             # Non-dict or mismatched types: DB value replaces config (unchanged behavior)
             current_config[param_name] = db_param_value

--- a/litellm/repositories/config_repository.py
+++ b/litellm/repositories/config_repository.py
@@ -53,6 +53,24 @@ class ConfigParam:
         self.param_value = param_value
 
 
+ROUTER_FALLBACK_SETTING_KEYS: Final[tuple[str, ...]] = (
+    "fallbacks",
+    "context_window_fallbacks",
+    "content_policy_fallbacks",
+)
+
+
+def apply_empty_router_fallback_lists(
+    router_settings: dict,
+    db_router_settings: Mapping[str, object],
+) -> None:
+    # _deep_merge_dicts skips empty lists so yaml lists survive; fallback deletes must still clear them
+    for key in ROUTER_FALLBACK_SETTING_KEYS:
+        value = db_router_settings.get(key)
+        if isinstance(value, list) and len(value) == 0:
+            router_settings[key] = []
+
+
 class ConfigRepository:
     """Repository for config database operations with reconciliation support."""
 
@@ -195,6 +213,8 @@ class ConfigRepository:
 
         if isinstance(current_config[param_name], dict) and isinstance(db_param_value, dict):
             self._deep_merge_dicts(current_config[param_name], db_param_value)
+            if param_name == "router_settings":
+                apply_empty_router_fallback_lists(current_config[param_name], db_param_value)
         else:
             current_config[param_name] = db_param_value
 

--- a/tests/test_litellm/proxy/management_endpoints/test_model_management_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_model_management_endpoints.py
@@ -4256,3 +4256,139 @@ class TestAutoRouterClassifierDefaultPrompt:
         for empty in (None, "", "{}"):
             response = await get_auto_router_classifier_default_prompt(context_window_size=5, tier_labels=empty)
             assert response.system_prompt == classification_system_prompt(5)
+
+
+class TestDeleteModelScrubsOrphanFallbacks:
+    """Regression for issue #37670.
+
+    /model/delete left router_settings.fallbacks pointing at the deleted
+    model_name, so a later primary failure retried the missing group and 500'd.
+    """
+
+    @staticmethod
+    def _db_row(model_id: str, model_name: str):
+        row = MagicMock()
+        row.model_dump.return_value = {
+            "model_name": model_name,
+            "litellm_params": {"model": "openai/gpt-4o"},
+            "model_info": {"id": model_id},
+        }
+        return row
+
+    @pytest.mark.asyncio
+    async def test_delete_last_deployment_drops_fallback_refs(self, monkeypatch):
+        from litellm.proxy.management_endpoints.model_management_endpoints import (
+            ModelInfoDelete,
+            delete_model,
+        )
+
+        model_id = "fallback-target-id"
+        model_name = "fallback-target"
+        row = self._db_row(model_id, model_name)
+
+        table = MagicMock()
+        table.find_unique = AsyncMock(return_value=row)
+        table.delete = AsyncMock(return_value=row)
+
+        prisma = MagicMock()
+        prisma.db.litellm_proxymodeltable = table
+        prisma.db.litellm_config.upsert = AsyncMock()
+
+        model_names = {"primary", "fallback-target"}
+
+        def _delete_deployment(*, id: str):
+            model_names.discard(model_name)
+            return True
+
+        router = MagicMock()
+        router.model_names = model_names
+        router.fallbacks = [{"primary": ["fallback-target"]}]
+        router.context_window_fallbacks = []
+        router.content_policy_fallbacks = []
+        router.delete_deployment.side_effect = _delete_deployment
+
+        proxy_config = MagicMock()
+        proxy_config.get_config = AsyncMock(
+            return_value={
+                "router_settings": {
+                    "num_retries": 2,
+                    "fallbacks": [{"primary": ["fallback-target"]}],
+                }
+            }
+        )
+
+        monkeypatch.setattr("litellm.proxy.proxy_server.prisma_client", prisma)
+        monkeypatch.setattr("litellm.proxy.proxy_server.llm_router", router)
+        monkeypatch.setattr("litellm.proxy.proxy_server.proxy_config", proxy_config)
+        monkeypatch.setattr("litellm.proxy.proxy_server.store_model_in_db", True)
+        monkeypatch.setattr("litellm.proxy.proxy_server.premium_user", True)
+        monkeypatch.setattr(
+            "litellm.proxy.management_endpoints.model_management_endpoints.ModelManagementAuthChecks.can_user_make_model_call",
+            AsyncMock(return_value=True),
+        )
+
+        result = await delete_model(
+            model_info=ModelInfoDelete(id=model_id),
+            user_api_key_dict=UserAPIKeyAuth(
+                user_id="admin",
+                user_role=LitellmUserRoles.PROXY_ADMIN,
+                api_key="sk-admin",
+            ),
+        )
+        assert "deleted successfully" in result["message"]
+
+        prisma.db.litellm_config.upsert.assert_called_once()
+        saved = json.loads(
+            prisma.db.litellm_config.upsert.call_args.kwargs["data"]["update"][
+                "param_value"
+            ]
+        )
+        assert saved["num_retries"] == 2
+        assert saved["fallbacks"] == []
+        assert router.fallbacks == []
+
+    @pytest.mark.asyncio
+    async def test_delete_keeps_fallbacks_when_a_sibling_deployment_remains(
+        self, monkeypatch
+    ):
+        from litellm.proxy.management_endpoints.model_management_endpoints import (
+            ModelInfoDelete,
+            delete_model,
+        )
+
+        model_id = "shared-group-replica-1"
+        model_name = "shared-group"
+        row = self._db_row(model_id, model_name)
+
+        table = MagicMock()
+        table.find_unique = AsyncMock(return_value=row)
+        table.delete = AsyncMock(return_value=row)
+
+        prisma = MagicMock()
+        prisma.db.litellm_proxymodeltable = table
+        prisma.db.litellm_config.upsert = AsyncMock()
+
+        router = MagicMock()
+        router.model_names = {model_name}
+        router.delete_deployment = MagicMock(return_value=True)
+
+        monkeypatch.setattr("litellm.proxy.proxy_server.prisma_client", prisma)
+        monkeypatch.setattr("litellm.proxy.proxy_server.llm_router", router)
+        monkeypatch.setattr("litellm.proxy.proxy_server.store_model_in_db", True)
+        monkeypatch.setattr("litellm.proxy.proxy_server.premium_user", True)
+        monkeypatch.setattr(
+            "litellm.proxy.management_endpoints.model_management_endpoints.ModelManagementAuthChecks.can_user_make_model_call",
+            AsyncMock(return_value=True),
+        )
+
+        result = await delete_model(
+            model_info=ModelInfoDelete(id=model_id),
+            user_api_key_dict=UserAPIKeyAuth(
+                user_id="admin",
+                user_role=LitellmUserRoles.PROXY_ADMIN,
+                api_key="sk-admin",
+            ),
+        )
+        assert "deleted successfully" in result["message"]
+        router.delete_deployment.assert_called_once_with(id=model_id)
+        prisma.db.litellm_config.upsert.assert_not_called()

--- a/tests/test_litellm/proxy/management_endpoints/test_model_management_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_model_management_endpoints.py
@@ -4323,6 +4323,10 @@ class TestDeleteModelScrubsOrphanFallbacks:
         monkeypatch.setattr("litellm.proxy.proxy_server.store_model_in_db", True)
         monkeypatch.setattr("litellm.proxy.proxy_server.premium_user", True)
         monkeypatch.setattr(
+            "litellm.proxy.utils.invalidate_config_param",
+            AsyncMock(),
+        )
+        monkeypatch.setattr(
             "litellm.proxy.management_endpoints.model_management_endpoints.ModelManagementAuthChecks.can_user_make_model_call",
             AsyncMock(return_value=True),
         )

--- a/tests/test_litellm/proxy/test_fallback_management_endpoints.py
+++ b/tests/test_litellm/proxy/test_fallback_management_endpoints.py
@@ -8,6 +8,7 @@ Tests:
 4. Validation tests (invalid models, duplicate fallbacks, etc.)
 """
 
+import json
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -553,3 +554,121 @@ class TestDeleteFallback:
 
         assert exc_info.value.status_code == 400
         assert "Database storage not enabled" in str(exc_info.value.detail)
+
+
+class TestScrubModelFromFallbackEntries:
+    def test_drops_mappings_from_deleted_model_and_refs_to_it(self):
+        from litellm.proxy.management_endpoints.fallback_management_endpoints import (
+            scrub_model_from_fallback_entries,
+        )
+
+        cleaned = scrub_model_from_fallback_entries(
+            [
+                {"gone": ["still-there"]},
+                {"kept": ["gone", "other"]},
+                {"also-kept": ["gone"]},
+            ],
+            "gone",
+        )
+
+        assert cleaned == [{"kept": ["other"]}]
+
+    def test_leaves_unrelated_entries_unchanged(self):
+        from litellm.proxy.management_endpoints.fallback_management_endpoints import (
+            scrub_model_from_fallback_entries,
+        )
+
+        existing = [{"primary": ["fb-a", "fb-b"]}]
+        assert scrub_model_from_fallback_entries(existing, "missing") == existing
+
+    def test_treats_non_list_config_as_empty(self):
+        from litellm.proxy.management_endpoints.fallback_management_endpoints import (
+            scrub_model_from_fallback_entries,
+        )
+
+        assert scrub_model_from_fallback_entries(None, "gone") == []
+        assert scrub_model_from_fallback_entries("not-a-list", "gone") == []
+
+    def test_router_lost_last_deployment_only_when_model_names_is_a_real_collection(self):
+        from litellm.proxy.management_endpoints.fallback_management_endpoints import (
+            router_lost_last_deployment_for_model,
+        )
+
+        present = MagicMock()
+        present.model_names = {"kept", "gone"}
+        gone = MagicMock()
+        gone.model_names = {"kept"}
+        unknown = MagicMock()
+
+        assert router_lost_last_deployment_for_model(present, "gone") is False
+        assert router_lost_last_deployment_for_model(gone, "gone") is True
+        assert router_lost_last_deployment_for_model(unknown, "gone") is False
+
+
+@pytest.mark.asyncio
+class TestRemoveDeletedModelFromRouterFallbacks:
+    async def test_persists_scrubbed_lists_and_updates_router(self):
+        from litellm.proxy.management_endpoints.fallback_management_endpoints import (
+            remove_deleted_model_from_router_fallbacks,
+        )
+
+        router = MagicMock()
+        router.fallbacks = [{"primary": ["gone"]}]
+        router.context_window_fallbacks = [{"primary": ["gone", "other"]}]
+        router.content_policy_fallbacks = []
+
+        prisma = MagicMock()
+        prisma.db.litellm_config.upsert = AsyncMock()
+
+        proxy_config = MagicMock()
+        proxy_config.get_config = AsyncMock(
+            return_value={
+                "router_settings": {
+                    "num_retries": 2,
+                    "fallbacks": [{"primary": ["gone"]}],
+                    "context_window_fallbacks": [{"primary": ["gone", "other"]}],
+                }
+            }
+        )
+
+        with patch("litellm.proxy.proxy_server.proxy_config", proxy_config):
+            await remove_deleted_model_from_router_fallbacks(
+                model_name="gone",
+                prisma_client=prisma,
+                llm_router=router,
+            )
+
+        prisma.db.litellm_config.upsert.assert_called_once()
+        saved = json.loads(
+            prisma.db.litellm_config.upsert.call_args.kwargs["data"]["update"][
+                "param_value"
+            ]
+        )
+        assert saved["num_retries"] == 2
+        assert saved["fallbacks"] == []
+        assert saved["context_window_fallbacks"] == [{"primary": ["other"]}]
+        assert saved["content_policy_fallbacks"] == []
+        assert router.fallbacks == []
+        assert router.context_window_fallbacks == [{"primary": ["other"]}]
+        assert router.content_policy_fallbacks == []
+
+    async def test_skips_persist_when_model_is_not_referenced(self):
+        from litellm.proxy.management_endpoints.fallback_management_endpoints import (
+            remove_deleted_model_from_router_fallbacks,
+        )
+
+        prisma = MagicMock()
+        prisma.db.litellm_config.upsert = AsyncMock()
+        proxy_config = MagicMock()
+        proxy_config.get_config = AsyncMock(
+            return_value={"router_settings": {"fallbacks": [{"primary": ["other"]}]}}
+        )
+
+        with patch("litellm.proxy.proxy_server.proxy_config", proxy_config):
+            await remove_deleted_model_from_router_fallbacks(
+                model_name="gone",
+                prisma_client=prisma,
+                llm_router=MagicMock(),
+            )
+
+        prisma.db.litellm_config.upsert.assert_not_called()

--- a/tests/test_litellm/proxy/test_fallback_management_endpoints.py
+++ b/tests/test_litellm/proxy/test_fallback_management_endpoints.py
@@ -631,7 +631,13 @@ class TestRemoveDeletedModelFromRouterFallbacks:
             }
         )
 
-        with patch("litellm.proxy.proxy_server.proxy_config", proxy_config):
+        with (
+            patch("litellm.proxy.proxy_server.proxy_config", proxy_config),
+            patch(
+                "litellm.proxy.utils.invalidate_config_param",
+                new_callable=AsyncMock,
+            ) as invalidate,
+        ):
             await remove_deleted_model_from_router_fallbacks(
                 model_name="gone",
                 prisma_client=prisma,
@@ -651,6 +657,7 @@ class TestRemoveDeletedModelFromRouterFallbacks:
         assert router.fallbacks == []
         assert router.context_window_fallbacks == [{"primary": ["other"]}]
         assert router.content_policy_fallbacks == []
+        invalidate.assert_awaited_once_with("router_settings")
 
     async def test_skips_persist_when_model_is_not_referenced(self):
         from litellm.proxy.management_endpoints.fallback_management_endpoints import (
@@ -664,7 +671,13 @@ class TestRemoveDeletedModelFromRouterFallbacks:
             return_value={"router_settings": {"fallbacks": [{"primary": ["other"]}]}}
         )
 
-        with patch("litellm.proxy.proxy_server.proxy_config", proxy_config):
+        with (
+            patch("litellm.proxy.proxy_server.proxy_config", proxy_config),
+            patch(
+                "litellm.proxy.utils.invalidate_config_param",
+                new_callable=AsyncMock,
+            ) as invalidate,
+        ):
             await remove_deleted_model_from_router_fallbacks(
                 model_name="gone",
                 prisma_client=prisma,
@@ -672,3 +685,4 @@ class TestRemoveDeletedModelFromRouterFallbacks:
             )
 
         prisma.db.litellm_config.upsert.assert_not_called()
+        invalidate.assert_not_awaited()

--- a/tests/test_litellm/proxy/test_proxy_server.py
+++ b/tests/test_litellm/proxy/test_proxy_server.py
@@ -6107,6 +6107,26 @@ def test_deep_merge_dicts_skips_none_and_empty_lists(monkeypatch):
     assert result["general_settings"]["nested"]["key3"] == "value3"
 
 
+def test_update_config_fields_empty_router_fallbacks_override_yaml():
+    from litellm.proxy.proxy_server import ProxyConfig
+
+    proxy_config = ProxyConfig()
+    current_config = {
+        "router_settings": {
+            "num_retries": 2,
+            "fallbacks": [{"primary": ["gone"]}],
+        }
+    }
+    result = proxy_config._update_config_fields(
+        current_config,
+        "router_settings",
+        {"num_retries": 2, "fallbacks": [], "content_policy_fallbacks": []},
+    )
+    assert result["router_settings"]["fallbacks"] == []
+    assert result["router_settings"]["content_policy_fallbacks"] == []
+    assert result["router_settings"]["num_retries"] == 2
+
+
 class TestInvitationEndpoints:
     """Tests for /invitation/new and /invitation/delete endpoints."""
 

--- a/tests/test_litellm/repositories/test_repositories.py
+++ b/tests/test_litellm/repositories/test_repositories.py
@@ -1448,6 +1448,50 @@ class TestConfigRepository:
         repo._deep_merge_dicts(dst, src)
         assert dst["models"] == ["gpt-4"]
 
+    def test_update_config_fields_empty_router_fallbacks_override_yaml(self, repo):
+        current_config = {
+            "router_settings": {
+                "num_retries": 2,
+                "fallbacks": [{"primary": ["gone"]}],
+                "context_window_fallbacks": [{"primary": ["other"]}],
+                "allowed_fails": ["keep-this-empty-skip-is-unrelated"],
+            }
+        }
+        repo._update_config_fields(
+            current_config,
+            "router_settings",
+            {
+                "num_retries": 2,
+                "fallbacks": [],
+                "context_window_fallbacks": [{"primary": ["other"]}],
+                "content_policy_fallbacks": [],
+                "allowed_fails": [],
+            },
+        )
+        assert current_config["router_settings"]["fallbacks"] == []
+        assert current_config["router_settings"]["context_window_fallbacks"] == [
+            {"primary": ["other"]}
+        ]
+        assert current_config["router_settings"]["content_policy_fallbacks"] == []
+        assert current_config["router_settings"]["num_retries"] == 2
+        assert current_config["router_settings"]["allowed_fails"] == [
+            "keep-this-empty-skip-is-unrelated"
+        ]
+
+    def test_apply_empty_router_fallback_lists_only_clears_fallback_keys(self):
+        from litellm.repositories.config_repository import apply_empty_router_fallback_lists
+
+        router_settings = {
+            "fallbacks": [{"primary": ["gone"]}],
+            "models": ["gpt-4"],
+        }
+        apply_empty_router_fallback_lists(
+            router_settings,
+            {"fallbacks": [], "models": []},
+        )
+        assert router_settings["fallbacks"] == []
+        assert router_settings["models"] == ["gpt-4"]
+
     @pytest.mark.asyncio
     async def test_get_param(self, repo):
         repo._prisma_client.db.litellm_config._records["general_settings"] = {


### PR DESCRIPTION
## TLDR

Problem this solves:

- Deleting a model left its name in fallback mappings
- Primary failure then retried the missing group and returned 500
- GET /fallback still listed the deleted model

How it solves it:

- /model/delete drops leftover fallback refs for that group
- Only when no sibling deployment still uses the name
- General, context window, and content policy lists are all cleaned
- Other proxy workers pick up the cleaned lists
- Empty lists stay cleared after a reload even if yaml still lists them

## User Flow

Before: a proxy admin deletes the fallback target model, and the fallback mapping stays around so a later primary outage 500s on the missing group

1. They POST https://litellm-domain/model/new twice, once for `test-primary-tmp` and once for `test-fallback-tmp`
2. They POST https://litellm-domain/fallback with `{"model": "test-primary-tmp", "fallback_models": ["test-fallback-tmp"]}` and get 200
3. They POST https://litellm-domain/model/delete with the fallback target's id and get 200 with no warning
4. They GET https://litellm-domain/fallback/test-primary-tmp and still see `fallback_models: ["test-fallback-tmp"]`
5. They POST https://litellm-domain/v1/chat/completions for `test-primary-tmp` after the primary fails, and get HTTP 500 naming `Available Model Group Fallbacks=['test-fallback-tmp']` and `There are no healthy deployments for this model`

After: the same delete removes the leftover mapping, so a later primary outage no longer retries a model that is gone

1. They POST https://litellm-domain/model/new twice, once for `test-primary-tmp` and once for `test-fallback-tmp`
2. They POST https://litellm-domain/fallback with `{"model": "test-primary-tmp", "fallback_models": ["test-fallback-tmp"]}` and get 200
3. They POST https://litellm-domain/model/delete with the fallback target's id and get 200
4. They GET https://litellm-domain/fallback/test-primary-tmp and get 404 `No general fallbacks configured for model 'test-primary-tmp'`
5. They POST https://litellm-domain/v1/chat/completions for `test-primary-tmp` after the primary fails, and the 500 no longer lists the deleted model as an available fallback (`Fallbacks=[]`, `Available Model Group Fallbacks=None`)

## Relevant issues

Fixes #37670

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Shared setup: `STORE_MODEL_IN_DB=True`. Two throwaway models that fail on purpose (`api_base=https://127.0.0.1:9`). Auth header is `Authorization: Bearer $LITELLM_MASTER_KEY`

### Before (40423e6ec0)

1. `curl -sS -X POST http://127.0.0.1:7000/model/new -H "Authorization: Bearer $LITELLM_MASTER_KEY" -H "Content-Type: application/json" -d '{"model_name":"issue37670-primary","litellm_params":{"model":"openai/nonexistent-model","api_base":"https://127.0.0.1:9","api_key":"fake-key"},"model_info":{}}'`
2. Same POST for `issue37670-fallback`, then `curl -sS -X POST http://127.0.0.1:7000/fallback -H "Authorization: Bearer $LITELLM_MASTER_KEY" -H "Content-Type: application/json" -d '{"model":"issue37670-primary","fallback_models":["issue37670-fallback"]}'` returned 200 `Fallback configuration created successfully`
3. `curl -sS -X POST http://127.0.0.1:7000/model/delete -H "Authorization: Bearer $LITELLM_MASTER_KEY" -H "Content-Type: application/json" -d '{"id":"<fallback-model-id>"}'` returned 200 `Model: <id> deleted successfully`
4. `curl -sS http://127.0.0.1:7000/fallback/issue37670-primary -H "Authorization: Bearer $LITELLM_MASTER_KEY"` returned 200 `{"model":"issue37670-primary","fallback_models":["issue37670-fallback"],"fallback_type":"general"}`
5. `curl -sS -X POST http://127.0.0.1:7000/v1/chat/completions -H "Authorization: Bearer $LITELLM_MASTER_KEY" -H "Content-Type: application/json" -d '{"model":"issue37670-primary","messages":[{"role":"user","content":"test"}],"max_tokens":5}'` returned HTTP 500 including `Available Model Group Fallbacks=['issue37670-fallback']` and `There are no healthy deployments for this model`

### After (176215b2f2)

1. Same two `/model/new` calls and the same POST `/fallback` returned 200
2. Same POST `/model/delete` of the fallback target returned 200 `Model: f6abb29f-081b-480e-900e-acde3b8ee6db deleted successfully`
3. `curl -sS http://127.0.0.1:7000/fallback/issue37670-primary-1787739296-390553 -H "Authorization: Bearer $LITELLM_MASTER_KEY"` returned 404 `{"detail":{"error":"No general fallbacks configured for model 'issue37670-primary-1787739296-390553'"}}`
4. The same POST `/v1/chat/completions` returned HTTP 500 for the failing primary, with `Fallbacks=[]` and `Available Model Group Fallbacks=None` (the deleted model is no longer retried)

## Type

🐛 Bug Fix

## Caveats (if any)

### Medium

- No UI warning on delete. The mapping is removed instead
- `/team/model/delete` is unchanged. This PR only covers `POST /model/delete`

### Low

- If another deployment still uses the same `model_name`, fallbacks stay
- A down primary still 500s. The orphaned fallback retry is what this removes
- If those fallbacks are also in config.yaml, a reload after delete now keeps them cleared

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

