### PR TITLE
fix(cost): apply Anthropic fast-speed multiplier to reasoning cost breakdown

### DIFF
--- a/litellm/litellm_core_utils/llm_cost_calc/utils.py
+++ b/litellm/litellm_core_utils/llm_cost_calc/utils.py
@@ -801,6 +801,24 @@ def get_provider_specific_geo_multiplier(model_info: ModelInfo, usage: Usage) ->
     return float(provider_specific_entry.get(inference_geo.lower(), 1.0))
 
 
+def get_provider_specific_speed_multiplier(model_info: ModelInfo, usage: Usage) -> float:
+    """
+    Resolve Anthropic's "fast" speed-mode multiplier (``provider_specific_entry.fast``)
+    for a request served at ``usage.speed == "fast"``.
+
+    The multiplier scales non-cache token costs only - see
+    ``anthropic/cost_calculation.py::cost_per_token`` - so callers must not apply it to
+    cache read/write costs.
+
+    Returns 1.0 when the request was not served in fast mode or the model carries no
+    fast multiplier.
+    """
+    if getattr(usage, "speed", None) != "fast":
+        return 1.0
+    provider_specific_entry: Final[dict[str, float]] = model_info.get("provider_specific_entry") or {}
+    return float(provider_specific_entry.get("fast", 1.0))
+
+
 def _resolve_reasoning_token_cost(
     model_info: ModelInfo,
     service_tier: str | None,
@@ -1074,6 +1092,13 @@ def get_token_type_cost_breakdown(
         else (flat_reasoning_rate if flat_reasoning_rate is not None else completion_base_cost)
     )
     reasoning_cost = float(reasoning_tokens) * reasoning_rate
+
+    # Anthropic's "fast" speed mode scales non-cache token costs only (cache rates
+    # are unchanged), mirroring anthropic/cost_calculation.py::cost_per_token so this
+    # line item never drifts from the completion total it is a slice of.
+    speed_multiplier: Final = get_provider_specific_speed_multiplier(model_info=model_info, usage=usage)
+    if speed_multiplier != 1.0:
+        reasoning_cost *= speed_multiplier
 
     cache_read_tokens = 0
     cache_creation_tokens = 0

--- a/litellm/llms/anthropic/cost_calculation.py
+++ b/litellm/llms/anthropic/cost_calculation.py
@@ -13,6 +13,7 @@ from litellm.litellm_core_utils.llm_cost_calc.utils import (
     calculate_cache_writing_cost,
     generic_cost_per_token,
     get_provider_specific_geo_multiplier,
+    get_provider_specific_speed_multiplier,
     parse_prompt_tokens_details,
 )
 
@@ -81,12 +82,9 @@ def cost_per_token(model: str, usage: "Usage", service_tier: str | None = None) 
     # Apply provider_specific_entry multipliers for geo/speed routing
     try:
         model_info: Final = litellm.get_model_info(model=model, custom_llm_provider="anthropic")
-        provider_specific_entry: Final[dict] = model_info.get("provider_specific_entry") or {}
 
         geo_multiplier: Final = get_provider_specific_geo_multiplier(model_info=model_info, usage=usage)
-        speed_multiplier: Final = (
-            provider_specific_entry.get("fast", 1.0) if getattr(usage, "speed", None) == "fast" else 1.0
-        )
+        speed_multiplier: Final = get_provider_specific_speed_multiplier(model_info=model_info, usage=usage)
 
         if speed_multiplier != 1.0:
             cache_cost: Final = _compute_cache_only_cost(model_info=model_info, usage=usage, service_tier=service_tier)

--- a/tests/test_litellm/litellm_core_utils/llm_cost_calc/test_llm_cost_calc_utils.py
+++ b/tests/test_litellm/litellm_core_utils/llm_cost_calc/test_llm_cost_calc_utils.py
@@ -2670,6 +2670,42 @@ def test_token_type_cost_breakdown_includes_cache_creation_from_top_level_usage(
     )
 
 
+def test_token_type_cost_breakdown_applies_anthropic_fast_speed_multiplier_to_reasoning(
+    _local_model_cost_map,
+):
+    """
+    Regression: Anthropic's "fast" speed mode multiplies the completion cost
+    (anthropic/cost_calculation.py::cost_per_token), and reasoning tokens are billed
+    as part of completion cost. The breakdown's reasoning_cost must scale by the same
+    multiplier, or the reported reasoning cost silently drifts from (i.e. undercounts
+    relative to) the completion total it is supposed to be a slice of.
+    """
+    model = "claude-test-fast-reasoning-breakdown-model"
+    litellm.register_model(
+        model_cost={
+            model: {
+                "input_cost_per_token": 3e-6,
+                "output_cost_per_token": 15e-6,
+                "litellm_provider": "anthropic",
+                "max_tokens": 8192,
+                "provider_specific_entry": {"fast": 2.0},
+            }
+        }
+    )
+
+    usage = Usage(
+        prompt_tokens=1000,
+        completion_tokens=500,
+        total_tokens=1500,
+        completion_tokens_details=CompletionTokensDetailsWrapper(reasoning_tokens=300),
+    )
+    usage.speed = "fast"
+
+    breakdown = get_token_type_cost_breakdown(model=model, custom_llm_provider="anthropic", usage=usage)
+
+    assert breakdown.reasoning_cost == pytest.approx(300 * 15e-6 * 2)
+
+
 def test_token_type_cost_breakdown_reads_cache_write_tokens(_local_model_cost_map):
     """
     Some OpenAI-compatible providers (e.g. kimi-k2) report cache-write tokens under


### PR DESCRIPTION
## TLDR

Problem this solves:

- the `reasoning_cost` spend-log line item omits Anthropic's fast-mode price multiplier
- fast-mode Claude Opus requests with extended thinking (claude-opus-5, claude-opus-4-8) under-report reasoning cost in spend logs and the UI

How it solves it:

- apply the same provider speed multiplier to the reasoning cost breakdown that the total-cost path already applies, via a shared helper

## Relevant issues

## Type

🐛 Bug Fix

## Changes

`get_token_type_cost_breakdown` in `litellm/litellm_core_utils/llm_cost_calc/utils.py` computed the `reasoning_cost` line item without Anthropic's fast speed-mode multiplier, even though the billed total in `anthropic/cost_calculation.py` applies it. Models carrying `fast` in the cost map (e.g. claude-opus-5 at 2.0, claude-opus-4-8 at 6.0) therefore reported an undercounted reasoning cost in spend logs and the UI, while the actual total charge stayed correct, so the breakdown did not reconcile with the total. This factors the multiplier lookup into a shared `get_provider_specific_speed_multiplier` helper used by both the total-cost path and the breakdown, so they can no longer drift apart.

## Screenshots / Proof of Fix

For a fast-mode Claude request with extended thinking, the reported `reasoning_cost` goes from `0.0045` to `0.009`, matching its proportional share of the (already correct) `0.015` total. A regression test asserts this and fails on the pre-fix code; verified with a standalone repro against both commits. 358 related tests pass; lint and format clean.

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
