### PR TITLE
fix(terraform): pass additional_drop_params through to litellm_params

### DIFF
--- a/terraform/provider/docs/resources/model.md
+++ b/terraform/provider/docs/resources/model.md
@@ -182,11 +182,11 @@ The following arguments are supported:
   * Note: the remote API may not echo back all custom parameters; this provider preserves `additional_litellm_params` in state when present in configuration.
 
   **Special parameter: `additional_drop_params`**
-  * When `additional_drop_params` is provided as a JSON array string, it specifies parameters to remove from the final `litellm_params` before sending to the API
-  * This allows you to override or remove built-in parameters if needed
-  * The `additional_drop_params` key itself is not included in the final parameters
+  * When `additional_drop_params` is provided as a JSON array string, it is stored on the model as `litellm_params.additional_drop_params` (a `[]string`)
+  * At request time the proxy strips those parameter names from client payloads before calling the upstream provider
+  * This matches LiteLLM proxy/config semantics — it is not a Terraform-only filter on the create/update body
 
-  Example showing booleans, integers, floats, strings, and parameter dropping:
+  Example showing booleans, integers, floats, strings, and runtime drop params:
 
   ```hcl
   resource "litellm_model" "with_additional" {
@@ -202,7 +202,7 @@ The following arguments are supported:
       "scale"                  = "0.75"                    # becomes float 0.75
       "note"                   = "for testing"             # stays string
       "complex_config"         = "{\"nested\": {\"value\": 42}}"  # parsed as JSON object
-      "additional_drop_params" = "[\"reasoningEffort\"]"   # removes reasoningEffort parameter
+      "additional_drop_params" = "[\"reasoningEffort\"]"   # stored on the model; proxy drops this param on each request
     }
   }
   ```

--- a/terraform/provider/docs/resources/model.md
+++ b/terraform/provider/docs/resources/model.md
@@ -181,12 +181,9 @@ The following arguments are supported:
   * The provider merges these keys into the `litellm_params` payload sent to the API.
   * Note: the remote API may not echo back all custom parameters; this provider preserves `additional_litellm_params` in state when present in configuration.
 
-  **Special parameter: `additional_drop_params`**
-  * When `additional_drop_params` is provided as a JSON array string, it is stored on the model as `litellm_params.additional_drop_params` (a `[]string`)
-  * At request time the proxy strips those parameter names from client payloads before calling the upstream provider
-  * This matches LiteLLM proxy/config semantics — it is not a Terraform-only filter on the create/update body
+  **`additional_drop_params`:** pass a JSON array string; the provider unmarshals it to a string list and includes it in `litellm_params` on create/update (same as other JSON map values).
 
-  Example showing booleans, integers, floats, strings, and runtime drop params:
+  Example:
 
   ```hcl
   resource "litellm_model" "with_additional" {
@@ -202,7 +199,7 @@ The following arguments are supported:
       "scale"                  = "0.75"                    # becomes float 0.75
       "note"                   = "for testing"             # stays string
       "complex_config"         = "{\"nested\": {\"value\": 42}}"  # parsed as JSON object
-      "additional_drop_params" = "[\"reasoningEffort\"]"   # stored on the model; proxy drops this param on each request
+      "additional_drop_params" = "[\"reasoningEffort\"]"   # JSON array -> []string in litellm_params
     }
   }
   ```

--- a/terraform/provider/examples/model_additional_params.tf
+++ b/terraform/provider/examples/model_additional_params.tf
@@ -10,7 +10,7 @@ provider "litellm" {
 # - JSON strings (starting with [ or {) will be parsed as JSON objects/arrays.
 # - Non-convertible strings remain strings.
 # - Non-string map values are passed through unchanged.
-# - Use "additional_drop_params" as a JSON array of client param names the proxy should strip at request time.
+# - Use "additional_drop_params" as a JSON array string (sent as []string in litellm_params).
 
 resource "litellm_model" "with_additional" {
   model_name          = "custom-model"
@@ -26,7 +26,7 @@ resource "litellm_model" "with_additional" {
     "temperature_scale"      = "0.75"                           # becomes float 0.75
     "experimental_feature"   = "enabled"                        # stays string "enabled"
     "complex_config"         = "{\"nested\": {\"value\": 42}}"  # parsed as JSON object
-    "additional_drop_params" = "[\"reasoningEffort\"]"          # stored on model; proxy drops at request time
+    "additional_drop_params" = "[\"reasoningEffort\"]"          # JSON array -> []string in litellm_params
     # You may also pass non-string values (they will be passed through unchanged)
     # "raw_flag" = true
   }
@@ -47,7 +47,6 @@ resource "litellm_model" "azure_with_drop_params" {
   tier                = "paid"
   mode                = "completion"
 
-  # Ask the proxy to strip reasoningEffort from client requests for this deployment
   additional_litellm_params = {
     "additional_drop_params" = "[\"reasoningEffort\"]"
   }

--- a/terraform/provider/examples/model_additional_params.tf
+++ b/terraform/provider/examples/model_additional_params.tf
@@ -10,7 +10,7 @@ provider "litellm" {
 # - JSON strings (starting with [ or {) will be parsed as JSON objects/arrays.
 # - Non-convertible strings remain strings.
 # - Non-string map values are passed through unchanged.
-# - Use "additional_drop_params" as a JSON array to remove parameters from the final request.
+# - Use "additional_drop_params" as a JSON array of client param names the proxy should strip at request time.
 
 resource "litellm_model" "with_additional" {
   model_name          = "custom-model"
@@ -26,7 +26,7 @@ resource "litellm_model" "with_additional" {
     "temperature_scale"      = "0.75"                           # becomes float 0.75
     "experimental_feature"   = "enabled"                        # stays string "enabled"
     "complex_config"         = "{\"nested\": {\"value\": 42}}"  # parsed as JSON object
-    "additional_drop_params" = "[\"reasoningEffort\"]"          # removes reasoningEffort parameter
+    "additional_drop_params" = "[\"reasoningEffort\"]"          # stored on model; proxy drops at request time
     # You may also pass non-string values (they will be passed through unchanged)
     # "raw_flag" = true
   }
@@ -47,7 +47,7 @@ resource "litellm_model" "azure_with_drop_params" {
   tier                = "paid"
   mode                = "completion"
 
-  # Drop the reasoningEffort parameter that might be automatically added
+  # Ask the proxy to strip reasoningEffort from client requests for this deployment
   additional_litellm_params = {
     "additional_drop_params" = "[\"reasoningEffort\"]"
   }

--- a/terraform/provider/litellm/resource_model_additional_params_test.go
+++ b/terraform/provider/litellm/resource_model_additional_params_test.go
@@ -1,0 +1,86 @@
+package litellm
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestMergeAdditionalLiteLLMParams_PassesAdditionalDropParams(t *testing.T) {
+	litellmParams := map[string]interface{}{
+		"model":               "azure/gpt-5-mini",
+		"custom_llm_provider": "azure",
+		"drop_params":         true,
+	}
+	additional := map[string]interface{}{
+		"additional_drop_params": `["reasoning_content", "include_reasoning", "promptCacheKey"]`,
+		"drop_params":            "true",
+		"timeout":                "60",
+		"temperature_scale":      "0.75",
+		"note":                   "keep-as-string",
+		"complex_config":         `{"nested":{"value":42}}`,
+	}
+
+	mergeAdditionalLiteLLMParams(litellmParams, additional)
+
+	got, ok := litellmParams["additional_drop_params"].([]string)
+	if !ok {
+		t.Fatalf("additional_drop_params type = %T, want []string", litellmParams["additional_drop_params"])
+	}
+	want := []string{"reasoning_content", "include_reasoning", "promptCacheKey"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("additional_drop_params = %#v, want %#v", got, want)
+	}
+
+	// Must not strip unrelated keys from the request body (old broken behavior).
+	if _, stillThere := litellmParams["model"]; !stillThere {
+		t.Fatalf("model was deleted from litellmParams; additional_drop_params must not mutate sibling keys")
+	}
+	if litellmParams["drop_params"] != true {
+		t.Fatalf("drop_params = %#v, want true", litellmParams["drop_params"])
+	}
+	if litellmParams["timeout"] != 60 {
+		t.Fatalf("timeout = %#v, want 60", litellmParams["timeout"])
+	}
+	if litellmParams["temperature_scale"] != 0.75 {
+		t.Fatalf("temperature_scale = %#v, want 0.75", litellmParams["temperature_scale"])
+	}
+	if litellmParams["note"] != "keep-as-string" {
+		t.Fatalf("note = %#v, want keep-as-string", litellmParams["note"])
+	}
+	cfg, ok := litellmParams["complex_config"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("complex_config type = %T, want map", litellmParams["complex_config"])
+	}
+	nested, ok := cfg["nested"].(map[string]interface{})
+	if !ok || nested["value"] != float64(42) {
+		t.Fatalf("complex_config = %#v, want nested.value=42", litellmParams["complex_config"])
+	}
+}
+
+func TestMergeAdditionalLiteLLMParams_DoesNotDeleteNamedKeys(t *testing.T) {
+	// Regression: previous implementation treated additional_drop_params as a
+	// list of keys to delete from the Terraform->API payload.
+	litellmParams := map[string]interface{}{
+		"model":               "x",
+		"reasoning_effort":    "high",
+		"reasoningEffort":     "high",
+		"custom_llm_provider": "azure",
+	}
+	additional := map[string]interface{}{
+		"additional_drop_params": `["reasoningEffort", "reasoning_effort"]`,
+	}
+
+	mergeAdditionalLiteLLMParams(litellmParams, additional)
+
+	if _, ok := litellmParams["reasoning_effort"]; !ok {
+		t.Fatal("reasoning_effort was deleted from payload; must remain and be stripped at proxy runtime instead")
+	}
+	if _, ok := litellmParams["reasoningEffort"]; !ok {
+		t.Fatal("reasoningEffort was deleted from payload; must remain and be stripped at proxy runtime instead")
+	}
+	got := litellmParams["additional_drop_params"].([]string)
+	want := []string{"reasoningEffort", "reasoning_effort"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("additional_drop_params = %#v, want %#v", got, want)
+	}
+}

--- a/terraform/provider/litellm/resource_model_additional_params_test.go
+++ b/terraform/provider/litellm/resource_model_additional_params_test.go
@@ -31,7 +31,6 @@ func TestMergeAdditionalLiteLLMParams_PassesAdditionalDropParams(t *testing.T) {
 		t.Fatalf("additional_drop_params = %#v, want %#v", got, want)
 	}
 
-	// Must not strip unrelated keys from the request body (old broken behavior).
 	if _, stillThere := litellmParams["model"]; !stillThere {
 		t.Fatalf("model was deleted from litellmParams; additional_drop_params must not mutate sibling keys")
 	}
@@ -58,8 +57,6 @@ func TestMergeAdditionalLiteLLMParams_PassesAdditionalDropParams(t *testing.T) {
 }
 
 func TestMergeAdditionalLiteLLMParams_DoesNotDeleteNamedKeys(t *testing.T) {
-	// Regression: previous implementation treated additional_drop_params as a
-	// list of keys to delete from the Terraform->API payload.
 	litellmParams := map[string]interface{}{
 		"model":               "x",
 		"reasoning_effort":    "high",
@@ -73,10 +70,10 @@ func TestMergeAdditionalLiteLLMParams_DoesNotDeleteNamedKeys(t *testing.T) {
 	mergeAdditionalLiteLLMParams(litellmParams, additional)
 
 	if _, ok := litellmParams["reasoning_effort"]; !ok {
-		t.Fatal("reasoning_effort was deleted from payload; must remain and be stripped at proxy runtime instead")
+		t.Fatal("reasoning_effort was deleted from payload")
 	}
 	if _, ok := litellmParams["reasoningEffort"]; !ok {
-		t.Fatal("reasoningEffort was deleted from payload; must remain and be stripped at proxy runtime instead")
+		t.Fatal("reasoningEffort was deleted from payload")
 	}
 	got := litellmParams["additional_drop_params"].([]string)
 	want := []string{"reasoningEffort", "reasoning_effort"}

--- a/terraform/provider/litellm/resource_model_crud.go
+++ b/terraform/provider/litellm/resource_model_crud.go
@@ -166,75 +166,7 @@ func createOrUpdateModel(d *schema.ResourceData, m interface{}, isUpdate bool) e
 
 	// Add additional parameters if provided
 	if additionalParams, ok := d.GetOk("additional_litellm_params"); ok {
-		var dropParams []string
-
-		for key, value := range additionalParams.(map[string]interface{}) {
-			// Convert string values to appropriate types where possible
-			if strValue, ok := value.(string); ok {
-				// Check if it's JSON (starts with [ or {)
-				trimmedValue := strings.TrimSpace(strValue)
-				if strings.HasPrefix(trimmedValue, "[") || strings.HasPrefix(trimmedValue, "{") {
-					var parsedValue interface{}
-					if err := json.Unmarshal([]byte(strValue), &parsedValue); err == nil {
-						// Successfully parsed JSON
-						if key == "additional_drop_params" {
-							// Handle drop params specially
-							if dropList, ok := parsedValue.([]interface{}); ok {
-								for _, item := range dropList {
-									if paramStr, ok := item.(string); ok {
-										dropParams = append(dropParams, paramStr)
-									}
-								}
-							}
-							continue // Don't add to litellmParams
-						} else {
-							litellmParams[key] = parsedValue
-						}
-					} else {
-						// Not valid JSON, apply existing conversion logic
-						if strValue == "true" {
-							litellmParams[key] = true
-						} else if strValue == "false" {
-							litellmParams[key] = false
-						} else {
-							// Try to convert numeric strings
-							if intValue, err := strconv.Atoi(strValue); err == nil {
-								litellmParams[key] = intValue
-							} else if floatValue, err := strconv.ParseFloat(strValue, 64); err == nil {
-								litellmParams[key] = floatValue
-							} else {
-								// Keep as string
-								litellmParams[key] = strValue
-							}
-						}
-					}
-				} else {
-					// Apply existing conversion logic for non-JSON strings
-					if strValue == "true" {
-						litellmParams[key] = true
-					} else if strValue == "false" {
-						litellmParams[key] = false
-					} else {
-						// Try to convert numeric strings
-						if intValue, err := strconv.Atoi(strValue); err == nil {
-							litellmParams[key] = intValue
-						} else if floatValue, err := strconv.ParseFloat(strValue, 64); err == nil {
-							litellmParams[key] = floatValue
-						} else {
-							// Keep as string
-							litellmParams[key] = strValue
-						}
-					}
-				}
-			} else {
-				litellmParams[key] = value
-			}
-		}
-
-		// Apply drop params at the end
-		for _, paramToDrop := range dropParams {
-			delete(litellmParams, paramToDrop)
-		}
+		mergeAdditionalLiteLLMParams(litellmParams, additionalParams.(map[string]interface{}))
 	}
 
 	// Add litellm_credential_name to litellmParams if provided
@@ -421,4 +353,63 @@ func resourceLiteLLMModelDelete(d *schema.ResourceData, m interface{}) error {
 
 	d.SetId("")
 	return nil
+}
+
+// mergeAdditionalLiteLLMParams coerces additional_litellm_params values and
+// merges them into litellmParams. additional_drop_params is a first-class
+// LiteLLM litellm_params field (runtime param strip list) and must be sent to
+// the API as []string — it must not be used to delete keys from this request body.
+func mergeAdditionalLiteLLMParams(litellmParams map[string]interface{}, additionalParams map[string]interface{}) {
+	for key, value := range additionalParams {
+		strValue, ok := value.(string)
+		if !ok {
+			litellmParams[key] = value
+			continue
+		}
+
+		trimmedValue := strings.TrimSpace(strValue)
+		if strings.HasPrefix(trimmedValue, "[") || strings.HasPrefix(trimmedValue, "{") {
+			var parsedValue interface{}
+			if err := json.Unmarshal([]byte(strValue), &parsedValue); err == nil {
+				if key == "additional_drop_params" {
+					litellmParams[key] = coerceStringList(parsedValue)
+					continue
+				}
+				litellmParams[key] = parsedValue
+				continue
+			}
+		}
+
+		litellmParams[key] = coerceStringScalar(strValue)
+	}
+}
+
+func coerceStringList(parsedValue interface{}) []string {
+	dropList, ok := parsedValue.([]interface{})
+	if !ok {
+		return nil
+	}
+	out := make([]string, 0, len(dropList))
+	for _, item := range dropList {
+		if paramStr, ok := item.(string); ok {
+			out = append(out, paramStr)
+		}
+	}
+	return out
+}
+
+func coerceStringScalar(strValue string) interface{} {
+	if strValue == "true" {
+		return true
+	}
+	if strValue == "false" {
+		return false
+	}
+	if intValue, err := strconv.Atoi(strValue); err == nil {
+		return intValue
+	}
+	if floatValue, err := strconv.ParseFloat(strValue, 64); err == nil {
+		return floatValue
+	}
+	return strValue
 }

--- a/terraform/provider/litellm/resource_model_crud.go
+++ b/terraform/provider/litellm/resource_model_crud.go
@@ -355,10 +355,6 @@ func resourceLiteLLMModelDelete(d *schema.ResourceData, m interface{}) error {
 	return nil
 }
 
-// mergeAdditionalLiteLLMParams coerces additional_litellm_params values and
-// merges them into litellmParams. additional_drop_params is a first-class
-// LiteLLM litellm_params field (runtime param strip list) and must be sent to
-// the API as []string — it must not be used to delete keys from this request body.
 func mergeAdditionalLiteLLMParams(litellmParams map[string]interface{}, additionalParams map[string]interface{}) {
 	for key, value := range additionalParams {
 		strValue, ok := value.(string)


### PR DESCRIPTION
## TLDR

Problem this solves:

- TF `additional_drop_params` never lands on the model in the proxy DB
- Provider treated that key as a client-side body filter instead
- Stock provider leaves `/model/info` without the runtime drop list

How it solves it:

- Parse the JSON array and set `litellm_params.additional_drop_params`
- Stop deleting sibling keys from the create/update payload
- Docs/examples match LiteLLM proxy semantics; unit tests cover the regression

## User Flow

Before: a proxy admin configures a Fireworks (or Azure) deployment via Terraform so the proxy strips unsupported client params, but the setting never sticks

1. They set on `litellm_model`:
   ```hcl
   additional_litellm_params = {
     drop_params            = "true"
     additional_drop_params = jsonencode([
       "reasoning_content",
       "include_reasoning",
       "promptCacheKey",
       "prompt_cache_key"
     ])
   }
   ```
2. They run `terraform apply` against the live proxy (`POST /model/new` or `POST /model/update`)
3. Apply succeeds and TF state shows `additional_drop_params`
4. They call `GET /model/info?litellm_model_id=<id>` and `litellm_params.additional_drop_params` is missing / null
5. Client requests still send those params upstream (or they must re-patch via UI/API after every apply)

After: the same Terraform config persists the drop list on the deployment

1. Same HCL as above
2. Same `terraform apply` (`POST /model/new` or `POST /model/update`)
3. Apply succeeds
4. `GET /model/info?litellm_model_id=<id>` returns
   ```json
   "additional_drop_params": [
     "reasoning_content",
     "include_reasoning",
     "promptCacheKey",
     "prompt_cache_key"
   ]
   ```
5. The proxy can strip those names at request time for that deployment without a manual `/model/update`

## Relevant issues

Fixes #38349

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally (`go test ./litellm/ -run TestMergeAdditionalLiteLLMParams -v`)
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

Shared setup: provider binary built from this branch, `dev_overrides` pointed at it, admin key with `/model/new|update|delete|info` + `/credentials/by_name`, target `https://litellm.shared.getflex.org`, Fireworks credential `Fireworks AI Service Account`, base model `accounts/fireworks/routers/glm-5p2-fast-us`.

### Before (BerriAI/litellm provider v1.98.0 registry — same HCL)

1. `terraform apply` with `additional_drop_params = jsonencode(["reasoning_content", "include_reasoning", "promptCacheKey", "prompt_cache_key"])`
2. `GET /model/info?litellm_model_id=<id>` → `litellm_params.additional_drop_params` absent (provider never POSTs the field; it only deletes those names from the TF request body, which usually has none of them)

### After (this branch tip)

1. Built provider from this PR and applied:
   ```hcl
   resource "litellm_model" "test" {
     model_name              = "tf-test-glm-5-2-fast-adp-1787753666"
     base_model              = "accounts/fireworks/routers/glm-5p2-fast-us"
     custom_llm_provider     = "fireworks_ai"
     litellm_credential_name = "Fireworks AI Service Account"
     mode                    = "chat"
     additional_litellm_params = {
       drop_params            = "true"
       additional_drop_params = jsonencode([
         "reasoning_content",
         "include_reasoning",
         "promptCacheKey",
         "prompt_cache_key"
       ])
     }
   }
   ```
2. Apply created id `af59e31a-96fc-4729-842c-91f8dd632a1d`
3. `GET /model/info?litellm_model_id=af59e31a-96fc-4729-842c-91f8dd632a1d` returned:
   ```json
   {
     "model_name": "tf-test-glm-5-2-fast-adp-1787753666",
     "model": "fireworks_ai/accounts/fireworks/routers/glm-5p2-fast-us",
     "drop_params": true,
     "additional_drop_params": [
       "reasoning_content",
       "include_reasoning",
       "promptCacheKey",
       "prompt_cache_key"
     ],
     "credential": "Fireworks AI Service Account"
   }
   ```
4. `terraform destroy` removed the test deployment

## Type

🐛 Bug Fix
📖 Documentation
✅ Test

## Caveats (if any)

### Medium

- **Behavior change for anyone relying on the old meaning**: previously `additional_drop_params` tried to delete keys from the Terraform→API payload and never stored the list. If someone depended on that (unlikely in practice — those keys are rarely in the TF-built map), they lose that client-side omit behavior. Runtime drop-list storage is what LiteLLM documents and what the field name implies

### Low

- Fix ships with the next LiteLLM/provider release that includes this commit (provider version tracks proxy version). Until then, pin a build from this branch or re-patch via `/model/update` after applies
- Read still preserves `additional_litellm_params` from state when the API omits custom fields (pre-existing); no change to that path

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
