### PR TITLE
refactor(token-counter): remove redundant tokenizer branch

### DIFF
--- a/litellm/litellm_core_utils/token_counter.py
+++ b/litellm/litellm_core_utils/token_counter.py
@@ -546,10 +546,7 @@ def _get_count_function(
         elif tokenizer_json["type"] == "openai_tokenizer":
             model_to_use: Final = _fix_model_name(model)
             try:
-                if "gpt-4o" in model_to_use:
-                    encoding = tiktoken.get_encoding("o200k_base")
-                else:
-                    encoding = tiktoken.encoding_for_model(model_to_use)
+                encoding = tiktoken.encoding_for_model(model_to_use)
             except KeyError:
                 print_verbose("Warning: model not found. Using cl100k_base encoding.")
                 encoding = tiktoken.get_encoding("cl100k_base")

--- a/tests/test_litellm/litellm_core_utils/test_token_counter.py
+++ b/tests/test_litellm/litellm_core_utils/test_token_counter.py
@@ -14,7 +14,10 @@ import litellm
 from litellm import create_pretrained_tokenizer, decode, encode, get_modified_max_tokens
 from litellm import token_counter as token_counter_old
 import litellm.constants
-from litellm.litellm_core_utils.token_counter import _get_tiktoken_count_function
+from litellm.litellm_core_utils.token_counter import (
+    _get_count_function,
+    _get_tiktoken_count_function,
+)
 from litellm.litellm_core_utils.token_counter import token_counter as token_counter_new
 from tests.large_text import text
 from tests.test_litellm.litellm_core_utils.messages_with_counts import (
@@ -535,18 +538,21 @@ def test_empty_tools():
     print(result)
 
 
-@pytest.mark.skip(
-    reason="Skipping this test temporarily because it relies on a function being called that I am removing."
-)
-def test_gpt_4o_token_counter():
-    with patch.object(
-        litellm.utils, "openai_token_counter", new=MagicMock()
-    ) as mock_client:
-        token_counter(
-            model="gpt-4o-2024-05-13", messages=[{"role": "user", "content": "Hey!"}]
-        )
+def test_openai_tokenizer_uses_tiktoken_model_mapping():
+    with (
+        patch(
+            "litellm.litellm_core_utils.token_counter.tiktoken.encoding_for_model"
+        ) as mock_encoding_for_model,
+        patch(
+            "litellm.litellm_core_utils.token_counter.tiktoken.get_encoding"
+        ) as mock_get_encoding,
+    ):
+        _get_count_function(model="gpt-4o-2024-05-13")
 
-        mock_client.assert_called()
+        mock_encoding_for_model.assert_called_once_with(
+            "gpt-4o-2024-05-13"
+        )
+        mock_get_encoding.assert_not_called()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## TLDR

Problem this solves:

- LiteLLM maintains a GPT-4o-only tokenizer branch
- The branch duplicates tiktoken's supported model mapping
- Its existing regression test is stale and skipped

How it solves it:

- Use `encoding_for_model` for the affected model
- Preserve the existing unknown-model fallback
- Replace the skipped test with focused regression coverage

LiteLLM requires `tiktoken>=0.8.0`, which already maps `gpt-4o` and `gpt-4o-*` to `o200k_base`

Reference: [tiktoken 0.8.0 model mapping](https://github.com/openai/tiktoken/blob/0.8.0/tiktoken/model.py)

## User Flow

Before: a developer counts GPT-4o input locally and receives the expected count

1. They call `litellm.token_counter(model="gpt-4o-2024-05-13", text="Hey!")`
2. The call returns `2`

After: the same public call preserves its existing result

1. They call `litellm.token_counter(model="gpt-4o-2024-05-13", text="Hey!")`
2. The call returns `2`

## Relevant issues

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally
- [ ] My PR passes all required CI/CD checks
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

This is a behavior-preserving tokenizer refactor, so the public result remains unchanged

### Before (40423e6ec02b)

1. Run `python -c 'import litellm; print(litellm.token_counter(model="gpt-4o-2024-05-13", text="Hey!"))'`
2. Observe `2`

### After (ad18517)

1. Run the same command
2. Observe `2`

## Type

Refactoring

## Caveats (if any)

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR