### PR TITLE
fix(bedrock): populate response headers into _hidden_params['additional_headers'] (#38357)

### DIFF
--- a/litellm/llms/bedrock/chat/converse_transformation.py
+++ b/litellm/llms/bedrock/chat/converse_transformation.py
@@ -21,6 +21,7 @@ from litellm.litellm_core_utils.core_helpers import (
     filter_exceptions_from_params,
     filter_internal_params,
     map_finish_reason,
+    process_response_headers,
     safe_deep_copy,
 )
 from litellm.litellm_core_utils.litellm_logging import Logging
@@ -2336,6 +2337,11 @@ class AmazonConverseConfig(BaseConfig):
             service_tier_block: Final = completion_response["serviceTier"]
             if isinstance(service_tier_block, dict) and "type" in service_tier_block:
                 setattr(model_response, "service_tier", service_tier_block["type"])
+
+        # Populate response headers into _hidden_params["additional_headers"]
+        if hasattr(response, "headers") and response.headers is not None:
+            raw_headers = dict(response.headers)
+            model_response._hidden_params["additional_headers"] = process_response_headers(raw_headers)
 
         return model_response
 

--- a/tests/test_litellm/llms/bedrock/test_bedrock_additional_headers_38357.py
+++ b/tests/test_litellm/llms/bedrock/test_bedrock_additional_headers_38357.py
@@ -1,0 +1,58 @@
+import httpx
+import pytest
+from litellm.llms.bedrock.chat.converse_transformation import AmazonConverseConfig
+from litellm.types.utils import ModelResponse
+
+def test_bedrock_converse_populates_additional_headers():
+    """
+    Regression test for #38357: Bedrock Converse handler should populate
+    response headers (e.g. x-amzn-RequestId) into _hidden_params['additional_headers'].
+    """
+    config = AmazonConverseConfig()
+    
+    mock_payload = {
+        "output": {
+            "message": {
+                "role": "assistant",
+                "content": [{"text": "Hello world"}]
+            }
+        },
+        "stopReason": "end_turn",
+        "usage": {
+            "inputTokens": 10,
+            "outputTokens": 5,
+            "totalTokens": 15
+        }
+    }
+    
+    headers = {
+        "x-amzn-RequestId": "test-request-id-12345",
+        "content-type": "application/json",
+        "date": "Wed, 26 Aug 2026 16:00:00 GMT"
+    }
+    
+    raw_response = httpx.Response(
+        status_code=200,
+        json=mock_payload,
+        headers=headers,
+        request=httpx.Request("POST", "https://bedrock.test")
+    )
+    
+    model_response = ModelResponse()
+    
+    res = config._transform_response(
+        model="bedrock/anthropic.claude-v2",
+        response=raw_response,
+        model_response=model_response,
+        stream=False,
+        logging_obj=None,
+        optional_params={},
+        api_key="test-key",
+        data={},
+        messages=[{"role": "user", "content": "hi"}],
+        encoding=None
+    )
+    
+    additional_headers = res._hidden_params.get("additional_headers", {})
+    assert "llm_provider-x-amzn-requestid" in additional_headers or "x-amzn-requestid" in additional_headers
+    assert additional_headers.get("llm_provider-x-amzn-requestid") == "test-request-id-12345" or additional_headers.get("x-amzn-requestid") == "test-request-id-12345"


### PR DESCRIPTION
## Summary

Fixes #38357.

When calling Bedrock via `litellm.completion(model="bedrock/...")`, `response._hidden_params["additional_headers"]`. The AWS request id (`x-amzn-RequestId`) and other raw response headers were never processed because `AmazonConverseConfig._transform_response()` only parsed the body.

### Changes
- Calls `process_response_headers(raw_headers)` on `response.headers` inside `AmazonConverseConfig._transform_response` and stores it into `model_response._hidden_params["additional_headers"]`.
- Adds regression unit test covering header extraction (e.g. `x-amzn-RequestId`).