### PR TITLE
fix(cost-map): add US data residency uplift to claude-sonnet-4-6 and mythos entries

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -12515,7 +12515,10 @@
         "supports_tool_choice": true,
         "supports_vision": true,
         "supports_output_config": true,
-        "prompt_cache_min_tokens": 1024
+        "prompt_cache_min_tokens": 1024,
+        "provider_specific_entry": {
+            "us": 1.1
+        }
     },
     "claude-sonnet-4-5-20250929-v1:0": {
         "cache_creation_input_token_cost": 3.75e-06,
@@ -50825,7 +50828,10 @@
         "supports_tool_choice": true,
         "supports_vision": true,
         "supports_xhigh_reasoning_effort": true,
-        "supports_native_structured_output": true
+        "supports_native_structured_output": true,
+        "provider_specific_entry": {
+            "us": 1.1
+        }
     },
     "claude-mythos-preview": {
         "cache_creation_input_token_cost": 1.25e-05,
@@ -50860,7 +50866,10 @@
         "supports_tool_choice": true,
         "supports_vision": true,
         "supports_xhigh_reasoning_effort": true,
-        "supports_native_structured_output": true
+        "supports_native_structured_output": true,
+        "provider_specific_entry": {
+            "us": 1.1
+        }
     },
     "gemini/gemini-robotics-er-2-streaming-preview": {
         "input_cost_per_audio_token": 2e-06,

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -12515,7 +12515,10 @@
         "supports_tool_choice": true,
         "supports_vision": true,
         "supports_output_config": true,
-        "prompt_cache_min_tokens": 1024
+        "prompt_cache_min_tokens": 1024,
+        "provider_specific_entry": {
+            "us": 1.1
+        }
     },
     "claude-sonnet-4-5-20250929-v1:0": {
         "cache_creation_input_token_cost": 3.75e-06,
@@ -50825,7 +50828,10 @@
         "supports_tool_choice": true,
         "supports_vision": true,
         "supports_xhigh_reasoning_effort": true,
-        "supports_native_structured_output": true
+        "supports_native_structured_output": true,
+        "provider_specific_entry": {
+            "us": 1.1
+        }
     },
     "claude-mythos-preview": {
         "cache_creation_input_token_cost": 1.25e-05,
@@ -50860,7 +50866,10 @@
         "supports_tool_choice": true,
         "supports_vision": true,
         "supports_xhigh_reasoning_effort": true,
-        "supports_native_structured_output": true
+        "supports_native_structured_output": true,
+        "provider_specific_entry": {
+            "us": 1.1
+        }
     },
     "gemini/gemini-robotics-er-2-streaming-preview": {
         "input_cost_per_audio_token": 2e-06,

--- a/tests/test_litellm/test_cost_calculator.py
+++ b/tests/test_litellm/test_cost_calculator.py
@@ -2840,6 +2840,38 @@ def test_anthropic_geo_and_fast_multipliers_compose(_local_model_cost_map, monke
     assert completion_cost == pytest.approx(500 * 25e-6 * 2.0 * 1.1)
 
 
+@pytest.mark.parametrize(
+    "model",
+    ["claude-sonnet-4-6", "claude-mythos-5", "claude-mythos-preview"],
+)
+def test_anthropic_us_data_residency_uplift_on_claude_4_6_and_later_models(_local_model_cost_map, monkeypatch, model):
+    """
+    Anthropic bills every Claude 4.6+ model served with ``inference_geo="us"`` at
+    1.1x, and echoes that geo back in the response usage, so each of these real
+    cost-map entries has to carry the ``us`` multiplier or US-pinned traffic is
+    under-reported by 10%.
+    """
+    from litellm.llms.anthropic.cost_calculation import (
+        cost_per_token as anthropic_cost_per_token,
+    )
+    from litellm.types.utils import Usage
+
+    monkeypatch.setenv("LITELLM_LOCAL_MODEL_COST_MAP", "True")
+
+    def make_usage() -> "Usage":
+        return Usage(prompt_tokens=1_000, completion_tokens=100, total_tokens=1_100)
+
+    base_prompt_cost, base_completion_cost = anthropic_cost_per_token(model=model, usage=make_usage())
+
+    geo_usage = make_usage()
+    geo_usage.inference_geo = "us"
+    geo_prompt_cost, geo_completion_cost = anthropic_cost_per_token(model=model, usage=geo_usage)
+
+    assert base_prompt_cost > 0
+    assert geo_prompt_cost == pytest.approx(base_prompt_cost * 1.1)
+    assert geo_completion_cost == pytest.approx(base_completion_cost * 1.1)
+
+
 def test_gemini_cache_tokens_details_no_negative_values():
     """
     Test for Issue #18750: Negative text_tokens with Gemini caching

--- a/tests/test_litellm/test_cost_calculator.py
+++ b/tests/test_litellm/test_cost_calculator.py
@@ -2844,7 +2844,9 @@ def test_anthropic_geo_and_fast_multipliers_compose(_local_model_cost_map, monke
     "model",
     ["claude-sonnet-4-6", "claude-mythos-5", "claude-mythos-preview"],
 )
-def test_anthropic_us_data_residency_uplift_on_claude_4_6_and_later_models(_local_model_cost_map, monkeypatch, model):
+def test_anthropic_us_data_residency_uplift_on_claude_4_6_and_later_models(
+    _local_model_cost_map, monkeypatch, model
+):
     """
     Anthropic bills every Claude 4.6+ model served with ``inference_geo="us"`` at
     1.1x, and echoes that geo back in the response usage, so each of these real


### PR DESCRIPTION
## TLDR

Problem this solves:

- Anthropic bills US data residency (`inference_geo: "us"`) at 1.1x on every Claude 4.6+ model
- Our cost map only carries that uplift on some entries
- claude-sonnet-4-6, claude-mythos-5, and claude-mythos-preview lack it, so US-pinned traffic under-reports spend by 10%

How it solves it:

- Adds `provider_specific_entry: {"us": 1.1}` to those three entries in both cost maps
- Adds a regression test asserting the 1.1x uplift on each entry

## User Flow

Before: a developer whose org pins US data residency on claude-sonnet-4-6 sees gateway spend 10% below Anthropic's invoice

1. They send POST https://litellm-domain/v1/chat/completions with `{"model": "claude-sonnet-4-6", "inference_geo": "us", ...}`
2. The response usage echoes `"inference_geo": "us"`, confirming Anthropic served and billed the request at the 1.1x US rate
3. The `x-litellm-response-cost` header (and every spend surface fed by it) shows the standard price, e.g. $0.000219 where Anthropic bills $0.0002409
4. The same happens on POST https://litellm-domain/v1/messages, so all their US-pinned Anthropic traffic under-reports by 10%

After: the same requests report the 1.1x US price Anthropic actually bills

1. They send the same POST https://litellm-domain/v1/chat/completions with `{"model": "claude-sonnet-4-6", "inference_geo": "us", ...}`
2. The response usage echoes `"inference_geo": "us"` as before
3. The `x-litellm-response-cost` header now shows the 1.1x price, e.g. $0.0002409, matching Anthropic's invoice
4. POST https://litellm-domain/v1/messages reports the uplifted price too, and requests without `inference_geo` still bill at the standard rate

## Relevant issues

## Linear ticket

Resolves LIT-6178

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Both legs ran live against the real Anthropic API (no mocks, real spend), each from its own worktree with `LITELLM_LOCAL_MODEL_COST_MAP=True`, a DB-less proxy, and 2 uvicorn workers. Before: commit cdb60af024 (merge base), port 48074. After: commit a2cd2d8a4b (PR tip), port 24355. Config for both:

```yaml
model_list:
  - model_name: claude-sonnet-4-6
    litellm_params:
      model: anthropic/claude-sonnet-4-6
      api_key: os.environ/ANTHROPIC_API_KEY
  - model_name: claude-opus-4-8
    litellm_params:
      model: anthropic/claude-opus-4-8
      api_key: os.environ/ANTHROPIC_API_KEY
general_settings:
  master_key: sk-lit6178qa
```

Every call: `-H 'Authorization: Bearer sk-lit6178qa' -H 'Content-Type: application/json'`. Standard-rate expectation for the sonnet cases (12 prompt / 4 completion tokens): 12x$3/M + 4x$15/M = $0.000096; US uplift: x1.1 = $0.0001056.

### Before (cdb60af024)

#### /v1/chat/completions with inference_geo us

1. `curl -s -D chat_us.hdr -X POST http://localhost:48074/v1/chat/completions -d '{"model":"claude-sonnet-4-6","messages":[{"role":"user","content":"Reply with exactly: hello"}],"max_tokens":16,"inference_geo":"us"}'`
2. 200; usage echoes `"inference_geo": "us"` (Anthropic billed the 1.1x US rate), but `x-litellm-response-cost: 9.6e-05`: the standard rate, an 11% undercount

#### /v1/messages with inference_geo us

1. `curl -s -D msgs_us.hdr -X POST http://localhost:48074/v1/messages -d '{"model":"claude-sonnet-4-6","max_tokens":16,"messages":[{"role":"user","content":"Reply with exactly: hello"}],"inference_geo":"us"}'`
2. 200; `usage.inference_geo: "us"`, yet `x-litellm-response-cost: 9.6e-05` (standard rate)

#### /v1/responses with inference_geo us

1. `curl -s -D resp_us.hdr -X POST http://localhost:48074/v1/responses -d '{"model":"claude-sonnet-4-6","input":"Reply with exactly: hello","max_output_tokens":16,"inference_geo":"us"}'`
2. 200; `x-litellm-response-cost: 9.6e-05` (standard rate)

#### control: /v1/chat/completions without inference_geo

1. Same chat command with the `inference_geo` field removed
2. 200; usage echoes `"inference_geo": "global"`, `x-litellm-response-cost: 9.6e-05`: correct

#### control: claude-opus-4-8 with inference_geo us (entry already has us 1.1)

1. Same chat command with `"model": "claude-opus-4-8"`
2. 200; `x-litellm-response-cost: 0.00019800000000000004` = (16x$5/M + 4x$25/M) x 1.1: the uplift applies where the map carries it

### After (a2cd2d8a4b)

#### /v1/chat/completions with inference_geo us

1. `curl -s -D chat_us.hdr -X POST http://localhost:24355/v1/chat/completions -d '{"model":"claude-sonnet-4-6","messages":[{"role":"user","content":"Reply with exactly: hello"}],"max_tokens":16,"inference_geo":"us"}'`
2. 200; usage echoes `"inference_geo": "us"` and `x-litellm-response-cost: 0.00010560000000000002` = 1.1x, matching Anthropic's US billing (per-component headers agree: input 3.96e-05 = 12 x 3e-06 x 1.1, output 6.6e-05 = 4 x 1.5e-05 x 1.1)

#### /v1/messages with inference_geo us

1. `curl -s -D msgs_us.hdr -X POST http://localhost:24355/v1/messages -d '{"model":"claude-sonnet-4-6","max_tokens":16,"messages":[{"role":"user","content":"Reply with exactly: hello"}],"inference_geo":"us"}'`
2. 200; `usage.inference_geo: "us"`, `x-litellm-response-cost: 0.00010560000000000002` (1.1x)

#### /v1/responses with inference_geo us

1. `curl -s -D resp_us.hdr -X POST http://localhost:24355/v1/responses -d '{"model":"claude-sonnet-4-6","input":"Reply with exactly: hello","max_output_tokens":16,"inference_geo":"us"}'`
2. 200; `x-litellm-response-cost: 0.00010560000000000002` (1.1x)

#### control: /v1/chat/completions without inference_geo

1. Same chat command with the `inference_geo` field removed
2. 200; usage echoes `"inference_geo": "global"`, `x-litellm-response-cost: 9.6e-05`: standard traffic unchanged

#### control: claude-opus-4-8 with inference_geo us (entry already has us 1.1)

1. Same chat command with `"model": "claude-opus-4-8"`
2. 200; `x-litellm-response-cost: 0.00019800000000000004`: unchanged

QA observations (pre-existing, this PR leaves them alone):

- /v1/responses drops the `inference_geo` echo from usage; billing still correct
- chat without geo echoes `inference_geo: "global"`, billed standard: harmless

Commit dbe52a80c1 since this run only rewraps a test function declaration, so it cannot change behavior and the proof above stands.

## Type

🐛 Bug Fix

## Caveats (if any)

### Low

- mythos uplift rests on Anthropic's "Claude 4.6 and later" docs; those models are not callable with our org key
- the multiplier only fires when the response echoes `inference_geo: "us"`, so it cannot overcharge non-US traffic

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR


- [x] a2cd2d8a4b3758c48909fec7b50815aaa66de06d passes /live-pr-risk
- [x] dbe52a80c1c925d7f5594c937e024c0b3f8173d5 passes /live-pr-risk

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Data-only cost map updates plus tests; no billing logic changes, and the US uplift only applies when usage reports inference_geo "us".
> 
> **Overview**
> Fixes **under-reported spend** when Anthropic serves Claude 4.6+ with US data residency (`inference_geo: "us"`), which bills at **1.1×** standard rates.
> 
> Adds `provider_specific_entry: {"us": 1.1}` to **`claude-sonnet-4-6`**, **`claude-mythos-5`**, and **`claude-mythos-preview`** in both `model_prices_and_context_window.json` and its backup, aligning them with other Claude 4.6+ entries that already carried the multiplier. Existing Anthropic cost logic applies this when usage echoes `inference_geo: "us"`; requests without US geo are unchanged.
> 
> A parametrized regression test in `test_cost_calculator.py` asserts prompt and completion costs scale by 1.1× for each of those three models.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dbe52a80c1c925d7f5594c937e024c0b3f8173d5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->