### PR TITLE
fix(model_prices): price 1-hour cache writes on claude-3-haiku and claude-3-opus at 2x input

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -12282,7 +12282,7 @@
     },
     "claude-3-haiku-20240307": {
         "cache_creation_input_token_cost": 3e-07,
-        "cache_creation_input_token_cost_above_1hr": 6e-06,
+        "cache_creation_input_token_cost_above_1hr": 5e-07,
         "cache_read_input_token_cost": 3e-08,
         "deprecation_date": "2026-04-20",
         "input_cost_per_token": 2.5e-07,
@@ -12301,7 +12301,7 @@
     },
     "claude-3-opus-20240229": {
         "cache_creation_input_token_cost": 1.875e-05,
-        "cache_creation_input_token_cost_above_1hr": 6e-06,
+        "cache_creation_input_token_cost_above_1hr": 3e-05,
         "cache_read_input_token_cost": 1.5e-06,
         "deprecation_date": "2026-01-05",
         "input_cost_per_token": 1.5e-05,

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -12282,7 +12282,7 @@
     },
     "claude-3-haiku-20240307": {
         "cache_creation_input_token_cost": 3e-07,
-        "cache_creation_input_token_cost_above_1hr": 6e-06,
+        "cache_creation_input_token_cost_above_1hr": 5e-07,
         "cache_read_input_token_cost": 3e-08,
         "deprecation_date": "2026-04-20",
         "input_cost_per_token": 2.5e-07,
@@ -12301,7 +12301,7 @@
     },
     "claude-3-opus-20240229": {
         "cache_creation_input_token_cost": 1.875e-05,
-        "cache_creation_input_token_cost_above_1hr": 6e-06,
+        "cache_creation_input_token_cost_above_1hr": 3e-05,
         "cache_read_input_token_cost": 1.5e-06,
         "deprecation_date": "2026-01-05",
         "input_cost_per_token": 1.5e-05,

--- a/tests/test_litellm/test_cost_calculator.py
+++ b/tests/test_litellm/test_cost_calculator.py
@@ -1,4 +1,7 @@
 
+import json
+from pathlib import Path
+
 import pytest
 
 
@@ -14,7 +17,13 @@ from litellm.cost_calculator import (
     response_cost_calculator,
 )
 from litellm.types.llms.openai import OpenAIRealtimeStreamList
-from litellm.types.utils import ModelInfo, ModelResponse, PromptTokensDetailsWrapper, Usage
+from litellm.types.utils import (
+    CacheCreationTokenDetails,
+    ModelInfo,
+    ModelResponse,
+    PromptTokensDetailsWrapper,
+    Usage,
+)
 from litellm.utils import TranscriptionResponse
 
 
@@ -3781,3 +3790,51 @@ def test_completion_cost_prices_anthropic_shaped_cache_read_tokens(_local_model_
     )
 
     assert cost == pytest.approx(3 * 4e-6 + 4014 * 4e-7 + 5 * 2e-5, rel=1e-9)
+
+
+@pytest.mark.parametrize(
+    ("model", "expected_1hr_rate"),
+    [("claude-3-haiku-20240307", 5e-07), ("claude-3-opus-20240229", 3e-05)],
+)
+def test_claude_3_one_hour_cache_writes_bill_at_double_input(
+    _local_model_cost_map, model: str, expected_1hr_rate: float
+):
+    """Regression: both models carried the Sonnet 1h cache-write rate (6e-06) instead of
+    2x their own input price, overbilling haiku 12x and underbilling opus 5x."""
+
+    usage = Usage(
+        prompt_tokens=1000,
+        completion_tokens=0,
+        total_tokens=1000,
+        prompt_tokens_details=PromptTokensDetailsWrapper(
+            cached_tokens=0,
+            cache_creation_tokens=1000,
+            cache_creation_token_details=CacheCreationTokenDetails(
+                ephemeral_5m_input_tokens=0, ephemeral_1h_input_tokens=1000
+            ),
+        ),
+    )
+
+    prompt_cost, _ = cost_per_token(model=model, usage_object=usage, custom_llm_provider="anthropic")
+
+    assert prompt_cost == pytest.approx(1000 * expected_1hr_rate, rel=1e-9)
+
+
+def test_every_one_hour_cache_write_rate_is_double_its_input_rate():
+    """Guard against pasting one model's 1h cache-write price onto another: every provider
+    LiteLLM tracks (Anthropic, Bedrock, Vertex, Azure) publishes the 1h write at 2x input."""
+
+    cost_map = json.loads(
+        (Path(__file__).parents[2] / "model_prices_and_context_window.json").read_text()
+    )
+    one_hour_prefix = "cache_creation_input_token_cost_above_1hr"
+    deviations = {
+        (name, key): (entry["input_cost_per_token" + key[len(one_hour_prefix) :]], entry[key])
+        for name, entry in cost_map.items()
+        if isinstance(entry, dict)
+        for key in entry
+        if key.startswith(one_hour_prefix)
+        and entry[key] != pytest.approx(2 * entry["input_cost_per_token" + key[len(one_hour_prefix) :]], rel=1e-9)
+    }
+
+    assert deviations == {}


### PR DESCRIPTION
## TLDR

Problem this solves:

- 1-hour cache writes on `claude-3-haiku-20240307` billed at 24x input (12x too high)
- The same writes on `claude-3-opus-20240229` billed at 0.4x input (5x too low)
- Both carried Sonnet's `6e-06`, pasted across models in a 2025-09-16 pricing commit

How it solves it:

- Haiku 3: `cache_creation_input_token_cost_above_1hr` 6e-06 -> 5e-07 (2x its 2.5e-07 input)
- Opus 3: 6e-06 -> 3e-05 (2x its 1.5e-05 input)
- Regression test pins both, plus a map-wide 2x invariant on every 1h key

## User Flow

Before: a team whose spend is tracked at Claude 3 Haiku prices pays 12x the published rate on every 1-hour cache write, and one tracked at Claude 3 Opus prices pays a fifth of it

1. The proxy admin adds a deployment with `base_model: claude-3-haiku-20240307` under `model_info` so its spend tracks Claude 3 Haiku pricing, and restarts the proxy
2. A developer sends POST http://litellm-domain/v1/messages with a ~9,600-token system block marked `"cache_control": {"type": "ephemeral", "ttl": "1h"}`
3. The 200 response reports `"cache_creation": {"ephemeral_1h_input_tokens": 9628}` and an `x-litellm-response-cost` header of $0.0578, though Anthropic's published 1-hour write price for that model ($0.50/MTok, 2x its $0.25/MTok input) makes the same write $0.0048
4. The same request against a deployment tracked as `claude-3-opus-20240229` comes back at $0.0583, a fifth of the $0.2892 that Anthropic's $30/MTok 1-hour write price implies
5. http://litellm-domain/ui/?page=logs shows both requests at those wrong amounts, so Haiku-tracked teams are overbilled 12x and Opus-tracked spend leaks 5x

After: the same requests bill 1-hour cache writes at exactly 2x each model's own input price

1. The proxy admin adds a deployment with `base_model: claude-3-haiku-20240307` under `model_info` so its spend tracks Claude 3 Haiku pricing, and restarts the proxy
2. A developer sends POST http://litellm-domain/v1/messages with a ~9,600-token system block marked `"cache_control": {"type": "ephemeral", "ttl": "1h"}`
3. The 200 response now carries `x-litellm-response-cost: 0.00482`, the 9,628-token write priced at $0.50/MTok
4. The opus-tracked deployment comes back at $0.2894, its 9,631-token write priced at $30/MTok
5. http://litellm-domain/ui/?page=logs shows both requests at the corrected spend

## Relevant issues

## Linear ticket

Resolves LIT-6181

## Sweep of every 1-hour cache-write price in the map

Anthropic prices prompt caching uniformly: 5-minute writes at 1.25x input, 1-hour writes at 2x input, reads at 0.1x (https://platform.claude.com/docs/en/about-claude/pricing). Before removal from that page, the Claude 3 rows listed Haiku 3 at $0.25 input / $0.50 1h write and Opus 3 at $15 input / $30 1h write, both exactly 2x. A script over the whole map checked every `cache_creation_input_token_cost_above_1hr*` key against 2x its matching input key:

| Scope | Entries | Already 2x | Action |
|---|---|---|---|
| Base 1h keys, whole map | 126 | 124 | fix the 2 below |
| Above-200k 1h keys | 10 | 10 | none |
| `claude-3-haiku-20240307` | 1 | no, 24x | 6e-06 -> 5e-07 |
| `claude-3-opus-20240229` | 1 | no, 0.4x | 6e-06 -> 3e-05 |

Entries left alone, none provably wrong:

| Left alone | Why |
|---|---|
| Bedrock Claude 3 Haiku/Opus, all region prefixes | no 1h key; AWS publishes no 1h tier for them |
| `vertex_ai/claude-3-haiku*`, `vertex_ai/claude-3-opus*` | no cache pricing at all |
| `openrouter`, `gradient_ai`, `vercel_ai_gateway` variants | no 1h key |
| `sarvam/sarvam-m` | 1h and input both 0, trivially 2x |

Why fix the values instead of dropping the key: Anthropic retired both models on its first-party API (Haiku 3 on 2026-04-20, Opus 3 on 2026-01-05), but the entries still price deployments pinned via `base_model` and gateways that kept serving them, retired siblings like Sonnet 4 and Opus 4 keep their 1h tiers in the map, and a missing 1h key makes the cost calculator fall back to the 5-minute rate, which is still the wrong price

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Both models are retired on Anthropic's first-party API and every request to them returns 404 (case 1), so a live 1h-cache call on the literal models is impossible. The closest real call is a live `claude-haiku-4-5-20251001` deployment whose spend is pinned to each Claude 3 model via `base_model`, which exercises exactly the map entries this PR fixes, plus a direct `litellm.cost_per_token` check on the literal model names (case 8). Each leg boots one proxy with `--num_workers 2` at its commit; every request is a real Anthropic API call

Shared setup, proxy config:

```yaml
model_list:
  - model_name: claude-3-haiku-20240307
    litellm_params:
      model: anthropic/claude-3-haiku-20240307
      api_key: os.environ/ANTHROPIC_API_KEY
  - model_name: claude-3-opus-20240229
    litellm_params:
      model: anthropic/claude-3-opus-20240229
      api_key: os.environ/ANTHROPIC_API_KEY
  - model_name: haiku-4-5-priced-as-claude-3-haiku
    litellm_params:
      model: anthropic/claude-haiku-4-5-20251001
      api_key: os.environ/ANTHROPIC_API_KEY
    model_info:
      base_model: claude-3-haiku-20240307
  - model_name: haiku-4-5-priced-as-claude-3-opus
    litellm_params:
      model: anthropic/claude-haiku-4-5-20251001
      api_key: os.environ/ANTHROPIC_API_KEY
    model_info:
      base_model: claude-3-opus-20240229
general_settings:
  master_key: sk-1234
```

Proxy boot and the shared cached system block (a fresh ~9,600-token uuid-prefixed filler per request, sent as an Anthropic `system` block on /v1/messages, a system message content part on /v1/chat/completions, and an `input_text` part on /v1/responses, always with `"cache_control": {"type": "ephemeral", "ttl": "1h"}`):

```bash
python litellm/proxy/proxy_cli.py --config lit6181_config.yaml --port $PORT --num_workers 2
curl -s -D - "http://localhost:$PORT/v1/messages" -H "Authorization: Bearer sk-1234" -H "content-type: application/json" \
  -d '{"model": "haiku-4-5-priced-as-claude-3-haiku", "max_tokens": 20, "system": [{"type": "text", "text": "<9,600-token filler>", "cache_control": {"type": "ephemeral", "ttl": "1h"}}], "messages": [{"role": "user", "content": "Reply with the single word ok."}]}'
```

### Before (cdb60af024)

#### 1. POST /v1/messages to the real claude-3-haiku-20240307 and claude-3-opus-20240229

1. Sent the cached payload to both literal model names
2. Both return `HTTP 404`, `"type":"not_found_error","message":"model: claude-3-haiku-20240307"` (same for opus): retired upstream, so pricing is proven through the base_model-pinned deployments below

#### 2. POST /v1/messages, priced as claude-3-haiku-20240307

1. `HTTP 200`, usage `"cache_creation": {"ephemeral_5m_input_tokens": 0, "ephemeral_1h_input_tokens": 9629}`
2. `x-litellm-response-cost: 0.05778225`, `x-litellm-response-cost-cache-creation: 0.057774` = 9629 x 6e-06, 12x the published $0.50/MTok

#### 3. POST /v1/chat/completions, priced as claude-3-haiku-20240307

1. `HTTP 200`, usage `"cache_creation_token_details": {"ephemeral_5m_input_tokens": 0, "ephemeral_1h_input_tokens": 9630}`
2. `x-litellm-response-cost: 0.05778825`, `x-litellm-response-cost-cache-creation: 0.05778`

#### 4. POST /v1/responses, priced as claude-3-haiku-20240307

1. `HTTP 200`, usage `"input_tokens_details": {..., "cache_write_tokens": 9628}`
2. `x-litellm-response-cost: 0.05777625`, `x-litellm-response-cost-cache-creation: 0.057768`

#### 5. POST /v1/messages, priced as claude-3-opus-20240229

1. `HTTP 200`, usage `"cache_creation": {"ephemeral_5m_input_tokens": 0, "ephemeral_1h_input_tokens": 9630}`
2. `x-litellm-response-cost: 0.058275`, `x-litellm-response-cost-cache-creation: 0.05778` = 9630 x 6e-06, a fifth of the published $30/MTok

#### 6. POST /v1/chat/completions, priced as claude-3-opus-20240229

1. `HTTP 200`, usage `"cache_creation_token_details": {"ephemeral_5m_input_tokens": 0, "ephemeral_1h_input_tokens": 9626}`
2. `x-litellm-response-cost: 0.058251`, `x-litellm-response-cost-cache-creation: 0.057756`

#### 7. POST /v1/responses, priced as claude-3-opus-20240229

1. `HTTP 200`, usage `"input_tokens_details": {..., "cache_write_tokens": 9629}`
2. `x-litellm-response-cost: 0.058269`, `x-litellm-response-cost-cache-creation: 0.057774`

#### 8. litellm.cost_per_token with 1000 one-hour cache-write tokens on the literal models

1. Ran a script building `Usage` with `ephemeral_1h_input_tokens=1000` against the local map for both literal model names
2. `claude-3-haiku-20240307: ... 1h=6e-06 -> 1000 one-hour cache-write tokens bill $0.006000`
3. `claude-3-opus-20240229: ... 1h=6e-06 -> 1000 one-hour cache-write tokens bill $0.006000`

### After (6416a97a4d)

#### 1. POST /v1/messages to the real claude-3-haiku-20240307 and claude-3-opus-20240229

1. Sent the cached payload to both literal model names
2. Both still return `HTTP 404` `not_found_error`: unchanged, the models stay retired upstream

#### 2. POST /v1/messages, priced as claude-3-haiku-20240307

1. `HTTP 200`, usage `"cache_creation": {"ephemeral_5m_input_tokens": 0, "ephemeral_1h_input_tokens": 9630}`
2. `x-litellm-response-cost: 0.00482325`, `x-litellm-response-cost-cache-creation: 0.004815` = 9630 x 5e-07, exactly $0.50/MTok

#### 3. POST /v1/chat/completions, priced as claude-3-haiku-20240307

1. `HTTP 200`, usage `"cache_creation_token_details": {"ephemeral_5m_input_tokens": 0, "ephemeral_1h_input_tokens": 9627}`
2. `x-litellm-response-cost: 0.00482175`, `x-litellm-response-cost-cache-creation: 0.0048135`

#### 4. POST /v1/responses, priced as claude-3-haiku-20240307

1. `HTTP 200`, usage `"input_tokens_details": {..., "cache_write_tokens": 9628}`
2. `x-litellm-response-cost: 0.00482225`, `x-litellm-response-cost-cache-creation: 0.004814`

#### 5. POST /v1/messages, priced as claude-3-opus-20240229

1. `HTTP 200`, usage `"cache_creation": {"ephemeral_5m_input_tokens": 0, "ephemeral_1h_input_tokens": 9630}`
2. `x-litellm-response-cost: 0.289395`, `x-litellm-response-cost-cache-creation: 0.2889` = 9630 x 3e-05, exactly $30/MTok

#### 6. POST /v1/chat/completions, priced as claude-3-opus-20240229

1. `HTTP 200`, usage `"cache_creation_token_details": {"ephemeral_5m_input_tokens": 0, "ephemeral_1h_input_tokens": 9631}`
2. `x-litellm-response-cost: 0.289425`, `x-litellm-response-cost-cache-creation: 0.28893`

#### 7. POST /v1/responses, priced as claude-3-opus-20240229

1. `HTTP 200`, usage `"input_tokens_details": {..., "cache_write_tokens": 9629}`
2. `x-litellm-response-cost: 0.289365`, `x-litellm-response-cost-cache-creation: 0.28887`

#### 8. litellm.cost_per_token with 1000 one-hour cache-write tokens on the literal models

1. Ran the same script against the fixed local map
2. `claude-3-haiku-20240307: ... 1h=5e-07 -> 1000 one-hour cache-write tokens bill $0.000500`
3. `claude-3-opus-20240229: ... 1h=3e-05 -> 1000 one-hour cache-write tokens bill $0.030000`

## Type

🐛 Bug Fix

## Caveats (if any)

### Low

- Both models are retired at Anthropic, so only base_model pins and other gateways hit these entries
- Bedrock and Vertex Claude 3 entries stay without a 1h price, matching those providers
- The map-wide invariant test will fail any future entry whose 1h write price is not 2x its input, on purpose: a provider publishing a different ratio should force that pricing PR to look twice

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

- [x] 6416a97a4d passes /live-pr-risk
