### PR TITLE
test(prometheus): cover caller-identity config failure cases

### DIFF
--- a/tests/test_litellm/integrations/test_prometheus_caller_identity.py
+++ b/tests/test_litellm/integrations/test_prometheus_caller_identity.py
@@ -440,7 +440,7 @@ def test_validate_mode_rejects_invalid_values_and_names_accepted_ones(
 ):
     monkeypatch.setattr(litellm, "prometheus_deployment_and_latency_caller_identity", invalid_mode)
 
-    with pytest.raises(ValueError) as exc_info:
+    with pytest.raises(ValueError, match="prometheus_deployment_and_latency_caller_identity") as exc_info:
         validate_prometheus_deployment_and_latency_caller_identity()
 
     message = str(exc_info.value)
@@ -491,7 +491,7 @@ def test_user_email_mode_conflict_error_names_every_conflicting_metric_and_only_
         },
     ]
 
-    with pytest.raises(ValueError) as exc_info:
+    with pytest.raises(ValueError, match="prometheus_deployment_and_latency_caller_identity") as exc_info:
         validate_caller_identity_settings(_identity_settings("user_email", metrics_config))
 
     message = str(exc_info.value)

--- a/tests/test_litellm/integrations/test_prometheus_caller_identity.py
+++ b/tests/test_litellm/integrations/test_prometheus_caller_identity.py
@@ -16,9 +16,12 @@ from litellm.proxy._types import UserAPIKeyAuth
 from litellm.types.integrations.prometheus import (
     DEFINED_PROMETHEUS_METRICS,
     PROMETHEUS_DEPLOYMENT_AND_LATENCY_CALLER_IDENTITY_METRICS,
+    LabelValidationError,
     PrometheusMetricLabels,
     UserAPIKeyLabelNames,
     UserAPIKeyLabelValues,
+    validate_caller_identity_settings,
+    validate_prometheus_deployment_and_latency_caller_identity,
 )
 from litellm.types.utils import StandardLoggingPayload
 
@@ -379,23 +382,12 @@ def test_deployment_failure_email_fallbacks_reach_both_real_counters(
 async def test_proxy_config_loads_caller_identity_before_initializing_callbacks(tmp_path: Path):
     from litellm.proxy.proxy_server import ProxyConfig
 
-    config_path = tmp_path / "config.yaml"
-    config_path.write_text(
-        yaml.safe_dump(
-            {
-                "model_list": [
-                    {
-                        "model_name": "test-model",
-                        "litellm_params": {"model": "openai/gpt-4", "api_key": "test-key"},
-                    }
-                ],
-                "litellm_settings": {
-                    "callbacks": ["prometheus"],
-                    "prometheus_deployment_and_latency_caller_identity": "both",
-                },
-            },
-            sort_keys=False,
-        )
+    config_path = _write_proxy_config(
+        tmp_path,
+        {
+            "callbacks": ["prometheus"],
+            "prometheus_deployment_and_latency_caller_identity": "both",
+        },
     )
     observed_modes: list[str] = []
 
@@ -409,3 +401,287 @@ async def test_proxy_config_loads_caller_identity_before_initializing_callbacks(
 
     assert observed_modes == ["both"]
     assert litellm.prometheus_deployment_and_latency_caller_identity == "both"
+
+
+def _identity_settings(mode: object, metrics_config: object = None) -> dict[str, object]:
+    settings: dict[str, object] = {"prometheus_deployment_and_latency_caller_identity": mode}
+    if metrics_config is not None:
+        settings["prometheus_metrics_config"] = metrics_config
+    return settings
+
+
+def test_validate_mode_returns_each_accepted_value_and_defaults_to_api_key_alias(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    for mode in IDENTITY_MODES:
+        _set_caller_identity(monkeypatch, mode)
+        assert validate_prometheus_deployment_and_latency_caller_identity() == mode
+
+    monkeypatch.delattr(litellm, "prometheus_deployment_and_latency_caller_identity")
+    assert validate_prometheus_deployment_and_latency_caller_identity() == "api_key_alias"
+
+
+def test_accepted_values_constant_matches_parametrized_modes():
+    from litellm.types.integrations.prometheus import (
+        PROMETHEUS_DEPLOYMENT_AND_LATENCY_CALLER_IDENTITY_VALUES,
+    )
+
+    assert PROMETHEUS_DEPLOYMENT_AND_LATENCY_CALLER_IDENTITY_VALUES == IDENTITY_MODES
+    assert len(TARGET_METRICS) == 9
+
+
+@pytest.mark.parametrize(
+    "invalid_mode",
+    ("user-email", "USER_EMAIL", "", None, True, 1, ["user_email"], {"mode": "user_email"}),
+)
+def test_validate_mode_rejects_invalid_values_and_names_accepted_ones(
+    monkeypatch: pytest.MonkeyPatch,
+    invalid_mode: object,
+):
+    monkeypatch.setattr(litellm, "prometheus_deployment_and_latency_caller_identity", invalid_mode)
+
+    with pytest.raises(ValueError) as exc_info:
+        validate_prometheus_deployment_and_latency_caller_identity()
+
+    message = str(exc_info.value)
+    assert repr(invalid_mode) in message
+    for accepted_value in IDENTITY_MODES:
+        assert accepted_value in message
+
+
+def test_validate_caller_identity_settings_without_key_leaves_mode_untouched(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    _set_caller_identity(monkeypatch, "both")
+
+    validate_caller_identity_settings({"prometheus_metrics_config": []})
+
+    assert litellm.prometheus_deployment_and_latency_caller_identity == "both"
+
+
+@pytest.mark.parametrize("mode", IDENTITY_MODES)
+def test_validate_caller_identity_settings_stores_each_valid_mode(mode: str):
+    validate_caller_identity_settings(_identity_settings(mode))
+
+    assert litellm.prometheus_deployment_and_latency_caller_identity == mode
+
+
+@pytest.mark.parametrize("invalid_mode", ("user-email", None))
+def test_validate_caller_identity_settings_rejects_invalid_and_null_modes(invalid_mode: object):
+    with pytest.raises(ValueError, match="prometheus_deployment_and_latency_caller_identity"):
+        validate_caller_identity_settings(_identity_settings(invalid_mode))
+
+
+def test_user_email_mode_conflict_error_names_every_conflicting_metric_and_only_those():
+    metrics_config = [
+        {
+            "group": "non_target",
+            "metrics": ["litellm_overhead_with_guardrails_latency_metric"],
+            "include_labels": ["api_key_alias"],
+        },
+        {
+            "group": "target_pair",
+            "metrics": ["litellm_deployment_total_requests", "litellm_llm_api_latency_metric"],
+            "include_labels": ["api_key_alias"],
+        },
+        {
+            "group": "target_single",
+            "metrics": ["litellm_request_queue_time_seconds"],
+            "include_labels": ["api_key_alias"],
+        },
+    ]
+
+    with pytest.raises(ValueError) as exc_info:
+        validate_caller_identity_settings(_identity_settings("user_email", metrics_config))
+
+    message = str(exc_info.value)
+    for conflicting_metric in (
+        "litellm_deployment_total_requests",
+        "litellm_llm_api_latency_metric",
+        "litellm_request_queue_time_seconds",
+    ):
+        assert conflicting_metric in message
+    assert "litellm_overhead_with_guardrails_latency_metric" not in message
+    assert "prometheus_deployment_and_latency_caller_identity" in message
+    assert "user_email" in message
+
+
+@pytest.mark.parametrize(
+    ("mode", "metrics_config"),
+    (
+        (
+            "user_email",
+            [
+                {
+                    "group": "g",
+                    "metrics": ["litellm_deployment_total_requests"],
+                    "include_labels": ["user_email"],
+                }
+            ],
+        ),
+        (
+            "user_email",
+            [
+                {
+                    "group": "g",
+                    "metrics": ["litellm_overhead_with_guardrails_latency_metric"],
+                    "include_labels": ["api_key_alias"],
+                }
+            ],
+        ),
+        (
+            "api_key_alias",
+            [
+                {
+                    "group": "g",
+                    "metrics": ["litellm_deployment_total_requests"],
+                    "include_labels": ["api_key_alias"],
+                }
+            ],
+        ),
+        (
+            "both",
+            [
+                {
+                    "group": "g",
+                    "metrics": ["litellm_deployment_total_requests"],
+                    "include_labels": ["api_key_alias"],
+                }
+            ],
+        ),
+        ("user_email", None),
+        ("user_email", ["not-a-dict"]),
+        (
+            "user_email",
+            [{"group": "g", "metrics": ["litellm_deployment_total_requests"], "include_labels": None}],
+        ),
+        ("user_email", [{"group": "g", "metrics": None, "include_labels": ["api_key_alias"]}]),
+    ),
+)
+def test_validate_caller_identity_settings_accepts_non_conflicting_configs(
+    mode: str,
+    metrics_config: object,
+):
+    settings = _identity_settings(mode)
+    settings["prometheus_metrics_config"] = metrics_config
+
+    validate_caller_identity_settings(settings)
+
+    assert litellm.prometheus_deployment_and_latency_caller_identity == mode
+
+
+def _write_proxy_config(tmp_path: Path, litellm_settings: dict[str, object]) -> Path:
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(
+        yaml.safe_dump(
+            {
+                "model_list": [
+                    {
+                        "model_name": "test-model",
+                        "litellm_params": {"model": "openai/gpt-4", "api_key": "test-key"},
+                    }
+                ],
+                "litellm_settings": litellm_settings,
+            },
+            sort_keys=False,
+        )
+    )
+    return config_path
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "litellm_settings",
+    (
+        {
+            "callbacks": ["prometheus"],
+            "prometheus_deployment_and_latency_caller_identity": "user-email",
+        },
+        {
+            "callbacks": ["prometheus"],
+            "prometheus_deployment_and_latency_caller_identity": None,
+        },
+        {
+            "callbacks": ["prometheus"],
+            "prometheus_deployment_and_latency_caller_identity": "user_email",
+            "prometheus_metrics_config": [
+                {
+                    "group": "g",
+                    "metrics": ["litellm_deployment_total_requests"],
+                    "include_labels": ["api_key_alias"],
+                }
+            ],
+        },
+    ),
+    ids=("typo-mode", "null-mode", "include-labels-conflict"),
+)
+async def test_proxy_config_fails_boot_before_callbacks_on_invalid_caller_identity_config(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    litellm_settings: dict[str, object],
+):
+    from litellm.proxy.proxy_server import ProxyConfig
+
+    monkeypatch.setattr("litellm.proxy.proxy_server.prisma_client", None)
+    monkeypatch.setattr("litellm.proxy.proxy_server.store_model_in_db", False)
+    monkeypatch.delenv("LITELLM_CONFIG_BUCKET_NAME", raising=False)
+    config_path = _write_proxy_config(tmp_path, litellm_settings)
+
+    with patch(  # test-quality-ok: asserts boot fails before any callback initialization
+        "litellm.proxy.proxy_server.initialize_callbacks_on_proxy"
+    ) as callback_init:
+        with pytest.raises(ValueError, match="prometheus_deployment_and_latency_caller_identity"):
+            await ProxyConfig().load_config(router=None, config_file_path=str(config_path))
+
+    callback_init.assert_not_called()
+
+
+def test_failed_init_leaves_registry_clean_so_a_corrected_retry_succeeds(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    _set_caller_identity(monkeypatch, "user-email")
+    with pytest.raises(ValueError, match="prometheus_deployment_and_latency_caller_identity"):
+        PrometheusLogger()
+
+    assert list(REGISTRY._collector_to_names) == []  # pyright: ignore[reportPrivateUsage]
+
+    _set_caller_identity(monkeypatch, "user_email")
+    logger = PrometheusLogger()
+    assert "user_email" in logger.get_labels_for_metric("litellm_deployment_total_requests")
+
+
+@pytest.mark.parametrize("invalid_label", ("api_key_alias", "user_email"))
+def test_label_validation_error_names_mode_setting_for_identity_labels_on_target_metric(
+    monkeypatch: pytest.MonkeyPatch,
+    invalid_label: str,
+):
+    _set_caller_identity(monkeypatch, "user_email")
+
+    error = LabelValidationError(
+        metric_name="litellm_deployment_total_requests",
+        invalid_labels=[invalid_label],
+        valid_labels=["user_email"],
+    )
+
+    assert "prometheus_deployment_and_latency_caller_identity='user_email'" in error.message
+    assert invalid_label in error.message
+
+
+def test_label_validation_error_keeps_base_message_for_non_identity_cases(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    _set_caller_identity(monkeypatch, "user_email")
+    non_target_metric = LabelValidationError(
+        metric_name="litellm_overhead_with_guardrails_latency_metric",
+        invalid_labels=["api_key_alias"],
+        valid_labels=[],
+    )
+    non_identity_label = LabelValidationError(
+        metric_name="litellm_deployment_total_requests",
+        invalid_labels=["bogus_label"],
+        valid_labels=[],
+    )
+
+    for error in (non_target_metric, non_identity_label):
+        assert "caller-identity" not in error.message
+        assert error.message.startswith("Invalid labels for metric")


### PR DESCRIPTION
## TLDR

Problem this solves:

- The caller-identity config validation added in #38221 had no unit tests
- A regression in those guards would ship without any test failing

How it solves it:

- Extends the mapped test file with the config failure cases
- Covers typo, null, and include_labels-conflict boot failures end to end
- Pins the error messages, registry retry safety, and accepted values

## User Flow

This PR only adds tests, so the user-visible flow is identical before and after. The flow below is what the new tests pin

Before and after: a proxy admin who misconfigures the caller-identity mode gets a failed boot naming the bad setting instead of a silently empty /metrics

1. The admin sets `prometheus_deployment_and_latency_caller_identity: user-email` (a typo) in config.yaml and starts the proxy
2. The boot exits non-zero with `ValueError: Invalid prometheus_deployment_and_latency_caller_identity='user-email'. Accepted values: api_key_alias, user_email, both.`
3. Same for a null value, and for `include_labels: ["api_key_alias"]` on a target metric while the mode is `user_email`, whose error names the conflicting metrics and the fix
4. With a valid mode the proxy boots and serves traffic

## Relevant issues

Follow-up to #38221 (refs #38159): adds the unit tests requested in review for the config failure cases

## Linear ticket

Resolves LIT-6134

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

This PR changes no runtime code (287 net added lines, all in one test file), so there is no Before leg to capture: the guarded behavior shipped in #38221 and is identical at the merge base and the tip. The run below shows the live proxy behavior the new unit tests pin, captured at the PR tip

Shared setup: config files as described per case, each with one `model_list` entry and `callbacks: ["prometheus"]`, proxy started with `python litellm/proxy/proxy_cli.py --config <case>.yaml --port 46134`

### Behavior pinned by the new tests (5bf21fa0ca)

#### typo mode

1. config.yaml sets `prometheus_deployment_and_latency_caller_identity: user-email`
2. Boot exits with code 3: `ValueError: Invalid prometheus_deployment_and_latency_caller_identity='user-email'. Accepted values: api_key_alias, user_email, both.`

#### null mode

1. config.yaml sets `prometheus_deployment_and_latency_caller_identity: null`
2. Boot exits with code 3: `ValueError: Invalid prometheus_deployment_and_latency_caller_identity=None. Accepted values: api_key_alias, user_email, both.`

#### include_labels conflict

1. config.yaml sets the mode to `user_email` and `prometheus_metrics_config` with `include_labels: ["api_key_alias"]` for `litellm_deployment_total_requests`
2. Boot exits with code 3: `ValueError: prometheus_metrics_config include_labels contains 'api_key_alias' for litellm_deployment_total_requests, but prometheus_deployment_and_latency_caller_identity='user_email' replaces that label on these metrics. Use 'user_email' in include_labels or change the mode.`

#### valid mode (control)

1. config.yaml sets `prometheus_deployment_and_latency_caller_identity: user_email`
2. Proxy boots, and `curl http://127.0.0.1:46134/health/liveliness` returns `"I'm alive!"`

## Type

✅ Test

## Behavior changes

None, this PR only adds tests

## Caveats (if any)

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR