### PR TITLE
fix(router): resolve model_group_alias before pre-routing strategy dispatch

### DIFF
--- a/litellm/router.py
+++ b/litellm/router.py
@@ -205,6 +205,7 @@ from litellm.types.router import (
     PreRoutingStrategy,
     RetryPolicy,
     RouterCacheEnum,
+    RouterErrors,
     RouterGeneralSettings,
     RouterModelGroupAliasItem,
     RouterRateLimitError,
@@ -11521,10 +11522,8 @@ class Router:
 
             # If still no deployments after checking for fallbacks, raise an error
             if len(healthy_deployments) == 0:
-                message: Final = f"You passed in model={model}. There are no healthy deployments for this model"
-
                 raise litellm.BadRequestError(
-                    message=message,
+                    message=f"You passed in model={model}. {RouterErrors.no_healthy_deployments.value}",
                     model=model,
                     llm_provider="",
                 )
@@ -11535,11 +11534,18 @@ class Router:
             ]  # update the model to the actual value if an alias has been passed in
 
         marker_flags: Final = tuple(self._is_strategy_marker_deployment(d) for d in healthy_deployments)
-        if all(marker_flags) or not any(marker_flags):
+        if not any(marker_flags):
             return model, healthy_deployments
-        return model, [  # mutable-ok: matches this function's list contract expected by downstream filters
+        selectable: Final = [  # mutable-ok: matches this function's list contract expected by downstream filters
             d for d, is_marker in zip(healthy_deployments, marker_flags, strict=True) if not is_marker
         ]
+        if not selectable:
+            raise litellm.BadRequestError(
+                message=f"You passed in model={model}. {RouterErrors.only_strategy_marker_deployments.value}",
+                model=model,
+                llm_provider="",
+            )
+        return model, selectable
 
     def _filter_deployments_by_model_access_groups(
         self,
@@ -12128,7 +12134,15 @@ class Router:
         This hook is called before the routing decision is made.
 
         Used for the litellm auto-router to modify the request before the routing decision is made.
+
+        `model` is whatever the caller asked for, which may be a `model_group_alias` key, while the
+        strategy registries and the marker deployment are keyed by the marker's own `model_name`, so
+        every lookup below resolves the alias first. Only the lookups: the caller-facing name stays
+        the alias, since spend metadata is stamped before routing and the response carries the tier
+        group the strategy picked.
         """
+        registered_model_name: Final = self._get_model_from_alias(model=model) or model
+
         #########################################################
         # Run the routing-plugin pipeline, if any plugins are configured.
         # Plugins narrow the candidate deployment pool (consumed later by
@@ -12136,9 +12150,13 @@ class Router:
         # downstream strategies (auto-router, complexity-router, ...) to read.
         #########################################################
         if self.routing_plugins:
-            await self._run_routing_plugins(model=model, request_kwargs=request_kwargs, messages=messages)
+            await self._run_routing_plugins(
+                model=registered_model_name, request_kwargs=request_kwargs, messages=messages
+            )
 
-        selected_strategy: Final = self._select_pre_routing_strategy(model=model, request_kwargs=request_kwargs)
+        selected_strategy: Final = self._select_pre_routing_strategy(
+            model=registered_model_name, request_kwargs=request_kwargs
+        )
         if selected_strategy is None:
             self._record_routing_decision(request_kwargs=request_kwargs, routing_decision=None)
             self._stamp_or_clear_metadata_key(
@@ -12153,7 +12171,7 @@ class Router:
             return None
 
         pre_routing_hook_response: Final = await selected_strategy.strategy.async_pre_routing_hook(
-            model=model,
+            model=registered_model_name,
             request_kwargs=request_kwargs,
             messages=messages,
             input=input,
@@ -12205,7 +12223,7 @@ class Router:
         # Per-tier `litellm_params` on the hook response are deliberate overrides
         # the caller applies on top, so those keys are never forwarded here.
         marker_params: Final = (
-            self._forwardable_alias_marker_params(model=model, strategy_tags=selected_strategy.tags)
+            self._forwardable_alias_marker_params(model=registered_model_name, strategy_tags=selected_strategy.tags)
             if pre_routing_hook_response is not None
             else ()
         )

--- a/litellm/types/router.py
+++ b/litellm/types/router.py
@@ -576,6 +576,11 @@ class RouterErrors(enum.Enum):
     no_deployments_available = "No deployments available for selected model"
     no_deployments_with_tag_routing = "Not allowed to access model due to tags configuration"
     no_deployments_with_provider_budget_routing = "No deployments available - crossed budget"
+    no_healthy_deployments = "There are no healthy deployments for this model"
+    only_strategy_marker_deployments = (
+        "Every deployment for it is a strategy router marker (auto_router/...), which is not a callable "
+        "model, and no pre-routing strategy selected a deployment for this request"
+    )
 
 
 class AllowedFailsPolicy(BaseModel):

--- a/tests/test_litellm/test_router.py
+++ b/tests/test_litellm/test_router.py
@@ -8855,6 +8855,119 @@ class TestAutoRoutedRequestMarker:
         assert AUTO_ROUTED_REQUEST_METADATA_KEY not in request_kwargs["metadata"]
 
 
+class TestModelGroupAliasReachesPreRoutingStrategies:
+    """A `model_group_alias` whose target is a strategy router must dispatch exactly like the
+    router's own model_name. The four strategy registries are keyed by the marker deployment's
+    model_name, so the alias has to be resolved before the pre-routing hook looks anything up,
+    and a group that resolves only to markers is not callable at all (LIT-4664)."""
+
+    MARKER_TIMEOUT = 42.0
+    REGISTRY_NAMES = ("auto_routers", "complexity_routers", "adaptive_routers", "quality_routers")
+
+    class _RewriteStrategy:
+        async def async_pre_routing_hook(
+            self, model, request_kwargs, messages=None, input=None, specific_deployment=False
+        ):
+            from litellm.types.router import PreRoutingHookResponse
+
+            return PreRoutingHookResponse(model="gemini-flash", messages=messages)
+
+    @classmethod
+    def _router(cls, registry_name: str | None) -> "litellm.Router":
+        from litellm.types.router import TaggedPreRoutingStrategy
+
+        tiers = dict.fromkeys(("SIMPLE", "MEDIUM", "COMPLEX", "REASONING"), "gemini-flash")
+        router = litellm.Router(
+            model_list=[
+                {
+                    "model_name": "smart-route",
+                    "litellm_params": {
+                        "model": "auto_router/complexity_router",
+                        "complexity_router_config": {"tiers": tiers},
+                        "complexity_router_default_model": "gemini-flash",
+                        "timeout": cls.MARKER_TIMEOUT,
+                    },
+                },
+                {
+                    "model_name": "gemini-flash",
+                    "litellm_params": {"model": "gemini/gemini-3.6-flash", "mock_response": "routed by the tier"},
+                },
+            ],
+            model_group_alias={"smart-alias": "smart-route"},
+        )
+        for name in cls.REGISTRY_NAMES:
+            setattr(router, name, {})
+        if registry_name is not None:
+            setattr(
+                router,
+                registry_name,
+                {"smart-route": [TaggedPreRoutingStrategy(tags=(), strategy=cls._RewriteStrategy())]},
+            )
+        return router
+
+    @staticmethod
+    def _messages() -> list[dict[str, str]]:
+        return [{"role": "user", "content": "What is the capital of France?"}]
+
+    @pytest.mark.parametrize("registry_name", REGISTRY_NAMES)
+    @pytest.mark.asyncio
+    async def test_alias_dispatches_to_the_strategy_registered_under_the_target(self, registry_name):
+        from litellm.constants import AUTO_ROUTED_REQUEST_METADATA_KEY
+
+        router = self._router(registry_name)
+        request_kwargs = {"metadata": {}}
+
+        response = await router.async_pre_routing_hook(
+            model="smart-alias", request_kwargs=request_kwargs, messages=self._messages()
+        )
+
+        assert response is not None
+        assert response.model == "gemini-flash"
+        assert request_kwargs["metadata"][AUTO_ROUTED_REQUEST_METADATA_KEY] is True
+
+    @pytest.mark.asyncio
+    async def test_alias_call_still_forwards_the_marker_own_params_to_the_routed_tier(self):
+        router = self._router("auto_routers")
+        request_kwargs = {"metadata": {}}
+
+        await router.async_pre_routing_hook(
+            model="smart-alias", request_kwargs=request_kwargs, messages=self._messages()
+        )
+
+        assert request_kwargs["timeout"] == self.MARKER_TIMEOUT
+
+    @pytest.mark.asyncio
+    async def test_alias_deployment_selection_lands_on_the_tier_never_the_marker(self):
+        router = self._router("auto_routers")
+
+        deployment = await router.async_get_available_deployment(
+            model="smart-alias", request_kwargs={"metadata": {}}, messages=self._messages()
+        )
+
+        assert deployment["litellm_params"]["model"] == "gemini/gemini-3.6-flash"
+
+    @pytest.mark.asyncio
+    async def test_alias_call_completes_and_still_bills_the_name_the_caller_sent(self):
+        router = self._router("auto_routers")
+        metadata: dict = {}
+
+        response = await router.acompletion(
+            model="smart-alias", messages=self._messages(), metadata=metadata
+        )
+
+        assert response.choices[0].message.content == "routed by the tier"
+        assert metadata["model_group"] == "smart-alias"
+        assert metadata["model_group_alias"] == "smart-alias"
+
+    def test_a_group_of_only_markers_is_not_a_callable_model(self):
+        router = self._router(None)
+
+        with pytest.raises(litellm.BadRequestError, match="strategy router marker"):
+            router.get_available_deployment(
+                model="smart-route", messages=self._messages(), request_kwargs={"metadata": {}}
+            )
+
+
 @pytest.mark.usefixtures("local_model_cost_map")
 class TestAzureBaseModelFallbackLogging:
     """When an azure deployment has no base_model but its model name is a known


### PR DESCRIPTION
## TLDR

Problem this solves:

- A model group alias for an auto router 400s on every call
- The error blames a provider that was never involved
- Router markers can go out to a provider as callable models

How it solves it:

- Resolve the alias before the pre routing strategy is picked
- Keep the caller facing model name and spend attribution unchanged
- A group that is only markers now raises instead of calling out

## User Flow

Before: an admin gives their auto router a friendlier public name, and the new name is unusable

1. The admin creates an auto router named `complexity-router-live` on https://litellm-domain/ui/?page=models-and-endpoints
2. Under Router Settings they add a model group alias `auto-test` pointing at it
3. GET https://litellm-domain/v1/models lists `auto-test`, and the playground model picker offers it
4. POST https://litellm-domain/v1/chat/completions with `"model": "auto-test"` comes back 400 `Unmapped LLM provider for this endpoint. You passed model=complexity_router, custom_llm_provider=auto_router`
5. POST https://litellm-domain/v1/responses and POST https://litellm-domain/v1/messages with the same model fail the same way
6. Only the original name `complexity-router-live` works, so the alias is dead weight

After: the alias behaves exactly like the auto router's own name

1. The admin creates an auto router named `complexity-router-live` on https://litellm-domain/ui/?page=models-and-endpoints
2. Under Router Settings they add a model group alias `auto-test` pointing at it
3. GET https://litellm-domain/v1/models lists `auto-test`, and the playground model picker offers it
4. POST https://litellm-domain/v1/chat/completions with `"model": "auto-test"` comes back 200 with real content, the body still says `"model": "auto-test"`, and `router_model_name` names the tier that served it
5. POST https://litellm-domain/v1/responses and POST https://litellm-domain/v1/messages with the same model come back 200 the same way
6. https://litellm-domain/ui/?page=logs shows the request under `auto-test`, so budgets and spend still read the name the caller sent

## Relevant issues

- Fixes a model group alias pointing at an auto router being listed but not callable
- Stops an `auto_router/` marker deployment from ever being handed to a provider as a real model
- Covers all four strategy routers (semantic, complexity, adaptive, quality) through their one shared lookup
- Moves both of this function's error strings into the shared `RouterErrors` enum

Fixes #27473

Same fix shape as the stalled community PR #34311, which is blocked on an unsigned CLA. Credit to that author for the first diagnosis. This one adds the marker guard, the four-registry coverage and the live before and after runs

## Linear ticket

Resolves LIT-4664

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

Shared setup, a real proxy on a real Postgres, tiers pointing at real Anthropic models, the auto router created through the API and the alias set through the config endpoint exactly like the dashboard does

```bash
export KEY=sk-rig-1234 BASE=http://127.0.0.1:4842
# a second proxy on the same config plus router_settings.routing_strategy: usage-based-routing
export BASE_V1=http://127.0.0.1:4843

curl -s -X POST $BASE/model/new -H "Authorization: Bearer $KEY" -H "Content-Type: application/json" -d '{
  "model_name": "complexity-router-live",
  "litellm_params": {
    "model": "auto_router/complexity_router",
    "complexity_router_config": {"tiers": {"SIMPLE": "tier-cheap", "MEDIUM": "tier-cheap", "COMPLEX": "tier-strong", "REASONING": "tier-strong"}},
    "complexity_router_default_model": "tier-cheap"
  }, "model_info": {}}'

curl -s -X POST $BASE/config/update -H "Authorization: Bearer $KEY" -H "Content-Type: application/json" \
  -d '{"router_settings": {"model_group_alias": {"auto-test": "complexity-router-live"}}}'
```

### Before (cdb60af024)

#### The alias is discoverable

1. `curl -s $BASE/v1/models -H "Authorization: Bearer $KEY" | jq -c '[.data[].id]'`
2. `["auto-test","tier-cheap","tier-strong","complexity-router-live"]`

#### /v1/chat/completions

1. `curl -s -X POST $BASE/v1/chat/completions -H "Authorization: Bearer $KEY" -H "Content-Type: application/json" -d '{"model":"auto-test","messages":[{"role":"user","content":"say hi in 3 words"}]}'`
2. `{"error":{"message":"litellm.BadRequestError: Unmapped LLM provider for this endpoint. You passed model=complexity_router, custom_llm_provider=auto_router. Check supported provider and route: https://docs.litellm.ai/docs/providers. Received Model Group=auto-test\nAvailable Model Group Fallbacks=None","type":null,"param":null,"code":"400"}}`

#### /v1/responses

1. `curl -s -X POST $BASE/v1/responses -H "Authorization: Bearer $KEY" -H "Content-Type: application/json" -d '{"model":"auto-test","input":"say hi in 3 words"}'`
2. `{"error":{"message":"litellm.BadRequestError: Unmapped LLM provider for this endpoint. You passed model=complexity_router, custom_llm_provider=auto_router. Check supported provider and route: https://docs.litellm.ai/docs/providers. Received Model Group=auto-test\nAvailable Model Group Fallbacks=None","type":null,"param":null,"code":"400"}}`

#### /v1/messages

1. `curl -s -X POST $BASE/v1/messages -H "Authorization: Bearer $KEY" -H "Content-Type: application/json" -d '{"model":"auto-test","max_tokens":32,"messages":[{"role":"user","content":"say hi in 3 words"}]}'`
2. `{"error":{"message":"litellm.BadRequestError: Unmapped LLM provider for this endpoint. You passed model=complexity_router, custom_llm_provider=auto_router. Check supported provider and route: https://docs.litellm.ai/docs/providers. Received Model Group=auto-test\nAvailable Model Group Fallbacks=None","type":null,"param":null,"code":"400"}}`

#### A marker reaching the provider, on `router_settings.routing_strategy: usage-based-routing`, calling the auto router by its own name

1. `curl -s -X POST $BASE_V1/v1/chat/completions -H "Authorization: Bearer $KEY" -H "Content-Type: application/json" -d '{"model":"complexity-router-live","messages":[{"role":"user","content":"say hi in 3 words"}]}'`
2. `{"error":{"message":"litellm.BadRequestError: Unmapped LLM provider for this endpoint. You passed model=complexity_router, custom_llm_provider=auto_router. Check supported provider and route: https://docs.litellm.ai/docs/providers. Received Model Group=complexity-router-live\nAvailable Model Group Fallbacks=None","type":null,"param":null,"code":"400"}}`

### After (468f4a9427)

#### The alias is discoverable

1. `curl -s $BASE/v1/models -H "Authorization: Bearer $KEY" | jq -c '[.data[].id]'`
2. `["auto-test","tier-cheap","tier-strong","complexity-router-live"]`

#### /v1/chat/completions

1. `curl -s -X POST $BASE/v1/chat/completions -H "Authorization: Bearer $KEY" -H "Content-Type: application/json" -d '{"model":"auto-test","messages":[{"role":"user","content":"say hi in 3 words"}]}'`
2. `{"model": "auto-test", "router_model_name": "tier-cheap", "content": "Hi there, friend!", "total_tokens": 22}`

#### /v1/responses

1. `curl -s -X POST $BASE/v1/responses -H "Authorization: Bearer $KEY" -H "Content-Type: application/json" -d '{"model":"auto-test","input":"say hi in 3 words"}'`
2. `{"model": "auto-test", "status": "completed", "text": ["Hi there friend."]}`

#### /v1/messages

1. `curl -s -X POST $BASE/v1/messages -H "Authorization: Bearer $KEY" -H "Content-Type: application/json" -d '{"model":"auto-test","max_tokens":32,"messages":[{"role":"user","content":"say hi in 3 words"}]}'`
2. `{"model": "auto-test", "stop_reason": "end_turn", "text": ["Hey there, friend!"]}`

#### A marker reaching the provider, on `router_settings.routing_strategy: usage-based-routing`, calling the auto router by its own name

1. `curl -s -X POST $BASE_V1/v1/chat/completions -H "Authorization: Bearer $KEY" -H "Content-Type: application/json" -d '{"model":"complexity-router-live","messages":[{"role":"user","content":"say hi in 3 words"}]}'`
2. `{"error":{"message":"litellm.BadRequestError: You passed in model=complexity-router-live. Every deployment for it is a strategy router marker (auto_router/...), which is not a callable model, and no pre-routing strategy selected a deployment for this request. Received Model Group=complexity-router-live\nAvailable Model Group Fallbacks=None","type":null,"param":null,"code":"400"}}`

The request never leaves the gateway now, and the message names what is actually wrong instead of a provider nobody configured

## Type

🐛 Bug Fix

## Caveats (if any)

### Medium

- A team scoped auto router still does not route
  - Its strategy is keyed on the internal team model name while the router is called with the public one
  - It now fails with the clear 400 above instead of a provider error
- The synchronous selection path still never runs the pre routing hook
  - That is open PR #28615, and the same clear 400 covers it meanwhile

### Low

- Cooldown helpers no longer count a marker as a deployment for a marker only group
- Fallbacks keyed on an alias are a separate gap, open PR #29378

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core request routing and deployment selection for aliases and strategy markers; incorrect resolution could break auto-router calls or mis-route spend, though behavior is covered by new tests.
> 
> **Overview**
> **Model group aliases** that point at strategy routers (auto/complexity/adaptive/quality) now work end-to-end: `async_pre_routing_hook` resolves the alias to the marker’s `model_name` before routing plugins, strategy selection, the hook itself, and marker param forwarding—while the caller-facing model name and spend metadata stay on the alias.
> 
> **Deployment selection** no longer treats an all-marker pool as callable. Non-marker deployments are filtered out when any real tier exists; if every healthy deployment is a strategy marker and pre-routing did not pick a tier, the router raises a **`BadRequestError`** with a dedicated message instead of sending `auto_router/...` to a provider.
> 
> Two router error strings move into **`RouterErrors`** (`no_healthy_deployments`, `only_strategy_marker_deployments`). New tests cover alias dispatch across all four strategy registries, marker param forwarding, tier selection, billing metadata, and the marker-only failure path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 468f4a94273614c965dd5324f2408b318a91dc71. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->