### PR TITLE
feat(cost-map): add Cloudflare Workers AI whisper transcription models

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -13297,6 +13297,39 @@
         "output_cost_per_token": 1e-06,
         "supports_reasoning": true
     },
+    "cloudflare/@cf/openai/whisper": {
+        "input_cost_per_second": 7.5e-06,
+        "litellm_provider": "cloudflare",
+        "mode": "audio_transcription",
+        "output_cost_per_second": 0.0,
+        "source": "https://developers.cloudflare.com/workers-ai/models/whisper/",
+        "supported_endpoints": [
+            "/v1/audio/transcriptions"
+        ]
+    },
+    "cloudflare/@cf/openai/whisper-large-v3-turbo": {
+        "input_cost_per_second": 8.5e-06,
+        "litellm_provider": "cloudflare",
+        "mode": "audio_transcription",
+        "output_cost_per_second": 0.0,
+        "source": "https://developers.cloudflare.com/workers-ai/models/whisper-large-v3-turbo/",
+        "supported_endpoints": [
+            "/v1/audio/transcriptions"
+        ]
+    },
+    "cloudflare/@cf/openai/whisper-tiny-en": {
+        "input_cost_per_second": 0.0,
+        "litellm_provider": "cloudflare",
+        "metadata": {
+            "notes": "Cloudflare publishes no unit pricing for this beta model, so cost tracking reports $0 until they do"
+        },
+        "mode": "audio_transcription",
+        "output_cost_per_second": 0.0,
+        "source": "https://developers.cloudflare.com/workers-ai/models/whisper-tiny-en/",
+        "supported_endpoints": [
+            "/v1/audio/transcriptions"
+        ]
+    },
     "codestral/codestral-2405": {
         "input_cost_per_token": 0.0,
         "litellm_provider": "codestral",

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -13297,6 +13297,39 @@
         "output_cost_per_token": 1e-06,
         "supports_reasoning": true
     },
+    "cloudflare/@cf/openai/whisper": {
+        "input_cost_per_second": 7.5e-06,
+        "litellm_provider": "cloudflare",
+        "mode": "audio_transcription",
+        "output_cost_per_second": 0.0,
+        "source": "https://developers.cloudflare.com/workers-ai/models/whisper/",
+        "supported_endpoints": [
+            "/v1/audio/transcriptions"
+        ]
+    },
+    "cloudflare/@cf/openai/whisper-large-v3-turbo": {
+        "input_cost_per_second": 8.5e-06,
+        "litellm_provider": "cloudflare",
+        "mode": "audio_transcription",
+        "output_cost_per_second": 0.0,
+        "source": "https://developers.cloudflare.com/workers-ai/models/whisper-large-v3-turbo/",
+        "supported_endpoints": [
+            "/v1/audio/transcriptions"
+        ]
+    },
+    "cloudflare/@cf/openai/whisper-tiny-en": {
+        "input_cost_per_second": 0.0,
+        "litellm_provider": "cloudflare",
+        "metadata": {
+            "notes": "Cloudflare publishes no unit pricing for this beta model, so cost tracking reports $0 until they do"
+        },
+        "mode": "audio_transcription",
+        "output_cost_per_second": 0.0,
+        "source": "https://developers.cloudflare.com/workers-ai/models/whisper-tiny-en/",
+        "supported_endpoints": [
+            "/v1/audio/transcriptions"
+        ]
+    },
     "codestral/codestral-2405": {
         "input_cost_per_token": 0.0,
         "litellm_provider": "codestral",

--- a/tests/test_litellm/test_cloudflare_workers_ai_model_metadata.py
+++ b/tests/test_litellm/test_cloudflare_workers_ai_model_metadata.py
@@ -75,6 +75,29 @@ def test_additional_current_models_are_present():
         assert entry["output_cost_per_token"] > 0
 
 
+@pytest.mark.parametrize(
+    "key, published_price_per_audio_minute",
+    [
+        ("cloudflare/@cf/openai/whisper", 0.00045),
+        ("cloudflare/@cf/openai/whisper-large-v3-turbo", 0.00051),
+    ],
+)
+def test_whisper_transcription_pricing_is_stored_per_second(key, published_price_per_audio_minute):
+    entry = litellm.model_cost[key]
+    assert entry["litellm_provider"] == "cloudflare"
+    assert entry["mode"] == "audio_transcription"
+    assert entry["supported_endpoints"] == ["/v1/audio/transcriptions"]
+    assert entry["output_cost_per_second"] == 0.0
+    assert entry["input_cost_per_second"] == pytest.approx(published_price_per_audio_minute / 60)
+
+
+def test_whisper_tiny_en_is_present_and_unpriced():
+    entry = litellm.model_cost["cloudflare/@cf/openai/whisper-tiny-en"]
+    assert entry["mode"] == "audio_transcription"
+    assert entry["input_cost_per_second"] == 0.0
+    assert entry["output_cost_per_second"] == 0.0
+
+
 def test_root_and_backup_have_identical_cloudflare_keys():
     if not os.path.exists(ROOT_MAP):
         pytest.skip("root cost map only ships in source checkouts")


### PR DESCRIPTION
## TLDR

Problem this solves:

- Cloudflare Workers AI whisper models missing from the cost map
- Their transcriptions log as $0 spend
- No mode or pricing shows on /model/info

How it solves it:

- Add the three whisper models with per-second pricing
- Prices converted from Cloudflare's published per-audio-minute rates
- Keep root and bundled cost maps in sync

## User Flow

Before: an admin who adds Cloudflare's whisper models to their config sees no pricing or task type for them, so they cannot tell what a transcription will cost

1. They add `cloudflare/@cf/openai/whisper`, `cloudflare/@cf/openai/whisper-large-v3-turbo` and `cloudflare/@cf/openai/whisper-tiny-en` to their proxy config and restart
2. They call GET http://localhost:4010/model/info with the master key
3. Every one of the three comes back with `"mode": null`, `"input_cost_per_second": null` and `"output_cost_per_second": null`, the same shape an unknown model would return

After: the same three models come back with their task type and Cloudflare's published rates

1. They add the same three models to their proxy config and restart
2. They call GET http://localhost:4010/model/info with the master key
3. Each comes back with `"mode": "audio_transcription"`, and `input_cost_per_second` of `7.5e-06` for whisper and `8.5e-06` for whisper-large-v3-turbo, matching Cloudflare's $0.00045 and $0.00051 per audio minute
4. whisper-tiny-en comes back at `0.0`, since Cloudflare publishes no rate for it while it is in beta

## Relevant issues

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Shared setup, used for both runs:

```yaml
model_list:
  - model_name: cf-whisper
    litellm_params:
      model: cloudflare/@cf/openai/whisper
      api_key: os.environ/CLOUDFLARE_API_KEY
  - model_name: cf-whisper-large-v3-turbo
    litellm_params:
      model: cloudflare/@cf/openai/whisper-large-v3-turbo
      api_key: os.environ/CLOUDFLARE_API_KEY
  - model_name: cf-whisper-tiny-en
    litellm_params:
      model: cloudflare/@cf/openai/whisper-tiny-en
      api_key: os.environ/CLOUDFLARE_API_KEY

general_settings:
  master_key: sk-1234
```

Both runs start the proxy the same way, from the checkout under test:

```
LITELLM_LOCAL_MODEL_COST_MAP=True python3 -m litellm.proxy.proxy_cli --config /tmp/cf_whisper_config.yaml --port 4010
```

### Before (7bc80994b7)

1. Ask the proxy what it knows about the three models

```
curl -s -H "Authorization: Bearer sk-1234" http://localhost:4010/model/info \
  | python3 -c "
import json,sys
for m in json.load(sys.stdin)['data']:
    if 'whisper' in m['model_name']:
        i = m['model_info']
        print(json.dumps({k: i.get(k) for k in ('mode','input_cost_per_second','output_cost_per_second')} | {'model_name': m['model_name']}))
"
```

2. All three report no task type and no price

```
{"mode": null, "input_cost_per_second": null, "output_cost_per_second": null, "model_name": "cf-whisper"}
{"mode": null, "input_cost_per_second": null, "output_cost_per_second": null, "model_name": "cf-whisper-large-v3-turbo"}
{"mode": null, "input_cost_per_second": null, "output_cost_per_second": null, "model_name": "cf-whisper-tiny-en"}
```

### After (de33cffbf1)

1. Run the exact same command

```
curl -s -H "Authorization: Bearer sk-1234" http://localhost:4010/model/info \
  | python3 -c "
import json,sys
for m in json.load(sys.stdin)['data']:
    if 'whisper' in m['model_name']:
        i = m['model_info']
        print(json.dumps({k: i.get(k) for k in ('mode','input_cost_per_second','output_cost_per_second')} | {'model_name': m['model_name']}))
"
```

2. Each model now reports its task type and Cloudflare's rate

```
{"mode": "audio_transcription", "input_cost_per_second": 7.5e-06, "output_cost_per_second": 0.0, "model_name": "cf-whisper"}
{"mode": "audio_transcription", "input_cost_per_second": 8.5e-06, "output_cost_per_second": 0.0, "model_name": "cf-whisper-large-v3-turbo"}
{"mode": "audio_transcription", "input_cost_per_second": 0.0, "output_cost_per_second": 0.0, "model_name": "cf-whisper-tiny-en"}
```

3. Confirm the per-second numbers are Cloudflare's per-minute rates divided by 60

```
python3 -c "print(0.00045/60, 0.00051/60)"
7.5e-06 8.5e-06
```

## Type

🆕 New Feature

## Caveats (if any)

### Medium

- Audio sent to these models still fails
  - The cloudflare provider only handles chat today
  - `/v1/audio/transcriptions` returns "Unmapped provider passed in"
  - Wiring up that route is follow-up work
- whisper-tiny-en tracks as $0 spend
  - Cloudflare publishes no rate while it is in beta
  - Revisit once they publish one

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only cost-map and test changes; no runtime routing or billing logic is modified in this PR.
> 
> **Overview**
> Adds **three Cloudflare Workers AI Whisper models** to the model cost map (`model_prices_and_context_window.json` and its backup) so `/model/info` and spend tracking can treat them as **`audio_transcription`** instead of unknown models.
> 
> **`cloudflare/@cf/openai/whisper`** and **`whisper-large-v3-turbo`** get **`input_cost_per_second`** derived from Cloudflare’s published per-audio-minute rates (`7.5e-06` and `8.5e-06`), zero output cost, and **`supported_endpoints`** `["/v1/audio/transcriptions"]`. **`whisper-tiny-en`** is registered the same way but priced at **$0** with metadata noting missing public pricing while in beta.
> 
> New tests in `test_cloudflare_workers_ai_model_metadata.py` assert per-second conversion, endpoint/mode metadata, and that root and backup Cloudflare entries stay aligned.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit de33cffbf17fd6010f785fccdb2892b2d803fc9b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->