### PR TITLE
docs(CLAUDE.md): add pull-before-work rule

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,6 +66,8 @@ Commit and push your work when you're done without asking
 
 When referencing or running models (coding, QA'ing, writing docs, writing tests, etc.), use the latest model in that model family unless otherwise specified; treat your training knowledge, memories, configs, and tests as stale, and determine the family's latest with model_prices_and_context_window.json or the web
 
+Always pull before starting any work. The checkout or worktree may be sitting on a stale branch, and work built on a stale base lands on top of code that has already moved. Run `git fetch origin` first, then fast-forward the branch you're on with `git pull --no-rebase`. When working a feature branch, bring it up to date with a freshly fetched `origin/litellm_internal_staging` before touching it: rebase onto it while the branch is still unpushed, merge it in once it has been pushed, and never rewrite pushed history
+
 If you're an internal contributor, when creating a new PR, the typical flow is to branch off litellm_internal_staging and create a branch prefixed with litellm_. Do not create a branch prefixed with claude/ and generally do not have / in your branch names
 
 Do not add `Co-Authored-By: Claude` or any Claude attribution to commit messages. Never use a `claude/` prefix or put a `/` in a branch name. Do not add "Generated with Claude Code" (or any similar attribution) to PR descriptions or comments. Do not create a new PR/branch off the existing PR to fix/add something that is related and could've just been committed directly to the existing PR's branch

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,7 +66,7 @@ Commit and push your work when you're done without asking
 
 When referencing or running models (coding, QA'ing, writing docs, writing tests, etc.), use the latest model in that model family unless otherwise specified; treat your training knowledge, memories, configs, and tests as stale, and determine the family's latest with model_prices_and_context_window.json or the web
 
-Always pull before starting any work. The checkout or worktree may be sitting on a stale branch, and work built on a stale base lands on top of code that has already moved. Run `git fetch origin` first, then fast-forward the branch you're on with `git pull --no-rebase`. When working a feature branch, bring it up to date with a freshly fetched `origin/litellm_internal_staging` before touching it: rebase onto it while the branch is still unpushed, merge it in once it has been pushed, and never rewrite pushed history
+Always pull before starting any work. The checkout or worktree may be sitting on a stale branch, and work built on a stale base lands on top of code that has already moved. Run `git fetch origin` first, then update the branch you're on with `git pull --no-rebase`, which fast-forwards when the branch hasn't diverged and merges the remote tip in when it has. When working a feature branch, bring it up to date with a freshly fetched `origin/litellm_internal_staging` before touching it: rebase onto it while the branch is still unpushed, merge it in once it has been pushed, and never rewrite pushed history
 
 If you're an internal contributor, when creating a new PR, the typical flow is to branch off litellm_internal_staging and create a branch prefixed with litellm_. Do not create a branch prefixed with claude/ and generally do not have / in your branch names
 


### PR DESCRIPTION
## TLDR

Problem this solves:

- Agents and contributors start work on stale checkouts or worktrees
- Work built on a stale base lands on code that already moved

How it solves it:

- CLAUDE.md now says to fetch and fast-forward before starting any work
- Feature branches sync with origin/litellm_internal_staging before being touched

## User Flow

Before: a contributor starting from an existing checkout builds their change on a stale base and only finds out at PR time

1. They open an existing checkout or worktree and start editing right away, without fetching
2. The branch is days behind origin/litellm_internal_staging, so their change is built on code that has since moved
3. They push and open a PR, and GitHub reports merge conflicts or CI fails on findings already fixed upstream
4. They spend an extra review cycle merging the base branch in and redoing the change at the current tip

After: the same contributor pulls first and their change lands on the current tip

1. They open the same checkout or worktree, and CLAUDE.md tells them to pull before starting any work
2. They run `git fetch origin`, update the branch with `git pull --no-rebase`, and bring a feature branch up to date with `origin/litellm_internal_staging`
3. They build the change on the current tip, push, and open a PR
4. The PR opens with no conflicts and CI runs against the code it will actually merge into

## Relevant issues

## Linear ticket


## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests (docs-only change, nothing testable)
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

The deliverable is the rule text itself, so the proof is the file's content at the merge base and at the tip

### Before (80843ae7cb)

1. `git show 80843ae7cb:CLAUDE.md | grep -n -i "pull before"`
2. No output, exit 1: CLAUDE.md carries no pull-before-work rule

### After (1332f27729)

1. `git show 1332f27729:CLAUDE.md | grep -n -i "pull before"`
2. Line 69 comes back: "Always pull before starting any work. The checkout or worktree may be sitting on a stale branch, and work built on a stale base lands on top of code that has already moved. Run `git fetch origin` first, then update the branch you're on with `git pull --no-rebase`, which fast-forwards when the branch hasn't diverged and merges the remote tip in when it has. When working a feature branch, bring it up to date with a freshly fetched `origin/litellm_internal_staging` before touching it: rebase onto it while the branch is still unpushed, merge it in once it has been pushed, and never rewrite pushed history"

## Type

📖 Documentation

## Caveats (if any)

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

- [x] 1332f27729 passes /live-pr-risk

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to contributor workflow guidance; no runtime, security, or data-handling impact.
> 
> **Overview**
> Adds a **pull-before-work** rule to `CLAUDE.md` so agents and contributors sync before editing.
> 
> The new paragraph requires `git fetch origin`, then `git pull --no-rebase` on the current branch. For feature branches it says to update from `origin/litellm_internal_staging` first: rebase while unpushed, merge after push, and avoid rewriting pushed history
> 
> It is placed right before the existing internal branching guidance, with a blank line after the prior “latest model” rule
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1332f27729fd59910fa71c24bd558ddeb45ee581. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->