### PR TITLE
fix(health): probe Azure GA realtime path for transcription-only models

### DIFF
--- a/litellm/realtime_api/main.py
+++ b/litellm/realtime_api/main.py
@@ -557,6 +557,34 @@ async def _arealtime(
         raise ValueError(f"Unsupported model: {model}")
 
 
+def _is_transcription_only_realtime_model(model: str, custom_llm_provider: str) -> bool:
+    try:
+        model_info: Final = litellm.get_model_info(model=model, custom_llm_provider=custom_llm_provider)
+    except Exception:  # noqa: BLE001  # get_model_info raises bare Exception for unmapped models
+        return False
+    if model_info.get("mode") == "audio_transcription":
+        return True
+    return "/v1/realtime/transcription_sessions" in (model_info.get("supported_endpoints") or ())
+
+
+_TRANSCRIPTION_QUERY_PARAMS: Final[RealtimeQueryParams] = {"intent": "transcription"}
+
+
+def _azure_realtime_health_protocol(
+    model: str, realtime_protocol: str | None, model_params: Mapping[str, Any]
+) -> tuple[str, RealtimeQueryParams | None]:
+    query_params: Final = _TRANSCRIPTION_QUERY_PARAMS if _is_transcription_only_realtime_model(model, "azure") else None
+    configured_raw: Final = (
+        realtime_protocol or model_params.get("realtime_protocol") or os.environ.get("LITELLM_AZURE_REALTIME_PROTOCOL")
+    )
+    configured: Final = configured_raw if isinstance(configured_raw, str) else None
+    if configured is not None:
+        return configured, query_params
+    if query_params is not None:
+        return "GA", query_params
+    return "beta", None
+
+
 def _realtime_health_check_auth_headers(
     custom_llm_provider: str, api_key: str | None, model_params: Mapping[str, Any]
 ) -> Mapping[str, str | None]:
@@ -586,7 +614,9 @@ async def _realtime_health_check(
         api_version: Optional[str] - api version
         api_key: str - api key
         custom_llm_provider: str - custom llm provider
-        realtime_protocol: Optional[str] - protocol version ("GA"/"v1" for GA path, "beta"/None for beta path)
+        realtime_protocol: Optional[str] - protocol version ("GA"/"v1" for GA path, "beta" for beta path);
+            None resolves it for Azure from model_params/env, with transcription-only models probing GA
+            plus intent=transcription the way real calls do
 
     Returns:
         bool - True if connection is successful, False otherwise
@@ -602,11 +632,17 @@ async def _realtime_health_check(
         model_params=model_params or _EMPTY_MODEL_PARAMS,
     )
     if custom_llm_provider == "azure":
+        resolved_protocol, azure_query_params = _azure_realtime_health_protocol(
+            model=model,
+            realtime_protocol=realtime_protocol,
+            model_params=model_params or _EMPTY_MODEL_PARAMS,
+        )
         url = azure_realtime._construct_url(
             api_base=api_base or "",
             model=model,
             api_version=api_version or "2024-10-01-preview",
-            realtime_protocol=realtime_protocol,
+            realtime_protocol=resolved_protocol,
+            query_params=azure_query_params,
         )
     elif custom_llm_provider == "openai":
         url = openai_realtime._construct_url(

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -5845,6 +5845,7 @@ def _get_model_info_helper(
                 tiered_pricing=_model_info.get("tiered_pricing", None),
                 litellm_provider=_model_info.get("litellm_provider", custom_llm_provider),
                 mode=_model_info.get("mode"),
+                supported_endpoints=_model_info.get("supported_endpoints", None),
                 supports_system_messages=_model_info.get("supports_system_messages", None),
                 supports_response_schema=_model_info.get("supports_response_schema", None),
                 supports_vision=_model_info.get("supports_vision", None),

--- a/tests/test_litellm/llms/github_copilot/responses/test_github_copilot_responses_transformation.py
+++ b/tests/test_litellm/llms/github_copilot/responses/test_github_copilot_responses_transformation.py
@@ -436,10 +436,9 @@ class TestGithubCopilotResponsesAPIRouting:
         catalog entries that lack ``mode``).
 
         Exercises the real ``_cached_get_model_info_helper`` plumbing via
-        ``register_model`` (no mock). ``supported_endpoints`` is not carried on
-        the normalized ``ModelInfoBase`` the helper returns, so the gate must
-        read it from the raw ``litellm.model_cost`` entry; a mock-based test
-        would mask that.
+        ``register_model`` (no mock). The gate reads ``supported_endpoints``
+        from the raw ``litellm.model_cost`` entry; a mock-based test would
+        mask that.
         """
         litellm.register_model(
             {

--- a/tests/test_litellm/realtime_api/test_main.py
+++ b/tests/test_litellm/realtime_api/test_main.py
@@ -1,10 +1,11 @@
 import asyncio
 import time
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 
 import pytest
 
+import litellm
 from litellm.realtime_api import main as realtime_main
 from litellm.realtime_api.main import _with_resolved_session_model
 
@@ -190,3 +191,92 @@ def test_client_secret_forwards_nested_transcription_model_untouched(monkeypatch
     session = captured["request_data"]["session"]
     assert session["model"] == "gpt-4o-realtime-preview"
     assert session["input_audio_transcription"]["model"] == "whisper-1"
+
+
+class _CapturingConnect:
+    def __init__(self):
+        self.url = None
+        self.additional_headers = None
+
+    def __call__(self, url, **kwargs):
+        self.url = url
+        self.additional_headers = kwargs.get("additional_headers")
+        return self
+
+    async def __aenter__(self):
+        return MagicMock()
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return None
+
+
+@pytest.mark.asyncio
+async def test_azure_health_check_probes_ga_transcription_url_for_transcription_model(local_model_cost_map):
+    """Regression for LIT-6240: transcription-only models (mode audio_transcription
+    in the cost map) are GA-only and 400 on the beta path, so the health probe
+    must hit /openai/v1/realtime?intent=transcription like real calls do."""
+    connect = _CapturingConnect()
+    with patch("websockets.connect", connect):
+        assert await realtime_main._realtime_health_check(
+            model="gpt-realtime-whisper",
+            custom_llm_provider="azure",
+            api_key="fake-key",
+            api_base="https://my-endpoint.openai.azure.com",
+            api_version="2025-04-01-preview",
+        )
+    assert connect.url == "wss://my-endpoint.openai.azure.com/openai/v1/realtime?intent=transcription"
+
+
+@pytest.mark.asyncio
+async def test_azure_health_check_stays_on_ga_when_deployment_registration_overwrites_mode(
+    local_model_cost_map, monkeypatch
+):
+    """In a live proxy, Router._register_deployment_in_model_cost writes the
+    operator's deployment model_info (mode: realtime) over the catalog entry for
+    azure/gpt-realtime-whisper, so mode alone misreads the model as speech-capable
+    and the probe regresses to the beta path. supported_endpoints survives that
+    registration and must keep the probe on the GA transcription path."""
+    polluted = {**litellm.model_cost["azure/gpt-realtime-whisper"], "mode": "realtime"}
+    monkeypatch.setitem(litellm.model_cost, "azure/gpt-realtime-whisper", polluted)
+    connect = _CapturingConnect()
+    with patch("websockets.connect", connect):
+        assert await realtime_main._realtime_health_check(
+            model="gpt-realtime-whisper",
+            custom_llm_provider="azure",
+            api_key="fake-key",
+            api_base="https://my-endpoint.openai.azure.com",
+            api_version="2025-04-01-preview",
+        )
+    assert connect.url == "wss://my-endpoint.openai.azure.com/openai/v1/realtime?intent=transcription"
+
+
+@pytest.mark.asyncio
+async def test_azure_health_check_keeps_beta_path_for_speech_model():
+    connect = _CapturingConnect()
+    with patch("websockets.connect", connect):
+        assert await realtime_main._realtime_health_check(
+            model="gpt-4o-realtime-preview",
+            custom_llm_provider="azure",
+            api_key="fake-key",
+            api_base="https://my-endpoint.openai.azure.com",
+            api_version="2024-10-01-preview",
+        )
+    assert connect.url == (
+        "wss://my-endpoint.openai.azure.com/openai/realtime"
+        "?api-version=2024-10-01-preview&deployment=gpt-4o-realtime-preview"
+    )
+
+
+@pytest.mark.asyncio
+async def test_azure_health_check_honors_deployment_realtime_protocol():
+    connect = _CapturingConnect()
+    with patch("websockets.connect", connect):
+        assert await realtime_main._realtime_health_check(
+            model="gpt-4o-realtime-preview",
+            custom_llm_provider="azure",
+            api_key="fake-key",
+            api_base="https://my-endpoint.openai.azure.com",
+            api_version="2024-10-01-preview",
+            model_params={"realtime_protocol": "GA"},
+        )
+    assert connect.url == "wss://my-endpoint.openai.azure.com/openai/v1/realtime?model=gpt-4o-realtime-preview"

--- a/tests/test_litellm/realtime_api/test_main.py
+++ b/tests/test_litellm/realtime_api/test_main.py
@@ -254,6 +254,16 @@ async def test_azure_health_check_stays_on_ga_when_deployment_registration_overw
     assert connect.url == "wss://my-endpoint.openai.azure.com/openai/v1/realtime?intent=transcription"
 
 
+def test_transcription_only_detection_falls_back_to_mode(local_model_cost_map):
+    """azure/whisper-1 declares mode audio_transcription but no supported_endpoints,
+    so only the mode signal can classify it as transcription-only."""
+    assert realtime_main._is_transcription_only_realtime_model("whisper-1", "azure") is True
+
+
+def test_transcription_only_detection_rejects_speech_model(local_model_cost_map):
+    assert realtime_main._is_transcription_only_realtime_model("gpt-realtime-mini", "azure") is False
+
+
 @pytest.mark.asyncio
 async def test_azure_health_check_keeps_beta_path_for_speech_model():
     connect = _CapturingConnect()

--- a/tests/test_litellm/realtime_api/test_main.py
+++ b/tests/test_litellm/realtime_api/test_main.py
@@ -1,5 +1,6 @@
 import asyncio
 import time
+from types import TracebackType
 from unittest.mock import MagicMock, patch
 
 
@@ -194,19 +195,22 @@ def test_client_secret_forwards_nested_transcription_model_untouched(monkeypatch
 
 
 class _CapturingConnect:
-    def __init__(self):
-        self.url = None
-        self.additional_headers = None
+    def __init__(self) -> None:
+        self.url: str | None = None
 
-    def __call__(self, url, **kwargs):
+    def __call__(self, url: str, **kwargs: object) -> "_CapturingConnect":
         self.url = url
-        self.additional_headers = kwargs.get("additional_headers")
         return self
 
-    async def __aenter__(self):
+    async def __aenter__(self) -> MagicMock:
         return MagicMock()
 
-    async def __aexit__(self, exc_type, exc, tb):
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: TracebackType | None,
+    ) -> None:
         return None
 
 

--- a/tests/test_litellm/test_utils.py
+++ b/tests/test_litellm/test_utils.py
@@ -120,6 +120,15 @@ def test_get_model_info_surfaces_supports_adaptive_thinking(local_model_cost_map
     assert generalized["supports_adaptive_thinking"] is True
 
 
+def test_get_model_info_surfaces_supported_endpoints(local_model_cost_map):
+    """supported_endpoints ships in the cost map and is declared on ModelInfoBase,
+    but the constructor never copied it, so get_model_info always returned None.
+    The realtime health check reads it to spot GA-only transcription models
+    (LIT-6240)."""
+    info = litellm.get_model_info(model="gpt-realtime-whisper", custom_llm_provider="azure")
+    assert info["supported_endpoints"] == ["/v1/realtime", "/v1/realtime/transcription_sessions"]
+
+
 def test_potential_model_names_keeps_provider_prefixed_candidate():
     """A provider whose own model ids repeat the litellm provider name (Perplexity's
     Agent API serves `perplexity/glm-5.2`, mapped as `perplexity/perplexity/glm-5.2`)


### PR DESCRIPTION
## TLDR

Problem this solves:

- `/health` always probes Azure realtime over the beta websocket path
- GA-only transcription models (`azure/gpt-realtime-whisper`) 400 there, so they always report unhealthy
- Real transcription calls through the same proxy work fine

How it solves it:

- Health probe resolves the protocol the way real calls do
- Transcription-only models get GA plus `intent=transcription`, everything else keeps beta
- Explicit `realtime_protocol` (deployment or env) still wins
- `get_model_info` now returns `supported_endpoints`; it declared the field but never filled it

## User Flow

Before: the health check reports a working Azure transcription deployment as permanently unhealthy, even though real transcription sessions through the proxy succeed

1. An operator adds an `azure/gpt-realtime-whisper` deployment (Azure api_base, api_version, Entra credentials, `model_info.mode: realtime`) to the proxy config and starts the proxy
2. A client opens `ws://litellm-domain/v1/realtime?model=azure-realtime-whisper&intent=transcription` with `Authorization: Bearer <key>`, and the connection is accepted with a `session.created` event (`sess_...`)
3. The operator runs `GET http://litellm-domain/health` with the master key
4. The response lists `azure/gpt-realtime-whisper` under `unhealthy_endpoints` with `"server rejected WebSocket connection: HTTP 400"`, on every run, while the speech model `azure/gpt-realtime` on the same resource shows healthy

After: the same health check now reports the transcription deployment healthy

1. An operator adds an `azure/gpt-realtime-whisper` deployment (Azure api_base, api_version, Entra credentials, `model_info.mode: realtime`) to the proxy config and starts the proxy
2. A client opens `ws://litellm-domain/v1/realtime?model=azure-realtime-whisper&intent=transcription` with `Authorization: Bearer <key>`, and the connection is accepted with a `session.created` event (`sess_...`)
3. The operator runs `GET http://litellm-domain/health` with the master key
4. The response lists both `azure/gpt-realtime-whisper` and `azure/gpt-realtime` under `healthy_endpoints`

## Relevant issues

## Linear ticket

Resolves LIT-6240

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Live proxy against a real Azure AI Foundry resource (Sweden Central) with live `gpt-realtime` and `gpt-realtime-whisper` deployments, Entra service principal auth, no mocks. Each leg is one proxy process with 2 uvicorn workers (`--num_workers 2`), no DB. Config used for both legs (credential values redacted, injected via env):

```yaml
model_list:
  - model_name: azure-realtime
    litellm_params:
      model: azure/gpt-realtime
      api_base: https://krris-mnb3t0vd-swedencentral.cognitiveservices.azure.com
      api_version: "2025-04-01-preview"
      tenant_id: os.environ/QA_AZURE_TENANT_ID
      client_id: os.environ/QA_AZURE_CLIENT_ID
      client_secret: os.environ/QA_AZURE_CLIENT_SECRET
    model_info:
      mode: realtime
  - model_name: azure-realtime-whisper
    litellm_params:
      model: azure/gpt-realtime-whisper
      api_base: https://krris-mnb3t0vd-swedencentral.cognitiveservices.azure.com
      api_version: "2025-04-01-preview"
      tenant_id: os.environ/QA_AZURE_TENANT_ID
      client_id: os.environ/QA_AZURE_CLIENT_ID
      client_secret: os.environ/QA_AZURE_CLIENT_SECRET
    model_info:
      mode: realtime

general_settings:
  master_key: sk-1234
```

### Before (80843ae7cb)

#### /health on the transcription deployment

1. `python litellm/proxy/proxy_cli.py --config realtime_health_config.yaml --port 32724 --num_workers 2`
2. `curl -s http://127.0.0.1:32724/health -H 'Authorization: Bearer sk-1234'` (health output redacted)

```json
"healthy_endpoints": [{"model": "azure/gpt-realtime", "api_base": "https://krris-mnb3t0vd-swedencentral.cognitiveservices.azure.com", "api_version": "2025-04-01-preview"}]
"unhealthy_endpoints": [{"model": "azure/gpt-realtime-whisper", "api_base": "https://krris-mnb3t0vd-swedencentral.cognitiveservices.azure.com", "api_version": "2025-04-01-preview", "error": "server rejected WebSocket connection: HTTP 400\nstack trace: ..."}]
```

#### A real transcription session on the same proxy

1. Websocket client connects twice to `ws://127.0.0.1:32724/v1/realtime?model=azure-realtime-whisper&intent=transcription` with `Authorization: Bearer sk-1234`

```text
SERVER EVENT: type=session.created
  session id: sess_EHDRVBtZL2aKYZRIrSbht
SERVER EVENT: type=session.created
  session id: sess_EHDRVHKLPshXhqNoCgBSS
```

### After (e56c42862c)

#### /health on the transcription deployment

1. `python litellm/proxy/proxy_cli.py --config realtime_health_config.yaml --port 40080 --num_workers 2`
2. `curl -s http://127.0.0.1:40080/health -H 'Authorization: Bearer sk-1234'` (health output redacted)

```json
"healthy_endpoints": [
  {"model": "azure/gpt-realtime", "api_base": "https://krris-mnb3t0vd-swedencentral.cognitiveservices.azure.com", "api_version": "2025-04-01-preview"},
  {"model": "azure/gpt-realtime-whisper", "api_base": "https://krris-mnb3t0vd-swedencentral.cognitiveservices.azure.com", "api_version": "2025-04-01-preview"}
]
```

#### A real transcription session on the same proxy

1. Websocket client connects twice to `ws://127.0.0.1:40080/v1/realtime?model=azure-realtime-whisper&intent=transcription` with `Authorization: Bearer sk-1234`

```text
SERVER EVENT: type=session.created
  session id: sess_EHDRXcDCIGvbYSkUgRKzA
SERVER EVENT: type=session.created
  session id: sess_EHDRYngaoZPmHObAomaUQ
```

QA observations:

- Speech model `azure/gpt-realtime` stays healthy on both legs
- Both uvicorn workers served transcription sessions on both legs

Commits 3c9690c4f5 and 7c717c7c6a after the proven hash touch only test files and a test docstring, so the proof at e56c42862c carries to the tip

## Type

🐛 Bug Fix

## Caveats (if any)

### Low

- Transcription-only models not in the cost map still probe beta
  - Workaround: set `realtime_protocol: GA` on the deployment
- `get_model_info` now returns `supported_endpoints` instead of always `None`
  - Additive for every current consumer: `/model/info`, `/v2/model/info`, and the logged model info gain the catalog's `supported_endpoints` array, and the Admin UI model-edit form round-trips it into the saved `model_info` blob. No dashboard code or router filter reads the field

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

- [x] 7c717c7c6a passes /live-pr-risk

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to Azure realtime health URL construction and an additive `get_model_info` field; no auth or request-path changes for live realtime sessions.
> 
> **Overview**
> Fixes **false unhealthy** Azure realtime transcription deployments on `/health` by aligning the websocket probe with how live traffic connects.
> 
> **Azure realtime health checks** now resolve `realtime_protocol` and query params like production: transcription-only models (via `mode: audio_transcription` or `supported_endpoints` including `/v1/realtime/transcription_sessions`) use the **GA** path with **`intent=transcription`**; speech models still default to **beta**. Explicit `realtime_protocol` from deployment params or `LITELLM_AZURE_REALTIME_PROTOCOL` still overrides defaults.
> 
> **`get_model_info`** now populates **`supported_endpoints`** from the cost map (the field existed on the type but was never copied), so classification still works when proxy deployment registration overwrites `mode` to `realtime`.
> 
> Regression tests cover transcription vs speech URLs, polluted `mode`, and explicit GA protocol.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7c717c7c6a2f172fcdbd0a5f64a22417d9d15983. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->