### PR TITLE
feat(ui): toggle internal health check visibility in request logs

### DIFF
--- a/litellm/proxy/spend_tracking/spend_management_endpoints.py
+++ b/litellm/proxy/spend_tracking/spend_management_endpoints.py
@@ -23,6 +23,7 @@ from typing_extensions import ReadOnly
 
 import litellm
 from litellm._logging import verbose_proxy_logger
+from litellm.constants import LITTELM_INTERNAL_HEALTH_SERVICE_ACCOUNT_NAME
 from litellm.proxy._types import *
 from litellm.proxy._types import ProviderBudgetResponse, ProviderBudgetResponseObject
 from litellm.proxy.auth.user_api_key_auth import user_api_key_auth
@@ -53,6 +54,11 @@ else:
 router: Final = APIRouter()
 
 SPEND_LOGS_PAGINATION_COUNT_CAP: Final = 10000
+
+_INTERNAL_HEALTH_CHECK_API_KEYS: Final = (
+    LITTELM_INTERNAL_HEALTH_SERVICE_ACCOUNT_NAME,
+    hash_token(token=LITTELM_INTERNAL_HEALTH_SERVICE_ACCOUNT_NAME),
+)
 
 _RowT = TypeVar("_RowT")
 
@@ -2259,6 +2265,10 @@ async def ui_view_spend_logs(
         default="desc",
         description="Sort order: asc or desc",
     ),
+    exclude_internal_health_checks: bool = fastapi.Query(
+        default=False,
+        description="Exclude LiteLLM internal health check requests from results",
+    ),
 ):
     """
     View spend logs with pagination support.
@@ -2550,6 +2560,11 @@ async def ui_view_spend_logs(
                 sql_conditions.append(f"status = ${p}")
                 sql_params.append(status_filter)
                 p += 1
+
+        if exclude_internal_health_checks:
+            sql_conditions.append(f"api_key NOT IN (${p}, ${p + 1})")
+            sql_params.extend(_INTERNAL_HEALTH_CHECK_API_KEYS)
+            p += 2  # rebind-ok: advances the file's shared $N placeholder counter
 
         # Spend range
         if min_spend is not None:

--- a/tests/test_litellm/proxy/spend_tracking/test_spend_management_endpoints.py
+++ b/tests/test_litellm/proxy/spend_tracking/test_spend_management_endpoints.py
@@ -1,6 +1,7 @@
 import asyncio
 import collections
 import datetime
+import hashlib
 import json
 import re
 from datetime import timezone
@@ -96,6 +97,7 @@ def _reconstruct_ui_where_from_sql(sql_query, params):
         msg = re.search(r"error_message' LIKE \$(\d+)", cond)
         sess = re.fullmatch(r"session_id LIKE \$(\d+)", cond)
         status = re.fullmatch(r"status = \$(\d+)", cond)
+        api_key_not_in = re.fullmatch(r"api_key NOT IN \(\$(\d+), \$(\d+)\)", cond)
         if gte:
             date_bounds["gte"] = _iso(params[int(gte.group(1)) - 1])
         elif lte:
@@ -108,6 +110,11 @@ def _reconstruct_ui_where_from_sql(sql_query, params):
             where["session_id"] = {"contains": str(params[int(sess.group(1)) - 1]).strip("%")}
         elif status:
             where["status"] = {"equals": params[int(status.group(1)) - 1]}
+        elif api_key_not_in:
+            where["api_key_not_in"] = [
+                params[int(api_key_not_in.group(1)) - 1],
+                params[int(api_key_not_in.group(2)) - 1],
+            ]
         elif alias:
             metadata_conds.append(
                 {
@@ -196,6 +203,7 @@ def make_ui_spend_logs_mock_prisma(mock_spend_logs, filter_fn, team_lookup_fn=No
     return MockPrismaClient()
 
 
+from litellm.constants import LITTELM_INTERNAL_HEALTH_SERVICE_ACCOUNT_NAME
 from litellm.proxy._types import (
     LitellmUserRoles,
     Member,
@@ -1252,6 +1260,140 @@ async def test_ui_view_spend_logs_with_team_id(client, monkeypatch):
         assert data["total"] == 1
         assert len(data["data"]) == 1
         assert data["data"][0]["team_id"] == "team1"
+    finally:
+        app.dependency_overrides.pop(ps.user_api_key_auth, None)
+
+
+_HEALTH_CHECK_HASHED_API_KEY = hashlib.sha256(LITTELM_INTERNAL_HEALTH_SERVICE_ACCOUNT_NAME.encode()).hexdigest()
+
+
+def _spend_logs_with_health_check_rows():
+    now = datetime.datetime.now(timezone.utc).isoformat()
+    return [
+        {
+            "id": "log1",
+            "request_id": "req1",
+            "api_key": "sk-test-key",
+            "user": "test_user_1",
+            "team_id": None,
+            "spend": 0.05,
+            "startTime": now,
+            "model": "gpt-4",
+        },
+        {
+            "id": "log2",
+            "request_id": "req2",
+            "api_key": _HEALTH_CHECK_HASHED_API_KEY,
+            "user": None,
+            "team_id": LITTELM_INTERNAL_HEALTH_SERVICE_ACCOUNT_NAME,
+            "spend": 0.0,
+            "startTime": now,
+            "model": "gpt-4",
+        },
+        {
+            "id": "log3",
+            "request_id": "req3",
+            "api_key": LITTELM_INTERNAL_HEALTH_SERVICE_ACCOUNT_NAME,
+            "user": None,
+            "team_id": LITTELM_INTERNAL_HEALTH_SERVICE_ACCOUNT_NAME,
+            "spend": 0.0,
+            "startTime": now,
+            "model": "gpt-4",
+        },
+    ]
+
+
+@pytest.mark.asyncio
+async def test_ui_view_spend_logs_exclude_internal_health_checks(client, monkeypatch):
+    mock_spend_logs = _spend_logs_with_health_check_rows()
+
+    def filter_health_checks(where):
+        excluded = where.get("api_key_not_in")
+        if excluded is None:
+            return mock_spend_logs
+        return [log for log in mock_spend_logs if log["api_key"] not in excluded]
+
+    observed_queries = []
+
+    def observe_query(sql_query, params):
+        if 'FROM "LiteLLM_SpendLogs"' in sql_query:
+            observed_queries.append((sql_query, params))
+
+    monkeypatch.setattr(
+        "litellm.proxy.proxy_server.prisma_client",
+        make_ui_spend_logs_mock_prisma(mock_spend_logs, filter_health_checks, query_observer=observe_query),
+    )
+    app.dependency_overrides[ps.user_api_key_auth] = lambda: UserAPIKeyAuth(
+        user_role=LitellmUserRoles.PROXY_ADMIN, user_id="admin_user"
+    )
+
+    try:
+        start_date, end_date = _default_date_range()
+        response = client.get(
+            "/spend/logs/ui",
+            params={
+                "exclude_internal_health_checks": "true",
+                "start_date": start_date,
+                "end_date": end_date,
+            },
+            headers={"Authorization": "Bearer sk-test"},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["total"] == 1
+        assert [row["request_id"] for row in data["data"]] == ["req1"]
+
+        page_sql, page_params = next((sql, params) for sql, params in observed_queries if "ORDER BY" in sql)
+        not_in = re.search(r"api_key NOT IN \(\$(\d+), \$(\d+)\)", page_sql)
+        assert not_in is not None
+        assert LITTELM_INTERNAL_HEALTH_SERVICE_ACCOUNT_NAME not in page_sql
+        assert _HEALTH_CHECK_HASHED_API_KEY not in page_sql
+        assert {
+            page_params[int(not_in.group(1)) - 1],
+            page_params[int(not_in.group(2)) - 1],
+        } == {LITTELM_INTERNAL_HEALTH_SERVICE_ACCOUNT_NAME, _HEALTH_CHECK_HASHED_API_KEY}
+    finally:
+        app.dependency_overrides.pop(ps.user_api_key_auth, None)
+
+
+@pytest.mark.asyncio
+async def test_ui_view_spend_logs_includes_internal_health_checks_by_default(client, monkeypatch):
+    mock_spend_logs = _spend_logs_with_health_check_rows()
+
+    def filter_health_checks(where):
+        excluded = where.get("api_key_not_in")
+        if excluded is None:
+            return mock_spend_logs
+        return [log for log in mock_spend_logs if log["api_key"] not in excluded]
+
+    observed_queries = []
+
+    def observe_query(sql_query, params):
+        if 'FROM "LiteLLM_SpendLogs"' in sql_query:
+            observed_queries.append((sql_query, params))
+
+    monkeypatch.setattr(
+        "litellm.proxy.proxy_server.prisma_client",
+        make_ui_spend_logs_mock_prisma(mock_spend_logs, filter_health_checks, query_observer=observe_query),
+    )
+    app.dependency_overrides[ps.user_api_key_auth] = lambda: UserAPIKeyAuth(
+        user_role=LitellmUserRoles.PROXY_ADMIN, user_id="admin_user"
+    )
+
+    try:
+        start_date, end_date = _default_date_range()
+        response = client.get(
+            "/spend/logs/ui",
+            params={"start_date": start_date, "end_date": end_date},
+            headers={"Authorization": "Bearer sk-test"},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["total"] == 3
+        assert [row["request_id"] for row in data["data"]] == ["req1", "req2", "req3"]
+        assert all("NOT IN" not in sql for sql, _ in observed_queries)
     finally:
         app.dependency_overrides.pop(ps.user_api_key_auth, None)
 

--- a/ui/litellm-dashboard/src/components/networking.test.ts
+++ b/ui/litellm-dashboard/src/components/networking.test.ts
@@ -459,6 +459,64 @@ describe("teamInfoCall", () => {
   });
 });
 
+describe("uiSpendLogsCall exclude_internal_health_checks serialization", () => {
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  const mockOkFetch = () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: vi.fn().mockResolvedValue({ data: [], total: 0, page: 1, page_size: 50, total_pages: 0 }),
+    } as any);
+    global.fetch = mockFetch as any;
+    return mockFetch;
+  };
+
+  const callWith = (params: Parameters<typeof Networking.uiSpendLogsCall>[0]["params"]) =>
+    Networking.uiSpendLogsCall({
+      accessToken: "token",
+      start_date: "2026-01-01 00:00:00",
+      end_date: "2026-01-02 00:00:00",
+      params,
+    });
+
+  const lastUrl = (mockFetch: ReturnType<typeof vi.fn>) => {
+    const [url] = mockFetch.mock.calls.at(-1) ?? [];
+    return new URL(url as string, "http://example.com");
+  };
+
+  it("appends exclude_internal_health_checks=true when the toggle is on", async () => {
+    const mockFetch = mockOkFetch();
+
+    await callWith({ exclude_internal_health_checks: true });
+
+    expect(lastUrl(mockFetch).searchParams.get("exclude_internal_health_checks")).toBe("true");
+  });
+
+  it("omits exclude_internal_health_checks when the toggle is off", async () => {
+    const mockFetch = mockOkFetch();
+
+    await callWith({ exclude_internal_health_checks: false });
+
+    expect(lastUrl(mockFetch).searchParams.has("exclude_internal_health_checks")).toBe(false);
+  });
+
+  it("omits exclude_internal_health_checks when the param is absent", async () => {
+    const mockFetch = mockOkFetch();
+
+    await callWith({});
+
+    expect(lastUrl(mockFetch).searchParams.has("exclude_internal_health_checks")).toBe(false);
+  });
+});
+
 describe("sessionSpendLogsCall", () => {
   const originalFetch = global.fetch;
 

--- a/ui/litellm-dashboard/src/components/networking.tsx
+++ b/ui/litellm-dashboard/src/components/networking.tsx
@@ -2013,6 +2013,7 @@ interface UiSpendLogsParams {
   sort_order?: "asc" | "desc";
   min_spend?: number;
   max_spend?: number;
+  exclude_internal_health_checks?: boolean;
 }
 
 interface UiSpendLogsCallOptions {
@@ -2047,6 +2048,8 @@ export const uiSpendLogsCall = async ({
       if (value == null) continue;
       if (key === "min_spend" || key === "max_spend") {
         queryParams.append(key, value.toString());
+      } else if (typeof value === "boolean") {
+        if (value) queryParams.append(key, "true");
       } else if (typeof value === "string" && value !== "") {
         queryParams.append(key, String(value));
       }

--- a/ui/litellm-dashboard/src/components/view_logs/LogsTableToolbar.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/LogsTableToolbar.tsx
@@ -23,6 +23,8 @@ interface LogsTableToolbarProps {
   onSelectedTimeIntervalChange: (value: { value: number; unit: string }) => void;
   isLiveTail: boolean;
   onIsLiveTailChange: (value: boolean) => void;
+  excludeInternalHealthChecks: boolean;
+  onExcludeInternalHealthChecksChange: (value: boolean) => void;
   onResetToFirstPage: () => void;
   onResetFilters: () => void;
 }
@@ -38,6 +40,8 @@ export function LogsTableToolbar({
   onSelectedTimeIntervalChange,
   isLiveTail,
   onIsLiveTailChange,
+  excludeInternalHealthChecks,
+  onExcludeInternalHealthChecksChange,
   onResetToFirstPage,
   onResetFilters,
 }: LogsTableToolbarProps) {
@@ -123,6 +127,15 @@ export function LogsTableToolbar({
       <div className="flex items-center gap-2">
         <span className="text-sm font-medium">Live Tail</span>
         <Switch checked={isLiveTail} onCheckedChange={onIsLiveTailChange} aria-label="Live Tail" />
+      </div>
+
+      <div className="flex items-center gap-2">
+        <span className="text-sm font-medium">Hide Health Checks</span>
+        <Switch
+          checked={excludeInternalHealthChecks}
+          onCheckedChange={onExcludeInternalHealthChecksChange}
+          aria-label="Hide Health Checks"
+        />
       </div>
 
       <Button variant="outline" size="sm" onClick={onResetFilters}>

--- a/ui/litellm-dashboard/src/components/view_logs/RequestLogsPanel.test.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/RequestLogsPanel.test.tsx
@@ -434,6 +434,35 @@ describe("RequestLogsPanel", () => {
     });
   });
 
+  describe("hide health checks", () => {
+    const toggle = () => screen.getByRole("switch", { name: "Hide Health Checks" });
+
+    it("defaults to showing health checks and refetches without them from page 1 when toggled on", async () => {
+      const user = userEvent.setup();
+      renderPanel();
+
+      await waitFor(() => expect(uiSpendLogsCall).toHaveBeenCalled());
+      expect(lastCall()?.params?.exclude_internal_health_checks).toBe(false);
+      expect(toggle()).not.toBeChecked();
+
+      await user.click(toggle());
+
+      await waitFor(() => expect(lastCall()?.params?.exclude_internal_health_checks).toBe(true));
+      expect(lastCall()?.page).toBe(1);
+      expect(toggle()).toBeChecked();
+      expect(sessionStorage.getItem("excludeInternalHealthChecks")).toBe("true");
+    });
+
+    it("restores the persisted toggle from sessionStorage", async () => {
+      sessionStorage.setItem("excludeInternalHealthChecks", "true");
+      renderPanel();
+
+      await waitFor(() => expect(uiSpendLogsCall).toHaveBeenCalled());
+      expect(lastCall()?.params?.exclude_internal_health_checks).toBe(true);
+      expect(toggle()).toBeChecked();
+    });
+  });
+
   describe("live tail", () => {
     it("shows the auto-refresh banner on the first page and hides it once stopped", async () => {
       const user = userEvent.setup();

--- a/ui/litellm-dashboard/src/components/view_logs/RequestLogsPanel.test.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/RequestLogsPanel.test.tsx
@@ -461,6 +461,15 @@ describe("RequestLogsPanel", () => {
       expect(lastCall()?.params?.exclude_internal_health_checks).toBe(true);
       expect(toggle()).toBeChecked();
     });
+
+    it("falls back to showing health checks when the persisted value is malformed", async () => {
+      sessionStorage.setItem("excludeInternalHealthChecks", "{not json");
+      renderPanel();
+
+      await waitFor(() => expect(uiSpendLogsCall).toHaveBeenCalled());
+      expect(lastCall()?.params?.exclude_internal_health_checks).toBe(false);
+      expect(toggle()).not.toBeChecked();
+    });
   });
 
   describe("live tail", () => {

--- a/ui/litellm-dashboard/src/components/view_logs/RequestLogsPanel.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/RequestLogsPanel.tsx
@@ -72,10 +72,9 @@ export default function RequestLogsPanel({ accessToken, token, userRole, userID,
     sessionStorage.setItem("isLiveTail", JSON.stringify(isLiveTail));
   }, [isLiveTail]);
 
-  const [excludeInternalHealthChecks, setExcludeInternalHealthChecks] = useState<boolean>(() => {
-    const storedValue = sessionStorage.getItem("excludeInternalHealthChecks");
-    return storedValue !== null ? JSON.parse(storedValue) : false;
-  });
+  const [excludeInternalHealthChecks, setExcludeInternalHealthChecks] = useState<boolean>(
+    () => sessionStorage.getItem("excludeInternalHealthChecks") === "true",
+  );
 
   useEffect(() => {
     sessionStorage.setItem("excludeInternalHealthChecks", JSON.stringify(excludeInternalHealthChecks));

--- a/ui/litellm-dashboard/src/components/view_logs/RequestLogsPanel.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/RequestLogsPanel.tsx
@@ -72,6 +72,15 @@ export default function RequestLogsPanel({ accessToken, token, userRole, userID,
     sessionStorage.setItem("isLiveTail", JSON.stringify(isLiveTail));
   }, [isLiveTail]);
 
+  const [excludeInternalHealthChecks, setExcludeInternalHealthChecks] = useState<boolean>(() => {
+    const storedValue = sessionStorage.getItem("excludeInternalHealthChecks");
+    return storedValue !== null ? JSON.parse(storedValue) : false;
+  });
+
+  useEffect(() => {
+    sessionStorage.setItem("excludeInternalHealthChecks", JSON.stringify(excludeInternalHealthChecks));
+  }, [excludeInternalHealthChecks]);
+
   const { logsQuery, filteredLogs, allTeams } = useLogFilterLogic({
     accessToken,
     token,
@@ -80,6 +89,7 @@ export default function RequestLogsPanel({ accessToken, token, userRole, userID,
     columnFilters,
     activeTab: isActive ? "request logs" : "inactive",
     isLiveTail,
+    excludeInternalHealthChecks,
     startTime,
     endTime,
     pagination,
@@ -219,6 +229,14 @@ export default function RequestLogsPanel({ accessToken, token, userRole, userID,
     setPagination((previous) => ({ ...previous, pageIndex: 0 }));
   }, []);
 
+  const handleExcludeInternalHealthChecksChange = useCallback(
+    (value: boolean) => {
+      setExcludeInternalHealthChecks(value);
+      resetToFirstPage();
+    },
+    [resetToFirstPage],
+  );
+
   const handleResetFilters = useCallback(() => {
     setColumnFilters([]);
     setStartTime(moment().subtract(24, "hours").format("YYYY-MM-DDTHH:mm"));
@@ -313,6 +331,8 @@ export default function RequestLogsPanel({ accessToken, token, userRole, userID,
             onSelectedTimeIntervalChange={setSelectedTimeInterval}
             isLiveTail={isLiveTail}
             onIsLiveTailChange={setIsLiveTail}
+            excludeInternalHealthChecks={excludeInternalHealthChecks}
+            onExcludeInternalHealthChecksChange={handleExcludeInternalHealthChecksChange}
             onResetToFirstPage={resetToFirstPage}
             onResetFilters={handleResetFilters}
           />

--- a/ui/litellm-dashboard/src/components/view_logs/log_filter_logic.test.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/log_filter_logic.test.tsx
@@ -47,6 +47,7 @@ const defaultProps = {
   columnFilters: [] as ColumnFiltersState,
   activeTab: "request logs",
   isLiveTail: false,
+  excludeInternalHealthChecks: false,
   startTime: "2025-01-01T00:00:00",
   endTime: "2025-01-01T23:59:59",
   pagination: FIRST_PAGE,
@@ -152,6 +153,7 @@ describe("useLogFilterLogic", () => {
       ["pagination", { pagination: { pageIndex: 1, pageSize: 50 } }],
       ["startTime", { startTime: "2025-02-02T00:00:00" }],
       ["columnFilters", { columnFilters: [{ id: LOG_FILTER_IDS.TEAM_ID, value: "team-2" }] }],
+      ["excludeInternalHealthChecks", { excludeInternalHealthChecks: true }],
     ])("refetches when %s changes", async (_label, nextProps) => {
       const { rerender } = renderHook((props: HookOverrides) => useLogFilterLogic({ ...defaultProps, ...props }), {
         wrapper,
@@ -161,6 +163,22 @@ describe("useLogFilterLogic", () => {
       await waitFor(() => expect(uiSpendLogsCall).toHaveBeenCalledTimes(1));
       rerender(nextProps);
       await waitFor(() => expect(uiSpendLogsCall).toHaveBeenCalledTimes(2));
+    });
+  });
+
+  describe("hide health checks toggle", () => {
+    it("passes exclude_internal_health_checks when the toggle is on", async () => {
+      renderFilterHook({ excludeInternalHealthChecks: true });
+
+      await waitFor(() => expect(uiSpendLogsCall).toHaveBeenCalled());
+      expect(lastCallParams()?.params).toMatchObject({ exclude_internal_health_checks: true });
+    });
+
+    it("passes exclude_internal_health_checks as false when the toggle is off", async () => {
+      renderFilterHook();
+
+      await waitFor(() => expect(uiSpendLogsCall).toHaveBeenCalled());
+      expect(lastCallParams()?.params).toMatchObject({ exclude_internal_health_checks: false });
     });
   });
 

--- a/ui/litellm-dashboard/src/components/view_logs/log_filter_logic.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/log_filter_logic.tsx
@@ -101,6 +101,7 @@ export function useLogFilterLogic({
   columnFilters,
   activeTab,
   isLiveTail,
+  excludeInternalHealthChecks,
   startTime,
   endTime,
   pagination,
@@ -114,6 +115,7 @@ export function useLogFilterLogic({
   columnFilters: ColumnFiltersState;
   activeTab: string;
   isLiveTail: boolean;
+  excludeInternalHealthChecks: boolean;
   startTime: string;
   endTime: string;
   pagination: PaginationState;
@@ -137,6 +139,7 @@ export function useLogFilterLogic({
       columnFilters,
       sortBy,
       sortOrder,
+      excludeInternalHealthChecks,
     ],
     queryFn: async () => {
       if (!accessToken || !token || !userRole || !userID) {
@@ -174,6 +177,7 @@ export function useLogFilterLogic({
           error_message: getFilterValue(columnFilters, LOG_FILTER_IDS.ERROR_MESSAGE),
           sort_by: sortBy,
           sort_order: sortOrder,
+          exclude_internal_health_checks: excludeInternalHealthChecks,
         },
       });
     },

--- a/ui/litellm-dashboard/src/lib/http/schema.d.ts
+++ b/ui/litellm-dashboard/src/lib/http/schema.d.ts
@@ -53256,6 +53256,8 @@ export interface operations {
                 sort_by?: string;
                 /** @description Sort order: asc or desc */
                 sort_order?: string | null;
+                /** @description Exclude LiteLLM internal health check requests from results */
+                exclude_internal_health_checks?: boolean;
             };
             header?: never;
             path?: never;
@@ -53364,6 +53366,8 @@ export interface operations {
                 sort_by?: string;
                 /** @description Sort order: asc or desc */
                 sort_order?: string | null;
+                /** @description Exclude LiteLLM internal health check requests from results */
+                exclude_internal_health_checks?: boolean;
             };
             header?: never;
             path?: never;


### PR DESCRIPTION
## TLDR

Problem this solves:

- Background health checks write `litellm-internal-health-check` rows into the request logs
- The Logs page has no way to hide them; only inclusive filters exist
- Admins must hand-pick every real team just to see actual traffic

How it solves it:

- New "Hide Health Checks" switch in the Logs toolbar, next to Live Tail
- Sends `exclude_internal_health_checks=true` to `/spend/logs/ui` and `/spend/logs/v2`
- Backend filters those rows out with a parameterized query condition
- The choice persists for the browser session and resets pagination to page 1

## User Flow

Before: the flow fails at the last step, where the admin scans the Logs page and cannot get the `litellm-internal-health-check` rows out of the way

1. As a proxy admin with background health checks enabled, open the Admin UI Logs page at `https://litellm-domain/ui/?page=logs`
2. The page loads via `GET https://litellm-domain/spend/logs/ui?start_date=...&end_date=...&page=1&page_size=50`, returning 200 with the most recent requests
3. The table shows real user traffic interleaved with `litellm-internal-health-check` rows (one per health check cycle, tagged with that team and key alias)
4. Open the Filters panel looking for a way to hide them: only inclusive filters exist (Team ID, Status, Key Alias, User ID, End User, Model, and the like), so there is no way to exclude the health check rows, and hand-picking every real team on every visit is the only workaround

After: the flow succeeds at step 4, where a new toolbar switch hides the health check rows and the choice sticks for the session

1. As a proxy admin with background health checks enabled, open the Admin UI Logs page at `https://litellm-domain/ui/?page=logs`
2. The page loads via `GET https://litellm-domain/spend/logs/ui?start_date=...&end_date=...&page=1&page_size=50`, returning 200 with the most recent requests
3. The table shows real user traffic interleaved with `litellm-internal-health-check` rows (one per health check cycle, tagged with that team and key alias)
4. Flip the new "Hide Health Checks" switch in the toolbar next to Live Tail: the table refetches via `GET https://litellm-domain/spend/logs/ui?...&exclude_internal_health_checks=true`, returns 200 with only real traffic, jumps back to page 1, and the switch stays on across reloads for the rest of the session

## Relevant issues

## Linear ticket

Resolves LIT-6141

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Setup, identical on both legs except the commit the proxy was booted from: fresh Postgres per leg, one proxy instance with 2 uvicorn workers on a random port, a real OpenAI `gpt-5-mini` deployment, `background_health_checks: true` with `health_check_interval: 300`, master key `sk-lit6141-test`. Each leg sent one real completion (real OpenAI spend), then `GET /health` to write `litellm-internal-health-check` spend rows (each worker writes its own row, so counts vary; presence is what matters). The Admin UI was driven from the dashboard dev server pointed at the same proxy

Config:

```yaml
model_list:
  - model_name: gpt-5-mini
    litellm_params:
      model: openai/gpt-5-mini
      api_key: os.environ/OPENAI_API_KEY

general_settings:
  master_key: sk-lit6141-test
  background_health_checks: true
  health_check_interval: 300
```

### Before (80843ae7cb)

#### /spend/logs/ui

1. Default listing shows the real request plus the health check rows:

```
$ curl -s "http://localhost:41873/spend/logs/ui?start_date=2026-08-26%2000:00:00&end_date=2026-08-26%2023:59:59&page=1&page_size=50" -H "Authorization: Bearer sk-lit6141-test" | jq '{total, rows: [.data[] | {request_id, model, api_key, team_id}]}'
{
  "total": 3,
  "rows": [
    {"request_id": "chatcmpl-EHDaEeL0C8AnErDYSw3sjTUGWXLI0", "model": "openai/gpt-5-mini", "api_key": "litellm_proxy_master_key", "team_id": ""},
    {"request_id": "chatcmpl-EHDa8ITA5lsU9IJFi7cC2sq6EzBaP", "model": "gpt-5-mini", "api_key": "2ee659761968def976c7905217d96fa6e765f300dfb066f6c73fd3c279b3435a", "team_id": "litellm-internal-health-check"},
    {"request_id": "chatcmpl-EHDa8GRSiBNYONNgtk3T6MJFfO2Hr", "model": "gpt-5-mini", "api_key": "2ee659761968def976c7905217d96fa6e765f300dfb066f6c73fd3c279b3435a", "team_id": "litellm-internal-health-check"}
  ]
}
```

2. Adding `&exclude_internal_health_checks=true` returns the byte-identical response: `total` stays 3 and both `litellm-internal-health-check` rows are still there, so the param is silently ignored:

```
$ curl -s "http://localhost:41873/spend/logs/ui?start_date=2026-08-26%2000:00:00&end_date=2026-08-26%2023:59:59&page=1&page_size=50&exclude_internal_health_checks=true" -H "Authorization: Bearer sk-lit6141-test" | jq '{total, rows: [.data[] | {request_id, model, api_key, team_id}]}'
{
  "total": 3,
  "rows": [
    {"request_id": "chatcmpl-EHDaEeL0C8AnErDYSw3sjTUGWXLI0", "model": "openai/gpt-5-mini", "api_key": "litellm_proxy_master_key", "team_id": ""},
    {"request_id": "chatcmpl-EHDa8ITA5lsU9IJFi7cC2sq6EzBaP", "model": "gpt-5-mini", "api_key": "2ee659761968def976c7905217d96fa6e765f300dfb066f6c73fd3c279b3435a", "team_id": "litellm-internal-health-check"},
    {"request_id": "chatcmpl-EHDa8GRSiBNYONNgtk3T6MJFfO2Hr", "model": "gpt-5-mini", "api_key": "2ee659761968def976c7905217d96fa6e765f300dfb066f6c73fd3c279b3435a", "team_id": "litellm-internal-health-check"}
  ]
}
```

#### /spend/logs/v2

1. The same pair of requests against `/spend/logs/v2` behaves identically: the no-param and `exclude_internal_health_checks=true` responses are byte-identical, `total: 3` with both health check rows present both times (outputs matched the `/spend/logs/ui` blocks above row for row)

#### Admin UI Logs page

1. Logged into the dashboard as `admin` / master key and opened the Logs page (Last 24 Hours): the table shows the real `gpt-5-mini` request alongside rows with Team Name `litellm-internal-health-check`
2. The toolbar contains only Search by Request ID, the time range picker, Live Tail, Reset Filters, refresh, and Filters; the only switch on the page is Live Tail, and nothing matching "Hide Health Checks" exists anywhere in the rendered page
3. The Filters panel offers only inclusive filters (Team ID, Status, Key Alias, User ID, End User, Error Code, Error Message, Key Hash, Session ID, Model); no control excludes health checks

### After (19a1d5c4c6)

#### /spend/logs/ui

1. Default listing is unchanged: the real request plus the health check rows (one per uvicorn worker):

```
$ curl -s "http://localhost:47311/spend/logs/ui?start_date=2026-08-26%2000:00:00&end_date=2026-08-26%2023:59:59&page=1&page_size=50" -H "Authorization: Bearer sk-lit6141-test" | jq '{total, rows: [.data[] | {request_id, model, api_key, team_id}]}'
{
  "total": 3,
  "rows": [
    {"request_id": "chatcmpl-EHDzMzUOi6oK17QOY3mV2TztJ9HK0", "model": "openai/gpt-5-mini", "api_key": "litellm_proxy_master_key", "team_id": ""},
    {"request_id": "chatcmpl-EHDzHjnhiOSy6rAH10F9XLcQ3SRs1", "model": "gpt-5-mini", "api_key": "2ee659761968def976c7905217d96fa6e765f300dfb066f6c73fd3c279b3435a", "team_id": "litellm-internal-health-check"},
    {"request_id": "chatcmpl-EHDzHhp0sFrD5ZheYrp7k2sm4kSxM", "model": "gpt-5-mini", "api_key": "2ee659761968def976c7905217d96fa6e765f300dfb066f6c73fd3c279b3435a", "team_id": "litellm-internal-health-check"}
  ]
}
```

2. Adding `&exclude_internal_health_checks=true` now drops every health check row while keeping the real request, and `total` reflects the exclusion:

```
$ curl -s "http://localhost:47311/spend/logs/ui?start_date=2026-08-26%2000:00:00&end_date=2026-08-26%2023:59:59&page=1&page_size=50&exclude_internal_health_checks=true" -H "Authorization: Bearer sk-lit6141-test" | jq '{total, rows: [.data[] | {request_id, model, api_key, team_id}]}'
{
  "total": 1,
  "rows": [
    {"request_id": "chatcmpl-EHDzMzUOi6oK17QOY3mV2TztJ9HK0", "model": "openai/gpt-5-mini", "api_key": "litellm_proxy_master_key", "team_id": ""}
  ]
}
```

#### /spend/logs/v2

1. The same pair against `/spend/logs/v2`: default returns the same 3 rows including both health check rows, and with the param it filters the same way:

```
$ curl -s "http://localhost:47311/spend/logs/v2?start_date=2026-08-26%2000:00:00&end_date=2026-08-26%2023:59:59&page=1&page_size=50&exclude_internal_health_checks=true" -H "Authorization: Bearer sk-lit6141-test" | jq '{total, rows: [.data[] | {request_id, model, api_key, team_id}]}'
{
  "total": 1,
  "rows": [
    {"request_id": "chatcmpl-EHDzMzUOi6oK17QOY3mV2TztJ9HK0", "model": "openai/gpt-5-mini", "api_key": "litellm_proxy_master_key", "team_id": ""}
  ]
}
```

#### Admin UI Logs page

1. Logged into the dashboard as `admin` / master key and opened the Logs page: health check rows are visible by default, and a "Hide Health Checks" switch now sits in the toolbar directly next to Live Tail, off by default
2. Flipping the switch on refetched the table with `GET .../spend/logs/ui?start_date=...&end_date=...&page=1&page_size=50&sort_by=startTime&sort_order=desc&exclude_internal_health_checks=true` (note `page=1`): both `litellm-internal-health-check` rows disappeared and the real request remained ("Showing 1-1 of 1")
3. Reloading the page in the same tab kept the switch on and the health check rows hidden (session persistence)
4. Flipping the switch off brought the health check rows back and the refetch dropped the param
5. Seeding the browser's stored toggle value with garbage (`sessionStorage.setItem("excludeInternalHealthChecks", "{not json")`) and reloading rendered the page normally with the switch off and all rows visible, with zero page errors

Observations from the run, none introduced by this PR:

- Each uvicorn worker writes its own health check row; pre-existing
- Health check rows accrue every interval per worker; pre-existing
- Live Tail defaults on with 15s auto-refresh; pre-existing

## Type

🆕 New Feature

## Caveats (if any)

### Low

- Preference is per browser session; a new session shows health checks again
- Hides rows from the Logs list only; spend and usage aggregates still count them
- The switch reaches self-hosted UIs once the prebuilt dashboard bundle is rebuilt at the next release

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

- [x] 19a1d5c4c6 passes /live-pr-risk
