### PR TITLE
fix(minimax): attach MINIMAX_API_KEY on anthropic messages requests

### DIFF
--- a/litellm/llms/minimax/messages/transformation.py
+++ b/litellm/llms/minimax/messages/transformation.py
@@ -2,7 +2,7 @@
 MiniMax Anthropic transformation config - extends AnthropicConfig for MiniMax's Anthropic-compatible API
 """
 
-from typing import Final
+from typing import Any, Final  # noqa: TID251  # override below must mirror the legacy base signature
 
 import litellm
 from litellm.llms.anthropic.experimental_pass_through.messages.transformation import (
@@ -48,6 +48,26 @@ class MinimaxMessagesConfig(AnthropicMessagesConfig):
         For China, set to: https://api.minimaxi.com/anthropic
         """
         return api_base or get_secret_str("MINIMAX_API_BASE") or "https://api.minimax.io/anthropic/v1/messages"
+
+    def validate_anthropic_messages_environment(
+        self,
+        headers: dict,  # mutable-ok: mirrors the legacy base override signature
+        model: str,
+        messages: list[Any],  # mutable-ok: mirrors the legacy base override signature
+        optional_params: dict,  # mutable-ok: mirrors the legacy base override signature
+        litellm_params: dict,  # mutable-ok: mirrors the legacy base override signature
+        api_key: str | None = None,
+        api_base: str | None = None,
+    ) -> tuple[dict, str | None]:  # mutable-ok: mirrors the legacy base override signature
+        return super().validate_anthropic_messages_environment(
+            headers=headers,
+            model=model,
+            messages=messages,
+            optional_params=optional_params,
+            litellm_params=litellm_params,
+            api_key=self.get_api_key(api_key=api_key),
+            api_base=api_base,
+        )
 
     def get_complete_url(
         self,

--- a/tests/test_litellm/llms/minimax/messages/test_transformation.py
+++ b/tests/test_litellm/llms/minimax/messages/test_transformation.py
@@ -142,3 +142,33 @@ if __name__ == "__main__":
     print("✓ Provider config manager test passed")
 
     print("\n✅ All basic tests passed!")
+
+
+def test_minimax_messages_env_key_attached(monkeypatch):
+    """Regression: an env-only MINIMAX_API_KEY must be attached on /v1/messages validation"""
+    monkeypatch.setenv("MINIMAX_API_KEY", "test-minimax-env-key")
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.delenv("ANTHROPIC_AUTH_TOKEN", raising=False)
+    config = MinimaxMessagesConfig()
+    headers, _ = config.validate_anthropic_messages_environment(
+        headers={},
+        model="MiniMax-M2.1",
+        messages=[{"role": "user", "content": "hi"}],
+        optional_params={},
+        litellm_params={},
+    )
+    assert headers["x-api-key"] == "test-minimax-env-key"
+
+
+def test_minimax_messages_explicit_key_wins_over_env(monkeypatch):
+    monkeypatch.setenv("MINIMAX_API_KEY", "env-key")
+    config = MinimaxMessagesConfig()
+    headers, _ = config.validate_anthropic_messages_environment(
+        headers={},
+        model="MiniMax-M2.1",
+        messages=[{"role": "user", "content": "hi"}],
+        optional_params={},
+        litellm_params={},
+        api_key="param-key",
+    )
+    assert headers["x-api-key"] == "param-key"


### PR DESCRIPTION
## TLDR

Problem this solves:

- `MINIMAX_API_KEY` from the environment is never sent on `/v1/messages`
- Requests to MiniMax models fail locally asking for `ANTHROPIC_API_KEY`

How it solves it:

- MiniMax now resolves its own env key during messages validation
- Same override shape Tencent already uses for this path

## User Flow

Before: a proxy admin sets `MINIMAX_API_KEY` and adds a MiniMax model, but every `/v1/messages` call fails asking for an Anthropic key

1. The admin exports `MINIMAX_API_KEY` and adds `minimax/MiniMax-M2.1` to the proxy config
2. A developer points Claude Code at the proxy (`ANTHROPIC_BASE_URL=http://litellm-domain`, `ANTHROPIC_MODEL=minimax-m2.1`) and sends a prompt
3. Claude Code shows `401 litellm.AuthenticationError: Missing Anthropic API Key ... Please set ANTHROPIC_API_KEY or ANTHROPIC_AUTH_TOKEN` and retries until it gives up; the request never leaves the proxy
4. The same POST to http://litellm-domain/v1/messages via curl returns the same local 401

After: the same setup sends the MiniMax key with the request, so the call reaches MiniMax and completes

1. The admin exports `MINIMAX_API_KEY` and adds `minimax/MiniMax-M2.1` to the proxy config
2. The developer sends the same prompt from Claude Code
3. The request arrives at api.minimax.io carrying the key in the `X-Api-Key` header and the completion streams back

## Relevant issues

## Linear ticket

Resolves LIT-6254

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Shared setup for both legs: a live proxy booted with `--num_workers 2`, `MINIMAX_API_KEY=sk-minimax-qa-placeholder` in the proxy env, no `ANTHROPIC_API_KEY`/`ANTHROPIC_AUTH_TOKEN` anywhere, and this config

```yaml
model_list:
  - model_name: minimax-m2.1
    litellm_params:
      model: minimax/MiniMax-M2.1

general_settings:
  master_key: sk-qa-lit6123-8f2c
  forward_llm_provider_auth_headers: true
```

The key is a placeholder because no real MiniMax key was on hand, so After shows MiniMax's own upstream 401 instead of a completion: Before proves the request dies inside the proxy with the env key ignored, After proves the env key is resolved and the request reaches api.minimax.io (a non-attached key would still die locally exactly like Before). The unit test pins the exact `x-api-key` header value. A real-key completion run is pending a human-provided `MINIMAX_API_KEY`

### Before (ace28fd97a)

#### Claude Code, interactive

1. `env -u ANTHROPIC_API_KEY ANTHROPIC_BASE_URL=http://localhost:25849 ANTHROPIC_AUTH_TOKEN=sk-qa-lit6123-8f2c ANTHROPIC_MODEL=minimax-m2.1 claude` in a tmux TUI session, prompt `Reply with only the single word pong`
2. Observed pane:

```
 ▐▛███▛█   Claude Code v2.1.246
▝▜██████▀  minimax-m2.1 with xhigh effort · API Usage Billing
❯ Reply with only the single word pong
✻ 401 litellm.AuthenticationError: Missing Anthropic API Key - A call is being made to anthropic but no key is set either in… · Retrying in 21s · attempt 9/10
```

#### curl /v1/messages

1. `curl -s http://localhost:25849/v1/messages -H "x-api-key: sk-qa-lit6123-8f2c" -H "anthropic-version: 2023-06-01" -H "content-type: application/json" -d '{"model":"minimax-m2.1","max_tokens":32,"messages":[{"role":"user","content":"Reply with only the single word pong"}]}'`
2. Observed output:

```
{"error":{"message":"litellm.AuthenticationError: Missing Anthropic API Key - A call is being made to anthropic but no key is set either in the environment variables or via params. Please set `ANTHROPIC_API_KEY` or `ANTHROPIC_AUTH_TOKEN` in your environment vars. Received Model Group=minimax-m2.1\nAvailable Model Group Fallbacks=None","type":null,"param":null,"code":"401"}}
```

### After (74263bcb23)

#### Claude Code, interactive

1. Same tmux TUI session shape against the after proxy: `env -u ANTHROPIC_API_KEY ANTHROPIC_BASE_URL=http://localhost:45631 ANTHROPIC_AUTH_TOKEN=sk-qa-lit6123-8f2c ANTHROPIC_MODEL=minimax-m2.1 claude`, same prompt
2. Observed pane, the request now reaches MiniMax and comes back with MiniMax's own auth error for the placeholder key:

```
 ▐▛███▛█   Claude Code v2.1.246
▝▜██████▀  minimax-m2.1 with xhigh effort · API Usage Billing
❯ Reply with only the single word pong
✻ 401 litellm.AuthenticationError: MinimaxException - {"type":"error","error":{"type":"authentication_error","message":"login fail: Please carry the API secret key … · Retrying in 10s · attempt 5/10
```

#### curl /v1/messages

1. Same curl against port 45631
2. Observed output, an upstream MiniMax response with a MiniMax request_id instead of the local 401:

```
{"error":{"message":"litellm.AuthenticationError: MinimaxException - {\"type\":\"error\",\"error\":{\"type\":\"authentication_error\",\"message\":\"login fail: Please carry the API secret key in the 'X-Api-Key' field of the request header\"},\"request_id\":\"06de712a0616f5631727297fe08639c9\"}. Received Model Group=minimax-m2.1\nAvailable Model Group Fallbacks=None","type":null,"param":null,"code":"401"}}
```

- Both proxies ran 2 uvicorn workers, same config, same env
- Before leg import origin verified at the merge base worktree, after leg at the PR tip

## Type

🐛 Bug Fix

## Caveats (if any)

### Low

- Real-key completion leg still pending; placeholder key proved attachment path only

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow MiniMax messages auth wiring with tests; no changes to core Anthropic or shared proxy auth beyond this provider override.
> 
> **Overview**
> Fixes MiniMax Anthropic-compatible **`/v1/messages`** calls failing locally with a missing **`ANTHROPIC_API_KEY`** when only **`MINIMAX_API_KEY`** is set.
> 
> **`MinimaxMessagesConfig`** now overrides **`validate_anthropic_messages_environment`** so the parent Anthropic messages path receives an API key from **`get_api_key`** (env **`MINIMAX_API_KEY`**, params, or **`litellm.api_key`**) instead of defaulting to Anthropic env vars. Explicit **`api_key`** still wins over the environment.
> 
> Unit tests assert **`x-api-key`** is set from env-only config and that a passed-in key overrides env.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 74263bcb231e4b439795baf37093bfd9cfe78b37. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

- [x] 74263bcb23 passes /live-pr-risk
