### PR TITLE
fix(gemini-realtime): keep the client's voice on Vertex AI native-audio Live

### DIFF
--- a/litellm/llms/gemini/realtime/transformation.py
+++ b/litellm/llms/gemini/realtime/transformation.py
@@ -5,7 +5,6 @@ This file contains the transformation logic for the Gemini realtime API.
 import json
 from collections import OrderedDict
 from collections.abc import Mapping
-from types import MappingProxyType
 from typing import Any, Final, cast
 
 import litellm
@@ -74,20 +73,26 @@ MAP_GEMINI_FIELD_TO_OPENAI_EVENT: Final[dict[str, OpenAIRealtimeEventTypes | Res
 _KNOWN_GEMINI_TOP_LEVEL_KEYS: Final[set] = {map_key.split(".", 1)[0] for map_key in MAP_GEMINI_FIELD_TO_OPENAI_EVENT}
 
 
-GEMINI_LIVE_VOICE_MAPPINGS: Final[Mapping[str, str]] = MappingProxyType(
-    {
-        "alloy": "Zephyr",
-        "ash": "Charon",
-        "ballad": "Fenrir",
-        "cedar": "Charon",
-        "coral": "Aoede",
-        "echo": "Puck",
-        "marin": "Aoede",
-        "sage": "Kore",
-        "shimmer": "Leda",
-        "verse": "Orus",
-    }
+OPENAI_STOCK_REALTIME_VOICES: Final[frozenset[str]] = frozenset(
+    {"alloy", "ash", "ballad", "cedar", "coral", "echo", "marin", "sage", "shimmer", "verse"}
 )
+
+
+def _gemini_live_speech_config(voice: object) -> Mapping[str, object] | None:
+    """Build the Gemini Live speechConfig for a client-requested voice.
+
+    OpenAI stock voice names have no Gemini equivalent and Gemini Live closes
+    the session on an unknown voice, so they are dropped with a warning and
+    the model keeps its default voice. Every other name is forwarded verbatim.
+    """
+    if isinstance(voice, str) and voice.lower() in OPENAI_STOCK_REALTIME_VOICES:
+        verbose_logger.warning(
+            "Gemini Realtime: voice %s is an OpenAI voice with no Gemini equivalent; "
+            "dropping it so the session keeps the model's default voice.",
+            voice,
+        )
+        return None
+    return VertexGeminiConfig()._map_audio_params({"voice": voice})
 
 
 class GeminiRealtimeConfig(BaseRealtimeConfig):
@@ -307,13 +312,7 @@ class GeminiRealtimeConfig(BaseRealtimeConfig):
                         automaticActivityDetection=transformed_audio_activity_config
                     )
             elif key == "voice":
-                from litellm.llms.vertex_ai.gemini.vertex_and_google_ai_studio_gemini import (
-                    VertexGeminiConfig,
-                )
-
-                vertex_gemini_config = VertexGeminiConfig()
-                gemini_voice = GEMINI_LIVE_VOICE_MAPPINGS.get(value.lower(), value) if isinstance(value, str) else value
-                speech_config = vertex_gemini_config._map_audio_params({"voice": gemini_voice})
+                speech_config = _gemini_live_speech_config(value)
                 if speech_config:
                     optional_params["generationConfig"]["speechConfig"] = speech_config
         if len(optional_params["generationConfig"]) == 0:

--- a/litellm/llms/gemini/realtime/transformation.py
+++ b/litellm/llms/gemini/realtime/transformation.py
@@ -115,13 +115,6 @@ class GeminiRealtimeConfig(BaseRealtimeConfig):
         """Google AI Studio Gemini 3.5+ accepts ``id`` on functionResponses; Vertex AI rejects it."""
         return True
 
-    def _strip_native_audio_speech_config(self) -> bool:
-        """Google AI Studio native-audio Live was never verified to accept ``speechConfig`` on setup.
-
-        Vertex AI accepts it and reads the requested voice.
-        """
-        return True
-
     @staticmethod
     def _usage_detail_alias(details: Any, defaults: dict[str, int]) -> dict[str, Any]:
         if not isinstance(details, dict):
@@ -391,10 +384,6 @@ class GeminiRealtimeConfig(BaseRealtimeConfig):
         return bool(entry.get("gemini_native_audio") or entry.get("gemini_audio_only_live"))
 
     @staticmethod
-    def _is_native_audio_model(model: str) -> bool:
-        return bool(GeminiRealtimeConfig._model_cost_entry(model).get("gemini_native_audio"))
-
-    @staticmethod
     def _coerce_response_modalities(model: str, modalities: list[Any]) -> list[str]:
         """Map unsupported TEXT responseModalities to AUDIO for audio-only Live models."""
         normalized: Final = [
@@ -407,8 +396,8 @@ class GeminiRealtimeConfig(BaseRealtimeConfig):
         without_text: Final = [modality for modality in normalized if modality != "TEXT"]
         return without_text if without_text else ["AUDIO"]
 
-    def _finalize_gemini_live_setup(self, model: str, setup: dict[str, Any]) -> dict[str, Any]:
-        """Drop fields Gemini Live native-audio rejects on ``setup``."""
+    @staticmethod
+    def _finalize_gemini_live_setup(model: str, setup: dict[str, Any]) -> dict[str, Any]:
         generation_config: Final = setup.get("generationConfig")
         if isinstance(generation_config, dict):
             modalities: Final = generation_config.get("responseModalities")
@@ -416,8 +405,6 @@ class GeminiRealtimeConfig(BaseRealtimeConfig):
                 generation_config["responseModalities"] = GeminiRealtimeConfig._coerce_response_modalities(
                     model, modalities
                 )
-            if self._strip_native_audio_speech_config() and GeminiRealtimeConfig._is_native_audio_model(model):
-                generation_config.pop("speechConfig", None)
         return setup
 
     def _handle_session_update(

--- a/litellm/llms/gemini/realtime/transformation.py
+++ b/litellm/llms/gemini/realtime/transformation.py
@@ -4,6 +4,8 @@ This file contains the transformation logic for the Gemini realtime API.
 
 import json
 from collections import OrderedDict
+from collections.abc import Mapping
+from types import MappingProxyType
 from typing import Any, Final, cast
 
 import litellm
@@ -72,6 +74,22 @@ MAP_GEMINI_FIELD_TO_OPENAI_EVENT: Final[dict[str, OpenAIRealtimeEventTypes | Res
 _KNOWN_GEMINI_TOP_LEVEL_KEYS: Final[set] = {map_key.split(".", 1)[0] for map_key in MAP_GEMINI_FIELD_TO_OPENAI_EVENT}
 
 
+GEMINI_LIVE_VOICE_MAPPINGS: Final[Mapping[str, str]] = MappingProxyType(
+    {
+        "alloy": "Zephyr",
+        "ash": "Charon",
+        "ballad": "Fenrir",
+        "cedar": "Charon",
+        "coral": "Aoede",
+        "echo": "Puck",
+        "marin": "Aoede",
+        "sage": "Kore",
+        "shimmer": "Leda",
+        "verse": "Orus",
+    }
+)
+
+
 class GeminiRealtimeConfig(BaseRealtimeConfig):
     _TOOL_CALL_ID_TO_NAME_MAX = 256  # LRU cap for call_id→name mapping
 
@@ -93,7 +111,7 @@ class GeminiRealtimeConfig(BaseRealtimeConfig):
         return True
 
     def _strip_native_audio_speech_config(self) -> bool:
-        """Google AI Studio native-audio Live rejects ``speechConfig`` on setup; Vertex AI accepts it."""
+        """Google AI Studio native-audio Live was never verified to accept ``speechConfig`` on setup; Vertex AI accepts it."""
         return True
 
     @staticmethod
@@ -291,7 +309,8 @@ class GeminiRealtimeConfig(BaseRealtimeConfig):
                 )
 
                 vertex_gemini_config = VertexGeminiConfig()
-                speech_config = vertex_gemini_config._map_audio_params({"voice": value})
+                gemini_voice = GEMINI_LIVE_VOICE_MAPPINGS.get(value.lower(), value) if isinstance(value, str) else value
+                speech_config = vertex_gemini_config._map_audio_params({"voice": gemini_voice})
                 if speech_config:
                     optional_params["generationConfig"]["speechConfig"] = speech_config
         if len(optional_params["generationConfig"]) == 0:

--- a/litellm/llms/gemini/realtime/transformation.py
+++ b/litellm/llms/gemini/realtime/transformation.py
@@ -111,7 +111,10 @@ class GeminiRealtimeConfig(BaseRealtimeConfig):
         return True
 
     def _strip_native_audio_speech_config(self) -> bool:
-        """Google AI Studio native-audio Live was never verified to accept ``speechConfig`` on setup; Vertex AI accepts it."""
+        """Google AI Studio native-audio Live was never verified to accept ``speechConfig`` on setup.
+
+        Vertex AI accepts it and reads the requested voice.
+        """
         return True
 
     @staticmethod

--- a/litellm/llms/gemini/realtime/transformation.py
+++ b/litellm/llms/gemini/realtime/transformation.py
@@ -92,6 +92,10 @@ class GeminiRealtimeConfig(BaseRealtimeConfig):
         """Google AI Studio Gemini 3.5+ accepts ``id`` on functionResponses; Vertex AI rejects it."""
         return True
 
+    def _strip_native_audio_speech_config(self) -> bool:
+        """Google AI Studio native-audio Live rejects ``speechConfig`` on setup; Vertex AI accepts it."""
+        return True
+
     @staticmethod
     def _usage_detail_alias(details: Any, defaults: dict[str, int]) -> dict[str, Any]:
         if not isinstance(details, dict):
@@ -382,8 +386,7 @@ class GeminiRealtimeConfig(BaseRealtimeConfig):
         without_text: Final = [modality for modality in normalized if modality != "TEXT"]
         return without_text if without_text else ["AUDIO"]
 
-    @staticmethod
-    def _finalize_gemini_live_setup(model: str, setup: dict[str, Any]) -> dict[str, Any]:
+    def _finalize_gemini_live_setup(self, model: str, setup: dict[str, Any]) -> dict[str, Any]:
         """Drop fields Gemini Live native-audio rejects on ``setup``."""
         generation_config: Final = setup.get("generationConfig")
         if isinstance(generation_config, dict):
@@ -392,7 +395,7 @@ class GeminiRealtimeConfig(BaseRealtimeConfig):
                 generation_config["responseModalities"] = GeminiRealtimeConfig._coerce_response_modalities(
                     model, modalities
                 )
-            if GeminiRealtimeConfig._is_native_audio_model(model):
+            if self._strip_native_audio_speech_config() and GeminiRealtimeConfig._is_native_audio_model(model):
                 generation_config.pop("speechConfig", None)
         return setup
 

--- a/litellm/llms/vertex_ai/realtime/transformation.py
+++ b/litellm/llms/vertex_ai/realtime/transformation.py
@@ -35,9 +35,6 @@ class VertexAIRealtimeConfig(GeminiRealtimeConfig):
     def _include_function_response_id(self) -> bool:
         return False
 
-    def _strip_native_audio_speech_config(self) -> bool:
-        return False
-
     # ------------------------------------------------------------------
     # URL
     # ------------------------------------------------------------------

--- a/litellm/llms/vertex_ai/realtime/transformation.py
+++ b/litellm/llms/vertex_ai/realtime/transformation.py
@@ -35,6 +35,9 @@ class VertexAIRealtimeConfig(GeminiRealtimeConfig):
     def _include_function_response_id(self) -> bool:
         return False
 
+    def _strip_native_audio_speech_config(self) -> bool:
+        return False
+
     # ------------------------------------------------------------------
     # URL
     # ------------------------------------------------------------------

--- a/tests/test_litellm/llms/gemini/realtime/test_gemini_realtime_transformation.py
+++ b/tests/test_litellm/llms/gemini/realtime/test_gemini_realtime_transformation.py
@@ -1298,8 +1298,7 @@ def test_gemini_realtime_pipecat_ga_session_voice_and_tools(patch_gemini_audio_c
     assert len(messages) == 1
     setup = json.loads(messages[0])["setup"]
     assert setup["generationConfig"]["responseModalities"] == ["AUDIO"]
-    # Native-audio Live rejects speechConfig on setup (see _finalize_gemini_live_setup).
-    assert "speechConfig" not in setup.get("generationConfig", {})
+    assert setup["generationConfig"]["speechConfig"]["voiceConfig"]["prebuiltVoiceConfig"]["voiceName"] == "Kore"
     assert setup["tools"][0]["function_declarations"][0]["name"] == "terminate_call"
     assert setup["realtimeInputConfig"]["automaticActivityDetection"]["disabled"] is False
 
@@ -1841,20 +1840,6 @@ def patch_gemini_audio_cost_map_entries(monkeypatch):
 )
 def test_is_audio_only_live_model_uses_cost_map(model, expected, patch_gemini_audio_cost_map_entries):
     assert GeminiRealtimeConfig._is_audio_only_live_model(model) == expected
-
-
-@pytest.mark.parametrize(
-    "model,expected",
-    [
-        ("gemini-2.5-flash-native-audio-latest", True),
-        ("gemini/gemini-2.5-flash-native-audio-latest", True),
-        ("gemini-3.1-flash-live-preview", False),
-        ("gemini/gemini-3.1-flash-live-preview", False),
-        ("gemini-2.0-flash", False),
-    ],
-)
-def test_is_native_audio_model_uses_cost_map(model, expected, patch_gemini_audio_cost_map_entries):
-    assert GeminiRealtimeConfig._is_native_audio_model(model) == expected
 
 
 def test_is_setup_message_and_is_content_message():

--- a/tests/test_litellm/llms/gemini/realtime/test_gemini_realtime_transformation.py
+++ b/tests/test_litellm/llms/gemini/realtime/test_gemini_realtime_transformation.py
@@ -1865,3 +1865,14 @@ def test_is_setup_message_and_is_content_message():
     assert config.is_content_message({"clientContent": {}}) is True
     assert config.is_content_message({"toolResponse": {}}) is True
     assert config.is_content_message({"setup": {}}) is False
+
+
+def test_map_openai_params_maps_stock_voice_case_insensitively():
+    """Regression: OpenAI stock voices map to Gemini prebuilt voices regardless of casing; unknown names pass through."""
+    cfg = GeminiRealtimeConfig()
+
+    mapped = cfg.map_openai_params(optional_params={}, non_default_params={"voice": "Alloy"})
+    assert mapped["generationConfig"]["speechConfig"]["voiceConfig"]["prebuiltVoiceConfig"]["voiceName"] == "Zephyr"
+
+    passthrough = cfg.map_openai_params(optional_params={}, non_default_params={"voice": "Kore"})
+    assert passthrough["generationConfig"]["speechConfig"]["voiceConfig"]["prebuiltVoiceConfig"]["voiceName"] == "Kore"

--- a/tests/test_litellm/llms/gemini/realtime/test_gemini_realtime_transformation.py
+++ b/tests/test_litellm/llms/gemini/realtime/test_gemini_realtime_transformation.py
@@ -1867,15 +1867,15 @@ def test_is_setup_message_and_is_content_message():
     assert config.is_content_message({"setup": {}}) is False
 
 
-def test_map_openai_params_maps_stock_voice_case_insensitively():
-    """Regression: OpenAI stock voices map to Gemini prebuilt voices regardless of casing.
+def test_map_openai_params_drops_stock_voice_case_insensitively():
+    """Regression: OpenAI stock voices are dropped regardless of casing so Gemini Live keeps its default voice.
 
-    Unknown names pass through verbatim.
+    Non-OpenAI names pass through verbatim.
     """
     cfg = GeminiRealtimeConfig()
 
-    mapped = cfg.map_openai_params(optional_params={}, non_default_params={"voice": "Alloy"})
-    assert mapped["generationConfig"]["speechConfig"]["voiceConfig"]["prebuiltVoiceConfig"]["voiceName"] == "Zephyr"
+    dropped = cfg.map_openai_params(optional_params={}, non_default_params={"voice": "Alloy"})
+    assert "speechConfig" not in dropped.get("generationConfig", {})
 
     passthrough = cfg.map_openai_params(optional_params={}, non_default_params={"voice": "Kore"})
     assert passthrough["generationConfig"]["speechConfig"]["voiceConfig"]["prebuiltVoiceConfig"]["voiceName"] == "Kore"

--- a/tests/test_litellm/llms/gemini/realtime/test_gemini_realtime_transformation.py
+++ b/tests/test_litellm/llms/gemini/realtime/test_gemini_realtime_transformation.py
@@ -1868,7 +1868,10 @@ def test_is_setup_message_and_is_content_message():
 
 
 def test_map_openai_params_maps_stock_voice_case_insensitively():
-    """Regression: OpenAI stock voices map to Gemini prebuilt voices regardless of casing; unknown names pass through."""
+    """Regression: OpenAI stock voices map to Gemini prebuilt voices regardless of casing.
+
+    Unknown names pass through verbatim.
+    """
     cfg = GeminiRealtimeConfig()
 
     mapped = cfg.map_openai_params(optional_params={}, non_default_params={"voice": "Alloy"})

--- a/tests/test_litellm/llms/vertex_ai/realtime/test_vertex_ai_realtime_transformation.py
+++ b/tests/test_litellm/llms/vertex_ai/realtime/test_vertex_ai_realtime_transformation.py
@@ -491,8 +491,8 @@ def test_vertex_native_audio_keeps_requested_voice(patch_native_audio_cost_map_e
     assert generation_config["responseModalities"] == ["AUDIO"]
 
 
-def test_google_ai_studio_native_audio_still_strips_voice(patch_native_audio_cost_map_entry):
-    """Google AI Studio's own native-audio Live is untouched: only Vertex was verified to accept speechConfig."""
+def test_google_ai_studio_native_audio_keeps_requested_voice(patch_native_audio_cost_map_entry):
+    """Regression: AI Studio native-audio Live accepts speechConfig too, so the voice survives on both providers."""
     from litellm.llms.gemini.realtime.transformation import GeminiRealtimeConfig
 
     messages = GeminiRealtimeConfig().transform_realtime_request(
@@ -510,7 +510,7 @@ def test_google_ai_studio_native_audio_still_strips_voice(patch_native_audio_cos
     )
 
     generation_config = json.loads(messages[0])["setup"]["generationConfig"]
-    assert "speechConfig" not in generation_config
+    assert generation_config["speechConfig"]["voiceConfig"]["prebuiltVoiceConfig"]["voiceName"] == "Aoede"
 
 
 def test_vertex_native_audio_drops_openai_stock_voice(patch_native_audio_cost_map_entry):

--- a/tests/test_litellm/llms/vertex_ai/realtime/test_vertex_ai_realtime_transformation.py
+++ b/tests/test_litellm/llms/vertex_ai/realtime/test_vertex_ai_realtime_transformation.py
@@ -15,7 +15,6 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 import websockets.exceptions  # registers websockets.exceptions on the websockets namespace
 
-
 import litellm
 from litellm.llms.vertex_ai.realtime.transformation import VertexAIRealtimeConfig
 
@@ -278,7 +277,7 @@ async def test_vertex_realtime_text_in_text_out():
         SERVER_TURN_COMPLETE,
     ]
 
-    async def _backend_recv(decode=True):  # noqa: ARG001
+    async def _backend_recv(decode=True):
         if not upstream_messages:
             # Signal normal connection close so the loop exits cleanly
             raise websockets.exceptions.ConnectionClosedOK(None, None)  # type: ignore[arg-type]
@@ -512,3 +511,47 @@ def test_google_ai_studio_native_audio_still_strips_voice(patch_native_audio_cos
 
     generation_config = json.loads(messages[0])["setup"]["generationConfig"]
     assert "speechConfig" not in generation_config
+
+
+def test_vertex_native_audio_maps_openai_stock_voice(patch_native_audio_cost_map_entry):
+    """Regression: OpenAI stock voice names must be mapped, not forwarded verbatim.
+
+    Vertex Live closes the socket with 1007 on an unknown voice name, so a
+    client sending OpenAI's default voice would lose the session entirely.
+    """
+    cfg = VertexAIRealtimeConfig(
+        access_token="tok", project="my-proj", location="us-central1"
+    )
+    session_update = {
+        "type": "session.update",
+        "session": {"audio": {"output": {"voice": "alloy"}}},
+    }
+
+    messages = cfg.transform_realtime_request(
+        json.dumps(session_update),
+        _NATIVE_AUDIO_MODEL,
+        session_configuration_request=None,
+    )
+
+    generation_config = json.loads(messages[0])["setup"]["generationConfig"]
+    assert generation_config["speechConfig"]["voiceConfig"]["prebuiltVoiceConfig"]["voiceName"] == "Zephyr"
+
+
+def test_vertex_native_audio_unmapped_voice_passes_through(patch_native_audio_cost_map_entry):
+    """A voice name outside the OpenAI stock set is forwarded verbatim so Gemini-native names keep working."""
+    cfg = VertexAIRealtimeConfig(
+        access_token="tok", project="my-proj", location="us-central1"
+    )
+    session_update = {
+        "type": "session.update",
+        "session": {"audio": {"output": {"voice": "Kore"}}},
+    }
+
+    messages = cfg.transform_realtime_request(
+        json.dumps(session_update),
+        _NATIVE_AUDIO_MODEL,
+        session_configuration_request=None,
+    )
+
+    generation_config = json.loads(messages[0])["setup"]["generationConfig"]
+    assert generation_config["speechConfig"]["voiceConfig"]["prebuiltVoiceConfig"]["voiceName"] == "Kore"

--- a/tests/test_litellm/llms/vertex_ai/realtime/test_vertex_ai_realtime_transformation.py
+++ b/tests/test_litellm/llms/vertex_ai/realtime/test_vertex_ai_realtime_transformation.py
@@ -513,11 +513,12 @@ def test_google_ai_studio_native_audio_still_strips_voice(patch_native_audio_cos
     assert "speechConfig" not in generation_config
 
 
-def test_vertex_native_audio_maps_openai_stock_voice(patch_native_audio_cost_map_entry):
-    """Regression: OpenAI stock voice names must be mapped, not forwarded verbatim.
+def test_vertex_native_audio_drops_openai_stock_voice(patch_native_audio_cost_map_entry):
+    """Regression: OpenAI stock voice names must be dropped, not forwarded verbatim.
 
     Vertex Live closes the socket with 1007 on an unknown voice name, so a
     client sending OpenAI's default voice would lose the session entirely.
+    Dropping the voice keeps the session alive on the model's default voice.
     """
     cfg = VertexAIRealtimeConfig(
         access_token="tok", project="my-proj", location="us-central1"
@@ -534,7 +535,7 @@ def test_vertex_native_audio_maps_openai_stock_voice(patch_native_audio_cost_map
     )
 
     generation_config = json.loads(messages[0])["setup"]["generationConfig"]
-    assert generation_config["speechConfig"]["voiceConfig"]["prebuiltVoiceConfig"]["voiceName"] == "Zephyr"
+    assert "speechConfig" not in generation_config
 
 
 def test_vertex_native_audio_unmapped_voice_passes_through(patch_native_audio_cost_map_entry):

--- a/tests/test_litellm/llms/vertex_ai/realtime/test_vertex_ai_realtime_transformation.py
+++ b/tests/test_litellm/llms/vertex_ai/realtime/test_vertex_ai_realtime_transformation.py
@@ -462,3 +462,53 @@ def test_vertex_function_call_output_omits_id():
     assert "id" not in function_response
     assert function_response["name"] == "terminate_call"
     assert function_response["response"] == {"status": "ok"}
+
+
+def test_vertex_native_audio_keeps_requested_voice(patch_native_audio_cost_map_entry):
+    """Regression: Vertex Live accepts speechConfig on native audio, so the client's voice must survive.
+
+    Stripping it silently dropped voice selection for every Vertex native-audio
+    session. TEXT is still coerced away, which Vertex does reject.
+    """
+    cfg = VertexAIRealtimeConfig(
+        access_token="tok", project="my-proj", location="us-central1"
+    )
+    session_update = {
+        "type": "session.update",
+        "session": {
+            "output_modalities": ["text"],
+            "audio": {"output": {"voice": "Aoede"}},
+        },
+    }
+
+    messages = cfg.transform_realtime_request(
+        json.dumps(session_update),
+        _NATIVE_AUDIO_MODEL,
+        session_configuration_request=None,
+    )
+
+    generation_config = json.loads(messages[0])["setup"]["generationConfig"]
+    assert generation_config["speechConfig"]["voiceConfig"]["prebuiltVoiceConfig"]["voiceName"] == "Aoede"
+    assert generation_config["responseModalities"] == ["AUDIO"]
+
+
+def test_google_ai_studio_native_audio_still_strips_voice(patch_native_audio_cost_map_entry):
+    """Google AI Studio's own native-audio Live is untouched: only Vertex was verified to accept speechConfig."""
+    from litellm.llms.gemini.realtime.transformation import GeminiRealtimeConfig
+
+    messages = GeminiRealtimeConfig().transform_realtime_request(
+        json.dumps(
+            {
+                "type": "session.update",
+                "session": {
+                    "output_modalities": ["audio"],
+                    "audio": {"output": {"voice": "Aoede"}},
+                },
+            }
+        ),
+        _NATIVE_AUDIO_MODEL,
+        session_configuration_request=None,
+    )
+
+    generation_config = json.loads(messages[0])["setup"]["generationConfig"]
+    assert "speechConfig" not in generation_config


### PR DESCRIPTION
## TLDR

Problem this solves:

- Gemini and Vertex native-audio Live silently ignored the client's requested voice
- The old `speechConfig` strip rested on a false premise: live probes show both providers accept it on setup
- OpenAI stock voice names like `alloy` (the default an OpenAI-compatible client sends) would kill the session with an unpropagated 1007

How it solves it:

- Remove the native-audio `speechConfig` strip on both providers, so the client's voice reaches the model (adopted from #36885, extended to Google AI Studio after probing every flagged model)
- Drop the ten OpenAI stock realtime voice names, which have no Gemini equivalent, with a warning so the session survives on the model's default voice
- Every other voice name is forwarded verbatim and stays the caller's choice

## User Flow

Before: a developer whose voice agent asks for a Gemini voice always hears the model's default voice, with no hint the request was ignored

1. They point their OpenAI-SDK realtime client at `wss://litellm-domain/v1/realtime?model=vertex-gemini-native-audio` (gateway running with `LITELLM_GEMINI_LIVE_DEFER_SETUP=true`) and receive `session.created`
2. They send `{"type":"session.update","session":{"audio":{"output":{"voice":"Charon"}}}}`, then a user message and `{"type":"response.create"}`
3. Audio deltas arrive and `response.done` closes the turn, but the speech is the model's default voice, not Charon
4. Any voice name at all, `alloy` or even a misspelled one, behaves exactly the same, so misconfigurations pass silently

After: the same session speaks in the requested voice, and an OpenAI voice name degrades gracefully to the default voice

1. They point their OpenAI-SDK realtime client at `wss://litellm-domain/v1/realtime?model=vertex-gemini-native-audio` (gateway running with `LITELLM_GEMINI_LIVE_DEFER_SETUP=true`) and receive `session.created`
2. They send `{"type":"session.update","session":{"audio":{"output":{"voice":"Charon"}}}}`, then a user message and `{"type":"response.create"}`
3. The audio deltas that arrive are audibly Charon, a deep voice clearly distinct from the default
4. With `"voice":"alloy"` the gateway drops the name Gemini doesn't know and the session answers normally in the default voice instead of dying
5. The same holds on a Google AI Studio native-audio model (`gemini/gemini-2.5-flash-native-audio-preview-09-2025`)

## Relevant issues

Adopts #36885 by @marty-sullivan and supersedes it; his commit is preserved as authored. Mirrored onto a `litellm_` branch so CircleCI and the internal lint workflow run

## Linear ticket

Resolves LIT-6280

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Real Live sessions over `/v1/realtime`, no mocks: a local proxy booted from each commit with `LITELLM_GEMINI_LIVE_DEFER_SETUP=true` and 2 uvicorn workers, real Vertex AI (`vertex_ai/gemini-live-2.5-flash-preview-native-audio-09-2025`, us-central1) and real Google AI Studio (`gemini/gemini-2.5-flash-native-audio-preview-09-2025`). The client is the OpenAI Python SDK's realtime client, driven the way an end user writes it, and it measures the median pitch of the audio it hears, so honored vs ignored is audible and objective (Charon is a deep male voice, Aoede a female one; the default sits near 180-200 Hz):

```python
async with client.realtime.connect(model="vertex-native") as conn:
    await conn.session.update(session={"type": "realtime", "output_modalities": ["audio"],
                                       "audio": {"output": {"voice": voice}}})
    await conn.conversation.item.create(item={"type": "message", "role": "user",
        "content": [{"type": "input_text", "text": "Count from one to ten slowly."}]})
    await conn.response.create()
    # collect *audio.delta events until response.done, then report count, length, median pitch
```

### Before (ace28fd97a)

#### Vertex AI native-audio Live

1. `python realtime_voice_qa.py 52706 vertex-native Aoede,Charon,alloy,NotARealVoice1 before`
2. Every voice "works" and sounds the same; the deep voice Charon comes back at the default pitch:

```
before vertex-native voice=Aoede           -> 51 audio deltas, response.done, 13.2s audio, median pitch 200.0 Hz
before vertex-native voice=Charon          -> 50 audio deltas, response.done, 13.2s audio, median pitch 183.2 Hz
before vertex-native voice=alloy           -> 49 audio deltas, response.done, 12.6s audio, median pitch 199.2 Hz
before vertex-native voice=NotARealVoice1  -> 47 audio deltas, response.done, 13.0s audio, median pitch 184.6 Hz
```

#### Google AI Studio native-audio Live

1. `python realtime_voice_qa.py 52706 gemini-native Aoede,Charon,alloy,NotARealVoice1 before`
2. Same silent discard; three of the four runs return byte-identical audio, so the setup Gemini saw was identical regardless of the requested voice:

```
before gemini-native voice=Aoede           -> 366 audio deltas, response.done, 15.6s audio, median pitch 186.0 Hz
before gemini-native voice=Charon          -> 296 audio deltas, response.done, 12.8s audio, median pitch 181.8 Hz
before gemini-native voice=alloy           -> 296 audio deltas, response.done, 12.8s audio, median pitch 181.8 Hz
before gemini-native voice=NotARealVoice1  -> 296 audio deltas, response.done, 12.8s audio, median pitch 181.8 Hz
```

### After (aabbc3204b)

#### Vertex AI native-audio Live

1. `python realtime_voice_qa.py 59698 vertex-native Aoede,Charon,alloy,NotARealVoice1 after`
2. Charon now speaks at 94 Hz (audibly a deep male voice), alloy is dropped and the session survives on the default voice, and the misspelled name visibly reaches Vertex, which rejects it:

```
after vertex-native voice=Aoede           -> 53 audio deltas, response.done, 14.0s audio, median pitch 172.7 Hz
after vertex-native voice=Charon          -> 49 audio deltas, response.done, 12.8s audio, median pitch 94.3 Hz
after vertex-native voice=alloy           -> 45 audio deltas, response.done, 12.0s audio, median pitch 206.9 Hz
after vertex-native voice=NotARealVoice1  -> HANG: no response within 45s (0 audio deltas so far)
```

#### Google AI Studio native-audio Live

1. `python realtime_voice_qa.py 59698 gemini-native Aoede,Charon,alloy,NotARealVoice1 after`
2. Same on AI Studio: the requested voice is honored there too

```
after gemini-native voice=Aoede           -> 379 audio deltas, response.done, 16.1s audio, median pitch 177.1 Hz
after gemini-native voice=Charon          -> 328 audio deltas, response.done, 14.0s audio, median pitch 131.1 Hz
after gemini-native voice=alloy           -> 533 audio deltas, response.done, 22.2s audio, median pitch 177.1 Hz
after gemini-native voice=NotARealVoice1  -> HANG: no response within 45s (0 audio deltas so far)
```

Direct-to-provider probes with no LiteLLM in the path, run against every `gemini_native_audio` model in the cost map on both providers, confirm the strip's premise was false everywhere: `setup` with a valid prebuilt voice returns `setupComplete`, and only unknown voice names are rejected (`1007 Invalid voice name` / `Requested voice api_name ... is not available`)

Observations from the run:

- Bogus voice rejection surfaces as client-side hang; pre-existing, unchanged
- Before leg: AI Studio audio byte-identical across requested voices
- Cost-map id `gemini/gemini-live-2.5-flash-preview-native-audio-09-2025` does not exist upstream

## Type

🐛 Bug Fix

## Caveats (if any)

### Medium

- Voice selection needs `LITELLM_GEMINI_LIVE_DEFER_SETUP=true`; default-mode auto-setup still wins (pre-existing)
- A bogus voice now hangs the session instead of being ignored; the backend 1007 close is swallowed (pre-existing gap in the stream bridge, untouched here)

### Low

- OpenAI stock voices are now dropped, with a warning, on every Gemini/Vertex Live model
  - Live-checked on `gemini/gemini-3.1-flash-live-preview`: `alloy` hung the session before (backend 1011 swallowed), now completes on the default voice
- Cost-map entry `gemini/gemini-live-2.5-flash-preview-native-audio-09-2025` names a model AI Studio does not serve (probe: 1008 not found); left alone

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

- [x] aabbc3204b51e9ea7f35e2b4fc0ec3027b167a40 passes /live-pr-risk

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes realtime session setup for Gemini/Vertex Live (voice and speechConfig), which can affect live WebSocket sessions; scope is limited to transformation logic with strong regression tests.
> 
> **Overview**
> Fixes **silent voice ignoring** on Gemini and Vertex **native-audio Live** by removing the setup step that stripped `speechConfig` for those models. Client-requested voices (e.g. Kore, Aoede, Charon) now reach `generationConfig.speechConfig` on both Google AI Studio and Vertex.
> 
> Adds **`_gemini_live_speech_config`**, which maps voices through existing `VertexGeminiConfig._map_audio_params` but **drops the ten OpenAI stock realtime voice names** (case-insensitive, with a warning) so Gemini/Vertex do not close the session on unknown names like `alloy`. **TEXT** modality coercion for audio-only Live models is unchanged.
> 
> Tests cover stock-voice dropping, Gemini-native passthrough, and Vertex/AI Studio session.update voice survival.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aabbc3204b51e9ea7f35e2b4fc0ec3027b167a40. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
