### PR TITLE
feat(zai): add glm-5.2 and glm-5.3 model pricing

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -44251,6 +44251,36 @@
         "supports_tool_choice": true,
         "source": "https://docs.z.ai/guides/overview/pricing"
     },
+    "zai/glm-5.2": {
+        "cache_creation_input_token_cost": 0,
+        "cache_read_input_token_cost": 2.6e-07,
+        "input_cost_per_token": 1.4e-06,
+        "output_cost_per_token": 4.4e-06,
+        "litellm_provider": "zai",
+        "max_input_tokens": 1048576,
+        "max_output_tokens": 128000,
+        "mode": "chat",
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true,
+        "source": "https://docs.z.ai/guides/overview/pricing"
+    },
+    "zai/glm-5.3": {
+        "cache_creation_input_token_cost": 0,
+        "cache_read_input_token_cost": 2.6e-07,
+        "input_cost_per_token": 1.4e-06,
+        "output_cost_per_token": 4.4e-06,
+        "litellm_provider": "zai",
+        "max_input_tokens": 1048576,
+        "max_output_tokens": 128000,
+        "mode": "chat",
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true,
+        "source": "https://docs.z.ai/guides/overview/pricing"
+    },
     "zai/glm-5-code": {
         "cache_creation_input_token_cost": 0,
         "cache_read_input_token_cost": 3e-07,

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -44251,6 +44251,36 @@
         "supports_tool_choice": true,
         "source": "https://docs.z.ai/guides/overview/pricing"
     },
+    "zai/glm-5.2": {
+        "cache_creation_input_token_cost": 0,
+        "cache_read_input_token_cost": 2.6e-07,
+        "input_cost_per_token": 1.4e-06,
+        "output_cost_per_token": 4.4e-06,
+        "litellm_provider": "zai",
+        "max_input_tokens": 1048576,
+        "max_output_tokens": 128000,
+        "mode": "chat",
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true,
+        "source": "https://docs.z.ai/guides/overview/pricing"
+    },
+    "zai/glm-5.3": {
+        "cache_creation_input_token_cost": 0,
+        "cache_read_input_token_cost": 2.6e-07,
+        "input_cost_per_token": 1.4e-06,
+        "output_cost_per_token": 4.4e-06,
+        "litellm_provider": "zai",
+        "max_input_tokens": 1048576,
+        "max_output_tokens": 128000,
+        "mode": "chat",
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true,
+        "source": "https://docs.z.ai/guides/overview/pricing"
+    },
     "zai/glm-5-code": {
         "cache_creation_input_token_cost": 0,
         "cache_read_input_token_cost": 3e-07,

--- a/tests/test_litellm/test_zai_glm_5_2_5_3_model_metadata.py
+++ b/tests/test_litellm/test_zai_glm_5_2_5_3_model_metadata.py
@@ -1,0 +1,101 @@
+import json
+from pathlib import Path
+
+import pytest
+
+import litellm
+from litellm.litellm_core_utils.get_llm_provider_logic import get_llm_provider
+from litellm.types.utils import PromptTokensDetailsWrapper, Usage
+from litellm.utils import supports_prompt_caching, supports_reasoning
+
+REPO_ROOT = Path(__file__).parents[2]
+MAIN_PATH = REPO_ROOT / "model_prices_and_context_window.json"
+BACKUP_PATH = REPO_ROOT / "litellm" / "model_prices_and_context_window_backup.json"
+
+GLM_MODELS = ("zai/glm-5.2", "zai/glm-5.3")
+
+INPUT_COST = 1.4e-06
+CACHED_INPUT_COST = 2.6e-07
+OUTPUT_COST = 4.4e-06
+
+
+def _load(path):
+    with open(path) as f:
+        return json.load(f)
+
+
+@pytest.fixture
+def local_model_cost_map(monkeypatch):
+    """Force get_model_info to resolve against the in-repo cost map instead of the
+    remote one fetched at import time, which still carries the pre-merge pricing."""
+    monkeypatch.setenv("LITELLM_LOCAL_MODEL_COST_MAP", "True")
+    monkeypatch.setattr(litellm, "model_cost", litellm.get_model_cost_map(url=""))
+    litellm.get_model_info.cache_clear()
+    yield
+    litellm.get_model_info.cache_clear()
+
+
+@pytest.mark.parametrize("model", GLM_MODELS)
+def test_zai_glm_5_2_and_5_3_specs(model):
+    info = _load(MAIN_PATH).get(model)
+    assert info is not None, f"{model} missing from model_prices_and_context_window.json"
+
+    assert info["litellm_provider"] == "zai"
+    assert info["mode"] == "chat"
+
+    assert info["input_cost_per_token"] == INPUT_COST
+    assert info["output_cost_per_token"] == OUTPUT_COST
+    assert info["cache_read_input_token_cost"] == CACHED_INPUT_COST
+    assert info["cache_creation_input_token_cost"] == 0
+
+    assert info["max_input_tokens"] == 1048576
+    assert info["max_output_tokens"] == 128000
+
+    assert info["supports_function_calling"] is True
+    assert info["supports_prompt_caching"] is True
+    assert info["supports_reasoning"] is True
+    assert info["supports_tool_choice"] is True
+
+    routed_model, provider, _, _ = get_llm_provider(model=model)
+    assert routed_model == model.split("/", 1)[1]
+    assert provider == "zai"
+
+
+@pytest.mark.parametrize("model", GLM_MODELS)
+def test_zai_glm_capabilities_are_visible_to_callers(local_model_cost_map, model):
+    """Z.ai advertises reasoning and context caching on both models, so the helpers
+    every caller checks before sending a request must say so too."""
+    assert supports_reasoning(model=model) is True
+    assert supports_prompt_caching(model=model) is True
+
+    info = litellm.get_model_info(model=model)
+    assert info["max_input_tokens"] == 1048576
+    assert info["max_output_tokens"] == 128000
+
+
+@pytest.mark.parametrize("model", GLM_MODELS)
+def test_cached_prompt_tokens_bill_at_the_cached_rate(local_model_cost_map, model):
+    """A cache hit reports its reused tokens under prompt_tokens_details, and those
+    tokens cost $0.26 per million rather than the full $1.40 input rate."""
+    usage = Usage(
+        prompt_tokens=21010,
+        completion_tokens=100,
+        total_tokens=21110,
+        prompt_tokens_details=PromptTokensDetailsWrapper(cached_tokens=20992),
+    )
+
+    prompt_cost, completion_cost = litellm.cost_per_token(
+        model=model, usage_object=usage, custom_llm_provider="zai"
+    )
+
+    assert prompt_cost == pytest.approx(18 * INPUT_COST + 20992 * CACHED_INPUT_COST)
+    assert completion_cost == pytest.approx(100 * OUTPUT_COST)
+
+
+@pytest.mark.parametrize("model", GLM_MODELS)
+def test_backup_matches_main(model):
+    """Ensure the bundled (backup) cost map stays in sync with the canonical file."""
+    main_cost = _load(MAIN_PATH)
+    backup_cost = _load(BACKUP_PATH)
+
+    assert backup_cost.get(model) == main_cost.get(model), f"{model} differs between main and backup model cost maps"


### PR DESCRIPTION
## TLDR

Problem this solves:

- Z.ai serves GLM-5.2 and GLM-5.3 on its own API, litellm's `zai` cost map stops at `glm-5.1`
- Every call to either model is logged at $0, so budgets scoped to them never apply
- Resellers already carry these models (`azure_ai/FW-GLM-5.2`, `together_ai/zai-org/GLM-5.2`, `dashscope/glm-5.2`, `cloudflare/@cf/zai-org/glm-5.2`), so only the direct `zai` bucket was missing

How it solves it:

- Adds `zai/glm-5.2` and `zai/glm-5.3` with Z.ai's published prices
- Prices cached input at $0.26 per million, matching the rate Z.ai lists alongside the other GLM 5 models
- Takes the 1M context window and 128K max output from Z.ai's per-model docs
- Adds a test pinning every number to the in-repo map

Prices, from https://docs.z.ai/guides/overview/pricing:

| Model | Input | Cached input | Output |
|---|---|---|---|
| GLM-5.3 | $1.40 | $0.26 | $4.40 |
| GLM-5.2 | $1.40 | $0.26 | $4.40 |

Both match `zai/glm-5.1`, which is already in the map at the same rates.

## User Flow

Before: a developer pointing their app at Z.ai's GLM-5.3 gets every request logged at zero spend, so their cost dashboard and their budgets are blind to the model

1. They add a deployment for `zai/glm-5.3` and send POST https://litellm-domain/v1/chat/completions
2. The completion comes back fine, but the response carries `x-litellm-response-cost-original: 0.0`
3. They call GET https://litellm-domain/model/info?model=glm-5.3 and every field they need is empty: `max_input_tokens` null, `input_cost_per_token` 0, `cache_read_input_token_cost` null, `supports_reasoning` null
4. They try `zai/glm-5.2` and get the same empty metadata and the same $0
5. They open https://litellm-domain/ui/?page=logs and see the requests at $0 spend, so a key or team budget scoped to these models can never be exceeded

After: the same requests are priced correctly, and a cache hit visibly costs a fraction of a cold call

1. They add the same deployment and send the same POST https://litellm-domain/v1/chat/completions
2. The response now carries a real `x-litellm-response-cost`, billing input at $1.40 per million
3. On a cache hit the reused tokens bill at $0.26 per million rather than the full input rate
4. GET https://litellm-domain/model/info?model=glm-5.3 returns `max_input_tokens` 1048576, `max_output_tokens` 128000, `input_cost_per_token` 0.0000014, `cache_read_input_token_cost` 2.6e-07, and `supports_reasoning` true
5. `zai/glm-5.2` returns the same metadata and prices identically
6. https://litellm-domain/ui/?page=logs shows real spend on both requests, so key and team budgets now apply to these models

## Testing

`tests/test_litellm/test_zai_glm_5_2_5_3_model_metadata.py` covers both models:

- every price, limit and capability flag pinned against the in-repo map
- `get_llm_provider` routes both to the `zai` provider
- `supports_reasoning` / `supports_prompt_caching` report true to callers
- a cache hit bills reused tokens at the cached rate, not the input rate and not nothing
- the bundled backup cost map stays in sync with the canonical file

```
8 passed
```

## Relevant issues

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)
