### PR TITLE
fix: forward image content lists to DeepSeek vision models

### DIFF
--- a/litellm/llms/deepseek/chat/transformation.py
+++ b/litellm/llms/deepseek/chat/transformation.py
@@ -179,10 +179,20 @@ class DeepSeekChatConfig(OpenAIGPTConfig):
             return False
         block_type: Final = block.get("type")
         if block_type == "image_url":
-            return block.get("image_url") is not None
+            return DeepSeekChatConfig._is_image_url_payload(block.get("image_url"))
         if block_type == "text":
             return isinstance(block.get("text"), str)
         return False
+
+    @staticmethod
+    def _is_image_url_payload(payload: object) -> bool:
+        """A url string or an object carrying one, per the OpenAI image_url shape."""
+        if isinstance(payload, str):
+            return bool(payload)
+        if not isinstance(payload, Mapping):
+            return False
+        url: Final = payload.get("url")
+        return isinstance(url, str) and bool(url)
 
     def _with_search_results_text_block(self, message: AllMessageValues, content: Sequence[object]) -> AllMessageValues:
         """

--- a/litellm/llms/deepseek/chat/transformation.py
+++ b/litellm/llms/deepseek/chat/transformation.py
@@ -2,16 +2,17 @@
 Translates from OpenAI's `/v1/chat/completions` to DeepSeek's `/v1/chat/completions`
 """
 
-from collections.abc import Coroutine
+from collections.abc import Coroutine, Mapping, Sequence
 from typing import Any, Final, Literal, cast, overload
 
 import litellm
 from litellm.litellm_core_utils.prompt_templates.common_utils import (
-    handle_messages_with_content_list_to_str_conversion,
+    convert_content_list_to_str,
+    extract_search_results_text,
 )
 from litellm.secret_managers.main import get_secret_str
 from litellm.types.llms.openai import AllMessageValues
-from litellm.utils import supports_reasoning
+from litellm.utils import supports_reasoning, supports_vision
 
 from ...openai.chat.gpt_transformation import OpenAIGPTConfig
 
@@ -117,13 +118,88 @@ class DeepSeekChatConfig(OpenAIGPTConfig):
         self, messages: list[AllMessageValues], model: str, is_async: bool = False
     ) -> list[AllMessageValues] | Coroutine[Any, Any, list[AllMessageValues]]:
         """
-        DeepSeek does not support content in list format.
+        DeepSeek vision models accept image_url content blocks in user
+        messages (https://api-docs.deepseek.com/guides/vision), so those
+        content lists are forwarded as-is, with any search_results text
+        appended as a trailing text block. Every other message keeps the
+        historical string collapse (which also folds search_results text
+        into string content); a list with no extractable text stays
+        unchanged, matching what DeepSeek historically received.
         """
-        messages = handle_messages_with_content_list_to_str_conversion(messages)
+        forward_images: Final = any(
+            isinstance(message.get("content"), list) for message in messages
+        ) and supports_vision(model=model, custom_llm_provider="deepseek")
+        transformed: Final = [  # mutable-ok: provider messages must stay JSON-array lists the base transform mutates
+            self._forward_or_collapse_content(message=message, forward_images=forward_images) for message in messages
+        ]
+
         if is_async:
-            return super()._transform_messages(messages=messages, model=model, is_async=True)
+            return super()._transform_messages(messages=transformed, model=model, is_async=True)
         else:
-            return super()._transform_messages(messages=messages, model=model, is_async=False)
+            return super()._transform_messages(messages=transformed, model=model, is_async=False)
+
+    def _forward_or_collapse_content(self, message: AllMessageValues, forward_images: bool) -> AllMessageValues:
+        """
+        Returns the vision-forwardable message with any search_results text
+        appended as a text block; every other message keeps the historical
+        string collapse, which extracts the text from a content list and
+        folds search_results text into string content.
+        """
+        content: Final = message.get("content")
+        if (
+            forward_images
+            and isinstance(content, list)
+            and self._is_vision_forwardable_content(message=message, content=content)
+        ):
+            return self._with_search_results_text_block(message=message, content=content)
+        collapsed: Final = convert_content_list_to_str(message=message)
+        if not collapsed or collapsed == content:
+            return message
+        collapsed_message: Final = {**message, "content": collapsed}  # mutable-ok: wire messages are plain JSON dicts
+        return cast(AllMessageValues, collapsed_message)  # cast-ok: TypedDict spread narrows to dict
+
+    def _is_vision_forwardable_content(self, message: AllMessageValues, content: Sequence[object]) -> bool:
+        """
+        True only for a user message whose content list holds well-formed
+        text and image_url blocks with at least one image; a block missing
+        its payload falls back to the string collapse instead of crashing
+        or reaching the wire malformed. The model capability gate lives in
+        the caller.
+        """
+        if message.get("role") != "user":
+            return False
+        if not all(self._is_forwardable_block(block) for block in content):
+            return False
+        return any(isinstance(block, dict) and block.get("type") == "image_url" for block in content)
+
+    @staticmethod
+    def _is_forwardable_block(block: object) -> bool:
+        """A dict block typed text or image_url that carries its payload."""
+        if not isinstance(block, dict):
+            return False
+        block_type: Final = block.get("type")
+        if block_type == "image_url":
+            return block.get("image_url") is not None
+        if block_type == "text":
+            return isinstance(block.get("text"), str)
+        return False
+
+    def _with_search_results_text_block(self, message: AllMessageValues, content: Sequence[object]) -> AllMessageValues:
+        """
+        Appends the message's search_results text as a trailing text block,
+        keeping the context that the string collapse used to fold in, and
+        drops the non-OpenAI search_results key from the wire message.
+        """
+        message_fields: Final = cast(Mapping[str, object], message)  # cast-ok: search_results is not on the TypedDicts
+        search_text: Final = extract_search_results_text(message_fields.get("search_results"))
+        if not search_text:
+            return message
+        forwarded_content: Final = [*content, {"type": "text", "text": search_text}]  # mutable-ok: JSON-array content
+        forwarded: Final = {  # mutable-ok: wire messages are plain JSON dicts
+            **{key: value for key, value in message_fields.items() if key != "search_results"},
+            "content": forwarded_content,
+        }
+        return cast(AllMessageValues, forwarded)  # cast-ok: TypedDict spread narrows to dict
 
     def _thinking_mode_active(self, model: str, optional_params: dict) -> bool:
         """

--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -50413,6 +50413,32 @@
         "supports_tool_choice": true,
         "supports_vision": false
     },
+    "deepseek-v4-flash-vision-exp": {
+        "cache_creation_input_token_cost": 0.0,
+        "cache_read_input_token_cost": 1.4e-08,
+        "input_cost_per_token": 4.4e-07,
+        "input_cost_per_token_cache_hit": 1.4e-08,
+        "litellm_provider": "deepseek",
+        "max_input_tokens": 1000000,
+        "max_output_tokens": 393216,
+        "max_tokens": 393216,
+        "mode": "chat",
+        "output_cost_per_token": 1.32e-06,
+        "source": "https://api-docs.deepseek.com/quick_start/pricing",
+        "supported_endpoints": [
+            "/v1/chat/completions"
+        ],
+        "supports_assistant_prefill": true,
+        "supports_function_calling": true,
+        "supports_native_streaming": true,
+        "supports_parallel_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_vision": true
+    },
     "deepseek-v4-pro": {
         "cache_creation_input_token_cost": 0.0,
         "cache_read_input_token_cost": 4.4e-08,
@@ -50464,6 +50490,32 @@
         "supports_system_messages": true,
         "supports_tool_choice": true,
         "supports_vision": false
+    },
+    "deepseek/deepseek-v4-flash-vision-exp": {
+        "cache_creation_input_token_cost": 0.0,
+        "cache_read_input_token_cost": 1.4e-08,
+        "input_cost_per_token": 4.4e-07,
+        "input_cost_per_token_cache_hit": 1.4e-08,
+        "litellm_provider": "deepseek",
+        "max_input_tokens": 1000000,
+        "max_output_tokens": 393216,
+        "max_tokens": 393216,
+        "mode": "chat",
+        "output_cost_per_token": 1.32e-06,
+        "source": "https://api-docs.deepseek.com/quick_start/pricing",
+        "supported_endpoints": [
+            "/v1/chat/completions"
+        ],
+        "supports_assistant_prefill": true,
+        "supports_function_calling": true,
+        "supports_native_streaming": true,
+        "supports_parallel_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_vision": true
     },
     "deepseek/deepseek-v4-pro": {
         "cache_creation_input_token_cost": 0.0,

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -50413,6 +50413,32 @@
         "supports_tool_choice": true,
         "supports_vision": false
     },
+    "deepseek-v4-flash-vision-exp": {
+        "cache_creation_input_token_cost": 0.0,
+        "cache_read_input_token_cost": 1.4e-08,
+        "input_cost_per_token": 4.4e-07,
+        "input_cost_per_token_cache_hit": 1.4e-08,
+        "litellm_provider": "deepseek",
+        "max_input_tokens": 1000000,
+        "max_output_tokens": 393216,
+        "max_tokens": 393216,
+        "mode": "chat",
+        "output_cost_per_token": 1.32e-06,
+        "source": "https://api-docs.deepseek.com/quick_start/pricing",
+        "supported_endpoints": [
+            "/v1/chat/completions"
+        ],
+        "supports_assistant_prefill": true,
+        "supports_function_calling": true,
+        "supports_native_streaming": true,
+        "supports_parallel_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_vision": true
+    },
     "deepseek-v4-pro": {
         "cache_creation_input_token_cost": 0.0,
         "cache_read_input_token_cost": 4.4e-08,
@@ -50464,6 +50490,32 @@
         "supports_system_messages": true,
         "supports_tool_choice": true,
         "supports_vision": false
+    },
+    "deepseek/deepseek-v4-flash-vision-exp": {
+        "cache_creation_input_token_cost": 0.0,
+        "cache_read_input_token_cost": 1.4e-08,
+        "input_cost_per_token": 4.4e-07,
+        "input_cost_per_token_cache_hit": 1.4e-08,
+        "litellm_provider": "deepseek",
+        "max_input_tokens": 1000000,
+        "max_output_tokens": 393216,
+        "max_tokens": 393216,
+        "mode": "chat",
+        "output_cost_per_token": 1.32e-06,
+        "source": "https://api-docs.deepseek.com/quick_start/pricing",
+        "supported_endpoints": [
+            "/v1/chat/completions"
+        ],
+        "supports_assistant_prefill": true,
+        "supports_function_calling": true,
+        "supports_native_streaming": true,
+        "supports_parallel_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_vision": true
     },
     "deepseek/deepseek-v4-pro": {
         "cache_creation_input_token_cost": 0.0,

--- a/tests/test_litellm/llms/deepseek/chat/test_deepseek_chat_transformation.py
+++ b/tests/test_litellm/llms/deepseek/chat/test_deepseek_chat_transformation.py
@@ -1,3 +1,4 @@
+import litellm
 from litellm.llms.deepseek.chat.transformation import DeepSeekChatConfig
 
 
@@ -106,6 +107,254 @@ async def test_async_transform_request_strips_unsupported_tools_from_body():
 def test_thinking_mode_active_bool_thinking_returns_false_without_crashing():
     config = DeepSeekChatConfig()
     assert config._thinking_mode_active(model="deepseek-reasoner", optional_params={"thinking": True}) is False
+
+
+class TestDeepSeekVisionMultimodalContent:
+    """Image content lists are forwarded only for user messages on vision models."""
+
+    VISION_MODEL = "deepseek/deepseek-v4-flash-vision-exp"
+    NON_VISION_MODEL = "deepseek/deepseek-chat"
+
+    def setup_method(self):
+        self.config = DeepSeekChatConfig()
+        prior_entry = litellm.model_cost.get(self.VISION_MODEL)
+        self._prior_registry_entry = dict(prior_entry) if prior_entry is not None else None
+        litellm.register_model(
+            {
+                "deepseek/deepseek-v4-flash-vision-exp": {
+                    "litellm_provider": "deepseek",
+                    "mode": "chat",
+                    "input_cost_per_token": 4.4e-07,
+                    "output_cost_per_token": 1.32e-06,
+                    "supports_vision": True,
+                }
+            }
+        )
+
+    def teardown_method(self):
+        if self._prior_registry_entry is None:
+            litellm.model_cost.pop(self.VISION_MODEL, None)
+        else:
+            litellm.model_cost[self.VISION_MODEL] = self._prior_registry_entry
+
+    @staticmethod
+    def _image_message(role="user"):
+        return {
+            "role": role,
+            "content": [
+                {"type": "text", "text": "what is in this image?"},
+                {
+                    "type": "image_url",
+                    "image_url": {"url": "https://example.com/image.jpg", "detail": "auto"},
+                },
+            ],
+        }
+
+    def test_user_image_list_forwarded_on_vision_model(self):
+        result = self.config._transform_messages([self._image_message()], model=self.VISION_MODEL)
+
+        assert isinstance(result[0]["content"], list)
+        assert result[0]["content"][0]["type"] == "text"
+        assert result[0]["content"][1]["type"] == "image_url"
+        assert result[0]["content"][1]["image_url"]["url"] == "https://example.com/image.jpg"
+
+    def test_image_list_collapsed_on_non_vision_model(self):
+        result = self.config._transform_messages([self._image_message()], model=self.NON_VISION_MODEL)
+
+        assert result[0]["content"] == "what is in this image?"
+
+    def test_image_list_collapsed_on_non_user_roles_even_on_vision_model(self):
+        for role in ("assistant", "system"):
+            result = self.config._transform_messages([self._image_message(role=role)], model=self.VISION_MODEL)
+
+            assert result[0]["content"] == "what is in this image?"
+
+    def test_audio_block_collapsed_even_on_vision_model(self):
+        messages = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "transcribe this"},
+                    {"type": "input_audio", "input_audio": {"data": "UklGRg==", "format": "wav"}},
+                ],
+            }
+        ]
+
+        result = self.config._transform_messages(messages, model=self.VISION_MODEL)
+
+        assert result[0]["content"] == "transcribe this"
+
+    def test_typeless_image_block_collapses(self):
+        messages = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "what is this"},
+                    {"image_url": {"url": "https://example.com/image.jpg"}},
+                ],
+            }
+        ]
+
+        result = self.config._transform_messages(messages, model=self.VISION_MODEL)
+
+        assert result[0]["content"] == "what is this"
+
+    def test_text_only_content_list_collapses(self):
+        messages = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "Hello "},
+                    {"type": "text", "text": "world"},
+                ],
+            }
+        ]
+
+        result = self.config._transform_messages(messages, model=self.VISION_MODEL)
+
+        assert isinstance(result[0]["content"], str)
+        assert result[0]["content"] == "Hello world"
+
+    def test_search_results_text_appended_on_forwarded_message(self):
+        message = self._image_message()
+        message["search_results"] = [{"source": "kb", "content": [{"text": "article body"}]}]
+
+        result = self.config._transform_messages([message], model=self.VISION_MODEL)
+
+        content = result[0]["content"]
+        assert isinstance(content, list)
+        assert content[-1] == {"type": "text", "text": "kbarticle body"}
+        assert any(block.get("type") == "image_url" for block in content)
+        assert "search_results" not in result[0]
+
+    def test_search_results_text_kept_on_collapse(self):
+        messages = [
+            {
+                "role": "user",
+                "content": [{"type": "text", "text": "context: "}],
+                "search_results": [{"source": "kb", "content": [{"text": "article body"}]}],
+            }
+        ]
+
+        result = self.config._transform_messages(messages, model=self.NON_VISION_MODEL)
+
+        assert result[0]["content"] == "context: kbarticle body"
+
+    def test_responses_shape_blocks_collapse_even_on_vision_model(self):
+        messages = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "input_text", "text": "what is this?"},
+                    {"type": "image_url", "image_url": {"url": "https://example.com/image.jpg"}},
+                ],
+            }
+        ]
+
+        result = self.config._transform_messages(messages, model=self.VISION_MODEL)
+
+        assert result[0]["content"] == "what is this?"
+
+    def test_image_block_missing_payload_collapses(self):
+        messages = [
+            {
+                "role": "user",
+                "content": [{"type": "text", "text": "hi"}, {"type": "image_url"}],
+            }
+        ]
+
+        result = self.config._transform_messages(messages, model=self.VISION_MODEL)
+
+        assert result[0]["content"] == "hi"
+
+    def test_text_block_missing_text_field_collapses(self):
+        messages = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "hi"},
+                    {"type": "text"},
+                    {"type": "image_url", "image_url": {"url": "https://example.com/image.jpg"}},
+                ],
+            }
+        ]
+
+        result = self.config._transform_messages(messages, model=self.VISION_MODEL)
+
+        assert result[0]["content"] == "hi"
+
+    def test_string_content_search_results_folded_into_string(self):
+        messages = [
+            {
+                "role": "tool",
+                "tool_call_id": "call_1",
+                "content": "summarize the docs",
+                "search_results": [{"source": "kb", "content": [{"text": "article body"}]}],
+            }
+        ]
+
+        result = self.config._transform_messages(messages, model=self.NON_VISION_MODEL)
+
+        assert result[0]["content"] == "summarize the docskbarticle body"
+
+    def test_plain_string_content_message_unchanged(self):
+        messages = [{"role": "user", "content": "hello"}]
+
+        result = self.config._transform_messages(messages, model=self.VISION_MODEL)
+
+        assert result[0] is messages[0]
+
+    def test_empty_content_list_untouched(self):
+        messages = [{"role": "user", "content": []}]
+
+        result = self.config._transform_messages(messages, model=self.NON_VISION_MODEL)
+
+        assert result[0]["content"] == []
+
+    def test_later_messages_still_collapsed_after_forwarded_one(self):
+        messages = [
+            self._image_message(),
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "and "},
+                    {"type": "text", "text": "then?"},
+                ],
+            },
+            self._image_message(),
+        ]
+
+        result = self.config._transform_messages(messages, model=self.VISION_MODEL)
+
+        assert isinstance(result[0]["content"], list)
+        assert result[1]["content"] == "and then?"
+        assert isinstance(result[2]["content"], list)
+
+    def test_transform_request_preserves_image_url_block(self):
+        body = self.config.transform_request(
+            model=self.VISION_MODEL,
+            messages=[self._image_message()],
+            optional_params={},
+            litellm_params={},
+            headers={},
+        )
+
+        content = body["messages"][0]["content"]
+        assert isinstance(content, list)
+        assert any(block.get("type") == "image_url" for block in content)
+
+    async def test_async_transform_request_preserves_image_url_block(self):
+        body = await self.config.async_transform_request(
+            model=self.VISION_MODEL,
+            messages=[self._image_message()],
+            optional_params={},
+            litellm_params={},
+            headers={},
+        )
+
+        content = body["messages"][0]["content"]
+        assert isinstance(content, list)
+        assert any(block.get("type") == "image_url" for block in content)
 
 
 class TestDeepSeekThinkingParams:
@@ -282,8 +531,6 @@ class TestDeepSeekThinkingParams:
 
         result = self.config._drop_unsupported_tools(optional_params)
 
-        assert result["tools"] == [
-            {"type": "function", "function": {"name": "get_weather"}}
-        ]
+        assert result["tools"] == [{"type": "function", "function": {"name": "get_weather"}}]
         assert "tool_choice" not in result
         assert result["parallel_tool_calls"] is True

--- a/tests/test_litellm/llms/deepseek/chat/test_deepseek_chat_transformation.py
+++ b/tests/test_litellm/llms/deepseek/chat/test_deepseek_chat_transformation.py
@@ -267,6 +267,36 @@ class TestDeepSeekVisionMultimodalContent:
 
         assert result[0]["content"] == "hi"
 
+    def test_image_block_empty_payload_object_collapses(self):
+        for payload in ({}, {"url": ""}, {"detail": "auto"}, None, 42):
+            messages = [
+                {
+                    "role": "user",
+                    "content": [{"type": "text", "text": "hi"}, {"type": "image_url", "image_url": payload}],
+                }
+            ]
+
+            result = self.config._transform_messages(messages, model=self.VISION_MODEL)
+
+            assert result[0]["content"] == "hi"
+
+    def test_image_block_string_payload_forwarded(self):
+        messages = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "what is this?"},
+                    {"type": "image_url", "image_url": "https://example.com/image.jpg"},
+                ],
+            }
+        ]
+
+        result = self.config._transform_messages(messages, model=self.VISION_MODEL)
+
+        content = result[0]["content"]
+        assert isinstance(content, list)
+        assert content[1]["image_url"] == {"url": "https://example.com/image.jpg"}
+
     def test_text_block_missing_text_field_collapses(self):
         messages = [
             {


### PR DESCRIPTION
## TLDR

Problem this solves:

- DeepSeek vision requests drop the image; model says it sees none
- Naive forwarding breaks non-vision models, non-user roles, audio, RAG text

How it solves it:

- Forwards image content lists only for user messages on vision models, and only when every block is a well-formed text or image_url block carrying its payload
- Registers deepseek-v4-flash-vision-exp so capability and cost resolve
- Keeps search_results text on forwarded messages as a text block, and keeps folding it into string content the way the collapse always did
- Everything else keeps the historical collapse-to-string behavior

Credit: this adopts and hardens #37854 by @otaviofbrito, who found the dropped-image bug and wrote the original forwarding fix

## User Flow

Before: a developer asking a DeepSeek vision model about an image is told no image was attached

1. They send POST http://localhost:4000/v1/chat/completions with `"model": "deepseek/deepseek-v4-flash-vision-exp"` and a content list holding a text question and an `image_url` block
2. The gateway returns 200, but the assistant says "I can't see an image—please upload or describe it."
3. Usage shows 96 input tokens: only the text reached DeepSeek

After: the same request returns a real description of the image, and requests that worked before keep working

1. They send the identical POST http://localhost:4000/v1/chat/completions request
2. The gateway returns 200 and the assistant identifies the animal in the photo
3. Usage shows 451 input tokens: the image reached DeepSeek, which bills an image at up to 384 tokens
4. The same image payload sent to `deepseek/deepseek-v4-flash` (no vision) still returns 200 with a text-only answer instead of a new DeepSeek 400

## Relevant issues

Adopts #37854

## Linear ticket

Resolves LIT-6279

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

All runs hit the real DeepSeek API through two live proxies, one per commit, each booted with `--num_workers 2` from the same wildcard `deepseek/*` config with a real `DEEPSEEK_API_KEY`, no DB, no mocks, identical payload files on both sides. The image is a Samoyed photo (https://raw.githubusercontent.com/pytorch/hub/master/images/dog.jpg) sent inline as a base64 `data:` URL, except the one case that sends the public URL itself. DeepSeek bills an image at up to 384 tokens, so `prompt_tokens=451` proves the image reached the model and `prompt_tokens=96` proves it was dropped

```bash
curl -sS http://127.0.0.1:<port>/v1/chat/completions -H "Authorization: Bearer sk-1234" \
  -H "Content-Type: application/json" -d @<case>.json
```

### Before (da528e455c)

#### Vision model, text + image_url

1. POST /v1/chat/completions, `deepseek/deepseek-v4-flash-vision-exp`, content list holding a text question and a base64 `image_url` block with `detail: "auto"`
2. 200, `prompt_tokens=96`, "I can't determine the animal because no image was provided.", no `x-litellm-response-cost` header (the model is unknown to the cost map)

#### Non-vision deepseek-v4-flash, same image payload

1. The same POST with `"model": "deepseek/deepseek-v4-flash"`
2. 200, `prompt_tokens=96`, text-only answer, cost header 0.00012144

#### Image in an assistant turn

1. POST with the image block inside an assistant message, vision model
2. 200, `prompt_tokens=91`, "ok" (collapsed, no DeepSeek 400)

#### input_audio block

1. POST with a text block plus an `input_audio` block, vision model
2. 200, `prompt_tokens=85`, "ok" (collapsed)

#### Image + search_results

1. POST with text and image blocks plus a `search_results` key, asking what the results say
2. 200, `prompt_tokens=113`, "I can't see the image to identify the animal, but the search result says the fence is painted bright green." (search text folded in, image dropped)

#### Streaming with image

1. The vision payload with `"stream": true` and `"stream_options": {"include_usage": true}`
2. Streamed 200, `prompt_tokens=96`, "I can't see an image—please upload it."

#### Malformed image_url block

1. POST with a text block plus `{"type": "image_url", "image_url": {}}`
2. 200, `prompt_tokens=85`, "ok" (collapsed, never reaches DeepSeek as an image)

#### String content + search_results

1. POST with plain string content and a `search_results` key
2. 200, `prompt_tokens=105`, "Green"

#### Base64 image_url, no detail field

1. POST vision model, `image_url` holding only a base64 `data:` URL
2. 200, `prompt_tokens=96`, "I can't identify the animal because no image was provided."

#### Public https image URL, detail high

1. POST vision model, `image_url` holding the public URL and `detail: "high"`
2. 200, `prompt_tokens=96`, "I don't see an image attached, so I can't identify the animal."

#### /v1/messages, Anthropic image block

1. POST /v1/messages, vision model, Anthropic-format content: text plus a base64 `image` source
2. 200, `input_tokens=451`, "The animal in the image is a fluffy white dog." (this surface rides DeepSeek's Anthropic-compatible endpoint, not this transform, so the image already arrives)

#### /v1/responses, input_image block

1. POST /v1/responses, vision model, `input_text` plus `input_image` blocks
2. 200, `input_tokens=94`, "I can't determine the animal because no image was provided."

#### Responses-shape input_text on /v1/chat/completions

1. POST /v1/chat/completions with an `input_text` block next to an image block
2. 500, "Invalid user message at index 0", rejected upstream of the provider transform

### After (c3c9903ba5)

#### Vision model, text + image_url

1. The identical POST
2. 200, `prompt_tokens=451`, "This is a fluffy white dog.", `x-litellm-response-cost: 0.00029612`

#### Non-vision deepseek-v4-flash, same image payload

1. The identical POST
2. 200, `prompt_tokens=96`, text-only answer, unchanged (the naive forward in #37854 turned this into a DeepSeek 400 "This model does not support image")

#### Image in an assistant turn

1. The identical POST
2. 200, `prompt_tokens=91`, "ok", unchanged (naive forward: 400 "Image in assistant message is not supported")

#### input_audio block

1. The identical POST
2. 200, `prompt_tokens=85`, "ok", unchanged (naive forward: 400 "unknown variant `input_audio`")

#### Image + search_results

1. The identical POST
2. 200, `prompt_tokens=468`, "The animal in the image is a white dog (American Eskimo Dog), and the search result says the fence is painted bright green." (image forwarded AND search text preserved as a trailing text block)

#### Streaming with image

1. The identical POST
2. Streamed 200, `prompt_tokens=451`, "The animal in the image is a fluffy white dog."

#### Malformed image_url block

1. The identical POST
2. 200, `prompt_tokens=85`, "ok", unchanged

#### String content + search_results

1. The identical POST
2. 200, `prompt_tokens=105`, "Green", unchanged

#### Base64 image_url, no detail field

1. The identical POST
2. 200, `prompt_tokens=451`, "The animal in the image is a white, fluffy dog."

#### Public https image URL, detail high

1. The identical POST
2. 200, `prompt_tokens=451`, "The animal in the image is a dog." (DeepSeek fetched the URL itself)

#### /v1/messages, Anthropic image block

1. The identical POST
2. 200, `input_tokens=451`, "The animal is a fluffy white dog.", unchanged: this surface is unaffected

#### /v1/responses, input_image block

1. The identical POST
2. 200, `input_tokens=451`, "The animal in the image is a dog." (the Responses bridge now delivers the image)

#### Responses-shape input_text on /v1/chat/completions

1. The identical POST
2. 500, identical to Before, rejected upstream of the provider transform on both sides

Regression-direction check: this PR's test file fails 6 of 38 cases when run against the merge base and all 38 pass at the tip

Observations from the run:

- /v1/messages rides DeepSeek's Anthropic endpoint; unaffected by this PR
- DeepSeek's own URL fetcher intermittently 400s on some hosts; upstream
- Streaming omits the cost header on both legs; pre-existing

## Type

🐛 Bug Fix

## Changes

- `DeepSeekChatConfig._transform_messages` now forwards a content list untouched only when the message role is `user`, every block is a well-formed dict typed text or image_url carrying its payload, at least one image is present, and `supports_vision` is true for the model (resolved once per request); every other message keeps the historical collapse to a plain string, including the fold of `search_results` text into string content
- Forwarded messages with `search_results` get that text appended as a trailing text block, matching what the collapse used to fold in, and the non-OpenAI `search_results` key is dropped from the forwarded wire message
- Adds `deepseek-v4-flash-vision-exp` and `deepseek/deepseek-v4-flash-vision-exp` to both cost maps (same pricing as deepseek-v4-flash per https://api-docs.deepseek.com/quick_start/pricing, `supports_vision: true`), which is also what makes the capability gate resolvable

## Caveats (if any)

### Low

- A DeepSeek vision model missing from the cost map keeps the pre-PR collapse (`supports_vision` resolves false); today DeepSeek's only vision model is registered by this PR, and `litellm.register_model` or the remote cost map covers custom entries
- Debug callbacks now see the original content list, not the collapsed string
- Malformed or typeless blocks keep collapsing and never reach the forward path
- Forwarded messages ship `search_results` as a trailing text block, not the raw key
- DeepSeek's `file` content blocks still collapse; follow-up if anyone needs them

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes request shaping for all DeepSeek chat calls that use list content (vision forwarding vs collapse) and alters whether `search_results` is sent raw on forwarded vision messages; behavior is gated but easy to misconfigure for unregistered vision models.
> 
> **Overview**
> Fixes DeepSeek vision chat where **`image_url` blocks were stripped** because every message was collapsed to a string before the request left LiteLLM.
> 
> **`DeepSeekChatConfig._transform_messages`** now keeps OpenAI-style content lists for **user** messages on models with **`supports_vision`**, but only when every block is a valid **`text`** or **`image_url`** payload and at least one image is present. Non-vision models, other roles, audio/`input_text` blocks, and malformed image blocks still use the **collapse-to-string** path via **`convert_content_list_to_str`**. **`search_results`** on forwarded vision messages is turned into a trailing **text** block and removed from the wire payload; collapsed messages still fold that text into the string as before.
> 
> Registers **`deepseek-v4-flash-vision-exp`** (and the **`deepseek/`** alias) in the model cost maps with **`supports_vision: true`**. Adds broad unit coverage for forwarding, collapse, and sync/async **`transform_request`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c3c9903ba5222f046a4e544d4998e18273b90219. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

- [x] c3c9903ba5222f046a4e544d4998e18273b90219 passes /live-pr-risk
