### PR TITLE
fix(mcp): canonicalize bearer scheme on bridge egress

### DIFF
--- a/litellm/proxy/_experimental/mcp_server/outbound_credentials/bridge_credentials.py
+++ b/litellm/proxy/_experimental/mcp_server/outbound_credentials/bridge_credentials.py
@@ -239,5 +239,6 @@ def resolve_bridge_envelope(
     if opened.identity.server_id != expected_server_id:
         return BridgeEnvelopeInvalid()
     grant: Final = opened.grant
-    upstream_authorization: Final = f"{grant.token_type} {grant.access_token.get_secret_value()}"
+    authorization_scheme: Final = "Bearer" if grant.token_type.lower() == "bearer" else grant.token_type
+    upstream_authorization: Final = f"{authorization_scheme} {grant.access_token.get_secret_value()}"
     return BridgeEnvelopeAdmitted(identity=opened.identity, upstream_authorization=SecretStr(upstream_authorization))

--- a/tests/test_litellm/proxy/_experimental/mcp_server/outbound_credentials/test_bridge_credentials.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/outbound_credentials/test_bridge_credentials.py
@@ -10,6 +10,7 @@ through the consumer; and no path leaks the upstream token in a repr.
 
 from datetime import datetime, timedelta, timezone
 
+import pytest
 from pydantic import SecretStr
 
 from litellm.proxy._experimental.mcp_server.outbound_credentials.bridge_credentials import (
@@ -186,6 +187,31 @@ def test_resolve_strips_optional_bearer_scheme_before_detection():
     assert isinstance(prefixed, BridgeEnvelopeAdmitted)
     assert isinstance(lower, BridgeEnvelopeAdmitted)
     assert prefixed.upstream_authorization.get_secret_value() == bare.upstream_authorization.get_secret_value()
+
+
+@pytest.mark.parametrize("token_type", ("bearer", "BEARER", "beArEr"))
+def test_resolve_canonicalizes_case_insensitive_bearer_token_type(token_type: str):
+    keys = envelope_keys_from_master_key(_MASTER_KEY)
+    grant = UpstreamTokenGrant(access_token=SecretStr(_ACCESS_TOKEN), token_type=token_type, expires_in=600)
+    sealed = mint_envelope(_IDENTITY, grant, keys, _NOW)
+    assert isinstance(sealed, SealedEnvelope)
+
+    result = resolve_bridge_envelope(sealed.token.get_secret_value(), keys, _NOW, _SERVER_ID)
+
+    assert isinstance(result, BridgeEnvelopeAdmitted)
+    assert result.upstream_authorization.get_secret_value() == f"Bearer {_ACCESS_TOKEN}"
+
+
+def test_resolve_preserves_non_bearer_token_type():
+    keys = envelope_keys_from_master_key(_MASTER_KEY)
+    grant = UpstreamTokenGrant(access_token=SecretStr(_ACCESS_TOKEN), token_type="DPoP", expires_in=600)
+    sealed = mint_envelope(_IDENTITY, grant, keys, _NOW)
+    assert isinstance(sealed, SealedEnvelope)
+
+    result = resolve_bridge_envelope(sealed.token.get_secret_value(), keys, _NOW, _SERVER_ID)
+
+    assert isinstance(result, BridgeEnvelopeAdmitted)
+    assert result.upstream_authorization.get_secret_value() == f"DPoP {_ACCESS_TOKEN}"
 
 
 def test_resolve_expired_envelope_is_invalid_not_admitted():


### PR DESCRIPTION
## TLDR

Problem this solves:

- Lowercase `bearer` prefix in the outbound Auth header can get rejected

How it solves it:

- Canonicalizes Bearer casing at protected-resource egress
- Preserves extension schemes such as `DPoP`

## User Flow

Before: a developer completes MCP authorization but receives no tools after token refresh

1. They authorize an MCP server through the gateway
2. They send a tool request after the upstream access token refreshes
3. The upstream resource receives `Authorization: bearer <token>` and returns HTTP 401 `invalid_token`
4. The client shows no available tools and requires authorization again

After: the same refreshed credential continues to serve MCP tools

1. They authorize the same MCP server through the gateway
2. They send the same tool request after the upstream access token refreshes
3. The upstream resource receives `Authorization: Bearer <token>` and accepts the valid token
4. The client lists and calls tools without another authorization flow

## Relevant issues

Fixes #34743

## Linear ticket

Resolves LIT-6271

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The focused bridge credential test file passes locally
- [x] My PR passes all required CI/CD checks
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile Confidence Score of at least 4/5 before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in this PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA)

## Screenshots / Proof of Fix

Live e2e A/B run, no mocks. Each leg boots its own proxy from that leg's commit with `--num_workers 2`, its own Postgres database, and a master key, pointed at a real MCP server built on the official `mcp` SDK (FastMCP over streamable-http) fronted by a minimal OAuth authorization server whose token endpoint returns `"token_type": "bearer"` in lowercase (RFC 6749 allows it) while the resource enforces a case-strict `Bearer ` prefix on Authorization, the provider behavior recorded in #34743. The end-user client is an MCP host on the same SDK (`OAuthClientProvider` plus `streamable_http_client`): it performs the full RFC 9728/8414 discovery, RFC 7591 dynamic client registration, PKCE authorize, and token exchange through the gateway front door, presenting a LiteLLM virtual key on the token request, then lists and calls tools. Both legs run the identical client, flow, topology, and upstream; only the proxy commit differs

Per-leg `mcp_servers` config (upstream port differs per leg):

```yaml
mcp_servers:
  strictmcp:
    url: http://127.0.0.1:52217/mcp
    transport: http
    auth_type: oauth_delegate
    dcr_bridge: true
    allow_all_keys: true
    authorization_url: http://127.0.0.1:52217/authorize
    token_url: http://127.0.0.1:52217/token
    registration_url: http://127.0.0.1:52217/register
```

### Before (04818a3554)

```
$ .venv/bin/python client.py http://127.0.0.1:52194 strictmcp sk-frPI...
TOOLS: []
VERDICT: FAIL (no tools listed)
```

The OAuth dance itself completes (registration, the authorize redirect chain back to the client redirect_uri, and a 200 token exchange that mints the bridge credential), but the gateway forwards the upstream's lowercase `token_type` verbatim, so its requests upstream carry `Authorization: bearer <token>`, the strict upstream rejects them with 401 `invalid_token`, and the end user sees an MCP server with no tools

### After (cc400502fa)

```
$ .venv/bin/python client.py http://127.0.0.1:52218 strictmcp sk-2OFX...
Tool whoami not listed by server, cannot validate any structured content
Tool add not listed by server, cannot validate any structured content
TOOLS: ['strictmcp-add', 'strictmcp-whoami']
TOOL-CALL whoami -> isError=False text='strict-upstream says hello: bearer-scheme QA rig for LIT-6271'
TOOL-CALL add(20,22) -> isError=False text='42'
VERDICT: SUCCESS
```

Same client, same dance, same strict upstream: the gateway now sends `Authorization: Bearer <token>`, the upstream accepts it, tools list, and both tool calls succeed. The two SDK notice lines are client-side only, from tools being listed under their `strictmcp-` prefixed names

QA observations:

- x-litellm-api-key on /mcp requests bypasses bridge admission; pre-existing

## Type

🐛 Bug Fix

## Caveats (if any)

None

## Final Attestation

- [x] The tests cover casing variants and non-Bearer extension schemes

---

🧭🛠️ Generated with Codex

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to outbound header formatting on the MCP bridge admission path; no auth logic or credential storage changes.
> 
> **Overview**
> Fixes MCP tool calls failing after token refresh when upstream OAuth returns a lowercase `bearer` `token_type`, which some resource servers reject with HTTP 401.
> 
> When `resolve_bridge_envelope` builds the forwarded `Authorization` value, it now maps any case-insensitive `bearer` grant type to canonical **`Bearer`**, while leaving other schemes (e.g. **`DPoP`**) unchanged. Tests cover mixed-case bearer variants and non-Bearer token types.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cc400502fa84f04db5a7cc2301b4764caa68e9e7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


- [x] cc400502fa passes /live-pr-risk
