### PR TITLE
fix(mcp): add litellm[mcp] extra and actionable error when streamable_http_client is missing

### DIFF
--- a/litellm/experimental_mcp_client/client.py
+++ b/litellm/experimental_mcp_client/client.py
@@ -7,6 +7,7 @@ import base64
 import os
 from collections.abc import Awaitable, Callable, Generator
 from datetime import timedelta
+from importlib import metadata
 from typing import Any, Final, TypeVar
 
 import httpx
@@ -21,6 +22,18 @@ try:
     streamable_http_client = getattr(streamable_http_module, "streamable_http_client", None)
 except ImportError:
     pass
+
+MCP_STREAMABLE_HTTP_REQUIREMENT: Final = "mcp>=1.28.1"
+
+
+def missing_streamable_http_client_error() -> ImportError:
+    return ImportError(
+        f"MCP streamable HTTP transport requires {MCP_STREAMABLE_HTTP_REQUIREMENT}, but the installed "
+        f"mcp {metadata.version('mcp')} does not provide streamable_http_client. "
+        "Fix with: pip install 'litellm[mcp]' (or upgrade mcp directly: pip install -U mcp)"
+    )
+
+
 from mcp.types import CallToolRequestParams as MCPCallToolRequestParams
 from mcp.types import CallToolResult as MCPCallToolResult
 from mcp.types import (
@@ -323,7 +336,7 @@ class MCPClient:
             )
         # HTTP transport (default)
         if streamable_http_client is None:
-            raise ImportError("streamable_http_client is not available. Please install mcp with HTTP support.")
+            raise missing_streamable_http_client_error()
         headers = self._get_auth_headers()
         httpx_client_factory = self._create_httpx_client_factory()
         verbose_logger.debug("litellm headers for streamable_http_client: %s", headers)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,6 +106,7 @@ utils = [
     "numpydoc>=1.8.0,<2.0",
 ]
 caching = ["diskcache>=5.6.3,<6.0"]
+mcp = ["mcp>=1.28.1,<2.0"]
 # SAML SSO for the admin UI. python3-saml pulls in xmlsec/lxml, whose wheels
 # bundle the native libxmlsec1/libxml2 libraries, so no system packages are
 # required. Kept out of the base `proxy` extra so it stays optional.

--- a/tests/test_litellm/experimental_mcp_client/test_mcp_client.py
+++ b/tests/test_litellm/experimental_mcp_client/test_mcp_client.py
@@ -2,6 +2,8 @@ import asyncio
 import base64
 import os
 import sys
+from importlib import metadata
+from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import anyio
@@ -24,9 +26,11 @@ from mcp.types import (
 
 import litellm.experimental_mcp_client.client as mcp_client_module
 from litellm.experimental_mcp_client.client import (
+    MCP_STREAMABLE_HTTP_REQUIREMENT,
     MCPClient,
     _as_read_timeout,
     _first_non_cancelled_cause,
+    missing_streamable_http_client_error,
     strip_auth_scheme,
 )
 from litellm.proxy._experimental.mcp_server.faults.list_outcomes import (
@@ -1047,3 +1051,42 @@ def test_openapi_byok_auth_header_emits_exactly_one_scheme(auth_type, auth_value
 
     assert server.is_byok is False
     assert _format_byok_openapi_auth_header(server, auth_value) == expected
+
+
+def test_missing_streamable_http_client_error_names_requirement_and_remedy():
+    message = str(missing_streamable_http_client_error())
+
+    assert MCP_STREAMABLE_HTTP_REQUIREMENT in message
+    assert "pip install 'litellm[mcp]'" in message
+    assert metadata.version("mcp") in message
+
+
+@pytest.mark.asyncio
+async def test_http_transport_without_streamable_http_client_raises_actionable_import_error():
+    client = MCPClient(
+        server_url="https://mcp-server.example.com",
+        transport_type=MCPTransport.http,
+    )
+
+    with patch.object(mcp_client_module, "streamable_http_client", None):  # test-quality-ok: simulates mcp<1.24.0 whose module lacks this import-time symbol; no HTTP boundary exists before the raise
+        with pytest.raises(ImportError, match=r"pip install 'litellm\[mcp\]'"):
+            await client.list_tools(raise_on_error=True)
+
+
+def test_mcp_extra_matches_proxy_extra_and_supports_streamable_http():
+    tomllib = pytest.importorskip("tomllib")
+    from packaging.requirements import Requirement
+
+    pyproject_path = Path(__file__).parents[3] / "pyproject.toml"
+    with pyproject_path.open("rb") as f:
+        extras = tomllib.load(f)["project"]["optional-dependencies"]
+
+    mcp_extra = extras["mcp"]
+    assert len(mcp_extra) == 1
+
+    proxy_mcp_requirements = [req for req in extras["proxy"] if Requirement(req).name == "mcp"]
+    assert mcp_extra == proxy_mcp_requirements
+
+    specifier = Requirement(mcp_extra[0]).specifier
+    assert not specifier.contains("1.23.0")
+    assert specifier.contains("1.28.1")

--- a/tests/test_litellm/experimental_mcp_client/test_mcp_client.py
+++ b/tests/test_litellm/experimental_mcp_client/test_mcp_client.py
@@ -1068,13 +1068,18 @@ async def test_http_transport_without_streamable_http_client_raises_actionable_i
         transport_type=MCPTransport.http,
     )
 
-    with patch.object(mcp_client_module, "streamable_http_client", None):  # test-quality-ok: simulates mcp<1.24.0 whose module lacks this import-time symbol; no HTTP boundary exists before the raise
+    with patch.object(  # test-quality-ok: simulates mcp<1.24.0 whose module lacks this import-time symbol
+        mcp_client_module, "streamable_http_client", None
+    ):
         with pytest.raises(ImportError, match=r"pip install 'litellm\[mcp\]'"):
             await client.list_tools(raise_on_error=True)
 
 
 def test_mcp_extra_matches_proxy_extra_and_supports_streamable_http():
-    tomllib = pytest.importorskip("tomllib")
+    try:
+        import tomllib
+    except ImportError:
+        tomllib = pytest.importorskip("tomli")
     from packaging.requirements import Requirement
 
     pyproject_path = Path(__file__).parents[3] / "pyproject.toml"

--- a/uv.lock
+++ b/uv.lock
@@ -10,7 +10,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-08-23T02:27:57.028643Z"
+exclude-newer = "2026-08-23T20:15:58.934396Z"
 exclude-newer-span = "P3D"
 
 [manifest]
@@ -4315,6 +4315,9 @@ google = [
 grpc = [
     { name = "grpcio" },
 ]
+mcp = [
+    { name = "mcp" },
+]
 mlflow = [
     { name = "mlflow" },
 ]
@@ -4526,6 +4529,7 @@ requires-dist = [
     { name = "litellm-proxy-extras", marker = "extra == 'proxy'", editable = "litellm-proxy-extras" },
     { name = "llm-sandbox", marker = "extra == 'proxy-runtime'", specifier = ">=0.3.39,<1.0" },
     { name = "mangum", marker = "extra == 'proxy-runtime'", specifier = ">=0.17.0,<1.0" },
+    { name = "mcp", marker = "extra == 'mcp'", specifier = ">=1.28.1,<2.0" },
     { name = "mcp", marker = "extra == 'proxy'", specifier = ">=1.28.1,<2.0" },
     { name = "mlflow", marker = "extra == 'mlflow'", specifier = ">=3.11.1,<4.0" },
     { name = "numpy", marker = "extra == 'stt-nvidia-riva'", specifier = ">=1.26.0" },
@@ -4569,7 +4573,7 @@ requires-dist = [
     { name = "uvloop", marker = "sys_platform != 'win32' and extra == 'proxy'", specifier = ">=0.21.0,<1.0" },
     { name = "websockets", marker = "extra == 'proxy'", specifier = ">=15.0.1,<16.0" },
 ]
-provides-extras = ["proxy", "cli", "extra-proxy", "utils", "caching", "saml", "semantic-router", "mlflow", "grpc", "stt-nvidia-riva", "google", "bedrock-realtime", "proxy-runtime"]
+provides-extras = ["proxy", "cli", "extra-proxy", "utils", "caching", "mcp", "saml", "semantic-router", "mlflow", "grpc", "stt-nvidia-riva", "google", "bedrock-realtime", "proxy-runtime"]
 
 [package.metadata.requires-dev]
 ci = [


### PR DESCRIPTION
## TLDR

Problem this solves:

- HTTP MCP servers need mcp >= 1.24.0 for streamable HTTP
- Base `pip install litellm` declares no mcp floor at all
- With an older mcp, the gateway silently serves zero MCP tools
- The logged error names no version floor and no installable fix

How it solves it:

- New `litellm[mcp]` extra pinning `mcp>=1.28.1,<2.0` (same as proxy extra)
- The error now names the floor, the installed version, and the fix

## User Flow

Before: a proxy admin whose environment carries an older mcp (litellm itself never pinned one) configures an HTTP MCP server, and every MCP client sees zero tools with no hint why

1. The admin adds an MCP server to the proxy config, e.g. `mcp_servers: {deepwiki: {url: https://mcp.deepwiki.com/mcp, transport: http}}`, and boots the proxy; startup shows no complaint
2. A developer points a real MCP client (Claude Code, Cursor, or the mcp SDK) at `http://litellm-domain/mcp` with their LiteLLM key and asks for the tool list
3. The client gets back an empty tool list, so the agent has no MCP tools to call
4. The proxy log shows `ImportError: streamable_http_client is not available. Please install mcp with HTTP support.`, but "mcp with HTTP support" matches no installable package or extra, and nothing says which mcp version is needed
5. The admin runs `pip install 'litellm[mcp]'` to fix it and gets a warning that litellm does not provide the extra 'mcp', leaving them to diff mcp changelogs to find the floor

After: the same setup either works, or fails with an error naming the exact fix

1. The admin adds the same `mcp_servers` block and boots the proxy
2. If the environment's mcp is still too old, the proxy log now reads `MCP streamable HTTP transport requires mcp>=1.28.1, but the installed mcp 1.23.0 does not provide streamable_http_client. Fix with: pip install 'litellm[mcp]' (or upgrade mcp directly: pip install -U mcp)`
3. The admin runs `pip install 'litellm[mcp]'`, which now exists and installs `mcp>=1.28.1,<2.0`, and restarts the proxy
4. The developer's MCP client asks `http://litellm-domain/mcp` for the tool list and gets the server's real tools back (`deepwiki-ask_question`, `deepwiki-read_wiki_contents`, `deepwiki-read_wiki_structure`)

## Relevant issues

## Linear ticket

Resolves LIT-3372

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Shared setup for both runs: a live proxy booted with `--num_workers 2` from a worktree at the named commit, this config (real DeepWiki MCP server over HTTP), and a venv holding litellm's proxy deps with `mcp==1.23.0` pinned to simulate an environment whose mcp predates the streamable HTTP client API

```yaml
model_list:
  - model_name: gpt-5.1
    litellm_params:
      model: openai/gpt-5.1
      api_key: os.environ/OPENAI_API_KEY

mcp_servers:
  deepwiki:
    url: https://mcp.deepwiki.com/mcp
    transport: http

general_settings:
  master_key: sk-lit3372-repro
```

The MCP client is the official mcp Python SDK 1.29.0 (streamable HTTP + `ClientSession.list_tools`) hitting the gateway's `/mcp` with the LiteLLM key in `x-litellm-api-key`

### Before (724c5c2d96)

#### MCP gateway tool listing

1. Boot the proxy and confirm it is up

```
$ .venv-repro/bin/python litellm/proxy/proxy_cli.py --config lit3372_config.yaml --port 35955 --num_workers 2
$ curl -s http://localhost:35955/health/liveliness
"I'm alive!"
```

2. Ask the gateway for the tool list with the real MCP client: it silently serves zero tools even though DeepWiki is up

```
$ uv run --no-project --with 'mcp==1.29.0' python lit3372_mcp_client.py http://localhost:35955/mcp 'Bearer sk-lit3372-repro'
TOOLS: []
```

3. The admin's own proxy log gives no version floor and no installable remedy

```
$ grep -m2 'streamable_http_client' proxy.log
13:27:44 - LiteLLM:WARNING: mcp_server_manager.py:4668 - Error listing tools from deepwiki: streamable_http_client is not available. Please install mcp with HTTP support.
13:27:44 - LiteLLM:WARNING: mcp_server_manager.py:4668 - Error listing tools from deepwiki: streamable_http_client is not available. Please install mcp with HTTP support.
```

#### pip install 'litellm[mcp]'

1. The natural remedy an admin would try does not exist on this commit, and mcp stays at the broken 1.23.0

```
$ uv pip install -p .venv-repro/bin/python -e '.[mcp]'
 ~ litellm==1.100.0 (from file:///.../lit3372_repro)
warning: The package `litellm @ file:///.../lit3372_repro` does not have an extra named `mcp`
$ uv pip list -p .venv-repro/bin/python | grep -i mcp
mcp                       1.23.0
```

#### SDK list_tools(raise_on_error=True)

1. A developer calling the litellm SDK directly against the real DeepWiki server gets the same vague error

```
$ .venv-repro/bin/python -c "
import asyncio
from litellm.experimental_mcp_client.client import MCPClient
from litellm.types.mcp import MCPTransport
asyncio.run(MCPClient(server_url='https://mcp.deepwiki.com/mcp', transport_type=MCPTransport.http).list_tools(raise_on_error=True))"
  File ".../litellm/experimental_mcp_client/client.py", line 326, in _create_transport_context
    raise ImportError("streamable_http_client is not available. Please install mcp with HTTP support.")
ImportError: streamable_http_client is not available. Please install mcp with HTTP support.
```

### After (09c9e4360e)

#### MCP gateway tool listing

1. Boot the proxy the same way and confirm it is up

```
$ .venv/bin/python litellm/proxy/proxy_cli.py --config lit3372_config.yaml --port 26450 --num_workers 2
$ curl -s http://localhost:26450/health/liveliness
"I'm alive!"
```

2. Same client command while the old mcp is still installed: the tool list is still empty, but the log (step 3) now says exactly what to do

```
$ uv run --no-project --with 'mcp==1.29.0' python lit3372_mcp_client.py http://localhost:26450/mcp 'Bearer sk-lit3372-repro'
TOOLS: []
```

3. The admin's proxy log now names the floor, the installed version, and the fix

```
$ grep -m2 'streamable' proxy.log
13:36:33 - LiteLLM:WARNING: mcp_server_manager.py:4668 - Error listing tools from deepwiki: MCP streamable HTTP transport requires mcp>=1.28.1, but the installed mcp 1.23.0 does not provide streamable_http_client. Fix with: pip install 'litellm[mcp]' (or upgrade mcp directly: pip install -U mcp)
```

4. Apply the remedy the error names, restart the proxy, rerun the exact same client command: all three real DeepWiki tools come back

```
$ uv pip install -p .venv/bin/python -e '.[mcp]'
$ .venv/bin/python litellm/proxy/proxy_cli.py --config lit3372_config.yaml --port 26450 --num_workers 2
$ uv run --no-project --with 'mcp==1.29.0' python lit3372_mcp_client.py http://localhost:26450/mcp 'Bearer sk-lit3372-repro'
TOOLS: ['deepwiki-ask_question', 'deepwiki-read_wiki_contents', 'deepwiki-read_wiki_structure']
```

#### pip install 'litellm[mcp]'

1. The extra now exists and lands mcp inside the pinned range

```
$ uv pip install -p .venv/bin/python -e '.[mcp]'
Prepared 1 package in 11.70s
Uninstalled 2 packages in 17ms
Installed 2 packages in 4ms
 ~ litellm==1.100.0 (from file:///.../lit3372_qa_after)
 - mcp==1.23.0
 + mcp==1.29.0
$ uv pip list -p .venv/bin/python | grep -i mcp
mcp                       1.29.0
```

#### SDK list_tools(raise_on_error=True)

1. Direct SDK use with the old mcp now raises the actionable error

```
$ .venv/bin/python -c "
import asyncio
from litellm.experimental_mcp_client.client import MCPClient
from litellm.types.mcp import MCPTransport
asyncio.run(MCPClient(server_url='https://mcp.deepwiki.com/mcp', transport_type=MCPTransport.http).list_tools(raise_on_error=True))"
  File ".../litellm/experimental_mcp_client/client.py", line 339, in _create_transport_context
    raise missing_streamable_http_client_error()
ImportError: MCP streamable HTTP transport requires mcp>=1.28.1, but the installed mcp 1.23.0 does not provide streamable_http_client. Fix with: pip install 'litellm[mcp]' (or upgrade mcp directly: pip install -U mcp)
```

/live-pr-risk CHECKED at 09c9e4360e: no breaking or backward-incompatible dependents; gateway tools/list and tools/call, direct SDK, and the extra's install surface were all A/B'd on live proxies at the merge base and the tip (2 uvicorn workers each, real DeepWiki upstream); nothing in the repo, tests, dashboard, or docs matches the old error text, the fault classifier keys on exception structure rather than message, and uv.lock resolved zero package version changes

## Type

🐛 Bug Fix

## Caveats (if any)

### Low

- Base `pip install litellm` still ships no mcp; the extra is opt-in
- Gateway still serves an empty tool list on old mcp; only the log/SDK error improved
- A vendored mcp without pip metadata would raise PackageNotFoundError instead of this ImportError

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Packaging and clearer import-time errors only; no change to MCP protocol behavior when a sufficient mcp version is installed.
> 
> **Overview**
> Adds a **`litellm[mcp]`** optional extra (`mcp>=1.28.1,<2.0`, aligned with the **`proxy`** extra) so admins can install a compatible MCP SDK without the full proxy stack.
> 
> When HTTP MCP transport needs **`streamable_http_client`** but the installed **`mcp`** package is too old or missing that symbol, **`MCPClient`** now raises an **`ImportError`** that states the required version, the installed **`mcp`** version, and **`pip install 'litellm[mcp]'`** (or upgrading **`mcp`** directly)—replacing the vague “install mcp with HTTP support” message.
> 
> Tests cover the error text, HTTP transport failure when **`streamable_http_client`** is absent, and that **`pyproject.toml`** **`mcp`** extra matches **`proxy`** and excludes **`1.23.0`** while accepting **`1.28.1`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 09c9e4360ef1027bbbf84e1fbd6551196aba92ef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->