### PR TITLE
fix(aiohttp): honor global ssl_verify on the aiohttp_openai handler path

### DIFF
--- a/litellm/llms/custom_httpx/aiohttp_handler.py
+++ b/litellm/llms/custom_httpx/aiohttp_handler.py
@@ -1,3 +1,4 @@
+import ssl
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Any, Final, cast
 
@@ -18,6 +19,7 @@ from litellm.llms.custom_httpx.http_handler import (
     AsyncHTTPHandler,
     HTTPHandler,
     _get_httpx_client,
+    get_ssl_configuration,
 )
 from litellm.types.llms.openai import FileTypes
 from litellm.types.utils import HttpHandlerRequestFields, ImageResponse, LlmProviders
@@ -56,7 +58,11 @@ class BaseLLMAIOHTTPHandler:
 
         # Create a transport using AsyncHTTPHandler's logic
         try:
-            self.transport = AsyncHTTPHandler._create_aiohttp_transport()
+            ssl_config: Final = get_ssl_configuration()
+            self.transport = AsyncHTTPHandler._create_aiohttp_transport(
+                ssl_verify=ssl_config if isinstance(ssl_config, bool) else None,
+                ssl_context=ssl_config if isinstance(ssl_config, ssl.SSLContext) else None,
+            )
             self._owns_transport = True
             return self.transport
         except Exception:
@@ -79,20 +85,19 @@ class BaseLLMAIOHTTPHandler:
 
     def _create_client_session_with_transport(self) -> ClientSession:
         """Create a new client session using transport or connector configuration."""
-        connector: Final = self._get_connector()
+        if self.transport is None:
+            connector: Final = self._get_connector()
+            if connector:
+                return aiohttp.ClientSession(connector=connector)
 
-        if self.transport and hasattr(self.transport, "_get_valid_client_session"):
-            # Use transport's session creation if available
-            session = self.transport._get_valid_client_session()
-            return session
-        elif connector:
-            # Use provided connector
-            session = aiohttp.ClientSession(connector=connector)
-            return session
-        else:
-            # Default session creation
-            session = aiohttp.ClientSession()
-            return session
+        transport: Final = self.transport or self._get_or_create_transport()
+        if transport is not None and hasattr(transport, "_get_valid_client_session"):
+            try:
+                return transport._get_valid_client_session()
+            except RuntimeError:
+                pass
+
+        return aiohttp.ClientSession()
 
     def _get_async_client_session(self, dynamic_client_session: ClientSession | None = None) -> ClientSession:
         if dynamic_client_session:

--- a/tests/test_litellm/llms/custom_httpx/test_aiohttp_handler.py
+++ b/tests/test_litellm/llms/custom_httpx/test_aiohttp_handler.py
@@ -3,7 +3,7 @@ from unittest.mock import AsyncMock, Mock, patch
 import aiohttp
 import pytest
 
-
+import litellm
 from litellm.llms.custom_httpx.aiohttp_handler import BaseLLMAIOHTTPHandler
 from litellm.llms.custom_httpx.aiohttp_transport import LiteLLMAiohttpTransport
 
@@ -318,19 +318,47 @@ class TestBaseLLMAIOHTTPHandler:
         mock_client_session.assert_called_once_with(connector=mock_connector)
         assert result is mock_session_instance
 
-    @patch("aiohttp.ClientSession")
-    def test_create_client_session_default(self, mock_client_session):
-        """Test default session creation when no transport/connector provided"""
-        mock_session_instance = Mock()
-        mock_client_session.return_value = mock_session_instance
+    @pytest.mark.asyncio
+    async def test_create_client_session_default_honors_global_ssl_verify_false(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        """Regression test for LIT-3369: `litellm.ssl_verify = False` (set via
+        `litellm_settings.ssl_verify: false`) must reach the default session's
+        connector instead of being ignored by a bare `aiohttp.ClientSession()`."""
+        monkeypatch.setattr(litellm, "ssl_verify", False)
 
         handler = BaseLLMAIOHTTPHandler()
+        session = handler._create_client_session_with_transport()
+        try:
+            assert isinstance(session.connector, aiohttp.TCPConnector)
+            assert session.connector._ssl is False
+        finally:
+            await session.close()
+            await handler.close()
 
-        result = handler._create_client_session_with_transport()
+    @pytest.mark.asyncio
+    async def test_create_client_session_default_keeps_ssl_verification(self):
+        """Default `ssl_verify=True` must not collapse to `ssl=False`."""
+        handler = BaseLLMAIOHTTPHandler()
+        session = handler._create_client_session_with_transport()
+        try:
+            assert isinstance(session.connector, aiohttp.TCPConnector)
+            assert session.connector._ssl is not False
+        finally:
+            await session.close()
+            await handler.close()
 
-        # Should create default session
-        mock_client_session.assert_called_once_with()
-        assert result is mock_session_instance
+    def test_get_or_create_transport_resolves_global_ssl_verify(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        """The lazily created transport must carry the resolved global ssl config."""
+        monkeypatch.setattr(litellm, "ssl_verify", False)
+
+        handler = BaseLLMAIOHTTPHandler()
+        transport = handler._get_or_create_transport()
+
+        assert transport is not None
+        assert transport._ssl_verify is False
 
     def test_get_or_create_transport(self):
         """Test that _get_or_create_transport creates or returns a transport.


### PR DESCRIPTION
## TLDR

Problem this solves:

- `litellm_settings.ssl_verify: false` was ignored by `aiohttp_openai/` models
- Requests to upstreams with self-signed or corporate-CA certs failed with SSLCertVerificationError

How it solves it:

- The aiohttp handler now builds its session from the resolved global ssl configuration
- Default sessions get a connector carrying `ssl_verify` instead of a bare `aiohttp.ClientSession()`

## User Flow

Before: an admin whose gateway must reach an upstream behind a TLS-intercepting proxy sets `ssl_verify: false`, but models configured with the `aiohttp_openai/` prefix still reject the certificate

1. The admin sets `litellm_settings: ssl_verify: false` in config.yaml, points an `aiohttp_openai/gpt-5.4-mini` model's `api_base` at the self-signed upstream, and restarts the proxy
2. A developer sends POST https://litellm-domain/v1/chat/completions with that model and a normal chat payload
3. They get a 500 back: `litellm.InternalServerError: Aiohttp_openaiException - Cannot connect to host ... ssl:True [SSLCertVerificationError: certificate verify failed: self-signed certificate]`
4. The same request against a plain `openai/` model on the same `api_base` returns 200, so only the `aiohttp_openai/` models ignore the setting

After: the same config now works for both model prefixes, and verification stays on when the setting is absent

1. The admin sets `litellm_settings: ssl_verify: false` in config.yaml, points an `aiohttp_openai/gpt-5.4-mini` model's `api_base` at the self-signed upstream, and restarts the proxy
2. A developer sends POST https://litellm-domain/v1/chat/completions with that model and a normal chat payload
3. They get a 200 with the model's real completion, same as the `openai/` model
4. Removing `ssl_verify: false` makes the request fail again with the certificate error, so verification is still the default

## Relevant issues

Supersedes #29126, which had the same diagnosis but went stale against a non-staging base branch

## Linear ticket

Resolves LIT-3369

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Setup, shared by both runs: a self-signed cert (CN=localhost) on an aiohttp TLS reverse proxy at https://127.0.0.1:37546 forwarding verbatim to the real https://api.openai.com, and a proxy config with two models on that `api_base`, `openai-default-path` (`openai/gpt-5.4-mini`) and `openai-aiohttp-path` (`aiohttp_openai/gpt-5.4-mini`), plus `litellm_settings.ssl_verify: false`. Every proxy runs with `--num_workers 2`; the control run uses the same config minus `ssl_verify` on its own port. All requests hit the real OpenAI API

```
curl -s http://127.0.0.1:<port><route> \
  -H "Authorization: Bearer sk-lit3369-repro" -H "x-api-key: sk-lit3369-repro" \
  -H "anthropic-version: 2023-06-01" -H "Content-Type: application/json" -d '<payload>'
```

Payloads: chat and messages send `{"model": "<model>", "messages": [{"role": "user", "content": "Say REPRO-OK and nothing else"}]}` (messages adds `"max_tokens": 64`), responses sends `{"model": "<model>", "input": "Say REPRO-OK and nothing else"}`

### Before (724c5c2d96)

#### POST /v1/chat/completions, openai default path

1. curl with `"model": "openai-default-path"`
2. 200, content `REPRO-OK` (real completion through the self-signed hop)

#### POST /v1/chat/completions, aiohttp_openai path

1. curl with `"model": "openai-aiohttp-path"`
2. 500, `litellm.InternalServerError: Aiohttp_openaiException - Cannot connect to host localhost:37546 ssl:True [SSLCertVerificationError: (1, '[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: self-signed certificate (_ssl.c:1010)')]`

#### POST /v1/messages, aiohttp_openai path

1. curl with `"model": "openai-aiohttp-path"`
2. 500, same `SSLCertVerificationError`

#### POST /v1/responses, aiohttp_openai path

1. curl with `"model": "openai-aiohttp-path"`
2. 500, same `SSLCertVerificationError`

#### safety control: config without ssl_verify, aiohttp_openai chat

1. Same chat curl against the control proxy
2. 500, same `SSLCertVerificationError` (verification on, as expected)

### After (f0412345b5)

#### POST /v1/chat/completions, openai default path

1. curl with `"model": "openai-default-path"`
2. 200, content `REPRO-OK`

#### POST /v1/chat/completions, aiohttp_openai path

1. curl with `"model": "openai-aiohttp-path"`, sent twice so both uvicorn workers serve one
2. 200 both times, content `REPRO-OK`

#### POST /v1/messages, aiohttp_openai path

1. curl with `"model": "openai-aiohttp-path"`
2. The SSL failure is gone: the request now traverses the self-signed hop and the real upstream answers 400 `Bad Request`, because `aiohttp_openai` forwards `max_tokens` raw and gpt-5.x rejects it. The same 400 comes back from `curl https://api.openai.com/v1/chat/completions` directly with `"max_tokens": 64` (`Unsupported parameter: 'max_tokens' is not supported with this model`), so that rejection is the provider's own, pre-existing and untouched by this PR

#### POST /v1/responses, aiohttp_openai path

1. curl with `"model": "openai-aiohttp-path"`
2. 200, a real response object whose output message reads `REPRO-OK`

#### safety control: config without ssl_verify, aiohttp_openai chat

1. Same chat curl against the control proxy
2. 500, same `SSLCertVerificationError` (default verification unchanged)

QA observations:

- aiohttp_openai forwards max_tokens raw; gpt-5.x upstreams reject it
  - Pre-existing: same 400 hitting OpenAI directly; this PR leaves it alone

## Type

🐛 Bug Fix

## Caveats (if any)

### Low

- Session creation outside a running event loop falls back to aiohttp defaults
- The global ssl setting is read once per process, at first session build
- Injected transports lacking the session helper no longer fall back to connector extraction

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

- [x] f0412345b5 passes /live-pr-risk
