### PR TITLE
fix(caching): require the namespace delimiter when checking already-namespaced redis keys

### DIFF
--- a/litellm/caching/redis_cache.py
+++ b/litellm/caching/redis_cache.py
@@ -435,7 +435,7 @@ class RedisCache(BaseCache):
         """
         if key is None:
             return key
-        if self.namespace is not None and not key.startswith(self.namespace):
+        if self.namespace is not None and not key.startswith(self.namespace + ":"):
             key = self.namespace + ":" + key
 
         return key

--- a/litellm/caching/redis_cache.py
+++ b/litellm/caching/redis_cache.py
@@ -435,7 +435,7 @@ class RedisCache(BaseCache):
         """
         if key is None:
             return key
-        if self.namespace is not None and not key.startswith(self.namespace + ":"):
+        if self.namespace and not key.startswith(self.namespace + ":"):
             key = self.namespace + ":" + key
 
         return key

--- a/tests/test_litellm/caching/test_redis_cache.py
+++ b/tests/test_litellm/caching/test_redis_cache.py
@@ -17,6 +17,30 @@ def redis_no_ping():
         yield
 
 
+@pytest.mark.parametrize(
+    ("namespace", "key", "expected"),
+    [
+        ("litellm", "litellm_spend_update_buffer", "litellm:litellm_spend_update_buffer"),
+        ("litellm", "litellm_config:param:general_settings", "litellm:litellm_config:param:general_settings"),
+        ("litellm", "litellm:3997c4abcdef", "litellm:3997c4abcdef"),
+        ("litellm", "spend:key:3997c4abcdef", "litellm:spend:key:3997c4abcdef"),
+        (None, "litellm_spend_update_buffer", "litellm_spend_update_buffer"),
+    ],
+)
+def test_check_and_fix_namespace_prefixes_keys_sharing_the_namespace_prefix(
+    namespace, key, expected, monkeypatch, redis_no_ping
+):
+    """A key whose name merely begins with the namespace string (e.g.
+    litellm_spend_update_buffer under namespace "litellm") is not namespaced
+    yet and must still get the "namespace:" prefix; only a key already carrying
+    the delimited prefix is left alone. Without this, spend update buffers and
+    litellm_config:param:* keys reach Redis unprefixed and NOPERM under an ACL
+    scoped to the namespace pattern."""
+    monkeypatch.setenv("REDIS_HOST", "https://my-test-host")
+    redis_cache = RedisCache(namespace=namespace)
+    assert redis_cache.check_and_fix_namespace(key=key) == expected
+
+
 @pytest.mark.parametrize("namespace", [None, "litellm"])
 @pytest.mark.asyncio
 async def test_async_delete_cache_applies_namespace(

--- a/tests/test_litellm/caching/test_redis_cache.py
+++ b/tests/test_litellm/caching/test_redis_cache.py
@@ -25,6 +25,7 @@ def redis_no_ping():
         ("litellm", "litellm:3997c4abcdef", "litellm:3997c4abcdef"),
         ("litellm", "spend:key:3997c4abcdef", "litellm:spend:key:3997c4abcdef"),
         (None, "litellm_spend_update_buffer", "litellm_spend_update_buffer"),
+        ("", "litellm_spend_update_buffer", "litellm_spend_update_buffer"),
     ],
 )
 def test_check_and_fix_namespace_prefixes_keys_sharing_the_namespace_prefix(


### PR DESCRIPTION
## TLDR

Problem this solves:

- Cache namespace "litellm" plus a scoped Valkey/Redis ACL breaks spend tracking
- Keys whose literal names start with "litellm" were treated as already namespaced
- So `litellm_spend_update_buffer`, the daily buffers, and `litellm_config:param:*` hit Redis unprefixed
- A least-privilege `~litellm:*` ACL then denies them: "No permissions to access a key"
- Spend loops through in-memory retry queues forever and never lands

How it solves it:

- A key counts as already namespaced only when it starts with `<namespace>:`, delimiter included
- The internal buffer and config keys now get the prefix like every other key
- An empty-string namespace keeps meaning no namespace, exactly as before

## User Flow

Before: an operator who scopes their Valkey user to the cache namespace watches spend tracking break

1. The operator sets cache namespace `litellm` in the proxy config, creates a Valkey user granted only `~litellm:*` per their security team's least-privilege policy, and boots two proxy replicas with `use_redis_transaction_buffer: true`
2. A developer sends POST https://litellm-domain/v1/chat/completions with a virtual key and gets a normal 200 completion back
3. The proxy logs immediately stream "No permissions to access a key" every few seconds, plus "Restoring N transaction sets to in-memory queues for retry on next tick"
4. Minutes after the traffic, GET https://litellm-domain/key/info for that key still shows `"spend": 0.0`, so budgets and spend reports read zero indefinitely

After: the same setup tracks spend normally under the same scoped ACL

1. The operator sets cache namespace `litellm` in the proxy config, creates a Valkey user granted only `~litellm:*` per their security team's least-privilege policy, and boots two proxy replicas with `use_redis_transaction_buffer: true`
2. A developer sends POST https://litellm-domain/v1/chat/completions with a virtual key and gets a normal 200 completion back
3. The proxy logs show no key permission errors; every key the proxy touches lives under the granted `litellm:*` pattern
4. GET https://litellm-domain/key/info shows real spend (`"spend": 0.000165`) after the next flush window, so budgets and reports are accurate

## Relevant issues

## Linear ticket

Resolves LIT-3373

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Shared setup for both legs: a local Valkey with a least-privilege user, two proxy processes with 2 uvicorn workers each sharing one fresh database and that Valkey, real OpenAI calls

```
docker run -d --name lit3373-valkey -p 127.0.0.1:53134:6379 valkey/valkey-bundle:latest
docker exec lit3373-valkey valkey-cli ACL SETUSER litellmacl on '>lit3373aclpass' '~litellm:*' +@all
```

```yaml
model_list:
  - model_name: gpt-5.4-mini
    litellm_params:
      model: openai/gpt-5.4-mini
      api_key: os.environ/OPENAI_API_KEY

litellm_settings:
  cache: true
  cache_params:
    type: redis
    host: "127.0.0.1"
    port: 53134
    username: litellmacl
    password: lit3373aclpass
    namespace: "litellm"

general_settings:
  use_redis_transaction_buffer: true
```

Both legs run the identical sequence: `/key/generate` on process 1, then the three endpoints alternating across the two processes, a 90s wait for the spend flush window, then `/key/info` read back through the other process

### Before (f6571a653f)

#### /v1/chat/completions

1. `curl -sS http://localhost:24363/v1/chat/completions -H "Authorization: Bearer $KEY" -d '{"model": "gpt-5.4-mini", "messages": [{"role": "user", "content": "Say hi in five words"}]}'`
2. 200: `{"id": "chatcmpl-EHEWSrpf05bzYI24MFOo1ROriHyBg", "content": "Hi there, nice to meet you.", "total_tokens": 22}` (requests keep serving; the damage is behind the scenes)

#### /v1/responses

1. `curl -sS http://localhost:48682/v1/responses -H "Authorization: Bearer $KEY" -d '{"model": "gpt-5.4-mini", "input": "Name one planet, one word"}'` (second proxy process)
2. 200: `{"id": "resp_...", "status": "completed", "text": "Mars"}`

#### /v1/messages

1. `curl -sS http://localhost:24363/v1/messages -H "Authorization: Bearer $KEY" -d '{"model": "gpt-5.4-mini", "max_tokens": 64, "messages": [{"role": "user", "content": "Name one color, one word"}]}'`
2. 200: `{"role": "assistant", "text": "Blue", "usage": {"input_tokens": 12, "output_tokens": 5}}`

#### Spend tracking under the scoped ACL

1. 90s after that traffic: `curl -sS http://localhost:48682/key/info -H "Authorization: Bearer $KEY"` returns `{"key_alias": "lit3373-qa-before", "spend": 0.0}`: the spend never lands
2. Proxy logs: 266 and 270 "No permissions" lines on the two processes in ~6 minutes, e.g. `redis_update_buffer.py:264 - Spend tracking - failed to push aggregated spend updates to Redis. Restoring 3 transaction sets to in-memory queues for retry on next tick. Error: Command # 1 (RPUSH litellm_spend_update_buffer ...) of pipeline caused error: ('No permissions to access a key',)`
3. Valkey `ACL LOG` shows every denied key is unprefixed: `litellm_spend_update_buffer`, `litellm_daily_{,tag_,team_,org_,end_user_,agent_}spend_update_buffer`, `litellm_config:param:{general_settings,litellm_settings,router_settings,environment_variables,anthropic_beta_headers_reload_config}`

### After (57f553aec8)

#### /v1/chat/completions

1. `curl -sS http://localhost:25646/v1/chat/completions -H "Authorization: Bearer $KEY" -d '{"model": "gpt-5.4-mini", "messages": [{"role": "user", "content": "Say hi in five words"}]}'`
2. 200: `{"id": "chatcmpl-EHErlnWXpZLUEjQtUnbksXLHlPzcX", "content": "Hi there, nice to meet you.", "total_tokens": 22}`

#### /v1/responses

1. `curl -sS http://localhost:52177/v1/responses -H "Authorization: Bearer $KEY" -d '{"model": "gpt-5.4-mini", "input": "Name one planet, one word"}'` (second proxy process)
2. 200: `{"id": "resp_...", "status": "completed", "text": "Mars"}`

#### /v1/messages

1. `curl -sS http://localhost:25646/v1/messages -H "Authorization: Bearer $KEY" -d '{"model": "gpt-5.4-mini", "max_tokens": 64, "messages": [{"role": "user", "content": "Name one color, one word"}]}'`
2. 200: `{"role": "assistant", "text": "Blue", "usage": {"input_tokens": 12, "output_tokens": 5}}`

#### Spend tracking under the scoped ACL

1. 90s after the same traffic: `curl -sS http://localhost:52177/key/info -H "Authorization: Bearer $KEY"` returns `{"key_alias": "lit3373-qa-after", "spend": 0.000165}`: spend lands, read back through the other process
2. Proxy logs: zero "No permissions to access a key" lines on either process
3. Valkey `ACL LOG` holds only the two pubsub channel entries (see Caveats); every key in the store is prefixed, e.g. `litellm:litellm_config:param:general_settings`, `litellm:{api_key:...}:requests`
4. Channel remedy proven live at 7b8d48782b: after `docker exec lit3373-valkey valkey-cli ACL SETUSER litellmacl resetchannels '&litellm:*'`, the every-5s "No permissions to access a channel" warnings stop on both processes within the next minute with no restart (the follow-up commit only changes empty-namespace handling and cannot affect channels)

/live-pr-risk CHECKED at 57f553aec8: one external dependent (MCP refresh lock passes the method as a callable; its `mcp:refresh_lock:*` keys are unaffected), no overrides, no string dispatch, no wire-contract fields; the changed key class was driven live base-vs-head on the 2-process x 2-worker rig above. The empty-namespace guard commit restores the merge base's exact behavior for `namespace: ""` (unit-tested), so its only delta vs base is nothing. The deliberate key rename for colliding namespaces is the Medium caveat below

## Type

🐛 Bug Fix

## Caveats (if any)

### Medium

- Config sync pubsub channels still need an ACL channel grant: `&litellm:*`
  - Valkey/Redis 7 `resetchannels` default denies all channels to new users
  - One-line remedy shown in the proof; documented in BerriAI/litellm-docs#1034 (merged)
- Rolling upgrade with a colliding namespace ("litellm") renames the buffer keys
  - Spend buffered under the old unprefixed name at switchover is not drained
  - Bounded by one flush tick; scoped-ACL deployments lost that spend entirely before

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

- [x] 57f553aec8 passes /live-pr-risk
