### PR TITLE
fix(prompts): reject keyed prompt_data with prompt_id and populate prompt version

### DIFF
--- a/litellm/integrations/dotprompt/__init__.py
+++ b/litellm/integrations/dotprompt/__init__.py
@@ -62,12 +62,16 @@ def prompt_initializer(litellm_params: "PromptLiteLLMParams", prompt_spec: "Prom
     if dotprompt_content and not prompt_data and not prompt_file:
         prompt_data = _get_prompt_data_from_dotprompt_content(dotprompt_content)
 
+    from .prompt_manager import strip_version_suffix
+
+    registration_prompt_id: Final = prompt_id or strip_version_suffix(prompt_spec.prompt_id) or prompt_spec.prompt_id
+
     try:
         dot_prompt_manager: Final = DotpromptManager(
             prompt_directory=prompt_directory,
             prompt_data=prompt_data,
             prompt_file=prompt_file,
-            prompt_id=prompt_id,
+            prompt_id=registration_prompt_id,
         )
 
         return dot_prompt_manager

--- a/litellm/integrations/dotprompt/dotprompt_manager.py
+++ b/litellm/integrations/dotprompt/dotprompt_manager.py
@@ -96,7 +96,7 @@ class DotpromptManager(CustomPromptManagement):
         if prompt_id is None:
             return False
         try:
-            return prompt_id in self.prompt_manager.list_prompts()
+            return self.prompt_manager.get_prompt(prompt_id) is not None
         except Exception:
             # If there's any error accessing prompts, don't run prompt management
             return False

--- a/litellm/integrations/dotprompt/prompt_manager.py
+++ b/litellm/integrations/dotprompt/prompt_manager.py
@@ -11,6 +11,13 @@ from jinja2 import DictLoader, select_autoescape
 from jinja2.sandbox import ImmutableSandboxedEnvironment
 
 
+def strip_version_suffix(prompt_id: str) -> str | None:
+    base, separator, version = prompt_id.rpartition(".v")
+    if separator and base and version.isdigit():
+        return base
+    return None
+
+
 class PromptTemplate:
     """Represents a single prompt template with metadata and content."""
 
@@ -124,11 +131,13 @@ class PromptManager:
             "content": "template content",
             "metadata": {"model": "gpt-4", "temperature": 0.7, ...}
         } + prompt_id
-        """
-        if prompt_id:
-            prompt_data = {prompt_id: prompt_data}
 
-        for prompt_id, prompt_info in prompt_data.items():
+        A dict carrying a "content" key is a single flat template registered under
+        prompt_id; anything else is treated as already keyed by template ID.
+        """
+        keyed_prompts: Final = {prompt_id: prompt_data} if prompt_id and "content" in prompt_data else prompt_data
+
+        for template_id, prompt_info in keyed_prompts.items():
             try:
                 content = prompt_info.get("content", "")
                 metadata = prompt_info.get("metadata", {})
@@ -136,11 +145,11 @@ class PromptManager:
                 template = PromptTemplate(
                     content=content,
                     metadata=metadata,
-                    template_id=prompt_id,
+                    template_id=template_id,
                 )
-                self.prompts[prompt_id] = template
+                self.prompts[template_id] = template
             except Exception:
-                # Optional: print(f"Error loading prompt from JSON: {prompt_id}")
+                # Optional: print(f"Error loading prompt from JSON: {template_id}")
                 pass
 
     def _load_prompt_file(self, file_path: str | Path, prompt_id: str) -> PromptTemplate:
@@ -272,8 +281,12 @@ class PromptManager:
             if versioned_id in self.prompts:
                 return self.prompts[versioned_id]
 
-        # Fall back to base prompt_id
-        return self.prompts.get(prompt_id)
+        direct_match: Final = self.prompts.get(prompt_id)
+        if direct_match is not None:
+            return direct_match
+
+        base_prompt_id: Final = strip_version_suffix(prompt_id)
+        return self.prompts.get(base_prompt_id) if base_prompt_id else None
 
     def list_prompts(self) -> list[str]:
         """Get a list of all available prompt IDs."""

--- a/litellm/proxy/_lazy_openapi_snapshot.json
+++ b/litellm/proxy/_lazy_openapi_snapshot.json
@@ -23538,7 +23538,7 @@
     "paths": {
       "/prompts": {
         "post": {
-          "description": "Create a new prompt\n\n\ud83d\udc49 [Prompt docs](https://docs.litellm.ai/docs/proxy/prompt_management)\n\nExample Request:\n```bash\ncurl -X POST \"http://localhost:4000/prompts\" \\\n    -H \"Authorization: Bearer <your_api_key>\" \\\n    -H \"Content-Type: application/json\" \\\n    -d '{\n        \"prompt_id\": \"my_prompt\",\n        \"litellm_params\": {\n            \"prompt_id\": \"json_prompt\",\n            \"prompt_integration\": \"dotprompt\",\n            ### EITHER prompt_directory OR prompt_data MUST BE PROVIDED\n            \"prompt_directory\": \"/path/to/dotprompt/folder\",\n            \"prompt_data\": {\"json_prompt\": {\"content\": \"This is a prompt\", \"metadata\": {\"model\": \"gpt-4\"}}}\n        },\n        \"prompt_info\": {\n            \"prompt_type\": \"config\"\n        }\n    }'\n```",
+          "description": "Create a new prompt\n\n\ud83d\udc49 [Prompt docs](https://docs.litellm.ai/docs/proxy/prompt_management)\n\nExample Request:\n```bash\ncurl -X POST \"http://localhost:4000/prompts\" \\\n    -H \"Authorization: Bearer <your_api_key>\" \\\n    -H \"Content-Type: application/json\" \\\n    -d '{\n        \"prompt_id\": \"my_prompt\",\n        \"litellm_params\": {\n            \"prompt_id\": \"my_prompt\",\n            \"prompt_integration\": \"dotprompt\",\n            \"prompt_data\": {\"content\": \"This is a prompt\", \"metadata\": {\"model\": \"gpt-4\"}}\n        },\n        \"prompt_info\": {\n            \"prompt_type\": \"config\"\n        }\n    }'\n```",
           "operationId": "create_prompt_prompts_post",
           "requestBody": {
             "content": {

--- a/litellm/proxy/prompts/prompt_endpoints.py
+++ b/litellm/proxy/prompts/prompt_endpoints.py
@@ -1106,6 +1106,9 @@ async def patch_prompt(
     if prisma_client is None:
         raise HTTPException(status_code=500, detail=CommonProxyErrors.db_not_connected_error.value)
 
+    if request.litellm_params is not None and is_ambiguous_keyed_prompt_data(request.litellm_params):
+        raise HTTPException(status_code=400, detail=AMBIGUOUS_PROMPT_DATA_ERROR)
+
     try:
         # Resolve the target row: find the latest version in the given environment
         base_prompt_id: Final = get_base_prompt_id(prompt_id=prompt_id)
@@ -1162,9 +1165,6 @@ async def patch_prompt(
         # Ensure we have valid litellm_params
         if updated_litellm_params is None:
             raise HTTPException(status_code=400, detail="litellm_params cannot be None")
-
-        if is_ambiguous_keyed_prompt_data(updated_litellm_params):
-            raise HTTPException(status_code=400, detail=AMBIGUOUS_PROMPT_DATA_ERROR)
 
         # Build update data dict
         update_data: Final[dict[str, str]] = {

--- a/litellm/proxy/prompts/prompt_endpoints.py
+++ b/litellm/proxy/prompts/prompt_endpoints.py
@@ -323,6 +323,7 @@ def create_versioned_prompt_spec(db_prompt: _PromptRow) -> PromptSpec:
         prompt_info=prompt_info,
         created_at=row.created_at,
         updated_at=row.updated_at,
+        version=row.version,
         environment=row.environment,
         created_by=row.created_by,
     )
@@ -332,6 +333,21 @@ class Prompt(BaseModel):
     prompt_id: str
     litellm_params: PromptLiteLLMParams
     prompt_info: PromptInfo | None = None
+
+
+AMBIGUOUS_PROMPT_DATA_ERROR: Final = (
+    "litellm_params.prompt_id cannot be combined with prompt_data keyed by template name. "
+    'Send a flat template, prompt_data={"content": "...", "metadata": {...}}, together with litellm_params.prompt_id, '
+    'or send prompt_data={"<template_id>": {"content": "...", "metadata": {...}}} without litellm_params.prompt_id.'
+)
+
+
+def is_ambiguous_keyed_prompt_data(litellm_params: PromptLiteLLMParams) -> bool:
+    extra_fields: Final = litellm_params.model_extra or {}
+    prompt_data: Final = extra_fields.get("prompt_data")
+    if not litellm_params.prompt_id or not isinstance(prompt_data, dict):
+        return False
+    return bool(prompt_data) and "content" not in prompt_data
 
 
 class PatchPromptRequest(BaseModel):
@@ -737,11 +753,9 @@ async def create_prompt(
         -d '{
             "prompt_id": "my_prompt",
             "litellm_params": {
-                "prompt_id": "json_prompt",
+                "prompt_id": "my_prompt",
                 "prompt_integration": "dotprompt",
-                ### EITHER prompt_directory OR prompt_data MUST BE PROVIDED
-                "prompt_directory": "/path/to/dotprompt/folder",
-                "prompt_data": {"json_prompt": {"content": "This is a prompt", "metadata": {"model": "gpt-4"}}}
+                "prompt_data": {"content": "This is a prompt", "metadata": {"model": "gpt-4"}}
             },
             "prompt_info": {
                 "prompt_type": "config"
@@ -762,6 +776,9 @@ async def create_prompt(
 
     if prisma_client is None:
         raise HTTPException(status_code=500, detail=CommonProxyErrors.db_not_connected_error.value)
+
+    if is_ambiguous_keyed_prompt_data(request.litellm_params):
+        raise HTTPException(status_code=400, detail=AMBIGUOUS_PROMPT_DATA_ERROR)
 
     try:
         # Extract environment from request
@@ -856,6 +873,9 @@ async def update_prompt(
 
     if prisma_client is None:
         raise HTTPException(status_code=500, detail=CommonProxyErrors.db_not_connected_error.value)
+
+    if is_ambiguous_keyed_prompt_data(request.litellm_params):
+        raise HTTPException(status_code=400, detail=AMBIGUOUS_PROMPT_DATA_ERROR)
 
     try:
         # Strip version suffix from prompt_id if present (e.g., "jack_success.v1" -> "jack_success")
@@ -1142,6 +1162,9 @@ async def patch_prompt(
         # Ensure we have valid litellm_params
         if updated_litellm_params is None:
             raise HTTPException(status_code=400, detail="litellm_params cannot be None")
+
+        if is_ambiguous_keyed_prompt_data(updated_litellm_params):
+            raise HTTPException(status_code=400, detail=AMBIGUOUS_PROMPT_DATA_ERROR)
 
         # Build update data dict
         update_data: Final[dict[str, str]] = {

--- a/litellm/proxy/prompts/prompt_registry.py
+++ b/litellm/proxy/prompts/prompt_registry.py
@@ -147,6 +147,9 @@ class InMemoryPromptRegistry:
             prompt_info=prompt.prompt_info or PromptInfo(prompt_type="config"),
             created_at=prompt.created_at,
             updated_at=prompt.updated_at,
+            version=prompt.version,
+            environment=prompt.environment,
+            created_by=prompt.created_by,
         )
 
         # store references to the prompt in memory

--- a/tests/test_litellm/integrations/dotprompt/test_prompt_manager.py
+++ b/tests/test_litellm/integrations/dotprompt/test_prompt_manager.py
@@ -577,3 +577,83 @@ async def test_dotprompt_with_prompt_version():
     )
     assert "Version 2:" in v2_rendered
     assert "Test v2" in v2_rendered
+
+
+def test_keyed_prompt_data_with_prompt_id_keeps_real_content():
+    prompt_data = {
+        "json_prompt": {
+            "content": "You are a pirate. Begin every reply with AHOY.",
+            "metadata": {"model": "gpt-4o-mini"},
+        }
+    }
+
+    manager = PromptManager(prompt_data=prompt_data, prompt_id="agent-prompt")
+
+    template = manager.get_prompt("json_prompt")
+    assert template is not None
+    assert template.content == "You are a pirate. Begin every reply with AHOY."
+    assert template.model == "gpt-4o-mini"
+    assert "agent-prompt" not in manager.prompts
+
+
+def test_flat_prompt_data_with_prompt_id_registers_under_prompt_id():
+    manager = PromptManager(
+        prompt_data={"content": "Hello {{name}}", "metadata": {"model": "gpt-4o-mini"}},
+        prompt_id="flat-prompt",
+    )
+
+    template = manager.get_prompt("flat-prompt")
+    assert template is not None
+    assert template.content == "Hello {{name}}"
+    assert manager.render("flat-prompt", {"name": "world"}) == "Hello world"
+
+
+def test_get_prompt_falls_back_to_base_id_for_versioned_id():
+    manager = PromptManager(
+        prompt_data={"content": "Hi", "metadata": {}},
+        prompt_id="my-prompt",
+    )
+
+    assert manager.get_prompt("my-prompt.v1") is not None
+    assert manager.get_prompt("my-prompt.v12") is not None
+    assert manager.get_prompt("my-prompt.vx") is None
+    assert manager.get_prompt("other-prompt.v1") is None
+
+
+def test_should_run_prompt_management_accepts_versioned_id():
+    from litellm.integrations.dotprompt import DotpromptManager
+
+    dotprompt_manager = DotpromptManager(
+        prompt_data={"content": "Hi", "metadata": {}},
+        prompt_id="versioned-prompt",
+    )
+
+    assert dotprompt_manager.should_run_prompt_management("versioned-prompt", None, {}) is True
+    assert dotprompt_manager.should_run_prompt_management("versioned-prompt.v1", None, {}) is True
+    assert dotprompt_manager.should_run_prompt_management("missing-prompt", None, {}) is False
+
+
+def test_prompt_initializer_registers_flat_db_prompt_under_base_id():
+    from litellm.integrations.dotprompt import DotpromptManager, prompt_initializer
+    from litellm.types.prompts.init_prompts import (
+        PromptInfo,
+        PromptLiteLLMParams,
+        PromptSpec,
+    )
+
+    litellm_params = PromptLiteLLMParams(
+        prompt_integration="dotprompt",
+        prompt_data={"content": "AHOY {{name}}", "metadata": {"model": "gpt-4o-mini"}},
+    )
+    prompt_spec = PromptSpec(
+        prompt_id="agent-prompt.v1",
+        litellm_params=litellm_params,
+        prompt_info=PromptInfo(prompt_type="db"),
+    )
+
+    dotprompt_manager = prompt_initializer(litellm_params, prompt_spec)
+
+    assert isinstance(dotprompt_manager, DotpromptManager)
+    template = dotprompt_manager.prompt_manager.get_prompt("agent-prompt")
+    assert template is not None
+    assert template.content == "AHOY {{name}}"

--- a/tests/test_litellm/proxy/prompts/test_prompt_endpoints_crud.py
+++ b/tests/test_litellm/proxy/prompts/test_prompt_endpoints_crud.py
@@ -1,3 +1,4 @@
+import json
 import pytest
 from unittest.mock import MagicMock, AsyncMock, patch
 from litellm.proxy._types import UserAPIKeyAuth, LitellmUserRoles
@@ -307,6 +308,98 @@ async def test_create_prompt_rejects_keyed_prompt_data_with_prompt_id():
 
     assert exc_info.value.status_code == 400
     assert exc_info.value.detail == AMBIGUOUS_PROMPT_DATA_ERROR
+
+
+@pytest.mark.asyncio
+async def test_patch_prompt_rejects_keyed_prompt_data_with_prompt_id():
+    from fastapi import HTTPException
+
+    from litellm.proxy.prompts.prompt_endpoints import (
+        AMBIGUOUS_PROMPT_DATA_ERROR,
+        PatchPromptRequest,
+        patch_prompt,
+    )
+
+    mock_user_auth = UserAPIKeyAuth(
+        api_key="sk-1234", user_role=LitellmUserRoles.PROXY_ADMIN
+    )
+    request = PatchPromptRequest(
+        litellm_params=PromptLiteLLMParams(
+            prompt_id="agent-prompt",
+            prompt_integration="dotprompt",
+            prompt_data={"json_prompt": {"content": "AHOY", "metadata": {}}},
+        ),
+    )
+
+    with patch("litellm.proxy.proxy_server.prisma_client", MagicMock()):  # test-quality-ok: proxy_server module global is the endpoint's only injection point
+        with pytest.raises(HTTPException) as exc_info:
+            await patch_prompt(
+                prompt_id="agent-prompt",
+                request=request,
+                user_api_key_dict=mock_user_auth,
+            )
+
+    assert exc_info.value.status_code == 400
+    assert exc_info.value.detail == AMBIGUOUS_PROMPT_DATA_ERROR
+
+
+@pytest.mark.asyncio
+async def test_patch_prompt_info_only_keeps_legacy_keyed_row_patchable():
+    from litellm.proxy.prompts.prompt_endpoints import PatchPromptRequest, patch_prompt
+
+    mock_user_auth = UserAPIKeyAuth(
+        api_key="sk-1234", user_role=LitellmUserRoles.PROXY_ADMIN
+    )
+    legacy_params = PromptLiteLLMParams(
+        prompt_id="agent-prompt",
+        prompt_integration="dotprompt",
+        prompt_data={"json_prompt": {"content": "AHOY", "metadata": {}}},
+    )
+    target_row = MagicMock()
+    target_row.id = "row-1"
+    target_row.version = 1
+    updated_row = MagicMock()
+    updated_row.model_dump.return_value = {
+        "prompt_id": "agent-prompt",
+        "version": 1,
+        "environment": "production",
+        "created_by": None,
+        "litellm_params": legacy_params.model_dump_json(),
+        "prompt_info": PromptInfo(prompt_type="db", environment="production").model_dump_json(),
+    }
+
+    mock_prisma_client = MagicMock()
+    mock_prisma_client.db.litellm_prompttable.find_many = AsyncMock(
+        return_value=[target_row]
+    )
+    mock_prisma_client.db.litellm_prompttable.update = AsyncMock(return_value=updated_row)
+
+    existing_prompt = PromptSpec(
+        prompt_id="agent-prompt.v1",
+        litellm_params=legacy_params,
+        prompt_info=PromptInfo(prompt_type="db"),
+    )
+
+    with (
+        patch("litellm.proxy.proxy_server.prisma_client", mock_prisma_client),  # test-quality-ok: proxy_server module global is the endpoint's only injection point
+        patch(  # test-quality-ok: keeps the registry reload from touching global callback state
+            "litellm.proxy.prompts.prompt_registry.IN_MEMORY_PROMPT_REGISTRY"
+        ) as mock_registry,
+    ):
+        mock_registry.get_prompt_by_id.return_value = existing_prompt
+
+        await patch_prompt(
+            prompt_id="agent-prompt",
+            request=PatchPromptRequest(prompt_info=PromptInfo(prompt_type="db", environment="production")),
+            user_api_key_dict=mock_user_auth,
+        )
+
+    update_kwargs = mock_prisma_client.db.litellm_prompttable.update.await_args.kwargs
+    assert update_kwargs["where"] == {"id": "row-1"}
+    assert json.loads(update_kwargs["data"]["prompt_info"])["environment"] == "production"
+    assert json.loads(update_kwargs["data"]["litellm_params"])["prompt_data"] == {
+        "json_prompt": {"content": "AHOY", "metadata": {}}
+    }
 
 
 @pytest.mark.asyncio

--- a/tests/test_litellm/proxy/prompts/test_prompt_endpoints_crud.py
+++ b/tests/test_litellm/proxy/prompts/test_prompt_endpoints_crud.py
@@ -246,3 +246,149 @@ async def test_patch_prompt_row_deleted_mid_update_returns_404():
         exc_info.value.detail
         == "Prompt with ID test_prompt not found in environment development"
     )
+
+
+def test_is_ambiguous_keyed_prompt_data_shapes():
+    from litellm.proxy.prompts.prompt_endpoints import is_ambiguous_keyed_prompt_data
+
+    keyed_with_id = PromptLiteLLMParams(
+        prompt_id="agent-prompt",
+        prompt_integration="dotprompt",
+        prompt_data={"json_prompt": {"content": "AHOY", "metadata": {}}},
+    )
+    flat_with_id = PromptLiteLLMParams(
+        prompt_id="agent-prompt",
+        prompt_integration="dotprompt",
+        prompt_data={"content": "AHOY", "metadata": {}},
+    )
+    keyed_without_id = PromptLiteLLMParams(
+        prompt_integration="dotprompt",
+        prompt_data={"json_prompt": {"content": "AHOY", "metadata": {}}},
+    )
+    no_prompt_data = PromptLiteLLMParams(
+        prompt_id="agent-prompt", prompt_integration="dotprompt"
+    )
+    empty_prompt_data = PromptLiteLLMParams(
+        prompt_id="agent-prompt", prompt_integration="dotprompt", prompt_data={}
+    )
+
+    assert is_ambiguous_keyed_prompt_data(keyed_with_id) is True
+    assert is_ambiguous_keyed_prompt_data(flat_with_id) is False
+    assert is_ambiguous_keyed_prompt_data(keyed_without_id) is False
+    assert is_ambiguous_keyed_prompt_data(no_prompt_data) is False
+    assert is_ambiguous_keyed_prompt_data(empty_prompt_data) is False
+
+
+@pytest.mark.asyncio
+async def test_create_prompt_rejects_keyed_prompt_data_with_prompt_id():
+    from fastapi import HTTPException
+
+    from litellm.proxy.prompts.prompt_endpoints import (
+        AMBIGUOUS_PROMPT_DATA_ERROR,
+        Prompt,
+        create_prompt,
+    )
+
+    mock_user_auth = UserAPIKeyAuth(
+        api_key="sk-1234", user_role=LitellmUserRoles.PROXY_ADMIN
+    )
+    request = Prompt(
+        prompt_id="agent-prompt",
+        litellm_params=PromptLiteLLMParams(
+            prompt_id="agent-prompt",
+            prompt_integration="dotprompt",
+            prompt_data={"json_prompt": {"content": "AHOY", "metadata": {}}},
+        ),
+    )
+
+    with patch("litellm.proxy.proxy_server.prisma_client", MagicMock()):  # test-quality-ok: proxy_server module global is the endpoint's only injection point
+        with pytest.raises(HTTPException) as exc_info:
+            await create_prompt(request=request, user_api_key_dict=mock_user_auth)
+
+    assert exc_info.value.status_code == 400
+    assert exc_info.value.detail == AMBIGUOUS_PROMPT_DATA_ERROR
+
+
+@pytest.mark.asyncio
+async def test_update_prompt_rejects_keyed_prompt_data_with_prompt_id():
+    from fastapi import HTTPException
+
+    from litellm.proxy.prompts.prompt_endpoints import (
+        AMBIGUOUS_PROMPT_DATA_ERROR,
+        Prompt,
+        update_prompt,
+    )
+
+    mock_user_auth = UserAPIKeyAuth(
+        api_key="sk-1234", user_role=LitellmUserRoles.PROXY_ADMIN
+    )
+    request = Prompt(
+        prompt_id="agent-prompt",
+        litellm_params=PromptLiteLLMParams(
+            prompt_id="agent-prompt",
+            prompt_integration="dotprompt",
+            prompt_data={"json_prompt": {"content": "AHOY", "metadata": {}}},
+        ),
+    )
+
+    with patch("litellm.proxy.proxy_server.prisma_client", MagicMock()):  # test-quality-ok: proxy_server module global is the endpoint's only injection point
+        with pytest.raises(HTTPException) as exc_info:
+            await update_prompt(
+                prompt_id="agent-prompt",
+                request=request,
+                user_api_key_dict=mock_user_auth,
+            )
+
+    assert exc_info.value.status_code == 400
+    assert exc_info.value.detail == AMBIGUOUS_PROMPT_DATA_ERROR
+
+
+def test_create_versioned_prompt_spec_populates_version():
+    from litellm.proxy.prompts.prompt_endpoints import create_versioned_prompt_spec
+
+    db_prompt = MagicMock()
+    db_prompt.model_dump.return_value = {
+        "prompt_id": "agent-prompt",
+        "version": 3,
+        "environment": "development",
+        "created_by": "user-1",
+        "litellm_params": {
+            "prompt_id": "agent-prompt",
+            "prompt_integration": "dotprompt",
+        },
+        "prompt_info": {"prompt_type": "db"},
+        "created_at": None,
+        "updated_at": None,
+    }
+
+    prompt_spec = create_versioned_prompt_spec(db_prompt=db_prompt)
+
+    assert prompt_spec.prompt_id == "agent-prompt.v3"
+    assert prompt_spec.version == 3
+
+
+def test_initialize_prompt_keeps_version_and_created_by():
+    import litellm
+    from litellm.proxy.prompts.prompt_registry import InMemoryPromptRegistry
+
+    registry = InMemoryPromptRegistry()
+    prompt_spec = PromptSpec(
+        prompt_id="agent-prompt.v3",
+        litellm_params=PromptLiteLLMParams(
+            prompt_id="agent-prompt",
+            prompt_integration="dotprompt",
+            prompt_data={"content": "AHOY", "metadata": {}},
+        ),
+        prompt_info=PromptInfo(prompt_type="db"),
+        version=3,
+        environment="development",
+        created_by="user-1",
+    )
+
+    with patch.object(litellm.logging_callback_manager, "add_litellm_callback"):  # test-quality-ok: keeps initialize_prompt from registering a global callback that would leak across tests
+        initialized_prompt = registry.initialize_prompt(prompt=prompt_spec)
+
+    assert initialized_prompt is not None
+    assert initialized_prompt.version == 3
+    assert initialized_prompt.created_by == "user-1"
+    assert initialized_prompt.environment == "development"

--- a/ui/litellm-dashboard/src/lib/http/schema.d.ts
+++ b/ui/litellm-dashboard/src/lib/http/schema.d.ts
@@ -11029,11 +11029,9 @@ export interface paths {
          *         -d '{
          *             "prompt_id": "my_prompt",
          *             "litellm_params": {
-         *                 "prompt_id": "json_prompt",
+         *                 "prompt_id": "my_prompt",
          *                 "prompt_integration": "dotprompt",
-         *                 ### EITHER prompt_directory OR prompt_data MUST BE PROVIDED
-         *                 "prompt_directory": "/path/to/dotprompt/folder",
-         *                 "prompt_data": {"json_prompt": {"content": "This is a prompt", "metadata": {"model": "gpt-4"}}}
+         *                 "prompt_data": {"content": "This is a prompt", "metadata": {"model": "gpt-4"}}
          *             },
          *             "prompt_info": {
          *                 "prompt_type": "config"


### PR DESCRIPTION
## TLDR

Problem this solves:

- POST /prompts with `litellm_params.prompt_id` plus keyed `prompt_data` silently stored an empty template
- Requests using that prompt id got answers with no prompt applied, no error anywhere
- Every create and update response returned `"version": null`
- The versioned id the create API returns (`my-prompt.v1`) silently applied nothing on `prompt_id` requests

How it solves it:

- The template loader wraps only a flat `prompt_data` (one carrying `content`); keyed dicts register as-is
- create, update, and patch return 400 for the ambiguous keyed-plus-prompt_id combination, naming both valid shapes
- patch validates only the `litellm_params` it is sent, so a metadata-only patch on a row stored pre-fix keeps working
- `version`, `environment`, and `created_by` now survive the create response and registry reload
- `.vN` ids resolve to their base template on the prompt hooks
- A flat DB prompt with no `litellm_params.prompt_id` now registers under its base API id

## User Flow

Before: a developer creates a prompt exactly as the API docs show and every request using it silently ignores the template

1. They send POST https://litellm-domain/prompts with `"prompt_id": "agent-prompt"`, `litellm_params.prompt_id` `"agent-prompt"`, and `prompt_data` keyed by template name (`{"json_prompt": {"content": "You are a pirate assistant... begin every reply with AHOY.", "metadata": {"model": "gpt-4o-mini"}}}`)
2. It returns 200 with `"prompt_id": "agent-prompt.v1"` and `"version": null`
3. They send POST https://litellm-domain/v1/responses with `"prompt_id": "agent-prompt"` and get a 200 whose reply is a generic assistant answer with no AHOY
4. They retry with `"prompt_id": "agent-prompt.v1"`, the id the create handed back, and still get no AHOY
5. They check GET https://litellm-domain/prompts/agent-prompt/info and see the stored template is `"content": ""` with `"metadata": {}`: their prompt was silently swallowed

After: the ambiguous create is refused on the spot with the two valid shapes spelled out, and the working shape applies everywhere, versioned id included

1. They send the same POST https://litellm-domain/prompts with `litellm_params.prompt_id` plus keyed `prompt_data`
2. It returns 400: "litellm_params.prompt_id cannot be combined with prompt_data keyed by template name. Send a flat template ... or send prompt_data={"<template_id>": {...}} without litellm_params.prompt_id."
3. They resend with the flat shape, `"prompt_data": {"content": "You are a pirate assistant...", "metadata": {"model": "gpt-4o-mini"}}`, and get 200 with `"prompt_id": "agent-prompt.v1"` and `"version": 1`
4. POST https://litellm-domain/v1/responses with `"prompt_id": "agent-prompt"` replies starting with AHOY
5. Retrying with `"prompt_id": "agent-prompt.v1"` also replies starting with AHOY
6. GET https://litellm-domain/prompts/agent-prompt/info shows the real template content

## Relevant issues

## Linear ticket

Resolves LIT-6266

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Real OpenAI `gpt-4o-mini` traffic through live proxies booted from `litellm/proxy/dev_config.yaml`. Each leg runs the customer topology: two proxy instances (instance A and instance B) sharing one fresh Postgres database, each with `--num_workers 2`; every create goes to instance A and every read-back and inference request to instance B, so the prompt must survive the cross-instance DB sync. Prompt management hooks serve `/v1/chat/completions` and `/v1/responses`; `/v1/messages` does not carry them (unchanged by this PR)

### Before (f6571a653f)

#### Keyed prompt_data + litellm_params.prompt_id (the shape the API docs showed)

1. `curl -sS -X POST http://localhost:52505/prompts -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" -d '{"prompt_id": "lit6266r2-agent-prompt", "litellm_params": {"prompt_id": "lit6266r2-agent-prompt", "prompt_integration": "dotprompt", "prompt_data": {"json_prompt": {"content": "You are a pirate assistant. Always answer in pirate speak and begin every reply with AHOY.", "metadata": {"model": "gpt-4o-mini"}}}}, "prompt_info": {"prompt_type": "db"}}'`
2. HTTP 200 with `"prompt_id": "lit6266r2-agent-prompt.v1"` and `"version": null`: the broken create is accepted silently
3. `curl -sS http://localhost:26036/prompts/lit6266r2-agent-prompt/info -H "Authorization: Bearer sk-1234"` (instance B) returns HTTP 400 prompt not found: the row exists in the DB but the other instance never loads it under the id the create returned
4. `curl -sS -X POST http://localhost:26036/v1/responses -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" -d '{"model": "gpt-4o-mini", "input": "Who are you?", "prompt_id": "lit6266r2-agent-prompt"}'` returns 200 with `"I'm an AI developed by OpenAI, designed to assist with a wide range of questions and tasks..."`: no AHOY, the template was never applied

#### Flat prompt_data + litellm_params.prompt_id (the working shape)

1. `curl -sS -X POST http://localhost:52505/prompts -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" -d '{"prompt_id": "lit6266r2-flat-prompt", "litellm_params": {"prompt_id": "lit6266r2-flat-prompt", "prompt_integration": "dotprompt", "prompt_data": {"content": "You are a pirate assistant. Always answer in pirate speak and begin every reply with AHOY.", "metadata": {"model": "gpt-4o-mini"}}}, "prompt_info": {"prompt_type": "db"}}'`
2. HTTP 200 with `"prompt_id": "lit6266r2-flat-prompt.v1"` and `"version": null`: even the working shape reports no version
3. `curl -sS http://localhost:26036/prompts/lit6266r2-flat-prompt/info -H "Authorization: Bearer sk-1234"` (instance B, ~10s later) returns 200 with `"raw_prompt_template": null`
4. `/v1/responses` on instance B with `"prompt_id": "lit6266r2-flat-prompt"`: `"I'm an AI language model created to assist with providing information..."`: no AHOY
5. `/v1/responses` on instance B with `"prompt_id": "lit6266r2-flat-prompt.v1"` (the id step 2 returned): `"I'm an AI developed by OpenAI, here to assist you..."`: no AHOY
6. `/v1/chat/completions` on instance B with `"prompt_id": "lit6266r2-flat-prompt"`: `"I'm an AI language model created by OpenAI..."`: no AHOY
7. `/v1/chat/completions` on instance B with `"prompt_id": "lit6266r2-flat-prompt.v1"`: `"I am an AI language model created by OpenAI..."`: no AHOY
8. `/v1/responses` on instance A (the instance that served the create) with `"prompt_id": "lit6266r2-flat-prompt"`: `"AHOY! I be yer trusty pirate assistant, ready t' help ye navigate..."`: only the creating instance applies the working shape

#### PATCH on the row the pre-fix proxy stored with the keyed shape

1. `curl -sS -X PATCH http://localhost:52505/prompts/lit6266r2-agent-prompt -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" -d '{"prompt_info": {"prompt_type": "db", "description": "legacy keyed row"}}'`: HTTP 200, `litellm_params.prompt_data` still the keyed dict
2. Same PATCH with `"litellm_params": {"prompt_id": "lit6266r2-agent-prompt", "prompt_integration": "dotprompt", "prompt_data": {"json_prompt": {...}}}` (keyed + prompt_id again): HTTP 200, the ambiguous shape is accepted silently
3. Same PATCH with the flat shape, `"prompt_data": {"content": "You are a pirate assistant...", "metadata": {"model": "gpt-4o-mini"}}` plus `litellm_params.prompt_id`: HTTP 200
4. `curl -sS http://localhost:52505/prompts/lit6266r2-agent-prompt/info -H "Authorization: Bearer sk-1234"` shows the flat template
5. `/v1/responses` on instance A and on instance B with `"prompt_id": "lit6266r2-agent-prompt"` right after: no AHOY on either (see the QA observations below)

### After (43b8ed0fd9)

#### Keyed prompt_data + litellm_params.prompt_id (the shape the API docs showed)

1. Same create against the after proxy: `curl -sS -X POST http://localhost:37201/prompts ... -d '{"prompt_id": "lit6266r2-agent-prompt", "litellm_params": {"prompt_id": "lit6266r2-agent-prompt", "prompt_integration": "dotprompt", "prompt_data": {"json_prompt": {...}}}, ...}'`
2. HTTP 400: `"litellm_params.prompt_id cannot be combined with prompt_data keyed by template name. Send a flat template, prompt_data={\"content\": \"...\", \"metadata\": {...}}, together with litellm_params.prompt_id, or send prompt_data={\"<template_id>\": {\"content\": \"...\", \"metadata\": {...}}} without litellm_params.prompt_id."`
3. `curl -sS http://localhost:48580/prompts/lit6266r2-agent-prompt/info -H "Authorization: Bearer sk-1234"` (instance B) returns HTTP 400 prompt not found: nothing empty was silently stored
4. `/v1/responses` on instance B with `"prompt_id": "lit6266r2-agent-prompt"` returns a plain reply with no template, consistent with the create having been refused

#### Flat prompt_data + litellm_params.prompt_id (the working shape)

1. `curl -sS -X POST http://localhost:37201/prompts -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" -d '{"prompt_id": "lit6266r2-flat-prompt", "litellm_params": {"prompt_id": "lit6266r2-flat-prompt", "prompt_integration": "dotprompt", "prompt_data": {"content": "You are a pirate assistant. Always answer in pirate speak and begin every reply with AHOY.", "metadata": {"model": "gpt-4o-mini"}}}, "prompt_info": {"prompt_type": "db"}}'`
2. HTTP 200 with `"prompt_id": "lit6266r2-flat-prompt.v1"` and `"version": 1`
3. `curl -sS http://localhost:48580/prompts/lit6266r2-flat-prompt/info -H "Authorization: Bearer sk-1234"` (instance B, ~30s later) shows the real template, `"content": "You are a pirate assistant. Always answer in pirate speak and begin every reply with AHOY."`, and `"prompt_spec": {..., "version": 1}`
4. `/v1/responses` on instance B with `"prompt_id": "lit6266r2-flat-prompt"`: the first hit, sent the moment info synced, came back plain; the next four hits all reply `"AHOY! I be yer trusty pirate assistant..."` (the second worker was still syncing, see the observations)
5. `/v1/responses` on instance B with `"prompt_id": "lit6266r2-flat-prompt.v1"`: `"AHOY! I be yer trusty pirate assistant, ready to aid ye on the high seas of knowledge..."`
6. `/v1/chat/completions` on instance B with `"prompt_id": "lit6266r2-flat-prompt"`: `"AHOY! I be yer trusty pirate assistant, ready to aid ye on yer plunderin' adventures..."`
7. `/v1/chat/completions` on instance B with `"prompt_id": "lit6266r2-flat-prompt.v1"`: `"AHOY! I be yer trusty pirate assistant, ready to help ye navigate the treacherous seas..."`
8. `/v1/responses` on instance A with `"prompt_id": "lit6266r2-flat-prompt"`: `"AHOY! I be yer trusty pirate assistant, here t' help ye navigate the stormy seas o' knowledge!"`

#### PATCH on the row the pre-fix proxy stored with the keyed shape

Two instances at this tip (ports 42445 and 33320, `--num_workers 2` each) booted against the before leg's database, which still holds the keyed row the pre-fix proxy accepted above

1. `curl -sS -X PATCH http://localhost:42445/prompts/lit6266r2-agent-prompt -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" -d '{"prompt_info": {"prompt_type": "db", "description": "legacy keyed row"}}'`: HTTP 200, `litellm_params.prompt_data` untouched, so a metadata-only patch on a legacy row keeps working
2. Same PATCH with `"litellm_params": {"prompt_id": "lit6266r2-agent-prompt", "prompt_integration": "dotprompt", "prompt_data": {"json_prompt": {...}}}`: HTTP 400 with the same message as the create
3. Same PATCH with the flat shape plus `litellm_params.prompt_id`: HTTP 200, `prompt_data` now `{"content": "You are a pirate assistant...", "metadata": {"model": "gpt-4o-mini"}}`
4. `curl -sS http://localhost:42445/prompts/lit6266r2-agent-prompt/info -H "Authorization: Bearer sk-1234"` shows the flat template

QA observations:

- Right after create, one worker can briefly serve info before its sibling syncs
- PATCHed templates reach only the worker that served the PATCH; pre-existing, LIT-6276
- Pre-fix, the non-creating instance never applies the flat shape either
- .vN resolves to the registered template, not historical version N; pre-existing on this path

## Type

🐛 Bug Fix

## Caveats (if any)

### Low

- API callers that automated the keyed-plus-prompt_id shape now get 400 where they got a silent 200 with an empty template; that shape never produced a working prompt
- Keyed `prompt_data` whose single key equals `litellm_params.prompt_id` is rejected too; the 400 names the flat shape to send. config.yaml prompts are not validated, and that documented shape now loads its real template instead of an empty one
- Rows already stored with the ambiguous shape keep passing through untouched under their API id and become reachable under the inner key name; a PATCH with the flat shape repairs them (shown above)
- `x.vN` in `prompt_id` resolves to the latest version, as it did before this PR; `prompt_version: N` selects the historical version (verified live: v1 after a v2 PUT replied with v1's template 3/3)
- A keyed `prompt_data` holding a template literally named `content` is read as a flat template

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

- [x] f334108f33 passes /live-pr-risk
- [x] 43b8ed0fd9 passes /live-pr-risk
