### PR TITLE
fix(proxy): stop empty DB router_settings lists from clobbering yaml fallbacks

### DIFF
--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -6268,10 +6268,14 @@ class ProxyConfig:
             ):
                 from litellm.utils import _update_dictionary
 
-                db_overlay_without_empty_lists: Final = {
-                    k: v for k, v in db_router_settings.param_value.items() if not (isinstance(v, list) and len(v) == 0)
+                db_overlay_deferring_empty_lists_to_config: Final = {
+                    k: v
+                    for k, v in db_router_settings.param_value.items()
+                    if not (k in config_router_settings and isinstance(v, list) and len(v) == 0)
                 }
-                combined_router_settings = _update_dictionary(config_router_settings, db_overlay_without_empty_lists)
+                combined_router_settings = _update_dictionary(
+                    config_router_settings, db_overlay_deferring_empty_lists_to_config
+                )
             elif config_router_settings is not None and isinstance(config_router_settings, dict):
                 combined_router_settings = config_router_settings
             elif db_router_settings is not None and isinstance(db_router_settings.param_value, dict):

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -6268,7 +6268,10 @@ class ProxyConfig:
             ):
                 from litellm.utils import _update_dictionary
 
-                combined_router_settings = _update_dictionary(config_router_settings, db_router_settings.param_value)
+                db_overlay_without_empty_lists: Final = {
+                    k: v for k, v in db_router_settings.param_value.items() if not (isinstance(v, list) and len(v) == 0)
+                }
+                combined_router_settings = _update_dictionary(config_router_settings, db_overlay_without_empty_lists)
             elif config_router_settings is not None and isinstance(config_router_settings, dict):
                 combined_router_settings = config_router_settings
             elif db_router_settings is not None and isinstance(db_router_settings.param_value, dict):

--- a/tests/test_litellm/proxy/test_proxy_server.py
+++ b/tests/test_litellm/proxy/test_proxy_server.py
@@ -4791,6 +4791,41 @@ async def test_add_router_settings_from_db_config_empty_db_lists_do_not_clobber_
 
 
 @pytest.mark.asyncio
+async def test_add_router_settings_from_db_config_empty_db_list_still_clears_unconfigured_key():
+    """
+    An empty DB list only yields to config.yaml where the yaml configures that key.
+    When the yaml router_settings has no fallbacks, a DB {"fallbacks": []} (the
+    dashboard's delete-last-fallback write) must still reach the router so the
+    running pods drop the deleted fallback without a restart.
+    """
+    from unittest.mock import AsyncMock, MagicMock
+
+    from litellm.proxy.proxy_server import ProxyConfig
+
+    proxy_config = ProxyConfig()
+    mock_router = MagicMock()
+    mock_router.update_settings = MagicMock()
+
+    config_data = {"router_settings": {"num_retries": 1}}
+
+    mock_db_config = MagicMock()
+    mock_db_config.param_value = {"fallbacks": [], "model_group_alias": {}}
+
+    mock_prisma_client = MagicMock()
+    mock_prisma_client.db.litellm_config.find_first = AsyncMock(return_value=mock_db_config)
+
+    await proxy_config._add_router_settings_from_db_config(
+        config_data=config_data,
+        llm_router=mock_router,
+        prisma_client=mock_prisma_client,
+    )
+
+    combined_settings = mock_router.update_settings.call_args.kwargs
+    assert combined_settings["fallbacks"] == []
+    assert combined_settings["num_retries"] == 1
+
+
+@pytest.mark.asyncio
 async def test_add_router_settings_from_db_config_edge_cases():
     """
     Test edge cases for _add_router_settings_from_db_config method.
@@ -11353,9 +11388,7 @@ class TestRouterModelNameOnStreamingChunks:
             with patch.object(ProxyLogging, "_fire_deferred_stream_logging"):
                 return [
                     data
-                    async for data in async_data_generator(
-                        mock_response, MagicMock(spec=UserAPIKeyAuth), request_data
-                    )
+                    async for data in async_data_generator(mock_response, MagicMock(spec=UserAPIKeyAuth), request_data)
                 ]
 
     @staticmethod

--- a/tests/test_litellm/proxy/test_proxy_server.py
+++ b/tests/test_litellm/proxy/test_proxy_server.py
@@ -4742,6 +4742,55 @@ async def test_add_router_settings_from_db_config_merge_logic():
 
 
 @pytest.mark.asyncio
+async def test_add_router_settings_from_db_config_empty_db_lists_do_not_clobber_config_fallbacks():
+    """
+    Regression test for DB router_settings rows carrying explicit empty lists
+    (e.g. {"fallbacks": []} written by the dashboard's delete-last-fallback flow):
+    empty lists are "no value" and must not clobber config.yaml fallbacks,
+    matching _deep_merge_dicts semantics. Non-empty DB lists still win.
+    """
+    from unittest.mock import AsyncMock, MagicMock
+
+    from litellm.proxy.proxy_server import ProxyConfig
+
+    proxy_config = ProxyConfig()
+    mock_router = MagicMock()
+    mock_router.update_settings = MagicMock()
+
+    config_data = {
+        "router_settings": {
+            "fallbacks": [{"gpt-oss-120b": ["granite-4-h-small"]}],
+            "context_window_fallbacks": [{"gpt-oss-120b": ["granite-4-h-small"]}],
+            "content_policy_fallbacks": [{"gpt-oss-120b": ["granite-4-h-small"]}],
+        }
+    }
+
+    mock_db_config = MagicMock()
+    mock_db_config.param_value = {
+        "fallbacks": [],
+        "context_window_fallbacks": [],
+        "content_policy_fallbacks": [{"gpt-oss-120b": ["other-model"]}],
+        "model_group_alias": {},
+        "num_retries": 3,
+    }
+
+    mock_prisma_client = MagicMock()
+    mock_prisma_client.db.litellm_config.find_first = AsyncMock(return_value=mock_db_config)
+
+    await proxy_config._add_router_settings_from_db_config(
+        config_data=config_data,
+        llm_router=mock_router,
+        prisma_client=mock_prisma_client,
+    )
+
+    combined_settings = mock_router.update_settings.call_args.kwargs
+    assert combined_settings["fallbacks"] == [{"gpt-oss-120b": ["granite-4-h-small"]}]
+    assert combined_settings["context_window_fallbacks"] == [{"gpt-oss-120b": ["granite-4-h-small"]}]
+    assert combined_settings["content_policy_fallbacks"] == [{"gpt-oss-120b": ["other-model"]}]
+    assert combined_settings["num_retries"] == 3
+
+
+@pytest.mark.asyncio
 async def test_add_router_settings_from_db_config_edge_cases():
     """
     Test edge cases for _add_router_settings_from_db_config method.


### PR DESCRIPTION
## TLDR

Problem this solves:

- A DB router_settings row holding `fallbacks: []` wipes config.yaml fallbacks
- The wipe re-applies on every boot and every config resync
- Requests then fail with `Available Model Group Fallbacks=None` instead of failing over

How it solves it:

- An empty list in the DB row no longer overrides a key the yaml sets
- Where the yaml sets nothing, the empty list still applies
  - So deleting DB-managed fallbacks keeps clearing running pods
- Yaml fallbacks survive; non-empty DB lists still override yaml

## User Flow

Before: a proxy admin defines model fallbacks in config.yaml, but once an empty fallback list is saved through the UI or API, every boot silently drops the yaml fallbacks and user requests fail instead of failing over

1. The admin runs the proxy with `DATABASE_URL` set, `store_model_in_db: true`, and `router_settings.fallbacks: [{"gpt-oss-120b": ["granite-4-h-small"]}]` in config.yaml
2. A user sends POST http://litellm-domain/v1/chat/completions with model `gpt-oss-120b`; the primary deployment errors and the request still returns 200, answered by `granite-4-h-small`
3. The admin deletes the last fallback row on http://litellm-domain/ui/?page=router-settings (equivalently POST http://litellm-domain/config/update with `{"router_settings": {"fallbacks": []}}`), which returns 200 "Config updated successfully"
4. The proxy restarts on the next deploy
5. The same POST http://litellm-domain/v1/chat/completions now returns 401 `No fallback model group found for original model_group=gpt-oss-120b ... Available Model Group Fallbacks=None`, and /v1/messages and /v1/responses fail the same way, on every pod, until someone deletes the stored row by hand

After: the same boot keeps the yaml fallbacks, so requests keep failing over as configured

1. The admin runs the proxy with `DATABASE_URL` set, `store_model_in_db: true`, and `router_settings.fallbacks: [{"gpt-oss-120b": ["granite-4-h-small"]}]` in config.yaml
2. A user sends POST http://litellm-domain/v1/chat/completions with model `gpt-oss-120b`; the primary deployment errors and the request still returns 200, answered by `granite-4-h-small`
3. The admin deletes the last fallback row on http://litellm-domain/ui/?page=router-settings (equivalently POST http://litellm-domain/config/update with `{"router_settings": {"fallbacks": []}}`), which returns 200 "Config updated successfully"
4. The proxy restarts on the next deploy
5. The same POST http://litellm-domain/v1/chat/completions still returns 200, answered by `granite-4-h-small`, and /v1/messages and /v1/responses fail over the same way on every pod

## Relevant issues

## Linear ticket

Resolves LIT-3367

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Shared setup for both legs: two proxy instances, 2 uvicorn workers each, sharing one fresh Postgres DB (`--num_workers 2`, ports 41783/41927 before, 41213/41777 after). Config mirrors the customer shape, with an invalid key on the primary so it always errors:

```yaml
model_list:
  - model_name: gpt-oss-120b
    litellm_params:
      model: anthropic/claude-haiku-4-5
      api_key: sk-ant-invalid-key-lit3367
  - model_name: granite-4-h-small
    litellm_params:
      model: anthropic/claude-haiku-4-5
      api_key: os.environ/ANTHROPIC_API_KEY

router_settings:
  fallbacks: [{"gpt-oss-120b": ["granite-4-h-small"]}]

general_settings:
  master_key: sk-1234
  store_model_in_db: true
```

Both legs ran the same sequence: with no DB row, all three endpoints returned 200 via the fallback on both instances (baseline); then the delete-all-fallbacks write went through instance A and both instances were restarted with the row present:

```bash
curl -s http://localhost:$PORT/config/update -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' \
  -d '{"router_settings": {"fallbacks": []}}' -w '\nHTTP %{http_code}\n'
```
```
{"message":"Config updated successfully"}
HTTP 200
```

Post-restart results below are from instance A; instance B returned byte-identical verdicts on all three endpoints in both legs

### Before (e4037978f1)

#### /v1/chat/completions

1. `curl -s http://localhost:41783/v1/chat/completions -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' -d '{"model":"gpt-oss-120b","messages":[{"role":"user","content":"Reply with the single word ok"}],"max_tokens":16}' -w '\nHTTP %{http_code}\n'`
2. Observed: `{"error":{"message":"litellm.AuthenticationError: ... No fallback model group found for original model_group=gpt-oss-120b. Fallbacks=[]. Received Model Group=gpt-oss-120b\nAvailable Model Group Fallbacks=None ...","code":"401"}}` then `HTTP 401`

#### /v1/messages

1. `curl -s http://localhost:41783/v1/messages -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' -d '{"model":"gpt-oss-120b","max_tokens":16,"messages":[{"role":"user","content":"Reply with the single word ok"}]}' -w '\nHTTP %{http_code}\n'`
2. Observed: same 401 `Available Model Group Fallbacks=None` body, `HTTP 401`

#### /v1/responses

1. `curl -s http://localhost:41783/v1/responses -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' -d '{"model":"gpt-oss-120b","input":"Reply with the single word ok","max_output_tokens":16}' -w '\nHTTP %{http_code}\n'`
2. Observed: same 401 `Available Model Group Fallbacks=None` body, `HTTP 401`

### After (3b9f6ee2aa)

#### /v1/chat/completions

1. `curl -s http://localhost:41213/v1/chat/completions -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' -d '{"model":"gpt-oss-120b","messages":[{"role":"user","content":"Reply with the single word ok"}],"max_tokens":16}' -w '\nHTTP %{http_code}\n'`
2. Observed: `{"id":"chatcmpl-b03b2f06-...","model":"claude-haiku-4-5-20251001","choices":[{"finish_reason":"stop","index":0,"message":{"content":"ok","role":"assistant",...}}],...}` then `HTTP 200`, answered by the yaml fallback

#### /v1/messages

1. `curl -s http://localhost:41213/v1/messages -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' -d '{"model":"gpt-oss-120b","max_tokens":16,"messages":[{"role":"user","content":"Reply with the single word ok"}]}' -w '\nHTTP %{http_code}\n'`
2. Observed: `{"model":"claude-haiku-4-5-20251001","id":"msg_...","content":[{"type":"text","text":"ok"}],...}` then `HTTP 200`

#### /v1/responses

1. `curl -s http://localhost:41213/v1/responses -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' -d '{"model":"gpt-oss-120b","input":"Reply with the single word ok","max_output_tokens":16}' -w '\nHTTP %{http_code}\n'`
2. Observed: `{"id":"resp_...","output":[{"type":"message","status":"completed","content":[{"type":"output_text","text":"ok",...}],...}],"status":"completed",...}` then `HTTP 200`

QA observations:

- After fix, requests right after the empty-list write also stay 200
- Before fix, the write clobbered instance A in-process immediately
- Cross-instance: row written via A clobbered B only after B rebooted
- Delete-all of DB-managed fallbacks still clears running pods

## Type

🐛 Bug Fix

## Caveats (if any)

### Medium

- Deleting the last yaml-defined fallback in the UI now visibly no-ops
  - The rows reappear on refresh; routing keeps using them
  - Removing yaml-defined fallbacks means editing config.yaml
  - Same yaml-wins policy the DB config overlay already has for lists
  - UI-managed fallbacks (no yaml value for that key) still clear live within a resync, verified on both sides
  - A real fix needs delete tombstones in the DB contract, out of scope here

### Low

- Empty-string or zero DB scalars can still shadow yaml values (pre-existing, unchanged)
- Open PR #38335 proposes the opposite semantics (empty DB lists override yaml) for its model-delete scrub; the two need reconciling if both land

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

- [x] 3b9f6ee2aa passes /live-pr-risk
