### PR TITLE
fix(cost-map): correct Gemini TTS and native-audio rates

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -21091,18 +21091,15 @@
     },
     "gemini-2.5-pro-preview-tts": {
         "cache_read_input_token_cost": 1.25e-07,
-        "cache_read_input_token_cost_above_200k_tokens": 2.5e-07,
         "input_cost_per_audio_token": 7e-07,
-        "input_cost_per_token": 1.25e-06,
-        "input_cost_per_token_above_200k_tokens": 2.5e-06,
+        "input_cost_per_token": 1e-06,
         "litellm_provider": "vertex_ai-language-models",
         "max_input_tokens": 1048576,
         "max_output_tokens": 65535,
         "max_tokens": 65535,
         "mode": "chat",
-        "output_cost_per_token": 1e-05,
-        "output_cost_per_token_above_200k_tokens": 1.5e-05,
-        "source": "https://ai.google.dev/gemini-api/docs/pricing#gemini-2.5-pro-preview",
+        "output_cost_per_token": 2e-05,
+        "source": "https://ai.google.dev/gemini-api/docs/pricing",
         "supported_modalities": [
             "text"
         ],
@@ -22212,11 +22209,11 @@
         "supports_image_size": false
     },
     "gemini/gemini-2.5-flash-preview-tts": {
-        "input_cost_per_token": 3e-07,
+        "input_cost_per_token": 5e-07,
         "litellm_provider": "gemini",
         "mode": "audio_speech",
-        "output_cost_per_token": 2.5e-06,
-        "source": "https://ai.google.dev/pricing",
+        "output_cost_per_token": 1e-05,
+        "source": "https://ai.google.dev/gemini-api/docs/pricing",
         "supported_endpoints": [
             "/v1/audio/speech"
         ],
@@ -23156,19 +23153,16 @@
     },
     "gemini/gemini-2.5-pro-preview-tts": {
         "cache_read_input_token_cost": 1.25e-07,
-        "cache_read_input_token_cost_above_200k_tokens": 2.5e-07,
         "input_cost_per_audio_token": 7e-07,
-        "input_cost_per_token": 1.25e-06,
-        "input_cost_per_token_above_200k_tokens": 2.5e-06,
+        "input_cost_per_token": 1e-06,
         "litellm_provider": "gemini",
         "max_input_tokens": 1048576,
         "max_output_tokens": 65535,
         "max_tokens": 65535,
         "mode": "chat",
-        "output_cost_per_token": 1e-05,
-        "output_cost_per_token_above_200k_tokens": 1.5e-05,
+        "output_cost_per_token": 2e-05,
         "rpm": 10000,
-        "source": "https://ai.google.dev/gemini-api/docs/pricing#gemini-2.5-pro-preview",
+        "source": "https://ai.google.dev/gemini-api/docs/pricing",
         "supported_modalities": [
             "text"
         ],
@@ -48804,15 +48798,16 @@
         }
     },
     "gemini-2.5-flash-native-audio-latest": {
-        "input_cost_per_audio_token": 1e-06,
-        "input_cost_per_token": 3e-07,
+        "input_cost_per_audio_token": 3e-06,
+        "input_cost_per_token": 5e-07,
         "litellm_provider": "gemini",
         "max_input_tokens": 1048576,
         "max_output_tokens": 8192,
         "max_tokens": 8192,
         "mode": "chat",
-        "output_cost_per_token": 2.5e-06,
-        "source": "https://ai.google.dev/pricing",
+        "output_cost_per_audio_token": 1.2e-05,
+        "output_cost_per_token": 2e-06,
+        "source": "https://ai.google.dev/gemini-api/docs/pricing",
         "supported_endpoints": [
             "/v1/realtime"
         ],
@@ -48829,15 +48824,16 @@
         "gemini_native_audio": true
     },
     "gemini-2.5-flash-native-audio-preview-09-2025": {
-        "input_cost_per_audio_token": 1e-06,
-        "input_cost_per_token": 3e-07,
+        "input_cost_per_audio_token": 3e-06,
+        "input_cost_per_token": 5e-07,
         "litellm_provider": "gemini",
         "max_input_tokens": 1048576,
         "max_output_tokens": 8192,
         "max_tokens": 8192,
         "mode": "chat",
-        "output_cost_per_token": 2.5e-06,
-        "source": "https://ai.google.dev/pricing",
+        "output_cost_per_audio_token": 1.2e-05,
+        "output_cost_per_token": 2e-06,
+        "source": "https://ai.google.dev/gemini-api/docs/pricing",
         "supported_endpoints": [
             "/v1/realtime"
         ],
@@ -48854,15 +48850,16 @@
         "gemini_native_audio": true
     },
     "gemini-2.5-flash-native-audio-preview-12-2025": {
-        "input_cost_per_audio_token": 1e-06,
-        "input_cost_per_token": 3e-07,
+        "input_cost_per_audio_token": 3e-06,
+        "input_cost_per_token": 5e-07,
         "litellm_provider": "gemini",
         "max_input_tokens": 1048576,
         "max_output_tokens": 8192,
         "max_tokens": 8192,
         "mode": "chat",
-        "output_cost_per_token": 2.5e-06,
-        "source": "https://ai.google.dev/pricing",
+        "output_cost_per_audio_token": 1.2e-05,
+        "output_cost_per_token": 2e-06,
+        "source": "https://ai.google.dev/gemini-api/docs/pricing",
         "supported_endpoints": [
             "/v1/realtime"
         ],
@@ -48912,15 +48909,16 @@
         "gemini_audio_only_live": true
     },
     "gemini/gemini-2.5-flash-native-audio-latest": {
-        "input_cost_per_audio_token": 1e-06,
-        "input_cost_per_token": 3e-07,
+        "input_cost_per_audio_token": 3e-06,
+        "input_cost_per_token": 5e-07,
         "litellm_provider": "gemini",
         "max_input_tokens": 1048576,
         "max_output_tokens": 8192,
         "max_tokens": 8192,
         "mode": "chat",
-        "output_cost_per_token": 2.5e-06,
-        "source": "https://ai.google.dev/pricing",
+        "output_cost_per_audio_token": 1.2e-05,
+        "output_cost_per_token": 2e-06,
+        "source": "https://ai.google.dev/gemini-api/docs/pricing",
         "supported_endpoints": [
             "/v1/realtime"
         ],
@@ -48939,15 +48937,16 @@
         "gemini_native_audio": true
     },
     "gemini/gemini-2.5-flash-native-audio-preview-09-2025": {
-        "input_cost_per_audio_token": 1e-06,
-        "input_cost_per_token": 3e-07,
+        "input_cost_per_audio_token": 3e-06,
+        "input_cost_per_token": 5e-07,
         "litellm_provider": "gemini",
         "max_input_tokens": 1048576,
         "max_output_tokens": 8192,
         "max_tokens": 8192,
         "mode": "chat",
-        "output_cost_per_token": 2.5e-06,
-        "source": "https://ai.google.dev/pricing",
+        "output_cost_per_audio_token": 1.2e-05,
+        "output_cost_per_token": 2e-06,
+        "source": "https://ai.google.dev/gemini-api/docs/pricing",
         "supported_endpoints": [
             "/v1/realtime"
         ],
@@ -48966,15 +48965,16 @@
         "gemini_native_audio": true
     },
     "gemini/gemini-2.5-flash-native-audio-preview-12-2025": {
-        "input_cost_per_audio_token": 1e-06,
-        "input_cost_per_token": 3e-07,
+        "input_cost_per_audio_token": 3e-06,
+        "input_cost_per_token": 5e-07,
         "litellm_provider": "gemini",
         "max_input_tokens": 1048576,
         "max_output_tokens": 8192,
         "max_tokens": 8192,
         "mode": "chat",
-        "output_cost_per_token": 2.5e-06,
-        "source": "https://ai.google.dev/pricing",
+        "output_cost_per_audio_token": 1.2e-05,
+        "output_cost_per_token": 2e-06,
+        "source": "https://ai.google.dev/gemini-api/docs/pricing",
         "supported_endpoints": [
             "/v1/realtime"
         ],
@@ -49043,11 +49043,11 @@
         "rpm": 10
     },
     "gemini-2.5-flash-preview-tts": {
-        "input_cost_per_token": 3e-07,
+        "input_cost_per_token": 5e-07,
         "litellm_provider": "gemini",
         "mode": "audio_speech",
-        "output_cost_per_token": 2.5e-06,
-        "source": "https://ai.google.dev/pricing",
+        "output_cost_per_token": 1e-05,
+        "source": "https://ai.google.dev/gemini-api/docs/pricing",
         "supported_endpoints": [
             "/v1/audio/speech"
         ]

--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -20355,7 +20355,7 @@
     "gemini-live-2.5-flash-preview-native-audio-09-2025": {
         "cache_read_input_token_cost": 7.5e-08,
         "input_cost_per_audio_token": 3e-06,
-        "input_cost_per_token": 3e-07,
+        "input_cost_per_token": 5e-07,
         "litellm_provider": "vertex_ai-language-models",
         "max_input_tokens": 1048576,
         "max_output_tokens": 65535,
@@ -20399,7 +20399,7 @@
     "gemini/gemini-live-2.5-flash-preview-native-audio-09-2025": {
         "cache_read_input_token_cost": 7.5e-08,
         "input_cost_per_audio_token": 3e-06,
-        "input_cost_per_token": 3e-07,
+        "input_cost_per_token": 5e-07,
         "litellm_provider": "gemini",
         "max_input_tokens": 1048576,
         "max_output_tokens": 65535,

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -21091,18 +21091,15 @@
     },
     "gemini-2.5-pro-preview-tts": {
         "cache_read_input_token_cost": 1.25e-07,
-        "cache_read_input_token_cost_above_200k_tokens": 2.5e-07,
         "input_cost_per_audio_token": 7e-07,
-        "input_cost_per_token": 1.25e-06,
-        "input_cost_per_token_above_200k_tokens": 2.5e-06,
+        "input_cost_per_token": 1e-06,
         "litellm_provider": "vertex_ai-language-models",
         "max_input_tokens": 1048576,
         "max_output_tokens": 65535,
         "max_tokens": 65535,
         "mode": "chat",
-        "output_cost_per_token": 1e-05,
-        "output_cost_per_token_above_200k_tokens": 1.5e-05,
-        "source": "https://ai.google.dev/gemini-api/docs/pricing#gemini-2.5-pro-preview",
+        "output_cost_per_token": 2e-05,
+        "source": "https://ai.google.dev/gemini-api/docs/pricing",
         "supported_modalities": [
             "text"
         ],
@@ -22212,11 +22209,11 @@
         "supports_image_size": false
     },
     "gemini/gemini-2.5-flash-preview-tts": {
-        "input_cost_per_token": 3e-07,
+        "input_cost_per_token": 5e-07,
         "litellm_provider": "gemini",
         "mode": "audio_speech",
-        "output_cost_per_token": 2.5e-06,
-        "source": "https://ai.google.dev/pricing",
+        "output_cost_per_token": 1e-05,
+        "source": "https://ai.google.dev/gemini-api/docs/pricing",
         "supported_endpoints": [
             "/v1/audio/speech"
         ],
@@ -23156,19 +23153,16 @@
     },
     "gemini/gemini-2.5-pro-preview-tts": {
         "cache_read_input_token_cost": 1.25e-07,
-        "cache_read_input_token_cost_above_200k_tokens": 2.5e-07,
         "input_cost_per_audio_token": 7e-07,
-        "input_cost_per_token": 1.25e-06,
-        "input_cost_per_token_above_200k_tokens": 2.5e-06,
+        "input_cost_per_token": 1e-06,
         "litellm_provider": "gemini",
         "max_input_tokens": 1048576,
         "max_output_tokens": 65535,
         "max_tokens": 65535,
         "mode": "chat",
-        "output_cost_per_token": 1e-05,
-        "output_cost_per_token_above_200k_tokens": 1.5e-05,
+        "output_cost_per_token": 2e-05,
         "rpm": 10000,
-        "source": "https://ai.google.dev/gemini-api/docs/pricing#gemini-2.5-pro-preview",
+        "source": "https://ai.google.dev/gemini-api/docs/pricing",
         "supported_modalities": [
             "text"
         ],
@@ -48804,15 +48798,16 @@
         }
     },
     "gemini-2.5-flash-native-audio-latest": {
-        "input_cost_per_audio_token": 1e-06,
-        "input_cost_per_token": 3e-07,
+        "input_cost_per_audio_token": 3e-06,
+        "input_cost_per_token": 5e-07,
         "litellm_provider": "gemini",
         "max_input_tokens": 1048576,
         "max_output_tokens": 8192,
         "max_tokens": 8192,
         "mode": "chat",
-        "output_cost_per_token": 2.5e-06,
-        "source": "https://ai.google.dev/pricing",
+        "output_cost_per_audio_token": 1.2e-05,
+        "output_cost_per_token": 2e-06,
+        "source": "https://ai.google.dev/gemini-api/docs/pricing",
         "supported_endpoints": [
             "/v1/realtime"
         ],
@@ -48829,15 +48824,16 @@
         "gemini_native_audio": true
     },
     "gemini-2.5-flash-native-audio-preview-09-2025": {
-        "input_cost_per_audio_token": 1e-06,
-        "input_cost_per_token": 3e-07,
+        "input_cost_per_audio_token": 3e-06,
+        "input_cost_per_token": 5e-07,
         "litellm_provider": "gemini",
         "max_input_tokens": 1048576,
         "max_output_tokens": 8192,
         "max_tokens": 8192,
         "mode": "chat",
-        "output_cost_per_token": 2.5e-06,
-        "source": "https://ai.google.dev/pricing",
+        "output_cost_per_audio_token": 1.2e-05,
+        "output_cost_per_token": 2e-06,
+        "source": "https://ai.google.dev/gemini-api/docs/pricing",
         "supported_endpoints": [
             "/v1/realtime"
         ],
@@ -48854,15 +48850,16 @@
         "gemini_native_audio": true
     },
     "gemini-2.5-flash-native-audio-preview-12-2025": {
-        "input_cost_per_audio_token": 1e-06,
-        "input_cost_per_token": 3e-07,
+        "input_cost_per_audio_token": 3e-06,
+        "input_cost_per_token": 5e-07,
         "litellm_provider": "gemini",
         "max_input_tokens": 1048576,
         "max_output_tokens": 8192,
         "max_tokens": 8192,
         "mode": "chat",
-        "output_cost_per_token": 2.5e-06,
-        "source": "https://ai.google.dev/pricing",
+        "output_cost_per_audio_token": 1.2e-05,
+        "output_cost_per_token": 2e-06,
+        "source": "https://ai.google.dev/gemini-api/docs/pricing",
         "supported_endpoints": [
             "/v1/realtime"
         ],
@@ -48912,15 +48909,16 @@
         "gemini_audio_only_live": true
     },
     "gemini/gemini-2.5-flash-native-audio-latest": {
-        "input_cost_per_audio_token": 1e-06,
-        "input_cost_per_token": 3e-07,
+        "input_cost_per_audio_token": 3e-06,
+        "input_cost_per_token": 5e-07,
         "litellm_provider": "gemini",
         "max_input_tokens": 1048576,
         "max_output_tokens": 8192,
         "max_tokens": 8192,
         "mode": "chat",
-        "output_cost_per_token": 2.5e-06,
-        "source": "https://ai.google.dev/pricing",
+        "output_cost_per_audio_token": 1.2e-05,
+        "output_cost_per_token": 2e-06,
+        "source": "https://ai.google.dev/gemini-api/docs/pricing",
         "supported_endpoints": [
             "/v1/realtime"
         ],
@@ -48939,15 +48937,16 @@
         "gemini_native_audio": true
     },
     "gemini/gemini-2.5-flash-native-audio-preview-09-2025": {
-        "input_cost_per_audio_token": 1e-06,
-        "input_cost_per_token": 3e-07,
+        "input_cost_per_audio_token": 3e-06,
+        "input_cost_per_token": 5e-07,
         "litellm_provider": "gemini",
         "max_input_tokens": 1048576,
         "max_output_tokens": 8192,
         "max_tokens": 8192,
         "mode": "chat",
-        "output_cost_per_token": 2.5e-06,
-        "source": "https://ai.google.dev/pricing",
+        "output_cost_per_audio_token": 1.2e-05,
+        "output_cost_per_token": 2e-06,
+        "source": "https://ai.google.dev/gemini-api/docs/pricing",
         "supported_endpoints": [
             "/v1/realtime"
         ],
@@ -48966,15 +48965,16 @@
         "gemini_native_audio": true
     },
     "gemini/gemini-2.5-flash-native-audio-preview-12-2025": {
-        "input_cost_per_audio_token": 1e-06,
-        "input_cost_per_token": 3e-07,
+        "input_cost_per_audio_token": 3e-06,
+        "input_cost_per_token": 5e-07,
         "litellm_provider": "gemini",
         "max_input_tokens": 1048576,
         "max_output_tokens": 8192,
         "max_tokens": 8192,
         "mode": "chat",
-        "output_cost_per_token": 2.5e-06,
-        "source": "https://ai.google.dev/pricing",
+        "output_cost_per_audio_token": 1.2e-05,
+        "output_cost_per_token": 2e-06,
+        "source": "https://ai.google.dev/gemini-api/docs/pricing",
         "supported_endpoints": [
             "/v1/realtime"
         ],
@@ -49043,11 +49043,11 @@
         "rpm": 10
     },
     "gemini-2.5-flash-preview-tts": {
-        "input_cost_per_token": 3e-07,
+        "input_cost_per_token": 5e-07,
         "litellm_provider": "gemini",
         "mode": "audio_speech",
-        "output_cost_per_token": 2.5e-06,
-        "source": "https://ai.google.dev/pricing",
+        "output_cost_per_token": 1e-05,
+        "source": "https://ai.google.dev/gemini-api/docs/pricing",
         "supported_endpoints": [
             "/v1/audio/speech"
         ]

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -20355,7 +20355,7 @@
     "gemini-live-2.5-flash-preview-native-audio-09-2025": {
         "cache_read_input_token_cost": 7.5e-08,
         "input_cost_per_audio_token": 3e-06,
-        "input_cost_per_token": 3e-07,
+        "input_cost_per_token": 5e-07,
         "litellm_provider": "vertex_ai-language-models",
         "max_input_tokens": 1048576,
         "max_output_tokens": 65535,
@@ -20399,7 +20399,7 @@
     "gemini/gemini-live-2.5-flash-preview-native-audio-09-2025": {
         "cache_read_input_token_cost": 7.5e-08,
         "input_cost_per_audio_token": 3e-06,
-        "input_cost_per_token": 3e-07,
+        "input_cost_per_token": 5e-07,
         "litellm_provider": "gemini",
         "max_input_tokens": 1048576,
         "max_output_tokens": 65535,

--- a/tests/test_litellm/test_gemini_tts_native_audio_pricing.py
+++ b/tests/test_litellm/test_gemini_tts_native_audio_pricing.py
@@ -1,0 +1,144 @@
+import json
+from pathlib import Path
+from typing import Final
+
+import pytest
+
+import litellm
+from litellm.litellm_core_utils.llm_cost_calc.utils import generic_cost_per_token
+from litellm.types.utils import CompletionTokensDetailsWrapper, PromptTokensDetailsWrapper, Usage
+
+REPO_ROOT: Final = Path(__file__).parents[2]
+MAIN_PATH: Final = REPO_ROOT / "model_prices_and_context_window.json"
+BACKUP_PATH: Final = REPO_ROOT / "litellm" / "model_prices_and_context_window_backup.json"
+
+FLASH_TTS_KEYS: Final = ("gemini-2.5-flash-preview-tts", "gemini/gemini-2.5-flash-preview-tts")
+PRO_TTS_KEYS: Final = ("gemini-2.5-pro-preview-tts", "gemini/gemini-2.5-pro-preview-tts")
+NATIVE_AUDIO_KEYS: Final = tuple(
+    f"{prefix}gemini-2.5-flash-native-audio-{suffix}"
+    for prefix in ("", "gemini/")
+    for suffix in ("latest", "preview-09-2025", "preview-12-2025")
+)
+
+FLASH_TTS_INPUT: Final = 5e-07
+FLASH_TTS_AUDIO_OUTPUT: Final = 1e-05
+PRO_TTS_INPUT: Final = 1e-06
+PRO_TTS_AUDIO_OUTPUT: Final = 2e-05
+NATIVE_AUDIO_TEXT_INPUT: Final = 5e-07
+NATIVE_AUDIO_AUDIO_INPUT: Final = 3e-06
+NATIVE_AUDIO_TEXT_OUTPUT: Final = 2e-06
+NATIVE_AUDIO_AUDIO_OUTPUT: Final = 1.2e-05
+
+PUBLISHED_RATES: Final = {
+    **{
+        key: {"input_cost_per_token": FLASH_TTS_INPUT, "output_cost_per_token": FLASH_TTS_AUDIO_OUTPUT}
+        for key in FLASH_TTS_KEYS
+    },
+    **{
+        key: {"input_cost_per_token": PRO_TTS_INPUT, "output_cost_per_token": PRO_TTS_AUDIO_OUTPUT}
+        for key in PRO_TTS_KEYS
+    },
+    **{
+        key: {
+            "input_cost_per_token": NATIVE_AUDIO_TEXT_INPUT,
+            "input_cost_per_audio_token": NATIVE_AUDIO_AUDIO_INPUT,
+            "output_cost_per_token": NATIVE_AUDIO_TEXT_OUTPUT,
+            "output_cost_per_audio_token": NATIVE_AUDIO_AUDIO_OUTPUT,
+        }
+        for key in NATIVE_AUDIO_KEYS
+    },
+}
+ALL_KEYS: Final = tuple(PUBLISHED_RATES)
+LONG_CONTEXT_TIER_FIELDS: Final = (
+    "input_cost_per_token_above_200k_tokens",
+    "output_cost_per_token_above_200k_tokens",
+    "cache_read_input_token_cost_above_200k_tokens",
+)
+
+
+def _load(path: Path) -> dict:
+    with open(path, encoding="utf-8") as f:
+        return json.load(f)
+
+
+@pytest.fixture
+def local_model_cost_map(monkeypatch):
+    original_model_cost = litellm.model_cost
+    monkeypatch.setenv("LITELLM_LOCAL_MODEL_COST_MAP", "True")
+    litellm.model_cost = litellm.get_model_cost_map(url="")
+    litellm.get_model_info.cache_clear()
+    try:
+        yield
+    finally:
+        litellm.model_cost = original_model_cost
+        litellm.get_model_info.cache_clear()
+
+
+@pytest.mark.parametrize("model", ALL_KEYS)
+@pytest.mark.parametrize("path", (MAIN_PATH, BACKUP_PATH), ids=("main", "backup"))
+def test_published_rates_are_registered(model: str, path: Path):
+    info = _load(path)[model]
+    for field, value in PUBLISHED_RATES[model].items():
+        assert info[field] == value, f"{model} {field} in {path.name}: {info.get(field)} != {value}"
+
+
+@pytest.mark.parametrize("model", PRO_TTS_KEYS)
+@pytest.mark.parametrize("path", (MAIN_PATH, BACKUP_PATH), ids=("main", "backup"))
+def test_pro_tts_has_no_long_context_tier(model: str, path: Path):
+    info = _load(path)[model]
+    for field in LONG_CONTEXT_TIER_FIELDS:
+        assert field not in info, f"{model} has {field} but Google publishes one flat TTS rate"
+
+
+@pytest.mark.parametrize("model", ALL_KEYS)
+def test_backup_matches_main(model: str):
+    assert _load(BACKUP_PATH)[model] == _load(MAIN_PATH)[model]
+
+
+@pytest.mark.parametrize(
+    ("model", "provider", "input_rate", "audio_output_rate"),
+    (
+        ("gemini-2.5-flash-preview-tts", "gemini", FLASH_TTS_INPUT, FLASH_TTS_AUDIO_OUTPUT),
+        ("gemini-2.5-pro-preview-tts", "gemini", PRO_TTS_INPUT, PRO_TTS_AUDIO_OUTPUT),
+        ("gemini-2.5-pro-preview-tts", "vertex_ai", PRO_TTS_INPUT, PRO_TTS_AUDIO_OUTPUT),
+    ),
+)
+def test_tts_audio_output_is_billed_at_the_audio_rate(
+    model: str, provider: str, input_rate: float, audio_output_rate: float, local_model_cost_map
+):
+    usage: Final = Usage(
+        prompt_tokens=9,
+        completion_tokens=49,
+        total_tokens=58,
+        prompt_tokens_details=PromptTokensDetailsWrapper(text_tokens=9),
+        completion_tokens_details=CompletionTokensDetailsWrapper(audio_tokens=49, text_tokens=0),
+    )
+    prompt_cost, completion_cost = generic_cost_per_token(model=model, usage=usage, custom_llm_provider=provider)
+    assert prompt_cost == pytest.approx(9 * input_rate)
+    assert completion_cost == pytest.approx(49 * audio_output_rate)
+
+
+@pytest.mark.parametrize("model", NATIVE_AUDIO_KEYS)
+def test_native_audio_output_is_billed_at_the_audio_rate(model: str, local_model_cost_map):
+    usage: Final = Usage(
+        prompt_tokens=377,
+        completion_tokens=84,
+        total_tokens=461,
+        prompt_tokens_details=PromptTokensDetailsWrapper(text_tokens=377),
+        completion_tokens_details=CompletionTokensDetailsWrapper(audio_tokens=48, reasoning_tokens=36, text_tokens=0),
+    )
+    prompt_cost, completion_cost = generic_cost_per_token(model=model, usage=usage, custom_llm_provider="gemini")
+    assert prompt_cost == pytest.approx(377 * NATIVE_AUDIO_TEXT_INPUT)
+    assert completion_cost == pytest.approx(48 * NATIVE_AUDIO_AUDIO_OUTPUT + 36 * NATIVE_AUDIO_TEXT_OUTPUT)
+
+
+@pytest.mark.parametrize("model", NATIVE_AUDIO_KEYS)
+def test_native_audio_input_is_billed_at_the_audio_rate(model: str, local_model_cost_map):
+    usage: Final = Usage(
+        prompt_tokens=1000,
+        completion_tokens=0,
+        total_tokens=1000,
+        prompt_tokens_details=PromptTokensDetailsWrapper(text_tokens=100, audio_tokens=900),
+    )
+    prompt_cost, _ = generic_cost_per_token(model=model, usage=usage, custom_llm_provider="gemini")
+    assert prompt_cost == pytest.approx(100 * NATIVE_AUDIO_TEXT_INPUT + 900 * NATIVE_AUDIO_AUDIO_INPUT)

--- a/tests/test_litellm/test_gemini_tts_native_audio_pricing.py
+++ b/tests/test_litellm/test_gemini_tts_native_audio_pricing.py
@@ -20,6 +20,11 @@ NATIVE_AUDIO_KEYS: Final = tuple(
     for suffix in ("latest", "preview-09-2025", "preview-12-2025")
 )
 
+LIVE_NATIVE_AUDIO_KEYS: Final = (
+    "gemini-live-2.5-flash-preview-native-audio-09-2025",
+    "gemini/gemini-live-2.5-flash-preview-native-audio-09-2025",
+)
+
 FLASH_TTS_INPUT: Final = 5e-07
 FLASH_TTS_AUDIO_OUTPUT: Final = 1e-05
 PRO_TTS_INPUT: Final = 1e-06
@@ -45,10 +50,15 @@ PUBLISHED_RATES: Final = {
             "output_cost_per_token": NATIVE_AUDIO_TEXT_OUTPUT,
             "output_cost_per_audio_token": NATIVE_AUDIO_AUDIO_OUTPUT,
         }
-        for key in NATIVE_AUDIO_KEYS
+        for key in (*NATIVE_AUDIO_KEYS, *LIVE_NATIVE_AUDIO_KEYS)
     },
 }
 ALL_KEYS: Final = tuple(PUBLISHED_RATES)
+NATIVE_AUDIO_BILLING_CASES: Final = (
+    *((key, "gemini") for key in NATIVE_AUDIO_KEYS),
+    ("gemini-live-2.5-flash-preview-native-audio-09-2025", "vertex_ai"),
+    ("gemini/gemini-live-2.5-flash-preview-native-audio-09-2025", "gemini"),
+)
 LONG_CONTEXT_TIER_FIELDS: Final = (
     "input_cost_per_token_above_200k_tokens",
     "output_cost_per_token_above_200k_tokens",
@@ -118,8 +128,8 @@ def test_tts_audio_output_is_billed_at_the_audio_rate(
     assert completion_cost == pytest.approx(49 * audio_output_rate)
 
 
-@pytest.mark.parametrize("model", NATIVE_AUDIO_KEYS)
-def test_native_audio_output_is_billed_at_the_audio_rate(model: str, local_model_cost_map):
+@pytest.mark.parametrize("model, provider", NATIVE_AUDIO_BILLING_CASES)
+def test_native_audio_output_is_billed_at_the_audio_rate(model: str, provider: str, local_model_cost_map):
     usage: Final = Usage(
         prompt_tokens=377,
         completion_tokens=84,
@@ -127,18 +137,18 @@ def test_native_audio_output_is_billed_at_the_audio_rate(model: str, local_model
         prompt_tokens_details=PromptTokensDetailsWrapper(text_tokens=377),
         completion_tokens_details=CompletionTokensDetailsWrapper(audio_tokens=48, reasoning_tokens=36, text_tokens=0),
     )
-    prompt_cost, completion_cost = generic_cost_per_token(model=model, usage=usage, custom_llm_provider="gemini")
+    prompt_cost, completion_cost = generic_cost_per_token(model=model, usage=usage, custom_llm_provider=provider)
     assert prompt_cost == pytest.approx(377 * NATIVE_AUDIO_TEXT_INPUT)
     assert completion_cost == pytest.approx(48 * NATIVE_AUDIO_AUDIO_OUTPUT + 36 * NATIVE_AUDIO_TEXT_OUTPUT)
 
 
-@pytest.mark.parametrize("model", NATIVE_AUDIO_KEYS)
-def test_native_audio_input_is_billed_at_the_audio_rate(model: str, local_model_cost_map):
+@pytest.mark.parametrize("model, provider", NATIVE_AUDIO_BILLING_CASES)
+def test_native_audio_input_is_billed_at_the_audio_rate(model: str, provider: str, local_model_cost_map):
     usage: Final = Usage(
         prompt_tokens=1000,
         completion_tokens=0,
         total_tokens=1000,
         prompt_tokens_details=PromptTokensDetailsWrapper(text_tokens=100, audio_tokens=900),
     )
-    prompt_cost, _ = generic_cost_per_token(model=model, usage=usage, custom_llm_provider="gemini")
+    prompt_cost, _ = generic_cost_per_token(model=model, usage=usage, custom_llm_provider=provider)
     assert prompt_cost == pytest.approx(100 * NATIVE_AUDIO_TEXT_INPUT + 900 * NATIVE_AUDIO_AUDIO_INPUT)

--- a/tests/test_litellm/test_gemini_tts_native_audio_pricing.py
+++ b/tests/test_litellm/test_gemini_tts_native_audio_pricing.py
@@ -74,15 +74,11 @@ def _load(path: Path) -> dict[str, dict[str, object]]:
 
 @pytest.fixture
 def local_model_cost_map(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
-    original_model_cost = litellm.model_cost
     monkeypatch.setenv("LITELLM_LOCAL_MODEL_COST_MAP", "True")
-    litellm.model_cost = litellm.get_model_cost_map(url="")
+    monkeypatch.setattr(litellm, "model_cost", litellm.get_model_cost_map(url=""))
     litellm.get_model_info.cache_clear()
-    try:
-        yield
-    finally:
-        litellm.model_cost = original_model_cost
-        litellm.get_model_info.cache_clear()
+    yield
+    litellm.get_model_info.cache_clear()
 
 
 @pytest.mark.parametrize("model", ALL_KEYS)

--- a/tests/test_litellm/test_gemini_tts_native_audio_pricing.py
+++ b/tests/test_litellm/test_gemini_tts_native_audio_pricing.py
@@ -1,4 +1,5 @@
 import json
+from collections.abc import Iterator
 from pathlib import Path
 from typing import Final
 
@@ -66,13 +67,13 @@ LONG_CONTEXT_TIER_FIELDS: Final = (
 )
 
 
-def _load(path: Path) -> dict:
+def _load(path: Path) -> dict[str, dict[str, object]]:
     with open(path, encoding="utf-8") as f:
         return json.load(f)
 
 
 @pytest.fixture
-def local_model_cost_map(monkeypatch):
+def local_model_cost_map(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
     original_model_cost = litellm.model_cost
     monkeypatch.setenv("LITELLM_LOCAL_MODEL_COST_MAP", "True")
     litellm.model_cost = litellm.get_model_cost_map(url="")


### PR DESCRIPTION
## TLDR

Problem this solves:

- Gemini TTS models bill audio output at text rates, 4x under Google
- Pro TTS carries Pro chat rates plus a long-context tier TTS lacks
- Native-audio (Live API) entries miss the $12/M audio output rate
- The gemini-live Vertex entry under-prices text input at $0.30/M

How it solves it:

- Sets flash and pro preview TTS rates to Google's published TTS pricing
- Sets native-audio text, audio input, and audio output rates per Live API pricing
- Raises the gemini-live text input rate to the published $0.50/M
- Drops the long-context tier fields from the pro TTS entries

## User Flow

Before: a developer generating Gemini speech through the gateway sees spend far below what Google invoices them

1. They send POST https://litellm-domain/v1/chat/completions with `"model": "gemini-2.5-flash-preview-tts"`, `"modalities": ["audio"]`, and a short prompt
2. Audio comes back with an `x-litellm-response-cost` header of $0.00013 for 9 text tokens in and 51 audio tokens out, but Google's pricing page says those tokens cost $0.00051, so the gateway under-bills about 4x (the pro TTS model under-bills about 2x the same way)
3. They hold a voice conversation over a `/v1/realtime` session with `"model": "gemini-2.5-flash-native-audio-preview-12-2025"`
4. GET https://litellm-domain/spend/logs/ui shows that session billed at $0.30/M in and $2.50/M out, rates Google does not charge for this model, about 2.6x under its bill

After: the same requests are billed at Google's published rates

1. They send the same POST https://litellm-domain/v1/chat/completions with `"model": "gemini-2.5-flash-preview-tts"`, `"modalities": ["audio"]`, and the same prompt
2. The `x-litellm-response-cost` header now prices input at $0.50/M and audio output at $10/M, matching Google's invoice (pro TTS likewise at $1/M and $20/M)
3. They hold the same `/v1/realtime` conversation on the native-audio model
4. GET https://litellm-domain/spend/logs/ui shows the session priced at Google's Live API rates, $0.50/M text in and $2/M text out

## Relevant issues

Fixes #32111

## Linear ticket

Resolves LIT-6246

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Shared setup for both legs: a live proxy from the leg's checkout with `--num_workers 2`, `LITELLM_LOCAL_MODEL_COST_MAP=True` so it prices from that checkout's cost map, a Postgres-backed spend log, and this config (the first five deployments hit the real Gemini API, the sixth the real Vertex AI Live API):

```yaml
model_list:
  - model_name: gemini-2.5-flash-preview-tts
    litellm_params:
      model: gemini/gemini-2.5-flash-preview-tts
      api_key: os.environ/GEMINI_API_KEY
  - model_name: gemini-2.5-pro-preview-tts
    litellm_params:
      model: gemini/gemini-2.5-pro-preview-tts
      api_key: os.environ/GEMINI_API_KEY
  - model_name: gemini-2.5-flash-native-audio-preview-12-2025
    litellm_params:
      model: gemini/gemini-2.5-flash-native-audio-preview-12-2025
      api_key: os.environ/GEMINI_API_KEY
  - model_name: gemini-2.5-flash-native-audio-preview-09-2025
    litellm_params:
      model: gemini/gemini-2.5-flash-native-audio-preview-09-2025
      api_key: os.environ/GEMINI_API_KEY
  - model_name: gemini-2.5-flash-native-audio-latest
    litellm_params:
      model: gemini/gemini-2.5-flash-native-audio-latest
      api_key: os.environ/GEMINI_API_KEY
  - model_name: gemini-live-vertex
    litellm_params:
      model: vertex_ai/gemini-live-2.5-flash-preview-native-audio-09-2025
      vertex_project: <project>
      vertex_location: us-central1
      vertex_credentials: <service account json>

general_settings:
  master_key: sk-lit6246-qa
```

The TTS legs are plain curl. The realtime legs run this client, the code an end user of the realtime surface would write ($PORT and $MODEL per leg):

<details>
<summary>realtime websocket client</summary>

```python
import json, sys, time
from urllib.parse import urlencode
from websockets.sync.client import connect

port, model = sys.argv[1], sys.argv[2]
url = f"ws://localhost:{port}/v1/realtime?{urlencode({'model': model})}"
with connect(url, additional_headers={"Authorization": "Bearer sk-lit6246-qa"}, max_size=None) as ws:
    ws.send(json.dumps({"type": "session.update", "session": {"modalities": ["audio", "text"], "instructions": "Answer out loud in one short sentence."}}))
    ws.send(json.dumps({"type": "conversation.item.create", "item": {"type": "message", "role": "user", "content": [{"type": "input_text", "text": "Say cheerfully: Have a wonderful day!"}]}}))
    ws.send(json.dumps({"type": "response.create"}))
    deadline = time.monotonic() + 60
    while time.monotonic() < deadline:
        ev = json.loads(ws.recv(timeout=max(0.1, deadline - time.monotonic())))
        if ev.get("type") == "response.done":
            print("usage:", json.dumps(ev["response"].get("usage")))
            break
```

</details>

### Before (f57e4b812c)

#### gemini-2.5-flash-preview-tts via /v1/chat/completions

1. `curl -sD- http://localhost:29106/v1/chat/completions -H "Authorization: Bearer sk-lit6246-qa" -H 'Content-Type: application/json' -d '{"model":"gemini-2.5-flash-preview-tts","modalities":["audio"],"audio":{"voice":"Kore","format":"pcm16"},"messages":[{"role":"user","content":"Say cheerfully: Have a wonderful day!"}]}'`
2. HTTP 200 with audio, usage 9 prompt / 51 completion (all audio), and `x-litellm-response-cost: 0.00013020000000000002`: that is 9 x $0.30/M + 51 x $2.50/M, where Google publishes $0.50/M input and $10/M audio output, so the correct price is $0.0005145, 4x more

#### gemini-2.5-pro-preview-tts via /v1/chat/completions

1. Same curl with `"model":"gemini-2.5-pro-preview-tts"`
2. HTTP 200, usage 9 / 62, `x-litellm-response-cost: 0.00063125`: that is 9 x $1.25/M + 62 x $10/M, where Google publishes $1/M input and $20/M audio output, so the correct price is $0.001249, 2x more

#### native-audio models via /v1/realtime

1. Run the websocket client above against port 29106 for each of `gemini-2.5-flash-native-audio-preview-12-2025`, `-09-2025`, and `-latest`; each session answers with spoken audio and reports usage 378/83, 1123/76, and 378/83 tokens
2. `curl -s "http://localhost:29106/spend/logs/ui?start_date=<30m ago>&end_date=<now>" -H "Authorization: Bearer sk-lit6246-qa"` shows the three sessions logged at the old text rates ($0.30/M in, $2.50/M out), which this model's Live API pricing does not use:

```json
{"model": "gemini/gemini-2.5-flash-native-audio-preview-12-2025", "spend": 0.0003209, "prompt_tokens": 378, "completion_tokens": 83}
{"model": "gemini/gemini-2.5-flash-native-audio-preview-09-2025", "spend": 0.0005269000000000001, "prompt_tokens": 1123, "completion_tokens": 76}
{"model": "gemini/gemini-2.5-flash-native-audio-latest", "spend": 0.0003209, "prompt_tokens": 378, "completion_tokens": 83}
```

#### gemini-live-2.5-flash-preview-native-audio-09-2025 via /v1/realtime on Vertex AI

1. Same websocket client with `"model": "gemini-live-vertex"`; the session answers with real audio, usage 8 prompt / 57 completion (2 text)
2. The `/spend/logs/ui` row bills it $0.0000064 = 8 x $0.30/M text in + 2 x $2/M text out, and $0.30/M is a rate Google does not publish for this model ($0.50/M)

### After (2548e960f1)

The commits since, d565860f6 (gemini-live map entries only), fb13b47ee (test annotations only), and 54b57575d (test fixture only), cannot change these three cases: their map entries are byte-identical from 2548e960f1 through the tip

#### gemini-2.5-flash-preview-tts via /v1/chat/completions

1. Same curl against the head proxy on port 29758
2. HTTP 200, usage 9 prompt / 44 completion (all audio), `x-litellm-response-cost: 0.0004445` = 9 x $0.50/M + 44 x $10/M, exactly Google's published TTS pricing

#### gemini-2.5-pro-preview-tts via /v1/chat/completions

1. Same curl with `"model":"gemini-2.5-pro-preview-tts"`
2. HTTP 200, usage 9 / 56, `x-litellm-response-cost: 0.001129` = 9 x $1/M + 56 x $20/M, exactly Google's published TTS pricing

#### native-audio models via /v1/realtime

1. Same three websocket sessions against port 29758; usage 378/77, 1123/87, and 378/78 tokens
2. The same `/spend/logs/ui` query now shows every session priced at the corrected Live API rates ($0.50/M text in, $2/M text out):

```json
{"model": "gemini/gemini-2.5-flash-native-audio-preview-12-2025", "spend": 0.000343, "prompt_tokens": 378, "completion_tokens": 77}
{"model": "gemini/gemini-2.5-flash-native-audio-preview-09-2025", "spend": 0.0007354999999999999, "prompt_tokens": 1123, "completion_tokens": 87}
{"model": "gemini/gemini-2.5-flash-native-audio-latest", "spend": 0.000345, "prompt_tokens": 378, "completion_tokens": 78}
```

### After (fb13b47ee)

#### gemini-live-2.5-flash-preview-native-audio-09-2025 via /v1/realtime on Vertex AI

1. Same websocket client against the tip proxy; an identical session, usage 8 prompt / 57 completion (2 text)
2. The `/spend/logs/ui` row now bills it $0.000008 = 8 x $0.50/M text in + 2 x $2/M text out, the published text input rate

QA notes:

- Realtime usage reports zero audio output tokens on both legs
- Pre-existing pipeline gap, unchanged by this PR, tracked as LIT-6277
- On the Vertex leg those unattributed audio output tokens go unbilled entirely
- Native-audio $3/M audio input rate is unit-tested, not exercised live
- The Gemini API rejects the gemini-live model name for bidi; only Vertex serves it

## Type

🐛 Bug Fix

## Caveats (if any)

### Medium

- Realtime sessions still under-bill audio output
  - The usage pipeline drops Live API audio output token counts (LIT-6277)
  - Gemini API sessions bill those tokens at the text rate; Vertex sessions not at all
  - This PR fixes the rates; that follow-up fixes the attribution

### Low

- Pro TTS keeps copied cache-read, audio-input, and search fields Google does not document for TTS
- Vertex publishes no TTS pricing, so the vertex pro TTS entry follows Gemini API rates
- Native-audio entries keep mode `chat` though the models are Live API only

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

- [x] fb13b47ee59552bdd4fef11f1354085d6beae686 passes /live-pr-risk
- [x] 54b57575d716d8ba55932a60dca00cb21b0ce701 passes /live-pr-risk (delta from fb13b47ee is one test fixture, no runtime symbols or map entries touched)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes per-token billing rates for several Gemini audio models, which directly affects spend logs and response-cost headers; logic is config-only with tests, but misconfiguration would still skew customer billing.
> 
> **Overview**
> Updates the model cost map so **Gemini TTS and Live native-audio** pricing matches Google’s published rates in `model_prices_and_context_window.json` and its backup.
> 
> **Flash preview TTS** (`gemini-2.5-flash-preview-tts` and `gemini/` variants) now uses **$0.50/M** text input and **$10/M** audio output instead of the old $0.30/M and $2.50/M. **Pro preview TTS** entries use **$1/M** input and **$20/M** audio output, and **long-context tier fields** (`*_above_200k_tokens`) are removed where Google only publishes flat TTS pricing.
> 
> **Native-audio / Live** models (including `gemini-live-2.5-flash-preview-native-audio-09-2025` on Vertex and Gemini) get **$0.50/M** text input, **$3/M** audio input, **$2/M** text output, and **$12/M** audio output via new or corrected `input_cost_per_audio_token` and `output_cost_per_audio_token` fields. Pricing `source` URLs are normalized to `https://ai.google.dev/gemini-api/docs/pricing`.
> 
> A new test module asserts the registered rates, main/backup parity, and that `generic_cost_per_token` bills TTS and native-audio usage at the audio rates when token details are present.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 54b57575d716d8ba55932a60dca00cb21b0ce701. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->