### PR TITLE
fix(proxy): key lazy openapi stubs off registered features, not sys.modules

### DIFF
--- a/litellm/proxy/_lazy_features.py
+++ b/litellm/proxy/_lazy_features.py
@@ -8,8 +8,8 @@ omits each feature's routes until the feature is warmed.
 
 import asyncio
 import importlib
-import sys
 from collections.abc import Callable
+from collections.abc import Set as AbstractSet
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Final
 
@@ -397,11 +397,27 @@ def _make_warmup_router(app: "FastAPI") -> "APIRouter":
     return router
 
 
-def inject_lazy_stubs(schema: dict) -> dict:
-    """Inject openapi entries for unloaded features. Uses the snapshot file
-    when available (full route info), otherwise falls back to a single
-    placeholder per feature. Any failure logs and returns the schema unchanged
-    so /openapi.json never 500s on a cosmetic injection bug."""
+def loaded_lazy_modules(app: "FastAPI") -> frozenset[str]:
+    """The set of lazy feature modules whose routers are actually registered
+    on this app (tracked by _force_load), empty before the middleware ever ran.
+    sys.modules is the wrong signal: boot code imports several feature modules
+    (mcp_management, cloudzero, vantage, config_overrides) without mounting
+    their routers, and their stubs must still be injected."""
+    loaded: Final = getattr(app.state, "lazy_loaded", None)
+    if not isinstance(loaded, set):
+        return frozenset()
+    return frozenset(m for m in loaded if isinstance(m, str))
+
+
+def inject_lazy_stubs(
+    schema: dict,
+    loaded_modules: AbstractSet[str],
+    features: tuple[LazyFeature, ...] = LAZY_FEATURES,
+) -> dict:
+    """Inject openapi entries for features not in loaded_modules. Uses the
+    snapshot file when available (full route info), otherwise falls back to a
+    single placeholder per feature. Any failure logs and returns the schema
+    unchanged so /openapi.json never 500s on a cosmetic injection bug."""
     try:
         from litellm.proxy._lazy_openapi_snapshot import load_snapshot
 
@@ -409,8 +425,8 @@ def inject_lazy_stubs(schema: dict) -> dict:
         paths: Final = schema.setdefault("paths", {})
         schemas: Final = schema.setdefault("components", {}).setdefault("schemas", {})
 
-        for feat in LAZY_FEATURES:
-            if feat.module_path in sys.modules and not feat.persistent_swagger_stub:
+        for feat in features:
+            if feat.module_path in loaded_modules and not feat.persistent_swagger_stub:
                 continue
 
             fragment = (snapshot or {}).get(feat.name)

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -1502,9 +1502,9 @@ def get_openapi_schema():
     openapi_schema = CustomOpenAPISpec.add_llm_api_request_schema_body(openapi_schema)
 
     # Stub unloaded lazy features so they appear as Swagger sections.
-    from litellm.proxy._lazy_features import inject_lazy_stubs
+    from litellm.proxy._lazy_features import inject_lazy_stubs, loaded_lazy_modules
 
-    openapi_schema = inject_lazy_stubs(openapi_schema)
+    openapi_schema = inject_lazy_stubs(openapi_schema, loaded_lazy_modules(app))
     openapi_schema = ensure_unique_openapi_operation_ids(openapi_schema)
 
     # Fix Swagger UI execute path error when server_root_path is set
@@ -1534,9 +1534,9 @@ def custom_openapi():
     openapi_schema = CustomOpenAPISpec.add_llm_api_request_schema_body(openapi_schema)
 
     # Stub unloaded lazy features so they appear as Swagger sections.
-    from litellm.proxy._lazy_features import inject_lazy_stubs
+    from litellm.proxy._lazy_features import inject_lazy_stubs, loaded_lazy_modules
 
-    openapi_schema = inject_lazy_stubs(openapi_schema)
+    openapi_schema = inject_lazy_stubs(openapi_schema, loaded_lazy_modules(app))
     openapi_schema = ensure_unique_openapi_operation_ids(openapi_schema)
 
     # Fix Swagger UI execute path error when server_root_path is set

--- a/tests/test_litellm/proxy/test_proxy_server.py
+++ b/tests/test_litellm/proxy/test_proxy_server.py
@@ -9152,6 +9152,78 @@ class TestLazyFeatureMiddleware:
         )
 
 
+class TestInjectLazyStubs:
+    """Stub injection keys off the app-tracked loaded set, never sys.modules:
+    proxy boot imports several feature modules (mcp_management, cloudzero,
+    vantage, config_overrides) without mounting their routers, and their
+    /openapi.json entries must survive that (LIT-6275)."""
+
+    def test_imported_but_unregistered_module_still_gets_stub(self):
+        import sys
+
+        from litellm.proxy._lazy_features import LazyFeature, inject_lazy_stubs
+
+        feat = LazyFeature(
+            name="dummy_lazy_test",
+            module_path="json",
+            path_prefixes=("/dummy-lazy-test",),
+        )
+        assert feat.module_path in sys.modules
+
+        schema = inject_lazy_stubs({"paths": {}}, loaded_modules=frozenset(), features=(feat,))
+        assert "/dummy-lazy-test" in schema["paths"]
+
+    def test_registered_module_gets_no_stub(self):
+        from litellm.proxy._lazy_features import LazyFeature, inject_lazy_stubs
+
+        feat = LazyFeature(
+            name="dummy_lazy_test",
+            module_path="json",
+            path_prefixes=("/dummy-lazy-test",),
+        )
+        schema = inject_lazy_stubs({"paths": {}}, loaded_modules=frozenset({"json"}), features=(feat,))
+        assert "/dummy-lazy-test" not in schema["paths"]
+
+    def test_snapshot_fragments_injected_for_boot_imported_features(self):
+        from litellm.proxy._lazy_features import LAZY_FEATURES, inject_lazy_stubs
+        from litellm.proxy._lazy_openapi_snapshot import load_snapshot
+
+        snapshot = load_snapshot()
+        assert snapshot
+        boot_imported = tuple(
+            f for f in LAZY_FEATURES if f.name in ("mcp_management", "cloudzero", "vantage", "config_overrides")
+        )
+        assert len(boot_imported) == 4
+
+        schema = inject_lazy_stubs({"paths": {}}, loaded_modules=frozenset(), features=boot_imported)
+        for feat in boot_imported:
+            missing = [p for p in snapshot[feat.name]["paths"] if p not in schema["paths"]]
+            assert not missing, f"{feat.name} snapshot paths missing from /openapi.json: {missing}"
+
+    def test_persistent_stub_survives_load(self):
+        from litellm.proxy._lazy_features import LazyFeature, inject_lazy_stubs
+
+        feat = LazyFeature(
+            name="dummy_lazy_test",
+            module_path="json",
+            path_prefixes=("/dummy-lazy-test",),
+            persistent_swagger_stub=True,
+        )
+        schema = inject_lazy_stubs({"paths": {}}, loaded_modules=frozenset({"json"}), features=(feat,))
+        assert "/dummy-lazy-test" in schema["paths"]
+
+    def test_loaded_lazy_modules_reads_app_state(self):
+        from fastapi import FastAPI
+
+        from litellm.proxy._lazy_features import loaded_lazy_modules
+
+        app = FastAPI()
+        assert loaded_lazy_modules(app) == frozenset()
+
+        app.state.lazy_loaded = {"litellm.proxy.spend_tracking.cloudzero_endpoints"}
+        assert loaded_lazy_modules(app) == frozenset({"litellm.proxy.spend_tracking.cloudzero_endpoints"})
+
+
 @pytest.mark.asyncio
 async def test_get_current_spend_redis_clean_miss_skips_stale_in_memory():
     """When Redis is reachable and cleanly returns None (TTL expired,


### PR DESCRIPTION
## TLDR

Problem this solves:

- DB-connected proxies drop all MCP admin routes from /openapi.json
- /cloudzero, /vantage, and /config_overrides docs disappear too
- Swagger and generated clients miss those API surfaces

How it solves it:

- Stub injection now checks the tracked set of registered features
- A boot-time import alone no longer hides a feature's docs

## User Flow

Before: an engineer reading a DB-connected gateway's API docs finds every MCP admin route missing

1. They open http://litellm-domain/ (the Swagger docs page) on a proxy that has a database connected
2. There is no MCP server management section: none of the `/v1/mcp/...` admin routes (list, register, health) appear anywhere on the page
3. They fetch GET http://litellm-domain/openapi.json and filter for `/v1/mcp/server`: the result is empty, and every `/cloudzero/*`, `/vantage/*`, and `/config_overrides/*` path is missing too
4. A client generated from that spec has no MCP, CloudZero, Vantage, or config override methods, even though calling those routes directly still works, so the spec understates the real API surface

After: the same docs page and spec cover every route

1. They open http://litellm-domain/ (the Swagger docs page) on a proxy that has a database connected
2. The MCP server management, cloudzero, vantage, and config_overrides sections are all on the page with their routes
3. GET http://litellm-domain/openapi.json lists all 21 `/v1/mcp/...` admin paths plus 5 `/cloudzero/*`, 5 `/vantage/*`, and 2 `/config_overrides/*` paths
4. A client generated from that spec covers the full API surface

## Relevant issues

## Linear ticket

Resolves LIT-6275

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Shared setup: a DB-backed proxy (Postgres with the LiteLLM schema applied, `DATABASE_URL` exported), started with `python litellm/proxy/proxy_cli.py --config config.yaml --port <port> --num_workers 2`, where config.yaml is one openai/gpt-5-mini model plus `general_settings: {master_key: ..., database_url: os.environ/DATABASE_URL, store_model_in_db: true}`. The coverage table comes from this helper, saved as coverage.py:

```python
import json, sys
snapshot = json.load(open(sys.argv[1]))
live = json.load(sys.stdin)["paths"]
for name, frag in sorted(snapshot.items()):
    paths = list(frag["paths"])
    present = [p for p in paths if p in live]
    flag = "" if len(present) == len(paths) else "  <-- MISSING"
    print(f"{name:28s} {len(present):3d}/{len(paths):<3d}{flag}")
```

### Before (632a007967)

1. `curl -s http://localhost:29873/openapi.json | python3 -c 'import json,sys; p=json.load(sys.stdin)["paths"]; print([k for k in p if k.startswith("/v1/mcp/server")])'` prints `[]`
2. `curl -s http://localhost:29873/openapi.json | python3 -c 'import json,sys; p=json.load(sys.stdin)["paths"]; print([k for k in p if k.startswith(("/cloudzero","/vantage","/config_overrides"))])'` prints `[]`
3. `curl -s http://localhost:29873/openapi.json | python3 coverage.py litellm/proxy/_lazy_openapi_snapshot.json | grep MISSING` shows exactly four features dropped, all other 27 fully present:

    ```
    cloudzero                      0/5    <-- MISSING
    config_overrides               0/2    <-- MISSING
    mcp_management                 0/21   <-- MISSING
    vantage                        0/5    <-- MISSING
    ```

4. The Swagger page at http://localhost:29873/ serves off the same spec, so those four sections are missing there too

### After (fd751a5023)

1. `curl -s http://localhost:31137/openapi.json | python3 -c 'import json,sys; p=json.load(sys.stdin)["paths"]; print([k for k in p if k.startswith("/v1/mcp/server")])'` prints 11 paths: `/v1/mcp/server`, `/v1/mcp/server/health`, `/v1/mcp/server/register`, `/v1/mcp/server/{server_id}`, ...
2. `curl -s http://localhost:31137/openapi.json | python3 -c 'import json,sys; p=json.load(sys.stdin)["paths"]; print([k for k in p if k.startswith(("/cloudzero","/vantage","/config_overrides"))])'` prints all 12: `/cloudzero/delete`, `/cloudzero/dry-run`, `/cloudzero/export`, `/cloudzero/init`, `/cloudzero/settings`, `/config_overrides/hashicorp_vault`, `/config_overrides/hashicorp_vault/test_connection`, `/vantage/delete`, `/vantage/dry-run`, `/vantage/export`, `/vantage/init`, `/vantage/settings`
3. `curl -s http://localhost:31137/openapi.json | python3 coverage.py litellm/proxy/_lazy_openapi_snapshot.json` shows all 31 features fully covered, zero MISSING rows (`mcp_management 21/21`, `cloudzero 5/5`, `vantage 5/5`, `config_overrides 2/2`)
4. Lazy loading still works: `curl -s -o /dev/null -w '%{http_code}' -H "Authorization: Bearer $LITELLM_MASTER_KEY" http://localhost:31137/v1/mcp/server` returns `200` (first hit mounts the real routes), and re-running the coverage table afterwards still shows zero MISSING rows

## Type

🐛 Bug Fix

## Caveats (if any)

### Low

- Injected route docs come from the snapshot; its freshness is guarded separately (#38410)

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

Live PR risk: CHECKED at fd751a5023. Both spec builders (default and DOCS_FILTERED premium mode) verified live on a DB-backed 2-worker proxy, the schema.d.ts codegen produced zero diff, and the only callers of the re-signed function are the two updated call sites plus the new tests
- [x] fd751a5023 passes /live-pr-risk

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only OpenAPI stub logic change with targeted tests; runtime routing and lazy-load behavior are unchanged aside from fixing incorrect stub suppression.
> 
> **Overview**
> Fixes **missing Swagger/OpenAPI paths** on DB-backed proxies for MCP admin, CloudZero, Vantage, and config overrides when those modules are imported at boot but their routers are not mounted yet.
> 
> **`inject_lazy_stubs`** no longer treats `sys.modules` as “loaded.” It takes an explicit **`loaded_modules`** set and skips stub injection only when a feature’s module is in that set (unless **`persistent_swagger_stub`**). New helper **`loaded_lazy_modules(app)`** reads **`app.state.lazy_loaded`**, which **`_force_load`** updates when a lazy router is actually registered. Both OpenAPI builders in **`proxy_server.py`** pass **`loaded_lazy_modules(app)`** into **`inject_lazy_stubs`**.
> 
> Adds **`TestInjectLazyStubs`** covering boot-imported-but-unregistered modules, loaded modules, snapshot injection, persistent stubs, and **`loaded_lazy_modules`** state.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fd751a5023458884fbebb125ec945b51250873d9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->