### PR TITLE
fix(cost): price gemini-live-2.5-flash-native-audio realtime sessions

### DIFF
--- a/litellm/cost_calculator.py
+++ b/litellm/cost_calculator.py
@@ -2393,7 +2393,10 @@ def _cost_map_entry_declares_pricing(model_name: str, custom_llm_provider: str) 
         litellm.model_cost.get(model_name),
         litellm.model_cost.get(f"{custom_llm_provider}/{model_name}"),
     )
-    return any(entry is not None and any("cost_per" in field for field in entry) for entry in entries)
+    return any(
+        entry is not None and any("cost_per" in field and value is not None for field, value in entry.items())
+        for entry in entries
+    )
 
 
 def _first_priced_realtime_token_costs(

--- a/litellm/cost_calculator.py
+++ b/litellm/cost_calculator.py
@@ -2,6 +2,7 @@
 ## File for 'response_cost' calculation in Logging
 import logging
 import time
+from collections.abc import Sequence
 from functools import lru_cache
 from typing import TYPE_CHECKING, Any, Final, Literal, cast
 
@@ -2370,6 +2371,61 @@ class RealtimeAPITokenUsageProcessor(BaseTokenUsageProcessor):
 _TRANSCRIPTION_COMPLETED_EVENT_TYPE: Final = "conversation.item.input_audio_transcription.completed"
 
 
+def _candidate_realtime_token_costs(
+    model_name: str,
+    combined_usage_object: Usage,
+    custom_llm_provider: str,
+    data_residency: str | None,
+) -> tuple[float, float] | None:
+    try:
+        return generic_cost_per_token(
+            model=model_name,
+            usage=combined_usage_object,
+            custom_llm_provider=custom_llm_provider,
+            data_residency=data_residency,
+        )
+    except Exception:
+        return None
+
+
+def _cost_map_entry_declares_pricing(model_name: str, custom_llm_provider: str) -> bool:
+    entries: Final = (
+        litellm.model_cost.get(model_name),
+        litellm.model_cost.get(f"{custom_llm_provider}/{model_name}"),
+    )
+    return any(entry is not None and any("cost_per" in field for field in entry) for entry in entries)
+
+
+def _first_priced_realtime_token_costs(
+    potential_model_names: Sequence[str | None],
+    combined_usage_object: Usage,
+    custom_llm_provider: str,
+    data_residency: str | None,
+) -> tuple[float, float]:
+    candidate_costs: Final = (
+        (model_name, costs)
+        for model_name in potential_model_names
+        if model_name is not None
+        and (
+            costs := _candidate_realtime_token_costs(
+                model_name=model_name,
+                combined_usage_object=combined_usage_object,
+                custom_llm_provider=custom_llm_provider,
+                data_residency=data_residency,
+            )
+        )
+        is not None
+    )
+    return next(
+        (
+            costs
+            for model_name, costs in candidate_costs
+            if sum(costs) > 0 or _cost_map_entry_declares_pricing(model_name, custom_llm_provider)
+        ),
+        (0.0, 0.0),
+    )
+
+
 def handle_realtime_stream_cost_calculation(
     results: OpenAIRealtimeStreamList,
     combined_usage_object: Usage,
@@ -2394,24 +2450,12 @@ def handle_realtime_stream_cost_calculation(
             potential_model_names.append(received_model)
 
     potential_model_names.append(litellm_model_name)
-    input_cost_per_token = 0.0
-    output_cost_per_token = 0.0
-
-    for model_name in potential_model_names:
-        try:
-            if model_name is None:
-                continue
-            _input_cost_per_token, _output_cost_per_token = generic_cost_per_token(
-                model=model_name,
-                usage=combined_usage_object,
-                custom_llm_provider=custom_llm_provider,
-                data_residency=data_residency,
-            )
-        except Exception:
-            continue
-        input_cost_per_token += _input_cost_per_token
-        output_cost_per_token += _output_cost_per_token
-        break  # exit if we find a valid model
+    input_cost_per_token, output_cost_per_token = _first_priced_realtime_token_costs(
+        potential_model_names=potential_model_names,
+        combined_usage_object=combined_usage_object,
+        custom_llm_provider=custom_llm_provider,
+        data_residency=data_residency,
+    )
     transcription_cost: Final = (
         handle_realtime_transcription_cost_calculation(
             results=results,

--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -20370,6 +20370,49 @@
         },
         "supports_image_size": false
     },
+    "gemini-live-2.5-flash-native-audio": {
+        "input_cost_per_audio_token": 3e-06,
+        "input_cost_per_token": 5e-07,
+        "litellm_provider": "vertex_ai-language-models",
+        "max_input_tokens": 1048576,
+        "max_output_tokens": 65535,
+        "max_tokens": 65535,
+        "mode": "realtime",
+        "output_cost_per_audio_token": 1.2e-05,
+        "output_cost_per_token": 2e-06,
+        "source": "https://cloud.google.com/vertex-ai/generative-ai/pricing",
+        "supported_endpoints": [
+            "/vertex_ai/live"
+        ],
+        "supported_modalities": [
+            "text",
+            "image",
+            "audio",
+            "video"
+        ],
+        "supported_output_modalities": [
+            "text",
+            "audio"
+        ],
+        "supports_audio_input": true,
+        "supports_audio_output": true,
+        "supports_function_calling": true,
+        "supports_parallel_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_response_schema": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_url_context": true,
+        "supports_vision": true,
+        "supports_web_search": true,
+        "search_context_cost_per_query": {
+            "search_context_size_low": 0.035,
+            "search_context_size_medium": 0.035,
+            "search_context_size_high": 0.035
+        },
+        "gemini_native_audio": true
+    },
     "gemini-live-2.5-flash-preview-native-audio-09-2025": {
         "cache_read_input_token_cost": 7.5e-08,
         "input_cost_per_audio_token": 3e-06,

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -20370,6 +20370,49 @@
         },
         "supports_image_size": false
     },
+    "gemini-live-2.5-flash-native-audio": {
+        "input_cost_per_audio_token": 3e-06,
+        "input_cost_per_token": 5e-07,
+        "litellm_provider": "vertex_ai-language-models",
+        "max_input_tokens": 1048576,
+        "max_output_tokens": 65535,
+        "max_tokens": 65535,
+        "mode": "realtime",
+        "output_cost_per_audio_token": 1.2e-05,
+        "output_cost_per_token": 2e-06,
+        "source": "https://cloud.google.com/vertex-ai/generative-ai/pricing",
+        "supported_endpoints": [
+            "/vertex_ai/live"
+        ],
+        "supported_modalities": [
+            "text",
+            "image",
+            "audio",
+            "video"
+        ],
+        "supported_output_modalities": [
+            "text",
+            "audio"
+        ],
+        "supports_audio_input": true,
+        "supports_audio_output": true,
+        "supports_function_calling": true,
+        "supports_parallel_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_response_schema": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_url_context": true,
+        "supports_vision": true,
+        "supports_web_search": true,
+        "search_context_cost_per_query": {
+            "search_context_size_low": 0.035,
+            "search_context_size_medium": 0.035,
+            "search_context_size_high": 0.035
+        },
+        "gemini_native_audio": true
+    },
     "gemini-live-2.5-flash-preview-native-audio-09-2025": {
         "cache_read_input_token_cost": 7.5e-08,
         "input_cost_per_audio_token": 3e-06,

--- a/tests/test_litellm/test_cost_calculator.py
+++ b/tests/test_litellm/test_cost_calculator.py
@@ -4116,3 +4116,94 @@ def test_every_one_hour_cache_write_rate_is_double_its_input_rate():
     }
 
     assert deviations == {}
+
+
+def test_gemini_live_native_audio_ga_realtime_cost(_local_model_cost_map: None) -> None:
+    """Regression for https://github.com/BerriAI/litellm/issues/31087: realtime sessions on the
+    GA vertex model gemini-live-2.5-flash-native-audio must bill at its published rates instead
+    of logging zero spend because only the preview-09-2025 key existed in the cost map."""
+    from litellm.types.utils import CompletionTokensDetailsWrapper
+
+    results: OpenAIRealtimeStreamList = [
+        {"type": "session.created", "session": {"model": "gemini-live-2.5-flash-native-audio"}},
+    ]
+    combined_usage_object = Usage(
+        prompt_tokens=8,
+        completion_tokens=25,
+        total_tokens=33,
+        prompt_tokens_details=PromptTokensDetailsWrapper(text_tokens=8, audio_tokens=0),
+        completion_tokens_details=CompletionTokensDetailsWrapper(text_tokens=2, audio_tokens=23),
+    )
+
+    cost = handle_realtime_stream_cost_calculation(
+        results=results,
+        combined_usage_object=combined_usage_object,
+        custom_llm_provider="vertex_ai",
+        litellm_model_name="vertex_ai/gemini-live-2.5-flash-native-audio",
+    )
+
+    expected_cost = 8 * 5e-07 + 2 * 2e-06 + 23 * 1.2e-05
+    assert cost == pytest.approx(expected_cost, rel=1e-9)
+
+
+def test_realtime_priceless_deployment_entry_falls_through_to_priced_model(
+    _local_model_cost_map: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Regression for https://github.com/BerriAI/litellm/issues/31087: the router registers every
+    deployment's backend key into litellm.model_cost without price fields, and the realtime cost
+    handler used to accept that zero-defaulted entry for the session.created model and stop, so a
+    configured base_model never priced the session."""
+    monkeypatch.setitem(
+        litellm.model_cost,
+        "vertex_ai/some-unmapped-live-model",
+        {"litellm_provider": "vertex_ai", "mode": "realtime"},
+    )
+    priced_model = "vertex_ai/gemini-live-2.5-flash-preview-native-audio-09-2025"
+    priced_entry = litellm.model_cost["gemini-live-2.5-flash-preview-native-audio-09-2025"]
+
+    results: OpenAIRealtimeStreamList = [
+        {"type": "session.created", "session": {"model": "some-unmapped-live-model"}},
+    ]
+    combined_usage_object = Usage(prompt_tokens=8, completion_tokens=25, total_tokens=33)
+
+    cost = handle_realtime_stream_cost_calculation(
+        results=results,
+        combined_usage_object=combined_usage_object,
+        custom_llm_provider="vertex_ai",
+        litellm_model_name=priced_model,
+    )
+
+    expected_cost = 8 * priced_entry["input_cost_per_token"] + 25 * priced_entry["output_cost_per_token"]
+    assert cost == pytest.approx(expected_cost, rel=1e-9)
+    assert cost > 0
+
+
+def test_realtime_explicitly_free_session_model_still_bills_zero(
+    _local_model_cost_map: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A session model whose cost map entry explicitly declares zero rates is genuinely free, so
+    the handler must keep billing it at zero instead of falling through to a priced fallback."""
+    monkeypatch.setitem(
+        litellm.model_cost,
+        "vertex_ai/free-live-model",
+        {
+            "litellm_provider": "vertex_ai",
+            "mode": "realtime",
+            "input_cost_per_token": 0.0,
+            "output_cost_per_token": 0.0,
+        },
+    )
+
+    results: OpenAIRealtimeStreamList = [
+        {"type": "session.created", "session": {"model": "free-live-model"}},
+    ]
+    combined_usage_object = Usage(prompt_tokens=8, completion_tokens=25, total_tokens=33)
+
+    cost = handle_realtime_stream_cost_calculation(
+        results=results,
+        combined_usage_object=combined_usage_object,
+        custom_llm_provider="vertex_ai",
+        litellm_model_name="vertex_ai/gemini-live-2.5-flash-preview-native-audio-09-2025",
+    )
+
+    assert cost == 0.0

--- a/tests/test_litellm/test_cost_calculator.py
+++ b/tests/test_litellm/test_cost_calculator.py
@@ -4119,9 +4119,7 @@ def test_every_one_hour_cache_write_rate_is_double_its_input_rate():
 
 
 def test_gemini_live_native_audio_ga_realtime_cost(_local_model_cost_map: None) -> None:
-    """Regression for https://github.com/BerriAI/litellm/issues/31087: realtime sessions on the
-    GA vertex model gemini-live-2.5-flash-native-audio must bill at its published rates instead
-    of logging zero spend because only the preview-09-2025 key existed in the cost map."""
+    """Regression for https://github.com/BerriAI/litellm/issues/31087."""
     from litellm.types.utils import CompletionTokensDetailsWrapper
 
     results: OpenAIRealtimeStreamList = [
@@ -4163,11 +4161,7 @@ def test_gemini_live_native_audio_ga_realtime_cost(_local_model_cost_map: None) 
 def test_realtime_priceless_deployment_entry_falls_through_to_priced_model(
     _local_model_cost_map: None, monkeypatch: pytest.MonkeyPatch, priceless_entry: dict
 ) -> None:
-    """Regression for https://github.com/BerriAI/litellm/issues/31087: the router registers every
-    deployment's backend key into litellm.model_cost without price fields (and merges a None-valued
-    ModelInfo skeleton into mapped entries), and the realtime cost handler used to accept that
-    zero-defaulted entry for the session.created model and stop, so a configured base_model never
-    priced the session."""
+    """Regression for https://github.com/BerriAI/litellm/issues/31087 (router-registered priceless entries)."""
     monkeypatch.setitem(
         litellm.model_cost,
         "vertex_ai/some-unmapped-live-model",
@@ -4196,8 +4190,6 @@ def test_realtime_priceless_deployment_entry_falls_through_to_priced_model(
 def test_realtime_explicitly_free_session_model_still_bills_zero(
     _local_model_cost_map: None, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """A session model whose cost map entry explicitly declares zero rates is genuinely free, so
-    the handler must keep billing it at zero instead of falling through to a priced fallback."""
     monkeypatch.setitem(
         litellm.model_cost,
         "vertex_ai/free-live-model",

--- a/tests/test_litellm/test_cost_calculator.py
+++ b/tests/test_litellm/test_cost_calculator.py
@@ -4146,17 +4146,32 @@ def test_gemini_live_native_audio_ga_realtime_cost(_local_model_cost_map: None) 
     assert cost == pytest.approx(expected_cost, rel=1e-9)
 
 
+@pytest.mark.parametrize(
+    "priceless_entry",
+    [
+        {"litellm_provider": "vertex_ai", "mode": "realtime"},
+        {
+            "litellm_provider": "vertex_ai",
+            "mode": "realtime",
+            "input_cost_per_token": None,
+            "output_cost_per_token": None,
+            "input_cost_per_audio_token": None,
+        },
+    ],
+    ids=["registered_without_price_fields", "registered_with_none_valued_price_fields"],
+)
 def test_realtime_priceless_deployment_entry_falls_through_to_priced_model(
-    _local_model_cost_map: None, monkeypatch: pytest.MonkeyPatch
+    _local_model_cost_map: None, monkeypatch: pytest.MonkeyPatch, priceless_entry: dict
 ) -> None:
     """Regression for https://github.com/BerriAI/litellm/issues/31087: the router registers every
-    deployment's backend key into litellm.model_cost without price fields, and the realtime cost
-    handler used to accept that zero-defaulted entry for the session.created model and stop, so a
-    configured base_model never priced the session."""
+    deployment's backend key into litellm.model_cost without price fields (and merges a None-valued
+    ModelInfo skeleton into mapped entries), and the realtime cost handler used to accept that
+    zero-defaulted entry for the session.created model and stop, so a configured base_model never
+    priced the session."""
     monkeypatch.setitem(
         litellm.model_cost,
         "vertex_ai/some-unmapped-live-model",
-        {"litellm_provider": "vertex_ai", "mode": "realtime"},
+        priceless_entry,
     )
     priced_model = "vertex_ai/gemini-live-2.5-flash-preview-native-audio-09-2025"
     priced_entry = litellm.model_cost["gemini-live-2.5-flash-preview-native-audio-09-2025"]


### PR DESCRIPTION
## TLDR

Problem this solves:

- Realtime sessions on `vertex_ai/gemini-live-2.5-flash-native-audio` always log $0 spend
- The GA model has no cost map entry, only the preview one does
- Setting `base_model` to the priced preview model does not help either

How it solves it:

- Adds the `gemini-live-2.5-flash-native-audio` GA entry at its published Vertex rates
- Realtime cost now skips zero-defaulted lookups and falls through to `base_model`
- Models whose cost map entry explicitly declares $0 rates still bill $0

## User Flow

Before: a developer running a voice agent over the proxy sees every Gemini Live session logged at $0, so their spend tracking and budgets never count that traffic

1. They connect to `ws://litellm-domain/v1/realtime?model=gemini-live-native` (a deployment of `vertex_ai/gemini-live-2.5-flash-native-audio`) and hold a short conversation
2. The session works: `session.created` arrives, then `response.done` with real usage (e.g. 8 input tokens, 22 output tokens)
3. They open `http://litellm-domain/ui/?page=logs` and the session's row shows $0.00 spend
4. They add `base_model: vertex_ai/gemini-live-2.5-flash-preview-native-audio-09-2025` (a priced model) to the deployment, reconnect, and the new session still logs $0.00

After: the same sessions log real spend, with or without `base_model`

1. They connect to `ws://litellm-domain/v1/realtime?model=gemini-live-native` and hold the same short conversation
2. The session works exactly as before: `session.created`, then `response.done` with real usage
3. They open `http://litellm-domain/ui/?page=logs` and the session's row now shows non-zero spend at the model's published rates (e.g. $0.000008 for 8 tokens in, 2 out)
4. The `base_model` deployment's sessions also log non-zero spend now (the new GA entry prices the model directly)

## Relevant issues

Fixes #31087

## Linear ticket

Resolves LIT-6247

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Both legs are live e2e runs against the real Vertex AI Live API (real $$$). Per leg: a fresh worktree at the named commit, 2 proxy processes x 2 uvicorn workers each sharing one fresh Postgres DB, realtime sessions opened through instance A and spend read back through instance B, so every row survives a cross-process read exactly as it would across pods. The client is a ~50 line `websockets` script speaking the OpenAI realtime protocol: `session.update` (text modality), one "Say the word hello and nothing else." user message, `response.create`, then it prints every event and the final usage

The After leg was captured at b48bff7b54; the PR tip e7b843d69b only trims test docstrings on top of it (no code change), so the run is current

Config for both legs (only the master key differs per leg):

```yaml
model_list:
  - model_name: gemini-live-native
    litellm_params:
      model: vertex_ai/gemini-live-2.5-flash-native-audio
      vertex_project: os.environ/VERTEXAI_PROJECT
      vertex_location: us-central1
      vertex_credentials: <service account json path>
  - model_name: gemini-live-native-basemodel
    litellm_params:
      model: vertex_ai/gemini-live-2.5-flash-native-audio
      vertex_project: os.environ/VERTEXAI_PROJECT
      vertex_location: us-central1
      vertex_credentials: <service account json path>
    model_info:
      base_model: vertex_ai/gemini-live-2.5-flash-preview-native-audio-09-2025

general_settings:
  master_key: sk-lit6247-qa-<leg>
  database_url: os.environ/DATABASE_URL
```

### Before (f7220556e1)

#### Plain deployment (gemini-live-native)

1. Open a realtime session through instance A and hold the conversation

```
$ .venv/bin/python realtime_client.py 21618 gemini-live-native sk-lit6247-qa-before
session.created model=gemini-live-2.5-flash-native-audio
event: response.created
event: response.output_item.added
event: conversation.item.added
event: response.content_part.added
event: response.output_audio_transcript.delta
event: response.output_audio.delta
event: response.output_audio.delta
event: response.output_audio.delta
event: response.output_audio.delta
event: response.output_audio.done
event: response.content_part.done
event: response.output_item.done
response.done usage={"input_tokens": 8, "input_tokens_details": {"audio_tokens": null, "cached_tokens": 0, "text_tokens": 8}, "output_tokens": 22, "output_tokens_details": {"reasoning_tokens": 0, "text_tokens": 1}, "total_tokens": 30, "cost": null, "input_token_details": {"cached_tokens": 0, "text_tokens": 8, "audio_tokens": 0}, "output_token_details": {"text_tokens": 1, "audio_tokens": 0, "reasoning_tokens": 0}}
```

2. The session works (8 input / 22 output tokens) but the usage event carries `"cost": null`

#### base_model deployment (gemini-live-native-basemodel)

1. Same session against the deployment whose `base_model` points at the priced preview model. The first attempt came back instantly with 0 output tokens (a provider hiccup) and was retried once per the runbook; the retry is shown

```
$ .venv/bin/python realtime_client.py 21618 gemini-live-native-basemodel sk-lit6247-qa-before
session.created model=gemini-live-2.5-flash-native-audio
event: response.created
event: response.output_item.added
event: conversation.item.added
event: response.content_part.added
event: response.output_audio_transcript.delta
event: response.output_audio.delta
event: response.output_audio.delta
event: response.output_audio.delta
event: response.output_audio.delta
event: response.output_audio.done
event: response.content_part.done
event: response.output_item.done
response.done usage={"input_tokens": 8, "input_tokens_details": {"audio_tokens": null, "cached_tokens": 0, "text_tokens": 8}, "output_tokens": 23, "output_tokens_details": {"reasoning_tokens": 0, "text_tokens": 2}, "total_tokens": 31, "cost": null, "input_token_details": {"cached_tokens": 0, "text_tokens": 8, "audio_tokens": 0}, "output_token_details": {"text_tokens": 2, "audio_tokens": 0, "reasoning_tokens": 0}}
```

2. The session works (8 input / 23 output tokens), `"cost": null` again

#### Spend read via the other proxy instance

1. Read the spend rows back through instance B

```
$ curl -s "http://127.0.0.1:21619/spend/logs" -H "Authorization: Bearer sk-lit6247-qa-before" | jq '[.[] | {request_id, model, spend, prompt_tokens, completion_tokens, total_tokens}]'
[
  {
    "request_id": "c641c04e-8dd4-4d0b-b367-4a88c907dcbd",
    "model": "vertex_ai/gemini-live-2.5-flash-native-audio",
    "spend": 0.0,
    "prompt_tokens": 8,
    "completion_tokens": 23,
    "total_tokens": 31
  },
  {
    "request_id": "2baf9b22-ffba-4841-b4e8-ae1724908dc9",
    "model": "vertex_ai/gemini-live-2.5-flash-native-audio",
    "spend": 0.0,
    "prompt_tokens": 8,
    "completion_tokens": 0,
    "total_tokens": 8
  },
  {
    "request_id": "ac761dff-d32c-4e3f-bcc3-0615af34c2dc",
    "model": "vertex_ai/gemini-live-2.5-flash-native-audio",
    "spend": 0.0,
    "prompt_tokens": 8,
    "completion_tokens": 22,
    "total_tokens": 30
  }
]
```

2. Every row shows `spend: 0.0` despite real token counts: `ac761dff` is the plain deployment, `c641c04e` the base_model retry, `2baf9b22` the hiccuped attempt

### After (b48bff7b54)

#### Plain deployment (gemini-live-native)

1. Same command, same conversation. The first attempt hiccuped empty and was retried once; the retry is shown

```
$ .venv/bin/python realtime_client.py 31742 gemini-live-native sk-lit6247-qa-after
session.created model=gemini-live-2.5-flash-native-audio
event: response.created
event: response.output_item.added
event: conversation.item.added
event: response.content_part.added
event: response.output_audio_transcript.delta
event: response.output_audio.delta
event: response.output_audio.delta
event: response.output_audio.delta
event: response.output_audio.done
event: response.content_part.done
event: response.output_item.done
response.done usage={"input_tokens": 8, "input_tokens_details": {"audio_tokens": null, "cached_tokens": 0, "text_tokens": 8}, "output_tokens": 18, "output_tokens_details": {"reasoning_tokens": 0, "text_tokens": 1}, "total_tokens": 26, "cost": null, "input_token_details": {"cached_tokens": 0, "text_tokens": 8, "audio_tokens": 0}, "output_token_details": {"text_tokens": 1, "audio_tokens": 0, "reasoning_tokens": 0}}
```

2. The session works (8 input / 18 output tokens)

#### base_model deployment (gemini-live-native-basemodel)

1. Same session against the base_model deployment. First attempt hiccuped empty and was retried once; the retry is shown

```
$ .venv/bin/python realtime_client.py 31742 gemini-live-native-basemodel sk-lit6247-qa-after
session.created model=gemini-live-2.5-flash-native-audio
event: response.created
event: response.output_item.added
event: conversation.item.added
event: response.content_part.added
event: response.output_audio_transcript.delta
event: response.output_audio.delta
event: response.output_audio.delta
event: response.output_audio.delta
event: response.output_audio.delta
event: response.output_audio.done
event: response.content_part.done
event: response.output_item.done
response.done usage={"input_tokens": 8, "input_tokens_details": {"audio_tokens": null, "cached_tokens": 0, "text_tokens": 8}, "output_tokens": 25, "output_tokens_details": {"reasoning_tokens": 0, "text_tokens": 2}, "total_tokens": 33, "cost": null, "input_token_details": {"cached_tokens": 0, "text_tokens": 8, "audio_tokens": 0}, "output_token_details": {"text_tokens": 2, "audio_tokens": 0, "reasoning_tokens": 0}}
```

2. The session works (8 input / 25 output tokens)

#### Spend read via the other proxy instance

1. Read the spend rows back through instance B

```
$ curl -s "http://127.0.0.1:31743/spend/logs" -H "Authorization: Bearer sk-lit6247-qa-after" | jq '[.[] | {request_id, model, model_group: (.metadata.model_group // .model_group), spend, prompt_tokens, completion_tokens, total_tokens}]'
[
  {
    "request_id": "be3f7cd8-d11c-4b96-9131-acb78f48886a",
    "model": "vertex_ai/gemini-live-2.5-flash-native-audio",
    "model_group": "gemini-live-native-basemodel",
    "spend": 0.000008,
    "prompt_tokens": 8,
    "completion_tokens": 25,
    "total_tokens": 33
  },
  {
    "request_id": "a7700329-5863-471f-89cb-fc401ebc5879",
    "model": "vertex_ai/gemini-live-2.5-flash-native-audio",
    "model_group": "gemini-live-native-basemodel",
    "spend": 0.000004,
    "prompt_tokens": 8,
    "completion_tokens": 0,
    "total_tokens": 8
  },
  {
    "request_id": "3b40fc3a-81ae-4dd2-b1ff-31d1d7566265",
    "model": "vertex_ai/gemini-live-2.5-flash-native-audio",
    "model_group": "gemini-live-native",
    "spend": 0.000006,
    "prompt_tokens": 8,
    "completion_tokens": 18,
    "total_tokens": 26
  },
  {
    "request_id": "abda989a-d8fc-452a-bae0-ac5cd6ea3f8f",
    "model": "vertex_ai/gemini-live-2.5-flash-native-audio",
    "model_group": "gemini-live-native",
    "spend": 0.000004,
    "prompt_tokens": 8,
    "completion_tokens": 0,
    "total_tokens": 8
  }
]
```

2. All four rows bill non-zero: the full sessions match GA-rate math exactly (0.000006 = 8 x 5e-07 + 1 x 2e-06 and 0.000008 = 8 x 5e-07 + 2 x 2e-06) and even the two input-only hiccup rows bill 0.000004

Notes from the runs:

- First sessions sometimes arrive empty; retried once (provider flake, unrelated)
- base_model rows bill GA rates, not preview (pre-existing candidate order)
- Vertex reports output audio tokens as 0; those bill $0 (pre-existing)
- Input-only hiccup rows also bill non-zero now (intended)

## Type

🐛 Bug Fix

## Caveats (if any)

### Medium

- Unmapped realtime models without a priced `base_model` still bill $0
  - The router registers deployment models into the cost map priceless
  - Those entries used to win at zero-defaulted rates, swallowing `base_model`
  - Now they fall through; with no priced fallback, $0 remains

### Low

- GA cache-read pricing is unverified, so the new entry omits `cache_read_input_token_cost`
- No `gemini/` (AI Studio) twin entry: AI Studio exposes a different model id for Live
- The GA entry now prices sessions directly, superseding `base_model` workarounds
- `/vertex_ai/live` passthrough sessions on this model now bill too
- Vertex Live reports output audio tokens as 0, so those bill $0 (pre-existing)
- Bedrock realtime remains entirely uncosted (pre-existing)
- Realtime transcription costing keeps the old first-match rule (pre-existing)
- OpenAI realtime verified unchanged: live base vs head spend identical

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

- [x] b48bff7b54 passes /live-pr-risk

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes shared realtime spend logic used across providers; misclassification of “priceless” vs “explicitly free” entries could over- or under-bill sessions.
> 
> **Overview**
> Fixes **$0 spend logging** for Vertex Gemini Live GA (`gemini-live-2.5-flash-native-audio`) by adding a **model cost map entry** with published text/audio token rates in both pricing JSON files.
> 
> **Realtime stream billing** no longer stops at the first model name that resolves without error. New helpers pick the first candidate whose lookup yields **non-zero cost** or whose cost-map entry **explicitly declares** `cost_per*` fields (including explicit **$0**). Router-registered entries with no pricing therefore **fall through** to `litellm_model_name` / `base_model` instead of locking spend at zero.
> 
> Regression tests cover GA native-audio costing, priceless deployment fallthrough, and explicitly free models.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e7b843d69b1ed8d23228ef5012a5aba9a1164a0f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->