### PR TITLE
fix(model_prices): correct gemini-3.5-flash-lite flex cache-read pricing

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -22488,7 +22488,7 @@
     },
     "gemini/gemini-3.5-flash-lite": {
         "cache_read_input_token_cost": 3e-08,
-        "cache_read_input_token_cost_flex": 1.5e-08,
+        "cache_read_input_token_cost_flex": 2e-08,
         "cache_read_input_token_cost_priority": 5e-08,
         "input_cost_per_token": 3e-07,
         "input_cost_per_token_batches": 1.5e-07,

--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -20147,7 +20147,7 @@
     "gemini-3.5-flash-lite": {
         "deprecation_date": "2027-07-21",
         "cache_read_input_token_cost": 3e-08,
-        "cache_read_input_token_cost_flex": 2e-08,
+        "cache_read_input_token_cost_flex": 1.5e-08,
         "cache_read_input_token_cost_priority": 5e-08,
         "input_cost_per_token": 3e-07,
         "input_cost_per_token_batches": 1.5e-07,
@@ -22488,7 +22488,7 @@
     },
     "gemini/gemini-3.5-flash-lite": {
         "cache_read_input_token_cost": 3e-08,
-        "cache_read_input_token_cost_flex": 2e-08,
+        "cache_read_input_token_cost_flex": 1.5e-08,
         "cache_read_input_token_cost_priority": 5e-08,
         "input_cost_per_token": 3e-07,
         "input_cost_per_token_batches": 1.5e-07,
@@ -41987,7 +41987,7 @@
     "vertex_ai/gemini-3.5-flash-lite": {
         "deprecation_date": "2027-07-21",
         "cache_read_input_token_cost": 3e-08,
-        "cache_read_input_token_cost_flex": 2e-08,
+        "cache_read_input_token_cost_flex": 1.5e-08,
         "cache_read_input_token_cost_priority": 5e-08,
         "input_cost_per_token": 3e-07,
         "input_cost_per_token_batches": 1.5e-07,

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -22488,7 +22488,7 @@
     },
     "gemini/gemini-3.5-flash-lite": {
         "cache_read_input_token_cost": 3e-08,
-        "cache_read_input_token_cost_flex": 1.5e-08,
+        "cache_read_input_token_cost_flex": 2e-08,
         "cache_read_input_token_cost_priority": 5e-08,
         "input_cost_per_token": 3e-07,
         "input_cost_per_token_batches": 1.5e-07,

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -20147,7 +20147,7 @@
     "gemini-3.5-flash-lite": {
         "deprecation_date": "2027-07-21",
         "cache_read_input_token_cost": 3e-08,
-        "cache_read_input_token_cost_flex": 2e-08,
+        "cache_read_input_token_cost_flex": 1.5e-08,
         "cache_read_input_token_cost_priority": 5e-08,
         "input_cost_per_token": 3e-07,
         "input_cost_per_token_batches": 1.5e-07,
@@ -22488,7 +22488,7 @@
     },
     "gemini/gemini-3.5-flash-lite": {
         "cache_read_input_token_cost": 3e-08,
-        "cache_read_input_token_cost_flex": 2e-08,
+        "cache_read_input_token_cost_flex": 1.5e-08,
         "cache_read_input_token_cost_priority": 5e-08,
         "input_cost_per_token": 3e-07,
         "input_cost_per_token_batches": 1.5e-07,
@@ -41987,7 +41987,7 @@
     "vertex_ai/gemini-3.5-flash-lite": {
         "deprecation_date": "2027-07-21",
         "cache_read_input_token_cost": 3e-08,
-        "cache_read_input_token_cost_flex": 2e-08,
+        "cache_read_input_token_cost_flex": 1.5e-08,
         "cache_read_input_token_cost_priority": 5e-08,
         "input_cost_per_token": 3e-07,
         "input_cost_per_token_batches": 1.5e-07,

--- a/tests/test_litellm/litellm_core_utils/llm_cost_calc/test_llm_cost_calc_utils.py
+++ b/tests/test_litellm/litellm_core_utils/llm_cost_calc/test_llm_cost_calc_utils.py
@@ -3377,26 +3377,26 @@ def test_generic_cost_per_token_gemini_35_flash_lite(_local_model_cost_map):
     assert completion_cost == pytest.approx(0.00125)
 
 
-GEMINI_35_FLASH_LITE_SERVICE_TIER_PRICING = [
-    (None, 3e-07, 2.5e-06, 3e-08),
-    ("flex", 1.5e-07, 1.25e-06, 1.5e-08),
-    ("priority", 5.4e-07, 4.5e-06, 5e-08),
+GEMINI_35_FLASH_LITE_TIER_RATES_BY_SURFACE = [
+    ("gemini", None, 3e-07, 2.5e-06, 3e-08),
+    ("gemini", "flex", 1.5e-07, 1.25e-06, 2e-08),
+    ("gemini", "priority", 5.4e-07, 4.5e-06, 5e-08),
+    ("vertex_ai", None, 3e-07, 2.5e-06, 3e-08),
+    ("vertex_ai", "flex", 1.5e-07, 1.25e-06, 1.5e-08),
+    ("vertex_ai", "priority", 5.4e-07, 4.5e-06, 5e-08),
 ]
 
 
 @pytest.mark.parametrize(
-    "service_tier,input_rate,output_rate,cache_read_rate", GEMINI_35_FLASH_LITE_SERVICE_TIER_PRICING
-)
-@pytest.mark.parametrize(
-    "model",
-    ["gemini-3.5-flash-lite", "gemini/gemini-3.5-flash-lite", "vertex_ai/gemini-3.5-flash-lite"],
+    "custom_llm_provider,service_tier,input_rate,output_rate,cache_read_rate",
+    GEMINI_35_FLASH_LITE_TIER_RATES_BY_SURFACE,
 )
 def test_gemini_35_flash_lite_service_tier_pricing(
-    model, service_tier, input_rate, output_rate, cache_read_rate, _local_model_cost_map
+    custom_llm_provider, service_tier, input_rate, output_rate, cache_read_rate, _local_model_cost_map
 ):
-    """Regression: Vertex publishes flash-lite Flex/Batch context caching at $0.015/M
-    (1.5e-08/token), so flex cache reads must not be billed at the 2e-08 rate the map
-    used to carry."""
+    """Regression: Vertex publishes flash-lite flex context caching at $0.015/M while the
+    Gemini API publishes $0.02/M, so vertex_ai flex cache reads must bill 1.5e-08/token
+    instead of the 2e-08 the map used to carry, without disturbing the Gemini API rate."""
     usage = Usage(
         prompt_tokens=1_000,
         completion_tokens=500,
@@ -3405,14 +3405,23 @@ def test_gemini_35_flash_lite_service_tier_pricing(
     )
 
     prompt_cost, completion_cost = generic_cost_per_token(
-        model=model.split("/")[-1],
+        model="gemini-3.5-flash-lite",
         usage=usage,
-        custom_llm_provider=model.split("/")[0] if "/" in model else "gemini",
+        custom_llm_provider=custom_llm_provider,
         service_tier=service_tier,
     )
 
     assert prompt_cost == pytest.approx(800 * input_rate + 200 * cache_read_rate, rel=1e-9)
     assert completion_cost == pytest.approx(500 * output_rate, rel=1e-9)
+
+
+def test_gemini_35_flash_lite_flex_cache_read_map_entries(_local_model_cost_map):
+    """Each map entry carries its own surface's published flex cache-read rate: the bare
+    and vertex_ai keys are the Vertex surface at $0.015/M, the gemini key is the Gemini
+    API surface at $0.02/M."""
+    assert litellm.model_cost["gemini-3.5-flash-lite"]["cache_read_input_token_cost_flex"] == 1.5e-08
+    assert litellm.model_cost["vertex_ai/gemini-3.5-flash-lite"]["cache_read_input_token_cost_flex"] == 1.5e-08
+    assert litellm.model_cost["gemini/gemini-3.5-flash-lite"]["cache_read_input_token_cost_flex"] == 2e-08
 
 
 @pytest.mark.parametrize(

--- a/tests/test_litellm/litellm_core_utils/llm_cost_calc/test_llm_cost_calc_utils.py
+++ b/tests/test_litellm/litellm_core_utils/llm_cost_calc/test_llm_cost_calc_utils.py
@@ -3377,6 +3377,44 @@ def test_generic_cost_per_token_gemini_35_flash_lite(_local_model_cost_map):
     assert completion_cost == pytest.approx(0.00125)
 
 
+GEMINI_35_FLASH_LITE_SERVICE_TIER_PRICING = [
+    (None, 3e-07, 2.5e-06, 3e-08),
+    ("flex", 1.5e-07, 1.25e-06, 1.5e-08),
+    ("priority", 5.4e-07, 4.5e-06, 5e-08),
+]
+
+
+@pytest.mark.parametrize(
+    "service_tier,input_rate,output_rate,cache_read_rate", GEMINI_35_FLASH_LITE_SERVICE_TIER_PRICING
+)
+@pytest.mark.parametrize(
+    "model",
+    ["gemini-3.5-flash-lite", "gemini/gemini-3.5-flash-lite", "vertex_ai/gemini-3.5-flash-lite"],
+)
+def test_gemini_35_flash_lite_service_tier_pricing(
+    model, service_tier, input_rate, output_rate, cache_read_rate, _local_model_cost_map
+):
+    """Regression: Vertex publishes flash-lite Flex/Batch context caching at $0.015/M
+    (1.5e-08/token), so flex cache reads must not be billed at the 2e-08 rate the map
+    used to carry."""
+    usage = Usage(
+        prompt_tokens=1_000,
+        completion_tokens=500,
+        total_tokens=1_500,
+        prompt_tokens_details=PromptTokensDetailsWrapper(cached_tokens=200, text_tokens=800),
+    )
+
+    prompt_cost, completion_cost = generic_cost_per_token(
+        model=model.split("/")[-1],
+        usage=usage,
+        custom_llm_provider=model.split("/")[0] if "/" in model else "gemini",
+        service_tier=service_tier,
+    )
+
+    assert prompt_cost == pytest.approx(800 * input_rate + 200 * cache_read_rate, rel=1e-9)
+    assert completion_cost == pytest.approx(500 * output_rate, rel=1e-9)
+
+
 @pytest.mark.parametrize(
     "service_tier,input_rate,cache_read_rate,cache_write_rate,output_rate",
     [


### PR DESCRIPTION
## TLDR

Problem this solves:

- Cost map bills Vertex flash-lite flex cache reads at 2e-08/token
- Google's Vertex page publishes flash-lite Flex/Batch caching at $0.015/M (1.5e-08)

How it solves it:

- Sets `cache_read_input_token_cost_flex` to 1.5e-08 on the two Vertex flash-lite entries (bare and `vertex_ai/`)
- Leaves the `gemini/` entry at 2e-08 because the Gemini API pricing page publishes its flex caching at $0.02/M

## User Flow

Before: a proxy admin running Vertex gemini-3.5-flash-lite on flex sees cached reads billed a third above Google's published flex caching price

1. The admin adds a `vertex_ai/gemini-3.5-flash-lite` deployment with flex processing (`extra_headers`: `X-Vertex-AI-LLM-Request-Type: shared`, `X-Vertex-AI-LLM-Shared-Request-Type: flex`) on the global endpoint
2. Their app sends the same ~4k-token prompt repeatedly to POST https://litellm-domain/v1/chat/completions; by the third call the response usage shows `cached_tokens: 4058` of 4061 prompt tokens and 34 completion tokens
3. That flex-served response comes back with `x-litellm-response-cost: 0.00011536`, pricing the 4058 cached tokens at $0.02/M where Google's Vertex page publishes flash-lite Flex/Batch caching at $0.015/M
4. https://litellm-domain/ui/?page=logs records the same overstated spend, so every cache-heavy flex workload tracks high

After: the same flex response is billed at Google's published flex caching price

1. The admin adds the same `vertex_ai/gemini-3.5-flash-lite` flex deployment
2. Their app sends the same repeated prompt to POST https://litellm-domain/v1/chat/completions and again sees `cached_tokens: 4058`
3. That response now comes back with `x-litellm-response-cost: 0.00010257`, matching 3 x $0.15/M input + 4058 x $0.015/M cached + 33 x $1.25/M output
4. https://litellm-domain/ui/?page=logs shows spend matching what Google will actually invoice

## Relevant issues

## Linear ticket

Resolves LIT-6283

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Shared setup: two live proxies against real Vertex (project `vertex-check-481318`, global endpoint), each booted with `--num_workers 2` and `LITELLM_LOCAL_MODEL_COST_MAP=True` on this config

```yaml
model_list:
  - model_name: flash-lite-flex
    litellm_params:
      model: vertex_ai/gemini-3.5-flash-lite
      vertex_project: vertex-check-481318
      vertex_location: global
      vertex_credentials: <service account json>
      extra_headers:
        X-Vertex-AI-LLM-Request-Type: shared
        X-Vertex-AI-LLM-Shared-Request-Type: flex
```

At this PR's merge base a flex-served vertex gemini-3.x response bills full standard rates and never reads the `_flex` keys at all, so both legs below also carry the two companion fixes merged locally: #37724 (maps Vertex's `ON_DEMAND_FLEX` label to the flex tier) and #38421 (routes the tier into pricing for gemini-3.x). #37724 has since merged into staging carrying the same threading #38421 added, so #38421 is closed as superseded and current staging contains both fixes. That isolates this PR's delta to the vertex cache-read rate itself. The map change rides the shared cost path under all three unified endpoints, so both legs prove every one: two warm-up calls per payload trigger implicit caching, then one probe per endpoint

```bash
for ep in /v1/chat/completions /v1/responses /v1/messages; do
  curl -s -D headers.txt http://localhost:$PORT$ep \
    -H "Authorization: Bearer $MASTER_KEY" -H "Content-Type: application/json" \
    -d @payload_for_that_endpoint.json -o resp.json
  grep -iE 'x-litellm-response-cost(-cache-read)?:' headers.txt
done
```

### Before (f7220556e1 + companions, map still at 2e-08)

1. POST /v1/chat/completions: usage `in 4061, cached 4058, out 33`, `x-litellm-response-cost: 0.00012286` with `cost-cache-read: 8.116e-05` = 4058 x 2e-08, a third above Google's published Vertex flex caching price
2. POST /v1/responses: usage `in 4061, cached 4058, out 26`, `x-litellm-response-cost: 0.00011411`, same 8.116e-05 cache-read component
3. POST /v1/messages: usage `in 3, cache_read 4058, out 27`, `x-litellm-response-cost: 0.00011536` = 3 x 1.5e-07 + 4058 x 2e-08 + 27 x 1.25e-06: the same overbilled rate

### After (bd75c38e84 + companions)

1. POST /v1/chat/completions: usage `in 4061, cached 4058, out 22`, `x-litellm-response-cost: 8.882e-05` with `cost-cache-read: 6.087e-05` = 4058 x 1.5e-08, matching the published price exactly
2. POST /v1/responses: usage `in 4061, cached 4058, out 34`, `x-litellm-response-cost: 0.00010382` = 3 x 1.5e-07 + 4058 x 1.5e-08 + 34 x 1.25e-06
3. POST /v1/messages: usage `in 3, cached 4058, out 34`, `x-litellm-response-cost: 0.00010382`: identical published-rate math

Observations from the run:

- /v1/messages `cost-cache-read` breakdown header shows the standard-rate component on both legs; totals are right; pre-existing, this PR leaves it alone
- messages needed its own warm-up; chat warm-ups did not seed its cache

## Type

🐛 Bug Fix

## Caveats (if any)

### Low

- Vertex flex keys need #37724's threading; merged into staging now
- Vertex also publishes its $0.015/M caching rate for the batch tier, but no flash-lite entry carries a `cache_read_input_token_cost_batches` key, so batch cache reads fall back to the standard 3e-08; pre-existing and untouched here
- gemini-3.5-flash twins already match published pricing and are untouched

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
- [x] bd75c38e84ea064866252024e3e9ecbce05ee668 passes /live-pr-risk

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pricing-map and test-only changes; no runtime logic. Risk is limited to reported spend for Vertex flex cache hits on this model.
> 
> **Overview**
> Fixes **overstated flex-tier context-cache billing** for **Vertex** `gemini-3.5-flash-lite` by lowering `cache_read_input_token_cost_flex` from **2e-08** to **1.5e-08** ($0.015/M) on the bare and `vertex_ai/` entries in `model_prices_and_context_window.json` and its backup.
> 
> The **`gemini/gemini-3.5-flash-lite`** map entry stays at **2e-08** ($0.02/M) to match the Gemini API pricing page.
> 
> Adds regression tests that parametrize flex/standard/priority costs per provider surface and assert the three map keys carry the correct flex cache-read rates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bd75c38e84ea064866252024e3e9ecbce05ee668. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->