### PR TITLE
fix(cost): make cost-breakdown headers respect service tier

### DIFF
--- a/litellm/litellm_core_utils/llm_cost_calc/utils.py
+++ b/litellm/litellm_core_utils/llm_cost_calc/utils.py
@@ -1063,15 +1063,17 @@ def get_token_type_cost_breakdown(
         reasoning_tokens = _coerce_token_count(getattr(usage, "reasoning_tokens", 0))
 
     # Reasoning is billed at the selected tier's reasoning rate for tiered models,
-    # else at the explicit per-reasoning-token rate when the model defines one,
-    # otherwise at the standard output-token rate - this mirrors how the total
-    # completion cost is computed, so the breakdown can never diverge from it.
+    # else at the service-tier-aware per-reasoning-token rate - this mirrors how the
+    # total completion cost is computed, so the breakdown can never diverge from it.
     tiered_reasoning_rate: Final = _get_tiered_reasoning_rate(model_info=model_info, usage=usage)
-    flat_reasoning_rate: Final = _get_cost_per_unit(model_info, "output_cost_per_reasoning_token", None)
     reasoning_rate: Final = (
         tiered_reasoning_rate
         if tiered_reasoning_rate is not None
-        else (flat_reasoning_rate if flat_reasoning_rate is not None else completion_base_cost)
+        else _resolve_reasoning_token_cost(
+            model_info=model_info,
+            service_tier=service_tier,
+            completion_base_cost=completion_base_cost,
+        )
     )
     reasoning_cost = float(reasoning_tokens) * reasoning_rate
 

--- a/litellm/litellm_core_utils/llm_response_utils/response_metadata.py
+++ b/litellm/litellm_core_utils/llm_response_utils/response_metadata.py
@@ -178,7 +178,7 @@ def update_response_metadata(
         - response._hidden_params["litellm_overhead_time_ms"]
         - response.response_time_ms
     """
-    if result is None:
+    if result is None or not hasattr(result, "_hidden_params"):
         return
 
     metadata: Final = ResponseMetadata(result)

--- a/tests/test_litellm/litellm_core_utils/llm_cost_calc/test_llm_cost_calc_utils.py
+++ b/tests/test_litellm/litellm_core_utils/llm_cost_calc/test_llm_cost_calc_utils.py
@@ -2764,6 +2764,46 @@ def test_token_type_cost_breakdown_matches_real_gemini_numbers(_local_model_cost
     assert breakdown.cache_creation_cost == 0.0
 
 
+def test_token_type_cost_breakdown_flex_tier_prices_reasoning_at_flex_rate(_local_model_cost_map):
+    """Regression for the flex-tier breakdown drift: gemini-3.5-flash defines a flat
+    output_cost_per_reasoning_token (9e-06, the standard output rate) but no _flex
+    variant, so the breakdown priced reasoning at the standard rate on flex requests
+    while the total billed it at the flex output rate (4.5e-06). The reasoning
+    sub-cost then exceeded the entire flex completion cost."""
+
+    usage = Usage(
+        prompt_tokens=7,
+        completion_tokens=320,
+        total_tokens=327,
+        completion_tokens_details=CompletionTokensDetailsWrapper(reasoning_tokens=315, text_tokens=5),
+    )
+
+    breakdown = get_token_type_cost_breakdown(
+        model="gemini-3.5-flash",
+        custom_llm_provider="vertex_ai",
+        usage=usage,
+        service_tier="flex",
+    )
+
+    assert breakdown.reasoning_cost == pytest.approx(315 * 4.5e-06)
+
+    _, flex_completion_cost = generic_cost_per_token(
+        model="gemini-3.5-flash",
+        usage=usage,
+        custom_llm_provider="vertex_ai",
+        service_tier="flex",
+    )
+    assert breakdown.reasoning_cost <= flex_completion_cost
+
+    standard_breakdown = get_token_type_cost_breakdown(
+        model="gemini-3.5-flash",
+        custom_llm_provider="vertex_ai",
+        usage=usage,
+        service_tier=None,
+    )
+    assert standard_breakdown.reasoning_cost == pytest.approx(315 * 9e-06)
+
+
 def test_token_type_cost_breakdown_xai_at_exactly_200k_uses_higher_tier_rates(_local_model_cost_map):
 
     usage = Usage(

--- a/tests/test_litellm/litellm_core_utils/llm_response_utils/test_response_metadata.py
+++ b/tests/test_litellm/litellm_core_utils/llm_response_utils/test_response_metadata.py
@@ -92,6 +92,39 @@ class TestCallbackDurationMs:
         assert hidden.get("litellm_overhead_time_ms") is not None
 
 
+class TestDictResultsSkipMetadataUpdate:
+    """Regression for /v1/messages cost-breakdown clobbering: AnthropicMessagesResponse
+    is a TypedDict, so apply() can never attach _hidden_params to it and the whole
+    metadata pass is discarded - except the cost recompute, whose only observable
+    effect was overwriting the logging object's already-correct cost breakdown with a
+    service-tier-less, reasoning-less recompute on the adapted response."""
+
+    def test_update_response_metadata_skips_cost_recompute_for_dict_results(self):
+        anthropic_response = {
+            "id": "msg_123",
+            "type": "message",
+            "role": "assistant",
+            "content": [{"type": "text", "text": "hi"}],
+            "usage": {"input_tokens": 7, "output_tokens": 320},
+        }
+        logging_obj = MagicMock()
+        logging_obj.model_call_details = {}
+        logging_obj.caching_details = None
+        logging_obj.litellm_call_id = "test-call-id"
+
+        update_response_metadata(
+            result=anthropic_response,
+            logging_obj=logging_obj,
+            model="vertex_ai/gemini-3.5-flash",
+            kwargs={},
+            start_time=datetime.datetime(2025, 1, 1, 0, 0, 0),
+            end_time=datetime.datetime(2025, 1, 1, 0, 0, 1),
+        )
+
+        logging_obj._response_cost_calculator.assert_not_called()
+        assert "_hidden_params" not in anthropic_response
+
+
 class TestCallbackDurationInCustomHeaders:
     """Test that callback_duration_ms flows into get_custom_headers."""
 


### PR DESCRIPTION
## TLDR

Problem this solves:

- Breakdown headers priced reasoning at the standard rate on flex requests
- The reasoning header could exceed the whole billed response cost
- /v1/messages breakdown headers lost the service tier entirely

How it solves it:

- Breakdown reasoning rate now resolves through the same tier-aware helper as the total
- Responses that cannot carry hidden params no longer trigger a tier-less cost recompute

Billing was always correct: `x-litellm-response-cost`, key spend, and DB spend all used flex rates. Only the informational `x-litellm-response-cost-*` breakdown headers disagreed.

## User Flow

Before: a developer sending Vertex Gemini flex traffic reads cost breakdown headers that contradict the billed cost

1. They send POST https://litellm-domain/v1/chat/completions with `"model": "vertex_ai/gemini-3.5-flash"` and `"extra_headers": {"X-Vertex-AI-LLM-Request-Type": "shared", "X-Vertex-AI-LLM-Shared-Request-Type": "flex"}`
2. The response headers show `x-litellm-response-cost: 0.00138675` (the flex price, billed correctly) next to `x-litellm-response-cost-reasoning: 0.002718`, a reasoning sub-cost at the standard rate that exceeds the entire response cost
3. They send the same prompt to POST https://litellm-domain/v1/messages and the breakdown headers come back at standard prices (`x-litellm-response-cost-original: 0.0021075`, double the billed `x-litellm-response-cost: 0.00105375`) with the reasoning header missing entirely

After: the same requests come back with breakdown headers that agree with the billed cost

1. They send POST https://litellm-domain/v1/chat/completions with `"model": "vertex_ai/gemini-3.5-flash"` and the same flex opt-in headers
2. The response headers show the flex `x-litellm-response-cost` next to an `x-litellm-response-cost-reasoning` at the flex rate, always within the response cost
3. The same prompt to POST https://litellm-domain/v1/messages returns breakdown headers at flex prices that sum to `x-litellm-response-cost`, with the reasoning header present

## Relevant issues

## Linear ticket

Resolves LIT-6290

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Both legs ran a live proxy (`--num_workers 2`, no DB) from a worktree at the leg's commit, with `LITELLM_LOCAL_MODEL_COST_MAP=True` and real Vertex AI `gemini-3.5-flash` calls. Shared config:

```yaml
model_list:
  - model_name: gemini-flash
    litellm_params:
      model: vertex_ai/gemini-3.5-flash
      vertex_project: os.environ/VERTEXAI_PROJECT
      vertex_location: global
  - model_name: gemini-flash-flex
    litellm_params:
      model: vertex_ai/gemini-3.5-flash
      vertex_project: os.environ/VERTEXAI_PROJECT
      vertex_location: global
      extra_headers:
        X-Vertex-AI-LLM-Request-Type: shared
        X-Vertex-AI-LLM-Shared-Request-Type: flex
general_settings:
  master_key: sk-lit6290-qa
```

Rates for `gemini-3.5-flash`: input 1.5e-06 (flex 7.5e-07), output and reasoning 9e-06 (flex 4.5e-06)

### Before (8a9d5b15b4, merge base)

1. Chat completions with flex opt-in: the reasoning sub-cost header exceeds the entire billed cost

```
curl -sS -D chat_flex_headers.txt -o chat_flex_body.json -X POST http://127.0.0.1:24683/v1/chat/completions -H "Authorization: Bearer sk-lit6290-qa" -H "Content-Type: application/json" -d '{"model":"gemini-flash","messages":[{"role":"user","content":"Say hello in 3 words."}],"max_tokens":512,"extra_headers":{"X-Vertex-AI-LLM-Request-Type":"shared","X-Vertex-AI-LLM-Shared-Request-Type":"flex"}}'

x-litellm-response-cost: 0.00155325
x-litellm-response-cost-original: 0.00155325
x-litellm-response-cost-input: 5.2500000000000006e-06
x-litellm-response-cost-output: 0.001548
x-litellm-response-cost-reasoning: 0.003051

usage: completion_tokens 344 (reasoning 339), prompt_tokens 7
```

Total and input/output are flex (7 x 7.5e-07 + 344 x 4.5e-06 = 0.00155325), but reasoning is 339 x 9e-06 = 0.003051, the standard rate, roughly double the output cost it is supposed to be a subset of

2. Chat completions standard control: internally consistent, everything at standard rates

```
curl -sS -D chat_standard_headers.txt -o chat_standard_body.json -X POST http://127.0.0.1:24683/v1/chat/completions -H "Authorization: Bearer sk-lit6290-qa" -H "Content-Type: application/json" -d '{"model":"gemini-flash","messages":[{"role":"user","content":"Say hello in 3 words."}],"max_tokens":512}'

x-litellm-response-cost: 0.0030885
x-litellm-response-cost-input: 1.0500000000000001e-05
x-litellm-response-cost-output: 0.003078
x-litellm-response-cost-reasoning: 0.003042

usage: completion_tokens 342 (reasoning 338), prompt_tokens 7
```

3. Responses API with flex: same contradiction

```
curl -sS -D responses_flex_headers.txt -o responses_flex_body.json -X POST http://127.0.0.1:24683/v1/responses -H "Authorization: Bearer sk-lit6290-qa" -H "Content-Type: application/json" -d '{"model":"gemini-flash-flex","input":"Say hello in 3 words.","max_output_tokens":512}'

x-litellm-response-cost: 0.00091875
x-litellm-response-cost-input: 5.2500000000000006e-06
x-litellm-response-cost-output: 0.0009134999999999999
x-litellm-response-cost-reasoning: 0.001782

usage: output_tokens 203 (reasoning 198), input_tokens 7
```

Reasoning 198 x 9e-06 = 0.001782, nearly 2x the whole flex output cost 0.0009135

4. Anthropic messages with flex: breakdown loses the tier entirely and drops the reasoning header

```
curl -sS -D messages_flex_headers.txt -o messages_flex_body.json -X POST http://127.0.0.1:24683/v1/messages -H "Authorization: Bearer sk-lit6290-qa" -H "Content-Type: application/json" -d '{"model":"gemini-flash-flex","messages":[{"role":"user","content":"Say hello in 3 words."}],"max_tokens":512}'

x-litellm-response-cost: 0.0013687500000000002
x-litellm-response-cost-original: 0.0027375000000000003
x-litellm-response-cost-input: 1.0500000000000001e-05
x-litellm-response-cost-output: 0.0027270000000000003
(no x-litellm-response-cost-reasoning header)

usage: input_tokens 7, output_tokens 303
```

Headline is the flex total (0.00136875) while original, input, and output are all standard-rate, exactly 2x the billed cost

### After (c0f9af0802, PR tip)

1. Chat completions with flex opt-in: every header at flex rates, reasoning within output

```
curl -sS -D chat_flex_headers.txt -o chat_flex_body.json -X POST http://127.0.0.1:47101/v1/chat/completions -H "Authorization: Bearer sk-lit6290-qa" -H "Content-Type: application/json" -d '{"model":"gemini-flash","messages":[{"role":"user","content":"Say hello in 3 words."}],"max_tokens":512,"extra_headers":{"X-Vertex-AI-LLM-Request-Type":"shared","X-Vertex-AI-LLM-Shared-Request-Type":"flex"}}'

x-litellm-response-cost: 0.00108525
x-litellm-response-cost-original: 0.00108525
x-litellm-response-cost-input: 5.2500000000000006e-06
x-litellm-response-cost-output: 0.00108
x-litellm-response-cost-reasoning: 0.0010575

usage: completion_tokens 240 (reasoning 235), prompt_tokens 7
```

Reasoning 235 x 4.5e-06 = 0.0010575 at the flex rate, within output 0.00108, and input + output = total

2. Chat completions standard control: unchanged, still consistent at standard rates

```
curl -sS -D chat_standard_headers.txt -o chat_standard_body.json -X POST http://127.0.0.1:47101/v1/chat/completions -H "Authorization: Bearer sk-lit6290-qa" -H "Content-Type: application/json" -d '{"model":"gemini-flash","messages":[{"role":"user","content":"Say hello in 3 words."}],"max_tokens":512}'

x-litellm-response-cost: 0.0026655000000000003
x-litellm-response-cost-input: 1.0500000000000001e-05
x-litellm-response-cost-output: 0.0026550000000000002
x-litellm-response-cost-reasoning: 0.0026190000000000002

usage: completion_tokens 295 (reasoning 291), prompt_tokens 7
```

3. Responses API with flex: consistent at flex rates

```
curl -sS -D responses_flex_headers.txt -o responses_flex_body.json -X POST http://127.0.0.1:47101/v1/responses -H "Authorization: Bearer sk-lit6290-qa" -H "Content-Type: application/json" -d '{"model":"gemini-flash-flex","input":"Say hello in 3 words.","max_output_tokens":512}'

x-litellm-response-cost: 0.0017377500000000001
x-litellm-response-cost-input: 5.2500000000000006e-06
x-litellm-response-cost-output: 0.0017325
x-litellm-response-cost-reasoning: 0.0017100000000000001

usage: output_tokens 385 (reasoning 380), input_tokens 7
```

Reasoning 380 x 4.5e-06 = 0.00171 at the flex rate, within output 0.0017325

4. Anthropic messages with flex: breakdown keeps the tier and the reasoning header is present

```
curl -sS -D messages_flex_headers.txt -o messages_flex_body.json -X POST http://127.0.0.1:47101/v1/messages -H "Authorization: Bearer sk-lit6290-qa" -H "Content-Type: application/json" -d '{"model":"gemini-flash-flex","messages":[{"role":"user","content":"Say hello in 3 words."}],"max_tokens":512}'

x-litellm-response-cost: 0.00132375
x-litellm-response-cost-original: 0.00132375
x-litellm-response-cost-input: 5.2500000000000006e-06
x-litellm-response-cost-output: 0.0013185
x-litellm-response-cost-reasoning: 0.001296

usage: input_tokens 7, output_tokens 293
```

Original equals the billed flex headline, output 293 x 4.5e-06 = 0.0013185, reasoning present at the flex rate (0.001296 / 4.5e-06 = 288 tokens, within the 293 output tokens), and input + output = total

## Type

🐛 Bug Fix

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR


- [x] c0f9af08022b22f8bf48812c8eb37c70ba75b353 passes /live-pr-risk
