### PR TITLE
fix(ui): block the auto-router submit on a missing classifier model and an orphaned keyword rule

### DIFF
--- a/ui/litellm-dashboard/src/components/add_model/add_auto_router_tab.test.tsx
+++ b/ui/litellm-dashboard/src/components/add_model/add_auto_router_tab.test.tsx
@@ -5,6 +5,8 @@ import AddAutoRouterTab from "./add_auto_router_tab";
 import { toast } from "@/lib/toast";
 import { handleAddAutoRouterSubmit } from "./handle_add_auto_router_submit";
 import { getMissingTiersError } from "./build_complexity_router_config";
+import { getSubmitBlockedReason } from "./add_auto_router_tab";
+import { buildModelAvailability } from "@/lib/autorouter_presets";
 import { testAutoRouterRouting } from "../networking";
 import { ModelGroup } from "@/components/llm_calls/fetch_models";
 import { getAllPresets, getPresetByKey, getRequiredModelsInPreset } from "@/lib/autorouter_presets";
@@ -862,5 +864,40 @@ describe("AddAutoRouterTab", () => {
         },
       });
     });
+  });
+});
+
+describe("getSubmitBlockedReason", () => {
+  const tiers = {
+    SIMPLE: ["gpt-4o-mini"],
+    MEDIUM: ["gpt-4o-mini"],
+    COMPLEX: ["gpt-4o-mini"],
+    REASONING: ["gpt-4o-mini"],
+  };
+  const availability = buildModelAvailability(["gpt-4o-mini"], []);
+  const referenced = {
+    tiers,
+    classifierType: "heuristic" as const,
+    classifierLlmConfig: undefined,
+    semanticMatchingEnabled: false,
+    embeddingModel: undefined,
+    defaultModel: undefined,
+  };
+
+  it("lets a complete heuristic router through", () => {
+    expect(getSubmitBlockedReason({ tiers, classifier_type: "heuristic" }, [], referenced, availability)).toBeNull();
+  });
+
+  it("blocks an LLM classifier with no model, which the button previously left enabled", () => {
+    expect(getSubmitBlockedReason({ tiers, classifier_type: "llm" }, [], referenced, availability)).toContain(
+      "Please select a classifier model",
+    );
+  });
+
+  it("blocks a keyword rule aimed at a tier this router does not have", () => {
+    const rules = [{ id: "r1", keywords: ["audit"], tier: "AUDIT" }];
+    expect(getSubmitBlockedReason({ tiers, classifier_type: "heuristic" }, rules, referenced, availability)).toContain(
+      "no longer has",
+    );
   });
 });

--- a/ui/litellm-dashboard/src/components/add_model/add_auto_router_tab.tsx
+++ b/ui/litellm-dashboard/src/components/add_model/add_auto_router_tab.tsx
@@ -34,6 +34,7 @@ import {
   BuildComplexityRouterConfigParams,
   buildComplexityRouterConfig,
   getKeywordTierRulesError,
+  getClassifierModelError,
   getMissingTiersError,
   getPlanModeTierError,
   getSemanticConfigError,
@@ -116,7 +117,7 @@ const tierConfigSummary = (config: ComplexityRouterConfigValue): string => {
 // itself and to say what is missing, so the two can never give different answers. Checks the
 // config actually being built, not which preset (if any) it came from: a preset only ever
 // prefills once (handlePresetChange), and everything after that is edited exactly like Custom.
-const getSubmitBlockedReason = (
+export const getSubmitBlockedReason = (
   config: ComplexityRouterConfigValue,
   keywordTierRules: KeywordTierRule[],
   referencedModelsParams: Parameters<typeof getReferencedModelsError>[0],
@@ -125,7 +126,8 @@ const getSubmitBlockedReason = (
   getMissingTiersError(activeTierRows(config)) ??
   getTierLabelsError(config.tier_labels) ??
   getPlanModeTierError(config.plan_mode_min_tier, activeTierRows(config)) ??
-  getKeywordTierRulesError(keywordTierRules) ??
+  getKeywordTierRulesError(keywordTierRules, activeTierRows(config)) ??
+  getClassifierModelError(config) ??
   getReferencedModelsError(referencedModelsParams, availability);
 
 const autoRouterSchema = (requiresTeamScope: boolean) =>
@@ -370,50 +372,21 @@ const AddAutoRouterTab: React.FC<AddAutoRouterTabProps> = ({
   };
 
   const submitRecommendedRouter = async (name: string) => {
-    const { tiers, tierLabels, classifierType, classifierLlmConfig } = complexityRouterConfigParams;
+    const { tiers } = complexityRouterConfigParams;
 
-    const missingTiersError = getMissingTiersError(activeTierRows(complexityRouterConfig));
-    if (missingTiersError) {
+    // The one answer the submit button reads, so a disabled button and a refused submit cannot
+    // disagree about why. The handler needs it in its own right: the form fires this on Enter
+    // regardless of the button's disabled state.
+    const blockedReason =
+      getSubmitBlockedReason(
+        complexityRouterConfig,
+        keywordTierRules,
+        referencedModelsParams,
+        groupsOnlyAvailability,
+      ) ?? getSemanticConfigError({ semanticMatchingEnabled, embeddingModel, keywordTierRules });
+    if (blockedReason) {
       setShowValidationErrors(true);
-      toast.fromError(missingTiersError);
-      return;
-    }
-
-    const tierLabelsError = getTierLabelsError(tierLabels);
-    if (tierLabelsError) {
-      setShowValidationErrors(true);
-      toast.fromError(tierLabelsError);
-      return;
-    }
-
-    if (classifierType === "llm" && !classifierLlmConfig?.model) {
-      setShowValidationErrors(true);
-      toast.fromError("Please select a classifier model, or switch back to Heuristic");
-      return;
-    }
-
-    const keywordRulesError = getKeywordTierRulesError(keywordTierRules);
-    if (keywordRulesError) {
-      setShowValidationErrors(true);
-      toast.fromError(keywordRulesError);
-      return;
-    }
-
-    const semanticError = getSemanticConfigError({ semanticMatchingEnabled, embeddingModel, keywordTierRules });
-    if (semanticError) {
-      setShowValidationErrors(true);
-      toast.fromError(semanticError);
-      return;
-    }
-
-    // submitBlockedReason already disables the button for this, but the form's submit handler (wired to
-    // this same function) fires on Enter regardless of the button's disabled state - without this check,
-    // Enter in the name field could still create a router referencing a model that disappeared from
-    // availableModelSet after the tiers were filled in.
-    const referencedModelsError = getReferencedModelsError(referencedModelsParams, groupsOnlyAvailability);
-    if (referencedModelsError) {
-      setShowValidationErrors(true);
-      toast.fromError(referencedModelsError);
+      toast.fromError(blockedReason);
       return;
     }
 

--- a/ui/litellm-dashboard/src/components/add_model/build_complexity_router_config.test.ts
+++ b/ui/litellm-dashboard/src/components/add_model/build_complexity_router_config.test.ts
@@ -3,6 +3,7 @@ import {
   getPlanModeTierError,
   normalizeClassifierLlmConfig,
   getKeywordTierRulesError,
+  getClassifierModelError,
   getMissingTiersError,
   getSemanticConfigError,
   getTierLabelsError,
@@ -334,21 +335,24 @@ describe("getSemanticConfigError", () => {
 describe("getKeywordTierRulesError", () => {
   it("returns null when every rule carries a keyword", () => {
     expect(
-      getKeywordTierRulesError([
-        { id: "r1", keywords: ["invoice"], tier: "MEDIUM" },
-        { id: "r2", keywords: ["deploy to k8s"], tier: "REASONING" },
-      ]),
+      getKeywordTierRulesError(
+        [
+          { id: "r1", keywords: ["invoice"], tier: "MEDIUM" },
+          { id: "r2", keywords: ["deploy to k8s"], tier: "REASONING" },
+        ],
+        activeTierRows({ tiers }),
+      ),
     ).toBeNull();
   });
 
   it("returns null when there are no rules at all, since the section is optional", () => {
-    expect(getKeywordTierRulesError([])).toBeNull();
+    expect(getKeywordTierRulesError([], activeTierRows({ tiers }))).toBeNull();
   });
 
   // The whole point of the ticket: the semantic toggle is off by default, and an unfilled row
   // used to be discarded silently on an otherwise successful create.
   it("rejects a row left empty while semantic matching is off", () => {
-    expect(getKeywordTierRulesError([{ id: "r1", keywords: [], tier: "COMPLEX" }])).toBe(
+    expect(getKeywordTierRulesError([{ id: "r1", keywords: [], tier: "COMPLEX" }], activeTierRows({ tiers }))).toBe(
       "Add at least one keyword to keyword rule(s): 1",
     );
   });
@@ -357,7 +361,9 @@ describe("getKeywordTierRulesError", () => {
     ["whitespace only", ["   "]],
     ["blank strings, as an unfilled row between filled ones leaves behind", ["", " ", ""]],
   ])("treats %s as empty rather than as a keyword", (_label, keywords) => {
-    expect(getKeywordTierRulesError([{ id: "r1", keywords, tier: "SIMPLE" }])).toMatch(/keyword rule\(s\): 1/);
+    expect(getKeywordTierRulesError([{ id: "r1", keywords, tier: "SIMPLE" }], activeTierRows({ tiers }))).toMatch(
+      /keyword rule\(s\): 1/,
+    );
   });
 
   // Row numbers have to survive rules that are fine, or the message points at the wrong input.
@@ -373,7 +379,9 @@ describe("getKeywordTierRulesError", () => {
   });
 
   it("keeps a keyword whose surrounding whitespace is the only thing trimmed", () => {
-    expect(getKeywordTierRulesError([{ id: "r1", keywords: ["  invoice  "], tier: "MEDIUM" }])).toBeNull();
+    expect(
+      getKeywordTierRulesError([{ id: "r1", keywords: ["  invoice  "], tier: "MEDIUM" }], activeTierRows({ tiers })),
+    ).toBeNull();
   });
 });
 
@@ -672,5 +680,49 @@ describe("buildComplexityRouterConfig tier model params", () => {
     expect(config.tier_model_configs).toEqual({
       COMPLEX: [{ model_name: "claude-sonnet-4", litellm_params: { reasoning_effort: "high" } }],
     });
+  });
+});
+
+describe("getClassifierModelError", () => {
+  it("stays quiet for a heuristic router, which needs no classifier model", () => {
+    expect(getClassifierModelError({ classifier_type: "heuristic" })).toBeNull();
+  });
+
+  it("blocks an LLM classifier with no model, which the router cannot start without", () => {
+    expect(getClassifierModelError({ classifier_type: "llm" })).toBe(
+      "Please select a classifier model, or switch back to Heuristic",
+    );
+  });
+
+  it("stays quiet once a model is chosen", () => {
+    expect(
+      getClassifierModelError({ classifier_type: "llm", classifier_llm_config: { model: "m", timeout_ms: 3000 } }),
+    ).toBeNull();
+  });
+});
+
+describe("getKeywordTierRulesError orphaned tiers", () => {
+  const rows = activeTierRows({ tiers });
+
+  it("accepts a rule naming a tier the router has", () => {
+    expect(getKeywordTierRulesError([{ id: "r1", keywords: ["k"], tier: "COMPLEX" }], rows)).toBeNull();
+  });
+
+  it("names the rule pointing at a tier this router does not have", () => {
+    expect(getKeywordTierRulesError([{ id: "r1", keywords: ["k"], tier: "AUDIT" }], rows)).toBe(
+      "Keyword rule(s) 1 route to a tier this router no longer has",
+    );
+  });
+
+  it("rejects a differently cased tier, because _validate_keyword_rule_tiers matches exactly", () => {
+    expect(getKeywordTierRulesError([{ id: "r1", keywords: ["k"], tier: "complex" }], rows)).toBe(
+      "Keyword rule(s) 1 route to a tier this router no longer has",
+    );
+  });
+
+  it("reports an empty keyword row before an orphaned tier, since that is the nearer problem", () => {
+    expect(getKeywordTierRulesError([{ id: "r1", keywords: [], tier: "AUDIT" }], rows)).toContain(
+      "Add at least one keyword",
+    );
   });
 });

--- a/ui/litellm-dashboard/src/components/add_model/build_complexity_router_config.ts
+++ b/ui/litellm-dashboard/src/components/add_model/build_complexity_router_config.ts
@@ -9,6 +9,7 @@ import {
   ClassifierLLMConfig,
   ClassifierType,
   ComplexityTierLabels,
+  ComplexityRouterConfigValue,
   ComplexityTiers,
   DimensionWeights,
   TIER_KEYS,
@@ -187,11 +188,29 @@ export const getPlanModeTierError = (planModeMinTier: string | undefined, rows: 
   return `The plan-mode minimum tier (${floor ? activeTierName(floor) : planModeMinTier}) has no models. Add one or turn the override off.`;
 };
 
-export const getKeywordTierRulesError = (keywordTierRules: KeywordTierRule[]): string | null => {
+// The tier is a free string since #37413, and _validate_keyword_rule_tiers matches it EXACTLY, so a
+// rule naming a tier this router does not have is a raw 400 unless the gate catches it first.
+export const getKeywordTierRulesError = (
+  keywordTierRules: KeywordTierRule[],
+  rows: readonly TierRow[],
+): string | null => {
   const emptyRows = emptyKeywordTierRuleIndexes(keywordTierRules);
-  if (emptyRows.length === 0) return null;
-  return `Add at least one keyword to keyword rule(s): ${emptyRows.map((index) => index + 1).join(", ")}`;
+  if (emptyRows.length > 0)
+    return `Add at least one keyword to keyword rule(s): ${emptyRows.map((index) => index + 1).join(", ")}`;
+  const names = rows.map(activeTierName);
+  const orphaned = keywordTierRules.flatMap((rule, index) => (names.includes(rule.tier) ? [] : [index + 1]));
+  if (orphaned.length === 0) return null;
+  return `Keyword rule(s) ${orphaned.join(", ")} route to a tier this router no longer has`;
 };
+
+// The submit gate and the submit handler both read this, so a disabled button and a refused submit
+// cannot disagree about why.
+export const getClassifierModelError = (
+  config: Pick<ComplexityRouterConfigValue, "classifier_type" | "classifier_llm_config">,
+): string | null =>
+  config.classifier_type === "llm" && !config.classifier_llm_config?.model
+    ? "Please select a classifier model, or switch back to Heuristic"
+    : null;
 
 export const getSemanticConfigError = ({
   semanticMatchingEnabled,

--- a/ui/litellm-dashboard/src/components/edit_auto_router/edit_auto_router_modal.tsx
+++ b/ui/litellm-dashboard/src/components/edit_auto_router/edit_auto_router_modal.tsx
@@ -20,6 +20,7 @@ import { isComplexityRouter } from "../add_model/auto_router_strategies";
 import {
   type BuildComplexityRouterConfigParams,
   buildComplexityRouterConfig,
+  getClassifierModelError,
   getKeywordTierRulesError,
   getSemanticConfigError,
   getPlanModeTierError,
@@ -268,7 +269,8 @@ const EditAutoRouterModal: React.FC<EditAutoRouterModalProps> = ({
         : null) ??
       getTierLabelsError(complexityRouterConfig.tier_labels) ??
       getPlanModeTierError(complexityRouterConfig.plan_mode_min_tier, activeTierRows(complexityRouterConfig)) ??
-      getKeywordTierRulesError(keywordTierRules);
+      getKeywordTierRulesError(keywordTierRules, activeTierRows(complexityRouterConfig)) ??
+      getClassifierModelError(complexityRouterConfig);
 
   useEffect(() => {
     if (isVisible && modelData) {
@@ -428,16 +430,17 @@ const EditAutoRouterModal: React.FC<EditAutoRouterModalProps> = ({
         toast.fromError("Please select at least one model for a complexity tier");
         return;
       }
-      if (classifier_type === "llm" && !classifier_llm_config?.model) {
+      const classifierError = getClassifierModelError(complexityRouterConfig);
+      if (classifierError) {
         setShowValidationErrors(true);
-        toast.fromError("Please select a classifier model, or switch back to Heuristic");
+        toast.fromError(classifierError);
         return;
       }
       // Same guards the create form applies (add_auto_router_tab.tsx). The backend rejects a
       // keyword rule with no keyword, and semantic_keyword_matching without an embedding model
       // or keyword rules (complexity_router/config.py), so without these a save fails as a raw
       // 400 instead of an inline message.
-      const keywordRulesError = getKeywordTierRulesError(keywordTierRules);
+      const keywordRulesError = getKeywordTierRulesError(keywordTierRules, activeTierRows(complexityRouterConfig));
       if (keywordRulesError) {
         setShowValidationErrors(true);
         toast.fromError(keywordRulesError);


### PR DESCRIPTION
## TLDR

Problem this solves:

- Picking the LLM classifier with no model leaves submit enabled
- Test Routing then posts a config the backend rejects
- A keyword rule can name a tier the router does not have
- That rule clears the gate and fails the save as a raw 400

How it solves it:

- Both checks move into the shared gate the submit button reads
- Each form's submit handler reads that same gate, not its own list
- A disabled button and a refused submit cannot disagree

## User Flow

Before: an operator switching to the LLM classifier gets a confusing failure instead of a blocked button

1. They open http://localhost:4000/ui/?page=models-and-endpoints, Add Model, Auto Router tab, and expand Detailed Configuration
2. Under Advanced: Classification Method they select LLM Classifier and leave Classifier Model empty
3. Test Connection and Test Routing stay clickable, and Test Routing returns an error from the proxy rather than telling them what is missing
4. Only after clicking Add Auto Router does a toast say a classifier model is required

After: the form says what is missing before anything is sent

1. They follow the same steps
2. The Add Auto Router button is disabled, and hovering it says a classifier model is required
3. Choosing a classifier model enables it again

## Relevant issues

Split out of #38409 so these two fixes stand on their own. Both reproduce on staging today without any custom tier set

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Shared setup: a proxy on port 4000 with three model groups, and the Admin UI dev server on port 3000

### Before (53a607e088, staging)

#### The submit gate

1. Run the create form's blocked-reason gate on a config whose classifier_type is `llm` with no classifier model
2. It returns null, which is why the button stays enabled and Test Routing fires

#### The keyword-rule gate

1. Run the keyword gate on a rule whose tier is `AUDIT` against a router with the built-in four tiers
2. It returns null, so the save proceeds and the backend answers `keyword_tier_rules reference unknown tiers: AUDIT`

### After (cd0ab14f26)

#### The submit gate

1. The same call returns "Please select a classifier model, or switch back to Heuristic", so the button is disabled and says why
2. Adding a classifier model returns null again

#### The keyword-rule gate

1. The same call returns "Keyword rule(s) 1 route to a tier this router no longer has"
2. A rule naming `COMPLEX` returns null, and one naming `complex` is still rejected, matching the backend's exact-name rule

#### Suite

1. `npx vitest run --project unit --project component src/components/add_model src/components/edit_auto_router src/lib/autorouter_presets.test.ts` reports 576 passed
2. `npm run build` succeeds

## Type

🐛 Bug Fix

## Caveats (if any)

### Low

- The submit handlers keep their own semantic-matching check, which the button's gate does not read, because it depends on state the gate is not given

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dashboard-only client validation and messaging; no auth, API, or routing runtime changes beyond preventing known-invalid payloads from being sent.
> 
> **Overview**
> Tightens **auto-router create/edit validation** so invalid configs are blocked in the UI before Test Routing or save, with one shared reason the disabled button and submit handler both use.
> 
> Adds **`getClassifierModelError`** and wires it into **`getSubmitBlockedReason`** (now exported) plus the edit modal gate, so **LLM classifier without a selected model** disables submit and shows the same message as a refused save (including Enter-key submit).
> 
> Extends **`getKeywordTierRulesError`** with the router’s **active tier rows** and rejects keyword rules that target a tier the config no longer has (exact name match, including wrong casing), instead of letting the backend return a 400.
> 
> The create flow’s **`submitRecommendedRouter`** drops duplicated inline checks and calls **`getSubmitBlockedReason`**, with semantic-matching validation still applied only on submit.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 83bccee0f7419ac0e74609e0601a223a996921c0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->