### PR TITLE
fix(budget): serialize model_max_budget before the /budget/update write

### DIFF
--- a/litellm/proxy/management_endpoints/budget_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/budget_management_endpoints.py
@@ -13,6 +13,7 @@ All /budget management endpoints
 
 #### BUDGET TABLE MANAGEMENT ####
 import math
+from collections.abc import Mapping
 from typing import Final
 
 from fastapi import APIRouter, Depends, HTTPException
@@ -178,13 +179,17 @@ async def update_budget(
         else {}
     )
 
-    response: Final = await BudgetRepository(prisma_client).table.update(
-        where={"budget_id": budget_obj.budget_id},
-        data={
+    budget_obj_jsonified: Final[Mapping[str, object]] = jsonify_object(
+        {
             **budget_obj.model_dump(exclude_unset=True),
             **recomputed_reset_at,
             "updated_by": user_api_key_dict.user_id or litellm_proxy_admin_name,
-        },
+        }
+    )
+
+    response: Final = await BudgetRepository(prisma_client).table.update(
+        where={"budget_id": budget_obj.budget_id},
+        data=budget_obj_jsonified,
     )
 
     return response

--- a/tests/test_litellm/proxy/management_endpoints/test_budget_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_budget_endpoints.py
@@ -1,5 +1,6 @@
 # tests/test_budget_endpoints.py
 
+import json
 import types
 from datetime import datetime, timedelta, timezone
 import pytest
@@ -388,3 +389,34 @@ async def test_update_budget_duration_none_does_not_recompute(client_and_mocks):
 
     assert "budget_duration" in captured and captured["budget_duration"] is None
     assert "budget_reset_at" not in captured
+
+
+@pytest.mark.asyncio
+async def test_update_budget_serializes_model_max_budget_for_prisma(
+    client_and_mocks, monkeypatch
+):
+    monkeypatch.setattr(ps, "premium_user", True)
+
+    client, _, mock_table = client_and_mocks
+    captured = _capture_update_data(mock_table)
+
+    resp = client.post(
+        "/budget/update",
+        json={
+            "budget_id": "budget_per_model",
+            "model_max_budget": {
+                "gpt4o": {"budget_limit": 5.0, "time_period": "1d"},
+                "glm-5.2": {"budget_limit": 7.5, "time_period": "30d"},
+            },
+        },
+    )
+    assert resp.status_code == 200, resp.text
+
+    stored = captured["model_max_budget"]
+    assert isinstance(stored, str), (
+        f"model_max_budget must reach prisma as a JSON string, got {type(stored).__name__}"
+    )
+    assert json.loads(stored) == {
+        "gpt4o": {"max_budget": 5.0, "budget_duration": "1d"},
+        "glm-5.2": {"max_budget": 7.5, "budget_duration": "30d"},
+    }

--- a/tests/test_litellm/proxy/management_endpoints/test_budget_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_budget_endpoints.py
@@ -3,6 +3,7 @@
 import json
 import types
 from datetime import datetime, timedelta, timezone
+from typing import Final
 import pytest
 from unittest.mock import AsyncMock, MagicMock
 from fastapi.testclient import TestClient
@@ -398,9 +399,9 @@ async def test_update_budget_serializes_model_max_budget_for_prisma(
     monkeypatch.setattr(ps, "premium_user", True)
 
     client, _, mock_table = client_and_mocks
-    captured = _capture_update_data(mock_table)
+    captured: Final = _capture_update_data(mock_table)
 
-    resp = client.post(
+    resp: Final = client.post(
         "/budget/update",
         json={
             "budget_id": "budget_per_model",
@@ -412,7 +413,7 @@ async def test_update_budget_serializes_model_max_budget_for_prisma(
     )
     assert resp.status_code == 200, resp.text
 
-    stored = captured["model_max_budget"]
+    stored: Final = captured["model_max_budget"]
     assert isinstance(stored, str), (
         f"model_max_budget must reach prisma as a JSON string, got {type(stored).__name__}"
     )


### PR DESCRIPTION
## TLDR

Problem this solves:

- `/budget/update` returned 500 on any `model_max_budget`
- Per-model caps could never be set on an existing budget
- Team member and org member budget updates hit the same wall

How it solves it:

- Serialize the update payload before the write, like `/budget/new` does
- Add a unit test asserting what the endpoint hands the database

## User Flow

Before: an admin who created a budget cannot add per-model spend caps to it, and the API gives no usable reason

1. They send POST https://litellm-domain/budget/new with `{"budget_id": "team-a", "max_budget": 5.5}` and get back 200 with the new budget
2. They send POST https://litellm-domain/budget/update with `{"budget_id": "team-a", "model_max_budget": {"gpt4o": {"budget_limit": 5.0, "time_period": "1d"}}}`
3. The response is 500 `{"error":{"message":"Internal server error","type":"internal_server_error"}}`, with nothing naming the offending field
4. They send POST https://litellm-domain/budget/info with `{"budgets": ["team-a"]}` and see `"model_max_budget": null`, so the cap was never stored
5. The same 500 happens for a model id carrying punctuation, such as `glm-5.2`
6. Setting per-model caps on team members and org members fails the same way, since those routes update the budget through this endpoint

After: the same update succeeds and the caps are readable straight back

1. They send the same POST https://litellm-domain/budget/new and get back 200
2. They send the same POST https://litellm-domain/budget/update, now with both `gpt4o` and `glm-5.2` caps in one call
3. The response is 200 and the body already shows `"model_max_budget": {"gpt4o": {"max_budget": 5.0, "budget_duration": "1d"}, "glm-5.2": {"max_budget": 7.5, "budget_duration": "30d"}}`
4. POST https://litellm-domain/budget/info for that budget returns the same per-model caps
5. Team member and org member budget updates carrying per-model caps now go through as well

## Relevant issues

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Run against a local proxy on port 4001 with a database and an enterprise license. `$MK` is the master key. The same three commands are run on both sides.

```bash
BID=demo-1
curl -sS -w "\nHTTP %{http_code}\n" -X POST http://localhost:4001/budget/new \
  -H "Authorization: Bearer $MK" -H 'Content-Type: application/json' \
  -d "{\"budget_id\":\"$BID\",\"max_budget\":5.5}"

curl -sS -w "\nHTTP %{http_code}\n" -X POST http://localhost:4001/budget/update \
  -H "Authorization: Bearer $MK" -H 'Content-Type: application/json' \
  -d "{\"budget_id\":\"$BID\",\"model_max_budget\":{\"gpt4o\":{\"budget_limit\":5.0,\"time_period\":\"1d\"},\"glm-5.2\":{\"budget_limit\":7.5,\"time_period\":\"30d\"}}}"

curl -sS -w "\nHTTP %{http_code}\n" -X POST http://localhost:4001/budget/info \
  -H "Authorization: Bearer $MK" -H 'Content-Type: application/json' \
  -d "{\"budgets\":[\"$BID\"]}"
```

### Before (ecc49764af35345798716d0cb30aa7a05cd4605e)

1. Create the budget

```
{"budget_id":"pof-before-ecc4976","max_budget":5.5,"soft_budget":null,"max_parallel_requests":null,"tpm_limit":null,"rpm_limit":null,"model_max_budget":null,"budget_duration":null,"budget_reset_at":null,"allowed_models":[],"created_at":"2026-08-27T00:47:22.006000Z","created_by":"default_user_id","updated_at":"2026-08-27T00:47:22.006000Z","updated_by":"default_user_id",...}
HTTP 200
```

2. Set the per-model caps

```
{"error":{"message":"Internal server error","type":"internal_server_error"}}
HTTP 500
```

The proxy log shows why:

```
prisma.errors.DataError: Error parsing GraphQL query: query parse error: Parse error at 11:12
Expected `:`
```

3. Read the budget back, and the caps are absent

```
[{"budget_id":"pof-before-ecc4976","max_budget":5.5,...,"model_max_budget":null,...}]
HTTP 200
```

### After (315144c9cc9c7097718c3db06931a0c79e20e079)

1. Create the budget

```
{"budget_id":"pof-after-315144c","max_budget":5.5,"soft_budget":null,"max_parallel_requests":null,"tpm_limit":null,"rpm_limit":null,"model_max_budget":null,"budget_duration":null,"budget_reset_at":null,"allowed_models":[],"created_at":"2026-08-27T00:56:35.499000Z","created_by":"default_user_id","updated_at":"2026-08-27T00:56:35.499000Z","updated_by":"default_user_id",...}
HTTP 200
```

2. Set the per-model caps

```
{"budget_id":"pof-after-315144c","max_budget":5.5,...,"model_max_budget":{"gpt4o":{"max_budget":5.0,"budget_duration":"1d"},"glm-5.2":{"max_budget":7.5,"budget_duration":"30d"}},...}
HTTP 200
```

3. Read the budget back, and the caps are there

```
[{"budget_id":"pof-after-315144c","max_budget":5.5,...,"model_max_budget":{"gpt4o":{"max_budget":5.0,"budget_duration":"1d"},"glm-5.2":{"max_budget":7.5,"budget_duration":"30d"}},...}]
HTTP 200
```

## Type

🐛 Bug Fix

## Caveats (if any)

### Low

- Stored keys are the canonical `max_budget` / `budget_duration` names
- Callers sending `budget_limit` / `time_period` read back the canonical pair

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
