### PR TITLE
fix(anthropic-adapter): pass provider-native and OpenAI-format tools through on /v1/messages

### DIFF
--- a/litellm/llms/anthropic/chat/guardrail_translation/handler.py
+++ b/litellm/llms/anthropic/chat/guardrail_translation/handler.py
@@ -24,10 +24,12 @@ from litellm._logging import verbose_proxy_logger
 from litellm.llms.anthropic.chat.transformation import AnthropicConfig
 from litellm.llms.anthropic.experimental_pass_through.adapters.transformation import (
     LiteLLMAnthropicMessagesAdapter,
+    is_provider_native_tool_dict,
 )
 from litellm.llms.base_llm.guardrail_translation.base_translation import BaseTranslation
 from litellm.llms.base_llm.guardrail_translation.utils import (
     anthropic_tool_name,
+    anthropic_tool_names,
     effective_scan_only_tool_results_for_guardrail,
     effective_skip_system_message_for_guardrail,
     effective_skip_tool_message_for_guardrail,
@@ -360,7 +362,13 @@ class AnthropicMessagesHandler(BaseTranslation):
         structured_messages: Final = [full_structured_messages[index] for index in scoped_message_indices]
 
         tools_to_check: Final[list[ChatCompletionToolParam]] = (
-            [] if scan_only_tool_results else chat_completion_compatible_request.get("tools", [])
+            []
+            if scan_only_tool_results
+            else [
+                tool
+                for tool in chat_completion_compatible_request.get("tools", [])
+                if not is_provider_native_tool_dict(tool)
+            ]
         )
 
         # Step 1: Extract all text content and images
@@ -419,7 +427,10 @@ class AnthropicMessagesHandler(BaseTranslation):
                         tool_name=anthropic_tool_name,
                     )
                     if scan_only_tool_results
-                    else anthropic_tools
+                    else [
+                        *(tool for tool in data.get("tools") or [] if is_provider_native_tool_dict(tool)),
+                        *anthropic_tools,
+                    ]
                 )
 
             guardrailed_structured_messages: Final = guardrailed_inputs.get("structured_messages")
@@ -677,9 +688,9 @@ class AnthropicMessagesHandler(BaseTranslation):
         )
 
     def extract_request_tool_names(self, data: dict) -> list[str]:
-        """Extract tool names from Anthropic messages request (tools[].name, or
-        tools[].function.name for OpenAI-format tools the bridge forwards verbatim)."""
-        return [name for tool in data.get("tools") or [] if (name := anthropic_tool_name(tool))]
+        """Extract every tool name in an Anthropic messages request: tools[].name, plus
+        tools[].function.name for OpenAI-format tools the bridge forwards verbatim."""
+        return [name for tool in data.get("tools") or [] for name in anthropic_tool_names(tool)]
 
     @classmethod
     def _extract_input_text_and_images(

--- a/litellm/llms/anthropic/chat/guardrail_translation/handler.py
+++ b/litellm/llms/anthropic/chat/guardrail_translation/handler.py
@@ -677,12 +677,9 @@ class AnthropicMessagesHandler(BaseTranslation):
         )
 
     def extract_request_tool_names(self, data: dict) -> list[str]:
-        """Extract tool names from Anthropic messages request (tools[].name)."""
-        names: Final[list[str]] = []
-        for tool in data.get("tools") or []:
-            if isinstance(tool, dict) and tool.get("name"):
-                names.append(str(tool["name"]))
-        return names
+        """Extract tool names from Anthropic messages request (tools[].name, or
+        tools[].function.name for OpenAI-format tools the bridge forwards verbatim)."""
+        return [name for tool in data.get("tools") or [] if (name := anthropic_tool_name(tool))]
 
     @classmethod
     def _extract_input_text_and_images(

--- a/litellm/llms/anthropic/experimental_pass_through/adapters/transformation.py
+++ b/litellm/llms/anthropic/experimental_pass_through/adapters/transformation.py
@@ -18,6 +18,22 @@ TOOL_NAME_PREFIX_LENGTH: Final = OPENAI_MAX_TOOL_NAME_LENGTH - TOOL_NAME_HASH_LE
 PROVIDERS_PROXYING_AN_UNKNOWN_BACKEND: Final = frozenset({"litellm_proxy"})
 
 
+_ANTHROPIC_TOOL_SCHEMA_KEYS: Final = frozenset(
+    {"name", "type", "input_schema", "description", "cache_control", "strict"}
+)
+
+
+def _is_openai_function_tool(tool: Mapping[str, object]) -> bool:
+    return tool.get("type") == "function" and "function" in tool
+
+
+def _is_provider_native_tool_dict(tool: Mapping[str, object]) -> bool:
+    if len(tool) != 1:
+        return False
+    key, value = next(iter(tool.items()))
+    return key not in _ANTHROPIC_TOOL_SCHEMA_KEYS and isinstance(value, dict)
+
+
 def truncate_tool_name(name: str) -> str:
     """
     Truncate tool names that exceed OpenAI's 64-character limit.
@@ -768,6 +784,10 @@ class LiteLLMAnthropicMessagesAdapter:
             if any(tool_type.startswith(t.value) for t in ANTHROPIC_HOSTED_TOOLS):
                 # Keep Anthropic-native tools in their original format
                 new_tools.append(tool)
+                continue
+
+            if _is_openai_function_tool(tool) or _is_provider_native_tool_dict(tool):
+                new_tools.append(cast(ChatCompletionToolParam, tool))  # cast-ok: passed through verbatim to provider
                 continue
 
             raw_name = tool.get("name")

--- a/litellm/llms/anthropic/experimental_pass_through/adapters/transformation.py
+++ b/litellm/llms/anthropic/experimental_pass_through/adapters/transformation.py
@@ -27,7 +27,7 @@ def _is_openai_function_tool(tool: Mapping[str, object]) -> bool:
     return tool.get("type") == "function" and "function" in tool
 
 
-def _is_provider_native_tool_dict(tool: Mapping[str, object]) -> bool:
+def is_provider_native_tool_dict(tool: Mapping[str, object]) -> bool:
     if len(tool) != 1:
         return False
     key, value = next(iter(tool.items()))
@@ -786,7 +786,7 @@ class LiteLLMAnthropicMessagesAdapter:
                 new_tools.append(tool)
                 continue
 
-            if _is_openai_function_tool(tool) or _is_provider_native_tool_dict(tool):
+            if _is_openai_function_tool(tool) or is_provider_native_tool_dict(tool):
                 new_tools.append(cast(ChatCompletionToolParam, tool))  # cast-ok: passed through verbatim to provider
                 continue
 

--- a/litellm/llms/base_llm/guardrail_translation/utils.py
+++ b/litellm/llms/base_llm/guardrail_translation/utils.py
@@ -209,17 +209,20 @@ def openai_tool_name(tool: object) -> str | None:
     return flat_name if isinstance(flat_name, str) else None
 
 
-def anthropic_tool_name(tool: object) -> str | None:
-    """Anthropic tools carry a flat ``name``; an OpenAI-format function tool, which the
-    non-Anthropic bridge forwards verbatim, carries it under ``function.name`` instead."""
+def anthropic_tool_names(tool: object) -> tuple[str, ...]:
+    """Every name a /v1/messages tool dict can act under: the flat Anthropic ``name`` plus
+    ``function.name`` for OpenAI-format tools the bridge forwards verbatim. Allowlist checks
+    must see both, or a decoy flat name could smuggle a disallowed ``function.name`` through."""
     if not isinstance(tool, dict):
-        return None
-    flat_name: Final = tool.get("name")
-    if isinstance(flat_name, str):
-        return flat_name
+        return ()
     function: Final = tool.get("function") if tool.get("type") == "function" else None
     function_name: Final = function.get("name") if isinstance(function, dict) else None
-    return function_name if isinstance(function_name, str) else None
+    return tuple(name for name in (tool.get("name"), function_name) if isinstance(name, str) and name)
+
+
+def anthropic_tool_name(tool: object) -> str | None:
+    names: Final = anthropic_tool_names(tool)
+    return names[0] if names else None
 
 
 def merge_returned_tools_into_request_tools(

--- a/litellm/llms/base_llm/guardrail_translation/utils.py
+++ b/litellm/llms/base_llm/guardrail_translation/utils.py
@@ -210,8 +210,16 @@ def openai_tool_name(tool: object) -> str | None:
 
 
 def anthropic_tool_name(tool: object) -> str | None:
-    name: Final = tool.get("name") if isinstance(tool, dict) else None
-    return name if isinstance(name, str) else None
+    """Anthropic tools carry a flat ``name``; an OpenAI-format function tool, which the
+    non-Anthropic bridge forwards verbatim, carries it under ``function.name`` instead."""
+    if not isinstance(tool, dict):
+        return None
+    flat_name: Final = tool.get("name")
+    if isinstance(flat_name, str):
+        return flat_name
+    function: Final = tool.get("function") if tool.get("type") == "function" else None
+    function_name: Final = function.get("name") if isinstance(function, dict) else None
+    return function_name if isinstance(function_name, str) else None
 
 
 def merge_returned_tools_into_request_tools(

--- a/tests/test_litellm/llms/anthropic/chat/guardrail_translation/test_anthropic_guardrail_handler.py
+++ b/tests/test_litellm/llms/anthropic/chat/guardrail_translation/test_anthropic_guardrail_handler.py
@@ -291,6 +291,24 @@ class TestAnthropicMessagesHandlerInputProcessing:
         assert guardrail.dynamic_params == {"policy_id": "policy-123"}
 
     @pytest.mark.asyncio
+    async def test_provider_native_tools_survive_guardrail_round_trip(self):
+        handler = AnthropicMessagesHandler()
+        guardrail = MockPassThroughGuardrail(guardrail_name="test")
+        data = {
+            "model": "gemini-2.5-flash",
+            "messages": [{"role": "user", "content": "coffee shops near Union Square?"}],
+            "tools": [
+                {"googleMaps": {"enable_widget": True}},
+                {"name": "get_weather", "input_schema": {"type": "object", "properties": {}}},
+            ],
+        }
+
+        await handler.process_input_messages(data=data, guardrail_to_apply=guardrail)
+
+        assert {"googleMaps": {"enable_widget": True}} in data["tools"]
+        assert [tool["name"] for tool in data["tools"] if "name" in tool] == ["get_weather"]
+
+    @pytest.mark.asyncio
     async def test_midturn_system_correction_is_guardrailed_when_top_level_system_is_skipped(
         self,
     ):

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_anthropic_experimental_pass_through_adapters_transformation.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_anthropic_experimental_pass_through_adapters_transformation.py
@@ -16,6 +16,7 @@ from litellm.litellm_core_utils.prompt_templates.factory import (
 )
 from litellm.llms.anthropic.experimental_pass_through.adapters.transformation import (
     OPENAI_MAX_TOOL_NAME_LENGTH,
+    AnthropicAdapter,
     LiteLLMAnthropicMessagesAdapter,
     create_tool_name_mapping,
     truncate_tool_name,
@@ -2305,6 +2306,53 @@ def test_translate_anthropic_tools_to_openai_fills_missing_tool_name():
     result, _ = adapter.translate_anthropic_tools_to_openai(tools=tools, model=None)
     assert result[0]["function"]["name"] == "litellm_unnamed_tool_0"
     assert result[1]["function"]["name"] == "litellm_unnamed_tool_1"
+
+
+def test_translate_anthropic_tools_to_openai_passes_provider_native_tool_dicts_through():
+    """Deployment-level provider-native tools (e.g. Gemini googleMaps) must reach the provider transformation verbatim (LIT-6286)."""
+    tools = [
+        {"googleMaps": {}},
+        {"googleSearch": {}},
+        {
+            "name": "get_weather",
+            "input_schema": {"type": "object", "properties": {"location": {"type": "string"}}},
+        },
+    ]
+    adapter = LiteLLMAnthropicMessagesAdapter()
+    result, tool_name_mapping = adapter.translate_anthropic_tools_to_openai(tools=tools, model=None)
+    assert result[0] == {"googleMaps": {}}
+    assert result[1] == {"googleSearch": {}}
+    assert result[2]["function"]["name"] == "get_weather"
+    assert tool_name_mapping == {}
+
+
+def test_translate_anthropic_tools_to_openai_passes_openai_function_tools_through():
+    """A tool already in OpenAI function format must pass through unchanged instead of becoming litellm_unnamed_tool_N."""
+    openai_tool = {
+        "type": "function",
+        "function": {
+            "name": "get_weather",
+            "parameters": {"type": "object", "properties": {"location": {"type": "string"}}},
+        },
+    }
+    adapter = LiteLLMAnthropicMessagesAdapter()
+    result, _ = adapter.translate_anthropic_tools_to_openai(tools=[openai_tool], model=None)
+    assert result == [openai_tool]
+
+
+def test_translate_completion_input_params_keeps_provider_native_tools():
+    """/v1/messages request translation must keep router-merged provider-native tools in kwargs['tools'] (LIT-6286)."""
+    adapter = AnthropicAdapter()
+    translated = adapter.translate_completion_input_params(
+        {
+            "model": "gemini/gemini-2.5-flash",
+            "max_tokens": 1024,
+            "messages": [{"role": "user", "content": "coffee shops near Union Square"}],
+            "tools": [{"googleMaps": {}}],
+        }
+    )
+    assert translated is not None
+    assert translated["tools"] == [{"googleMaps": {}}]
 
 
 def test_translate_openai_content_to_anthropic_reasoning_content_without_thinking_blocks():

--- a/tests/test_litellm/proxy/test_tools_allowlist_enforcement.py
+++ b/tests/test_litellm/proxy/test_tools_allowlist_enforcement.py
@@ -106,6 +106,19 @@ class TestExtractRequestToolNames:
             "run_sql",
         ]
 
+    def test_anthropic_hybrid_tool_yields_every_name(self):
+        data = {
+            "tools": [
+                {"type": "function", "name": "decoy", "function": {"name": "blocked_fn"}},
+                {"type": "function", "name": "", "function": {"name": "hidden_fn"}},
+            ]
+        }
+        assert extract_request_tool_names("/v1/messages", data) == [
+            "decoy",
+            "blocked_fn",
+            "hidden_fn",
+        ]
+
     def test_generate_content_tools(self):
         data = {
             "tools": [
@@ -185,6 +198,20 @@ class TestCheckToolsAllowlist:
             )
         assert exc_info.value.type == ProxyErrorTypes.tool_access_denied
         assert "get_weather" in str(exc_info.value.message)
+
+    @pytest.mark.asyncio
+    async def test_hybrid_tool_with_decoy_name_raises_on_messages_route(self):
+        token = _token(metadata={"allowed_tools": ["decoy"]})
+        body = {"tools": [{"type": "function", "name": "decoy", "function": {"name": "run_sql"}}]}
+        with pytest.raises(ProxyException) as exc_info:
+            await check_tools_allowlist(
+                request_body=body,
+                valid_token=token,
+                team_object=None,
+                route="/v1/messages",
+            )
+        assert exc_info.value.type == ProxyErrorTypes.tool_access_denied
+        assert "run_sql" in str(exc_info.value.message)
 
     @pytest.mark.asyncio
     async def test_disallowed_custom_tool_raises_on_responses_route(self):

--- a/tests/test_litellm/proxy/test_tools_allowlist_enforcement.py
+++ b/tests/test_litellm/proxy/test_tools_allowlist_enforcement.py
@@ -93,6 +93,19 @@ class TestExtractRequestToolNames:
             "run_sql",
         ]
 
+    def test_anthropic_openai_format_tools_forwarded_by_bridge(self):
+        data = {
+            "tools": [
+                {"type": "function", "function": {"name": "get_weather"}},
+                {"name": "run_sql"},
+                {"googleSearch": {}},
+            ]
+        }
+        assert extract_request_tool_names("/v1/messages", data) == [
+            "get_weather",
+            "run_sql",
+        ]
+
     def test_generate_content_tools(self):
         data = {
             "tools": [
@@ -155,6 +168,20 @@ class TestCheckToolsAllowlist:
                 valid_token=token,
                 team_object=None,
                 route="/v1/chat/completions",
+            )
+        assert exc_info.value.type == ProxyErrorTypes.tool_access_denied
+        assert "get_weather" in str(exc_info.value.message)
+
+    @pytest.mark.asyncio
+    async def test_disallowed_openai_format_tool_raises_on_messages_route(self):
+        token = _token(metadata={"allowed_tools": ["other_tool"]})
+        body = {"tools": [{"type": "function", "function": {"name": "get_weather"}}]}
+        with pytest.raises(ProxyException) as exc_info:
+            await check_tools_allowlist(
+                request_body=body,
+                valid_token=token,
+                team_object=None,
+                route="/v1/messages",
             )
         assert exc_info.value.type == ProxyErrorTypes.tool_access_denied
         assert "get_weather" in str(exc_info.value.message)


### PR DESCRIPTION
## TLDR

Problem this solves:

- Deployment-level provider-native tools (e.g. Gemini `googleMaps`) are dropped on /v1/messages
- The bridge wraps them as a garbage `litellm_unnamed_tool_N` function tool
- Same config works on /v1/chat/completions and /v1/responses, so /v1/messages silently loses grounding

How it solves it:

- The anthropic-messages bridge now passes single-key provider-native tool dicts through verbatim
- Tools already in OpenAI function format also pass through unchanged
- Anthropic custom tools keep the existing name-mapped translation
- The /v1/messages tool-name extractor now reads every name a tool dict carries, flat `name` and `function.name`
- So restricted keys cannot slip disallowed tools through the pass-through, decoy flat names included
- Unified guardrails skip provider-native tool dicts and keep them on the request instead of crashing on them

## User Flow

Before: an app on the Anthropic Messages API gets ungrounded refusals from a Gemini deployment the admin configured with Google Maps grounding

1. The proxy admin adds a Gemini deployment whose model-level config lists the provider-native tool `googleMaps: {}`, so every request through it should be Maps-grounded
2. A developer sanity-checks it with POST https://litellm-domain/v1/chat/completions asking "What are three well-reviewed coffee shops near Union Square in San Francisco?" and gets back real cafes with ratings and maps.google.com grounding links
3. Their Anthropic-SDK app sends the same question as POST https://litellm-domain/v1/messages with the same model name
4. The 200 response is a text-only refusal saying it cannot access real-time business or maps information, with no grounding anywhere in it
5. A key the admin restricted with `allowed_tools: ["get_weather"]` sends POST https://litellm-domain/v1/messages with an OpenAI-format `run_sql` tool and is not blocked, though the tool arrives at the model garbled and unusable

After: the same /v1/messages request comes back Maps-grounded, matching the other endpoints

1. The proxy admin adds a Gemini deployment whose model-level config lists the provider-native tool `googleMaps: {}`, so every request through it should be Maps-grounded
2. A developer sanity-checks it with POST https://litellm-domain/v1/chat/completions asking "What are three well-reviewed coffee shops near Union Square in San Francisco?" and gets back real cafes with ratings and maps.google.com grounding links
3. Their Anthropic-SDK app sends the same question as POST https://litellm-domain/v1/messages with the same model name
4. The 200 response now names the same kind of real cafes with ratings and review counts, grounded through Google Maps exactly like the /v1/chat/completions answer
5. That same restricted key now gets HTTP 403 `tool_access_denied` naming `run_sql`, while its allowed `get_weather` tool still comes back as a normal `tool_use` call

## Relevant issues

## Linear ticket

Resolves LIT-6286

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

All legs ran a live proxy with 2 uvicorn workers against the real Gemini API from this config (`GEMINI_API_KEY` from env). The before leg was DB-less; the head legs ran Postgres-backed so the key-level `allowed_tools` proof below could use a real virtual key:

```yaml
model_list:
  - model_name: gemini-2.5-flash-maps
    litellm_params:
      model: gemini/gemini-2.5-flash
      api_key: os.environ/GEMINI_API_KEY
      tools:
        - googleMaps: {}
  - model_name: gemini-2.5-flash-plain
    litellm_params:
      model: gemini/gemini-2.5-flash
      api_key: os.environ/GEMINI_API_KEY
  - model_name: gemini-2.5-flash-fn
    litellm_params:
      model: gemini/gemini-2.5-flash
      api_key: os.environ/GEMINI_API_KEY
      tools:
        - type: function
          function:
            name: get_weather
            description: Get current weather for a location
            parameters:
              type: object
              properties:
                location:
                  type: string
              required:
                - location

general_settings:
  master_key: sk-lit6286-qa
```

### Before (f677292901)

#### /v1/messages with deployment-level googleMaps

1. `curl -sS -X POST http://localhost:23425/v1/messages -H 'Authorization: Bearer sk-lit6286-qa' -H 'Content-Type: application/json' -d '{"model":"gemini-2.5-flash-maps","max_tokens":1024,"messages":[{"role":"user","content":"What are three well-reviewed coffee shops near Union Square in San Francisco?"}]}'`
2. HTTP 200 whose only content block is the refusal "I am sorry, I cannot fulfill this request. I do not have access to real-time business information or reviews.", no cafe names, no grounding: the model-level googleMaps tool was dropped

#### /v1/chat/completions with deployment-level googleMaps

1. `curl -sS -X POST http://localhost:23425/v1/chat/completions -H 'Authorization: Bearer sk-lit6286-qa' -H 'Content-Type: application/json' -d '{"model":"gemini-2.5-flash-maps","messages":[{"role":"user","content":"What are three well-reviewed coffee shops near Union Square in San Francisco?"}]}'`
2. HTTP 200 grounded answer naming ADAN CAFE (4.9 stars, 66 reviews), Painted Leopard Coffee (4.9, 70), and Origin Lab Coffee & Matcha (4.7, 512), with top-level `vertex_ai_grounding_metadata` carrying real maps groundingChunks (title, placeId, uri) and `usage.prompt_tokens_details.google_maps_grounding_requests: 1`

#### /v1/responses with deployment-level googleMaps

1. `curl -sS -X POST http://localhost:23425/v1/responses -H 'Authorization: Bearer sk-lit6286-qa' -H 'Content-Type: application/json' -d '{"model":"gemini-2.5-flash-maps","input":"What are three well-reviewed coffee shops near Union Square in San Francisco?"}'`
2. HTTP 200 grounded output_text naming Origin Lab Coffee & Matcha (4.7, 512 reviews), Caffe Central (4.5, 1611), and Bella Cafe (4.7, 153), with street addresses

#### /v1/messages with a custom function tool

1. `curl -sS -X POST http://localhost:23425/v1/messages -H 'Authorization: Bearer sk-lit6286-qa' -H 'Content-Type: application/json' -d '{"model":"gemini-2.5-flash-plain","max_tokens":1024,"tools":[{"name":"get_weather","description":"Get current weather for a location","input_schema":{"type":"object","properties":{"location":{"type":"string"}},"required":["location"]}}],"messages":[{"role":"user","content":"What is the weather in San Francisco? Use the get_weather tool."}]}'`
2. HTTP 200 with stop_reason `tool_use` and content `{"type":"tool_use","name":"get_weather","input":{"location":"San Francisco"}}`

### After (6d7fafa347, this PR's head)

#### /v1/messages with deployment-level googleMaps

1. `curl -sS -X POST http://localhost:41042/v1/messages -H 'Authorization: Bearer sk-lit6286-qa' -H 'Content-Type: application/json' -d '{"model":"gemini-2.5-flash-maps","max_tokens":1024,"messages":[{"role":"user","content":"What are three well-reviewed coffee shops near Union Square in San Francisco?"}]}'`
2. HTTP 200 grounded text block, no refusal: "**ADAN CAFE** is an Arabian-inspired coffee shop with a 4.9-star rating based on 66 reviews ... **Painted Leopard Coffee** has a 4.9-star rating from 70 reviews ..."

#### /v1/chat/completions with deployment-level googleMaps

1. `curl -sS -X POST http://localhost:41042/v1/chat/completions -H 'Authorization: Bearer sk-lit6286-qa' -H 'Content-Type: application/json' -d '{"model":"gemini-2.5-flash-maps","messages":[{"role":"user","content":"What are three well-reviewed coffee shops near Union Square in San Francisco?"}]}'`
2. HTTP 200 grounded answer with the same cafes, top-level `vertex_ai_grounding_metadata` with real maps groundingChunks, and `usage.prompt_tokens_details.google_maps_grounding_requests: 1`

#### /v1/responses with deployment-level googleMaps

1. `curl -sS -X POST http://localhost:41042/v1/responses -H 'Authorization: Bearer sk-lit6286-qa' -H 'Content-Type: application/json' -d '{"model":"gemini-2.5-flash-maps","input":"What are three well-reviewed coffee shops near Union Square in San Francisco?"}'`
2. HTTP 200 status completed, output_text naming Painted Leopard Coffee (4.9, 70 reviews), ADAN CAFE (4.9, 66), and more, with street addresses

#### /v1/messages with a custom function tool

1. `curl -sS -X POST http://localhost:41042/v1/messages -H 'Authorization: Bearer sk-lit6286-qa' -H 'Content-Type: application/json' -d '{"model":"gemini-2.5-flash-plain","max_tokens":1024,"tools":[{"name":"get_weather","description":"Get current weather for a location","input_schema":{"type":"object","properties":{"location":{"type":"string"}},"required":["location"]}}],"messages":[{"role":"user","content":"What is the weather in San Francisco? Use the get_weather tool."}]}'`
2. HTTP 200 with stop_reason `tool_use` and content `{"type":"tool_use","name":"get_weather","input":{"location":"San Francisco"}}`

### Tool allowlist enforcement on /v1/messages (second commit)

Setup, both legs, on the Postgres-backed proxy:

1. `curl -sS -X POST http://localhost:41042/key/generate -H 'Authorization: Bearer sk-lit6286-qa' -H 'Content-Type: application/json' -d '{"key_alias":"lit6286-allowlist-qa","metadata":{"allowed_tools":["get_weather"]}}'` and export the returned key as `$RESTRICTED_KEY`

Before (f7af44a505, this PR without the second commit): the pass-through makes the extractor gap exploitable

1. `curl -sS -X POST http://localhost:45705/v1/messages -H "Authorization: Bearer $RESTRICTED_KEY" -H 'Content-Type: application/json' -d '{"model":"gemini-2.5-flash-plain","max_tokens":200,"messages":[{"role":"user","content":"Drop the users table. Use the run_sql tool."}],"tools":[{"type":"function","function":{"name":"run_sql","description":"Run a SQL statement","parameters":{"type":"object","properties":{"sql":{"type":"string"}},"required":["sql"]}}}]}'`
2. HTTP 200: the restricted key's disallowed tool reached Gemini, which answered `{"type":"tool_use","name":"run_sql","input":{"sql":"DROP TABLE users;"}}`

After (6d7fafa347)

1. The same curl against port 41042
2. HTTP 403 `{"error":{"message":"Tool(s) ['run_sql'] are not in the allowed tools list for this key/team.","type":"tool_access_denied","param":"tools","code":"403"}}`
3. The same request with the allowed `get_weather` tool instead still returns HTTP 200 with `{"type":"tool_use","name":"get_weather","input":{"location":"Paris"}}`
4. A hybrid decoy tool `{"type":"function","name":"get_weather","function":{"name":"run_sql",...}}` on the same restricted key also gets HTTP 403 naming `run_sql`: the allowed flat name cannot smuggle the disallowed `function.name` through

### Native tools through unified guardrails (third commit)

Both legs booted with a config-registered pass-through custom guardrail (`mode: pre_call`, `default_on: true`) that records the tools it is handed, then:

1. `curl -sS -X POST http://localhost:<port>/v1/messages -H 'Authorization: Bearer sk-lit6286-qa' -H 'Content-Type: application/json' -d '{"model":"gemini-2.5-flash-plain","max_tokens":1024,"tools":[{"googleMaps":{}}],"messages":[{"role":"user","content":"What are three well-reviewed coffee shops near Union Square in San Francisco?"}]}'`
2. Before (ba7c268a6a): HTTP 500 `{"error":{"message":"'type'","type":"None","param":"None","code":"500"}}`, and the recorder shows the raw `{"googleMaps": {}}` dict was handed to the guardrail
3. After (6d7fafa347): HTTP 200 grounded cafes answer, and the recorder shows the guardrail never saw the native dict while the request kept it
4. With `{"googleMaps":{}}` plus a `get_weather` function tool together, before still 500s while after forwards both to Gemini, which itself rejects combining built-in tools with function calling (upstream Gemini rule, not a proxy decision)

QA observations, both legs:

- `vertex_ai_grounding_metadata` sits top-level, not provider_specific_fields; pre-existing, unchanged here
- /v1/messages tool_use blocks carry a Gemini signature field; pre-existing, unchanged here

## Type

🐛 Bug Fix

## Caveats (if any)

### Low

- Provider-native single-key tool dicts (e.g. `googleMaps: {}`) carry no tool name
- So `allowed_tools` cannot match them, on /v1/messages or any other endpoint
- That gap predates this PR and is out of scope here

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

CHECKED: /live-pr-risk at 6d7fafa347; no breaking dependents (bridge route A/B'd live base vs head vs staging-merged, allowlist decider A/B'd live f7af44a505 vs head incl. the hybrid decoy case on a Postgres-backed proxy, guardrail write-back A/B'd live ba7c268a6a vs head through a config-registered custom guardrail with recorder evidence, tool-name extractor delta has a single caller and unit coverage, no stale renamed references, no legacy-suite or registry references)
- [x] 6d7fafa347 passes /live-pr-risk
