### PR TITLE
fix(prompts): propagate prompt deletes to every worker and pod

### DIFF
--- a/litellm/proxy/prompts/prompt_endpoints.py
+++ b/litellm/proxy/prompts/prompt_endpoints.py
@@ -1021,19 +1021,7 @@ async def delete_prompt(
         # Delete versions from the database (scoped to environment if provided)
         await _prompt_table(prisma_client).delete_many(where=delete_where)
 
-        # Remove matching prompts from memory — scope to environment if provided
-        if environment:
-            prompts_to_delete: Final = [
-                pid
-                for pid, prompt in IN_MEMORY_PROMPT_REGISTRY.IN_MEMORY_PROMPTS.items()
-                if get_base_prompt_id(prompt_id=pid) == base_prompt_id and prompt.environment == environment
-            ]
-            for pid in prompts_to_delete:
-                del IN_MEMORY_PROMPT_REGISTRY.IN_MEMORY_PROMPTS[pid]
-                if pid in IN_MEMORY_PROMPT_REGISTRY.prompt_id_to_custom_prompt:
-                    del IN_MEMORY_PROMPT_REGISTRY.prompt_id_to_custom_prompt[pid]
-        else:
-            IN_MEMORY_PROMPT_REGISTRY.delete_prompts_by_base_id(base_prompt_id)
+        IN_MEMORY_PROMPT_REGISTRY.delete_prompts_by_base_id(base_prompt_id, environment=environment or None)
 
         env_msg: Final = f" from {environment}" if environment else ""
         return {"message": f"Prompt {base_prompt_id} deleted successfully{env_msg}"}

--- a/litellm/proxy/prompts/prompt_registry.py
+++ b/litellm/proxy/prompts/prompt_registry.py
@@ -195,12 +195,22 @@ class InMemoryPromptRegistry:
         """
         return self.prompt_id_to_custom_prompt.get(prompt_id)
 
-    def delete_prompts_by_base_id(self, base_prompt_id: str) -> list[str]:
+    def remove_prompt(self, prompt_id: str) -> None:
+        import litellm
+
+        self.IN_MEMORY_PROMPTS.pop(prompt_id, None)
+        stale_callback: Final = self.prompt_id_to_custom_prompt.pop(prompt_id, None)
+        if stale_callback is not None:
+            litellm.logging_callback_manager.remove_callback_from_all_lists(stale_callback)
+
+    def delete_prompts_by_base_id(self, base_prompt_id: str, environment: str | None = None) -> list[str]:
         """
-        Delete all prompts matching the given base prompt ID from memory.
+        Delete all prompts matching the given base prompt ID from memory, along with their
+        registered callbacks; scoped to one environment when given.
 
         Args:
             base_prompt_id: The base prompt ID (without version suffix)
+            environment: When set, only delete prompts deployed to this environment
 
         Returns:
             List of prompt IDs that were deleted
@@ -208,13 +218,14 @@ class InMemoryPromptRegistry:
         from litellm.proxy.prompts.prompt_endpoints import get_base_prompt_id
 
         prompts_to_delete: Final = [
-            pid for pid in self.IN_MEMORY_PROMPTS if get_base_prompt_id(prompt_id=pid) == base_prompt_id
+            pid
+            for pid, prompt in self.IN_MEMORY_PROMPTS.items()
+            if get_base_prompt_id(prompt_id=pid) == base_prompt_id
+            and (environment is None or prompt.environment == environment)
         ]
 
         for pid in prompts_to_delete:
-            del self.IN_MEMORY_PROMPTS[pid]
-            if pid in self.prompt_id_to_custom_prompt:
-                del self.prompt_id_to_custom_prompt[pid]
+            self.remove_prompt(prompt_id=pid)
 
         return prompts_to_delete
 

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -7291,6 +7291,16 @@ class ProxyConfig:
                         prompt_spec.prompt_id,
                         prompt_sync_error,
                     )
+            # An unparsable row still exists in the DB, so skip the sweep rather than unload its in-memory copy
+            every_row_parsed: Final = len(parsed_specs) == len(prompts_in_db)
+            if every_row_parsed:
+                deleted_db_prompt_ids: Final = tuple(
+                    prompt_id
+                    for prompt_id, spec in IN_MEMORY_PROMPT_REGISTRY.IN_MEMORY_PROMPTS.items()
+                    if spec.prompt_info.prompt_type == "db" and prompt_id not in newest_spec_per_id
+                )
+                for deleted_prompt_id in deleted_db_prompt_ids:
+                    IN_MEMORY_PROMPT_REGISTRY.remove_prompt(prompt_id=deleted_prompt_id)
         except Exception as e:
             verbose_proxy_logger.debug("litellm.proxy.proxy_server.py::ProxyConfig:_init_prompts_in_db - %s", e)
 

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -7269,6 +7269,7 @@ class ProxyConfig:
                 return None
 
         try:
+            prompt_ids_loaded_before_db_read: Final = frozenset(IN_MEMORY_PROMPT_REGISTRY.IN_MEMORY_PROMPTS)
             prompts_in_db: Final[Sequence[object]] = await PromptRepository(prisma_client).table.find_many()
             parsed_specs: Final[tuple[PromptSpec, ...]] = tuple(
                 spec for row in prompts_in_db if (spec := parse_row(row)) is not None
@@ -7296,8 +7297,10 @@ class ProxyConfig:
             if every_row_parsed:
                 deleted_db_prompt_ids: Final = tuple(
                     prompt_id
-                    for prompt_id, spec in IN_MEMORY_PROMPT_REGISTRY.IN_MEMORY_PROMPTS.items()
-                    if spec.prompt_info.prompt_type == "db" and prompt_id not in newest_spec_per_id
+                    for prompt_id in prompt_ids_loaded_before_db_read
+                    if (loaded_spec := IN_MEMORY_PROMPT_REGISTRY.IN_MEMORY_PROMPTS.get(prompt_id)) is not None
+                    and loaded_spec.prompt_info.prompt_type == "db"
+                    and prompt_id not in newest_spec_per_id
                 )
                 for deleted_prompt_id in deleted_db_prompt_ids:
                     IN_MEMORY_PROMPT_REGISTRY.remove_prompt(prompt_id=deleted_prompt_id)

--- a/tests/test_litellm/proxy/prompts/test_prompt_endpoints_crud.py
+++ b/tests/test_litellm/proxy/prompts/test_prompt_endpoints_crud.py
@@ -79,7 +79,7 @@ async def test_delete_prompt_success():
 
             # 2. Memory deletion should use base ID
             mock_registry.delete_prompts_by_base_id.assert_called_once_with(
-                expected_base_id
+                expected_base_id, environment=None
             )
 
             assert response == {
@@ -150,12 +150,43 @@ async def test_delete_prompt_by_base_id_success():
 
             # 2. Memory deletion should use base ID
             mock_registry.delete_prompts_by_base_id.assert_called_once_with(
-                expected_base_id
+                expected_base_id, environment=None
             )
 
             assert response == {
                 "message": f"Prompt {expected_base_id} deleted successfully"
             }
+
+
+@pytest.mark.asyncio
+async def test_delete_prompt_environment_scope_reaches_db_and_registry():
+    from litellm.proxy.prompts.prompt_endpoints import delete_prompt
+
+    mock_user_auth = UserAPIKeyAuth(api_key="sk-1234", user_role=LitellmUserRoles.PROXY_ADMIN)
+    mock_prisma_client = MagicMock()
+    mock_prisma_client.db.litellm_prompttable.delete_many = AsyncMock(return_value=None)
+
+    with patch(  # test-quality-ok: stubs the collaborator so the test pins what the endpoint deletes
+        "litellm.proxy.prompts.prompt_registry.IN_MEMORY_PROMPT_REGISTRY"
+    ) as mock_registry:
+        mock_registry.get_prompt_by_id.return_value = PromptSpec(
+            prompt_id="test_prompt.v2",
+            litellm_params=PromptLiteLLMParams(prompt_id="test_prompt", prompt_integration="dotprompt"),
+            prompt_info=PromptInfo(prompt_type="db"),
+        )
+
+        with patch("litellm.proxy.proxy_server.prisma_client", mock_prisma_client):  # test-quality-ok: proxy_server module global is the endpoint's only injection point
+            response = await delete_prompt(
+                prompt_id="test_prompt.v2",
+                environment="production",
+                user_api_key_dict=mock_user_auth,
+            )
+
+    mock_prisma_client.db.litellm_prompttable.delete_many.assert_called_once_with(
+        where={"prompt_id": "test_prompt", "environment": "production"}
+    )
+    mock_registry.delete_prompts_by_base_id.assert_called_once_with("test_prompt", environment="production")
+    assert response == {"message": "Prompt test_prompt deleted successfully from production"}
 
 
 @pytest.mark.asyncio

--- a/tests/test_litellm/proxy/prompts/test_prompt_registry.py
+++ b/tests/test_litellm/proxy/prompts/test_prompt_registry.py
@@ -88,3 +88,55 @@ def test_reload_prompt_keeps_the_old_template_when_the_replacement_fails(isolate
     assert registry.get_prompt_callback_by_id("greeting.v1") is old_callback
     assert _served_content(registry) == "begin every reply with AHOY"
     assert isolated_callbacks == [old_callback]
+
+
+def _versioned_prompt_spec(version: int, environment: str) -> PromptSpec:
+    return PromptSpec(
+        prompt_id=f"greeting.v{version}",
+        litellm_params=PromptLiteLLMParams(
+            prompt_id="greeting",
+            prompt_integration="dotprompt",
+            prompt_data={"content": f"begin every reply with AHOY v{version}", "metadata": {}},
+        ),
+        prompt_info=PromptInfo(prompt_type="db", environment=environment),
+        version=version,
+        environment=environment,
+    )
+
+
+def test_delete_prompts_by_base_id_removes_the_callbacks_from_litellm_callbacks(isolated_callbacks: list) -> None:
+    registry = InMemoryPromptRegistry()
+    registry.initialize_prompt(prompt=_versioned_prompt_spec(1, "development"))
+    registry.initialize_prompt(prompt=_versioned_prompt_spec(2, "development"))
+    assert len(isolated_callbacks) == 1
+
+    deleted = registry.delete_prompts_by_base_id("greeting")
+
+    assert sorted(deleted) == ["greeting.v1", "greeting.v2"]
+    assert registry.get_prompt_by_id("greeting.v1") is None
+    assert registry.get_prompt_callback_by_id("greeting.v2") is None
+    assert isolated_callbacks == []
+
+
+def test_delete_prompts_by_base_id_environment_scope_keeps_other_environments(isolated_callbacks: list) -> None:
+    registry = InMemoryPromptRegistry()
+    registry.initialize_prompt(prompt=_versioned_prompt_spec(1, "development"))
+    registry.initialize_prompt(prompt=_versioned_prompt_spec(2, "production"))
+    production_callback = registry.get_prompt_callback_by_id("greeting.v2")
+
+    deleted = registry.delete_prompts_by_base_id("greeting", environment="development")
+
+    assert deleted == ["greeting.v1"]
+    assert registry.get_prompt_by_id("greeting.v1") is None
+    assert registry.get_prompt_by_id("greeting.v2") is not None
+    assert registry.get_prompt_callback_by_id("greeting.v2") is production_callback
+
+
+def test_remove_prompt_is_a_no_op_for_an_unknown_id(isolated_callbacks: list) -> None:
+    registry = InMemoryPromptRegistry()
+    registry.initialize_prompt(prompt=_versioned_prompt_spec(1, "development"))
+
+    registry.remove_prompt(prompt_id="not_there.v1")
+
+    assert registry.get_prompt_by_id("greeting.v1") is not None
+    assert len(isolated_callbacks) == 1

--- a/tests/test_litellm/proxy/test_proxy_server.py
+++ b/tests/test_litellm/proxy/test_proxy_server.py
@@ -11600,6 +11600,42 @@ async def test_init_prompts_in_db_keeps_the_in_memory_copy_when_a_row_fails_to_p
         IN_MEMORY_PROMPT_REGISTRY.delete_prompts_by_base_id("greeting_broken")
 
 
+@pytest.mark.asyncio
+async def test_init_prompts_in_db_keeps_a_prompt_created_while_the_sync_was_reading(monkeypatch):
+    from litellm.proxy.prompts.prompt_registry import IN_MEMORY_PROMPT_REGISTRY
+    from litellm.proxy.proxy_server import ProxyConfig
+    from litellm.types.prompts.init_prompts import PromptInfo, PromptLiteLLMParams, PromptSpec
+
+    monkeypatch.setattr(litellm, "callbacks", [])
+
+    prisma_client = MagicMock()
+    try:
+
+        async def create_prompt_behind_the_select() -> list:
+            IN_MEMORY_PROMPT_REGISTRY.initialize_prompt(
+                prompt=PromptSpec(
+                    prompt_id="greeting_race.v1",
+                    litellm_params=PromptLiteLLMParams(
+                        prompt_id="greeting_race",
+                        prompt_integration="dotprompt",
+                        prompt_data={"content": "Begin every reply with AHOY", "metadata": {}},
+                    ),
+                    prompt_info=PromptInfo(prompt_type="db"),
+                )
+            )
+            return []
+
+        prisma_client.db.litellm_prompttable.find_many = AsyncMock(side_effect=create_prompt_behind_the_select)
+        await ProxyConfig()._init_prompts_in_db(prisma_client=prisma_client)
+
+        surviving_callback = IN_MEMORY_PROMPT_REGISTRY.get_prompt_callback_by_id("greeting_race.v1")
+        assert IN_MEMORY_PROMPT_REGISTRY.get_prompt_by_id("greeting_race.v1") is not None
+        assert surviving_callback is not None
+        assert litellm.callbacks == [surviving_callback]
+    finally:
+        IN_MEMORY_PROMPT_REGISTRY.delete_prompts_by_base_id("greeting_race")
+
+
 class TestEmbeddingsFailureHookRequestData:
     @pytest.mark.asyncio
     async def test_failure_hook_gets_post_setup_data_with_logging_obj(self):

--- a/tests/test_litellm/proxy/test_proxy_server.py
+++ b/tests/test_litellm/proxy/test_proxy_server.py
@@ -11492,6 +11492,114 @@ async def test_init_prompts_in_db_serves_the_newest_row_when_environments_collid
         IN_MEMORY_PROMPT_REGISTRY.delete_prompts_by_base_id("greeting_env")
 
 
+def _prompt_db_row(prompt_id: str, litellm_params: str) -> MagicMock:
+    row = MagicMock()
+    row.model_dump.return_value = {
+        "prompt_id": prompt_id,
+        "version": 1,
+        "environment": "development",
+        "created_by": None,
+        "litellm_params": litellm_params,
+        "prompt_info": json.dumps({"prompt_type": "db"}),
+        "created_at": None,
+        "updated_at": None,
+    }
+    return row
+
+
+def _dotprompt_params(prompt_id: str) -> str:
+    return json.dumps(
+        {
+            "prompt_id": prompt_id,
+            "prompt_integration": "dotprompt",
+            "prompt_data": {"content": "Begin every reply with AHOY", "metadata": {}},
+        }
+    )
+
+
+@pytest.mark.asyncio
+async def test_init_prompts_in_db_unloads_rows_deleted_on_another_worker(monkeypatch):
+    from litellm.proxy.prompts.prompt_registry import IN_MEMORY_PROMPT_REGISTRY
+    from litellm.proxy.proxy_server import ProxyConfig
+
+    monkeypatch.setattr(litellm, "callbacks", [])
+
+    prisma_client = MagicMock()
+    try:
+        prisma_client.db.litellm_prompttable.find_many = AsyncMock(
+            return_value=[_prompt_db_row("greeting_del", _dotprompt_params("greeting_del"))]
+        )
+        await ProxyConfig()._init_prompts_in_db(prisma_client=prisma_client)
+        assert IN_MEMORY_PROMPT_REGISTRY.get_prompt_callback_by_id("greeting_del.v1") is not None
+
+        prisma_client.db.litellm_prompttable.find_many = AsyncMock(return_value=[])
+        await ProxyConfig()._init_prompts_in_db(prisma_client=prisma_client)
+
+        assert IN_MEMORY_PROMPT_REGISTRY.get_prompt_by_id("greeting_del.v1") is None
+        assert IN_MEMORY_PROMPT_REGISTRY.get_prompt_callback_by_id("greeting_del.v1") is None
+        assert litellm.callbacks == []
+    finally:
+        IN_MEMORY_PROMPT_REGISTRY.delete_prompts_by_base_id("greeting_del")
+
+
+@pytest.mark.asyncio
+async def test_init_prompts_in_db_keeps_config_prompts_when_their_id_has_no_db_row(monkeypatch):
+    from litellm.proxy.prompts.prompt_registry import IN_MEMORY_PROMPT_REGISTRY
+    from litellm.proxy.proxy_server import ProxyConfig
+    from litellm.types.prompts.init_prompts import PromptInfo, PromptLiteLLMParams, PromptSpec
+
+    monkeypatch.setattr(litellm, "callbacks", [])
+
+    config_prompt = PromptSpec(
+        prompt_id="greeting_cfg",
+        litellm_params=PromptLiteLLMParams(
+            prompt_id="greeting_cfg",
+            prompt_integration="dotprompt",
+            prompt_data={"content": "Begin every reply with AHOY", "metadata": {}},
+        ),
+        prompt_info=PromptInfo(prompt_type="config"),
+    )
+
+    prisma_client = MagicMock()
+    try:
+        IN_MEMORY_PROMPT_REGISTRY.initialize_prompt(prompt=config_prompt)
+        prisma_client.db.litellm_prompttable.find_many = AsyncMock(return_value=[])
+
+        await ProxyConfig()._init_prompts_in_db(prisma_client=prisma_client)
+
+        assert IN_MEMORY_PROMPT_REGISTRY.get_prompt_callback_by_id("greeting_cfg") is not None
+        assert len(litellm.callbacks) == 1
+    finally:
+        IN_MEMORY_PROMPT_REGISTRY.remove_prompt(prompt_id="greeting_cfg")
+
+
+@pytest.mark.asyncio
+async def test_init_prompts_in_db_keeps_the_in_memory_copy_when_a_row_fails_to_parse(monkeypatch):
+    from litellm.proxy.prompts.prompt_registry import IN_MEMORY_PROMPT_REGISTRY
+    from litellm.proxy.proxy_server import ProxyConfig
+
+    monkeypatch.setattr(litellm, "callbacks", [])
+
+    prisma_client = MagicMock()
+    try:
+        prisma_client.db.litellm_prompttable.find_many = AsyncMock(
+            return_value=[_prompt_db_row("greeting_broken", _dotprompt_params("greeting_broken"))]
+        )
+        await ProxyConfig()._init_prompts_in_db(prisma_client=prisma_client)
+        loaded_callback = IN_MEMORY_PROMPT_REGISTRY.get_prompt_callback_by_id("greeting_broken.v1")
+        assert loaded_callback is not None
+
+        prisma_client.db.litellm_prompttable.find_many = AsyncMock(
+            return_value=[_prompt_db_row("greeting_broken", "this is not json")]
+        )
+        await ProxyConfig()._init_prompts_in_db(prisma_client=prisma_client)
+
+        assert IN_MEMORY_PROMPT_REGISTRY.get_prompt_callback_by_id("greeting_broken.v1") is loaded_callback
+        assert litellm.callbacks == [loaded_callback]
+    finally:
+        IN_MEMORY_PROMPT_REGISTRY.delete_prompts_by_base_id("greeting_broken")
+
+
 class TestEmbeddingsFailureHookRequestData:
     @pytest.mark.asyncio
     async def test_failure_hook_gets_post_setup_data_with_logging_obj(self):


### PR DESCRIPTION
## TLDR

Problem this solves:

- DELETE /prompts/{id} unloaded the prompt only on the worker that served it
- Every other worker and pod kept serving the deleted prompt until restart
- The deleted prompt's callback also stayed registered forever

How it solves it:

- The periodic DB sync now unloads in-memory DB prompts whose rows are gone
- Registry deletion now also unregisters the prompt's callback
- Environment-scoped deletes go through the same registry path
- The sweep only touches prompts loaded before the sync's DB read, so a prompt created mid-sync survives (race found and regression-tested during QA)

The PATCH twin of this bug was fixed in #38411; this closes the DELETE half

## User Flow

Before: an admin deletes a prompt on a multi-worker deployment, but other workers and pods keep serving it indefinitely

1. The admin sends POST https://litellm-domain/prompts with a dotprompt template saying every reply must start with HOWDY, and gets back `greeting.v1`
2. Within ~30s every pod has it: GET https://litellm-domain/prompts/greeting/info returns the template everywhere, and developers' POST https://litellm-domain/v1/chat/completions with `"prompt_id": "greeting"` come back HOWDY-prefixed
3. The admin sends DELETE https://litellm-domain/prompts/greeting and gets back 200 "Prompt greeting deleted successfully"
4. Minutes later GET https://litellm-domain/prompts/greeting/info still returns the deleted template, and chat completions with `"prompt_id": "greeting"` still come back HOWDY-prefixed on every worker except the single one that served the DELETE; only a full restart clears the rest

After: the same DELETE reaches every worker and pod within one sync interval

1. The admin sends POST https://litellm-domain/prompts with a dotprompt template saying every reply must start with HOWDY, and gets back `greeting.v1`
2. Within ~30s every pod has it: GET https://litellm-domain/prompts/greeting/info returns the template everywhere, and developers' POST https://litellm-domain/v1/chat/completions with `"prompt_id": "greeting"` come back HOWDY-prefixed
3. The admin sends DELETE https://litellm-domain/prompts/greeting and gets back 200 "Prompt greeting deleted successfully"
4. Within ~30s GET https://litellm-domain/prompts/greeting/info returns 404 "Prompt greeting not found" on every pod, and chat completions with `"prompt_id": "greeting"` come back as plain replies with no HOWDY on every worker

## Relevant issues

## Linear ticket

Resolves LIT-6282

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Rig: two proxy instances (pods), each `--num_workers 1`, sharing one fresh Postgres per leg; model gpt-4o-mini (real OpenAI calls). Two dotprompt prompts: `greeting` ("Begin every reply with the single word HOWDY.", the one deleted) and `farewell` ("... CHEERIO.", a control that must survive). Instance A serves the POST and DELETE; instance B only ever learns about prompts from the DB. Probes cover chat completions with `prompt_id`, /v1/responses with `prompt_id`, and chat pinned to `"prompt_version": 1`. An earlier run of the same flow at 26b7bc3583 with 2 pods x 2 workers showed the same before/after; the sync loop runs per process, so worker and pod propagation are one code path

### Before (f677292901)

1. Create both prompts on instance A; after one sync interval both instances serve both, and all baseline probes obey them

```
$ curl -s http://127.0.0.1:48921/prompts -H 'Authorization: Bearer sk-lit6282' -H 'Content-Type: application/json' -d '{"prompt_id":"greeting","litellm_params":{"prompt_id":"greeting","prompt_integration":"dotprompt","prompt_data":{"content":"System: Begin every reply with the single word HOWDY.","metadata":{}}},"prompt_info":{"prompt_type":"db"}}' | jq -c '{prompt_id}'
{"prompt_id":"greeting.v1"}
[S1 round 1][A :48921] greeting chat="HOWDY! Greetings to you!"
[S1 round 1][B :48618] greeting chat="HOWDY, hello there!"
[S2][B :48618] responses="HOWDY, nice to meet!"
[S3][B :48618] pinned-v1 chat="HOWDY, greetings to you!"
```

2. Delete it on instance A

```
$ curl -s -X DELETE http://127.0.0.1:48921/prompts/greeting -H 'Authorization: Bearer sk-lit6282' | jq -c .
{"message":"Prompt greeting deleted successfully"}
```

3. 65s later (two full sync intervals) instance A's registry 404s it, yet A still templates with it (the stale callback survives), and instance B still serves it everywhere: info, list, chat, responses, pinned version

```
$ curl -s http://127.0.0.1:48921/prompts/greeting/info -H 'Authorization: Bearer sk-lit6282' | jq -c '{content: .prompt_spec.litellm_params.prompt_data.content, error: .detail}'
{"content":null,"error":"Prompt greeting not found"}
$ curl -s http://127.0.0.1:48618/prompts/greeting/info -H 'Authorization: Bearer sk-lit6282' | jq -c '{content: .prompt_spec.litellm_params.prompt_data.content, error: .detail}'
{"content":"System: Begin every reply with the single word HOWDY.","error":null}
$ curl -s http://127.0.0.1:48618/prompts/list -H 'Authorization: Bearer sk-lit6282' | jq -c '[.prompts[]?.prompt_id]'
["greeting","farewell"]
[S1 round 1][A :48921] greeting chat="HOWDY. Hello there, friend!"
[S1 round 1][B :48618] greeting chat="HOWDY! Hello there!"
[S2][A :48921] responses="HOWDY! Hi there, friend!"
[S2][B :48618] responses="HOWDY! Hey there, friend!"
[S3][A :48921] pinned-v1 chat="HOWDY. Hello there, friend!"
[S3][B :48618] pinned-v1 chat="HOWDY! Greetings to you!"
```

### After (4fd7b9946f)

1. Create both prompts on instance A; same baseline, all probes HOWDY/CHEERIO-prefixed on both instances

```
$ curl -s http://127.0.0.1:22611/prompts -H 'Authorization: Bearer sk-lit6282' -H 'Content-Type: application/json' -d '{"prompt_id":"greeting","litellm_params":{"prompt_id":"greeting","prompt_integration":"dotprompt","prompt_data":{"content":"System: Begin every reply with the single word HOWDY.","metadata":{}}},"prompt_info":{"prompt_type":"db"}}' | jq -c '{prompt_id}'
{"prompt_id":"greeting.v1"}
[S1 round 1][A :22611] greeting chat="HOWDY! Greetings to you!"
[S1 round 1][B :29911] greeting chat="HOWDY! Greetings to you!"
[S2][B :29911] responses="HOWDY! Hello there, friend!"
[S3][B :29911] pinned-v1 chat="HOWDY, greetings to you!"
```

2. Delete it on instance A

```
$ curl -s -X DELETE http://127.0.0.1:22611/prompts/greeting -H 'Authorization: Bearer sk-lit6282' | jq -c .
{"message":"Prompt greeting deleted successfully"}
```

3. 65s later BOTH instances 404 it, the list shows only the control prompt, and every probe surface comes back plain (no HOWDY) while `farewell` still answers CHEERIO on both instances

```
$ curl -s http://127.0.0.1:22611/prompts/greeting/info -H 'Authorization: Bearer sk-lit6282' | jq -c '{content: .prompt_spec.litellm_params.prompt_data.content, error: .detail}'
{"content":null,"error":"Prompt greeting not found"}
$ curl -s http://127.0.0.1:29911/prompts/greeting/info -H 'Authorization: Bearer sk-lit6282' | jq -c '{content: .prompt_spec.litellm_params.prompt_data.content, error: .detail}'
{"content":null,"error":"Prompt greeting not found"}
$ curl -s http://127.0.0.1:29911/prompts/list -H 'Authorization: Bearer sk-lit6282' | jq -c '[.prompts[]?.prompt_id]'
["farewell"]
[S1 round 1][A :22611] greeting chat="Hello! How are you?"
[S1 round 1][A :22611] farewell chat="CHEERIO. Hello there, friend!"
[S1 round 1][B :29911] greeting chat="Hello, nice to meet!"
[S1 round 1][B :29911] farewell chat="CHEERIO! Hello there, friend!"
[S2][A :22611] responses="Hello, nice to meet!"
[S2][B :29911] responses="Hello, how are you?"
[S3][A :22611] pinned-v1 chat="Hello, how are you?"
[S3][B :29911] pinned-v1 chat="Hello, nice to meet!"
```

## Type

🐛 Bug Fix

## Caveats (if any)

### Low

- Deletes reach other workers on the next periodic sync, default 30s
- The sweep pauses while any DB prompt row fails to parse
- A DELETE that races an in-flight sync on the same worker can bring the prompt back for one interval; the next sweep removes it

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

- [x] 4fd7b9946f passes /live-pr-risk
