### PR TITLE
test(e2e): un-skip the per-model budget update case

### DIFF
--- a/tests/e2e/management/test_budget_customer_user_org_e2e.py
+++ b/tests/e2e/management/test_budget_customer_user_org_e2e.py
@@ -163,12 +163,6 @@ class TestBudgetManagement:
             f"/budget/list never included the created budget {budget_id}",
         )
 
-    @pytest.mark.skip(
-        reason=(
-            "stage red: product gap, /budget/update 500s on any model_max_budget "
-            "(prisma Json arg + unquoted GraphQL interpolation)"
-        )
-    )
     @pytest.mark.covers("mgmt.budget.update.accepts_model_max_budget")
     def test_update_accepts_per_model_budgets_including_punctuated_names(
         self, client: ManagementClient, resources: ResourceManager


### PR DESCRIPTION
## TLDR

Problem this solves:

- An e2e case sat skipped for a bug that is now fixed
- Per-model budget updates have no live coverage while it stays skipped

How it solves it:

- Drop the skip so the case runs again
- Depends on #38430; merge that first

## User Flow

No behavior change for anyone using the proxy. This restores the live coverage that guards the flow #38430 fixes.

Before: an admin can set per-model spend caps on an existing budget, and nothing in the e2e suite would catch it if that broke again

1. They send POST https://litellm-domain/budget/new with `{"budget_id": "team-a", "max_budget": 5.5}` and get back 200
2. They send POST https://litellm-domain/budget/update with `{"budget_id": "team-a", "model_max_budget": {"gpt4o": {"budget_limit": 5.0, "time_period": "1d"}}}` and get back 200
3. POST https://litellm-domain/budget/info shows the caps stored
4. A future change that breaks step 2 ships without the suite going red, because the case that covers it is skipped

After: the same flow, now guarded

1. Steps 1 to 3 are unchanged and still succeed
2. A future change that breaks step 2 turns the e2e suite red instead of reaching a customer

## Relevant issues

Depends on #38430

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Run against a local proxy on port 4001 with a database and an enterprise license, driving the real e2e case. The same command runs on both sides.

```bash
LITELLM_PROXY_URL=http://localhost:4001 LITELLM_MASTER_KEY=$MK \
  uv run pytest "tests/e2e/management/test_budget_customer_user_org_e2e.py::TestBudgetManagement::test_update_accepts_per_model_budgets_including_punctuated_names" -q
```

### Before (77765fd302)

1. The case is skipped, so it asserts nothing

```
1 skipped in 0.05s
```

2. With the skip removed but the proxy still on staging, the case fails with the 500 it was skipped for

```
E       AssertionError: /budget/update rejected a per-model budget for 'gpt4o': kind='unknown' status_code=500 body='{"error":{"message":"Internal server error","type":"internal_server_error"}}'; a customer cannot cap spend per model on an existing budget
1 failed, 1 rerun in 1.48s
```

### After (4f56e8a7d500019c564ccab9eb11d556d0c6ed5e)

1. Same case, same command, against a proxy carrying #38430

```
.                                                                        [100%]
1 passed in 1.70s
```

## Type

✅ Test

## Caveats (if any)

### High

- Red until #38430 merges; the case needs that fix

## QA runbook

- tests/e2e/management/test_budget_customer_user_org_e2e.py::TestBudgetManagement::test_update_accepts_per_model_budgets_including_punctuated_names - per-model spend caps can be set on an existing budget, for a plain model id and one carrying punctuation
  - [ ] Needs an enterprise license on the proxy, since `model_max_budget` is gated behind one
  - [ ] Create a budget: curl -X POST http://localhost:4000/budget/new -H "Authorization: Bearer sk-1234" -H 'Content-Type: application/json' -d '{"budget_id":"qa-1","max_budget":5.5}'
  - [ ] Set a cap for a plain model id: curl -X POST http://localhost:4000/budget/update -H "Authorization: Bearer sk-1234" -H 'Content-Type: application/json' -d '{"budget_id":"qa-1","model_max_budget":{"gpt4o":{"budget_limit":5.0,"time_period":"1d"}}}' and expect 200
  - [ ] Read it back: curl -X POST http://localhost:4000/budget/info -H "Authorization: Bearer sk-1234" -H 'Content-Type: application/json' -d '{"budgets":["qa-1"]}' and expect model_max_budget to carry gpt4o with max_budget 5.0 and budget_duration 1d
  - [ ] Repeat both steps on a fresh budget with the punctuated id glm-5.2 and expect the same 200 and the same round trip
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey (e.g., assert actual expected spend instead of just spend > 0) or potentially flaky

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
