### PR TITLE
fix(snowflake): reject invalid Claude tool_choice strings

### DIFF
--- a/litellm/llms/snowflake/chat/transformation.py
+++ b/litellm/llms/snowflake/chat/transformation.py
@@ -322,7 +322,12 @@ class SnowflakeConfig(SnowflakeBaseConfig, OpenAIGPTConfig):
                 "required": {"type": "any"},
                 "none": {"type": "none"},
             }
-            return mapping.get(tool_choice, {"type": "auto"})
+            if tool_choice not in mapping:
+                raise ValueError(
+                    "Unsupported tool_choice value for Snowflake Claude model: "
+                    f"{tool_choice!r}. Expected one of: auto, required, none."
+                )
+            return mapping[tool_choice]
         elif isinstance(tool_choice, dict):
             if tool_choice.get("type") == "function":
                 func: Final = tool_choice.get("function", {})

--- a/tests/test_litellm/llms/snowflake/chat/test_snowflake_chat_transformation.py
+++ b/tests/test_litellm/llms/snowflake/chat/test_snowflake_chat_transformation.py
@@ -118,6 +118,21 @@ class TestSnowflakeToolTransformation:
                 f"got {transformed_request['tool_choice']}"
             )
 
+    def test_claude_rejects_invalid_string_tool_choice(self):
+        """
+        Test that invalid string tool_choice values are not silently downgraded to auto.
+        """
+        config = SnowflakeConfig()
+
+        with pytest.raises(ValueError, match="Unsupported tool_choice value"):
+            config.transform_request(
+                model="snowflake/claude-sonnet-4-5",
+                messages=[{"role": "user", "content": "Test"}],
+                optional_params={"tool_choice": "requried"},
+                litellm_params={},
+                headers={},
+            )
+
     def test_transform_response_with_tool_calls(self):
         """
         Test that standard OpenAI tool_calls response format is parsed correctly.


### PR DESCRIPTION
## TLDR

Problem this solves:

- Snowflake Claude silently changed invalid `tool_choice` strings to auto.
- Typos like `requried` made required tool use optional.

How it solves it:

- Rejects unsupported string values during Snowflake Claude request transformation.
- Adds an offline regression test for invalid string values.

## User Flow

Before: a developer forcing Snowflake Claude tool use can accidentally get optional tool use instead.

1. They send POST https://litellm-domain/v1/chat/completions with model `snowflake/claude-sonnet-4-5` and `"tool_choice": "requried"`.
2. The request is sent upstream with `"tool_choice": {"type": "auto"}`.
3. Snowflake Claude may answer without calling a tool, even though the developer intended required tool use.

After: the same invalid request fails early instead of changing semantics.

1. They send POST https://litellm-domain/v1/chat/completions with model `snowflake/claude-sonnet-4-5` and `"tool_choice": "requried"`.
2. LiteLLM raises an unsupported `tool_choice` value error before sending the request upstream.
3. The developer can correct the typo to `"required"` and get required tool use.

## Relevant issues

Fixes #38372

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

### Before (d8595cb647328a7384bbbb4cb4bfc8a0f51a0c29)

1. Command: `python -m pytest tests\test_litellm\llms\snowflake\chat\test_snowflake_chat_transformation.py::TestSnowflakeToolTransformation::test_claude_rejects_invalid_string_tool_choice -q`
2. Observed output: `Failed: DID NOT RAISE <class 'ValueError'>`

### After (6f4fbe412120eaf402d73aec84453f5992ce0aca)

1. Command: `python -m pytest tests\test_litellm\llms\snowflake\chat\test_snowflake_chat_transformation.py tests\test_litellm\llms\snowflake\test_snowflake_native_endpoints.py -q`
2. Observed output: `53 passed in 8.48s`

## Type

?? Bug Fix

## Caveats (if any)

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
