### PR TITLE
fix(ui): show custom technical keywords on every router whose scorer runs

### DIFF
--- a/ui/litellm-dashboard/src/components/add_model/ClassificationMethodConfig.tsx
+++ b/ui/litellm-dashboard/src/components/add_model/ClassificationMethodConfig.tsx
@@ -27,6 +27,7 @@ import {
   CLASSIFICATION_RUBRIC_KEYS,
   ClassificationRubric,
   effectiveTierLabel,
+  heuristicScoringRole,
   usesLlmClassifier,
   DEFAULT_HEURISTIC_FIRST_MAX_TIER,
   HEURISTIC_FIRST_MAX_TIER_KEYS,
@@ -502,7 +503,7 @@ const ClassificationMethodConfig: React.FC<ClassificationMethodConfigProps> = ({
         </div>
       )}
 
-      {value.classifier_type === "heuristic" && (
+      {heuristicScoringRole(value) !== "never" && (
         <div className="mt-4">
           <div className="flex items-center gap-2 mb-1">
             <strong className="font-semibold">Custom Technical Keywords</strong>

--- a/ui/litellm-dashboard/src/components/add_model/ComplexityRouterConfig.test.tsx
+++ b/ui/litellm-dashboard/src/components/add_model/ComplexityRouterConfig.test.tsx
@@ -1012,3 +1012,49 @@ describe("ComplexityRouterConfig per-model effort filtering", () => {
     );
   });
 });
+
+describe("ComplexityRouterConfig custom technical keywords", () => {
+  // The keywords feed the scorer's technical dimension, so the control belongs on every router whose
+  // scorer runs, which is the same question HeuristicScoringConfig asks right below it.
+  const openClassificationPanel = (value: ComplexityRouterConfigValue) => {
+    renderWithProviders(<ComplexityRouterConfig modelInfo={mockModelInfo} value={value} onChange={vi.fn()} />);
+    fireEvent.click(screen.getByText("Advanced: Classification Method"));
+  };
+
+  const llmConfig = { model: "gpt-3.5-turbo", timeout_ms: 3000 };
+
+  it.each([
+    ["heuristic", { ...defaultValue, classifier_type: "heuristic" as const }],
+    [
+      "heuristic_first",
+      {
+        ...defaultValue,
+        classifier_type: "heuristic_first" as const,
+        heuristic_first_max_tier: "SIMPLE",
+        classifier_llm_config: llmConfig,
+      },
+    ],
+    [
+      "llm falling back to the scorer",
+      {
+        ...defaultValue,
+        classifier_type: "llm" as const,
+        classifier_llm_config: llmConfig,
+        classifier_fallback: "heuristic" as const,
+      },
+    ],
+  ])("offers the keywords on a router whose scorer runs: %s", (_label, value) => {
+    openClassificationPanel(value);
+    expect(screen.getByText("Custom Technical Keywords")).toBeInTheDocument();
+  });
+
+  it("hides the keywords when the scorer never runs, so they cannot imply an effect they have none", () => {
+    openClassificationPanel({
+      ...defaultValue,
+      classifier_type: "llm",
+      classifier_llm_config: llmConfig,
+      classifier_fallback: "default_model",
+    });
+    expect(screen.queryByText("Custom Technical Keywords")).not.toBeInTheDocument();
+  });
+});

--- a/ui/litellm-dashboard/src/components/add_model/ComplexityRouterConfig.test.tsx
+++ b/ui/litellm-dashboard/src/components/add_model/ComplexityRouterConfig.test.tsx
@@ -1014,8 +1014,6 @@ describe("ComplexityRouterConfig per-model effort filtering", () => {
 });
 
 describe("ComplexityRouterConfig custom technical keywords", () => {
-  // The keywords feed the scorer's technical dimension, so the control belongs on every router whose
-  // scorer runs, which is the same question HeuristicScoringConfig asks right below it.
   const openClassificationPanel = (value: ComplexityRouterConfigValue) => {
     renderWithProviders(<ComplexityRouterConfig modelInfo={mockModelInfo} value={value} onChange={vi.fn()} />);
     fireEvent.click(screen.getByText("Advanced: Classification Method"));


### PR DESCRIPTION
## TLDR

Problem this solves:

- Custom technical keywords change tier decisions on any scoring router
- The control only rendered for `classifier_type: heuristic`
- So operators could not see or set them on two other router shapes

How it solves it:

- Gate the control on the same predicate the scoring knobs below it use
- One line, and it deletes a divergent second answer to one question

## User Flow

Before: an operator running an LLM classifier on its default fallback tunes the scorer's boundaries, but cannot see the keyword list that feeds it

1. They open https://litellm-domain/ui/models-and-endpoints, Auto-Routers, Add Auto Router
2. They expand Detailed Configuration, then Advanced: Classification Method
3. They pick "LLM Classifier" and leave the fallback on "Score with the heuristic", which is the default
4. The tier boundaries, dimension weights and token thresholds are all editable, so the scorer clearly matters on this router
5. "Custom Technical Keywords" is absent from the form, and no wording explains why. The keywords still take effect if they were set in `config.yaml`, so the page disagrees with the running config

After: the keyword control appears wherever the scorer runs, matching the knobs beside it

1. Same steps 1 to 3
2. "Custom Technical Keywords" now renders alongside the boundaries and weights, and accepts terms like `kafka`, `terraform`
3. Picking "Heuristic first" shows it too, which matters because that router scores every request to decide whether to skip the classifier
4. Only when the fallback is switched to "Route to the default model", where the scorer never runs, does the control disappear along with the other scorer knobs

## Relevant issues

- Follow-up to #38428, which added `classifier_type: heuristic_first`. The gap predates it: the same control was already hidden for an LLM classifier on its default heuristic fallback

## Linear ticket

Resolves LIT-6301

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally
- [x] My PR passes all required CI/CD checks
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review
- [x] 8aafe8555b passes /live-pr-risk

## Screenshots / Proof of Fix

UI-only change, QA'd against a live proxy on `localhost:30896` running `dev_config.yaml` with the dashboard dev server on `localhost:3000`, the worktree checked out at the merge base for Before and at the tip for After. Shared steps for every case: open http://localhost:3000/models-and-endpoints, Auto-Routers, Add Auto Router, set Default Model to `gpt-4o` so every fallback option is selectable, expand Detailed Configuration, then Advanced: Classification Method, and read whether "Custom Technical Keywords" renders

The four router shapes and whether the scorer runs on them:

| classifier_type | scorer runs | keywords control before | after |
|---|---|---|---|
| `heuristic` | yes | shown | shown |
| `heuristic_first` | yes, on every request | hidden | shown |
| `llm` + heuristic fallback (default) | yes, when the call fails | hidden | shown |
| `llm` + default_model fallback | no | hidden | hidden |

### Before (587f227b9d)

#### Heuristic

1. Select "Heuristic"
2. Observed: "Custom Technical Keywords" renders directly under the classification method radios

#### Heuristic first

1. Select "Heuristic first"
2. Observed: the classifier settings and the Advanced scoring section all render, but "Custom Technical Keywords" is nowhere in the panel

#### LLM Classifier, heuristic fallback

1. Select "LLM Classifier" and leave "If the classifier fails" on "Score with the heuristic", the default
2. Observed: the panel jumps from "Include Assistant Turns" straight to Advanced scoring, with no "Custom Technical Keywords" anywhere

#### LLM Classifier, default model fallback

1. Select "LLM Classifier", then "Route to the default model (gpt-4o)"
2. Observed: no "Custom Technical Keywords", matching the other scorer knobs which are hidden too

### After (8aafe8555b)

#### Heuristic

1. Select "Heuristic"
2. Observed: "Custom Technical Keywords" renders directly under the classification method radios, as before

#### Heuristic first

1. Select "Heuristic first"
2. Observed: "Custom Technical Keywords" now renders with the scorer's other settings, above Advanced scoring

#### LLM Classifier, heuristic fallback

1. Select "LLM Classifier" and leave "If the classifier fails" on "Score with the heuristic", the default
2. Observed: "Custom Technical Keywords" now renders between "Include Assistant Turns" and Advanced scoring

#### LLM Classifier, default model fallback

1. Select "LLM Classifier", then "Route to the default model (gpt-4o)"
2. Observed: "Custom Technical Keywords" stays hidden, since the scorer never runs on this shape

## Type

🐛 Bug Fix

## Caveats (if any)

### Low

- The payload builder and the backend already handled this correctly. `custom_technical_keywords` is emitted ungated by `buildComplexityRouterConfig`, and the scorer builds `self.technical_keywords` from it regardless of classifier type, so this was purely the form hiding a field that was always live

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dashboard form visibility only; keyword payload and backend scoring behavior were already correct.
> 
> **Overview**
> **Custom Technical Keywords** in Advanced: Classification Method now appears whenever the heuristic scorer can run, not only when `classifier_type` is **heuristic**.
> 
> The visibility gate matches **`heuristicScoringRole`** (same as **HeuristicScoringConfig**): keywords show for **heuristic**, **heuristic_first**, and **LLM** with the default **Score with the heuristic** fallback. They stay hidden when the classifier fails to **Route to the default model**, where the scorer never runs.
> 
> Tests cover those three scoring shapes and the **default_model** fallback case where the control must not appear.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 89673e64ba29521def7d15e55ed11673fbac2775. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
