### PR TITLE
fix(ui): carry a preset's per-tier litellm_params through the prefill

### DIFF
--- a/ui/litellm-dashboard/src/lib/autorouter_presets.test.ts
+++ b/ui/litellm-dashboard/src/lib/autorouter_presets.test.ts
@@ -604,6 +604,28 @@ describe("autorouter_presets", () => {
       });
     });
 
+    // Two spellings of one model in a tier collapse to a single registered key, and one model can
+    // only hold one param set downstream. Merging keeps whatever only one spelling set instead of
+    // dropping that spelling's params wholesale.
+    it("merges rather than drops params when two spellings resolve to the same registered model", () => {
+      const config = {
+        tiers: { SIMPLE: [], MEDIUM: [], COMPLEX: [], REASONING: ["claude-sonnet-4-5", "claude-sonnet-4.5"] },
+        tier_model_configs: {
+          REASONING: [
+            { model_name: "claude-sonnet-4-5", litellm_params: { reasoning_effort: "high", temperature: 0.2 } },
+            { model_name: "claude-sonnet-4.5", litellm_params: { reasoning_effort: "low" } },
+          ],
+        },
+        classifier_type: "heuristic" as const,
+      };
+      const prefill = buildPresetPrefill(config, groupsOnly(["claude-sonnet-4.5"]));
+      // temperature survives from the spelling that would otherwise have been overwritten;
+      // reasoning_effort, set by both, resolves last-wins.
+      expect(prefill.complexityRouterConfig.tier_model_params).toEqual({
+        REASONING: { "claude-sonnet-4.5": { reasoning_effort: "low", temperature: 0.2 } },
+      });
+    });
+
     it("leaves tier_model_params undefined for a preset that carries no per-model params", () => {
       const config = {
         tiers: { SIMPLE: ["gpt-5-nano"], MEDIUM: [], COMPLEX: [], REASONING: [] },

--- a/ui/litellm-dashboard/src/lib/autorouter_presets.test.ts
+++ b/ui/litellm-dashboard/src/lib/autorouter_presets.test.ts
@@ -11,6 +11,7 @@ import {
   buildPresetPrefill,
   buildModelAvailability,
   deploymentRefsFromModelInfo,
+  normalizeModelName,
 } from "./autorouter_presets";
 import { DEFAULT_MATCH_THRESHOLD } from "@/components/add_model/SemanticKeywordMatching";
 import { DEFAULT_ESCALATION_KEYWORDS } from "@/components/add_model/EscalationKeywords";
@@ -25,6 +26,29 @@ describe("autorouter_presets", () => {
     for (const p of presets) {
       expect(p).toMatchObject({ key: expect.any(String), label: expect.any(String), description: expect.any(String) });
       expect(p.complexity_router_config.tiers).toBeTruthy();
+    }
+  });
+
+  // buildPresetPrefill resolves every model reference through normalizeModelName, so two spellings
+  // of the same model in one tier (e.g. "claude-sonnet-4-5" and "claude-sonnet-4.5") collapse to one
+  // key. For tier_model_configs that silently drops one model's litellm_params; catch it in the
+  // bundled data itself, since nothing else validates preset authoring.
+  it("never spells the same model two ways within a single tier", () => {
+    for (const preset of getAllPresets()) {
+      const { tiers, tier_model_configs: configs } = preset.complexity_router_config;
+      for (const tier of Object.keys(tiers) as (keyof typeof tiers)[]) {
+        const fromTierList = tiers[tier] ?? [];
+        const fromConfigs = (configs?.[tier] ?? []).map((entry) => entry.model_name);
+        const names = new Set([...fromTierList, ...fromConfigs]);
+        const byNormalized = new Map<string, string[]>();
+        for (const name of names) {
+          const key = normalizeModelName(name);
+          byNormalized.set(key, [...(byNormalized.get(key) ?? []), name]);
+        }
+        for (const spellings of byNormalized.values()) {
+          expect(new Set(spellings).size, `${preset.key}.${tier}: ${spellings.join(", ")}`).toBe(1);
+        }
+      }
     }
   });
 

--- a/ui/litellm-dashboard/src/lib/autorouter_presets.test.ts
+++ b/ui/litellm-dashboard/src/lib/autorouter_presets.test.ts
@@ -544,5 +544,51 @@ describe("autorouter_presets", () => {
       const prefill = buildPresetPrefill(config, groupsOnly(["claude-sonnet-4.5"]));
       expect(prefill.complexityRouterConfig.tiers.SIMPLE).toEqual(["claude-sonnet-4.5"]);
     });
+
+    it("prefills the per-model litellm_params a preset carries in tier_model_configs", () => {
+      const config = {
+        tiers: { SIMPLE: ["gpt-5-nano"], MEDIUM: [], COMPLEX: [], REASONING: ["o3"] },
+        tier_model_configs: {
+          REASONING: [{ model_name: "o3", litellm_params: { reasoning_effort: "high" } }],
+        },
+        classifier_type: "heuristic" as const,
+        session_affinity: false,
+        deployment_affinity: true,
+      };
+      const prefill = buildPresetPrefill(config, groupsOnly(["gpt-5-nano", "o3"]));
+      expect(prefill.complexityRouterConfig.tier_model_params).toEqual({
+        REASONING: { o3: { reasoning_effort: "high" } },
+      });
+    });
+
+    // The params key on the preset's own spelling while the tier entry gets rewritten to the
+    // caller's. Leaving the key alone names a model the tier no longer holds, and
+    // serializeTierModelConfigs then drops the params on submit without saying so.
+    it("rewrites a param key to the same registered spelling its tier entry was rewritten to", () => {
+      const config = {
+        tiers: { SIMPLE: [], MEDIUM: [], COMPLEX: [], REASONING: ["claude-sonnet-4-5"] },
+        tier_model_configs: {
+          REASONING: [{ model_name: "claude-sonnet-4-5", litellm_params: { reasoning_effort: "high" } }],
+        },
+        classifier_type: "heuristic" as const,
+        session_affinity: false,
+        deployment_affinity: true,
+      };
+      const prefill = buildPresetPrefill(config, groupsOnly(["claude-sonnet-4.5"]));
+      expect(prefill.complexityRouterConfig.tier_model_params).toEqual({
+        REASONING: { "claude-sonnet-4.5": { reasoning_effort: "high" } },
+      });
+    });
+
+    it("leaves tier_model_params undefined for a preset that carries no per-model params", () => {
+      const config = {
+        tiers: { SIMPLE: ["gpt-5-nano"], MEDIUM: [], COMPLEX: [], REASONING: [] },
+        classifier_type: "heuristic" as const,
+        session_affinity: false,
+        deployment_affinity: true,
+      };
+      const prefill = buildPresetPrefill(config, groupsOnly(["gpt-5-nano"]));
+      expect(prefill.complexityRouterConfig.tier_model_params).toBeUndefined();
+    });
   });
 });

--- a/ui/litellm-dashboard/src/lib/autorouter_presets.ts
+++ b/ui/litellm-dashboard/src/lib/autorouter_presets.ts
@@ -55,7 +55,7 @@ export const getRequiredModels = (
 // differing only in that separator. Canonicalizing on "-" (the presets' own convention) lets both
 // spellings match without doing anything looser - two DIFFERENT model names never collide here,
 // only the punctuation within one version number does.
-const normalizeModelName = (model: string): string => model.replace(/(\d)\.(\d)/g, "$1-$2");
+export const normalizeModelName = (model: string): string => model.replace(/(\d)\.(\d)/g, "$1-$2");
 
 export interface DeploymentModelRef {
   modelGroup: string;

--- a/ui/litellm-dashboard/src/lib/autorouter_presets.ts
+++ b/ui/litellm-dashboard/src/lib/autorouter_presets.ts
@@ -12,7 +12,11 @@ import {
 } from "@/components/add_model/ComplexityRouterConfig";
 import { KeywordTierRule } from "@/components/add_model/KeywordTierRules";
 import { hydrateKeywordTierRules } from "@/components/add_model/complexity_router_keywords";
-import { TierModelParamsByTier, hydrateTierModelParams } from "@/components/add_model/complexity_router_tiers";
+import {
+  TierModelParams,
+  TierModelParamsByTier,
+  hydrateTierModelParams,
+} from "@/components/add_model/complexity_router_tiers";
 import { DEFAULT_ESCALATION_KEYWORDS } from "@/components/add_model/EscalationKeywords";
 import { DEFAULT_MATCH_THRESHOLD } from "@/components/add_model/SemanticKeywordMatching";
 import presetsRaw from "@/autorouter_presets.json";
@@ -248,12 +252,20 @@ export const buildPresetPrefill = (
   // Params key on the model name the preset spells while every tier entry is rewritten to the
   // caller's registered spelling, so the keys have to be rewritten the same way. Otherwise
   // serializeTierModelConfigs drops them for naming a model the tier no longer holds.
+  //
+  // Two spellings in one tier can resolve to the same registered model, and one model holds one
+  // param set here and in the payload, so a collision has to collapse. Merge rather than replace:
+  // params only one spelling set still survive, and a key both set resolves last-wins, matching
+  // how hydrateTierModelParams already collapses two entries spelled identically.
   const resolveParamKeys = (params: TierModelParamsByTier | undefined): TierModelParamsByTier | undefined =>
     params &&
     Object.fromEntries(
       Object.entries(params).map(([tier, byModel]) => [
         tier,
-        Object.fromEntries(Object.entries(byModel).map(([model, litellmParams]) => [resolve(model), litellmParams])),
+        Object.entries(byModel).reduce<Record<string, TierModelParams>>((byResolved, [model, litellmParams]) => {
+          const resolved = resolve(model);
+          return { ...byResolved, [resolved]: { ...byResolved[resolved], ...litellmParams } };
+        }, {}),
       ]),
     );
 

--- a/ui/litellm-dashboard/src/lib/autorouter_presets.ts
+++ b/ui/litellm-dashboard/src/lib/autorouter_presets.ts
@@ -12,6 +12,7 @@ import {
 } from "@/components/add_model/ComplexityRouterConfig";
 import { KeywordTierRule } from "@/components/add_model/KeywordTierRules";
 import { hydrateKeywordTierRules } from "@/components/add_model/complexity_router_keywords";
+import { TierModelParamsByTier, hydrateTierModelParams } from "@/components/add_model/complexity_router_tiers";
 import { DEFAULT_ESCALATION_KEYWORDS } from "@/components/add_model/EscalationKeywords";
 import { DEFAULT_MATCH_THRESHOLD } from "@/components/add_model/SemanticKeywordMatching";
 import presetsRaw from "@/autorouter_presets.json";
@@ -244,6 +245,17 @@ export const buildPresetPrefill = (
 ): PresetPrefill => {
   const resolve = (model: string): string => resolveAvailableModel(model, availability) ?? model;
   const resolveTier = (models: string[]): string[] => models.map(resolve);
+  // Params key on the model name the preset spells while every tier entry is rewritten to the
+  // caller's registered spelling, so the keys have to be rewritten the same way. Otherwise
+  // serializeTierModelConfigs drops them for naming a model the tier no longer holds.
+  const resolveParamKeys = (params: TierModelParamsByTier | undefined): TierModelParamsByTier | undefined =>
+    params &&
+    Object.fromEntries(
+      Object.entries(params).map(([tier, byModel]) => [
+        tier,
+        Object.fromEntries(Object.entries(byModel).map(([model, litellmParams]) => [resolve(model), litellmParams])),
+      ]),
+    );
 
   return {
     complexityRouterConfig: {
@@ -253,6 +265,7 @@ export const buildPresetPrefill = (
         COMPLEX: resolveTier(config.tiers.COMPLEX),
         REASONING: resolveTier(config.tiers.REASONING),
       },
+      tier_model_params: resolveParamKeys(hydrateTierModelParams(config.tiers, config.tier_model_configs)),
       tier_labels: hydrateTierLabels(config.tier_labels),
       classifier_type: config.classifier_type,
       classifier_llm_config: config.classifier_llm_config && {


### PR DESCRIPTION
## TLDR

Problem this solves:

- A preset's per-model `litellm_params` never reach the create form
- Picking such a preset silently loses `reasoning_effort` and friends
- Params key on the preset's model spelling, not the caller's

How it solves it:

- Prefill now emits `tier_model_params` from the preset config
- Param keys resolve to the caller's registered model names
- Two spellings resolving to one model merge instead of dropping one

## User Flow

Before: an admin who picks a preset that sets a per-tier reasoning effort ends up with a router that has no reasoning effort anywhere

1. They open http://localhost:3000/ui/?page=llm-model-hub, click Add Model, then the Auto Router tab
2. They pick a preset whose REASONING tier is meant to run at high reasoning effort
3. The tiers fill in with the right models, and the per-model settings under REASONING are empty
4. They name the router and save it
5. They reopen the router from the model list, and the REASONING model still shows no reasoning effort
6. Requests that route to REASONING run at the model's default effort instead of the preset's

After: the same preset carries its reasoning effort all the way into the saved router

1. They open http://localhost:3000/ui/?page=llm-model-hub, click Add Model, then the Auto Router tab
2. They pick the same preset
3. The tiers fill in with the right models, and the REASONING model shows reasoning effort set to high
4. They name the router and save it
5. They reopen the router from the model list, and the setting is still there
6. Requests that route to REASONING run at high reasoning effort

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

No bundled preset ships per-tier `litellm_params` yet, so reproducing this needs a preset that carries some. Add one locally and don't commit it: in `ui/litellm-dashboard/src/autorouter_presets.json`, inside the `anthropic_family` preset's `complexity_router_config`, add a sibling key to `tiers`:

```json
"tier_model_configs": {
  "REASONING": [{ "model_name": "claude-fable-5", "litellm_params": { "reasoning_effort": "high" } }]
}
```

Shared setup, run once:

1. Start the proxy: `python litellm/proxy/proxy_cli.py --config litellm/proxy/dev_config.yaml --detailed_debug --reload --use_v2_migration_resolver 2>&1 | tee litellm.log`
2. Start the dashboard: `npm run dev` in `ui/litellm-dashboard`
3. Register `claude-haiku-4-5`, `claude-sonnet-5`, `claude-opus-5`, and `claude-fable-5` as model groups if they aren't already, so every model the preset names resolves

### Before (02035120e44cc127c5d7fd77ed8e3208aa460659)

1. Open http://localhost:3000/ui/?page=llm-model-hub, click Add Model, then the Auto Router tab
2. Pick the Anthropic Family preset from the preset dropdown
3. Open the per-model settings for `claude-fable-5` under the REASONING tier: reasoning effort is unset
4. Name the router `my-auto-router` and save it
5. Reopen it from the model list: `claude-fable-5` still has no reasoning effort

### After (90c40fdfee)

1. Open http://localhost:3000/ui/?page=llm-model-hub, click Add Model, then the Auto Router tab
2. Pick the Anthropic Family preset from the preset dropdown
3. Open the per-model settings for `claude-fable-5` under the REASONING tier: reasoning effort reads high
4. Name the router `my-auto-router` and save it
5. Reopen it from the model list: reasoning effort on `claude-fable-5` is still high
6. Send a request that routes to REASONING, then check http://localhost:3000/ui/?page=logs to confirm it ran at high effort:

```bash
curl -s http://localhost:4000/v1/chat/completions \
  -H "Authorization: Bearer $LITELLM_API_KEY" \
  -H "Content-Type: application/json" \
  -d '{"model": "my-auto-router", "messages": [{"role": "user", "content": "Prove that every finite integral domain is a field."}]}'
```

## Type

🐛 Bug Fix

## Caveats (if any)

### Low

- No shipped preset carries these params yet, so nothing visibly changes
- A preset naming a tier key outside the four built-ins passes through unfiltered

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to dashboard preset prefill and tests; no auth or backend routing changes, and shipped presets do not yet use tier_model_configs.
> 
> **Overview**
> Fixes auto-router preset selection **silently dropping** per-model `litellm_params` (e.g. `reasoning_effort`) that presets define in `tier_model_configs`.
> 
> **`buildPresetPrefill`** now hydrates those settings into **`tier_model_params`** on the form config, using the same model-name resolution as tier lists so param keys match the admin’s registered spelling (hyphen vs dot versions). When two preset spellings map to one model, param objects **merge** (unique keys kept; shared keys last-wins) instead of losing one side.
> 
> **`normalizeModelName`** is exported so tests can assert bundled presets never reference the same model twice in one tier under different spellings—a case that would otherwise drop params on collapse.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 90c40fdfee732b57fde03cad946835dd726770a1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->