### PR TITLE
fix(e2e): move the vertex realtime suite off the retired Live preview model

### DIFF
--- a/tests/e2e/llm_translation/realtime/REALTIME_COVERAGE_MATRIX.md
+++ b/tests/e2e/llm_translation/realtime/REALTIME_COVERAGE_MATRIX.md
@@ -42,7 +42,7 @@ at call time. The provider table below is the source of truth; edit `PROVIDERS` 
 | openai | `openai-realtime` | `openai/gpt-realtime-2` |
 | azure | `azure-realtime` | `azure/gpt-realtime-2` (GA protocol) |
 | gemini | `gemini-realtime` | `gemini/gemini-3.1-flash-live-preview` |
-| vertex_ai | `vertex-realtime` | `vertex_ai/gemini-live-2.5-flash-preview-native-audio-09-2025` |
+| vertex_ai | `vertex-realtime` | `vertex_ai/gemini-live-2.5-flash-native-audio` |
 
 Bedrock and xai (`xai/grok-4-1-fast-non-reasoning`) are supported by the proxy but
 kept commented out in `PROVIDERS` until they pass end-to-end here; re-enable them by

--- a/tests/e2e/llm_translation/realtime/realtime_client.py
+++ b/tests/e2e/llm_translation/realtime/realtime_client.py
@@ -78,7 +78,7 @@ PROVIDERS = (
         "vertex_ai",
         "vertex-realtime",
         LiteLLMParamsBody(
-            model="vertex_ai/gemini-live-2.5-flash-preview-native-audio-09-2025",
+            model="vertex_ai/gemini-live-2.5-flash-native-audio",
             vertex_location="us-central1",
             vertex_credentials="os.environ/VERTEXAI_CREDENTIALS",
         ),


### PR DESCRIPTION
Google withdrew `gemini-live-2.5-flash-preview-native-audio-09-2025` from the Vertex Live API. Every session now dies at `setup`:

```
websockets.exceptions.ConnectionClosedError: received 1007 (invalid frame payload data)
gemini-live-2.5-flash-preview-native-audio-09-2025 is not supported in the live api.
```

The client sees `session.created` (the proxy synthesizes it on connect) and then zero frames, so both `[vertex_ai]` realtime tests time out on `session.updated`. This has failed every e2e run since scheduled build 75 (Aug 27 00:00 UTC); build 74 six hours earlier was the last green one.

## Evidence

Captured from the stage proxy's own logs (`litellm-gateway`, ns `litellm`), one entry per failing test.

Then confirmed by probing the Vertex Live endpoint directly with the e2e stack's own credentials, from inside the proxy pod:

| model | result |
|---|---|
| `gemini-live-2.5-flash-preview-native-audio-09-2025` | `1007 … is not supported in the live api` |
| `gemini-live-2.5-flash-native-audio` | `{"setupComplete": {"sessionId": …}}` |

So this swaps to the non-preview sibling — same native-audio class, and already what the cost map carries for `vertex_ai`.

## This is not a litellm regression

Suspicion initially fell on #38395, which removed the native-audio `speechConfig` strip. That PR is not the cause:

- The `setup` payload this suite sends is **byte-identical** either side of that change — verified by executing `VertexAIRealtimeConfig.transform_realtime_request` at both SHAs with the exact session.update payloads and model these two tests use.
- The strip only fires when a client sends a `voice`, and the e2e `SessionConfig` has no voice field at all.
- Google's rejection names the **model**, not any field that PR touches.

## Scope

Test-config only; no production code. The `gemini` (Google AI Studio) provider keeps the `-09-2025` id, which still works there — only the Vertex endpoint dropped it.

Unblocks the e2e lane for every open PR, not just mine.
