### PR TITLE
fix(streaming): preserve provider service-tier metadata so Vertex flex streams bill at flex rates

### DIFF
--- a/litellm/litellm_core_utils/streaming_handler.py
+++ b/litellm/litellm_core_utils/streaming_handler.py
@@ -8,11 +8,12 @@ import time
 import traceback
 from collections.abc import AsyncIterator, Callable, Iterable, Iterator, Mapping, Sequence
 from dataclasses import dataclass
+from types import MappingProxyType
 from typing import Any, Final, NoReturn, Protocol, TypeVar, cast
 
 import anyio
 import httpx
-from pydantic import BaseModel
+from pydantic import BaseModel, ValidationError
 from typing_extensions import NotRequired, TypedDict
 
 import litellm
@@ -180,6 +181,23 @@ class _VertexCandidateLike(Protocol):
 class _VertexChunkLike(Protocol):
     text: str
     candidates: Sequence[_VertexCandidateLike]
+
+
+class _ParsedChunkHiddenParams(BaseModel):
+    provider_specific_fields: Mapping[str, object] | None = None
+
+
+def _provider_hidden_params(chunk: object) -> Mapping[str, object] | None:
+    hidden: Final[object] = getattr(chunk, "_hidden_params", None)
+    if not isinstance(hidden, dict):
+        return None
+    try:
+        parsed: Final = _ParsedChunkHiddenParams.model_validate(hidden)
+    except ValidationError:
+        return None
+    if not parsed.provider_specific_fields:
+        return None
+    return MappingProxyType({"provider_specific_fields": dict(parsed.provider_specific_fields)})
 
 
 class CustomStreamWrapper:
@@ -801,7 +819,7 @@ class CustomStreamWrapper:
         except Exception as e:
             raise e
 
-    def model_response_creator(self, chunk: dict | None = None, hidden_params: dict | None = None):
+    def model_response_creator(self, chunk: dict | None = None, hidden_params: Mapping[str, object] | None = None):
         _model: Final = self._cached_model_name
         _logging_obj_llm_provider: Final = self._cached_logging_llm_provider
 
@@ -1504,7 +1522,7 @@ class CustomStreamWrapper:
     def chunk_creator(self, chunk: Any):
         if hasattr(chunk, "id"):
             self.response_id = chunk.id
-        model_response = self.model_response_creator()
+        model_response = self.model_response_creator(hidden_params=_provider_hidden_params(chunk))
         response_obj: dict[str, Any] = {}
         try:
             # return this for all models

--- a/tests/test_litellm/litellm_core_utils/test_streaming_handler.py
+++ b/tests/test_litellm/litellm_core_utils/test_streaming_handler.py
@@ -4460,3 +4460,62 @@ def test_handle_stream_fallback_error_restores_context_only_after_exception_mapp
     finally:
         trace_id_var.set("")
         session_id_var.set("")
+
+
+def test_chunk_creator_preserves_hidden_provider_specific_fields_from_parsed_chunk():
+    """
+    Vertex/Gemini chunk_parser stores usageMetadata.trafficType in the parsed
+    chunk's _hidden_params["provider_specific_fields"], but chunk_creator builds
+    a fresh ModelResponseStream per outgoing chunk. Before the fix those hidden
+    provider fields were dropped, so streaming flex traffic was billed at
+    standard rates (LIT-6292).
+    """
+    wrapper = CustomStreamWrapper(
+        completion_stream=None,
+        model="gemini-3.5-flash",
+        logging_obj=MagicMock(),
+        custom_llm_provider="vertex_ai",
+    )
+    parsed_chunk = ModelResponseStream(
+        choices=[StreamingChoices(index=0, delta=Delta(content="hello", role="assistant"), finish_reason=None)],
+    )
+    parsed_chunk._hidden_params["provider_specific_fields"] = {"traffic_type": "ON_DEMAND_FLEX"}
+
+    result = wrapper.chunk_creator(chunk=parsed_chunk)
+
+    assert result is not None
+    assert result._hidden_params["provider_specific_fields"] == {"traffic_type": "ON_DEMAND_FLEX"}
+
+
+@pytest.mark.asyncio
+async def test_async_stream_assembled_response_keeps_vertex_traffic_type(logging_obj: Logging):
+    """
+    End-to-end through the async wrapper: the assembled response handed to cost
+    tracking must carry traffic_type so flex/priority tiers price correctly.
+    """
+    content_chunk = ModelResponseStream(
+        choices=[StreamingChoices(index=0, delta=Delta(content="hello", role="assistant"), finish_reason=None)],
+    )
+    final_chunk = ModelResponseStream(
+        choices=[StreamingChoices(index=0, delta=Delta(content=""), finish_reason="stop")],
+    )
+    setattr(final_chunk, "usage", Usage(prompt_tokens=7, completion_tokens=5, total_tokens=12))
+    final_chunk._hidden_params["provider_specific_fields"] = {"traffic_type": "ON_DEMAND_FLEX"}
+
+    async def _stream():
+        yield content_chunk
+        yield final_chunk
+
+    wrapper = CustomStreamWrapper(
+        completion_stream=_stream(),
+        model="gemini-3.5-flash",
+        logging_obj=logging_obj,
+        custom_llm_provider="vertex_ai",
+        stream_options={"include_usage": True},
+    )
+
+    received = [chunk async for chunk in wrapper]
+
+    assembled = litellm.stream_chunk_builder(chunks=received, messages=[{"role": "user", "content": "hi"}])
+    assert assembled is not None
+    assert assembled._hidden_params["provider_specific_fields"]["traffic_type"] == "ON_DEMAND_FLEX"

--- a/tests/test_litellm/litellm_core_utils/test_streaming_handler.py
+++ b/tests/test_litellm/litellm_core_utils/test_streaming_handler.py
@@ -4463,13 +4463,6 @@ def test_handle_stream_fallback_error_restores_context_only_after_exception_mapp
 
 
 def test_chunk_creator_preserves_hidden_provider_specific_fields_from_parsed_chunk():
-    """
-    Vertex/Gemini chunk_parser stores usageMetadata.trafficType in the parsed
-    chunk's _hidden_params["provider_specific_fields"], but chunk_creator builds
-    a fresh ModelResponseStream per outgoing chunk. Before the fix those hidden
-    provider fields were dropped, so streaming flex traffic was billed at
-    standard rates (LIT-6292).
-    """
     wrapper = CustomStreamWrapper(
         completion_stream=None,
         model="gemini-3.5-flash",
@@ -4489,10 +4482,6 @@ def test_chunk_creator_preserves_hidden_provider_specific_fields_from_parsed_chu
 
 @pytest.mark.asyncio
 async def test_async_stream_assembled_response_keeps_vertex_traffic_type(logging_obj: Logging):
-    """
-    End-to-end through the async wrapper: the assembled response handed to cost
-    tracking must carry traffic_type so flex/priority tiers price correctly.
-    """
     content_chunk = ModelResponseStream(
         choices=[StreamingChoices(index=0, delta=Delta(content="hello", role="assistant"), finish_reason=None)],
     )


### PR DESCRIPTION
## TLDR

Problem this solves:

- Streamed Vertex/Gemini flex traffic was billed at standard rates
- Spend logs showed no service tier for any streamed call
- Non-streaming calls on the same deployment priced flex correctly

How it solves it:

- Streaming chunks keep the provider's traffic-type metadata end to end
- Cost tracking now sees the tier and applies flex pricing

## User Flow

Before: a platform admin who routes streaming traffic to a Vertex flex deployment sees every streamed call billed at the standard rate, so flex saves them nothing

1. The admin points their coding agent at the proxy, with the model backed by a Vertex deployment opted into flex
2. The agent sends POST https://litellm-domain/v1/messages with `"stream": true` and the SSE stream completes normally
3. They open https://litellm-domain/ui/?page=logs: the streamed request shows spend at standard rates (about 2x the flex price) and an empty service tier
4. They send the identical request with `"stream": false`: that log line says tier `flex` with roughly half the spend, so only streaming loses the discount
5. A streamed POST https://litellm-domain/v1/chat/completions on the same deployment is mispriced the same way

After: the same streamed calls bill at the flex rate, matching non-streaming

1. The admin points their coding agent at the proxy, with the model backed by a Vertex deployment opted into flex
2. The agent sends POST https://litellm-domain/v1/messages with `"stream": true` and the SSE stream completes normally
3. They open https://litellm-domain/ui/?page=logs: the streamed request now shows tier `flex` and flex-rate spend
4. The identical `"stream": false` request logs the same tier and matching per-token rates
5. A streamed POST https://litellm-domain/v1/chat/completions prices flex too

## Relevant issues

## Linear ticket

Resolves LIT-6292

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Live before/after A/B on two proxies (own worktree, venv imports via PYTHONPATH, own Postgres DB, `--num_workers 2`), both with the same config: `gemini-flash-flex` = `vertex_ai/gemini-3.5-flash` plus the Vertex flex opt-in extra_headers (`X-Vertex-AI-LLM-Request-Type: shared`, `X-Vertex-AI-LLM-Shared-Request-Type: flex`). Real Vertex API calls, real $$$. gemini-3.5-flash rates: standard in 1.5e-06 / out 9e-06 per token, flex in 7.5e-07 / out 4.5e-06. Spend rows read back through the admin API (`GET /spend/logs?request_id=<response id>`) with the master key, exactly what the admin sees in the UI

### Before (merge base 1df25e26cfa53523932f8cb486425f944e36ad1c, port 36300)

Streamed /v1/chat/completions (with `"stream_options":{"include_usage":true}`):

```
curl -sS -X POST http://127.0.0.1:36300/v1/chat/completions \
  -H "Authorization: Bearer sk-lit6292-qa-before" -H "Content-Type: application/json" \
  -d '{"model":"gemini-flash-flex","messages":[{"role":"user","content":"Say hello in 3 words."}],"max_tokens":512,"stream":true,"stream_options":{"include_usage":true}}'
```

```
data: {"id":"lMOPaovvFe6a998Pp4_eyAo","object":"chat.completion.chunk","created":1787806627,"model":"gemini-flash-flex","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}
data: {"id":"lMOPaovvFe6a998Pp4_eyAo","created":1787806627,"model":"gemini-flash-flex","object":"chat.completion.chunk","choices":[{"index":0,"delta":{}}],"usage":{"completion_tokens":338,"prompt_tokens":7,"total_tokens":345,"completion_tokens_details":{"reasoning_tokens":333,"text_tokens":5},"prompt_tokens_details":{"text_tokens":7}}}
data: [DONE]
```

```
curl -sS "http://127.0.0.1:36300/spend/logs?request_id=lMOPaovvFe6a998Pp4_eyAo" -H "Authorization: Bearer sk-lit6292-qa-before"
```

Spend row: spend 0.0030525 for 7 in / 338 out. Standard math is 7\*1.5e-06 + 338\*9e-06 = 0.0030525 (exact match); flex math would be 0.00152625. Billed at standard despite the flex opt-in

Streamed /v1/messages:

```
curl -sS -X POST http://127.0.0.1:36300/v1/messages \
  -H "Authorization: Bearer sk-lit6292-qa-before" -H "Content-Type: application/json" \
  -d '{"model":"gemini-flash-flex","messages":[{"role":"user","content":"Say hello in 3 words."}],"max_tokens":512,"stream":true}'
```

```
data: {"type": "message_delta", "delta": {"stop_reason": "end_turn"}, "usage": {"input_tokens": 7, "output_tokens": 180}}
event: message_stop
data: {"type": "message_stop"}
```

Spend row (call_type anthropic_messages, request_id asSPapHHOO2K9LsPwa2XuAc): spend 0.0016305 for 7 in / 180 out. Standard math = 0.0016305 (exact); flex would be 0.00081525. Standard again

Streamed /v1/responses:

```
curl -sS -X POST http://127.0.0.1:36300/v1/responses \
  -H "Authorization: Bearer sk-lit6292-qa-before" -H "Content-Type: application/json" \
  -d '{"model":"gemini-flash-flex","input":"Say hello in 3 words.","max_output_tokens":512,"stream":true}'
```

```
data: {"type":"response.completed","response":{"id":"resp_fiQX...","model":"gemini-3.5-flash",...,"usage":{"input_tokens":7,"output_tokens":426,"output_tokens_details":{"reasoning_tokens":421,"text_tokens":5},"total_tokens":433},...}}
data: [DONE]
```

Spend row (call_type aresponses, request_id N8WPavjHJveW998PtvXckAY): spend 0.0038445 for 7 in / 426 out. Standard math = 0.0038445 (exact); flex would be 0.00192225. Standard again

Non-stream /v1/chat/completions control (same deployment, no `stream`):

```
curl -sS -D - -X POST http://127.0.0.1:36300/v1/chat/completions \
  -H "Authorization: Bearer sk-lit6292-qa-before" -H "Content-Type: application/json" \
  -d '{"model":"gemini-flash-flex","messages":[{"role":"user","content":"Say hello in 3 words."}],"max_tokens":512}'
```

Response header `x-litellm-response-cost: 0.00117525`, spend row 0.00117525 for 7 in / 260 out. Flex math = 7\*7.5e-07 + 260\*4.5e-06 = 0.00117525 (exact). Non-stream already billed flex, so the bug is stream-only

| case | spend | flex math | standard math | billed as |
|---|---|---|---|---|
| chat stream | 0.0030525 | 0.00152625 | 0.0030525 | standard (bug) |
| messages stream | 0.0016305 | 0.00081525 | 0.0016305 | standard (bug) |
| responses stream | 0.0038445 | 0.00192225 | 0.0038445 | standard (bug) |
| chat non-stream | 0.00117525 | 0.00117525 | 0.0023505 | flex (correct) |

### After (PR tip f7228a46702b19e384626b25a0fa84d6d7cb5ed9, port 28540)

Streamed /v1/chat/completions (with `"stream_options":{"include_usage":true}`):

```
curl -sS -X POST http://127.0.0.1:28540/v1/chat/completions \
  -H "Authorization: Bearer sk-lit6292-qa-after" -H "Content-Type: application/json" \
  -d '{"model":"gemini-flash-flex","messages":[{"role":"user","content":"Say hello in 3 words."}],"max_tokens":512,"stream":true,"stream_options":{"include_usage":true}}'
```

```
data: {"id":"FcSParPlEdKl998P_oqs8AY","object":"chat.completion.chunk",...,"choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}
data: {"id":"FcSParPlEdKl998P_oqs8AY",...,"usage":{"completion_tokens":418,"prompt_tokens":7,"total_tokens":425,...}}
data: [DONE]
```

```
curl -sS "http://127.0.0.1:28540/spend/logs?request_id=FcSParPlEdKl998P_oqs8AY" -H "Authorization: Bearer sk-lit6292-qa-after"
```

Spend row: spend 0.00188625 for 7 in / 418 out. Flex math = 7\*7.5e-07 + 418\*4.5e-06 = 0.00188625 (exact); standard would be 0.0037725. Now billed flex

Streamed /v1/messages:

```
curl -sS -X POST http://127.0.0.1:28540/v1/messages \
  -H "Authorization: Bearer sk-lit6292-qa-after" -H "Content-Type: application/json" \
  -d '{"model":"gemini-flash-flex","messages":[{"role":"user","content":"Say hello in 3 words."}],"max_tokens":512,"stream":true}'
```

```
data: {"type": "message_delta", "delta": {"stop_reason": "end_turn"}, "usage": {"input_tokens": 7, "output_tokens": 331}}
event: message_stop
data: {"type": "message_stop"}
```

Spend row (call_type anthropic_messages, request_id C8WPaqLzHrKm9LsP1_ST8Q0): spend 0.00149475 for 7 in / 331 out. Flex math = 0.00149475 (exact); standard would be 0.0029895. Flex

Streamed /v1/responses:

```
curl -sS -X POST http://127.0.0.1:28540/v1/responses \
  -H "Authorization: Bearer sk-lit6292-qa-after" -H "Content-Type: application/json" \
  -d '{"model":"gemini-flash-flex","input":"Say hello in 3 words.","max_output_tokens":512,"stream":true}'
```

```
data: {"type":"response.completed","response":{"id":"resp_IUn7gbipba5-...","usage":{"input_tokens":7,"output_tokens":234,"output_tokens_details":{"reasoning_tokens":229,"text_tokens":5},"total_tokens":241},...}}
data: [DONE]
```

Spend row (call_type aresponses, request_id zcWPatftFMKw_9MP1tGE4As): spend 0.00105825 for 7 in / 234 out. Flex math = 0.00105825 (exact); standard would be 0.0021165. Flex

Non-stream /v1/chat/completions control:

```
curl -sS -D - -X POST http://127.0.0.1:28540/v1/chat/completions \
  -H "Authorization: Bearer sk-lit6292-qa-after" -H "Content-Type: application/json" \
  -d '{"model":"gemini-flash-flex","messages":[{"role":"user","content":"Say hello in 3 words."}],"max_tokens":512}'
```

Spend row (request_id CMePapClM6GR9LsP0oba0QE): spend 0.00146325 for 7 in / 324 out. Flex math = 0.00146325 (exact). Still flex, no regression

| case | spend | flex math | standard math | billed as |
|---|---|---|---|---|
| chat stream | 0.00188625 | 0.00188625 | 0.0037725 | flex (fixed) |
| messages stream | 0.00149475 | 0.00149475 | 0.0029895 | flex (fixed) |
| responses stream | 0.00105825 | 0.00105825 | 0.0021165 | flex (fixed) |
| chat non-stream | 0.00146325 | 0.00146325 | 0.0029265 | flex (still correct) |

Note observed on both legs, pre-existing and unrelated to this PR: `/spend/logs?request_id=<x-litellm-call-id>` returns `[]` for these Vertex requests; the spend rows are keyed by the upstream Vertex response id, which /v1/messages and /v1/responses bodies never expose. Filed separately

The current tip ab71807985237352965250bc3c3e9be73ef803da differs from the proven commit only by deleted test docstrings (zero lines under litellm/ changed), so the after leg holds at the tip

Verdict: PASS (before = streams billed standard, after = streams billed flex, control unchanged)

## Type

🐛 Bug Fix

## Caveats (if any)

### Low

- Streaming responses still carry no `x-litellm-response-cost` header: headers go out before the stream finishes, so this is inherent to streaming; spend logs are the source of truth
- Tier detection from the `x-gemini-service-tier` response header is still non-streaming only; Vertex flex signals via usage metadata, which this PR covers

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

live-pr-risk CHECKED at f7228a46702b19e384626b25a0fa84d6d7cb5ed9: no breaking or backward-incompatible dependents found; vertex standard-tier and OpenAI streaming A/B run base vs head showed identical exact-math spend and clean SSE bodies
- [x] f7228a46702b19e384626b25a0fa84d6d7cb5ed9 passes /live-pr-risk

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the central streaming path used for all providers, but the logic only forwards validated provider metadata and is covered by new tests; primary impact is billing accuracy for Vertex flex streams.
> 
> **Overview**
> **Streaming chunks now carry Vertex/Gemini `traffic_type` through to assembled responses** so spend logs and cost calculation can apply flex (and other tier) pricing on streamed calls, matching non-streaming behavior.
> 
> `CustomStreamWrapper.chunk_creator` reads validated `provider_specific_fields` from each upstream chunk’s `_hidden_params` (via new `_provider_hidden_params`) and merges them into outgoing stream chunks through `model_response_creator`, which now accepts typed `hidden_params`. Malformed hidden metadata is ignored instead of breaking the stream.
> 
> Tests cover per-chunk preservation and end-to-end async assembly via `stream_chunk_builder`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ab71807985237352965250bc3c3e9be73ef803da. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
