### PR TITLE
fix(e2e): size the mid-conversation-system cache prefix above the minimum deterministically

### DIFF
--- a/tests/e2e/llm_translation/test_messages_mid_conversation_system_e2e.py
+++ b/tests/e2e/llm_translation/test_messages_mid_conversation_system_e2e.py
@@ -50,11 +50,14 @@ CACHE_WARM_CONSECUTIVE_READS = 3
 
 
 def _cacheable_system_block(marker: str) -> TextBlock:
-    """A system prompt comfortably above the 4096-token minimum cacheable size
-    of Haiku 4.5 (the smallest model here), unique per run so no other run's
-    cache entry can satisfy the read."""
-    text = " ".join(
-        f"Reference paragraph {index} for run {marker}." for index in range(300)
+    """A system prompt at roughly twice the 4096-token minimum cacheable size of
+    Haiku 4.5 (the smallest model here), unique per run so no other run's cache
+    entry can satisfy the read. The marker appears once instead of in every
+    paragraph: repeating it swung the block's size by ~1800 tokens with the
+    marker's own tokenization and left it under the minimum on ~15% of runs, so
+    the system breakpoint went uncached and the priming loop never saw a read."""
+    text = f"Run {marker}.\n" + " ".join(
+        f"Reference paragraph {index}." for index in range(1500)
     )
     return TextBlock(text=text, cache_control=CacheControl())
 
@@ -101,8 +104,8 @@ def _first_turn_user_text(marker: str) -> str:
     """A first user turn heavy enough (hundreds of tokens) that losing its cache
     entry is unambiguous in the usage numbers, unique per attempt so priming
     retries never depend on the proxy's response cache behavior."""
-    notes = " ".join(f"Session note {index} for attempt {marker}." for index in range(100))
-    return f"Reply with one word.\n{notes}"
+    notes = " ".join(f"Session note {index}." for index in range(100))
+    return f"Reply with one word. Attempt {marker}.\n{notes}"
 
 
 class PrimedCache(BaseModel):

--- a/tests/e2e/llm_translation/test_messages_mid_conversation_system_native_providers_e2e.py
+++ b/tests/e2e/llm_translation/test_messages_mid_conversation_system_native_providers_e2e.py
@@ -70,9 +70,15 @@ def _vertex_params(model: str, location: str) -> LiteLLMParamsBody:
 
 
 def _cacheable_system_block(marker: str) -> TextBlock:
-    """A system prompt comfortably above the 1024-token minimum cacheable size,
-    unique per run so no other run's cache entry can satisfy the read."""
-    text = " ".join(f"Reference paragraph {index} for run {marker}." for index in range(300))
+    """A system prompt at roughly twice the 4096-token minimum cacheable size of
+    Haiku 4.5 (the smallest model here), unique per run so no other run's cache
+    entry can satisfy the read. The marker appears once instead of in every
+    paragraph: repeating it swung the block's size by ~1800 tokens with the
+    marker's own tokenization and left it under the minimum on ~15% of runs, so
+    the system breakpoint went uncached and the priming loop never saw a read."""
+    text = f"Run {marker}.\n" + " ".join(
+        f"Reference paragraph {index}." for index in range(1500)
+    )
     return TextBlock(text=text, cache_control=CacheControl())
 
 
@@ -110,8 +116,8 @@ def _first_turn_user_text(marker: str) -> str:
     """A first user turn heavy enough (hundreds of tokens) that losing its cache
     entry is unambiguous in the usage numbers, unique per attempt so priming
     retries never depend on the proxy's response cache behavior."""
-    notes = " ".join(f"Session note {index} for attempt {marker}." for index in range(100))
-    return f"Reply with one word.\n{notes}"
+    notes = " ".join(f"Session note {index}." for index in range(100))
+    return f"Reply with one word. Attempt {marker}.\n{notes}"
 
 
 class PrimedCache(BaseModel):


### PR DESCRIPTION
## The flake

`TestBedrockInvokeMidConversationSystem::test_unflagged_model_converts_system_reminder_and_succeeds` is the single most frequent flake in the e2e suite — 9 of 38 runs in a recent survey — always failing as:

```
prompt cache never became readable in full within 60.0s
(last usage: cache_creation_input_tokens=5610 cache_read_input_tokens=0)
```

The same error appears identically for the Azure Foundry and Vertex classes, because all three share a copied `_cacheable_system_block` / `_prime_prompt_cache` helper.

## Root cause

`_cacheable_system_block` embedded the per-run marker in **every one of its 300 paragraphs**, so the block's token count moved with the marker's own tokenization. Measured over 40 random `unique_marker()` values against the Haiku 4.5 tokenizer:

| | tokens |
|---|---|
| min | 3611 |
| median | 4509 |
| max | 5408 |
| **spread** | **1797** |
| **below the 4096 minimum** | **6/40 = 15%** |

The docstring claimed the prompt was "comfortably above the 4096-token minimum cacheable size" — it cleared it by ~113 tokens at the median, and fell under it on roughly one run in seven.

When the system block is under the minimum, no cache entry is written at the system breakpoint. The entry at the *second* breakpoint is still written, because system + first user turn clears the minimum — which is exactly what the failure usage shows: `cache_creation_input_tokens=5610` is the **whole** prefix (~4209 system + ~1411 user), not the user turn's share, and `cache_read_input_tokens=0`.

`_prime_prompt_cache` then rotates the user turn on every attempt, so that second entry never prefix-matches the next attempt either. Every attempt re-creates the full prefix from scratch, `cache_read` never rises above 0, the `read > 0 and creation > 0` condition can never be satisfied, and the loop burns its full 60s deadline. Once a run draws a short-tokenizing marker the failure is deterministic, not racy — which is why retries within the run never rescue it.

## Fix

Move the marker out of the repeated paragraph so it appears once, and size the block at 1500 paragraphs:

| | before | after |
|---|---|---|
| system block | 3611–5408 tokens | 8056–8060 tokens |
| spread across markers | 1797 | **4** |
| worst case vs. 4096 min | **0.88x** | **1.97x** |

`_first_turn_user_text` had the same marker-per-repetition pattern and is fixed the same way. Both copies of the helpers stay byte-identical (verified by hash).

No assertion, timeout, or retry-count is changed — the test's contract is untouched, it is only given a prefix that is actually cacheable on every run.

## Verification

- Token figures above produced by executing the patched helpers through `litellm.token_counter` for `anthropic/claude-haiku-4-5-20251001`.
- `make lint-e2e-basedpyright` → 0 errors, 0 warnings.
- `ruff check --config ruff-tests.toml` → all checks passed.
- The two files' pre-existing `ruff format` drift is unchanged by this PR (identical at base) and is outside the format gate's `litellm/*.py` scope.