### PR TITLE
fix(e2e): disable thinking on the gemini chat cost test instead of racing its budget

### DIFF
--- a/tests/e2e/llm_translation/test_chat_completions_regression_e2e.py
+++ b/tests/e2e/llm_translation/test_chat_completions_regression_e2e.py
@@ -308,7 +308,8 @@ class TestGeminiChatCompletions:
                             content=f"Reply with the single word pong. marker={tag}",
                         )
                     ],
-                    max_tokens=32,
+                    max_tokens=64,
+                    reasoning_effort="none",
                 ),
             )
         )


### PR DESCRIPTION
## The failure

`TestGeminiChatCompletions::test_gemini_chat_returns_content_and_logs_cost` asks `gemini-2.5-flash` to *"Reply with the single word pong"* under `max_tokens=32`, and has been observed returning no content at all:

```
completion_tokens=29, reasoning_tokens=29, content=None
```

`gemini-2.5-flash` defaults to **dynamic thinking**, and `max_tokens` maps to `maxOutputTokens`, which on the 2.5 family counts thinking tokens as well as visible output. The model is therefore free to spend the entire budget on thoughts and emit nothing — which is precisely what that usage shows: 29 of a 32-token budget consumed, all of it reasoning.

## Why raising the limit is not the fix

I was asked to research a good token limit. The honest answer is that **no reasonable limit makes this safe while thinking is on.** Dynamic thinking on 2.5 Flash is documented up to 24576 tokens, so any budget small enough to be sensible for a one-word smoke test can still be swallowed whole. A bump from 32 to, say, 256 would lower the odds without removing the failure mode.

The fix is to take thinking out of the picture. `reasoning_effort="none"` maps to `thinkingConfig.thinkingBudget = 0` for the 2.5 family, so the entire limit is available to visible output. Verified against this checkout:

```python
get_optional_params(model="gemini-2.5-flash", custom_llm_provider="gemini",
                    max_tokens=32)
# -> {'max_output_tokens': 32}                      # no thinkingConfig at all

get_optional_params(model="gemini-2.5-flash", custom_llm_provider="gemini",
                    max_tokens=64, reasoning_effort="none")
# -> {'max_output_tokens': 64,
#     'thinkingConfig': {'thinkingBudget': 0, 'includeThoughts': False}}
```

This is the same treatment the OpenAI tool tests in this very file already apply to `gpt-5.6` for the identical failure mode. `max_tokens` goes to 64 for headroom; with thinking disabled that is ample for a one-word answer.

Neither `covers` claim is weakened: the call still exercises the gemini chat translation path and still produces a costed SpendLogs row.

## Verification and its limits

- Wire payload proven by executing `get_optional_params` against this checkout (output above).
- `thinkingBudget == 0` for `reasoning_effort="none"` is separately pinned by an existing unit test at `tests/llm_translation/test_gemini.py:1447`.
- `ruff check --config ruff-tests.toml` → all checks passed.

Worth stating plainly: **I could not reproduce this live.** I have no Gemini key locally, and a scan of the 15 most recent `litellm-e2e` builds plus the recent `litellm-e2e-pr` builds found the test present and passing every time, with zero empty-content failures. So this is a rare, latent hazard rather than a frequent flake — the reasoning above is grounded in the observed usage numbers and the documented/verified request mapping, not in a reproduction. That `gemini-2.5-flash` accepts a budget of 0 follows Google's documented range for Flash (2.5 Pro cannot go below 128) and litellm's own handling, but I have not confirmed it against the live API.