### PR TITLE
feat(ui): put the auto-router savings hero on a spend rail and a four-tile row

### DIFF
--- a/ui/litellm-dashboard/src/app/(dashboard)/cost-optimization/_components/AutoRouterBenchmarksTab.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/cost-optimization/_components/AutoRouterBenchmarksTab.test.tsx
@@ -1,5 +1,5 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, within } from "@testing-library/react";
 import React from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -151,15 +151,18 @@ describe("AutoRouterBenchmarksTab", () => {
     mockAutoRouters();
   });
 
-  it("leads with total estimated savings, before the three session-shape metrics", () => {
+  it("leads with total estimated savings, before the four session-shape metrics", () => {
     mockHook({ data: response([group(), group({ router_name: "gpt-auto" })]) });
     renderTab();
 
     const labels = screen
-      .getAllByText(/Total estimated savings|Avg turns per session|Avg session length|Avg tokens per session/)
+      .getAllByText(
+        /Total estimated savings|Avg saved per session|Avg turns per session|Avg session length|Avg tokens per session/,
+      )
       .map((node) => node.textContent);
     expect(labels).toEqual([
       "Total estimated savings",
+      "Avg saved per session",
       "Avg turns per session",
       "Avg session length",
       "Avg tokens per session",
@@ -181,13 +184,35 @@ describe("AutoRouterBenchmarksTab", () => {
     expect(screen.getByText("5.3M")).toBeInTheDocument();
   });
 
-  it("pairs the savings with the session count it was earned over", () => {
+  it("pairs the savings with the session count it was earned over, in its own tile", () => {
     mockHook({ data: response([group(), group({ router_name: "gpt-auto" })]) });
     renderTab();
 
-    expect(screen.getByText("Avg saved per session")).toBeInTheDocument();
-    expect(screen.getByText("$23.13")).toBeInTheDocument();
-    expect(screen.getByText("across 94 sessions")).toBeInTheDocument();
+    const tile = screen.getByText("Avg saved per session").closest('[data-slot="card"]');
+    if (!tile) throw new Error("expected avg saved per session to render as a metric tile");
+
+    expect(within(tile).getByText("$23.13")).toBeInTheDocument();
+    expect(within(tile).getByText("· 94 sessions")).toBeInTheDocument();
+  });
+
+  it("exposes each spend row as a term and its value, not as loose text", () => {
+    mockHook({ data: response([group()]) });
+    renderTab();
+
+    const terms = screen.getAllByRole("term").map((node) => node.textContent);
+    const values = screen.getAllByRole("definition").map((node) => node.textContent);
+    expect(terms).toEqual(["Actual auto-router spend", "Estimated spend at highest-tier model"]);
+    expect(values).toEqual(["$359.86", "$2,534.45"]);
+  });
+
+  it("lets both hero columns shrink below their content so a large total cannot clip", () => {
+    const huge = totals({ saved_spend: 123_456_789_012.34 });
+    mockHook({ data: response([group(huge)], huge) });
+    renderTab();
+
+    const figure = screen.getByText("$123,456,789,012.34");
+    const grid = figure.closest('[data-slot="card"]')?.firstElementChild;
+    expect(grid).toHaveClass("md:grid-cols-[minmax(0,1fr)_minmax(0,1fr)]");
   });
 
   it("shows a cost increase as a positive delta rather than a saving", () => {
@@ -315,7 +340,7 @@ describe("AutoRouterBenchmarksTab", () => {
 
     expect(screen.getByText("Total estimated savings")).toBeInTheDocument();
     expect(screen.getAllByText("$0.00")).toHaveLength(4);
-    expect(screen.getByText("across 0 sessions")).toBeInTheDocument();
+    expect(screen.getByText("· 0 sessions")).toBeInTheDocument();
     expect(screen.getByText("0s")).toBeInTheDocument();
     expect(screen.getByText(/turns measured/)).toBeInTheDocument();
     expect(screen.getAllByText("0.0%").length).toBeGreaterThan(0);

--- a/ui/litellm-dashboard/src/app/(dashboard)/cost-optimization/_components/AutoRouterBenchmarksTab.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/cost-optimization/_components/AutoRouterBenchmarksTab.tsx
@@ -8,6 +8,7 @@ import AdvancedDatePicker from "@/components/shared/advanced_date_picker";
 import { Badge } from "@/components/ui/badge";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Separator } from "@/components/ui/separator";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
@@ -39,15 +40,23 @@ const Message: React.FC<{ children: React.ReactNode }> = ({ children }) => (
   <p className="py-8 text-center text-sm text-muted-foreground">{children}</p>
 );
 
-const Metric: React.FC<{ label: string; value: string }> = ({ label, value }) => (
+const Metric: React.FC<{ label: string; value: string; hint?: string }> = ({ label, value, hint }) => (
   <Card size="sm">
     <CardHeader>
       <CardTitle className="text-sm font-normal text-muted-foreground">{label}</CardTitle>
     </CardHeader>
-    <CardContent>
+    <CardContent className="flex flex-wrap items-baseline gap-2">
       <p className="text-3xl font-semibold text-foreground">{value}</p>
+      {hint && <p className="text-sm text-muted-foreground">{hint}</p>}
     </CardContent>
   </Card>
+);
+
+const SpendRow: React.FC<{ label: string; value: string }> = ({ label, value }) => (
+  <dl className="flex items-baseline justify-between gap-6 py-3">
+    <dt className="text-sm text-muted-foreground">{label}</dt>
+    <dd className="text-base font-semibold tabular-nums text-foreground">{value}</dd>
+  </dl>
 );
 
 const HeroCard: React.FC<{ view: BenchmarkView }> = ({ view }) => {
@@ -55,35 +64,27 @@ const HeroCard: React.FC<{ view: BenchmarkView }> = ({ view }) => {
   const cheaper = stats.saved_spend >= 0;
   return (
     <Card className="overflow-hidden py-0">
-      <div className="grid md:grid-cols-[1fr_1fr]">
-        <div className="flex flex-col justify-center gap-3 p-6">
-          <p className="text-sm text-muted-foreground">Total estimated savings</p>
-          <div className="flex flex-wrap items-center gap-3">
-            <p className="text-5xl font-semibold tracking-tight text-foreground">{usd(stats.saved_spend)}</p>
+      <div className="grid md:grid-cols-[minmax(0,1fr)_minmax(0,1fr)]">
+        <div className="flex flex-col items-center justify-center gap-2 p-6">
+          <p className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+            Total estimated savings
+          </p>
+          <div className="flex flex-wrap items-center justify-center gap-3">
+            <p className="text-6xl font-semibold tracking-tight text-foreground">{usd(stats.saved_spend)}</p>
             <Badge
               variant="secondary"
-              className={cheaper ? "bg-success/10 text-success" : "bg-destructive/10 text-destructive"}
+              className={`h-6 px-2.5 text-sm ${cheaper ? "bg-success/10 text-success" : "bg-destructive/10 text-destructive"}`}
             >
               {stats.saved_spend !== 0 && (cheaper ? "-" : "+")}
               {Math.abs(stats.saved_pct).toFixed(0)}%
             </Badge>
           </div>
-          <dl className="divide-y text-sm">
-            <div className="flex items-baseline justify-between gap-6 py-3">
-              <dt className="text-muted-foreground">Actual auto-router spend</dt>
-              <dd className="font-medium tabular-nums text-foreground">{usd(stats.spend)}</dd>
-            </div>
-            <div className="flex items-baseline justify-between gap-6 py-3">
-              <dt className="text-muted-foreground">Estimated spend at highest-tier model</dt>
-              <dd className="font-medium tabular-nums text-foreground">{usd(stats.baseline_spend)}</dd>
-            </div>
-          </dl>
         </div>
 
-        <div className="flex flex-col items-center justify-center gap-2 border-t p-6 md:border-t-0 md:border-l">
-          <p className="text-[11px] uppercase tracking-wide text-muted-foreground">Avg saved per session</p>
-          <p className="text-5xl font-semibold tracking-tight text-foreground">{usd(stats.saved_per_session)}</p>
-          <p className="text-sm text-muted-foreground">across {stats.sessions.toLocaleString()} sessions</p>
+        <div className="flex flex-col justify-center border-t p-6 md:border-t-0 md:border-l">
+          <SpendRow label="Actual auto-router spend" value={usd(stats.spend)} />
+          <Separator />
+          <SpendRow label="Estimated spend at highest-tier model" value={usd(stats.baseline_spend)} />
         </div>
       </div>
     </Card>
@@ -239,7 +240,12 @@ const BenchmarksBody: React.FC<BenchmarksBodyProps> = ({ isPending, error, data,
 
       <TierTurnsChart view={view} autoRouters={autoRouters} />
 
-      <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
+        <Metric
+          label="Avg saved per session"
+          value={usd(stats.saved_per_session)}
+          hint={`· ${stats.sessions.toLocaleString()} sessions`}
+        />
         <Metric label="Avg turns per session" value={stats.avg_turns_per_session.toFixed(1)} />
         <Metric label="Avg session length" value={durationLabel(stats.avg_session_seconds)} />
         <Metric label="Avg tokens per session" value={formatNumberWithCommas(stats.avg_tokens_per_session, 1, true)} />


### PR DESCRIPTION
## TLDR

Problem this solves:

- Savings card crams four numbers into two stacked halves
- Headline saving competes with the two spend rows above it
- Avg saved per session gets a whole half-card
- Session-shape metrics sit in a lopsided three-tile row

How it solves it:

- Headline saving and delta get the entire left half
- Two spend rows move to a right-hand rail
- Avg saved per session becomes the first metric tile
- Session count rides along as an inline hint

## User Flow

Before: a proxy admin checking what the auto-router saved has to read the headline number past two spend rows sharing its column, while a second big number of equal weight sits beside it

1. They open http://localhost:4000/ui/?page=cost-optimization and pick the Auto-Router tab
2. The savings card shows two 48px figures side by side, $1,909.03 and $10.38, so neither reads as the headline
3. Below the figure on the left, the same column also carries Actual auto-router spend and Estimated spend at highest-tier model
4. Underneath the card, three tiles show avg turns, avg session length and avg tokens

After: the headline saving owns the left half at 60px, the two spend numbers read as a supporting rail, and every per-session average lives in one four-tile row

1. They open http://localhost:4000/ui/?page=cost-optimization and pick the Auto-Router tab
2. The savings card shows one centred figure, $1,909.03 with its -42% pill, under a TOTAL ESTIMATED SAVINGS eyebrow
3. The right half of the same card lists Actual auto-router spend and Estimated spend at highest-tier model, one above the other
4. Underneath the card, four tiles show avg saved per session ($10.38, 184 sessions), avg turns, avg session length and avg tokens

## Relevant issues

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

Shared setup, a local proxy on :4300 against a database seeded with 184 auto-router sessions, and the dashboard dev server on :3300 pointed at it:

```
psql -U tin -d litellm_savingshero -c \
  'SELECT count(*) sessions, sum(turns) turns, round(sum(spend)::numeric,2) spend,
          round(sum(saved_spend)::numeric,2) saved
   FROM "LiteLLM_AutoRouterSession";'

 sessions | turns |  spend  |  saved
----------+-------+---------+---------
      184 | 19798 | 2629.80 | 1909.03
```

```
curl -s "http://localhost:4300/auto_router/benchmarks?start_date=2026-07-28&end_date=2026-08-26" \
  -H "Authorization: Bearer sk-1234"

sessions                   184
turns                      19798
avg_turns_per_session      107.59782608695652
avg_session_seconds        23040.0
avg_tokens_per_session     13600000.0
spend                      2629.799999999995
saved_spend                1909.0300000000002
baseline_spend             4538.829999999995
saved_pct                  42.1
saved_per_session          10.375163043478262
```

Both captures use that one payload, so every number on screen is the same number in both shots and only the layout moves.

### Before (166694948f)

1. Open http://localhost:3300/cost-optimization/ and click the Auto-Router tab, then Usage
2. The savings card and the metric row render like this

![before](https://raw.githubusercontent.com/BerriAI/litellm/litellm_savings_hero_screenshots/autorouter-savings-hero-before.png)

3. Measure the hero in the console:

```
$$('[data-slot="card"]')[0].getBoundingClientRect().height   // 229
getComputedStyle(headlineFigure).fontSize                     // "48px"
```

### After (58466c5bf8)

1. Open http://localhost:3300/cost-optimization/ and click the Auto-Router tab, then Usage
2. The same payload now renders like this

![after](https://raw.githubusercontent.com/BerriAI/litellm/litellm_savings_hero_screenshots/autorouter-savings-hero-after.png)

3. Measure the hero in the console:

```
$$('[data-slot="card"]')[0].getBoundingClientRect().height   // 145
getComputedStyle(headlineFigure).fontSize                     // "60px"
```

The card is 84px shorter and the headline figure is 25% larger, on identical data

4. Sweep the headline through three magnitudes at seven card widths, checking each
   for a card that scrolls sideways or a figure whose right edge passes the card's:

```
for (const val of ['$1,909.03','$12,847,301.66','$123,456,789,012.34'])
  for (const w of [1336,900,760,640,560,480,420]) { ... }

// with md:grid-cols-[1fr_1fr]                    11 of 21 cases overflow, 5 clip digits
// with md:grid-cols-[minmax(0,1fr)_minmax(0,1fr)] 0 of 21 overflow, 0 clip
```

5. Confirm the arbitrary grid value really compiles, since a class Tailwind drops
   would fail silently:

```
grep -o '\.md\\:grid-cols[^{]*{[^}]*}' .next/**/*.css

.md\:grid-cols-\[minmax\(0\,1fr\)_minmax\(0\,1fr\)\]{grid-template-columns:minmax(0, 1fr) minmax(0, 1fr)}
```

The screenshot above was captured at 608f355069, the first commit on this branch. The
two changes since then are the spend rows becoming description lists and the columns
becoming minmax(0,1fr), and neither one repaints at this width: identical classes and
flex layout for the first, and 1fr and minmax(0,1fr) resolve the same wherever no
column is at its min-content, which step 4 shows is the case at 1336px

## Type

🧹 Refactoring

## Caveats (if any)

### Low

- Session count reads "· 184 sessions" instead of "across 184 sessions"
- Routing by tier chart still sits between hero and tiles per router

On the default All auto-routers view the tier chart renders nothing, because it needs a single router's per-tier turn counts, so the tile row already sits directly under the hero there. Selecting one router puts the chart back between them, which this PR leaves alone.

The narrow-width overflow this PR started with is gone rather than carried forward. It predated the branch, the old 1fr columns refused to shrink below their content, and moving the spend rows beside the figure made it easier to hit. Both columns are now minmax(0,1fr), so step 4 above finds no width and no magnitude that overflows or clips.

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dashboard-only layout and presentation on the cost-optimization Auto-Router tab; no API or data logic changes.
> 
> **Overview**
> **Redesigns the Auto-Router usage savings hero** so **total estimated savings** is the sole focal on the left (larger figure, centered layout, percent badge), while **actual** and **estimated highest-tier spend** move to a **right-hand rail** as structured `term`/`definition` rows with a separator.
> 
> **Avg saved per session** leaves the hero and becomes the **first of four metric tiles**, with session count shown inline as **· N sessions** instead of under the hero. The metric grid is **four columns** on large screens (`lg:grid-cols-4`). Hero columns use **`minmax(0,1fr)`** so very large dollar totals do not overflow or clip.
> 
> Tests are updated for metric order, tile scoping, spend-row semantics, zero-session copy, and the responsive grid class.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 58466c5bf8de88749d18e47e42390991b144ba4f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->