### PR TITLE
fix(ui): let the paginated search select keep what the user types

### DIFF
--- a/ui/litellm-dashboard/src/components/shared/PaginatedSearchSelect.test.tsx
+++ b/ui/litellm-dashboard/src/components/shared/PaginatedSearchSelect.test.tsx
@@ -149,11 +149,12 @@ describe("PaginatedSearchSelect", () => {
     function ServerBacked() {
       const [search, setSearch] = useState("");
       const [value, setValue] = useState("alias-alpha");
-      // A refetch hands back structurally equal but freshly built option objects.
-      const options = OPTIONS.filter((option) => option.label.includes(search)).map((option) => ({ ...option }));
+      const freshlyBuiltOptions = OPTIONS.filter((option) => option.label.includes(search)).map((option) => ({
+        ...option,
+      }));
       return (
         <PaginatedSearchSelect
-          options={options}
+          options={freshlyBuiltOptions}
           value={value}
           onValueChange={setValue}
           onSearchChange={(query) => {

--- a/ui/litellm-dashboard/src/components/shared/PaginatedSearchSelect.test.tsx
+++ b/ui/litellm-dashboard/src/components/shared/PaginatedSearchSelect.test.tsx
@@ -142,6 +142,125 @@ describe("PaginatedSearchSelect", () => {
     expect(onValueChange).toHaveBeenCalledWith("alias-beta");
   });
 
+  it("keeps the typed query when a refreshed page of options arrives while a value is selected", async () => {
+    const user = userEvent.setup();
+    const onSearchChange = vi.fn();
+
+    function ServerBacked() {
+      const [search, setSearch] = useState("");
+      const [value, setValue] = useState("alias-alpha");
+      // A refetch hands back structurally equal but freshly built option objects.
+      const options = OPTIONS.filter((option) => option.label.includes(search)).map((option) => ({ ...option }));
+      return (
+        <PaginatedSearchSelect
+          options={options}
+          value={value}
+          onValueChange={setValue}
+          onSearchChange={(query) => {
+            onSearchChange(query);
+            setSearch(query);
+          }}
+          onLoadMore={vi.fn()}
+        />
+      );
+    }
+    render(<ServerBacked />);
+
+    const input = screen.getByRole("combobox");
+    await user.click(input);
+    await user.type(input, "gamma");
+
+    await waitFor(() => expect(onSearchChange).toHaveBeenLastCalledWith("gamma"));
+    await waitFor(() => expect(input).toHaveValue("gamma"));
+    expect(await screen.findByText("gamma-key")).toBeInTheDocument();
+  });
+
+  it("shows the selection again after the popup closes with the query abandoned", async () => {
+    const user = userEvent.setup();
+    renderSelect({ value: "alias-alpha" });
+
+    const input = screen.getByRole("combobox");
+    await user.click(input);
+    expect(input).toHaveValue("");
+
+    await user.type(input, "gamma");
+    await user.keyboard("{Escape}");
+
+    await waitFor(() => expect(input).toHaveValue("alias-alpha"));
+  });
+
+  it("puts the unfiltered page back when a typed query is abandoned", async () => {
+    const user = userEvent.setup();
+    const onSearchChange = vi.fn();
+    renderSelect({ onSearchChange });
+
+    const input = screen.getByRole("combobox");
+    await user.click(input);
+    await user.type(input, "gamma");
+    await waitFor(() => expect(onSearchChange).toHaveBeenCalledWith("gamma"));
+
+    await user.keyboard("{Escape}");
+
+    await waitFor(() => expect(onSearchChange).toHaveBeenLastCalledWith(""));
+  });
+
+  it("puts the unfiltered page back once an option found by typing is picked", async () => {
+    const user = userEvent.setup();
+    const onSearchChange = vi.fn();
+    renderSelect({ onSearchChange });
+
+    const input = screen.getByRole("combobox");
+    await user.click(input);
+    await user.type(input, "gamma");
+    await waitFor(() => expect(onSearchChange).toHaveBeenCalledWith("gamma"));
+
+    await user.click(await screen.findByText("gamma-key"));
+
+    await waitFor(() => expect(onSearchChange).toHaveBeenLastCalledWith(""));
+  });
+
+  it("keeps the first character when typing is what opened the list", async () => {
+    const user = userEvent.setup();
+    const onSearchChange = vi.fn();
+    renderSelect({ onSearchChange });
+
+    await user.tab();
+    await user.keyboard("gamma");
+
+    expect(screen.getByRole("combobox")).toHaveValue("gamma");
+    await waitFor(() => expect(onSearchChange).toHaveBeenLastCalledWith("gamma"));
+  });
+
+  it("keeps showing a picked option's label after it drops out of the loaded page", async () => {
+    const user = userEvent.setup();
+
+    function Refetching() {
+      const [options, setOptions] = useState<SearchSelectOption[]>([{ label: "Beta Team", value: "team-2" }]);
+      const [value, setValue] = useState("");
+      return (
+        <>
+          <PaginatedSearchSelect
+            options={options}
+            value={value}
+            onValueChange={setValue}
+            onSearchChange={vi.fn()}
+            onLoadMore={vi.fn()}
+          />
+          <button type="button" onClick={() => setOptions([])}>
+            refetch
+          </button>
+        </>
+      );
+    }
+    render(<Refetching />);
+
+    await user.click(screen.getByRole("combobox"));
+    await user.click(await screen.findByText("Beta Team"));
+    await user.click(screen.getByRole("button", { name: "refetch" }));
+
+    expect(screen.getByRole("combobox")).toHaveValue("Beta Team");
+  });
+
   it("surfaces loading and fetching-more affordances", async () => {
     const user = userEvent.setup();
     const { unmount } = render(

--- a/ui/litellm-dashboard/src/components/shared/PaginatedSearchSelect.test.tsx
+++ b/ui/litellm-dashboard/src/components/shared/PaginatedSearchSelect.test.tsx
@@ -262,6 +262,34 @@ describe("PaginatedSearchSelect", () => {
     expect(screen.getByRole("combobox")).toHaveValue("Beta Team");
   });
 
+  it("starts a fresh query when typing lands after the selected label", async () => {
+    const user = userEvent.setup();
+    const onSearchChange = vi.fn();
+    renderSelect({ onSearchChange, value: "alias-alpha" });
+
+    const input = screen.getByRole("combobox") as HTMLInputElement;
+    input.focus();
+    input.setSelectionRange(input.value.length, input.value.length);
+    await user.keyboard("gamma");
+
+    expect(input).toHaveValue("gamma");
+    await waitFor(() => expect(onSearchChange).toHaveBeenLastCalledWith("gamma"));
+  });
+
+  it("starts a fresh query when typing lands inside the selected label", async () => {
+    const user = userEvent.setup();
+    const onSearchChange = vi.fn();
+    renderSelect({ onSearchChange, value: "alias-alpha" });
+
+    const input = screen.getByRole("combobox") as HTMLInputElement;
+    input.focus();
+    input.setSelectionRange(3, 3);
+    await user.keyboard("g");
+
+    expect(input).toHaveValue("g");
+    await waitFor(() => expect(onSearchChange).toHaveBeenLastCalledWith("g"));
+  });
+
   it("surfaces loading and fetching-more affordances", async () => {
     const user = userEvent.setup();
     const { unmount } = render(

--- a/ui/litellm-dashboard/src/components/shared/PaginatedSearchSelect.tsx
+++ b/ui/litellm-dashboard/src/components/shared/PaginatedSearchSelect.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Loader2 } from "lucide-react";
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
 
 import {
   Combobox,
@@ -54,10 +54,15 @@ export function PaginatedSearchSelect({
   "aria-invalid": ariaInvalid,
   "aria-describedby": ariaDescribedBy,
 }: PaginatedSearchSelectProps) {
+  const [pickedOption, setPickedOption] = useState<SearchSelectOption | null>(null);
+
   const selected = useMemo<SearchSelectOption | null>(() => {
     if (value === undefined || value === "") return null;
-    return options.find((option) => option.value === value) ?? { label: value, value };
-  }, [options, value]);
+    return (
+      options.find((option) => option.value === value) ??
+      (pickedOption?.value === value ? pickedOption : { label: value, value })
+    );
+  }, [options, value, pickedOption]);
 
   const items = useMemo<SearchSelectOption[]>(() => {
     if (selected === null) return options;
@@ -66,14 +71,19 @@ export function PaginatedSearchSelect({
   }, [options, selected]);
 
   const pagination = { onSearchChange, onLoadMore, hasNextPage, isFetchingNextPage };
-  const { handleInputValueChange, handleScroll } = usePaginatedCombobox(pagination);
+  const { query, handleInputValueChange, handleOpenChange, handleScroll } = usePaginatedCombobox(pagination);
 
   return (
     <Combobox
       items={items}
       value={selected}
-      onValueChange={(item: SearchSelectOption | null) => onValueChange(item?.value ?? "")}
+      inputValue={query ?? selected?.label ?? ""}
+      onValueChange={(item: SearchSelectOption | null) => {
+        setPickedOption(item);
+        onValueChange(item?.value ?? "");
+      }}
       onInputValueChange={(next, eventDetails) => handleInputValueChange(next, eventDetails.reason)}
+      onOpenChange={(nextOpen, eventDetails) => handleOpenChange(nextOpen, eventDetails.reason)}
       isItemEqualToValue={(a: SearchSelectOption, b: SearchSelectOption) => a.value === b.value}
       itemToStringLabel={(item: SearchSelectOption) => item.label}
       filter={null}

--- a/ui/litellm-dashboard/src/components/shared/PaginatedSearchSelect.tsx
+++ b/ui/litellm-dashboard/src/components/shared/PaginatedSearchSelect.tsx
@@ -71,13 +71,13 @@ export function PaginatedSearchSelect({
   }, [options, selected]);
 
   const pagination = { onSearchChange, onLoadMore, hasNextPage, isFetchingNextPage };
-  const { query, handleInputValueChange, handleOpenChange, handleScroll } = usePaginatedCombobox(pagination);
+  const { typedQuery, handleInputValueChange, handleOpenChange, handleScroll } = usePaginatedCombobox(pagination);
 
   return (
     <Combobox
       items={items}
       value={selected}
-      inputValue={query ?? selected?.label ?? ""}
+      inputValue={typedQuery ?? selected?.label ?? ""}
       onValueChange={(item: SearchSelectOption | null) => {
         setPickedOption(item);
         onValueChange(item?.value ?? "");

--- a/ui/litellm-dashboard/src/components/shared/PaginatedSearchSelect.tsx
+++ b/ui/litellm-dashboard/src/components/shared/PaginatedSearchSelect.tsx
@@ -35,6 +35,19 @@ interface PaginatedSearchSelectProps {
   "aria-describedby"?: string;
 }
 
+const typedInsertion = (previous: string, next: string): string => {
+  let start = 0;
+  while (start < previous.length && start < next.length && previous[start] === next[start]) start++;
+  let end = 0;
+  while (
+    end < previous.length - start &&
+    end < next.length - start &&
+    previous[previous.length - 1 - end] === next[next.length - 1 - end]
+  )
+    end++;
+  return next.slice(start, next.length - end);
+};
+
 export function PaginatedSearchSelect({
   options,
   value,
@@ -82,7 +95,12 @@ export function PaginatedSearchSelect({
         setPickedOption(item);
         onValueChange(item?.value ?? "");
       }}
-      onInputValueChange={(next, eventDetails) => handleInputValueChange(next, eventDetails.reason)}
+      onInputValueChange={(next, eventDetails) =>
+        handleInputValueChange(
+          typedQuery === null ? typedInsertion(selected?.label ?? "", next) : next,
+          eventDetails.reason,
+        )
+      }
       onOpenChange={(nextOpen, eventDetails) => handleOpenChange(nextOpen, eventDetails.reason)}
       isItemEqualToValue={(a: SearchSelectOption, b: SearchSelectOption) => a.value === b.value}
       itemToStringLabel={(item: SearchSelectOption) => item.label}

--- a/ui/litellm-dashboard/src/components/shared/usePaginatedCombobox.ts
+++ b/ui/litellm-dashboard/src/components/shared/usePaginatedCombobox.ts
@@ -1,7 +1,7 @@
 "use client";
 
 import { useDebouncedCallback } from "@tanstack/react-pacer/debouncer";
-import type { UIEvent } from "react";
+import { useState, type UIEvent } from "react";
 
 import { DEBOUNCE_WAIT_MS } from "@/utils/debounceConstants";
 
@@ -23,10 +23,26 @@ export function usePaginatedCombobox({
   isFetchingNextPage,
 }: PaginatedComboboxCallbacks) {
   const debouncedSearch = useDebouncedCallback(onSearchChange, { wait: DEBOUNCE_WAIT_MS });
+  // null means "not searching": the input then shows the selected option's label instead.
+  const [query, setQuery] = useState<string | null>(null);
 
   const handleInputValueChange = (next: string, reason: string) => {
-    if (!SEARCH_REASONS.has(reason)) return;
+    if (!SEARCH_REASONS.has(reason)) {
+      setQuery(null);
+      return;
+    }
+    setQuery(next);
     debouncedSearch(next);
+  };
+
+  const handleOpenChange = (open: boolean, reason: string) => {
+    if (!open) {
+      if (query) debouncedSearch("");
+      setQuery(null);
+      return;
+    }
+    // Typing into a closed combobox opens it, and that keystroke is already the query.
+    if (!SEARCH_REASONS.has(reason)) setQuery("");
   };
 
   const handleScroll = (event: UIEvent<HTMLDivElement>) => {
@@ -38,5 +54,5 @@ export function usePaginatedCombobox({
     }
   };
 
-  return { handleInputValueChange, handleScroll };
+  return { query, handleInputValueChange, handleOpenChange, handleScroll };
 }

--- a/ui/litellm-dashboard/src/components/shared/usePaginatedCombobox.ts
+++ b/ui/litellm-dashboard/src/components/shared/usePaginatedCombobox.ts
@@ -23,26 +23,25 @@ export function usePaginatedCombobox({
   isFetchingNextPage,
 }: PaginatedComboboxCallbacks) {
   const debouncedSearch = useDebouncedCallback(onSearchChange, { wait: DEBOUNCE_WAIT_MS });
-  // null means "not searching": the input then shows the selected option's label instead.
-  const [query, setQuery] = useState<string | null>(null);
+  const [typedQuery, setTypedQuery] = useState<string | null>(null);
 
   const handleInputValueChange = (next: string, reason: string) => {
     if (!SEARCH_REASONS.has(reason)) {
-      setQuery(null);
+      setTypedQuery(null);
       return;
     }
-    setQuery(next);
+    setTypedQuery(next);
     debouncedSearch(next);
   };
 
   const handleOpenChange = (open: boolean, reason: string) => {
     if (!open) {
-      if (query) debouncedSearch("");
-      setQuery(null);
+      if (typedQuery) debouncedSearch("");
+      setTypedQuery(null);
       return;
     }
-    // Typing into a closed combobox opens it, and that keystroke is already the query.
-    if (!SEARCH_REASONS.has(reason)) setQuery("");
+    const openedByTyping = SEARCH_REASONS.has(reason);
+    if (!openedByTyping) setTypedQuery("");
   };
 
   const handleScroll = (event: UIEvent<HTMLDivElement>) => {
@@ -54,5 +53,5 @@ export function usePaginatedCombobox({
     }
   };
 
-  return { query, handleInputValueChange, handleOpenChange, handleScroll };
+  return { typedQuery, handleInputValueChange, handleOpenChange, handleScroll };
 }


### PR DESCRIPTION
## TLDR

Problem this solves:

- Once a user was picked, the Usage filter box refused typing
- Each keystroke was wiped or tacked onto the picked name
- The same picker on the Logs page behaved the same way

How it solves it:

- The box now keeps the query while its list is open
- A keystroke over a picked name starts a new query
- It shows the picked option again once the list closes

## User Flow

Before: an admin who already filtered usage by one user cannot switch to another without clearing the box

1. They open http://localhost:4000/ui/?page=usage and pick "User Usage" in the Usage View dropdown
2. They click "Filter by user", type `alpha10`, and pick `alpha10@example.com (u-alpha-10)`; the spend, request and token panels scope to that user
3. They click the same box again and type `alpha55` to look at a different user
4. The letters show up for about a second and then vanish: the box goes back to `alpha10@example.com (u-alpha-10)` and the list still offers only `alpha10@example.com (u-alpha-10)`, so no other user is reachable
5. Tabbing into the box instead of clicking it is no better: the letters stick to the end of the picked name, the box reads `alpha10@example.com (u-alpha-10)alpha55`, and the list still offers only `alpha10@example.com (u-alpha-10)`

After: the same admin types a new name and gets it

1. They open http://localhost:4000/ui/?page=usage and pick "User Usage" in the Usage View dropdown
2. They click "Filter by user", type `alpha10`, and pick `alpha10@example.com (u-alpha-10)`; the spend, request and token panels scope to that user
3. They click the same box again and type `alpha55` to look at a different user
4. The box holds `alpha55`, the list offers `alpha55@example.com (u-alpha-55)` alongside the ticked current pick, and choosing it scopes the panels to that user
5. Tabbing into the box instead of clicking it does the same thing: the box holds `alpha55` and the list offers `alpha55@example.com (u-alpha-55)`

## Relevant issues

## Linear ticket

Resolves LIT-5591

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Shared setup, run against a live proxy on a throwaway postgres, with the dashboard dev server on port 3000 (`npm run dev` in `ui/litellm-dashboard`):

```bash
for i in $(seq 0 71); do
  curl -s -X POST http://localhost:4000/user/new \
    -H "Authorization: Bearer $LITELLM_MASTER_KEY" -H 'Content-Type: application/json' \
    -d "{\"user_id\": \"u-alpha-$i\", \"user_email\": \"alpha$i@example.com\", \"user_role\": \"internal_user\"}" > /dev/null
done
```

Both runs walk the same steps in a real browser at http://localhost:3000/usage/ with "User Usage" selected.

### Before (807ee7f232)

#### Case A: pick a user with nothing selected yet

1. Click "Filter by user" and type `alpha10`
2. The box shows `alpha10`
3. The list shows `alpha10@example.com (u-alpha-10)`
4. Click it: the box shows `alpha10@example.com (u-alpha-10)`

#### Case B: click the box and type a different user

1. Click the same box and type `alpha55`
2. The box shows `alpha10@example.com (u-alpha-10)`, so the typing was thrown away
3. The list still shows only `alpha10@example.com (u-alpha-10)`

#### Case C: focus the box from the keyboard and type a different user

1. Click away, focus the box without clicking it, and type `alpha55`
2. The box shows `alpha10@example.com (u-alpha-10)alpha55`, so the typing ran onto the end of the picked name
3. The list still shows only `alpha10@example.com (u-alpha-10)`

### After (3c3315b6e9)

#### Case A: pick a user with nothing selected yet

1. Click "Filter by user" and type `alpha10`
2. The box shows `alpha10`
3. The list shows `alpha10@example.com (u-alpha-10)`
4. Click it: the box shows `alpha10@example.com (u-alpha-10)`

#### Case B: click the box and type a different user

1. Click the same box and type `alpha55`
2. The box shows `alpha55`
3. The list shows `alpha10@example.com (u-alpha-10)` (the current pick, ticked) and `alpha55@example.com (u-alpha-55)`

#### Case C: focus the box from the keyboard and type a different user

1. Click away, focus the box without clicking it, and type `alpha55`
2. The box shows `alpha55`
3. The list shows `alpha10@example.com (u-alpha-10)` (the current pick, ticked) and `alpha55@example.com (u-alpha-55)`

## Caveats (if any)

- Opening the list now blanks the box so the next query starts clean; closing it puts the picked option's label back
