### PR TITLE
fix(logging): stop stream-based log collectors classifying INFO logs as errors

### DIFF
--- a/litellm/_logging.py
+++ b/litellm/_logging.py
@@ -5,7 +5,7 @@ import os
 import sys
 from datetime import datetime
 from logging import Formatter
-from typing import Any, Final
+from typing import Any, Final, TextIO
 
 import litellm
 from litellm.constants import (
@@ -234,11 +234,65 @@ class CorrelationContextFilter(logging.Filter):
 _correlation_filter: Final = CorrelationContextFilter()
 
 
-json_logs = bool(os.getenv("JSON_LOGS", False))
+_LOG_FORMAT_PREFIX: Final = "%(asctime)s - %(name)s:%(levelname)s"
+_LOG_FORMAT_SUFFIX: Final = ": %(filename)s:%(lineno)s - %(message)s"
+_PLAIN_LOG_FORMAT: Final = _LOG_FORMAT_PREFIX + _LOG_FORMAT_SUFFIX
+_COLOR_LOG_FORMAT: Final = f"\033[92m{_LOG_FORMAT_PREFIX}\033[0m{_LOG_FORMAT_SUFFIX}"
+
+
+def _stream_is_tty(stream: TextIO | None) -> bool:
+    """True when the stream is an open interactive terminal; never raises.
+
+    A stream can be None (pythonw/embedded interpreters), lack isatty entirely
+    (GUI log-redirect shims), or be closed; import must survive all three.
+    """
+    try:
+        return stream is not None and stream.isatty()
+    except (AttributeError, ValueError):
+        return False
+
+
+def _plain_log_format(stdout: TextIO | None, stderr: TextIO | None) -> str:
+    """The plain-text log format, colorized only when both streams are an interactive terminal.
+
+    Honors the NO_COLOR convention from no-color.org: color is disabled when
+    NO_COLOR is present with a non-empty value.
+    """
+    if os.environ.get("NO_COLOR"):
+        return _PLAIN_LOG_FORMAT
+    return _COLOR_LOG_FORMAT if _stream_is_tty(stdout) and _stream_is_tty(stderr) else _PLAIN_LOG_FORMAT
+
+
+class LevelRoutingStreamHandler(logging.StreamHandler):
+    """Writes records below WARNING to stdout and WARNING and above to stderr.
+
+    Collectors that derive severity from the stream report every stderr line as an error.
+    """
+
+    def emit(self, record: logging.LogRecord) -> None:
+        preferred: Final = sys.stdout if record.levelno < logging.WARNING else sys.stderr
+        if preferred is None or getattr(preferred, "closed", False):
+            self.stream = sys.stderr  # rebind-ok: fall back to the pre-fix stream rather than raising per record
+        else:
+            self.stream = preferred  # rebind-ok: StreamHandler.emit writes self.stream under the handler lock
+        super().emit(record)
+
+
+def _parse_json_logs_env(value: str | None) -> bool:
+    """Strict opt-in parse for the JSON_LOGS env var: only "true" (any case) enables JSON logs.
+
+    Matches the reader in litellm-proxy-extras/_logging.py. The previous
+    bool(os.getenv(...)) treated any non-empty value, including "false" and "0",
+    as enabled.
+    """
+    return (value or "").lower() == "true"
+
+
+json_logs: Final = _parse_json_logs_env(os.getenv("JSON_LOGS"))
 # Create a handler for the logger (you may need to adapt this based on your needs)
 log_level: Final = os.getenv("LITELLM_LOG", "DEBUG")
 numeric_level: Final[str] = getattr(logging, log_level.upper())
-handler: Final = logging.StreamHandler()
+handler: Final = LevelRoutingStreamHandler()
 handler.setLevel(numeric_level)
 handler.addFilter(_secret_filter)
 handler.addFilter(_correlation_filter)
@@ -447,7 +501,7 @@ if json_logs:
     _setup_json_exception_handlers(JsonFormatter())
 else:
     formatter: Final = CorrelationPlainFormatter(
-        "\033[92m%(asctime)s - %(name)s:%(levelname)s\033[0m: %(filename)s:%(lineno)s - %(message)s",
+        _plain_log_format(sys.stdout, sys.stderr),
         datefmt="%H:%M:%S",
     )
 
@@ -628,7 +682,7 @@ def _turn_on_json():
 
     - Adds a JSON formatter to all loggers
     """
-    handler: Final = logging.StreamHandler()
+    handler: Final = LevelRoutingStreamHandler()
     handler.setFormatter(JsonFormatter())
     _initialize_loggers_with_handler(handler)
     # Set up exception handlers

--- a/tests/test_litellm/test_logging.py
+++ b/tests/test_litellm/test_logging.py
@@ -12,13 +12,18 @@ import logging
 
 import litellm
 from litellm._logging import (
+    _COLOR_LOG_FORMAT,
+    _PLAIN_LOG_FORMAT,
     ALL_LOGGERS,
     CorrelationContextFilter,
     CorrelationPlainFormatter,
     JsonFormatter,
+    LevelRoutingStreamHandler,
     SecretRedactionFilter,
     StdoutLogTruncationFilter,
     _initialize_loggers_with_handler,
+    _parse_json_logs_env,
+    _plain_log_format,
     _stdout_truncation_marker,
     _turn_on_json,
     session_id_var,
@@ -57,11 +62,10 @@ def test_json_mode_emits_one_record_per_logger(capfd):
     verbose_router_logger.info("second info from router")
     verbose_proxy_logger.info("third info from proxy")
 
-    # Capture stdout
+    # All three records are INFO, so they must route to stdout and none to stderr
     out, err = capfd.readouterr()
-    print("out", out)
-    print("err", err)
-    lines = [l for l in err.splitlines() if l.strip()]
+    assert [raw for raw in err.splitlines() if raw.strip()] == []
+    lines = [raw for raw in out.splitlines() if raw.strip()]
 
     # Expect exactly three JSON lines
     assert len(lines) == 3, f"got {len(lines)} lines, want 3: {lines!r}"
@@ -831,3 +835,136 @@ def test_set_session_id_bounds_length():
         assert len(session_id_var.get()) == 256
     finally:
         session_id_var.reset(token)
+
+
+class _FakeStream:
+    def __init__(self, tty: bool) -> None:
+        self._tty = tty
+
+    def isatty(self) -> bool:
+        return self._tty
+
+
+def test_records_below_warning_go_to_stdout_and_the_rest_to_stderr(capsys):
+    logger = logging.getLogger("test_level_routing")
+    logger.handlers.clear()
+    logger.propagate = False
+    logger.setLevel(logging.DEBUG)
+    handler = LevelRoutingStreamHandler()
+    handler.setFormatter(logging.Formatter("%(levelname)s %(message)s"))
+    logger.addHandler(handler)
+
+    try:
+        logger.debug("d")
+        logger.info("i")
+        logger.warning("w")
+        logger.error("e")
+        logger.critical("c")
+    finally:
+        logger.handlers.clear()
+
+    out, err = capsys.readouterr()
+    assert out.splitlines() == ["DEBUG d", "INFO i"]
+    assert err.splitlines() == ["WARNING w", "ERROR e", "CRITICAL c"]
+
+
+def test_verbose_loggers_route_records_by_level():
+    for lg in (verbose_logger, verbose_router_logger, verbose_proxy_logger):
+        assert any(isinstance(h, LevelRoutingStreamHandler) for h in lg.handlers), lg.name
+
+
+@pytest.mark.parametrize(
+    "stdout_tty, stderr_tty, no_color, want_color",
+    [
+        (True, True, None, True),
+        (False, False, None, False),
+        (False, True, None, False),
+        (True, False, None, False),
+        (True, True, "1", False),
+        (True, True, "", True),
+    ],
+)
+def test_plain_log_format_colorizes_only_for_a_terminal(monkeypatch, stdout_tty, stderr_tty, no_color, want_color):
+    if no_color is None:
+        monkeypatch.delenv("NO_COLOR", raising=False)
+    else:
+        monkeypatch.setenv("NO_COLOR", no_color)
+
+    fmt = _plain_log_format(_FakeStream(stdout_tty), _FakeStream(stderr_tty))
+
+    assert fmt == (_COLOR_LOG_FORMAT if want_color else _PLAIN_LOG_FORMAT)
+    assert ("\033[" in fmt) is want_color
+
+
+def test_plain_format_carries_no_ansi_codes():
+    assert "\033[" not in _PLAIN_LOG_FORMAT
+
+
+class _Brokenstream:
+    """A write-only shim without isatty, like GUI log redirectors install."""
+
+
+class _ClosedStream:
+    closed = True
+
+    def isatty(self) -> bool:
+        raise ValueError("I/O operation on closed file")
+
+
+@pytest.mark.parametrize(
+    "stdout, stderr",
+    [
+        (None, None),
+        (_FakeStream(True), None),
+        (_Brokenstream(), _FakeStream(True)),
+        (_ClosedStream(), _FakeStream(True)),
+    ],
+)
+def test_plain_log_format_survives_hostile_streams(stdout, stderr):
+    """sys.stdout/sys.stderr can be None, shimmed, or closed; import must not crash."""
+    assert _plain_log_format(stdout, stderr) == _PLAIN_LOG_FORMAT
+
+
+def test_level_routing_handler_falls_back_to_stderr_when_stdout_is_unusable(monkeypatch, capsys):
+    logger = logging.getLogger("test_level_routing_fallback")
+    logger.handlers.clear()
+    logger.propagate = False
+    logger.setLevel(logging.DEBUG)
+    handler = LevelRoutingStreamHandler()
+    handler.setFormatter(logging.Formatter("%(levelname)s %(message)s"))
+    logger.addHandler(handler)
+
+    try:
+        monkeypatch.setattr(sys, "stdout", None)
+        logger.info("stdout is gone")
+    finally:
+        logger.handlers.clear()
+
+    err = capsys.readouterr().err
+    assert "INFO stdout is gone" in err
+    assert "--- Logging error ---" not in err
+
+
+@pytest.mark.parametrize(
+    "value, want",
+    [
+        ("true", True),
+        ("True", True),
+        ("TRUE", True),
+        ("false", False),
+        ("False", False),
+        ("0", False),
+        ("1", False),
+        ("", False),
+        (None, False),
+    ],
+)
+def test_parse_json_logs_env_enables_only_on_true(value, want):
+    """JSON_LOGS=false / 0 must not enable JSON logs (LIT-5558)."""
+    assert _parse_json_logs_env(value) is want
+
+
+def test_plain_log_format_survives_none_streams():
+    """sys.stdout/sys.stderr can be None in embedded interpreters; import must not crash."""
+    assert _plain_log_format(None, None) == _PLAIN_LOG_FORMAT
+    assert _plain_log_format(_FakeStream(True), None) == _PLAIN_LOG_FORMAT


### PR DESCRIPTION
## TLDR

Problem this solves:

- Datadog shows every LiteLLM INFO log as an ERROR
- All log levels write to stderr, which collectors map to error status
- Hardcoded ANSI codes make plain-text logs unparseable off-terminal
- JSON_LOGS=false (or any non-empty value) enables JSON logs

How it solves it:

- Records below WARNING now write to stdout, WARNING and above to stderr
- ANSI colors only when both streams are a TTY, NO_COLOR honored
- JSON_LOGS enables only on "true" (any case), matching litellm-proxy-extras

## User Flow

Before: a platform engineer shipping proxy container logs to Datadog sees every INFO line flagged as an error

1. They deploy the proxy container and send POST https://litellm-domain/v1/chat/completions, which returns 200
2. The container runtime captures every LiteLLM log line, INFO included, from stderr
3. In Datadog Log Explorer the INFO lines arrive with status:error and leading `[92m` garbage, so error monitors fire on healthy traffic

After: the same traffic shows INFO lines as info and only real warnings/errors as errors

1. They deploy the proxy container and send the same POST https://litellm-domain/v1/chat/completions, which returns 200
2. INFO lines now arrive from stdout as clean plain text (no ANSI codes), so Datadog reads them as info
3. Only WARNING and above arrive from stderr, so error monitors fire only on real problems

## Relevant issues

## Linear ticket

Resolves LIT-5558

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

### Real-Datadog end-to-end proof (the customer's actual symptom)

Rig: two containerized proxies at **base `192ccaaf02`** and **head `882a2cb559`** — identical config (`gemini/gemini-2.5-flash`, real Gemini calls), plus a real **Datadog Agent** (`gcr.io/datadoghq/agent:7`, `DD_LOGS_CONFIG_CONTAINER_COLLECT_ALL=true`) shipping each container's stdout/stderr to Datadog (us5) as `service:lit5558-base` / `service:lit5558-head`. Datadog sets `status:error` on container **stderr** lines it cannot parse — exactly the reported symptom.

Same traffic per side: one real `POST /v1/chat/completions` (200), one bad-key request, plus startup.

**Datadog dashboard** ([public link, events retained 15 days](https://p.us5.datadoghq.com/sb/9b1eff10-830b-11f0-b7cb-de02bd9ba50c-16eebab7a56b79814c8337eecd3d8750?from_ts=1787866710000&to_ts=1787866890000&live=false)) — tile queries: `service:lit5558-{base|head} status:{error|info} *LiteLLM* *INFO* -*WARNING*`; "(No data)" = zero matching events:

![Datadog dashboard: LiteLLM INFO logs indexed status:error before vs after](https://raw.githubusercontent.com/yucheng-berri/opentelemetry-python-contrib/assets-pr38476/dd-dashboard.png)

*(tile counts span the dashboard rolling window — three traffic rounds; the pinned evidence-window API counts below are 6 -> 0)*

**Live recording** (Datadog UI on a rolling window while real traffic is sent through both proxies mid-recording — BEFORE tile turns red as base INFO logs are indexed `status:error`, AFTER error tile stays at zero and the same INFO logs land `status:info`):

![Live Datadog recording](https://raw.githubusercontent.com/yucheng-berri/opentelemetry-python-contrib/assets-pr38476/dd-live.gif)

**Read back through Datadog's own search API** (`POST /api/v2/logs/events/search`, evidence window 21:38:50Z–21:41:00Z):

Before (base): every LiteLLM INFO line is indexed `status:error` (6/6), ANSI bytes intact:
```
status=error  \x1b[92m21:39:42 - LiteLLM Router:INFO\x1b[0m: router.py:3206 - litellm.acompletion(model=gemini/gemini-2.5-flash) 200 OK
status=error  \x1b[92m21:39:41 - LiteLLM Proxy:INFO\x1b[0m: route_llm_request.py:273 - SESSION REUSE: ...
status=error  \x1b[92m21:39:11 - LiteLLM Router:INFO\x1b[0m: router.py:1159 - Routing strategy: simple-shuffle
... (6 total; query `service:lit5558-base status:error *LiteLLM* *INFO* -*WARNING*` -> 6)
```

After (head): the same query returns **0**; the same 6 INFO lines are indexed `status:info`, clean text:
```
status=info   21:39:xx - LiteLLM Router:INFO: router.py:3206 - litellm.acompletion(model=gemini/gemini-2.5-flash) 200 OK
status=info   21:39:xx - LiteLLM Proxy:INFO: route_llm_request.py:273 - SESSION REUSE: ...
status=info   21:39:xx - LiteLLM Router:INFO: router.py:1159 - Routing strategy: simple-shuffle
... (query `service:lit5558-head status:info *LiteLLM* *INFO* -*WARNING*` -> 6; status:error -> 0)
```

WARNING/ERROR correctly remain `status:error` on head (e.g. `LiteLLM:WARNING ... register_model`, bad-key auth error). Residual on both sides: **uvicorn's own** `INFO:` startup lines still go to stderr (uvicorn's logger config, not litellm's) — deferred on the ticket.

### Mechanism detail: per-stream before/after (same runs)

### Before (807ee7f232)

#### Case 1: plain-text mode sends INFO to stderr with ANSI garbage

1. Launch proxy, send the requests, count levels per stream
```
INFO lines on stderr: 24    INFO lines on stdout: 0
ANSI-coded lines on stderr: 40
```
2. Raw stderr bytes (what Datadog receives; `cat -v`):
```
^[[92m23:35:04 - LiteLLM Router:INFO^[[0m: router.py:1159 - Routing strategy: simple-shuffle
```

#### Case 2: JSON mode (JSON_LOGS=true) still writes INFO to stderr

1. Same run with JSON_LOGS=true, count JSON INFO records per stream
```
INFO {"level": "INFO"} records on stderr: 24, on stdout: 6 (uvicorn only)
```

#### Case 3: JSON_LOGS=false enables JSON logs

1. Launch with `JSON_LOGS=false`, inspect log format
```
{"message": "background_health_check_config enabled=False shared=False interval_seconds=300 max_concurrency=None details=True health_check_routing=False", "leve
JSON records across both streams: 31   plain-text records: 0
```

### After (882a2cb559)

#### Case 1: plain-text mode sends INFO to stdout, clean text; WARNING+ stays on stderr

1. Same launch and requests, count levels per stream
```
INFO lines on stderr: 0    INFO lines on stdout: 24
ANSI-coded lines on either stream: 0
```
2. Raw stdout bytes (`cat -v`):
```
00:11:37 - LiteLLM Router:INFO: router.py:1159 - Routing strategy: simple-shuffle
```
3. WARNING and ERROR records remain on stderr:
```
00:11:37 - LiteLLM:WARNING: utils.py:3018 - register_model: model=669e6bac2eee2ab76d36577adef65e58d234bfaf998942cb0133ced83f200aaf not in built-in cost map and
00:11:37 - LiteLLM:ERROR: redis_cache.py:364 - Error connecting to Sync Redis client
```

#### Case 2: JSON mode (JSON_LOGS=true) routes INFO to stdout

1. Same run with JSON_LOGS=true
```
INFO {"level": "INFO"} records on stderr: 0, on stdout: 39
```

#### Case 3: JSON_LOGS=false now means plain text

1. Launch with `JSON_LOGS=false`, inspect log format
```
00:13:00 - LiteLLM Router:INFO: router.py:1159 - Routing strategy: simple-shuffle
JSON records across both streams: 0   plain-text INFO records: 29
```

## Type

🐛 Bug Fix

## Caveats (if any)

### Medium

- Behavior change: INFO/DEBUG move from stderr to stdout; stderr scrapers must read stdout
- Behavior change: JSON_LOGS=1/yes no longer enables JSON logs, only "true" does

### Low

- Behavior change: piped/redirected plain-text logs lose ANSI color codes; terminals keep them
- Duplicate lines from a root-logger handler (propagate=True) are deliberately not changed here: flipping the default silently breaks the /key/health logging check and pytest caplog capture; deferred to the ticket
- ANSI codes embedded in some router.py message bodies (not the formatter) are untouched; they do not affect level parsing

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

