### PR TITLE
fix(bedrock): credit gateway caching where the tool cachePoint is placed

### DIFF
--- a/litellm/integrations/anthropic_cache_control_hook.py
+++ b/litellm/integrations/anthropic_cache_control_hook.py
@@ -753,7 +753,7 @@ class AnthropicCacheControlHook(CustomPromptManagement):
 
     @staticmethod
     def record_gateway_injection(
-        request_kwargs: dict[str, Any],  # mutable-ok: stamps the marker into the caller's live request kwargs
+        request_kwargs: Mapping[str, object],
         added: int,
     ) -> None:
         """Name the deployment whose payload the gateway, not the client, put breakpoints on.
@@ -780,6 +780,11 @@ class AnthropicCacheControlHook(CustomPromptManagement):
         that Bedrock credit is the fail-closed direction, and the alternative is a
         provider transform that carries spend-attribution state.
 
+        Reads whichever bucket the request actually carries rather than asking the shared
+        name resolver, which answers on key presence: ``litellm_params`` declares
+        ``litellm_metadata`` as None on every request, so the resolver names a bucket that
+        is not there and the mark is dropped.
+
         Never CREATES the bucket. The proxy seeds it on every request and is the marker's
         only reader, so a request without one is a bare SDK call nothing would consume it
         from. Creating it would also add a key to a dict call sites splat as ``**kwargs``,
@@ -788,10 +793,15 @@ class AnthropicCacheControlHook(CustomPromptManagement):
         """
         if added <= 0:
             return
-        from litellm.litellm_core_utils.core_helpers import get_metadata_variable_name_from_kwargs
-
-        bucket: Final = request_kwargs.get(get_metadata_variable_name_from_kwargs(request_kwargs))
-        if isinstance(bucket, dict):
+        bucket: Final = next(
+            (
+                candidate
+                for candidate in (request_kwargs.get("litellm_metadata"), request_kwargs.get("metadata"))
+                if isinstance(candidate, dict)
+            ),
+            None,
+        )
+        if bucket is not None:
             model_info: Final = request_kwargs.get("model_info")
             bucket[GATEWAY_INJECTED_CACHE_METADATA_KEY] = (
                 model_info.get("id", GATEWAY_INJECTED_FOR_EVERY_DEPLOYMENT)

--- a/litellm/llms/bedrock/chat/converse_transformation.py
+++ b/litellm/llms/bedrock/chat/converse_transformation.py
@@ -1543,6 +1543,7 @@ class AmazonConverseConfig(BaseConfig):
         messages: list[AllMessageValues] | None = None,
         headers: dict | None = None,
         drop_params: bool = False,
+        litellm_params: Mapping[str, object] | None = None,
     ) -> CommonRequestObject:
         ## VALIDATE REQUEST
         """
@@ -1605,6 +1606,16 @@ class AmazonConverseConfig(BaseConfig):
                 if point.get("location") == "tool_config":
                     cache_point = self._build_cache_point_block(point.get("control"), model)
                     bedrock_tools.append(ToolBlock(cachePoint=cache_point))
+                    # Spend attribution credits the gateway only for breakpoints it placed, and
+                    # this is the one place a tool_config point becomes one. The hook that reads
+                    # the configuration cannot record it: whether a cachePoint lands depends on
+                    # this provider and on the request carrying tools, neither of which it sees.
+                    if litellm_params is not None:
+                        from litellm.integrations.anthropic_cache_control_hook import (
+                            AnthropicCacheControlHook,
+                        )
+
+                        AnthropicCacheControlHook.record_gateway_injection(litellm_params, 1)
                     break
 
         bedrock_tool_config: ToolConfigBlock | None = None
@@ -1667,6 +1678,7 @@ class AmazonConverseConfig(BaseConfig):
             messages=messages,
             headers=headers,
             drop_params=litellm_params.get("drop_params") is True,
+            litellm_params=litellm_params,
         )
 
         bedrock_messages: Final = await BedrockConverseMessagesProcessor._bedrock_converse_messages_pt_async(
@@ -1726,6 +1738,7 @@ class AmazonConverseConfig(BaseConfig):
             messages=messages,
             headers=headers,
             drop_params=litellm_params.get("drop_params") is True,
+            litellm_params=litellm_params,
         )
 
         ## TRANSFORMATION ##

--- a/tests/test_litellm/llms/bedrock/chat/test_converse_transformation.py
+++ b/tests/test_litellm/llms/bedrock/chat/test_converse_transformation.py
@@ -887,6 +887,43 @@ def test_get_supported_openai_params_bedrock_converse():
         print(f"✅ Passed for model: {model}")
 
 
+@pytest.mark.parametrize(
+    "tools, expected_marker",
+    [
+        pytest.param(
+            [{"type": "function", "function": {"name": "f", "parameters": {"type": "object", "properties": {}}}}],
+            "dep-bedrock",
+            id="tools-present-so-the-cachepoint-is-placed",
+        ),
+        pytest.param(None, None, id="no-tools-so-nothing-is-placed"),
+    ],
+)
+def test_tool_config_cachepoint_is_credited_only_where_it_is_placed(tools, expected_marker):
+    """Spend attribution credits the gateway for breakpoints it placed, and a tool_config
+    point becomes one here or nowhere.
+
+    The hook that reads the configuration cannot record it: whether a cachePoint lands
+    depends on this provider and on the request carrying tools, neither of which the hook
+    sees, so marking on the point's presence credited request shapes that inject nothing.
+    """
+    bucket: dict = {"user_api_key": "sk-test"}
+    optional_params = {"cache_control_injection_points": [{"location": "tool_config"}]}
+    if tools is not None:
+        optional_params["tools"] = tools
+
+    data = AmazonConverseConfig()._transform_request_helper(
+        model="anthropic.claude-sonnet-4-5-20250929-v1:0",
+        system_content_blocks=[],
+        optional_params=optional_params,
+        messages=[{"role": "user", "content": "hi"}],
+        litellm_params={"metadata": bucket, "litellm_metadata": None, "model_info": {"id": "dep-bedrock"}},
+    )
+
+    placed = "cachePoint" in json.dumps(data.get("toolConfig", {}))
+    assert placed is (expected_marker is not None)
+    assert bucket.get("litellm_gateway_injected_cache") == expected_marker
+
+
 def test_transform_request_helper_includes_anthropic_beta_and_tools():
     """Test _transform_request_helper includes anthropic_beta for computer tools."""
     config = AmazonConverseConfig()


### PR DESCRIPTION
## TLDR

Problem this solves:

- Bedrock tool caching LiteLLM caused was never credited to it
- The hook that reads the config cannot tell whether a cachePoint lands
- Marking on the config instead credited requests that cached nothing

How it solves it:

- Record the injection where the cachePoint is actually appended
- Requests without tools, and non-Bedrock providers, stay uncredited

## User Flow

Before: an admin who configured tool caching sees the savings, but the gateway is credited with none of it

1. Their admin configures a Bedrock deployment with a `tool_config` cache injection point
2. They send POST https://litellm-domain/v1/chat/completions with a large set of tool definitions
3. They repeat the same request and the response reports 13,416 cached tokens, so caching is clearly working
4. They open https://litellm-domain/ui/?page=cost-optimization and read "Prompt caching savings"
5. The total shows the money caching saved, but the LiteLLM-injected figure beside it reads $0.00, even though nothing else put those breakpoints there

After: the same traffic credits the gateway for the caching it caused

1. Their admin configures the same deployment the same way
2. They send the same POST https://litellm-domain/v1/chat/completions with the same tool definitions
3. The repeat request still reports 13,416 cached tokens
4. They open the same page and the LiteLLM-injected figure now carries that request's share
5. A request sent without tools caches nothing and still adds nothing to that figure

## Relevant issues

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally
- [x] My PR passes all required CI/CD checks
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5**

## Notes for reviewers

Stacked on #38134, which introduces the marker this reads and writes. It cannot go on `litellm_internal_staging` on its own, because `record_gateway_injection` does not exist there yet.

#38134 deliberately leaves this case uncredited. The hook that reads `cache_control_injection_points` runs before the provider is involved, so it cannot know whether a `tool_config` point becomes a cachePoint: that depends on the provider being Bedrock converse and on the request carrying tools. Marking on the point's presence credited three request shapes out of four that place nothing, so #38134 stopped claiming it and named the gap. This closes it from the other side, by recording at the one place the cachePoint is actually appended.

Two things came out of the plumbing, both worth a look:

- `record_gateway_injection` asked the shared metadata-name resolver for its bucket, and that resolver answers on key presence. `litellm_params` declares `litellm_metadata` as None on every request, so the resolver named a bucket that was not there and the mark was silently dropped. It now reads whichever bucket actually holds a dict. The shared resolver is untouched: 26 callers, and key presence is arguably right for `get_or_create_metadata_bucket`, which has to name a bucket even when none exists. Worth its own change rather than a drive-by here.
- The function never writes to the request dict, only to the bucket inside it, so its parameter is now a `Mapping` and its `mutable-ok` suppression is gone.

## Screenshots / Proof of Fix

Real Bedrock, `us.anthropic.claude-haiku-4-5-20251001-v1:0` in `us-east-1`, 40 tool definitions so the tool block clears the minimum cacheable prefix. Same request twice, so the second one reads the entry the first wrote.

### Before (76cc6a6cbe)

1. Send the request twice with a `tool_config` injection point configured

```
call 1, tool_config point configured
   cache_creation=0  cache_read=13416  prompt=13747
   marker=None
   credited=False
call 2, same request
   cache_creation=0  cache_read=13416  prompt=13747
   marker=None
   credited=False
```

2. 13,416 tokens are served from cache, and the gateway is credited for none of it

### After (2d90d9e75a)

1. Send the identical request twice against the same deployment

```
call 1, tool_config point configured
   cache_creation=0  cache_read=13416  prompt=13747
   marker=''
   credited=True
call 2, same request
   cache_creation=0  cache_read=13416  prompt=13747
   marker=''
   credited=True
```

2. The same 13,416 cached tokens now credit the gateway that put the breakpoint there
