### PR TITLE
fix(router): apply model renames to the in-memory deployment list

### DIFF
--- a/litellm/router.py
+++ b/litellm/router.py
@@ -9075,7 +9075,8 @@ class Router:
             if _deployment_on_router is not None:
                 # deployment with this model_id exists on the router
                 if (
-                    deployment.litellm_params == _deployment_on_router.litellm_params
+                    deployment.model_name == _deployment_on_router.model_name
+                    and deployment.litellm_params == _deployment_on_router.litellm_params
                     and deployment.model_info == _deployment_on_router.model_info
                 ):
                     # No need to update

--- a/tests/test_litellm/test_router.py
+++ b/tests/test_litellm/test_router.py
@@ -8096,6 +8096,71 @@ class TestUpsertDeploymentRollback:
         assert len(router.model_list) == 1
 
 
+class TestUpsertDeploymentRename:
+    """
+    Issue #38360: renaming a model wrote the new `model_name` to the db, but the reload's
+    `upsert_deployment` compared only `litellm_params` and `model_info`. A rename with no
+    other edit therefore compared equal and the router kept the old name until a restart,
+    so `/model/info` and `/v1/models` served the stale name and the new one was unroutable.
+    """
+
+    @staticmethod
+    def _router() -> "litellm.Router":
+        return litellm.Router(
+            model_list=[
+                {
+                    "model_name": "old-name",
+                    "litellm_params": {"model": "openai/gpt-4o", "api_key": "sk-test"},
+                    "model_info": {"id": "rename-1", "db_model": True},
+                }
+            ]
+        )
+
+    @staticmethod
+    def _deployment(model_name: str, tpm: int | None = None):
+        from litellm.types.router import Deployment, LiteLLM_Params, ModelInfo
+
+        return Deployment(
+            model_name=model_name,
+            litellm_params=LiteLLM_Params(model="openai/gpt-4o", api_key="sk-test", tpm=tpm),
+            model_info=ModelInfo(id="rename-1", db_model=True),
+        )
+
+    def test_rename_only_updates_the_router(self):
+        router = self._router()
+
+        assert router.upsert_deployment(deployment=self._deployment("new-name")) is not None
+
+        assert [model["model_name"] for model in router.model_list] == ["new-name"]
+        renamed = router.get_deployment(model_id="rename-1")
+        assert renamed is not None
+        assert renamed.model_name == "new-name"
+
+    def test_rename_only_makes_the_new_name_routable(self):
+        router = self._router()
+
+        router.upsert_deployment(deployment=self._deployment("new-name"))
+
+        assert router.get_model_ids(model_name="new-name") == ["rename-1"]
+        assert router.get_model_ids(model_name="old-name") == []
+
+    def test_rename_alongside_another_edit_still_updates(self):
+        router = self._router()
+
+        router.upsert_deployment(deployment=self._deployment("new-name", tpm=1234))
+
+        assert router.get_model_ids(model_name="new-name") == ["rename-1"]
+        renamed = router.get_deployment(model_id="rename-1")
+        assert renamed is not None
+        assert renamed.litellm_params.tpm == 1234
+
+    def test_unchanged_deployment_is_still_a_no_op(self):
+        router = self._router()
+
+        assert router.upsert_deployment(deployment=self._deployment("old-name")) is None
+        assert [model["model_name"] for model in router.model_list] == ["old-name"]
+
+
 class TestConsumedRequestTagsStamp:
     """Issue #36621: when a request's tags select a tagged pre-routing strategy, those
     tags are consumed by the selection; the hook must stamp the rewritten model group so


### PR DESCRIPTION
## TLDR

Problem this solves:

- Renaming a model saves, then reverts on refresh
- The new name returns 400, the old name still works
- Only a proxy restart makes the rename appear

How it solves it:

- Treat a changed model name as a real change
- The router now reloads the deployment on rename


## User Flow

Before: an admin renames a model, is told it saved, and finds the old name back on refresh

1. They open https://litellm-domain/ui/models-and-endpoints and click a model named `gpt4-prod`
2. They hit Edit, change Model Name to `gpt4-team-a`, and Save
3. A green "Model settings updated successfully" toast appears
4. They refresh the page and the model is named `gpt4-prod` again
5. They send POST https://litellm-domain/v1/chat/completions with `"model": "gpt4-team-a"` and get 400 `Invalid model name passed in`
6. The same call with `"model": "gpt4-prod"` still returns 200

After: the rename holds on refresh and the new name is immediately callable

1. They open https://litellm-domain/ui/models-and-endpoints and click a model named `gpt4-prod`
2. They hit Edit, change Model Name to `gpt4-team-a`, and Save
3. A green "Model settings updated successfully" toast appears
4. They refresh the page and the model is named `gpt4-team-a`
5. They send POST https://litellm-domain/v1/chat/completions with `"model": "gpt4-team-a"` and get 200
6. The same call with `"model": "gpt4-prod"` now returns 400 `Invalid model name passed in`

## Relevant issues

 Fixes #38360 

## Linear ticket

Resolves LIT-6548

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review
## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Setup for both sides: 2 proxy instances x 2 uvicorn workers each, sharing one Postgres with `store_model_in_db: true`, model `openai/gpt-5.4-mini`, real OpenAI calls. Booted WITHOUT `LITELLM_LICENSE`: a licensed proxy stamps `updated_at` into every deployment on DB sync, which already forces a refresh and hides this bug, so it only bites license-free deployments (verified both ways during QA). `$MASTER_KEY` masked. Before ran on ports 28541 (A) and 21436 (B), After on 34486 (A) and 34100 (B)

### Before (192ccaaf02518c38d92f2d7ef04435559dc94500)

#### Admin UI rename

1. Open http://localhost:28541/ui/models-and-endpoints, click the model, Edit Settings, change Model Name `gpt4-round2` to `gpt4-round3`, Save Changes
2. Toast says "Model settings updated successfully", and the DB row is renamed:

```
$ psql .../litellm_qa -c 'SELECT model_name, updated_at FROM "LiteLLM_ProxyModelTable";'
gpt4-round3 | 2026-08-31 22:13:24.837
```

3. Refresh the models page: the row shows `gpt4-round2` again. The rename silently reverted
4. Both instances polled every 15s for 90s, stuck on the old name the whole time:

```
poll 1 (22:13:50Z): A/v1/models=[gpt4-round2] A/model/info=[gpt4-round2] B/v1/models=[gpt4-round2] B/model/info=[gpt4-round2]
... identical ...
poll 7 (22:15:22Z): A/v1/models=[gpt4-round2] A/model/info=[gpt4-round2] B/v1/models=[gpt4-round2] B/model/info=[gpt4-round2]
```

5. Chat completions, 2x per name per port to cover every worker:

```
$ curl -s -X POST http://localhost:<port>/v1/chat/completions -H "Authorization: Bearer $MASTER_KEY" \
    -H 'Content-Type: application/json' -d '{"model": "<name>", "messages": [{"role": "user", "content": "Reply with exactly: ok"}]}'
port 28541 model gpt4-round3: 400 400  (Invalid model name passed in model=gpt4-round3)
port 28541 model gpt4-round2: 200 200  (content 'ok', id chatcmpl-EJ4aHClrG6WRoVKVfRqoT19ZhTgOV)
port 21436 model gpt4-round3: 400 400  (Invalid model name passed in model=gpt4-round3)
port 21436 model gpt4-round2: 200 200  (content 'ok', id chatcmpl-EJ4aKfxopc9dDNuxrYWHgBR45gz6r)
```

#### Rename-only PATCH via API

1. Rename the deployment `gpt4-prod` to `gpt4-team-a` (this is the request the UI edit reduces to):

```
$ curl -s -X PATCH http://localhost:28541/model/c9935483-9096-4ba8-8f3b-acea8524c5ca/update \
    -H "Authorization: Bearer $MASTER_KEY" -H 'Content-Type: application/json' -d '{"model_name": "gpt4-team-a"}'
HTTP 200, response and DB row both say gpt4-team-a
```

2. Poll `GET /v1/models` and `GET /model/info` on both instances every 15s for 150s: every poll on every surface still lists only `gpt4-prod`
3. Chat completions: `gpt4-team-a` gets 400 `Invalid model name passed in` on all 4 workers, `gpt4-prod` still gets 200 with a real completion everywhere

### After (f0c336cccb6e136de44c045709c60e60a5f62dcc)

#### Admin UI rename

1. Open http://localhost:34486/ui/models-and-endpoints, click the model, Edit Settings, change Model Name `gpt4-team-b` to `gpt4-team-c`, Save Changes
2. Toast says "Model settings updated successfully", DB row says `gpt4-team-c` (updated_at 2026-08-31 22:17:38.974)
3. Refresh the models page: the row shows `gpt4-team-c` and stays
4. Both instances already converged on the first poll:

```
poll 1 (22:18:04Z): A/v1/models=[gpt4-team-c] B/v1/models=[gpt4-team-c]
```

5. Chat completions, 2x per name per port:

```
port 34486 model gpt4-team-c: 200 200  (content 'ok', id chatcmpl-EJ4cPFMbbHjae8heaDphv9xna2rei)
port 34486 model gpt4-team-b: 400 400  (Invalid model name passed in model=gpt4-team-b)
port 34100 model gpt4-team-c: 200 200  (content 'ok', id chatcmpl-EJ4cTfwRq3Leympw3uTDmTDyKmDp6)
port 34100 model gpt4-team-b: 400 400  (Invalid model name passed in model=gpt4-team-b)
```

#### Rename-only PATCH via API

1. Same request shape as the Before side, renaming `gpt4-team-c` to `gpt4-team-d`:

```
$ curl -s -X PATCH http://localhost:34486/model/6341bc37-eb48-4847-8b5e-8bcd26839757/update \
    -H "Authorization: Bearer $MASTER_KEY" -H 'Content-Type: application/json' -d '{"model_name": "gpt4-team-d"}'
model_name: gpt4-team-d | updated_at: 2026-08-31T22:19:26.125000Z
```

2. Both instances converge within one DB-poll cycle:

```
poll 1 (22:19:34Z): A/v1/models=[gpt4-team-d] B/v1/models=[gpt4-team-c]
poll 3 (22:19:50Z): A/v1/models=[gpt4-team-d] B/v1/models=[gpt4-team-d]
```

3. Chat completions: `gpt4-team-d` gets 200 with a real completion on all 4 workers (id chatcmpl-EJ4e76k04sXQpZOEx9T3kYZhoTLMp on A, chatcmpl-EJ4e9oxjPi4dLfyUHYK6PUmxLnNbg on B), `gpt4-team-c` gets 400 everywhere

## Type

🐛 Bug Fix


## Caveats (if any)

### Low

- Renaming now pops and re-adds the deployment
- In-flight requests keep using the old name until reload
- Licensed (premium) proxies never hit this bug: their DB sync already forced the refresh

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

- [x] f0c336cccb6e136de44c045709c60e60a5f62dcc passes /live-pr-risk

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches hot-path deployment reload logic and model-name routing indexes; behavior change is narrow (renames now trigger replace) but affects how live proxy state syncs from DB.
> 
> **Overview**
> Fixes a bug where **renaming a model** in the admin UI persisted to the DB but the in-memory router kept the old `model_name` until restart, so `/model/info` and `/v1/models` were stale and routing used the wrong name.
> 
> `upsert_deployment` now treats a **`model_name` change** as a real update: the early “no change” path requires `model_name` to match in addition to `litellm_params` and `model_info`, so a rename-only reload replaces the deployment and updates name-based routing maps.
> 
> New tests (`TestUpsertDeploymentRename`) cover rename-only updates, routability of the new name, rename combined with param edits, and unchanged deployments still returning no-op.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f0c336cccb6e136de44c045709c60e60a5f62dcc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
