### PR TITLE
feat(model_prices): let a map entry declare its exact reasoning_effort levels

### DIFF
--- a/ci_cd/generate_model_prices_schema.py
+++ b/ci_cd/generate_model_prices_schema.py
@@ -73,6 +73,11 @@ ARRAY_KEYS: dict[str, JsonSchema] = {
         "description": "Output modalities the model can produce.",
         "items": {"type": "string", "enum": ["text", "image", "audio", "video", "code"]},
     },
+    "reasoning_effort_levels": {
+        "type": "array",
+        "description": "Exact reasoning_effort levels this deployment accepts; wins over supports_* flags.",
+        "items": {"type": "string", "enum": ["none", "minimal", "low", "medium", "high", "xhigh", "max"]},
+    },
     "supported_regions": {
         "type": "array",
         "description": "Cloud regions the model is available in ('global' or region ids).",

--- a/litellm/llms/anthropic/experimental_pass_through/utils.py
+++ b/litellm/llms/anthropic/experimental_pass_through/utils.py
@@ -1,4 +1,6 @@
 import os
+from collections.abc import Mapping
+from types import MappingProxyType
 from typing import Final
 
 import litellm
@@ -21,6 +23,29 @@ def local_model_name(model: str, custom_llm_provider: object) -> str:
 def is_reasoning_auto_summary_enabled() -> bool:
     """Check whether the default 'summary: detailed' injection is enabled (opt-in)."""
     return litellm.reasoning_auto_summary or os.getenv("LITELLM_REASONING_AUTO_SUMMARY", "false").lower() == "true"
+
+
+_DECLARED_DEGRADATION_CHAINS: Final[Mapping[str, tuple[str, ...]]] = MappingProxyType(
+    {"max": ("max", "xhigh", "high"), "xhigh": ("xhigh", "high"), "minimal": ("minimal", "low")}
+)
+
+
+def _effort_from_declaration(model_info: ModelInfo, effort: str) -> str | None:
+    """A declared level set is the WHOLE answer for this gate, so a level it omits degrades even
+    where a per-level flag would have allowed it. Honoring both would let /model_group/info and
+    this path disagree about the same entry. None means the entry declares nothing, and the flag
+    chain below decides as before.
+
+    A declaration that omits every level in a chain still lands on that chain's terminal, which can
+    itself be undeclared. Picking a nearer declared level instead would need a strength ordering,
+    and the advertisement order is presentation only by design, so the terminal stays the answer."""
+    from litellm.router_utils.reasoning_effort_capability import declared_reasoning_efforts
+
+    declared: Final = declared_reasoning_efforts(model_info)
+    if declared is None:
+        return None
+    chain: Final = _DECLARED_DEGRADATION_CHAINS[effort]
+    return next((level for level in chain if level in declared), chain[-1])
 
 
 def normalize_reasoning_effort_value(
@@ -47,6 +72,10 @@ def normalize_reasoning_effort_value(
         model_info = get_model_info(model=model, custom_llm_provider=custom_llm_provider)
     except Exception:
         model_info = None
+
+    declared_effort: Final = _effort_from_declaration(model_info, effort) if model_info is not None else None
+    if declared_effort is not None:
+        return declared_effort
 
     if effort == "max":
         if model_info and model_info.get("supports_max_reasoning_effort"):

--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -9315,6 +9315,11 @@
         "max_tokens": 131072,
         "mode": "chat",
         "output_cost_per_token": 1.65e-05,
+        "reasoning_effort_levels": [
+            "low",
+            "high",
+            "max"
+        ],
         "source": "https://techcommunity.microsoft.com/blog/azure-ai-foundry-blog/introducing-kimi-k3-through-fireworks-ai-on-microsoft-foundry/4540187",
         "supported_modalities": [
             "text",
@@ -31632,6 +31637,11 @@
         "max_tokens": 1048576,
         "mode": "chat",
         "output_cost_per_token": 1.5e-05,
+        "reasoning_effort_levels": [
+            "low",
+            "high",
+            "max"
+        ],
         "source": "https://platform.kimi.ai/docs/pricing/chat-k3",
         "supports_function_calling": true,
         "supports_reasoning": true,
@@ -36240,6 +36250,14 @@
         "litellm_provider": "perplexity",
         "mode": "responses",
         "output_cost_per_token": 1.5e-05,
+        "reasoning_effort_levels": [
+            "minimal",
+            "low",
+            "medium",
+            "high",
+            "xhigh",
+            "max"
+        ],
         "source": "https://docs.perplexity.ai/docs/agent-api/models",
         "supports_web_search": true,
         "supports_reasoning": true,
@@ -38698,6 +38716,11 @@
         "max_tokens": 1048576,
         "mode": "chat",
         "output_cost_per_token": 1.5e-05,
+        "reasoning_effort_levels": [
+            "low",
+            "high",
+            "max"
+        ],
         "source": "https://docs.together.ai/docs/serverless-models",
         "supports_function_calling": true,
         "supports_parallel_function_calling": true,
@@ -51487,6 +51510,11 @@
         "max_tokens": 131072,
         "mode": "chat",
         "output_cost_per_token": 1.5e-05,
+        "reasoning_effort_levels": [
+            "low",
+            "high",
+            "max"
+        ],
         "source": "https://docs.fireworks.ai/serverless/pricing",
         "supports_function_calling": true,
         "supports_reasoning": true,
@@ -51551,6 +51579,11 @@
         "max_tokens": 131072,
         "mode": "chat",
         "output_cost_per_token": 1.5e-05,
+        "reasoning_effort_levels": [
+            "low",
+            "high",
+            "max"
+        ],
         "source": "https://docs.fireworks.ai/serverless/pricing",
         "supports_function_calling": true,
         "supports_reasoning": true,
@@ -51567,6 +51600,11 @@
         "max_tokens": 131072,
         "mode": "chat",
         "output_cost_per_token": 2.25e-05,
+        "reasoning_effort_levels": [
+            "low",
+            "high",
+            "max"
+        ],
         "source": "https://docs.fireworks.ai/serverless/pricing",
         "supports_function_calling": true,
         "supports_reasoning": true,
@@ -51583,6 +51621,11 @@
         "max_tokens": 131072,
         "mode": "chat",
         "output_cost_per_token": 1.65e-05,
+        "reasoning_effort_levels": [
+            "low",
+            "high",
+            "max"
+        ],
         "source": "https://docs.fireworks.ai/serverless/pricing",
         "supports_function_calling": true,
         "supports_reasoning": true,
@@ -51755,6 +51798,11 @@
         "max_tokens": 131072,
         "mode": "chat",
         "output_cost_per_token": 2.25e-05,
+        "reasoning_effort_levels": [
+            "low",
+            "high",
+            "max"
+        ],
         "source": "https://docs.fireworks.ai/serverless/pricing",
         "supports_function_calling": true,
         "supports_reasoning": true,
@@ -51771,6 +51819,11 @@
         "max_tokens": 131072,
         "mode": "chat",
         "output_cost_per_token": 1.65e-05,
+        "reasoning_effort_levels": [
+            "low",
+            "high",
+            "max"
+        ],
         "source": "https://docs.fireworks.ai/serverless/pricing",
         "supports_function_calling": true,
         "supports_reasoning": true,

--- a/litellm/router_utils/reasoning_effort_capability.py
+++ b/litellm/router_utils/reasoning_effort_capability.py
@@ -1,10 +1,13 @@
 """Resolve which reasoning_effort values a deployment, and by intersection a model group, accepts.
 
-The model map's supports_*_reasoning_effort flags are the only signal, and each level's polarity
-mirrors how a request path reads that same flag. medium and high are unconditional for a reasoning
-model. minimal and low are opt-out: openai/chat/gpt_5_transformation.py refuses them only when the
-map says false. xhigh and max are opt-in. none is opt-out everywhere except the azure gpt-5 family,
-whose config raises UnsupportedParamsError without an explicit true.
+An entry that states its levels outright in reasoning_effort_levels is read first and wins
+whole, for a model whose set the per-level flags cannot express: Kimi K3 takes low, high and max,
+and no flag can drop medium because medium has none. Every other entry answers through the
+supports_*_reasoning_effort flags below, whose polarity mirrors how a request path reads that same
+flag. medium and high are unconditional for a reasoning model. minimal and low are opt-out:
+openai/chat/gpt_5_transformation.py refuses them only when the map says false. xhigh and max are
+opt-in. none is opt-out everywhere except the azure gpt-5 family, whose config raises
+UnsupportedParamsError without an explicit true.
 
 xhigh is gated on the request path by the openai and azure gpt-5 configs. max is not gated there at
 all: every entry carrying supports_max_reasoning_effort is Claude-family, and
@@ -41,6 +44,7 @@ _EFFORT_FLAGS: Final = (
     ("xhigh", "supports_xhigh_reasoning_effort"),
     ("max", "supports_max_reasoning_effort"),
 )
+_DECLARED_EFFORTS_KEY: Final = "reasoning_effort_levels"
 _OPT_OUT_EFFORTS: Final = ("minimal", "low")
 _OPT_IN_EFFORTS: Final = ("xhigh", "max")
 _UNCONDITIONAL_EFFORTS: Final = frozenset(("medium", "high"))
@@ -67,6 +71,20 @@ def _declared_effort_flags(model_info: Mapping[str, object]) -> Mapping[str, obj
             for effort, flag in _EFFORT_FLAGS
         }
     )
+
+
+def declared_reasoning_efforts(model_info: Mapping[str, object]) -> tuple[str, ...] | None:
+    """The entry's own answer, read through the same bare twin as the flags so both spellings of one
+    model agree. Present-and-a-list IS the answer, so a declared [] correctly empties the group and
+    an unknown level is dropped rather than raised: the bundled map is enum-validated by
+    validate-model-prices-json, but an operator can put this key on a config.yaml model_info block
+    where that schema never runs, and one mistyped level must not fail every sibling on the proxy."""
+    own: Final = model_info.get(_DECLARED_EFFORTS_KEY)
+    raw: Final = own if own is not None else _bare_model_entry(model_info).get(_DECLARED_EFFORTS_KEY)
+    if not isinstance(raw, Sequence) or isinstance(raw, (str, bytes)):
+        return None
+    declared: Final = frozenset(effort for effort in raw if isinstance(effort, str))
+    return tuple(effort for effort in REASONING_EFFORT_ADVERTISEMENT_ORDER if effort in declared)
 
 
 def _supports_none_reasoning_effort(model_info: Mapping[str, object], flag: object) -> bool:
@@ -118,6 +136,10 @@ def resolve_supported_reasoning_efforts(
     supports_reasoning: Final = model_info.get("supports_reasoning")
     if supports_reasoning is not True:
         return () if supports_reasoning is False or deployment_is_mapped else None
+
+    declared: Final = declared_reasoning_efforts(model_info)
+    if declared is not None:
+        return declared
 
     flags: Final = _declared_effort_flags(model_info)
     if all(value is None for value in flags.values()):

--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -164,6 +164,7 @@ class ProviderSpecificModelInfo(TypedDict, total=False):
     supports_low_reasoning_effort: bool | None
     supports_xhigh_reasoning_effort: bool | None
     supports_max_reasoning_effort: bool | None
+    reasoning_effort_levels: ReadOnly[Sequence[str] | None]
     supports_output_config: bool | None
     supports_image_size: bool | None
     bedrock_output_config_effort_ceiling: Literal["low", "medium", "high", "max", "xhigh"] | None

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -5876,6 +5876,7 @@ def _get_model_info_helper(
                 supports_low_reasoning_effort=_model_info.get("supports_low_reasoning_effort", None),
                 supports_xhigh_reasoning_effort=_model_info.get("supports_xhigh_reasoning_effort", None),
                 supports_max_reasoning_effort=_model_info.get("supports_max_reasoning_effort", None),
+                reasoning_effort_levels=_model_info.get("reasoning_effort_levels", None),
                 bedrock_output_config_effort_ceiling=_model_info.get("bedrock_output_config_effort_ceiling", None),
                 bedrock_converse_supports_strict_tools=_model_info.get("bedrock_converse_supports_strict_tools", None),
                 supports_computer_use=_model_info.get("supports_computer_use", None),

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -9315,6 +9315,11 @@
         "max_tokens": 131072,
         "mode": "chat",
         "output_cost_per_token": 1.65e-05,
+        "reasoning_effort_levels": [
+            "low",
+            "high",
+            "max"
+        ],
         "source": "https://techcommunity.microsoft.com/blog/azure-ai-foundry-blog/introducing-kimi-k3-through-fireworks-ai-on-microsoft-foundry/4540187",
         "supported_modalities": [
             "text",
@@ -31632,6 +31637,11 @@
         "max_tokens": 1048576,
         "mode": "chat",
         "output_cost_per_token": 1.5e-05,
+        "reasoning_effort_levels": [
+            "low",
+            "high",
+            "max"
+        ],
         "source": "https://platform.kimi.ai/docs/pricing/chat-k3",
         "supports_function_calling": true,
         "supports_reasoning": true,
@@ -36240,6 +36250,14 @@
         "litellm_provider": "perplexity",
         "mode": "responses",
         "output_cost_per_token": 1.5e-05,
+        "reasoning_effort_levels": [
+            "minimal",
+            "low",
+            "medium",
+            "high",
+            "xhigh",
+            "max"
+        ],
         "source": "https://docs.perplexity.ai/docs/agent-api/models",
         "supports_web_search": true,
         "supports_reasoning": true,
@@ -38698,6 +38716,11 @@
         "max_tokens": 1048576,
         "mode": "chat",
         "output_cost_per_token": 1.5e-05,
+        "reasoning_effort_levels": [
+            "low",
+            "high",
+            "max"
+        ],
         "source": "https://docs.together.ai/docs/serverless-models",
         "supports_function_calling": true,
         "supports_parallel_function_calling": true,
@@ -51487,6 +51510,11 @@
         "max_tokens": 131072,
         "mode": "chat",
         "output_cost_per_token": 1.5e-05,
+        "reasoning_effort_levels": [
+            "low",
+            "high",
+            "max"
+        ],
         "source": "https://docs.fireworks.ai/serverless/pricing",
         "supports_function_calling": true,
         "supports_reasoning": true,
@@ -51551,6 +51579,11 @@
         "max_tokens": 131072,
         "mode": "chat",
         "output_cost_per_token": 1.5e-05,
+        "reasoning_effort_levels": [
+            "low",
+            "high",
+            "max"
+        ],
         "source": "https://docs.fireworks.ai/serverless/pricing",
         "supports_function_calling": true,
         "supports_reasoning": true,
@@ -51567,6 +51600,11 @@
         "max_tokens": 131072,
         "mode": "chat",
         "output_cost_per_token": 2.25e-05,
+        "reasoning_effort_levels": [
+            "low",
+            "high",
+            "max"
+        ],
         "source": "https://docs.fireworks.ai/serverless/pricing",
         "supports_function_calling": true,
         "supports_reasoning": true,
@@ -51583,6 +51621,11 @@
         "max_tokens": 131072,
         "mode": "chat",
         "output_cost_per_token": 1.65e-05,
+        "reasoning_effort_levels": [
+            "low",
+            "high",
+            "max"
+        ],
         "source": "https://docs.fireworks.ai/serverless/pricing",
         "supports_function_calling": true,
         "supports_reasoning": true,
@@ -51755,6 +51798,11 @@
         "max_tokens": 131072,
         "mode": "chat",
         "output_cost_per_token": 2.25e-05,
+        "reasoning_effort_levels": [
+            "low",
+            "high",
+            "max"
+        ],
         "source": "https://docs.fireworks.ai/serverless/pricing",
         "supports_function_calling": true,
         "supports_reasoning": true,
@@ -51771,6 +51819,11 @@
         "max_tokens": 131072,
         "mode": "chat",
         "output_cost_per_token": 1.65e-05,
+        "reasoning_effort_levels": [
+            "low",
+            "high",
+            "max"
+        ],
         "source": "https://docs.fireworks.ai/serverless/pricing",
         "supports_function_calling": true,
         "supports_reasoning": true,

--- a/model_prices_and_context_window.schema.json
+++ b/model_prices_and_context_window.schema.json
@@ -532,6 +532,22 @@
           "type": "object",
           "description": "Provider-internal routing hints (e.g. bedrock_invocation_schema)."
         },
+        "reasoning_effort_levels": {
+          "type": "array",
+          "description": "Exact reasoning_effort levels this deployment accepts; wins over supports_* flags.",
+          "items": {
+            "type": "string",
+            "enum": [
+              "none",
+              "minimal",
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ]
+          }
+        },
         "regional_endpoint_uplift_multiplier": {
           "type": "number",
           "minimum": 1,

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/test_reasoning_effort_fields.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/test_reasoning_effort_fields.py
@@ -14,6 +14,8 @@ from unittest.mock import patch
 
 import pytest
 
+import litellm
+
 from litellm.llms.anthropic.experimental_pass_through.utils import (
     normalize_reasoning_effort_value,
 )
@@ -291,3 +293,91 @@ class TestAdapterAdaptiveThinking:
         )
         assert result is not None
         assert result["effort"] == "medium"
+
+
+class TestDeclaredEffortsAnswerTheDegradationGate:
+    """Without this the chain reads only the per-level booleans, so a kimi-k3 request asking for
+    max silently arrives as high."""
+
+    @pytest.mark.parametrize(
+        "model, provider",
+        [("kimi-k3", "moonshot"), ("kimi-k3", "fireworks_ai"), ("kimi-k3-us", "fireworks_ai")],
+    )
+    def test_a_declared_level_survives_instead_of_degrading(self, local_model_cost_map, model, provider):
+        assert normalize_reasoning_effort_value("max", model, provider) == "max"
+
+    def test_a_level_the_entry_does_not_declare_still_degrades(self, local_model_cost_map):
+        """xhigh is not on kimi-k3's declaration, so it must keep degrading rather than be waved
+        past by the mere presence of one."""
+        assert normalize_reasoning_effort_value("xhigh", "kimi-k3", "moonshot") == "high"
+        assert normalize_reasoning_effort_value("minimal", "kimi-k3", "moonshot") == "low"
+
+    def test_the_wider_perplexity_entry_keeps_the_levels_it_declares(self, local_model_cost_map):
+        assert normalize_reasoning_effort_value("xhigh", "perplexity/kimi-k3", "perplexity") == "xhigh"
+        assert normalize_reasoning_effort_value("minimal", "perplexity/kimi-k3", "perplexity") == "minimal"
+
+    @pytest.mark.parametrize(
+        "model, provider, effort, expected",
+        [
+            ("claude-opus-4-7", "anthropic", "max", "max"),
+            ("claude-sonnet-4-6", "anthropic", "minimal", "low"),
+            ("gpt-5-mini", "azure", "max", "high"),
+        ],
+    )
+    def test_an_entry_on_the_per_level_flags_is_untouched(
+        self, local_model_cost_map, model, provider, effort, expected
+    ):
+        """The negative class that bounds this change to entries carrying the key."""
+        assert normalize_reasoning_effort_value(effort, model, provider) == expected
+
+
+class TestDeclarationBeatsThePerLevelFlags:
+    """An entry can carry both shapes. The declaration wins whole, or /model_group/info and this
+    path would disagree about the same deployment. Driven through the public entry point over a
+    seeded map entry rather than a patched get_model_info, so it pins behaviour and not wiring."""
+
+    MODEL = "declared-and-flagged"
+
+    @pytest.fixture
+    def seeded(self, local_model_cost_map, monkeypatch):
+        def _seed(**entry):
+            monkeypatch.setitem(
+                litellm.model_cost,
+                self.MODEL,
+                {"litellm_provider": "openai", "mode": "chat", "supports_reasoning": True, **entry},
+            )
+            litellm.get_model_info.cache_clear()
+
+        return _seed
+
+    @pytest.mark.parametrize("effort, expected", [("max", "max"), ("xhigh", "high"), ("minimal", "low")])
+    def test_a_flag_cannot_re_add_a_level_the_declaration_omits(self, seeded, effort, expected):
+        seeded(
+            reasoning_effort_levels=["low", "high", "max"],
+            supports_xhigh_reasoning_effort=True,
+            supports_minimal_reasoning_effort=True,
+            supports_max_reasoning_effort=False,
+        )
+
+        assert normalize_reasoning_effort_value(effort, self.MODEL, "openai") == expected
+
+    def test_a_flag_cannot_keep_max_when_the_declaration_drops_it(self, seeded):
+        seeded(
+            reasoning_effort_levels=["low", "high"],
+            supports_max_reasoning_effort=True,
+            supports_xhigh_reasoning_effort=True,
+        )
+
+        assert normalize_reasoning_effort_value("max", self.MODEL, "openai") == "high"
+
+    def test_a_false_flag_cannot_remove_a_level_the_declaration_names(self, seeded):
+        seeded(reasoning_effort_levels=["high", "xhigh"], supports_xhigh_reasoning_effort=False)
+
+        assert normalize_reasoning_effort_value("xhigh", self.MODEL, "openai") == "xhigh"
+        assert normalize_reasoning_effort_value("max", self.MODEL, "openai") == "xhigh"
+
+    def test_a_chain_the_declaration_omits_entirely_lands_on_its_terminal(self, seeded):
+        """Documented residual: no strength ordering exists to pick a nearer declared level."""
+        seeded(reasoning_effort_levels=["high", "xhigh"])
+
+        assert normalize_reasoning_effort_value("minimal", self.MODEL, "openai") == "low"

--- a/tests/test_litellm/router_utils/test_reasoning_effort_capability.py
+++ b/tests/test_litellm/router_utils/test_reasoning_effort_capability.py
@@ -1,5 +1,6 @@
 import pytest
 
+import litellm
 from litellm.router_utils.reasoning_effort_capability import (
     deployment_is_catalog_mapped,
     intersect_supported_reasoning_efforts,
@@ -196,3 +197,158 @@ class TestIntersectSupportedReasoningEfforts:
 
     def test_disjoint_sets_intersect_to_empty(self):
         assert intersect_supported_reasoning_efforts(["max"], ["minimal"]) == ()
+
+
+class TestDeclaredEffortList:
+    """reasoning_effort_levels is what the catalog DECLARES per deployment;
+    ModelGroupInfo.supported_reasoning_efforts is what a group COMPUTED. test_router.py pins that
+    the computed one is never seeded from model_info, so the two names must stay apart."""
+
+    def test_a_declared_list_answers_where_no_flag_could(self):
+        """No flag can drop medium, so before this key the entry could only stay silent or
+        over-advertise a level the model does not document."""
+        resolved = resolve_supported_reasoning_efforts(
+            {"supports_reasoning": True, "reasoning_effort_levels": ["low", "high", "max"]},
+            deployment_is_mapped=True,
+        )
+        assert resolved == ("low", "high", "max")
+
+    def test_a_declared_list_wins_whole_over_the_flags(self):
+        resolved = resolve_supported_reasoning_efforts(
+            {
+                "supports_reasoning": True,
+                "reasoning_effort_levels": ["low", "high", "max"],
+                "supports_none_reasoning_effort": True,
+                "supports_minimal_reasoning_effort": True,
+                "supports_xhigh_reasoning_effort": True,
+                "supports_max_reasoning_effort": False,
+            },
+            deployment_is_mapped=True,
+        )
+        assert resolved == ("low", "high", "max")
+
+    def test_a_declaration_is_reordered_into_the_advertisement_order(self):
+        resolved = resolve_supported_reasoning_efforts(
+            {"supports_reasoning": True, "reasoning_effort_levels": ["max", "low", "high"]},
+            deployment_is_mapped=True,
+        )
+        assert resolved == ("low", "high", "max")
+
+    def test_a_declared_empty_list_empties_the_group(self):
+        assert (
+            resolve_supported_reasoning_efforts(
+                {"supports_reasoning": True, "reasoning_effort_levels": []},
+                deployment_is_mapped=True,
+            )
+            == ()
+        )
+
+    @pytest.mark.parametrize("declared", [["low", "bogus"], ["bogus"], ["low", 7, None]])
+    def test_an_unknown_level_is_dropped_rather_than_raised(self, declared):
+        """A config.yaml model_info block bypasses the map's enum schema, and one mistyped level
+        must not fail every sibling on the proxy."""
+        resolved = resolve_supported_reasoning_efforts(
+            {"supports_reasoning": True, "reasoning_effort_levels": declared},
+            deployment_is_mapped=True,
+        )
+        assert resolved == tuple(effort for effort in ("low",) if effort in declared)
+
+    @pytest.mark.parametrize("malformed", ["low,high,max", {"low": True}, 3, True])
+    def test_a_malformed_declaration_falls_through_to_the_flags(self, malformed):
+        resolved = resolve_supported_reasoning_efforts(
+            {
+                "supports_reasoning": True,
+                "reasoning_effort_levels": malformed,
+                "supports_max_reasoning_effort": True,
+            },
+            deployment_is_mapped=True,
+        )
+        assert resolved == ("none", "minimal", "low", "medium", "high", "max")
+
+    def test_a_model_the_map_calls_non_reasoning_ignores_its_declaration(self):
+        assert (
+            resolve_supported_reasoning_efforts(
+                {"supports_reasoning": False, "reasoning_effort_levels": ["low", "high", "max"]},
+                deployment_is_mapped=True,
+            )
+            == ()
+        )
+
+    def test_a_declaration_is_read_through_the_bare_twin(self, monkeypatch):
+        monkeypatch.setitem(
+            litellm.model_cost,
+            "some-declared-reasoner",
+            {"supports_reasoning": True, "reasoning_effort_levels": ["low", "max"]},
+        )
+        resolved = resolve_supported_reasoning_efforts(
+            {
+                "supports_reasoning": True,
+                "litellm_provider": "openai",
+                "key": "openai/some-declared-reasoner",
+            },
+            deployment_is_mapped=True,
+        )
+        assert resolved == ("low", "max")
+
+
+KIMI_K3_PASSTHROUGH_KEYS = (
+    "azure_ai/FW-Kimi-K3",
+    "moonshot/kimi-k3",
+    "together_ai/moonshotai/Kimi-K3",
+    "fireworks_ai/kimi-k3",
+    "fireworks_ai/kimi-k3-fast",
+    "fireworks_ai/kimi-k3-us",
+    "fireworks_ai/accounts/fireworks/models/kimi-k3",
+    "fireworks_ai/accounts/fireworks/routers/kimi-k3-fast",
+    "fireworks_ai/accounts/fireworks/routers/kimi-k3-us",
+)
+KIMI_K3_PERPLEXITY_KEY = "perplexity/perplexity/kimi-k3"
+
+
+class TestKimiK3AdvertisesItsDocumentedLevels:
+    @pytest.mark.parametrize("model_key", KIMI_K3_PASSTHROUGH_KEYS)
+    def test_a_passthrough_entry_advertises_the_models_own_levels(self, local_model_cost_map, model_key):
+        """platform.kimi.ai documents exactly low, high and max, and these providers forward the
+        level unchanged. Undeclared, each entry resolves to unknown and the dashboard falls back to
+        a capability-blind list that omits max."""
+        entry = dict(litellm.model_cost[model_key], key=model_key)
+
+        assert resolve_supported_reasoning_efforts(entry, deployment_is_mapped=True) == ("low", "high", "max")
+
+    def test_the_perplexity_entry_advertises_the_wider_set_it_maps_down(self, local_model_cost_map):
+        """Perplexity's Agent API takes a six-value enum and maps it down internally, so this
+        deployment is legitimately wider than a passthrough. One blanket list could not say both."""
+        entry = dict(litellm.model_cost[KIMI_K3_PERPLEXITY_KEY], key=KIMI_K3_PERPLEXITY_KEY)
+
+        assert resolve_supported_reasoning_efforts(entry, deployment_is_mapped=True) == (
+            "minimal",
+            "low",
+            "medium",
+            "high",
+            "xhigh",
+            "max",
+        )
+
+    @pytest.mark.parametrize("model, provider", [("kimi-k3", "moonshot"), ("kimi-k3", "fireworks_ai")])
+    def test_the_declaration_survives_model_info_hydration(self, local_model_cost_map, model, provider):
+        """The hydration line is the load-bearing seam: without it the key the map carries never
+        reaches the resolver and reads as absent everywhere downstream."""
+        from litellm.utils import _get_model_info_helper
+
+        model_info = dict(_get_model_info_helper(model=model, custom_llm_provider=provider))
+
+        assert model_info["reasoning_effort_levels"] == ["low", "high", "max"]
+        assert resolve_supported_reasoning_efforts(model_info, deployment_is_mapped=True) == ("low", "high", "max")
+
+    def test_a_kimi_k3_deployment_now_narrows_a_mixed_group(self, local_model_cost_map):
+        """kimi used to contribute unknown, which never narrows, so the group advertised whatever
+        its other deployments agreed on."""
+        kimi = resolve_supported_reasoning_efforts(
+            dict(litellm.model_cost["fireworks_ai/kimi-k3"], key="fireworks_ai/kimi-k3"),
+            deployment_is_mapped=True,
+        )
+
+        assert intersect_supported_reasoning_efforts(("none", "minimal", "low", "medium", "high", "xhigh"), kimi) == (
+            "low",
+            "high",
+        )

--- a/tests/test_litellm/test_utils.py
+++ b/tests/test_litellm/test_utils.py
@@ -1014,6 +1014,10 @@ def test_aaamodel_prices_and_context_window_json_is_valid():
                 "supports_none_reasoning_effort": {"type": "boolean"},
                 "supports_xhigh_reasoning_effort": {"type": "boolean"},
                 "supports_max_reasoning_effort": {"type": "boolean"},
+                "reasoning_effort_levels": {
+                    "type": "array",
+                    "items": {"type": "string", "enum": ["none", "minimal", "low", "medium", "high", "xhigh", "max"]},
+                },
                 "supports_adaptive_thinking": {"type": "boolean"},
                 "supports_legacy_thinking": {"type": "boolean"},
                 "thinking_always_on": {"type": "boolean"},


### PR DESCRIPTION
## TLDR

Problem this solves:

- Kimi K3 takes only low, high and max
- The model map had no way to say that
- So the dashboard cannot offer max for kimi-k3

How it solves it:

- New `reasoning_effort_levels` array key on a map entry
- Present means it wins whole, over the per-level flags
- Each kimi-k3 entry declares what its own deployment takes

## User Flow

Before: an admin building an auto-router cannot put Kimi K3 on the max thinking its own docs call the default

1. They open https://litellm-domain/ui/models-and-endpoints, go to the Auto-Routers tab and click Add Auto Router
2. Under Detailed Configuration they put `kimi-k3` in the Complex tier
3. The Reasoning effort dropdown beside it offers Default, none, minimal, low, medium, high, xhigh
4. `max` is absent, so they cannot select it, and four levels Kimi does not document are offered instead
5. They pick `high` and lose the depth Kimi K3 runs at by default

After: the same dropdown offers exactly what Kimi K3 accepts

1. They open the same page and put `kimi-k3` in the Complex tier
2. The Reasoning effort dropdown beside it now offers Default, low, high, max
3. They select `max` and save the router
4. Requests the router sends to that tier carry `reasoning_effort: max`

## Relevant issues

- The auto-router preset work that needs `max` on kimi-k3 is stacked on this branch

## Linear ticket

Resolves LIT-6325

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally
- [x] My PR passes all required CI/CD checks
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5**

## Screenshots / Proof of Fix

Two identical rigs, one per leg: before at `493bca667b` (the merge base) and after at `e377a0472e` (the PR tip). Each leg is its own worktree running a live proxy on a random port with 2 uvicorn workers, a real Postgres database and `LITELLM_LOCAL_MODEL_COST_MAP=True`, so the proxy reads the map at that commit. The model list registers real Moonshot and Fireworks Kimi K3 deployments (both providers sell it, and the real calls below hit them and cost real money), plus copies of the same litellm model strings pointed at a local echo upstream that replies with the `reasoning_effort` it received, which makes the wire value the gateway sends observable. `gpt56-stub` is an `openai/gpt-5.6` deployment on the echo upstream and `kimi-mixed` holds one Moonshot kimi-k3 plus one `openai/gpt-5.6`. One pre-existing gate to know about, identical at both commits: of the five providers with a declared kimi-k3 entry, only `fireworks_ai` lets an explicit `reasoning_effort` through on chat completions (`perplexity` appends it when `supports_reasoning` resolves), while `moonshot`, `together_ai` and `azure_ai` reject it with UnsupportedParamsError unless the caller passes `allowed_openai_params: ["reasoning_effort"]` or sets `drop_params`. That is why the stub cases below ride the Fireworks model string and the real Moonshot call carries the hatch; LIT-6330 tracks it

```yaml
model_list:
  - model_name: kimi-k3
    litellm_params: {model: moonshot/kimi-k3, api_key: os.environ/MOONSHOT_API_KEY}
  - model_name: kimi-k3-fireworks
    litellm_params: {model: fireworks_ai/accounts/fireworks/models/kimi-k3, api_key: os.environ/FIREWORKS_AI_API_KEY}
  - model_name: kimi-k3-stub
    litellm_params: {model: moonshot/kimi-k3, api_key: stub-key, api_base: http://127.0.0.1:29545/v1}
  - model_name: kimi-k3-fw-stub
    litellm_params: {model: fireworks_ai/accounts/fireworks/models/kimi-k3, api_key: stub-key, api_base: http://127.0.0.1:29545/v1}
  - model_name: gpt56-stub
    litellm_params: {model: openai/gpt-5.6, api_key: stub-key, api_base: http://127.0.0.1:29545/v1}
  - model_name: kimi-mixed
    litellm_params: {model: moonshot/kimi-k3, api_key: os.environ/MOONSHOT_API_KEY}
  - model_name: kimi-mixed
    litellm_params: {model: openai/gpt-5.6, api_key: os.environ/OPENAI_API_KEY}
```

### Before (493bca667b, the merge base)

#### Case 1: what the proxy advertises

1. `curl -s -H "Authorization: Bearer $KEY" http://127.0.0.1:51296/model_group/info`
2. Output, one line per group:

   ```
   kimi-k3              supported_reasoning_efforts=None
   kimi-k3-fireworks    supported_reasoning_efforts=None
   kimi-k3-stub         supported_reasoning_efforts=None
   kimi-k3-fw-stub      supported_reasoning_efforts=None
   gpt56-stub           supported_reasoning_efforts=['none', 'low', 'medium', 'high', 'xhigh']
   kimi-mixed           supported_reasoning_efforts=['none', 'low', 'medium', 'high', 'xhigh']
   ```

3. Every kimi-k3 group answers None, which the dashboard reads as "this proxy knows nothing" and falls back to a capability-blind list that leaves out max. `kimi-mixed` takes the gpt-5.6 set whole because the kimi deployment carries no opinion

#### Case 2: /v1/chat/completions request path

1. `curl -s -X POST http://127.0.0.1:51296/v1/chat/completions -H "Authorization: Bearer $KEY" -H 'content-type: application/json' -d '{"model":"kimi-k3-fw-stub","messages":[{"role":"user","content":"hi"}],"reasoning_effort":"max"}'`
2. 200, and the echo upstream received the level unchanged: `forwarded reasoning_effort=max`

#### Case 3: /v1/responses request path

1. `curl -s -X POST http://127.0.0.1:51296/v1/responses -H "Authorization: Bearer $KEY" -H 'content-type: application/json' -d '{"model":"kimi-k3-fw-stub","input":"hi","reasoning":{"effort":"max"}}'`
2. 200, same story: `forwarded reasoning_effort=max`

#### Case 4: /v1/messages request path

1. `curl -s -X POST http://127.0.0.1:51296/v1/messages -H "Authorization: Bearer $KEY" -H 'content-type: application/json' -d '{"model":"kimi-k3-fw-stub","max_tokens":128,"messages":[{"role":"user","content":"hi"}],"thinking":{"type":"adaptive"},"output_config":{"effort":"max"}}'`
2. 200, but the level was silently lowered: `forwarded reasoning_effort=high`
3. This surface maps `output_config.effort` into `reasoning_effort` only when the body carries `"thinking": {"type": "adaptive"}`; its degradation chain reads the per-level boolean flags, finds no max flag on the kimi entry and lowers a level the model actually takes

#### Case 5: real provider calls

1. `curl -s -X POST http://127.0.0.1:51296/v1/chat/completions -H "Authorization: Bearer $KEY" -H 'content-type: application/json' -d '{"model":"kimi-k3-fireworks","messages":[{"role":"user","content":"Reply with exactly: ok"}],"reasoning_effort":"max","max_tokens":600}'`
2. 200 from the real Fireworks API, content `ok`, usage 93/114 tokens

#### Case 6: Admin UI reasoning-effort dropdown

1. Boot the Admin UI dev server from this commit's `ui/litellm-dashboard` pointed at this leg's proxy. The dashboard build packaged in `_experimental/out` predates the capability-aware dropdown, and this PR touches no `ui/` files, so the identical dashboard source ran against both legs
2. Open http://localhost:3518/models-and-endpoints, go to the Auto-Routers tab, click Add Auto Router, expand Detailed Configuration
3. Put `kimi-k3` in the Complex tier and open the Reasoning effort dropdown beside it: it offers Default, none, minimal, low, medium, high, xhigh. No max
4. Put `kimi-mixed` in the Reasoning tier: its dropdown offers the gpt-5.6 set, Default, none, low, medium, high, xhigh

### After (e377a0472e)

#### Case 1: what the proxy advertises

1. Same curl against the after rig: `curl -s -H "Authorization: Bearer $KEY" http://127.0.0.1:47594/model_group/info`
2. Output:

   ```
   kimi-k3              supported_reasoning_efforts=['low', 'high', 'max']
   kimi-k3-fireworks    supported_reasoning_efforts=['low', 'high', 'max']
   kimi-k3-stub         supported_reasoning_efforts=['low', 'high', 'max']
   kimi-k3-fw-stub      supported_reasoning_efforts=['low', 'high', 'max']
   gpt56-stub           supported_reasoning_efforts=['none', 'low', 'medium', 'high', 'xhigh']
   kimi-mixed           supported_reasoning_efforts=['low', 'high']
   ```

3. Each kimi-k3 group now names the three levels Kimi documents and gpt56-stub is byte-identical to before. `kimi-mixed` narrows to the intersection because a kimi deployment now carries an opinion where it used to carry none: that is the one behavior change a mixed group sees, and it is the intended one

#### Case 2: /v1/chat/completions request path

1. Same curl as before
2. 200, unchanged: `forwarded reasoning_effort=max`

#### Case 3: /v1/responses request path

1. Same curl as before
2. 200, unchanged: `forwarded reasoning_effort=max`

#### Case 4: /v1/messages request path

1. Same curl as before
2. 200, and the level now survives: `forwarded reasoning_effort=max`
3. The degradation chain consults the declaration first, sees max is a level this entry takes and leaves it alone. Entries without a declaration keep the exact answer the chain gave them before, pinned by a negative-class test

#### Case 5: real provider calls

1. Same real Fireworks curl as before: 200, content `ok`, usage 93/14 tokens
2. `curl -s -X POST http://127.0.0.1:47594/v1/messages -H "Authorization: Bearer $KEY" -H 'content-type: application/json' -d '{"model":"kimi-k3","max_tokens":600,"messages":[{"role":"user","content":"Reply with exactly: ok"}],"thinking":{"type":"adaptive"},"output_config":{"effort":"max"},"allowed_openai_params":["reasoning_effort"]}'`
3. 200 from the real Moonshot API, text `ok`, with the max effort carried through the hatch

#### Case 6: Admin UI reasoning-effort dropdown

1. Same dev-server flow against the after proxy, on http://localhost:3517/models-and-endpoints
2. Same page, same dialog, `kimi-k3` in the Complex tier
3. The Reasoning effort dropdown offers exactly Default, low, high, max
4. `kimi-mixed` in the Reasoning tier narrows to Default, low, high

## Type

🆕 New Feature

## Caveats (if any)

### Low

- Three of the five declared providers reject an explicit `reasoning_effort` today
  - `moonshot`, `together_ai` and `azure_ai` 400 on chat completions
  - Pre-existing at the merge base; only `fireworks_ai` forwards it
  - `perplexity` appends it when `supports_reasoning` resolves
  - Hatches: `allowed_openai_params` or `drop_params`; LIT-6330 tracks real support
  - The tip commit's message overstates this; only Fireworks forwards today
- Two ways to express one fact now coexist, arbitrated by precedence
  - A declaration wins whole; the ~915 flag entries are untouched
  - Pinned by a test; flags stay the idiom where they suffice
- The seven undocumented entries are an inference, deliberately flagged
  - Moonshot, Together and Perplexity document their levels; Fireworks and Azure Foundry do not for K3
  - Same K3 weights, so they get the model's own levels
  - Azure Foundry still rejects an explicit level (LIT-6330), advertisement-only until then
  - Happy to narrow those to flag-thin if a reviewer disagrees
- PR #38415 adds a databricks kimi-k3 entry and would land without this key

## Final Attestation

- [x] The tests check the right things, including the edge cases

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes shared reasoning-effort resolution and request normalization for any entry with the new key; mixed model groups now intersect to narrower effort sets when Kimi deployments declare levels.
> 
> **Overview**
> Adds **`reasoning_effort_levels`** on model catalog entries so deployments can advertise an exact set of `reasoning_effort` values (e.g. Kimi K3’s **low / high / max**) instead of inferring from per-level `supports_*` flags, which cannot express “no medium.”
> 
> When present, the list **wins over** the boolean flags in **`resolve_supported_reasoning_efforts`** (router / **`model_group/info`**) and in **`normalize_reasoning_effort_value`** on the Anthropic messages path, so **`max`** is no longer silently degraded to **`high`** for declared Kimi entries. Schema, **`ModelInfo`**, and model-info hydration carry the new field; Kimi K3 variants across Moonshot, Fireworks, Together, Azure AI, and Perplexity are populated in the price map.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e377a0472ece47dca84e876b143bdd5efdf4ebb8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

