### PR TITLE
feat(ui): run the Lite preset's medium and complex tiers at their documented efforts

### DIFF
--- a/ui/litellm-dashboard/src/autorouter_presets.json
+++ b/ui/litellm-dashboard/src/autorouter_presets.json
@@ -36,13 +36,17 @@
   },
   "lite": {
     "label": "Lite",
-    "description": "Cost-optimized routing across providers: DeepSeek V4 Flash for simple queries, Muse Spark 1.2 for medium, Kimi K3 for complex, Claude Opus 5 for reasoning-heavy requests. An LLM classifier with the agentic rubric assigns tiers.",
+    "description": "Cost-optimized routing across providers: DeepSeek V4 Flash for simple queries, Muse Spark 1.2 at xhigh for medium, Kimi K3 at max for complex, Claude Opus 5 for reasoning. An LLM classifier with the agentic rubric assigns tiers.",
     "complexity_router_config": {
       "tiers": {
         "SIMPLE": ["deepseek-v4-flash"],
         "MEDIUM": ["muse-spark-1.2"],
         "COMPLEX": ["kimi-k3"],
         "REASONING": ["claude-opus-5"]
+      },
+      "tier_model_configs": {
+        "MEDIUM": [{ "model_name": "muse-spark-1.2", "litellm_params": { "reasoning_effort": "xhigh" } }],
+        "COMPLEX": [{ "model_name": "kimi-k3", "litellm_params": { "reasoning_effort": "max" } }]
       },
       "classifier_type": "llm",
       "classifier_llm_config": {

--- a/ui/litellm-dashboard/src/lib/autorouter_presets.test.ts
+++ b/ui/litellm-dashboard/src/lib/autorouter_presets.test.ts
@@ -109,6 +109,14 @@ describe("autorouter_presets", () => {
     });
   });
 
+  // Kimi K3 at max needs the map to declare max for kimi-k3, which is the commit below this one.
+  it("pins the lite preset's per-tier reasoning efforts", () => {
+    expect(getPresetByKey("lite")!.complexity_router_config.tier_model_configs).toEqual({
+      MEDIUM: [{ model_name: "muse-spark-1.2", litellm_params: { reasoning_effort: "xhigh" } }],
+      COMPLEX: [{ model_name: "kimi-k3", litellm_params: { reasoning_effort: "max" } }],
+    });
+  });
+
   // serializeTierModelConfigs filters on the tier's models, so a stray name drops silently.
   it("never names a model in tier_model_configs that its own tier does not hold", () => {
     for (const preset of getAllPresets()) {
@@ -126,6 +134,15 @@ describe("autorouter_presets", () => {
     const prefill = buildPresetPrefill(preset.complexity_router_config, groupsOnly(getRequiredModelsInPreset(preset)));
     expect(prefill.complexityRouterConfig.tier_model_params).toEqual({
       REASONING: { "claude-opus-5": { reasoning_effort: "high" } },
+    });
+  });
+
+  it("prefills the lite preset's efforts through to tier_model_params", () => {
+    const lite = getPresetByKey("lite")!;
+    const prefill = buildPresetPrefill(lite.complexity_router_config, groupsOnly(getRequiredModelsInPreset(lite)));
+    expect(prefill.complexityRouterConfig.tier_model_params).toEqual({
+      MEDIUM: { "muse-spark-1.2": { reasoning_effort: "xhigh" } },
+      COMPLEX: { "kimi-k3": { reasoning_effort: "max" } },
     });
   });
 


### PR DESCRIPTION
## TLDR

Problem this solves:

- Lite runs Muse Spark and Kimi K3 at provider defaults
- Kimi K3's own default is max, which it never got
- No bundled preset ever set a per-tier effort

How it solves it:

- Medium runs Muse Spark 1.2 at xhigh
- Complex runs Kimi K3 at max
- Both efforts are what those models document

## User Flow

Before: an admin picking the Lite template gets two mid-tier models on whatever thinking their provider defaults to

1. They open https://litellm-domain/ui/?page=llm-playground, go to Add Model, then the Auto Router tab
2. They pick the Lite template
3. Medium fills in with `muse-spark-1.2` and Complex with `kimi-k3`
4. Every Reasoning effort dropdown reads Default
5. They try to set Complex to `max` by hand and the dropdown does not offer it

After: both tiers arrive on the effort their model documents

1. They open the same page and pick the Lite template
2. The Reasoning effort dropdown beside `muse-spark-1.2` reads `xhigh`, and the one beside `kimi-k3` reads `max`
3. They save the router
4. A complex prompt reaches Kimi K3 with `reasoning_effort: max` even though the caller sent none
5. A medium one reaches Muse Spark 1.2 with `reasoning_effort: xhigh`

## Relevant issues

- Stacked on #38481, which is what lets the map declare `max` for kimi-k3 at all
- Sibling change for the Anthropic Family preset is #38490 and is independent of both

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally
- [x] My PR passes all required CI/CD checks
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5**

## Screenshots / Proof of Fix

Shared setup. A local proxy holding the four model groups this preset names, each pointed at a local stub upstream that echoes the body it received. The auto-router is built by reading `autorouter_presets.json` straight off the branch and handing its `complexity_router_config` to the proxy verbatim, so what is under test is the shipped preset data rather than a hand-copied version of it.

```bash
LITELLM_LOCAL_MODEL_COST_MAP=True litellm --config rig/preset_config.yaml --port 4481
```

No request below sends `reasoning_effort`. Every value the stub reports came from the preset. Tiers are reached by prompt complexity, with `LITELLM ESCALATE` bumping the scored tier one step up.

Substitution declared: no provider on this account sells Kimi K3, Muse Spark or Claude Opus 5, so the upstream is a local stub. The stub only ever receives what the gateway decided to send, which is the whole question here.

### Before (49655dae4f, the parent commit)

1. Trivial prompt routes to `fireworks_ai/deepseek-v4-flash`, the stub receives no effort
2. Escalated trivial prompt routes to `meta/muse-spark-1.2`, the stub receives no effort
3. Hard prompt routes to `fireworks_ai/kimi-k3`, the stub receives no effort
4. Escalated hard prompt routes to `anthropic/claude-opus-5`, the stub receives no effort

### After (98a7b4a5ca)

1. The same four prompts, same commands:

```
SIMPLE      routed=fireworks_ai/deepseek-v4-flash  stub received: nothing (provider default)
MEDIUM      routed=meta/muse-spark-1.2             stub received: {'reasoning_effort': 'xhigh'}
COMPLEX     routed=fireworks_ai/kimi-k3            stub received: {'reasoning_effort': 'max'}
REASONING   routed=anthropic/claude-opus-5         stub received: nothing (provider default)
```

2. Medium and Complex carry the efforts the preset declares, on requests that asked for none
3. Simple and Reasoning send nothing, so the effort is scoped to its tier rather than applied router-wide

## Type

🆕 New Feature

## Caveats (if any)

### Medium

- Kimi K3 at max needs #38481 to merge first
  - Without it the map does not declare max for kimi-k3, so the dropdown will not offer it
  - A stored value still renders and stays clearable, so the preset works, but an admin cannot re-pick max after clearing it

### Low

- Muse Spark 1.2 needed no map change
  - It already carries `supports_xhigh_reasoning_effort: true`, confirmed on the live rig

## Final Attestation

- [x] The tests check the right things, including the edge cases

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Bundled preset JSON and dashboard tests only; behavior change is default routing params for admins who choose the Lite template, with no auth or core gateway logic edits in this diff.
> 
> **Overview**
> The **Lite** auto-router preset now declares per-tier `reasoning_effort` for its medium and complex models instead of leaving them on provider defaults.
> 
> `autorouter_presets.json` adds `tier_model_configs` for **MEDIUM** (`muse-spark-1.2` → `xhigh`) and **COMPLEX** (`kimi-k3` → `max`), and the preset description is updated to match. SIMPLE and REASONING tiers are unchanged.
> 
> Tests lock in those `tier_model_configs` values and assert `buildPresetPrefill` maps them into `tier_model_params` so the Add Model / Auto Router UI shows the correct effort dropdowns and saved routers forward the params on routed requests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 542649b59a8b8efd6033f4ed9b9192b304d87a1b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->