### PR TITLE
fix: thinking lost on /v1/messages for OpenAI-compatible backends (e.g. sglang)

### DIFF
--- a/litellm/llms/anthropic/experimental_pass_through/adapters/handler.py
+++ b/litellm/llms/anthropic/experimental_pass_through/adapters/handler.py
@@ -334,6 +334,11 @@ class LiteLLMMessagesToCompletionTransformationHandler:
         If the user provides a `summary` field in the thinking dict, it is passed
         through to the OpenAI reasoning params (opt-in per OpenAI spec).
         """
+        if litellm.use_chat_completions_url_for_anthropic_messages:
+            # Honor the chat/completions opt-out; OpenAI-compatible backends
+            # (e.g. sglang) already return reasoning_content over chat/completions.
+            return
+
         custom_llm_provider = completion_kwargs.get("custom_llm_provider")
         if custom_llm_provider is None:
             try:

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_anthropic_experimental_pass_through_messages_handler.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_anthropic_experimental_pass_through_messages_handler.py
@@ -429,6 +429,32 @@ class TestThinkingParameterTransformation:
 class TestThinkingSummaryPreservation:
     """Tests for thinking.summary preservation and reasoning_auto_summary flag."""
 
+    def test_use_chat_completions_url_skips_responses_api_routing(self):
+        """Enabled thinking + use_chat_completions_url_for_anthropic_messages should NOT
+        rewrite the model to openai/responses/* (stays on chat/completions)."""
+        import litellm
+
+        from litellm.llms.anthropic.experimental_pass_through.adapters.handler import (
+            LiteLLMMessagesToCompletionTransformationHandler,
+        )
+
+        original = litellm.use_chat_completions_url_for_anthropic_messages
+        try:
+            litellm.use_chat_completions_url_for_anthropic_messages = True
+            completion_kwargs = {
+                "model": "openai/gpt-5.1",
+                "custom_llm_provider": "openai",
+                "reasoning_effort": "medium",
+            }
+            LiteLLMMessagesToCompletionTransformationHandler._route_openai_thinking_to_responses_api_if_needed(
+                completion_kwargs, thinking={"type": "enabled", "budget_tokens": 5000}
+            )
+            # model must remain on chat/completions, not be rewritten to openai/responses/*
+            assert completion_kwargs["model"] == "openai/gpt-5.1"
+            assert "responses/" not in completion_kwargs["model"]
+        finally:
+            litellm.use_chat_completions_url_for_anthropic_messages = original
+
     def test_thinking_summary_concise_preserved_for_openai(self):
         """User-provided summary='concise' should not be replaced with 'detailed'."""
         from litellm.llms.anthropic.experimental_pass_through.adapters.handler import (


### PR DESCRIPTION
## Problem

When calling `/v1/messages` with `thinking={"type": "enabled"}` against an OpenAI-compatible backend such as sglang, the thinking block is silently lost — the client receives no thinking content back.

### Why the existing opt-out doesn't help

`use_chat_completions_url_for_anthropic_messages` only governs the *first* routing decision. There is a **second** routing point — `_route_openai_thinking_to_responses_api_if_needed` — that runs later and rewrites enabled thinking to `openai/responses/*` **without checking** that flag:

- `_should_route_to_responses_api` **honors** the flag → returns `False`, routes to chat/completions.
- `_route_openai_thinking_to_responses_api_if_needed` **ignores** the flag → sees `thinking={"type":"enabled"}`, rewrites the model back to `openai/responses/*`, forcing the Responses API anyway.

So even with the opt-out set, enabled-thinking requests still hit the Responses API.

This breaks OpenAI-**compatible** backends (e.g. GLM served through sglang) that:

1. already return `reasoning_content` over chat/completions, so routing to the Responses API is unnecessary; and
2. implement `/v1/responses` with a reasoning item shape that differs from OpenAI's (`content` instead of `summary`), which LiteLLM then rejects with `Unknown items in responses API response` and drops the thinking block.

## Fix

When `litellm.use_chat_completions_url_for_anthropic_messages` is True, return early from `_route_openai_thinking_to_responses_api_if_needed` and keep the chat/completions route — making the second routing point honor the same opt-out the first one already does. Adaptive thinking and requests without `thinking` are unaffected (they already stay on chat/completions).

## Testing

Verified against a GLM model served through sglang:

- `thinking={"type":"enabled","budget_tokens":8000}`: previously `Unknown items in responses API response` / empty thinking block, now returns the full thinking block.
- `thinking={"type":"adaptive"}` and no-thinking requests: unchanged.
