### PR TITLE
test(together_ai): assert fail-open supported params for models missing from the registry

### DIFF
--- a/tests/llm_translation/test_together_ai.py
+++ b/tests/llm_translation/test_together_ai.py
@@ -23,26 +23,18 @@ class TestTogetherAI(BaseLLMChatTest):
         pass
 
     @pytest.mark.parametrize(
-        "model, expected_bool",
+        "model",
         [
-            ("meta-llama/Meta-Llama-3.1-8B-Instruct-Turbo", True),
-            ("nvidia/Llama-3.1-Nemotron-70B-Instruct-HF", False),
+            "meta-llama/Meta-Llama-3.1-8B-Instruct-Turbo",
+            "nvidia/Llama-3.1-Nemotron-70B-Instruct-HF",
         ],
     )
-    def test_get_supported_response_format_together_ai(
-        self, model: str, expected_bool: bool
-    ) -> None:
+    def test_get_supported_response_format_together_ai(self, model: str) -> None:
         os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = "True"
         litellm.model_cost = litellm.get_model_cost_map(url="")
         optional_params = litellm.get_supported_openai_params(
             model, custom_llm_provider="together_ai"
         )
-        # Mapped provider
         assert isinstance(optional_params, list)
-
-        if expected_bool:
-            assert "response_format" in optional_params
-            assert "tools" in optional_params
-        else:
-            assert "response_format" not in optional_params
-            assert "tools" not in optional_params
+        assert "response_format" in optional_params
+        assert "tools" in optional_params


### PR DESCRIPTION
## TLDR

Problem this solves:

- Staging CircleCI llm_translation suite reds at the current head
- test_together_ai.py still asserts the pre-#38265 fail-closed contract
- Unregistered models now advertise tools and response_format on purpose

How it solves it:

- The unregistered-model case now asserts the fail-open contract
- Suite reds again if fail-open ever silently reverts
- Registered-model case stays as the mapped-path guard

## User Flow

Before: an engineer pushes to litellm_internal_staging and the CircleCI llm_translation job fails on a Together AI test unrelated to their change

1. They push a commit to litellm_internal_staging (or add the run-ci label to their PR)
2. CircleCI runs the llm_translation job, which executes `pytest tests/llm_translation/test_together_ai.py`
3. The job reds with `FAILED ... test_get_supported_response_format_together_ai[nvidia/Llama-3.1-Nemotron-70B-Instruct-HF-False]` even though they touched nothing near Together AI
4. Every staging push reds the same way, so the suite tells them nothing about their own change

After: the same push comes back green because the test asserts the behavior the proxy actually ships

1. They push a commit to litellm_internal_staging (or add the run-ci label to their PR)
2. CircleCI runs the llm_translation job, which executes the same pytest command
3. test_together_ai.py passes (23 passed, 18 skipped), so the job's verdict reflects only their own change

## Relevant issues

## Linear ticket

Resolves LIT-6306

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

The affected end user is staging CI itself, so the pytest command CircleCI runs is the end-user-visible surface here; that is why the proof is the exact suite invocation rather than a live proxy curl. PR #38265 (with commit 5ab9e63628) deliberately made together_ai fail OPEN for models missing from the registry: `get_supported_openai_params` returns the full inherited list for every model, and registry gating moved into `map_openai_params`, which passes `tools` and `response_format` through for unregistered models. `together_ai/nvidia/Llama-3.1-Nemotron-70B-Instruct-HF` has no cost-map entry, so the old fail-closed assertion is stale. The fail-closed drop-and-warn behavior for registry-disabled models stays covered by `tests/test_litellm/llms/together_ai/chat/test_together_ai_chat_transformation.py`

### Before (cd63c7e5a7)

1. `uv run --no-sync pytest 'tests/llm_translation/test_together_ai.py' -x`
2. Observed output:

```
FAILED tests/llm_translation/test_together_ai.py::TestTogetherAI::test_get_supported_response_format_together_ai[nvidia/Llama-3.1-Nemotron-70B-Instruct-HF-False]
E           AssertionError: assert 'response_format' not in ['frequency_penalty', 'logit_bias', 'logprobs', 'top_logprobs', 'max_tokens', 'max_completion_tokens', ...]
=================== 1 failed, 7 passed, 3 skipped in 11.75s ====================
```

### After (bcb6a0a998)

1. `uv run --no-sync pytest 'tests/llm_translation/test_together_ai.py' -x`
2. Observed output:

```
======================= 23 passed, 18 skipped in 37.05s ========================
```

## Type

✅ Test

## Caveats (if any)

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

## CI triage

The run-ci CircleCI suites ran twice on this head. Both fixed test cases passed inside llm_translation_testing both times (jobs 2137179 and 2137215). That job's only failures are 4 test_a2a connection errors that fail on this PR's runners both runs yet pass on staging, so they are runner-env issues unrelated to this diff. The other red CircleCI suites are pre-existing credential and env issues that reproduced identically on the rerun: the dead Manus CI key in batches_testing is LIT-6307 and the exception-mapping UnboundLocalError behind llm_responses_api_testing is LIT-6308, each now driven separately

- [x] bcb6a0a998 passes /live-pr-risk

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change to assertions in one translation test file; no production code paths modified.
> 
> **Overview**
> Updates **`test_get_supported_response_format_together_ai`** so both the registered Llama model and the unregistered Nemotron model must include **`response_format`** and **`tools`** in `get_supported_openai_params` results.
> 
> The test no longer parametrizes an **`expected_bool`** or asserts that unregistered models omit those params. That fail-closed expectation was stale after **#38265**, which made Together AI **fail open** for models missing from the cost map while registry gating moved to **`map_openai_params`**.
> 
> **Intent:** stop **`llm_translation`** CircleCI reds on staging when engineers did not touch Together AI, and lock in the fail-open contract this suite exercises. Fail-closed **`map_openai_params`** behavior remains covered in **`test_together_ai_chat_transformation.py`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bcb6a0a998c5059b6668c9d122bdd1ed33ab8a38. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->