### PR TITLE
feat(ui): run the Anthropic Family preset's reasoning tier on Opus 5 at high thinking

### DIFF
--- a/ui/litellm-dashboard/src/autorouter_presets.json
+++ b/ui/litellm-dashboard/src/autorouter_presets.json
@@ -1,13 +1,16 @@
 {
   "anthropic_family": {
     "label": "Anthropic Family",
-    "description": "Routes across the Claude model family: Haiku for simple queries, Sonnet for medium, Opus for complex and reasoning-heavy requests.",
+    "description": "Routes across the Claude model family: Haiku for simple queries, Sonnet for medium, Opus for complex, Opus at high thinking for reasoning.",
     "complexity_router_config": {
       "tiers": {
         "SIMPLE": ["claude-haiku-4-5"],
         "MEDIUM": ["claude-sonnet-5"],
         "COMPLEX": ["claude-opus-5"],
-        "REASONING": ["claude-fable-5"]
+        "REASONING": ["claude-opus-5"]
+      },
+      "tier_model_configs": {
+        "REASONING": [{ "model_name": "claude-opus-5", "litellm_params": { "reasoning_effort": "high" } }]
       },
       "classifier_type": "heuristic",
       "escalation_keywords": ["LITELLM ESCALATE"],

--- a/ui/litellm-dashboard/src/components/add_model/add_auto_router_tab.test.tsx
+++ b/ui/litellm-dashboard/src/components/add_model/add_auto_router_tab.test.tsx
@@ -592,6 +592,28 @@ describe("AddAutoRouterTab", () => {
       });
     });
 
+    // Every step between the bundled JSON and the payload drops these params silently.
+    it("carries a preset's per-tier reasoning effort through to the create payload", async () => {
+      const user = userEvent.setup();
+      mockFetchAvailableModels.mockResolvedValue(ALL_FAMILY_MODELS);
+
+      renderWithProviders(<Harness />);
+      await waitForPresetEnabled("Anthropic Family");
+      await selectTemplate("Anthropic Family");
+
+      await user.type(screen.getByPlaceholderText(/smart_router/i), "anthropic-router");
+      await user.click(screen.getByRole("button", { name: /add auto router/i }));
+
+      await waitFor(() => expect(handleAddAutoRouterSubmit).toHaveBeenCalled());
+      expect(vi.mocked(handleAddAutoRouterSubmit).mock.calls.at(-1)?.[0]).toMatchObject({
+        complexity_router_config: {
+          tier_model_configs: {
+            REASONING: [{ model_name: "claude-opus-5", litellm_params: { reasoning_effort: "high" } }],
+          },
+        },
+      });
+    });
+
     // Bugbot-found bug: submitBlockedReason disables the button for this, but Form's onFinish
     // (wired to the same handler as the button) fires whenever the form itself is submitted,
     // independent of the button's own disabled state. Without submitRecommendedRouter re-checking

--- a/ui/litellm-dashboard/src/lib/autorouter_presets.test.ts
+++ b/ui/litellm-dashboard/src/lib/autorouter_presets.test.ts
@@ -99,6 +99,36 @@ describe("autorouter_presets", () => {
     );
   });
 
+  // Opus serves both tiers, so the effort is all that separates them and losing it fails silently.
+  it("pins the anthropic preset's reasoning tier to Opus at high thinking", () => {
+    const config = getPresetByKey("anthropic_family")!.complexity_router_config;
+    expect(config.tiers.COMPLEX).toEqual(["claude-opus-5"]);
+    expect(config.tiers.REASONING).toEqual(["claude-opus-5"]);
+    expect(config.tier_model_configs).toEqual({
+      REASONING: [{ model_name: "claude-opus-5", litellm_params: { reasoning_effort: "high" } }],
+    });
+  });
+
+  // serializeTierModelConfigs filters on the tier's models, so a stray name drops silently.
+  it("never names a model in tier_model_configs that its own tier does not hold", () => {
+    for (const preset of getAllPresets()) {
+      const { tiers, tier_model_configs: configs } = preset.complexity_router_config;
+      for (const [tier, entries] of Object.entries(configs ?? {})) {
+        for (const entry of entries) {
+          expect(tiers[tier as keyof typeof tiers] ?? [], `${preset.key}.${tier}`).toContain(entry.model_name);
+        }
+      }
+    }
+  });
+
+  it("prefills the anthropic preset's effort through to tier_model_params", () => {
+    const preset = getPresetByKey("anthropic_family")!;
+    const prefill = buildPresetPrefill(preset.complexity_router_config, groupsOnly(getRequiredModelsInPreset(preset)));
+    expect(prefill.complexityRouterConfig.tier_model_params).toEqual({
+      REASONING: { "claude-opus-5": { reasoning_effort: "high" } },
+    });
+  });
+
   it("pins the gemini preset to concrete model ids, never Google's hot-swapping -latest aliases", () => {
     const gemini = getPresetByKey("gemini_family")!;
     const config = gemini.complexity_router_config;


### PR DESCRIPTION
## TLDR

Problem this solves:

- The reasoning tier runs Fable 5, a lighter model than Opus
- It sits above Opus in the same ladder
- No bundled preset ever set a thinking level

How it solves it:

- Reasoning tier becomes Opus 5 at high thinking
- Complex keeps Opus 5 on the provider default
- The tier is the only thing that differs

## User Flow

Before: an admin picking the Anthropic template gets a reasoning tier on a lighter model than the tier below it

1. They open https://litellm-domain/ui/?page=llm-playground, go to Add Model, then the Auto Router tab
2. They pick the Anthropic Family template
3. Complex fills in with `claude-opus-5` and Reasoning fills in with `claude-fable-5`
4. Every Reasoning effort dropdown reads Default, so a reasoning-heavy prompt gets whatever thinking the provider happens to default to
5. They have to keep a Fable 5 deployment registered purely so this template stays selectable

After: the reasoning tier is the same model thinking harder

1. They open the same page and pick the Anthropic Family template
2. Complex fills in with `claude-opus-5` and Reasoning now fills in with `claude-opus-5` too
3. The Reasoning effort dropdown beside the Reasoning entry reads `high`, and the one beside Complex still reads Default
4. They save the router, and a reasoning-heavy prompt reaches Opus with thinking turned up while a merely complex one does not
5. Fable 5 is no longer required for this template

## Relevant issues

- Sibling change for the Lite preset is stacked elsewhere and does not depend on this

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally
- [x] My PR passes all required CI/CD checks
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5**

## Screenshots / Proof of Fix

Shared setup. A local proxy holding the three model groups this preset names, each pointed at a local stub upstream that echoes the body it received. The auto-router is built by reading `autorouter_presets.json` straight off the branch and handing its `complexity_router_config` to the proxy verbatim, so what is under test is the shipped preset data rather than a hand-copied version of it.

```bash
LITELLM_LOCAL_MODEL_COST_MAP=True litellm --config rig/preset_config.yaml --port 4481
```

No request below sends `reasoning_effort`. Every value the stub reports came from the preset. Tiers are reached by prompt complexity, with `LITELLM ESCALATE` bumping the scored tier one step up.

Substitution declared: no provider on this account sells Claude Opus 5 or Haiku 4.5, so the upstream is a local stub. The stub only ever receives what the gateway decided to send, which is the whole question here.

### Before (cd63c7e5a7, the merge base)

1. Trivial prompt routes to `anthropic/claude-haiku-4-5`, the stub receives no thinking settings
2. Hard prompt routes to `anthropic/claude-opus-5`, the stub receives no thinking settings
3. Escalated hard prompt routes to `anthropic/claude-fable-5`, the stub receives no thinking settings

### After (6131934da1)

1. The same three prompts, same commands:

```
SIMPLE      routed=anthropic/claude-haiku-4-5   stub received: nothing (provider default)
COMPLEX     routed=anthropic/claude-opus-5      stub received: nothing (provider default)
REASONING   routed=anthropic/claude-opus-5      stub received: {'thinking': {'type': 'adaptive', 'display': 'summarized'}, 'output_config': {'effort': 'high'}}
```

2. Complex and Reasoning route to the same model now, and the thinking settings are the only difference between them, which is the point of the change
3. Simple and Complex send nothing, so the effort is scoped to its tier rather than applied router-wide

## Type

🆕 New Feature

## Caveats (if any)

### Low

- The preset drops from four distinct models to three
  - Opus 5 serves both Complex and Reasoning, differing only by thinking
  - An admin who registered Fable 5 only for this preset no longer needs it
- This is the first bundled preset carrying `tier_model_configs`
  - The round trip was already built and unit tested, but no preset exercised it
  - Added a preset-to-create-payload assertion, which nothing covered before

## Final Attestation

- [x] The tests check the right things, including the edge cases

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Bundled preset data and dashboard tests only; routing behavior changes for new routers from this template but does not alter shared routing code paths.
> 
> **Overview**
> Updates the **Anthropic Family** auto-router preset so **Reasoning** uses **`claude-opus-5`** with **`reasoning_effort: high`** instead of **`claude-fable-5`**, matching **Complex** on the same model while separating tiers by thinking level. The preset is the first bundled config to ship **`tier_model_configs`**, and the copy now describes Opus at high thinking for reasoning.
> 
> Adds regression tests that the JSON pins Reasoning correctly, that **`tier_model_configs`** entries only name models in their tier, that prefill maps effort into **`tier_model_params`**, and that choosing the template submits **`tier_model_configs`** on create (so params are not dropped silently in the UI pipeline).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 45f0e108bd66b602a6adc06728330f93624bc922. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->