### PR TITLE
fix(proxy): preserve spend metadata on auth failures

### DIFF
--- a/litellm/proxy/auth/auth_exception_handler.py
+++ b/litellm/proxy/auth/auth_exception_handler.py
@@ -19,6 +19,9 @@ from litellm.proxy._types import (
     UserAPIKeyAuth,
 )
 from litellm.proxy.auth.auth_utils import _get_request_ip_address
+from litellm.proxy.common_utils.http_parsing_utils import (
+    _safe_get_request_headers,  # pyright: ignore[reportPrivateUsage]  # canonical non-throwing request header reader
+)
 from litellm.proxy.db.exception_handler import PrismaDBExceptionHandler
 from litellm.types.services import ServiceTypes
 
@@ -177,7 +180,7 @@ class UserAPIKeyAuthExceptionHandler:
             from litellm.proxy.litellm_pre_call_utils import LiteLLMProxyRequestSetup
 
             spend_logs_metadata: Final = LiteLLMProxyRequestSetup.get_spend_logs_metadata_from_request_headers(
-                dict(request.headers)
+                _safe_get_request_headers(request)
             )
             transformed_exception: Final = await proxy_logging_obj.post_call_failure_hook(
                 request_data=_with_auth_failure_metadata(

--- a/litellm/proxy/auth/auth_exception_handler.py
+++ b/litellm/proxy/auth/auth_exception_handler.py
@@ -36,17 +36,35 @@ else:
     Span = Any
 
 
-def _with_requester_ip_address(request_data: dict[str, object], requester_ip: str | None) -> dict[str, object]:
-    """Auth gate rejections are raised before `add_litellm_data_to_request` records the
-    caller IP, so their failure logs would otherwise carry no IP nor key/user identity."""
+def _with_auth_failure_metadata(
+    request_data: dict[str, object],
+    requester_ip: str | None,
+    spend_logs_metadata: Mapping[str, object] | None,
+) -> dict[str, object]:
+    """Add metadata normally populated after auth without mutating the request body."""
+    raw_spend_metadata: Final = request_data.get("metadata")
+    spend_metadata_base: Final[Mapping[str, object]] = (  # pyright: ignore[reportUnknownVariableType]  # request JSON mappings have string keys
+        raw_spend_metadata if isinstance(raw_spend_metadata, Mapping) else EMPTY_MAPPING
+    )
+    request_data_with_spend_metadata: Final = (
+        {
+            **request_data,
+            "metadata": {**spend_metadata_base, "spend_logs_metadata": spend_logs_metadata},
+        }
+        if spend_logs_metadata is not None
+        else request_data
+    )  # mutable-ok: logging hooks require plain dictionaries
     if not requester_ip:
-        return request_data
-    key: Final = "litellm_metadata" if "litellm_metadata" in request_data else "metadata"
-    metadata: Final = request_data.get(key)
+        return request_data_with_spend_metadata
+    key: Final = "litellm_metadata" if "litellm_metadata" in request_data_with_spend_metadata else "metadata"
+    metadata: Final = request_data_with_spend_metadata.get(key)
     base: Final[Mapping[str, object]] = metadata if isinstance(metadata, Mapping) else EMPTY_MAPPING
     if base.get("requester_ip_address"):
-        return request_data
-    return {**request_data, key: {**base, "requester_ip_address": requester_ip}}  # mutable-ok: logging needs dicts
+        return request_data_with_spend_metadata
+    return {
+        **request_data_with_spend_metadata,
+        key: {**base, "requester_ip_address": requester_ip},
+    }  # mutable-ok: logging needs dicts
 
 
 class UserAPIKeyAuthExceptionHandler:
@@ -156,8 +174,17 @@ class UserAPIKeyAuthExceptionHandler:
                 )
 
             # Allow callbacks to transform the error response
+            from litellm.proxy.litellm_pre_call_utils import LiteLLMProxyRequestSetup
+
+            spend_logs_metadata: Final = LiteLLMProxyRequestSetup.get_spend_logs_metadata_from_request_headers(
+                dict(request.headers)
+            )
             transformed_exception: Final = await proxy_logging_obj.post_call_failure_hook(
-                request_data=_with_requester_ip_address(request_data, requester_ip),
+                request_data=_with_auth_failure_metadata(
+                    request_data=request_data,
+                    requester_ip=requester_ip,
+                    spend_logs_metadata=spend_logs_metadata,
+                ),
                 original_exception=e,
                 user_api_key_dict=user_api_key_dict,
                 error_type=ProxyErrorTypes.auth_error,

--- a/litellm/proxy/litellm_pre_call_utils.py
+++ b/litellm/proxy/litellm_pre_call_utils.py
@@ -9,6 +9,7 @@ from types import MappingProxyType
 from typing import TYPE_CHECKING, Any, Final
 
 from fastapi import HTTPException, Request
+from pydantic import TypeAdapter
 from pydantic import ValidationError as PydanticValidationError
 from starlette.datastructures import Headers
 
@@ -78,6 +79,7 @@ _CODEX_CLIENT_PREFIX_RE: Final = re.compile(r"^codex[-_ /]", re.IGNORECASE)
 _SESSION_ID_VALUE_RE: Final = re.compile(r"^[a-zA-Z0-9_\-]{8,}$")
 
 _SHA256_HEX_RE: Final = re.compile(r"^[0-9a-f]{64}$")
+_SPEND_LOGS_METADATA_ADAPTER: Final = TypeAdapter(dict[str, object])
 
 # W3C Trace Context traceparent header: https://www.w3.org/TR/trace-context/
 # e.g. "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"
@@ -995,16 +997,19 @@ class LiteLLMProxyRequestSetup:
         return None
 
     @staticmethod
-    def _get_spend_logs_metadata_from_request_headers(headers: dict) -> dict | None:
+    def get_spend_logs_metadata_from_request_headers(
+        headers: Mapping[str, object],
+    ) -> dict[str, object] | None:  # mutable-ok: request metadata is stored in a TypedDict
         """
         Get the `spend_logs_metadata` from the request headers.
         """
-        from litellm.litellm_core_utils.safe_json_loads import safe_json_loads
-
         spend_logs_metadata_header: Final = headers.get("x-litellm-spend-logs-metadata", None)
-        if spend_logs_metadata_header is not None:
-            return safe_json_loads(spend_logs_metadata_header)
-        return None
+        if not isinstance(spend_logs_metadata_header, str):
+            return None
+        try:
+            return _SPEND_LOGS_METADATA_ADAPTER.validate_json(spend_logs_metadata_header)
+        except PydanticValidationError:
+            return None
 
     @staticmethod
     def _get_forwardable_headers(
@@ -1236,7 +1241,7 @@ class LiteLLMProxyRequestSetup:
         from litellm.proxy._types import LitellmMetadataFromRequestHeaders
 
         metadata_from_headers: Final = LitellmMetadataFromRequestHeaders()
-        spend_logs_metadata: Final = LiteLLMProxyRequestSetup._get_spend_logs_metadata_from_request_headers(headers)
+        spend_logs_metadata: Final = LiteLLMProxyRequestSetup.get_spend_logs_metadata_from_request_headers(headers)
         if spend_logs_metadata is not None:
             metadata_from_headers["spend_logs_metadata"] = spend_logs_metadata
 

--- a/tests/test_litellm/proxy/auth/test_auth_exception_handler.py
+++ b/tests/test_litellm/proxy/auth/test_auth_exception_handler.py
@@ -1,5 +1,6 @@
 import asyncio
 import json
+from copy import deepcopy
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
@@ -530,36 +531,57 @@ def _http_request(client_host: str | None = "10.1.2.3", headers: dict[str, str] 
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    "header_value, expected_spend_logs_metadata",
+    "header_value, has_body_metadata, expected_spend_logs_metadata",
     [
         pytest.param(
             json.dumps({"my_request_id": "req_rejected_2"}),
+            True,
             {"my_request_id": "req_rejected_2"},
             id="valid_header_overrides_body",
         ),
         pytest.param(
+            json.dumps({"my_request_id": "req_rejected_2"}),
+            False,
+            {"my_request_id": "req_rejected_2"},
+            id="valid_header_without_body_metadata",
+        ),
+        pytest.param(
             "{invalid-json",
+            True,
             {"source": "request-body"},
             id="invalid_header_keeps_body",
         ),
         pytest.param(
             "null",
+            True,
             {"source": "request-body"},
             id="null_header_keeps_body",
+        ),
+        pytest.param(
+            None,
+            True,
+            {"source": "request-body"},
+            id="missing_headers_scope_keeps_body",
         ),
     ],
 )
 async def test_budget_auth_failure_logs_spend_metadata_from_request_header(
-    header_value: str,
+    header_value: str | None,
+    has_body_metadata: bool,
     expected_spend_logs_metadata: dict[str, str],
 ) -> None:
-    request_data: dict[str, object] = {
-        "model": "gpt-4o",
-        "metadata": {
+    request_data: dict[str, object] = {"model": "gpt-4o"}
+    if has_body_metadata:
+        request_data["metadata"] = {
             "existing": "keep-me",
             "spend_logs_metadata": {"source": "request-body"},
-        },
-    }
+        }
+    original_request_data = deepcopy(request_data)
+    request = _http_request(
+        headers={"x-litellm-spend-logs-metadata": header_value} if header_value is not None else None
+    )
+    if header_value is None:
+        request.scope.pop("headers")
 
     with (
         patch(  # test-quality-ok: identity seeding is outside the failure-log payload contract
@@ -578,11 +600,7 @@ async def test_budget_auth_failure_logs_spend_metadata_from_request_header(
         with pytest.raises(ProxyException):
             await UserAPIKeyAuthExceptionHandler._handle_authentication_error(
                 BudgetExceededError(message="Budget exceeded", current_cost=100, max_budget=100),
-                _http_request(
-                    headers={
-                        "x-litellm-spend-logs-metadata": header_value,
-                    }
-                ),
+                request,
                 request_data,
                 "/v1/chat/completions",
                 None,
@@ -591,14 +609,10 @@ async def test_budget_auth_failure_logs_spend_metadata_from_request_header(
 
     logged_request_data = mock_hook.call_args.kwargs["request_data"]
     assert logged_request_data["metadata"]["spend_logs_metadata"] == expected_spend_logs_metadata
-    assert logged_request_data["metadata"]["existing"] == "keep-me"
-    assert request_data == {
-        "model": "gpt-4o",
-        "metadata": {
-            "existing": "keep-me",
-            "spend_logs_metadata": {"source": "request-body"},
-        },
-    }
+    assert logged_request_data["metadata"]["requester_ip_address"] == "10.1.2.3"
+    if has_body_metadata:
+        assert logged_request_data["metadata"]["existing"] == "keep-me"
+    assert request_data == original_request_data
 
 
 @pytest.mark.asyncio

--- a/tests/test_litellm/proxy/auth/test_auth_exception_handler.py
+++ b/tests/test_litellm/proxy/auth/test_auth_exception_handler.py
@@ -530,6 +530,79 @@ def _http_request(client_host: str | None = "10.1.2.3", headers: dict[str, str] 
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
+    "header_value, expected_spend_logs_metadata",
+    [
+        pytest.param(
+            json.dumps({"my_request_id": "req_rejected_2"}),
+            {"my_request_id": "req_rejected_2"},
+            id="valid_header_overrides_body",
+        ),
+        pytest.param(
+            "{invalid-json",
+            {"source": "request-body"},
+            id="invalid_header_keeps_body",
+        ),
+        pytest.param(
+            "null",
+            {"source": "request-body"},
+            id="null_header_keeps_body",
+        ),
+    ],
+)
+async def test_budget_auth_failure_logs_spend_metadata_from_request_header(
+    header_value: str,
+    expected_spend_logs_metadata: dict[str, str],
+) -> None:
+    request_data: dict[str, object] = {
+        "model": "gpt-4o",
+        "metadata": {
+            "existing": "keep-me",
+            "spend_logs_metadata": {"source": "request-body"},
+        },
+    }
+
+    with (
+        patch(  # test-quality-ok: identity seeding is outside the failure-log payload contract
+            "litellm.proxy.auth.auth_exception_handler.seed_request_identity"
+        ),
+        patch(  # test-quality-ok: capture the exact payload sent to the spend logger
+            "litellm.proxy.proxy_server.proxy_logging_obj.post_call_failure_hook",
+            new_callable=AsyncMock,
+            return_value=None,
+        ) as mock_hook,
+        patch(  # test-quality-ok: disable the unrelated database-outage fallback
+            "litellm.proxy.proxy_server.general_settings",
+            {"allow_requests_on_db_unavailable": False},
+        ),
+    ):
+        with pytest.raises(ProxyException):
+            await UserAPIKeyAuthExceptionHandler._handle_authentication_error(
+                BudgetExceededError(message="Budget exceeded", current_cost=100, max_budget=100),
+                _http_request(
+                    headers={
+                        "x-litellm-spend-logs-metadata": header_value,
+                    }
+                ),
+                request_data,
+                "/v1/chat/completions",
+                None,
+                "sk-over-budget",
+            )
+
+    logged_request_data = mock_hook.call_args.kwargs["request_data"]
+    assert logged_request_data["metadata"]["spend_logs_metadata"] == expected_spend_logs_metadata
+    assert logged_request_data["metadata"]["existing"] == "keep-me"
+    assert request_data == {
+        "model": "gpt-4o",
+        "metadata": {
+            "existing": "keep-me",
+            "spend_logs_metadata": {"source": "request-body"},
+        },
+    }
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
     "auth_error, general_settings, request_kwargs, expected_ip",
     [
         pytest.param(


### PR DESCRIPTION
## TLDR

Problem this solves:

- Budget-rejected requests drop caller-provided spend metadata
- Operators cannot correlate auth failures with gateway request IDs

How it solves it:

- Preserve valid spend metadata before failure logging
- Keep malformed headers and existing request metadata safe
- Preserve upstream authentication errors and invalid-key logging markers

## User Flow

Before: a gateway operator cannot correlate a budget rejection with the request ID supplied by their client

1. They send POST https://litellm-domain/v1/chat/completions with an over-budget virtual key and `x-litellm-spend-logs-metadata: {"my_request_id":"req_rejected"}`
2. The proxy returns HTTP 429 with `type: "budget_exceeded"`
3. They send GET https://litellm-domain/spend/logs/v2 and find the failure row with `spend_logs_metadata: null`

After: the same budget rejection is searchable by the request ID supplied by their client

1. They send the same POST https://litellm-domain/v1/chat/completions with an over-budget virtual key and `x-litellm-spend-logs-metadata: {"my_request_id":"req_rejected"}`
2. The proxy returns the same HTTP 429 with `type: "budget_exceeded"`
3. They send the same GET https://litellm-domain/spend/logs/v2 and find the failure row with `spend_logs_metadata: {"my_request_id":"req_rejected"}`

## Relevant issues

Fixes #37260

## Affected release

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you are seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Ran on September 22, 2026 (Asia/Shanghai), using a live proxy on `http://127.0.0.1:14093`, PostgreSQL 17.11, `STORE_MODEL_IN_DB=True`, and `proxy_batch_write_at: 1`. Each revision used a separate clean database and the same configuration and date window. The configured model alias was `auth-metadata-repro`. These requests fail during authentication, before any provider invocation, so no billable LLM call applies

Shared `config.yaml` used for both revisions, with `DATABASE_URL` pointing to that revision's clean database

```yaml
model_list:
  - model_name: auth-metadata-repro
    litellm_params:
      model: openai/gpt-5
      api_key: sk-local-unused-provider-key
      api_base: http://127.0.0.1:15993/v1
litellm_settings:
  drop_params: true
  set_verbose: false
general_settings:
  master_key: sk-local-auth-metadata-master
  database_url: os.environ/DATABASE_URL
  proxy_batch_write_at: 1
  disable_prisma_schema_update: true
```

The database was initialized from each checkout's `litellm/proxy/schema.prisma`. Port 15993 had no listener; the provider was never needed because authentication rejected every request

Before each run, created a virtual key with the following command, setting `PHASE` to `before` or `after`, and stored the returned key as `KEY`

```bash
curl -sS -X POST http://127.0.0.1:14093/key/generate \
  -H 'Authorization: Bearer sk-local-auth-metadata-master' \
  -H 'Content-Type: application/json' \
  -d "{\"key_alias\":\"budget-repro-$PHASE-20260922\",\"models\":[\"auth-metadata-repro\"],\"spend\":1,\"max_budget\":0.01}"
```

Both runs returned HTTP 200 with `"spend": 1.0` and `"max_budget": 0.01`

The log query below returned HTTP 200 and three failure rows per run after the background flush. Define this URL once and use the same query for each case

```bash
LOGS_URL='http://127.0.0.1:14093/spend/logs/v2?start_date=2026-09-20%2000%3A00%3A00&end_date=2026-09-22%2023%3A59%3A59&page=1&page_size=100'
```

### Before (252c71c0b22197d5dd99eac730696f28032796af)

#### Chat Completions

1. Send the over-budget request with caller metadata

   ```bash
   curl -sS -i -X POST http://127.0.0.1:14093/v1/chat/completions \
     -H "Authorization: Bearer $KEY" \
     -H 'Content-Type: application/json' \
     -H 'x-litellm-spend-logs-metadata: {"my_request_id":"req_rejected_before_chat"}' \
     -d '{"model":"auth-metadata-repro","messages":[{"role":"user","content":"hi"}]}'
   ```

2. Observe HTTP 429 with error fields `"type": "budget_exceeded"` and `"code": "429"`

3. Read the persisted failure log

   ```bash
   curl -sS "$LOGS_URL" -H 'Authorization: Bearer sk-local-auth-metadata-master'
   ```

   Matching row, showing the relevant fields:

   ```json
   {"status":"failure","call_type":"acompletion","metadata":{"spend_logs_metadata":null}}
   ```

#### Responses

1. Send the over-budget request with caller metadata

   ```bash
   curl -sS -i -X POST http://127.0.0.1:14093/v1/responses \
     -H "Authorization: Bearer $KEY" \
     -H 'Content-Type: application/json' \
     -H 'x-litellm-spend-logs-metadata: {"my_request_id":"req_rejected_before_responses"}' \
     -d '{"model":"auth-metadata-repro","input":"hi"}'
   ```

2. Observe HTTP 429 with error fields `"type": "budget_exceeded"` and `"code": "429"`

3. Read the persisted failure log

   ```bash
   curl -sS "$LOGS_URL" -H 'Authorization: Bearer sk-local-auth-metadata-master'
   ```

   Matching row, showing the relevant fields:

   ```json
   {"status":"failure","call_type":"aresponses","metadata":{"spend_logs_metadata":null}}
   ```

#### Anthropic Messages

1. Send the over-budget request with caller metadata

   ```bash
   curl -sS -i -X POST http://127.0.0.1:14093/v1/messages \
     -H "Authorization: Bearer $KEY" \
     -H 'Content-Type: application/json' \
     -H 'x-litellm-spend-logs-metadata: {"my_request_id":"req_rejected_before_messages"}' \
     -d '{"model":"auth-metadata-repro","max_tokens":16,"messages":[{"role":"user","content":"hi"}]}'
   ```

2. Observe HTTP 429 with error fields `"type": "budget_exceeded"` and `"code": "429"`

3. Read the persisted failure log

   ```bash
   curl -sS "$LOGS_URL" -H 'Authorization: Bearer sk-local-auth-metadata-master'
   ```

   Matching row, showing the relevant fields:

   ```json
   {"status":"failure","call_type":"anthropic_messages","metadata":{"spend_logs_metadata":null}}
   ```

### After (033fe540ea3f7f1afec5059dd5ad079aa525c73d)

#### Chat Completions

1. Send the over-budget request with caller metadata

   ```bash
   curl -sS -i -X POST http://127.0.0.1:14093/v1/chat/completions \
     -H "Authorization: Bearer $KEY" \
     -H 'Content-Type: application/json' \
     -H 'x-litellm-spend-logs-metadata: {"my_request_id":"req_rejected_after_chat"}' \
     -d '{"model":"auth-metadata-repro","messages":[{"role":"user","content":"hi"}]}'
   ```

2. Observe HTTP 429 with error fields `"type": "budget_exceeded"` and `"code": "429"`

3. Read the persisted failure log

   ```bash
   curl -sS "$LOGS_URL" -H 'Authorization: Bearer sk-local-auth-metadata-master'
   ```

   Matching row, showing the relevant fields:

   ```json
   {"status":"failure","call_type":"acompletion","metadata":{"spend_logs_metadata":{"my_request_id":"req_rejected_after_chat"}}}
   ```

#### Responses

1. Send the over-budget request with caller metadata

   ```bash
   curl -sS -i -X POST http://127.0.0.1:14093/v1/responses \
     -H "Authorization: Bearer $KEY" \
     -H 'Content-Type: application/json' \
     -H 'x-litellm-spend-logs-metadata: {"my_request_id":"req_rejected_after_responses"}' \
     -d '{"model":"auth-metadata-repro","input":"hi"}'
   ```

2. Observe HTTP 429 with error fields `"type": "budget_exceeded"` and `"code": "429"`

3. Read the persisted failure log

   ```bash
   curl -sS "$LOGS_URL" -H 'Authorization: Bearer sk-local-auth-metadata-master'
   ```

   Matching row, showing the relevant fields:

   ```json
   {"status":"failure","call_type":"aresponses","metadata":{"spend_logs_metadata":{"my_request_id":"req_rejected_after_responses"}}}
   ```

#### Anthropic Messages

1. Send the over-budget request with caller metadata

   ```bash
   curl -sS -i -X POST http://127.0.0.1:14093/v1/messages \
     -H "Authorization: Bearer $KEY" \
     -H 'Content-Type: application/json' \
     -H 'x-litellm-spend-logs-metadata: {"my_request_id":"req_rejected_after_messages"}' \
     -d '{"model":"auth-metadata-repro","max_tokens":16,"messages":[{"role":"user","content":"hi"}]}'
   ```

2. Observe HTTP 429 with error fields `"type": "budget_exceeded"` and `"code": "429"`

3. Read the persisted failure log

   ```bash
   curl -sS "$LOGS_URL" -H 'Authorization: Bearer sk-local-auth-metadata-master'
   ```

   Matching row, showing the relevant fields:

   ```json
   {"status":"failure","call_type":"anthropic_messages","metadata":{"spend_logs_metadata":{"my_request_id":"req_rejected_after_messages"}}}
   ```

## Type

Bug Fix

## Validation

At `033fe540`, the auth handler suite passes 53 cases and the request setup suite passes 373 cases. Related auth, rate-limit, and invalid-key metrics suites pass 304 cases; their remaining expired-key test passes with `TZ=UTC`, matching CI. That test also fails on the unchanged base in UTC+8 because it constructs a naive local expiry timestamp

Repository-wide Ruff checks, formatting of changed production files, strict-rule, type-discipline and test-quality gates, circular-import and import-safety checks pass. The e2e type checker reports zero errors. The [canonical full lint check](https://github.com/BerriAI/litellm/actions/runs/35633673074/job/106445720767), including the core type-check gate, also passes on this commit. Auth, proxy-endpoint, key-generation, JWT, proxy-core, MCP and proxy-behavior checks have passed in Actions; the remaining jobs and final coverage result are still running

## Caveats (if any)

The PR still targets `litellm_internal_staging`. Its unrelated documentation parser and dependency scan failures require upstream baseline updates. Vertex's four cost assertions also fail on that base. A timing-sensitive database test has an upstream fix in #40996 that the target branch does not contain. Current-tip CI is still running, so the all-checks and review attestations remain unchecked

## Final Attestation

- [ ] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
