### PR TITLE
fix(exception_mapping_utils): map unmapped exceptions when model and provider are unset

### DIFF
--- a/litellm/litellm_core_utils/exception_mapping_utils.py
+++ b/litellm/litellm_core_utils/exception_mapping_utils.py
@@ -2341,6 +2341,7 @@ def exception_type(
     litellm_response_headers: Final = _get_response_headers(original_exception=original_exception)
     try:
         error_str = redact_string(str(original_exception)) if _ENABLE_SECRET_REDACTION else str(original_exception)
+        extra_information = ""
         if model or custom_llm_provider:
             if hasattr(original_exception, "message"):
                 error_str = (
@@ -2357,7 +2358,6 @@ def exception_type(
             # Common Extra information needed for all providers
             # We pass num retries, api_base, vertex_deployment etc to the exception here
             ################################################################################
-            extra_information = ""
             try:
                 _api_base: Final = litellm.get_api_base(model=model, optional_params=extra_kwargs)
                 messages: Final = litellm.get_first_chars_messages(kwargs=completion_kwargs)

--- a/tests/test_litellm/litellm_core_utils/test_exception_mapping_utils.py
+++ b/tests/test_litellm/litellm_core_utils/test_exception_mapping_utils.py
@@ -1002,6 +1002,17 @@ def test_an_exception_without_a_status_is_still_a_connection_error(quiet_excepti
         )
 
 
+def test_an_unmapped_exception_with_no_model_or_provider_is_a_connection_error(quiet_exception_mapping):
+    with pytest.raises(litellm.APIConnectionError) as raised:
+        exception_type(
+            model=None,
+            original_exception=ValueError("boom"),
+            custom_llm_provider=None,
+        )
+
+    assert "boom" in raised.value.message
+
+
 CONTEXT_WINDOW_MESSAGE = "This model's maximum context length is 4096 tokens."
 CONTENT_POLICY_MESSAGE = (
     '{"error": {"type": "invalid_request_error", "code": "content_policy_violation"}}'


### PR DESCRIPTION
## TLDR

Problem this solves:

- `exception_type` crashed with `UnboundLocalError` when model and provider were both unset
- Callers got the interpreter error instead of the mapped `APIConnectionError`
- Hit in the real product: canceling an unknown response id, per the `llm_responses_api_testing` CI failures on #38487

How it solves it:

- Binds `extra_information` before the `if model or custom_llm_provider:` guard so the unmapped-exception fallback always has it
- Adds a regression test for the no-model, no-provider path

## User Flow

Before: a developer canceling a response by an id the gateway cannot place gets a bare Python interpreter error

1. They run the gateway the quickstart way (`litellm --model azure/gpt-4.1-mini`) and their app sends POST https://litellm-domain/v1/responses/invalid_response_id_12345/cancel with their API key
2. Back comes HTTP 500 with `{"error":{"message":"cannot access local variable 'extra_information' where it is not associated with a value"}}`, an internal interpreter error saying nothing about what went wrong

After: the same cancel comes back with the real reason it failed

1. They run the gateway the quickstart way (`litellm --model azure/gpt-4.1-mini`) and their app sends POST https://litellm-domain/v1/responses/invalid_response_id_12345/cancel with their API key
2. Back comes the mapped error naming the actual problem: HTTP 500 with `litellm.APIConnectionError: custom_llm_provider is required but passed as None`, so they can see the id does not identify a provider

## Relevant issues

Surfaced by the `llm_responses_api_testing` CI failures on #38487 (`test_cancel_responses_invalid_response_id`, both runs)

## Linear ticket

Resolves LIT-6308

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Setup: each leg boots two proxies with `--num_workers 2` (2 uvicorn workers each), no mocks, real Azure credentials. Proxy A is the quickstart form, `litellm --model azure/gpt-4.1-mini --port <port> --num_workers 2` with no config and no database. Proxy B is config-routed with a real Azure deployment, same worker count:

```yaml
model_list:
  - model_name: azure-gpt-4.1-mini
    litellm_params:
      model: azure/gpt-4.1-mini
      api_base: os.environ/AZURE_AI_API_BASE
      api_key: os.environ/AZURE_AI_API_KEY
      api_version: "2025-03-01-preview"
```

Each request below was sent twice so both workers serve one; both runs answered identically

### Before (cd63c7e5a7)

#### Cancel an unknown response id on the quickstart proxy

1. `curl -s -X POST "http://localhost:21847/v1/responses/invalid_response_id_12345/cancel" -H "Authorization: Bearer $LITELLM_MASTER_KEY" -H "Content-Type: application/json" -w "\nHTTP %{http_code}\n"`
2. Observed (both runs): `{"error":{"message":"cannot access local variable 'extra_information' where it is not associated with a value","type":"None","param":"None","code":"500"}}` then `HTTP 500`

#### Control: cancel through a config-routed Azure deployment (real Azure call)

1. `curl -s -X POST "http://localhost:27193/v1/responses/invalid_response_id_12345/cancel" -H "Authorization: Bearer $LITELLM_MASTER_KEY" -H "Content-Type: application/json" -d '{"model": "azure-gpt-4.1-mini"}' -w "\nHTTP %{http_code}\n"`
2. Observed (both runs): `{"error":{"message":"litellm.BadRequestError: AzureException BadRequestError - ... Invalid 'response_id': 'invalid_response_id_12345'. Expected an ID that begins with 'resp'. ...","code":"400"}}` then `HTTP 400` (already mapped correctly when the model is resolvable)

### After (ae95acfb05)

#### Cancel an unknown response id on the quickstart proxy

1. `curl -s -X POST "http://localhost:25611/v1/responses/invalid_response_id_12345/cancel" -H "Authorization: Bearer $LITELLM_MASTER_KEY" -H "Content-Type: application/json" -w "\nHTTP %{http_code}\n"`
2. Observed (both runs): `{"error":{"message":"litellm.APIConnectionError: custom_llm_provider is required but passed as None\n...","code":"500"}}` then `HTTP 500`: the mapped error carrying the real cause, no interpreter error

#### Control: cancel through a config-routed Azure deployment (real Azure call)

1. `curl -s -X POST "http://localhost:29402/v1/responses/invalid_response_id_12345/cancel" -H "Authorization: Bearer $LITELLM_MASTER_KEY" -H "Content-Type: application/json" -d '{"model": "azure-gpt-4.1-mini"}' -w "\nHTTP %{http_code}\n"`
2. Observed (both runs): `{"error":{"message":"litellm.BadRequestError: AzureException BadRequestError - ... Invalid 'response_id': 'invalid_response_id_12345'. Expected an ID that begins with 'resp'. ...","code":"400"}}` then `HTTP 400`, unchanged

QA observations:

- Mapped fallback error still embeds a server-side traceback; pre-existing
- Chat completions on the same proxy maps Azure errors correctly; unchanged

## Type

🐛 Bug Fix

## Caveats (if any)

Low: the mapped fallback still answers HTTP 500 (`APIConnectionError`) for an unknown response id on a router-less proxy; that is the pre-existing contract for unmapped exceptions (#4201), unchanged here

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

- [x] ae95acfb056a45da9a4b6d831988d9f05106c6f1 passes /live-pr-risk
