### PR TITLE
docs: added prices for GLM-5.2 and deepseek-v4-flash-0731 on scaleway

### DIFF
--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -46916,6 +46916,30 @@
         "supports_tool_choice": true,
         "supports_vision": true
     },
+    "scaleway/glm-5.2": {
+        "input_cost_per_token": 1.8e-06,
+        "litellm_provider": "scaleway",
+        "max_input_tokens": 256000,
+        "max_output_tokens": 16384,
+        "max_tokens": 16384,
+        "mode": "chat",
+        "output_cost_per_token": 5.5e-06,
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_vision": false
+    },    
+    "scaleway/deepseek-v4-flash-0731": {
+        "input_cost_per_token": 4e-07,
+        "litellm_provider": "scaleway",
+        "max_input_tokens": 256000,
+        "max_output_tokens": 32768,
+        "max_tokens": 32768,
+        "mode": "chat",
+        "output_cost_per_token": 8e-07,
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_vision": false
+    },
     "scaleway/qwen/qwen3.5-397b-a17b": {
         "input_cost_per_token": 6e-07,
         "litellm_provider": "scaleway",

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -46930,6 +46930,7 @@
     },    
     "scaleway/deepseek-v4-flash-0731": {
         "input_cost_per_token": 4e-07,
+        "cache_read_input_token_cost": 8e-08
         "litellm_provider": "scaleway",
         "max_input_tokens": 256000,
         "max_output_tokens": 32768,

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -46930,7 +46930,7 @@
     },    
     "scaleway/deepseek-v4-flash-0731": {
         "input_cost_per_token": 4e-07,
-        "cache_read_input_token_cost": 8e-08
+        "cache_read_input_token_cost": 8e-08,
         "litellm_provider": "scaleway",
         "max_input_tokens": 256000,
         "max_output_tokens": 32768,


### PR DESCRIPTION
<!-- The whole description's target audience is humans, not AI agents: write it in plain, simple,
     everyday engineering language, extremely parsable and readable at a glance. This goes double for
     the TLDR, User Flow, and Caveats sections -->

## TLDR

Added prices for GLM-5.2 and deepseek-v4-flash-0731 on scaleway

Problem this solves:

- missing prices

How it solves it:

- modified [model_prices_and_context_window.json]()

## User Flow

not relevant

## Relevant issues

none

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have added meaningful tests
- [ ] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

not relevant

## Type

📖 Documentation

## Caveats (if any)

- lower costs for cached input tokens cannot be specified "Input:€0.40/M tokens(€0.08/M tokens cached)" (see https://www.scaleway.com/en/generative-apis/)

## QA runbook

not relevant

## Final Attestation

not relevant