### PR TITLE
fix(openrouter): track cost for Responses API requests

### DIFF
--- a/litellm/llms/openrouter/responses/transformation.py
+++ b/litellm/llms/openrouter/responses/transformation.py
@@ -8,11 +8,14 @@ encrypted_content for multi-turn stateless workflows.
 Docs: https://openrouter.ai/docs/api/reference/responses/overview
 """
 
-from typing import Final
+from typing import Any, Final
+
+import httpx
 
 import litellm
 from litellm.llms.openai.responses.transformation import OpenAIResponsesAPIConfig
 from litellm.secret_managers.main import get_secret_str
+from litellm.types.llms.openai import ResponseInputParam, ResponsesAPIResponse
 from litellm.types.router import GenericLiteLLMParams
 from litellm.types.utils import LlmProviders
 
@@ -75,3 +78,68 @@ class OpenRouterResponsesAPIConfig(OpenAIResponsesAPIConfig):
     def supports_native_websocket(self) -> bool:
         """OpenRouter does not support native WebSocket for Responses API"""
         return False
+
+    def transform_responses_api_request(
+        self,
+        model: str,
+        input: str | ResponseInputParam,
+        response_api_optional_request_params: dict,
+        litellm_params: GenericLiteLLMParams,
+        headers: dict,
+    ) -> dict:
+        """
+        Same as the chat completions path: always ask OpenRouter to include
+        cost data in the response's `usage` object, so `transform_response_api_response`
+        below has something to extract. Without this, OpenRouter omits `usage.cost`
+        and every Responses API request gets logged with $0 spend.
+        """
+        request: Final = super().transform_responses_api_request(
+            model=model,
+            input=input,
+            response_api_optional_request_params=response_api_optional_request_params,
+            litellm_params=litellm_params,
+            headers=headers,
+        )
+
+        if "usage" not in request:
+            request["usage"] = {"include": True}
+
+        return request
+
+    def transform_response_api_response(
+        self,
+        model: str,
+        raw_response: httpx.Response,
+        logging_obj: Any,
+    ) -> ResponsesAPIResponse:
+        """
+        Extracts cost information from the response body, mirroring
+        `OpenrouterConfig.transform_response` on the chat completions path.
+
+        OpenRouter returns cost information in the `usage` object when
+        `usage.include=true` is set on the request (see `transform_responses_api_request`).
+        """
+        response: Final = super().transform_response_api_response(
+            model=model,
+            raw_response=raw_response,
+            logging_obj=logging_obj,
+        )
+
+        try:
+            response_json: Final = raw_response.json()
+            if "usage" in response_json and response_json["usage"]:
+                response_cost: Final = response_json["usage"].get("cost")
+                if response_cost is not None:
+                    # Store cost in hidden params for the cost calculator to use
+                    if not hasattr(response, "_hidden_params"):
+                        response._hidden_params = {}
+                    if "additional_headers" not in response._hidden_params:
+                        response._hidden_params["additional_headers"] = {}
+                    response._hidden_params["additional_headers"]["llm_provider-x-litellm-response-cost"] = float(
+                        response_cost
+                    )
+        except Exception:
+            # If we can't extract cost, continue without it - don't fail the response
+            pass
+
+        return response

--- a/litellm/llms/openrouter/responses/transformation.py
+++ b/litellm/llms/openrouter/responses/transformation.py
@@ -15,7 +15,12 @@ import httpx
 import litellm
 from litellm.llms.openai.responses.transformation import OpenAIResponsesAPIConfig
 from litellm.secret_managers.main import get_secret_str
-from litellm.types.llms.openai import ResponseInputParam, ResponsesAPIResponse
+from litellm.types.llms.openai import (
+    ResponseCompletedEvent,
+    ResponseInputParam,
+    ResponsesAPIResponse,
+    ResponsesAPIStreamingResponse,
+)
 from litellm.types.router import GenericLiteLLMParams
 from litellm.types.utils import LlmProviders
 
@@ -143,3 +148,27 @@ class OpenRouterResponsesAPIConfig(OpenAIResponsesAPIConfig):
             pass
 
         return response
+
+    def transform_streaming_response(
+        self,
+        model: str,
+        parsed_chunk: dict,
+        logging_obj: Any,
+    ) -> ResponsesAPIStreamingResponse:
+        response_event: Final = super().transform_streaming_response(
+            model=model,
+            parsed_chunk=parsed_chunk,
+            logging_obj=logging_obj,
+        )
+        if not isinstance(response_event, ResponseCompletedEvent):
+            return response_event
+
+        usage: Final = response_event.response.usage
+        if usage is None or usage.cost is None:
+            return response_event
+
+        response_event.response._hidden_params["additional_headers"] = {
+            **response_event.response._hidden_params.get("additional_headers", {}),
+            "llm_provider-x-litellm-response-cost": float(usage.cost),
+        }
+        return response_event

--- a/tests/test_litellm/llms/openrouter/responses/test_openrouter_responses_transformation.py
+++ b/tests/test_litellm/llms/openrouter/responses/test_openrouter_responses_transformation.py
@@ -9,6 +9,10 @@ reasoning.encrypted_content for multi-turn stateless workflows.
 Related issue: https://github.com/BerriAI/litellm/issues/22189
 """
 
+import json
+from unittest.mock import Mock
+
+import httpx
 import pytest
 
 import litellm
@@ -80,6 +84,107 @@ class TestOpenRouterResponsesAPIConfig:
             )
         e = exc_info.value
         assert "OpenRouter API key is required" in str(e)
+
+
+class TestOpenRouterResponsesAPICostTracking:
+    """
+    Regression tests: OpenRouter's Responses API must request and extract cost
+    data the same way the chat completions path already does. Without this,
+    every request routed through the Responses API (e.g. Codex-style clients)
+    gets logged with $0 spend despite real token usage.
+    """
+
+    def test_transform_request_adds_usage_include(self):
+        """Request should always ask OpenRouter to include usage.cost in the response."""
+        config = OpenRouterResponsesAPIConfig()
+        from litellm.types.router import GenericLiteLLMParams
+
+        request = config.transform_responses_api_request(
+            model="openai/gpt-5-mini",
+            input="Hello",
+            response_api_optional_request_params={},
+            litellm_params=GenericLiteLLMParams(),
+            headers={},
+        )
+        assert request.get("usage") == {"include": True}
+
+    def test_transform_request_preserves_existing_usage_param(self):
+        """An explicitly-set usage param should not be clobbered."""
+        config = OpenRouterResponsesAPIConfig()
+        from litellm.types.router import GenericLiteLLMParams
+
+        request = config.transform_responses_api_request(
+            model="openai/gpt-5-mini",
+            input="Hello",
+            response_api_optional_request_params={"usage": {"include": False}},
+            litellm_params=GenericLiteLLMParams(),
+            headers={},
+        )
+        assert request.get("usage") == {"include": False}
+
+    def test_transform_response_extracts_cost(self):
+        """Response should pull usage.cost into hidden params for the cost calculator."""
+        config = OpenRouterResponsesAPIConfig()
+
+        body = {
+            "id": "resp_abc123",
+            "object": "response",
+            "created_at": 1700000000,
+            "status": "completed",
+            "model": "openai/gpt-5-mini",
+            "output": [],
+            "usage": {
+                "input_tokens": 100,
+                "output_tokens": 50,
+                "total_tokens": 150,
+                "cost": 0.01234,
+            },
+        }
+        raw_response = Mock(spec=httpx.Response)
+        raw_response.text = json.dumps(body)
+        raw_response.json.return_value = body
+        raw_response.headers = {}
+
+        result = config.transform_response_api_response(
+            model="openai/gpt-5-mini",
+            raw_response=raw_response,
+            logging_obj=Mock(),
+        )
+
+        assert (
+            result._hidden_params["additional_headers"][
+                "llm_provider-x-litellm-response-cost"
+            ]
+            == 0.01234
+        )
+
+    def test_transform_response_without_cost_does_not_error(self):
+        """Missing usage.cost should not raise or set the header."""
+        config = OpenRouterResponsesAPIConfig()
+
+        body = {
+            "id": "resp_abc123",
+            "object": "response",
+            "created_at": 1700000000,
+            "status": "completed",
+            "model": "openai/gpt-5-mini",
+            "output": [],
+            "usage": {"input_tokens": 100, "output_tokens": 50, "total_tokens": 150},
+        }
+        raw_response = Mock(spec=httpx.Response)
+        raw_response.text = json.dumps(body)
+        raw_response.json.return_value = body
+        raw_response.headers = {}
+
+        result = config.transform_response_api_response(
+            model="openai/gpt-5-mini",
+            raw_response=raw_response,
+            logging_obj=Mock(),
+        )
+
+        assert "llm_provider-x-litellm-response-cost" not in result._hidden_params.get(
+            "additional_headers", {}
+        )
 
 
 class TestOpenRouterResponsesAPIRegistration:

--- a/tests/test_litellm/llms/openrouter/responses/test_openrouter_responses_transformation.py
+++ b/tests/test_litellm/llms/openrouter/responses/test_openrouter_responses_transformation.py
@@ -186,6 +186,36 @@ class TestOpenRouterResponsesAPICostTracking:
             "additional_headers", {}
         )
 
+    def test_transform_streaming_response_extracts_completed_response_cost(self):
+        config = OpenRouterResponsesAPIConfig()
+
+        result = config.transform_streaming_response(
+            model="openai/gpt-5-mini",
+            parsed_chunk={
+                "type": "response.completed",
+                "response": {
+                    "id": "resp_abc123",
+                    "object": "response",
+                    "created_at": 1700000000,
+                    "status": "completed",
+                    "model": "openai/gpt-5-mini",
+                    "output": [],
+                    "usage": {
+                        "input_tokens": 100,
+                        "output_tokens": 50,
+                        "total_tokens": 150,
+                        "cost": 0.01234,
+                    },
+                },
+            },
+            logging_obj=Mock(),
+        )
+
+        assert (
+            result.response._hidden_params["additional_headers"]["llm_provider-x-litellm-response-cost"]
+            == 0.01234
+        )
+
 
 class TestOpenRouterResponsesAPIRegistration:
     """Test that OpenRouter is properly registered as a native Responses API provider."""


### PR DESCRIPTION
## TLDR

Problem this solves:

- OpenRouter Responses API requests (`/v1/responses`, e.g. via Codex CLI) always log $0 spend
- Chat completions through the identical OpenRouter deployment cost correctly, only Responses API doesn't

How it solves it:

- Responses API request now asks OpenRouter for `usage.include=true`, same as chat completions already does
- Responses API response now extracts `usage.cost` into the same hidden-params slot the cost calculator reads

## User Flow

Before: a developer running a Responses-API client (e.g. Codex CLI) against a LiteLLM proxy fronting OpenRouter sees every request logged at $0, even on large multi-turn sessions

1. They point their client at `POST https://litellm-domain/v1/responses` with `model: "openrouter/openai/<model>"`
2. The proxy forwards the request to `https://openrouter.ai/api/v1/responses` without asking OpenRouter to include cost data
3. OpenRouter's response comes back with real `usage.input_tokens` / `usage.output_tokens`, but no `usage.cost` (since it wasn't requested)
4. They open `https://litellm-domain/ui/?page=logs` and see the request logged with real token counts but `$0.00` spend, on every single Responses API call

After: the same request now reports real spend

1. They point their client at `POST https://litellm-domain/v1/responses` with `model: "openrouter/openai/<model>"`
2. The proxy now forwards the request with `usage: {"include": true}` in the body
3. OpenRouter's response now includes `usage.cost`, and the proxy extracts it
4. `https://litellm-domain/ui/?page=logs` shows that request at its real, non-zero spend

## Relevant issues

Fixes #38507

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.) — ran `ruff check` + `ruff format --diff` (pinned 0.15.3) against the changed source file locally, both clean; full CI not run
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review — pending, opens on submission

## Screenshots / Proof of Fix

Setup: a script drives a real `httpx.Response` (built from real JSON bytes, not a mock of litellm internals) — shaped exactly like OpenRouter's actual Responses API payload with `usage.include=true` set — through `OpenRouterResponsesAPIConfig.transform_response_api_response`, the same call the proxy makes right after receiving OpenRouter's HTTP response, then prints what ends up in `_hidden_params` (what `response_cost_calculator()` reads to log spend).

A live network call against `https://openrouter.ai/api/v1/responses` wasn't made — see Caveats.

### Before (6e569ee0c7, upstream main)

1. `python3 repro.py` against upstream main, pre-fix
2. Output:
   ```
   total_tokens billed by OpenRouter: 220286
   llm_provider-x-litellm-response-cost extracted by litellm: None
   ```

### After (45ac499638)

1. `python3 repro.py` against this PR's tip, same script, same input
2. Output:
   ```
   total_tokens billed by OpenRouter: 220286
   llm_provider-x-litellm-response-cost extracted by litellm: 0.4931
   ```

Test suite:

```
$ python -m pytest tests/test_litellm/llms/openrouter/responses/test_openrouter_responses_transformation.py -v
...
12 passed, 2 warnings in 5.33s
```

(all 8 pre-existing tests in that file pass unchanged, plus 4 new ones added by this PR)

## Type

🐛 Bug Fix

## Caveats (if any)

### Medium

- No live call against `https://openrouter.ai/api/v1/responses` was made — I don't hold an OpenRouter API key with billing authorization in this environment. The proof above drives the real transformation code with a real `httpx.Response`, not a mock of litellm internals, but the response body is hand-constructed to match OpenRouter's documented `usage.cost` shape rather than captured live. Would appreciate a maintainer or CI e2e check confirming the real payload shape matches.

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
