### PR TITLE
fix(models): drop retired xAI models and mark multi-agent responses-only

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -43560,85 +43560,6 @@
             "/v1/audio/transcriptions"
         ]
     },
-    "xai/grok-2": {
-        "input_cost_per_token": 2e-06,
-        "litellm_provider": "xai",
-        "max_input_tokens": 131072,
-        "max_output_tokens": 131072,
-        "max_tokens": 131072,
-        "mode": "chat",
-        "output_cost_per_token": 1e-05,
-        "supports_function_calling": true,
-        "supports_tool_choice": true,
-        "supports_web_search": true
-    },
-    "xai/grok-2-1212": {
-        "input_cost_per_token": 2e-06,
-        "litellm_provider": "xai",
-        "max_input_tokens": 131072,
-        "max_output_tokens": 131072,
-        "max_tokens": 131072,
-        "mode": "chat",
-        "output_cost_per_token": 1e-05,
-        "supports_function_calling": true,
-        "supports_tool_choice": true,
-        "supports_web_search": true
-    },
-    "xai/grok-2-latest": {
-        "input_cost_per_token": 2e-06,
-        "litellm_provider": "xai",
-        "max_input_tokens": 131072,
-        "max_output_tokens": 131072,
-        "max_tokens": 131072,
-        "mode": "chat",
-        "output_cost_per_token": 1e-05,
-        "supports_function_calling": true,
-        "supports_tool_choice": true,
-        "supports_web_search": true
-    },
-    "xai/grok-2-vision": {
-        "input_cost_per_image": 2e-06,
-        "input_cost_per_token": 2e-06,
-        "litellm_provider": "xai",
-        "max_input_tokens": 32768,
-        "max_output_tokens": 32768,
-        "max_tokens": 32768,
-        "mode": "chat",
-        "output_cost_per_token": 1e-05,
-        "supports_function_calling": true,
-        "supports_tool_choice": true,
-        "supports_vision": true,
-        "supports_web_search": true
-    },
-    "xai/grok-2-vision-1212": {
-        "deprecation_date": "2026-02-28",
-        "input_cost_per_image": 2e-06,
-        "input_cost_per_token": 2e-06,
-        "litellm_provider": "xai",
-        "max_input_tokens": 32768,
-        "max_output_tokens": 32768,
-        "max_tokens": 32768,
-        "mode": "chat",
-        "output_cost_per_token": 1e-05,
-        "supports_function_calling": true,
-        "supports_tool_choice": true,
-        "supports_vision": true,
-        "supports_web_search": true
-    },
-    "xai/grok-2-vision-latest": {
-        "input_cost_per_image": 2e-06,
-        "input_cost_per_token": 2e-06,
-        "litellm_provider": "xai",
-        "max_input_tokens": 32768,
-        "max_output_tokens": 32768,
-        "max_tokens": 32768,
-        "mode": "chat",
-        "output_cost_per_token": 1e-05,
-        "supports_function_calling": true,
-        "supports_tool_choice": true,
-        "supports_vision": true,
-        "supports_web_search": true
-    },
     "xai/grok-3": {
         "cache_read_input_token_cost": 7.5e-07,
         "input_cost_per_token": 3e-06,
@@ -44024,7 +43945,7 @@
         "max_input_tokens": 1000000,
         "max_output_tokens": 1000000,
         "max_tokens": 1000000,
-        "mode": "chat",
+        "mode": "responses",
         "output_cost_per_token": 2.5e-06,
         "source": "https://docs.x.ai/docs/models",
         "supports_function_calling": true,
@@ -44036,7 +43957,10 @@
         "input_cost_per_token_above_200k_tokens": 2.5e-06,
         "output_cost_per_token_above_200k_tokens": 5e-06,
         "cache_read_input_token_cost_above_200k_tokens": 4e-07,
-        "supports_response_schema": true
+        "supports_response_schema": true,
+        "supported_endpoints": [
+            "/v1/responses"
+        ]
     },
     "xai/grok-4.20-beta-0309-reasoning": {
         "cache_read_input_token_cost": 2e-07,
@@ -44205,19 +44129,6 @@
         "supports_vision": true,
         "supports_web_search": true
     },
-    "xai/grok-beta": {
-        "input_cost_per_token": 5e-06,
-        "litellm_provider": "xai",
-        "max_input_tokens": 131072,
-        "max_output_tokens": 131072,
-        "max_tokens": 131072,
-        "mode": "chat",
-        "output_cost_per_token": 1.5e-05,
-        "supports_function_calling": true,
-        "supports_tool_choice": true,
-        "supports_vision": true,
-        "supports_web_search": true
-    },
     "xai/grok-code-fast": {
         "cache_read_input_token_cost": 2e-07,
         "input_cost_per_token": 1e-06,
@@ -44280,20 +44191,6 @@
         "supports_response_schema": true,
         "supports_vision": true,
         "deprecation_date": "2026-05-15"
-    },
-    "xai/grok-vision-beta": {
-        "input_cost_per_image": 5e-06,
-        "input_cost_per_token": 5e-06,
-        "litellm_provider": "xai",
-        "max_input_tokens": 8192,
-        "max_output_tokens": 8192,
-        "max_tokens": 8192,
-        "mode": "chat",
-        "output_cost_per_token": 1.5e-05,
-        "supports_function_calling": true,
-        "supports_tool_choice": true,
-        "supports_vision": true,
-        "supports_web_search": true
     },
     "zai.glm-4.7": {
         "input_cost_per_token": 6e-07,
@@ -50964,7 +50861,7 @@
         "max_input_tokens": 1000000,
         "max_output_tokens": 1000000,
         "max_tokens": 1000000,
-        "mode": "chat",
+        "mode": "responses",
         "output_cost_per_token": 2.5e-06,
         "source": "https://docs.x.ai/docs/models",
         "supports_function_calling": true,
@@ -50976,7 +50873,10 @@
         "input_cost_per_token_above_200k_tokens": 2.5e-06,
         "output_cost_per_token_above_200k_tokens": 5e-06,
         "cache_read_input_token_cost_above_200k_tokens": 4e-07,
-        "supports_response_schema": true
+        "supports_response_schema": true,
+        "supported_endpoints": [
+            "/v1/responses"
+        ]
     },
     "xai/grok-build-0.1": {
         "cache_read_input_token_cost": 2e-07,

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -43560,85 +43560,6 @@
             "/v1/audio/transcriptions"
         ]
     },
-    "xai/grok-2": {
-        "input_cost_per_token": 2e-06,
-        "litellm_provider": "xai",
-        "max_input_tokens": 131072,
-        "max_output_tokens": 131072,
-        "max_tokens": 131072,
-        "mode": "chat",
-        "output_cost_per_token": 1e-05,
-        "supports_function_calling": true,
-        "supports_tool_choice": true,
-        "supports_web_search": true
-    },
-    "xai/grok-2-1212": {
-        "input_cost_per_token": 2e-06,
-        "litellm_provider": "xai",
-        "max_input_tokens": 131072,
-        "max_output_tokens": 131072,
-        "max_tokens": 131072,
-        "mode": "chat",
-        "output_cost_per_token": 1e-05,
-        "supports_function_calling": true,
-        "supports_tool_choice": true,
-        "supports_web_search": true
-    },
-    "xai/grok-2-latest": {
-        "input_cost_per_token": 2e-06,
-        "litellm_provider": "xai",
-        "max_input_tokens": 131072,
-        "max_output_tokens": 131072,
-        "max_tokens": 131072,
-        "mode": "chat",
-        "output_cost_per_token": 1e-05,
-        "supports_function_calling": true,
-        "supports_tool_choice": true,
-        "supports_web_search": true
-    },
-    "xai/grok-2-vision": {
-        "input_cost_per_image": 2e-06,
-        "input_cost_per_token": 2e-06,
-        "litellm_provider": "xai",
-        "max_input_tokens": 32768,
-        "max_output_tokens": 32768,
-        "max_tokens": 32768,
-        "mode": "chat",
-        "output_cost_per_token": 1e-05,
-        "supports_function_calling": true,
-        "supports_tool_choice": true,
-        "supports_vision": true,
-        "supports_web_search": true
-    },
-    "xai/grok-2-vision-1212": {
-        "deprecation_date": "2026-02-28",
-        "input_cost_per_image": 2e-06,
-        "input_cost_per_token": 2e-06,
-        "litellm_provider": "xai",
-        "max_input_tokens": 32768,
-        "max_output_tokens": 32768,
-        "max_tokens": 32768,
-        "mode": "chat",
-        "output_cost_per_token": 1e-05,
-        "supports_function_calling": true,
-        "supports_tool_choice": true,
-        "supports_vision": true,
-        "supports_web_search": true
-    },
-    "xai/grok-2-vision-latest": {
-        "input_cost_per_image": 2e-06,
-        "input_cost_per_token": 2e-06,
-        "litellm_provider": "xai",
-        "max_input_tokens": 32768,
-        "max_output_tokens": 32768,
-        "max_tokens": 32768,
-        "mode": "chat",
-        "output_cost_per_token": 1e-05,
-        "supports_function_calling": true,
-        "supports_tool_choice": true,
-        "supports_vision": true,
-        "supports_web_search": true
-    },
     "xai/grok-3": {
         "cache_read_input_token_cost": 7.5e-07,
         "input_cost_per_token": 3e-06,
@@ -44024,7 +43945,7 @@
         "max_input_tokens": 1000000,
         "max_output_tokens": 1000000,
         "max_tokens": 1000000,
-        "mode": "chat",
+        "mode": "responses",
         "output_cost_per_token": 2.5e-06,
         "source": "https://docs.x.ai/docs/models",
         "supports_function_calling": true,
@@ -44036,7 +43957,10 @@
         "input_cost_per_token_above_200k_tokens": 2.5e-06,
         "output_cost_per_token_above_200k_tokens": 5e-06,
         "cache_read_input_token_cost_above_200k_tokens": 4e-07,
-        "supports_response_schema": true
+        "supports_response_schema": true,
+        "supported_endpoints": [
+            "/v1/responses"
+        ]
     },
     "xai/grok-4.20-beta-0309-reasoning": {
         "cache_read_input_token_cost": 2e-07,
@@ -44205,19 +44129,6 @@
         "supports_vision": true,
         "supports_web_search": true
     },
-    "xai/grok-beta": {
-        "input_cost_per_token": 5e-06,
-        "litellm_provider": "xai",
-        "max_input_tokens": 131072,
-        "max_output_tokens": 131072,
-        "max_tokens": 131072,
-        "mode": "chat",
-        "output_cost_per_token": 1.5e-05,
-        "supports_function_calling": true,
-        "supports_tool_choice": true,
-        "supports_vision": true,
-        "supports_web_search": true
-    },
     "xai/grok-code-fast": {
         "cache_read_input_token_cost": 2e-07,
         "input_cost_per_token": 1e-06,
@@ -44280,20 +44191,6 @@
         "supports_response_schema": true,
         "supports_vision": true,
         "deprecation_date": "2026-05-15"
-    },
-    "xai/grok-vision-beta": {
-        "input_cost_per_image": 5e-06,
-        "input_cost_per_token": 5e-06,
-        "litellm_provider": "xai",
-        "max_input_tokens": 8192,
-        "max_output_tokens": 8192,
-        "max_tokens": 8192,
-        "mode": "chat",
-        "output_cost_per_token": 1.5e-05,
-        "supports_function_calling": true,
-        "supports_tool_choice": true,
-        "supports_vision": true,
-        "supports_web_search": true
     },
     "zai.glm-4.7": {
         "input_cost_per_token": 6e-07,
@@ -50964,7 +50861,7 @@
         "max_input_tokens": 1000000,
         "max_output_tokens": 1000000,
         "max_tokens": 1000000,
-        "mode": "chat",
+        "mode": "responses",
         "output_cost_per_token": 2.5e-06,
         "source": "https://docs.x.ai/docs/models",
         "supports_function_calling": true,
@@ -50976,7 +50873,10 @@
         "input_cost_per_token_above_200k_tokens": 2.5e-06,
         "output_cost_per_token_above_200k_tokens": 5e-06,
         "cache_read_input_token_cost_above_200k_tokens": 4e-07,
-        "supports_response_schema": true
+        "supports_response_schema": true,
+        "supported_endpoints": [
+            "/v1/responses"
+        ]
     },
     "xai/grok-build-0.1": {
         "cache_read_input_token_cost": 2e-07,

--- a/tests/test_litellm/llms/xai/test_xai_model_registry.py
+++ b/tests/test_litellm/llms/xai/test_xai_model_registry.py
@@ -1,0 +1,75 @@
+"""
+Registry regression tests for xAI entries in the model cost map.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).parents[4]
+PRICES_PATH = REPO_ROOT / "model_prices_and_context_window.json"
+BACKUP_PRICES_PATH = REPO_ROOT / "litellm" / "model_prices_and_context_window_backup.json"
+
+# Retired by xAI and no longer served: requests to these slugs 404 rather than
+# redirecting, and they are absent from https://docs.x.ai/docs/models
+RETIRED_MODELS = (
+    "xai/grok-2",
+    "xai/grok-2-1212",
+    "xai/grok-2-latest",
+    "xai/grok-2-vision",
+    "xai/grok-2-vision-1212",
+    "xai/grok-2-vision-latest",
+    "xai/grok-beta",
+    "xai/grok-vision-beta",
+)
+
+# https://docs.x.ai/developers/model-capabilities/text/multi-agent
+# "The multi-agent model does not work with the OpenAI Chat Completions API."
+RESPONSES_ONLY_MODELS = (
+    "xai/grok-4.20-multi-agent-0309",
+    "xai/grok-4.20-multi-agent-beta-0309",
+)
+
+MAP_PATHS = (PRICES_PATH, BACKUP_PRICES_PATH)
+
+
+@pytest.fixture(scope="module", params=[p.name for p in MAP_PATHS])
+def cost_map(request: pytest.FixtureRequest) -> dict:
+    path = next(p for p in MAP_PATHS if p.name == request.param)
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+@pytest.mark.parametrize("model", RETIRED_MODELS)
+def test_retired_xai_models_are_not_advertised(cost_map: dict, model: str):
+    assert model not in cost_map
+
+
+@pytest.mark.parametrize("model", RESPONSES_ONLY_MODELS)
+def test_multi_agent_models_are_responses_only(cost_map: dict, model: str):
+    entry = cost_map[model]
+    assert entry["supported_endpoints"] == ["/v1/responses"]
+    assert entry["mode"] == "responses"
+    assert "/v1/chat/completions" not in entry["supported_endpoints"]
+
+
+def test_surviving_xai_chat_models_still_serve_chat_completions(cost_map: dict):
+    """Guard against the removal above over-reaching into live models."""
+    chat_models = [
+        key
+        for key, value in cost_map.items()
+        if isinstance(value, dict) and value.get("litellm_provider") == "xai" and value.get("mode") == "chat"
+    ]
+    assert "xai/grok-4.3" in chat_models
+    assert "xai/grok-4.6" in chat_models
+    assert not any(key.startswith("xai/grok-2") for key in chat_models)
+
+
+def test_both_cost_maps_agree_on_xai_entries():
+    prices = json.loads(PRICES_PATH.read_text(encoding="utf-8"))
+    backup = json.loads(BACKUP_PRICES_PATH.read_text(encoding="utf-8"))
+    xai_keys = {k for k, v in prices.items() if isinstance(v, dict) and v.get("litellm_provider") == "xai"}
+    assert xai_keys
+    assert {k: prices[k] for k in xai_keys} == {k: backup[k] for k in xai_keys}


### PR DESCRIPTION
## TLDR

Problem this solves:

- The registry advertises xAI models that no longer exist
- Picking one gets a 404 from xAI, not a redirect
- Multi-agent models are listed as chat models
- xAI does not serve them on Chat Completions at all

How it solves it:

- Remove the grok-2 family, grok-beta and grok-vision-beta
- Mark both multi-agent models responses-only
- Leave every model xAI still serves untouched

## User Flow

Before: a developer browsing the gateway's xAI models picks one that xAI stopped serving, and only finds out at request time

1. They open https://litellm-domain/ui/?page=models and see `xai/grok-2`, `xai/grok-2-vision`, `xai/grok-beta` and `xai/grok-vision-beta` offered with full pricing and a 131k context window
2. They add `xai/grok-2` to their config and send POST https://litellm-domain/v1/chat/completions
3. The call fails with a 404 from xAI saying the model does not exist, and no amount of config fixes it
4. They try `xai/grok-4.20-multi-agent-0309`, which the same page lists as a chat model, on POST https://litellm-domain/v1/chat/completions
5. That fails too, because xAI serves the multi-agent models only on the Responses API

After: the list only offers models xAI still serves, and the multi-agent models are pointed at the right endpoint

1. They open https://litellm-domain/ui/?page=models and the retired slugs are gone, so there is nothing dead to pick
2. `xai/grok-4.20-multi-agent-0309` now shows as a `/v1/responses` model rather than a chat model
3. They send it to POST https://litellm-domain/v1/responses and it works
4. `xai/grok-4.3`, `xai/grok-4.6` and every other live xAI model are listed and priced exactly as before

## Relevant issues

Fixes #38179

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Sources

- https://docs.x.ai/docs/models no longer lists the grok-2 family, grok-beta or grok-vision-beta
- https://docs.x.ai/developers/migration/may-15-retirement lists the eight slugs that were retired with a redirect to grok-4.3, and the models removed here are not among them, which is why they 404 instead of redirecting
- https://docs.x.ai/developers/model-capabilities/text/multi-agent states "The multi-agent model does **not** work with the OpenAI Chat Completions API"

## Screenshots / Proof of Fix

This is a registry-metadata change, so the user-visible surface is what the proxy reports for a configured deployment. Live proxy on localhost:4000, config:

```yaml
model_list:
  - model_name: grok-2
    litellm_params: {model: xai/grok-2, api_key: fake-xai-key}
  - model_name: grok-beta
    litellm_params: {model: xai/grok-beta, api_key: fake-xai-key}
  - model_name: grok-multi-agent
    litellm_params: {model: xai/grok-4.20-multi-agent-0309, api_key: fake-xai-key}
  - model_name: grok-4-3
    litellm_params: {model: xai/grok-4.3, api_key: fake-xai-key}

general_settings:
  master_key: sk-qa-38179
```

Each case reads `GET /model/info` and prints the resolved `model_info` for one deployment:

```
curl -s http://localhost:4000/model/info -H 'Authorization: Bearer sk-qa-38179'
```

### Before (cd63c7e5a7)

#### retired slugs are priced as live chat models

1. `curl -s http://localhost:4000/model/info -H 'Authorization: Bearer sk-qa-38179'`
2. `xai/grok-2: mode=chat input_cost_per_token=2e-06`
3. `xai/grok-beta: mode=chat input_cost_per_token=5e-06`

#### multi-agent advertised for chat completions

1. `curl -s http://localhost:4000/model/info -H 'Authorization: Bearer sk-qa-38179'`
2. `xai/grok-4.20-multi-agent-0309: mode=chat supported_endpoints=None`

#### a live xAI model

1. `curl -s http://localhost:4000/model/info -H 'Authorization: Bearer sk-qa-38179'`
2. `xai/grok-4.3: mode=chat input_cost_per_token=1.25e-06`

### After (7a65f3ae2f)

#### retired slugs are priced as live chat models

1. `curl -s http://localhost:4000/model/info -H 'Authorization: Bearer sk-qa-38179'`
2. `xai/grok-2: mode=None input_cost_per_token=0`
3. `xai/grok-beta: mode=None input_cost_per_token=0`
4. The registry no longer claims these are live chat models

#### multi-agent advertised for chat completions

1. `curl -s http://localhost:4000/model/info -H 'Authorization: Bearer sk-qa-38179'`
2. `xai/grok-4.20-multi-agent-0309: mode=responses supported_endpoints=['/v1/responses']`

#### a live xAI model

1. `curl -s http://localhost:4000/model/info -H 'Authorization: Bearer sk-qa-38179'`
2. `xai/grok-4.3: mode=chat input_cost_per_token=1.25e-06`, unchanged

No request is sent to xAI here, since I have no xAI key and the retired slugs would only return the 404 the issue already reports.

## Type

🐛 Bug Fix

## Caveats (if any)

### Medium

- Anyone still naming a removed slug loses its cost-map entry, so spend logs for it read 0
  - The call itself already fails at xAI, so there is no real spend to lose
  - Reinstating an entry is the fix if xAI ever brings a slug back

### Low

- Removed rather than dated, because xAI published no retirement date for these
  - This repo reverts unverified deprecation dates, see 30b14597af
  - `xai/grok-2-vision-1212` did already carry `deprecation_date: 2026-02-28`; if maintainers would rather mark the family than remove it, that is the date to apply
- `litellm/constants.py` still lists Clarifai-hosted `grok-2` slugs, deliberately left alone since Clarifai serves those independently of xAI
- Two older tests still use retired slugs as fixture strings; they exercise provider routing and param mapping, never the cost map, so they are untouched and still pass

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
