### PR TITLE
fix(snowflake): raise on unsupported tool_choice instead of silently defaulting to auto

### DIFF
--- a/litellm/llms/snowflake/chat/transformation.py
+++ b/litellm/llms/snowflake/chat/transformation.py
@@ -15,6 +15,7 @@ from typing import TYPE_CHECKING, Any, Final, Protocol, TypedDict
 import httpx
 from typing_extensions import ReadOnly
 
+from litellm.exceptions import UnsupportedParamsError
 from litellm.types.llms.openai import AllMessageValues, ChatCompletionToolCallChunk
 from litellm.types.utils import (
     ChatCompletionMessageToolCall,
@@ -308,21 +309,43 @@ class SnowflakeConfig(SnowflakeBaseConfig, OpenAIGPTConfig):
 
         return body
 
-    def _transform_tool_choice_to_anthropic(self, tool_choice: Any) -> dict[str, Any]:
+    def _transform_tool_choice_to_anthropic(self, tool_choice: Any) -> dict[str, Any] | None:
         """
         Convert tool_choice from OpenAI format to Anthropic format.
 
         OpenAI string values: "auto", "required", "none"
         OpenAI dict: {"type": "function", "function": {"name": "..."}}
         Anthropic: {"type": "auto"}, {"type": "any"}, {"type": "tool", "name": "..."}
+
+        Returns None when the value is unsupported and `litellm.drop_params`
+        is set, in which case the caller drops the parameter.
+
+        Unrecognized strings raise rather than defaulting to "auto". Falling
+        back inverts the caller's intent — "required" means the model must
+        call a tool, "auto" means it may — and the only symptom is the model
+        occasionally not calling one, which reads as a model quality problem
+        rather than a silently dropped constraint.
         """
+        import litellm
+
         if isinstance(tool_choice, str):
             mapping: Final = {
                 "auto": {"type": "auto"},
                 "required": {"type": "any"},
                 "none": {"type": "none"},
             }
-            return mapping.get(tool_choice, {"type": "auto"})
+            if tool_choice not in mapping:
+                if litellm.drop_params is True:
+                    return None
+                raise UnsupportedParamsError(
+                    message=(
+                        f"Snowflake doesn't support tool_choice={tool_choice}. "
+                        "Supported tool_choice values=['auto', 'required', 'none', json object]. "
+                        "To drop it from the call, set `litellm.drop_params = True`."
+                    ),
+                    status_code=400,
+                )
+            return mapping[tool_choice]
         elif isinstance(tool_choice, dict):
             if tool_choice.get("type") == "function":
                 func: Final = tool_choice.get("function", {})
@@ -345,7 +368,11 @@ class SnowflakeConfig(SnowflakeBaseConfig, OpenAIGPTConfig):
             optional_params["tools"] = self._transform_tools_to_anthropic(optional_params["tools"])
 
         if "tool_choice" in optional_params:
-            optional_params["tool_choice"] = self._transform_tool_choice_to_anthropic(optional_params["tool_choice"])
+            transformed_tool_choice: Final = self._transform_tool_choice_to_anthropic(optional_params["tool_choice"])
+            if transformed_tool_choice is None:  # unsupported + litellm.drop_params
+                optional_params.pop("tool_choice")
+            else:
+                optional_params["tool_choice"] = transformed_tool_choice
 
         max_completion_tokens: Final = optional_params.pop("max_completion_tokens", None)
         if max_completion_tokens and "max_tokens" not in optional_params:

--- a/tests/test_litellm/llms/snowflake/chat/test_snowflake_chat_transformation.py
+++ b/tests/test_litellm/llms/snowflake/chat/test_snowflake_chat_transformation.py
@@ -17,6 +17,7 @@ import pytest
 import litellm
 from litellm import completion, acompletion
 from litellm.llms.custom_httpx.http_handler import AsyncHTTPHandler, HTTPHandler
+from litellm.exceptions import UnsupportedParamsError
 from litellm.llms.snowflake.chat.transformation import SnowflakeConfig
 from litellm.types.utils import ModelResponse
 
@@ -117,6 +118,76 @@ class TestSnowflakeToolTransformation:
                 f"tool_choice='{value}' should pass through unchanged, "
                 f"got {transformed_request['tool_choice']}"
             )
+
+    def test_claude_tool_choice_maps_supported_string_values(self):
+        """
+        Claude models route through the Anthropic request path, where OpenAI
+        string tool_choice values are translated to Anthropic's object form.
+        """
+        config = SnowflakeConfig()
+
+        expected = {
+            "auto": {"type": "auto"},
+            "required": {"type": "any"},
+            "none": {"type": "none"},
+        }
+
+        for value, want in expected.items():
+            transformed_request = config.transform_request(
+                model="snowflake/claude-3-5-sonnet",
+                messages=[{"role": "user", "content": "Test"}],
+                optional_params={"tool_choice": value},
+                litellm_params={},
+                headers={},
+            )
+
+            assert transformed_request["tool_choice"] == want, (
+                f"tool_choice='{value}' should map to {want}, got {transformed_request['tool_choice']}"
+            )
+
+    @pytest.mark.parametrize(
+        "tool_choice",
+        ["any", "Required", "REQUIRED", "required ", "requried", "tool"],
+    )
+    def test_claude_unsupported_tool_choice_string_raises(self, tool_choice):
+        """
+        Unrecognized strings must raise, not silently fall back to "auto".
+
+        "required" means the model must call a tool and "auto" means it may,
+        so defaulting inverts the caller's intent with no error surfaced. The
+        lookup is exact-match, so casing and whitespace variants land here too.
+        """
+        config = SnowflakeConfig()
+
+        with pytest.raises(UnsupportedParamsError) as exc_info:
+            config.transform_request(
+                model="snowflake/claude-3-5-sonnet",
+                messages=[{"role": "user", "content": "Test"}],
+                optional_params={"tool_choice": tool_choice},
+                litellm_params={},
+                headers={},
+            )
+
+        assert "tool_choice" in str(exc_info.value)
+
+    def test_claude_unsupported_tool_choice_dropped_when_drop_params_set(self):
+        """With litellm.drop_params, an unsupported value is dropped, not raised."""
+        config = SnowflakeConfig()
+
+        original = litellm.drop_params
+        litellm.drop_params = True
+        try:
+            transformed_request = config.transform_request(
+                model="snowflake/claude-3-5-sonnet",
+                messages=[{"role": "user", "content": "Test"}],
+                optional_params={"tool_choice": "any"},
+                litellm_params={},
+                headers={},
+            )
+        finally:
+            litellm.drop_params = original
+
+        assert "tool_choice" not in transformed_request
 
     def test_transform_response_with_tool_calls(self):
         """


### PR DESCRIPTION
## TLDR

Problem this solves:

- Snowflake silently turned unknown `tool_choice` into `"auto"`
- Forced tool calls became optional, with no error
- A capital letter in `"Required"` was enough to trigger it

How it solves it:

- Raise `UnsupportedParamsError` instead of defaulting
- Matches how Bedrock, Vertex and watsonx already behave
- Honours `litellm.drop_params` for callers who prefer dropping

## User Flow

Before: a developer forcing a tool call on a Snowflake Claude model gets optional tool use instead, and nothing tells them.

1. They send `POST https://litellm-domain/v1/chat/completions` with `"model": "snowflake/claude-3-5-sonnet"`, a `get_weather` tool, and `"tool_choice": "Required"`
2. They get back `200 OK` with a normal assistant message and **no** `tool_calls`
3. They retry with `"tool_choice": "any"` (the spelling Anthropic's own API uses) and get the same `200 OK` with no `tool_calls`
4. Nothing in the response or in `https://litellm-domain/ui/?page=logs` mentions that the constraint was discarded, so it looks like the model chose not to call the tool

After: the same request is rejected with a message naming the accepted values.

1. They send the same `POST https://litellm-domain/v1/chat/completions` with `"tool_choice": "Required"`
2. They get back `400` with `Snowflake doesn't support tool_choice=Required. Supported tool_choice values=['auto', 'required', 'none', json object]. To drop it from the call, set litellm.drop_params = True.`
3. They correct it to `"tool_choice": "required"` and get `200 OK` with the expected `tool_calls`
4. If they would rather the parameter be ignored than the call fail, setting `drop_params` makes step 1 return `200 OK` with the parameter dropped

## Relevant issues

Fixes #38372

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

Shared setup — the same script at both commits, printing the `tool_choice` actually placed on the outgoing Snowflake request body:

```python
import json, litellm
from litellm.llms.snowflake.chat.transformation import SnowflakeConfig
cfg = SnowflakeConfig()
for value in ["required", "Required", "any"]:
    try:
        body = cfg.transform_request(
            model="snowflake/claude-3-5-sonnet",
            messages=[{"role": "user", "content": "What's the weather in Paris?"}],
            optional_params={"tool_choice": value},
            litellm_params={}, headers={},
        )
        print(f'tool_choice={value!r:12} -> sent as {json.dumps(body.get("tool_choice"))}')
    except Exception as e:
        print(f'tool_choice={value!r:12} -> {type(e).__name__}: {str(e)[:95]}')
```

### Before (47cfd3f)

1. `python repro.py`
2. Observed:

```
tool_choice='required'   -> sent as {"type": "any"}
tool_choice='Required'   -> sent as {"type": "auto"}
tool_choice='any'        -> sent as {"type": "auto"}
```

Rows 2 and 3 are the bug: the caller asked the model to call a tool, and `{"type": "auto"}` goes out instead.

### After (57f5918)

1. `python repro.py`
2. Observed:

```
tool_choice='required'   -> sent as {"type": "any"}
tool_choice='Required'   -> UnsupportedParamsError: litellm.UnsupportedParamsError: Snowflake doesn't support tool_choice=Required. Supported tool_
tool_choice='any'        -> UnsupportedParamsError: litellm.UnsupportedParamsError: Snowflake doesn't support tool_choice=any. Supported tool_choic
```

3. `pytest tests/test_litellm/llms/snowflake/ -q` → `63 passed`
4. With `litellm/llms/snowflake/chat/transformation.py` reverted to 47cfd3f and the new tests kept, 7 of the 8 new tests fail — confirming they pin the fix rather than passing either way. The eighth covers `auto`/`required`/`none`, whose behaviour is unchanged.

## Type

🐛 Bug Fix

## Caveats (if any)

### Medium

- Behaviour change: previously-silent values now raise 400
- Callers relying on the old fallback need `drop_params` or a correction

### Low

- No live Snowflake account, so proof is transform-level not a billed call
- `"any"` still rejected here; central normalization discussed in #37980
