### PR TITLE
fix(alerting): stop leaking a Slack periodic flush task on every config reload

### DIFF
--- a/litellm/integrations/SlackAlerting/slack_alerting.py
+++ b/litellm/integrations/SlackAlerting/slack_alerting.py
@@ -106,6 +106,7 @@ class SlackAlerting(CustomBatchLogger):
         self.default_webhook_url = default_webhook_url
         self.flush_lock = asyncio.Lock()
         self.periodic_started = False
+        self._periodic_flush_task: asyncio.Task | None = None
         self.hanging_request_check = AlertingHangingRequestCheck(
             slack_alerting_object=self,
         )
@@ -116,6 +117,20 @@ class SlackAlerting(CustomBatchLogger):
         self.digest_buckets: dict[str, DigestEntry] = {}
         self.digest_lock = asyncio.Lock()
         super().__init__(**kwargs, flush_lock=self.flush_lock)
+
+    def _ensure_periodic_flush_started(self) -> None:
+        """Start the periodic flush loop, at most once.
+
+        ``update_values`` is re-invoked on a timer by the proxy's deployment
+        refresh, so creating the task unconditionally leaks one ``while True``
+        task per call for the lifetime of the process.
+        """
+        if self.periodic_started:
+            return
+        # Keep a reference: a bare create_task may be garbage collected
+        # mid-execution, and this is now the only flush task.
+        self._periodic_flush_task = asyncio.create_task(self.periodic_flush())
+        self.periodic_started = True
 
     def update_values(
         self,
@@ -129,17 +144,14 @@ class SlackAlerting(CustomBatchLogger):
     ):
         if alerting is not None:
             self.alerting = alerting
-            asyncio.create_task(self.periodic_flush())
-            self.periodic_started = True
+            self._ensure_periodic_flush_started()
         if alerting_threshold is not None:
             self.alerting_threshold = alerting_threshold
         if alert_types is not None:
             self.alert_types = alert_types
         if alerting_args is not None:
             self.alerting_args = SlackAlertingArgs(**alerting_args)
-            if not self.periodic_started:
-                asyncio.create_task(self.periodic_flush())
-                self.periodic_started = True
+            self._ensure_periodic_flush_started()
         if alert_type_config is not None:
             for key, val in alert_type_config.items():
                 self.alert_type_config[key] = AlertTypeConfig(**val) if isinstance(val, dict) else val
@@ -1420,9 +1432,8 @@ Model Info:
             return
 
         # Start periodic flush if not already started
-        if not self.periodic_started and self.alerting is not None and len(self.alerting) > 0:
-            asyncio.create_task(self.periodic_flush())
-            self.periodic_started = True
+        if len(self.alerting) > 0:
+            self._ensure_periodic_flush_started()
 
         if "webhook" in self.alerting and alert_type == "budget_alerts" and user_info is not None:
             await self.send_webhook_alert(webhook_event=user_info)

--- a/tests/test_litellm/integrations/SlackAlerting/test_slack_alerting.py
+++ b/tests/test_litellm/integrations/SlackAlerting/test_slack_alerting.py
@@ -15,6 +15,16 @@ from litellm.proxy._types import CallInfo, Litellm_EntityType
 from litellm.types.integrations.slack_alerting import SlackAlertingCacheKeys
 
 
+def _close_and_stub(coro):
+    """asyncio.create_task stand-in: close the coroutine nothing will await.
+
+    Leaving it open emits an unawaited-coroutine warning, which is an error
+    under -W error.
+    """
+    coro.close()
+    return MagicMock()
+
+
 class TestSlackAlerting(unittest.TestCase):
     def setUp(self):
         self.slack_alerting = SlackAlerting()
@@ -156,8 +166,7 @@ class TestSlackAlerting(unittest.TestCase):
     # Calling update_values with alerting args should try to start the periodic task
     @patch("asyncio.create_task")
     def test_update_values_starts_periodic_task(self, mock_create_task):
-        # Make it do nothing (or return a dummy future)
-        mock_create_task.return_value = AsyncMock()  # prevents awaiting errors
+        mock_create_task.side_effect = _close_and_stub
 
         assert self.slack_alerting.periodic_started == False
 
@@ -169,7 +178,7 @@ class TestSlackAlerting(unittest.TestCase):
     # never exits, so they accumulate for the lifetime of the process).
     @patch("asyncio.create_task")
     def test_update_values_starts_periodic_task_only_once(self, mock_create_task):
-        mock_create_task.return_value = AsyncMock()
+        mock_create_task.side_effect = _close_and_stub
 
         for _ in range(5):
             self.slack_alerting.update_values(alerting=["slack"])

--- a/tests/test_litellm/integrations/SlackAlerting/test_slack_alerting.py
+++ b/tests/test_litellm/integrations/SlackAlerting/test_slack_alerting.py
@@ -164,6 +164,20 @@ class TestSlackAlerting(unittest.TestCase):
         self.slack_alerting.update_values(alerting_args={"slack_alerting": "True"})
         assert self.slack_alerting.periodic_started == True
 
+    # The proxy re-invokes update_values on a timer; it must not spawn a new
+    # periodic_flush task each time (each one is a `while True` loop that
+    # never exits, so they accumulate for the lifetime of the process).
+    @patch("asyncio.create_task")
+    def test_update_values_starts_periodic_task_only_once(self, mock_create_task):
+        mock_create_task.return_value = AsyncMock()
+
+        for _ in range(5):
+            self.slack_alerting.update_values(alerting=["slack"])
+            self.slack_alerting.update_values(alerting_args={"slack_alerting": "True"})
+
+        assert self.slack_alerting.periodic_started is True
+        assert mock_create_task.call_count == 1
+
     @patch("litellm.integrations.SlackAlerting.slack_alerting.datetime")
     def test_alert_type_in_formatted_message(self, mock_datetime):
         # Setup mocks


### PR DESCRIPTION
## TLDR

Problem this solves:

- A running proxy gains a background task every config reload
- Each one is a loop that never exits
- After days, a proxy holds tens of thousands of them
- Makes `/debug/asyncio-tasks` useless for diagnosing anything else

How it solves it:

- Start the Slack flush loop once, not per reload
- One helper now guards every start site
- Keeps a reference so the single task is not collected

## User Flow

Before: an operator running the proxy with Slack alerting on watches its background task count climb forever, and cannot use the task list to diagnose anything

1. They start the proxy with `alerting: ["slack"]` and `store_model_in_db: true` in their config
2. They send `GET https://litellm-domain/debug/asyncio-tasks` with the master key and see `SlackAlerting.periodic_flush` at `2`
3. They wait and send the same request each reload interval; the count reads `3`, then `5`, `6`, `8`, `9`, and keeps rising
4. It never comes back down, so on a proxy that has been up for days the response reports tens of thousands of active tasks
5. Any other task they were trying to spot is buried, and the count is capped at 5000 per name, so the number stops being informative

After: the same count settles at one and stays there, so the task list stays readable

1. They start the proxy with the same config
2. They send `GET https://litellm-domain/debug/asyncio-tasks` with the master key and see `SlackAlerting.periodic_flush` at `1`
3. They wait and send the same request each reload interval; the count still reads `1`
4. Total active tasks stay flat across reloads
5. Slack alerts keep arriving exactly as before

## Relevant issues

Fixes #41357 — filed after this PR was opened, reporting the same unguarded branch (`slack_alerting.py` L138-141) from a 4-worker v1.101.0 deployment: ~1,500 `SlackAlerting.periodic_flush` tasks per worker at 44,860s uptime, exactly uptime ÷ 30s, with worker RSS growing until OOM-kill drops in-flight client connections silently.

[#24218](https://github.com/BerriAI/litellm/pull/24218) was an earlier attempt at the same leak; it was closed without review. That PR was raised when both branches of the start path were unguarded. One of the two has since been guarded, so the leak is narrower today but still present on the other.

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Shared setup, identical for both runs. A throwaway Postgres, and a config with Slack alerting on and the reload interval shortened to 10s so the growth is visible in a 90-second window:

```bash
docker run -d --name litellm-leak-pg -e POSTGRES_PASSWORD=llm -e POSTGRES_USER=llm \
  -e POSTGRES_DB=llm -p 55432:5432 postgres:16
```

```yaml
# config.yaml
model_list:
  - model_name: fake
    litellm_params:
      model: openai/fake
      api_key: sk-fake
      api_base: http://localhost:9/v1

general_settings:
  master_key: sk-1234
  database_url: postgresql://llm:llm@localhost:55432/llm
  store_model_in_db: true
  alerting: ["slack"]
  proxy_config_reload_interval_seconds: 10
```

Each run starts the proxy on a freshly created database, waits for `/health/liveliness`, then polls every 15s:

```bash
litellm --config config.yaml --port 4000
curl -s -H "Authorization: Bearer sk-1234" http://localhost:4000/debug/asyncio-tasks
```

### Before (cd63c7e5a)

1. Start the proxy on the shared config and wait for it to come up
2. Poll `/debug/asyncio-tasks` every 15s; `SlackAlerting.periodic_flush` climbs by one per reload and never drops:

```
  t=15s  SlackAlerting.periodic_flush tasks: 2   (total active: 11)
  t=30s  SlackAlerting.periodic_flush tasks: 3   (total active: 12)
  t=45s  SlackAlerting.periodic_flush tasks: 5   (total active: 14)
  t=60s  SlackAlerting.periodic_flush tasks: 6   (total active: 15)
  t=75s  SlackAlerting.periodic_flush tasks: 8   (total active: 17)
  t=90s  SlackAlerting.periodic_flush tasks: 9   (total active: 18)
```

### After (f16a63ebf)

1. Start the proxy on the same config and wait for it to come up
2. Poll `/debug/asyncio-tasks` every 15s; the count stays at one, and the total stays flat:

```
  t=15s  SlackAlerting.periodic_flush tasks: 1   (total active: 10)
  t=30s  SlackAlerting.periodic_flush tasks: 1   (total active: 10)
  t=45s  SlackAlerting.periodic_flush tasks: 1   (total active: 10)
  t=60s  SlackAlerting.periodic_flush tasks: 1   (total active: 10)
  t=75s  SlackAlerting.periodic_flush tasks: 1   (total active: 10)
  t=90s  SlackAlerting.periodic_flush tasks: 1   (total active: 10)
```

The starts were also traced on the `After` build: the helper is entered once per reload, seven times over the run on a single alerting instance, and only the first entry created a task. The remaining six returned without creating one.

## Type

🐛 Bug Fix

## Caveats (if any)

### Low

- Only the Slack alerting loop is covered here
- Other batch loggers create their flush task in `__init__`, so they do not share this path
- The reload interval was shortened only to make the growth visible quickly; the leak rate follows whatever interval a deployment runs
- The second commit also closes the intercepted coroutine in the pre-existing start test, which patches `create_task` the same way; fixing only the new test would have left the warning in the file

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

