### PR TITLE
fix(proxy): exempt zero-cost models from the personal budget check

### DIFF
--- a/litellm/proxy/hooks/max_budget_limiter.py
+++ b/litellm/proxy/hooks/max_budget_limiter.py
@@ -40,6 +40,26 @@ class _PROXY_MaxBudgetLimiter(CustomLogger):
             ):
                 return
 
+            # Zero-cost models bypass budget enforcement everywhere else - both
+            # common_checks and the reservation path skip them via
+            # _is_model_cost_zero. Without the same exemption here, a user at
+            # their personal max_budget also loses access to models that cannot
+            # incur cost, so a free-model fallback stops working under a
+            # personal cap while it keeps working under a team cap.
+            # Imported lazily to avoid a circular import via proxy.utils.
+            from litellm.proxy.auth.auth_checks import _is_model_cost_zero
+            from litellm.proxy.proxy_server import llm_router
+
+            if _is_model_cost_zero(
+                model=data.get("model") if data else None,
+                llm_router=llm_router,
+            ):
+                verbose_proxy_logger.debug(
+                    "MaxBudgetLimiter: skipping personal budget check for zero-cost model: %s",
+                    data.get("model") if data else None,
+                )
+                return
+
             # The reservation path admits at the strict-`<` boundary and
             # atomically pre-fills the same counter we'd read here. Re-checking
             # with `>=` would reject a request the reservation already admitted

--- a/tests/test_litellm/proxy/hooks/test_max_budget_limiter.py
+++ b/tests/test_litellm/proxy/hooks/test_max_budget_limiter.py
@@ -235,3 +235,58 @@ async def test_no_max_budget_passes():
 
     assert result is None
     mock_get_spend.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_skips_for_zero_cost_model_when_over_budget():
+    """
+    Zero-cost models bypass budget enforcement in common_checks and in the
+    reservation path (both via `_is_model_cost_zero`). This hook must apply the
+    same exemption, otherwise a user at their personal `max_budget` also loses
+    access to models that cannot incur cost - while the same models stay usable
+    when a *team* budget is the one exhausted, since this hook only ever reads
+    `user_max_budget`.
+    """
+    handler = _PROXY_MaxBudgetLimiter()
+    user_api_key_dict = _make_user_api_key_auth(user_max_budget=10.0)
+
+    with patch(
+        "litellm.proxy.auth.auth_checks._is_model_cost_zero",
+        return_value=True,
+    ), patch(
+        "litellm.proxy.proxy_server.get_current_spend",
+        new=AsyncMock(return_value=10.0),
+    ) as mock_get_spend:
+        result = await handler.async_pre_call_hook(
+            user_api_key_dict=user_api_key_dict,
+            cache=DualCache(),
+            data={"model": "free-model"},
+            call_type="completion",
+        )
+
+    assert result is None
+    mock_get_spend.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_still_rejects_priced_model_when_over_budget():
+    """The zero-cost exemption must not weaken enforcement for priced models."""
+    handler = _PROXY_MaxBudgetLimiter()
+    user_api_key_dict = _make_user_api_key_auth(user_max_budget=10.0)
+
+    with patch(
+        "litellm.proxy.auth.auth_checks._is_model_cost_zero",
+        return_value=False,
+    ), patch(
+        "litellm.proxy.proxy_server.get_current_spend",
+        new=AsyncMock(return_value=10.0),
+    ), pytest.raises(HTTPException) as exc_info:
+        await handler.async_pre_call_hook(
+            user_api_key_dict=user_api_key_dict,
+            cache=DualCache(),
+            data={"model": "paid-model"},
+            call_type="completion",
+        )
+
+    assert exc_info.value.status_code == 429
+    assert "Max budget limit reached." in exc_info.value.detail

--- a/tests/test_litellm/proxy/hooks/test_max_budget_limiter.py
+++ b/tests/test_litellm/proxy/hooks/test_max_budget_limiter.py
@@ -250,10 +250,10 @@ async def test_skips_for_zero_cost_model_when_over_budget():
     handler = _PROXY_MaxBudgetLimiter()
     user_api_key_dict = _make_user_api_key_auth(user_max_budget=10.0)
 
-    with patch(
+    with patch(  # test-quality-ok: hook resolves both collaborators as module globals, no injection seam
         "litellm.proxy.auth.auth_checks._is_model_cost_zero",
         return_value=True,
-    ), patch(
+    ), patch(  # test-quality-ok: proxy module global, no injection seam
         "litellm.proxy.proxy_server.get_current_spend",
         new=AsyncMock(return_value=10.0),
     ) as mock_get_spend:
@@ -274,10 +274,10 @@ async def test_still_rejects_priced_model_when_over_budget():
     handler = _PROXY_MaxBudgetLimiter()
     user_api_key_dict = _make_user_api_key_auth(user_max_budget=10.0)
 
-    with patch(
+    with patch(  # test-quality-ok: hook resolves both collaborators as module globals, no injection seam
         "litellm.proxy.auth.auth_checks._is_model_cost_zero",
         return_value=False,
-    ), patch(
+    ), patch(  # test-quality-ok: proxy module global, no injection seam
         "litellm.proxy.proxy_server.get_current_spend",
         new=AsyncMock(return_value=10.0),
     ), pytest.raises(HTTPException) as exc_info:


### PR DESCRIPTION
## TLDR

Problem this solves:

- Free ($0-cost) models get blocked when a user's personal budget runs out
- Team budgets don't do this, so behaviour is inconsistent
- Users lose the free-model fallback and can't send anything

How it solves it:

- Skip the personal budget check for zero-cost models
- Reuses the zero-cost check the auth layer already does
- Paid models are still blocked exactly as before

## User Flow

A team chat app buys paid-model credits and also offers always-free models so work continues once the paid credits run out. Each member has a personal cap on top so one user can't drain the team. Members call the gateway with a team-scoped key.

### Before: breaks at step 3 - hitting a personal cap also blocks the always-free models, so the user can't send anything even though the team still has credits

1. They send `POST https://litellm-domain/v1/chat/completions` with `{"model": "chat-model-free"}` and get `200`.
2. They work on a paid model until one request returns `429` with `"type": "budget_exceeded"` and `ExceededBudget: User=alice over budget. Spend=0.12, Budget=0.12`. Expected - personal cap reached.
3. They switch back to the free model from step 1. The identical request now returns **`429` with `"type": "throttling_error"` and `Max budget limit reached.`**, though the model is free and the team has used only $0.12 of $1.00.
4. Every other free model returns the same `429`, so the app is unusable to them. A teammate under their own cap still gets `200` on those models, so only this user is locked out.

### After: the same flow completes - paid models stay capped, free models keep working

1. They send `POST https://litellm-domain/v1/chat/completions` with `{"model": "chat-model-free"}` and get `200`.
2. They work on a paid model until one request returns `429` with `"type": "budget_exceeded"` and `ExceededBudget: User=alice over budget. Spend=0.12, Budget=0.12`. Expected - personal cap reached.
3. They switch back to the free model from step 1. The identical request returns **`200`**.
4. They keep working on the free models; paid models keep returning `429 budget_exceeded`, which is the intended cap.

## Relevant issues

Fixes #38515  

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Shared setup. `chat-model-free` priced at `0`/`0`, `chat-model-paid` at `0.000003`/`0.000015`, `general_settings` with `apply_user_budget_to_team_keys: true` (only needed because the key is team-scoped; the bug also hits personal keys without it). Proxy run with `litellm --config config.yaml --port 4000 --detailed_debug` against real Postgres + Redis.

```bash
# personal cap $0.12, team pool $1.00
curl -sX POST localhost:4000/user/new -H "Authorization: Bearer $MASTER_KEY" -H 'Content-Type: application/json' \
  -d '{"user_id":"alice","user_email":"alice@example.com","user_role":"internal_user","max_budget":0.12}'
curl -sX POST localhost:4000/team/new -H "Authorization: Bearer $MASTER_KEY" -H 'Content-Type: application/json' \
  -d '{"team_id":"engineering","max_budget":1.00,"members_with_roles":[{"user_id":"alice","role":"user"}]}'
curl -sX POST localhost:4000/key/generate -H "Authorization: Bearer $MASTER_KEY" -H 'Content-Type: application/json' \
  -d '{"team_id":"engineering","user_id":"alice"}'   # -> $USER_KEY

FREE='{"model":"chat-model-free","messages":[{"role":"user","content":"hi"}],"max_tokens":200}'
PAID='{"model":"chat-model-paid","messages":[{"role":"user","content":"hi"}],"max_tokens":200}'
```

### Before (6e569ee0c7)

#### Personal budget exhausted

1. Free model works first:

```bash
$ curl -sX POST localhost:4000/v1/chat/completions -H "Authorization: Bearer $USER_KEY" -H 'Content-Type: application/json' -d "$FREE" -o /dev/null -w '%{http_code}\n'
200
```

2. Burn the personal cap on the paid model:

```bash
$ for i in $(seq 1 30); do code=$(curl -sX POST localhost:4000/v1/chat/completions -H "Authorization: Bearer $USER_KEY" -H 'Content-Type: application/json' -d "$PAID" -o /tmp/r.json -w '%{http_code}'); echo "$i -> $code"; [ "$code" != 200 ] && cat /tmp/r.json && break; done
1 -> 200
...
21 -> 429
{"error":{"message":"ExceededBudget: User=alice over budget. Spend=0.12, Budget=0.12","type":"budget_exceeded","code":"429"}}
```

3. Repeat step 1 - the free model is now rejected:

```bash
$ curl -sX POST localhost:4000/v1/chat/completions -H "Authorization: Bearer $USER_KEY" -H 'Content-Type: application/json' -d "$FREE"
{"error":{"message":"Max budget limit reached.","type":"throttling_error","code":"429"}}

# GET /v1/models still returns 200 and still lists the free models
# all three zero-cost models: 0/3 usable
```

#### Team budget exhausted (control)

1. Same setup with no personal cap and the team cap binding - free models are unaffected:

```bash
21 -> 429
{"error":{"message":"Budget has been exceeded! Team=engineering Current cost: 0.123024, Max budget: 0.12","type":"budget_exceeded","code":"429"}}

# all three zero-cost models: 3/3 usable
```

### After (96db813262)

#### Personal budget exhausted

1. Free model works first:

```bash
$ curl -sX POST localhost:4000/v1/chat/completions -H "Authorization: Bearer $USER_KEY" -H 'Content-Type: application/json' -d "$FREE" -o /dev/null -w '%{http_code}\n'
200
```

2. Burn the personal cap on the paid model - still enforced, same request, same error:

```bash
21 -> 429
{"error":{"message":"ExceededBudget: User=alice over budget. Spend=0.12, Budget=0.12","type":"budget_exceeded","code":"429"}}
```

3. Repeat step 1 - the free model is now allowed:

```bash
$ curl -sX POST localhost:4000/v1/chat/completions -H "Authorization: Bearer $USER_KEY" -H 'Content-Type: application/json' -d "$FREE" -o /dev/null -w '%{http_code}\n'
200

# all three zero-cost models: 3/3 usable
```

#### Team budget exhausted (control)

1. Unchanged by this PR:

```bash
21 -> 429
{"error":{"message":"Budget has been exceeded! Team=engineering Current cost: 0.123024, Max budget: 0.12","type":"budget_exceeded","code":"429"}}

# all three zero-cost models: 3/3 usable
```

Both cases now agree at `3/3`, and paid models are still capped.

## Type

🐛 Bug Fix

## Caveats (if any)

### Medium

- This rejection uses `"type": "throttling_error"` while other budget rejections use `"budget_exceeded"`, so clients branching on the latter can't detect it. Unchanged here; happy to align in a follow-up.

### Low

- Only reachable with a personal budget in play: a personal key, or a team key with `apply_user_budget_to_team_keys: true`. Other deployments see no change.
- Proof captured on `/v1/chat/completions`; the check sits on a shared pre-call path, so `/v1/messages` and `/v1/responses` should match.

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
