### PR TITLE
feat(bedrock/agentcore): optionally forward client tool declarations in InvokeAgentRuntime payload

### DIFF
--- a/litellm/llms/bedrock/chat/agentcore/transformation.py
+++ b/litellm/llms/bedrock/chat/agentcore/transformation.py
@@ -5,7 +5,7 @@ https://docs.aws.amazon.com/bedrock/latest/APIReference/API_agentcore_InvokeAgen
 """
 
 import json
-from collections.abc import AsyncGenerator
+from collections.abc import AsyncGenerator, Mapping
 from typing import TYPE_CHECKING, Any, Final, Optional, Union, cast
 from urllib.parse import quote
 
@@ -226,10 +226,19 @@ class AmazonAgentCoreConfig(BaseConfig, BaseAWSLLM):
           OpenAI-shaped multimodal blocks. This is opt-in because an AgentCore agent
           must be explicitly written to read ``payload["content"]``; by default the
           payload stays byte-identical to the legacy ``{"prompt": "..."}`` shape.
+        - ``tools`` is added ONLY when the ``forward_tools`` litellm param is truthy
+          AND the caller declared a non-empty OpenAI ``tools`` list, so a schemaless
+          agent can see what the caller offered this turn. Same opt-in reasoning as
+          ``content``. AgentCore reports no supported OpenAI params, so ``tools`` is
+          dropped (or rejected) before this method runs unless the caller also sets
+          ``allowed_openai_params=["tools"]``: that keeps
+          ``get_supported_openai_params()`` honest about what AgentCore natively
+          supports and makes forwarding a deliberate two-step opt-in. One-way signal
+          only, since AgentCore responses carry no tool-call channel.
 
         Returns:
-            dict: Payload dict containing the prompt and (optionally) the OpenAI
-            content list.
+            dict: Payload dict containing the prompt and, optionally, the OpenAI
+            content list and tool declarations.
         """
         verbose_logger.debug("AgentCore transform_request - optional_params keys: %s", list(optional_params.keys()))
 
@@ -243,7 +252,7 @@ class AmazonAgentCoreConfig(BaseConfig, BaseAWSLLM):
         # list verbatim under "content" so an attachment-aware agent can read the raw
         # blocks (image_url, file, etc.). Default off keeps the payload byte-identical
         # to the legacy {"prompt": "..."} shape for agents that only read the prompt.
-        if self._should_forward_multimodal_content(optional_params, litellm_params):
+        if self._is_flag_enabled(optional_params, litellm_params, "forward_multimodal_content"):
             last_content: Final = messages[-1].get("content")
             if isinstance(last_content, list) and any(
                 isinstance(block, dict) and block.get("type") not in (None, "text") for block in last_content
@@ -251,6 +260,14 @@ class AmazonAgentCoreConfig(BaseConfig, BaseAWSLLM):
                 # Copy so the payload never aliases messages[-1]["content"]; shallow,
                 # not deep, to avoid cloning large base64 media on the request path.
                 payload["content"] = list(last_content)
+
+        if self._is_flag_enabled(optional_params, litellm_params, "forward_tools"):
+            tools: Final = optional_params.get("tools")
+            if isinstance(tools, list) and tools:
+                # Immutable shallow copy: the payload can never alias the caller's list,
+                # the nested dicts stay shared to avoid a deep clone, and json.dumps
+                # serializes a tuple to the same JSON array a list would.
+                payload["tools"] = tuple(tools)
 
         # Get or generate session ID - this goes in the header
         runtime_session_id: Final = self._get_runtime_session_id(optional_params)
@@ -268,19 +285,25 @@ class AmazonAgentCoreConfig(BaseConfig, BaseAWSLLM):
         return payload
 
     @staticmethod
-    def _should_forward_multimodal_content(optional_params: dict, litellm_params: dict) -> bool:
-        """Whether to forward raw OpenAI content blocks under ``payload["content"]``.
+    def _is_flag_enabled(
+        optional_params: Mapping[str, object],
+        litellm_params: Mapping[str, object],
+        key: str,
+    ) -> bool:
+        """Whether the ``key`` payload-forwarding flag is on, ``optional_params`` first.
 
-        Opt-in via the ``forward_multimodal_content`` litellm param (default ``False``)
-        because AgentCore agents must be explicitly written to read the field. The
-        value may arrive as a bool or a config/env string ("true", "1", ...). Checks
-        ``optional_params`` first (where other AgentCore params land), then
-        ``litellm_params``.
+        These flags are opt-in (default ``False``) because AgentCore agents must be
+        explicitly written to read the field they add, and the value may arrive as a
+        bool or as a config/env string ("true", "1", ...).
+
+        Both a deployment-level and a per-request flag reach this method through
+        ``optional_params``: ``get_litellm_params`` only forwards an allowlist of keys
+        and these are not on it, so anything unrecognized is routed to the provider
+        params instead. ``litellm_params`` is the fallback for direct
+        ``transform_request`` callers.
         """
         for source in (optional_params, litellm_params):
-            if not isinstance(source, dict):
-                continue
-            value = source.get("forward_multimodal_content")
+            value = source.get(key)
             if value is None:
                 continue
             if isinstance(value, str):

--- a/tests/test_litellm/llms/bedrock/chat/agentcore/test_agentcore_transformation.py
+++ b/tests/test_litellm/llms/bedrock/chat/agentcore/test_agentcore_transformation.py
@@ -641,3 +641,311 @@ class TestAgentCoreMultimodalContent:
         payload = config.transform_request(messages=messages, **kwargs)
         assert payload["content"] == content
         assert payload["content"] is not content
+
+
+AGENTCORE_TEST_MODEL = (
+    "agentcore/arn:aws:bedrock-agentcore:us-west-2:111111111111:runtime/test_agent"
+)
+WEB_SEARCH_TOOL = {
+    "type": "function",
+    "function": {
+        "name": "web_search",
+        "description": "Search the web",
+        "parameters": {
+            "type": "object",
+            "properties": {"query": {"type": "string"}},
+        },
+    },
+}
+
+
+class TestAgentCoreForwardTools:
+    """Tests for transform_request forwarding the caller's OpenAI tool declarations.
+
+    AgentCore Runtime is schemaless on the agent side — the agent author's
+    @app.entrypoint handler parses whatever JSON arrives. An agent that implements
+    a capability itself (its own search, its own retrieval) has no way today to
+    learn whether the caller offered that capability for this turn: AgentCore
+    declares no supported OpenAI params, so ``tools`` never reaches the transform.
+
+    When the ``forward_tools`` litellm param is set, the OpenAI tools list is
+    forwarded verbatim under a "tools" field. This is opt-in: an agent must be
+    written to read payload["tools"]. Without the flag, the payload is
+    byte-identical to the legacy {"prompt": "..."} shape.
+
+    This is a one-way signal — AgentCore responses carry no tool-call channel, so
+    none of this implies function-calling support.
+    """
+
+    @pytest.fixture
+    def config(self):
+        return AmazonAgentCoreConfig()
+
+    @pytest.fixture
+    def messages(self):
+        return [{"role": "user", "content": "what happened today"}]
+
+    @pytest.fixture
+    def base_kwargs(self):
+        """Default kwargs — forwarding is OFF (no opt-in flag)."""
+        return {
+            "model": "bedrock/agentcore/arn:aws:bedrock-agentcore:us-west-2:111111111111:runtime/test_agent",
+            "optional_params": {},
+            "litellm_params": {},
+            "headers": {},
+        }
+
+    def test_tools_not_forwarded_by_default(self, config, messages, base_kwargs):
+        """Default (no opt-in flag): tools are NOT forwarded — backward compat."""
+        base_kwargs["optional_params"] = {"tools": [WEB_SEARCH_TOOL]}
+
+        payload = config.transform_request(messages=messages, **base_kwargs)
+
+        assert payload == {"prompt": "what happened today"}
+        assert "tools" not in payload
+
+    def test_tools_forwarded_when_opted_in(self, config, messages, base_kwargs):
+        """Flag on + tools present → forwarded verbatim."""
+        tools = [WEB_SEARCH_TOOL]
+        base_kwargs["optional_params"] = {"tools": tools, "forward_tools": True}
+
+        payload = config.transform_request(messages=messages, **base_kwargs)
+
+        assert payload["tools"] == tuple(tools)
+        assert payload["prompt"] == "what happened today"
+
+    def test_multiple_tools_forwarded_verbatim(self, config, messages, base_kwargs):
+        """The list is not filtered or reshaped — the agent decides what it wants."""
+        calculator = {"type": "function", "function": {"name": "calculator"}}
+        tools = [WEB_SEARCH_TOOL, calculator]
+        base_kwargs["optional_params"] = {"tools": tools, "forward_tools": True}
+
+        payload = config.transform_request(messages=messages, **base_kwargs)
+
+        assert payload["tools"] == tuple(tools)
+
+    def test_no_tools_key_when_opted_in_without_tools(
+        self, config, messages, base_kwargs
+    ):
+        """Flag on but the caller declared nothing → no "tools" field."""
+        base_kwargs["optional_params"] = {"forward_tools": True}
+
+        payload = config.transform_request(messages=messages, **base_kwargs)
+
+        assert payload == {"prompt": "what happened today"}
+
+    def test_empty_tools_list_not_forwarded(self, config, messages, base_kwargs):
+        """Clients send tools=[] when a tool toggle is off — treat it as absent."""
+        base_kwargs["optional_params"] = {"tools": [], "forward_tools": True}
+
+        payload = config.transform_request(messages=messages, **base_kwargs)
+
+        assert payload == {"prompt": "what happened today"}
+        assert "tools" not in payload
+
+    def test_non_list_tools_not_forwarded(self, config, messages, base_kwargs):
+        """A malformed tools value must not reach the payload."""
+        base_kwargs["optional_params"] = {
+            "tools": {"name": "web_search"},
+            "forward_tools": True,
+        }
+
+        payload = config.transform_request(messages=messages, **base_kwargs)
+
+        assert "tools" not in payload
+
+    @pytest.mark.parametrize("flag", ["true", "True", "1", "yes", "on", " TRUE "])
+    def test_truthy_string_flags(self, config, messages, base_kwargs, flag):
+        """Config/env values arrive as strings."""
+        base_kwargs["optional_params"] = {
+            "tools": [WEB_SEARCH_TOOL],
+            "forward_tools": flag,
+        }
+
+        payload = config.transform_request(messages=messages, **base_kwargs)
+
+        assert payload["tools"] == (WEB_SEARCH_TOOL,)
+
+    @pytest.mark.parametrize("flag", ["false", "0", "no", "off", ""])
+    def test_falsy_string_flags(self, config, messages, base_kwargs, flag):
+        base_kwargs["optional_params"] = {
+            "tools": [WEB_SEARCH_TOOL],
+            "forward_tools": flag,
+        }
+
+        payload = config.transform_request(messages=messages, **base_kwargs)
+
+        assert "tools" not in payload
+
+    def test_flag_read_from_litellm_params(self, config, messages, base_kwargs):
+        """litellm_params is the fallback source for direct transform_request callers.
+
+        Deployment-level and per-request flags both arrive in optional_params (see
+        TestAgentCoreForwardToolsEndToEnd), so this branch only serves callers that
+        build litellm_params themselves.
+        """
+        base_kwargs["optional_params"] = {"tools": [WEB_SEARCH_TOOL]}
+        base_kwargs["litellm_params"] = {"forward_tools": True}
+
+        payload = config.transform_request(messages=messages, **base_kwargs)
+
+        assert payload["tools"] == (WEB_SEARCH_TOOL,)
+
+    def test_optional_params_wins_over_litellm_params(
+        self, config, messages, base_kwargs
+    ):
+        """optional_params is read first, so it wins over the litellm_params fallback."""
+        base_kwargs["optional_params"] = {
+            "tools": [WEB_SEARCH_TOOL],
+            "forward_tools": False,
+        }
+        base_kwargs["litellm_params"] = {"forward_tools": True}
+
+        payload = config.transform_request(messages=messages, **base_kwargs)
+
+        assert "tools" not in payload
+
+    def test_payload_does_not_alias_optional_params(
+        self, config, messages, base_kwargs
+    ):
+        """The payload holds an immutable copy, so it cannot alias the caller's list.
+
+        The forwarded value serializes to the same JSON array either way, so the wire
+        format is asserted here too rather than just the in-memory type.
+        """
+        tools = [WEB_SEARCH_TOOL]
+        base_kwargs["optional_params"] = {"tools": tools, "forward_tools": True}
+
+        payload = config.transform_request(messages=messages, **base_kwargs)
+
+        assert isinstance(payload["tools"], tuple)
+        with pytest.raises(AttributeError):
+            payload["tools"].append({"type": "function", "function": {"name": "extra"}})
+        assert tools == [WEB_SEARCH_TOOL]
+        assert json.loads(json.dumps(payload))["tools"] == [WEB_SEARCH_TOOL]
+
+    def test_tools_and_multimodal_content_are_independent(self, config, base_kwargs):
+        """Both opt-ins together → both keys present, neither disturbs the other."""
+        content = [
+            {"type": "text", "text": "what is this"},
+            {
+                "type": "image_url",
+                "image_url": {"url": "data:image/png;base64,aGVsbG8="},
+            },
+        ]
+        tools = [WEB_SEARCH_TOOL]
+        base_kwargs["optional_params"] = {
+            "tools": tools,
+            "forward_tools": True,
+            "forward_multimodal_content": True,
+        }
+
+        payload = config.transform_request(
+            messages=[{"role": "user", "content": content}], **base_kwargs
+        )
+
+        assert payload["tools"] == tuple(tools)
+        assert payload["content"] == content
+        assert payload["prompt"] == "what is this"
+
+    def test_session_header_still_set_when_forwarding(
+        self, config, messages, base_kwargs
+    ):
+        """Forwarding must not disturb the existing header contract."""
+        base_kwargs["optional_params"] = {
+            "tools": [WEB_SEARCH_TOOL],
+            "forward_tools": True,
+            "runtimeSessionId": "session-abc",
+        }
+
+        config.transform_request(messages=messages, **base_kwargs)
+
+        assert (
+            base_kwargs["headers"]["X-Amzn-Bedrock-AgentCore-Runtime-Session-Id"]
+            == "session-abc"
+        )
+
+
+class TestAgentCoreForwardToolsEndToEnd:
+    """``tools`` only reaches transform_request via allowed_openai_params.
+
+    AgentCore reports no supported OpenAI params, so get_optional_params drops
+    ``tools`` (or raises without drop_params). ``allowed_openai_params=["tools"]``
+    is the documented escape hatch, and is what makes forwarding reachable.
+    """
+
+    def test_tools_dropped_without_allowed_openai_params(self):
+        optional_params = litellm.utils.get_optional_params(
+            model=AGENTCORE_TEST_MODEL,
+            custom_llm_provider="bedrock",
+            tools=[WEB_SEARCH_TOOL],
+            drop_params=True,
+        )
+
+        assert "tools" not in optional_params
+
+    def test_allowed_openai_params_carries_tools_to_the_transform(self):
+        optional_params = litellm.utils.get_optional_params(
+            model=AGENTCORE_TEST_MODEL,
+            custom_llm_provider="bedrock",
+            tools=[WEB_SEARCH_TOOL],
+            allowed_openai_params=["tools"],
+        )
+
+        assert optional_params["tools"] == [WEB_SEARCH_TOOL]
+
+        payload = AmazonAgentCoreConfig().transform_request(
+            model=AGENTCORE_TEST_MODEL,
+            messages=[{"role": "user", "content": "hi"}],
+            optional_params=optional_params,
+            litellm_params={"forward_tools": True},
+            headers={},
+        )
+
+        assert payload["tools"] == (WEB_SEARCH_TOOL,)
+
+    def test_flag_reaches_the_transform_via_optional_params(self):
+        """The flag itself is not an OpenAI param, so it lands in optional_params.
+
+        get_litellm_params only forwards an allowlist of keys, which excludes
+        forward_tools, so this is the path every real caller takes: both the flag and
+        the tools list arrive in optional_params and litellm_params stays empty.
+        """
+        optional_params = litellm.utils.get_optional_params(
+            model=AGENTCORE_TEST_MODEL,
+            custom_llm_provider="bedrock",
+            tools=[WEB_SEARCH_TOOL],
+            allowed_openai_params=["tools"],
+            forward_tools=True,
+        )
+
+        assert optional_params["forward_tools"] is True
+
+        payload = AmazonAgentCoreConfig().transform_request(
+            model=AGENTCORE_TEST_MODEL,
+            messages=[{"role": "user", "content": "hi"}],
+            optional_params=optional_params,
+            litellm_params={},
+            headers={},
+        )
+
+        assert payload["tools"] == (WEB_SEARCH_TOOL,)
+
+    def test_allowed_openai_params_alone_does_not_forward(self):
+        """Both opt-ins are required; the escape hatch alone changes nothing."""
+        optional_params = litellm.utils.get_optional_params(
+            model=AGENTCORE_TEST_MODEL,
+            custom_llm_provider="bedrock",
+            tools=[WEB_SEARCH_TOOL],
+            allowed_openai_params=["tools"],
+        )
+
+        payload = AmazonAgentCoreConfig().transform_request(
+            model=AGENTCORE_TEST_MODEL,
+            messages=[{"role": "user", "content": "hi"}],
+            optional_params=optional_params,
+            litellm_params={},
+            headers={},
+        )
+
+        assert payload == {"prompt": "hi"}


### PR DESCRIPTION
## TLDR

Problem this solves:

- The caller's `tools` list never reaches the AgentCore payload
- AgentCore reports no supported OpenAI params, so it's dropped
- The body on the wire stays `{"prompt": "..."}` regardless

How it solves it:

- New `forward_tools` litellm param, default off
- Forwards the OpenAI `tools` list verbatim under a `tools` key
- Same pattern as #28885, one param over

## User Flow

Before: a developer sending tool declarations to an `agentcore/...` model finds they never arrive, so the request their agent receives is indistinguishable from one that offered no tools at all

1. They set `allowed_openai_params: ["tools"]` on the deployment so the gateway stops rejecting the param
2. They send POST https://litellm-domain/v1/chat/completions for the `agentcore/...` model with a `tools` list declaring `web_search`
3. The call returns 200
4. The body their agent receives is `{"prompt": "what happened today"}`, with no `tools` key, so the declaration is gone with no way to recover it

After: the same request carries the declarations through to the agent

1. They add `forward_tools: true` alongside `allowed_openai_params: ["tools"]` and restart the proxy
2. They send the same POST https://litellm-domain/v1/chat/completions with the same `tools` list
3. The call returns 200, exactly as before
4. The body their agent receives is now `{"prompt": "what happened today", "tools": [{"type": "function", "function": {"name": "web_search", ...}}]}`
5. A caller who sends no `tools`, or `tools: []`, still gets the byte-identical legacy `{"prompt": "..."}` body

## Relevant issues

No issue filed. This follows #28885, which added `forward_multimodal_content` for the `content` key, and deliberately stays consistent with it: same flag parsing, same `optional_params`-then-`litellm_params` precedence, same default-off reasoning, same test structure

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Live proxy against a real Bedrock AgentCore runtime in a sandbox AWS account, SigV4 auth, real agent invocations billed to that account. Both legs use the identical config, the identical request body, and the same agent, and differ only in the commit the proxy was booted from

What this PR controls is the JSON body delivered to the agent, so that is what the two legs capture, alongside the response proving the change is non-breaking against a live runtime

Config, identical on both legs:

```yaml
model_list:
  - model_name: agentcore-tools
    litellm_params:
      model: bedrock/agentcore/arn:aws:bedrock-agentcore:eu-west-1:<account>:runtime/<sandbox-agent>
      aws_profile_name: <profile>
      aws_region_name: eu-west-1
      allowed_openai_params: ["tools"]
      forward_tools: true

general_settings:
  master_key: sk-agentcore-qa
```

Request body `body.json`, identical on both legs:

```json
{
  "model": "agentcore-tools",
  "messages": [{"role": "user", "content": "say the single word BANANA and nothing else"}],
  "tools": [{"type": "function", "function": {"name": "web_search", "description": "search the web", "parameters": {"type": "object", "properties": {"query": {"type": "string"}}}}}]
}
```

### Before (`cd63c7e5a7`)

1. Boot the proxy at the merge base: `python litellm/proxy/proxy_cli.py --config qa_config.yaml --port 41881 --detailed_debug`
2. Send the request: `curl -sS -X POST http://127.0.0.1:41881/v1/chat/completions -H "Authorization: Bearer sk-agentcore-qa" -H "Content-Type: application/json" -d @body.json`
3. HTTP 200, the agent answers:
   ```json
   {"choices":[{"finish_reason":"stop","index":0,"message":{"content":"BANANA","role":"assistant"}}],"usage":{"completion_tokens":3,"prompt_tokens":17,"total_tokens":20}}
   ```
4. Both the flag and the tools list did reach the transform:
   ```
   transformation.py:234 - AgentCore transform_request - optional_params keys: ['aws_region_name', 'aws_profile_name', 'forward_tools', 'tools']
   ```
5. Yet the body leaving the gateway carries no `tools`, so the agent can never see the declaration:
   ```
   POST Request Sent from LiteLLM:
   curl -X POST https://bedrock-agentcore.eu-west-1.amazonaws.com/runtimes/<encoded-arn>/invocations \
   -H 'Content-Type: application/json' -H 'X-Amzn-Bedrock-AgentCore-Runtime-Session-Id: litellm-session-d5ccf43b-4584-40cb-8766-7a87e6a318bc' -H 'Accept: application/json, text/event-stream' \
   -d '{'prompt': 'say the single word BANANA and nothing else'}'
   ```

### After (`e5ce332db5`)

1. Boot the proxy at this PR's tip, same config: `python litellm/proxy/proxy_cli.py --config qa_config.yaml --port 41882 --detailed_debug`
2. Send the identical request: `curl -sS -X POST http://127.0.0.1:41882/v1/chat/completions -H "Authorization: Bearer sk-agentcore-qa" -H "Content-Type: application/json" -d @body.json`
3. HTTP 200 and the same answer, so forwarding is non-breaking against a real runtime:
   ```json
   {"choices":[{"finish_reason":"stop","index":0,"message":{"content":"BANANA","role":"assistant"}}],"usage":{"completion_tokens":3,"prompt_tokens":17,"total_tokens":20}}
   ```
4. The body leaving the gateway now carries the declaration:
   ```
   POST Request Sent from LiteLLM:
   curl -X POST https://bedrock-agentcore.eu-west-1.amazonaws.com/runtimes/<encoded-arn>/invocations \
   -H 'Content-Type: application/json' -H 'X-Amzn-Bedrock-AgentCore-Runtime-Session-Id: litellm-session-065f3661-2bd3-4012-a291-5cdcc8aaefe1' -H 'Accept: application/json, text/event-stream' \
   -d '{'prompt': 'say the single word BANANA and nothing else', 'tools': ({'type': 'function', 'function': {'name': 'web_search', 'description': 'search the web', 'parameters': {'type': 'object', 'properties': {'query': {'type': 'string'}}}}},)}'
   ```
5. That debug line prints Python's `repr` of the payload dict, so the immutable copy shows as a tuple. The bytes actually sent are `json.dumps`'d, a plain JSON array:
   ```
   {"prompt": "say the single word BANANA and nothing else", "tools": [{"type": "function", "function": {"name": "web_search", "description": "search the web", "parameters": {"type": "object", "properties": {"query": {"type": "string"}}}}}]}
   ```
   AgentCore returning 200 is itself proof the body is well-formed JSON

Control run: invoking the same runtime directly with `aws bedrock-agentcore invoke-agent-runtime` and a hand-written payload carrying a `tools` key also returns 200 with a normal answer, confirming AgentCore's schemaless body tolerates the new key rather than rejecting it

## Type

🆕 New Feature

## Caveats (if any)

### Medium

- `forward_tools` without `allowed_openai_params: ["tools"]` silently does nothing

### Low

- Shallow copy, so nested tool dicts stay shared with the caller's list

## Final Attestation

- [ ] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

---

## Details

### What's broken

`AmazonAgentCoreConfig.get_supported_openai_params()` returns `[]` and `map_openai_params` ignores `non_default_params`, so a client that declares `tools` to a `bedrock/agentcore/...` model loses the declaration before `transform_request` ever runs. AgentCore Runtime is schemaless on the agent side, the agent author's `@app.entrypoint` handler parses whatever JSON arrives, so an agent that implements a capability itself has every reason to want that declaration and no way to get it

### The change

`forward_tools`, default `False`. When it is truthy and the caller sent a non-empty `tools` list, the list is forwarded verbatim under a new top-level `tools` key, next to the existing `prompt` and optional `content`

```yaml
- model_name: my-agent
  litellm_params:
    model: bedrock/agentcore/arn:aws:bedrock-agentcore:...
    allowed_openai_params: ["tools"]   # let `tools` reach optional_params
    forward_tools: true                # forward it into the payload
```

The second commit folds `_should_forward_multimodal_content` and `_should_forward_tools` into a single `_is_flag_enabled(optional_params, litellm_params, key)`, since they were identical apart from the key they read. Both flags keep the bool-or-string parsing (`"1"`, `"true"`, `"yes"`, `"on"`) and the `optional_params`-then-`litellm_params` precedence that #28885 established

### Why two config keys

Requiring `allowed_openai_params: ["tools"]` is deliberate rather than an oversight:

- `get_supported_openai_params()` keeps reporting what AgentCore natively supports, which is nothing. Declaring `["tools"]` there would make `/model_group/info` advertise tool support for models that do nothing with tools
- `allowed_openai_params` already means "I know this is unsupported, pass it anyway", which is exactly this situation
- Zero behavior change for every existing agentcore deployment. Nobody who has not set both keys sees any difference

### Tests

26 new cases across two classes, 17 test methods expanded by parametrize, mirroring #28885's structure

- `TestAgentCoreForwardTools` covers the transform itself
  - default off, payload byte-identical to the legacy `{"prompt": ...}` shape
  - forwards when opted in, multiple tools verbatim
  - flag on without tools, empty list (the common "tool toggle off" case), and a non-list value each yield no key
  - 6 truthy and 5 falsy string flags
  - flag read from `litellm_params`, and `optional_params` winning over it
  - aliasing regression: the payload holds an immutable copy, the caller's list is untouched, and the serialized body still carries a plain JSON array
  - tools and multimodal content together, both keys present, neither disturbing the other
  - session header contract unchanged
- `TestAgentCoreForwardToolsEndToEnd` pins the real routing through `get_optional_params`
  - `tools` dropped without the escape hatch
  - carried to the transform with it
  - the flag arriving via `optional_params`, the path every real caller takes, since `get_litellm_params` only forwards an allowlist that excludes it
  - `allowed_openai_params` alone still yielding `{"prompt": ...}`

### Verification

- `tests/test_litellm/llms/bedrock/chat/agentcore/` passes, 58 tests
- `tests/test_litellm/llms/bedrock/` is 1398 passed, 1 skipped, 9 failed, and those 9 fail identically on the base branch. They live in `messages/invoke_transformations/` and `test_mantle.py`, untouched here
- `scripts/type_discipline_gate.py` reports every LIT rule within its ceiling
- `basedpyright` on the touched file goes from 228 findings to 225, and LIT001 from 42 to 40, so the file ends up cleaner than it started despite gaining a feature

