### PR TITLE
fix(proxy): exempt zero-cost models from the personal max_budget limiter

### DIFF
--- a/litellm/proxy/hooks/max_budget_limiter.py
+++ b/litellm/proxy/hooks/max_budget_limiter.py
@@ -53,18 +53,15 @@ class _PROXY_MaxBudgetLimiter(CustomLogger):
             if user_counter_key in get_reserved_counter_keys(user_api_key_dict.budget_reservation):
                 return
 
-            # Zero-cost models are exempt from budget checks — mirrors the auth
-            # layer (user_api_key_auth.py). A free model must stay usable when
-            # the user's personal budget is exhausted. Imported lazily like the
-            # other proxy_server imports in this hook to avoid import cycles.
+            # Zero-cost models skip budget checks, mirroring the auth layer
+            # (user_api_key_auth.py) so both personal-budget gates agree.
             from litellm.proxy.auth.auth_checks import (
                 _is_model_cost_zero,  # pyright: ignore[reportPrivateUsage]  # auth layer's own exemption helper, reused for parity across budget gates
             )
             from litellm.proxy.proxy_server import llm_router
 
-            # Runtime-checked narrowing: `data` is an untyped dict at this
-            # boundary, and pre-call data carries the caller's single model
-            # name, which is also what the 429 label below accepts.
+            # Runtime-checked narrowing; pre-call data carries the caller's
+            # single model name, which is also what the 429 label accepts.
             raw_model: Final[object] = data.get("model") if data else None  # pyright: ignore[reportUnknownMemberType]  # bare `dict` param, same pattern the raise site below has always used
             requested_model: Final[str | None] = raw_model if isinstance(raw_model, str) else None
             if _is_model_cost_zero(model=requested_model, llm_router=llm_router):

--- a/litellm/proxy/hooks/max_budget_limiter.py
+++ b/litellm/proxy/hooks/max_budget_limiter.py
@@ -1,4 +1,4 @@
-from typing import Final, cast
+from typing import Final
 
 from fastapi import HTTPException
 
@@ -62,11 +62,11 @@ class _PROXY_MaxBudgetLimiter(CustomLogger):
             )
             from litellm.proxy.proxy_server import llm_router
 
-            # cast-ok: `data` is an untyped dict at this boundary; every reader
-            # treats "model" as a single name or a fallback list.
-            requested_model: Final[str | list[str] | None] = (
-                cast("str | list[str] | None", data.get("model")) if data else None  # pyright: ignore[reportUnknownMemberType]  # bare `dict` param, same pattern as the raise site below
-            )
+            # Runtime-checked narrowing: `data` is an untyped dict at this
+            # boundary, and pre-call data carries the caller's single model
+            # name, which is also what the 429 label below accepts.
+            raw_model: Final[object] = data.get("model") if data else None  # pyright: ignore[reportUnknownMemberType]  # bare `dict` param, same pattern the raise site below has always used
+            requested_model: Final[str | None] = raw_model if isinstance(raw_model, str) else None
             if _is_model_cost_zero(model=requested_model, llm_router=llm_router):
                 verbose_proxy_logger.info(
                     "Skipping MaxBudgetLimiter check for zero-cost model: %s",
@@ -90,9 +90,7 @@ class _PROXY_MaxBudgetLimiter(CustomLogger):
 
             # CHECK IF REQUEST ALLOWED
             if curr_spend >= max_budget:
-                # cast-ok: this call site labels a single model; a fallback list
-                # narrows to None so the label stays deterministic.
-                resolved_model, llm_provider = resolve_llm_provider_for_rate_limit(cast("str | None", requested_model))
+                resolved_model, llm_provider = resolve_llm_provider_for_rate_limit(requested_model)
                 raise ProxyRateLimitError(
                     detail="Max budget limit reached.",
                     rate_limit_type=RateLimitType.BUDGET,

--- a/litellm/proxy/hooks/max_budget_limiter.py
+++ b/litellm/proxy/hooks/max_budget_limiter.py
@@ -1,4 +1,4 @@
-from typing import Final
+from typing import Final, cast
 
 from fastapi import HTTPException
 
@@ -53,6 +53,27 @@ class _PROXY_MaxBudgetLimiter(CustomLogger):
             if user_counter_key in get_reserved_counter_keys(user_api_key_dict.budget_reservation):
                 return
 
+            # Zero-cost models are exempt from budget checks — mirrors the auth
+            # layer (user_api_key_auth.py). A free model must stay usable when
+            # the user's personal budget is exhausted. Imported lazily like the
+            # other proxy_server imports in this hook to avoid import cycles.
+            from litellm.proxy.auth.auth_checks import (
+                _is_model_cost_zero,  # pyright: ignore[reportPrivateUsage]  # auth layer's own exemption helper, reused for parity across budget gates
+            )
+            from litellm.proxy.proxy_server import llm_router
+
+            # cast-ok: `data` is an untyped dict at this boundary; every reader
+            # treats "model" as a single name or a fallback list.
+            requested_model: Final[str | list[str] | None] = (
+                cast("str | list[str] | None", data.get("model")) if data else None  # pyright: ignore[reportUnknownMemberType]  # bare `dict` param, same pattern as the raise site below
+            )
+            if _is_model_cost_zero(model=requested_model, llm_router=llm_router):
+                verbose_proxy_logger.info(
+                    "Skipping MaxBudgetLimiter check for zero-cost model: %s",
+                    requested_model,
+                )
+                return
+
             from litellm.proxy.proxy_server import get_current_spend
 
             curr_spend: Final = await get_current_spend(
@@ -69,7 +90,9 @@ class _PROXY_MaxBudgetLimiter(CustomLogger):
 
             # CHECK IF REQUEST ALLOWED
             if curr_spend >= max_budget:
-                resolved_model, llm_provider = resolve_llm_provider_for_rate_limit(data.get("model") if data else None)
+                # cast-ok: this call site labels a single model; a fallback list
+                # narrows to None so the label stays deterministic.
+                resolved_model, llm_provider = resolve_llm_provider_for_rate_limit(cast("str | None", requested_model))
                 raise ProxyRateLimitError(
                     detail="Max budget limit reached.",
                     rate_limit_type=RateLimitType.BUDGET,

--- a/tests/test_litellm/proxy/hooks/test_max_budget_limiter.py
+++ b/tests/test_litellm/proxy/hooks/test_max_budget_limiter.py
@@ -196,12 +196,15 @@ async def test_team_keys_enforce_personal_budget_when_flag_enabled():
         team_id="team-1",
     )
 
-    with patch.dict(
-        "litellm.proxy.proxy_server.general_settings",
-        {"apply_user_budget_to_team_keys": True},
-    ), patch(
-        "litellm.proxy.proxy_server.get_current_spend",
-        new=AsyncMock(return_value=999.0),
+    with (
+        patch.dict(
+            "litellm.proxy.proxy_server.general_settings",
+            {"apply_user_budget_to_team_keys": True},
+        ),
+        patch(
+            "litellm.proxy.proxy_server.get_current_spend",
+            new=AsyncMock(return_value=999.0),
+        ),
     ):
         with pytest.raises(HTTPException) as exc_info:
             await handler.async_pre_call_hook(
@@ -235,3 +238,105 @@ async def test_no_max_budget_passes():
 
     assert result is None
     mock_get_spend.assert_not_awaited()
+
+
+def _router_with_free_and_paid_models():
+    """Real router with one explicitly zero-cost model and one priced model.
+
+    `_is_model_cost_zero` only bypasses when both per-token costs are
+    explicitly configured as 0 — a real Router (not a stand-in) is required so
+    the cost fields land in the router's model_cost registry the way
+    `mock_router_with_zero_cost_model` in test_zero_cost_model_budget_bypass.py
+    sets them up.
+    """
+    from litellm.router import Router
+
+    return Router(
+        model_list=[
+            {
+                "model_name": "chat-model-free",
+                "litellm_params": {
+                    "model": "openai/chat-model-free",
+                    "api_key": "sk-test",
+                    "input_cost_per_token": 0.0,
+                    "output_cost_per_token": 0.0,
+                },
+                "model_info": {
+                    "id": "chat-model-free-id",
+                    "input_cost_per_token": 0.0,
+                    "output_cost_per_token": 0.0,
+                },
+            },
+            {
+                "model_name": "chat-model-paid",
+                "litellm_params": {
+                    "model": "openai/chat-model-paid",
+                    "api_key": "sk-test",
+                    "input_cost_per_token": 0.000003,
+                    "output_cost_per_token": 0.000015,
+                },
+                "model_info": {
+                    "id": "chat-model-paid-id",
+                },
+            },
+        ]
+    )
+
+
+@pytest.mark.asyncio
+async def test_zero_cost_model_skips_personal_budget_check():
+    """Regression for #38515: once the user's personal max_budget is exhausted,
+    a zero-cost model must stay usable — the auth layer already exempts it
+    (user_api_key_auth.py), this hook must not become the stricter second
+    gate."""
+    handler = _PROXY_MaxBudgetLimiter()
+    user_api_key_dict = _make_user_api_key_auth(user_max_budget=0.12, user_spend=0.12)
+
+    with (
+        patch(  # test-quality-ok: proxy_server module global is the hook's only router injection point
+            "litellm.proxy.proxy_server.llm_router",
+            new=_router_with_free_and_paid_models(),
+        ),
+        patch(  # test-quality-ok: proxy_server module global is the hook's only injection point
+            "litellm.proxy.proxy_server.get_current_spend",
+            new=AsyncMock(return_value=999.0),
+        ) as mock_get_spend,
+    ):
+        result = await handler.async_pre_call_hook(
+            user_api_key_dict=user_api_key_dict,
+            cache=DualCache(),
+            data={"model": "chat-model-free"},
+            call_type="completion",
+        )
+
+    assert result is None
+    mock_get_spend.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_priced_model_still_rejected_when_budget_exhausted():
+    """The zero-cost exemption must not leak: a priced model on the same
+    exhausted budget still gets the 429."""
+    handler = _PROXY_MaxBudgetLimiter()
+    user_api_key_dict = _make_user_api_key_auth(user_max_budget=0.12, user_spend=0.12)
+
+    with (
+        patch(  # test-quality-ok: proxy_server module global is the hook's only router injection point
+            "litellm.proxy.proxy_server.llm_router",
+            new=_router_with_free_and_paid_models(),
+        ),
+        patch(  # test-quality-ok: proxy_server module global is the hook's only injection point
+            "litellm.proxy.proxy_server.get_current_spend",
+            new=AsyncMock(return_value=0.12),
+        ),
+    ):
+        with pytest.raises(HTTPException) as exc_info:
+            await handler.async_pre_call_hook(
+                user_api_key_dict=user_api_key_dict,
+                cache=DualCache(),
+                data={"model": "chat-model-paid"},
+                call_type="completion",
+            )
+
+    assert exc_info.value.status_code == 429
+    assert "Max budget limit reached." in exc_info.value.detail


### PR DESCRIPTION
Fixes #38515

## TLDR

- A user with an exhausted personal `max_budget` gets 429'd on every request — including explicitly zero-cost models, which the auth layer already exempts.
- Fix: the personal-budget pre-call hook reuses the auth layer's `_is_model_cost_zero` exemption, so free models stay usable whichever budget ran out.

`_PROXY_MaxBudgetLimiter` (the personal-budget pre-call hook) never looked at the requested model, so once a user's personal `max_budget` was exhausted it 429'd **every** request — including explicitly zero-cost models that the auth layer (`user_api_key_auth.py`) already exempts. Free models behaved differently depending on which budget ran out (team cap: usable; personal cap: blocked).

**Change**: reuse the auth layer's `_is_model_cost_zero` exemption in the hook, before the spend comparison — same rule on both personal-budget gates. The `model` extraction is also hoisted so the 429 raise site reuses it.

**Tests** (`tests/test_litellm/proxy/hooks/test_max_budget_limiter.py`): zero-cost model on an exhausted personal budget passes without reading spend (verified red without the source change); a priced model on the same budget still gets the 429. All 9 tests in the file pass.
