### PR TITLE
fix(ui): prefer caller requests over internal sub-calls in log sessions

### DIFF
--- a/litellm/proxy/spend_tracking/spend_management_endpoints.py
+++ b/litellm/proxy/spend_tracking/spend_management_endpoints.py
@@ -26,7 +26,7 @@ from typing_extensions import ReadOnly
 
 import litellm
 from litellm._logging import verbose_proxy_logger
-from litellm.constants import LITTELM_INTERNAL_HEALTH_SERVICE_ACCOUNT_NAME
+from litellm.constants import INTERNAL_CALL_ORIGIN_METADATA_KEY, LITTELM_INTERNAL_HEALTH_SERVICE_ACCOUNT_NAME
 from litellm.proxy._types import *
 from litellm.proxy._types import ProviderBudgetResponse, ProviderBudgetResponseObject
 from litellm.proxy.auth.user_api_key_auth import user_api_key_auth
@@ -62,6 +62,10 @@ _SESSION_KEY_EXPR: Final = "COALESCE(NULLIF(session_id, ''), request_id)"
 _SESSION_GROUP_KEY_SQL: Final = f"{_SESSION_KEY_EXPR}, api_key"
 _MCP_CALL_TYPES_SQL: Final = "('call_mcp_tool', 'list_mcp_tools')"
 _AGENT_CALL_TYPE_SQL: Final = "'asend_message'"
+_INTERNAL_SUB_CALL_SQL: Final = f"(metadata->>'{INTERNAL_CALL_ORIGIN_METADATA_KEY}') IS NOT NULL"
+_SESSION_REPRESENTATIVE_ORDER_SQL: Final = (
+    f'{_SESSION_GROUP_KEY_SQL}, {_INTERNAL_SUB_CALL_SQL}, call_type IN {_MCP_CALL_TYPES_SQL}, "startTime" DESC'
+)
 _SPEND_LOG_LIST_COLUMNS: Final = """
                 request_id, call_type, api_key, spend, total_tokens,
                 prompt_tokens, completion_tokens, "startTime", "endTime",
@@ -2830,7 +2834,7 @@ async def ui_view_spend_logs(
                         {_SPEND_LOG_LIST_COLUMNS}
                     FROM "LiteLLM_SpendLogs"
                     WHERE {joined_conditions}
-                    ORDER BY {_SESSION_GROUP_KEY_SQL}, call_type IN {_MCP_CALL_TYPES_SQL}, "startTime" DESC
+                    ORDER BY {_SESSION_REPRESENTATIVE_ORDER_SQL}
                 ) AS session_representatives
                 ORDER BY {_order_expr} {_sql_dir}{_nulls_clause}, request_id
                 LIMIT ${p} OFFSET ${p + 1}
@@ -2894,7 +2898,7 @@ async def _fetch_session_representatives(
     next_param_index: int,
     session_keys: Sequence[tuple[str, str]],
 ) -> list[dict[str, object]]:  # mutable-ok: _build_ui_spend_logs_response writes session counts onto each row
-    """Fetch the newest non-MCP row of each ``(session_key, api_key)`` session, in ``session_keys`` order."""
+    """Fetch the newest caller-sent non-MCP row of each ``(session_key, api_key)`` session, in ``session_keys`` order."""
     rep_query: Final = f"""
         SELECT * FROM (
             SELECT DISTINCT ON ({_SESSION_GROUP_KEY_SQL})
@@ -2904,7 +2908,7 @@ async def _fetch_session_representatives(
               AND ({_SESSION_GROUP_KEY_SQL}) IN (
                   SELECT * FROM unnest(${next_param_index}::text[], ${next_param_index + 1}::text[])
               )
-            ORDER BY {_SESSION_GROUP_KEY_SQL}, call_type IN {_MCP_CALL_TYPES_SQL}, "startTime" DESC
+            ORDER BY {_SESSION_REPRESENTATIVE_ORDER_SQL}
         ) AS session_representatives
     """
     rep_rows: Final[Sequence[dict[str, object]]] = await _query_raw(  # mutable-ok: rows are enriched in place
@@ -2940,7 +2944,7 @@ async def _ui_session_grouped_spend_logs(
     api_key)``, resumed from the ``session_cursor`` keyset
     ``'<last_activity>|<api_key>|<session_key>'`` instead of an OFFSET, so
     page depth does not degrade the query plan. Each session is represented
-    by its newest non-MCP row, enriched by ``_build_ui_spend_logs_response``
+    by its newest caller-sent non-MCP row, enriched by ``_build_ui_spend_logs_response``
     exactly like the flat listing, and the response carries
     ``next_session_cursor`` / ``has_more`` while ``total`` counts sessions
     (capped like the flat total).

--- a/tests/test_litellm/proxy/spend_tracking/test_spend_management_endpoints.py
+++ b/tests/test_litellm/proxy/spend_tracking/test_spend_management_endpoints.py
@@ -6635,9 +6635,9 @@ async def test_ui_view_spend_logs_group_by_session_first_page(client, monkeypatc
         rep_call = emitted[2]
         assert f"DISTINCT ON ({SESSION_GROUP_KEY_SQL})" in rep_call[0]
         assert (
-            f"ORDER BY {SESSION_GROUP_KEY_SQL}, call_type IN ('call_mcp_tool', 'list_mcp_tools'), \"startTime\" DESC"
-            in rep_call[0]
-        ), "the session representative must prefer the newest non-MCP call"
+            f"ORDER BY {SESSION_GROUP_KEY_SQL}, (metadata->>'internal_call_origin') IS NOT NULL, "
+            f"call_type IN ('call_mcp_tool', 'list_mcp_tools'), \"startTime\" DESC" in rep_call[0]
+        ), "the session representative must prefer the newest caller-sent non-MCP call"
         assert rep_call[-2] == ["sess-1", "req-solo"]
         assert rep_call[-1] == ["hashed-key", "hashed-key"]
     finally:

--- a/tests/test_litellm/proxy/spend_tracking/test_spend_query_optimization.py
+++ b/tests/test_litellm/proxy/spend_tracking/test_spend_query_optimization.py
@@ -584,9 +584,10 @@ async def test_spend_logs_ui_group_by_session_paginates_sessions(monkeypatch):
 
     rep_sql = emitted[2][0]
     assert f"DISTINCT ON ({group_key})" in rep_sql, f"page must return one row per session. SQL was:\n{rep_sql}"
-    assert f"ORDER BY {group_key}, call_type IN ('call_mcp_tool', 'list_mcp_tools'), \"startTime\" DESC" in rep_sql, (
-        "the session representative must prefer the newest non-MCP call"
-    )
+    assert (
+        f"ORDER BY {group_key}, (metadata->>'internal_call_origin') IS NOT NULL, "
+        f"call_type IN ('call_mcp_tool', 'list_mcp_tools'), \"startTime\" DESC" in rep_sql
+    ), "the session representative must prefer the newest caller-sent non-MCP call"
     assert "COUNT(*) OVER ()" not in rep_sql
 
     assert [row["request_id"] for row in response["data"]] == ["req-1", "req-2"]
@@ -595,6 +596,94 @@ async def test_spend_logs_ui_group_by_session_paginates_sessions(monkeypatch):
     assert response["total_pages"] == 1
     assert response["has_more"] is False
     assert response["next_session_cursor"] is None
+
+
+def test_session_representative_order_ranks_internal_sub_calls_last():
+    """
+    A session's representative must be traffic the caller sent. The auto-router
+    stamps its classifier sub-call with metadata.internal_call_origin and
+    forwards the parent's session id, so the sub-call shares the session and
+    would otherwise represent it whenever it is the newest surviving row --
+    e.g. when the call it routed failed and never logged.
+    """
+    from litellm.constants import INTERNAL_CALL_ORIGIN_METADATA_KEY
+    from litellm.proxy.spend_tracking.spend_management_endpoints import (
+        _SESSION_REPRESENTATIVE_ORDER_SQL,
+    )
+
+    internal_term = f"(metadata->>'{INTERNAL_CALL_ORIGIN_METADATA_KEY}') IS NOT NULL"
+    mcp_term = "call_type IN ('call_mcp_tool', 'list_mcp_tools')"
+
+    assert internal_term in _SESSION_REPRESENTATIVE_ORDER_SQL, (
+        "internal sub-calls must be deprioritized, not left to the startTime tiebreak"
+    )
+    assert _SESSION_REPRESENTATIVE_ORDER_SQL.index(internal_term) < _SESSION_REPRESENTATIVE_ORDER_SQL.index(
+        mcp_term
+    ), "a caller-sent MCP call outranks any internal sub-call"
+    assert _SESSION_REPRESENTATIVE_ORDER_SQL.index(mcp_term) < _SESSION_REPRESENTATIVE_ORDER_SQL.index(
+        '"startTime" DESC'
+    ), "startTime only breaks ties within a tier"
+
+
+@pytest.mark.asyncio
+async def test_spend_logs_ui_group_by_session_prefers_caller_sent_over_classifier(monkeypatch):
+    """
+    End-to-end guard for the ordering above: both DISTINCT ON sites must carry
+    the internal_call_origin term, so neither the flat grouped page nor the
+    keyset representative fetch can promote a classifier sub-call.
+    """
+    from litellm.constants import INTERNAL_CALL_ORIGIN_METADATA_KEY
+    from litellm.proxy._types import LitellmUserRoles, UserAPIKeyAuth
+    from litellm.proxy.spend_tracking.spend_management_endpoints import ui_view_spend_logs
+
+    caller_sent = {
+        "request_id": "req-main",
+        "api_key": "k",
+        "session_id": "sess-1",
+        "metadata": "{}",
+    }
+
+    async def mock_query_raw(sql_query, *params):
+        if "COUNT(*) AS total_count" in sql_query:
+            return [{"total_count": 1}]
+        if "DISTINCT ON" in sql_query:
+            return [caller_sent]
+        return [{"session_key": "sess-1", "api_key": "k", "last_activity": "2026-02-16 10:00:00"}]
+
+    mock_prisma = MagicMock()
+    mock_prisma.db = MagicMock()
+    mock_prisma.db.query_raw = AsyncMock(side_effect=mock_query_raw)
+    monkeypatch.setattr("litellm.proxy.proxy_server.prisma_client", mock_prisma)
+
+    auth = UserAPIKeyAuth(user_role=LitellmUserRoles.PROXY_ADMIN, user_id="admin")
+    mock_request = MagicMock()
+    mock_request.url.path = "/spend/logs/ui"
+
+    response = await ui_view_spend_logs(
+        request=mock_request,
+        api_key=None,
+        user_id=None,
+        request_id=None,
+        search=None,
+        start_date="2026-02-16 00:00:00",
+        end_date="2026-02-16 23:59:59",
+        page=1,
+        page_size=50,
+        sort_by="startTime",
+        sort_order="desc",
+        user_api_key_dict=auth,
+        group_by_session=True,
+        session_cursor=None,
+    )
+
+    distinct_on_sql = [call[0][0] for call in mock_prisma.db.query_raw.call_args_list if "DISTINCT ON" in call[0][0]]
+    assert distinct_on_sql, "the grouped listing must select representatives with DISTINCT ON"
+    for sql in distinct_on_sql:
+        assert f"(metadata->>'{INTERNAL_CALL_ORIGIN_METADATA_KEY}') IS NOT NULL" in sql, (
+            f"every representative query must deprioritize internal sub-calls. SQL was:\n{sql}"
+        )
+
+    assert [row["request_id"] for row in response["data"]] == ["req-main"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
<!-- The whole description's target audience is humans, not AI agents: write it in plain, simple,
     everyday engineering language, extremely parsable and readable at a glance. This goes double for
     the TLDR, User Flow, and Caveats sections -->

## TLDR

Problem this solves:

- Request Logs shows the wrong row for a multi-call auto-router session
- Auto-router's own classifier call can be shown instead of the real request

How it solves it:

- Rank caller-sent calls above internal sub-calls when picking the session row
- Internal origin now outranks the existing MCP-vs-LLM tie-break

## User Flow

Before: an admin using an LLM-classifier auto-router opens Request Logs and sees the classifier's own call representing a session, not the request the caller sent

1. They open `/ui/?page=logs` (Request Logs) on a proxy with an `auto_router/complexity_router` model using `classifier_type: llm`
2. A caller sends a chat completion through the router; internally this also triggers one classifier sub-call, so the session now holds 2+ log rows
3. The session collapses to a single row in the table, and depending on row order, it can show the classifier sub-call's model/tokens/duration instead of the caller's request
4. Opening the row and inspecting the session sidebar shows the classifier call tagged "Classify", but the collapsed row itself in the table already showed the wrong summary before that

After: the collapsed row always reflects the caller's own request, regardless of any internal sub-calls in the session

1. They open the same `/ui/?page=logs` page
2. The same session is sent, still producing the caller's request plus the classifier sub-call
3. The collapsed row now always shows the caller's request (model, tokens, duration) as the summary
4. Opening the row still shows the classifier sub-call in the session sidebar, correctly tagged "Classify", it is just never the row that represents the session

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `npx vitest run src/components/view_logs/RequestLogsPanel.test.tsx` (20/20 passing, including the new test)
- [x] My PR passes all required CI/CD checks (lint, eslint budgets, knip, `npm run test:types`, `npm run build` all verified locally against this diff)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

<!-- TODO before opening the PR: replace this section with a real Before/After run against a live
     proxy using an auto_router/complexity_router model with classifier_type: llm, per the template's
     rules (no mocks, actual LLM calls). Capture Before at the merge base commit and After at this
     branch's tip. -->

### Before (`cd63c7e5a`)

1. Configure an `auto_router/complexity_router` model with `classifier_type: llm`
2. Send a chat completion through the router with a session id so the request and the classifier sub-call share a session
3. Open `/ui/?page=logs`, find the session's collapsed row
4. Observe: the row's model/tokens/duration match the classifier sub-call, not the request sent

(ministral-14b-latest is classify model here)
<img width="2143" height="1461" alt="before" src="https://github.com/user-attachments/assets/8ce8aeec-e852-4b54-9644-4bb218fbe9f0" />

### After (`598729c5`)

1. Same config and request as Before
2. Open `/ui/?page=logs`, find the same session's collapsed row
3. Observe: the row's model/tokens/duration match the caller's request

<img width="2279" height="1576" alt="after" src="https://github.com/user-attachments/assets/a63b0c03-8185-41b5-b5c8-cefa8eebe844" />

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix

## Caveats (if any)

### Low

- Fix is UI-only; `internal_call_origin` was already excluded correctly from spend/billing/savings, so no backend change was needed
- Only affects the collapsed *summary row* of a multi-call session; the session detail drawer already labeled the classifier call correctly before this fix

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
