### PR TITLE
fix(openrouter): track responses API cost from usage.cost

### DIFF
--- a/litellm/llms/openrouter/responses/transformation.py
+++ b/litellm/llms/openrouter/responses/transformation.py
@@ -8,13 +8,19 @@ encrypted_content for multi-turn stateless workflows.
 Docs: https://openrouter.ai/docs/api/reference/responses/overview
 """
 
-from typing import Final
+from typing import TYPE_CHECKING, Final
+
+import httpx
 
 import litellm
 from litellm.llms.openai.responses.transformation import OpenAIResponsesAPIConfig
 from litellm.secret_managers.main import get_secret_str
+from litellm.types.llms.openai import ResponseAPIUsage, ResponseInputParam, ResponsesAPIResponse
 from litellm.types.router import GenericLiteLLMParams
 from litellm.types.utils import LlmProviders
+
+if TYPE_CHECKING:
+    from litellm.litellm_core_utils.litellm_logging import Logging
 
 
 class OpenRouterResponsesAPIConfig(OpenAIResponsesAPIConfig):
@@ -27,6 +33,7 @@ class OpenRouterResponsesAPIConfig(OpenAIResponsesAPIConfig):
     Key difference from direct OpenAI:
     - Uses https://openrouter.ai/api/v1 as the API base
     - Uses OPENROUTER_API_KEY for authentication
+    - Requests OpenRouter's `usage.cost` and surfaces it for spend tracking
     """
 
     @property
@@ -75,3 +82,55 @@ class OpenRouterResponsesAPIConfig(OpenAIResponsesAPIConfig):
     def supports_native_websocket(self) -> bool:
         """OpenRouter does not support native WebSocket for Responses API"""
         return False
+
+    def transform_responses_api_request(
+        self,
+        model: str,
+        input: str | ResponseInputParam,
+        response_api_optional_request_params: dict[str, object],  # mutable-ok: base signature
+        litellm_params: GenericLiteLLMParams,
+        headers: dict[str, str],  # mutable-ok: base signature
+    ) -> dict[str, object]:  # mutable-ok: request body, the HTTP handler extends it in place
+        """Ask OpenRouter to report real spend in `usage.cost`.
+
+        Mirrors the chat path (`OpenrouterConfig.transform_request`). Without
+        `usage.include=true` OpenRouter omits `cost` from the response, so the
+        Responses API path has nothing to fall back on and every request logs
+        `spend = 0` for any model not in litellm's bundled pricing JSON.
+        """
+        transformed: Final = super().transform_responses_api_request(
+            model=model,
+            input=input,
+            response_api_optional_request_params=response_api_optional_request_params,
+            litellm_params=litellm_params,
+            headers=headers,
+        )
+        if "usage" not in transformed:
+            transformed["usage"] = {"include": True}  # mutable-ok: extends the request body super() just built
+        return transformed
+
+    def transform_response_api_response(
+        self,
+        model: str,
+        raw_response: httpx.Response,
+        logging_obj: "Logging",
+    ) -> ResponsesAPIResponse:
+        """Carry OpenRouter's returned `usage.cost` into hidden params.
+
+        `get_response_cost_from_hidden_params()` reads
+        `additional_headers["llm_provider-x-litellm-response-cost"]` before any
+        static price-map lookup, so this keeps cost accounting working for
+        OpenRouter models that are absent from litellm's bundled pricing JSON.
+        Same mechanism as the chat path (`OpenrouterConfig.transform_response`).
+        """
+        response: Final = super().transform_response_api_response(
+            model=model,
+            raw_response=raw_response,
+            logging_obj=logging_obj,
+        )
+        usage: Final = response.usage
+        response_cost: Final = usage.cost if isinstance(usage, ResponseAPIUsage) else None
+        if response_cost is not None:
+            hidden: Final = response._hidden_params  # pyright: ignore[reportPrivateUsage]  # cost-header write, mirrors chat path
+            hidden["additional_headers"]["llm_provider-x-litellm-response-cost"] = float(response_cost)
+        return response

--- a/tests/test_litellm/llms/openrouter/responses/test_openrouter_responses_transformation.py
+++ b/tests/test_litellm/llms/openrouter/responses/test_openrouter_responses_transformation.py
@@ -9,12 +9,17 @@ reasoning.encrypted_content for multi-turn stateless workflows.
 Related issue: https://github.com/BerriAI/litellm/issues/22189
 """
 
+from unittest.mock import MagicMock
+
+import httpx
 import pytest
 
 import litellm
+from litellm.cost_calculator import get_response_cost_from_hidden_params
 from litellm.llms.openrouter.responses.transformation import (
     OpenRouterResponsesAPIConfig,
 )
+from litellm.types.router import GenericLiteLLMParams
 from litellm.types.utils import LlmProviders
 from litellm.utils import ProviderConfigManager
 
@@ -57,9 +62,7 @@ class TestOpenRouterResponsesAPIConfig:
         from litellm.types.router import GenericLiteLLMParams
 
         params = GenericLiteLLMParams(api_key="sk-or-test-key")
-        headers = config.validate_environment(
-            headers={}, model="openai/o4-mini", litellm_params=params
-        )
+        headers = config.validate_environment(headers={}, model="openai/o4-mini", litellm_params=params)
         assert headers["Authorization"] == "Bearer sk-or-test-key"
 
     def test_validate_environment_raises_without_key(self, monkeypatch):
@@ -97,8 +100,7 @@ class TestOpenRouterResponsesAPIRegistration:
             provider=LlmProviders.OPENROUTER,
         )
         assert config is not None, (
-            "OpenRouter must be registered as a native Responses API provider "
-            "to preserve reasoning.encrypted_content"
+            "OpenRouter must be registered as a native Responses API provider to preserve reasoning.encrypted_content"
         )
         assert isinstance(config, OpenRouterResponsesAPIConfig)
 
@@ -116,3 +118,120 @@ class TestOpenRouterResponsesAPIRegistration:
         # The URL should point to OpenRouter's responses endpoint
         url = config.get_complete_url(api_base=None, litellm_params={})
         assert "/responses" in url
+
+
+_RESPONSE_BODY = {
+    "id": "resp_123",
+    "object": "response",
+    "created_at": 1234567890,
+    "status": "completed",
+    "model": "openrouter/anthropic/claude-3.5-sonnet",
+    "output": [],
+    "parallel_tool_calls": True,
+    "tool_choice": "auto",
+    "tools": [],
+    "usage": {"input_tokens": 100, "output_tokens": 50, "total_tokens": 150},
+}
+
+
+def _raw_response(body: dict) -> httpx.Response:
+    return httpx.Response(
+        status_code=200,
+        json=body,
+        request=httpx.Request("POST", "https://openrouter.ai/api/v1/responses"),
+    )
+
+
+class TestOpenRouterResponsesAPICostTracking:
+    """
+    Regression for https://github.com/BerriAI/litellm/issues/38507.
+
+    OpenRouter's Responses API path never requested `usage.include=true` and
+    never read OpenRouter's returned `usage.cost`, so every `aresponses`
+    request against an OpenRouter model missing from litellm's bundled
+    pricing JSON logged `spend = 0` despite real token usage.
+    """
+
+    def test_transform_request_adds_usage_include(self):
+        """usage.include=true is added so OpenRouter returns real cost."""
+        config = OpenRouterResponsesAPIConfig()
+        body = config.transform_responses_api_request(
+            model="anthropic/claude-3.5-sonnet",
+            input="hello",
+            response_api_optional_request_params={},
+            litellm_params=GenericLiteLLMParams(),
+            headers={},
+        )
+        assert body["usage"] == {"include": True}
+
+    def test_transform_request_preserves_caller_usage(self):
+        """A usage value the caller already set is left untouched."""
+        config = OpenRouterResponsesAPIConfig()
+        body = config.transform_responses_api_request(
+            model="anthropic/claude-3.5-sonnet",
+            input="hello",
+            response_api_optional_request_params={"usage": {"include": False}},
+            litellm_params=GenericLiteLLMParams(),
+            headers={},
+        )
+        assert body["usage"] == {"include": False}
+
+    def test_transform_response_extracts_openrouter_cost(self):
+        """usage.cost from the response body reaches the cost calculator."""
+        config = OpenRouterResponsesAPIConfig()
+        body = {**_RESPONSE_BODY, "usage": {**_RESPONSE_BODY["usage"], "cost": 0.001234}}
+
+        response = config.transform_response_api_response(
+            model="anthropic/claude-3.5-sonnet",
+            raw_response=_raw_response(body),
+            logging_obj=MagicMock(),
+        )
+
+        additional_headers = response._hidden_params["additional_headers"]
+        assert additional_headers["llm_provider-x-litellm-response-cost"] == 0.001234
+        assert get_response_cost_from_hidden_params(response._hidden_params) == 0.001234
+
+    def test_transform_response_no_cost_in_body(self):
+        """No usage.cost -> no cost header, and nothing raised."""
+        config = OpenRouterResponsesAPIConfig()
+
+        response = config.transform_response_api_response(
+            model="anthropic/claude-3.5-sonnet",
+            raw_response=_raw_response(_RESPONSE_BODY),
+            logging_obj=MagicMock(),
+        )
+
+        additional_headers = response._hidden_params.get("additional_headers", {})
+        assert "llm_provider-x-litellm-response-cost" not in additional_headers
+        assert get_response_cost_from_hidden_params(response._hidden_params) is None
+
+    def test_transform_response_no_usage_object(self):
+        """A response with no usage object at all -> no cost header, no crash."""
+        config = OpenRouterResponsesAPIConfig()
+        body = {k: v for k, v in _RESPONSE_BODY.items() if k != "usage"}
+
+        response = config.transform_response_api_response(
+            model="anthropic/claude-3.5-sonnet",
+            raw_response=_raw_response(body),
+            logging_obj=MagicMock(),
+        )
+
+        additional_headers = response._hidden_params.get("additional_headers", {})
+        assert "llm_provider-x-litellm-response-cost" not in additional_headers
+
+    def test_transform_response_preserves_response_headers(self):
+        """The cost key is merged in, not written over the parent's headers."""
+        config = OpenRouterResponsesAPIConfig()
+        body = {**_RESPONSE_BODY, "usage": {**_RESPONSE_BODY["usage"], "cost": 0.5}}
+        raw = _raw_response(body)
+        raw.headers["x-ratelimit-remaining"] = "42"
+
+        response = config.transform_response_api_response(
+            model="anthropic/claude-3.5-sonnet",
+            raw_response=raw,
+            logging_obj=MagicMock(),
+        )
+
+        additional_headers = response._hidden_params["additional_headers"]
+        assert additional_headers["llm_provider-x-litellm-response-cost"] == 0.5
+        assert additional_headers["llm_provider-x-ratelimit-remaining"] == "42"


### PR DESCRIPTION
## TLDR

Problem this solves:

- OpenRouter Responses API requests always log spend as $0
- Real token usage is recorded, only the cost is missing
- Chat completions through the same model are costed fine

How it solves it:

- Request `usage.include=true` so OpenRouter returns cost
- Read `usage.cost` from the response into hidden params
- Cost calculator already reads that hidden-params key

## User Flow

Before: a developer routing an OpenRouter model through /v1/responses gets $0 spend on every request

1. They send POST https://litellm-domain/v1/responses with an `openrouter/...` model and `"stream": false`
2. The response comes back with real token counts in `usage`
3. They open https://litellm-domain/ui/?page=logs and the request is logged at $0 spend

After: the same request is logged at real spend

1. They send POST https://litellm-domain/v1/responses with an `openrouter/...` model and `"stream": false`
2. The response comes back with real token counts in `usage`, and now a `cost` field too
3. https://litellm-domain/ui/?page=logs shows that request at non-zero spend

## Relevant issues

Fixes #38507

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

Shared setup

- config.yaml with one OpenRouter model:
  ```yaml
  model_list:
    - model_name: or-gpt-4o-mini
      litellm_params:
        model: openrouter/openai/gpt-4o-mini
        api_key: os.environ/OPENROUTER_API_KEY
  ```
- proxy started with `python litellm/proxy/proxy_cli.py --config config.yaml --detailed_debug`

### Before (cd63c7e5a7f925268f899c0992d4fc3e6bc79650)

1. `curl -sS http://localhost:4000/v1/responses -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" -d '{"model":"or-gpt-4o-mini","input":"say hi","stream":false}'`
   <!-- paste response: real usage.input_tokens / output_tokens, no usage.cost -->
2. Open http://localhost:4000/ui/?page=logs
   <!-- screenshot: the request row shows $0 spend -->

### After (71bb14f280e5878493a192b260b1b40a4dc09182)

1. Same curl as above
   <!-- paste response: usage now includes a cost field -->
2. Open http://localhost:4000/ui/?page=logs
   <!-- screenshot: the same request row now shows non-zero spend -->

## Type

🐛 Bug Fix

## Caveats (if any)

### Medium

- Streaming Responses API requests through OpenRouter are still not costed
- That path assembles usage per chunk; needs a separate follow-up

## QA runbook

Both added tests are unit tests in `tests/test_litellm/`, not e2e, so no QA runbook. Manual reproduction is in Screenshots / Proof of Fix above.

## Final Attestation

- [ ] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
