### PR TITLE
fix(ui): order the auto-routers table newest first so a new router lands on page one

### DIFF
--- a/ui/litellm-dashboard/src/app/(dashboard)/models-and-endpoints/components/AutoRouters/AutoRoutersPanel.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/models-and-endpoints/components/AutoRouters/AutoRoutersPanel.test.tsx
@@ -107,6 +107,33 @@ const mockDeploymentsPage = () => {
   modelInfoCall.mockResolvedValue(pageOf(DEPLOYMENTS));
 };
 
+// Oldest-first, as the proxy returns them, and two more than the ten-row first page holds.
+const BULK_ROUTER_NAMES = [
+  "router-01-oldest",
+  ...Array.from({ length: 10 }, (_, i) => `router-${i + 2}`),
+  "router-12-newest",
+];
+
+const A_FULL_PAGE_AND_TWO_MORE = Array.from({ length: 12 }, (_, index) => ({
+  model_name: BULK_ROUTER_NAMES[index],
+  litellm_params: {
+    model: "auto_router/complexity_router",
+    complexity_router_config: { tiers: {}, classifier_type: "heuristic" },
+  },
+  model_info: {
+    id: `bulk-${index + 1}`,
+    db_model: true,
+    created_at: `2026-08-${String(index + 1).padStart(2, "0")}T00:00:00.000000+00:00`,
+  },
+}));
+
+/** Row order as rendered, header row dropped. */
+const routerNamesInOrder = () =>
+  screen
+    .getAllByRole("row")
+    .slice(1)
+    .map((row) => row.querySelector("span.text-sm.font-medium")?.textContent ?? "");
+
 const renderPanel = (canModify = true) =>
   renderWithProviders(
     <AutoRoutersPanel
@@ -256,5 +283,33 @@ describe("AutoRoutersPanel", () => {
 
     await screen.findByText("config-router");
     expect(screen.queryByTestId("auto-router-actions-auto-4")).not.toBeInTheDocument();
+  });
+
+  // /v2/model/info returns an unordered model_list, and created_at is absent on config routers
+  // and on non-enterprise proxies, so both halves of the order have to be pinned here.
+  it("orders newest first, then the undated routers by name", async () => {
+    renderPanel();
+
+    await screen.findByText("tri-tier-router");
+
+    expect(routerNamesInOrder()).toEqual([
+      "tri-tier-router", // 2026-07-28
+      "support-router", // 2026-07-27
+      "adaptive-router", // undated, sorts after every dated row, then by name
+      "config-router",
+    ]);
+  });
+
+  // The reported bug: the newest router was rendered last, so it landed on page 2 and read
+  // as never created.
+  it("puts a just-created router on the first page of a list longer than one page", async () => {
+    modelInfoCall.mockResolvedValue(pageOf(A_FULL_PAGE_AND_TWO_MORE));
+
+    renderPanel();
+
+    expect(await screen.findByRole("button", { name: "router-12-newest" })).toBeInTheDocument();
+    // Page one holds the ten newest, so the two oldest are the ones pushed off it.
+    expect(screen.queryByRole("button", { name: "router-01-oldest" })).not.toBeInTheDocument();
+    expect(routerNamesInOrder()[0]).toBe("router-12-newest");
   });
 });

--- a/ui/litellm-dashboard/src/app/(dashboard)/models-and-endpoints/components/AutoRouters/AutoRoutersTable.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/models-and-endpoints/components/AutoRouters/AutoRoutersTable.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { SortingState } from "@tanstack/react-table";
-import { useMemo, useState } from "react";
+import { useMemo } from "react";
 
 import { DataTable } from "@/components/shared/DataTable";
 import { AutoRouterIcon } from "@/components/shared/table_cells";
@@ -18,6 +18,11 @@ interface AutoRoutersTableProps {
 }
 
 const PAGE_SIZE_OPTIONS = [10, 25, 50];
+
+const DEFAULT_SORTING: SortingState = [
+  { id: "createdAt", desc: true },
+  { id: "name", desc: false },
+];
 
 function EmptyState({ canModify }: { canModify: boolean }) {
   return (
@@ -42,8 +47,6 @@ export function AutoRoutersTable({
   onRouterClick,
   onDeleteClick,
 }: AutoRoutersTableProps) {
-  const [sorting, setSorting] = useState<SortingState>([]);
-
   const columns = useMemo(
     () => getAutoRoutersTableColumns({ canModify, onRouterClick, onDeleteClick }),
     [canModify, onRouterClick, onDeleteClick],
@@ -55,8 +58,7 @@ export function AutoRoutersTable({
       columns={columns}
       getRowId={(router) => router.id}
       sortingMode="client"
-      sorting={sorting}
-      onSortingChange={setSorting}
+      defaultSorting={DEFAULT_SORTING}
       paginationMode="client"
       pageSizeOptions={PAGE_SIZE_OPTIONS}
       isLoading={isLoading}

--- a/ui/litellm-dashboard/src/app/(dashboard)/models-and-endpoints/components/AutoRouters/AutoRoutersTableColumns.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/models-and-endpoints/components/AutoRouters/AutoRoutersTableColumns.tsx
@@ -155,6 +155,7 @@ export const getAutoRoutersTableColumns = ({
     size: 150,
     enableSorting: true,
     sortingFn: "datetime",
+    sortUndefined: "last",
     cell: ({ row }) => <DateCell value={row.original.createdAt} precision="date" />,
   },
   ...(canModify

--- a/ui/litellm-dashboard/src/app/(dashboard)/models-and-endpoints/components/AutoRouters/autoRouterRows.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/models-and-endpoints/components/AutoRouters/autoRouterRows.ts
@@ -30,7 +30,8 @@ export interface AutoRouterRow {
   editBlockedReason: EditBlockedReason | null;
   targets: string[];
   defaultModel: string | null;
-  createdAt: string | null;
+  /** `undefined`, not `null`: the table's `sortUndefined` pin only matches `undefined` */
+  createdAt: string | undefined;
   deployment: AutoRouterDeployment;
 }
 
@@ -113,7 +114,7 @@ export const toAutoRouterRow = (
     canEdit: canEdit && mayActOnRow,
     canDelete: canDelete && mayActOnRow,
     editBlockedReason,
-    createdAt: info.created_at ?? null,
+    createdAt: info.created_at ?? undefined,
     defaultModel: (params[strategy.defaultModelKey] as string | null | undefined) ?? null,
     deployment,
     ...PRESENTERS[strategy.kind](asRecord(params[strategy.configKey])),


### PR DESCRIPTION
## TLDR

Problem this solves:

- A newly added auto router did not appear in the list
- The table had no default order, so rows came back arbitrary
- The newest router fell past the ten-row first page

How it solves it:

- Sort newest first by default, name as the tiebreak
- Pin undated routers last, in both sort directions
- Works on open-source proxies, where created_at is withheld

## User Flow

Before: an admin who adds an auto router on a proxy that already has ten cannot find it anywhere on the page, and concludes the create failed

1. They open https://litellm-domain/ui/models-and-endpoints and pick the Auto-Routers tab, which lists ten routers
2. They click Add Auto Router, fill in the tiers and a default model, and submit
3. A success toast appears and the dialog closes
4. The list still shows the same ten routers, none of them the new one
5. They add it a second time, get a duplicate, and still see neither on the page

After: the same admin sees the new router as the top row the moment the dialog closes

1. They open https://litellm-domain/ui/models-and-endpoints and pick the Auto-Routers tab, which lists the ten most recently created routers, newest at the top
2. They click Add Auto Router, fill in the tiers and a default model, and submit
3. A success toast appears and the dialog closes
4. The new router is the first row in the table, with today's date in Created
5. Routers created before the newest ten are still reachable on page two, and the Created and Name headers still re-sort the list

## Relevant issues

- The Auto-Routers tab listed rows in whatever order `/v2/model/info` returned, which is unordered
- On a proxy with more than ten auto routers this hid the most recently created ones behind page two
- Routers defined in config.yaml, and every router on a non-enterprise proxy, have no creation date and had no defined position at all

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally
- [x] My PR passes all required CI/CD checks
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile Confidence Score of at least 4/5

## Screenshots / Proof of Fix

Live proxy on `localhost:4801` with real Postgres and an enterprise license, so `created_at` is populated exactly as it is on a customer proxy. Twelve auto routers were created one at a time through `POST /model/new`, oldest first. Both legs render the real `AutoRoutersTable` against that proxy's own `/v2/model/info` response and print the first page.

Shared setup:

```
curl -s -H "Authorization: Bearer $KEY" \
  "http://localhost:4801/v2/model/info?include_team_models=true&page=1&size=1000"
```

returns 12 auto routers in creation order, `seeded-router-01` through `seeded-router-12`, newest last.

### Before (02dcc4d347)

1. Render the table against that payload
2. First page is the ten OLDEST routers, and the two newest are absent:

```
["seeded-router-01","seeded-router-02","seeded-router-03","seeded-router-04","seeded-router-05",
 "seeded-router-06","seeded-router-07","seeded-router-08","seeded-router-09","seeded-router-10"]
```

### After (a9be7204bf)

1. Render the table against the same payload, same command
2. First page leads with the newest router, and the two oldest are the ones on page two:

```
["seeded-router-12","seeded-router-11","seeded-router-10","seeded-router-09","seeded-router-08",
 "seeded-router-07","seeded-router-06","seeded-router-05","seeded-router-04","seeded-router-03"]
```

The same bug is visible on the shared sandbox: `GET /v1/model/info` there returns 12 auto routers, and the two created that day sit at positions 11 and 12, off the first page.

## Type

🐛 Bug Fix

## Caveats (if any)

### Low

- Open-source proxies still show an empty Created column
- There, routers order by name, which is at least stable
- Page size stays at ten, deliberately

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dashboard-only client sort and row typing; no API or auth changes.
> 
> **Overview**
> Fixes the Auto-Routers tab showing **no new router** when the proxy already has more than ten entries: the list had **no default sort**, so API order left the newest rows on **page two**.
> 
> The table now opens with **client-side default sorting** — **Created** descending, then **Name** ascending — via `defaultSorting` instead of empty sorting state. Rows without a date use **`sortUndefined: "last"`**, and row mapping sets **`createdAt` to `undefined`** (not `null`) so undated config / OSS routers stay at the bottom and tie-break by name.
> 
> **Tests** lock in that order (newest dated first, undated by name) and that a 12-router list puts **`router-12-newest`** on the first page while the oldest falls off page one.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a9be7204bfe5a43a8e572db76ef3d6ec39d245a0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->