### PR TITLE
fix(gemini): send googleMaps retrievalConfig in the request body

### DIFF
--- a/litellm/llms/vertex_ai/gemini/transformation.py
+++ b/litellm/llms/vertex_ai/gemini/transformation.py
@@ -1191,6 +1191,7 @@ def _transform_request_body(
             )
         tools: Final[Tools | None] = optional_params.pop("tools", None)
         tool_choice: Final[ToolConfig | None] = optional_params.pop("tool_choice", None)
+        tool_config: Final[ToolConfig | None] = optional_params.pop("toolConfig", None)
         include_server_side_tool_invocations: bool = optional_params.pop("include_server_side_tool_invocations", False)
         safety_settings: list[SafetSettingsConfig] | None = optional_params.pop("safety_settings", None)
         # Drop output_config as it's not supported by Vertex AI
@@ -1223,8 +1224,15 @@ def _transform_request_body(
                 data["system_instruction"] = system_instructions
             if tools is not None:
                 data["tools"] = tools
-            if tool_choice is not None:
-                data["toolConfig"] = tool_choice
+            merged_tool_config: Final[ToolConfig | None] = (
+                {**tool_config, **tool_choice}
+                if tool_config is not None and tool_choice is not None
+                else tool_config
+                if tool_config is not None
+                else tool_choice
+            )
+            if merged_tool_config is not None:
+                data["toolConfig"] = merged_tool_config
             if include_server_side_tool_invocations:
                 if "toolConfig" not in data:
                     data["toolConfig"] = {}

--- a/litellm/types/llms/vertex_ai.py
+++ b/litellm/types/llms/vertex_ai.py
@@ -2,6 +2,7 @@ from enum import Enum
 from typing import Any, Final, Literal, Protocol
 
 from typing_extensions import (
+    ReadOnly,
     Required,
     TypedDict,
 )
@@ -278,9 +279,20 @@ class Tools(TypedDict, total=False):
     retrieval: Retrieval
 
 
+class LatLng(TypedDict):
+    latitude: ReadOnly[float]
+    longitude: ReadOnly[float]
+
+
+class RetrievalConfig(TypedDict, total=False):
+    latLng: ReadOnly[LatLng]
+    languageCode: ReadOnly[str]
+
+
 class ToolConfig(TypedDict, total=False):
     functionCallingConfig: FunctionCallingConfig
     includeServerSideToolInvocations: bool
+    retrievalConfig: ReadOnly[RetrievalConfig]
 
 
 class TTL(TypedDict, total=False):

--- a/tests/test_litellm/llms/vertex_ai/gemini/test_transformation.py
+++ b/tests/test_litellm/llms/vertex_ai/gemini/test_transformation.py
@@ -338,3 +338,56 @@ def test_map_function_enterprise_web_search_snake_case():
 
     assert len(result) == 1
     assert "enterpriseWebSearch" in result[0]
+
+
+def test__transform_request_body_google_maps_retrieval_config_is_sent():
+    """
+    googleMaps latitude/longitude are extracted into optional_params["toolConfig"]["retrievalConfig"]
+    by VertexGeminiConfig._map_function. That toolConfig must reach the request body, otherwise
+    Google grounds without a location.
+    """
+    optional_params = {}
+    tools = VertexGeminiConfig()._map_function(
+        value=[{"googleMaps": {"latitude": 37.7749, "longitude": -122.4194}}],
+        optional_params=optional_params,
+    )
+    optional_params["tools"] = tools
+
+    rb: RequestBody = transformation._transform_request_body(
+        messages=[{"role": "user", "content": "coffee near me"}],
+        model="gemini-3-flash-preview",
+        optional_params=optional_params,
+        custom_llm_provider="gemini",
+        litellm_params={},
+        cached_content=None,
+    )
+
+    assert rb["tools"] == [{"googleMaps": {}}]
+    assert rb["toolConfig"] == {"retrievalConfig": {"latLng": {"latitude": 37.7749, "longitude": -122.4194}}}
+
+
+def test__transform_request_body_tool_config_merges_with_tool_choice():
+    """
+    A googleMaps retrievalConfig and a function-calling tool_choice both live under toolConfig;
+    neither should clobber the other.
+    """
+    optional_params = {
+        "toolConfig": {"retrievalConfig": {"latLng": {"latitude": 1.0, "longitude": 2.0}}},
+        "tool_choice": {"functionCallingConfig": {"mode": "AUTO"}},
+        "include_server_side_tool_invocations": True,
+    }
+
+    rb: RequestBody = transformation._transform_request_body(
+        messages=[{"role": "user", "content": "hi"}],
+        model="gemini-3-flash-preview",
+        optional_params=optional_params,
+        custom_llm_provider="gemini",
+        litellm_params={},
+        cached_content=None,
+    )
+
+    assert rb["toolConfig"] == {
+        "retrievalConfig": {"latLng": {"latitude": 1.0, "longitude": 2.0}},
+        "functionCallingConfig": {"mode": "AUTO"},
+        "includeServerSideToolInvocations": True,
+    }


### PR DESCRIPTION
## TLDR

Problem this solves:

- `googleMaps` tool latitude/longitude never reach Google
- Maps grounding answers "near me" for the wrong city
- Location is extracted, then silently dropped before the request is sent

How it solves it:

- Carry the extracted `retrievalConfig` into the request body's `toolConfig`
- Merge it with any function-calling `tool_choice` instead of clobbering
- Type `retrievalConfig` on `ToolConfig`

## User Flow

Before: a developer grounding a Gemini request with Google Maps gets places from a random city, no matter what coordinates they send

1. They send POST https://litellm-domain/v1/chat/completions with `"tools": [{"googleMaps": {"latitude": 43.0731, "longitude": -89.4012}}]` (Madison, WI) and ask for coffee shops near me
2. The response comes back grounded, but the `groundingChunks` name shops in a different state
3. They send the same request with San Francisco coordinates and get the exact same shops back

After: the same requests come back grounded to the coordinates they sent

1. They send the same POST https://litellm-domain/v1/chat/completions with the Madison coordinates
2. The response's `groundingChunks` name Madison coffee shops
3. They send the same request with San Francisco coordinates and get San Francisco coffee shops

## Relevant issues

No existing issue. Root cause: `VertexGeminiConfig._map_function` extracts `latitude`/`longitude` from the `googleMaps` tool into `optional_params["toolConfig"]["retrievalConfig"]`, but `_transform_request_body` only ever built `toolConfig` from `tool_choice`, so that key was discarded. The existing unit test asserts on `optional_params` only, which is why it stayed green

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/llms/vertex_ai/gemini/test_transformation.py -v`
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

Real Google AI Studio calls against `gemini/gemini-3-flash-preview`. Same two requests on both sides; the only thing that changes between the cases is the coordinates

Shared setup

- config.yaml:
  ```yaml
  model_list:
    - model_name: gemini-3-flash
      litellm_params:
        model: gemini/gemini-3-flash-preview
        api_key: os.environ/GEMINI_API_KEY
  ```
- proxy started with `litellm --config config.yaml --port 4010`
- request body (`madison.json`; `sf.json` is identical with `37.7749, -122.4194`):
  ```json
  {"model":"gemini-3-flash",
   "messages":[{"role":"user","content":"Name 3 coffee shops near me. Return a JSON list of names."}],
   "tools":[{"googleMaps":{"latitude":43.0731,"longitude":-89.4012}}],
   "temperature":0.2,"max_tokens":400}
  ```
- output shown is `jq '{answer: .choices[0].message.content, grounded_places: [.vertex_ai_grounding_metadata[0].groundingChunks[].maps.title] | unique}'` with the "Review of …" duplicates dropped

### Before (252c71c0b)

#### Madison, WI (43.0731, -89.4012)

1. `curl -sS http://localhost:4010/v1/chat/completions -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" -d @madison.json`
2. Observed:
   ```
   answer: ["Mocha Moment", "Havana Coffee", "The Bodacious Brew (Bodacious Shops)"]
   grounded_places: ["Havana Coffee", "Mocha Moment", "The Bodacious Brew (Bodacious Shops)",
                     "The Coffee Depot", "The Little Castle Coffee Shop"]
   ```
   None of these are in Madison (rerun 2026-09-22 after rebasing onto current staging)

#### San Francisco, CA (37.7749, -122.4194)

1. `curl -sS http://localhost:4010/v1/chat/completions -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" -d @sf.json`
2. Observed:
   ```
   answer: ["Mocha Moment", "Havana Coffee", "The Bodacious Brew"]
   grounded_places: ["Havana Coffee", "Mocha Moment", "The Bodacious Brew (Bodacious Shops)",
                     "The Coffee Depot", "The Little Castle Coffee Shop"]
   ```
   Identical to the Madison run: the coordinates are not reaching Google. The request body LiteLLM sends has `"tools": [{"googleMaps": {}}]` and no `toolConfig`

### After (bb0133fbd)

#### Madison, WI (43.0731, -89.4012)

1. Same curl with `madison.json`
2. Observed:
   ```
   answer: ["Indie Coffee", "Valentia Coffee", "MOKA"]
   grounded_places: ["Indie Coffee", "Leopold's Books Bar Caffè", "MOKA", "The Shop by EBNS", "Valentia Coffee"]
   ```
   All Madison. The request body now carries `"toolConfig": {"retrievalConfig": {"latLng": {"latitude": 43.0731, "longitude": -89.4012}}}`

#### San Francisco, CA (37.7749, -122.4194)

1. Same curl with `sf.json`
2. Observed:
   ```
   answer: ["Doppio Coffee & Brunch", "Sextant Coffee Roasters", "Paris Cafe"]
   grounded_places: ["Doppio Coffee & Brunch", "Kopê House", "Paris Cafe", "Ritual Coffee Roasters", "Sextant Coffee Roasters"]
   ```
   All San Francisco

## Type

🐛 Bug Fix

## Caveats (if any)

### Low

- The nested `{"googleMaps": {"retrievalConfig": {...}}}` form named in `_extract_google_maps_retrieval_config`'s docstring is still not implemented; it is passed through unchanged and Google rejects it with 400. Pre-existing, out of scope here
- `languageCode` rides along in `retrievalConfig` the same way it always was extracted; not exercised in the proof above

## QA runbook

Both added tests are unit tests in `tests/test_litellm/`, not e2e, so no QA runbook. Manual reproduction is in Screenshots / Proof of Fix above

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

