### PR TITLE
fix(ui): open select popups below the trigger instead of over it

### DIFF
--- a/tests/e2e/ui/tests/modelsPage/autoRouterTemplateSelect.spec.ts
+++ b/tests/e2e/ui/tests/modelsPage/autoRouterTemplateSelect.spec.ts
@@ -1,0 +1,59 @@
+import { expect, test, type Page as PlaywrightPage } from "@playwright/test";
+import { ADMIN_STORAGE_PATH } from "../../constants";
+import { navigateToPage } from "../../helpers/navigation";
+import { Page } from "../../fixtures/pages";
+
+/**
+ * Opens Add Auto Router and returns the Template select's trigger, which is the
+ * shallowest real page that renders SelectContent with tall multi-line options.
+ */
+async function openTemplateSelect(page: PlaywrightPage) {
+  await navigateToPage(page, Page.Models);
+  await page.getByRole("tab", { name: "Auto-Routers" }).click();
+  await page.getByRole("button", { name: "Add Auto Router" }).click();
+
+  const trigger = page.getByTestId("template-selector");
+  await expect(trigger).toBeVisible();
+  return trigger;
+}
+
+test.describe("Auto Router template select anchoring", () => {
+  test.use({ storageState: ADMIN_STORAGE_PATH });
+
+  test("opens the options below the trigger rather than over it", async ({ page }) => {
+    await page.setViewportSize({ width: 1280, height: 900 });
+    const trigger = await openTemplateSelect(page);
+    const triggerBox = await trigger.boundingBox();
+
+    await trigger.click();
+    const popup = page.locator('[data-slot="select-content"]');
+    await expect(popup).toBeVisible();
+    const popupBox = await popup.boundingBox();
+
+    expect(triggerBox).not.toBeNull();
+    expect(popupBox).not.toBeNull();
+
+    // Item-aligned mode reports "none" and puts the active item over the trigger.
+    await expect(popup).toHaveAttribute("data-side", "bottom");
+    expect(popupBox!.y).toBeGreaterThanOrEqual(triggerBox!.y + triggerBox!.height);
+  });
+
+  test("flips above the trigger instead of covering it when there is no room below", async ({ page }) => {
+    await page.setViewportSize({ width: 1280, height: 560 });
+    const trigger = await openTemplateSelect(page);
+    await trigger.scrollIntoViewIfNeeded();
+    const triggerBox = await trigger.boundingBox();
+
+    await trigger.click();
+    const popup = page.locator('[data-slot="select-content"]');
+    await expect(popup).toBeVisible();
+    const popupBox = await popup.boundingBox();
+
+    expect(triggerBox).not.toBeNull();
+    expect(popupBox).not.toBeNull();
+
+    const overlaps =
+      popupBox!.y < triggerBox!.y + triggerBox!.height && popupBox!.y + popupBox!.height > triggerBox!.y;
+    expect(overlaps).toBe(false);
+  });
+});

--- a/ui/litellm-dashboard/src/app/(dashboard)/guardrails/_components/TeamGuardrailsTab.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/guardrails/_components/TeamGuardrailsTab.tsx
@@ -1106,7 +1106,7 @@ export function TeamGuardrailsTab({ accessToken }: TeamGuardrailsTabProps) {
                       >
                         <SelectValue />
                       </SelectTrigger>
-                      <SelectContent alignItemWithTrigger={false}>
+                      <SelectContent>
                         {GUARDRAIL_MODES.map((mode) => (
                           <SelectItem key={mode.value} value={mode.value} title={mode.label}>
                             {mode.label}

--- a/ui/litellm-dashboard/src/app/(dashboard)/guardrails/_components/content_filter/CategoryTable.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/guardrails/_components/content_filter/CategoryTable.tsx
@@ -64,7 +64,7 @@ const CategoryTable: React.FC<CategoryTableProps> = ({
             <SelectTrigger size="sm" className="w-[150px]" aria-label="Severity Threshold">
               <SelectValue />
             </SelectTrigger>
-            <SelectContent alignItemWithTrigger={false}>
+            <SelectContent>
               {SEVERITY_ITEMS.map((item) => (
                 <SelectItem key={item.value} value={item.value}>
                   {item.label}
@@ -93,7 +93,7 @@ const CategoryTable: React.FC<CategoryTableProps> = ({
             <SelectTrigger size="sm" className="w-[120px]" aria-label="Action">
               <SelectValue />
             </SelectTrigger>
-            <SelectContent alignItemWithTrigger={false}>
+            <SelectContent>
               {ACTION_ITEMS.map((item) => (
                 <SelectItem key={item.value} value={item.value}>
                   {item.label}

--- a/ui/litellm-dashboard/src/app/(dashboard)/guardrails/_components/content_filter/CompetitorIntentConfiguration.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/guardrails/_components/content_filter/CompetitorIntentConfiguration.tsx
@@ -194,7 +194,7 @@ const CompetitorIntentConfiguration: React.FC<CompetitorIntentConfigurationProps
               <SelectTrigger id={`${fieldId}-type`} className="w-full">
                 <SelectValue />
               </SelectTrigger>
-              <SelectContent alignItemWithTrigger={false}>
+              <SelectContent>
                 {INTENT_TYPES.map((type) => (
                   <SelectItem key={type.value} value={type.value} title={type.label}>
                     {type.label}
@@ -268,7 +268,7 @@ const CompetitorIntentConfiguration: React.FC<CompetitorIntentConfigurationProps
               <SelectTrigger id={`${fieldId}-competitor-comparison`} className="w-full">
                 <SelectValue />
               </SelectTrigger>
-              <SelectContent alignItemWithTrigger={false}>
+              <SelectContent>
                 {COMPETITOR_COMPARISON_POLICIES.map((policy) => (
                   <SelectItem key={policy.value} value={policy.value} title={policy.label}>
                     {policy.label}
@@ -292,7 +292,7 @@ const CompetitorIntentConfiguration: React.FC<CompetitorIntentConfigurationProps
               <SelectTrigger id={`${fieldId}-possible-competitor-comparison`} className="w-full">
                 <SelectValue />
               </SelectTrigger>
-              <SelectContent alignItemWithTrigger={false}>
+              <SelectContent>
                 {POSSIBLE_COMPETITOR_COMPARISON_POLICIES.map((policy) => (
                   <SelectItem key={policy.value} value={policy.value} title={policy.label}>
                     {policy.label}

--- a/ui/litellm-dashboard/src/app/(dashboard)/guardrails/_components/content_filter/ContentCategoryConfiguration.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/guardrails/_components/content_filter/ContentCategoryConfiguration.tsx
@@ -199,7 +199,7 @@ const ContentCategoryConfiguration: React.FC<ContentCategoryConfigurationProps> 
           <SelectTrigger size="sm" className="w-full" aria-label="Action">
             <SelectValue />
           </SelectTrigger>
-          <SelectContent alignItemWithTrigger={false}>
+          <SelectContent>
             {ACTION_ITEMS.map((item) => (
               <SelectItem key={item.value} value={item.value}>
                 <Badge variant={item.value === "BLOCK" ? "destructive" : "secondary"}>{item.value}</Badge>
@@ -224,7 +224,7 @@ const ContentCategoryConfiguration: React.FC<ContentCategoryConfigurationProps> 
           <SelectTrigger size="sm" className="w-full" aria-label="Severity Threshold">
             <SelectValue />
           </SelectTrigger>
-          <SelectContent alignItemWithTrigger={false}>
+          <SelectContent>
             {SEVERITY_ITEMS.map((item) => (
               <SelectItem key={item.value} value={item.value}>
                 {item.label}

--- a/ui/litellm-dashboard/src/app/(dashboard)/guardrails/_components/content_filter/CustomPatternModal.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/guardrails/_components/content_filter/CustomPatternModal.tsx
@@ -70,7 +70,7 @@ const CustomPatternModal: React.FC<CustomPatternModalProps> = ({
               <SelectTrigger className="w-full" aria-label="Action">
                 <SelectValue />
               </SelectTrigger>
-              <SelectContent alignItemWithTrigger={false}>
+              <SelectContent>
                 {ACTION_ITEMS.map((item) => (
                   <SelectItem key={item.value} value={item.value}>
                     {item.label}

--- a/ui/litellm-dashboard/src/app/(dashboard)/guardrails/_components/content_filter/KeywordModal.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/guardrails/_components/content_filter/KeywordModal.tsx
@@ -60,7 +60,7 @@ const KeywordModal: React.FC<KeywordModalProps> = ({
               <SelectTrigger className="w-full" aria-label="Action">
                 <SelectValue />
               </SelectTrigger>
-              <SelectContent alignItemWithTrigger={false}>
+              <SelectContent>
                 {ACTION_ITEMS.map((item) => (
                   <SelectItem key={item.value} value={item.value}>
                     {item.label}

--- a/ui/litellm-dashboard/src/app/(dashboard)/guardrails/_components/content_filter/KeywordTable.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/guardrails/_components/content_filter/KeywordTable.tsx
@@ -38,7 +38,7 @@ const KeywordTable: React.FC<KeywordTableProps> = ({ keywords, onActionChange, o
           <SelectTrigger size="sm" className="w-[120px]" aria-label="Action">
             <SelectValue />
           </SelectTrigger>
-          <SelectContent alignItemWithTrigger={false}>
+          <SelectContent>
             {ACTION_ITEMS.map((item) => (
               <SelectItem key={item.value} value={item.value}>
                 {item.label}

--- a/ui/litellm-dashboard/src/app/(dashboard)/guardrails/_components/content_filter/PatternModal.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/guardrails/_components/content_filter/PatternModal.tsx
@@ -114,7 +114,7 @@ const PatternModal: React.FC<PatternModalProps> = ({
               <SelectTrigger className="w-full" aria-label="Action">
                 <SelectValue />
               </SelectTrigger>
-              <SelectContent alignItemWithTrigger={false}>
+              <SelectContent>
                 {ACTION_ITEMS.map((item) => (
                   <SelectItem key={item.value} value={item.value}>
                     {item.label}

--- a/ui/litellm-dashboard/src/app/(dashboard)/guardrails/_components/content_filter/PatternTable.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/guardrails/_components/content_filter/PatternTable.tsx
@@ -58,7 +58,7 @@ const PatternTable: React.FC<PatternTableProps> = ({ patterns, onActionChange, o
           <SelectTrigger size="sm" className="w-[120px]" aria-label="Action">
             <SelectValue />
           </SelectTrigger>
-          <SelectContent alignItemWithTrigger={false}>
+          <SelectContent>
             {ACTION_ITEMS.map((item) => (
               <SelectItem key={item.value} value={item.value}>
                 {item.label}

--- a/ui/litellm-dashboard/src/app/(dashboard)/guardrails/_components/custom_code/CustomCodeModal.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/guardrails/_components/custom_code/CustomCodeModal.tsx
@@ -556,7 +556,7 @@ const CustomCodeModal: React.FC<CustomCodeModalProps> = ({ visible, onClose, onS
               <SelectTrigger className="w-full" aria-label="Template">
                 <SelectValue />
               </SelectTrigger>
-              <SelectContent alignItemWithTrigger={false}>
+              <SelectContent>
                 <SelectGroup>
                   <SelectLabel>STANDARD</SelectLabel>
                   {TEMPLATE_ITEMS.map((template) => (

--- a/ui/litellm-dashboard/src/app/(dashboard)/guardrails/_components/pii_components.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/guardrails/_components/pii_components.tsx
@@ -179,7 +179,7 @@ export const PiiEntityList: React.FC<PiiEntityListProps> = ({
                     <SelectTrigger className={`w-[120px] ${isSelected ? "" : "opacity-50"}`} aria-label="Action">
                       <SelectValue />
                     </SelectTrigger>
-                    <SelectContent alignItemWithTrigger={false}>
+                    <SelectContent>
                       {actions.map((action) => (
                         <SelectItem key={action} value={action}>
                           <span className="flex items-center">

--- a/ui/litellm-dashboard/src/app/(dashboard)/guardrails/_components/tool_permission/ToolPermissionRulesEditor.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/guardrails/_components/tool_permission/ToolPermissionRulesEditor.tsx
@@ -280,7 +280,7 @@ const ToolPermissionRulesEditor: React.FC<ToolPermissionRulesEditorProps> = ({ v
                       <SelectTrigger className="w-[200px]" aria-label="Decision">
                         <SelectValue />
                       </SelectTrigger>
-                      <SelectContent alignItemWithTrigger={false}>
+                      <SelectContent>
                         {DECISION_ITEMS.map((item) => (
                           <SelectItem key={item.value} value={item.value}>
                             {item.label}
@@ -313,7 +313,7 @@ const ToolPermissionRulesEditor: React.FC<ToolPermissionRulesEditorProps> = ({ v
               <SelectTrigger className="w-full" aria-label="Default action">
                 <SelectValue />
               </SelectTrigger>
-              <SelectContent alignItemWithTrigger={false}>
+              <SelectContent>
                 {DECISION_ITEMS.map((item) => (
                   <SelectItem key={item.value} value={item.value}>
                     {item.label}
@@ -350,7 +350,7 @@ const ToolPermissionRulesEditor: React.FC<ToolPermissionRulesEditorProps> = ({ v
               <SelectTrigger className="w-full" aria-label="On disallowed action">
                 <SelectValue />
               </SelectTrigger>
-              <SelectContent alignItemWithTrigger={false}>
+              <SelectContent>
                 {ON_DISALLOWED_ITEMS.map((item) => (
                   <SelectItem key={item.value} value={item.value}>
                     {item.label}

--- a/ui/litellm-dashboard/src/app/(dashboard)/vector-stores/_components/CreateVectorStore.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/vector-stores/_components/CreateVectorStore.tsx
@@ -342,7 +342,7 @@ const CreateVectorStore: React.FC<CreateVectorStoreProps> = ({ accessToken, onSu
                   <SelectTrigger id="vector-store-provider" className="w-full">
                     <SelectValue placeholder="Select a provider" />
                   </SelectTrigger>
-                  <SelectContent alignItemWithTrigger={false}>
+                  <SelectContent>
                     {providerItems.map((item) => (
                       <SelectItem key={item.value} value={item.value}>
                         <Logo src={vectorStoreProviderLogoMap[item.label]} label={item.label} className="w-5 h-5" />

--- a/ui/litellm-dashboard/src/app/(dashboard)/vector-stores/_components/VectorStoreForm.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/vector-stores/_components/VectorStoreForm.tsx
@@ -298,7 +298,7 @@ const VectorStoreForm: React.FC<VectorStoreFormProps> = ({
                         }}
                       </SelectValue>
                     </SelectTrigger>
-                    <SelectContent alignItemWithTrigger={false}>
+                    <SelectContent>
                       {Object.entries(VectorStoreProviders).map(([providerEnum, providerDisplayName]) => (
                         <SelectItem key={providerEnum} value={vectorStoreProviderMap[providerEnum]}>
                           <Logo

--- a/ui/litellm-dashboard/src/app/(dashboard)/vector-stores/_components/vector_store_info.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/vector-stores/_components/vector_store_info.tsx
@@ -280,7 +280,7 @@ const VectorStoreInfoView: React.FC<VectorStoreInfoViewProps> = ({
                                   }}
                                 </SelectValue>
                               </SelectTrigger>
-                              <SelectContent alignItemWithTrigger={false}>
+                              <SelectContent>
                                 {Object.entries(Providers)
                                   .filter(([providerEnum]) => providerEnum === "Bedrock")
                                   .map(([providerEnum, providerDisplayName]) => (

--- a/ui/litellm-dashboard/src/components/ui/select.test.tsx
+++ b/ui/litellm-dashboard/src/components/ui/select.test.tsx
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 
 const ENVIRONMENTS = [
@@ -61,5 +62,42 @@ describe("SelectValue label resolution", () => {
     });
 
     expect(screen.getByTestId("trigger")).toHaveTextContent("Any environment");
+  });
+});
+
+function renderOpenableSelect(contentProps?: React.ComponentProps<typeof SelectContent>) {
+  return render(
+    <Select value={null} items={ENVIRONMENTS}>
+      <SelectTrigger data-testid="trigger">
+        <SelectValue placeholder="Pick an environment" />
+      </SelectTrigger>
+      <SelectContent data-testid="content" {...contentProps}>
+        {ENVIRONMENTS.map((environment) => (
+          <SelectItem key={environment.value} value={environment.value}>
+            {environment.label}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>,
+  );
+}
+
+describe("SelectContent anchoring", () => {
+  it("anchors to the edge of the trigger rather than over it by default", async () => {
+    const user = userEvent.setup();
+    renderOpenableSelect();
+
+    await user.click(screen.getByTestId("trigger"));
+
+    expect(await screen.findByTestId("content")).toHaveAttribute("data-align-trigger", "false");
+  });
+
+  it("still lets a caller opt into item-aligned anchoring", async () => {
+    const user = userEvent.setup();
+    renderOpenableSelect({ alignItemWithTrigger: true });
+
+    await user.click(screen.getByTestId("trigger"));
+
+    expect(await screen.findByTestId("content")).toHaveAttribute("data-align-trigger", "true");
   });
 });

--- a/ui/litellm-dashboard/src/components/ui/select.tsx
+++ b/ui/litellm-dashboard/src/components/ui/select.tsx
@@ -49,7 +49,7 @@ function SelectContent({
   sideOffset = 4,
   align = "center",
   alignOffset = 0,
-  alignItemWithTrigger = true,
+  alignItemWithTrigger = false,
   ...props
 }: SelectPrimitive.Popup.Props &
   Pick<SelectPrimitive.Positioner.Props, "align" | "alignOffset" | "side" | "sideOffset" | "alignItemWithTrigger">) {


### PR DESCRIPTION
## TLDR

Problem this solves:

- Select dropdowns open on top of their own trigger
- Autorouter Template picker covers its label and box
- 21 call sites already hand-patched around the default

How it solves it:

- Flip `alignItemWithTrigger` default to false in the shared wrapper
- `side` and `sideOffset` become live, so collision handling works
- Delete the 21 now-redundant hand-written opt-outs

## User Flow

Before: an admin adding an auto router cannot read the Template field, because the options list covers it

1. They open https://litellm-domain/ui/?page=models, go to the Auto Routers tab and click Add Auto Router
2. They fill in Auto Router Name, then click the Template select
3. The options list opens upward over the select, hiding both the box they just clicked and the "Template" label above it
4. To see which template is selected they have to close the list again

After: the same click opens the list below the field, leaving the label and the box visible

1. They open https://litellm-domain/ui/?page=models, go to the Auto Routers tab and click Add Auto Router
2. They fill in Auto Router Name, then click the Template select
3. The options list opens directly beneath the select, with the "Template" label and the box still on screen
4. If the field sits too low for the list to fit, the list opens above the field instead of covering it

## Relevant issues

- The Template picker on Add Auto Router renders its option list over the trigger, hiding the field and its label
- Every select in the dashboard that does not explicitly opt out has the same behavior, which is 127 of 148 call sites
- 21 call sites across 15 files already worked around it by hand, so the shared default was serving nobody

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Tests

`select.test.tsx` pins the wrapper's contract in jsdom: the popup edge-anchors by default, and a caller can still opt back into item-aligned mode. jsdom neither lays out nor paints, so that file can only assert which mode rendered, never where the popup landed

`tests/e2e/ui/tests/modelsPage/autoRouterTemplateSelect.spec.ts` covers the geometry in real Chromium, driving the Add Auto Router modal the same way a user does. At 1280x900 it asserts `data-side` is `bottom` and the popup's top edge is at or below the trigger's bottom edge. At 1280x560, where the list cannot fit underneath, it asserts the popup and the trigger do not overlap at all, which is what proves collision handling is live rather than merely configured

Both browser assertions were mutation-checked against the unfixed wrapper: with the default back at true the first reports `data-side: none` with the popup starting 52px above the trigger's bottom edge, and the second has the popup spanning 269 to 545 straight through a trigger at 285 to 321. Both fail. With the fix both pass

## Screenshots / Proof of Fix
<img width="1512" height="982" alt="image" src="https://github.com/user-attachments/assets/9ea18540-0a12-455c-949b-302ca7722677" />

To reproduce by hand, run the dashboard against a live proxy, open http://localhost:4000/ui/?page=models, pick the Auto Routers tab, click Add Auto Router, then click the Template select and watch where the option list lands

Measured in a real Chromium at 1280x900 against the same page markup, reading the trigger's and the popup's bounding boxes. `data-side` is what Base UI reports it actually did

### Before (ca9007be39)

#### Template picker, four tall option cards

1. Trigger occupies y 314 to 350, popup occupies y 298 to 550
2. Popup starts 52px above the trigger's bottom edge and 16px above its top, so it covers the whole field
3. `data-side` is `none`, meaning the `side="bottom"` and `sideOffset={4}` the wrapper passes were both ignored

#### Full sweep, all seven cases fail

| case | viewport | data-side | trigger | popup | covers trigger |
|---|---|---|---|---|---|
| baseline, 4 tall items | 1280x900 | none | 314-350 | 298-550 | yes |
| long list, 24 items | 1280x900 | none | 314-350 | 298-839 | yes |
| late item preselected | 1280x900 | none | 314-350 | 10-380 | yes |
| narrow viewport | 640x900 | none | 314-350 | 298-550 | yes |
| short viewport | 1280x520 | none | 314-350 | 298-510 | yes |

### After (9f2af10ee8)

#### Template picker, four tall option cards

1. Trigger occupies y 314 to 350, popup occupies y 354 to 606
2. Popup starts exactly 4px below the trigger's bottom edge, which is the `sideOffset={4}` the wrapper always passed
3. `data-side` is `bottom`

#### Full sweep, all seven cases pass

| case | viewport | data-side | trigger | popup | covers trigger |
|---|---|---|---|---|---|
| baseline, 4 tall items | 1280x900 | bottom | 314-350 | 354-606 | no |
| long list, 24 items | 1280x900 | bottom | 314-350 | 354-895 | no |
| late item preselected | 1280x900 | bottom | 314-350 | 354-895 | no |
| narrow viewport | 640x900 | bottom | 314-350 | 354-606 | no |
| short viewport | 1280x520 | top | 314-350 | 58-310 | no |

The short viewport case is the one worth reading twice. With no room below, the popup now flips above the trigger and stops at y 310, four pixels clear of the field, instead of sitting on top of it

## Type

🐛 Bug Fix

## Caveats (if any)

### Medium

- Changes where every inheriting select opens, which is 127 call sites
- Behavior is unchanged for the 21 sites that already opted out

### Low

- `alignItemWithTrigger` stays on the wrapper as an escape hatch
- No call site currently passes true

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches default positioning for most dashboard selects (~127 call sites); behavior should improve globally but any screen that relied on item-aligned popups without opting in would change.
> 
> **Overview**
> Fixes dashboard **Select** dropdowns opening on top of their trigger (e.g. the Auto Router **Template** field hiding its label) by changing the shared `SelectContent` default **`alignItemWithTrigger`** from `true` to **`false`**, so lists edge-anchor to the trigger and normal **`side` / collision** behavior applies.
> 
> Removes the now-redundant **`alignItemWithTrigger={false}`** overrides across guardrails, vector store, and related screens.
> 
> Adds **`select.test.tsx`** coverage for the default vs opt-in anchoring contract and a new Playwright spec **`autoRouterTemplateSelect.spec.ts`** that asserts popup placement below the trigger and non-overlap when space is tight.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1a22f2ca49488f421da0370b42baa889bdea07ec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->