### PR TITLE
fix(proxy): expand wildcards for providers discovered from their endpoint

### DIFF
--- a/litellm/proxy/auth/model_checks.py
+++ b/litellm/proxy/auth/model_checks.py
@@ -13,7 +13,7 @@ from litellm.router import Router
 from litellm.router_utils.fallback_event_handlers import get_fallback_model_group
 from litellm.types.router import CredentialLiteLLMParams, LiteLLM_Params
 from litellm.types.utils import LlmProviders
-from litellm.utils import get_valid_models
+from litellm.utils import ProviderConfigManager, get_valid_models
 
 _CREDENTIAL_LITELLM_PARAM_FIELDS = set(CredentialLiteLLMParams.model_fields)
 
@@ -35,6 +35,26 @@ def _check_wildcard_routing(model: str) -> bool:
     return False
 
 
+def _can_discover_models_from_provider_endpoint(provider: str) -> bool:
+    """
+    True if `provider` can list its models by querying its own endpoint.
+
+    Dynamic-list providers such as `litellm_proxy` and `hosted_vllm` have no static
+    catalog, so gating discovery on `litellm.models_by_provider` alone skips exactly the
+    providers that need it. Mirrors the condition `get_valid_models` applies before
+    fetching, so the gate only opens where discovery would actually happen
+    """
+    if not litellm.check_provider_endpoint:
+        return False
+
+    try:
+        provider_enum: Final = LlmProviders(provider)
+    except ValueError:
+        return False
+
+    return ProviderConfigManager.get_provider_model_info(model=None, provider=provider_enum) is not None
+
+
 def get_provider_models(provider: str, litellm_params: LiteLLM_Params | None = None) -> list[str] | None:
     """
     Returns the list of known models by provider
@@ -42,7 +62,7 @@ def get_provider_models(provider: str, litellm_params: LiteLLM_Params | None = N
     if provider == "*":
         return get_valid_models(litellm_params=litellm_params)
 
-    if provider in litellm.models_by_provider:
+    if provider in litellm.models_by_provider or _can_discover_models_from_provider_endpoint(provider):
         provider_models: Final = get_valid_models(custom_llm_provider=provider, litellm_params=litellm_params)
         return provider_models
     return None

--- a/tests/test_litellm/proxy/auth/test_model_checks.py
+++ b/tests/test_litellm/proxy/auth/test_model_checks.py
@@ -1,9 +1,12 @@
-from unittest.mock import AsyncMock, patch
+from typing import Final
+from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 
+import litellm
 from litellm.proxy._types import LiteLLM_TeamTable, LiteLLM_UserTable, Member
 from litellm.proxy.auth.handle_jwt import JWTAuthManager
+from litellm.types.router import LiteLLM_Params
 
 
 def test_get_team_models_for_all_models_and_team_only_models():
@@ -803,3 +806,75 @@ def test_get_complete_model_list_sentinel_only_grants_nothing():
         infer_model_from_keys=False,
     )
     assert result == []
+
+class TestProviderEndpointModelDiscovery:
+    """`get_provider_models` gated provider-endpoint discovery on membership in the
+    static `litellm.models_by_provider` catalog. Dynamic-list providers like
+    `litellm_proxy` and `hosted_vllm` are absent from that dict, so discovery was
+    skipped for exactly the providers needing it: a chained proxy's GET /v1/models
+    returned the literal `litellm_proxy/*` and never queried the upstream (#38547)"""
+
+    @staticmethod
+    def _upstream_params() -> LiteLLM_Params:
+        return LiteLLM_Params(
+            model="litellm_proxy/*",
+            api_base="http://127.0.0.1:4010",
+            api_key="sk-upstream-1234",
+        )
+
+    def test_dynamic_provider_delegates_to_discovery_when_enabled(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from litellm.proxy.auth import model_checks
+
+        monkeypatch.setattr(litellm, "check_provider_endpoint", True)
+        discover: Final = Mock(return_value=["gpt-4o", "claude-sonnet"])
+        monkeypatch.setattr(model_checks, "get_valid_models", discover)
+
+        params: Final = self._upstream_params()
+        result: Final = model_checks.get_provider_models("litellm_proxy", params)
+
+        assert result == ["gpt-4o", "claude-sonnet"]
+        discover.assert_called_once_with(custom_llm_provider="litellm_proxy", litellm_params=params)
+
+    def test_dynamic_provider_returns_none_when_discovery_disabled(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Discovery stays opt-in, so nothing should be fetched with the flag off"""
+        from litellm.proxy.auth import model_checks
+
+        monkeypatch.setattr(litellm, "check_provider_endpoint", False)
+        discover: Final = Mock(return_value=["unused"])
+        monkeypatch.setattr(model_checks, "get_valid_models", discover)
+
+        assert model_checks.get_provider_models("litellm_proxy", self._upstream_params()) is None
+        discover.assert_not_called()
+
+    def test_unknown_provider_returns_none(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """An unrecognised provider must not raise out of the gate's enum conversion"""
+        from litellm.proxy.auth.model_checks import get_provider_models
+
+        monkeypatch.setattr(litellm, "check_provider_endpoint", True)
+
+        assert get_provider_models("not_a_real_provider") is None
+
+    @pytest.mark.parametrize("provider", ["litellm_proxy", "hosted_vllm"])
+    def test_gate_admits_dynamic_providers_when_enabled(self, monkeypatch: pytest.MonkeyPatch, provider: str) -> None:
+        """The gate is not specific to litellm_proxy: it covers every provider whose
+        model list comes from its endpoint rather than a static catalog"""
+        from litellm.proxy.auth.model_checks import _can_discover_models_from_provider_endpoint
+
+        assert provider not in litellm.models_by_provider
+
+        monkeypatch.setattr(litellm, "check_provider_endpoint", True)
+        assert _can_discover_models_from_provider_endpoint(provider) is True
+
+        monkeypatch.setattr(litellm, "check_provider_endpoint", False)
+        assert _can_discover_models_from_provider_endpoint(provider) is False
+
+    def test_static_catalog_provider_unaffected(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Providers with a static catalog keep listing from it with discovery off"""
+        from litellm.proxy.auth.model_checks import get_provider_models
+
+        monkeypatch.setattr(litellm, "check_provider_endpoint", False)
+
+        result: Final = get_provider_models("anthropic")
+
+        assert result is not None
+        assert any("claude" in model for model in result)


### PR DESCRIPTION
## TLDR

Problem this solves:

- Chained proxy lists `litellm_proxy/*` instead of the upstream's models
- Providers without a static catalog were skipped by discovery
- No upstream request was made and nothing was logged

How it solves it:

- Admit providers that register a model-info config
- Only when `check_provider_endpoint` is already enabled
- Same pair of conditions `get_valid_models` applies before fetching

## User Flow

Before: a developer whose app lists models from a chained LiteLLM gateway sees a wildcard string instead of model names, so their model picker is broken

1. They send GET http://litellm-downstream:4000/v1/models with their gateway key
2. The response's `data` array holds one entry whose id is the literal string `litellm_proxy/*`, no matter how many models the upstream serves
3. Their model picker, populated from that endpoint, offers only `litellm_proxy/*`, and choosing it fails, so they have to learn real model names out of band
4. If they already know a name, POST http://litellm-downstream:4000/v1/chat/completions with `"model": "litellm_proxy/gpt-4o"` works and reaches the upstream

After: the same gateway lists every model the upstream serves, so the picker works

1. They send GET http://litellm-downstream:4000/v1/models with their gateway key
2. The response's `data` array holds one entry per upstream model, `litellm_proxy/gpt-4o` and `litellm_proxy/claude-sonnet`
3. Their model picker offers those names and they choose one
4. POST http://litellm-downstream:4000/v1/chat/completions with the chosen name works exactly as before

## Relevant issues

Fixes #38547

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Two proxies, one in front of the other. The discovery path never reaches an LLM provider, it queries the upstream proxy's own `/v1/models`, so the upstream's provider keys are deliberately fake and no provider spend is involved. Routing through the same chain does reach the provider and is unchanged by this PR

`upstream.yaml`, served on port 4010:

```yaml
model_list:
  - model_name: gpt-4o
    litellm_params:
      model: openai/gpt-4o
      api_key: sk-fake-upstream-provider-key
  - model_name: claude-sonnet
    litellm_params:
      model: anthropic/claude-sonnet-4-5
      api_key: sk-fake-upstream-provider-key

general_settings:
  master_key: sk-upstream-1234
```

`downstream.yaml`, served on port 4020:

```yaml
model_list:
  - model_name: "litellm_proxy/*"
    litellm_params:
      model: "litellm_proxy/*"
      api_base: http://127.0.0.1:4010
      api_key: sk-upstream-1234

litellm_settings:
  check_provider_endpoint: true

general_settings:
  master_key: sk-downstream-1234
```

Both runs start the pair the same way:

```
uv run litellm --config upstream.yaml   --port 4010
uv run litellm --config downstream.yaml --port 4020
```

### Before (2d0c9eed)

1. The upstream lists its own models fine:

```
$ curl -s http://127.0.0.1:4010/v1/models -H "Authorization: Bearer sk-upstream-1234"
{"data":[{"id":"gpt-4o","object":"model","created":1677610602,"owned_by":"openai","mode":"chat","max_input_tokens":128000,"max_output_tokens":16384},{"id":"claude-sonnet","object":"model","created":1677610602,"owned_by":"openai"}],"object":"list"}
```

2. The downstream returns only the literal wildcard, and the upstream's access log shows no incoming request:

```
$ curl -s http://127.0.0.1:4020/v1/models -H "Authorization: Bearer sk-downstream-1234"
{"data":[{"id":"litellm_proxy/*","object":"model","created":1677610602,"owned_by":"openai"}],"object":"list"}
```

### After (9e0d8913)

1. The upstream is unchanged:

```
$ curl -s http://127.0.0.1:4010/v1/models -H "Authorization: Bearer sk-upstream-1234"
{"data":[{"id":"gpt-4o","object":"model","created":1677610602,"owned_by":"openai","mode":"chat","max_input_tokens":128000,"max_output_tokens":16384},{"id":"claude-sonnet","object":"model","created":1677610602,"owned_by":"openai"}],"object":"list"}
```

2. The downstream now expands the wildcard into the upstream's models:

```
$ curl -s http://127.0.0.1:4020/v1/models -H "Authorization: Bearer sk-downstream-1234"
{"data":[{"id":"litellm_proxy/*","object":"model","created":1677610602,"owned_by":"openai"},{"id":"litellm_proxy/gpt-4o","object":"model","created":1677610602,"owned_by":"openai","mode":"chat","max_input_tokens":128000,"max_output_tokens":16384},{"id":"litellm_proxy/claude-sonnet","object":"model","created":1677610602,"owned_by":"openai"}],"object":"list"}
```

## Type

🐛 Bug Fix

## Caveats (if any)

### Low

- Literal `litellm_proxy/*` entry still listed, tracked in #29165
- `hosted_vllm` gains the same discovery, covered by a test
- Sibling gate for `custom_openai` still open, see #31856

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
