### PR TITLE
fix(realtime): bill trailing audio when a Gemini transcribe Live session closes

### DIFF
--- a/litellm/litellm_core_utils/realtime_streaming.py
+++ b/litellm/litellm_core_utils/realtime_streaming.py
@@ -330,6 +330,24 @@ class RealTimeStreaming:
         except (AttributeError, TypeError):
             pass
 
+    def _flush_unbilled_transcription_usage(self) -> None:
+        if self.provider_config is None:
+            return
+        usage: Final = self.provider_config.unbilled_usage_on_session_close(self.model)
+        if usage is None:
+            return
+        flush_event: Final = (
+            cast(  # cast-ok: usage-only partial event, the same shape _capture_transcription_usage logs
+                OpenAIRealtimeEvents,
+                {
+                    "type": "conversation.item.input_audio_transcription.completed",
+                    "usage": usage,
+                },
+            )
+        )
+        self.store_message(flush_event)
+        self._capture_transcription_usage(flush_event)
+
     def _collect_tool_calls_from_response_done(self, event_obj: dict | OpenAIRealtimeEvents) -> None:
         """Extract function_call items from response.done events for spend logging."""
         try:
@@ -1069,6 +1087,7 @@ class RealTimeStreaming:
         except Exception as e:
             verbose_logger.exception("Error in backend to client send messages: %s", e)
         finally:
+            self._flush_unbilled_transcription_usage()
             await self.log_messages()
 
     @staticmethod

--- a/litellm/llms/base_llm/realtime/transformation.py
+++ b/litellm/llms/base_llm/realtime/transformation.py
@@ -5,6 +5,7 @@ import httpx
 
 from litellm.types.llms.openai import OpenAIRealtimeStreamSessionEvents
 from litellm.types.realtime import (
+    RealtimeInputAudioTranscriptionUsage,
     RealtimeResponseTransformInput,
     RealtimeResponseTypedDict,
 )
@@ -68,6 +69,9 @@ class BaseRealtimeConfig(ABC):
         return False
 
     def session_configuration_request(self, model: str) -> str | None:  # message sent to setup the realtime session
+        return None
+
+    def unbilled_usage_on_session_close(self, model: str) -> RealtimeInputAudioTranscriptionUsage | None:
         return None
 
     def transform_session_created_event(

--- a/litellm/llms/gemini/realtime/transformation.py
+++ b/litellm/llms/gemini/realtime/transformation.py
@@ -1191,6 +1191,9 @@ class GeminiRealtimeConfig(BaseRealtimeConfig):
         }
         return usage
 
+    def unbilled_usage_on_session_close(self, model: str) -> RealtimeInputAudioTranscriptionUsage | None:
+        return self._consume_input_transcription_usage_estimate(model)
+
     def transform_realtime_response(
         self,
         message: str | bytes,

--- a/tests/test_litellm/litellm_core_utils/test_realtime_streaming.py
+++ b/tests/test_litellm/litellm_core_utils/test_realtime_streaming.py
@@ -3019,3 +3019,95 @@ async def test_provider_config_path_captures_transcription_usage():
         and message.get("usage") == usage
     )
     assert len(usage_events) == 1
+
+
+@pytest.mark.asyncio
+async def test_session_close_flushes_unbilled_transcription_usage():
+    """Trailing audio appended after the last transcript frame must still be billed:
+    on session close the provider's unbilled estimate is flushed into the logged
+    messages before log_messages runs, and never forwarded to the client."""
+    from typing import Final
+
+    from litellm.types.realtime import RealtimeInputAudioTranscriptionUsage
+
+    client_ws: Final = MagicMock()
+    client_ws.send_text = AsyncMock()
+    backend_ws: Final = MagicMock()
+    backend_ws.recv = AsyncMock(side_effect=ConnectionClosed(None, None))
+    logging_obj: Final = MagicMock()
+    logging_obj.async_success_handler = AsyncMock()
+    logging_obj.success_handler = MagicMock()
+
+    usage: Final[RealtimeInputAudioTranscriptionUsage] = {
+        "type": "tokens",
+        "input_tokens": 153,
+        "output_tokens": 18,
+        "total_tokens": 171,
+        "input_token_details": {"text_tokens": 0, "audio_tokens": 153},
+    }
+    provider_config: Final = MagicMock()
+    provider_config.unbilled_usage_on_session_close = MagicMock(return_value=usage)
+
+    streaming: Final = RealTimeStreaming(
+        client_ws,
+        backend_ws,
+        logging_obj,
+        provider_config=provider_config,
+        model="gemini-3.5-transcribe-live",
+    )
+    logged_snapshots: Final[list[tuple]] = []
+
+    original_log_messages: Final = streaming.log_messages
+
+    async def _snapshot_then_log():
+        logged_snapshots.append(tuple(streaming.messages))
+        await original_log_messages()
+
+    streaming.log_messages = _snapshot_then_log
+
+    await streaming.backend_to_client_send_messages()
+
+    provider_config.unbilled_usage_on_session_close.assert_called_once_with("gemini-3.5-transcribe-live")
+    flushed: Final = tuple(
+        message
+        for message in streaming.messages
+        if isinstance(message, dict)
+        and message.get("type") == "conversation.item.input_audio_transcription.completed"
+        and message.get("usage") == usage
+    )
+    assert len(flushed) == 1
+    assert flushed[0] in logged_snapshots[0]
+    assert not client_ws.send_text.called
+
+
+@pytest.mark.asyncio
+async def test_session_close_flush_noop_without_unbilled_usage():
+    """Everything already billed mid-stream: the session-close flush must not append
+    a duplicate transcription event."""
+    from typing import Final
+
+    client_ws: Final = MagicMock()
+    client_ws.send_text = AsyncMock()
+    backend_ws: Final = MagicMock()
+    backend_ws.recv = AsyncMock(side_effect=ConnectionClosed(None, None))
+    logging_obj: Final = MagicMock()
+    logging_obj.async_success_handler = AsyncMock()
+    logging_obj.success_handler = MagicMock()
+
+    provider_config: Final = MagicMock()
+    provider_config.unbilled_usage_on_session_close = MagicMock(return_value=None)
+
+    streaming: Final = RealTimeStreaming(
+        client_ws,
+        backend_ws,
+        logging_obj,
+        provider_config=provider_config,
+        model="gemini-3.5-transcribe-live",
+    )
+
+    await streaming.backend_to_client_send_messages()
+
+    assert not any(
+        isinstance(message, dict) and message.get("type") == "conversation.item.input_audio_transcription.completed"
+        for message in streaming.messages
+    )

--- a/tests/test_litellm/llms/gemini/realtime/test_gemini_realtime_transformation.py
+++ b/tests/test_litellm/llms/gemini/realtime/test_gemini_realtime_transformation.py
@@ -2119,3 +2119,27 @@ def test_non_transcription_live_model_completed_event_has_no_usage(patch_gemini_
     )
     assert len(completed) == 1
     assert "usage" not in completed[0]
+
+
+def test_unbilled_usage_on_session_close_flushes_trailing_audio(patch_gemini_transcribe_live_cost_map_entry):
+    """Audio appended after the last transcript frame is still unbilled when the
+    session closes; the session-close hook must hand back the estimate exactly once
+    so the streaming layer can bill it (144000 pcm16 bytes = 3s -> 75 in / 9 out)."""
+    from typing import Final
+
+    from litellm.types.realtime import RealtimeInputAudioTranscriptionUsage
+
+    config: Final = GeminiRealtimeConfig()
+    config.transform_realtime_request(_input_audio_append_message(144000), "gemini-3.5-transcribe-live")
+
+    usage: Final = config.unbilled_usage_on_session_close("gemini-3.5-transcribe-live")
+
+    expected: Final[RealtimeInputAudioTranscriptionUsage] = {
+        "type": "tokens",
+        "input_tokens": 75,
+        "output_tokens": 9,
+        "total_tokens": 84,
+        "input_token_details": {"text_tokens": 0, "audio_tokens": 75},
+    }
+    assert usage == expected
+    assert config.unbilled_usage_on_session_close("gemini-3.5-transcribe-live") is None


### PR DESCRIPTION
## TLDR

Problem this solves:

- Gemini transcribe Live sessions never bill audio streamed after the last transcript
- Hanging up mid-turn makes that trailing audio free (55% of spend in the repro)

How it solves it:

- On session close, the provider config hands back the unbilled usage estimate
- It lands in spend logs as one more transcription usage event

## User Flow

Before: a developer streaming live speech to a transcribe Live session gets any audio after the last transcript for free, so session spend under-reports

1. They connect to ws://litellm-domain/v1/realtime?model=gemini-3.5-transcribe-live with their LiteLLM key, stream 5 seconds of speech as `input_audio_buffer.append` frames, and send `input_audio_buffer.commit`
2. A `conversation.item.input_audio_transcription.completed` event comes back with the transcript and `"usage": {"input_tokens": 125, "output_tokens": 15, ...}`
3. They stream 6 more seconds of speech and hang up before the next transcript arrives
4. On http://litellm-domain/ui/?page=logs the session shows $0.0007525 spend: only the first 5 seconds; the trailing 6 seconds were never billed

After: the same session bills every second of streamed audio

1. They connect to ws://litellm-domain/v1/realtime?model=gemini-3.5-transcribe-live with their LiteLLM key, stream 5 seconds of speech as `input_audio_buffer.append` frames, and send `input_audio_buffer.commit`
2. A `conversation.item.input_audio_transcription.completed` event comes back with the transcript and `"usage": {"input_tokens": 125, "output_tokens": 15, ...}`
3. They stream 6 more seconds of speech and hang up before the next transcript arrives
4. On http://litellm-domain/ui/?page=logs the session now shows $0.001666: the trailing 6.1 seconds are billed at the same per-second rate as the rest

## Relevant issues

Follow-up to #38540: bills the trailing-audio gap bugbot flagged on that PR

## Linear ticket

Resolves LIT-6324

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Both legs ran live against real Gemini (`gemini/gemini-3.5-transcribe-live`, real $$$), each in its own worktree, venv, and empty database. Same client both legs: a Python websockets client speaking the OpenAI realtime protocol that streams 5.00s of speech (chunk1, 240128 bytes), commits, waits for the transcript, then streams 6.11s more speech (chunk2, 293120 bytes) and hangs up immediately. Each proxy runs as a single instance with 2 uvicorn workers (the session's billing state is connection-scoped; spend is read back through the DB-backed API). Verdict read from the end-user surface, `GET /spend/logs`.

### Before (493bca667b)

1. Boot the proxy at the merge base:

    ```
    .venv/bin/python litellm/proxy/proxy_cli.py --config qa/proxy_config.yaml --port 41131 --num_workers 2 --use_v2_migration_resolver
    ```

2. Run the realtime client:

    ```
    .venv/bin/python qa/live_probe_trailing.py "ws://127.0.0.1:41131/v1/realtime?model=gemini-3.5-transcribe-live" qa/chunk1.wav qa/chunk2.wav qa/before_events.json sk-lit6324-test
    ```
    ```
    SENT chunk1: 240128 bytes
    EVT: session.created
    EVT: conversation.item.input_audio_transcription.completed
    TRANSCRIPT: The quick brown fox jumps over the lazy dog near the riverbank on a bright sunny morning.
    USAGE1: {"type": "tokens", "input_tokens": 125, "output_tokens": 15, "total_tokens": 140, "input_token_details": {"text_tokens": 0, "audio_tokens": 125}}
    SENT trailing-chunk2: 293120 bytes
    closing client socket immediately after trailing audio
    ```

3. Read the session's spend through the API:

    ```
    curl -s "http://127.0.0.1:41131/spend/logs" -H "Authorization: Bearer sk-lit6324-test" | python3 -m json.tool
    ```
    ```json
    {
      "request_id": "08f3c48a-c281-4bfa-aff0-639a7625e62e",
      "call_type": "_arealtime",
      "model": "gemini/gemini-3.5-transcribe-live",
      "spend": 0.0007524999999999999,
      "total_tokens": 0,
      "prompt_tokens": 0,
      "completion_tokens": 0,
      "startTime": "2026-08-27T19:51:41.585000Z",
      "endTime": "2026-08-27T19:51:43.810000Z"
    }
    ```

4. Only the first 5.00s made it into billing: 125 audio-in + 15 output tokens = $0.0007525 (the row's `metadata.cost_breakdown` carries it all as `transcription_cost`, input/output token costs 0.0). The trailing 6.11s ($0.0009135 worth) is absent

### After (c251703e8b)

1. Boot the proxy at the PR tip:

    ```
    .venv/bin/python litellm/proxy/proxy_cli.py --config qa/proxy_config.yaml --port 40024 --num_workers 2 --use_v2_migration_resolver
    ```

2. Run the same realtime client:

    ```
    .venv/bin/python qa/live_probe_trailing.py "ws://127.0.0.1:40024/v1/realtime?model=gemini-3.5-transcribe-live" qa/chunk1.wav qa/chunk2.wav qa/after_events.json sk-lit6324-test
    ```
    ```
    SENT chunk1: 240128 bytes
    EVT: session.created
    EVT: conversation.item.input_audio_transcription.completed
    TRANSCRIPT: The quick brown fox jumps over the lazy dog near the riverbank on a bright sunny morning.
    USAGE1: {"type": "tokens", "input_tokens": 125, "output_tokens": 15, "total_tokens": 140, "input_token_details": {"text_tokens": 0, "audio_tokens": 125}}
    SENT trailing-chunk2: 293120 bytes
    closing client socket immediately after trailing audio
    ```

3. Read the session's spend through the API:

    ```
    curl -s "http://127.0.0.1:40024/spend/logs" -H "Authorization: Bearer sk-lit6324-test" | python3 -m json.tool
    ```
    ```json
    {
        "request_id": "1a6dc12a-925b-424a-acce-767ca730d451",
        "call_type": "_arealtime",
        "spend": 0.001666,
        "startTime": "2026-08-27T19:50:36.529000Z",
        "endTime": "2026-08-27T19:50:38.678000Z",
        "model": "gemini/gemini-3.5-transcribe-live",
        "custom_llm_provider": "gemini",
        "metadata": {
            "cost_breakdown": {
                "input_cost": 0.0,
                "total_cost": 0.001666,
                "output_cost": 0.0,
                "additional_costs": {"transcription_cost": 0.001666}
            }
        },
        "status": "success"
    }
    ```

4. Full spend: $0.0007525 (transcript-time charge) + $0.0009135 (trailing 6.11s flushed at close) = $0.001666. The client-visible protocol is unchanged; only billing moved

Observations from the legs:

- Spend row's total_tokens stays 0 despite usage events
- Whole cost lands in additional_costs.transcription_cost, input_cost 0
- Both pre-existing on the before leg; this PR leaves them alone
- Gemini sometimes returns no transcript right after boot (before leg: 2 timeouts)
- Before, those no-transcript sessions billed $0.0 despite streamed audio
- Earlier tip run billed a timed-out session $0.0007525

## Type

🐛 Bug Fix

## Caveats (if any)

### Low

- Trailing audio is billed by duration estimate, same basis the mid-stream estimator already uses
- Only Gemini implements the session-close hook; other providers are unchanged

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

- [x] c251703e8b passes /live-pr-risk


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes realtime session teardown billing for Gemini transcribe Live; spend can increase for trailing audio but client protocol is unchanged and only Gemini implements the hook.
> 
> **Overview**
> Fixes **under-reported spend** when a Gemini transcribe Live session ends after audio is sent but before another `conversation.item.input_audio_transcription.completed` event.
> 
> On WebSocket teardown, `RealTimeStreaming` now calls a new provider hook **`unbilled_usage_on_session_close`**. If it returns usage, the proxy records a **usage-only** transcription-completed event for spend logging (same path as `_capture_transcription_usage`) and does **not** send it to the client. The hook runs in the `finally` block of `backend_to_client_send_messages`, immediately before `log_messages()`.
> 
> **Gemini** implements the hook by draining its existing `_unbilled_input_audio_bytes` estimate (same duration/token math as mid-stream billing). The base realtime config defaults to `None`, so other providers are unchanged.
> 
> Tests cover flush-on-close, no-op when nothing is unbilled, and Gemini trailing-audio token math (single consume).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c251703e8bed8f310eb0452858497affa670e555. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
