### PR TITLE
fix(perplexity): add integration attribution

### DIFF
--- a/litellm/llms/perplexity/chat/transformation.py
+++ b/litellm/llms/perplexity/chat/transformation.py
@@ -37,7 +37,8 @@ class PerplexityChatConfig(OpenAIGPTConfig):
         api_key: str | None = None,
         api_base: str | None = None,
     ) -> dict:  # mutable-ok: matches the base chat transform signature
-        headers.setdefault("X-Pplx-Integration", "litellm")
+        if not any(name.lower() == "x-pplx-integration" for name in headers):
+            headers["X-Pplx-Integration"] = "litellm"
         return super().validate_environment(
             headers, model, messages, optional_params, litellm_params, api_key, api_base
         )

--- a/litellm/llms/perplexity/chat/transformation.py
+++ b/litellm/llms/perplexity/chat/transformation.py
@@ -27,6 +27,21 @@ class PerplexityChatConfig(OpenAIGPTConfig):
         dynamic_api_key = api_key or get_secret_str("PERPLEXITYAI_API_KEY") or get_secret_str("PERPLEXITY_API_KEY")
         return api_base, dynamic_api_key
 
+    def validate_environment(
+        self,
+        headers: dict,
+        model: str,
+        messages: list[AllMessageValues],
+        optional_params: dict,
+        litellm_params: dict,
+        api_key: str | None = None,
+        api_base: str | None = None,
+    ) -> dict:
+        headers.setdefault("X-Pplx-Integration", "litellm")
+        return super().validate_environment(
+            headers, model, messages, optional_params, litellm_params, api_key, api_base
+        )
+
     def get_supported_openai_params(self, model: str) -> list:
         """
         Perplexity supports a subset of OpenAI params

--- a/litellm/llms/perplexity/chat/transformation.py
+++ b/litellm/llms/perplexity/chat/transformation.py
@@ -29,14 +29,14 @@ class PerplexityChatConfig(OpenAIGPTConfig):
 
     def validate_environment(
         self,
-        headers: dict,
+        headers: dict,  # mutable-ok: matches the base chat transform signature
         model: str,
-        messages: list[AllMessageValues],
-        optional_params: dict,
-        litellm_params: dict,
+        messages: list[AllMessageValues],  # mutable-ok: matches the base chat transform signature
+        optional_params: dict,  # mutable-ok: matches the base chat transform signature
+        litellm_params: dict,  # mutable-ok: matches the base chat transform signature
         api_key: str | None = None,
         api_base: str | None = None,
-    ) -> dict:
+    ) -> dict:  # mutable-ok: matches the base chat transform signature
         headers.setdefault("X-Pplx-Integration", "litellm")
         return super().validate_environment(
             headers, model, messages, optional_params, litellm_params, api_key, api_base

--- a/tests/test_litellm/llms/perplexity/chat/test_perplexity_chat_transformation.py
+++ b/tests/test_litellm/llms/perplexity/chat/test_perplexity_chat_transformation.py
@@ -21,15 +21,21 @@ class TestPerplexityChatTransformation:
         ("headers", "expected"),
         [({}, "litellm"), ({"x-pplx-integration": "custom"}, "custom")],
     )
-    def test_integration_header_default_is_caller_overridable(self, headers, expected):
-        headers = PerplexityChatConfig().validate_environment(
+    def test_integration_header_default_is_caller_overridable(
+        self, headers: dict[str, str], expected: str
+    ):
+        validated_headers = PerplexityChatConfig().validate_environment(
             headers=headers,
             model="sonar",
             messages=[],
             optional_params={},
             litellm_params={},
         )
-        request = httpx.Request("POST", "https://api.perplexity.ai/chat/completions", headers=headers)
+        request = httpx.Request(
+            "POST",
+            "https://api.perplexity.ai/chat/completions",
+            headers=validated_headers,
+        )
 
         assert request.headers.get_list("x-pplx-integration") == [expected]
 

--- a/tests/test_litellm/llms/perplexity/chat/test_perplexity_chat_transformation.py
+++ b/tests/test_litellm/llms/perplexity/chat/test_perplexity_chat_transformation.py
@@ -5,12 +5,10 @@ Tests the response transformation to extract citation tokens and search queries
 from Perplexity API responses.
 """
 
-from unittest.mock import Mock
-
+import httpx
 import pytest
 
 # Add the project root to Python path
-
 from litellm import ModelResponse
 from litellm.llms.perplexity.chat.transformation import PerplexityChatConfig
 from litellm.types.utils import Usage
@@ -21,18 +19,19 @@ class TestPerplexityChatTransformation:
 
     @pytest.mark.parametrize(
         ("headers", "expected"),
-        [({}, "litellm"), ({"X-Pplx-Integration": "custom"}, "custom")],
+        [({}, "litellm"), ({"x-pplx-integration": "custom"}, "custom")],
     )
     def test_integration_header_default_is_caller_overridable(self, headers, expected):
-        result = PerplexityChatConfig().validate_environment(
+        headers = PerplexityChatConfig().validate_environment(
             headers=headers,
             model="sonar",
             messages=[],
             optional_params={},
             litellm_params={},
         )
+        request = httpx.Request("POST", "https://api.perplexity.ai/chat/completions", headers=headers)
 
-        assert result["X-Pplx-Integration"] == expected
+        assert request.headers.get_list("x-pplx-integration") == [expected]
 
     def test_enhance_usage_with_citation_tokens(self):
         """Test extraction of citation tokens from API response."""

--- a/tests/test_litellm/llms/perplexity/chat/test_perplexity_chat_transformation.py
+++ b/tests/test_litellm/llms/perplexity/chat/test_perplexity_chat_transformation.py
@@ -19,6 +19,21 @@ from litellm.types.utils import Usage
 class TestPerplexityChatTransformation:
     """Test suite for Perplexity chat transformation functionality."""
 
+    @pytest.mark.parametrize(
+        ("headers", "expected"),
+        [({}, "litellm"), ({"X-Pplx-Integration": "custom"}, "custom")],
+    )
+    def test_integration_header_default_is_caller_overridable(self, headers, expected):
+        result = PerplexityChatConfig().validate_environment(
+            headers=headers,
+            model="sonar",
+            messages=[],
+            optional_params={},
+            litellm_params={},
+        )
+
+        assert result["X-Pplx-Integration"] == expected
+
     def test_enhance_usage_with_citation_tokens(self):
         """Test extraction of citation tokens from API response."""
         config = PerplexityChatConfig()


### PR DESCRIPTION
## TLDR

Problem this solves:

- Perplexity would like to identify LiteLLM chat requests in request and billing logs

How it solves it:

- Adds a LiteLLM attribution header while preserving caller overrides with any header casing

## User Flow

1. A developer sends `POST /v1/chat/completions` through LiteLLM with a Perplexity model
2. LiteLLM forwards it with `X-Pplx-Integration: litellm`
3. A caller-provided integration value takes precedence without producing a duplicate header

## Relevant issues

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The focused test file passes locally
- [x] My PR passes all required CI/CD checks
- [x] My PR's scope is as isolated as possible
- [x] Greptile reports a confidence score of at least 4/5

## Screenshots / Proof of Fix

The focused test prepares the outbound request and verifies that both the default and a case-insensitive caller override produce exactly one integration header.

## Type

New Feature

## Caveats (if any)

### Low

- Search, Responses, and embeddings are intentionally out of scope

## Final Attestation

- [x] The tests cover the default and case-insensitive caller override behavior

