### PR TITLE
test(e2e): let the together tool tests accept parallel calls

### DIFF
--- a/tests/e2e/llm_translation/test_together_ai_e2e.py
+++ b/tests/e2e/llm_translation/test_together_ai_e2e.py
@@ -210,16 +210,24 @@ def _deltas(result: StreamingResponse) -> list[_StreamDelta]:
     ]
 
 
-def _single_weather_call(message: OutMessage) -> ToolCall:
-    assert message.tool_calls, f"Together dropped the tool call: {message}"
-    assert len(message.tool_calls) == 1, f"expected one tool call, got {message.tool_calls}"
-    call = message.tool_calls[0]
+def _validated_weather_call_id(call: ToolCall) -> str:
     assert call.id, f"tool call carries no id, so a tool result cannot answer it: {call}"
     assert call.function.name == "get_weather", f"wrong tool called: {call}"
     assert call.function.arguments, f"tool call carries no arguments: {call}"
     args = _WeatherArgs.model_validate_json(call.function.arguments)
     assert "paris" in args.location.lower(), f"tool arguments lost the location: {args}"
-    return call
+    return call.id
+
+
+def _weather_call_ids(message: OutMessage) -> tuple[str, ...]:
+    """The id of every tool call the model made, each one checked for the fields a
+    caller needs to answer it. The backend is whichever together_ai row is cheapest
+    with tools and reasoning, and those rows carry supports_parallel_function_calling,
+    so one weather prompt can legitimately come back as several get_weather calls.
+    What the gateway owes us is that each call survives translation intact; how many
+    the model chose to make is the model's business."""
+    assert message.tool_calls, f"Together dropped the tool call: {message}"
+    return tuple(_validated_weather_call_id(call) for call in message.tool_calls)
 
 
 def _weather_call(client: PassthroughClient, key: str, model: str) -> OutMessage:
@@ -289,7 +297,7 @@ class TestTogetherChatCompletions:
         self, client: PassthroughClient, resources: ResourceManager, reasoning_tool_backend: str
     ) -> None:
         model, key = _register(client, resources, reasoning_tool_backend)
-        _single_weather_call(_weather_call(client, key, model))
+        _ = _weather_call_ids(_weather_call(client, key, model))
 
     @pytest.mark.covers("llm.chat_completions.together_ai.tool_use.stream.works")
     def test_tool_call_is_streamed(
@@ -328,8 +336,7 @@ class TestTogetherChatCompletions:
     ) -> None:
         model, key = _register(client, resources, reasoning_tool_backend)
         first = _weather_call(client, key, model)
-        call = _single_weather_call(first)
-        assert call.id is not None
+        call_ids = _weather_call_ids(first)
 
         answer = _message(
             unwrap(
@@ -344,7 +351,10 @@ class TestTogetherChatCompletions:
                                 reasoning_content=first.reasoning_content,
                                 tool_calls=first.tool_calls,
                             ),
-                            ChatToolResultTurn(tool_call_id=call.id, content=WEATHER_REPORT),
+                            *(
+                                ChatToolResultTurn(tool_call_id=call_id, content=WEATHER_REPORT)
+                                for call_id in call_ids
+                            ),
                         ],
                         tools=[WEATHER_TOOL],
                         max_tokens=512,
@@ -470,9 +480,18 @@ def _tool_use_blocks(content: list[AnthropicContentBlock] | None) -> list[Anthro
     return [block for block in content if block.type == "tool_use"]
 
 
+def _validated_tool_use_id(block: AnthropicContentBlock) -> str:
+    assert block.name == "get_weather", f"wrong tool called: {block}"
+    assert block.id, f"tool_use block carries no id, so a tool_result cannot answer it: {block}"
+    return block.id
+
+
 def _messages_weather_call(
     client: PassthroughClient, key: str, model: str
-) -> tuple[list[AnthropicContentBlock], AnthropicContentBlock]:
+) -> tuple[list[AnthropicContentBlock], tuple[str, ...]]:
+    """The blocks /v1/messages returned and the id of every tool_use among them. The
+    count is the model's choice (see _weather_call_ids); what this surface owes us is
+    that each tool_use arrives named and addressable."""
     response = unwrap(
         client.proxy.messages(
             key,
@@ -485,12 +504,9 @@ def _messages_weather_call(
         )
     )
     tool_uses = _tool_use_blocks(response.content)
-    assert len(tool_uses) == 1, f"expected one tool_use block, got {response.content}"
-    block = tool_uses[0]
-    assert block.name == "get_weather", f"wrong tool called: {block}"
-    assert block.id, f"tool_use block carries no id, so a tool_result cannot answer it: {block}"
+    assert tool_uses, f"/v1/messages carried no tool_use block: {response.content}"
     assert response.content is not None
-    return response.content, block
+    return response.content, tuple(_validated_tool_use_id(block) for block in tool_uses)
 
 
 class TestTogetherMessages:
@@ -506,8 +522,7 @@ class TestTogetherMessages:
         self, client: PassthroughClient, resources: ResourceManager, reasoning_tool_backend: str
     ) -> None:
         model, key = _register(client, resources, reasoning_tool_backend)
-        first_content, block = _messages_weather_call(client, key, model)
-        assert block.id is not None
+        first_content, tool_use_ids = _messages_weather_call(client, key, model)
 
         response = unwrap(
             client.proxy.messages(
@@ -520,7 +535,10 @@ class TestTogetherMessages:
                         ChatMessage(role="user", content=WEATHER_PROMPT),
                         AnthropicAssistantTurn(content=first_content),
                         AnthropicToolResultTurn(
-                            content=[AnthropicToolResultBlock(tool_use_id=block.id, content=WEATHER_REPORT)]
+                            content=[
+                                AnthropicToolResultBlock(tool_use_id=tool_use_id, content=WEATHER_REPORT)
+                                for tool_use_id in tool_use_ids
+                            ]
                         ),
                     ],
                 ),

--- a/tests/e2e/llm_translation/test_together_ai_e2e.py
+++ b/tests/e2e/llm_translation/test_together_ai_e2e.py
@@ -483,6 +483,9 @@ def _tool_use_blocks(content: list[AnthropicContentBlock] | None) -> list[Anthro
 def _validated_tool_use_id(block: AnthropicContentBlock) -> str:
     assert block.name == "get_weather", f"wrong tool called: {block}"
     assert block.id, f"tool_use block carries no id, so a tool_result cannot answer it: {block}"
+    assert block.input is not None, f"tool_use block carries no input: {block}"
+    args = _WeatherArgs.model_validate(block.input)
+    assert "paris" in args.location.lower(), f"tool input lost the location: {args}"
     return block.id
 
 

--- a/tests/e2e/models.py
+++ b/tests/e2e/models.py
@@ -421,6 +421,7 @@ class AnthropicContentBlock(BaseModel):
     text: str | None = None
     id: str | None = None
     name: str | None = None
+    input: dict[str, object] | None = None
 
 
 class AnthropicToolResultBlock(BaseModel):


### PR DESCRIPTION
## TLDR

Problem this solves:

- The together e2e tool tests assert exactly one tool call
- The backend they pick supports parallel function calling
- A parallel answer fails them even though the gateway is correct
- This turned the e2e lane red on unrelated PRs

How it solves it:

- Check every returned tool call instead of counting them
- Each must be a get_weather naming Paris, with an answerable id
- The round trips now answer every call, not just the first

## User Flow

This changes tests only, so nothing an end user does changes. What changes is whether the suite goes red when a model answers with more than one tool call

### Before (d8415c42e6)

A developer asks the gateway for the weather through a Together model that is allowed to make parallel tool calls, and the suite calls a correct answer a failure

1. They send POST https://litellm-domain/v1/messages with the `get_weather` tool and "What is the weather in Paris? Use the tool."
2. The model answers with three `get_weather` calls, all naming Paris, each with its own id
3. The gateway hands all three back intact
4. The suite fails with `expected one tool_use block`, blaming the gateway for the model's choice

### After (2cab010c73)

The same answer is accepted, and a gateway that actually damages a call is still caught

1. They send the same POST https://litellm-domain/v1/messages
2. The model answers with three `get_weather` calls, all naming Paris, each with its own id
3. The suite checks each call carries the right name, an id, and Paris, and passes
4. If the gateway had dropped a call, lost an id, or mangled the name or the location, the suite still fails

## Relevant issues

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

I do not have a TOGETHER_API_KEY, so I could not drive the real Together model. What I could prove without one is the part the failure was actually blamed on: that the gateway sends the same request on both surfaces and hands the model's answer back intact. Steps to reproduce the real thing are in the QA runbook

Setup: a proxy on port 4062 with one deployment pointing `together_ai/openai/gpt-oss-120b` at a local upstream that records what it receives and always answers with two `get_weather` calls

### Before (d8415c42e6)

#### the two surfaces send the same thing upstream, so the model is not being treated differently

1. `curl -s -X POST http://localhost:4062/chat/completions -H "Authorization: Bearer sk-probe-1234" -H "Content-Type: application/json" -d '{"model":"probe-model","messages":[{"role":"user","content":"What is the weather in Paris? Use the tool."}],"tools":[{"type":"function","function":{"name":"get_weather","description":"Get the current weather for a location.","parameters":{"type":"object","properties":{"location":{"type":"string"}},"required":["location"]}}}],"max_tokens":512}'` -> `HTTP 200`
2. `curl -s -X POST http://localhost:4062/v1/messages -H "Authorization: Bearer sk-probe-1234" -H "Content-Type: application/json" -d '{"model":"probe-model","max_tokens":512,"tools":[{"name":"get_weather","description":"Get the current weather for a location.","input_schema":{"type":"object","properties":{"location":{"type":"string"}},"required":["location"]}}],"messages":[{"role":"user","content":"What is the weather in Paris? Use the tool."}]}'` -> `HTTP 200`
3. The upstream recorded both calls. They are identical apart from `"stream": false`, which only the chat call spells out:

```
--- call 1: /v1/chat/completions (from /chat/completions) ---
{"max_tokens": 512, "messages": [{"content": "What is the weather in Paris? Use the tool.", "role": "user"}], "model": "openai/gpt-oss-120b", "stream": false, "tools": [{"function": {"description": "Get the current weather for a location.", "name": "get_weather", "parameters": {"properties": {"location": {"type": "string"}}, "required": ["location"], "type": "object"}}, "type": "function"}]}

--- call 2: /v1/chat/completions (from /v1/messages) ---
{"max_tokens": 512, "messages": [{"content": "What is the weather in Paris? Use the tool.", "role": "user"}], "model": "openai/gpt-oss-120b", "tools": [{"function": {"description": "Get the current weather for a location.", "name": "get_weather", "parameters": {"properties": {"location": {"type": "string"}}, "required": ["location"], "type": "object"}}, "type": "function"}]}
```

4. The `/v1/messages` answer renders the two upstream calls faithfully, so nothing is being invented or duplicated:

```
stop_reason: tool_use
 - thinking | thinking about paris
 - text | assistantWe need the output. assistant
 - tool_use | get_weather
 - tool_use | get_weather
```

5. So the red build was the model choosing to call the tool three times, not the gateway misbehaving

### After (2cab010c73)

#### the loosened assertions accept parallel calls and still catch a damaged one

1. Drive the changed helpers over a parallel answer and over each way the gateway could damage a call, and print whether each behaved as intended
2. Output:

```
OK  | chat: 3 parallel get_weather calls: PASS (wanted PASS)
OK  | msgs: 3 parallel tool_use blocks: PASS (wanted PASS)
OK  | chat: gateway dropped all tool calls: FAIL (AssertionError) (wanted FAIL)
OK  | chat: gateway lost a call id: FAIL (AssertionError) (wanted FAIL)
OK  | chat: gateway mangled the tool name: FAIL (AssertionError) (wanted FAIL)
OK  | chat: gateway lost the arguments: FAIL (AssertionError) (wanted FAIL)
OK  | chat: gateway lost the location: FAIL (AssertionError) (wanted FAIL)
OK  | msgs: gateway lost a block id: FAIL (AssertionError) (wanted FAIL)
OK  | msgs: gateway mangled the block name: FAIL (AssertionError) (wanted FAIL)
OK  | msgs: gateway lost the input: FAIL (AssertionError) (wanted FAIL)
OK  | msgs: gateway lost the location: FAIL (AssertionError) (wanted FAIL)
OK  | msgs: no tool_use blocks at all: FAIL (AssertionError) (wanted FAIL)

ALL 12 CHECKS BEHAVED AS INTENDED
```

## Type

✅ Test

## Caveats (if any)

### Medium

- I could not run these against Together; no API key on hand
- A reviewer with TOGETHER_API_KEY should run the QA runbook below

### Low

- The backend is still whichever row is cheapest, so it can drift again
- Pinning it would trade drift for staleness; left as is deliberately
- `AnthropicContentBlock.input` is now declared rather than an `extra` field
- Bodies dump with `exclude_none`, so replayed blocks serialize unchanged

## QA runbook

Both tests need TOGETHER_API_KEY on the proxy. The backend is resolved at runtime as the cheapest `together_ai/` chat row with both `supports_function_calling` and `supports_reasoning`, today `together_ai/openai/gpt-oss-120b`. That model answers with one call most of the time, so a single passing run does not prove much on its own; the point of the change is that a multi-call answer is no longer a failure

- tests/e2e/llm_translation/test_together_ai_e2e.py::TestTogetherMessages::test_tool_use_block_is_returned - every tool_use block coming back through /v1/messages is a usable get_weather call, however many the model made
  - [ ] Register the backend: `curl -X POST http://localhost:4000/model/new -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" -d '{"model_name":"qa-together","litellm_params":{"model":"together_ai/openai/gpt-oss-120b","api_key":"os.environ/TOGETHER_API_KEY"}}'`
  - [ ] Ask for the weather: `curl -X POST http://localhost:4000/v1/messages -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" -d '{"model":"qa-together","max_tokens":512,"tools":[{"name":"get_weather","description":"Get the current weather for a location.","input_schema":{"type":"object","properties":{"location":{"type":"string"}},"required":["location"]}}],"messages":[{"role":"user","content":"What is the weather in Paris? Use the tool."}]}'`
  - [ ] Expect at least one `tool_use` block; every one of them should be named `get_weather`, carry an `id`, and have `input.location` mentioning Paris. All three are asserted, so damage to any parallel call is caught
  - [ ] Run it about ten times in a loop and expect a pass whether the model answers with one call or several, which is the case that used to fail
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey (e.g., assert actual expected spend instead of just spend > 0) or potentially flaky

- tests/e2e/llm_translation/test_together_ai_e2e.py::TestTogetherMessages::test_tool_result_round_trip - answering every tool_use the model made gets the weather report back into the next turn
  - [ ] Do the call above and keep the whole `content` array plus the `id` of every `tool_use` block
  - [ ] Send a second /v1/messages with the same tools, the original user turn, an assistant turn carrying that `content`, and a user turn holding one `tool_result` per `id`, each with content `Paris: 22 degrees Celsius, clear skies, wind from the northwest at 9 km/h`
  - [ ] Expect the reply text to mention `22`
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey (e.g., assert actual expected spend instead of just spend > 0) or potentially flaky

- tests/e2e/llm_translation/test_together_ai_e2e.py::TestTogetherChatCompletions::test_tool_call_is_returned and ::test_tool_result_round_trip - the same two behaviors on /chat/completions
  - [ ] Repeat the two runs above against POST http://localhost:4000/chat/completions with the OpenAI tool shape, and answer with one `role: tool` message per `tool_calls[].id`
  - [ ] Expect the same outcomes: every call named `get_weather` with Paris, and `22` in the final answer
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey (e.g., assert actual expected spend instead of just spend > 0) or potentially flaky

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
