### PR TITLE
fix(router): reject complexity-router settings written outside complexity_router_config

### DIFF
--- a/litellm/proxy/management_endpoints/model_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/model_management_endpoints.py
@@ -85,6 +85,8 @@ from litellm.router_strategy.complexity_router import (
 )
 from litellm.router_utils.auto_router_model_naming import (
     STRATEGY_ROUTER_PARAM_FIELDS,
+    carries_complexity_router_settings,
+    validate_complexity_router_config_placement,
     validate_complexity_router_config_write,
     validate_strategy_router_model_write,
 )
@@ -226,14 +228,19 @@ def _strategy_router_write_violation(
     )
     if config_violation is not None:
         return config_violation
-    if incoming_params.model is None:
-        return None
     present_fields: Final = frozenset(
         field
         for field in STRATEGY_ROUTER_PARAM_FIELDS
         for source in (incoming_params, existing_params)
         if source is not None and getattr(source, field, None) is not None
     )
+    # Scope reads the incoming model because the stored one is encrypted at rest.
+    if carries_complexity_router_settings(incoming_params.model, present_fields):
+        placement_violation: Final = validate_complexity_router_config_placement(incoming_params.model_extra)
+        if placement_violation is not None:
+            return placement_violation
+    if incoming_params.model is None:
+        return None
     return validate_strategy_router_model_write(model=incoming_params.model, present_fields=present_fields)
 
 

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -116,6 +116,11 @@ from litellm.router_utils.add_retry_fallback_headers import (
     get_fallback_errors_from_headers,
     get_hidden_params_dict,
 )
+from litellm.router_utils.auto_router_model_naming import (
+    STRATEGY_ROUTER_PARAM_FIELDS,
+    carries_complexity_router_settings,
+    validate_complexity_router_config_placement,
+)
 from litellm.types.utils import (
     ModelResponse,
     ModelResponseStream,
@@ -4151,6 +4156,28 @@ def validate_deployment_max_agentic_loops(model: Mapping[str, object]) -> None:
     )
 
 
+def validate_deployment_complexity_router_placement(model: Mapping[str, object]) -> None:
+    """
+    Reject a complexity-router setting written one level above `complexity_router_config`.
+
+    Checked here rather than on `LiteLLM_Params` for the same reason as
+    `max_agentic_loops`: the proxy builds its router with
+    `ignore_invalid_deployments=True`, so a rejection further down turns a bad
+    deployment into a silently missing model instead of a refusal to start.
+    """
+    litellm_params: Final = model.get("litellm_params")
+    if not isinstance(litellm_params, Mapping):
+        return
+    present_fields: Final = frozenset(
+        field for field in STRATEGY_ROUTER_PARAM_FIELDS if litellm_params.get(field) is not None
+    )
+    if not carries_complexity_router_settings(str(litellm_params.get("model") or ""), present_fields):
+        return
+    violation: Final = validate_complexity_router_config_placement(litellm_params)
+    if violation is not None:
+        raise ValueError(f"model {model.get('model_name', '')!r}: {violation}")
+
+
 def pin_complexity_router_model_id(model: dict) -> None:  # mutable-ok: out-param, model_info is stamped in place
     """
     Stamps `model_info.id` from the raw litellm_params before plugin resolution swaps
@@ -5499,6 +5526,7 @@ class ProxyConfig:
                     if isinstance(v, str) and v.startswith("os.environ/"):
                         model["litellm_params"][k] = get_secret(v)
                 validate_deployment_max_agentic_loops(model)
+                validate_deployment_complexity_router_placement(model)
                 pin_complexity_router_model_id(model)
                 complexity_router_config = model["litellm_params"].get("complexity_router_config")
                 if isinstance(complexity_router_config, dict):

--- a/litellm/router_strategy/complexity_router/config.py
+++ b/litellm/router_strategy/complexity_router/config.py
@@ -1246,6 +1246,28 @@ class ComplexityRouterConfig(BaseModel):
             )
         return self
 
+    @model_validator(mode="after")
+    def _validate_tier_param_placement(self) -> "ComplexityRouterConfig":
+        """Reject a router setting written into a tier entry's request params.
+
+        A tier entry's ``litellm_params`` are request params for that deployment: the
+        pre-routing hook spreads them onto the outbound call, so a config key placed
+        there configures nothing and reaches the provider as an unknown body field.
+        """
+        misplaced: Final = tuple(
+            f"{tier}.{key}"
+            for tier, entries in self.tier_model_configs.items()
+            for entry in entries
+            for key in sorted(frozenset(entry.litellm_params) & COMPLEXITY_ROUTER_CONFIG_KEYS)
+        )
+        if misplaced:
+            raise ValueError(
+                "tier entries carry complexity_router_config settings in their litellm_params, where the "
+                "router never reads them and the outbound request forwards them to the provider as unknown "
+                f"body fields: {', '.join(misplaced)}. Set these on complexity_router_config itself"
+            )
+        return self
+
     def tier_label(self, tier: ComplexityTier) -> str:
         """Operator-facing display name for a tier, falling back to its canonical name."""
         return self.tier_labels.get(tier, "").strip() or tier.value
@@ -1262,6 +1284,15 @@ class ComplexityRouterConfig(BaseModel):
             (tier for tier, tier_label in labeled if tier_label.casefold() == folded),
             next((tier for tier in TIER_SEVERITY_ORDER if tier.value.casefold() == folded), None),
         )
+
+
+COMPLEXITY_ROUTER_CONFIG_KEYS: Final[frozenset[str]] = frozenset(ComplexityRouterConfig.model_fields)
+"""Every setting name this config owns, derived from the model so a field added later is covered.
+
+These names are disjoint from the OpenAI request params, from ``all_litellm_params``, and from the
+``LiteLLM_Params`` fields, so one of them appearing where a request param belongs is always a
+misplaced setting rather than a parameter the caller meant to send.
+"""
 
 
 # Combined default config

--- a/litellm/router_utils/auto_router_model_naming.py
+++ b/litellm/router_utils/auto_router_model_naming.py
@@ -15,7 +15,10 @@ from dataclasses import dataclass
 from types import MappingProxyType
 from typing import Final, Literal, TypeAlias
 
-from litellm.router_strategy.complexity_router.config import LLM_CLASSIFIER_TYPES
+from litellm.router_strategy.complexity_router.config import (
+    COMPLEXITY_ROUTER_CONFIG_KEYS,
+    LLM_CLASSIFIER_TYPES,
+)
 
 AUTO_ROUTER_MODEL_PREFIX: Final = "auto_router/"
 
@@ -186,6 +189,47 @@ def validate_complexity_router_config_write(complexity_router_config: Mapping[st
             "The router would drop this deployment at load time, so the write is rejected instead."
         )
     return None
+
+
+_COMPLEXITY_ROUTER_FIELDS: Final[frozenset[str]] = frozenset(
+    field for group in _REQUIRED_FIELD_GROUPS["complexity"] for field in group
+)
+
+
+def carries_complexity_router_settings(model: str | None, present_fields: frozenset[str]) -> bool:
+    """Whether this deployment configures a complexity router, so is judged on its key set.
+
+    Scoped rather than applied to every deployment because the setting names are only
+    unambiguous in this context: ``embedding_model``, for one, is a legitimate flat param
+    on an s3_vectors vector store. ``present_fields`` carries the same merged view
+    ``validate_strategy_router_model_write`` is judged on, so a router named only by its
+    default model is in scope, and a field added to the table above is covered here for free.
+    """
+    return classify_strategy_router_model(model or "") == "complexity" or bool(
+        present_fields & _COMPLEXITY_ROUTER_FIELDS
+    )
+
+
+def validate_complexity_router_config_placement(litellm_params: Mapping[str, object] | None) -> str | None:
+    """Reject a complexity-router setting written beside ``complexity_router_config``.
+
+    The router reads its settings only from ``litellm_params.complexity_router_config``, so a
+    key one level too high configures nothing. It does not stay inert: the alias-marker
+    forwarding carries every unrecognized ``litellm_params`` key onto the outbound request,
+    where the provider rejects it as an unknown body field, and the deployment then fails
+    every call with an error naming an internal config key. Caller scopes; this judges.
+    """
+    if litellm_params is None:
+        return None
+    misplaced: Final = tuple(sorted(frozenset(litellm_params) & COMPLEXITY_ROUTER_CONFIG_KEYS))
+    if not misplaced:
+        return None
+    return (
+        f"litellm_params sets complexity_router_config settings directly: {', '.join(misplaced)}. "
+        "The router reads these only from complexity_router_config, so there they configure nothing "
+        "and are forwarded to the provider as unknown request params, which rejects the call. "
+        "Move them under complexity_router_config."
+    )
 
 
 def validate_strategy_router_model_write(model: str, present_fields: frozenset[str]) -> str | None:

--- a/tests/test_litellm/proxy/management_endpoints/test_model_management_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_model_management_endpoints.py
@@ -4106,6 +4106,72 @@ class TestStrategyRouterWriteValidation:
             assert "requires" in str(exc_info.value.message)
             mock_prisma.db.litellm_proxymodeltable.create.assert_not_called()
 
+    def test_settings_written_beside_the_config_rejected(self):
+        """A setting one level above complexity_router_config configures nothing, and the alias
+        marker forwards it onto every outbound call, so the provider rejects the request with an
+        error naming an internal config key. The write is the last boundary that can refuse it."""
+        from litellm.proxy.management_endpoints.model_management_endpoints import (
+            _strategy_router_write_violation,
+        )
+
+        violation = _strategy_router_write_violation(
+            incoming_params=LiteLLM_Params(
+                model="auto_router/complexity_router",
+                complexity_router_config={"tiers": {"SIMPLE": ["gpt-4o-mini"]}},
+                tier_boundaries={"simple_medium": 0.1},
+                token_thresholds={"medium": 100},
+            ),
+            existing_params=None,
+        )
+        assert violation is not None
+        assert "tier_boundaries" in violation
+        assert "token_thresholds" in violation
+
+    @pytest.mark.parametrize(
+        "stored_field",
+        ["complexity_router_config", "complexity_router_default_model"],
+    )
+    def test_settings_beside_the_config_rejected_on_a_patch_of_a_stored_router(self, stored_field):
+        """The patch carries only the stray key, so scope has to come from the stored deployment:
+        the stored model is encrypted at rest and cannot be classified here. Either field names a
+        complexity router on its own, which is what the load requires, so either has to be scope."""
+        from litellm.proxy.management_endpoints.model_management_endpoints import (
+            _strategy_router_write_violation,
+        )
+        from litellm.types.router import updateLiteLLMParams
+
+        stored = {
+            "complexity_router_config": {"tiers": {"SIMPLE": "gpt-4o-mini"}},
+            "complexity_router_default_model": "gpt-4o-mini",
+        }[stored_field]
+
+        violation = _strategy_router_write_violation(
+            incoming_params=updateLiteLLMParams(tier_boundaries={"simple_medium": 0.1}),
+            existing_params=LiteLLM_Params(model="auto_router/complexity_router", **{stored_field: stored}),
+        )
+        assert violation is not None
+        assert "tier_boundaries" in violation
+
+    def test_documented_nesting_still_accepted(self):
+        from litellm.proxy.management_endpoints.model_management_endpoints import (
+            _strategy_router_write_violation,
+        )
+
+        assert (
+            _strategy_router_write_violation(
+                incoming_params=LiteLLM_Params(
+                    model="auto_router/complexity_router",
+                    complexity_router_default_model="gpt-4o-mini",
+                    complexity_router_config={
+                        "tiers": {"SIMPLE": ["gpt-4o-mini"]},
+                        "tier_boundaries": {"simple_medium": 0.1},
+                    },
+                ),
+                existing_params=None,
+            )
+            is None
+        )
+
     @pytest.mark.asyncio
     async def test_update_model_rejects_prefix_strip(self):
         from litellm.proxy._types import ProxyException

--- a/tests/test_litellm/proxy/proxy_server/test_proxy_config.py
+++ b/tests/test_litellm/proxy/proxy_server/test_proxy_config.py
@@ -26,6 +26,7 @@ from litellm.proxy.proxy_server import (
     _scrub_guardrail_inner,
     resolve_complexity_router_plugins,
     resolve_routing_plugins,
+    validate_deployment_complexity_router_placement,
     validate_deployment_max_agentic_loops,
 )
 
@@ -152,6 +153,44 @@ def test_resolve_complexity_router_plugins_resolves_dotted_path_to_live_instance
     assert len(config["plugins"]) == 1
     assert hasattr(config["plugins"][0], "run")
     assert type(config["plugins"][0]).__name__ == "_Plugin"
+
+
+def test_validate_deployment_complexity_router_placement_refuses_to_start():
+    """Rejected here rather than at router build for the same reason as max_agentic_loops: the
+    proxy builds its router with ignore_invalid_deployments=True, so a rejection further down
+    turns the bad deployment into a silently missing model instead of a refusal to start."""
+    model = {
+        "model_name": "smart-router",
+        "litellm_params": {
+            "model": "auto_router/complexity_router",
+            "complexity_router_config": {"tiers": {"SIMPLE": "gpt-4o-mini"}},
+            "tier_boundaries": {"simple_medium": 0.1},
+        },
+    }
+
+    with pytest.raises(ValueError, match="tier_boundaries"):
+        validate_deployment_complexity_router_placement(model)
+
+
+@pytest.mark.parametrize(
+    "litellm_params",
+    [
+        {"model": "gpt-4o"},
+        {"model": "openai/gpt-4o", "embedding_model": "text-embedding-3-small"},
+        {
+            "model": "auto_router/complexity_router",
+            "complexity_router_config": {"tiers": {"SIMPLE": "gpt-4o-mini"}, "tier_boundaries": {"simple_medium": 0.1}},
+        },
+    ],
+)
+def test_validate_deployment_complexity_router_placement_leaves_valid_deployments_alone(litellm_params):
+    """`embedding_model` is a legitimate flat param on an s3_vectors vector store, so the gate is
+    scoped to complexity routers rather than applied to every deployment."""
+    model = {"model_name": "m", "litellm_params": dict(litellm_params)}
+
+    validate_deployment_complexity_router_placement(model)
+
+    assert model["litellm_params"] == litellm_params
 
 
 def test_validate_deployment_max_agentic_loops_allows_a_deployment_without_the_key():

--- a/tests/test_litellm/router_strategy/test_complexity_router.py
+++ b/tests/test_litellm/router_strategy/test_complexity_router.py
@@ -8690,6 +8690,38 @@ def test_tier_model_params_reject_malformed_entries(tiers):
         ComplexityRouterConfig(tiers=tiers)
 
 
+@pytest.mark.parametrize(
+    "misplaced",
+    [
+        {"tier_boundaries": {"simple_medium": 0.1}},
+        {"token_thresholds": {"medium": 100}},
+        {"classifier_type": "llm"},
+    ],
+)
+def test_tier_model_params_reject_router_settings(misplaced):
+    """A tier entry's litellm_params are request params for that deployment: the pre-routing hook
+    spreads them onto the outbound call, so a router setting placed there configures nothing and
+    reaches the provider as an unknown body field, failing every call through that tier."""
+    with pytest.raises(ValidationError, match="complexity_router_config settings"):
+        ComplexityRouterConfig(tiers={"REASONING": [{"model_name": "opus", "litellm_params": misplaced}]})
+
+
+@pytest.mark.parametrize(
+    "params",
+    [
+        {"reasoning_effort": "xhigh"},
+        {"thinking": {"type": "enabled"}},
+        {"max_tokens": 512, "temperature": 0.2},
+    ],
+)
+def test_tier_model_params_still_accept_real_request_params(params):
+    """The negative class for the gate above: per-tier request-param overrides are a shipped
+    feature, so the check must reject only names the config itself owns."""
+    config = ComplexityRouterConfig(tiers={"REASONING": [{"model_name": "opus", "litellm_params": params}]})
+
+    assert config.tier_model_configs["REASONING"][0].litellm_params == params
+
+
 def test_tier_model_params_reject_duplicate_models():
     with pytest.raises(ValidationError, match="duplicate model_name"):
         ComplexityRouterConfig(

--- a/tests/test_litellm/router_utils/test_auto_router_model_naming.py
+++ b/tests/test_litellm/router_utils/test_auto_router_model_naming.py
@@ -1,8 +1,10 @@
 import pytest
 
 from litellm.router_utils.auto_router_model_naming import (
+    carries_complexity_router_settings,
     classify_strategy_router_model,
     strategy_router_dependencies,
+    validate_complexity_router_config_placement,
     validate_complexity_router_config_write,
     validate_strategy_router_model_write,
 )
@@ -300,3 +302,70 @@ def test_complexity_embedding_model_is_a_dependency_only_when_semantic_matching_
     )
 
     assert tuple(d.model_name for d in found) == expected
+
+
+@pytest.mark.parametrize(
+    "misplaced",
+    [
+        ("tier_boundaries",),
+        ("token_thresholds", "dimension_weights"),
+        ("reasoning_override_min_score",),
+        ("tiers",),
+    ],
+)
+def test_placement_rejects_settings_written_beside_the_config(misplaced):
+    """A setting one level above complexity_router_config configures nothing and is forwarded to
+    the provider as an unknown body field, so the deployment fails every call with an error naming
+    an internal config key. The whole key set leaks the same way, not just the one first reported."""
+    violation = validate_complexity_router_config_placement(
+        {
+            "model": "auto_router/complexity_router",
+            "complexity_router_config": {"tiers": VALID_TIERS},
+            **{key: {"anything": 1} for key in misplaced},
+        }
+    )
+    assert violation is not None
+    for key in misplaced:
+        assert key in violation
+    assert "Move them under complexity_router_config" in violation
+
+
+def test_placement_accepts_the_documented_nesting():
+    assert (
+        validate_complexity_router_config_placement(
+            {
+                "model": "auto_router/complexity_router",
+                "complexity_router_config": {"tiers": VALID_TIERS, "tier_boundaries": {"simple_medium": 0.1}},
+            }
+        )
+        is None
+    )
+
+
+def test_placement_guards_every_setting_the_config_owns():
+    """Derived from the model rather than listed here, so a field added to ComplexityRouterConfig
+    later is covered without editing this gate. Pinned so a rename cannot silently shrink it."""
+    from litellm.router_strategy.complexity_router.config import (
+        COMPLEXITY_ROUTER_CONFIG_KEYS,
+        ComplexityRouterConfig,
+    )
+
+    assert COMPLEXITY_ROUTER_CONFIG_KEYS == frozenset(ComplexityRouterConfig.model_fields)
+    assert {"tier_boundaries", "token_thresholds", "dimension_weights"} <= COMPLEXITY_ROUTER_CONFIG_KEYS
+
+
+@pytest.mark.parametrize(
+    "model,present_fields,scoped",
+    [
+        ("auto_router/complexity_router", frozenset(), True),
+        ("openai/gpt-4o", frozenset({"complexity_router_config"}), True),
+        (None, frozenset({"complexity_router_default_model"}), True),
+        ("auto_router/semantic_router", frozenset({"auto_router_default_model"}), False),
+        ("openai/gpt-4o", frozenset(), False),
+    ],
+)
+def test_placement_is_scoped_to_complexity_router_deployments(model, present_fields, scoped):
+    """The setting names only mean this on a complexity router: `embedding_model` is a legitimate
+    flat param on an s3_vectors vector store, so an unscoped gate would reject a valid deployment.
+    Either complexity field names one on its own, which is what the load itself requires."""
+    assert carries_complexity_router_settings(model, present_fields) is scoped


### PR DESCRIPTION
## TLDR

Problem this solves:

- A complexity-router setting written one level too high is silently accepted
- The router never reads it there, so the tuning does nothing
- It is then forwarded to the provider, which rejects every call
- The 400 names an internal config key the caller never sent

How it solves it:

- Reject the misplaced setting at the write, with a 400 naming it
- config.yaml refuses to start, matching how max_agentic_loops is handled
- A tier entry carrying one is rejected by the config model itself
- Guards all 43 settings, derived from the model, not a hand-listed few

## User Flow

Before: an admin who tunes an auto-router's scoring thresholds saves it successfully, then finds every request through that router failing with an error naming something they never sent

1. They send POST https://litellm-domain/model/new for an auto-router, putting `tier_boundaries` next to `complexity_router_config` instead of inside it
2. It returns 200 with a model id, so the router looks saved and correctly tuned
3. They send POST https://litellm-domain/v1/chat/completions with `"model": "misplaced-router"`
4. It comes back 400 saying `tier_boundaries: Extra inputs are not permitted`, quoting a name they never put in the request
5. Every request through that router fails the same way, and nothing tells them which setting is wrong or where it belongs. The thresholds they thought they set were never in effect either

After: the same mistake is refused at save time, with a message naming the setting and where it goes

1. They send the same POST https://litellm-domain/model/new
2. It returns 400 saying `litellm_params sets complexity_router_config settings directly: tier_boundaries`, and telling them to move it under `complexity_router_config`
3. They move the setting inside `complexity_router_config` and save again, which returns 200
4. They send the same POST https://litellm-domain/v1/chat/completions and get a normal completion back
5. The thresholds they set are the ones the router actually scores with

## Relevant issues

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

Real Bedrock upstream, real spend. Shared setup, used by both runs:

```yaml
model_list:
  - model_name: bedrock-sonnet
    litellm_params:
      model: openai/bedrock/global.anthropic.claude-sonnet-4-6
      api_base: https://<gateway-host>/v1
      api_key: os.environ/LITELLM_MASTER_KEY
general_settings:
  master_key: sk-1234
```

Both runs use `STORE_MODEL_IN_DB=True` against the same fresh Postgres. Every chat completion uses
unique prompt content, since an identical prompt comes back from cache and reads as a pass.

### Before (49affa7c01)

#### saving a router with the setting one level too high, then calling it

1. `POST /model/new` with `tier_boundaries` beside `complexity_router_config`

```
POST /model/new -> HTTP 200
```

2. `POST /v1/chat/completions` with `{"model":"misplaced-b2","messages":[{"role":"user","content":"rebase before probe gamma 8842, name one fruit"}],"max_tokens":16}`

```json
{"error":{"message":"litellm.BadRequestError: OpenAIException - litellm.BadRequestError: BedrockException - {\"message\":\"The model returned the following errors: tier_boundaries: Extra inputs are not permitted\"}No fallback model group found for original model_group=bedrock/global.anthropic.claude-sonnet-4-6. ...","type":null,"param":null,"code":"400"}}
HTTP 400
```

#### patching a router stored with only complexity_router_default_model

1. Create it with `complexity_router_default_model` and no config: `HTTP 200`

2. `PATCH /model/defaultonly-b2/update` with `{"litellm_params":{"tier_boundaries":{"simple_medium":0.1}}}`

```
HTTP 200
```

#### chat completion through a router saved the documented way

1. Create it nested, then `POST /v1/chat/completions` with `"rebase before probe delta 3317, name one fruit"`

```json
{"id":"chatcmpl-920ac0c2-58ad-499f-9001-ffd49d30072e","model":"nested-b2","choices":[{"finish_reason":"length","message":{"content":"**Apple** 🍎","role":"assistant"}}],"usage":{"completion_tokens":16,"prompt_tokens":19,"total_tokens":35}}
HTTP 200
```

### After (790554b0f0)

#### saving a router with the setting one level too high, then calling it

1. Same `POST /model/new`

```json
{"error":{"message":"litellm_params sets complexity_router_config settings directly: tier_boundaries. The router reads these only from complexity_router_config, so there they configure nothing and are forwarded to the provider as unknown request params, which rejects the call. Move them under complexity_router_config.","type":"validation_error","param":"litellm_params.model","code":"400"}}
HTTP 400
```

2. There is nothing to call, the router was never stored in that shape

#### patching a router stored with only complexity_router_default_model

1. Create it the same way: `HTTP 200`

2. Same `PATCH /model/defaultonly-a2/update`

```json
{"error":{"message":"litellm_params sets complexity_router_config settings directly: tier_boundaries. The router reads these only from complexity_router_config, so there they configure nothing and are forwarded to the provider as unknown request params, which rejects the call. Move them under complexity_router_config.","type":"validation_error","param":"litellm_params.model","code":"400"}}
HTTP 400
```

#### chat completion through a router saved the documented way

1. Create it nested, then `POST /v1/chat/completions` with `"rebase after probe epsilon 6104, name one fruit"`

```json
{"id":"chatcmpl-72535c45-1fc1-4308-a69e-b380d1e812a1","model":"nested-a2","choices":[{"finish_reason":"length","message":{"content":"**Apple** 🍎","role":"assistant"}}],"usage":{"completion_tokens":16,"prompt_tokens":19,"total_tokens":35}}
HTTP 200
```

## Type

🐛 Bug Fix

## Caveats (if any)

### Severe

- config.yaml with a misplaced setting now refuses to start

  - Same trade as `max_agentic_loops`: the proxy builds its router with `ignore_invalid_deployments=True`, so rejecting further down would silently drop the deployment instead of refusing to boot. The deployment was already failing every request, so nothing that worked stops working, but an operator upgrading with that config in the file needs to fix it before the proxy comes up

### Medium

- An already-stored deployment carrying the setting keeps loading

  - Deliberate, so an upgrade cannot take a running gateway down over a row written before the gate existed. It behaves exactly as it does today, and the operator is now refused the next time they save it. Verified on the same rig: a router stored before the fix is still served afterwards

- A tier entry mistake in config.yaml drops that deployment rather than refusing to boot

  - It is caught by the config model, which runs under `ignore_invalid_deployments`, so the reason is logged and the deployment is skipped. No leak either way, and both write endpoints and the dashboard preflight reject it outright

### Low

- The gate is scoped to complexity-router deployments on purpose

  - The setting names only mean this there. `embedding_model` is a legitimate flat param on an s3_vectors vector store, so an unscoped check would reject a valid deployment

- `ComplexityRouterConfig` is still `extra="allow"`

  - A typo nested inside `complexity_router_config` is silently kept. Tightening that is a separate, larger behavior change and is left out of scope here

- `ProxyException.param` stays `litellm_params.model` for this violation

  - It comes from the shared raiser used by every strategy-router write check. The message names the offending settings explicitly

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes proxy model-write and startup validation for complexity-router deployments; mis-nested configs that previously loaded will now 400 on save or block proxy boot, though correctly nested configs are unchanged.
> 
> **Overview**
> **Rejects misplaced complexity-router tuning keys** (e.g. `tier_boundaries`, `token_thresholds`) when they sit on `litellm_params` next to `complexity_router_config` instead of inside it—settings the router never reads but that still get forwarded to the provider and break every completion.
> 
> Validation is added at three boundaries: **model create/update** via `_strategy_router_write_violation` and `validate_complexity_router_config_placement` (scoped with `carries_complexity_router_settings` so unrelated deployments like vector stores with `embedding_model` are untouched); **proxy config load** via `validate_deployment_complexity_router_placement` so bad `config.yaml` fails startup like `max_agentic_loops`; and **`ComplexityRouterConfig`** via `_validate_tier_param_placement`, which blocks the same keys inside per-tier `litellm_params`. The guarded key set is **`COMPLEXITY_ROUTER_CONFIG_KEYS`**, derived from `ComplexityRouterConfig.model_fields` so new config fields are covered automatically.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 790554b0f0fca5a0b44a790d890c64b38638291e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->