### PR TITLE
feat: add moonshot/kimi-k2.7-code pricing

### DIFF
--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -31872,6 +31872,17 @@
         "supports_video_input": true,
         "supports_vision": true
     },
+    "moonshot/kimi-k2.7-code": {
+        "cache_read_input_token_cost": 1.9e-07,
+        "input_cost_per_token": 9.5e-07,
+        "litellm_provider": "moonshot",
+        "max_input_tokens": 262144,
+        "max_tokens": 262144,
+        "mode": "chat",
+        "output_cost_per_token": 4e-06,
+        "source": "https://platform.kimi.ai/docs/pricing/chat-k27-code",
+        "supports_prompt_caching": true
+    },
     "moonshot/kimi-k3": {
         "cache_read_input_token_cost": 3e-07,
         "input_cost_per_token": 3e-06,


### PR DESCRIPTION

## Relevant issues

None — this adds a missing model entry.

## Type

🆕 New Feature (model pricing data)

## Changes

Adds a direct `moonshot/` entry for **Kimi K2.7 Code**. The model is currently
only reachable in the map through third-party gateways
(`dashscope/`, `cloudflare/`, `fireworks_ai/`, `perplexity/`, `together_ai/`,
`novita/`, `deepinfra/`, `wandb/`, `azure_ai/`), so anyone calling Moonshot's
own API for this model gets no cost data.

| field | value |
|---|---|
| `input_cost_per_token` | `9.5e-07` ($0.95 / 1M, cache miss) |
| `cache_read_input_token_cost` | `1.9e-07` ($0.19 / 1M, cache hit) |
| `output_cost_per_token` | `4e-06` ($4.00 / 1M) |
| `max_input_tokens` / `max_tokens` | `262144` |

**Source:** https://platform.kimi.ai/docs/pricing/chat-k27-code (verified 2026-08-27)

This mirrors the existing `moonshot/kimi-k2.6` entry, which cites the sibling
page `.../pricing/chat-k26`.

### Cross-check

The provider's published rates match, to the cent, what five independent
gateways already carry in this file:

| key already in the map | input | output | cache read |
|---|---|---|---|
| `cloudflare/@cf/moonshotai/kimi-k2.7-code` | $0.95 | $4.00 | $0.19 |
| `dashscope/kimi-k2.7-code` | $0.95 | $4.00 | $0.19 |
| `fireworks_ai/kimi-k2p7-code` | $0.95 | $4.00 | $0.19 |
| `perplexity/perplexity/kimi-k2.7-code` | $0.95 | $4.00 | $0.19 |
| `together_ai/moonshotai/Kimi-K2.7-Code` | $0.95 | $4.00 | — |

### Deliberate omissions

- **`max_output_tokens`** — Moonshot's page states the 262,144-token context
  window but does not publish a separate output ceiling for this model, so I
  left the field out rather than mirror the context value on a guess.
- **`supports_function_calling` / `_reasoning` / `_response_schema` /
  `_tool_choice` / `_vision`** — the sibling `kimi-k2.6` entry carries these,
  but the K2.7 Code pricing page doesn't state them, and I didn't want to
  assert capabilities I couldn't cite. Happy to add them in this PR if a
  maintainer can point me at the right source.
- `supports_prompt_caching: true` **is** included: the page publishes a distinct
  cache-hit rate, which is direct evidence the feature exists and is billed.

## Testing

The change is data-only: one key added, none modified or removed
(3361 → 3362 keys), and the file still parses as valid JSON. Diff is the
11 added lines and nothing else.
