### PR TITLE
fix(duration_parser): fix overflow when hours/sec/mins rollover to > 1d

### DIFF
--- a/litellm/litellm_core_utils/duration_parser.py
+++ b/litellm/litellm_core_utils/duration_parser.py
@@ -272,8 +272,9 @@ def _handle_hour_reset(current_time: datetime, base_midnight: datetime, value: i
 
     # Handle overnight case
     if next_hour >= 24:
+        days_to_add: Final = next_hour // 24
         next_hour = next_hour % 24
-        next_day: Final = base_midnight + timedelta(days=1)
+        next_day: Final = base_midnight + timedelta(days=days_to_add)
         return next_day.replace(hour=next_hour)
 
     return current_time.replace(hour=next_hour, minute=0, second=0, microsecond=0)
@@ -306,8 +307,9 @@ def _handle_minute_reset(current_time: datetime, base_midnight: datetime, value:
 
     # Handle overnight case
     if next_hour >= 24:
+        days_to_add: Final = next_hour // 24
         next_hour = next_hour % 24
-        next_day: Final = base_midnight + timedelta(days=1)
+        next_day: Final = base_midnight + timedelta(days=days_to_add)
         return next_day.replace(hour=next_hour, minute=next_minute, second=0, microsecond=0)
 
     return current_time.replace(hour=next_hour, minute=next_minute, second=0, microsecond=0)
@@ -345,8 +347,9 @@ def _handle_second_reset(current_time: datetime, base_midnight: datetime, value:
 
     # Handle overnight case
     if next_hour >= 24:
+        days_to_add: Final = next_hour // 24
         next_hour = next_hour % 24
-        next_day: Final = base_midnight + timedelta(days=1)
+        next_day: Final = base_midnight + timedelta(days=days_to_add)
         return next_day.replace(hour=next_hour, minute=next_minute, second=next_second, microsecond=0)
 
     return current_time.replace(hour=next_hour, minute=next_minute, second=next_second, microsecond=0)

--- a/tests/test_litellm/litellm_core_utils/test_duration_parser.py
+++ b/tests/test_litellm/litellm_core_utils/test_duration_parser.py
@@ -23,9 +23,7 @@ class TestStandardizedResetTime(unittest.TestCase):
 
         # Weekly reset (7d) - should reset on next Monday
         wednesday = datetime(2023, 5, 17, 15, 45, 0, tzinfo=timezone.utc)  # A Wednesday
-        weekly_expected = datetime(
-            2023, 5, 22, 0, 0, 0, tzinfo=timezone.utc
-        )  # Next Monday
+        weekly_expected = datetime(2023, 5, 22, 0, 0, 0, tzinfo=timezone.utc)  # Next Monday
         weekly_result = get_next_standardized_reset_time("7d", wednesday, "UTC")
         self.assertEqual(weekly_result, weekly_expected)
 
@@ -76,6 +74,43 @@ class TestStandardizedResetTime(unittest.TestCase):
         second_result = get_next_standardized_reset_time("15s", base_time, "UTC")
         self.assertEqual(second_result, second_expected)
 
+    def test_multi_day_overflow_for_sub_day_units(self):
+        """Large hour/minute/second durations that span more than 24h must advance
+        by the actual number of days they overflow, not always exactly 1 day.
+
+        Regression test for https://github.com/BerriAI/litellm/issues/17993:
+        _handle_hour_reset/_handle_minute_reset/_handle_second_reset hardcoded
+        `timedelta(days=1)` on overnight rollover regardless of how many days the
+        value actually spanned, so e.g. "8760h" (365 days) landed 1 day out
+        instead of 365.
+        """
+        base_time = datetime(2023, 5, 15, 0, 0, 0, tzinfo=timezone.utc)
+
+        # 50h from midnight = 2 days + 2h out
+        hour_expected = datetime(2023, 5, 17, 2, 0, 0, tzinfo=timezone.utc)
+        hour_result = get_next_standardized_reset_time("50h", base_time, "UTC")
+        self.assertEqual(hour_result, hour_expected)
+
+        # 4000m (66h40m) from midnight = 2 days, 18h, 40m out
+        minute_expected = datetime(2023, 5, 17, 18, 40, 0, tzinfo=timezone.utc)
+        minute_result = get_next_standardized_reset_time("4000m", base_time, "UTC")
+        self.assertEqual(minute_result, minute_expected)
+
+        # 200000s from midnight = 2 days, 7h, 33m, 20s out
+        second_expected = datetime(2023, 5, 17, 7, 33, 20, tzinfo=timezone.utc)
+        second_result = get_next_standardized_reset_time("200000s", base_time, "UTC")
+        self.assertEqual(second_result, second_expected)
+
+        # Durations expressed in different units but covering the same span
+        # (365 days) must land on the exact same instant.
+        year_in_days = get_next_standardized_reset_time("365d", base_time, "UTC")
+        year_in_hours = get_next_standardized_reset_time("8760h", base_time, "UTC")
+        year_in_minutes = get_next_standardized_reset_time("525600m", base_time, "UTC")
+        year_in_seconds = get_next_standardized_reset_time("31536000s", base_time, "UTC")
+        self.assertEqual(year_in_days, year_in_hours)
+        self.assertEqual(year_in_days, year_in_minutes)
+        self.assertEqual(year_in_days, year_in_seconds)
+
     def test_timezone_handling(self):
         """Test timezone handling with different regions"""
         # Base time: 2023-05-15 22:30:00 UTC (late in UTC day)
@@ -105,17 +140,13 @@ class TestStandardizedResetTime(unittest.TestCase):
         # Europe/London (UTC+1): 11:30 PM, so next 15m reset is 11:45 PM
         london = ZoneInfo("Europe/London")
         london_expected = datetime(2023, 5, 15, 23, 45, 0, tzinfo=london)
-        london_result = get_next_standardized_reset_time(
-            "15m", base_time, "Europe/London"
-        )
+        london_result = get_next_standardized_reset_time("15m", base_time, "Europe/London")
         self.assertEqual(london_result, london_expected)
 
         # Test Bangkok timezone (UTC+7): 5:30 AM next day, so next reset is midnight the day after
         bangkok = ZoneInfo("Asia/Bangkok")
         bangkok_expected = datetime(2023, 5, 17, 0, 0, 0, tzinfo=bangkok)
-        bangkok_result = get_next_standardized_reset_time(
-            "1d", base_time, "Asia/Bangkok"
-        )
+        bangkok_result = get_next_standardized_reset_time("1d", base_time, "Asia/Bangkok")
         self.assertEqual(bangkok_result, bangkok_expected)
 
     def test_edge_cases(self):
@@ -137,16 +168,12 @@ class TestStandardizedResetTime(unittest.TestCase):
 
         # 30m near midnight - should roll over to next day
         midnight_minute_expected = datetime(2023, 5, 16, 0, 0, 0, tzinfo=timezone.utc)
-        midnight_minute_result = get_next_standardized_reset_time(
-            "30m", near_midnight, "UTC"
-        )
+        midnight_minute_result = get_next_standardized_reset_time("30m", near_midnight, "UTC")
         self.assertEqual(midnight_minute_result, midnight_minute_expected)
 
         # Invalid timezone - should fall back to UTC
         invalid_tz_expected = datetime(2023, 5, 16, 0, 0, 0, tzinfo=timezone.utc)
-        invalid_tz_result = get_next_standardized_reset_time(
-            "1d", on_hour, "NonExistentTimeZone"
-        )
+        invalid_tz_result = get_next_standardized_reset_time("1d", on_hour, "NonExistentTimeZone")
         self.assertEqual(invalid_tz_result, invalid_tz_expected)
 
     def test_iana_timezones_previously_unsupported(self):
@@ -164,17 +191,13 @@ class TestStandardizedResetTime(unittest.TestCase):
         sydney = ZoneInfo("Australia/Sydney")
         # At 15:00 UTC it's 01:00 AEST May 16 → next midnight is May 17 00:00 AEST
         sydney_expected = datetime(2023, 5, 17, 0, 0, 0, tzinfo=sydney)
-        sydney_result = get_next_standardized_reset_time(
-            "1d", base_time, "Australia/Sydney"
-        )
+        sydney_result = get_next_standardized_reset_time("1d", base_time, "Australia/Sydney")
         self.assertEqual(sydney_result, sydney_expected)
 
         # America/Chicago (UTC-5): at 15:00 UTC it's 10:00 CDT → next midnight is May 16 00:00 CDT
         chicago = ZoneInfo("America/Chicago")
         chicago_expected = datetime(2023, 5, 16, 0, 0, 0, tzinfo=chicago)
-        chicago_result = get_next_standardized_reset_time(
-            "1d", base_time, "America/Chicago"
-        )
+        chicago_result = get_next_standardized_reset_time("1d", base_time, "America/Chicago")
         self.assertEqual(chicago_result, chicago_expected)
 
     def test_dst_fall_back(self):
@@ -209,107 +232,77 @@ class TestResetTimeOfDay(unittest.TestCase):
 
     def test_daily_reset_before_offset_is_today(self):
         now = datetime(2023, 5, 15, 8, 0, 0, tzinfo=timezone.utc)
-        result = get_next_standardized_reset_time(
-            "1d", now, "UTC", reset_time_of_day=time(12, 0)
-        )
+        result = get_next_standardized_reset_time("1d", now, "UTC", reset_time_of_day=time(12, 0))
         self.assertEqual(result, datetime(2023, 5, 15, 12, 0, 0, tzinfo=timezone.utc))
 
     def test_daily_reset_after_offset_is_tomorrow(self):
         now = datetime(2023, 5, 15, 14, 0, 0, tzinfo=timezone.utc)
-        result = get_next_standardized_reset_time(
-            "1d", now, "UTC", reset_time_of_day=time(12, 0)
-        )
+        result = get_next_standardized_reset_time("1d", now, "UTC", reset_time_of_day=time(12, 0))
         self.assertEqual(result, datetime(2023, 5, 16, 12, 0, 0, tzinfo=timezone.utc))
 
     def test_daily_reset_exactly_at_offset_rolls_forward(self):
         now = datetime(2023, 5, 15, 12, 0, 0, tzinfo=timezone.utc)
-        result = get_next_standardized_reset_time(
-            "1d", now, "UTC", reset_time_of_day=time(12, 0)
-        )
+        result = get_next_standardized_reset_time("1d", now, "UTC", reset_time_of_day=time(12, 0))
         self.assertEqual(result, datetime(2023, 5, 16, 12, 0, 0, tzinfo=timezone.utc))
 
     def test_daily_reset_with_seconds_offset(self):
         now = datetime(2023, 5, 15, 8, 0, 0, tzinfo=timezone.utc)
-        result = get_next_standardized_reset_time(
-            "1d", now, "UTC", reset_time_of_day=time(9, 30, 15)
-        )
+        result = get_next_standardized_reset_time("1d", now, "UTC", reset_time_of_day=time(9, 30, 15))
         self.assertEqual(result, datetime(2023, 5, 15, 9, 30, 15, tzinfo=timezone.utc))
 
     def test_offset_applies_in_configured_timezone(self):
         # 2023-05-15 22:30 UTC == 2023-05-16 01:30 in Jerusalem (IDT, UTC+3),
         # so the next noon-Jerusalem reset is 2023-05-16 12:00 IDT.
         now = datetime(2023, 5, 15, 22, 30, 0, tzinfo=timezone.utc)
-        result = get_next_standardized_reset_time(
-            "1d", now, "Asia/Jerusalem", reset_time_of_day=time(12, 0)
-        )
+        result = get_next_standardized_reset_time("1d", now, "Asia/Jerusalem", reset_time_of_day=time(12, 0))
         jerusalem = result.astimezone(ZoneInfo("Asia/Jerusalem"))
-        self.assertEqual(
-            (jerusalem.year, jerusalem.month, jerusalem.day), (2023, 5, 16)
-        )
+        self.assertEqual((jerusalem.year, jerusalem.month, jerusalem.day), (2023, 5, 16))
         self.assertEqual(jerusalem.hour, 12)
         self.assertEqual(jerusalem.minute, 0)
 
     def test_weekly_reset_lands_on_monday_at_offset(self):
         wednesday = datetime(2023, 5, 17, 15, 45, 0, tzinfo=timezone.utc)
-        result = get_next_standardized_reset_time(
-            "7d", wednesday, "UTC", reset_time_of_day=time(12, 0)
-        )
+        result = get_next_standardized_reset_time("7d", wednesday, "UTC", reset_time_of_day=time(12, 0))
         self.assertEqual(result, datetime(2023, 5, 22, 12, 0, 0, tzinfo=timezone.utc))
 
     def test_weekly_reset_today_is_monday_before_offset_is_today(self):
         monday_morning = datetime(2023, 5, 22, 9, 0, 0, tzinfo=timezone.utc)
-        result = get_next_standardized_reset_time(
-            "7d", monday_morning, "UTC", reset_time_of_day=time(12, 0)
-        )
+        result = get_next_standardized_reset_time("7d", monday_morning, "UTC", reset_time_of_day=time(12, 0))
         self.assertEqual(result, datetime(2023, 5, 22, 12, 0, 0, tzinfo=timezone.utc))
 
     def test_weekly_reset_today_is_monday_after_offset_is_next_week(self):
         monday_afternoon = datetime(2023, 5, 22, 15, 0, 0, tzinfo=timezone.utc)
-        result = get_next_standardized_reset_time(
-            "7d", monday_afternoon, "UTC", reset_time_of_day=time(12, 0)
-        )
+        result = get_next_standardized_reset_time("7d", monday_afternoon, "UTC", reset_time_of_day=time(12, 0))
         self.assertEqual(result, datetime(2023, 5, 29, 12, 0, 0, tzinfo=timezone.utc))
 
     def test_monthly_30d_lands_on_first_at_offset(self):
         now = datetime(2023, 5, 15, 10, 30, 0, tzinfo=timezone.utc)
-        result = get_next_standardized_reset_time(
-            "30d", now, "UTC", reset_time_of_day=time(12, 0)
-        )
+        result = get_next_standardized_reset_time("30d", now, "UTC", reset_time_of_day=time(12, 0))
         self.assertEqual(result, datetime(2023, 6, 1, 12, 0, 0, tzinfo=timezone.utc))
 
     def test_monthly_1mo_today_is_first_before_offset_is_today(self):
         now = datetime(2023, 5, 1, 9, 0, 0, tzinfo=timezone.utc)
-        result = get_next_standardized_reset_time(
-            "1mo", now, "UTC", reset_time_of_day=time(12, 0)
-        )
+        result = get_next_standardized_reset_time("1mo", now, "UTC", reset_time_of_day=time(12, 0))
         self.assertEqual(result, datetime(2023, 5, 1, 12, 0, 0, tzinfo=timezone.utc))
 
     def test_monthly_year_rollover_at_offset(self):
         now = datetime(2023, 12, 15, 9, 0, 0, tzinfo=timezone.utc)
-        result = get_next_standardized_reset_time(
-            "1mo", now, "UTC", reset_time_of_day=time(12, 0)
-        )
+        result = get_next_standardized_reset_time("1mo", now, "UTC", reset_time_of_day=time(12, 0))
         self.assertEqual(result, datetime(2024, 1, 1, 12, 0, 0, tzinfo=timezone.utc))
 
     def test_custom_day_reset_applies_offset(self):
         now = datetime(2023, 5, 15, 10, 30, 0, tzinfo=timezone.utc)
-        result = get_next_standardized_reset_time(
-            "3d", now, "UTC", reset_time_of_day=time(12, 0)
-        )
+        result = get_next_standardized_reset_time("3d", now, "UTC", reset_time_of_day=time(12, 0))
         self.assertEqual(result, datetime(2023, 5, 18, 12, 0, 0, tzinfo=timezone.utc))
 
     def test_sub_day_durations_ignore_offset(self):
         base = datetime(2023, 5, 15, 15, 20, 30, tzinfo=timezone.utc)
         self.assertEqual(
-            get_next_standardized_reset_time(
-                "2h", base, "UTC", reset_time_of_day=time(12, 0)
-            ),
+            get_next_standardized_reset_time("2h", base, "UTC", reset_time_of_day=time(12, 0)),
             datetime(2023, 5, 15, 16, 0, 0, tzinfo=timezone.utc),
         )
         self.assertEqual(
-            get_next_standardized_reset_time(
-                "30m", base, "UTC", reset_time_of_day=time(12, 0)
-            ),
+            get_next_standardized_reset_time("30m", base, "UTC", reset_time_of_day=time(12, 0)),
             datetime(2023, 5, 15, 15, 30, 0, tzinfo=timezone.utc),
         )
 


### PR DESCRIPTION

_handle_hour_reset, _handle_minute_reset, and _handle_second_reset each hardcoded timedelta(days=1) when the aligned hour overflowed past 24, regardless of how many days the value actually spanned. A duration like "8760h" (365 days) landed 1 day out instead of 365, same for large "s"/"m" values. Resolves #17993.

<!-- The whole description's target audience is humans, not AI agents: write it in plain, simple,
     everyday engineering language, extremely parsable and readable at a glance. This goes double for
     the TLDR, User Flow, and Caveats sections -->

## TLDR

<!-- Fill in the bullets below and keep each one short and concrete: one line per bullet, roughly 10 words max -->

Problem this solves:

- <blah>
- ...

How it solves it:

- <blah>
- ...

## User Flow

<!-- Two ordered lists, Before and After, walking the same end user through the same task, written strictly from that user's seat
     Read the linked issue, ticket, or customer thread first so the flow reflects the real application and the routes its users actually hit; don't invent a generic scenario
     Lead each list with one plain sentence saying where the flow fails (Before) or succeeds (After), then number the steps
     Every step is something the user does or observes: the HTTP method and full URL they hit, what they sent, and what visibly came back (status code, error text, the shape of an ID). UI steps name the page URL and what is on screen
     No LiteLLM internals: never name functions, files, DB tables, config classes, hooks, callbacks, or code paths. "The upload hands back an ID that looks like OpenAI's own `file-abc123` instead of the scrambled one the gateway returned" is right, "no managed-file row was registered" is wrong
     Keep the two lists step-for-step identical until they diverge, so the changed step is obvious
     If the bug had a security or authorization consequence, end each list with what another user could or could no longer do
     Regenerate this section whenever new commits change the PR's behavior, so it never describes an older revision

Example:

Before: a developer whose app streams chat completions gets no token counts back, so their cost dashboard reads zero

1. They send POST https://litellm-domain/v1/chat/completions with `"stream": true` and no `stream_options`
2. The last SSE chunk arrives with `"usage": null`, so their app records 0 prompt and 0 completion tokens
3. They open https://litellm-domain/ui/?page=logs and see the request logged at $0 spend

After: the same request comes back with real token counts, so the dashboard shows real spend

1. The proxy admin sets `always_include_stream_usage: true` and restarts the proxy
2. The developer sends the same POST https://litellm-domain/v1/chat/completions with `"stream": true` and no `stream_options`
3. The last SSE chunk now carries a `usage` object with real prompt and completion token counts
4. https://litellm-domain/ui/?page=logs shows that request at non-zero spend
-->

## Relevant issues

<!-- e.g., "Fixes #000" -->

## Linear ticket

<!-- if you are an internal contributor, add "Resolves " followed by the Linear ticket e.g., "Resolves LIT-1234" to link the Linear ticket to the GitHub PR. If you don't have one, leave the section blank rather than guessing -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have added meaningful tests
- [ ] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [ ] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

<!-- Include screenshots, screen recordings, or command (e.g., curl) + output demonstrating that your changes work as expected
     The proof must be completely e2e with no mocks, using actual LLM calls costing real $$$ if applicable. `pytest` commands are not enough
     Show ONLY the latest run: capture Before at the merge base and After at the PR's current tip, and when new commits change behavior, replace this whole section with the fresh run instead of stacking it on top of older ones. The run must be up to date. As soon as a new commit is made and it makes this PR description's after sha stale (it's no longer tip of PR), you must re-run the QA
     Structure the section exactly as below: Before and After one heading level below this section, each naming the commit hash it was captured at, one lower-level heading per case inside each, the same case names in the same order on both sides, and numbered steps (command, observed output) under every case, never loose prose; shared setup (config, payloads) goes above Before, and with a single case, drop the case headings and number the steps directly

### Before (<hash>)

#### <case 1>

1. ...
2. ...

#### <case 2>

1. ...

### After (<hash>)

#### <case 1>

1. ...
2. ...

#### <case 2>

1. ...

     For bug fixes: Before shows the reproduction, After shows the same steps passing
     For new features: Before shows the capability missing, After shows it working end-to-end
     If the change applies to all three LLM endpoints (/v1/responses, /v1/chat/completions, /v1/messages), make each endpoint its own case, not just one
     For UI changes: before/after screenshots under the same headings -->

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
🐛 Bug Fix
🧹 Refactoring
📖 Documentation
🚄 Infrastructure
✅ Test

## Caveats (if any)

<!-- Group caveats under severity subheadings (### Severe, ### High, ### Medium, ### Low), with
     short bullet points inside each, just like the TLDR: one line per bullet, roughly 10 words max
     Call out known limitations, follow-up work, or anything a reviewer should watch out for
     Include only the tiers that have caveats; drop the empty ones
     - Severe: inherent to what the PR deliberately ships, there even when the code works as intended:
       it can degrade or take down a running deployment (e.g. a slow or table-locking boot migration),
       rewrite data by design, break an existing workflow on purpose, or change auth behavior. An
       operator must plan around it before rollout
     - High: an unintended hole: a correctness, security, data-loss, or backward-compatibility bug,
       unsafe to ship as is
     - Medium: a real gap someone can hit, but with a workaround or a narrow blast radius
     - Low: anything else worth noting: naming, cleanup, an edge case nobody hits
     Nest bullets as deep as helps: hierarchy beats one long line when it makes things clearer to a
     human reader
     Leave this section empty if there are none -->

## QA runbook

<!-- Only needed when your PR edits tests/e2e; delete this section otherwise

For each e2e test you added or changed, list the manual steps a reviewer can follow to reproduce it by hand against a live proxy, mapping 1:1 to what the test asserts: one top-level bullet per test giving its pytest node id followed by what it proves in plain words, then a nested "- [ ]" checklist where each item is a concrete action (route, request body, expected response) and the final item is the sanity-check step shown in the examples. Note environment prerequisites (provider credentials, config flags) and any nuances a manual run will hit. See PRs #32914 and #32963 for full examples

Example checklists:

- tests/e2e/quota_management/ratelimit/test_rate_limit_e2e.py::TestKeyRateLimits::test_rpm_limit_blocks_over_limit - a key allowed 2 requests a minute serves exactly 2 and refuses the 3rd
  - [ ] Generate a limited key: curl -X POST http://localhost:4000/key/generate -H "Authorization: Bearer sk-1234" -d '{"rpm_limit": 2}'
  - [ ] Send three /v1/chat/completions requests with that key inside one minute
  - [ ] Expect the first two to return 200 and the third to return 429 naming the rpm limit
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey (e.g., assert actual expected spend instead of just spend > 0) or potentially flaky

- tests/e2e/management/test_management_e2e.py::TestModelRoutes::test_model_create_appears_in_ui - a deployment created through the API shows up on the Admin UI models page
  - [ ] POST /model/new with the master key, a bedrock model, and aws_region_name (needs STORE_MODEL_IN_DB=True and AWS credentials)
  - [ ] Open http://localhost:4000/ui/?page=models and expect a deployment row showing the returned model id
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey (e.g., assert actual expected spend instead of just spend > 0) or potentially flaky
-->

## Final Attestation

- [ ] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
