### PR TITLE
fix(langfuse): warn and drop invalid LANGFUSE_TRACING_ENVIRONMENT instead of failing requests

### DIFF
--- a/litellm/integrations/langfuse/langfuse.py
+++ b/litellm/integrations/langfuse/langfuse.py
@@ -5,6 +5,7 @@ import os
 import traceback
 from collections.abc import Callable, Iterable, Mapping
 from datetime import datetime
+from functools import lru_cache
 from types import MappingProxyType
 from typing import TYPE_CHECKING, Any, Final, Literal, Protocol, cast
 
@@ -137,6 +138,16 @@ def resolve_langfuse_credentials(
     return public_key, secret_key, resolved_host
 
 
+@lru_cache(maxsize=8)
+def _warn_invalid_deployment_environment(raw_value: str, error: str) -> None:
+    verbose_logger.warning(
+        "Ignoring invalid LANGFUSE_TRACING_ENVIRONMENT=%r for the langfuse callback: %s. "
+        "Traces will be sent to Langfuse's default environment.",
+        raw_value,
+        error,
+    )
+
+
 class LangFuseLogger:
     # Class variables or attributes
     def __init__(
@@ -165,9 +176,11 @@ class LangFuseLogger:
             # add http:// if unset, assume communicating over private network - e.g. render
             self.langfuse_host = "http://" + self.langfuse_host
         _env_override: Final = str(langfuse_environment).strip() if langfuse_environment is not None else None
-        self.langfuse_environment = _env_override or os.getenv("LANGFUSE_TRACING_ENVIRONMENT")
-        if self.langfuse_environment:
-            validate_langfuse_environment_value(self.langfuse_environment)
+        if _env_override:
+            validate_langfuse_environment_value(_env_override)
+            self.langfuse_environment: str | None = _env_override
+        else:
+            self.langfuse_environment = self.resolve_deployment_environment()
         self.langfuse_release = os.getenv("LANGFUSE_RELEASE")
         self.langfuse_debug = os.getenv("LANGFUSE_DEBUG")
         self.langfuse_flush_interval = LangFuseLogger._get_langfuse_flush_interval(flush_interval)
@@ -952,6 +965,20 @@ class LangFuseLogger:
         except Exception as e:
             verbose_logger.warning("Failed to apply masking function: %s. Returning original data.", e)
             return data
+
+    @staticmethod
+    def resolve_deployment_environment() -> str | None:
+        """Resolve LANGFUSE_TRACING_ENVIRONMENT: stripped value, "default" plus a warning when invalid, None when unset."""
+        raw: Final = os.getenv("LANGFUSE_TRACING_ENVIRONMENT")
+        if not raw:
+            return None
+        value: Final = raw.strip()
+        try:
+            validate_langfuse_environment_value(value)
+        except ValueError as e:
+            _warn_invalid_deployment_environment(raw, str(e))
+            return "default"
+        return value
 
     @staticmethod
     def _get_langfuse_flush_interval(flush_interval: int) -> int:

--- a/litellm/integrations/langfuse/langfuse_handler.py
+++ b/litellm/integrations/langfuse/langfuse_handler.py
@@ -6,6 +6,7 @@ Used to get the LangFuseLogger for a given request
 Handles Key/Team Based Langfuse Logging
 """
 
+import os
 from typing import TYPE_CHECKING, Any, Final
 
 from litellm.litellm_core_utils.litellm_logging import StandardCallbackDynamicParams
@@ -155,7 +156,11 @@ class LangFuseHandler:
         if raw is None:
             return None
         value = str(raw).strip()
-        if not value or value == LangFuseLogger.resolve_deployment_environment():
+        if (
+            not value
+            or value == os.getenv("LANGFUSE_TRACING_ENVIRONMENT")
+            or value == LangFuseLogger.resolve_deployment_environment()
+        ):
             return None
         return value
 

--- a/litellm/integrations/langfuse/langfuse_handler.py
+++ b/litellm/integrations/langfuse/langfuse_handler.py
@@ -1,5 +1,3 @@
-import os
-
 """
 This file contains the LangFuseHandler class
 
@@ -157,7 +155,7 @@ class LangFuseHandler:
         if raw is None:
             return None
         value = str(raw).strip()
-        if not value or value == os.getenv("LANGFUSE_TRACING_ENVIRONMENT"):
+        if not value or value == LangFuseLogger.resolve_deployment_environment():
             return None
         return value
 

--- a/litellm/integrations/langfuse/langfuse_prompt_management.py
+++ b/litellm/integrations/langfuse/langfuse_prompt_management.py
@@ -2,6 +2,7 @@
 Call Hook for LiteLLM Proxy which allows Langfuse prompt management.
 """
 
+import inspect
 import os
 from functools import lru_cache
 from typing import TYPE_CHECKING, Any, Final, Literal, TypeAlias, cast
@@ -108,6 +109,9 @@ def langfuse_client_init(
             verify=get_ssl_configuration(),
             cert=os.getenv("SSL_CERTIFICATE", litellm.ssl_certificate),
         )
+
+    if "environment" in inspect.signature(Langfuse.__init__).parameters:
+        parameters["environment"] = LangFuseLogger.resolve_deployment_environment()
 
     client: Final = Langfuse(**parameters)
 

--- a/tests/test_litellm/integrations/langfuse/test_langfuse_prompt_management.py
+++ b/tests/test_litellm/integrations/langfuse/test_langfuse_prompt_management.py
@@ -1,4 +1,8 @@
+from types import MappingProxyType
+from typing import Final
 from unittest.mock import MagicMock, patch
+
+import pytest
 
 from litellm.integrations.langfuse.langfuse_prompt_management import (
     LangfusePromptManagement,
@@ -106,3 +110,30 @@ class TestLangfusePromptManagement:
             mock_get_ssl.assert_called_once()
 
         langfuse_client_init.cache_clear()
+
+
+class _RecordingLangfuseForEnv:
+    last_environment: str | None = None
+
+    def __init__(self, *, environment: str | None = None, **parameters: object) -> None:  # kwargs-ok: records only environment out of whatever langfuse_client_init forwards
+        type(self).last_environment = environment
+
+
+@pytest.mark.parametrize(
+    ("env_value", "expected"),
+    (("Production", "default"), ("production ", "production"), ("prod", "prod")),
+)
+def test_langfuse_client_init_resolves_deployment_environment(monkeypatch, env_value, expected):
+    mock_langfuse_module: Final = MagicMock()
+    mock_langfuse_module.version.__version__ = "2.60.0"
+    mock_langfuse_module.Langfuse = _RecordingLangfuseForEnv
+    monkeypatch.setenv("LANGFUSE_PUBLIC_KEY", "pk-test")
+    monkeypatch.setenv("LANGFUSE_SECRET_KEY", "sk-test")
+    monkeypatch.setenv("LANGFUSE_HOST", "https://test.langfuse.com")
+    monkeypatch.setenv("LANGFUSE_TRACING_ENVIRONMENT", env_value)
+    monkeypatch.setattr(_RecordingLangfuseForEnv, "last_environment", None)
+    with patch.dict("sys.modules", MappingProxyType({"langfuse": mock_langfuse_module})):
+        langfuse_client_init.cache_clear()
+        langfuse_client_init()
+    langfuse_client_init.cache_clear()
+    assert _RecordingLangfuseForEnv.last_environment == expected

--- a/tests/test_litellm/integrations/test_langfuse.py
+++ b/tests/test_litellm/integrations/test_langfuse.py
@@ -1527,6 +1527,11 @@ def test_langfuse_empty_environment_falls_back_and_is_not_dynamic(monkeypatch):
     stripped_redundant_params: Final = StandardCallbackDynamicParams(langfuse_environment="production")
     assert LangFuseHandler._dynamic_langfuse_credentials_are_passed(stripped_redundant_params) is False
 
+    # a dynamic value repeating the raw (even invalid) deployment value is redundant, not an override
+    monkeypatch.setenv("LANGFUSE_TRACING_ENVIRONMENT", "Production")
+    raw_redundant_params: Final = StandardCallbackDynamicParams(langfuse_environment="Production")
+    assert LangFuseHandler._dynamic_langfuse_credentials_are_passed(raw_redundant_params) is False
+
 
 @pytest.mark.parametrize(
     ("env_value", "expected"),

--- a/tests/test_litellm/integrations/test_langfuse.py
+++ b/tests/test_litellm/integrations/test_langfuse.py
@@ -3,7 +3,7 @@ import json
 import sys
 import types
 import unittest
-from typing import Optional
+from typing import Final, Optional
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -1521,3 +1521,31 @@ def test_langfuse_empty_environment_falls_back_and_is_not_dynamic(monkeypatch):
 
     params = StandardCallbackDynamicParams(langfuse_environment="team-a-prod")
     assert LangFuseHandler._dynamic_langfuse_credentials_are_passed(params) is True
+
+    # a dynamic value equal to the logger's effective (stripped) environment is redundant
+    monkeypatch.setenv("LANGFUSE_TRACING_ENVIRONMENT", "production ")
+    stripped_redundant_params: Final = StandardCallbackDynamicParams(langfuse_environment="production")
+    assert LangFuseHandler._dynamic_langfuse_credentials_are_passed(stripped_redundant_params) is False
+
+
+@pytest.mark.parametrize(
+    ("env_value", "expected"),
+    (
+        ("Production", "default"),
+        ("EU-Prod", "default"),
+        ("langfuse-prod", "default"),
+        ("   ", "default"),
+        ("production ", "production"),
+        ("prod", "prod"),
+    ),
+)
+def test_langfuse_deployment_environment_fallback_never_raises(monkeypatch, env_value, expected):
+    monkeypatch.setenv("LANGFUSE_MOCK", "true")
+    monkeypatch.setenv("LANGFUSE_TRACING_ENVIRONMENT", env_value)
+    monkeypatch.setattr(litellm, "initialized_langfuse_clients", 0)
+    logger: Final = LangFuseLogger(
+        langfuse_public_key="pk-env",
+        langfuse_secret="sk-env",
+        langfuse_host="https://test.langfuse.com",
+    )
+    assert logger.langfuse_environment == expected


### PR DESCRIPTION
## TLDR

Problem this solves:

- #38264 made an invalid `LANGFUSE_TRACING_ENVIRONMENT` fail the first request per worker with a 500
- After that 500, langfuse tracing stayed silently off for the rest of the process
- `/health/services?service=langfuse` also returned 500 on such deployments

How it solves it:

- The env var fallback now warns and uses Langfuse's default environment instead of raising
- Values that are valid after stripping whitespace are stripped and used
- Explicit per-key and per-team `langfuse_environment` values still fail fast with a 400 at save time
- The langfuse client behind the `success_callback: ["langfuse"]` route receives the resolved value too, so the SDK's own env var fallback cannot re-apply the invalid string

## User Flow

Before: an operator upgrading past #38264 with a legacy `LANGFUSE_TRACING_ENVIRONMENT=Production` sees requests fail and traces vanish

1. They run the proxy with `litellm_settings.success_callback: ["langfuse"]` and `LANGFUSE_TRACING_ENVIRONMENT=Production`
2. They send POST http://localhost:4000/v1/chat/completions and get HTTP 500 with "Invalid langfuse_environment 'Production': must be lowercase alphanumerics/hyphens/underscores..."
3. They retry and the second request returns 200 with a normal model answer
4. No traces ever reach Langfuse, and GET http://localhost:4000/health/services?service=langfuse returns the same 500

After: the same deployment serves every request and traces flow to the default environment

1. They run the proxy with the same config and the same env var
2. They send POST http://localhost:4000/v1/chat/completions and get 200 on the first try
3. The proxy log carries one warning naming the invalid value and saying traces go to Langfuse's default environment
4. Traces arrive in Langfuse under the default environment, and GET http://localhost:4000/health/services?service=langfuse returns 200

## Behavior changes

Invalid `LANGFUSE_TRACING_ENVIRONMENT` value: the first request per worker returned 500 and langfuse tracing was silently disabled afterwards; it now logs one warning at client init and delivers traces to Langfuse's default environment. This matches the request-time policy #38264's description declared (warn instead of failing the request) and keeps its save-time contract: `/key/update` and team callbacks with an invalid explicit `langfuse_environment` still return 400

Values valid only after stripping whitespace (for example `"production "`) previously raised on this route; the stripped value is now used and traces are tagged with it

The langfuse clients built by `langfuse_client_init` (used by the string callback route and prompt management) now receive the resolved environment explicitly. Before, the langfuse SDK read the raw env var itself (`environment or os.environ.get("LANGFUSE_TRACING_ENVIRONMENT")` in its constructor) and its own client-side validation then logged an error and ignored the setting, so those traces landed untagged in the default environment. A live probe of cloud.langfuse.com confirms the server does not reject such values either: raw ingestion-API events carrying Production are stored lowercased as production, and unparseable shapes fall back to default, so the warn-and-drop path here produces the same destination the SDK already chose while making it visible in the proxy log

Whitespace-only values (previously a 500 via the same raise) now warn and use the default environment; an exactly-empty value keeps its merge-base behavior

The per-request dedup in the langfuse handler now treats a dynamic `langfuse_environment` as redundant when it equals either the raw `LANGFUSE_TRACING_ENVIRONMENT` value or the resolved deployment value. Comparing against the raw value keeps a per-key value that merely repeats an invalid deployment value out of the dynamic-credentials path, where it previously reached the logger constructor's strict validation and raised inside logging, dropping that request's trace. Comparing against the resolved value means an override equal to the effective environment no longer mints a duplicate SDK client (each client costs a thread and counts against the client cap)

The invalid-value warning is emitted once per distinct value per process instead of once per constructed client

Valid values, unset values, and explicit per-key/team values behave as before

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Shared setup: proxy on port 44264 with one real Gemini model (real API calls, real cost), Postgres, and `litellm_settings.success_callback: ["langfuse"]`. The langfuse destination is a local capture sink (a ThreadingHTTPServer that prints every ingestion POST body and serves a stub `/api/public/projects` for the SDK auth check) so the exact delivered events can be shown; the LLM legs hit the real Gemini API

```yaml
model_list:
  - model_name: gemini-flash
    litellm_params:
      model: gemini/gemini-3.7-flash
      api_key: os.environ/GEMINI_API_KEY

litellm_settings:
  success_callback: ["langfuse"]

general_settings:
  master_key: sk-t38264-master
```

```bash
export LANGFUSE_PUBLIC_KEY="pk-t38264" LANGFUSE_SECRET_KEY="sk-t38264" LANGFUSE_HOST="http://127.0.0.1:45680"
```

### Before (7083c47998)

#### Invalid env value: first chat completion

1. `LANGFUSE_TRACING_ENVIRONMENT=Production`, then `curl -sS -w '\nHTTP_STATUS:%{http_code}\n' http://127.0.0.1:44264/v1/chat/completions -H "Authorization: Bearer sk-t38264-master" -H "Content-Type: application/json" -d '{"model": "gemini-flash", "messages": [{"role": "user", "content": "Reply with exactly: base-run-1"}]}'`
2. Observed:

```
{"error":{"message":"Invalid langfuse_environment 'Production': must be lowercase alphanumerics/hyphens/underscores and must not start with 'langfuse' (pattern ^(?!langfuse)[a-z0-9-_]+$)","type":"None","param":"None","code":"500"}}
HTTP_STATUS:500
```

#### Invalid env value: second chat completion and langfuse delivery

1. Same curl again with `"Reply with exactly: base-run-2"`
2. Observed: HTTP 200 with `"content":"base-run-2"` in the response body
3. `grep -c "SINK POST" /tmp/t38264-sink.log` after the flush interval: `0` ingestion requests ever reach langfuse, traces are silently lost

#### Invalid env value: /health/services?service=langfuse

1. `curl -sS -w '\nHTTP_STATUS:%{http_code}\n' "http://127.0.0.1:44264/health/services?service=langfuse" -H "Authorization: Bearer sk-t38264-master"`
2. Observed:

```
{"error":{"message":"Authentication Error, Invalid langfuse_environment 'Production': must be lowercase alphanumerics/hyphens/underscores and must not start with 'langfuse' (pattern ^(?!langfuse)[a-z0-9-_]+$)","type":"auth_error","param":"None","code":"500"}}
HTTP_STATUS:500
```

#### Valid env value and per-key langfuse_environment

1. Restart with `LANGFUSE_TRACING_ENVIRONMENT=prod`, send one completion: HTTP 200 and the sink shows every event with `"environment": "prod"`
2. `curl -sS http://127.0.0.1:44264/key/generate -H "Authorization: Bearer sk-t38264-master" -d '{"key_alias": "t38264-perkey-base"}'` returns a key
3. `/key/update` on that key with `callback_vars.langfuse_environment: "Bad Value"`: observed `{"error":{"message":"{'error': \"Invalid langfuse_environment 'Bad Value': ...\"}","code":"400"}}` with HTTP_STATUS:400
4. `/key/update` with `langfuse_environment: "key-env"`: HTTP_STATUS:200
5. Completion with that key: HTTP 200 and the sink now also shows events with `"environment": "key-env"`

#### Empty env value

1. Restart with `LANGFUSE_TRACING_ENVIRONMENT=""`, send one completion
2. Observed: HTTP 200, 1 ingestion POST, events carry `"environment": ""`, 0 env-var log lines

#### Whitespace and trailing-space env values

1. Restart with `LANGFUSE_TRACING_ENVIRONMENT="  "` (whitespace only), send one completion
2. Observed:

```
{"error":{"message":"Invalid langfuse_environment '  ': must be lowercase alphanumerics/hyphens/underscores and must not start with 'langfuse' (pattern ^(?!langfuse)[a-z0-9-_]+$)","type":"None","param":"None","code":"500"}}
HTTP_STATUS:500
```

3. `LANGFUSE_TRACING_ENVIRONMENT="production "` (trailing space) raises the same 500 through the same validator; sink shows 0 ingestion POSTs either way

### After (875df9fe5c)

The proxy cases below were captured at the first fix commit (pre-rebase sha 9684bb0867, identical content to 73d2462b8b); the dynamic override case at the end was captured at the current head 875df9fe5c

#### Invalid env value: first chat completion

1. `LANGFUSE_TRACING_ENVIRONMENT=Production`, same curl with `"Reply with exactly: fix-final-1"`
2. Observed: HTTP 200 on the very first request, response contains `"content": "fix-final-1"` from the real Gemini call
3. Proxy log carries exactly one warning:

```
Ignoring invalid LANGFUSE_TRACING_ENVIRONMENT='Production' for the langfuse callback: Invalid langfuse_environment 'Production': must be lowercase alphanumerics/hyphens/underscores and must not start with 'langfuse' (pattern ^(?!langfuse)[a-z0-9-_]+$). Traces will be sent to Langfuse's default environment.
```

#### Invalid env value: second chat completion and langfuse delivery

1. Same curl again with `"Reply with exactly: fix-final-2"`: HTTP 200
2. The sink receives the ingestion POST; every event carries `"environment": "default"`, the invalid value never reaches langfuse:

```
ingestion POSTs: 1
   1         "environment": "default"
   1         "environment": "default",
```

#### Invalid env value: /health/services?service=langfuse

1. Same health curl
2. Observed:

```
{"status":"success","message":"Mock LLM request made - check langfuse."}
HTTP_STATUS:200
```

#### Valid env value and per-key langfuse_environment

1. Restart with `LANGFUSE_TRACING_ENVIRONMENT=prod`, send one completion: HTTP 200 and the sink shows every event with `"environment": "prod"`
2. `/key/generate` returns a key
3. `/key/update` with `callback_vars.langfuse_environment: "Bad Value"`: observed the same 400 as before the change (save-time validation intact)
4. `/key/update` with `langfuse_environment: "key-env"`: HTTP_STATUS:200
5. Completion with that key: HTTP 200 and the sink shows events with `"environment": "key-env"`

#### Empty env value

1. Restart with `LANGFUSE_TRACING_ENVIRONMENT=""`, send one completion
2. Observed: HTTP 200, 1 ingestion POST, events carry `"environment": ""`, 0 warning lines, identical to the merge base

#### Whitespace and trailing-space env values

1. Restart with `LANGFUSE_TRACING_ENVIRONMENT="  "` (whitespace only), send one completion
2. Observed: HTTP 200, one warning `Ignoring invalid LANGFUSE_TRACING_ENVIRONMENT='  ' for the langfuse callback`, 1 ingestion POST, events carry `"environment": "default"`
3. Restart with `LANGFUSE_TRACING_ENVIRONMENT="production "` (trailing space), send one completion: HTTP 200 and events carry `"environment": "production"` (stripped)
4. `/key/update` a key with `callback_vars.langfuse_environment: "production"` (equal to the stripped value) and send a completion with it: HTTP 200, still exactly 1 `Created langfuse client` line in the proxy log, so the redundant override mints no duplicate SDK client

#### Dynamic langfuse_environment repeating the invalid deployment value

1. Driven through the library route because the proxy rejects a request-body `langfuse_environment` with a 401 unless the admin opts into clientside credentials: `LANGFUSE_TRACING_ENVIRONMENT=Production`, `litellm.success_callback = ["langfuse"]`, then `litellm.completion(..., langfuse_environment="Production")`
2. Before the second commit the dedup compared only the resolved value, so the repeated raw value counted as a dynamic override, reached the logger constructor's strict validation, and raised `ValueError: Invalid langfuse_environment 'Production'` inside the logging path; the sink received 0 ingestion POSTs and that trace was dropped
3. At 875df9fe5c the same call completes with no error, the sink ingestion count rises from 0 to 1, and every delivered event carries `"environment": "default"`
4. Also confirmed through the proxy surface at 875df9fe5c with `general_settings.allow_client_side_credentials: true` and `"langfuse_environment": "Production"` in the request body: HTTP 200, the trace is delivered tagged `"default"`, no ValueError and no extra SDK client. A raw invalid value stored in key-level `callback_vars` never reaches this code path because the pre-existing guard in `litellm_pre_call_utils.py` drops invalid key-level callback metadata with a warning

## Type

🐛 Bug Fix

## Caveats

### Low

- An empty env var value still reaches events as an empty `environment` field, identical to the behavior at the merge base
- `langfuse_otel` reads the same env var independently and is out of scope here

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

