### PR TITLE
fix(router): copy instead of mutating caller metadata when scrubbing fallback stamp keys

### DIFF
--- a/litellm/router.py
+++ b/litellm/router.py
@@ -6982,9 +6982,13 @@ class Router:
             _sibling_metadata_key: Final = (
                 "metadata" if _fallback_metadata_key == "litellm_metadata" else "litellm_metadata"
             )
-            if isinstance(_sibling_metadata := kwargs.get(_sibling_metadata_key), dict):
-                _sibling_metadata.pop("attempted_fallbacks", None)
-                _sibling_metadata.pop("original_model_group", None)
+            if isinstance(_sibling_metadata := kwargs.get(_sibling_metadata_key), dict) and (
+                "attempted_fallbacks" in _sibling_metadata or "original_model_group" in _sibling_metadata
+            ):
+                _scrubbed_sibling_metadata: Final = _sibling_metadata.copy()
+                _scrubbed_sibling_metadata.pop("attempted_fallbacks", None)
+                _scrubbed_sibling_metadata.pop("original_model_group", None)
+                kwargs[_sibling_metadata_key] = _scrubbed_sibling_metadata
             if isinstance(_fallback_metadata := kwargs.get(_fallback_metadata_key), dict):
                 _fallback_metadata["attempted_fallbacks"] = 0
                 if model_group is not None:

--- a/litellm/router_utils/fallback_event_handlers.py
+++ b/litellm/router_utils/fallback_event_handlers.py
@@ -375,12 +375,14 @@ async def run_async_fallback(
             elif isinstance(mg, dict):
                 kwargs.update(mg)
             fallback_depth = fallback_depth + 1
-            kwargs[metadata_variable_name] = {
-                "original_model_group": original_model_group,
-                **(kwargs.get(metadata_variable_name) or {}),
-                "model_group": kwargs.get("model", None),
-                "attempted_fallbacks": fallback_depth,
-            }
+            _hop_metadata = dict(kwargs.get(metadata_variable_name) or {})
+            _original_model_group_stamp = _hop_metadata.pop("original_model_group", original_model_group)
+            _hop_metadata.pop("model_group", None)
+            _hop_metadata.pop("attempted_fallbacks", None)
+            _hop_metadata["original_model_group"] = _original_model_group_stamp
+            _hop_metadata["model_group"] = kwargs.get("model", None)
+            _hop_metadata["attempted_fallbacks"] = fallback_depth
+            kwargs[metadata_variable_name] = _hop_metadata
             kwargs["fallback_depth"] = fallback_depth
             kwargs["max_fallbacks"] = max_fallbacks
             kwargs["attempted_targets"] = attempted

--- a/tests/test_litellm/test_router.py
+++ b/tests/test_litellm/test_router.py
@@ -1,5 +1,6 @@
 import asyncio
 import copy
+import functools
 import json
 import logging
 import os
@@ -7,6 +8,7 @@ import threading
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
+import openai
 import pytest
 
 
@@ -10595,11 +10597,26 @@ async def test_async_function_with_fallbacks_skips_stamp_on_genuine_reentrant_ho
     assert metadata["original_model_group"] == "prod-chat"
 
 
+def _record_router_acompletion_kwargs(router: litellm.Router) -> list:
+    """Spy on router._acompletion, recording each call's kwargs while delegating through."""
+    records = []
+    original_acompletion = router._acompletion
+
+    @functools.wraps(original_acompletion)
+    async def _spy(*args, **spy_kwargs):
+        records.append(spy_kwargs)
+        return await original_acompletion(*args, **spy_kwargs)
+
+    router._acompletion = _spy
+    return records
+
+
 @pytest.mark.asyncio
 async def test_async_function_with_fallbacks_scrubs_spoofed_values_from_sibling_bucket():
     """Spend logs read a truthy litellm_metadata dict in preference to metadata, so spoofed
-    stamp keys planted in the bucket the route does not own are removed on entry instead of
-    flowing into the spend log row."""
+    stamp keys planted in the bucket the route does not own are removed from the request's
+    downstream view on entry instead of flowing into the spend log row. The caller's own
+    dict object is never mutated: the scrub replaces the kwargs entry with a cleaned copy."""
     router = litellm.Router(
         model_list=[
             {
@@ -10614,6 +10631,7 @@ async def test_async_function_with_fallbacks_scrubs_spoofed_values_from_sibling_
         "original_model_group": "spoofed-group",
         "client_key": "client_value",
     }
+    downstream_calls = _record_router_acompletion_kwargs(router)
 
     await router.acompletion(
         model="gpt-3.5-turbo",
@@ -10622,11 +10640,206 @@ async def test_async_function_with_fallbacks_scrubs_spoofed_values_from_sibling_
         litellm_metadata=litellm_metadata,
     )
 
-    assert "attempted_fallbacks" not in litellm_metadata
-    assert "original_model_group" not in litellm_metadata
-    assert litellm_metadata["client_key"] == "client_value"
+    assert len(downstream_calls) == 1
+    downstream_sibling = downstream_calls[0]["litellm_metadata"]
+    assert "attempted_fallbacks" not in downstream_sibling
+    assert "original_model_group" not in downstream_sibling
+    assert downstream_sibling["client_key"] == "client_value"
+    assert litellm_metadata == {
+        "attempted_fallbacks": 99,
+        "original_model_group": "spoofed-group",
+        "client_key": "client_value",
+    }
     assert metadata["attempted_fallbacks"] == 0
     assert metadata["original_model_group"] == "gpt-3.5-turbo"
+
+
+@pytest.mark.asyncio
+async def test_async_function_with_fallbacks_leaves_caller_sibling_dict_object_untouched():
+    """The sibling-bucket scrub hands downstream a cleaned copy and never edits the dict
+    object the caller passed in: callers reuse metadata dicts across requests, and logging
+    callbacks observe the caller's object."""
+    router = litellm.Router(
+        model_list=[
+            {
+                "model_name": "gpt-3.5-turbo",
+                "litellm_params": {"model": "gpt-3.5-turbo", "mock_response": "hi"},
+            }
+        ]
+    )
+    litellm_metadata = {
+        "attempted_fallbacks": 7,
+        "original_model_group": "planted-group",
+        "client_key": "client_value",
+    }
+    caller_snapshot = copy.deepcopy(litellm_metadata)
+    downstream_calls = _record_router_acompletion_kwargs(router)
+
+    await router.acompletion(
+        model="gpt-3.5-turbo",
+        messages=[{"role": "user", "content": "hey"}],
+        metadata={},
+        litellm_metadata=litellm_metadata,
+    )
+
+    assert len(downstream_calls) == 1
+    assert downstream_calls[0]["litellm_metadata"] is not litellm_metadata
+    assert litellm_metadata == caller_snapshot
+
+
+@pytest.mark.asyncio
+async def test_async_function_with_fallbacks_passes_clean_sibling_bucket_through_unchanged():
+    """A sibling bucket carrying no reserved stamp keys is forwarded downstream as the
+    caller's own object with no copy made, matching pre-scrub behavior. Retry accounting
+    stamped into that bucket downstream predates the scrub and is out of its scope."""
+    router = litellm.Router(
+        model_list=[
+            {
+                "model_name": "gpt-3.5-turbo",
+                "litellm_params": {"model": "gpt-3.5-turbo", "mock_response": "hi"},
+            }
+        ]
+    )
+    litellm_metadata = {"client_key": "client_value"}
+    downstream_calls = _record_router_acompletion_kwargs(router)
+
+    await router.acompletion(
+        model="gpt-3.5-turbo",
+        messages=[{"role": "user", "content": "hey"}],
+        metadata={},
+        litellm_metadata=litellm_metadata,
+    )
+
+    assert len(downstream_calls) == 1
+    assert downstream_calls[0]["litellm_metadata"] is litellm_metadata
+    assert litellm_metadata["client_key"] == "client_value"
+    assert "attempted_fallbacks" not in litellm_metadata
+    assert "original_model_group" not in litellm_metadata
+
+
+@pytest.mark.asyncio
+async def test_run_async_fallback_keeps_caller_metadata_keys_on_the_wire(monkeypatch):
+    """Under enable_preview_features, add_openai_metadata forwards only the first 16
+    string pairs of request metadata to the provider body, so the fallback hop must
+    spread caller keys before the router's own stamps: a stamp inserted first evicts
+    the caller's 16th key from the wire while the internal stamp rides in its place."""
+    monkeypatch.setattr(litellm, "enable_preview_features", True)
+    caller_metadata = {f"user_key_{i}": f"value_{i}" for i in range(16)}
+    router = litellm.Router(
+        model_list=[
+            {
+                "model_name": "primary-group",
+                "litellm_params": {"model": "gpt-3.5-turbo", "api_key": "sk-test"},
+            },
+            {
+                "model_name": "fallback-group",
+                "litellm_params": {"model": "gpt-3.5-turbo", "api_key": "sk-test"},
+            },
+        ],
+        fallbacks=[{"primary-group": ["fallback-group"]}],
+        num_retries=0,
+    )
+
+    wire_bodies = []
+
+    def _respond(request: httpx.Request) -> httpx.Response:
+        wire_bodies.append(json.loads(request.content))
+        return httpx.Response(
+            200,
+            json={
+                "id": "chatcmpl-wire",
+                "object": "chat.completion",
+                "created": 1,
+                "model": "gpt-3.5-turbo",
+                "choices": [{"index": 0, "message": {"role": "assistant", "content": "ok"}, "finish_reason": "stop"}],
+                "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+            },
+        )
+
+    client = openai.AsyncOpenAI(
+        api_key="sk-test",
+        http_client=httpx.AsyncClient(transport=httpx.MockTransport(_respond)),
+    )
+
+    await router.acompletion(
+        model="primary-group",
+        messages=[{"role": "user", "content": "hey"}],
+        metadata=dict(caller_metadata),
+        mock_testing_fallbacks=True,
+        client=client,
+    )
+
+    assert len(wire_bodies) == 1
+    assert wire_bodies[0]["metadata"] == caller_metadata
+
+    wire_bodies.clear()
+    small_metadata = {"team": "alpha", "env": "prod"}
+    await router.acompletion(
+        model="primary-group",
+        messages=[{"role": "user", "content": "hey again"}],
+        metadata=dict(small_metadata),
+        mock_testing_fallbacks=True,
+        client=client,
+    )
+
+    assert len(wire_bodies) == 1
+    small_wire = wire_bodies[0]["metadata"]
+    assert {k: small_wire[k] for k in small_metadata} == small_metadata
+    assert small_wire["original_model_group"] == "primary-group"
+    assert small_wire["model_group"] == "fallback-group"
+
+
+@pytest.mark.asyncio
+async def test_run_async_fallback_two_hop_chain_reports_entry_group_and_hop_count():
+    """A two-hop fallback chain stamps attempted_fallbacks=2 on the final leg and keeps
+    original_model_group at the group requested on entry: a later hop's stamp appends
+    after caller keys without overriding the value stamped by an earlier hop."""
+    router = litellm.Router(
+        model_list=[
+            {
+                "model_name": "group-a",
+                "litellm_params": {"model": "gpt-3.5-turbo", "mock_response": "litellm.InternalServerError"},
+            },
+            {
+                "model_name": "group-b",
+                "litellm_params": {"model": "gpt-3.5-turbo", "mock_response": "litellm.InternalServerError"},
+            },
+            {
+                "model_name": "group-c",
+                "litellm_params": {"model": "gpt-3.5-turbo", "mock_response": "ok"},
+            },
+        ],
+        fallbacks=[{"group-a": ["group-b"]}, {"group-b": ["group-c"]}],
+        num_retries=0,
+    )
+    metadata = {}
+    leg_records = []
+    original_acompletion = router._acompletion
+
+    @functools.wraps(original_acompletion)
+    async def _spy(*args, **spy_kwargs):
+        leg_records.append((spy_kwargs.get("model"), copy.deepcopy(spy_kwargs.get("metadata"))))
+        return await original_acompletion(*args, **spy_kwargs)
+
+    router._acompletion = _spy
+
+    await router.acompletion(
+        model="group-a",
+        messages=[{"role": "user", "content": "hey"}],
+        metadata=metadata,
+    )
+
+    assert [model for model, _ in leg_records] == ["group-a", "group-b", "group-c"]
+    hop_one_metadata = leg_records[1][1]
+    assert hop_one_metadata["attempted_fallbacks"] == 1
+    assert hop_one_metadata["original_model_group"] == "group-a"
+    assert hop_one_metadata["model_group"] == "group-b"
+    hop_two_metadata = leg_records[2][1]
+    assert hop_two_metadata["attempted_fallbacks"] == 2
+    assert hop_two_metadata["original_model_group"] == "group-a"
+    assert hop_two_metadata["model_group"] == "group-c"
+    assert metadata["attempted_fallbacks"] == 0
+    assert metadata["original_model_group"] == "group-a"
 
 
 def _permission_denied_error() -> litellm.PermissionDeniedError:


### PR DESCRIPTION
## TLDR

Problem this solves (two side effects of #38107's fallback stamping):

- The sibling-bucket scrub popped keys out of the caller's own metadata dict
- The fallback stamp sat at dict index 0, evicting a caller key from the outbound body

How it solves it:

- Scrub now hands downstream a scrubbed copy; the caller's object is untouched
- Fallback hops append router stamps after caller keys, values unchanged

## User Flow

Before: an SDK user calling the router with metadata on a model group that falls back gets their own dict corrupted, and one of their metadata keys never reaches the provider

1. They call `router.acompletion(..., litellm_metadata={...})` with a dict that happens to carry keys named `attempted_fallbacks` or `original_model_group` next to their own keys
2. When the call returns, those entries have vanished from their own dict, so the next request they send with the same dict silently carries different metadata
3. With `enable_preview_features` on, they send 16 metadata keys on a request that falls back; the provider receives `user_key_0` through `user_key_14` plus a router-internal `original_model_group`, and `user_key_15` never arrives

After: the same calls leave the caller's dict alone and deliver every caller key

1. The same `router.acompletion` call returns and their dict still holds exactly the entries they put in it
2. The same 16-key fallback request delivers all 16 caller keys to the provider and no router-internal key
3. Spend logs still record the real `attempted_fallbacks` count and the originally requested model group, and planted values in either metadata bucket still read back corrected

## Relevant issues

Follow-up to #38107, which introduced the fallback stamps, the sibling-bucket scrub, and the spend-log plumbing this PR keeps intact

## Linear ticket

## Behavior changes

The caller's `metadata` / `litellm_metadata` dict object is no longer edited in place when the sibling-bucket scrub fires. Downstream still sees the scrubbed view, so the spend-log anti-spoof from #38107 is unchanged: planted `attempted_fallbacks` / `original_model_group` values in the bucket the route does not own still never reach spend rows

On fallback hops the router stamps (`original_model_group`, `model_group`, `attempted_fallbacks`) now append after the caller's metadata keys instead of `original_model_group` leading the dict. `add_openai_metadata` keeps only the first 16 string pairs for the outbound body under `litellm.enable_preview_features`, so the budget is spent on caller keys first. Values are unchanged: `original_model_group` keeps the earliest stamped value across chained hops (a two-hop chain still reports the entry group), `model_group` and `attempted_fallbacks` keep stamp-wins semantics

One deliberate consequence of the no-mutation contract: on the proxy, `request_data` and the router kwargs share the same bucket objects, so the base code's in-place pops also happened to strip planted stamp keys from the proxy's own request dict. With the copy, a post-call reader of `request_data["litellm_metadata"]` (alerting payloads, guardrail vendor context) sees the request exactly as the client sent it. Nothing in the repo branches on those two keys from that dict, and every logging, spend, and policy path downstream of the router reads the scrubbed view; pre-call hooks always saw the raw client values on both sides

One #38107 test was reconciled: `test_async_function_with_fallbacks_scrubs_spoofed_values_from_sibling_bucket` asserted the in-place pop on the caller's dict, which is the defect itself rather than the declared spoof defense. It now asserts the scrub on what downstream receives (via a spy on `router._acompletion`) plus the caller's dict staying unmutated. The other #38107 stamp tests pass unmodified

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Rig: proxy launched from each tree on port 44107 with Postgres attached, `enable_preview_features: true`, real Gemini deployments (`gemini/gemini-3.7-flash`, spend costs real money) plus deliberately invalid Gemini model names to force real fallbacks. OpenAI has no funded key, so the two OpenAI-shaped groups point at a local OpenAI-compatible sink (a stdlib `ThreadingHTTPServer` that logs every request body verbatim and answers a canned completion; `fail-model` answers 500 to force the fallback). The wire captures below therefore show the sink legs; every completion, fallback, and spend-log leg is real Gemini. The two SDK cases run this snippet in-process against each tree, because both defects are SDK-visible (the proxy nests client metadata under `requester_metadata`, which shields the proxy body path; shown as case 4)

```python
caller = {"attempted_fallbacks": 99, "original_model_group": "spoofed-group", "client_key": "client_value"}
before = copy.deepcopy(caller)
await router.acompletion(model="gemini-flash", messages=[...], metadata={}, litellm_metadata=caller)
print("caller dict unchanged:", before == caller)
```

and for the wire case sends `metadata={f"user_key_{i}": f"v{i}" for i in range(16)}` on a `sink-primary -> sink-fallback` fallback, then reads the sink's request log

### Before (44d84360fb)

#### Case 1: caller metadata dict across an SDK call (real Gemini)

1. Run the snippet above from the base tree
2. Observed:

```
caller litellm_metadata before: {"attempted_fallbacks": 99, "client_key": "client_value", "original_model_group": "spoofed-group"}
caller litellm_metadata after : {"attempted_retries": 0, "client_key": "client_value", "max_retries": 0}
caller dict unchanged: False
```

#### Case 2: 16 caller metadata keys on a fallback, outbound body (local sink)

1. Run the SDK wire snippet from the base tree, then read the sink's captured body
2. Observed: the router's stamp rides in the caller's 16th slot

```
wire metadata key count: 16
user_key_15 on wire: False
original_model_group on wire: True
```

#### Case 3: fallback spend attribution through the proxy (real Gemini)

1. `curl -sS -D - http://127.0.0.1:44107/v1/chat/completions -H 'Authorization: Bearer sk-38107' -d '{"model":"gemini-flash","messages":[{"role":"user","content":"say before2-plain"}]}'` and the same for `gemini-onehop-bad` (falls back once), `gemini-twohop-bad` (falls back twice), and a spoof attempt carrying `"metadata":{"attempted_fallbacks":99,"original_model_group":"spoofed-group",...},"litellm_metadata":{"attempted_fallbacks":77,"original_model_group":"spoofed-sibling"}`
2. All four return 200 with `x-litellm-attempted-fallbacks: 0|1|1|0` respectively
3. Spend rows (`SELECT model_group, metadata->>'attempted_fallbacks', metadata->>'original_model_group' FROM "LiteLLM_SpendLogs"`):

```
 plain   | gemini-flash | 0 | gemini-flash
 onehop  | gemini-flash | 1 | gemini-onehop-bad
 twohop  | gemini-flash | 2 | gemini-twohop-bad
 spoof   | gemini-flash | 0 | gemini-flash        <- planted 99/77 and spoofed groups corrected
```

#### Case 4: 16 metadata keys through the proxy body (local sink)

1. Same 16-key metadata payload as case 2 but sent through the proxy against `sink-primary`
2. Observed: 200 with `x-litellm-attempted-fallbacks: 1`; sink body carries all 16 keys (the proxy nests client metadata under `requester_metadata`, so this path was already immune)

### After (6880e3d846)

#### Case 1: caller metadata dict across an SDK call (real Gemini)

1. Run the snippet above from this branch
2. Observed:

```
caller litellm_metadata before: {"attempted_fallbacks": 99, "client_key": "client_value", "original_model_group": "spoofed-group"}
caller litellm_metadata after : {"attempted_fallbacks": 99, "client_key": "client_value", "original_model_group": "spoofed-group"}
caller dict unchanged: True
```

#### Case 2: 16 caller metadata keys on a fallback, outbound body (local sink)

1. Run the SDK wire snippet from this branch, then read the sink's captured body
2. Observed: all 16 caller keys, no router stamp

```
wire metadata key count: 16
user_key_15 on wire: True
original_model_group on wire: False
```

#### Case 3: fallback spend attribution through the proxy (real Gemini)

1. Identical four curls as Before (markers `after2-*`)
2. All four return 200 with the same `x-litellm-attempted-fallbacks` headers
3. Spend rows are identical to Before, byte for byte:

```
 plain   | gemini-flash | 0 | gemini-flash
 onehop  | gemini-flash | 1 | gemini-onehop-bad
 twohop  | gemini-flash | 2 | gemini-twohop-bad
 spoof   | gemini-flash | 0 | gemini-flash        <- spoof still corrected, scrub semantics intact
```

#### Case 4: 16 metadata keys through the proxy body (local sink)

1. Identical request as Before
2. Observed: identical result, 200 with all 16 keys on the sink body

## Type

🐛 Bug Fix

## Caveats (if any)

### Low

- Pre-existing from #38107: a truthy caller `litellm_metadata` wins the spend read and only `user_api_key*` keys merge over from `metadata`, so fallback stamps are absent from such spend rows (observed identically on both sides, before and after)
- Retry accounting (`attempted_retries`, `max_retries`) still writes into the caller's sibling dict when no reserved keys triggered the copy; pre-existing and out of scope
- The route-owned bucket is still stamped in place on entry (`attempted_fallbacks=0`, `original_model_group`), the designed #38107 behavior that its tests pin; this PR only stops the sibling-bucket scrub from editing the caller's object
- With 15 or more caller string metadata keys on a fallback leg, the router stamps now fall off the 16-pair provider body budget instead of a caller key; caller keys win by design, and the new wire test pins stamps still present when room remains
- On a two-hop chain the `x-litellm-attempted-fallbacks` response header reports the outer hop (1) while spend metadata records the true 2; pre-existing on both sides

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
