### PR TITLE
chore(proxy): resync the generated API artifacts with the current models

### DIFF
--- a/litellm/proxy/_lazy_openapi_snapshot.json
+++ b/litellm/proxy/_lazy_openapi_snapshot.json
@@ -10238,6 +10238,18 @@
               "description": "AWS Bedrock runtime endpoint URL",
               "title": "Aws Bedrock Runtime Endpoint"
             },
+            "aws_external_id": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "External ID required by the target role's trust policy on sts:AssumeRole",
+              "title": "Aws External Id"
+            },
             "aws_profile_name": {
               "anyOf": [
                 {
@@ -25237,6 +25249,9 @@
                       },
                       {
                         "$ref": "#/components/schemas/ChatCompletionImageObject"
+                      },
+                      {
+                        "$ref": "#/components/schemas/ChatCompletionToolReferenceObject"
                       }
                     ]
                   },
@@ -25322,6 +25337,26 @@
             "name"
           ],
           "title": "ChatCompletionToolParamFunctionChunk",
+          "type": "object"
+        },
+        "ChatCompletionToolReferenceObject": {
+          "description": "Anthropic tool-search result block, carried through untouched so it survives a round trip.",
+          "properties": {
+            "tool_name": {
+              "title": "Tool Name",
+              "type": "string"
+            },
+            "type": {
+              "const": "tool_reference",
+              "title": "Type",
+              "type": "string"
+            }
+          },
+          "required": [
+            "type",
+            "tool_name"
+          ],
+          "title": "ChatCompletionToolReferenceObject",
           "type": "object"
         },
         "ChatCompletionUserMessage": {

--- a/ui/litellm-dashboard/src/lib/http/schema.d.ts
+++ b/ui/litellm-dashboard/src/lib/http/schema.d.ts
@@ -29467,6 +29467,11 @@ export interface components {
              */
             aws_bedrock_runtime_endpoint?: string | null;
             /**
+             * Aws External Id
+             * @description External ID required by the target role's trust policy on sts:AssumeRole
+             */
+            aws_external_id?: string | null;
+            /**
              * Aws Profile Name
              * @description AWS profile name for credential retrieval
              */


### PR DESCRIPTION
## TLDR

Problem this solves:

- The lazy OpenAPI snapshot is missing `ChatCompletionToolReferenceObject`
- The dashboard types are missing `aws_external_id`
- `check-ui-api-types` regenerates both and fails on any diff
- Every branch off staging is red on this check

How it solves it:

- Regenerate both artifacts, no hand edits

## User Flow

Before: anyone opening a PR sees a red required check they did not cause

1. They push any branch off `litellm_internal_staging`
2. `Verify schema.d.ts matches the proxy OpenAPI spec` fails
3. The log names `ChatCompletionToolReferenceObject`, which their branch never touched

After: the same push has that check green

1. They push any branch off `litellm_internal_staging`
2. The check regenerates both artifacts, finds no diff, and passes

## Relevant issues

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

The check itself is the proof: it regenerates the file and fails on any diff. There is no
runtime behavior to curl, the file is a build artifact `/openapi.json` serves for unloaded features.

### Before (44d84360fb)

1. `python -m litellm.proxy._lazy_openapi_snapshot` then `git diff --stat`

```
 litellm/proxy/_lazy_openapi_snapshot.json | 35 +++++++++++++++++++++++++++++++
 1 file changed, 35 insertions(+)
```

2. Every added line belongs to one symbol, which is what the workflow reports as the failure:

```
"ChatCompletionToolReferenceObject"
"$ref": "#/components/schemas/ChatCompletionToolReferenceObject"
```

2. Fixing only the snapshot let the check reach its second step, which then reported the
   dashboard types stale on a different model:

```
 ui/litellm-dashboard/src/lib/http/schema.d.ts | 5 +++++
 1 file changed, 5 insertions(+)
```

### After (01f735e589)

1. `python -m litellm.proxy._lazy_openapi_snapshot` and `npm run gen:api`, then
   `git diff --exit-code -- litellm/proxy/_lazy_openapi_snapshot.json ui/litellm-dashboard/src/lib/http/schema.d.ts`

```
 (no output, exit 0)
```

## Type

🚄 Infrastructure

## Caveats (if any)

### Low

- Generated file, regenerate rather than hand-edit if it conflicts
