### PR TITLE
fix(anthropic): carry the effort tier only where the target declares reasoning_effort

### DIFF
--- a/litellm/llms/anthropic/experimental_pass_through/adapters/transformation.py
+++ b/litellm/llms/anthropic/experimental_pass_through/adapters/transformation.py
@@ -890,6 +890,31 @@ class LiteLLMAnthropicMessagesAdapter:
         )
         return "prompt_cache_key" in (supported_params or ())
 
+    @staticmethod
+    def _target_declares_reasoning_effort(model: str, custom_llm_provider: str | None) -> bool:
+        """Whether the target declares ``reasoning_effort`` among its supported params.
+
+        A Claude-family target is recognized by name, which says nothing about the carrier the
+        provider serving it accepts: Snowflake serves Claude over the Anthropic dialect and
+        declares ``thinking`` alone, so storing the tier there raises before the request reaches
+        the wire.
+
+        Without a resolved provider the tier stays behind, which is what this bridge sent before
+        it carried one at all. Reading the declaration from the model's own prefix instead would
+        resolve the provider through a lookup that runs an OAuth device flow for two of them, and
+        this runs inside a logging callback as well as on the request path.
+
+        Unlike ``_supports_prompt_cache_key`` this does not exclude a provider that proxies an
+        unknown backend, because that provider declares this param and forwards it to a proxy
+        that resolves the real target itself, where a derived cache key has no such guarantee.
+        """
+        if not model or not custom_llm_provider:
+            return False
+        supported_params: Final = litellm.get_supported_openai_params(
+            model=model, custom_llm_provider=custom_llm_provider
+        )
+        return "reasoning_effort" in (supported_params or ())
+
     def _translate_metadata_to_openai(
         self,
         anthropic_message_request: AnthropicMessagesRequest,
@@ -978,6 +1003,8 @@ class LiteLLMAnthropicMessagesAdapter:
         self,
         anthropic_message_request: AnthropicMessagesRequest,
         new_kwargs: ChatCompletionRequest,
+        *,
+        custom_llm_provider: str | None = None,
     ) -> None:
         """Translate Anthropic thinking to either thinking or reasoning_effort.
 
@@ -986,11 +1013,15 @@ class LiteLLMAnthropicMessagesAdapter:
         because the two are not interchangeable at the provider mapping below.
 
         Bedrock takes ``output_config`` directly, which attaches the tier and leaves ``thinking``
-        alone. Every other bridged Claude target takes ``reasoning_effort``, and used to be sent no
-        tier at all, so an adaptive request arrived byte-identical whichever effort the caller
-        asked for. That tier stays a plain string there, since the summary it would otherwise be
-        wrapped with already travels inside the forwarded ``thinking`` block, and the wrapped dict
-        is rejected outright by some of these providers.
+        alone. Another bridged Claude target takes ``reasoning_effort`` if it declares that param,
+        and used to be sent no tier at all, so an adaptive request arrived byte-identical whichever
+        effort the caller asked for. That tier stays a plain string there, since the summary it
+        would otherwise be wrapped with already travels inside the forwarded ``thinking`` block,
+        and the wrapped dict is rejected outright by some of these providers.
+
+        A target declaring neither carrier keeps its bare ``thinking`` block. Being Claude-family
+        is a fact about the model, not about the params the provider in front of it accepts, so
+        the tier is offered only where the target says it is taken.
 
         ``reasoning_effort`` is not a substitute for ``output_config`` on the Bedrock side: an
         application inference profile ARN resolves to neither, so the tier is dropped, and providers
@@ -1019,6 +1050,8 @@ class LiteLLMAnthropicMessagesAdapter:
                     effort_config: Final = {k: v for k, v in output_config.items() if k != "format"}
                     if effort_config:
                         new_kwargs["output_config"] = effort_config  # rebind-ok: out-param store like thinking above
+                return
+            if not self._target_declares_reasoning_effort(model, custom_llm_provider):
                 return
 
         thinking_type: Final = thinking.get("type") if isinstance(thinking, dict) else None
@@ -1133,6 +1166,7 @@ class LiteLLMAnthropicMessagesAdapter:
         self._translate_thinking_to_openai(
             anthropic_message_request=anthropic_message_request,
             new_kwargs=new_kwargs,
+            custom_llm_provider=custom_llm_provider,
         )
         ## CONVERT STOP_SEQUENCES
         self._translate_stop_sequences_to_openai(

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_anthropic_experimental_pass_through_adapters_transformation.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_anthropic_experimental_pass_through_adapters_transformation.py
@@ -2054,7 +2054,7 @@ def test_adaptive_thinking_output_config_not_forwarded_for_non_bedrock_claude_mo
     from litellm.types.llms.anthropic import AnthropicMessagesRequest
 
     anthropic_request = AnthropicMessagesRequest(
-        model="openrouter/anthropic/claude-opus-4-7",
+        model="openrouter/anthropic/claude-opus-4.7",
         max_tokens=1024,
         messages=[{"role": "user", "content": "hi"}],
         thinking={"type": "adaptive"},
@@ -2062,7 +2062,9 @@ def test_adaptive_thinking_output_config_not_forwarded_for_non_bedrock_claude_mo
     )
 
     adapter = LiteLLMAnthropicMessagesAdapter()
-    openai_request, _ = adapter.translate_anthropic_to_openai(anthropic_message_request=anthropic_request)
+    openai_request, _ = adapter.translate_anthropic_to_openai(
+        anthropic_message_request=anthropic_request, custom_llm_provider="openrouter"
+    )
 
     assert openai_request["thinking"] == {"type": "adaptive"}
     assert "output_config" not in openai_request
@@ -2079,12 +2081,13 @@ def test_every_adaptive_effort_tier_reaches_a_bridged_claude_target(effort):
     adapter = LiteLLMAnthropicMessagesAdapter()
     openai_request, _ = adapter.translate_anthropic_to_openai(
         anthropic_message_request=AnthropicMessagesRequest(
-            model="openrouter/anthropic/claude-opus-4-7",
+            model="openrouter/anthropic/claude-opus-4.7",
             max_tokens=1024,
             messages=[{"role": "user", "content": "hi"}],
             thinking={"type": "adaptive"},
             output_config={"effort": effort},
-        )
+        ),
+        custom_llm_provider="openrouter",
     )
 
     assert openai_request["reasoning_effort"] == effort
@@ -4295,7 +4298,7 @@ def test_completion_cost_on_translated_anthropic_response_includes_web_search():
     "model, provider, carried",
     [
         ("databricks/databricks-claude-opus-4-7", "databricks", "max"),
-        ("openrouter/anthropic/claude-opus-4-7", "openrouter", "xhigh"),
+        ("openrouter/anthropic/claude-opus-4.7", "openrouter", "xhigh"),
     ],
 )
 def test_a_summary_bearing_adaptive_request_still_delivers_its_tier(model, provider, carried):
@@ -4318,7 +4321,8 @@ def test_a_summary_bearing_adaptive_request_still_delivers_its_tier(model, provi
             messages=[{"role": "user", "content": "hi"}],
             thinking={"type": "adaptive", "summary": "detailed"},
             output_config={"effort": "max"},
-        )
+        ),
+        custom_llm_provider=provider,
     )
 
     assert openai_request["reasoning_effort"] == "max"
@@ -4435,7 +4439,8 @@ def test_a_databricks_target_trades_its_thinking_display_for_the_tier():
             messages=[{"role": "user", "content": "hi"}],
             thinking={"type": "adaptive", "display": "omitted"},
             output_config={"effort": "max"},
-        )
+        ),
+        custom_llm_provider="databricks",
     )
 
     on_the_wire = get_optional_params(
@@ -4447,3 +4452,147 @@ def test_a_databricks_target_trades_its_thinking_display_for_the_tier():
 
     assert on_the_wire["output_config"] == {"effort": "max"}
     assert on_the_wire["thinking"]["display"] == "summarized"
+
+
+@pytest.mark.parametrize(
+    "thinking, output_config",
+    [
+        ({"type": "adaptive"}, {"effort": "max"}),
+        ({"type": "adaptive"}, {"effort": "minimal"}),
+        ({"type": "adaptive", "summary": "detailed"}, {"effort": "high"}),
+        ({"type": "adaptive", "display": "omitted"}, {"effort": "high"}),
+    ],
+)
+def test_a_target_declaring_no_reasoning_effort_is_sent_none(thinking, output_config):
+    """Regression: snowflake serves Claude over the Anthropic dialect and declares `thinking`
+    alone, so storing the tier raised `UnsupportedParamsError` in `get_optional_params` before the
+    request reached the wire. Every adaptive shape carrying a tier turned a 200 into a 400.
+
+    Being Claude-family is a fact about the model, not about the params the provider in front of
+    it accepts. The tier stays behind and the caller's `thinking` block travels untouched."""
+    from litellm.types.llms.anthropic import AnthropicMessagesRequest
+    from litellm.utils import get_optional_params
+
+    adapter = LiteLLMAnthropicMessagesAdapter()
+    openai_request, _ = adapter.translate_anthropic_to_openai(
+        anthropic_message_request=AnthropicMessagesRequest(
+            model="snowflake/claude-sonnet-4-6",
+            max_tokens=1024,
+            messages=[{"role": "user", "content": "hi"}],
+            thinking=thinking,
+            output_config=output_config,
+        ),
+        custom_llm_provider="snowflake",
+    )
+
+    assert "reasoning_effort" not in openai_request
+    assert "output_config" not in openai_request
+    assert openai_request["thinking"] == thinking
+
+    on_the_wire = get_optional_params(
+        model="snowflake/claude-sonnet-4-6",
+        custom_llm_provider="snowflake",
+        thinking=openai_request["thinking"],
+    )
+
+    assert on_the_wire["thinking"] == thinking
+
+
+def test_a_target_declaring_reasoning_effort_still_gets_its_tier():
+    """The negative class for the gate. Same request shape, a provider that does declare the
+    param, so the tier must still travel: the gate must drop it for snowflake alone, not for
+    every Claude target, or it would undo the fix it is protecting."""
+    from litellm.types.llms.anthropic import AnthropicMessagesRequest
+
+    adapter = LiteLLMAnthropicMessagesAdapter()
+    openai_request, _ = adapter.translate_anthropic_to_openai(
+        anthropic_message_request=AnthropicMessagesRequest(
+            model="databricks/databricks-claude-opus-4-7",
+            max_tokens=1024,
+            messages=[{"role": "user", "content": "hi"}],
+            thinking={"type": "adaptive"},
+            output_config={"effort": "max"},
+        ),
+        custom_llm_provider="databricks",
+    )
+
+    assert openai_request["reasoning_effort"] == "max"
+
+
+@pytest.mark.parametrize(
+    "model",
+    ["snowflake/claude-sonnet-4-6", "databricks/databricks-claude-opus-4-7", "github_copilot/claude-sonnet-4"],
+)
+def test_a_caller_that_names_no_provider_carries_no_tier(model):
+    """`translate_anthropic_to_openai` is also called without a provider, by `adapter_completion`
+    and by the shadow-eval logger. There is no declaration to read there, so the tier stays behind
+    rather than being offered to a target that may reject it, which is what this bridge sent
+    before it carried a tier at all.
+
+    The databricks arm is the cost of that, stated rather than hidden: a provider that does take
+    the tier does not get one from these two callers. The copilot arm is why the cost is worth
+    paying, and why this must not be "fixed" by resolving the provider from the model prefix.
+    That resolution runs an OAuth device flow for copilot and chatgpt, which would block this
+    call for minutes, and one of the two callers is a logging callback. A test asserting the
+    absence here is also a test that this stays fast."""
+    from litellm.types.llms.anthropic import AnthropicMessagesRequest
+
+    adapter = LiteLLMAnthropicMessagesAdapter()
+    openai_request, _ = adapter.translate_anthropic_to_openai(
+        anthropic_message_request=AnthropicMessagesRequest(
+            model=model,
+            max_tokens=1024,
+            messages=[{"role": "user", "content": "hi"}],
+            thinking={"type": "adaptive"},
+            output_config={"effort": "max"},
+        )
+    )
+
+    assert openai_request["thinking"] == {"type": "adaptive"}
+    assert "reasoning_effort" not in openai_request
+
+
+def test_a_chained_litellm_proxy_target_still_takes_the_tier():
+    """The one place this deliberately parts company with `_supports_prompt_cache_key`, which
+    excludes a provider that proxies an unknown backend. That exclusion is right for a derived
+    cache key and wrong here: the downstream proxy declares this param and resolves the real
+    target itself, so excluding it would drop a tier that arrives perfectly well."""
+    from litellm.types.llms.anthropic import AnthropicMessagesRequest
+
+    adapter = LiteLLMAnthropicMessagesAdapter()
+    openai_request, _ = adapter.translate_anthropic_to_openai(
+        anthropic_message_request=AnthropicMessagesRequest(
+            model="litellm_proxy/claude-sonnet-4-6",
+            max_tokens=1024,
+            messages=[{"role": "user", "content": "hi"}],
+            thinking={"type": "adaptive"},
+            output_config={"effort": "max"},
+        ),
+        custom_llm_provider="litellm_proxy",
+    )
+
+    assert openai_request["reasoning_effort"] == "max"
+    assert openai_request["thinking"] == {"type": "adaptive"}
+
+
+def test_a_bedrock_target_still_takes_output_config_not_the_declared_gate():
+    """Bedrock declares both carriers, so the gate must not change which one it gets: the tier
+    rides in `output_config`, which leaves `thinking` alone, and `reasoning_effort` is never
+    stored alongside it."""
+    from litellm.types.llms.anthropic import AnthropicMessagesRequest
+
+    adapter = LiteLLMAnthropicMessagesAdapter()
+    openai_request, _ = adapter.translate_anthropic_to_openai(
+        anthropic_message_request=AnthropicMessagesRequest(
+            model="bedrock/converse/us.anthropic.claude-opus-4-7",
+            max_tokens=1024,
+            messages=[{"role": "user", "content": "hi"}],
+            thinking={"type": "adaptive", "display": "omitted"},
+            output_config={"effort": "max"},
+        ),
+        custom_llm_provider="bedrock",
+    )
+
+    assert openai_request["output_config"] == {"effort": "max"}
+    assert "reasoning_effort" not in openai_request
+    assert openai_request["thinking"] == {"type": "adaptive", "display": "omitted"}


### PR DESCRIPTION
## TLDR

Problem this solves:

- Snowflake Claude deployments 400 on any adaptive request with an effort tier
- Broke in #38533, live on staging now, all 7 snowflake Claude entries
- The bridge read capability from the model name, not the provider

How it solves it:

- Offer the tier only where the target declares `reasoning_effort`
- A target declaring neither carrier keeps its bare `thinking` block
- Reads the same supported-params helper the sibling method reads

## User Flow

Before: a developer whose app asks a Snowflake Claude deployment to think harder gets a hard failure instead of an answer

1. They send POST https://litellm-domain/v1/messages with `"model": "snowflake-claude"`, `"thinking": {"type": "adaptive"}` and `"output_config": {"effort": "max"}`
2. The call comes back `400` with `litellm.UnsupportedParamsError: snowflake does not support parameters: ['reasoning_effort'], for model=claude-sonnet-4-6`
3. Nothing reaches Snowflake, so there is no answer and no token usage to show for it
4. They open https://litellm-domain/ui/?page=logs and see the request logged as a failure at $0
5. Dropping `output_config` makes the same call succeed, so the only way through is to give up asking for an effort level

After: the same request goes through, and the effort level is simply not offered to a provider that does not take one

1. They send the same POST https://litellm-domain/v1/messages with `"thinking": {"type": "adaptive"}` and `"output_config": {"effort": "max"}`
2. The call comes back `200` with a normal message body
3. Snowflake receives the caller's `thinking` block exactly as written, including a `summary` or `display` they set
4. https://litellm-domain/ui/?page=logs shows the request as a success with real token counts
5. Deployments that do take an effort level, like openrouter and databricks Claude, still receive the tier they did before

## Relevant issues

- Regression from #38533, which started sending `reasoning_effort` to every non-Bedrock Claude target
- Same class as #31187 (azure_ai) and #35645 (deepseek), both open: a provider serving Claude that does not take the param litellm sends
- Not fixed here, worth its own issue: `vercel_ai_gateway`, `heroku`, `replicate`, `gradient_ai` and `gmi` carry Claude-named models while declaring neither `thinking` nor `reasoning_effort`, so they already fail on `thinking` alone, before and after this change

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally
- [x] My PR passes all required CI/CD checks

## What changed

`_translate_thinking_to_openai` decided a Claude target could take `reasoning_effort` from the model name. `is_anthropic_claude_model` is a substring test for "anthropic" or "claude", which is a fact about the model and says nothing about the params the provider in front of it accepts. Snowflake serves Claude over the Anthropic dialect at `/cortex/v1/messages` and declares `thinking` alone, so `get_optional_params` raised before the request reached the wire.

The tier is now offered only where the target declares the param, read through `get_supported_openai_params`, the same helper `_supports_prompt_cache_key` reads twelve lines up in this file. A target that declares neither carrier keeps its bare `thinking` block, which is what this bridge sent before it carried a tier at all.

Without a resolved provider the tier stays behind rather than being offered blind. The two callers in that position are `adapter_completion` and the shadow-eval logger, and the cost is real and stated: a provider that does take the tier, like databricks, does not get one from those two. Resolving a provider from the model's prefix instead looks like the obvious improvement and is a trap. That lookup runs an OAuth device flow for `github_copilot` and `chatgpt`, so it blocks for minutes, and one of the two callers is a logging callback. I tried it, measured a shadow-eval translation for a copilot Claude model blocking in GitHub's device-code poll, and backed it out. A copilot case in the provider-less test keeps that door shut, and it runs in well under a second.

The other deliberate choice: unlike `_supports_prompt_cache_key` this does not exclude a provider that proxies an unknown backend. That provider declares this param and forwards it to a proxy that resolves the real target itself, where a derived cache key has no such guarantee. Both asymmetries are pinned by tests.

Considered and rejected: adding `reasoning_effort` to snowflake's supported list. Snowflake has no reasoning handling at all, and its `map_openai_params` is an identity filter that splats whatever survives into the wire body, so declaring the param would post a bare `reasoning_effort` key into an Anthropic-dialect body. That trades litellm's 400 for Snowflake's.

Also considered: making the Bedrock carve-out itself declaration-driven, which would delete the hardcoded `("bedrock/", "converse/", "invoke/")` prefix list. Bedrock and its inference-profile ARNs are the only bridged targets that declare `output_config`, so it does reproduce the carve-out exactly, but it swaps a name test that works without a provider for a lookup that needs one, and would drop the tier on the two provider-less callers. Left as follow-up.

## Blast radius

Measured, not estimated, by driving all 73 bridged Claude targets through the adapter and then each provider's own `get_optional_params`, on the merge base and on this branch.

Changes behavior: the 7 snowflake Claude entries, on the 4 request shapes that carry a tier (adaptive with any effort, adaptive with a summary, adaptive with a display). 28 calls that returned 200 before #38533, 400 after it, and 200 again here.

Unchanged: bedrock converse and inference-profile ARNs keep taking the tier as `output_config`; databricks and openrouter keep taking it as `reasoning_effort`; adaptive with no tier, budgeted thinking, and requests with no thinking block are byte-identical on both sides. `deepinfra`, `gmi`, `gradient_ai`, `heroku`, `replicate` and `vercel_ai_gateway` fail on `thinking` before and after, unrelated to this change: they carry Claude-named models while declaring neither param, which is worth its own issue.

On the proxy path nothing loses a tier: sweeping all 73 targets with the provider passed, as the proxy does, no target drops a tier that staging delivers, and failing cases go from 268 on staging back to 240, exactly the pre-#38533 count. On the two provider-less callers the tier is not carried at all, which is 64 cases across openrouter and databricks returning to their pre-#38533 behavior. None of them error; they just carry no effort level.

## Proof of fix

One proxy, same config and same commands on both sides, with a real Postgres and an HTTP upstream that records the exact body it was handed. Snowflake credentials were not available, so the recorder stands in for Snowflake's own API; the failure this fixes is raised inside the proxy before any upstream call, which is why the before leg shows nothing arriving at all.

```bash
for shape in \
  '"thinking":{"type":"adaptive"},"output_config":{"effort":"max"}' \
  '"thinking":{"type":"adaptive"},"output_config":{"effort":"minimal"}' \
  '"thinking":{"type":"adaptive","summary":"detailed"},"output_config":{"effort":"high"}' \
  '"thinking":{"type":"adaptive","display":"omitted"},"output_config":{"effort":"high"}' ; do
  curl -sS -o /dev/null -w "%{http_code}\n" http://127.0.0.1:4000/v1/messages \
    -H 'content-type: application/json' -H 'authorization: Bearer sk-1234' \
    -d "{\"model\":\"snowflake-claude\",\"max_tokens\":256,\"messages\":[{\"role\":\"user\",\"content\":\"hi\"}],$shape}"
done
```

Before, on the merge base:

```
400
400
400
400
```

```
litellm.UnsupportedParamsError: snowflake does not support parameters: ['reasoning_effort'],
for model=claude-sonnet-4-6. To drop these, set `litellm.drop_params=True`
```

After, on this branch:

```
200
200
200
200
```

The bodies Snowflake was handed on the after leg, showing the caller's `thinking` block arriving untouched:

```json
{"model": "claude-sonnet-4-6", "thinking": {"type": "adaptive"}}
{"model": "claude-sonnet-4-6", "thinking": {"type": "adaptive"}}
{"model": "claude-sonnet-4-6", "thinking": {"summary": "detailed", "type": "adaptive"}}
{"model": "claude-sonnet-4-6", "thinking": {"display": "omitted", "type": "adaptive"}}
```

On the before leg none of those four requests reached the upstream at all.

The guards, run in the same suite on both legs, to show #38533's fix is intact:

```bash
curl -sS http://127.0.0.1:4000/v1/messages -H 'content-type: application/json' \
  -H 'authorization: Bearer sk-1234' \
  -d '{"model":"openrouter-claude","max_tokens":256,"messages":[{"role":"user","content":"hi"}],
       "thinking":{"type":"adaptive"},"output_config":{"effort":"minimal"}}'
```

openrouter still carries the tier, and still distinguishes the levels, identically on both legs:

```json
{"model": "anthropic/claude-opus-4.5", "reasoning_effort": "low",  "thinking": {"type": "adaptive"}}
{"model": "anthropic/claude-opus-4.5", "reasoning_effort": "high", "thinking": {"type": "adaptive"}}
```

databricks still rebuilds `output_config` from the tier, identically on both legs:

```json
{"model": "databricks-claude-opus-4-7", "output_config": {"effort": "high"},
 "thinking": {"display": "summarized", "type": "adaptive"}}
```

Bedrock converse and the inference-profile ARN return the same AWS 403 on both legs, which is the fake credential and not the change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes request shaping on the Anthropic `/v1/messages` pass-through path for adaptive thinking; wrong gating could drop effort on supported providers or reintroduce UnsupportedParamsError on Snowflake-like backends.
> 
> **Overview**
> Fixes a regression where adaptive **`output_config.effort`** was mapped to **`reasoning_effort`** for every non-Bedrock Claude model name, which made Snowflake (and similar) reject requests before they left LiteLLM.
> 
> **`_translate_thinking_to_openai`** now takes **`custom_llm_provider`** and, after the Bedrock **`output_config`** path, only adds **`reasoning_effort`** when **`_target_declares_reasoning_effort`** sees that param in **`get_supported_openai_params`**. Providers that only accept **`thinking`** keep the caller’s block unchanged with no tier. If no provider is passed (e.g. shadow-eval logging), the tier is omitted rather than inferred from the model string.
> 
> OpenRouter/Databricks behavior with an explicit provider is unchanged; **`litellm_proxy`** still gets the tier even though it proxies an unknown backend. Tests cover Snowflake, proxy, Bedrock, and provider-less translation paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b9ee5656b26cb929ee4ac8dd2400ee8ea8084b2a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->