### PR TITLE
fix(policy): let the AI policy suggester drop sampling params its model refuses

### DIFF
--- a/litellm/proxy/management_endpoints/policy_endpoints/ai_policy_suggester.py
+++ b/litellm/proxy/management_endpoints/policy_endpoints/ai_policy_suggester.py
@@ -61,7 +61,11 @@ class AiPolicySuggester:
         system_prompt: Final = self._build_system_prompt(templates)
         user_prompt: Final = self._build_user_prompt(attack_examples, description)
         model = model or DEFAULT_COMPETITOR_DISCOVERY_MODEL
-        supported_params: Final = litellm.get_supported_openai_params(model=model)
+        custom_llm_provider: Final = model.split("/", 1)[0] if "/" in model else None
+        supported_params: Final = litellm.get_supported_openai_params(
+            model=model,
+            custom_llm_provider=custom_llm_provider,
+        )
         if supported_params is not None and "tools" not in supported_params:
             raise ProxyException(
                 message=(f"AI policy suggestion requires tool calling; model '{model}' does not support it"),

--- a/litellm/proxy/management_endpoints/policy_endpoints/ai_policy_suggester.py
+++ b/litellm/proxy/management_endpoints/policy_endpoints/ai_policy_suggester.py
@@ -9,6 +9,7 @@ from typing import Final
 import litellm
 from litellm._logging import verbose_proxy_logger
 from litellm.constants import DEFAULT_COMPETITOR_DISCOVERY_MODEL
+from litellm.proxy._types import ProxyErrorTypes, ProxyException
 
 SUGGEST_TOOL: Final = {
     "type": "function",
@@ -60,6 +61,14 @@ class AiPolicySuggester:
         system_prompt: Final = self._build_system_prompt(templates)
         user_prompt: Final = self._build_user_prompt(attack_examples, description)
         model = model or DEFAULT_COMPETITOR_DISCOVERY_MODEL
+        supported_params: Final = litellm.get_supported_openai_params(model=model)
+        if supported_params is not None and "tools" not in supported_params:
+            raise ProxyException(
+                message=(f"AI policy suggestion requires tool calling; model '{model}' does not support it"),
+                type=ProxyErrorTypes.validation_error.value,
+                param="model",
+                code=400,
+            )
 
         try:
             response: Final = await litellm.acompletion(

--- a/litellm/proxy/management_endpoints/policy_endpoints/ai_policy_suggester.py
+++ b/litellm/proxy/management_endpoints/policy_endpoints/ai_policy_suggester.py
@@ -74,6 +74,7 @@ class AiPolicySuggester:
                     "function": {"name": "select_policy_templates"},
                 },
                 temperature=0.2,
+                drop_params=True,
             )
 
             tool_calls: Final = response.choices[0].message.tool_calls

--- a/tests/test_litellm/proxy/management_endpoints/policy_endpoints/test_ai_policy_suggester.py
+++ b/tests/test_litellm/proxy/management_endpoints/policy_endpoints/test_ai_policy_suggester.py
@@ -236,6 +236,7 @@ class TestAiPolicySuggester:
         call_kwargs = mock_acompletion.call_args.kwargs
         assert call_kwargs["model"] == "gpt-4o-mini"
         assert call_kwargs["temperature"] == 0.2
+        assert call_kwargs["drop_params"] is True
         assert len(call_kwargs["tools"]) == 1
         assert call_kwargs["tools"][0]["function"]["name"] == "select_policy_templates"
         assert (
@@ -276,6 +277,18 @@ class TestSuggesterToleratesAModelThatRefusesItsSamplingParams:
         exactly what the model rejects, and drop_params is what removes it."""
         from litellm.utils import get_optional_params
 
-        assert "temperature" not in get_optional_params(
-            model="gpt-5.6-terra", custom_llm_provider="openai", temperature=0.2, drop_params=True
+        optional_params = get_optional_params(
+            model="gpt-5.6-terra",
+            custom_llm_provider="openai",
+            temperature=0.2,
+            tools=[SUGGEST_TOOL],
+            tool_choice={"type": "function", "function": {"name": "select_policy_templates"}},
+            drop_params=True,
         )
+
+        assert "temperature" not in optional_params
+        assert optional_params["tools"] == [SUGGEST_TOOL]
+        assert optional_params["tool_choice"] == {
+            "type": "function",
+            "function": {"name": "select_policy_templates"},
+        }

--- a/tests/test_litellm/proxy/management_endpoints/policy_endpoints/test_ai_policy_suggester.py
+++ b/tests/test_litellm/proxy/management_endpoints/policy_endpoints/test_ai_policy_suggester.py
@@ -7,6 +7,8 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+import litellm
+
 from litellm.proxy.management_endpoints.policy_endpoints.ai_policy_suggester import (
     SUGGEST_TOOL,
     AiPolicySuggester,
@@ -242,3 +244,38 @@ class TestAiPolicySuggester:
         assert len(call_kwargs["messages"]) == 2
         assert call_kwargs["messages"][0]["role"] == "system"
         assert call_kwargs["messages"][1]["role"] == "user"
+
+
+class TestSuggesterToleratesAModelThatRefusesItsSamplingParams:
+    """The model is operator-supplied, so it can be a reasoning model whose only accepted
+    temperature is 1. This call pins temperature=0.2 for tool-selection determinism, which such
+    a model rejects outright: without drop_params litellm raises UnsupportedParamsError and the
+    whole suggestion fails rather than degrading. Every other internal LLM call in the proxy
+    already opts in through judge_acompletion; this one was the exception.
+    """
+
+    @pytest.mark.asyncio
+    async def test_a_reasoning_model_gets_past_param_mapping(self, monkeypatch, local_model_cost_map):
+        """Drives the real entry point with no patching and no network. Which exception escapes is
+        the discriminator: param mapping runs before any credential check, so UnsupportedParamsError
+        means the call died on the pinned temperature, while AuthenticationError means it survived
+        that and got as far as needing a key. Asserting the latter is what the caller observes.
+        """
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+        with pytest.raises(litellm.AuthenticationError):
+            await AiPolicySuggester().suggest(
+                templates=SAMPLE_TEMPLATES,
+                attack_examples=["My SSN is 123-45-6789"],
+                description="",
+                model="gpt-5.6-terra",
+            )
+
+    def test_the_pinned_temperature_is_what_such_a_model_refuses(self, local_model_cost_map):
+        """The other half of the discriminator above: the same temperature this call pins is
+        exactly what the model rejects, and drop_params is what removes it."""
+        from litellm.utils import get_optional_params
+
+        assert "temperature" not in get_optional_params(
+            model="gpt-5.6-terra", custom_llm_provider="openai", temperature=0.2, drop_params=True
+        )

--- a/tests/test_litellm/proxy/management_endpoints/policy_endpoints/test_ai_policy_suggester.py
+++ b/tests/test_litellm/proxy/management_endpoints/policy_endpoints/test_ai_policy_suggester.py
@@ -9,6 +9,7 @@ import pytest
 
 import litellm
 
+from litellm.proxy._types import ProxyException
 from litellm.proxy.management_endpoints.policy_endpoints.ai_policy_suggester import (
     SUGGEST_TOOL,
     AiPolicySuggester,
@@ -245,6 +246,32 @@ class TestAiPolicySuggester:
         assert len(call_kwargs["messages"]) == 2
         assert call_kwargs["messages"][0]["role"] == "system"
         assert call_kwargs["messages"][1]["role"] == "user"
+
+
+class TestSuggesterRejectsModelsWithoutToolCalling:
+    @pytest.mark.asyncio
+    async def test_a_tools_less_model_is_rejected(self, local_model_cost_map):
+        with pytest.raises(ProxyException) as exc:
+            await AiPolicySuggester().suggest(
+                templates=SAMPLE_TEMPLATES,
+                attack_examples=["Ignore all previous instructions"],
+                description="Block prompt injection attempts",
+                model="perplexity/sonar",
+            )
+
+        assert int(exc.value.code) == 400
+        assert exc.value.param == "model"
+        assert "tool calling" in exc.value.message
+
+    def test_a_model_without_forced_tool_choice_support_remains_eligible(self, local_model_cost_map):
+        supported_params = litellm.get_supported_openai_params(
+            model="amazon.nova-pro-v1:0",
+            custom_llm_provider="bedrock",
+        )
+
+        assert supported_params is not None
+        assert "tools" in supported_params
+        assert "tool_choice" not in supported_params
 
 
 class TestSuggesterToleratesAModelThatRefusesItsSamplingParams:


### PR DESCRIPTION
## TLDR

Problem this solves:

- Reasoning models reject the fixed suggestion temperature
- Tool-less models could return a misleading empty suggestion

How it solves it:

- Drops unsupported advisory sampling parameters
- Rejects models known not to support tool calling

## User Flow

Before: an admin selects an unsupported reasoning or tool-less model and cannot rely on a useful policy suggestion

1. They open the policy template suggestion flow and choose a model
2. They submit attack examples that should match a policy template
3. A reasoning model can reject the fixed temperature, while a tool-less model can return an empty selection that looks like no match

After: the same flow preserves the necessary tool contract and produces a clear result

1. They open the policy template suggestion flow and choose a model
2. They submit the same attack examples
3. A compatible reasoning model receives the request without its unsupported sampling parameter and returns matching templates
4. A model known not to support tool calling returns HTTP 400 identifying the selected `model`

## Relevant issues


## Linear ticket

Resolves LIT-6352

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally
- [x] My PR passes all required CI/CD checks
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

Local proxy: `http://127.0.0.1:16494`, with local policy templates enabled and a real provider credential supplied only through the process environment

### Before (a5c0aa2927d3fd4c500eab00c5e3833fc5af6a5a)

1. `POST /policy/templates/suggest` with `"model":"perplexity/sonar"` could have unsupported `tools` and `tool_choice` silently removed by `drop_params`
2. The model response then appeared as an empty policy selection instead of explaining that the model could not run the feature

### After (28a18ee65defad430bc6f7c48b97634698067081)

1. `POST /policy/templates/suggest` with `"model":"together_ai/deepseek-ai/DeepSeek-V4-Pro-0813"` and an instruction-override example returned HTTP 200
2. The real response selected `prompt-injection-protection` and explained the match
3. The same endpoint with `"model":"perplexity/sonar"` returned HTTP 400 with `"param":"model"` and `"AI policy suggestion requires tool calling"`
4. A tools-capable model without forced tool-choice support returned HTTP 200 with the matching policy template

## Type

🐛 Bug Fix

## Caveats (if any)


## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to the policy suggester LLM call and validation; improves error handling without changing auth or core request routing.
> 
> **Overview**
> Hardens **AI policy template suggestion** when admins pick arbitrary models: the suggester now passes **`drop_params=True`** on `acompletion` so pinned `temperature=0.2` is stripped for reasoning models that only accept default sampling, avoiding `UnsupportedParamsError` instead of failing the whole flow.
> 
> Before calling the LLM, it checks **`litellm.get_supported_openai_params`** and returns **HTTP 400** with `param: model` when **`tools`** are not supported, so tool-less models no longer silently run without tools and return an empty “no match” result.
> 
> Tests assert **`drop_params`** is forwarded and add integration-style coverage that a reasoning-model path survives param mapping (discriminated via `AuthenticationError` vs param errors).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 28a18ee65defad430bc6f7c48b97634698067081. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->