### PR TITLE
feat(ui): dry-run an auto-router config against the backend before saving it

### DIFF
--- a/ui/litellm-dashboard/src/components/add_model/add_auto_router_tab.test.tsx
+++ b/ui/litellm-dashboard/src/components/add_model/add_auto_router_tab.test.tsx
@@ -194,9 +194,6 @@ describe("AddAutoRouterTab", () => {
     expect(vi.mocked(handleAddAutoRouterSubmit).mock.calls.at(-1)?.[0]).toMatchObject({ team_id: "team-1" });
   });
 
-  // The dry-run exists so a config the write gate would refuse shows the backend's own message
-  // inline instead of coming back as a raw 400. Nothing asserted that its verdict actually stops
-  // the submit, so the whole gate could be deleted with the suite still green.
   it("does not submit when the backend's dry-run rejects the config", async () => {
     const user = userEvent.setup();
     vi.mocked(getMissingTiersError).mockReturnValue(null);
@@ -223,6 +220,32 @@ describe("AddAutoRouterTab", () => {
     await user.click(screen.getByRole("button", { name: /add auto router/i }));
 
     await waitFor(() => expect(handleAddAutoRouterSubmit).toHaveBeenCalled());
+  });
+
+  // A second submit while the dry-run round-trip is pending must not start another create: the
+  // button disables, and the handler itself refuses re-entry since a form submit (Enter) fires it
+  // regardless of the button's disabled state.
+  it("creates the router once when the form is submitted again mid dry-run", async () => {
+    vi.mocked(getMissingTiersError).mockReturnValue(null);
+    let resolveVerdict: (verdict: { valid: boolean }) => void = () => {};
+    validateAutoRouterConfig.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveVerdict = resolve;
+        }),
+    );
+
+    const { container } = renderWithProviders(<Harness />);
+    fireEvent.change(screen.getByPlaceholderText(/smart_router/i), { target: { value: "double-submit-router" } });
+
+    fireEvent.submit(container.querySelector("form")!);
+    await waitFor(() => expect(screen.getByRole("button", { name: /add auto router/i })).toBeDisabled());
+    fireEvent.submit(container.querySelector("form")!);
+
+    resolveVerdict({ valid: true });
+    await waitFor(() => expect(screen.getByRole("button", { name: /add auto router/i })).toBeEnabled());
+    expect(validateAutoRouterConfig).toHaveBeenCalledTimes(1);
+    expect(handleAddAutoRouterSubmit).toHaveBeenCalledTimes(1);
   });
 
   // LIT-5133: "Add keyword rule" seeds a row with no keywords, and the semantic toggle that used

--- a/ui/litellm-dashboard/src/components/add_model/add_auto_router_tab.test.tsx
+++ b/ui/litellm-dashboard/src/components/add_model/add_auto_router_tab.test.tsx
@@ -70,9 +70,14 @@ const { mockFetchAvailableModels, mockFetchAllModelDeployments } = vi.hoisted(()
   mockFetchAllModelDeployments: vi.fn(),
 }));
 
+const { validateAutoRouterConfig } = vi.hoisted(() => ({
+  validateAutoRouterConfig: vi.fn().mockResolvedValue({ valid: true }),
+}));
+
 vi.mock("../networking", () => ({
   modelAvailableCall: vi.fn().mockResolvedValue({ data: [] }),
   testAutoRouterRouting: vi.fn(),
+  validateAutoRouterConfig,
 }));
 
 vi.mock("@/components/llm_calls/fetch_models", () => ({
@@ -187,6 +192,37 @@ describe("AddAutoRouterTab", () => {
 
     await waitFor(() => expect(handleAddAutoRouterSubmit).toHaveBeenCalled());
     expect(vi.mocked(handleAddAutoRouterSubmit).mock.calls.at(-1)?.[0]).toMatchObject({ team_id: "team-1" });
+  });
+
+  // The dry-run exists so a config the write gate would refuse shows the backend's own message
+  // inline instead of coming back as a raw 400. Nothing asserted that its verdict actually stops
+  // the submit, so the whole gate could be deleted with the suite still green.
+  it("does not submit when the backend's dry-run rejects the config", async () => {
+    const user = userEvent.setup();
+    vi.mocked(getMissingTiersError).mockReturnValue(null);
+    validateAutoRouterConfig.mockResolvedValueOnce({
+      valid: false,
+      error: "session_affinity cannot be combined with tier_definitions",
+    });
+
+    renderWithProviders(<Harness />);
+    await user.type(screen.getByPlaceholderText(/smart_router/i), "rejected-router");
+    await user.click(screen.getByRole("button", { name: /add auto router/i }));
+
+    await waitFor(() => expect(validateAutoRouterConfig).toHaveBeenCalled());
+    expect(handleAddAutoRouterSubmit).not.toHaveBeenCalled();
+  });
+
+  it("submits when the dry-run passes, so the gate is not simply blocking everything", async () => {
+    const user = userEvent.setup();
+    vi.mocked(getMissingTiersError).mockReturnValue(null);
+    validateAutoRouterConfig.mockResolvedValueOnce({ valid: true });
+
+    renderWithProviders(<Harness />);
+    await user.type(screen.getByPlaceholderText(/smart_router/i), "accepted-router");
+    await user.click(screen.getByRole("button", { name: /add auto router/i }));
+
+    await waitFor(() => expect(handleAddAutoRouterSubmit).toHaveBeenCalled());
   });
 
   // LIT-5133: "Add keyword rule" seeds a row with no keywords, and the semantic toggle that used

--- a/ui/litellm-dashboard/src/components/add_model/add_auto_router_tab.tsx
+++ b/ui/litellm-dashboard/src/components/add_model/add_auto_router_tab.tsx
@@ -13,7 +13,7 @@ import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/comp
 import { UiLoadingSpinner } from "@/components/ui/ui-loading-spinner";
 import { useZodForm } from "@/lib/forms/useZodForm";
 import AccessGroupTagsCombobox from "./AccessGroupTagsCombobox";
-import { modelAvailableCall } from "../networking";
+import { modelAvailableCall, validateAutoRouterConfig } from "../networking";
 import { all_admin_roles } from "@/utils/roles";
 import { type ModelWriteScope } from "@/utils/modelPermissions";
 import TeamDropdown from "../common_components/team_dropdown";
@@ -33,6 +33,7 @@ import { DEFAULT_MATCH_THRESHOLD } from "./SemanticKeywordMatching";
 import {
   BuildComplexityRouterConfigParams,
   buildComplexityRouterConfig,
+  dryRunRejection,
   getKeywordTierRulesError,
   getClassifierModelError,
   getMissingTiersError,
@@ -401,6 +402,19 @@ const AddAutoRouterTab: React.FC<AddAutoRouterTabProps> = ({
       return;
     }
 
+    const complexityRouterConfigPayload = buildComplexityRouterConfig(complexityRouterConfigParams);
+    const serverVerdict = await validateAutoRouterConfig(
+      accessToken,
+      complexityRouterConfigPayload as unknown as Record<string, unknown>,
+      requiresTeamScope ? form.getValues("team_id") : undefined,
+    );
+    const dryRunError = dryRunRejection(serverVerdict);
+    if (dryRunError) {
+      setShowValidationErrors(true);
+      toast.fromError(dryRunError);
+      return;
+    }
+
     // auto_router_default_model (-> litellm_params, read by the backend at init) and
     // complexity_router_config.default_model (-> the pin marker read back on edit, see
     // hydratePinnedDefaultModel in edit_auto_router_modal.tsx) must both come from the same
@@ -410,7 +424,7 @@ const AddAutoRouterTab: React.FC<AddAutoRouterTabProps> = ({
       ...teamScopePayload(requiresTeamScope, form.getValues("team_id")),
       auto_router_default_model: defaultModel,
       model_type: "complexity_router",
-      complexity_router_config: buildComplexityRouterConfig(complexityRouterConfigParams),
+      complexity_router_config: complexityRouterConfigPayload,
       model_access_group: form.getValues("model_access_group"),
     };
 

--- a/ui/litellm-dashboard/src/components/add_model/add_auto_router_tab.tsx
+++ b/ui/litellm-dashboard/src/components/add_model/add_auto_router_tab.tsx
@@ -197,6 +197,7 @@ const AddAutoRouterTab: React.FC<AddAutoRouterTabProps> = ({
   const [matchThreshold, setMatchThreshold] = useState<number>(DEFAULT_MATCH_THRESHOLD);
   const [escalationKeywords, setEscalationKeywords] = useState<string[]>(DEFAULT_ESCALATION_KEYWORDS);
   const [showValidationErrors, setShowValidationErrors] = useState<boolean>(false);
+  const [isSubmitting, setIsSubmitting] = useState<boolean>(false);
 
   const [selectedPreset, setSelectedPreset] = useState<string | undefined>(undefined);
   // Closed by default: a caller opens it deliberately, either by clicking it or by choosing Custom
@@ -428,10 +429,11 @@ const AddAutoRouterTab: React.FC<AddAutoRouterTabProps> = ({
       model_access_group: form.getValues("model_access_group"),
     };
 
-    handleAddAutoRouterSubmit(submitValues, accessToken, () => form.reset(EMPTY_FORM_VALUES), handleOk);
+    await handleAddAutoRouterSubmit(submitValues, accessToken, () => form.reset(EMPTY_FORM_VALUES), handleOk);
   };
 
   const handleAutoRouterSubmit = async () => {
+    if (isSubmitting) return;
     const name = form.getValues("auto_router_name");
     if (!name) {
       setShowValidationErrors(true);
@@ -440,7 +442,12 @@ const AddAutoRouterTab: React.FC<AddAutoRouterTabProps> = ({
       return;
     }
 
-    await submitRecommendedRouter(name);
+    setIsSubmitting(true);
+    try {
+      await submitRecommendedRouter(name);
+    } finally {
+      setIsSubmitting(false);
+    }
   };
 
   const handleTestConnection = () => {
@@ -654,11 +661,12 @@ const AddAutoRouterTab: React.FC<AddAutoRouterTabProps> = ({
                   <BlockedReasonTooltip reason={submitBlockedReason}>
                     <Button
                       type="button"
-                      disabled={submitBlockedReason !== null}
+                      disabled={submitBlockedReason !== null || isSubmitting}
                       onClick={() => {
                         void handleAutoRouterSubmit();
                       }}
                     >
+                      {isSubmitting && <UiLoadingSpinner className="size-4" />}
                       Add Auto Router
                     </Button>
                   </BlockedReasonTooltip>

--- a/ui/litellm-dashboard/src/components/add_model/build_complexity_router_config.test.ts
+++ b/ui/litellm-dashboard/src/components/add_model/build_complexity_router_config.test.ts
@@ -763,8 +763,6 @@ describe("heuristic_first", () => {
 
 describe("dryRunRejection", () => {
   it("blocks the save on a rejection whose message is missing, which the write would return as a raw 400", () => {
-    // The verdict's two fields arrive independently, so a rejection carrying no message must still
-    // stop the save rather than fall through to the write endpoint.
     expect(dryRunRejection({ valid: false })).toBe("The proxy rejected this auto-router configuration");
     expect(dryRunRejection({ valid: false, error: null })).toBe("The proxy rejected this auto-router configuration");
     expect(dryRunRejection({ valid: false, error: "   " })).toBe("The proxy rejected this auto-router configuration");

--- a/ui/litellm-dashboard/src/components/add_model/build_complexity_router_config.test.ts
+++ b/ui/litellm-dashboard/src/components/add_model/build_complexity_router_config.test.ts
@@ -9,6 +9,7 @@ import {
   getTierLabelsError,
   hydrateTierLabels,
   BuildComplexityRouterConfigParams,
+  dryRunRejection,
 } from "./build_complexity_router_config";
 import { activeTierRows } from "./tier_rows";
 
@@ -757,5 +758,26 @@ describe("heuristic_first", () => {
       const config = buildComplexityRouterConfig({ ...heuristicFirstParams, classifierType });
       expect(config.heuristic_first_max_tier).toBeUndefined();
     }
+  });
+});
+
+describe("dryRunRejection", () => {
+  it("blocks the save on a rejection whose message is missing, which the write would return as a raw 400", () => {
+    // The verdict's two fields arrive independently, so a rejection carrying no message must still
+    // stop the save rather than fall through to the write endpoint.
+    expect(dryRunRejection({ valid: false })).toBe("The proxy rejected this auto-router configuration");
+    expect(dryRunRejection({ valid: false, error: null })).toBe("The proxy rejected this auto-router configuration");
+    expect(dryRunRejection({ valid: false, error: "   " })).toBe("The proxy rejected this auto-router configuration");
+  });
+
+  it("surfaces the backend's own message when it sent one", () => {
+    expect(dryRunRejection({ valid: false, error: "session_affinity cannot be combined with tier_definitions" })).toBe(
+      "session_affinity cannot be combined with tier_definitions",
+    );
+  });
+
+  it("lets a valid verdict through, including the fail-open one a transport failure returns", () => {
+    expect(dryRunRejection({ valid: true })).toBeNull();
+    expect(dryRunRejection({ valid: true, error: null })).toBeNull();
   });
 });

--- a/ui/litellm-dashboard/src/components/add_model/build_complexity_router_config.ts
+++ b/ui/litellm-dashboard/src/components/add_model/build_complexity_router_config.ts
@@ -108,14 +108,6 @@ export interface BuildComplexityRouterConfigParams {
   tierModelParams?: TierModelParamsByTier;
 }
 
-/**
- * The message to surface when the dry-run rejects a save, or null to let it through.
- *
- * Gated on `valid` alone. The verdict's `valid` is derived from `error` server side today, but the
- * two arrive as independent fields, so reading `error` as the gate would let a rejection whose
- * message is missing or blank through to the write and back as a raw 400. A transport failure fails
- * open as `{valid: true}`, which this passes, leaving the write gate authoritative.
- */
 export const dryRunRejection = (verdict: { valid: boolean; error?: string | null }): string | null =>
   verdict.valid ? null : verdict.error?.trim() || "The proxy rejected this auto-router configuration";
 

--- a/ui/litellm-dashboard/src/components/add_model/build_complexity_router_config.ts
+++ b/ui/litellm-dashboard/src/components/add_model/build_complexity_router_config.ts
@@ -108,6 +108,17 @@ export interface BuildComplexityRouterConfigParams {
   tierModelParams?: TierModelParamsByTier;
 }
 
+/**
+ * The message to surface when the dry-run rejects a save, or null to let it through.
+ *
+ * Gated on `valid` alone. The verdict's `valid` is derived from `error` server side today, but the
+ * two arrive as independent fields, so reading `error` as the gate would let a rejection whose
+ * message is missing or blank through to the write and back as a raw 400. A transport failure fails
+ * open as `{valid: true}`, which this passes, leaving the write gate authoritative.
+ */
+export const dryRunRejection = (verdict: { valid: boolean; error?: string | null }): string | null =>
+  verdict.valid ? null : verdict.error?.trim() || "The proxy rejected this auto-router configuration";
+
 export interface ComplexityRouterConfigPayload {
   tiers: ComplexityTiers;
   default_model?: string;

--- a/ui/litellm-dashboard/src/components/edit_auto_router/edit_auto_router_modal.test.tsx
+++ b/ui/litellm-dashboard/src/components/edit_auto_router/edit_auto_router_modal.test.tsx
@@ -101,8 +101,6 @@ describe("EditAutoRouterModal keyword matching", () => {
     expect(config.match_threshold).toBe(0.72);
   });
 
-  // Same gate as the create form: the dry-run's verdict has to stop the PATCH, or an operator sees
-  // a raw 400 instead of the inline message the dry-run was added to give them.
   it("does not PATCH when the backend's dry-run rejects the config", async () => {
     const user = userEvent.setup();
     validateAutoRouterConfig.mockResolvedValueOnce({

--- a/ui/litellm-dashboard/src/components/edit_auto_router/edit_auto_router_modal.test.tsx
+++ b/ui/litellm-dashboard/src/components/edit_auto_router/edit_auto_router_modal.test.tsx
@@ -16,10 +16,15 @@ const { modelPatchUpdateCall, modelAvailableCall, getAutoRouterClassifierDefault
   getAutoRouterClassifierDefaultPromptCall: vi.fn().mockResolvedValue("Classify the request into exactly one tier."),
 }));
 
+const { validateAutoRouterConfig } = vi.hoisted(() => ({
+  validateAutoRouterConfig: vi.fn().mockResolvedValue({ valid: true }),
+}));
+
 vi.mock("../networking", () => ({
   modelPatchUpdateCall,
   modelAvailableCall,
   getAutoRouterClassifierDefaultPromptCall,
+  validateAutoRouterConfig,
 }));
 
 vi.mock("@/app/(dashboard)/hooks/useAuthorized", () => ({ default: () => ({ accessToken: "sk-test" }) }));
@@ -94,6 +99,23 @@ describe("EditAutoRouterModal keyword matching", () => {
     expect(config.semantic_keyword_matching).toBe(true);
     expect(config.embedding_model).toBe("voyage-4-large");
     expect(config.match_threshold).toBe(0.72);
+  });
+
+  // Same gate as the create form: the dry-run's verdict has to stop the PATCH, or an operator sees
+  // a raw 400 instead of the inline message the dry-run was added to give them.
+  it("does not PATCH when the backend's dry-run rejects the config", async () => {
+    const user = userEvent.setup();
+    validateAutoRouterConfig.mockResolvedValueOnce({
+      valid: false,
+      error: "tier_labels cannot be combined with tier_definitions",
+    });
+
+    renderModal();
+    await screen.findByText(/Escalation Keywords/i);
+    await user.click(screen.getByRole("button", { name: /save changes/i }));
+
+    await waitFor(() => expect(validateAutoRouterConfig).toHaveBeenCalled());
+    expect(modelPatchUpdateCall).not.toHaveBeenCalled();
   });
 
   // The create form blocks this; the edit modal renders the same controls, so it must block it

--- a/ui/litellm-dashboard/src/components/edit_auto_router/edit_auto_router_modal.tsx
+++ b/ui/litellm-dashboard/src/components/edit_auto_router/edit_auto_router_modal.tsx
@@ -11,7 +11,7 @@ import { UiLoadingSpinner } from "@/components/ui/ui-loading-spinner";
 import { useZodForm } from "@/lib/forms/useZodForm";
 import AccessGroupTagsCombobox from "../add_model/AccessGroupTagsCombobox";
 import ModelChoiceCombobox, { type ModelChoice } from "../add_model/ModelChoiceCombobox";
-import { modelAvailableCall, modelPatchUpdateCall } from "../networking";
+import { modelAvailableCall, modelPatchUpdateCall, validateAutoRouterConfig } from "../networking";
 import { fetchAvailableModels, ModelGroup } from "@/components/llm_calls/fetch_models";
 import RouterConfigBuilder from "../add_model/RouterConfigBuilder";
 import { hydrateTierModelParams, normalizeTierModels } from "../add_model/complexity_router_tiers";
@@ -26,6 +26,7 @@ import {
   getPlanModeTierError,
   getTierLabelsError,
   hydrateTierLabels,
+  dryRunRejection,
 } from "../add_model/build_complexity_router_config";
 import { KeywordTierRule } from "../add_model/KeywordTierRules";
 import { DEFAULT_MATCH_THRESHOLD } from "../add_model/SemanticKeywordMatching";
@@ -516,23 +517,26 @@ const EditAutoRouterModal: React.FC<EditAutoRouterModalProps> = ({
         return;
       }
 
+      const updatedConfig = buildUpdatedComplexityRouterConfig(
+        modelData.litellm_params?.complexity_router_config,
+        complexityRouterConfig,
+        customTechnicalKeywords,
+        { keywordTierRules, escalationKeywords, semanticMatchingEnabled, embeddingModel, matchThreshold },
+      );
+      const serverVerdict = await validateAutoRouterConfig(accessToken, updatedConfig, modelData?.model_info?.team_id);
+      const dryRunError = dryRunRejection(serverVerdict);
+      if (dryRunError) {
+        setShowValidationErrors(true);
+        toast.fromError(dryRunError);
+        return;
+      }
+
       // Dual write: complexity_router_config.default_model (the pin marker hydratePinnedDefaultModel
       // reads back) and complexity_router_default_model (what the backend routes on) must always be
       // written together from the same value. Same pairing in add_auto_router_tab.tsx.
       const updatedLitellmParams = {
         ...modelData.litellm_params,
-        complexity_router_config: buildUpdatedComplexityRouterConfig(
-          modelData.litellm_params?.complexity_router_config,
-          complexityRouterConfig,
-          customTechnicalKeywords,
-          {
-            keywordTierRules,
-            escalationKeywords,
-            semanticMatchingEnabled,
-            embeddingModel,
-            matchThreshold,
-          },
-        ),
+        complexity_router_config: updatedConfig,
         complexity_router_default_model: defaultModel,
       };
       const updatedModelInfo = {

--- a/ui/litellm-dashboard/src/components/networking.tsx
+++ b/ui/litellm-dashboard/src/components/networking.tsx
@@ -8074,3 +8074,27 @@ export const deleteMemory = async (accessToken: string, key: string): Promise<vo
     throw new Error(errorData);
   }
 };
+
+export interface ComplexityRouterConfigValidation {
+  valid: boolean;
+  error?: string | null;
+}
+
+// Dry-runs the same write gate /model/new and /model/update apply, so a save that would come back
+// as a raw 400 shows the backend's own message inline first. Transport failures fail open: the
+// write gate stays authoritative.
+export const validateAutoRouterConfig = async (
+  accessToken: string,
+  complexityRouterConfig: Record<string, unknown>,
+  teamId?: string,
+): Promise<ComplexityRouterConfigValidation> => {
+  try {
+    return await apiClient.post<ComplexityRouterConfigValidation>("/auto_router/validate_complexity_router_config", {
+      accessToken,
+      body: { complexity_router_config: complexityRouterConfig, ...(teamId && { team_id: teamId }) },
+    });
+  } catch (error) {
+    console.warn("Could not dry-run the complexity router config; the save will be validated server side", error);
+    return { valid: true };
+  }
+};

--- a/ui/litellm-dashboard/src/components/networking.tsx
+++ b/ui/litellm-dashboard/src/components/networking.tsx
@@ -8080,9 +8080,6 @@ export interface ComplexityRouterConfigValidation {
   error?: string | null;
 }
 
-// Dry-runs the same write gate /model/new and /model/update apply, so a save that would come back
-// as a raw 400 shows the backend's own message inline first. Transport failures fail open: the
-// write gate stays authoritative.
 export const validateAutoRouterConfig = async (
   accessToken: string,
   complexityRouterConfig: Record<string, unknown>,


### PR DESCRIPTION
## TLDR

Problem this solves:

- Both auto-router forms build a payload and post it straight to the write endpoint
- Anything the write gate refuses comes back as a raw 400 with the message buried
- The operator has no way to see which setting combination was rejected

How it solves it:

- Both forms POST the exact payload to the existing dry-run endpoint first
- Its verdict shows inline, using the backend's own wording
- One `dryRunRejection` owns the gate, so the two forms cannot drift
- A transport failure fails open, leaving the write gate authoritative

## User Flow

Before: an operator saves a config the backend refuses

1. They open http://localhost:4000/ui/?page=models-and-endpoints, click Add Model, pick the Auto Router tab
2. They configure a combination the write gate rejects, then click Add Auto Router
3. The save fails with a raw 400 whose message is nested inside a proxy exception

After: the same save is stopped before it is attempted

1. Same steps, but the form dry-runs the payload first
2. The backend's own message appears inline and the create is never sent

## Relevant issues

Split out of the custom tier set work. It gates every auto-router save, built-in tiers included, so it stands on its own

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally
- [x] My PR passes all required CI/CD checks
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5**

## Screenshots / Proof of Fix

To be added: create an auto-router with a rejected setting combination and show the inline message replacing the raw 400

## Type

🆕 New Feature

## Caveats (if any)

- The dry-run costs one extra round trip per save. It runs only on submit, not per keystroke

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dashboard-only submit gating with fail-open on validate errors; no change to backend auth or persistence beyond skipping writes when dry-run rejects.
> 
> **Overview**
> Auto-router **create** and **edit** flows now POST the built `complexity_router_config` to `/auto_router/validate_complexity_router_config` before calling the write APIs. A failed dry-run shows the proxy’s error (or a generic fallback) via toast and **does not** create or PATCH.
> 
> Shared helper **`dryRunRejection`** maps validation verdicts to user-facing messages; **`validateAutoRouterConfig`** in networking wraps the API and **fails open** on transport errors so the server write gate stays authoritative.
> 
> The add form adds **`isSubmitting`**: the submit button disables with a spinner during the dry-run, and the handler blocks re-entry so double submit (e.g. Enter mid-request) cannot fire two validations or creates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9909c10043156e2018e04cd6292aefda41c5c35b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->