### PR TITLE
fix(router): fall over on raised mid-stream errors in /v1/messages streams

### DIFF
--- a/litellm/router.py
+++ b/litellm/router.py
@@ -420,6 +420,46 @@ def _anthropic_stream_should_decline_fallback(has_generated_content: bool, error
     return has_generated_content or not error.is_pre_first_chunk
 
 
+def _anthropic_stream_raised_error_status(error: Exception) -> int | None:
+    raw_status: Final = getattr(error, "status_code", None)
+    if isinstance(raw_status, int):
+        return raw_status
+    if isinstance(raw_status, str) and raw_status.isdigit():
+        return int(raw_status)
+    response_status: Final = getattr(getattr(error, "response", None), "status_code", None)
+    return response_status if isinstance(response_status, int) else None
+
+
+def _anthropic_stream_fallback_error_for_raised(
+    error: Exception, model: str, llm_provider: str, has_generated_content: bool
+) -> "MidStreamFallbackError | None":
+    """
+    A provider iterator that fails mid-stream by raising (Bedrock surfaces
+    its event-stream exception frames as a BedrockError, a transport drop
+    raises httpx's error) never produces the Anthropic SSE `event: error`
+    frame the wrapper detects, so the raise is converted into the same
+    MidStreamFallbackError a detected error event gets, under the same gate:
+    only before real content reached the caller and only for a retriable
+    status (429, 5xx, or none at all for a transport failure), mirroring
+    CustomStreamWrapper._handle_stream_fallback_error on /chat/completions.
+    None means the exception propagates to the caller unchanged.
+    """
+    from litellm.exceptions import MidStreamFallbackError
+
+    if has_generated_content:
+        return None
+    status_code: Final = _anthropic_stream_raised_error_status(error)
+    if status_code is not None and not _is_retriable_anthropic_status(status_code):
+        return None
+    return MidStreamFallbackError(
+        message=str(error),
+        model=model,
+        llm_provider=llm_provider,
+        original_exception=error,
+        is_pre_first_chunk=True,
+    )
+
+
 def _anthropic_stream_commits_now(chunk: object, has_generated_content: bool, buffered_chunk_count: int) -> bool:
     """
     Whether `chunk` should make Router._aanthropic_messages_streaming_iterator
@@ -5019,6 +5059,8 @@ class Router:
             has_generated_content = False  # rebind-ok: set once real content is seen, or the buffer cap is hit
             buffered_lifecycle_chunks: tuple[bytes, ...] = ()  # rebind-ok: flushed once committed or on decline
             model: Final = cast(str, initial_kwargs.get("model"))  # cast-ok: kwargs always carries the model group
+            custom_llm_provider: Final = initial_kwargs.get("custom_llm_provider")
+            llm_provider: Final = custom_llm_provider if isinstance(custom_llm_provider, str) else "anthropic"
             try:
                 async for chunk in source_iterator:
                     if _anthropic_stream_forwards_ping_live(
@@ -5061,14 +5103,16 @@ class Router:
                     yield chunk
                 for buffered_chunk in buffered_lifecycle_chunks:
                     yield buffered_chunk
-            except MidStreamFallbackError as e:
-                if _anthropic_stream_should_decline_fallback(has_generated_content, e):
-                    for buffered_chunk in buffered_lifecycle_chunks:
-                        yield buffered_chunk
-                    if e.original_exception is not None:
-                        raise e.original_exception from e
-                    raise
-                async for item in self._aanthropic_messages_fallback_attempt(e, initial_kwargs, wrapper):
+            except Exception as stream_error:  # noqa: BLE001  # any raised provider error must reach the fallback gate, like CustomStreamWrapper
+                async for item in self._aanthropic_messages_recover_stream_error(
+                    stream_error,
+                    has_generated_content,
+                    buffered_lifecycle_chunks,
+                    model,
+                    llm_provider,
+                    initial_kwargs,
+                    wrapper,
+                ):
                     yield item
             finally:
                 with anyio.CancelScope(shield=True), contextlib.suppress(BaseException):
@@ -5079,6 +5123,47 @@ class Router:
         # being defined textually after the function that captures it.
         wrapper: Final = FallbackAwareAnthropicMessagesStream(stream_with_fallbacks(), source_iterator)
         return wrapper
+
+    async def _aanthropic_messages_recover_stream_error(
+        self,
+        stream_error: Exception,
+        has_generated_content: bool,
+        buffered_lifecycle_chunks: tuple[bytes, ...],
+        model: str,
+        llm_provider: str,
+        initial_kwargs: dict[str, Any],  # mutable-ok: handed to _aanthropic_messages_fallback_attempt, which mutates it
+        wrapper: "FallbackAwareAnthropicMessagesStream",
+    ) -> AsyncGenerator[bytes, None]:
+        """
+        Decides what a source-iterator failure in
+        Router._aanthropic_messages_streaming_iterator turns into: a fallback
+        attempt, or the error reaching the caller. A MidStreamFallbackError
+        (completion-bridge path, or the wrapper's own SSE error-event
+        detection) is declined per _anthropic_stream_should_decline_fallback
+        with the held-back lifecycle frames flushed first; any other raise is
+        converted per _anthropic_stream_fallback_error_for_raised and, when
+        not convertible, propagates untouched so the caller still gets a
+        clean error response.
+        """
+        from litellm.exceptions import MidStreamFallbackError
+
+        if isinstance(stream_error, MidStreamFallbackError) and _anthropic_stream_should_decline_fallback(
+            has_generated_content, stream_error
+        ):
+            for buffered_chunk in buffered_lifecycle_chunks:
+                yield buffered_chunk
+            if stream_error.original_exception is not None:
+                raise stream_error.original_exception from stream_error
+            raise stream_error
+        fallback_error: Final = (
+            stream_error
+            if isinstance(stream_error, MidStreamFallbackError)
+            else _anthropic_stream_fallback_error_for_raised(stream_error, model, llm_provider, has_generated_content)
+        )
+        if fallback_error is None:
+            raise stream_error
+        async for item in self._aanthropic_messages_fallback_attempt(fallback_error, initial_kwargs, wrapper):
+            yield item
 
     async def _aanthropic_messages_fallback_attempt(
         self,

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -431,7 +431,7 @@ def _anthropic_stream_raised_error_status(error: Exception) -> int | None:
 
 
 def _anthropic_stream_fallback_error_for_raised(
-    error: Exception, model: str, llm_provider: str, has_generated_content: bool
+    error: Exception, model: str, has_generated_content: bool
 ) -> "MidStreamFallbackError | None":
     """
     A provider iterator that fails mid-stream by raising (Bedrock surfaces
@@ -454,7 +454,7 @@ def _anthropic_stream_fallback_error_for_raised(
     return MidStreamFallbackError(
         message=str(error),
         model=model,
-        llm_provider=llm_provider,
+        llm_provider="anthropic",
         original_exception=error,
         is_pre_first_chunk=True,
     )
@@ -5059,8 +5059,6 @@ class Router:
             has_generated_content = False  # rebind-ok: set once real content is seen, or the buffer cap is hit
             buffered_lifecycle_chunks: tuple[bytes, ...] = ()  # rebind-ok: flushed once committed or on decline
             model: Final = cast(str, initial_kwargs.get("model"))  # cast-ok: kwargs always carries the model group
-            custom_llm_provider: Final = initial_kwargs.get("custom_llm_provider")
-            llm_provider: Final = custom_llm_provider if isinstance(custom_llm_provider, str) else "anthropic"
             try:
                 async for chunk in source_iterator:
                     if _anthropic_stream_forwards_ping_live(
@@ -5109,7 +5107,6 @@ class Router:
                     has_generated_content,
                     buffered_lifecycle_chunks,
                     model,
-                    llm_provider,
                     initial_kwargs,
                     wrapper,
                 ):
@@ -5130,7 +5127,6 @@ class Router:
         has_generated_content: bool,
         buffered_lifecycle_chunks: tuple[bytes, ...],
         model: str,
-        llm_provider: str,
         initial_kwargs: dict[str, Any],  # mutable-ok: handed to _aanthropic_messages_fallback_attempt, which mutates it
         wrapper: "FallbackAwareAnthropicMessagesStream",
     ) -> AsyncGenerator[bytes, None]:
@@ -5158,7 +5154,7 @@ class Router:
         fallback_error: Final = (
             stream_error
             if isinstance(stream_error, MidStreamFallbackError)
-            else _anthropic_stream_fallback_error_for_raised(stream_error, model, llm_provider, has_generated_content)
+            else _anthropic_stream_fallback_error_for_raised(stream_error, model, has_generated_content)
         )
         if fallback_error is None:
             raise stream_error

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -433,17 +433,7 @@ def _anthropic_stream_raised_error_status(error: Exception) -> int | None:
 def _anthropic_stream_fallback_error_for_raised(
     error: Exception, model: str, has_generated_content: bool
 ) -> "MidStreamFallbackError | None":
-    """
-    A provider iterator that fails mid-stream by raising (Bedrock surfaces
-    its event-stream exception frames as a BedrockError, a transport drop
-    raises httpx's error) never produces the Anthropic SSE `event: error`
-    frame the wrapper detects, so the raise is converted into the same
-    MidStreamFallbackError a detected error event gets, under the same gate:
-    only before real content reached the caller and only for a retriable
-    status (429, 5xx, or none at all for a transport failure), mirroring
-    CustomStreamWrapper._handle_stream_fallback_error on /chat/completions.
-    None means the exception propagates to the caller unchanged.
-    """
+    """Same gate as a detected SSE error event; None means the raise propagates unchanged."""
     from litellm.exceptions import MidStreamFallbackError
 
     if has_generated_content:
@@ -5101,7 +5091,7 @@ class Router:
                     yield chunk
                 for buffered_chunk in buffered_lifecycle_chunks:
                     yield buffered_chunk
-            except Exception as stream_error:  # noqa: BLE001  # any raised provider error must reach the fallback gate, like CustomStreamWrapper
+            except Exception as stream_error:  # noqa: BLE001  # any raised provider error must reach the fallback gate
                 async for item in self._aanthropic_messages_recover_stream_error(
                     stream_error,
                     has_generated_content,
@@ -5130,17 +5120,7 @@ class Router:
         initial_kwargs: dict[str, Any],  # mutable-ok: handed to _aanthropic_messages_fallback_attempt, which mutates it
         wrapper: "FallbackAwareAnthropicMessagesStream",
     ) -> AsyncGenerator[bytes, None]:
-        """
-        Decides what a source-iterator failure in
-        Router._aanthropic_messages_streaming_iterator turns into: a fallback
-        attempt, or the error reaching the caller. A MidStreamFallbackError
-        (completion-bridge path, or the wrapper's own SSE error-event
-        detection) is declined per _anthropic_stream_should_decline_fallback
-        with the held-back lifecycle frames flushed first; any other raise is
-        converted per _anthropic_stream_fallback_error_for_raised and, when
-        not convertible, propagates untouched so the caller still gets a
-        clean error response.
-        """
+        """Turns a source-iterator failure into a fallback attempt or the error reaching the caller."""
         from litellm.exceptions import MidStreamFallbackError
 
         if isinstance(stream_error, MidStreamFallbackError) and _anthropic_stream_should_decline_fallback(

--- a/tests/test_litellm/test_router.py
+++ b/tests/test_litellm/test_router.py
@@ -15,6 +15,7 @@ import litellm
 from litellm import Router
 from litellm.exceptions import MidStreamFallbackError
 from litellm.integrations.custom_logger import CustomLogger
+from litellm.llms.bedrock.common_utils import BedrockError
 from litellm.llms.anthropic.experimental_pass_through.messages.agentic_streaming_iterator import (
     SERVER_FULFILLED_TOOL_LEAK_ERROR_SSE_BYTES,
 )
@@ -10220,6 +10221,119 @@ async def test_anthropic_messages_fallback_also_catches_raised_midstream_error()
     assert collected == [_anthropic_messages_content_chunk("fallback answer")]
     mock_fallback.assert_awaited_once()
     assert mock_fallback.await_args.kwargs["e"] is raised_error
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "raised_error",
+    [
+        BedrockError(status_code=503, message='serviceUnavailableException {"message": "Service unavailable"}'),
+        BedrockError(status_code=500, message='internalServerException {"message": "Internal error"}'),
+        BedrockError(status_code=429, message='throttlingException {"message": "Too many requests"}'),
+        httpx.ReadError("connection reset by upstream"),
+    ],
+    ids=["503", "500", "429", "transport-drop"],
+)
+async def test_anthropic_messages_raised_provider_error_before_content_triggers_fallback(raised_error):
+    """Bedrock surfaces a mid-stream exception frame by raising BedrockError
+    out of its iterator rather than yielding an Anthropic SSE error event, so
+    the wrapper must convert a retriable pre-content raise into a fallback
+    attempt exactly like a detected error event (parity with
+    CustomStreamWrapper._handle_stream_fallback_error on /chat/completions)."""
+    router = _anthropic_messages_make_router()
+    source = _AnthropicMessagesRaisingByteStream([_anthropic_messages_message_start_chunk()], raised_error)
+    fallback_stream = _AnthropicMessagesFallbackByteStream([_anthropic_messages_content_chunk("fallback answer")])
+
+    with patch.object(
+        router,
+        "async_function_with_fallbacks_common_utils",
+        new=AsyncMock(return_value=fallback_stream),
+    ) as mock_fallback:
+        wrapped = await router._aanthropic_messages_streaming_iterator(
+            response=source,
+            initial_kwargs={"model": "primary"},
+        )
+        collected = [chunk async for chunk in wrapped]
+
+    assert collected == [_anthropic_messages_content_chunk("fallback answer")]
+    mock_fallback.assert_awaited_once()
+    converted = mock_fallback.await_args.kwargs["e"]
+    assert isinstance(converted, MidStreamFallbackError)
+    assert converted.original_exception is raised_error
+    assert converted.is_pre_first_chunk is True
+    assert source.closed is True
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "raised_error",
+    [
+        BedrockError(status_code=400, message='validationException {"message": "Malformed input"}'),
+        BedrockError(status_code=424, message='modelStreamErrorException {"message": "Model stream error"}'),
+    ],
+    ids=["400", "424"],
+)
+async def test_anthropic_messages_raised_non_retriable_provider_error_propagates_unchanged(raised_error):
+    """A raised 4xx (other than 429) is a client error no other deployment can
+    fix: it reaches the caller as the very same exception, with no fallback
+    attempt and nothing flushed, so the proxy still answers a clean 4xx."""
+    router = _anthropic_messages_make_router()
+    source = _AnthropicMessagesRaisingByteStream([_anthropic_messages_message_start_chunk()], raised_error)
+
+    with patch.object(
+        router,
+        "async_function_with_fallbacks_common_utils",
+        new=AsyncMock(),
+    ) as mock_fallback:
+        wrapped = await router._aanthropic_messages_streaming_iterator(
+            response=source,
+            initial_kwargs={"model": "primary"},
+        )
+        collected = []
+
+        async def _consume():
+            async for chunk in wrapped:
+                collected.append(chunk)
+
+        with pytest.raises(BedrockError) as exc_info:
+            await _consume()
+
+    assert collected == []
+    assert exc_info.value is raised_error
+    mock_fallback.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_anthropic_messages_raised_provider_error_after_content_propagates_unchanged():
+    """Once real content reached the caller a fallback would append a second
+    message lifecycle to the same SSE stream, so a raised provider error after
+    content propagates as-is even when its status is retriable."""
+    router = _anthropic_messages_make_router()
+    content = _anthropic_messages_content_chunk("partial answer")
+    raised_error = BedrockError(status_code=503, message='serviceUnavailableException {"message": "Service unavailable"}')
+    source = _AnthropicMessagesRaisingByteStream([content], raised_error)
+
+    with patch.object(
+        router,
+        "async_function_with_fallbacks_common_utils",
+        new=AsyncMock(),
+    ) as mock_fallback:
+        wrapped = await router._aanthropic_messages_streaming_iterator(
+            response=source,
+            initial_kwargs={"model": "primary"},
+        )
+        collected = []
+
+        async def _consume():
+            async for chunk in wrapped:
+                collected.append(chunk)
+
+        with pytest.raises(BedrockError) as exc_info:
+            await _consume()
+
+    assert collected == [content]
+    assert exc_info.value is raised_error
+    mock_fallback.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/tests/test_litellm/test_router.py
+++ b/tests/test_litellm/test_router.py
@@ -24,6 +24,8 @@ from litellm.router import (
     MAX_BUFFERED_PRE_CONTENT_ANTHROPIC_CHUNKS,
     FallbackAwareAnthropicMessagesStream,
     _anthropic_stream_commits_now,
+    _anthropic_stream_fallback_error_for_raised,
+    _anthropic_stream_raised_error_status,
     _anthropic_stream_should_decline_fallback,
     _anthropic_stream_error_is_gateway_verdict,
     _anthropic_stream_forwards_ping_live,
@@ -10236,11 +10238,7 @@ async def test_anthropic_messages_fallback_also_catches_raised_midstream_error()
     ids=["503", "500", "429", "transport-drop"],
 )
 async def test_anthropic_messages_raised_provider_error_before_content_triggers_fallback(raised_error):
-    """Bedrock surfaces a mid-stream exception frame by raising BedrockError
-    out of its iterator rather than yielding an Anthropic SSE error event, so
-    the wrapper must convert a retriable pre-content raise into a fallback
-    attempt exactly like a detected error event (parity with
-    CustomStreamWrapper._handle_stream_fallback_error on /chat/completions)."""
+    """A retriable raise before content falls over exactly like a detected SSE error event."""
     router = _anthropic_messages_make_router()
     source = _AnthropicMessagesRaisingByteStream([_anthropic_messages_message_start_chunk()], raised_error)
     fallback_stream = _AnthropicMessagesFallbackByteStream([_anthropic_messages_content_chunk("fallback answer")])
@@ -10289,9 +10287,7 @@ class _AnthropicMessagesResponseOnlyStatusError(Exception):
     ids=["400", "424", "str-400", "response-only-400"],
 )
 async def test_anthropic_messages_raised_non_retriable_provider_error_propagates_unchanged(raised_error):
-    """A raised 4xx (other than 429) is a client error no other deployment can
-    fix: it reaches the caller as the very same exception, with no fallback
-    attempt and nothing flushed, so the proxy still answers a clean 4xx."""
+    """A raised client error reaches the caller as the same exception, nothing flushed, no fallback."""
     router = _anthropic_messages_make_router()
     source = _AnthropicMessagesRaisingByteStream([_anthropic_messages_message_start_chunk()], raised_error)
 
@@ -10320,12 +10316,12 @@ async def test_anthropic_messages_raised_non_retriable_provider_error_propagates
 
 @pytest.mark.asyncio
 async def test_anthropic_messages_raised_provider_error_after_content_propagates_unchanged():
-    """Once real content reached the caller a fallback would append a second
-    message lifecycle to the same SSE stream, so a raised provider error after
-    content propagates as-is even when its status is retriable."""
+    """A raise after content propagates unchanged even when its status is retriable."""
     router = _anthropic_messages_make_router()
     content = _anthropic_messages_content_chunk("partial answer")
-    raised_error = BedrockError(status_code=503, message='serviceUnavailableException {"message": "Service unavailable"}')
+    raised_error = BedrockError(
+        status_code=503, message='serviceUnavailableException {"message": "Service unavailable"}'
+    )
     source = _AnthropicMessagesRaisingByteStream([content], raised_error)
 
     with patch.object(
@@ -10349,6 +10345,93 @@ async def test_anthropic_messages_raised_provider_error_after_content_propagates
     assert collected == [content]
     assert exc_info.value is raised_error
     mock_fallback.assert_not_awaited()
+
+
+@pytest.mark.parametrize(
+    "error, expected_status",
+    [
+        (BedrockError(status_code=503, message="unavailable"), 503),
+        (_AnthropicMessagesStringStatusError(), 400),
+        (_AnthropicMessagesResponseOnlyStatusError(), 400),
+        (httpx.ReadError("connection reset by upstream"), None),
+    ],
+    ids=["int", "digit-str", "response-only", "none"],
+)
+def test_anthropic_stream_raised_error_status_reads_every_status_shape(error, expected_status):
+    assert _anthropic_stream_raised_error_status(error) == expected_status
+
+
+@pytest.mark.parametrize(
+    "error, has_generated_content, converts",
+    [
+        (BedrockError(status_code=503, message="unavailable"), False, True),
+        (httpx.ReadError("connection reset by upstream"), False, True),
+        (BedrockError(status_code=400, message="malformed"), False, False),
+        (BedrockError(status_code=503, message="unavailable"), True, False),
+    ],
+    ids=["retriable", "no-status", "client-error", "after-content"],
+)
+def test_anthropic_stream_fallback_error_for_raised_gates_like_a_detected_error_event(
+    error, has_generated_content, converts
+):
+    converted = _anthropic_stream_fallback_error_for_raised(error, "primary", has_generated_content)
+    if not converts:
+        assert converted is None
+        return
+    assert isinstance(converted, MidStreamFallbackError)
+    assert converted.original_exception is error
+    assert converted.is_pre_first_chunk is True
+    assert converted.llm_provider == "anthropic"
+
+
+@pytest.mark.asyncio
+async def test_aanthropic_messages_recover_stream_error_flushes_buffered_frames_before_declining():
+    router = _anthropic_messages_make_router()
+    original = BedrockError(status_code=503, message="unavailable")
+    declined = MidStreamFallbackError(
+        message="unavailable",
+        model="primary",
+        llm_provider="anthropic",
+        original_exception=original,
+        is_pre_first_chunk=False,
+    )
+    buffered = (_anthropic_messages_message_start_chunk(),)
+    flushed = []
+
+    async def drain(recovery) -> None:
+        async for chunk in recovery:
+            flushed.append(chunk)
+
+    with patch.object(router, "_aanthropic_messages_fallback_attempt") as mock_attempt:
+        recovery = router._aanthropic_messages_recover_stream_error(
+            declined, True, buffered, "primary", {"model": "primary"}, _anthropic_messages_make_wrapper()
+        )
+        with pytest.raises(BedrockError) as exc_info:
+            await drain(recovery)
+    assert flushed == list(buffered)
+    assert exc_info.value is original
+    mock_attempt.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_aanthropic_messages_recover_stream_error_hands_converted_raise_to_fallback_attempt():
+    router = _anthropic_messages_make_router()
+    raised = BedrockError(status_code=503, message="unavailable")
+    handed_over = []
+
+    async def fake_attempt(fallback_error, initial_kwargs, wrapper):
+        handed_over.append(fallback_error)
+        yield b"fallback"
+
+    with patch.object(router, "_aanthropic_messages_fallback_attempt", new=fake_attempt):
+        recovery = router._aanthropic_messages_recover_stream_error(
+            raised, False, (), "primary", {"model": "primary"}, _anthropic_messages_make_wrapper()
+        )
+        collected = [chunk async for chunk in recovery]
+    assert collected == [b"fallback"]
+    assert len(handed_over) == 1
+    assert isinstance(handed_over[0], MidStreamFallbackError)
+    assert handed_over[0].original_exception is raised
 
 
 @pytest.mark.asyncio

--- a/tests/test_litellm/test_router.py
+++ b/tests/test_litellm/test_router.py
@@ -4,6 +4,7 @@ import json
 import logging
 import os
 import threading
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
@@ -10264,14 +10265,28 @@ async def test_anthropic_messages_raised_provider_error_before_content_triggers_
     assert source.closed is True
 
 
+class _AnthropicMessagesStringStatusError(Exception):
+    def __init__(self):
+        super().__init__("bad request")
+        self.status_code = "400"
+
+
+class _AnthropicMessagesResponseOnlyStatusError(Exception):
+    def __init__(self):
+        super().__init__("bad request")
+        self.response = SimpleNamespace(status_code=400)
+
+
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     "raised_error",
     [
         BedrockError(status_code=400, message='validationException {"message": "Malformed input"}'),
         BedrockError(status_code=424, message='modelStreamErrorException {"message": "Model stream error"}'),
+        _AnthropicMessagesStringStatusError(),
+        _AnthropicMessagesResponseOnlyStatusError(),
     ],
-    ids=["400", "424"],
+    ids=["400", "424", "str-400", "response-only-400"],
 )
 async def test_anthropic_messages_raised_non_retriable_provider_error_propagates_unchanged(raised_error):
     """A raised 4xx (other than 429) is a client error no other deployment can
@@ -10295,7 +10310,7 @@ async def test_anthropic_messages_raised_non_retriable_provider_error_propagates
             async for chunk in wrapped:
                 collected.append(chunk)
 
-        with pytest.raises(BedrockError) as exc_info:
+        with pytest.raises(type(raised_error)) as exc_info:
             await _consume()
 
     assert collected == []


### PR DESCRIPTION
## TLDR

Problem this solves:

- Bedrock `/v1/messages` streams that fail mid-stream never fall over
- Bedrock raises the exception frame instead of yielding an SSE error event
- The router's messages wrapper only handled the SSE error event shape
- Claude Code retries the same dead primary ten times, then gives up

How it solves it:

- The wrapper now catches exceptions the source iterator raises
- Pre-content raises with a retriable status become a fallback attempt
- 4xx (except 429) and post-content raises still propagate unchanged
- Same rule `/chat/completions` already applies to raised stream errors

## User Flow

Before: a developer whose Claude Code session runs through the gateway against a Bedrock deployment with a fallback configured watches the session die with a 503 whenever Bedrock fails right after the stream opens, and the fallback never serves

1. The proxy admin configures model group `bedrock-claude-primary` (a Bedrock Claude deployment) and `bedrock-claude-fallback`, with `router_settings.fallbacks: [{bedrock-claude-primary: [bedrock-claude-fallback]}]`
2. The developer starts Claude Code with `ANTHROPIC_BASE_URL=https://litellm-domain` and `ANTHROPIC_MODEL=bedrock-claude-primary` and sends a prompt; Claude Code sends POST https://litellm-domain/v1/messages with `"stream": true`
3. Bedrock opens the stream, sends `message_start`, then fails with a `serviceUnavailableException` frame before any text
4. The response comes back `503 Service Unavailable` with body `{"error":{"message":"serviceUnavailableException {\"message\": ...}","code":"503"}}` and `x-litellm-attempted-fallbacks: 0`; `bedrock-claude-fallback` is never called
5. Claude Code shows `API error · Retrying in 0s · attempt 2/10` through `attempt 10/10` and ends with `API Error: 503 serviceUnavailableException ...` after about three and a half minutes, every retry landing on the same failing primary
6. The same prompt sent to POST https://litellm-domain/v1/chat/completions with `"stream": true` does fall over to `bedrock-claude-fallback`

After: the same session gets its answer from the fallback deployment, with no client-side retries

1. The proxy admin configures model group `bedrock-claude-primary` (a Bedrock Claude deployment) and `bedrock-claude-fallback`, with `router_settings.fallbacks: [{bedrock-claude-primary: [bedrock-claude-fallback]}]`
2. The developer starts Claude Code with `ANTHROPIC_BASE_URL=https://litellm-domain` and `ANTHROPIC_MODEL=bedrock-claude-primary` and sends a prompt; Claude Code sends POST https://litellm-domain/v1/messages with `"stream": true`
3. Bedrock opens the stream, sends `message_start`, then fails with a `serviceUnavailableException` frame before any text
4. The response comes back `200 OK` as a normal SSE stream (`message_start`, `content_block_delta` text, `message_stop` with usage) answered by `bedrock-claude-fallback`
5. Claude Code prints the answer in about five seconds with no retry banner
6. The same prompt sent to POST https://litellm-domain/v1/chat/completions with `"stream": true` falls over to `bedrock-claude-fallback` as before

## Relevant issues

## Linear ticket

Resolves LIT-6257

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Setup: a fault-injecting bedrock-runtime upstream on `127.0.0.1:34820` answers `POST /model/{id}/invoke-with-response-stream` (and `converse-stream` for the control) with a real AWS event-stream: one `chunk` frame carrying `message_start`, then an exception frame (`:exception-type: serviceUnavailableException`), which is exactly what a throttled or degraded Bedrock endpoint sends after the stream has started. The `bedrock-claude-primary` deployment points at it through `aws_bedrock_runtime_endpoint`; `bedrock-claude-fallback` is the same model on real Bedrock `us-east-1` with real credentials from the environment. Both legs ran the proxy the way customers deploy it, with 2 uvicorn workers (`--num_workers 2`), from the same config and the same environment, differing only in the tree the proxy was booted from: the merge base `7083c47998` on port 31262 for the before leg, this PR's tip `406db3fccf` on port 37572 for the after leg. The end-user client is Claude Code v2.1.250 in gateway mode, driven interactively under tmux, plus the curl commands shown

<details>
<summary>config.yaml</summary>

```yaml
model_list:
  - model_name: bedrock-claude-primary
    litellm_params:
      model: bedrock/us.anthropic.claude-haiku-4-5-20251001-v1:0
      aws_region_name: us-east-1
      aws_access_key_id: FAKEPRIMARYKEY
      aws_secret_access_key: FAKEPRIMARYSECRET
      aws_bedrock_runtime_endpoint: http://127.0.0.1:34820
  - model_name: bedrock-claude-fallback
    litellm_params:
      model: bedrock/us.anthropic.claude-haiku-4-5-20251001-v1:0
      aws_region_name: us-east-1
  - model_name: bedrock-claude-nofallback
    litellm_params: <same as bedrock-claude-primary>
  - model_name: bedrock-claude-doublefail
    litellm_params: <same as bedrock-claude-primary>
  - model_name: bedrock-claude-fake-fallback
    litellm_params: <same as bedrock-claude-primary>
router_settings:
  fallbacks:
    - bedrock-claude-primary: ["bedrock-claude-fallback"]
    - bedrock-claude-doublefail: ["bedrock-claude-fake-fallback"]
general_settings:
  master_key: sk-1234
litellm_settings:
  drop_params: true
```

The last three groups exist only for the two blast-radius checks at the bottom of each leg (no fallback configured, fallback fails the same way) and are inert for the primary cases
</details>

Proxy boot, identical on both sides except the tree:

```
$ python litellm/proxy/proxy_cli.py --config config.yaml --port <port> --num_workers 2 --use_v2_migration_resolver
INFO:     Uvicorn running on http://0.0.0.0:<port> (Press CTRL+C to quit)
INFO:     Started server process [65191]
INFO:     Started server process [65190]
```

Claude Code launch, identical on both sides except the port:

```
$ ANTHROPIC_BASE_URL=http://127.0.0.1:<port> ANTHROPIC_AUTH_TOKEN=sk-1234 ANTHROPIC_MODEL=bedrock-claude-primary claude
```

### Before (7083c47998, 2 workers)

#### /v1/messages stream

```
$ curl -sS -i -N http://127.0.0.1:31262/v1/messages -H "Authorization: Bearer sk-1234" -H "content-type: application/json" -d '{"model":"bedrock-claude-primary","max_tokens":64,"stream":true,"messages":[{"role":"user","content":"Reply with exactly one word: pong"}]}'
HTTP/1.1 503 Service Unavailable
x-litellm-model-group: bedrock-claude-primary
x-litellm-attempted-retries: 0
x-litellm-attempted-fallbacks: 0
content-type: application/json

{"error":{"message":"serviceUnavailableException {\"message\": \"fake upstream injected serviceUnavailableException mid-stream\"}","type":"None","param":"None","code":"503"}}
```

The fake upstream logged the hit (`sent message_start, now injecting serviceUnavailableException`); the fallback deployment was never called

#### Claude Code

Sent `Reply with exactly one word: pong` in the tmux session. The client retried ten times against the failing primary, every retry hitting the fake upstream, and gave up after three minutes:

```
❯ Reply with exactly one word: pong
✻ 503 serviceUnavailableException {"message": "fake upstream injected serviceUnavailableException mid-stream"} · Retrying in 1s · attempt 9/10
⏺ API Error: 503 serviceUnavailableException {"message": "fake upstream injected serviceUnavailableException mid-stream"}. This is a server-side issue,
  usually temporary — try again in a moment. If it persists, check your inference gateway (127.0.0.1:31262).
✻ Brewed for 3m 8s · done 6:29 PM
```

#### /v1/chat/completions stream (control, path not touched by this PR)

```
$ curl -sS -i -N http://127.0.0.1:31262/v1/chat/completions -H "Authorization: Bearer sk-1234" -H "content-type: application/json" -d '{"model":"bedrock-claude-primary","max_tokens":64,"stream":true,"messages":[{"role":"user","content":"Reply with exactly one word: pong"}]}'
HTTP/1.1 200 OK
x-litellm-model-group: bedrock-claude-primary
x-litellm-attempted-fallbacks: 0
content-type: text/event-stream; charset=utf-8

data: {"id":"chatcmpl-a672582b-1cef-4abb-9043-91db6c8b1aa7","created":1787880357,"model":"bedrock-claude-fallback","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"content":"p","role":"assistant"}}],"provider_specific_fields":{}}
data: {"id":"chatcmpl-a672582b-1cef-4abb-9043-91db6c8b1aa7","created":1787880357,"model":"bedrock-claude-fallback","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"content":"ong"}}],"provider_specific_fields":{}}
data: {"id":"chatcmpl-a672582b-1cef-4abb-9043-91db6c8b1aa7","created":1787880357,"model":"bedrock-claude-fallback","object":"chat.completion.chunk","choices":[{"finish_reason":"stop","index":0,"delta":{}}],"provider_specific_fields":{}}
data: [DONE]
```

The same raised mid-stream error already falls over on this endpoint (`"model":"bedrock-claude-fallback"` in every chunk), which is the parity this PR brings to `/v1/messages`

#### Blast-radius checks: no fallback configured, and fallback fails the same way

```
$ curl -sS -i -N http://127.0.0.1:31262/v1/messages ... -d '{"model":"bedrock-claude-nofallback", ...same body...}'
HTTP/1.1 503 Service Unavailable
x-litellm-model-group: bedrock-claude-nofallback
x-litellm-attempted-fallbacks: 0

{"error":{"message":"serviceUnavailableException {\"message\": \"fake upstream injected serviceUnavailableException mid-stream\"}","type":"None","param":"None","code":"503"}}

$ curl -sS -i -N http://127.0.0.1:31262/v1/messages ... -d '{"model":"bedrock-claude-doublefail", ...same body...}'
HTTP/1.1 503 Service Unavailable
x-litellm-model-group: bedrock-claude-doublefail
x-litellm-attempted-fallbacks: 0

{"error":{"message":"serviceUnavailableException {\"message\": \"fake upstream injected serviceUnavailableException mid-stream\"}","type":"None","param":"None","code":"503"}}
```

### After (406db3fccf, 2 workers)

#### /v1/messages stream

```
$ curl -sS -i -N http://127.0.0.1:37572/v1/messages -H "Authorization: Bearer sk-1234" -H "content-type: application/json" -d '{"model":"bedrock-claude-primary","max_tokens":64,"stream":true,"messages":[{"role":"user","content":"Reply with exactly one word: pong"}]}'
HTTP/1.1 200 OK
x-litellm-model-group: bedrock-claude-primary
x-litellm-attempted-retries: 0
x-litellm-attempted-fallbacks: 0
content-type: text/event-stream; charset=utf-8

event: message_start
data: {"type": "message_start", "message": {"model": "claude-haiku-4-5-20251001", "id": "msg_bdrk_01GLboCLNqAbMpazcPEdhgJ5", "type": "message", "role": "assistant", "content": [], "stop_reason": null, "stop_sequence": null, "usage": {...}}}
event: content_block_start
data: {"type": "content_block_start", "index": 0, "content_block": {"type": "text", "text": ""}}
event: content_block_delta
data: {"type": "content_block_delta", "index": 0, "delta": {"type": "text_delta", "text": "p"}}
event: content_block_delta
data: {"type": "content_block_delta", "index": 0, "delta": {"type": "text_delta", "text": "ong"}}
event: content_block_stop
data: {"type": "content_block_stop", "index": 0}
event: message_delta
data: {"type": "message_delta", "delta": {"stop_reason": "end_turn", "stop_sequence": null}, "usage": {"input_tokens": 15, "cache_creation_input_tokens": 0, "cache_read_input_tokens": 0, "output_tokens": 5, ...}}
event: message_stop
data: {"type": "message_stop", "usage": {"input_tokens": 15, "output_tokens": 5}}
```

The fake upstream logged the same hit and injected the same exception frame; the `msg_bdrk_` id and the text came from the real Bedrock fallback deployment

#### Claude Code

Same prompt in a fresh tmux session pointed at port 37572. One hit on the fake upstream, no retry banner, answer in two seconds from the fallback:

```
❯ Reply with exactly one word: pong
  Thought for 2s
⏺ pong
✻ Worked for 2s · done 6:31 PM
```

#### /v1/chat/completions stream (control, path not touched by this PR)

```
$ curl -sS -i -N http://127.0.0.1:37572/v1/chat/completions -H "Authorization: Bearer sk-1234" -H "content-type: application/json" -d '{"model":"bedrock-claude-primary","max_tokens":64,"stream":true,"messages":[{"role":"user","content":"Reply with exactly one word: pong"}]}'
HTTP/1.1 200 OK
x-litellm-model-group: bedrock-claude-primary
x-litellm-attempted-fallbacks: 0
content-type: text/event-stream; charset=utf-8

data: {"id":"chatcmpl-cf2cedbb-f6d2-42d4-a5fd-51d51b1521ef","created":1787880641,"model":"bedrock-claude-fallback","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"content":"p","role":"assistant"}}],"provider_specific_fields":{}}
data: {"id":"chatcmpl-cf2cedbb-f6d2-42d4-a5fd-51d51b1521ef","created":1787880641,"model":"bedrock-claude-fallback","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"content":"ong"}}],"provider_specific_fields":{}}
data: {"id":"chatcmpl-cf2cedbb-f6d2-42d4-a5fd-51d51b1521ef","created":1787880641,"model":"bedrock-claude-fallback","object":"chat.completion.chunk","choices":[{"finish_reason":"stop","index":0,"delta":{}}],"provider_specific_fields":{}}
data: [DONE]
```

Unchanged, as expected

#### Blast-radius checks: no fallback configured, and fallback fails the same way

```
$ curl -sS -i -N http://127.0.0.1:37572/v1/messages ... -d '{"model":"bedrock-claude-nofallback", ...same body...}'
HTTP/1.1 503 Service Unavailable
x-litellm-model-group: bedrock-claude-nofallback
x-litellm-attempted-fallbacks: 0

{"error":{"message":"serviceUnavailableException {\"message\": \"fake upstream injected serviceUnavailableException mid-stream\"}","type":"None","param":"None","code":"503"}}

$ curl -sS -i -N http://127.0.0.1:37572/v1/messages ... -d '{"model":"bedrock-claude-doublefail", ...same body...}'
HTTP/1.1 200 OK
x-litellm-model-group: bedrock-claude-doublefail
x-litellm-attempted-fallbacks: 0
content-type: text/event-stream; charset=utf-8

event: message_start
data: {"type": "message_start", "message": {"id": "msg_fake", "type": "message", "role": "assistant", "model": "us.anthropic.claude-haiku-4-5-20251001-v1:0", "content": [], "stop_reason": null, "usage": {...}}}

data: {"error": {"message": "serviceUnavailableException {\"message\": \"fake upstream injected serviceUnavailableException mid-stream\"}", "type": "None", "param": "None", "code": "503"}}
```

With no fallback group the original provider error still reaches the caller unchanged, byte for byte the same body as before. When the fallback fails the same way, the client now gets a 200 whose stream carries the fallback's `message_start` and then the upstream error as an SSE error chunk, instead of the 503 JSON it got before: the fallback's lifecycle events are put on the wire as they arrive (the same shape a fallback that fails after an SSE-detected error has today), so the status cannot change afterwards. Claude Code pointed at `bedrock-claude-doublefail` treated that stream as an error and recovered on its own: it printed `Streaming response ended before any complete data was received. Retrying without streaming.` and then showed the answer the fake upstream's non-streaming `/invoke` returned (`FAKE-UPSTREAM-OK`)

QA notes:

- Fallback-served streams still report `x-litellm-attempted-fallbacks: 0`; pre-existing, left alone
- Double failure answers 200 plus SSE error chunk, not 503; pre-existing fallback shape
- Claude Code retries that shape without streaming; no spin
- No-fallback error body is byte-identical before and after
- Claude Code also sends non-streaming `/v1/messages` calls; unaffected either way

The same four curl cases, re-run with the proxy booted from this branch merged into `litellm_internal_staging` at `10cd9259a3` (merge commit built locally, 2 workers), answer identically to the tip

Commits after `406db3fccf` (`e6a568d99b`) add direct unit tests for the new helpers and trim their docstrings, which cannot change behavior, so the proof above stays at the hash it ran at

## Type

🐛 Bug Fix

## Caveats (if any)

### Low

- Response headers of a fallback-served stream still describe the primary attempt
  - `x-litellm-attempted-fallbacks: 0` and the primary's `x-litellm-model-id`
  - Headers leave before the body; same for the existing SSE error-event fallback path
- A fallback that fails the same way before content answers 200 with its `message_start` and an SSE error chunk, where the primary failure alone used to answer 503 JSON
  - The fallback's lifecycle frames go on the wire as they arrive, the shape the SSE error-event path already has; observed on the after leg above, and Claude Code recovers by retrying without streaming
  - Holding the fallback's frames back the way the primary's are held would fix it for both paths; left as a follow-up since it changes the pre-existing path too, tracked in #38610
- A raised error with no status (transport drop, read timeout on the native passthrough) counts as retriable and falls over
  - Bedrock's `modelTimeoutException` (408) and the completion bridge's mapped `Timeout` (408) propagate unchanged, as on `/chat/completions`; falling over on a status-less pre-content failure is deliberate here
- The `/v1/chat/completions` control only falls over with IAM-shaped AWS env creds present
  - Bearer-token-only Bedrock env crashes that path with `'NoneType' object has no attribute 'access_key'`
  - Unrelated to this PR, on the converse path since #37241; filed as #38579

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
- [x] 406db3fccf passes /live-pr-risk (carried to e6a568d99b, tests and docstrings only)
