### PR TITLE
feat(a2a): semantic search over the agent registry via GET /v1/agents?query and an agent_search MCP tool

### DIFF
--- a/litellm/__init__.py
+++ b/litellm/__init__.py
@@ -487,6 +487,7 @@ public_mcp_servers: Optional[List[str]] = None
 public_mcp_hub_strict_whitelist: bool = True
 public_model_groups: Optional[List[str]] = None
 public_agent_groups: Optional[List[str]] = None
+agent_search_embedding_model: Optional[str] = None
 # Supports both old format (Dict[str, str]) and new format (Dict[str, Dict[str, Any]])
 # New format: { "displayName": { "url": "...", "index": 0 } }
 # Old format: { "displayName": "url" } (for backward compatibility)

--- a/litellm/proxy/_experimental/mcp_server/rest_endpoints.py
+++ b/litellm/proxy/_experimental/mcp_server/rest_endpoints.py
@@ -168,8 +168,11 @@ if MCP_AVAILABLE:
             MCPRequestHandler,
         )
         from litellm.proxy._experimental.mcp_server.tool_search import (
+            AGENT_SEARCH_TOOL_NAME,
+            DEFAULT_AGENT_SEARCH_TOP_K,
             MCP_TOOL_SEARCH_TOOL_NAME,
             coerce_top_k,
+            handle_agent_search,
             handle_mcp_tool_call,
             handle_mcp_tool_search,
         )
@@ -182,6 +185,14 @@ if MCP_AVAILABLE:
                 detail={"error": "forbidden", "message": f"{tool_name} requires mcp_tool_search_enabled on the key"},
             )
         tool_arguments: Final = data.get("arguments") or {}
+        if tool_name == AGENT_SEARCH_TOOL_NAME:
+            return await handle_agent_search(
+                query=str(tool_arguments.get("query", "")),
+                top_k=coerce_top_k(
+                    tool_arguments.get("top_k", DEFAULT_AGENT_SEARCH_TOP_K), default=DEFAULT_AGENT_SEARCH_TOP_K
+                ),
+                user_api_key_dict=user_api_key_dict,
+            )
         rest_client_ip: Final = IPAddressUtils.get_mcp_client_ip(request)
         (
             virtual_mcp_auth_header,
@@ -939,12 +950,9 @@ if MCP_AVAILABLE:
             tool_name: Final[str | None] = data.get("name")
             tool_arguments: Final[dict[str, object]] = data.get("arguments") or {}
 
-            from litellm.proxy._experimental.mcp_server.tool_search import (
-                MCP_TOOL_CALL_TOOL_NAME,
-                MCP_TOOL_SEARCH_TOOL_NAME,
-            )
+            from litellm.proxy._experimental.mcp_server.tool_search import VIRTUAL_TOOL_NAMES
 
-            if tool_name in (MCP_TOOL_SEARCH_TOOL_NAME, MCP_TOOL_CALL_TOOL_NAME):
+            if tool_name in VIRTUAL_TOOL_NAMES:
                 return await _handle_virtual_mcp_tool(request, data, tool_name, user_api_key_dict)
 
             # Validate required parameters early

--- a/litellm/proxy/_experimental/mcp_server/server.py
+++ b/litellm/proxy/_experimental/mcp_server/server.py
@@ -912,14 +912,17 @@ if MCP_AVAILABLE:
         the caller falls through to normal tool routing.
         """
         from litellm.proxy._experimental.mcp_server.tool_search import (
-            MCP_TOOL_CALL_TOOL_NAME,
+            AGENT_SEARCH_TOOL_NAME,
+            DEFAULT_AGENT_SEARCH_TOP_K,
             MCP_TOOL_SEARCH_TOOL_NAME,
+            VIRTUAL_TOOL_NAMES,
             coerce_top_k,
+            handle_agent_search,
             handle_mcp_tool_call,
             handle_mcp_tool_search,
         )
 
-        if name not in (MCP_TOOL_SEARCH_TOOL_NAME, MCP_TOOL_CALL_TOOL_NAME):
+        if name not in VIRTUAL_TOOL_NAMES:
             return None
 
         if not getattr(
@@ -952,6 +955,12 @@ if MCP_AVAILABLE:
             )
 
         assert user_api_key_auth is not None  # guaranteed by the flag check above
+        if name == AGENT_SEARCH_TOOL_NAME:
+            return await handle_agent_search(
+                query=str(args.get("query", "")),
+                top_k=coerce_top_k(args.get("top_k", DEFAULT_AGENT_SEARCH_TOP_K), default=DEFAULT_AGENT_SEARCH_TOP_K),
+                user_api_key_dict=user_api_key_auth,
+            )
         virtual_logging_obj: Final = await _build_virtual_call_logging_obj(
             name=name,
             arguments=args,

--- a/litellm/proxy/_experimental/mcp_server/tool_search.py
+++ b/litellm/proxy/_experimental/mcp_server/tool_search.py
@@ -142,6 +142,7 @@ async def handle_agent_search(query: str, top_k: int, user_api_key_dict: UserAPI
         router=llm_router,
         embedding_model=litellm.agent_search_embedding_model,
         index=global_agent_search_index,
+        user_api_key_dict=user_api_key_dict,
     )
     match outcome:
         case AgentSearchHits(hits):

--- a/litellm/proxy/_experimental/mcp_server/tool_search.py
+++ b/litellm/proxy/_experimental/mcp_server/tool_search.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import json
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 from datetime import datetime
 from typing import TYPE_CHECKING, Any, Final, TypedDict, assert_never
 
@@ -51,13 +51,17 @@ class _ToolParamSchema(TypedDict, total=False):
 class _ToolInputSchema(TypedDict):
     type: ReadOnly[str]
     properties: ReadOnly[Mapping[str, _ToolParamSchema]]
-    required: ReadOnly[tuple[str, ...]]
+    required: ReadOnly[Sequence[str]]
 
 
 class VirtualToolDefinition(TypedDict):
     name: ReadOnly[str]
     description: ReadOnly[str]
     inputSchema: ReadOnly[_ToolInputSchema]
+
+
+def _json_array(*items: str) -> Sequence[str]:
+    return list(items)  # mutable-ok: jsonschema's metaschema only accepts a JSON array for required
 
 
 _MCP_TOOL_SEARCH_DEFINITION: Final[VirtualToolDefinition] = {
@@ -69,7 +73,7 @@ _MCP_TOOL_SEARCH_DEFINITION: Final[VirtualToolDefinition] = {
             "query": {"type": "string", "description": "Keywords to search for in tool names and descriptions."},
             "top_k": {"type": "integer", "description": "Maximum number of results to return.", "default": 5},
         },
-        "required": ("query",),
+        "required": _json_array("query"),
     },
 }
 
@@ -82,7 +86,7 @@ _MCP_TOOL_CALL_DEFINITION: Final[VirtualToolDefinition] = {
             "tool_name": {"type": "string", "description": "The exact name of the MCP tool to call."},
             "arguments": {"type": "object", "description": "Arguments to pass to the tool."},
         },
-        "required": ("tool_name",),
+        "required": _json_array("tool_name"),
     },
 }
 
@@ -99,7 +103,7 @@ _AGENT_SEARCH_DEFINITION: Final[VirtualToolDefinition] = {
                 "default": DEFAULT_AGENT_SEARCH_TOP_K,
             },
         },
-        "required": ("query",),
+        "required": _json_array("query"),
     },
 }
 

--- a/litellm/proxy/_experimental/mcp_server/tool_search.py
+++ b/litellm/proxy/_experimental/mcp_server/tool_search.py
@@ -1,8 +1,14 @@
 from __future__ import annotations
 
 import json
+from collections.abc import Mapping
 from datetime import datetime
-from typing import TYPE_CHECKING, Any, Final
+from typing import TYPE_CHECKING, Any, Final, TypedDict, assert_never
+
+from typing_extensions import ReadOnly, Required
+
+import litellm
+from litellm.proxy.agent_endpoints.agent_search import DEFAULT_AGENT_SEARCH_TOP_K
 
 if TYPE_CHECKING:
     from mcp.types import CallToolResult
@@ -12,6 +18,8 @@ if TYPE_CHECKING:
 
 MCP_TOOL_SEARCH_TOOL_NAME: Final[str] = "mcp_tool_search"
 MCP_TOOL_CALL_TOOL_NAME: Final[str] = "mcp_tool_call"
+AGENT_SEARCH_TOOL_NAME: Final[str] = "agent_search"
+VIRTUAL_TOOL_NAMES: Final = frozenset((MCP_TOOL_SEARCH_TOOL_NAME, MCP_TOOL_CALL_TOOL_NAME, AGENT_SEARCH_TOOL_NAME))
 
 
 def coerce_top_k(value: Any, default: int = 5) -> int:
@@ -34,46 +42,111 @@ def search_tools(query: str, tools: list[dict[str, Any]], top_k: int = 5) -> lis
     return [tool for _, tool in sorted(scored, key=lambda x: x[0], reverse=True)[:top_k]]
 
 
-def get_virtual_tool_definitions() -> list[dict[str, Any]]:
-    return [
-        {
-            "name": MCP_TOOL_SEARCH_TOOL_NAME,
-            "description": "Search for MCP tools by keyword. Returns top matching tools with names, descriptions, and input schemas.",
-            "inputSchema": {
-                "type": "object",
-                "properties": {
-                    "query": {
-                        "type": "string",
-                        "description": "Keywords to search for in tool names and descriptions.",
-                    },
-                    "top_k": {
-                        "type": "integer",
-                        "description": "Maximum number of results to return.",
-                        "default": 5,
-                    },
-                },
-                "required": ["query"],
+class _ToolParamSchema(TypedDict, total=False):
+    type: Required[ReadOnly[str]]
+    description: Required[ReadOnly[str]]
+    default: ReadOnly[int]
+
+
+class _ToolInputSchema(TypedDict):
+    type: ReadOnly[str]
+    properties: ReadOnly[Mapping[str, _ToolParamSchema]]
+    required: ReadOnly[tuple[str, ...]]
+
+
+class VirtualToolDefinition(TypedDict):
+    name: ReadOnly[str]
+    description: ReadOnly[str]
+    inputSchema: ReadOnly[_ToolInputSchema]
+
+
+_MCP_TOOL_SEARCH_DEFINITION: Final[VirtualToolDefinition] = {
+    "name": MCP_TOOL_SEARCH_TOOL_NAME,
+    "description": "Search for MCP tools by keyword. Returns top matching tools with names, descriptions, and input schemas.",
+    "inputSchema": {
+        "type": "object",
+        "properties": {
+            "query": {"type": "string", "description": "Keywords to search for in tool names and descriptions."},
+            "top_k": {"type": "integer", "description": "Maximum number of results to return.", "default": 5},
+        },
+        "required": ("query",),
+    },
+}
+
+_MCP_TOOL_CALL_DEFINITION: Final[VirtualToolDefinition] = {
+    "name": MCP_TOOL_CALL_TOOL_NAME,
+    "description": "Call an MCP tool by name with the given arguments.",
+    "inputSchema": {
+        "type": "object",
+        "properties": {
+            "tool_name": {"type": "string", "description": "The exact name of the MCP tool to call."},
+            "arguments": {"type": "object", "description": "Arguments to pass to the tool."},
+        },
+        "required": ("tool_name",),
+    },
+}
+
+_AGENT_SEARCH_DEFINITION: Final[VirtualToolDefinition] = {
+    "name": AGENT_SEARCH_TOOL_NAME,
+    "description": "Find A2A agents by describing the task in natural language. Returns the best matching agents you can access, ranked by semantic similarity, each with its agent_id, name, description, skills, and score.",
+    "inputSchema": {
+        "type": "object",
+        "properties": {
+            "query": {"type": "string", "description": "The task the agent should be able to do, in natural language."},
+            "top_k": {
+                "type": "integer",
+                "description": "Maximum number of agents to return.",
+                "default": DEFAULT_AGENT_SEARCH_TOP_K,
             },
         },
-        {
-            "name": MCP_TOOL_CALL_TOOL_NAME,
-            "description": "Call an MCP tool by name with the given arguments.",
-            "inputSchema": {
-                "type": "object",
-                "properties": {
-                    "tool_name": {
-                        "type": "string",
-                        "description": "The exact name of the MCP tool to call.",
-                    },
-                    "arguments": {
-                        "type": "object",
-                        "description": "Arguments to pass to the tool.",
-                    },
-                },
-                "required": ["tool_name"],
-            },
-        },
-    ]
+        "required": ("query",),
+    },
+}
+
+
+def get_virtual_tool_definitions() -> tuple[VirtualToolDefinition, ...]:
+    return (_MCP_TOOL_SEARCH_DEFINITION, _MCP_TOOL_CALL_DEFINITION, _AGENT_SEARCH_DEFINITION)
+
+
+def _text_tool_result(text: str, is_error: bool) -> CallToolResult:
+    from mcp.types import CallToolResult, TextContent
+
+    return CallToolResult(
+        content=[TextContent(type="text", text=text)],  # mutable-ok: CallToolResult accepts only list content
+        isError=is_error,
+    )
+
+
+async def handle_agent_search(query: str, top_k: int, user_api_key_dict: UserAPIKeyAuth) -> CallToolResult:
+    from litellm.proxy.agent_endpoints.agent_search import (
+        AgentSearchEmbeddingFailed,
+        AgentSearchHits,
+        AgentSearchNotConfigured,
+        agent_search_result,
+        global_agent_search_index,
+        search_agents,
+    )
+    from litellm.proxy.agent_endpoints.auth.agent_permission_handler import accessible_agents
+    from litellm.proxy.common_utils.rbac_utils import check_feature_access_for_user
+    from litellm.proxy.proxy_server import llm_router
+
+    await check_feature_access_for_user(user_api_key_dict, "agents")
+    outcome: Final = await search_agents(
+        query=query,
+        agents=await accessible_agents(user_api_key_dict),
+        top_k=max(top_k, 1),
+        router=llm_router,
+        embedding_model=litellm.agent_search_embedding_model,
+        index=global_agent_search_index,
+    )
+    match outcome:
+        case AgentSearchHits(hits):
+            results: Final = tuple(agent_search_result(hit).model_dump() for hit in hits)
+            return _text_tool_result(json.dumps(results), is_error=False)
+        case AgentSearchNotConfigured(reason) | AgentSearchEmbeddingFailed(reason):
+            return _text_tool_result(reason, is_error=True)
+        case _:
+            assert_never(outcome)
 
 
 async def handle_mcp_tool_search(

--- a/litellm/proxy/_lazy_openapi_snapshot.json
+++ b/litellm/proxy/_lazy_openapi_snapshot.json
@@ -2377,6 +2377,17 @@
               ],
               "title": "Rpm Limit"
             },
+            "search_score": {
+              "anyOf": [
+                {
+                  "type": "number"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Search Score"
+            },
             "session_rpm_limit": {
               "anyOf": [
                 {
@@ -3404,7 +3415,7 @@
       },
       "/v1/agents": {
         "get": {
-          "description": "Example usage:\n```\ncurl -X GET \"http://localhost:4000/v1/agents\"       -H \"Content-Type: application/json\"       -H \"Authorization: Bearer your-key\"     ```\n\nPass `?health_check=true` to filter out agents whose URL is unreachable:\n```\ncurl -X GET \"http://localhost:4000/v1/agents?health_check=true\"       -H \"Content-Type: application/json\"       -H \"Authorization: Bearer your-key\"     ```\n\nReturns: List[AgentResponse]",
+          "description": "Example usage:\n```\ncurl -X GET \"http://localhost:4000/v1/agents\"       -H \"Content-Type: application/json\"       -H \"Authorization: Bearer your-key\"     ```\n\nPass `?health_check=true` to filter out agents whose URL is unreachable:\n```\ncurl -X GET \"http://localhost:4000/v1/agents?health_check=true\"       -H \"Content-Type: application/json\"       -H \"Authorization: Bearer your-key\"     ```\n\nPass `?query=<task>` to get the best matching agents ranked by semantic similarity:\n```\ncurl -X GET \"http://localhost:4000/v1/agents?query=translate+a+PDF+document&top_k=5\"       -H \"Content-Type: application/json\"       -H \"Authorization: Bearer your-key\"     ```\n\nReturns: List[AgentResponse]",
           "operationId": "get_agents_v1_agents_get",
           "parameters": [
             {
@@ -3417,6 +3428,39 @@
                 "description": "When true, performs a GET request to each agent's URL. Agents with reachable URLs (HTTP status < 500) and agents without a URL are returned; unreachable agents are filtered out.",
                 "title": "Health Check",
                 "type": "boolean"
+              }
+            },
+            {
+              "description": "Describe the task in natural language to rank the agents you can reach by semantic similarity over their name, description, and skills. Each result carries a search_score. Requires litellm_settings.agent_search_embedding_model.",
+              "in": "query",
+              "name": "query",
+              "required": false,
+              "schema": {
+                "anyOf": [
+                  {
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "description": "Describe the task in natural language to rank the agents you can reach by semantic similarity over their name, description, and skills. Each result carries a search_score. Requires litellm_settings.agent_search_embedding_model.",
+                "title": "Query"
+              }
+            },
+            {
+              "description": "With query: the maximum number of ranked agents to return.",
+              "in": "query",
+              "name": "top_k",
+              "required": false,
+              "schema": {
+                "default": 5,
+                "description": "With query: the maximum number of ranked agents to return.",
+                "maximum": 100,
+                "minimum": 1,
+                "title": "Top K",
+                "type": "integer"
               }
             }
           ],
@@ -15038,6 +15082,17 @@
                 }
               ],
               "title": "Upstream Resource"
+            },
+            "upstream_token_header": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Upstream Token Header"
             }
           },
           "title": "MCPCredentials",
@@ -17518,6 +17573,17 @@
                 }
               ],
               "title": "Upstream Resource"
+            },
+            "upstream_token_header": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Upstream Token Header"
             }
           },
           "title": "MCPCredentials",
@@ -20352,6 +20418,17 @@
                 }
               ],
               "title": "Upstream Resource"
+            },
+            "upstream_token_header": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Upstream Token Header"
             }
           },
           "title": "MCPCredentials",
@@ -23699,6 +23776,17 @@
                 }
               ],
               "title": "Upstream Resource"
+            },
+            "upstream_token_header": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Upstream Token Header"
             }
           },
           "title": "MCPCredentials",

--- a/litellm/proxy/agent_endpoints/agent_search.py
+++ b/litellm/proxy/agent_endpoints/agent_search.py
@@ -16,6 +16,7 @@ from litellm.exceptions import BudgetExceededError
 from litellm.types.agents import AgentResponse
 
 if TYPE_CHECKING:
+    from litellm.proxy._types import UserAPIKeyAuth
     from litellm.router import Router
 
 DEFAULT_AGENT_SEARCH_TOP_K: Final = 5
@@ -122,10 +123,21 @@ def cosine_similarity(left: Vector, right: Vector) -> float:
     return dot / norms if norms else 0.0
 
 
-def router_embedder(router: Router, embedding_model: str) -> Embedder:
+def embedding_spend_metadata(user_api_key_dict: UserAPIKeyAuth) -> dict[str, object]:
+    from litellm.proxy.litellm_pre_call_utils import LiteLLMProxyRequestSetup
+
+    return {  # mutable-ok: the router mutates the metadata dict it is handed
+        **LiteLLMProxyRequestSetup.get_sanitized_user_information_from_key(user_api_key_dict),
+        "user_api_key": user_api_key_dict.api_key,
+    }
+
+
+def router_embedder(router: Router, embedding_model: str, user_api_key_dict: UserAPIKeyAuth) -> Embedder:
     async def embed(texts: Sequence[str]) -> Sequence[Vector]:
         batch: Final = list(texts)  # mutable-ok: Router.aembedding accepts only str | list input
-        response: Final = await router.aembedding(model=embedding_model, input=batch)
+        response: Final = await router.aembedding(
+            model=embedding_model, input=batch, metadata=embedding_spend_metadata(user_api_key_dict)
+        )
         return tuple(item.embedding for item in _EmbeddingData.model_validate(response.model_dump()).data)
 
     return embed
@@ -174,6 +186,7 @@ async def search_agents(
     router: Router | None,
     embedding_model: str | None,
     index: AgentSearchIndex,
+    user_api_key_dict: UserAPIKeyAuth,
 ) -> AgentSearchOutcome:
     if embedding_model is None:
         return AgentSearchNotConfigured(
@@ -181,4 +194,4 @@ async def search_agents(
         )
     if router is None:
         return AgentSearchNotConfigured(reason="agent search needs a model_list so the embedding model can be called")
-    return await index.search(query, agents, top_k, router_embedder(router, embedding_model))
+    return await index.search(query, agents, top_k, router_embedder(router, embedding_model, user_api_key_dict))

--- a/litellm/proxy/agent_endpoints/agent_search.py
+++ b/litellm/proxy/agent_endpoints/agent_search.py
@@ -1,0 +1,184 @@
+"""Semantic ranking over the in-memory A2A agent registry, shared by GET /v1/agents?query= and the agent_search MCP tool."""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Awaitable, Mapping, Sequence
+from dataclasses import dataclass
+from itertools import chain
+from types import MappingProxyType
+from typing import TYPE_CHECKING, Final, Protocol, TypeAlias
+
+from openai import OpenAIError
+from pydantic import BaseModel, ConfigDict, ValidationError
+
+from litellm.exceptions import BudgetExceededError
+from litellm.types.agents import AgentResponse
+
+if TYPE_CHECKING:
+    from litellm.router import Router
+
+DEFAULT_AGENT_SEARCH_TOP_K: Final = 5
+
+Vector: TypeAlias = tuple[float, ...]
+
+
+class Embedder(Protocol):
+    def __call__(self, texts: Sequence[str]) -> Awaitable[Sequence[Vector]]: ...
+
+
+@dataclass(frozen=True, slots=True)
+class AgentSearchHit:
+    agent: AgentResponse
+    score: float
+
+
+@dataclass(frozen=True, slots=True)
+class AgentSearchHits:
+    hits: tuple[AgentSearchHit, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class AgentSearchNotConfigured:
+    reason: str
+
+
+@dataclass(frozen=True, slots=True)
+class AgentSearchEmbeddingFailed:
+    reason: str
+
+
+AgentSearchOutcome: TypeAlias = AgentSearchHits | AgentSearchNotConfigured | AgentSearchEmbeddingFailed
+
+
+class _SearchableSkill(BaseModel):
+    model_config = ConfigDict(frozen=True, extra="ignore")
+
+    name: str = ""
+    description: str = ""
+    tags: tuple[str, ...] = ()
+
+
+class _SearchableCard(BaseModel):
+    model_config = ConfigDict(frozen=True, extra="ignore")
+
+    description: str = ""
+    skills: tuple[_SearchableSkill, ...] = ()
+
+
+class _EmbeddingItem(BaseModel):
+    model_config = ConfigDict(frozen=True, extra="ignore")
+
+    embedding: tuple[float, ...]
+
+
+class _EmbeddingData(BaseModel):
+    model_config = ConfigDict(frozen=True, extra="ignore")
+
+    data: tuple[_EmbeddingItem, ...]
+
+
+class AgentSearchResult(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    agent_id: str
+    agent_name: str
+    description: str
+    skills: tuple[_SearchableSkill, ...]
+    score: float
+
+
+def _searchable_card(agent: AgentResponse) -> _SearchableCard:
+    try:
+        return _SearchableCard.model_validate(agent.agent_card_params)
+    except ValidationError:
+        return _SearchableCard()
+
+
+def _skill_text(skill: _SearchableSkill) -> str:
+    return " ".join(part for part in (skill.name, skill.description, " ".join(skill.tags)) if part)
+
+
+def agent_search_text(agent: AgentResponse) -> str:
+    card: Final = _searchable_card(agent)
+    skill_lines: Final = tuple(_skill_text(skill) for skill in card.skills)
+    return "\n".join(part for part in (agent.agent_name, card.description, *skill_lines) if part)
+
+
+def agent_search_result(hit: AgentSearchHit) -> AgentSearchResult:
+    card: Final = _searchable_card(hit.agent)
+    return AgentSearchResult(
+        agent_id=hit.agent.agent_id,
+        agent_name=hit.agent.agent_name,
+        description=card.description,
+        skills=card.skills,
+        score=hit.score,
+    )
+
+
+def cosine_similarity(left: Vector, right: Vector) -> float:
+    dot: Final = sum(a * b for a, b in zip(left, right, strict=True))
+    norms: Final = math.sqrt(sum(a * a for a in left)) * math.sqrt(sum(b * b for b in right))
+    return dot / norms if norms else 0.0
+
+
+def router_embedder(router: Router, embedding_model: str) -> Embedder:
+    async def embed(texts: Sequence[str]) -> Sequence[Vector]:
+        batch: Final = list(texts)  # mutable-ok: Router.aembedding accepts only str | list input
+        response: Final = await router.aembedding(model=embedding_model, input=batch)
+        return tuple(item.embedding for item in _EmbeddingData.model_validate(response.model_dump()).data)
+
+    return embed
+
+
+class AgentSearchIndex:
+    """Caches one vector per distinct agent text, so repeat searches only embed the query."""
+
+    def __init__(self) -> None:
+        self._vectors: Mapping[str, Vector] = MappingProxyType({})
+
+    async def search(
+        self, query: str, agents: Sequence[AgentResponse], top_k: int, embed: Embedder
+    ) -> AgentSearchHits | AgentSearchEmbeddingFailed:
+        if not agents:
+            return AgentSearchHits(hits=())
+        texts: Final = tuple(agent_search_text(agent) for agent in agents)
+        missing: Final = tuple(dict.fromkeys(text for text in texts if text not in self._vectors))
+        try:
+            vectors: Final = await embed((query, *missing))
+        except (OpenAIError, ValueError, BudgetExceededError) as exc:
+            return AgentSearchEmbeddingFailed(reason=f"embedding the search query failed: {exc}")
+        if len(vectors) != len(missing) + 1:
+            return AgentSearchEmbeddingFailed(
+                reason=f"embedding model returned {len(vectors)} vectors for {len(missing) + 1} inputs"
+            )
+        self._vectors = MappingProxyType(dict(chain(self._vectors.items(), zip(missing, vectors[1:], strict=True))))
+        ranked: Final = sorted(
+            (
+                AgentSearchHit(agent=agent, score=cosine_similarity(vectors[0], self._vectors[text]))
+                for agent, text in zip(agents, texts, strict=True)
+            ),
+            key=lambda hit: hit.score,
+            reverse=True,
+        )
+        return AgentSearchHits(hits=tuple(ranked[:top_k]))
+
+
+global_agent_search_index: Final = AgentSearchIndex()
+
+
+async def search_agents(
+    query: str,
+    agents: Sequence[AgentResponse],
+    top_k: int,
+    router: Router | None,
+    embedding_model: str | None,
+    index: AgentSearchIndex,
+) -> AgentSearchOutcome:
+    if embedding_model is None:
+        return AgentSearchNotConfigured(
+            reason="agent search needs litellm_settings.agent_search_embedding_model set to an embedding model from model_list"
+        )
+    if router is None:
+        return AgentSearchNotConfigured(reason="agent search needs a model_list so the embedding model can be called")
+    return await index.search(query, agents, top_k, router_embedder(router, embedding_model))

--- a/litellm/proxy/agent_endpoints/agent_search.py
+++ b/litellm/proxy/agent_endpoints/agent_search.py
@@ -143,31 +143,56 @@ def router_embedder(router: Router, embedding_model: str, user_api_key_dict: Use
     return embed
 
 
+_NO_VECTORS: Final[Mapping[str, Vector]] = MappingProxyType({})
+
+
+async def _embed_all(embed: Embedder, texts: Sequence[str]) -> tuple[Vector, ...] | AgentSearchEmbeddingFailed:
+    try:
+        vectors: Final = tuple(await embed(texts))
+    except (OpenAIError, ValueError, BudgetExceededError) as exc:
+        return AgentSearchEmbeddingFailed(reason=f"embedding the search query failed: {exc}")
+    if len(vectors) != len(texts):
+        return AgentSearchEmbeddingFailed(
+            reason=f"embedding model returned {len(vectors)} vectors for {len(texts)} inputs"
+        )
+    return vectors
+
+
 class AgentSearchIndex:
-    """Caches one vector per distinct agent text, so repeat searches only embed the query."""
+    """Caches one vector per distinct agent text per embedding model, so repeat searches only embed the query."""
 
     def __init__(self) -> None:
-        self._vectors: Mapping[str, Vector] = MappingProxyType({})
+        self._vectors: Mapping[str, Mapping[str, Vector]] = MappingProxyType({})
 
     async def search(
-        self, query: str, agents: Sequence[AgentResponse], top_k: int, embed: Embedder
+        self, query: str, agents: Sequence[AgentResponse], top_k: int, embed: Embedder, embedding_model: str
     ) -> AgentSearchHits | AgentSearchEmbeddingFailed:
         if not agents:
             return AgentSearchHits(hits=())
         texts: Final = tuple(agent_search_text(agent) for agent in agents)
-        missing: Final = tuple(dict.fromkeys(text for text in texts if text not in self._vectors))
-        try:
-            vectors: Final = await embed((query, *missing))
-        except (OpenAIError, ValueError, BudgetExceededError) as exc:
-            return AgentSearchEmbeddingFailed(reason=f"embedding the search query failed: {exc}")
-        if len(vectors) != len(missing) + 1:
+        cached: Final = self._vectors.get(embedding_model, _NO_VECTORS)
+        missing: Final = tuple(dict.fromkeys(text for text in texts if text not in cached))
+        embedded: Final = await _embed_all(embed, (query, *missing))
+        if isinstance(embedded, AgentSearchEmbeddingFailed):
+            return embedded
+        query_vector: Final = embedded[0]
+        stale: Final = tuple(
+            dict.fromkeys(text for text in texts if text in cached and len(cached[text]) != len(query_vector))
+        )
+        refreshed: Final = await _embed_all(embed, stale) if stale else ()
+        if isinstance(refreshed, AgentSearchEmbeddingFailed):
+            return refreshed
+        vectors: Final = MappingProxyType(
+            dict(chain(cached.items(), zip(missing, embedded[1:], strict=True), zip(stale, refreshed, strict=True)))
+        )
+        if any(len(vectors[text]) != len(query_vector) for text in texts):
             return AgentSearchEmbeddingFailed(
-                reason=f"embedding model returned {len(vectors)} vectors for {len(missing) + 1} inputs"
+                reason=f"embedding model {embedding_model} returned vectors of mixed dimensions"
             )
-        self._vectors = MappingProxyType(dict(chain(self._vectors.items(), zip(missing, vectors[1:], strict=True))))
+        self._vectors = MappingProxyType({**self._vectors, embedding_model: vectors})
         ranked: Final = sorted(
             (
-                AgentSearchHit(agent=agent, score=cosine_similarity(vectors[0], self._vectors[text]))
+                AgentSearchHit(agent=agent, score=cosine_similarity(query_vector, vectors[text]))
                 for agent, text in zip(agents, texts, strict=True)
             ),
             key=lambda hit: hit.score,
@@ -194,4 +219,6 @@ async def search_agents(
         )
     if router is None:
         return AgentSearchNotConfigured(reason="agent search needs a model_list so the embedding model can be called")
-    return await index.search(query, agents, top_k, router_embedder(router, embedding_model, user_api_key_dict))
+    return await index.search(
+        query, agents, top_k, router_embedder(router, embedding_model, user_api_key_dict), embedding_model
+    )

--- a/litellm/proxy/agent_endpoints/agent_search.py
+++ b/litellm/proxy/agent_endpoints/agent_search.py
@@ -158,6 +158,35 @@ async def _embed_all(embed: Embedder, texts: Sequence[str]) -> tuple[Vector, ...
     return vectors
 
 
+@dataclass(frozen=True, slots=True)
+class _Embedded:
+    query_vector: Vector
+    vectors: Mapping[str, Vector]
+
+
+def _same_dimension(query_vector: Vector, vectors: Mapping[str, Vector], texts: Sequence[str]) -> bool:
+    return all(len(vectors[text]) == len(query_vector) for text in texts)
+
+
+async def _embed_query_and_agents(
+    embed: Embedder, query: str, texts: Sequence[str], cached: Mapping[str, Vector]
+) -> _Embedded | AgentSearchEmbeddingFailed:
+    missing: Final = tuple(dict.fromkeys(text for text in texts if text not in cached))
+    embedded: Final = await _embed_all(embed, (query, *missing))
+    if isinstance(embedded, AgentSearchEmbeddingFailed):
+        return embedded
+    vectors: Final = MappingProxyType(dict(chain(cached.items(), zip(missing, embedded[1:], strict=True))))
+    if _same_dimension(embedded[0], vectors, texts):
+        return _Embedded(query_vector=embedded[0], vectors=vectors)
+    unique: Final = tuple(dict.fromkeys(texts))
+    reembedded: Final = await _embed_all(embed, (query, *unique))
+    if isinstance(reembedded, AgentSearchEmbeddingFailed):
+        return reembedded
+    return _Embedded(
+        query_vector=reembedded[0], vectors=MappingProxyType(dict(zip(unique, reembedded[1:], strict=True)))
+    )
+
+
 class AgentSearchIndex:
     """Caches one vector per distinct agent text per embedding model, so repeat searches only embed the query."""
 
@@ -171,28 +200,19 @@ class AgentSearchIndex:
             return AgentSearchHits(hits=())
         texts: Final = tuple(agent_search_text(agent) for agent in agents)
         cached: Final = self._vectors.get(embedding_model, _NO_VECTORS)
-        missing: Final = tuple(dict.fromkeys(text for text in texts if text not in cached))
-        embedded: Final = await _embed_all(embed, (query, *missing))
+        embedded: Final = await _embed_query_and_agents(embed, query, texts, cached)
         if isinstance(embedded, AgentSearchEmbeddingFailed):
             return embedded
-        query_vector: Final = embedded[0]
-        stale: Final = tuple(
-            dict.fromkeys(text for text in texts if text in cached and len(cached[text]) != len(query_vector))
-        )
-        refreshed: Final = await _embed_all(embed, stale) if stale else ()
-        if isinstance(refreshed, AgentSearchEmbeddingFailed):
-            return refreshed
-        vectors: Final = MappingProxyType(
-            dict(chain(cached.items(), zip(missing, embedded[1:], strict=True), zip(stale, refreshed, strict=True)))
-        )
-        if any(len(vectors[text]) != len(query_vector) for text in texts):
+        if not _same_dimension(embedded.query_vector, embedded.vectors, texts):
             return AgentSearchEmbeddingFailed(
                 reason=f"embedding model {embedding_model} returned vectors of mixed dimensions"
             )
-        self._vectors = MappingProxyType({**self._vectors, embedding_model: vectors})
+        self._vectors = MappingProxyType(
+            {**self._vectors, embedding_model: MappingProxyType({**cached, **embedded.vectors})}
+        )
         ranked: Final = sorted(
             (
-                AgentSearchHit(agent=agent, score=cosine_similarity(query_vector, vectors[text]))
+                AgentSearchHit(agent=agent, score=cosine_similarity(embedded.query_vector, embedded.vectors[text]))
                 for agent, text in zip(agents, texts, strict=True)
             ),
             key=lambda hit: hit.score,

--- a/litellm/proxy/agent_endpoints/agent_search.py
+++ b/litellm/proxy/agent_endpoints/agent_search.py
@@ -193,6 +193,14 @@ class AgentSearchIndex:
     def __init__(self) -> None:
         self._vectors: Mapping[str, Mapping[str, Vector]] = MappingProxyType({})
 
+    def _merged(self, embedding_model: str, embedded: _Embedded) -> Mapping[str, Vector]:
+        kept: Final = {
+            text: vector
+            for text, vector in self._vectors.get(embedding_model, _NO_VECTORS).items()
+            if len(vector) == len(embedded.query_vector)
+        }
+        return MappingProxyType({**kept, **embedded.vectors})
+
     async def search(
         self, query: str, agents: Sequence[AgentResponse], top_k: int, embed: Embedder, embedding_model: str
     ) -> AgentSearchHits | AgentSearchEmbeddingFailed:
@@ -207,9 +215,7 @@ class AgentSearchIndex:
             return AgentSearchEmbeddingFailed(
                 reason=f"embedding model {embedding_model} returned vectors of mixed dimensions"
             )
-        self._vectors = MappingProxyType(
-            {**self._vectors, embedding_model: MappingProxyType({**cached, **embedded.vectors})}
-        )
+        self._vectors = MappingProxyType({**self._vectors, embedding_model: self._merged(embedding_model, embedded)})
         ranked: Final = sorted(
             (
                 AgentSearchHit(agent=agent, score=cosine_similarity(embedded.query_vector, embedded.vectors[text]))

--- a/litellm/proxy/agent_endpoints/auth/agent_permission_handler.py
+++ b/litellm/proxy/agent_endpoints/auth/agent_permission_handler.py
@@ -13,9 +13,11 @@ from litellm.proxy._types import (
     UI_TEAM_ID,
     LiteLLM_ObjectPermissionTable,
     LiteLLM_TeamTable,
+    LitellmUserRoles,
     UserAPIKeyAuth,
 )
 from litellm.repositories.table_repositories import AgentsRepository
+from litellm.types.agents import AgentResponse
 
 
 @dataclass(frozen=True, slots=True)
@@ -439,3 +441,17 @@ class AgentRequestHandler:
         except Exception as e:
             verbose_logger.warning("Failed to get agent access groups for team: %s", e)
             return []
+
+
+async def accessible_agents(user_api_key_auth: UserAPIKeyAuth) -> tuple[AgentResponse, ...]:
+    """Every registry agent for proxy admins, else the agents the key's and team's grants reach."""
+    from litellm.proxy.agent_endpoints.agent_registry import global_agent_registry
+
+    all_agents: Final = global_agent_registry.get_agent_list()
+    if user_api_key_auth.user_role in (LitellmUserRoles.PROXY_ADMIN, LitellmUserRoles.PROXY_ADMIN.value):
+        return all_agents
+    match await AgentRequestHandler.resolve_agent_access(user_api_key_auth=user_api_key_auth):
+        case UnrestrictedAgentAccess():
+            return all_agents
+        case RestrictedAgentAccess(allowed_agent_ids):
+            return tuple(agent for agent in all_agents if agent.agent_id in allowed_agent_ids)

--- a/litellm/proxy/agent_endpoints/endpoints.py
+++ b/litellm/proxy/agent_endpoints/endpoints.py
@@ -231,7 +231,9 @@ def _agent_search_error(status_code: int, error: str, message: str) -> HTTPExcep
     return HTTPException(status_code=status_code, detail=detail)
 
 
-async def _rank_agents_by_query(query: str, agents: Sequence[AgentResponse], top_k: int) -> tuple[AgentResponse, ...]:
+async def _rank_agents_by_query(
+    query: str, agents: Sequence[AgentResponse], top_k: int, user_api_key_dict: UserAPIKeyAuth
+) -> tuple[AgentResponse, ...]:
     from litellm.proxy.proxy_server import llm_router
 
     outcome: Final = await search_agents(
@@ -241,6 +243,7 @@ async def _rank_agents_by_query(query: str, agents: Sequence[AgentResponse], top
         router=llm_router,
         embedding_model=litellm.agent_search_embedding_model,
         index=global_agent_search_index,
+        user_api_key_dict=user_api_key_dict,
     )
     match outcome:
         case AgentSearchHits(hits):
@@ -376,7 +379,7 @@ async def get_agents(
 
         if query is None:
             return returned_agents
-        return await _rank_agents_by_query(query, returned_agents, top_k)
+        return await _rank_agents_by_query(query, returned_agents, top_k, user_api_key_dict)
     except HTTPException:
         raise
     except Exception as e:

--- a/litellm/proxy/agent_endpoints/endpoints.py
+++ b/litellm/proxy/agent_endpoints/endpoints.py
@@ -12,10 +12,11 @@ import asyncio
 import os
 import uuid
 from collections.abc import Mapping, Sequence
-from typing import Final, TypedDict
+from types import MappingProxyType
+from typing import Annotated, Final, TypedDict, assert_never
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
-from typing_extensions import Required
+from typing_extensions import ReadOnly, Required
 
 import litellm
 from litellm._logging import verbose_proxy_logger
@@ -32,6 +33,15 @@ from litellm.proxy.a2a.agent_card import (
     merge_agent_card,
     normalize_protocol_version,
 )
+from litellm.proxy.agent_endpoints.agent_search import (
+    DEFAULT_AGENT_SEARCH_TOP_K,
+    AgentSearchEmbeddingFailed,
+    AgentSearchHits,
+    AgentSearchNotConfigured,
+    global_agent_search_index,
+    search_agents,
+)
+from litellm.proxy.agent_endpoints.auth.agent_permission_handler import accessible_agents
 from litellm.proxy.auth.user_api_key_auth import user_api_key_auth
 from litellm.proxy.common_utils.rbac_utils import check_feature_access_for_user
 from litellm.proxy.management_endpoints.common_daily_activity import get_daily_activity
@@ -211,6 +221,38 @@ async def _check_agent_url_health(
         }
 
 
+class _AgentSearchErrorDetail(TypedDict):
+    error: ReadOnly[str]
+    message: ReadOnly[str]
+
+
+def _agent_search_error(status_code: int, error: str, message: str) -> HTTPException:
+    detail: Final[_AgentSearchErrorDetail] = {"error": error, "message": message}
+    return HTTPException(status_code=status_code, detail=detail)
+
+
+async def _rank_agents_by_query(query: str, agents: Sequence[AgentResponse], top_k: int) -> tuple[AgentResponse, ...]:
+    from litellm.proxy.proxy_server import llm_router
+
+    outcome: Final = await search_agents(
+        query=query,
+        agents=agents,
+        top_k=top_k,
+        router=llm_router,
+        embedding_model=litellm.agent_search_embedding_model,
+        index=global_agent_search_index,
+    )
+    match outcome:
+        case AgentSearchHits(hits):
+            return tuple(hit.agent.model_copy(update=MappingProxyType({"search_score": hit.score})) for hit in hits)
+        case AgentSearchNotConfigured(reason):
+            raise _agent_search_error(400, "agent_search_not_configured", reason)
+        case AgentSearchEmbeddingFailed(reason):
+            raise _agent_search_error(503, "agent_search_unavailable", reason)
+        case _:
+            assert_never(outcome)
+
+
 @router.get(
     "/v1/agents",
     tags=["[beta] A2A Agents"],
@@ -223,6 +265,17 @@ async def get_agents(
         False,
         description="When true, performs a GET request to each agent's URL. Agents with reachable URLs (HTTP status < 500) and agents without a URL are returned; unreachable agents are filtered out.",
     ),
+    query: Annotated[
+        str | None,
+        Query(
+            min_length=1,
+            description="Describe the task in natural language to rank the agents you can reach by semantic similarity over their name, description, and skills. Each result carries a search_score. Requires litellm_settings.agent_search_embedding_model.",
+        ),
+    ] = None,
+    top_k: Annotated[
+        int,
+        Query(ge=1, le=100, description="With query: the maximum number of ranked agents to return."),
+    ] = DEFAULT_AGENT_SEARCH_TOP_K,
     user_api_key_dict: UserAPIKeyAuth = Depends(user_api_key_auth),  # Used for auth
 ):
     """
@@ -240,37 +293,22 @@ async def get_agents(
       -H "Authorization: Bearer your-key" \
     ```
 
+    Pass `?query=<task>` to get the best matching agents ranked by semantic similarity:
+    ```
+    curl -X GET "http://localhost:4000/v1/agents?query=translate+a+PDF+document&top_k=5" \
+      -H "Content-Type: application/json" \
+      -H "Authorization: Bearer your-key" \
+    ```
+
     Returns: List[AgentResponse]
 
     """
     await check_feature_access_for_user(user_api_key_dict, "agents")
 
     from litellm.proxy.agent_endpoints.agent_registry import global_agent_registry
-    from litellm.proxy.agent_endpoints.auth.agent_permission_handler import (
-        AgentRequestHandler,
-        RestrictedAgentAccess,
-        UnrestrictedAgentAccess,
-    )
 
     try:
-        returned_agents: Sequence[AgentResponse] = ()
-
-        # Admin users get all agents
-        if (
-            user_api_key_dict.user_role == LitellmUserRoles.PROXY_ADMIN
-            or user_api_key_dict.user_role == LitellmUserRoles.PROXY_ADMIN.value
-        ):
-            returned_agents = global_agent_registry.get_agent_list()
-        else:
-            # Get allowed agents from object_permission (key/team level)
-            agent_access: Final = await AgentRequestHandler.resolve_agent_access(user_api_key_auth=user_api_key_dict)
-            all_agents: Final = global_agent_registry.get_agent_list()
-
-            match agent_access:
-                case UnrestrictedAgentAccess():
-                    returned_agents = all_agents
-                case RestrictedAgentAccess(allowed_agent_ids):
-                    returned_agents = [agent for agent in all_agents if agent.agent_id in allowed_agent_ids]
+        returned_agents: Sequence[AgentResponse] = await accessible_agents(user_api_key_dict)
 
         # Fetch current spend from DB for all returned agents
         from litellm.proxy.proxy_server import prisma_client
@@ -336,7 +374,9 @@ async def get_agents(
             healthy_ids: Final = {result["agent_id"] for result in health_results if result["healthy"]}
             returned_agents = [agent for agent in agents_with_url if agent.agent_id in healthy_ids] + agents_without_url
 
-        return returned_agents
+        if query is None:
+            return returned_agents
+        return await _rank_agents_by_query(query, returned_agents, top_k)
     except HTTPException:
         raise
     except Exception as e:

--- a/litellm/types/agents.py
+++ b/litellm/types/agents.py
@@ -225,6 +225,7 @@ class AgentResponse(BaseModel):
     static_headers: dict[str, str] | None = None
     extra_headers: list[str] | None = None
     keys: list[AgentKeySummary] | None = None
+    search_score: float | None = None
     created_at: datetime | None = None
     updated_at: datetime | None = None
     created_by: str | None = None

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_tool_search.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_tool_search.py
@@ -18,6 +18,7 @@ import pytest
 from litellm.models.object_permission import LiteLLM_ObjectPermissionTable
 from litellm.proxy._experimental.mcp_server.faults.list_outcomes import AggregateToolListing
 from litellm.proxy._experimental.mcp_server.tool_search import (
+    AGENT_SEARCH_TOOL_NAME,
     MCP_TOOL_CALL_TOOL_NAME,
     MCP_TOOL_SEARCH_TOOL_NAME,
     coerce_top_k,
@@ -114,8 +115,15 @@ class TestSearchTools:
 
 
 class TestGetVirtualToolDefinitions:
-    def test_returns_two_tools(self) -> None:
-        assert len(get_virtual_tool_definitions()) == 2
+    def test_returns_three_tools(self) -> None:
+        assert len(get_virtual_tool_definitions()) == 3
+
+    def test_agent_search_schema_requires_query(self) -> None:
+        tools = get_virtual_tool_definitions()
+        agent_tool = next(t for t in tools if t["name"] == AGENT_SEARCH_TOOL_NAME)
+        props = agent_tool["inputSchema"]["properties"]
+        assert set(props) == {"query", "top_k"}
+        assert agent_tool["inputSchema"]["required"] == ("query",)
 
     def test_has_mcp_tool_search(self) -> None:
         names = [t["name"] for t in get_virtual_tool_definitions()]
@@ -130,7 +138,7 @@ class TestGetVirtualToolDefinitions:
         search_tool = next(t for t in tools if t["name"] == MCP_TOOL_SEARCH_TOOL_NAME)
         props = search_tool["inputSchema"]["properties"]
         assert "query" in props
-        assert search_tool["inputSchema"]["required"] == ["query"]
+        assert search_tool["inputSchema"]["required"] == ("query",)
 
     def test_mcp_tool_call_schema_has_tool_name_and_arguments(self) -> None:
         tools = get_virtual_tool_definitions()
@@ -153,6 +161,7 @@ class TestGetVirtualToolDefinitions:
         assert {t.name for t in built} == {
             MCP_TOOL_SEARCH_TOOL_NAME,
             MCP_TOOL_CALL_TOOL_NAME,
+            AGENT_SEARCH_TOOL_NAME,
         }
 
 
@@ -187,7 +196,7 @@ class TestListToolRestApiWithToolSearch:
 
         assert result["error"] is None
         tool_names = [t["name"] for t in result["tools"]]
-        assert set(tool_names) == {MCP_TOOL_SEARCH_TOOL_NAME, MCP_TOOL_CALL_TOOL_NAME}
+        assert set(tool_names) == {MCP_TOOL_SEARCH_TOOL_NAME, MCP_TOOL_CALL_TOOL_NAME, AGENT_SEARCH_TOOL_NAME}
 
     @pytest.mark.asyncio
     async def test_returns_full_catalog_when_flag_disabled(self) -> None:
@@ -518,6 +527,81 @@ class TestCallToolRestApiVirtualTools:
         assert mock_list.await_args.kwargs["client_ip"] == "203.0.113.7"
 
     @pytest.mark.asyncio
+    async def test_agent_search_call_ranks_accessible_agents(self) -> None:
+        from litellm.proxy.agent_endpoints.agent_search import AgentSearchHit, AgentSearchHits
+        from litellm.types.agents import AgentResponse
+
+        user_api_key_dict = UserAPIKeyAuth(api_key="k", object_permission=_make_perm(mcp_tool_search_enabled=True))
+        request = self._make_request(
+            {"name": AGENT_SEARCH_TOOL_NAME, "arguments": {"query": "translate a document", "top_k": "1"}}
+        )
+        translator = AgentResponse(
+            agent_id="translator",
+            agent_name="document-translator",
+            agent_card_params={"description": "Translates files", "skills": [{"id": "t", "name": "Translate"}]},
+        )
+        with (
+            patch(  # test-quality-ok: the tool resolves agent access through proxy_server globals, no injection seam
+                "litellm.proxy.agent_endpoints.auth.agent_permission_handler.accessible_agents",
+                new_callable=AsyncMock,
+                return_value=(translator,),
+            ),
+            patch(  # test-quality-ok: the embedding router only resolves via proxy_server globals, no injection seam
+                "litellm.proxy.agent_endpoints.agent_search.search_agents",
+                new_callable=AsyncMock,
+                return_value=AgentSearchHits(hits=(AgentSearchHit(agent=translator, score=0.91),)),
+            ) as mock_search,
+        ):
+            result = await self._get_call_fn()(request=request, user_api_key_dict=user_api_key_dict)
+
+        assert result.isError is False
+        assert json.loads(result.content[0].text) == [
+            {
+                "agent_id": "translator",
+                "agent_name": "document-translator",
+                "description": "Translates files",
+                "skills": [{"name": "Translate", "description": "", "tags": []}],
+                "score": 0.91,
+            }
+        ]
+        assert mock_search.await_args.kwargs["query"] == "translate a document"
+        assert mock_search.await_args.kwargs["top_k"] == 1
+        assert mock_search.await_args.kwargs["agents"] == (translator,)
+
+    @pytest.mark.asyncio
+    async def test_agent_search_call_reports_missing_embedding_model_as_tool_error(self) -> None:
+        from litellm.proxy.agent_endpoints.agent_search import AgentSearchNotConfigured
+
+        user_api_key_dict = UserAPIKeyAuth(api_key="k", object_permission=_make_perm(mcp_tool_search_enabled=True))
+        request = self._make_request({"name": AGENT_SEARCH_TOOL_NAME, "arguments": {"query": "anything"}})
+        with (
+            patch(  # test-quality-ok: the tool resolves agent access through proxy_server globals, no injection seam
+                "litellm.proxy.agent_endpoints.auth.agent_permission_handler.accessible_agents",
+                new_callable=AsyncMock,
+                return_value=(),
+            ),
+            patch(  # test-quality-ok: the embedding router only resolves via proxy_server globals, no injection seam
+                "litellm.proxy.agent_endpoints.agent_search.search_agents",
+                new_callable=AsyncMock,
+                return_value=AgentSearchNotConfigured(reason="set agent_search_embedding_model"),
+            ),
+        ):
+            result = await self._get_call_fn()(request=request, user_api_key_dict=user_api_key_dict)
+
+        assert result.isError is True
+        assert result.content[0].text == "set agent_search_embedding_model"
+
+    @pytest.mark.asyncio
+    async def test_agent_search_requires_flag_enabled(self) -> None:
+        from fastapi import HTTPException
+
+        user_api_key_dict = UserAPIKeyAuth(api_key="k", object_permission=_make_perm(mcp_tool_search_enabled=False))
+        request = self._make_request({"name": AGENT_SEARCH_TOOL_NAME, "arguments": {"query": "anything"}})
+        with pytest.raises(HTTPException) as exc_info:
+            await self._get_call_fn()(request=request, user_api_key_dict=user_api_key_dict)
+        assert exc_info.value.status_code == 403
+
+    @pytest.mark.asyncio
     async def test_mcp_tool_search_requires_flag_enabled(self) -> None:
         from fastapi import HTTPException
 
@@ -591,6 +675,41 @@ class TestDispatchVirtualMcpTool:
         assert mock_search.await_args.kwargs["client_ip"] == "203.0.113.9"
         assert mock_search.await_args.kwargs["query"] == "q"
         assert mock_search.await_args.kwargs["top_k"] == 3
+
+    @pytest.mark.asyncio
+    async def test_routes_agent_search_to_its_handler(self) -> None:
+        from litellm.proxy._experimental.mcp_server import server as srv
+
+        uak = UserAPIKeyAuth(api_key="k", object_permission=_make_perm(mcp_tool_search_enabled=True))
+        with patch(  # test-quality-ok: dispatch routing is the subject; the handler is faked like its siblings here
+            "litellm.proxy._experimental.mcp_server.tool_search.handle_agent_search",
+            new_callable=AsyncMock,
+            return_value="AGENT_RESULT",
+        ) as mock_agent_search:
+            result = await srv._dispatch_virtual_mcp_tool(
+                name=AGENT_SEARCH_TOOL_NAME,
+                arguments={"query": "translate a document", "top_k": "2"},
+                user_api_key_auth=uak,
+                client_ip=None,
+            )
+
+        assert result == "AGENT_RESULT"
+        assert mock_agent_search.await_args.kwargs == {
+            "query": "translate a document",
+            "top_k": 2,
+            "user_api_key_dict": uak,
+        }
+
+    @pytest.mark.asyncio
+    async def test_agent_search_rejected_when_flag_disabled(self) -> None:
+        from litellm.proxy._experimental.mcp_server.server import _dispatch_virtual_mcp_tool
+
+        uak = UserAPIKeyAuth(api_key="k", object_permission=_make_perm(mcp_tool_search_enabled=False))
+        result = await _dispatch_virtual_mcp_tool(
+            name=AGENT_SEARCH_TOOL_NAME, arguments={"query": "x"}, user_api_key_auth=uak, client_ip=None
+        )
+        assert result is not None
+        assert result.isError is True
 
     @pytest.mark.asyncio
     async def test_routes_call_with_client_ip(self) -> None:
@@ -850,6 +969,7 @@ class TestHandleListToolsVirtual:
         assert {t.name for t in tools} == {
             MCP_TOOL_SEARCH_TOOL_NAME,
             MCP_TOOL_CALL_TOOL_NAME,
+            AGENT_SEARCH_TOOL_NAME,
         }
 
 

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_tool_search.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_tool_search.py
@@ -566,6 +566,7 @@ class TestCallToolRestApiVirtualTools:
             result = await self._get_call_fn()(request=request, user_api_key_dict=user_api_key_dict)
 
         assert result.isError is False
+        assert mock_search.await_args.kwargs["user_api_key_dict"] is user_api_key_dict
         assert json.loads(result.content[0].text) == [
             {
                 "agent_id": "translator",

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_tool_search.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_tool_search.py
@@ -123,7 +123,7 @@ class TestGetVirtualToolDefinitions:
         agent_tool = next(t for t in tools if t["name"] == AGENT_SEARCH_TOOL_NAME)
         props = agent_tool["inputSchema"]["properties"]
         assert set(props) == {"query", "top_k"}
-        assert agent_tool["inputSchema"]["required"] == ("query",)
+        assert agent_tool["inputSchema"]["required"] == ["query"]
 
     def test_has_mcp_tool_search(self) -> None:
         names = [t["name"] for t in get_virtual_tool_definitions()]
@@ -138,7 +138,7 @@ class TestGetVirtualToolDefinitions:
         search_tool = next(t for t in tools if t["name"] == MCP_TOOL_SEARCH_TOOL_NAME)
         props = search_tool["inputSchema"]["properties"]
         assert "query" in props
-        assert search_tool["inputSchema"]["required"] == ("query",)
+        assert search_tool["inputSchema"]["required"] == ["query"]
 
     def test_mcp_tool_call_schema_has_tool_name_and_arguments(self) -> None:
         tools = get_virtual_tool_definitions()
@@ -147,6 +147,17 @@ class TestGetVirtualToolDefinitions:
         assert "tool_name" in props
         assert "arguments" in props
         assert "tool_name" in call_tool["inputSchema"]["required"]
+
+    def test_input_schemas_validate_arguments_like_the_mcp_server_does(self) -> None:
+        from jsonschema import ValidationError, validate
+        from mcp.types import Tool
+
+        for definition in get_virtual_tool_definitions():
+            tool = Tool.model_validate(definition)
+            required_arguments = {name: "x" for name in tool.inputSchema["required"]}
+            validate(instance=required_arguments, schema=tool.inputSchema)
+            with pytest.raises(ValidationError):
+                validate(instance={}, schema=tool.inputSchema)
 
     def test_all_tools_have_description(self) -> None:
         for tool in get_virtual_tool_definitions():

--- a/tests/test_litellm/proxy/agent_endpoints/test_agent_search.py
+++ b/tests/test_litellm/proxy/agent_endpoints/test_agent_search.py
@@ -77,6 +77,16 @@ class FakeEmbedder:
         return tuple(VECTORS[text] for text in texts)
 
 
+class FixedDimensionEmbedder:
+    def __init__(self, dimensions: int) -> None:
+        self.dimensions: Final = dimensions
+        self.calls: list[tuple[str, ...]] = []  # mutable-ok: test spy recording embed inputs
+
+    async def __call__(self, texts: Sequence[str]) -> Sequence[Vector]:
+        self.calls.append(tuple(texts))
+        return tuple((1.0,) * self.dimensions for _ in texts)
+
+
 class TestAgentSearchText:
     def test_joins_name_description_and_skills_with_tags(self) -> None:
         assert agent_search_text(TRANSLATOR) == (
@@ -109,7 +119,9 @@ class TestCosineSimilarity:
 class TestAgentSearchIndex:
     @pytest.mark.asyncio
     async def test_ranks_by_similarity_and_truncates_to_top_k(self) -> None:
-        outcome = await AgentSearchIndex().search("language translation", AGENTS, top_k=2, embed=FakeEmbedder())
+        outcome = await AgentSearchIndex().search(
+            "language translation", AGENTS, top_k=2, embed=FakeEmbedder(), embedding_model="m"
+        )
         assert isinstance(outcome, AgentSearchHits)
         assert [hit.agent.agent_id for hit in outcome.hits] == ["translator", "trip"]
         assert outcome.hits[0].score > outcome.hits[1].score
@@ -118,15 +130,42 @@ class TestAgentSearchIndex:
     async def test_second_search_only_embeds_the_query(self) -> None:
         index = AgentSearchIndex()
         embedder = FakeEmbedder()
-        await index.search("language translation", AGENTS, top_k=5, embed=embedder)
-        await index.search("language translation", AGENTS, top_k=5, embed=embedder)
+        await index.search("language translation", AGENTS, top_k=5, embed=embedder, embedding_model="m")
+        await index.search("language translation", AGENTS, top_k=5, embed=embedder, embedding_model="m")
         assert len(embedder.calls[0]) == 1 + len(AGENTS)
         assert embedder.calls[1] == ("language translation",)
 
     @pytest.mark.asyncio
+    async def test_switching_embedding_models_does_not_reuse_cached_vectors(self) -> None:
+        index = AgentSearchIndex()
+        await index.search("language translation", AGENTS, top_k=5, embed=FakeEmbedder(), embedding_model="small")
+        wide = FixedDimensionEmbedder(2)
+        outcome = await index.search("language translation", AGENTS, top_k=5, embed=wide, embedding_model="wide")
+        assert isinstance(outcome, AgentSearchHits)
+        assert len(wide.calls[0]) == 1 + len(AGENTS)
+
+    @pytest.mark.asyncio
+    async def test_cached_vectors_of_another_dimension_are_re_embedded(self) -> None:
+        index = AgentSearchIndex()
+        await index.search("language translation", AGENTS, top_k=5, embed=FakeEmbedder(), embedding_model="m")
+        fallback = FixedDimensionEmbedder(2)
+        outcome = await index.search("language translation", AGENTS, top_k=5, embed=fallback, embedding_model="m")
+        assert isinstance(outcome, AgentSearchHits)
+        assert fallback.calls == [("language translation",), tuple(agent_search_text(agent) for agent in AGENTS)]
+
+    @pytest.mark.asyncio
+    async def test_mixed_dimensions_in_one_batch_become_embedding_failed(self) -> None:
+        async def mixed(texts: Sequence[str]) -> Sequence[Vector]:
+            return ((1.0, 0.0), *((1.0, 0.0, 0.0) for _ in texts[1:]))
+
+        outcome = await AgentSearchIndex().search("q", AGENTS, top_k=5, embed=mixed, embedding_model="m")
+        assert isinstance(outcome, AgentSearchEmbeddingFailed)
+        assert "mixed dimensions" in outcome.reason
+
+    @pytest.mark.asyncio
     async def test_empty_registry_returns_no_hits_without_embedding(self) -> None:
         embedder = FakeEmbedder()
-        outcome = await AgentSearchIndex().search("anything", (), top_k=5, embed=embedder)
+        outcome = await AgentSearchIndex().search("anything", (), top_k=5, embed=embedder, embedding_model="m")
         assert outcome == AgentSearchHits(hits=())
         assert embedder.calls == []
 
@@ -135,7 +174,7 @@ class TestAgentSearchIndex:
         async def failing(texts: Sequence[str]) -> Sequence[Vector]:
             raise APIConnectionError(request=MagicMock())
 
-        outcome = await AgentSearchIndex().search("q", AGENTS, top_k=5, embed=failing)
+        outcome = await AgentSearchIndex().search("q", AGENTS, top_k=5, embed=failing, embedding_model="m")
         assert isinstance(outcome, AgentSearchEmbeddingFailed)
         assert "embedding the search query failed" in outcome.reason
 
@@ -144,7 +183,7 @@ class TestAgentSearchIndex:
         async def short(texts: Sequence[str]) -> Sequence[Vector]:
             return ((1.0, 0.0, 0.0),)
 
-        outcome = await AgentSearchIndex().search("q", AGENTS, top_k=5, embed=short)
+        outcome = await AgentSearchIndex().search("q", AGENTS, top_k=5, embed=short, embedding_model="m")
         assert isinstance(outcome, AgentSearchEmbeddingFailed)
 
 

--- a/tests/test_litellm/proxy/agent_endpoints/test_agent_search.py
+++ b/tests/test_litellm/proxy/agent_endpoints/test_agent_search.py
@@ -1,3 +1,4 @@
+import asyncio
 from collections.abc import Sequence
 from types import MappingProxyType
 from typing import Final
@@ -84,6 +85,7 @@ class FixedDimensionEmbedder:
 
     async def __call__(self, texts: Sequence[str]) -> Sequence[Vector]:
         self.calls.append(tuple(texts))
+        await asyncio.sleep(0)
         return tuple((1.0,) * self.dimensions for _ in texts)
 
 
@@ -155,6 +157,26 @@ class TestAgentSearchIndex:
             ("language translation",),
             ("language translation", *(agent_search_text(agent) for agent in AGENTS)),
         ]
+
+    @pytest.mark.asyncio
+    async def test_re_embedding_a_subset_drops_the_other_agents_old_vectors(self) -> None:
+        index = AgentSearchIndex()
+        await index.search("language translation", AGENTS, top_k=5, embed=FakeEmbedder(), embedding_model="m")
+        wide = FixedDimensionEmbedder(2)
+        await index.search("language translation", AGENTS[:1], top_k=5, embed=wide, embedding_model="m")
+        await index.search("language translation", AGENTS, top_k=5, embed=wide, embedding_model="m")
+        assert wide.calls[-1] == ("language translation", *(agent_search_text(agent) for agent in AGENTS[1:]))
+
+    @pytest.mark.asyncio
+    async def test_concurrent_searches_keep_each_others_vectors(self) -> None:
+        index = AgentSearchIndex()
+        embedder = FixedDimensionEmbedder(3)
+        await asyncio.gather(
+            index.search("q", AGENTS[:1], top_k=5, embed=embedder, embedding_model="m"),
+            index.search("q", AGENTS[1:], top_k=5, embed=embedder, embedding_model="m"),
+        )
+        await index.search("q", AGENTS, top_k=5, embed=embedder, embedding_model="m")
+        assert embedder.calls[-1] == ("q",)
 
     @pytest.mark.asyncio
     async def test_mixed_dimensions_in_one_batch_become_embedding_failed(self) -> None:

--- a/tests/test_litellm/proxy/agent_endpoints/test_agent_search.py
+++ b/tests/test_litellm/proxy/agent_endpoints/test_agent_search.py
@@ -151,7 +151,10 @@ class TestAgentSearchIndex:
         fallback = FixedDimensionEmbedder(2)
         outcome = await index.search("language translation", AGENTS, top_k=5, embed=fallback, embedding_model="m")
         assert isinstance(outcome, AgentSearchHits)
-        assert fallback.calls == [("language translation",), tuple(agent_search_text(agent) for agent in AGENTS)]
+        assert fallback.calls == [
+            ("language translation",),
+            ("language translation", *(agent_search_text(agent) for agent in AGENTS)),
+        ]
 
     @pytest.mark.asyncio
     async def test_mixed_dimensions_in_one_batch_become_embedding_failed(self) -> None:

--- a/tests/test_litellm/proxy/agent_endpoints/test_agent_search.py
+++ b/tests/test_litellm/proxy/agent_endpoints/test_agent_search.py
@@ -24,6 +24,8 @@ from litellm.proxy.agent_endpoints.auth.agent_permission_handler import Restrict
 from litellm.proxy.agent_endpoints.endpoints import router, user_api_key_auth
 from litellm.types.agents import AgentResponse
 
+CALLER: Final = UserAPIKeyAuth(api_key="hashed-caller-key", team_id="team-1", user_id="user-1")
+
 TRANSLATOR: Final = AgentResponse(
     agent_id="translator",
     agent_name="document-translator",
@@ -150,21 +152,23 @@ class TestSearchAgents:
     @pytest.mark.asyncio
     async def test_no_embedding_model_is_not_configured(self) -> None:
         outcome = await search_agents(
-            "q", AGENTS, 5, router=MagicMock(), embedding_model=None, index=AgentSearchIndex()
+            "q", AGENTS, 5, router=MagicMock(), embedding_model=None, index=AgentSearchIndex(), user_api_key_dict=CALLER
         )
         assert isinstance(outcome, AgentSearchNotConfigured)
         assert "agent_search_embedding_model" in outcome.reason
 
     @pytest.mark.asyncio
     async def test_no_router_is_not_configured(self) -> None:
-        outcome = await search_agents("q", AGENTS, 5, router=None, embedding_model="m", index=AgentSearchIndex())
+        outcome = await search_agents(
+            "q", AGENTS, 5, router=None, embedding_model="m", index=AgentSearchIndex(), user_api_key_dict=CALLER
+        )
         assert isinstance(outcome, AgentSearchNotConfigured)
 
     @pytest.mark.asyncio
     async def test_router_embeddings_are_read_from_the_response(self) -> None:
         router = MagicMock()
         router.aembedding = AsyncMock(
-            side_effect=lambda model, input: litellm.EmbeddingResponse(
+            side_effect=lambda model, input, metadata: litellm.EmbeddingResponse(
                 model=model,
                 data=[{"object": "embedding", "index": i, "embedding": list(VECTORS[t])} for i, t in enumerate(input)],
             )
@@ -176,10 +180,34 @@ class TestSearchAgents:
             router=router,
             embedding_model="text-embedding-3-small",
             index=AgentSearchIndex(),
+            user_api_key_dict=CALLER,
         )
         assert isinstance(outcome, AgentSearchHits)
         assert [hit.agent.agent_id for hit in outcome.hits] == ["translator"]
         assert router.aembedding.await_args.kwargs["model"] == "text-embedding-3-small"
+
+    @pytest.mark.asyncio
+    async def test_embedding_spend_is_attributed_to_the_calling_key(self) -> None:
+        router = MagicMock()
+        router.aembedding = AsyncMock(
+            side_effect=lambda model, input, metadata: litellm.EmbeddingResponse(
+                model=model,
+                data=[{"object": "embedding", "index": i, "embedding": list(VECTORS[t])} for i, t in enumerate(input)],
+            )
+        )
+        await search_agents(
+            "language translation",
+            AGENTS,
+            1,
+            router=router,
+            embedding_model="text-embedding-3-small",
+            index=AgentSearchIndex(),
+            user_api_key_dict=CALLER,
+        )
+        metadata = router.aembedding.await_args.kwargs["metadata"]
+        assert metadata["user_api_key"] == "hashed-caller-key"
+        assert metadata["user_api_key_team_id"] == "team-1"
+        assert metadata["user_api_key_user_id"] == "user-1"
 
 
 def _client(role: LitellmUserRoles) -> TestClient:
@@ -205,7 +233,7 @@ def registry(monkeypatch: pytest.MonkeyPatch) -> MagicMock:
 def embedding_router(monkeypatch: pytest.MonkeyPatch) -> MagicMock:
     router = MagicMock()
     router.aembedding = AsyncMock(
-        side_effect=lambda model, input: litellm.EmbeddingResponse(
+        side_effect=lambda model, input, metadata: litellm.EmbeddingResponse(
             model=model,
             data=[{"object": "embedding", "index": i, "embedding": list(VECTORS[t])} for i, t in enumerate(input)],
         )
@@ -231,6 +259,7 @@ class TestGetAgentsQuery:
         body = response.json()
         assert [agent["agent_id"] for agent in body] == ["translator", "trip"]
         assert body[0]["search_score"] > body[1]["search_score"]
+        assert embedding_router.aembedding.await_args.kwargs["metadata"]["user_api_key_user_id"] == "u"
 
     def test_without_query_the_list_is_unchanged_and_unscored(
         self, registry: MagicMock, embedding_router: MagicMock, no_db: None

--- a/tests/test_litellm/proxy/agent_endpoints/test_agent_search.py
+++ b/tests/test_litellm/proxy/agent_endpoints/test_agent_search.py
@@ -1,0 +1,281 @@
+from collections.abc import Sequence
+from types import MappingProxyType
+from typing import Final
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from openai import APIConnectionError
+
+import litellm
+from litellm.proxy._types import LitellmUserRoles, UserAPIKeyAuth
+from litellm.proxy.agent_endpoints.agent_search import (
+    AgentSearchEmbeddingFailed,
+    AgentSearchHits,
+    AgentSearchIndex,
+    AgentSearchNotConfigured,
+    Vector,
+    agent_search_text,
+    cosine_similarity,
+    search_agents,
+)
+from litellm.proxy.agent_endpoints.auth.agent_permission_handler import RestrictedAgentAccess
+from litellm.proxy.agent_endpoints.endpoints import router, user_api_key_auth
+from litellm.types.agents import AgentResponse
+
+TRANSLATOR: Final = AgentResponse(
+    agent_id="translator",
+    agent_name="document-translator",
+    agent_card_params={
+        "name": "Document Translator",
+        "description": "Converts files from one language into another",
+        "skills": [
+            {
+                "id": "t",
+                "name": "Translate a file",
+                "description": "Produce the document in the target language",
+                "tags": ["localization", "documents"],
+            }
+        ],
+    },
+)
+SQL_ANALYST: Final = AgentResponse(
+    agent_id="sql",
+    agent_name="warehouse-sql-analyst",
+    agent_card_params={
+        "name": "Warehouse SQL Analyst",
+        "description": "Runs SQL against the inventory database",
+        "skills": [],
+    },
+)
+TRIP_PLANNER: Final = AgentResponse(
+    agent_id="trip",
+    agent_name="trip-planner",
+    agent_card_params={"name": "Trip Planner", "description": "Books flights and hotels"},
+)
+AGENTS: Final = (TRANSLATOR, SQL_ANALYST, TRIP_PLANNER)
+
+VECTORS: Final = MappingProxyType(
+    {
+        "language translation": (1.0, 0.0, 0.0),
+        agent_search_text(TRANSLATOR): (0.9, 0.1, 0.0),
+        agent_search_text(SQL_ANALYST): (0.0, 1.0, 0.0),
+        agent_search_text(TRIP_PLANNER): (0.3, 0.0, 1.0),
+    }
+)
+
+
+class FakeEmbedder:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, ...]] = []  # mutable-ok: test spy recording embed inputs
+
+    async def __call__(self, texts: Sequence[str]) -> Sequence[Vector]:
+        self.calls.append(tuple(texts))
+        return tuple(VECTORS[text] for text in texts)
+
+
+class TestAgentSearchText:
+    def test_joins_name_description_and_skills_with_tags(self) -> None:
+        assert agent_search_text(TRANSLATOR) == (
+            "document-translator\n"
+            "Converts files from one language into another\n"
+            "Translate a file Produce the document in the target language localization documents"
+        )
+
+    def test_missing_card_fields_fall_back_to_the_name(self) -> None:
+        assert agent_search_text(AgentResponse(agent_id="x", agent_name="bare", agent_card_params={})) == "bare"
+
+    def test_malformed_skills_do_not_break_the_text(self) -> None:
+        agent = AgentResponse(
+            agent_id="x", agent_name="odd", agent_card_params={"skills": "not-a-list", "description": "d"}
+        )
+        assert agent_search_text(agent) == "odd"
+
+
+class TestCosineSimilarity:
+    def test_identical_direction_scores_one(self) -> None:
+        assert cosine_similarity((2.0, 0.0), (1.0, 0.0)) == pytest.approx(1.0)
+
+    def test_orthogonal_scores_zero(self) -> None:
+        assert cosine_similarity((1.0, 0.0), (0.0, 1.0)) == pytest.approx(0.0)
+
+    def test_zero_vector_scores_zero_instead_of_dividing(self) -> None:
+        assert cosine_similarity((0.0, 0.0), (1.0, 0.0)) == 0.0
+
+
+class TestAgentSearchIndex:
+    @pytest.mark.asyncio
+    async def test_ranks_by_similarity_and_truncates_to_top_k(self) -> None:
+        outcome = await AgentSearchIndex().search("language translation", AGENTS, top_k=2, embed=FakeEmbedder())
+        assert isinstance(outcome, AgentSearchHits)
+        assert [hit.agent.agent_id for hit in outcome.hits] == ["translator", "trip"]
+        assert outcome.hits[0].score > outcome.hits[1].score
+
+    @pytest.mark.asyncio
+    async def test_second_search_only_embeds_the_query(self) -> None:
+        index = AgentSearchIndex()
+        embedder = FakeEmbedder()
+        await index.search("language translation", AGENTS, top_k=5, embed=embedder)
+        await index.search("language translation", AGENTS, top_k=5, embed=embedder)
+        assert len(embedder.calls[0]) == 1 + len(AGENTS)
+        assert embedder.calls[1] == ("language translation",)
+
+    @pytest.mark.asyncio
+    async def test_empty_registry_returns_no_hits_without_embedding(self) -> None:
+        embedder = FakeEmbedder()
+        outcome = await AgentSearchIndex().search("anything", (), top_k=5, embed=embedder)
+        assert outcome == AgentSearchHits(hits=())
+        assert embedder.calls == []
+
+    @pytest.mark.asyncio
+    async def test_provider_error_becomes_embedding_failed(self) -> None:
+        async def failing(texts: Sequence[str]) -> Sequence[Vector]:
+            raise APIConnectionError(request=MagicMock())
+
+        outcome = await AgentSearchIndex().search("q", AGENTS, top_k=5, embed=failing)
+        assert isinstance(outcome, AgentSearchEmbeddingFailed)
+        assert "embedding the search query failed" in outcome.reason
+
+    @pytest.mark.asyncio
+    async def test_wrong_vector_count_becomes_embedding_failed(self) -> None:
+        async def short(texts: Sequence[str]) -> Sequence[Vector]:
+            return ((1.0, 0.0, 0.0),)
+
+        outcome = await AgentSearchIndex().search("q", AGENTS, top_k=5, embed=short)
+        assert isinstance(outcome, AgentSearchEmbeddingFailed)
+
+
+class TestSearchAgents:
+    @pytest.mark.asyncio
+    async def test_no_embedding_model_is_not_configured(self) -> None:
+        outcome = await search_agents(
+            "q", AGENTS, 5, router=MagicMock(), embedding_model=None, index=AgentSearchIndex()
+        )
+        assert isinstance(outcome, AgentSearchNotConfigured)
+        assert "agent_search_embedding_model" in outcome.reason
+
+    @pytest.mark.asyncio
+    async def test_no_router_is_not_configured(self) -> None:
+        outcome = await search_agents("q", AGENTS, 5, router=None, embedding_model="m", index=AgentSearchIndex())
+        assert isinstance(outcome, AgentSearchNotConfigured)
+
+    @pytest.mark.asyncio
+    async def test_router_embeddings_are_read_from_the_response(self) -> None:
+        router = MagicMock()
+        router.aembedding = AsyncMock(
+            side_effect=lambda model, input: litellm.EmbeddingResponse(
+                model=model,
+                data=[{"object": "embedding", "index": i, "embedding": list(VECTORS[t])} for i, t in enumerate(input)],
+            )
+        )
+        outcome = await search_agents(
+            "language translation",
+            AGENTS,
+            1,
+            router=router,
+            embedding_model="text-embedding-3-small",
+            index=AgentSearchIndex(),
+        )
+        assert isinstance(outcome, AgentSearchHits)
+        assert [hit.agent.agent_id for hit in outcome.hits] == ["translator"]
+        assert router.aembedding.await_args.kwargs["model"] == "text-embedding-3-small"
+
+
+def _client(role: LitellmUserRoles) -> TestClient:
+    app = FastAPI()
+    app.include_router(router)
+    app.dependency_overrides[user_api_key_auth] = lambda: UserAPIKeyAuth(user_id="u", user_role=role)
+    return TestClient(app)
+
+
+@pytest.fixture
+def registry(monkeypatch: pytest.MonkeyPatch) -> MagicMock:
+    from litellm.proxy.agent_endpoints import agent_registry as registry_module
+
+    mock_registry = MagicMock()
+    mock_registry.get_agent_list = MagicMock(return_value=AGENTS)
+    mock_registry.ids_for_agent = MagicMock(side_effect=lambda agent_id: frozenset({agent_id}))
+    monkeypatch.setattr(registry_module, "global_agent_registry", mock_registry)
+    monkeypatch.setattr("litellm.proxy.agent_endpoints.endpoints.global_agent_search_index", AgentSearchIndex())
+    return mock_registry
+
+
+@pytest.fixture
+def embedding_router(monkeypatch: pytest.MonkeyPatch) -> MagicMock:
+    router = MagicMock()
+    router.aembedding = AsyncMock(
+        side_effect=lambda model, input: litellm.EmbeddingResponse(
+            model=model,
+            data=[{"object": "embedding", "index": i, "embedding": list(VECTORS[t])} for i, t in enumerate(input)],
+        )
+    )
+    monkeypatch.setattr("litellm.proxy.proxy_server.llm_router", router)
+    monkeypatch.setattr(litellm, "agent_search_embedding_model", "text-embedding-3-small")
+    return router
+
+
+@pytest.fixture
+def no_db(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("litellm.proxy.proxy_server.prisma_client", None)
+
+
+class TestGetAgentsQuery:
+    def test_query_ranks_and_scores_and_truncates(
+        self, registry: MagicMock, embedding_router: MagicMock, no_db: None
+    ) -> None:
+        response = _client(LitellmUserRoles.PROXY_ADMIN).get(
+            "/v1/agents", params={"query": "language translation", "top_k": 2}, headers={"Authorization": "Bearer k"}
+        )
+        assert response.status_code == 200
+        body = response.json()
+        assert [agent["agent_id"] for agent in body] == ["translator", "trip"]
+        assert body[0]["search_score"] > body[1]["search_score"]
+
+    def test_without_query_the_list_is_unchanged_and_unscored(
+        self, registry: MagicMock, embedding_router: MagicMock, no_db: None
+    ) -> None:
+        response = _client(LitellmUserRoles.PROXY_ADMIN).get("/v1/agents", headers={"Authorization": "Bearer k"})
+        assert response.status_code == 200
+        assert [agent["agent_id"] for agent in response.json()] == ["translator", "sql", "trip"]
+        assert all(agent["search_score"] is None for agent in response.json())
+        embedding_router.aembedding.assert_not_awaited()
+
+    def test_restricted_key_only_ranks_its_own_agents(
+        self, registry: MagicMock, embedding_router: MagicMock, no_db: None, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(
+            "litellm.proxy.agent_endpoints.auth.agent_permission_handler.AgentRequestHandler.resolve_agent_access",
+            AsyncMock(return_value=RestrictedAgentAccess(frozenset({"sql"}))),
+        )
+        response = _client(LitellmUserRoles.INTERNAL_USER).get(
+            "/v1/agents", params={"query": "language translation"}, headers={"Authorization": "Bearer k"}
+        )
+        assert response.status_code == 200
+        assert [agent["agent_id"] for agent in response.json()] == ["sql"]
+
+    def test_missing_embedding_model_is_a_400(
+        self, registry: MagicMock, embedding_router: MagicMock, no_db: None, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(litellm, "agent_search_embedding_model", None)
+        response = _client(LitellmUserRoles.PROXY_ADMIN).get(
+            "/v1/agents", params={"query": "anything"}, headers={"Authorization": "Bearer k"}
+        )
+        assert response.status_code == 400
+        assert response.json()["detail"]["error"] == "agent_search_not_configured"
+
+    def test_embedding_provider_failure_is_a_503(
+        self, registry: MagicMock, embedding_router: MagicMock, no_db: None
+    ) -> None:
+        embedding_router.aembedding = AsyncMock(side_effect=APIConnectionError(request=MagicMock()))
+        response = _client(LitellmUserRoles.PROXY_ADMIN).get(
+            "/v1/agents", params={"query": "anything"}, headers={"Authorization": "Bearer k"}
+        )
+        assert response.status_code == 503
+        assert response.json()["detail"]["error"] == "agent_search_unavailable"
+
+    def test_top_k_is_validated(self, registry: MagicMock, embedding_router: MagicMock, no_db: None) -> None:
+        response = _client(LitellmUserRoles.PROXY_ADMIN).get(
+            "/v1/agents", params={"query": "anything", "top_k": 0}, headers={"Authorization": "Bearer k"}
+        )
+        assert response.status_code == 422

--- a/ui/litellm-dashboard/src/lib/http/schema.d.ts
+++ b/ui/litellm-dashboard/src/lib/http/schema.d.ts
@@ -16575,6 +16575,10 @@ export interface paths {
          *     ```
          *     curl -X GET "http://localhost:4000/v1/agents?health_check=true"       -H "Content-Type: application/json"       -H "Authorization: Bearer your-key"     ```
          *
+         *     Pass `?query=<task>` to get the best matching agents ranked by semantic similarity:
+         *     ```
+         *     curl -X GET "http://localhost:4000/v1/agents?query=translate+a+PDF+document&top_k=5"       -H "Content-Type: application/json"       -H "Authorization: Bearer your-key"     ```
+         *
          *     Returns: List[AgentResponse]
          */
         get: operations["get_agents_v1_agents_get"];
@@ -22487,6 +22491,8 @@ export interface components {
             } | null;
             /** Rpm Limit */
             rpm_limit?: number | null;
+            /** Search Score */
+            search_score?: number | null;
             /** Session Rpm Limit */
             session_rpm_limit?: number | null;
             /** Session Tpm Limit */
@@ -30208,6 +30214,8 @@ export interface components {
             token_exchange_profile?: string | null;
             /** Upstream Resource */
             upstream_resource?: string | null;
+            /** Upstream Token Header */
+            upstream_token_header?: string | null;
         };
         /**
          * MCPEnvVar
@@ -58515,6 +58523,10 @@ export interface operations {
             query?: {
                 /** @description When true, performs a GET request to each agent's URL. Agents with reachable URLs (HTTP status < 500) and agents without a URL are returned; unreachable agents are filtered out. */
                 health_check?: boolean;
+                /** @description Describe the task in natural language to rank the agents you can reach by semantic similarity over their name, description, and skills. Each result carries a search_score. Requires litellm_settings.agent_search_embedding_model. */
+                query?: string | null;
+                /** @description With query: the maximum number of ranked agents to return. */
+                top_k?: number;
             };
             header?: never;
             path?: never;


### PR DESCRIPTION
## TLDR

Problem this solves:

- Agent registries grow past what an agent can scan by name
- GET /v1/agents only lists; there is no way to search it
- MCP clients get mcp_tool_search for tools but nothing for agents

How it solves it:

- GET /v1/agents accepts query and top_k, ranks by semantic similarity
- New agent_search MCP virtual tool for keys with tool search enabled
- One config key: litellm_settings.agent_search_embedding_model picks the embedding model
- Results only cover agents the calling key can access
- Ranked responses carry a search_score field per agent
- Embedding spend is tracked against the calling key, so /key/info and /spend/logs see it
- Agent vectors are cached per embedding model and re-embedded when the vector size changes, so a fallback or a config change to another embedding model never breaks search
- Fresh agent vectors merge into the live cache, so searches running at the same time keep each other's work and the next search never pays to embed an agent twice

## User Flow

Before: a developer whose agents reach other agents through the gateway can only list the registry, so picking the right agent means reading every card by hand

1. They send GET https://litellm-domain/v1/agents?query=translate+a+pdf+document with their key and get 200 with the whole registry, unranked; the query parameter is silently ignored
2. They send POST https://litellm-domain/mcp-rest/tools/call with `{"name": "agent_search", "arguments": {"query": "translate a pdf document"}}` and get back an error naming agent_search an unknown tool
3. Their MCP client lists tools over POST https://litellm-domain/mcp/ and sees only mcp_tool_search and mcp_tool_call, neither of which covers agents

After: the same developer describes the task in natural language and gets back the best-matching agents their key can reach, ranked

1. The proxy admin sets `litellm_settings.agent_search_embedding_model: text-embedding-3-small` (any embedding model from model_list) and restarts the proxy
2. They send GET https://litellm-domain/v1/agents?query=translate+a+pdf+document&top_k=3 and get 200 with up to 3 agents ranked by semantic similarity, each carrying a `search_score`
3. They send POST https://litellm-domain/mcp-rest/tools/call with `{"name": "agent_search", "arguments": {"query": "translate a pdf document"}}` and get the ranked agents as JSON: agent_id, name, description, skills, score
4. Their MCP client lists tools over POST https://litellm-domain/mcp/, sees agent_search alongside the two existing tools, and tools/call on it returns the same ranked JSON
5. A key restricted to specific agents only ever gets its own agents back, whatever the query says
6. If the admin never set the config key, GET /v1/agents?query=... answers 400 `agent_search_not_configured` naming the exact setting to add
7. The embedding calls those searches make show up under their key: GET https://litellm-domain/key/info spend grows and GET https://litellm-domain/spend/logs?api_key=<key hash> lists them
8. If the admin later points agent_search_embedding_model at a model with a different vector size, or the router falls back to one, the next GET https://litellm-domain/v1/agents?query=... still answers 200 with a ranked list
9. Two keys that see different agents can search at the same time; the next search from a key that sees every agent embeds only its query, so GET https://litellm-domain/spend/logs?api_key=<key hash> shows 3 prompt tokens for it, not the whole registry

## Relevant issues

Fixes #37829

## Linear ticket

Resolves LIT-6309

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Shared setup for both legs: two proxy processes share one Postgres DB (`--config` below, started once each on ports A and B, plus a third process for the last case), so the second-instance case proves the ranking works from a process that never registered the agents. The same `config.yaml` is used on both sides; the base ignores the unknown `litellm_settings` key

```yaml
model_list:
  - model_name: text-embedding-3-small
    litellm_params:
      model: openai/text-embedding-3-small
      api_key: os.environ/OPENAI_API_KEY
litellm_settings:
  agent_search_embedding_model: text-embedding-3-small
general_settings:
  store_model_in_db: true
agents:
  - agent_name: document-translator
    agent_card_params:
      name: Document Translator
      description: Converts PDF, Word and text files from one language into another while preserving layout
      url: http://localhost:10001
      protocolVersion: "0.3"
      version: "1.0.0"
      capabilities: {}
      defaultInputModes: ["text"]
      defaultOutputModes: ["text"]
      skills:
        - id: translate-file
          name: Translate a file
          description: Take an uploaded document and produce the same document in the target language
          tags: ["localization", "documents"]
```

Two more agents are registered through the API on instance A with the master key, then two virtual keys are minted: `$KEY_SEARCH` (`{"object_permission": {"mcp_tool_search_enabled": true}}`) and `$KEY_RESTRICTED` (`{"object_permission": {"agents": ["<warehouse-sql-analyst agent_id>"]}}`)

```bash
curl -s http://localhost:$A/v1/agents -H "Authorization: Bearer $MASTER" -H 'Content-Type: application/json' -d '{"agent_name": "trip-planner", "agent_card_params": {"protocolVersion": "0.3", "name": "Trip Planner", "description": "Books flights and hotels for a business trip given dates, origin and destination", "url": "http://localhost:10003", "version": "1.0.0", "capabilities": {}, "defaultInputModes": ["text"], "defaultOutputModes": ["text"], "skills": [{"id": "book-travel", "name": "Book travel", "description": "Find and book the flights and hotel for a business trip", "tags": ["travel", "booking"]}]}}'
curl -s http://localhost:$A/v1/agents -H "Authorization: Bearer $MASTER" -H 'Content-Type: application/json' -d '{"agent_name": "warehouse-sql-analyst", "agent_card_params": {"protocolVersion": "0.3", "name": "Warehouse SQL Analyst", "description": "Answers questions about stock by running SQL queries against the inventory database", "url": "http://localhost:10002", "version": "1.0.0", "capabilities": {}, "defaultInputModes": ["text"], "defaultOutputModes": ["text"], "skills": [{"id": "query-stock-levels", "name": "Query stock levels", "description": "Run a SQL query against the inventory database and summarize the stock levels it returns", "tags": ["sql", "analytics"]}]}}'
```

`jq -c '.[] | {agent_name, search_score}'` prints `null` for `search_score` wherever the response has no such field

### Before (7083c479)

#### GET /v1/agents?query= ranks agents

1. `curl -s "http://localhost:$A/v1/agents?query=plan+a+vacation+itinerary&top_k=3" -H "Authorization: Bearer $MASTER" | jq -c '.[] | {agent_name, search_score}'`
2. The query and top_k are ignored: the full registry comes back in insertion order with no score
   ```
   {"agent_name":"trip-planner","search_score":null}
   {"agent_name":"warehouse-sql-analyst","search_score":null}
   {"agent_name":"document-translator","search_score":null}
   ```

#### Same query on the second instance

1. `curl -s "http://localhost:$B/v1/agents?query=plan+a+vacation+itinerary&top_k=3" -H "Authorization: Bearer $MASTER" | jq -c '.[] | {agent_name, search_score}'`
2. Same unranked list
   ```
   {"agent_name":"trip-planner","search_score":null}
   {"agent_name":"warehouse-sql-analyst","search_score":null}
   {"agent_name":"document-translator","search_score":null}
   ```

#### Config-declared agent is searchable

1. `curl -s "http://localhost:$B/v1/agents?query=translate+a+pdf+document&top_k=1" -H "Authorization: Bearer $MASTER" | jq -c '.[] | {agent_name, search_score}'`
2. top_k=1 is ignored too; all three agents come back unranked
   ```
   {"agent_name":"trip-planner","search_score":null}
   {"agent_name":"warehouse-sql-analyst","search_score":null}
   {"agent_name":"document-translator","search_score":null}
   ```

#### agent_search via POST /mcp-rest/tools/call

1. `curl -s http://localhost:$A/mcp-rest/tools/call -H "Authorization: Bearer $KEY_SEARCH" -H 'Content-Type: application/json' -d '{"name": "agent_search", "arguments": {"query": "check how many units are left in stock", "top_k": 2}}' | jq -c .`
2. agent_search is not a virtual tool, so the REST route treats it as a regular MCP tool and rejects the call
   ```
   {"detail":{"error":"missing_parameter","message":"server_id is required in request body"}}
   ```

#### tools/list and tools/call over POST /mcp/

1. `curl -s http://localhost:$B/mcp/ -H "Authorization: Bearer $KEY_SEARCH" -H 'Content-Type: application/json' -H 'Accept: application/json, text/event-stream' -d '{"jsonrpc": "2.0", "id": 1, "method": "tools/list"}' | grep '^data:' | sed 's/^data: //' | jq -c '[.result.tools[].name]'`
2. Only the two existing virtual tools are listed
   ```
   ["mcp_tool_search","mcp_tool_call"]
   ```
3. `curl -s http://localhost:$B/mcp/ -H "Authorization: Bearer $KEY_SEARCH" -H 'Content-Type: application/json' -H 'Accept: application/json, text/event-stream' -d '{"jsonrpc": "2.0", "id": 2, "method": "tools/call", "params": {"name": "agent_search", "arguments": {"query": "book a flight and hotel", "top_k": 1}}}' | grep '^data:' | sed 's/^data: //' | jq -c '.result.content[0].text | fromjson? // .'`
4. The call is refused
   ```
   "Error: User not allowed to call this tool."
   ```

#### Restricted key only sees its own agents

1. `curl -s "http://localhost:$A/v1/agents?query=plan+a+vacation+itinerary&top_k=3" -H "Authorization: Bearer $KEY_RESTRICTED" | jq -c '.[] | {agent_name, search_score}'`
2. The key's one agent comes back, unscored
   ```
   {"agent_name":"warehouse-sql-analyst","search_score":null}
   ```

#### No embedding model configured

1. `curl -s -w '\nHTTP %{http_code}\n' "http://localhost:$A/v1/agents?query=plan+a+vacation+itinerary" -H "Authorization: Bearer $MASTER"`
2. Nothing tells the caller that search is unavailable: 200 with the full registry (payload elided, it is the same three agents)
   ```
   [{"agent_id":"e6210b81-5505-4595-920b-53288f704809","agent_name":"trip-planner", ...}, {"agent_id":"ad1c73ee-deff-4d1c-85f7-a42fbc1ec255","agent_name":"warehouse-sql-analyst", ...}, {"agent_id":"a9cb3976...","agent_name":"document-translator", ...}]
   HTTP 200
   ```

### After (e9cc9c9b)

#### GET /v1/agents?query= ranks agents

1. `curl -s 'http://localhost:$A/v1/agents?query=plan+a+vacation+itinerary&top_k=3' -H 'Authorization: Bearer $MASTER' | jq -c '.[] | {agent_name, search_score}'`
2. trip-planner ranks first and every agent carries its cosine score
   ```
   {"agent_name":"trip-planner","search_score":0.46068230836959995}
   {"agent_name":"document-translator","search_score":0.11200725760167635}
   {"agent_name":"warehouse-sql-analyst","search_score":0.09470067778779014}
   ```

#### Same query on the second instance

1. `curl -s 'http://localhost:$B/v1/agents?query=plan+a+vacation+itinerary&top_k=3' -H 'Authorization: Bearer $MASTER' | jq -c '.[] | {agent_name, search_score}'`
2. Instance B never registered the two API agents; it embeds them from the shared DB and ranks identically
   ```
   {"agent_name":"trip-planner","search_score":0.4607150537704817}
   {"agent_name":"document-translator","search_score":0.11204450076080524}
   {"agent_name":"warehouse-sql-analyst","search_score":0.094646121092808}
   ```

#### Config-declared agent is searchable

1. `curl -s 'http://localhost:$A/v1/agents?query=translate+a+pdf+document&top_k=1' -H 'Authorization: Bearer $MASTER' | jq -c '.[] | {agent_name, search_score}'`
2. The agent declared in config.yaml is ranked like the DB ones, and top_k=1 trims the list
   ```
   {"agent_name":"document-translator","search_score":0.6732450375047712}
   ```

#### agent_search via POST /mcp-rest/tools/call

1. `curl -s http://localhost:$A/mcp-rest/tools/call -H 'Authorization: Bearer $KEY_SEARCH' -H 'Content-Type: application/json' -d '{"name": "agent_search", "arguments": {"query": "check how many units are left in stock", "top_k": 2}}' | jq -c .`
2. The ranked agents come back as JSON text with agent_id, name, description, skills, and score
   ```
   {"_meta":null,"content":[{"type":"text","text":"[{\"agent_id\": \"b21b8787-8b9e-4c5f-a45c-3f5e4061d70e\", \"agent_name\": \"warehouse-sql-analyst\", \"description\": \"Answers questions about stock by running SQL queries against the inventory database\", \"skills\": [{\"name\": \"Query stock levels\", \"description\": \"Run a SQL query against the inventory database and summarize the stock levels it returns\", \"tags\": [\"sql\", \"analytics\"]}], \"score\": 0.3791485568539873}, {\"agent_id\": \"fc98c971-659a-42dc-902c-b8b8f59a50ef\", \"agent_name\": \"trip-planner\", \"description\": \"Books flights and hotels for a business trip given dates, origin and destination\", \"skills\": [{\"name\": \"Book travel\", \"description\": \"Find and book the flights and hotel for a business trip\", \"tags\": [\"travel\", \"booking\"]}], \"score\": 0.12168402727229097}]","annotations":null,"_meta":null}],"structuredContent":null,"isError":false}
   ```

#### tools/list and tools/call over POST /mcp/

1. `curl -s http://localhost:$A/mcp/ -H 'Authorization: Bearer $KEY_SEARCH' -H 'Content-Type: application/json' -H 'Accept: application/json, text/event-stream' -d '{"jsonrpc": "2.0", "id": 1, "method": "tools/list"}' | grep '^data:' | sed 's/^data: //' | jq -c '[.result.tools[].name]'`
2. agent_search is listed next to the two existing virtual tools
   ```
   ["mcp_tool_search","mcp_tool_call","agent_search"]
   ```
3. `curl -s http://localhost:$A/mcp/ -H 'Authorization: Bearer $KEY_SEARCH' -H 'Content-Type: application/json' -H 'Accept: application/json, text/event-stream' -d '{"jsonrpc": "2.0", "id": 2, "method": "tools/call", "params": {"name": "agent_search", "arguments": {"query": "book a flight and hotel", "top_k": 1}}}' | grep '^data:' | sed 's/^data: //' | jq -c '.result.content[0].text | fromjson? // .'`
4. The MCP server's jsonschema validation passes and the best agent comes back
   ```
   [{"agent_id":"fc98c971-659a-42dc-902c-b8b8f59a50ef","agent_name":"trip-planner","description":"Books flights and hotels for a business trip given dates, origin and destination","skills":[{"name":"Book travel","description":"Find and book the flights and hotel for a business trip","tags":["travel","booking"]}],"score":0.6081425046921755}]
   ```
5. `curl -s http://localhost:$A/mcp/ -H 'Authorization: Bearer $KEY_SEARCH' -H 'Content-Type: application/json' -H 'Accept: application/json, text/event-stream' -d '{"jsonrpc": "2.0", "id": 3, "method": "tools/call", "params": {"name": "mcp_tool_search", "arguments": {"query": "add numbers"}}}' | grep '^data:' | sed 's/^data: //' | jq -c '{isError: .result.isError, text: .result.content[0].text}'`
6. The pre-existing mcp_tool_search still validates and answers (no MCP servers are configured, so the match list is empty)
   ```
   {"isError":false,"text":"[]"}
   ```

#### Restricted key only sees its own agents

1. `curl -s 'http://localhost:$A/v1/agents?query=plan+a+vacation+itinerary&top_k=3' -H 'Authorization: Bearer $KEY_RESTRICTED' | jq -c '.[] | {agent_name, search_score}'`
2. trip-planner is the best match but this key cannot see it; only its own agent is ranked
   ```
   {"agent_name":"warehouse-sql-analyst","search_score":0.09472462377311118}
   ```

#### Embedding spend lands on the calling key

1. `curl -s http://localhost:$A/key/info -H 'Authorization: Bearer $KEY_SEARCH' | jq -c '{key_alias: .info.key_alias, spend: .info.spend}'`
2. The search key starts with no spend
   ```
   {"key_alias":null,"spend":0.0}
   ```
3. `curl -s 'http://localhost:$A/v1/agents?query=find+the+cheapest+flight+to+paris&top_k=1' -H 'Authorization: Bearer $KEY_SEARCH' | jq -c '[.[] | {agent_name, search_score}]'`
4. One ranked search with that key
   ```
   [{"agent_name":"trip-planner","search_score":0.30937728168379236}]
   ```
5. `curl -s http://localhost:$A/key/info -H 'Authorization: Bearer $KEY_SEARCH' | jq -c '{key_alias: .info.key_alias, spend: .info.spend}'`
6. 20 seconds later the key's spend includes the embedding calls the searches on this process made
   ```
   {"key_alias":null,"spend":3.8E-7}
   ```
7. `curl -s 'http://localhost:$A/spend/logs?api_key=$KEY_SEARCH_HASH' -H 'Authorization: Bearer $MASTER' | jq -c '[.[] | {model, call_type, spend, team_id}]'`
8. `$KEY_SEARCH_HASH` is the `.key` field of the key's own `/key/info`; every spend log row is an embedding call attributed to it
   ```
   [{"model":"openai/text-embedding-3-small","call_type":"aembedding","spend":1.2E-7,"team_id":""},{"model":"openai/text-embedding-3-small","call_type":"aembedding","spend":1E-7,"team_id":""},{"model":"openai/text-embedding-3-small","call_type":"aembedding","spend":1.6E-7,"team_id":""}]
   ```

#### No embedding model configured

1. Start a third process from the same config minus the `agent_search_embedding_model` line, then `curl -s -w '\nHTTP %{http_code}\n' "http://localhost:$C/v1/agents?query=plan+a+vacation+itinerary" -H "Authorization: Bearer $MASTER"`
2. The caller is told exactly which setting is missing
   ```
   {"detail":{"error":"agent_search_not_configured","message":"agent search needs litellm_settings.agent_search_embedding_model set to an embedding model from model_list"}}
   HTTP 400
   ```

#### Dependent paths the change touches, same tip

1. `curl -s http://localhost:$A/mcp-rest/tools/list -H 'Authorization: Bearer $KEY_SEARCH' | jq -c '[.tools[] | {name, required: .inputSchema.required}]'`
2. GET /mcp-rest/tools/list serializes the virtual tool tuple and every `required` is a JSON array
   ```
   [{"name":"mcp_tool_search","required":["query"]},{"name":"mcp_tool_call","required":["tool_name"]},{"name":"agent_search","required":["query"]}]
   ```
3. `curl -s http://localhost:$A/mcp-rest/tools/call -H 'Authorization: Bearer $KEY_SEARCH' -H 'Content-Type: application/json' -d '{"name": "mcp_tool_search", "arguments": {"query": "add numbers"}}' | jq -c '{isError, text: .content[0].text}'`
4. mcp_tool_search still dispatches over /mcp-rest
   ```
   {"isError":false,"text":"[]"}
   ```
5. `curl -s http://localhost:$A/mcp-rest/tools/call -H 'Authorization: Bearer $KEY_SEARCH' -H 'Content-Type: application/json' -d '{"name": "agent_search", "arguments": {}}' | jq -c '{isError, text: .content[0].text[0:120]}'`
6. Over /mcp-rest nothing validates arguments, so a missing query reaches the embedding model and comes back as a tool error, never a 500
   ```
   {"isError":true,"text":"embedding the search query failed: litellm.BadRequestError: OpenAIException - Error code: 400 - {'error': {'message': \"I"}
   ```
7. `curl -s http://localhost:$A/mcp-rest/tools/call -H 'Authorization: Bearer $KEY_SEARCH' -H 'Content-Type: application/json' -d '{"name": "agent_search", "arguments": {"query": "inventory levels", "top_k": "abc"}}' | jq -c '.content[0].text | fromjson | [.[] | {agent_name, score}]'`
8. A non-numeric top_k falls back to the default of 5
   ```
   [{"agent_name":"warehouse-sql-analyst","score":0.4423848043943892},{"agent_name":"trip-planner","score":0.1824006902772436},{"agent_name":"document-translator","score":0.11647182300071149}]
   ```
9. `curl -s http://localhost:$A/v1/agents -H 'Authorization: Bearer $MASTER' | jq -c '[.[] | {agent_name, search_score}]'`
10. Without query the list is unranked and search_score is null
   ```
   [{"agent_name":"warehouse-sql-analyst","search_score":null},{"agent_name":"trip-planner","search_score":null},{"agent_name":"document-translator","search_score":null}]
   ```
11. `curl -s -o /dev/null -w 'HTTP %{http_code}\n' -X PATCH http://localhost:$A/v1/agents/fc98c971-659a-42dc-902c-b8b8f59a50ef -H 'Authorization: Bearer $MASTER' -H 'Content-Type: application/json' -d '{"agent_name": "trip-planner", "search_score": 0.42}'`
12. PATCH /v1/agents/{id} with a body carrying search_score (the dashboard round-trips whole agent objects) still writes; the field never reaches Prisma
   ```
   HTTP 200
   ```

### Before (e9cc9c9b) and After (db02cf81): the vector cache survives a change of embedding model

Same DB, keys, and agents as above. Only the config differs: one `agent-embedder` model group with two deployments of different vector sizes (text-embedding-3-small is 1536-wide, text-embedding-3-large is 3072-wide), which stands in for a router fallback or a config reload onto an embedding model with another vector size

```yaml
model_list:
  - model_name: agent-embedder
    litellm_params:
      model: openai/text-embedding-3-small
      api_key: os.environ/OPENAI_API_KEY
  - model_name: agent-embedder
    litellm_params:
      model: openai/text-embedding-3-large
      api_key: os.environ/OPENAI_API_KEY
litellm_settings:
  agent_search_embedding_model: agent-embedder
```

#### Before (e9cc9c9b): the second deployment poisons the cache

1. `curl -s 'http://localhost:$A/v1/agents?top_k=1' --get --data-urlencode 'query=plan a vacation itinerary' -H 'Authorization: Bearer $MASTER' | jq -c 'if type == "array" then [.[] | {agent_name, search_score}] else . end'`
2. The first search embeds the agents through whichever deployment the router picks and caches those vectors
   ```
   [{"agent_name":"trip-planner","search_score":0.4297847119797013}]
   ```
3. `curl -s 'http://localhost:$A/v1/agents?top_k=1' --get --data-urlencode 'query=translate a pdf document' -H 'Authorization: Bearer $MASTER' | jq -c 'if type == "array" then [.[] | {agent_name, search_score}] else . end'`
4. A search whose query lands on the other deployment compares a 3072-wide query against 1536-wide cached vectors and dies with a 500
   ```
   {"detail":{"error":"Internal server error: zip() argument 2 is longer than argument 1"}}
   ```
5. `curl -s 'http://localhost:$A/v1/agents?top_k=1' --get --data-urlencode 'query=check how many units are left in stock' -H 'Authorization: Bearer $MASTER' | jq -c 'if type == "array" then [.[] | {agent_name, search_score}] else . end'`
6. Same again; nothing evicts the poisoned cache
   ```
   {"detail":{"error":"Internal server error: zip() argument 2 is longer than argument 1"}}
   ```
7. `curl -s 'http://localhost:$A/v1/agents?top_k=1' --get --data-urlencode 'query=book flights and hotels' -H 'Authorization: Bearer $MASTER' | jq -c 'if type == "array" then [.[] | {agent_name, search_score}] else . end'`
8. A search that happens to land on the cached deployment still works, so the failure looks random to the caller
   ```
   [{"agent_name":"trip-planner","search_score":0.5967593470541304}]
   ```
9. `curl -s 'http://localhost:$A/v1/agents?top_k=1' --get --data-urlencode 'query=convert a word file to spanish' -H 'Authorization: Bearer $MASTER' | jq -c 'if type == "array" then [.[] | {agent_name, search_score}] else . end'`
10. Works when the router picks the cached deployment
   ```
   [{"agent_name":"document-translator","search_score":0.5123179525580667}]
   ```
11. `curl -s 'http://localhost:$A/v1/agents?top_k=1' --get --data-urlencode 'query=inventory levels by warehouse' -H 'Authorization: Bearer $MASTER' | jq -c 'if type == "array" then [.[] | {agent_name, search_score}] else . end'`
12. Works for the same reason; the 500s keep coming for as long as the worker lives
   ```
   [{"agent_name":"warehouse-sql-analyst","search_score":0.49354130916348515}]
   ```

#### After (db02cf81): searches keep answering across both vector sizes

1. `curl -s 'http://localhost:$A/v1/agents?top_k=1' --get --data-urlencode 'query=plan a vacation itinerary' -H 'Authorization: Bearer $MASTER' | jq -c 'if type == "array" then [.[] | {agent_name, search_score}] else . end'`
2. First search fills the cache for this embedding model
   ```
   [{"agent_name":"trip-planner","search_score":0.46070815142107585}]
   ```
3. `curl -s 'http://localhost:$A/v1/agents?top_k=1' --get --data-urlencode 'query=translate a pdf document' -H 'Authorization: Bearer $MASTER' | jq -c 'if type == "array" then [.[] | {agent_name, search_score}] else . end'`
4. A query embedded at the other vector size re-embeds the query and the agents together in one call, then ranks
   ```
   [{"agent_name":"document-translator","search_score":0.6732450375047712}]
   ```
5. `curl -s 'http://localhost:$A/v1/agents?top_k=1' --get --data-urlencode 'query=check how many units are left in stock' -H 'Authorization: Bearer $MASTER' | jq -c 'if type == "array" then [.[] | {agent_name, search_score}] else . end'`
6. Ranks
   ```
   [{"agent_name":"warehouse-sql-analyst","search_score":0.3771639080808998}]
   ```
7. `curl -s 'http://localhost:$A/v1/agents?top_k=1' --get --data-urlencode 'query=book flights and hotels' -H 'Authorization: Bearer $MASTER' | jq -c 'if type == "array" then [.[] | {agent_name, search_score}] else . end'`
8. Ranks
   ```
   [{"agent_name":"trip-planner","search_score":0.5967593470541304}]
   ```
9. `curl -s 'http://localhost:$A/v1/agents?top_k=1' --get --data-urlencode 'query=convert a word file to spanish' -H 'Authorization: Bearer $MASTER' | jq -c 'if type == "array" then [.[] | {agent_name, search_score}] else . end'`
10. Ranks
   ```
   [{"agent_name":"document-translator","search_score":0.5382340353586434}]
   ```
11. `curl -s 'http://localhost:$A/v1/agents?top_k=1' --get --data-urlencode 'query=inventory levels by warehouse' -H 'Authorization: Bearer $MASTER' | jq -c 'if type == "array" then [.[] | {agent_name, search_score}] else . end'`
12. Six searches over a group that flips between 1536 and 3072 dimensions, six ranked answers, no 500 and no 503
   ```
   [{"agent_name":"warehouse-sql-analyst","search_score":0.5334472063220455}]
   ```

#### GET /v1/agents?query= ranks agents

1. `curl -s 'http://localhost:$A/v1/agents?query=plan+a+vacation+itinerary&top_k=3' -H 'Authorization: Bearer $MASTER' | jq -c '.[] | {agent_name, search_score}'`
2. trip-planner ranks first and every agent carries its cosine score
   ```
   {"agent_name":"trip-planner","search_score":0.46070815142107585}
   {"agent_name":"document-translator","search_score":0.11203058136724742}
   {"agent_name":"warehouse-sql-analyst","search_score":0.09471439825275152}
   ```

#### Config-declared agent is searchable

1. `curl -s 'http://localhost:$A/v1/agents?query=translate+a+pdf+document&top_k=1' -H 'Authorization: Bearer $MASTER' | jq -c '.[] | {agent_name, search_score}'`
2. The yaml-declared translator still ranks first for its own task
   ```
   {"agent_name":"document-translator","search_score":0.6732509313613476}
   ```

#### agent_search via POST /mcp-rest/tools/call

1. `curl -s http://localhost:$A/mcp-rest/tools/call -H 'Authorization: Bearer $KEY_SEARCH' -H 'Content-Type: application/json' -d '{"name": "agent_search", "arguments": {"query": "check how many units are left in stock", "top_k": 2}}' | jq -c .`
2. The MCP virtual tool ranks the same registry through the same cache
   ```
   {"_meta":null,"content":[{"type":"text","text":"[{\"agent_id\": \"b21b8787-8b9e-4c5f-a45c-3f5e4061d70e\", \"agent_name\": \"warehouse-sql-analyst\", \"description\": \"Answers questions about stock by running SQL queries against the inventory database\", \"skills\": [{\"name\": \"Query stock levels\", \"description\": \"Run a SQL query against the inventory database and summarize the stock levels it returns\", \"tags\": [\"sql\", \"analytics\"]}], \"score\": 0.377168456111392}, {\"agent_id\": \"fc98c971-659a-42dc-902c-b8b8f59a50ef\", \"agent_name\": \"trip-planner\", \"description\": \"Books flights and hotels for a business trip given dates, origin and destination\", \"skills\": [{\"name\": \"Book travel\", \"description\": \"Find and book the flights and hotel for a business trip\", \"tags\": [\"travel\", \"booking\"]}], \"score\": 0.12617954845303345}]","annotations":null,"_meta":null}],"structuredContent":null,"isError":false}
   ```

#### tools/list and tools/call over POST /mcp/

1. `curl -s http://localhost:$A/mcp/ -H 'Authorization: Bearer $KEY_SEARCH' -H 'Content-Type: application/json' -H 'Accept: application/json, text/event-stream' -d '{"jsonrpc": "2.0", "id": 1, "method": "tools/list"}' | grep '^data:' | sed 's/^data: //' | jq -c '[.result.tools[].name]'`
2. agent_search is listed next to the two existing virtual tools
   ```
   ["mcp_tool_search","mcp_tool_call","agent_search"]
   ```
3. `curl -s http://localhost:$A/mcp/ -H 'Authorization: Bearer $KEY_SEARCH' -H 'Content-Type: application/json' -H 'Accept: application/json, text/event-stream' -d '{"jsonrpc": "2.0", "id": 2, "method": "tools/call", "params": {"name": "agent_search", "arguments": {"query": "book a flight and hotel", "top_k": 1}}}' | grep '^data:' | sed 's/^data: //' | jq -c '.result.content[0].text | fromjson? // .'`
4. tools/call on it returns the ranked JSON
   ```
   [{"agent_id":"fc98c971-659a-42dc-902c-b8b8f59a50ef","agent_name":"trip-planner","description":"Books flights and hotels for a business trip given dates, origin and destination","skills":[{"name":"Book travel","description":"Find and book the flights and hotel for a business trip","tags":["travel","booking"]}],"score":0.5697225709111288}]
   ```

#### Restricted key only sees its own agents

1. `curl -s 'http://localhost:$A/v1/agents?query=plan+a+vacation+itinerary&top_k=3' -H 'Authorization: Bearer $KEY_RESTRICTED' | jq -c '.[] | {agent_name, search_score}'`
2. A key limited to the warehouse agent gets only that agent back, whatever the query
   ```
   {"agent_name":"warehouse-sql-analyst","search_score":0.05868779048073312}
   ```

#### Embedding spend lands on the calling key

1. `curl -s http://localhost:$A/key/info -H 'Authorization: Bearer $KEY_SEARCH' | jq -c '{key_alias: .info.key_alias, spend: .info.spend}'`
2. The search key's spend before this search
   ```
   {"key_alias":null,"spend":0.00002451}
   ```
3. `curl -s 'http://localhost:$A/v1/agents?query=find+the+cheapest+flight+to+paris&top_k=1' -H 'Authorization: Bearer $KEY_SEARCH' | jq -c '[.[] | {agent_name, search_score}]'`
4. One ranked search with that key
   ```
   [{"agent_name":"trip-planner","search_score":0.3307554907253355}]
   ```
5. `curl -s http://localhost:$A/key/info -H 'Authorization: Bearer $KEY_SEARCH' | jq -c '{key_alias: .info.key_alias, spend: .info.spend}'`
6. 20 seconds later the key's spend has grown by the embedding calls, including the re-embed after a vector-size flip
   ```
   {"key_alias":null,"spend":0.0000575}
   ```
7. `curl -s 'http://localhost:$A/spend/logs?api_key=$KEY_SEARCH_HASH' -H 'Authorization: Bearer $MASTER' | jq -c '[.[] | {model, call_type, spend, team_id}]'`
8. `$KEY_SEARCH_HASH` is the `.key` field of the key's own `/key/info`; both embedding deployments show up as rows attributed to it
   ```
   [{"model":"openai/text-embedding-3-large","call_type":"aembedding","spend":7.799999999999999E-7,"team_id":""},{"model":"openai/text-embedding-3-large","call_type":"aembedding","spend":0.00001534,"team_id":""},{"model":"openai/text-embedding-3-small","call_type":"aembedding","spend":1E-7,"team_id":""},{"model":"openai/text-embedding-3-large","call_type":"aembedding","spend":0.00001573,"team_id":""},{"model":"openai/text-embedding-3-large","call_type":"aembedding","spend":0.00000104,"team_id":""},{"model":"openai/text-embedding-3-small","call_type":"aembedding","spend":0.00000238,"team_id":""},{"model":"openai/text-embedding-3-large","call_type":"aembedding","spend":7.799999999999999E-7,"team_id":""},{"model":"openai/text-embedding-3-small","call_type":"aembedding","spend":1E-7,"team_id":""},{"model":"openai/text-embedding-3-small","call_type":"aembedding","spend":0.00000242,"team_id":""},{"model":"openai/text-embedding-3-large","call_type":"aembedding","spend":0.00000104,"team_id":""},{"model":"openai/text-embedding-3-small","call_type":"aembedding","spend":8E-7,"team_id":""},{"model":"openai/text-embedding-3-large","call_type":"aembedding","spend":7.799999999999999E-7,"team_id":""},{"model":"openai/text-embedding-3-large","call_type":"aembedding","spend":0.00001469,"team_id":""},{"model":"openai/text-embedding-3-small","call_type":"aembedding","spend":1E-7,"team_id":""},{"model":"openai/text-embedding-3-large","call_type":"aembedding","spend":0.00000104,"team_id":""},{"model":"openai/text-embedding-3-small","call_type":"aembedding","spend":0.0000023,"team_id":""},{"model":"openai/text-embedding-3-small","call_type":"aembedding","spend":1.2E-7,"team_id":""},{"model":"openai/text-embedding-3-small","call_type":"aembedding","spend":1E-7,"team_id":""},{"model":"openai/text-embedding-3-small","call_type":"aembedding","spend":1.6E-7,"team_id":""}]
   ```

### Before (db02cf81) and After (4026aa65): searches running at the same time keep each other's vectors

Same DB and agents as above, back on the single text-embedding-3-small config. Three fresh keys: KEY_TRIP sees trip-planner, KEY_OTHERS sees warehouse-sql-analyst and document-translator, KEY_ALL sees all three. The two restricted keys search at the same time, then KEY_ALL searches twice, and /spend/logs for KEY_ALL shows how many prompt tokens each of its searches embedded (the query alone is 3 tokens)

#### Before (db02cf81): the first all-agents search pays to embed two agents again

1. `curl -s 'http://localhost:$A/v1/agents?query=book+a+trip&top_k=1' -H "Authorization: Bearer $KEY_TRIP" | jq -c '[.[] | {agent_name, search_score}]' & curl -s 'http://localhost:$A/v1/agents?query=book+a+trip&top_k=1' -H "Authorization: Bearer $KEY_OTHERS" | jq -c '[.[] | {agent_name, search_score}]' & wait`
   ```
   [{"agent_name":"document-translator","search_score":0.15166149306363558}]
   [{"agent_name":"trip-planner","search_score":0.6536557773948982}]
   ```
2. `curl -s 'http://localhost:$A/v1/agents?query=book+a+trip&top_k=3' -H "Authorization: Bearer $KEY_ALL" | jq -c '[.[] | {agent_name, search_score}]'`
   ```
   [{"agent_name":"trip-planner","search_score":0.653619854480488},{"agent_name":"document-translator","search_score":0.15166149306363558},{"agent_name":"warehouse-sql-analyst","search_score":0.1008761074424888}]
   ```
3. `curl -s 'http://localhost:$A/v1/agents?query=book+a+trip&top_k=3' -H "Authorization: Bearer $KEY_ALL" | jq -c '[.[] | {agent_name, search_score}]'`
   ```
   [{"agent_name":"trip-planner","search_score":0.6537126920899458},{"agent_name":"document-translator","search_score":0.15167465008416967},{"agent_name":"warehouse-sql-analyst","search_score":0.10085297030343146}]
   ```
4. `curl -s 'http://localhost:$A/spend/logs?api_key=$KEY_ALL_HASH' -H 'Authorization: Bearer $MASTER' | jq -c 'sort_by(.startTime) | .[] | {model, call_type, prompt_tokens, spend}'`
   ```
   {"model":"openai/text-embedding-3-small","call_type":"aembedding","prompt_tokens":82,"spend":0.00000164}
   {"model":"openai/text-embedding-3-small","call_type":"aembedding","prompt_tokens":3,"spend":6.000000000000001E-8}
   ```

#### After (4026aa65): the first all-agents search embeds only its query

1. `curl -s 'http://localhost:$A/v1/agents?query=book+a+trip&top_k=1' -H "Authorization: Bearer $KEY_TRIP" | jq -c '[.[] | {agent_name, search_score}]' & curl -s 'http://localhost:$A/v1/agents?query=book+a+trip&top_k=1' -H "Authorization: Bearer $KEY_OTHERS" | jq -c '[.[] | {agent_name, search_score}]' & wait`
   ```
   [{"agent_name":"document-translator","search_score":0.1516644645463074}]
   [{"agent_name":"trip-planner","search_score":0.6536557773948982}]
   ```
2. `curl -s 'http://localhost:$A/v1/agents?query=book+a+trip&top_k=3' -H "Authorization: Bearer $KEY_ALL" | jq -c '[.[] | {agent_name, search_score}]'`
   ```
   [{"agent_name":"trip-planner","search_score":0.653648258815919},{"agent_name":"document-translator","search_score":0.151685216698004},{"agent_name":"warehouse-sql-analyst","search_score":0.10088637991190563}]
   ```
3. `curl -s 'http://localhost:$A/v1/agents?query=book+a+trip&top_k=3' -H "Authorization: Bearer $KEY_ALL" | jq -c '[.[] | {agent_name, search_score}]'`
   ```
   [{"agent_name":"trip-planner","search_score":0.6537126920899458},{"agent_name":"document-translator","search_score":0.15168268706219803},{"agent_name":"warehouse-sql-analyst","search_score":0.10085822210487842}]
   ```
4. `curl -s 'http://localhost:$A/spend/logs?api_key=$KEY_ALL_HASH' -H 'Authorization: Bearer $MASTER' | jq -c 'sort_by(.startTime) | .[] | {model, call_type, prompt_tokens, spend}'`
   ```
   {"model":"openai/text-embedding-3-small","call_type":"aembedding","prompt_tokens":3,"spend":6.000000000000001E-8}
   {"model":"openai/text-embedding-3-small","call_type":"aembedding","prompt_tokens":3,"spend":6.000000000000001E-8}
   ```

#### Dependent paths the change touches, same tip

Back on the two-deployment `agent-embedder` group from the section above, at 4026aa65: six searches across both vector sizes, agent_search over /mcp-rest, tools/list and tools/call over /mcp/, and a restricted key

1. `curl -s 'http://localhost:$A/v1/agents?top_k=1' --get --data-urlencode 'query=plan a vacation itinerary' -H 'Authorization: Bearer $MASTER' | jq -c 'if type == "array" then [.[] | {agent_name, search_score}] else . end'`
   ```
   [{"agent_name":"trip-planner","search_score":0.42980679079763334}]
   ```
2. `curl -s 'http://localhost:$A/v1/agents?top_k=1' --get --data-urlencode 'query=translate a pdf document' -H 'Authorization: Bearer $MASTER' | jq -c 'if type == "array" then [.[] | {agent_name, search_score}] else . end'`
   ```
   [{"agent_name":"document-translator","search_score":0.6732450375047712}]
   ```
3. `curl -s 'http://localhost:$A/v1/agents?top_k=1' --get --data-urlencode 'query=check how many units are left in stock' -H 'Authorization: Bearer $MASTER' | jq -c 'if type == "array" then [.[] | {agent_name, search_score}] else . end'`
   ```
   [{"agent_name":"warehouse-sql-analyst","search_score":0.3791131959166272}]
   ```
4. `curl -s 'http://localhost:$A/v1/agents?top_k=1' --get --data-urlencode 'query=book flights and hotels' -H 'Authorization: Bearer $MASTER' | jq -c 'if type == "array" then [.[] | {agent_name, search_score}] else . end'`
   ```
   [{"agent_name":"trip-planner","search_score":0.6201761715746669}]
   ```
5. `curl -s 'http://localhost:$A/v1/agents?top_k=1' --get --data-urlencode 'query=convert a word file to spanish' -H 'Authorization: Bearer $MASTER' | jq -c 'if type == "array" then [.[] | {agent_name, search_score}] else . end'`
   ```
   [{"agent_name":"document-translator","search_score":0.5382262072991886}]
   ```
6. `curl -s 'http://localhost:$A/v1/agents?top_k=1' --get --data-urlencode 'query=inventory levels by warehouse' -H 'Authorization: Bearer $MASTER' | jq -c 'if type == "array" then [.[] | {agent_name, search_score}] else . end'`
   ```
   [{"agent_name":"warehouse-sql-analyst","search_score":0.5334299390626673}]
   ```
7. `curl -s http://localhost:$A/mcp-rest/tools/call -H 'Authorization: Bearer $KEY_SEARCH' -H 'Content-Type: application/json' -d '{"name": "agent_search", "arguments": {"query": "check how many units are left in stock", "top_k": 2}}' | jq -c .`
   ```
   {"_meta":null,"content":[{"type":"text","text":"[{\"agent_id\": \"b21b8787-8b9e-4c5f-a45c-3f5e4061d70e\", \"agent_name\": \"warehouse-sql-analyst\", \"description\": \"Answers questions about stock by running SQL queries against the inventory database\", \"skills\": [{\"name\": \"Query stock levels\", \"description\": \"Run a SQL query against the inventory database and summarize the stock levels it returns\", \"tags\": [\"sql\", \"analytics\"]}], \"score\": 0.3791485568539873}, {\"agent_id\": \"fc98c971-659a-42dc-902c-b8b8f59a50ef\", \"agent_name\": \"trip-planner\", \"description\": \"Books flights and hotels for a business trip given dates, origin and destination\", \"skills\": [{\"name\": \"Book travel\", \"description\": \"Find and book the flights and hotel for a business trip\", \"tags\": [\"travel\", \"booking\"]}], \"score\": 0.12168402727229097}]","annotations":null,"_meta":null}],"structuredContent":null,"isError":false}
   ```
8. `curl -s http://localhost:$A/mcp/ -H 'Authorization: Bearer $KEY_SEARCH' -H 'Content-Type: application/json' -H 'Accept: application/json, text/event-stream' -d '{"jsonrpc": "2.0", "id": 1, "method": "tools/list"}' | grep '^data:' | sed 's/^data: //' | jq -c '[.result.tools[].name]'`
   ```
   ["mcp_tool_search","mcp_tool_call","agent_search"]
   ```
9. `curl -s http://localhost:$A/mcp/ -H 'Authorization: Bearer $KEY_SEARCH' -H 'Content-Type: application/json' -H 'Accept: application/json, text/event-stream' -d '{"jsonrpc": "2.0", "id": 2, "method": "tools/call", "params": {"name": "agent_search", "arguments": {"query": "book a flight and hotel", "top_k": 1}}}' | grep '^data:' | sed 's/^data: //' | jq -c '.result.content[0].text | fromjson? // .'`
   ```
   [{"agent_id":"fc98c971-659a-42dc-902c-b8b8f59a50ef","agent_name":"trip-planner","description":"Books flights and hotels for a business trip given dates, origin and destination","skills":[{"name":"Book travel","description":"Find and book the flights and hotel for a business trip","tags":["travel","booking"]}],"score":0.6081681268257517}]
   ```
10. `curl -s 'http://localhost:$A/v1/agents?query=plan+a+vacation+itinerary&top_k=3' -H 'Authorization: Bearer $KEY_RESTRICTED' | jq -c '.[] | {agent_name, search_score}'`
   ```
   {"agent_name":"warehouse-sql-analyst","search_score":0.09470067778779014}
   ```

## Type

🆕 New Feature

## Caveats (if any)

### Low

- Keys with mcp_tool_search_enabled now see three virtual tools, not two; gating agent_search behind its own flag would add a setting nobody asked for
- Vector cache is per process and per embedding model; each worker embeds agents once per model (again after a vector-size change), and that fill is billed to whichever key searched first on that worker
- Over /mcp-rest, which never validates tool arguments, agent_search with no query returns the embedding provider's empty-input error as an isError result; /mcp/ rejects it up front via jsonschema
- Unknown litellm_settings keys are accepted silently, so typos mean 400s at query time

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

- [x] 4026aa6575 passes /live-pr-risk

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Search triggers billable embedding calls and merges a global in-process vector cache, but behavior is scoped to agent discovery, reuses existing key RBAC, and fails explicitly when misconfigured.
> 
> **Overview**
> Adds **semantic ranking** over the A2A agent registry so callers can describe a task in natural language instead of scanning every agent card.
> 
> **REST:** `GET /v1/agents` now accepts optional `query` and `top_k`. When `query` is set, accessible agents are embedded and ranked by cosine similarity; each row gets a **`search_score`**. Missing `litellm_settings.agent_search_embedding_model` returns **400**; embedding failures return **503**. Listing without `query` is unchanged (scores stay null).
> 
> **Config:** New **`agent_search_embedding_model`** selects an embedding model from `model_list`. Embedding spend is attributed to the calling API key via router metadata.
> 
> **Shared core:** New `agent_search` module implements text extraction from agent cards, router-backed embeddings, a per-model vector cache (handles mixed vector dimensions and concurrent searches), and `search_agents()` used by both REST and MCP.
> 
> **MCP:** Virtual tool **`agent_search`** joins `mcp_tool_search` / `mcp_tool_call` behind **`VIRTUAL_TOOL_NAMES`**, still gated on **`mcp_tool_search_enabled`**. REST and protocol MCP paths dispatch to the same handler and return ranked JSON (or tool errors when not configured).
> 
> **RBAC:** Agent listing and search use shared **`accessible_agents()`** so results only include agents the key (and team grants) can reach.
> 
> OpenAPI / dashboard **`schema.d.ts`** are updated for the new query params, `search_score`, and virtual tool schema typing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4026aa6575ab13b86e08e9d149d64e5aeb24e232. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->