### PR TITLE
fix(moonshot, together_ai): send the reasoning effort Kimi K3 accepts

### DIFF
--- a/litellm/llms/moonshot/chat/transformation.py
+++ b/litellm/llms/moonshot/chat/transformation.py
@@ -2,7 +2,7 @@
 Translates from OpenAI's `/v1/chat/completions` to Moonshot AI's `/v1/chat/completions`
 """
 
-from collections.abc import Coroutine
+from collections.abc import Coroutine, Mapping
 from typing import Any, Final, Literal, cast, overload
 
 import litellm
@@ -14,6 +14,15 @@ from litellm.types.llms.openai import AllMessageValues
 from litellm.utils import supports_reasoning
 
 from ...openai.chat.gpt_transformation import OpenAIGPTConfig
+
+
+def _reasoning_effort_string(value: object) -> str | None:
+    """The /v1/messages and /v1/responses bridges wrap the level as {"effort", "summary"} for
+    providers with a reasoning-summary surface. Moonshot's API takes only the bare string and 400s
+    on an object, so the level is unwrapped and the summary, which has no Moonshot equivalent, is
+    dropped."""
+    effort: Final = value.get("effort") if isinstance(value, Mapping) else value
+    return effort if isinstance(effort, str) else None
 
 
 class MoonshotChatConfig(OpenAIGPTConfig):
@@ -124,7 +133,12 @@ class MoonshotChatConfig(OpenAIGPTConfig):
         for param, value in non_default_params.items():
             if param == "max_completion_tokens":
                 optional_params["max_tokens"] = value
-            elif param in supported_openai_params:
+            elif param not in supported_openai_params:
+                continue
+            elif param == "reasoning_effort":
+                if (effort := _reasoning_effort_string(value)) is not None:
+                    optional_params["reasoning_effort"] = effort
+            else:
                 optional_params[param] = value
 
         ##########################################

--- a/litellm/llms/moonshot/chat/transformation.py
+++ b/litellm/llms/moonshot/chat/transformation.py
@@ -93,20 +93,18 @@ class MoonshotChatConfig(OpenAIGPTConfig):
         - functions parameter is not supported (use tools instead)
         - tool_choice doesn't support "required" value
         - kimi-thinking-preview doesn't support tool calls at all
+
+        A reasoning model additionally takes `reasoning_effort`, which the OpenAI base list this
+        subtracts from does not carry, so it has to be added back rather than merely kept.
         """
-        excluded_params: Final[list[str]] = ["functions"]
-
-        # kimi-thinking-preview has additional limitations
-        if "kimi-thinking-preview" in model:
-            excluded_params.extend(["tools", "tool_choice"])
-
+        excluded_params: Final = frozenset(
+            ("functions", "tools", "tool_choice") if "kimi-thinking-preview" in model else ("functions",)
+        )
         base_openai_params: Final = super().get_supported_openai_params(model=model)
-        final_params: Final[list[str]] = []
-        for param in base_openai_params:
-            if param not in excluded_params:
-                final_params.append(param)
-
-        return final_params
+        supported: Final = [param for param in base_openai_params if param not in excluded_params]
+        if supports_reasoning(model=model, custom_llm_provider="moonshot"):
+            return [*supported, "reasoning_effort"]
+        return supported
 
     def map_openai_params(
         self,

--- a/litellm/llms/together_ai/chat/transformation.py
+++ b/litellm/llms/together_ai/chat/transformation.py
@@ -18,6 +18,7 @@ from typing_extensions import ReadOnly, TypedDict
 import litellm
 from litellm._logging import verbose_logger
 from litellm.exceptions import UnsupportedParamsError
+from litellm.router_utils.reasoning_effort_capability import declared_reasoning_efforts_for_model
 from litellm.types.llms.openai import AllMessageValues
 from litellm.utils import supports_function_calling, supports_reasoning, supports_response_schema
 
@@ -139,6 +140,8 @@ def _reasoning_effort_payload(effort: str, model: str) -> Mapping[str, object]:
     if effort == "none":
         disable_reasoning: Final[TogetherReasoningToggle] = {"enabled": False}
         return MappingProxyType({"reasoning": disable_reasoning})
+    if effort in (declared_reasoning_efforts_for_model(model, "together_ai") or ()):
+        return MappingProxyType({"reasoning_effort": effort})
     if model.startswith(HIGH_MAX_EFFORT_MODEL_PREFIX):
         return MappingProxyType({"reasoning_effort": HIGH_MAX_EFFORT_TRANSLATION.get(effort, effort)})
     return MappingProxyType({"reasoning_effort": EFFORT_TRANSLATION.get(effort, effort)})

--- a/litellm/router_utils/reasoning_effort_capability.py
+++ b/litellm/router_utils/reasoning_effort_capability.py
@@ -87,6 +87,22 @@ def declared_reasoning_efforts(model_info: Mapping[str, object]) -> tuple[str, .
     return tuple(effort for effort in REASONING_EFFORT_ADVERTISEMENT_ORDER if effort in declared)
 
 
+def declared_reasoning_efforts_for_model(model: str, custom_llm_provider: str) -> tuple[str, ...] | None:
+    """The levels an entry declares, resolved from the model string a provider config holds rather
+    than from a router deployment's model_info.
+
+    None means the map has no opinion, either because the entry declares nothing or because it
+    describes no such model, so a caller keeps whatever it did before the entry was described. The
+    entry is read straight off the map rather than through get_model_info, which raises for a model
+    it does not know: a provider config runs on the request path for every model it serves, most of
+    which the map never named, and a lookup miss there must not fail the call.
+    """
+    entry: Final = litellm.model_cost.get(f"{custom_llm_provider}/{model}") or litellm.model_cost.get(model)
+    if not isinstance(entry, dict):
+        return None
+    return declared_reasoning_efforts(entry)
+
+
 def _supports_none_reasoning_effort(model_info: Mapping[str, object], flag: object) -> bool:
     """Opt-in only where a request path refuses the level. AzureOpenAIGPT5Config raises
     UnsupportedParamsError on reasoning_effort='none' without an explicit true, and it is selected

--- a/tests/test_litellm/llms/moonshot/test_moonshot_chat_transformation.py
+++ b/tests/test_litellm/llms/moonshot/test_moonshot_chat_transformation.py
@@ -807,3 +807,24 @@ class TestMoonshotReasoningEffort:
                 reasoning_effort="high",
                 drop_params=False,
             )
+
+    def test_bridge_effort_dict_is_unwrapped_to_the_level_string(self):
+        optional_params = MoonshotChatConfig().map_openai_params(
+            non_default_params={"reasoning_effort": {"effort": "high", "summary": "detailed"}},
+            optional_params={},
+            model="kimi-k3",
+            drop_params=False,
+        )
+
+        assert optional_params["reasoning_effort"] == "high"
+
+    @pytest.mark.parametrize("value", [{"summary": "detailed"}, {"effort": 3}, 7])
+    def test_effort_without_a_level_string_is_omitted(self, value):
+        optional_params = MoonshotChatConfig().map_openai_params(
+            non_default_params={"reasoning_effort": value},
+            optional_params={},
+            model="kimi-k3",
+            drop_params=False,
+        )
+
+        assert "reasoning_effort" not in optional_params

--- a/tests/test_litellm/llms/moonshot/test_moonshot_chat_transformation.py
+++ b/tests/test_litellm/llms/moonshot/test_moonshot_chat_transformation.py
@@ -769,3 +769,41 @@ class TestMoonshotResponseSchemaSupport:
     def test_supports_response_schema_utility_reports_true(self, model_cost_map, monkeypatch):
         monkeypatch.setattr(litellm, "model_cost", model_cost_map)
         assert litellm.utils.supports_response_schema(model="moonshot/kimi-k2.5") is True
+
+
+class TestMoonshotReasoningEffort:
+    """Moonshot documents reasoning_effort as a top-level chat completions field for its reasoning
+    models, defaulting to max, but the OpenAI base list this config subtracts from never carried it,
+    so an explicit level raised UnsupportedParamsError before it reached the wire."""
+
+    @pytest.fixture(autouse=True)
+    def force_local_model_cost(self, monkeypatch):
+        monkeypatch.setattr(litellm, "model_cost", GetModelCostMap.load_local_model_cost_map())
+
+    @pytest.mark.parametrize("model", ["kimi-k3", "kimi-k2.5", "kimi-k2.6", "kimi-k2-thinking"])
+    def test_reasoning_model_supports_reasoning_effort(self, model):
+        assert "reasoning_effort" in MoonshotChatConfig().get_supported_openai_params(model)
+
+    @pytest.mark.parametrize("model", ["moonshot-v1-8k", "kimi-latest", "kimi-k2-turbo-preview"])
+    def test_non_reasoning_model_does_not_support_reasoning_effort(self, model):
+        assert "reasoning_effort" not in MoonshotChatConfig().get_supported_openai_params(model)
+
+    @pytest.mark.parametrize("effort", ["low", "high", "max"])
+    def test_declared_effort_reaches_optional_params(self, effort):
+        optional_params = litellm.get_optional_params(
+            model="kimi-k3",
+            custom_llm_provider="moonshot",
+            reasoning_effort=effort,
+            drop_params=False,
+        )
+
+        assert optional_params["reasoning_effort"] == effort
+
+    def test_non_reasoning_model_still_rejects_reasoning_effort(self):
+        with pytest.raises(litellm.UnsupportedParamsError):
+            litellm.get_optional_params(
+                model="moonshot-v1-8k",
+                custom_llm_provider="moonshot",
+                reasoning_effort="high",
+                drop_params=False,
+            )

--- a/tests/test_litellm/llms/together_ai/chat/test_together_ai_chat_transformation.py
+++ b/tests/test_litellm/llms/together_ai/chat/test_together_ai_chat_transformation.py
@@ -1069,3 +1069,42 @@ def test_anthropic_messages_streams_together_tool_call_as_input_json_delta():
     )
     assert thinking_text == "Need weather and time."
     assert [event["delta"]["stop_reason"] for event in events if event["type"] == "message_delta"] == ["tool_use"]
+
+
+DECLARED_LEVELS_MODEL = "moonshotai/Kimi-K3"
+
+
+@pytest.mark.parametrize("effort", ["low", "high", "max"])
+def test_declared_level_is_sent_unchanged(effort):
+    """Kimi K3 declares low, high and max in the model map and Together accepts all three, but the
+    per-model clamp below only spares deepseek-ai/DeepSeek-V4-Pro, so max used to arrive as high and
+    the caller silently lost half the reasoning budget they asked for."""
+    mapped = _map_reasoning_effort(DECLARED_LEVELS_MODEL, effort)
+
+    assert mapped["reasoning_effort"] == effort
+
+
+@pytest.mark.parametrize("effort, expected", [("minimal", "low"), ("medium", "medium"), ("xhigh", "high")])
+def test_undeclared_level_still_uses_the_clamp(effort, expected):
+    """The declared set is not a licence to widen: a level the entry does not name keeps whatever
+    the hardcoded table did for it."""
+    mapped = _map_reasoning_effort(DECLARED_LEVELS_MODEL, effort)
+
+    assert mapped["reasoning_effort"] == expected
+
+
+def test_declared_levels_model_still_disables_reasoning_on_none():
+    mapped = _map_reasoning_effort(DECLARED_LEVELS_MODEL, "none")
+
+    assert mapped["reasoning"] == {"enabled": False}
+    assert "reasoning_effort" not in mapped
+
+
+def test_get_optional_params_preserves_max_for_declared_levels_model():
+    optional_params = litellm.get_optional_params(
+        model=DECLARED_LEVELS_MODEL,
+        custom_llm_provider="together_ai",
+        reasoning_effort="max",
+    )
+
+    assert optional_params["reasoning_effort"] == "max"


### PR DESCRIPTION
## TLDR

Problem this solves:

- Moonshot 400s on any explicit reasoning_effort
- Together silently folds Kimi K3 max down to high
- Both providers document and accept low, high, max

How it solves it:

- Moonshot offers reasoning_effort when the registry says the model reasons
- Together sends a level the map entry declares, unchanged
- Undeclared levels keep the existing per-model clamp
- A bridge-derived {effort, summary} object is unwrapped to its level string

## User Flow

Before: a developer routing Kimi K3 through the gateway cannot ask for max thinking, on either provider

1. They send POST https://litellm-domain/v1/chat/completions with `"model": "kimi-k3-moonshot"` and `"reasoning_effort": "max"`
2. It comes back 400 with `moonshot does not support parameters: ['reasoning_effort']`, and the request never left the gateway
3. They drop the parameter to get a 200, and every call now runs at whatever effort the provider defaults to
4. They try the same thing against Together with `"model": "kimi-k3-together"` and get a 200, so it looks fine
5. Together bills and answers at high, because the gateway rewrote max on the way out, and nothing in the response says so
6. Their Anthropic-format client sends POST https://litellm-domain/v1/messages with a `thinking` block and gets the same 400

After: both providers take the level the caller asked for

1. They send the same POST with `"model": "kimi-k3-moonshot"` and `"reasoning_effort": "max"`
2. It comes back 200 with a completion
3. They send the same POST with `"model": "kimi-k3-together"` and `"reasoning_effort": "max"`
4. It comes back 200, and Together receives `"reasoning_effort": "max"` rather than high
5. Asking for low or high on either provider does what it says, and both are reachable for the first time on Moonshot
6. The same POST https://litellm-domain/v1/messages with a `thinking` block comes back 200 with a thinking content block

## Relevant issues

- Moonshot never listed `reasoning_effort` among its supported params, so an explicit level raised before the request left the proxy
- Together clamps `max` to `high` for every model except one prefix, which caught Kimi K3 after the map declared it takes max
- Only Kimi K3 on Together changes value; every other Together model keeps its current clamp exactly
- The /v1/messages and /v1/responses bridges already derived `reasoning_effort` for non-Claude targets, so the same 400 blocked both surfaces; when a thinking summary is in play the derived value is an object like `{"effort": "high", "summary": "detailed"}`, which Moonshot rejects with "expected type string" even once the param is allowed, so the config unwraps it to the level string

## Linear ticket

Resolves LIT-6330

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

Shared setup, a proxy with both providers registered on their real APIs, launched with `LITELLM_LOCAL_MODEL_COST_MAP=true` so the bundled map's `reasoning_effort_levels` entry is loaded (see Caveats):

```yaml
model_list:
  - model_name: kimi-k3-moonshot
    litellm_params:
      model: moonshot/kimi-k3
      api_key: os.environ/MOONSHOT_API_KEY
  - model_name: kimi-k3-together
    litellm_params:
      model: together_ai/moonshotai/Kimi-K3
      api_key: os.environ/TOGETHERAI_API_KEY
```

Outgoing bodies are captured by pointing one extra deployment per provider at a local listener, since a downgrade is invisible from the client side.

### Before (74050e03c5)

#### /v1/chat/completions, Moonshot rejects the parameter

1. `curl -s -X POST http://127.0.0.1:16422/v1/chat/completions -H "Authorization: Bearer sk-1234" -d '{"model":"kimi-k3-moonshot","messages":[{"role":"user","content":"Reply ok."}],"reasoning_effort":"max","max_tokens":2048}'`
2. `status=400`, body `litellm.UnsupportedParamsError: moonshot does not support parameters: ['reasoning_effort'], for model=kimi-k3`

#### /v1/chat/completions, Together downgrades max on the wire

1. Same request against the wire-capture deployment for each of low, high, max, minimal, xhigh
2. What Together received:

   | asked | sent |
   |---|---|
   | low | low |
   | high | high |
   | max | **high** |
   | minimal | low |
   | xhigh | high |

#### /v1/messages, thinking never reaches Moonshot

1. `curl -s -X POST http://127.0.0.1:16422/v1/messages -H "Authorization: Bearer sk-1234" -d '{"model":"kimi-k3-moonshot","max_tokens":4096,"messages":[{"role":"user","content":"Reply ok."}],"thinking":{"type":"enabled","budget_tokens":4096}}'`
2. `status=400`, same `UnsupportedParamsError` for `['reasoning_effort']`

#### /v1/responses, reasoning effort never reaches Moonshot

1. `curl -s -X POST http://127.0.0.1:16422/v1/responses -H "Authorization: Bearer sk-1234" -d '{"model":"kimi-k3-moonshot","input":"Reply ok.","reasoning":{"effort":"max"}}'`
2. `status=400`, same `UnsupportedParamsError` for `['reasoning_effort']`

### After (7fd136d496)

#### /v1/chat/completions, Moonshot rejects the parameter

1. `curl -s -X POST http://127.0.0.1:16431/v1/chat/completions -H "Authorization: Bearer sk-1234" -d '{"model":"kimi-k3-moonshot","messages":[{"role":"user","content":"Reply ok."}],"reasoning_effort":"max","max_tokens":2048}'`
2. `status=200`, `model=kimi-k3-moonshot completion_tokens=46`

#### /v1/chat/completions, Together downgrades max on the wire

1. Same five requests against the wire-capture deployment
2. What Together received:

   | asked | before | after |
   |---|---|---|
   | low | low | low |
   | high | high | high |
   | max | high | **max** |
   | minimal | low | low |
   | xhigh | high | high |

3. A real call to `kimi-k3-together` at max returns `status=200`

#### /v1/messages, thinking never reaches Moonshot

1. Same request as before, `status=200`, and the wire shows `reasoning_effort: "high"` derived from the 4096 budget
2. With `"thinking":{"type":"enabled","budget_tokens":8192,"summary":"detailed"}` the wire still shows the plain string `"high"` rather than the `{"effort","summary"}` object, and the real call returns `status=200` with content types `['thinking', 'text']`; before the unwrap commit Moonshot answered that object with `400 the reasoning_effort field (expected type string) is illegal`

#### /v1/responses, reasoning effort never reaches Moonshot

1. Same request as before, `status=200`, wire shows `reasoning_effort: "max"`

#### Why max is worth having

Measured directly against both provider APIs on one prompt, so the downgrade is not cosmetic:

| provider | high | max |
|---|---|---|
| Moonshot kimi-k3 | 400 reasoning tokens | 872 |
| Together Kimi-K3 | 453 reasoning tokens | 889 |

## Type

🐛 Bug Fix

## Caveats (if any)

### Medium

- azure_ai also rejects the param, left out because Foundry is unverified
- LIT-6330 covers azure_ai too, so it stays open
- Together passthrough reads `reasoning_effort_levels` off the loaded map
  - the public remote map carries the key on no entry yet
  - a default proxy therefore keeps the max to high clamp until it ships
  - `LITELLM_LOCAL_MODEL_COST_MAP=true` or a `model_info` declaration activates it today

### Low

- Bedrock Moonshot skips this config's param list, so it is unaffected
- 5 of 23 Moonshot entries gain the param, all kimi reasoning models
- Together tests copy the clamp tables' literals rather than importing them
- A bridge thinking summary has no Moonshot equivalent and is dropped

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes request-parameter mapping on the hot path for Moonshot and Together chat completions; scope is narrow and well-tested, but wrong mapping could still change provider billing or reasoning behavior for Kimi reasoning models.
> 
> **Overview**
> Fixes **Moonshot** rejecting `reasoning_effort` and **Together** silently rewriting `max` to `high` for Kimi K3-style models that declare `low`, `high`, and `max` in the model map.
> 
> **Moonshot** now advertises `reasoning_effort` for models where `supports_reasoning` is true, maps it in `map_openai_params`, and unwraps bridge-style `{"effort", "summary"}` values to the bare string Moonshot expects (invalid or missing effort strings are omitted).
> 
> **Together** checks `declared_reasoning_efforts_for_model` before the hardcoded effort translation tables, so declared levels like `max` are sent unchanged; undeclared levels and `none` still follow the existing clamps and disable-reasoning behavior.
> 
> Adds **`declared_reasoning_efforts_for_model`** in `reasoning_effort_capability.py` to read `reasoning_effort_levels` from `model_cost` without raising on unknown models. Unit tests cover Moonshot optional-params and unwrap behavior and Together declared vs undeclared effort mapping.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7fd136d4961c7ee7267df5784c98ec500458af9d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->