### PR TITLE
fix(chatgpt): preserve parallel_tool_calls and enforce Codex Responses-Lite contract

### DIFF
--- a/litellm/llms/chatgpt/responses/transformation.py
+++ b/litellm/llms/chatgpt/responses/transformation.py
@@ -1,3 +1,4 @@
+from collections.abc import Mapping
 from typing import Any, Final
 
 from litellm.exceptions import AuthenticationError
@@ -27,6 +28,25 @@ from ..common_utils import (
     get_chatgpt_default_headers,
     get_chatgpt_default_instructions,
 )
+
+# Codex >= 0.144 sends this header for models served over the "Responses
+# Lite" transport (gpt-5.6-* at the time of writing). When the header is
+# present the backend rejects the request unless `parallel_tool_calls` is
+# exactly false and `reasoning.context` is "all_turns":
+#   "X-OpenAI-Internal-Codex-Responses-Lite requires `parallel_tool_calls`
+#    to be false." (param=parallel_tool_calls, code=unsupported_value)
+CODEX_RESPONSES_LITE_HEADER: Final[str] = "x-openai-internal-codex-responses-lite"
+_FALSY_HEADER_VALUES: Final[frozenset[str]] = frozenset({"", "0", "false", "no"})
+
+
+def is_codex_responses_lite_request(headers: Mapping[str, object] | None) -> bool:
+    """True when the outbound headers carry the Codex Responses-Lite marker."""
+    if not headers:
+        return False
+    for key, value in headers.items():
+        if key.lower() == CODEX_RESPONSES_LITE_HEADER:
+            return str(value).strip().lower() not in _FALSY_HEADER_VALUES
+    return False
 
 
 class ChatGPTResponsesAPIConfig(OpenAIResponsesAPIConfig):
@@ -96,12 +116,32 @@ class ChatGPTResponsesAPIConfig(OpenAIResponsesAPIConfig):
             "include",
             "tools",
             "tool_choice",
+            "parallel_tool_calls",
             "reasoning",
             "previous_response_id",
             "truncation",
         }
 
-        return {k: v for k, v in request.items() if k in allowed_keys}
+        filtered: Final[dict[str, object]] = {  # mutable-ok: outgoing JSON request body
+            k: v for k, v in request.items() if k in allowed_keys
+        }
+
+        if is_codex_responses_lite_request(headers):
+            # The Responses-Lite backend hard-rejects any other combination,
+            # so normalize even when the caller omitted these fields (codex
+            # 0.144.x can omit the reasoning object on a metadata race).
+            filtered["parallel_tool_calls"] = False
+            raw_reasoning: Final = filtered.get("reasoning")
+            reasoning_items: Final = raw_reasoning.items() if isinstance(raw_reasoning, dict) else ()
+            reasoning: dict[str, object] = {  # mutable-ok: rebuilt to force the required context key
+                reasoning_key: reasoning_value
+                for reasoning_key, reasoning_value in reasoning_items
+                if isinstance(reasoning_key, str)
+            }
+            reasoning["context"] = "all_turns"
+            filtered["reasoning"] = reasoning
+
+        return filtered
 
     def transform_response_api_response(
         self,

--- a/tests/test_litellm/llms/chatgpt/responses/test_chatgpt_responses_transformation.py
+++ b/tests/test_litellm/llms/chatgpt/responses/test_chatgpt_responses_transformation.py
@@ -155,6 +155,91 @@ class TestChatGPTResponsesAPITransformation:
             "function": {"name": "hello"},
         }
 
+    @pytest.mark.parametrize("parallel_tool_calls", [True, False])
+    def test_chatgpt_preserves_parallel_tool_calls(self, parallel_tool_calls):
+        """parallel_tool_calls is validated by the Codex backend and must not
+        be dropped by the allowed-keys filter."""
+        config = ChatGPTResponsesAPIConfig()
+        request = config.transform_responses_api_request(
+            model="chatgpt/gpt-5.3-codex",
+            input="hi",
+            response_api_optional_request_params={
+                "parallel_tool_calls": parallel_tool_calls,
+            },
+            litellm_params=GenericLiteLLMParams(),
+            headers={},
+        )
+
+        assert request["parallel_tool_calls"] is parallel_tool_calls
+
+    def test_chatgpt_responses_lite_restores_stripped_false(self):
+        """Regression: a Responses-Lite request (codex >= 0.144, gpt-5.6-*)
+        carries parallel_tool_calls=false; dropping it made the backend
+        reject every request with
+        "X-OpenAI-Internal-Codex-Responses-Lite requires `parallel_tool_calls`
+        to be false."."""
+        config = ChatGPTResponsesAPIConfig()
+        request = config.transform_responses_api_request(
+            model="chatgpt/gpt-5.6-sol",
+            input="hi",
+            response_api_optional_request_params={
+                "parallel_tool_calls": False,
+                "reasoning": {"context": "all_turns"},
+            },
+            litellm_params=GenericLiteLLMParams(),
+            headers={"X-OpenAI-Internal-Codex-Responses-Lite": "true"},
+        )
+
+        assert request["parallel_tool_calls"] is False
+        assert request["reasoning"]["context"] == "all_turns"
+
+    def test_chatgpt_responses_lite_forces_lite_contract(self):
+        """Under the Lite header the backend hard-rejects any other value,
+        so true is normalized to false and reasoning.context is pinned."""
+        config = ChatGPTResponsesAPIConfig()
+        request = config.transform_responses_api_request(
+            model="chatgpt/gpt-5.6-sol",
+            input="hi",
+            response_api_optional_request_params={
+                "parallel_tool_calls": True,
+                "reasoning": {"effort": "high"},
+            },
+            litellm_params=GenericLiteLLMParams(),
+            headers={"x-openai-internal-codex-responses-lite": "true"},
+        )
+
+        assert request["parallel_tool_calls"] is False
+        assert request["reasoning"] == {"effort": "high", "context": "all_turns"}
+
+    def test_chatgpt_responses_lite_normalizes_omitted_fields(self):
+        """codex 0.144.x can omit the reasoning object entirely; the Lite
+        validator rejects the omission the same way."""
+        config = ChatGPTResponsesAPIConfig()
+        request = config.transform_responses_api_request(
+            model="chatgpt/gpt-5.6-sol",
+            input="hi",
+            response_api_optional_request_params={},
+            litellm_params=GenericLiteLLMParams(),
+            headers={"x-openai-internal-codex-responses-lite": "true"},
+        )
+
+        assert request["parallel_tool_calls"] is False
+        assert request["reasoning"] == {"context": "all_turns"}
+
+    @pytest.mark.parametrize("header_value", ["false", "0", "no", ""])
+    def test_chatgpt_responses_lite_falsy_header_is_ignored(self, header_value):
+        config = ChatGPTResponsesAPIConfig()
+        request = config.transform_responses_api_request(
+            model="chatgpt/gpt-5.6-sol",
+            input="hi",
+            response_api_optional_request_params={},
+            litellm_params=GenericLiteLLMParams(),
+            headers={"x-openai-internal-codex-responses-lite": header_value},
+        )
+
+        assert "parallel_tool_calls" not in request
+        assert "reasoning" not in request
+
     @pytest.mark.parametrize(
         ("model_name", "response_model"),
         [

--- a/tests/test_litellm/llms/chatgpt/responses/test_chatgpt_responses_transformation.py
+++ b/tests/test_litellm/llms/chatgpt/responses/test_chatgpt_responses_transformation.py
@@ -226,6 +226,21 @@ class TestChatGPTResponsesAPITransformation:
         assert request["parallel_tool_calls"] is False
         assert request["reasoning"] == {"context": "all_turns"}
 
+    def test_chatgpt_unrelated_headers_do_not_trigger_lite_normalization(self):
+        """Ordinary outbound headers (auth etc.) without the Lite marker must
+        leave the request untouched."""
+        config = ChatGPTResponsesAPIConfig()
+        request = config.transform_responses_api_request(
+            model="chatgpt/gpt-5.6-sol",
+            input="hi",
+            response_api_optional_request_params={},
+            litellm_params=GenericLiteLLMParams(),
+            headers={"Authorization": "Bearer token", "originator": "codex_cli_rs"},
+        )
+
+        assert "parallel_tool_calls" not in request
+        assert "reasoning" not in request
+
     @pytest.mark.parametrize("header_value", ["false", "0", "no", ""])
     def test_chatgpt_responses_lite_falsy_header_is_ignored(self, header_value):
         config = ChatGPTResponsesAPIConfig()


### PR DESCRIPTION
## TLDR

Problem this solves:

- Codex CLI >= 0.144 on `gpt-5.6-*` always 400s through the proxy
- The chatgpt provider's allowed-keys filter strips `parallel_tool_calls`
- The forwarded Responses-Lite header then makes the backend reject every turn

How it solves it:

- Adds `parallel_tool_calls` to the chatgpt transformation's allowed keys
- When the Lite header is outbound, forces `parallel_tool_calls: false` and `reasoning.context: "all_turns"`
- 8 regression tests, including the exact stripped-`false` failure

## User Flow

Before: a developer points Codex CLI at their LiteLLM proxy and every `gpt-5.6-sol` turn dies

1. They run `codex exec -m gpt-5.6-sol "fix this test"` with the CLI's base URL set to `https://litellm-domain/v1`
2. Every turn comes back 400: ``X-OpenAI-Internal-Codex-Responses-Lite requires `parallel_tool_calls` to be false.``
3. They have to pin an older model (`-m gpt-5.5`) to get any work done

After: the same command streams normally on the current default Codex model

1. They run `codex exec -m gpt-5.6-sol "fix this test"` with the CLI's base URL set to `https://litellm-domain/v1`
2. The turn streams, shell/tool calls execute, and the task completes
3. No model pin or client-side workaround is needed

## Relevant issues

Fixes #38612

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/llms/chatgpt/responses/test_chatgpt_responses_transformation.py -v` (28 passed)
- [x] My PR passes all required CI/CD checks (`make lint` green locally, including the basedpyright / type-discipline / ruff-strict budget gates)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Captured end-to-end on a production LiteLLM proxy (`ghcr.io/berriai/litellm:main-stable`, v1.98.0) fronting a real ChatGPT Codex subscription. "After" runs the same image with this PR's transformation change applied; requests spend real subscription quota.

Shared setup: `$KEY` is a proxy virtual key; the `chatgpt/gpt-5.6-sol` route is configured; the proxy forwards client headers.

### Before (6e569ee0c)

#### Responses-Lite request with explicit parallel_tool_calls=false

1. `curl -sS -X POST http://<proxy>/v1/responses -H "Authorization: Bearer $KEY" -H "x-openai-internal-codex-responses-lite: true" -d '{"model":"gpt-5.6-sol","input":[{"role":"user","content":"Say ok"}],"parallel_tool_calls":false,"reasoning":{"context":"all_turns"},"tools":[{"type":"function","name":"noop","parameters":{"type":"object","properties":{}}}]}'`
2. Observed: `400` — `{"error":{"message":"X-OpenAI-Internal-Codex-Responses-Lite requires \`parallel_tool_calls\` to be false.","param":"parallel_tool_calls","code":"unsupported_value"}}`

#### Codex CLI 0.149.1 tool round trip

1. `codex exec -m gpt-5.6-sol "Run the shell command: echo ok"` with the CLI provider's `base_url` pointed at the proxy (`wire_api = "responses"`)
2. Observed: every turn fails with the same 400; no work possible on gpt-5.6-sol

### After (d8f0d36aa)

#### Responses-Lite request with explicit parallel_tool_calls=false

1. Same curl as Before
2. Observed: `200`, normal SSE stream — `data: {"type":"response.created","response":{"id":"resp_Soe30kkY3Y-..."}}` followed by a full completion

#### Codex CLI 0.149.1 tool round trip

1. Same `codex exec` as Before
2. Observed: turn streams, the shell tool call executes (`echo ok` → `ok`), codex reports the output and completes (~21k tokens used)

## Type

🐛 Bug Fix

## Caveats (if any)

### Low

- `extra_body` merges after this transform and can still override the forced Lite fields — same pre-existing exposure as the provider's forced `store`/`stream`; Codex clients never send `extra_body`
- A pydantic `Reasoning` object (SDK-side) is rebuilt from dict form only; proxy JSON always arrives as a dict
