### PR TITLE
fix(cost): sum built-in tool costs instead of billing only the first match

### DIFF
--- a/litellm/litellm_core_utils/llm_cost_calc/tool_call_cost_tracking.py
+++ b/litellm/litellm_core_utils/llm_cost_calc/tool_call_cost_tracking.py
@@ -63,12 +63,12 @@ class StandardBuiltInToolCostTracking:
         - Code Interpreter (Azure)
         """
         standard_built_in_tools_params = standard_built_in_tools_params or {}
+        total_cost = 0.0
 
-        # Handle web search
         if StandardBuiltInToolCostTracking.response_object_includes_web_search_call(
             response_object=response_object, usage=usage
         ):
-            return StandardBuiltInToolCostTracking._handle_web_search_cost(
+            total_cost += StandardBuiltInToolCostTracking._handle_web_search_cost(
                 model=model,
                 custom_llm_provider=custom_llm_provider,
                 usage=usage,
@@ -76,20 +76,20 @@ class StandardBuiltInToolCostTracking:
                 response_object=response_object,
             )
 
-        # Handle file search
         if StandardBuiltInToolCostTracking.response_object_includes_file_search_call(response_object=response_object):
-            return StandardBuiltInToolCostTracking._handle_file_search_cost(
+            total_cost += StandardBuiltInToolCostTracking._handle_file_search_cost(
                 model=model,
                 custom_llm_provider=custom_llm_provider,
                 standard_built_in_tools_params=standard_built_in_tools_params,
             )
 
-        # Handle Azure assistant features
-        return StandardBuiltInToolCostTracking._handle_azure_assistant_costs(
+        total_cost += StandardBuiltInToolCostTracking._handle_azure_assistant_costs(
             model=model,
             custom_llm_provider=custom_llm_provider,
             standard_built_in_tools_params=standard_built_in_tools_params,
         )
+
+        return total_cost
 
     @staticmethod
     def _handle_web_search_cost(

--- a/tests/test_litellm/litellm_core_utils/llm_cost_calc/test_tool_call_cost_tracking.py
+++ b/tests/test_litellm/litellm_core_utils/llm_cost_calc/test_tool_call_cost_tracking.py
@@ -806,6 +806,56 @@ def test_response_includes_output_type_reads_dict_output_items():
     )
 
 
+def test_get_cost_for_built_in_tools_sums_web_search_and_file_search(local_model_cost_map):
+    """
+    Regression: get_cost_for_built_in_tools used sequential `if ... return` checks, so a
+    single response using both web search and file search (a normal multi-tool Responses API
+    turn) only billed the web search cost and silently dropped the file search cost. The two
+    costs must be summed instead of the first match winning.
+    """
+    from litellm.constants import OPENAI_FILE_SEARCH_COST_PER_1K_CALLS
+    from litellm.types.llms.openai import ResponsesAPIResponse
+    from litellm.types.utils import Usage
+
+    model = "gpt-4o-search-preview"
+    web_search_options = WebSearchOptions(search_context_size="medium")
+    per_call_web_search_cost = litellm.get_model_info(model)["search_context_cost_per_query"][
+        "search_context_size_medium"
+    ]
+    standard_built_in_tools_params = StandardBuiltInToolsParams(
+        web_search_options=web_search_options,
+        file_search=FileSearchTool(type="file_search"),
+    )
+
+    response = ResponsesAPIResponse.model_validate(
+        {
+            "id": "resp_1",
+            "created_at": 1754900000,
+            "model": model,
+            "object": "response",
+            "status": "completed",
+            "output": [
+                {"type": "web_search_call", "id": "ws_1", "status": "completed"},
+                {"type": "file_search_call", "id": "fs_1", "status": "completed"},
+            ],
+        }
+    )
+
+    cost = StandardBuiltInToolCostTracking.get_cost_for_built_in_tools(
+        model=model,
+        response_object=response,
+        usage=Usage(prompt_tokens=10, completion_tokens=5, total_tokens=15),
+        custom_llm_provider="openai",
+        standard_built_in_tools_params=standard_built_in_tools_params,
+    )
+
+    expected_cost = per_call_web_search_cost + OPENAI_FILE_SEARCH_COST_PER_1K_CALLS
+    assert cost == pytest.approx(expected_cost), (
+        f"web search (${per_call_web_search_cost}) and file search (${OPENAI_FILE_SEARCH_COST_PER_1K_CALLS}) "
+        f"must both be billed, got ${cost}"
+    )
+
+
 def test_web_search_gate_reads_server_side_tool_usage_details_without_citations():
     """
     Regression: xAI chat responses bridged from the Responses API only carry


### PR DESCRIPTION
## Title

fix(cost): sum built-in tool costs instead of billing only the first match

## Relevant issues

## Type

🐛 Bug Fix

## Changes

`StandardBuiltInToolCostTracking.get_cost_for_built_in_tools` walked web search, file search, and Azure assistant features with sequential if-return checks, so a single response that used more than one built-in tool only billed the first category detected and silently dropped the rest. A response that ran both a web search and a file search, for example, was charged for the web search alone.

This sums the cost of every applicable category instead of returning on the first match. Categories that do not apply contribute zero, so single-tool responses bill identically to before. Added regression coverage in `test_tool_call_cost_tracking.py` that exercises a response using multiple built-in tools and asserts the total is the sum of each tool's cost, which fails on the pre-fix early-return code and passes after.
