### PR TITLE
fix(proxy): admit litellm_proxy/hosted_vllm in provider-endpoint discovery

### DIFF
--- a/litellm/proxy/auth/model_checks.py
+++ b/litellm/proxy/auth/model_checks.py
@@ -13,7 +13,7 @@ from litellm.router import Router
 from litellm.router_utils.fallback_event_handlers import get_fallback_model_group
 from litellm.types.router import CredentialLiteLLMParams, LiteLLM_Params
 from litellm.types.utils import LlmProviders
-from litellm.utils import get_valid_models
+from litellm.utils import ProviderConfigManager, get_valid_models
 
 _CREDENTIAL_LITELLM_PARAM_FIELDS = set(CredentialLiteLLMParams.model_fields)
 
@@ -45,7 +45,18 @@ def get_provider_models(provider: str, litellm_params: LiteLLM_Params | None = N
     if provider in litellm.models_by_provider:
         provider_models: Final = get_valid_models(custom_llm_provider=provider, litellm_params=litellm_params)
         return provider_models
-    return None
+
+    # Providers with no static catalog (litellm_proxy, hosted_vllm, ollama, ...) are absent
+    # from models_by_provider by design: their model list only exists behind the provider's
+    # own endpoint. ProviderConfigManager still knows about them, so admit them here instead
+    # of returning None before endpoint discovery is ever attempted.
+    try:
+        llm_provider: Final = LlmProviders(provider)
+    except ValueError:
+        return None
+    if ProviderConfigManager.get_provider_model_info(model=None, provider=llm_provider) is None:
+        return None
+    return get_valid_models(custom_llm_provider=provider, litellm_params=litellm_params)
 
 
 def _get_models_from_access_groups(

--- a/tests/test_litellm/proxy/auth/test_model_checks.py
+++ b/tests/test_litellm/proxy/auth/test_model_checks.py
@@ -803,3 +803,38 @@ def test_get_complete_model_list_sentinel_only_grants_nothing():
         infer_model_from_keys=False,
     )
     assert result == []
+
+
+def test_get_provider_models_admits_providers_without_a_static_catalog():
+    """litellm_proxy and hosted_vllm have no entry in litellm.models_by_provider
+    (their model list only exists behind the provider's own endpoint), so the
+    static-dict gate must not reject them before endpoint discovery runs.
+    """
+    import litellm
+    from litellm.proxy.auth.model_checks import get_provider_models
+    from litellm.types.router import LiteLLM_Params
+
+    assert "litellm_proxy" not in litellm.models_by_provider
+    assert "hosted_vllm" not in litellm.models_by_provider
+
+    with patch(
+        "litellm.proxy.auth.model_checks.get_valid_models",
+        return_value=["litellm_proxy/gpt-4o"],
+    ) as mock_get_valid_models:
+        result = get_provider_models(
+            "litellm_proxy",
+            litellm_params=LiteLLM_Params(
+                model="litellm_proxy/*",
+                api_base="http://upstream:4000",
+                api_key="sk-upstream",
+            ),
+        )
+
+    assert result == ["litellm_proxy/gpt-4o"]
+    mock_get_valid_models.assert_called_once()
+
+
+def test_get_provider_models_returns_none_for_an_unknown_provider():
+    from litellm.proxy.auth.model_checks import get_provider_models
+
+    assert get_provider_models("not-a-real-provider") is None

--- a/tests/test_litellm/proxy/auth/test_model_checks.py
+++ b/tests/test_litellm/proxy/auth/test_model_checks.py
@@ -809,6 +809,11 @@ def test_get_provider_models_admits_providers_without_a_static_catalog():
     """litellm_proxy and hosted_vllm have no entry in litellm.models_by_provider
     (their model list only exists behind the provider's own endpoint), so the
     static-dict gate must not reject them before endpoint discovery runs.
+
+    Regression check only, not a discovery test: with check_provider_endpoint
+    left at its default (off), get_valid_models never reaches the network and
+    falls back to models_by_provider.get(provider, []) -- an empty list, not
+    None. Before the fix, the gate itself returned None for these providers.
     """
     import litellm
     from litellm.proxy.auth.model_checks import get_provider_models
@@ -817,21 +822,16 @@ def test_get_provider_models_admits_providers_without_a_static_catalog():
     assert "litellm_proxy" not in litellm.models_by_provider
     assert "hosted_vllm" not in litellm.models_by_provider
 
-    with patch(
-        "litellm.proxy.auth.model_checks.get_valid_models",
-        return_value=["litellm_proxy/gpt-4o"],
-    ) as mock_get_valid_models:
-        result = get_provider_models(
-            "litellm_proxy",
-            litellm_params=LiteLLM_Params(
-                model="litellm_proxy/*",
-                api_base="http://upstream:4000",
-                api_key="sk-upstream",
-            ),
-        )
+    result = get_provider_models(
+        "litellm_proxy",
+        litellm_params=LiteLLM_Params(
+            model="litellm_proxy/*",
+            api_base="http://upstream:4000",
+            api_key="sk-upstream",
+        ),
+    )
 
-    assert result == ["litellm_proxy/gpt-4o"]
-    mock_get_valid_models.assert_called_once()
+    assert result == []
 
 
 def test_get_provider_models_returns_none_for_an_unknown_provider():


### PR DESCRIPTION
## TLDR

Problem this solves:

- GET /v1/models returns the literal `litellm_proxy/*` string, not the upstream's models
- Same for any provider with no static model catalog (e.g. `hosted_vllm`)

How it solves it:

- Admit a provider into endpoint discovery once its config is registered, not only when it is in the static `models_by_provider` dict

## User Flow

Before: an operator chaining one LiteLLM proxy in front of another gets no model list from the downstream proxy

1. They configure the downstream proxy with a `litellm_proxy/*` wildcard deployment pointing at the upstream proxy, and set `check_provider_endpoint: true`
2. They call GET /v1/models on the downstream proxy
3. The response is `{"data": [{"id": "litellm_proxy/*", ...}]}`, a single literal entry instead of the upstream's actual models
4. Their client (e.g. a model picker in a custom UI) has nothing usable to show

After: the downstream proxy discovers and returns the upstream's real models

1. Same config, same GET /v1/models call
2. The response includes one `litellm_proxy/<name>` entry per model the upstream proxy exposes
3. Their client shows the real model list, and calling any of those ids routes through to the upstream as expected

## Relevant issues

Fixes #38547

## Linear ticket



## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Two local proxies: an "upstream" (port 4010) with two static models, and a "downstream" (port 4020/4021) with a `litellm_proxy/*` wildcard deployment pointing at the upstream, `check_provider_endpoint: true`.

### Before (3002994c0e, the fix's parent commit)

1. `curl http://127.0.0.1:4021/v1/models -H "Authorization: Bearer sk-downstream-1234"` returns:
   ```json
   {"data":[{"id":"litellm_proxy/*","object":"model","created":1677610602,"owned_by":"openai"}],"object":"list"}
   ```
2. Only the literal wildcard string comes back. No request ever reaches the upstream's /v1/models.

### After (0ac1c45fdf, this PR's tip)

1. `curl http://127.0.0.1:4020/v1/models -H "Authorization: Bearer sk-downstream-1234"` returns:
   ```json
   {"data":[{"id":"litellm_proxy/*","object":"model","created":1677610602,"owned_by":"openai"},{"id":"litellm_proxy/gpt-4o","object":"model","created":1677610602,"owned_by":"openai","mode":"chat","max_input_tokens":128000,"max_output_tokens":16384},{"id":"litellm_proxy/claude-sonnet","object":"model","created":1677610602,"owned_by":"openai"}],"object":"list"}
   ```
2. Both upstream models are now discovered and listed.
3. Routing still works end to end: `curl http://127.0.0.1:4020/v1/chat/completions -H "Authorization: Bearer sk-downstream-1234" -d '{"model":"litellm_proxy/gpt-4o","messages":[{"role":"user","content":"hi"}]}'` forwards to the upstream and fails only on the fake OpenAI key (`AuthenticationError: Incorrect API key`), confirming the request reached the right model group rather than a "model not found" error.

## Type

🐛 Bug Fix

## Caveats (if any)

### Low

- Only providers registered in `ProviderConfigManager.get_provider_model_info` are admitted; a provider with neither a static catalog nor a registered config still returns `None`, unchanged from before

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
