### PR TITLE
fix(anthropic): handle per-level reasoning_effort flags without supports_reasoning

### DIFF
--- a/litellm/router_utils/reasoning_effort_capability.py
+++ b/litellm/router_utils/reasoning_effort_capability.py
@@ -148,16 +148,23 @@ def resolve_supported_reasoning_efforts(
     unset flag as () would let one custom deployment empty every level its mapped siblings agree
     on. deployment_is_mapped is that provenance, and an operator who wants either answer for an
     off-map deployment gets it by setting supports_reasoning explicitly.
+
+    If no explicit supports_reasoning flag is set but at least one per-level flag (e.g.
+    supports_minimal_reasoning_effort) is present, treat supports_reasoning as implicitly True,
+    since the per-level flags are evidence the model supports reasoning.
     """
     supports_reasoning: Final = model_info.get("supports_reasoning")
+    flags: Final = _declared_effort_flags(model_info)
+    has_per_level_flag: Final = any(value is not None for value in flags.values())
+
     if supports_reasoning is not True:
-        return () if supports_reasoning is False or deployment_is_mapped else None
+        if not has_per_level_flag:
+            return () if supports_reasoning is False or deployment_is_mapped else None
 
     declared: Final = declared_reasoning_efforts(model_info)
     if declared is not None:
         return declared
 
-    flags: Final = _declared_effort_flags(model_info)
     if all(value is None for value in flags.values()):
         return None
 

--- a/litellm/router_utils/reasoning_effort_capability.py
+++ b/litellm/router_utils/reasoning_effort_capability.py
@@ -149,17 +149,19 @@ def resolve_supported_reasoning_efforts(
     on. deployment_is_mapped is that provenance, and an operator who wants either answer for an
     off-map deployment gets it by setting supports_reasoning explicitly.
 
-    If no explicit supports_reasoning flag is set but at least one per-level flag (e.g.
-    supports_minimal_reasoning_effort) is present, treat supports_reasoning as implicitly True,
-    since the per-level flags are evidence the model supports reasoning.
+    If supports_reasoning is unset but at least one per-level flag (e.g.
+    supports_minimal_reasoning_effort) is present, treat it as implicitly True, since the
+    per-level flags are evidence the model supports reasoning. An explicit False always wins:
+    it is the operator's escape hatch and must not be overridden by inherited per-level flags.
     """
     supports_reasoning: Final = model_info.get("supports_reasoning")
+    if supports_reasoning is False:
+        return ()
+
     flags: Final = _declared_effort_flags(model_info)
     has_per_level_flag: Final = any(value is not None for value in flags.values())
-
-    if supports_reasoning is not True:
-        if not has_per_level_flag:
-            return () if supports_reasoning is False or deployment_is_mapped else None
+    if supports_reasoning is not True and not has_per_level_flag:
+        return () if deployment_is_mapped else None
 
     declared: Final = declared_reasoning_efforts(model_info)
     if declared is not None:

--- a/tests/test_litellm/router_utils/test_reasoning_effort_capability.py
+++ b/tests/test_litellm/router_utils/test_reasoning_effort_capability.py
@@ -85,6 +85,18 @@ class TestResolveSupportedReasoningEfforts:
         )
         assert resolved == ("none", "minimal", "low", "medium", "high")
 
+    def test_per_level_flag_without_supports_reasoning_treats_as_implicit_true(self):
+        # A model with only a per-level flag (e.g. supports_minimal_reasoning_effort) but no
+        # explicit supports_reasoning should be treated as reasoning-capable, since the per-level
+        # flag is evidence of reasoning support.
+        resolved = resolve_supported_reasoning_efforts(
+            {
+                "supports_minimal_reasoning_effort": True,
+            },
+            deployment_is_mapped=True,
+        )
+        assert resolved == ("none", "minimal", "low", "medium", "high")
+
 
 class TestBareModelNameFallback:
     def test_a_prefixed_entry_inherits_the_flags_of_its_unprefixed_twin(self):

--- a/tests/test_litellm/router_utils/test_reasoning_effort_capability.py
+++ b/tests/test_litellm/router_utils/test_reasoning_effort_capability.py
@@ -86,9 +86,6 @@ class TestResolveSupportedReasoningEfforts:
         assert resolved == ("none", "minimal", "low", "medium", "high")
 
     def test_per_level_flag_without_supports_reasoning_treats_as_implicit_true(self):
-        # A model with only a per-level flag (e.g. supports_minimal_reasoning_effort) but no
-        # explicit supports_reasoning should be treated as reasoning-capable, since the per-level
-        # flag is evidence of reasoning support.
         resolved = resolve_supported_reasoning_efforts(
             {
                 "supports_minimal_reasoning_effort": True,
@@ -96,6 +93,16 @@ class TestResolveSupportedReasoningEfforts:
             deployment_is_mapped=True,
         )
         assert resolved == ("none", "minimal", "low", "medium", "high")
+
+    def test_explicit_supports_reasoning_false_wins_over_per_level_flags(self):
+        resolved = resolve_supported_reasoning_efforts(
+            {
+                "supports_reasoning": False,
+                "supports_minimal_reasoning_effort": True,
+            },
+            deployment_is_mapped=True,
+        )
+        assert resolved == ()
 
 
 class TestBareModelNameFallback:


### PR DESCRIPTION
## Problem

`gpt-5-search-api` declares `supports_minimal_reasoning_effort: true` but has no `supports_reasoning` flag. The resolver was treating this as "no reasoning support" and falling back to the chain floor, causing `minimal` requests to downgrade to `low`.

## Solution

When a model has any per-level flag set (not None), treat `supports_reasoning` as implicitly True and proceed through the flag resolution path. This allows models like `gpt-5-search-api` to correctly advertise and accept their declared effort levels.

## Behavior change

20 azure deployments (those with `max` or `xhigh` per-level flags set) will now forward those efforts instead of degrading to `high`. This is intended (avoiding unnecessary degradation) but is a latency/cost change; operators should monitor reasoning effort changes in logs if they see bill increases.

## Testing

- ✅ New test verifies per-level flag enables resolution without explicit `supports_reasoning`
- ✅ All existing reasoning effort capability tests pass

Fixes the regression identified in PR #38492 follow-up review.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes router-advertised reasoning effort levels for map entries with per-level flags but no `supports_reasoning`, which can alter forwarded effort (including higher tiers on some Azure deployments) and affect latency/cost.
> 
> **Overview**
> **Fixes incorrect downgrades** when a catalog entry sets per-level `supports_*_reasoning_effort` flags but omits `supports_reasoning` (e.g. `gpt-5-search-api` with `supports_minimal_reasoning_effort: true`).
> 
> `resolve_supported_reasoning_efforts` now treats **any non-`None` per-level flag as implicit evidence that reasoning is supported**, so resolution continues through the flag/opt-in/opt-out path instead of behaving like a mapped non-reasoning model (`()`) or unknown. **`supports_reasoning: false` is checked first** and still returns no efforts, even if per-level flags are present.
> 
> Tests cover implicit enablement from a lone per-level flag and that explicit `supports_reasoning: false` overrides inherited per-level metadata.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 460361923cdcf385171aab24b4c06325be1690bf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->