### PR TITLE
fix(exceptions): keep a refused connection an APIConnectionError

### DIFF
--- a/litellm/litellm_core_utils/exception_mapping_utils.py
+++ b/litellm/litellm_core_utils/exception_mapping_utils.py
@@ -2222,6 +2222,8 @@ def _map_exception_by_status(
     status_code: Final = original_exception.status_code if hasattr(original_exception, "status_code") else None
     if not isinstance(status_code, int) or status_code < 400:
         return
+    if getattr(original_exception, "status_code_is_synthesized", False):
+        return
     message: Final = f"{exception_provider} - {error_str}"
     response: Final = original_exception.response if hasattr(original_exception, "response") else None
     match status_code:

--- a/litellm/llms/base_llm/chat/transformation.py
+++ b/litellm/llms/base_llm/chat/transformation.py
@@ -46,8 +46,10 @@ class BaseLLMException(Exception):
         request: httpx.Request | None = None,
         response: httpx.Response | None = None,
         body: dict | None = None,
+        status_code_is_synthesized: bool = False,
     ):
         self.status_code = status_code
+        self.status_code_is_synthesized = status_code_is_synthesized
         self.message: str = message
         self.headers = headers
         if request:

--- a/litellm/llms/custom_httpx/llm_http_handler.py
+++ b/litellm/llms/custom_httpx/llm_http_handler.py
@@ -5947,11 +5947,13 @@ class BaseLLMHTTPHandler:
             BaseEvalsAPIConfig,
         ],
     ):
-        status_code = getattr(e, "status_code", 500)
+        received_status_code: Final = (
+            e.response.status_code if isinstance(e, httpx.HTTPStatusError) else getattr(e, "status_code", None)
+        )
+        status_code = received_status_code if isinstance(received_status_code, int) else 500
         error_headers = getattr(e, "headers", None)
         if isinstance(e, httpx.HTTPStatusError):
             error_text = e.response.text
-            status_code = e.response.status_code
         else:
             error_text = getattr(e, "text", str(e))
         error_response: Final = getattr(e, "response", None)
@@ -5971,13 +5973,17 @@ class BaseLLMHTTPHandler:
                 status_code=status_code,
                 message=error_text,
                 headers=error_headers,
+                status_code_is_synthesized=not isinstance(received_status_code, int),
             )
 
-        raise provider_config.get_error_class(
+        provider_error: Final = provider_config.get_error_class(
             error_message=error_text,
             status_code=status_code,
             headers=error_headers,
         )
+        if not isinstance(received_status_code, int):
+            provider_error.status_code_is_synthesized = True
+        raise provider_error
 
     @staticmethod
     def _append_query_params(url: str, query_params: RealtimeQueryParams | None) -> str:

--- a/tests/test_litellm/litellm_core_utils/test_exception_mapping_utils.py
+++ b/tests/test_litellm/litellm_core_utils/test_exception_mapping_utils.py
@@ -1163,3 +1163,52 @@ def test_bedrock_mantle_context_overflow_maps_to_context_window_exceeded():
 
     assert excinfo.value.status_code == 400
     assert "prompt is too long: 1055489 tokens > 1050000 maximum" in excinfo.value.message
+
+
+def test_branchless_provider_transport_error_maps_to_api_connection_error():
+    from litellm.llms.base_llm.chat.transformation import BaseLLMException
+
+    original_exception = BaseLLMException(status_code=500, message="[Errno 111] Connection refused")
+    original_exception.status_code_is_synthesized = True
+
+    with pytest.raises(litellm.APIConnectionError):
+        exception_type(
+            model="test-agent",
+            original_exception=original_exception,
+            custom_llm_provider="a2a",
+        )
+
+
+def test_branchless_provider_upstream_500_still_maps_to_internal_server_error():
+    from litellm.llms.base_llm.chat.transformation import BaseLLMException
+
+    original_exception = BaseLLMException(status_code=500, message="upstream exploded")
+
+    with pytest.raises(litellm.InternalServerError):
+        exception_type(
+            model="test-agent",
+            original_exception=original_exception,
+            custom_llm_provider="a2a",
+        )
+
+
+def test_handle_error_marks_only_a_status_code_it_never_received():
+    from litellm.llms.custom_httpx.llm_http_handler import BaseLLMHTTPHandler
+
+    handler = BaseLLMHTTPHandler()
+
+    with pytest.raises(litellm.llms.base_llm.chat.transformation.BaseLLMException) as transport:
+        raise handler._handle_error(e=httpx.ConnectError("Connection refused"), provider_config=None)
+    assert transport.value.status_code == 500
+    assert transport.value.status_code_is_synthesized is True
+
+    request = httpx.Request(method="POST", url="https://example.invalid")
+    upstream = httpx.HTTPStatusError(
+        "server error",
+        request=request,
+        response=httpx.Response(status_code=500, request=request, text="upstream exploded"),
+    )
+    with pytest.raises(litellm.llms.base_llm.chat.transformation.BaseLLMException) as received:
+        raise handler._handle_error(e=upstream, provider_config=None)
+    assert received.value.status_code == 500
+    assert received.value.status_code_is_synthesized is False

--- a/tests/test_litellm/llms/base_llm/search/test_base_search_transformation.py
+++ b/tests/test_litellm/llms/base_llm/search/test_base_search_transformation.py
@@ -322,7 +322,7 @@ async def test_query_param_key_not_leaked_with_dummy_caller_key(
         "litellm.llms.custom_httpx.http_handler.AsyncHTTPHandler.get",
         fake_get,
     ):
-        with pytest.raises(litellm.InternalServerError):
+        with pytest.raises(litellm.APIConnectionError):
             await litellm.asearch(
                 query="secrets",
                 search_provider=provider,


### PR DESCRIPTION
## TLDR

Problem this solves:

- A refused connection now surfaces as InternalServerError
- Router cools down deployments that never actually failed
- Regression landed in #38318, caught by CI

How it solves it:

- Mark a status code the handler invented, not received
- Skip status-based mapping when the code was invented
- Restore the search test assertion #38318 had loosened

## User Flow

Before: a developer routing to a deployment whose upstream is unreachable gets the deployment cooled down, so later requests skip a healthy target

1. They add two deployments for the same model name, one pointing at a host that refuses connections
2. They send POST https://litellm-domain/v1/chat/completions for that model name
3. The refused connection comes back as `litellm.InternalServerError` instead of `litellm.APIConnectionError`
4. Because it reads as a 5xx from the provider, the router puts that deployment in cooldown
5. They open https://litellm-domain/ui/?page=logs and see the deployment sitting out of rotation for the cooldown window, even after the host comes back

After: the same refused connection is reported as a connection error and leaves the deployment in rotation

1. They add the same two deployments, one pointing at a host that refuses connections
2. They send the same POST https://litellm-domain/v1/chat/completions
3. The refused connection comes back as `litellm.APIConnectionError` again
4. The router leaves that deployment out of cooldown, so it is retried as soon as the host is reachable
5. A real upstream 500 still comes back as `litellm.InternalServerError` and still cools the deployment down

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Pending live-proxy QA

## Type

🐛 Bug Fix

## Caveats (if any)

### Low

- Both errors are still HTTP 500 to the caller
- Only providers without a dedicated mapping branch were affected

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core exception classification used by the router for cooldown/retry; scope is narrow (synthesized status only) but affects all providers without dedicated mapping branches.
> 
> **Overview**
> Fixes a regression where **transport failures** (e.g. connection refused) were classified as **`InternalServerError`** because the HTTP handler defaulted missing status codes to **500**, and generic status-based mapping treated that as a real upstream 5xx.
> 
> **`BaseLLMException`** and **`_handle_error`** now set **`status_code_is_synthesized`** when no integer HTTP status was received (e.g. `httpx.ConnectError`). **`_map_exception_by_status`** skips status-code mapping when that flag is set, so branchless providers fall through to **`APIConnectionError`** again while **real upstream 500s** still map to **`InternalServerError`**.
> 
> Tests cover synthesized vs received 500, handler behavior, and restore the search regression expectation from **`InternalServerError`** back to **`APIConnectionError`** for transport-style failures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a4049b730cfdc1047452e466edc2528b08d62e50. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->