### PR TITLE
test(e2e): unskip four tests whose blockers no longer hold

### DIFF
--- a/tests/e2e/llm_translation/test_files_batches_contract_e2e.py
+++ b/tests/e2e/llm_translation/test_files_batches_contract_e2e.py
@@ -46,9 +46,6 @@ class TestFilesBatchesContract:
             case other:
                 pytest.fail(f"upload without purpose expected 4xx, got {other!r}")
 
-    @pytest.mark.skip(
-        reason="stage red: product gap, /v1/batches 500s (acreate_batch TypeError) on missing input_file_id instead of 400"
-    )
     @pytest.mark.covers("llm.batches.openai.input_validation.nonstream.works")
     def test_create_batch_missing_input_file_id_returns_error(
         self, proxy: ProxyClient, resources: ResourceManager

--- a/tests/e2e/mcp/test_mcp_datadog_e2e.py
+++ b/tests/e2e/mcp/test_mcp_datadog_e2e.py
@@ -49,16 +49,6 @@ def _seed_completion(proxy: ProxyClient, *, key: str, marker: str) -> None:
 
 
 class TestDatadogMcpRoundTrip:
-    @pytest.mark.skip(
-        reason=(
-            "LIT-5052: this test sends a `telemetry` argument that Datadog's "
-            "search_datadog_logs tool now rejects, so every tool call fails validation with "
-            "'unexpected additional properties [\"telemetry\"]' before the round-trip "
-            "assertion is reached. `telemetry` was never a documented Datadog parameter; the "
-            "test relied on the server ignoring unknown properties. Unskip once the argument "
-            "is dropped."
-        )
-    )
     @pytest.mark.covers("mcp.list_tools.api_key.succeeds", "mcp.call_tool.api_key.succeeds")
     def test_search_logs_finds_seeded_completion(
         self,
@@ -98,9 +88,6 @@ class TestDatadogMcpRoundTrip:
                 "from": DD_SEARCH_FROM,
                 "to": "now",
                 "max_tokens": 5000,
-                "telemetry": {
-                    "intent": "e2e assert seeded litellm completion log is searchable via MCP"
-                },
             },
         )
         assert call.is_error is not True, f"search_datadog_logs errored: {call}"

--- a/tests/e2e/mcp/test_mcp_guardrail_e2e.py
+++ b/tests/e2e/mcp/test_mcp_guardrail_e2e.py
@@ -78,16 +78,6 @@ def _search_on_synced_pod(
 
 
 class TestMcpToolCallGuardrail:
-    @pytest.mark.skip(
-        reason=(
-            "LIT-5052: the control call sends a `telemetry` argument that Datadog's "
-            "search_datadog_logs tool now rejects, so the clean-argument half of this test "
-            "errors with 'unexpected additional properties [\"telemetry\"]' and the guardrail "
-            "block it exists to prove is never exercised. `telemetry` was never a documented "
-            "Datadog parameter; the test relied on the server ignoring unknown properties. "
-            "Unskip once the argument is dropped."
-        )
-    )
     @pytest.mark.covers(
         "guardrail.litellm_content_filter.pre_mcp_call.blocks",
         exercised_on=["mcp_operations"],
@@ -118,7 +108,6 @@ class TestMcpToolCallGuardrail:
                 "from": DD_SEARCH_FROM,
                 "to": "now",
                 "max_tokens": 500,
-                "telemetry": {"intent": "e2e mcp guardrail check"},
             }
             return client.call_tool(key, server_id=server_id, name=tool_name, arguments=arguments)
 

--- a/tests/e2e/mcp/test_mcp_key_access_e2e.py
+++ b/tests/e2e/mcp/test_mcp_key_access_e2e.py
@@ -51,16 +51,6 @@ class TestMcpKeyWithoutAccessIsDenied:
             f"boundary: {denied_tools}"
         )
 
-    @pytest.mark.skip(
-        reason=(
-            "LIT-5052: the control call proving a granted key CAN invoke the tool sends a "
-            "`telemetry` argument that Datadog's search_datadog_logs tool now rejects, so it "
-            "errors with 'unexpected additional properties [\"telemetry\"]' and the denial "
-            "assertion is never reached. `telemetry` was never a documented Datadog "
-            "parameter; the test relied on the server ignoring unknown properties. Unskip "
-            "once the argument is dropped."
-        )
-    )
     @pytest.mark.covers("mcp.call_tool.api_key.denied_without_permission")
     def test_call_tool_denied_without_permission(
         self,
@@ -80,7 +70,6 @@ class TestMcpKeyWithoutAccessIsDenied:
             "from": DD_SEARCH_FROM,
             "to": "now",
             "max_tokens": 1000,
-            "telemetry": {"intent": "e2e control call proving granted key can invoke Datadog MCP"},
         }
         permitted_call = client.await_call_tool(
             permitted_key, server_id=server_id, name=tool_name, arguments=search_args


### PR DESCRIPTION
## TLDR

Problem this solves:

- Four e2e tests stay skipped after their blocker went away
- The batches skip reason no longer reproduces, the route returns 400
- Three MCP tests are blocked by their own bad argument, not the product

How it solves it:

- Drop the batches skip, nothing else in that test changes
- Drop the undocumented `telemetry` argument from the Datadog tool calls
- Drop the three MCP skips that only existed because of that argument

## User Flow

Before: a developer posting a batch without an input file gets an opaque failure, and nobody notices if that ever comes back

1. They send POST https://litellm-domain/v1/batches with `{"endpoint": "/v1/chat/completions", "completion_window": "24h"}` and no `input_file_id`
2. They expect a 400 naming the missing field, and today they do get one
3. Nothing in the e2e gate checks that, so a regression back to a 500 ships silently

After: the same request is pinned by a test that runs on every gated PR

1. They send the same POST https://litellm-domain/v1/batches with no `input_file_id`
2. They get `400` with `"/batches: Missing required parameter: 'input_file_id'."` and `"param": "input_file_id"`
3. The e2e gate now fails if that ever turns back into a 500

## Relevant issues

## Linear ticket

Resolves LIT-5052

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

Local proxy on port 4001 from this worktree, master key `sk-1234`. Only the batches test is provable on a laptop, since the three Datadog MCP tests need `DD_API_KEY` / `DD_APP_KEY` that the Buildkite e2e stack injects and my machine does not have. Their evidence is the two gate runs at the end of this section, each on its own ephemeral stack against the real Datadog MCP server.

### Before (2b10dc5a7a)

1. `uv run --no-sync pytest tests/e2e/llm_translation/test_files_batches_contract_e2e.py -rs -q`

```
SKIPPED [1] tests/e2e/llm_translation/test_files_batches_contract_e2e.py:49: stage red: product gap, /v1/batches 500s (acreate_batch TypeError) on missing input_file_id instead of 400
```

2. The reason no longer holds. Same proxy, same request the skipped test sends:

```
curl -s -w "\nHTTP %{http_code}\n" -X POST http://localhost:4001/v1/batches \
  -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
  -d '{"endpoint":"/v1/chat/completions","completion_window":"24h"}'
```

```
{"error":{"message":"/batches: Missing required parameter: 'input_file_id'.","type":"invalid_request_error","param":"input_file_id","code":"400"}}
HTTP 400
```

### After (0c5c96dbf6)

1. Same curl, same 400:

```
curl -s -w "\nHTTP %{http_code}\n" -X POST http://localhost:4001/v1/batches \
  -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
  -d '{"endpoint":"/v1/chat/completions","completion_window":"24h"}'
```

```
{"error":{"message":"/batches: Missing required parameter: 'input_file_id'.","type":"invalid_request_error","param":"input_file_id","code":"400"}}
HTTP 400
```

2. The test now runs instead of being skipped, and it passes:

```
uv run --no-sync pytest tests/e2e/llm_translation/test_files_batches_contract_e2e.py -rA -q
```

```
PASSED tests/e2e/llm_translation/test_files_batches_contract_e2e.py::TestFilesBatchesContract::test_upload_without_purpose_returns_error
PASSED tests/e2e/llm_translation/test_files_batches_contract_e2e.py::TestFilesBatchesContract::test_create_batch_missing_input_file_id_returns_error
PASSED tests/e2e/llm_translation/test_files_batches_contract_e2e.py::TestFilesBatchesContract::test_retrieve_invalid_batch_id_returns_error
3 passed in 4.17s
```

3. All four unskipped tests run and pass on the Buildkite e2e gate, twice, each on a fresh ephemeral stack. Build [#6348](https://buildkite.com/berriai-1/e2e-tests/builds/6348):

```
[gw0] [ 28%] PASSED llm_translation/test_files_batches_contract_e2e.py::TestFilesBatchesContract::test_create_batch_missing_input_file_id_returns_error
[gw1] [ 71%] PASSED mcp/test_mcp_key_access_e2e.py::TestMcpKeyWithoutAccessIsDenied::test_call_tool_denied_without_permission
[gw2] [ 85%] PASSED mcp/test_mcp_datadog_e2e.py::TestDatadogMcpRoundTrip::test_search_logs_finds_seeded_completion
[gw3] [100%] PASSED mcp/test_mcp_guardrail_e2e.py::TestMcpToolCallGuardrail::test_content_filter_blocks_banned_keyword_in_tool_args
7 passed in 74.81s (0:01:14)
```

4. Rebuild [#6352](https://buildkite.com/berriai-1/e2e-tests/builds/6352) on the same commit, second stack, same result and no reruns:

```
[gw0] [ 28%] PASSED llm_translation/test_files_batches_contract_e2e.py::TestFilesBatchesContract::test_create_batch_missing_input_file_id_returns_error
[gw1] [ 71%] PASSED mcp/test_mcp_key_access_e2e.py::TestMcpKeyWithoutAccessIsDenied::test_call_tool_denied_without_permission
[gw2] [ 85%] PASSED mcp/test_mcp_datadog_e2e.py::TestDatadogMcpRoundTrip::test_search_logs_finds_seeded_completion
[gw4] [100%] PASSED mcp/test_mcp_guardrail_e2e.py::TestMcpToolCallGuardrail::test_content_filter_blocks_banned_keyword_in_tool_args
7 passed in 75.10s (0:01:15)
```

5. Five back-to-back local runs of the batches file, no flake:

```
for i in 1 2 3 4 5; do uv run --no-sync pytest tests/e2e/llm_translation/test_files_batches_contract_e2e.py -q --no-header | tail -1; done
```

```
3 passed in 4.29s
3 passed in 3.60s
3 passed in 3.27s
3 passed in 3.33s
3 passed in 3.50s
```

## Type

✅ Test

## Caveats

### Low

- The guardrail test waits a 40s pod sync, so it is the slowest of the four
- Two gate samples is a small flake sample, though neither needed a rerun

- 27 other e2e skips stay, each still a real product or environment gap
- I reproduced several on a live proxy: /v1/moderations, /v1/responses, /v1/audio/speech, /v1/ocr, /v1/images/generations and /v1/messages still return 500 on a missing required field
- `REQUIRED_BODY_PARAMS_BY_ROUTE` in `litellm/proxy/route_llm_request.py` is where those would be fixed, follow-up work

## QA runbook

- tests/e2e/llm_translation/test_files_batches_contract_e2e.py::TestFilesBatchesContract::test_create_batch_missing_input_file_id_returns_error - posting a batch with no input_file_id is refused with a 4xx, not a 500
  - [ ] Generate a key: curl -X POST http://localhost:4000/key/generate -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" -d '{}'
  - [ ] POST /v1/batches with that key and body {"endpoint": "/v1/chat/completions", "completion_window": "24h"}
  - [ ] Expect 400 with message "/batches: Missing required parameter: 'input_file_id'." and param "input_file_id"
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey (e.g., assert actual expected spend instead of just spend > 0) or potentially flaky

- tests/e2e/mcp/test_mcp_key_access_e2e.py::TestMcpKeyWithoutAccessIsDenied::test_call_tool_denied_without_permission - a key with no MCP grant cannot call a tool that a granted key can
  - [ ] Needs DD_API_KEY and DD_APP_KEY in the proxy env
  - [ ] Register the Datadog MCP server: POST /v1/mcp/server with url https://mcp.datadoghq.com/api/unstable/mcp-server/mcp?toolsets=core, transport http, static headers DD-API-KEY and DD-APPLICATION-KEY, allowed_tools ["search_datadog_logs"]
  - [ ] Generate two keys, one with object_permission.mcp_servers set to that server id and one with no MCP grant
  - [ ] POST /mcp-rest/tools/call with the granted key, tool search_datadog_logs, arguments {"query": "service:litellm", "from": "now-30m", "to": "now", "max_tokens": 1000}, and expect a non-error result
  - [ ] Send the same call with the ungranted key and expect 403 whose body says access_denied
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey (e.g., assert actual expected spend instead of just spend > 0) or potentially flaky

- tests/e2e/mcp/test_mcp_datadog_e2e.py::TestDatadogMcpRoundTrip::test_search_logs_finds_seeded_completion - a completion the proxy logs to Datadog is findable through the brokered MCP server
  - [ ] Needs DD_API_KEY, DD_APP_KEY, and the DataDogLogger callback active; check GET /health/readiness/details names DataDogLogger
  - [ ] Register the Datadog MCP server as above and generate a key granted it
  - [ ] Send a /v1/chat/completions carrying a unique marker like e2e-datadog-mcp-<random> in the prompt
  - [ ] Wait for the log to land, then POST /mcp-rest/tools/call with tool search_datadog_logs and arguments {"query": "<that marker>", "from": "now-30m", "to": "now", "max_tokens": 5000}
  - [ ] Expect the tool result text to contain the marker
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey (e.g., assert actual expected spend instead of just spend > 0) or potentially flaky

- tests/e2e/mcp/test_mcp_guardrail_e2e.py::TestMcpToolCallGuardrail::test_content_filter_blocks_banned_keyword_in_tool_args - a content filter on the MCP tool-call path blocks banned words in tool arguments and lets clean ones through
  - [ ] Needs DD_API_KEY and DD_APP_KEY
  - [ ] Create a litellm_content_filter guardrail with mode pre_mcp_call and default_on, banning a unique word
  - [ ] Register the Datadog MCP server and generate a key granted it
  - [ ] POST /mcp-rest/tools/call with tool search_datadog_logs and a query containing the banned word, retrying until the guardrail syncs to the data plane
  - [ ] Expect 400 whose body names the banned word and pre_mcp_call
  - [ ] Wait 40s for every pod to sync, repeat the banned call four times, and expect 400 each time
  - [ ] Send a clean query with arguments {"query": "e2e-clean-<random>", "from": "now-30m", "to": "now", "max_tokens": 500} and expect a non-error result
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey (e.g., assert actual expected spend instead of just spend > 0) or potentially flaky

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
