### PR TITLE
fix(logging): preserve null end user in callbacks

### DIFF
--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -6058,7 +6058,7 @@ def get_standard_logging_object_payload(
             prompt_tokens=usage_dict.get("prompt_tokens", 0),
             completion_tokens=usage_dict.get("completion_tokens", 0),
             request_tags=request_tags,
-            end_user=end_user_id or "",
+            end_user=end_user_id,
             api_base=StandardLoggingPayloadSetup.strip_trailing_slash(litellm_params.get("api_base", "")) or "",
             model_group=_model_group,
             model_id=_model_id,

--- a/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
+++ b/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
@@ -3727,6 +3727,41 @@ def test_get_standard_logging_object_payload_includes_litellm_call_id(logging_ob
     assert payload["litellm_call_id"] == call_id
 
 
+def test_get_standard_logging_object_payload_preserves_absent_end_user_as_none(logging_obj):
+    from datetime import datetime
+    from typing import Final
+
+    from litellm.litellm_core_utils.litellm_logging import get_standard_logging_object_payload
+    from litellm.types.utils import StandardLoggingPayload
+
+    now: Final = datetime.now()
+    payload: Final[StandardLoggingPayload | None] = get_standard_logging_object_payload(
+        kwargs={
+            "model": "gpt-4o",
+            "messages": [],
+            "litellm_params": {
+                "metadata": {
+                    "user_api_key_alias": "test-key-alias",
+                    "user_api_key_user_id": "test-key-user",
+                    "user_api_key_end_user_id": None,
+                },
+                "proxy_server_request": {"body": {}},
+            },
+        },
+        init_response_obj={},
+        start_time=now,
+        end_time=now,
+        logging_obj=logging_obj,
+        status="success",
+    )
+
+    assert payload is not None
+    assert payload["metadata"]["user_api_key_alias"] == "test-key-alias"
+    assert payload["metadata"]["user_api_key_user_id"] == "test-key-user"
+    assert payload["metadata"]["user_api_key_end_user_id"] is None
+    assert payload["end_user"] is None
+
+
 # ── Azure Model Router selected-model attribution ────────────────────────────
 
 


### PR DESCRIPTION
## TLDR

Problem this solves:

- Optional callback end-user identity became an empty string

How it solves it:

- Preserve the missing value as `null` in callback payloads
- Keep identity fields under standard payload metadata

## User Flow

Before: a developer receives callback payloads with inconsistent missing identity values

1. They send POST `http://localhost:20635/v1/chat/completions` without a request user
2. The terminal callback has the key identity metadata, but `end_user` is `""`

After: the same request preserves the optional end-user identity as `null`

1. They send the same POST `http://localhost:20635/v1/chat/completions` without a request user
2. The terminal callback has the key identity metadata and `end_user` is `null`

## Relevant issues

## Linear ticket

Resolves LIT-5635

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally
- [ ] My PR passes all required CI/CD checks
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile Confidence Score of at least 4/5 before requesting a maintainer review

## Screenshots / Proof of Fix

The proxy used an isolated Postgres database, a generated virtual key with an alias and user ID but no end-user ID, and Gemini API calls

### Before (ca0b951a43)

#### Terminal callbacks

1. POST requests to `/v1/chat/completions`, `/v1/responses`, `/v1/messages`, streaming chat completions, and Gemini pass-through all returned 200. An invalid model returned 400
2. Each terminal callback retained `user_api_key_alias` and `user_api_key_user_id` in `standard_logging_object.metadata`, retained `user_api_key_end_user_id: null`, and emitted `end_user: ""`

### After (4f827f5fc7)

#### Terminal callbacks

1. The same real Gemini requests returned the same 200 or 400 status
2. Each terminal callback retained the same metadata identity fields and emitted `end_user: null`

## Type

🐛 Bug Fix

## Caveats (if any)

### Low

- Callback consumers should accept `null` for unavailable end-user identity

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/berriai/litellm/pull/38642" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small logging payload semantics change: callback consumers that assumed `end_user` was always a string may need to treat `null` as absent identity.
> 
> **Overview**
> Fixes inconsistent callback payloads where a missing end-user identity was serialized as an empty string instead of **`null`**.
> 
> In **`get_standard_logging_object_payload`**, **`end_user`** is now set directly from **`end_user_id`** (removed **`end_user_id or ""`**), matching **`StandardLoggingPayload`**’s **`end_user: str | None`** and keeping **`metadata.user_api_key_end_user_id`** as **`null`** when absent.
> 
> Adds **`test_get_standard_logging_object_payload_preserves_absent_end_user_as_none`** to assert **`payload["end_user"]`** and related metadata stay **`None`** when no end-user ID is provided.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4f827f5fc759585f7d037dac5135eaee9a8bc0f5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->