### PR TITLE
fix(proxy): register config-file custom loggers as instances so pass-through endpoints reach Langfuse

### DIFF
--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -703,34 +703,7 @@ from litellm.types.secret_managers.main import (
 from litellm.types.utils import CredentialItem, CustomHuggingfaceTokenizer, RawRequestTypedDict, StandardLoggingPayload
 from litellm.types.utils import ModelInfo as ModelMapInfo
 from litellm.utils import _add_custom_logger_callback_to_specific_event
-
-
-def _register_config_custom_logger_callback(callback: str, logging_event: Literal["success", "failure"]) -> None:
-    """Register a config-file custom-logger name as an instance, not a string.
-
-    Pass-through endpoints log through the async success path only; a string in
-    ``litellm.success_callback`` never reaches them. Falls back to the string
-    when the custom-logger class cannot be initialized (e.g. missing env
-    credentials), so standard-route logging still works. Mirrors the DB-config path.
-    """
-    from litellm.litellm_core_utils.litellm_logging import (
-        _init_custom_logger_compatible_class,
-    )
-
-    if (
-        _init_custom_logger_compatible_class(  # pyright: ignore[reportPrivateUsage]  # mirrors DB-config path
-            callback, internal_usage_cache=None, llm_router=None
-        )
-        is None
-    ):
-        if logging_event == "success":
-            litellm.logging_callback_manager.add_litellm_success_callback(callback)
-        else:
-            litellm.logging_callback_manager.add_litellm_failure_callback(callback)
-        return
-    _add_custom_logger_callback_to_specific_event(  # pyright: ignore[reportPrivateUsage]  # mirrors DB-config path
-        callback, logging_event
-    )
+from litellm.utils import register_config_custom_logger_callback
 
 
 try:
@@ -5151,7 +5124,7 @@ class ProxyConfig:
                         # these are litellm callbacks - "langfuse", "sentry", "wandb"
                         else:
                             if callback in litellm._known_custom_logger_compatible_callbacks:
-                                _register_config_custom_logger_callback(callback, "success")
+                                register_config_custom_logger_callback(callback, "success")
                             else:
                                 litellm.logging_callback_manager.add_litellm_success_callback(callback)
                             if "prometheus" in callback:
@@ -5181,7 +5154,7 @@ class ProxyConfig:
                         # these are litellm callbacks - "langfuse", "sentry", "wandb"
                         else:
                             if callback in litellm._known_custom_logger_compatible_callbacks:
-                                _register_config_custom_logger_callback(callback, "failure")
+                                register_config_custom_logger_callback(callback, "failure")
                             else:
                                 litellm.logging_callback_manager.add_litellm_failure_callback(callback)
                     print(  # noqa: T201

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -5121,7 +5121,10 @@ class ProxyConfig:
                             )
                         # these are litellm callbacks - "langfuse", "sentry", "wandb"
                         else:
-                            litellm.logging_callback_manager.add_litellm_success_callback(callback)
+                            if callback in litellm._known_custom_logger_compatible_callbacks:
+                                _add_custom_logger_callback_to_specific_event(callback, "success")
+                            else:
+                                litellm.logging_callback_manager.add_litellm_success_callback(callback)
                             if "prometheus" in callback:
                                 from litellm.integrations.prometheus import (
                                     PrometheusLogger,
@@ -5148,7 +5151,10 @@ class ProxyConfig:
                             )
                         # these are litellm callbacks - "langfuse", "sentry", "wandb"
                         else:
-                            litellm.logging_callback_manager.add_litellm_failure_callback(callback)
+                            if callback in litellm._known_custom_logger_compatible_callbacks:
+                                _add_custom_logger_callback_to_specific_event(callback, "failure")
+                            else:
+                                litellm.logging_callback_manager.add_litellm_failure_callback(callback)
                     print(  # noqa: T201
                         f"{blue_color_code} Initialized Failure Callbacks - {litellm.failure_callback} {reset_color_code}"
                     )

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -5122,7 +5122,14 @@ class ProxyConfig:
                         # these are litellm callbacks - "langfuse", "sentry", "wandb"
                         else:
                             if callback in litellm._known_custom_logger_compatible_callbacks:
-                                _add_custom_logger_callback_to_specific_event(callback, "success")
+                                # drop the string first: _add_custom_logger_callback_to_specific_event
+                                # skips registration (and the string removal inside it) when an
+                                # instance already exists from an earlier registration
+                                if callback in litellm.success_callback:
+                                    litellm.success_callback.remove(callback)
+                                _add_custom_logger_callback_to_specific_event(  # pyright: ignore[reportPrivateUsage]  # mirrors the DB-config registration path
+                                    callback, "success"
+                                )
                             else:
                                 litellm.logging_callback_manager.add_litellm_success_callback(callback)
                             if "prometheus" in callback:
@@ -5152,7 +5159,11 @@ class ProxyConfig:
                         # these are litellm callbacks - "langfuse", "sentry", "wandb"
                         else:
                             if callback in litellm._known_custom_logger_compatible_callbacks:
-                                _add_custom_logger_callback_to_specific_event(callback, "failure")
+                                if callback in litellm.failure_callback:
+                                    litellm.failure_callback.remove(callback)
+                                _add_custom_logger_callback_to_specific_event(  # pyright: ignore[reportPrivateUsage]  # mirrors the DB-config registration path
+                                    callback, "failure"
+                                )
                             else:
                                 litellm.logging_callback_manager.add_litellm_failure_callback(callback)
                     print(  # noqa: T201

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -5127,8 +5127,9 @@ class ProxyConfig:
                                 # instance already exists from an earlier registration
                                 if callback in litellm.success_callback:
                                     litellm.success_callback.remove(callback)
-                                _add_custom_logger_callback_to_specific_event(  # pyright: ignore[reportPrivateUsage]  # mirrors the DB-config registration path
-                                    callback, "success"
+                                _add_custom_logger_callback_to_specific_event(  # pyright: ignore[reportPrivateUsage]
+                                    callback,
+                                    "success",  # mirrors the DB-config registration path
                                 )
                             else:
                                 litellm.logging_callback_manager.add_litellm_success_callback(callback)
@@ -5161,8 +5162,9 @@ class ProxyConfig:
                             if callback in litellm._known_custom_logger_compatible_callbacks:
                                 if callback in litellm.failure_callback:
                                     litellm.failure_callback.remove(callback)
-                                _add_custom_logger_callback_to_specific_event(  # pyright: ignore[reportPrivateUsage]  # mirrors the DB-config registration path
-                                    callback, "failure"
+                                _add_custom_logger_callback_to_specific_event(  # pyright: ignore[reportPrivateUsage]
+                                    callback,
+                                    "failure",  # mirrors the DB-config registration path
                                 )
                             else:
                                 litellm.logging_callback_manager.add_litellm_failure_callback(callback)

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -702,8 +702,7 @@ from litellm.types.secret_managers.main import (
 )
 from litellm.types.utils import CredentialItem, CustomHuggingfaceTokenizer, RawRequestTypedDict, StandardLoggingPayload
 from litellm.types.utils import ModelInfo as ModelMapInfo
-from litellm.utils import _add_custom_logger_callback_to_specific_event
-from litellm.utils import register_config_custom_logger_callback
+from litellm.utils import _add_custom_logger_callback_to_specific_event, register_config_custom_logger_callback
 
 
 try:

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -704,6 +704,18 @@ from litellm.types.utils import CredentialItem, CustomHuggingfaceTokenizer, RawR
 from litellm.types.utils import ModelInfo as ModelMapInfo
 from litellm.utils import _add_custom_logger_callback_to_specific_event
 
+
+def _register_config_custom_logger_callback(callback: str, logging_event: Literal["success", "failure"]) -> None:
+    """Register a config-file custom-logger name as an instance, not a string.
+
+    Pass-through endpoints log through the async success path only; a string in
+    ``litellm.success_callback`` never reaches them. Mirrors the DB-config path.
+    """
+    _add_custom_logger_callback_to_specific_event(  # pyright: ignore[reportPrivateUsage]  # mirrors DB-config path
+        callback, logging_event
+    )
+
+
 try:
     from litellm._version import version
 except Exception:
@@ -5127,10 +5139,7 @@ class ProxyConfig:
                                 # instance already exists from an earlier registration
                                 if callback in litellm.success_callback:
                                     litellm.success_callback.remove(callback)
-                                _add_custom_logger_callback_to_specific_event(  # pyright: ignore[reportPrivateUsage]
-                                    callback,
-                                    "success",  # mirrors the DB-config registration path
-                                )
+                                _register_config_custom_logger_callback(callback, "success")
                             else:
                                 litellm.logging_callback_manager.add_litellm_success_callback(callback)
                             if "prometheus" in callback:
@@ -5162,10 +5171,7 @@ class ProxyConfig:
                             if callback in litellm._known_custom_logger_compatible_callbacks:
                                 if callback in litellm.failure_callback:
                                     litellm.failure_callback.remove(callback)
-                                _add_custom_logger_callback_to_specific_event(  # pyright: ignore[reportPrivateUsage]
-                                    callback,
-                                    "failure",  # mirrors the DB-config registration path
-                                )
+                                _register_config_custom_logger_callback(callback, "failure")
                             else:
                                 litellm.logging_callback_manager.add_litellm_failure_callback(callback)
                     print(  # noqa: T201

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -709,8 +709,25 @@ def _register_config_custom_logger_callback(callback: str, logging_event: Litera
     """Register a config-file custom-logger name as an instance, not a string.
 
     Pass-through endpoints log through the async success path only; a string in
-    ``litellm.success_callback`` never reaches them. Mirrors the DB-config path.
+    ``litellm.success_callback`` never reaches them. Falls back to the string
+    when the custom-logger class cannot be initialized (e.g. missing env
+    credentials), so standard-route logging still works. Mirrors the DB-config path.
     """
+    from litellm.litellm_core_utils.litellm_logging import (
+        _init_custom_logger_compatible_class,
+    )
+
+    if (
+        _init_custom_logger_compatible_class(  # pyright: ignore[reportPrivateUsage]  # mirrors DB-config path
+            callback, internal_usage_cache=None, llm_router=None
+        )
+        is None
+    ):
+        if logging_event == "success":
+            litellm.logging_callback_manager.add_litellm_success_callback(callback)
+        else:
+            litellm.logging_callback_manager.add_litellm_failure_callback(callback)
+        return
     _add_custom_logger_callback_to_specific_event(  # pyright: ignore[reportPrivateUsage]  # mirrors DB-config path
         callback, logging_event
     )
@@ -5134,11 +5151,6 @@ class ProxyConfig:
                         # these are litellm callbacks - "langfuse", "sentry", "wandb"
                         else:
                             if callback in litellm._known_custom_logger_compatible_callbacks:
-                                # drop the string first: _add_custom_logger_callback_to_specific_event
-                                # skips registration (and the string removal inside it) when an
-                                # instance already exists from an earlier registration
-                                if callback in litellm.success_callback:
-                                    litellm.success_callback.remove(callback)
                                 _register_config_custom_logger_callback(callback, "success")
                             else:
                                 litellm.logging_callback_manager.add_litellm_success_callback(callback)
@@ -5169,8 +5181,6 @@ class ProxyConfig:
                         # these are litellm callbacks - "langfuse", "sentry", "wandb"
                         else:
                             if callback in litellm._known_custom_logger_compatible_callbacks:
-                                if callback in litellm.failure_callback:
-                                    litellm.failure_callback.remove(callback)
                                 _register_config_custom_logger_callback(callback, "failure")
                             else:
                                 litellm.logging_callback_manager.add_litellm_failure_callback(callback)

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -5123,7 +5123,7 @@ class ProxyConfig:
                         else:
                             self._add_callback_from_db_to_in_memory_litellm_callbacks(
                                 callback=callback,
-                                event_types=["success"],
+                                event_types=["success"],  # mutable-ok: mirrors the DB-config call site
                                 existing_callbacks=litellm.success_callback,
                             )
                             if "prometheus" in callback:
@@ -5154,7 +5154,7 @@ class ProxyConfig:
                         else:
                             self._add_callback_from_db_to_in_memory_litellm_callbacks(
                                 callback=callback,
-                                event_types=["failure"],
+                                event_types=["failure"],  # mutable-ok: mirrors the DB-config call site
                                 existing_callbacks=litellm.failure_callback,
                             )
                     print(  # noqa: T201

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -702,7 +702,7 @@ from litellm.types.secret_managers.main import (
 )
 from litellm.types.utils import CredentialItem, CustomHuggingfaceTokenizer, RawRequestTypedDict, StandardLoggingPayload
 from litellm.types.utils import ModelInfo as ModelMapInfo
-from litellm.utils import _add_custom_logger_callback_to_specific_event, register_config_custom_logger_callback
+from litellm.utils import _add_custom_logger_callback_to_specific_event
 
 try:
     from litellm._version import version
@@ -5121,10 +5121,11 @@ class ProxyConfig:
                             )
                         # these are litellm callbacks - "langfuse", "sentry", "wandb"
                         else:
-                            if callback in litellm._known_custom_logger_compatible_callbacks:
-                                register_config_custom_logger_callback(callback, "success")
-                            else:
-                                litellm.logging_callback_manager.add_litellm_success_callback(callback)
+                            self._add_callback_from_db_to_in_memory_litellm_callbacks(
+                                callback=callback,
+                                event_types=["success"],
+                                existing_callbacks=litellm.success_callback,
+                            )
                             if "prometheus" in callback:
                                 from litellm.integrations.prometheus import (
                                     PrometheusLogger,
@@ -5151,10 +5152,11 @@ class ProxyConfig:
                             )
                         # these are litellm callbacks - "langfuse", "sentry", "wandb"
                         else:
-                            if callback in litellm._known_custom_logger_compatible_callbacks:
-                                register_config_custom_logger_callback(callback, "failure")
-                            else:
-                                litellm.logging_callback_manager.add_litellm_failure_callback(callback)
+                            self._add_callback_from_db_to_in_memory_litellm_callbacks(
+                                callback=callback,
+                                event_types=["failure"],
+                                existing_callbacks=litellm.failure_callback,
+                            )
                     print(  # noqa: T201
                         f"{blue_color_code} Initialized Failure Callbacks - {litellm.failure_callback} {reset_color_code}"
                     )

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -704,7 +704,6 @@ from litellm.types.utils import CredentialItem, CustomHuggingfaceTokenizer, RawR
 from litellm.types.utils import ModelInfo as ModelMapInfo
 from litellm.utils import _add_custom_logger_callback_to_specific_event, register_config_custom_logger_callback
 
-
 try:
     from litellm._version import version
 except Exception:

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -593,6 +593,28 @@ def _add_custom_logger_callback_to_specific_event(callback: str, logging_event: 
                 litellm.failure_callback.remove(callback)  # remove the string from the callback list
             if callback in litellm._async_failure_callback:
                 litellm._async_failure_callback.remove(callback)  # remove the string from the callback list
+    else:
+        # Custom-logger class could not be initialized (e.g. missing env
+        # credentials). Fall back to string registration so standard-route
+        # logging still works; pass-through endpoints only reach instance
+        # callbacks, so they keep missing out in this degraded state.
+        if logging_event == "success":
+            litellm.logging_callback_manager.add_litellm_success_callback(callback)
+        else:
+            litellm.logging_callback_manager.add_litellm_failure_callback(callback)
+
+
+def register_config_custom_logger_callback(callback: str, logging_event: Literal["success", "failure"]) -> None:
+    """Register a config-file custom-logger name as an instance, not a string.
+
+    Config-file ``success_callback`` / ``failure_callback`` strings previously
+    landed in ``litellm.success_callback`` as bare strings; pass-through
+    endpoints log through the async path only, so they never saw them.
+    Registering the custom-logger instance covers both paths. Falls back to
+    string registration when the class cannot be initialized (e.g. missing env
+    credentials), so standard-route logging keeps working.
+    """
+    _add_custom_logger_callback_to_specific_event(callback, logging_event)
 
 
 def _custom_logger_class_exists_in_success_callbacks(

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -604,19 +604,6 @@ def _add_custom_logger_callback_to_specific_event(callback: str, logging_event: 
             litellm.logging_callback_manager.add_litellm_failure_callback(callback)
 
 
-def register_config_custom_logger_callback(callback: str, logging_event: Literal["success", "failure"]) -> None:
-    """Register a config-file custom-logger name as an instance, not a string.
-
-    Config-file ``success_callback`` / ``failure_callback`` strings previously
-    landed in ``litellm.success_callback`` as bare strings; pass-through
-    endpoints log through the async path only, so they never saw them.
-    Registering the custom-logger instance covers both paths. Falls back to
-    string registration when the class cannot be initialized (e.g. missing env
-    credentials), so standard-route logging keeps working.
-    """
-    _add_custom_logger_callback_to_specific_event(callback, logging_event)
-
-
 def _custom_logger_class_exists_in_success_callbacks(
     callback_class: CustomLogger,
 ) -> bool:

--- a/tests/proxy_unit_tests/test_proxy_config_unit_test.py
+++ b/tests/proxy_unit_tests/test_proxy_config_unit_test.py
@@ -159,7 +159,7 @@ async def test_multiple_includes():
 
 
 @pytest.mark.asyncio
-async def test_config_file_success_callback_registers_custom_logger_instance():
+async def test_config_file_success_callback_registers_custom_logger_instance(monkeypatch):
     """Config-file success_callback must register a custom-logger instance, not just the
     string.
 
@@ -176,8 +176,8 @@ async def test_config_file_success_callback_registers_custom_logger_instance():
         LangfusePromptManagement,
     )
 
-    litellm.success_callback = []
-    litellm._async_success_callback = []
+    monkeypatch.setattr(litellm, "success_callback", [])
+    monkeypatch.setattr(litellm, "_async_success_callback", [])
 
     config_content = {"litellm_settings": {"success_callback": ["langfuse"]}}
     with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as temp_file:
@@ -197,8 +197,6 @@ async def test_config_file_success_callback_registers_custom_logger_instance():
         )
         assert num_langfuse_instances == 1
     finally:
-        litellm.success_callback = []
-        litellm._async_success_callback = []
         os.unlink(temp_file_path)
 
 

--- a/tests/proxy_unit_tests/test_proxy_config_unit_test.py
+++ b/tests/proxy_unit_tests/test_proxy_config_unit_test.py
@@ -180,6 +180,13 @@ async def test_config_file_success_callback_registers_custom_logger_instance(mon
     monkeypatch.setattr(litellm, "_async_success_callback", [])
     monkeypatch.setattr(litellm, "failure_callback", [])
     monkeypatch.setattr(litellm, "_async_failure_callback", [])
+    # test_add_callbacks_from_db_config clears _known_custom_logger_compatible_callbacks
+    # without restoring it (and the conftest snapshot skips underscore attrs), so
+    # re-assert the precondition explicitly instead of depending on test order.
+    known_callbacks = list(getattr(litellm, "_known_custom_logger_compatible_callbacks", []))
+    if "langfuse" not in known_callbacks:
+        known_callbacks.append("langfuse")
+    monkeypatch.setattr(litellm, "_known_custom_logger_compatible_callbacks", known_callbacks)
     # the custom-logger instance path needs env credentials; without them the
     # config path falls back to the string and this test would not exercise
     # the instance registration
@@ -236,6 +243,13 @@ async def test_config_file_callback_falls_back_to_string_when_init_fails(monkeyp
     monkeypatch.setattr(litellm, "_async_success_callback", [])
     monkeypatch.setattr(litellm, "failure_callback", [])
     monkeypatch.setattr(litellm, "_async_failure_callback", [])
+    # same precondition as the sibling instance test: langfuse must be a known
+    # custom-logger name, otherwise the config path skips the helper entirely
+    # and this test would not exercise the fallback branch
+    known_callbacks = list(getattr(litellm, "_known_custom_logger_compatible_callbacks", []))
+    if "langfuse" not in known_callbacks:
+        known_callbacks.append("langfuse")
+    monkeypatch.setattr(litellm, "_known_custom_logger_compatible_callbacks", known_callbacks)
     monkeypatch.setattr(
         "litellm.litellm_core_utils.litellm_logging._init_custom_logger_compatible_class",
         lambda callback, internal_usage_cache=None, llm_router=None: None,

--- a/tests/proxy_unit_tests/test_proxy_config_unit_test.py
+++ b/tests/proxy_unit_tests/test_proxy_config_unit_test.py
@@ -220,6 +220,53 @@ async def test_config_file_success_callback_registers_custom_logger_instance(mon
         os.unlink(temp_file_path)
 
 
+@pytest.mark.asyncio
+async def test_config_file_callback_falls_back_to_string_when_init_fails(monkeypatch):
+    """When the custom-logger class cannot be initialized, config-file callbacks
+    must fall back to string registration so standard-route logging still works."""
+    import tempfile
+
+    import yaml
+
+    from litellm.integrations.langfuse.langfuse_prompt_management import (
+        LangfusePromptManagement,
+    )
+
+    monkeypatch.setattr(litellm, "success_callback", [])
+    monkeypatch.setattr(litellm, "_async_success_callback", [])
+    monkeypatch.setattr(litellm, "failure_callback", [])
+    monkeypatch.setattr(litellm, "_async_failure_callback", [])
+    monkeypatch.setattr(
+        "litellm.litellm_core_utils.litellm_logging._init_custom_logger_compatible_class",
+        lambda callback, internal_usage_cache=None, llm_router=None: None,
+    )
+
+    config_content = {
+        "litellm_settings": {
+            "success_callback": ["langfuse"],
+            "failure_callback": ["langfuse"],
+        }
+    }
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as temp_file:
+        yaml.dump(config_content, temp_file)
+        temp_file_path = temp_file.name
+
+    try:
+        proxy_config = ProxyConfig()
+        await proxy_config.load_config(
+            router=None,
+            config_file_path=temp_file_path,
+        )
+
+        # init failed -> fall back to the string path, standard route keeps logging
+        assert "langfuse" in litellm.success_callback
+        assert "langfuse" in litellm.failure_callback
+        assert not any(isinstance(callback, LangfusePromptManagement) for callback in litellm._async_success_callback)
+        assert not any(isinstance(callback, LangfusePromptManagement) for callback in litellm._async_failure_callback)
+    finally:
+        os.unlink(temp_file_path)
+
+
 def test_add_callbacks_from_db_config():
     """Test that callbacks are added correctly and duplicates are prevented"""
     # Setup

--- a/tests/proxy_unit_tests/test_proxy_config_unit_test.py
+++ b/tests/proxy_unit_tests/test_proxy_config_unit_test.py
@@ -180,6 +180,12 @@ async def test_config_file_success_callback_registers_custom_logger_instance(mon
     monkeypatch.setattr(litellm, "_async_success_callback", [])
     monkeypatch.setattr(litellm, "failure_callback", [])
     monkeypatch.setattr(litellm, "_async_failure_callback", [])
+    # the custom-logger instance path needs env credentials; without them the
+    # config path falls back to the string and this test would not exercise
+    # the instance registration
+    monkeypatch.setenv("LANGFUSE_PUBLIC_KEY", "pk-lf-test")
+    monkeypatch.setenv("LANGFUSE_SECRET_KEY", "sk-lf-test")
+    monkeypatch.setenv("LANGFUSE_HOST", "http://localhost:3000")
 
     config_content = {
         "litellm_settings": {

--- a/tests/proxy_unit_tests/test_proxy_config_unit_test.py
+++ b/tests/proxy_unit_tests/test_proxy_config_unit_test.py
@@ -158,6 +158,50 @@ async def test_multiple_includes():
     assert config["litellm_settings"]["callbacks"] == ["prometheus"]
 
 
+@pytest.mark.asyncio
+async def test_config_file_success_callback_registers_custom_logger_instance():
+    """Config-file success_callback must register a custom-logger instance, not just the
+    string.
+
+    Pass-through endpoints log through the async success path only; string registration
+    leaves langfuse out of both callback lists because
+    `_should_run_sync_callbacks_for_async_calls` filters strings in
+    `_known_custom_logger_compatible_callbacks`.
+    """
+    import tempfile
+
+    import yaml
+
+    from litellm.integrations.langfuse.langfuse_prompt_management import (
+        LangfusePromptManagement,
+    )
+
+    litellm.success_callback = []
+    litellm._async_success_callback = []
+
+    config_content = {"litellm_settings": {"success_callback": ["langfuse"]}}
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as temp_file:
+        yaml.dump(config_content, temp_file)
+        temp_file_path = temp_file.name
+
+    try:
+        proxy_config = ProxyConfig()
+        await proxy_config.load_config(
+            router=None,
+            config_file_path=temp_file_path,
+        )
+
+        assert "langfuse" not in litellm.success_callback
+        num_langfuse_instances = sum(
+            isinstance(callback, LangfusePromptManagement) for callback in litellm._async_success_callback
+        )
+        assert num_langfuse_instances == 1
+    finally:
+        litellm.success_callback = []
+        litellm._async_success_callback = []
+        os.unlink(temp_file_path)
+
+
 def test_add_callbacks_from_db_config():
     """Test that callbacks are added correctly and duplicates are prevented"""
     # Setup

--- a/tests/proxy_unit_tests/test_proxy_config_unit_test.py
+++ b/tests/proxy_unit_tests/test_proxy_config_unit_test.py
@@ -178,8 +178,15 @@ async def test_config_file_success_callback_registers_custom_logger_instance(mon
 
     monkeypatch.setattr(litellm, "success_callback", [])
     monkeypatch.setattr(litellm, "_async_success_callback", [])
+    monkeypatch.setattr(litellm, "failure_callback", [])
+    monkeypatch.setattr(litellm, "_async_failure_callback", [])
 
-    config_content = {"litellm_settings": {"success_callback": ["langfuse"]}}
+    config_content = {
+        "litellm_settings": {
+            "success_callback": ["langfuse", "sentry"],
+            "failure_callback": ["langfuse"],
+        }
+    }
     with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as temp_file:
         yaml.dump(config_content, temp_file)
         temp_file_path = temp_file.name
@@ -191,11 +198,18 @@ async def test_config_file_success_callback_registers_custom_logger_instance(mon
             config_file_path=temp_file_path,
         )
 
+        # custom-logger-compatible names are registered as instances, not strings
         assert "langfuse" not in litellm.success_callback
+        # non-compatible names still take the string path
+        assert "sentry" in litellm.success_callback
         num_langfuse_instances = sum(
             isinstance(callback, LangfusePromptManagement) for callback in litellm._async_success_callback
         )
         assert num_langfuse_instances == 1
+        num_failure_instances = sum(
+            isinstance(callback, LangfusePromptManagement) for callback in litellm._async_failure_callback
+        )
+        assert num_failure_instances == 1
     finally:
         os.unlink(temp_file_path)
 


### PR DESCRIPTION
Config-file `success_callback: ["langfuse"]` currently registers only the string in `litellm.success_callback`. Pass-through requests (`general_settings.pass_through_endpoints`) log through the async success path only: langfuse is absent from `litellm._async_success_callback`, and the sync fallback is gated by `_should_run_sync_callbacks_for_async_calls()`, which filters the string because `langfuse` is in `_known_custom_logger_compatible_callbacks`. Net result: pass-through requests never reach Langfuse, while standard routes log fine.

This routes config-file known custom-logger names through `_add_custom_logger_callback_to_specific_event`, registering a `LangfusePromptManagement` instance in both the sync and async callback lists, matching the DB-config path (`_add_callbacks_from_db_config`). Applies to both success and failure callbacks.

Regression test `test_config_file_success_callback_registers_custom_logger_instance` asserts the string is removed from `litellm.success_callback` and exactly one `LangfusePromptManagement` instance exists in `litellm._async_success_callback` after `load_config`.