### PR TITLE
fix(azure/realtime): mint ephemeral token for transcription sessions

### DIFF
--- a/litellm/llms/azure/realtime/handler.py
+++ b/litellm/llms/azure/realtime/handler.py
@@ -19,6 +19,7 @@ from litellm.constants import (
 from litellm.types.realtime import RealtimeQueryParams
 
 from ....litellm_core_utils.litellm_logging import Logging as LiteLLMLogging
+from ....litellm_core_utils.realtime_errors import websocket_close_reason
 from ....litellm_core_utils.realtime_streaming import (
     RealTimeStreaming,
     ScopedWebSocket,
@@ -242,7 +243,12 @@ class AzureOpenAIRealtime(AzureChatCompletion):
             else None
         )
         if isinstance(minted, _EphemeralMintError):
-            await websocket.close(code=1008, reason=_redact_string(minted.reason)[:120])
+            await websocket.close(
+                code=1008,
+                reason=websocket_close_reason(
+                    _redact_string(minted.reason), fallback="Realtime transcription session error"
+                ),
+            )
             return
 
         url: Final = self._construct_url(
@@ -280,6 +286,9 @@ class AzureOpenAIRealtime(AzureChatCompletion):
                 await realtime_streaming.bidirectional_forward()
 
         except websockets.exceptions.InvalidStatusCode as e:
-            await websocket.close(code=e.status_code, reason=_redact_string(str(e)))
+            await websocket.close(
+                code=e.status_code,
+                reason=websocket_close_reason(_redact_string(str(e)), fallback="Invalid status code"),
+            )
         except Exception:
             verbose_proxy_logger.exception("Error in AzureOpenAIRealtime.async_realtime")

--- a/litellm/llms/azure/realtime/handler.py
+++ b/litellm/llms/azure/realtime/handler.py
@@ -5,11 +5,17 @@ This requires websockets, and is currently only supported on LiteLLM Proxy.
 """
 
 from collections.abc import Mapping
+from dataclasses import dataclass
 from types import MappingProxyType
 from typing import Any, Final, Protocol, cast
 
+from pydantic import BaseModel, ValidationError
+
 from litellm._logging import _redact_string, verbose_proxy_logger
-from litellm.constants import REALTIME_WEBSOCKET_MAX_MESSAGE_SIZE_BYTES
+from litellm.constants import (
+    REALTIME_CREDENTIAL_RESOLUTION_TIMEOUT_SECONDS,
+    REALTIME_WEBSOCKET_MAX_MESSAGE_SIZE_BYTES,
+)
 from litellm.types.realtime import RealtimeQueryParams
 
 from ....litellm_core_utils.litellm_logging import Logging as LiteLLMLogging
@@ -19,9 +25,14 @@ from ....litellm_core_utils.realtime_streaming import (
     client_sent_openai_beta_realtime_header,
 )
 from ....llms.custom_httpx.http_handler import get_shared_realtime_ssl_context
+from ....llms.custom_httpx.llm_http_handler import BaseLLMHTTPHandler
 from ..azure import AzureChatCompletion
+from .http_transformation import AzureRealtimeHTTPConfig
 
 # BACKEND_WS_URL = "ws://localhost:8080/v1/realtime?model=gpt-4o-realtime-preview-2024-10-01"
+
+_http_handler: Final = BaseLLMHTTPHandler()
+_azure_realtime_http_config: Final = AzureRealtimeHTTPConfig()
 
 
 async def forward_messages(client_ws: Any, backend_ws: Any):
@@ -52,6 +63,24 @@ class _ProxyClientWebSocket(Protocol):
     """Client-facing websocket handle: this path only closes it after a failed handshake."""
 
     async def close(self, code: int = ..., reason: str | None = ...) -> None: ...
+
+
+@dataclass(frozen=True, slots=True)
+class _EphemeralKey:
+    value: str
+
+
+@dataclass(frozen=True, slots=True)
+class _EphemeralMintError:
+    reason: str
+
+
+class _AzureClientSecret(BaseModel):
+    value: str
+
+
+class _AzureTranscriptionSessionResponse(BaseModel):
+    client_secret: _AzureClientSecret
 
 
 class AzureOpenAIRealtime(AzureChatCompletion):
@@ -124,6 +153,52 @@ class AzureOpenAIRealtime(AzureChatCompletion):
         qs: Final = "&".join(query_parts)
         return f"{api_base}{path}?{qs}" if qs else f"{api_base}{path}"
 
+    async def _mint_transcription_session_key(
+        self,
+        api_base: str,
+        model: str,
+        api_key: str | None,
+        azure_ad_token: str | None,
+        api_version: str | None,
+        timeout: float | None,
+        logging_obj: LiteLLMLogging,
+        http_handler: BaseLLMHTTPHandler | None,
+    ) -> _EphemeralKey | _EphemeralMintError:
+        """
+        Azure rejects a standing api-key on the realtime transcription socket with
+        "This operation requires ephemeral authentication". Exchange the standing
+        credential for a short-lived client secret via POST
+        /openai/realtime/transcription_sessions and connect the socket with that.
+        """
+        if not api_key and not azure_ad_token:
+            return _EphemeralMintError(
+                "Missing Azure credentials to mint a realtime transcription session. "
+                "Set an api_key, or configure Azure AD auth"
+            )
+        bearer: Final[dict[str, object]] = {"Authorization": f"Bearer {azure_ad_token}"}  # mutable-ok: request headers
+        handler: Final = http_handler if http_handler is not None else _http_handler
+        try:
+            response: Final = await handler.async_realtime_transcription_session_handler(
+                api_base=api_base,
+                api_key=api_key or "",
+                request_data={"input_audio_transcription": {"model": model}},  # mutable-ok: one-shot httpx request body
+                logging_obj=logging_obj,
+                timeout=timeout or REALTIME_CREDENTIAL_RESOLUTION_TIMEOUT_SECONDS,
+                provider_config=_azure_realtime_http_config,
+                model=model,
+                extra_headers=None if api_key else bearer,
+                api_version=api_version,
+            )
+        except Exception as e:  # noqa: BLE001  # upstream failure is surfaced to the client as a socket close reason
+            return _EphemeralMintError(f"Azure realtime transcription session request failed: {_redact_string(str(e))}")
+        try:
+            parsed: Final = _AzureTranscriptionSessionResponse.model_validate(response.json())
+        except (ValidationError, ValueError) as e:
+            return _EphemeralMintError(
+                f"Azure realtime transcription session response was not understood: {_redact_string(str(e))}"
+            )
+        return _EphemeralKey(parsed.client_secret.value)
+
     async def async_realtime(
         self,
         model: str,
@@ -139,6 +214,7 @@ class AzureOpenAIRealtime(AzureChatCompletion):
         query_params: RealtimeQueryParams | None = None,
         user_api_key_dict: object | None = None,
         litellm_metadata: dict | None = None,
+        http_handler: BaseLLMHTTPHandler | None = None,
     ):
         import websockets
         from websockets.asyncio.client import ClientConnection
@@ -149,6 +225,26 @@ class AzureOpenAIRealtime(AzureChatCompletion):
         if api_version is None and backend_uses_beta_protocol:
             raise ValueError("api_version is required for Azure OpenAI calls")
 
+        is_transcription: Final = (query_params or {}).get("intent") == "transcription"
+
+        minted: Final = (
+            await self._mint_transcription_session_key(
+                api_base=api_base,
+                model=model,
+                api_key=api_key,
+                azure_ad_token=azure_ad_token,
+                api_version=api_version,
+                timeout=timeout,
+                logging_obj=logging_obj,
+                http_handler=http_handler,
+            )
+            if is_transcription
+            else None
+        )
+        if isinstance(minted, _EphemeralMintError):
+            await websocket.close(code=1008, reason=_redact_string(minted.reason)[:120])
+            return
+
         url: Final = self._construct_url(
             api_base,
             model,
@@ -157,7 +253,11 @@ class AzureOpenAIRealtime(AzureChatCompletion):
             query_params=query_params,
         )
 
-        auth_headers: Final = self.get_auth_headers(api_key=api_key, azure_ad_token=azure_ad_token)
+        auth_headers: Final = (
+            self.get_auth_headers(api_key=minted.value, azure_ad_token=None)
+            if isinstance(minted, _EphemeralKey)
+            else self.get_auth_headers(api_key=api_key, azure_ad_token=azure_ad_token)
+        )
 
         try:
             ssl_context: Final = get_shared_realtime_ssl_context()
@@ -175,9 +275,7 @@ class AzureOpenAIRealtime(AzureChatCompletion):
                     user_api_key_dict=user_api_key_dict,
                     request_data={"litellm_metadata": litellm_metadata or {}},
                     backend_uses_beta_protocol=backend_uses_beta_protocol,
-                    force_transcription_model=(
-                        model if (query_params or {}).get("intent") == "transcription" else None
-                    ),
+                    force_transcription_model=(model if is_transcription else None),
                 )
                 await realtime_streaming.bidirectional_forward()
 

--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -5846,6 +5846,24 @@
             "/v1/audio/transcriptions"
         ]
     },
+    "azure/gpt-live-transcribe": {
+        "input_cost_per_second": 0.0002833333333333333,
+        "litellm_provider": "azure",
+        "mode": "audio_transcription",
+        "source": "https://learn.microsoft.com/en-us/azure/ai-foundry/openai/concepts/models",
+        "supported_endpoints": [
+            "/v1/realtime",
+            "/v1/realtime/transcription_sessions"
+        ],
+        "supported_modalities": [
+            "text",
+            "audio"
+        ],
+        "supported_output_modalities": [
+            "text"
+        ],
+        "supports_audio_input": true
+    },
     "azure/gpt-realtime-whisper": {
         "input_cost_per_second": 0.0002833333333333333,
         "litellm_provider": "azure",

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -5846,6 +5846,24 @@
             "/v1/audio/transcriptions"
         ]
     },
+    "azure/gpt-live-transcribe": {
+        "input_cost_per_second": 0.0002833333333333333,
+        "litellm_provider": "azure",
+        "mode": "audio_transcription",
+        "source": "https://learn.microsoft.com/en-us/azure/ai-foundry/openai/concepts/models",
+        "supported_endpoints": [
+            "/v1/realtime",
+            "/v1/realtime/transcription_sessions"
+        ],
+        "supported_modalities": [
+            "text",
+            "audio"
+        ],
+        "supported_output_modalities": [
+            "text"
+        ],
+        "supports_audio_input": true
+    },
     "azure/gpt-realtime-whisper": {
         "input_cost_per_second": 0.0002833333333333333,
         "litellm_provider": "azure",

--- a/tests/test_litellm/llms/azure/realtime/test_azure_realtime_handler.py
+++ b/tests/test_litellm/llms/azure/realtime/test_azure_realtime_handler.py
@@ -6,7 +6,6 @@ import pytest
 from litellm.llms.custom_httpx.http_handler import get_shared_realtime_ssl_context
 
 
-
 @pytest.mark.asyncio
 async def test_async_realtime_uses_max_size_parameter():
     """
@@ -15,7 +14,6 @@ async def test_async_realtime_uses_max_size_parameter():
 
     This verifies the fix for: https://github.com/BerriAI/litellm/issues/15747
     """
-    from litellm.constants import REALTIME_WEBSOCKET_MAX_MESSAGE_SIZE_BYTES
     from litellm.llms.azure.realtime.handler import AzureOpenAIRealtime
 
     handler = AzureOpenAIRealtime()
@@ -432,7 +430,6 @@ async def test_realtime_protocol_env_var_fallback():
     Test that LITELLM_AZURE_REALTIME_PROTOCOL env var is used as fallback.
     Fixes #22127: no way to set realtime_protocol from config.
     """
-    from litellm.realtime_api.main import _arealtime
     from litellm.types.router import GenericLiteLLMParams
 
     with patch.dict(os.environ, {"LITELLM_AZURE_REALTIME_PROTOCOL": "v1"}):
@@ -739,6 +736,216 @@ async def test_realtime_health_check_uses_bearer_token_when_no_api_key(monkeypat
         is True
     )
     assert connect_calls[0]["additional_headers"] == {"Authorization": "Bearer my-entra-token"}
+
+
+def _mint_handler(value="ephemeral-xyz", side_effect=None):
+    from litellm.llms.custom_httpx.llm_http_handler import BaseLLMHTTPHandler
+
+    response = MagicMock()
+    response.json.return_value = {"client_secret": {"value": value}}
+    handler = MagicMock(spec=BaseLLMHTTPHandler)
+    handler.async_realtime_transcription_session_handler = AsyncMock(
+        return_value=response, side_effect=side_effect
+    )
+    return handler
+
+
+@pytest.mark.asyncio
+async def test_async_realtime_transcription_intent_mints_ephemeral_key():
+    """
+    Azure rejects a standing api-key on the realtime transcription socket
+    ("This operation requires ephemeral authentication"). The handler must first
+    POST /openai/realtime/transcription_sessions with the standing credential and
+    open the socket with the returned client_secret instead.
+
+    Regression test for https://github.com/BerriAI/litellm/issues/38635
+    """
+    from litellm.llms.azure.realtime.handler import AzureOpenAIRealtime, AzureRealtimeHTTPConfig
+
+    handler = AzureOpenAIRealtime()
+    http_handler = _mint_handler("ephemeral-xyz")
+
+    mock_backend_ws = AsyncMock()
+    with (
+        patch(
+            "websockets.connect",
+            return_value=_DummyAsyncContextManager(mock_backend_ws),
+        ) as mock_ws_connect,
+        patch(  # test-quality-ok: the streaming loop is covered elsewhere, only the handshake auth is under test
+            "litellm.llms.azure.realtime.handler.RealTimeStreaming"
+        ) as mock_realtime_streaming,
+    ):
+        mock_realtime_streaming.return_value.bidirectional_forward = AsyncMock()
+
+        await handler.async_realtime(
+            model="gpt-live-transcribe",
+            websocket=AsyncMock(),
+            logging_obj=MagicMock(),
+            api_base="https://my-endpoint.openai.azure.com",
+            api_key="static-key",
+            api_version="2025-04-01-preview",
+            realtime_protocol="GA",
+            query_params={"intent": "transcription"},
+            http_handler=http_handler,
+        )
+
+    http_handler.async_realtime_transcription_session_handler.assert_awaited_once()
+    mint_kwargs = http_handler.async_realtime_transcription_session_handler.call_args.kwargs
+    assert mint_kwargs["api_base"] == "https://my-endpoint.openai.azure.com"
+    assert mint_kwargs["api_key"] == "static-key"
+    assert mint_kwargs["api_version"] == "2025-04-01-preview"
+    assert mint_kwargs["request_data"] == {"input_audio_transcription": {"model": "gpt-live-transcribe"}}
+    assert isinstance(mint_kwargs["provider_config"], AzureRealtimeHTTPConfig)
+    assert mint_kwargs["extra_headers"] is None
+
+    assert mock_ws_connect.call_args.kwargs["additional_headers"] == {"api-key": "ephemeral-xyz"}
+
+
+@pytest.mark.asyncio
+async def test_async_realtime_transcription_intent_mints_with_entra_token():
+    """An Entra ID-only deployment mints the session with a bearer token."""
+    from litellm.llms.azure.realtime.handler import AzureOpenAIRealtime
+
+    handler = AzureOpenAIRealtime()
+    http_handler = _mint_handler("ephemeral-abc")
+
+    with (
+        patch(
+            "websockets.connect",
+            return_value=_DummyAsyncContextManager(AsyncMock()),
+        ) as mock_ws_connect,
+        patch(  # test-quality-ok: only the handshake auth is under test here
+            "litellm.llms.azure.realtime.handler.RealTimeStreaming"
+        ) as mock_realtime_streaming,
+    ):
+        mock_realtime_streaming.return_value.bidirectional_forward = AsyncMock()
+
+        await handler.async_realtime(
+            model="gpt-live-transcribe",
+            websocket=AsyncMock(),
+            logging_obj=MagicMock(),
+            api_base="https://my-endpoint.openai.azure.com",
+            api_key=None,
+            api_version="2025-04-01-preview",
+            azure_ad_token="my-entra-token",
+            realtime_protocol="GA",
+            query_params={"intent": "transcription"},
+            http_handler=http_handler,
+        )
+
+    mint_kwargs = http_handler.async_realtime_transcription_session_handler.call_args.kwargs
+    assert mint_kwargs["api_key"] == ""
+    assert mint_kwargs["extra_headers"] == {"Authorization": "Bearer my-entra-token"}
+    assert mock_ws_connect.call_args.kwargs["additional_headers"] == {"api-key": "ephemeral-abc"}
+
+
+@pytest.mark.asyncio
+async def test_non_transcription_realtime_keeps_static_key():  # test-quality-ok: injected minter raises if called
+    """
+    A normal realtime session opens the backend socket with the static api-key,
+    unchanged. A minting http_handler that raises would surface if it were called.
+    """
+    from litellm.llms.azure.realtime.handler import AzureOpenAIRealtime
+
+    handler = AzureOpenAIRealtime()
+    http_handler = _mint_handler(side_effect=AssertionError("must not mint for a non-transcription session"))
+
+    with (
+        patch(
+            "websockets.connect",
+            return_value=_DummyAsyncContextManager(AsyncMock()),
+        ) as mock_ws_connect,
+        patch(  # test-quality-ok: only the handshake auth is under test here
+            "litellm.llms.azure.realtime.handler.RealTimeStreaming"
+        ) as mock_realtime_streaming,
+    ):
+        mock_realtime_streaming.return_value.bidirectional_forward = AsyncMock()
+
+        await handler.async_realtime(
+            model="gpt-4o-realtime-preview",
+            websocket=AsyncMock(),
+            logging_obj=MagicMock(),
+            api_base="https://my-endpoint.openai.azure.com",
+            api_key="static-key",
+            api_version="2025-04-01-preview",
+            realtime_protocol="GA",
+            query_params={"model": "gpt-4o-realtime-preview"},
+            http_handler=http_handler,
+        )
+
+    assert mock_ws_connect.call_args.kwargs["additional_headers"] == {"api-key": "static-key"}
+    assert mock_realtime_streaming.call_args.kwargs["force_transcription_model"] is None
+
+
+@pytest.mark.asyncio
+async def test_async_realtime_transcription_mint_failure_closes_client_socket():
+    """
+    A failed ephemeral mint must close the client socket with a readable reason
+    instead of letting the raw upstream 401 bubble through the socket.
+    """
+    from litellm.llms.azure.realtime.handler import AzureOpenAIRealtime
+
+    handler = AzureOpenAIRealtime()
+    http_handler = _mint_handler(side_effect=Exception("401 Unauthorized"))
+
+    client_ws = AsyncMock()
+    with patch("websockets.connect") as mock_ws_connect:
+        await handler.async_realtime(
+            model="gpt-live-transcribe",
+            websocket=client_ws,
+            logging_obj=MagicMock(),
+            api_base="https://my-endpoint.openai.azure.com",
+            api_key="static-key",
+            api_version="2025-04-01-preview",
+            realtime_protocol="GA",
+            query_params={"intent": "transcription"},
+            http_handler=http_handler,
+        )
+
+    mock_ws_connect.assert_not_called()
+    client_ws.close.assert_awaited_once()
+    close_kwargs = client_ws.close.call_args.kwargs
+    assert close_kwargs["code"] == 1008
+    assert "transcription session" in close_kwargs["reason"]
+
+
+@pytest.mark.asyncio
+async def test_async_realtime_transcription_missing_credentials_closes_client_socket():
+    """No api_key and no Entra token means there is nothing to exchange for a session."""
+    from litellm.llms.azure.realtime.handler import AzureOpenAIRealtime
+
+    handler = AzureOpenAIRealtime()
+    client_ws = AsyncMock()
+    with patch("websockets.connect") as mock_ws_connect:
+        await handler.async_realtime(
+            model="gpt-live-transcribe",
+            websocket=client_ws,
+            logging_obj=MagicMock(),
+            api_base="https://my-endpoint.openai.azure.com",
+            api_key=None,
+            api_version="2025-04-01-preview",
+            realtime_protocol="GA",
+            query_params={"intent": "transcription"},
+        )
+
+    mock_ws_connect.assert_not_called()
+    client_ws.close.assert_awaited_once()
+    close_kwargs = client_ws.close.call_args.kwargs
+    assert close_kwargs["code"] == 1008
+    assert "Missing Azure credentials" in close_kwargs["reason"]
+
+
+def test_azure_gpt_live_transcribe_is_registered(local_model_cost_map):
+    """
+    `azure/gpt-live-transcribe` must be in the model registry so routing infers the
+    transcription mode and cost tracking has an entry to key on.
+    """
+    import litellm
+
+    info = litellm.get_model_info(model="gpt-live-transcribe", custom_llm_provider="azure")
+    assert info["litellm_provider"] == "azure"
+    assert info["mode"] == "audio_transcription"
+    assert "/v1/realtime/transcription_sessions" in (info.get("supported_endpoints") or [])
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## TLDR

Problem this solves:

- Azure realtime transcription over the proxy fails with "requires ephemeral authentication"
- `azure/gpt-live-transcribe` is not in the model map, so routing and cost tracking miss it

How it solves it:

- Exchange the standing api-key or Entra token for a short-lived client secret first
- Open the Azure transcription socket with that ephemeral secret
- Close the client socket with a readable reason when the exchange fails
- Register `azure/gpt-live-transcribe` so transcription mode is inferred

## User Flow

Before: a developer points the proxy at an Azure AI Foundry `gpt-live-transcribe` deployment and every realtime transcription connection is rejected

1. The proxy admin adds a model with `model: azure/gpt-live-transcribe`, `api_base`, `api_key`, `api_version: 2025-04-01-preview` and restarts the proxy
2. The developer opens a WebSocket to `ws://litellm-domain/v1/realtime?model=gpt-live-transcribe&intent=transcription`
3. The socket is closed almost immediately and the error text reads `{"error":{"code":"Unauthorized","message":"This operation requires ephemeral authentication."}}`
4. No transcription events ever arrive

After: the same connection opens and streams transcripts

1. The proxy admin adds the same model and restarts the proxy
2. The developer opens the same WebSocket to `ws://litellm-domain/v1/realtime?model=gpt-live-transcribe&intent=transcription`
3. The proxy calls Azure's `transcription_sessions` endpoint with the configured credential, gets a short-lived secret, and connects the upstream socket with it
4. The socket stays open, the developer streams PCM16 audio, and `conversation.item.input_audio_transcription.completed` events come back with text
5. If the credential is wrong, the socket closes with a readable reason like `Azure realtime transcription session request failed: ...` instead of the raw upstream 401

## Relevant issues

Fixes #38635

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/llms/azure/realtime/test_azure_realtime_handler.py -v`
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile Confidence Score of at least 4/5 before requesting a maintainer review

## Root cause

`gpt-live-transcribe` is Azure's streaming transcription model, the Azure sibling of `azure/gpt-realtime-whisper`. Two things were missing.

First, `azure/gpt-live-transcribe` was not in `model_prices_and_context_window.json`, so `_is_transcription_only_realtime_model` in `litellm/realtime_api/main.py:560` could not infer the mode and cost tracking had nothing to key on.

Second, the Azure realtime WebSocket handler never minted an ephemeral token. The flow for a transcription connection is `proxy_server.py:11128` routes `intent=transcription` to the realtime handler, `litellm/realtime_api/main.py:403` sets `realtime_protocol="GA"` for that intent and calls `azure_realtime.async_realtime`, and `litellm/llms/azure/realtime/handler.py` opened the upstream socket straight away with `{"api-key": <standing key>}`. Azure's realtime transcription intent does not accept a standing key on the socket. It requires `POST .../openai/realtime/transcription_sessions` with the standing credential to get a `client_secret`, then a socket authenticated with that secret. LiteLLM already had this plumbing for the WebRTC HTTP path (`AzureRealtimeHTTPConfig.get_transcription_session_url`), the WebSocket handler just did not use it. OpenAI's own realtime accepts a normal key here, which is why only Azure tripped.

## The fix

`AzureOpenAIRealtime.async_realtime` now detects `intent=transcription` and, before connecting the upstream socket, calls `async_realtime_transcription_session_handler` with the resolved api-key or Entra token to mint a `client_secret`. The socket then connects with that secret. Minting is skipped entirely for non-transcription realtime sessions, so nothing changes there. If minting fails or the response is missing the secret, the client socket is closed with code 1008 and a readable reason rather than letting the raw upstream 401 surface. The minter is injected so it can be faked in tests. `azure/gpt-live-transcribe` is added to the model map, mirroring `azure/gpt-realtime-whisper`.

## Type

🐛 Bug Fix

## Caveats (if any)

### Medium

- Azure's websocket transcription over `transcription_sessions` is partly preview. The exact upstream host and header for the ephemeral socket may need a small tweak once verified against a live Foundry resource. The mint step itself is required regardless.

### Low

- Entra ID only deployments send an empty `api-key` header alongside the bearer token on the mint call. If Azure rejects that, a follow-up can teach `AzureRealtimeHTTPConfig` to emit only the bearer header.

## Screenshots / Proof of Fix

Shared setup. Add to the proxy config and restart, replacing the env vars with a real Azure AI Foundry `gpt-live-transcribe` deployment:

```yaml
model_list:
  - model_name: gpt-live-transcribe
    litellm_params:
      model: azure/gpt-live-transcribe
      api_key: os.environ/AZURE_GPT_LIVE_TRANSCRIBE_API_KEY
      api_base: os.environ/AZURE_GPT_LIVE_TRANSCRIBE_API_BASE
      api_version: 2025-04-01-preview
```

Run the proxy with `python litellm/proxy/proxy_cli.py --config <config>.yaml --detailed_debug`

### Before (2b10dc5)

#### realtime transcription connection is rejected

1. Install a small websocket client: `pip install websockets`
2. Connect and read the first frame:
   ```bash
   python -c "
   import asyncio, websockets
   async def main():
       async with websockets.connect('ws://localhost:4000/v1/realtime?model=gpt-live-transcribe&intent=transcription', additional_headers={'api-key': 'sk-1234'}) as ws:
           print(await ws.recv())
   asyncio.run(main())
   "
   ```
3. Observe the connection close with `This operation requires ephemeral authentication` and `No fallback model group found for original model_group=gpt-live-transcribe`

### After (9da7ab1)

#### realtime transcription session mints and opens

1. First confirm the HTTP session endpoint returns an ephemeral secret:
   ```bash
   curl -sS http://localhost:4000/v1/realtime/transcription_sessions \
     -H "Authorization: Bearer sk-1234" \
     -H "Content-Type: application/json" \
     -d '{"model": "gpt-live-transcribe", "input_audio_transcription": {"model": "gpt-live-transcribe"}}'
   ```
2. Expect a JSON body with `client_secret.value` set
3. Open the realtime websocket:
   ```bash
   python -c "
   import asyncio, json, websockets
   async def main():
       async with websockets.connect('ws://localhost:4000/v1/realtime?model=gpt-live-transcribe&intent=transcription', additional_headers={'api-key': 'sk-1234'}) as ws:
           for _ in range(2):
               print(await ws.recv())
   asyncio.run(main())
   "
   ```
4. Expect a `transcription_session.created` (or `session.created`) event and the socket staying open, not a close with an auth error

#### wrong credential closes with a readable reason

1. Set a bad `api_key` on the model in the config and restart
2. Run the same websocket command as above
3. Expect the socket to close with a reason starting `Azure realtime transcription session request failed:` instead of a bare 401

## QA runbook

- tests/test_litellm/llms/azure/realtime/test_azure_realtime_handler.py::test_async_realtime_transcription_intent_mints_ephemeral_key - a transcription connection mints a client secret and opens the upstream socket with it
  - [ ] Start the proxy with the config above pointed at a real `gpt-live-transcribe` deployment
  - [ ] Run the After step 3 websocket command with the correct `api-key`
  - [ ] Expect a session-created event and the socket staying open
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey; it asserts the minted secret value reaches the upstream handshake headers, not just that a mock was called
- tests/test_litellm/llms/azure/realtime/test_azure_realtime_handler.py::test_async_realtime_transcription_intent_mints_with_entra_token - an Entra ID only deployment mints the session with a bearer token
  - [ ] Configure the model with `tenant_id`, `client_id`, `client_secret` and no `api_key`
  - [ ] Run the After step 3 websocket command
  - [ ] Expect the same session-created event; the proxy log shows the mint call carrying `Authorization: Bearer`
  - [ ] Sanity check: asserts the bearer header on the mint call and the ephemeral key on the handshake
- tests/test_litellm/llms/azure/realtime/test_azure_realtime_handler.py::test_non_transcription_realtime_keeps_static_key - a normal realtime session never touches the transcription_sessions endpoint
  - [ ] Open `ws://localhost:4000/v1/realtime?model=<a normal azure realtime deployment>` with no `intent`
  - [ ] Expect it to connect as before with the static api-key
  - [ ] Sanity check: the injected minter raises if it is called, so a regression that mints for every session fails the test
- tests/test_litellm/llms/azure/realtime/test_azure_realtime_handler.py::test_async_realtime_transcription_mint_failure_closes_client_socket - a failed mint closes the client socket with a readable reason
  - [ ] Set a bad `api_key` on the model and restart
  - [ ] Run the After step 3 websocket command
  - [ ] Expect a close with code 1008 and a reason starting `Azure realtime transcription session request failed:`
  - [ ] Sanity check: asserts the close code and reason text, and that the upstream socket is never opened
- tests/test_litellm/llms/azure/realtime/test_azure_realtime_handler.py::test_azure_gpt_live_transcribe_is_registered - the model map has an `azure/gpt-live-transcribe` entry with the transcription mode and endpoint
  - [ ] `curl -sS http://localhost:4000/model/info -H "Authorization: Bearer sk-1234" | grep -A5 gpt-live-transcribe`
  - [ ] Expect `mode: audio_transcription` and `/v1/realtime/transcription_sessions` in `supported_endpoints`
  - [ ] Sanity check: reads the real registry entry, not a stubbed value

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
