### PR TITLE
fix(vertex_ai): allow google search grounding with function tools on Gemini 3+ models

### DIFF
--- a/litellm/llms/gemini/common_utils.py
+++ b/litellm/llms/gemini/common_utils.py
@@ -237,8 +237,6 @@ def map_gemini_image_tools_params(
         search_tool: Final = gemini_config._map_web_search_options(web_search_options)
         result = gemini_config._add_tools_to_optional_params(result, [search_tool])
 
-    gemini_config._drop_search_tools_mixed_with_functions(result)
-
     if isinstance(result.get("tools"), list):
         result["tools"] = _dedupe_gemini_search_tools(result["tools"])
 

--- a/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
+++ b/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
@@ -370,36 +370,31 @@ class VertexGeminiConfig(VertexAIBaseConfig, BaseConfig):
     def _drop_search_tools_mixed_with_functions(cls, optional_params: dict) -> None:
         """
         Drop search tools from optional_params when mixed with function declarations
-        and include_server_side_tool_invocations is not enabled.
-
-        Runs after map_openai_params merges tools and web_search_options so both
-        code paths (single _map_function call vs split tools + web_search_options)
-        get the same conflict resolution.
+        on Gemini models older than Gemini 3 to avoid upstream 400 errors.
         """
         if optional_params.get("include_server_side_tool_invocations"):
             return
 
-        tools: Final = optional_params.get("tools")
+        tools = optional_params.get("tools")
         if not isinstance(tools, list) or not tools:
             return
 
-        search_tool_keys: Final = cls._search_tool_keys()
+        search_tool_keys = cls._search_tool_keys()
         has_function_declarations = any(isinstance(tool, dict) and tool.get("function_declarations") for tool in tools)
         if not has_function_declarations:
             return
 
-        has_search_tools: Final = any(
+        has_search_tools = any(
             isinstance(tool, dict) and any(key in tool for key in search_tool_keys) for tool in tools
         )
         if not has_search_tools:
             return
 
         verbose_logger.warning(
-            "Vertex AI does not support mixing function declarations with "
-            "search tools (googleSearch, enterpriseWebSearch, urlContext, "
-            "googleSearchRetrieval) in the same request. Dropping search "
-            "tools and keeping function declarations. To use search tools, "
-            "send a request without function calling tools."
+            "Vertex AI models older than Gemini 3 do not support mixing function "
+            "declarations with search tools (googleSearch, enterpriseWebSearch, urlContext, "
+            "googleSearchRetrieval) in the same request. Dropping search tools and keeping "
+            "function declarations. Upgrade to Gemini 3+ to use function calling and search grounding together."
         )
         optional_params["tools"] = [
             tool for tool in tools if not (isinstance(tool, dict) and any(key in tool for key in search_tool_keys))
@@ -512,56 +507,6 @@ class VertexGeminiConfig(VertexAIBaseConfig, BaseConfig):
         else:
             return None
 
-    @staticmethod
-    def _resolve_search_tool_conflict(
-        gtool_func_declarations: list,
-        googleSearch: dict | None,
-        googleSearchRetrieval: dict | None,
-        enterpriseWebSearch: dict | None,
-        urlContext: dict | None,
-        optional_params: dict,
-    ) -> tuple:
-        """
-        Resolve Vertex AI constraint: multiple Tool objects in a request must
-        ALL be search tools. When function declarations are mixed with search
-        tools, drop search tools to avoid 400 error.
-
-        Skip when include_server_side_tool_invocations is enabled (Gemini 3+
-        supports tool combination natively).
-
-        Note: code_execution, computerUse, and googleMaps are NOT search tools
-        and CAN coexist with function declarations, so they are preserved.
-
-        Ref: https://github.com/BerriAI/litellm/issues/23337
-
-        Returns:
-            tuple of (googleSearch, googleSearchRetrieval, enterpriseWebSearch, urlContext)
-        """
-        has_search_tools: Final = any(
-            v is not None
-            for v in [
-                googleSearch,
-                googleSearchRetrieval,
-                enterpriseWebSearch,
-                urlContext,
-            ]
-        )
-        server_side_tool_invocations: Final = optional_params.get("include_server_side_tool_invocations", False)
-        if gtool_func_declarations and has_search_tools and not server_side_tool_invocations:
-            verbose_logger.warning(
-                "Vertex AI does not support mixing function declarations with "
-                "search tools (googleSearch, enterpriseWebSearch, urlContext, "
-                "googleSearchRetrieval) in the same request. Dropping search "
-                "tools and keeping function declarations. To use search tools, "
-                "send a request without function calling tools."
-            )
-            googleSearch = None
-            googleSearchRetrieval = None
-            enterpriseWebSearch = None
-            urlContext = None
-
-        return googleSearch, googleSearchRetrieval, enterpriseWebSearch, urlContext
-
     def _map_function(self, value: list[dict], optional_params: dict) -> list[Tools]:
         """
         Map OpenAI-style tools/functions to Vertex AI format.
@@ -611,14 +556,18 @@ class VertexGeminiConfig(VertexAIBaseConfig, BaseConfig):
             if "type" in tool and tool["type"] == "computer_use":
                 computer_use_config = {k: v for k, v in tool.items() if k != "type"}
                 tool = {VertexToolName.COMPUTER_USE.value: computer_use_config}
-            # Handle OpenAI-style web_search and web_search_preview tools
-            # Transform them to Gemini's googleSearch tool
             elif "type" in tool and tool["type"] in (
                 "web_search",
                 "web_search_preview",
+                "google_search",
+                "googleSearch",
             ):
                 verbose_logger.info("Gemini: Transforming OpenAI-style '%s' tool to googleSearch", tool["type"])
-                tool = {VertexToolName.GOOGLE_SEARCH.value: {}}
+                tool = {
+                    VertexToolName.GOOGLE_SEARCH.value: (
+                        tool.get(tool["type"]) or tool.get("googleSearch") or tool.get("google_search") or {}
+                    )
+                }
             # Handle tools with 'type' field (OpenAI spec compliance) Ignore this field -> https://github.com/BerriAI/litellm/issues/14644#issuecomment-3342061838
             elif "type" in tool:
                 tool = {k: tool[k] for k in tool if k != "type"}
@@ -681,20 +630,6 @@ class VertexGeminiConfig(VertexAIBaseConfig, BaseConfig):
         # Build list of Tool objects - each Tool should contain exactly one type
         # per Vertex AI API spec: "A Tool object should contain exactly one type of Tool"
         _tools_list: Final[list[Tools]] = []
-
-        (
-            googleSearch,
-            googleSearchRetrieval,
-            enterpriseWebSearch,
-            urlContext,
-        ) = self._resolve_search_tool_conflict(
-            gtool_func_declarations=gtool_func_declarations,
-            googleSearch=googleSearch,
-            googleSearchRetrieval=googleSearchRetrieval,
-            enterpriseWebSearch=enterpriseWebSearch,
-            urlContext=urlContext,
-            optional_params=optional_params,
-        )
 
         # Function declarations can be grouped together in one Tool
         if gtool_func_declarations:
@@ -1212,8 +1147,8 @@ class VertexGeminiConfig(VertexAIBaseConfig, BaseConfig):
         if VertexGeminiConfig._is_gemini_3_or_newer(model):
             if "temperature" not in optional_params:
                 optional_params["temperature"] = 1.0
-
-        self._drop_search_tools_mixed_with_functions(optional_params)
+        else:
+            self._drop_search_tools_mixed_with_functions(optional_params)
 
         return optional_params
 

--- a/tests/test_litellm/llms/vertex_ai/gemini/test_vertex_and_google_ai_studio_gemini.py
+++ b/tests/test_litellm/llms/vertex_ai/gemini/test_vertex_and_google_ai_studio_gemini.py
@@ -3307,13 +3307,7 @@ def test_vertex_ai_multiple_tool_types_separate_objects():
 def test_vertex_ai_function_declarations_with_other_tools_separate():
     """
     Test that when function declarations are mixed with search tools AND
-    non-search tools like code_execution, search tools are dropped but
-    non-search tools are preserved.
-
-    Vertex AI constraint: "Multiple tools are supported only when they are
-    all search tools." So mixing function declarations with googleSearch
-    would cause a 400 error. code_execution is NOT a search tool, so it
-    is preserved.
+    non-search tools like code_execution, all tools are preserved in separate Tool objects.
 
     Input:
         value=[
@@ -3325,6 +3319,7 @@ def test_vertex_ai_function_declarations_with_other_tools_separate():
     Expected Output:
         tools=[
             {"function_declarations": [{"name": "get_weather", "description": "Get weather"}]},
+            {"googleSearch": {}},
             {"code_execution": {}},
         ]
     """
@@ -3343,25 +3338,23 @@ def test_vertex_ai_function_declarations_with_other_tools_separate():
         optional_params=optional_params,
     )
 
-    # Should have 2 Tool objects: function declarations + code_execution
-    # googleSearch is dropped to avoid Vertex AI 400 error
-    assert len(tools) == 2, f"Expected 2 Tool objects, got {len(tools)}"
+    assert len(tools) == 3, f"Expected 3 Tool objects, got {len(tools)}"
 
-    # Find each tool type
     func_tool = None
+    search_tool = None
     code_tool = None
 
     for tool in tools:
         if "function_declarations" in tool:
             func_tool = tool
+        elif "googleSearch" in tool:
+            search_tool = tool
         elif "code_execution" in tool:
             code_tool = tool
 
-    # Verify function declarations and code_execution are present
     assert func_tool is not None, "function_declarations Tool should be present"
+    assert search_tool is not None, "googleSearch Tool should be present"
     assert code_tool is not None, "code_execution Tool should be present"
-
-    # Verify function declaration content
     assert func_tool["function_declarations"][0]["name"] == "get_weather"
 
 
@@ -3387,16 +3380,10 @@ def test_vertex_ai_single_tool_type_still_works():
     assert tools[0]["code_execution"] == {}
 
 
-def test_vertex_ai_mixed_search_and_function_tools_drops_search():
+def test_vertex_ai_mixed_search_and_function_tools_preserved():
     """
     Test that when both search tools and function declarations are present,
-    search tools are dropped to avoid Vertex AI 400 error:
-    "Multiple tools are supported only when they are all search tools."
-
-    This happens when deployment config has search tools (enterpriseWebSearch,
-    urlContext) and user request adds function calling tools (e.g. via MCP).
-
-    Ref: https://github.com/BerriAI/litellm/issues/23337
+    both are preserved as sibling tool objects in the tools list.
     """
     v = VertexGeminiConfig()
     optional_params = {}
@@ -3420,15 +3407,18 @@ def test_vertex_ai_mixed_search_and_function_tools_drops_search():
         optional_params=optional_params,
     )
 
-    # Should only have function declarations (search tools dropped)
-    assert len(tools) == 1, f"Expected 1 Tool object, got {len(tools)}: {tools}"
-    assert "function_declarations" in tools[0]
-    assert tools[0]["function_declarations"][0]["name"] == "get_weather"
+    assert len(tools) == 3, f"Expected 3 Tool objects, got {len(tools)}: {tools}"
+    tool_keys = set()
+    for tool in tools:
+        tool_keys.update(tool.keys())
+    assert "function_declarations" in tool_keys
+    assert "enterpriseWebSearch" in tool_keys
+    assert "url_context" in tool_keys
 
 
-def test_vertex_ai_mixed_google_search_and_function_tools_drops_search():
+def test_vertex_ai_mixed_google_search_and_function_tools_preserved():
     """
-    Test that googleSearch is also dropped when mixed with function declarations.
+    Test that googleSearch is preserved when mixed with function declarations.
     """
     v = VertexGeminiConfig()
     optional_params = {}
@@ -3444,9 +3434,12 @@ def test_vertex_ai_mixed_google_search_and_function_tools_drops_search():
         optional_params=optional_params,
     )
 
-    assert len(tools) == 1
-    assert "function_declarations" in tools[0]
-    assert tools[0]["function_declarations"][0]["name"] == "my_func"
+    assert len(tools) == 2
+    tool_keys = set()
+    for tool in tools:
+        tool_keys.update(tool.keys())
+    assert "function_declarations" in tool_keys
+    assert "googleSearch" in tool_keys
 
 
 def test_vertex_ai_search_tools_only_no_drop():
@@ -3603,10 +3596,10 @@ def test_map_openai_params_tools_before_include_server_side_flag():
     assert "googleSearch" in tool_keys
 
 
-def test_vertex_ai_mixed_tools_and_web_search_options_drops_search():
+def test_vertex_ai_mixed_tools_and_web_search_options_preserved():
     """
     When function tools and web_search_options are sent separately (Codex-style),
-    search tools are dropped unless include_server_side_tool_invocations is set.
+    both function_declarations and googleSearch are preserved in tools.
     """
     v = VertexGeminiConfig()
     optional_params: dict = {}
@@ -3627,12 +3620,11 @@ def test_vertex_ai_mixed_tools_and_web_search_options_drops_search():
         drop_params=True,
     )
 
-    assert not result.get("include_server_side_tool_invocations")
     tool_keys = set()
     for tool in result.get("tools", []):
         tool_keys.update(tool.keys())
     assert "function_declarations" in tool_keys
-    assert "googleSearch" not in tool_keys
+    assert "googleSearch" in tool_keys
 
 
 def test_vertex_ai_openai_web_search_tool_transformation():
@@ -3698,8 +3690,7 @@ def test_vertex_ai_openai_web_search_preview_tool_transformation():
 def test_vertex_ai_openai_web_search_with_function_tools():
     """
     Test that when OpenAI-style web_search tool (transformed to googleSearch)
-    is mixed with function tools, search tools are dropped to avoid Vertex AI
-    400 error: "Multiple tools are supported only when they are all search tools."
+    is mixed with function tools, both are preserved in separate Tool objects.
 
     Input:
         value=[
@@ -3710,6 +3701,7 @@ def test_vertex_ai_openai_web_search_with_function_tools():
     Expected Output:
         tools=[
             {"function_declarations": [{"name": "get_weather", "description": "Get weather"}]},
+            {"googleSearch": {}},
         ]
     """
     v = VertexGeminiConfig()
@@ -3726,13 +3718,128 @@ def test_vertex_ai_openai_web_search_with_function_tools():
         optional_params=optional_params,
     )
 
-    # Should have 1 Tool object: function declarations only
-    # googleSearch (from web_search) is dropped to avoid Vertex AI 400 error
-    assert len(tools) == 1, f"Expected 1 Tool object, got {len(tools)}"
+    assert len(tools) == 2, f"Expected 2 Tool objects, got {len(tools)}"
 
-    func_tool = tools[0]
-    assert "function_declarations" in func_tool
+    func_tool = next((t for t in tools if "function_declarations" in t), None)
+    search_tool = next((t for t in tools if "googleSearch" in t), None)
+    assert func_tool is not None
+    assert search_tool is not None
     assert func_tool["function_declarations"][0]["name"] == "get_weather"
+    assert search_tool["googleSearch"] == {}
+
+
+def test_vertex_ai_mixed_openai_tools_google_search_and_functions():
+    """
+    Test that OpenAI tools array containing both function definitions and google_search
+    maps to separate function_declarations and googleSearch tool objects on Gemini 3+ models.
+    """
+    v = VertexGeminiConfig()
+    optional_params: dict = {}
+    non_default_params = {
+        "tools": [
+            {
+                "type": "function",
+                "function": {
+                    "name": "get_current_weather",
+                    "description": "Get weather",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {"location": {"type": "string"}},
+                        "required": ["location"],
+                    },
+                },
+            },
+            {"google_search": {}},
+        ]
+    }
+
+    result = v.map_openai_params(
+        non_default_params=non_default_params,
+        optional_params=optional_params,
+        model="gemini-3.7-flash",
+        drop_params=True,
+    )
+
+    tools = result.get("tools", [])
+    assert len(tools) == 2
+    assert tools[0]["function_declarations"][0]["name"] == "get_current_weather"
+    assert tools[1] == {"googleSearch": {}}
+
+
+def test_vertex_ai_mixed_tools_and_google_search_drops_on_older_models():
+    """
+    Test that on Gemini models older than Gemini 3 (e.g., gemini-2.5-flash),
+    search tools are dropped when mixed with functions to avoid upstream 400 errors.
+    """
+    v = VertexGeminiConfig()
+    optional_params: dict = {}
+    non_default_params = {
+        "tools": [
+            {
+                "type": "function",
+                "function": {
+                    "name": "get_current_weather",
+                    "description": "Get weather",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {"location": {"type": "string"}},
+                        "required": ["location"],
+                    },
+                },
+            },
+            {"google_search": {}},
+        ]
+    }
+
+    result = v.map_openai_params(
+        non_default_params=non_default_params,
+        optional_params=optional_params,
+        model="gemini-2.5-flash",
+        drop_params=True,
+    )
+
+    tools = result.get("tools", [])
+    assert len(tools) == 1
+    assert tools[0]["function_declarations"][0]["name"] == "get_current_weather"
+
+
+def test_vertex_ai_mixed_tools_and_google_search_preserved_with_server_side_flag_on_older_models():
+    """
+    Test that when include_server_side_tool_invocations is explicitly set on an older model,
+    search tools are not dropped.
+    """
+    v = VertexGeminiConfig()
+    optional_params: dict = {}
+    non_default_params = {
+        "tools": [
+            {
+                "type": "function",
+                "function": {
+                    "name": "get_current_weather",
+                    "description": "Get weather",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {"location": {"type": "string"}},
+                        "required": ["location"],
+                    },
+                },
+            },
+            {"google_search": {}},
+        ],
+        "include_server_side_tool_invocations": True,
+    }
+
+    result = v.map_openai_params(
+        non_default_params=non_default_params,
+        optional_params=optional_params,
+        model="gemini-2.5-flash",
+        drop_params=True,
+    )
+
+    tools = result.get("tools", [])
+    assert len(tools) == 2
+    assert tools[0]["function_declarations"][0]["name"] == "get_current_weather"
+    assert tools[1] == {"googleSearch": {}}
 
 
 def test_vertex_ai_multiple_function_declarations_grouped():


### PR DESCRIPTION
## TLDR

Problem this solves:

- Search grounding tools are dropped when function tools exist
- Gemini 3+ models cannot use live search with tools

How it solves it:

- Removes legacy search tool stripping in Vertex Gemini formatting
- Preserves function declarations and googleSearch as separate tool objects

## User Flow

Before: a user sending both function definitions and google search grounding to Gemini 3+ gets static, ungrounded responses because search tools are stripped

1. They send POST http://localhost:4000/v1/chat/completions with model `vertex_ai/gemini-3.7-flash`, a custom function tool in `tools`, and `google_search` in `tools`
2. The proxy strips `google_search` under the legacy pre-Gemini 3 assumption that Vertex AI rejects mixed tools
3. The response comes back generated from static training memory without live grounding metadata

After: the same request preserves both tool types on Gemini 3+, returning live search grounded results

1. They send the same POST http://localhost:4000/v1/chat/completions with model `vertex_ai/gemini-3.7-flash`, the custom function tool, and `google_search`
2. The proxy formats `tools` containing both `function_declarations` and `googleSearch`
3. The response comes back with live grounded search content and search metadata

## Relevant issues

Fixes #38648

## Linear ticket



## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

### Before

#### Mixed Function Declarations and Google Search on Gemini 3+

1. Run curl against local proxy:
```bash
curl -s -X POST "http://localhost:4000/v1/chat/completions" \
  -H "Authorization: Bearer sk-1234" \
  -H "Content-Type: application/json" \
  -d '{
    "model": "vertex_ai/gemini-3.7-flash",
    "messages": [
      {
        "role": "user",
        "content": "What is the exact EUR to HUF exchange rate today?"
      }
    ],
    "tools": [
      {
        "type": "function",
        "function": {
          "name": "get_weather",
          "description": "Get current weather for a city",
          "parameters": {
            "type": "object",
            "properties": {
              "location": { "type": "string" }
            },
            "required": ["location"]
          }
        }
      },
      {
        "google_search": {}
      }
    ]
  }'
```
2. Observed proxy log:
```text
LiteLLM:WARNING vertex_and_google_ai_studio_gemini.py: Vertex AI does not support mixing function declarations with search tools... Dropping search tools.
```
3. Observed response payload:
```json
{
  "choices": [
    {
      "message": {
        "role": "assistant",
        "content": "I do not have access to real-time financial market data. Please consult a live currency converter."
      }
    }
  ]
}
```

### After (tip)

#### Mixed Function Declarations and Google Search on Gemini 3+

1. Run curl against local proxy:
```bash
curl -s -X POST "http://localhost:4000/v1/chat/completions" \
  -H "Authorization: Bearer sk-1234" \
  -H "Content-Type: application/json" \
  -d '{
    "model": "vertex_ai/gemini-3.7-flash",
    "messages": [
      {
        "role": "user",
        "content": "What is the exact EUR to HUF exchange rate today?"
      }
    ],
    "tools": [
      {
        "type": "function",
        "function": {
          "name": "get_weather",
          "description": "Get current weather for a city",
          "parameters": {
            "type": "object",
            "properties": {
              "location": { "type": "string" }
            },
            "required": ["location"]
          }
        }
      },
      {
        "google_search": {}
      }
    ]
  }'
```
2. Observed proxy log:
```text
No warning emitted. Forwarded tools: [{"function_declarations": [{"name": "get_weather", ...}]}, {"googleSearch": {}}]
```
3. Observed response payload:
```json
{
  "choices": [
    {
      "message": {
        "role": "assistant",
        "content": "The EUR to HUF exchange rate is approximately 1 EUR = 361.9 - 364.5 HUF today."
      }
    }
  ]
}
```

## Type

🐛 Bug Fix

## Caveats (if any)

### Low

- Pre-Gemini 3 models (Gemini 1.5, Gemini 2.0, Gemini 2.5) on Vertex AI do not support mixed tool types upstream and return HTTP 400 from Google if functions and search are combined in one request

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR