### PR TITLE
fix(bedrock): safely handle None credentials when extracting from aws_bedrock_client (#38579)

### DIFF
--- a/litellm/main.py
+++ b/litellm/main.py
@@ -4016,14 +4016,16 @@ def _complete_bedrock(ctx: _CompletionDispatchContext) -> _CompletionDispatchRes
         )
         # Extract credentials for legacy boto3 client and pass thru to httpx
         aws_bedrock_client: Final = optional_params.pop("aws_bedrock_client")
-        creds: Final = aws_bedrock_client._get_credentials().get_frozen_credentials()
+        creds_obj = aws_bedrock_client._get_credentials()
+        creds = creds_obj.get_frozen_credentials() if creds_obj is not None else None
 
-        if creds.access_key:
-            optional_params["aws_access_key_id"] = creds.access_key
-        if creds.secret_key:
-            optional_params["aws_secret_access_key"] = creds.secret_key
-        if creds.token:
-            optional_params["aws_session_token"] = creds.token
+        if creds is not None:
+            if creds.access_key:
+                optional_params["aws_access_key_id"] = creds.access_key
+            if creds.secret_key:
+                optional_params["aws_secret_access_key"] = creds.secret_key
+            if creds.token:
+                optional_params["aws_session_token"] = creds.token
         if "aws_region_name" not in optional_params or optional_params["aws_region_name"] is None:
             optional_params["aws_region_name"] = aws_bedrock_client.meta.region_name
 


### PR DESCRIPTION
## Summary

Fixes #38579.

In `litellm/main.py`, when extracting credentials from `aws_bedrock_client`, `aws_bedrock_client._get_credentials()` can return `None` for bearer-token-only or uncredentialed client instances. Calling `.get_frozen_credentials()` directly caused an unhandled `AttributeError: 'NoneType' object has no attribute 'get_frozen_credentials'`.

This PR:
- Adds a null check on `aws_bedrock_client._get_credentials()` before attempting to freeze credentials.
- Gracefully continues and passes execution to the underlying Bedrock handler which supports Bearer token authentication via `AWS_BEARER_TOKEN_BEDROCK` / `api_key`.