### PR TITLE
fix(vertex_ai): append user after text-only model tail

### DIFF
--- a/litellm/llms/vertex_ai/gemini/transformation.py
+++ b/litellm/llms/vertex_ai/gemini/transformation.py
@@ -7,6 +7,7 @@ Why separate file? Make it easy to see how transformation works
 import json
 import os
 import re
+from collections.abc import Sequence
 from typing import TYPE_CHECKING, Any, Final, Literal, cast
 from urllib.parse import quote
 
@@ -1075,6 +1076,8 @@ def _gemini_convert_messages_with_history(
 # Keys that LiteLLM consumes internally and must never be forwarded to the
 _LITELLM_INTERNAL_EXTRA_BODY_KEYS: Final[frozenset] = frozenset({"cache", "tags"})
 
+_TEXT_ONLY_MODEL_PART_KEYS: Final[frozenset[str]] = frozenset({"text", "thought", "thoughtSignature"})
+
 
 def _pop_and_merge_extra_body(data: RequestBody, optional_params: dict) -> None:
     """Pop extra_body from optional_params and shallow-merge into data, deep-merging dict values."""
@@ -1143,6 +1146,30 @@ def _rewrite_google_maps_response_format(data: RequestBody) -> None:
         _rewrite_mime_type_to_response_format(generation_config)
 
 
+def _is_text_only_model_content(content: ContentType) -> bool:
+    if content.get("role") != "model":
+        return False
+
+    parts: Final = content.get("parts", [])
+    if not parts:
+        return False
+
+    return all("text" in part and frozenset(part).issubset(_TEXT_ONLY_MODEL_PART_KEYS) for part in parts)
+
+
+def _append_user_after_text_only_model_tail(
+    contents: Sequence[ContentType],
+) -> tuple[ContentType, ...]:
+    if not contents or not _is_text_only_model_content(contents[-1]):
+        return tuple(contents)
+
+    placeholder: Final = ContentType(
+        role="user",
+        parts=[PartType(text=".")],
+    )
+    return (*contents, placeholder)
+
+
 def _transform_request_body(
     messages: list[AllMessageValues],
     model: str,
@@ -1181,14 +1208,31 @@ def _transform_request_body(
     optional_params = {k: v for k, v in optional_params.items() if k not in remove_keys}
 
     try:
-        if custom_llm_provider == "gemini":
-            content = litellm.GoogleAIStudioGeminiConfig()._transform_messages(
-                messages=messages, model=model, litellm_params=litellm_params
+        transformed_content: Final = (
+            litellm.GoogleAIStudioGeminiConfig()._transform_messages(
+                messages=messages,
+                model=model,
+                litellm_params=litellm_params,
             )
-        else:
-            content = litellm.VertexGeminiConfig()._transform_messages(
-                messages=messages, model=model, litellm_params=litellm_params
+            if custom_llm_provider == "gemini"
+            else litellm.VertexGeminiConfig()._transform_messages(
+                messages=messages,
+                model=model,
+                litellm_params=litellm_params,
             )
+        )
+
+        should_normalize_model_tail: Final = custom_llm_provider in (
+            "vertex_ai",
+            "vertex_ai_beta",
+        ) and litellm.VertexGeminiConfig._is_gemini_3_or_newer(  # pyright: ignore[reportPrivateUsage]  # reuse the existing Vertex Gemini version gate without duplicating it
+            model
+        )
+        normalized_content: Final = (
+            _append_user_after_text_only_model_tail(transformed_content)
+            if should_normalize_model_tail
+            else tuple(transformed_content)
+        )
         tools: Final[Tools | None] = optional_params.pop("tools", None)
         tool_choice: Final[ToolConfig | None] = optional_params.pop("tool_choice", None)
         include_server_side_tool_invocations: bool = optional_params.pop("include_server_side_tool_invocations", False)
@@ -1214,7 +1258,7 @@ def _transform_request_body(
                 if media_resolution_value and generation_config is not None:
                     generation_config["mediaResolution"] = media_resolution_value["level"]
 
-        data: Final = RequestBody(contents=content)
+        data: Final = RequestBody(contents=list(normalized_content))
         # Vertex rejects system_instruction/tools/toolConfig alongside cachedContent.
         # Treat dropping these fields as a request mutation guarded by modify_params.
         can_send_cache_incompatible_fields: Final = cached_content is None or litellm.modify_params is False

--- a/tests/test_litellm/llms/vertex_ai/files/test_vertex_ai_files_transformation.py
+++ b/tests/test_litellm/llms/vertex_ai/files/test_vertex_ai_files_transformation.py
@@ -974,6 +974,30 @@ def _wrap_entries(openai_jsonl_content):
     ]
 
 
+def test_vertex_batch_text_model_tail_appends_user_placeholder() -> None:
+    vertex_rows = _wrap_entries(
+        [
+            {
+                "custom_id": "request-model-tail",
+                "method": "POST",
+                "url": "/v1/chat/completions",
+                "body": {
+                    "model": "gemini-3.7-flash",
+                    "messages": [
+                        {"role": "user", "content": "Remember cobalt"},
+                        {"role": "assistant", "content": "stored"},
+                    ],
+                },
+            }
+        ]
+    )
+
+    assert vertex_rows[0]["request"]["contents"][-1] == {
+        "role": "user",
+        "parts": [{"text": "."}],
+    }
+
+
 class TestVertexBatchCustomIdLabels:
     """Test custom_id handling in batch transformations"""
 

--- a/tests/test_litellm/llms/vertex_ai/gemini/test_transformation.py
+++ b/tests/test_litellm/llms/vertex_ai/gemini/test_transformation.py
@@ -1,4 +1,6 @@
 
+from typing import Literal
+
 import pytest
 
 from litellm.llms.vertex_ai.gemini import transformation
@@ -7,7 +9,23 @@ from litellm.llms.vertex_ai.gemini.vertex_and_google_ai_studio_gemini import (
 )
 from litellm.types.llms import openai
 from litellm.types import completion
-from litellm.types.llms.vertex_ai import RequestBody
+from litellm.types.llms.vertex_ai import ContentType, PartType, RequestBody
+
+
+def _transform_vertex_messages(
+    messages: list[openai.AllMessageValues],
+    *,
+    model: str = "gemini-3.7-flash",
+    provider: Literal["vertex_ai", "vertex_ai_beta", "gemini"] = "vertex_ai",
+) -> RequestBody:
+    return transformation._transform_request_body(
+        messages=messages,
+        model=model,
+        optional_params={},
+        custom_llm_provider=provider,
+        litellm_params={},
+        cached_content=None,
+    )
 
 
 @pytest.mark.asyncio
@@ -338,3 +356,218 @@ def test_map_function_enterprise_web_search_snake_case():
 
     assert len(result) == 1
     assert "enterpriseWebSearch" in result[0]
+
+
+@pytest.mark.parametrize("provider", ["vertex_ai", "vertex_ai_beta"])
+def test_text_only_model_tail_appends_user_placeholder(
+    provider: Literal["vertex_ai", "vertex_ai_beta"],
+) -> None:
+    body: RequestBody = _transform_vertex_messages(
+        [
+            {"role": "user", "content": "Remember cobalt"},
+            {"role": "assistant", "content": "stored"},
+        ],
+        provider=provider,
+    )
+
+    assert body["contents"] == [
+        {"role": "user", "parts": [{"text": "Remember cobalt"}]},
+        {"role": "model", "parts": [{"text": "stored"}]},
+        {"role": "user", "parts": [{"text": "."}]},
+    ]
+
+
+def test_text_only_model_tail_before_system_message_appends_user_placeholder() -> None:
+    body: RequestBody = _transform_vertex_messages(
+        [
+            {"role": "user", "content": "Remember cobalt"},
+            {"role": "assistant", "content": "stored"},
+            {"role": "system", "content": "Keep replies short"},
+        ]
+    )
+
+    assert body["contents"][-1] == {
+        "role": "user",
+        "parts": [{"text": "."}],
+    }
+    assert body["system_instruction"] == {
+        "parts": [{"text": "Keep replies short"}]
+    }
+
+
+@pytest.mark.parametrize(
+    "assistant_message",
+    [
+        {
+            "role": "assistant",
+            "content": "stored",
+            "provider_specific_fields": {"thought_signatures": ["sig-1"]},
+        },
+        {
+            "role": "assistant",
+            "content": "stored",
+            "reasoning_content": "Remembering the requested word",
+        },
+    ],
+)
+def test_text_model_tail_with_reasoning_metadata_appends_user_placeholder(
+    assistant_message: openai.ChatCompletionAssistantMessage,
+) -> None:
+    body: RequestBody = _transform_vertex_messages(
+        [
+            {"role": "user", "content": "Remember cobalt"},
+            assistant_message,
+        ]
+    )
+
+    assert body["contents"][-1] == {
+        "role": "user",
+        "parts": [{"text": "."}],
+    }
+
+
+@pytest.mark.parametrize(
+    ("model", "provider"),
+    [
+        ("gemini-2.5-flash", "vertex_ai"),
+        ("gemini-3.7-flash", "gemini"),
+    ],
+)
+def test_text_model_tail_outside_vertex_gemini_3_scope_is_unchanged(
+    model: str,
+    provider: Literal["vertex_ai", "gemini"],
+) -> None:
+    body: RequestBody = _transform_vertex_messages(
+        [
+            {"role": "user", "content": "Remember cobalt"},
+            {"role": "assistant", "content": "stored"},
+        ],
+        model=model,
+        provider=provider,
+    )
+
+    assert body["contents"][-1] == {
+        "role": "model",
+        "parts": [{"text": "stored"}],
+    }
+
+
+def test_user_tail_is_unchanged() -> None:
+    body: RequestBody = _transform_vertex_messages(
+        [
+            {"role": "user", "content": "Remember cobalt"},
+            {"role": "assistant", "content": "stored"},
+            {"role": "user", "content": "What was it?"},
+        ]
+    )
+
+    assert body["contents"][-1] == {
+        "role": "user",
+        "parts": [{"text": "What was it?"}],
+    }
+
+
+def test_empty_assistant_tail_does_not_add_a_second_user_turn() -> None:
+    body: RequestBody = _transform_vertex_messages(
+        [
+            {"role": "user", "content": "Remember cobalt"},
+            {"role": "assistant", "content": None},
+        ]
+    )
+
+    assert body["contents"] == [
+        {"role": "user", "parts": [{"text": "Remember cobalt"}]}
+    ]
+
+
+def test_function_call_model_tail_is_unchanged() -> None:
+    body: RequestBody = _transform_vertex_messages(
+        [
+            {"role": "user", "content": "Look up cobalt"},
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {
+                        "id": "call-1",
+                        "type": "function",
+                        "function": {"name": "lookup", "arguments": "{}"},
+                    }
+                ],
+            },
+        ]
+    )
+
+    assert body["contents"][-1]["role"] == "model"
+    assert "function_call" in body["contents"][-1]["parts"][0]
+
+
+def test_server_side_tool_model_tail_is_unchanged() -> None:
+    body: RequestBody = _transform_vertex_messages(
+        [
+            {"role": "user", "content": "Search for cobalt"},
+            {
+                "role": "assistant",
+                "content": "stored",
+                "provider_specific_fields": {
+                    "server_side_tool_invocations": [
+                        {
+                            "tool_type": "googleSearch",
+                            "id": "tool-1",
+                            "args": {"query": "cobalt"},
+                            "response": {"result": "stored"},
+                        }
+                    ]
+                },
+            },
+        ]
+    )
+
+    assert body["contents"][-1]["role"] == "model"
+    assert any(
+        "toolCall" in part or "toolResponse" in part
+        for part in body["contents"][-1]["parts"]
+    )
+
+
+def test_assistant_media_model_tail_is_unchanged() -> None:
+    image_data_uri = (
+        "data:image/png;base64,"
+        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=="
+    )
+    body: RequestBody = _transform_vertex_messages(
+        [
+            {"role": "user", "content": "Generate an image"},
+            {
+                "role": "assistant",
+                "content": "generated",
+                "images": [
+                    {
+                        "image_url": {"url": image_data_uri, "detail": "auto"},
+                        "index": 0,
+                        "type": "image_url",
+                    }
+                ],
+            },
+        ]
+    )
+
+    assert body["contents"][-1]["role"] == "model"
+    assert any(
+        "inline_data" in part for part in body["contents"][-1]["parts"]
+    )
+
+
+def test_text_part_with_disallowed_key_model_tail_is_unchanged() -> None:
+    contents: tuple[ContentType, ...] = (
+        ContentType(role="user", parts=[PartType(text="Remember cobalt")]),
+        ContentType(
+            role="model",
+            parts=[PartType(text="stored", media_resolution="low")],
+        ),
+    )
+
+    assert transformation._append_user_after_text_only_model_tail(contents) == (
+        {"role": "user", "parts": [{"text": "Remember cobalt"}]},
+        {"role": "model", "parts": [{"text": "stored", "media_resolution": "low"}]},
+    )

--- a/tests/test_litellm/llms/vertex_ai/gemini/test_transformation.py
+++ b/tests/test_litellm/llms/vertex_ai/gemini/test_transformation.py
@@ -571,3 +571,12 @@ def test_text_part_with_disallowed_key_model_tail_is_unchanged() -> None:
         {"role": "user", "parts": [{"text": "Remember cobalt"}]},
         {"role": "model", "parts": [{"text": "stored", "media_resolution": "low"}]},
     )
+
+
+def test_empty_parts_model_tail_is_unchanged() -> None:
+    contents: tuple[ContentType, ...] = (
+        ContentType(role="user", parts=[PartType(text="Remember cobalt")]),
+        ContentType(role="model", parts=[]),
+    )
+
+    assert transformation._append_user_after_text_only_model_tail(contents) == contents


### PR DESCRIPTION
## TLDR

Problem this solves:

- Vertex Gemini rejects text-only assistant-tail histories
- Agent loops stop with a model-turn HTTP 400
- Trailing system messages hide the same wire shape

How it solves it:

- Checks the final transformed Gemini contents
- Appends a period user turn after text-only model turns
- Leaves tools, media, Gemini 2.x and AI Studio unchanged

## User Flow

Before: a developer replaying a text-only assistant turn through Vertex Gemini gets a hard error, so the agent loop stops

1. They send `POST http://localhost:4002/v1/chat/completions` with a user message followed by a text-only assistant message
2. The proxy routes the request to `vertex_ai/gemini-3.7-flash`
3. They receive HTTP 400 with `Requests ending with a model turn are not supported.`
4. Their agent loop cannot continue the conversation

After: the same replay reaches Vertex in an accepted shape and the agent loop continues

1. They send the same `POST http://localhost:4002/v1/chat/completions` with the same two messages
2. The proxy routes the request to `vertex_ai/gemini-3.7-flash`
3. They receive HTTP 200 with the expected context-dependent assistant response
4. Their agent loop continues the conversation

## Relevant issues

Fixes #38537

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally: `uv run pytest tests/test_litellm/llms/vertex_ai/gemini/test_transformation.py tests/test_litellm/llms/vertex_ai/files/test_vertex_ai_files_transformation.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in about 15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA)

## Screenshots / Proof of Fix

Shared setup: the same proxy config, Vertex project, credentials, model, and request bodies were used on both commits. Secrets and the project name are redacted

### Before (98d231c09bbdbfc9997a3b49e0017b28db6c4485)

#### text-only assistant tail

1. Start the proxy on port 4002 with

   ```bash
   export VERTEXAI_PROJECT=<project-id-from-SA, redacted>
   export GOOGLE_APPLICATION_CREDENTIALS=<SA JSON path, redacted>
   export PYTHONPATH=/home/ubuntu/Workspace/litellm-contributors/.worktrees/litellm-vertex-gemini-model-tail-before
   cd /home/ubuntu/Workspace/litellm-contributors/.worktrees/litellm-vertex-gemini-model-tail-before
   nohup /home/ubuntu/Workspace/litellm-contributors/.venv/bin/python litellm/proxy/proxy_cli.py \
     --config <sdd>/litellm-vertex-model-tail-config.yaml \
     --port 4002 \
     --detailed_debug \
     > <sdd>/task-10-before-proxy.log 2>&1 &
   ```

2. Send

   ```bash
   curl -sS -w '\nHTTP %{http_code}\n' \
     http://localhost:4002/v1/chat/completions \
     -H 'Authorization: Bearer sk-1234' \
     -H 'Content-Type: application/json' \
     -d '{
       "model": "vertex-gemini-3-7",
       "messages": [
         {"role": "user", "content": "When the next user message is exactly one period, reply only with cobalt-17"},
         {"role": "assistant", "content": "Understood"}
       ],
       "disable_fallbacks": true
     }'
   ```

3. The proxy returns HTTP 400 with

   ```json
   {"error":{"message":"litellm.BadRequestError: Vertex_aiException BadRequestError - {\n  \"error\": {\n    \"code\": 400,\n    \"message\": \"Requests ending with a model turn are not supported.\",\n    \"status\": \"INVALID_ARGUMENT\"\n  }\n}\n","type":null,"param":null,"code":"400"}}
   HTTP 400
   ```

#### trailing system after assistant

1. Send

   ```bash
   curl -sS -w '\nHTTP %{http_code}\n' \
     http://localhost:4002/v1/chat/completions \
     -H 'Authorization: Bearer sk-1234' \
     -H 'Content-Type: application/json' \
     -d '{
       "model": "vertex-gemini-3-7",
       "messages": [
         {"role": "user", "content": "When the next user message is exactly one period, reply only with cobalt-17"},
         {"role": "assistant", "content": "Understood"},
         {"role": "system", "content": "Keep replies short"}
       ],
       "disable_fallbacks": true
     }'
   ```

2. The proxy returns HTTP 400 with

   ```json
   {"error":{"message":"litellm.BadRequestError: Vertex_aiException BadRequestError - {\n  \"error\": {\n    \"code\": 400,\n    \"message\": \"Requests ending with a model turn are not supported.\",\n    \"status\": \"INVALID_ARGUMENT\"\n  }\n}\n","type":null,"param":null,"code":"400"}}
   HTTP 400
   ```

### After (baaed90bcbd451300c4e9c45ab01812cb1e8c668)

#### text-only assistant tail

1. Start the proxy on port 4002 with

   ```bash
   export VERTEXAI_PROJECT=<project-id-from-SA, redacted>
   export GOOGLE_APPLICATION_CREDENTIALS=<SA JSON path, redacted>
   export PYTHONPATH=/home/ubuntu/Workspace/litellm-contributors/.worktrees/litellm-vertex-gemini-model-tail
   cd /home/ubuntu/Workspace/litellm-contributors/.worktrees/litellm-vertex-gemini-model-tail
   nohup /home/ubuntu/Workspace/litellm-contributors/.venv/bin/python litellm/proxy/proxy_cli.py \
     --config <sdd>/litellm-vertex-model-tail-config.yaml \
     --port 4002 \
     --detailed_debug \
     > <sdd>/task-10-after-proxy.log 2>&1 &
   ```

2. Send the same request

   ```bash
   curl -sS -w '\nHTTP %{http_code}\n' \
     http://localhost:4002/v1/chat/completions \
     -H 'Authorization: Bearer sk-1234' \
     -H 'Content-Type: application/json' \
     -d '{
       "model": "vertex-gemini-3-7",
       "messages": [
         {"role": "user", "content": "When the next user message is exactly one period, reply only with cobalt-17"},
         {"role": "assistant", "content": "Understood"}
       ],
       "disable_fallbacks": true
     }'
   ```

3. The proxy returns HTTP 200 with the exact context-dependent value:

   ```json
   {"id":"4FSRapypIdzojNAP8ImT2AU","created":1787909344,"model":"vertex-gemini-3-7","object":"chat.completion","choices":[{"finish_reason":"stop","index":0,"message":{"content":"cobalt-17","role":"assistant","images":[],"thinking_blocks":[],"provider_specific_fields":{"thought_signatures":["AY89a1/..."]}}}],"usage":{"completion_tokens":127,"prompt_tokens":20,"total_tokens":147,"completion_tokens_details":{"reasoning_tokens":122,"text_tokens":5},"prompt_tokens_details":{"text_tokens":20}},"vertex_ai_grounding_metadata":[],"vertex_ai_url_context_metadata":[],"vertex_ai_safety_results":[],"vertex_ai_citation_metadata":[]}
   HTTP 200
   ```

   Detailed-debug wire body sent to Vertex shows the injected user-period turn after the text-only model tail:

   ```json
   {"contents": [{"role": "user", "parts": [{"text": "When the next user message is exactly one period, reply only with cobalt-17"}]}, {"role": "model", "parts": [{"text": "Understood"}]}, {"role": "user", "parts": [{"text": "."}]}], "generationConfig": {"temperature": 1.0}}
   ```

#### trailing system after assistant

1. Send the same trailing-system request

   ```bash
   curl -sS -w '\nHTTP %{http_code}\n' \
     http://localhost:4002/v1/chat/completions \
     -H 'Authorization: Bearer sk-1234' \
     -H 'Content-Type: application/json' \
     -d '{
       "model": "vertex-gemini-3-7",
       "messages": [
         {"role": "user", "content": "When the next user message is exactly one period, reply only with cobalt-17"},
         {"role": "assistant", "content": "Understood"},
         {"role": "system", "content": "Keep replies short"}
       ],
       "disable_fallbacks": true
     }'
   ```

2. The proxy returns HTTP 200 with a non-empty response:

   ```json
   {"id":"6FSRavfkKIbt694PxODgwQg","created":1787909352,"model":"vertex-gemini-3-7","object":"chat.completion","choices":[{"finish_reason":"stop","index":0,"message":{"content":"cobalt-17","role":"assistant","images":[],"thinking_blocks":[],"provider_specific_fields":{"thought_signatures":["AY89a1+..."]}}}],"usage":{"completion_tokens":118,"prompt_tokens":23,"total_tokens":141,"completion_tokens_details":{"reasoning_tokens":113,"text_tokens":5},"prompt_tokens_details":{"text_tokens":23}},"vertex_ai_grounding_metadata":[],"vertex_ai_url_context_metadata":[],"vertex_ai_safety_results":[],"vertex_ai_citation_metadata":[]}
   HTTP 200
   ```

   Detailed-debug wire body moves the trailing system into `system_instruction` and appends the user-period turn after the model tail:

   ```json
   {"contents": [{"role": "user", "parts": [{"text": "When the next user message is exactly one period, reply only with cobalt-17"}]}, {"role": "model", "parts": [{"text": "Understood"}]}, {"role": "user", "parts": [{"text": "."}]}], "system_instruction": {"parts": [{"text": "Keep replies short"}]}, "generationConfig": {"temperature": 1.0}}
   ```

#### non-regression controls

1. Send the normal user-tail request and observe HTTP 200

   ```bash
   curl -sS -w '\nHTTP %{http_code}\n' \
     http://localhost:4002/v1/chat/completions \
     -H 'Authorization: Bearer sk-1234' \
     -H 'Content-Type: application/json' \
     -d '{
       "model": "vertex-gemini-3-7",
       "messages": [
         {"role": "user", "content": "Reply with exactly two words: hello world"}
       ],
       "disable_fallbacks": true
     }'
   ```

   ```json
   {"id":"9VSRas-zJJio694Px-aosAo","created":1787909365,"model":"vertex-gemini-3-7","object":"chat.completion","choices":[{"finish_reason":"stop","index":0,"message":{"content":"...","role":"assistant","images":[],"thinking_blocks":[],"provider_specific_fields":{"thought_signatures":["AY89a1/..."]}}}],"usage":{"completion_tokens":96,"prompt_tokens":8,"total_tokens":104,"completion_tokens_details":{"reasoning_tokens":94,"text_tokens":2},"prompt_tokens_details":{"text_tokens":8}},"vertex_ai_grounding_metadata":[],"vertex_ai_url_context_metadata":[],"vertex_ai_safety_results":[],"vertex_ai_citation_metadata":[]}
   HTTP 200
   ```

   Wire body unchanged (ends with the user turn, no injected turn):

   ```json
   {"contents": [{"role": "user", "parts": [{"text": "Reply with exactly two words: hello world"}]}], "generationConfig": {"temperature": 1.0}}
   ```

2. Send the normal user-assistant-user request and observe HTTP 200

   ```bash
   curl -sS -w '\nHTTP %{http_code}\n' \
     http://localhost:4002/v1/chat/completions \
     -H 'Authorization: Bearer sk-1234' \
     -H 'Content-Type: application/json' \
     -d '{
       "model": "vertex-gemini-3-7",
       "messages": [
         {"role": "user", "content": "Remember the secret word"},
         {"role": "assistant", "content": "Stored"},
         {"role": "user", "content": "What is the secret word? Reply with exactly that word."}
       ],
       "disable_fallbacks": true
     }'
   ```

   ```json
   {"id":"_FSRatVuhOzr3g_46OTACg","created":1787909371,"model":"vertex-gemini-3-7","object":"chat.completion","choices":[{"finish_reason":"stop","index":0,"message":{"content":"...","role":"assistant","images":[],"thinking_blocks":[],"provider_specific_fields":{"thought_signatures":["AY89a188..."]}}}],"usage":{"completion_tokens":96,"prompt_tokens":23,"total_tokens":119,"completion_tokens_details":{"reasoning_tokens":94,"text_tokens":2},"prompt_tokens_details":{"text_tokens":23}},"vertex_ai_grounding_metadata":[],"vertex_ai_url_context_metadata":[],"vertex_ai_safety_results":[],"vertex_ai_citation_metadata":[]}
   HTTP 200
   ```

   Wire body unchanged (ends with the user turn, no injected turn):

   ```json
   {"contents": [{"role": "user", "parts": [{"text": "Remember the secret word"}]}, {"role": "model", "parts": [{"text": "Stored"}]}, {"role": "user", "parts": [{"text": "What is the secret word? Reply with exactly that word."}]}], "generationConfig": {"temperature": 1.0}}
   ```

3. Send the tool-call-tail request and verify no period user turn is injected

   ```bash
   curl -sS -w '\nHTTP %{http_code}\n' \
     http://localhost:4002/v1/chat/completions \
     -H 'Authorization: Bearer sk-1234' \
     -H 'Content-Type: application/json' \
     -d '{
       "model": "vertex-gemini-3-7",
       "messages": [
         {"role": "user", "content": "Look up cobalt"},
         {"role": "assistant", "content": null, "tool_calls": [
           {"id": "call-1", "type": "function", "function": {"name": "lookup", "arguments": "{}"}}
         ]}
       ],
       "disable_fallbacks": true
     }'
   ```

   Vertex still rejects a bare tool-call model turn (unchanged behavior, HTTP 400):

   ```json
   {"error":{"message":"litellm.BadRequestError: Vertex_aiException BadRequestError - {\n  \"error\": {\n    \"code\": 400,\n    \"message\": \"Requests ending with a model turn are not supported.\",\n    \"status\": \"INVALID_ARGUMENT\"\n  }\n}\n","type":null,"param":null,"code":"400"}}
   HTTP 400
   ```

   Detailed-debug wire body shows the model tail keeps its `function_call` part and is NOT followed by any injected user-period turn:

   ```json
   {"contents": [{"role": "user", "parts": [{"text": "Look up cobalt"}]}, {"role": "model", "parts": [{"function_call": {"name": "lookup", "args": {}, "id": "call-1"}, "thoughtSignature": "c2tpcF90aG91Z2h0X3NpZ25hdHVyZV92YWxpZGF0b3I="}]}], "generationConfig": {"temperature": 1.0}}
   ```

4. Gemini 2.5 assistant tail control: omitted. No Gemini 2.5 deployment is available on this machine; the live config only contains `vertex_ai/gemini-3.7-flash`. The direct unit control `test_text_model_tail_outside_vertex_gemini_3_scope_is_unchanged` covers `gemini-2.5-flash` / `vertex_ai` and asserts the text model tail is left unchanged. No live result was invented.

## Type

🐛 Bug Fix

## Caveats (if any)

### Low

- Adds one period user turn to affected Vertex requests
- Raw `extra_body.contents` remains caller-controlled
- Google AI Studio behavior remains unchanged

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Mutates outbound Vertex Gemini 3+ request contents for a narrow history shape; low blast radius due to version/provider gating but could surprise callers sensitive to exact turn structure.
> 
> **Overview**
> Fixes Vertex Gemini 3+ **HTTP 400** when transformed `contents` end on a **text-only model** turn (`Requests ending with a model turn are not supported`), including histories where a trailing **system** message leaves the wire shape ending on model.
> 
> **Vertex `vertex_ai` / `vertex_ai_beta` + Gemini 3+** now run message normalization after `_transform_messages`: if the last content is model with only text/thought/thoughtSignature parts, LiteLLM appends a minimal **user** turn (`"."`). Tool-call, media, server-side tool, and empty assistant tails are left alone; **Gemini 2.x**, **Google AI Studio (`gemini`)**, and conversations that already end on user are unchanged.
> 
> The same path is used for **Vertex batch** chat JSONL via `_transform_request_body`. Tests cover the helper, request transform, and batch rows. Proxy auth prefetch tests pin `InMemoryCache` to a fixed clock for stability.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9c9caf39074959ac018c368ae04299380a1f5ad5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->