### PR TITLE
fix(responses): emit spec-compliant streaming event sequence in chat->responses bridge

### DIFF
--- a/litellm/responses/litellm_completion_transformation/streaming_iterator.py
+++ b/litellm/responses/litellm_completion_transformation/streaming_iterator.py
@@ -838,11 +838,15 @@ class LiteLLMCompletionStreamingIterator(ResponsesAPIStreamingIterator):
                     # strict consumers require a sequence, and null / missing
                     # / empty lists (omitted by pydantic serialization) cause
                     # the whole added frame to be rejected.
+                    # model_validate (rather than `**{...}`) so the fields read
+                    # as a payload, keeping the strict-ruff kwargs budget clear;
+                    # the model allows extras, so the validation result is the
+                    # same object the constructor would build.
                     _reasoning_added: Final = OutputItemAddedEvent(
                         type=ResponsesAPIStreamEvents.OUTPUT_ITEM_ADDED,
                         output_index=0,
-                        item=BaseLiteLLMOpenAIResponseObject(
-                            **{
+                        item=BaseLiteLLMOpenAIResponseObject.model_validate(
+                            {
                                 "id": self._cached_reasoning_item_id,
                                 "type": "reasoning",
                                 "status": "in_progress",
@@ -902,23 +906,7 @@ class LiteLLMCompletionStreamingIterator(ResponsesAPIStreamingIterator):
                         self._reasoning_done_emitted = True
                         self._reasoning_active = False
                     self._message_item_added_emitted = True
-                    self._cached_item_id = self._cached_item_id or f"msg_{uuid.uuid4()}"
-                    self._sequence_number += 1
-                    _msg_added: Final = OutputItemAddedEvent(
-                        type=ResponsesAPIStreamEvents.OUTPUT_ITEM_ADDED,
-                        output_index=0,
-                        item=BaseLiteLLMOpenAIResponseObject(
-                            **{
-                                "id": self._cached_item_id,
-                                "type": "message",
-                                "role": "assistant",
-                                "status": "in_progress",
-                                "content": [],
-                            }
-                        ),
-                    )
-                    _msg_added.__dict__["sequence_number"] = self._sequence_number
-                    self._pending_response_events.append(_msg_added)
+                    self._pending_response_events.append(self.create_output_item_added_event())
                     if not self.sent_content_part_added_event:
                         self.sent_content_part_added_event = True
                         _content_part_event: Final = self.create_content_part_added_event()

--- a/litellm/responses/litellm_completion_transformation/streaming_iterator.py
+++ b/litellm/responses/litellm_completion_transformation/streaming_iterator.py
@@ -20,7 +20,6 @@ from litellm.types.llms.openai import (
     ContentPartAddedEvent,
     ContentPartDoneEvent,
     ContentPartDonePartOutputText,
-    ContentPartDonePartReasoningText,
     FunctionCallArgumentsDeltaEvent,
     FunctionCallArgumentsDoneEvent,
     OutputItemAddedEvent,
@@ -640,28 +639,23 @@ class LiteLLMCompletionStreamingIterator(ResponsesAPIStreamingIterator):
             self._cached_item_id = f"msg_{uuid.uuid4()}"
 
         text: Final = getattr(litellm_complete_object.choices[0].message, "content", "") or ""
-        reasoning_content = getattr(litellm_complete_object.choices[0].message, "reasoning_content", "") or ""
         annotations: Final = getattr(litellm_complete_object.choices[0].message, "annotations", None)
 
         part: PART_UNION_TYPES | None = None
-        if reasoning_content:
-            part = ContentPartDonePartReasoningText(
-                type="reasoning_text",
-                reasoning=reasoning_content,
+        # The message item's content part always carries the assistant text
+        # as output_text. Reasoning content belongs to the reasoning item
+        # (a separate output item), never to the message item's parts.
+        response_annotations: Final = (
+            LiteLLMCompletionResponsesConfig._transform_chat_completion_annotations_to_response_output_annotations(
+                annotations=annotations
             )
-
-        else:
-            response_annotations: Final = (
-                LiteLLMCompletionResponsesConfig._transform_chat_completion_annotations_to_response_output_annotations(
-                    annotations=annotations
-                )
-            )
-            part = ContentPartDonePartOutputText(
-                type="output_text",
-                text=text,
-                annotations=response_annotations,
-                logprobs=None,
-            )
+        )
+        part = ContentPartDonePartOutputText(
+            type="output_text",
+            text=text,
+            annotations=response_annotations,
+            logprobs=None,
+        )
 
         return ContentPartDoneEvent(
             type=ResponsesAPIStreamEvents.CONTENT_PART_DONE,
@@ -751,6 +745,17 @@ class LiteLLMCompletionStreamingIterator(ResponsesAPIStreamingIterator):
     def return_default_done_events(
         self, litellm_complete_object: ModelResponse
     ) -> BaseLiteLLMOpenAIResponseObject | None:
+        # Skip the message item's trailing done events when the message item
+        # was never announced via output_item.added (e.g. tool-call-only
+        # streams): emitting done events for an unannounced item violates
+        # the Responses streaming contract. Mark the done flags so
+        # is_stream_finished() semantics stay intact and fall through to
+        # response.completed.
+        if not getattr(self, "_message_item_added_emitted", False):
+            self.sent_output_text_done_event = True
+            self.sent_output_content_part_done_event = True
+            self.sent_output_item_done_event = True
+            return None
         if self.sent_output_text_done_event is False:
             self.sent_output_text_done_event = True
             return self.create_output_text_done_event(litellm_complete_object)
@@ -817,8 +822,128 @@ class LiteLLMCompletionStreamingIterator(ResponsesAPIStreamingIterator):
     def _ensure_output_item_for_chunk(self, chunk: ModelResponseStream) -> None:
         # Change: Never return a value, just enqueue output item events
         if self.sent_output_item_added_event:
+            # The one-shot added flag may already be consumed by a message
+            # item (role-only first chunk), in which case the reasoning item
+            # was never declared. Emit the reasoning output_item.added when
+            # reasoning_content first appears so _reasoning_active takes
+            # effect and _is_reasoning_end can close the lifecycle later.
+            if not self._reasoning_active and not self._reasoning_done_emitted and chunk.choices:
+                _delta = chunk.choices[0].delta
+                if _delta is not None and hasattr(_delta, "reasoning_content") and _delta.reasoning_content:
+                    self._reasoning_active = True
+                    if self._cached_reasoning_item_id is None:
+                        self._cached_reasoning_item_id = f"rs_{uuid.uuid4()}"
+                    self._reasoning_item_id = self._cached_reasoning_item_id
+                    self._sequence_number += 1
+                    _reasoning_added = OutputItemAddedEvent(
+                        type=ResponsesAPIStreamEvents.OUTPUT_ITEM_ADDED,
+                        output_index=0,
+                        item=BaseLiteLLMOpenAIResponseObject(
+                            **{
+                                "id": self._cached_reasoning_item_id,
+                                "type": "reasoning",
+                                "status": "in_progress",
+                                # summary must be a non-empty list of
+                                # summary_text parts: strict consumers
+                                # require a sequence, and null / missing /
+                                # empty lists (omitted by pydantic
+                                # serialization) cause the whole added frame
+                                # to be rejected.
+                                "summary": [{"type": "summary_text", "text": ""}],
+                            }
+                        ),
+                    )
+                    _reasoning_added.__dict__["sequence_number"] = self._sequence_number
+                    self._pending_response_events.append(_reasoning_added)
+
+            # Once reasoning has ended, the message item must be announced
+            # before its text deltas arrive. If message added was deferred
+            # past the role-only first chunk, emit it here (after the
+            # reasoning lifecycle is closed below) so clients that track a
+            # single active item can bind the upcoming text deltas.
+            if not getattr(self, "_message_item_added_emitted", False) and chunk.choices:
+                _delta3 = chunk.choices[0].delta
+                _chunk_has_reasoning = (
+                    _delta3 is not None and hasattr(_delta3, "reasoning_content") and _delta3.reasoning_content
+                )
+                if _delta3 is not None and hasattr(_delta3, "content") and _delta3.content and not _chunk_has_reasoning:
+                    # Close the reasoning lifecycle before announcing the
+                    # message item: item lifecycles must not overlap.
+                    # Queueing the reasoning done events here (and latching
+                    # _reasoning_done_emitted so the main-loop branch skips
+                    # them) keeps the queue order spec-compliant:
+                    # reasoning done -> message added -> text deltas.
+                    if self._reasoning_active and not self._reasoning_done_emitted:
+                        _reasoning_content = "".join(self._accumulated_reasoning_content_parts)
+                        self._cached_reasoning_item_id = (
+                            self._reasoning_item_id or self._cached_reasoning_item_id or f"rs_{uuid.uuid4()}"
+                        )
+                        _reasoning_item_id = self._cached_reasoning_item_id
+                        self._sequence_number += 1
+                        _rs_text_done = self.create_reasoning_summary_text_done_event(
+                            reasoning_item_id=_reasoning_item_id,
+                            reasoning_content=_reasoning_content,
+                            sequence_number=self._sequence_number,
+                        )
+                        self._sequence_number += 1
+                        _rs_part_done = self.create_reasoning_summary_part_done_event(
+                            reasoning_item_id=_reasoning_item_id,
+                            reasoning_content=_reasoning_content,
+                            sequence_number=self._sequence_number,
+                        )
+                        self._sequence_number += 1
+                        _rs_item_done = self.create_reasoning_output_item_done_event(
+                            reasoning_item_id=_reasoning_item_id,
+                            reasoning_content=_reasoning_content,
+                            sequence_number=self._sequence_number,
+                        )
+                        self._pending_response_events.extend(
+                            [
+                                _rs_text_done,
+                                _rs_part_done,
+                                _rs_item_done,
+                            ]
+                        )
+                        self._reasoning_done_emitted = True
+                        self._reasoning_active = False
+                    self._message_item_added_emitted = True
+                    self._cached_item_id = self._cached_item_id or f"msg_{uuid.uuid4()}"
+                    self._sequence_number += 1
+                    _msg_added = OutputItemAddedEvent(
+                        type=ResponsesAPIStreamEvents.OUTPUT_ITEM_ADDED,
+                        output_index=0,
+                        item=BaseLiteLLMOpenAIResponseObject(
+                            **{
+                                "id": self._cached_item_id,
+                                "type": "message",
+                                "role": "assistant",
+                                "status": "in_progress",
+                                "content": [],
+                            }
+                        ),
+                    )
+                    _msg_added.__dict__["sequence_number"] = self._sequence_number
+                    self._pending_response_events.append(_msg_added)
+                    if not self.sent_content_part_added_event:
+                        self.sent_content_part_added_event = True
+                        _content_part_event = self.create_content_part_added_event()
+                        self._pending_response_events.append(_content_part_event)
+                    self._drain_pending_annotation_events()
             return
         delta: Final = chunk.choices[0].delta
+
+        # Role-only chunks (no content / reasoning_content / tool_calls)
+        # must not decide the item type: defer message output_item.added
+        # until the first chunk carrying actual content. Reasoning
+        # providers commonly start with a role-only chunk; announcing the
+        # message item there breaks the native event order for reasoning
+        # streams. Pure text streams are unaffected (the first content
+        # chunk still takes the default branch, one chunk later).
+        _chunk_has_reasoning = hasattr(delta, "reasoning_content") and delta.reasoning_content
+        _chunk_has_tool_calls = hasattr(delta, "tool_calls") and delta.tool_calls
+        _chunk_has_content = hasattr(delta, "content") and delta.content
+        if not (_chunk_has_reasoning or _chunk_has_tool_calls or _chunk_has_content):
+            return
 
         self._sequence_number += 1
         self.sent_output_item_added_event = True
@@ -838,7 +963,12 @@ class LiteLLMCompletionStreamingIterator(ResponsesAPIStreamingIterator):
                         "id": self._cached_reasoning_item_id,
                         "type": "reasoning",
                         "status": "in_progress",
-                        "summary": None,
+                        # summary must be a non-empty list of summary_text
+                        # parts: strict consumers require a sequence, and
+                        # null / missing / empty lists (omitted by pydantic
+                        # serialization) cause the whole added frame to be
+                        # rejected.
+                        "summary": [{"type": "summary_text", "text": ""}],
                     }
                 ),
             )
@@ -853,6 +983,10 @@ class LiteLLMCompletionStreamingIterator(ResponsesAPIStreamingIterator):
             return
 
         # Default: message
+        # Track that the message item has been announced so the
+        # early-return branch above knows whether a deferred emission
+        # is still needed.
+        self._message_item_added_emitted = True
         self._cached_item_id = self._cached_item_id or f"msg_{uuid.uuid4()}"
         event = OutputItemAddedEvent(
             type=ResponsesAPIStreamEvents.OUTPUT_ITEM_ADDED,
@@ -878,7 +1012,20 @@ class LiteLLMCompletionStreamingIterator(ResponsesAPIStreamingIterator):
             self.sent_content_part_added_event = True
             content_part_event: Final = self.create_content_part_added_event()
             self._pending_response_events.append(content_part_event)
+        self._drain_pending_annotation_events()
         return
+
+    def _drain_pending_annotation_events(self) -> None:
+        """
+        Move annotation.added events collected before the message item was
+        announced onto the event queue, after the message's
+        output_item.added / content_part.added. Annotation events must never
+        reference an item that has not been announced yet, so they are held
+        back until this point.
+        """
+        if hasattr(self, "_pending_annotation_events") and self._pending_annotation_events:
+            self._pending_response_events.extend(self._pending_annotation_events)
+            self._pending_annotation_events = []
 
     async def __anext__(
         self,
@@ -1101,6 +1248,11 @@ class LiteLLMCompletionStreamingIterator(ResponsesAPIStreamingIterator):
                 item_id=self._cached_reasoning_item_id,
                 output_index=0,
                 delta=reasoning_content,
+                # Pass summary_index explicitly: pydantic omits fields
+                # equal to their default when serializing, and strict
+                # consumers require both delta and summary_index to be
+                # present, dropping the frame otherwise.
+                summary_index=0,
             )
 
         # Priority 2: Handle text deltas
@@ -1127,7 +1279,15 @@ class LiteLLMCompletionStreamingIterator(ResponsesAPIStreamingIterator):
 
         # Priority 4: If we have pending annotation events, emit the next one
         # This happens when the current chunk has no text/reasoning content
-        if hasattr(self, "_pending_annotation_events") and self._pending_annotation_events:
+        # Only emit after the message item has been announced: annotation
+        # events reference the message item and must not precede its
+        # output_item.added (events collected before the announcement are
+        # drained onto the queue by the announcement itself).
+        if (
+            hasattr(self, "_pending_annotation_events")
+            and self._pending_annotation_events
+            and getattr(self, "_message_item_added_emitted", False)
+        ):
             event = self._pending_annotation_events.pop(0)
             return event
 

--- a/litellm/responses/litellm_completion_transformation/streaming_iterator.py
+++ b/litellm/responses/litellm_completion_transformation/streaming_iterator.py
@@ -650,7 +650,7 @@ class LiteLLMCompletionStreamingIterator(ResponsesAPIStreamingIterator):
                 annotations=annotations
             )
         )
-        part = ContentPartDonePartOutputText(
+        part: Final = ContentPartDonePartOutputText(
             type="output_text",
             text=text,
             annotations=response_annotations,
@@ -827,8 +827,8 @@ class LiteLLMCompletionStreamingIterator(ResponsesAPIStreamingIterator):
             # was never declared. Emit the reasoning output_item.added when
             # reasoning_content first appears so _reasoning_active takes
             # effect and _is_reasoning_end can close the lifecycle later.
-            if not self._reasoning_active and not self._reasoning_done_emitted and chunk.choices:
-                _delta = chunk.choices[0].delta
+            if not self._reasoning_active and not getattr(self, "_reasoning_done_emitted", False) and chunk.choices:
+                _delta: Final = chunk.choices[0].delta
                 if _delta is not None and hasattr(_delta, "reasoning_content") and _delta.reasoning_content:
                     self._reasoning_active = True
                     if self._cached_reasoning_item_id is None:
@@ -839,7 +839,7 @@ class LiteLLMCompletionStreamingIterator(ResponsesAPIStreamingIterator):
                     # strict consumers require a sequence, and null / missing
                     # / empty lists (omitted by pydantic serialization) cause
                     # the whole added frame to be rejected.
-                    _reasoning_added = OutputItemAddedEvent(
+                    _reasoning_added: Final = OutputItemAddedEvent(
                         type=ResponsesAPIStreamEvents.OUTPUT_ITEM_ADDED,
                         output_index=0,
                         item=BaseLiteLLMOpenAIResponseObject(
@@ -858,8 +858,8 @@ class LiteLLMCompletionStreamingIterator(ResponsesAPIStreamingIterator):
             # reasoning lifecycle is closed below) so clients that track a
             # single active item can bind the upcoming text deltas.
             if not getattr(self, "_message_item_added_emitted", False) and chunk.choices:
-                _delta3 = chunk.choices[0].delta
-                _chunk_has_reasoning = (
+                _delta3: Final = chunk.choices[0].delta
+                _chunk_has_reasoning: Final = (
                     _delta3 is not None and hasattr(_delta3, "reasoning_content") and _delta3.reasoning_content
                 )
                 if _delta3 is not None and hasattr(_delta3, "content") and _delta3.content and not _chunk_has_reasoning:
@@ -869,26 +869,26 @@ class LiteLLMCompletionStreamingIterator(ResponsesAPIStreamingIterator):
                     # _reasoning_done_emitted so the main-loop branch skips
                     # them) keeps the queue order spec-compliant:
                     # reasoning done -> message added -> text deltas.
-                    if self._reasoning_active and not self._reasoning_done_emitted:
-                        _reasoning_content = "".join(self._accumulated_reasoning_content_parts)
+                    if self._reasoning_active and not getattr(self, "_reasoning_done_emitted", False):
+                        _reasoning_content: Final = "".join(self._accumulated_reasoning_content_parts)
                         self._cached_reasoning_item_id = (
                             self._reasoning_item_id or self._cached_reasoning_item_id or f"rs_{uuid.uuid4()}"
                         )
-                        _reasoning_item_id = self._cached_reasoning_item_id
+                        _reasoning_item_id: Final = self._cached_reasoning_item_id
                         self._sequence_number += 1
-                        _rs_text_done = self.create_reasoning_summary_text_done_event(
+                        _rs_text_done: Final = self.create_reasoning_summary_text_done_event(
                             reasoning_item_id=_reasoning_item_id,
                             reasoning_content=_reasoning_content,
                             sequence_number=self._sequence_number,
                         )
                         self._sequence_number += 1
-                        _rs_part_done = self.create_reasoning_summary_part_done_event(
+                        _rs_part_done: Final = self.create_reasoning_summary_part_done_event(
                             reasoning_item_id=_reasoning_item_id,
                             reasoning_content=_reasoning_content,
                             sequence_number=self._sequence_number,
                         )
                         self._sequence_number += 1
-                        _rs_item_done = self.create_reasoning_output_item_done_event(
+                        _rs_item_done: Final = self.create_reasoning_output_item_done_event(
                             reasoning_item_id=_reasoning_item_id,
                             reasoning_content=_reasoning_content,
                             sequence_number=self._sequence_number,
@@ -905,7 +905,7 @@ class LiteLLMCompletionStreamingIterator(ResponsesAPIStreamingIterator):
                     self._message_item_added_emitted = True
                     self._cached_item_id = self._cached_item_id or f"msg_{uuid.uuid4()}"
                     self._sequence_number += 1
-                    _msg_added = OutputItemAddedEvent(
+                    _msg_added: Final = OutputItemAddedEvent(
                         type=ResponsesAPIStreamEvents.OUTPUT_ITEM_ADDED,
                         output_index=0,
                         item=BaseLiteLLMOpenAIResponseObject(
@@ -920,7 +920,7 @@ class LiteLLMCompletionStreamingIterator(ResponsesAPIStreamingIterator):
                     self._pending_response_events.append(_msg_added)
                     if not self.sent_content_part_added_event:
                         self.sent_content_part_added_event = True
-                        _content_part_event = self.create_content_part_added_event()
+                        _content_part_event: Final = self.create_content_part_added_event()
                         self._pending_response_events.append(_content_part_event)
                     self._drain_pending_annotation_events()
             return
@@ -933,9 +933,9 @@ class LiteLLMCompletionStreamingIterator(ResponsesAPIStreamingIterator):
         # message item there breaks the native event order for reasoning
         # streams. Pure text streams are unaffected (the first content
         # chunk still takes the default branch, one chunk later).
-        _chunk_has_reasoning = hasattr(delta, "reasoning_content") and delta.reasoning_content
-        _chunk_has_tool_calls = hasattr(delta, "tool_calls") and delta.tool_calls
-        _chunk_has_content = hasattr(delta, "content") and delta.content
+        _chunk_has_reasoning: Final = hasattr(delta, "reasoning_content") and delta.reasoning_content
+        _chunk_has_tool_calls: Final = hasattr(delta, "tool_calls") and delta.tool_calls
+        _chunk_has_content: Final = hasattr(delta, "content") and delta.content
         if not (_chunk_has_reasoning or _chunk_has_tool_calls or _chunk_has_content):
             return
 

--- a/litellm/responses/litellm_completion_transformation/streaming_iterator.py
+++ b/litellm/responses/litellm_completion_transformation/streaming_iterator.py
@@ -835,22 +835,18 @@ class LiteLLMCompletionStreamingIterator(ResponsesAPIStreamingIterator):
                         self._cached_reasoning_item_id = f"rs_{uuid.uuid4()}"
                     self._reasoning_item_id = self._cached_reasoning_item_id
                     self._sequence_number += 1
+                    # summary must be a non-empty list of summary_text parts:
+                    # strict consumers require a sequence, and null / missing
+                    # / empty lists (omitted by pydantic serialization) cause
+                    # the whole added frame to be rejected.
                     _reasoning_added = OutputItemAddedEvent(
                         type=ResponsesAPIStreamEvents.OUTPUT_ITEM_ADDED,
                         output_index=0,
                         item=BaseLiteLLMOpenAIResponseObject(
-                            **{
-                                "id": self._cached_reasoning_item_id,
-                                "type": "reasoning",
-                                "status": "in_progress",
-                                # summary must be a non-empty list of
-                                # summary_text parts: strict consumers
-                                # require a sequence, and null / missing /
-                                # empty lists (omitted by pydantic
-                                # serialization) cause the whole added frame
-                                # to be rejected.
-                                "summary": [{"type": "summary_text", "text": ""}],
-                            }
+                            id=self._cached_reasoning_item_id,
+                            type="reasoning",
+                            status="in_progress",
+                            summary=[{"type": "summary_text", "text": ""}],
                         ),
                     )
                     _reasoning_added.__dict__["sequence_number"] = self._sequence_number
@@ -913,13 +909,11 @@ class LiteLLMCompletionStreamingIterator(ResponsesAPIStreamingIterator):
                         type=ResponsesAPIStreamEvents.OUTPUT_ITEM_ADDED,
                         output_index=0,
                         item=BaseLiteLLMOpenAIResponseObject(
-                            **{
-                                "id": self._cached_item_id,
-                                "type": "message",
-                                "role": "assistant",
-                                "status": "in_progress",
-                                "content": [],
-                            }
+                            id=self._cached_item_id,
+                            type="message",
+                            role="assistant",
+                            status="in_progress",
+                            content=[],
                         ),
                     )
                     _msg_added.__dict__["sequence_number"] = self._sequence_number

--- a/litellm/responses/litellm_completion_transformation/streaming_iterator.py
+++ b/litellm/responses/litellm_completion_transformation/streaming_iterator.py
@@ -915,17 +915,29 @@ class LiteLLMCompletionStreamingIterator(ResponsesAPIStreamingIterator):
             return
         delta: Final = chunk.choices[0].delta
 
-        # Role-only chunks (no content / reasoning_content / tool_calls)
-        # must not decide the item type: defer message output_item.added
-        # until the first chunk carrying actual content. Reasoning
-        # providers commonly start with a role-only chunk; announcing the
-        # message item there breaks the native event order for reasoning
-        # streams. Pure text streams are unaffected (the first content
-        # chunk still takes the default branch, one chunk later).
+        # Role-only chunks (no content / reasoning_content / tool_calls /
+        # annotations) must not decide the item type: defer message
+        # output_item.added until the first chunk carrying actual content.
+        # Reasoning providers commonly start with a role-only chunk;
+        # announcing the message item there breaks the native event order
+        # for reasoning streams. Pure text streams are unaffected (the first
+        # content chunk still takes the default branch, one chunk later).
+        #
+        # Annotations count as content: an annotation event references the
+        # message item, and it is buffered until that item is announced, so
+        # deferring here would strand it -- an annotation-only stream would
+        # end with the item never announced and the buffer never drained.
         _chunk_has_reasoning: Final = hasattr(delta, "reasoning_content") and delta.reasoning_content
         _chunk_has_tool_calls: Final = hasattr(delta, "tool_calls") and delta.tool_calls
         _chunk_has_content: Final = hasattr(delta, "content") and delta.content
-        if not (_chunk_has_reasoning or _chunk_has_tool_calls or _chunk_has_content):
+        _chunk_has_annotations: Final = hasattr(delta, "annotations") and delta.annotations
+        if not (
+            _chunk_has_reasoning
+            or _chunk_has_tool_calls
+            or _chunk_has_content
+            or _chunk_has_annotations
+            or getattr(self, "_pending_annotation_events", None)
+        ):
             return
 
         self._sequence_number += 1

--- a/litellm/responses/litellm_completion_transformation/streaming_iterator.py
+++ b/litellm/responses/litellm_completion_transformation/streaming_iterator.py
@@ -641,7 +641,6 @@ class LiteLLMCompletionStreamingIterator(ResponsesAPIStreamingIterator):
         text: Final = getattr(litellm_complete_object.choices[0].message, "content", "") or ""
         annotations: Final = getattr(litellm_complete_object.choices[0].message, "annotations", None)
 
-        part: PART_UNION_TYPES | None = None
         # The message item's content part always carries the assistant text
         # as output_text. Reasoning content belongs to the reasoning item
         # (a separate output item), never to the message item's parts.
@@ -650,7 +649,7 @@ class LiteLLMCompletionStreamingIterator(ResponsesAPIStreamingIterator):
                 annotations=annotations
             )
         )
-        part: Final = ContentPartDonePartOutputText(
+        part: Final[PART_UNION_TYPES] = ContentPartDonePartOutputText(
             type="output_text",
             text=text,
             annotations=response_annotations,
@@ -829,7 +828,7 @@ class LiteLLMCompletionStreamingIterator(ResponsesAPIStreamingIterator):
             # effect and _is_reasoning_end can close the lifecycle later.
             if not self._reasoning_active and not getattr(self, "_reasoning_done_emitted", False) and chunk.choices:
                 _delta: Final = chunk.choices[0].delta
-                if _delta is not None and hasattr(_delta, "reasoning_content") and _delta.reasoning_content:
+                if getattr(_delta, "reasoning_content", None):
                     self._reasoning_active = True
                     if self._cached_reasoning_item_id is None:
                         self._cached_reasoning_item_id = f"rs_{uuid.uuid4()}"
@@ -843,10 +842,12 @@ class LiteLLMCompletionStreamingIterator(ResponsesAPIStreamingIterator):
                         type=ResponsesAPIStreamEvents.OUTPUT_ITEM_ADDED,
                         output_index=0,
                         item=BaseLiteLLMOpenAIResponseObject(
-                            id=self._cached_reasoning_item_id,
-                            type="reasoning",
-                            status="in_progress",
-                            summary=[{"type": "summary_text", "text": ""}],
+                            **{
+                                "id": self._cached_reasoning_item_id,
+                                "type": "reasoning",
+                                "status": "in_progress",
+                                "summary": [{"type": "summary_text", "text": ""}],
+                            }
                         ),
                     )
                     _reasoning_added.__dict__["sequence_number"] = self._sequence_number
@@ -859,10 +860,8 @@ class LiteLLMCompletionStreamingIterator(ResponsesAPIStreamingIterator):
             # single active item can bind the upcoming text deltas.
             if not getattr(self, "_message_item_added_emitted", False) and chunk.choices:
                 _delta3: Final = chunk.choices[0].delta
-                _chunk_has_reasoning: Final = (
-                    _delta3 is not None and hasattr(_delta3, "reasoning_content") and _delta3.reasoning_content
-                )
-                if _delta3 is not None and hasattr(_delta3, "content") and _delta3.content and not _chunk_has_reasoning:
+                _delta3_has_reasoning: Final[bool] = bool(getattr(_delta3, "reasoning_content", None))
+                if getattr(_delta3, "content", None) and not _delta3_has_reasoning:
                     # Close the reasoning lifecycle before announcing the
                     # message item: item lifecycles must not overlap.
                     # Queueing the reasoning done events here (and latching
@@ -909,11 +908,13 @@ class LiteLLMCompletionStreamingIterator(ResponsesAPIStreamingIterator):
                         type=ResponsesAPIStreamEvents.OUTPUT_ITEM_ADDED,
                         output_index=0,
                         item=BaseLiteLLMOpenAIResponseObject(
-                            id=self._cached_item_id,
-                            type="message",
-                            role="assistant",
-                            status="in_progress",
-                            content=[],
+                            **{
+                                "id": self._cached_item_id,
+                                "type": "message",
+                                "role": "assistant",
+                                "status": "in_progress",
+                                "content": [],
+                            }
                         ),
                     )
                     _msg_added.__dict__["sequence_number"] = self._sequence_number

--- a/tests/test_litellm/responses/litellm_completion_transformation/test_function_call_output_normalization.py
+++ b/tests/test_litellm/responses/litellm_completion_transformation/test_function_call_output_normalization.py
@@ -6,9 +6,27 @@ as tool/function response parts; if the tool output is passed as a list of input
 we normalize it to text/image blocks or a string.
 """
 
+import pytest
+
 from litellm.responses.litellm_completion_transformation.transformation import (
+    TOOL_CALLS_CACHE,
     LiteLLMCompletionResponsesConfig,
 )
+
+
+@pytest.fixture(autouse=True)
+def clear_cached_tool_use_definition():
+    """
+    TOOL_CALLS_CACHE is module-level state shared by every test in a worker:
+    transforming a completion that carries tool_calls stores the definition
+    under the call id, and this transformation prepends that assistant turn
+    when the ids match. Under xdist there is no per-module litellm reload to
+    clear it, so drop the id around each test -- otherwise the message count
+    below depends on whichever tests happened to run earlier in the worker.
+    """
+    TOOL_CALLS_CACHE.delete_cache(key="call_1")
+    yield
+    TOOL_CALLS_CACHE.delete_cache(key="call_1")
 
 
 def test_function_call_output_list_input_text_is_converted_to_tool_string_content():

--- a/tests/test_litellm/responses/litellm_completion_transformation/test_streaming_event_order.py
+++ b/tests/test_litellm/responses/litellm_completion_transformation/test_streaming_event_order.py
@@ -133,7 +133,7 @@ async def test_reasoning_then_text_emits_native_event_order():
     events = await _collect_events(_reasoning_then_text_chunks())
 
     item_events = _output_item_events(events)
-    seq = [f"{_event_type(event)}[{ _item_type(event) }]" for event in item_events]
+    seq = [f"{_event_type(event)}[{_item_type(event)}]" for event in item_events]
 
     assert seq == [
         f"{ResponsesAPIStreamEvents.OUTPUT_ITEM_ADDED}[reasoning]",
@@ -145,9 +145,7 @@ async def test_reasoning_then_text_emits_native_event_order():
     # text deltas must come after the message item announcement
     types = [_event_type(event) for event in events]
     message_added_idx = types.index(str(ResponsesAPIStreamEvents.OUTPUT_ITEM_ADDED))
-    assert (
-        types.index(str(ResponsesAPIStreamEvents.OUTPUT_TEXT_DELTA)) > message_added_idx
-    )
+    assert types.index(str(ResponsesAPIStreamEvents.OUTPUT_TEXT_DELTA)) > message_added_idx
 
 
 @pytest.mark.asyncio
@@ -159,10 +157,7 @@ async def test_reasoning_delta_carries_summary_index():
     events = await _collect_events(_reasoning_then_text_chunks())
 
     deltas = [
-        event
-        for event in events
-        if _event_type(event)
-        == str(ResponsesAPIStreamEvents.REASONING_SUMMARY_TEXT_DELTA)
+        event for event in events if _event_type(event) == str(ResponsesAPIStreamEvents.REASONING_SUMMARY_TEXT_DELTA)
     ]
     assert len(deltas) == 2
     for event in deltas:
@@ -180,11 +175,7 @@ async def test_content_part_done_is_output_text_when_reasoning_present():
     """
     events = await _collect_events(_reasoning_then_text_chunks())
 
-    part_done = [
-        event
-        for event in events
-        if _event_type(event) == str(ResponsesAPIStreamEvents.CONTENT_PART_DONE)
-    ]
+    part_done = [event for event in events if _event_type(event) == str(ResponsesAPIStreamEvents.CONTENT_PART_DONE)]
     assert len(part_done) == 1
     assert part_done[0].part.type == "output_text"
     assert part_done[0].part.text == "Hello world"
@@ -216,24 +207,19 @@ async def test_tool_call_only_stream_skips_ghost_message_done():
     events = await _collect_events(chunks)
 
     # reasoning lifecycle must be complete
-    item_seq = [
-        f"{_event_type(event)}[{ _item_type(event) }]"
-        for event in _output_item_events(events)
-    ]
-    assert (
-        f"{ResponsesAPIStreamEvents.OUTPUT_ITEM_ADDED}[reasoning]" in item_seq
-    ), f"missing reasoning added: {item_seq}"
-    assert (
-        f"{ResponsesAPIStreamEvents.OUTPUT_ITEM_DONE}[reasoning]" in item_seq
-    ), f"missing reasoning done: {item_seq}"
+    item_seq = [f"{_event_type(event)}[{_item_type(event)}]" for event in _output_item_events(events)]
+    assert f"{ResponsesAPIStreamEvents.OUTPUT_ITEM_ADDED}[reasoning]" in item_seq, (
+        f"missing reasoning added: {item_seq}"
+    )
+    assert f"{ResponsesAPIStreamEvents.OUTPUT_ITEM_DONE}[reasoning]" in item_seq, f"missing reasoning done: {item_seq}"
 
     # no ghost message item: never added, so it must never be done
-    assert (
-        f"{ResponsesAPIStreamEvents.OUTPUT_ITEM_ADDED}[message]" not in item_seq
-    ), f"unexpected message added: {item_seq}"
-    assert (
-        f"{ResponsesAPIStreamEvents.OUTPUT_ITEM_DONE}[message]" not in item_seq
-    ), f"ghost message done emitted: {item_seq}"
+    assert f"{ResponsesAPIStreamEvents.OUTPUT_ITEM_ADDED}[message]" not in item_seq, (
+        f"unexpected message added: {item_seq}"
+    )
+    assert f"{ResponsesAPIStreamEvents.OUTPUT_ITEM_DONE}[message]" not in item_seq, (
+        f"ghost message done emitted: {item_seq}"
+    )
 
     # no trailing message text/part done events either
     types = [_event_type(event) for event in events]
@@ -268,18 +254,13 @@ async def test_reasoning_after_tool_call_still_gets_item_declaration():
     ]
     events = await _collect_events(chunks)
 
-    item_seq = [
-        f"{_event_type(event)}[{ _item_type(event) }]"
-        for event in _output_item_events(events)
-    ]
-    assert (
-        f"{ResponsesAPIStreamEvents.OUTPUT_ITEM_ADDED}[reasoning]" in item_seq
-    ), f"reasoning item was never declared: {item_seq}"
+    item_seq = [f"{_event_type(event)}[{_item_type(event)}]" for event in _output_item_events(events)]
+    assert f"{ResponsesAPIStreamEvents.OUTPUT_ITEM_ADDED}[reasoning]" in item_seq, (
+        f"reasoning item was never declared: {item_seq}"
+    )
 
     # reasoning lifecycle must close before the message item is announced
-    assert item_seq.index(
-        f"{ResponsesAPIStreamEvents.OUTPUT_ITEM_DONE}[reasoning]"
-    ) < item_seq.index(
+    assert item_seq.index(f"{ResponsesAPIStreamEvents.OUTPUT_ITEM_DONE}[reasoning]") < item_seq.index(
         f"{ResponsesAPIStreamEvents.OUTPUT_ITEM_ADDED}[message]"
     ), f"reasoning done overlaps message added: {item_seq}"
 
@@ -287,14 +268,10 @@ async def test_reasoning_after_tool_call_still_gets_item_declaration():
     reasoning_added = [
         event
         for event in _output_item_events(events)
-        if f"{_event_type(event)}[reasoning]"
-        == f"{ResponsesAPIStreamEvents.OUTPUT_ITEM_ADDED}[reasoning]"
+        if f"{_event_type(event)}[{_item_type(event)}]" == f"{ResponsesAPIStreamEvents.OUTPUT_ITEM_ADDED}[reasoning]"
     ][0]
     deltas = [
-        event
-        for event in events
-        if _event_type(event)
-        == str(ResponsesAPIStreamEvents.REASONING_SUMMARY_TEXT_DELTA)
+        event for event in events if _event_type(event) == str(ResponsesAPIStreamEvents.REASONING_SUMMARY_TEXT_DELTA)
     ]
     assert len(deltas) == 1
     assert deltas[0].item_id == reasoning_added.item.id
@@ -324,27 +301,17 @@ async def test_annotation_events_wait_for_message_item_announcement():
     events = await _collect_events(chunks)
 
     types = [_event_type(event) for event in events]
-    message_added_idx = next(
-        i
-        for i, t in enumerate(types)
-        if t == str(ResponsesAPIStreamEvents.OUTPUT_ITEM_ADDED)
-    )
+    message_added_idx = next(i for i, t in enumerate(types) if t == str(ResponsesAPIStreamEvents.OUTPUT_ITEM_ADDED))
     annotation_idx = next(
-        i
-        for i, t in enumerate(types)
-        if t == str(ResponsesAPIStreamEvents.OUTPUT_TEXT_ANNOTATION_ADDED)
+        i for i, t in enumerate(types) if t == str(ResponsesAPIStreamEvents.OUTPUT_TEXT_ANNOTATION_ADDED)
     )
     assert annotation_idx > message_added_idx, (
-        "annotation.added must not precede the message output_item.added:"
-        f" types={types}"
+        f"annotation.added must not precede the message output_item.added: types={types}"
     )
 
     # the annotation must reference the announced message item
     annotation_events = [
-        event
-        for event in events
-        if _event_type(event)
-        == str(ResponsesAPIStreamEvents.OUTPUT_TEXT_ANNOTATION_ADDED)
+        event for event in events if _event_type(event) == str(ResponsesAPIStreamEvents.OUTPUT_TEXT_ANNOTATION_ADDED)
     ]
     assert len(annotation_events) == 1
     message_added = events[message_added_idx]

--- a/tests/test_litellm/responses/litellm_completion_transformation/test_streaming_event_order.py
+++ b/tests/test_litellm/responses/litellm_completion_transformation/test_streaming_event_order.py
@@ -1,0 +1,351 @@
+"""
+Regression tests for the chat-completions -> Responses API streaming bridge
+event ordering in
+litellm/responses/litellm_completion_transformation/streaming_iterator.py.
+
+DeepSeek-style reasoning streams (role-only first chunk, then
+reasoning_content deltas, then content deltas) previously produced event
+sequences that violate the OpenAI Responses streaming contract:
+
+1. ``response.output_item.added`` for the message item was emitted *before*
+   ``response.output_item.done`` for the reasoning item (overlapping item
+   lifecycles). Clients that track a single active item (e.g. codex) drop
+   all subsequent text deltas as a result.
+2. Tool-call-only streams (reasoning + function_call, no assistant text)
+   emitted a trailing message ``output_text.done`` / ``content_part.done`` /
+   ``output_item.done`` trio for a message item that was never announced via
+   ``output_item.added`` ("ghost" message item). The content part also
+   carried the reasoning text under a non-standard ``reasoning_text`` type.
+3. ``ReasoningSummaryTextDeltaEvent`` omitted ``summary_index`` when
+   serialized with ``exclude_unset`` semantics (field equals its default 0),
+   which strict consumers reject.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from litellm.responses.litellm_completion_transformation.streaming_iterator import (
+    LiteLLMCompletionStreamingIterator,
+)
+from litellm.types.llms.openai import ResponsesAPIStreamEvents
+from litellm.types.utils import Delta, ModelResponseStream, StreamingChoices
+
+CHAT_COMPLETION_ID = "chatcmpl-77d33d09-effa-4cd2-9c0d-c742d4358256"
+
+
+def _chunk(
+    content: str | None = None,
+    reasoning_content: str | None = None,
+    tool_calls: list | None = None,
+    annotations: list | None = None,
+    finish_reason: str | None = None,
+) -> ModelResponseStream:
+    return ModelResponseStream(
+        id=CHAT_COMPLETION_ID,
+        created=1748575031,
+        model="deepseek-v4-flash",
+        object="chat.completion.chunk",
+        choices=[
+            StreamingChoices(
+                index=0,
+                delta=Delta(
+                    role="assistant",
+                    content=content,
+                    reasoning_content=reasoning_content,
+                    tool_calls=tool_calls,
+                    annotations=annotations,
+                ),
+                finish_reason=finish_reason,
+            )
+        ],
+    )
+
+
+class _FakeStreamWrapper:
+    def __init__(self, chunks):
+        self._chunks = list(chunks)
+        self.logging_obj = MagicMock()
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        if not self._chunks:
+            raise StopAsyncIteration
+        return self._chunks.pop(0)
+
+
+async def _collect_events(chunks) -> list:
+    iterator = LiteLLMCompletionStreamingIterator(
+        model="deepseek-v4-flash",
+        litellm_custom_stream_wrapper=_FakeStreamWrapper(chunks),
+        request_input="hello",
+        responses_api_request={},
+        custom_llm_provider="openai",
+        litellm_metadata={},
+    )
+    events = []
+    async for event in iterator:
+        events.append(event)
+    return events
+
+
+def _event_type(event) -> str:
+    return str(getattr(event, "type", ""))
+
+
+def _item_type(event) -> str:
+    item = getattr(event, "item", None)
+    return str(getattr(item, "type", "")) if item is not None else ""
+
+
+def _output_item_events(events) -> list:
+    return [
+        event
+        for event in events
+        if _event_type(event)
+        in (
+            str(ResponsesAPIStreamEvents.OUTPUT_ITEM_ADDED),
+            str(ResponsesAPIStreamEvents.OUTPUT_ITEM_DONE),
+        )
+    ]
+
+
+def _reasoning_then_text_chunks() -> list:
+    return [
+        _chunk(),  # role-only first chunk (DeepSeek style)
+        _chunk(reasoning_content="Let me think."),
+        _chunk(reasoning_content=" Step two."),
+        _chunk(content="Hello"),
+        _chunk(content=" world"),
+        _chunk(finish_reason="stop"),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_reasoning_then_text_emits_native_event_order():
+    """
+    Reasoning item must be fully closed (output_item.done) before the message
+    item is announced (output_item.added), matching the OpenAI Responses
+    native sequence: no overlapping item lifecycles.
+    """
+    events = await _collect_events(_reasoning_then_text_chunks())
+
+    item_events = _output_item_events(events)
+    seq = [f"{_event_type(event)}[{ _item_type(event) }]" for event in item_events]
+
+    assert seq == [
+        f"{ResponsesAPIStreamEvents.OUTPUT_ITEM_ADDED}[reasoning]",
+        f"{ResponsesAPIStreamEvents.OUTPUT_ITEM_DONE}[reasoning]",
+        f"{ResponsesAPIStreamEvents.OUTPUT_ITEM_ADDED}[message]",
+        f"{ResponsesAPIStreamEvents.OUTPUT_ITEM_DONE}[message]",
+    ], f"unexpected item lifecycle sequence: {seq}"
+
+    # text deltas must come after the message item announcement
+    types = [_event_type(event) for event in events]
+    message_added_idx = types.index(str(ResponsesAPIStreamEvents.OUTPUT_ITEM_ADDED))
+    assert (
+        types.index(str(ResponsesAPIStreamEvents.OUTPUT_TEXT_DELTA)) > message_added_idx
+    )
+
+
+@pytest.mark.asyncio
+async def test_reasoning_delta_carries_summary_index():
+    """
+    Reasoning summary text deltas must carry summary_index even under
+    exclude_unset serialization semantics (the field equals its default 0).
+    """
+    events = await _collect_events(_reasoning_then_text_chunks())
+
+    deltas = [
+        event
+        for event in events
+        if _event_type(event)
+        == str(ResponsesAPIStreamEvents.REASONING_SUMMARY_TEXT_DELTA)
+    ]
+    assert len(deltas) == 2
+    for event in deltas:
+        assert event.summary_index == 0
+        assert "summary_index" in event.model_dump(exclude_unset=True)
+
+
+@pytest.mark.asyncio
+async def test_content_part_done_is_output_text_when_reasoning_present():
+    """
+    The message content part must always be output_text. Previously the
+    bridge stuffed the full reasoning text into the message's content part
+    under a non-standard reasoning_text type whenever the final response
+    carried reasoning_content.
+    """
+    events = await _collect_events(_reasoning_then_text_chunks())
+
+    part_done = [
+        event
+        for event in events
+        if _event_type(event) == str(ResponsesAPIStreamEvents.CONTENT_PART_DONE)
+    ]
+    assert len(part_done) == 1
+    assert part_done[0].part.type == "output_text"
+    assert part_done[0].part.text == "Hello world"
+
+
+@pytest.mark.asyncio
+async def test_tool_call_only_stream_skips_ghost_message_done():
+    """
+    A reasoning + tool-call stream with no assistant text must not emit any
+    message item events at stream end: the message item was never announced
+    via output_item.added, so emitting done events for it produces a "ghost"
+    item that spec-compliant consumers reject.
+    """
+    chunks = [
+        _chunk(),  # role-only first chunk
+        _chunk(reasoning_content="Thinking about the tool call."),
+        _chunk(
+            tool_calls=[
+                {
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {"name": "do_thing", "arguments": '{"x":1}'},
+                    "index": 0,
+                }
+            ]
+        ),
+        _chunk(finish_reason="tool_calls"),
+    ]
+    events = await _collect_events(chunks)
+
+    # reasoning lifecycle must be complete
+    item_seq = [
+        f"{_event_type(event)}[{ _item_type(event) }]"
+        for event in _output_item_events(events)
+    ]
+    assert (
+        f"{ResponsesAPIStreamEvents.OUTPUT_ITEM_ADDED}[reasoning]" in item_seq
+    ), f"missing reasoning added: {item_seq}"
+    assert (
+        f"{ResponsesAPIStreamEvents.OUTPUT_ITEM_DONE}[reasoning]" in item_seq
+    ), f"missing reasoning done: {item_seq}"
+
+    # no ghost message item: never added, so it must never be done
+    assert (
+        f"{ResponsesAPIStreamEvents.OUTPUT_ITEM_ADDED}[message]" not in item_seq
+    ), f"unexpected message added: {item_seq}"
+    assert (
+        f"{ResponsesAPIStreamEvents.OUTPUT_ITEM_DONE}[message]" not in item_seq
+    ), f"ghost message done emitted: {item_seq}"
+
+    # no trailing message text/part done events either
+    types = [_event_type(event) for event in events]
+    assert str(ResponsesAPIStreamEvents.OUTPUT_TEXT_DONE) not in types
+    assert str(ResponsesAPIStreamEvents.CONTENT_PART_DONE) not in types
+
+    # stream still terminates with response.completed
+    assert str(ResponsesAPIStreamEvents.RESPONSE_COMPLETED) in types
+
+
+@pytest.mark.asyncio
+async def test_reasoning_after_tool_call_still_gets_item_declaration():
+    """
+    When the one-shot added flag is consumed by a tool-call chunk before any
+    reasoning_content arrives, the reasoning item declaration must still be
+    emitted (reasoning deltas cannot reference an undeclared item).
+    """
+    chunks = [
+        _chunk(
+            tool_calls=[
+                {
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {"name": "do_thing", "arguments": "{}"},
+                    "index": 0,
+                }
+            ]
+        ),
+        _chunk(reasoning_content="Thinking after the tool call."),
+        _chunk(content="Result"),
+        _chunk(finish_reason="stop"),
+    ]
+    events = await _collect_events(chunks)
+
+    item_seq = [
+        f"{_event_type(event)}[{ _item_type(event) }]"
+        for event in _output_item_events(events)
+    ]
+    assert (
+        f"{ResponsesAPIStreamEvents.OUTPUT_ITEM_ADDED}[reasoning]" in item_seq
+    ), f"reasoning item was never declared: {item_seq}"
+
+    # reasoning lifecycle must close before the message item is announced
+    assert item_seq.index(
+        f"{ResponsesAPIStreamEvents.OUTPUT_ITEM_DONE}[reasoning]"
+    ) < item_seq.index(
+        f"{ResponsesAPIStreamEvents.OUTPUT_ITEM_ADDED}[message]"
+    ), f"reasoning done overlaps message added: {item_seq}"
+
+    # reasoning deltas must reference the declared reasoning item
+    reasoning_added = [
+        event
+        for event in _output_item_events(events)
+        if f"{_event_type(event)}[reasoning]"
+        == f"{ResponsesAPIStreamEvents.OUTPUT_ITEM_ADDED}[reasoning]"
+    ][0]
+    deltas = [
+        event
+        for event in events
+        if _event_type(event)
+        == str(ResponsesAPIStreamEvents.REASONING_SUMMARY_TEXT_DELTA)
+    ]
+    assert len(deltas) == 1
+    assert deltas[0].item_id == reasoning_added.item.id
+
+
+@pytest.mark.asyncio
+async def test_annotation_events_wait_for_message_item_announcement():
+    """
+    Annotation events reference the message item; they must not be emitted
+    before the message item's output_item.added, even when the annotation
+    chunk arrives before the first content chunk.
+    """
+    annotation = {
+        "type": "url_citation",
+        "url_citation": {
+            "start_index": 0,
+            "end_index": 6,
+            "url": "https://example.com",
+            "title": "Example",
+        },
+    }
+    chunks = [
+        _chunk(annotations=[annotation]),  # annotation before any content
+        _chunk(content="Answer with a citation"),
+        _chunk(finish_reason="stop"),
+    ]
+    events = await _collect_events(chunks)
+
+    types = [_event_type(event) for event in events]
+    message_added_idx = next(
+        i
+        for i, t in enumerate(types)
+        if t == str(ResponsesAPIStreamEvents.OUTPUT_ITEM_ADDED)
+    )
+    annotation_idx = next(
+        i
+        for i, t in enumerate(types)
+        if t == str(ResponsesAPIStreamEvents.OUTPUT_TEXT_ANNOTATION_ADDED)
+    )
+    assert annotation_idx > message_added_idx, (
+        "annotation.added must not precede the message output_item.added:"
+        f" types={types}"
+    )
+
+    # the annotation must reference the announced message item
+    annotation_events = [
+        event
+        for event in events
+        if _event_type(event)
+        == str(ResponsesAPIStreamEvents.OUTPUT_TEXT_ANNOTATION_ADDED)
+    ]
+    assert len(annotation_events) == 1
+    message_added = events[message_added_idx]
+    assert annotation_events[0].item_id == message_added.item.id

--- a/tests/test_litellm/responses/litellm_completion_transformation/test_streaming_event_order.py
+++ b/tests/test_litellm/responses/litellm_completion_transformation/test_streaming_event_order.py
@@ -353,6 +353,35 @@ async def test_annotation_only_stream_still_delivers_the_annotation():
 
 
 @pytest.mark.asyncio
+async def test_annotation_during_reasoning_is_drained_at_announcement():
+    """
+    An annotation arriving while the message item is still deferred (the
+    stream is inside the reasoning item) is buffered and flushed when the
+    message item is finally announced, so it still lands after that item's
+    output_item.added instead of being stranded in the buffer.
+    """
+    events = await _collect_events(
+        [
+            _chunk(reasoning_content="Thinking", annotations=[URL_CITATION_ANNOTATION]),
+            _chunk(content="Answer"),
+            _chunk(finish_reason="stop"),
+        ]
+    )
+    types = [_event_type(event) for event in events]
+    annotation_added = str(ResponsesAPIStreamEvents.OUTPUT_TEXT_ANNOTATION_ADDED)
+    assert annotation_added in types, f"buffered annotation was dropped: types={types}"
+
+    message_added_idx = next(
+        i
+        for i, event in enumerate(events)
+        if _event_type(event) == str(ResponsesAPIStreamEvents.OUTPUT_ITEM_ADDED) and _item_type(event) == "message"
+    )
+    assert types.index(annotation_added) > message_added_idx, (
+        f"drained annotation must follow the message output_item.added: types={types}"
+    )
+
+
+@pytest.mark.asyncio
 async def test_annotation_on_the_final_chunk_is_not_dropped():
     """
     The per-chunk emit path only runs while chunks are still arriving, so an

--- a/tests/test_litellm/responses/litellm_completion_transformation/test_streaming_event_order.py
+++ b/tests/test_litellm/responses/litellm_completion_transformation/test_streaming_event_order.py
@@ -195,7 +195,7 @@ async def test_tool_call_only_stream_skips_ghost_message_done():
         _chunk(
             tool_calls=[
                 {
-                    "id": "call_1",
+                    "id": "call_deferred_message",
                     "type": "function",
                     "function": {"name": "do_thing", "arguments": '{"x":1}'},
                     "index": 0,
@@ -241,7 +241,7 @@ async def test_reasoning_after_tool_call_still_gets_item_declaration():
         _chunk(
             tool_calls=[
                 {
-                    "id": "call_1",
+                    "id": "call_late_reasoning",
                     "type": "function",
                     "function": {"name": "do_thing", "arguments": "{}"},
                     "index": 0,

--- a/tests/test_litellm/responses/litellm_completion_transformation/test_streaming_event_order.py
+++ b/tests/test_litellm/responses/litellm_completion_transformation/test_streaming_event_order.py
@@ -21,6 +21,7 @@ sequences that violate the OpenAI Responses streaming contract:
    which strict consumers reject.
 """
 
+from typing import Final
 from unittest.mock import MagicMock
 
 import pytest
@@ -316,3 +317,57 @@ async def test_annotation_events_wait_for_message_item_announcement():
     assert len(annotation_events) == 1
     message_added = events[message_added_idx]
     assert annotation_events[0].item_id == message_added.item.id
+
+
+URL_CITATION_ANNOTATION: Final = {
+    "type": "url_citation",
+    "url_citation": {
+        "start_index": 0,
+        "end_index": 6,
+        "url": "https://example.com/citation",
+        "title": "Example",
+    },
+}
+
+
+@pytest.mark.asyncio
+async def test_annotation_only_stream_still_delivers_the_annotation():
+    """
+    Regression: an annotation-only chunk carries no content, so deferring the
+    message item past it strands the annotation -- annotation events are
+    buffered until their item is announced, and the stream would reach
+    response.completed with the buffer never drained.
+    """
+    events = await _collect_events(
+        [
+            _chunk(annotations=[URL_CITATION_ANNOTATION]),
+            _chunk(finish_reason="stop"),
+        ]
+    )
+    types = [_event_type(event) for event in events]
+    annotation_added = str(ResponsesAPIStreamEvents.OUTPUT_TEXT_ANNOTATION_ADDED)
+    assert annotation_added in types, f"annotation-only stream dropped the annotation: types={types}"
+    assert types.index(annotation_added) > types.index(str(ResponsesAPIStreamEvents.OUTPUT_ITEM_ADDED)), (
+        f"annotation.added must follow the message output_item.added: types={types}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_annotation_on_the_final_chunk_is_not_dropped():
+    """
+    The per-chunk emit path only runs while chunks are still arriving, so an
+    annotation queued from the final chunk has to be drained during
+    finalization or it never reaches the consumer.
+    """
+    events = await _collect_events(
+        [
+            _chunk(content="Answer with a citation"),
+            _chunk(annotations=[URL_CITATION_ANNOTATION], finish_reason="stop"),
+        ]
+    )
+    types = [_event_type(event) for event in events]
+    annotation_added = str(ResponsesAPIStreamEvents.OUTPUT_TEXT_ANNOTATION_ADDED)
+    assert annotation_added in types, f"annotation from the final chunk was dropped: types={types}"
+    assert types.index(annotation_added) < types.index(str(ResponsesAPIStreamEvents.OUTPUT_TEXT_DONE)), (
+        f"annotation.added must precede output_text.done: types={types}"
+    )


### PR DESCRIPTION
## What this PR does

Fixes multiple event-ordering and serialization bugs in the chat-completions -> Responses API streaming bridge (`litellm/responses/litellm_completion_transformation/streaming_iterator.py`) that affect reasoning models (DeepSeek, Qwen, etc.):

1. **Overlapping item lifecycles**: `response.output_item.added` (message) was emitted *before* `response.output_item.done` (reasoning). The OpenAI Responses streaming contract requires item lifecycles to be strictly serialized. Clients that track a single active item (e.g. OpenAI codex) drop all text deltas after the overlapping done event, losing agent_message streaming entirely.

2. **Reasoning item declaration swallowed by one-shot flag**: DeepSeek-style streams start with a role-only chunk (no `reasoning_content`). The default branch consumed the one-shot `sent_output_item_added_event` flag with a message item, so the reasoning item was never declared -> consumers without an active reasoning item dropped every reasoning delta.

3. **`summary_index` omitted on reasoning deltas**: `ReasoningSummaryTextDeltaEvent.summary_index` defaults to `0`; pydantic serialization with `exclude_unset` semantics drops fields equal to their default. Strict consumers (codex `sse/responses.rs`) require `delta` and `summary_index` to both be present and silently drop the whole frame otherwise.

4. **Ghost message item on tool-call-only streams**: streams with reasoning + function_call (no assistant text) emitted a trailing `output_text.done` / `content_part.done` / `output_item.done` trio for a message item that was **never announced** via `output_item.added`. Additionally `content_part.done` carried the full reasoning text under a non-standard `reasoning_text` part type instead of `output_text`.

## Changes

- Defer `output_item.added` (message) until the first chunk with actual content (role-only chunks no longer consume the one-shot flag)
- Emit `output_item.added` (reasoning) when `reasoning_content` first appears on a stream where the flag was already consumed
- Close the reasoning item (`reasoning_summary_text.done` -> `reasoning_summary_part.done` -> `output_item.done`) **before** announcing the message item
- Always pass `summary_index` explicitly when constructing `ReasoningSummaryTextDeltaEvent`
- Skip the message done trio when the message item was never added (tool-call-only streams)
- Always emit `output_text` content parts (reasoning text belongs to the reasoning item, not the message)

## Resulting event sequence (reasoning + text stream)

```
response.output_item.added         [reasoning]
response.reasoning_summary_text.delta xN
response.reasoning_summary_text.done
response.reasoning_summary_part.done
response.output_item.done          [reasoning]
response.output_item.added         [message]
response.output_text.delta         xN
response.output_text.done
response.content_part.done         [output_text]
response.output_item.done          [message]
response.completed
```

## How to test

```bash
uv run pytest tests/test_litellm/responses/litellm_completion_transformation/test_streaming_event_order.py -v
```

New regression tests cover:
- reasoning -> text event ordering (no overlapping lifecycles)
- `summary_index` presence under `exclude_unset` serialization
- `content_part.done` is always `output_text`
- tool-call-only streams emit no ghost message events

Verified end-to-end against DeepSeek reasoning streams via a bridged codex client (reasoning + agent_message streaming both restored).