### PR TITLE
fix(streaming): preserve provider model for cost calculation

### DIFF
--- a/litellm/cost_calculator.py
+++ b/litellm/cost_calculator.py
@@ -2,7 +2,7 @@
 ## File for 'response_cost' calculation in Logging
 import logging
 import time
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from functools import lru_cache
 from typing import TYPE_CHECKING, Any, Final, Literal, cast
 
@@ -739,6 +739,13 @@ def _get_provider_for_cost_calc(
     return custom_llm_provider
 
 
+def _get_provider_response_model_for_cost_calc(hidden_params: object) -> str | None:
+    if not isinstance(hidden_params, Mapping):
+        return None
+    model: Final[object] = hidden_params.get("provider_response_model")
+    return model if isinstance(model, str) and model else None
+
+
 def _select_model_name_for_cost_calc(
     model: str | None,
     completion_response: object | None,
@@ -755,7 +762,6 @@ def _select_model_name_for_cost_calc(
     """
 
     return_model: str | None = None
-    region_name: str | None = None
     custom_llm_provider = _get_provider_for_cost_calc(model=model, custom_llm_provider=custom_llm_provider)
 
     completion_response_model: str | None = None
@@ -765,6 +771,9 @@ def _select_model_name_for_cost_calc(
         elif isinstance(completion_response, dict):
             completion_response_model = completion_response.get("model", None)
     hidden_params: Final[dict | None] = getattr(completion_response, "_hidden_params", None)
+    provider_response_model: Final = _get_provider_response_model_for_cost_calc(hidden_params)
+    region_name_value: Final[object] = hidden_params.get("region_name") if hidden_params is not None else None
+    region_name: str | None = region_name_value if isinstance(region_name_value, str) else None
 
     if custom_pricing is True:
         if router_model_id is not None and router_model_id in litellm.model_cost:
@@ -780,14 +789,12 @@ def _select_model_name_for_cost_calc(
         else:
             return_model = model
 
-    elif base_model is not None:
-        return_model = base_model
+    elif base_model is not None or provider_response_model is not None:
+        return_model = base_model if base_model is not None else provider_response_model
 
     elif completion_response_model is None and hidden_params is not None:
         if hidden_params.get("model", None) is not None and len(hidden_params["model"]) > 0:
             return_model = hidden_params.get("model", model)
-    elif hidden_params is not None and hidden_params.get("region_name", None) is not None:
-        region_name = hidden_params.get("region_name", None)
 
     if return_model is None and completion_response_model is not None:
         return_model = completion_response_model

--- a/litellm/cost_calculator.py
+++ b/litellm/cost_calculator.py
@@ -739,11 +739,11 @@ def _get_provider_for_cost_calc(
     return custom_llm_provider
 
 
-def _get_provider_response_model_for_cost_calc(hidden_params: object) -> str | None:
+def _get_hidden_str_for_cost_calc(hidden_params: object, key: str) -> str | None:
     if not isinstance(hidden_params, Mapping):
         return None
-    model: Final[object] = hidden_params.get("provider_response_model")
-    return model if isinstance(model, str) and model else None
+    value: Final[object] = hidden_params.get(key)
+    return value if isinstance(value, str) and value else None
 
 
 def _select_model_name_for_cost_calc(
@@ -771,9 +771,14 @@ def _select_model_name_for_cost_calc(
         elif isinstance(completion_response, dict):
             completion_response_model = completion_response.get("model", None)
     hidden_params: Final[dict | None] = getattr(completion_response, "_hidden_params", None)
-    provider_response_model: Final = _get_provider_response_model_for_cost_calc(hidden_params)
-    region_name_value: Final[object] = hidden_params.get("region_name") if hidden_params is not None else None
-    region_name: str | None = region_name_value if isinstance(region_name_value, str) else None
+    provider_response_model: Final = _get_hidden_str_for_cost_calc(hidden_params, "provider_response_model")
+    explicit_pricing: Final = custom_pricing is True or base_model is not None
+    priced_from_response: Final = provider_response_model is not None or completion_response_model is not None
+    region_name: Final = (
+        _get_hidden_str_for_cost_calc(hidden_params, "region_name")
+        if not explicit_pricing and priced_from_response
+        else None
+    )
 
     if custom_pricing is True:
         if router_model_id is not None and router_model_id in litellm.model_cost:

--- a/litellm/litellm_core_utils/streaming_chunk_builder_utils.py
+++ b/litellm/litellm_core_utils/streaming_chunk_builder_utils.py
@@ -240,6 +240,22 @@ class ChunkProcessor:
         return model_response
 
     @staticmethod
+    def _get_provider_response_model(
+        chunks: Sequence["_BaseChunk"],
+        first_chunk_model: str,
+    ) -> str | None:
+        models: Final = tuple(
+            model
+            for chunk in chunks
+            if isinstance((hidden_params := chunk.get("_hidden_params")), Mapping)
+            if isinstance((model := hidden_params.get("provider_response_model")), str) and model
+        )
+        return next(
+            (model for model in models if model != first_chunk_model),
+            models[0] if models else None,
+        )
+
+    @staticmethod
     def apply_provider_assembled_streaming_metadata(
         response: ModelResponse,
         chunks: list[object],
@@ -360,6 +376,15 @@ class ChunkProcessor:
         )
 
         response = self.update_model_response_with_hidden_params(model_response=response, chunk=chunk)
+        provider_response_model: Final = self._get_provider_response_model(
+            chunks,
+            first_chunk_model,
+        )
+        if provider_response_model is not None:
+            response._hidden_params = dict(  # pyright: ignore[reportPrivateUsage]  # ModelResponse exposes no public hidden-params setter
+                response._hidden_params,  # pyright: ignore[reportPrivateUsage]  # ModelResponse exposes no public hidden-params getter
+                provider_response_model=provider_response_model,
+            )
         return response
 
     @staticmethod

--- a/litellm/litellm_core_utils/streaming_handler.py
+++ b/litellm/litellm_core_utils/streaming_handler.py
@@ -187,17 +187,42 @@ class _ParsedChunkHiddenParams(BaseModel):
     provider_specific_fields: Mapping[str, object] | None = None
 
 
-def _provider_hidden_params(chunk: object) -> Mapping[str, object] | None:
-    hidden: Final[object] = getattr(chunk, "_hidden_params", None)
+def _provider_response_model(chunk: object) -> str | None:
+    model: Final[object] = chunk.get("model") if isinstance(chunk, Mapping) else getattr(chunk, "model", None)
+    return model if isinstance(model, str) and model else None
+
+
+def _parsed_provider_hidden_params(hidden: object) -> _ParsedChunkHiddenParams | None:
     if not isinstance(hidden, dict):
         return None
     try:
-        parsed: Final = _ParsedChunkHiddenParams.model_validate(hidden)
+        return _ParsedChunkHiddenParams.model_validate(hidden)
     except ValidationError:
         return None
-    if not parsed.provider_specific_fields:
-        return None
-    return MappingProxyType({"provider_specific_fields": dict(parsed.provider_specific_fields)})
+
+
+def _provider_hidden_params(
+    chunk: object,
+    provider_response_model: str | None,
+) -> Mapping[str, object] | None:
+    hidden: Final[object] = getattr(chunk, "_hidden_params", None)
+    parsed: Final = _parsed_provider_hidden_params(hidden)
+    provider_specific_fields: Final[object | None] = (
+        dict(parsed.provider_specific_fields)  # mutable-ok: stream assembly merges provider metadata into this dict
+        if parsed is not None and parsed.provider_specific_fields
+        else None
+    )
+    params: Final[Mapping[str, object]] = MappingProxyType(
+        {
+            key: value
+            for key, value in (
+                ("provider_response_model", provider_response_model),
+                ("provider_specific_fields", provider_specific_fields),
+            )
+            if value is not None
+        }
+    )
+    return params or None
 
 
 class CustomStreamWrapper:
@@ -229,6 +254,7 @@ class CustomStreamWrapper:
         self.thinking_content = ""
 
         self.system_fingerprint: str | None = None
+        self._provider_response_model: str | None = None
         self.received_finish_reason: str | None = None
         self.intermittent_finish_reason: str | None = None  # finish reasons that show up mid-stream
         self.special_tokens = [
@@ -1522,7 +1548,12 @@ class CustomStreamWrapper:
     def chunk_creator(self, chunk: Any):
         if hasattr(chunk, "id"):
             self.response_id = chunk.id
-        model_response = self.model_response_creator(hidden_params=_provider_hidden_params(chunk))
+        provider_response_model: Final = _provider_response_model(chunk)
+        if provider_response_model is not None:
+            self._provider_response_model = provider_response_model
+        model_response = self.model_response_creator(
+            hidden_params=_provider_hidden_params(chunk, self._provider_response_model)
+        )
         response_obj: dict[str, Any] = {}
         try:
             # return this for all models

--- a/tests/test_litellm/litellm_core_utils/test_streaming_handler.py
+++ b/tests/test_litellm/litellm_core_utils/test_streaming_handler.py
@@ -4478,6 +4478,55 @@ def test_chunk_creator_preserves_hidden_provider_specific_fields_from_parsed_chu
 
     assert result is not None
     assert result._hidden_params["provider_specific_fields"] == {"traffic_type": "ON_DEMAND_FLEX"}
+    assembled = litellm.stream_chunk_builder(chunks=[result])
+    assert assembled is not None
+    assert assembled._hidden_params["provider_specific_fields"] == {"traffic_type": "ON_DEMAND_FLEX"}
+
+
+def test_chunk_creator_keeps_provider_model_private_across_stream():
+    wrapper = CustomStreamWrapper(
+        completion_stream=None,
+        model="requested-route",
+        logging_obj=MagicMock(),
+        custom_llm_provider="openai",
+    )
+    selected_chunk = ModelResponseStream(
+        id="chunk-1",
+        model="selected-model",
+        choices=[
+            StreamingChoices(
+                finish_reason=None,
+                index=0,
+                delta=Delta(content="hello"),
+            )
+        ],
+    )
+    terminal_chunk = ModelResponseStream(
+        id="chunk-1",
+        model=None,
+        choices=[
+            StreamingChoices(
+                finish_reason="stop",
+                index=0,
+                delta=Delta(),
+            )
+        ],
+    )
+
+    first_result = wrapper.chunk_creator(chunk=selected_chunk)
+    terminal_result = wrapper.chunk_creator(chunk=terminal_chunk)
+
+    assert first_result is not None
+    assert terminal_result is not None
+    assert first_result.model == "requested-route"
+    assert terminal_result.model == "requested-route"
+    assert first_result._hidden_params["provider_response_model"] == "selected-model"
+    assert terminal_result._hidden_params["provider_response_model"] == "selected-model"
+
+    assembled = litellm.stream_chunk_builder(chunks=[first_result, terminal_result])
+    assert assembled is not None
+    assert assembled.model == "requested-route"
+    assert assembled._hidden_params["provider_response_model"] == "selected-model"
 
 
 @pytest.mark.asyncio

--- a/tests/test_litellm/litellm_core_utils/test_streaming_handler.py
+++ b/tests/test_litellm/litellm_core_utils/test_streaming_handler.py
@@ -4484,6 +4484,10 @@ def test_chunk_creator_preserves_hidden_provider_specific_fields_from_parsed_chu
 
 
 def test_chunk_creator_keeps_provider_model_private_across_stream():
+    from litellm.router_utils.add_retry_fallback_headers import (
+        get_hidden_params_dict,
+    )
+
     wrapper = CustomStreamWrapper(
         completion_stream=None,
         model="requested-route",
@@ -4520,13 +4524,129 @@ def test_chunk_creator_keeps_provider_model_private_across_stream():
     assert terminal_result is not None
     assert first_result.model == "requested-route"
     assert terminal_result.model == "requested-route"
-    assert first_result._hidden_params["provider_response_model"] == "selected-model"
-    assert terminal_result._hidden_params["provider_response_model"] == "selected-model"
+    assert (
+        get_hidden_params_dict(first_result)["provider_response_model"]
+        == "selected-model"
+    )
+    assert (
+        get_hidden_params_dict(terminal_result)["provider_response_model"]
+        == "selected-model"
+    )
 
     assembled = litellm.stream_chunk_builder(chunks=[first_result, terminal_result])
     assert assembled is not None
     assert assembled.model == "requested-route"
-    assert assembled._hidden_params["provider_response_model"] == "selected-model"
+    assert (
+        get_hidden_params_dict(assembled)["provider_response_model"]
+        == "selected-model"
+    )
+
+
+def test_assembled_stream_uses_later_provider_model_for_cost(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    from litellm.router_utils.add_retry_fallback_headers import (
+        get_hidden_params_dict,
+    )
+
+    selected_model_info = {
+        "input_cost_per_token": 0.000002,
+        "output_cost_per_token": 0.000004,
+        "litellm_provider": "azure",
+    }
+    monkeypatch.setitem(
+        litellm.model_cost,
+        "azure/gpt-4.1-nano-2025-04-14",
+        selected_model_info,
+    )
+    monkeypatch.setitem(
+        litellm.model_cost,
+        "azure/azure-model-router",
+        {
+            "input_cost_per_token": 0.00002,
+            "output_cost_per_token": 0.00004,
+            "litellm_provider": "azure",
+        },
+    )
+    logging_obj = MagicMock()
+    logging_obj.model_call_details = {"custom_llm_provider": "azure"}
+    wrapper = CustomStreamWrapper(
+        completion_stream=None,
+        model="azure-model-router",
+        logging_obj=logging_obj,
+        custom_llm_provider="azure",
+    )
+    router_chunk = ModelResponseStream(
+        id="chunk-1",
+        model="azure-model-router",
+        choices=[
+            StreamingChoices(
+                finish_reason=None,
+                index=0,
+                delta=Delta(content="hello "),
+            )
+        ],
+    )
+    selected_chunk = ModelResponseStream(
+        id="chunk-1",
+        model="gpt-4.1-nano-2025-04-14",
+        choices=[
+            StreamingChoices(
+                finish_reason=None,
+                index=0,
+                delta=Delta(content="world"),
+            )
+        ],
+    )
+    terminal_chunk = ModelResponseStream(
+        id="chunk-1",
+        model="azure-model-router",
+        choices=[
+            StreamingChoices(
+                finish_reason="stop",
+                index=0,
+                delta=Delta(),
+            )
+        ],
+    )
+
+    router_result = wrapper.chunk_creator(chunk=router_chunk)
+    selected_result = wrapper.chunk_creator(chunk=selected_chunk)
+    terminal_result = wrapper.chunk_creator(chunk=terminal_chunk)
+
+    assert router_result is not None
+    assert selected_result is not None
+    assert terminal_result is not None
+    assert (
+        get_hidden_params_dict(router_result)["provider_response_model"]
+        == "azure-model-router"
+    )
+    assert (
+        get_hidden_params_dict(selected_result)["provider_response_model"]
+        == "gpt-4.1-nano-2025-04-14"
+    )
+    assert (
+        get_hidden_params_dict(terminal_result)["provider_response_model"]
+        == "azure-model-router"
+    )
+
+    assembled = litellm.stream_chunk_builder(
+        chunks=[router_result, selected_result, terminal_result]
+    )
+    assert assembled is not None
+    assert assembled.model == "gpt-4.1-nano-2025-04-14"
+    assert (
+        get_hidden_params_dict(assembled)["provider_response_model"]
+        == "gpt-4.1-nano-2025-04-14"
+    )
+    assembled.usage = Usage(prompt_tokens=10, completion_tokens=5, total_tokens=15)
+    assert litellm.completion_cost(
+        completion_response=assembled,
+        custom_llm_provider="azure",
+    ) == pytest.approx(
+        10 * selected_model_info["input_cost_per_token"]
+        + 5 * selected_model_info["output_cost_per_token"]
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/test_litellm/llms/fireworks_ai/chat/test_fireworks_ai_chat_transformation.py
+++ b/tests/test_litellm/llms/fireworks_ai/chat/test_fireworks_ai_chat_transformation.py
@@ -1719,3 +1719,82 @@ def test_in_schema_unsupported_params_still_raise():
         store=True,
     )
     assert "store" not in optional_params
+
+
+def test_streaming_preserves_selected_model_for_private_accounting():
+    from litellm.llms.custom_httpx.http_handler import HTTPHandler
+
+    requested_route = (
+        "accounts/fireworks/routers/firerouter/"
+        "kimi-k3/deepseek-v4-pro-0813/deepseek-v4-flash-0731"
+    )
+    selected_model = "deepseek-v4-flash-0731"
+    sse_lines = [
+        "data: "
+        + json.dumps(
+            {
+                "id": "stream-1",
+                "object": "chat.completion.chunk",
+                "created": 1,
+                "model": selected_model,
+                "choices": [
+                    {
+                        "index": 0,
+                        "delta": {"role": "assistant", "content": "Hi"},
+                    }
+                ],
+            }
+        ),
+        "data: "
+        + json.dumps(
+            {
+                "id": "stream-1",
+                "object": "chat.completion.chunk",
+                "created": 1,
+                "model": selected_model,
+                "choices": [{"index": 0, "delta": {}, "finish_reason": "stop"}],
+                "usage": {
+                    "prompt_tokens": 5,
+                    "completion_tokens": 1,
+                    "total_tokens": 6,
+                },
+            }
+        ),
+        "data: [DONE]",
+    ]
+
+    raw_response = MagicMock()
+    raw_response.status_code = 200
+    raw_response.headers = {}
+    raw_response.iter_lines = lambda: iter(sse_lines)
+
+    client = HTTPHandler()
+    with patch.object(client, "post", return_value=raw_response):
+        stream = litellm.completion(
+            model=f"fireworks_ai/{requested_route}",
+            messages=[{"role": "user", "content": "hi"}],
+            stream=True,
+            api_key="test-key",
+            client=client,
+        )
+        chunks = list(stream)
+
+    assert chunks
+    assert {chunk.model for chunk in chunks} == {requested_route}
+    assert {
+        chunk._hidden_params.get("provider_response_model") for chunk in chunks
+    } == {selected_model}
+
+    assembled = litellm.stream_chunk_builder(chunks=chunks)
+    assert assembled is not None
+    assert assembled.model == requested_route
+    assert assembled._hidden_params["provider_response_model"] == selected_model
+    selected_model_info = litellm.model_cost[f"fireworks_ai/{selected_model}"]
+    expected_cost = (
+        5 * selected_model_info["input_cost_per_token"]
+        + selected_model_info["output_cost_per_token"]
+    )
+    assert litellm.completion_cost(
+        completion_response=assembled,
+        custom_llm_provider="fireworks_ai",
+    ) == pytest.approx(expected_cost)

--- a/tests/test_litellm/test_cost_calculator.py
+++ b/tests/test_litellm/test_cost_calculator.py
@@ -4095,7 +4095,10 @@ def test_select_model_name_strips_duplicated_region_segment(_local_model_cost_ma
         ],
         model="us-east-1/anthropic.claude-v2:1",
     )
-    response._hidden_params = {"region_name": "us-east-1"}
+    response._hidden_params = {
+        "provider_response_model": "anthropic.claude-v2:1",
+        "region_name": "us-east-1",
+    }
 
     selected = _select_model_name_for_cost_calc(
         model=None,
@@ -4350,3 +4353,79 @@ def test_realtime_explicitly_free_session_model_still_bills_zero(
     )
 
     assert cost == 0.0
+
+
+def test_completion_cost_prefers_private_provider_response_model(
+    _local_model_cost_map: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setitem(
+        litellm.model_cost,
+        "openai/selected-cost-model",
+        {
+            "input_cost_per_token": 0.000002,
+            "output_cost_per_token": 0.000004,
+            "litellm_provider": "openai",
+        },
+    )
+    response = litellm.ModelResponse(
+        id="x",
+        choices=[
+            {
+                "index": 0,
+                "message": {"role": "assistant", "content": "hi"},
+                "finish_reason": "stop",
+            }
+        ],
+        model="requested-route",
+    )
+    response._hidden_params = {
+        "custom_llm_provider": "openai",
+        "provider_response_model": "selected-cost-model",
+    }
+    response.usage = litellm.Usage(prompt_tokens=100, completion_tokens=50)
+
+    cost = litellm.completion_cost(
+        completion_response=response,
+        custom_llm_provider="openai",
+    )
+
+    assert response.model == "requested-route"
+    assert cost == pytest.approx(100 * 0.000002 + 50 * 0.000004)
+
+
+@pytest.mark.parametrize(
+    ("base_model", "custom_pricing", "expected"),
+    [
+        ("openai/base-model", False, "openai/base-model"),
+        (None, True, "openai/requested-route"),
+    ],
+)
+def test_explicit_pricing_precedes_private_provider_response_model(
+    base_model: str | None,
+    custom_pricing: bool,
+    expected: str,
+) -> None:
+    from litellm.cost_calculator import _select_model_name_for_cost_calc
+
+    response = litellm.ModelResponse(
+        id="x",
+        choices=[
+            {
+                "index": 0,
+                "message": {"role": "assistant", "content": "hi"},
+                "finish_reason": "stop",
+            }
+        ],
+        model="requested-route",
+    )
+    response._hidden_params = {"provider_response_model": "selected-cost-model"}
+
+    selected = _select_model_name_for_cost_calc(
+        model="requested-route",
+        completion_response=response,
+        base_model=base_model,
+        custom_pricing=custom_pricing,
+        custom_llm_provider="openai",
+    )
+
+    assert selected == expected

--- a/tests/test_litellm/test_cost_calculator.py
+++ b/tests/test_litellm/test_cost_calculator.py
@@ -4095,10 +4095,7 @@ def test_select_model_name_strips_duplicated_region_segment(_local_model_cost_ma
         ],
         model="us-east-1/anthropic.claude-v2:1",
     )
-    response._hidden_params = {
-        "provider_response_model": "anthropic.claude-v2:1",
-        "region_name": "us-east-1",
-    }
+    response._hidden_params = {"region_name": "us-east-1"}
 
     selected = _select_model_name_for_cost_calc(
         model=None,
@@ -4107,6 +4104,53 @@ def test_select_model_name_strips_duplicated_region_segment(_local_model_cost_ma
     )
 
     assert selected == "bedrock/us-east-1/anthropic.claude-v2:1"
+
+
+def _bedrock_response_with_private_model(model: str, region_name: str) -> litellm.ModelResponse:
+    response = litellm.ModelResponse(
+        id="x",
+        choices=[
+            {
+                "index": 0,
+                "message": {"role": "assistant", "content": "hi"},
+                "finish_reason": "stop",
+            }
+        ],
+        model=model,
+    )
+    response._hidden_params = {"provider_response_model": model, "region_name": region_name}
+    return response
+
+
+def test_select_model_name_applies_region_to_private_provider_response_model(_local_model_cost_map):
+    """A Bedrock stream carries its requested model as the private provider model and must keep the
+    request's region in the cost key, exactly as the same request does without streaming."""
+
+    from litellm.cost_calculator import _select_model_name_for_cost_calc
+
+    selected = _select_model_name_for_cost_calc(
+        model=None,
+        completion_response=_bedrock_response_with_private_model("anthropic.claude-v2:1", "us-east-1"),
+        custom_llm_provider="bedrock",
+    )
+
+    assert selected == "bedrock/us-east-1/anthropic.claude-v2:1"
+
+
+def test_select_model_name_keeps_base_model_free_of_region(_local_model_cost_map):
+    """An explicit base_model keeps pricing on that model's own key even when the request carries a
+    region with different regional rates, so the private provider model never widens region pricing."""
+
+    from litellm.cost_calculator import _select_model_name_for_cost_calc
+
+    selected = _select_model_name_for_cost_calc(
+        model="my-bedrock-deployment",
+        completion_response=_bedrock_response_with_private_model("moonshotai.kimi-k2.5", "ap-northeast-1"),
+        base_model="moonshotai.kimi-k2.5",
+        custom_llm_provider="bedrock",
+    )
+
+    assert selected == "bedrock/moonshotai.kimi-k2.5"
 
 
 def test_completion_cost_nonzero_for_slash_alias_model_name(_local_model_cost_map):


### PR DESCRIPTION
## TLDR

Problem this solves:

- Streaming routers like Fireworks FireRouter can serve a different model than the route name says
- LiteLLM discards that identity when assembling the stream, so cost is computed from the route name (or not at all)

How it solves it:

- Keeps the requested route public: chunks and the assembled response are byte-identical to before
- Captures the provider-reported chunk model in private metadata (`provider_response_model`)
- Prices that model after explicit overrides (custom pricing and `base_model` still win)

## User Flow

Before: a user streams through a FireRouter route and the spend log records 0 instead of the served model's price

1. An admin configures `firerouter-deepseek-kimi` pointing at `fireworks_ai/accounts/fireworks/routers/firerouter/deepseek-v4-flash-0731/kimi-k3`
2. A user sends POST https://litellm-domain/v1/chat/completions with `"model": "firerouter-deepseek-kimi"`, `"stream": true`, and `"stream_options": {"include_usage": true}`
3. The stream returns 200, every chunk carries `"model": "firerouter-deepseek-kimi"`, and the usage chunk reports 90 prompt and 10 completion tokens
4. The Logs page at https://litellm-domain/ui/?page=logs shows that call with spend 0.0, while the identical request without `stream` bills 2.64e-05, so streamed FireRouter traffic rides free

After: the same streamed call bills the model FireRouter actually served

1. An admin configures `firerouter-deepseek-kimi` pointing at `fireworks_ai/accounts/fireworks/routers/firerouter/deepseek-v4-flash-0731/kimi-k3`
2. A user sends POST https://litellm-domain/v1/chat/completions with `"model": "firerouter-deepseek-kimi"`, `"stream": true`, and `"stream_options": {"include_usage": true}`
3. The stream returns 200 with the same chunks: `"model"` still reads `"firerouter-deepseek-kimi"` everywhere
4. The Logs page shows spend 1.54e-05, DeepSeek V4 Flash's price for 90 prompt and 10 completion tokens

## Relevant issues

## Linear ticket

Resolves LIT-6364

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally
- [x] My PR passes all required CI/CD checks (GitHub checks green at the tip; the `ci/circleci:` contexts come from a mirror-branch run of the legacy suites, red only on failures a per-test diff shows are identical to `litellm_internal_staging`'s own latest pipeline, zero attributable to this PR)
- [x] My PR's scope is as isolated as possible
- [x] I have received a Greptile Confidence Score of at least 4/5 (5/5 at c11a1f0bc1)

## Screenshots / Proof of Fix

Shared setup: live proxy at each hash with Postgres spend logs, model `firerouter-deepseek-kimi` mapped to `fireworks_ai/accounts/fireworks/routers/firerouter/deepseek-v4-flash-0731/kimi-k3`, plus `gpt-5.5` as a non-Fireworks control. Three real calls per leg:

```bash
# streamed FireRouter
curl -sD - http://localhost:36599/v1/chat/completions -H "Authorization: Bearer $MASTER_KEY" -H 'Content-Type: application/json' \
  -d '{"model": "firerouter-deepseek-kimi", "messages": [{"role": "user", "content": "Return only the number 8437"}], "stream": true, "stream_options": {"include_usage": true}}'
# non-streaming FireRouter: same body without the stream fields
# streamed control: same stream body with "model": "gpt-5.5"
```

### Before (3300fc3a96)

1. Streamed FireRouter: 200, 11 chunks all `"model":"firerouter-deepseek-kimi"`, usage 90 prompt / 15 completion, spend row 0. The assembled response carries only the public alias, which is not in the cost map, so the cost silently computes as nothing. The same stream priced through `litellm.completion_cost`, where the response carries the route string, bills 0.000495, kimi-k3's rates (90 x 3e-06 + 15 x 1.5e-05), though FireRouter served DeepSeek V4 Flash
2. Non-streaming FireRouter: 200, `x-litellm-response-cost: 2.64e-05`, spend row 2.64e-05
3. Streamed gpt-5.5: 200, spend row 0.000665 for 13 prompt / 20 completion

```
                request_id                 |       model_group        |  spend   | prompt_tokens | completion_tokens
-------------------------------------------+--------------------------+----------+---------------+-------------------
 chatcmpl-e0c331d22d5b4695994ac49df999342b | firerouter-deepseek-kimi |        0 |            90 |                15
 chatcmpl-019ce08674874021a5cecb6e085927c6 | firerouter-deepseek-kimi | 2.64e-05 |            90 |                10
 chatcmpl-EHwJcOUsMkeXrWTeZN11LFWvYUMvl    | gpt-5.5                  | 0.000665 |            13 |                20
```

### After (c11a1f0bc1)

1. Streamed FireRouter: 200, chunks byte-identical (all `"model":"firerouter-deepseek-kimi"`), usage 90 prompt / 10 completion, spend row 1.54e-05 = 90 x 1.4e-07 + 10 x 2.8e-07, DeepSeek V4 Flash's price for exactly those tokens
2. Non-streaming FireRouter: unchanged, `x-litellm-response-cost: 2.64e-05` and spend row 2.64e-05
3. Streamed gpt-5.5: unchanged formula, spend row 0.000695 for 13 prompt / 21 completion

```
                request_id                 |       model_group        |  spend   | prompt_tokens | completion_tokens
-------------------------------------------+--------------------------+----------+---------------+-------------------
 chatcmpl-013e044dde0144719e7e1dd92771fc61 | firerouter-deepseek-kimi | 1.54e-05 |            90 |                10
 chatcmpl-b063d48f609e463dac133458e6869c2d | firerouter-deepseek-kimi | 2.64e-05 |            90 |                10
 chatcmpl-EHwPPeKOZwIqf3cF9pUwteWtMBcme    | gpt-5.5                  | 0.000695 |            13 |                21
```

## Type

Bug Fix

## Caveats

### Low

- The cost map holds two disagreeing entries for this model (`fireworks_ai/deepseek-v4-flash-0731` vs `fireworks_ai/accounts/fireworks/models/deepseek-v4-flash-0731`), so non-streaming (priced by the route name) and streaming (priced by the provider-reported name) use different entries until LIT-6408 aligns them
- Providers whose chunks echo the requested model (Bedrock) or carry no model (Vertex Gemini) keep existing behavior: the private field then adds nothing new
- Explicit custom pricing and `base_model` still take precedence, and region prefixing stays scoped to response-derived names as on the base branch, so a `base_model` deployment cannot drift onto a regional cost-map key

## Final Attestation

- [x] The tests check the right things, including edge cases and regressions

- [x] c11a1f0bc1 passes /live-pr-risk. CircleCI at the tip (mirror pipeline 88691) is red on 8 legacy-suite jobs; every failed test also fails on `litellm_internal_staging`'s own latest pipeline at the same test list (zero PR-attributable), and `using_litellm_on_windows` fails there while passing here
