### PR TITLE
fix(proxy): count tools, system, and Anthropic image and document blocks in the count_tokens fallback (internal copy of #36671)

### DIFF
--- a/litellm/litellm_core_utils/token_counter.py
+++ b/litellm/litellm_core_utils/token_counter.py
@@ -656,11 +656,6 @@ def _validate_anthropic_content(content: Mapping[str, Any]) -> type:
 def _anthropic_image_source_data(
     source: AnthropicContentParamSource | AnthropicContentParamSourceUrl | AnthropicContentParamSourceFileId,
 ) -> str:
-    """
-    Resolve an Anthropic image `source` to the data string `calculate_img_tokens` prices.
-
-    Returns "" for a `file` source, whose bytes the proxy cannot resolve locally.
-    """
     if source["type"] == "base64":
         data: Final = source.get("data")
         if not data:
@@ -678,12 +673,6 @@ def _count_document_tokens(
     use_default_image_token_count: bool,
     default_token_count: int | None,
 ) -> int:
-    """
-    Count an Anthropic `document` block: its title and context text, plus the source itself.
-
-    Text-bearing sources (`text`, `content`) count their text; opaque ones (`base64`, `url`,
-    `file`) are priced like an image, since their bytes cannot be tokenized locally.
-    """
     source: Final = document["source"]
     metadata_tokens: Final = sum(
         count_function(text) for text in (document.get("title"), document.get("context")) if text
@@ -765,13 +754,7 @@ def _count_content_list(
     use_default_image_token_count: bool,
     default_token_count: int | None,
 ) -> int:
-    """
-    Recursively count tokens from a list of content blocks.
-
-    The block union is wider than OpenAI's: the proxy's Anthropic endpoints count
-    their native blocks through this same helper, so an `image` block is as much
-    an input here as OpenAI's `image_url`.
-    """
+    """Recursively count tokens from a list of content blocks."""
     try:
         num_tokens = 0
         for c in content_list:

--- a/litellm/litellm_core_utils/token_counter.py
+++ b/litellm/litellm_core_utils/token_counter.py
@@ -646,6 +646,24 @@ def _validate_anthropic_content(content: Mapping[str, Any]) -> type:
     return expected_cls
 
 
+def _anthropic_image_source_data(source: Mapping[str, str]) -> str:
+    """
+    Resolve an Anthropic image `source` to the data string `calculate_img_tokens` prices.
+
+    Returns "" for a `file` source, whose bytes the proxy cannot resolve locally.
+    """
+    source_type: Final = source.get("type")
+    if source_type == "base64":
+        data: Final = source.get("data")
+        if not data:
+            return ""
+        media_type: Final = source.get("media_type") or "image/png"
+        return f"data:{media_type};base64,{data}"
+    if source_type == "url":
+        return source.get("url") or ""
+    return ""
+
+
 def _count_anthropic_content(
     content: Mapping[str, Any],
     count_function: TokenCounterFunction,
@@ -714,6 +732,13 @@ def _count_content_list(
             elif c["type"] == "image_url":
                 image_url = c.get("image_url")
                 num_tokens += _count_image_tokens(image_url, use_default_image_token_count)
+            elif c["type"] == "image":
+                source = c.get("source")
+                num_tokens += calculate_img_tokens(
+                    data=_anthropic_image_source_data(source) if isinstance(source, dict) else "",
+                    mode="auto",
+                    use_default_image_token_count=use_default_image_token_count,
+                )
             elif c["type"] in ("tool_use", "tool_result"):
                 num_tokens += _count_anthropic_content(
                     c,
@@ -742,7 +767,8 @@ def _count_content_list(
                 content_type = c.get("type", type(c).__name__) if isinstance(c, dict) else type(c).__name__
                 raise ValueError(
                     f"Invalid content item type: {content_type}. "
-                    f"Expected str or dict with 'type' field (text, image_url, tool_use, tool_result, thinking, tool_reference)."
+                    f"Expected str or dict with 'type' field "
+                    f"(text, image_url, image, tool_use, tool_result, thinking, tool_reference)."
                 )
         return num_tokens
     except Exception as e:

--- a/litellm/litellm_core_utils/token_counter.py
+++ b/litellm/litellm_core_utils/token_counter.py
@@ -3,7 +3,7 @@
 import base64
 import io
 import struct
-from collections.abc import Callable, Iterable, Mapping
+from collections.abc import Callable, Iterable, Mapping, Sequence
 from typing import Any, Final, Literal, cast
 
 import tiktoken
@@ -28,12 +28,15 @@ from litellm.types.llms.anthropic import (
     AnthropicContentParamSource,
     AnthropicContentParamSourceFileId,
     AnthropicContentParamSourceUrl,
+    AnthropicMessagesDocumentParam,
     AnthropicMessagesImageParam,
+    AnthropicMessagesTextParam,
     AnthropicMessagesToolResultParam,
     AnthropicMessagesToolUseParam,
 )
 from litellm.types.llms.openai import (
     AllMessageValues,
+    ChatCompletionDocumentObject,
     ChatCompletionNamedToolChoiceParam,
     ChatCompletionToolParam,
     OpenAIMessageContentListBlock,
@@ -350,7 +353,7 @@ def token_counter(
     model="",
     custom_tokenizer: dict | SelectTokenizerResponse | None = None,
     text: str | list[str] | None = None,
-    messages: list[AllMessageValues | Message] | None = None,
+    messages: Sequence[AllMessageValues | Message] | None = None,
     count_response_tokens: bool | None = False,
     tools: list[ChatCompletionToolParam] | None = None,
     tool_choice: ChatCompletionNamedToolChoiceParam | None = None,
@@ -669,6 +672,38 @@ def _anthropic_image_source_data(
     return ""
 
 
+def _count_document_tokens(
+    document: ChatCompletionDocumentObject | AnthropicMessagesDocumentParam,
+    count_function: TokenCounterFunction,
+    use_default_image_token_count: bool,
+    default_token_count: int | None,
+) -> int:
+    """
+    Count an Anthropic `document` block: its title and context text, plus the source itself.
+
+    Text-bearing sources (`text`, `content`) count their text; opaque ones (`base64`, `url`,
+    `file`) are priced like an image, since their bytes cannot be tokenized locally.
+    """
+    source: Final = document["source"]
+    metadata_tokens: Final = sum(
+        count_function(text) for text in (document.get("title"), document.get("context")) if text
+    )
+    if source["type"] == "text":
+        return metadata_tokens + count_function(source["data"])
+    if source["type"] == "content":
+        content: Final = source["content"]
+        if isinstance(content, str):
+            return metadata_tokens + count_function(content)
+        return metadata_tokens + _count_content_list(
+            count_function, content, use_default_image_token_count, default_token_count
+        )
+    return metadata_tokens + calculate_img_tokens(
+        data=_anthropic_image_source_data(source),
+        mode="auto",
+        use_default_image_token_count=use_default_image_token_count,
+    )
+
+
 def _count_anthropic_content(
     content: Mapping[str, Any],
     count_function: TokenCounterFunction,
@@ -720,7 +755,13 @@ def _count_anthropic_content(
 
 def _count_content_list(
     count_function: TokenCounterFunction,
-    content_list: str | Iterable[OpenAIMessageContentListBlock | AnthropicMessagesImageParam],
+    content_list: str
+    | Iterable[
+        OpenAIMessageContentListBlock
+        | AnthropicMessagesTextParam
+        | AnthropicMessagesImageParam
+        | AnthropicMessagesDocumentParam
+    ],
     use_default_image_token_count: bool,
     default_token_count: int | None,
 ) -> int:
@@ -746,6 +787,13 @@ def _count_content_list(
                     data=_anthropic_image_source_data(c["source"]),
                     mode="auto",
                     use_default_image_token_count=use_default_image_token_count,
+                )
+            elif c["type"] == "document":
+                num_tokens += _count_document_tokens(
+                    c,
+                    count_function,
+                    use_default_image_token_count,
+                    default_token_count,
                 )
             elif c["type"] in ("tool_use", "tool_result"):
                 num_tokens += _count_anthropic_content(
@@ -776,7 +824,7 @@ def _count_content_list(
                 raise ValueError(
                     f"Invalid content item type: {content_type}. "
                     f"Expected str or dict with 'type' field "
-                    f"(text, image_url, image, tool_use, tool_result, thinking, tool_reference)."
+                    f"(text, image_url, image, document, tool_use, tool_result, thinking, tool_reference)."
                 )
         return num_tokens
     except Exception as e:

--- a/litellm/litellm_core_utils/token_counter.py
+++ b/litellm/litellm_core_utils/token_counter.py
@@ -3,7 +3,7 @@
 import base64
 import io
 import struct
-from collections.abc import Callable, Mapping
+from collections.abc import Callable, Iterable, Mapping
 from typing import Any, Final, Literal, cast
 
 import tiktoken
@@ -25,6 +25,10 @@ from litellm.litellm_core_utils.default_encoding import encoding as default_enco
 from litellm.litellm_core_utils.url_utils import safe_get
 from litellm.llms.custom_httpx.http_handler import _get_httpx_client
 from litellm.types.llms.anthropic import (
+    AnthropicContentParamSource,
+    AnthropicContentParamSourceFileId,
+    AnthropicContentParamSourceUrl,
+    AnthropicMessagesImageParam,
     AnthropicMessagesToolResultParam,
     AnthropicMessagesToolUseParam,
 )
@@ -32,7 +36,7 @@ from litellm.types.llms.openai import (
     AllMessageValues,
     ChatCompletionNamedToolChoiceParam,
     ChatCompletionToolParam,
-    OpenAIMessageContent,
+    OpenAIMessageContentListBlock,
 )
 from litellm.types.utils import Message, SelectTokenizerResponse
 
@@ -646,20 +650,21 @@ def _validate_anthropic_content(content: Mapping[str, Any]) -> type:
     return expected_cls
 
 
-def _anthropic_image_source_data(source: Mapping[str, str]) -> str:
+def _anthropic_image_source_data(
+    source: AnthropicContentParamSource | AnthropicContentParamSourceUrl | AnthropicContentParamSourceFileId,
+) -> str:
     """
     Resolve an Anthropic image `source` to the data string `calculate_img_tokens` prices.
 
     Returns "" for a `file` source, whose bytes the proxy cannot resolve locally.
     """
-    source_type: Final = source.get("type")
-    if source_type == "base64":
+    if source["type"] == "base64":
         data: Final = source.get("data")
         if not data:
             return ""
         media_type: Final = source.get("media_type") or "image/png"
         return f"data:{media_type};base64,{data}"
-    if source_type == "url":
+    if source["type"] == "url":
         return source.get("url") or ""
     return ""
 
@@ -715,12 +720,16 @@ def _count_anthropic_content(
 
 def _count_content_list(
     count_function: TokenCounterFunction,
-    content_list: OpenAIMessageContent,
+    content_list: str | Iterable[OpenAIMessageContentListBlock | AnthropicMessagesImageParam],
     use_default_image_token_count: bool,
     default_token_count: int | None,
 ) -> int:
     """
     Recursively count tokens from a list of content blocks.
+
+    The block union is wider than OpenAI's: the proxy's Anthropic endpoints count
+    their native blocks through this same helper, so an `image` block is as much
+    an input here as OpenAI's `image_url`.
     """
     try:
         num_tokens = 0
@@ -733,9 +742,8 @@ def _count_content_list(
                 image_url = c.get("image_url")
                 num_tokens += _count_image_tokens(image_url, use_default_image_token_count)
             elif c["type"] == "image":
-                source = c.get("source")
                 num_tokens += calculate_img_tokens(
-                    data=_anthropic_image_source_data(source) if isinstance(source, dict) else "",
+                    data=_anthropic_image_source_data(c["source"]),
                     mode="auto",
                     use_default_image_token_count=use_default_image_token_count,
                 )

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -12244,7 +12244,7 @@ async def token_counter(request: TokenCountRequest, call_endpoint: bool = False)
         typed_messages if typed_messages is None or system_message is None else (system_message, *typed_messages)
     )
     counted_tools: Final = cast(  # cast-ok: raw OpenAI or Anthropic tool dicts, both of which token_counter formats
-        list[ChatCompletionToolParam] | None, tools
+        list[ChatCompletionToolParam] | None, tools if counted_messages is not None else None
     )
     total_tokens: Final = await asyncify(litellm.token_counter)(
         model=model_to_use,

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -672,7 +672,12 @@ from litellm.types.llms.anthropic import (
     AnthropicResponseContentBlockText,
     AnthropicResponseUsageBlock,
 )
-from litellm.types.llms.openai import HttpxBinaryResponseContent
+from litellm.types.llms.openai import (
+    AllMessageValues,
+    ChatCompletionSystemMessage,
+    ChatCompletionToolParam,
+    HttpxBinaryResponseContent,
+)
 from litellm.types.proxy.control_plane_endpoints import WorkerRegistryEntry
 from litellm.types.proxy.management_endpoints.model_management_endpoints import (
     ModelGroupInfoProxy,
@@ -12126,6 +12131,13 @@ async def _try_provider_token_count(
     return result
 
 
+def _system_message(system: object) -> ChatCompletionSystemMessage | None:
+    if not isinstance(system, (str, list)) or not system:
+        return None
+    message: Final[ChatCompletionSystemMessage] = {"role": "system", "content": system}
+    return message
+
+
 @router.post(
     "/utils/token_counter",
     tags=["llm utils"],
@@ -12224,10 +12236,21 @@ async def token_counter(request: TokenCountRequest, call_endpoint: bool = False)
     _tokenizer_used: Final = litellm.utils._select_tokenizer(model=model_to_use, custom_tokenizer=custom_tokenizer)
 
     tokenizer_used: Final = str(_tokenizer_used["type"])
+    system_message: Final = _system_message(system)
+    typed_messages: Final = cast(  # cast-ok: request messages are raw chat-shaped dicts that token_counter normalizes
+        Sequence[AllMessageValues] | None, messages
+    )
+    counted_messages: Final = (
+        typed_messages if typed_messages is None or system_message is None else (system_message, *typed_messages)
+    )
+    counted_tools: Final = cast(  # cast-ok: raw OpenAI or Anthropic tool dicts, both of which token_counter formats
+        list[ChatCompletionToolParam] | None, tools
+    )
     total_tokens: Final = await asyncify(litellm.token_counter)(
         model=model_to_use,
         text=prompt,
-        messages=messages,
+        messages=counted_messages,
+        tools=counted_tools,
         custom_tokenizer=_tokenizer_used,
     )
     return TokenCountResponse(

--- a/litellm/types/llms/anthropic.py
+++ b/litellm/types/llms/anthropic.py
@@ -1,4 +1,4 @@
-from collections.abc import Iterable
+from collections.abc import Iterable, Sequence
 from enum import Enum
 from typing import Any, Final, Literal, TypeAlias
 
@@ -254,6 +254,17 @@ class AnthropicContentParamSourceFileId(TypedDict):
     file_id: str
 
 
+class AnthropicContentParamSourceText(TypedDict):
+    type: ReadOnly[Literal["text"]]
+    media_type: ReadOnly[Literal["text/plain"]]
+    data: ReadOnly[str]
+
+
+class AnthropicContentParamSourceContent(TypedDict):
+    type: ReadOnly[Literal["content"]]
+    content: ReadOnly[str | Sequence["AnthropicMessagesTextParam | AnthropicMessagesImageParam"]]
+
+
 class AnthropicMessagesContainerUploadParam(TypedDict, total=False):
     type: Required[Literal["container_upload"]]
     file_id: str
@@ -305,7 +316,13 @@ AnthropicCitation = AnthropicCitationPageLocation | AnthropicCitationCharLocatio
 
 class AnthropicMessagesDocumentParam(TypedDict, total=False):
     type: Required[Literal["document"]]
-    source: Required[AnthropicContentParamSource | AnthropicContentParamSourceFileId | AnthropicContentParamSourceUrl]
+    source: Required[
+        AnthropicContentParamSource
+        | AnthropicContentParamSourceFileId
+        | AnthropicContentParamSourceUrl
+        | AnthropicContentParamSourceText
+        | AnthropicContentParamSourceContent
+    ]
     cache_control: dict | ChatCompletionCachedContent | None
     title: str
     context: str

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -2302,7 +2302,7 @@ def token_counter(
     model="",
     custom_tokenizer: dict | SelectTokenizerResponse | None = None,
     text: str | list[str] | None = None,
-    messages: list | None = None,
+    messages: Sequence | None = None,
     count_response_tokens: bool | None = False,
     tools: list[ChatCompletionToolParam] | None = None,
     tool_choice: ChatCompletionNamedToolChoiceParam | None = None,
@@ -7741,7 +7741,7 @@ def convert_to_dict(message: BaseModel | dict) -> dict:
         raise TypeError(f"Invalid message type: {type(message)}. Expected dict or Pydantic model.")
 
 
-def convert_list_message_to_dict(messages: list):
+def convert_list_message_to_dict(messages: Sequence):
     new_messages: Final = []
     for message in messages:
         convert_msg_to_dict = cast(AllMessageValues, convert_to_dict(message))

--- a/tests/test_litellm/litellm_core_utils/test_token_counter.py
+++ b/tests/test_litellm/litellm_core_utils/test_token_counter.py
@@ -1171,7 +1171,7 @@ def test_count_content_list_rejects_unknown_type():
     ],
     ids=["base64", "url", "file"],
 )
-def test_token_counter_with_anthropic_image_block(source):
+def test_token_counter_with_anthropic_image_block(source: dict[str, str]):
     """
     Anthropic-native `image` blocks must NOT raise, for every source variant.
 

--- a/tests/test_litellm/litellm_core_utils/test_token_counter.py
+++ b/tests/test_litellm/litellm_core_utils/test_token_counter.py
@@ -1172,16 +1172,7 @@ def test_count_content_list_rejects_unknown_type():
     ids=["base64", "url", "file"],
 )
 def test_token_counter_with_anthropic_image_block(source: dict[str, str]):
-    """
-    Anthropic-native `image` blocks must NOT raise, for every source variant.
-
-    Before this fix `_count_content_list` raised
-    `Invalid content item type: image`. That 500s /v1/messages/count_tokens and
-    /utils/token_counter, and it makes the router's context-window pre-call
-    check swallow the error and return every deployment unfiltered, so an
-    oversized prompt carrying an image is dispatched upstream instead of being
-    rejected locally.
-    """
+    """Anthropic `image` blocks must count for every source variant, not raise `Invalid content item type` (which the router's context-window pre-call check swallows into an unfiltered dispatch)."""
     from litellm.constants import DEFAULT_IMAGE_TOKEN_COUNT
 
     messages = [
@@ -1205,11 +1196,7 @@ def test_token_counter_with_anthropic_image_block(source: dict[str, str]):
 
 
 def test_anthropic_image_block_matches_equivalent_image_url():
-    """
-    An Anthropic `image` block must price identically to the OpenAI `image_url`
-    block carrying the same bytes, so the count does not depend on which
-    endpoint shape the caller used.
-    """
+    """An Anthropic `image` block prices identically to the OpenAI `image_url` carrying the same bytes."""
     anthropic_messages = [
         {
             "role": "user",
@@ -1247,11 +1234,7 @@ def test_anthropic_image_block_matches_equivalent_image_url():
 
 
 def test_anthropic_image_block_nested_in_tool_result():
-    """
-    An `image` block nested inside a `tool_result.content` list must be counted
-    too. `_count_anthropic_content` recurses back into `_count_content_list`, so
-    the nested case failed for the same reason the top-level one did.
-    """
+    """An `image` block nested in a `tool_result.content` list is counted through the same recursion."""
     messages = [
         {
             "role": "user",
@@ -1292,22 +1275,14 @@ def test_anthropic_image_block_nested_in_tool_result():
     ids=["base64", "url", "file"],
 )
 def test_anthropic_image_source_resolves_to_what_the_image_pricer_reads(source: dict[str, str], expected: str):
-    """
-    The image pricer reads either a data URI or a fetchable URL: a base64 source keeps its
-    media type inside the URI, a url source passes through untouched, and a file source has
-    no bytes the proxy can measure locally.
-    """
+    """base64 sources become a data URI, url sources pass through, file sources resolve to an empty string."""
     from litellm.litellm_core_utils.token_counter import _anthropic_image_source_data
 
     assert _anthropic_image_source_data(source) == expected
 
 
 def test_anthropic_image_block_with_empty_base64_data():
-    """
-    A base64 source carrying no bytes must still price as an image rather than
-    raise: the block is well-formed enough to count, and an empty `data` only
-    means there is nothing to measure the dimensions from.
-    """
+    """A base64 source with empty `data` prices as an image rather than raising."""
     from litellm.litellm_core_utils.token_counter import _count_content_list
 
     tokens = _count_content_list(
@@ -1322,11 +1297,7 @@ def test_anthropic_image_block_with_empty_base64_data():
 
 
 def test_anthropic_image_block_without_source_raises():
-    """
-    An `image` block with no `source` is malformed, and must fail the same way
-    the OpenAI `image_url` block with no `url` does - a ValueError the caller
-    can turn into a 400 - instead of being silently counted as a valid image.
-    """
+    """An `image` block with no `source` raises, matching the OpenAI `image_url`-without-`url` behavior."""
     from litellm.litellm_core_utils.token_counter import _count_content_list
 
     with pytest.raises(ValueError, match="Error getting number of tokens from content list"):
@@ -1369,10 +1340,7 @@ def _count_user_content(content: list[dict]) -> int:
     ids=["base64", "url", "file"],
 )
 def test_anthropic_document_block_with_opaque_source_is_priced_like_an_image(source: dict[str, str]):
-    """
-    A `document` whose bytes cannot be tokenized locally must not raise (it 500ed
-    /v1/messages/count_tokens before) and is priced exactly like an `image` block.
-    """
+    """A `document` whose bytes can't be tokenized locally is priced like an `image`, not raised on."""
     prompt = {"type": "text", "text": "Summarize this file."}
 
     assert _count_user_content([prompt, {"type": "document", "source": source}]) == _count_user_content(

--- a/tests/test_litellm/litellm_core_utils/test_token_counter.py
+++ b/tests/test_litellm/litellm_core_utils/test_token_counter.py
@@ -1280,3 +1280,50 @@ def test_anthropic_image_block_nested_in_tool_result():
         use_default_image_token_count=True,
     )
     assert tokens > 0
+
+
+def test_anthropic_image_block_with_empty_base64_data():
+    """
+    A base64 source carrying no bytes must still price as an image rather than
+    raise: the block is well-formed enough to count, and an empty `data` only
+    means there is nothing to measure the dimensions from.
+    """
+    from litellm.litellm_core_utils.token_counter import _count_content_list
+
+    tokens = _count_content_list(
+        count_function=len,
+        content_list=[
+            {"type": "image", "source": {"type": "base64", "media_type": "image/png", "data": ""}}
+        ],
+        use_default_image_token_count=False,
+        default_token_count=None,
+    )
+    assert tokens > 0
+
+
+def test_anthropic_image_block_without_source_raises():
+    """
+    An `image` block with no `source` is malformed, and must fail the same way
+    the OpenAI `image_url` block with no `url` does - a ValueError the caller
+    can turn into a 400 - instead of being silently counted as a valid image.
+    """
+    from litellm.litellm_core_utils.token_counter import _count_content_list
+
+    with pytest.raises(ValueError):
+        _count_content_list(
+            count_function=len,
+            content_list=[{"type": "image"}],
+            use_default_image_token_count=False,
+            default_token_count=None,
+        )
+
+    # ... and `default_token_count`, the caller's opt-out from raising, still wins.
+    assert (
+        _count_content_list(
+            count_function=len,
+            content_list=[{"type": "image"}],
+            use_default_image_token_count=False,
+            default_token_count=7,
+        )
+        == 7
+    )

--- a/tests/test_litellm/litellm_core_utils/test_token_counter.py
+++ b/tests/test_litellm/litellm_core_utils/test_token_counter.py
@@ -1282,6 +1282,26 @@ def test_anthropic_image_block_nested_in_tool_result():
     assert tokens > 0
 
 
+@pytest.mark.parametrize(
+    ("source", "expected"),
+    [
+        ({"type": "base64", "media_type": "image/jpeg", "data": "/9j/4AAQ"}, "data:image/jpeg;base64,/9j/4AAQ"),
+        ({"type": "url", "url": "https://example.com/image.png"}, "https://example.com/image.png"),
+        ({"type": "file", "file_id": "file-abc123"}, ""),
+    ],
+    ids=["base64", "url", "file"],
+)
+def test_anthropic_image_source_resolves_to_what_the_image_pricer_reads(source: dict[str, str], expected: str):
+    """
+    The image pricer reads either a data URI or a fetchable URL: a base64 source keeps its
+    media type inside the URI, a url source passes through untouched, and a file source has
+    no bytes the proxy can measure locally.
+    """
+    from litellm.litellm_core_utils.token_counter import _anthropic_image_source_data
+
+    assert _anthropic_image_source_data(source) == expected
+
+
 def test_anthropic_image_block_with_empty_base64_data():
     """
     A base64 source carrying no bytes must still price as an image rather than
@@ -1309,7 +1329,7 @@ def test_anthropic_image_block_without_source_raises():
     """
     from litellm.litellm_core_utils.token_counter import _count_content_list
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="Error getting number of tokens from content list"):
         _count_content_list(
             count_function=len,
             content_list=[{"type": "image"}],
@@ -1326,4 +1346,66 @@ def test_anthropic_image_block_without_source_raises():
             default_token_count=7,
         )
         == 7
+    )
+
+
+def _count_user_content(content: list[dict]) -> int:
+    from litellm.litellm_core_utils.token_counter import token_counter
+
+    return token_counter(
+        model="anthropic/claude-fable-5",
+        messages=[{"role": "user", "content": content}],
+        use_default_image_token_count=True,
+    )
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        {"type": "base64", "media_type": "application/pdf", "data": "JVBERi0xLjQK"},
+        {"type": "url", "url": "https://example.com/report.pdf"},
+        {"type": "file", "file_id": "file-abc123"},
+    ],
+    ids=["base64", "url", "file"],
+)
+def test_anthropic_document_block_with_opaque_source_is_priced_like_an_image(source: dict[str, str]):
+    """
+    A `document` whose bytes cannot be tokenized locally must not raise (it 500ed
+    /v1/messages/count_tokens before) and is priced exactly like an `image` block.
+    """
+    prompt = {"type": "text", "text": "Summarize this file."}
+
+    assert _count_user_content([prompt, {"type": "document", "source": source}]) == _count_user_content(
+        [prompt, {"type": "image", "source": source}]
+    )
+
+
+def test_anthropic_document_block_text_sources_count_their_text():
+    """`text` and `content` document sources count the text they carry, as inline text blocks would."""
+    prompt = {"type": "text", "text": "Summarize this file."}
+    body = {"type": "text", "text": "Revenue grew eleven percent while churn fell to two percent."}
+    picture = {"type": "image", "source": {"type": "base64", "media_type": "image/png", "data": "iVBORw0KGgo="}}
+
+    text_source = {"type": "document", "source": {"type": "text", "media_type": "text/plain", "data": body["text"]}}
+    assert _count_user_content([prompt, text_source]) == _count_user_content([prompt, body])
+
+    string_content = {"type": "document", "source": {"type": "content", "content": body["text"]}}
+    assert _count_user_content([prompt, string_content]) == _count_user_content([prompt, body])
+
+    block_content = {"type": "document", "source": {"type": "content", "content": [body, picture]}}
+    assert _count_user_content([prompt, block_content]) == _count_user_content([prompt, body, picture])
+
+
+def test_anthropic_document_title_and_context_add_their_tokens():
+    prompt = {"type": "text", "text": "Summarize this file."}
+    source = {"type": "base64", "media_type": "application/pdf", "data": "JVBERi0xLjQK"}
+    described = {"type": "document", "source": source, "title": "Q3 board packet", "context": "Shared by finance"}
+
+    assert _count_user_content([prompt, described]) == _count_user_content(
+        [
+            prompt,
+            {"type": "text", "text": "Q3 board packet"},
+            {"type": "text", "text": "Shared by finance"},
+            {"type": "document", "source": source},
+        ]
     )

--- a/tests/test_litellm/litellm_core_utils/test_token_counter.py
+++ b/tests/test_litellm/litellm_core_utils/test_token_counter.py
@@ -1160,3 +1160,123 @@ def test_count_content_list_rejects_unknown_type():
     message = str(exc_info.value)
     assert "Invalid content item type: totally_unknown_block" in message
     assert "tool_reference" in message
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        {"type": "base64", "media_type": "image/png", "data": "iVBORw0KGgo="},
+        {"type": "url", "url": "https://example.com/image.png"},
+        {"type": "file", "file_id": "file-abc123"},
+    ],
+    ids=["base64", "url", "file"],
+)
+def test_token_counter_with_anthropic_image_block(source):
+    """
+    Anthropic-native `image` blocks must NOT raise, for every source variant.
+
+    Before this fix `_count_content_list` raised
+    `Invalid content item type: image`. That 500s /v1/messages/count_tokens and
+    /utils/token_counter, and it makes the router's context-window pre-call
+    check swallow the error and return every deployment unfiltered, so an
+    oversized prompt carrying an image is dispatched upstream instead of being
+    rejected locally.
+    """
+    from litellm.constants import DEFAULT_IMAGE_TOKEN_COUNT
+
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "What is in this image?"},
+                {"type": "image", "source": source},
+            ],
+        }
+    ]
+
+    tokens = token_counter(
+        model="anthropic/claude-sonnet-4-5-20250929",
+        messages=messages,
+        use_default_image_token_count=True,
+    )
+    assert tokens > DEFAULT_IMAGE_TOKEN_COUNT, (
+        f"Expected the image block to contribute tokens, got {tokens}"
+    )
+
+
+def test_anthropic_image_block_matches_equivalent_image_url():
+    """
+    An Anthropic `image` block must price identically to the OpenAI `image_url`
+    block carrying the same bytes, so the count does not depend on which
+    endpoint shape the caller used.
+    """
+    anthropic_messages = [
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "image",
+                    "source": {
+                        "type": "base64",
+                        "media_type": "image/png",
+                        "data": "iVBORw0KGgo=",
+                    },
+                }
+            ],
+        }
+    ]
+    openai_messages = [
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "image_url",
+                    "image_url": {"url": "data:image/png;base64,iVBORw0KGgo="},
+                }
+            ],
+        }
+    ]
+
+    anthropic_tokens = token_counter(
+        model="anthropic/claude-sonnet-4-5-20250929", messages=anthropic_messages
+    )
+    openai_tokens = token_counter(
+        model="anthropic/claude-sonnet-4-5-20250929", messages=openai_messages
+    )
+    assert anthropic_tokens == openai_tokens
+
+
+def test_anthropic_image_block_nested_in_tool_result():
+    """
+    An `image` block nested inside a `tool_result.content` list must be counted
+    too. `_count_anthropic_content` recurses back into `_count_content_list`, so
+    the nested case failed for the same reason the top-level one did.
+    """
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "tool_result",
+                    "tool_use_id": "toolu_01",
+                    "content": [
+                        {
+                            "type": "image",
+                            "source": {
+                                "type": "base64",
+                                "media_type": "image/png",
+                                "data": "iVBORw0KGgo=",
+                            },
+                        }
+                    ],
+                }
+            ],
+        }
+    ]
+
+    tokens = token_counter(
+        model="anthropic/claude-sonnet-4-5-20250929",
+        messages=messages,
+        use_default_image_token_count=True,
+    )
+    assert tokens > 0

--- a/tests/test_litellm/proxy/proxy_server/test_routes_utils.py
+++ b/tests/test_litellm/proxy/proxy_server/test_routes_utils.py
@@ -229,3 +229,33 @@ def test_token_counter_fallback_counts_tools_system_and_anthropic_blocks(client,
         tools=tools,
     )
     assert full > bare
+
+
+def test_token_counter_fallback_prompt_with_tools_does_not_500(client, auth_as, monkeypatch):
+    """
+    Regression: a raw-text ``prompt`` request that also carries ``tools`` (no ``messages``) must
+    still count. ``litellm.token_counter`` rejects tools on the text path, so the fallback route
+    only attaches tools when it is counting messages; otherwise this 500'd instead of returning
+    the plain text count.
+    """
+    monkeypatch.setattr(proxy_server, "llm_router", None)
+    monkeypatch.setattr(litellm, "disable_token_counter", False, raising=False)
+    prompt = "count the tokens in this sentence please"
+    tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": "get_weather",
+                "description": "Look up the current weather for a city",
+                "parameters": {"type": "object", "properties": {"city": {"type": "string"}}, "required": ["city"]},
+            },
+        }
+    ]
+
+    with auth_as():
+        response = client.post(
+            "/utils/token_counter", json={"model": "claude-fable-5", "prompt": prompt, "tools": tools}
+        )
+
+    assert response.status_code == 200, response.text
+    assert response.json()["total_tokens"] == litellm.token_counter(model="claude-fable-5", text=prompt)

--- a/tests/test_litellm/proxy/proxy_server/test_routes_utils.py
+++ b/tests/test_litellm/proxy/proxy_server/test_routes_utils.py
@@ -187,11 +187,7 @@ def test_transform_request_unsafe_body(client, auth_as, monkeypatch):
 
 
 def test_token_counter_fallback_counts_tools_system_and_anthropic_blocks(client, auth_as, monkeypatch):
-    """
-    Without a provider counter the route falls back to ``litellm.token_counter``. That count
-    must include the request's tools and system prompt, and Anthropic ``image`` and ``document``
-    blocks must be counted instead of turning the whole request into a 500.
-    """
+    """The ``litellm.token_counter`` fallback counts the request's tools and system prompt, and Anthropic ``image``/``document`` blocks, instead of 500ing."""
     monkeypatch.setattr(proxy_server, "llm_router", None)
     monkeypatch.setattr(litellm, "disable_token_counter", False, raising=False)
     system = [{"type": "text", "text": "You are a terse assistant. Answer in one sentence."}]
@@ -232,12 +228,7 @@ def test_token_counter_fallback_counts_tools_system_and_anthropic_blocks(client,
 
 
 def test_token_counter_fallback_prompt_with_tools_does_not_500(client, auth_as, monkeypatch):
-    """
-    Regression: a raw-text ``prompt`` request that also carries ``tools`` (no ``messages``) must
-    still count. ``litellm.token_counter`` rejects tools on the text path, so the fallback route
-    only attaches tools when it is counting messages; otherwise this 500'd instead of returning
-    the plain text count.
-    """
+    """Regression: a ``prompt`` request carrying ``tools`` but no ``messages`` still counts, because the fallback attaches tools only when counting messages (``token_counter`` rejects tools on the text path)."""
     monkeypatch.setattr(proxy_server, "llm_router", None)
     monkeypatch.setattr(litellm, "disable_token_counter", False, raising=False)
     prompt = "count the tokens in this sentence please"

--- a/tests/test_litellm/proxy/proxy_server/test_routes_utils.py
+++ b/tests/test_litellm/proxy/proxy_server/test_routes_utils.py
@@ -184,3 +184,48 @@ def test_transform_request_unsafe_body(client, auth_as, monkeypatch):
         response = client.post("/utils/transform_request", json=payload)
     assert response.status_code == 400
     assert "unsafe" in response.text or "error" in response.text
+
+
+def test_token_counter_fallback_counts_tools_system_and_anthropic_blocks(client, auth_as, monkeypatch):
+    """
+    Without a provider counter the route falls back to ``litellm.token_counter``. That count
+    must include the request's tools and system prompt, and Anthropic ``image`` and ``document``
+    blocks must be counted instead of turning the whole request into a 500.
+    """
+    monkeypatch.setattr(proxy_server, "llm_router", None)
+    monkeypatch.setattr(litellm, "disable_token_counter", False, raising=False)
+    system = [{"type": "text", "text": "You are a terse assistant. Answer in one sentence."}]
+    tools = [
+        {
+            "name": "get_weather",
+            "description": "Look up the current weather for a city",
+            "input_schema": {"type": "object", "properties": {"city": {"type": "string"}}, "required": ["city"]},
+        }
+    ]
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "What is in this file?"},
+                {"type": "image", "source": {"type": "base64", "media_type": "image/png", "data": "iVBORw0KGgo="}},
+                {"type": "document", "source": {"type": "base64", "media_type": "application/pdf", "data": "JVBERi0xLjQK"}},
+            ],
+        }
+    ]
+
+    def count(payload: dict) -> int:
+        with auth_as():
+            response = client.post("/utils/token_counter", json={"model": "claude-fable-5", **payload})
+        assert response.status_code == 200, response.text
+        return response.json()["total_tokens"]
+
+    bare = count({"messages": messages})
+    full = count({"messages": messages, "tools": tools, "system": system})
+
+    assert bare == litellm.token_counter(model="claude-fable-5", messages=messages)
+    assert full == litellm.token_counter(
+        model="claude-fable-5",
+        messages=[{"role": "system", "content": system}, *messages],
+        tools=tools,
+    )
+    assert full > bare


### PR DESCRIPTION
Internal copy of #36671 (head c85a7b7c29 on FazeelUsmani:fix/token-counter-anthropic-image-blocks). That PR's three commits are kept as-is under their original author, rebased onto litellm_internal_staging, with the tools, system, and document commit on top. The fork branch had absorbed a base merge that made its diff render as 4,478 files, which is why the same work continues here

## TLDR

Problem this solves:

- `/v1/messages/count_tokens` local fallback ignores `tools` and `system`
- Claude Code's context gauge misses the whole system prompt and tool set
- Anthropic `image` blocks crash the local count with a 500
- Anthropic `document` (PDF) blocks crash it the same way
- Context-window pre-call check silently skipped when a message carries an image

How it solves it:

- Fallback now passes `tools` and `system` into the shared counter
- Count `image` blocks through the existing image path
- Handle all three image sources: base64, url, file
- Count `document` blocks: text sources by their text, opaque ones like an image
- Nested `tool_result` image blocks covered by the same branch

## User Flow

Before: a developer running Claude Code in VS Code against the gateway, on a Bedrock-backed Claude model whose provider-side token counting is rejected, sees the context gauge ignore the system prompt and tools and then break outright once a screenshot enters the session

1. They start Claude Code with `ANTHROPIC_BASE_URL=https://litellm-domain` and `ANTHROPIC_MODEL=claude-fable-5-bedrock` and ask it to summarize the repo layout
2. Claude Code sizes the turn with `POST https://litellm-domain/v1/messages/count_tokens` carrying the system prompt, the tool schemas, and the messages; the gateway answers `200 {"input_tokens": 16}`, the same 16 it answers for the messages alone, while Anthropic's own `POST https://api.anthropic.com/v1/messages/count_tokens` reports 1302 for the identical body
3. `/context` shows the system prompt and tools costing almost nothing, so auto-compaction runs off a gauge that is short by everything but the messages (the customer saw 197 compactions in 14 hours)
4. They paste a screenshot into the conversation; the next `POST https://litellm-domain/v1/messages/count_tokens` carries an `image` block and comes back `500 {"detail": {"error": "Internal server error: ... Invalid content item type: image ..."}}`, and every later count for that session fails the same way
5. They attach a PDF as a `document` block and get the same `500`, this time naming `document`
6. They send `POST https://litellm-domain/v1/messages` with a roughly 5,400-token prompt plus that screenshot to a model group whose deployment declares a 100-token input limit: the gateway forwards it upstream and returns `200` with `usage.input_tokens: 5424`, billed by the provider, instead of rejecting it

After: the same session gets real system, tool, image, and PDF counts, and image messages are size-checked like text-only ones

1. They start Claude Code with `ANTHROPIC_BASE_URL=https://litellm-domain` and `ANTHROPIC_MODEL=claude-fable-5-bedrock` and ask it to summarize the repo layout
2. The same `POST https://litellm-domain/v1/messages/count_tokens` with the system prompt and tools answers `200 {"input_tokens": 568}`, up from the 16 the messages alone cost, so the gauge moves with the prompt the way Anthropic's own endpoint does
3. `/context` shows the system prompt and tools at their real weight, so auto-compaction fires when the context is actually full
4. The screenshot request comes back `200 {"input_tokens": 98}`
5. The PDF request comes back `200 {"input_tokens": 102}`
6. The oversized prompt plus screenshot comes back `400` with `Context Window exceeded for given call`, and nothing leaves the gateway

## Relevant issues

Fixes #36604

## Linear ticket

Resolves LIT-5545

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Three proxies, one per checkpoint, booted from the same config with no database and real provider keys in the environment (`ANTHROPIC_API_KEY`, `AWS_BEARER_TOKEN_BEDROCK`), then hit with the same curl battery. The Bedrock deployment's provider-side count fails on the QA account (`403 not authorized to perform: bedrock:CountTokens`) and the proxy logs `Provider token counting failed (403) ... Falling back to local tokenizer.`, which is the same local fallback the customer lands in when Bedrock answers 400 for their model. The `anthropic/` deployment goes through Anthropic's own count endpoint and serves as ground truth

The tip is now 24d226c6c2cb, a docstring-only cleanup (Greptile P2) with no behavioral change, so the proof below still stands at the commit it ran at, 83ab87091b

| Checkpoint | Proxy commit | messages only -> plus system and 3 tools | image block | document block | /utils/token_counter, image | oversized prompt + image, 100-token deployment |
| --- | --- | --- | --- | --- | --- | --- |
| Merge base | ca0b951a43 | 16 -> 16, FAIL | 500, FAIL | 500, FAIL | 500, FAIL | 200 forwarded, FAIL |
| #36671's commits | 7cd3a27d60 | 16 -> 16, FAIL | 98, PASS | 500, FAIL | 98, PASS | 400 rejected, PASS |
| This PR's tip | 83ab87091b | 16 -> 568, PASS | 98, PASS | 102, PASS | 98, PASS | 400 rejected, PASS |
| Anthropic's own count | n/a | 18 -> 1302 | 432 | 1620 | n/a | n/a |

Shared setup

```yaml
model_list:
  - model_name: claude-fable-5-bedrock
    litellm_params:
      model: bedrock/us.anthropic.claude-fable-5
      aws_region_name: us-east-1
  - model_name: claude-fable-5
    litellm_params:
      model: anthropic/claude-fable-5
      api_key: os.environ/ANTHROPIC_API_KEY
  - model_name: tiny-context-haiku
    litellm_params:
      model: anthropic/claude-haiku-4-5
      api_key: os.environ/ANTHROPIC_API_KEY
    model_info:
      max_input_tokens: 100

router_settings:
  enable_pre_call_checks: true

general_settings:
  master_key: sk-1234
```

```bash
python litellm/proxy/proxy_cli.py --config config.yaml --port $PORT --detailed_debug
```

Payloads, all with `"model": "claude-fable-5-bedrock"` unless a case says otherwise: `msgs.json` is one user message, `Summarize the repo layout for me.`; `full.json` is the same message plus a 40-sentence `system` array and three Anthropic-shaped tools (`read_file`, `write_file`, `run_shell`, each with an `input_schema`); `image.json` is a text block plus a base64 `image` block holding a 640x480 PNG; `doc.json` is a text block plus a base64 `document` block holding a one-page PDF with `"title": "Q3 board packet"`; `cw.json` is `"hello " * 5000` plus that same image block, `max_tokens: 5`, model `tiny-context-haiku`

```bash
H=(-H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json')
```

### Before (ca0b951a43)

#### tools and system in the local fallback

1. `curl -s -w '\nhttp=%{http_code}\n' http://localhost:50186/v1/messages/count_tokens "${H[@]}" -d @msgs.json`
2. `{"input_tokens":16}` `http=200`
3. `curl -s -w '\nhttp=%{http_code}\n' http://localhost:50186/v1/messages/count_tokens "${H[@]}" -d @full.json`
4. `{"input_tokens":16}` `http=200`, the system prompt and three tools add nothing
5. Ground truth, same two bodies with `"model": "claude-fable-5"`: `{"input_tokens":18}` and `{"input_tokens":1302}`

#### image block

1. `curl -s -w '\nhttp=%{http_code}\n' http://localhost:50186/v1/messages/count_tokens "${H[@]}" -d @image.json`
2. `{"detail":{"error":"Internal server error: Error getting number of tokens from content list: Invalid content item type: image. Expected str or dict with 'type' field (text, image_url, tool_use, tool_result, thinking, tool_reference)., default_token_count=None"}}` `http=500`

#### document block

1. `curl -s -w '\nhttp=%{http_code}\n' http://localhost:50186/v1/messages/count_tokens "${H[@]}" -d @doc.json`
2. `{"detail":{"error":"Internal server error: Error getting number of tokens from content list: Invalid content item type: document. Expected str or dict with 'type' field (text, image_url, tool_use, tool_result, thinking, tool_reference)., default_token_count=None"}}` `http=500`

#### /utils/token_counter with the image block

1. `curl -s -w '\nhttp=%{http_code}\n' http://localhost:50186/utils/token_counter "${H[@]}" -d @image.json`
2. `{"error":{"message":"Internal server error","type":"internal_server_error"}}` `http=500`

#### oversized prompt plus image through the context-window pre-call check

1. `curl -s -w '\nhttp=%{http_code}\n' http://localhost:50186/v1/messages "${H[@]}" -d @cw.json`
2. `{"model":"tiny-context-haiku","id":"msg_011CeVAYh7RN2w63KEqv2Sg9","type":"message","role":"assistant","content":[{"type":"text","text":"Hello! 👋"}],"stop_reason":"max_tokens",...,"usage":{"input_tokens":5424,...}}` `http=200`, forwarded to Anthropic and billed despite the deployment's 100-token limit

### After (83ab87091b)

#### tools and system in the local fallback

1. `curl -s -w '\nhttp=%{http_code}\n' http://localhost:51822/v1/messages/count_tokens "${H[@]}" -d @msgs.json`
2. `{"input_tokens":16}` `http=200`
3. `curl -s -w '\nhttp=%{http_code}\n' http://localhost:51822/v1/messages/count_tokens "${H[@]}" -d @full.json`
4. `{"input_tokens":568}` `http=200`, the system prompt and tools now count
5. Ground truth, same two bodies with `"model": "claude-fable-5"`: `{"input_tokens":18}` and `{"input_tokens":1302}`, unchanged from Before since the provider path is untouched

#### image block

1. `curl -s -w '\nhttp=%{http_code}\n' http://localhost:51822/v1/messages/count_tokens "${H[@]}" -d @image.json`
2. `{"input_tokens":98}` `http=200`

#### document block

1. `curl -s -w '\nhttp=%{http_code}\n' http://localhost:51822/v1/messages/count_tokens "${H[@]}" -d @doc.json`
2. `{"input_tokens":102}` `http=200`

#### /utils/token_counter with the image block

1. `curl -s -w '\nhttp=%{http_code}\n' http://localhost:51822/utils/token_counter "${H[@]}" -d @image.json`
2. `{"total_tokens":98,"request_model":"claude-fable-5-bedrock","model_used":"us.anthropic.claude-fable-5","tokenizer_type":"openai_tokenizer","original_response":null,"error":false,"error_message":null,"status_code":null}` `http=200`

#### oversized prompt plus image through the context-window pre-call check

1. `curl -s -w '\nhttp=%{http_code}\n' http://localhost:51822/v1/messages "${H[@]}" -d @cw.json`
2. `{"error":{"message":"litellm.ContextWindowExceededError: litellm.BadRequestError: litellm._pre_call_checks: Context Window exceeded for given call. No models have context window large enough for this call.\nModel=anthropic/claude-haiku-4-5, Max Input Tokens=100, ...` `http=400`, rejected before anything leaves the proxy

### Regression guard: a `prompt` with `tools` and no `messages`

`litellm.token_counter` rejects `tools` on the raw-text path, so the fallback must only attach tools when it is counting messages. An earlier commit on this branch (70ba0bb973) attached them unconditionally and 500'd a `prompt` + `tools` request that the merge base had answered `200`; commit 83ab87091b restores it. The same body run against all three proxies:

```json
{"model":"claude-fable-5-bedrock","prompt":"count the tokens in this sentence please","tools":[{"type":"function","function":{"name":"get_weather","description":"Look up the current weather","parameters":{"type":"object","properties":{"city":{"type":"string"}},"required":["city"]}}}]}
```

1. Merge base ca0b951a43, port 50186: `{"total_tokens":7,...}` `http=200`
2. Intermediate commit 70ba0bb973, port 45126: `{"error":{"message":"Internal server error","type":"internal_server_error"}}` `http=500`
3. This PR's tip 83ab87091b, port 51822: `{"total_tokens":7,...}` `http=200`, the same count as the prompt alone, since tools carry no weight without messages to attach them to

### Observations

- prompt + tools 500 was branch-internal, found by /live-pr-risk, fixed before merge
- Provider-count ground truth stable across every checkpoint: 18 and 1302
- Fallback still undercounts Anthropic tool-use overhead, an approximation left as a caveat

## Type

🐛 Bug Fix

## Caveats (if any)

### Low

- The local fallback stays an approximation: 568 here where Anthropic counts 1302, since Anthropic's tool-use system overhead is not modeled
- Anthropic `image` blocks use the existing `image_url` formula: 85 tokens for a 640x480 screenshot where Anthropic counts 432
- Opaque document sources (base64, url, file) priced at the image base rate, not per page
- A `file` image source falls back to the default image token count, since its bytes cannot be resolved locally

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR


- [x] 83ab87091b passes /live-pr-risk

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shared token counting and proxy fallback used for context limits and billing estimates; behavior changes are intentional but local counts remain approximations vs Anthropic’s API.
> 
> **Overview**
> Fixes local token counting when provider APIs are unavailable (e.g. Bedrock `CountTokens` denied), so Claude Code–style `count_tokens` and context-window checks stop undercounting or 500ing on rich Anthropic payloads.
> 
> **Core counter** (`token_counter.py`): `_count_content_list` now handles Anthropic **`image`** blocks (base64/url/file via `_anthropic_image_source_data` → existing image pricing) and **`document`** blocks (`_count_document_tokens`: inline `text`/`content` sources tokenized as text; opaque PDF-like sources priced like images; `title`/`context` counted). Anthropic TypedDicts gain `text`/`content` document source variants.
> 
> **Proxy fallback** (`/utils/token_counter`): prepends request **`system`** as a synthetic system message and passes **`tools`** into `litellm.token_counter` only when counting **messages** (not `prompt`-only), avoiding the prior regression where `tools` + `prompt` would error.
> 
> **Typing**: `messages` accept `Sequence` in `utils`/`token_counter` for tuple prepends.
> 
> Tests cover image/document parity, nested `tool_result` images, and proxy fallback vs direct `litellm.token_counter`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 24d226c6c2cba581a3833486ce099d240705fd77. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
