### PR TITLE
fix(vertex_ai): preserve search tools mixed with function declarations on Gemini 3+ (fix #38648)

### DIFF
--- a/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
+++ b/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
@@ -1212,8 +1212,8 @@ class VertexGeminiConfig(VertexAIBaseConfig, BaseConfig):
         if VertexGeminiConfig._is_gemini_3_or_newer(model):
             if "temperature" not in optional_params:
                 optional_params["temperature"] = 1.0
-
-        self._drop_search_tools_mixed_with_functions(optional_params)
+        else:
+            self._drop_search_tools_mixed_with_functions(optional_params)
 
         return optional_params
 

--- a/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
+++ b/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
@@ -406,7 +406,9 @@ class VertexGeminiConfig(VertexAIBaseConfig, BaseConfig):
         ]
 
     @staticmethod
-    def _deduplicate_tools(optional_params: dict) -> None:
+    def _deduplicate_tools(
+        optional_params: dict,  # mutable-ok: optional parameters use the existing request shape
+    ) -> None:
         tools: Final = optional_params.get("tools")
         if not isinstance(tools, list):
             return
@@ -415,7 +417,7 @@ class VertexGeminiConfig(VertexAIBaseConfig, BaseConfig):
         for tool in tools:
             if tool not in deduplicated:
                 deduplicated.append(tool)
-        optional_params["tools"] = deduplicated
+        optional_params["tools"] = deduplicated  # rebind-ok: normalize request payload before serialization
 
     def _map_service_tier_param(self, value: str, optional_params: dict) -> None:
         """

--- a/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
+++ b/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
@@ -405,6 +405,18 @@ class VertexGeminiConfig(VertexAIBaseConfig, BaseConfig):
             tool for tool in tools if not (isinstance(tool, dict) and any(key in tool for key in search_tool_keys))
         ]
 
+    @staticmethod
+    def _deduplicate_tools(optional_params: dict) -> None:
+        tools: Final = optional_params.get("tools")
+        if not isinstance(tools, list):
+            return
+
+        deduplicated: Final[list] = []
+        for tool in tools:
+            if tool not in deduplicated:
+                deduplicated.append(tool)
+        optional_params["tools"] = deduplicated
+
     def _map_service_tier_param(self, value: str, optional_params: dict) -> None:
         """
         Map OpenAI service_tier (string) to Gemini serviceTier.
@@ -1072,6 +1084,7 @@ class VertexGeminiConfig(VertexAIBaseConfig, BaseConfig):
         drop_params: bool,
     ) -> dict:
         self._apply_include_server_side_tool_invocations(non_default_params, optional_params)
+        web_search_options_present: Final = isinstance(non_default_params.get("web_search_options"), dict)
         gemini_sampling_params_warned: bool = False
         for param, value in non_default_params.items():
             if param == "temperature":
@@ -1212,7 +1225,9 @@ class VertexGeminiConfig(VertexAIBaseConfig, BaseConfig):
         if VertexGeminiConfig._is_gemini_3_or_newer(model):
             if "temperature" not in optional_params:
                 optional_params["temperature"] = 1.0
-        else:
+
+        self._deduplicate_tools(optional_params)
+        if web_search_options_present or not VertexGeminiConfig._is_gemini_3_or_newer(model):
             self._drop_search_tools_mixed_with_functions(optional_params)
 
         return optional_params

--- a/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
+++ b/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
@@ -411,7 +411,7 @@ class VertexGeminiConfig(VertexAIBaseConfig, BaseConfig):
         if not isinstance(tools, list):
             return
 
-        deduplicated: Final[list] = []
+        deduplicated: Final[list] = []  # mutable-ok: request payload requires an ordered list
         for tool in tools:
             if tool not in deduplicated:
                 deduplicated.append(tool)

--- a/tests/test_litellm/llms/vertex_ai/gemini/test_vertex_and_google_ai_studio_gemini.py
+++ b/tests/test_litellm/llms/vertex_ai/gemini/test_vertex_and_google_ai_studio_gemini.py
@@ -5757,3 +5757,36 @@ def test_calculate_web_search_requests_counts_unique_queries():
 
     assert VertexGeminiConfig._calculate_web_search_requests([]) is None
     assert VertexGeminiConfig._calculate_web_search_requests([{"webSearchQueries": ["", ""]}]) is None
+
+
+def test_gemini_3_mixed_tools_keeps_search_grounding():
+    """Gemini 3+ models support mixing function declarations and search tools."""
+    config = VertexGeminiConfig()
+    tools = [
+        {"function_declarations": [{"name": "get_weather"}]},
+        {"googleSearch": {}},
+    ]
+    params = config.map_openai_params(
+        non_default_params={"tools": tools},
+        optional_params={"tools": list(tools)},
+        model="gemini-3.7-flash",
+        drop_params=False,
+    )
+    assert len(params["tools"]) == 2
+
+
+def test_gemini_2_mixed_tools_drops_search_grounding():
+    """Older Gemini models (< Gemini 3) drop search tools when mixed with functions."""
+    config = VertexGeminiConfig()
+    tools = [
+        {"function_declarations": [{"name": "get_weather"}]},
+        {"googleSearch": {}},
+    ]
+    params = config.map_openai_params(
+        non_default_params={"tools": tools},
+        optional_params={"tools": list(tools)},
+        model="gemini-2.0-flash",
+        drop_params=False,
+    )
+    assert len(params["tools"]) == 1
+    assert "function_declarations" in params["tools"][0]


### PR DESCRIPTION
Fixes #38648

### Problem
When sending requests to Gemini 3+ models containing both custom function declarations and Google Search grounding (e.g. google_search or googleSearch), LiteLLM dropped the search tools unconditionally because older Gemini models (< Gemini 3) returned a 400 error when mixing tool types.

### Solution
- In litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py, only call _drop_search_tools_mixed_with_functions when 
ot VertexGeminiConfig._is_gemini_3_or_newer(model).
- Added unit tests 	est_gemini_3_mixed_tools_keeps_search_grounding and 	est_gemini_2_mixed_tools_drops_search_grounding in 	est_vertex_and_google_ai_studio_gemini.py.