### PR TITLE
fix(bedrock): route Cohere English embedding parameters

### DIFF
--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -3536,7 +3536,7 @@ def get_optional_params_embeddings(
             object = litellm.AmazonTitanMultimodalEmbeddingG1Config()
         elif "amazon.titan-embed-text-v2:0" in model:
             object = litellm.AmazonTitanV2Config()
-        elif "cohere.embed-multilingual-v3" in model or "cohere.embed-v4" in model:
+        elif "cohere.embed" in model:
             object = litellm.BedrockCohereEmbeddingConfig()
         elif "twelvelabs" in model or "marengo" in model:
             object = litellm.TwelveLabsMarengoEmbeddingConfig()

--- a/tests/llm_translation/test_optional_params.py
+++ b/tests/llm_translation/test_optional_params.py
@@ -187,6 +187,15 @@ def test_bedrock_optional_params_embeddings():
     )
     assert len(optional_params) == 0
 
+def test_bedrock_cohere_english_optional_params_embeddings():
+    optional_params = get_optional_params_embeddings(
+        model="bedrock/cohere.embed-english-v3",
+        encoding_format="float",
+        custom_llm_provider="bedrock",
+    )
+
+    assert optional_params["embedding_types"] == "float"
+
 
 @pytest.mark.parametrize(
     "model",


### PR DESCRIPTION
## TLDR

Problem this solves:

- Bedrock rejects Cohere English embedding encoding parameters
- Dropping parameters also removes the requested response format

How it solves it:

- Route every Cohere embedding model through its Bedrock config
- Cover the English v3 model with a regression test

## User Flow

Before: a developer cannot request float embeddings from Cohere English v3 through Bedrock

1. They send `POST http://localhost:4000/v1/embeddings` with model `bedrock/cohere.embed-english-v3`, input `hello`, and `encoding_format: float`
2. The request fails before Bedrock with `UnsupportedParamsError` for `encoding_format`
3. Enabling `drop_params` avoids that error but silently removes the requested format

After: the same request translates the format for Bedrock Cohere embeddings

1. They send the same `POST http://localhost:4000/v1/embeddings` request
2. LiteLLM translates `encoding_format: float` to `embedding_types: float`
3. Bedrock receives the supported provider parameter instead of rejecting it

## Relevant issues

Fixes #38659

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA)

## Screenshots / Proof of Fix

AWS credentials were not available for a live Bedrock request, so this draft includes the deterministic parameter-mapping reproduction and leaves the end-to-end checklist open

### Before (ca0b951a430171d4dce86679a8a1cfc86bf0c3c9)

1. Call `get_optional_params_embeddings(model="bedrock/cohere.embed-english-v3", encoding_format="float", custom_llm_provider="bedrock")`
2. Observe `UnsupportedParamsError: bedrock does not support parameters: {'encoding_format': 'float'}`

### After (f25d94fec447b54277430c5e4216e02989b41e70)

1. Call the same parameter-mapping entry point with the same arguments
2. Observe `{"embedding_types": "float"}`

## Type

🐛 Bug Fix
✅ Test

## Caveats (if any)

### Low

- A live Bedrock call still requires AWS credentials

## QA runbook

- `tests/llm_translation/test_optional_params.py::test_bedrock_cohere_english_optional_params_embeddings` proves English v3 uses the Cohere Bedrock parameter mapping
  - [ ] Call `/v1/embeddings` with `bedrock/cohere.embed-english-v3`
  - [ ] Include `encoding_format: float` and valid AWS credentials
  - [ ] Expect a successful response with float embeddings
  - [ ] Sanity check: repeat without `encoding_format` and expect success

## Final Attestation

- [x] The test targets the reported English v3 regression without broad unrelated changes
