### PR TITLE
fix(bedrock/embeddings): route cohere.embed-english-v3 to BedrockCohereEmbeddingConfig

### DIFF
--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -3403,7 +3403,7 @@ def get_optional_params_embeddings(
             object = litellm.AmazonTitanMultimodalEmbeddingG1Config()
         elif "amazon.titan-embed-text-v2:0" in model:
             object = litellm.AmazonTitanV2Config()
-        elif "cohere.embed-multilingual-v3" in model or "cohere.embed-v4" in model:
+        elif "cohere.embed" in model:
             object = litellm.BedrockCohereEmbeddingConfig()
         elif "twelvelabs" in model or "marengo" in model:
             object = litellm.TwelveLabsMarengoEmbeddingConfig()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,5 +1,5 @@
-import pytest
 import litellm
+
 
 def test_bedrock_cohere_english_v3_supported_params():
     """Verify cohere.embed-english-v3 routes to BedrockCohereEmbeddingConfig and supports encoding_format."""
@@ -9,4 +9,3 @@ def test_bedrock_cohere_english_v3_supported_params():
         encoding_format="float",
     )
     assert "encoding_format" in optional_params or optional_params.get("encoding_format") == "float"
-

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,12 @@
+import pytest
+import litellm
+
+def test_bedrock_cohere_english_v3_supported_params():
+    """Verify cohere.embed-english-v3 routes to BedrockCohereEmbeddingConfig and supports encoding_format."""
+    optional_params = litellm.utils.get_optional_params_embeddings(
+        model="cohere.embed-english-v3",
+        custom_llm_provider="bedrock",
+        encoding_format="float",
+    )
+    assert "encoding_format" in optional_params or optional_params.get("encoding_format") == "float"
+


### PR DESCRIPTION
## Title
fix(bedrock/embeddings): route cohere.embed-english-v3 to BedrockCohereEmbeddingConfig

## Description
Fixes #38659 where calling `/v1/embeddings` with `cohere.embed-english-v3` on AWS Bedrock fails with a `400 UnsupportedParamsError` for default parameters like `encoding_format="float"`.

### Cause
In `litellm/utils.py`, `get_optional_params_embeddings()` for `custom_llm_provider == "bedrock"` explicitly checked for `"cohere.embed-multilingual-v3"` and `"cohere.embed-v4"`. As a result, `cohere.embed-english-v3` fell through into the unmapped `else:` branch which defaults `supported_params = []`.

### Solution
Broadened the match condition to `elif "cohere.embed" in model:` so all Cohere Bedrock embedding models (including `cohere.embed-english-v3`) map to `litellm.BedrockCohereEmbeddingConfig()`.

## Related Issues
Closes #38659

## How Has This Been Tested?
- Added unit test `test_bedrock_cohere_english_v3_supported_params` in `tests/test_utils.py` verifying parameter resolution for `cohere.embed-english-v3` under `bedrock`.
- Ran `pytest tests/test_utils.py` (Passed).

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective
- [x] Signed off commits (`git commit -s`)