### PR TITLE
fix(anthropic): respect chat completions override for thinking

### DIFF
--- a/litellm/llms/anthropic/experimental_pass_through/adapters/handler.py
+++ b/litellm/llms/anthropic/experimental_pass_through/adapters/handler.py
@@ -322,6 +322,7 @@ class LiteLLMMessagesToCompletionTransformationHandler:
         completion_kwargs: _CompletionKwargs,
         *,
         thinking: Mapping[str, object] | None,
+        use_chat_completions_url: bool = False,
     ) -> None:
         """
         When users call `litellm.anthropic.messages.*` with a non-Anthropic model and
@@ -344,7 +345,7 @@ class LiteLLMMessagesToCompletionTransformationHandler:
             except Exception:
                 custom_llm_provider = None
 
-        if custom_llm_provider != "openai":
+        if custom_llm_provider != "openai" or use_chat_completions_url:
             return
 
         if not isinstance(thinking, dict) or thinking.get("type") != "enabled":
@@ -544,6 +545,7 @@ class LiteLLMMessagesToCompletionTransformationHandler:
         LiteLLMMessagesToCompletionTransformationHandler._route_openai_thinking_to_responses_api_if_needed(
             completion_kwargs,
             thinking=thinking,
+            use_chat_completions_url=litellm.use_chat_completions_url_for_anthropic_messages,
         )
 
         return completion_kwargs, tool_name_mapping

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_anthropic_experimental_pass_through_messages_handler.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_anthropic_experimental_pass_through_messages_handler.py
@@ -434,6 +434,24 @@ class TestThinkingParameterTransformation:
 class TestThinkingSummaryPreservation:
     """Tests for thinking.summary preservation and reasoning_auto_summary flag."""
 
+    def test_thinking_respects_chat_completions_url_override(self):
+        from litellm.llms.anthropic.experimental_pass_through.adapters.handler import (
+            LiteLLMMessagesToCompletionTransformationHandler,
+        )
+
+        completion_kwargs = {
+            "model": "openai/gpt-5.6",
+            "custom_llm_provider": "openai",
+            "reasoning_effort": "medium",
+        }
+        LiteLLMMessagesToCompletionTransformationHandler._route_openai_thinking_to_responses_api_if_needed(
+            completion_kwargs,
+            thinking={"type": "enabled", "budget_tokens": 5000},
+            use_chat_completions_url=True,
+        )
+
+        assert completion_kwargs["model"] == "openai/gpt-5.6"
+
     def test_thinking_summary_concise_preserved_for_openai(self):
         """User-provided summary='concise' should not be replaced with 'detailed'."""
         from litellm.llms.anthropic.experimental_pass_through.adapters.handler import (


### PR DESCRIPTION
## TLDR

Problem this solves:

- Thinking requests ignore forced Chat Completions routing
- Some compatible endpoints cannot serve Responses API requests

How it solves it:

- Pass the route preference into thinking auto-routing
- Preserve the selected model when Chat Completions is forced

## User Flow

Before: a developer forces Anthropic Messages through Chat Completions, but thinking still sends the request through the Responses API

1. The proxy admin sets `LITELLM_USE_CHAT_COMPLETIONS_URL_FOR_ANTHROPIC_MESSAGES=true` and restarts the proxy
2. The developer sends `POST https://litellm-domain/v1/messages` with an OpenAI model and `"thinking": {"type": "enabled", "budget_tokens": 1024}`
3. The downstream request goes to `/v1/responses`, ignoring the configured route preference
4. A Chat Completions-only endpoint rejects the request

After: the same request stays on the configured Chat Completions route

1. The proxy admin sets `LITELLM_USE_CHAT_COMPLETIONS_URL_FOR_ANTHROPIC_MESSAGES=true` and restarts the proxy
2. The developer sends `POST https://litellm-domain/v1/messages` with an OpenAI model and `"thinking": {"type": "enabled", "budget_tokens": 1024}`
3. The downstream request goes to `/v1/chat/completions`
4. The endpoint returns an Anthropic Messages response

## Relevant issues

Addresses bug 4 in #23841

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally
- [ ] My PR passes all required CI/CD checks
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile Confidence Score of at least 4/5 before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Both runs used the same local llama.cpp server with an actual Llama 3.2 model

A transparent reverse proxy recorded the downstream path without changing request or response bodies

LiteLLM used `openai/gpt-5.6` as the routing model name to exercise the OpenAI thinking path

### Before (ca0b951a43)

1. Start the proxy from the merge base

   ```shell
   LITELLM_USE_CHAT_COMPLETIONS_URL_FOR_ANTHROPIC_MESSAGES=true \
   OPENAI_API_KEY=local \
   litellm --model openai/gpt-5.6 \
     --api_base http://127.0.0.1:11436/v1 \
     --port 4011 \
     --telemetry False
   ```

2. Send an Anthropic Messages request with thinking enabled

   ```shell
   curl http://127.0.0.1:4011/v1/messages \
     -H 'Content-Type: application/json' \
     -d '{
       "model": "openai/gpt-5.6",
       "max_tokens": 2048,
       "messages": [
         {"role": "user", "content": "Reply with exactly OK"}
       ],
       "thinking": {
         "type": "enabled",
         "budget_tokens": 1024
       }
     }'
   ```

3. The response comes back from the real model

   ```text
   status=200
   type=message
   model=openai/gpt-5.6
   content_types=text
   text='OK'
   ```

4. The downstream trace shows the route preference was ignored

   ```text
   POST http://127.0.0.1:11435/v1/responses
   200 OK
   ```

### After (859cde4a43)

1. Start the proxy from the PR commit

   ```shell
   LITELLM_USE_CHAT_COMPLETIONS_URL_FOR_ANTHROPIC_MESSAGES=true \
   OPENAI_API_KEY=local \
   litellm --model openai/gpt-5.6 \
     --api_base http://127.0.0.1:11436/v1 \
     --port 4012 \
     --telemetry False
   ```

2. Send the same Anthropic Messages request with thinking enabled

   ```shell
   curl http://127.0.0.1:4012/v1/messages \
     -H 'Content-Type: application/json' \
     -d '{
       "model": "openai/gpt-5.6",
       "max_tokens": 2048,
       "messages": [
         {"role": "user", "content": "Reply with exactly OK"}
       ],
       "thinking": {
         "type": "enabled",
         "budget_tokens": 1024
       }
     }'
   ```

3. The response still comes back from the real model

   ```text
   status=200
   type=message
   model=openai/gpt-5.6
   content_types=text
   text='OK'
   ```

4. The downstream trace now shows the configured route

   ```text
   POST http://127.0.0.1:11435/v1/chat/completions
   200 OK
   ```

## Type

Bug Fix

## Caveats (if any)

## Final Attestation

- [x] The tests check the right behavior for the affected route preference
