### PR TITLE
fix(responses): preserve detailed token usage for websocket responses

### DIFF
--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -1969,6 +1969,11 @@ class Logging(LiteLLMLoggingBaseClass):
                 results=result,
             )
 
+        elif self.call_type == CallTypes.aresponses_websocket.value and isinstance(result, list):
+            from litellm.responses.utils import ResponseAPILoggingUtils
+
+            logging_result = ResponseAPILoggingUtils.build_response_from_websocket_events(events=result) or result
+
         elif (
             self.call_type == CallTypes.llm_passthrough_route.value
             or self.call_type == CallTypes.allm_passthrough_route.value

--- a/litellm/responses/utils.py
+++ b/litellm/responses/utils.py
@@ -1183,11 +1183,15 @@ class ResponseAPILoggingUtils:
 
         from litellm.cost_calculator import BaseTokenUsageProcessor
 
-        usage_objects: Final = [
-            ResponseAPILoggingUtils._transform_response_api_usage_to_chat_usage(cast(Mapping[str, object], usage))
+        usage_objects: Final = tuple(
+            ResponseAPILoggingUtils._transform_response_api_usage_to_chat_usage(
+                usage if isinstance(usage, (dict, ResponseAPIUsage)) else None
+            )
             for usage in raw_usages
-        ]
-        combined: Final = BaseTokenUsageProcessor.combine_usage_objects(usage_objects)
+        )
+        combined: Final = BaseTokenUsageProcessor.combine_usage_objects(
+            list(usage_objects)  # mutable-ok: combine_usage_objects expects list
+        )
 
         input_tokens_details: Final = (
             InputTokensDetails(
@@ -1226,11 +1230,11 @@ class ResponseAPILoggingUtils:
         the HTTP /v1/responses path.
         """
         terminal_responses: Final = tuple(
-            cast(Mapping[str, object], event["response"])
+            resp
             for event in events
             if isinstance(event, dict)
             and event.get("type") in ("response.completed", "response.incomplete")
-            and isinstance(event.get("response"), dict)
+            and isinstance((resp := event.get("response")), dict)
         )
         if not terminal_responses:
             return None
@@ -1240,13 +1244,24 @@ class ResponseAPILoggingUtils:
         )
         last_response: Final = terminal_responses[-1]
         response_dict: Final = (
-            {"id": "", "created_at": 0, "output": [], **last_response, "usage": combined_usage}
+            {  # mutable-ok: dict payload for model_validate
+                "id": "",
+                "created_at": 0,
+                "output": (),
+                **last_response,
+                "usage": combined_usage,
+            }
             if combined_usage is not None
-            else {"id": "", "created_at": 0, "output": [], **last_response}
+            else {  # mutable-ok: dict payload for model_validate
+                "id": "",
+                "created_at": 0,
+                "output": (),
+                **last_response,
+            }
         )
 
         try:
-            return ResponsesAPIResponse(**response_dict)
+            return ResponsesAPIResponse.model_validate(response_dict)
         except ValidationError as e:
             verbose_logger.debug("could not build ResponsesAPIResponse from websocket events: %s", e)
             return None

--- a/litellm/responses/utils.py
+++ b/litellm/responses/utils.py
@@ -3,7 +3,7 @@ import re
 from collections.abc import Iterable, Mapping, Sequence
 from typing import Any, Final, Optional, Union, cast, get_type_hints, overload
 
-from pydantic import BaseModel
+from pydantic import BaseModel, ValidationError
 from typing_extensions import TypeIs  # noqa: TID251  # narrows untyped wire payloads without a runtime conversion
 
 import litellm
@@ -11,6 +11,7 @@ from litellm._logging import verbose_logger
 from litellm.llms.base_llm.responses.transformation import BaseResponsesAPIConfig
 from litellm.types.llms.openai import (
     AllMessageValues,
+    InputTokensDetails,
     OutputTokensDetails,
     ResponseAPIUsage,
     ResponseInputParam,
@@ -1169,3 +1170,71 @@ class ResponseAPILoggingUtils:
             setattr(chat_usage, "cost", response_api_usage.cost)
 
         return chat_usage
+
+    @staticmethod
+    def build_response_from_websocket_events(
+        events: Iterable[Any],
+    ) -> ResponsesAPIResponse | None:
+        """
+        Build a single ResponsesAPIResponse from the events collected on a
+        Responses API WebSocket connection so token usage (including details
+        like cached and reasoning tokens) and cost are logged the same way as
+        the HTTP /v1/responses path.
+        """
+        terminal_responses = tuple(
+            event["response"]
+            for event in events
+            if isinstance(event, dict)
+            and event.get("type") in ("response.completed", "response.incomplete")
+            and isinstance(event.get("response"), dict)
+        )
+        if not terminal_responses:
+            return None
+
+        usage_objects: Final[list[Usage]] = [
+            ResponseAPILoggingUtils._transform_response_api_usage_to_chat_usage(r["usage"])
+            for r in terminal_responses
+            if isinstance(r.get("usage"), (dict, ResponseAPIUsage))
+        ]
+
+        combined_usage: ResponseAPIUsage | None = None
+        if usage_objects:
+            from litellm.cost_calculator import BaseTokenUsageProcessor
+
+            combined: Final = BaseTokenUsageProcessor.combine_usage_objects(usage_objects)
+            input_tokens_details: InputTokensDetails | None = None
+            if combined.prompt_tokens_details:
+                input_tokens_details = InputTokensDetails(
+                    cached_tokens=combined.prompt_tokens_details.cached_tokens or 0,
+                    audio_tokens=combined.prompt_tokens_details.audio_tokens,
+                    text_tokens=combined.prompt_tokens_details.text_tokens,
+                )
+            output_tokens_details: OutputTokensDetails | None = None
+            if combined.completion_tokens_details:
+                output_tokens_details = OutputTokensDetails(
+                    reasoning_tokens=combined.completion_tokens_details.reasoning_tokens,
+                    audio_tokens=combined.completion_tokens_details.audio_tokens,
+                    text_tokens=combined.completion_tokens_details.text_tokens,
+                )
+            combined_usage = ResponseAPIUsage(
+                input_tokens=combined.prompt_tokens,
+                output_tokens=combined.completion_tokens,
+                total_tokens=combined.total_tokens,
+                input_tokens_details=input_tokens_details,
+                output_tokens_details=output_tokens_details,
+            )
+
+        response_dict = {
+            "id": "",
+            "created_at": 0,
+            "output": [],
+            **terminal_responses[-1],
+        }
+        if combined_usage is not None:
+            response_dict["usage"] = combined_usage
+
+        try:
+            return ResponsesAPIResponse(**response_dict)
+        except ValidationError as e:
+            verbose_logger.debug("could not build ResponsesAPIResponse from websocket events: %s", e)
+            return None

--- a/litellm/responses/utils.py
+++ b/litellm/responses/utils.py
@@ -1172,8 +1172,54 @@ class ResponseAPILoggingUtils:
         return chat_usage
 
     @staticmethod
+    def _extract_combined_usage_from_terminal_responses(
+        terminal_responses: Sequence[Mapping[str, object]],
+    ) -> ResponseAPIUsage | None:
+        raw_usages: Final = tuple(
+            r["usage"]
+            for r in terminal_responses
+            if isinstance(r.get("usage"), (dict, ResponseAPIUsage))
+        )
+        if not raw_usages:
+            return None
+
+        from litellm.cost_calculator import BaseTokenUsageProcessor
+
+        usage_objects: Final = [
+            ResponseAPILoggingUtils._transform_response_api_usage_to_chat_usage(cast(Mapping[str, object], usage))
+            for usage in raw_usages
+        ]
+        combined: Final = BaseTokenUsageProcessor.combine_usage_objects(usage_objects)
+
+        input_tokens_details: Final = (
+            InputTokensDetails(
+                cached_tokens=combined.prompt_tokens_details.cached_tokens or 0,
+                audio_tokens=combined.prompt_tokens_details.audio_tokens,
+                text_tokens=combined.prompt_tokens_details.text_tokens,
+            )
+            if combined.prompt_tokens_details
+            else None
+        )
+        output_tokens_details: Final = (
+            OutputTokensDetails(
+                reasoning_tokens=combined.completion_tokens_details.reasoning_tokens,
+                audio_tokens=combined.completion_tokens_details.audio_tokens,
+                text_tokens=combined.completion_tokens_details.text_tokens,
+            )
+            if combined.completion_tokens_details
+            else None
+        )
+        return ResponseAPIUsage(
+            input_tokens=combined.prompt_tokens,
+            output_tokens=combined.completion_tokens,
+            total_tokens=combined.total_tokens,
+            input_tokens_details=input_tokens_details,
+            output_tokens_details=output_tokens_details,
+        )
+
+    @staticmethod
     def build_response_from_websocket_events(
-        events: Iterable[Any],
+        events: Iterable[Mapping[str, object]],
     ) -> ResponsesAPIResponse | None:
         """
         Build a single ResponsesAPIResponse from the events collected on a
@@ -1181,8 +1227,8 @@ class ResponseAPILoggingUtils:
         like cached and reasoning tokens) and cost are logged the same way as
         the HTTP /v1/responses path.
         """
-        terminal_responses = tuple(
-            event["response"]
+        terminal_responses: Final = tuple(
+            cast(Mapping[str, object], event["response"])
             for event in events
             if isinstance(event, dict)
             and event.get("type") in ("response.completed", "response.incomplete")
@@ -1191,47 +1237,15 @@ class ResponseAPILoggingUtils:
         if not terminal_responses:
             return None
 
-        usage_objects: Final[list[Usage]] = [
-            ResponseAPILoggingUtils._transform_response_api_usage_to_chat_usage(r["usage"])
-            for r in terminal_responses
-            if isinstance(r.get("usage"), (dict, ResponseAPIUsage))
-        ]
-
-        combined_usage: ResponseAPIUsage | None = None
-        if usage_objects:
-            from litellm.cost_calculator import BaseTokenUsageProcessor
-
-            combined: Final = BaseTokenUsageProcessor.combine_usage_objects(usage_objects)
-            input_tokens_details: InputTokensDetails | None = None
-            if combined.prompt_tokens_details:
-                input_tokens_details = InputTokensDetails(
-                    cached_tokens=combined.prompt_tokens_details.cached_tokens or 0,
-                    audio_tokens=combined.prompt_tokens_details.audio_tokens,
-                    text_tokens=combined.prompt_tokens_details.text_tokens,
-                )
-            output_tokens_details: OutputTokensDetails | None = None
-            if combined.completion_tokens_details:
-                output_tokens_details = OutputTokensDetails(
-                    reasoning_tokens=combined.completion_tokens_details.reasoning_tokens,
-                    audio_tokens=combined.completion_tokens_details.audio_tokens,
-                    text_tokens=combined.completion_tokens_details.text_tokens,
-                )
-            combined_usage = ResponseAPIUsage(
-                input_tokens=combined.prompt_tokens,
-                output_tokens=combined.completion_tokens,
-                total_tokens=combined.total_tokens,
-                input_tokens_details=input_tokens_details,
-                output_tokens_details=output_tokens_details,
-            )
-
-        response_dict = {
-            "id": "",
-            "created_at": 0,
-            "output": [],
-            **terminal_responses[-1],
-        }
-        if combined_usage is not None:
-            response_dict["usage"] = combined_usage
+        combined_usage: Final = ResponseAPILoggingUtils._extract_combined_usage_from_terminal_responses(
+            terminal_responses
+        )
+        last_response: Final = terminal_responses[-1]
+        response_dict: Final = (
+            {"id": "", "created_at": 0, "output": [], **last_response, "usage": combined_usage}
+            if combined_usage is not None
+            else {"id": "", "created_at": 0, "output": [], **last_response}
+        )
 
         try:
             return ResponsesAPIResponse(**response_dict)

--- a/litellm/responses/utils.py
+++ b/litellm/responses/utils.py
@@ -1176,9 +1176,7 @@ class ResponseAPILoggingUtils:
         terminal_responses: Sequence[Mapping[str, object]],
     ) -> ResponseAPIUsage | None:
         raw_usages: Final = tuple(
-            r["usage"]
-            for r in terminal_responses
-            if isinstance(r.get("usage"), (dict, ResponseAPIUsage))
+            r["usage"] for r in terminal_responses if isinstance(r.get("usage"), (dict, ResponseAPIUsage))
         )
         if not raw_usages:
             return None

--- a/tests/test_litellm/responses/test_responses_websocket_all_providers.py
+++ b/tests/test_litellm/responses/test_responses_websocket_all_providers.py
@@ -2619,3 +2619,174 @@ class TestNativeWebSocketUrlConstruction:
         mock_config.get_websocket_url.assert_called_once()
         _, call_kwargs = mock_config.get_websocket_url.call_args
         assert call_kwargs["litellm_params"]["api_version"] == "2025-04-01-preview"
+
+
+class TestResponsesWebSocketUsageLogging:
+    def _build_logging_obj(self):
+        import time
+
+        from litellm.litellm_core_utils.litellm_logging import (
+            Logging as LitellmLogging,
+        )
+
+        logging_obj = LitellmLogging(
+            model="gpt-4o",
+            messages=[{"role": "user", "content": "Reply with one word: ok"}],
+            stream=False,
+            call_type="_aresponses_websocket",
+            start_time=time.time(),
+            litellm_call_id="test-call-id",
+            function_id="fn",
+        )
+        logging_obj.update_environment_variables(
+            model="gpt-4o",
+            optional_params={},
+            litellm_params={"metadata": {}},
+            custom_llm_provider="openai",
+        )
+        return logging_obj
+
+    @pytest.mark.asyncio
+    async def test_websocket_completed_event_usage_is_logged(self):
+        from unittest.mock import AsyncMock
+
+        import websockets.exceptions
+
+        from litellm.responses.streaming_iterator import ResponsesWebSocketStreaming
+
+        class FakeBackendWS:
+            def __init__(self, events):
+                self._events = list(events)
+
+            async def recv(self, decode=False):
+                if self._events:
+                    return self._events.pop(0)
+                raise websockets.exceptions.ConnectionClosed(None, None)
+
+        completed_event = json.dumps(
+            {
+                "type": "response.completed",
+                "response": {
+                    "id": "resp_abc",
+                    "object": "response",
+                    "created_at": 1234567890,
+                    "model": "gpt-4o",
+                    "status": "completed",
+                    "output": [
+                        {
+                            "type": "message",
+                            "role": "assistant",
+                            "content": [{"type": "output_text", "text": "ok"}],
+                        }
+                    ],
+                    "usage": {
+                        "input_tokens": 100,
+                        "output_tokens": 50,
+                        "total_tokens": 150,
+                        "input_tokens_details": {
+                            "cached_tokens": 80,
+                            "text_tokens": 20,
+                        },
+                        "output_tokens_details": {
+                            "reasoning_tokens": 10,
+                        },
+                    },
+                },
+            }
+        )
+
+        client_ws = MagicMock()
+        client_ws.send_text = AsyncMock()
+        logging_obj = self._build_logging_obj()
+
+        handler = ResponsesWebSocketStreaming(
+            websocket=client_ws,
+            backend_ws=FakeBackendWS([completed_event]),
+            logging_obj=logging_obj,
+        )
+
+        await handler.backend_to_client()
+
+        assert any(event.get("type") == "response.completed" for event in handler.messages)
+
+        logging_obj._success_handler_helper_fn(
+            result=handler.messages,
+            cache_hit=False,
+            standard_logging_object=None,
+        )
+
+        slo = logging_obj.model_call_details["standard_logging_object"]
+        assert slo["prompt_tokens"] == 100
+        assert slo["completion_tokens"] == 50
+        assert slo["total_tokens"] == 150
+        assert slo["response_cost"] > 0
+        usage_obj = slo["metadata"]["usage_object"]
+        assert usage_obj["prompt_tokens_details"]["cached_tokens"] == 80
+        assert usage_obj["completion_tokens_details"]["reasoning_tokens"] == 10
+
+    def test_build_response_from_websocket_events_combines_usage_with_details(self):
+        from litellm.responses.utils import ResponseAPILoggingUtils
+
+        events = [
+            {"type": "response.created", "response": {"id": "r1"}},
+            {
+                "type": "response.completed",
+                "response": {
+                    "id": "r1",
+                    "created_at": 1,
+                    "output": [],
+                    "usage": {
+                        "input_tokens": 100,
+                        "output_tokens": 50,
+                        "total_tokens": 150,
+                        "input_tokens_details": {
+                            "cached_tokens": 80,
+                            "text_tokens": 20,
+                        },
+                        "output_tokens_details": {
+                            "reasoning_tokens": 10,
+                        },
+                    },
+                },
+            },
+            {
+                "type": "response.completed",
+                "response": {
+                    "id": "r2",
+                    "created_at": 2,
+                    "output": [],
+                    "usage": {
+                        "input_tokens": 40,
+                        "output_tokens": 10,
+                        "total_tokens": 50,
+                        "input_tokens_details": {
+                            "cached_tokens": 20,
+                        },
+                        "output_tokens_details": {
+                            "reasoning_tokens": 5,
+                        },
+                    },
+                },
+            },
+        ]
+
+        response = ResponseAPILoggingUtils.build_response_from_websocket_events(events=events)
+
+        assert response is not None
+        assert response.id == "r2"
+        assert response.usage.input_tokens == 140
+        assert response.usage.output_tokens == 60
+        assert response.usage.total_tokens == 200
+        assert response.usage.input_tokens_details.cached_tokens == 100
+        assert response.usage.input_tokens_details.text_tokens == 20
+        assert response.usage.output_tokens_details.reasoning_tokens == 15
+
+    def test_build_response_from_websocket_events_without_completed_returns_none(self):
+        from litellm.responses.utils import ResponseAPILoggingUtils
+
+        events = [
+            {"type": "response.created", "response": {"id": "r1"}},
+            {"type": "response.output_text.delta", "delta": "hi"},
+        ]
+
+        assert ResponseAPILoggingUtils.build_response_from_websocket_events(events=events) is None

--- a/tests/test_litellm/responses/test_responses_websocket_all_providers.py
+++ b/tests/test_litellm/responses/test_responses_websocket_all_providers.py
@@ -44,16 +44,12 @@ class TestResponsesAPIWebSocketSupport:
     def test_openai_supports_native_websocket(self):
         """OpenAI should support native websocket"""
         config = OpenAIResponsesAPIConfig()
-        assert (
-            config.supports_native_websocket() is True
-        ), "OpenAI should support native websocket"
+        assert config.supports_native_websocket() is True, "OpenAI should support native websocket"
 
     def test_azure_supports_native_websocket(self):
         """Azure should support native websocket"""
         config = AzureOpenAIResponsesAPIConfig()
-        assert (
-            config.supports_native_websocket() is True
-        ), "Azure should support native websocket"
+        assert config.supports_native_websocket() is True, "Azure should support native websocket"
 
     def test_azure_websocket_url_uses_v1_path(self):
         """Azure WebSocket URL must use /openai/v1/responses (no api-version)"""
@@ -84,7 +80,7 @@ class TestResponsesAPIWebSocketSupport:
 
     def test_azure_websocket_url_requires_api_base(self):
         config = AzureOpenAIResponsesAPIConfig()
-        with pytest.raises(ValueError, match='api_base is required for Azure WebSocket'):
+        with pytest.raises(ValueError, match="api_base is required for Azure WebSocket"):
             config.get_websocket_url(api_base=None, litellm_params={})
 
     def test_azure_model_not_in_websocket_url(self):
@@ -94,9 +90,7 @@ class TestResponsesAPIWebSocketSupport:
     def test_openai_default_websocket_url_converts_scheme(self):
         """The base get_websocket_url default converts the HTTP endpoint to wss://"""
         config = OpenAIResponsesAPIConfig()
-        url = config.get_websocket_url(
-            api_base="https://api.openai.com/v1", litellm_params={}
-        )
+        url = config.get_websocket_url(api_base="https://api.openai.com/v1", litellm_params={})
         assert url == "wss://api.openai.com/v1/responses"
 
     def test_openai_model_in_websocket_url_default(self):
@@ -105,72 +99,52 @@ class TestResponsesAPIWebSocketSupport:
     def test_xai_uses_managed_websocket(self):
         """XAI should use managed websocket handler"""
         config = XAIResponsesAPIConfig()
-        assert (
-            config.supports_native_websocket() is False
-        ), "XAI should use managed websocket handler"
+        assert config.supports_native_websocket() is False, "XAI should use managed websocket handler"
 
     def test_github_copilot_uses_managed_websocket(self):
         """GitHub Copilot should use managed websocket handler"""
         config = GithubCopilotResponsesAPIConfig()
-        assert (
-            config.supports_native_websocket() is False
-        ), "GitHub Copilot should use managed websocket handler"
+        assert config.supports_native_websocket() is False, "GitHub Copilot should use managed websocket handler"
 
     def test_chatgpt_uses_managed_websocket(self):
         """ChatGPT should use managed websocket handler"""
         config = ChatGPTResponsesAPIConfig()
-        assert (
-            config.supports_native_websocket() is False
-        ), "ChatGPT should use managed websocket handler"
+        assert config.supports_native_websocket() is False, "ChatGPT should use managed websocket handler"
 
     def test_litellm_proxy_uses_managed_websocket(self):
         """LiteLLM Proxy should use managed websocket handler"""
         config = LiteLLMProxyResponsesAPIConfig()
-        assert (
-            config.supports_native_websocket() is False
-        ), "LiteLLM Proxy should use managed websocket handler"
+        assert config.supports_native_websocket() is False, "LiteLLM Proxy should use managed websocket handler"
 
     def test_volcengine_uses_managed_websocket(self):
         """VolcEngine should use managed websocket handler"""
         config = VolcEngineResponsesAPIConfig()
-        assert (
-            config.supports_native_websocket() is False
-        ), "VolcEngine should use managed websocket handler"
+        assert config.supports_native_websocket() is False, "VolcEngine should use managed websocket handler"
 
     def test_manus_uses_managed_websocket(self):
         """Manus should use managed websocket handler"""
         config = ManusResponsesAPIConfig()
-        assert (
-            config.supports_native_websocket() is False
-        ), "Manus should use managed websocket handler"
+        assert config.supports_native_websocket() is False, "Manus should use managed websocket handler"
 
     def test_perplexity_uses_managed_websocket(self):
         """Perplexity should use managed websocket handler"""
         config = PerplexityResponsesConfig()
-        assert (
-            config.supports_native_websocket() is False
-        ), "Perplexity should use managed websocket handler"
+        assert config.supports_native_websocket() is False, "Perplexity should use managed websocket handler"
 
     def test_databricks_uses_managed_websocket(self):
         """Databricks should use managed websocket handler"""
         config = DatabricksResponsesAPIConfig()
-        assert (
-            config.supports_native_websocket() is False
-        ), "Databricks should use managed websocket handler"
+        assert config.supports_native_websocket() is False, "Databricks should use managed websocket handler"
 
     def test_openrouter_uses_managed_websocket(self):
         """OpenRouter should use managed websocket handler"""
         config = OpenRouterResponsesAPIConfig()
-        assert (
-            config.supports_native_websocket() is False
-        ), "OpenRouter should use managed websocket handler"
+        assert config.supports_native_websocket() is False, "OpenRouter should use managed websocket handler"
 
     def test_hosted_vllm_uses_managed_websocket(self):
         """Hosted vLLM should use managed websocket handler"""
         config = HostedVLLMResponsesAPIConfig()
-        assert (
-            config.supports_native_websocket() is False
-        ), "Hosted vLLM should use managed websocket handler"
+        assert config.supports_native_websocket() is False, "Hosted vLLM should use managed websocket handler"
 
 
 class TestManagedWebSocketHandlerIntegration:
@@ -275,9 +249,7 @@ class TestManagedWebSocketHandlerIntegration:
         assert captured["model"] == "bedrock_mantle/openai.gpt-5.5"
 
     @pytest.mark.asyncio
-    async def test_warmup_frame_skips_provider_and_sends_synthetic_ack(
-        self, monkeypatch
-    ):
+    async def test_warmup_frame_skips_provider_and_sends_synthetic_ack(self, monkeypatch):
         """
         A generate=false warmup frame (codex prewarm) carries empty input that
         managed HTTP providers reject. It must not call the provider, and should
@@ -331,9 +303,7 @@ class TestManagedWebSocketHandlerIntegration:
 
         assert called is False
         assert mock_websocket.send_text.call_count == 2
-        events = [
-            json.loads(call.args[0]) for call in mock_websocket.send_text.call_args_list
-        ]
+        events = [json.loads(call.args[0]) for call in mock_websocket.send_text.call_args_list]
         assert events[0]["type"] == "response.created"
         assert events[0]["response"]["status"] == "in_progress"
         assert events[1]["type"] == "response.completed"
@@ -342,9 +312,7 @@ class TestManagedWebSocketHandlerIntegration:
         assert events[1]["response"]["model"] == "gpt-5.5-mantle"
 
     @pytest.mark.asyncio
-    async def test_warmup_previous_response_id_not_forwarded_to_provider(
-        self, monkeypatch
-    ):
+    async def test_warmup_previous_response_id_not_forwarded_to_provider(self, monkeypatch):
         import json
         from unittest.mock import AsyncMock, MagicMock
 
@@ -395,9 +363,7 @@ class TestManagedWebSocketHandlerIntegration:
                 }
             )
         )
-        warmup_id = json.loads(mock_websocket.send_text.call_args_list[1].args[0])[
-            "response"
-        ]["id"]
+        warmup_id = json.loads(mock_websocket.send_text.call_args_list[1].args[0])["response"]["id"]
 
         await handler._process_response_create(
             json.dumps(
@@ -471,9 +437,7 @@ class TestChunkTransformation:
             },
         }
 
-        messages = ManagedResponsesWebSocketHandler._extract_output_messages(
-            completed_event
-        )
+        messages = ManagedResponsesWebSocketHandler._extract_output_messages(completed_event)
         assert len(messages) == 1
         assert messages[0]["type"] == "message"
         assert messages[0]["role"] == "assistant"
@@ -502,9 +466,7 @@ class TestChunkTransformation:
             },
         }
 
-        messages = ManagedResponsesWebSocketHandler._extract_output_messages(
-            completed_event
-        )
+        messages = ManagedResponsesWebSocketHandler._extract_output_messages(completed_event)
         assert len(messages) == 1
         assert messages[0]["content"][0]["text"] == "Part 1. Part 2."
 
@@ -529,9 +491,7 @@ class TestChunkTransformation:
             },
         }
 
-        messages = ManagedResponsesWebSocketHandler._extract_output_messages(
-            completed_event
-        )
+        messages = ManagedResponsesWebSocketHandler._extract_output_messages(completed_event)
         assert len(messages) == 1
         assert messages[0]["type"] == "function_call"
         assert messages[0]["id"] == "call_123"
@@ -562,9 +522,7 @@ class TestChunkTransformation:
             },
         }
 
-        messages = ManagedResponsesWebSocketHandler._extract_output_messages(
-            completed_event
-        )
+        messages = ManagedResponsesWebSocketHandler._extract_output_messages(completed_event)
         assert len(messages) == 1
         assert messages[0]["content"][0]["text"] == "Valid text"
 
@@ -591,9 +549,7 @@ class TestChunkTransformation:
             },
         }
 
-        messages = ManagedResponsesWebSocketHandler._extract_output_messages(
-            completed_event
-        )
+        messages = ManagedResponsesWebSocketHandler._extract_output_messages(completed_event)
         assert len(messages) == 1
         assert messages[0]["content"][0]["text"] == "Valid"
 
@@ -897,9 +853,7 @@ class TestMultiTurnSessionHistory:
             },
         }
 
-        messages = ManagedResponsesWebSocketHandler._extract_output_messages(
-            completed_event
-        )
+        messages = ManagedResponsesWebSocketHandler._extract_output_messages(completed_event)
         assert len(messages) == 3
         assert messages[0]["content"][0]["text"] == "First message"
         assert messages[1]["type"] == "function_call"
@@ -951,9 +905,7 @@ class TestMultiTurnSessionHistory:
             },
         }
 
-        messages = ManagedResponsesWebSocketHandler._extract_output_messages(
-            completed_event
-        )
+        messages = ManagedResponsesWebSocketHandler._extract_output_messages(completed_event)
         assert len(messages) == 1
         assert messages[0]["content"][0]["text"] == "Part 1Part 2"
 
@@ -968,9 +920,7 @@ class TestMultiTurnSessionHistory:
             "response": {"id": "resp_abc123", "status": "completed"},
         }
 
-        response_id = ManagedResponsesWebSocketHandler._extract_response_id(
-            completed_event
-        )
+        response_id = ManagedResponsesWebSocketHandler._extract_response_id(completed_event)
         assert response_id == "resp_abc123"
 
     def test_extract_response_id_handles_missing_response(self):
@@ -981,9 +931,7 @@ class TestMultiTurnSessionHistory:
 
         completed_event = {"type": "response.completed"}
 
-        response_id = ManagedResponsesWebSocketHandler._extract_response_id(
-            completed_event
-        )
+        response_id = ManagedResponsesWebSocketHandler._extract_response_id(completed_event)
         assert response_id is None
 
 
@@ -1161,9 +1109,7 @@ class TestWebSocketProjectQuotaEnforcement:
             quota_callbacks=[quota_callback],
         )
 
-        allowed = await handler._enforce_or_reject_frame(
-            json.dumps({"type": "response.create", "input": "hi"})
-        )
+        allowed = await handler._enforce_or_reject_frame(json.dumps({"type": "response.create", "input": "hi"}))
 
         assert allowed is False
         mock_backend_ws.send.assert_not_called()
@@ -1187,9 +1133,7 @@ class TestWebSocketProjectQuotaEnforcement:
             quota_callbacks=[quota_callback],
         )
 
-        allowed = await handler._enforce_or_reject_frame(
-            json.dumps({"type": "response.create", "input": "hi"})
-        )
+        allowed = await handler._enforce_or_reject_frame(json.dumps({"type": "response.create", "input": "hi"}))
 
         assert allowed is True
         quota_callback.enforce_project_io_token_quota_for_frame.assert_awaited_once()
@@ -1210,17 +1154,13 @@ class TestNativeWebSocketGuardrails:
             authorized_model="authorized-deployment",
         )
 
-        flat_message = await handler._mask_response_create(
-            json.dumps({"type": "response.create", "input": "hi"})
-        )
+        flat_message = await handler._mask_response_create(json.dumps({"type": "response.create", "input": "hi"}))
         nested_message = await handler._mask_response_create(
             json.dumps({"type": "response.create", "response": {"input": "hi"}})
         )
 
         assert json.loads(flat_message)["model"] == "authorized-deployment"
-        assert (
-            json.loads(nested_message)["response"]["model"] == "authorized-deployment"
-        )
+        assert json.loads(nested_message)["response"]["model"] == "authorized-deployment"
 
     @pytest.mark.asyncio
     async def test_completed_event_with_null_response_passes_through(self):
@@ -1268,9 +1208,7 @@ class TestNativeWebSocketGuardrails:
             def _unmask_pii_text(self, text, pii_tokens):
                 return text
 
-            async def check_pii(
-                self, text, output_parse_pii, presidio_config, request_data
-            ):
+            async def check_pii(self, text, output_parse_pii, presidio_config, request_data):
                 self.check_pii_calls.append(text)
                 return text
 
@@ -1289,21 +1227,11 @@ class TestNativeWebSocketGuardrails:
         logging_obj = MagicMock()
         logging_obj.dispatch_success_handlers = AsyncMock()
 
-        delta_event = json.dumps(
-            {"type": "response.output_text.delta", "delta": "alice@example.com"}
-        )
+        delta_event = json.dumps({"type": "response.output_text.delta", "delta": "alice@example.com"})
         completed_event = json.dumps(
             {
                 "type": "response.completed",
-                "response": {
-                    "output": [
-                        {
-                            "content": [
-                                {"type": "output_text", "text": "alice@example.com"}
-                            ]
-                        }
-                    ]
-                },
+                "response": {"output": [{"content": [{"type": "output_text", "text": "alice@example.com"}]}]},
             }
         )
 
@@ -1342,9 +1270,7 @@ class TestNativeWebSocketGuardrails:
             def _unmask_pii_text(self, text, pii_tokens):
                 return text
 
-            async def check_pii(
-                self, text, output_parse_pii, presidio_config, request_data
-            ):
+            async def check_pii(self, text, output_parse_pii, presidio_config, request_data):
                 self.check_pii_calls.append(text)
                 return text.replace("alice@example.com", "<EMAIL_ADDRESS>")
 
@@ -1364,9 +1290,7 @@ class TestNativeWebSocketGuardrails:
         logging_obj.dispatch_success_handlers = AsyncMock()
 
         done_events = [
-            json.dumps(
-                {"type": "response.output_text.done", "text": "alice@example.com"}
-            ),
+            json.dumps({"type": "response.output_text.done", "text": "alice@example.com"}),
             json.dumps(
                 {
                     "type": "response.content_part.done",
@@ -1378,9 +1302,7 @@ class TestNativeWebSocketGuardrails:
                     "type": "response.output_item.done",
                     "item": {
                         "type": "message",
-                        "content": [
-                            {"type": "output_text", "text": "alice@example.com"}
-                        ],
+                        "content": [{"type": "output_text", "text": "alice@example.com"}],
                     },
                 }
             ),
@@ -1388,15 +1310,7 @@ class TestNativeWebSocketGuardrails:
         completed_event = json.dumps(
             {
                 "type": "response.completed",
-                "response": {
-                    "output": [
-                        {
-                            "content": [
-                                {"type": "output_text", "text": "alice@example.com"}
-                            ]
-                        }
-                    ]
-                },
+                "response": {"output": [{"content": [{"type": "output_text", "text": "alice@example.com"}]}]},
             }
         )
 
@@ -1479,17 +1393,13 @@ class TestNativeWebSocketGuardrailMasking:
         )
 
         masked = await handler._mask_response_create(
-            json.dumps(
-                {"type": "response.create", "input": "email alice@example.com now"}
-            )
+            json.dumps({"type": "response.create", "input": "email alice@example.com now"})
         )
         obj = json.loads(masked)
 
         assert obj["model"] == "auth-model"
         assert obj["input"] == "email <EMAIL_ADDRESS_1> now"
-        assert handler.request_data["metadata"]["pii_tokens"] == {
-            "<EMAIL_ADDRESS_1>": "alice@example.com"
-        }
+        assert handler.request_data["metadata"]["pii_tokens"] == {"<EMAIL_ADDRESS_1>": "alice@example.com"}
 
     @pytest.mark.asyncio
     async def test_mask_response_create_list_content_string(self):
@@ -1564,9 +1474,7 @@ class TestNativeWebSocketGuardrailMasking:
         obj = json.loads(masked)
 
         assert obj["input"][0]["output"] == "tool returned <EMAIL_ADDRESS_1>"
-        assert handler.request_data["metadata"]["pii_tokens"] == {
-            "<EMAIL_ADDRESS_1>": "alice@example.com"
-        }
+        assert handler.request_data["metadata"]["pii_tokens"] == {"<EMAIL_ADDRESS_1>": "alice@example.com"}
 
     @pytest.mark.asyncio
     async def test_mask_response_create_function_call_output_blocks(self):
@@ -1635,9 +1543,7 @@ class TestNativeWebSocketGuardrailMasking:
         obj = json.loads(masked)
 
         assert obj["instructions"] == "reply to <EMAIL_ADDRESS_1>"
-        assert handler.request_data["metadata"]["pii_tokens"] == {
-            "<EMAIL_ADDRESS_1>": "alice@example.com"
-        }
+        assert handler.request_data["metadata"]["pii_tokens"] == {"<EMAIL_ADDRESS_1>": "alice@example.com"}
 
     @pytest.mark.asyncio
     async def test_mask_response_create_nested_instructions(self):
@@ -1658,9 +1564,7 @@ class TestNativeWebSocketGuardrailMasking:
         obj = json.loads(masked)
 
         assert obj["response"]["instructions"] == "email <EMAIL_ADDRESS_1>"
-        assert handler.request_data["metadata"]["pii_tokens"] == {
-            "<EMAIL_ADDRESS_1>": "alice@example.com"
-        }
+        assert handler.request_data["metadata"]["pii_tokens"] == {"<EMAIL_ADDRESS_1>": "alice@example.com"}
 
     @pytest.mark.asyncio
     async def test_mask_response_create_non_create_unchanged(self):
@@ -1676,9 +1580,7 @@ class TestNativeWebSocketGuardrailMasking:
 
     @pytest.mark.asyncio
     async def test_mask_response_create_invalid_json_unchanged(self):
-        handler = _make_streaming(
-            request_data={}, guardrail_callbacks=[_FakeWSGuardrail()]
-        )
+        handler = _make_streaming(request_data={}, guardrail_callbacks=[_FakeWSGuardrail()])
         assert await handler._mask_response_create("not json {{{") == "not json {{{"
 
     @pytest.mark.asyncio
@@ -1738,60 +1640,39 @@ class TestNativeWebSocketGuardrailMasking:
     async def test_unmask_response_event_completed(self):
         guardrail = _FakeWSGuardrail()
         handler = _make_streaming(
-            request_data={
-                "metadata": {"pii_tokens": {"<EMAIL_ADDRESS_1>": "alice@example.com"}}
-            },
+            request_data={"metadata": {"pii_tokens": {"<EMAIL_ADDRESS_1>": "alice@example.com"}}},
             guardrail_callbacks=[guardrail],
         )
 
         event = json.dumps(
             {
                 "type": "response.completed",
-                "response": {
-                    "output": [
-                        {
-                            "content": [
-                                {"type": "output_text", "text": "to <EMAIL_ADDRESS_1>"}
-                            ]
-                        }
-                    ]
-                },
+                "response": {"output": [{"content": [{"type": "output_text", "text": "to <EMAIL_ADDRESS_1>"}]}]},
             }
         )
         unmasked = json.loads(handler._unmask_response_event(event))
-        assert (
-            unmasked["response"]["output"][0]["content"][0]["text"]
-            == "to alice@example.com"
-        )
+        assert unmasked["response"]["output"][0]["content"][0]["text"] == "to alice@example.com"
 
     @pytest.mark.asyncio
     async def test_unmask_response_event_delta(self):
         guardrail = _FakeWSGuardrail()
         handler = _make_streaming(
-            request_data={
-                "metadata": {"pii_tokens": {"<EMAIL_ADDRESS_1>": "alice@example.com"}}
-            },
+            request_data={"metadata": {"pii_tokens": {"<EMAIL_ADDRESS_1>": "alice@example.com"}}},
             guardrail_callbacks=[guardrail],
         )
 
-        event = json.dumps(
-            {"type": "response.output_text.delta", "delta": "<EMAIL_ADDRESS_1>"}
-        )
+        event = json.dumps({"type": "response.output_text.delta", "delta": "<EMAIL_ADDRESS_1>"})
         unmasked = json.loads(handler._unmask_response_event(event))
         assert unmasked["delta"] == "alice@example.com"
 
     def test_unmask_response_event_no_tokens_unchanged(self):
         guardrail = _FakeWSGuardrail()
         handler = _make_streaming(request_data={}, guardrail_callbacks=[guardrail])
-        event = json.dumps(
-            {"type": "response.output_text.delta", "delta": "<EMAIL_ADDRESS_1>"}
-        )
+        event = json.dumps({"type": "response.output_text.delta", "delta": "<EMAIL_ADDRESS_1>"})
         assert handler._unmask_response_event(event) == event
 
     def test_unmask_response_event_no_guardrails_unchanged(self):
-        handler = _make_streaming(
-            request_data={"metadata": {"pii_tokens": {"<EMAIL_ADDRESS_1>": "x"}}}
-        )
+        handler = _make_streaming(request_data={"metadata": {"pii_tokens": {"<EMAIL_ADDRESS_1>": "x"}}})
         event = json.dumps({"type": "response.completed", "response": {}})
         assert handler._unmask_response_event(event) == event
 
@@ -1812,9 +1693,7 @@ class TestNativeWebSocketGuardrailMasking:
 
     def test_unmask_response_event_malformed_output_items_unchanged(self):
         handler = _make_streaming(
-            request_data={
-                "metadata": {"pii_tokens": {"<EMAIL_ADDRESS_1>": "alice@example.com"}}
-            },
+            request_data={"metadata": {"pii_tokens": {"<EMAIL_ADDRESS_1>": "alice@example.com"}}},
             guardrail_callbacks=[_FakeWSGuardrail()],
         )
         event = json.dumps(
@@ -1836,17 +1715,13 @@ class TestNativeWebSocketGuardrailMasking:
             request_data={"metadata": {"pii_tokens": {"<EMAIL_ADDRESS_1>": "x"}}},
             guardrail_callbacks=[_FakeWSGuardrail()],
         )
-        event = json.dumps(
-            {"type": "response.in_progress", "delta": "<EMAIL_ADDRESS_1>"}
-        )
+        event = json.dumps({"type": "response.in_progress", "delta": "<EMAIL_ADDRESS_1>"})
         assert handler._unmask_response_event(event) == event
 
     @pytest.mark.asyncio
     async def test_mask_response_completed_event(self):
         guardrail = _FakeWSGuardrail()
-        handler = _make_streaming(
-            request_data={}, output_guardrail_callbacks=[guardrail]
-        )
+        handler = _make_streaming(request_data={}, output_guardrail_callbacks=[guardrail])
 
         event = json.dumps(
             {
@@ -1866,17 +1741,12 @@ class TestNativeWebSocketGuardrailMasking:
             }
         )
         masked = json.loads(await handler._mask_response_completed(event))
-        assert (
-            masked["response"]["output"][0]["content"][0]["text"]
-            == "contact <EMAIL_ADDRESS_1>"
-        )
+        assert masked["response"]["output"][0]["content"][0]["text"] == "contact <EMAIL_ADDRESS_1>"
 
     @pytest.mark.asyncio
     async def test_mask_response_completed_masks_function_call_arguments(self):
         guardrail = _FakeWSGuardrail()
-        handler = _make_streaming(
-            request_data={}, output_guardrail_callbacks=[guardrail]
-        )
+        handler = _make_streaming(request_data={}, output_guardrail_callbacks=[guardrail])
 
         event = json.dumps(
             {
@@ -1893,17 +1763,12 @@ class TestNativeWebSocketGuardrailMasking:
             }
         )
         masked = json.loads(await handler._mask_response_completed(event))
-        assert (
-            masked["response"]["output"][0]["arguments"]
-            == '{"to": "<EMAIL_ADDRESS_1>"}'
-        )
+        assert masked["response"]["output"][0]["arguments"] == '{"to": "<EMAIL_ADDRESS_1>"}'
 
     @pytest.mark.asyncio
     async def test_mask_response_completed_masks_reasoning_summary(self):
         guardrail = _FakeWSGuardrail()
-        handler = _make_streaming(
-            request_data={}, output_guardrail_callbacks=[guardrail]
-        )
+        handler = _make_streaming(request_data={}, output_guardrail_callbacks=[guardrail])
 
         event = json.dumps(
             {
@@ -1924,43 +1789,30 @@ class TestNativeWebSocketGuardrailMasking:
             }
         )
         masked = json.loads(await handler._mask_response_completed(event))
-        assert (
-            masked["response"]["output"][0]["summary"][0]["text"]
-            == "user is <EMAIL_ADDRESS_1>"
-        )
+        assert masked["response"]["output"][0]["summary"][0]["text"] == "user is <EMAIL_ADDRESS_1>"
 
     @pytest.mark.asyncio
     async def test_mask_response_completed_delta_unchanged(self):
         guardrail = _FakeWSGuardrail()
-        handler = _make_streaming(
-            request_data={}, output_guardrail_callbacks=[guardrail]
-        )
+        handler = _make_streaming(request_data={}, output_guardrail_callbacks=[guardrail])
 
-        event = json.dumps(
-            {"type": "response.output_text.delta", "delta": "alice@example.com"}
-        )
+        event = json.dumps({"type": "response.output_text.delta", "delta": "alice@example.com"})
         assert await handler._mask_response_completed(event) == event
 
     @pytest.mark.asyncio
     async def test_mask_response_completed_no_guardrails_unchanged(self):
         handler = _make_streaming(request_data={})
-        event = json.dumps(
-            {"type": "response.output_text.delta", "delta": "alice@example.com"}
-        )
+        event = json.dumps({"type": "response.output_text.delta", "delta": "alice@example.com"})
         assert await handler._mask_response_completed(event) == event
 
     @pytest.mark.asyncio
     async def test_mask_response_completed_invalid_json_unchanged(self):
-        handler = _make_streaming(
-            request_data={}, output_guardrail_callbacks=[_FakeWSGuardrail()]
-        )
+        handler = _make_streaming(request_data={}, output_guardrail_callbacks=[_FakeWSGuardrail()])
         assert await handler._mask_response_completed("not json {{{") == "not json {{{"
 
     @pytest.mark.asyncio
     async def test_mask_response_completed_malformed_unchanged(self):
-        handler = _make_streaming(
-            request_data={}, output_guardrail_callbacks=[_FakeWSGuardrail()]
-        )
+        handler = _make_streaming(request_data={}, output_guardrail_callbacks=[_FakeWSGuardrail()])
         event = json.dumps(
             {
                 "type": "response.completed",
@@ -1977,9 +1829,7 @@ class TestNativeWebSocketGuardrailMasking:
 
     @pytest.mark.asyncio
     async def test_mask_response_completed_non_dict_response_unchanged(self):
-        handler = _make_streaming(
-            request_data={}, output_guardrail_callbacks=[_FakeWSGuardrail()]
-        )
+        handler = _make_streaming(request_data={}, output_guardrail_callbacks=[_FakeWSGuardrail()])
         event = json.dumps({"type": "response.completed", "response": ["bad"]})
         assert await handler._mask_response_completed(event) == event
 
@@ -1993,9 +1843,7 @@ class TestNativeWebSocketGuardrailMasking:
         websocket = MagicMock()
         websocket.receive_text = AsyncMock(
             side_effect=[
-                json.dumps(
-                    {"type": "response.create", "input": "ping alice@example.com"}
-                ),
+                json.dumps({"type": "response.create", "input": "ping alice@example.com"}),
                 Exception("stop"),
             ]
         )
@@ -2004,9 +1852,7 @@ class TestNativeWebSocketGuardrailMasking:
             websocket=websocket,
             backend_ws=backend_ws,
             request_data={},
-            first_message=json.dumps(
-                {"type": "response.create", "input": "alice@example.com"}
-            ),
+            first_message=json.dumps({"type": "response.create", "input": "alice@example.com"}),
             guardrail_callbacks=[guardrail],
             authorized_model="auth-model",
         )
@@ -2020,9 +1866,7 @@ class TestNativeWebSocketGuardrailMasking:
         second_sent = json.loads(backend_ws.send.await_args_list[1][0][0])
         assert second_sent["model"] == "auth-model"
         assert second_sent["input"] == "ping <EMAIL_ADDRESS_1>"
-        assert handler.request_data["metadata"]["pii_tokens"] == {
-            "<EMAIL_ADDRESS_1>": "alice@example.com"
-        }
+        assert handler.request_data["metadata"]["pii_tokens"] == {"<EMAIL_ADDRESS_1>": "alice@example.com"}
 
     @pytest.mark.asyncio
     async def test_backend_to_client_suppresses_deltas_and_masks_completed(self):
@@ -2036,9 +1880,7 @@ class TestNativeWebSocketGuardrailMasking:
         backend_ws = MagicMock()
         backend_ws.recv = AsyncMock(
             side_effect=[
-                json.dumps(
-                    {"type": "response.output_text.delta", "delta": "alice@example.com"}
-                ),
+                json.dumps({"type": "response.output_text.delta", "delta": "alice@example.com"}),
                 json.dumps(
                     {
                         "type": "response.completed",
@@ -2075,10 +1917,7 @@ class TestNativeWebSocketGuardrailMasking:
         websocket.send_text.assert_awaited_once()
         forwarded = json.loads(websocket.send_text.await_args[0][0])
         assert forwarded["type"] == "response.completed"
-        assert (
-            forwarded["response"]["output"][0]["content"][0]["text"]
-            == "contact <EMAIL_ADDRESS_1>"
-        )
+        assert forwarded["response"]["output"][0]["content"][0]["text"] == "contact <EMAIL_ADDRESS_1>"
 
     @pytest.mark.asyncio
     async def test_backend_to_client_suppresses_function_call_arguments_done(self):
@@ -2134,10 +1973,7 @@ class TestNativeWebSocketGuardrailMasking:
         sent_payload = websocket.send_text.await_args[0][0]
         forwarded = json.loads(sent_payload)
         assert forwarded["type"] == "response.completed"
-        assert (
-            forwarded["response"]["output"][0]["arguments"]
-            == '{"to": "<EMAIL_ADDRESS_1>"}'
-        )
+        assert forwarded["response"]["output"][0]["arguments"] == '{"to": "<EMAIL_ADDRESS_1>"}'
         assert "alice@example.com" not in sent_payload
 
     @pytest.mark.asyncio
@@ -2261,10 +2097,7 @@ class TestNativeWebSocketGuardrailMasking:
         sent_payload = websocket.send_text.await_args[0][0]
         forwarded = json.loads(sent_payload)
         assert forwarded["type"] == "response.completed"
-        assert (
-            forwarded["response"]["output"][0]["summary"][0]["text"]
-            == "user is <EMAIL_ADDRESS_1>"
-        )
+        assert forwarded["response"]["output"][0]["summary"][0]["text"] == "user is <EMAIL_ADDRESS_1>"
         assert "alice@example.com" not in sent_payload
 
 
@@ -2403,9 +2236,7 @@ class TestWebSocketChunkTypes:
             },
         }
 
-        messages = ManagedResponsesWebSocketHandler._extract_output_messages(
-            completed_event
-        )
+        messages = ManagedResponsesWebSocketHandler._extract_output_messages(completed_event)
         assert len(messages) == 3
         assert messages[0]["content"][0]["text"] == "First message"
         assert messages[1]["type"] == "function_call"
@@ -2457,9 +2288,7 @@ class TestWebSocketChunkTypes:
             },
         }
 
-        messages = ManagedResponsesWebSocketHandler._extract_output_messages(
-            completed_event
-        )
+        messages = ManagedResponsesWebSocketHandler._extract_output_messages(completed_event)
         assert len(messages) == 1
         assert messages[0]["content"][0]["text"] == "Part 1Part 2"
 
@@ -2517,9 +2346,7 @@ class TestNativeWebSocketUrlConstruction:
         from urllib.parse import parse_qs, urlparse
 
         qs = parse_qs(urlparse(captured_urls[0]).query)
-        assert qs.get("model") == [
-            "gpt-4o-mini"
-        ], f"Expected model in URL, got: {captured_urls[0]}"
+        assert qs.get("model") == ["gpt-4o-mini"], f"Expected model in URL, got: {captured_urls[0]}"
 
     @pytest.mark.asyncio
     async def test_ws_url_preserves_existing_params_and_adds_model(self):
@@ -2540,9 +2367,7 @@ class TestNativeWebSocketUrlConstruction:
 
         mock_config = MagicMock(spec=OpenAIResponsesAPIConfig)
         mock_config.supports_native_websocket.return_value = True
-        mock_config.get_websocket_url.return_value = (
-            "wss://custom.example.com/v1/responses?api-version=2024-05-01"
-        )
+        mock_config.get_websocket_url.return_value = "wss://custom.example.com/v1/responses?api-version=2024-05-01"
         mock_config.validate_environment.return_value = {}
 
         mock_logging = MagicMock()
@@ -2567,12 +2392,8 @@ class TestNativeWebSocketUrlConstruction:
         from urllib.parse import parse_qs, urlparse
 
         qs = parse_qs(urlparse(captured_urls[0]).query)
-        assert qs.get("model") == [
-            "gpt-4o"
-        ], f"model missing from URL: {captured_urls[0]}"
-        assert qs.get("api-version") == [
-            "2024-05-01"
-        ], f"existing param lost: {captured_urls[0]}"
+        assert qs.get("model") == ["gpt-4o"], f"model missing from URL: {captured_urls[0]}"
+        assert qs.get("api-version") == ["2024-05-01"], f"existing param lost: {captured_urls[0]}"
 
     @pytest.mark.asyncio
     async def test_ws_passes_litellm_params_to_get_websocket_url(self):
@@ -2581,9 +2402,7 @@ class TestNativeWebSocketUrlConstruction:
 
         mock_config = MagicMock(spec=OpenAIResponsesAPIConfig)
         mock_config.supports_native_websocket.return_value = True
-        mock_config.get_websocket_url.return_value = (
-            "wss://example.openai.azure.com/openai/v1/responses"
-        )
+        mock_config.get_websocket_url.return_value = "wss://example.openai.azure.com/openai/v1/responses"
         mock_config.validate_environment.return_value = {}
 
         mock_logging = MagicMock()

--- a/tests/test_litellm/responses/test_responses_websocket_all_providers.py
+++ b/tests/test_litellm/responses/test_responses_websocket_all_providers.py
@@ -2609,3 +2609,37 @@ class TestResponsesWebSocketUsageLogging:
         ]
 
         assert ResponseAPILoggingUtils.build_response_from_websocket_events(events=events) is None
+
+    def test_build_response_from_websocket_events_without_usage(self):
+        from litellm.responses.utils import ResponseAPILoggingUtils
+
+        events = [
+            {
+                "type": "response.completed",
+                "response": {
+                    "id": "r1",
+                    "created_at": 1,
+                    "output": [],
+                },
+            },
+        ]
+
+        response = ResponseAPILoggingUtils.build_response_from_websocket_events(events=events)
+        assert response is not None
+        assert response.id == "r1"
+        assert response.usage is None
+
+    def test_build_response_from_websocket_events_invalid_response_returns_none(self):
+        from litellm.responses.utils import ResponseAPILoggingUtils
+
+        events = [
+            {
+                "type": "response.completed",
+                "response": {
+                    "id": 12345,  # id must be str, will cause validation error
+                    "output": "invalid_not_list",
+                },
+            },
+        ]
+
+        assert ResponseAPILoggingUtils.build_response_from_websocket_events(events=events) is None


### PR DESCRIPTION
## TLDR

Fixes token usage and cost tracking for Responses API WebSocket mode (`_aresponses_websocket`), ensuring `cached_tokens`, `reasoning_tokens`, and breakdown token details are preserved.

Fixes #38674

## Problem

1. When using the Responses API over WebSocket (`_aresponses_websocket`), the logging pipeline receives a raw `list` of streamed events. Because `normalize_logging_result` did not handle `CallTypes.aresponses_websocket`, the list collapsed to an empty dict `{}`, logging **0 tokens** (`prompt_tokens=0`, `completion_tokens=0`, `total_tokens=0`).
2. Simply summing `input_tokens`, `output_tokens`, `total_tokens` into a new usage dictionary drops `input_tokens_details` (`cached_tokens`, `text_tokens`, etc.) and `output_tokens_details` (`reasoning_tokens`, etc.), leading to inaccurate cached-token discounting and lost breakdown details.

## Changes

1. **`litellm/responses/utils.py`**:
   - Added `build_response_from_websocket_events` to `ResponseAPILoggingUtils`.
   - Transforms each terminal response's usage via `_transform_response_api_usage_to_chat_usage` and combines them using `BaseTokenUsageProcessor.combine_usage_objects` to retain nested token details (`cached_tokens`, `reasoning_tokens`, `audio_tokens`, `text_tokens`).
   - Builds a complete `ResponsesAPIResponse` with full `ResponseAPIUsage` including `InputTokensDetails` and `OutputTokensDetails`.
2. **`litellm/litellm_core_utils/litellm_logging.py`**:
   - Added a normalization branch for `CallTypes.aresponses_websocket` in `normalize_logging_result`.
3. **`tests/test_litellm/responses/test_responses_websocket_all_providers.py`**:
   - Added unit tests verifying token usage, cached/reasoning token breakdowns, and multiple terminal event aggregations.