### PR TITLE
fix(access groups): run key membership UPDATEs on the writer, not the read replica

### DIFF
--- a/litellm/proxy/management_helpers/access_group_key_sync.py
+++ b/litellm/proxy/management_helpers/access_group_key_sync.py
@@ -18,6 +18,13 @@ every group the request touches at once, so the size of the caller's id list doe
 into a matching number of round trips, and returns the ids it actually moved so only those
 groups are dropped from cache.
 
+Each statement is an `UPDATE ... RETURNING` run inside a transaction so it lands on the
+writer. `RoutingPrismaWrapper` routes a bare `query_raw` to the read replica, where the
+write fails with `cannot execute UPDATE in a read-only transaction`; it routes `tx()` to
+the writer, so wrapping the statement keeps the write off the read-only reader while still
+yielding its RETURNING rows. The cache is dropped only after the transaction commits, so a
+rolled-back write never evicts a still-valid entry. This mirrors `access_group_team_sync`.
+
 It deliberately lives outside `access_group_endpoints`, which is a lazily
 registered feature router (see `_lazy_features.LAZY_FEATURES`). Importing that
 module eagerly from `key_management_endpoints` would put it in `sys.modules`
@@ -45,8 +52,18 @@ class _MovedGroupRow(BaseModel):
     access_group_id: str
 
 
-class _RawExecutor(Protocol):
+class _AccessGroupSyncTx(Protocol):
     async def query_raw(self, query: str, *args: str | Sequence[str]) -> Sequence[object]: ...
+
+
+class _Transaction(Protocol):
+    async def __aenter__(self) -> _AccessGroupSyncTx: ...
+
+    async def __aexit__(self, *exc_info: object) -> None: ...
+
+
+class _PrismaDb(Protocol):
+    def tx(self) -> _Transaction: ...
 
 
 _ATTACH_KEY_SQL: Final = (
@@ -71,8 +88,8 @@ _REPOINT_KEY_SQL: Final = (
 )
 
 
-def _raw_executor(prisma_client: object) -> _RawExecutor:
-    """Narrow the untyped Prisma client down to the raw-query call this module makes."""
+def _prisma_db(prisma_client: object) -> _PrismaDb:
+    """Narrow the untyped Prisma client down to the transaction accessor this module needs."""
     return AccessGroupRepository(prisma_client).prisma_client.db  # pyright: ignore[reportAny]  # untyped Prisma client
 
 
@@ -97,13 +114,25 @@ async def _invalidate_moved_groups(moved_rows: Sequence[object]) -> None:
         await _invalidate_access_group_cache(_MovedGroupRow.model_validate(row).access_group_id)
 
 
+async def _run_membership_statement(
+    prisma_client: object, sql: str, *args: str | Sequence[str]
+) -> Sequence[object]:
+    """Run one guarded membership `UPDATE ... RETURNING` on the writer and return the rows it moved.
+
+    Wrapped in a transaction because `RoutingPrismaWrapper` routes a bare `query_raw` to the
+    read replica, where the write fails with `cannot execute UPDATE in a read-only transaction`,
+    whereas it routes `tx()` to the writer.
+    """
+    async with _prisma_db(prisma_client).tx() as tx:
+        return await tx.query_raw(sql, *args)
+
+
 async def _write_membership(prisma_client: object, sql: str, access_group_ids: frozenset[str], key_token: str) -> None:
     """Run one guarded membership statement for every listed group, dropping the cache of those it moved."""
     if not access_group_ids:
         return
-    await _invalidate_moved_groups(
-        await _raw_executor(prisma_client).query_raw(sql, key_token, sorted(access_group_ids))
-    )
+    moved: Final = await _run_membership_statement(prisma_client, sql, key_token, sorted(access_group_ids))
+    await _invalidate_moved_groups(moved)
 
 
 async def sync_key_access_group_membership(
@@ -161,9 +190,8 @@ async def sync_key_regeneration_access_group_membership(
     edited in between is neither resurrected nor skipped. Removing the new token before
     appending it keeps a re-run from duplicating it.
     """
-    await _invalidate_moved_groups(
-        await _raw_executor(prisma_client).query_raw(_REPOINT_KEY_SQL, previous_key_token, new_key_token)
-    )
+    moved: Final = await _run_membership_statement(prisma_client, _REPOINT_KEY_SQL, previous_key_token, new_key_token)
+    await _invalidate_moved_groups(moved)
     if data is not None:
         await sync_key_update_access_group_membership(
             prisma_client=prisma_client,


### PR DESCRIPTION
## TLDR

Problem this solves:

- Key regenerate fails on any proxy with `DATABASE_URL_READ_REPLICA` set
- Cause: the key access-group sync runs `UPDATE` via `query_raw`, routed to the read-only replica
- Failed regenerate rotates the token first, so keys then 404 on every op

How it solves it:

- Run each membership `UPDATE ... RETURNING` inside `db.tx()`, which routes to the writer
- Drop the access-group cache only after the transaction commits
- Mirrors the existing `access_group_team_sync` helper

## User Flow

Only manifests when the proxy runs with a read replica configured (`DATABASE_URL_READ_REPLICA`, e.g. an Aurora reader endpoint). Regenerating Virtual Keys is an Enterprise feature.

**Before:** a developer regenerates their virtual key, it errors, and from then on the key can no longer be viewed, rotated, or revoked.

1. They send `POST https://<litellm-proxy>/key/{key}/regenerate`.
2. The response is `500` with error text `cannot execute UPDATE in a read-only transaction`. No new key is returned, so they keep using the old one.
3. The old key has actually already been rotated away, so it no longer works.
4. They retry, or send `GET https://<litellm-proxy>/key/info?key={key}` or `POST https://<litellm-proxy>/key/delete` for that key — every call now returns `404` (`Key not found` / `No keys found`).
5. The key is stuck: it cannot be regenerated, inspected, or revoked through the API.

**After:** the same regenerate succeeds and the key stays manageable.

1. They send `POST https://<litellm-proxy>/key/{key}/regenerate`.
2. The response is `200` with the new key string.
3. `GET https://<litellm-proxy>/key/info?key={new_key}` and `POST https://<litellm-proxy>/key/delete` for that key work normally.

Availability consequence: before this change, any user who regenerates a key on a read-replica deployment loses the ability to manage that key at all (it is rotated but unrecoverable via the API). After, regeneration is atomic from the user's seat and the key stays manageable.

## Relevant issues

Fixes #38667

## Linear ticket

<!-- external contributor -->

## Pre-Submission checklist

- [ ] I have added meaningful tests
- [ ] The handful of test files covering my change pass locally
- [ ] My PR passes all required CI/CD checks
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile Confidence Score of at least 4/5

> Draft: opened to share the root cause and proposed fix. Still to do before review — add a regression test that asserts the key membership writes run on the writer (inside a transaction) rather than via a bare `query_raw`, and capture the live-proxy After run below on a patched image.

## Root cause (for reviewers)

`access_group_key_sync.py` issues its membership statements as `UPDATE "LiteLLM_AccessGroupTable" ... RETURNING ...` through Prisma **`query_raw`**. `litellm/proxy/db/routing_prisma_wrapper.py` classifies `query_raw` as a read (`_TOP_LEVEL_READ_METHODS` / `_MODEL_READ_METHODS`) and routes it to the reader when `DATABASE_URL_READ_REPLICA` is set. The reader is read-only, so the `UPDATE` is rejected (`SQLSTATE 25006`).

`sync_key_regeneration_access_group_membership` runs its repoint `UPDATE` unconditionally, so every regenerate hits it; create/update/delete hit it when `access_group_ids` are involved. In `_execute_virtual_key_regeneration` the new token is written to the writer **before** this call, so a failure here leaves the token rotated while the caller receives an error and keeps the old token — hence the cascade of `404`s.

The sibling `access_group_team_sync.py` already avoids this by running its statements inside `db.tx()` (routed to the writer). This PR applies the same pattern to the key side.

## Screenshots / Proof of Fix

Config the proxy ran with (secrets redacted): `DATABASE_URL` = writer, `DATABASE_URL_READ_REPLICA` = Aurora reader endpoint (read-only). Any read-only Postgres hot standby as the replica reproduces it.

### Before (`d8f71d7`, v1.98.0)

#### Regenerate a virtual key

1. `POST /key/{key}/regenerate`
2. Live proxy logs:
```json
{"message": "Error regenerating key: ERROR: cannot execute UPDATE in a read-only transaction", "level": "ERROR", "logger": "key_management_endpoints.py:5067"}
```
3. Follow-up `GET /key/info` and `POST /key/delete` on the same key:
```json
{"message": "Exception: Key not found in database", "level": "ERROR", "logger": "key_management_endpoints.py (info_key_fn)"}
{"message": "delete_verification_tokens(): Exception occured - 404: {'error': 'No keys found'}", "level": "ERROR"}
```

Control: with the read replica unset, or on v1.97.0 with the same topology, the identical request succeeds — isolating the regression to the v1.98.0 sync helper.

### After (`a308da1`)

_Pending: to be captured against a proxy image built from this branch with the read replica configured. Expected: `POST /key/{key}/regenerate` returns `200` with the new key, and subsequent `/key/info` and `/key/delete` succeed._