### PR TITLE
feat(cerebras): sync current model metadata

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -12213,6 +12213,22 @@
         "supports_response_schema": true,
         "supports_tool_choice": true
     },
+    "cerebras/gemma-4-31b": {
+        "input_cost_per_token": 9.9e-07,
+        "litellm_provider": "cerebras",
+        "max_input_tokens": 131072,
+        "max_output_tokens": 40960,
+        "max_tokens": 40960,
+        "mode": "chat",
+        "output_cost_per_token": 1.49e-06,
+        "source": "https://api.cerebras.ai/public/v1/models/gemma-4-31b",
+        "supports_function_calling": true,
+        "supports_parallel_function_calling": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true,
+        "supports_vision": true
+    },
     "cerebras/qwen-3-32b": {
         "input_cost_per_token": 4e-07,
         "litellm_provider": "cerebras",
@@ -12241,6 +12257,7 @@
         "supports_tool_choice": true
     },
     "cerebras/zai-glm-4.7": {
+        "deprecation_date": "2026-08-17",
         "input_cost_per_token": 2.25e-06,
         "litellm_provider": "cerebras",
         "max_input_tokens": 128000,

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -12213,6 +12213,22 @@
         "supports_response_schema": true,
         "supports_tool_choice": true
     },
+    "cerebras/gemma-4-31b": {
+        "input_cost_per_token": 9.9e-07,
+        "litellm_provider": "cerebras",
+        "max_input_tokens": 131072,
+        "max_output_tokens": 40960,
+        "max_tokens": 40960,
+        "mode": "chat",
+        "output_cost_per_token": 1.49e-06,
+        "source": "https://api.cerebras.ai/public/v1/models/gemma-4-31b",
+        "supports_function_calling": true,
+        "supports_parallel_function_calling": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true,
+        "supports_vision": true
+    },
     "cerebras/qwen-3-32b": {
         "input_cost_per_token": 4e-07,
         "litellm_provider": "cerebras",
@@ -12241,6 +12257,7 @@
         "supports_tool_choice": true
     },
     "cerebras/zai-glm-4.7": {
+        "deprecation_date": "2026-08-17",
         "input_cost_per_token": 2.25e-06,
         "litellm_provider": "cerebras",
         "max_input_tokens": 128000,


### PR DESCRIPTION
## Summary

- add the current `cerebras/gemma-4-31b` registry entry using the public Cerebras model endpoint
- mark the retained `cerebras/zai-glm-4.7` entry deprecated as of August 17, 2026
- keep the root and packaged registry copies synchronized

## Context

This replaces #35007. That PR was closed as absorbed by #37902, but #37902 was later declined and closed without merging, so the Cerebras metadata never reached `litellm_internal_staging`.

Closes #37184

## Validation

- queried `https://api.cerebras.ai/public/v1/models/gemma-4-31b` on August 28, 2026 and matched its pricing, limits, and capabilities exactly
- both JSON files parse successfully
- `python3 ci_cd/check_files_match.py` passes
- `tests/test_litellm/test_model_prices_schema.py`: 21 passed
- `git diff --check` passes