### PR TITLE
fix(streaming): include reasoning tokens in estimated usage

### DIFF
--- a/litellm/litellm_core_utils/streaming_chunk_builder_utils.py
+++ b/litellm/litellm_core_utils/streaming_chunk_builder_utils.py
@@ -981,14 +981,16 @@ class ChunkProcessor:
         except Exception:  # don't allow this failing to block a complete streaming response from being returned
             print_verbose("token_counter failed, assuming prompt tokens is 0")
             returned_usage.prompt_tokens = 0
-        returned_usage.completion_tokens = (
+        resolved_completion_tokens: Final = (
             completion_tokens
             or token_counter(
                 model=model,
                 text=completion_output,
                 count_response_tokens=True,  # count_response_tokens is a Flag to tell token counter this is a response, No need to add extra tokens we do for input messages
             )
+            + (reasoning_tokens or 0)
         )
+        returned_usage.completion_tokens = resolved_completion_tokens
         returned_usage.total_tokens = returned_usage.prompt_tokens + returned_usage.completion_tokens
 
         if cache_creation_input_tokens is not None:

--- a/tests/test_litellm/litellm_core_utils/test_streaming_chunk_builder_utils.py
+++ b/tests/test_litellm/litellm_core_utils/test_streaming_chunk_builder_utils.py
@@ -1391,6 +1391,43 @@ def test_count_reasoning_tokens_counts_visible_reasoning():
     assert processor.count_reasoning_tokens(response) > 0
 
 
+def test_stream_chunk_builder_includes_reasoning_in_estimated_completion_tokens():
+    reasoning_content = "let me count the primes under thirty"
+    visible_content = "10"
+    chunks = [
+        ModelResponseStream(
+            id="chatcmpl-estimated-reasoning",
+            model="claude-opus-4-8",
+            choices=[
+                StreamingChoices(
+                    finish_reason=None,
+                    index=0,
+                    delta=Delta(role="assistant", reasoning_content=reasoning_content),
+                )
+            ],
+        ),
+        ModelResponseStream(
+            id="chatcmpl-estimated-reasoning",
+            model="claude-opus-4-8",
+            choices=[
+                StreamingChoices(
+                    finish_reason="stop",
+                    index=0,
+                    delta=Delta(content=visible_content),
+                )
+            ],
+        ),
+    ]
+
+    response = stream_chunk_builder(chunks=chunks, messages=[{"role": "user", "content": "count"}])
+
+    assert response is not None
+    reasoning_tokens = response.usage.completion_tokens_details.reasoning_tokens
+    assert reasoning_tokens is not None
+    assert response.usage.completion_tokens > reasoning_tokens
+    assert response.usage.total_tokens == response.usage.prompt_tokens + response.usage.completion_tokens
+
+
 @pytest.mark.parametrize(
     "estimated_reasoning_tokens, expected_reasoning_tokens, expected_text_tokens",
     [(40, 40, 60), (250, 100, 0)],


### PR DESCRIPTION
## TLDR

Problem this solves:

- Estimated streamed usage omits reasoning tokens
- Downstream token accounting can undercount generated output

How it solves it:

- Add reasoning tokens to local completion estimates
- Keep provider-reported usage unchanged

## User Flow

Before: a developer streams a reasoning response without provider usage and sees undercounted output metrics

1. They send `POST /v1/chat/completions` with `"stream": true`, thinking enabled, and `stream_options.include_usage=false`
2. The response streams both `reasoning_content` and final `content`
3. `litellm_output_tokens_metric_total` counts only visible content
4. Reported output tokens can be lower than `litellm_output_reasoning_tokens_metric_total`

After: the same flow records reasoning and visible content in the estimated output total

1. They send the same request
2. The response streams the same fields
3. `litellm_output_tokens_metric_total` includes reasoning and visible content
4. Downstream token and cost accounting use the complete estimate

## Relevant issues

N/A

## Linear ticket

N/A

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in PR merge, ping the LiteLLM Team on Slack in `#pr-review`

## Screenshots / Proof of Fix

### Automated tests

The regression test fails against the merge base because estimated completion tokens exclude reasoning tokens

```text
completion_tokens=1
reasoning_tokens=7
```

The patched branch passes:

```text
32 passed
158 passed, 12 warnings
make lint passed
```

### Paid provider verification

Ran the merge base and patched commit through separate local LiteLLM proxies backed by a paid DeepSeek V4 Flash endpoint

Both requests used the same payload, explicitly disabled provider usage, and returned the same final answer:

```text
9.8 is greater than 9.11.
```

| Version | HTTP | Provider usage chunks | Reasoning tokens | Visible output estimate | Reported output tokens |
| --- | ---: | ---: | ---: | ---: | ---: |
| Merge base | 200 | 0 | 38 | 11 | 11 |
| Patched commit | 200 | 0 | 50 | 11 | 61 |

The merge base reports fewer output tokens than reasoning tokens, while the patched commit reports `61 = 50 reasoning + 11 visible`

## Type

🐛 Bug Fix

## Caveats (if any)

Reasoning token counts vary between model runs, so the proof checks each run's accounting invariant instead of comparing raw totals

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
