### PR TITLE
fix(bedrock): route all Cohere Embed models to BedrockCohereEmbeddingConfig

### DIFF
--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -3536,7 +3536,7 @@ def get_optional_params_embeddings(
             object = litellm.AmazonTitanMultimodalEmbeddingG1Config()
         elif "amazon.titan-embed-text-v2:0" in model:
             object = litellm.AmazonTitanV2Config()
-        elif "cohere.embed-multilingual-v3" in model or "cohere.embed-v4" in model:
+        elif "cohere.embed" in model:
             object = litellm.BedrockCohereEmbeddingConfig()
         elif "twelvelabs" in model or "marengo" in model:
             object = litellm.TwelveLabsMarengoEmbeddingConfig()

--- a/tests/test_litellm/test_utils.py
+++ b/tests/test_litellm/test_utils.py
@@ -4412,6 +4412,71 @@ class TestVertexEmbeddingEncodingFormat:
         assert optional_params.get("outputDimensionality") == 256
 
 
+class TestBedrockCohereEmbeddingParams:
+    """All Bedrock Cohere Embed models are served by the same Cohere Embed API
+    and share one transformation class, so they must all reach it. Previously
+    only multilingual-v3 and v4 were routed there, and english-v3 fell through
+    to the unmapped-model branch that supports no params at all — rejecting
+    encoding_format="float", the OpenAI SDK default. Issue #38659."""
+
+    @pytest.mark.parametrize(
+        "model",
+        [
+            "cohere.embed-english-v3",
+            "cohere.embed-multilingual-v3",
+            "cohere.embed-v4:0",
+        ],
+    )
+    def test_encoding_format_float_is_supported(self, model):
+        optional_params = litellm.utils.get_optional_params_embeddings(
+            model=model,
+            encoding_format="float",
+            custom_llm_provider="bedrock",
+        )
+        assert optional_params.get("embedding_types") == ["float"]
+
+    @pytest.mark.parametrize(
+        "model",
+        [
+            "cohere.embed-english-v3",
+            "cohere.embed-multilingual-v3",
+            "cohere.embed-v4:0",
+        ],
+    )
+    def test_dimensions_is_mapped(self, model):
+        optional_params = litellm.utils.get_optional_params_embeddings(
+            model=model,
+            dimensions=512,
+            custom_llm_provider="bedrock",
+        )
+        assert optional_params.get("output_dimension") == 512
+
+    def test_region_prefixed_model_id_is_supported(self):
+        optional_params = litellm.utils.get_optional_params_embeddings(
+            model="us.cohere.embed-english-v3",
+            encoding_format="float",
+            custom_llm_provider="bedrock",
+        )
+        assert optional_params.get("embedding_types") == ["float"]
+
+    def test_unsupported_param_still_rejected(self):
+        with pytest.raises(Exception, match="To drop these, set `litellm\\.drop_params=True` or for proxy"):
+            litellm.utils.get_optional_params_embeddings(
+                model="cohere.embed-english-v3",
+                user="some-user",
+                custom_llm_provider="bedrock",
+            )
+
+    def test_unsupported_param_dropped_with_drop_params(self):
+        optional_params = litellm.utils.get_optional_params_embeddings(
+            model="cohere.embed-english-v3",
+            user="some-user",
+            custom_llm_provider="bedrock",
+            drop_params=True,
+        )
+        assert "user" not in optional_params
+
+
 @pytest.mark.parametrize(
     "model",
     [


### PR DESCRIPTION
## TLDR

Problem this solves:

- `cohere.embed-english-v3` on Bedrock returns 400 on every embeddings call
- The OpenAI SDK always sends `encoding_format="float"`, which the model rejects
- `drop_params: true` only masks it, by discarding the parameter
- Its sibling `cohere.embed-multilingual-v3` works fine today

How it solves it:

- Route every Bedrock Cohere Embed model to the Cohere embed config
- That config already declares `encoding_format` and `dimensions` support
- Also covers `cohere.embed-v4` and region-prefixed ids

## User Flow

Before: a developer building a RAG pipeline picks `cohere.embed-english-v3` as their embedding model and cannot get a single vector back

1. They send `POST https://litellm-domain/v1/embeddings` with `{"model": "cohere.embed-english-v3", "input": "hello world"}` from the standard OpenAI Python SDK
2. The response is `400 Bad Request` reading `bedrock does not support parameters: {'encoding_format': 'float'}, for model=cohere.embed-english-v3`, even though they never set `encoding_format`
3. They add `drop_params: true` to `litellm_settings` and restart the proxy; the same request returns the same 400
4. They switch the model to `cohere.embed-multilingual-v3`, change nothing else, and it returns `200 OK` with a vector, so the failure looks specific to the English model

After: the same request returns a normal embedding vector

1. They send the same `POST https://litellm-domain/v1/embeddings` with `{"model": "cohere.embed-english-v3", "input": "hello world"}`
2. The response is `200 OK` with a `data[0].embedding` array, matching what `cohere.embed-multilingual-v3` already returns for the same input
3. `drop_params` is no longer needed for this model
4. Switching between the English and multilingual models now behaves identically

## Relevant issues

Fixes #38659

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally
- [x] My PR passes all required CI/CD checks (ruff format + ruff check verified locally on the changed files; full CI pending on this PR)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** — pending, Greptile reviews once the PR is opened

## Screenshots / Proof of Fix

Run against a live proxy (`python litellm/proxy/proxy_cli.py --config config.yaml`) with the reporter's two deployments and deliberately invalid AWS credentials, so any request that gets past parameter validation fails at Bedrock with a 403 rather than a 400. `cohere.embed-multilingual-v3` is the control — the sibling the report says already works.

```yaml
model_list:
  - model_name: cohere.embed-english-v3
    litellm_params: {model: bedrock/cohere.embed-english-v3, aws_region_name: eu-central-1}
  - model_name: cohere.embed-multilingual-v3
    litellm_params: {model: bedrock/cohere.embed-multilingual-v3, aws_region_name: eu-central-1}
litellm_settings:
  drop_params: false
```

```bash
curl -s -X POST http://localhost:4000/v1/embeddings \
  -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
  -d '{"model":"<model>","input":"hello world","encoding_format":"float"}'
```

`encoding_format` is sent explicitly because that is what the OpenAI SDK puts on every embeddings call.

### Before (5476f91b4a)

1. `cohere.embed-english-v3` — rejected before anything leaves the proxy:

```
{"error":{"message":"litellm.UnsupportedParamsError: bedrock does not support parameters:
 {'encoding_format': 'float'}, for model=cohere.embed-english-v3 ...","code":"400"}}
```

2. `cohere.embed-multilingual-v3` — same request reaches Bedrock, failing only on the fake credentials:

```
{"error":{"message":"litellm.AuthenticationError: BedrockException Invalid Authentication
 - The security token included in the request is invalid.","code":"403"}}
```

### After (3633edcb6c)

1. `cohere.embed-english-v3` — now behaves exactly like its sibling, past parameter validation and failing only on the fake credentials:

```
{"error":{"message":"litellm.AuthenticationError: BedrockException Invalid Authentication
 - The security token included in the request is invalid.","code":"403"}}
```

2. `cohere.embed-multilingual-v3` — unchanged, same 403.

With real credentials this is where the 200 and the embedding vector would be. I do not have Bedrock access, so the honest limit of this run is "the request now reaches the provider" — which is exactly what the dispatch controls.

### A correction to the issue

The report states that `drop_params: true` does not help. On the merge base it does: with `drop_params: true` the same `cohere.embed-english-v3` request reaches Bedrock (403) instead of returning the 400. The parameter is silently discarded, so `encoding_format` still cannot actually be used, but the 400 is avoidable that way. The TLDR above is worded accordingly rather than repeating the original claim.

### Unit-level

- `pytest tests/test_litellm/test_utils.py::TestBedrockCohereEmbeddingParams -v` → `9 passed`; with `litellm/utils.py` reverted to the merge base, `3 failed` — one per newly covered id, while the six cases for already-working models still pass.
- `pytest tests/test_litellm/llms/bedrock/embed/ -q` → `48 passed`.
- `pytest tests/test_litellm/test_utils.py -q` → `308 passed, 1 failed`; that failure is `test_generate_gcp_iam_access_token`, which needs `google-cloud-iam` and fails identically on unmodified `main`.
- `ruff format --check litellm/utils.py` → already formatted; `ruff check` reports the same finding count before and after.

## Type

🐛 Bug Fix

## Caveats (if any)

### Low

- Match widened to `"cohere.embed"`, so future Bedrock Cohere embed ids route here automatically
- That is the intent: they share one Cohere Embed API and one config class
- `cohere.embed-english-v3` was already registered in `constants.bedrock_embedding_models`, only the params dispatch missed it
- Unsupported params are still rejected for these models; tests cover that

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

