### PR TITLE
feat(ui): let users pick which columns the logs tables show

### DIFF
--- a/ui/litellm-dashboard/src/components/shared/DataTable/DataTable.test.tsx
+++ b/ui/litellm-dashboard/src/components/shared/DataTable/DataTable.test.tsx
@@ -1,4 +1,4 @@
-import type { ColumnDef, ExpandedState } from "@tanstack/react-table";
+import type { ColumnDef, ExpandedState, VisibilityState } from "@tanstack/react-table";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { useState } from "react";
@@ -463,6 +463,51 @@ describe("DataTable column visibility", () => {
     await user.click(screen.getByTestId("view-options-trigger"));
     expect(await screen.findByTestId("view-option-email")).toBeInTheDocument();
     expect(screen.queryByTestId("view-option-name")).not.toBeInTheDocument();
+  });
+
+  it("renders the visibility it is handed and reports a toggle instead of applying it", async () => {
+    const user = userEvent.setup();
+    const onColumnVisibilityChange = vi.fn();
+    const tree = (visibility: VisibilityState) => (
+      <DataTable
+        data={CHARLIE_ALICE_BOB}
+        columns={nameEmailColumns}
+        columnVisibility={visibility}
+        onColumnVisibilityChange={onColumnVisibilityChange}
+        toolbar={(table) => <DataTableViewOptions table={table} />}
+      />
+    );
+    const { container, rerender } = render(tree({ email: false }));
+
+    expect(container.querySelector('th[data-header-id="email"]')).toBeNull();
+
+    await user.click(screen.getByTestId("view-options-trigger"));
+    await user.click(await screen.findByTestId("view-option-email"));
+
+    expect(container.querySelector('th[data-header-id="email"]')).toBeNull();
+    expect(onColumnVisibilityChange).toHaveBeenCalledTimes(1);
+    const updater = onColumnVisibilityChange.mock.calls[0][0];
+    expect(typeof updater === "function" ? updater({ email: false }) : updater).toEqual({ email: true });
+
+    rerender(tree({ email: true }));
+    expect(container.querySelector('th[data-header-id="email"]')).not.toBeNull();
+  });
+
+  it("seeds from defaultColumnVisibility and still toggles when left uncontrolled", async () => {
+    const user = userEvent.setup();
+    const { container } = render(
+      <DataTable
+        data={CHARLIE_ALICE_BOB}
+        columns={nameEmailColumns}
+        defaultColumnVisibility={{ email: false }}
+        toolbar={(table) => <DataTableViewOptions table={table} />}
+      />,
+    );
+
+    expect(container.querySelector('th[data-header-id="email"]')).toBeNull();
+    await user.click(screen.getByTestId("view-options-trigger"));
+    await user.click(await screen.findByTestId("view-option-email"));
+    await waitFor(() => expect(container.querySelector('th[data-header-id="email"]')).not.toBeNull());
   });
 });
 

--- a/ui/litellm-dashboard/src/components/shared/DataTable/DataTable.tsx
+++ b/ui/litellm-dashboard/src/components/shared/DataTable/DataTable.tsx
@@ -439,6 +439,8 @@ function useDataTableInstance<TData extends RowData, TValue>(
     onGlobalFilterChange,
     enableColumnResizing = false,
     columnResizeMode = "onEnd",
+    columnVisibility,
+    onColumnVisibilityChange,
     defaultColumnVisibility,
     getRowCanExpand,
     renderSubComponent,
@@ -462,7 +464,11 @@ function useDataTableInstance<TData extends RowData, TValue>(
   const globalFilterState = useControllable<string>(globalFilter, onGlobalFilterChange, "");
   const expandedState = useControllable<ExpandedState>(expanded, onExpandedChange, {});
   const rowSelectionState = useControllable<RowSelectionState>(rowSelection, onRowSelectionChange, {});
-  const [columnVisibility, setColumnVisibility] = useState<VisibilityState>(defaultColumnVisibility ?? {});
+  const columnVisibilityState = useControllable<VisibilityState>(
+    columnVisibility,
+    onColumnVisibilityChange,
+    defaultColumnVisibility ?? {},
+  );
   const [columnSizing, setColumnSizing] = useState<ColumnSizingState>({});
   const columnPinning = React.useMemo(() => derivePinning(columns), [columns]);
   const expansionGuard = renderSubComponent !== undefined ? getRowCanExpand : undefined;
@@ -477,7 +483,7 @@ function useDataTableInstance<TData extends RowData, TValue>(
       globalFilter: globalFilterState.value,
       expanded: expandedState.value,
       rowSelection: rowSelectionState.value,
-      columnVisibility,
+      columnVisibility: columnVisibilityState.value,
       columnSizing,
     },
     initialState: { columnPinning },
@@ -493,7 +499,7 @@ function useDataTableInstance<TData extends RowData, TValue>(
     onGlobalFilterChange: globalFilterState.onChange,
     onExpandedChange: expandedState.onChange,
     onRowSelectionChange: rowSelectionState.onChange,
-    onColumnVisibilityChange: setColumnVisibility,
+    onColumnVisibilityChange: columnVisibilityState.onChange,
     onColumnSizingChange: setColumnSizing,
     getCoreRowModel: getCoreRowModel(),
     ...buildRowModels(sortingMode, paginationMode, filterMode, expansionGuard),

--- a/ui/litellm-dashboard/src/components/shared/DataTable/columnVisibilityPreference.test.ts
+++ b/ui/litellm-dashboard/src/components/shared/DataTable/columnVisibilityPreference.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+
+import { parseColumnVisibility } from "./columnVisibilityPreference";
+
+const COLUMN_IDS = ["startTime", "model", "key_hash"] as const;
+
+const parse = (raw: string | null) => parseColumnVisibility(raw, COLUMN_IDS);
+
+describe("parseColumnVisibility", () => {
+  it("treats a missing preference as every column visible", () => {
+    expect(parse(null)).toEqual({});
+  });
+
+  it("falls back to every column visible when the stored value is not valid JSON", () => {
+    expect(parse("{not json")).toEqual({});
+  });
+
+  it.each([
+    ["an array", "[1,2]"],
+    ["a JSON null", "null"],
+    ["a bare number", "3"],
+    ["a bare string", '"nope"'],
+  ])("ignores %s, which cannot describe column visibility", (_label, raw) => {
+    expect(parse(raw)).toEqual({});
+  });
+
+  it("keeps a hidden column that the user actually chose to hide", () => {
+    expect(parse('{"key_hash":false}')).toEqual({ key_hash: false });
+  });
+
+  it("keeps an explicitly visible column", () => {
+    expect(parse('{"model":true}')).toEqual({ model: true });
+  });
+
+  it("drops an id that is no longer a column, so a renamed column cannot resurrect stale state", () => {
+    expect(parse('{"column_that_never_existed":false}')).toEqual({});
+  });
+
+  it("drops a non-boolean value instead of coercing it", () => {
+    expect(parse('{"model":"false"}')).toEqual({});
+  });
+
+  it("keeps the known entries and drops the unknown ones from the same object", () => {
+    expect(parse('{"model":true,"gone":false,"key_hash":false}')).toEqual({ model: true, key_hash: false });
+  });
+});

--- a/ui/litellm-dashboard/src/components/shared/DataTable/columnVisibilityPreference.ts
+++ b/ui/litellm-dashboard/src/components/shared/DataTable/columnVisibilityPreference.ts
@@ -1,0 +1,49 @@
+"use client";
+
+import type { ColumnDef, OnChangeFn, RowData, VisibilityState } from "@tanstack/react-table";
+import { useEffect, useMemo, useState } from "react";
+
+import { getLocalStorageItem, setLocalStorageItem } from "@/utils/localStorageUtils";
+
+function decode(raw: string): unknown {
+  try {
+    return JSON.parse(raw) as unknown;
+  } catch {
+    return null;
+  }
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return null;
+  }
+  return value as Record<string, unknown>;
+}
+
+export function parseColumnVisibility(raw: string | null, columnIds: readonly string[]): VisibilityState {
+  const stored = raw === null ? null : asRecord(decode(raw));
+  if (stored === null) {
+    return {};
+  }
+  return Object.fromEntries(
+    Object.entries(stored).filter(
+      (entry): entry is [string, boolean] => columnIds.includes(entry[0]) && typeof entry[1] === "boolean",
+    ),
+  );
+}
+
+export function useColumnVisibilityPreference<TData extends RowData, TValue>(
+  storageKey: string,
+  columns: readonly ColumnDef<TData, TValue>[],
+): readonly [VisibilityState, OnChangeFn<VisibilityState>] {
+  const columnIds = useMemo(() => columns.flatMap((column) => (column.id === undefined ? [] : [column.id])), [columns]);
+  const [visibility, setVisibility] = useState<VisibilityState>(() =>
+    parseColumnVisibility(getLocalStorageItem(storageKey), columnIds),
+  );
+
+  useEffect(() => {
+    setLocalStorageItem(storageKey, JSON.stringify(visibility));
+  }, [storageKey, visibility]);
+
+  return [visibility, setVisibility] as const;
+}

--- a/ui/litellm-dashboard/src/components/shared/DataTable/index.ts
+++ b/ui/litellm-dashboard/src/components/shared/DataTable/index.ts
@@ -1,6 +1,7 @@
 import "./columnMeta";
 
 export { DataTable } from "./DataTable";
+export { parseColumnVisibility, useColumnVisibilityPreference } from "./columnVisibilityPreference";
 export { DataTableFilterDrawer, DataTableFilterField, type FilterDraft } from "./DataTableFilterDrawer";
 export { DataTablePagination, DEFAULT_PAGE_SIZE_OPTIONS } from "./DataTablePagination";
 export { createSelectionColumn } from "./DataTableSelectionColumn";

--- a/ui/litellm-dashboard/src/components/shared/DataTable/types.ts
+++ b/ui/litellm-dashboard/src/components/shared/DataTable/types.ts
@@ -53,6 +53,8 @@ export interface DataTableResolvedProps<TData extends RowData, TValue> {
 
   enableColumnResizing?: boolean;
   columnResizeMode?: ColumnResizeMode;
+  columnVisibility?: VisibilityState;
+  onColumnVisibilityChange?: OnChangeFn<VisibilityState>;
   defaultColumnVisibility?: VisibilityState;
 
   getRowCanExpand?: (row: Row<TData>) => boolean;
@@ -96,6 +98,9 @@ type DataTableBaseProps<TData extends RowData, TValue> = Omit<
   | "columnFilters"
   | "onColumnFiltersChange"
   | "defaultColumnFilters"
+  | "columnVisibility"
+  | "onColumnVisibilityChange"
+  | "defaultColumnVisibility"
   | "rowSelection"
   | "onRowSelectionChange"
 >;
@@ -142,6 +147,18 @@ type FilterProps =
       defaultColumnFilters?: ColumnFiltersState;
     };
 
+type ColumnVisibilityProps =
+  | {
+      columnVisibility: VisibilityState;
+      onColumnVisibilityChange: OnChangeFn<VisibilityState>;
+      defaultColumnVisibility?: never;
+    }
+  | {
+      columnVisibility?: never;
+      onColumnVisibilityChange?: never;
+      defaultColumnVisibility?: VisibilityState;
+    };
+
 type RowSelectionProps =
   | { rowSelection: RowSelectionState; onRowSelectionChange: OnChangeFn<RowSelectionState> }
   | { rowSelection?: never; onRowSelectionChange?: OnChangeFn<RowSelectionState> };
@@ -150,4 +167,5 @@ export type DataTableProps<TData extends RowData, TValue> = DataTableBaseProps<T
   SortingProps &
   PaginationProps &
   FilterProps &
+  ColumnVisibilityProps &
   RowSelectionProps;

--- a/ui/litellm-dashboard/src/components/view_logs/AuditLogsTable.test.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/AuditLogsTable.test.tsx
@@ -1,7 +1,7 @@
 import type { ColumnFiltersState, PaginationState } from "@tanstack/react-table";
-import { fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { AuditLogsTable } from "./AuditLogsTable";
 import type { AuditLogEntry } from "./AuditLogsTableColumns";
@@ -52,6 +52,10 @@ function renderTable(overrides: Partial<React.ComponentProps<typeof AuditLogsTab
 }
 
 describe("AuditLogsTable", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
   it("renders each audit column with the migrated shared cells", () => {
     renderTable();
 
@@ -169,5 +173,30 @@ describe("AuditLogsTable", () => {
 
     expect(action).toHaveTextContent("Created");
     expect(table).toHaveTextContent("Teams");
+  });
+});
+
+describe("AuditLogsTable column visibility", () => {
+  const header = (columnId: string) => document.querySelector(`th[data-header-id="${columnId}"]`);
+
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it("hides an audit column chosen in the Columns menu", async () => {
+    const user = userEvent.setup();
+    renderTable();
+
+    expect(header("changed_by_api_key")).not.toBeNull();
+    await user.click(screen.getByTestId("view-options-trigger"));
+    await user.click(await screen.findByTestId("view-option-changed_by_api_key"));
+    await waitFor(() => expect(header("changed_by_api_key")).toBeNull());
+  });
+
+  it("keeps its preference under its own key, untouched by the request logs table", () => {
+    localStorage.setItem("litellm_request_logs_column_visibility", '{"changed_by_api_key":false}');
+    renderTable();
+
+    expect(header("changed_by_api_key")).not.toBeNull();
   });
 });

--- a/ui/litellm-dashboard/src/components/view_logs/AuditLogsTable.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/AuditLogsTable.tsx
@@ -9,6 +9,7 @@ import {
   DataTableFilterDrawer,
   DataTableFilterField,
   DataTableToolbar,
+  useColumnVisibilityPreference,
 } from "@/components/shared/DataTable";
 import { Input } from "@/components/ui/input";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
@@ -27,6 +28,8 @@ interface AuditLogsTableProps {
   onRefresh: () => void;
   onViewLog: (log: AuditLogEntry) => void;
 }
+
+const COLUMN_VISIBILITY_STORAGE_KEY = "litellm_audit_logs_column_visibility";
 
 const ALL_VALUE = "all";
 
@@ -107,6 +110,10 @@ export function AuditLogsTable({
 }: AuditLogsTableProps) {
   const [filtersOpen, setFiltersOpen] = useState(false);
   const columns = useMemo(() => getAuditLogsTableColumns({ onViewLog }), [onViewLog]);
+  const [columnVisibility, onColumnVisibilityChange] = useColumnVisibilityPreference(
+    COLUMN_VISIBILITY_STORAGE_KEY,
+    columns,
+  );
 
   return (
     <DataTable
@@ -120,6 +127,8 @@ export function AuditLogsTable({
       filterMode="server"
       columnFilters={columnFilters}
       onColumnFiltersChange={onColumnFiltersChange}
+      columnVisibility={columnVisibility}
+      onColumnVisibilityChange={onColumnVisibilityChange}
       isLoading={isLoading}
       loadingMessage="Loading audit logs…"
       noDataMessage={<AuditLogsEmptyState filtered={columnFilters.length > 0} />}
@@ -133,7 +142,6 @@ export function AuditLogsTable({
             onOpenFilters={() => setFiltersOpen(true)}
             filterLabels={FILTER_LABELS}
             formatFilterValue={formatFilterValue}
-            showViewOptions={false}
           />
           <DataTableFilterDrawer
             table={table}

--- a/ui/litellm-dashboard/src/components/view_logs/RequestLogsPanel.test.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/RequestLogsPanel.test.tsx
@@ -134,6 +134,7 @@ describe("RequestLogsPanel", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     sessionStorage.clear();
+    localStorage.clear();
     testQueryClient.clear();
     respondWith([]);
   });
@@ -482,6 +483,62 @@ describe("RequestLogsPanel", () => {
       await user.click(screen.getByRole("button", { name: "Stop" }));
 
       expect(screen.queryByText("Auto-refreshing every 15 seconds")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("column visibility preference", () => {
+    const header = (columnId: string) => document.querySelector(`th[data-header-id="${columnId}"]`);
+    const ALL_COLUMN_IDS = [
+      "startTime",
+      "type",
+      "status",
+      "session_id",
+      "request_id",
+      "spend",
+      "request_duration_ms",
+      "ttft_ms",
+      "team_alias",
+      "key_hash",
+      "key_alias",
+      "model",
+      "total_tokens",
+      "user",
+      "end_user",
+      "request_tags",
+    ];
+
+    it("shows every column on a first visit, before anyone has customised the table", async () => {
+      respondWith([logEntry({})]);
+      renderPanel();
+
+      await waitFor(() => expect(header("startTime")).not.toBeNull());
+      const missing = ALL_COLUMN_IDS.filter((columnId) => header(columnId) === null);
+      expect(missing).toEqual([]);
+    });
+
+    it("remembers a column hidden through the menu across a remount", async () => {
+      const user = userEvent.setup();
+      respondWith([logEntry({})]);
+      const view = renderPanel();
+
+      await waitFor(() => expect(header("key_hash")).not.toBeNull());
+      await user.click(screen.getByTestId("view-options-trigger"));
+      await user.click(await screen.findByTestId("view-option-key_hash"));
+      await waitFor(() => expect(header("key_hash")).toBeNull());
+
+      view.unmount();
+      renderPanel();
+
+      await waitFor(() => expect(header("startTime")).not.toBeNull());
+      expect(header("key_hash")).toBeNull();
+    });
+
+    it("falls back to every column when the stored preference is malformed", async () => {
+      localStorage.setItem("litellm_request_logs_column_visibility", "{not json");
+      respondWith([logEntry({})]);
+      renderPanel();
+
+      await waitFor(() => expect(header("key_hash")).not.toBeNull());
     });
   });
 });

--- a/ui/litellm-dashboard/src/components/view_logs/RequestLogsTable.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/RequestLogsTable.tsx
@@ -4,13 +4,20 @@ import type { ColumnFiltersState, OnChangeFn, PaginationState, SortingState } fr
 import { ScrollText } from "lucide-react";
 import { useMemo, useState, type ReactNode } from "react";
 
-import { DataTable, DataTableFilterDrawer, DataTableToolbar } from "@/components/shared/DataTable";
+import {
+  DataTable,
+  DataTableFilterDrawer,
+  DataTableToolbar,
+  useColumnVisibilityPreference,
+} from "@/components/shared/DataTable";
 
 import type { Team } from "../key_team_helpers/key_list";
 import type { LogEntry } from "./columns";
 import { LOG_FILTER_LABELS, type LogsWindow } from "./log_filter_logic";
 import { RequestLogsFilters } from "./RequestLogsFilters";
 import { getRequestLogsTableColumns } from "./RequestLogsTableColumns";
+
+const COLUMN_VISIBILITY_STORAGE_KEY = "litellm_request_logs_column_visibility";
 
 interface RequestLogsTableProps {
   data: LogEntry[];
@@ -78,6 +85,11 @@ export function RequestLogsTable({
     return getRequestLogsTableColumns(deps);
   }, [onKeyHashClick, onSessionClick]);
 
+  const [columnVisibility, onColumnVisibilityChange] = useColumnVisibilityPreference(
+    COLUMN_VISIBILITY_STORAGE_KEY,
+    columns,
+  );
+
   const isFiltered = columnFilters.length > 0 || searchValue !== "";
 
   return (
@@ -95,6 +107,8 @@ export function RequestLogsTable({
       filterMode="server"
       columnFilters={columnFilters}
       onColumnFiltersChange={onColumnFiltersChange}
+      columnVisibility={columnVisibility}
+      onColumnVisibilityChange={onColumnVisibilityChange}
       isLoading={isLoading}
       loadingMessage="Loading request logs…"
       noDataMessage={<RequestLogsEmptyState filtered={isFiltered} />}
@@ -111,7 +125,6 @@ export function RequestLogsTable({
             isRefreshing={isRefreshing}
             onOpenFilters={() => setFiltersOpen(true)}
             filterLabels={LOG_FILTER_LABELS}
-            showViewOptions={false}
           >
             {toolbarChildren}
           </DataTableToolbar>

--- a/ui/litellm-dashboard/src/components/view_logs/RequestLogsTableColumns.test.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/RequestLogsTableColumns.test.tsx
@@ -2,7 +2,7 @@ import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 
-import { DataTable } from "@/components/shared/DataTable";
+import { DataTable, DataTableViewOptions } from "@/components/shared/DataTable";
 
 import type { LogEntry } from "./columns";
 import { getRequestLogsTableColumns } from "./RequestLogsTableColumns";
@@ -132,5 +132,44 @@ describe("TTFT column", () => {
     ]);
 
     expect(screen.getByText("1.00")).toBeInTheDocument();
+  });
+});
+
+describe("Columns menu", () => {
+  const EXPECTED_LABELS: [string, string][] = [
+    ["startTime", "Time"],
+    ["type", "Type"],
+    ["status", "Status"],
+    ["session_id", "Session ID"],
+    ["request_id", "Request ID"],
+    ["spend", "Cost"],
+    ["request_duration_ms", "Duration (s)"],
+    ["ttft_ms", "TTFT (s)"],
+    ["team_alias", "Team Name"],
+    ["key_hash", "Key Hash"],
+    ["key_alias", "Key Alias"],
+    ["model", "Model"],
+    ["total_tokens", "Tokens"],
+    ["user", "Internal User"],
+    ["end_user", "End User"],
+    ["request_tags", "Tags"],
+  ];
+
+  it("labels every column with its header text rather than the raw column id", async () => {
+    const user = userEvent.setup();
+    render(
+      <DataTable
+        data={[logEntry({})]}
+        columns={getRequestLogsTableColumns(noopDeps)}
+        getRowId={(row) => row.request_id}
+        size="compact"
+        toolbar={(table) => <DataTableViewOptions table={table} />}
+      />,
+    );
+
+    await user.click(screen.getByTestId("view-options-trigger"));
+
+    const items = await screen.findAllByRole("menuitemcheckbox");
+    expect(items.map((item) => item.textContent)).toEqual(EXPECTED_LABELS.map(([, label]) => label));
   });
 });

--- a/ui/litellm-dashboard/src/components/view_logs/RequestLogsTableColumns.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/RequestLogsTableColumns.tsx
@@ -46,6 +46,7 @@ export const getRequestLogsTableColumns = ({
     header: ({ column }) => <DataTableSortHeader column={column} title="Time" variant="dropdown-tristate" />,
     size: 200,
     enableSorting: true,
+    meta: { title: "Time" },
     cell: ({ row }) => <DateCell value={row.original.startTime} />,
   },
   {
@@ -128,7 +129,7 @@ export const getRequestLogsTableColumns = ({
     header: ({ column }) => <DataTableSortHeader column={column} title="Cost" variant="dropdown-tristate" />,
     size: 110,
     enableSorting: true,
-    meta: { numeric: true, skeleton: "twoLine" },
+    meta: { numeric: true, skeleton: "twoLine", title: "Cost" },
     cell: ({ row }) => {
       const log = row.original;
       const mcpCount = log.mcp_tool_call_count || 0;
@@ -159,7 +160,7 @@ export const getRequestLogsTableColumns = ({
     accessorKey: "request_duration_ms",
     header: ({ column }) => <DataTableSortHeader column={column} title="Duration (s)" variant="dropdown-tristate" />,
     enableSorting: true,
-    meta: { numeric: true },
+    meta: { numeric: true, title: "Duration (s)" },
     cell: ({ row }) => {
       const ms = row.original.request_duration_ms;
       if (ms == null) return <span>-</span>;
@@ -176,7 +177,7 @@ export const getRequestLogsTableColumns = ({
     accessorKey: "completionStartTime",
     header: ({ column }) => <DataTableSortHeader column={column} title="TTFT (s)" variant="dropdown-tristate" />,
     enableSorting: true,
-    meta: { numeric: true },
+    meta: { numeric: true, title: "TTFT (s)" },
     cell: ({ row }) => {
       const log = row.original;
       const completionStartTime = log.completionStartTime;
@@ -221,6 +222,7 @@ export const getRequestLogsTableColumns = ({
     header: ({ column }) => <DataTableSortHeader column={column} title="Model" variant="dropdown-tristate" />,
     size: 200,
     enableSorting: true,
+    meta: { title: "Model" },
     cell: ({ row }) => {
       const log = row.original;
       const provider = log.custom_llm_provider;
@@ -248,7 +250,7 @@ export const getRequestLogsTableColumns = ({
     header: ({ column }) => <DataTableSortHeader column={column} title="Tokens" variant="dropdown-tristate" />,
     size: 140,
     enableSorting: true,
-    meta: { numeric: true },
+    meta: { numeric: true, title: "Tokens" },
     cell: ({ row }) => {
       const log = row.original;
       return (


### PR DESCRIPTION
## TLDR

Problem this solves:

- Request Logs shows 16 fixed columns, forcing horizontal scroll on laptops
- The existing "Columns" picker was disabled on both logs tables
- Hiding a column reset on every reload, so the scroll always came back

How it solves it:

- Enables the shared DataTable "Columns" menu on Request Logs and Audit Logs
- Makes column visibility a controlled DataTable prop, not internal state
- Persists the choice per table in localStorage, validated on read

## User Flow

Before: an admin reading Request Logs on a laptop fights a horizontal scrollbar every time

1. They open http://localhost:4000/ui/?page=logs
2. All 16 columns render at once, wider than the viewport
3. They scroll sideways to see Model or Cost, and the scrollbar returns on every reload
4. No "Columns" button exists in the toolbar to hide what they don't read

After: the same admin hides the columns they don't need, once, and it sticks

1. They open http://localhost:4000/ui/?page=logs
2. They click the "Columns" button in the toolbar and uncheck Session ID, Request ID, Duration, TTFT, Team Name, Key Hash, Key Alias, Internal User, End User, and Tags
3. The table narrows to fit the viewport with no horizontal scrollbar
4. They reload the page, close and reopen the browser: the same six columns stay visible
5. The Audit Logs tab gets the same "Columns" button, with its own independent preference

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Ran against a live proxy on localhost:4000 and the dashboard dev server on localhost:3000, following the steps below. Screenshots to be attached after running through this checklist.

<img width="2089" height="1098" alt="image" src="https://github.com/user-attachments/assets/eaf09390-6562-402d-9de8-9b33243b2464" />
<img width="2111" height="1134" alt="image" src="https://github.com/user-attachments/assets/eba5465d-50fb-41e1-9340-773fa13c750d" />


### Before (22a349ee70)

1. Open http://localhost:3000/logs/, Request Logs tab
2. Resize the browser to 1280×800 and reload
3. Run in the console:
   ```js
   const c = document.querySelector('[data-slot="table-container"]');
   ({ scrollWidth: c.scrollWidth, clientWidth: c.clientWidth, overflows: c.scrollWidth > c.clientWidth })
   ```
4. Expect `overflows: true`, with `scrollWidth` around 2100, and no "Columns" button in the toolbar

### After (90842f56dc)

1. Open http://localhost:3000/logs/, Request Logs tab
2. Click the "Columns" button, hide Session ID, Request ID, Duration (s), TTFT (s), Team Name, Key Hash, Key Alias, Internal User, End User, Tags
3. Re-run the same console snippet at 1280×800
4. Expect `overflows: false`
5. Reload the page, then open the same URL in a new tab: the six visible columns persist
6. Switch to the Audit Logs tab: it also has a "Columns" button, and a preference set there does not affect Request Logs

## Type

🆕 New Feature

## Caveats (if any)

### Low

- All 16/6 columns stay visible by default until a user opens the Columns menu once
- Column order is not customizable, only visibility (matches the ask: remove/add columns)

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
