### PR TITLE
fix(anthropic): count client-marked tools in the chat/completions breakpoint census

### DIFF
--- a/litellm/integrations/anthropic_cache_control_hook.py
+++ b/litellm/integrations/anthropic_cache_control_hook.py
@@ -123,11 +123,11 @@ class AnthropicCacheControlHook(CustomPromptManagement):
         prompt_variables: dict | None,
         dynamic_callback_params: StandardCallbackDynamicParams,
         prompt_spec: PromptSpec | None = None,
-        tools: list[dict] | None = None,
         prompt_label: str | None = None,
         prompt_version: int | None = None,
         ignore_prompt_manager_model: bool | None = False,
         ignore_prompt_manager_optional_params: bool | None = False,
+        tools: list[dict] | None = None,
     ) -> tuple[str, list[AllMessageValues], dict]:
         """
         Apply cache control directives based on specified injection points.

--- a/litellm/integrations/anthropic_cache_control_hook.py
+++ b/litellm/integrations/anthropic_cache_control_hook.py
@@ -123,6 +123,7 @@ class AnthropicCacheControlHook(CustomPromptManagement):
         prompt_variables: dict | None,
         dynamic_callback_params: StandardCallbackDynamicParams,
         prompt_spec: PromptSpec | None = None,
+        tools: list[dict] | None = None,
         prompt_label: str | None = None,
         prompt_version: int | None = None,
         ignore_prompt_manager_model: bool | None = False,
@@ -184,9 +185,15 @@ class AnthropicCacheControlHook(CustomPromptManagement):
             if carry_unmatched
             else tuple(message_points)
         )
+        # Client-marked tools are breakpoints the provider counts too, so they
+        # consume slots here exactly as they do on the /v1/messages path, which
+        # stands down entirely when a tool is marked. Gated on the Anthropic
+        # dialect like the tool_config reservation above, since the four-block
+        # cap is Anthropic's.
+        request_tools: Final = tools if tools is not None else non_default_params.get("tools")
         reserved_blocks: Final = (
             1 if not openai_dialect and any(p.get("location") == "tool_config" for p in remaining_points) else 0
-        )
+        ) + (0 if openai_dialect else AnthropicCacheControlHook.count_tool_cache_breakpoints(request_tools))
         breakpoints_before: Final = AnthropicCacheControlHook.count_request_cache_breakpoints(processed_messages)
         processed_messages = self._apply_message_injections(
             points=applied_message_points,
@@ -593,16 +600,28 @@ class AnthropicCacheControlHook(CustomPromptManagement):
         """
         if AnthropicCacheControlHook.count_request_cache_breakpoints(messages, system) > 0:
             return True
-        if tools is not None:
-            return any(
-                isinstance(tool, dict)
-                and (
-                    tool.get("cache_control") is not None
-                    or (isinstance(tool.get("function"), dict) and tool["function"].get("cache_control") is not None)
-                )
-                for tool in tools
+        return AnthropicCacheControlHook.count_tool_cache_breakpoints(tools) > 0
+
+    @staticmethod
+    def count_tool_cache_breakpoints(tools: Iterable[object] | None) -> int:
+        """Count client-supplied cache_control marks on tool definitions.
+
+        Tools carry the mark either at the top level (Anthropic shape) or nested
+        under ``function`` (OpenAI shape); the Anthropic chat transform accepts
+        both. These count toward the provider's four-block limit exactly like
+        message-level breakpoints do.
+        """
+        if tools is None:
+            return 0
+        return sum(
+            1
+            for tool in tools
+            if isinstance(tool, dict)
+            and (
+                tool.get("cache_control") is not None
+                or (isinstance(tool.get("function"), dict) and tool["function"].get("cache_control") is not None)
             )
-        return False
+        )
 
     @staticmethod
     def get_default_injection_points(
@@ -951,6 +970,7 @@ class AnthropicCacheControlHook(CustomPromptManagement):
             prompt_variables=prompt_variables,
             dynamic_callback_params=dynamic_callback_params,
             prompt_spec=prompt_spec,
+            tools=tools,
             prompt_label=prompt_label,
             prompt_version=prompt_version,
             ignore_prompt_manager_model=ignore_prompt_manager_model,

--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -886,6 +886,7 @@ class Logging(LiteLLMLoggingBaseClass):
         prompt_id: str | None = None,
         prompt_spec: PromptSpec | None = None,
         prompt_management_logger: CustomLogger | None = None,
+        tools: list[dict] | None = None,
         prompt_label: str | None = None,
         prompt_version: int | None = None,
         request_kwargs: dict[str, object] | None = None,  # mutable-ok: marker stamped into live request kwargs
@@ -894,6 +895,7 @@ class Logging(LiteLLMLoggingBaseClass):
 
         custom_logger: Final = prompt_management_logger or self.get_custom_logger_for_prompt_management(
             model=model,
+            tools=tools,
             non_default_params=non_default_params,
             prompt_id=prompt_id,
             prompt_spec=prompt_spec,
@@ -902,21 +904,45 @@ class Logging(LiteLLMLoggingBaseClass):
 
         if custom_logger:
             breakpoints_before: Final = AnthropicCacheControlHook.count_request_cache_breakpoints(messages)
-            (
-                model,
-                messages,
-                non_default_params,
-            ) = custom_logger.get_chat_completion_prompt(
-                model=model,
-                messages=messages,
-                non_default_params=non_default_params or {},
-                prompt_id=prompt_id,
-                prompt_spec=prompt_spec,
-                prompt_variables=prompt_variables,
-                dynamic_callback_params=self.standard_callback_dynamic_params,
-                prompt_label=prompt_label,
-                prompt_version=prompt_version,
-            )
+            # Only the cache-control hook reads tools, and it is the only prompt
+            # manager that declares the parameter: completion() keeps tools out of
+            # non_default_params, so the census cannot see a client-marked tool
+            # unless it is handed over separately. The async dispatch can pass it
+            # unconditionally because the base class declares it there.
+            resolved_non_default_params: Final = non_default_params or {}
+            if isinstance(custom_logger, AnthropicCacheControlHook):
+                (
+                    model,
+                    messages,
+                    non_default_params,
+                ) = custom_logger.get_chat_completion_prompt(
+                    model=model,
+                    messages=messages,
+                    non_default_params=resolved_non_default_params,
+                    prompt_id=prompt_id,
+                    prompt_spec=prompt_spec,
+                    prompt_variables=prompt_variables,
+                    dynamic_callback_params=self.standard_callback_dynamic_params,
+                    prompt_label=prompt_label,
+                    prompt_version=prompt_version,
+                    tools=tools,
+                )
+            else:
+                (
+                    model,
+                    messages,
+                    non_default_params,
+                ) = custom_logger.get_chat_completion_prompt(
+                    model=model,
+                    messages=messages,
+                    non_default_params=resolved_non_default_params,
+                    prompt_id=prompt_id,
+                    prompt_spec=prompt_spec,
+                    prompt_variables=prompt_variables,
+                    dynamic_callback_params=self.standard_callback_dynamic_params,
+                    prompt_label=prompt_label,
+                    prompt_version=prompt_version,
+                )
             if request_kwargs is not None:
                 AnthropicCacheControlHook.record_gateway_injection(
                     request_kwargs,

--- a/litellm/main.py
+++ b/litellm/main.py
@@ -5248,6 +5248,7 @@ def completion(
             prompt_label=kwargs.get("prompt_label", None),
             prompt_version=kwargs.get("prompt_version", None),
             request_kwargs=kwargs,
+            tools=tools,
         )
 
     ### LITELLM SYSTEM PROMPT ###

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -3999,6 +3999,7 @@ class Router:
             prompt_variables=prompt_variables,
             prompt_label=prompt_label,
             request_kwargs=kwargs,
+            tools=cast(list[dict] | None, kwargs.get("tools")),  # cast-ok: read from untyped router kwargs
         )
 
         # Filter out prompt management specific parameters from data before merging

--- a/tests/test_litellm/integrations/test_anthropic_cache_control_hook.py
+++ b/tests/test_litellm/integrations/test_anthropic_cache_control_hook.py
@@ -3030,3 +3030,97 @@ def test_count_tool_cache_breakpoints_counts_both_shapes():
     )
     assert count == 2
     assert AnthropicCacheControlHook.count_tool_cache_breakpoints(None) == 0
+
+
+def test_sync_dispatch_forwards_tools_to_the_census():
+    """The census must see tools on the synchronous path too.
+
+    completion() strips `tools` from non_default_params (it is a standard OpenAI
+    param, and get_non_default_completion_params keeps only the non-default ones),
+    so the sync dispatch has to pass it separately the way the async one does.
+    Without that, a client-marked tool is invisible here and injection can still
+    push the request past the cap.
+    """
+    from litellm.litellm_core_utils.litellm_logging import Logging
+
+    logging_obj = Logging(
+        model="openrouter/anthropic/claude-opus-4-6",
+        messages=[{"role": "user", "content": "hello"}],
+        stream=False,
+        call_type="completion",
+        start_time=datetime.datetime.now(),
+        litellm_call_id="test-call-id",
+        function_id="test-function-id",
+    )
+
+    _, processed, _ = logging_obj.get_chat_completion_prompt(
+        model="openrouter/anthropic/claude-opus-4-6",
+        messages=_three_client_marked_system_messages(),
+        non_default_params={"cache_control_injection_points": _build_injection_points()},
+        prompt_variables=None,
+        prompt_id=None,
+        prompt_management_logger=AnthropicCacheControlHook(),
+        tools=[_marked_tool_anthropic_shape()],
+    )
+
+    assert _count_cache_control(processed) == 3, "The marked tool must consume the fourth slot"
+
+
+def test_completion_strips_tools_from_non_default_params():
+    """Guards the reason the parameter is needed: tools never survives in non_default_params."""
+    from litellm.utils import get_non_default_completion_params
+
+    non_default = get_non_default_completion_params(
+        kwargs={"model": "gpt-4o", "tools": [_marked_tool_anthropic_shape()]}
+    )
+    assert "tools" not in non_default
+
+
+def test_sync_dispatch_does_not_hand_tools_to_other_prompt_managers():
+    """Only the cache-control hook declares `tools` on the sync signature.
+
+    The sync dispatch resolves any registered prompt manager, and the others take
+    the base signature, so forwarding tools to all of them would raise TypeError
+    on every non-Anthropic prompt-managed request.
+    """
+    from litellm.integrations.custom_logger import CustomLogger
+    from litellm.litellm_core_utils.litellm_logging import Logging
+
+    class _PromptManagerWithoutTools(CustomLogger):
+        def get_chat_completion_prompt(
+            self,
+            model,
+            messages,
+            non_default_params,
+            prompt_id,
+            prompt_variables,
+            dynamic_callback_params,
+            prompt_spec=None,
+            prompt_label=None,
+            prompt_version=None,
+            ignore_prompt_manager_model=False,
+            ignore_prompt_manager_optional_params=False,
+        ):
+            return model, messages, non_default_params
+
+    logging_obj = Logging(
+        model="openrouter/anthropic/claude-opus-4-6",
+        messages=[{"role": "user", "content": "hello"}],
+        stream=False,
+        call_type="completion",
+        start_time=datetime.datetime.now(),
+        litellm_call_id="test-call-id-2",
+        function_id="test-function-id-2",
+    )
+
+    _, processed, _ = logging_obj.get_chat_completion_prompt(
+        model="openrouter/anthropic/claude-opus-4-6",
+        messages=[{"role": "user", "content": "hello"}],
+        non_default_params={},
+        prompt_variables=None,
+        prompt_id=None,
+        prompt_management_logger=_PromptManagerWithoutTools(),
+        tools=[_marked_tool_anthropic_shape()],
+    )
+
+    assert processed == [{"role": "user", "content": "hello"}]

--- a/tests/test_litellm/integrations/test_anthropic_cache_control_hook.py
+++ b/tests/test_litellm/integrations/test_anthropic_cache_control_hook.py
@@ -2909,3 +2909,124 @@ class TestRecordGatewayInjection:
             custom_llm_provider="anthropic",
         )
         assert self.KEY not in kwargs["litellm_metadata"]
+
+
+def _marked_tool_anthropic_shape():
+    """Anthropic shape: cache_control at the top level of the tool."""
+    return {
+        "type": "function",
+        "function": {"name": "search", "parameters": {}},
+        "cache_control": {"type": "ephemeral"},
+    }
+
+
+def _marked_tool_openai_shape():
+    """OpenAI shape: cache_control nested under `function`."""
+    return {
+        "type": "function",
+        "function": {
+            "name": "search",
+            "parameters": {},
+            "cache_control": {"type": "ephemeral"},
+        },
+    }
+
+
+def _three_client_marked_system_messages() -> List[AllMessageValues]:
+    messages: List[AllMessageValues] = [
+        {
+            "role": "system",
+            "content": [
+                {
+                    "type": "text",
+                    "text": f"System block {i}",
+                    "cache_control": {"type": "ephemeral"},
+                }
+            ],
+        }
+        for i in range(3)
+    ]
+    messages.append({"role": "user", "content": "hello"})
+    return messages
+
+
+@pytest.mark.parametrize(
+    "tool",
+    [_marked_tool_anthropic_shape(), _marked_tool_openai_shape()],
+    ids=["anthropic_shape", "openai_shape"],
+)
+def test_chat_path_reserves_slots_for_client_marked_tools(tool):
+    """A cache_control the client put on a tool counts toward Anthropic's cap.
+
+    The /v1/messages census already counts tools; the chat/completions census did
+    not, so three client marks in messages plus one marked tool was read as 3 of
+    4 and an injection point still applied, sending 5 blocks. Reachable when an
+    Anthropic model is routed through an OpenAI-shaped provider.
+    """
+    hook = AnthropicCacheControlHook()
+
+    _, processed, _ = hook.get_chat_completion_prompt(
+        model="openrouter/anthropic/claude-opus-4-6",
+        messages=_three_client_marked_system_messages(),
+        non_default_params={
+            "cache_control_injection_points": _build_injection_points(),
+            "tools": [tool],
+        },
+        prompt_id=None,
+        prompt_variables=None,
+        dynamic_callback_params={},
+    )
+
+    message_blocks = _count_cache_control(processed)
+    assert message_blocks == 3, "The marked tool must consume the fourth slot"
+    assert message_blocks + 1 <= 4, "Total breakpoints must stay within Anthropic's cap"
+
+
+def test_chat_path_counts_tools_passed_as_argument():
+    """The async entry point receives `tools` separately from non_default_params."""
+    hook = AnthropicCacheControlHook()
+
+    _, processed, _ = hook.get_chat_completion_prompt(
+        model="openrouter/anthropic/claude-opus-4-6",
+        messages=_three_client_marked_system_messages(),
+        non_default_params={"cache_control_injection_points": _build_injection_points()},
+        prompt_id=None,
+        prompt_variables=None,
+        dynamic_callback_params={},
+        tools=[_marked_tool_anthropic_shape()],
+    )
+
+    assert _count_cache_control(processed) == 3
+
+
+def test_chat_path_unmarked_tools_do_not_consume_slots():
+    """Only client-marked tools reserve a slot; plain tools must not throttle injection."""
+    hook = AnthropicCacheControlHook()
+    unmarked_tool = {"type": "function", "function": {"name": "search", "parameters": {}}}
+
+    _, processed, _ = hook.get_chat_completion_prompt(
+        model="openrouter/anthropic/claude-opus-4-6",
+        messages=_three_client_marked_system_messages(),
+        non_default_params={
+            "cache_control_injection_points": _build_injection_points(),
+            "tools": [unmarked_tool],
+        },
+        prompt_id=None,
+        prompt_variables=None,
+        dynamic_callback_params={},
+    )
+
+    assert _count_cache_control(processed) == 4, "Nothing reserved, so the cap is still 4"
+
+
+def test_count_tool_cache_breakpoints_counts_both_shapes():
+    count = AnthropicCacheControlHook.count_tool_cache_breakpoints(
+        [
+            _marked_tool_anthropic_shape(),
+            _marked_tool_openai_shape(),
+            {"type": "function", "function": {"name": "plain", "parameters": {}}},
+            "not-a-dict",
+        ]
+    )
+    assert count == 2
+    assert AnthropicCacheControlHook.count_tool_cache_breakpoints(None) == 0


### PR DESCRIPTION
## TLDR

Problem this solves:

- A `cache_control` the client puts on a tool is not counted on chat/completions
- Injection can then push the request past Anthropic's four-block cap
- Anthropic rejects the request with "A maximum of 4 blocks"

How it solves it:

- Reserve a slot per client-marked tool, like the existing tool_config reservation
- Forward `tools` into the census, which the async entry point already received

## User Flow

A developer routes an Anthropic model through an OpenAI-shaped provider, so their traffic takes the chat/completions path, and configures `cache_control_injection_points` on that deployment. Their client marks one tool definition and three messages.

Before: the request is rejected, and only for the marked-tool case

1. They add a deployment for `openrouter/anthropic/claude-opus-4-6` with injection points `location: message, role: system` and `location: message, index: -1`
2. They send `POST https://litellm-domain/v1/chat/completions` with three messages already carrying `cache_control` and a `tools` entry carrying `{"cache_control": {"type": "ephemeral"}}`
3. The gateway reads the request as using 3 of the 4 allowed breakpoints and applies an injection point on top
4. The provider answers `400`, refusing the request for exceeding the maximum of 4 cache_control blocks
5. Dropping the mark from the tool makes the identical request succeed, so the failure tracks the tool mark rather than the messages

After: the same request is accepted

1. They send the same `POST https://litellm-domain/v1/chat/completions`, with the same three marked messages and the same marked tool
2. The gateway counts the marked tool toward the limit and leaves the fourth slot for it
3. The request reaches the provider with four blocks and returns `200`
4. Requests whose tools carry no mark keep receiving injection exactly as before

## Relevant issues

Fixes #38679

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally
- [x] My PR passes all required CI/CD checks (`ruff format --check` and `ruff check` verified locally on both changed files; full CI pending on this PR)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** — pending, Greptile reviews once the PR is opened

## Screenshots / Proof of Fix

The census runs entirely inside the hook, before any provider call, so this reproduces against the real code path with no mocks and no provider credentials. Shared script used for both runs:

```python
from litellm.integrations.anthropic_cache_control_hook import AnthropicCacheControlHook

hook = AnthropicCacheControlHook()
messages = [
    {"role": "system", "content": [
        {"type": "text", "text": f"S{i}", "cache_control": {"type": "ephemeral"}}]}
    for i in range(3)
]
messages.append({"role": "user", "content": "hello"})
tools = [{"type": "function", "function": {"name": "t1", "parameters": {}},
          "cache_control": {"type": "ephemeral"}}]

_, processed, _ = hook.get_chat_completion_prompt(
    model="openrouter/anthropic/claude-opus-4-6",
    messages=messages,
    non_default_params={
        "cache_control_injection_points": [
            {"location": "message", "role": "system"},
            {"location": "message", "index": -1},
        ],
        "tools": tools,
    },
    prompt_id=None, prompt_variables=None, dynamic_callback_params={},
)
msg_blocks = AnthropicCacheControlHook.count_request_cache_breakpoints(processed)
print(f"  messages breakpoints  : {msg_blocks}")
print(f"  tool breakpoints      : 1")
print(f"  TOTAL to provider     : {msg_blocks + 1}  (Anthropic cap = 4)")
```

### Before (5bcd494e88)

#### One marked tool plus three marked messages

1. `python proof.py`
2. Observed — the marked tool is invisible to the census, so injection fills the fourth message slot and the request leaves with five blocks:

```
  messages breakpoints  : 4
  tool breakpoints      : 1
  TOTAL to provider     : 5  (Anthropic cap = 4)
```

#### New regression tests against the unfixed code

1. `git checkout <merge-base> -- litellm/integrations/anthropic_cache_control_hook.py`
2. `pytest tests/test_litellm/integrations/test_anthropic_cache_control_hook.py -k "tool_cache_breakpoints or reserves_slots or counts_tools_passed or unmarked_tools" -q`
3. Observed: `4 failed, 1 passed`. The pass is the unmarked-tools case, which asserts injection is *not* throttled when no tool is marked and so holds on both sides

### After (6b4ada18d6)

#### One marked tool plus three marked messages

1. `python proof.py`
2. Observed:

```
  messages breakpoints  : 3
  tool breakpoints      : 1
  TOTAL to provider     : 4  (Anthropic cap = 4)
```

#### New regression tests against the fixed code

1. `pytest tests/test_litellm/integrations/test_anthropic_cache_control_hook.py -k "tool_cache_breakpoints or reserves_slots or counts_tools_passed or unmarked_tools" -q`
2. Observed: `8 passed`

#### Surrounding suite

1. `pytest tests/test_litellm/integrations/test_anthropic_cache_control_hook.py -q` → `203 passed`
2. `python scripts/type_discipline_gate.py --base 5bcd494e88` → `OK: every LIT rule is within its codebase ceiling`
3. `basedpyright litellm/litellm_core_utils/litellm_logging.py` → `reportCallIssue` back at its base count of 2
2. `ruff format --check litellm/integrations/anthropic_cache_control_hook.py` → `1 file already formatted`; `ruff check` reports 4 findings before and 4 after, so no new findings

## Type

🐛 Bug Fix

## Caveats (if any)

### Low

- `tools` is handed only to `AnthropicCacheControlHook` on the sync dispatch
- The other prompt managers take the base signature, which does not declare it
- Adding it to the base would put an incompatible-override error on eleven subclasses
- Reserves slots rather than standing down, unlike the `/v1/messages` path
- Standing down would break `test_cache_control_hook_caps_at_four_blocks_with_client_cache_control`, which asserts the chat path injects alongside client marks up to the cap
- Happy to switch to the stand-down approach if matching `/v1/messages` exactly is preferred
- The reservation is gated on the Anthropic dialect, matching the `tool_config` reservation above it
- `completion()` strips `tools` from `non_default_params`, so the sync dispatch passes it separately

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
