### PR TITLE
fix(router): scrub fallback stamp keys in place and strip them at the proxy boundary

### DIFF
--- a/litellm/proxy/litellm_pre_call_utils.py
+++ b/litellm/proxy/litellm_pre_call_utils.py
@@ -313,6 +313,10 @@ _CLIENT_PRICING_CONTROL_FIELDS: Final = frozenset(CustomPricingLiteLLMParams.mod
 # into response_cost and spend; a client seeding it forges (even negative)
 # guardrail cost.
 _CLIENT_PRICING_METADATA_FIELDS: Final = frozenset({"model_info", "standard_logging_guardrail_information"})
+# ``attempted_fallbacks`` and ``original_model_group`` are written by the router
+# and read by spend logs as fact; a client value has no legitimate meaning and no
+# key or team setting keeps it, so the strip is never gated.
+_ROUTER_RESERVED_METADATA_FIELDS: Final = frozenset({"attempted_fallbacks", "original_model_group"})
 _ALLOW_CLIENT_PRICING_OVERRIDE_METADATA_KEY: Final = "allow_client_pricing_override"
 
 # Request fields whose value, when URL-valued, becomes the outbound destination
@@ -536,6 +540,20 @@ def _strip_client_pricing_overrides(data: dict[str, Any]) -> None:
             "metadata to keep these values.",
             ", ".join(stripped),
         )
+
+
+def _strip_router_reserved_metadata(
+    data: dict[str, Any],  # mutable-ok: strips in place on the request body the pre-call pipeline threads through
+) -> None:
+    """Drop the router-owned fallback stamps from any client-supplied metadata bucket."""
+    for metadata_key in ("metadata", "litellm_metadata"):
+        if not isinstance(metadata := data.get(metadata_key), dict):
+            continue
+        for field in _ROUTER_RESERVED_METADATA_FIELDS & metadata.keys():
+            metadata.pop(field)
+            verbose_proxy_logger.debug(
+                "Stripped router-reserved metadata field from request body: %s.%s", metadata_key, field
+            )
 
 
 def _get_metadata_variable_name(request: Request) -> str:
@@ -1882,6 +1900,7 @@ async def add_litellm_data_to_request(
     # would silently skip the field.
     if not _key_or_team_allows_client_pricing_override(user_api_key_dict):
         _strip_client_pricing_overrides(data)
+    _strip_router_reserved_metadata(data)
 
     # Same reason as the strips above: runs after the metadata string-to-dict parse
     # so JSON-string metadata cannot smuggle callback credentials past the dict guard.

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -7048,13 +7048,11 @@ class Router:
             _sibling_metadata_key: Final = (
                 "metadata" if _fallback_metadata_key == "litellm_metadata" else "litellm_metadata"
             )
-            if isinstance(_sibling_metadata := kwargs.get(_sibling_metadata_key), dict) and (
-                "attempted_fallbacks" in _sibling_metadata or "original_model_group" in _sibling_metadata
-            ):
-                _scrubbed_sibling_metadata: Final = _sibling_metadata.copy()
-                _scrubbed_sibling_metadata.pop("attempted_fallbacks", None)
-                _scrubbed_sibling_metadata.pop("original_model_group", None)
-                kwargs[_sibling_metadata_key] = _scrubbed_sibling_metadata
+            if isinstance(_sibling_metadata := kwargs.get(_sibling_metadata_key), dict):
+                # In place, like every other router bucket write: downstream resolves the bucket by
+                # key presence, so rebinding kwargs to a copy detaches the proxy's request_data write-backs
+                _sibling_metadata.pop("attempted_fallbacks", None)
+                _sibling_metadata.pop("original_model_group", None)
             if isinstance(_fallback_metadata := kwargs.get(_fallback_metadata_key), dict):
                 _fallback_metadata["attempted_fallbacks"] = 0
                 if model_group is not None:

--- a/tests/test_litellm/proxy/test_litellm_pre_call_utils.py
+++ b/tests/test_litellm/proxy/test_litellm_pre_call_utils.py
@@ -7456,3 +7456,190 @@ def test_newrelic_vars_scoped_to_newrelic_callback_entry():
         None,
     )
     assert legit.callback_vars == {"newrelic_api_key": "REAL", "newrelic_region": "us"}
+
+
+def _reserved_stamp_request(path: str) -> MagicMock:
+    request_mock = MagicMock(spec=Request)
+    request_mock.url = MagicMock()
+    request_mock.url.path = path
+    request_mock.url.__str__.return_value = f"http://localhost{path}"
+    request_mock.method = "POST"
+    request_mock.query_params = {}
+    request_mock.headers = {"Content-Type": "application/json"}
+    request_mock.client = MagicMock()
+    request_mock.client.host = "127.0.0.1"
+    return request_mock
+
+
+def _reserved_stamp_key(key_metadata: dict | None = None) -> UserAPIKeyAuth:
+    return UserAPIKeyAuth(
+        api_key="hashed-key",
+        metadata=key_metadata or {},
+        team_metadata={},
+        spend=0.0,
+        max_budget=100.0,
+        model_max_budget={},
+        team_spend=0.0,
+        team_max_budget=200.0,
+    )
+
+
+_PLANTED_STAMPS = {"attempted_fallbacks": 99, "original_model_group": "spoofed-group", "client_key": "client_value"}
+
+
+@pytest.mark.asyncio
+async def test_add_litellm_data_to_request_strips_router_reserved_stamps_from_both_buckets():
+    """attempted_fallbacks and original_model_group are router-written facts the spend row
+    reads back; a client planting them in either bucket is dropped at the boundary so the
+    router never sees a reserved key it did not write."""
+    from litellm.proxy.litellm_pre_call_utils import add_litellm_data_to_request
+
+    data = {
+        "model": "gpt-3.5-turbo",
+        "messages": [{"role": "user", "content": "hi"}],
+        "metadata": dict(_PLANTED_STAMPS),
+        "litellm_metadata": dict(_PLANTED_STAMPS),
+    }
+
+    updated = await add_litellm_data_to_request(
+        data=data,
+        request=_reserved_stamp_request("/v1/chat/completions"),
+        user_api_key_dict=_reserved_stamp_key(),
+        proxy_config=MagicMock(),
+        general_settings={},
+        version="test-version",
+    )
+
+    for bucket in ("metadata", "litellm_metadata"):
+        assert "attempted_fallbacks" not in updated[bucket]
+        assert "original_model_group" not in updated[bucket]
+        assert updated[bucket]["client_key"] == "client_value"
+
+
+@pytest.mark.asyncio
+async def test_add_litellm_data_to_request_strips_router_reserved_stamps_from_json_string_litellm_metadata():
+    from litellm.proxy.litellm_pre_call_utils import add_litellm_data_to_request
+
+    data = {
+        "model": "gpt-3.5-turbo",
+        "messages": [{"role": "user", "content": "hi"}],
+        "litellm_metadata": json.dumps(_PLANTED_STAMPS),
+    }
+
+    updated = await add_litellm_data_to_request(
+        data=data,
+        request=_reserved_stamp_request("/v1/chat/completions"),
+        user_api_key_dict=_reserved_stamp_key(),
+        proxy_config=MagicMock(),
+        general_settings={},
+        version="test-version",
+    )
+
+    assert isinstance(updated["litellm_metadata"], dict)
+    assert "attempted_fallbacks" not in updated["litellm_metadata"]
+    assert "original_model_group" not in updated["litellm_metadata"]
+    assert updated["litellm_metadata"]["client_key"] == "client_value"
+
+
+@pytest.mark.asyncio
+async def test_add_litellm_data_to_request_strips_router_reserved_stamps_despite_pricing_override_opt_in():
+    """The pricing strip is gated on allow_client_pricing_override; the reserved-stamp strip
+    is not, because no key or team setting makes a client-written fallback count valid."""
+    from litellm.proxy.litellm_pre_call_utils import add_litellm_data_to_request
+
+    data = {
+        "model": "gpt-3.5-turbo",
+        "messages": [{"role": "user", "content": "hi"}],
+        "litellm_metadata": {**_PLANTED_STAMPS, "model_info": {"input_cost_per_token": 0.0}},
+    }
+
+    updated = await add_litellm_data_to_request(
+        data=data,
+        request=_reserved_stamp_request("/v1/chat/completions"),
+        user_api_key_dict=_reserved_stamp_key({"allow_client_pricing_override": True}),
+        proxy_config=MagicMock(),
+        general_settings={},
+        version="test-version",
+    )
+
+    assert updated["litellm_metadata"]["model_info"] == {"input_cost_per_token": 0.0}
+    assert "attempted_fallbacks" not in updated["litellm_metadata"]
+    assert "original_model_group" not in updated["litellm_metadata"]
+
+
+@pytest.mark.asyncio
+async def test_add_litellm_data_to_request_strips_router_reserved_stamps_on_responses_route():
+    """On the Responses family the proxy-owned bucket is litellm_metadata and the client's
+    OpenAI metadata param is the sibling; both lose the reserved keys."""
+    from litellm.proxy.litellm_pre_call_utils import add_litellm_data_to_request
+
+    data = {
+        "model": "gpt-3.5-turbo",
+        "input": "hi",
+        "metadata": dict(_PLANTED_STAMPS),
+        "litellm_metadata": dict(_PLANTED_STAMPS),
+    }
+
+    updated = await add_litellm_data_to_request(
+        data=data,
+        request=_reserved_stamp_request("/v1/responses"),
+        user_api_key_dict=_reserved_stamp_key(),
+        proxy_config=MagicMock(),
+        general_settings={},
+        version="test-version",
+    )
+
+    for bucket in ("metadata", "litellm_metadata"):
+        assert "attempted_fallbacks" not in updated[bucket]
+        assert "original_model_group" not in updated[bucket]
+        assert updated[bucket]["client_key"] == "client_value"
+
+
+@pytest.mark.asyncio
+async def test_router_keeps_proxy_metadata_bucket_identity_after_reserved_stamp_strip():
+    """Regression for the #38586 break: a client that planted a reserved key in
+    litellm_metadata made the router hand downstream a scrubbed copy, so the proxy's
+    post_call write-backs (guardrail telemetry, applied guardrails) landed in a dict the
+    spend row never read. After the boundary strip plus the in-place scrub, the object the
+    router forwards is the proxy's own request_data bucket."""
+    from litellm.proxy.litellm_pre_call_utils import add_litellm_data_to_request
+
+    data = {
+        "model": "gpt-3.5-turbo",
+        "messages": [{"role": "user", "content": "hi"}],
+        "litellm_metadata": dict(_PLANTED_STAMPS),
+    }
+    request_data = await add_litellm_data_to_request(
+        data=data,
+        request=_reserved_stamp_request("/v1/chat/completions"),
+        user_api_key_dict=_reserved_stamp_key(),
+        proxy_config=MagicMock(),
+        general_settings={},
+        version="test-version",
+    )
+    proxy_bucket = request_data["litellm_metadata"]
+    router = litellm.Router(
+        model_list=[
+            {
+                "model_name": "gpt-3.5-turbo",
+                "litellm_params": {"model": "gpt-3.5-turbo", "mock_response": "hi"},
+            }
+        ]
+    )
+    forwarded_buckets = []
+    original_acompletion = router._acompletion
+
+    async def _spy(*args, **spy_kwargs):
+        forwarded_buckets.append(spy_kwargs["litellm_metadata"])
+        return await original_acompletion(*args, **spy_kwargs)
+
+    router._acompletion = _spy
+
+    await router.acompletion(**request_data)
+
+    assert forwarded_buckets == [proxy_bucket]
+    assert forwarded_buckets[0] is proxy_bucket
+    assert "attempted_fallbacks" not in proxy_bucket
+    assert "original_model_group" not in proxy_bucket
+    proxy_bucket["standard_logging_guardrail_information"] = [{"guardrail_name": "postcall-guard"}]
+    assert forwarded_buckets[0]["standard_logging_guardrail_information"] == [{"guardrail_name": "postcall-guard"}]

--- a/tests/test_litellm/test_router.py
+++ b/tests/test_litellm/test_router.py
@@ -10826,9 +10826,8 @@ def _record_router_acompletion_kwargs(router: litellm.Router) -> list:
 @pytest.mark.asyncio
 async def test_async_function_with_fallbacks_scrubs_spoofed_values_from_sibling_bucket():
     """Spend logs read a truthy litellm_metadata dict in preference to metadata, so spoofed
-    stamp keys planted in the bucket the route does not own are removed from the request's
-    downstream view on entry instead of flowing into the spend log row. The caller's own
-    dict object is never mutated: the scrub replaces the kwargs entry with a cleaned copy."""
+    stamp keys planted in the bucket the route does not own are removed on entry, in place,
+    before they can flow into the spend log row."""
     router = litellm.Router(
         model_list=[
             {
@@ -10857,20 +10856,19 @@ async def test_async_function_with_fallbacks_scrubs_spoofed_values_from_sibling_
     assert "attempted_fallbacks" not in downstream_sibling
     assert "original_model_group" not in downstream_sibling
     assert downstream_sibling["client_key"] == "client_value"
-    assert litellm_metadata == {
-        "attempted_fallbacks": 99,
-        "original_model_group": "spoofed-group",
-        "client_key": "client_value",
-    }
+    assert "attempted_fallbacks" not in litellm_metadata
+    assert "original_model_group" not in litellm_metadata
+    assert litellm_metadata["client_key"] == "client_value"
     assert metadata["attempted_fallbacks"] == 0
     assert metadata["original_model_group"] == "gpt-3.5-turbo"
 
 
 @pytest.mark.asyncio
-async def test_async_function_with_fallbacks_leaves_caller_sibling_dict_object_untouched():
-    """The sibling-bucket scrub hands downstream a cleaned copy and never edits the dict
-    object the caller passed in: callers reuse metadata dicts across requests, and logging
-    callbacks observe the caller's object."""
+async def test_async_function_with_fallbacks_scrubs_sibling_bucket_in_place():
+    """Everything below the router resolves the bucket by key presence, so the scrub edits
+    the caller's dict object like every other router bucket write. Rebinding kwargs to a
+    scrubbed copy detaches the proxy's request_data write-backs (guardrail telemetry, retry
+    accounting) from the object the spend row is built from."""
     router = litellm.Router(
         model_list=[
             {
@@ -10895,8 +10893,43 @@ async def test_async_function_with_fallbacks_leaves_caller_sibling_dict_object_u
     )
 
     assert len(downstream_calls) == 1
-    assert downstream_calls[0]["litellm_metadata"] is not litellm_metadata
-    assert litellm_metadata == caller_snapshot
+    assert downstream_calls[0]["litellm_metadata"] is litellm_metadata
+    assert "attempted_fallbacks" not in litellm_metadata
+    assert "original_model_group" not in litellm_metadata
+    assert litellm_metadata["client_key"] == caller_snapshot["client_key"]
+
+
+@pytest.mark.asyncio
+async def test_async_function_with_fallbacks_stamps_aliased_buckets_on_every_call():
+    """One dict object passed as both metadata and litellm_metadata: the first call's own
+    stamp puts the reserved keys into the shared object, so the second call enters the
+    scrub with them present. Scrubbing in place keeps the stamp and the bucket on the same
+    object; a scrubbed copy would leave the spend reader's preferred bucket unstamped."""
+    router = litellm.Router(
+        model_list=[
+            {
+                "model_name": "chat-group",
+                "litellm_params": {"model": "gpt-3.5-turbo", "mock_response": "hi"},
+            }
+        ]
+    )
+    shared_metadata = {"team": "alpha"}
+    downstream_calls = _record_router_acompletion_kwargs(router)
+
+    for _ in range(3):
+        await router.acompletion(
+            model="chat-group",
+            messages=[{"role": "user", "content": "hey"}],
+            metadata=shared_metadata,
+            litellm_metadata=shared_metadata,
+        )
+
+    assert len(downstream_calls) == 3
+    for call_kwargs in downstream_calls:
+        assert call_kwargs["litellm_metadata"] is shared_metadata
+        assert call_kwargs["metadata"] is shared_metadata
+        assert call_kwargs["litellm_metadata"]["attempted_fallbacks"] == 0
+        assert call_kwargs["litellm_metadata"]["original_model_group"] == "chat-group"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## TLDR

Problem this solves:

- PR #38586 made the fallback-stamp scrub hand the router a detached copy
- On a proxy request, guardrail cost and status then drop from the spend row
- An SDK caller aliasing one metadata dict as both buckets loses the stamps

How it solves it:

- Scrub the reserved keys in place again, like every other router bucket write
- Strip client-supplied attempted_fallbacks / original_model_group at the proxy
- So proxy traffic never carries a reserved key, and no copy is ever taken

## User Flow

Before: an operator runs a post_call guardrail that charges $0.05 and looks at the Logs page to reconcile spend

1. A caller sends POST https://litellm-domain/v1/chat/completions with a `litellm_metadata` object that happens to (or maliciously does) contain `attempted_fallbacks`
2. The request succeeds, the response header `x-litellm-response-cost` reads 0.0500
3. https://litellm-domain/ui/?page=logs shows that same request at 0.00006 spend with no guardrail recorded, so the header and the row disagree and the $0.05 guardrail charge is missing

After: the same request records the guardrail and the full charge

1. The caller sends the same POST https://litellm-domain/v1/chat/completions with the same `litellm_metadata`
2. The request succeeds, `x-litellm-response-cost` reads 0.0500
3. https://litellm-domain/ui/?page=logs shows the request at 0.0500 spend with the guardrail recorded, matching the header
4. The client-supplied `attempted_fallbacks` value never appears in the row; the row shows the real fallback count the gateway computed

## Relevant issues

Follow-up to #38586 and #38107

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile Confidence Score of at least 4/5 before requesting a maintainer review

## Behavior changes

- Client-supplied `attempted_fallbacks` and `original_model_group` in `metadata` or `litellm_metadata` are now dropped at the proxy on every route, including the Responses-family `metadata` param. These are gateway-written spend-log fields, so a client value has no meaning; this matches the existing client pricing-field strip. Not gated by any key or team flag
- The sibling-bucket scrub in `async_function_with_fallbacks` mutates the caller's dict in place again (as it did before #38586). An SDK caller that plants a reserved key in the sibling bucket has it removed from that dict, the same way every other router stamp already mutates the caller's metadata
- Post_call guardrail cost and status, and the failure spend row, behave as they did before #38586

Regression tests: `test_async_function_with_fallbacks_scrubs_sibling_bucket_in_place`, `test_async_function_with_fallbacks_stamps_aliased_buckets_on_every_call`, `test_router_keeps_proxy_metadata_bucket_identity_after_reserved_stamp_strip`, and the `_strips_router_reserved_stamps_*` family in `test_litellm_pre_call_utils.py`

## Screenshots / Proof of Fix

Logs page, same planted request on each proxy (base carries #38586, After is the fix). The client planted `attempted_fallbacks: 99` in `litellm_metadata` and a post_call guardrail charges $0.05. The top row on each is the planted request.

After (08c85d5d35) keeps the $0.05 guardrail charge in the row:

![After - Logs page, planted request costed at 0.050151](https://raw.githubusercontent.com/BerriAI/litellm/assets-pr38690/logs-head.png)

Before (4d9025c2bf) drops the guardrail charge, so the same planted request records 0.000066:

![Before - Logs page, planted request costed at 0.000066](https://raw.githubusercontent.com/BerriAI/litellm/assets-pr38690/logs-base.png)

Terminal A/B, same planted request on both proxies read straight from the spend log:

![Terminal A/B: head keeps guardrail + 0.05, base drops both](https://raw.githubusercontent.com/BerriAI/litellm/assets-pr38690/demo.gif)

Real base-vs-head A/B on two proxies (base = staging 4d9025c2bf which carries #38586, After = 08c85d5d35), real Gemini calls, real Postgres, a post_call guardrail that charges $0.05. A caller plants `attempted_fallbacks: 99` / `original_model_group: "spoofed-group"` in `litellm_metadata` on /v1/chat/completions.

Shared setup (config, both proxies):

```yaml
model_list:
  - {model_name: gemini-flash, litellm_params: {model: gemini/gemini-2.5-flash, api_key: os.environ/GEMINI_API_KEY}}
guardrails:
  - {guardrail_name: postcall-guard, litellm_params: {guardrail: postcall_guard.PostCallGuard, mode: post_call, default_on: true}}
# PostCallGuard.async_post_call_success_hook records standard_logging_guardrail_information (guardrail_cost 0.05)
```

### Before (4d9025c2bf)

#### planted litellm_metadata, success spend rows

1. Send several `POST /v1/chat/completions` with `"litellm_metadata": {"attempted_fallbacks": 99, "original_model_group": "spoofed-group", "client_key": "cv"}`, plus control requests with no planted key
2. Read the success rows back from `LiteLLM_SpendLogs`:

```
model_group  | spend      | guardrail_information | attempted_fallbacks | original_model_group
gemini-flash | 5.84e-05   | <none>                | (empty)             | (empty)     <- planted: guardrail + $0.05 dropped
gemini-flash | 0.0500709  | success               | 0                   | gemini-flash  <- control: correct
fallback-group | 6.59e-05 | <none>                | (empty)             | (empty)     <- planted
gemini-flash | 6.59e-05   | <none>                | (empty)             | (empty)     <- planted
gemini-flash | 0.0500659  | success               | 0                   | gemini-flash  <- control
```

### After (08c85d5d35)

#### planted litellm_metadata, success spend rows

1. Send the identical requests to the head proxy
2. Read the success rows back:

```
model_group    | spend      | guardrail_information | attempted_fallbacks | original_model_group
gemini-flash   | 0.0500659  | success               | (empty/0)           | (real)   <- every row keeps the guardrail + $0.05
gemini-flash   | 0.05004090 | success               | 0                   | gemini-flash
fallback-group | 0.05004090 | success               | (empty/0)           | (real)
gemini-flash   | 0.05004090 | success               | (empty/0)           | (real)
gemini-flash   | 0.0500659  | success               | (empty/0)           | (real)
```

#### anti-spoof holds on both legs

3. The planted `attempted_fallbacks: 99` / `original_model_group: "spoofed-group"` never reach a spend row on either side:

```
SELECT count(*) FROM LiteLLM_SpendLogs WHERE metadata->>'original_model_group'='spoofed-group' OR metadata->>'attempted_fallbacks'='99';
base: 0    head: 0
```

#### fallback attribution unchanged

4. A real two-group fallback (`primary-group` -> `fallback-group`) returns `x-litellm-attempted-fallbacks: 1` on both legs
