### PR TITLE
fix(proxy): price the /v1/messages cost header by the deployment model, not the client alias

### DIFF
--- a/litellm/proxy/common_request_processing.py
+++ b/litellm/proxy/common_request_processing.py
@@ -2551,16 +2551,6 @@ class ProxyBaseLLMRequestProcessing:
                     except Exception as e:
                         verbose_proxy_logger.exception("Error in orphaned streaming async logging: %s", e)
 
-        # Always return the client-requested model name (not provider-prefixed internal identifiers)
-        # for OpenAI-compatible responses.
-        if requested_model_from_client:
-            _override_openai_response_model(
-                response_obj=response,
-                requested_model=requested_model_from_client,
-                log_context=f"litellm_call_id={logging_obj.litellm_call_id}",
-                return_raw_model_name=_should_return_raw_model_name(self.data),
-            )
-
         hidden_params = get_hidden_params_dict(response)  # get any updated response headers
         additional_headers = hidden_params.get("additional_headers", {}) or {}
 
@@ -2585,6 +2575,16 @@ class ProxyBaseLLMRequestProcessing:
             if guardrail_cost_for_headers > 0
             else llm_cost_for_headers
         )
+
+        # Always return the client-requested model name (not provider-prefixed internal identifiers)
+        # for OpenAI-compatible responses.
+        if requested_model_from_client:
+            _override_openai_response_model(
+                response_obj=response,
+                requested_model=requested_model_from_client,
+                log_context=f"litellm_call_id={logging_obj.litellm_call_id}",
+                return_raw_model_name=_should_return_raw_model_name(self.data),
+            )
 
         fastapi_response.headers.update(
             ProxyBaseLLMRequestProcessing.get_custom_headers(

--- a/tests/test_litellm/proxy/test_common_request_processing.py
+++ b/tests/test_litellm/proxy/test_common_request_processing.py
@@ -4710,7 +4710,9 @@ class TestResponseCostHeaderForTypedDictResponses:
         logging_obj._on_deferred_stream_complete = None
         return logging_obj
 
-    async def _drive_non_streaming(self, *, monkeypatch, response, logging_obj, route_type, return_result=False):
+    async def _drive_non_streaming(
+        self, *, monkeypatch, response, logging_obj, route_type, return_result=False, client_model=None
+    ):
         import litellm.proxy.common_request_processing as crp
         from litellm.proxy._types import UserAPIKeyAuth as RealUserAPIKeyAuth
 
@@ -4732,7 +4734,9 @@ class TestResponseCostHeaderForTypedDictResponses:
         proxy_logging_obj.post_call_success_hook = fake_post_call_success_hook
 
         fastapi_response = Response()
-        processing_obj = ProxyBaseLLMRequestProcessing(data={"litellm_logging_obj": logging_obj})
+        processing_obj = ProxyBaseLLMRequestProcessing(
+            data={"litellm_logging_obj": logging_obj, **({"model": client_model} if client_model else {})}
+        )
 
         with patch.object(
             ProxyBaseLLMRequestProcessing,
@@ -4782,6 +4786,48 @@ class TestResponseCostHeaderForTypedDictResponses:
 
         assert fastapi_response.headers["x-litellm-response-cost"] == "0.00123"
         recompute.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_messages_cost_recompute_prices_provider_model_not_client_alias(self, monkeypatch):
+        """
+        Regression for LIT-6339 / GH #38578. The header cost recompute ran after the
+        response model had already been restamped to the client alias, so /v1/messages
+        priced a Together deployment by its alias (tripping the parameter-size bucket)
+        while recorded spend used the registry rate. The recompute must see the
+        provider-reported model; the body must still return the client alias.
+        """
+        from litellm.types.utils import AnthropicMessagesResponse
+
+        response = AnthropicMessagesResponse(
+            id="msg_1",
+            type="message",
+            role="assistant",
+            content=[{"type": "text", "text": "hi"}],
+            model="meta-models/Muse-Glimmer-30B",
+            usage={"input_tokens": 10, "output_tokens": 5},
+        )
+        cost_by_model_at_recompute_time: Final = {
+            "meta-models/Muse-Glimmer-30B": 0.003,
+            "muse-glimmer-30b": 0.007,
+        }
+        recompute = MagicMock(side_effect=lambda result: cost_by_model_at_recompute_time[result["model"]])
+        logging_obj = self._build_logging_obj(
+            model_call_details={},
+            response_cost_calculator=recompute,
+        )
+
+        fastapi_response, result = await self._drive_non_streaming(
+            monkeypatch=monkeypatch,
+            response=response,
+            logging_obj=logging_obj,
+            route_type="anthropic_messages",
+            client_model="muse-glimmer-30b",
+            return_result=True,
+        )
+
+        assert fastapi_response.headers["x-litellm-response-cost"] == "0.003"
+        assert result["model"] == "muse-glimmer-30b"
+        recompute.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_generate_content_typeddict_emits_cost_header_via_recompute(self, monkeypatch):


### PR DESCRIPTION
## TLDR

Problem this solves:

- `/v1/messages` cost header prices the client alias, not the deployment model
- an alias like `muse-glimmer-30b` bills Together's 21.1b-41b bucket at $0.80/M
- header disagrees with recorded spend and with `/v1/chat/completions`
- warm-cache tokens priced at $0 instead of $0.04/M

How it solves it:

- restamp `model` to the alias only after computing the header cost
- cost recompute sees the provider model, so registry and cache rates apply
- regression test pins provider-model pricing while the body keeps the alias

## User Flow

Before: a developer's `/v1/messages` request on a Together deployment whose alias carries a size marker is billed at the size bucket in the cost header, more than double what the same prompt costs on `/v1/chat/completions`

1. A proxy admin adds `model_name: muse-glimmer-30b` mapping to `together_ai/meta-models/Muse-Glimmer-30B`
2. A developer sends POST https://litellm-domain/v1/chat/completions with `"model": "muse-glimmer-30b"` and a ~13k token system prompt; the headers read `x-litellm-response-cost: 0.00053805` for 12735 prompt tokens of which 12720 were cached (15 x $0.35/M + 12720 x $0.04/M + 16 x $1.50/M, the registry rates)
3. They send the same prompt to POST https://litellm-domain/v1/messages with `"model": "muse-glimmer-30b"` and a cache-busting line; the headers read `x-litellm-response-cost: 0.0102112` for 12748 input tokens (12748 x $0.80/M + 16 x $0.80/M, the 21.1b-41b bucket instead of 0.0044858 at the registry rates) and `x-litellm-key-spend` moves by the same amount
4. They send it again without the cache-busting line and Together serves it from cache: `usage` shows `cache_read_input_tokens: 12720`, but the header reads `x-litellm-response-cost: 2.48e-05` with no `x-litellm-response-cost-cache-read`, the 12720 cached tokens priced at $0 instead of $0.04/M

After: the same `/v1/messages` requests bill the registry rates, matching `/v1/chat/completions` and `/v1/responses`

1. A proxy admin adds `model_name: muse-glimmer-30b` mapping to `together_ai/meta-models/Muse-Glimmer-30B`
2. A developer sends POST https://litellm-domain/v1/chat/completions with `"model": "muse-glimmer-30b"` and a ~13k token system prompt; the headers read `x-litellm-response-cost: 0.00053805`, unchanged
3. They send the same prompt to POST https://litellm-domain/v1/messages with `"model": "muse-glimmer-30b"` and a cache-busting line; the headers read `x-litellm-response-cost: 0.00448545` for 12747 input tokens (12747 x $0.35/M + 16 x $1.50/M, the registry rates) and `x-litellm-key-spend` moves by the same amount
4. They send it again without the cache-busting line and Together serves it from cache: `usage` shows `cache_read_input_tokens: 12720` and the header reads `x-litellm-response-cost: 0.00053805` with `x-litellm-response-cost-cache-read: 0.0005088` (12720 x $0.04/M), the same figure the chat completions call produced

## Relevant issues

Fixes #38578

## Linear ticket

Resolves LIT-6339

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Each leg boots its own proxy from a worktree at the named commit with two uvicorn workers, `python litellm/proxy/proxy_cli.py --config lit6339_config.yaml --port <port> --num_workers 2 --detailed_debug` (before on port 38348, after on port 41047), `LITELLM_LOCAL_MODEL_COST_MAP=True` and `TOGETHER_API_KEY` set, no database, config:

```yaml
model_list:
  - model_name: muse-glimmer-30b
    litellm_params:
      model: together_ai/meta-models/Muse-Glimmer-30B
      api_key: os.environ/TOGETHER_API_KEY

general_settings:
  master_key: sk-lit6339-test
```

`muse_chat.json` is `{"model": "muse-glimmer-30b", "messages": [{"role": "system", "content": "<52000 chars of repo markdown>"}, {"role": "user", "content": "Reply with the word ready and nothing else."}], "max_tokens": 16}`. `muse_responses.json` carries the same corpus as `instructions` with `"input": "Reply with the word ready and nothing else."` and `"max_output_tokens": 16`. `muse_messages.json` carries it as `system` with `"messages": [{"role": "user", "content": "Reply with the word ready and nothing else."}]` and `"max_tokens": 16`. `muse_messages_nocache.json` is the same with a fresh random nonce line prepended to `system` per leg so Together's prefix cache misses. Registry rates for `together_ai/meta-models/Muse-Glimmer-30B`: $0.35/M input, $0.04/M cached input, $1.50/M output; the `together-ai-21.1b-41b` bucket is $0.80/M in and out with no cached rate. The four requests run in the order shown, so the chat call warms Together's cache for the warm `/v1/messages` case

### Before (4d9025c2bf)

#### /v1/chat/completions (control)

1. `curl -s -D - -o chat_body.json http://127.0.0.1:38348/v1/chat/completions -H 'Authorization: Bearer sk-lit6339-test' -H 'Content-Type: application/json' -d @muse_chat.json | grep -i -E '^x-litellm-(response-cost(-input|-output|-cache-read)?|model-name|key-spend):'`
2. Output:
   ```
   HTTP/1.1 200 OK
   x-litellm-model-name: together_ai/meta-models/Muse-Glimmer-30B
   x-litellm-response-cost: 0.0005380500000000001
   x-litellm-response-cost-input: 5.250000000000046e-06
   x-litellm-response-cost-output: 2.4e-05
   x-litellm-response-cost-cache-read: 0.0005088
   x-litellm-key-spend: 0.0005380500000000001
   ```
   body `model`: `muse-glimmer-30b`, `usage`: `{"completion_tokens": 16, "prompt_tokens": 12735, "total_tokens": 12751, "prompt_tokens_details": {"cached_tokens": 12720, "created_cache_tokens": 0}}`
3. registry: 15 x $0.35/M + 12720 x $0.04/M + 16 x $1.50/M = 0.00053805; bucket: 15 x $0.80/M + 16 x $0.80/M with cached tokens at $0 = 0.0000248; header matches the registry rate

#### /v1/responses (control)

1. `curl -s -D - -o responses_body.json http://127.0.0.1:38348/v1/responses -H 'Authorization: Bearer sk-lit6339-test' -H 'Content-Type: application/json' -d @muse_responses.json | grep -i -E '^x-litellm-(response-cost(-input|-output|-cache-read)?|model-name|key-spend):'`
2. Output:
   ```
   HTTP/1.1 200 OK
   x-litellm-model-name: together_ai/meta-models/Muse-Glimmer-30B
   x-litellm-response-cost: 0.0005380500000000001
   x-litellm-response-cost-input: 5.250000000000046e-06
   x-litellm-response-cost-output: 2.4e-05
   x-litellm-response-cost-cache-read: 0.0005088
   x-litellm-key-spend: 0.0005380500000000001
   ```
   body `model`: `muse-glimmer-30b`, `usage`: `{"input_tokens": 12735, "input_tokens_details": {"audio_tokens": null, "cached_tokens": 12720, "text_tokens": null}, "output_tokens": 16, "output_tokens_details": null, "total_tokens": 12751, "cost": null}`
3. registry: 15 x $0.35/M + 12720 x $0.04/M + 16 x $1.50/M = 0.00053805; bucket: 15 x $0.80/M + 16 x $0.80/M with cached tokens at $0 = 0.0000248; header matches the registry rate

#### /v1/messages, cold cache

1. `curl -s -D - -o messages_cold_body.json http://127.0.0.1:38348/v1/messages -H 'Authorization: Bearer sk-lit6339-test' -H 'Content-Type: application/json' -d @muse_messages_nocache.json | grep -i -E '^x-litellm-(response-cost(-input|-output|-cache-read)?|model-name|key-spend):'`
2. Output:
   ```
   HTTP/1.1 200 OK
   x-litellm-model-name: together_ai/meta-models/Muse-Glimmer-30B
   x-litellm-response-cost: 0.0102112
   x-litellm-response-cost-input: 0.0101984
   x-litellm-response-cost-output: 1.28e-05
   x-litellm-key-spend: 0.0102112
   ```
   body `model`: `muse-glimmer-30b`, `usage`: `{"input_tokens": 12748, "output_tokens": 16}`
3. registry: 12748 x $0.35/M + 16 x $1.50/M = 0.0044858; bucket: 12748 x $0.80/M + 16 x $0.80/M = 0.0102112; header matches the 21.1b-41b bucket

#### /v1/messages, warm cache

1. `curl -s -D - -o messages_warm_body.json http://127.0.0.1:38348/v1/messages -H 'Authorization: Bearer sk-lit6339-test' -H 'Content-Type: application/json' -d @muse_messages.json | grep -i -E '^x-litellm-(response-cost(-input|-output|-cache-read)?|model-name|key-spend):'`
2. Output:
   ```
   HTTP/1.1 200 OK
   x-litellm-model-name: together_ai/meta-models/Muse-Glimmer-30B
   x-litellm-response-cost: 2.48e-05
   x-litellm-response-cost-input: 1.2e-05
   x-litellm-response-cost-output: 1.28e-05
   x-litellm-key-spend: 2.48e-05
   ```
   body `model`: `muse-glimmer-30b`, `usage`: `{"input_tokens": 15, "output_tokens": 16, "cache_read_input_tokens": 12720}`
3. registry: 15 x $0.35/M + 12720 x $0.04/M + 16 x $1.50/M = 0.00053805; bucket: 15 x $0.80/M + 16 x $0.80/M with cached tokens at $0 = 0.0000248; header matches the 21.1b-41b bucket

### After (3daf7a3095)

#### /v1/chat/completions (control)

1. `curl -s -D - -o chat_body.json http://127.0.0.1:41047/v1/chat/completions -H 'Authorization: Bearer sk-lit6339-test' -H 'Content-Type: application/json' -d @muse_chat.json | grep -i -E '^x-litellm-(response-cost(-input|-output|-cache-read)?|model-name|key-spend):'`
2. Output:
   ```
   HTTP/1.1 200 OK
   x-litellm-model-name: together_ai/meta-models/Muse-Glimmer-30B
   x-litellm-response-cost: 0.0005380500000000001
   x-litellm-response-cost-input: 5.250000000000046e-06
   x-litellm-response-cost-output: 2.4e-05
   x-litellm-response-cost-cache-read: 0.0005088
   x-litellm-key-spend: 0.0005380500000000001
   ```
   body `model`: `muse-glimmer-30b`, `usage`: `{"completion_tokens": 16, "prompt_tokens": 12735, "total_tokens": 12751, "prompt_tokens_details": {"cached_tokens": 12720, "created_cache_tokens": 0}}`
3. registry: 15 x $0.35/M + 12720 x $0.04/M + 16 x $1.50/M = 0.00053805; bucket: 15 x $0.80/M + 16 x $0.80/M with cached tokens at $0 = 0.0000248; header matches the registry rate

#### /v1/responses (control)

1. `curl -s -D - -o responses_body.json http://127.0.0.1:41047/v1/responses -H 'Authorization: Bearer sk-lit6339-test' -H 'Content-Type: application/json' -d @muse_responses.json | grep -i -E '^x-litellm-(response-cost(-input|-output|-cache-read)?|model-name|key-spend):'`
2. Output:
   ```
   HTTP/1.1 200 OK
   x-litellm-model-name: together_ai/meta-models/Muse-Glimmer-30B
   x-litellm-response-cost: 0.0005380500000000001
   x-litellm-response-cost-input: 5.250000000000046e-06
   x-litellm-response-cost-output: 2.4e-05
   x-litellm-response-cost-cache-read: 0.0005088
   x-litellm-key-spend: 0.0005380500000000001
   ```
   body `model`: `muse-glimmer-30b`, `usage`: `{"input_tokens": 12735, "input_tokens_details": {"audio_tokens": null, "cached_tokens": 12720, "text_tokens": null}, "output_tokens": 16, "output_tokens_details": null, "total_tokens": 12751, "cost": null}`
3. registry: 15 x $0.35/M + 12720 x $0.04/M + 16 x $1.50/M = 0.00053805; bucket: 15 x $0.80/M + 16 x $0.80/M with cached tokens at $0 = 0.0000248; header matches the registry rate

#### /v1/messages, cold cache

1. `curl -s -D - -o messages_cold_body.json http://127.0.0.1:41047/v1/messages -H 'Authorization: Bearer sk-lit6339-test' -H 'Content-Type: application/json' -d @muse_messages_nocache.json | grep -i -E '^x-litellm-(response-cost(-input|-output|-cache-read)?|model-name|key-spend):'`
2. Output:
   ```
   HTTP/1.1 200 OK
   x-litellm-model-name: together_ai/meta-models/Muse-Glimmer-30B
   x-litellm-response-cost: 0.004485449999999999
   x-litellm-response-cost-input: 0.00446145
   x-litellm-response-cost-output: 2.4e-05
   x-litellm-key-spend: 0.004485449999999999
   ```
   body `model`: `muse-glimmer-30b`, `usage`: `{"input_tokens": 12747, "output_tokens": 16}`
3. registry: 12747 x $0.35/M + 16 x $1.50/M = 0.00448545; bucket: 12747 x $0.80/M + 16 x $0.80/M = 0.0102104; header matches the registry rate

#### /v1/messages, warm cache

1. `curl -s -D - -o messages_warm_body.json http://127.0.0.1:41047/v1/messages -H 'Authorization: Bearer sk-lit6339-test' -H 'Content-Type: application/json' -d @muse_messages.json | grep -i -E '^x-litellm-(response-cost(-input|-output|-cache-read)?|model-name|key-spend):'`
2. Output:
   ```
   HTTP/1.1 200 OK
   x-litellm-model-name: together_ai/meta-models/Muse-Glimmer-30B
   x-litellm-response-cost: 0.0005380500000000001
   x-litellm-response-cost-input: 5.250000000000046e-06
   x-litellm-response-cost-output: 2.4e-05
   x-litellm-response-cost-cache-read: 0.0005088
   x-litellm-key-spend: 0.0005380500000000001
   ```
   body `model`: `muse-glimmer-30b`, `usage`: `{"input_tokens": 15, "output_tokens": 16, "cache_read_input_tokens": 12720}`
3. registry: 15 x $0.35/M + 12720 x $0.04/M + 16 x $1.50/M = 0.00053805; bucket: 15 x $0.80/M + 16 x $0.80/M with cached tokens at $0 = 0.0000248; header matches the registry rate

Observations from the run, none caused by this PR:

- Assistant text empty at max_tokens 16 on every endpoint, both legs; left alone
- `/v1/messages` headers omit `x-litellm-model-api-base`, both legs; left alone
- Chat and responses controls hit Together's cache from earlier runs; left alone

## Type

🐛 Bug Fix

## Caveats (if any)

### Low

- Only the non-streaming header path moved; streaming `/v1/messages` never carried a cost header, so nothing changes there
- Callbacks that read the response after the headers hook still see the client alias in `model`, same as before
- With the `run-ci` label, `ci/circleci: logging_testing` is red; pre-existing: the same 4 tests fail at the merge base locally, and the job is red on 6 of the last 8 run-ci PRs. Every other CircleCI job (122) is green, including `proxy_e2e_anthropic_messages_tests` and `proxy_spend_accuracy_tests`

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

- [x] 3daf7a3095 passes /live-pr-risk
