### PR TITLE
fix(ci): fall back to github.token when the GH_TOKEN secret is unset in the Together sync workflow

### DIFF
--- a/.github/workflows/sync-together-ai-models.yml
+++ b/.github/workflows/sync-together-ai-models.yml
@@ -32,7 +32,7 @@ jobs:
             echo "An open sync PR already exists on branch $open_pr; skipping this run."
           fi
         env:
-          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          GH_TOKEN: ${{ secrets.GH_TOKEN || github.token }}
       - name: Run the sync
         if: steps.existing.outputs.open_pr == ''
         run: |
@@ -65,4 +65,4 @@ jobs:
             --head "$branch" \
             --base litellm_internal_staging
         env:
-          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          GH_TOKEN: ${{ secrets.GH_TOKEN || github.token }}


### PR DESCRIPTION
## TLDR

Problem this solves:

- The daily Together AI registry sync workflow failed on every run
- Both `gh` steps read the nonexistent `GH_TOKEN` repo secret
- `gh` exits 4 on an empty `GH_TOKEN`, so no sync PR could ever open

How it solves it:

- Fall back to the built-in `github.token` when the secret is unset
- `GH_TOKEN: ${{ secrets.GH_TOKEN || github.token }}` on both `gh` steps

## User Flow

Before: the daily sync never delivers a PR, so the Together AI registry drifts stale

1. The 06:30 UTC cron fires the "Sync Together AI model registry" workflow
2. The maintainer opens https://github.com/BerriAI/litellm/actions/runs/33160873909 and sees the run failed at its first step with "gh: To use GitHub CLI in a GitHub Actions workflow, set the GH_TOKEN environment variable." and exit code 4
3. No `litellm_together_registry_sync_*` PR appears in https://github.com/BerriAI/litellm/pulls, so stale Together AI prices and context windows stay live

After: the same run completes and hands the maintainer a review-ready sync PR

1. The 06:30 UTC cron (or a manual dispatch) fires the same workflow
2. The maintainer opens https://github.com/BerriAI/litellm/actions/runs/33204191332 and sees every step green
3. https://github.com/BerriAI/litellm/pull/38694 appears with the day's real registry diff (corrected gpt-oss-20b context window, updated Qwen3.8 pricing), ready to review and merge

## Relevant issues

## Linear ticket

Resolves LIT-6407

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have added meaningful tests (workflow YAML has no unit-test surface; the live `workflow_dispatch` runs below are the proof)
- [ ] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

### Before (936e07b0a5)

1. Dispatch the workflow at the staging head, which the first scheduled run (33160873909, 2026-08-28 09:48 UTC) had already failed identically:

```
gh workflow run sync-together-ai-models.yml --ref litellm_internal_staging
# -> https://github.com/BerriAI/litellm/actions/runs/33203448985  completed / failure
```

2. The failing step is "Look for an already-open sync PR", the workflow's first `gh` call:

```
gh run view 33203448985 --log-failed | grep -E 'GH_TOKEN|gh: To use|exit code'
#   env:
#     GH_TOKEN:
#   gh: To use GitHub CLI in a GitHub Actions workflow, set the GH_TOKEN environment variable.
#   ##[error]Process completed with exit code 4.
```

3. Every later step (Run the sync, Regenerate the JSON schema, Create a pull request when the registry changed) is skipped, so no sync PR exists

### After (f46f66d101)

1. Dispatch the workflow from this PR's branch:

```
gh workflow run sync-together-ai-models.yml --ref litellm_fix_together_sync_gh_token
# -> https://github.com/BerriAI/litellm/actions/runs/33204191332  completed / success
```

2. Every step now succeeds, and the step env shows a masked (present) token instead of an empty one:

```
gh run view 33204191332 --json conclusion,jobs -q '.conclusion, (.jobs[].steps[] | "\(.conclusion) \(.name)")'
# success
# success Look for an already-open sync PR
# success Run the sync
# success Regenerate the JSON schema
# success Create a pull request when the registry changed
#   (step env: GH_TOKEN: ***)
```

3. The run pushed `litellm_together_registry_sync_2026-08-28` and opened a real sync PR with the day's registry diff: https://github.com/BerriAI/litellm/pull/38694

4. An earlier dispatch from this branch (run 33203712175) already passed the fixed `gh` step but failed at "Run the sync" because the `TOGETHER_API_KEY` repo secret was also missing (the caveat PR #38257 shipped with); that secret was provisioned on 2026-08-28, and the run above is the clean end-to-end pass

## Type

🐛 Bug Fix
🚄 Infrastructure

## Caveats (if any)

### Medium

- Sync PRs open under the built-in token, so required CI never auto-triggers
  - A maintainer close/reopen triggers it (done on #38694), or add a `GH_TOKEN` PAT secret

### Low

- The `TOGETHER_API_KEY` repo secret was also missing; provisioned 2026-08-28

## Final Attestation

- [ ] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR (no tests to attest; the daily scheduled run is the regression surface, and it now fails loudly instead of silently skipping the sync)

CHECKED: /live-pr-risk at f46f66d101: SAFE. No in-repo dependents beyond the workflow itself; a later `GH_TOKEN` secret takes precedence over the fallback; cron leg unexercised but evaluates the same expression the passing dispatch did; bot-token PR caveat verified live on #38694 and mitigated by close/reopen
