### PR TITLE
fix(streaming): report response_cost and Anthropic citations from stream_chunk_builder

### DIFF
--- a/litellm/litellm_core_utils/streaming_handler.py
+++ b/litellm/litellm_core_utils/streaming_handler.py
@@ -2338,6 +2338,7 @@ class CustomStreamWrapper:
             partial_response: Final = litellm.stream_chunk_builder(
                 chunks=self.chunks,
                 messages=self.messages if isinstance(self.messages, list) else None,
+                logging_obj=self.logging_obj,
             )
             if partial_response is None:
                 return

--- a/litellm/main.py
+++ b/litellm/main.py
@@ -8602,6 +8602,18 @@ def _stream_builder_response_cost(response: ModelResponse, logging_obj: Optional
     try:
         return litellm.completion_cost(completion_response=response, custom_llm_provider=provider_hint)
     except Exception:
+        return _stream_builder_model_map_cost(response)
+
+
+def _stream_builder_model_map_cost(response: ModelResponse) -> float | None:
+    model_name: Final = getattr(response, "model", None)
+    usage: Final = getattr(response, "usage", None)
+    if not isinstance(model_name, str) or not model_name or not isinstance(usage, Usage):
+        return None
+    try:
+        prompt_cost, completion_tokens_cost = litellm.cost_per_token(model=model_name, usage_object=usage)
+        return prompt_cost + completion_tokens_cost
+    except Exception:  # noqa: BLE001  # cost_per_token raises bare Exception for unpriceable models
         return None
 
 

--- a/litellm/main.py
+++ b/litellm/main.py
@@ -8590,6 +8590,29 @@ def stream_chunk_builder_text_completion(chunks: list, messages: list | None = N
     return TextCompletionResponse(**response)
 
 
+def _stream_builder_response_cost(response: ModelResponse, logging_obj: Optional["Logging"]) -> float | None:
+    usage_cost: Final = getattr(getattr(response, "usage", None), "cost", None)
+    if isinstance(usage_cost, (int, float)):
+        return float(usage_cost)
+    if logging_obj is not None:
+        return None
+    provider_hint: Final = response._hidden_params.get(  # pyright: ignore[reportPrivateUsage]  # no public accessor
+        "custom_llm_provider"
+    )
+    try:
+        return litellm.completion_cost(completion_response=response, custom_llm_provider=provider_hint)
+    except Exception:
+        return None
+
+
+def _set_stream_builder_response_cost(response: ModelResponse, logging_obj: Optional["Logging"]) -> None:
+    response_cost: Final = _stream_builder_response_cost(response, logging_obj)
+    if response_cost is None:
+        return
+    hidden_params: Final = response._hidden_params  # pyright: ignore[reportPrivateUsage]  # no public accessor
+    hidden_params["response_cost"] = response_cost
+
+
 def stream_chunk_builder(
     chunks: list,
     messages: list | None = None,
@@ -8690,6 +8713,8 @@ def stream_chunk_builder(
                     "cost",
                     logging_obj._response_cost_calculator(result=response),
                 )
+            _set_stream_builder_response_cost(response, logging_obj)
+
             processor.apply_provider_assembled_streaming_metadata(response, chunks, logging_obj)
             return response
 
@@ -8814,18 +8839,24 @@ def stream_chunk_builder(
         ]
 
         if len(provider_specific_chunks) > 0:
-            combined_provider_fields: Final[dict[str, object]] = {}
-            for chunk in provider_specific_chunks:
-                fields = chunk["choices"][0]["delta"]["provider_specific_fields"]
-                if isinstance(fields, dict):
-                    for key, value in fields.items():
-                        if key not in combined_provider_fields:
-                            combined_provider_fields[key] = value
-                        elif isinstance(value, list) and isinstance(combined_provider_fields[key], list):
-                            # For lists like web_search_results, take the last (most complete) one
-                            combined_provider_fields[key] = value
-                        else:
-                            combined_provider_fields[key] = value
+            provider_field_dicts: Final = tuple(
+                fields
+                for chunk in provider_specific_chunks
+                for fields in (chunk["choices"][0]["delta"]["provider_specific_fields"],)
+                if isinstance(fields, dict)
+            )
+            streamed_citations: Final = tuple(
+                fields["citation"] for fields in provider_field_dicts if fields.get("citation") is not None
+            )
+            citation_fields: Final = (
+                {"citations": [list(streamed_citations)]} if streamed_citations else {}  # mutable-ok: JSON dict field
+            )
+            combined_provider_fields: Final = {  # mutable-ok: Message.provider_specific_fields is a plain dict field
+                key: value
+                for fields in (citation_fields, *provider_field_dicts)
+                for key, value in fields.items()
+                if key != "citation"
+            }
 
             if combined_provider_fields:
                 _choice = cast(Choices, response.choices[0])
@@ -8861,6 +8892,8 @@ def stream_chunk_builder(
         # Add cost to usage object if include_cost_in_streaming_usage is True
         if litellm.include_cost_in_streaming_usage and logging_obj is not None:
             setattr(usage, "cost", logging_obj._response_cost_calculator(result=response))
+
+        _set_stream_builder_response_cost(response, logging_obj)
 
         processor.apply_provider_assembled_streaming_metadata(response, chunks, logging_obj)
         return response

--- a/litellm/main.py
+++ b/litellm/main.py
@@ -8605,6 +8605,12 @@ def _stream_builder_response_cost(response: ModelResponse, logging_obj: Optional
         return _stream_builder_model_map_cost(response)
 
 
+def _joined_streamed_citations(streamed_citations: "tuple[object, ...]") -> "list[object]":
+    if all(isinstance(citation, list) for citation in streamed_citations):
+        return list(streamed_citations)  # mutable-ok: JSON list field
+    return [list(streamed_citations)]  # mutable-ok: JSON list field
+
+
 def _stream_builder_model_map_cost(response: ModelResponse) -> float | None:
     model_name: Final = getattr(response, "model", None)
     usage: Final = getattr(response, "usage", None)
@@ -8861,7 +8867,9 @@ def stream_chunk_builder(
                 fields["citation"] for fields in provider_field_dicts if fields.get("citation") is not None
             )
             citation_fields: Final = (
-                {"citations": [list(streamed_citations)]} if streamed_citations else {}  # mutable-ok: JSON dict field
+                {"citations": _joined_streamed_citations(streamed_citations)}  # mutable-ok: JSON dict field
+                if streamed_citations
+                else {}  # mutable-ok: JSON dict field
             )
             combined_provider_fields: Final = {  # mutable-ok: Message.provider_specific_fields is a plain dict field
                 key: value

--- a/tests/test_litellm/litellm_core_utils/test_streaming_handler.py
+++ b/tests/test_litellm/litellm_core_utils/test_streaming_handler.py
@@ -3469,6 +3469,21 @@ def test_record_partial_usage_for_failure_backfills_missing_cache_fields():
     assert stashed.prompt_tokens_details.cached_tokens == 0
 
 
+def test_record_partial_usage_for_failure_prices_corrected_model_not_chunk_model():
+    wrapper, logging_obj = _wrapper_with_partial_chunks(
+        chunk_model="claude-opus-5",
+        usage=Usage(prompt_tokens=40, completion_tokens=5, total_tokens=45),
+        model="gpt-4o-mini",
+        custom_llm_provider="openai",
+    )
+
+    wrapper._record_partial_usage_for_failure()
+
+    rates = litellm.model_cost["gpt-4o-mini"]
+    expected = 40 * rates["input_cost_per_token"] + 5 * rates["output_cost_per_token"]
+    assert logging_obj.model_call_details["response_cost"] == pytest.approx(expected)
+
+
 def test_record_partial_usage_for_failure_carries_up_openai_style_cached_tokens():
     recovered = Usage(
         prompt_tokens=1000,

--- a/tests/test_litellm/test_main.py
+++ b/tests/test_litellm/test_main.py
@@ -3113,6 +3113,24 @@ def test_stream_chunk_builder_unknown_model_leaves_response_cost_unset():
     assert response.choices[0].message.content == "Hello world."
 
 
+def test_stream_chunk_builder_prices_proxy_alias_via_model_map():
+    chunks: Final = [
+        _stream_builder_text_chunk("claude-opus-5", "Hello "),
+        _stream_builder_text_chunk("claude-opus-5", "world.", finish_reason="stop"),
+    ]
+    for chunk in chunks:
+        chunk._hidden_params = {"custom_llm_provider": "openai"}
+
+    response: Final = litellm.stream_chunk_builder(chunks=chunks, messages=[{"role": "user", "content": "hi"}])
+
+    assert response is not None
+    assert response._hidden_params["custom_llm_provider"] == "openai"
+    prompt_cost, completion_cost = litellm.cost_per_token(model="claude-opus-5", usage_object=response.usage)
+    expected_cost: Final = prompt_cost + completion_cost
+    assert expected_cost > 0
+    assert response._hidden_params["response_cost"] == pytest.approx(expected_cost)
+
+
 def _stream_builder_logging_obj() -> LiteLLMLogging:
     logging_obj: Final = LiteLLMLogging(
         model="gpt-4o",

--- a/tests/test_litellm/test_main.py
+++ b/tests/test_litellm/test_main.py
@@ -1,5 +1,6 @@
 import asyncio
 import base64
+from datetime import datetime
 import contextlib
 import copy
 import json
@@ -21,7 +22,8 @@ import litellm
 from litellm import main as litellm_main
 from litellm.integrations.custom_logger import CustomLogger
 from litellm.litellm_core_utils.core_helpers import get_litellm_metadata_from_kwargs
-from litellm.types.utils import Usage
+from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLogging
+from litellm.types.utils import Delta, ModelResponseStream, StreamingChoices, Usage
 
 
 async def _async_fake_bedrock_image_details(image_url):
@@ -3071,3 +3073,93 @@ async def test_aspeech_gemini_bridge_keeps_proxy_metadata_for_spend_tracking(
     assert expected_cost > 0
     assert speech_event.response_cost == pytest.approx(expected_cost)
     assert speech_event.logged_response_cost == pytest.approx(expected_cost)
+
+
+def _stream_builder_text_chunk(model: str, content: str, finish_reason: str | None = None) -> ModelResponseStream:
+    return ModelResponseStream(
+        id="chatcmpl-cost",
+        created=1724900000,
+        model=model,
+        object="chat.completion.chunk",
+        choices=[StreamingChoices(finish_reason=finish_reason, index=0, delta=Delta(content=content, role="assistant"))],
+    )
+
+
+def test_stream_chunk_builder_sets_hidden_response_cost_for_known_model():
+    chunks: Final = [
+        _stream_builder_text_chunk("gpt-4o", "Hello "),
+        _stream_builder_text_chunk("gpt-4o", "world.", finish_reason="stop"),
+    ]
+
+    response: Final = litellm.stream_chunk_builder(chunks=chunks, messages=[{"role": "user", "content": "hi"}])
+
+    assert response is not None
+    prompt_cost, completion_cost = litellm.cost_per_token(model="gpt-4o", usage_object=response.usage)
+    expected_cost: Final = prompt_cost + completion_cost
+    assert expected_cost > 0
+    assert response._hidden_params["response_cost"] == pytest.approx(expected_cost)
+
+
+def test_stream_chunk_builder_unknown_model_leaves_response_cost_unset():
+    chunks: Final = [
+        _stream_builder_text_chunk("totally-unknown-model-xyz", "Hello "),
+        _stream_builder_text_chunk("totally-unknown-model-xyz", "world.", finish_reason="stop"),
+    ]
+
+    response: Final = litellm.stream_chunk_builder(chunks=chunks, messages=[{"role": "user", "content": "hi"}])
+
+    assert response is not None
+    assert response._hidden_params.get("response_cost") is None
+    assert response.choices[0].message.content == "Hello world."
+
+
+def _stream_builder_logging_obj() -> LiteLLMLogging:
+    logging_obj: Final = LiteLLMLogging(
+        model="gpt-4o",
+        messages=[{"role": "user", "content": "hi"}],
+        stream=True,
+        call_type="completion",
+        start_time=datetime.now(),
+        litellm_call_id="test-call-id",
+        function_id="test-function-id",
+    )
+    logging_obj.update_environment_variables(
+        model="gpt-4o",
+        user=None,
+        optional_params={},
+        litellm_params={"custom_llm_provider": "openai"},
+    )
+    return logging_obj
+
+
+def test_stream_chunk_builder_reports_streaming_usage_cost_when_enabled(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(litellm, "include_cost_in_streaming_usage", True)
+    chunks: Final = [
+        _stream_builder_text_chunk("gpt-4o", "Hello "),
+        _stream_builder_text_chunk("gpt-4o", "world.", finish_reason="stop"),
+    ]
+
+    response: Final = litellm.stream_chunk_builder(
+        chunks=chunks, messages=[{"role": "user", "content": "hi"}], logging_obj=_stream_builder_logging_obj()
+    )
+
+    assert response is not None
+    usage_cost: Final = getattr(response.usage, "cost", None)
+    assert usage_cost is not None
+    assert usage_cost > 0
+    assert response._hidden_params["response_cost"] == pytest.approx(usage_cost)
+
+
+def test_stream_chunk_builder_defers_cost_to_logging_obj_when_usage_cost_absent(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(litellm, "include_cost_in_streaming_usage", False)
+    chunks: Final = [
+        _stream_builder_text_chunk("gpt-4o", "Hello "),
+        _stream_builder_text_chunk("gpt-4o", "world.", finish_reason="stop"),
+    ]
+
+    response: Final = litellm.stream_chunk_builder(
+        chunks=chunks, messages=[{"role": "user", "content": "hi"}], logging_obj=_stream_builder_logging_obj()
+    )
+
+    assert response is not None
+    assert response._hidden_params.get("response_cost") is None

--- a/tests/test_litellm/test_stream_chunk_builder_citations.py
+++ b/tests/test_litellm/test_stream_chunk_builder_citations.py
@@ -83,3 +83,22 @@ def test_stream_chunk_builder_without_citation_deltas_sets_no_citations_key():
     assert fields is not None
     assert "citations" not in fields
     assert fields["web_search_results"] == [{"url": "https://example.com"}]
+
+
+def test_stream_chunk_builder_keeps_block_list_citation_deltas_unnested():
+    block_one: Final = [dict(_CITATION_ONE), dict(_CITATION_TWO)]
+    block_two: Final = [dict(_CITATION_ONE)]
+    chunks: Final = [
+        _chunk(Delta(content="Green sky.", role="assistant")),
+        _chunk(Delta(content="", provider_specific_fields={"citation": block_one})),
+        _chunk(Delta(content="", provider_specific_fields={"citation": block_two})),
+        _chunk(Delta(content=""), finish_reason="stop"),
+    ]
+
+    response: Final = stream_chunk_builder(chunks=chunks)
+
+    assert response is not None
+    fields: Final = response.choices[0].message.provider_specific_fields
+    assert fields is not None
+    assert fields["citations"] == [block_one, block_two]
+    assert "citation" not in fields

--- a/tests/test_litellm/test_stream_chunk_builder_citations.py
+++ b/tests/test_litellm/test_stream_chunk_builder_citations.py
@@ -1,0 +1,85 @@
+from typing import Final
+
+from litellm import stream_chunk_builder
+from litellm.types.utils import Delta, ModelResponseStream, StreamingChoices
+
+_CITATION_ONE: Final = {
+    "type": "char_location",
+    "cited_text": "The grass is green.",
+    "document_index": 0,
+    "document_title": "My Document",
+    "start_char_index": 0,
+    "end_char_index": 20,
+}
+_CITATION_TWO: Final = {
+    "type": "char_location",
+    "cited_text": "The sky is blue.",
+    "document_index": 0,
+    "document_title": "My Document",
+    "start_char_index": 20,
+    "end_char_index": 36,
+}
+
+
+def _chunk(delta: Delta, finish_reason: str | None = None) -> ModelResponseStream:
+    return ModelResponseStream(
+        id="chatcmpl-citations",
+        created=1724900000,
+        model="claude-opus-5",
+        object="chat.completion.chunk",
+        choices=[StreamingChoices(finish_reason=finish_reason, index=0, delta=delta)],
+    )
+
+
+def test_stream_chunk_builder_collects_every_streamed_citation():
+    chunks: Final = [
+        _chunk(Delta(content="The grass is green", role="assistant")),
+        _chunk(Delta(content="", provider_specific_fields={"citation": _CITATION_ONE})),
+        _chunk(Delta(content=" and the sky is blue.")),
+        _chunk(Delta(content="", provider_specific_fields={"citation": _CITATION_TWO})),
+        _chunk(Delta(content=""), finish_reason="stop"),
+    ]
+
+    response: Final = stream_chunk_builder(chunks=chunks)
+
+    assert response is not None
+    fields: Final = response.choices[0].message.provider_specific_fields
+    assert fields is not None
+    assert fields["citations"] == [[_CITATION_ONE, _CITATION_TWO]]
+    assert "citation" not in fields
+    assert response.choices[0].message.content == "The grass is green and the sky is blue."
+
+
+def test_stream_chunk_builder_keeps_other_provider_fields_alongside_citations():
+    thinking_blocks: Final = [{"type": "thinking", "thinking": "checking the document", "signature": "sig"}]
+    chunks: Final = [
+        _chunk(Delta(content="Green.", role="assistant")),
+        _chunk(Delta(content="", provider_specific_fields={"citation": _CITATION_ONE})),
+        _chunk(Delta(content="", provider_specific_fields={"thinking_blocks": thinking_blocks})),
+        _chunk(Delta(content=""), finish_reason="stop"),
+    ]
+
+    response: Final = stream_chunk_builder(chunks=chunks)
+
+    assert response is not None
+    fields: Final = response.choices[0].message.provider_specific_fields
+    assert fields is not None
+    assert fields["citations"] == [[_CITATION_ONE]]
+    assert fields["thinking_blocks"] == thinking_blocks
+    assert "citation" not in fields
+
+
+def test_stream_chunk_builder_without_citation_deltas_sets_no_citations_key():
+    chunks: Final = [
+        _chunk(Delta(content="Hello", role="assistant")),
+        _chunk(Delta(content="", provider_specific_fields={"web_search_results": [{"url": "https://example.com"}]})),
+        _chunk(Delta(content=""), finish_reason="stop"),
+    ]
+
+    response: Final = stream_chunk_builder(chunks=chunks)
+
+    assert response is not None
+    fields: Final = response.choices[0].message.provider_specific_fields
+    assert fields is not None
+    assert "citations" not in fields
+    assert fields["web_search_results"] == [{"url": "https://example.com"}]


### PR DESCRIPTION
## TLDR

Problem this solves:

- Responses joined from streamed chunks carry no response cost
- DSPy's `track_usage` records `cost: None` for every streamed call
- Streamed Anthropic citations are dropped when chunks are joined

How it solves it:

- The joined response now carries its response cost in hidden params
- Provider-reported usage cost wins; otherwise litellm prices the usage, falling back to the bare model name in the model map when the declared provider can't price it (models aliased through a LiteLLM proxy)
- Citation deltas are collected into the final message's `citations` list
- Block-list citation deltas (Databricks) join without extra nesting, matching the non-streamed shape
- Internal joins that feed the proxy's logging pipeline (mid-stream failure spend recovery) now declare their logging object, so failure spend keeps coming from the full cost pipeline (custom pricing, corrected model) instead of a cost stamped from the raw chunk model

## User Flow

Before: a DSPy developer who turns on streaming loses cost tracking and citations

1. They wrap their program in `dspy.streamify(dspy.Predict("question -> answer"))` with `track_usage=True` and `dspy.LM("anthropic/claude-opus-5", cache=False)`
2. DSPy sends POST https://api.anthropic.com/v1/messages with `"stream": true` and the answer streams back fine
3. `lm.history[-1]["cost"]` reads `None`, so their spend tracking records nothing, while the identical non-streamed call records 0.00306
4. With a document attached and citations enabled, they watch citation deltas arrive in the stream, yet the final prediction's citations come back empty, while the identical non-streamed call returns the citation

After: the same streamed program reports real spend and keeps its citations

1. They wrap their program in `dspy.streamify(dspy.Predict("question -> answer"))` with `track_usage=True` and `dspy.LM("anthropic/claude-opus-5", cache=False)`
2. DSPy sends POST https://api.anthropic.com/v1/messages with `"stream": true` and the answer streams back fine
3. `lm.history[-1]["cost"]` now reads 0.00318, in line with the non-streamed call
4. The final prediction carries every citation that streamed by

## Relevant issues

## Linear ticket

Resolves LIT-6376

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Legs: before at the merge base 936e07b0a5, after at this PR's head 9b1b8e7ea2. Same client both sides: DSPy 3.3.1 driving real Anthropic, OpenAI, Gemini, and Bedrock APIs, no mocks. SDK cases call providers directly. Proxy cases boot one proxy instance from the leg's commit with `--num_workers 2` (no DB) on a random localhost port, with the client litellm at the same commit and models exposed as OpenAI-compatible aliases (`gpt-5.6`, `claude-opus-5`; the after leg also drives `gemini-3.7-flash`). `stream_chunk_builder` only joins chat-completions-shaped streams (SDK joining and proxy chat logging); /v1/messages and /v1/responses have their own assemblers and never ride this code, so those endpoints are out of scope here

Streamed cost, run with DSPy exactly as an end user would:

```bash
python - <<'PY'
import asyncio
import dspy

lm = dspy.LM("anthropic/claude-opus-5", cache=False)
dspy.configure(lm=lm, track_usage=True)
program = dspy.streamify(dspy.Predict("question -> answer"))

async def run():
    async for _ in program(question="Why is the sky blue? One sentence."):
        pass

asyncio.run(run())
print("cost:", lm.history[-1]["cost"])
PY
```

Same thing through a LiteLLM proxy, pointing DSPy at the alias:

```python
lm = dspy.LM("openai/claude-opus-5", api_base="http://localhost:<port>/v1", api_key=MASTER_KEY, cache=False)
```

Streamed citations, run against the live Anthropic API:

```bash
python - <<'PY'
import litellm

doc = {
    "type": "document",
    "source": {"type": "text", "media_type": "text/plain",
               "data": "The Eiffel Tower was completed in 1889. It is 330 metres tall."},
    "title": "facts",
    "citations": {"enabled": True},
}
chunks = list(litellm.completion(
    model="anthropic/claude-opus-5",
    messages=[{"role": "user", "content": [doc, {"type": "text", "text": "How tall is the Eiffel Tower and when was it completed? Cite the document."}]}],
    stream=True,
))
built = litellm.stream_chunk_builder(chunks)
print("citations:", (built.choices[0].message.provider_specific_fields or {}).get("citations"))
print("response_cost:", built._hidden_params.get("response_cost"))
PY
```

### Before (936e07b0a5)

#### Streamed cost lost

1. Ran the DSPy snippet per provider (`anthropic/claude-opus-5`, `gpt-5.6`, `gemini/gemini-3.7-flash`, `bedrock/us.anthropic.claude-sonnet-5`)
2. Observed `cost: None` on all four, while the identical non-streamed calls priced fine
3. Through the proxy (2 workers), streamed `cost: None` on both the `gpt-5.6` and `claude-opus-5` aliases, while the identical non-streamed calls read 0.001164 and 0.003125

#### Streamed citations lost

1. Ran the citations snippet: 3 citation deltas arrived in the stream, then `citations: None` and `response_cost: None` on the joined response
2. DSPy's streaming Citations program direct to Anthropic ended with 0 citations on the final prediction, where the identical non-streamed run returned 1
3. Through the proxy, the joined response likewise carried 0 citations

### After (9b1b8e7ea2)

#### Streamed cost lost

1. Ran the same DSPy snippet per provider
2. Observed real spend on all four: anthropic 0.00355, openai 0.001204, gemini 0.00108375, bedrock 0.001276
3. Through the proxy (2 workers), streamed cost now reads on the aliases: `gpt-5.6` 0.001148 (nonstream 0.001164), `claude-opus-5` 0.00295 (nonstream 0.003125), `gemini-3.7-flash` 0.000996 (nonstream 0.001065)

#### Streamed citations lost

1. Ran the same citations snippet: 1 citation delta arrived and the joined response carries 1 citation (`char_location` on the document) instead of `None`
2. DSPy's streaming Citations program direct to Anthropic ended with 1 citation on the final prediction, matching the non-streamed run (cost 0.007655 streamed, 0.00763 non-streamed)
3. Through the proxy, the joined response carries 1 citation (non-streamed also 1) and the streamed DSPy Citations run reports cost 0.009825

### Databricks streamed citations A/B (SDK direct)

Same joined-stream flow against the real Databricks workspace, model `databricks/databricks-claude-sonnet-5`, no mocks:

```bash
python - <<'PY'
import json
import litellm

document = {
    "type": "document",
    "source": {
        "type": "text",
        "media_type": "text/plain",
        "data": "The sky is blue because of Rayleigh scattering. Grass is green because of chlorophyll.",
    },
    "title": "Science facts",
    "citations": {"enabled": True},
}

chunks = list(
    litellm.completion(
        model="databricks/databricks-claude-sonnet-5",
        messages=[{"role": "user", "content": [document, {"type": "text", "text": "Why is the sky blue, and why is grass green? Cite the document for each fact."}]}],
        stream=True,
    )
)
built = litellm.stream_chunk_builder(chunks)
print(json.dumps((built.choices[0].message.provider_specific_fields or {}).get("citations"), default=str))
PY
```

1. Before (936e07b0a5): the stream delivered 2 citation deltas, and the joined response printed `null`; the citations never reach the joined message
2. After (9b1b8e7ea2): both citations survive as one per-block list, `[[c1, c2]]` with `char_location` entries, no double nesting. This live run emitted singular `citation` deltas; the block-list delta shape from the original report stays locked by the regression tests in `tests/test_litellm/test_stream_chunk_builder_citations.py`

Observations from the runs:

- Proxy `openai/` aliases reject `reasoning_effort` client-side; pre-existing, left alone
- Streamed citation dicts lack `supported_text`; pre-existing, left alone
- Streaming responses carry no plain response-cost header; pre-existing, left alone
- DSPy's own citation collection masked the loss via proxy; unaffected
- Alias missing from the model map streams cost 0.0
- litellm's wrapper logging already stamps 0.0 there; pre-existing, unchanged

Live PR risk: CHECKED at 9b1b8e7ea2. Two findings were fixed in-PR, each with a regression test: mid-stream failure spend priced off the raw chunk model, and Databricks block-list citation deltas double-nested. CircleCI ran under the run-ci label; the logging_testing red is pre-existing (it fails on staging commits c11a1f0bc1 and 3daf7a3095 and on unrelated PR #38440, with identical failure sets at head vs merge base locally). A follow-up live Databricks A/B (above) closed the citation-join gap that had only unit-level coverage

## Type

🐛 Bug Fix

## Caveats (if any)

### Low

- Streamed citation dicts lack `supported_text`; non-streamed ones carry it
- Without a provider-reported usage cost, pricing falls back to litellm's model map, and a model aliased through a proxy prices by its bare model name, which assumes the alias matches the upstream model
- An alias matching nothing in the model map prices streamed calls at 0.0 (litellm's default zero-cost info for unknown OpenAI-compatible models; the non-streamed call reads the real cost from the proxy's cost header, which streams don't carry)

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes billing-adjacent assembly (response_cost, partial-failure spend) and provider metadata merging; behavior is covered by new tests but affects all consumers of joined streams.
> 
> **Overview**
> **Joined streamed chat responses now expose spend and citations** that were previously missing for tools like DSPy `track_usage` and Anthropic document citations.
> 
> `stream_chunk_builder` stamps **`response_cost`** on `_hidden_params` when it can derive a price: provider `usage.cost` wins; otherwise it prices via `completion_cost` / the model map (with a proxy-alias fallback). When a `logging_obj` is passed and usage has no cost, hidden `response_cost` is left unset so the existing logging cost pipeline applies (e.g. `include_cost_in_streaming_usage`).
> 
> **Citation deltas** in `provider_specific_fields` are aggregated into a final **`citations`** list (singular `citation` keys removed), including block-list citation shapes without extra nesting.
> 
> **Mid-stream failure spend recovery** passes `logging_obj` into `stream_chunk_builder` so partial failures use the corrected model and full cost calculator instead of raw chunk model pricing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9b1b8e7ea26bd84c557a061654290f3ca68086f3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
