### PR TITLE
fix(router): tier-pinned reasoning_effort supersedes client effort carriers

### DIFF
--- a/litellm/router.py
+++ b/litellm/router.py
@@ -11952,6 +11952,33 @@ class Router:
 
         return healthy_deployments
 
+    @staticmethod
+    def _pop_effort_from_nested_carrier(request_kwargs: dict[str, object], carrier: str) -> None:
+        nested: Final = request_kwargs.get(carrier)
+        if not isinstance(nested, dict):
+            return
+        nested.pop("effort", None)
+        if not nested:
+            request_kwargs.pop(carrier, None)
+
+    @staticmethod
+    def _drop_client_effort_carriers_a_tier_pin_supersedes(
+        request_kwargs: dict[str, object],
+        tier_litellm_params: Mapping[str, object],
+    ) -> None:
+        """Tier litellm_params are deliberate operator overrides, but provider
+        translations let a caller-supplied carrier of the same setting
+        (``thinking``, ``output_config.effort``, ``reasoning.effort``) outrank
+        the ``reasoning_effort`` alias, so a pinned effort only reaches the wire
+        if the client's other encodings are removed before the merge. Non-effort
+        fields a carrier also holds (``output_config.format``,
+        ``reasoning.summary``) are kept."""
+        if "reasoning_effort" not in tier_litellm_params:
+            return
+        request_kwargs.pop("thinking", None)
+        Router._pop_effort_from_nested_carrier(request_kwargs, "output_config")
+        Router._pop_effort_from_nested_carrier(request_kwargs, "reasoning")
+
     async def async_get_available_deployment(
         self,
         model: str,
@@ -11997,11 +12024,11 @@ class Router:
                 model = pre_routing_hook_response.model
                 messages = pre_routing_hook_response.messages
                 if pre_routing_hook_response.litellm_params:
-                    request_kwargs.update(
-                        self._tier_params_the_target_accepts(
-                            model, pre_routing_hook_response.litellm_params, request_kwargs
-                        )
+                    accepted_tier_params: Final = self._tier_params_the_target_accepts(
+                        model, pre_routing_hook_response.litellm_params, request_kwargs
                     )
+                    self._drop_client_effort_carriers_a_tier_pin_supersedes(request_kwargs, accepted_tier_params)
+                    request_kwargs.update(accepted_tier_params)
             #########################################################
 
             # Resolve the strategy and logger AFTER the pre-routing hook, since
@@ -12112,11 +12139,11 @@ class Router:
                 model = pre_routing_hook_response.model
                 messages = pre_routing_hook_response.messages
                 if pre_routing_hook_response.litellm_params:
-                    request_kwargs.update(
-                        self._tier_params_the_target_accepts(
-                            model, pre_routing_hook_response.litellm_params, request_kwargs
-                        )
+                    accepted_tier_params: Final = self._tier_params_the_target_accepts(
+                        model, pre_routing_hook_response.litellm_params, request_kwargs
                     )
+                    self._drop_client_effort_carriers_a_tier_pin_supersedes(request_kwargs, accepted_tier_params)
+                    request_kwargs.update(accepted_tier_params)
 
             # 2. Get healthy deployments
             healthy_deployments: Final = await self.async_get_healthy_deployments(

--- a/tests/test_litellm/router_strategy/test_complexity_router.py
+++ b/tests/test_litellm/router_strategy/test_complexity_router.py
@@ -2234,6 +2234,171 @@ class TestRouterPreRoutingAliasOverrides:
         assert deployment["model_name"] == "gpt-5-mini"
         assert request_kwargs["reasoning_effort"] == "xhigh"
 
+    def _make_effort_pinned_router(self, tier_litellm_params: Dict) -> Router:
+        return Router(
+            model_list=[
+                {
+                    "model_name": "smart-router",
+                    "litellm_params": {
+                        "model": "auto_router/complexity_router",
+                        "complexity_router_config": {
+                            "tiers": {
+                                "SIMPLE": {
+                                    "model_name": "gpt-5-mini",
+                                    "litellm_params": tier_litellm_params,
+                                }
+                            }
+                        },
+                    },
+                },
+                {"model_name": "gpt-5-mini", "litellm_params": {"model": "openai/gpt-5-mini"}},
+            ]
+        )
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "client_carriers, expected_absent, expected_present",
+        [
+            (
+                {"thinking": {"type": "adaptive"}, "output_config": {"effort": "max"}},
+                ("thinking", "output_config"),
+                {},
+            ),
+            ({"reasoning": {"effort": "high"}}, ("reasoning",), {}),
+            (
+                {"reasoning": {"effort": "high", "summary": "concise"}},
+                (),
+                {"reasoning": {"summary": "concise"}},
+            ),
+            (
+                {"output_config": {"effort": "max", "format": {"type": "json_schema"}}},
+                (),
+                {"output_config": {"format": {"type": "json_schema"}}},
+            ),
+        ],
+    )
+    async def test_tier_pinned_effort_supersedes_client_effort_carriers(
+        self, client_carriers, expected_absent, expected_present
+    ):
+        """A tier-pinned reasoning_effort is an operator override, but provider
+        translations give a caller-supplied thinking/output_config/reasoning
+        carrier precedence over the reasoning_effort alias, so the pin only
+        reaches the wire if those carriers are dropped at the merge."""
+        router = self._make_effort_pinned_router({"reasoning_effort": "xhigh"})
+        request_kwargs: Dict = dict(client_carriers)
+
+        await router.async_get_available_deployment(
+            model="smart-router",
+            request_kwargs=request_kwargs,
+            messages=[{"role": "user", "content": "hi"}],
+        )
+
+        assert request_kwargs["reasoning_effort"] == "xhigh"
+        for key in expected_absent:
+            assert key not in request_kwargs
+        for key, value in expected_present.items():
+            assert request_kwargs[key] == value
+
+    @pytest.mark.asyncio
+    async def test_tier_pinned_effort_supersedes_client_carriers_on_pass_through_path(self):
+        router = Router(
+            model_list=[
+                {
+                    "model_name": "smart-router",
+                    "litellm_params": {
+                        "model": "auto_router/complexity_router",
+                        "complexity_router_config": {
+                            "tiers": {
+                                "SIMPLE": {
+                                    "model_name": "gpt-5-mini",
+                                    "litellm_params": {"reasoning_effort": "xhigh"},
+                                }
+                            }
+                        },
+                    },
+                },
+                {
+                    "model_name": "gpt-5-mini",
+                    "litellm_params": {"model": "openai/gpt-5-mini", "use_in_pass_through": True},
+                },
+            ]
+        )
+        request_kwargs: Dict = {"thinking": {"type": "adaptive"}, "output_config": {"effort": "max"}}
+
+        await router.async_get_available_deployment_for_pass_through(
+            model="smart-router",
+            request_kwargs=request_kwargs,
+            messages=[{"role": "user", "content": "hi"}],
+        )
+
+        assert request_kwargs["reasoning_effort"] == "xhigh"
+        assert "thinking" not in request_kwargs
+        assert "output_config" not in request_kwargs
+
+    def test_drop_client_effort_carriers_helper_edge_shapes(self):
+        no_pin: Dict = {"thinking": {"type": "adaptive"}}
+        Router._drop_client_effort_carriers_a_tier_pin_supersedes(no_pin, {"temperature": 0.1})
+        assert no_pin == {"thinking": {"type": "adaptive"}}
+
+        non_dict_carriers: Dict = {"output_config": "max", "reasoning": 3}
+        Router._drop_client_effort_carriers_a_tier_pin_supersedes(non_dict_carriers, {"reasoning_effort": "low"})
+        assert non_dict_carriers == {"output_config": "max", "reasoning": 3}
+
+        effort_only: Dict = {"output_config": {"effort": "max"}, "reasoning": {"effort": "high"}}
+        Router._pop_effort_from_nested_carrier(effort_only, "output_config")
+        Router._pop_effort_from_nested_carrier(effort_only, "reasoning")
+        assert effort_only == {}
+
+    @pytest.mark.asyncio
+    async def test_client_effort_carriers_survive_when_gate_drops_the_tier_pin(self):
+        """The tier-param gate removes a pin the routed target cannot take, and a
+        pin that never applies must not strip the client's own effort carriers."""
+        router = Router(
+            model_list=[
+                {
+                    "model_name": "smart-router",
+                    "litellm_params": {
+                        "model": "auto_router/complexity_router",
+                        "complexity_router_config": {
+                            "tiers": {
+                                "SIMPLE": {
+                                    "model_name": "gpt-4o-mini",
+                                    "litellm_params": {"reasoning_effort": "xhigh"},
+                                }
+                            }
+                        },
+                    },
+                },
+                {"model_name": "gpt-4o-mini", "litellm_params": {"model": "openai/gpt-4o-mini"}},
+            ]
+        )
+        request_kwargs: Dict = {"thinking": {"type": "adaptive"}, "output_config": {"effort": "max"}}
+
+        await router.async_get_available_deployment(
+            model="smart-router",
+            request_kwargs=request_kwargs,
+            messages=[{"role": "user", "content": "hi"}],
+        )
+
+        assert "reasoning_effort" not in request_kwargs
+        assert request_kwargs["thinking"] == {"type": "adaptive"}
+        assert request_kwargs["output_config"] == {"effort": "max"}
+
+    @pytest.mark.asyncio
+    async def test_client_effort_carriers_survive_when_tier_pins_no_effort(self):
+        router = self._make_effort_pinned_router({"temperature": 0.2})
+        request_kwargs: Dict = {"thinking": {"type": "adaptive"}, "output_config": {"effort": "max"}}
+
+        await router.async_get_available_deployment(
+            model="smart-router",
+            request_kwargs=request_kwargs,
+            messages=[{"role": "user", "content": "hi"}],
+        )
+
+        assert request_kwargs["thinking"] == {"type": "adaptive"}
+        assert request_kwargs["output_config"] == {"effort": "max"}
+        assert request_kwargs["temperature"] == 0.2
+
     @pytest.mark.asyncio
     async def test_routing_never_resolves_an_authenticating_provider(self, monkeypatch, tmp_path):
         """Resolving github_copilot runs its OAuth device flow, so the whole routing path must


### PR DESCRIPTION
## TLDR

Problem this solves:

- Auto-router tier `reasoning_effort` pins never reached the provider for Claude Code traffic
- Clients sending `output_config.effort` or `thinking` silently beat the operator's tier pin

How it solves it:

- At the tier-param merge, drop the client's other encodings of the same setting
- `thinking` and `reasoning` are removed; `output_config` keeps its non-effort fields

## User Flow

Before: an operator pins `reasoning_effort: medium` on a tier, but Claude Code sessions still run at the client's `effort: "max"` on every turn

1. The operator configures an auto-router tier with `litellm_params: {reasoning_effort: medium}` and points Claude Code at the router
2. Claude Code sends POST https://litellm-domain/v1/messages with `"output_config": {"effort": "max"}` and `"thinking": {"type": "adaptive"}`
3. The request is classified into the pinned tier, yet the provider receives `"output_config": {"effort": "max"}`; the logs page shows the tier decision saying medium while the request body shows max
4. Only requests that omit `output_config` (for example the client's small utility calls) actually run at medium, which reads as "the override works on the first turn and then stops"

After: the same session runs every classified turn at the tier's pinned effort

1. Same config, same Claude Code session
2. Claude Code sends the same POST https://litellm-domain/v1/messages with `"output_config": {"effort": "max"}`
3. The provider now receives `"output_config": {"effort": "medium"}`; a client `output_config.format` is preserved untouched
4. Requests to tiers without a pinned effort keep the client's carriers exactly as before

## Relevant issues

- Tier-pinned `reasoning_effort` was silently swallowed whenever the client sent a native effort carrier
- The pin now supersedes client `thinking`, `output_config.effort`, and `reasoning` at the merge point
- Tiers without an effort pin, and non-router traffic, are untouched

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Shared setup: proxy at localhost:4581 with an auto-router `claude-auto-router` (heuristic classifier, MEDIUM tier `claude-opus-4-8` pinned to `reasoning_effort: medium`), real Anthropic-family upstream. Evidence is the outbound request body logged by `--detailed_debug` ("POST Request Sent from LiteLLM"). The prompt classifies MEDIUM

### Before (18830667b2)

#### client sends output_config.effort max

1. `curl -sS http://127.0.0.1:4581/v1/messages -H "Authorization: Bearer sk-..." -H "content-type: application/json" -d '{"model":"claude-auto-router","max_tokens":32000,"thinking":{"type":"adaptive"},"output_config":{"effort":"max"},"messages":[{"role":"user","content":"write a python function that returns true if a dict has a key, with an if branch"}]}'`
2. Outbound body: `'model': 'claude-opus-4-8', ..., 'thinking': {'type': 'adaptive'}, 'output_config': {'effort': 'max'}`; the tier pin never reached the wire

#### client sends no effort carrier

1. Same curl without `thinking`/`output_config`
2. Outbound body: `'output_config': {'effort': 'medium'}`; the pin only works when the client stays silent

### After (618a3ba777)

#### client sends output_config.effort max

1. Same curl as Before
2. Outbound body: `'thinking': {'type': 'adaptive', 'display': 'summarized'}, 'output_config': {'effort': 'medium'}`; the tier pin wins

#### client sends no effort carrier

1. Same curl as Before
2. Outbound body: `'output_config': {'effort': 'medium'}`; unchanged

#### client output_config also carries format

1. `curl ... -d '{"model":"claude-auto-router","max_tokens":32000,"output_config":{"effort":"max","format":{"type":"text"}},"messages":[...]}'`
2. Outbound body: `'output_config': {'format': {'type': 'text'}, 'effort': 'medium'}`; the non-effort field survives, the effort is the tier's

#### real Claude Code multi-turn session (After only; session-level validation on top of the request-level Before/After above)

1. `ANTHROPIC_BASE_URL=http://127.0.0.1:4581 ANTHROPIC_AUTH_TOKEN=sk-... ANTHROPIC_MODEL=<router group> claude -p "what time zone is tokyo in?"` then two `claude -p --continue` turns (a code question, then a short follow-up)
2. Every main-loop request carried the client's `thinking` and `output_config` (effort high, Claude Code's default; proven by the proxy's received-body key list)
3. Wire per turn: turn 1 SIMPLE tier `thinking: {enabled, budget_tokens: 4096}` (tier high), turn 2 MEDIUM tier `output_config: {"effort": "medium"}` against the client's high, turn 3 SIMPLE tier again; the mid-session MEDIUM turn is the reported failure shape and now carries the pin

## Type

🐛 Bug Fix

## Caveats (if any)

### Low

- A client `thinking.display` is dropped when a pinned tier supersedes the carrier, matching the existing `reasoning_effort: "none"` semantics; `reasoning.summary` and `output_config.format` are preserved
- On the open tier-param-gate PR's branch, the drop should run only for tier params that survive the gate

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
