### PR TITLE
fix(spend): remove the proxy-wide autorouter savings baseline override

### DIFF
--- a/litellm/__init__.py
+++ b/litellm/__init__.py
@@ -274,7 +274,6 @@ databricks_key: Optional[str] = None
 openai_like_key: Optional[str] = None
 azure_key: Optional[str] = None
 anthropic_key: Optional[str] = None
-autorouter_savings_baseline_model: Optional[str] = None
 replicate_key: Optional[str] = None
 bytez_key: Optional[str] = None
 gdc_key: Optional[str] = None

--- a/litellm/proxy/spend_tracking/savings.py
+++ b/litellm/proxy/spend_tracking/savings.py
@@ -502,14 +502,11 @@ def autorouter_savings_for_request(
     usage: Final = _usage_from_spend_log(usage_object)
     if usage is None or not model:
         return None
-    # The configured `autorouter_savings_baseline_model` wins; otherwise the baseline
-    # the deciding router recorded on its decision; neither means the driver is off.
     decision: Final = routing_decision if isinstance(routing_decision, Mapping) else {}
     recorded: Final = decision.get("savings_baseline_model")
     recorded_id: Final = decision.get("savings_baseline_deployment_id")
-    configured: Final = litellm.autorouter_savings_baseline_model
-    baseline_model: Final = configured or (recorded if isinstance(recorded, str) else None)
-    baseline_id: Final = recorded_id if configured is None and isinstance(recorded_id, str) else None
+    baseline_model: Final = recorded if isinstance(recorded, str) else None
+    baseline_id: Final = recorded_id if isinstance(recorded_id, str) else None
     if not decision or not baseline_model:
         return None
     router_instance: Final = llm_router() if llm_router else None

--- a/litellm/router_strategy/complexity_router/complexity_router.py
+++ b/litellm/router_strategy/complexity_router/complexity_router.py
@@ -947,17 +947,15 @@ class ComplexityRouter(CustomLogger):
     def savings_baseline(self) -> Baseline | None:
         """The derived counterfactual this router's savings are measured against.
 
-        ``None`` when `litellm_settings.autorouter_savings_baseline_model` is set (the
-        spend writer reads that setting directly and it wins) or when this router was
-        built with ``derive_savings_baseline=False``. Derived once on first use and
-        pinned for the instance's lifetime: creating or editing the router rebuilds
-        the instance, which re-derives. Deferred past ``__init__`` because during a
-        config load this router can be constructed before its tier deployments are.
+        ``None`` when this router was built with ``derive_savings_baseline=False``.
+        Derived once on first use and pinned for the instance's lifetime: creating or
+        editing the router rebuilds the instance, which re-derives. Deferred past
+        ``__init__`` because during a config load this router can be constructed
+        before its tier deployments are.
         """
-        import litellm
         from litellm.router_strategy.savings_baseline import resolve_baseline
 
-        if not self._derive_savings_baseline or litellm.autorouter_savings_baseline_model is not None:
+        if not self._derive_savings_baseline:
             return None
         if not self._savings_baseline_derived:
             self._savings_baseline = resolve_baseline(self.litellm_router_instance, self._hardest_tier_models())

--- a/litellm/router_strategy/savings_baseline.py
+++ b/litellm/router_strategy/savings_baseline.py
@@ -1,16 +1,13 @@
-"""The default counterfactual a complexity router's savings are measured against.
+"""The counterfactual a complexity router's savings are measured against.
 
-`litellm_settings.autorouter_savings_baseline_model` names the model the traffic would
-have run on without a router. When the operator sets it, that answer wins and nothing
-here runs. When they do not, the router's own tier ladder already names it: without a
-router a deployment has to pick one model that can carry the hardest request it will
-see, so the default baseline is the priciest model in the hardest configured tier. A
-cheap tier is a choice the router made, not a ceiling it was bounded by.
+The router's own tier ladder names the model the traffic would have run on without a
+router: a deployment has to pick one model that can carry the hardest request it will
+see, so the baseline is the priciest model in the hardest configured tier. A cheap
+tier is a choice the router made, not a ceiling it was bounded by.
 
 Candidates are ranked once against a fixed reference request, not against each request
 that runs. Ranking per request means reading the request, and every input shape it can
-take; a default must not carry that surface. An operator whose pool ordering genuinely
-depends on request shape names the baseline in config, which skips this file entirely.
+take; a per-router default must not carry that surface.
 
 Baselines are always provider-qualified, because they travel to the spend writer as a
 bare string with no provider beside them; an operator who writes ``deepseek-r1`` meaning

--- a/tests/test_litellm/proxy/db/test_autorouter_session_rollup.py
+++ b/tests/test_litellm/proxy/db/test_autorouter_session_rollup.py
@@ -246,11 +246,9 @@ class TestFlush:
 class TestEnqueueSeam:
     @pytest.mark.asyncio
     async def test_update_database_seam_enqueues_only_auto_routed_success(self, monkeypatch: pytest.MonkeyPatch):
-        import litellm
         from litellm.proxy.db.db_spend_update_writer import DBSpendUpdateWriter
         from litellm.proxy.utils import PrismaClient
 
-        monkeypatch.setattr(litellm, "autorouter_savings_baseline_model", None)
         monkeypatch.setattr(PrismaClient, "autorouter_turn_transactions", [])
         writer = DBSpendUpdateWriter()
         fake_prisma = type("P", (), {})()

--- a/tests/test_litellm/proxy/spend_tracking/test_savings.py
+++ b/tests/test_litellm/proxy/spend_tracking/test_savings.py
@@ -540,16 +540,15 @@ def test_autorouter_savings_zero_without_baseline():
     assert result.autorouter == 0.0
 
 
-def test_compute_savings_spend_carries_a_losing_switch_through(monkeypatch):
+def test_compute_savings_spend_carries_a_losing_switch_through():
     """The signed value must survive into SavingsSpend; clamping it here would put the
     dashboard back to only ever showing gains."""
-    monkeypatch.setattr(litellm, "autorouter_savings_baseline_model", "claude-sonnet-5")
     result = compute_savings_spend(
         model="claude-haiku-4-5",
         custom_llm_provider="anthropic",
         compression_saved_tokens=0,
         gateway_injected_cache=True,
-        routing_decision={"conversation_continuing": True},
+        routing_decision={"conversation_continuing": True, "savings_baseline_model": "anthropic/claude-sonnet-5"},
         usage_object=_cached_usage_object(),
     )
     assert result.autorouter < 0
@@ -911,26 +910,17 @@ def test_a_baseline_recorded_on_the_decision_turns_the_driver_on():
     assert result.autorouter != 0.0
 
 
-def test_the_configured_baseline_overrides_the_recorded_one(monkeypatch):
-    """The recorded baseline and its deployment id are both ignored under the setting."""
-    monkeypatch.setattr(litellm, "autorouter_savings_baseline_model", "claude-sonnet-5")
-    with_override = compute_savings_spend(
+def test_a_leftover_configured_baseline_does_not_override_the_recorded_one(monkeypatch):
+    """The proxy config loader setattrs unknown litellm_settings keys, so a stale
+    autorouter_savings_baseline_model key must stay inert."""
+    monkeypatch.setattr(litellm, "autorouter_savings_baseline_model", "claude-sonnet-5", raising=False)
+    result = compute_savings_spend(
         model="claude-haiku-4-5",
         custom_llm_provider="anthropic",
         compression_saved_tokens=0,
         gateway_injected_cache=True,
-        routing_decision={
-            "conversation_continuing": True,
-            "savings_baseline_model": "anthropic/claude-opus-5",
-            "savings_baseline_deployment_id": "some-deployment-id",
-        },
+        routing_decision={"conversation_continuing": True, "savings_baseline_model": "anthropic/claude-opus-5"},
         usage_object=_cached_usage_object(),
-    )
-    against_sonnet = compute_autorouter_savings(
-        baseline_model="claude-sonnet-5",
-        selected_model="claude-haiku-4-5",
-        selected_provider="anthropic",
-        usage=Usage(**_cached_usage_object()),
     )
     against_opus = compute_autorouter_savings(
         baseline_model="anthropic/claude-opus-5",
@@ -938,8 +928,7 @@ def test_the_configured_baseline_overrides_the_recorded_one(monkeypatch):
         selected_provider="anthropic",
         usage=Usage(**_cached_usage_object()),
     )
-    assert against_sonnet != against_opus, "the test needs baselines that price apart"
-    assert with_override.autorouter == against_sonnet
+    assert result.autorouter == against_opus
 
 
 def test_a_non_string_recorded_baseline_is_ignored():

--- a/tests/test_litellm/router_strategy/test_complexity_router.py
+++ b/tests/test_litellm/router_strategy/test_complexity_router.py
@@ -7877,10 +7877,12 @@ class TestSavingsBaselineOnDecision:
         router = self._router_with_tiers({"SIMPLE": "cheap", "MEDIUM": "mid"})
         assert router.savings_baseline.model == "anthropic/claude-sonnet-5"
 
-    def test_a_configured_proxy_wide_baseline_disables_derivation(self, monkeypatch):
-        monkeypatch.setattr(litellm, "autorouter_savings_baseline_model", "claude-opus-5")
+    def test_a_leftover_proxy_wide_baseline_setting_does_not_disable_derivation(self, monkeypatch):
+        """The proxy config loader setattrs unknown litellm_settings keys, so a stale
+        autorouter_savings_baseline_model key must stay inert."""
+        monkeypatch.setattr(litellm, "autorouter_savings_baseline_model", "claude-opus-5", raising=False)
         router = self._router_with_tiers({"SIMPLE": "cheap", "REASONING": "top"})
-        assert router.savings_baseline is None
+        assert router.savings_baseline.model == "anthropic/claude-fable-5"
 
     def test_the_decision_record_carries_the_derived_baseline_and_its_deployment(self):
         """The deployment id is what lets the spend writer price a baseline whose
@@ -7953,12 +7955,6 @@ class TestSavingsBaselinePinnedPerInstance:
             complexity_router_config={"tiers": {"SIMPLE": "cheap", "REASONING": ["cheap", "top"]}},
         )
         assert rebuilt.savings_baseline is None
-
-    def test_the_configured_setting_bypasses_the_pin(self, monkeypatch):
-        router, _ = self._router_and_parent()
-        assert router.savings_baseline.model == "anthropic/claude-sonnet-5"
-        monkeypatch.setattr(litellm, "autorouter_savings_baseline_model", "claude-opus-5")
-        assert router.savings_baseline is None
 
     def test_an_unresolvable_pool_is_derived_once_and_pinned_as_none(self):
         router, parent = self._router_and_parent()


### PR DESCRIPTION
## TLDR

Problem this solves:

- One proxy-wide savings baseline distorted every auto router's savings figure
- Setting it also stopped routers recording their own derived baseline

How it solves it:

- Deletes `litellm_settings.autorouter_savings_baseline_model` entirely
- Every complexity router derives its baseline from its hardest configured tier
- The spend writer always prices against the decision-recorded baseline and deployment id

## User Flow

Before: an operator who set the proxy-wide baseline sees the same counterfactual applied to every auto router, so a router whose cheap tier matches that global model reports zero savings forever

1. The admin sets `litellm_settings.autorouter_savings_baseline_model: anthropic/claude-haiku-4-5-20251001` and restarts the proxy
2. A client sends POST http://localhost:4010/v1/chat/completions with `"model": "smart-router"` and a short prompt, and the router serves it on the cheap haiku tier
3. On http://localhost:4010/ui/?page=logs that request shows auto-router savings of $0, because the global baseline is the same cheap model the router picked, even though this router's top tier is claude-fable-5

After: the same request is measured against this router's own hardest tier, and the old key does nothing

1. The admin upgrades; the leftover key is ignored and can be deleted from the config
2. The client sends the same POST http://localhost:4010/v1/chat/completions with `"model": "smart-router"`
3. The log row now records the router's own counterfactual, claude-fable-5, and non-zero savings against it

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Shared setup: a live proxy on :4010 with a Postgres spend DB and this config. The two tier deployments point at a litellm gateway upstream, so the calls are real Anthropic traffic and cost real money. The `litellm_settings` key is present in BOTH runs to prove it is inert after the change

```yaml
model_list:
  - model_name: cheap
    litellm_params:
      model: anthropic/claude-haiku-4-5-20251001
      api_base: https://<gateway>
      api_key: os.environ/GW_KEY
  - model_name: top
    litellm_params:
      model: anthropic/claude-fable-5
      api_base: https://<gateway>
      api_key: os.environ/GW_KEY
  - model_name: smart-router
    litellm_params:
      model: auto_router/complexity_router
      complexity_router_config:
        tiers:
          SIMPLE: cheap
          REASONING:
            - cheap
            - top

litellm_settings:
  autorouter_savings_baseline_model: anthropic/claude-haiku-4-5-20251001

general_settings:
  master_key: sk-1234
```

### Before (d4f6b4491d)

1. Route one request through the auto router:

```
$ curl -s -D - http://localhost:4010/v1/chat/completions -H "Authorization: Bearer sk-1234" \
    -H "content-type: application/json" \
    -d '{"model":"smart-router","messages":[{"role":"user","content":"hi"}]}' -o /dev/null | grep x-litellm-model-name
x-litellm-model-name: anthropic/claude-haiku-4-5-20251001
```

2. Read the spend log row the proxy wrote for it:

```
$ psql litellm_baseline_repro -t -c "select metadata->>'autorouter_savings', metadata->'routing_decision' from \"LiteLLM_SpendLogs\" order by \"startTime\" desc limit 1"
 0.0 | {"tier": "SIMPLE", "cause": "heuristic_scorer", ... "routed_model": "cheap", "router_model_name": "smart-router", ...}
```

The decision carries no `savings_baseline_model` (the global setting disabled derivation) and the savings figure is 0.0, priced against the configured global baseline, which is the very model the router routed to

### After (ed0a66a429)

1. Same request:

```
$ curl -s -D - http://localhost:4010/v1/chat/completions -H "Authorization: Bearer sk-1234" \
    -H "content-type: application/json" \
    -d '{"model":"smart-router","messages":[{"role":"user","content":"hi"}]}' -o /dev/null | grep x-litellm-model-name
x-litellm-model-name: anthropic/claude-haiku-4-5-20251001
```

2. Same query:

```
$ psql litellm_baseline_repro -t -c "select metadata->>'autorouter_savings', metadata->'routing_decision'->>'savings_baseline_model', metadata->'routing_decision'->>'savings_baseline_deployment_id', spend from \"LiteLLM_SpendLogs\" order by \"startTime\" desc limit 1"
 0.001152 | anthropic/claude-fable-5 | a2936e9e7c3e... | 0.000128
```

The decision now records the router's own derived baseline (the priciest model of its hardest configured tier, claude-fable-5) plus its deployment id, and the savings figure is computed against it, with the leftover `litellm_settings` key present and ignored

## Type

🧹 Refactoring

## Caveats (if any)

### Severe

- `litellm_settings.autorouter_savings_baseline_model` no longer has any effect; a leftover key is silently ignored, never rejected

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how auto-router savings are computed and reported in spend logs/dashboards; operators who relied on the removed global baseline will see different figures, though behavior is more consistent per router.
> 
> **Overview**
> Removes **`litellm_settings.autorouter_savings_baseline_model`** so a single proxy-wide counterfactual no longer overrides every auto-router’s savings math or blocks per-router baseline derivation.
> 
> **Spend tracking** now prices auto-router savings only from the routing decision’s `savings_baseline_model` and `savings_baseline_deployment_id`. The complexity router always derives its baseline from the priciest model in the hardest configured tier (when derivation is enabled) and records that on the decision.
> 
> Leftover config keys are **silently ignored** (proxy `setattr` can still attach unknown settings); tests were updated to assert stale values do not change spend or router behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ed0a66a42915d7f365a9b991ff28bbd068d6e5e5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->