### PR TITLE
fix(shadow-eval): validate Anthropic SDK judge credentials

### DIFF
--- a/litellm/proxy/management_endpoints/auto_router_endpoints.py
+++ b/litellm/proxy/management_endpoints/auto_router_endpoints.py
@@ -15,6 +15,7 @@ from uuid import uuid4
 
 from pydantic import BaseModel, ConfigDict, TypeAdapter, field_validator
 
+import litellm
 from litellm._logging import verbose_proxy_logger
 from litellm.exceptions import BudgetExceededError
 from litellm.litellm_core_utils.llm_judge import judge_target
@@ -678,6 +679,20 @@ def _is_configured_pre_routing_strategy(llm_router: "Router", router_name: str) 
     )
 
 
+def _sdk_model_is_missing_anthropic_credentials(model: str) -> bool:
+    _, provider, _, _ = litellm.get_llm_provider(model=model)
+    if provider != "anthropic" or litellm.anthropic_key or litellm.api_key:
+        return False
+    from litellm.llms.anthropic.common_utils import AnthropicModelInfo
+    from litellm.secret_managers.main import secret_manager_would_be_consulted
+
+    if AnthropicModelInfo.get_api_key() or AnthropicModelInfo.get_auth_token():
+        return False
+    return not any(
+        secret_manager_would_be_consulted(secret_name) for secret_name in ("ANTHROPIC_API_KEY", "ANTHROPIC_AUTH_TOKEN")
+    )
+
+
 def _validate_plain_model(
     llm_router: "Router | None", model: str, field_name: str, team_ids: Sequence[str | None]
 ) -> None:
@@ -694,14 +709,26 @@ def _validate_plain_model(
             status_code=400,
             detail=f"{field_name} '{model}' is an auto-router; it must be a plain model",
         )
-    unreachable: Final = tuple(team for team in team_ids if judge_target(llm_router, model, team).via == "nothing")
-    if not unreachable:
+    targets: Final = tuple((team, judge_target(llm_router, model, team)) for team in team_ids)
+    unreachable: Final = tuple(team for team, target in targets if target.via == "nothing")
+    if unreachable:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                f"{field_name} '{model}' is neither a model configured on this proxy nor a "
+                "provider-qualified public model name (e.g. 'anthropic/claude-sonnet-5')" + _for_teams(unreachable)
+            ),
+        )
+    sdk_teams: Final = tuple(team for team, target in targets if target.via == "sdk")
+    if not sdk_teams:
+        return
+    if not _sdk_model_is_missing_anthropic_credentials(model):
         return
     raise HTTPException(
         status_code=400,
         detail=(
-            f"{field_name} '{model}' is neither a model configured on this proxy nor a "
-            "provider-qualified public model name (e.g. 'anthropic/claude-sonnet-5')" + _for_teams(unreachable)
+            f"{field_name} '{model}' uses the LiteLLM SDK but required credentials are not configured: "
+            "ANTHROPIC_API_KEY or ANTHROPIC_AUTH_TOKEN" + _for_teams(sdk_teams)
         ),
     )
 

--- a/tests/test_litellm/proxy/management_endpoints/test_auto_router_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_auto_router_endpoints.py
@@ -850,6 +850,11 @@ def _shadow_router() -> Router:
                 "model_info": {"team_id": "team-a", "team_public_model_name": "house-judge"},
             },
             {
+                "model_name": "anthropic/claude-sonnet-5-team-a",
+                "litellm_params": {"model": "anthropic/claude-sonnet-5", "api_key": "fake"},
+                "model_info": {"team_id": "team-a", "team_public_model_name": "anthropic/claude-sonnet-5"},
+            },
+            {
                 "model_name": "model_name_team-b_y",
                 "litellm_params": {"model": "anthropic/claude-sonnet-5", "api_key": "fake"},
                 "model_info": {"team_id": "team-b", "team_public_model_name": "b-tier"},
@@ -1075,6 +1080,107 @@ async def test_start_shadow_eval_writes_one_leg_per_key_in_one_statement(monkeyp
 
 
 @pytest.mark.asyncio
+async def test_start_shadow_eval_rejects_an_uncredentialed_sdk_judge(monkeypatch: pytest.MonkeyPatch) -> None:
+    import litellm
+    import litellm.proxy.proxy_server as proxy_server
+
+    prisma = _shadow_prisma()
+    monkeypatch.setattr(proxy_server, "prisma_client", prisma)
+    monkeypatch.setattr(proxy_server, "llm_router", _shadow_router())
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.delenv("ANTHROPIC_AUTH_TOKEN", raising=False)
+    monkeypatch.setattr(litellm, "anthropic_key", None)
+    monkeypatch.setattr(litellm, "api_key", None)
+
+    with pytest.raises(HTTPException, match="ANTHROPIC_API_KEY") as exc:
+        await start_shadow_eval(_start_request(), ADMIN)
+
+    assert exc.value.status_code == 400
+    prisma.db.litellm_shadowevaljob.create_many.assert_not_called()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("credential_name", ("ANTHROPIC_API_KEY", "ANTHROPIC_AUTH_TOKEN"))
+async def test_start_shadow_eval_accepts_an_sdk_judge_with_anthropic_credentials(
+    monkeypatch: pytest.MonkeyPatch, credential_name: str
+) -> None:
+    import litellm
+    import litellm.proxy.proxy_server as proxy_server
+
+    prisma = _shadow_prisma()
+    monkeypatch.setattr(proxy_server, "prisma_client", prisma)
+    monkeypatch.setattr(proxy_server, "llm_router", _shadow_router())
+    monkeypatch.setattr(litellm, "anthropic_key", None)
+    monkeypatch.setattr(litellm, "api_key", None)
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.delenv("ANTHROPIC_AUTH_TOKEN", raising=False)
+    monkeypatch.setenv(credential_name, "test-credential")
+
+    response = await start_shadow_eval(_start_request(), ADMIN)
+
+    assert response.status == "running"
+    prisma.db.litellm_shadowevaljob.create_many.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_start_shadow_eval_accepts_an_sdk_judge_when_anthropic_secret_lookup_is_available(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import litellm
+    from litellm.integrations.custom_secret_manager import CustomSecretManager
+    import litellm.proxy.proxy_server as proxy_server
+    from litellm.types.secret_managers.main import KeyManagementSettings, KeyManagementSystem
+
+    class AnthropicSecretManager(CustomSecretManager):
+        def sync_read_secret(
+            self, secret_name: str, optional_params: dict | None = None, timeout: float | None = None
+        ) -> str | None:
+            return "test-credential" if secret_name == "ANTHROPIC_API_KEY" else None
+
+        async def async_read_secret(
+            self, secret_name: str, optional_params: dict | None = None, timeout: float | None = None
+        ) -> str | None:
+            return self.sync_read_secret(secret_name, optional_params, timeout)
+
+    prisma = _shadow_prisma()
+    monkeypatch.setattr(proxy_server, "prisma_client", prisma)
+    monkeypatch.setattr(proxy_server, "llm_router", _shadow_router())
+    monkeypatch.setattr(litellm, "anthropic_key", None)
+    monkeypatch.setattr(litellm, "api_key", None)
+    monkeypatch.setattr(litellm, "secret_manager_client", AnthropicSecretManager())
+    monkeypatch.setattr(litellm, "_key_management_system", KeyManagementSystem.CUSTOM)
+    monkeypatch.setattr(litellm, "_key_management_settings", KeyManagementSettings(access_mode="read_only"))
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.delenv("ANTHROPIC_AUTH_TOKEN", raising=False)
+
+    response = await start_shadow_eval(_start_request(), ADMIN)
+
+    assert response.status == "running"
+    prisma.db.litellm_shadowevaljob.create_many.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_start_shadow_eval_accepts_a_configured_judge_without_anthropic_credentials(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import litellm
+    import litellm.proxy.proxy_server as proxy_server
+
+    prisma = _shadow_prisma()
+    monkeypatch.setattr(proxy_server, "prisma_client", prisma)
+    monkeypatch.setattr(proxy_server, "llm_router", _shadow_router())
+    monkeypatch.setattr(litellm, "anthropic_key", None)
+    monkeypatch.setattr(litellm, "api_key", None)
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.delenv("ANTHROPIC_AUTH_TOKEN", raising=False)
+
+    response = await start_shadow_eval(_start_request(judge_model="house-sonnet"), ADMIN)
+
+    assert response.status == "running"
+    prisma.db.litellm_shadowevaljob.create_many.assert_awaited_once()
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     "caller,request_overrides,claimed,expected_status",
     [
@@ -1153,6 +1259,9 @@ async def test_start_shadow_eval_accepts_a_judge_that_serves_neither_arm(
     Without these, a gate that refused every judge would pass the rejection table above
     while making the endpoint useless.
     """
+    import litellm
+
+    monkeypatch.setattr(litellm, "api_key", "sk-test")
     import litellm.proxy.proxy_server as proxy_server
 
     prisma = _shadow_prisma()
@@ -1219,6 +1328,34 @@ async def test_start_shadow_eval_reuses_a_key_whose_previous_job_already_stopped
 
     assert job.status == "running"
     prisma.db.litellm_shadowevaljob.create_many.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_start_shadow_eval_rejects_an_uncredentialed_sdk_baseline(monkeypatch: pytest.MonkeyPatch) -> None:
+    import litellm
+    import litellm.proxy.proxy_server as proxy_server
+
+    prisma = _shadow_prisma()
+    monkeypatch.setattr(proxy_server, "prisma_client", prisma)
+    monkeypatch.setattr(proxy_server, "llm_router", _shadow_router())
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.delenv("ANTHROPIC_AUTH_TOKEN", raising=False)
+    monkeypatch.setattr(litellm, "anthropic_key", None)
+    monkeypatch.setattr(litellm, "api_key", None)
+
+    with pytest.raises(HTTPException, match=r"baseline_model.*ANTHROPIC_API_KEY") as exc:
+        await start_shadow_eval(
+            _start_request(
+                direction="reverse",
+                router_name="sonnet-router",
+                judge_model="pricey",
+                baseline_model="anthropic/claude-sonnet-5",
+            ),
+            ADMIN,
+        )
+
+    assert exc.value.status_code == 400
+    prisma.db.litellm_shadowevaljob.create_many.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -1946,6 +2083,30 @@ async def test_two_racing_stops_produce_exactly_one_winner(monkeypatch: pytest.M
 
 
 @pytest.mark.asyncio
+async def test_start_shadow_eval_scopes_missing_sdk_judge_credentials_to_the_sdk_team(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import litellm
+    import litellm.proxy.proxy_server as proxy_server
+
+    prisma = _shadow_prisma(key_teams={"key-hash": "team-a", "key-hash-2": "team-b"})
+    monkeypatch.setattr(proxy_server, "prisma_client", prisma)
+    monkeypatch.setattr(proxy_server, "llm_router", _shadow_router())
+    monkeypatch.setattr(litellm, "anthropic_key", None)
+    monkeypatch.setattr(litellm, "api_key", None)
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.delenv("ANTHROPIC_AUTH_TOKEN", raising=False)
+
+    with pytest.raises(HTTPException, match="ANTHROPIC_API_KEY") as exc:
+        await start_shadow_eval(_start_request(api_key_ids=("key-hash", "key-hash-2")), ADMIN)
+
+    assert exc.value.status_code == 400
+    assert "team-b" in exc.value.detail
+    assert "team-a" not in exc.value.detail
+    prisma.db.litellm_shadowevaljob.create_many.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_start_shadow_eval_finds_a_collision_only_the_keys_team_can_see(monkeypatch: pytest.MonkeyPatch):
     """The shadow and judge calls carry the shadowed key's team, so the router selects
     deployments with it and an unscoped check answers for a caller that does not exist.
@@ -2039,11 +2200,13 @@ async def test_start_shadow_eval_matches_a_bare_public_judge_name_to_a_prefixed_
     configured. Comparing those two spellings finds nothing, and the job runs a week with
     the judge grading its own answers, which is the whole defect this endpoint guards.
     """
+    import litellm
     import litellm.proxy.proxy_server as proxy_server
 
     prisma = _shadow_prisma()
     monkeypatch.setattr(proxy_server, "prisma_client", prisma)
     monkeypatch.setattr(proxy_server, "llm_router", _shadow_router())
+    monkeypatch.setattr(litellm, "api_key", "sk-test")
 
     with pytest.raises(HTTPException) as exc:
         await start_shadow_eval(_start_request(router_name="prefixed-router", judge_model="gpt-4o"), ADMIN)
@@ -2064,11 +2227,13 @@ async def test_start_shadow_eval_matches_a_prefixed_judge_name_to_a_bare_tier_de
     is the same model, so the collision would be missed for exactly the configs that spell
     the two ends differently, which is every config this guard exists for.
     """
+    import litellm
     import litellm.proxy.proxy_server as proxy_server
 
     prisma = _shadow_prisma()
     monkeypatch.setattr(proxy_server, "prisma_client", prisma)
     monkeypatch.setattr(proxy_server, "llm_router", _shadow_router())
+    monkeypatch.setattr(litellm, "api_key", "sk-test")
 
     with pytest.raises(HTTPException) as exc:
         await start_shadow_eval(_start_request(router_name="bare-router", judge_model="openai/gpt-4o"), ADMIN)

--- a/tests/test_litellm/proxy/management_endpoints/test_auto_router_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_auto_router_endpoints.py
@@ -862,12 +862,8 @@ def _shadow_router() -> Router:
             _complexity_router_deployment(
                 "my-router", {"SIMPLE": "cheap", "MEDIUM": "mid", "COMPLEX": "pricey"}, "mid"
             ),
-            _complexity_router_deployment(
-                "sonnet-router", {"SIMPLE": "cheap", "MEDIUM": "house-sonnet"}, "cheap"
-            ),
-            _complexity_router_deployment(
-                "classifier-router", {"SIMPLE": "cheap"}, "cheap", classifier="pricey"
-            ),
+            _complexity_router_deployment("sonnet-router", {"SIMPLE": "cheap", "MEDIUM": "house-sonnet"}, "cheap"),
+            _complexity_router_deployment("classifier-router", {"SIMPLE": "cheap"}, "cheap", classifier="pricey"),
             _complexity_router_deployment("b-team-router", {"SIMPLE": "cheap", "MEDIUM": "b-tier"}, "cheap"),
             _complexity_router_deployment("prefixed-router", {"SIMPLE": "prefixed-tier"}, "prefixed-tier"),
             _complexity_router_deployment("bare-router", {"SIMPLE": "bare-tier"}, "bare-tier"),
@@ -1038,6 +1034,12 @@ def _start_request(**overrides: object) -> StartShadowEvalRequest:
     return StartShadowEvalRequest.model_validate(payload)
 
 
+def _configure_anthropic_sdk_judge(monkeypatch: pytest.MonkeyPatch) -> None:
+    import litellm
+
+    monkeypatch.setattr(litellm, "anthropic_key", "sk-test")
+
+
 @pytest.mark.asyncio
 async def test_start_shadow_eval_writes_one_leg_per_key_in_one_statement(monkeypatch: pytest.MonkeyPatch):
     """N keys become N sibling rows sharing group_id and identical config, written by a
@@ -1045,6 +1047,7 @@ async def test_start_shadow_eval_writes_one_leg_per_key_in_one_statement(monkeyp
     budget exhaustion frees every requested key's slot first."""
     import litellm.proxy.proxy_server as proxy_server
 
+    _configure_anthropic_sdk_judge(monkeypatch)
     prisma = _shadow_prisma()
     monkeypatch.setattr(proxy_server, "prisma_client", prisma)
     monkeypatch.setattr(proxy_server, "llm_router", _shadow_router())
@@ -1223,6 +1226,7 @@ async def test_start_shadow_eval_rejections(
 ):
     import litellm.proxy.proxy_server as proxy_server
 
+    _configure_anthropic_sdk_judge(monkeypatch)
     prisma = _shadow_prisma(legs=[_leg_record(id=f"leg-{key}", group_id="job-7", api_key_id=key) for key in claimed])
     monkeypatch.setattr(proxy_server, "prisma_client", prisma)
     monkeypatch.setattr(proxy_server, "llm_router", _shadow_router())
@@ -1287,6 +1291,7 @@ async def test_start_shadow_eval_names_the_colliding_arm_by_the_deployment_the_a
     """
     import litellm.proxy.proxy_server as proxy_server
 
+    _configure_anthropic_sdk_judge(monkeypatch)
     monkeypatch.setattr(proxy_server, "prisma_client", _shadow_prisma())
     monkeypatch.setattr(proxy_server, "llm_router", _shadow_router())
 
@@ -1304,6 +1309,7 @@ async def test_start_shadow_eval_names_the_busy_key_and_its_job(monkeypatch: pyt
     it, and the 409 names which key and which job so the caller can stop or drop it."""
     import litellm.proxy.proxy_server as proxy_server
 
+    _configure_anthropic_sdk_judge(monkeypatch)
     prisma = _shadow_prisma(legs=[_leg_record(id="leg-b", group_id="job-7", api_key_id="key-hash-2")])
     monkeypatch.setattr(proxy_server, "prisma_client", prisma)
     monkeypatch.setattr(proxy_server, "llm_router", _shadow_router())
@@ -1320,6 +1326,7 @@ async def test_start_shadow_eval_reuses_a_key_whose_previous_job_already_stopped
     that forgets that would strand every key that has ever finished a job."""
     import litellm.proxy.proxy_server as proxy_server
 
+    _configure_anthropic_sdk_judge(monkeypatch)
     prisma = _shadow_prisma(legs=[_leg_record(group_id="job-7", stopped_at=datetime.now(timezone.utc))])
     monkeypatch.setattr(proxy_server, "prisma_client", prisma)
     monkeypatch.setattr(proxy_server, "llm_router", _shadow_router())
@@ -1364,6 +1371,7 @@ async def test_start_shadow_eval_reverse_records_its_arms_and_holds_its_own_slot
     the slot must not block a reverse one. The second reverse start still 409s."""
     import litellm.proxy.proxy_server as proxy_server
 
+    _configure_anthropic_sdk_judge(monkeypatch)
     legs = [_leg_record(group_id="job-fwd")]
     prisma = _shadow_prisma(legs=legs)
     monkeypatch.setattr(proxy_server, "prisma_client", prisma)
@@ -1387,6 +1395,7 @@ async def test_start_shadow_eval_reverse_records_its_arms_and_holds_its_own_slot
 async def test_start_shadow_eval_forward_leaves_the_baseline_column_empty(monkeypatch: pytest.MonkeyPatch):
     import litellm.proxy.proxy_server as proxy_server
 
+    _configure_anthropic_sdk_judge(monkeypatch)
     prisma = _shadow_prisma()
     monkeypatch.setattr(proxy_server, "prisma_client", prisma)
     monkeypatch.setattr(proxy_server, "llm_router", _shadow_router())
@@ -1432,6 +1441,7 @@ async def test_start_shadow_eval_concurrent_unique_violation_is_a_409(monkeypatc
     import litellm.proxy.proxy_server as proxy_server
     from prisma.errors import UniqueViolationError
 
+    _configure_anthropic_sdk_judge(monkeypatch)
     prisma = _shadow_prisma()
     prisma.db.litellm_shadowevaljob.create_many = AsyncMock(
         side_effect=UniqueViolationError(MagicMock(message="unique constraint"))
@@ -2169,9 +2179,7 @@ async def test_start_shadow_eval_sees_a_collision_hidden_behind_the_second_teams
     monkeypatch.setattr(proxy_server, "llm_router", _shadow_router())
 
     monkeypatch.setattr(proxy_server, "prisma_client", _shadow_prisma(key_teams={"key-hash": "team-a"}))
-    accepted = await start_shadow_eval(
-        _start_request(router_name="b-team-router", judge_model="house-sonnet"), ADMIN
-    )
+    accepted = await start_shadow_eval(_start_request(router_name="b-team-router", judge_model="house-sonnet"), ADMIN)
     assert accepted.job_id
 
     monkeypatch.setattr(


### PR DESCRIPTION
## TLDR

Problem this solves:

- Shadow jobs accepted unavailable Anthropic SDK judges

How it solves it:

- Rejects known-missing Anthropic SDK credentials at creation
- Preserves configured judges and secret-managed credentials

## User Flow

Before: a proxy admin starts a shadow evaluation with the default judge, then the job wastes attempts on authentication failures

1. They send POST http://localhost:4585/auto_router/shadow_eval/start with a router name and no judge model
2. The proxy returns 201 with a running job even though Anthropic credentials are unavailable
3. The job later records judge authentication errors instead of verdicts

After: the same start request returns an actionable validation error before the job is created

1. They send POST http://localhost:4585/auto_router/shadow_eval/start with the same router name and no judge model
2. The proxy returns 400 naming ANTHROPIC_API_KEY or ANTHROPIC_AUTH_TOKEN
3. They select a configured judge or configure direct Anthropic credentials

## Relevant issues

## Linear ticket

Resolves LIT-6385

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally
- [ ] My PR passes all required CI/CD checks
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile Confidence Score of at least 4/5 before requesting a maintainer review

## Screenshots / Proof of Fix

Shared setup: a local proxy runs without Anthropic credentials. `test-router` uses a configured Bedrock tier and `configured-judge` is a configured Anthropic deployment

### Before (b724ebc225)

1. `curl -sS -o response.json -w "%{http_code}" -X POST http://localhost:4585/auto_router/shadow_eval/start -H "Authorization: Bearer <fresh-key>" -H "Content-Type: application/json" -d '{"router_name":"test-router"}'` returned `201`
2. The response created a running job using `anthropic/claude-sonnet-5` without available direct credentials

### After (1122c64ba9)

#### Default SDK judge

1. The same curl command returned `400`
2. The response was `{"detail":"judge_model 'anthropic/claude-sonnet-5' uses the LiteLLM SDK but required credentials are not configured: ANTHROPIC_API_KEY or ANTHROPIC_AUTH_TOKEN"}`

#### Configured judge

1. `curl -sS -o response.json -w "%{http_code}" -X POST http://localhost:4585/auto_router/shadow_eval/start -H "Authorization: Bearer <fresh-key>" -H "Content-Type: application/json" -d '{"router_name":"test-router","judge_model":"configured-judge"}'` returned `201`
2. The response created a running job using `configured-judge`

## Type

🐛 Bug Fix

## Caveats (if any)

### Low

- Other direct SDK providers retain existing start behavior

## Final Attestation

- [x] The tests check the right things, including edge cases, and regressions in the respective user flow are not possible after this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to shadow-eval start validation and clearer 400 responses; runtime routing and auth for live traffic are unchanged.
> 
> **Overview**
> Shadow eval **start** now fails fast when a judge or reverse **baseline** resolves through the LiteLLM SDK as Anthropic but no credentials are available, instead of creating a job that later errors on every judge call.
> 
> `_validate_plain_model` still rejects unresolvable models and auto-routers per team, then adds a separate check for `judge_target(...).via == "sdk"`: it calls `_sdk_model_is_missing_anthropic_credentials`, which looks at `litellm` keys, `AnthropicModelInfo`, env vars, and whether the secret manager would supply `ANTHROPIC_API_KEY` / `ANTHROPIC_AUTH_TOKEN`. Missing creds return **400** with an explicit message; proxy-configured judges and valid env/secret paths are unchanged. Errors can be scoped to the affected **team(s)** when keys differ.
> 
> Tests stub Anthropic creds for existing flows and cover rejection, env/secret acceptance, configured judges, reverse baselines, and team-specific detail.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 90b410dd41edbd53a12163ba31355a76ea71780f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->