### PR TITLE
feat(complexity_router): advisor-backed tiers for Anthropic executors

### DIFF
--- a/litellm/constants.py
+++ b/litellm/constants.py
@@ -1787,6 +1787,10 @@ DEFAULT_COMPETITOR_DISCOVERY_MODEL: Final = "gpt-4o-mini"
 ADVISOR_NATIVE_PROVIDERS: Final[frozenset] = frozenset({"anthropic"})
 # Hard cap on advisor iterations per request to prevent runaway loops.
 ADVISOR_MAX_USES: Final[int] = 5
+# Request marker set by the complexity router when IT injected the advisor tool for a tier,
+# so the response transformations strip advisor blocks only for callers who never asked for
+# them. Must stay listed in types/utils.py all_litellm_params so it never reaches a provider.
+ADVISOR_INJECTED_PARAM: Final[str] = "_advisor_injected_by_router"
 # Description injected into the synthetic advisor tool definition sent to non-native providers.
 ADVISOR_TOOL_DESCRIPTION: Final[str] = (
     "Consult a highly intelligent advisor model when you need expert guidance, "

--- a/litellm/litellm_core_utils/get_litellm_params.py
+++ b/litellm/litellm_core_utils/get_litellm_params.py
@@ -2,6 +2,7 @@ from collections.abc import Mapping, MutableMapping
 from types import MappingProxyType
 from typing import Final
 
+from litellm.constants import ADVISOR_INJECTED_PARAM
 from litellm.llms.openai.data_residency import infer_openai_data_residency
 
 AWS_CREDENTIAL_KWARGS_KEYS: Final = frozenset(
@@ -27,7 +28,7 @@ RUST_KWARG_KEY: Final = "rust"
 # Keys `completion()` forwards from its own kwargs into `get_litellm_params`,
 # which are otherwise invisible to it because that call site passes explicit
 # named arguments rather than `**kwargs`.
-FORWARDED_KWARGS_KEYS: Final = AWS_CREDENTIAL_KWARGS_KEYS | frozenset({RUST_KWARG_KEY})
+FORWARDED_KWARGS_KEYS: Final = AWS_CREDENTIAL_KWARGS_KEYS | frozenset({RUST_KWARG_KEY, ADVISOR_INJECTED_PARAM})
 
 # Pre-define optional kwargs keys as frozenset for O(1) lookups
 # These are extracted from kwargs only if present, avoiding unnecessary .get() calls
@@ -59,6 +60,10 @@ OPTIONAL_KWARGS_KEYS: Final = (
             # of the provider body; this keeps it *in* litellm_params, which is
             # where the chat completions handlers read it from.
             RUST_KWARG_KEY,
+            # Router-injected advisor marker: same pattern as RUST_KWARG_KEY, read by
+            # the Anthropic response transform to strip advisor blocks the caller
+            # never asked for.
+            ADVISOR_INJECTED_PARAM,
         }
     )
     | AWS_CREDENTIAL_KWARGS_KEYS

--- a/litellm/llms/anthropic/chat/transformation.py
+++ b/litellm/llms/anthropic/chat/transformation.py
@@ -10,6 +10,7 @@ from pydantic import ValidationError
 
 import litellm
 from litellm.constants import (
+    ADVISOR_INJECTED_PARAM,
     ANTHROPIC_MIN_THINKING_BUDGET_TOKENS,
     ANTHROPIC_WEB_SEARCH_TOOL_MAX_USES,
     DEFAULT_ANTHROPIC_CHAT_MAX_TOKENS,
@@ -89,6 +90,7 @@ from ..common_utils import (
     AnthropicModelInfo,
     process_anthropic_headers,
     strip_advisor_blocks_from_messages,
+    stripped_response_content_for_injected_advisor,
 )
 
 if TYPE_CHECKING:
@@ -2605,6 +2607,13 @@ class AnthropicConfig(AnthropicModelInfo, BaseConfig):
             _candidate: Final = litellm_params.get(ANTHROPIC_TOOL_NAME_REVERSE_MAP_KEY)
             if isinstance(_candidate, dict):
                 tool_name_reverse_map = _candidate
+
+        if litellm_params.get(ADVISOR_INJECTED_PARAM):
+            _stripped_content: Final = stripped_response_content_for_injected_advisor(
+                completion_response.get("content")
+            )
+            if _stripped_content is not None:
+                completion_response["content"] = list(_stripped_content)  # mutable-ok: response JSON list
 
         model_response = self.transform_parsed_response(
             completion_response=completion_response,

--- a/litellm/llms/anthropic/common_utils.py
+++ b/litellm/llms/anthropic/common_utils.py
@@ -4,7 +4,7 @@ This file contains common utils for anthropic calls.
 
 import copy
 import re
-from collections.abc import Mapping, MutableMapping, Sequence
+from collections.abc import Iterator, Mapping, MutableMapping, Sequence
 from datetime import datetime, timezone
 from types import MappingProxyType
 from typing import Any, Final, Literal
@@ -23,10 +23,13 @@ from litellm.litellm_core_utils.prompt_templates.factory import (
 from litellm.llms.base_llm.base_utils import BaseLLMModelInfo, BaseTokenCounter
 from litellm.llms.base_llm.chat.transformation import BaseLLMException
 from litellm.types.llms.anthropic import (
+    ANTHROPIC_ADVISOR_TOOL_NAME,
+    ANTHROPIC_ADVISOR_TOOL_TYPE,
     ANTHROPIC_HOSTED_TOOLS,
     ANTHROPIC_OAUTH_BETA_HEADER,
     ANTHROPIC_OAUTH_TOKEN_PREFIX,
     AllAnthropicToolsValues,
+    AnthropicAdvisorTool,
     AnthropicMcpServerTool,
 )
 from litellm.types.llms.openai import AllMessageValues
@@ -888,6 +891,102 @@ class AnthropicModelInfo(BaseLLMModelInfo):
         return AnthropicTokenCounter()
 
 
+def _advisor_result_text(block: Mapping[str, Any]) -> str:
+    raw: Final = block.get("content") or ""
+    if isinstance(raw, str):
+        return raw
+    return "\n".join(b.get("text", "") for b in raw if isinstance(b, dict) and b.get("type") == "text").strip()
+
+
+def _is_advisor_use(block: Mapping[str, Any]) -> bool:
+    return block.get("type") == "server_tool_use" and block.get("name") == ANTHROPIC_ADVISOR_TOOL_NAME
+
+
+def build_advisor_tool(
+    model: str, max_uses: int | None = None, caching: Mapping[str, object] | None = None
+) -> AnthropicAdvisorTool:
+    """The one place the advisor wire tool is assembled, so non-provider layers
+    (e.g. the complexity router's tier injection) never hand-write the block."""
+    return {
+        "type": ANTHROPIC_ADVISOR_TOOL_TYPE,
+        "name": ANTHROPIC_ADVISOR_TOOL_NAME,
+        "model": model,
+        **({"max_uses": max_uses} if max_uses is not None else {}),
+        **({"caching": {**caching}} if caching is not None else {}),
+    }
+
+
+def _advisor_feedback_block(advice: str) -> Mapping[str, str]:
+    return {"type": "text", "text": f"<advisor_feedback>\n{advice}\n</advisor_feedback>"}  # mutable-ok: JSON block
+
+
+def strip_advisor_blocks_from_content(content: Sequence[Any], replace_with_text: bool = False) -> Sequence[Any] | None:
+    """Rewrite one content-block list without its advisor exchange.
+
+    Returns the rewritten blocks, or None when the list carries no advisor
+    server_tool_use. In replace mode the exchange collapses into an <advisor_feedback>
+    text block so the guidance survives as ordinary text, otherwise it is stripped
+    silently; paired advisor_tool_result blocks are always dropped."""
+    advisor_ids: Final[frozenset[str]] = frozenset(
+        block_id
+        for block in content
+        if isinstance(block, dict)
+        and _is_advisor_use(block)
+        and isinstance(block_id := block.get("id"), str)
+        and block_id
+    )
+    if not advisor_ids:
+        return None
+    advice_by_id: Final[Mapping[str, str]] = MappingProxyType(
+        {
+            tool_use_id: _advisor_result_text(block)
+            for block in content
+            if isinstance(block, dict)
+            and block.get("type") == "advisor_tool_result"
+            and isinstance(tool_use_id := block.get("tool_use_id"), str)
+            and tool_use_id in advisor_ids
+        }
+    )
+
+    def _rewritten_blocks() -> Iterator[Any]:
+        for block in content:
+            if not isinstance(block, dict):
+                yield block
+            elif _is_advisor_use(block) and block.get("id") in advisor_ids:
+                advice = advice_by_id.get(str(block.get("id")), "") if replace_with_text else ""
+                if advice:
+                    yield _advisor_feedback_block(advice)
+            elif block.get("type") == "advisor_tool_result" and block.get("tool_use_id") in advisor_ids:
+                continue
+            else:
+                yield block
+
+    return tuple(_rewritten_blocks())
+
+
+def stripped_response_content_for_injected_advisor(content: object) -> Sequence[Any] | None:
+    """Response-side strip for an advisor tool the router injected.
+
+    Returns the rewritten content blocks (advice kept as <advisor_feedback> text so a
+    caller replaying the history keeps the plan), or None when no advisor exchange is
+    present. A plain tool_use named advisor means the upstream account never orchestrated
+    the consult (advisor beta not enabled); it stays untouched, because stripping it
+    would orphan the response's stop_reason."""
+    if not isinstance(content, list):
+        return None
+    rewritten: Final = strip_advisor_blocks_from_content(content, replace_with_text=True)
+    if rewritten is None:
+        blocks: Final = [block for block in content if isinstance(block, dict)]
+        if any(b.get("type") == "tool_use" and b.get("name") == ANTHROPIC_ADVISOR_TOOL_NAME for b in blocks):
+            litellm.verbose_logger.warning(
+                "Advisor tool_use came back unorchestrated (upstream may lack the advisor beta); returning unchanged"
+            )
+        return None
+    consults: Final = sum(1 for block in content if isinstance(block, dict) and _is_advisor_use(block))
+    litellm.verbose_logger.info("Advisor: stripped %d consult(s) from the response", consults)
+    return rewritten
+
+
 def strip_advisor_blocks_from_messages(messages: list[Any], replace_with_text: bool = False) -> list[Any]:
     """
     Remove (or replace) server_tool_use (name='advisor') and advisor_tool_result blocks
@@ -910,67 +1009,9 @@ def strip_advisor_blocks_from_messages(messages: list[Any], replace_with_text: b
         content = message.get("content")
         if not isinstance(content, list):
             continue
-
-        # Collect advisor server_tool_use ids and their advice text (for replace mode).
-        advisor_id_to_text: dict = {}
-        for block in content:
-            if isinstance(block, dict) and block.get("type") == "server_tool_use" and block.get("name") == "advisor":
-                bid = block.get("id")
-                if bid:
-                    advisor_id_to_text[bid] = None  # text filled in below
-
-        if not advisor_id_to_text:
-            continue
-
-        # If replacing, collect the advisor response text from advisor_tool_result blocks.
-        if replace_with_text:
-            for block in content:
-                if (
-                    isinstance(block, dict)
-                    and block.get("type") == "advisor_tool_result"
-                    and block.get("tool_use_id") in advisor_id_to_text
-                ):
-                    raw = block.get("content") or ""
-                    text = (
-                        raw
-                        if isinstance(raw, str)
-                        else next(
-                            (b.get("text", "") for b in raw if isinstance(b, dict) and b.get("type") == "text"),
-                            "",
-                        )
-                    )
-                    advisor_id_to_text[block["tool_use_id"]] = text
-
-        new_content = []
-        for block in content:
-            if not isinstance(block, dict):
-                new_content.append(block)
-                continue
-            is_advisor_use = (
-                block.get("type") == "server_tool_use"
-                and block.get("name") == "advisor"
-                and block.get("id") in advisor_id_to_text
-            )
-            is_advisor_result = (
-                block.get("type") == "advisor_tool_result" and block.get("tool_use_id") in advisor_id_to_text
-            )
-            if is_advisor_use:
-                if replace_with_text:
-                    advice = advisor_id_to_text.get(block.get("id")) or ""
-                    if advice:
-                        new_content.append(
-                            {
-                                "type": "text",
-                                "text": f"<advisor_feedback>\n{advice}\n</advisor_feedback>",
-                            }
-                        )
-                # else: drop silently
-            elif is_advisor_result:
-                pass  # always drop — replaced above (or stripped)
-            else:
-                new_content.append(block)
-
-        message["content"] = new_content
+        rewritten = strip_advisor_blocks_from_content(content, replace_with_text)
+        if rewritten is not None:
+            message["content"] = list(rewritten)  # mutable-ok: request content stays a JSON list
     return messages
 
 

--- a/litellm/llms/custom_httpx/llm_http_handler.py
+++ b/litellm/llms/custom_httpx/llm_http_handler.py
@@ -19,7 +19,7 @@ import litellm.types
 import litellm.types.utils
 from litellm._logging import _redact_string, verbose_logger
 from litellm.anthropic_beta_headers_manager import update_headers_with_filtered_beta
-from litellm.constants import REALTIME_WEBSOCKET_MAX_MESSAGE_SIZE_BYTES
+from litellm.constants import ADVISOR_INJECTED_PARAM, REALTIME_WEBSOCKET_MAX_MESSAGE_SIZE_BYTES
 from litellm.litellm_core_utils.agentic_loop_settings import (
     DEFAULT_MAX_AGENTIC_LOOPS,
     validated_max_agentic_loops,
@@ -2339,6 +2339,12 @@ class BaseLLMHTTPHandler:
         api_key: str | None,
         kwargs: dict,
     ) -> AnthropicMessagesResponse | AsyncIterator:
+        if kwargs.get(ADVISOR_INJECTED_PARAM):
+            from litellm.llms.anthropic.common_utils import stripped_response_content_for_injected_advisor
+
+            stripped_content: Final = stripped_response_content_for_injected_advisor(initial_response.get("content"))
+            if stripped_content is not None:
+                initial_response["content"] = list(stripped_content)  # mutable-ok: response JSON list
         # Inject api_key into kwargs so follow-up calls in agentic hooks can
         # authenticate. api_key is a named param here (not in kwargs), so
         # _prepare_followup_kwargs would miss it otherwise.

--- a/litellm/proxy/auth/auth_checks.py
+++ b/litellm/proxy/auth/auth_checks.py
@@ -92,6 +92,7 @@ from litellm.proxy.common_utils.user_api_key_cache import (
 from litellm.proxy.db.exception_handler import PrismaDBExceptionHandler
 from litellm.proxy.guardrails.tool_name_extraction import (
     TOOL_CAPABLE_CALL_TYPES,
+    effective_allowed_tools,
     extract_request_tool_names,
 )
 from litellm.proxy.route_llm_request import route_request
@@ -745,14 +746,9 @@ async def check_tools_allowlist(
     tool_names: Final = extract_request_tool_names(route, request_body)
     if not tool_names:
         return
-    key_meta: Final = (valid_token.metadata or {}) if isinstance(valid_token.metadata, dict) else {}
-    team_meta: Final = (valid_token.team_metadata or {}) if isinstance(valid_token.team_metadata, dict) else {}
-    key_allowed: Final = key_meta.get("allowed_tools")
-    team_allowed: Final = team_meta.get("allowed_tools")
-    effective: Final = key_allowed if (isinstance(key_allowed, list) and len(key_allowed) > 0) else team_allowed
-    if not isinstance(effective, list) or len(effective) == 0:
+    allowed_set: Final = effective_allowed_tools(valid_token.metadata, valid_token.team_metadata)
+    if allowed_set is None:
         return
-    allowed_set: Final = {str(t) for t in effective}
     disallowed: Final = [n for n in tool_names if n not in allowed_set]
     if disallowed:
         raise ProxyException(

--- a/litellm/proxy/guardrails/tool_name_extraction.py
+++ b/litellm/proxy/guardrails/tool_name_extraction.py
@@ -60,6 +60,19 @@ TOOL_CAPABLE_CALL_TYPES: Final = frozenset(
 )
 
 
+def effective_allowed_tools(key_metadata: object, team_metadata: object) -> frozenset[str] | None:
+    """The allowlist in force for a caller: key-level allowed_tools beats team-level.
+    None means no allowlist is configured and every tool is permitted."""
+    key_meta: Final = key_metadata if isinstance(key_metadata, dict) else {}
+    team_meta: Final = team_metadata if isinstance(team_metadata, dict) else {}
+    key_allowed: Final = key_meta.get("allowed_tools")
+    team_allowed: Final = team_meta.get("allowed_tools")
+    effective: Final = key_allowed if isinstance(key_allowed, list) and key_allowed else team_allowed
+    if not isinstance(effective, list) or not effective:
+        return None
+    return frozenset(str(tool) for tool in effective)
+
+
 def extract_request_tool_names(route: str, data: dict) -> list[str]:
     """
     Extract tool names from the request body for the given route.

--- a/litellm/router_strategy/complexity_router/README.md
+++ b/litellm/router_strategy/complexity_router/README.md
@@ -68,6 +68,45 @@ still resolve to a deployment in `model_list`; this configuration does not creat
             - abc
 ```
 
+### Advisor-backed tiers (Anthropic executors only)
+
+A tier entry may pair its executor with a higher-tier advisor via Anthropic's advisor tool
+(`advisor_20260301`). The router appends the tool to the caller's own tools on the way out
+(the beta header is added by the Anthropic transformation) and strips the advisor exchange
+from the response on the way back, replacing it with an `<advisor_feedback>` text block so
+the guidance survives in the caller's history. Callers see an unchanged request and
+response shape and never have to know the advisor exists
+
+```yaml
+        tiers:
+          SIMPLE: haiku
+          MEDIUM:
+            model_name: haiku
+            advisor:
+              model: opus            # a model_list name (resolved to its Anthropic model id) or a raw Anthropic model id
+              max_uses: 2            # optional consult budget per request; omitted means Anthropic's default
+              caching: {type: ephemeral, ttl: 5m}   # optional, forwarded verbatim
+          COMPLEX:
+            model_name: sonnet
+            advisor: {model: opus, max_uses: 2}
+          REASONING: opus
+```
+
+Scope and fail-closed rules, all reported as `advisor_offered: false` on the routing
+decision instead of erroring:
+
+- The tier's model group must resolve entirely to Anthropic deployments (the only provider
+  that orchestrates the advisor natively). Prefix executor models with `anthropic/` or set
+  `custom_llm_provider`
+- Streaming requests are not advised; the response strip is non-streaming only
+- A caller who already sends their own advisor tool keeps it untouched, blocks included
+- A key or team whose `allowed_tools` excludes `advisor` never has the tool injected, matching
+  the allowlist auth enforces on caller-sent tools
+- `max_uses` resets per request, not per session; keep it small for agentic traffic
+- Advisor tokens (`usage.iterations[]`, type `advisor_message`) are counted in the request's
+  usage but priced at the executor's rate for now; the split advisor-rate pricing is a
+  known follow-up
+
 ### Renaming the tiers
 
 `tier_labels` puts your own vocabulary on the four tiers:

--- a/litellm/router_strategy/complexity_router/complexity_router.py
+++ b/litellm/router_strategy/complexity_router/complexity_router.py
@@ -26,12 +26,19 @@ from typing import TYPE_CHECKING, Any, Final, Literal, NamedTuple, cast
 from pydantic import BaseModel, create_model
 
 from litellm._logging import verbose_router_logger
-from litellm.constants import EMPTY_MAPPING, RETURN_RAW_MODEL_NAME_METADATA_KEY
+from litellm.constants import (
+    ADVISOR_INJECTED_PARAM,
+    ADVISOR_NATIVE_PROVIDERS,
+    EMPTY_MAPPING,
+    RETURN_RAW_MODEL_NAME_METADATA_KEY,
+)
 from litellm.integrations.custom_logger import CustomLogger
 from litellm.litellm_core_utils.core_helpers import get_metadata_variable_name_from_kwargs
 from litellm.litellm_core_utils.internal_call_metadata import forwarded_internal_call_metadata
 from litellm.litellm_core_utils.sensitive_data_masker import mask_credentials_in_payload
+from litellm.llms.anthropic.common_utils import build_advisor_tool
 from litellm.llms.base_llm.base_utils import type_to_response_format_param
+from litellm.types.llms.anthropic import ANTHROPIC_ADVISOR_TOOL_NAME, ANTHROPIC_ADVISOR_TOOL_TYPE
 from litellm.types.utils import (
     AUTOROUTER_CLASSIFIER_CALL_ORIGIN,
     ModelResponse,
@@ -56,6 +63,7 @@ from .config import (
     ClassificationRubric,
     ComplexityRouterConfig,
     ComplexityTier,
+    ComplexityTierModel,
     TierDefinition,
 )
 
@@ -764,6 +772,40 @@ class _SessionAffinityPin(NamedTuple):
     tier: ComplexityTier | None
 
 
+class _AdvisorInjection(NamedTuple):
+    """Tier params for the routed decision plus the advisor outcome for its record.
+
+    `effective` is what the request carries (declared params, plus the merged tools list
+    and the injected-marker when the advisor applies); `declared` is what the operator
+    wrote on the tier entry and is what the routing decision reports, so decision logs
+    never swell with the caller's full tool list. `offered` is None when the tier has no
+    advisor config, so the decision only carries advisor fields where one was declared.
+    """
+
+    effective: Mapping[str, object]
+    declared: Mapping[str, object]
+    offered: bool | None
+    advisor_model: str | None
+
+
+def _declared_provider(deployment: Mapping[str, object]) -> str:
+    """Deployment provider read from declared config only.
+
+    Never resolves through litellm.get_llm_provider: some providers run an OAuth
+    device flow on resolution, which would block the routing hot path.
+    """
+    params: Final = deployment.get("litellm_params")
+    if not isinstance(params, Mapping):
+        return ""
+    provider: Final = params.get("custom_llm_provider")
+    if isinstance(provider, str) and provider:
+        return provider
+    model_value: Final = params.get("model")
+    if isinstance(model_value, str) and "/" in model_value:
+        return model_value.split("/", 1)[0]
+    return ""
+
+
 def _parse_session_affinity_pin(value: object) -> _SessionAffinityPin | None:
     if isinstance(value, str):
         return _SessionAffinityPin(model=value, tier=None)
@@ -1195,6 +1237,8 @@ class ComplexityRouter(CustomLogger):
         classifier_cost: float | None = None,
         conversation_continuing: bool = True,
         tier_litellm_params: Mapping[str, object] | None = None,
+        advisor_offered: bool | None = None,
+        advisor_model: str | None = None,
     ) -> StandardLoggingRoutingDecision:
         """Assemble the per-request provenance record for this router's decision.
 
@@ -1248,6 +1292,10 @@ class ComplexityRouter(CustomLogger):
             masked_tier_litellm_params: Final = mask_credentials_in_payload(tier_litellm_params)
             if isinstance(masked_tier_litellm_params, Mapping):
                 decision["tier_litellm_params"] = masked_tier_litellm_params
+        if advisor_offered is not None:
+            decision["advisor_offered"] = advisor_offered
+        if advisor_model is not None:
+            decision["advisor_model"] = advisor_model
         return decision
 
     async def aclassify(
@@ -1636,12 +1684,99 @@ class ComplexityRouter(CustomLogger):
 
         raise ValueError(f"No model configured for tier {tier_key} and no default_model set")
 
-    def _litellm_params_for_model(self, tier: ComplexityTier | str | None, model: str) -> Mapping[str, object]:
+    def _tier_entry_for_model(self, tier: ComplexityTier | str | None, model: str) -> ComplexityTierModel | None:
         if tier is None:
-            return MappingProxyType({})
+            return None
         entries: Final = self.config.tier_model_configs.get(_tier_name(tier), ())
-        entry: Final = next((candidate for candidate in entries if candidate.model_name == model), None)
+        return next((candidate for candidate in entries if candidate.model_name == model), None)
+
+    def _litellm_params_for_model(self, tier: ComplexityTier | str | None, model: str) -> Mapping[str, object]:
+        entry: Final = self._tier_entry_for_model(tier, model)
         return entry.litellm_params if entry is not None else MappingProxyType({})
+
+    def _model_group_is_all_anthropic(self, model: str) -> bool:
+        deployments: Final = self.litellm_router_instance.get_model_list(model_name=model)
+        if not deployments:
+            return False
+        return all(_declared_provider(deployment) in ADVISOR_NATIVE_PROVIDERS for deployment in deployments)
+
+    def _resolve_advisor_model(self, configured: str) -> str | None:
+        """Resolve a configured advisor model to the Anthropic model id sent on the wire.
+
+        A name serving router deployments resolves through them (a group name forwarded
+        verbatim is rejected upstream, LIT-6020); a name serving none passes through as a
+        raw Anthropic model id. Fails closed with None on any non-Anthropic deployment,
+        on more than one distinct underlying model (config order must never pick the
+        consulted model), and on a wildcard surviving resolution (the pattern router
+        substitutes matched segments, so a survivor is a literal wildcard model)."""
+        stripped_configured: Final = configured.removeprefix("anthropic/")
+        deployments: Final = self.litellm_router_instance.get_model_list(model_name=configured) or ()
+        if not deployments:
+            return stripped_configured
+        if any(_declared_provider(deployment) not in ADVISOR_NATIVE_PROVIDERS for deployment in deployments):
+            return None
+        distinct_models: Final = frozenset(
+            model_value.removeprefix("anthropic/")
+            for deployment in deployments
+            if isinstance(model_value := deployment["litellm_params"].get("model"), str) and model_value
+        )
+        if len(distinct_models) != 1:
+            return None
+        resolved: Final = next(iter(distinct_models))
+        return None if "*" in resolved else resolved
+
+    def _advisor_augmented_params(
+        self,
+        tier: ComplexityTier | str | None,
+        model: str,
+        request_kwargs: Mapping[str, object],
+    ) -> _AdvisorInjection:
+        """Tier litellm_params for the routed (tier, model), advisor tool appended when it applies.
+
+        Fail-closed: injected only for a non-streaming request, a tools list without its
+        own advisor tool, a caller whose allowed_tools policy permits it, and a tier group
+        resolving entirely to Anthropic (the only provider orchestrating advisor_20260301
+        natively). Every skip reports advisor_offered=False instead of erroring."""
+        declared: Final = self._litellm_params_for_model(tier, model)
+        entry: Final = self._tier_entry_for_model(tier, model)
+        advisor: Final = entry.advisor if entry is not None else None
+        if advisor is None:
+            return _AdvisorInjection(effective=declared, declared=declared, offered=None, advisor_model=None)
+
+        advised_tier_name: Final = _tier_name(tier) if tier is not None else ""
+
+        def _skipped(reason: str) -> _AdvisorInjection:
+            verbose_router_logger.warning(
+                "ComplexityRouter: advisor for tier=%s model=%s not offered: %s", advised_tier_name, model, reason
+            )
+            return _AdvisorInjection(effective=declared, declared=declared, offered=False, advisor_model=None)
+
+        if request_kwargs.get("stream"):
+            return _skipped("streaming requests are not advised (response strip is non-streaming only)")
+        declared_tools: Final = declared.get("tools")
+        base_tools: Final = declared_tools if declared_tools is not None else request_kwargs.get("tools")
+        if base_tools is not None and not isinstance(base_tools, list):
+            return _skipped("request tools is not a list")
+        if isinstance(base_tools, list) and any(
+            isinstance(tool, dict) and tool.get("type") == ANTHROPIC_ADVISOR_TOOL_TYPE for tool in base_tools
+        ):
+            return _skipped("an advisor tool is already present on the request")
+        caller_allowed: Final = self._caller_allowed_tools(request_kwargs)
+        if caller_allowed is not None and ANTHROPIC_ADVISOR_TOOL_NAME not in caller_allowed:
+            return _skipped("the caller's allowed_tools policy excludes the advisor tool")
+        if not self._model_group_is_all_anthropic(model):
+            return _skipped("tier model group does not resolve to Anthropic deployments only")
+        advisor_model: Final = self._resolve_advisor_model(advisor.model)
+        if advisor_model is None:
+            return _skipped(f"advisor model {advisor.model!r} does not resolve to exactly one Anthropic model")
+        advisor_tool: Final = build_advisor_tool(
+            model=advisor_model, max_uses=advisor.max_uses, caching=advisor.caching
+        )
+        merged_tools: Final = (
+            [*base_tools, advisor_tool] if isinstance(base_tools, list) else [advisor_tool]
+        )  # mutable-ok: request tools stays a JSON list transforms iterate and copy
+        effective: Final = MappingProxyType({**declared, "tools": merged_tools, ADVISOR_INJECTED_PARAM: True})
+        return _AdvisorInjection(effective=effective, declared=declared, offered=True, advisor_model=advisor_model)
 
     @staticmethod
     def _pick_from_tier_value(model: str | list[str], tier_key: str) -> str:
@@ -2218,6 +2353,20 @@ class ComplexityRouter(CustomLogger):
         ]
 
     @staticmethod
+    def _caller_allowed_tools(request_kwargs: Mapping[str, object]) -> frozenset[str] | None:
+        """The authenticated caller's effective tool allowlist, so router-injected tools
+        honor the same policy check_tools_allowlist enforced on the raw request at auth."""
+        from litellm.proxy.guardrails.tool_name_extraction import effective_allowed_tools
+
+        for metadata in ComplexityRouter._iter_metadata_dicts(dict(request_kwargs)):
+            allowed = effective_allowed_tools(
+                metadata.get("user_api_key_metadata"), metadata.get("user_api_key_team_metadata")
+            )
+            if allowed is not None:
+                return allowed
+        return None
+
+    @staticmethod
     def _get_session_id_from_request_kwargs(request_kwargs: dict) -> str | None:
         """Resolve a client-supplied session_id."""
         for metadata in ComplexityRouter._iter_metadata_dicts(request_kwargs):
@@ -2363,13 +2512,15 @@ class ComplexityRouter(CustomLogger):
                         "ComplexityRouter: routing decision cause=%s, routed_model=%s", cause, routed_model
                     )
                     routed_pin_tier: Final = self._tier_for_model(routed_model) if plan_floored else resolved_pin_tier
-                    session_tier_litellm_params: Final = self._litellm_params_for_model(routed_pin_tier, routed_model)
+                    session_advised: Final = self._advisor_augmented_params(
+                        routed_pin_tier, routed_model, request_kwargs
+                    )
                     has_original_messages: Final = messages is not None and len(messages) > 0
                     return self._with_session_deployment_affinity(
                         PreRoutingHookResponse(
                             model=routed_model,
                             messages=messages if has_original_messages else None,
-                            litellm_params=session_tier_litellm_params,
+                            litellm_params=session_advised.effective,
                             routing_decision=self._build_routing_decision(
                                 routed_model=routed_model,
                                 cause=cause,
@@ -2378,7 +2529,9 @@ class ComplexityRouter(CustomLogger):
                                 escalation_keyword=pin_escalation_keyword,
                                 escalated=escalated,
                                 conversation_continuing=conversation_continuing,
-                                tier_litellm_params=session_tier_litellm_params,
+                                tier_litellm_params=session_advised.declared,
+                                advisor_offered=session_advised.offered,
+                                advisor_model=session_advised.advisor_model,
                             ),
                         )
                     )
@@ -2497,9 +2650,11 @@ class ComplexityRouter(CustomLogger):
                 _tier_name(plan_floor),
                 routed_model,
             )
+            plan_advised: Final = self._advisor_augmented_params(plan_floor, routed_model, request_kwargs)
             return PreRoutingHookResponse(
                 model=routed_model,
                 messages=messages if has_original_messages else None,
+                litellm_params=plan_advised.effective,
                 routing_decision=self._build_routing_decision(
                     routed_model=routed_model,
                     conversation_continuing=conversation_continuing,
@@ -2508,6 +2663,9 @@ class ComplexityRouter(CustomLogger):
                     matched_keyword=plan_mode_sentinel,
                     escalation_keyword=escalation_keyword,
                     escalated=False,
+                    tier_litellm_params=plan_advised.declared,
+                    advisor_offered=plan_advised.offered,
+                    advisor_model=plan_advised.advisor_model,
                 ),
             )
 
@@ -2522,7 +2680,7 @@ class ComplexityRouter(CustomLogger):
             )
             keyword_plan_floored: Final = routed_tier != escalated_tier
             routed_model = await self._pick_model_for_tier(routed_tier, messages, resolved_messages, request_kwargs)
-            keyword_tier_litellm_params: Final = self._litellm_params_for_model(routed_tier, routed_model)
+            keyword_advised: Final = self._advisor_augmented_params(routed_tier, routed_model, request_kwargs)
             keyword_cause: Final[RoutingDecisionCause] = (
                 "plan_mode"
                 if keyword_plan_floored
@@ -2538,7 +2696,7 @@ class ComplexityRouter(CustomLogger):
             return PreRoutingHookResponse(
                 model=routed_model,
                 messages=messages if has_original_messages else None,
-                litellm_params=keyword_tier_litellm_params,
+                litellm_params=keyword_advised.effective,
                 routing_decision=self._build_routing_decision(
                     routed_model=routed_model,
                     conversation_continuing=conversation_continuing,
@@ -2547,7 +2705,9 @@ class ComplexityRouter(CustomLogger):
                     matched_keyword=plan_mode_sentinel if keyword_plan_floored else override.matched_keyword,
                     escalation_keyword=escalation_keyword,
                     escalated=keyword_escalated,
-                    tier_litellm_params=keyword_tier_litellm_params,
+                    tier_litellm_params=keyword_advised.declared,
+                    advisor_offered=keyword_advised.offered,
+                    advisor_model=keyword_advised.advisor_model,
                 ),
             )
 
@@ -2647,7 +2807,7 @@ class ComplexityRouter(CustomLogger):
                 routed_model,
             )
 
-        tier_litellm_params: Final = self._litellm_params_for_model(tier, routed_model)
+        classified_advised: Final = self._advisor_augmented_params(tier, routed_model, request_kwargs)
         classifier_model: Final = (
             self.config.classifier_llm_config.model
             if outcome.cause == "llm_classifier" and self.config.classifier_llm_config is not None
@@ -2676,7 +2836,7 @@ class ComplexityRouter(CustomLogger):
         return PreRoutingHookResponse(
             model=routed_model,
             messages=messages if has_original_messages else None,
-            litellm_params=tier_litellm_params,
+            litellm_params=classified_advised.effective,
             routing_decision=self._build_routing_decision(
                 routed_model=routed_model,
                 conversation_continuing=conversation_continuing,
@@ -2689,6 +2849,8 @@ class ComplexityRouter(CustomLogger):
                 escalated=escalated,
                 classifier_model=classifier_model,
                 classifier_cost=outcome.classifier_cost,
-                tier_litellm_params=tier_litellm_params,
+                tier_litellm_params=classified_advised.declared,
+                advisor_offered=classified_advised.offered,
+                advisor_model=classified_advised.advisor_model,
             ),
         )

--- a/litellm/router_strategy/complexity_router/config.py
+++ b/litellm/router_strategy/complexity_router/config.py
@@ -184,10 +184,36 @@ class ReminderMarkerPair(BaseModel):
         return self
 
 
+class AdvisorConfig(BaseModel):
+    """Advisor pairing for a tier: the executor consults this model via Anthropic's advisor tool.
+
+    `extra="forbid"` keeps the surface to routing intent only: credentials or endpoints
+    (api_key, api_base) are deliberately not configurable here.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    model: str = Field(min_length=1, description="Router model_name or provider model id to consult")
+    max_uses: int | None = Field(default=None, ge=1, description="Consult budget per request")
+    caching: Mapping[str, object] | None = Field(default=None, description="Advisor-side cache block, sent verbatim")
+
+    @field_validator("caching", mode="before")
+    @classmethod
+    def _freeze_caching(cls, value: Mapping[str, object] | None) -> Mapping[str, object] | None:
+        return None if value is None else MappingProxyType(dict(value))
+
+    @field_serializer("caching")
+    def _serialize_caching(self, value: Mapping[str, object] | None) -> Mapping[str, object] | None:
+        return (
+            None if value is None else dict(value)
+        )  # mutable-ok: Pydantic JSON serialization needs a concrete mapping
+
+
 class ComplexityTierModel(BaseModel):
     model_config = ConfigDict(frozen=True)
 
     model_name: str
+    advisor: AdvisorConfig | None = None
     litellm_params: Annotated[Mapping[str, object], SkipValidation()] = Field(
         default_factory=lambda: MappingProxyType({})
     )
@@ -200,6 +226,10 @@ class ComplexityTierModel(BaseModel):
     @field_serializer("litellm_params")
     def _serialize_litellm_params(self, value: Mapping[str, object]) -> Mapping[str, object]:
         return dict(value)  # mutable-ok: Pydantic JSON serialization requires a concrete mapping
+
+
+def _entry_carries_state(entry: ComplexityTierModel) -> bool:
+    return bool(entry.litellm_params or entry.advisor)
 
 
 def _normalize_tier_entries(
@@ -931,10 +961,10 @@ class ComplexityRouterConfig(BaseModel):
         normalized_tiers: Final = MappingProxyType(
             {tier: normalized for tier, (normalized, _) in normalized_entries.items()}
         )
-        incoming_params: Final = (
+        incoming_entries: Final = (
             MappingProxyType(
                 {
-                    (tier, entry.model_name): entry.litellm_params
+                    (tier, entry.model_name): entry
                     for tier, entries in existing_configs.items()
                     for entry in (ComplexityTierModel.model_validate(item) for item in entries)
                 }
@@ -945,17 +975,11 @@ class ComplexityRouterConfig(BaseModel):
         tier_model_configs: Final = MappingProxyType(
             {
                 tier: tuple(
-                    entry.model_copy(
-                        update=MappingProxyType(
-                            {
-                                "litellm_params": incoming_params.get((tier, entry.model_name), entry.litellm_params),
-                            }
-                        )
-                    )
+                    entry if _entry_carries_state(entry) else incoming_entries.get((tier, entry.model_name), entry)
                     for entry in entries
                 )
                 for tier, (_, entries) in normalized_entries.items()
-                if any(entry.litellm_params for entry in entries)
+                if any(_entry_carries_state(entry) for entry in entries)
                 or (isinstance(existing_configs, dict) and tier in existing_configs)
             }
         )

--- a/litellm/types/llms/anthropic.py
+++ b/litellm/types/llms/anthropic.py
@@ -132,6 +132,7 @@ class AnthropicToolSearchToolBM25(TypedDict, total=False):
 
 
 ANTHROPIC_ADVISOR_TOOL_TYPE: Final = "advisor_20260301"
+ANTHROPIC_ADVISOR_TOOL_NAME: Final = "advisor"
 
 
 class AnthropicAdvisorTool(TypedDict, total=False):
@@ -564,9 +565,9 @@ class CompactionBlock(TypedDict, total=False):
 
 
 class UsageIteration(TypedDict, total=False):
-    """One sampling iteration's token usage (compact_20260112)."""
+    """One sampling iteration's token usage (compact_20260112, advisor-tool-2026-03-01)."""
 
-    type: Required[Literal["compaction", "message"]]
+    type: Required[ReadOnly[Literal["compaction", "message", "advisor_message"]]]
     input_tokens: int
     output_tokens: int
 

--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -2885,6 +2885,8 @@ class StandardLoggingRoutingDecision(TypedDict, total=False):
     savings_baseline_model: str
     savings_baseline_deployment_id: str
     tier_litellm_params: Mapping[str, object]  # writable-ok: Pydantic warns on ReadOnly TypedDict fields
+    advisor_offered: bool  # writable-ok: Pydantic warns on ReadOnly TypedDict fields
+    advisor_model: str  # writable-ok: Pydantic warns on ReadOnly TypedDict fields
 
 
 # Fields whose values quote the caller's prompt. Dropped when an operator turns message
@@ -2911,6 +2913,8 @@ DERIVED_ROUTING_DECISION_FIELDS: Final[frozenset[str]] = frozenset(
         "savings_baseline_model",
         "savings_baseline_deployment_id",
         "tier_litellm_params",
+        "advisor_offered",
+        "advisor_model",
     }
 )
 
@@ -3501,6 +3505,7 @@ agentic_loop_internal_litellm_params: Final = [
     "_code_interpreter_interception_converted_stream",
     "_websearch_interception_emit_native_blocks",
     "_websearch_interception_converted_stream",
+    "_advisor_injected_by_router",
 ]
 
 # Proxy-owned callback credentials, stamped from admin-configured team/key callback

--- a/tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_transformation.py
+++ b/tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_transformation.py
@@ -6207,3 +6207,115 @@ def test_disabled_thinking_omitted_only_for_always_on_models(
         assert "thinking" not in request
     else:
         assert request["thinking"] == {"type": "disabled"}
+
+
+def _advised_completion_response() -> dict:
+    return {
+        "id": "msg_advised",
+        "type": "message",
+        "role": "assistant",
+        "model": "claude-haiku-4-5",
+        "content": [
+            {"type": "text", "text": "Let me consult the advisor."},
+            {"type": "server_tool_use", "id": "srvtoolu_1", "name": "advisor", "input": {}},
+            {
+                "type": "advisor_tool_result",
+                "tool_use_id": "srvtoolu_1",
+                "content": [{"type": "text", "text": "Use a token bucket."}],
+            },
+            {"type": "text", "text": "Final answer: token bucket."},
+        ],
+        "stop_reason": "end_turn",
+        "stop_sequence": None,
+        "usage": {"input_tokens": 100, "output_tokens": 50},
+    }
+
+
+def _run_transform_response(litellm_params: dict, response: dict | None = None):
+    import httpx
+    from unittest.mock import MagicMock
+
+    from litellm.types.utils import ModelResponse
+
+    config = AnthropicConfig()
+    raw_response = httpx.Response(status_code=200, headers={}, json=response or _advised_completion_response())
+    return config.transform_response(
+        model="claude-haiku-4-5",
+        raw_response=raw_response,
+        model_response=ModelResponse(),
+        logging_obj=MagicMock(),
+        request_data={},
+        messages=[{"role": "user", "content": "Redis or Postgres?"}],
+        optional_params={},
+        litellm_params=litellm_params,
+        encoding=None,
+    )
+
+
+def test_transform_response_strips_router_injected_advisor_blocks():
+    """With the router-injected marker set, the advisor exchange collapses into an
+    <advisor_feedback> text block: no phantom tool_call named advisor, no advisor
+    tool_results, and the guidance survives as ordinary assistant text."""
+    from litellm.constants import ADVISOR_INJECTED_PARAM
+
+    result = _run_transform_response({ADVISOR_INJECTED_PARAM: True})
+
+    message = result.choices[0].message
+    assert not message.tool_calls
+    content = message.content or ""
+    assert "<advisor_feedback>" in content
+    assert "Use a token bucket." in content
+    assert "Final answer: token bucket." in content
+    tool_results = (message.provider_specific_fields or {}).get("tool_results") or []
+    assert not any(block.get("type") == "advisor_tool_result" for block in tool_results)
+
+
+def test_transform_response_keeps_advisor_blocks_without_marker():
+    """A caller who supplied their own advisor tool gets the blocks back untouched."""
+    result = _run_transform_response({})
+
+    message = result.choices[0].message
+    assert any(call.function.name == "advisor" for call in (message.tool_calls or []))
+    tool_results = (message.provider_specific_fields or {}).get("tool_results") or []
+    assert any(block.get("type") == "advisor_tool_result" for block in tool_results)
+
+
+def test_transform_response_leaves_unorchestrated_advisor_tool_use():
+    """A plain tool_use named advisor means the upstream never ran the consult; stripping
+    it would orphan stop_reason=tool_use, so it passes through even with the marker."""
+    from litellm.constants import ADVISOR_INJECTED_PARAM
+
+    unorchestrated = {
+        **_advised_completion_response(),
+        "content": [{"type": "tool_use", "id": "toolu_1", "name": "advisor", "input": {}}],
+        "stop_reason": "tool_use",
+    }
+
+    result = _run_transform_response({ADVISOR_INJECTED_PARAM: True}, response=unorchestrated)
+
+    message = result.choices[0].message
+    assert any(call.function.name == "advisor" for call in (message.tool_calls or []))
+
+
+def test_advisor_feedback_joins_all_result_text_blocks():
+    """A multi-block advisor result keeps every text block, not just the first."""
+    from litellm.llms.anthropic.common_utils import strip_advisor_blocks_from_content
+
+    content = [
+        {"type": "server_tool_use", "id": "srv_1", "name": "advisor", "input": {}},
+        {
+            "type": "advisor_tool_result",
+            "tool_use_id": "srv_1",
+            "content": [
+                {"type": "text", "text": "First part of the plan."},
+                {"type": "text", "text": "Second part of the plan."},
+            ],
+        },
+    ]
+
+    rewritten = strip_advisor_blocks_from_content(content, replace_with_text=True)
+
+    assert rewritten is not None
+    feedback = rewritten[0]["text"]
+    assert "First part of the plan." in feedback
+    assert "Second part of the plan." in feedback

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_advisor_integration.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_advisor_integration.py
@@ -364,3 +364,67 @@ async def test_pre_request_hook_override_does_not_collide_with_explicit_kwargs()
     assert captured["thinking"] == {"type": "enabled", "budget_tokens": 2048}
     assert captured["system"] == "Hook overrode the system prompt."
     assert captured["temperature"] == 0.1
+
+
+async def _finalize_advised(kwargs: Dict) -> Dict:
+    from unittest.mock import MagicMock
+
+    from litellm.llms.custom_httpx.llm_http_handler import BaseLLMHTTPHandler
+
+    advised = {
+        "id": "msg_native",
+        "type": "message",
+        "role": "assistant",
+        "model": "claude-haiku-4-5",
+        "content": [
+            {"type": "text", "text": "Consulting."},
+            {"type": "server_tool_use", "id": "srv_1", "name": "advisor", "input": {}},
+            {
+                "type": "advisor_tool_result",
+                "tool_use_id": "srv_1",
+                "content": [{"type": "text", "text": "Advisor plan text."}],
+            },
+            {"type": "text", "text": "Done."},
+        ],
+        "stop_reason": "end_turn",
+        "usage": {"input_tokens": 10, "output_tokens": 20},
+    }
+    logging_obj = MagicMock()
+    logging_obj.model_call_details = {}
+    return await BaseLLMHTTPHandler()._finalize_anthropic_messages_response(
+        initial_response=advised,
+        model="claude-haiku-4-5",
+        messages=list(MESSAGES),
+        anthropic_messages_provider_config=MagicMock(),
+        anthropic_messages_optional_request_params={},
+        logging_obj=logging_obj,
+        custom_llm_provider="anthropic",
+        api_key=None,
+        kwargs=kwargs,
+    )
+
+
+@pytest.mark.asyncio
+async def test_finalize_strips_router_injected_advisor_blocks():
+    """On the native /v1/messages path the response strip lives in
+    _finalize_anthropic_messages_response, gated on the router-injected marker in kwargs:
+    the caller gets <advisor_feedback> text instead of advisor tool machinery."""
+    from litellm.constants import ADVISOR_INJECTED_PARAM
+
+    result = await _finalize_advised({ADVISOR_INJECTED_PARAM: True})
+
+    block_types = [block["type"] for block in result["content"]]
+    assert "server_tool_use" not in block_types
+    assert "advisor_tool_result" not in block_types
+    feedback_blocks = [b for b in result["content"] if b["type"] == "text" and "<advisor_feedback>" in b["text"]]
+    assert len(feedback_blocks) == 1
+    assert "Advisor plan text." in feedback_blocks[0]["text"]
+
+
+@pytest.mark.asyncio
+async def test_finalize_keeps_advisor_blocks_without_marker():
+    result = await _finalize_advised({})
+
+    block_types = [block["type"] for block in result["content"]]
+    assert "server_tool_use" in block_types
+    assert "advisor_tool_result" in block_types

--- a/tests/test_litellm/router_strategy/test_complexity_router.py
+++ b/tests/test_litellm/router_strategy/test_complexity_router.py
@@ -17,7 +17,7 @@ import litellm
 from litellm import Router
 from litellm._logging import verbose_router_logger
 from litellm.caching.dual_cache import DualCache
-from litellm.constants import RETURN_RAW_MODEL_NAME_METADATA_KEY
+from litellm.constants import ADVISOR_INJECTED_PARAM, RETURN_RAW_MODEL_NAME_METADATA_KEY
 from litellm.router_strategy.complexity_router.complexity_router import (
     _CLASSIFICATION_CURRENT_MESSAGE_ONLY,
     _CLASSIFICATION_WITH_CONVERSATION,
@@ -9762,3 +9762,390 @@ class TestHeuristicFirst:
         )
         outcome = await router.aclassify(NO_SIGNAL_PROMPT)
         assert outcome.cause == "default_model_fallback"
+
+
+class TestAdvisorTiers:
+    """An `advisor:` block on a tier entry injects Anthropic's advisor tool into the routed
+    request (merged with the caller's tools, never replacing them) and reports the decision,
+    failing closed everywhere it cannot apply."""
+
+    CALLER_TOOL = {
+        "type": "function",
+        "function": {"name": "bash", "description": "run", "parameters": {"type": "object", "properties": {}}},
+    }
+
+    @staticmethod
+    def _advised_model_list(tier_entry: Dict | None = None, executor_model: str = "anthropic/claude-haiku-4-5"):
+        return [
+            {
+                "model_name": "smart-router",
+                "litellm_params": {
+                    "model": "auto_router/complexity_router",
+                    "complexity_router_config": {
+                        "tiers": {
+                            "SIMPLE": tier_entry
+                            or {
+                                "model_name": "haiku-tier",
+                                "advisor": {"model": "opus-tier", "max_uses": 2},
+                            }
+                        }
+                    },
+                },
+            },
+            {"model_name": "haiku-tier", "litellm_params": {"model": executor_model, "api_key": "sk-test"}},
+            {"model_name": "opus-tier", "litellm_params": {"model": "anthropic/claude-opus-5", "api_key": "sk-test"}},
+        ]
+
+    @staticmethod
+    def _hook_router(config_tiers: Dict, deployments: Dict | None = None, **config_extra) -> ComplexityRouter:
+        deployments = deployments or {  # rebind-ok: default fixture fill-in
+            "haiku-tier": [{"model_name": "haiku-tier", "litellm_params": {"model": "anthropic/claude-haiku-4-5"}}],
+            "opus-tier": [{"model_name": "opus-tier", "litellm_params": {"model": "anthropic/claude-opus-5"}}],
+            "gpt-tier": [{"model_name": "gpt-tier", "litellm_params": {"model": "openai/gpt-4o-mini"}}],
+        }
+        instance = MagicMock()
+        instance.get_model_list = lambda model_name=None, team_id=None: deployments.get(model_name, [])
+        instance.cache = DualCache()
+        return ComplexityRouter(
+            model_name="test-router",
+            litellm_router_instance=instance,
+            complexity_router_config={"tiers": config_tiers, **config_extra},
+        )
+
+    @classmethod
+    def _pool_router(cls, pool_models: List[str]) -> ComplexityRouter:
+        return cls._hook_router(
+            {"SIMPLE": {"model_name": "haiku-tier", "advisor": {"model": "opus-pool"}}},
+            deployments={
+                "haiku-tier": [
+                    {"model_name": "haiku-tier", "litellm_params": {"model": "anthropic/claude-haiku-4-5"}}
+                ],
+                "opus-pool": [{"model_name": "opus-pool", "litellm_params": {"model": m}} for m in pool_models],
+            },
+        )
+
+    def test_advisor_config_rejects_credential_keys(self):
+        with pytest.raises(ValidationError):
+            ComplexityRouterConfig.model_validate(
+                {
+                    "tiers": {
+                        "SIMPLE": {
+                            "model_name": "haiku-tier",
+                            "advisor": {"model": "opus-tier", "api_key": "sk-evil"},
+                        }
+                    }
+                }
+            )
+
+    def test_advisor_config_rejects_non_positive_max_uses(self):
+        with pytest.raises(ValidationError):
+            ComplexityRouterConfig.model_validate(
+                {"tiers": {"SIMPLE": {"model_name": "haiku-tier", "advisor": {"model": "opus-tier", "max_uses": 0}}}}
+            )
+
+    @pytest.mark.asyncio
+    async def test_advisor_tool_is_appended_to_caller_tools(self):
+        """The caller's own tools survive byte-identical, the advisor tool is appended with the
+        model resolved through the router, and the injected-marker rides the request."""
+        router = Router(model_list=self._advised_model_list())
+        request_kwargs = {"tools": [dict(self.CALLER_TOOL)]}
+
+        deployment = await router.async_get_available_deployment(
+            model="smart-router", request_kwargs=request_kwargs, messages=[{"role": "user", "content": "hi"}]
+        )
+
+        assert deployment["model_name"] == "haiku-tier"
+        assert request_kwargs["tools"][0] == self.CALLER_TOOL
+        assert request_kwargs["tools"][1] == {
+            "type": "advisor_20260301",
+            "name": "advisor",
+            "model": "claude-opus-5",
+            "max_uses": 2,
+        }
+        assert request_kwargs[ADVISOR_INJECTED_PARAM] is True
+
+    @pytest.mark.asyncio
+    async def test_advisor_tool_alone_when_caller_sends_no_tools(self):
+        router = Router(model_list=self._advised_model_list())
+        request_kwargs = {}
+
+        await router.async_get_available_deployment(
+            model="smart-router", request_kwargs=request_kwargs, messages=[{"role": "user", "content": "hi"}]
+        )
+
+        assert [tool["type"] for tool in request_kwargs["tools"]] == ["advisor_20260301"]
+        assert request_kwargs[ADVISOR_INJECTED_PARAM] is True
+
+    @pytest.mark.asyncio
+    async def test_streaming_request_is_not_advised(self):
+        """The response strip is non-streaming only, so a streaming request must not be advised."""
+        router = Router(model_list=self._advised_model_list())
+        request_kwargs = {"stream": True}
+
+        await router.async_get_available_deployment(
+            model="smart-router", request_kwargs=request_kwargs, messages=[{"role": "user", "content": "hi"}]
+        )
+
+        assert "tools" not in request_kwargs
+        assert ADVISOR_INJECTED_PARAM not in request_kwargs
+
+    @pytest.mark.asyncio
+    async def test_caller_supplied_advisor_tool_is_left_untouched(self):
+        """A caller who brought their own advisor keeps it: no double tool, no marker."""
+        router = Router(model_list=self._advised_model_list())
+        caller_advisor = {"type": "advisor_20260301", "name": "advisor", "model": "claude-opus-4-6"}
+        request_kwargs = {"tools": [dict(caller_advisor)]}
+
+        await router.async_get_available_deployment(
+            model="smart-router", request_kwargs=request_kwargs, messages=[{"role": "user", "content": "hi"}]
+        )
+
+        assert request_kwargs["tools"] == [caller_advisor]
+        assert ADVISOR_INJECTED_PARAM not in request_kwargs
+
+    @pytest.mark.asyncio
+    async def test_advisor_skipped_when_tier_group_is_not_all_anthropic(self):
+        router = Router(model_list=self._advised_model_list(executor_model="openai/gpt-4o-mini"))
+        request_kwargs = {}
+
+        await router.async_get_available_deployment(
+            model="smart-router", request_kwargs=request_kwargs, messages=[{"role": "user", "content": "hi"}]
+        )
+
+        assert "tools" not in request_kwargs
+        assert ADVISOR_INJECTED_PARAM not in request_kwargs
+
+    @pytest.mark.asyncio
+    async def test_unresolvable_advisor_model_passes_through_verbatim(self):
+        """A name serving no deployment is an operator-stated raw Anthropic model id; new model
+        ids lag the local catalogs, so the router must not reject them."""
+        tier_entry = {"model_name": "haiku-tier", "advisor": {"model": "claude-opus-5-20991231"}}
+        router = Router(model_list=self._advised_model_list(tier_entry=tier_entry))
+        request_kwargs = {}
+
+        await router.async_get_available_deployment(
+            model="smart-router", request_kwargs=request_kwargs, messages=[{"role": "user", "content": "hi"}]
+        )
+
+        assert request_kwargs["tools"] == [
+            {"type": "advisor_20260301", "name": "advisor", "model": "claude-opus-5-20991231"}
+        ]
+
+    @pytest.mark.asyncio
+    async def test_decision_reports_advisor_and_declared_params_not_merged_tools(self):
+        """The decision names the advisor outcome and declared tier params; the merged tool list
+        stays off the record, or every agentic request would write its tool schemas to spend logs."""
+        router = self._hook_router(
+            {"SIMPLE": {"model_name": "haiku-tier", "advisor": {"model": "opus-tier", "max_uses": 2}}}
+        )
+        request_kwargs = {"tools": [dict(self.CALLER_TOOL)]}
+
+        response = await router.async_pre_routing_hook(
+            model="test-model", request_kwargs=request_kwargs, messages=[{"role": "user", "content": "hi"}]
+        )
+
+        assert response.routing_decision["advisor_offered"] is True
+        assert response.routing_decision["advisor_model"] == "claude-opus-5"
+        assert "tier_litellm_params" not in response.routing_decision
+        assert response.litellm_params["tools"][0] == self.CALLER_TOOL
+        assert response.litellm_params[ADVISOR_INJECTED_PARAM] is True
+
+    @pytest.mark.asyncio
+    async def test_decision_reports_advisor_not_offered_on_skip(self):
+        router = self._hook_router(
+            {"SIMPLE": {"model_name": "haiku-tier", "advisor": {"model": "opus-tier", "max_uses": 2}}}
+        )
+
+        response = await router.async_pre_routing_hook(
+            model="test-model",
+            request_kwargs={"stream": True},
+            messages=[{"role": "user", "content": "hi"}],
+        )
+
+        assert response.routing_decision["advisor_offered"] is False
+        assert "advisor_model" not in response.routing_decision
+
+    @pytest.mark.asyncio
+    async def test_tier_without_advisor_config_records_no_advisor_fields(self):
+        router = self._hook_router({"SIMPLE": {"model_name": "haiku-tier"}})
+
+        response = await router.async_pre_routing_hook(
+            model="test-model", request_kwargs={}, messages=[{"role": "user", "content": "hi"}]
+        )
+
+        assert "advisor_offered" not in response.routing_decision
+        assert "advisor_model" not in response.routing_decision
+
+    @pytest.mark.asyncio
+    async def test_session_pin_turn_reapplies_the_advisor(self):
+        """The pin stores (model, tier) and re-derives tier params per turn, so a pinned turn 2
+        must carry the advisor tool exactly like the classified turn 1."""
+        router = self._hook_router(
+            {"SIMPLE": {"model_name": "haiku-tier", "advisor": {"model": "opus-tier", "max_uses": 2}}},
+            session_affinity=True,
+        )
+        first_kwargs = {"metadata": {"session_id": "advisor-session"}}
+        second_kwargs = {"metadata": {"session_id": "advisor-session"}}
+
+        first = await router.async_pre_routing_hook(
+            model="test-model", request_kwargs=first_kwargs, messages=[{"role": "user", "content": "hi"}]
+        )
+        second = await router.async_pre_routing_hook(
+            model="test-model", request_kwargs=second_kwargs, messages=[{"role": "user", "content": "hi again"}]
+        )
+
+        assert first.routing_decision["advisor_offered"] is True
+        assert second.routing_decision["cause"] in ("session_affinity_pin", "session_affinity_escalation")
+        assert second.routing_decision["advisor_offered"] is True
+        assert [tool["type"] for tool in second.litellm_params["tools"]] == ["advisor_20260301"]
+
+    @pytest.mark.asyncio
+    async def test_plan_mode_short_circuit_carries_tier_litellm_params(self):
+        """The plan-mode top-tier short-circuit skips classification, not the tier's params: a
+        tier's litellm_params (and advisor) apply on this path the same as on every other."""
+        router = self._hook_router(
+            {
+                "SIMPLE": {"model_name": "gpt-tier"},
+                "REASONING": {"model_name": "haiku-tier", "litellm_params": {"reasoning_effort": "xhigh"}},
+            },
+            plan_mode_min_tier="REASONING",
+        )
+
+        response = await router.async_pre_routing_hook(
+            model="test-model",
+            request_kwargs={},
+            messages=[
+                {"role": "system", "content": 'You are currently running in "Plan" mode.'},
+                {"role": "user", "content": "hi"},
+            ],
+        )
+
+        assert response.routing_decision["cause"] == "plan_mode"
+        assert response.litellm_params == {"reasoning_effort": "xhigh"}
+        assert response.routing_decision["tier_litellm_params"] == {"reasoning_effort": "xhigh"}
+
+    @pytest.mark.asyncio
+    async def test_tier_declared_tools_stay_deliberate_overrides_and_gain_the_advisor(self):
+        """Tier litellm_params are deliberate overrides: declared tier tools replace the caller's
+        and the advisor appends to the list that ships, pinning the pre-existing carrier semantics."""
+        declared_tool = {"type": "function", "function": {"name": "operator_tool", "parameters": {}}}
+        router = self._hook_router(
+            {
+                "SIMPLE": {
+                    "model_name": "haiku-tier",
+                    "advisor": {"model": "opus-tier", "max_uses": 2},
+                    "litellm_params": {"tools": [dict(declared_tool)]},
+                }
+            }
+        )
+        request_kwargs = {"tools": [dict(self.CALLER_TOOL)]}
+
+        response = await router.async_pre_routing_hook(
+            model="test-model", request_kwargs=request_kwargs, messages=[{"role": "user", "content": "hi"}]
+        )
+
+        effective_tools = response.litellm_params["tools"]
+        assert effective_tools[0] == declared_tool
+        assert [tool.get("type") for tool in effective_tools] == ["function", "advisor_20260301"]
+
+    @pytest.mark.asyncio
+    async def test_advisor_group_with_one_underlying_model_across_deployments_resolves(self):
+        router = self._pool_router(["anthropic/claude-opus-5", "anthropic/claude-opus-5"])
+
+        response = await router.async_pre_routing_hook(
+            model="test-model", request_kwargs={}, messages=[{"role": "user", "content": "hi"}]
+        )
+
+        assert response.routing_decision["advisor_model"] == "claude-opus-5"
+
+    @pytest.mark.asyncio
+    async def test_advisor_group_with_distinct_underlying_models_is_skipped(self):
+        """Two deployments serving different models under one advisor name would make config
+        order pick the consulted model; the router fails closed instead."""
+        router = self._pool_router(["anthropic/claude-opus-5", "anthropic/claude-opus-4-6"])
+
+        response = await router.async_pre_routing_hook(
+            model="test-model", request_kwargs={}, messages=[{"role": "user", "content": "hi"}]
+        )
+
+        assert response.routing_decision["advisor_offered"] is False
+        assert "tools" not in response.litellm_params
+
+    def test_advisor_survives_a_config_dump_and_revalidate_round_trip(self):
+        """The normalizer restores per-entry state from tier_model_configs when tiers arrives
+        flattened; it must carry the whole entry, advisor included, or a dumped-and-revalidated
+        config silently routes to the bare executor."""
+        first = ComplexityRouterConfig.model_validate(
+            {
+                "tiers": {
+                    "SIMPLE": {
+                        "model_name": "haiku-tier",
+                        "advisor": {"model": "opus-tier", "max_uses": 2},
+                        "litellm_params": {"reasoning_effort": "low"},
+                    }
+                }
+            }
+        )
+
+        round_tripped = ComplexityRouterConfig.model_validate(first.model_dump())
+
+        entry = round_tripped.tier_model_configs["SIMPLE"][0]
+        assert entry.advisor is not None
+        assert entry.advisor.model == "opus-tier"
+        assert entry.advisor.max_uses == 2
+        assert dict(entry.litellm_params) == {"reasoning_effort": "low"}
+
+    def test_inline_advisor_beats_a_stale_stored_tier_entry(self):
+        """An inline entry that itself carries state is the operator's newest statement of intent
+        and replaces the stored copy wholesale; stored configs only backfill flattened bare names."""
+        cfg = ComplexityRouterConfig.model_validate(
+            {
+                "tiers": {"SIMPLE": {"model_name": "haiku-tier", "advisor": {"model": "opus-tier"}}},
+                "tier_model_configs": {"SIMPLE": [{"model_name": "haiku-tier", "litellm_params": {"temperature": 0.2}}]},
+            }
+        )
+
+        entry = cfg.tier_model_configs["SIMPLE"][0]
+        assert entry.advisor is not None
+        assert entry.advisor.model == "opus-tier"
+        assert dict(entry.litellm_params) == {}
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("allowed_tools,offered", [(["bash"], False), (["bash", "advisor"], True)])
+    async def test_advisor_honors_the_callers_tool_allowlist(self, allowed_tools, offered):
+        """check_tools_allowlist runs at auth against the raw request body, so the injection point
+        must apply the same policy or a key whose allowed_tools excludes advisor gets it anyway."""
+        router = Router(model_list=self._advised_model_list())
+        request_kwargs = {
+            "tools": [dict(self.CALLER_TOOL)],
+            "metadata": {"user_api_key_metadata": {"allowed_tools": allowed_tools}},
+        }
+
+        await router.async_get_available_deployment(
+            model="smart-router", request_kwargs=request_kwargs, messages=[{"role": "user", "content": "hi"}]
+        )
+
+        assert any(t.get("type") == "advisor_20260301" for t in request_kwargs["tools"]) is offered
+        assert (request_kwargs.get(ADVISOR_INJECTED_PARAM) is True) is offered
+
+    @pytest.mark.asyncio
+    async def test_wildcard_served_advisor_name_resolves_and_literal_wildcard_fails_closed(self):
+        """A wildcard-served model id resolves concretely (the pattern router substitutes the
+        matched segments); a wildcard surviving resolution is a literal and fails closed."""
+        real_router = Router(
+            model_list=[
+                {"model_name": "haiku-tier", "litellm_params": {"model": "anthropic/claude-haiku-4-5"}},
+                {"model_name": "anthropic/*", "litellm_params": {"model": "anthropic/*", "api_key": "sk-test"}},
+            ]
+        )
+        wildcard_served = ComplexityRouter(
+            model_name="test-router",
+            litellm_router_instance=real_router,
+            complexity_router_config={
+                "tiers": {"SIMPLE": {"model_name": "haiku-tier", "advisor": {"model": "anthropic/claude-opus-5"}}}
+            },
+        )
+        assert wildcard_served._resolve_advisor_model("anthropic/claude-opus-5") == "claude-opus-5"
+
+        literal_wildcard = self._pool_router(["anthropic/claude-*"])
+        assert literal_wildcard._resolve_advisor_model("opus-pool") is None

--- a/ui/litellm-dashboard/src/lib/http/schema.d.ts
+++ b/ui/litellm-dashboard/src/lib/http/schema.d.ts
@@ -22294,6 +22294,32 @@ export interface components {
             };
         };
         /**
+         * AdvisorConfig
+         * @description Advisor pairing for a tier: the executor consults this model via Anthropic's advisor tool.
+         *
+         *     `extra="forbid"` keeps the surface to routing intent only: credentials or endpoints
+         *     (api_key, api_base) are deliberately not configurable here.
+         */
+        AdvisorConfig: {
+            /**
+             * Caching
+             * @description Advisor-side cache block, sent verbatim
+             */
+            caching?: {
+                [key: string]: unknown;
+            } | null;
+            /**
+             * Max Uses
+             * @description Consult budget per request
+             */
+            max_uses?: number | null;
+            /**
+             * Model
+             * @description Router model_name or provider model id to consult
+             */
+            model: string;
+        };
+        /**
          * AgentCapabilities
          * @description Defines optional capabilities supported by an agent.
          */
@@ -24858,6 +24884,7 @@ export interface components {
         ComplexityTier: "SIMPLE" | "MEDIUM" | "COMPLEX" | "REASONING";
         /** ComplexityTierModel */
         ComplexityTierModel: {
+            advisor?: components["schemas"]["AdvisorConfig"] | null;
             /** Litellm Params */
             litellm_params?: {
                 [key: string]: unknown;
@@ -35095,6 +35122,10 @@ export interface components {
          * @description Per-request provenance for a pre-routing strategy (auto-router) decision.
          */
         StandardLoggingRoutingDecision: {
+            /** Advisor Model */
+            advisor_model?: string;
+            /** Advisor Offered */
+            advisor_offered?: boolean;
             /**
              * Cause
              * @enum {string}


### PR DESCRIPTION
## TLDR

Problem this solves:

- Complexity-router tiers cannot pair a cheap executor with an advisor model
- Tier-injected tools silently deleted the caller's own tools
- Advisor blocks leaked to callers as phantom tool calls
- The plan-mode short-circuit dropped tier litellm_params entirely

How it solves it:

- First-class `advisor:` block on tier entries, config.yaml only
- Router appends the advisor tool to the caller's tools, never replaces
- Anthropic response transforms strip the advisor exchange into `<advisor_feedback>` text
- Routing decision records `advisor_offered` and the resolved `advisor_model`
- Plan-mode path now carries tier litellm_params like every other path
- Injection honors the caller's `allowed_tools` allowlist through the same helper auth uses, so a router-injected advisor never bypasses key or team tool policy
- On re-validation, an inline tier entry carrying `advisor` or `litellm_params` beats a stale stored `tier_model_configs` copy instead of being silently dropped

## User Flow

Before: an operator wants MEDIUM traffic served by Haiku with an Opus advisor, and there is no way to configure it

1. The operator adds `advisor:` under a tier in `complexity_router_config` and restarts the proxy
2. The proxy boots, the key is silently ignored, and requests route to the bare executor
3. If they instead hand-write the advisor tool into tier `litellm_params.tools`, a coding agent sending POST https://litellm-domain/v1/chat/completions with its own `bash` and `edit_file` tools gets them silently deleted: the model can no longer call the agent's tools
4. When the upstream does return an advised response, the agent receives a `tool_calls` entry named `advisor` it never registered, and its loop breaks trying to execute it

After: the same config works end to end and callers never see the advisor

1. The operator writes `advisor: {model: opus, max_uses: 2}` under the MEDIUM tier and restarts the proxy
2. The same agent sends POST https://litellm-domain/v1/chat/completions with `model: auto` and its own tools; the request reaches Anthropic with `bash`, `edit_file`, and the advisor tool, plus the advisor beta header
3. The response comes back as plain assistant text; the advisor's guidance appears inline inside an `<advisor_feedback>` block, so the agent keeps the plan in its history without any tool machinery
4. The same holds on POST /v1/messages and POST /v1/responses
5. The spend log's routing decision shows `advisor_offered: true` and `advisor_model: claude-opus-5`

## Relevant issues

- Design doc: advisor-backed tiers in the auto-router (internal)
- Advisor model names are resolved through the router before injection, so a model-group name is never forwarded verbatim (the LIT-6020 failure shape)

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Setup shared by both runs: proxy on localhost:4000 backed by Postgres. The executor deployment points at a local Anthropic-shaped upstream that records every request body verbatim and answers with the advisor response shape Anthropic documents for the beta (`server_tool_use` + `advisor_tool_result` blocks, `usage.iterations` with `type: advisor_message`); the available Anthropic account does not have the advisor beta enabled (details in Caveats), so the orchestrated-response leg uses this recorder while one leg below runs against the real upstream. Config:

```yaml
model_list:
  - model_name: haiku-tier
    litellm_params: {model: anthropic/claude-haiku-4-5, api_base: http://127.0.0.1:4801, api_key: ...}
  - model_name: opus
    litellm_params: {model: anthropic/claude-opus-5, api_key: os.environ/ANTHROPIC_API_KEY}
  - model_name: auto
    litellm_params:
      model: auto_router/complexity_router
      complexity_router_config:
        tiers:
          SIMPLE: {model_name: haiku-tier, advisor: {model: opus, max_uses: 2}}
          MEDIUM: {model_name: haiku-tier, advisor: {model: opus, max_uses: 2}}
          COMPLEX: {model_name: haiku-tier, advisor: {model: opus, max_uses: 2}}
          REASONING: {model_name: haiku-tier, advisor: {model: opus, max_uses: 2}}
```

### Before (18830667b2)

#### tier-injected tools clobber the caller's tools (/v1/chat/completions)

1. Tier configured with hand-written `litellm_params.tools` carrying the advisor block (the only pre-advisor option); caller sends its own `bash` and `edit_file` function tools

```
curl -s http://127.0.0.1:4000/v1/chat/completions -H "Authorization: Bearer sk-1234" -d '{"model":"auto","messages":[{"role":"user","content":"Refactor the rate limiter..."}],"tools":[{"type":"function","function":{"name":"bash",...}},{"type":"function","function":{"name":"edit_file",...}}]}'
```

2. Upstream recorder shows the caller's tools deleted; only the tier's tool arrived

```
OUTBOUND tools: [('advisor_20260301', 'advisor')]
```

#### `advisor:` tier key is silently ignored

1. Same request against the `advisor:` config above
2. Recorder shows no advisor tool and no beta header

```
OUTBOUND beta: None | tools: None
```

#### advised response leaks advisor machinery to the caller

1. Upstream answers with the documented advised shape; caller receives a phantom tool call and raw advisor blocks

```
"tool_calls": [{"function": {"name": "advisor", "arguments": "{}"}, ...}]
"provider_specific_fields": {"tool_results": [{"type": "advisor_tool_result", ...}]}
```

2. On /v1/messages the raw `server_tool_use` and `advisor_tool_result` blocks pass straight through to the caller

### After (bb96fd6b44)

#### /v1/chat/completions: merge on the way out, strip on the way back

1. Same caller request with `bash` and `edit_file` tools

```
OUTBOUND beta: advisor-tool-2026-03-01
OUTBOUND tools: [('custom', 'bash'), ('custom', 'edit_file'), ('advisor_20260301', 'advisor')]
OUTBOUND advisor tool: [{'type': 'advisor_20260301', 'name': 'advisor', 'model': 'claude-opus-5', 'max_uses': 2}]
```

The advisor `model` is `claude-opus-5`, resolved from the `opus` model group; the config name is never forwarded verbatim

2. Response to the caller is clean

```
RESPONSE tool_calls: None
RESPONSE content: Let me consult the advisor.<advisor_feedback> | Advisor plan: use a Redis token bucket per tenant; ... | </advisor_feedback>Final answer: ...
RESPONSE tool_results: None
```

#### /v1/messages

1. Caller sends its own `bash` tool on POST /v1/messages

```
OUTBOUND tools: [(None, 'bash'), ('advisor_20260301', 'advisor')]
RESPONSE blocks: [('text', 'Let me consult the advisor.'), ('text', '<advisor_feedback> Advisor plan: ...'), ('text', 'Final answer: ...')]
iterations: [{'type': 'message', ...}, {'type': 'advisor_message', 'input_tokens': 5000, 'output_tokens': 500}]
```

#### /v1/responses

1. POST /v1/responses with `model: auto` rides the chat bridge

```
OUTBOUND beta: advisor-tool-2026-03-01
OUTBOUND tools: [('advisor_20260301', 'advisor')]
RESPONSE output: [[('output_text', 'Let me consult the advisor.<advisor_feedback> Advisor plan: ...')]]
```

#### streaming requests are not advised

1. Same chat request with `"stream": true` streams normally

```
OUTBOUND tools: None
OUTBOUND beta: None
```

#### a caller-supplied advisor tool is untouched

1. Caller sends their own `advisor_20260301` tool on /v1/messages

```
OUTBOUND tools: [('advisor_20260301', 'advisor', 'claude-opus-4-6')]   <- caller's model and budget, not the tier's
RESPONSE blocks: [('text', ...), ('server_tool_use', 'advisor'), ('advisor_tool_result', ...), ('text', ...)]   <- blocks returned as sent
```

#### real upstream (real API spend): account without the advisor beta

1. Executor deployment flipped to the real Anthropic upstream; same /v1/messages request. Whether the executor consults is the model's call, so this leg has two observed outcomes on the same code
2. When the executor emits the advisor call (captured on this code path at 29e5c941), the account does not orchestrate it; the proxy passes the response through unchanged and logs the condition instead of corrupting it

```
blocks: [('tool_use', 'advisor', '')]
WARNING ... Advisor tool_use came back unorchestrated (the upstream account may lack the advisor beta); returning the response unchanged
```

3. When the executor answers without consulting (captured at the final tip), the response is ordinary text and nothing is stripped or logged; the injection itself at the final tip is proven by the recorder legs above

## Type

🆕 New Feature

## Caveats (if any)

### Medium

- Streaming requests never get the advisor; deliberate, logged, `advisor_offered: false`
- Advisor tokens are counted but priced at the executor's rate; advisor-rate split is follow-up work
- Fallback to a non-Anthropic group carries the injected tool and can 400; same pre-existing behavior as every tier param, class fix tracked in #38622

### Low

- Orchestrated-response legs above use a recording upstream because no available Anthropic account has the advisor beta; owed re-run on a beta-enabled account is the same curl set verbatim
- An advisor model that resolves to no deployment passes through verbatim as a raw Anthropic model id
- An advisor group whose deployments declare multiple distinct models is skipped fail-closed
- Adaptive routers that pick a model outside the tier's configured entries drop tier params, advisor included; pre-existing tier-param semantics

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

