### PR TITLE
chore: drop stray learnings.md workflow note from CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,8 +74,6 @@ Do not add `Co-Authored-By: Claude` or any Claude attribution to commit messages
 
 When working on a PR, keep the PR description in sync with new commits being made
 
-Whenever a review round, bot or human, finds a real bug that survived multiple prior rounds of automated review or your own testing, or you learn a non-obvious codebase fact or process gap that would have changed your approach had you known it upfront, capture it immediately in `litellm/learnings.md` without waiting to be asked. If the finding is specific to a skill's own process rather than the codebase itself, also add it to that skill's own `learnings.md` (e.g. `.claude/skills/implement-litellm-plan/learnings.md`, `.claude/skills/review-loop/learnings.md`). Before appending, skim the file for an existing entry covering the same root cause and extend or correct that one instead of adding a near-duplicate. Write the entry as soon as you understand the root cause, not just at the end of the session, and be direct about what was missed rather than softening it
-
 All GitHub comments must be human-readable and 15-25 words max
 
 Monkeypatching attributes of a class to do testing is an anti-pattern. Prefer dependency-injecting things into classes. That way, at unit test time, you can pass a mocked dependency in


### PR DESCRIPTION
PR #34940 (Lakera v2 guardrail) incidentally added a paragraph to `CLAUDE.md` instructing agents to record findings in `litellm/learnings.md` and per-skill `learnings.md` files. It has nothing to do with that feature and appears to have ridden along from a local setup:

- `litellm/learnings.md` does not exist anywhere in the repo, so the instruction points at a missing file.
- The skill paths it references (`.claude/skills/implement-litellm-plan/learnings.md`, `.claude/skills/review-loop/learnings.md`) are agent-local, not repo files.

This reverts `CLAUDE.md` to its pre-#34940 state (blob otherwise unchanged).

## Behavior changes

None. Docs-only; removes an orphaned instruction from `CLAUDE.md`. No code, tests, or runtime behavior affected.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/berriai/litellm/pull/38704" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->