### PR TITLE
fix(proxy): return empty list from /organization/list for keys without a user

### DIFF
--- a/litellm/proxy/management_endpoints/organization_endpoints.py
+++ b/litellm/proxy/management_endpoints/organization_endpoints.py
@@ -1034,12 +1034,9 @@ async def list_organization(
         )
     # if internal user - get orgs they are a member of (with optional filters)
     else:
-        # Keys that are not tied to a user - team and service keys - reach this
-        # branch with user_id set to None. Prisma rejects that filter with
-        # MissingRequiredValueError, which surfaces as HTTP 500. Such a key is a
-        # member of no organization, so the correct response is an empty list.
+        # Prisma rejects a null `user_id` filter with MissingRequiredValueError.
         if user_api_key_dict.user_id is None:
-            return []  # mutable-ok: empty response body for a caller that belongs to no organization
+            return []  # mutable-ok: no organization membership to return
         org_memberships: Final = await _table(OrganizationMembershipRepository(prisma_client)).find_many(
             where={"user_id": user_api_key_dict.user_id}
         )

--- a/litellm/proxy/management_endpoints/organization_endpoints.py
+++ b/litellm/proxy/management_endpoints/organization_endpoints.py
@@ -1039,7 +1039,7 @@ async def list_organization(
         # MissingRequiredValueError, which surfaces as HTTP 500. Such a key is a
         # member of no organization, so the correct response is an empty list.
         if user_api_key_dict.user_id is None:
-            return []
+            return []  # mutable-ok: empty response body for a caller that belongs to no organization
         org_memberships: Final = await _table(OrganizationMembershipRepository(prisma_client)).find_many(
             where={"user_id": user_api_key_dict.user_id}
         )

--- a/litellm/proxy/management_endpoints/organization_endpoints.py
+++ b/litellm/proxy/management_endpoints/organization_endpoints.py
@@ -1034,6 +1034,12 @@ async def list_organization(
         )
     # if internal user - get orgs they are a member of (with optional filters)
     else:
+        # Keys that are not tied to a user - team and service keys - reach this
+        # branch with user_id set to None. Prisma rejects that filter with
+        # MissingRequiredValueError, which surfaces as HTTP 500. Such a key is a
+        # member of no organization, so the correct response is an empty list.
+        if user_api_key_dict.user_id is None:
+            return []
         org_memberships: Final = await _table(OrganizationMembershipRepository(prisma_client)).find_many(
             where={"user_id": user_api_key_dict.user_id}
         )

--- a/tests/test_litellm/proxy/management_endpoints/test_organization_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_organization_endpoints.py
@@ -9,7 +9,6 @@ from fastapi import HTTPException
 from fastapi.testclient import TestClient
 
 
-
 @pytest.mark.asyncio
 async def test_organization_update_object_permissions_existing_permission(monkeypatch):
     """
@@ -1063,3 +1062,33 @@ async def test_find_member_if_email_missing_row_raises_documented_400():
             "non-existent user_email in LiteLLM_UserTable. Use 'user_id' instead."
         )
     }
+
+
+@pytest.mark.asyncio
+async def test_list_organization_returns_empty_for_key_without_user(monkeypatch):
+    """
+    Keys that are not tied to a user - team and service keys - have user_id set to None.
+
+    The non-admin branch of /organization/list filtered organization memberships by
+    that value, and Prisma rejects a null filter with MissingRequiredValueError, so the
+    endpoint answered HTTP 500 instead of denying or returning nothing. A key with no
+    user belongs to no organization, so the expected response is an empty list.
+    """
+    from litellm.proxy._types import UserAPIKeyAuth
+    from litellm.proxy.management_endpoints.organization_endpoints import (
+        list_organization,
+    )
+
+    mock_prisma_client = MagicMock()
+    monkeypatch.setattr("litellm.proxy.proxy_server.prisma_client", mock_prisma_client)
+
+    # A team key: authenticated, but with no user behind it.
+    team_key = UserAPIKeyAuth(
+        api_key="sk-team-key",
+        user_id=None,
+        team_id="team-abc",
+    )
+
+    response = await list_organization(user_api_key_dict=team_key)
+
+    assert response == []

--- a/tests/test_litellm/proxy/management_endpoints/test_organization_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_organization_endpoints.py
@@ -1082,7 +1082,6 @@ async def test_list_organization_returns_empty_for_key_without_user(monkeypatch)
     mock_prisma_client = MagicMock()
     monkeypatch.setattr("litellm.proxy.proxy_server.prisma_client", mock_prisma_client)
 
-    # A team key: authenticated, but with no user behind it.
     team_key = UserAPIKeyAuth(
         api_key="sk-team-key",
         user_id=None,

--- a/tests/test_litellm/proxy/spend_tracking/test_savings.py
+++ b/tests/test_litellm/proxy/spend_tracking/test_savings.py
@@ -6,8 +6,10 @@ import litellm
 from litellm.litellm_core_utils.llm_cost_calc.utils import generic_cost_per_token
 from litellm.proxy.spend_tracking.savings import (
     _baseline_usage,
+    _resolve_model,
     compute_autorouter_savings,
     compute_savings_spend,
+    marks_gateway_injection,
 )
 from litellm.router import Router
 from litellm.types.utils import Usage
@@ -59,6 +61,7 @@ def test_compression_savings_priced_at_input_rate():
         model="claude-sonnet-5",
         custom_llm_provider="anthropic",
         compression_saved_tokens=4389,
+        gateway_injected_cache=True,
     )
     assert result.compression == pytest.approx(4389 * input_cost)
     assert result.compression > 0
@@ -74,6 +77,7 @@ def test_prompt_caching_savings_priced_at_input_minus_cache_read():
         model="claude-sonnet-5",
         custom_llm_provider="anthropic",
         compression_saved_tokens=0,
+        gateway_injected_cache=True,
         usage_object={"cache_read_input_tokens": 8200},
     )
     assert result.prompt_caching == pytest.approx(8200 * (input_cost - cache_read_cost))
@@ -126,6 +130,7 @@ def test_prompt_caching_savings_nets_out_the_cache_write_premium():
         model="claude-sonnet-5",
         custom_llm_provider="anthropic",
         compression_saved_tokens=0,
+        gateway_injected_cache=True,
         usage_object=usage_object,
     )
     assert result.prompt_caching == pytest.approx(_net_caching_savings_against_biller(usage_object))
@@ -141,6 +146,7 @@ def test_prompt_caching_savings_go_negative_on_a_write_only_request():
         model="claude-sonnet-5",
         custom_llm_provider="anthropic",
         compression_saved_tokens=0,
+        gateway_injected_cache=True,
         usage_object=usage_object,
     )
     true_savings = _net_caching_savings_against_biller(usage_object)
@@ -156,6 +162,7 @@ def test_prompt_caching_savings_negative_when_writes_outweigh_reads():
         model="claude-sonnet-5",
         custom_llm_provider="anthropic",
         compression_saved_tokens=0,
+        gateway_injected_cache=True,
         usage_object=usage_object,
     )
     true_savings = _net_caching_savings_against_biller(usage_object)
@@ -172,6 +179,7 @@ def test_read_only_request_is_unchanged_by_the_write_premium():
         model="claude-sonnet-5",
         custom_llm_provider="anthropic",
         compression_saved_tokens=0,
+        gateway_injected_cache=True,
         usage_object=_caching_usage(read=20000, written=0),
     )
     assert result.prompt_caching == pytest.approx(20000 * (input_cost - cache_read_cost))
@@ -185,12 +193,14 @@ def test_openai_style_cache_write_tokens_are_netted_out():
         model="claude-sonnet-5",
         custom_llm_provider="anthropic",
         compression_saved_tokens=0,
+        gateway_injected_cache=True,
         usage_object={"cache_read_input_tokens": 5000, "cache_creation_input_tokens": 800},
     )
     nested_only = compute_savings_spend(
         model="claude-sonnet-5",
         custom_llm_provider="anthropic",
         compression_saved_tokens=0,
+        gateway_injected_cache=True,
         usage_object={
             "prompt_tokens_details": {"cached_tokens": 5000, "cache_write_tokens": 800},
         },
@@ -221,6 +231,7 @@ def test_model_without_a_cache_write_price_takes_no_premium():
         model=model,
         custom_llm_provider=None,
         compression_saved_tokens=0,
+        gateway_injected_cache=True,
         usage_object=_caching_usage(read=5000, written=5000),
     )
     assert result.prompt_caching == pytest.approx(5000 * (input_cost - cache_read_cost))
@@ -244,6 +255,7 @@ def test_zero_cache_write_price_is_read_as_unpublished():
         model="deepseek-chat",
         custom_llm_provider="deepseek",
         compression_saved_tokens=0,
+        gateway_injected_cache=True,
         usage_object=_caching_usage(read=0, written=10000),
     )
     assert result.prompt_caching == pytest.approx(0.0)
@@ -268,6 +280,7 @@ def test_zero_cache_read_price_stays_literal():
         model=model,
         custom_llm_provider=None,
         compression_saved_tokens=0,
+        gateway_injected_cache=True,
         usage_object=_caching_usage(read=10000, written=0),
     )
     # free reads => the whole input rate is saved, not zero
@@ -293,6 +306,7 @@ def test_sub_input_cache_write_price_is_an_extra_saving():
         model=model,
         custom_llm_provider=None,
         compression_saved_tokens=0,
+        gateway_injected_cache=True,
         usage_object=_caching_usage(read=1000, written=4000),
     )
     assert result.prompt_caching == pytest.approx(4000 * (input_cost - cheap_write))
@@ -306,6 +320,7 @@ def test_negative_cache_write_count_clamps_to_zero():
         model="claude-sonnet-5",
         custom_llm_provider="anthropic",
         compression_saved_tokens=0,
+        gateway_injected_cache=True,
         usage_object={"cache_read_input_tokens": 1000, "cache_creation_input_tokens": -5000},
     )
     assert result.prompt_caching == pytest.approx(1000 * (input_cost - cache_read_cost))
@@ -316,6 +331,7 @@ def test_unknown_model_fails_open_to_zero():
         model="totally-made-up-model-xyz",
         custom_llm_provider="anthropic",
         compression_saved_tokens=1000,
+        gateway_injected_cache=True,
         usage_object={"cache_read_input_tokens": 1000},
     )
     assert result.compression == 0.0
@@ -327,6 +343,7 @@ def test_missing_model_fails_open_to_zero():
         model=None,
         custom_llm_provider=None,
         compression_saved_tokens=1000,
+        gateway_injected_cache=True,
         usage_object={"cache_read_input_tokens": 1000},
     )
     assert result.compression == 0.0
@@ -338,6 +355,7 @@ def test_negative_token_counts_clamp_to_zero():
         model="claude-sonnet-5",
         custom_llm_provider="anthropic",
         compression_saved_tokens=-500,
+        gateway_injected_cache=True,
         usage_object={"cache_read_input_tokens": -500},
     )
     assert result.compression == 0.0
@@ -516,21 +534,22 @@ def test_autorouter_savings_zero_without_baseline():
         model="claude-haiku-4-5",
         custom_llm_provider="anthropic",
         compression_saved_tokens=0,
+        gateway_injected_cache=True,
         routing_decision=None,
         usage_object=_cached_usage_object(),
     )
     assert result.autorouter == 0.0
 
 
-def test_compute_savings_spend_carries_a_losing_switch_through(monkeypatch):
+def test_compute_savings_spend_carries_a_losing_switch_through():
     """The signed value must survive into SavingsSpend; clamping it here would put the
     dashboard back to only ever showing gains."""
-    monkeypatch.setattr(litellm, "autorouter_savings_baseline_model", "claude-sonnet-5")
     result = compute_savings_spend(
         model="claude-haiku-4-5",
         custom_llm_provider="anthropic",
         compression_saved_tokens=0,
-        routing_decision={"conversation_continuing": True},
+        gateway_injected_cache=True,
+        routing_decision={"conversation_continuing": True, "savings_baseline_model": "anthropic/claude-sonnet-5"},
         usage_object=_cached_usage_object(),
     )
     assert result.autorouter < 0
@@ -543,6 +562,7 @@ def test_the_driver_is_off_until_a_baseline_is_configured():
         model="claude-haiku-4-5",
         custom_llm_provider="anthropic",
         compression_saved_tokens=1000,
+        gateway_injected_cache=True,
         routing_decision={"conversation_continuing": True},
         usage_object=_cached_usage_object(),
     )
@@ -557,6 +577,7 @@ def test_malformed_usage_object_does_not_fail_the_spend_write():
         model="claude-haiku-4-5",
         custom_llm_provider="anthropic",
         compression_saved_tokens=1000,
+        gateway_injected_cache=True,
         routing_decision={"conversation_continuing": True},
         usage_object={"prompt_tokens": ["not", "a", "number"]},
     )
@@ -573,6 +594,7 @@ def test_model_without_cache_read_pricing_yields_no_caching_savings():
         model=model,
         custom_llm_provider="azure",
         compression_saved_tokens=0,
+        gateway_injected_cache=True,
         usage_object={"cache_read_input_tokens": 5000},
     )
     assert result.prompt_caching == 0.0
@@ -733,24 +755,55 @@ def test_a_baseline_that_prices_caching_implicitly_still_pays_for_its_prompt():
     assert reported > 0, "routing a cold first turn onto a cheaper model is a saving, not a loss"
 
 
+def _priced_chat_model_without_cache_read_rate() -> tuple[str, str, str]:
+    """A chat model the bundled map prices per token for input and output but not for cache
+    reads, derived from the map itself: a hardcoded pick goes stale the moment the registry
+    prices that model's cache reads, which is exactly how this test's premise last broke.
+    Candidates go through the savings module's own resolver, so the pick is one the code
+    under test can actually price."""
+    for key in sorted(litellm.model_cost):
+        entry = litellm.model_cost[key]
+        provider = entry.get("litellm_provider")
+        if not isinstance(provider, str) or not key.startswith(f"{provider}/"):
+            continue
+        if entry.get("mode") != "chat" or entry.get("cache_read_input_token_cost") is not None:
+            continue
+        if not entry.get("input_cost_per_token") or not entry.get("output_cost_per_token"):
+            continue
+        if _resolve_model(key, None) is None:
+            continue
+        priced = compute_autorouter_savings(
+            baseline_model=key,
+            selected_model="claude-haiku-4-5",
+            selected_provider="anthropic",
+            usage=_usage(fresh=1_000, cached=0, written=0, out=100),
+            conversation_continuing=True,
+        )
+        if priced == 0.0:
+            continue
+        return key, key.removeprefix(f"{provider}/"), provider
+    raise AssertionError("the bundled map has no per-token chat model without a cache-read rate")
+
+
 def test_a_baseline_with_no_cache_read_rate_is_charged_its_input_rate():
     """The same hole on the other bucket. A baseline whose entry has no
     `cache_read_input_token_cost` reads for 0.0, so a continuing turn priced the whole
     prompt at nothing and every switch away from it reported a loss.
     """
+    baseline_key, baseline_name, baseline_provider = _priced_chat_model_without_cache_read_rate()
     continuing = _usage(fresh=0, cached=0, written=20_000, out=1_000)
     reported = compute_autorouter_savings(
-        baseline_model="xai/grok-4",
+        baseline_model=baseline_key,
         selected_model="claude-haiku-4-5",
         selected_provider="anthropic",
         usage=continuing,
         conversation_continuing=True,
     )
 
-    grok = litellm.get_model_info("grok-4", "xai")
-    assert grok.get("cache_read_input_token_cost") is None, "pick a baseline with no cache-read rate"
+    baseline = litellm.get_model_info(baseline_name, baseline_provider)
+    assert baseline.get("cache_read_input_token_cost") is None, "pick a baseline with no cache-read rate"
     haiku = litellm.get_model_info("claude-haiku-4-5", "anthropic")
-    baseline_pays_input = 20_000 * grok["input_cost_per_token"] + 1_000 * grok["output_cost_per_token"]
+    baseline_pays_input = 20_000 * baseline["input_cost_per_token"] + 1_000 * baseline["output_cost_per_token"]
     actually_paid = 20_000 * haiku["cache_creation_input_token_cost"] + 1_000 * haiku["output_cost_per_token"]
     assert reported == pytest.approx(baseline_pays_input - actually_paid)
 
@@ -882,31 +935,24 @@ def test_a_baseline_recorded_on_the_decision_turns_the_driver_on():
         model="claude-haiku-4-5",
         custom_llm_provider="anthropic",
         compression_saved_tokens=0,
+        gateway_injected_cache=True,
         routing_decision={"conversation_continuing": True, "savings_baseline_model": "anthropic/claude-opus-5"},
         usage_object=_cached_usage_object(),
     )
     assert result.autorouter != 0.0
 
 
-def test_the_configured_baseline_overrides_the_recorded_one(monkeypatch):
-    """The recorded baseline and its deployment id are both ignored under the setting."""
-    monkeypatch.setattr(litellm, "autorouter_savings_baseline_model", "claude-sonnet-5")
-    with_override = compute_savings_spend(
+def test_a_leftover_configured_baseline_does_not_override_the_recorded_one(monkeypatch):
+    """The proxy config loader setattrs unknown litellm_settings keys, so a stale
+    autorouter_savings_baseline_model key must stay inert."""
+    monkeypatch.setattr(litellm, "autorouter_savings_baseline_model", "claude-sonnet-5", raising=False)
+    result = compute_savings_spend(
         model="claude-haiku-4-5",
         custom_llm_provider="anthropic",
         compression_saved_tokens=0,
-        routing_decision={
-            "conversation_continuing": True,
-            "savings_baseline_model": "anthropic/claude-opus-5",
-            "savings_baseline_deployment_id": "some-deployment-id",
-        },
+        gateway_injected_cache=True,
+        routing_decision={"conversation_continuing": True, "savings_baseline_model": "anthropic/claude-opus-5"},
         usage_object=_cached_usage_object(),
-    )
-    against_sonnet = compute_autorouter_savings(
-        baseline_model="claude-sonnet-5",
-        selected_model="claude-haiku-4-5",
-        selected_provider="anthropic",
-        usage=Usage(**_cached_usage_object()),
     )
     against_opus = compute_autorouter_savings(
         baseline_model="anthropic/claude-opus-5",
@@ -914,8 +960,7 @@ def test_the_configured_baseline_overrides_the_recorded_one(monkeypatch):
         selected_provider="anthropic",
         usage=Usage(**_cached_usage_object()),
     )
-    assert against_sonnet != against_opus, "the test needs baselines that price apart"
-    assert with_override.autorouter == against_sonnet
+    assert result.autorouter == against_opus
 
 
 def test_a_non_string_recorded_baseline_is_ignored():
@@ -923,6 +968,7 @@ def test_a_non_string_recorded_baseline_is_ignored():
         model="claude-haiku-4-5",
         custom_llm_provider="anthropic",
         compression_saved_tokens=0,
+        gateway_injected_cache=True,
         routing_decision={"conversation_continuing": True, "savings_baseline_model": ["anthropic/claude-opus-5"]},
         usage_object=_cached_usage_object(),
     )
@@ -954,6 +1000,7 @@ def test_prompt_caching_prices_at_the_deployment_rate_not_the_public_one():
         model="claude-sonnet-4-5",
         custom_llm_provider="anthropic",
         compression_saved_tokens=0,
+        gateway_injected_cache=True,
         usage_object=_caching_usage(read=1000, written=20000),
         model_id=deployment_id,
         llm_router=lambda: router,
@@ -965,6 +1012,7 @@ def test_prompt_caching_prices_at_the_deployment_rate_not_the_public_one():
         model="claude-sonnet-4-5",
         custom_llm_provider="anthropic",
         compression_saved_tokens=0,
+        gateway_injected_cache=True,
         usage_object=_caching_usage(read=1000, written=20000),
     )
     assert result.prompt_caching > at_public_rates.prompt_caching
@@ -995,6 +1043,7 @@ def test_a_recorded_baseline_deployment_prices_at_its_configured_rate():
         model="claude-haiku-4-5",
         custom_llm_provider="anthropic",
         compression_saved_tokens=0,
+        gateway_injected_cache=True,
         routing_decision=decision,
         usage_object=_cached_usage_object(),
         llm_router=lambda: router,
@@ -1003,6 +1052,7 @@ def test_a_recorded_baseline_deployment_prices_at_its_configured_rate():
         model="claude-haiku-4-5",
         custom_llm_provider="anthropic",
         compression_saved_tokens=0,
+        gateway_injected_cache=True,
         routing_decision={k: v for k, v in decision.items() if k != "savings_baseline_deployment_id"},
         usage_object=_cached_usage_object(),
         llm_router=lambda: router,
@@ -1021,6 +1071,7 @@ def test_recorded_savings_win_over_recomputation():
         model="claude-haiku-4-5",
         custom_llm_provider="anthropic",
         compression_saved_tokens=0,
+        gateway_injected_cache=False,
         routing_decision=_routed_decision(),
         usage_object=_cached_usage_object(),
         recorded_autorouter_savings=0.5,
@@ -1035,6 +1086,7 @@ def test_recorded_savings_survive_an_unusable_usage_object():
         model="claude-haiku-4-5",
         custom_llm_provider="anthropic",
         compression_saved_tokens=0,
+        gateway_injected_cache=False,
         routing_decision=_routed_decision(),
         usage_object={"prompt_tokens": ["not", "a", "number"]},
         recorded_autorouter_savings=0.25,
@@ -1047,6 +1099,7 @@ def test_a_boolean_is_not_a_recorded_savings_figure():
         model="claude-haiku-4-5",
         custom_llm_provider="anthropic",
         compression_saved_tokens=0,
+        gateway_injected_cache=False,
         routing_decision=None,
         usage_object=_cached_usage_object(),
         recorded_autorouter_savings=True,
@@ -1063,6 +1116,7 @@ def test_rows_written_before_the_field_shipped_recompute():
         model="claude-haiku-4-5",
         custom_llm_provider="anthropic",
         compression_saved_tokens=0,
+        gateway_injected_cache=False,
         routing_decision=_routed_decision(),
         usage_object=_cached_usage_object(),
     )
@@ -1127,3 +1181,150 @@ def test_logging_payload_never_stamps_internal_calls():
         cost_breakdown=None,
     )
     assert internal is None
+
+
+def test_savings_are_net_of_a_priced_classifier():
+    """The classifier call is part of what routing cost, so the per-request figure
+    deducts it; a charge big enough to outweigh the model saving goes negative,
+    since the figure is signed on purpose (GH #38816)."""
+    from litellm.proxy.spend_tracking.savings import autorouter_savings_for_request
+
+    gross = autorouter_savings_for_request(
+        model="claude-haiku-4-5",
+        custom_llm_provider="anthropic",
+        routing_decision=_routed_decision(),
+        usage_object=_cached_usage_object(),
+    )
+    net = autorouter_savings_for_request(
+        model="claude-haiku-4-5",
+        custom_llm_provider="anthropic",
+        routing_decision={**_routed_decision(), "classifier_cost": 0.005},
+        usage_object=_cached_usage_object(),
+    )
+    assert gross is not None and net == pytest.approx(gross - 0.005)
+
+
+@pytest.mark.parametrize("classifier_cost", [0.0, "bogus", True])
+def test_an_unpriced_classifier_deducts_nothing(classifier_cost: object):
+    from litellm.proxy.spend_tracking.savings import autorouter_savings_for_request
+
+    gross = autorouter_savings_for_request(
+        model="claude-haiku-4-5",
+        custom_llm_provider="anthropic",
+        routing_decision=_routed_decision(),
+        usage_object=_cached_usage_object(),
+    )
+    with_cost_field = autorouter_savings_for_request(
+        model="claude-haiku-4-5",
+        custom_llm_provider="anthropic",
+        routing_decision={**_routed_decision(), "classifier_cost": classifier_cost},
+        usage_object=_cached_usage_object(),
+    )
+    assert with_cost_field == gross
+
+
+def test_recorded_savings_are_already_net_and_not_deducted_again():
+    """The deduction lives at the figure's computation owner, so a stamped figure is
+    net by construction; the recorded-wins path must not subtract a second time."""
+    result = compute_savings_spend(
+        model="claude-haiku-4-5",
+        custom_llm_provider="anthropic",
+        compression_saved_tokens=0,
+        gateway_injected_cache=False,
+        routing_decision={**_routed_decision(), "classifier_cost": 0.005},
+        usage_object=_cached_usage_object(),
+        recorded_autorouter_savings=0.5,
+    )
+    assert result.autorouter == 0.5
+
+
+def test_caching_savings_require_a_gateway_injected_breakpoint():
+    """The same cached usage is attributed to the gateway only when it added a breakpoint.
+
+    Client-sent cache_control and implicit provider caching (OpenAI, Gemini) produce
+    cache reads the gateway had no hand in. Those still count as caching savings the
+    customer really got, so the total is unchanged, but nothing about them is the
+    gateway's doing and the attributed figure has to stay empty.
+    """
+    input_cost, cache_read_cost = _anthropic_costs("claude-sonnet-5")
+    credited = compute_savings_spend(
+        model="claude-sonnet-5",
+        custom_llm_provider="anthropic",
+        compression_saved_tokens=0,
+        gateway_injected_cache=True,
+        usage_object=_caching_usage(read=8200, written=0),
+    )
+    expected = 8200 * (input_cost - cache_read_cost)
+    assert credited.prompt_caching == pytest.approx(expected)
+    assert credited.gateway_injected_caching == pytest.approx(expected)
+    unattributed = compute_savings_spend(
+        model="claude-sonnet-5",
+        custom_llm_provider="anthropic",
+        compression_saved_tokens=0,
+        gateway_injected_cache=False,
+        usage_object=_caching_usage(read=8200, written=0),
+    )
+    assert unattributed.prompt_caching == pytest.approx(expected)
+    assert unattributed.gateway_injected_caching == 0.0
+
+
+def test_unattributed_write_only_request_still_reports_its_loss_in_the_total():
+    """A write-only request really did cost more than not caching, whoever asked for it.
+
+    The attributed figure drops it because the gateway added no breakpoint, and dropping a
+    negative is why the attributed number can sit above the total rather than below it.
+    """
+    result = compute_savings_spend(
+        model="claude-sonnet-5",
+        custom_llm_provider="anthropic",
+        compression_saved_tokens=0,
+        gateway_injected_cache=False,
+        usage_object=_caching_usage(read=0, written=20000),
+    )
+    assert result.prompt_caching < 0
+    assert result.gateway_injected_caching == 0.0
+    assert result.gateway_injected_caching > result.prompt_caching
+
+
+def test_injected_request_keeps_its_negative_net():
+    """A gateway-injected write-heavy request still reports its real loss."""
+    result = compute_savings_spend(
+        model="claude-sonnet-5",
+        custom_llm_provider="anthropic",
+        compression_saved_tokens=0,
+        gateway_injected_cache=True,
+        usage_object=_caching_usage(read=0, written=20000),
+    )
+    assert result.prompt_caching < 0
+
+
+def test_attribution_does_not_touch_compression_or_autorouter_legs():
+    input_cost, _ = _anthropic_costs("claude-sonnet-5")
+    result = compute_savings_spend(
+        model="claude-sonnet-5",
+        custom_llm_provider="anthropic",
+        compression_saved_tokens=4389,
+        gateway_injected_cache=False,
+        usage_object=_caching_usage(read=8200, written=0),
+    )
+    assert result.compression == pytest.approx(4389 * input_cost)
+    assert result.prompt_caching > 0
+    assert result.gateway_injected_caching == 0.0
+
+
+def test_marks_gateway_injection_credits_only_the_deployment_that_was_injected():
+    """Every retry, failover and fallback of a request shares one metadata bucket and one
+    litellm_call_id, so the deployment is what tells those legs apart. A marker naming a
+    sibling has to read here as no injection; that is what keeps the credit on the leg
+    that earned it without any seam having to strip it. Anything that is not this row's
+    own deployment, the missing key included, is fail-closed."""
+    assert marks_gateway_injection(None, "dep-a") is False
+    assert marks_gateway_injection({}, "dep-a") is False
+    assert marks_gateway_injection({"litellm_gateway_injected_cache": "dep-a"}, "dep-a") is True
+    assert marks_gateway_injection({"litellm_gateway_injected_cache": "dep-a"}, "dep-b") is False
+    assert marks_gateway_injection({"litellm_gateway_injected_cache": "dep-a"}, None) is False
+    # injected before a deployment was chosen, so it is in the payload every leg sends
+    assert marks_gateway_injection({"litellm_gateway_injected_cache": ""}, "dep-a") is True
+    assert marks_gateway_injection({"litellm_gateway_injected_cache": ""}, None) is True
+    assert marks_gateway_injection({"litellm_call_id": "c1"}, "dep-a") is False
+    assert marks_gateway_injection({"litellm_gateway_injected_cache": True}, "dep-a") is False


### PR DESCRIPTION
GET /organization/list answers HTTP 500 when called with a virtual key that has no user behind it.

## Reproduction

1. Create a team, then a key scoped to that team (no `user_id`):

```bash
curl -X POST http://0.0.0.0:4000/team/new \
  -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
  -d "{\"team_alias\":\"demo\"}"

curl -X POST http://0.0.0.0:4000/key/generate \
  -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
  -d "{\"team_id\":\"<team_id>\"}"
```

2. Call the endpoint with that key:

```bash
curl http://0.0.0.0:4000/organization/list -H "Authorization: Bearer <team key>"
```

Response:

```json
{"error":{"message":"Internal server error","type":"internal_server_error"}}
```

Server log:

```
prisma.errors.MissingRequiredValueError: Unable to match input value to any allowed
input type for the field. Parse errors: [`where.user_id`: A value is required but
not set, `where.user_id`: A value is required but not set]
```

Other endpoints handle this caller correctly — `/team/info` on another team answers 403 and `/team/list` answers 401 — so this one stands out as an internal error on an authorization path.

## Cause

In `list_organization`, the non-admin branch filters organization memberships by the caller `user_id`:

```python
org_memberships: Final = await _table(OrganizationMembershipRepository(prisma_client)).find_many(
    where={"user_id": user_api_key_dict.user_id}
)
```

Team and service keys are authenticated but have `user_id` set to `None`, and Prisma rejects a null filter.

## Change

Return early when there is no user. A key with no user is a member of no organization, so the correct response is an empty list rather than an exception. No behaviour changes for admin keys or for user keys.

## Test

Adds a regression test in `tests/test_litellm/proxy/management_endpoints/test_organization_endpoints.py`, covered by the `proxy-endpoints` shard of `test-unit.yml`.