### PR TITLE
fix(proxy): route invalid virtual key logs to stdout

### DIFF
--- a/litellm/_logging.py
+++ b/litellm/_logging.py
@@ -690,6 +690,7 @@ def _turn_on_json():
     - Adds a JSON formatter to all loggers
     """
     handler: Final = LevelRoutingStreamHandler()
+    handler.setLevel(numeric_level)
     handler.setFormatter(JsonFormatter())
     _initialize_loggers_with_handler(handler)
     # Set up exception handlers

--- a/litellm/_logging.py
+++ b/litellm/_logging.py
@@ -510,23 +510,16 @@ else:
 
     handler.setFormatter(formatter)
 
-verbose_proxy_logger: Final = logging.getLogger("LiteLLM Proxy")
+verbose_proxy_logger = logging.getLogger("LiteLLM Proxy")
+# Malformed virtual key rejections log through this child; LevelRoutingStreamHandler
+# writes its WARNING records to stdout. It has no handler or level of its own.
 verbose_proxy_stdout_logger: Final = verbose_proxy_logger.getChild("stdout")
-verbose_router_logger: Final = logging.getLogger("LiteLLM Router")
-verbose_logger: Final = logging.getLogger("LiteLLM")
-
-verbose_proxy_stdout_handler: Final = LevelRoutingStreamHandler()
-verbose_proxy_stdout_handler.setLevel(logging.WARNING)
-verbose_proxy_stdout_handler.setFormatter(handler.formatter)
-verbose_proxy_stdout_handler.addFilter(_secret_filter)
-verbose_proxy_stdout_handler.addFilter(_correlation_filter)
+verbose_router_logger = logging.getLogger("LiteLLM Router")
+verbose_logger = logging.getLogger("LiteLLM")
 
 # Add the handler to the loggers
 verbose_router_logger.addHandler(handler)
 verbose_proxy_logger.addHandler(handler)
-verbose_proxy_stdout_logger.setLevel(logging.WARNING)
-verbose_proxy_stdout_logger.addHandler(verbose_proxy_stdout_handler)
-verbose_proxy_stdout_logger.propagate = False
 verbose_logger.addHandler(handler)
 
 # Filters attached to the logger, not the handler, survive callers swapping in their own
@@ -592,7 +585,6 @@ ALL_LOGGERS: Final = [
     verbose_logger,
     verbose_router_logger,
     verbose_proxy_logger,
-    verbose_proxy_stdout_logger,
 ]
 
 
@@ -700,7 +692,6 @@ def _turn_on_json():
     handler: Final = LevelRoutingStreamHandler()
     handler.setFormatter(JsonFormatter())
     _initialize_loggers_with_handler(handler)
-    verbose_proxy_stdout_logger.setLevel(logging.WARNING)
     # Set up exception handlers
     _setup_json_exception_handlers(JsonFormatter())
 

--- a/litellm/_logging.py
+++ b/litellm/_logging.py
@@ -264,13 +264,16 @@ def _plain_log_format(stdout: TextIO | None, stderr: TextIO | None) -> str:
 
 
 class LevelRoutingStreamHandler(logging.StreamHandler):
-    """Writes records below WARNING to stdout and WARNING and above to stderr.
+    """Writes records below WARNING and invalid-key warnings to stdout.
 
     Collectors that derive severity from the stream report every stderr line as an error.
     """
 
     def emit(self, record: logging.LogRecord) -> None:
-        preferred: Final = sys.stdout if record.levelno < logging.WARNING else sys.stderr
+        is_stdout_record: Final = record.levelno < logging.WARNING or (
+            record.levelno == logging.WARNING and record.name == verbose_proxy_stdout_logger.name
+        )
+        preferred: Final = sys.stdout if is_stdout_record else sys.stderr
         if preferred is None or getattr(preferred, "closed", False):
             self.stream = sys.stderr  # rebind-ok: fall back to the pre-fix stream rather than raising per record
         else:
@@ -507,19 +510,30 @@ else:
 
     handler.setFormatter(formatter)
 
-verbose_proxy_logger = logging.getLogger("LiteLLM Proxy")
-verbose_router_logger = logging.getLogger("LiteLLM Router")
-verbose_logger = logging.getLogger("LiteLLM")
+verbose_proxy_logger: Final = logging.getLogger("LiteLLM Proxy")
+verbose_proxy_stdout_logger: Final = verbose_proxy_logger.getChild("stdout")
+verbose_router_logger: Final = logging.getLogger("LiteLLM Router")
+verbose_logger: Final = logging.getLogger("LiteLLM")
+
+verbose_proxy_stdout_handler: Final = LevelRoutingStreamHandler()
+verbose_proxy_stdout_handler.setLevel(logging.WARNING)
+verbose_proxy_stdout_handler.setFormatter(handler.formatter)
+verbose_proxy_stdout_handler.addFilter(_secret_filter)
+verbose_proxy_stdout_handler.addFilter(_correlation_filter)
 
 # Add the handler to the loggers
 verbose_router_logger.addHandler(handler)
 verbose_proxy_logger.addHandler(handler)
+verbose_proxy_stdout_logger.setLevel(logging.WARNING)
+verbose_proxy_stdout_logger.addHandler(verbose_proxy_stdout_handler)
+verbose_proxy_stdout_logger.propagate = False
 verbose_logger.addHandler(handler)
 
 # Filters attached to the logger, not the handler, survive callers swapping in their own
 # handlers (JSON mode, uvicorn log config, a host app's root handler).
 verbose_router_logger.addFilter(_stdout_truncation_filter)
 verbose_proxy_logger.addFilter(_stdout_truncation_filter)
+verbose_proxy_stdout_logger.addFilter(_stdout_truncation_filter)
 verbose_logger.addFilter(_stdout_truncation_filter)
 
 
@@ -578,6 +592,7 @@ ALL_LOGGERS: Final = [
     verbose_logger,
     verbose_router_logger,
     verbose_proxy_logger,
+    verbose_proxy_stdout_logger,
 ]
 
 
@@ -685,6 +700,7 @@ def _turn_on_json():
     handler: Final = LevelRoutingStreamHandler()
     handler.setFormatter(JsonFormatter())
     _initialize_loggers_with_handler(handler)
+    verbose_proxy_stdout_logger.setLevel(logging.WARNING)
     # Set up exception handlers
     _setup_json_exception_handlers(JsonFormatter())
 
@@ -700,12 +716,14 @@ def _disable_debugging():
     verbose_logger.disabled = True
     verbose_router_logger.disabled = True
     verbose_proxy_logger.disabled = True
+    verbose_proxy_stdout_logger.disabled = True
 
 
 def _enable_debugging():
     verbose_logger.disabled = False
     verbose_router_logger.disabled = False
     verbose_proxy_logger.disabled = False
+    verbose_proxy_stdout_logger.disabled = False
 
 
 def print_verbose(print_statement):

--- a/litellm/proxy/auth/auth_exception_handler.py
+++ b/litellm/proxy/auth/auth_exception_handler.py
@@ -54,6 +54,41 @@ def _with_requester_ip_address(request_data: dict[str, object], requester_ip: st
     return {**request_data, key: {**base, "requester_ip_address": requester_ip}}  # mutable-ok: logging needs dicts
 
 
+def _as_proxy_exception(e: Exception) -> ProxyException:
+    """Convert an authentication failure into the ProxyException the client receives."""
+    if isinstance(e, litellm.BudgetExceededError):
+        return ProxyException(
+            message=e.message,
+            type=ProxyErrorTypes.budget_exceeded,
+            param=None,
+            code=getattr(e, "status_code", status.HTTP_429_TOO_MANY_REQUESTS),
+        )
+    if isinstance(e, HTTPException):
+        return ProxyException(
+            message=getattr(e, "detail", f"Authentication Error({e})"),
+            type=ProxyErrorTypes.auth_error,
+            param=getattr(e, "param", "None"),
+            code=getattr(e, "status_code", status.HTTP_401_UNAUTHORIZED),
+        )
+    if isinstance(e, ProxyException):
+        return e
+    if PrismaDBExceptionHandler.is_database_service_unavailable_error(e):
+        return ProxyException(
+            message=(
+                "Service Unavailable, the authentication database is temporarily unreachable. Please retry shortly."
+            ),
+            type=ProxyErrorTypes.no_db_connection,
+            param="None",
+            code=status.HTTP_503_SERVICE_UNAVAILABLE,
+        )
+    return ProxyException(
+        message="Authentication Error, " + str(e),
+        type=ProxyErrorTypes.auth_error,
+        param=getattr(e, "param", "None"),
+        code=status.HTTP_401_UNAUTHORIZED,
+    )
+
+
 class UserAPIKeyAuthExceptionHandler:
     @staticmethod
     async def _handle_authentication_error(
@@ -115,8 +150,17 @@ class UserAPIKeyAuthExceptionHandler:
                 request=request,
                 use_x_forwarded_for=general_settings.get("use_x_forwarded_for") is True,
             )
-            original_exception: Final = e
             is_invalid_virtual_key: Final = is_invalid_virtual_key_error(e)
+            is_quiet_log: Final = is_invalid_virtual_key and not litellm.log_client_error_tracebacks
+            logger: Final = verbose_proxy_stdout_logger if is_quiet_log else verbose_proxy_logger
+            logger.log(
+                logging.WARNING if is_quiet_log else logging.ERROR,
+                "litellm.proxy.proxy_server.user_api_key_auth(): Exception occured - %s\nRequester IP Address:%s",
+                e,
+                requester_ip,
+                exc_info=True if litellm.log_client_error_tracebacks or not is_expected_client_error(e) else None,
+                extra={"requester_ip": requester_ip},
+            )
 
             # Log this exception to OTEL, Datadog etc. Reuse the identity resolved
             # before the failure (team alias/id, metadata, user) so the failed span
@@ -154,7 +198,7 @@ class UserAPIKeyAuthExceptionHandler:
             # Allow callbacks to transform the error response
             transformed_exception: Final = await proxy_logging_obj.post_call_failure_hook(
                 request_data=_with_requester_ip_address(request_data, requester_ip),
-                original_exception=original_exception,
+                original_exception=e,
                 user_api_key_dict=user_api_key_dict,
                 error_type=ProxyErrorTypes.auth_error,
                 route=route,
@@ -163,51 +207,4 @@ class UserAPIKeyAuthExceptionHandler:
             if transformed_exception is not None:
                 e = transformed_exception
 
-            proxy_exception: Final
-            if isinstance(e, litellm.BudgetExceededError):
-                proxy_exception = ProxyException(
-                    message=e.message,
-                    type=ProxyErrorTypes.budget_exceeded,
-                    param=None,
-                    code=getattr(e, "status_code", status.HTTP_429_TOO_MANY_REQUESTS),
-                )
-            elif isinstance(e, HTTPException):
-                proxy_exception = ProxyException(
-                    message=getattr(e, "detail", f"Authentication Error({e})"),
-                    type=ProxyErrorTypes.auth_error,
-                    param=getattr(e, "param", "None"),
-                    code=getattr(e, "status_code", status.HTTP_401_UNAUTHORIZED),
-                )
-            elif isinstance(e, ProxyException):
-                proxy_exception = e
-            elif PrismaDBExceptionHandler.is_database_service_unavailable_error(e):
-                proxy_exception = ProxyException(
-                    message=(
-                        "Service Unavailable, the authentication database is "
-                        "temporarily unreachable. Please retry shortly."
-                    ),
-                    type=ProxyErrorTypes.no_db_connection,
-                    param="None",
-                    code=status.HTTP_503_SERVICE_UNAVAILABLE,
-                )
-            else:
-                proxy_exception = ProxyException(
-                    message="Authentication Error, " + str(e),
-                    type=ProxyErrorTypes.auth_error,
-                    param=getattr(e, "param", "None"),
-                    code=status.HTTP_401_UNAUTHORIZED,
-                )
-            final_exception: Final = mark_invalid_virtual_key_error(proxy_exception, is_invalid_virtual_key)
-            is_quiet_log: Final = (
-                is_invalid_virtual_key_error(final_exception) and not litellm.log_client_error_tracebacks
-            )
-            logger: Final = verbose_proxy_stdout_logger if is_quiet_log else verbose_proxy_logger
-            logger.log(
-                logging.WARNING if is_quiet_log else logging.ERROR,
-                "litellm.proxy.proxy_server.user_api_key_auth(): Exception occured - %s\nRequester IP Address:%s",
-                final_exception,
-                requester_ip,
-                exc_info=not (is_expected_client_error(original_exception) and not litellm.log_client_error_tracebacks),
-                extra={"requester_ip": requester_ip},
-            )
-            raise final_exception
+            raise mark_invalid_virtual_key_error(_as_proxy_exception(e), is_invalid_virtual_key)

--- a/litellm/proxy/auth/auth_exception_handler.py
+++ b/litellm/proxy/auth/auth_exception_handler.py
@@ -2,13 +2,14 @@
 Handles Authentication Errors
 """
 
+import logging
 from collections.abc import Mapping
 from typing import TYPE_CHECKING, Any, Final
 
 from fastapi import HTTPException, Request, status
 
 import litellm
-from litellm._logging import verbose_proxy_logger
+from litellm._logging import verbose_proxy_logger, verbose_proxy_stdout_logger
 from litellm.constants import EMPTY_MAPPING
 from litellm.integrations.otel.runtime import seed_request_identity
 from litellm.litellm_core_utils.core_helpers import is_expected_client_error
@@ -18,7 +19,11 @@ from litellm.proxy._types import (
     ProxyException,
     UserAPIKeyAuth,
 )
-from litellm.proxy.auth.auth_utils import _get_request_ip_address
+from litellm.proxy.auth.auth_utils import (
+    _get_request_ip_address,
+    is_invalid_virtual_key_error,
+    mark_invalid_virtual_key_error,
+)
 from litellm.proxy.db.exception_handler import PrismaDBExceptionHandler
 from litellm.types.services import ServiceTypes
 
@@ -110,17 +115,8 @@ class UserAPIKeyAuthExceptionHandler:
                 request=request,
                 use_x_forwarded_for=general_settings.get("use_x_forwarded_for") is True,
             )
-            log_fn: Final = (
-                verbose_proxy_logger.error
-                if is_expected_client_error(e) and not litellm.log_client_error_tracebacks
-                else verbose_proxy_logger.exception
-            )
-            log_fn(
-                "litellm.proxy.proxy_server.user_api_key_auth(): Exception occured - %s\nRequester IP Address:%s",
-                e,
-                requester_ip,
-                extra={"requester_ip": requester_ip},
-            )
+            original_exception: Final = e
+            is_invalid_virtual_key: Final = is_invalid_virtual_key_error(e)
 
             # Log this exception to OTEL, Datadog etc. Reuse the identity resolved
             # before the failure (team alias/id, metadata, user) so the failed span
@@ -158,7 +154,7 @@ class UserAPIKeyAuthExceptionHandler:
             # Allow callbacks to transform the error response
             transformed_exception: Final = await proxy_logging_obj.post_call_failure_hook(
                 request_data=_with_requester_ip_address(request_data, requester_ip),
-                original_exception=e,
+                original_exception=original_exception,
                 user_api_key_dict=user_api_key_dict,
                 error_type=ProxyErrorTypes.auth_error,
                 route=route,
@@ -167,24 +163,25 @@ class UserAPIKeyAuthExceptionHandler:
             if transformed_exception is not None:
                 e = transformed_exception
 
+            proxy_exception: Final
             if isinstance(e, litellm.BudgetExceededError):
-                raise ProxyException(
+                proxy_exception = ProxyException(
                     message=e.message,
                     type=ProxyErrorTypes.budget_exceeded,
                     param=None,
                     code=getattr(e, "status_code", status.HTTP_429_TOO_MANY_REQUESTS),
                 )
-            if isinstance(e, HTTPException):
-                raise ProxyException(
+            elif isinstance(e, HTTPException):
+                proxy_exception = ProxyException(
                     message=getattr(e, "detail", f"Authentication Error({e})"),
                     type=ProxyErrorTypes.auth_error,
                     param=getattr(e, "param", "None"),
                     code=getattr(e, "status_code", status.HTTP_401_UNAUTHORIZED),
                 )
             elif isinstance(e, ProxyException):
-                raise e
-            if PrismaDBExceptionHandler.is_database_service_unavailable_error(e):
-                raise ProxyException(
+                proxy_exception = e
+            elif PrismaDBExceptionHandler.is_database_service_unavailable_error(e):
+                proxy_exception = ProxyException(
                     message=(
                         "Service Unavailable, the authentication database is "
                         "temporarily unreachable. Please retry shortly."
@@ -193,9 +190,24 @@ class UserAPIKeyAuthExceptionHandler:
                     param="None",
                     code=status.HTTP_503_SERVICE_UNAVAILABLE,
                 )
-            raise ProxyException(
-                message="Authentication Error, " + str(e),
-                type=ProxyErrorTypes.auth_error,
-                param=getattr(e, "param", "None"),
-                code=status.HTTP_401_UNAUTHORIZED,
+            else:
+                proxy_exception = ProxyException(
+                    message="Authentication Error, " + str(e),
+                    type=ProxyErrorTypes.auth_error,
+                    param=getattr(e, "param", "None"),
+                    code=status.HTTP_401_UNAUTHORIZED,
+                )
+            final_exception: Final = mark_invalid_virtual_key_error(proxy_exception, is_invalid_virtual_key)
+            is_quiet_log: Final = (
+                is_invalid_virtual_key_error(final_exception) and not litellm.log_client_error_tracebacks
             )
+            logger: Final = verbose_proxy_stdout_logger if is_quiet_log else verbose_proxy_logger
+            logger.log(
+                logging.WARNING if is_quiet_log else logging.ERROR,
+                "litellm.proxy.proxy_server.user_api_key_auth(): Exception occured - %s\nRequester IP Address:%s",
+                final_exception,
+                requester_ip,
+                exc_info=not (is_expected_client_error(original_exception) and not litellm.log_client_error_tracebacks),
+                extra={"requester_ip": requester_ip},
+            )
+            raise final_exception

--- a/litellm/proxy/auth/auth_exception_handler.py
+++ b/litellm/proxy/auth/auth_exception_handler.py
@@ -150,6 +150,7 @@ class UserAPIKeyAuthExceptionHandler:
                 request=request,
                 use_x_forwarded_for=general_settings.get("use_x_forwarded_for") is True,
             )
+            log_extra: Final = {"requester_ip": requester_ip}
             is_invalid_virtual_key: Final = is_invalid_virtual_key_error(e)
             is_quiet_log: Final = is_invalid_virtual_key and not litellm.log_client_error_tracebacks
             logger: Final = verbose_proxy_stdout_logger if is_quiet_log else verbose_proxy_logger
@@ -159,7 +160,7 @@ class UserAPIKeyAuthExceptionHandler:
                 e,
                 requester_ip,
                 exc_info=True if litellm.log_client_error_tracebacks or not is_expected_client_error(e) else None,
-                extra={"requester_ip": requester_ip},
+                extra=log_extra,
             )
 
             # Log this exception to OTEL, Datadog etc. Reuse the identity resolved
@@ -207,4 +208,12 @@ class UserAPIKeyAuthExceptionHandler:
             if transformed_exception is not None:
                 e = transformed_exception
 
-            raise mark_invalid_virtual_key_error(_as_proxy_exception(e), is_invalid_virtual_key)
+            final_exception: Final = mark_invalid_virtual_key_error(_as_proxy_exception(e), is_invalid_virtual_key)
+            if is_quiet_log and str(final_exception.code) != str(status.HTTP_401_UNAUTHORIZED):
+                verbose_proxy_logger.error(
+                    "litellm.proxy.proxy_server.user_api_key_auth(): Exception occured - %s\nRequester IP Address:%s",
+                    final_exception,
+                    requester_ip,
+                    extra=log_extra,
+                )
+            raise final_exception

--- a/litellm/proxy/auth/auth_utils.py
+++ b/litellm/proxy/auth/auth_utils.py
@@ -76,7 +76,7 @@ def mark_invalid_virtual_key_error(exception: ProxyException, is_invalid_virtual
         param=exception.param,
         code=exception.code,
         headers=exception.headers.copy(),
-        openai_code=exception.openai_code,
+        openai_code=None if exception.openai_code is None else str(exception.openai_code),
         provider_specific_fields=exception.provider_specific_fields,
     )
     setattr(marked_exception, _INVALID_VIRTUAL_KEY_ERROR_MARKER, True)

--- a/litellm/proxy/auth/auth_utils.py
+++ b/litellm/proxy/auth/auth_utils.py
@@ -33,6 +33,9 @@ from litellm.types.passthrough_endpoints.pass_through_endpoints import (
 from litellm.types.router import CONFIGURABLE_CLIENTSIDE_AUTH_PARAMS
 from litellm.types.utils import CustomPricingLiteLLMParams
 
+INVALID_VIRTUAL_KEY_ERROR_MESSAGE: Final = "LiteLLM Virtual Key expected"
+_INVALID_VIRTUAL_KEY_ERROR_MARKER: Final = "_litellm_invalid_virtual_key_error"
+
 
 def _get_request_ip_address(request: Request, use_x_forwarded_for: bool | None = False) -> str | None:
     client_ip = None
@@ -44,6 +47,40 @@ def _get_request_ip_address(request: Request, use_x_forwarded_for: bool | None =
         client_ip = ""
 
     return client_ip
+
+
+def is_invalid_virtual_key_error(exception: BaseException | None) -> bool:
+    """True when an authentication error rejects a malformed virtual key."""
+    if not isinstance(exception, (HTTPException, ProxyException)):
+        return False
+
+    code: Final[object] = getattr(exception, "code", None)
+    status_code: Final[object] = code if code is not None else getattr(exception, "status_code", None)
+    if str(status_code) != str(status.HTTP_401_UNAUTHORIZED):
+        return False
+
+    if getattr(exception, _INVALID_VIRTUAL_KEY_ERROR_MARKER, False) is True:
+        return True
+
+    message: Final = getattr(exception, "detail", None) or getattr(exception, "message", "")
+    return INVALID_VIRTUAL_KEY_ERROR_MESSAGE in str(message)
+
+
+def mark_invalid_virtual_key_error(exception: ProxyException, is_invalid_virtual_key: bool) -> ProxyException:
+    """Return an independently marked malformed-key exception after callback transformations."""
+    if not is_invalid_virtual_key or str(exception.code) != str(status.HTTP_401_UNAUTHORIZED):
+        return exception
+    marked_exception: Final = ProxyException(
+        message=exception.message,
+        type=exception.type,
+        param=exception.param,
+        code=exception.code,
+        headers=exception.headers.copy(),
+        openai_code=exception.openai_code,
+        provider_specific_fields=exception.provider_specific_fields,
+    )
+    setattr(marked_exception, _INVALID_VIRTUAL_KEY_ERROR_MARKER, True)
+    return marked_exception
 
 
 def _check_valid_ip(

--- a/litellm/proxy/auth/user_api_key_auth.py
+++ b/litellm/proxy/auth/user_api_key_auth.py
@@ -19,6 +19,7 @@ import fastapi
 import orjson
 from fastapi import HTTPException, Request, WebSocket, status
 from fastapi.security.api_key import APIKeyHeader
+from starlette.exceptions import WebSocketException
 
 import litellm
 from litellm._logging import verbose_logger, verbose_proxy_logger
@@ -60,11 +61,13 @@ from litellm.proxy.auth.auth_checks import (
 from litellm.proxy.auth.auth_exception_handler import UserAPIKeyAuthExceptionHandler
 from litellm.proxy.auth.auth_method import AuthMethod
 from litellm.proxy.auth.auth_utils import (
+    INVALID_VIRTUAL_KEY_ERROR_MESSAGE,
     abbreviate_api_key,
     get_end_user_id_from_request_body,
     get_model_from_request,
     get_request_route,
     get_request_route_template,
+    is_invalid_virtual_key_error,
     iter_request_fallback_targets,
     normalize_request_route,
     pre_db_read_auth_checks,
@@ -539,6 +542,8 @@ async def user_api_key_auth_websocket(websocket: WebSocket):
     try:
         return await user_api_key_auth(request=request, api_key=f"Bearer {api_key}")
     except Exception as e:
+        if is_invalid_virtual_key_error(e):
+            raise WebSocketException(code=status.WS_1008_POLICY_VIOLATION)
         verbose_proxy_logger.exception(e)
         await websocket.close(code=status.WS_1008_POLICY_VIOLATION)
         raise HTTPException(status_code=403, detail=str(e))
@@ -1870,7 +1875,7 @@ async def _user_api_key_auth_builder(
                     raise HTTPException(
                         status_code=status.HTTP_401_UNAUTHORIZED,
                         detail=(
-                            f"LiteLLM Virtual Key expected. Received={_masked_key}, "
+                            f"{INVALID_VIRTUAL_KEY_ERROR_MESSAGE}. Received={_masked_key}, "
                             f"expected to start with 'sk-'.{_hint}"
                         ),
                     )  # prevent token hashes from being used

--- a/tests/proxy_unit_tests/test_user_api_key_auth.py
+++ b/tests/proxy_unit_tests/test_user_api_key_auth.py
@@ -875,6 +875,44 @@ async def test_user_api_key_auth_websocket():
 
 
 @pytest.mark.asyncio
+async def test_user_api_key_auth_websocket_skips_duplicate_invalid_key_log():
+    from litellm.proxy._types import ProxyException
+    from litellm.proxy.auth.auth_utils import mark_invalid_virtual_key_error
+    from litellm.proxy.auth.user_api_key_auth import WebSocketException, user_api_key_auth_websocket
+
+    mock_websocket = MagicMock(spec=WebSocket)
+    mock_websocket.query_params = {"model": "some_model"}
+    mock_websocket.headers = {"authorization": "Bearer undefined"}
+    mock_websocket.scope = {"headers": [(b"authorization", b"Bearer undefined")]}
+    mock_websocket.url = URL(url="/v1/responses")
+    transformed_invalid_virtual_key = mark_invalid_virtual_key_error(
+        ProxyException(
+            message="Please authenticate again",
+            type="auth_error",
+            param="None",
+            code=status.HTTP_401_UNAUTHORIZED,
+        ),
+        True,
+    )
+
+    with (
+        patch(
+            "litellm.proxy.auth.user_api_key_auth.user_api_key_auth",
+            side_effect=transformed_invalid_virtual_key,
+            autospec=True,
+        ),
+        patch("litellm.proxy.auth.user_api_key_auth.verbose_proxy_logger.exception") as exception_log,
+        pytest.raises(WebSocketException) as exc_info,
+    ):
+        await user_api_key_auth_websocket(mock_websocket)
+
+    assert exc_info.value.code == status.WS_1008_POLICY_VIOLATION
+    assert exc_info.value.reason == ""
+    exception_log.assert_not_called()
+    mock_websocket.close.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_user_api_key_auth_websocket_carries_asgi_path():
     """
     The synthetic Request must carry the ASGI scope's ``path`` so

--- a/tests/proxy_unit_tests/test_user_api_key_auth.py
+++ b/tests/proxy_unit_tests/test_user_api_key_auth.py
@@ -875,44 +875,6 @@ async def test_user_api_key_auth_websocket():
 
 
 @pytest.mark.asyncio
-async def test_user_api_key_auth_websocket_skips_duplicate_invalid_key_log():
-    from litellm.proxy._types import ProxyException
-    from litellm.proxy.auth.auth_utils import mark_invalid_virtual_key_error
-    from litellm.proxy.auth.user_api_key_auth import WebSocketException, user_api_key_auth_websocket
-
-    mock_websocket = MagicMock(spec=WebSocket)
-    mock_websocket.query_params = {"model": "some_model"}
-    mock_websocket.headers = {"authorization": "Bearer undefined"}
-    mock_websocket.scope = {"headers": [(b"authorization", b"Bearer undefined")]}
-    mock_websocket.url = URL(url="/v1/responses")
-    transformed_invalid_virtual_key = mark_invalid_virtual_key_error(
-        ProxyException(
-            message="Please authenticate again",
-            type="auth_error",
-            param="None",
-            code=status.HTTP_401_UNAUTHORIZED,
-        ),
-        True,
-    )
-
-    with (
-        patch(
-            "litellm.proxy.auth.user_api_key_auth.user_api_key_auth",
-            side_effect=transformed_invalid_virtual_key,
-            autospec=True,
-        ),
-        patch("litellm.proxy.auth.user_api_key_auth.verbose_proxy_logger.exception") as exception_log,
-        pytest.raises(WebSocketException) as exc_info,
-    ):
-        await user_api_key_auth_websocket(mock_websocket)
-
-    assert exc_info.value.code == status.WS_1008_POLICY_VIOLATION
-    assert exc_info.value.reason == ""
-    exception_log.assert_not_called()
-    mock_websocket.close.assert_not_called()
-
-
-@pytest.mark.asyncio
 async def test_user_api_key_auth_websocket_carries_asgi_path():
     """
     The synthetic Request must carry the ASGI scope's ``path`` so

--- a/tests/test_litellm/proxy/auth/test_auth_exception_handler.py
+++ b/tests/test_litellm/proxy/auth/test_auth_exception_handler.py
@@ -1,5 +1,6 @@
 import asyncio
 import json
+import logging
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
@@ -24,8 +25,7 @@ from prisma.errors import (
     UniqueViolationError,
 )
 
-
-from litellm._logging import verbose_proxy_logger
+from litellm._logging import verbose_proxy_logger, verbose_proxy_stdout_logger
 from litellm.exceptions import BudgetExceededError
 from litellm.proxy._types import ProxyErrorTypes, ProxyException, UserAPIKeyAuth
 from litellm.proxy.auth.auth_exception_handler import UserAPIKeyAuthExceptionHandler
@@ -335,9 +335,7 @@ async def test_handle_authentication_error_budget_exceeded():
     # Test with budget exceeded error
     from litellm.exceptions import BudgetExceededError
 
-    budget_error = BudgetExceededError(
-        message="Budget exceeded", current_cost=100, max_budget=100
-    )
+    budget_error = BudgetExceededError(message="Budget exceeded", current_cost=100, max_budget=100)
 
     with pytest.raises(ProxyException) as exc_info:
         await handler._handle_authentication_error(
@@ -705,19 +703,79 @@ async def test_auth_failure_ip_stamp_does_not_mutate_callers_request_data():
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    "auth_error,expect_traceback",
+    "auth_error,expected_level,expect_traceback,log_client_error_tracebacks",
     [
         pytest.param(
-            ProxyException(
-                message="Authentication Error", type=ProxyErrorTypes.auth_error, param=None, code=401
+            HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="LiteLLM Virtual Key expected. Received=unde****ined, expected to start with 'sk-'.",
             ),
+            logging.WARNING,
             False,
-            id="expected_401_no_traceback",
+            False,
+            id="invalid_virtual_key_logs_at_warning_without_traceback",
         ),
-        pytest.param(ValueError("unexpected internal error"), True, id="unexpected_error_keeps_traceback"),
+        pytest.param(
+            HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="LiteLLM Virtual Key expected. Received=unde****ined, expected to start with 'sk-'.",
+            ),
+            logging.ERROR,
+            True,
+            True,
+            id="invalid_virtual_key_keeps_traceback_opt_in",
+        ),
+        pytest.param(
+            HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="Authentication Error",
+            ),
+            logging.ERROR,
+            False,
+            False,
+            id="other_http_401_keeps_error_level_without_traceback",
+        ),
+        pytest.param(
+            ProxyException(
+                message="LiteLLM Virtual Key expected",
+                type=ProxyErrorTypes.auth_error,
+                param=None,
+                code=401,
+            ),
+            logging.WARNING,
+            False,
+            False,
+            id="custom_auth_invalid_virtual_key_logs_at_warning_without_traceback",
+        ),
+        pytest.param(
+            ProxyException(message="Authentication Error", type=ProxyErrorTypes.auth_error, param=None, code=401),
+            logging.ERROR,
+            False,
+            False,
+            id="other_expected_401_keeps_error_level_without_traceback",
+        ),
+        pytest.param(
+            ValueError("unexpected internal error"),
+            logging.ERROR,
+            True,
+            False,
+            id="unexpected_error_keeps_traceback",
+        ),
+        pytest.param(
+            HTTPException(
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                detail="Authentication database unavailable",
+            ),
+            logging.ERROR,
+            True,
+            False,
+            id="server_error_keeps_traceback",
+        ),
     ],
 )
-async def test_handle_authentication_error_traceback_only_for_unexpected_errors(auth_error, expect_traceback, caplog):
+async def test_handle_authentication_error_traceback_only_for_unexpected_errors(
+    auth_error, expected_level, expect_traceback, log_client_error_tracebacks, caplog
+):
     """Regression for LIT-6043: expected 4xx auth rejections must not format a
     traceback via logger.exception; unexpected errors must keep it."""
     handler = UserAPIKeyAuthExceptionHandler()
@@ -731,17 +789,22 @@ async def test_handle_authentication_error_traceback_only_for_unexpected_errors(
         patch(  # test-quality-ok: handler reads proxy_server globals at call time
             "litellm.proxy.auth.auth_exception_handler.seed_request_identity",
         ),
+        patch(  # test-quality-ok: handler reads this global flag at call time
+            "litellm.proxy.auth.auth_exception_handler.litellm.log_client_error_tracebacks",
+            log_client_error_tracebacks,
+        ),
         patch(  # test-quality-ok: handler reads proxy_server globals at call time
             "litellm.proxy.proxy_server.general_settings",
             {"allow_requests_on_db_unavailable": False},
         ),
     ):
         verbose_proxy_logger.propagate = True
+        verbose_proxy_stdout_logger.propagate = True
         try:
             try:
                 raise auth_error
-            except (ProxyException, ValueError) as caught:
-                with caplog.at_level("ERROR", logger="LiteLLM Proxy"), pytest.raises(ProxyException):
+            except (HTTPException, ProxyException, ValueError) as caught:
+                with caplog.at_level(logging.DEBUG), pytest.raises(ProxyException):
                     await handler._handle_authentication_error(
                         caught,
                         MagicMock(),
@@ -752,7 +815,158 @@ async def test_handle_authentication_error_traceback_only_for_unexpected_errors(
                     )
         finally:
             verbose_proxy_logger.propagate = False
+            verbose_proxy_stdout_logger.propagate = False
 
     records = [r for r in caplog.records if "user_api_key_auth(): Exception occured" in r.getMessage()]
     assert len(records) == 1
-    assert (records[0].exc_info is not None) is expect_traceback
+    assert records[0].levelno == expected_level
+    assert bool(records[0].exc_info) is expect_traceback
+    assert records[0].name == (
+        verbose_proxy_stdout_logger.name
+        if expected_level == logging.WARNING and not log_client_error_tracebacks
+        else verbose_proxy_logger.name
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "transformed_exception",
+    [
+        HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Please authenticate again"),
+        ProxyException(
+            message="Please authenticate again",
+            type=ProxyErrorTypes.auth_error,
+            param=None,
+            code=status.HTTP_401_UNAUTHORIZED,
+        ),
+    ],
+)
+async def test_handle_authentication_error_preserves_invalid_virtual_key_marker_after_callback_transform(
+    caplog,
+    transformed_exception,
+):
+    handler = UserAPIKeyAuthExceptionHandler()
+    original_exception = HTTPException(
+        status_code=status.HTTP_401_UNAUTHORIZED,
+        detail="LiteLLM Virtual Key expected. Received=unde****ined, expected to start with 'sk-'.",
+    )
+
+    with (
+        patch(
+            "litellm.proxy.proxy_server.proxy_logging_obj.post_call_failure_hook",
+            new_callable=AsyncMock,
+            return_value=transformed_exception,
+        ),
+        patch("litellm.proxy.auth.auth_exception_handler.seed_request_identity"),
+        patch("litellm.proxy.proxy_server.general_settings", {"allow_requests_on_db_unavailable": False}),
+    ):
+        verbose_proxy_stdout_logger.propagate = True
+        try:
+            with pytest.raises(ProxyException) as exc_info:
+                await handler._handle_authentication_error(
+                    original_exception,
+                    MagicMock(),
+                    {},
+                    "/v1/chat/completions",
+                    None,
+                    "undefined",
+                )
+        finally:
+            verbose_proxy_stdout_logger.propagate = False
+
+    records = [r for r in caplog.records if "user_api_key_auth(): Exception occured" in r.getMessage()]
+    assert len(records) == 1
+    assert records[0].name == verbose_proxy_stdout_logger.name
+    assert records[0].levelno == logging.WARNING
+    assert exc_info.value.message == "Please authenticate again"
+    assert getattr(exc_info.value, "_litellm_invalid_virtual_key_error") is True
+    if isinstance(transformed_exception, ProxyException):
+        assert not hasattr(transformed_exception, "_litellm_invalid_virtual_key_error")
+
+
+@pytest.mark.asyncio
+async def test_handle_authentication_error_keeps_unexpected_source_traceback_after_callback_4xx(
+    caplog,
+):
+    handler = UserAPIKeyAuthExceptionHandler()
+
+    with (
+        patch(
+            "litellm.proxy.proxy_server.proxy_logging_obj.post_call_failure_hook",
+            new_callable=AsyncMock,
+            return_value=HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="Please authenticate again",
+            ),
+        ),
+        patch("litellm.proxy.auth.auth_exception_handler.seed_request_identity"),
+        patch("litellm.proxy.proxy_server.general_settings", {"allow_requests_on_db_unavailable": False}),
+    ):
+        verbose_proxy_logger.propagate = True
+        try:
+            with pytest.raises(ProxyException) as exc_info:
+                await handler._handle_authentication_error(
+                    ValueError("unexpected internal error"),
+                    MagicMock(),
+                    {},
+                    "/v1/chat/completions",
+                    None,
+                    "sk-bad-key",
+                )
+        finally:
+            verbose_proxy_logger.propagate = False
+
+    records = [r for r in caplog.records if "user_api_key_auth(): Exception occured" in r.getMessage()]
+    assert len(records) == 1
+    assert records[0].name == verbose_proxy_logger.name
+    assert records[0].levelno == logging.ERROR
+    assert records[0].exc_info is not None
+    assert "Please authenticate again" in records[0].getMessage()
+    assert exc_info.value.code == str(status.HTTP_401_UNAUTHORIZED)
+
+
+@pytest.mark.asyncio
+async def test_handle_authentication_error_does_not_preserve_invalid_virtual_key_marker_for_callback_503(
+    caplog,
+):
+    handler = UserAPIKeyAuthExceptionHandler()
+    original_exception = HTTPException(
+        status_code=status.HTTP_401_UNAUTHORIZED,
+        detail="LiteLLM Virtual Key expected. Received=unde****ined, expected to start with 'sk-'.",
+    )
+    transformed_exception = HTTPException(
+        status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+        detail="Authentication service temporarily unavailable",
+    )
+
+    with (
+        patch(
+            "litellm.proxy.proxy_server.proxy_logging_obj.post_call_failure_hook",
+            new_callable=AsyncMock,
+            return_value=transformed_exception,
+        ),
+        patch("litellm.proxy.auth.auth_exception_handler.seed_request_identity"),
+        patch("litellm.proxy.proxy_server.general_settings", {"allow_requests_on_db_unavailable": False}),
+    ):
+        verbose_proxy_logger.propagate = True
+        try:
+            with pytest.raises(ProxyException) as exc_info:
+                await handler._handle_authentication_error(
+                    original_exception,
+                    MagicMock(),
+                    {},
+                    "/v1/chat/completions",
+                    None,
+                    "undefined",
+                )
+        finally:
+            verbose_proxy_logger.propagate = False
+
+    records = [r for r in caplog.records if "user_api_key_auth(): Exception occured" in r.getMessage()]
+    assert len(records) == 1
+    assert records[0].name == verbose_proxy_logger.name
+    assert records[0].levelno == logging.ERROR
+    assert records[0].exc_info is not None
+    assert "Authentication service temporarily unavailable" in records[0].getMessage()
+    assert exc_info.value.code == str(status.HTTP_503_SERVICE_UNAVAILABLE)
+    assert not hasattr(exc_info.value, "_litellm_invalid_virtual_key_error")

--- a/tests/test_litellm/proxy/auth/test_auth_exception_handler.py
+++ b/tests/test_litellm/proxy/auth/test_auth_exception_handler.py
@@ -882,7 +882,7 @@ async def test_handle_authentication_error_keeps_unexpected_source_traceback_aft
 
 
 @pytest.mark.asyncio
-async def test_handle_authentication_error_does_not_preserve_invalid_virtual_key_marker_for_callback_503(caplog):
+async def test_handle_authentication_error_logs_callback_503_at_error_level_without_the_marker(caplog):
     handler = UserAPIKeyAuthExceptionHandler()
     transformed_exception = HTTPException(
         status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
@@ -895,11 +895,12 @@ async def test_handle_authentication_error_does_not_preserve_invalid_virtual_key
         )
 
     records = _auth_failure_records(caplog)
-    assert len(records) == 1
-    assert records[0].name == verbose_proxy_stdout_logger.name
-    assert records[0].levelno == logging.WARNING
-    assert records[0].exc_info is None
+    assert [(r.name, r.levelno, r.exc_info) for r in records] == [
+        (verbose_proxy_stdout_logger.name, logging.WARNING, None),
+        (verbose_proxy_logger.name, logging.ERROR, None),
+    ]
     assert "LiteLLM Virtual Key expected" in records[0].getMessage()
+    assert "Authentication service temporarily unavailable" in records[1].getMessage()
     assert exc_info.value.message == "Authentication service temporarily unavailable"
     assert exc_info.value.code == str(status.HTTP_503_SERVICE_UNAVAILABLE)
     assert not hasattr(exc_info.value, "_litellm_invalid_virtual_key_error")

--- a/tests/test_litellm/proxy/auth/test_auth_exception_handler.py
+++ b/tests/test_litellm/proxy/auth/test_auth_exception_handler.py
@@ -1,6 +1,7 @@
 import asyncio
 import json
 import logging
+from contextlib import contextmanager
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
@@ -117,22 +118,12 @@ async def test_handle_authentication_error_permanent_fault_gets_no_fallback_iden
     "prisma_error",
     [
         DataError(data={"user_facing_error": {"meta": {"table": "test_table"}}}),
-        UniqueViolationError(
-            data={"user_facing_error": {"meta": {"table": "test_table"}}}
-        ),
-        ForeignKeyViolationError(
-            data={"user_facing_error": {"meta": {"table": "test_table"}}}
-        ),
-        MissingRequiredValueError(
-            data={"user_facing_error": {"meta": {"table": "test_table"}}}
-        ),
+        UniqueViolationError(data={"user_facing_error": {"meta": {"table": "test_table"}}}),
+        ForeignKeyViolationError(data={"user_facing_error": {"meta": {"table": "test_table"}}}),
+        MissingRequiredValueError(data={"user_facing_error": {"meta": {"table": "test_table"}}}),
         RawQueryError(data={"user_facing_error": {"meta": {"table": "test_table"}}}),
-        TableNotFoundError(
-            data={"user_facing_error": {"meta": {"table": "test_table"}}}
-        ),
-        RecordNotFoundError(
-            data={"user_facing_error": {"meta": {"table": "test_table"}}}
-        ),
+        TableNotFoundError(data={"user_facing_error": {"meta": {"table": "test_table"}}}),
+        RecordNotFoundError(data={"user_facing_error": {"meta": {"table": "test_table"}}}),
     ],
 )
 async def test_handle_authentication_error_data_layer_errors_do_not_fall_back(
@@ -781,46 +772,29 @@ async def test_handle_authentication_error_traceback_only_for_unexpected_errors(
     handler = UserAPIKeyAuthExceptionHandler()
 
     with (
-        patch(  # test-quality-ok: handler reads proxy_server globals at call time
-            "litellm.proxy.proxy_server.proxy_logging_obj.post_call_failure_hook",
-            new_callable=AsyncMock,
-            return_value=None,
-        ),
-        patch(  # test-quality-ok: handler reads proxy_server globals at call time
-            "litellm.proxy.auth.auth_exception_handler.seed_request_identity",
-        ),
+        _auth_failure_boundaries(return_value=None),
         patch(  # test-quality-ok: handler reads this global flag at call time
             "litellm.proxy.auth.auth_exception_handler.litellm.log_client_error_tracebacks",
             log_client_error_tracebacks,
         ),
-        patch(  # test-quality-ok: handler reads proxy_server globals at call time
-            "litellm.proxy.proxy_server.general_settings",
-            {"allow_requests_on_db_unavailable": False},
-        ),
     ):
-        verbose_proxy_logger.propagate = True
-        verbose_proxy_stdout_logger.propagate = True
         try:
-            try:
-                raise auth_error
-            except (HTTPException, ProxyException, ValueError) as caught:
-                with caplog.at_level(logging.DEBUG), pytest.raises(ProxyException):
-                    await handler._handle_authentication_error(
-                        caught,
-                        MagicMock(),
-                        {},
-                        "/v1/chat/completions",
-                        None,
-                        "sk-bad-key",
-                    )
-        finally:
-            verbose_proxy_logger.propagate = False
-            verbose_proxy_stdout_logger.propagate = False
+            raise auth_error
+        except (HTTPException, ProxyException, ValueError) as caught:
+            with caplog.at_level(logging.DEBUG), pytest.raises(ProxyException):
+                await handler._handle_authentication_error(
+                    caught,
+                    MagicMock(),
+                    {},
+                    "/v1/chat/completions",
+                    None,
+                    "sk-bad-key",
+                )
 
-    records = [r for r in caplog.records if "user_api_key_auth(): Exception occured" in r.getMessage()]
+    records = _auth_failure_records(caplog)
     assert len(records) == 1
     assert records[0].levelno == expected_level
-    assert bool(records[0].exc_info) is expect_traceback
+    assert (records[0].exc_info is not None and records[0].exc_info[1] is auth_error) is expect_traceback
     assert records[0].name == (
         verbose_proxy_stdout_logger.name
         if expected_level == logging.WARNING and not log_client_error_tracebacks
@@ -828,145 +802,127 @@ async def test_handle_authentication_error_traceback_only_for_unexpected_errors(
     )
 
 
-@pytest.mark.asyncio
-@pytest.mark.parametrize(
-    "transformed_exception",
-    [
-        HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Please authenticate again"),
-        ProxyException(
-            message="Please authenticate again",
-            type=ProxyErrorTypes.auth_error,
-            param=None,
-            code=status.HTTP_401_UNAUTHORIZED,
+@contextmanager
+def _auth_failure_boundaries(**failure_hook_kwargs):
+    """Stub the proxy globals the handler reads and let its records reach caplog."""
+    with (
+        patch(  # test-quality-ok: handler reads proxy_server globals at call time
+            "litellm.proxy.proxy_server.proxy_logging_obj.post_call_failure_hook",
+            new_callable=AsyncMock,
+            **failure_hook_kwargs,
         ),
-    ],
-)
-async def test_handle_authentication_error_preserves_invalid_virtual_key_marker_after_callback_transform(
-    caplog,
-    transformed_exception,
-):
-    handler = UserAPIKeyAuthExceptionHandler()
-    original_exception = HTTPException(
+        patch(  # test-quality-ok: handler reads proxy_server globals at call time
+            "litellm.proxy.auth.auth_exception_handler.seed_request_identity"
+        ),
+        patch(  # test-quality-ok: handler reads proxy_server globals at call time
+            "litellm.proxy.proxy_server.general_settings", {"allow_requests_on_db_unavailable": False}
+        ),
+    ):
+        verbose_proxy_logger.propagate = True
+        yield
+
+
+def _auth_failure_records(caplog) -> list[logging.LogRecord]:
+    return [r for r in caplog.records if "user_api_key_auth(): Exception occured" in r.getMessage()]
+
+
+def _invalid_virtual_key_error() -> HTTPException:
+    return HTTPException(
         status_code=status.HTTP_401_UNAUTHORIZED,
         detail="LiteLLM Virtual Key expected. Received=unde****ined, expected to start with 'sk-'.",
     )
 
-    with (
-        patch(
-            "litellm.proxy.proxy_server.proxy_logging_obj.post_call_failure_hook",
-            new_callable=AsyncMock,
-            return_value=transformed_exception,
-        ),
-        patch("litellm.proxy.auth.auth_exception_handler.seed_request_identity"),
-        patch("litellm.proxy.proxy_server.general_settings", {"allow_requests_on_db_unavailable": False}),
-    ):
-        verbose_proxy_stdout_logger.propagate = True
-        try:
-            with pytest.raises(ProxyException) as exc_info:
-                await handler._handle_authentication_error(
-                    original_exception,
-                    MagicMock(),
-                    {},
-                    "/v1/chat/completions",
-                    None,
-                    "undefined",
-                )
-        finally:
-            verbose_proxy_stdout_logger.propagate = False
 
-    records = [r for r in caplog.records if "user_api_key_auth(): Exception occured" in r.getMessage()]
+@pytest.mark.asyncio
+async def test_handle_authentication_error_preserves_invalid_virtual_key_marker_after_callback_transform(caplog):
+    handler = UserAPIKeyAuthExceptionHandler()
+    transformed_exception = HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Please authenticate again")
+
+    with _auth_failure_boundaries(return_value=transformed_exception), pytest.raises(ProxyException) as exc_info:
+        await handler._handle_authentication_error(
+            _invalid_virtual_key_error(), MagicMock(), {}, "/v1/chat/completions", None, "undefined"
+        )
+
+    records = _auth_failure_records(caplog)
     assert len(records) == 1
     assert records[0].name == verbose_proxy_stdout_logger.name
     assert records[0].levelno == logging.WARNING
+    assert records[0].exc_info is None
+    assert "LiteLLM Virtual Key expected" in records[0].getMessage()
     assert exc_info.value.message == "Please authenticate again"
+    assert exc_info.value.code == str(status.HTTP_401_UNAUTHORIZED)
     assert getattr(exc_info.value, "_litellm_invalid_virtual_key_error") is True
-    if isinstance(transformed_exception, ProxyException):
-        assert not hasattr(transformed_exception, "_litellm_invalid_virtual_key_error")
 
 
 @pytest.mark.asyncio
-async def test_handle_authentication_error_keeps_unexpected_source_traceback_after_callback_4xx(
-    caplog,
-):
+async def test_handle_authentication_error_keeps_unexpected_source_traceback_after_callback_4xx(caplog):
     handler = UserAPIKeyAuthExceptionHandler()
+    transformed_exception = HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Please authenticate again")
 
-    with (
-        patch(
-            "litellm.proxy.proxy_server.proxy_logging_obj.post_call_failure_hook",
-            new_callable=AsyncMock,
-            return_value=HTTPException(
-                status_code=status.HTTP_401_UNAUTHORIZED,
-                detail="Please authenticate again",
-            ),
-        ),
-        patch("litellm.proxy.auth.auth_exception_handler.seed_request_identity"),
-        patch("litellm.proxy.proxy_server.general_settings", {"allow_requests_on_db_unavailable": False}),
-    ):
-        verbose_proxy_logger.propagate = True
-        try:
-            with pytest.raises(ProxyException) as exc_info:
-                await handler._handle_authentication_error(
-                    ValueError("unexpected internal error"),
-                    MagicMock(),
-                    {},
-                    "/v1/chat/completions",
-                    None,
-                    "sk-bad-key",
-                )
-        finally:
-            verbose_proxy_logger.propagate = False
+    try:
+        raise ValueError("unexpected internal error")
+    except ValueError as caught:
+        source_error = caught
+        with _auth_failure_boundaries(return_value=transformed_exception), pytest.raises(ProxyException) as exc_info:
+            await handler._handle_authentication_error(
+                source_error, MagicMock(), {}, "/v1/chat/completions", None, "sk-bad-key"
+            )
 
-    records = [r for r in caplog.records if "user_api_key_auth(): Exception occured" in r.getMessage()]
+    records = _auth_failure_records(caplog)
     assert len(records) == 1
     assert records[0].name == verbose_proxy_logger.name
     assert records[0].levelno == logging.ERROR
     assert records[0].exc_info is not None
-    assert "Please authenticate again" in records[0].getMessage()
+    assert records[0].exc_info[1] is source_error
+    assert "unexpected internal error" in records[0].getMessage()
+    assert "Please authenticate again" not in records[0].getMessage()
+    assert exc_info.value.message == "Please authenticate again"
     assert exc_info.value.code == str(status.HTTP_401_UNAUTHORIZED)
+    assert not hasattr(exc_info.value, "_litellm_invalid_virtual_key_error")
 
 
 @pytest.mark.asyncio
-async def test_handle_authentication_error_does_not_preserve_invalid_virtual_key_marker_for_callback_503(
-    caplog,
-):
+async def test_handle_authentication_error_does_not_preserve_invalid_virtual_key_marker_for_callback_503(caplog):
     handler = UserAPIKeyAuthExceptionHandler()
-    original_exception = HTTPException(
-        status_code=status.HTTP_401_UNAUTHORIZED,
-        detail="LiteLLM Virtual Key expected. Received=unde****ined, expected to start with 'sk-'.",
-    )
     transformed_exception = HTTPException(
         status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
         detail="Authentication service temporarily unavailable",
     )
 
-    with (
-        patch(
-            "litellm.proxy.proxy_server.proxy_logging_obj.post_call_failure_hook",
-            new_callable=AsyncMock,
-            return_value=transformed_exception,
-        ),
-        patch("litellm.proxy.auth.auth_exception_handler.seed_request_identity"),
-        patch("litellm.proxy.proxy_server.general_settings", {"allow_requests_on_db_unavailable": False}),
-    ):
-        verbose_proxy_logger.propagate = True
-        try:
-            with pytest.raises(ProxyException) as exc_info:
-                await handler._handle_authentication_error(
-                    original_exception,
-                    MagicMock(),
-                    {},
-                    "/v1/chat/completions",
-                    None,
-                    "undefined",
-                )
-        finally:
-            verbose_proxy_logger.propagate = False
+    with _auth_failure_boundaries(return_value=transformed_exception), pytest.raises(ProxyException) as exc_info:
+        await handler._handle_authentication_error(
+            _invalid_virtual_key_error(), MagicMock(), {}, "/v1/chat/completions", None, "undefined"
+        )
 
-    records = [r for r in caplog.records if "user_api_key_auth(): Exception occured" in r.getMessage()]
+    records = _auth_failure_records(caplog)
     assert len(records) == 1
-    assert records[0].name == verbose_proxy_logger.name
-    assert records[0].levelno == logging.ERROR
-    assert records[0].exc_info is not None
-    assert "Authentication service temporarily unavailable" in records[0].getMessage()
+    assert records[0].name == verbose_proxy_stdout_logger.name
+    assert records[0].levelno == logging.WARNING
+    assert records[0].exc_info is None
+    assert "LiteLLM Virtual Key expected" in records[0].getMessage()
+    assert exc_info.value.message == "Authentication service temporarily unavailable"
     assert exc_info.value.code == str(status.HTTP_503_SERVICE_UNAVAILABLE)
     assert not hasattr(exc_info.value, "_litellm_invalid_virtual_key_error")
+
+
+@pytest.mark.asyncio
+async def test_handle_authentication_error_logs_before_the_failure_hook_can_raise(caplog):
+    handler = UserAPIKeyAuthExceptionHandler()
+    hook_error = TypeError("function_setup() got multiple values for keyword argument 'start_time'")
+
+    with _auth_failure_boundaries(side_effect=hook_error), pytest.raises(TypeError) as exc_info:
+        await handler._handle_authentication_error(
+            _invalid_virtual_key_error(),
+            MagicMock(),
+            {"start_time": "client-controlled"},
+            "/v1/chat/completions",
+            None,
+            "undefined",
+        )
+
+    assert exc_info.value is hook_error
+    records = _auth_failure_records(caplog)
+    assert len(records) == 1
+    assert records[0].name == verbose_proxy_stdout_logger.name
+    assert records[0].levelno == logging.WARNING
+    assert "LiteLLM Virtual Key expected" in records[0].getMessage()

--- a/tests/test_litellm/proxy/auth/test_user_api_key_auth.py
+++ b/tests/test_litellm/proxy/auth/test_user_api_key_auth.py
@@ -6872,3 +6872,46 @@ class TestLitellmReceivedAtStamping:
 
         assert result == earlier
         assert request.state.litellm_received_at == earlier
+
+
+@pytest.mark.asyncio
+async def test_user_api_key_auth_websocket_skips_duplicate_invalid_key_log():
+    from fastapi import WebSocket
+    from starlette.datastructures import URL
+
+    from litellm.proxy._types import ProxyException
+    from litellm.proxy.auth.auth_utils import mark_invalid_virtual_key_error
+    from litellm.proxy.auth.user_api_key_auth import WebSocketException, user_api_key_auth_websocket
+
+    mock_websocket = MagicMock(spec=WebSocket)
+    mock_websocket.query_params = {"model": "some_model"}
+    mock_websocket.headers = {"authorization": "Bearer undefined"}
+    mock_websocket.scope = {"headers": [(b"authorization", b"Bearer undefined")]}
+    mock_websocket.url = URL(url="/v1/responses")
+    transformed_invalid_virtual_key = mark_invalid_virtual_key_error(
+        ProxyException(
+            message="Please authenticate again",
+            type="auth_error",
+            param="None",
+            code=status.HTTP_401_UNAUTHORIZED,
+        ),
+        True,
+    )
+
+    with (
+        patch(  # test-quality-ok: auth error test injects this runtime boundary
+            "litellm.proxy.auth.user_api_key_auth.user_api_key_auth",
+            side_effect=transformed_invalid_virtual_key,
+            autospec=True,
+        ),
+        patch(  # test-quality-ok: auth error test injects this runtime boundary
+            "litellm.proxy.auth.user_api_key_auth.verbose_proxy_logger.exception"
+        ) as exception_log,
+        pytest.raises(WebSocketException) as exc_info,
+    ):
+        await user_api_key_auth_websocket(mock_websocket)
+
+    assert exc_info.value.code == status.WS_1008_POLICY_VIOLATION
+    assert exc_info.value.reason == ""
+    exception_log.assert_not_called()
+    mock_websocket.close.assert_not_called()

--- a/tests/test_litellm/test_logging.py
+++ b/tests/test_litellm/test_logging.py
@@ -1,14 +1,14 @@
 import ast
 import asyncio
 import json
+import logging
 import re
 import sys
+from io import StringIO
 from pathlib import Path
 from typing import List
 
 import pytest
-
-import logging
 
 import litellm
 from litellm._logging import (
@@ -32,6 +32,7 @@ from litellm._logging import (
     trace_id_var,
     verbose_logger,
     verbose_proxy_logger,
+    verbose_proxy_stdout_logger,
     verbose_router_logger,
 )
 from litellm.constants import LITELLM_TRUNCATED_PAYLOAD_FIELD
@@ -76,6 +77,21 @@ def test_json_mode_emits_one_record_per_logger(capfd):
         assert "message" in obj, "`message` key missing"
         assert "level" in obj, "`level` key missing"
         assert "timestamp" in obj, "`timestamp` key missing"
+
+
+def test_json_mode_routes_invalid_key_record_once_to_stdout(capfd):
+    _turn_on_json()
+
+    verbose_proxy_stdout_logger.warning("invalid virtual key")
+
+    out, err = capfd.readouterr()
+    assert [raw for raw in err.splitlines() if raw.strip()] == []
+    lines = [raw for raw in out.splitlines() if raw.strip()]
+    assert len(lines) == 1, f"got {len(lines)} lines, want 1: {lines!r}"
+
+    record = json.loads(lines[0])
+    assert record["message"] == "invalid virtual key"
+    assert record["component"] == verbose_proxy_stdout_logger.name
 
 
 def test_json_formatter_parses_embedded_json_message():
@@ -845,32 +861,121 @@ class _FakeStream:
         return self._tty
 
 
-def test_records_below_warning_go_to_stdout_and_the_rest_to_stderr(capsys):
-    logger = logging.getLogger("test_level_routing")
+def test_invalid_key_warning_routes_as_json_to_stdout(capsys):
+    logger = logging.getLogger("LiteLLM Proxy.stdout")
+    original_handlers = logger.handlers[:]
+    original_propagate = logger.propagate
+    original_level = logger.level
     logger.handlers.clear()
     logger.propagate = False
     logger.setLevel(logging.DEBUG)
     handler = LevelRoutingStreamHandler()
+    handler.setFormatter(JsonFormatter())
+    logger.addHandler(handler)
+
+    try:
+        logger.warning("invalid virtual key")
+    finally:
+        logger.handlers = original_handlers
+        logger.propagate = original_propagate
+        logger.setLevel(original_level)
+
+    out, err = capsys.readouterr()
+    assert err == ""
+    log_record = json.loads(out)
+    assert log_record["message"] == "invalid virtual key"
+    assert log_record["level"] == "WARNING"
+
+
+def test_records_below_warning_and_invalid_key_warnings_go_to_stdout(capsys):
+    logger = logging.getLogger("test_level_routing")
+    invalid_key_logger = logging.getLogger("LiteLLM Proxy.stdout")
+    original_handlers = logger.handlers[:]
+    original_propagate = logger.propagate
+    original_level = logger.level
+    original_invalid_key_handlers = invalid_key_logger.handlers[:]
+    original_invalid_key_propagate = invalid_key_logger.propagate
+    original_invalid_key_level = invalid_key_logger.level
+    logger.handlers.clear()
+    logger.propagate = False
+    logger.setLevel(logging.DEBUG)
+    invalid_key_logger.handlers.clear()
+    invalid_key_logger.propagate = False
+    invalid_key_logger.setLevel(logging.DEBUG)
+    handler = LevelRoutingStreamHandler()
     handler.setFormatter(logging.Formatter("%(levelname)s %(message)s"))
     logger.addHandler(handler)
+    invalid_key_logger.addHandler(handler)
 
     try:
         logger.debug("d")
         logger.info("i")
         logger.warning("w")
+        invalid_key_logger.warning("invalid-key-warning")
         logger.error("e")
         logger.critical("c")
     finally:
-        logger.handlers.clear()
+        logger.handlers = original_handlers
+        logger.propagate = original_propagate
+        logger.setLevel(original_level)
+        invalid_key_logger.handlers = original_invalid_key_handlers
+        invalid_key_logger.propagate = original_invalid_key_propagate
+        invalid_key_logger.setLevel(original_invalid_key_level)
 
     out, err = capsys.readouterr()
-    assert out.splitlines() == ["DEBUG d", "INFO i"]
+    assert out.splitlines() == ["DEBUG d", "INFO i", "WARNING invalid-key-warning"]
     assert err.splitlines() == ["WARNING w", "ERROR e", "CRITICAL c"]
 
 
 def test_verbose_loggers_route_records_by_level():
-    for lg in (verbose_logger, verbose_router_logger, verbose_proxy_logger):
+    for lg in (verbose_logger, verbose_router_logger, verbose_proxy_logger, verbose_proxy_stdout_logger):
         assert any(isinstance(h, LevelRoutingStreamHandler) for h in lg.handlers), lg.name
+    assert verbose_proxy_stdout_logger.level == logging.WARNING
+    assert verbose_proxy_stdout_logger.handlers[0].level == logging.WARNING
+
+
+def test_invalid_virtual_key_record_does_not_propagate_to_root_handler():
+    root_logger = logging.getLogger()
+    root_stream = StringIO()
+    root_handler = logging.StreamHandler(root_stream)
+    root_handler.setFormatter(logging.Formatter("ROOT %(levelname)s %(message)s"))
+    root_logger.addHandler(root_handler)
+
+    try:
+        verbose_proxy_stdout_logger.warning("invalid virtual key")
+    finally:
+        root_logger.removeHandler(root_handler)
+
+    assert root_stream.getvalue() == ""
+
+
+def test_turn_on_json_preserves_invalid_key_warning_visibility(monkeypatch, capfd):
+    monkeypatch.setenv("LITELLM_LOG", "ERROR")
+    _turn_on_json()
+
+    verbose_proxy_stdout_logger.warning("invalid virtual key")
+
+    out, err = capfd.readouterr()
+    assert [raw for raw in err.splitlines() if raw.strip()] == []
+    records = [json.loads(raw) for raw in out.splitlines() if raw.strip()]
+    assert len(records) == 1
+    assert records[0]["component"] == verbose_proxy_stdout_logger.name
+    assert records[0]["level"] == "WARNING"
+
+
+def test_ordinary_proxy_records_still_propagate_to_root_handler():
+    root_logger = logging.getLogger()
+    root_stream = StringIO()
+    root_handler = logging.StreamHandler(root_stream)
+    root_handler.setFormatter(logging.Formatter("ROOT %(levelname)s %(message)s"))
+    root_logger.addHandler(root_handler)
+
+    try:
+        verbose_proxy_logger.error("ordinary proxy error")
+    finally:
+        root_logger.removeHandler(root_handler)
+
+    assert "ROOT ERROR ordinary proxy error" in root_stream.getvalue()
 
 
 @pytest.mark.parametrize(

--- a/tests/test_litellm/test_logging.py
+++ b/tests/test_litellm/test_logging.py
@@ -11,6 +11,7 @@ from typing import List
 import pytest
 
 import litellm
+import litellm._logging as litellm_logging
 from litellm._logging import (
     _COLOR_LOG_FORMAT,
     _PLAIN_LOG_FORMAT,
@@ -978,6 +979,21 @@ def test_error_threshold_suppresses_invalid_key_warning_like_ordinary_warnings(c
     finally:
         for h, level in zip(proxy_handlers, original_levels, strict=True):
             h.setLevel(level)
+
+    out, err = capsys.readouterr()
+    assert out == ""
+    assert "invalid virtual key" not in err
+    assert "ordinary proxy warning" not in err
+    assert "ordinary proxy error" in err
+
+
+def test_config_json_mode_handler_honors_the_litellm_log_threshold(monkeypatch, capsys):
+    monkeypatch.setattr(litellm_logging, "numeric_level", logging.ERROR)
+    _turn_on_json()
+
+    verbose_proxy_stdout_logger.warning("invalid virtual key")
+    verbose_proxy_logger.warning("ordinary proxy warning")
+    verbose_proxy_logger.error("ordinary proxy error")
 
     out, err = capsys.readouterr()
     assert out == ""

--- a/tests/test_litellm/test_logging.py
+++ b/tests/test_litellm/test_logging.py
@@ -928,13 +928,24 @@ def test_records_below_warning_and_invalid_key_warnings_go_to_stdout(capsys):
 
 
 def test_verbose_loggers_route_records_by_level():
-    for lg in (verbose_logger, verbose_router_logger, verbose_proxy_logger, verbose_proxy_stdout_logger):
+    for lg in (verbose_logger, verbose_router_logger, verbose_proxy_logger):
         assert any(isinstance(h, LevelRoutingStreamHandler) for h in lg.handlers), lg.name
-    assert verbose_proxy_stdout_logger.level == logging.WARNING
-    assert verbose_proxy_stdout_logger.handlers[0].level == logging.WARNING
 
 
-def test_invalid_virtual_key_record_does_not_propagate_to_root_handler():
+def test_invalid_key_logger_inherits_proxy_logger_configuration():
+    assert verbose_proxy_stdout_logger.parent is verbose_proxy_logger
+    assert verbose_proxy_stdout_logger.handlers == []
+    assert verbose_proxy_stdout_logger.level == logging.NOTSET
+    assert verbose_proxy_stdout_logger.propagate is True
+    assert verbose_proxy_stdout_logger.getEffectiveLevel() == verbose_proxy_logger.getEffectiveLevel()
+    assert verbose_proxy_stdout_logger not in ALL_LOGGERS
+
+
+def test_invalid_virtual_key_record_propagates_to_root_handler_like_ordinary_records(capsys):
+    proxy_handlers = list(verbose_proxy_logger.handlers)
+    original_levels = [h.level for h in proxy_handlers]
+    for h in proxy_handlers:
+        h.setLevel(logging.WARNING)
     root_logger = logging.getLogger()
     root_stream = StringIO()
     root_handler = logging.StreamHandler(root_stream)
@@ -945,22 +956,34 @@ def test_invalid_virtual_key_record_does_not_propagate_to_root_handler():
         verbose_proxy_stdout_logger.warning("invalid virtual key")
     finally:
         root_logger.removeHandler(root_handler)
+        for h, level in zip(proxy_handlers, original_levels, strict=True):
+            h.setLevel(level)
 
-    assert root_stream.getvalue() == ""
+    out, err = capsys.readouterr()
+    assert out.count("invalid virtual key") == 1
+    assert err == ""
+    assert "ROOT WARNING invalid virtual key" in root_stream.getvalue()
 
 
-def test_turn_on_json_preserves_invalid_key_warning_visibility(monkeypatch, capfd):
-    monkeypatch.setenv("LITELLM_LOG", "ERROR")
-    _turn_on_json()
+def test_error_threshold_suppresses_invalid_key_warning_like_ordinary_warnings(capsys):
+    proxy_handlers = list(verbose_proxy_logger.handlers)
+    original_levels = [h.level for h in proxy_handlers]
+    for h in proxy_handlers:
+        h.setLevel(logging.ERROR)
 
-    verbose_proxy_stdout_logger.warning("invalid virtual key")
+    try:
+        verbose_proxy_stdout_logger.warning("invalid virtual key")
+        verbose_proxy_logger.warning("ordinary proxy warning")
+        verbose_proxy_logger.error("ordinary proxy error")
+    finally:
+        for h, level in zip(proxy_handlers, original_levels, strict=True):
+            h.setLevel(level)
 
-    out, err = capfd.readouterr()
-    assert [raw for raw in err.splitlines() if raw.strip()] == []
-    records = [json.loads(raw) for raw in out.splitlines() if raw.strip()]
-    assert len(records) == 1
-    assert records[0]["component"] == verbose_proxy_stdout_logger.name
-    assert records[0]["level"] == "WARNING"
+    out, err = capsys.readouterr()
+    assert out == ""
+    assert "invalid virtual key" not in err
+    assert "ordinary proxy warning" not in err
+    assert "ordinary proxy error" in err
 
 
 def test_ordinary_proxy_records_still_propagate_to_root_handler():


### PR DESCRIPTION
## TLDR

Problem this solves:

- Every request carrying a malformed virtual key (for example `Authorization: Bearer undefined`) logs an ERROR with the proxy's own error format on stderr
- Deployments with a browser or SDK misconfiguration flood error dashboards and alerts with these expected client rejections
- `LITELLM_LOG=ERROR` cannot quiet them, and websocket rejections log the same rejection twice plus a traceback

How it solves it:

- Malformed virtual key rejections now log once at WARNING on stdout, through the `LiteLLM Proxy.stdout` logger
- That logger inherits the proxy logger's thresholds, handlers and JSON mode, so `LITELLM_LOG=ERROR` silences the line like any other warning
- `log_client_error_tracebacks: true` keeps today's ERROR plus traceback for operators who want it
- Websocket rejections close the handshake with policy violation 1008 and log once, without the traceback
- Unknown but well formed keys, budget errors, DB outages and every other auth failure keep logging exactly as before

## User Flow

Before: an operator whose clients send a malformed key sees every rejection as a proxy ERROR on stderr and cannot turn it down

1. A client sends GET https://litellm-domain/v1/models with `Authorization: Bearer undefined`
2. It gets back HTTP 401 `{"error":{"message":"LiteLLM Virtual Key expected. Received=unde****ined, expected to start with 'sk-'.","type":"auth_error","param":"None","code":"401"}}`
3. The proxy writes `LiteLLM Proxy:ERROR: ... user_api_key_auth(): Exception occured - 401: LiteLLM Virtual Key expected ...` to stderr, once per request
4. The operator restarts the proxy with `LITELLM_LOG=ERROR` and the same request still produces the same ERROR line
5. A websocket client opening GET https://litellm-domain/v1/realtime with the same key gets HTTP 403 and the proxy writes two ERROR lines and a traceback for it

After: the same rejections show up as warnings on stdout that the operator can filter, and `LITELLM_LOG=ERROR` removes them

1. A client sends GET https://litellm-domain/v1/models with `Authorization: Bearer undefined`
2. It gets back the same HTTP 401 body and headers as before
3. The proxy writes `LiteLLM Proxy.stdout:WARNING: ... user_api_key_auth(): Exception occured - 401: LiteLLM Virtual Key expected ...` to stdout, once per request, and stderr stays clean
4. The operator restarts the proxy with `LITELLM_LOG=ERROR` and the same request produces no log line at all
5. A websocket client opening GET https://litellm-domain/v1/realtime with the same key gets HTTP 403 and the proxy writes one WARNING line to stdout, no traceback

## Relevant issues

## Linear ticket

Resolves LIT-5362

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Real proxy with real Postgres on each side, one worker, same `config.yaml`, same requests in the same order. The proxy's stdout and stderr are captured to separate files. Every case sends the control request first (`GET /v1/models` with the master key, 200 on both sides), then the malformed key request.

```yaml
model_list:
  - model_name: fake-model
    litellm_params:
      model: openai/fake-model
      api_key: fake
      api_base: http://127.0.0.1:1/never
general_settings:
  master_key: sk-lit5362-master
```

Recording of cases 1, 2 and 6 side by side (Before proxies on :15590 and :15592, After proxies on :15591 and :15593):

![LIT-5362 before/after recording](https://raw.githubusercontent.com/BerriAI/litellm/assets-pr38712/lit5362-demo.gif)

### Before (4d9025c2bf)

#### Case 1: default log level

1. `curl -s -w '\nHTTP %{http_code}\n' http://127.0.0.1:15590/v1/models -H 'Authorization: Bearer undefined'`
2. Output: `{"error":{"message":"LiteLLM Virtual Key expected. Received=unde****ined, expected to start with 'sk-'.","type":"auth_error","param":"None","code":"401"}}` then `HTTP 401`
3. `grep -c user_api_key_auth proxy.stdout` prints `0`
4. `grep user_api_key_auth proxy.stderr` prints `13:25:26 - LiteLLM Proxy:ERROR: auth_exception_handler.py:118 - litellm.proxy.proxy_server.user_api_key_auth(): Exception occured - 401: LiteLLM Virtual Key expected. Received=unde****ined, expected to start with 'sk-'.`

#### Case 2: LITELLM_LOG=ERROR

1. Start the proxy with `LITELLM_LOG=ERROR`, send the same `GET /v1/models` with `Authorization: Bearer undefined`, get `HTTP 401`
2. `grep user_api_key_auth proxy.stderr` still prints `13:15:43 - LiteLLM Proxy:ERROR: auth_exception_handler.py:118 - litellm.proxy.proxy_server.user_api_key_auth(): Exception occured - 401: LiteLLM Virtual Key expected ...`

#### Case 3: JSON_LOGS=true

1. Start the proxy with `JSON_LOGS=true`, send the same request, get `HTTP 401`
2. `proxy.stderr` contains `{"message": "litellm.proxy.proxy_server.user_api_key_auth(): Exception occured - 401: LiteLLM Virtual Key expected. Received=unde****ined, expected to start with 'sk-'.\nRequester IP Address:127.0.0.1", "level": "ERROR", ..., "component": "LiteLLM Proxy"}` and `proxy.stdout` contains no auth record
3. With `JSON_LOGS=true LITELLM_LOG=ERROR` the ERROR record is still written

#### Case 4: log_client_error_tracebacks: true

1. Add `litellm_settings: {log_client_error_tracebacks: true}` to the config, start the proxy, send the same request, get `HTTP 401`
2. `proxy.stderr` prints the ERROR line followed by `Traceback (most recent call last): File ".../litellm/proxy/auth/user_api_key_auth.py", line 1870, in _user_api_key_auth_builder raise HTTPException(`

#### Case 5: websocket upgrade with a malformed key

1. `curl -s -o /dev/null -w 'ws upgrade http=%{http_code}\n' --http1.1 -H 'Connection: Upgrade' -H 'Upgrade: websocket' -H 'Sec-WebSocket-Version: 13' -H 'Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==' 'http://127.0.0.1:15590/v1/realtime?model=fake-model' -H 'Authorization: Bearer undefined'`
2. Output: `ws upgrade http=403`
3. `proxy.stderr` prints `LiteLLM Proxy:ERROR: auth_exception_handler.py:118 - ... 401: LiteLLM Virtual Key expected ...` and `LiteLLM Proxy:ERROR: user_api_key_auth.py:542 - LiteLLM Virtual Key expected. Received=unde****ined, expected to start with 'sk-'.` plus 6 traceback blocks for one handshake, `proxy.stdout` has none

#### Case 6: a well formed unknown key

1. `curl -s -o /dev/null -w 'HTTP %{http_code}\n' http://127.0.0.1:15590/v1/models -H 'Authorization: Bearer sk-unknown-1234'` prints `HTTP 401`
2. `proxy.stderr` prints `LiteLLM Proxy:ERROR: auth_exception_handler.py:118 - litellm.proxy.proxy_server.user_api_key_auth(): Exception occured - Authentication Error, Invalid proxy server token passed. Received API Key = sk-...1234, Key Hash (Token) =...`

#### Case 7: a failure callback rewrites the error

1. Register a `CustomLogger` whose `async_post_call_failure_hook` returns `HTTPException(status_code=401, detail="Please authenticate again")` via `litellm_settings.callbacks`, start the proxy, send the same malformed key request
2. Output: `HTTP 401` with body `{"error":{"message":"Please authenticate again","type":"auth_error","param":"None","code":"401"}}`
3. `proxy.stderr` prints `LiteLLM Proxy:ERROR: ... Exception occured - 401: LiteLLM Virtual Key expected ...`

#### Case 8: the failure callback pipeline raises

1. Same malformed key request, body `{"model":"fake-model","messages":[{"role":"user","content":"hi"}],"start_time":"client-controlled"}`
2. Output: `HTTP 500` `{"error":{"message":"Internal server error","type":"internal_server_error"}}`
3. `proxy.stderr` prints `LiteLLM Proxy:ERROR: auth_exception_handler.py:118 - ... Exception occured - 401: LiteLLM Virtual Key expected ...` before the traceback

### After (4c8e9d78dc)

#### Case 1: default log level

1. `curl -s -w '\nHTTP %{http_code}\n' http://127.0.0.1:15591/v1/models -H 'Authorization: Bearer undefined'`
2. Output: `{"error":{"message":"LiteLLM Virtual Key expected. Received=unde****ined, expected to start with 'sk-'.","type":"auth_error","param":"None","code":"401"}}` then `HTTP 401` (body and response headers diffed identical to Before)
3. `grep user_api_key_auth proxy.stdout` prints `13:25:29 - LiteLLM Proxy.stdout:WARNING: auth_exception_handler.py:156 - litellm.proxy.proxy_server.user_api_key_auth(): Exception occured - 401: LiteLLM Virtual Key expected. Received=unde****ined, expected to start with 'sk-'.`
4. `grep -c user_api_key_auth proxy.stderr` prints `0`

#### Case 2: LITELLM_LOG=ERROR

1. Start the proxy with `LITELLM_LOG=ERROR`, send the same `GET /v1/models` with `Authorization: Bearer undefined`, get `HTTP 401`
2. `cat proxy.stdout proxy.stderr | grep -c user_api_key_auth` prints `0`

#### Case 3: JSON_LOGS=true

1. Start the proxy with `JSON_LOGS=true`, send the same request, get `HTTP 401`
2. `proxy.stdout` contains `{"message": "litellm.proxy.proxy_server.user_api_key_auth(): Exception occured - 401: LiteLLM Virtual Key expected. Received=unde****ined, expected to start with 'sk-'.\nRequester IP Address:127.0.0.1", "level": "WARNING", ..., "component": "LiteLLM Proxy.stdout"}` and `proxy.stderr` contains no auth record
3. With `JSON_LOGS=true LITELLM_LOG=ERROR` no auth record is written to either stream

#### Case 3b: config json_logs: true with LITELLM_LOG=ERROR

1. Set `litellm_settings: {json_logs: true}` in the config file (not env var), start the proxy with `LITELLM_LOG=ERROR`, send the same request, get `HTTP 401`
2. `proxy.stdout` contains nothing and `proxy.stderr` contains nothing (the config-file path now honors the threshold like the env-var path)

#### Case 4: log_client_error_tracebacks: true

1. Add `litellm_settings: {log_client_error_tracebacks: true}` to the config, start the proxy, send the same request, get `HTTP 401`
2. `proxy.stderr` prints the same ERROR line followed by `Traceback (most recent call last): File ".../litellm/proxy/auth/user_api_key_auth.py", line 1875, in _user_api_key_auth_builder raise HTTPException(` (unchanged behavior)

#### Case 5: websocket upgrade with a malformed key

1. Same curl against `http://127.0.0.1:15591/v1/realtime?model=fake-model`
2. Output: `ws upgrade http=403`
3. `proxy.stdout` prints one line `LiteLLM Proxy.stdout:WARNING: auth_exception_handler.py:156 - ... 401: LiteLLM Virtual Key expected ...`, `proxy.stderr` has no auth line and no traceback

#### Case 6: a well formed unknown key

1. `curl -s -o /dev/null -w 'HTTP %{http_code}\n' http://127.0.0.1:15591/v1/models -H 'Authorization: Bearer sk-unknown-1234'` prints `HTTP 401`
2. `proxy.stderr` prints `LiteLLM Proxy:ERROR: auth_exception_handler.py:156 - litellm.proxy.proxy_server.user_api_key_auth(): Exception occured - Authentication Error, Invalid proxy server token passed. Received API Key = sk-...1234, Key Hash (Token) =...` (unchanged)

#### Case 7: a failure callback rewrites the error

1. Same `CustomLogger` returning `HTTPException(status_code=401, detail="Please authenticate again")`, same request
2. Output: `HTTP 401` with body `{"error":{"message":"Please authenticate again","type":"auth_error","param":"None","code":"401"}}` (identical to Before)
3. `proxy.stdout` prints `LiteLLM Proxy.stdout:WARNING: auth_exception_handler.py:156 - ... Exception occured - 401: LiteLLM Virtual Key expected ...` (the log keeps the original cause, the client gets the rewritten error); a callback that rewrites to 503 gives the client `HTTP 503` and logs the same WARNING line, since the log describes the malformed key that was received

#### Case 8: the failure callback pipeline raises

1. Same malformed key request, body `{"model":"fake-model","messages":[{"role":"user","content":"hi"}],"start_time":"client-controlled"}`
2. Output: `HTTP 500` `{"error":{"message":"Internal server error","type":"internal_server_error"}}` (unchanged, the `start_time` key collides inside the failure pipeline on both sides)
3. `proxy.stdout` prints `LiteLLM Proxy.stdout:WARNING: auth_exception_handler.py:156 - ... Exception occured - 401: LiteLLM Virtual Key expected ...` before the traceback, so the rejection is still recorded

## Type

🐛 Bug Fix

## Caveats (if any)

### Medium

- Malformed key rejections now reach root logger handlers as WARNING, so an ERROR only sink stops receiving them
- Set `litellm_settings.log_client_error_tracebacks: true` to restore the ERROR line with its traceback

### Low

- The `LiteLLM Proxy.stdout` logger has no configuration of its own, `LITELLM_LOG`, `JSON_LOGS` and `--detailed_debug` apply to it through `LiteLLM Proxy`
- JSON log consumers filtering on `component == "LiteLLM Proxy"` see these lines under `LiteLLM Proxy.stdout`
- A failure callback that rewrites the 401 to another status still gets the WARNING line, the line describes the malformed key that was received
- The JWT auth disabled hint appended to this rejection moves to the same WARNING line
- Unknown but well formed keys still log at ERROR, short circuiting them earlier is a separate change

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes proxy auth failure logging and stdout/stderr routing, which can shift alerting and dashboards; HTTP/WebSocket client responses are unchanged but operators relying on stderr ERROR-only sinks may miss malformed-key rejections unless they adjust filters or enable tracebacks.
> 
> **Overview**
> Malformed virtual key rejections (401 with **LiteLLM Virtual Key expected**) no longer flood stderr as **ERROR** with tracebacks. They log **once at WARNING** through the child logger **`LiteLLM Proxy.stdout`**, which **`LevelRoutingStreamHandler`** sends to **stdout** so log collectors do not treat them as errors.
> 
> **`is_invalid_virtual_key_error`** / **`mark_invalid_virtual_key_error`** classify these failures (including after failure-callback rewrites). **`log_client_error_tracebacks: true`** keeps the previous ERROR + traceback on the main proxy logger. **`LITELLM_LOG=ERROR`** and config JSON mode now suppress these warnings like any other warning; **`_turn_on_json`** applies the log threshold to the handler.
> 
> Websocket auth for invalid keys raises **`WebSocketException`** (policy violation) without a duplicate **`verbose_proxy_logger.exception`** line. Other auth failures (unknown keys, budget, DB outages) keep their existing log levels and streams.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4c8e9d78dc2b60c985a7ff9ed83470a76d278a63. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->