### PR TITLE
fix(guardrails): record post_call scans on native /v1/messages streams

### DIFF
--- a/litellm/llms/anthropic/experimental_pass_through/messages/streaming_iterator.py
+++ b/litellm/llms/anthropic/experimental_pass_through/messages/streaming_iterator.py
@@ -342,7 +342,7 @@ class BaseAnthropicMessagesStreamingIterator:
         self.start_time = datetime.now()
         self.completion_start_time: datetime | None = None
 
-    async def _handle_streaming_logging(self, collected_chunks: list[bytes]):
+    async def _handle_streaming_logging(self, collected_chunks: list[bytes], *, stream_teardown: bool = False):
         """Handle the logging after all chunks have been collected."""
         from litellm.proxy.pass_through_endpoints.streaming_handler import (
             PassThroughStreamingHandler,
@@ -354,21 +354,32 @@ class BaseAnthropicMessagesStreamingIterator:
         if self.completion_start_time is not None:
             self.litellm_logging_obj.completion_start_time = self.completion_start_time
             self.litellm_logging_obj.model_call_details["completion_start_time"] = self.completion_start_time
+        logging_coroutine: Final = PassThroughStreamingHandler._route_streaming_logging_to_handler(
+            litellm_logging_obj=self.litellm_logging_obj,
+            passthrough_success_handler_obj=GLOBAL_PASS_THROUGH_SUCCESS_HANDLER_OBJ,
+            url_route="/v1/messages",
+            request_body=self.request_body or {},
+            endpoint_type=EndpointType.ANTHROPIC,
+            start_time=self.start_time,
+            raw_bytes=collected_chunks,
+            end_time=end_time,
+        )
+        deferred_dispatch_armed: Final = (
+            getattr(self.litellm_logging_obj, "_on_deferred_stream_complete", None) is not None
+        )
+        # Post-call guardrails run their end-of-stream scan AFTER this iterator
+        # is exhausted, so enqueueing now would build the spend log before the
+        # scan writes guardrail_information. Park the coroutine instead; the
+        # proxy fires it via _fire_deferred_stream_logging once the guardrail
+        # chain drains. Teardown (client disconnect) keeps enqueueing
+        # immediately: the scan never runs there and billing must not be lost.
+        if deferred_dispatch_armed and not stream_teardown:
+            self.litellm_logging_obj._deferred_stream_complete_args = (logging_coroutine,)
+            return
         # Enqueue on the rooted logging worker rather than asyncio.create_task:
         # this also runs during generator teardown after a client disconnect,
         # where an unrooted task could be garbage-collected before it bills.
-        GLOBAL_LOGGING_WORKER.ensure_initialized_and_enqueue(
-            async_coroutine=PassThroughStreamingHandler._route_streaming_logging_to_handler(
-                litellm_logging_obj=self.litellm_logging_obj,
-                passthrough_success_handler_obj=GLOBAL_PASS_THROUGH_SUCCESS_HANDLER_OBJ,
-                url_route="/v1/messages",
-                request_body=self.request_body or {},
-                endpoint_type=EndpointType.ANTHROPIC,
-                start_time=self.start_time,
-                raw_bytes=collected_chunks,
-                end_time=end_time,
-            )
-        )
+        GLOBAL_LOGGING_WORKER.ensure_initialized_and_enqueue(async_coroutine=logging_coroutine)
 
     def get_async_streaming_response_iterator(
         self,
@@ -433,7 +444,7 @@ class BaseAnthropicMessagesStreamingIterator:
             # post-loop logging below never runs and the tokens already streamed
             # (and billed by the provider) would never reach spend tracking. See LIT-5839.
             if collected_chunks:
-                await self._handle_streaming_logging(collected_chunks)
+                await self._handle_streaming_logging(collected_chunks, stream_teardown=True)
             raise
 
         if not saw_terminal_event:

--- a/litellm/llms/anthropic/experimental_pass_through/messages/streaming_iterator.py
+++ b/litellm/llms/anthropic/experimental_pass_through/messages/streaming_iterator.py
@@ -367,12 +367,6 @@ class BaseAnthropicMessagesStreamingIterator:
         deferred_dispatch_armed: Final = (
             getattr(self.litellm_logging_obj, "_on_deferred_stream_complete", None) is not None
         )
-        # Post-call guardrails run their end-of-stream scan AFTER this iterator
-        # is exhausted, so enqueueing now would build the spend log before the
-        # scan writes guardrail_information. Park the coroutine instead; the
-        # proxy fires it via _fire_deferred_stream_logging once the guardrail
-        # chain drains. Teardown (client disconnect) keeps enqueueing
-        # immediately: the scan never runs there and billing must not be lost.
         if deferred_dispatch_armed and not stream_teardown:
             self.litellm_logging_obj._deferred_stream_complete_args = (logging_coroutine,)
             return

--- a/litellm/proxy/common_request_processing.py
+++ b/litellm/proxy/common_request_processing.py
@@ -2377,11 +2377,6 @@ class ProxyBaseLLMRequestProcessing:
                     and route_type == "anthropic_messages"
                     and self._is_streaming_response(response)
                 ):
-                    # Native /v1/messages SSE streams bypass CSW, so the raw
-                    # iterator parks its logging coroutine at stream end (see
-                    # BaseAnthropicMessagesStreamingIterator._handle_streaming_logging)
-                    # and _fire_deferred_stream_logging hands it here after the
-                    # guardrail end-of-stream scans complete.
                     from litellm.litellm_core_utils.logging_worker import (
                         GLOBAL_LOGGING_WORKER,
                     )

--- a/litellm/proxy/common_request_processing.py
+++ b/litellm/proxy/common_request_processing.py
@@ -4,7 +4,7 @@ import json
 import logging
 import math
 import traceback
-from collections.abc import AsyncGenerator, Awaitable, Callable, Mapping, Sequence
+from collections.abc import AsyncGenerator, Awaitable, Callable, Coroutine, Mapping, Sequence
 from datetime import datetime
 from functools import lru_cache
 from types import MappingProxyType
@@ -2372,6 +2372,26 @@ class ProxyBaseLLMRequestProcessing:
                         )
 
                     logging_obj._on_deferred_stream_complete = _on_deferred_stream_complete
+                elif (
+                    _post_call_guardrails_active
+                    and route_type == "anthropic_messages"
+                    and self._is_streaming_response(response)
+                ):
+                    # Native /v1/messages SSE streams bypass CSW, so the raw
+                    # iterator parks its logging coroutine at stream end (see
+                    # BaseAnthropicMessagesStreamingIterator._handle_streaming_logging)
+                    # and _fire_deferred_stream_logging hands it here after the
+                    # guardrail end-of-stream scans complete.
+                    from litellm.litellm_core_utils.logging_worker import (
+                        GLOBAL_LOGGING_WORKER,
+                    )
+
+                    async def _on_deferred_native_stream_complete(
+                        logging_coroutine: Coroutine[object, object, object],
+                    ) -> None:
+                        GLOBAL_LOGGING_WORKER.ensure_initialized_and_enqueue(async_coroutine=logging_coroutine)
+
+                    logging_obj._on_deferred_stream_complete = _on_deferred_native_stream_complete
 
                 if route_type == "allm_passthrough_route":
                     # Check if response is an async generator

--- a/litellm/proxy/utils.py
+++ b/litellm/proxy/utils.py
@@ -3227,12 +3227,6 @@ class ProxyLogging:
                     ),
                 )
 
-        # Actually iterate through the chained async generator and yield chunks.
-        # A guardrail block raised after upstream exhaustion (e.g.
-        # unified_guardrail re-raising HTTPException) must still flush any
-        # parked deferred logging, or the blocked stream loses its spend log.
-        # GeneratorExit/CancelledError stay untouched: disconnect cleanup owns
-        # those.
         try:
             async for chunk in current_response:
                 yield chunk

--- a/litellm/proxy/utils.py
+++ b/litellm/proxy/utils.py
@@ -3167,8 +3167,14 @@ class ProxyLogging:
         # through each of them adds N pass-through trampolines per chunk for
         # zero behavior change. Skip the chain entirely and stream through.
         if not caps.iterator_overrides:
-            async for chunk in response:
-                yield chunk
+            try:
+                async for chunk in response:
+                    yield chunk
+            except (GeneratorExit, asyncio.CancelledError):
+                raise
+            except Exception:
+                ProxyLogging._fire_deferred_stream_logging(request_data)
+                raise
             ProxyLogging._fire_deferred_stream_logging(request_data)
             return
 
@@ -3221,9 +3227,20 @@ class ProxyLogging:
                     ),
                 )
 
-        # Actually iterate through the chained async generator and yield chunks
-        async for chunk in current_response:
-            yield chunk
+        # Actually iterate through the chained async generator and yield chunks.
+        # A guardrail block raised after upstream exhaustion (e.g.
+        # unified_guardrail re-raising HTTPException) must still flush any
+        # parked deferred logging, or the blocked stream loses its spend log.
+        # GeneratorExit/CancelledError stay untouched: disconnect cleanup owns
+        # those.
+        try:
+            async for chunk in current_response:
+                yield chunk
+        except (GeneratorExit, asyncio.CancelledError):
+            raise
+        except Exception:
+            ProxyLogging._fire_deferred_stream_logging(request_data)
+            raise
 
         # Fire deferred logging AFTER all guardrail end-of-stream blocks
         # completed.  unified_guardrail writes guardrail_information during

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_streaming_iterator.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_streaming_iterator.py
@@ -6,6 +6,9 @@ import pytest
 
 
 from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObj
+from litellm.llms.anthropic.experimental_pass_through.messages import (
+    streaming_iterator as streaming_iterator_module,
+)
 from litellm.llms.anthropic.experimental_pass_through.messages.streaming_iterator import (
     INCOMPLETE_STREAM_ERROR_MESSAGE,
     AnthropicMessagesStreamHiddenParams,
@@ -26,7 +29,7 @@ class _RecordingLoggingIterator(BaseAnthropicMessagesStreamingIterator):
         self.logged_chunks: list = []
         self.logging_call_count: int = 0
 
-    async def _handle_streaming_logging(self, collected_chunks):
+    async def _handle_streaming_logging(self, collected_chunks, *, stream_teardown=False):
         self.logged_chunks = list(collected_chunks)
         self.logging_call_count += 1
 
@@ -543,3 +546,86 @@ def test_anthropic_messages_response_as_sse_events_no_content_blocks():
     response = {"id": "msg_4", "content": [], "stop_reason": "end_turn"}
     decoded = _decode_sse_events(anthropic_messages_response_as_sse_events(response))
     assert [event_type for event_type, _ in decoded] == ["message_start", "message_delta", "message_stop"]
+
+
+class _RecordingLoggingWorker:
+    def __init__(self):
+        self.enqueued = []
+
+    def ensure_initialized_and_enqueue(self, async_coroutine):
+        self.enqueued.append(async_coroutine)
+
+    def close_enqueued(self):
+        for coroutine in self.enqueued:
+            coroutine.close()
+
+
+async def _noop_deferred_dispatch(logging_coroutine):
+    logging_coroutine.close()
+
+
+async def _stream_of(events):
+    for event in events:
+        yield event
+
+
+COMPLETE_STREAM_EVENTS = TRUNCATED_TOOL_USE_EVENTS + ({"type": "message_stop"},)
+
+
+@pytest.mark.asyncio
+async def test_normal_end_with_deferred_dispatch_armed_parks_logging_coroutine(monkeypatch):
+    """
+    Regression test for LIT-6409: with post_call guardrails active the proxy
+    arms logging_obj._on_deferred_stream_complete, and the native /v1/messages
+    iterator must park its logging coroutine instead of enqueueing it at
+    upstream exhaustion, otherwise the spend log is built before the
+    guardrail end-of-stream scan writes its post_call entry.
+    """
+    worker = _RecordingLoggingWorker()
+    monkeypatch.setattr(streaming_iterator_module, "GLOBAL_LOGGING_WORKER", worker)
+    iterator = _make_iterator("test_deferred_parks_logging_coroutine")
+    iterator.litellm_logging_obj._on_deferred_stream_complete = _noop_deferred_dispatch
+
+    await _collect(iterator, _stream_of(COMPLETE_STREAM_EVENTS))
+
+    parked = getattr(iterator.litellm_logging_obj, "_deferred_stream_complete_args", None)
+    assert worker.enqueued == []
+    assert parked is not None
+    assert len(parked) == 1
+    assert asyncio.iscoroutine(parked[0])
+    parked[0].close()
+
+
+@pytest.mark.asyncio
+async def test_client_disconnect_enqueues_immediately_even_when_deferred_dispatch_armed(monkeypatch):
+    """
+    On client disconnect the guardrail end-of-stream scan never runs, so
+    deferral would strand the spend log; the teardown path must keep
+    enqueueing immediately (LIT-5839) even when the deferred callback is armed.
+    """
+    worker = _RecordingLoggingWorker()
+    monkeypatch.setattr(streaming_iterator_module, "GLOBAL_LOGGING_WORKER", worker)
+    iterator = _make_iterator("test_disconnect_enqueues_when_armed")
+    iterator.litellm_logging_obj._on_deferred_stream_complete = _noop_deferred_dispatch
+
+    wrapped = iterator.async_sse_wrapper(_events_then_hang(TRUNCATED_TOOL_USE_EVENTS))
+    for _ in range(len(TRUNCATED_TOOL_USE_EVENTS)):
+        await wrapped.__anext__()
+    await wrapped.aclose()
+
+    assert len(worker.enqueued) == 1
+    assert getattr(iterator.litellm_logging_obj, "_deferred_stream_complete_args", None) is None
+    worker.close_enqueued()
+
+
+@pytest.mark.asyncio
+async def test_normal_end_without_deferred_dispatch_enqueues_immediately(monkeypatch):
+    worker = _RecordingLoggingWorker()
+    monkeypatch.setattr(streaming_iterator_module, "GLOBAL_LOGGING_WORKER", worker)
+    iterator = _make_iterator("test_unarmed_enqueues_at_stream_end")
+
+    await _collect(iterator, _stream_of(COMPLETE_STREAM_EVENTS))
+
+    assert len(worker.enqueued) == 1
+    assert getattr(iterator.litellm_logging_obj, "_deferred_stream_complete_args", None) is None
+    worker.close_enqueued()

--- a/tests/test_litellm/proxy/utils/proxy_logging/test_streaming_hooks.py
+++ b/tests/test_litellm/proxy/utils/proxy_logging/test_streaming_hooks.py
@@ -10,6 +10,7 @@ Covers ``_wrap_streaming_iterator_with_enrichment``,
 from __future__ import annotations
 
 import asyncio
+from datetime import datetime
 from typing import Any, Dict, List
 from unittest.mock import AsyncMock, MagicMock
 
@@ -18,6 +19,10 @@ from fastapi import HTTPException
 
 import litellm
 from litellm.integrations.custom_logger import CustomLogger
+from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObj
+from litellm.llms.anthropic.experimental_pass_through.messages.streaming_iterator import (
+    BaseAnthropicMessagesStreamingIterator,
+)
 from litellm.proxy.utils import ProxyLogging
 
 
@@ -344,6 +349,134 @@ async def test_async_post_call_streaming_iterator_hook_upstream_error_raises(pro
             request_data={},
         ):
             pass
+
+
+# ---------------------------------------------------------------------------
+# deferred native /v1/messages stream logging (LIT-6409)
+# ---------------------------------------------------------------------------
+
+
+_NATIVE_MESSAGES_STREAM_EVENTS = (
+    {"type": "message_start", "message": {"id": "msg_1", "usage": {"input_tokens": 3, "output_tokens": 1}}},
+    {"type": "content_block_start", "index": 0, "content_block": {"type": "text", "text": ""}},
+    {"type": "content_block_delta", "index": 0, "delta": {"type": "text_delta", "text": "hi"}},
+    {"type": "message_stop"},
+)
+
+
+def _armed_native_messages_stream(test_name: str, request_data: Dict[str, Any], events: List[Any]):
+    """The proxy-side setup for a native /v1/messages stream with post_call
+    guardrails active: a real BaseAnthropicMessagesStreamingIterator whose
+    logging_obj carries the deferred-dispatch callback the proxy arms in
+    common_request_processing. The callback records what the guardrail
+    metadata contained at the moment the deferred logging was dispatched."""
+    logging_obj = LiteLLMLoggingObj(
+        model="bedrock/invoke/anthropic.claude-sonnet-4-20250514-v1:0",
+        messages=[{"role": "user", "content": "hi"}],
+        stream=True,
+        call_type="anthropic_messages",
+        start_time=datetime.now(),
+        litellm_call_id=test_name,
+        function_id=test_name,
+    )
+
+    async def _dispatch_deferred_logging(logging_coroutine):
+        events.append(
+            (
+                "logging_dispatched",
+                "post_call_entry_visible",
+                bool(request_data.get("metadata", {}).get("standard_logging_guardrail_information")),
+            )
+        )
+        logging_coroutine.close()
+
+    logging_obj._on_deferred_stream_complete = _dispatch_deferred_logging
+    request_data["litellm_logging_obj"] = logging_obj
+
+    iterator = BaseAnthropicMessagesStreamingIterator(litellm_logging_obj=logging_obj, request_body={})
+
+    async def _upstream():
+        for event in _NATIVE_MESSAGES_STREAM_EVENTS:
+            yield event
+
+    return logging_obj, iterator.async_sse_wrapper(_upstream())
+
+
+@pytest.mark.asyncio
+async def test_native_messages_stream_logging_fires_after_guardrail_end_of_stream_scan(
+    proxy_logging, make_user_api_key_auth, monkeypatch
+):
+    """
+    Regression test for LIT-6409: on native /v1/messages streams the
+    end-of-stream guardrail scan writes its post_call entry AFTER the
+    upstream iterator is exhausted, so success logging dispatched at
+    upstream exhaustion never sees it. The deferred dispatch must fire
+    only after the guardrail chain fully drains.
+    """
+    events: List[Any] = []
+    request_data: Dict[str, Any] = {"metadata": {}}
+    _, native_stream = _armed_native_messages_stream(
+        "test_native_stream_deferred_ordering", request_data, events
+    )
+
+    class _EndOfStreamScanGuardrail(CustomLogger):
+        async def async_post_call_streaming_iterator_hook(self, user_api_key_dict, response, request_data):
+            async for chunk in response:
+                yield chunk
+            request_data.setdefault("metadata", {})["standard_logging_guardrail_information"] = [
+                {"guardrail_mode": "post_call", "guardrail_status": "success"}
+            ]
+            events.append("scan_appended")
+
+    monkeypatch.setattr(litellm, "callbacks", [_EndOfStreamScanGuardrail()])
+
+    async for _ in proxy_logging.async_post_call_streaming_iterator_hook(
+        response=native_stream,
+        user_api_key_dict=make_user_api_key_auth(),
+        request_data=request_data,
+    ):
+        pass
+    await asyncio.sleep(0)
+    await asyncio.sleep(0)
+
+    assert events == ["scan_appended", ("logging_dispatched", "post_call_entry_visible", True)]
+
+
+@pytest.mark.asyncio
+async def test_native_messages_stream_logging_fires_when_guardrail_blocks_after_stream_end(
+    proxy_logging, make_user_api_key_auth, monkeypatch
+):
+    """
+    A guardrail block raised after upstream exhaustion (unified_guardrail
+    re-raises HTTPException for blocked content) must still flush the
+    parked deferred logging, or the blocked stream loses its spend log.
+    """
+    events: List[Any] = []
+    request_data: Dict[str, Any] = {"metadata": {}}
+    logging_obj, native_stream = _armed_native_messages_stream(
+        "test_native_stream_deferred_block", request_data, events
+    )
+
+    class _BlockingGuardrail(CustomLogger):
+        async def async_post_call_streaming_iterator_hook(self, user_api_key_dict, response, request_data):
+            async for chunk in response:
+                yield chunk
+            raise HTTPException(status_code=400, detail={"error": "Violated guardrail policy"})
+
+    monkeypatch.setattr(litellm, "callbacks", [_BlockingGuardrail()])
+
+    with pytest.raises(HTTPException):
+        async for _ in proxy_logging.async_post_call_streaming_iterator_hook(
+            response=native_stream,
+            user_api_key_dict=make_user_api_key_auth(),
+            request_data=request_data,
+        ):
+            pass
+    await asyncio.sleep(0)
+    await asyncio.sleep(0)
+
+    assert [event[0] for event in events] == ["logging_dispatched"]
+    assert logging_obj._deferred_stream_complete_args is None
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## TLDR

Problem this solves:

- Streamed /v1/messages spend logs miss the post_call guardrail entry
- The output scan runs and bills, but the Guardrails Monitor never sees it

How it solves it:

- Success logging for native /v1/messages streams now waits for the guardrail output scan
- Blocked streams still get logged; client disconnects keep billing immediately

## User Flow

Before: the output scan runs but never shows up in the request's guardrail trail

1. An admin configures a Bedrock post_call guardrail with `default_on: true` on the proxy
2. A client sends POST https://litellm-domain/v1/messages with `"stream": true` to a `bedrock/invoke/...` Claude deployment and streams the full response back
3. The guardrail scans the finished output (Bedrock ApplyGuardrail is called and billed)
4. The request's row at https://litellm-domain/ui/?page=logs and the charts at https://litellm-domain/ui/guardrails-monitor show only the pre_call entry, so the output scan is missing from the audit trail

After: the same request's log row carries both scans

1. An admin configures a Bedrock post_call guardrail with `default_on: true` on the proxy
2. A client sends POST https://litellm-domain/v1/messages with `"stream": true` to a `bedrock/invoke/...` Claude deployment and streams the full response back
3. The guardrail scans the finished output (Bedrock ApplyGuardrail is called and billed)
4. The request's row at https://litellm-domain/ui/?page=logs and the charts at https://litellm-domain/ui/guardrails-monitor show both the pre_call and post_call entries

## Relevant issues

## Linear ticket

Resolves LIT-6409

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Shared setup for both runs: one proxy process with 2 uvicorn workers (`--num_workers 2`), a fresh Postgres DB per run, real Bedrock model and ApplyGuardrail calls in us-east-1, no mocks. The config maps `bedrock-claude-haiku` -> `bedrock/invoke/us.anthropic.claude-haiku-4-5-20251001-v1:0` with two Bedrock guardrails on guardrail id `wk4ijrsk7ska`: `bedrock-pre` (`mode: pre_call`) and `bedrock-post` (`mode: post_call`), both `default_on: true`. Spend rows are read only through the admin HTTP surface the UI Logs page uses: `GET /spend/logs?request_id=<x-litellm-call-id>` for streamed native rows, and `GET /spend/logs/ui?start_date=...&end_date=...` matched on `metadata.litellm_call_id` for the rest, which store request_id as `chatcmpl-*`. The profane string configured as this QA guardrail's block message is elided below

### Before (4ebedf901a)

Proxy booted at the merge base on port 20767

#### Claude Code streamed /v1/messages

1. Run Claude Code, a real end-user client, against the proxy in an interactive terminal session and send one prompt:

```
$ env ANTHROPIC_BASE_URL=http://127.0.0.1:20767 ANTHROPIC_AUTH_TOKEN=$LITELLM_MASTER_KEY \
      ANTHROPIC_MODEL=bedrock-claude-haiku ANTHROPIC_SMALL_FAST_MODEL=bedrock-claude-haiku claude

 ▐▛███▛█   Claude Code v2.1.251
▝▜██████▀  bedrock-claude-haiku with xhigh effort · API Usage Billing
❯ Reply with exactly: hello from qa
⏺ hello from qa
```

2. The session produced 2 streamed POST /v1/messages requests; their spend rows (`3bf5ac43-2284...` and `8dc6dd47-c8be...` at 23:12:54-55 UTC) both carry the pre_call entry only

#### 10 streamed /v1/messages via curl

1. Send 10 streamed requests and read every stream to `message_stop`:

```
$ for i in {1..10}; do
    curl -sN -D headers_$i.txt -o body_$i.txt -X POST http://127.0.0.1:20767/v1/messages \
      -H "Authorization: Bearer $LITELLM_MASTER_KEY" -H 'Content-Type: application/json' \
      -d '{"model":"bedrock-claude-haiku","max_tokens":120,"stream":true,
           "messages":[{"role":"user","content":"Name three rivers in Europe and one fact about each, briefly."}]}'
    grep -i '^x-litellm-call-id:' headers_$i.txt
  done
1 94fa6f1c-ed80-428b-a30d-f07e914d9859
2 43d98a06-7f21-4381-9c50-e163d12c129b
3 559e82b1-a420-4ebb-ac0f-65c96e00783d
... (7 more ids, all completed streams ending in)
event: message_stop
data: {"type": "message_stop", "usage": {"input_tokens": 20, "output_tokens": 92}}
```

2. Fetch each row: all 10 carry only the pre_call entry. This is the bug:

```
$ curl -s "http://127.0.0.1:20767/spend/logs?request_id=94fa6f1c-ed80-428b-a30d-f07e914d9859" \
    -H "Authorization: Bearer $LITELLM_MASTER_KEY" | jq '.[0].metadata.guardrail_information'
[
  {
    "guardrail_mode": "pre_call",
    "guardrail_name": "bedrock-pre",
    "guardrail_action": "NONE",
    "guardrail_status": "success",
    "guardrail_cost": 0.00015,
    "guardrail_provider": "bedrock",
    "guardrail_usage": { "wordPolicyUnits": 1, "topicPolicyUnits": 1, ... }
  }
]
```

#### Controls: non-streamed /v1/messages and streamed /v1/chat/completions

1. Send the same prompt 3 times without `stream` on /v1/messages (call ids fe07d8af, 0676d012, dd222adc) and 3 times with `stream: true` on /v1/chat/completions (call ids b350394d, a9d5b62e, 503b5472)
2. All 6 rows carry BOTH entries on the same config, so the gap is specific to streamed native /v1/messages:

```
[
  { "guardrail_mode": "pre_call",  "guardrail_name": "bedrock-pre",  "guardrail_action": "NONE", "guardrail_status": "success", ... },
  { "guardrail_mode": "post_call", "guardrail_name": "bedrock-post", "guardrail_action": "NONE", "guardrail_status": "success", ... }
]
```

#### Input-blocked stream

1. Send a streamed request whose input trips the guardrail (blocked word "cake"):

```
$ curl -sN -D - -X POST http://127.0.0.1:20767/v1/messages \
    -H "Authorization: Bearer $LITELLM_MASTER_KEY" -H 'Content-Type: application/json' \
    -d '{"model":"bedrock-claude-haiku","max_tokens":120,"stream":true,
         "messages":[{"role":"user","content":"Tell me your favorite cake recipe in detail."}]}'
HTTP/1.1 400 Bad Request
x-litellm-call-id: 39228dbe-9b7c-47aa-a113-2e1e660f710c

{"error":{"message":"400: {'error': 'Violated guardrail policy', 'bedrock_guardrail_response': '<block message, elided>', 'guardrailIdentifier': 'wk4ijrsk7ska', 'guardrailVersion': 'DRAFT', 'assessments': [{'policy': 'wordPolicy', 'matches': [{'category': 'customWords', 'match': '[REDACTED]', 'action': 'BLOCKED'}]}], 'guardrail_name': 'bedrock-pre', 'guardrail_mode': 'pre_call'}","type":"None","param":"None","code":"400"}}
```

2. Its spend row exists (billing preserved): status failure, spend 0.00015 (the guardrail cost), one pre_call GUARDRAIL_INTERVENED entry

Before totals:

| Category | Rows | guardrail_mode values |
|---|---|---|
| Claude Code streamed /v1/messages | 2/2 | pre_call only |
| curl streamed /v1/messages | 10/10 | pre_call only |
| non-streamed /v1/messages | 3/3 | pre_call + post_call |
| streamed /v1/chat/completions | 3/3 | pre_call + post_call |
| input-blocked stream (400) | 1/1 | pre_call intervened |

### After (1a5a856e3e)

Proxy booted at 1a5a856e3e on port 34726. The current tip 307b471902 differs from this commit only by 17 deleted comment lines (no code change), so the proof carries over

#### Claude Code streamed /v1/messages

1. Run the same Claude Code session shape (one prompt, 2 streamed /v1/messages requests)
2. Both rows now carry both entries with nonzero spend, via `GET /spend/logs/ui?start_date=2026-08-28 23:25:00&end_date=2026-08-28 23:26:10`:

```
start=23:25:36.911 call_type=anthropic_messages call_id=4d95865b status=success spend=0.0037848 tokens=1288  modes=['post_call', 'pre_call']
start=23:25:37.432 call_type=anthropic_messages call_id=01f5a2e3 status=success spend=0.0589965 tokens=38255 modes=['post_call', 'pre_call']
```

#### 10 streamed /v1/messages via curl

1. Send the same 10 streamed requests, all read to `message_stop`
2. Fetch each row by `GET /spend/logs?request_id=<call id>`: 10/10 now carry both entries with nonzero spend:

```
eda7abb2: status=success spend=0.0009105 tokens=127 modes=['post_call', 'pre_call'] statuses=['success']
1fbdaa30: status=success spend=0.000861  tokens=118 modes=['post_call', 'pre_call'] statuses=['success']
42b18238: status=success spend=0.000839  tokens=114 modes=['post_call', 'pre_call'] statuses=['success']
6d18b203: status=success spend=0.0008445 tokens=115 modes=['post_call', 'pre_call'] statuses=['success']
0fde00a1: status=success spend=0.000916  tokens=128 modes=['post_call', 'pre_call'] statuses=['success']
71a1662f: status=success spend=0.00096   tokens=136 modes=['post_call', 'pre_call'] statuses=['success']
99a6ed5c: status=success spend=0.0009655 tokens=137 modes=['post_call', 'pre_call'] statuses=['success']
f8b327f6: status=success spend=0.000839  tokens=114 modes=['post_call', 'pre_call'] statuses=['success']
1a5164ae: status=success spend=0.000982  tokens=140 modes=['post_call', 'pre_call'] statuses=['success']
147ced97: status=success spend=0.00085   tokens=116 modes=['post_call', 'pre_call'] statuses=['success']
```

3. The first row's full `guardrail_information` (`GET /spend/logs?request_id=eda7abb2-2d9f-44d3-a365-cec6724b60ed`):

```json
[
 {"duration": 0.491918, "guardrail_cost": 0.00015, "guardrail_mode": "pre_call", "guardrail_name": "bedrock-pre",
  "guardrail_usage": {"wordPolicyUnits": 1, "topicPolicyUnits": 1, "contentPolicyUnits": 0, "contentPolicyImageUnits": 0, "automatedReasoningPolicies": 0, "automatedReasoningPolicyUnits": 0, "contextualGroundingPolicyUnits": 0, "sensitiveInformationPolicyUnits": 0, "sensitiveInformationPolicyFreeUnits": 0},
  "guardrail_action": "NONE", "guardrail_status": "success", "guardrail_provider": "bedrock",
  "guardrail_response": "REDACTED_BY_LITELM", "masked_entity_count": null},
 {"duration": 0.365125, "guardrail_cost": 0.00015, "guardrail_mode": "post_call", "guardrail_name": "bedrock-post",
  "guardrail_usage": {"wordPolicyUnits": 1, "topicPolicyUnits": 1, "contentPolicyUnits": 0, "contentPolicyImageUnits": 0, "automatedReasoningPolicies": 0, "automatedReasoningPolicyUnits": 0, "contextualGroundingPolicyUnits": 0, "sensitiveInformationPolicyUnits": 0, "sensitiveInformationPolicyFreeUnits": 0},
  "guardrail_action": "NONE", "guardrail_status": "success", "guardrail_provider": "bedrock",
  "guardrail_response": "REDACTED_BY_LITELM", "masked_entity_count": null}
]
```

#### Controls: non-streamed /v1/messages and streamed /v1/chat/completions

1. Send the same 3 + 3 control requests
2. All 6 rows are unchanged by the fix, both entries and nonzero spend:

```
nostream_1: call_id=cacdadb8 request_id=chatcmpl-2b15f1a4-... status=success spend=0.000883  tokens=122 modes=['post_call', 'pre_call']
nostream_2: call_id=019e2737 request_id=chatcmpl-c39df9aa-... status=success spend=0.000872  tokens=120 modes=['post_call', 'pre_call']
nostream_3: call_id=60247f16 request_id=chatcmpl-ea6d5270-... status=success spend=0.0008665 tokens=119 modes=['post_call', 'pre_call']
chat_1:     call_id=d42c48b1 request_id=chatcmpl-bd0b13d4-... status=success spend=0.0008995 tokens=125 modes=['post_call', 'pre_call']
chat_2:     call_id=61039292 request_id=chatcmpl-8912dad9-... status=success spend=0.000883  tokens=122 modes=['post_call', 'pre_call']
chat_3:     call_id=b3b3af83 request_id=chatcmpl-f3261ffa-... status=success spend=0.0008995 tokens=125 modes=['post_call', 'pre_call']
```

#### Input-blocked stream

1. Send the same "cake recipe" streamed request
2. Behavior is unchanged from Before: HTTP 400, call id 12c99c00-3ceb-499b-9139-47cf9e095f2b, spend row status failure, spend 0.00015, one pre_call guardrail_intervened entry

#### Output-blocked stream

This case exists only on the After side; it exercises the deferred path this PR adds when the end-of-stream output scan blocks (at the merge base the equivalent non-regression bar, a spend row existing, is what the streamed cases above already showed)

1. Send a streamed request whose input avoids the blocked word but whose answer contains it, so the post_call scan intervenes at end of stream:

```
$ curl -s -D - http://127.0.0.1:34726/v1/messages -H "Authorization: Bearer $LITELLM_MASTER_KEY" -H 'Content-Type: application/json' \
    -d '{"model":"bedrock-claude-haiku","max_tokens":120,"stream":true,"messages":[{"role":"user","content":"What one-word dessert is served with candles at birthday parties? Answer with just that single word."}]}'
HTTP 400   x-litellm-call-id: 907ad292-35d2-463b-bc48-555a9b161c98
data: {"error": {"message": "Violated guardrail policy", "type": "None", "param": "None", "code": "400", "provider_specific_fields": {"error": "Violated guardrail policy", "bedrock_guardrail_response": "<block message, elided>", "guardrailIdentifier": "wk4ijrsk7ska", "guardrailVersion": "DRAFT", "assessments": [{"policy": "wordPolicy", "matches": [{"category": "customWords", "match": "[REDACTED]", "action": "BLOCKED"}]}], "guardrail_name": "bedrock-post", "guardrail_mode": "post_call"}}}

data: [DONE]
```

2. Its spend row exists (no billing lost on the new deferred path), `GET /spend/logs?request_id=907ad292-...`:

```
status=failure spend=0.0003 tokens=0
guardrail_information:
  bedrock-pre  / pre_call  / success
  bedrock-post / post_call / guardrail_intervened
```

After totals:

| Category | Rows | guardrail_mode values | Spend/tokens |
|---|---|---|---|
| Claude Code streamed /v1/messages | 2/2 | pre_call + post_call | nonzero |
| curl streamed /v1/messages | 10/10 | pre_call + post_call | nonzero |
| non-streamed /v1/messages | 3/3 | pre_call + post_call | nonzero |
| streamed /chat/completions | 3/3 | pre_call + post_call | nonzero |
| input-blocked stream (400) | 1/1 | pre_call intervened | 0.00015 / 0 |
| output-blocked stream (400) | 1/1 | pre success + post intervened | 0.0003 / 0 |

Observations from the runs, none caused or worsened by this PR:

- Output-block sends HTTP 400 with an SSE-framed error body (pre-existing framing, left alone)
- Blocked rows bill guardrail cost with zero token counts (pre-existing, left alone)
- Non-streamed and chat-completions rows key request_id as `chatcmpl-*`, streamed native rows use the call id (pre-existing, left alone)
- Failure rows from a provider 403 carry pre_call only (expected, there is no output to scan)

## Type

🐛 Bug Fix

## Caveats (if any)

### Low

- On client disconnect the log still carries only the pre_call entry: the output scan never runs there, and immediate billing on disconnect is kept on purpose

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

- [x] 307b47190295b4438b57f04d22f5aeb2a7e29f42 passes /live-pr-risk
