### PR TITLE
test(shadow_eval): configure the anthropic sdk judge in the funnel-seed test

### DIFF
--- a/tests/test_litellm/proxy/management_endpoints/test_auto_router_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_auto_router_endpoints.py
@@ -2388,6 +2388,7 @@ async def test_start_shadow_eval_seeds_a_zero_funnel_row_per_leg(monkeypatch: py
     prisma = _shadow_prisma(legs=[])
     monkeypatch.setattr(proxy_server, "prisma_client", prisma)
     monkeypatch.setattr(proxy_server, "llm_router", _shadow_router())
+    _configure_anthropic_sdk_judge(monkeypatch)
 
     await start_shadow_eval(_start_request(api_key_ids=("key-hash", "key-hash-2")), ADMIN)
 


### PR DESCRIPTION
## What

Fixes the `proxy-endpoints / Run tests` failure red on `litellm_internal_staging` since today: `test_start_shadow_eval_seeds_a_zero_funnel_row_per_leg` fails with

```
HTTPException: 400: judge_model 'anthropic/claude-sonnet-5' uses the LiteLLM SDK but required credentials are not configured: ANTHROPIC_API_KEY or ANTHROPIC_AUTH_TOKEN
```

## Why

Two PRs crossed: #38631 added this test (green on its own CI), and #38701 added SDK-judge credential validation to `start_shadow_eval`. Merged together, the new test is the only two-key `start_shadow_eval` test that never calls the module's `_configure_anthropic_sdk_judge(monkeypatch)` helper, so on a runner without Anthropic env vars the start call now 400s before reaching the funnel-seed assertions. Its siblings (`test_start_shadow_eval_writes_one_leg_per_key_in_one_statement`, `test_start_shadow_eval_names_the_busy_key_and_its_job`) already configure it.

## Fix

One line: call `_configure_anthropic_sdk_judge(monkeypatch)` like the sibling tests.

Verified in a clean worktree with `ANTHROPIC_API_KEY`/`ANTHROPIC_AUTH_TOKEN` stripped from the env: the test fails without this change (same 400 as CI) and the full module (130 tests) passes with it.

## Behavior changes

None — tests only; no runtime code is touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/berriai/litellm/pull/38717" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->