### PR TITLE
fix(chatgpt): recover output items from streaming chunks, not just full-body SSE

### DIFF
--- a/litellm/llms/chatgpt/responses/transformation.py
+++ b/litellm/llms/chatgpt/responses/transformation.py
@@ -59,7 +59,9 @@ class ChatGPTResponsesAPIConfig(OpenAIResponsesAPIConfig):
 
         account_id: Final = self.authenticator.get_account_id()
         session_id: Final = ensure_chatgpt_session_id(litellm_params)
-        default_headers: Final = get_chatgpt_default_headers(access_token, account_id, session_id)
+        default_headers: Final = get_chatgpt_default_headers(
+            access_token, account_id, session_id
+        )
         return {**default_headers, **headers}
 
     def transform_responses_api_request(
@@ -81,7 +83,9 @@ class ChatGPTResponsesAPIConfig(OpenAIResponsesAPIConfig):
         existing_instructions: Final = request.get("instructions")
         if existing_instructions:
             if base_instructions not in existing_instructions:
-                request["instructions"] = f"{base_instructions}\n\n{existing_instructions}"
+                request["instructions"] = (
+                    f"{base_instructions}\n\n{existing_instructions}"
+                )
         else:
             request["instructions"] = base_instructions
         request["store"] = False
@@ -148,7 +152,9 @@ class ChatGPTResponsesAPIConfig(OpenAIResponsesAPIConfig):
             item_accumulator: Final = logging_obj.model_call_details.setdefault(
                 "_chatgpt_streamed_output_items", {}
             )
-            record_output_item_chunk(parsed_chunk=parsed_chunk, output_items=item_accumulator)
+            record_output_item_chunk(
+                parsed_chunk=parsed_chunk, output_items=item_accumulator
+            )
         elif event_type == ResponsesAPIStreamEvents.OUTPUT_TEXT_DONE:
             item_accumulator = logging_obj.model_call_details.setdefault(
                 "_chatgpt_streamed_output_items", {}
@@ -163,13 +169,19 @@ class ChatGPTResponsesAPIConfig(OpenAIResponsesAPIConfig):
             )
         elif event_type == ResponsesAPIStreamEvents.RESPONSE_COMPLETED:
             response_payload: Final = parsed_chunk.get("response")
-            if isinstance(response_payload, dict) and not response_payload.get("output"):
-                item_accumulator = logging_obj.model_call_details.get(
-                    "_chatgpt_streamed_output_items"
-                ) or {}
-                text_accumulator = logging_obj.model_call_details.get(
-                    "_chatgpt_text_only_output_items"
-                ) or {}
+            if isinstance(response_payload, dict) and not response_payload.get(
+                "output"
+            ):
+                item_accumulator = (
+                    logging_obj.model_call_details.get("_chatgpt_streamed_output_items")
+                    or {}
+                )
+                text_accumulator = (
+                    logging_obj.model_call_details.get(
+                        "_chatgpt_text_only_output_items"
+                    )
+                    or {}
+                )
                 merged_items: dict[int, dict] = {**text_accumulator}
                 merged_items.update(item_accumulator)
                 if merged_items:
@@ -192,7 +204,9 @@ class ChatGPTResponsesAPIConfig(OpenAIResponsesAPIConfig):
         logging_obj: "LiteLLMLoggingObj",
     ):
         body_text: Final = raw_response.text or ""
-        if not self._should_parse_as_sse(raw_response=raw_response, body_text=body_text):
+        if not self._should_parse_as_sse(
+            raw_response=raw_response, body_text=body_text
+        ):
             return super().transform_response_api_response(
                 model=model,
                 raw_response=raw_response,
@@ -204,14 +218,18 @@ class ChatGPTResponsesAPIConfig(OpenAIResponsesAPIConfig):
             additional_args={"complete_input_dict": {}},
         )
 
-        completed_response, error_message = self._extract_completed_response_from_sse(body_text=body_text)
+        completed_response, error_message = self._extract_completed_response_from_sse(
+            body_text=body_text
+        )
         if completed_response is None:
             raise OpenAIError(
                 message=error_message or raw_response.text,
                 status_code=raw_response.status_code,
             )
 
-        self._attach_response_headers(completed_response=completed_response, raw_response=raw_response)
+        self._attach_response_headers(
+            completed_response=completed_response, raw_response=raw_response
+        )
         return completed_response
 
     def _should_parse_as_sse(self, raw_response: Any, body_text: str) -> bool:
@@ -226,7 +244,9 @@ class ChatGPTResponsesAPIConfig(OpenAIResponsesAPIConfig):
             or "\ndata:" in body_text
         )
 
-    def _extract_completed_response_from_sse(self, body_text: str) -> tuple[ResponsesAPIResponse | None, str | None]:
+    def _extract_completed_response_from_sse(
+        self, body_text: str
+    ) -> tuple[ResponsesAPIResponse | None, str | None]:
         completed_response = None
         error_message = None
         streamed_output_items: Final[dict[int, dict]] = {}
@@ -283,16 +303,22 @@ class ChatGPTResponsesAPIConfig(OpenAIResponsesAPIConfig):
             return None
         response_payload = dict(response_payload)
         if not response_payload.get("output") and streamed_output_items:
-            response_payload["output"] = [item for _, item in sorted(streamed_output_items.items())]
+            response_payload["output"] = [
+                item for _, item in sorted(streamed_output_items.items())
+            ]
         if "created_at" in response_payload:
-            response_payload["created_at"] = _safe_convert_created_field(response_payload["created_at"])
+            response_payload["created_at"] = _safe_convert_created_field(
+                response_payload["created_at"]
+            )
         try:
             return ResponsesAPIResponse(**response_payload)
         except Exception:
             return ResponsesAPIResponse.model_construct(**response_payload)
 
     def _extract_error_message(self, parsed_chunk: dict[str, Any]) -> str | None:
-        error_obj: Final = parsed_chunk.get("error") or (parsed_chunk.get("response") or {}).get("error")
+        error_obj: Final = parsed_chunk.get("error") or (
+            parsed_chunk.get("response") or {}
+        ).get("error")
         if error_obj is None:
             return None
         if isinstance(error_obj, dict):

--- a/litellm/llms/chatgpt/responses/transformation.py
+++ b/litellm/llms/chatgpt/responses/transformation.py
@@ -15,6 +15,7 @@ from litellm.responses.sse_output_recovery import (
 from litellm.types.llms.openai import (
     ResponsesAPIResponse,
     ResponsesAPIStreamEvents,
+    ResponsesAPIStreamingResponse,
 )
 from litellm.types.router import GenericLiteLLMParams
 from litellm.types.utils import LlmProviders
@@ -105,6 +106,84 @@ class ChatGPTResponsesAPIConfig(OpenAIResponsesAPIConfig):
         }
 
         return {k: v for k, v in request.items() if k in allowed_keys}
+
+    def transform_streaming_response(
+        self,
+        model: str,
+        parsed_chunk: dict,
+        logging_obj: "LiteLLMLoggingObj",
+    ) -> "ResponsesAPIStreamingResponse":
+        """
+        chatgpt.com's Codex backend always ships `response.output: []` on the
+        terminal `response.completed` event -- the actual message content only
+        ever appears in earlier `response.output_item.done` /
+        `response.output_text.done` events. `transform_response_api_response`
+        (below) already accounts for this when it gets the full SSE body in
+        one shot, but this provider *always* forces `stream=True` upstream
+        (see `transform_responses_api_request`), so `response_api_handler`
+        always takes the streaming branch and this method -- not
+        `transform_response_api_response` -- is what actually runs for every
+        chatgpt call. Without this override,
+        `SyncResponsesAPIStreamingIterator.completed_response` ends up
+        holding the empty-output completed event verbatim, and
+        `transform_response()` in the Responses-to-Chat-Completions bridge
+        (`completion_extras/litellm_responses_transformation/
+        transformation.py`) raises "Unknown items in responses API response:
+        []" -- reproducing upstream BerriAI/litellm#25429 and #27175.
+
+        Accumulate the same `OUTPUT_ITEM_DONE`/`OUTPUT_TEXT_DONE` chunks this
+        provider's own non-streaming path already recovers from
+        (`_extract_completed_response_from_sse`/
+        `_build_completed_response_from_chunk`), keyed on
+        `logging_obj.model_call_details` so state is scoped to this one
+        request rather than the shared, long-lived provider-config instance
+        (which every request reuses -- attribute state on `self` would leak
+        across concurrent calls). Merge them into `response.completed`'s
+        `output` field before the base class turns the chunk into a typed
+        event, so a genuinely empty `output` never reaches the bridge.
+        """
+        event_type: Final = parsed_chunk.get("type")
+
+        if event_type == ResponsesAPIStreamEvents.OUTPUT_ITEM_DONE:
+            item_accumulator: Final = logging_obj.model_call_details.setdefault(
+                "_chatgpt_streamed_output_items", {}
+            )
+            record_output_item_chunk(parsed_chunk=parsed_chunk, output_items=item_accumulator)
+        elif event_type == ResponsesAPIStreamEvents.OUTPUT_TEXT_DONE:
+            item_accumulator = logging_obj.model_call_details.setdefault(
+                "_chatgpt_streamed_output_items", {}
+            )
+            text_accumulator: Final = logging_obj.model_call_details.setdefault(
+                "_chatgpt_text_only_output_items", {}
+            )
+            record_output_text_chunk(
+                parsed_chunk=parsed_chunk,
+                output_items=item_accumulator,
+                text_only_items=text_accumulator,
+            )
+        elif event_type == ResponsesAPIStreamEvents.RESPONSE_COMPLETED:
+            response_payload: Final = parsed_chunk.get("response")
+            if isinstance(response_payload, dict) and not response_payload.get("output"):
+                item_accumulator = logging_obj.model_call_details.get(
+                    "_chatgpt_streamed_output_items"
+                ) or {}
+                text_accumulator = logging_obj.model_call_details.get(
+                    "_chatgpt_text_only_output_items"
+                ) or {}
+                merged_items: dict[int, dict] = {**text_accumulator}
+                merged_items.update(item_accumulator)
+                if merged_items:
+                    parsed_chunk = dict(parsed_chunk)
+                    parsed_chunk["response"] = {
+                        **response_payload,
+                        "output": [item for _, item in sorted(merged_items.items())],
+                    }
+
+        return super().transform_streaming_response(
+            model=model,
+            parsed_chunk=parsed_chunk,
+            logging_obj=logging_obj,
+        )
 
     def transform_response_api_response(
         self,

--- a/litellm/llms/chatgpt/responses/transformation.py
+++ b/litellm/llms/chatgpt/responses/transformation.py
@@ -59,9 +59,7 @@ class ChatGPTResponsesAPIConfig(OpenAIResponsesAPIConfig):
 
         account_id: Final = self.authenticator.get_account_id()
         session_id: Final = ensure_chatgpt_session_id(litellm_params)
-        default_headers: Final = get_chatgpt_default_headers(
-            access_token, account_id, session_id
-        )
+        default_headers: Final = get_chatgpt_default_headers(access_token, account_id, session_id)
         return {**default_headers, **headers}
 
     def transform_responses_api_request(
@@ -83,9 +81,7 @@ class ChatGPTResponsesAPIConfig(OpenAIResponsesAPIConfig):
         existing_instructions: Final = request.get("instructions")
         if existing_instructions:
             if base_instructions not in existing_instructions:
-                request["instructions"] = (
-                    f"{base_instructions}\n\n{existing_instructions}"
-                )
+                request["instructions"] = f"{base_instructions}\n\n{existing_instructions}"
         else:
             request["instructions"] = base_instructions
         request["store"] = False
@@ -159,19 +155,11 @@ class ChatGPTResponsesAPIConfig(OpenAIResponsesAPIConfig):
         event_type: Final = parsed_chunk.get("type")
 
         if event_type == ResponsesAPIStreamEvents.OUTPUT_ITEM_DONE:
-            item_accumulator: Final = logging_obj.model_call_details.setdefault(
-                "_chatgpt_streamed_output_items", {}
-            )
-            record_output_item_chunk(
-                parsed_chunk=parsed_chunk, output_items=item_accumulator
-            )
+            item_accumulator: Final = logging_obj.model_call_details.setdefault("_chatgpt_streamed_output_items", {})
+            record_output_item_chunk(parsed_chunk=parsed_chunk, output_items=item_accumulator)
         elif event_type == ResponsesAPIStreamEvents.OUTPUT_TEXT_DONE:
-            item_accumulator = logging_obj.model_call_details.setdefault(
-                "_chatgpt_streamed_output_items", {}
-            )
-            text_accumulator: Final = logging_obj.model_call_details.setdefault(
-                "_chatgpt_text_only_output_items", {}
-            )
+            item_accumulator = logging_obj.model_call_details.setdefault("_chatgpt_streamed_output_items", {})
+            text_accumulator: Final = logging_obj.model_call_details.setdefault("_chatgpt_text_only_output_items", {})
             record_output_text_chunk(
                 parsed_chunk=parsed_chunk,
                 output_items=item_accumulator,
@@ -182,18 +170,8 @@ class ChatGPTResponsesAPIConfig(OpenAIResponsesAPIConfig):
             ResponsesAPIStreamEvents.RESPONSE_FAILED,
             ResponsesAPIStreamEvents.RESPONSE_INCOMPLETE,
         ):
-            item_accumulator = (
-                logging_obj.model_call_details.pop(
-                    "_chatgpt_streamed_output_items", None
-                )
-                or {}
-            )
-            text_accumulator = (
-                logging_obj.model_call_details.pop(
-                    "_chatgpt_text_only_output_items", None
-                )
-                or {}
-            )
+            item_accumulator = logging_obj.model_call_details.pop("_chatgpt_streamed_output_items", None) or {}
+            text_accumulator = logging_obj.model_call_details.pop("_chatgpt_text_only_output_items", None) or {}
             response_payload: Final = parsed_chunk.get("response")
             if (
                 event_type == ResponsesAPIStreamEvents.RESPONSE_COMPLETED
@@ -222,9 +200,7 @@ class ChatGPTResponsesAPIConfig(OpenAIResponsesAPIConfig):
         logging_obj: "LiteLLMLoggingObj",
     ):
         body_text: Final = raw_response.text or ""
-        if not self._should_parse_as_sse(
-            raw_response=raw_response, body_text=body_text
-        ):
+        if not self._should_parse_as_sse(raw_response=raw_response, body_text=body_text):
             return super().transform_response_api_response(
                 model=model,
                 raw_response=raw_response,
@@ -236,18 +212,14 @@ class ChatGPTResponsesAPIConfig(OpenAIResponsesAPIConfig):
             additional_args={"complete_input_dict": {}},
         )
 
-        completed_response, error_message = self._extract_completed_response_from_sse(
-            body_text=body_text
-        )
+        completed_response, error_message = self._extract_completed_response_from_sse(body_text=body_text)
         if completed_response is None:
             raise OpenAIError(
                 message=error_message or raw_response.text,
                 status_code=raw_response.status_code,
             )
 
-        self._attach_response_headers(
-            completed_response=completed_response, raw_response=raw_response
-        )
+        self._attach_response_headers(completed_response=completed_response, raw_response=raw_response)
         return completed_response
 
     def _should_parse_as_sse(self, raw_response: Any, body_text: str) -> bool:
@@ -262,9 +234,7 @@ class ChatGPTResponsesAPIConfig(OpenAIResponsesAPIConfig):
             or "\ndata:" in body_text
         )
 
-    def _extract_completed_response_from_sse(
-        self, body_text: str
-    ) -> tuple[ResponsesAPIResponse | None, str | None]:
+    def _extract_completed_response_from_sse(self, body_text: str) -> tuple[ResponsesAPIResponse | None, str | None]:
         completed_response = None
         error_message = None
         streamed_output_items: Final[dict[int, dict]] = {}
@@ -321,22 +291,16 @@ class ChatGPTResponsesAPIConfig(OpenAIResponsesAPIConfig):
             return None
         response_payload = dict(response_payload)
         if not response_payload.get("output") and streamed_output_items:
-            response_payload["output"] = [
-                item for _, item in sorted(streamed_output_items.items())
-            ]
+            response_payload["output"] = [item for _, item in sorted(streamed_output_items.items())]
         if "created_at" in response_payload:
-            response_payload["created_at"] = _safe_convert_created_field(
-                response_payload["created_at"]
-            )
+            response_payload["created_at"] = _safe_convert_created_field(response_payload["created_at"])
         try:
             return ResponsesAPIResponse(**response_payload)
         except Exception:
             return ResponsesAPIResponse.model_construct(**response_payload)
 
     def _extract_error_message(self, parsed_chunk: dict[str, Any]) -> str | None:
-        error_obj: Final = parsed_chunk.get("error") or (
-            parsed_chunk.get("response") or {}
-        ).get("error")
+        error_obj: Final = parsed_chunk.get("error") or (parsed_chunk.get("response") or {}).get("error")
         if error_obj is None:
             return None
         if isinstance(error_obj, dict):

--- a/litellm/llms/chatgpt/responses/transformation.py
+++ b/litellm/llms/chatgpt/responses/transformation.py
@@ -145,6 +145,16 @@ class ChatGPTResponsesAPIConfig(OpenAIResponsesAPIConfig):
         across concurrent calls). Merge them into `response.completed`'s
         `output` field before the base class turns the chunk into a typed
         event, so a genuinely empty `output` never reaches the bridge.
+
+        The two accumulator keys are popped off `model_call_details` on every
+        terminal event (completed, failed, or incomplete) once they're no
+        longer needed. `redact_message_input_output_from_logging` (triggered
+        by `litellm.turn_off_message_logging`) only knows to scrub a fixed
+        set of recognized fields -- it has no idea these two custom keys
+        exist, so leaving them in `model_call_details` would let a logging
+        callback that reads `kwargs`/`model_call_details` directly (rather
+        than only the redacted typed response) export the raw recovered
+        response text even when message logging is explicitly disabled.
         """
         event_type: Final = parsed_chunk.get("type")
 
@@ -167,21 +177,29 @@ class ChatGPTResponsesAPIConfig(OpenAIResponsesAPIConfig):
                 output_items=item_accumulator,
                 text_only_items=text_accumulator,
             )
-        elif event_type == ResponsesAPIStreamEvents.RESPONSE_COMPLETED:
+        elif event_type in (
+            ResponsesAPIStreamEvents.RESPONSE_COMPLETED,
+            ResponsesAPIStreamEvents.RESPONSE_FAILED,
+            ResponsesAPIStreamEvents.RESPONSE_INCOMPLETE,
+        ):
+            item_accumulator = (
+                logging_obj.model_call_details.pop(
+                    "_chatgpt_streamed_output_items", None
+                )
+                or {}
+            )
+            text_accumulator = (
+                logging_obj.model_call_details.pop(
+                    "_chatgpt_text_only_output_items", None
+                )
+                or {}
+            )
             response_payload: Final = parsed_chunk.get("response")
-            if isinstance(response_payload, dict) and not response_payload.get(
-                "output"
+            if (
+                event_type == ResponsesAPIStreamEvents.RESPONSE_COMPLETED
+                and isinstance(response_payload, dict)
+                and not response_payload.get("output")
             ):
-                item_accumulator = (
-                    logging_obj.model_call_details.get("_chatgpt_streamed_output_items")
-                    or {}
-                )
-                text_accumulator = (
-                    logging_obj.model_call_details.get(
-                        "_chatgpt_text_only_output_items"
-                    )
-                    or {}
-                )
                 merged_items: dict[int, dict] = {**text_accumulator}
                 merged_items.update(item_accumulator)
                 if merged_items:
@@ -333,7 +351,7 @@ class ChatGPTResponsesAPIConfig(OpenAIResponsesAPIConfig):
         raw_headers: Final = dict(raw_response.headers)
         processed_headers: Final = process_response_headers(raw_headers)
         if not hasattr(completed_response, "_hidden_params"):
-            setattr(completed_response, "_hidden_params", {})
+            completed_response._hidden_params = {}
         completed_response._hidden_params["additional_headers"] = processed_headers
         completed_response._hidden_params["headers"] = raw_headers
 

--- a/tests/test_litellm/llms/chatgpt/responses/test_chatgpt_responses_transformation.py
+++ b/tests/test_litellm/llms/chatgpt/responses/test_chatgpt_responses_transformation.py
@@ -447,3 +447,104 @@ class TestChatGPTResponsesAPITransformation:
         )
 
         assert completed_event_b.response.output == []
+
+    def test_transform_streaming_response_cleans_up_accumulator_state_on_completion(
+        self,
+    ):
+        """`_chatgpt_streamed_output_items`/`_chatgpt_text_only_output_items`
+        must be popped off `model_call_details` once the completed event is
+        handled -- otherwise a logging callback that reads
+        `kwargs`/`model_call_details` directly (rather than only the
+        redacted typed response) could export the raw recovered response
+        text even when `litellm.turn_off_message_logging` is set, since
+        `redact_message_input_output_from_logging` only scrubs a fixed set
+        of recognized fields and has no knowledge of these two custom keys.
+        """
+        config = ChatGPTResponsesAPIConfig()
+        logging_obj = MagicMock()
+        logging_obj.model_call_details = {}
+
+        streamed_item = {
+            "type": "message",
+            "role": "assistant",
+            "content": [{"type": "output_text", "text": "Sensitive content"}],
+        }
+        config.transform_streaming_response(
+            model="chatgpt/gpt-5.4",
+            parsed_chunk={
+                "type": "response.output_item.done",
+                "output_index": 0,
+                "item": streamed_item,
+            },
+            logging_obj=logging_obj,
+        )
+        assert "_chatgpt_streamed_output_items" in logging_obj.model_call_details
+
+        config.transform_streaming_response(
+            model="chatgpt/gpt-5.4",
+            parsed_chunk={
+                "type": "response.completed",
+                "response": {
+                    "id": "resp_test",
+                    "object": "response",
+                    "created_at": 1700000000,
+                    "status": "completed",
+                    "model": "gpt-5.4",
+                    "output": [],
+                },
+            },
+            logging_obj=logging_obj,
+        )
+
+        assert "_chatgpt_streamed_output_items" not in logging_obj.model_call_details
+        assert "_chatgpt_text_only_output_items" not in logging_obj.model_call_details
+
+    @pytest.mark.parametrize(
+        "terminal_event_type",
+        ["response.failed", "response.incomplete"],
+    )
+    def test_transform_streaming_response_cleans_up_accumulator_state_on_failure(
+        self, terminal_event_type
+    ):
+        """Same cleanup must happen on failed/incomplete terminal events, not
+        just on a successful completion -- a response that errors out
+        mid-stream must not leave recovered content sitting un-redacted in
+        `model_call_details` either."""
+        config = ChatGPTResponsesAPIConfig()
+        logging_obj = MagicMock()
+        logging_obj.model_call_details = {}
+
+        streamed_item = {
+            "type": "message",
+            "role": "assistant",
+            "content": [{"type": "output_text", "text": "Partial before failure"}],
+        }
+        config.transform_streaming_response(
+            model="chatgpt/gpt-5.4",
+            parsed_chunk={
+                "type": "response.output_item.done",
+                "output_index": 0,
+                "item": streamed_item,
+            },
+            logging_obj=logging_obj,
+        )
+        assert "_chatgpt_streamed_output_items" in logging_obj.model_call_details
+
+        config.transform_streaming_response(
+            model="chatgpt/gpt-5.4",
+            parsed_chunk={
+                "type": terminal_event_type,
+                "response": {
+                    "id": "resp_test",
+                    "object": "response",
+                    "created_at": 1700000000,
+                    "status": "failed",
+                    "model": "gpt-5.4",
+                    "output": [],
+                },
+            },
+            logging_obj=logging_obj,
+        )
+
+        assert "_chatgpt_streamed_output_items" not in logging_obj.model_call_details
+        assert "_chatgpt_text_only_output_items" not in logging_obj.model_call_details

--- a/tests/test_litellm/llms/chatgpt/responses/test_chatgpt_responses_transformation.py
+++ b/tests/test_litellm/llms/chatgpt/responses/test_chatgpt_responses_transformation.py
@@ -10,12 +10,11 @@ from unittest.mock import MagicMock, patch
 import httpx
 import pytest
 
-
+from litellm.llms.chatgpt.responses.transformation import ChatGPTResponsesAPIConfig
 from litellm.llms.openai.common_utils import OpenAIError
 from litellm.types.router import GenericLiteLLMParams
 from litellm.types.utils import LlmProviders
 from litellm.utils import ProviderConfigManager
-from litellm.llms.chatgpt.responses.transformation import ChatGPTResponsesAPIConfig
 
 
 class TestChatGPTResponsesAPITransformation:
@@ -323,3 +322,128 @@ class TestChatGPTResponsesAPITransformation:
 
         assert "ChatGPT upstream failed" in str(exc_info.value)
         assert exc_info.value.status_code == 502
+
+    def test_transform_streaming_response_recovers_output_from_live_chunks(self):
+        """chatgpt.com always ships `response.completed.output: []` (see the
+        non-streaming recovery tests above) -- but this provider also always
+        forces `stream=True` upstream, so `transform_streaming_response`,
+        not `transform_response_api_response`, is what actually runs on
+        every real call (BerriAI/litellm#25429, #27175). Without accumulating
+        `output_item.done`/`output_text.done` chunks here, the completed
+        event's `output` stays empty and the Responses-to-Chat-Completions
+        bridge raises "Unknown items in responses API response: []".
+        """
+        config = ChatGPTResponsesAPIConfig()
+        logging_obj = MagicMock()
+        logging_obj.model_call_details = {}
+
+        streamed_item = {
+            "type": "message",
+            "role": "assistant",
+            "content": [{"type": "output_text", "text": "Hello from stream!"}],
+        }
+        item_done_event = config.transform_streaming_response(
+            model="chatgpt/gpt-5.4",
+            parsed_chunk={
+                "type": "response.output_item.done",
+                "output_index": 0,
+                "item": streamed_item,
+            },
+            logging_obj=logging_obj,
+        )
+        # Passthrough chunks are still forwarded to the base transform.
+        assert item_done_event.type == "response.output_item.done"
+
+        completed_event = config.transform_streaming_response(
+            model="chatgpt/gpt-5.4",
+            parsed_chunk={
+                "type": "response.completed",
+                "response": {
+                    "id": "resp_test",
+                    "object": "response",
+                    "created_at": 1700000000,
+                    "status": "completed",
+                    "model": "gpt-5.4",
+                    "output": [],
+                },
+            },
+            logging_obj=logging_obj,
+        )
+
+        assert completed_event.response.output == [streamed_item]
+
+    def test_transform_streaming_response_leaves_populated_output_untouched(self):
+        """A completed event that already carries real output (the standard
+        OpenAI shape) must not be altered by the recovery logic."""
+        config = ChatGPTResponsesAPIConfig()
+        logging_obj = MagicMock()
+        logging_obj.model_call_details = {}
+
+        real_output_item = {
+            "type": "message",
+            "role": "assistant",
+            "content": [{"type": "output_text", "text": "Already there"}],
+        }
+        completed_event = config.transform_streaming_response(
+            model="chatgpt/gpt-5.4",
+            parsed_chunk={
+                "type": "response.completed",
+                "response": {
+                    "id": "resp_test",
+                    "object": "response",
+                    "created_at": 1700000000,
+                    "status": "completed",
+                    "model": "gpt-5.4",
+                    "output": [real_output_item],
+                },
+            },
+            logging_obj=logging_obj,
+        )
+
+        assert completed_event.response.output == [real_output_item]
+
+    def test_transform_streaming_response_state_scoped_per_request(self):
+        """Accumulator state must live on `logging_obj.model_call_details`
+        (per-request), not on the shared, long-lived `ChatGPTResponsesAPIConfig`
+        instance -- otherwise output from one concurrent call could leak into
+        another call's completed event on a proxy serving multiple requests.
+        """
+        config = ChatGPTResponsesAPIConfig()
+
+        logging_obj_a = MagicMock()
+        logging_obj_a.model_call_details = {}
+        item_a = {
+            "type": "message",
+            "role": "assistant",
+            "content": [{"type": "output_text", "text": "From request A"}],
+        }
+        config.transform_streaming_response(
+            model="chatgpt/gpt-5.4",
+            parsed_chunk={
+                "type": "response.output_item.done",
+                "output_index": 0,
+                "item": item_a,
+            },
+            logging_obj=logging_obj_a,
+        )
+
+        # A second, independent request must not see request A's accumulated item.
+        logging_obj_b = MagicMock()
+        logging_obj_b.model_call_details = {}
+        completed_event_b = config.transform_streaming_response(
+            model="chatgpt/gpt-5.4",
+            parsed_chunk={
+                "type": "response.completed",
+                "response": {
+                    "id": "resp_test_b",
+                    "object": "response",
+                    "created_at": 1700000000,
+                    "status": "completed",
+                    "model": "gpt-5.4",
+                    "output": [],
+                },
+            },
+            logging_obj=logging_obj_b,
+        )
+
+        assert completed_event_b.response.output == []


### PR DESCRIPTION
Fixes #25429, #27175

## The bug

ChatGPT/Codex OAuth models always force `stream=True` on the outbound request to chatgpt.com (`ChatGPTResponsesAPIConfig.transform_responses_api_request`), which means `response_api_handler()` always takes its streaming branch for this provider — the existing `output`-recovery logic in `transform_response_api_response()` (`_extract_completed_response_from_sse`/`_build_completed_response_from_chunk`) is dead code for ChatGPT, since it only runs on the non-streaming branch.

chatgpt.com's terminal `response.completed` event always ships `output: []`; the real content only appears in `output_item.done`/`output_text.done` events earlier in the stream. Any caller going through the `/chat/completions`-to-Responses bridge (`litellm.completion()`, or an HTTP `/chat/completions` call against a `mode: responses` model) hits this and gets:

```
litellm.APIConnectionError: APIConnectionError: ChatgptException - Unknown items in responses API response: []
```

on every single call — reproduced 100% of the time, both with `stream: false` explicit and the key omitted entirely. This is not about the *caller's* streaming preference (that's a separate, correctly-handled concern) — it fires regardless.

### Repro

```bash
curl -s http://localhost:4000/chat/completions \
  -H "Content-Type: application/json" -H "Authorization: Bearer $LITELLM_MASTER_KEY" \
  -d '{"model":"<your-chatgpt-model-alias>","messages":[{"role":"user","content":"Say OK"}]}'
```

or

```python
import litellm
litellm.completion(model="chatgpt/gpt-5.6-terra", messages=[{"role": "user", "content": "Say OK"}])
```

## The fix

Adds `ChatGPTResponsesAPIConfig.transform_streaming_response()`, reusing the same `record_output_item_chunk`/`record_output_text_chunk` helpers the (unreachable, for this provider) non-streaming path already depends on, to accumulate output live as the stream arrives and merge it into the completed event before it's turned into a typed object.

Accumulator state lives on `logging_obj.model_call_details` (a per-request dict, matching this codebase's own existing pattern — see the `original_response` key used elsewhere) rather than on `self`, since `ChatGPTResponsesAPIConfig` is a shared, long-lived provider-config instance reused across every request — state on `self` would leak between concurrent callers on a proxy serving multiple users.

## Verified

Against three real Codex/ChatGPT OAuth models (`gpt-5.6-terra`, `-sol`, `-luna`) through a live proxy:

- `POST /chat/completions` with `"stream": false` → clean `{"choices":[{"message":{"content":"OK",...}}]}`
- `POST /chat/completions` with no `stream` key at all (defaults non-streaming) → same, clean
- `POST /chat/completions` with `"stream": true` → unaffected, still correct SSE chunks (no regression)
- `litellm.completion(model="chatgpt/gpt-5.6-terra", ...)` in Python → works, `.choices[0].message.content == "OK"`

All of the above reproduced the crash 100% of the time before this fix; 100% clean after.

## Not addressed here (flagging as separate follow-ups; kept this patch minimal)

- `litellm.responses(model="chatgpt/...", stream=False)` — the native, non-bridged entry point — still returns a `SyncResponsesAPIStreamingIterator` instead of resolving to a plain `ResponsesAPIResponse`, even when the caller explicitly asks for non-streaming. Doesn't crash, but is inconsistent with every other provider's `stream=False` contract. Root cause is the same `stream = bool(stream or data.get("stream"))` line in `llm_http_handler.py`'s `response_api_handler()` — a proper fix means decoupling "should we stream the *upstream* HTTP request" (always yes, for ChatGPT) from "should we hand the *caller* a stream or a resolved object" (whatever they asked for).
- `logging_obj.model_call_details.get("original_response")` is set to the literal placeholder string `"first stream response received"` rather than real content in `llm_http_handler.py`'s streaming helpers — looks like dead/broken code for the `_recover_output_items_from_logging` fallback in every provider's bridge path, not ChatGPT-specific. Left untouched since this fix makes it unnecessary for ChatGPT specifically, but flagging for whoever's more familiar with why that placeholder exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)