### PR TITLE
fix(deps): raise RestrictedPython floor to 8.3 to clear GHSA-ffg3-p8fm-mjx2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,7 +69,7 @@ proxy = [
     "mcp>=1.28.1,<2.0",
     "litellm-proxy-extras==0.4.90",
     "litellm-enterprise==0.1.61",
-    "RestrictedPython>=8.1,<9.0",
+    "RestrictedPython>=8.3,<9.0",
     "rich>=13.9.4,<14.0",
     "InquirerPy>=0.3.4,<1.0",
     "polars>=1.38.1,<2.0",

--- a/uv.lock
+++ b/uv.lock
@@ -10,7 +10,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-08-24T20:19:42.376246Z"
+exclude-newer = "2026-08-26T00:49:23.065531Z"
 exclude-newer-span = "P3D"
 
 [manifest]
@@ -4558,7 +4558,7 @@ requires-dist = [
     { name = "redisvl", marker = "extra == 'extra-proxy'", specifier = ">=0.4.1,<1.0" },
     { name = "requests", marker = "extra == 'cli'", specifier = ">=2.32.0,<3.0" },
     { name = "resend", marker = "extra == 'extra-proxy'", specifier = ">=2.23.0,<3.0" },
-    { name = "restrictedpython", marker = "extra == 'proxy'", specifier = ">=8.1,<9.0" },
+    { name = "restrictedpython", marker = "extra == 'proxy'", specifier = ">=8.3,<9.0" },
     { name = "rich", marker = "extra == 'cli'", specifier = ">=13.9.4,<14.0" },
     { name = "rich", marker = "extra == 'proxy'", specifier = ">=13.9.4,<14.0" },
     { name = "rq", marker = "extra == 'proxy'", specifier = ">=2.7.0,<3.0" },
@@ -8265,11 +8265,11 @@ wheels = [
 
 [[package]]
 name = "restrictedpython"
-version = "8.1"
+version = "8.5"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/5f/1c/aec08bcb4ab14a1521579fbe21ceff2a634bb1f737f11cf7f9c8bb96e680/restrictedpython-8.1.tar.gz", hash = "sha256:4a69304aceacf6bee74bdf153c728221d4e3109b39acbfe00b3494927080d898", size = 838331, upload-time = "2025-10-19T14:11:32.531Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7c/3b/8e41f7cfabbb30b1013ebc7484303d6c87da2906ec432d69dea11d2f7d75/restrictedpython-8.5.tar.gz", hash = "sha256:4ed1269dbe3caa88db650d1af325198a952aeb1451eca05df0cfa65db4466215", size = 455879, upload-time = "2026-08-19T07:02:10.934Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1a/c0/3848f4006f7e164ee20833ca984067e4b3fc99fe7f1dfa88b4927e681299/restrictedpython-8.1-py3-none-any.whl", hash = "sha256:4769449c6cdb10f2071649ba386902befff0eff2a8fd6217989fa7b16aeae926", size = 27651, upload-time = "2025-10-19T14:11:30.201Z" },
+    { url = "https://files.pythonhosted.org/packages/58/57/16ce3c721f5a33317e4110575d5c9976c0c45f7fd96ca2e0adeab06e6026/restrictedpython-8.5-py3-none-any.whl", hash = "sha256:6c70e0a3af13e830d37225788cdc8ab5804a8df4b500c135086eaef34b5c01e0", size = 30962, upload-time = "2026-08-19T07:02:09.553Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## TLDR

Problem this solves:

- osv-scan turned red on every PR tonight
- uv.lock pins RestrictedPython 8.1, hit by GHSA-ffg3-p8fm-mjx2 (High, CVSS 8.3)
- The advisory was just published, so previously green scans now fail

How it solves it:

- Raise the RestrictedPython floor to >=8.3 (the fixed release)
- Re-lock the one package; uv resolved it to 8.5
- Custom-code sandbox guardrail tests pass on 8.5

## User Flow

Before: every contributor's PR fails a required check for a dependency they never touched

1. A contributor pushes any commit to any open PR
2. The osv-scan check on their PR goes red with "Total 1 package affected by 1 known vulnerability (0 Critical, 1 High ...)" naming restrictedpython 8.1, fixed in 8.3
3. Their PR cannot go fully green no matter what they change

After: the scan is clean again

1. The contributor rebases or the merge commit picks up this lockfile
2. The osv-scan check on their PR passes with no findings
3. Their PR can go fully green

## Relevant issues

- https://osv.dev/GHSA-ffg3-p8fm-mjx2 (RestrictedPython information disclosure in try/except*, fixed in 8.3)

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have added meaningful tests (dependency bump; the existing sandbox guardrail suite covers the library)
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

### Before (cbdaa3b153)

1. osv-scan job against the unchanged lockfile (run 33224256228, job 99024612539):

```
Total 1 package affected by 1 known vulnerability (0 Critical, 1 High, 0 Medium, 0 Low, 0 Unknown) from 1 ecosystem.
1 vulnerability can be fixed.
| https://osv.dev/GHSA-ffg3-p8fm-mjx2 | 8.3  | PyPI      | restrictedpython | 8.1     | 8.3           | uv.lock |
##[error]Process completed with exit code 1.
```

### After (tip of this PR)

1. `uv lock --upgrade-package restrictedpython` resolved `restrictedpython v8.1 -> v8.5`; the uv.lock diff touches only the restrictedpython entry and the resolver's exclude-newer stamp
2. `.venv/bin/python -c "from importlib.metadata import version; print(version('RestrictedPython'))"` prints `8.5`
3. `uv run pytest tests/test_litellm/proxy/guardrails/test_custom_code_security.py -q` gives `18 passed` (the RestrictedPython-backed sandbox guardrail)
4. This PR's own osv-scan check is the live proof: it runs the scanner against the bumped lockfile

## Type

🚄 Infrastructure

## Caveats (if any)

### Low

- Floor moves 8.1 to 8.3; both are in the same major, and the only in-repo consumer is the custom-code sandbox

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
