### PR TITLE
fix(aws): forward aws_external_id in Bedrock embeddings and SageMaker credential loading

### DIFF
--- a/litellm/llms/bedrock/embed/embedding.py
+++ b/litellm/llms/bedrock/embed/embedding.py
@@ -58,6 +58,7 @@ class BedrockEmbedding(BaseAWSLLM):
         aws_profile_name: Final = optional_params.pop("aws_profile_name", None)
         aws_web_identity_token: Final = optional_params.pop("aws_web_identity_token", None)
         aws_sts_endpoint: Final = optional_params.pop("aws_sts_endpoint", None)
+        aws_external_id: Final = optional_params.pop("aws_external_id", None)
 
         ### SET REGION NAME ###
         if aws_region_name is None:
@@ -84,6 +85,7 @@ class BedrockEmbedding(BaseAWSLLM):
             aws_role_name=aws_role_name,
             aws_web_identity_token=aws_web_identity_token,
             aws_sts_endpoint=aws_sts_endpoint,
+            aws_external_id=aws_external_id,
         )
         return credentials, aws_region_name
 

--- a/litellm/llms/sagemaker/chat/handler.py
+++ b/litellm/llms/sagemaker/chat/handler.py
@@ -34,6 +34,7 @@ class SagemakerChatHandler(BaseAWSLLM):
         optional_params.pop("aws_bedrock_runtime_endpoint", None)  # https://bedrock-runtime.{region_name}.amazonaws.com
         aws_web_identity_token: Final = optional_params.pop("aws_web_identity_token", None)
         aws_sts_endpoint: Final = optional_params.pop("aws_sts_endpoint", None)
+        aws_external_id: Final = optional_params.pop("aws_external_id", None)
 
         ### SET REGION NAME ###
         if aws_region_name is None:
@@ -60,6 +61,7 @@ class SagemakerChatHandler(BaseAWSLLM):
             aws_role_name=aws_role_name,
             aws_web_identity_token=aws_web_identity_token,
             aws_sts_endpoint=aws_sts_endpoint,
+            aws_external_id=aws_external_id,
         )
         return credentials, aws_region_name
 

--- a/litellm/llms/sagemaker/completion/handler.py
+++ b/litellm/llms/sagemaker/completion/handler.py
@@ -57,6 +57,7 @@ class SagemakerLLM(BaseAWSLLM):
         optional_params.pop("aws_bedrock_runtime_endpoint", None)  # https://bedrock-runtime.{region_name}.amazonaws.com
         aws_web_identity_token: Final = optional_params.pop("aws_web_identity_token", None)
         aws_sts_endpoint: Final = optional_params.pop("aws_sts_endpoint", None)
+        aws_external_id: Final = optional_params.pop("aws_external_id", None)
 
         ### SET REGION NAME ###
         if aws_region_name is None:
@@ -83,6 +84,7 @@ class SagemakerLLM(BaseAWSLLM):
             aws_role_name=aws_role_name,
             aws_web_identity_token=aws_web_identity_token,
             aws_sts_endpoint=aws_sts_endpoint,
+            aws_external_id=aws_external_id,
         )
         return credentials, aws_region_name
 

--- a/tests/test_litellm/llms/bedrock/embed/test_bedrock_embedding.py
+++ b/tests/test_litellm/llms/bedrock/embed/test_bedrock_embedding.py
@@ -985,3 +985,51 @@ def test_bedrock_cohere_embedding_types_wrapped_as_list(
         assert "embedding_types" in request_body
         assert request_body["embedding_types"] == expected_embedding_types
         assert isinstance(request_body["embedding_types"], list)
+
+
+def test_load_credentials_assumes_role_with_external_id(monkeypatch):
+    """A trust policy requiring sts:ExternalId must be satisfied by the deployment's aws_external_id."""
+    import datetime
+
+    import boto3
+    from botocore.exceptions import ClientError
+
+    from litellm.llms.bedrock.embed.embedding import BedrockEmbedding
+
+    monkeypatch.delenv("AWS_EXTERNAL_ID", raising=False)
+
+    class FakeSTSClient:
+        def get_caller_identity(self):
+            return {"Arn": "arn:aws:iam::111111111111:user/litellm-proxy-pod"}
+
+        def assume_role(self, **params):
+            if params.get("ExternalId") != "external-id-embed":
+                raise ClientError(
+                    {"Error": {"Code": "AccessDenied", "Message": "is not authorized to perform: sts:AssumeRole"}},
+                    "AssumeRole",
+                )
+            return {
+                "Credentials": {
+                    "AccessKeyId": "ASIAEMBEDROLEKEY",
+                    "SecretAccessKey": "assumed-secret",
+                    "SessionToken": "assumed-session-token",
+                    "Expiration": datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(minutes=30),
+                }
+            }
+
+    optional_params = {
+        "aws_access_key_id": "AKIAEMBEDCALLERKEY",
+        "aws_secret_access_key": "pod-caller-secret",
+        "aws_region_name": "us-east-1",
+        "aws_role_name": "arn:aws:iam::999999999999:role/litellm-embed-role",
+        "aws_session_name": "litellm-embed-session",
+        "aws_external_id": "external-id-embed",
+    }
+
+    with patch.object(boto3, "client", return_value=FakeSTSClient()):
+        credentials, aws_region_name = BedrockEmbedding()._load_credentials(optional_params)
+
+    assert credentials.access_key == "ASIAEMBEDROLEKEY"
+    assert credentials.token == "assumed-session-token"
+    assert aws_region_name == "us-east-1"
+    assert "aws_external_id" not in optional_params

--- a/tests/test_litellm/llms/sagemaker/test_sagemaker_chat_handler.py
+++ b/tests/test_litellm/llms/sagemaker/test_sagemaker_chat_handler.py
@@ -1,0 +1,48 @@
+import datetime
+from unittest.mock import patch
+
+import boto3
+from botocore.exceptions import ClientError
+
+from litellm.llms.sagemaker.chat.handler import SagemakerChatHandler
+
+
+def test_load_credentials_assumes_role_with_external_id(monkeypatch):
+    """A trust policy requiring sts:ExternalId must be satisfied by the deployment's aws_external_id."""
+    monkeypatch.delenv("AWS_EXTERNAL_ID", raising=False)
+
+    class FakeSTSClient:
+        def get_caller_identity(self):
+            return {"Arn": "arn:aws:iam::111111111111:user/litellm-proxy-pod"}
+
+        def assume_role(self, **params):
+            if params.get("ExternalId") != "external-id-sm-chat":
+                raise ClientError(
+                    {"Error": {"Code": "AccessDenied", "Message": "is not authorized to perform: sts:AssumeRole"}},
+                    "AssumeRole",
+                )
+            return {
+                "Credentials": {
+                    "AccessKeyId": "ASIASMCHATROLEKEY",
+                    "SecretAccessKey": "assumed-secret",
+                    "SessionToken": "assumed-session-token",
+                    "Expiration": datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(minutes=30),
+                }
+            }
+
+    optional_params = {
+        "aws_access_key_id": "AKIASMCHATCALLERKEY",
+        "aws_secret_access_key": "pod-caller-secret",
+        "aws_region_name": "us-east-1",
+        "aws_role_name": "arn:aws:iam::999999999999:role/litellm-sm-chat-role",
+        "aws_session_name": "litellm-sm-chat-session",
+        "aws_external_id": "external-id-sm-chat",
+    }
+
+    with patch.object(boto3, "client", return_value=FakeSTSClient()):
+        credentials, aws_region_name = SagemakerChatHandler()._load_credentials(optional_params)
+
+    assert credentials.access_key == "ASIASMCHATROLEKEY"
+    assert credentials.token == "assumed-session-token"
+    assert aws_region_name == "us-east-1"
+    assert "aws_external_id" not in optional_params

--- a/tests/test_litellm/llms/sagemaker/test_sagemaker_completion_handler.py
+++ b/tests/test_litellm/llms/sagemaker/test_sagemaker_completion_handler.py
@@ -172,3 +172,50 @@ async def test_async_native_streaming_forwards_each_frame_incrementally():
 
     assert texts == [f"token{i} " for i in range(len(frames))]
     assert consumed_at_token == list(range(1, len(frames) + 1))
+
+
+def test_load_credentials_assumes_role_with_external_id(monkeypatch):
+    """A trust policy requiring sts:ExternalId must be satisfied by the deployment's aws_external_id."""
+    import datetime
+
+    import boto3
+    from botocore.exceptions import ClientError
+    from unittest.mock import patch
+
+    monkeypatch.delenv("AWS_EXTERNAL_ID", raising=False)
+
+    class FakeSTSClient:
+        def get_caller_identity(self):
+            return {"Arn": "arn:aws:iam::111111111111:user/litellm-proxy-pod"}
+
+        def assume_role(self, **params):
+            if params.get("ExternalId") != "external-id-sm-completion":
+                raise ClientError(
+                    {"Error": {"Code": "AccessDenied", "Message": "is not authorized to perform: sts:AssumeRole"}},
+                    "AssumeRole",
+                )
+            return {
+                "Credentials": {
+                    "AccessKeyId": "ASIASMCOMPROLEKEY",
+                    "SecretAccessKey": "assumed-secret",
+                    "SessionToken": "assumed-session-token",
+                    "Expiration": datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(minutes=30),
+                }
+            }
+
+    optional_params = {
+        "aws_access_key_id": "AKIASMCOMPCALLERKEY",
+        "aws_secret_access_key": "pod-caller-secret",
+        "aws_region_name": "us-east-1",
+        "aws_role_name": "arn:aws:iam::999999999999:role/litellm-sm-completion-role",
+        "aws_session_name": "litellm-sm-completion-session",
+        "aws_external_id": "external-id-sm-completion",
+    }
+
+    with patch.object(boto3, "client", return_value=FakeSTSClient()):
+        credentials, aws_region_name = SagemakerLLM()._load_credentials(optional_params)
+
+    assert credentials.access_key == "ASIASMCOMPROLEKEY"
+    assert credentials.token == "assumed-session-token"
+    assert aws_region_name == "us-east-1"
+    assert "aws_external_id" not in optional_params


### PR DESCRIPTION
## TLDR

Problem this solves:

- Bedrock embeddings dropped `aws_external_id` before assuming the role
- Both SageMaker handlers dropped it the same way
- Roles whose trust policy requires an ExternalId fail with STS AccessDenied
- The Bedrock chat path already forwarded it, so only these paths broke

How it solves it:

- Pop `aws_external_id` from the request params in each path
- Forward it to the shared credential loader, matching the chat path and #38376

## User Flow

Before: a proxy admin whose IAM role requires an ExternalId gets a 500 on every embeddings and SageMaker request, while chat on the same role works

1. The admin configures three deployments with the same `aws_role_name` and `aws_external_id`: a Bedrock embedding model, a SageMaker endpoint, and a Bedrock chat model
2. They send POST https://litellm-domain/v1/chat/completions with the chat model and get HTTP 200 with a normal reply, proving the role and external id are good
3. They send POST https://litellm-domain/v1/embeddings with `{"model": "bedrock-embed", "input": "hello external id"}` and get HTTP 500: "AccessDenied when calling the AssumeRole operation: User ... is not authorized to perform: sts:AssumeRole"
4. They send POST https://litellm-domain/v1/completions with the SageMaker model and get the same HTTP 500 AccessDenied

After: the same embeddings and SageMaker requests succeed with no config change

1. The admin configures three deployments with the same `aws_role_name` and `aws_external_id`: a Bedrock embedding model, a SageMaker endpoint, and a Bedrock chat model
2. They send POST https://litellm-domain/v1/chat/completions with the chat model and get HTTP 200 with a normal reply, proving the role and external id are good
3. They send POST https://litellm-domain/v1/embeddings with `{"model": "bedrock-embed", "input": "hello external id"}` and get HTTP 200 with a 1024-dimension embedding
4. They send POST https://litellm-domain/v1/completions with the SageMaker model and get HTTP 200 with generated text from their endpoint

## Relevant issues

## Linear ticket

Resolves LIT-6341

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Shared setup, all against real AWS (account 654278500801). IAM user `litellm-lit6341-proxy` can only `sts:AssumeRole` into role `litellm-lit6341-extid-qa`, whose trust policy requires `sts:ExternalId == lit6341-qa-external-id`; the role allows `bedrock:InvokeModel` and `sagemaker:InvokeEndpoint`. The SageMaker model is a real serverless endpoint (`litellm-lit6341-distilgpt2`, us-east-1, InService). The proxy env carries only that user's access key pair: no `AWS_EXTERNAL_ID`, no bearer token

```yaml
model_list:
  - model_name: bedrock-embed
    litellm_params:
      model: bedrock/amazon.titan-embed-text-v2:0
      aws_region_name: us-east-1
      aws_role_name: arn:aws:iam::654278500801:role/litellm-lit6341-extid-qa
      aws_session_name: lit6341-embed
      aws_external_id: lit6341-qa-external-id
  - model_name: sagemaker-comp
    litellm_params:
      model: sagemaker/litellm-lit6341-distilgpt2
      aws_region_name: us-east-1
      aws_role_name: arn:aws:iam::654278500801:role/litellm-lit6341-extid-qa
      aws_session_name: lit6341-sm
      aws_external_id: lit6341-qa-external-id
  - model_name: bedrock-chat-control
    litellm_params:
      model: bedrock/converse/us.amazon.nova-lite-v1:0
      aws_region_name: us-east-1
      aws_role_name: arn:aws:iam::654278500801:role/litellm-lit6341-extid-qa
      aws_session_name: lit6341-chat
      aws_external_id: lit6341-qa-external-id

general_settings:
  master_key: sk-lit6341-qa
```

```bash
env -i HOME=$HOME PATH=$PATH \
  AWS_ACCESS_KEY_ID=$AWS_LIT6341_QA_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY=$AWS_LIT6341_QA_SECRET_ACCESS_KEY \
  python litellm/proxy/proxy_cli.py --config lit6341_config.yaml --port $PORT --num_workers 2
```

Each leg ran with 2 uvicorn workers (before leg on port 31516, after leg on 20959), and every curl below was sent twice per leg so both workers served requests

### Before (ae7e50f096, the merge base)

#### Bedrock embeddings (/v1/embeddings)

1. `curl http://localhost:$PORT/v1/embeddings -H 'Authorization: Bearer sk-lit6341-qa' -H 'Content-Type: application/json' -d '{"model":"bedrock-embed","input":"hello external id"}'`
2. HTTP 500 on both tries: `litellm.APIConnectionError: An error occurred (AccessDenied) when calling the AssumeRole operation: User: arn:aws:iam::654278500801:user/litellm-lit6341-proxy is not authorized to perform: sts:AssumeRole on resource: arn:aws:iam::654278500801:role/litellm-lit6341-extid-qa`

#### SageMaker completion (/v1/completions)

1. `curl http://localhost:$PORT/v1/completions -H 'Authorization: Bearer sk-lit6341-qa' -H 'Content-Type: application/json' -d '{"model":"sagemaker-comp","prompt":"The capital of France is","max_tokens":10}'`
2. HTTP 500 on both tries: same `AccessDenied` on the AssumeRole operation

#### Bedrock chat control (/v1/chat/completions)

1. `curl http://localhost:$PORT/v1/chat/completions -H 'Authorization: Bearer sk-lit6341-qa' -H 'Content-Type: application/json' -d '{"model":"bedrock-chat-control","messages":[{"role":"user","content":"Say hi in three words"}]}'`
2. HTTP 200 on both tries: a short Nova greeting with real usage. Same role and external id as the failing paths, so the credentials are proven good and the drop is isolated to embeddings and SageMaker

### After (d7bd6ca614, PR head; it only adds a no-conflict sync merge from litellm_internal_staging on top of the QA'd diff)

#### Bedrock embeddings (/v1/embeddings)

1. Same curl as Before
2. HTTP 200 on both tries: `"model": "bedrock-embed"` with a 1024-dimension embedding

#### SageMaker completion (/v1/completions)

1. Same curl as Before
2. HTTP 200 on both tries, e.g. `"text": "The capital of France is being rebuilt into a thriving tourist destination. (B"` from the live serverless endpoint

#### Bedrock chat control (/v1/chat/completions)

1. Same curl as Before
2. HTTP 200 on both tries with a normal Nova greeting and real usage, confirming no regression on the already-working path

## Type

🐛 Bug Fix

## Caveats (if any)

### Medium

- Bedrock files and batches-signing paths still drop `aws_external_id` (files handler and transformation call sites, plus `sign_aws_request` in common_utils); the `AWS_EXTERNAL_ID` env var is the workaround and the fix is tracked in LIT-6460

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

- [x] d7bd6ca614 passes /live-pr-risk


