### PR TITLE
fix(cache_control): let a hosted deployment opt into the OpenAI cache dialect

### DIFF
--- a/litellm/integrations/anthropic_cache_control_hook.py
+++ b/litellm/integrations/anthropic_cache_control_hook.py
@@ -12,7 +12,7 @@ Supported for both `v1/chat/completions` (via the prompt-management hook) and
 import copy
 import os
 import re
-from collections.abc import Iterable, Mapping, Sequence
+from collections.abc import Callable, Iterable, Mapping, Sequence
 from typing import TYPE_CHECKING, Any, Final, cast
 from urllib.parse import urlparse
 
@@ -102,6 +102,27 @@ def _model_map_prompt_cache_breakpoint_flag(model: str) -> bool | None:
     entries: Final = (litellm.model_cost.get(key) for key in (model, model.rsplit("/", 1)[-1]))
     flags: Final = (entry.get("supports_prompt_cache_breakpoint") for entry in entries if isinstance(entry, dict))
     return next((bool(flag) for flag in flags if flag is not None), None)
+
+
+def _hosted_openai_dialect_flag(model: str, resolve_provider: Callable[[], str | None]) -> bool | None:
+    """
+    Explicit opt-in for an OpenAI-shaped deployment served by another provider.
+
+    ``model_cost`` is keyed per exact deployment string, so a flag on the deployment's
+    own entry states the dialect directly, which a provider name cannot express. Entries
+    for the openai provider are left to the caller's api_base check, so an
+    OpenAI-compatible third-party host is still not assumed to speak the dialect.
+    """
+    import litellm
+
+    entry: Final = litellm.model_cost.get(model)
+    if not isinstance(entry, dict):
+        return None
+    flag: Final = entry.get("supports_prompt_cache_breakpoint")
+    entry_provider: Final = entry.get("litellm_provider")
+    if flag is None or entry_provider is None or entry_provider == "openai":
+        return None
+    return bool(flag) if entry_provider == resolve_provider() else None
 
 
 def targets_openai_api(api_base: object) -> bool:
@@ -269,7 +290,14 @@ class AnthropicCacheControlHook(CustomPromptManagement):
         api_base: object = None,
         prompt_cache_options: object = None,
     ) -> bool:
-        if model is None or not supports_openai_prompt_cache_breakpoint(model):
+        if model is None:
+            return False
+        hosted_flag: Final = _hosted_openai_dialect_flag(
+            model, lambda: custom_llm_provider or AnthropicCacheControlHook._resolve_provider(model)
+        )
+        if hosted_flag is not None:
+            return hosted_flag
+        if not supports_openai_prompt_cache_breakpoint(model):
             return False
         if (custom_llm_provider or AnthropicCacheControlHook._resolve_provider(model)) != "openai":
             return False

--- a/tests/test_litellm/integrations/test_anthropic_cache_control_hook.py
+++ b/tests/test_litellm/integrations/test_anthropic_cache_control_hook.py
@@ -3049,6 +3049,81 @@ class TestPromptCacheBreakpointCapability:
         assert supports_openai_prompt_cache_breakpoint(model) is expected
 
 
+class TestHostedOpenAIDialectFlag:
+    """#38666: an OpenAI-shaped model served by another provider can opt in through its own
+    model-map entry, instead of being excluded by the openai-only provider check."""
+
+    MANTLE_MODEL = "bedrock_mantle/openai.gpt-5.6-sol"
+
+    def _register(self, monkeypatch, key, provider, flag=True, **extra):
+        entry = {"litellm_provider": provider, "mode": "chat", **extra}
+        if flag is not None:
+            entry["supports_prompt_cache_breakpoint"] = flag
+        monkeypatch.setitem(litellm.model_cost, key, entry)
+
+    def test_flagged_non_openai_deployment_is_eligible(self, monkeypatch):
+        self._register(monkeypatch, self.MANTLE_MODEL, "bedrock_mantle")
+        assert (
+            AnthropicCacheControlHook._targets_openai_prompt_cache_breakpoint(self.MANTLE_MODEL, "bedrock_mantle")
+            is True
+        )
+
+    def test_bedrock_api_base_does_not_veto_the_explicit_flag(self, monkeypatch):
+        """The api_base check exists to sniff for api.openai.com, which a Bedrock host never is."""
+        self._register(monkeypatch, self.MANTLE_MODEL, "bedrock_mantle")
+        assert (
+            AnthropicCacheControlHook._targets_openai_prompt_cache_breakpoint(
+                self.MANTLE_MODEL,
+                "bedrock_mantle",
+                api_base="https://bedrock-runtime.us-east-1.amazonaws.com",
+            )
+            is True
+        )
+
+    def test_flag_set_false_keeps_the_deployment_ineligible(self, monkeypatch):
+        self._register(monkeypatch, self.MANTLE_MODEL, "bedrock_mantle", flag=False)
+        assert (
+            AnthropicCacheControlHook._targets_openai_prompt_cache_breakpoint(self.MANTLE_MODEL, "bedrock_mantle")
+            is False
+        )
+
+    def test_unflagged_non_openai_deployment_stays_ineligible(self, monkeypatch):
+        self._register(monkeypatch, self.MANTLE_MODEL, "bedrock_mantle", flag=None)
+        assert (
+            AnthropicCacheControlHook._targets_openai_prompt_cache_breakpoint(self.MANTLE_MODEL, "bedrock_mantle")
+            is False
+        )
+
+    def test_entry_provider_must_match_the_request_provider(self, monkeypatch):
+        """A flagged entry does not license a different provider serving the same model string."""
+        self._register(monkeypatch, self.MANTLE_MODEL, "bedrock_mantle")
+        assert (
+            AnthropicCacheControlHook._targets_openai_prompt_cache_breakpoint(self.MANTLE_MODEL, "azure") is False
+        )
+
+    def test_openai_entries_still_go_through_the_api_base_check(self, monkeypatch):
+        """gpt-5.6 is flagged and openai-provided, so it must not bypass the host gate."""
+        assert litellm.model_cost["gpt-5.6"]["supports_prompt_cache_breakpoint"] is True
+        assert litellm.model_cost["gpt-5.6"]["litellm_provider"] == "openai"
+        assert (
+            AnthropicCacheControlHook._targets_openai_prompt_cache_breakpoint(
+                "gpt-5.6", "openai", api_base="https://some-compatible-host.example.com"
+            )
+            is False
+        )
+
+    def test_azure_hosted_gpt_5_6_remains_ineligible(self):
+        """Regression guard: the openai entry's flag must not leak to another provider."""
+        assert AnthropicCacheControlHook._targets_openai_prompt_cache_breakpoint("gpt-5.6", "azure") is False
+        assert AnthropicCacheControlHook._targets_openai_prompt_cache_breakpoint("azure/gpt-5.6", None) is False
+
+    def test_provider_is_not_resolved_when_no_flag_is_present(self):
+        """The cheap model-map lookup must short-circuit before the provider lookup."""
+        with patch.object(AnthropicCacheControlHook, "_resolve_provider") as resolve:
+            assert AnthropicCacheControlHook._targets_openai_prompt_cache_breakpoint("gpt-4.1", None) is False
+        resolve.assert_not_called()
+
+
 class TestRecordGatewayInjection:
     """The injection marker spend accounting gates prompt-caching savings on."""
 

--- a/tests/test_litellm/integrations/test_anthropic_cache_control_hook.py
+++ b/tests/test_litellm/integrations/test_anthropic_cache_control_hook.py
@@ -3117,12 +3117,6 @@ class TestHostedOpenAIDialectFlag:
         assert AnthropicCacheControlHook._targets_openai_prompt_cache_breakpoint("gpt-5.6", "azure") is False
         assert AnthropicCacheControlHook._targets_openai_prompt_cache_breakpoint("azure/gpt-5.6", None) is False
 
-    def test_provider_is_not_resolved_when_no_flag_is_present(self):
-        """The cheap model-map lookup must short-circuit before the provider lookup."""
-        with patch.object(AnthropicCacheControlHook, "_resolve_provider") as resolve:
-            assert AnthropicCacheControlHook._targets_openai_prompt_cache_breakpoint("gpt-4.1", None) is False
-        resolve.assert_not_called()
-
 
 class TestRecordGatewayInjection:
     """The injection marker spend accounting gates prompt-caching savings on."""


### PR DESCRIPTION
## TLDR

Problem this solves:

- An OpenAI-shaped model on another provider can never use `prompt_cache_breakpoint`
- The provider check runs even when the model map already answered
- Setting the flag explicitly on the deployment has no effect

How it solves it:

- Read the deployment's own model-map flag before the provider check
- Require the entry's provider to match the one serving the request
- Leave openai entries on their existing `api_base` check

## User Flow

Before: a team routing OpenAI-shaped models through Bedrock gets no prompt caching, and there is no setting that turns it on

1. They add a deployment with `litellm_params.model = "bedrock_mantle/openai.gpt-5.6-sol"`
2. They set `supports_prompt_cache_breakpoint: true` on that model's cost-map entry, which reads like the switch for this
3. They send a chat completion with a ~2500 token system prefix and an explicit `prompt_cache_breakpoint`
4. The breakpoint is stripped before the request leaves, so usage comes back with no `cache_write_tokens` and no `cached_tokens`
5. Every repeat call re-reads the whole prefix at full input price, even though the provider would have cached it

After: the explicit flag is honoured, and the same deployment caches

1. They add the same `bedrock_mantle/openai.gpt-5.6-sol` deployment
2. They set the same `supports_prompt_cache_breakpoint: true` on its entry
3. They send the same request, and the cold call reports `cache_write_tokens: 2514`
4. The repeat call with the same prefix reports `cached_tokens: 2514`, billed at the cache-read rate
5. A deployment without the flag, and one on a provider the entry does not name, are both unchanged

## Relevant issues

Fixes #38666

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Narrower than the issue asked for, on purpose

The issue suggests skipping the provider and host checks whenever the model-map flag is set. Taken literally that also flips two cases the current tests require to stay ineligible, because `_model_map_prompt_cache_breakpoint_flag` falls back to the bare model name: `azure/gpt-5.6` and `("gpt-5.6", "azure")` would both start injecting off the openai `gpt-5.6` entry's flag.

So the flag is authoritative only when the entry is the deployment's own, meaning an exact key match whose `litellm_provider` equals the provider serving the request, and only for non-openai providers. openai entries keep their `api_base` check, so an OpenAI-compatible third-party host still is not assumed to speak the dialect. That fixes the reported `bedrock_mantle` case and leaves every existing case alone.

## Screenshots / Proof of Fix

I have no AWS Bedrock credentials, so the end-to-end cache-token evidence in the issue is the reporter's, not mine. What I can show is the gate itself flipping, and that it flips only where it should. The flag lives on the deployment's cost-map entry:

```python
litellm.model_cost["bedrock_mantle/openai.gpt-5.6-sol"] = {
    "litellm_provider": "bedrock_mantle",
    "mode": "chat",
    "supports_prompt_cache_breakpoint": True,
}
```

### Before (4d7144160a)

#### the flagged Bedrock deployment is refused

1. `AnthropicCacheControlHook._targets_openai_prompt_cache_breakpoint("bedrock_mantle/openai.gpt-5.6-sol", "bedrock_mantle")`
2. `False`, so the breakpoint is stripped and nothing is cached

#### cases that must not change

1. `_targets_openai_prompt_cache_breakpoint("gpt-5.6", "azure")` -> `False`
2. `_targets_openai_prompt_cache_breakpoint("azure/gpt-5.6", None)` -> `False`
3. `_targets_openai_prompt_cache_breakpoint("gpt-5.6", "openai", api_base="https://some-compatible-host.example.com")` -> `False`

### After (f0230337c5)

#### the flagged Bedrock deployment is accepted

1. `AnthropicCacheControlHook._targets_openai_prompt_cache_breakpoint("bedrock_mantle/openai.gpt-5.6-sol", "bedrock_mantle")`
2. `True`, and it stays `True` with `api_base="https://bedrock-runtime.us-east-1.amazonaws.com"`
3. With the same entry flagged `false` it is `False`, and with no flag at all it is `False`

#### cases that must not change

1. `_targets_openai_prompt_cache_breakpoint("gpt-5.6", "azure")` -> `False`, unchanged
2. `_targets_openai_prompt_cache_breakpoint("azure/gpt-5.6", None)` -> `False`, unchanged
3. `_targets_openai_prompt_cache_breakpoint("gpt-5.6", "openai", api_base="https://some-compatible-host.example.com")` -> `False`, unchanged

Each line above is an assertion in `TestHostedOpenAIDialectFlag`. Run against the merge base, the two that assert the new behaviour fail and the five guards pass, which is the split you want from a regression test.

## Type

🐛 Bug Fix

## Caveats (if any)

### Medium

- Eligibility now depends on registry metadata, so a wrong `supports_prompt_cache_breakpoint` on a non-openai entry sends breakpoints to a provider that may not accept them
  - Today no shipped entry is affected: all four flagged entries are `openai`, so behaviour is identical until someone flags a non-openai deployment
  - The provider match means a flag can only ever license the provider its own entry names

### Low

- The flag lookup runs before the provider lookup, so it must stay cheap
  - It is a dict lookup that returns early when there is no entry or no flag, and the existing `test_provider_lookup_skipped_for_models_below_gpt_5_6` pins that
- The end-to-end cache-token numbers come from the issue reporter, since this needs Bedrock credentials to reproduce

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Eligibility now trusts per-deployment model-map metadata; a wrong flag on a non-openai entry could send breakpoints to a backend that rejects them, though provider matching limits scope.
> 
> **Overview**
> Fixes deployments like **Bedrock-hosted OpenAI-shaped models** being blocked from **`prompt_cache_breakpoint`** injection even when their **`model_cost`** entry sets **`supports_prompt_cache_breakpoint: true`**, because eligibility previously required provider **`openai`** (and **`api.openai.com`** for native OpenAI entries).
> 
> **`_targets_openai_prompt_cache_breakpoint`** now checks a new **`_hosted_openai_dialect_flag`** first: an **exact** **`model_cost`** key with the flag and a **`litellm_provider`** that **matches the request provider** can opt in **without** the OpenAI host gate—so a Bedrock **`api_base`** no longer vetoes the flag. **`openai`** map entries still use the existing **`api_base` / `prompt_cache_options`** rules, and flags on one provider do **not** apply to Azure or other routes serving similar model strings.
> 
> Adds **`TestHostedOpenAIDialectFlag`** to lock in the Bedrock mantle case and regression guards for Azure, mismatched providers, and third-party OpenAI-compatible hosts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f0230337c57e86347434eae0e5c04c8ce80e5b5b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->