### PR TITLE
feat(models): sync together_ai model registry

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -38941,14 +38941,14 @@
         "source": "https://docs.together.ai/docs/serverless-models"
     },
     "together_ai/Qwen/Qwen3.8-2.4T-A95B": {
-        "cache_read_input_token_cost": 2.5e-07,
-        "input_cost_per_token": 2e-06,
+        "cache_read_input_token_cost": 5e-07,
+        "input_cost_per_token": 2.5e-06,
         "litellm_provider": "together_ai",
         "max_input_tokens": 1010000,
         "max_output_tokens": 1010000,
         "max_tokens": 1010000,
         "mode": "chat",
-        "output_cost_per_token": 6e-06,
+        "output_cost_per_token": 6.25e-06,
         "source": "https://docs.together.ai/docs/serverless-models",
         "supports_prompt_caching": true
     },
@@ -39203,6 +39203,18 @@
         "supports_response_schema": true,
         "supports_tool_choice": true,
         "supports_vision": true
+    },
+    "together_ai/zai-org/GLM-5.3": {
+        "cache_read_input_token_cost": 2.6e-07,
+        "input_cost_per_token": 1.4e-06,
+        "litellm_provider": "together_ai",
+        "max_input_tokens": 1048575,
+        "max_output_tokens": 1048575,
+        "max_tokens": 1048575,
+        "mode": "chat",
+        "output_cost_per_token": 4.4e-06,
+        "source": "https://docs.together.ai/docs/serverless-models",
+        "supports_prompt_caching": true
     },
     "tts-1": {
         "input_cost_per_character": 1.5e-05,

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -38941,14 +38941,14 @@
         "source": "https://docs.together.ai/docs/serverless-models"
     },
     "together_ai/Qwen/Qwen3.8-2.4T-A95B": {
-        "cache_read_input_token_cost": 2.5e-07,
-        "input_cost_per_token": 2e-06,
+        "cache_read_input_token_cost": 5e-07,
+        "input_cost_per_token": 2.5e-06,
         "litellm_provider": "together_ai",
         "max_input_tokens": 1010000,
         "max_output_tokens": 1010000,
         "max_tokens": 1010000,
         "mode": "chat",
-        "output_cost_per_token": 6e-06,
+        "output_cost_per_token": 6.25e-06,
         "source": "https://docs.together.ai/docs/serverless-models",
         "supports_prompt_caching": true
     },
@@ -39203,6 +39203,18 @@
         "supports_response_schema": true,
         "supports_tool_choice": true,
         "supports_vision": true
+    },
+    "together_ai/zai-org/GLM-5.3": {
+        "cache_read_input_token_cost": 2.6e-07,
+        "input_cost_per_token": 1.4e-06,
+        "litellm_provider": "together_ai",
+        "max_input_tokens": 1048575,
+        "max_output_tokens": 1048575,
+        "max_tokens": 1048575,
+        "mode": "chat",
+        "output_cost_per_token": 4.4e-06,
+        "source": "https://docs.together.ai/docs/serverless-models",
+        "supports_prompt_caching": true
     },
     "tts-1": {
         "input_cost_per_character": 1.5e-05,


### PR DESCRIPTION
Automated daily sync of the together_ai entries in model_prices_and_context_window.json against `GET https://api.together.ai/v1/models?serverless` and https://docs.together.ai/docs/deprecations.md by scripts/sync_together_ai_models.py.

### Added (1)
- `together_ai/zai-org/GLM-5.3`

### Updated (1)
- `together_ai/Qwen/Qwen3.8-2.4T-A95B: input_cost_per_token: 2e-06 -> 2.5e-06; output_cost_per_token: 6e-06 -> 6.25e-06; cache_read_input_token_cost: 2.5e-07 -> 5e-07`

### Marked deprecated (0)
- none

### Returned to the catalog (0)
- none

### Warnings needing a human call (8)
- `together_ai/zai-org/GLM-5.3` added without a capability rule; review its tools/vision/reasoning support and add one
- `together_ai/BAAI/bge-base-en-v1.5` is absent from the serverless catalog with no removal date in the docs; needs a human deprecation call
- `together_ai/Qwen/Qwen2.5-7B-Instruct-Turbo` is absent from the serverless catalog with no removal date in the docs; needs a human deprecation call
- `together_ai/baai/bge-base-en-v1.5` is absent from the serverless catalog with no removal date in the docs; needs a human deprecation call
- `together_ai/deepseek-ai/DeepSeek-V3` is absent from the serverless catalog with no removal date in the docs; needs a human deprecation call
- `together_ai/moonshotai/Kimi-K2-Instruct` is absent from the serverless catalog with no removal date in the docs; needs a human deprecation call
- `together_ai/togethercomputer/CodeLlama-34b-Instruct` is absent from the serverless catalog with no removal date in the docs; needs a human deprecation call
- `together_ai/zai-org/GLM-4.6` is absent from the serverless catalog with no removal date in the docs; needs a human deprecation call

Catalog model types outside the sync's token-pricing scope, skipped: audio (5), image (29), transcribe (4), video (38)
