### PR TITLE
fix(batches): fill a managed batch page past rows that will not parse

### DIFF
--- a/enterprise/litellm_enterprise/proxy/hooks/managed_files.py
+++ b/enterprise/litellm_enterprise/proxy/hooks/managed_files.py
@@ -473,19 +473,56 @@ class _PROXY_LiteLLMManagedFiles(CustomLogger, BaseFileEndpoints):
                 )
 
         page_size: Final = min(limit or 20, 100)
-        cursor_args: _CursorPageArgs = {"cursor": {"unified_object_id": after}, "skip": 1} if after else {}
-
-        batches = await _managed_object_table(self.prisma_client).find_many(
-            where=where_clause,
-            take=page_size + 1,
-            order=[{"created_at": "desc"}, {"unified_object_id": "desc"}],
-            **cursor_args,
+        matches: Final = await self._collect_listed_batches(
+            where_clause=where_clause,
+            after=after,
+            wanted=page_size + 1,
+            user_api_key_dict=user_api_key_dict,
         )
+        return build_list_page(list(matches[:page_size]), has_more=len(matches) > page_size)
 
-        has_more = len(batches) > page_size
+    async def _collect_listed_batches(
+        self,
+        where_clause: Mapping[str, object],
+        after: Optional[str],
+        wanted: int,
+        user_api_key_dict: UserAPIKeyAuth,
+    ) -> tuple[LiteLLMBatch, ...]:
+        """Read chunks newest-first until ``wanted`` batches survive parsing and
+        file-id resolution or the caller's rows run out, so a run of rows that will
+        not parse refills the page instead of emptying it. The first chunk is
+        ``wanted`` rows, so a healthy page still costs one query; a scan that has to
+        continue widens to ``FILE_LIST_CONTINUATION_CHUNK_SIZE`` like ``afile_list``,
+        and every chunk advances the keyset cursor, so the walk ends once the
+        caller's rows are exhausted."""
+        matches: tuple[LiteLLMBatch, ...] = ()  # rebind-ok: accumulates survivors across chunks
+        cursor_id: Optional[str] = after  # rebind-ok: keyset cursor advances to each chunk's last row
+        chunk_size: int = wanted  # rebind-ok: widens once a scan has to continue past the first chunk
+        while len(matches) < wanted:
+            cursor_args: _CursorPageArgs = {"cursor": {"unified_object_id": cursor_id}, "skip": 1} if cursor_id else {}
+            chunk = await _managed_object_table(self.prisma_client).find_many(
+                where=where_clause,
+                take=chunk_size,
+                order=[{"created_at": "desc"}, {"unified_object_id": "desc"}],
+                **cursor_args,
+            )
+            matches = matches + await self._resolve_listed_rows(
+                rows=chunk, wanted=wanted - len(matches), user_api_key_dict=user_api_key_dict
+            )
+            if len(chunk) < chunk_size:
+                break
+            cursor_id = chunk[-1].unified_object_id
+            chunk_size = max(chunk_size, FILE_LIST_CONTINUATION_CHUNK_SIZE)
+        return matches
 
+    async def _resolve_listed_rows(
+        self,
+        rows: "Sequence[PrismaManagedObjectRow]",
+        wanted: int,
+        user_api_key_dict: UserAPIKeyAuth,
+    ) -> tuple[LiteLLMBatch, ...]:
         parsed_rows: Final = tuple(
-            (row, batch_obj) for row in batches[:page_size] if (batch_obj := _parse_managed_batch_row(row)) is not None
+            (row, batch_obj) for row in rows if (batch_obj := _parse_managed_batch_row(row)) is not None
         )
         unified_id_by_raw_id: Final = await map_raw_file_ids_to_unified(
             raw_file_ids=frozenset(
@@ -496,19 +533,19 @@ class _PROXY_LiteLLMManagedFiles(CustomLogger, BaseFileEndpoints):
             ),
             prisma_client=self.prisma_client,
         )
-        resolved_batches: Final = [
-            await self._resolve_listed_batch(
+        resolved: Final[list[LiteLLMBatch]] = []  # mutable-ok: resolution stops as soon as the page is full
+        for row, batch_obj in parsed_rows:
+            if len(resolved) == wanted:
+                break
+            resolved_batch = await self._resolve_listed_batch(
                 row=row,
                 batch_obj=batch_obj,
                 unified_id_by_raw_id=unified_id_by_raw_id,
                 user_api_key_dict=user_api_key_dict,
             )
-            for row, batch_obj in parsed_rows
-        ]
-        return build_list_page(
-            [batch_obj for batch_obj in resolved_batches if batch_obj is not None],
-            has_more=has_more,
-        )
+            if resolved_batch is not None:
+                resolved.append(resolved_batch)
+        return tuple(resolved)
 
     async def _resolve_listed_batch(
         self,

--- a/tests/enterprise/litellm_enterprise/proxy/hooks/test_managed_files.py
+++ b/tests/enterprise/litellm_enterprise/proxy/hooks/test_managed_files.py
@@ -2636,6 +2636,93 @@ async def test_list_batches_unparseable_row_does_not_truncate_pagination():
 
 
 @pytest.mark.asyncio
+async def test_list_batches_fills_a_page_past_a_full_page_of_unparseable_rows():
+    """A page whose rows all fail to parse must still let the caller advance.
+
+    ``has_more`` came from the raw fetch while ``last_id`` came from the parsed
+    survivors, so a full page of corrupt rows answered ``data: []``,
+    ``last_id: None``, ``has_more: True``, and a client following ``last_id``
+    could not move past them.
+    """
+    from litellm.proxy._types import UserAPIKeyAuth
+
+    rows = [_managed_batch_row(i) for i in range(5)]
+    for corrupt_row in rows[2:4]:
+        corrupt_row.file_object = "{ not valid json"
+    prisma_client = _fake_managed_object_table(rows)
+
+    proxy_managed_files = _PROXY_LiteLLMManagedFiles(
+        DualCache(), prisma_client=prisma_client
+    )
+
+    pages = await _walk_batch_pages(
+        proxy_managed_files, UserAPIKeyAuth(user_id="test-user"), limit=1
+    )
+
+    assert [[batch.id for batch in page["data"]] for page in pages] == [
+        [rows[4].unified_object_id],
+        [rows[1].unified_object_id],
+        [rows[0].unified_object_id],
+    ]
+    assert [page["has_more"] for page in pages] == [True, True, False]
+
+
+_DEEP_BATCH_SCAN_ROW_COUNT = 2000
+_DEEP_BATCH_SCAN_QUERY_BUDGET = 10
+
+
+@pytest.mark.asyncio
+async def test_list_batches_bounds_the_queries_a_deep_unparseable_run_costs():
+    """A tiny limit behind thousands of corrupt rows must not turn one request into thousands of queries."""
+    from litellm.proxy._types import UserAPIKeyAuth
+
+    rows = [_managed_batch_row(0)] + [
+        _managed_batch_row(index, file_object="{ not valid json")
+        for index in range(1, _DEEP_BATCH_SCAN_ROW_COUNT + 1)
+    ]
+    prisma_client = _fake_managed_object_table(rows)
+
+    proxy_managed_files = _PROXY_LiteLLMManagedFiles(
+        DualCache(), prisma_client=prisma_client
+    )
+
+    page = await proxy_managed_files.list_user_batches(
+        user_api_key_dict=UserAPIKeyAuth(user_id="test-user"), limit=1
+    )
+
+    assert [batch.id for batch in page["data"]] == [rows[0].unified_object_id]
+    assert page["has_more"] is False
+    assert (
+        prisma_client.db.litellm_managedobjecttable.find_many.call_count
+        <= _DEEP_BATCH_SCAN_QUERY_BUDGET
+    )
+
+
+@pytest.mark.asyncio
+async def test_list_batches_reads_one_chunk_when_the_first_one_fills_the_page():
+    """The widened chunk must stay off the common path, where the newest rows already fill the page."""
+    from litellm.proxy._types import UserAPIKeyAuth
+
+    rows = [_managed_batch_row(index) for index in range(_DEEP_BATCH_SCAN_ROW_COUNT)]
+    prisma_client = _fake_managed_object_table(rows)
+
+    proxy_managed_files = _PROXY_LiteLLMManagedFiles(
+        DualCache(), prisma_client=prisma_client
+    )
+
+    page = await proxy_managed_files.list_user_batches(
+        user_api_key_dict=UserAPIKeyAuth(user_id="test-user"), limit=2
+    )
+
+    assert [batch.id for batch in page["data"]] == [
+        rows[-1].unified_object_id,
+        rows[-2].unified_object_id,
+    ]
+    assert page["has_more"] is True
+    assert prisma_client.db.litellm_managedobjecttable.find_many.call_count == 1
+
+
+@pytest.mark.asyncio
 async def test_return_unified_file_id_includes_expires_at():
     from litellm.types.llms.openai import OpenAIFileObject
 


### PR DESCRIPTION
## TLDR

Problem this solves:

- A managed batch page whose stored rows all fail to parse returns `data: []`, `has_more: true`, no cursor
- The OpenAI SDK paginator cursors off the last item in `data`, so it stops silently
- The client ends up with a truncated batch list and no error

How it solves it:

- Keep reading rows until the page fills with parseable batches or rows run out
- `has_more` now reflects whether another parseable batch exists, not the raw fetch
- A healthy page still costs one query; only a scan past bad rows widens the chunk

## User Flow

Before: a developer listing their batches with the OpenAI SDK gets a silently truncated list when a run of older stored rows is unreadable

1. Their app calls `client.batches.list(limit=20)` against the gateway, sending GET https://litellm-domain/v1/batches?limit=20
2. The first pages come back fine and the SDK follows each page's last batch id as the `after` cursor
3. A page lands where the next 20 stored rows are unreadable legacy entries: the response is `"data": []` with `"has_more": true` and no batch id to cursor from
4. The SDK sees the empty page and stops silently, so the app believes it has every batch; the ones past the bad run never show up

After: the same listing pages straight past the unreadable rows and reaches every remaining batch

1. Their app calls `client.batches.list(limit=20)` against the gateway, sending GET https://litellm-domain/v1/batches?limit=20
2. The first pages come back fine and the SDK follows each page's last batch id as the `after` cursor
3. That page now comes back with 20 readable batches and `"has_more": true`, the gateway having read past the unreadable rows to fill it
4. The SDK keeps paginating and the app reaches the full set of batches, with `"has_more": false` only once nothing readable remains

## Relevant issues

## Linear ticket

Resolves LIT-6362

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Shared setup, identical on both legs; only the commit the proxy was booted from differs

- Fresh Postgres DB per leg (schema via `prisma db push`), proxy booted with `--num_workers 2` (2 uvicorn workers) on a random port, `LITELLM_LICENSE` set
- Config: one `gpt-4o-batch` -> `openai/gpt-4o-mini` deployment, `master_key: sk-1234`
- Seed: 6 real managed batches through the OpenAI SDK against real OpenAI. Per batch: upload a 1-line jsonl with `purpose="batch"` and `extra_body={"target_model_names": "gpt-4o-batch"}`, then `client.batches.create(input_file_id=..., endpoint="/v1/chat/completions", completion_window="24h")`, ~1.5s apart. `GET /v1/batches?limit=20` then shows all 6, newest first; call them id0..id5
- Setup step simulating the customer's legacy/corrupt rows (state injection, not evidence): corrupt the stored blobs of the 3rd and 4th newest batches (id2, id3). The `file_object` column is JSON-typed, so the corruption is stored as a JSON string whose contents are not valid JSON, which the listing fails to parse the same way it fails on the customer's rows

  ```sql
  UPDATE "LiteLLM_ManagedObjectTable"
  SET file_object = to_jsonb('{ not valid json'::text)
  WHERE unified_object_id IN ('<id2>', '<id3>');
  -- UPDATE 2
  ```

- Ids below are trimmed to `bGl0...<tail>`; each is a full unified batch id in reality

### Before (ca0b951a43)

1. Page 1 is fine

   ```
   $ curl -s "http://localhost:35116/v1/batches?limit=2" -H "Authorization: Bearer sk-1234"
   {
     "object": "list",
     "data": [
       {"id": "bGl0...NmQ3ZA", "object": "batch", "status": "validating", "created_at": 1787988580},
       {"id": "bGl0...MWQ3OQ", "object": "batch", "status": "validating", "created_at": 1787988578}
     ],
     "first_id": "bGl0...NmQ3ZA",
     "last_id": "bGl0...MWQ3OQ",
     "has_more": true
   }
   ```

2. Page 2, the window where both rows are corrupt, is the bug: empty data, `has_more: true`, and no cursor to continue from

   ```
   $ curl -s "http://localhost:35116/v1/batches?limit=2&after=<id1>" -H "Authorization: Bearer sk-1234"
   {"object":"list","data":[],"first_id":null,"last_id":null,"has_more":true}
   ```

3. The OpenAI SDK auto-paginator, which cursors off the last item in `data`, stops silently after that page: the user gets 2 batches instead of the 4 readable ones, and id4/id5 are never surfaced

   ```python
   from openai import OpenAI

   client = OpenAI(base_url="http://localhost:35116/v1", api_key="sk-1234")
   ids = [b.id for b in client.batches.list(limit=2)]
   print(len(ids), ids)
   ```

   ```
   2 ['bGl0...NmQ3ZA', 'bGl0...MWQ3OQ']
   ```

### After (3bbd2fac33)

1. Page 1 is the same

   ```
   $ curl -s "http://localhost:41873/v1/batches?limit=2" -H "Authorization: Bearer sk-1234"
   {
     "object": "list",
     "data": [
       {"id": "bGl0...OWM0Nw", "created_at": 1787988593, "metadata": {"description": "lit6362 qa batch 5"}},
       {"id": "bGl0...YjY5Yg", "created_at": 1787988591, "metadata": {"description": "lit6362 qa batch 4"}}
     ],
     "first_id": "bGl0...OWM0Nw",
     "last_id": "bGl0...YjY5Yg",
     "has_more": true
   }
   ```

2. Page 2 now reads past the two unparseable rows and fills the page with the next readable batches, with real cursors and a truthful `has_more`

   ```
   $ curl -s "http://localhost:41873/v1/batches?limit=2&after=<id1>" -H "Authorization: Bearer sk-1234"
   {
     "object": "list",
     "data": [
       {"id": "bGl0...MzQ5Nw", "created_at": 1787988584, "metadata": {"description": "lit6362 qa batch 1"}},
       {"id": "bGl0...ZjFlNg", "created_at": 1787988581, "metadata": {"description": "lit6362 qa batch 0"}}
     ],
     "first_id": "bGl0...MzQ5Nw",
     "last_id": "bGl0...ZjFlNg",
     "has_more": false
   }
   ```

3. The same OpenAI SDK auto-pagination now reaches all 4 readable batches and exits cleanly

   ```python
   from openai import OpenAI

   client = OpenAI(base_url="http://localhost:41873/v1", api_key="sk-1234")
   ids = [b.id for b in client.batches.list(limit=2)]
   print(len(ids), ids)
   ```

   ```
   4 ['bGl0...OWM0Nw', 'bGl0...YjY5Yg', 'bGl0...MzQ5Nw', 'bGl0...ZjFlNg']
   ```

4. Healthy-path sanity check after the corruption: a single-page listing returns exactly the 4 readable batches

   ```
   $ curl -s "http://localhost:41873/v1/batches?limit=20" -H "Authorization: Bearer sk-1234" | jq '{count: (.data | length), ids: [.data[].id], has_more}'
   {"count": 4, "ids": ["bGl0...OWM0Nw", "bGl0...YjY5Yg", "bGl0...MzQ5Nw", "bGl0...ZjFlNg"], "has_more": false}
   ```

QA observations

- Empty bug page also nulled `first_id`/`last_id`; this PR fixes that too
- SDK stops silently on empty `data` despite `has_more: true`; pre-existing SDK behavior, untouched
- `file_object` is a JSON column; corruption seeded as a JSON string blob

## Type

🐛 Bug Fix

## Caveats (if any)

### Low

- Unreadable rows are still skipped, logged as parse warnings, never served
- A long run of unreadable rows makes one request scan in 500-row chunks until the page fills or rows run out

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR


- [x] 3bbd2fac33e0aaed3cb9d4f66ae57cafbb10cf3f passes /live-pr-risk
