### PR TITLE
fix(anthropic_endpoints): serialize dict-detail HTTPExceptions on /v1/messages like sibling surfaces

### DIFF
--- a/litellm/proxy/anthropic_endpoints/endpoints.py
+++ b/litellm/proxy/anthropic_endpoints/endpoints.py
@@ -22,6 +22,7 @@ from litellm.proxy.auth.user_api_key_auth import user_api_key_auth
 from litellm.proxy.common_request_processing import (
     ProxyBaseLLMRequestProcessing,
     create_response,
+    proxy_exception_from_http_exception,
 )
 from litellm.proxy.common_utils.http_parsing_utils import _read_request_body
 from litellm.types.utils import TokenCountResponse
@@ -213,6 +214,9 @@ async def anthropic_response(
             timeout=getattr(e, "timeout", None),
             litellm_logging_obj=None,
         )
+
+        if isinstance(e, HTTPException):
+            raise proxy_exception_from_http_exception(e, headers)
 
         error_msg: Final = f"{e}"
         raise ProxyException(

--- a/litellm/proxy/common_request_processing.py
+++ b/litellm/proxy/common_request_processing.py
@@ -533,6 +533,21 @@ def _serialize_http_exception_detail(
     return str(detail), None
 
 
+def proxy_exception_from_http_exception(exc: HTTPException, headers: dict[str, str]) -> ProxyException:
+    raw_detail: Final = _getattr_object(exc, "detail", str(exc))
+    message, structured_fields = _serialize_http_exception_detail(raw_detail)
+    existing_fields: Final = getattr(exc, "provider_specific_fields", None) or {}
+    merged_fields: Final = {**existing_fields, **structured_fields} if structured_fields else (existing_fields or None)
+    return ProxyException(
+        message=message,
+        type=getattr(exc, "type", "None"),
+        param=getattr(exc, "param", "None"),
+        code=getattr(exc, "status_code", status.HTTP_400_BAD_REQUEST),
+        provider_specific_fields=merged_fields,
+        headers=headers,
+    )
+
+
 def _collect_response_file_search_vector_store_ids(data: Mapping[str, object]) -> set[str]:
     vector_store_ids: Final[set[str]] = set()
     tools: Final = data.get("tools")
@@ -3244,21 +3259,7 @@ class ProxyBaseLLMRequestProcessing:
             raise e
 
         if isinstance(e, HTTPException):
-            raw_detail: Final = _getattr_object(e, "detail", str(e))
-            message, structured_fields = _serialize_http_exception_detail(raw_detail)
-            existing_fields: Final = getattr(e, "provider_specific_fields", None) or {}
-            if structured_fields:
-                merged_fields: dict | None = {**existing_fields, **structured_fields}
-            else:
-                merged_fields = existing_fields or None
-            raise ProxyException(
-                message=message,
-                type=getattr(e, "type", "None"),
-                param=getattr(e, "param", "None"),
-                code=getattr(e, "status_code", status.HTTP_400_BAD_REQUEST),
-                provider_specific_fields=merged_fields,
-                headers=safe_headers,
-            )
+            raise proxy_exception_from_http_exception(e, safe_headers)
         elif isinstance(e, httpx.HTTPStatusError):
             # Handle httpx.HTTPStatusError - extract actual error from response
             # This matches the original behavior before the refactor in commit 511d435f6f

--- a/tests/test_litellm/proxy/anthropic_endpoints/test_endpoints.py
+++ b/tests/test_litellm/proxy/anthropic_endpoints/test_endpoints.py
@@ -164,6 +164,49 @@ class TestProxyExceptionPassthrough:
         mock_logging.post_call_failure_hook.assert_awaited_once()
 
 
+class TestHttpExceptionDictDetail:
+    @pytest.mark.asyncio
+    async def test_anthropic_response_serializes_dict_detail_http_exception(self):
+        """LIT-6466: a post_call guardrail's HTTPException(detail=<dict>) must
+        surface with a clean message plus provider_specific_fields, matching
+        /v1/chat/completions and /v1/responses, not the str() of the exception."""
+        from fastapi import HTTPException
+
+        import litellm.proxy.anthropic_endpoints.endpoints as ep
+        import litellm.proxy.proxy_server as proxy_server
+        from litellm.proxy._types import ProxyException, UserAPIKeyAuth
+
+        detail = {
+            "error": "Content blocked: keyword 'kumquat' detected",
+            "keyword": "kumquat",
+            "guardrail": "keyword-block",
+        }
+        exc = HTTPException(status_code=400, detail=detail)
+
+        with (
+            patch.object(ep, "_read_request_body", new=AsyncMock(return_value={})),  # test-quality-ok: endpoint reads the body via a module function; no injection seam
+            patch.object(  # test-quality-ok: the guardrail raise happens deep inside this call; the test targets the endpoint's except block
+                ep.ProxyBaseLLMRequestProcessing,
+                "base_process_llm_request",
+                new=AsyncMock(side_effect=exc),
+            ),
+            patch.object(proxy_server, "proxy_logging_obj") as mock_logging,  # test-quality-ok: module global imported at call time; no injection seam
+        ):
+            mock_logging.post_call_failure_hook = AsyncMock()
+            with pytest.raises(ProxyException) as exc_info:
+                await ep.anthropic_response(
+                    fastapi_response=MagicMock(),
+                    request=MagicMock(),
+                    user_api_key_dict=UserAPIKeyAuth(),
+                )
+
+        assert exc_info.value.message == "Content blocked: keyword 'kumquat' detected"
+        assert "{'error'" not in exc_info.value.message
+        assert exc_info.value.provider_specific_fields == detail
+        assert exc_info.value.code == "400"
+        mock_logging.post_call_failure_hook.assert_awaited_once()
+
+
 class TestFailureHookRequestData:
     @pytest.mark.asyncio
     async def test_failure_hook_gets_post_setup_data_with_logging_obj(self):

--- a/tests/test_litellm/proxy/test_common_request_processing.py
+++ b/tests/test_litellm/proxy/test_common_request_processing.py
@@ -1683,6 +1683,34 @@ class TestCommonRequestProcessingHelpers:
 
         assert _serialize_http_exception_detail(42) == ("42", None)
 
+    async def test_proxy_exception_from_http_exception_helper(self):
+        """The shared HTTPException -> ProxyException conversion keeps a clean
+        message, merges structured detail over existing provider_specific_fields,
+        and passes headers through."""
+        from litellm.proxy.common_request_processing import (
+            proxy_exception_from_http_exception,
+        )
+
+        exc = HTTPException(
+            status_code=400,
+            detail={"error": "Content blocked", "guardrail": "keyword-block"},
+        )
+        exc.provider_specific_fields = {"existing": "field", "guardrail": "stale"}
+        result = proxy_exception_from_http_exception(exc, {"x-litellm-call-id": "abc"})
+        assert result.message == "Content blocked"
+        assert result.code == "400"
+        assert result.provider_specific_fields == {
+            "existing": "field",
+            "error": "Content blocked",
+            "guardrail": "keyword-block",
+        }
+        assert result.headers == {"x-litellm-call-id": "abc"}
+
+        plain = proxy_exception_from_http_exception(HTTPException(status_code=429, detail="slow down"), {})
+        assert plain.message == "slow down"
+        assert plain.code == "429"
+        assert plain.provider_specific_fields is None
+
     async def test_create_streaming_response_first_chunk_error_string_code(self):
         """
         Test that when the first chunk contains a string error code, a JSON error response is returned


### PR DESCRIPTION
## TLDR

Problem this solves:

- /v1/messages returns guardrail dict-detail 400s as a python-repr blob
- /v1/chat/completions and /v1/responses serialize the same error cleanly
- clients cannot parse the block reason on /v1/messages

How it solves it:

- /v1/messages now uses the same error serialization as its sibling surfaces
- clean message plus the full details under provider_specific_fields

## User Flow

Before: a developer whose post_call guardrail blocks a request on /v1/messages gets a stringified python dict as the error message instead of the guardrail's clean message

1. They send POST https://litellm-domain/v1/messages with `{"model": "claude-sonnet-5", "max_tokens": 128, "messages": [{"role": "user", "content": "Say the word kumquat"}]}` while a guardrail that blocks "kumquat" is on
2. The response is HTTP 400 with `"message": "400: {'error': \"Content blocked: keyword 'kumquat' detected\", 'keyword': 'kumquat', 'guardrail': 'keyword-block', ...}"`, a python-repr blob their client cannot parse, and no `provider_specific_fields`
3. The same prompt on POST https://litellm-domain/v1/chat/completions comes back HTTP 400 with `"message": "Content blocked: keyword 'kumquat' detected"` and the full details under `provider_specific_fields`, so the two surfaces disagree

After: the same blocked request on /v1/messages returns the same clean error as the other endpoints

1. They send the same POST https://litellm-domain/v1/messages with the "kumquat" prompt and the same guardrail on
2. The response is HTTP 400 with `"message": "Content blocked: keyword 'kumquat' detected"` and the keyword, guardrail name, and mode under `provider_specific_fields`
3. POST https://litellm-domain/v1/chat/completions and POST https://litellm-domain/v1/responses return the identical error shape, so all three surfaces agree

## Relevant issues

Pre-existing bug found during LIT-6410 QA on PR #38721. That PR is in flight on the same subsystem but touches neither of the files changed here, so there is no dependency either way

## Linear ticket

Resolves LIT-6466

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Live proxy QA, no mocks, real Anthropic API calls costing real money. Both legs ran the same config (a post_call custom guardrail `keyword-block`, default_on, raising `HTTPException(status_code=400, detail={"error": "Content blocked: keyword 'kumquat' detected", "keyword": "kumquat", "guardrail": "keyword-block"})` when "kumquat" appears in the request) on the same topology, 1 instance x 2 uvicorn workers (`--num_workers 2`), only the proxy commit differing: before = merge base ae7e50f096 on port 30846, after = this PR's tip 817b5f44f6 on port 23226. The blocked /v1/messages request was sent twice per leg to cover both workers and the outputs were byte-identical each time

### Before (ae7e50f096)

#### POST /v1/messages happy path

1. Command:
```
curl -sS -X POST http://localhost:30846/v1/messages -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' -d '{"model": "claude-sonnet-5", "max_tokens": 128, "messages": [{"role": "user", "content": "Say hello in one short sentence"}]}' -w '\nHTTP_STATUS:%{http_code}\n'
```
2. Output:
```
{"model":"claude-sonnet-5","id":"msg_011CeWgANMgyW5syLc3gDJ7z","type":"message","role":"assistant","content":[{"type":"text","text":"Hello!"}],"stop_reason":"end_turn","stop_sequence":null,"stop_details":null,"usage":{"input_tokens":16,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":6,"output_tokens_details":{"thinking_tokens":0},"service_tier":"standard","inference_geo":"global"}}
HTTP_STATUS:200
```

#### POST /v1/messages blocked prompt

1. Command:
```
curl -sS -X POST http://localhost:30846/v1/messages -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' -d '{"model": "claude-sonnet-5", "max_tokens": 128, "messages": [{"role": "user", "content": "Say the word kumquat"}]}' -w '\nHTTP_STATUS:%{http_code}\n'
```
2. Output, the stringified python dict:
```
{"error":{"message":"400: {'error': \"Content blocked: keyword 'kumquat' detected\", 'keyword': 'kumquat', 'guardrail': 'keyword-block', 'guardrail_name': 'keyword-block', 'guardrail_mode': 'post_call'}","type":"None","param":"None","code":"400"}}
HTTP_STATUS:400
```

#### POST /v1/chat/completions blocked prompt

1. Command:
```
curl -sS -X POST http://localhost:30846/v1/chat/completions -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' -d '{"model": "claude-sonnet-5", "messages": [{"role": "user", "content": "Say the word kumquat"}]}' -w '\nHTTP_STATUS:%{http_code}\n'
```
2. Output, clean on the same proxy:
```
{"error":{"message":"Content blocked: keyword 'kumquat' detected","type":"None","param":"None","code":"400","provider_specific_fields":{"error":"Content blocked: keyword 'kumquat' detected","keyword":"kumquat","guardrail":"keyword-block","guardrail_name":"keyword-block","guardrail_mode":"post_call"}}}
HTTP_STATUS:400
```

#### POST /v1/responses blocked prompt

1. Command:
```
curl -sS -X POST http://localhost:30846/v1/responses -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' -d '{"model": "claude-sonnet-5", "input": "Say the word kumquat"}' -w '\nHTTP_STATUS:%{http_code}\n'
```
2. Output, also clean, so at the base only /v1/messages mangles the detail:
```
{"error":{"message":"Content blocked: keyword 'kumquat' detected","type":"None","param":"None","code":"400","provider_specific_fields":{"error":"Content blocked: keyword 'kumquat' detected","keyword":"kumquat","guardrail":"keyword-block","guardrail_name":"keyword-block","guardrail_mode":"post_call"}}}
HTTP_STATUS:400
```

### After (817b5f44f6)

#### POST /v1/messages happy path

1. Command:
```
curl -sS -X POST http://localhost:23226/v1/messages -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' -d '{"model": "claude-sonnet-5", "max_tokens": 128, "messages": [{"role": "user", "content": "Say hello in one short sentence"}]}' -w '\nHTTP_STATUS:%{http_code}\n'
```
2. Output:
```
{"model":"claude-sonnet-5","id":"msg_011CeWgBGBtRk524i66kdrZ9","type":"message","role":"assistant","content":[{"type":"text","text":"Hello! How's your day going?"}],"stop_reason":"end_turn","stop_sequence":null,"stop_details":null,"usage":{"input_tokens":16,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":12,"output_tokens_details":{"thinking_tokens":0},"service_tier":"standard","inference_geo":"global"}}
HTTP_STATUS:200
```

#### POST /v1/messages blocked prompt

1. Command:
```
curl -sS -X POST http://localhost:23226/v1/messages -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' -d '{"model": "claude-sonnet-5", "max_tokens": 128, "messages": [{"role": "user", "content": "Say the word kumquat"}]}' -w '\nHTTP_STATUS:%{http_code}\n'
```
2. Output, now the clean message plus `provider_specific_fields`:
```
{"error":{"message":"Content blocked: keyword 'kumquat' detected","type":"None","param":"None","code":"400","provider_specific_fields":{"error":"Content blocked: keyword 'kumquat' detected","keyword":"kumquat","guardrail":"keyword-block","guardrail_name":"keyword-block","guardrail_mode":"post_call"}}}
HTTP_STATUS:400
```

#### POST /v1/chat/completions blocked prompt

1. Command:
```
curl -sS -X POST http://localhost:23226/v1/chat/completions -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' -d '{"model": "claude-sonnet-5", "messages": [{"role": "user", "content": "Say the word kumquat"}]}' -w '\nHTTP_STATUS:%{http_code}\n'
```
2. Output, unchanged and byte-identical to /v1/messages above:
```
{"error":{"message":"Content blocked: keyword 'kumquat' detected","type":"None","param":"None","code":"400","provider_specific_fields":{"error":"Content blocked: keyword 'kumquat' detected","keyword":"kumquat","guardrail":"keyword-block","guardrail_name":"keyword-block","guardrail_mode":"post_call"}}}
HTTP_STATUS:400
```

#### POST /v1/responses blocked prompt

1. Command:
```
curl -sS -X POST http://localhost:23226/v1/responses -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' -d '{"model": "claude-sonnet-5", "input": "Say the word kumquat"}' -w '\nHTTP_STATUS:%{http_code}\n'
```
2. Output, unchanged and byte-identical too, so all three unified endpoints agree:
```
{"error":{"message":"Content blocked: keyword 'kumquat' detected","type":"None","param":"None","code":"400","provider_specific_fields":{"error":"Content blocked: keyword 'kumquat' detected","keyword":"kumquat","guardrail":"keyword-block","guardrail_name":"keyword-block","guardrail_mode":"post_call"}}}
HTTP_STATUS:400
```

## Type

🐛 Bug Fix

## Caveats (if any)

### Low

- any HTTPException on /v1/messages now serializes its detail as the message, not "code: detail"
- clients matching the old mangled string will see the new clean message
- error.type and error.param are literal "None" strings: pre-existing on all three surfaces, left alone
- provider_specific_fields carries guardrail_name and guardrail_mode extras: pre-existing, left alone
- /v1/messages errors use the OpenAI envelope, not Anthropic's: pre-existing, tracked as LIT-6468

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

- [x] 817b5f44f6712f130c0493ee74ab6ff8d5577141 passes /live-pr-risk

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow error-handling change on the proxy; it improves response shape for guardrail blocks and may change error `message` text for any `HTTPException` on `/v1/messages`, with no auth or data-path changes.
> 
> **Overview**
> **Fixes inconsistent guardrail error responses on `POST /v1/messages`.** When a guardrail raises `HTTPException` with a dict `detail`, that route used to turn the failure into a `ProxyException` whose `message` was essentially `str(HTTPException)` (a Python-repr blob) and omitted structured fields. Chat completions and responses already parsed dict details into a clean message plus `provider_specific_fields`.
> 
> The PR adds shared **`proxy_exception_from_http_exception`** in `common_request_processing` (using existing `_serialize_http_exception_detail` and merging `provider_specific_fields` with response headers) and wires **`anthropic_response`**’s generic `except` block to use it for `HTTPException` before the fallback `ProxyException` path. The same helper replaces the inlined conversion inside **`_handle_llm_api_exception`**, so behavior stays aligned without duplication.
> 
> Tests cover the Anthropic endpoint path (LIT-6466) and the helper’s message merge and header pass-through.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 817b5f44f6712f130c0493ee74ab6ff8d5577141. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->