### PR TITLE
fix(bedrock): map real batch record counts and guard zero-count retire

### DIFF
--- a/litellm/llms/bedrock/batches/handler.py
+++ b/litellm/llms/bedrock/batches/handler.py
@@ -71,13 +71,13 @@ def _predict_output_file_uri(output_prefix: str, input_uri: str, job_id: str | N
 
 def _record_counts_from_response(response: Mapping[str, object]) -> BatchRequestCounts | None:
     total_records: Final = response.get("totalRecordCount")
-    if not isinstance(total_records, int):
-        return None
     success_records: Final = response.get("successRecordCount")
+    if not isinstance(total_records, int) or not isinstance(success_records, int):
+        return None
     error_records: Final = response.get("errorRecordCount")
     return BatchRequestCounts(
         total=total_records,
-        completed=success_records if isinstance(success_records, int) else 0,
+        completed=success_records,
         failed=error_records if isinstance(error_records, int) else 0,
     )
 

--- a/litellm/llms/bedrock/batches/handler.py
+++ b/litellm/llms/bedrock/batches/handler.py
@@ -1,3 +1,4 @@
+from collections.abc import Mapping
 from datetime import datetime
 from typing import TYPE_CHECKING, Any, Final, cast
 
@@ -66,6 +67,19 @@ def _predict_output_file_uri(output_prefix: str, input_uri: str, job_id: str | N
     if not input_basename:
         return None
     return f"{output_prefix}{job_id}/{input_basename}.out"
+
+
+def _record_counts_from_response(response: Mapping[str, object]) -> BatchRequestCounts | None:
+    total_records: Final = response.get("totalRecordCount")
+    if not isinstance(total_records, int):
+        return None
+    success_records: Final = response.get("successRecordCount")
+    error_records: Final = response.get("errorRecordCount")
+    return BatchRequestCounts(
+        total=total_records,
+        completed=success_records if isinstance(success_records, int) else 0,
+        failed=error_records if isinstance(error_records, int) else 0,
+    )
 
 
 def _to_epoch(value: Any) -> int | None:
@@ -271,11 +285,11 @@ class BedrockBatchesHandler:
                 ``aws_external_id``). Unknown keys are ignored.
 
         Returns:
-            ``LiteLLMBatch`` shaped like an OpenAI Batch resource. Note that
-            ``request_counts`` is always ``(0, 0, 0)`` because
-            ``GetModelInvocationJob`` does not surface per-record counts;
-            callers that need accurate counts should parse
-            ``manifest.json.out`` from the output S3 prefix.
+            ``LiteLLMBatch`` shaped like an OpenAI Batch resource.
+            ``request_counts`` maps ``GetModelInvocationJob``'s
+            ``totalRecordCount`` / ``successRecordCount`` / ``errorRecordCount``
+            when the provider reports them, and is ``None`` when it does not
+            (older botocore, or a status that omits counts).
         """
         try:
             import boto3
@@ -386,7 +400,7 @@ class BedrockBatchesHandler:
             failed_at=completed_at if openai_status == "failed" else None,
             cancelled_at=completed_at if openai_status == "cancelled" else None,
             expired_at=completed_at if openai_status == "expired" else None,
-            request_counts=BatchRequestCounts(total=0, completed=0, failed=0),
+            request_counts=_record_counts_from_response(response),
             metadata=openai_batch_metadata,
             completion_window="24h",
             endpoint="/v1/chat/completions",

--- a/litellm/proxy/openai_files_endpoints/common_utils.py
+++ b/litellm/proxy/openai_files_endpoints/common_utils.py
@@ -1351,15 +1351,16 @@ def _completed_batch_safe_to_retire(response: "LiteLLMBatch") -> bool:
     provider response briefly lags before the output id populates). Retiring in that
     window loses the spend record forever. Retire only once we can prove there is
     nothing left to recover: the output file has actually arrived, or the provider
-    reports no successful request lines. When counts are unknown, stay eligible so
-    the next poller pass revisits it. (#37713)
+    reported a positive total with zero successful request lines, proving it
+    enumerated the batch and none succeeded. A zero or unknown total means counts
+    are unreported, so stay eligible and let the next poller pass revisit it. (#37713)
     """
     if response.output_file_id is not None:
         return True
     request_counts = response.request_counts
     if request_counts is None:
         return False
-    return request_counts.completed == 0
+    return request_counts.total > 0 and request_counts.completed == 0
 
 
 async def update_batch_in_database(

--- a/tests/proxy_unit_tests/test_check_batch_cost.py
+++ b/tests/proxy_unit_tests/test_check_batch_cost.py
@@ -1113,8 +1113,12 @@ class TestCheckBatchCost:
     @pytest.mark.asyncio
     @pytest.mark.parametrize(
         "request_counts",
-        [MagicMock(completed=7, failed=0, total=7), None],
-        ids=["lagging_output_id", "unknown_counts"],
+        [
+            MagicMock(completed=7, failed=0, total=7),
+            None,
+            MagicMock(completed=0, failed=0, total=0),
+        ],
+        ids=["lagging_output_id", "unknown_counts", "synthesized_zero_counts"],
     )
     async def test_completed_with_lagging_output_file_left_for_next_cycle(
         self,

--- a/tests/test_litellm/llms/bedrock/batches/test_handler.py
+++ b/tests/test_litellm/llms/bedrock/batches/test_handler.py
@@ -159,9 +159,12 @@ def test_handle_model_invocation_job_status_completed(patched_boto3):
 @pytest.mark.parametrize("success_count,error_count", [(100, 0), (86, 14)])
 def test_completed_job_maps_provider_record_counts(patched_boto3, success_count, error_count):
     fake_client, _ = patched_boto3
-    counted_response = _fake_boto3_response()
-    counted_response.update(totalRecordCount=100, successRecordCount=success_count, errorRecordCount=error_count)
-    fake_client.get_model_invocation_job.return_value = counted_response
+    fake_client.get_model_invocation_job.return_value = {
+        **_fake_boto3_response(),
+        "totalRecordCount": 100,
+        "successRecordCount": success_count,
+        "errorRecordCount": error_count,
+    }
 
     batch = BedrockBatchesHandler._handle_model_invocation_job_status(batch_id=JOB_ARN)
 
@@ -180,6 +183,29 @@ def test_missing_record_counts_leave_request_counts_none(patched_boto3):
     batch = BedrockBatchesHandler._handle_model_invocation_job_status(batch_id=JOB_ARN)
 
     assert batch.request_counts is None
+
+
+def test_total_without_success_count_leaves_request_counts_none(patched_boto3):
+    fake_client, _ = patched_boto3
+    fake_client.get_model_invocation_job.return_value = {**_fake_boto3_response(), "totalRecordCount": 100}
+
+    batch = BedrockBatchesHandler._handle_model_invocation_job_status(batch_id=JOB_ARN)
+
+    assert batch.request_counts is None
+
+
+def test_missing_error_count_maps_to_zero_failed(patched_boto3):
+    fake_client, _ = patched_boto3
+    fake_client.get_model_invocation_job.return_value = {
+        **_fake_boto3_response(),
+        "totalRecordCount": 100,
+        "successRecordCount": 100,
+    }
+
+    batch = BedrockBatchesHandler._handle_model_invocation_job_status(batch_id=JOB_ARN)
+
+    assert batch.request_counts is not None
+    assert (batch.request_counts.total, batch.request_counts.completed, batch.request_counts.failed) == (100, 100, 0)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_litellm/llms/bedrock/batches/test_handler.py
+++ b/tests/test_litellm/llms/bedrock/batches/test_handler.py
@@ -150,12 +150,36 @@ def test_handle_model_invocation_job_status_completed(patched_boto3):
     assert batch.completed_at == int(END_TIME.timestamp())
     assert batch.failed_at is None
     assert batch.cancelled_at is None
-    # Per-record counts aren't reported by GetModelInvocationJob, so we leave
-    # them zeroed; consumers should parse manifest.json.out for accurate counts.
-    assert batch.request_counts.total == 0
+    assert batch.request_counts is None
     assert batch.metadata["job_arn"] == JOB_ARN
     assert batch.metadata["output_file_uri"] == expected_out
     assert batch.metadata["output_s3_uri"] == OUTPUT_PREFIX
+
+
+@pytest.mark.parametrize("success_count,error_count", [(100, 0), (86, 14)])
+def test_completed_job_maps_provider_record_counts(patched_boto3, success_count, error_count):
+    fake_client, _ = patched_boto3
+    counted_response = _fake_boto3_response()
+    counted_response.update(totalRecordCount=100, successRecordCount=success_count, errorRecordCount=error_count)
+    fake_client.get_model_invocation_job.return_value = counted_response
+
+    batch = BedrockBatchesHandler._handle_model_invocation_job_status(batch_id=JOB_ARN)
+
+    assert batch.request_counts is not None
+    assert (batch.request_counts.total, batch.request_counts.completed, batch.request_counts.failed) == (
+        100,
+        success_count,
+        error_count,
+    )
+
+
+def test_missing_record_counts_leave_request_counts_none(patched_boto3):
+    fake_client, _ = patched_boto3
+    fake_client.get_model_invocation_job.return_value = _fake_boto3_response()
+
+    batch = BedrockBatchesHandler._handle_model_invocation_job_status(batch_id=JOB_ARN)
+
+    assert batch.request_counts is None
 
 
 @pytest.mark.parametrize(

--- a/tests/test_litellm/proxy/openai_files_endpoint/test_files_common_utils.py
+++ b/tests/test_litellm/proxy/openai_files_endpoint/test_files_common_utils.py
@@ -430,13 +430,15 @@ def test_add_internal_model_credentials_survives_a_failing_deployment_lookup():
     assert data == {"batch_id": "unified-batch-id"}
 
 
+from openai.types.batch import BatchRequestCounts
+
 from litellm.proxy.openai_files_endpoints.common_utils import (
     _completed_batch_safe_to_retire,
 )
 
 
 def _completed_batch_for_retire(
-    output_file_id: str | None, completed: int | None = None
+    output_file_id: str | None, counts: BatchRequestCounts | None = None
 ) -> LiteLLMBatch:
     kwargs = dict(
         id="batch-1",
@@ -449,26 +451,30 @@ def _completed_batch_for_retire(
         output_file_id=output_file_id,
         error_file_id=None,
     )
-    if completed is not None:
-        kwargs["request_counts"] = {"total": completed, "completed": completed, "failed": 0}
+    if counts is not None:
+        kwargs["request_counts"] = counts
     return LiteLLMBatch(**kwargs)
 
 
 class TestCompletedBatchSafeToRetire:
     """A completed batch is only safe to retire from cost recovery once its output
-    file has arrived or the provider proves no successful lines (#37713)."""
+    file has arrived or the provider proves it enumerated a positive total of
+    request lines and none succeeded (#37713, LIT-6360)."""
 
     def test_output_file_present_is_safe(self):
         assert _completed_batch_safe_to_retire(_completed_batch_for_retire("file-out")) is True
 
-    def test_no_output_and_no_successful_lines_is_safe(self):
-        # Every request line errored -> nothing left to recover.
-        assert _completed_batch_safe_to_retire(_completed_batch_for_retire(None, completed=0)) is True
+    def test_no_output_and_synthesized_zero_counts_is_not_safe(self):
+        counts = BatchRequestCounts(total=0, completed=0, failed=0)
+        assert _completed_batch_safe_to_retire(_completed_batch_for_retire(None, counts)) is False
 
     def test_no_output_but_successful_lines_is_not_safe(self):
-        # The bug: output_file_id is lagging; retiring here loses the spend record.
-        assert _completed_batch_safe_to_retire(_completed_batch_for_retire(None, completed=5)) is False
+        counts = BatchRequestCounts(total=100, completed=100, failed=0)
+        assert _completed_batch_safe_to_retire(_completed_batch_for_retire(None, counts)) is False
+
+    def test_no_output_and_all_lines_failed_is_safe(self):
+        counts = BatchRequestCounts(total=100, completed=0, failed=100)
+        assert _completed_batch_safe_to_retire(_completed_batch_for_retire(None, counts)) is True
 
     def test_no_output_and_unknown_counts_is_not_safe(self):
-        # Counts unknown -> stay eligible so the next poller pass revisits it.
         assert _completed_batch_safe_to_retire(_completed_batch_for_retire(None)) is False


### PR DESCRIPTION
## TLDR

Problem this solves:

- Bedrock batch retrieve hardcoded `request_counts` to (0, 0, 0)
- Real per-record counts from `GetModelInvocationJob` were thrown away
- The retire gate reads zero completed lines as "nothing to bill"
- A completed batch with an unknown output file id retired unbilled, losing the spend

How it solves it:

- Map `totalRecordCount` / `successRecordCount` / `errorRecordCount` into `request_counts`
- Return `None` when the provider omits the total or the success count
- Retire on zero completed lines only when the reported total is positive
- A zero or unknown total keeps the batch eligible next poller pass

## User Flow

Before: the flow breaks at step 4: a completed Bedrock batch reports all-zero request counts, and on any hiccup locating its output the gateway writes the run off as free

1. `POST https://litellm-domain/v1/files` with a 100-line JSONL (purpose `batch`) and get back a file ID
2. `POST https://litellm-domain/v1/batches` with that file ID and the Bedrock model; the response shows status `validating` and a batch ID
3. Poll `GET https://litellm-domain/v1/batches/{batch_id}` while AWS runs the job; status moves through `in_progress`
4. The final poll shows status `completed` but `request_counts` reads `{"total": 0, "completed": 0, "failed": 0}` even though all 100 prompts ran
5. Whenever that completed response is missing its output file reference, the gateway takes the zero counts at face value, decides there is nothing to bill, and permanently drops the batch from cost tracking
6. The admin opens the Usage page at `https://litellm-domain/ui/?page=usage` and the 100-request batch never shows any spend

After: the flow succeeds: the completed batch reports its real request counts and stays billable until its output is actually priced

1. `POST https://litellm-domain/v1/files` with a 100-line JSONL (purpose `batch`) and get back a file ID
2. `POST https://litellm-domain/v1/batches` with that file ID and the Bedrock model; the response shows status `validating` and a batch ID
3. Poll `GET https://litellm-domain/v1/batches/{batch_id}` while AWS runs the job; status moves through `in_progress`
4. The final poll shows status `completed` with the real numbers, e.g. `request_counts: {"total": 100, "completed": 100, "failed": 0}`
5. If that completed response is missing its output file reference, the gateway sees 100 successful lines still unbilled and keeps the batch queued for billing instead of retiring it
6. The admin's Usage page shows the batch's real cost once the output file is priced

## Relevant issues

## Linear ticket

Resolves LIT-6360

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Shared setup, identical on both sides: one proxy per commit, each booted from its own fresh worktree with a fresh Postgres and 2 uvicorn workers (`--num_workers 2`), config carrying a single bedrock model (`bedrock-haiku-batch`, mode `batch`) on `us.anthropic.claude-haiku-4-5` in `us-east-1`, real AWS credentials, real batch inference on the live Bedrock API, real $$$. The job both sides retrieve is a 100-record batch that ran to completion for real

AWS-side ground truth for that job, from `aws bedrock get-model-invocation-job`: status `Completed`, `totalRecordCount: 100`, `processedRecordCount: 100`, `successRecordCount: 100`, `errorRecordCount: 0`. Full snapshot in the fold at the end

### Before (3993829a)

1. Boot a proxy at the merge base on port 34823, then run the flow: `POST /v1/files` with the 100-line JSONL (purpose `batch`), then `POST /v1/batches` with the returned file id and `"model": "bedrock-haiku-batch"`. Both return 200 and AWS starts the job
2. Retrieve the completed batch (the id is the model-routing shape LiteLLM returns when a batch is created with a `model` param, so the retrieve routes through the `bedrock-haiku-batch` deployment):

   ```bash
   curl -s "http://localhost:34823/v1/batches/batch_bGl0ZWxsbTphcm46YXdzOmJlZHJvY2s6dXMtZWFzdC0xOjY1NDI3ODUwMDgwMTptb2RlbC1pbnZvY2F0aW9uLWpvYi9yODljbnEwcHl0dnM7bW9kZWwsYmVkcm9jay1oYWlrdS1iYXRjaA" \
     -H "Authorization: Bearer sk-lit6360-before"
   ```

3. It comes back completed with all-zero counts, contradicting the AWS snapshot above. Those zeros are what the cost-recovery pass reads as "nothing left to bill":

   ```json
   "status": "completed",
   "request_counts": {"completed": 0, "failed": 0, "total": 0}
   ```

### After (d5b5aca4)

1. Boot the tip proxy on port 39471 with the same config, then run the same flow: `POST /v1/files`, then `POST /v1/batches`. Both return 200 and AWS starts job `ue3cxzforryc`
2. Retrieve the same completed batch the Before leg retrieved:

   ```bash
   curl -s "http://localhost:39471/v1/batches/batch_bGl0ZWxsbTphcm46YXdzOmJlZHJvY2s6dXMtZWFzdC0xOjY1NDI3ODUwMDgwMTptb2RlbC1pbnZvY2F0aW9uLWpvYi9yODljbnEwcHl0dnM7bW9kZWwsYmVkcm9jay1oYWlrdS1iYXRjaA" \
     -H "Authorization: Bearer sk-lit6360-after"
   ```

3. It now reports the real counts, matching the AWS snapshot exactly. That curl was re-run unchanged at every commit of this PR and returns byte-identical output each time (`5d34fb20ff` on port 46351, `7fbcd9c3ed` on port 37349, `b0d485568b` on port 41287, and the tip `d5b5aca4` on port 39471):

   ```json
   "status": "completed",
   "request_counts": {"completed": 100, "failed": 0, "total": 100}
   ```

4. Retrieve the batch this leg created itself in step 1, now that AWS has finished it, so the proof is not limited to a pre-existing job:

   ```bash
   curl -s "http://localhost:39471/v1/batches/bGl0ZWxsbV9wcm94eTttb2RlbF9pZDplY2NjNTk0NmY2ZjI4MzcwOGFhNGFiNzllYWYyZTIwMTJhZTIyYTk4OTc5Y2ZjZTYwMTZlNDk5NWEyNDUzNzg4O2xsbV9iYXRjaF9pZDphcm46YXdzOmJlZHJvY2s6dXMtZWFzdC0xOjY1NDI3ODUwMDgwMTptb2RlbC1pbnZvY2F0aW9uLWpvYi91ZTNjeHpmb3JyeWM" \
     -H "Authorization: Bearer sk-lit6360-after"
   ```

5. It returns completed with its real counts and a non-null `output_file_id`, matching its own `GetModelInvocationJob` (`totalRecordCount` 100, `successRecordCount` 100, `errorRecordCount` 0). Earlier in the same leg, while AWS still had it `validating`, the same GET returned `{"total": 0, "completed": 0, "failed": 0}` because AWS itself reported `totalRecordCount: 0` at that stage, so those are real provider values mapped through rather than the old placeholder:

   ```json
   "status": "completed",
   "request_counts": {"completed": 100, "failed": 0, "total": 100}
   ```

<details>
<summary>Full JSON responses and AWS snapshot</summary>

Before, full response:

```json
{
  "id": "batch_bGl0ZWxsbTphcm46YXdzOmJlZHJvY2s6dXMtZWFzdC0xOjY1NDI3ODUwMDgwMTptb2RlbC1pbnZvY2F0aW9uLWpvYi9yODljbnEwcHl0dnM7bW9kZWwsYmVkcm9jay1oYWlrdS1iYXRjaA",
  "completion_window": "24h",
  "created_at": 1787991073,
  "endpoint": "/v1/chat/completions",
  "input_file_id": "file-bGl0ZWxsbTpzMzovL2xpdGVsbG0tZTJlLXN1aXRlLWJhdGNoZXMvbGl0ZWxsbS1saXQ2MzYwLWlucHV0LTRlNDU4NWJjLmpzb25sO21vZGVsLGJlZHJvY2staGFpa3UtYmF0Y2g",
  "object": "batch",
  "status": "completed",
  "cancelled_at": null,
  "cancelling_at": null,
  "completed_at": 1787991695,
  "error_file_id": null,
  "errors": null,
  "expired_at": null,
  "expires_at": null,
  "failed_at": null,
  "finalizing_at": null,
  "in_progress_at": 1787991697,
  "metadata": {
    "model_arn": "arn:aws:bedrock:us-east-1:654278500801:inference-profile/us.anthropic.claude-haiku-4-5-20251001-v1:0",
    "job_arn": "arn:aws:bedrock:us-east-1:654278500801:model-invocation-job/r89cnq0pytvs",
    "job_name": "lit6360-qa2-1d5f7f0c",
    "failure_message": "",
    "input_s3_uri": "s3://litellm-e2e-suite-batches/litellm-lit6360-input-4e4585bc.jsonl",
    "output_s3_uri": "s3://litellm-e2e-suite-batches/litellm-batch-outputs/lit6360-qa/",
    "output_file_uri": "s3://litellm-e2e-suite-batches/litellm-batch-outputs/lit6360-qa/r89cnq0pytvs/litellm-lit6360-input-4e4585bc.jsonl.out"
  },
  "model": null,
  "output_file_id": "file-bGl0ZWxsbTpzMzovL2xpdGVsbG0tZTJlLXN1aXRlLWJhdGNoZXMvbGl0ZWxsbS1iYXRjaC1vdXRwdXRzL2xpdDYzNjAtcWEvcjg5Y25xMHB5dHZzL2xpdGVsbG0tbGl0NjM2MC1pbnB1dC00ZTQ1ODViYy5qc29ubC5vdXQ7bW9kZWwsYmVkcm9jay1oYWlrdS1iYXRjaA",
  "request_counts": {"completed": 0, "failed": 0, "total": 0},
  "usage": null
}
```

After, full response for the shared job:

```json
{
  "id": "batch_bGl0ZWxsbTphcm46YXdzOmJlZHJvY2s6dXMtZWFzdC0xOjY1NDI3ODUwMDgwMTptb2RlbC1pbnZvY2F0aW9uLWpvYi9yODljbnEwcHl0dnM7bW9kZWwsYmVkcm9jay1oYWlrdS1iYXRjaA",
  "completion_window": "24h",
  "created_at": 1787991073,
  "endpoint": "/v1/chat/completions",
  "input_file_id": "file-bGl0ZWxsbTpzMzovL2xpdGVsbG0tZTJlLXN1aXRlLWJhdGNoZXMvbGl0ZWxsbS1saXQ2MzYwLWlucHV0LTRlNDU4NWJjLmpzb25sO21vZGVsLGJlZHJvY2staGFpa3UtYmF0Y2g",
  "object": "batch",
  "status": "completed",
  "cancelled_at": null,
  "cancelling_at": null,
  "completed_at": 1787991695,
  "error_file_id": null,
  "errors": null,
  "expired_at": null,
  "expires_at": null,
  "failed_at": null,
  "finalizing_at": null,
  "in_progress_at": 1787991697,
  "metadata": {
    "model_arn": "arn:aws:bedrock:us-east-1:654278500801:inference-profile/us.anthropic.claude-haiku-4-5-20251001-v1:0",
    "job_arn": "arn:aws:bedrock:us-east-1:654278500801:model-invocation-job/r89cnq0pytvs",
    "job_name": "lit6360-qa2-1d5f7f0c",
    "failure_message": "",
    "input_s3_uri": "s3://litellm-e2e-suite-batches/litellm-lit6360-input-4e4585bc.jsonl",
    "output_s3_uri": "s3://litellm-e2e-suite-batches/litellm-batch-outputs/lit6360-qa/",
    "output_file_uri": "s3://litellm-e2e-suite-batches/litellm-batch-outputs/lit6360-qa/r89cnq0pytvs/litellm-lit6360-input-4e4585bc.jsonl.out"
  },
  "model": null,
  "output_file_id": "file-bGl0ZWxsbTpzMzovL2xpdGVsbG0tZTJlLXN1aXRlLWJhdGNoZXMvbGl0ZWxsbS1iYXRjaC1vdXRwdXRzL2xpdDYzNjAtcWEvcjg5Y25xMHB5dHZzL2xpdGVsbG0tbGl0NjM2MC1pbnB1dC00ZTQ1ODViYy5qc29ubC5vdXQ7bW9kZWwsYmVkcm9jay1oYWlrdS1iYXRjaA",
  "request_counts": {"completed": 100, "failed": 0, "total": 100},
  "usage": null
}
```

After, full response for the batch this leg created end to end (job `ue3cxzforryc`):

```json
{
  "id": "bGl0ZWxsbV9wcm94eTttb2RlbF9pZDplY2NjNTk0NmY2ZjI4MzcwOGFhNGFiNzllYWYyZTIwMTJhZTIyYTk4OTc5Y2ZjZTYwMTZlNDk5NWEyNDUzNzg4O2xsbV9iYXRjaF9pZDphcm46YXdzOmJlZHJvY2s6dXMtZWFzdC0xOjY1NDI3ODUwMDgwMTptb2RlbC1pbnZvY2F0aW9uLWpvYi91ZTNjeHpmb3JyeWM",
  "completion_window": "24h",
  "created_at": 1787992335,
  "endpoint": "/v1/chat/completions",
  "input_file_id": "bGl0ZWxsbV9wcm94eTphcHBsaWNhdGlvbi9vY3RldC1zdHJlYW07dW5pZmllZF9pZCw3NzM2NzM4Ni0wNzA5LTRiNjYtYTFhYS1jNmM2ZDBmNTFmNWI7dGFyZ2V0X21vZGVsX25hbWVzLGJlZHJvY2staGFpa3UtYmF0Y2g7bGxtX291dHB1dF9maWxlX2lkLHMzOi8vbGl0ZWxsbS1lMmUtc3VpdGUtYmF0Y2hlcy9saXRlbGxtLWJlZHJvY2stZmlsZXMtdXMuYW50aHJvcGljLmNsYXVkZS1oYWlrdS00LTUtMjAyNTEwMDEtdjEtMC00Mzk3MjIxOC02YmQzLTQzOTgtYjI3OS1kNDZjNzEwY2ViODMuanNvbmw7bGxtX291dHB1dF9maWxlX21vZGVsX2lkLGVjY2M1OTQ2ZjZmMjgzNzA4YWE0YWI3OWVhZjJlMjAxMmFlMjJhOTg5NzljZmNlNjAxNmU0OTk1YTI0NTM3ODg",
  "object": "batch",
  "cancelled_at": null,
  "cancelling_at": null,
  "status": "completed",
  "completed_at": 1787992838,
  "error_file_id": null,
  "errors": null,
  "expired_at": null,
  "expires_at": null,
  "failed_at": null,
  "finalizing_at": null,
  "in_progress_at": 1787992838,
  "metadata": {
    "model_arn": "arn:aws:bedrock:us-east-1:654278500801:inference-profile/us.anthropic.claude-haiku-4-5-20251001-v1:0",
    "job_arn": "arn:aws:bedrock:us-east-1:654278500801:model-invocation-job/ue3cxzforryc",
    "job_name": "litellm-batch-217f77b9",
    "failure_message": "",
    "input_s3_uri": "s3://litellm-e2e-suite-batches/litellm-bedrock-files-us.anthropic.claude-haiku-4-5-20251001-v1-0-43972218-6bd3-4398-b279-d46c710ceb83.jsonl",
    "output_s3_uri": "s3://litellm-e2e-suite-batches/litellm-batch-outputs/litellm-batch-217f77b9/",
    "output_file_uri": "s3://litellm-e2e-suite-batches/litellm-batch-outputs/litellm-batch-217f77b9/ue3cxzforryc/litellm-bedrock-files-us.anthropic.claude-haiku-4-5-20251001-v1-0-43972218-6bd3-4398-b279-d46c710ceb83.jsonl.out"
  },
  "model": null,
  "output_file_id": "bGl0ZWxsbV9wcm94eTphcHBsaWNhdGlvbi9qc29uO3VuaWZpZWRfaWQsNDEzMDk3YzEtOTAzNy01ZGQ1LWExNDgtYTY1NWFjODMwMjhmO3RhcmdldF9tb2RlbF9uYW1lcyxiZWRyb2NrLWhhaWt1LWJhdGNoO2xsbV9vdXRwdXRfZmlsZV9pZCxzMzovL2xpdGVsbG0tZTJlLXN1aXRlLWJhdGNoZXMvbGl0ZWxsbS1iYXRjaC1vdXRwdXRzL2xpdGVsbG0tYmF0Y2gtMjE3Zjc3YjkvdWUzY3h6Zm9ycnljL2xpdGVsbG0tYmVkcm9jay1maWxlcy11cy5hbnRocm9waWMuY2xhdWRlLWhhaWt1LTQtNS0yMDI1MTAwMS12MS0wLTQzOTcyMjE4LTZiZDMtNDM5OC1iMjc5LWQ0NmM3MTBjZWI4My5qc29ubC5vdXQ7bGxtX291dHB1dF9maWxlX21vZGVsX2lkLGVjY2M1OTQ2ZjZmMjgzNzA4YWE0YWI3OWVhZjJlMjAxMmFlMjJhOTg5NzljZmNlNjAxNmU0OTk1YTI0NTM3ODg",
  "request_counts": {"completed": 100, "failed": 0, "total": 100},
  "usage": null
}
```

AWS `get-model-invocation-job` terminal snapshot of the shared job:

```json
{
  "jobArn": "arn:aws:bedrock:us-east-1:654278500801:model-invocation-job/r89cnq0pytvs",
  "jobName": "lit6360-qa2-1d5f7f0c",
  "modelId": "arn:aws:bedrock:us-east-1:654278500801:inference-profile/us.anthropic.claude-haiku-4-5-20251001-v1:0",
  "roleArn": "arn:aws:iam::654278500801:role/LiteLLMBedrockBatchRole",
  "status": "Completed",
  "submitTime": "2026-08-29T08:11:13.439000+00:00",
  "endTime": "2026-08-29T08:21:35.547000+00:00",
  "inputDataConfig": {"s3InputDataConfig": {"s3Uri": "s3://litellm-e2e-suite-batches/litellm-lit6360-input-4e4585bc.jsonl"}},
  "outputDataConfig": {"s3OutputDataConfig": {"s3Uri": "s3://litellm-e2e-suite-batches/litellm-batch-outputs/lit6360-qa/"}},
  "modelInvocationType": "InvokeModel",
  "totalRecordCount": 100,
  "processedRecordCount": 100,
  "successRecordCount": 100,
  "errorRecordCount": 0
}
```

</details>

One half of the fix cannot be forced against the real provider: a completed batch with no output file id and zero completed lines no longer leaves cost recovery, but every real completed job predicts a non-null output file id, as both full responses above show. That branch is pinned by `TestCompletedBatchSafeToRetire` in `tests/test_litellm/proxy/openai_files_endpoint/test_files_common_utils.py` and, at the poller level where the spend is actually lost, by the `synthesized_zero_counts` case of `test_completed_with_lagging_output_file_left_for_next_cycle` in `tests/proxy_unit_tests/test_check_batch_cost.py`. All of them fail on the pre-fix code

## Type

🐛 Bug Fix

## Caveats (if any)

### Low

- Twelve Labs async-invoke is intentionally unchanged: different ARN family, single-record jobs
- The retire-unbilled symptom needs a completed job whose output file id is unknown
  - That happens when the per-job output key cannot be predicted from the job's input and output URIs
- Retrieve now returns `request_counts: null` instead of zeros in two cases
  - Botocore versions old enough not to model the count fields
  - A provider response reporting a total without a success count
- A completed batch whose counts stay unknown holds its cost-recovery slot longer
  - It is bounded: the poller's staleness sweep force-retires it after `MANAGED_OBJECT_STALENESS_CUTOFF_DAYS` (7 by default)
  - Same for a genuinely empty batch, whose reported total is zero
  - Retiring either one sooner is the data-loss bug this PR removes, so the wait is the intended trade
- Batches already terminal in the DB before the upgrade keep showing the old zeros
  - `GET /v1/batches/{batch_id}` returns the stored copy for a terminal row instead of re-polling
  - Nothing regresses: that is what those rows returned before the fix too
  - The retire gate is never re-scored from a stored value; the poller and the non-terminal route both read a fresh `GetModelInvocationJob`
  - So check the fix against a batch retrieved fresh after the upgrade, and note spend already retired unbilled is not recovered retroactively

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
- [x] b0d485568b6d29f86db36d48d52a564c52e394dc passes /live-pr-risk
- [x] d5b5aca498249bdb99984410e9f3cbec3a1c7a12 passes /live-pr-risk
