### PR TITLE
fix(router): break least-busy ties fairly and ignore unhealthy deployments

### DIFF
--- a/litellm/router_strategy/least_busy.py
+++ b/litellm/router_strategy/least_busy.py
@@ -1,11 +1,3 @@
-#### What this does ####
-#   identifies least busy deployment
-#   How is this achieved?
-#   - Before each call, have the router print the state of requests {"deployment": "requests_in_flight"}
-#   - use litellm.input_callbacks to log when a request is just about to be made to a model - {"deployment-id": traffic}
-#   - use litellm.success + failure callbacks to log when a request completed
-#   - in get_available_deployment, for a given model group name -> pick based on traffic
-
 import random
 from typing import Final
 
@@ -22,11 +14,6 @@ class LeastBusyLoggingHandler(CustomLogger):
         self.router_cache = router_cache
 
     def log_pre_api_call(self, model, messages, kwargs):
-        """
-        Log when a model is being used.
-
-        Caching based on model group.
-        """
         try:
             if kwargs["litellm_params"].get("metadata") is None:
                 pass
@@ -39,7 +26,6 @@ class LeastBusyLoggingHandler(CustomLogger):
                     id = str(id)
 
                 request_count_api_key: Final = f"{model_group}_request_count"
-                # update cache
                 request_count_dict: Final = self.router_cache.get_cache(key=request_count_api_key) or {}
                 request_count_dict[id] = request_count_dict.get(id, 0) + 1
 
@@ -61,7 +47,6 @@ class LeastBusyLoggingHandler(CustomLogger):
                     id = str(id)
 
                 request_count_api_key: Final = f"{model_group}_request_count"
-                # decrement count in cache
                 request_count_dict: Final = self.router_cache.get_cache(key=request_count_api_key) or {}
                 request_count_value: Final[int | None] = request_count_dict.get(id, 0)
                 if request_count_value is None:
@@ -69,7 +54,6 @@ class LeastBusyLoggingHandler(CustomLogger):
                 request_count_dict[id] = request_count_value - 1
                 self.router_cache.set_cache(key=request_count_api_key, value=request_count_dict)
 
-                ### TESTING ###
                 if self.test_flag:
                     self.logged_success += 1
         except Exception:
@@ -88,7 +72,6 @@ class LeastBusyLoggingHandler(CustomLogger):
                     id = str(id)
 
                 request_count_api_key: Final = f"{model_group}_request_count"
-                # decrement count in cache
                 request_count_dict: Final = self.router_cache.get_cache(key=request_count_api_key) or {}
                 request_count_value: Final[int | None] = request_count_dict.get(id, 0)
                 if request_count_value is None:
@@ -96,7 +79,6 @@ class LeastBusyLoggingHandler(CustomLogger):
                 request_count_dict[id] = request_count_value - 1
                 self.router_cache.set_cache(key=request_count_api_key, value=request_count_dict)
 
-                ### TESTING ###
                 if self.test_flag:
                     self.logged_failure += 1
         except Exception:
@@ -116,7 +98,6 @@ class LeastBusyLoggingHandler(CustomLogger):
                     id = str(id)
 
                 request_count_api_key: Final = f"{model_group}_request_count"
-                # decrement count in cache
                 request_count_dict: Final = await self.router_cache.async_get_cache(key=request_count_api_key) or {}
                 request_count_value: Final[int | None] = request_count_dict.get(id, 0)
                 if request_count_value is None:
@@ -124,7 +105,6 @@ class LeastBusyLoggingHandler(CustomLogger):
                 request_count_dict[id] = request_count_value - 1
                 await self.router_cache.async_set_cache(key=request_count_api_key, value=request_count_dict)
 
-                ### TESTING ###
                 if self.test_flag:
                     self.logged_success += 1
         except Exception:
@@ -143,7 +123,6 @@ class LeastBusyLoggingHandler(CustomLogger):
                     id = str(id)
 
                 request_count_api_key: Final = f"{model_group}_request_count"
-                # decrement count in cache
                 request_count_dict: Final = await self.router_cache.async_get_cache(key=request_count_api_key) or {}
                 request_count_value: Final[int | None] = request_count_dict.get(id, 0)
                 if request_count_value is None:
@@ -151,7 +130,6 @@ class LeastBusyLoggingHandler(CustomLogger):
                 request_count_dict[id] = request_count_value - 1
                 await self.router_cache.async_set_cache(key=request_count_api_key, value=request_count_dict)
 
-                ### TESTING ###
                 if self.test_flag:
                     self.logged_failure += 1
         except Exception:
@@ -162,20 +140,10 @@ class LeastBusyLoggingHandler(CustomLogger):
         healthy_deployments: list,
         all_deployments: dict,
     ):
-        """
-        Helper to get deployments using least busy strategy
-
-        Only healthy deployments are weighed, so an id the cache still holds for a deployment that is
-        no longer healthy cannot win the minimum. Ties are broken at random: comparing with a strict
-        `<` always kept the first deployment, and since the counts drain back to zero between
-        requests, in light traffic every request is a tie.
-        """
         for d in healthy_deployments:
-            ## if healthy deployment not yet used
             if d["model_info"]["id"] not in all_deployments:
                 all_deployments[d["model_info"]["id"]] = 0
-        # map deployment to id
-        # pick least busy deployment
+        # counts drain back to zero between requests, so in light traffic every request is a tie
         traffic: Final = tuple(all_deployments[d["model_info"]["id"]] for d in healthy_deployments)
         min_traffic: Final = min(traffic)
         return random.choice(tuple(d for d, t in zip(healthy_deployments, traffic) if t == min_traffic))
@@ -185,9 +153,6 @@ class LeastBusyLoggingHandler(CustomLogger):
         model_group: str,
         healthy_deployments: list,
     ):
-        """
-        Sync helper to get deployments using least busy strategy
-        """
         request_count_api_key: Final = f"{model_group}_request_count"
         all_deployments: Final = self.router_cache.get_cache(key=request_count_api_key) or {}
         return self._get_available_deployments(
@@ -196,9 +161,6 @@ class LeastBusyLoggingHandler(CustomLogger):
         )
 
     async def async_get_available_deployments(self, model_group: str, healthy_deployments: list):
-        """
-        Async helper to get deployments using least busy strategy
-        """
         request_count_api_key: Final = f"{model_group}_request_count"
         all_deployments: Final = await self.router_cache.async_get_cache(key=request_count_api_key) or {}
         return self._get_available_deployments(

--- a/litellm/router_strategy/least_busy.py
+++ b/litellm/router_strategy/least_busy.py
@@ -5,6 +5,15 @@ from litellm.caching.caching import DualCache
 from litellm.integrations.custom_logger import CustomLogger
 
 
+def _count_key(model_group: str, deployment_id: str) -> str:
+    return f"{model_group}_request_count:{deployment_id}"
+
+
+def _took_a_slot(kwargs: dict) -> bool:
+    # pre_call stamps api_call_start_time right before taking the slot; cache hits and pre-call rejections never get there
+    return kwargs.get("cache_hit") is not True and kwargs.get("api_call_start_time") is not None
+
+
 class LeastBusyLoggingHandler(CustomLogger):
     test_flag: bool = False
     logged_success: int = 0
@@ -25,17 +34,13 @@ class LeastBusyLoggingHandler(CustomLogger):
                 elif isinstance(id, int):
                     id = str(id)
 
-                request_count_api_key: Final = f"{model_group}_request_count"
-                request_count_dict: Final = self.router_cache.get_cache(key=request_count_api_key) or {}
-                request_count_dict[id] = request_count_dict.get(id, 0) + 1
-
-                self.router_cache.set_cache(key=request_count_api_key, value=request_count_dict)
+                self.router_cache.increment_cache(key=_count_key(model_group, id), value=1)
         except Exception:
             pass
 
     def log_success_event(self, kwargs, response_obj, start_time, end_time):
         try:
-            if kwargs["litellm_params"].get("metadata") is None:
+            if kwargs["litellm_params"].get("metadata") is None or not _took_a_slot(kwargs):
                 pass
             else:
                 model_group: Final = kwargs["litellm_params"]["metadata"].get("model_group", None)
@@ -46,13 +51,7 @@ class LeastBusyLoggingHandler(CustomLogger):
                 elif isinstance(id, int):
                     id = str(id)
 
-                request_count_api_key: Final = f"{model_group}_request_count"
-                request_count_dict: Final = self.router_cache.get_cache(key=request_count_api_key) or {}
-                request_count_value: Final[int | None] = request_count_dict.get(id, 0)
-                if request_count_value is None:
-                    return
-                request_count_dict[id] = request_count_value - 1
-                self.router_cache.set_cache(key=request_count_api_key, value=request_count_dict)
+                self._release(_count_key(model_group, id))
 
                 if self.test_flag:
                     self.logged_success += 1
@@ -61,7 +60,7 @@ class LeastBusyLoggingHandler(CustomLogger):
 
     def log_failure_event(self, kwargs, response_obj, start_time, end_time):
         try:
-            if kwargs["litellm_params"].get("metadata") is None:
+            if kwargs["litellm_params"].get("metadata") is None or not _took_a_slot(kwargs):
                 pass
             else:
                 model_group: Final = kwargs["litellm_params"]["metadata"].get("model_group", None)
@@ -71,13 +70,7 @@ class LeastBusyLoggingHandler(CustomLogger):
                 elif isinstance(id, int):
                     id = str(id)
 
-                request_count_api_key: Final = f"{model_group}_request_count"
-                request_count_dict: Final = self.router_cache.get_cache(key=request_count_api_key) or {}
-                request_count_value: Final[int | None] = request_count_dict.get(id, 0)
-                if request_count_value is None:
-                    return
-                request_count_dict[id] = request_count_value - 1
-                self.router_cache.set_cache(key=request_count_api_key, value=request_count_dict)
+                self._release(_count_key(model_group, id))
 
                 if self.test_flag:
                     self.logged_failure += 1
@@ -86,7 +79,7 @@ class LeastBusyLoggingHandler(CustomLogger):
 
     async def async_log_success_event(self, kwargs, response_obj, start_time, end_time):
         try:
-            if kwargs["litellm_params"].get("metadata") is None:
+            if kwargs["litellm_params"].get("metadata") is None or not _took_a_slot(kwargs):
                 pass
             else:
                 model_group: Final = kwargs["litellm_params"]["metadata"].get("model_group", None)
@@ -97,13 +90,7 @@ class LeastBusyLoggingHandler(CustomLogger):
                 elif isinstance(id, int):
                     id = str(id)
 
-                request_count_api_key: Final = f"{model_group}_request_count"
-                request_count_dict: Final = await self.router_cache.async_get_cache(key=request_count_api_key) or {}
-                request_count_value: Final[int | None] = request_count_dict.get(id, 0)
-                if request_count_value is None:
-                    return
-                request_count_dict[id] = request_count_value - 1
-                await self.router_cache.async_set_cache(key=request_count_api_key, value=request_count_dict)
+                await self._async_release(_count_key(model_group, id))
 
                 if self.test_flag:
                     self.logged_success += 1
@@ -112,7 +99,7 @@ class LeastBusyLoggingHandler(CustomLogger):
 
     async def async_log_failure_event(self, kwargs, response_obj, start_time, end_time):
         try:
-            if kwargs["litellm_params"].get("metadata") is None:
+            if kwargs["litellm_params"].get("metadata") is None or not _took_a_slot(kwargs):
                 pass
             else:
                 model_group: Final = kwargs["litellm_params"]["metadata"].get("model_group", None)
@@ -122,18 +109,35 @@ class LeastBusyLoggingHandler(CustomLogger):
                 elif isinstance(id, int):
                     id = str(id)
 
-                request_count_api_key: Final = f"{model_group}_request_count"
-                request_count_dict: Final = await self.router_cache.async_get_cache(key=request_count_api_key) or {}
-                request_count_value: Final[int | None] = request_count_dict.get(id, 0)
-                if request_count_value is None:
-                    return
-                request_count_dict[id] = request_count_value - 1
-                await self.router_cache.async_set_cache(key=request_count_api_key, value=request_count_dict)
+                await self._async_release(_count_key(model_group, id))
 
                 if self.test_flag:
                     self.logged_failure += 1
         except Exception:
             pass
+
+    def _release(self, key: str) -> None:
+        if self.router_cache.increment_cache(key=key, value=-1) < 0:
+            self.router_cache.set_cache(key=key, value=0)
+
+    async def _async_release(self, key: str) -> None:
+        remaining: Final = await self.router_cache.async_increment_cache(key=key, value=-1)
+        if remaining is not None and remaining < 0:
+            await self.router_cache.async_set_cache(key=key, value=0)
+
+    def _read_counts(self, keys: list) -> list:
+        redis_cache: Final = self.router_cache.redis_cache
+        if redis_cache is None:
+            return [count or 0 for count in self.router_cache.in_memory_cache.batch_get_cache(keys)]
+        found: Final = redis_cache.batch_get_cache(key_list=keys) or {}
+        return [found.get(key) or 0 for key in keys]
+
+    async def _async_read_counts(self, keys: list) -> list:
+        redis_cache: Final = self.router_cache.redis_cache
+        if redis_cache is None:
+            return [count or 0 for count in await self.router_cache.in_memory_cache.async_batch_get_cache(keys)]
+        found: Final = await redis_cache.async_batch_get_cache(key_list=keys) or {}
+        return [found.get(key) or 0 for key in keys]
 
     def _get_available_deployments(
         self,
@@ -153,17 +157,17 @@ class LeastBusyLoggingHandler(CustomLogger):
         model_group: str,
         healthy_deployments: list,
     ):
-        request_count_api_key: Final = f"{model_group}_request_count"
-        all_deployments: Final = self.router_cache.get_cache(key=request_count_api_key) or {}
+        keys: Final = [_count_key(model_group, str(d["model_info"]["id"])) for d in healthy_deployments]
+        counts: Final = self._read_counts(keys)
         return self._get_available_deployments(
             healthy_deployments=healthy_deployments,
-            all_deployments=all_deployments,
+            all_deployments=dict(zip([d["model_info"]["id"] for d in healthy_deployments], counts)),
         )
 
     async def async_get_available_deployments(self, model_group: str, healthy_deployments: list):
-        request_count_api_key: Final = f"{model_group}_request_count"
-        all_deployments: Final = await self.router_cache.async_get_cache(key=request_count_api_key) or {}
+        keys: Final = [_count_key(model_group, str(d["model_info"]["id"])) for d in healthy_deployments]
+        counts: Final = await self._async_read_counts(keys)
         return self._get_available_deployments(
             healthy_deployments=healthy_deployments,
-            all_deployments=all_deployments,
+            all_deployments=dict(zip([d["model_info"]["id"] for d in healthy_deployments], counts)),
         )

--- a/litellm/router_strategy/least_busy.py
+++ b/litellm/router_strategy/least_busy.py
@@ -164,6 +164,11 @@ class LeastBusyLoggingHandler(CustomLogger):
     ):
         """
         Helper to get deployments using least busy strategy
+
+        Only healthy deployments are weighed, so an id the cache still holds for a deployment that is
+        no longer healthy cannot win the minimum. Ties are broken at random: comparing with a strict
+        `<` always kept the first deployment, and since the counts drain back to zero between
+        requests, in light traffic every request is a tie.
         """
         for d in healthy_deployments:
             ## if healthy deployment not yet used
@@ -171,21 +176,9 @@ class LeastBusyLoggingHandler(CustomLogger):
                 all_deployments[d["model_info"]["id"]] = 0
         # map deployment to id
         # pick least busy deployment
-        min_traffic = float("inf")
-        min_deployment = None
-        for k, v in all_deployments.items():
-            if v < min_traffic:
-                min_traffic = v
-                min_deployment = k
-        if min_deployment is not None:
-            ## check if min deployment is a string, if so, cast it to int
-            for m in healthy_deployments:
-                if m["model_info"]["id"] == min_deployment:
-                    return m
-            min_deployment = random.choice(healthy_deployments)
-        else:
-            min_deployment = random.choice(healthy_deployments)
-        return min_deployment
+        traffic: Final = tuple(all_deployments[d["model_info"]["id"]] for d in healthy_deployments)
+        min_traffic: Final = min(traffic)
+        return random.choice(tuple(d for d, t in zip(healthy_deployments, traffic) if t == min_traffic))
 
     def get_available_deployments(
         self,

--- a/tests/local_testing/test_least_busy_routing.py
+++ b/tests/local_testing/test_least_busy_routing.py
@@ -33,8 +33,8 @@ def test_model_added():
         }
     }
     least_busy_logger.log_pre_api_call(model="test", messages=[], kwargs=kwargs)
-    request_count_api_key = f"gpt-3.5-turbo_request_count"
-    assert test_cache.get_cache(key=request_count_api_key) is not None
+    request_count_api_key = "gpt-3.5-turbo_request_count:1234"
+    assert test_cache.get_cache(key=request_count_api_key) == 1
 
 
 def test_get_available_deployments():
@@ -52,8 +52,8 @@ def test_get_available_deployments():
         }
     }
     least_busy_logger.log_pre_api_call(model="test", messages=[], kwargs=kwargs)
-    request_count_api_key = f"{model_group}_request_count"
-    assert test_cache.get_cache(key=request_count_api_key) is not None
+    request_count_api_key = f"{model_group}_request_count:1234"
+    assert test_cache.get_cache(key=request_count_api_key) == 1
 
 
 # test_get_available_deployments()
@@ -105,14 +105,16 @@ async def test_router_get_available_deployments(async_test):
 
     model_group = "azure-model"
     request_count_dict = {"1": 10, "2": 54, "3": 100}
-    cache_key = f"{model_group}_request_count"
+    cache_keys = {f"{model_group}_request_count:{deployment_id}": count for deployment_id, count in request_count_dict.items()}
     if async_test is True:
-        await router.cache.async_set_cache(key=cache_key, value=request_count_dict)
+        for cache_key, count in cache_keys.items():
+            await router.cache.async_set_cache(key=cache_key, value=count)
         deployment = await router.async_get_available_deployment(
             model=model_group, messages=None, request_kwargs={}
         )
     else:
-        router.cache.set_cache(key=cache_key, value=request_count_dict)
+        for cache_key, count in cache_keys.items():
+            router.cache.set_cache(key=cache_key, value=count)
         deployment = router.get_available_deployment(model=model_group, messages=None)
     print(f"deployment: {deployment}")
     assert deployment["model_info"]["id"] == "1"
@@ -124,15 +126,11 @@ async def test_router_get_available_deployments(async_test):
         messages=[{"role": "user", "content": "Hey, how's it going?"}],
     )
 
-    return_dict = router.cache.get_cache(key=cache_key)
-
     # wait 2 seconds
     time.sleep(2)
 
     assert router.leastbusy_logger.logged_success == 1
-    assert return_dict["1"] == 10
-    assert return_dict["2"] == 54
-    assert return_dict["3"] == 100
+    assert {cache_key: router.cache.get_cache(key=cache_key) for cache_key in cache_keys} == cache_keys
 
 
 ## Test with Real calls ##

--- a/tests/local_testing/test_least_busy_routing.py
+++ b/tests/local_testing/test_least_busy_routing.py
@@ -104,7 +104,7 @@ async def test_router_get_available_deployments(async_test):
     router.leastbusy_logger.test_flag = True
 
     model_group = "azure-model"
-    request_count_dict = {1: 10, 2: 54, 3: 100}
+    request_count_dict = {"1": 10, "2": 54, "3": 100}
     cache_key = f"{model_group}_request_count"
     if async_test is True:
         await router.cache.async_set_cache(key=cache_key, value=request_count_dict)
@@ -130,9 +130,9 @@ async def test_router_get_available_deployments(async_test):
     time.sleep(2)
 
     assert router.leastbusy_logger.logged_success == 1
-    assert return_dict[1] == 10
-    assert return_dict[2] == 54
-    assert return_dict[3] == 100
+    assert return_dict["1"] == 10
+    assert return_dict["2"] == 54
+    assert return_dict["3"] == 100
 
 
 ## Test with Real calls ##

--- a/tests/test_litellm/router_strategy/test_least_busy.py
+++ b/tests/test_litellm/router_strategy/test_least_busy.py
@@ -1,13 +1,3 @@
-"""
-`least-busy` sent everything to the first-registered deployment and left the rest idle.
-
-Two defects in `_get_available_deployments`:
-- ties were compared with a strict `<`, so an equal count never displaced the first deployment. The
-  counts drain to zero between requests, so in light traffic every request is a tie
-- the counts came from a cache that can still hold ids for deployments that are no longer healthy.
-  When a stale id held the minimum, selection fell through to an arbitrary pick
-"""
-
 import collections
 
 import pytest
@@ -30,7 +20,6 @@ def _pick_counts(request_count: dict, healthy: list = HEALTHY, n: int = 1000) ->
 
 @pytest.mark.parametrize("request_count", [{}, {"A": 0, "B": 0}, {"A": 7, "B": 7}])
 def test_ties_are_spread_across_the_tied_deployments(request_count):
-    """Every deployment tied at the minimum must be reachable, not just the first one."""
     picks = _pick_counts(request_count)
 
     assert set(picks) == {"A", "B"}
@@ -58,18 +47,13 @@ def test_the_least_busy_deployment_wins(request_count, expected):
     assert set(_pick_counts(request_count, n=200)) == {expected}
 
 
-def test_an_unhealthy_deployment_cannot_win_the_minimum():
-    """
-    `C` is the least busy of the three but is in cooldown, so it is not in `healthy_deployments`. It
-    must neither be returned nor make the pick arbitrary: the answer is the least busy healthy one.
-    """
+def test_a_deployment_in_cooldown_cannot_win_the_minimum():
     picks = _pick_counts({"A": 5, "B": 3, "C": 0}, n=500)
 
     assert set(picks) == {"B"}
 
 
 def test_a_deployment_with_no_recorded_traffic_counts_as_idle():
-    """`B` has never been used, so it has no cache entry and must beat `A`."""
     picks = _pick_counts({"A": 4}, n=200)
 
     assert set(picks) == {"B"}

--- a/tests/test_litellm/router_strategy/test_least_busy.py
+++ b/tests/test_litellm/router_strategy/test_least_busy.py
@@ -1,0 +1,75 @@
+"""
+`least-busy` sent everything to the first-registered deployment and left the rest idle.
+
+Two defects in `_get_available_deployments`:
+- ties were compared with a strict `<`, so an equal count never displaced the first deployment. The
+  counts drain to zero between requests, so in light traffic every request is a tie
+- the counts came from a cache that can still hold ids for deployments that are no longer healthy.
+  When a stale id held the minimum, selection fell through to an arbitrary pick
+"""
+
+import collections
+
+import pytest
+
+from litellm.caching.caching import DualCache
+from litellm.router_strategy.least_busy import LeastBusyLoggingHandler
+
+HEALTHY = [{"model_info": {"id": "A"}}, {"model_info": {"id": "B"}}]
+
+
+def _pick_counts(request_count: dict, healthy: list = HEALTHY, n: int = 1000) -> collections.Counter:
+    handler = LeastBusyLoggingHandler(router_cache=DualCache())
+    return collections.Counter(
+        handler._get_available_deployments(healthy_deployments=healthy, all_deployments=dict(request_count))[
+            "model_info"
+        ]["id"]
+        for _ in range(n)
+    )
+
+
+@pytest.mark.parametrize("request_count", [{}, {"A": 0, "B": 0}, {"A": 7, "B": 7}])
+def test_ties_are_spread_across_the_tied_deployments(request_count):
+    """Every deployment tied at the minimum must be reachable, not just the first one."""
+    picks = _pick_counts(request_count)
+
+    assert set(picks) == {"A", "B"}
+    assert min(picks.values()) > 300
+
+
+def test_a_three_way_tie_reaches_every_deployment():
+    healthy = [{"model_info": {"id": name}} for name in ("A", "B", "C")]
+
+    picks = _pick_counts({}, healthy=healthy, n=1200)
+
+    assert set(picks) == {"A", "B", "C"}
+    assert min(picks.values()) > 250
+
+
+@pytest.mark.parametrize(
+    "request_count, expected",
+    [
+        ({"A": 5, "B": 1}, "B"),
+        ({"A": 1, "B": 5}, "A"),
+        ({"A": 0, "B": 3}, "A"),
+    ],
+)
+def test_the_least_busy_deployment_wins(request_count, expected):
+    assert set(_pick_counts(request_count, n=200)) == {expected}
+
+
+def test_an_unhealthy_deployment_cannot_win_the_minimum():
+    """
+    `C` is the least busy of the three but is in cooldown, so it is not in `healthy_deployments`. It
+    must neither be returned nor make the pick arbitrary: the answer is the least busy healthy one.
+    """
+    picks = _pick_counts({"A": 5, "B": 3, "C": 0}, n=500)
+
+    assert set(picks) == {"B"}
+
+
+def test_a_deployment_with_no_recorded_traffic_counts_as_idle():
+    """`B` has never been used, so it has no cache entry and must beat `A`."""
+    picks = _pick_counts({"A": 4}, n=200)
+
+    assert set(picks) == {"B"}

--- a/tests/test_litellm/router_strategy/test_least_busy.py
+++ b/tests/test_litellm/router_strategy/test_least_busy.py
@@ -1,11 +1,19 @@
+import asyncio
 import collections
+import inspect
+from datetime import UTC, datetime
 
 import pytest
 
+from litellm import Router
 from litellm.caching.caching import DualCache
+from litellm.caching.in_memory_cache import InMemoryCache
+from litellm.litellm_core_utils.logging_worker import GLOBAL_LOGGING_WORKER
 from litellm.router_strategy.least_busy import LeastBusyLoggingHandler
 
 HEALTHY = [{"model_info": {"id": "A"}}, {"model_info": {"id": "B"}}]
+MODEL_GROUP = "grp"
+RELEASE_METHODS = ("log_success_event", "log_failure_event", "async_log_success_event", "async_log_failure_event")
 
 
 def _pick_counts(request_count: dict, healthy: list = HEALTHY, n: int = 1000) -> collections.Counter:
@@ -19,14 +27,14 @@ def _pick_counts(request_count: dict, healthy: list = HEALTHY, n: int = 1000) ->
 
 
 @pytest.mark.parametrize("request_count", [{}, {"A": 0, "B": 0}, {"A": 7, "B": 7}])
-def test_ties_are_spread_across_the_tied_deployments(request_count):
+def test_ties_are_spread_across_the_tied_deployments(request_count: dict) -> None:
     picks = _pick_counts(request_count)
 
     assert set(picks) == {"A", "B"}
     assert min(picks.values()) > 300
 
 
-def test_a_three_way_tie_reaches_every_deployment():
+def test_a_three_way_tie_reaches_every_deployment() -> None:
     healthy = [{"model_info": {"id": name}} for name in ("A", "B", "C")]
 
     picks = _pick_counts({}, healthy=healthy, n=1200)
@@ -43,17 +51,194 @@ def test_a_three_way_tie_reaches_every_deployment():
         ({"A": 0, "B": 3}, "A"),
     ],
 )
-def test_the_least_busy_deployment_wins(request_count, expected):
+def test_the_least_busy_deployment_wins(request_count: dict, expected: str) -> None:
     assert set(_pick_counts(request_count, n=200)) == {expected}
 
 
-def test_a_deployment_in_cooldown_cannot_win_the_minimum():
+def test_a_deployment_in_cooldown_cannot_win_the_minimum() -> None:
     picks = _pick_counts({"A": 5, "B": 3, "C": 0}, n=500)
 
     assert set(picks) == {"B"}
 
 
-def test_a_deployment_with_no_recorded_traffic_counts_as_idle():
+def test_a_deployment_with_no_recorded_traffic_counts_as_idle() -> None:
     picks = _pick_counts({"A": 4}, n=200)
 
     assert set(picks) == {"B"}
+
+
+def _count_key(deployment_id: str) -> str:
+    return f"{MODEL_GROUP}_request_count:{deployment_id}"
+
+
+def _kwargs(deployment_id: str = "A", **logging_fields: object) -> dict:
+    return {
+        "litellm_params": {"metadata": {"model_group": MODEL_GROUP}, "model_info": {"id": deployment_id}},
+        **logging_fields,
+    }
+
+
+def _upstream_kwargs(deployment_id: str = "A") -> dict:
+    return _kwargs(deployment_id, api_call_start_time=datetime(2026, 1, 1, 12, 0, 0, tzinfo=UTC), cache_hit=None)
+
+
+def _handler(counts: dict | None = None) -> tuple[LeastBusyLoggingHandler, DualCache]:
+    cache = DualCache()
+    for deployment_id, count in (counts or {}).items():
+        cache.set_cache(key=_count_key(deployment_id), value=count)
+    return LeastBusyLoggingHandler(router_cache=cache), cache
+
+
+def _counts(cache: DualCache, *deployment_ids: str) -> dict:
+    return {deployment_id: cache.get_cache(key=_count_key(deployment_id)) or 0 for deployment_id in deployment_ids}
+
+
+async def _release(handler: LeastBusyLoggingHandler, method: str, kwargs: dict) -> None:
+    result = getattr(handler, method)(kwargs=kwargs, response_obj=None, start_time=None, end_time=None)
+    if inspect.isawaitable(result):
+        await result
+
+
+@pytest.mark.parametrize("method", RELEASE_METHODS)
+@pytest.mark.asyncio
+async def test_a_provider_call_takes_and_releases_one_slot(method: str) -> None:
+    handler, cache = _handler()
+
+    handler.log_pre_api_call(model="m", messages=[], kwargs=_kwargs("A"))
+    assert _counts(cache, "A") == {"A": 1}
+
+    await _release(handler, method, _upstream_kwargs("A"))
+    assert _counts(cache, "A") == {"A": 0}
+
+
+CACHE_HIT_SHAPES = {
+    "provider never called": _kwargs("A", cache_hit=True),
+    "an earlier attempt reached a provider": _upstream_kwargs("A") | {"cache_hit": True},
+}
+
+
+@pytest.mark.parametrize("method", RELEASE_METHODS)
+@pytest.mark.parametrize("kwargs", CACHE_HIT_SHAPES.values(), ids=CACHE_HIT_SHAPES.keys())
+@pytest.mark.asyncio
+async def test_a_cache_hit_does_not_release_a_slot(method: str, kwargs: dict) -> None:
+    handler, cache = _handler({"A": 1, "B": 1})
+
+    await _release(handler, method, kwargs)
+
+    assert _counts(cache, "A", "B") == {"A": 1, "B": 1}
+
+
+@pytest.mark.parametrize("method", ("log_failure_event", "async_log_failure_event"))
+@pytest.mark.asyncio
+async def test_a_failure_before_the_provider_call_does_not_release_a_slot(method: str) -> None:
+    handler, cache = _handler({"A": 1})
+
+    await _release(handler, method, _kwargs("A"))
+
+    assert _counts(cache, "A") == {"A": 1}
+
+
+@pytest.mark.parametrize("method", RELEASE_METHODS)
+@pytest.mark.parametrize("seed", (0, -5))
+@pytest.mark.asyncio
+async def test_a_slot_count_never_stays_below_zero(method: str, seed: int) -> None:
+    handler, cache = _handler({"A": seed})
+
+    await _release(handler, method, _upstream_kwargs("A"))
+
+    assert _counts(cache, "A") == {"A": 0}
+
+
+def _deployment(deployment_id: str) -> dict:
+    return {
+        "model_name": MODEL_GROUP,
+        "litellm_params": {"model": "openai/fake", "api_key": "x", "mock_response": "ok"},
+        "model_info": {"id": deployment_id},
+    }
+
+
+@pytest.mark.asyncio
+async def test_cache_hits_do_not_starve_a_deployment() -> None:
+    router = Router(
+        model_list=[_deployment("A"), _deployment("B")], routing_strategy="least-busy", cache_responses=True
+    )
+    messages = [{"role": "user", "content": "same prompt every time"}]
+
+    miss = await router.acompletion(model=MODEL_GROUP, messages=messages)
+    await asyncio.sleep(0)
+    await asyncio.wait_for(GLOBAL_LOGGING_WORKER.flush(), timeout=10)
+    assert miss._hidden_params.get("cache_hit") is not True
+    assert _counts(router.cache, "A", "B") == {"A": 0, "B": 0}
+
+    for deployment_id in ("A", "B"):
+        await router.cache.async_set_cache(key=_count_key(deployment_id), value=1)
+
+    hits = [await router.acompletion(model=MODEL_GROUP, messages=messages) for _ in range(5)]
+    await asyncio.wait_for(GLOBAL_LOGGING_WORKER.flush(), timeout=10)
+    assert all(hit._hidden_params.get("cache_hit") is True for hit in hits)
+    assert _counts(router.cache, "A", "B") == {"A": 1, "B": 1}
+
+    picks = [
+        (await router.async_get_available_deployment(model=MODEL_GROUP, request_kwargs={}, messages=messages))[
+            "model_info"
+        ]["id"]
+        for _ in range(100)
+    ]
+    assert set(picks) == {"A", "B"}
+
+
+class SharedStore:
+    def __init__(self) -> None:
+        self.values: dict = {}
+
+    def increment_cache(self, key: str, value: int, **kwargs: object) -> int:
+        self.values[key] = self.values.get(key, 0) + value
+        return self.values[key]
+
+    async def async_increment(self, key: str, value: int, **kwargs: object) -> int:
+        return self.increment_cache(key, value)
+
+    def set_cache(self, key: str, value: int, **kwargs: object) -> None:
+        self.values[key] = value
+
+    async def async_set_cache(self, key: str, value: int, **kwargs: object) -> None:
+        self.values[key] = value
+
+    def batch_get_cache(self, key_list: list[str], **kwargs: object) -> dict:
+        return {key: self.values.get(key) for key in key_list}
+
+    async def async_batch_get_cache(self, key_list: list[str], **kwargs: object) -> dict:
+        return self.batch_get_cache(key_list)
+
+
+def _worker(store: SharedStore) -> LeastBusyLoggingHandler:
+    return LeastBusyLoggingHandler(router_cache=DualCache(in_memory_cache=InMemoryCache(), redis_cache=store))
+
+
+def _pick(worker: LeastBusyLoggingHandler) -> str:
+    return worker.get_available_deployments(model_group=MODEL_GROUP, healthy_deployments=HEALTHY)["model_info"]["id"]
+
+
+async def _async_pick(worker: LeastBusyLoggingHandler) -> str:
+    chosen = await worker.async_get_available_deployments(model_group=MODEL_GROUP, healthy_deployments=HEALTHY)
+    return chosen["model_info"]["id"]
+
+
+@pytest.mark.asyncio
+async def test_in_flight_counts_are_shared_across_workers() -> None:
+    store = SharedStore()
+    worker_one, worker_two = _worker(store), _worker(store)
+
+    for _ in range(3):
+        worker_one.log_pre_api_call(model="m", messages=[], kwargs=_kwargs("A"))
+    assert {await _async_pick(worker_two) for _ in range(50)} == {"B"}
+
+    worker_two.log_pre_api_call(model="m", messages=[], kwargs=_kwargs("B"))
+    for _ in range(3):
+        await worker_one.async_log_success_event(
+            _upstream_kwargs("A"), response_obj=None, start_time=None, end_time=None
+        )
+
+    assert store.values == {_count_key("A"): 0, _count_key("B"): 1}
+    assert {_pick(worker_one) for _ in range(50)} == {"A"}
+    assert {await _async_pick(worker_two) for _ in range(50)} == {"A"}


### PR DESCRIPTION
## TLDR

Problem this solves:

- Least-busy sends everything to the first-listed deployment
- Under light traffic the other deployments get nothing
- A cooled-down deployment makes it pick at random

How it solves it:

- Split evenly when deployments are equally busy
- Only weigh deployments that are actually available

## User Flow

Before: an admin puts two identical servers behind one model name and sets least-busy, but only the first server ever gets used

1. They add two deployments under the same `model_name`, set `routing_strategy: least-busy`, and start the proxy
2. They send 30 POST https://litellm-domain/v1/chat/completions requests to that model name, one at a time, waiting for each to finish
3. Every response comes back with the same `x-litellm-model-id`, so all 30 went to the first server and the second served none
4. They send 100 more with 40 in flight at once. The first server takes 79 of them, and at one point is holding all 40 at the same time
5. They make the first server ten times slower and repeat. It still takes 60 of the 100, so the slower server gets more work than the fast one

After: the same setup spreads requests across both servers, and the faster one gets more of them

1. They add two deployments under the same `model_name`, set `routing_strategy: least-busy`, and start the proxy
2. They send 30 POST https://litellm-domain/v1/chat/completions requests to that model name, one at a time, waiting for each to finish
3. The `x-litellm-model-id` header alternates between the two servers, roughly 16 and 14
4. They send 100 more with 40 in flight at once. The split is roughly 50/50 and neither server is ever holding more than about half the in-flight requests
5. They make the first server ten times slower and repeat. It now takes 20 of the 100 while the faster one takes 80

## Relevant issues

Fixes #37622

## Linear ticket

<!-- if you are an internal contributor, add "Resolves " followed by the Linear ticket e.g., "Resolves LIT-1234" to link the Linear ticket to the GitHub PR. If you don't have one, leave the section blank rather than guessing -->

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix


Shared setup. Two real OpenAI deployments under one model name, so every request below is a live billed call. Which deployment served a request is read from the `x-litellm-model-id` response header.

`config.yaml`:

```yaml
model_list:
  - model_name: shared-model
    litellm_params:
      model: openai/gpt-4.1-mini
      api_key: os.environ/OPENAI_API_KEY
    model_info:
      id: deployment-one
  - model_name: shared-model
    litellm_params:
      model: openai/gpt-4.1-mini
      api_key: os.environ/OPENAI_API_KEY
    model_info:
      id: deployment-two

router_settings:
  routing_strategy: least-busy

general_settings:
  master_key: sk-1234
```

Start the proxy, then run:

```bash
for i in $(seq 1 30); do
  curl -sS -D - -o /dev/null -X POST http://localhost:4000/v1/chat/completions \
    -H "Authorization: Bearer sk-1234" -H 'Content-Type: application/json' \
    -d '{"model":"shared-model","messages":[{"role":"user","content":"hi"}],"max_tokens":5}' \
  | grep -i '^x-litellm-model-id'
done | sort | uniq -c
```

### Before

1. Thirty requests, one at a time

```
$ for i in $(seq 1 30); do ... done | sort | uniq -c
  30 x-litellm-model-id: deployment-one
```

Every request went to the first deployment. The second served nothing.

### After

1. Thirty requests, one at a time

```
$ for i in $(seq 1 30); do ... done | sort | uniq -c
  16 x-litellm-model-id: deployment-one
  14 x-litellm-model-id: deployment-two
```

Both deployments are used.
## Type

🐛 Bug Fix

## Caveats (if any)

### Low

- Ties are now random, so exact counts vary run to run
- Bursts arriving in the same instant can still stack up

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
