### PR TITLE
test(responses): adapt temperature tests to the gpt-5 reasoning validation

### DIFF
--- a/tests/llm_responses_api_testing/test_openai_responses_api.py
+++ b/tests/llm_responses_api_testing/test_openai_responses_api.py
@@ -1816,7 +1816,7 @@ async def test_extra_body_merges_with_request_data(extra_body_mock_response_data
         await litellm.aresponses(
             model="gpt-5.5",
             input="Test",
-            temperature=0.7,
+            temperature=1,
             max_output_tokens=20,
             extra_body={
                 "custom_field": "custom_value",

--- a/tests/openai_endpoints_tests/test_e2e_openai_responses_api.py
+++ b/tests/openai_endpoints_tests/test_e2e_openai_responses_api.py
@@ -115,9 +115,9 @@ def test_bad_request_error():
 def test_bad_request_bad_param_error():
     client = get_test_client()
     with pytest.raises(BadRequestError):
-        # Trigger error with invalid model name
+        # Out-of-range temperature on a non-reasoning model, so drop_params forwards it
         client.responses.create(
-            model="gpt-5.5", input="This should fail", temperature=2000
+            model="gpt-4.1", input="This should fail", temperature=2000
         )
 
 


### PR DESCRIPTION
## TLDR

Problem this solves:

- Staging commit e5c3df2da2 made gpt-5 models reject or drop temperature != 1 while reasoning is active
- `test_extra_body_merges_with_request_data` still sends temperature=0.7 to gpt-5.5, so `llm_responses_api_testing` fails at the merge base
- `test_bad_request_bad_param_error` sends temperature=2000 to gpt-5.5 expecting OpenAI's 400, but the proxy's `drop_params: True` now drops the param and the call succeeds, so `e2e_openai_endpoints` fails too
- Every PR carrying the run-ci label gets those red checks it didn't cause

How it solves it:

- The extra_body merge test now sends temperature=1, the reasoning-legal value; its assertion still verifies temperature is forwarded to OpenAI
- The bad-param test moves to gpt-4.1, a non-reasoning model, so the out-of-range temperature is forwarded and OpenAI's 400 comes back as before

## User Flow

Before: a contributor opens any PR with the run-ci label and two CircleCI suites fail on tests their change never touched

1. They push a branch and open a PR against litellm_internal_staging with the run-ci label
2. On the PR's checks tab, `ci/circleci: llm_responses_api_testing` goes red on `test_extra_body_merges_with_request_data` with "gpt-5.5 doesn't support temperature=0.7 while reasoning is active ..."
3. `ci/circleci: e2e_openai_endpoints` goes red on `test_bad_request_bad_param_error` with "DID NOT RAISE <class 'openai.BadRequestError'>"
4. Re-running the jobs fails identically, so the checks stay red no matter what their PR changes

After: the same PR's suites go green

1. They push a branch and open a PR against litellm_internal_staging with the run-ci label
2. On the PR's checks tab, `ci/circleci: llm_responses_api_testing` runs the same suite and `test_extra_body_merges_with_request_data` passes
3. `ci/circleci: e2e_openai_endpoints` runs and `test_bad_request_bad_param_error` gets its 400 and passes

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Test-only change, so the observable surface is the CI suites plus their live behavior; this PR carries the run-ci label so both jobs demonstrate the fix end to end

### Fix 1: `test_extra_body_merges_with_request_data` (mocked unit test)

Before (ae7e50f096):

```
$ uv run pytest "tests/llm_responses_api_testing/test_openai_responses_api.py::test_extra_body_merges_with_request_data"
E  litellm.exceptions.UnsupportedParamsError: litellm.UnsupportedParamsError: gpt-5.5 doesn't support temperature=0.7 while reasoning is active. Only temperature=1 is supported unless reasoning.effort resolves to 'none', either set explicitly on the request or declared as the model's default_reasoning_effort. To drop unsupported params set `litellm.drop_params = True`
FAILED tests/llm_responses_api_testing/test_openai_responses_api.py::test_extra_body_merges_with_request_data
============================== 1 failed in 0.27s ===============================
```

After (this branch):

```
$ uv run pytest "tests/llm_responses_api_testing/test_openai_responses_api.py::test_extra_body_merges_with_request_data"
tests/llm_responses_api_testing/test_openai_responses_api.py .           [100%]
============================== 1 passed in 0.04s ===============================
```

### Fix 2: `test_bad_request_bad_param_error` (live proxy, real OpenAI)

Live proxy booted from this branch with the job's own config (`litellm/proxy/example_config_yaml/oai_misc_config.yaml`, which sets `drop_params: True`), a real Postgres, and a real `OPENAI_API_KEY`; key minted via `POST /key/generate` exactly like the test's `get_test_client()`

The old test body, gpt-5.5 with temperature=2000, no longer 400s because the proxy drops the param (why the job fails at the merge base):

```
$ curl -sS -o /dev/null -w 'HTTP %{http_code}\n' -X POST http://localhost:41873/v1/responses \
    -H "Authorization: Bearer $GENERATED_KEY" -H "Content-Type: application/json" \
    -d '{"model":"gpt-5.5","input":"This should fail","temperature":2000,"max_output_tokens":16}'
HTTP 200
```

The new test body, gpt-4.1 with temperature=2000, forwards the param and OpenAI rejects it:

```
$ curl -sS -w '\nHTTP %{http_code}\n' -X POST http://localhost:41873/v1/responses \
    -H "Authorization: Bearer $GENERATED_KEY" -H "Content-Type: application/json" \
    -d '{"model":"gpt-4.1","input":"This should fail","temperature":2000}'
{"error":{"message":"litellm.BadRequestError: OpenAIException - {\n  \"error\": {\n    \"message\": \"Invalid 'temperature': decimal above maximum value. Expected a value <= 2.0, but got 2000 instead.\",\n    \"type\": \"invalid_request_error\",\n    \"param\": \"temperature\",\n    \"code\": \"decimal_above_max_value\"\n  }\n}. Received Model Group=gpt-4.1\nAvailable Model Group Fallbacks=None","code":"400"}}
HTTP 400
```

## Type

✅ Test

## Caveats (if any)

### Low

- Test-only change; runtime behavior is untouched
- The gpt-5 temperature validation itself shipped in e5c3df2da2, not here
- With `drop_params: True` there is no way to get a temperature 400 out of a gpt-5 model anymore, so the bad-param test intentionally moves to a non-reasoning model

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

CHECKED: /live-pr-risk at 66947fcf7c. Test-only diff, no production symbols changed; the only dependents are the two CircleCI jobs that run these files (llm_responses_api_testing, e2e_openai_endpoints), both green at this tip with run-ci. No staging drift: the merge base equals the current staging tip, so the merged tree is the head tree. The rewritten assertion's one upstream dependency, OpenAI returning 400 for temperature=2000 on gpt-4.1, is observed live in the proof above. Verdict: SAFE

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes; no production code paths are modified.
> 
> **Overview**
> Updates two Responses API tests that broke after **gpt-5** models started rejecting or dropping `temperature` values other than **1** while reasoning is active (and when the proxy uses **`drop_params: True`**).
> 
> In **`test_extra_body_merges_with_request_data`**, the mocked `aresponses` call now uses **`temperature=1`** instead of `0.7` on **`gpt-5.5`**, so the request is valid while the test still checks that **`temperature`** and **`extra_body`** fields are merged into the outbound JSON.
> 
> In **`test_bad_request_bad_param_error`**, the live e2e case switches from **`gpt-5.5`** to **`gpt-4.1`** with **`temperature=2000`**, so an invalid temperature is forwarded to OpenAI and **`BadRequestError`** is raised again instead of the param being dropped and the call succeeding.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 66947fcf7cd10e2c3bfdc98327c32c3dae13b971. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->