### PR TITLE
fix(proxy): send access-group key membership writes to the primary

### DIFF
--- a/litellm/proxy/management_helpers/access_group_key_sync.py
+++ b/litellm/proxy/management_helpers/access_group_key_sync.py
@@ -26,7 +26,7 @@ schema.
 """
 
 from collections.abc import Sequence
-from typing import Final, Protocol
+from typing import Final, Protocol, cast
 
 from pydantic import BaseModel
 
@@ -38,6 +38,7 @@ from litellm.proxy._types import (
 from litellm.proxy.auth.auth_checks import (
     _delete_cache_access_object,  # pyright: ignore[reportPrivateUsage]  # the access-group endpoints reach for this same cache primitive
 )
+from litellm.proxy.db.routing_prisma_wrapper import RoutingPrismaWrapper
 from litellm.repositories.table_repositories import AccessGroupRepository
 
 
@@ -72,8 +73,11 @@ _REPOINT_KEY_SQL: Final = (
 
 
 def _raw_executor(prisma_client: object) -> _RawExecutor:
-    """Narrow the untyped Prisma client down to the raw-query call this module makes."""
-    return AccessGroupRepository(prisma_client).prisma_client.db  # pyright: ignore[reportAny]  # untyped Prisma client
+    """Route raw membership writes to the primary database."""
+    db: Final[object] = AccessGroupRepository(prisma_client).prisma_client.db  # pyright: ignore[reportAny]  # untyped Prisma client
+    if isinstance(db, RoutingPrismaWrapper):
+        return cast(_RawExecutor, db.writer)
+    return cast(_RawExecutor, db)
 
 
 async def _invalidate_access_group_cache(access_group_id: str) -> None:

--- a/litellm/proxy/management_helpers/access_group_key_sync.py
+++ b/litellm/proxy/management_helpers/access_group_key_sync.py
@@ -26,7 +26,7 @@ schema.
 """
 
 from collections.abc import Sequence
-from typing import Final, Protocol, cast
+from typing import Final, Protocol
 
 from pydantic import BaseModel
 
@@ -75,9 +75,8 @@ _REPOINT_KEY_SQL: Final = (
 def _raw_executor(prisma_client: object) -> _RawExecutor:
     """Route raw membership writes to the primary database."""
     db: Final[object] = AccessGroupRepository(prisma_client).prisma_client.db  # pyright: ignore[reportAny]  # untyped Prisma client
-    if isinstance(db, RoutingPrismaWrapper):
-        return cast(_RawExecutor, db.writer)
-    return cast(_RawExecutor, db)
+    primary: Final[object] = db.writer if isinstance(db, RoutingPrismaWrapper) else db
+    return primary  # pyright: ignore[reportReturnType]  # untyped Prisma client; query_raw is the only call
 
 
 async def _invalidate_access_group_cache(access_group_id: str) -> None:

--- a/tests/test_litellm/proxy/management_helpers/test_access_group_key_sync.py
+++ b/tests/test_litellm/proxy/management_helpers/test_access_group_key_sync.py
@@ -1,0 +1,32 @@
+from types import SimpleNamespace
+from typing import Final
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from litellm.proxy._types import LiteLLM_VerificationToken
+from litellm.proxy.db.prisma_client import PrismaWrapper
+from litellm.proxy.db.routing_prisma_wrapper import RoutingPrismaWrapper
+from litellm.proxy.management_helpers.access_group_key_sync import (
+    sync_key_regeneration_access_group_membership,
+)
+
+
+@pytest.mark.asyncio
+async def test_key_regeneration_access_group_write_uses_primary() -> None:
+    writer_query: Final = AsyncMock(return_value=[])
+    reader_query: Final = AsyncMock(side_effect=RuntimeError("read-only transaction"))
+    writer: Final = PrismaWrapper(MagicMock(query_raw=writer_query))
+    reader: Final = PrismaWrapper(MagicMock(query_raw=reader_query))
+    prisma_client: Final = SimpleNamespace(db=RoutingPrismaWrapper(writer=writer, reader=reader))
+
+    await sync_key_regeneration_access_group_membership(
+        prisma_client=prisma_client,
+        previous_key_token="old-hash",
+        new_key_token="new-hash",
+        data=None,
+        existing_key_row=LiteLLM_VerificationToken(token="old-hash"),
+    )
+
+    writer_query.assert_awaited_once()
+    reader_query.assert_not_awaited()


### PR DESCRIPTION
## TLDR

Problem this solves:

- Key regenerate fails when a read replica is configured
- The membership write is sent to the replica, which rejects it
- The token is already rotated, so the old key then 404s on info, regenerate, and delete

How it solves it:

- Membership writes go to the primary instead of the replica
- Key regenerate, update, and delete keep working with a replica set
- Same routing as other primary-only database calls already use

## User Flow

Only shows up when the proxy is configured with `DATABASE_URL_READ_REPLICA`

Before: a developer regenerates their virtual key, gets an error, and from then on the key cannot be viewed, rotated, or revoked

1. They send POST https://<litellm-proxy>/key/{key}/regenerate with the master key
2. The response is 500 with `cannot execute UPDATE in a read-only transaction`. No new key is returned, so they keep using the old one
3. The old key has already been rotated away, so it no longer works
4. They retry, or send GET https://<litellm-proxy>/key/info?key={key} or POST https://<litellm-proxy>/key/delete for that key. Every call returns 404 (`Key not found` / `No keys found`)
5. The key is stuck: it cannot be regenerated, inspected, or revoked through the API

After: the same regenerate succeeds and the key stays manageable

1. They send POST https://<litellm-proxy>/key/{key}/regenerate with the master key
2. The response is 200 with the new key string
3. The old key has already been rotated away, so it no longer works
4. GET https://<litellm-proxy>/key/info?key={new_key} and POST https://<litellm-proxy>/key/delete for that key succeed
5. The key stays manageable through the API

Availability consequence: before this change, regenerating a key on a read-replica deployment leaves that key rotated but unrecoverable through the API. After, regenerate returns the new key and later info/delete still work

## Relevant issues

Fixes #38667

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Shared setup: `DATABASE_URL` is the writer, `DATABASE_URL_READ_REPLICA` is a read-only replica (Aurora reader endpoint or any Postgres hot standby). Master key in `Authorization`. This workspace has no replica, so Before is the live v1.98.0 capture from #38667 (same unpatched helper as merge base `ae7e50f096`). After is the routing regression at tip `bd36eb0dce`, plus the live curl a replica deployment should use

### Before (ae7e50f096)

1. `curl -sS -X POST "https://<litellm-proxy>/key/<key>/regenerate" -H "Authorization: Bearer <master_key>"`
2. Live proxy logs:
```json
{"message": "Error regenerating key: ERROR: cannot execute UPDATE in a read-only transaction", "level": "ERROR", "logger": "key_management_endpoints.py:5067"}
```
3. Follow-up `GET /key/info` and `POST /key/delete` on the same key:
```json
{"message": "Exception: Key not found in database", "level": "ERROR", "logger": "key_management_endpoints.py (info_key_fn)"}
{"message": "delete_verification_tokens(): Exception occured - 404: {'error': 'No keys found'}", "level": "ERROR"}
```

Control from the issue: unsetting the read replica, or staying on v1.97.0 with the same topology, makes the identical request succeed

### After (bd36eb0dce)

1. `uv run --no-sync pytest tests/test_litellm/proxy/management_helpers/test_access_group_key_sync.py -v`
2. Observed: `test_key_regeneration_access_group_write_uses_primary PASSED`. The helper talks to the primary. The replica mock that raises `read-only transaction` is never called
3. Live replica runbook (same as Before, against a proxy built from this branch):
```bash
curl -sS -X POST "http://localhost:4000/key/<key>/regenerate" \
  -H "Authorization: Bearer sk-1234"
```
Expect 200 with a new key string, then `GET /key/info?key=<new_key>` and `POST /key/delete` for that key succeed

## Type

🐛 Bug Fix
✅ Test

## Caveats (if any)

### Low

- Other `query_raw` writes elsewhere would still go to the replica; this PR only fixes the key membership path that is breaking regenerate
- Team membership already runs inside a writer transaction, so it is unchanged here

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR