### PR TITLE
fix(ui): trim whitespace on delete confirmation input

### DIFF
--- a/ui/litellm-dashboard/src/components/common_components/DeleteResourceModal.test.tsx
+++ b/ui/litellm-dashboard/src/components/common_components/DeleteResourceModal.test.tsx
@@ -134,6 +134,12 @@ describe("DeleteResourceModal", () => {
     expect(screen.getByRole("button", { name: /delete/i })).toBeDisabled();
   });
 
+  it("should enable delete when the stored name itself has surrounding whitespace", () => {
+    renderWithProviders(<DeleteResourceModal {...defaultProps} requiredConfirmation="  prod-key  " />);
+    fireEvent.change(screen.getByRole("textbox"), { target: { value: "prod-key" } });
+    expect(screen.getByRole("button", { name: /delete/i })).toBeEnabled();
+  });
+
   it("should reset requiredConfirmation input when modal opens", async () => {
     const user = userEvent.setup();
     const { rerender } = renderWithProviders(<DeleteResourceModal {...defaultProps} requiredConfirmation="DELETE" />);

--- a/ui/litellm-dashboard/src/components/common_components/DeleteResourceModal.test.tsx
+++ b/ui/litellm-dashboard/src/components/common_components/DeleteResourceModal.test.tsx
@@ -121,6 +121,19 @@ describe("DeleteResourceModal", () => {
     expect(deleteButton).toBeEnabled();
   });
 
+  it("should enable delete button when the confirmation input matches after surrounding whitespace is trimmed", () => {
+    renderWithProviders(<DeleteResourceModal {...defaultProps} requiredConfirmation="prod-key" />);
+    const input = screen.getByPlaceholderText("prod-key");
+    fireEvent.change(input, { target: { value: "  prod-key  " } });
+    expect(screen.getByRole("button", { name: /delete/i })).toBeEnabled();
+  });
+
+  it("should keep delete disabled when trimmed confirmation input still does not match", () => {
+    renderWithProviders(<DeleteResourceModal {...defaultProps} requiredConfirmation="prod-key" />);
+    fireEvent.change(screen.getByPlaceholderText("prod-key"), { target: { value: "  other-key  " } });
+    expect(screen.getByRole("button", { name: /delete/i })).toBeDisabled();
+  });
+
   it("should reset requiredConfirmation input when modal opens", async () => {
     const user = userEvent.setup();
     const { rerender } = renderWithProviders(<DeleteResourceModal {...defaultProps} requiredConfirmation="DELETE" />);

--- a/ui/litellm-dashboard/src/components/common_components/DeleteResourceModal.tsx
+++ b/ui/litellm-dashboard/src/components/common_components/DeleteResourceModal.tsx
@@ -102,7 +102,8 @@ export default function DeleteResourceModal({
             variant="destructive"
             onClick={onOk}
             disabled={
-              (!!requiredConfirmation && requiredConfirmationInput.trim() !== requiredConfirmation) || confirmLoading
+              (!!requiredConfirmation && requiredConfirmationInput.trim() !== requiredConfirmation.trim()) ||
+              confirmLoading
             }
           >
             {confirmLoading ? "Deleting..." : "Delete"}

--- a/ui/litellm-dashboard/src/components/common_components/DeleteResourceModal.tsx
+++ b/ui/litellm-dashboard/src/components/common_components/DeleteResourceModal.tsx
@@ -101,7 +101,9 @@ export default function DeleteResourceModal({
           <Button
             variant="destructive"
             onClick={onOk}
-            disabled={(!!requiredConfirmation && requiredConfirmationInput !== requiredConfirmation) || confirmLoading}
+            disabled={
+              (!!requiredConfirmation && requiredConfirmationInput.trim() !== requiredConfirmation) || confirmLoading
+            }
           >
             {confirmLoading ? "Deleting..." : "Delete"}
           </Button>


### PR DESCRIPTION
## TLDR

Problem this solves:

- Deleting a virtual key asks you to type the key name
- Copy-paste often includes a leading or trailing space
- That space keeps the Delete button disabled even when the name is right

How it solves it:

- Surrounding whitespace is ignored when matching the typed name
- A pasted name that only differs by spaces enables Delete
- A different name still keeps Delete disabled

## User Flow

Before: an admin copies a key name into the delete confirmation box, includes a stray space, and cannot click Delete

1. They open http://localhost:4000/ui/api-keys and click a virtual key to open its detail page
2. They open More key actions and click Delete Key
3. The dialog asks them to type the key name (for example `prod-key`) to confirm
4. They paste the name and accidentally include a leading or trailing space, so the field shows ` prod-key `
5. Delete stays disabled, so they cannot finish the deletion

After: the same paste enables Delete, because surrounding spaces are ignored

1. They open http://localhost:4000/ui/api-keys and click a virtual key to open its detail page
2. They open More key actions and click Delete Key
3. The dialog asks them to type the key name (for example `prod-key`) to confirm
4. They paste the name and accidentally include a leading or trailing space, so the field shows ` prod-key `
5. Delete is enabled, and clicking it deletes the key as usual

## Relevant issues

Fixes #38732

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Dashboard: `npm run dev` in `ui/litellm-dashboard` (port 3000) or the proxy UI at http://localhost:4000/ui/api-keys. Do not click Delete on a key you still need; confirming the button state is enough

### Before (ae7e50f096)

1. Open http://localhost:4000/ui/api-keys, click a key, then More key actions -> Delete Key
2. Paste the key name with a leading or trailing space
3. Delete stays disabled

### After (9000134849)

1. Open http://localhost:4000/ui/api-keys, click a key, then More key actions -> Delete Key
2. Paste the key name with a leading or trailing space
3. Delete is enabled

Local component check (renders the same dialog):

```bash
cd ui/litellm-dashboard
npx vitest run --project component src/components/common_components/DeleteResourceModal.test.tsx
```

27 tests passed, including paste-with-spaces and a padded stored name

## Type

🐛 Bug Fix
✅ Test

## Caveats (if any)

### Low

- The same confirmation dialog is used for other deletes (teams, credentials). Those type-to-confirm fields now ignore surrounding spaces too

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR