### PR TITLE
fix(anthropic): correctly inject cache_control into tool_result content block

### DIFF
--- a/litellm/integrations/anthropic_cache_control_hook.py
+++ b/litellm/integrations/anthropic_cache_control_hook.py
@@ -374,7 +374,12 @@ class AnthropicCacheControlHook(CustomPromptManagement):
 
         # 1. if string, insert cache control in the message
         if isinstance(message_content, str):
-            message["cache_control"] = control
+            if message.get("role") == "tool":
+                message["content"] = [  # pyright: ignore[reportGeneralTypeIssues]  # list conversion
+                    {"type": "text", "text": message_content, "cache_control": control}
+                ]
+            else:
+                message["cache_control"] = control  # pyright: ignore[reportGeneralTypeIssues]  # cache_control field
         # 2. list of objects - only apply to last item per Anthropic spec
         elif isinstance(message_content, list):
             if len(message_content) > 0 and isinstance(message_content[-1], dict):

--- a/tests/test_litellm/integrations/test_anthropic_cache_control_hook.py
+++ b/tests/test_litellm/integrations/test_anthropic_cache_control_hook.py
@@ -2909,3 +2909,23 @@ class TestRecordGatewayInjection:
             custom_llm_provider="anthropic",
         )
         assert self.KEY not in kwargs["litellm_metadata"]
+    def test_tool_result_string_content_wrapped_in_list(self):
+        from litellm.integrations.anthropic_cache_control_hook import AnthropicCacheControlHook
+        from litellm.types.llms.openai import ChatCompletionCachedContent
+
+        message = {
+            "role": "tool",
+            "tool_call_id": "call_1",
+            "content": "Sunny"
+        }
+
+        control = ChatCompletionCachedContent(type="ephemeral")
+
+        modified_message = AnthropicCacheControlHook._safe_insert_cache_control_in_message(message, control, False)
+        
+        # Should be converted to a list
+        assert isinstance(modified_message["content"], list)
+        assert len(modified_message["content"]) == 1
+        assert modified_message["content"][0]["type"] == "text"
+        assert modified_message["content"][0]["text"] == "Sunny"
+        assert modified_message["content"][0]["cache_control"] == control


### PR DESCRIPTION
## TLDR

Problem this solves:
- Tool responses as strings crash Anthropic cache control injection
- `cache_control` was being placed at the top level instead of in a text block

How it solves it:
- Converts string tool messages into a list containing a text block
- Applies `cache_control` inside the generated block per Anthropic spec

## User Flow

Before: an app making a multi-turn tool call with `ephemeral` caching fails Anthropic validation
1. The app sends a multi-turn tool conversation with prompt caching enabled.
2. The proxy receives a tool response where content is a simple string.
3. The proxy injects `cache_control` directly at the top level of the message dictionary.
4. Anthropic rejects the payload with a validation error because `cache_control` must be inside a content block array.

After: the same request succeeds and caches correctly
1. The app sends a multi-turn tool conversation with prompt caching enabled.
2. The proxy receives a tool response where content is a simple string.
3. The proxy automatically wraps the string into an array and injects `cache_control` correctly inside the text block.
4. Anthropic accepts the correctly shaped payload and applies the cache control breakpoint.

## Relevant issues

Fixes #38718

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

### Before (merge-base)
1. Run a reproduction script making an Anthropic tool request with `cache_control={"type": "ephemeral"}`
2. Fails with validation error on the Anthropic side due to misplaced `cache_control`

### After (tip)
1. Run the exact same reproduction script
2. The request succeeds natively, and the tool cache control breakpoint is correctly registered and accepted

## Type

🐛 Bug Fix

## Caveats (if any)
*(None)*

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
