### PR TITLE
fix(proxy): catch HTTPException cleanly on /key/delete to prevent infinite loop logging

### DIFF
--- a/litellm/proxy/management_endpoints/key_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/key_management_endpoints.py
@@ -3501,6 +3501,8 @@ async def delete_key_fn(
 
         return {"deleted_keys": deleted_keys}
     except Exception as e:
+        if isinstance(e, HTTPException):
+            raise handle_exception_on_proxy(e)
         verbose_proxy_logger.exception("litellm.proxy.proxy_server.delete_key_fn(): Exception occured - %s", e)
         raise handle_exception_on_proxy(e)
 
@@ -4251,6 +4253,8 @@ async def delete_verification_tokens(
         else:
             raise Exception("DB not connected. prisma_client is None")
     except Exception as e:
+        if isinstance(e, HTTPException):
+            raise
         verbose_proxy_logger.exception(
             "litellm.proxy.proxy_server.delete_verification_tokens(): Exception occured - %s", e
         )

--- a/tests/test_litellm/proxy/management_endpoints/test_key_management_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_key_management_endpoints.py
@@ -5151,6 +5151,42 @@ async def test_delete_key_fn_persists_deleted_keys(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_delete_key_fn_404_not_found(monkeypatch):
+    """Test that deleting a non-existent key raises a 404 cleanly."""
+    from litellm.proxy._types import KeyRequest, ProxyException
+    from litellm.proxy.management_endpoints.key_management_endpoints import delete_key_fn
+    from fastapi import HTTPException
+    
+    mock_prisma_client = AsyncMock()
+    mock_user_api_key_cache = MagicMock()
+
+    user_api_key_dict = UserAPIKeyAuth(
+        user_id="admin-user",
+        api_key="sk-admin",
+        user_role=LitellmUserRoles.PROXY_ADMIN.value,
+    )
+    
+    # Mock find_many to return an empty list, simulating a key that isn't found
+    mock_prisma_client.verificationtoken.find_many.return_value = []
+    
+    monkeypatch.setattr(
+        "litellm.proxy.proxy_server.prisma_client",
+        mock_prisma_client,
+    )
+
+    data = KeyRequest(keys=["sk-nonexistent-key"])
+
+    with pytest.raises(ProxyException) as excinfo:
+        await delete_key_fn(
+            data=data,
+            user_api_key_dict=user_api_key_dict,
+            litellm_changed_by="admin-user",
+        )
+    
+    assert "No keys found" in str(excinfo.value)
+
+
+@pytest.mark.asyncio
 async def test_can_delete_verification_token_proxy_admin_team_key(monkeypatch):
     """Test that team admin can delete team keys from their own team."""
     key_info = LiteLLM_VerificationToken(


### PR DESCRIPTION
<!--
Thank you for contributing to LiteLLM!

Please ensure your pull request conforms to the guidelines in CONTRIBUTING.md.
-->

<!-- Insert a brief description of what this PR does. -->
Fixes #38731 by cleanly catching `HTTPException` in `delete_key_fn` and `delete_verification_tokens` so that 404 Not Found errors on deleted/expired keys do not pollute the server logs with massive exception tracebacks. This prevents the illusion of the LiteLLM proxy being stuck in an infinite loop crash when a client script repeatedly tries to delete a non-existent key.

### What is this PR for?
<!-- Check the box that applies. -->
- [X] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### What's Changed
<!-- Detail the changes you've made. For example: -->
<!-- - Added functionality to parse JSON configuration files -->
<!-- - Fixed a memory leak in the data processing module -->
- Updated `delete_verification_tokens` to raise `HTTPException` directly without passing through `verbose_proxy_logger.exception` first.
- Updated `delete_key_fn` to do the same.

### Why is it needed?
<!-- Explain the rationale behind the changes. For instance: -->
<!-- - The existing configuration parsing was limited to INI files, restricting flexibility. -->
<!-- - The memory leak caused the application to crash under heavy load. -->
Because an external script polling or looping on a 404 from `/key/delete` will spam the proxy logs with huge python stack traces, causing users to mistakenly think the LiteLLM proxy itself is stuck in an infinite loop and crashing.

### How to test it
<!-- Describe the steps to test the changes. For example: -->
<!-- 1. Run the application with a JSON configuration file. -->
<!-- 2. Verify that the configuration settings are correctly loaded. -->
<!-- 3. Use a memory profiler to check for leaks during data processing. -->
1. Attempt to hit `POST /key/delete` with an invalid/fake key.
2. Observe that a 404 is properly returned without generating an `ERROR` stack trace in the server console.

### Related issue
<!-- Link to the related issue, if any. -->
<!-- For example: Fixes #123 -->
Fixes #38731
