### PR TITLE
docs: fix typo intialized -> initialized

### DIFF
--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -567,7 +567,7 @@ class Logging(LiteLLMLoggingBaseClass):
         """
         Initializes CustomLogger compatible callbacks in self.dynamic_* callbacks
 
-        If a callback is in litellm._known_custom_logger_compatible_callbacks, it needs to be intialized and added to the respective dynamic_* callback list.
+        If a callback is in litellm._known_custom_logger_compatible_callbacks, it needs to be initialized and added to the respective dynamic_* callback list.
         """
         # Process input callbacks
         self.dynamic_input_callbacks = self._process_dynamic_callback_list(


### PR DESCRIPTION
Corrects the misspelling `intialized` -> `initialized` in `litellm/litellm_core_utils/litellm_logging.py`.

Documentation only, no behaviour change.