### PR TITLE
perf(rust): use pythonize for bridge serialization

### DIFF
--- a/litellm-rust/Cargo.lock
+++ b/litellm-rust/Cargo.lock
@@ -3,6 +3,36 @@
 version = 4
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c982642fa9e8606056828ee9a8505737230110bb1099153c79efe865c59d12ba"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "alloca"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5a7d05ea6aea7e9e64d25b9156ba2fee3fdd659e34e41063cd2fc7cd020d7f4"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
+name = "anstyle"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
 name = "arc-swap"
 version = "1.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -507,6 +537,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "cc"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -540,6 +576,58 @@ dependencies = [
  "cpufeatures 0.3.0",
  "rand_core 0.10.1",
 ]
+
+[[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
+
+[[package]]
+name = "clap"
+version = "4.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "473c7e07f409a8d772161724aa8db6a765a2532a70f9667eeb7b49d3d02fbdca"
+dependencies = [
+ "clap_builder",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b48fea5a88e9ae728a2dcbedbfc0e730f7d60da42e1cb049a83c9fb8b789889"
+dependencies = [
+ "anstyle",
+ "clap_lex",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cmake"
@@ -595,6 +683,72 @@ checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "criterion"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "950046b2aa2492f9a536f5f4f9a3de7b9e2476e575e05bd6c333371add4d98f3"
+dependencies = [
+ "alloca",
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "itertools",
+ "num-traits",
+ "oorandom",
+ "page_size",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8d80a2f4f5b554395e47b5d8305bc3d27813bacb73493eb1001e8f76dae29ea"
+dependencies = [
+ "cast",
+ "itertools",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5181e0de7b61eb03a81e347d6dd8797bae9da5146707b51077e2d71a54ec0ceb"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
@@ -854,6 +1008,17 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
+]
+
+[[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
 ]
 
 [[package]]
@@ -1180,6 +1345,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1255,10 +1429,13 @@ dependencies = [
 name = "litellm-python-bridge"
 version = "0.1.0"
 dependencies = [
+ "criterion",
  "litellm-ai-gateway",
  "litellm-core",
  "pyo3",
  "pyo3-async-runtimes",
+ "pythonize",
+ "serde",
  "serde_json",
  "tokio",
 ]
@@ -1341,6 +1518,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
 name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1351,6 +1534,16 @@ name = "outref"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
+
+[[package]]
+name = "page_size"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30d5b2194ed13191c1999ae0704b7839fb18384fa22e49b57eeaa97d79ce40da"
+dependencies = [
+ "libc",
+ "winapi",
+]
 
 [[package]]
 name = "percent-encoding"
@@ -1375,6 +1568,34 @@ name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
+name = "plotters"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
+dependencies = [
+ "plotters-backend",
+]
 
 [[package]]
 name = "portable-atomic"
@@ -1484,6 +1705,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.119",
+]
+
+[[package]]
+name = "pythonize"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ec376e1216e0c929a74964ce2020012a1a39f32d80e78aa688721219ea7fb89"
+dependencies = [
+ "pyo3",
+ "serde",
 ]
 
 [[package]]
@@ -1614,10 +1845,59 @@ dependencies = [
 ]
 
 [[package]]
+name = "rayon"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "regex"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f020237b6c8eed93db2e2cb53c00c60a8e1bc73da7d073199a1180401450218d"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad8553b9b26413251cbf30e620595c7a41b3887f03da04579c0e6b0d6a06b4b2"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
 name = "regex-lite"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cab834c73d247e67f4fae452806d17d3c7501756d98c8808d7c9c7aa7d18f973"
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "reqwest"
@@ -1773,6 +2053,15 @@ name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "schannel"
@@ -2100,6 +2389,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "tinyvec"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2364,6 +2663,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "want"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2474,6 +2783,37 @@ checksum = "7dcd9d09a39985f5344844e66b0c530a33843579125f23e21e9f0f220850f22a"
 dependencies = [
  "rustls-pki-types",
 ]
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-link"

--- a/litellm-rust/Cargo.toml
+++ b/litellm-rust/Cargo.toml
@@ -18,6 +18,7 @@ litellm-ai-gateway = { path = "crates/ai-gateway", default-features = false }
 axum = "0.7"
 pyo3 = "0.29.0"
 pyo3-async-runtimes = { version = "0.29.0", features = ["tokio-runtime"] }
+pythonize = "0.29.0"
 rand = "0.8"
 reqwest = { version = "0.12", default-features = false, features = ["blocking", "json", "rustls-tls", "http2", "stream"] }
 serde = { version = "1.0", features = ["derive"] }

--- a/litellm-rust/crates/python-bridge/Cargo.toml
+++ b/litellm-rust/crates/python-bridge/Cargo.toml
@@ -9,10 +9,23 @@ repository.workspace = true
 name = "_native"
 crate-type = ["cdylib"]
 
+[features]
+default = ["extension-module"]
+extension-module = ["pyo3/extension-module"]
+
 [dependencies]
 litellm-core = { workspace = true, features = ["bedrock-auth"] }
 litellm-ai-gateway = { workspace = true, default-features = false }
-pyo3 = { workspace = true, features = ["extension-module"] }
+pyo3.workspace = true
 pyo3-async-runtimes.workspace = true
+pythonize.workspace = true
+serde.workspace = true
 serde_json.workspace = true
 tokio.workspace = true
+
+[dev-dependencies]
+criterion = "0.8.2"
+
+[[bench]]
+name = "serialization"
+harness = false

--- a/litellm-rust/crates/python-bridge/benches/serialization.rs
+++ b/litellm-rust/crates/python-bridge/benches/serialization.rs
@@ -6,7 +6,13 @@ use pyo3::prelude::*;
 use pyo3::types::PyDict;
 use serde_json::{Value, json};
 
-const PAYLOAD_BYTES: usize = 4 * 1024 * 1024;
+const PAYLOAD_SIZES: &[(&str, usize)] = &[
+    ("1_KiB", 1024),
+    ("64_KiB", 64 * 1024),
+    ("1_MiB", 1024 * 1024),
+    ("4_MiB", 4 * 1024 * 1024),
+    ("16_MiB", 16 * 1024 * 1024),
+];
 
 fn former_json_roundtrip_from_py(py: Python<'_>, value: &Bound<'_, PyAny>) -> Value {
     let json = py.import("json").expect("Python json module should import");
@@ -39,55 +45,60 @@ fn pythonize_to_py(py: Python<'_>, value: &Value) -> Py<PyAny> {
 fn serialization(c: &mut Criterion) {
     Python::initialize();
     Python::attach(|py| {
-        let data_uri = format!("data:image/png;base64,{}", "A".repeat(PAYLOAD_BYTES));
-        let document = PyDict::new(py);
-        document
-            .set_item("type", "image_url")
-            .expect("document type should be set");
-        document
-            .set_item("image_url", &data_uri)
-            .expect("document URL should be set");
-
-        let response = json!({
-            "pages": [{
-                "index": 0,
-                "markdown": "OCR text",
-                "images": [{"image_base64": data_uri}],
-            }],
-            "model": "mistral-ocr-latest",
-            "document_annotation": null,
-            "usage_info": {"pages_processed": 1},
-            "object": "ocr",
-        });
-
         let mut inbound = c.benchmark_group("python_to_rust_payload");
-        inbound.throughput(Throughput::Bytes(PAYLOAD_BYTES as u64));
-        inbound.bench_with_input(
-            BenchmarkId::new("former_json_roundtrip", "4_MiB"),
-            &document,
-            |b, document| {
-                b.iter(|| former_json_roundtrip_from_py(py, black_box(document.as_any())))
-            },
-        );
-        inbound.bench_with_input(
-            BenchmarkId::new("pythonize", "4_MiB"),
-            &document,
-            |b, document| b.iter(|| pythonize_from_py(black_box(document.as_any()))),
-        );
+        for &(label, payload_bytes) in PAYLOAD_SIZES {
+            let data_uri = format!("data:image/png;base64,{}", "A".repeat(payload_bytes));
+            let document = PyDict::new(py);
+            document
+                .set_item("type", "image_url")
+                .expect("document type should be set");
+            document
+                .set_item("image_url", data_uri)
+                .expect("document URL should be set");
+
+            inbound.throughput(Throughput::Bytes(payload_bytes as u64));
+            inbound.bench_with_input(
+                BenchmarkId::new("former_json_roundtrip", label),
+                &document,
+                |b, document| {
+                    b.iter(|| former_json_roundtrip_from_py(py, black_box(document.as_any())))
+                },
+            );
+            inbound.bench_with_input(
+                BenchmarkId::new("pythonize", label),
+                &document,
+                |b, document| b.iter(|| pythonize_from_py(black_box(document.as_any()))),
+            );
+        }
         inbound.finish();
 
         let mut outbound = c.benchmark_group("rust_to_python_payload");
-        outbound.throughput(Throughput::Bytes(PAYLOAD_BYTES as u64));
-        outbound.bench_with_input(
-            BenchmarkId::new("former_json_roundtrip", "4_MiB"),
-            &response,
-            |b, response| b.iter(|| former_json_roundtrip_to_py(py, black_box(response))),
-        );
-        outbound.bench_with_input(
-            BenchmarkId::new("pythonize", "4_MiB"),
-            &response,
-            |b, response| b.iter(|| pythonize_to_py(py, black_box(response))),
-        );
+        for &(label, payload_bytes) in PAYLOAD_SIZES {
+            let data_uri = format!("data:image/png;base64,{}", "A".repeat(payload_bytes));
+            let response = json!({
+                "pages": [{
+                    "index": 0,
+                    "markdown": "OCR text",
+                    "images": [{"image_base64": data_uri}],
+                }],
+                "model": "mistral-ocr-latest",
+                "document_annotation": null,
+                "usage_info": {"pages_processed": 1},
+                "object": "ocr",
+            });
+
+            outbound.throughput(Throughput::Bytes(payload_bytes as u64));
+            outbound.bench_with_input(
+                BenchmarkId::new("former_json_roundtrip", label),
+                &response,
+                |b, response| b.iter(|| former_json_roundtrip_to_py(py, black_box(response))),
+            );
+            outbound.bench_with_input(
+                BenchmarkId::new("pythonize", label),
+                &response,
+                |b, response| b.iter(|| pythonize_to_py(py, black_box(response))),
+            );
+        }
         outbound.finish();
     });
 }

--- a/litellm-rust/crates/python-bridge/benches/serialization.rs
+++ b/litellm-rust/crates/python-bridge/benches/serialization.rs
@@ -1,0 +1,103 @@
+use std::hint::black_box;
+use std::time::Duration;
+
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use pyo3::prelude::*;
+use pyo3::types::PyDict;
+use serde_json::{Value, json};
+
+const PAYLOAD_BYTES: usize = 4 * 1024 * 1024;
+
+fn former_json_roundtrip_from_py(py: Python<'_>, value: &Bound<'_, PyAny>) -> Value {
+    let json = py.import("json").expect("Python json module should import");
+    let encoded: String = json
+        .call_method1("dumps", (value,))
+        .expect("payload should serialize")
+        .extract()
+        .expect("json.dumps should return a string");
+    serde_json::from_str(&encoded).expect("serialized JSON should parse")
+}
+
+fn pythonize_from_py(value: &Bound<'_, PyAny>) -> Value {
+    pythonize::depythonize(value).expect("payload should depythonize")
+}
+
+fn former_json_roundtrip_to_py(py: Python<'_>, value: &Value) -> Py<PyAny> {
+    let json = py.import("json").expect("Python json module should import");
+    let encoded = serde_json::to_string(value).expect("response should serialize");
+    json.call_method1("loads", (encoded,))
+        .expect("serialized response should parse in Python")
+        .unbind()
+}
+
+fn pythonize_to_py(py: Python<'_>, value: &Value) -> Py<PyAny> {
+    pythonize::pythonize(py, value)
+        .expect("response should pythonize")
+        .unbind()
+}
+
+fn serialization(c: &mut Criterion) {
+    Python::initialize();
+    Python::attach(|py| {
+        let data_uri = format!("data:image/png;base64,{}", "A".repeat(PAYLOAD_BYTES));
+        let document = PyDict::new(py);
+        document
+            .set_item("type", "image_url")
+            .expect("document type should be set");
+        document
+            .set_item("image_url", &data_uri)
+            .expect("document URL should be set");
+
+        let response = json!({
+            "pages": [{
+                "index": 0,
+                "markdown": "OCR text",
+                "images": [{"image_base64": data_uri}],
+            }],
+            "model": "mistral-ocr-latest",
+            "document_annotation": null,
+            "usage_info": {"pages_processed": 1},
+            "object": "ocr",
+        });
+
+        let mut inbound = c.benchmark_group("python_to_rust_payload");
+        inbound.throughput(Throughput::Bytes(PAYLOAD_BYTES as u64));
+        inbound.bench_with_input(
+            BenchmarkId::new("former_json_roundtrip", "4_MiB"),
+            &document,
+            |b, document| {
+                b.iter(|| former_json_roundtrip_from_py(py, black_box(document.as_any())))
+            },
+        );
+        inbound.bench_with_input(
+            BenchmarkId::new("pythonize", "4_MiB"),
+            &document,
+            |b, document| b.iter(|| pythonize_from_py(black_box(document.as_any()))),
+        );
+        inbound.finish();
+
+        let mut outbound = c.benchmark_group("rust_to_python_payload");
+        outbound.throughput(Throughput::Bytes(PAYLOAD_BYTES as u64));
+        outbound.bench_with_input(
+            BenchmarkId::new("former_json_roundtrip", "4_MiB"),
+            &response,
+            |b, response| b.iter(|| former_json_roundtrip_to_py(py, black_box(response))),
+        );
+        outbound.bench_with_input(
+            BenchmarkId::new("pythonize", "4_MiB"),
+            &response,
+            |b, response| b.iter(|| pythonize_to_py(py, black_box(response))),
+        );
+        outbound.finish();
+    });
+}
+
+criterion_group! {
+    name = benches;
+    config = Criterion::default()
+        .sample_size(20)
+        .warm_up_time(Duration::from_secs(1))
+        .measurement_time(Duration::from_secs(4));
+    targets = serialization
+}
+criterion_main!(benches);

--- a/litellm-rust/crates/python-bridge/benches/serialization.rs
+++ b/litellm-rust/crates/python-bridge/benches/serialization.rs
@@ -1,7 +1,7 @@
 use std::hint::black_box;
 use std::time::Duration;
 
-use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
 use pyo3::prelude::*;
 use pyo3::types::PyDict;
 use serde_json::{Value, json};
@@ -45,7 +45,6 @@ fn pythonize_to_py(py: Python<'_>, value: &Value) -> Py<PyAny> {
 fn serialization(c: &mut Criterion) {
     Python::initialize();
     Python::attach(|py| {
-        let mut inbound = c.benchmark_group("python_to_rust_payload");
         for &(label, payload_bytes) in PAYLOAD_SIZES {
             let data_uri = format!("data:image/png;base64,{}", "A".repeat(payload_bytes));
             let document = PyDict::new(py);
@@ -53,28 +52,8 @@ fn serialization(c: &mut Criterion) {
                 .set_item("type", "image_url")
                 .expect("document type should be set");
             document
-                .set_item("image_url", data_uri)
+                .set_item("image_url", &data_uri)
                 .expect("document URL should be set");
-
-            inbound.throughput(Throughput::Bytes(payload_bytes as u64));
-            inbound.bench_with_input(
-                BenchmarkId::new("former_json_roundtrip", label),
-                &document,
-                |b, document| {
-                    b.iter(|| former_json_roundtrip_from_py(py, black_box(document.as_any())))
-                },
-            );
-            inbound.bench_with_input(
-                BenchmarkId::new("pythonize", label),
-                &document,
-                |b, document| b.iter(|| pythonize_from_py(black_box(document.as_any()))),
-            );
-        }
-        inbound.finish();
-
-        let mut outbound = c.benchmark_group("rust_to_python_payload");
-        for &(label, payload_bytes) in PAYLOAD_SIZES {
-            let data_uri = format!("data:image/png;base64,{}", "A".repeat(payload_bytes));
             let response = json!({
                 "pages": [{
                     "index": 0,
@@ -87,19 +66,29 @@ fn serialization(c: &mut Criterion) {
                 "object": "ocr",
             });
 
-            outbound.throughput(Throughput::Bytes(payload_bytes as u64));
-            outbound.bench_with_input(
-                BenchmarkId::new("former_json_roundtrip", label),
+            c.bench_with_input(
+                BenchmarkId::new("python_to_rust_json", label),
+                &document,
+                |b, document| {
+                    b.iter(|| former_json_roundtrip_from_py(py, black_box(document.as_any())))
+                },
+            );
+            c.bench_with_input(
+                BenchmarkId::new("python_to_rust_pythonize", label),
+                &document,
+                |b, document| b.iter(|| pythonize_from_py(black_box(document.as_any()))),
+            );
+            c.bench_with_input(
+                BenchmarkId::new("rust_to_python_json", label),
                 &response,
                 |b, response| b.iter(|| former_json_roundtrip_to_py(py, black_box(response))),
             );
-            outbound.bench_with_input(
-                BenchmarkId::new("pythonize", label),
+            c.bench_with_input(
+                BenchmarkId::new("rust_to_python_pythonize", label),
                 &response,
                 |b, response| b.iter(|| pythonize_to_py(py, black_box(response))),
             );
         }
-        outbound.finish();
     });
 }
 

--- a/litellm-rust/crates/python-bridge/src/lib.rs
+++ b/litellm-rust/crates/python-bridge/src/lib.rs
@@ -19,6 +19,9 @@ use pyo3::types::{PyAny, PyDict};
 use serde_json::{Map, Value};
 
 mod gil;
+mod marshal;
+
+use marshal::{from_py, to_py};
 
 pyo3::create_exception!(
     _native,
@@ -41,35 +44,18 @@ type MarshaledOcrInputs = (
     Option<Duration>,
 );
 
-fn py_to_json(py: Python<'_>, value: &Bound<'_, PyAny>) -> PyResult<Value> {
-    let json = py.import("json")?;
-    let encoded: String = json.call_method1("dumps", (value,))?.extract()?;
-    serde_json::from_str(&encoded).map_err(|err| PyValueError::new_err(err.to_string()))
-}
-
-fn json_to_py(py: Python<'_>, value: Value) -> PyResult<Py<PyAny>> {
-    let json = py.import("json")?;
-    let encoded =
-        serde_json::to_string(&value).map_err(|err| PyValueError::new_err(err.to_string()))?;
-    Ok(json.call_method1("loads", (encoded,))?.unbind())
-}
-
 fn messages_response_to_py(
     py: Python<'_>,
     response: AnthropicMessagesResponse,
 ) -> PyResult<Py<PyAny>> {
-    let value =
-        serde_json::to_value(response).map_err(|err| PyValueError::new_err(err.to_string()))?;
-    json_to_py(py, value)
+    to_py(py, &response)
 }
 
 fn chat_completions_response_to_py(
     py: Python<'_>,
     response: ChatCompletionsResponse,
 ) -> PyResult<Py<PyAny>> {
-    let value =
-        serde_json::to_value(response).map_err(|err| PyValueError::new_err(err.to_string()))?;
-    json_to_py(py, value)
+    to_py(py, &response)
 }
 
 fn core_error_to_pyerr(err: CoreError) -> PyErr {
@@ -116,7 +102,7 @@ fn optional_object_to_map(
     value: Option<Py<PyAny>>,
 ) -> PyResult<Map<String, Value>> {
     match value {
-        Some(value) => match py_to_json(py, value.bind(py))? {
+        Some(value) => match from_py(value.bind(py))? {
             Value::Object(map) => Ok(map),
             _ => Err(PyValueError::new_err(format!("{name} must be a dict"))),
         },
@@ -139,7 +125,7 @@ fn marshal_headers(
     headers: Option<Py<PyAny>>,
 ) -> PyResult<HashMap<String, String>> {
     let value = match headers {
-        Some(headers) => py_to_json(py, headers.bind(py))?,
+        Some(headers) => from_py(headers.bind(py))?,
         None => Value::Object(Map::new()),
     };
     let Value::Object(headers) = value else {
@@ -211,7 +197,7 @@ fn marshal_inputs(
     optional_params: Option<Py<PyAny>>,
     timeout_seconds: Option<f64>,
 ) -> PyResult<MarshaledOcrInputs> {
-    let document = py_to_json(py, document.bind(py))?;
+    let document = from_py(document.bind(py))?;
     let extra_headers = match extra_headers {
         Some(headers) => Some(optional_object_to_map(py, "extra_headers", Some(headers))?),
         None => None,
@@ -262,7 +248,7 @@ fn ocr(
     });
 
     match result {
-        Ok(value) => json_to_py(py, value),
+        Ok(value) => to_py(py, &value),
         Err(err) => Err(core_error_to_pyerr(err)),
     }
 }
@@ -307,7 +293,7 @@ fn aocr(
         .await
         .map_err(core_error_to_pyerr)?;
 
-        Python::attach(|py| json_to_py(py, value))
+        Python::attach(|py| to_py(py, &value))
     })
 }
 
@@ -325,7 +311,7 @@ fn transcription(
     optional_params: Option<Py<PyAny>>,
     timeout_seconds: Option<f64>,
 ) -> PyResult<Py<PyAny>> {
-    let audio = py_to_json(py, audio.bind(py))?;
+    let audio = from_py(audio.bind(py))?;
     let extra_headers = match extra_headers {
         Some(headers) => Some(optional_object_to_map(py, "extra_headers", Some(headers))?),
         None => None,
@@ -351,7 +337,7 @@ fn transcription(
         ))
     });
     match result {
-        Ok(value) => json_to_py(py, value),
+        Ok(value) => to_py(py, &value),
         Err(err) => Err(core_error_to_pyerr(err)),
     }
 }
@@ -370,7 +356,7 @@ fn atranscription(
     optional_params: Option<Py<PyAny>>,
     timeout_seconds: Option<f64>,
 ) -> PyResult<Bound<'_, PyAny>> {
-    let audio = py_to_json(py, audio.bind(py))?;
+    let audio = from_py(audio.bind(py))?;
     let extra_headers = match extra_headers {
         Some(headers) => Some(optional_object_to_map(py, "extra_headers", Some(headers))?),
         None => None,
@@ -394,7 +380,7 @@ fn atranscription(
         })
         .await
         .map_err(core_error_to_pyerr)?;
-        Python::attach(|py| json_to_py(py, value))
+        Python::attach(|py| to_py(py, &value))
     })
 }
 
@@ -406,7 +392,7 @@ fn marshal_messages_inputs(
     extra_headers: Option<Py<PyAny>>,
     timeout_seconds: Option<f64>,
 ) -> PyResult<MarshaledMessagesInputs> {
-    let body = py_to_json(py, body.bind(py))?;
+    let body: Value = from_py(body.bind(py))?;
     if !body.is_object() {
         return Err(PyValueError::new_err("body must be a dict"));
     }
@@ -498,7 +484,7 @@ fn marshal_chat_completions_inputs(
     extra_headers: Option<Py<PyAny>>,
     timeout_seconds: Option<f64>,
 ) -> PyResult<MarshaledChatCompletionsInputs> {
-    let messages = py_to_json(py, messages.bind(py))?;
+    let messages: Value = from_py(messages.bind(py))?;
     if !messages.is_array() {
         return Err(PyValueError::new_err("messages must be a list"));
     }
@@ -527,7 +513,7 @@ fn chat_completions_decline(
     optional_params: Option<Py<PyAny>>,
     custom_llm_provider: Option<String>,
 ) -> PyResult<Option<String>> {
-    let messages = py_to_json(py, messages.bind(py))?;
+    let messages = from_py(messages.bind(py))?;
     let optional_params = optional_object_to_map(py, "optional_params", optional_params)?;
     Ok(chat_completions_decline_reason(
         &model,

--- a/litellm-rust/crates/python-bridge/src/marshal.rs
+++ b/litellm-rust/crates/python-bridge/src/marshal.rs
@@ -1,0 +1,20 @@
+use pyo3::exceptions::PyValueError;
+use pyo3::prelude::*;
+use serde::Serialize;
+use serde::de::DeserializeOwned;
+
+pub fn from_py<T>(value: &Bound<'_, PyAny>) -> PyResult<T>
+where
+    T: DeserializeOwned,
+{
+    pythonize::depythonize(value).map_err(|error| PyValueError::new_err(error.to_string()))
+}
+
+pub fn to_py<T>(py: Python<'_>, value: &T) -> PyResult<Py<PyAny>>
+where
+    T: Serialize + ?Sized,
+{
+    pythonize::pythonize(py, value)
+        .map(Bound::unbind)
+        .map_err(|error| PyValueError::new_err(error.to_string()))
+}

--- a/litellm-rust/crates/python-bridge/tests/marshal_boundary.rs
+++ b/litellm-rust/crates/python-bridge/tests/marshal_boundary.rs
@@ -1,0 +1,46 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+
+const DISALLOWED_OUTSIDE_MARSHAL: &[&str] = &[
+    "py.import(\"json\")",
+    "pythonize::",
+    "serde_json::to_string",
+    "serde_json::from_str",
+];
+
+fn source_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("src")
+}
+
+fn rust_sources(directory: &Path, sources: &mut Vec<PathBuf>) {
+    for entry in fs::read_dir(directory).expect("bridge source directory should be readable") {
+        let entry = entry.expect("bridge source entry should be readable");
+        let path = entry.path();
+        if path.is_dir() {
+            rust_sources(&path, sources);
+        } else if path.extension().is_some_and(|extension| extension == "rs") {
+            sources.push(path);
+        }
+    }
+}
+
+#[test]
+fn serialization_is_centralized_in_marshal_module() {
+    let root = source_root();
+    let mut sources = Vec::new();
+    rust_sources(&root, &mut sources);
+
+    for path in sources {
+        if path == root.join("marshal.rs") {
+            continue;
+        }
+        let source = fs::read_to_string(&path).expect("bridge source should be readable");
+        for disallowed in DISALLOWED_OUTSIDE_MARSHAL {
+            assert!(
+                !source.contains(disallowed),
+                "{} bypasses the typed marshal module with `{disallowed}`",
+                path.display()
+            );
+        }
+    }
+}

--- a/litellm-rust/crates/python-bridge/tests/marshal_boundary.rs
+++ b/litellm-rust/crates/python-bridge/tests/marshal_boundary.rs
@@ -12,25 +12,31 @@ fn source_root() -> PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR")).join("src")
 }
 
-fn rust_sources(directory: &Path, sources: &mut Vec<PathBuf>) {
-    for entry in fs::read_dir(directory).expect("bridge source directory should be readable") {
-        let entry = entry.expect("bridge source entry should be readable");
-        let path = entry.path();
-        if path.is_dir() {
-            rust_sources(&path, sources);
-        } else if path.extension().is_some_and(|extension| extension == "rs") {
-            sources.push(path);
-        }
-    }
+fn rust_sources(directory: &Path) -> Vec<PathBuf> {
+    fs::read_dir(directory)
+        .expect("bridge source directory should be readable")
+        .map(|entry| {
+            entry
+                .expect("bridge source entry should be readable")
+                .path()
+        })
+        .flat_map(|path| {
+            if path.is_dir() {
+                rust_sources(&path)
+            } else if path.extension().is_some_and(|extension| extension == "rs") {
+                vec![path]
+            } else {
+                Vec::new()
+            }
+        })
+        .collect()
 }
 
 #[test]
 fn serialization_is_centralized_in_marshal_module() {
     let root = source_root();
-    let mut sources = Vec::new();
-    rust_sources(&root, &mut sources);
 
-    for path in sources {
+    for path in rust_sources(&root) {
         if path == root.join("marshal.rs") {
             continue;
         }


### PR DESCRIPTION
## TLDR

Problem this solves:

- JSON round trips copy large bridge payloads
- Conversion overhead scales into tens of milliseconds

How it solves it:

- Serialize directly with `pythonize`
- Add a boundary test and multi-size Criterion benchmark

Local Criterion median estimates from `1821aed4c1`:

| Payload | Python to Rust JSON | Python to Rust `pythonize` | Speedup | Rust to Python JSON | Rust to Python `pythonize` | Speedup |
|---:|---:|---:|---:|---:|---:|---:|
| 1 KiB | 4.96 us | 570 ns | 8.7x | 5.65 us | 1.00 us | 5.6x |
| 64 KiB | 104.57 us | 1.28 us | 81.9x | 78.59 us | 4.68 us | 16.8x |
| 1 MiB | 1.62 ms | 19.41 us | 83.2x | 1.24 ms | 66.97 us | 18.5x |
| 4 MiB | 7.14 ms | 86.72 us | 82.3x | 5.70 ms | 272.88 us | 20.9x |
| 16 MiB | 27.78 ms | 348.87 us | 79.6x | 23.16 ms | 1.10 ms | 21.0x |

## User Flow

Before: a developer sends a large OCR document and waits for an avoidable serialization round trip

1. They call `litellm.ocr(...)` with a 4 MiB data URI
2. Input conversion takes about 7.14 ms before request processing
3. Output conversion takes about 5.70 ms before the result returns

After: the same call avoids the JSON round trip and returns the same data with lower conversion overhead

1. They call `litellm.ocr(...)` with the same 4 MiB data URI
2. Input conversion takes about 87 us before request processing
3. Output conversion takes about 273 us before the result returns

## Relevant issues

Related to #38762

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The focused Rust tests pass locally
- [ ] My PR passes all required CI/CD checks
- [x] My PR scope only covers bridge serialization and benchmarks
- [ ] I have received a Greptile Confidence Score of at least 4/5

## Screenshots / Proof of Fix

## Type

Refactoring

## Caveats (if any)

## Final Attestation

- [x] The tests check the serialization boundary and prevent JSON round-trip regressions