### PR TITLE
fix(proxy): initialize coordination redis from environment

### DIFF
--- a/litellm/caching/dual_cache.py
+++ b/litellm/caching/dual_cache.py
@@ -89,17 +89,23 @@ class DualCache(BaseCache):
         redis_cache: RedisCache | None = None,
         *,
         default_redis_ttl: float | None = None,
+        replace_existing: bool = False,
     ) -> None:
         """
-        Attach a Redis backend if this DualCache does not already have one.
+        Attach a Redis backend.
 
-        No-op when ``redis_cache`` is None or when Redis was already set (constructor
-        or a prior attach). Use this for lazy wiring after a shared Redis client exists.
-        Does not backfill in-memory-only keys to Redis.
+        By default, an existing Redis backend is preserved.
+        ``replace_existing=True`` is used when a higher-priority
+        configuration must replace the current backend.
         """
-        if redis_cache is None or self.redis_cache is not None:
+        if redis_cache is None:
             return
+
+        if self.redis_cache is not None and not replace_existing:
+            return
+
         self.redis_cache = redis_cache
+
         if default_redis_ttl is not None:
             self.default_redis_ttl = default_redis_ttl
 

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -4163,7 +4163,11 @@ def _build_redis_usage_cache_from_environment() -> RedisCache | None:
     return _build_redis_usage_cache(litellm._redis._redis_kwargs_from_environment())
 
 
-def _attach_redis_usage_cache(redis_cache: RedisCache, enable_redis_auth_cache: bool) -> None:
+def _attach_redis_usage_cache(
+    redis_cache: RedisCache,
+    enable_redis_auth_cache: bool,
+    replace_existing: bool = False,
+) -> None:
     """
     Wires an established coordination Redis into the proxy-level caches that
     consume it directly: the spend counter cache, the CLI SSO login-session
@@ -4177,15 +4181,18 @@ def _attach_redis_usage_cache(redis_cache: RedisCache, enable_redis_auth_cache: 
     spend_counter_cache.attach_redis_cache(
         redis_cache,
         default_redis_ttl=litellm.default_redis_ttl,
+        replace_existing=replace_existing,
     )
     cli_sso_session_cache.attach_redis_cache(
         redis_cache,
         default_redis_ttl=CLI_SSO_SESSION_TTL_SECONDS,
+        replace_existing=replace_existing,
     )
     if enable_redis_auth_cache is True:
         user_api_key_cache.attach_redis_cache(
             redis_cache,
             default_redis_ttl=litellm.default_redis_ttl,
+            replace_existing=replace_existing,
         )
         verbose_proxy_logger.info(
             "enable_redis_auth_cache=True: attached Redis to "
@@ -4782,7 +4789,11 @@ class ProxyConfig:
         if resolved_usage_cache is not None:
             # Note: PKCE verifier storage uses redis_usage_cache directly (not
             # user_api_key_cache) to avoid routing all API-key lookups through Redis.
-            _attach_redis_usage_cache(resolved_usage_cache, enable_redis_auth_cache)
+            _attach_redis_usage_cache(
+                resolved_usage_cache,
+                enable_redis_auth_cache,
+                replace_existing=False,
+            )
         elif litellm_config_cache.redis_cache is None:
             verbose_proxy_logger.info("litellm_config_cache: no Redis configured; cluster-wide cache sharing disabled.")
         return resolved_usage_cache
@@ -5420,6 +5431,7 @@ class ProxyConfig:
                 _attach_redis_usage_cache(
                     environment_redis_cache,
                     enable_redis_auth_cache=(litellm_settings.get("enable_redis_auth_cache", False) is True),
+                    replace_existing=False,
                 )
                 _set_redis_usage_cache(environment_redis_cache)
 
@@ -8999,6 +9011,7 @@ class ProxyStartupEvent:
         _attach_redis_usage_cache(
             coordination_redis_cache,
             enable_redis_auth_cache=litellm_settings.get("enable_redis_auth_cache", False) is True,
+            replace_existing=True,
         )
         if llm_router is not None and llm_router.cache.redis_cache is None:
             llm_router._update_redis_cache(cache=coordination_redis_cache)

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -5409,6 +5409,20 @@ class ProxyConfig:
                         reset_audit_log_callback_cache()
                         _in_memory_loggers[:] = [cb for cb in _in_memory_loggers if not isinstance(cb, S3V2Logger)]
 
+        # Fall back to REDIS_* after explicit coordination Redis and response-cache Redis.
+        if redis_usage_cache is None:
+            environment_redis_cache = _build_redis_usage_cache_from_environment()
+            if environment_redis_cache is not None:
+                verbose_proxy_logger.info(
+                    "Built standalone Redis from REDIS_* environment variables "
+                    "for usage tracking, rate limiting, and cross-pod coordination."
+                )
+                _attach_redis_usage_cache(
+                    environment_redis_cache,
+                    enable_redis_auth_cache=(litellm_settings.get("enable_redis_auth_cache", False) is True),
+                )
+                _set_redis_usage_cache(environment_redis_cache)
+
         ## GENERAL SERVER SETTINGS (e.g. master key,..) # do this after initializing litellm, to ensure sentry logging works for proxylogging
         general_settings = config.get("general_settings", {})
         if general_settings is None:

--- a/tests/proxy_unit_tests/test_proxy_server.py
+++ b/tests/proxy_unit_tests/test_proxy_server.py
@@ -117,7 +117,6 @@ def fake_env_vars(monkeypatch):
     monkeypatch.setenv("AZURE_AI_API_BASE", "http://fake-azure-api-base")
     monkeypatch.setenv("AZURE_OPENAI_API_KEY", "fake_azure_openai_api_key")
     monkeypatch.setenv("AZURE_SWEDEN_API_BASE", "http://fake-azure-sweden-api-base")
-    monkeypatch.setenv("REDIS_HOST", "localhost")
 
 
 @pytest.fixture(scope="function")
@@ -1078,7 +1077,7 @@ async def test_get_team_redis(client_no_auth):
         litellm.proxy.proxy_server, "proxy_logging_obj"
     )
 
-    redis_cache = RedisCache()
+    redis_cache = RedisCache(host="localhost")
 
     from fastapi import HTTPException
 

--- a/tests/test_litellm/caching/test_dual_cache.py
+++ b/tests/test_litellm/caching/test_dual_cache.py
@@ -412,6 +412,26 @@ def test_dual_cache_late_attach_redis_wires_writes_and_ttl_sync():
     assert in_memory.get_cache(key_after) == val_after
 
 
+def test_attach_redis_cache_does_not_replace_existing_backend():
+    env_cache = MagicMock(spec=RedisCache)
+    persisted_cache = MagicMock(spec=RedisCache)
+    cache = DualCache(redis_cache=env_cache)
+
+    cache.attach_redis_cache(persisted_cache)
+
+    assert cache.redis_cache is env_cache
+
+
+def test_attach_redis_cache_replaces_existing_backend_when_requested():
+    env_cache = MagicMock(spec=RedisCache)
+    persisted_cache = MagicMock(spec=RedisCache)
+    cache = DualCache(redis_cache=env_cache)
+
+    cache.attach_redis_cache(persisted_cache, replace_existing=True)
+
+    assert cache.redis_cache is persisted_cache
+
+
 @pytest.mark.asyncio
 async def test_dual_cache_late_attach_redis_wires_writes_and_ttl_async():
     """

--- a/tests/test_litellm/proxy/proxy_server/test_proxy_config.py
+++ b/tests/test_litellm/proxy/proxy_server/test_proxy_config.py
@@ -29,7 +29,7 @@ from litellm.proxy.proxy_server import (
     validate_deployment_complexity_router_placement,
     validate_deployment_max_agentic_loops,
 )
-
+import litellm.proxy.proxy_server as ps
 from .conftest import normalize
 from pydantic import ValidationError
 
@@ -1661,6 +1661,47 @@ async def test_ProxyConfig_load_config_blank_callback_settings_does_not_crash(tm
     finally:
         litellm.callbacks = original_callbacks
 
+
+@pytest.mark.asyncio
+async def test_ProxyConfig_load_config_initializes_coordination_redis_from_environment_without_response_cache(
+    tmp_path,
+    monkeypatch,
+):
+    f = tmp_path / "c.yaml"
+    f.write_text(
+        "model_list: []\n"
+        "general_settings: {}\n"
+        "litellm_settings: {}\n"
+    )
+
+    monkeypatch.setattr(ps, "prisma_client", None)
+    monkeypatch.setattr(ps, "store_model_in_db", False)
+    monkeypatch.delenv("LITELLM_CONFIG_BUCKET_NAME", raising=False)
+
+    monkeypatch.setenv("REDIS_HOST", "localhost")
+    monkeypatch.setenv("REDIS_PORT", "6379")
+
+    fake_redis = MagicMock()
+    build_redis = MagicMock(return_value=fake_redis)
+    attach_redis = MagicMock()
+
+    monkeypatch.setattr(ps, "redis_usage_cache", None)
+    monkeypatch.setattr(ps, "_build_redis_usage_cache", build_redis)
+    monkeypatch.setattr(ps, "_attach_redis_usage_cache", attach_redis)
+
+    await ProxyConfig().load_config(
+        router=None,
+        config_file_path=str(f),
+    )
+
+    build_redis.assert_called_once()
+
+    attach_redis.assert_called_once_with(
+        fake_redis,
+        enable_redis_auth_cache=False,
+    )
+
+    assert ps.redis_usage_cache is fake_redis
 
 # ---------------------------------------------------------------------------
 # ProxyConfig._init_non_llm_configs

--- a/tests/test_litellm/proxy/proxy_server/test_proxy_config.py
+++ b/tests/test_litellm/proxy/proxy_server/test_proxy_config.py
@@ -1699,6 +1699,7 @@ async def test_ProxyConfig_load_config_initializes_coordination_redis_from_envir
     attach_redis.assert_called_once_with(
         fake_redis,
         enable_redis_auth_cache=False,
+        replace_existing=False,
     )
 
     assert ps.redis_usage_cache is fake_redis

--- a/tests/test_litellm/proxy/test_proxy_server.py
+++ b/tests/test_litellm/proxy/test_proxy_server.py
@@ -10957,6 +10957,31 @@ def test_env_fallback_builds_client_from_sentinel_nodes_env():
     assert isinstance(result, _EnvBuiltRedisCache)
 
 
+def test_persisted_redis_replaces_environment_redis():
+    env_cache = MagicMock(spec=RedisCache)
+    persisted_cache = MagicMock(spec=RedisCache)
+    cli_cache = DualCache(redis_cache=env_cache)
+
+    with (
+        patch.object(proxy_server_module, "spend_counter_cache", DualCache()),
+        patch.object(proxy_server_module, "cli_sso_session_cache", cli_cache),
+        patch.object(proxy_server_module, "user_api_key_cache", DualCache()),
+        patch.object(proxy_server_module, "litellm_config_cache", types.SimpleNamespace(redis_cache=None)),
+    ):
+        proxy_server_module._attach_redis_usage_cache(
+            env_cache,
+            enable_redis_auth_cache=False,
+            replace_existing=False,
+        )
+        proxy_server_module._attach_redis_usage_cache(
+            persisted_cache,
+            enable_redis_auth_cache=False,
+            replace_existing=True,
+        )
+
+    assert cli_cache.redis_cache is persisted_cache
+
+
 @pytest.mark.asyncio
 async def test_startup_applies_coordination_redis_saved_in_database():
     """A coordination_redis block saved from the admin UI lives only in the
@@ -10987,6 +11012,30 @@ async def test_startup_applies_coordination_redis_saved_in_database():
     assert result.init_kwargs["host"] == "db-host"
     assert fresh_spend_cache.redis_cache is result
     assert fresh_config_cache.redis_cache is result
+
+
+@pytest.mark.asyncio
+async def test_startup_database_coordination_redis_requests_backend_replacement():
+    persisted_cache = MagicMock(spec=RedisCache)
+    attach_redis = MagicMock()
+
+    with (
+        patch.object(proxy_server_module, "_build_redis_usage_cache", return_value=persisted_cache),
+        patch.object(proxy_server_module, "_attach_redis_usage_cache", attach_redis),
+        patch.object(
+            proxy_server_module,
+            "get_persisted_coordination_redis_settings",
+            AsyncMock(return_value={"host": "db-host", "port": 6381}),
+        ),
+    ):
+        result = await proxy_server_module.ProxyStartupEvent._init_coordination_redis_from_db(
+            litellm_settings={},
+            llm_router=None,
+        )
+
+    assert result is persisted_cache
+    attach_redis.assert_called_once()
+    assert attach_redis.call_args.kwargs["replace_existing"] is True
 
 
 @pytest.mark.asyncio

--- a/tests/test_litellm/proxy/test_proxy_server.py
+++ b/tests/test_litellm/proxy/test_proxy_server.py
@@ -10957,27 +10957,26 @@ def test_env_fallback_builds_client_from_sentinel_nodes_env():
     assert isinstance(result, _EnvBuiltRedisCache)
 
 
-def test_persisted_redis_replaces_environment_redis():
+def test_persisted_redis_replaces_environment_redis(monkeypatch):
     env_cache = MagicMock(spec=RedisCache)
     persisted_cache = MagicMock(spec=RedisCache)
     cli_cache = DualCache(redis_cache=env_cache)
 
-    with (
-        patch.object(proxy_server_module, "spend_counter_cache", DualCache()),
-        patch.object(proxy_server_module, "cli_sso_session_cache", cli_cache),
-        patch.object(proxy_server_module, "user_api_key_cache", DualCache()),
-        patch.object(proxy_server_module, "litellm_config_cache", types.SimpleNamespace(redis_cache=None)),
-    ):
-        proxy_server_module._attach_redis_usage_cache(
-            env_cache,
-            enable_redis_auth_cache=False,
-            replace_existing=False,
-        )
-        proxy_server_module._attach_redis_usage_cache(
-            persisted_cache,
-            enable_redis_auth_cache=False,
-            replace_existing=True,
-        )
+    monkeypatch.setattr(proxy_server_module, "spend_counter_cache", DualCache())
+    monkeypatch.setattr(proxy_server_module, "cli_sso_session_cache", cli_cache)
+    monkeypatch.setattr(proxy_server_module, "user_api_key_cache", DualCache())
+    monkeypatch.setattr(proxy_server_module, "litellm_config_cache", types.SimpleNamespace(redis_cache=None))
+
+    proxy_server_module._attach_redis_usage_cache(
+        env_cache,
+        enable_redis_auth_cache=False,
+        replace_existing=False,
+    )
+    proxy_server_module._attach_redis_usage_cache(
+        persisted_cache,
+        enable_redis_auth_cache=False,
+        replace_existing=True,
+    )
 
     assert cli_cache.redis_cache is persisted_cache
 
@@ -11015,23 +11014,22 @@ async def test_startup_applies_coordination_redis_saved_in_database():
 
 
 @pytest.mark.asyncio
-async def test_startup_database_coordination_redis_requests_backend_replacement():
+async def test_startup_database_coordination_redis_requests_backend_replacement(monkeypatch):
     persisted_cache = MagicMock(spec=RedisCache)
     attach_redis = MagicMock()
 
-    with (
-        patch.object(proxy_server_module, "_build_redis_usage_cache", return_value=persisted_cache),
-        patch.object(proxy_server_module, "_attach_redis_usage_cache", attach_redis),
-        patch.object(
-            proxy_server_module,
-            "get_persisted_coordination_redis_settings",
-            AsyncMock(return_value={"host": "db-host", "port": 6381}),
-        ),
-    ):
-        result = await proxy_server_module.ProxyStartupEvent._init_coordination_redis_from_db(
-            litellm_settings={},
-            llm_router=None,
-        )
+    monkeypatch.setattr(proxy_server_module, "_build_redis_usage_cache", MagicMock(return_value=persisted_cache))
+    monkeypatch.setattr(proxy_server_module, "_attach_redis_usage_cache", attach_redis)
+    monkeypatch.setattr(
+        proxy_server_module,
+        "get_persisted_coordination_redis_settings",
+        AsyncMock(return_value={"host": "db-host", "port": 6381}),
+    )
+
+    result = await proxy_server_module.ProxyStartupEvent._init_coordination_redis_from_db(
+        litellm_settings={},
+        llm_router=None,
+    )
 
     assert result is persisted_cache
     attach_redis.assert_called_once()


### PR DESCRIPTION
## TLDR

Problem this solves:

* `REDIS_*` alone does not initialize coordination Redis at startup
* GCP Terraform deployments can incorrectly report Redis as unconfigured

How it solves it:

* Falls back to `REDIS_*` when coordination Redis is still unresolved
* Initializes coordination Redis without requiring response caching

## User Flow

Before: a GCP Terraform deployment provisions Redis, but LiteLLM still reports that Redis is not configured.

1. The operator deploys LiteLLM with Redis connection details provided through `REDIS_HOST` and `REDIS_PORT`
2. They leave response caching disabled and do not configure a separate coordination Redis block
3. LiteLLM starts successfully and the Redis instance itself is reachable
4. The proxy still reports `show_no_redis_warning: true`, causing the UI to show the "No Redis configured" warning

After: the same deployment recognizes Redis without requiring response caching.

1. The operator deploys LiteLLM with the same `REDIS_HOST` and `REDIS_PORT`
2. They leave response caching disabled and do not configure a separate coordination Redis block
3. LiteLLM starts and initializes coordination Redis from the existing environment variables
4. The proxy reports `show_no_redis_warning: false`, so the Redis warning is no longer shown

## Relevant issues

Fixes #37988

## Linear ticket

## Pre-Submission checklist

* [x] I have added meaningful tests
* [x] The test file covering my change passes locally
* [x] My PR passes all required CI/CD checks
* [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
* [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

Shared setup:

* Redis running locally and responding to `PING`
* `REDIS_HOST=127.0.0.1`
* `REDIS_PORT=6379`
* Response caching is not enabled
* No explicit `general_settings.coordination_redis` configuration
<img width="1510" height="200" alt="image" src="https://github.com/user-attachments/assets/64afb86c-1c96-4321-aff6-14e8a7421afe" />
<img width="234" height="133" alt="image" src="https://github.com/user-attachments/assets/979911ad-7343-47f4-ab5b-ed39c298a5f1" />

### Before 

1. Start the proxy with the shared configuration above.
2. Call:

   `GET http://localhost:4000/health/readiness/details`

   with the proxy admin authorization header.
3. The response reports:

   `show_no_redis_warning: true`

<img width="1750" height="1172" alt="image" src="https://github.com/user-attachments/assets/50cccd45-7278-4432-b183-77eeb7cd879c" />

### After

1. Start the proxy with the exact same Redis and LiteLLM configuration.
2. Call:

   `GET http://localhost:4000/health/readiness/details`

   with the same authorization header.
3. The response now reports:

   `show_no_redis_warning: false`

<img width="1928" height="1212" alt="image" src="https://github.com/user-attachments/assets/df00a052-1dba-4d1c-8671-b569849f345a" />

## Type

🐛 Bug Fix
✅ Test

## Caveats (if any)

## Final Attestation

* [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
