### PR TITLE
fix(ui): make code blocks follow the theme in dark mode

### DIFF
--- a/ui/litellm-dashboard/src/components/CodeBlock.tsx
+++ b/ui/litellm-dashboard/src/components/CodeBlock.tsx
@@ -20,10 +20,10 @@ const CodeBlock = ({ code, language }: CodeBlockProps) => {
   };
 
   return (
-    <div className="relative rounded-lg border border-border overflow-hidden">
+    <div className="relative rounded-lg border border-border bg-muted overflow-hidden">
       <button
         onClick={copyToClipboard}
-        className="absolute top-3 right-3 p-2 rounded-md bg-muted hover:bg-accent text-muted-foreground z-raised"
+        className="absolute top-3 right-3 p-2 rounded-md border border-border bg-background text-muted-foreground hover:bg-accent hover:text-foreground z-raised"
         aria-label="Copy code"
       >
         {copied ? <CheckIcon size={16} /> : <ClipboardIcon size={16} />}
@@ -36,8 +36,9 @@ const CodeBlock = ({ code, language }: CodeBlockProps) => {
           padding: "1.5rem",
           borderRadius: "0.5rem",
           fontSize: "0.9rem",
-          backgroundColor: "#fafafa",
+          background: "transparent",
         }}
+        codeTagProps={{ style: { background: "transparent" } }}
         showLineNumbers
       >
         {code}


### PR DESCRIPTION
## TLDR

Problem this solves:

- Code blocks are unreadable in dark mode
- White card behind a dark box on every line

How it solves it:

- Code surface no longer paints its own background
- The block inherits the themed surface around it

## User Flow

Before: an admin browsing the dashboard in dark mode finds the code samples hard to read

1. They open http://localhost:4000/ui/?page=api-reference and switch the theme toggle in the top bar to dark
2. The page turns dark, but the sample code sits on a near white card
3. Each line of code has its own dark rectangle painted behind the text, sized to the text, so the block reads as stripes rather than one panel
4. The same thing happens on the Cost Tracking page and on the usage snippet in a routing group's detail view, since they show the same kind of code block

After: the same admin sees one dark code panel that matches the rest of the page

1. They open http://localhost:4000/ui/?page=api-reference and switch the theme toggle to dark
2. The sample code sits on a single dark panel, with the light syntax colors on top of it and no white card behind
3. There are no per line rectangles; the block reads as one surface
4. Switching the toggle back to light gives the same panel in light gray, with the copy button still visible in the corner
5. Cost Tracking and the routing group usage snippet pick up the same behavior

## Relevant issues

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

Setup: local proxy plus the dashboard dev server pointed at it, signed in as an admin, page http://localhost:3103/api-reference with the theme toggle set to dark

### Before (f0fadb7f99)

1. Open the API Reference page in dark mode
2. Observed: white card behind the samples, and a dark rectangle hugging each line of code

### After (8f07a12726)

1. Open the same page in dark mode
2. Observed: one dark code panel, no white card, no per line rectangles
3. Flip the theme toggle to light
4. Observed: one light gray panel with dark syntax text, copy button still visible
<img width="1154" height="561" alt="image" src="https://github.com/user-attachments/assets/fda03078-c5ed-498b-9010-867b81346d6a" />


## Type

🐛 Bug Fix

## Caveats (if any)

### Low

- Copy button restyled so it reads on both surfaces

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
