### PR TITLE
docs(claude.md): require tests to check behavior, not code structure

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,6 +23,8 @@ When adding new features, add meaningful tests. Don't add tests that don't check
 
 Same thing for bug fixes. The tests should make it so that this specific bug can never happen again without failing tests (i.e., regression)
 
+Never test structure of code only function of it
+
 `tests/test_litellm/` mirrors `litellm/` in a parallel path (see `tests/test_litellm/readme.md`). Name tests `test_<filename>.py`, but always match the existing test file in the directory you touch — many provider dirs use longer descriptive names (e.g. `test_anthropic_chat_transformation.py`) to avoid ambiguity across sibling folders. For bug fixes, extend the existing mapped test file rather than creating a new one. Only create a new test file for a new feature (provider, endpoint, or transformation module) that has no mapped test yet, following that directory's naming convention (or `test_<filename>.py` if you're the first test there). One focused regression test beats many shallow ones
 
 End-to-end tests belong in `tests/e2e/` and must follow the harness conventions documented in that directory's `CLAUDE.md`


### PR DESCRIPTION
## TLDR

Problem this solves:

- Tests get written against code shape, not behavior
- Those tests break on refactors and pass on real bugs

How it solves it:

- Adds one repo instruction: test function, never structure
- Sits with the existing meaningful-tests and regression rules

## User Flow

Before: someone adding a test to this repo reads the testing rules and gets no guidance on what a test should assert

1. They open CLAUDE.md and read the rules about meaningful tests, mutation kill rate, and regression coverage
2. Nothing tells them to avoid asserting on code shape, so they write a test that checks a function exists, an attribute is set, or a call happened
3. The test passes, a later refactor renames the thing, and the test fails without any behavior changing

After: the same person reads a rule that tells them what to assert

1. They open CLAUDE.md and read the same testing rules
2. Right after the regression rule they see "Never test structure of code only function of it"
3. They write a test that drives the real input and checks the real output, so it survives refactors and fails when behavior breaks

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have added meaningful tests
- [ ] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

The two test boxes are blank on purpose: this PR only adds a line to CLAUDE.md, so there is no code to test

## Screenshots / Proof of Fix

No runtime behavior changes, so there is nothing to run against a live proxy. The whole diff is the one line below

### After (80e0bc2dc6)

1. Run `git diff origin/litellm_internal_staging -- CLAUDE.md`
2. Output:

```diff
 Same thing for bug fixes. The tests should make it so that this specific bug can never happen again without failing tests (i.e., regression)

+Never test structure of code only function of it
+
 `tests/test_litellm/` mirrors `litellm/` in a parallel path (see `tests/test_litellm/readme.md`). ...
```

## Type

📖 Documentation

## Caveats (if any)

### Low

- Wording is deliberately verbatim, as requested

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edit to contributor guidelines with no product or deployment impact.
> 
> **Overview**
> Adds a single contributor rule to **CLAUDE.md** immediately after the regression-testing guidance: **"Never test structure of code only function of it"**
> 
> The change does not touch runtime code, tests, or CI. It tightens how agents and contributors are told to write tests alongside the existing rules on meaningful coverage, mutation kill rate, and regression tests
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 80e0bc2dc6861222781f3dc87aa5ab72786dae8f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->