### PR TITLE
fix(anthropic): rewrite backend model id in streaming message_start to requested model

### DIFF
--- a/litellm/llms/anthropic/experimental_pass_through/messages/streaming_iterator.py
+++ b/litellm/llms/anthropic/experimental_pass_through/messages/streaming_iterator.py
@@ -459,11 +459,7 @@ class BaseAnthropicMessagesStreamingIterator:
                         else:
                             new_lines.append(line)
                     if modified:
-                        trailing = (
-                            b"\n\n"
-                            if chunk.endswith(b"\n\n")
-                            else (b"\n" if chunk.endswith(b"\n") else b"")
-                        )
+                        trailing = b"\n\n" if chunk.endswith(b"\n\n") else (b"\n" if chunk.endswith(b"\n") else b"")
                         return "\n".join(new_lines).encode("utf-8") + trailing
                 except Exception:
                     pass

--- a/litellm/llms/anthropic/experimental_pass_through/messages/streaming_iterator.py
+++ b/litellm/llms/anthropic/experimental_pass_through/messages/streaming_iterator.py
@@ -397,6 +397,24 @@ class BaseAnthropicMessagesStreamingIterator:
             url_route="/v1/messages",
         )
 
+    def _get_requested_model(self) -> str | None:
+        """Helper to extract requested model name from request_body or logging_obj."""
+        if self.request_body and isinstance(self.request_body, dict):
+            model = self.request_body.get("model")
+            if isinstance(model, str) and model:
+                return model
+        if hasattr(self.litellm_logging_obj, "model_call_details") and isinstance(
+            self.litellm_logging_obj.model_call_details, dict
+        ):
+            model = self.litellm_logging_obj.model_call_details.get("model")
+            if isinstance(model, str) and model:
+                return model
+        if hasattr(self.litellm_logging_obj, "model"):
+            model = getattr(self.litellm_logging_obj, "model", None)
+            if isinstance(model, str) and model:
+                return model
+        return None
+
     def _convert_chunk_to_sse_format(self, chunk: dict | Any) -> bytes:
         """
         Convert a chunk to Server-Sent Events format.
@@ -404,10 +422,52 @@ class BaseAnthropicMessagesStreamingIterator:
         This method should be overridden by subclasses if they need custom
         chunk formatting logic.
         """
+        requested_model: Final = self._get_requested_model()
         if isinstance(chunk, dict):
+            if requested_model and chunk.get("type") == "message_start" and isinstance(chunk.get("message"), dict):
+                chunk = {
+                    **chunk,
+                    "message": {
+                        **chunk["message"],
+                        "model": requested_model,
+                    },
+                }
             event_type: Final[str] = str(chunk.get("type", "message"))
             payload: Final = f"event: {event_type}\ndata: {json.dumps(chunk)}\n\n"
             return payload.encode()
+        elif isinstance(chunk, (bytes, bytearray)):
+            if requested_model and b"message_start" in chunk:
+                try:
+                    decoded: Final = chunk.decode("utf-8")
+                    lines = decoded.splitlines()
+                    modified = False
+                    new_lines = []
+                    for line in lines:
+                        if line.startswith("data:"):
+                            data_str = line[len("data:") :].strip()
+                            data_obj = json.loads(data_str)
+                            if (
+                                isinstance(data_obj, dict)
+                                and data_obj.get("type") == "message_start"
+                                and isinstance(data_obj.get("message"), dict)
+                            ):
+                                data_obj["message"]["model"] = requested_model
+                                new_lines.append(f"data: {json.dumps(data_obj)}")
+                                modified = True
+                            else:
+                                new_lines.append(line)
+                        else:
+                            new_lines.append(line)
+                    if modified:
+                        trailing = (
+                            b"\n\n"
+                            if chunk.endswith(b"\n\n")
+                            else (b"\n" if chunk.endswith(b"\n") else b"")
+                        )
+                        return "\n".join(new_lines).encode("utf-8") + trailing
+                except Exception:
+                    pass
+            return chunk
         else:
             # For non-dict chunks, return as is
             return chunk

--- a/litellm/proxy/pass_through_endpoints/streaming_handler.py
+++ b/litellm/proxy/pass_through_endpoints/streaming_handler.py
@@ -102,11 +102,7 @@ class PassThroughStreamingHandler:
             )
         )
         is_anthropic_route: Final[bool] = bool(
-            model_name
-            and (
-                endpoint_type == EndpointType.ANTHROPIC
-                or "/v1/messages" in url_route
-            )
+            model_name and (endpoint_type == EndpointType.ANTHROPIC or "/v1/messages" in url_route)
         )
         saw_message_start = False
         try:
@@ -117,9 +113,7 @@ class PassThroughStreamingHandler:
                     PassThroughStreamingHandler._stamp_first_chunk_if_needed(litellm_logging_obj)
                     if is_anthropic_route and not saw_message_start and b"message_start" in chunk:
                         assert model_name is not None
-                        chunk = PassThroughStreamingHandler._rewrite_anthropic_message_start_chunk(
-                            chunk, model_name
-                        )
+                        chunk = PassThroughStreamingHandler._rewrite_anthropic_message_start_chunk(chunk, model_name)
                         saw_message_start = True
                     yield chunk
             else:
@@ -406,11 +400,7 @@ class PassThroughStreamingHandler:
                 else:
                     new_lines.append(line)
             if modified:
-                trailing = (
-                    b"\n\n"
-                    if chunk.endswith(b"\n\n")
-                    else (b"\n" if chunk.endswith(b"\n") else b"")
-                )
+                trailing = b"\n\n" if chunk.endswith(b"\n\n") else (b"\n" if chunk.endswith(b"\n") else b"")
                 return "\n".join(new_lines).encode("utf-8") + trailing
         except Exception:
             pass

--- a/litellm/proxy/pass_through_endpoints/streaming_handler.py
+++ b/litellm/proxy/pass_through_endpoints/streaming_handler.py
@@ -101,12 +101,26 @@ class PassThroughStreamingHandler:
                 )
             )
         )
+        is_anthropic_route: Final[bool] = bool(
+            model_name
+            and (
+                endpoint_type == EndpointType.ANTHROPIC
+                or "/v1/messages" in url_route
+            )
+        )
+        saw_message_start = False
         try:
             if not cost_injection_active:
                 # Hot path: just buffer for end-of-stream logging and forward.
                 async for chunk in response.aiter_bytes():
                     raw_bytes.append(chunk)
                     PassThroughStreamingHandler._stamp_first_chunk_if_needed(litellm_logging_obj)
+                    if is_anthropic_route and not saw_message_start and b"message_start" in chunk:
+                        assert model_name is not None
+                        chunk = PassThroughStreamingHandler._rewrite_anthropic_message_start_chunk(
+                            chunk, model_name
+                        )
+                        saw_message_start = True
                     yield chunk
             else:
                 # ``cost_injection_active`` already requires ``model_name`` to
@@ -118,6 +132,11 @@ class PassThroughStreamingHandler:
                 async for chunk in response.aiter_bytes():
                     raw_bytes.append(chunk)
                     PassThroughStreamingHandler._stamp_first_chunk_if_needed(litellm_logging_obj)
+                    if is_anthropic_route and not saw_message_start and b"message_start" in chunk:
+                        chunk = PassThroughStreamingHandler._rewrite_anthropic_message_start_chunk(
+                            chunk, resolved_model_name
+                        )
+                        saw_message_start = True
                     complete_frames, pending = split_complete_sse_frames(
                         pending + chunk
                     )  # rebind-ok: SSE frame reassembly buffer across transport chunks
@@ -355,3 +374,44 @@ class PassThroughStreamingHandler:
         lines: Final = [line.strip() for line in combined_str.split("\n") if line.strip()]
 
         return lines
+
+    @staticmethod
+    def _rewrite_anthropic_message_start_chunk(chunk: bytes, model_name: str) -> bytes:
+        """
+        Rewrite backend model ID in message_start SSE frame to the requested model name.
+        """
+        if b"message_start" not in chunk:
+            return chunk
+        try:
+            import json
+
+            decoded: Final = chunk.decode("utf-8")
+            lines: Final = decoded.splitlines()
+            modified = False
+            new_lines = []
+            for line in lines:
+                if line.startswith("data:"):
+                    data_str = line[len("data:") :].strip()
+                    data_obj = json.loads(data_str)
+                    if (
+                        isinstance(data_obj, dict)
+                        and data_obj.get("type") == "message_start"
+                        and isinstance(data_obj.get("message"), dict)
+                    ):
+                        data_obj["message"]["model"] = model_name
+                        new_lines.append(f"data: {json.dumps(data_obj)}")
+                        modified = True
+                    else:
+                        new_lines.append(line)
+                else:
+                    new_lines.append(line)
+            if modified:
+                trailing = (
+                    b"\n\n"
+                    if chunk.endswith(b"\n\n")
+                    else (b"\n" if chunk.endswith(b"\n") else b"")
+                )
+                return "\n".join(new_lines).encode("utf-8") + trailing
+        except Exception:
+            pass
+        return chunk

--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -60,6 +60,7 @@ from .llms.openai import (
     Batch,
     ChatCompletionAnnotation,
     ChatCompletionReasoningItem,
+    ChatCompletionReasoningSummaryTextBlock,
     ChatCompletionRedactedThinkingBlock,
     ChatCompletionThinkingBlock,
     ChatCompletionToolCallChunk,

--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -60,7 +60,6 @@ from .llms.openai import (
     Batch,
     ChatCompletionAnnotation,
     ChatCompletionReasoningItem,
-    ChatCompletionReasoningSummaryTextBlock,
     ChatCompletionRedactedThinkingBlock,
     ChatCompletionThinkingBlock,
     ChatCompletionToolCallChunk,

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_streaming_iterator.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_streaming_iterator.py
@@ -629,3 +629,94 @@ async def test_normal_end_without_deferred_dispatch_enqueues_immediately(monkeyp
     assert len(worker.enqueued) == 1
     assert getattr(iterator.litellm_logging_obj, "_deferred_stream_complete_args", None) is None
     worker.close_enqueued()
+
+
+@pytest.mark.asyncio
+async def test_async_sse_wrapper_rewrites_backend_model_in_message_start_dict():
+    """
+    Regression test for #38761: streaming response message_start event must rewrite
+    the backend model ID to the client-requested alias/model name.
+    """
+    stream_events = (
+        {
+            "type": "message_start",
+            "message": {
+                "id": "msg_1",
+                "type": "message",
+                "role": "assistant",
+                "content": [],
+                "model": "anthropic.claude-3-5-sonnet-20241022-v2:0",
+                "usage": {"input_tokens": 10, "output_tokens": 0},
+            },
+        },
+        {"type": "content_block_start", "index": 0, "content_block": {"type": "text", "text": ""}},
+        {"type": "content_block_delta", "index": 0, "delta": {"type": "text_delta", "text": "hello"}},
+        {"type": "content_block_stop", "index": 0},
+        {"type": "message_delta", "delta": {"stop_reason": "end_turn"}, "usage": {"output_tokens": 1}},
+        {"type": "message_stop"},
+    )
+
+    iterator = BaseAnthropicMessagesStreamingIterator(
+        litellm_logging_obj=_make_logging_obj("test_streaming_model_rewrite_dict"),
+        request_body={"model": "my-claude-alias"},
+    )
+
+    chunks = await _collect(iterator, _stream_of(stream_events))
+    assert len(chunks) == len(stream_events)
+
+    first_chunk = chunks[0].decode()
+    assert first_chunk.startswith("event: message_start\n")
+    first_payload = json.loads(first_chunk.split("data: ", 1)[1])
+    assert first_payload["message"]["model"] == "my-claude-alias"
+
+
+@pytest.mark.asyncio
+async def test_async_sse_wrapper_rewrites_backend_model_in_message_start_bytes():
+    """
+    Regression test for #38761: streaming response message_start bytes chunk must rewrite
+    the backend model ID to the client-requested alias/model name.
+    """
+    start_chunk = (
+        b"event: message_start\n"
+        b'data: {"type": "message_start", "message": {"id": "msg_1", "type": "message", '
+        b'"role": "assistant", "content": [], "model": "anthropic.claude-3-sonnet-backend-raw", '
+        b'"usage": {"input_tokens": 10, "output_tokens": 0}}}\n\n'
+    )
+    stop_chunk = b'event: message_stop\ndata: {"type": "message_stop"}\n\n'
+
+    async def _byte_stream():
+        yield start_chunk
+        yield stop_chunk
+
+    iterator = BaseAnthropicMessagesStreamingIterator(
+        litellm_logging_obj=_make_logging_obj("test_streaming_model_rewrite_bytes"),
+        request_body={"model": "custom-requested-model"},
+    )
+
+    chunks = await _collect(iterator, _byte_stream())
+    assert len(chunks) == 2
+
+    first_chunk = chunks[0].decode()
+    assert first_chunk.startswith("event: message_start\n")
+    first_payload = json.loads(first_chunk.split("data: ", 1)[1])
+    assert first_payload["message"]["model"] == "custom-requested-model"
+
+
+def test_passthrough_streaming_handler_rewrites_message_start_chunk():
+    """
+    Test PassThroughStreamingHandler._rewrite_anthropic_message_start_chunk rewrites model.
+    """
+    from litellm.proxy.pass_through_endpoints.streaming_handler import (
+        PassThroughStreamingHandler,
+    )
+
+    raw_chunk = (
+        b"event: message_start\n"
+        b'data: {"type": "message_start", "message": {"id": "msg_1", "model": "claude-backend-id"}}\n\n'
+    )
+    rewritten = PassThroughStreamingHandler._rewrite_anthropic_message_start_chunk(
+        raw_chunk, "my-requested-model"
+    )
+    assert b'"model": "my-requested-model"' in rewritten
+    assert b"claude-backend-id" not in rewritten
+


### PR DESCRIPTION
## What does this PR do?

Closes #38761

When streaming with Anthropic's `/v1/messages` endpoint (and pass-through streaming), the first SSE event (`message_start`) contains the raw upstream/backend model identifier (such as `anthropic.claude-3-5-sonnet-20241022-v2:0` or bedrock model IDs) instead of the client's requested model alias. In contrast, the non-streaming endpoint returns the requested model name.

This discrepancy causes client applications (such as Claude Code session restore) to break when comparing the returned model name against the configured model alias.

### Changes:
1. In `BaseAnthropicMessagesStreamingIterator._convert_chunk_to_sse_format`:
   - Checks if `chunk` is a `message_start` event (both dict format and raw SSE byte chunk).
   - Rewrites `chunk["message"]["model"]` to the client's requested model alias from `request_body` or `litellm_logging_obj`.
2. In `PassThroughStreamingHandler.chunk_processor`:
   - Adds `_rewrite_anthropic_message_start_chunk` to ensure pass-through streaming routes (`/v1/messages` and `EndpointType.ANTHROPIC`) rewrite the model identifier in the `message_start` frame before emitting.
   - Subsequent delta chunks pass through with zero overhead.
3. Added unit regression tests in `tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_streaming_iterator.py`:
   - `test_async_sse_wrapper_rewrites_backend_model_in_message_start_dict`
   - `test_async_sse_wrapper_rewrites_backend_model_in_message_start_bytes`
   - `test_passthrough_streaming_handler_rewrites_message_start_chunk`

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Unit Tests added / updated

## How has this been tested?
Ran unit tests:
```bash
pytest tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_streaming_iterator.py
```
All 44 tests passed.
