### PR TITLE
fix(ui): make the logs JSON viewer follow the theme in dark mode

### DIFF
--- a/ui/litellm-dashboard/src/components/view_logs/LogDetailsDrawer/JsonViewer.test.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/LogDetailsDrawer/JsonViewer.test.tsx
@@ -1,17 +1,26 @@
 import { render, screen } from "@testing-library/react";
+import { ThemeProvider } from "next-themes";
+import { darkStyles, defaultStyles } from "react-json-view-lite";
 import { describe, expect, it } from "vitest";
 import { JsonViewer } from "./JsonViewer";
 
+const renderWithTheme = (theme: "light" | "dark", data: unknown) =>
+  render(
+    <ThemeProvider attribute="class" defaultTheme={theme} enableSystem={false}>
+      <JsonViewer data={data} mode="formatted" />
+    </ThemeProvider>,
+  );
+
 describe("JsonViewer", () => {
   it("should render a placeholder and no tree when the log entry carries no payload", () => {
-    render(<JsonViewer data={null} mode="formatted" />);
+    renderWithTheme("light", null);
 
     expect(screen.getByText("No data")).toBeInTheDocument();
     expect(screen.queryByRole("tree")).not.toBeInTheDocument();
   });
 
   it("should render the payload as a tree exposing its keys", () => {
-    render(<JsonViewer data={{ model: "claude-opus-4-5", stream: true }} mode="formatted" />);
+    renderWithTheme("light", { model: "claude-opus-4-5", stream: true });
 
     expect(screen.getByRole("tree")).toBeInTheDocument();
     expect(screen.getByText(/model/)).toBeInTheDocument();
@@ -20,9 +29,26 @@ describe("JsonViewer", () => {
   });
 
   it("should treat an empty payload as data rather than showing the placeholder", () => {
-    render(<JsonViewer data={{}} mode="formatted" />);
+    renderWithTheme("light", {});
 
     expect(screen.getByRole("tree")).toBeInTheDocument();
     expect(screen.queryByText("No data")).not.toBeInTheDocument();
+  });
+
+  it("should style the tree with the light palette when the dashboard theme is light", () => {
+    renderWithTheme("light", { model: "claude-opus-4-5" });
+
+    expect(screen.getByRole("tree")).toHaveClass(...defaultStyles.container.split(" "));
+  });
+
+  it("should style the tree with the dark palette when the dashboard theme is dark", () => {
+    renderWithTheme("dark", { model: "claude-opus-4-5" });
+
+    const tree = screen.getByRole("tree");
+    expect(tree).toHaveClass(...darkStyles.container.split(" "));
+    defaultStyles.container
+      .split(" ")
+      .filter((className) => !darkStyles.container.split(" ").includes(className))
+      .forEach((lightOnlyClassName) => expect(tree).not.toHaveClass(lightOnlyClassName));
   });
 });

--- a/ui/litellm-dashboard/src/components/view_logs/LogDetailsDrawer/JsonViewer.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/LogDetailsDrawer/JsonViewer.tsx
@@ -1,4 +1,5 @@
-import { JsonView, defaultStyles } from "react-json-view-lite";
+import { useTheme } from "next-themes";
+import { JsonView, darkStyles, defaultStyles } from "react-json-view-lite";
 import "react-json-view-lite/dist/index.css";
 import { JSON_MAX_HEIGHT, SPACING_LARGE } from "./constants";
 
@@ -12,6 +13,8 @@ interface JsonViewerProps {
  * Uses an interactive tree component for easy navigation.
  */
 export function JsonViewer({ data }: JsonViewerProps) {
+  const { resolvedTheme } = useTheme();
+
   if (!data) return <span className="text-muted-foreground">No data</span>;
 
   return (
@@ -24,8 +27,8 @@ export function JsonViewer({ data }: JsonViewerProps) {
         borderRadius: 4,
       }}
     >
-      <div className="**:[[role='tree']]:bg-background! **:[[role='tree']]:text-foreground">
-        <JsonView data={data} style={defaultStyles} clickToExpandNode={true} />
+      <div className="**:[[role='tree']]:bg-transparent!">
+        <JsonView data={data} style={resolvedTheme === "dark" ? darkStyles : defaultStyles} clickToExpandNode={true} />
       </div>
     </div>
   );


### PR DESCRIPTION
## TLDR

Problem this solves:

- The logs JSON tree is unreadable in dark mode
- String values render dark green on near black
- Commas and braces render black, so they vanish

How it solves it:

- The tree now picks its colors from the active theme
- It inherits the panel behind it instead of painting its own

## User Flow

Before: an admin reading a request's raw payload in dark mode cannot make out the values

1. They open http://localhost:4000/ui/?page=logs and switch the theme toggle in the top bar to dark
2. They click a request row to open the detail panel
3. In Request & Response they click JSON, then Response
4. The keys are readable, but the string values sit in a dark green that is nearly the same as the panel behind them
5. The commas, braces and brackets are black, so the structure of the payload is invisible and the block reads as a list of loose keys
6. The same thing happens on the Request tab, and on every log they open

After: the same admin reads the payload the same way they would in light mode

1. They open http://localhost:4000/ui/?page=logs and switch the theme toggle to dark
2. They click a request row to open the detail panel
3. In Request & Response they click JSON, then Response
4. The keys, string values, numbers and nulls each have their own readable color against the dark panel
5. The commas, braces and brackets are visible, so the nesting of the payload reads at a glance
6. The panel behind the tree is the same surface as the rest of the detail view, with no second background inside it
7. Switching the toggle back to light gives the same tree in the colors it has always had

## Relevant issues

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

Setup: a local proxy with one real Anthropic deployment, the dashboard dev server pointed at it, signed in as an admin, one logged request to open

```
curl -X POST http://localhost:4000/model/new \
  -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
  -d '{"model_name":"claude-opus-5","litellm_params":{"model":"anthropic/claude-opus-5","api_key":"'"$ANTHROPIC_API_KEY"'"}}'

curl -X POST http://localhost:4000/v1/chat/completions \
  -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
  -d '{"model":"claude-opus-5","messages":[{"role":"user","content":"Reply with exactly: dark mode json check"}],"max_tokens":32}'
```

### Before (fa25ff2a2e)

#### Dark mode

1. Open http://localhost:4000/ui/?page=logs and set the theme toggle to dark
2. Click the logged request, then click JSON and Response in Request & Response
3. Observed: string values in dark green against the dark panel, and black commas and braces that do not show up at all

#### Light mode

1. Same steps with the theme toggle set to light
2. Observed: the tree reads normally

<img width="642" height="381" alt="image" src="https://github.com/user-attachments/assets/567571ed-e30c-4f1e-a6a1-1a8bf663be24" />


### After (2e3ae43b6f)

#### Dark mode

1. Open http://localhost:4000/ui/?page=logs and set the theme toggle to dark
2. Click the logged request, then click JSON and Response in Request & Response
4. Observed: keys, strings, numbers and nulls each readable against the panel, commas and braces visible, and one background rather than two
<img width="645" height="380" alt="image" src="https://github.com/user-attachments/assets/ebcc9104-1e1c-47c6-8608-321fc940b90c" />


#### Light mode

1. Same steps with the theme toggle set to light
2. Observed: unchanged from Before

## Type

🐛 Bug Fix

## Caveats (if any)

### Low

- Dark colors come from the library's own preset, not our tokens
- One frame of light colors before the theme resolves, same as the toasts

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
