### PR TITLE
fix(openai): flatten top-level anyOf/oneOf/allOf in Responses API tool schemas

### DIFF
--- a/litellm/litellm_core_utils/prompt_templates/common_utils.py
+++ b/litellm/litellm_core_utils/prompt_templates/common_utils.py
@@ -1093,6 +1093,7 @@ def sanitize_input_schema_for_anthropic(input_schema: dict) -> "AnthropicInputSc
 _TOP_LEVEL_SCHEMA_COMBINATORS: Final = ("allOf", "anyOf", "oneOf")
 _OPENAI_REJECTED_TOP_LEVEL_SCHEMA_KEYS: Final = ("enum", "const", "not")
 _LOCAL_SCHEMA_REF_PREFIXES: Final = (("#/$defs/", "$defs"), ("#/definitions/", "definitions"))
+_MAX_SCHEMA_FLATTEN_DEPTH: Final = 32
 _EMPTY_SCHEMA: Final[Mapping[str, object]] = MappingProxyType({})
 
 
@@ -1101,11 +1102,9 @@ def _schema_properties(schema: Mapping[str, object]) -> Mapping[str, object]:
     return properties if isinstance(properties, dict) else _EMPTY_SCHEMA
 
 
-def _schema_branches(schema: Mapping[str, object], combinator: str) -> tuple[Mapping[str, object], ...]:
+def _schema_branches(schema: Mapping[str, object], combinator: str) -> tuple[object, ...]:
     branches: Final = schema.get(combinator)
-    if not isinstance(branches, list):
-        return ()
-    return tuple(branch for branch in branches if isinstance(branch, dict))
+    return tuple(branches) if isinstance(branches, list) else ()
 
 
 def _schema_required_names(schema: Mapping[str, object]) -> frozenset[str]:
@@ -1140,29 +1139,48 @@ def _resolve_local_schema_ref(root: Mapping[str, object], ref: str) -> Mapping[s
 
 
 def _mergeable_branch(
-    root: Mapping[str, object], branch: Mapping[str, object], seen_refs: frozenset[str]
+    root: Mapping[str, object],
+    branch: object,
+    seen_refs: frozenset[str],
+    depth: int,
+    expanded_refs: dict[str, Mapping[str, object] | None],  # mutable-ok: per-call memo bounding repeated $ref work
 ) -> Mapping[str, object] | None:
-    ref: Final = branch.get("$ref")
-    if isinstance(ref, str):
-        if ref in seen_refs:
-            return None
-        target: Final = _resolve_local_schema_ref(root, ref)
-        if target is None:
-            return None
-        return _mergeable_branch(root, target, seen_refs | frozenset((ref,)))
-    flattened: Final = _flatten_schema_against_root(branch, root, seen_refs)
-    if any(combinator in flattened for combinator in _TOP_LEVEL_SCHEMA_COMBINATORS):
+    if not isinstance(branch, dict) or depth > _MAX_SCHEMA_FLATTEN_DEPTH:
         return None
-    return flattened
+    ref: Final = branch.get("$ref")
+    if not isinstance(ref, str):
+        flattened: Final = _flatten_schema_against_root(branch, root, seen_refs, depth, expanded_refs)
+        if any(combinator in flattened for combinator in _TOP_LEVEL_SCHEMA_COMBINATORS):
+            return None
+        return flattened
+    if ref in expanded_refs:
+        return expanded_refs[ref]
+    if ref in seen_refs:
+        return None
+    target: Final = _resolve_local_schema_ref(root, ref)
+    expanded: Final = (
+        None
+        if target is None
+        else _mergeable_branch(root, target, seen_refs | frozenset((ref,)), depth + 1, expanded_refs)
+    )
+    expanded_refs[ref] = expanded
+    return expanded
 
 
 def _flatten_schema_against_root(
-    schema: Mapping[str, object], root: Mapping[str, object], seen_refs: frozenset[str]
+    schema: Mapping[str, object],
+    root: Mapping[str, object],
+    seen_refs: frozenset[str],
+    depth: int,
+    expanded_refs: dict[str, Mapping[str, object] | None],  # mutable-ok: per-call memo bounding repeated $ref work
 ) -> Mapping[str, object]:
     raw_branch_groups: Final = tuple(
         (
             combinator,
-            tuple(_mergeable_branch(root, branch, seen_refs) for branch in _schema_branches(schema, combinator)),
+            tuple(
+                _mergeable_branch(root, branch, seen_refs, depth + 1, expanded_refs)
+                for branch in _schema_branches(schema, combinator)
+            ),
         )
         for combinator in _TOP_LEVEL_SCHEMA_COMBINATORS
         if isinstance(schema.get(combinator), list)
@@ -1189,15 +1207,11 @@ def _flatten_schema_against_root(
     merged_properties: Final = {  # mutable-ok: tool parameters are JSON dicts
         name: value for source in (*reversed(branches), schema) for name, value in _schema_properties(source).items()
     }
-    fallback_required: Final = frozenset(
-        name for combinator, group in branch_groups for name in _combinator_required_names(combinator, group)
+    required_names: Final = _schema_required_names(schema).union(
+        *(_combinator_required_names(combinator, group) for combinator, group in branch_groups)
     )
     kept: Final = MappingProxyType({key: value for key, value in schema.items() if key not in dropped})
-    required_update: Final = (
-        MappingProxyType({"required": sorted(fallback_required)})
-        if "required" not in kept and fallback_required
-        else _EMPTY_SCHEMA
-    )
+    required_update: Final = MappingProxyType({"required": sorted(required_names)}) if required_names else _EMPTY_SCHEMA
     return {  # mutable-ok: tool parameters are JSON dicts
         **kept,
         "type": "object",
@@ -1214,16 +1228,18 @@ def flatten_top_level_schema_combinators(schema: Mapping[str, object]) -> Mappin
     are accepted), while lenient backends such as the ChatGPT backend Codex
     talks to natively accept them, so an MCP tool declaring a top-level union
     400s through LiteLLM. Branch properties merge without clobbering (the
-    top-level schema wins, then earlier branches); a missing ``required``
-    becomes the intersection of the branch lists for anyOf/oneOf and their
-    union for allOf. Branches that are local ``$ref``s (``#/$defs/...`` or
-    ``#/definitions/...``) are resolved first and branches that are themselves
-    combinators are flattened recursively; a branch that cannot be fully
-    merged (an external or cyclic ``$ref``, or a non-object union) leaves the
-    whole schema untouched so OpenAI's own validation still applies.
-    Non-object schemas pass through unchanged and the input is never mutated.
+    top-level schema wins, then earlier branches); ``required`` becomes the
+    top-level list plus the intersection of the branch lists for anyOf/oneOf
+    or their union for allOf. Branches that are local ``$ref``s
+    (``#/$defs/...`` or ``#/definitions/...``) are resolved first, each ref
+    at most once per call, and branches that are themselves combinators are
+    flattened recursively up to a fixed depth; a branch that cannot be fully
+    merged (a boolean schema, an external or cyclic ``$ref``, a non-object
+    union, or nesting past the depth cap) leaves the whole schema untouched so
+    OpenAI's own validation still applies. Non-object schemas pass through
+    unchanged and the input is never mutated.
     """
-    return _flatten_schema_against_root(schema, schema, frozenset())
+    return _flatten_schema_against_root(schema, schema, frozenset(), 0, {})  # mutable-ok: fresh per-call $ref memo
 
 
 def _get_image_mime_type_from_url(url: str) -> str | None:

--- a/litellm/litellm_core_utils/prompt_templates/common_utils.py
+++ b/litellm/litellm_core_utils/prompt_templates/common_utils.py
@@ -1092,6 +1092,7 @@ def sanitize_input_schema_for_anthropic(input_schema: dict) -> "AnthropicInputSc
 
 _TOP_LEVEL_SCHEMA_COMBINATORS: Final = ("allOf", "anyOf", "oneOf")
 _OPENAI_REJECTED_TOP_LEVEL_SCHEMA_KEYS: Final = ("enum", "const", "not")
+_LOCAL_SCHEMA_REF_PREFIXES: Final = (("#/$defs/", "$defs"), ("#/definitions/", "definitions"))
 _EMPTY_SCHEMA: Final[Mapping[str, object]] = MappingProxyType({})
 
 
@@ -1123,31 +1124,61 @@ def _combinator_required_names(combinator: str, branches: tuple[Mapping[str, obj
     return branch_names[0].intersection(*branch_names[1:])
 
 
-def flatten_top_level_schema_combinators(schema: Mapping[str, object]) -> Mapping[str, object]:
-    """Merge top-level ``allOf``/``anyOf``/``oneOf`` branches into an object tool schema.
+def _resolve_local_schema_ref(root: Mapping[str, object], ref: str) -> Mapping[str, object] | None:
+    matched: Final = next(
+        ((prefix, container) for prefix, container in _LOCAL_SCHEMA_REF_PREFIXES if ref.startswith(prefix)),
+        None,
+    )
+    if matched is None:
+        return None
+    prefix, container = matched
+    definitions: Final = root.get(container)
+    if not isinstance(definitions, dict):
+        return None
+    target: Final = definitions.get(ref[len(prefix) :])
+    return target if isinstance(target, dict) else None
 
-    OpenAI's function-calling validator rejects tool ``parameters`` carrying
-    'oneOf'/'anyOf'/'allOf'/'enum'/'const'/'not' at the top level (nested uses
-    are accepted), while lenient backends such as the ChatGPT backend Codex
-    talks to natively accept them, so an MCP tool declaring a top-level union
-    400s through LiteLLM. Branch properties merge without clobbering (the
-    top-level schema wins, then earlier branches); a missing ``required``
-    becomes the intersection of the branch lists for anyOf/oneOf and their
-    union for allOf. Non-object schemas pass through unchanged and the input
-    is never mutated.
-    """
-    branch_groups: Final = tuple(
-        (combinator, _schema_branches(schema, combinator))
+
+def _mergeable_branch(
+    root: Mapping[str, object], branch: Mapping[str, object], seen_refs: frozenset[str]
+) -> Mapping[str, object] | None:
+    ref: Final = branch.get("$ref")
+    if isinstance(ref, str):
+        if ref in seen_refs:
+            return None
+        target: Final = _resolve_local_schema_ref(root, ref)
+        if target is None:
+            return None
+        return _mergeable_branch(root, target, seen_refs | frozenset((ref,)))
+    flattened: Final = _flatten_schema_against_root(branch, root, seen_refs)
+    if any(combinator in flattened for combinator in _TOP_LEVEL_SCHEMA_COMBINATORS):
+        return None
+    return flattened
+
+
+def _flatten_schema_against_root(
+    schema: Mapping[str, object], root: Mapping[str, object], seen_refs: frozenset[str]
+) -> Mapping[str, object]:
+    raw_branch_groups: Final = tuple(
+        (
+            combinator,
+            tuple(_mergeable_branch(root, branch, seen_refs) for branch in _schema_branches(schema, combinator)),
+        )
         for combinator in _TOP_LEVEL_SCHEMA_COMBINATORS
         if isinstance(schema.get(combinator), list)
     )
     dropped: Final = (
-        *(combinator for combinator, _ in branch_groups),
+        *(combinator for combinator, _ in raw_branch_groups),
         *(key for key in _OPENAI_REJECTED_TOP_LEVEL_SCHEMA_KEYS if key in schema),
     )
     if not dropped:
         return schema
 
+    if any(branch is None for _, group in raw_branch_groups for branch in group):
+        return schema
+    branch_groups: Final = tuple(
+        (combinator, tuple(branch for branch in group if branch is not None)) for combinator, group in raw_branch_groups
+    )
     branches: Final = tuple(branch for _, group in branch_groups for branch in group)
     is_object_schema: Final = schema.get("type") == "object" or (
         "type" not in schema and branches != () and all("properties" in branch for branch in branches)
@@ -1173,6 +1204,26 @@ def flatten_top_level_schema_combinators(schema: Mapping[str, object]) -> Mappin
         "properties": merged_properties,
         **required_update,
     }
+
+
+def flatten_top_level_schema_combinators(schema: Mapping[str, object]) -> Mapping[str, object]:
+    """Merge top-level ``allOf``/``anyOf``/``oneOf`` branches into an object tool schema.
+
+    OpenAI's function-calling validator rejects tool ``parameters`` carrying
+    'oneOf'/'anyOf'/'allOf'/'enum'/'const'/'not' at the top level (nested uses
+    are accepted), while lenient backends such as the ChatGPT backend Codex
+    talks to natively accept them, so an MCP tool declaring a top-level union
+    400s through LiteLLM. Branch properties merge without clobbering (the
+    top-level schema wins, then earlier branches); a missing ``required``
+    becomes the intersection of the branch lists for anyOf/oneOf and their
+    union for allOf. Branches that are local ``$ref``s (``#/$defs/...`` or
+    ``#/definitions/...``) are resolved first and branches that are themselves
+    combinators are flattened recursively; a branch that cannot be fully
+    merged (an external or cyclic ``$ref``, or a non-object union) leaves the
+    whole schema untouched so OpenAI's own validation still applies.
+    Non-object schemas pass through unchanged and the input is never mutated.
+    """
+    return _flatten_schema_against_root(schema, schema, frozenset())
 
 
 def _get_image_mime_type_from_url(url: str) -> str | None:

--- a/litellm/litellm_core_utils/prompt_templates/common_utils.py
+++ b/litellm/litellm_core_utils/prompt_templates/common_utils.py
@@ -1167,6 +1167,10 @@ def _mergeable_branch(
     return expanded
 
 
+def _is_object_schema(schema: Mapping[str, object]) -> bool:
+    return schema.get("type") == "object" or ("type" not in schema and "properties" in schema)
+
+
 def _flatten_schema_against_root(
     schema: Mapping[str, object],
     root: Mapping[str, object],
@@ -1198,8 +1202,8 @@ def _flatten_schema_against_root(
         (combinator, tuple(branch for branch in group if branch is not None)) for combinator, group in raw_branch_groups
     )
     branches: Final = tuple(branch for _, group in branch_groups for branch in group)
-    is_object_schema: Final = schema.get("type") == "object" or (
-        "type" not in schema and branches != () and all("properties" in branch for branch in branches)
+    is_object_schema: Final = _is_object_schema(schema) or (
+        "type" not in schema and branches != () and all(_is_object_schema(branch) for branch in branches)
     )
     if not is_object_schema:
         return schema

--- a/litellm/litellm_core_utils/prompt_templates/common_utils.py
+++ b/litellm/litellm_core_utils/prompt_templates/common_utils.py
@@ -10,6 +10,7 @@ from collections.abc import Iterable, Mapping, Sequence
 from itertools import groupby
 from os import PathLike
 from pathlib import Path
+from types import MappingProxyType
 from typing import TYPE_CHECKING, Any, Final, Literal, TypeVar, cast
 
 from openai.types.chat.chat_completion_custom_tool_param import (
@@ -1087,6 +1088,91 @@ def sanitize_input_schema_for_anthropic(input_schema: dict) -> "AnthropicInputSc
     allowed_keys: Final = set(AnthropicInputSchema.__annotations__.keys())
     filtered: Final = {key: value for key, value in normalized.items() if key in allowed_keys}
     return AnthropicInputSchema(**filtered)
+
+
+_TOP_LEVEL_SCHEMA_COMBINATORS: Final = ("allOf", "anyOf", "oneOf")
+_OPENAI_REJECTED_TOP_LEVEL_SCHEMA_KEYS: Final = ("enum", "const", "not")
+_EMPTY_SCHEMA: Final[Mapping[str, object]] = MappingProxyType({})
+
+
+def _schema_properties(schema: Mapping[str, object]) -> Mapping[str, object]:
+    properties: Final = schema.get("properties")
+    return properties if isinstance(properties, dict) else _EMPTY_SCHEMA
+
+
+def _schema_branches(schema: Mapping[str, object], combinator: str) -> tuple[Mapping[str, object], ...]:
+    branches: Final = schema.get(combinator)
+    if not isinstance(branches, list):
+        return ()
+    return tuple(branch for branch in branches if isinstance(branch, dict))
+
+
+def _schema_required_names(schema: Mapping[str, object]) -> frozenset[str]:
+    required: Final = schema.get("required")
+    if not isinstance(required, list):
+        return frozenset()
+    return frozenset(name for name in required if isinstance(name, str))
+
+
+def _combinator_required_names(combinator: str, branches: tuple[Mapping[str, object], ...]) -> frozenset[str]:
+    branch_names: Final = tuple(_schema_required_names(branch) for branch in branches)
+    if not branch_names:
+        return frozenset()
+    if combinator == "allOf":
+        return branch_names[0].union(*branch_names[1:])
+    return branch_names[0].intersection(*branch_names[1:])
+
+
+def flatten_top_level_schema_combinators(schema: Mapping[str, object]) -> Mapping[str, object]:
+    """Merge top-level ``allOf``/``anyOf``/``oneOf`` branches into an object tool schema.
+
+    OpenAI's function-calling validator rejects tool ``parameters`` carrying
+    'oneOf'/'anyOf'/'allOf'/'enum'/'const'/'not' at the top level (nested uses
+    are accepted), while lenient backends such as the ChatGPT backend Codex
+    talks to natively accept them, so an MCP tool declaring a top-level union
+    400s through LiteLLM. Branch properties merge without clobbering (the
+    top-level schema wins, then earlier branches); a missing ``required``
+    becomes the intersection of the branch lists for anyOf/oneOf and their
+    union for allOf. Non-object schemas pass through unchanged and the input
+    is never mutated.
+    """
+    branch_groups: Final = tuple(
+        (combinator, _schema_branches(schema, combinator))
+        for combinator in _TOP_LEVEL_SCHEMA_COMBINATORS
+        if isinstance(schema.get(combinator), list)
+    )
+    dropped: Final = (
+        *(combinator for combinator, _ in branch_groups),
+        *(key for key in _OPENAI_REJECTED_TOP_LEVEL_SCHEMA_KEYS if key in schema),
+    )
+    if not dropped:
+        return schema
+
+    branches: Final = tuple(branch for _, group in branch_groups for branch in group)
+    is_object_schema: Final = schema.get("type") == "object" or (
+        "type" not in schema and branches != () and all("properties" in branch for branch in branches)
+    )
+    if not is_object_schema:
+        return schema
+
+    merged_properties: Final = {  # mutable-ok: tool parameters are JSON dicts
+        name: value for source in (*reversed(branches), schema) for name, value in _schema_properties(source).items()
+    }
+    fallback_required: Final = frozenset(
+        name for combinator, group in branch_groups for name in _combinator_required_names(combinator, group)
+    )
+    kept: Final = MappingProxyType({key: value for key, value in schema.items() if key not in dropped})
+    required_update: Final = (
+        MappingProxyType({"required": sorted(fallback_required)})
+        if "required" not in kept and fallback_required
+        else _EMPTY_SCHEMA
+    )
+    return {  # mutable-ok: tool parameters are JSON dicts
+        **kept,
+        "type": "object",
+        "properties": merged_properties,
+        **required_update,
+    }
 
 
 def _get_image_mime_type_from_url(url: str) -> str | None:

--- a/litellm/llms/openai/responses/transformation.py
+++ b/litellm/llms/openai/responses/transformation.py
@@ -32,6 +32,7 @@ else:
     LiteLLMLoggingObj = Any
 
 _NO_TOOL_UPDATE: Final[Mapping[str, object]] = MappingProxyType({})
+_MODEL_FAMILIES_REJECTING_TOP_LEVEL_SCHEMA_COMBINATORS: Final = ("gpt-4", "gpt-3.5", "chatgpt-4o", "o1", "o3", "o4")
 
 
 class OpenAIResponsesAPIConfig(BaseResponsesAPIConfig):
@@ -171,7 +172,7 @@ class OpenAIResponsesAPIConfig(BaseResponsesAPIConfig):
         input = self._validate_input_param(input)
         tools = response_api_optional_request_params.get("tools")
         input, tools = self.remove_cache_control_flag_from_input_and_tools(model=model, input=input, tools=tools)
-        sanitized_tools: Final = self._flatten_tool_schema_combinators_for_openai(tools)
+        sanitized_tools: Final = self._flatten_tool_schema_combinators_for_openai(model=model, tools=tools)
         if sanitized_tools is not None:
             response_api_optional_request_params["tools"] = sanitized_tools
         final_request_params: Final = dict(
@@ -214,20 +215,34 @@ class OpenAIResponsesAPIConfig(BaseResponsesAPIConfig):
 
     def _flatten_tool_schema_combinators_for_openai(
         self,
+        model: str,
         tools: list[ALL_RESPONSES_API_TOOL_PARAMS] | None,  # mutable-ok: request tools are a JSON list
     ) -> list[ALL_RESPONSES_API_TOOL_PARAMS] | None:  # mutable-ok: request tools are a JSON list
-        """Flatten top-level schema combinators for OpenAI itself only.
+        """Flatten top-level schema combinators only where OpenAI's validator rejects them.
 
         OpenAI-compatible backends reusing this config (and the ChatGPT backend
-        Codex talks to natively) accept them. Codex wraps MCP tools inside
-        namespace entries, so nested ``tools`` arrays are walked too.
+        Codex talks to natively) accept them, and so do GPT-5 and later models,
+        which also call tools better with the union intact. Codex wraps MCP tools
+        inside namespace entries, so nested ``tools`` arrays are walked too.
         """
         if tools is None or self.custom_llm_provider != LlmProviders.OPENAI:
             return tools
+        if not self._rejects_top_level_schema_combinators(model):
+            return tools
         flattened: Final = [  # mutable-ok: request tools are a JSON list
-            self._flattened_tool_entry(tool) for tool in tools
+            self._flattened_tool_or_passthrough(tool) for tool in tools
         ]
         return cast("list[ALL_RESPONSES_API_TOOL_PARAMS]", flattened)  # cast-ok: dict spread keeps each tool's shape
+
+    @staticmethod
+    def _flattened_tool_or_passthrough(tool: object) -> object:
+        return OpenAIResponsesAPIConfig._flattened_tool_entry(tool) if isinstance(tool, dict) else tool
+
+    @staticmethod
+    def _rejects_top_level_schema_combinators(model: str) -> bool:
+        bare_model: Final = model.split("/")[-1]
+        base_model: Final = bare_model.split(":")[1] if bare_model.startswith("ft:") else bare_model
+        return base_model.startswith(_MODEL_FAMILIES_REJECTING_TOP_LEVEL_SCHEMA_COMBINATORS)
 
     @staticmethod
     def _flattened_tool_entry(
@@ -699,7 +714,7 @@ class OpenAIResponsesAPIConfig(BaseResponsesAPIConfig):
         input = self._validate_input_param(input)
         tools = response_api_optional_request_params.get("tools")
         input, tools = self.remove_cache_control_flag_from_input_and_tools(model=model, input=input, tools=tools)
-        sanitized_tools: Final = self._flatten_tool_schema_combinators_for_openai(tools)
+        sanitized_tools: Final = self._flatten_tool_schema_combinators_for_openai(model=model, tools=tools)
         if sanitized_tools is not None:
             response_api_optional_request_params["tools"] = sanitized_tools
         data: Final = dict(ResponsesAPIRequestParams(model=model, input=input, **response_api_optional_request_params))

--- a/litellm/llms/openai/responses/transformation.py
+++ b/litellm/llms/openai/responses/transformation.py
@@ -1,3 +1,5 @@
+from collections.abc import Mapping, Sequence
+from types import MappingProxyType
 from typing import TYPE_CHECKING, Any, Final, cast, get_type_hints
 
 import httpx
@@ -28,6 +30,8 @@ if TYPE_CHECKING:
     LiteLLMLoggingObj = _LiteLLMLoggingObj
 else:
     LiteLLMLoggingObj = Any
+
+_NO_TOOL_UPDATE: Final[Mapping[str, object]] = MappingProxyType({})
 
 
 class OpenAIResponsesAPIConfig(BaseResponsesAPIConfig):
@@ -167,8 +171,9 @@ class OpenAIResponsesAPIConfig(BaseResponsesAPIConfig):
         input = self._validate_input_param(input)
         tools = response_api_optional_request_params.get("tools")
         input, tools = self.remove_cache_control_flag_from_input_and_tools(model=model, input=input, tools=tools)
-        if tools is not None:
-            response_api_optional_request_params["tools"] = tools
+        sanitized_tools: Final = self._flatten_tool_schema_combinators_for_openai(tools)
+        if sanitized_tools is not None:
+            response_api_optional_request_params["tools"] = sanitized_tools
         final_request_params: Final = dict(
             ResponsesAPIRequestParams(model=model, input=input, **response_api_optional_request_params)
         )
@@ -206,6 +211,54 @@ class OpenAIResponsesAPIConfig(BaseResponsesAPIConfig):
                     filter_value_from_dict(cast(dict, tool), "cache_control")
 
         return input, tools
+
+    def _flatten_tool_schema_combinators_for_openai(
+        self,
+        tools: list[ALL_RESPONSES_API_TOOL_PARAMS] | None,  # mutable-ok: request tools are a JSON list
+    ) -> list[ALL_RESPONSES_API_TOOL_PARAMS] | None:  # mutable-ok: request tools are a JSON list
+        """Flatten top-level schema combinators for OpenAI itself only.
+
+        OpenAI-compatible backends reusing this config (and the ChatGPT backend
+        Codex talks to natively) accept them. Codex wraps MCP tools inside
+        namespace entries, so nested ``tools`` arrays are walked too.
+        """
+        if tools is None or self.custom_llm_provider != LlmProviders.OPENAI:
+            return tools
+        flattened: Final = [  # mutable-ok: request tools are a JSON list
+            self._flattened_tool_entry(tool) for tool in tools
+        ]
+        return cast("list[ALL_RESPONSES_API_TOOL_PARAMS]", flattened)  # cast-ok: dict spread keeps each tool's shape
+
+    @staticmethod
+    def _flattened_tool_entry(
+        entry: Mapping[str, object],
+    ) -> dict[str, object]:  # mutable-ok: request tools are JSON dicts
+        from litellm.litellm_core_utils.prompt_templates.common_utils import (
+            flatten_top_level_schema_combinators,
+        )
+
+        parameters: Final = entry.get("parameters")
+        nested_tools: Final = entry.get("tools")
+        parameters_update: Final = (
+            MappingProxyType({"parameters": flatten_top_level_schema_combinators(parameters)})
+            if isinstance(parameters, dict)
+            else _NO_TOOL_UPDATE
+        )
+        tools_update: Final = (
+            MappingProxyType({"tools": OpenAIResponsesAPIConfig._flattened_nested_tools(nested_tools)})
+            if isinstance(nested_tools, list)
+            else _NO_TOOL_UPDATE
+        )
+        return {**entry, **parameters_update, **tools_update}  # mutable-ok: request tools are JSON dicts
+
+    @staticmethod
+    def _flattened_nested_tools(
+        nested_tools: Sequence[object],
+    ) -> list[object]:  # mutable-ok: namespace tools are a JSON list
+        return [  # mutable-ok: namespace tools are a JSON list
+            OpenAIResponsesAPIConfig._flattened_tool_entry(item) if isinstance(item, dict) else item
+            for item in nested_tools
+        ]
 
     def _validate_input_param(self, input: str | ResponseInputParam) -> str | ResponseInputParam:
         """
@@ -646,8 +699,9 @@ class OpenAIResponsesAPIConfig(BaseResponsesAPIConfig):
         input = self._validate_input_param(input)
         tools = response_api_optional_request_params.get("tools")
         input, tools = self.remove_cache_control_flag_from_input_and_tools(model=model, input=input, tools=tools)
-        if tools is not None:
-            response_api_optional_request_params["tools"] = tools
+        sanitized_tools: Final = self._flatten_tool_schema_combinators_for_openai(tools)
+        if sanitized_tools is not None:
+            response_api_optional_request_params["tools"] = sanitized_tools
         data: Final = dict(ResponsesAPIRequestParams(model=model, input=input, **response_api_optional_request_params))
 
         return url, data

--- a/tests/code_coverage_tests/recursive_detector.py
+++ b/tests/code_coverage_tests/recursive_detector.py
@@ -57,6 +57,7 @@ IGNORE_FUNCTIONS = [
     "_filter_argument_value",  # max depth set (DEFAULT_MAX_RECURSE_DEPTH); fails closed by blocking the tool call at the cap.
     "_redact_scanned_content",  # max depth set (DEFAULT_MAX_RECURSE_DEPTH); fails closed by returning "[REDACTED]" at the cap.
     "_iter_fallback_targets",  # max depth set (2 * ROUTER_MAX_FALLBACKS); fails closed by raising ValueError at the cap.
+    "_mergeable_branch",  # max depth set (_MAX_SCHEMA_FLATTEN_DEPTH=32) plus a seen_refs cycle guard; passes the schema through untouched at the cap.
     "json_string_leaves",  # max depth set (MAX_STRUCTURED_CONTENT_SCAN_DEPTH); fails closed by raising at the cap so nothing goes unscanned.
     "with_json_string_leaves",  # transitively bounded: only runs on a tree json_string_leaves already walked under the cap.
     "json_unrewritable_labels",  # max depth set (MAX_STRUCTURED_CONTENT_SCAN_DEPTH); returns the None sentinel at the cap so the caller blocks.

--- a/tests/test_litellm/litellm_core_utils/prompt_templates/test_litellm_core_utils_prompt_templates_common_utils.py
+++ b/tests/test_litellm/litellm_core_utils/prompt_templates/test_litellm_core_utils_prompt_templates_common_utils.py
@@ -1094,3 +1094,140 @@ def test_drop_tool_reference_parts_leaves_non_tool_messages_alone():
 
     assert result[0] == user_message
     assert result[2]["content"] == ""
+
+
+class TestFlattenTopLevelSchemaCombinators:
+    def _customer_anyof_schema(self):
+        return {
+            "type": "object",
+            "anyOf": [
+                {
+                    "properties": {"id": {"type": "string"}, "enabled": {"type": "boolean"}},
+                    "required": ["id", "enabled"],
+                },
+                {
+                    "properties": {"id": {"type": "string"}, "schedule": {"type": "string"}},
+                    "required": ["id", "schedule"],
+                },
+            ],
+            "properties": {"id": {"type": "string"}},
+            "required": ["id"],
+        }
+
+    def test_merges_anyof_branches_into_object_schema(self):
+        from litellm.litellm_core_utils.prompt_templates.common_utils import (
+            flatten_top_level_schema_combinators,
+        )
+
+        result = flatten_top_level_schema_combinators(self._customer_anyof_schema())
+
+        assert "anyOf" not in result
+        assert result["type"] == "object"
+        assert set(result["properties"]) == {"id", "enabled", "schedule"}
+        assert result["properties"]["enabled"] == {"type": "boolean"}
+        assert result["required"] == ["id"]
+
+    def test_typeless_anyof_of_object_branches_gets_intersected_required(self):
+        from litellm.litellm_core_utils.prompt_templates.common_utils import (
+            flatten_top_level_schema_combinators,
+        )
+
+        schema = {
+            "anyOf": [
+                {"properties": {"id": {"type": "string"}, "enabled": {"type": "boolean"}}, "required": ["id", "enabled"]},
+                {"properties": {"id": {"type": "string"}, "schedule": {"type": "string"}}, "required": ["id", "schedule"]},
+            ]
+        }
+
+        result = flatten_top_level_schema_combinators(schema)
+
+        assert result["type"] == "object"
+        assert "anyOf" not in result
+        assert result["required"] == ["id"]
+
+    def test_allof_required_is_the_union_of_branches(self):
+        from litellm.litellm_core_utils.prompt_templates.common_utils import (
+            flatten_top_level_schema_combinators,
+        )
+
+        schema = {
+            "type": "object",
+            "allOf": [
+                {"properties": {"id": {"type": "string"}}, "required": ["id"]},
+                {"properties": {"enabled": {"type": "boolean"}}, "required": ["enabled"]},
+            ],
+        }
+
+        result = flatten_top_level_schema_combinators(schema)
+
+        assert "allOf" not in result
+        assert result["required"] == ["enabled", "id"]
+        assert set(result["properties"]) == {"id", "enabled"}
+
+    def test_top_level_schema_wins_property_collisions(self):
+        from litellm.litellm_core_utils.prompt_templates.common_utils import (
+            flatten_top_level_schema_combinators,
+        )
+
+        schema = {
+            "type": "object",
+            "anyOf": [
+                {"properties": {"id": {"type": "integer"}}},
+                {"properties": {"id": {"type": "number"}}},
+            ],
+            "properties": {"id": {"type": "string"}},
+        }
+
+        result = flatten_top_level_schema_combinators(schema)
+
+        assert result["properties"]["id"] == {"type": "string"}
+
+    def test_drops_openai_rejected_scalar_keys_on_object_schema(self):
+        from litellm.litellm_core_utils.prompt_templates.common_utils import (
+            flatten_top_level_schema_combinators,
+        )
+
+        schema = {
+            "type": "object",
+            "properties": {"id": {"type": "string"}},
+            "enum": [{"id": "a"}],
+            "const": {"id": "a"},
+            "not": {"required": ["other"]},
+        }
+
+        result = flatten_top_level_schema_combinators(schema)
+
+        assert "enum" not in result
+        assert "const" not in result
+        assert "not" not in result
+        assert result["properties"] == {"id": {"type": "string"}}
+
+    def test_non_object_union_passes_through_unchanged(self):
+        from litellm.litellm_core_utils.prompt_templates.common_utils import (
+            flatten_top_level_schema_combinators,
+        )
+
+        schema = {"anyOf": [{"type": "string"}, {"type": "number"}]}
+
+        assert flatten_top_level_schema_combinators(schema) is schema
+
+    def test_schema_without_rejected_keys_is_returned_as_is(self):
+        from litellm.litellm_core_utils.prompt_templates.common_utils import (
+            flatten_top_level_schema_combinators,
+        )
+
+        schema = {"type": "object", "properties": {"nested": {"anyOf": [{"type": "string"}, {"type": "null"}]}}}
+
+        assert flatten_top_level_schema_combinators(schema) is schema
+
+    def test_input_schema_is_never_mutated(self):
+        from litellm.litellm_core_utils.prompt_templates.common_utils import (
+            flatten_top_level_schema_combinators,
+        )
+
+        schema = self._customer_anyof_schema()
+        snapshot = json.loads(json.dumps(schema))
+
+        flatten_top_level_schema_combinators(schema)
+
+        assert schema == snapshot

--- a/tests/test_litellm/litellm_core_utils/prompt_templates/test_litellm_core_utils_prompt_templates_common_utils.py
+++ b/tests/test_litellm/litellm_core_utils/prompt_templates/test_litellm_core_utils_prompt_templates_common_utils.py
@@ -1134,8 +1134,14 @@ class TestFlattenTopLevelSchemaCombinators:
 
         schema = {
             "anyOf": [
-                {"properties": {"id": {"type": "string"}, "enabled": {"type": "boolean"}}, "required": ["id", "enabled"]},
-                {"properties": {"id": {"type": "string"}, "schedule": {"type": "string"}}, "required": ["id", "schedule"]},
+                {
+                    "properties": {"id": {"type": "string"}, "enabled": {"type": "boolean"}},
+                    "required": ["id", "enabled"],
+                },
+                {
+                    "properties": {"id": {"type": "string"}, "schedule": {"type": "string"}},
+                    "required": ["id", "schedule"],
+                },
             ]
         }
 
@@ -1201,6 +1207,79 @@ class TestFlattenTopLevelSchemaCombinators:
         assert "const" not in result
         assert "not" not in result
         assert result["properties"] == {"id": {"type": "string"}}
+
+    def test_resolves_local_ref_branches_from_defs(self):
+        from litellm.litellm_core_utils.prompt_templates.common_utils import (
+            flatten_top_level_schema_combinators,
+        )
+
+        schema = {
+            "anyOf": [{"$ref": "#/$defs/Enable"}, {"$ref": "#/$defs/Schedule"}],
+            "$defs": {
+                "Enable": {
+                    "properties": {"id": {"type": "string"}, "enabled": {"type": "boolean"}},
+                    "required": ["id", "enabled"],
+                },
+                "Schedule": {
+                    "properties": {"id": {"type": "string"}, "schedule": {"type": "string"}},
+                    "required": ["id", "schedule"],
+                },
+            },
+        }
+
+        result = flatten_top_level_schema_combinators(schema)
+
+        assert "anyOf" not in result
+        assert result["type"] == "object"
+        assert set(result["properties"]) == {"id", "enabled", "schedule"}
+        assert result["required"] == ["id"]
+        assert "$defs" in result
+
+    def test_flattens_nested_combinator_branch_from_definitions(self):
+        from litellm.litellm_core_utils.prompt_templates.common_utils import (
+            flatten_top_level_schema_combinators,
+        )
+
+        schema = {
+            "type": "object",
+            "oneOf": [
+                {"$ref": "#/definitions/Toggle"},
+                {"allOf": [{"properties": {"schedule": {"type": "string"}}, "required": ["schedule"]}]},
+            ],
+            "definitions": {"Toggle": {"properties": {"enabled": {"type": "boolean"}}, "required": ["enabled"]}},
+        }
+
+        result = flatten_top_level_schema_combinators(schema)
+
+        assert "oneOf" not in result
+        assert set(result["properties"]) == {"enabled", "schedule"}
+        assert "required" not in result
+
+    def test_unresolvable_ref_branch_leaves_schema_untouched(self):
+        from litellm.litellm_core_utils.prompt_templates.common_utils import (
+            flatten_top_level_schema_combinators,
+        )
+
+        schema = {
+            "type": "object",
+            "anyOf": [{"$ref": "https://example.com/schemas/automation.json"}],
+            "properties": {"id": {"type": "string"}},
+        }
+
+        assert flatten_top_level_schema_combinators(schema) is schema
+
+    def test_self_referencing_ref_branch_leaves_schema_untouched(self):
+        from litellm.litellm_core_utils.prompt_templates.common_utils import (
+            flatten_top_level_schema_combinators,
+        )
+
+        schema = {
+            "type": "object",
+            "anyOf": [{"$ref": "#/$defs/Node"}],
+            "$defs": {"Node": {"type": "object", "anyOf": [{"$ref": "#/$defs/Node"}]}},
+        }
+
+        assert flatten_top_level_schema_combinators(schema) is schema
 
     def test_non_object_union_passes_through_unchanged(self):
         from litellm.litellm_core_utils.prompt_templates.common_utils import (

--- a/tests/test_litellm/litellm_core_utils/prompt_templates/test_litellm_core_utils_prompt_templates_common_utils.py
+++ b/tests/test_litellm/litellm_core_utils/prompt_templates/test_litellm_core_utils_prompt_templates_common_utils.py
@@ -1360,6 +1360,50 @@ class TestFlattenTopLevelSchemaCombinators:
         assert "anyOf" not in flatten_top_level_schema_combinators(shallow)
         assert flatten_top_level_schema_combinators(deep) is deep
 
+    @pytest.mark.parametrize(
+        "branches",
+        [
+            [{"required": ["enabled"]}, {"required": ["schedule"]}],
+            [{"type": "object", "required": ["enabled"]}, {"type": "object", "required": ["schedule"]}],
+        ],
+    )
+    def test_typeless_root_with_properties_flattens_branches_without_properties(self, branches):
+        from litellm.litellm_core_utils.prompt_templates.common_utils import (
+            flatten_top_level_schema_combinators,
+        )
+
+        schema = {
+            "properties": {"id": {"type": "string"}, "enabled": {"type": "boolean"}, "schedule": {"type": "string"}},
+            "required": ["id"],
+            "anyOf": branches,
+        }
+
+        result = flatten_top_level_schema_combinators(schema)
+
+        assert "anyOf" not in result
+        assert result["type"] == "object"
+        assert set(result["properties"]) == {"id", "enabled", "schedule"}
+        assert result["required"] == ["id"]
+
+    def test_typeless_root_flattens_typed_object_branches_without_properties(self):
+        from litellm.litellm_core_utils.prompt_templates.common_utils import (
+            flatten_top_level_schema_combinators,
+        )
+
+        schema = {
+            "anyOf": [
+                {"type": "object", "properties": {"id": {"type": "string"}}},
+                {"type": "object", "required": ["id"]},
+            ]
+        }
+
+        result = flatten_top_level_schema_combinators(schema)
+
+        assert "anyOf" not in result
+        assert result["type"] == "object"
+        assert result["properties"] == {"id": {"type": "string"}}
+        assert "required" not in result
+
     def test_non_object_union_passes_through_unchanged(self):
         from litellm.litellm_core_utils.prompt_templates.common_utils import (
             flatten_top_level_schema_combinators,

--- a/tests/test_litellm/litellm_core_utils/prompt_templates/test_litellm_core_utils_prompt_templates_common_utils.py
+++ b/tests/test_litellm/litellm_core_utils/prompt_templates/test_litellm_core_utils_prompt_templates_common_utils.py
@@ -1,3 +1,4 @@
+import functools
 import json
 import os
 from unittest.mock import MagicMock, patch
@@ -1280,6 +1281,84 @@ class TestFlattenTopLevelSchemaCombinators:
         }
 
         assert flatten_top_level_schema_combinators(schema) is schema
+
+    @pytest.mark.parametrize("boolean_branch", [True, False])
+    def test_boolean_branch_leaves_schema_untouched(self, boolean_branch):
+        from litellm.litellm_core_utils.prompt_templates.common_utils import (
+            flatten_top_level_schema_combinators,
+        )
+
+        schema = {
+            "type": "object",
+            "anyOf": [boolean_branch, {"properties": {"id": {"type": "string"}}, "required": ["id"]}],
+        }
+
+        assert flatten_top_level_schema_combinators(schema) is schema
+
+    def test_root_required_is_combined_with_branch_required(self):
+        from litellm.litellm_core_utils.prompt_templates.common_utils import (
+            flatten_top_level_schema_combinators,
+        )
+
+        allof_schema = {
+            "type": "object",
+            "required": ["id"],
+            "properties": {"id": {"type": "string"}},
+            "allOf": [{"properties": {"enabled": {"type": "boolean"}}, "required": ["enabled"]}],
+        }
+        anyof_schema = {
+            "type": "object",
+            "required": ["id"],
+            "properties": {"id": {"type": "string"}},
+            "anyOf": [
+                {"properties": {"name": {"type": "string"}, "a": {"type": "string"}}, "required": ["name", "a"]},
+                {"properties": {"name": {"type": "string"}, "b": {"type": "string"}}, "required": ["name", "b"]},
+            ],
+        }
+
+        assert flatten_top_level_schema_combinators(allof_schema)["required"] == ["enabled", "id"]
+        assert flatten_top_level_schema_combinators(anyof_schema)["required"] == ["id", "name"]
+
+    def test_repeated_refs_are_expanded_once(self):
+        import time
+
+        from litellm.litellm_core_utils.prompt_templates.common_utils import (
+            flatten_top_level_schema_combinators,
+        )
+
+        fan_out, chain_length = 8, 8
+        schema = {
+            "type": "object",
+            "anyOf": [{"$ref": "#/$defs/Level0"}],
+            "$defs": {
+                **{
+                    f"Level{level}": {"anyOf": [{"$ref": f"#/$defs/Level{level + 1}"}] * fan_out}
+                    for level in range(chain_length)
+                },
+                f"Level{chain_length}": {"type": "object", "properties": {"id": {"type": "string"}}},
+            },
+        }
+
+        started = time.perf_counter()
+        result = flatten_top_level_schema_combinators(schema)
+
+        assert time.perf_counter() - started < 5
+        assert "anyOf" not in result
+        assert result["properties"] == {"id": {"type": "string"}}
+
+    def test_nesting_past_the_depth_cap_leaves_schema_untouched(self):
+        from litellm.litellm_core_utils.prompt_templates.common_utils import (
+            flatten_top_level_schema_combinators,
+        )
+
+        def nested(levels):
+            leaf = {"type": "object", "properties": {"id": {"type": "string"}}}
+            return functools.reduce(lambda inner, _: {"type": "object", "anyOf": [inner]}, range(levels), leaf)
+
+        shallow, deep = nested(20), nested(40)
+
+        assert "anyOf" not in flatten_top_level_schema_combinators(shallow)
+        assert flatten_top_level_schema_combinators(deep) is deep
 
     def test_non_object_union_passes_through_unchanged(self):
         from litellm.litellm_core_utils.prompt_templates.common_utils import (

--- a/tests/test_litellm/llms/openai/responses/test_openai_responses_transformation.py
+++ b/tests/test_litellm/llms/openai/responses/test_openai_responses_transformation.py
@@ -1626,3 +1626,138 @@ class TestResponsesSurfaceSharesTheEffortRule:
             drop_params=True,
         )
         assert ("temperature" in mapped) is temperature_survives
+
+
+class TestFlattenToolSchemaCombinatorsWiring:
+    """Regression tests for MCP tools with a top-level anyOf schema (Codex Desktop).
+
+    OpenAI's /v1/responses rejects function tool parameters carrying
+    'oneOf'/'anyOf'/'allOf'/'enum'/'const'/'not' at the top level, while the
+    ChatGPT backend Codex uses natively accepts them, so those tools 400'd
+    through the proxy with "Invalid schema for function ...".
+    """
+
+    def _anyof_parameters(self):
+        return {
+            "type": "object",
+            "anyOf": [
+                {
+                    "properties": {"id": {"type": "string"}, "enabled": {"type": "boolean"}},
+                    "required": ["id", "enabled"],
+                },
+                {
+                    "properties": {"id": {"type": "string"}, "schedule": {"type": "string"}},
+                    "required": ["id", "schedule"],
+                },
+            ],
+            "properties": {"id": {"type": "string"}},
+            "required": ["id"],
+        }
+
+    def _flat_function_tool(self):
+        return {
+            "type": "function",
+            "name": "mcp__codex_app__automation_update",
+            "description": "Update an automation",
+            "parameters": self._anyof_parameters(),
+            "strict": False,
+        }
+
+    def _codex_namespace_tool(self):
+        return {
+            "type": "namespace",
+            "name": "mcp__codex_app",
+            "tools": [
+                {
+                    "name": "automation_update",
+                    "description": "Update an automation",
+                    "parameters": self._anyof_parameters(),
+                    "strict": False,
+                }
+            ],
+        }
+
+    def test_openai_flattens_top_level_anyof_on_flat_function_tool(self):
+        result = OpenAIResponsesAPIConfig().transform_responses_api_request(
+            model="gpt-4o",
+            input="hi",
+            response_api_optional_request_params={"tools": [self._flat_function_tool()]},
+            litellm_params=GenericLiteLLMParams(),
+            headers={},
+        )
+
+        parameters = result["tools"][0]["parameters"]
+        assert "anyOf" not in parameters
+        assert parameters["type"] == "object"
+        assert set(parameters["properties"]) == {"id", "enabled", "schedule"}
+        assert parameters["required"] == ["id"]
+        assert json.loads(json.dumps(result["tools"])) == result["tools"]
+
+    def test_openai_flattens_anyof_inside_codex_namespace_tools(self):
+        result = OpenAIResponsesAPIConfig().transform_responses_api_request(
+            model="gpt-4o",
+            input="hi",
+            response_api_optional_request_params={"tools": [self._codex_namespace_tool()]},
+            litellm_params=GenericLiteLLMParams(),
+            headers={},
+        )
+
+        nested_parameters = result["tools"][0]["tools"][0]["parameters"]
+        assert "anyOf" not in nested_parameters
+        assert set(nested_parameters["properties"]) == {"id", "enabled", "schedule"}
+        assert json.loads(json.dumps(result["tools"])) == result["tools"]
+
+    def test_openai_compact_request_flattens_top_level_anyof(self):
+        _, data = OpenAIResponsesAPIConfig().transform_compact_response_api_request(
+            model="gpt-4o",
+            input="hi",
+            response_api_optional_request_params={"tools": [self._flat_function_tool()]},
+            api_base="https://api.openai.com/v1/responses",
+            litellm_params=GenericLiteLLMParams(),
+            headers={},
+        )
+
+        assert "anyOf" not in data["tools"][0]["parameters"]
+
+    def test_openai_leaves_tools_without_rejected_keys_alone(self):
+        clean_tool = {
+            "type": "function",
+            "name": "get_weather",
+            "parameters": {"type": "object", "properties": {"city": {"type": "string"}}},
+        }
+
+        result = OpenAIResponsesAPIConfig().transform_responses_api_request(
+            model="gpt-4o",
+            input="hi",
+            response_api_optional_request_params={"tools": [clean_tool]},
+            litellm_params=GenericLiteLLMParams(),
+            headers={},
+        )
+
+        assert result["tools"][0]["parameters"] == {"type": "object", "properties": {"city": {"type": "string"}}}
+
+    def test_openai_does_not_mutate_caller_tool_dicts(self):
+        tool = self._flat_function_tool()
+
+        OpenAIResponsesAPIConfig().transform_responses_api_request(
+            model="gpt-4o",
+            input="hi",
+            response_api_optional_request_params={"tools": [tool]},
+            litellm_params=GenericLiteLLMParams(),
+            headers={},
+        )
+
+        assert "anyOf" in tool["parameters"]
+
+    def test_non_openai_subclass_does_not_flatten(self):
+        from litellm.llms.hosted_vllm.responses.transformation import HostedVLLMResponsesAPIConfig
+
+        result = HostedVLLMResponsesAPIConfig().transform_responses_api_request(
+            model="hosted_vllm/qwen",
+            input="hi",
+            response_api_optional_request_params={"tools": [self._flat_function_tool()]},
+            litellm_params=GenericLiteLLMParams(),
+            headers={},
+        )
+
+        assert "anyOf" in result["tools"][0]["parameters"]

--- a/tests/test_litellm/llms/openai/responses/test_openai_responses_transformation.py
+++ b/tests/test_litellm/llms/openai/responses/test_openai_responses_transformation.py
@@ -1,4 +1,5 @@
 import json
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 import httpx
@@ -1761,3 +1762,57 @@ class TestFlattenToolSchemaCombinatorsWiring:
         )
 
         assert "anyOf" in result["tools"][0]["parameters"]
+
+    @pytest.mark.parametrize(
+        "model",
+        [
+            "gpt-4o",
+            "gpt-4.1-mini",
+            "gpt-4-turbo",
+            "o1",
+            "o3-pro",
+            "o4-mini",
+            "openai/gpt-4o",
+            "ft:gpt-4o-2024-08-06:org::abc",
+        ],
+    )
+    def test_openai_flattens_for_models_whose_validator_rejects_combinators(self, model):
+        result = OpenAIResponsesAPIConfig().transform_responses_api_request(
+            model=model,
+            input="hi",
+            response_api_optional_request_params={"tools": [self._flat_function_tool()]},
+            litellm_params=GenericLiteLLMParams(),
+            headers={},
+        )
+
+        assert "anyOf" not in result["tools"][0]["parameters"]
+
+    @pytest.mark.parametrize(
+        "model", ["gpt-5", "gpt-5-nano", "gpt-5.4-mini", "gpt-5.4-codex", "gpt-5.5", "openai/gpt-5.2"]
+    )
+    def test_openai_keeps_combinators_for_models_that_accept_them(self, model):
+        tool = self._flat_function_tool()
+
+        result = OpenAIResponsesAPIConfig().transform_responses_api_request(
+            model=model,
+            input="hi",
+            response_api_optional_request_params={"tools": [tool]},
+            litellm_params=GenericLiteLLMParams(),
+            headers={},
+        )
+
+        assert result["tools"][0] is tool
+
+    def test_openai_leaves_non_dict_tool_entries_alone(self):
+        opaque_tool = SimpleNamespace(type="function", name="automation_update")
+
+        result = OpenAIResponsesAPIConfig().transform_responses_api_request(
+            model="gpt-4o",
+            input="hi",
+            response_api_optional_request_params={"tools": [opaque_tool, self._flat_function_tool()]},
+            litellm_params=GenericLiteLLMParams(),
+            headers={},
+        )
+
+        assert result["tools"][0] is opaque_tool
+        assert "anyOf" not in result["tools"][1]["parameters"]


### PR DESCRIPTION
## TLDR

Problem this solves:

- Codex MCP tools with a top-level anyOf/oneOf/allOf 400 on OpenAI through the proxy
- The ChatGPT backend Codex uses natively accepts them, so it looks proxy-only

How it solves it:

- Merge top-level combinator branches into the object schema, OpenAI only, and only for the model families whose validator rejects them (gpt-4*, gpt-3.5, o1/o3/o4)
- GPT-5 and later accept the union natively and call tools better with it intact, so they keep the original schema
- Local $defs/definitions refs resolve once each; boolean, cyclic, or over-deep branches pass through untouched
- A typeless root with `properties` counts as an object; non-dict tool entries pass through
- Walks Codex namespace-nested tools on /v1/responses and /v1/responses/compact
- Providers reusing the OpenAI config (Azure, vLLM, xAI, ...) are left as is

## User Flow

Before: a Codex Desktop user pointed at the proxy cannot call an MCP tool whose parameters schema has a top-level `anyOf`, because OpenAI rejects the tool definition and the proxy relays the 400

1. They set Codex's model provider to the proxy (`base_url = https://litellm-domain/v1`, `wire_api = "responses"`, model `gpt-4o`) and add an MCP server whose `automation_update` tool declares `{"type": "object", "anyOf": [...], "properties": {...}, "required": ["id"]}` as its input schema
2. They type "Update automation abc123 to be enabled using the automation_update tool." into Codex
3. Codex sends POST https://litellm-domain/v1/responses with that tool in `tools` (current Codex builds nest it under the `mcp__codex_app` namespace entry)
4. The proxy answers 400 with `litellm.BadRequestError: OpenAIException - Invalid schema for function 'automation_update': schema must have type 'object' and not have 'oneOf'/'anyOf'/'allOf'/'enum'/'const'/'not' at the top level.` (`param: tools[9].tools[0].parameters`), and Codex shows that error block instead of calling the tool
5. The same Codex setup signed in with ChatGPT (no proxy) calls the tool fine, so the failure looks like a proxy bug

After: the same request goes through, OpenAI accepts the tool, and Codex calls it

1. They set Codex's model provider to the proxy (`base_url = https://litellm-domain/v1`, `wire_api = "responses"`, model `gpt-4o`) and add an MCP server whose `automation_update` tool declares `{"type": "object", "anyOf": [...], "properties": {...}, "required": ["id"]}` as its input schema
2. They type "Update automation abc123 to be enabled using the automation_update tool." into Codex
3. Codex sends POST https://litellm-domain/v1/responses with that tool in `tools` (current Codex builds nest it under the `mcp__codex_app` namespace entry)
4. The proxy forwards the tool to OpenAI with its `anyOf` branches folded into one object schema (`properties` id, enabled, schedule; `required` ["id"]), OpenAI returns 200, and Codex shows `Called codex_app.automation_update({"id":"abc123","enabled":true})` followed by "Automation abc123 is now enabled."

## Relevant issues

Reported on the community Discord (#feedback-and-help), no GitHub issue

## Linear ticket

Resolves LIT-6471

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Shared setup for both legs: one proxy process with 2 uvicorn workers (`--num_workers 2`) on a random high port (50930 for Before, 24564 for After) with the config below, real OpenAI key, and Codex CLI 0.145.0 (`model = "gpt-4o"`, `model_reasoning_effort = "medium"`, `wire_api = "responses"`, `approval_policy = "never"`) pointed at it over `http://127.0.0.1:<port>/v1` with a stdio MCP server (`codex_app`) whose `automation_update` tool declares the input schema below

```yaml
model_list:
  - model_name: gpt-4o
    litellm_params:
      model: openai/gpt-4o
      api_key: os.environ/OPENAI_API_KEY
      additional_drop_params: ["reasoning"]

general_settings:
  master_key: sk-lit6471-master
```

```json
{
  "type": "object",
  "anyOf": [
    {"properties": {"id": {"type": "string"}, "enabled": {"type": "boolean"}}, "required": ["id", "enabled"]},
    {"properties": {"id": {"type": "string"}, "schedule": {"type": "string"}}, "required": ["id", "schedule"]}
  ],
  "properties": {"id": {"type": "string"}},
  "required": ["id"]
}
```

`additional_drop_params: ["reasoning"]` is there because Codex 0.145.0 has no metadata for `gpt-4o` and sends `reasoning: {"effort": "medium", "summary": "auto"}` on every request, which OpenAI 400s for that model once the schema error no longer masks it (tracked in LIT-6495, see Caveats); both legs run with it

To repeat the After leg in Codex Desktop (the reporter's client) instead of the CLI:

1. In `~/.codex/config.toml` set `model = "gpt-4o"` and `model_provider = "litellm"`, add a `[model_providers.litellm]` block with `base_url = "http://127.0.0.1:<port>/v1"`, `wire_api = "responses"`, `env_key = "LITELLM_CODEX_KEY"`, and an `[mcp_servers.codex_app]` block running the same stdio MCP server, then export `LITELLM_CODEX_KEY=sk-lit6471-master`
2. Open Codex Desktop and start a new thread in any folder (it reads the same `config.toml` as the CLI)
3. Type `Update automation abc123 to be enabled using the automation_update tool.` and send it
4. Expect a `codex_app.automation_update` call with `{"id":"abc123","enabled":true}` and a reply saying automation abc123 is enabled, instead of the 400 error block

### Before (fa25ff2a2e)

1. Sanity check that the proxy reaches OpenAI

```bash
curl -s http://127.0.0.1:50930/v1/chat/completions \
  -H 'Authorization: Bearer sk-lit6471-master' -H 'Content-Type: application/json' \
  -d '{"model": "gpt-4o", "messages": [{"role": "user", "content": "Say hello in five words also say that we are testing gpt-4o."}]}'
```

```json
{"id":"chatcmpl-EILSVVeQJfnV97yuNYVhNKbsFhlZj","created":1788041099,"model":"gpt-4o","object":"chat.completion","system_fingerprint":"fp_1a8e2a470b","choices":[{"finish_reason":"stop","index":0,"message":{"content":"Hello, we’re testing GPT-4o.","role":"assistant","provider_specific_fields":{"refusal":null},"annotations":[]},"provider_specific_fields":{}}],"usage":{"completion_tokens":10,"prompt_tokens":24,"total_tokens":34,"completion_tokens_details":{"accepted_prediction_tokens":0,"audio_tokens":0,"reasoning_tokens":0,"rejected_prediction_tokens":0},"prompt_tokens_details":{"audio_tokens":0,"cached_tokens":0}},"service_tier":"default"}
```

2. In Codex, type `Update automation abc123 to be enabled using the automation_update tool.` and press Enter. The pane shows

```
› Update automation abc123 to be enabled using the automation_update tool.
⚠ Model metadata for `gpt-4o` not found. Defaulting to fallback metadata; this can degrade performance and cause issues.
■ {"error":{"message":"litellm.BadRequestError: OpenAIException - {\n  \"error\": {\n    \"message\": \"Invalid schema for function 'automation_update': schema must have type 'object' and not have'oneOf'/'anyOf'/'allOf'/'enum'/'const'/'not' at the top level.\",\n    \"type\": \"invalid_request_error\",\n    \"param\": \"tools[9].tools[0].parameters\",\n    \"code\":\"invalid_function_parameters\"\n  }\n}. Received Model Group=gpt-4o\nAvailable Model Group Fallbacks=None","type":null,"param":null,"code":"400"}}
```

Proxy log

```
INFO:     127.0.0.1:55099 - "POST /v1/chat/completions HTTP/1.1" 200 OK
INFO:     127.0.0.1:55211 - "POST /v1/responses HTTP/1.1" 400 Bad Request
```

### After (9448293903)

1. Same sanity curl as above against port 24564

```json
{"id":"chatcmpl-EIL3cxqQFTKMAMcHQt36SucSAPwFJ","created":1788039556,"model":"gpt-4o","object":"chat.completion","system_fingerprint":"fp_1a8e2a470b","choices":[{"finish_reason":"stop","index":0,"message":{"content":"Hello! We're testing GPT-4o.","role":"assistant","provider_specific_fields":{"refusal":null},"annotations":[]},"provider_specific_fields":{}}],"usage":{"completion_tokens":9,"prompt_tokens":24,"total_tokens":33,"completion_tokens_details":{"accepted_prediction_tokens":0,"audio_tokens":0,"reasoning_tokens":0,"rejected_prediction_tokens":0},"prompt_tokens_details":{"audio_tokens":0,"cached_tokens":0}},"service_tier":"default"}
```

2. Same prompt in Codex. The pane shows

```
› Update automation abc123 to be enabled using the automation_update tool.
⚠ Model metadata for `gpt-4o` not found. Defaulting to fallback metadata; this can degrade performance and cause issues.
• Called codex_app.automation_update({"id":"abc123","enabled":true})
  └ automation updated
• The automation with ID abc123 has been successfully enabled.
```

Proxy log

```
INFO:     127.0.0.1:49539 - "POST /v1/responses HTTP/1.1" 200 OK
INFO:     127.0.0.1:49561 - "POST /v1/responses HTTP/1.1" 200 OK
```

Verdict: PASS

- Codex asked to approve the MCP call despite `approval_policy = "never"`
- The "model metadata not found" warning is Codex-side and unrelated
- Both legs drive Codex CLI 0.145.0 under tmux; Codex Desktop shares the codex core and the report's error path (`tools[9].tools[0].parameters`) matches the Before pane exactly, and the Codex Desktop steps above repeat the After leg there

## Type

🐛 Bug Fix

## Caveats (if any)

### Medium

- /v1/chat/completions tools with the same schema still 400 on OpenAI; tracked in LIT-6488
- Azure OpenAI deployments keep the rejection (the gate is OpenAI-only because Azure's model is a deployment name); tracked in LIT-6500
- Codex on a non-reasoning model group (gpt-4o) still 400s on the `reasoning` it sends; needs `additional_drop_params: ["reasoning"]` until LIT-6495 lands

### Low

- Merging keeps root plus shared required only; per-branch extras (additionalProperties, branch-only required) and top-level enum/const/not go, the MCP server still validates calls
- The model gate is a name-prefix list (gpt-4, gpt-3.5, chatgpt-4o, o1, o3, o4); a future OpenAI family that still rejects the union 400s as before until it is added

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Request-time JSON Schema rewriting can change tool semantics for merged unions on affected models, though unmergeable schemas pass through and scope is limited to OpenAI Responses for specific model prefixes.
> 
> **Overview**
> Fixes proxy **400s** when Codex (and similar clients) send MCP tools whose `parameters` use top-level `anyOf`/`oneOf`/`allOf` on **OpenAI Responses** (`/v1/responses` and `/compact`), which stricter model families reject while native ChatGPT backends accept.
> 
> Adds **`flatten_top_level_schema_combinators`** in `common_utils` to merge combinator branches into a single `type: object` schema (union `properties`, combine `required` per combinator rules), strip top-level `enum`/`const`/`not`, resolve local `#/$defs` / `#/definitions` refs with depth and cycle limits, and **pass through unchanged** when flattening is unsafe (external refs, non-object unions, depth cap).
> 
> **`OpenAIResponsesAPIConfig`** applies that sanitizer only for **`LlmProviders.OPENAI`**, only when the model name matches families that still reject combinators (`gpt-4*`, `gpt-3.5`, `o1`/`o3`/`o4`, etc.), and **skips GPT-5+** so unions stay intact. It walks nested `tools` on namespace entries and copies tool dicts without mutating caller input.
> 
> Tests cover the flattening edge cases and request wiring; **`_mergeable_branch`** is allowlisted in the recursive-function detector.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9448293903c3315c92c80737874c6cf8a4d76f8c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

- [x] 9448293903 passes /live-pr-risk
