### PR TITLE
fix(model_prices): align fireworks deepseek-v4-flash-0731 twin cost entries at published pricing

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -51947,14 +51947,14 @@
         "supports_vision": true
     },
     "fireworks_ai/deepseek-v4-flash-0731": {
-        "cache_read_input_token_cost": 2.8e-08,
-        "input_cost_per_token": 1.4e-07,
+        "cache_read_input_token_cost": 7e-09,
+        "input_cost_per_token": 2.2e-07,
         "litellm_provider": "fireworks_ai",
         "max_input_tokens": 1048576,
         "max_output_tokens": 131072,
         "max_tokens": 131072,
         "mode": "chat",
-        "output_cost_per_token": 2.8e-07,
+        "output_cost_per_token": 6.6e-07,
         "source": "https://docs.fireworks.ai/serverless/pricing",
         "supports_function_calling": true,
         "supports_reasoning": true,

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -51947,14 +51947,14 @@
         "supports_vision": true
     },
     "fireworks_ai/deepseek-v4-flash-0731": {
-        "cache_read_input_token_cost": 2.8e-08,
-        "input_cost_per_token": 1.4e-07,
+        "cache_read_input_token_cost": 7e-09,
+        "input_cost_per_token": 2.2e-07,
         "litellm_provider": "fireworks_ai",
         "max_input_tokens": 1048576,
         "max_output_tokens": 131072,
         "max_tokens": 131072,
         "mode": "chat",
-        "output_cost_per_token": 2.8e-07,
+        "output_cost_per_token": 6.6e-07,
         "source": "https://docs.fireworks.ai/serverless/pricing",
         "supports_function_calling": true,
         "supports_reasoning": true,

--- a/tests/test_litellm/test_fireworks_serverless_model_costs.py
+++ b/tests/test_litellm/test_fireworks_serverless_model_costs.py
@@ -84,3 +84,41 @@ def test_bare_fireworks_ids_resolve_through_prefixed_entries():
         assert info["output_cost_per_token"] == pytest.approx(expected["output_cost_per_token"])
         assert info["max_input_tokens"] == expected["max_input_tokens"]
         assert info["max_output_tokens"] == expected["max_output_tokens"]
+
+
+TWIN_PINNED_PRICES = {
+    "deepseek-v4-flash-0731": {
+        "input_cost_per_token": 2.2e-07,
+        "cache_read_input_token_cost": 7e-09,
+        "output_cost_per_token": 6.6e-07,
+    },
+}
+
+
+def test_deepseek_v4_flash_0731_twins_pin_published_pricing(model_data):
+    """Both 0731 entries carry the price published at docs.fireworks.ai/serverless/pricing."""
+    for bare_suffix, expected in TWIN_PINNED_PRICES.items():
+        for key in (
+            f"fireworks_ai/{bare_suffix}",
+            f"fireworks_ai/accounts/fireworks/models/{bare_suffix}",
+        ):
+            entry = model_data[key]
+            for field, value in expected.items():
+                assert entry[field] == pytest.approx(value), f"{key}.{field}"
+
+
+def test_fireworks_account_prefixed_twins_agree_on_price(model_data):
+    """Every accounts/fireworks/models/X entry prices identically to its bare fireworks_ai/X twin."""
+    prefix = "fireworks_ai/accounts/fireworks/models/"
+    pairs_checked = 0
+    for key, entry in model_data.items():
+        if not key.startswith(prefix):
+            continue
+        bare_key = f"fireworks_ai/{key[len(prefix):]}"
+        bare_entry = model_data.get(bare_key)
+        if bare_entry is None:
+            continue
+        pairs_checked += 1
+        for field in sorted({f for f in (*entry, *bare_entry) if "cost" in f}):
+            assert entry.get(field) == bare_entry.get(field), f"{key} vs {bare_key}: {field}"
+    assert pairs_checked >= 20


### PR DESCRIPTION
## TLDR

Problem this solves:

- The cost map lists Fireworks deepseek-v4-flash-0731 twice with different prices
- Streamed FireRouter calls bill at the stale cheaper rate, non-streaming at the real one

How it solves it:

- Raises the bare `fireworks_ai/deepseek-v4-flash-0731` entry to Fireworks' published $0.22 / $0.007 / $0.66 per 1M
- Pins both 0731 entries in tests and sweeps every accounts-prefixed/bare twin pair for price agreement

## User Flow

Before: streaming the same FireRouter model bills at a stale cheaper rate than non-streaming, so proxy spend tracking undercounts the real Fireworks bill

1. An admin adds Fireworks' FireRouter model `fireworks_ai/accounts/fireworks/routers/firerouter/deepseek-v4-flash-0731/kimi-k3` to the gateway config and boots the proxy
2. They send POST https://litellm-domain/v1/chat/completions with `"model": "flash-0731-firerouter"` (non-streaming) and get 200 with `x-litellm-response-cost: 3.454e-05` for 91 prompt / 22 completion tokens, which is Fireworks' published $0.22 / $0.66 per 1M rate
3. They send the same request with `"stream": true, "stream_options": {"include_usage": true}`; the stream ends with a usage chunk showing 91 prompt / 14 completion tokens (90 cached)
4. GET https://litellm-domain/spend/logs?request_id=chatcmpl-... for that streamed call shows `"spend": 6.58e-06`, roughly a third of what the same usage costs non-streaming, so budgets and chargeback reports drift below the actual Fireworks invoice
5. GET https://litellm-domain/model/info shows the short-id deployment priced at `input_cost_per_token: 1.4e-07` while the full-id deployment of the very same model shows `2.2e-07`

After: streaming and non-streaming bill at the same published Fireworks price, and spend logs match the provider invoice

1. An admin adds Fireworks' FireRouter model `fireworks_ai/accounts/fireworks/routers/firerouter/deepseek-v4-flash-0731/kimi-k3` to the gateway config and boots the proxy
2. They send POST https://litellm-domain/v1/chat/completions with `"model": "flash-0731-firerouter"` (non-streaming) and get 200 with `x-litellm-response-cost` at the published $0.22 / $0.66 per 1M rate, as before
3. They send the same request with `"stream": true, "stream_options": {"include_usage": true}`; the stream ends with a usage chunk showing 91 prompt / 14 completion tokens
4. GET https://litellm-domain/spend/logs?request_id=chatcmpl-... for that streamed call shows `"spend": 2.926e-05`, exactly 91 x $0.22/1M + 14 x $0.66/1M, the same rate the non-streaming call was billed at
5. GET https://litellm-domain/model/info shows both deployments of the model at the same published price

## Relevant issues

## Linear ticket

Resolves LIT-6408

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Fireworks' own pricing page (https://docs.fireworks.ai/serverless/pricing) lists "DeepSeek V4 Flash (0731)" at $0.22 input / $0.007 cached input / $0.66 output per 1M tokens, matching the prefixed `fireworks_ai/accounts/fireworks/models/deepseek-v4-flash-0731` entry. The bare `fireworks_ai/deepseek-v4-flash-0731` twin still carried the older $0.14 / $0.028 / $0.28 rate

Shared setup, both legs: live proxy from the branch worktree against the real Fireworks serverless API, `LITELLM_LOCAL_MODEL_COST_MAP=True`, local Postgres, 2 uvicorn workers

```yaml
model_list:
  - model_name: flash-0731-full-id
    litellm_params:
      model: fireworks_ai/accounts/fireworks/models/deepseek-v4-flash-0731
      api_key: os.environ/FIREWORKS_API_KEY
  - model_name: flash-0731-short-id
    litellm_params:
      model: fireworks_ai/deepseek-v4-flash-0731
      api_key: os.environ/FIREWORKS_API_KEY
  - model_name: flash-0731-firerouter
    litellm_params:
      model: fireworks_ai/accounts/fireworks/routers/firerouter/deepseek-v4-flash-0731/kimi-k3
      api_key: os.environ/FIREWORKS_API_KEY
general_settings:
  master_key: os.environ/LITELLM_MASTER_KEY
  database_url: os.environ/DATABASE_URL
  proxy_batch_write_at: 2
```

Per model alias, the same two requests each leg, then the spend log lookup:

```bash
curl -s -D - http://127.0.0.1:$PORT/v1/chat/completions \
  -H "Authorization: Bearer $LITELLM_MASTER_KEY" -H 'Content-Type: application/json' \
  -d '{"model":"<alias>","messages":[{"role":"user","content":"Reply with exactly one word: pong"}],"max_tokens":40}'
curl -s -N http://127.0.0.1:$PORT/v1/chat/completions \
  -H "Authorization: Bearer $LITELLM_MASTER_KEY" -H 'Content-Type: application/json' \
  -d '{"model":"<alias>","messages":[{"role":"user","content":"Reply with exactly one word: pong"}],"max_tokens":40,"stream":true,"stream_options":{"include_usage":true}}'
curl -s "http://127.0.0.1:$PORT/spend/logs?request_id=<response id>" -H "Authorization: Bearer $LITELLM_MASTER_KEY"
```

### Before (e0ed0a4c7a78411e9d4156091b27a12ad665a476)

#### flash-0731-full-id

1. Non-streaming: `x-litellm-response-cost: 2.904e-05` for usage 12 prompt (0 cached) / 40 completion, which is 12 x 2.2e-07 + 40 x 6.6e-07 (published rate)
2. Streaming: final chunk usage 12 prompt (11 cached) / 40 completion; `GET /spend/logs?request_id=chatcmpl-8571354f593841b48cd99f4f7becf7ff` -> `{"model": "fireworks_ai/accounts/fireworks/models/deepseek-v4-flash-0731", "prompt_tokens": 12, "completion_tokens": 40, "spend": 2.6697e-05}` = 1 x 2.2e-07 + 11 x 7e-09 + 40 x 6.6e-07 (published rate)

#### flash-0731-short-id

1. Non-streaming: `x-litellm-response-cost: 2.6697000000000002e-05` for usage 12 prompt (11 cached) / 40 completion (published rate; the provider response reports the full model id, which resolves to the correctly priced prefixed entry)
2. Streaming: `GET /spend/logs?request_id=chatcmpl-25606b6847b9466097b989132afd467d` -> `{"model": "fireworks_ai/deepseek-v4-flash-0731", "prompt_tokens": 12, "completion_tokens": 40, "spend": 2.6697e-05}` (published rate)

#### flash-0731-firerouter

1. Non-streaming: `x-litellm-response-cost: 3.4540000000000005e-05` for usage 91 prompt (0 cached) / 22 completion, which is 91 x 2.2e-07 + 22 x 6.6e-07 (published rate)
2. Streaming: final chunk usage 91 prompt (90 cached) / 14 completion; `GET /spend/logs?request_id=chatcmpl-ef4ec7c1e7cc42829e6ec7b9a794e57e` -> `{"model": "fireworks_ai/accounts/fireworks/routers/firerouter/deepseek-v4-flash-0731/kimi-k3", "prompt_tokens": 91, "completion_tokens": 14, "spend": 6.580000000000001e-06}`
3. That 6.58e-06 is exactly 1 x 1.4e-07 + 90 x 2.8e-08 + 14 x 2.8e-07: the stale bare-entry rate. The same usage at the published rate is 1.009e-05, so the streamed call under-bills by ~35% (the streamed chunks report the short model id, which resolves to the stale bare twin)

### After (71d12372838b19f1b3456a6840bedf4aa9ddab5b)

#### flash-0731-full-id

1. Non-streaming: `x-litellm-response-cost: 2.904e-05` for usage 12 prompt (0 cached) / 40 completion (published rate, unchanged)
2. Streaming: final chunk usage 12 prompt (0 cached) / 40 completion; `GET /spend/logs?request_id=chatcmpl-d6288d0e7723420887d418cc7631c078` -> `{"model": "fireworks_ai/accounts/fireworks/models/deepseek-v4-flash-0731", "prompt_tokens": 12, "completion_tokens": 40, "spend": 2.904e-05}` (published rate, unchanged)

#### flash-0731-short-id

1. Non-streaming: `x-litellm-response-cost: 2.904e-05` for usage 12 prompt (0 cached) / 40 completion (published rate)
2. Streaming: `GET /spend/logs?request_id=chatcmpl-3c2f236c1a75457eb6da7e766bab9d70` -> `{"model": "fireworks_ai/deepseek-v4-flash-0731", "prompt_tokens": 12, "completion_tokens": 40, "spend": 2.904e-05}` (published rate)

#### flash-0731-firerouter

1. Non-streaming: `x-litellm-response-cost: 4.51e-05` for usage 91 prompt (0 cached) / 38 completion, which is 91 x 2.2e-07 + 38 x 6.6e-07 (published rate)
2. Streaming: final chunk usage 91 prompt (0 cached) / 14 completion; `GET /spend/logs?request_id=chatcmpl-32e847f4707d489f9a144879d84a0f1a` -> `{"model": "fireworks_ai/accounts/fireworks/routers/firerouter/deepseek-v4-flash-0731/kimi-k3", "prompt_tokens": 91, "completion_tokens": 14, "spend": 2.926e-05}`
3. That 2.926e-05 is exactly 91 x 2.2e-07 + 14 x 6.6e-07: streaming now bills at the same published rate as non-streaming

## Type

🐛 Bug Fix

## Caveats (if any)

### Low

- The undated deepseek-v4-flash twins keep their older price; Fireworks now 404s that id, so nothing bills through them
- Spend rows logged before this fix keep the old rate; no backfill
- Anything reading the bare entry now shows the correct, higher price

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
