### PR TITLE
fix(ui): allow in-place editing of classifier numeric inputs

### DIFF
--- a/ui/litellm-dashboard/src/components/add_model/ClassificationMethodConfig.tsx
+++ b/ui/litellm-dashboard/src/components/add_model/ClassificationMethodConfig.tsx
@@ -40,6 +40,10 @@ const DEFAULT_SCORING_EXPLANATION =
   "The router scores each request across 7 dimensions: token count, code presence, reasoning markers, technical " +
   "terms, simple indicators, multi-step patterns, and question complexity. The weighted score determines the tier:";
 
+const CLASSIFIER_TIMEOUT_ID = "classifier-timeout-ms";
+const CLASSIFIER_CONTEXT_WINDOW_SIZE_ID = "classifier-context-window-size";
+const CLASSIFIER_CONTEXT_BUDGET_CHARS_ID = "classifier-context-budget-chars";
+
 const CUSTOM_PROMPT_WITH_HEURISTIC_FALLBACK =
   "This router classifies with your own prompt, so the tier comes from whatever rubric it states. The four tier " +
   "names stay fixed. The scoring below is the heuristic, which now runs only when the classifier call fails:";
@@ -204,6 +208,7 @@ const ClassificationMethodConfig: React.FC<ClassificationMethodConfigProps> = ({
   showValidationErrors = false,
   defaultModel,
 }) => {
+  const [draft, setDraft] = React.useState<{ id: string; raw: string } | null>(null);
   const hasDefaultModel = Boolean(defaultModel);
   const classifierType = effectiveClassifierType(value);
   const classifierModelMissing =
@@ -261,13 +266,13 @@ const ClassificationMethodConfig: React.FC<ClassificationMethodConfigProps> = ({
     });
   };
 
-  const handleClassifierTimeoutChange = (timeoutMs: number | null) => {
+  const handleClassifierTimeoutChange = (timeoutMs: number) => {
     onChange({
       ...value,
       classifier_llm_config: {
         ...value.classifier_llm_config,
         model: value.classifier_llm_config?.model ?? "",
-        timeout_ms: timeoutMs ?? DEFAULT_CLASSIFIER_TIMEOUT_MS,
+        timeout_ms: timeoutMs,
       },
     });
   };
@@ -300,18 +305,30 @@ const ClassificationMethodConfig: React.FC<ClassificationMethodConfigProps> = ({
     onChange({ ...value, classifier_fallback: fallback });
   };
 
-  const handleClassifierContextWindowSizeChange = (windowSize: number | null) => {
+  const handleClassifierContextWindowSizeChange = (windowSize: number) => {
     onChange({
       ...value,
-      classifier_context_window_size: windowSize ?? DEFAULT_CLASSIFIER_CONTEXT_WINDOW_SIZE,
+      classifier_context_window_size: windowSize,
     });
   };
 
-  const handleClassifierContextBudgetCharsChange = (budgetChars: number | null) => {
+  const handleClassifierContextBudgetCharsChange = (budgetChars: number) => {
     onChange({
       ...value,
-      classifier_context_budget_chars: budgetChars ?? DEFAULT_CLASSIFIER_CONTEXT_BUDGET_CHARS,
+      classifier_context_budget_chars: budgetChars,
     });
+  };
+
+  const handleClassifierIntegerChange = (
+    id: string,
+    raw: string,
+    minimum: number,
+    onCommit: (value: number) => void,
+  ) => {
+    setDraft({ id, raw });
+    const parsed = Number(raw);
+    if (raw.trim() === "" || !Number.isFinite(parsed)) return;
+    onCommit(Math.max(minimum, Math.round(parsed)));
   };
 
   const handleClassifierContextIncludeAssistantTurnsChange = (includeAssistantTurns: boolean) => {
@@ -366,14 +383,27 @@ const ClassificationMethodConfig: React.FC<ClassificationMethodConfigProps> = ({
             {classifierModelMissing && <span className="text-xs text-destructive">A classifier model is required</span>}
           </div>
           <div>
-            <strong className="block mb-1 font-semibold">Timeout (ms)</strong>
+            <Label htmlFor={CLASSIFIER_TIMEOUT_ID} className="block mb-1 font-semibold">
+              Timeout (ms)
+            </Label>
             <Input
-              type="number"
-              value={value.classifier_llm_config?.timeout_ms ?? DEFAULT_CLASSIFIER_TIMEOUT_MS}
-              onChange={(event) =>
-                handleClassifierTimeoutChange(event.target.value === "" ? null : event.target.valueAsNumber)
+              id={CLASSIFIER_TIMEOUT_ID}
+              type="text"
+              inputMode="numeric"
+              value={
+                draft?.id === CLASSIFIER_TIMEOUT_ID
+                  ? draft.raw
+                  : String(value.classifier_llm_config?.timeout_ms ?? DEFAULT_CLASSIFIER_TIMEOUT_MS)
               }
-              min={1}
+              onChange={(event) =>
+                handleClassifierIntegerChange(
+                  CLASSIFIER_TIMEOUT_ID,
+                  event.target.value,
+                  1,
+                  handleClassifierTimeoutChange,
+                )
+              }
+              onBlur={() => setDraft(null)}
               className="w-full"
             />
             <span className="text-xs text-muted-foreground">
@@ -480,14 +510,27 @@ const ClassificationMethodConfig: React.FC<ClassificationMethodConfigProps> = ({
             </span>
           </RestrictedSection>
           <div>
-            <strong className="block mb-1 font-semibold">Context Window Size</strong>
+            <Label htmlFor={CLASSIFIER_CONTEXT_WINDOW_SIZE_ID} className="block mb-1 font-semibold">
+              Context Window Size
+            </Label>
             <Input
-              type="number"
-              value={value.classifier_context_window_size ?? DEFAULT_CLASSIFIER_CONTEXT_WINDOW_SIZE}
-              onChange={(event) =>
-                handleClassifierContextWindowSizeChange(event.target.value === "" ? null : event.target.valueAsNumber)
+              id={CLASSIFIER_CONTEXT_WINDOW_SIZE_ID}
+              type="text"
+              inputMode="numeric"
+              value={
+                draft?.id === CLASSIFIER_CONTEXT_WINDOW_SIZE_ID
+                  ? draft.raw
+                  : String(value.classifier_context_window_size ?? DEFAULT_CLASSIFIER_CONTEXT_WINDOW_SIZE)
               }
-              min={0}
+              onChange={(event) =>
+                handleClassifierIntegerChange(
+                  CLASSIFIER_CONTEXT_WINDOW_SIZE_ID,
+                  event.target.value,
+                  0,
+                  handleClassifierContextWindowSizeChange,
+                )
+              }
+              onBlur={() => setDraft(null)}
               className="w-full"
             />
             <span className="text-xs text-muted-foreground">
@@ -497,14 +540,27 @@ const ClassificationMethodConfig: React.FC<ClassificationMethodConfigProps> = ({
             </span>
           </div>
           <div>
-            <strong className="block mb-1 font-semibold">Context Character Budget</strong>
+            <Label htmlFor={CLASSIFIER_CONTEXT_BUDGET_CHARS_ID} className="block mb-1 font-semibold">
+              Context Character Budget
+            </Label>
             <Input
-              type="number"
-              value={value.classifier_context_budget_chars ?? DEFAULT_CLASSIFIER_CONTEXT_BUDGET_CHARS}
-              onChange={(event) =>
-                handleClassifierContextBudgetCharsChange(event.target.value === "" ? null : event.target.valueAsNumber)
+              id={CLASSIFIER_CONTEXT_BUDGET_CHARS_ID}
+              type="text"
+              inputMode="numeric"
+              value={
+                draft?.id === CLASSIFIER_CONTEXT_BUDGET_CHARS_ID
+                  ? draft.raw
+                  : String(value.classifier_context_budget_chars ?? DEFAULT_CLASSIFIER_CONTEXT_BUDGET_CHARS)
               }
-              min={0}
+              onChange={(event) =>
+                handleClassifierIntegerChange(
+                  CLASSIFIER_CONTEXT_BUDGET_CHARS_ID,
+                  event.target.value,
+                  0,
+                  handleClassifierContextBudgetCharsChange,
+                )
+              }
+              onBlur={() => setDraft(null)}
               className="w-full"
             />
             <span className="text-xs text-muted-foreground">

--- a/ui/litellm-dashboard/src/components/add_model/ComplexityRouterConfig.test.tsx
+++ b/ui/litellm-dashboard/src/components/add_model/ComplexityRouterConfig.test.tsx
@@ -131,10 +131,8 @@ describe("ComplexityRouterConfig", () => {
     fireEvent.click(screen.getByText("Advanced: Classification Method"));
 
     expect(screen.getByText("Classifier Model")).toBeInTheDocument();
-    expect(screen.getByText("Timeout (ms)")).toBeInTheDocument();
-    expect(screen.getByDisplayValue("750")).toBeInTheDocument();
-    expect(screen.getByText("Context Window Size")).toBeInTheDocument();
-    expect(screen.getByDisplayValue("5")).toBeInTheDocument();
+    expect(screen.getByLabelText("Timeout (ms)")).toHaveValue("750");
+    expect(screen.getByLabelText("Context Window Size")).toHaveValue("5");
     expect(screen.queryByText("Context Per-Turn Character Limit")).not.toBeInTheDocument();
   });
 
@@ -148,11 +146,8 @@ describe("ComplexityRouterConfig", () => {
 
     fireEvent.click(screen.getByText("Advanced: Classification Method"));
 
-    const windowSizeSection = screen.getByText("Context Window Size").closest("div") as HTMLElement;
-    expect(within(windowSizeSection).getByDisplayValue("3")).toBeInTheDocument();
-
-    const budgetSection = screen.getByText("Context Character Budget").closest("div") as HTMLElement;
-    expect(within(budgetSection).getByDisplayValue("8000")).toBeInTheDocument();
+    expect(screen.getByLabelText("Context Window Size")).toHaveValue("3");
+    expect(screen.getByLabelText("Context Character Budget")).toHaveValue("8000");
   });
 
   it("should warn when the budget is too small to quote any turn that does not already fit", () => {
@@ -247,7 +242,11 @@ describe("ComplexityRouterConfig", () => {
     expect(screen.queryByText("Context Per-Turn Character Limit")).not.toBeInTheDocument();
   });
 
-  it("should call onChange with the updated classifier_context_window_size when edited", () => {
+  it.each([
+    ["Timeout (ms)", "7", { classifier_llm_config: { model: "gpt-3.5-turbo", timeout_ms: 7 } }],
+    ["Context Window Size", "0", { classifier_context_window_size: 0 }],
+    ["Context Character Budget", "7", { classifier_context_budget_chars: 7 }],
+  ])("keeps %s empty while it is being edited, then commits %s", (label, replacement, expected) => {
     const onChange = vi.fn();
     const llmValue: ComplexityRouterConfigValue = {
       ...defaultValue,
@@ -257,14 +256,31 @@ describe("ComplexityRouterConfig", () => {
     renderWithProviders(<ComplexityRouterConfig modelInfo={mockModelInfo} value={llmValue} onChange={onChange} />);
     fireEvent.click(screen.getByText("Advanced: Classification Method"));
 
-    const windowSizeSection = screen.getByText("Context Window Size").closest("div") as HTMLElement;
-    const input = within(windowSizeSection).getByRole("spinbutton");
-    fireEvent.change(input, { target: { value: "7" } });
+    const input = screen.getByLabelText(label);
+    fireEvent.change(input, { target: { value: "" } });
 
-    expect(onChange).toHaveBeenCalledWith({
-      ...llmValue,
-      classifier_context_window_size: 7,
-    });
+    expect(input).toHaveValue("");
+    expect(onChange).not.toHaveBeenCalled();
+
+    fireEvent.change(input, { target: { value: replacement } });
+
+    expect(onChange).toHaveBeenLastCalledWith({ ...llmValue, ...expected });
+  });
+
+  it("restores the committed context window size after an empty field loses focus", () => {
+    const llmValue: ComplexityRouterConfigValue = {
+      ...defaultValue,
+      classifier_type: "llm",
+      classifier_llm_config: { model: "gpt-3.5-turbo", timeout_ms: 3000 },
+    };
+    renderWithProviders(<ComplexityRouterConfig modelInfo={mockModelInfo} value={llmValue} onChange={vi.fn()} />);
+    fireEvent.click(screen.getByText("Advanced: Classification Method"));
+
+    const input = screen.getByLabelText("Context Window Size");
+    fireEvent.change(input, { target: { value: "" } });
+    fireEvent.blur(input);
+
+    expect(input).toHaveValue("3");
   });
 
   it("should render the custom technical keywords field", () => {

--- a/ui/litellm-dashboard/src/components/edit_auto_router/edit_auto_router_modal.test.tsx
+++ b/ui/litellm-dashboard/src/components/edit_auto_router/edit_auto_router_modal.test.tsx
@@ -295,8 +295,7 @@ describe("EditAutoRouterModal classifier context window", () => {
     renderLlmModal();
 
     await user.click(await screen.findByText("Advanced: Classification Method"));
-    const windowSizeSection = (await screen.findByText("Context Window Size")).closest("div") as HTMLElement;
-    const input = within(windowSizeSection).getByRole("spinbutton");
+    const input = await screen.findByLabelText("Context Window Size");
     fireEvent.change(input, { target: { value: "8" } });
 
     await user.click(screen.getByRole("button", { name: /save changes/i }));


### PR DESCRIPTION
## TLDR

Problem this solves:

- Backspacing a classifier number instantly refills the default
- Only select-all then retype works, which is awkward
- Hits Timeout, Context Window Size, Context Character Budget

How it solves it:

- Field keeps raw text while you are typing in it
- Only a finite number is written to the config
- Leaving an empty field restores the last saved value

## User Flow

Before: an admin editing an auto router cannot change Context Window Size by ordinary typing, because the field refills itself the moment it goes empty

1. They open http://localhost:4000/ui/?page=models, pick an auto router, and hit Edit
2. They expand "Advanced: Classification Method" and pick the LLM classifier, so Timeout (ms), Context Window Size and Context Character Budget are on screen
3. Context Window Size shows `3`. They click into it and press Backspace
4. The field does not go blank. `3` is back in it immediately, so there is nothing to type after
5. Typing `5` at this point appends to the restored digit, so they get `35` or `53` instead of `5`
6. To actually set `5` they have to press Cmd+A first and overwrite the whole field. The same thing happens on Timeout (ms) and Context Character Budget

After: the same admin edits the field the way they would edit any other text box

1. They open http://localhost:4000/ui/?page=models, pick an auto router, and hit Edit
2. They expand "Advanced: Classification Method" and pick the LLM classifier
3. Context Window Size shows `3`. They click into it and press Backspace
4. The field is now blank and stays blank, and the router config is untouched
5. They type `5` and the field reads `5`. Save, reopen the router, and it still reads `5`
6. Typing `0` is accepted and saved as `0`, which is how they turn context off. Clicking away from a field they left blank puts the previous value back rather than saving a blank

## Relevant issues

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Setup for both sides: run the proxy with `python litellm/proxy/proxy_cli.py --config litellm/proxy/dev_config.yaml --detailed_debug --reload --use_v2_migration_resolver 2>&1 | tee litellm.log`, run `npm run dev` in `ui/litellm-dashboard`, then open http://localhost:3000/ui/?page=models, pick an auto router deployment, hit Edit, expand "Advanced: Classification Method" and set the classifier to LLM so all three number fields are visible.

### Before (002d0068f5)

#### Context Window Size cannot be cleared

1. Click into Context Window Size, which reads `3`, and press Backspace once
2. Screenshot: the field still reads `3`. It never goes empty
3. Type `5` without clearing first
4. Screenshot: the field reads `35`, not `5`

#### Same defect on the neighbouring fields

1. Repeat step 1 on Timeout (ms) and on Context Character Budget
2. Screenshot: both snap back to `3000` and `8000` instead of going empty

### After (a0ca3e7a7e)

#### Context Window Size cannot be cleared

1. Click into Context Window Size, which reads `3`, and press Backspace once
2. Screenshot: the field is empty and stays empty
3. Type `5`
4. Screenshot: the field reads `5`. Save the router, reopen it, and the field still reads `5`

#### Same defect on the neighbouring fields

1. Repeat step 1 on Timeout (ms) and on Context Character Budget
2. Screenshot: both go empty and accept a typed replacement

#### 0 is still a real value

1. Clear Context Window Size and type `0`
2. Screenshot: the field reads `0`. Save, reopen, and it is still `0`, so context stays off

## Type

🐛 Bug Fix

## Caveats (if any)

### Low

- Fields are now text with a numeric keypad hint
- That drops the native up/down spinner arrows
- Matches how the heuristic scoring fields already work

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
