### PR TITLE
fix(anthropic): emit signature-only thinking blocks on the /v1/messages bridge

### DIFF
--- a/litellm/llms/anthropic/common_utils.py
+++ b/litellm/llms/anthropic/common_utils.py
@@ -1099,6 +1099,25 @@ def is_empty_thinking_block(block: object) -> bool:
     return not isinstance(thinking, str) or not thinking.strip()
 
 
+def is_empty_unsigned_thinking_block(block: object) -> bool:
+    """
+    True for an empty ``{"type": "thinking"}`` block carrying no signature.
+
+    The emit-side predicate: response paths drop a thinking block only when it
+    holds nothing the client could need.  A signature-only block is a real
+    provider response (Bedrock Converse under adaptive thinking emits a
+    reasoning block with empty text and only a signature) and the client needs
+    the signature to replay reasoning across tool-use turns, so it must be
+    emitted.  Request paths keep using :func:`is_empty_thinking_block`:
+    Anthropic rejects empty thinking blocks in request history regardless of
+    signature, and the inbound strip self-heals a replayed signature-only
+    block.
+    """
+    if not isinstance(block, dict) or not is_empty_thinking_block(block):
+        return False
+    return not block.get("signature")
+
+
 def normalize_anthropic_tool_use_id(raw_id: str) -> str:
     """
     Normalize a tool_use / tool_result id for Anthropic's ``^[a-zA-Z0-9_-]+$``

--- a/litellm/llms/anthropic/experimental_pass_through/adapters/streaming_iterator.py
+++ b/litellm/llms/anthropic/experimental_pass_through/adapters/streaming_iterator.py
@@ -1029,7 +1029,7 @@ class AnthropicStreamWrapper(AdapterCompletionStreamWrapper):
 
     @staticmethod
     def _is_blank_delta(chunk: "ModelResponseStream") -> bool:
-        from litellm.llms.anthropic.common_utils import is_empty_thinking_block
+        from litellm.llms.anthropic.common_utils import is_empty_unsigned_thinking_block
 
         choice: Final = chunk.choices[0]
         if choice.finish_reason is not None:
@@ -1041,11 +1041,14 @@ class AnthropicStreamWrapper(AdapterCompletionStreamWrapper):
             return False
         if getattr(delta, "reasoning_content", None):
             return False
-        # thinking_blocks whose entries are all empty (even if signed) must not
+        # thinking_blocks whose entries are all empty AND unsigned must not
         # open a block: the emitted {"type": "thinking", "thinking": ""} gets
-        # replayed as history and Anthropic rejects it (LIT-6357).
+        # replayed as history and Anthropic rejects it (LIT-6357). A signed
+        # entry opens the block so the client receives the replay signature.
         thinking_blocks: Final = getattr(delta, "thinking_blocks", None)
-        if thinking_blocks and any(isinstance(b, dict) and not is_empty_thinking_block(b) for b in thinking_blocks):
+        if thinking_blocks and any(
+            isinstance(b, dict) and not is_empty_unsigned_thinking_block(b) for b in thinking_blocks
+        ):
             return False
         return True
 

--- a/litellm/llms/anthropic/experimental_pass_through/adapters/transformation.py
+++ b/litellm/llms/anthropic/experimental_pass_through/adapters/transformation.py
@@ -90,7 +90,7 @@ from litellm.litellm_core_utils.reasoning_effort_utils import (
     reasoning_effort_from_thinking_budget,
 )
 from litellm.llms.anthropic.common_utils import (
-    is_empty_thinking_block,
+    is_empty_unsigned_thinking_block,
     normalize_anthropic_tool_use_id,
 )
 from litellm.llms.anthropic.experimental_pass_through.context_management import (
@@ -1267,7 +1267,7 @@ class LiteLLMAnthropicMessagesAdapter:
             if hasattr(choice.message, "thinking_blocks") and choice.message.thinking_blocks:
                 for thinking_block in choice.message.thinking_blocks:
                     if thinking_block.get("type") == "thinking":
-                        if is_empty_thinking_block(thinking_block):
+                        if is_empty_unsigned_thinking_block(thinking_block):
                             continue
                         thinking_value = thinking_block.get("thinking", "")
                         signature_value = thinking_block.get("signature", "")

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_anthropic_experimental_pass_through_adapters_transformation.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_anthropic_experimental_pass_through_adapters_transformation.py
@@ -1013,12 +1013,15 @@ def test_translate_openai_content_to_anthropic_thinking_and_redacted_thinking():
     assert result[1]["data"] == "REDACTED"
 
 
-def test_translate_openai_content_to_anthropic_drops_empty_thinking_blocks():
-    """LIT-6357 non-streaming producer half: a bridged reasoning model whose
-    thinking_blocks entry has empty or whitespace-only text (signed or not)
-    must not surface as {"type": "thinking", "thinking": ""} — clients replay
-    it as history and Anthropic 400s with "each thinking block must contain
-    thinking". Non-empty thinking and redacted_thinking pass through."""
+def test_translate_openai_content_to_anthropic_drops_empty_unsigned_thinking_blocks():
+    """LIT-6357 non-streaming producer half, narrowed to unsigned blocks: a
+    bridged reasoning model whose thinking_blocks entry has empty or
+    whitespace-only text and no signature must not surface as
+    {"type": "thinking", "thinking": ""}. A signature-only block (Bedrock
+    Converse adaptive thinking) must be emitted so the client keeps the
+    signature for tool-use replay; the inbound strip self-heals it if the
+    client loops it back. Non-empty thinking and redacted_thinking pass
+    through."""
     openai_choices = [
         Choices(
             message=Message(
@@ -1037,9 +1040,11 @@ def test_translate_openai_content_to_anthropic_drops_empty_thinking_blocks():
     adapter = LiteLLMAnthropicMessagesAdapter()
     result = adapter._translate_openai_content_to_anthropic(choices=openai_choices)
 
-    assert [b["type"] for b in result] == ["thinking", "redacted_thinking", "text"]
-    assert result[0]["thinking"] == "real plan"
-    assert result[1]["data"] == "REDACTED"
+    assert [b["type"] for b in result] == ["thinking", "thinking", "redacted_thinking", "text"]
+    assert result[0]["thinking"] == ""
+    assert result[0]["signature"] == "sig_abc"
+    assert result[1]["thinking"] == "real plan"
+    assert result[2]["data"] == "REDACTED"
 
 
 def test_translate_streaming_openai_chunk_to_anthropic_thinking_delta():

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_streaming_iterator_first_delta.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_streaming_iterator_first_delta.py
@@ -1048,19 +1048,20 @@ def _empty_thinking_then_tool_chunks(thinking: str = "", signature: str = "") ->
 @pytest.mark.parametrize("is_async", [False, True])
 @pytest.mark.parametrize(
     "thinking,signature",
-    [("", ""), (" \n\t ", ""), ("", "sig_abc")],
-    ids=["empty", "whitespace-only", "empty-but-signed"],
+    [("", ""), (" \n\t ", "")],
+    ids=["empty", "whitespace-only"],
 )
 @pytest.mark.asyncio
 async def test_contentless_thinking_chunk_opens_no_thinking_block(is_async: bool, thinking: str, signature: str):
     """LIT-6357 producer half: a reasoning model that goes straight to tool
-    calls streams a ``thinking_blocks`` entry with no real thinking text; the
-    wrapper used to open ``{"type": "thinking", "thinking": ""}`` for it and
-    close the block with no delta. Clients (Claude Code) replay that block as
-    history and Anthropic rejects the next tool-loop request with
-    "each thinking block must contain thinking" — empty-but-signed included.
-    The contentless chunk must open nothing; the tool_use block must be
-    unaffected."""
+    calls streams a ``thinking_blocks`` entry with no real thinking text and
+    no signature; the wrapper used to open ``{"type": "thinking",
+    "thinking": ""}`` for it and close the block with no delta. Clients
+    (Claude Code) replay that block as history and Anthropic rejects the next
+    tool-loop request with "each thinking block must contain thinking".
+    The contentless unsigned chunk must open nothing; the tool_use block must
+    be unaffected. A SIGNED contentless chunk is different: see
+    test_signature_only_thinking_chunk_opens_signed_block."""
     chunks = _empty_thinking_then_tool_chunks(thinking, signature)
     if is_async:
         wrapper = AnthropicStreamWrapper(completion_stream=_AsyncStream(chunks), model="claude-x")
@@ -1138,11 +1139,38 @@ async def test_early_signature_on_blank_thinking_chunk_is_carried_to_the_opened_
 
 @pytest.mark.parametrize("is_async", [False, True])
 @pytest.mark.asyncio
-async def test_early_signature_discarded_when_first_block_is_not_thinking(is_async: bool):
-    """An early signature from a skipped blank thinking chunk must not leak
-    into a text or tool_use first block, and must not resurrect an empty
-    thinking block on its own (an empty-but-signed block is exactly what
-    Anthropic rejects)."""
+async def test_signature_only_thinking_chunk_opens_signed_block(is_async: bool):
+    """Bedrock Converse under adaptive thinking emits a reasoning delta with
+    empty text and only a signature. The signed chunk must open a thinking
+    block that carries the signature to the client (needed to replay reasoning
+    across tool-use turns); the tool_use block must be unaffected. Dropping it
+    like the unsigned case regressed the claude_code thinking e2e cells."""
+    chunks = _empty_thinking_then_tool_chunks("", "sig_bedrock")
+    if is_async:
+        wrapper = AnthropicStreamWrapper(completion_stream=_AsyncStream(chunks), model="claude-x")
+        events = await _drain_async(wrapper)
+    else:
+        wrapper = AnthropicStreamWrapper(completion_stream=iter(chunks), model="claude-x")
+        events = _drain_sync(wrapper)
+
+    starts = _thinking_block_starts(events)
+    assert len(starts) == 1
+    assert starts[0].get("signature") == "sig_bedrock" or _signature_deltas(events) == ["sig_bedrock"]
+    assert _thinking_deltas(events) == []
+    tool_starts = [
+        e["content_block"]
+        for e in events
+        if e.get("type") == "content_block_start" and e["content_block"].get("type") == "tool_use"
+    ]
+    assert [b["name"] for b in tool_starts] == ["get_weather"]
+    _assert_deltas_match_their_block_type(events)
+
+
+@pytest.mark.parametrize("is_async", [False, True])
+@pytest.mark.asyncio
+async def test_signature_only_thinking_chunk_before_text_leaks_no_signature(is_async: bool):
+    """The signed thinking block a signature-only chunk opens must stay its
+    own block: the text block that follows carries no signature."""
     chunks = [
         _thinking_chunk("", signature="sig_early"),
         _make_chunk(Delta(content="Hello")),
@@ -1155,7 +1183,9 @@ async def test_early_signature_discarded_when_first_block_is_not_thinking(is_asy
         wrapper = AnthropicStreamWrapper(completion_stream=iter(chunks), model="claude-x")
         events = _drain_sync(wrapper)
 
-    assert _thinking_block_starts(events) == []
+    starts = _thinking_block_starts(events)
+    assert len(starts) == 1
+    assert starts[0].get("signature") == "sig_early" or _signature_deltas(events) == ["sig_early"]
     text_starts = [
         e["content_block"]
         for e in events

--- a/tests/test_litellm/llms/anthropic/test_anthropic_common_utils.py
+++ b/tests/test_litellm/llms/anthropic/test_anthropic_common_utils.py
@@ -1364,6 +1364,23 @@ class TestAnthropicThinkingSignatureSelfHeal:
         assert is_empty_thinking_block({"type": "text", "text": ""}) is False
         assert is_empty_thinking_block("not a dict") is False
 
+    def test_is_empty_unsigned_thinking_block(self):
+        """Emit-side predicate: a signature-only block must be kept (Bedrock
+        Converse adaptive thinking emits empty text with only a signature, and
+        the client needs it to replay reasoning in tool-use turns); only an
+        empty block with nothing to preserve is droppable."""
+        from litellm.llms.anthropic.common_utils import is_empty_unsigned_thinking_block
+
+        assert is_empty_unsigned_thinking_block({"type": "thinking", "thinking": ""}) is True
+        assert is_empty_unsigned_thinking_block({"type": "thinking", "thinking": " \n\t "}) is True
+        assert is_empty_unsigned_thinking_block({"type": "thinking"}) is True
+        assert is_empty_unsigned_thinking_block({"type": "thinking", "thinking": "", "signature": ""}) is True
+        assert is_empty_unsigned_thinking_block({"type": "thinking", "thinking": "", "signature": "sig_abc"}) is False
+        assert is_empty_unsigned_thinking_block({"type": "thinking", "thinking": " ", "signature": "sig_abc"}) is False
+        assert is_empty_unsigned_thinking_block({"type": "thinking", "thinking": "plan"}) is False
+        assert is_empty_unsigned_thinking_block({"type": "redacted_thinking", "data": "opaque"}) is False
+        assert is_empty_unsigned_thinking_block("not a dict") is False
+
     def test_strip_empty_content_blocks_drops_empty_thinking_blocks(self):
         """LIT-6357 ingestion half: an assistant tool-loop turn carrying an
         empty (even signed) thinking block keeps its tool_use blocks and loses


### PR DESCRIPTION
## TLDR

Problem this solves:

- Bedrock Converse Opus 4.7 adaptive thinking returns signature-only thinking blocks
- The /v1/messages bridge dropped them as "empty", losing the signature
- Clients then cannot replay reasoning across tool-use turns
- Two claude_code thinking e2e cells went red from this

How it solves it:

- New emit-side predicate: drop only thinking blocks both empty and unsigned
- Both bridge emit paths (streaming and non-streaming) use it
- The request-side strip keeps rejecting empty blocks, signed included

## User Flow

Before: a Claude Code user on a Bedrock Converse Opus 4.7 deployment with effort max never sees a thinking block, and the reasoning signature is lost

1. They run `claude --model claude-opus-4-7-bedrock-converse --effort max` with a reasoning prompt, pointed at the proxy via `ANTHROPIC_BASE_URL=http://localhost:4000`
2. The stream from POST http://localhost:4000/v1/messages contains one text content block and nothing else: no thinking block opens and the word "signature" never appears in any SSE event
3. Their client has no signature to send back, so the reasoning that Bedrock signed for this turn cannot be carried into the next tool-use turn

After: the same command delivers the provider's signed thinking block

1. They run the same `claude --model claude-opus-4-7-bedrock-converse --effort max` command against the proxy
2. The stream now opens with a thinking content block carrying the provider's signature, followed by a signature_delta, then the text block
3. On a tool-use turn the client replays that signed block as history and the follow-up request succeeds

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Live proxy from the branch source on localhost:4620, one Bedrock Converse deployment (`bedrock/converse/us.anthropic.claude-opus-4-7`, us-east-1), real Bedrock calls. Raw boto3 confirms the upstream shape this exercises: under `thinking: {"type": "adaptive"}` plus `output_config: {"effort": "max"}` the model returns a reasoning block with empty text and only a signature (text_len=0, sig_len=2224)

Shared payload for the curl cases:

```
curl -s http://localhost:4620/v1/messages -H "Authorization: Bearer $KEY" -H "content-type: application/json" -d '{
  "model": "claude-opus-4-7-bedrock-converse",
  "max_tokens": 2048,
  "thinking": {"type": "adaptive"},
  "output_config": {"effort": "max"},
  "messages": [{"role": "user", "content": "I have a 3-gallon jug and a 5-gallon jug. How can I measure exactly 4 gallons of water? Think through the steps carefully."}]
}'
```

### Before (194a3cc202)

#### claude CLI, thinking

1. `claude --print --output-format stream-json --verbose --model claude-opus-4-7-bedrock-converse --effort max -- "I have a 3-gallon jug and a 5-gallon jug. How can I measure exactly 4 gallons of water? Think through the steps carefully."` with `ANTHROPIC_BASE_URL=http://localhost:4620`
2. Assistant events carry only a text block, no thinking block:

```
assistant blocks: [('text', ...)]
result success
```

#### /v1/messages streaming

1. Shared payload with `"stream": true`
2. Event type counts show a single text block and zero signature bytes anywhere in the stream:

```
   1 "type": "content_block_start"
  64 "type": "text_delta"
   1 "type": "text"
$ grep -c signature wire-head.sse
0
```

#### /v1/messages non-streaming

1. Shared payload without stream
2. `content` holds only the text block:

```
[('text')]
```

### After (5087b68b20)

#### claude CLI, thinking

1. Same command
2. The first assistant event now carries the signed thinking block, `(block type, thinking chars, signature chars)`:

```
assistant blocks: [('thinking', 0, 1468)]
assistant blocks: [('text', ...)]
result success
```

#### /v1/messages streaming

1. Same payload with `"stream": true`
2. A thinking block opens with the signature and a signature_delta follows, then the text block:

```
   2 "type": "content_block_start"
   1 "type": "signature_delta"
   1 "type": "thinking"
  71 "type": "text_delta"
data: {"type": "content_block_start", "index": 0, "content_block": {"type": "thinking", "thinking": "", "signature": "ErkOCnMIERABGAIqQOA8..."}}
```

#### /v1/messages non-streaming

1. Same payload without stream
2. `content` now leads with the signed thinking block, `(block type, thinking chars, signature chars)`:

```
[('thinking', 0, 2196), ('text', 0, 0)]
```

#### claude CLI, thinking with tool use (the replay leg)

1. `claude --print --output-format stream-json --verbose --model claude-opus-4-7-bedrock-converse --effort max --allowed-tools "Bash(echo pong)" --permission-mode dontAsk -- "Think step by step about why the command \`echo pong\` prints just the word 'pong'. Then use the Bash tool to run exactly the command \`echo pong\` and report what it printed."`
2. The session delivers the signed thinking block and the tool_use block, and the follow-up turn that replays the signed block as history succeeds:

```
assistant: [('thinking', 0, 860)]
assistant: [('text', ...)]
assistant: [('tool_use', ...)]
assistant: [('text', ...)]
result success is_error= False
```

### e2e: the two red compat cells pass from this branch

The litellm-e2e cells that went red at build 81 and stayed red since are `claude_code/thinking/test_bedrock_converse.py` and `claude_code/thinking_with_tool_use/test_bedrock_converse.py`. Both were run locally against a live proxy with real Bedrock calls in us-east-1, once from the base commit and once from this branch, same config and commands both times. The config is just the three `claude-*-bedrock-converse` deployments copied verbatim from `tests/e2e/claude_code/test_config.yaml` plus a master key; the driver runs the real claude CLI (2.1.251)

1. `uv run litellm --config bedrock-converse-only.yaml --port 4102`
2. `cd tests/e2e && LITELLM_PROXY_URL=http://localhost:4102 LITELLM_MASTER_KEY=sk-local-proof uv run pytest claude_code/thinking/test_bedrock_converse.py claude_code/thinking_with_tool_use/test_bedrock_converse.py -q`

From the base commit (194a3cc202), the thinking cell fails with the same error the Buildkite matrix shows, deterministically across two runs, and only for the opus deployment (haiku and sonnet pass):

```
[claude-opus-4-7-bedrock-converse] no `thinking` content block observed in stream-json events
FAILED claude_code/thinking/test_bedrock_converse.py::test_thinking_bedrock_converse
```

From this branch (5087b68b20):

```
2 passed in 338.86s (0:05:38)
```

The tool-use cell passing also covers the replay leg end to end: the CLI receives the signed empty thinking block, loops it back as history on the next turn, and the follow-up request succeeds

This surface is /v1/messages only: /v1/chat/completions passes thinking_blocks through unfiltered and the /v1/responses transformation only drops reasoning when both reasoning text and thinking blocks are absent, so neither had the bug

## Type

🐛 Bug Fix

## Caveats (if any)

### Medium

- Open PR #38049 would strip empty-text thinking on the bedrock replay path in `anthropic_messages_pt`, which would re-strip the block this PR emits when the client loops it back over /v1/chat/completions; it should be scoped to Anthropic-native destinations before merging
- `stream_chunk_builder` (`_flush_thinking_block` in `litellm_core_utils/streaming_chunk_builder_utils.py`) still discards a signature-only thinking block when rebuilding a response from chunks, a sibling of this bug on the logging and cache-replay path, predating #38625 and overlapping open PR #33035, so left to its owner

### Low

- The rust chat completions path from #38260 normalizes Bedrock reasoningContent in parallel and will need the same emit rule when it grows a /v1/messages bridge

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes response shaping on a widely used API surface (/v1/messages) for reasoning/tool loops; request stripping behavior is intentionally unchanged to avoid reintroducing LIT-6357 400s on replay.
> 
> **Overview**
> Fixes a regression where the **/v1/messages** bridge treated all empty thinking blocks as droppable, including Bedrock Converse adaptive-thinking responses that carry **only a signature** (no text). Clients like Claude Code need that signature to replay reasoning across tool-use turns.
> 
> Adds **`is_empty_unsigned_thinking_block`**: emit paths drop thinking blocks only when they are empty **and** have no signature. **`is_empty_thinking_block`** is unchanged for **inbound** request sanitization (Anthropic still rejects empty thinking in history, signed or not).
> 
> **Streaming** (`AnthropicStreamWrapper._is_blank_delta`) and **non-streaming** (`_translate_openai_content_to_anthropic`) now use the new predicate so signature-only blocks open a thinking block / appear in `content`. Tests were updated and expanded for the signed, contentless streaming case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5087b68b209c9635e1f3d7b17f53c8ca35701051. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
