### PR TITLE
fix(anthropic adapter): report client-requested model in streaming message_start

### DIFF
--- a/litellm/llms/anthropic/experimental_pass_through/adapters/handler.py
+++ b/litellm/llms/anthropic/experimental_pass_through/adapters/handler.py
@@ -87,6 +87,29 @@ def _extract_proxy_litellm_metadata(
     return litellm_metadata, user_api_key_auth
 
 
+def _client_facing_model(
+    model: str,
+    proxy_litellm_metadata: "Mapping[str, object] | None",
+) -> str:
+    """Return the model name to expose in translated Anthropic responses.
+
+    When the call arrives through the router/proxy, ``model`` is the
+    post-routing deployment identifier (e.g. ``hosted_vllm/my-internal-name``)
+    and the name the client actually requested travels in
+    ``litellm_metadata["model_group"]`` (stamped by the router). Prefer it so
+    the streaming ``message_start`` event reports the same model the
+    non-streaming path returns after the proxy's response-model restamp
+    (``_override_openai_response_model`` — which cannot reach the streaming
+    path because SSE bytes are serialized before it runs). SDK callers that
+    bypass the proxy carry no such metadata and keep the current behavior.
+    """
+    if isinstance(proxy_litellm_metadata, Mapping):
+        model_group: Final = proxy_litellm_metadata.get("model_group")
+        if isinstance(model_group, str) and model_group:
+            return model_group
+    return model
+
+
 async def _prepare_context_managed_request(
     *,
     model: str,
@@ -617,7 +640,10 @@ class LiteLLMMessagesToCompletionTransformationHandler:
         if stream:
             transformed_stream: Final = ANTHROPIC_ADAPTER.translate_completion_output_params_streaming(
                 completion_response,
-                model=local_model_name(model, kwargs.get("custom_llm_provider")),
+                model=_client_facing_model(
+                    local_model_name(model, kwargs.get("custom_llm_provider")),
+                    proxy_litellm_metadata,
+                ),
                 tool_name_mapping=tool_name_mapping,
                 polyfill_result=polyfill_result,
                 is_async=True,
@@ -707,6 +733,7 @@ class LiteLLMMessagesToCompletionTransformationHandler:
         # there is no work is pure overhead.
         if context_management is None and not _messages_have_compaction_block(messages):
             polyfill_result: PolyfillResult | None = None
+            proxy_litellm_metadata, _ = _extract_proxy_litellm_metadata(kwargs)
         else:
             proxy_litellm_metadata, user_api_key_auth = _extract_proxy_litellm_metadata(kwargs)
             polyfill_result = run_async_function(
@@ -751,7 +778,10 @@ class LiteLLMMessagesToCompletionTransformationHandler:
         if stream:
             transformed_stream: Final = ANTHROPIC_ADAPTER.translate_completion_output_params_streaming(
                 completion_response,
-                model=local_model_name(model, kwargs.get("custom_llm_provider")),
+                model=_client_facing_model(
+                    local_model_name(model, kwargs.get("custom_llm_provider")),
+                    proxy_litellm_metadata,
+                ),
                 tool_name_mapping=tool_name_mapping,
                 polyfill_result=polyfill_result,
                 is_async=False,

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_handler_stream_model_mirror.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_handler_stream_model_mirror.py
@@ -1,0 +1,149 @@
+"""
+Regression tests: streaming ``/v1/messages`` must report the client-requested
+model, not the internal post-routing deployment identifier.
+
+Background — what was broken:
+* Non-streaming ``/v1/messages`` responses already report the model name the
+  client asked for: the proxy restamps the response object after the call
+  (``_override_openai_response_model`` in
+  ``litellm/proxy/common_request_processing.py``).
+* Streaming responses bypass that restamp entirely: the adapter serializes the
+  ``message_start`` event to SSE bytes before the proxy-level restamp runs (a
+  bytes async-generator has no ``model`` attribute to restamp), and
+  ``AnthropicStreamWrapper`` is constructed with the POST-routing model the
+  handler received from the router (e.g. ``hosted_vllm/<internal-name>``).
+* Net effect: for aliased/wildcard ``model_list`` deployments, streaming and
+  non-streaming responses to the same endpoint disagree, and the streaming
+  path leaks internal deployment identifiers to Anthropic-protocol clients
+  (agent harnesses read ``message_start.model``).
+
+The fix threads the client-requested name — which the router already stamps
+into ``litellm_metadata["model_group"]`` — into the streaming translation via
+``_client_facing_model``. SDK callers that bypass the proxy carry no such
+metadata and keep the existing behavior.
+"""
+
+import json
+from unittest.mock import patch
+
+import pytest
+
+from litellm.llms.anthropic.experimental_pass_through.adapters.handler import (
+    LiteLLMMessagesToCompletionTransformationHandler,
+    _client_facing_model,
+)
+
+MESSAGES = [{"role": "user", "content": "hello"}]
+
+
+# ---------------------------------------------------------------------------
+# Helper-level coverage
+# ---------------------------------------------------------------------------
+
+
+def test_client_facing_model_prefers_model_group():
+    assert (
+        _client_facing_model(
+            "hosted_vllm/internal-served-name",
+            {"model_group": "claude-opus-5"},
+        )
+        == "claude-opus-5"
+    )
+
+
+def test_client_facing_model_without_metadata_keeps_model():
+    assert _client_facing_model("hosted_vllm/internal-served-name", None) == (
+        "hosted_vllm/internal-served-name"
+    )
+
+
+@pytest.mark.parametrize("bad_group", [None, "", 42, {"nested": "dict"}])
+def test_client_facing_model_ignores_unusable_model_group(bad_group):
+    assert (
+        _client_facing_model("deployment-model", {"model_group": bad_group})
+        == "deployment-model"
+    )
+
+
+# ---------------------------------------------------------------------------
+# End-to-end through the async handler: message_start carries the alias
+# ---------------------------------------------------------------------------
+
+
+class _EmptyAsyncStream:
+    """Minimal async completion stream: ends immediately.
+
+    ``AnthropicStreamWrapper`` emits ``message_start`` before consuming the
+    underlying stream, which is all these tests need.
+    """
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        raise StopAsyncIteration
+
+
+async def _first_message_start(transformed_stream) -> dict:
+    async for raw in transformed_stream:
+        text = raw.decode("utf-8") if isinstance(raw, bytes) else str(raw)
+        for line in text.splitlines():
+            line = line.strip()
+            if line.startswith("data: "):
+                event = json.loads(line[len("data: ") :])
+                if event.get("type") == "message_start":
+                    return event
+    raise AssertionError("no message_start event emitted")
+
+
+@pytest.mark.asyncio
+async def test_streaming_message_start_mirrors_requested_alias():
+    """Proxy-routed call: litellm_metadata.model_group wins over the
+    post-routing deployment model."""
+    with patch("litellm.acompletion", return_value=_EmptyAsyncStream()):  # test-quality-ok: the handler calls litellm.acompletion directly, no injection seam
+        transformed_stream = await (
+            LiteLLMMessagesToCompletionTransformationHandler.async_anthropic_messages_handler(
+                max_tokens=16,
+                messages=MESSAGES,
+                model="hosted_vllm/internal-served-name",
+                stream=True,
+                litellm_metadata={"model_group": "claude-opus-5"},
+            )
+        )
+        event = await _first_message_start(transformed_stream)
+        assert event["message"]["model"] == "claude-opus-5"
+
+
+@pytest.mark.asyncio
+async def test_streaming_message_start_without_proxy_metadata_unchanged():
+    """SDK-style call (no proxy metadata, no provider): the model passed to
+    the handler is reported as-is."""
+    with patch("litellm.acompletion", return_value=_EmptyAsyncStream()):  # test-quality-ok: the handler calls litellm.acompletion directly, no injection seam
+        transformed_stream = await (
+            LiteLLMMessagesToCompletionTransformationHandler.async_anthropic_messages_handler(
+                max_tokens=16,
+                messages=MESSAGES,
+                model="hosted_vllm/internal-served-name",
+                stream=True,
+            )
+        )
+        event = await _first_message_start(transformed_stream)
+        assert event["message"]["model"] == "hosted_vllm/internal-served-name"
+
+
+@pytest.mark.asyncio
+async def test_streaming_message_start_without_proxy_metadata_strips_provider_prefix():
+    """SDK-style call with a resolved provider: falls back to the
+    provider-local name (``local_model_name``), not the alias path."""
+    with patch("litellm.acompletion", return_value=_EmptyAsyncStream()):  # test-quality-ok: the handler calls litellm.acompletion directly, no injection seam
+        transformed_stream = await (
+            LiteLLMMessagesToCompletionTransformationHandler.async_anthropic_messages_handler(
+                max_tokens=16,
+                messages=MESSAGES,
+                model="hosted_vllm/internal-served-name",
+                stream=True,
+                custom_llm_provider="hosted_vllm",
+            )
+        )
+        event = await _first_message_start(transformed_stream)
+        assert event["message"]["model"] == "internal-served-name"


### PR DESCRIPTION
## TLDR

Problem this solves:

- Streaming `/v1/messages` leaks the internal deployment model name in `message_start`
- Non-streaming responses already restamp the client-requested name; streaming bypasses that restamp

How it solves it:

- Prefer the router-stamped requested name when building the streaming translation
- SDK callers without proxy metadata keep the existing behavior

## User Flow

Before: a client streaming from a proxy alias sees an internal deployment identifier in `message_start`, while the same request without streaming reports the alias

1. The proxy admin serves `model_name: "claude-*"` backed by `model: hosted_vllm/my-served-model`
2. The client sends POST http://localhost:4000/v1/messages with `"model": "claude-opus-5"` and gets back `"model": "claude-opus-5"`
3. The client sends the same request with `"stream": true`
4. The `message_start` event carries `"model": "my-served-model"`, an internal name the admin never meant to expose, and streaming and non-streaming now disagree about which model answered

After: both modes report the requested alias

1. The proxy admin serves `model_name: "claude-*"` backed by `model: hosted_vllm/my-served-model`
2. The client sends POST http://localhost:4000/v1/messages with `"model": "claude-opus-5"` and gets back `"model": "claude-opus-5"`
3. The client sends the same request with `"stream": true`
4. The `message_start` event carries `"model": "claude-opus-5"`, matching the non-streaming response

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Shared setup: a proxy on port 4001 with a wildcard alias in front of a local vLLM deployment

```yaml
model_list:
  - model_name: "claude-*"
    litellm_params:
      model: hosted_vllm/my-served-model
      api_base: http://localhost:8000/v1
      api_key: none
```

```bash
litellm --config config.yaml --port 4001
```

### Before (e09bbe9a14)

#### streaming message_start

1. `curl -sS http://127.0.0.1:4001/v1/messages -H "x-api-key: sk-1234" -H "anthropic-version: 2023-06-01" -H "Content-Type: application/json" -d '{"model": "claude-opus-5", "max_tokens": 30, "stream": true, "messages": [{"role": "user", "content": "hi"}]}' | grep -A1 "event: message_start"`
2. Observed: `data: {"type": "message_start", "message": {..., "model": "my-served-model", ...}}`, the internal deployment name

#### non-streaming

1. `curl -sS http://127.0.0.1:4001/v1/messages -H "x-api-key: sk-1234" -H "anthropic-version: 2023-06-01" -H "Content-Type: application/json" -d '{"model": "claude-opus-5", "max_tokens": 30, "messages": [{"role": "user", "content": "hi"}]}' | jq .model`
2. Observed: `"claude-opus-5"`, so the two modes disagree

### After (ef586bec5e)

#### streaming message_start

1. `curl -sS http://127.0.0.1:4001/v1/messages -H "x-api-key: sk-1234" -H "anthropic-version: 2023-06-01" -H "Content-Type: application/json" -d '{"model": "claude-opus-5", "max_tokens": 30, "stream": true, "messages": [{"role": "user", "content": "hi"}]}' | grep -A1 "event: message_start"`
2. Observed: `data: {"type": "message_start", "message": {..., "model": "claude-opus-5", ...}}`

#### non-streaming

1. `curl -sS http://127.0.0.1:4001/v1/messages -H "x-api-key: sk-1234" -H "anthropic-version: 2023-06-01" -H "Content-Type: application/json" -d '{"model": "claude-opus-5", "max_tokens": 30, "messages": [{"role": "user", "content": "hi"}]}' | jq .model`
2. Observed: `"claude-opus-5"`, unchanged

## Type

🐛 Bug Fix

## Caveats

- The non-streaming restamp skips fallback and model-router cases; streaming does not replicate those exceptions, it always reports the requested alias, which is still strictly less leaky than the raw internal name it reported before
- Without proxy metadata the fallback is now #37757's provider-local name, composing with that change rather than replacing it

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
