### PR TITLE
fix(cost): treat a zero rate as a price when selecting a cost metric

### DIFF
--- a/litellm/litellm_core_utils/llm_cost_calc/utils.py
+++ b/litellm/litellm_core_utils/llm_cost_calc/utils.py
@@ -137,10 +137,16 @@ def select_cost_metric_for_model(
     """
     Select 'cost_per_character' if model_info has 'input_cost_per_character'
     Select 'cost_per_token' if model_info has 'input_cost_per_token'
+
+    Presence is what selects the metric, not truthiness: a rate of ``0`` is a
+    valid price, declaring the model free. Testing truthiness treated such a
+    model as unpriced and raised below, reporting that fields it had explicitly
+    set were missing. This matches ``tier_rate`` in this package, where an
+    explicit zero already wins over the fallback.
     """
-    if model_info.get("input_cost_per_character"):
+    if model_info.get("input_cost_per_character") is not None:
         return "cost_per_character"
-    elif model_info.get("input_cost_per_token"):
+    elif model_info.get("input_cost_per_token") is not None:
         return "cost_per_token"
     else:
         raise ValueError(

--- a/tests/test_litellm/test_zero_cost_metric_selection.py
+++ b/tests/test_litellm/test_zero_cost_metric_selection.py
@@ -1,0 +1,63 @@
+"""Tests for cost-metric selection on models priced at zero.
+
+`select_cost_metric_for_model` chose a metric by truthiness, so a rate of 0 --
+a valid price declaring the model free -- was indistinguishable from an absent
+one, and the speech cost path raised ValueError claiming fields the model had
+explicitly set were missing.
+"""
+
+import pytest
+
+from litellm.litellm_core_utils.llm_cost_calc.utils import (
+    select_cost_metric_for_model,
+)
+
+
+@pytest.mark.parametrize(
+    "model_info, expected",
+    [
+        ({"key": "tts-1", "input_cost_per_token": 1.5e-05}, "cost_per_token"),
+        ({"key": "tts-1", "input_cost_per_character": 1.5e-05}, "cost_per_character"),
+        # character pricing wins when both are present
+        (
+            {
+                "key": "tts-1",
+                "input_cost_per_character": 1.5e-05,
+                "input_cost_per_token": 3.0e-05,
+            },
+            "cost_per_character",
+        ),
+    ],
+)
+def test_priced_models_select_their_metric(model_info, expected):
+    assert select_cost_metric_for_model(model_info) == expected
+
+
+@pytest.mark.parametrize(
+    "model_info, expected",
+    [
+        ({"key": "free-tts", "input_cost_per_character": 0}, "cost_per_character"),
+        ({"key": "free-tts", "input_cost_per_token": 0}, "cost_per_token"),
+        ({"key": "free-tts", "input_cost_per_character": 0.0}, "cost_per_character"),
+        (
+            {"key": "free-tts", "input_cost_per_character": 0, "input_cost_per_token": 0},
+            "cost_per_character",
+        ),
+    ],
+)
+def test_zero_is_a_price_not_an_absent_field(model_info, expected):
+    # A zero rate declares the model free. Selecting on truthiness dropped
+    # through to the ValueError below, so a free TTS model could not be costed.
+    assert select_cost_metric_for_model(model_info) == expected
+
+
+def test_missing_cost_fields_still_raise():
+    with pytest.raises(ValueError, match="does not have"):
+        select_cost_metric_for_model({"key": "unpriced-tts"})
+
+
+def test_explicit_none_is_treated_as_absent():
+    with pytest.raises(ValueError, match="does not have"):
+        select_cost_metric_for_model(
+            {"key": "unpriced-tts", "input_cost_per_character": None, "input_cost_per_token": None}
+        )


### PR DESCRIPTION
## The bug

`select_cost_metric_for_model` selects its metric by truthiness:

```python
if model_info.get("input_cost_per_character"):
    return "cost_per_character"
elif model_info.get("input_cost_per_token"):
    return "cost_per_token"
else:
    raise ValueError(f"Model {model_info['key']} does not have 'input_cost_per_character' or 'input_cost_per_token'")
```

A rate of `0` is a valid price — it declares the model free — but it's falsy, so a free model falls through to the raise and is told it's missing fields it explicitly set.

Reproduced on `main`:

```python
>>> select_cost_metric_for_model({"key": "my-free-tts", "input_cost_per_character": 0})
ValueError: Model my-free-tts does not have 'input_cost_per_character' or 'input_cost_per_token'
```

| `model_info` | before | after |
|---|---|---|
| `{"input_cost_per_token": 1.5e-05}` | `cost_per_token` | `cost_per_token` |
| `{"input_cost_per_character": 1.5e-05}` | `cost_per_character` | `cost_per_character` |
| `{"input_cost_per_character": 0}` | **ValueError** | `cost_per_character` |
| `{"input_cost_per_token": 0}` | **ValueError** | `cost_per_token` |
| `{}` | ValueError | ValueError |

The only caller is the `speech`/`aspeech` branch of `completion_cost` in `cost_calculator.py`, so a TTS model priced at `0` can't be costed at all — and the error is indistinguishable from a genuinely unpriced model, which sends you looking for a missing price rather than at the zero you set.

## The fix

Test presence with `is not None` rather than truthiness.

This matches `tier_rate` in this same package, which already documents the convention:

> "A rate that is explicitly present wins over the fallback, an explicit zero included, so a tier can declare a token type free."

Zero-cost models are a supported concept elsewhere too — the router's `_zero_cost_cache` and the auth layer's zero-cost budget bypass — so a free TTS model is a configuration users can reasonably expect to work.

## Scope

Deliberately narrow. I checked whether the same truthiness-on-a-cost-field pattern appears anywhere else in the codebase; this is the only instance, so nothing else is touched.

Unchanged: priced models, a model with both fields set (character pricing still wins), a model with neither (still raises), and a model setting both to an explicit `None` (still raises).

## Tests

`tests/test_litellm/test_zero_cost_metric_selection.py` — 9 tests, pure unit, no network or model download. **4 fail without this change**; the other 5 pin behaviour that must not move.

## Checks

- `ruff format --check` on the changed `litellm/**` file: already formatted
- `ruff check`: 6 findings on this branch, 6 on `main` — none added; they're pre-existing `BLE001`s on lines this PR doesn't touch

---

Supersedes #38807, which I opened against `main` from a fork (rejected by the source-branch guard) with a shallow clone that produced a bogus 600+ file diff. This one is 2 files against `litellm_internal_staging`.
