### PR TITLE
fix(proxy): bind --debug to LITELLM_DEBUG instead of the generic DEBUG

### DIFF
--- a/litellm/proxy/proxy_cli.py
+++ b/litellm/proxy/proxy_cli.py
@@ -698,7 +698,7 @@ class ProxyInitializationHelpers:
     is_flag=True,
     type=bool,
     help="To debug the input",
-    envvar="DEBUG",
+    envvar="LITELLM_DEBUG",
 )
 @click.option(
     "--detailed_debug",


### PR DESCRIPTION
Closes #38781.

`--debug` was bound to the bare `DEBUG` env var, which is one of the most reused names in tooling. A leftover value from an unrelated toolchain turns on proxy debug logging, and that logging can put request and response payloads into logs.

Measured with click's `CliRunner`, before and after:

| env | before | after |
|---|---|---|
| `DEBUG=1` | `debug=True` | `debug=False` |
| `DEBUG=true` | `debug=True` | `debug=False` |
| `DEBUG=release` | startup error | `debug=False` |
| `DEBUG=0` | `debug=False` | `debug=False` |

Two corrections to the issue, from running it rather than assuming:

- `DEBUG=release` does not silently enable debug on current click. It fails startup with `Invalid value for '--debug': 'release' is not a valid boolean`, which is louder but still an outage caused by an unrelated variable.
- `DEBUG=0` does **not** trip the flag. click parses falsy strings correctly, so only truthy values turn it on.

The real hazard is `DEBUG=1` and `DEBUG=true`, which are common and silently enable payload logging.

Anyone who set `DEBUG` deliberately now sets `LITELLM_DEBUG`. I left `--detailed_debug` on `DETAILED_DEBUG`, which is specific enough not to collide.