### PR TITLE
fix(ui): keep a deleted-from search query instead of blanking the box

### DIFF
--- a/ui/litellm-dashboard/src/components/shared/PaginatedSearchSelect.test.tsx
+++ b/ui/litellm-dashboard/src/components/shared/PaginatedSearchSelect.test.tsx
@@ -361,4 +361,32 @@ describe("PaginatedSearchSelect", () => {
     await user.click(screen.getByRole("combobox"));
     expect(await screen.findByTestId("paginated-search-select-loading-more")).toBeInTheDocument();
   });
+
+  it("queries the trimmed label when a character is deleted from the end of the selection", async () => {
+    const user = userEvent.setup();
+    const onSearchChange = vi.fn();
+    renderSelect({ onSearchChange, value: "alias-alpha" });
+
+    const input = screen.getByRole("combobox") as HTMLInputElement;
+    input.focus();
+    input.setSelectionRange(input.value.length, input.value.length);
+    await user.keyboard("{Backspace}");
+
+    expect(input).toHaveValue("alias-alph");
+    await waitFor(() => expect(onSearchChange).toHaveBeenLastCalledWith("alias-alph"));
+  });
+
+  it("queries what is left when a character is deleted from inside the selection", async () => {
+    const user = userEvent.setup();
+    const onSearchChange = vi.fn();
+    renderSelect({ onSearchChange, value: "alias-alpha" });
+
+    const input = screen.getByRole("combobox") as HTMLInputElement;
+    input.focus();
+    input.setSelectionRange(6, 6);
+    await user.keyboard("{Backspace}");
+
+    expect(input).toHaveValue("aliasalpha");
+    await waitFor(() => expect(onSearchChange).toHaveBeenLastCalledWith("aliasalpha"));
+  });
 });

--- a/ui/litellm-dashboard/src/components/shared/PaginatedSearchSelect.tsx
+++ b/ui/litellm-dashboard/src/components/shared/PaginatedSearchSelect.tsx
@@ -50,6 +50,11 @@ const typedInsertion = (previous: string, next: string): string => {
   return next.slice(start, next.length - end);
 };
 
+const editedQuery = (label: string, next: string): string => {
+  const inserted = typedInsertion(label, next);
+  return inserted === "" && next !== label ? next : inserted;
+};
+
 export function PaginatedSearchSelect({
   options,
   value,
@@ -101,7 +106,7 @@ export function PaginatedSearchSelect({
     const replacedWholeInput = wholeSelectionRef.current;
     wholeSelectionRef.current = false;
     handleInputValueChange(
-      typedQuery === null && !replacedWholeInput ? typedInsertion(selected?.label ?? "", next) : next,
+      typedQuery === null && !replacedWholeInput ? editedQuery(selected?.label ?? "", next) : next,
       reason,
     );
   };


### PR DESCRIPTION
## TLDR

Problem this solves:

- Backspacing in a search box that shows a picked value blanks it
- The typed-text diff can only express an insertion
- A deletion leaves nothing between prefix and suffix
- The empty result is stored as the query and sent upstream

How it solves it:

- Treat a no-insertion edit that changed the value as a deletion
- Use the remaining text as the query there
- Insertions and whole-selection replacements are untouched

## User Flow

Before: an admin filtering usage by user picks the wrong person, tries to correct the name by deleting a character, and the box empties itself

1. They open http://localhost:4000/ui/?page=usage and click the user filter box
2. They pick "alias-alpha" from the list, and the box shows "alias-alpha"
3. They tab away, then tab back into the box to fix the name, and press the right arrow to put the caret at the end
4. They press backspace once, expecting "alias-alph"
5. The box goes completely blank instead, and the list comes back unfiltered, so they have to retype the whole name from scratch

After: the same correction keeps what is left in the box and searches for it

1. They open http://localhost:4000/ui/?page=usage and click the user filter box
2. They pick "alias-alpha" from the list, and the box shows "alias-alpha"
3. They tab away, then tab back into the box to fix the name, and press the right arrow to put the caret at the end
4. They press backspace once
5. The box reads "alias-alph" and the list narrows to the users matching it, so they can keep editing toward the name they actually wanted

## Relevant issues

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

<!-- pending: UI walkthrough is in the User Flow section above; screenshots to be attached -->

## Type

🐛 Bug Fix

## Caveats (if any)

- Same box on the Logs and Create Key pages gets the fix too
- Reached only from a picked value with the list closed

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
