### PR TITLE
test(e2e): stop the reliability fallback tests flaking on gpt-5.5's reasoning budget

### DIFF
--- a/tests/e2e/models.py
+++ b/tests/e2e/models.py
@@ -333,6 +333,7 @@ class OutMessage(BaseModel):
 
 class ChatChoice(BaseModel):
     message: OutMessage | None = None
+    finish_reason: str | None = None
 
 
 class PromptTokensDetails(BaseModel):

--- a/tests/e2e/router/reliability_support.py
+++ b/tests/e2e/router/reliability_support.py
@@ -66,24 +66,39 @@ def chat_override(
     )
 
 
+def _parsed(resp: StreamingResponse) -> ChatResponse | None:
+    try:
+        return ChatResponse.model_validate_json(resp.body)
+    except ValidationError:
+        return None
+
+
 def content_of(resp: StreamingResponse) -> str | None:
     """The assistant message content of a successful chat response, or None when the
     body is not a success shape (an error body, or an elided streamed body)."""
-    try:
-        parsed = ChatResponse.model_validate_json(resp.body)
-    except ValidationError:
-        return None
-    if not parsed.choices:
+    parsed = _parsed(resp)
+    if parsed is None or not parsed.choices:
         return None
     message = parsed.choices[0].message
     return message.content if message is not None else None
 
 
 def finish_reason_of(resp: StreamingResponse) -> str | None:
-    try:
-        parsed = ChatResponse.model_validate_json(resp.body)
-    except ValidationError:
-        return None
-    if not parsed.choices:
+    parsed = _parsed(resp)
+    if parsed is None or not parsed.choices:
         return None
     return parsed.choices[0].finish_reason
+
+
+def completion_tokens_of(resp: StreamingResponse) -> int | None:
+    parsed = _parsed(resp)
+    if parsed is None or parsed.usage is None:
+        return None
+    return parsed.usage.completion_tokens
+
+
+def reasoning_tokens_of(resp: StreamingResponse) -> int | None:
+    parsed = _parsed(resp)
+    if parsed is None or parsed.usage is None or parsed.usage.completion_tokens_details is None:
+        return None
+    return parsed.usage.completion_tokens_details.reasoning_tokens

--- a/tests/e2e/router/reliability_support.py
+++ b/tests/e2e/router/reliability_support.py
@@ -57,7 +57,7 @@ def chat_override(
         json=ReliabilityChatBody(
             model=model,
             messages=[ChatMessage(role="user", content=content)],
-            max_tokens=64,
+            max_tokens=512,
             stream=stream,
             router_settings_override=override,
             cache=cache,
@@ -77,3 +77,13 @@ def content_of(resp: StreamingResponse) -> str | None:
         return None
     message = parsed.choices[0].message
     return message.content if message is not None else None
+
+
+def finish_reason_of(resp: StreamingResponse) -> str | None:
+    try:
+        parsed = ChatResponse.model_validate_json(resp.body)
+    except ValidationError:
+        return None
+    if not parsed.choices:
+        return None
+    return parsed.choices[0].finish_reason

--- a/tests/e2e/router/test_reliability_fallbacks_e2e.py
+++ b/tests/e2e/router/test_reliability_fallbacks_e2e.py
@@ -3,9 +3,11 @@ healthy one.
 
 Each test registers a primary deployment that fails (an unreachable base URL, or
 a 1ms deadline) and calls it with a `router_settings_override` mapping it to the
-real `gpt-5.5`. The proof the fallback fired is twofold: the response is a real
-completion from `gpt-5.5` (a non-empty content string), and the proxy reports at
-least one attempted fallback in the x-litellm-attempted-fallbacks header.
+real `gpt-5.5`. The proof the fallback fired is twofold: the response is a
+completion from `gpt-5.5`, and the proxy reports at least one attempted fallback
+in the x-litellm-attempted-fallbacks header. Empty content is accepted only for
+`finish_reason == "length"`, since gpt-5.5 counts reasoning against max_tokens
+and can consume the whole budget before emitting any text.
 """
 
 from __future__ import annotations
@@ -22,6 +24,7 @@ from reliability_support import (
     content_of,
     create_bad_base_deployment,
     create_timeout_deployment,
+    finish_reason_of,
 )
 
 pytestmark = pytest.mark.e2e
@@ -30,9 +33,15 @@ pytestmark = pytest.mark.e2e
 def _assert_served_by_fallback(resp: StreamingResponse) -> None:
     assert resp.status_code == 200, f"expected 200 after fallback, got {resp.status_code}: {resp.body[:300]}"
     content = content_of(resp)
-    assert isinstance(content, str) and content, (
-        f"the gpt-5.5 fallback should have returned a real completion, got content {content!r} "
+    finish_reason = finish_reason_of(resp)
+    assert isinstance(content, str), (
+        f"the gpt-5.5 fallback should have returned a completion body, got content {content!r} "
         f"(body={resp.body[:300]})"
+    )
+    assert content or finish_reason == "length", (
+        f"the gpt-5.5 fallback returned empty content with finish_reason={finish_reason!r}; only "
+        f"finish_reason='length' may be empty, since gpt-5.5 can spend the whole max_tokens "
+        f"budget on reasoning (body={resp.body[:300]})"
     )
     attempted = resp.headers.get("x-litellm-attempted-fallbacks")
     assert attempted is not None, "response is missing the x-litellm-attempted-fallbacks header"

--- a/tests/e2e/router/test_reliability_fallbacks_e2e.py
+++ b/tests/e2e/router/test_reliability_fallbacks_e2e.py
@@ -5,9 +5,10 @@ Each test registers a primary deployment that fails (an unreachable base URL, or
 a 1ms deadline) and calls it with a `router_settings_override` mapping it to the
 real `gpt-5.5`. The proof the fallback fired is twofold: the response is a
 completion from `gpt-5.5`, and the proxy reports at least one attempted fallback
-in the x-litellm-attempted-fallbacks header. Empty content is accepted only for
-`finish_reason == "length"`, since gpt-5.5 counts reasoning against max_tokens
-and can consume the whole budget before emitting any text.
+in the x-litellm-attempted-fallbacks header. Empty content is accepted only when
+`finish_reason == "length"` and the response billed completion tokens, since
+gpt-5.5 counts reasoning against max_tokens and can consume the whole budget
+before emitting any text; a fallback that produced nothing at all still fails.
 """
 
 from __future__ import annotations
@@ -21,10 +22,12 @@ from lifecycle import ResourceManager
 from models import RouterSettingsOverride
 from reliability_support import (
     chat_override,
+    completion_tokens_of,
     content_of,
     create_bad_base_deployment,
     create_timeout_deployment,
     finish_reason_of,
+    reasoning_tokens_of,
 )
 
 pytestmark = pytest.mark.e2e
@@ -34,14 +37,17 @@ def _assert_served_by_fallback(resp: StreamingResponse) -> None:
     assert resp.status_code == 200, f"expected 200 after fallback, got {resp.status_code}: {resp.body[:300]}"
     content = content_of(resp)
     finish_reason = finish_reason_of(resp)
+    completion_tokens = completion_tokens_of(resp) or 0
+    reasoning_tokens = reasoning_tokens_of(resp) or 0
     assert isinstance(content, str), (
         f"the gpt-5.5 fallback should have returned a completion body, got content {content!r} "
         f"(body={resp.body[:300]})"
     )
-    assert content or finish_reason == "length", (
-        f"the gpt-5.5 fallback returned empty content with finish_reason={finish_reason!r}; only "
-        f"finish_reason='length' may be empty, since gpt-5.5 can spend the whole max_tokens "
-        f"budget on reasoning (body={resp.body[:300]})"
+    assert content or (finish_reason == "length" and completion_tokens > 0), (
+        f"the gpt-5.5 fallback returned empty content with finish_reason={finish_reason!r}, "
+        f"completion_tokens={completion_tokens}, reasoning_tokens={reasoning_tokens}; empty "
+        f"content is only acceptable when the budget was spent on non-visible reasoning "
+        f"(body={resp.body[:300]})"
     )
     attempted = resp.headers.get("x-litellm-attempted-fallbacks")
     assert attempted is not None, "response is missing the x-litellm-attempted-fallbacks header"


### PR DESCRIPTION
## What

`tests/e2e/router/test_reliability_fallbacks_e2e.py::TestReliabilityFallbacks::test_5xx_routes_to_fallback` failed in litellm-e2e build 90 — its first failure in 16 builds.

The fallback worked. The response was a 200 served by `gpt-5.5-2026-04-23` with `x-litellm-attempted-fallbacks` present. What failed was the follow-up assertion that the content is non-empty:

```
content '' ... "finish_reason":"length"
```

## Why it happens

`chat_override` hardcodes `max_tokens=64`, and the fallback target is `openai/gpt-5.5`. On a reasoning model that cap covers reasoning **plus** visible output, so the model can spend the entire budget thinking and emit no text.

Confirmed from the response cost rather than inferred: `response_cost=0.002005`, and gpt-5.5 is $5e-06/input token and $3e-05/output token. That solves exactly at prompt=17, completion=**64** — the cap, to the token.

So it is model-side nondeterminism against a too-tight budget, not a routing defect. "say hi" usually needs a handful of reasoning tokens and fits; occasionally it does not.

## What this changes

- `tests/e2e/router/reliability_support.py` — `chat_override` budget 64 → 512, so reasoning and a short answer both fit.
- `tests/e2e/router/test_reliability_fallbacks_e2e.py` — `_assert_served_by_fallback` accepts empty content only when `finish_reason == "length"`. Empty content under any other finish_reason still fails.
- `tests/e2e/models.py` — `ChatChoice` gains an optional `finish_reason`, needed to make that distinction.

The test's stated proof is twofold: a completion from `gpt-5.5`, and `x-litellm-attempted-fallbacks >= 1`. Both still hold. The assertion being relaxed was measuring OpenAI's token budgeting, which we do not control.

## Verification

Ran the new predicate against the exact failing body from build 90:

| case | old | new |
|---|---|---|
| build 90's body (`content: ""`, `finish_reason: "length"`) | fails | passes |
| normal completion (`content: "hi there"`, `finish_reason: "stop"`) | passes | passes |
| empty content with `finish_reason: "stop"` — a real defect | fails | fails |

The last row is the one that matters: the relaxation does not blind the test to a fallback that genuinely returns nothing.

`_assert_served_by_fallback` is shared by both tests in the file, so `test_timeout_routes_to_fallback` is covered too — same shape, same latent flake, had not tripped yet.

Test-only; no `litellm/` source touched.