### PR TITLE
fix(spend): identify auto-router savings targets by deployment id

### DIFF
--- a/litellm/proxy/spend_tracking/savings.py
+++ b/litellm/proxy/spend_tracking/savings.py
@@ -314,6 +314,27 @@ def _baseline_usage(usage: Usage, conversation_continuing: bool, baseline_info: 
     )
 
 
+def _is_same_target(
+    baseline_deployment_id: str | None,
+    selected_deployment_id: str | None,
+    baseline: _ModelIdentity,
+    selected: _ModelIdentity,
+) -> bool:
+    """Whether the baseline and served sides are the same priced target.
+
+    Deployment id is the identity when both sides carry one: two deployments of a
+    model can hold different negotiated rates, so routing from the dear one to the
+    cheap one is a real saving that name equality reports as zero, and one
+    deployment can appear under an alias on one side and its base model on the
+    other, which name inequality reports as a phantom loss. Canonical
+    provider/model identity is the fallback when either id is missing, which is
+    every SDK caller and every row written before ids were threaded through.
+    """
+    if baseline_deployment_id and selected_deployment_id:
+        return baseline_deployment_id == selected_deployment_id
+    return baseline == selected
+
+
 def compute_autorouter_savings(
     baseline_model: str | None,
     selected_model: str | None,
@@ -323,6 +344,8 @@ def compute_autorouter_savings(
     selected_info: ModelInfo | None = None,
     baseline_info: ModelInfo | None = None,
     cost_breakdown: Mapping[str, object] | None = None,
+    baseline_deployment_id: str | None = None,
+    selected_deployment_id: str | None = None,
 ) -> float:
     """Net dollars the router saved, or cost, by serving this request on ``selected_model``.
 
@@ -358,11 +381,10 @@ def compute_autorouter_savings(
     selected: Final = _resolve_model(selected_model, selected_provider)
     if baseline is None or selected is None:
         return 0.0
-    # Same model is only the same cost when it is also the same deployment. Two
-    # deployments of one model can carry different negotiated rates, and routing from
-    # the dear one to the cheap one is a real saving that short-circuiting on the model
-    # name alone reports as zero.
-    if baseline == selected:
+    # Same model is only the same cost when it is also the same deployment, so the
+    # short-circuit keys on deployment id when both sides carry one and only falls
+    # back to model-name identity when an id is missing.
+    if _is_same_target(baseline_deployment_id, selected_deployment_id, baseline, selected):
         return 0.0
     basis: Final = _pricing_basis(cost_breakdown)
     effective_baseline_info: Final = baseline_info if baseline_info is not None else _model_info(baseline)
@@ -521,6 +543,8 @@ def autorouter_savings_for_request(
         selected_info=_effective_model_info(router_instance, model_id, model or ""),
         baseline_info=_effective_model_info(router_instance, baseline_id, baseline_model or ""),
         cost_breakdown=cost_breakdown,
+        baseline_deployment_id=baseline_id,
+        selected_deployment_id=model_id,
     )
 
 

--- a/tests/test_litellm/proxy/spend_tracking/test_savings.py
+++ b/tests/test_litellm/proxy/spend_tracking/test_savings.py
@@ -613,6 +613,73 @@ def test_the_same_deployment_spelled_two_ways_is_not_a_switch():
     assert _savings("claude-opus-5", "anthropic/claude-opus-5", usage) == 0.0
 
 
+def test_two_deployments_of_one_model_are_told_apart_by_deployment_id():
+    """Two deployments of one model can hold different negotiated rates, so routing from
+    the dear deployment to the cheap one is a real saving. Keying identity on the model
+    name alone resolves both sides to the same model and reports it as $0.00; the
+    deployment ids tell them apart."""
+    usage = _usage(fresh=20_000, cached=0, written=0, out=1_000)
+    negotiated_input, negotiated_output = 0.0123, 0.0456
+    reported = compute_autorouter_savings(
+        baseline_model="anthropic/claude-opus-5",
+        selected_model="anthropic/claude-opus-5",
+        selected_provider="anthropic",
+        usage=usage,
+        conversation_continuing=False,
+        cost_breakdown=_breakdown(negotiated_input, negotiated_output),
+        baseline_deployment_id="deployment-expensive",
+        selected_deployment_id="deployment-cheap",
+    )
+    opus = litellm.get_model_info("claude-opus-5", "anthropic")
+    public = 20_000 * opus["input_cost_per_token"] + 1_000 * opus["output_cost_per_token"]
+    assert reported == pytest.approx(public - (negotiated_input + negotiated_output))
+    assert reported > 0
+
+
+def test_the_same_deployment_id_is_never_a_switch():
+    """One deployment can be recorded under two model spellings, an Azure alias on one
+    side and its base model on the other, which resolve to different canonical models.
+    When the deployment ids agree it is one target, so the name difference must not price
+    as a switch and report a phantom loss."""
+    usage = _usage(fresh=20_000, cached=0, written=0, out=1_000)
+    reported = compute_autorouter_savings(
+        baseline_model="anthropic/claude-opus-5",
+        selected_model="anthropic/claude-haiku-4-5",
+        selected_provider="anthropic",
+        usage=usage,
+        conversation_continuing=False,
+        baseline_deployment_id="one-deployment",
+        selected_deployment_id="one-deployment",
+    )
+    assert reported == 0.0
+
+
+def test_identity_falls_back_to_model_name_without_both_deployment_ids():
+    """Deployment id is the identity only when both sides carry one. With an id on just
+    one side, an SDK caller, or a row written before ids were threaded through, it falls
+    back to canonical model identity: the same model spelled two ways is still one target,
+    and a genuine switch still prices."""
+    usage = _usage(fresh=20_000, cached=0, written=0, out=1_000)
+    same_model_one_id = compute_autorouter_savings(
+        baseline_model="anthropic/claude-opus-5",
+        selected_model="claude-opus-5",
+        selected_provider="anthropic",
+        usage=usage,
+        conversation_continuing=False,
+        baseline_deployment_id="only-the-baseline-has-one",
+        selected_deployment_id=None,
+    )
+    assert same_model_one_id == 0.0
+    real_switch_no_ids = compute_autorouter_savings(
+        baseline_model="anthropic/claude-opus-5",
+        selected_model="anthropic/claude-haiku-4-5",
+        selected_provider="anthropic",
+        usage=usage,
+        conversation_continuing=False,
+    )
+    assert real_switch_no_ids > 0
+
+
 def test_baseline_is_priced_under_its_own_provider():
     """Two providers can serve the same bare model name at different rates, so dropping
     the provider prices the baseline against a vendor the operator never named. Here it


### PR DESCRIPTION
## TLDR

Problem this solves:

- Auto-router savings compared only provider and model name
- Two differently priced deployments of one model reported $0.00
- One deployment under an alias vs its base model reported a phantom loss

How it solves it:

- Thread the baseline and selected deployment ids into the identity check
- Compare by deployment id when both sides carry one
- Fall back to canonical provider/model identity when an id is missing

## User Flow

Before: an operator routes between two differently priced deployments of one model, but the dashboard reports no saving

1. The operator configures an auto-router whose baseline and selected targets use the same provider model but have different deployment ids and negotiated rates
2. A developer sends POST `https://litellm-domain/v1/chat/completions` with the auto-router model and receives `200 OK` from the cheaper deployment
3. The operator opens `https://litellm-domain/ui/?page=cost-optimization` and sees `$0.00` auto-router savings although the cheaper deployment cost less

After: the same request is compared by deployment identity and reports the negotiated-rate saving

1. The operator configures the same auto-router whose baseline and selected targets use the same provider model but have different deployment ids and negotiated rates
2. A developer sends POST `https://litellm-domain/v1/chat/completions` with the auto-router model and receives `200 OK` from the cheaper deployment
3. The operator opens `https://litellm-domain/ui/?page=cost-optimization` and sees the baseline deployment cost minus the selected deployment cost

## Relevant issues

Fixes #38811

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Shared setup. `config.yaml` runs an auto-router over two deployments of one model at different negotiated rates:

```yaml
model_list:
  - model_name: opus-expensive
    litellm_params:
      model: anthropic/claude-opus-5
      api_key: os.environ/ANTHROPIC_API_KEY
      input_cost_per_token: 0.00002
      output_cost_per_token: 0.00006
  - model_name: opus-cheap
    litellm_params:
      model: anthropic/claude-opus-5
      api_key: os.environ/ANTHROPIC_API_KEY
      input_cost_per_token: 0.000005
      output_cost_per_token: 0.000015
router_settings:
  auto_router:
    savings_baseline: opus-expensive
```

Start the proxy: `python litellm/proxy/proxy_cli.py --config config.yaml --detailed_debug`

Single case: send the auto-router request, then read the auto-router savings the dashboard shows for that call.

```bash
curl -s http://localhost:4000/v1/chat/completions -H "Authorization: Bearer sk-1234" \
  -H "content-type: application/json" \
  -d '{"model":"auto_router","messages":[{"role":"user","content":"summarize the quarter"}]}'
```

Then open `http://localhost:4000/ui/?page=cost-optimization` and read the auto-router savings for that request.

### Before (b3235fa78)

1. Run the curl above; the request is served by the cheaper deployment
2. The cost-optimization page reports `$0.00` auto-router savings, because both sides resolve to `anthropic/claude-opus-5`

### After (f9ad597)

1. Run the same curl; the request is served by the cheaper deployment
2. The page reports the expensive deployment's cost minus the cheap one's, a real positive saving

Note: this hits a real provider so it costs usage. I will attach the captured Before/After dashboard figures from a live proxy.

## Type

🐛 Bug Fix

✅ Test

## Caveats (if any)

### Low

- Identity keys on deployment id only when both sides carry one; an SDK caller or a pre-id row still falls back to model-name identity, unchanged

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

cc the auto-router savings area authors: @tin-berri @mateo-berri
