### PR TITLE
fix(proxy): count auto-router classifier cost in savings and benchmarks

### DIFF
--- a/litellm/proxy/common_request_processing.py
+++ b/litellm/proxy/common_request_processing.py
@@ -1362,6 +1362,8 @@ def _classifier_cost_from_request_data(request_data: Mapping[str, object] | None
     routes and in `metadata` on chat-style routes, so both buckets are consulted, in the same
     precedence `get_or_create_metadata_bucket` writes them.
     """
+    from litellm.proxy.spend_tracking.savings import classifier_cost_from_decision
+
     data: Final = request_data or {}
     for metadata_key in ("litellm_metadata", "metadata"):
         metadata = data.get(metadata_key)
@@ -1370,10 +1372,10 @@ def _classifier_cost_from_request_data(request_data: Mapping[str, object] | None
         decision = metadata.get("routing_decision")
         if not isinstance(decision, dict):
             continue
-        cost = decision.get("classifier_cost")
-        if isinstance(cost, bool) or not isinstance(cost, (int, float)):
+        cost = classifier_cost_from_decision(decision)
+        if cost is None:
             continue
-        return float(cost)
+        return cost
     return None
 
 

--- a/litellm/proxy/db/autorouter_session_rollup.py
+++ b/litellm/proxy/db/autorouter_session_rollup.py
@@ -185,8 +185,10 @@ def build_autorouter_turn_transaction(
     of a request through the router) are excluded by their internal_call_origin stamp:
     they are not traffic a user sent, so counting them would manufacture sessions and
     savings in the adoption metrics. Failed requests served nothing and are excluded.
-    Cache facts are derived from the payload's own usage record through the savings
-    owner, never handed in beside it.
+    The classifier's charge still lands here exactly once, via the decision's own
+    classifier_cost folded into this turn's spend: the excluded classifier row is how
+    it was billed, the decision is how it is attributed. Cache facts are derived from
+    the payload's own usage record through the savings owner, never handed in beside it.
     """
     if payload.get("status") != "success":
         return None
@@ -204,9 +206,12 @@ def build_autorouter_turn_transaction(
     turn_at: Final = _turn_time_utc(str(payload.get("startTime") or ""))
     if turn_at is None:
         return None
+    from litellm.proxy.spend_tracking.savings import classifier_cost_from_decision
+
     usage_object_raw: Final = metadata.get("usage_object")
     cache: Final = turn_cache_facts(usage_object_raw if isinstance(usage_object_raw, Mapping) else None)
     tier_raw: Final = routing_decision.get("tier")
+    classifier_cost: Final = classifier_cost_from_decision(routing_decision)
     return AutoRouterTurnTransaction(
         api_key=api_key,
         session_id=_bounded_session_id(session_id),
@@ -216,7 +221,7 @@ def build_autorouter_turn_transaction(
         model=model,
         turn_at=turn_at,
         total_tokens=int(payload.get("prompt_tokens") or 0) + int(payload.get("completion_tokens") or 0),
-        spend=float(payload.get("spend") or 0.0),
+        spend=float(payload.get("spend") or 0.0) + (classifier_cost or 0.0),
         saved_spend=saved_spend,
         covered=cache.covered,
         cache_hit=cache.read_tokens > 0,

--- a/litellm/proxy/spend_tracking/savings.py
+++ b/litellm/proxy/spend_tracking/savings.py
@@ -481,6 +481,20 @@ def _numeric_savings(value: object) -> float | None:
     return float(value)
 
 
+def classifier_cost_from_decision(routing_decision: Mapping[str, object] | None) -> float | None:
+    """The LLM-classifier cost a routing decision recorded, or ``None`` when it holds none.
+
+    ``None`` covers the decision-less request, the heuristic short-circuit that never
+    called a classifier, the unpriced classifier model, and a malformed value alike:
+    in every one of those cases there is no dollar figure to move, so callers treat
+    ``None`` as zero rather than as an error. The one owner of that reading, shared by
+    the savings netting, the session rollup and the response header, so the three can
+    never disagree about what counts as a classifier charge.
+    """
+    decision: Final = routing_decision if isinstance(routing_decision, Mapping) else {}
+    return _numeric_savings(decision.get("classifier_cost"))
+
+
 def autorouter_savings_for_request(
     model: str | None,
     custom_llm_provider: str | None,
@@ -490,7 +504,8 @@ def autorouter_savings_for_request(
     llm_router: "Callable[[], Router | None] | None" = None,
     cost_breakdown: Mapping[str, object] | None = None,
 ) -> float | None:
-    """Auto-router savings for one request, or ``None`` when the driver is off.
+    """Auto-router savings for one request, net of the classifier call that routed it,
+    or ``None`` when the driver is off.
 
     ``None`` and ``0.0`` are different facts: ``None`` means this request cannot carry a
     figure at all (no routing decision, no baseline, unusable usage), while ``0.0`` is a
@@ -498,6 +513,11 @@ def autorouter_savings_for_request(
     Never raises: pricing failures inside degrade to zero, and the driver-off cases
     return ``None``, so this is safe on the logging path where a raise would fail the
     request's logging.
+
+    The classifier deduction lives here, at the figure's one computation owner, rather
+    than in any reader: the stamped ``autorouter_savings`` is then already net, so the
+    session rollup, the daily tables and every logging consumer agree without each
+    re-deriving the deduction, and the recorded-figure-wins path cannot deduct twice.
     """
     usage: Final = _usage_from_spend_log(usage_object)
     if usage is None or not model:
@@ -510,7 +530,7 @@ def autorouter_savings_for_request(
     if not decision or not baseline_model:
         return None
     router_instance: Final = llm_router() if llm_router else None
-    return compute_autorouter_savings(
+    gross: Final = compute_autorouter_savings(
         baseline_model=baseline_model,
         selected_model=model,
         selected_provider=custom_llm_provider,
@@ -522,6 +542,8 @@ def autorouter_savings_for_request(
         baseline_info=_effective_model_info(router_instance, baseline_id, baseline_model or ""),
         cost_breakdown=cost_breakdown,
     )
+    classifier_cost: Final = classifier_cost_from_decision(decision)
+    return gross if classifier_cost is None else gross - classifier_cost
 
 
 def autorouter_savings_for_logging_payload(

--- a/tests/test_litellm/proxy/db/test_autorouter_session_rollup.py
+++ b/tests/test_litellm/proxy/db/test_autorouter_session_rollup.py
@@ -106,6 +106,28 @@ class TestBuildTransaction:
         transaction = _build()
         assert transaction is not None and transaction.tier is None
 
+    def test_a_priced_classifier_rides_the_turns_spend(self):
+        """The classifier row is excluded from the rollup, so its charge lands here,
+        folded once into the turn that paid for it (GH #38816)."""
+        transaction = _build(metadata=_metadata(routing_decision={**ROUTING_DECISION, "classifier_cost": 0.005}))
+        assert transaction is not None and transaction.spend == pytest.approx(0.015)
+
+    @pytest.mark.parametrize(
+        "decision_extra", [{}, {"classifier_cost": 0.0}, {"classifier_cost": "bogus"}, {"classifier_cost": True}]
+    )
+    def test_an_unpriced_classifier_leaves_the_spend_alone(self, decision_extra: dict):
+        transaction = _build(metadata=_metadata(routing_decision={**ROUTING_DECISION, **decision_extra}))
+        assert transaction is not None and transaction.spend == pytest.approx(0.01)
+
+    def test_every_turn_carries_its_own_classifier_charge(self):
+        first = _build(metadata=_metadata(routing_decision={**ROUTING_DECISION, "classifier_cost": 0.005}))
+        second = _build(
+            payload=_payload(startTime="2026-08-01T12:01:00", spend=0.02),
+            metadata=_metadata(routing_decision={**ROUTING_DECISION, "classifier_cost": 0.007}),
+        )
+        assert first is not None and first.spend == pytest.approx(0.015)
+        assert second is not None and second.spend == pytest.approx(0.027)
+
     def test_router_name_falls_back_to_the_payload_model_group(self):
         transaction = _build(metadata=_metadata(routing_decision={"router_type": "complexity"}))
         assert transaction is not None and transaction.router_name == "live-auto"

--- a/tests/test_litellm/proxy/spend_tracking/test_savings.py
+++ b/tests/test_litellm/proxy/spend_tracking/test_savings.py
@@ -1151,6 +1151,61 @@ def test_logging_payload_never_stamps_internal_calls():
     assert internal is None
 
 
+def test_savings_are_net_of_a_priced_classifier():
+    """The classifier call is part of what routing cost, so the per-request figure
+    deducts it; a charge big enough to outweigh the model saving goes negative,
+    since the figure is signed on purpose (GH #38816)."""
+    from litellm.proxy.spend_tracking.savings import autorouter_savings_for_request
+
+    gross = autorouter_savings_for_request(
+        model="claude-haiku-4-5",
+        custom_llm_provider="anthropic",
+        routing_decision=_routed_decision(),
+        usage_object=_cached_usage_object(),
+    )
+    net = autorouter_savings_for_request(
+        model="claude-haiku-4-5",
+        custom_llm_provider="anthropic",
+        routing_decision={**_routed_decision(), "classifier_cost": 0.005},
+        usage_object=_cached_usage_object(),
+    )
+    assert gross is not None and net == pytest.approx(gross - 0.005)
+
+
+@pytest.mark.parametrize("classifier_cost", [0.0, "bogus", True])
+def test_an_unpriced_classifier_deducts_nothing(classifier_cost: object):
+    from litellm.proxy.spend_tracking.savings import autorouter_savings_for_request
+
+    gross = autorouter_savings_for_request(
+        model="claude-haiku-4-5",
+        custom_llm_provider="anthropic",
+        routing_decision=_routed_decision(),
+        usage_object=_cached_usage_object(),
+    )
+    with_cost_field = autorouter_savings_for_request(
+        model="claude-haiku-4-5",
+        custom_llm_provider="anthropic",
+        routing_decision={**_routed_decision(), "classifier_cost": classifier_cost},
+        usage_object=_cached_usage_object(),
+    )
+    assert with_cost_field == gross
+
+
+def test_recorded_savings_are_already_net_and_not_deducted_again():
+    """The deduction lives at the figure's computation owner, so a stamped figure is
+    net by construction; the recorded-wins path must not subtract a second time."""
+    result = compute_savings_spend(
+        model="claude-haiku-4-5",
+        custom_llm_provider="anthropic",
+        compression_saved_tokens=0,
+        gateway_injected_cache=False,
+        routing_decision={**_routed_decision(), "classifier_cost": 0.005},
+        usage_object=_cached_usage_object(),
+        recorded_autorouter_savings=0.5,
+    )
+    assert result.autorouter == 0.5
+
+
 def test_caching_savings_require_a_gateway_injected_breakpoint():
     """The same cached usage is attributed to the gateway only when it added a breakpoint.
 


### PR DESCRIPTION
## TLDR

Problem this solves:

- LLM classifier cost never reached any auto-router savings figure
- Benchmarks overstated savings and understated routed spend
- A losing router config could read as 80% saved

How it solves it:

- Savings figure is now net of the decision's classifier cost
- The rollup turn's spend includes the classifier charge once
- baseline_spend = spend + saved_spend still holds exactly

## User Flow

Before: an operator using an LLM classifier sees gross model savings presented as net savings

1. The operator configures a complexity router with an LLM classifier and a developer sends POST https://litellm-domain/v1/chat/completions with the router model, getting 200 OK after a paid classifier call picks a tier
2. The operator requests GET https://litellm-domain/auto_router/benchmarks and sees spend $0.000079, saved_spend $0.000316 and "80% saved", while the classifier's $0.002135 charge appears nowhere
3. The router actually lost money on the turn, and nothing on any page says so

After: the same benchmark reports the complete workflow cost and the net saving

1. The operator configures the same complexity router and the developer sends the same POST https://litellm-domain/v1/chat/completions, getting the same 200 OK
2. The operator requests GET https://litellm-domain/auto_router/benchmarks and sees spend $0.002214 (the served request plus the classifier charge, counted once) and saved_spend -$0.001819 (net of the classifier)
3. The negative figure tells the operator this classifier is too expensive for this traffic, which is the decision the page exists to inform

## Relevant issues

- Nets the recorded classifier cost out of the per-request auto-router savings figure, at its one computation owner, so the stamp, the daily tables and the session rollup all agree
- Folds the same cost into the rollup turn's spend, so /auto_router/benchmarks counts it exactly once and baseline_spend stays spend + saved_spend
- The x-litellm-classifier-cost header's numeric guard now reads through the same shared helper

Fixes #38816

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Live proxy on localhost:4620, real Postgres, real LLM calls. Complexity router `smart-router` with `classifier_type: llm` (classifier gpt-5.5), tiers SIMPLE/MEDIUM claude-haiku-4-5 and COMPLEX/REASONING claude-opus-5, so the derived savings baseline is claude-opus-5. Every request below routed SIMPLE with served cost $0.000079, gross model saving $0.000316 against the opus baseline, and a $0.002135 classifier charge (visible in x-litellm-classifier-cost and in the classifier's own spend log row on both runs)

### Before (36ea28b092)

1. `curl -sS -D - http://127.0.0.1:4620/v1/chat/completions -H "Authorization: Bearer sk-38816-rig" -d '{"model": "smart-router", "messages": [{"role": "user", "content": "What is 2+2?"}]}'` returns headers `x-litellm-model-name: anthropic/claude-haiku-4-5`, `x-litellm-response-cost: 7.9e-05`, `x-litellm-classifier-cost: 0.002135`
2. `curl -sS http://127.0.0.1:4620/auto_router/benchmarks -H "Authorization: Bearer sk-38816-rig"` totals: `"spend": 7.9e-05, "saved_spend": 0.000316, "baseline_spend": 0.000395, "saved_pct": 80.0`
3. Spend logs show the classifier row billed $0.002135 (`internal_call_origin: autorouter_classifier`) while the main row's `autorouter_savings` reads the gross 0.000316; all-in the turn cost $0.002214 to save a $0.000395 baseline, and the page says 80% saved

### After (d3db7cebca)

Same rig and commands, one request per endpoint

#### /v1/chat/completions

1. Same curl as before, same headers: routed haiku, served $0.000079, classifier $0.002135
2. Main spend log row now stamps `autorouter_savings: -0.001819` (0.000316 gross minus 0.002135); the classifier row is unchanged, still billed once under its own model
3. Rollup row: `spend 0.002214, saved_spend -0.001819`

#### /v1/messages

1. `curl -sS http://127.0.0.1:4620/v1/messages -H "Authorization: Bearer sk-38816-rig" -d '{"model": "smart-router", "max_tokens": 64, "messages": [{"role": "user", "content": "What is 3+3?"}]}'` returns 200
2. Its spend log row stamps the identical net figure: `classifier_cost 0.002135, autorouter_savings -0.001819`

#### /v1/responses

1. `curl -sS http://127.0.0.1:4620/v1/responses -H "Authorization: Bearer sk-38816-rig" -d '{"model": "smart-router", "input": "What is 5+5?"}'` returns `"status": "completed"`
2. Its spend log row (call_type aresponses) stamps `classifier_cost 0.002135, autorouter_savings -0.001819`

#### Benchmarks over all three turns

1. `curl -sS http://127.0.0.1:4620/auto_router/benchmarks -H "Authorization: Bearer sk-38816-rig"` totals: `"spend": 0.006642, "saved_spend": -0.005457, "baseline_spend": 0.001185, "saved_pct": -460.5`
2. The identity holds exactly: 0.006642 + (-0.005457) = 0.001185 = 3 x 0.000395, the unchanged baseline
3. `LiteLLM_DailyUserSpend.autorouter_savings_spend` reads the same net -0.001819 per request, so the usage tab and the benchmarks tab agree

## Type

🐛 Bug Fix

## Caveats (if any)

### Low

- Rows stamped before this fix keep their gross figures; no data rewrite
- StandardLoggingPayload.autorouter_savings is now net for logging consumers
- Heuristic, quality and adaptive routers record no classifier cost; unchanged

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes spend logging, daily savings rollups, and auto-router benchmark aggregates; historical rows keep gross figures with no backfill, and negative net savings are intentional for expensive classifiers.
> 
> **Overview**
> Auto-router **LLM classifier spend** is now included in savings and benchmark math instead of being ignored, so operators see **net** routing value (model delta minus classifier) rather than inflated “% saved” figures.
> 
> A shared **`classifier_cost_from_decision`** helper is the single place that reads `routing_decision.classifier_cost` (with the same numeric guards everywhere). **`autorouter_savings_for_request`** subtracts that cost from gross model savings at compute time, so stamped `autorouter_savings`, daily rollups, and the “recorded figure wins” path stay aligned and are **not** deducted twice. **Session rollup** adds the same classifier charge **once** to each routed turn’s `spend` (the classifier spend-log row stays excluded from rollup rows). **`x-litellm-classifier-cost`** uses the same helper as savings/rollup.
> 
> Tests cover net savings, malformed/zero classifier costs, per-turn attribution, and that pre-stamped net savings are honored unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d3db7cebca06f6c990086d8b09c9f48efd04e2a9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->