### PR TITLE
fix(anthropic): cap reasoning_effort thinking budget below max_tokens on /v1/messages

### DIFF
--- a/litellm/llms/anthropic/chat/transformation.py
+++ b/litellm/llms/anthropic/chat/transformation.py
@@ -1268,7 +1268,7 @@ class AnthropicConfig(AnthropicModelInfo, BaseConfig):
             )
 
     @staticmethod
-    def _cap_thinking_budget_to_max_tokens(
+    def cap_thinking_budget_to_max_tokens(
         thinking: AnthropicThinkingParam, max_tokens: int | None
     ) -> AnthropicThinkingParam | None:
         """Cap a legacy ``thinking.budget_tokens`` below ``max_tokens`` (Anthropic
@@ -1530,7 +1530,7 @@ class AnthropicConfig(AnthropicModelInfo, BaseConfig):
                         llm_provider=self._resolved_provider,
                     )
                     capped_thinking = (
-                        AnthropicConfig._cap_thinking_budget_to_max_tokens(legacy_thinking, max_tokens)
+                        AnthropicConfig.cap_thinking_budget_to_max_tokens(legacy_thinking, max_tokens)
                         if legacy_thinking is not None
                         else None
                     )

--- a/litellm/llms/anthropic/experimental_pass_through/messages/transformation.py
+++ b/litellm/llms/anthropic/experimental_pass_through/messages/transformation.py
@@ -40,6 +40,11 @@ DROP_UNSUPPORTED_ADAPTIVE_EFFORT_WARNING: Final = (
     "minimum thinking budget."
 )
 
+DROP_UNFITTING_REASONING_EFFORT_WARNING: Final = (
+    "Dropping `thinking` mapped from reasoning_effort=%s for model=%s: max_tokens=%s "
+    "is too small to fit the minimum thinking budget."
+)
+
 
 class AnthropicMessagesConfig(BaseAnthropicMessagesConfig):
     @property
@@ -335,11 +340,15 @@ class AnthropicMessagesConfig(BaseAnthropicMessagesConfig):
         return headers, api_base
 
     @staticmethod
-    def _translate_reasoning_effort_to_anthropic(model: str, optional_params: dict, custom_llm_provider: str) -> None:
+    def _translate_reasoning_effort_to_anthropic(
+        model: str, optional_params: dict, max_tokens: int | None, custom_llm_provider: str
+    ) -> None:
         """Map OpenAI-style ``reasoning_effort`` to native Anthropic params.
 
         Caller-supplied ``thinking`` / ``output_config`` win over the alias.
-        ``effort='none'`` clears both. Invalid efforts raise a 400.
+        ``effort='none'`` clears both. Invalid efforts raise a 400. A mapped
+        thinking budget is capped below ``max_tokens`` and dropped when even
+        the minimum budget cannot fit.
         """
         from litellm.exceptions import BadRequestError as _BadRequestError
         from litellm.llms.anthropic.chat.transformation import (
@@ -365,7 +374,12 @@ class AnthropicMessagesConfig(BaseAnthropicMessagesConfig):
             optional_params.pop("output_config", None)
             return
 
-        optional_params.setdefault("thinking", mapped_thinking)
+        fitted_thinking: Final = AnthropicConfig.cap_thinking_budget_to_max_tokens(mapped_thinking, max_tokens)
+        if fitted_thinking is None:
+            verbose_logger.warning(DROP_UNFITTING_REASONING_EFFORT_WARNING, reasoning_effort, model, max_tokens)
+            return
+
+        optional_params.setdefault("thinking", fitted_thinking)
         if AnthropicModelInfo._is_adaptive_thinking_model(model, custom_llm_provider):
             mapped_effort: Final = REASONING_EFFORT_TO_OUTPUT_CONFIG_EFFORT.get(reasoning_effort)
             if mapped_effort is None:
@@ -510,7 +524,7 @@ class AnthropicMessagesConfig(BaseAnthropicMessagesConfig):
         except _BadRequestError as e:
             raise AnthropicError(message=str(e.message), status_code=400)
         capped_thinking: Final = (
-            AnthropicConfig._cap_thinking_budget_to_max_tokens(legacy_thinking, max_tokens)
+            AnthropicConfig.cap_thinking_budget_to_max_tokens(legacy_thinking, max_tokens)
             if legacy_thinking is not None
             else None
         )
@@ -582,6 +596,7 @@ class AnthropicMessagesConfig(BaseAnthropicMessagesConfig):
         self._translate_reasoning_effort_to_anthropic(
             model=model,
             optional_params=anthropic_messages_optional_request_params,
+            max_tokens=max_tokens,
             custom_llm_provider=self._resolved_provider,
         )
 

--- a/litellm/llms/bedrock/chat/converse_transformation.py
+++ b/litellm/llms/bedrock/chat/converse_transformation.py
@@ -924,7 +924,7 @@ class AmazonConverseConfig(BaseConfig):
                         custom_llm_provider="bedrock",
                     )
                     capped = (
-                        AnthropicConfig._cap_thinking_budget_to_max_tokens(legacy_thinking, max_tokens)
+                        AnthropicConfig.cap_thinking_budget_to_max_tokens(legacy_thinking, max_tokens)
                         if legacy_thinking is not None
                         else None
                     )

--- a/tests/llm_translation/reasoning_effort_grid/grid_spec.py
+++ b/tests/llm_translation/reasoning_effort_grid/grid_spec.py
@@ -103,7 +103,7 @@ def _bedrock_clamps_effort(model: "ModelEntry", effort: str) -> bool:
     return _EFFORT_RANK[effort] > _EFFORT_RANK[model.bedrock_effort_ceiling]
 
 
-def expected(model: ModelEntry, effort: str) -> CellExpectation:
+def expected(route_name: str, model: ModelEntry, effort: str) -> CellExpectation:
     if effort in ("__omit__", "none"):
         if model.mode == "budget":
             return CellExpectation(
@@ -117,6 +117,15 @@ def expected(model: ModelEntry, effort: str) -> CellExpectation:
     if effort in ("xhigh", "max"):
         cap = f"supports_{effort}_reasoning_effort"
         if cap not in model.caps and not _bedrock_clamps_effort(model, effort):
+            if model.mode == "budget" and route_name == "bedrock_invoke_messages":
+                # the /v1/messages path caps the mapped budget below max_tokens
+                # (LIT-6498), so oversized tiers succeed there instead of 400ing
+                return CellExpectation(
+                    status=200,
+                    thinking_type="enabled",
+                    thinking_budget_tokens=BUDGET_MODE_MAX_TOKENS - 1,
+                    max_tokens=BUDGET_MODE_MAX_TOKENS,
+                )
             return CellExpectation(status=400, thinking_type=OMIT)
 
     if model.mode == "adaptive":
@@ -441,5 +450,7 @@ def all_cells() -> List[Tuple[str, ModelEntry, str, CellExpectation]]:
     for route in ROUTES:
         for model in route.models:
             for effort in EFFORTS:
-                cells.append((route.name, model, effort, expected(model, effort)))
+                cells.append(
+                    (route.name, model, effort, expected(route.name, model, effort))
+                )
     return cells

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_anthropic_messages_effort.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_anthropic_messages_effort.py
@@ -10,6 +10,10 @@ from litellm.llms.anthropic.common_utils import AnthropicError
 from litellm.llms.anthropic.experimental_pass_through.messages.transformation import (
     AnthropicMessagesConfig,
 )
+from litellm.llms.openai_like.json_loader import SimpleProviderConfig
+from litellm.llms.openai_like.messages.transformation import (
+    JSONProviderAnthropicMessagesConfig,
+)
 
 
 def _claude_code_payload(effort="medium", max_tokens=8192, **output_config_extra):
@@ -294,3 +298,39 @@ def test_non_adaptive_request_without_effort_is_untouched():
 
     assert "thinking" not in result
     assert "output_config" not in result
+
+
+def test_reasoning_effort_budget_capped_below_max_tokens():
+    result = _transform("claude-haiku-4-5", {"max_tokens": 4000, "reasoning_effort": "xhigh"})
+
+    assert result["thinking"] == {"type": "enabled", "budget_tokens": 3999}
+    assert result["max_tokens"] == 4000
+
+
+def test_reasoning_effort_thinking_dropped_when_min_budget_cannot_fit():
+    result = _transform("claude-haiku-4-5", {"max_tokens": 1024, "reasoning_effort": "xhigh"})
+
+    assert "thinking" not in result
+    assert result["max_tokens"] == 1024
+
+
+def test_reasoning_effort_budget_capped_for_openai_like_messages_upstream():
+    provider = SimpleProviderConfig(
+        "meta",
+        {
+            "base_url": "https://api.meta.ai/v1",
+            "api_key_env": "META_API_KEY",
+            "supported_endpoints": ["/v1/messages"],
+        },
+    )
+
+    result = JSONProviderAnthropicMessagesConfig(provider).transform_anthropic_messages_request(
+        model="muse-spark-1.2",
+        messages=[{"role": "user", "content": "Hello"}],
+        anthropic_messages_optional_request_params={"max_tokens": 4000, "reasoning_effort": "xhigh"},
+        litellm_params={},
+        headers={},
+    )
+
+    assert result["thinking"] == {"type": "enabled", "budget_tokens": 3999}
+    assert result["max_tokens"] == 4000

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_reasoning_effort_translation.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_reasoning_effort_translation.py
@@ -70,7 +70,7 @@ def test_reasoning_effort_none_clears_thinking_and_output_config():
 
 def test_reasoning_effort_on_non_adaptive_model_uses_thinking_budget():
     config = AnthropicMessagesConfig()
-    optional_params = {"max_tokens": 1024, "reasoning_effort": "high"}
+    optional_params = {"max_tokens": 8192, "reasoning_effort": "high"}
 
     result = config.transform_anthropic_messages_request(
         model="claude-opus-4-5",
@@ -86,7 +86,7 @@ def test_reasoning_effort_on_non_adaptive_model_uses_thinking_budget():
     assert isinstance(thinking, dict)
     assert thinking.get("type") == "enabled"
     assert isinstance(thinking.get("budget_tokens"), int)
-    assert thinking["budget_tokens"] >= 1024
+    assert 1024 <= thinking["budget_tokens"] < result["max_tokens"]
 
 
 @pytest.mark.parametrize("bad_effort", ["invalid", "disabled", ""])

--- a/tests/test_litellm/llms/openai_like/messages/test_openai_like_anthropic_messages_transformation.py
+++ b/tests/test_litellm/llms/openai_like/messages/test_openai_like_anthropic_messages_transformation.py
@@ -254,7 +254,7 @@ def test_request_maps_reasoning_effort_to_thinking(config):
         model="claude-sonnet-4-20250514",
         messages=[{"role": "user", "content": "hi"}],
         anthropic_messages_optional_request_params={
-            "max_tokens": 1024,
+            "max_tokens": 8192,
             "reasoning_effort": "medium",
         },
         litellm_params=GenericLiteLLMParams(),
@@ -264,6 +264,7 @@ def test_request_maps_reasoning_effort_to_thinking(config):
     assert "reasoning_effort" not in payload
     assert isinstance(payload.get("thinking"), dict)
     assert payload["thinking"].get("type") == "enabled"
+    assert payload["thinking"]["budget_tokens"] < payload["max_tokens"]
 
 
 def test_passthrough_disables_anthropic_beta_filtering(config):


### PR DESCRIPTION
## TLDR

Problem this solves:

- `reasoning_effort` on `/v1/messages` maps to a fixed thinking budget
- when that budget is >= the request's `max_tokens`, non-adaptive upstreams 400
- Claude Code pointed at such a deployment fails every turn

How it solves it:

- cap the mapped budget below `max_tokens` before sending
- drop `thinking` entirely when even the minimum budget cannot fit
- regression tests in the mapped test files
- live reasoning-effort grid now expects capped success on the messages route

## User Flow

Before: a developer using Claude Code against a `/v1/messages` deployment configured with `reasoning_effort` gets a 400 on every normal turn

1. The proxy admin adds a `/v1/messages` deployment with `reasoning_effort: xhigh` in its `litellm_params`
2. A developer sends POST https://litellm-domain/v1/messages with `"model": "muse-xhigh", "max_tokens": 4000` and a normal prompt
3. HTTP 400 comes back: `` `thinking.budget_tokens` must be less than `max_tokens` ``
4. In Claude Code pointed at the proxy, the turn shows `API Error: 400` with that same message

After: the same request returns 200 with the answer

1. The proxy admin adds the same `/v1/messages` deployment with `reasoning_effort: xhigh`
2. The developer sends the same POST https://litellm-domain/v1/messages with `"max_tokens": 4000`
3. HTTP 200 comes back with the assistant's answer; the thinking budget on the wire now sits below `max_tokens`
4. The Claude Code turn completes normally, and even `"max_tokens": 1024` returns 200 (extended thinking is skipped when no budget fits)

## Relevant issues

## Linear ticket

Resolves LIT-6498

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Shared setup: no-DB proxy from the worktree (`python litellm/proxy/proxy_cli.py --config lit6498_config.yaml --port 22054`), config's relevant deployment:

```yaml
- model_name: muse-xhigh
  litellm_params:
    model: meta/muse-spark-1.2
    api_key: os.environ/META_API_KEY
    reasoning_effort: xhigh
```

Claude Code v2.1.251 driven interactively under tmux with `ANTHROPIC_BASE_URL=http://127.0.0.1:<port>`, `ANTHROPIC_AUTH_TOKEN=$KEY`, `ANTHROPIC_MODEL=muse-xhigh`, `ANTHROPIC_SMALL_FAST_MODEL=muse-xhigh`, `ANTHROPIC_DEFAULT_HAIKU_MODEL=muse-xhigh`, `CLAUDE_CODE_MAX_OUTPUT_TOKENS=4000`, `MAX_THINKING_TOKENS=0`

Upstream controls straight to `https://api.meta.ai/v1/messages` (no LiteLLM), pinning the blame: same body with no `thinking` returns HTTP 200; `"thinking": {"type": "enabled", "budget_tokens": 8192}` with `"max_tokens": 4000` (what LiteLLM forwards today) returns HTTP 400 with `` `thinking.budget_tokens` must be less than `max_tokens` ``; `budget_tokens: 3999` with `max_tokens: 4000` (the capped shape) returns HTTP 200

### Before (5c034fda74)

#### curl: POST /v1/messages, max_tokens 4000

1. `curl -sS -w "\nHTTP %{http_code}\n" http://127.0.0.1:29814/v1/messages -H "Authorization: Bearer $KEY" -H "content-type: application/json" -d '{"model":"muse-xhigh","max_tokens":4000,"messages":[{"role":"user","content":"implement a distributed token bucket rate limiter on Redis, correct under concurrency"}]}'`
2. Output: `{"error":{"message":"litellm.BadRequestError: MetaException - {\"error\":{\"message\":\"`thinking.budget_tokens` must be less than `max_tokens`\",\"type\":\"invalid_request_error\"},\"type\":\"error\"}...","code":"400"}}` then `HTTP 400`
3. Control on the same proxy with `"max_tokens": 16000` (budget fits): `HTTP 200`

#### Claude Code turn

1. In the tmux Claude Code session, type: `implement a distributed token bucket rate limiter on Redis, correct under concurrency`
2. The turn fails visibly: `⏺ API Error: 400 litellm.BadRequestError: MetaException - {"error":{"message":"`thinking.budget_tokens` must be less than `max_tokens`","type":"invalid_request_error"},"type":"error"}`

### After (36c036cd2d)

#### curl: POST /v1/messages, max_tokens 4000

1. `curl -sS -w "\nHTTP %{http_code}\n" http://127.0.0.1:22054/v1/messages -H "Authorization: Bearer $KEY" -H "content-type: application/json" -d '{"model":"muse-xhigh","max_tokens":4000,"messages":[{"role":"user","content":"implement a distributed token bucket rate limiter on Redis, correct under concurrency"}]}'`
2. Output: `{"content":[{"data":"Q-PaDg...` (a full assistant answer) then `HTTP 200`
3. Same request with `"max_tokens": 1024` (no budget can fit below it): `HTTP 200`, thinking dropped instead of 400

#### Claude Code turn

1. In the tmux Claude Code session, type the same prompt
2. The turn proceeds normally (several assistant messages, a tool call) and pauses at an ordinary permission prompt, no API error anywhere in the session

## Type

🐛 Bug Fix

## Caveats (if any)

### Low

- with a tight `max_tokens`, the capped budget leaves little room for the visible answer
  - same policy the shared cap already applies on Bedrock converse and adaptive thinking
  - strictly better than the hard 400 before; raising `max_tokens` restores full room
- `/v1/chat/completions` maps `reasoning_effort` to a budget with no cap in code
  - pre-existing and untouched here; not reproduced live, so left as follow-up
- `cap_thinking_budget_to_max_tokens` went public so the messages path can reuse it
- a client-sent `thinking` block is passed through untouched, so an explicit oversized budget still 400s upstream, by design

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

live-pr-risk CHECKED at 36c036cd2d: PASS. The changed function's one caller serves `/v1/messages` for Anthropic-format and JSON providers, driven live base vs head on a real proxy against the real provider with curl and an interactive Claude Code session (400 -> 200, min-budget drop leg, upstream controls pinning blame); the helper rename has exactly its three intended callers and zero stale references repo-wide; Bedrock converse and the adaptive branch are rename-only and covered by their existing suites; no DB, schema, dashboard, or SDK surface changes; the tip's extra commit only updates the live grid's expectations (nothing under litellm/), re-proven live with the full opus-4-5 invoke row on both Bedrock routes (22 cells) plus the proxy legs re-captured at the tip

- [x] 36c036cd2d passes /live-pr-risk

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Request-shaping only on the `/v1/messages` reasoning_effort path; behavior is degrade (cap or drop thinking) rather than fail, with no auth or data-model changes.
> 
> **Overview**
> Fixes **400s on `/v1/messages`** when `reasoning_effort` maps to a `thinking.budget_tokens` that is not strictly less than `max_tokens` (e.g. Claude Code against a proxy with deployment-level `reasoning_effort: xhigh`).
> 
> The messages transform now passes **`max_tokens`** into `_translate_reasoning_effort_to_anthropic`, reuses **`AnthropicConfig.cap_thinking_budget_to_max_tokens`** (promoted from private) to clamp the mapped budget to `max_tokens - 1`, and **omits `thinking`** with a new warning when `max_tokens` cannot fit the minimum thinking budget. Bedrock converse and adaptive-thinking downgrade paths only switch to the public helper name.
> 
> Tests cover cap/drop behavior (including OpenAI-like JSON providers), and the reasoning-effort grid expects **200 with a capped budget** on `bedrock_invoke_messages` where oversized effort tiers would otherwise 400.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 36c036cd2dab3ab4bb5f2d3ee825a7a33974e147. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->