### PR TITLE
fix(azure): flatten top-level tool schema combinators for Azure Responses GPT-4-family deployments

### DIFF
--- a/litellm/llms/openai/responses/transformation.py
+++ b/litellm/llms/openai/responses/transformation.py
@@ -33,6 +33,7 @@ else:
 
 _NO_TOOL_UPDATE: Final[Mapping[str, object]] = MappingProxyType({})
 _MODEL_FAMILIES_REJECTING_TOP_LEVEL_SCHEMA_COMBINATORS: Final = ("gpt-4", "gpt-3.5", "chatgpt-4o", "o1", "o3", "o4")
+_PROVIDERS_WITH_COMBINATOR_REJECTING_VALIDATOR: Final = frozenset({LlmProviders.AZURE, LlmProviders.OPENAI})
 
 
 class OpenAIResponsesAPIConfig(BaseResponsesAPIConfig):
@@ -172,7 +173,9 @@ class OpenAIResponsesAPIConfig(BaseResponsesAPIConfig):
         input = self._validate_input_param(input)
         tools = response_api_optional_request_params.get("tools")
         input, tools = self.remove_cache_control_flag_from_input_and_tools(model=model, input=input, tools=tools)
-        sanitized_tools: Final = self._flatten_tool_schema_combinators_for_openai(model=model, tools=tools)
+        sanitized_tools: Final = self._flatten_tool_schema_combinators_for_openai(
+            model=model, tools=tools, litellm_params=litellm_params
+        )
         if sanitized_tools is not None:
             response_api_optional_request_params["tools"] = sanitized_tools
         final_request_params: Final = dict(
@@ -217,6 +220,7 @@ class OpenAIResponsesAPIConfig(BaseResponsesAPIConfig):
         self,
         model: str,
         tools: list[ALL_RESPONSES_API_TOOL_PARAMS] | None,  # mutable-ok: request tools are a JSON list
+        litellm_params: GenericLiteLLMParams,
     ) -> list[ALL_RESPONSES_API_TOOL_PARAMS] | None:  # mutable-ok: request tools are a JSON list
         """Flatten top-level schema combinators only where OpenAI's validator rejects them.
 
@@ -224,10 +228,14 @@ class OpenAIResponsesAPIConfig(BaseResponsesAPIConfig):
         Codex talks to natively) accept them, and so do GPT-5 and later models,
         which also call tools better with the union intact. Codex wraps MCP tools
         inside namespace entries, so nested ``tools`` arrays are walked too.
+        Azure OpenAI shares the validator but names deployments arbitrarily, so
+        the router's declared ``model_info.base_model`` wins over the deployment
+        name and an unrecognized name without one is left untouched.
         """
-        if tools is None or self.custom_llm_provider != LlmProviders.OPENAI:
+        if tools is None or self.custom_llm_provider not in _PROVIDERS_WITH_COMBINATOR_REJECTING_VALIDATOR:
             return tools
-        if not self._rejects_top_level_schema_combinators(model):
+        gate_model: Final = self._combinator_gate_model(model=model, litellm_params=litellm_params)
+        if not self._rejects_top_level_schema_combinators(gate_model):
             return tools
         flattened: Final = [  # mutable-ok: request tools are a JSON list
             self._flattened_tool_or_passthrough(tool) for tool in tools
@@ -243,6 +251,12 @@ class OpenAIResponsesAPIConfig(BaseResponsesAPIConfig):
         bare_model: Final = model.split("/")[-1]
         base_model: Final = bare_model.split(":")[1] if bare_model.startswith("ft:") else bare_model
         return base_model.startswith(_MODEL_FAMILIES_REJECTING_TOP_LEVEL_SCHEMA_COMBINATORS)
+
+    @staticmethod
+    def _combinator_gate_model(model: str, litellm_params: GenericLiteLLMParams) -> str:
+        model_info: Final[object] = getattr(litellm_params, "model_info", None)
+        base_model: Final[object] = model_info.get("base_model") if isinstance(model_info, dict) else None
+        return base_model if isinstance(base_model, str) and base_model else model
 
     @staticmethod
     def _flattened_tool_entry(
@@ -714,7 +728,9 @@ class OpenAIResponsesAPIConfig(BaseResponsesAPIConfig):
         input = self._validate_input_param(input)
         tools = response_api_optional_request_params.get("tools")
         input, tools = self.remove_cache_control_flag_from_input_and_tools(model=model, input=input, tools=tools)
-        sanitized_tools: Final = self._flatten_tool_schema_combinators_for_openai(model=model, tools=tools)
+        sanitized_tools: Final = self._flatten_tool_schema_combinators_for_openai(
+            model=model, tools=tools, litellm_params=litellm_params
+        )
         if sanitized_tools is not None:
             response_api_optional_request_params["tools"] = sanitized_tools
         data: Final = dict(ResponsesAPIRequestParams(model=model, input=input, **response_api_optional_request_params))

--- a/tests/test_litellm/llms/azure/response/test_azure_transformation.py
+++ b/tests/test_litellm/llms/azure/response/test_azure_transformation.py
@@ -537,3 +537,79 @@ class TestAzureResponsesAPIConfig:
         """
         supported = self.config.get_supported_openai_params(self.model)
         assert "context_management" not in supported
+
+    def _anyof_tool(self):
+        return {
+            "type": "function",
+            "name": "automation_update",
+            "description": "Update an automation",
+            "parameters": {
+                "type": "object",
+                "anyOf": [
+                    {
+                        "properties": {"id": {"type": "string"}, "enabled": {"type": "boolean"}},
+                        "required": ["id", "enabled"],
+                    },
+                    {
+                        "properties": {"id": {"type": "string"}, "schedule": {"type": "string"}},
+                        "required": ["id", "schedule"],
+                    },
+                ],
+                "properties": {"id": {"type": "string"}},
+                "required": ["id"],
+            },
+        }
+
+    def test_azure_flattens_top_level_anyof_for_gpt4_family_deployment_name(self):
+        result = self.config.transform_responses_api_request(
+            model="gpt-4o",
+            input="hi",
+            response_api_optional_request_params={"tools": [self._anyof_tool()]},
+            litellm_params=GenericLiteLLMParams(),
+            headers={},
+        )
+
+        parameters = result["tools"][0]["parameters"]
+        assert "anyOf" not in parameters
+        assert parameters["type"] == "object"
+        assert set(parameters["properties"]) == {"id", "enabled", "schedule"}
+        assert parameters["required"] == ["id"]
+
+    def test_azure_flattens_via_base_model_for_arbitrary_deployment_name(self):
+        result = self.config.transform_responses_api_request(
+            model="my-eastus-deployment",
+            input="hi",
+            response_api_optional_request_params={"tools": [self._anyof_tool()]},
+            litellm_params=GenericLiteLLMParams(model_info={"base_model": "azure/gpt-4o"}),
+            headers={},
+        )
+
+        assert "anyOf" not in result["tools"][0]["parameters"]
+
+    def test_azure_keeps_combinators_for_gpt5_base_model(self):
+        tool = self._anyof_tool()
+
+        result = self.config.transform_responses_api_request(
+            model="my-eastus-deployment",
+            input="hi",
+            response_api_optional_request_params={"tools": [tool]},
+            litellm_params=GenericLiteLLMParams(model_info={"base_model": "azure/gpt-5.4-mini"}),
+            headers={},
+        )
+
+        assert result["tools"][0] is tool
+        assert "anyOf" in result["tools"][0]["parameters"]
+
+    def test_azure_keeps_combinators_for_unrecognized_deployment_without_base_model(self):
+        tool = self._anyof_tool()
+
+        result = self.config.transform_responses_api_request(
+            model="my-eastus-deployment",
+            input="hi",
+            response_api_optional_request_params={"tools": [tool]},
+            litellm_params=GenericLiteLLMParams(),
+            headers={},
+        )
+
+        assert result["tools"][0] is tool
+        assert "anyOf" in result["tools"][0]["parameters"]


### PR DESCRIPTION
## TLDR

Problem this solves:

- Azure OpenAI Responses tools with top-level anyOf/oneOf/allOf still 400 through the proxy
- #38792 fixed this for `openai/` models only; its gate skips `azure/`
- Azure GPT-4-family rejects those schemas; GPT-5-family accepts them

How it solves it:

- Open #38792's flatten gate to Azure OpenAI as well
- Deployment names are arbitrary, so `model_info.base_model` wins over the name when declared
- Unrecognized deployment name with no `base_model` stays untouched (never lossy-flattens a working GPT-5 deployment)

## User Flow

Before: a Codex CLI user pointed at the proxy with an Azure OpenAI GPT-4-family deployment cannot use an MCP tool whose input schema is a top-level anyOf union

1. They configure Codex CLI with `base_url = "http://localhost:4000/v1"`, `wire_api = "responses"`, model `azure-gpt-4o`, and an MCP server whose `automation_update` tool declares `"anyOf"` at the top level of its input schema
2. They ask: Update automation abc123 to be enabled using the automation_update tool.
3. Codex sends POST http://localhost:4000/v1/responses and gets back 400 `Invalid schema for function 'automation_update': schema must have type 'object' and not have 'oneOf'/'anyOf'/'allOf'/'enum'/'const'/'not' at the top level` (code `invalid_function_parameters`)
4. The session dead-ends on that error; the same tool works when the model entry is `openai/gpt-4o`

After: the same Codex session on the Azure deployment calls the tool and finishes

1. Same Codex CLI config, same MCP tool, same prompt
2. Codex sends the same POST http://localhost:4000/v1/responses; the request Azure receives carries the flattened schema, and the model calls `automation_update({"id":"abc123","enabled":true})`
3. Codex runs the tool, prints "automation updated", and answers normally
4. A GPT-5-family deployment (`azure-gpt-5.4-mini`) still gets the anyOf union intact on the wire and keeps calling the tool with it

## Relevant issues

## Linear ticket

Resolves LIT-6500

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Stacked on #38792 (base branch `litellm_fix_responses_anyof_tool_schema`); retargets to `litellm_internal_staging` once it lands

Shared setup: proxy from the respective commit with two Azure OpenAI deployments, plus the anyOf tool from #38792's proof

```yaml
model_list:
  - model_name: azure-gpt-4o
    litellm_params:
      model: azure/gpt-4o
      api_base: os.environ/AZURE_FOUNDRY_API_BASE
      api_key: os.environ/AZURE_FOUNDRY_API_KEY
      api_version: preview
      additional_drop_params: ["reasoning"]
  - model_name: azure-gpt-5.4-mini
    litellm_params:
      model: azure/gpt-5.4-mini
      api_base: os.environ/AZURE_FOUNDRY_API_BASE
      api_key: os.environ/AZURE_FOUNDRY_API_KEY
      api_version: preview
```

```json
{"type": "function", "name": "automation_update", "description": "Update an automation", "parameters": {"type": "object", "anyOf": [{"properties": {"id": {"type": "string"}, "enabled": {"type": "boolean"}}, "required": ["id", "enabled"]}, {"properties": {"id": {"type": "string"}, "schedule": {"type": "string"}}, "required": ["id", "schedule"]}], "properties": {"id": {"type": "string"}}, "required": ["id"]}}
```

### Before (9448293903)

#### Codex CLI 0.145.0, MCP anyOf tool, model azure-gpt-4o

1. `CODEX_HOME=... LITELLM_CODEX_KEY=sk-...-master codex` (`wire_api = "responses"`, `base_url = "http://127.0.0.1:40464/v1"`), prompt: Update automation abc123 to be enabled using the automation_update tool.
2. Session dead-ends: `litellm.BadRequestError: AzureException BadRequestError - "Invalid schema for function 'automation_update': schema must have type 'object' and not have 'oneOf'/'anyOf'/'allOf'/'enum'/'const'/'not' at the top level.", "param": "tools[9].tools[0].parameters", "code": "invalid_function_parameters"`

#### curl /v1/responses, azure-gpt-4o

1. `curl -s http://127.0.0.1:40464/v1/responses -H 'Authorization: Bearer sk-...-master' -H 'Content-Type: application/json' -d '{"model": "azure-gpt-4o", "input": "Update automation abc123 to be enabled using the automation_update tool.", "tools": [<tool above>]}'`
2. HTTP 400, same `invalid_function_parameters` error at `tools[0].parameters`

#### curl /v1/responses, azure-gpt-5.4-mini

1. Same curl with `"model": "azure-gpt-5.4-mini"`
2. HTTP 200 `completed`, `function_call automation_update {"id":"abc123","enabled":true}`; `--detailed_debug` shows the outbound request keeps `anyOf` intact

### After (af186eaaf3)

#### Codex CLI 0.145.0, MCP anyOf tool, model azure-gpt-4o

1. Same Codex session against the fix proxy (port 40919), same prompt
2. `Called codex_app.automation_update({"id":"abc123","enabled":true})` -> `automation updated` -> "The automation with ID abc123 has been successfully updated to be enabled."

#### curl /v1/responses, azure-gpt-4o

1. Same curl against port 40919
2. HTTP 200 `completed`, `function_call automation_update`; outbound request shows the flattened schema: `{"type": "object", "properties": {"id": ..., "schedule": ..., "enabled": ...}, "required": ["id"]}`, no `anyOf`

#### curl /v1/responses, azure-gpt-5.4-mini

1. Same curl with `"model": "azure-gpt-5.4-mini"`
2. HTTP 200 `completed`, `function_call automation_update {"id":"abc123","enabled":true}`; outbound request still carries `anyOf` untouched

## Type

🐛 Bug Fix

## Caveats (if any)

### Medium

- A deployment name that hints no family (e.g. `my-eastus-deployment`) still 400s unless `model_info.base_model` is declared

### Low

- Flattening is lossy by design (merges union branches); same tradeoff #38792 ships for OpenAI
- Stacked on #38792; do not merge before it, retarget to staging after

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

- [x] af186eaaf3ad0104f25820bee976dfaae8b71e70 passes /live-pr-risk: blast radius is AZURE-only gate opening plus declared-base_model precedence on the OPENAI family gate; all other Responses subclasses unchanged; Azure /v1/responses A/B-proven live both families

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to Azure/OpenAI Responses tool sanitization with conservative passthrough when the model family is unknown; flattening behavior matches the existing OpenAI path.
> 
> **Overview**
> Extends the Responses API **top-level `anyOf`/`oneOf`/`allOf` tool-parameter flattening** (previously OpenAI-only) to **Azure OpenAI**, which uses the same strict validator and was still returning `invalid_function_parameters` for MCP-style unions on GPT-4-family deployments.
> 
> The flatten gate now runs when `custom_llm_provider` is OpenAI **or** Azure. For Azure’s arbitrary deployment names, **`litellm_params.model_info.base_model`** is used to decide GPT-4-family vs GPT-5-family instead of the deployment string; if the name is unrecognized and no `base_model` is set, tools are **left unchanged** so GPT-5 deployments are not lossy-flattened. The same logic is wired through normal **`/v1/responses`** and **compact** request transforms via an added `litellm_params` argument on `_flatten_tool_schema_combinators_for_openai`.
> 
> Azure transformation tests cover flattening by deployment name, by `base_model`, preserving combinators for GPT-5 `base_model`, and the no-`base_model` passthrough case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit af186eaaf3ad0104f25820bee976dfaae8b71e70. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
