### PR TITLE
fix(auth): quiet malformed virtual key rejections to stdout

### DIFF
--- a/litellm/_logging.py
+++ b/litellm/_logging.py
@@ -264,13 +264,17 @@ def _plain_log_format(stdout: TextIO | None, stderr: TextIO | None) -> str:
 
 
 class LevelRoutingStreamHandler(logging.StreamHandler):
-    """Writes records below WARNING to stdout and WARNING and above to stderr.
+    """Writes records below WARNING and invalid-key warnings to stdout, others to stderr.
 
     Collectors that derive severity from the stream report every stderr line as an error.
+    Invalid-key warnings route to stdout so LITELLM_LOG=ERROR can suppress them.
     """
 
     def emit(self, record: logging.LogRecord) -> None:
-        preferred: Final = sys.stdout if record.levelno < logging.WARNING else sys.stderr
+        is_stdout_record: Final = record.levelno < logging.WARNING or (
+            record.levelno == logging.WARNING and record.name == verbose_proxy_stdout_logger.name
+        )
+        preferred: Final = sys.stdout if is_stdout_record else sys.stderr
         if preferred is None or getattr(preferred, "closed", False):
             self.stream = sys.stderr  # rebind-ok: fall back to the pre-fix stream rather than raising per record
         else:
@@ -508,6 +512,9 @@ else:
     handler.setFormatter(formatter)
 
 verbose_proxy_logger = logging.getLogger("LiteLLM Proxy")
+# Malformed virtual key rejections log through this child; LevelRoutingStreamHandler
+# writes its WARNING records to stdout. It has no handler or level of its own.
+verbose_proxy_stdout_logger: Final = verbose_proxy_logger.getChild("stdout")
 verbose_router_logger = logging.getLogger("LiteLLM Router")
 verbose_logger = logging.getLogger("LiteLLM")
 
@@ -520,6 +527,7 @@ verbose_logger.addHandler(handler)
 # handlers (JSON mode, uvicorn log config, a host app's root handler).
 verbose_router_logger.addFilter(_stdout_truncation_filter)
 verbose_proxy_logger.addFilter(_stdout_truncation_filter)
+verbose_proxy_stdout_logger.addFilter(_stdout_truncation_filter)
 verbose_logger.addFilter(_stdout_truncation_filter)
 
 
@@ -683,6 +691,7 @@ def _turn_on_json():
     - Adds a JSON formatter to all loggers
     """
     handler: Final = LevelRoutingStreamHandler()
+    handler.setLevel(numeric_level)
     handler.setFormatter(JsonFormatter())
     _initialize_loggers_with_handler(handler)
     # Set up exception handlers
@@ -700,12 +709,14 @@ def _disable_debugging():
     verbose_logger.disabled = True
     verbose_router_logger.disabled = True
     verbose_proxy_logger.disabled = True
+    verbose_proxy_stdout_logger.disabled = True
 
 
 def _enable_debugging():
     verbose_logger.disabled = False
     verbose_router_logger.disabled = False
     verbose_proxy_logger.disabled = False
+    verbose_proxy_stdout_logger.disabled = False
 
 
 def print_verbose(print_statement):

--- a/litellm/constants.py
+++ b/litellm/constants.py
@@ -1409,6 +1409,12 @@ DEFAULT_SOFT_BUDGET: Final = float(
 )  # by default all litellm proxy keys have a soft budget of 50.0
 # makes it clear this is a rate limit error for a litellm virtual key
 RATE_LIMIT_ERROR_MESSAGE_FOR_VIRTUAL_KEY: Final = "LiteLLM Virtual Key user_api_key_hash"
+# Prefix of the 401 raised when a submitted virtual key is not shaped like one.
+INVALID_VIRTUAL_KEY_ERROR_MESSAGE: Final = "LiteLLM Virtual Key expected"
+# Attribute stamped on that 401 at its raise site so log routing recognises it by
+# provenance. Message text is caller-influenceable on other 401s, so it must not
+# be used to classify.
+INVALID_VIRTUAL_KEY_ERROR_MARKER: Final = "_litellm_invalid_virtual_key_error"
 
 # Python garbage collection threshold configuration
 # Format: "gen0,gen1,gen2" e.g., "1000,50,50"

--- a/litellm/proxy/auth/auth_exception_handler.py
+++ b/litellm/proxy/auth/auth_exception_handler.py
@@ -2,13 +2,14 @@
 Handles Authentication Errors
 """
 
+import logging
 from collections.abc import Mapping
 from typing import TYPE_CHECKING, Any, Final
 
 from fastapi import HTTPException, Request, status
 
 import litellm
-from litellm._logging import verbose_proxy_logger
+from litellm._logging import verbose_proxy_logger, verbose_proxy_stdout_logger
 from litellm.constants import EMPTY_MAPPING
 from litellm.integrations.otel.runtime import seed_request_identity
 from litellm.litellm_core_utils.core_helpers import is_expected_client_error
@@ -18,7 +19,11 @@ from litellm.proxy._types import (
     ProxyException,
     UserAPIKeyAuth,
 )
-from litellm.proxy.auth.auth_utils import _get_request_ip_address
+from litellm.proxy.auth.auth_utils import (
+    _get_request_ip_address,
+    is_invalid_virtual_key_error,
+    mark_invalid_virtual_key_error,
+)
 from litellm.proxy.db.exception_handler import PrismaDBExceptionHandler
 from litellm.types.services import ServiceTypes
 
@@ -34,6 +39,41 @@ if TYPE_CHECKING:
     Span = _Span | Any
 else:
     Span = Any
+
+
+def _as_proxy_exception(e: Exception) -> ProxyException:
+    """Convert an authentication failure into the ProxyException the client receives."""
+    if isinstance(e, litellm.BudgetExceededError):
+        return ProxyException(
+            message=e.message,
+            type=ProxyErrorTypes.budget_exceeded,
+            param=None,
+            code=getattr(e, "status_code", status.HTTP_429_TOO_MANY_REQUESTS),
+        )
+    if isinstance(e, HTTPException):
+        return ProxyException(
+            message=getattr(e, "detail", f"Authentication Error({e})"),
+            type=ProxyErrorTypes.auth_error,
+            param=getattr(e, "param", "None"),
+            code=getattr(e, "status_code", status.HTTP_401_UNAUTHORIZED),
+        )
+    if isinstance(e, ProxyException):
+        return e
+    if PrismaDBExceptionHandler.is_database_service_unavailable_error(e):
+        return ProxyException(
+            message=(
+                "Service Unavailable, the authentication database is temporarily unreachable. Please retry shortly."
+            ),
+            type=ProxyErrorTypes.no_db_connection,
+            param="None",
+            code=status.HTTP_503_SERVICE_UNAVAILABLE,
+        )
+    return ProxyException(
+        message="Authentication Error, " + str(e),
+        type=ProxyErrorTypes.auth_error,
+        param=getattr(e, "param", "None"),
+        code=status.HTTP_401_UNAUTHORIZED,
+    )
 
 
 def _with_requester_ip_address(request_data: dict[str, object], requester_ip: str | None) -> dict[str, object]:
@@ -110,16 +150,21 @@ class UserAPIKeyAuthExceptionHandler:
                 request=request,
                 use_x_forwarded_for=general_settings.get("use_x_forwarded_for") is True,
             )
-            log_fn: Final = (
-                verbose_proxy_logger.error
-                if is_expected_client_error(e) and not litellm.log_client_error_tracebacks
-                else verbose_proxy_logger.exception
-            )
-            log_fn(
+
+            # Log authentication failures before identity seeding and callbacks, so the log
+            # survives a raising callback pipeline. Classify and route malformed virtual-key
+            # rejections to WARNING on stdout (suppressible via LITELLM_LOG=ERROR).
+            log_extra: Final = {"requester_ip": requester_ip}
+            is_invalid_virtual_key: Final = is_invalid_virtual_key_error(e)
+            is_quiet_log: Final = is_invalid_virtual_key and not litellm.log_client_error_tracebacks
+            logger: Final = verbose_proxy_stdout_logger if is_quiet_log else verbose_proxy_logger
+            logger.log(
+                logging.WARNING if is_quiet_log else logging.ERROR,
                 "litellm.proxy.proxy_server.user_api_key_auth(): Exception occured - %s\nRequester IP Address:%s",
                 e,
                 requester_ip,
-                extra={"requester_ip": requester_ip},
+                exc_info=True if litellm.log_client_error_tracebacks or not is_expected_client_error(e) else None,
+                extra=log_extra,
             )
 
             # Log this exception to OTEL, Datadog etc. Reuse the identity resolved
@@ -167,35 +212,13 @@ class UserAPIKeyAuthExceptionHandler:
             if transformed_exception is not None:
                 e = transformed_exception
 
-            if isinstance(e, litellm.BudgetExceededError):
-                raise ProxyException(
-                    message=e.message,
-                    type=ProxyErrorTypes.budget_exceeded,
-                    param=None,
-                    code=getattr(e, "status_code", status.HTTP_429_TOO_MANY_REQUESTS),
+            final_exception: Final = mark_invalid_virtual_key_error(_as_proxy_exception(e), is_invalid_virtual_key)
+            # If a quiet-logged malformed-key transform yields non-401, escalate to ERROR
+            if is_quiet_log and str(final_exception.code) != str(status.HTTP_401_UNAUTHORIZED):
+                verbose_proxy_logger.error(
+                    "litellm.proxy.proxy_server.user_api_key_auth(): Exception occured - %s\nRequester IP Address:%s",
+                    final_exception,
+                    requester_ip,
+                    extra=log_extra,
                 )
-            if isinstance(e, HTTPException):
-                raise ProxyException(
-                    message=getattr(e, "detail", f"Authentication Error({e})"),
-                    type=ProxyErrorTypes.auth_error,
-                    param=getattr(e, "param", "None"),
-                    code=getattr(e, "status_code", status.HTTP_401_UNAUTHORIZED),
-                )
-            elif isinstance(e, ProxyException):
-                raise e
-            if PrismaDBExceptionHandler.is_database_service_unavailable_error(e):
-                raise ProxyException(
-                    message=(
-                        "Service Unavailable, the authentication database is "
-                        "temporarily unreachable. Please retry shortly."
-                    ),
-                    type=ProxyErrorTypes.no_db_connection,
-                    param="None",
-                    code=status.HTTP_503_SERVICE_UNAVAILABLE,
-                )
-            raise ProxyException(
-                message="Authentication Error, " + str(e),
-                type=ProxyErrorTypes.auth_error,
-                param=getattr(e, "param", "None"),
-                code=status.HTTP_401_UNAUTHORIZED,
-            )
+            raise final_exception

--- a/litellm/proxy/auth/auth_utils.py
+++ b/litellm/proxy/auth/auth_utils.py
@@ -33,6 +33,43 @@ from litellm.types.passthrough_endpoints.pass_through_endpoints import (
 from litellm.types.router import CONFIGURABLE_CLIENTSIDE_AUTH_PARAMS
 from litellm.types.utils import CustomPricingLiteLLMParams
 
+INVALID_VIRTUAL_KEY_ERROR_MESSAGE: Final = "LiteLLM Virtual Key expected"
+_INVALID_VIRTUAL_KEY_ERROR_MARKER: Final = "_litellm_invalid_virtual_key_error"
+
+
+def is_invalid_virtual_key_error(exception: BaseException | None) -> bool:
+    """True when an authentication error rejects a malformed virtual key."""
+    if not isinstance(exception, (HTTPException, ProxyException)):
+        return False
+
+    code: Final[object] = getattr(exception, "code", None)
+    status_code: Final[object] = code if code is not None else getattr(exception, "status_code", None)
+    if str(status_code) != str(status.HTTP_401_UNAUTHORIZED):
+        return False
+
+    if getattr(exception, _INVALID_VIRTUAL_KEY_ERROR_MARKER, False) is True:
+        return True
+
+    message: Final = getattr(exception, "detail", None) or getattr(exception, "message", "")
+    return INVALID_VIRTUAL_KEY_ERROR_MESSAGE in str(message)
+
+
+def mark_invalid_virtual_key_error(exception: ProxyException, is_invalid_virtual_key: bool) -> ProxyException:
+    """Return an independently marked malformed-key exception after callback transformations."""
+    if not is_invalid_virtual_key or str(exception.code) != str(status.HTTP_401_UNAUTHORIZED):
+        return exception
+    marked_exception: Final = ProxyException(
+        message=exception.message,
+        type=exception.type,
+        param=exception.param,
+        code=exception.code,
+        headers=exception.headers.copy(),
+        openai_code=None if exception.openai_code is None else str(exception.openai_code),
+        provider_specific_fields=exception.provider_specific_fields,
+    )
+    setattr(marked_exception, _INVALID_VIRTUAL_KEY_ERROR_MARKER, True)
+    return marked_exception
+
 
 def _get_request_ip_address(request: Request, use_x_forwarded_for: bool | None = False) -> str | None:
     client_ip = None

--- a/litellm/proxy/auth/auth_utils.py
+++ b/litellm/proxy/auth/auth_utils.py
@@ -15,6 +15,7 @@ from litellm._logging import verbose_proxy_logger
 from litellm.constants import (
     BATCH_ENQUEUED_TOKEN_LIMIT_METADATA_KEY,
     EMPTY_MAPPING,
+    INVALID_VIRTUAL_KEY_ERROR_MARKER,
     MINIMUM_CUSTOM_KEY_LENGTH,
     STANDARD_CUSTOMER_ID_HEADERS,
 )
@@ -33,12 +34,16 @@ from litellm.types.passthrough_endpoints.pass_through_endpoints import (
 from litellm.types.router import CONFIGURABLE_CLIENTSIDE_AUTH_PARAMS
 from litellm.types.utils import CustomPricingLiteLLMParams
 
-INVALID_VIRTUAL_KEY_ERROR_MESSAGE: Final = "LiteLLM Virtual Key expected"
-_INVALID_VIRTUAL_KEY_ERROR_MARKER: Final = "_litellm_invalid_virtual_key_error"
-
 
 def is_invalid_virtual_key_error(exception: BaseException | None) -> bool:
-    """True when an authentication error rejects a malformed virtual key."""
+    """True when an authentication error rejects a malformed virtual key.
+
+    Classifies only by the marker stamped where that 401 is raised. Message
+    content is never inspected: other 401s interpolate caller-supplied values
+    (vector store ids, organization ids) into their messages, so a phrase
+    match would let a request body demote an authorization failure to the
+    quiet log path.
+    """
     if not isinstance(exception, (HTTPException, ProxyException)):
         return False
 
@@ -47,11 +52,7 @@ def is_invalid_virtual_key_error(exception: BaseException | None) -> bool:
     if str(status_code) != str(status.HTTP_401_UNAUTHORIZED):
         return False
 
-    if getattr(exception, _INVALID_VIRTUAL_KEY_ERROR_MARKER, False) is True:
-        return True
-
-    message: Final = getattr(exception, "detail", None) or getattr(exception, "message", "")
-    return INVALID_VIRTUAL_KEY_ERROR_MESSAGE in str(message)
+    return getattr(exception, INVALID_VIRTUAL_KEY_ERROR_MARKER, False) is True
 
 
 def mark_invalid_virtual_key_error(exception: ProxyException, is_invalid_virtual_key: bool) -> ProxyException:
@@ -67,7 +68,7 @@ def mark_invalid_virtual_key_error(exception: ProxyException, is_invalid_virtual
         openai_code=None if exception.openai_code is None else str(exception.openai_code),
         provider_specific_fields=exception.provider_specific_fields,
     )
-    setattr(marked_exception, _INVALID_VIRTUAL_KEY_ERROR_MARKER, True)
+    setattr(marked_exception, INVALID_VIRTUAL_KEY_ERROR_MARKER, True)
     return marked_exception
 
 

--- a/litellm/proxy/auth/user_api_key_auth.py
+++ b/litellm/proxy/auth/user_api_key_auth.py
@@ -19,6 +19,7 @@ import fastapi
 import orjson
 from fastapi import HTTPException, Request, WebSocket, status
 from fastapi.security.api_key import APIKeyHeader
+from starlette.exceptions import WebSocketException
 
 import litellm
 from litellm._logging import verbose_logger, verbose_proxy_logger
@@ -60,11 +61,13 @@ from litellm.proxy.auth.auth_checks import (
 from litellm.proxy.auth.auth_exception_handler import UserAPIKeyAuthExceptionHandler
 from litellm.proxy.auth.auth_method import AuthMethod
 from litellm.proxy.auth.auth_utils import (
+    INVALID_VIRTUAL_KEY_ERROR_MESSAGE,
     abbreviate_api_key,
     get_end_user_id_from_request_body,
     get_model_from_request,
     get_request_route,
     get_request_route_template,
+    is_invalid_virtual_key_error,
     iter_request_fallback_targets,
     normalize_request_route,
     pre_db_read_auth_checks,
@@ -539,6 +542,8 @@ async def user_api_key_auth_websocket(websocket: WebSocket):
     try:
         return await user_api_key_auth(request=request, api_key=f"Bearer {api_key}")
     except Exception as e:
+        if is_invalid_virtual_key_error(e):
+            raise WebSocketException(code=status.WS_1008_POLICY_VIOLATION)
         verbose_proxy_logger.exception(e)
         await websocket.close(code=status.WS_1008_POLICY_VIOLATION)
         raise HTTPException(status_code=403, detail=str(e))
@@ -1870,7 +1875,7 @@ async def _user_api_key_auth_builder(
                     raise HTTPException(
                         status_code=status.HTTP_401_UNAUTHORIZED,
                         detail=(
-                            f"LiteLLM Virtual Key expected. Received={_masked_key}, "
+                            f"{INVALID_VIRTUAL_KEY_ERROR_MESSAGE}. Received={_masked_key}, "
                             f"expected to start with 'sk-'.{_hint}"
                         ),
                     )  # prevent token hashes from being used

--- a/litellm/proxy/auth/user_api_key_auth.py
+++ b/litellm/proxy/auth/user_api_key_auth.py
@@ -26,6 +26,8 @@ from litellm._logging import verbose_logger, verbose_proxy_logger
 from litellm._service_logger import ServiceLogging
 from litellm.constants import (
     GLOBAL_PROXY_SPEND_CACHE_KEY,
+    INVALID_VIRTUAL_KEY_ERROR_MARKER,
+    INVALID_VIRTUAL_KEY_ERROR_MESSAGE,
     LITELLM_PROXY_BUDGET_NAME,
     LITELLM_PROXY_MASTER_KEY_ALIAS,
 )
@@ -61,7 +63,6 @@ from litellm.proxy.auth.auth_checks import (
 from litellm.proxy.auth.auth_exception_handler import UserAPIKeyAuthExceptionHandler
 from litellm.proxy.auth.auth_method import AuthMethod
 from litellm.proxy.auth.auth_utils import (
-    INVALID_VIRTUAL_KEY_ERROR_MESSAGE,
     abbreviate_api_key,
     get_end_user_id_from_request_body,
     get_model_from_request,
@@ -1872,13 +1873,17 @@ async def _user_api_key_auth_builder(
                 _masked_key: Final = f"{api_key[:4]}****{api_key[-4:]}" if len(api_key) > 8 else "****"
                 if not api_key.startswith("sk-"):
                     _hint = _JWT_AUTH_DISABLED_HINT if not enable_jwt_auth and JWTHandler.is_jwt(token=api_key) else ""
-                    raise HTTPException(
+                    _malformed_key_error = HTTPException(
                         status_code=status.HTTP_401_UNAUTHORIZED,
                         detail=(
                             f"{INVALID_VIRTUAL_KEY_ERROR_MESSAGE}. Received={_masked_key}, "
                             f"expected to start with 'sk-'.{_hint}"
                         ),
                     )  # prevent token hashes from being used
+                    # Stamp provenance here so log routing classifies this 401 by
+                    # where it was raised, never by its message text.
+                    setattr(_malformed_key_error, INVALID_VIRTUAL_KEY_ERROR_MARKER, True)
+                    raise _malformed_key_error
             else:
                 verbose_logger.warning(
                     "litellm.proxy.proxy_server.user_api_key_auth(): Warning - Key is not a string. Got type={}".format(

--- a/tests/test_litellm/proxy/auth/test_auth_exception_handler.py
+++ b/tests/test_litellm/proxy/auth/test_auth_exception_handler.py
@@ -705,21 +705,28 @@ async def test_auth_failure_ip_stamp_does_not_mutate_callers_request_data():
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    "auth_error,expect_traceback",
+    "auth_error,expect_traceback,expect_level",
     [
         pytest.param(
             ProxyException(
                 message="Authentication Error", type=ProxyErrorTypes.auth_error, param=None, code=401
             ),
             False,
+            "ERROR",
             id="expected_401_no_traceback",
         ),
-        pytest.param(ValueError("unexpected internal error"), True, id="unexpected_error_keeps_traceback"),
+        pytest.param(ValueError("unexpected internal error"), True, "ERROR", id="unexpected_error_keeps_traceback"),
+        pytest.param(
+            HTTPException(status_code=401, detail="LiteLLM Virtual Key expected. Received=test"),
+            False,
+            "WARNING",
+            id="malformed_virtual_key_warning_no_traceback",
+        ),
     ],
 )
-async def test_handle_authentication_error_traceback_only_for_unexpected_errors(auth_error, expect_traceback, caplog):
+async def test_handle_authentication_error_traceback_only_for_unexpected_errors(auth_error, expect_traceback, expect_level, caplog):
     """Regression for LIT-6043: expected 4xx auth rejections must not format a
-    traceback via logger.exception; unexpected errors must keep it."""
+    traceback via logger.exception; malformed virtual keys log at WARNING."""
     handler = UserAPIKeyAuthExceptionHandler()
 
     with (
@@ -740,8 +747,8 @@ async def test_handle_authentication_error_traceback_only_for_unexpected_errors(
         try:
             try:
                 raise auth_error
-            except (ProxyException, ValueError) as caught:
-                with caplog.at_level("ERROR", logger="LiteLLM Proxy"), pytest.raises(ProxyException):
+            except (ProxyException, ValueError, HTTPException) as caught:
+                with caplog.at_level(expect_level, logger="LiteLLM Proxy"), pytest.raises((ProxyException, HTTPException)):
                     await handler._handle_authentication_error(
                         caught,
                         MagicMock(),
@@ -756,3 +763,6 @@ async def test_handle_authentication_error_traceback_only_for_unexpected_errors(
     records = [r for r in caplog.records if "user_api_key_auth(): Exception occured" in r.getMessage()]
     assert len(records) == 1
     assert (records[0].exc_info is not None) is expect_traceback
+    assert records[0].levelname == expect_level
+    expected_logger_name = "LiteLLM Proxy.stdout" if expect_level == "WARNING" else "LiteLLM Proxy"
+    assert records[0].name == expected_logger_name

--- a/tests/test_litellm/proxy/auth/test_auth_exception_handler.py
+++ b/tests/test_litellm/proxy/auth/test_auth_exception_handler.py
@@ -26,6 +26,7 @@ from prisma.errors import (
 
 
 from litellm._logging import verbose_proxy_logger
+from litellm.constants import INVALID_VIRTUAL_KEY_ERROR_MARKER
 from litellm.exceptions import BudgetExceededError
 from litellm.proxy._types import ProxyErrorTypes, ProxyException, UserAPIKeyAuth
 from litellm.proxy.auth.auth_exception_handler import UserAPIKeyAuthExceptionHandler
@@ -703,6 +704,13 @@ async def test_auth_failure_ip_stamp_does_not_mutate_callers_request_data():
     assert request_data == {"model": "gpt-4o"}
 
 
+def _marked_malformed_key_error() -> HTTPException:
+    """Build the malformed-key 401 as its raise site does: marker stamped on it."""
+    error = HTTPException(status_code=401, detail="LiteLLM Virtual Key expected. Received=test")
+    setattr(error, INVALID_VIRTUAL_KEY_ERROR_MARKER, True)
+    return error
+
+
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     "auth_error,expect_traceback,expect_level",
@@ -717,10 +725,16 @@ async def test_auth_failure_ip_stamp_does_not_mutate_callers_request_data():
         ),
         pytest.param(ValueError("unexpected internal error"), True, "ERROR", id="unexpected_error_keeps_traceback"),
         pytest.param(
-            HTTPException(status_code=401, detail="LiteLLM Virtual Key expected. Received=test"),
+            _marked_malformed_key_error(),
             False,
             "WARNING",
             id="malformed_virtual_key_warning_no_traceback",
+        ),
+        pytest.param(
+            HTTPException(status_code=401, detail="LiteLLM Virtual Key expected. Received=test"),
+            False,
+            "ERROR",
+            id="phrase_without_marker_stays_loud",
         ),
     ],
 )


### PR DESCRIPTION
## TLDR

Problem this solves:

- Invalid Bearer values create noisy proxy ERROR logs

How it solves it:

- Logs malformed virtual keys as stdout WARNING records
- Keeps the same HTTP 401 rejection and response body

## User Flow

Before: an app accidentally sends `Bearer undefined`; the proxy rejects it, but monitoring reports it as an error event

1. The app sends `GET https://litellm-domain/v1/models` with `Authorization: Bearer undefined`
2. The proxy returns HTTP `401` with `LiteLLM Virtual Key expected`
3. The proxy writes an `ERROR` record to stderr, which stream-based collectors classify as an error

After: the same rejected request stays visible without being reported as a proxy error

1. The app sends `GET https://litellm-domain/v1/models` with `Authorization: Bearer undefined`
2. The proxy returns the same HTTP `401` and response body
3. The proxy writes a `WARNING` record to stdout, which operators can suppress with `LITELLM_LOG=ERROR`

## Relevant issues


## Linear ticket

Resolves LIT-5362

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally
- [x] My PR passes all required CI/CD checks
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile Confidence Score of at least 4/5 before requesting a maintainer review

## Screenshots / Proof of Fix

Rig: two containerized LiteLLM proxies (base @ 36ea28b092, head @ 1b5e7848f6) with a real **Datadog Agent** shipping container logs to Datadog (us5). Datadog indexes stderr logs as `status:error` and stdout logs as `status:info` by default — the actual customer-facing symptom this PR fixes.

### Before (36ea28b092)

7 malformed virtual-key auth rejections indexed as **`status:error`** (noisy in error dashboards, inflates error metrics):

```
curl -X POST http://127.0.0.1:5684/v1/chat/completions \
  -H "Authorization: Bearer undefined" \
  -d '{"model":"gemini-flash","messages":[{"role":"user","content":"hi"}]}'

→ HTTP 401 LiteLLM Virtual Key expected

→ Datadog logs: "status:error | LiteLLM Proxy:ERROR: 401: LiteLLM Virtual Key expected"
```

### After (1b5e7848f6)

Same 7 rejections now indexed as **`status:info`** (no longer noise, correct severity):

```
curl -X POST http://127.0.0.1:5685/v1/chat/completions \
  -H "Authorization: Bearer undefined" \
  -d '{"model":"gemini-flash","messages":[{"role":"user","content":"hi"}]}'

→ HTTP 401 LiteLLM Virtual Key expected (identical)

→ Datadog logs: "status:info | LiteLLM Proxy.stdout:WARNING: 401: LiteLLM Virtual Key expected"
```

**Real Datadog dashboard (customer-visible symptom):**

![Datadog dashboard showing 7 malformed-key rejections: base indexed status:error (red), head indexed status:info (green)](https://raw.githubusercontent.com/BerriAI/litellm/assets-pr38838/evidence/lit5362/dd-dashboard.png)

**Mechanism detail:** `LevelRoutingStreamHandler` examines each log record's logger name; records originating from the child logger `LiteLLM Proxy.stdout` with level WARNING are routed to stdout (container stdout stream → Datadog `status:info`). Base logs to stderr because the default ERROR handler sends it there (→ Datadog `status:error`). API contract (401 + body) is unchanged on both sides.

## Type

🐛 Bug Fix

## Caveats (if any)

### Low

- `json_logs=true` now honors `LITELLM_LOG` at the handler level

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/berriai/litellm/pull/38838" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes auth-failure logging and stream routing only; HTTP 401 behavior for malformed keys is unchanged except WebSocket close semantics, with escalation if callbacks alter the status code.
> 
> **Overview**
> **Malformed virtual-key auth failures** (401 with “LiteLLM Virtual Key expected”) are now logged at **WARNING** on **stdout** via child logger `LiteLLM Proxy.stdout`, instead of **ERROR** on stderr, when `log_client_error_tracebacks` is off. **`LITELLM_LOG=ERROR`** can suppress them; **`LevelRoutingStreamHandler`** treats that child’s WARNING records like sub-WARNING stdout traffic so log collectors don’t treat them as errors.
> 
> Adds **`is_invalid_virtual_key_error`** / **`mark_invalid_virtual_key_error`** (message + marker through failure hooks), refactors exception conversion into **`_as_proxy_exception`**, and **re-escalates to ERROR** if a quiet-logged case ends up non-401 after callbacks. **WebSocket** auth raises **`WebSocketException(1008)`** for malformed keys to avoid duplicate traceback logs. **`_turn_on_json`** now sets the handler level from **`LITELLM_LOG`** (fixes prior NOTSET leak). Tests cover WARNING level and stdout logger name for malformed keys.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1022971913c2f6639da47baa0817f6dbde3404a6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
