### PR TITLE
fix(guardrails): stop Lakera monitor mode forwarding unmasked PII on Responses-API bodies

### DIFF
--- a/litellm/proxy/guardrails/guardrail_hooks/lakera_ai_v2.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/lakera_ai_v2.py
@@ -191,6 +191,25 @@ def _breakdown_has_pii_violation(lakera_response: LakeraAIResponse | None) -> bo
     )
 
 
+def _unmaskable_reason(
+    guardrail: "LakeraAIGuardrail",
+    data: dict[str, object],
+    lakera_response: LakeraAIResponse | None,
+) -> str | None:
+    """Why a PII-only violation on ``data`` can't be masked in place, or None when it can."""
+    if has_non_string_content(data):
+        return "multimodal content, masking would drop the image/audio parts"
+    if _has_combined_messages_and_input(data):
+        return "messages and input are both present, so the write-back is positionally ambiguous"
+    if "messages" in data and not isinstance(data.get("messages"), list):
+        return "a messages key that isn't a list, so there's nothing to merge the redacted content into"
+    if not _has_responses_instructions(guardrail, data):
+        return "no write-back path for the redacted content"
+    if not (lakera_response or {}).get("payload"):
+        return "Lakera reported no locations to redact, so payload=true is likely off"
+    return None
+
+
 def _build_lakera_inspection_messages(data: Mapping[str, object]) -> Sequence[Mapping[str, str]]:
     """Like build_inspection_messages, but also covers the Responses-API
     ``instructions`` field, placed first since litellm later converts it
@@ -473,6 +492,32 @@ class LakeraAIGuardrail(CustomGuardrail):
             msg["content"] = content
         return messages
 
+    def _mask_unwritable_instructions_pii_in_place(
+        self,
+        data: dict[str, object],  # mutable-ok: writes the redacted result back into the caller's request dict in place
+        inspected_messages: Sequence[AllMessageValues],
+        lakera_response: LakeraAIResponse | None,
+        masked_entity_count: dict[str, int],
+    ) -> bool:
+        """Mask a body whose only obstacle to mask-in-place is the Responses-API
+        ``instructions`` field, writing the redacted instructions straight into
+        ``data["instructions"]``: apply_redacted_messages_back has no path for
+        that field and would fold the instructions text into ``data["input"]``.
+        Returns False without masking anything when _unmaskable_reason names an
+        obstacle this can't get around."""
+        if _unmaskable_reason(self, data, lakera_response) is not None:
+            return False
+        redacted: Final = self._mask_pii_in_messages(
+            messages=inspected_messages,
+            lakera_response=lakera_response,
+            masked_entity_count=masked_entity_count,
+        )
+        # _build_lakera_inspection_messages puts instructions first and
+        # _filter_skipped_messages kept it, so index 0 is the instructions.
+        data["instructions"] = redacted[0]["content"]
+        _apply_redacted_messages_back_preserving_fields(self, data, redacted[1:])
+        return True
+
     async def async_pre_call_hook(
         self,
         user_api_key_dict: UserAPIKeyAuth,
@@ -537,11 +582,12 @@ class LakeraAIGuardrail(CustomGuardrail):
         ########## 2. Handle flagged content ##########
         #########################################################
         if lakera_guardrail_response.get("flagged") is True:
+            is_pii_only_violation: Final = self._is_only_pii_violation(lakera_guardrail_response)
             # PII-only violations get masked in place regardless of on_flagged: there's
             # no reason to expose raw PII to satisfy an advisory note, and masking is
             # strictly safer than either blocking or appending an advisory message next
             # to unredacted PII.
-            if self._is_only_pii_violation(lakera_guardrail_response) and not is_multimodal_input:
+            if is_pii_only_violation and not is_multimodal_input:
                 redacted_messages: Final = self._mask_pii_in_messages(
                     messages=new_messages,
                     lakera_response=lakera_guardrail_response,
@@ -583,18 +629,35 @@ class LakeraAIGuardrail(CustomGuardrail):
                     # blocking rather than silently letting the flagged request
                     # through with no advisory ever reaching the model.
                     raise self._get_http_exception_for_blocked_guardrail(lakera_guardrail_response)
-            else:
-                # Check on_flagged setting
-                if self.on_flagged == "monitor":
+            elif self.on_flagged == "monitor":
+                # Monitor means "don't block", not "don't redact": until the mask
+                # branch above started skipping shapes it can't write back to, a
+                # PII-only violation was masked whatever on_flagged said.
+                masked_in_place: Final = is_pii_only_violation and self._mask_unwritable_instructions_pii_in_place(
+                    data=data,
+                    inspected_messages=new_messages,
+                    lakera_response=lakera_guardrail_response,
+                    masked_entity_count=masked_entity_count,
+                )
+                if masked_in_place:
+                    verbose_proxy_logger.warning(
+                        "Lakera Guardrail: Monitoring mode - PII detected, masked in place and allowing request"
+                    )
+                elif is_pii_only_violation:
+                    verbose_proxy_logger.error(
+                        "Lakera Guardrail: Monitoring mode - PII detected but NOT masked, forwarding unredacted "
+                        "content to the model (reason: %s)",
+                        _unmaskable_reason(self, data, lakera_guardrail_response),
+                    )
+                else:
                     verbose_proxy_logger.warning(
                         "Lakera Guardrail: Monitoring mode - violation detected but allowing request"
                     )
-                    # Log violation but continue
-                elif self.on_flagged == "block":
-                    # Either non-PII violations, or PII on multimodal input
-                    # (which cannot be masked in place without dropping
-                    # image/audio parts) — raise the standard block error.
-                    raise self._get_http_exception_for_blocked_guardrail(lakera_guardrail_response)
+            elif self.on_flagged == "block":
+                # Either non-PII violations, or PII on multimodal input
+                # (which cannot be masked in place without dropping
+                # image/audio parts) — raise the standard block error.
+                raise self._get_http_exception_for_blocked_guardrail(lakera_guardrail_response)
 
         #########################################################
         ########## 3. Add the guardrail to the applied guardrails header ##########

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_lakera_ai_v2.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_lakera_ai_v2.py
@@ -5,6 +5,7 @@ PR checklist requires at least one test in tests/test_litellm/.
 Additional tests live in tests/guardrails_tests/test_lakera_v2.py.
 """
 
+import logging
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -537,6 +538,220 @@ class TestPiiMaskingSafetyGuard:
             )
         assert result["messages"][0] == SYSTEM_MSG
         assert "[MASKED" in result["messages"][1]["content"]
+
+    async def test_monitor_mode_masks_responses_input_when_instructions_present(self):
+        """
+        Regression: #34940 added `instructions` to the mask-in-place safety guard,
+        which skips the mask branch for every Responses-API body carrying one. In
+        on_flagged="monitor" that dropped through to "allow", so PII in `input`
+        that was masked before the PR now reached the model unredacted. Monitor
+        means "don't block", not "don't redact" -- the input is still writable, so
+        it must still be masked.
+        """
+        guardrail = LakeraAIGuardrail(api_key="test_key", on_flagged="monitor")
+        data = {
+            "instructions": "be nice",
+            "input": "a@b.com",
+            "model": "gpt-3.5-turbo",
+            "metadata": {},
+        }
+        lakera_response = {
+            "flagged": True,
+            "breakdown": [{"detector_type": "pii/email", "detected": True, "message_id": 1}],
+            "payload": [{"detector_type": "pii/email", "start": 0, "end": 7, "message_id": 1}],
+        }
+        with patch.object(guardrail, "call_v2_guard", new_callable=AsyncMock) as mock_call:
+            mock_call.return_value = (lakera_response, {})
+            result = await guardrail.async_pre_call_hook(
+                user_api_key_dict=UserAPIKeyAuth(api_key="test_key"),
+                cache=MagicMock(),
+                data=data,
+                call_type="responses",
+            )
+        assert result["input"] == "[MASKED EMAIL]"
+        assert result["instructions"] == "be nice"
+
+    async def test_monitor_mode_masks_pii_carried_in_responses_instructions(self):
+        """
+        Regression: `instructions` is inspected as a synthetic leading system
+        message but apply_redacted_messages_back has no path to rewrite it, so
+        monitor mode forwarded the flagged instructions text verbatim. The
+        redacted instructions must be written straight back into
+        data["instructions"], and must not be folded into data["input"].
+        """
+        guardrail = LakeraAIGuardrail(api_key="test_key", on_flagged="monitor")
+        data = {
+            "instructions": "a@b.com is the contact",
+            "input": "hi",
+            "model": "gpt-3.5-turbo",
+            "metadata": {},
+        }
+        lakera_response = {
+            "flagged": True,
+            "breakdown": [{"detector_type": "pii/email", "detected": True, "message_id": 0}],
+            "payload": [{"detector_type": "pii/email", "start": 0, "end": 7, "message_id": 0}],
+        }
+        with patch.object(guardrail, "call_v2_guard", new_callable=AsyncMock) as mock_call:
+            mock_call.return_value = (lakera_response, {})
+            result = await guardrail.async_pre_call_hook(
+                user_api_key_dict=UserAPIKeyAuth(api_key="test_key"),
+                cache=MagicMock(),
+                data=data,
+                call_type="responses",
+            )
+        assert result["instructions"] == "[MASKED EMAIL] is the contact"
+        assert "a@b.com" not in result["instructions"]
+        assert result["input"] == "hi"
+
+    async def test_monitor_mode_masks_messages_when_instructions_present(self):
+        """
+        Regression: a chat body that also carries `instructions` hit the same
+        guard. The messages list has a write-back path, so it must still be
+        masked in monitor mode, with the untouched instructions preserved.
+        """
+        guardrail = LakeraAIGuardrail(api_key="test_key", on_flagged="monitor")
+        data = {
+            "instructions": "be nice",
+            "messages": [{"role": "user", "content": "a@b.com", "name": "u1"}],
+            "model": "gpt-3.5-turbo",
+            "metadata": {},
+        }
+        lakera_response = {
+            "flagged": True,
+            "breakdown": [{"detector_type": "pii/email", "detected": True, "message_id": 1}],
+            "payload": [{"detector_type": "pii/email", "start": 0, "end": 7, "message_id": 1}],
+        }
+        with patch.object(guardrail, "call_v2_guard", new_callable=AsyncMock) as mock_call:
+            mock_call.return_value = (lakera_response, {})
+            result = await guardrail.async_pre_call_hook(
+                user_api_key_dict=UserAPIKeyAuth(api_key="test_key"),
+                cache=MagicMock(),
+                data=data,
+                call_type="completion",
+            )
+        assert result["messages"][0]["content"] == "[MASKED EMAIL]"
+        assert result["messages"][0]["name"] == "u1"
+        assert result["instructions"] == "be nice"
+
+    async def _monitor_unmasked(self, guardrail, data, lakera_response, caplog, call_type="completion"):
+        """Drive the monitor path and hand back the result plus the ERROR records it logged."""
+        with (
+            patch.object(guardrail, "call_v2_guard", new_callable=AsyncMock) as mock_call,
+            caplog.at_level(logging.ERROR, logger="LiteLLM Proxy"),
+        ):
+            mock_call.return_value = (lakera_response, {})
+            result = await guardrail.async_pre_call_hook(
+                user_api_key_dict=UserAPIKeyAuth(api_key="test_key"),
+                cache=MagicMock(),
+                data=data,
+                call_type=call_type,
+            )
+        return result, [r.getMessage() for r in caplog.records if r.levelno == logging.ERROR]
+
+    async def test_monitor_mode_leaves_combined_messages_and_input_unmasked(self, caplog):
+        """
+        The combined messages+input shape stays unmasked in monitor mode on
+        purpose: build_inspection_messages flattens both into one list, so
+        writing the redacted result back is positionally ambiguous (Greptile P1
+        on #34940, see
+        test_pii_only_violation_with_combined_messages_and_input_blocks_instead_of_masking).
+        Monitor still must not block, so the request goes through untouched and
+        the guardrail logs an error naming that reason.
+        """
+        guardrail = LakeraAIGuardrail(api_key="test_key", on_flagged="monitor")
+        data = {
+            "messages": [{"role": "user", "content": ""}, {"role": "user", "content": "a@b.com"}],
+            "input": "responses-api content",
+            "model": "gpt-3.5-turbo",
+            "metadata": {},
+        }
+        result, errors = await self._monitor_unmasked(guardrail, data, PII_ONLY_LAKERA_RESPONSE, caplog)
+        assert result["messages"][1]["content"] == "a@b.com"
+        assert result["input"] == "responses-api content"
+        assert any("messages and input are both present" in e for e in errors)
+
+    async def test_monitor_mode_multimodal_logs_the_multimodal_reason(self, caplog):
+        """The multimodal shape was already unmasked before this branch existed;
+        it must stay that way and say which obstacle it hit, not a generic one."""
+        guardrail = LakeraAIGuardrail(api_key="test_key", on_flagged="monitor")
+        data = {
+            "messages": [{"role": "user", "content": [{"type": "text", "text": "a@b.com"}]}],
+            "model": "gpt-3.5-turbo",
+            "metadata": {},
+        }
+        result, errors = await self._monitor_unmasked(guardrail, data, PII_ONLY_LAKERA_RESPONSE, caplog)
+        assert result["messages"][0]["content"] == [{"type": "text", "text": "a@b.com"}]
+        assert any("multimodal content" in e for e in errors)
+
+    async def test_monitor_mode_does_not_claim_masking_when_lakera_sent_no_locations(self, caplog):
+        """
+        payload=false is a supported config for block/monitor, and it makes
+        Lakera report the violation without the offsets masking needs. Masking
+        must not silently no-op and report success -- the request goes out
+        unredacted, so it has to be logged as unredacted.
+        """
+        guardrail = LakeraAIGuardrail(api_key="test_key", on_flagged="monitor", payload=False)
+        data = {
+            "instructions": "be nice",
+            "input": "a@b.com",
+            "model": "gpt-3.5-turbo",
+            "metadata": {},
+        }
+        lakera_response = {
+            "flagged": True,
+            "breakdown": [{"detector_type": "pii/email", "detected": True, "message_id": 1}],
+        }
+        result, errors = await self._monitor_unmasked(guardrail, data, lakera_response, caplog, call_type="responses")
+        assert result["input"] == "a@b.com"
+        assert any("no locations to redact" in e for e in errors)
+
+    async def test_monitor_mode_does_not_invent_a_messages_list(self, caplog):
+        """
+        A Responses body carrying a falsy non-list `messages` key must not come
+        out of the guardrail with a fabricated chat messages list -- the shared
+        write-back helper keys off `"messages" in data`, not off it being a list.
+        """
+        guardrail = LakeraAIGuardrail(api_key="test_key", on_flagged="monitor")
+        data = {
+            "instructions": "be nice",
+            "input": "a@b.com",
+            "messages": None,
+            "model": "gpt-3.5-turbo",
+            "metadata": {},
+        }
+        lakera_response = {
+            "flagged": True,
+            "breakdown": [{"detector_type": "pii/email", "detected": True, "message_id": 1}],
+            "payload": [{"detector_type": "pii/email", "start": 0, "end": 7, "message_id": 1}],
+        }
+        result, errors = await self._monitor_unmasked(guardrail, data, lakera_response, caplog, call_type="responses")
+        assert result["messages"] is None
+        assert result["input"] == "a@b.com"
+        assert any("isn't a list" in e for e in errors)
+
+    async def test_monitor_mode_mixed_violation_is_not_logged_as_an_error(self, caplog):
+        """
+        A PII-plus-prompt-injection violation on an ordinary chat body behaves
+        exactly as it did before this branch existed, so it must keep logging at
+        warning level rather than adding error volume to every mixed detection.
+        """
+        guardrail = LakeraAIGuardrail(api_key="test_key", on_flagged="monitor")
+        data = {
+            "messages": [{"role": "user", "content": "a@b.com"}],
+            "model": "gpt-3.5-turbo",
+            "metadata": {},
+        }
+        lakera_response = {
+            "flagged": True,
+            "breakdown": [
+                {"detector_type": "pii/email", "detected": True, "message_id": 0},
+                {"detector_type": "prompt_attack", "detected": True, "message_id": 0},
+            ],
+            "payload": [{"detector_type": "pii/email", "start": 0, "end": 7, "message_id": 0}],
+        }
+        result, errors = await self._monitor_unmasked(guardrail, data, lakera_response, caplog)
+        assert result["messages"][0]["content"] == "a@b.com"
+        assert errors == []
 
     async def test_pii_only_violation_with_uppercase_skipped_role_masks_without_raising(self):
         """


### PR DESCRIPTION
## TLDR

Problem this solves:

- Lakera `on_flagged: "monitor"` sends unmasked PII to the model
- Only on requests carrying an `instructions` field
- Those requests were masked before PR #34940

How it solves it:

- Monitor mode masks the request again instead of forwarding it raw
- The redacted `instructions` is written straight back into `instructions`
- Shapes that still cannot be masked log why, at error level

## User Flow

Before: a team running Lakera in monitor mode to tune their policy finds customer PII in their model provider's logs, but only for Responses-API traffic

1. The proxy admin sets up a Lakera v2 guardrail with `on_flagged: "monitor"` and turns it on by default
2. A developer sends `POST https://litellm-domain/v1/responses` with `"instructions": "be nice"` and `"input": "mail a@b.com now"`
3. The call returns 200, and the model provider receives `"input": "mail a@b.com now"` - the email address, unredacted
4. The same developer sends `POST https://litellm-domain/v1/chat/completions` with no `instructions` field and the same email in a message
5. That call also returns 200, but the model provider receives `"mail [MASKED EMAIL] now"`, so the same guardrail redacts one route and not the other
6. Anyone who can read the provider-side logs can read the email address that came through the Responses API

After: the same monitor-mode guardrail redacts both routes, and still never blocks

1. The proxy admin sets up the same Lakera v2 guardrail with `on_flagged: "monitor"`
2. A developer sends `POST https://litellm-domain/v1/responses` with `"instructions": "be nice"` and `"input": "mail a@b.com now"`
3. The call returns 200, and the model provider now receives `"input": "mail [MASKED EMAIL] now"`
4. The developer sends `POST https://litellm-domain/v1/responses` with the email inside `"instructions"` instead
5. That call also returns 200, the provider receives the redacted `instructions`, and `input` is left alone
6. Monitor mode still returns 200 on every request it flags, so nothing that used to succeed now fails
7. The email address no longer shows up in the provider-side logs for either route

## Relevant issues

## Linear ticket

Refs LIT-5801

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

### Verified against the real Lakera API

The A/B below runs the real `https://api.lakera.ai/v2/guard` (no `api_base` override, real
project `project-lakera-default` on the Lakera Default Policy). Only the *model* is a local
recording upstream, so the exact body the model received can be read off the wire. Both proxies
run the same config and the same request; the only difference is the tree.

```yaml
model_list:
  - model_name: echo-model
    litellm_params:
      model: openai/gpt-4o-mini
      api_base: http://127.0.0.1:8899/v1   # recording upstream, so we can read what the model got
      api_key: sk-stub

guardrails:
  - guardrail_name: lakera-monitor
    litellm_params:
      guardrail: lakera_v2
      mode: pre_call
      api_key: os.environ/LAKERA_API_KEY   # real Lakera, no api_base override
      on_flagged: monitor
      default_on: true

general_settings:
  master_key: sk-1234
```

Same request to both proxies:

```console
$ curl -s http://127.0.0.1:<port>/v1/responses \
    -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' \
    -d '{"model":"echo-model","instructions":"You are a helpful assistant.",
         "input":"mail me at john.smith@example.com now"}'
```

What the model was sent, captured at the upstream:

| tree | `instructions` | `input` the model received |
| --- | --- | --- |
| base `36ea28b0929` | `You are a helpful assistant.` | `mail me at john.smith@example.com now` |
| this PR `0cfaf39472` | `You are a helpful assistant.` | `mail me at [MASKED EMAIL] now` |

Lakera's own Logs page, showing the four calls in order (oldest at the bottom of the four):
the base proxy's guardrail scan, a re-scan of what base sent the model (**still flagged — the raw
address reached the model**), this PR's guardrail scan (identical detection, so Lakera saw the same
input on both trees), and a re-scan of what this PR sent the model (**Nothing detected**).

![Lakera Logs](https://raw.githubusercontent.com/BerriAI/litellm/assets-pr38841/lakera-ui-1-logs.png)

The guardrail scan itself. `instructions` is presented to Lakera as the `System` message and the
email is a confident `Data leakage / Email` detection, so the guardrail really was told there was
PII to mask:

![Lakera detection detail](https://raw.githubusercontent.com/BerriAI/litellm/assets-pr38841/lakera-ui-2-detection-flagged.png)

The same content after this PR masks it, put back through Lakera — 0 threats detected:

![Lakera clean detail](https://raw.githubusercontent.com/BerriAI/litellm/assets-pr38841/lakera-ui-3-detection-clean.png)

One cell cannot be shown against the real API: Lakera's default policy does not flag PII carried in
a `system`-role message, which is how `instructions` is presented to it, so a request whose *only*
PII sits in `instructions` never reaches the flagged branch on either tree. That cell is covered by
the deterministic transcript below.

### Deterministic transcript (local stand-in for the vendor)

The cases below use a local stand-in for Lakera at `api_base` that flags the literal `a@b.com` as
`pii/email` and returns the offsets Lakera would, so every body shape is reproducible without
depending on the vendor's live policy. The proxy, its request path, and the recorded upstream body
are real.
Same config as above with the guardrail's `api_base` pointed at the stand-in:

```yaml
      api_key: k
      api_base: "http://127.0.0.1:8899"
```

### Before (36ea28b0929)

#### /v1/responses — PII in input, instructions present
1. send the request:
   ```console
   $ curl -s -o /dev/null -w '%{http_code}\n' http://127.0.0.1:4000/v1/responses \
       -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' \
       -d '{"model":"echo-model","instructions":"be nice","input":"mail a@b.com now"}'
   200
   ```
2. what the model was sent, captured at the upstream:
   ```json
   {"input": "mail a@b.com now", "instructions": "be nice"}
   ```

#### /v1/responses — PII inside instructions
1. send the request:
   ```console
   $ curl -s -o /dev/null -w '%{http_code}\n' http://127.0.0.1:4000/v1/responses \
       -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' \
       -d '{"model":"echo-model","instructions":"contact a@b.com please","input":"hi"}'
   200
   ```
2. what the model was sent, captured at the upstream:
   ```json
   {"input": "hi", "instructions": "contact a@b.com please"}
   ```

#### /v1/chat/completions — PII in a message, instructions present
1. send the request:
   ```console
   $ curl -s -o /dev/null -w '%{http_code}\n' http://127.0.0.1:4000/v1/chat/completions \
       -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' \
       -d '{"model":"echo-model","instructions":"be nice","messages":[{"role":"user","content":"mail a@b.com now"}]}'
   200
   ```
2. what the model was sent, captured at the upstream:
   ```json
   {"messages": [{"role": "user", "content": "mail a@b.com now"}], "instructions": "be nice"}
   ```

#### /v1/messages — PII in a message, instructions present
1. send the request:
   ```console
   $ curl -s -o /dev/null -w '%{http_code}\n' http://127.0.0.1:4000/v1/messages \
       -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' \
       -d '{"model":"echo-model","max_tokens":16,"instructions":"be nice","messages":[{"role":"user","content":"mail a@b.com now"}]}'
   200
   ```
2. what the model was sent, captured at the upstream:
   ```json
   {"input": [{"type": "message", "role": "user", "content": [{"type": "input_text", "text": "mail a@b.com now"}]}], "instructions": "be nice"}
   ```


### After (0cfaf39472)

#### /v1/responses — PII in input, instructions present
1. send the request:
   ```console
   $ curl -s -o /dev/null -w '%{http_code}\n' http://127.0.0.1:4000/v1/responses \
       -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' \
       -d '{"model":"echo-model","instructions":"be nice","input":"mail a@b.com now"}'
   200
   ```
2. what the model was sent, captured at the upstream:
   ```json
   {"input": "mail [MASKED EMAIL] now", "instructions": "be nice"}
   ```

#### /v1/responses — PII inside instructions
1. send the request:
   ```console
   $ curl -s -o /dev/null -w '%{http_code}\n' http://127.0.0.1:4000/v1/responses \
       -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' \
       -d '{"model":"echo-model","instructions":"contact a@b.com please","input":"hi"}'
   200
   ```
2. what the model was sent, captured at the upstream:
   ```json
   {"input": "hi", "instructions": "contact [MASKED EMAIL] please"}
   ```

#### /v1/chat/completions — PII in a message, instructions present
1. send the request:
   ```console
   $ curl -s -o /dev/null -w '%{http_code}\n' http://127.0.0.1:4000/v1/chat/completions \
       -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' \
       -d '{"model":"echo-model","instructions":"be nice","messages":[{"role":"user","content":"mail a@b.com now"}]}'
   200
   ```
2. what the model was sent, captured at the upstream:
   ```json
   {"messages": [{"role": "user", "content": "mail [MASKED EMAIL] now"}], "instructions": "be nice"}
   ```

#### /v1/messages — PII in a message, instructions present
1. send the request:
   ```console
   $ curl -s -o /dev/null -w '%{http_code}\n' http://127.0.0.1:4000/v1/messages \
       -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' \
       -d '{"model":"echo-model","max_tokens":16,"instructions":"be nice","messages":[{"role":"user","content":"mail a@b.com now"}]}'
   200
   ```
2. what the model was sent, captured at the upstream:
   ```json
   {"input": [{"type": "message", "role": "user", "content": [{"type": "input_text", "text": "mail [MASKED EMAIL] now"}]}], "instructions": "be nice"}
   ```


## Type

🐛 Bug Fix

## Caveats (if any)

### Severe

- Monitor mode rewrites the request body again on these shapes
  - That is the fix: it is what monitor did before #34940
  - A guardrail running after Lakera therefore sees the masked text
  - Live A/B: a `[monitor, block]` chain on a Responses body with `instructions` goes 400 -> 200
  - The same chain on a plain chat body is already 200 on both sides, so this is masking's
    existing consequence reaching one more shape; the PII reaches the model in neither case
- `/v1/audio/speech` sending an `instructions` field now has its spoken text masked as well
  - Speech without `instructions` already masks today, so this removes an inconsistency
  - Not gated on call type on purpose: gating would leave `/v1/messages` and passthrough leaking

### Medium

- Three shapes still forward unmasked PII in monitor mode, on purpose
  - Multimodal content: masking would drop the image and audio parts
  - `messages` and `input` both present: the write-back is positionally ambiguous (Greptile P1 on #34940)
  - `payload: false`: Lakera reports the violation without the offsets masking needs
  - Each logs an error naming which one it hit
- `during_call` mode is untouched and still forwards unmasked on these shapes
  - Its own comment explains masking cannot reach the dispatched request there
- A Responses `input` given as a list is still not masked
  - Pre-existing: the shared write-back only handles a string `input`

### Low

- `block` and `inject_system_message` are deliberately unchanged
  - They still return 400 on these shapes, as #34940 shipped and its tests assert
- Pre-existing, reproduced on the base commit and not touched here: for a Responses body the
  standard logging payload records the unmasked `input` while the model gets the masked one

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/berriai/litellm/pull/38841" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Lakera pre-call handling of PII redaction in monitor mode on security-sensitive request paths; scope is limited to Lakera v2 and restores prior redaction behavior with explicit logging when redaction is impossible.
> 
> **Overview**
> Fixes a regression where Lakera **`on_flagged: "monitor"`** allowed **unredacted PII** to reach the model on requests that include Responses-API **`instructions`**, after #34940 treated those bodies as unsafe for the usual mask-in-place path.
> 
> **Monitor mode** again **redacts PII-only hits** when write-back is possible: redacted **`instructions`** go back into **`data["instructions"]`**, and **`input`** / **`messages`** are updated without folding instructions into **`input`**. **`_unmaskable_reason`** documents why masking cannot run (multimodal, **`messages`+`input`**, non-list **`messages`**, missing Lakera **`payload`**, etc.); when PII-only masking still fails, the hook **logs at ERROR** with that reason instead of silently allowing raw content.
> 
> **`block`** and **`inject_system_message`** behavior on these shapes is unchanged. Tests cover monitor masking for **`input`**, **`instructions`**, and **`messages`** with **`instructions`**, plus intentional unmasked cases and logging.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0cfaf39472c2cdffab826a69a5b1edf5fbb4c300. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
