### PR TITLE
feat(complexity_router): opt-in modality-based capability routing for image requests

### DIFF
--- a/litellm/litellm_core_utils/prompt_templates/common_utils.py
+++ b/litellm/litellm_core_utils/prompt_templates/common_utils.py
@@ -205,6 +205,41 @@ def is_non_content_values_set(message: AllMessageValues) -> bool:
     return any(message.get(key, None) is not None for key in message if key not in ignore_keys)
 
 
+_IMAGE_CONTENT_PART_TYPES: Final = frozenset({"image_url", "input_image", "image"})
+_IMAGE_SCAN_MAX_DEPTH: Final = 4
+
+
+def _content_parts_contain_image(parts: Sequence[object]) -> bool:
+    """Depth-bounded frontier walk over nested content lists, iterative because the repo bans
+    recursion; an Anthropic tool_result nests its image parts exactly one level down."""
+    frontier = parts  # rebind-ok: depth-bounded frontier walk
+    for _ in range(_IMAGE_SCAN_MAX_DEPTH):
+        if any(isinstance(part, Mapping) and part.get("type") in _IMAGE_CONTENT_PART_TYPES for part in frontier):
+            return True
+        frontier = tuple(  # rebind-ok: depth-bounded frontier walk
+            nested
+            for part in frontier
+            if isinstance(part, Mapping)
+            for content in (part.get("content"),)
+            if isinstance(content, list)
+            for nested in content
+        )
+        if not frontier:
+            return False
+    return False
+
+
+def request_contains_image_content(messages: Sequence[Mapping[str, object]]) -> bool:
+    """Whether any message carries an image content part, across the dialects that reach
+    pre-routing hooks untranslated: chat-completions ``image_url``, Responses ``input_image``,
+    and Anthropic Messages ``image``, including images nested inside ``tool_result`` blocks."""
+    return any(
+        isinstance(content, list) and _content_parts_contain_image(content)
+        for message in messages
+        for content in (message.get("content"),)
+    )
+
+
 def _audio_or_image_in_message_content(message: AllMessageValues) -> bool:
     """
     Checks if message content contains an image or audio

--- a/litellm/router_strategy/complexity_router/README.md
+++ b/litellm/router_strategy/complexity_router/README.md
@@ -154,6 +154,9 @@ model_list:
         
         # Fallback model if tier cannot be determined
         default_model: gpt-4o
+
+        # Route image requests only to vision-capable tier models (default: false)
+        modality_routing: true
 ```
 
 ## Usage
@@ -177,6 +180,31 @@ response = litellm.completion(
 ```
 
 ## Special Behaviors
+
+### Modality-based capability routing
+
+The classifier reads text alone, so a request carrying an image can classify cheap and land on a
+text-only model, which rejects it with a provider 400 no fallback catches. `modality_routing: true`
+makes every new placement capability-aware for image requests: the decided tier is kept when its
+pool has a model that accepts image input, otherwise the request is served by the nearest capable
+tier (walking up the ladder first, then down, never below a plan-mode floor), then by
+`default_model` when no tier qualifies, and rejected with a clear 400 naming the router when
+nothing can serve it. `default_model` is skipped when routing plugins are configured (it is never
+checked against the plugin pipeline) and under a plan-mode floor (it carries no tier guarantee).
+
+A model is excluded only when it is explicitly declared `supports_vision: false`, by a
+deployment-level `model_info` override first and the model cost map otherwise, so unmapped custom
+names stay routable. A group holding several deployments must accept on every one of them: the
+router picks the deployment inside the group after this gate runs, so a mixed group is treated
+text-only and escalated past rather than gambling the image on its text-only member.
+
+When the gate changes the placement, the routing decision records `cause: modality_escalation`
+with the displaced placement in `signals` (`modality_escalated_from:<TIER>` or
+`modality_displaced_default_model`); a same-tier pick that merely skipped text-only pool members
+keeps its original cause and carries `modality:image`. Two deliberate bounds: a session-affinity
+pin that is kept still wins even when an image arrives mid-session (replacement picks made on the
+pin path, an escalation keyword or the plan-mode floor, are gated), and the escalation itself is
+never pinned, so the next text turn classifies normally.
 
 ### Heuristic-first chaining
 

--- a/litellm/router_strategy/complexity_router/complexity_router.py
+++ b/litellm/router_strategy/complexity_router/complexity_router.py
@@ -30,6 +30,7 @@ from litellm.constants import EMPTY_MAPPING, RETURN_RAW_MODEL_NAME_METADATA_KEY
 from litellm.integrations.custom_logger import CustomLogger
 from litellm.litellm_core_utils.core_helpers import get_metadata_variable_name_from_kwargs
 from litellm.litellm_core_utils.internal_call_metadata import forwarded_internal_call_metadata
+from litellm.litellm_core_utils.prompt_templates.common_utils import request_contains_image_content
 from litellm.litellm_core_utils.sensitive_data_masker import mask_credentials_in_payload
 from litellm.llms.base_llm.base_utils import type_to_response_format_param
 from litellm.types.utils import (
@@ -58,6 +59,7 @@ from .config import (
     ComplexityTier,
     TierDefinition,
 )
+from .modality_gate import ModalityGate, ModalityPlacement
 
 if TYPE_CHECKING:
     from semantic_router.routers import SemanticRouter
@@ -706,11 +708,16 @@ def _decision_is_pinnable(decision: StandardLoggingRoutingDecision | None) -> bo
     of the three: an agent names the conversation on its first turn, so the cheapest tier would be
     the pin every session starts with, and the real work that follows would run there for the whole
     TTL. It describes what that one call is, never what the session's traffic looks like.
+
+    A modality escalation is transient the same way: it describes what this one call carries (an
+    image), not what the session's traffic looks like, and pinning it would hold every following
+    text turn on the vision-capable model the image forced.
     """
     return decision is None or decision.get("cause") not in (
         "default_model_fallback",
         "plan_mode",
         "housekeeping",
+        "modality_escalation",
     )
 
 
@@ -1612,12 +1619,14 @@ class ComplexityRouter(CustomLogger):
 
         return "\n".join(part for group in parts for part in group)
 
-    def get_model_for_tier(self, tier: ComplexityTier | str) -> str:
+    def get_model_for_tier(self, tier: ComplexityTier | str, eligible_models: frozenset[str] | None = None) -> str:
         """
         Get the model name for a given complexity tier.
 
         Args:
             tier: The complexity tier.
+            eligible_models: When set, the modality gate's per-request constraint; the pick is
+                restricted to pool members in this set.
 
         Returns:
             The model name configured for that tier.
@@ -1625,14 +1634,14 @@ class ComplexityRouter(CustomLogger):
         tier_key: Final = tier.value if isinstance(tier, ComplexityTier) else tier
 
         if tier_key in self.config.tiers:
-            return self._pick_from_tier_value(self.config.tiers[tier_key], tier_key)
+            return self._pick_from_tier_value(self.config.tiers[tier_key], tier_key, eligible_models)
 
         if self.config.default_model:
             return self.config.default_model
 
         medium_key: Final = ComplexityTier.MEDIUM.value
         if medium_key in self.config.tiers:
-            return self._pick_from_tier_value(self.config.tiers[medium_key], medium_key)
+            return self._pick_from_tier_value(self.config.tiers[medium_key], medium_key, eligible_models)
 
         raise ValueError(f"No model configured for tier {tier_key} and no default_model set")
 
@@ -1644,12 +1653,16 @@ class ComplexityRouter(CustomLogger):
         return entry.litellm_params if entry is not None else MappingProxyType({})
 
     @staticmethod
-    def _pick_from_tier_value(model: str | list[str], tier_key: str) -> str:
-        if isinstance(model, str):
-            return model
-        if not model:
+    def _pick_from_tier_value(
+        model: str | Sequence[str], tier_key: str, eligible_models: frozenset[str] | None = None
+    ) -> str:
+        pool: Final = (model,) if isinstance(model, str) else tuple(model)
+        candidates: Final = (
+            pool if eligible_models is None else tuple(entry for entry in pool if entry in eligible_models)
+        )
+        if not candidates:
             raise ValueError(f"Empty model pool for tier {tier_key}")
-        return random.choice(model)
+        return random.choice(candidates)
 
     def _tier_pools(self) -> dict[str, list[str]]:
         return {tier: (models if isinstance(models, list) else [models]) for tier, models in self.config.tiers.items()}
@@ -1660,15 +1673,20 @@ class ComplexityRouter(CustomLogger):
         raw_messages: list[dict[str, Any]] | None,
         resolved_messages: list[dict[str, Any]] | None,
         request_kwargs: dict,
+        eligible_models: frozenset[str] | None = None,
     ) -> str:
         if not self.config.plugins:
-            return self.get_model_for_tier(tier)
+            return self.get_model_for_tier(tier, eligible_models)
 
         from litellm.types.router import RoutingContext
 
         tier_key: Final = _tier_name(tier)
         metadata_key: Final = get_metadata_variable_name_from_kwargs(request_kwargs)
-        pool: Final = tuple(self._tier_pools().get(tier_key, ()))
+        pool: Final = tuple(
+            entry
+            for entry in self._tier_pools().get(tier_key, ())
+            if eligible_models is None or entry in eligible_models
+        )
         if not pool:
             # Nothing for the plugins to filter. Falling through would raise the
             # plugin-filtering error below and send the operator hunting for a policy
@@ -1762,6 +1780,7 @@ class ComplexityRouter(CustomLogger):
         request_kwargs: dict[str, Any] | None = None,
         hard_floor: ComplexityTier | str | None = None,
         hard_ceiling: ComplexityTier | str | None = None,
+        eligible_models: frozenset[str] | None = None,
     ) -> str:
         """hard_floor excludes every candidate whose tiers all sit below it, turning this pick's
         soft floors (a distance penalty a high-scoring cheap model can outweigh) into a hard
@@ -1785,12 +1804,16 @@ class ComplexityRouter(CustomLogger):
         if adaptive is None or not isinstance(classified_tier, ComplexityTier):
             # Custom tier names have no severity index; adaptive is rejected alongside
             # tier_definitions, so this guard is the contract for any future caller.
-            return self.get_model_for_tier(classified_tier)
+            return self.get_model_for_tier(classified_tier, eligible_models)
 
         request_type: Final = classify_prompt(user_message)
         classified_idx: Final = TIER_SEVERITY_ORDER.index(classified_tier)
         pools: Final = self._tier_pools()
-        classified_candidates: Final = tuple(pools.get(_tier_name(classified_tier), ()))
+        classified_candidates: Final = tuple(
+            model
+            for model in pools.get(_tier_name(classified_tier), ())
+            if eligible_models is None or model in eligible_models
+        )
         cold_start_candidates: Final = tuple(
             model for model in classified_candidates if adaptive._cells[(request_type, model)].total_samples == 0
         )
@@ -1820,9 +1843,13 @@ class ComplexityRouter(CustomLogger):
         if self.config.adaptive_eligible == "classified_tier":
             candidates = list(classified_candidates)
             if not candidates:
-                return self.get_model_for_tier(classified_tier)
+                return self.get_model_for_tier(classified_tier, eligible_models)
         else:
-            candidates = list(adaptive.config.available_models)
+            candidates = tuple(
+                model
+                for model in adaptive.config.available_models
+                if eligible_models is None or model in eligible_models
+            )
 
         all_costs: Final = [adaptive.model_to_cost.get(m, 0.0) for m in candidates]
         quality_weight: Final = self.config.adaptive_weights.quality
@@ -1869,7 +1896,7 @@ class ComplexityRouter(CustomLogger):
                 best_score = score
                 best_model = model
         if best_model is None:
-            return self.get_model_for_tier(classified_tier)
+            return self.get_model_for_tier(classified_tier, eligible_models)
         if request_kwargs is not None:
             metadata = request_kwargs.setdefault("metadata", {})
             if isinstance(metadata, dict):
@@ -2011,11 +2038,13 @@ class ComplexityRouter(CustomLogger):
         )
         return higher_tiers[0] if higher_tiers else tier
 
-    def _escalated_pin(self, pinned_model: str) -> str | None:
+    def _escalated_pin(self, pinned_model: str, gate: ModalityGate) -> str | None:
         """Bump a session's pinned model to the next-higher configured tier.
 
         Returns None when the pin no longer maps to any configured tier, signalling
-        a full reclassification instead.
+        a full reclassification instead. The escalated pick is a NEW placement rather than the
+        kept pin, so the modality gate applies to it, bounded below by the pinned tier; keeping
+        the pin untouched stays ungated by design.
         """
         pinned_tier: Final = self._tier_for_model(pinned_model)
         if pinned_tier is None:
@@ -2023,7 +2052,75 @@ class ComplexityRouter(CustomLogger):
         escalated_tier: Final = self._escalate_tier(pinned_tier)
         if escalated_tier == pinned_tier:
             return pinned_model
-        return self.get_model_for_tier(escalated_tier)
+        placement: Final = gate.place(escalated_tier, floor=pinned_tier, default_priority="never")
+        return self.get_model_for_tier(
+            placement.tier if placement.tier is not None else escalated_tier, gate.pool_filter()
+        )
+
+    def _model_accepts_image_input(self, model_name: str) -> bool:
+        """Whether a tier pool entry can serve an image request.
+
+        Resolved through the deployments that would actually serve the name; a name with no
+        deployment on the router is served by the SDK directly and is checked against the model
+        cost map itself. Only an explicit supports_vision false excludes, a deployment-level
+        model_info override first and the map otherwise, so unmapped custom names stay routable.
+
+        A multi-deployment group must accept on EVERY deployment: the router picks a deployment
+        inside the group after this gate runs, so a mixed group marked eligible could still hand
+        the image to its text-only member and fail with the exact 400 the gate exists to prevent.
+        A mixed group is treated text-only and escalated past; deployment-level filtering inside
+        a group is the generic router's layer.
+        """
+        from litellm.utils import is_vision_explicitly_disabled
+
+        def deployment_accepts(deployment: Mapping[str, Any]) -> bool:
+            declared: Final = (deployment.get("model_info") or EMPTY_MAPPING).get("supports_vision")
+            if declared is not None:
+                return declared is True
+            litellm_model: Final = (deployment.get("litellm_params") or EMPTY_MAPPING).get("model") or model_name
+            return not is_vision_explicitly_disabled(litellm_model)
+
+        deployments: Final = self.litellm_router_instance.get_model_list(model_name=model_name)
+        if not deployments:
+            return not is_vision_explicitly_disabled(model_name)
+        return all(deployment_accepts(deployment) for deployment in deployments)
+
+    def _modality_eligible_models(self) -> frozenset[str]:
+        """Every configured pool entry, plus default_model, that can serve an image request."""
+        names: Final = frozenset(entry for pool in self._tier_pools().values() for entry in pool) | frozenset(
+            name for name in (self.config.default_model,) if name
+        )
+        return frozenset(name for name in names if self._model_accepts_image_input(name))
+
+    def _build_modality_gate(self, resolved_messages: Sequence[Mapping[str, object]] | None) -> ModalityGate:
+        """This request's capability constraint; INACTIVE (and free of lookups) unless
+        modality_routing is on and the request carries an image content part."""
+        active: Final = (
+            self.config.modality_routing
+            and resolved_messages is not None
+            and request_contains_image_content(resolved_messages)
+        )
+        eligible: Final = self._modality_eligible_models() if active else frozenset()
+        return ModalityGate(
+            active=active,
+            eligible=eligible,
+            tier_names=tuple(self.config.tier_names()),
+            pools=self._tier_pools(),
+            default_model=self.config.default_model,
+            default_model_available=bool(self.config.default_model) and not self.config.plugins,
+            default_model_eligible=bool(self.config.default_model)
+            and (not active or self.config.default_model in eligible),
+            has_custom_tiers=self.config.has_custom_tiers,
+            router_name=self.model_name,
+        )
+
+    def _placed_default_model(self) -> str:
+        """The default_model behind a placement whose tier is None, which the gate only emits
+        when the config carries one; the raise is the type-level proof, not a reachable path."""
+        model: Final = self.config.default_model
+        if model is None:
+            raise ValueError(f"Auto-router {self.model_name}: modality gate routed to an unset default_model")
+        return model
 
     def _lexical_tier_override(self, user_message: str) -> KeywordOverride | None:
         """When keyword_tier_rules match literally, the most-severe matched tier wins.
@@ -2309,7 +2406,6 @@ class ComplexityRouter(CustomLogger):
             pinned_value: Final = await self.litellm_router_instance.cache.async_get_cache(key=cache_key)
             pinned_pin: Final = _parse_session_affinity_pin(pinned_value)
             if pinned_pin is not None:
-                routed_model: str | None = pinned_pin.model
                 pin_escalation_keyword: str | None = None
                 if self.escalation_keywords:
                     user_message: Final = (
@@ -2317,8 +2413,17 @@ class ComplexityRouter(CustomLogger):
                     )
                     if user_message is not None:
                         pin_escalation_keyword = self._matched_escalation_keyword(user_message)
-                    if pin_escalation_keyword is not None:
-                        routed_model = self._escalated_pin(pinned_pin.model)
+                pin_plan_sentinel: Final = self._matched_plan_mode_signal(request_kwargs, resolved_messages)
+                # A kept pin is ungated by design, so the gate's capability lookups are priced
+                # only when a REPLACEMENT pick (escalation or plan floor) can occur on this turn.
+                pin_gate: Final = self._build_modality_gate(
+                    resolved_messages if pin_escalation_keyword is not None or pin_plan_sentinel is not None else None
+                )
+                routed_model: str | None = (
+                    self._escalated_pin(pinned_pin.model, pin_gate)
+                    if pin_escalation_keyword is not None
+                    else pinned_pin.model
+                )
                 if routed_model is not None:
                     escalated: Final = routed_model != pinned_pin.model
                     resolved_pin_tier: Final = (
@@ -2331,14 +2436,20 @@ class ComplexityRouter(CustomLogger):
                     # the floor, and the stored pin deliberately keeps the session's own model so
                     # the first turn after plan mode exits auto-routes exactly as it would have.
                     # Escalation is the opposite on purpose -- an explicit ask to re-pin higher.
-                    pin_plan_sentinel: Final = self._matched_plan_mode_signal(request_kwargs, resolved_messages)
                     pinned_tier: Final = resolved_pin_tier if pin_plan_sentinel is not None else None
                     plan_floored: Final = (
                         pinned_tier is not None and self._apply_plan_mode_floor(pinned_tier) != pinned_tier
                     )
                     session_model: Final = routed_model
                     if plan_floored and pinned_tier is not None:
-                        routed_model = self.get_model_for_tier(self._apply_plan_mode_floor(pinned_tier))
+                        floored_pin_tier: Final = self._apply_plan_mode_floor(pinned_tier)
+                        pin_placement: Final = pin_gate.place(
+                            floored_pin_tier, floor=floored_pin_tier, default_priority="never"
+                        )
+                        routed_model = self.get_model_for_tier(
+                            pin_placement.tier if pin_placement.tier is not None else floored_pin_tier,
+                            pin_gate.pool_filter(),
+                        )
                     # Refresh the TTL on every hit so an active session doesn't lose its
                     # pin mid-conversation just because it outlives the original write.
                     await self.litellm_router_instance.cache.async_set_cache(
@@ -2379,6 +2490,7 @@ class ComplexityRouter(CustomLogger):
                                 escalated=escalated,
                                 conversation_continuing=conversation_continuing,
                                 tier_litellm_params=session_tier_litellm_params,
+                                signals=pin_gate.decision_signals(ModalityPlacement(None, None, False)),
                             ),
                         )
                     )
@@ -2412,6 +2524,48 @@ class ComplexityRouter(CustomLogger):
                 ttl=self.config.session_affinity_ttl_seconds,
             )
         return self._with_session_deployment_affinity(response)
+
+    async def _route_without_ask(
+        self,
+        gate: ModalityGate,
+        messages: list[dict[str, Any]] | None,  # mutable-ok: forwarded verbatim to list-typed hook params
+        resolved_messages: Sequence[Mapping[str, object]],
+        request_kwargs: dict,  # mutable-ok: same shape _classify_and_route receives
+        has_original_messages: bool,
+        conversation_continuing: bool,
+    ) -> PreRoutingHookResponse:
+        """Route a request with no extractable user ask (e.g. an image-only prompt)."""
+        from litellm.types.router import PreRoutingHookResponse
+
+        no_ask_floor: Final = (
+            self._resolve_plan_mode_floor()
+            if gate.active and self._matched_plan_mode_signal(request_kwargs, resolved_messages) is not None
+            else None
+        )
+        placement: Final = gate.place(ComplexityTier.MEDIUM, floor=no_ask_floor, default_priority="first")
+        if placement.tier is None:
+            # No plugins configured: preserve the pre-existing default_model-first
+            # priority exactly (changing it would be a silent behavior change for
+            # every non-plugin user, not just a security fix).
+            routed_model = self._placed_default_model()
+        else:
+            # Plugins configured, no usable default, or the gate displaced it: the pool
+            # pick runs, and with plugins the plugin pipeline runs with it. default_model
+            # is never checked against the plugins, so it must not bypass them here.
+            routed_model = await self._pick_model_for_tier(
+                placement.tier, messages, resolved_messages, request_kwargs, gate.pool_filter()
+            )
+        return PreRoutingHookResponse(
+            model=routed_model,
+            messages=messages if has_original_messages else None,
+            routing_decision=self._build_routing_decision(
+                routed_model=routed_model,
+                cause=gate.decision_cause(placement, "default_fallback"),
+                tier=placement.tier,
+                conversation_continuing=conversation_continuing,
+                signals=gate.decision_signals(placement),
+            ),
+        )
 
     async def _classify_and_route(
         self,
@@ -2453,33 +2607,14 @@ class ComplexityRouter(CustomLogger):
         # Determine whether the original request used messages directly
         has_original_messages: Final = messages is not None and len(messages) > 0
 
+        gate: Final = self._build_modality_gate(resolved_messages)
+
         user_message, system_prompt = _extract_current_ask_and_system_prompt(resolved_messages, self._reminder_markers)
 
         if user_message is None:
             verbose_router_logger.debug("ComplexityRouter: No user message found, routing to default model")
-            default_model_first: Final = not self.config.plugins and self.config.default_model
-            if default_model_first:
-                # No plugins configured: preserve the pre-existing default_model-first
-                # priority exactly (changing it would be a silent behavior change for
-                # every non-plugin user, not just a security fix).
-                routed_model = self.config.default_model
-            else:
-                # Plugins configured: default_model must never bypass them, so it's not
-                # checked here at all -- _pick_model_for_tier -> get_model_for_tier still
-                # falls back to it (after the MEDIUM tier) once the plugin pipeline runs.
-                routed_model = await self._pick_model_for_tier(
-                    ComplexityTier.MEDIUM, messages, resolved_messages, request_kwargs
-                )
-            fallback_tier: Final = None if default_model_first else ComplexityTier.MEDIUM
-            return PreRoutingHookResponse(
-                model=routed_model,
-                messages=messages if has_original_messages else None,
-                routing_decision=self._build_routing_decision(
-                    routed_model=routed_model,
-                    cause="default_fallback",
-                    tier=fallback_tier,
-                    conversation_continuing=conversation_continuing,
-                ),
+            return await self._route_without_ask(
+                gate, messages, resolved_messages, request_kwargs, has_original_messages, conversation_continuing
             )
 
         newest_ask: Final = _newest_turn_ask(resolved_messages, self._reminder_markers)
@@ -2491,10 +2626,19 @@ class ComplexityRouter(CustomLogger):
             # No configured tier outranks the floor, so neither the keyword rules nor the
             # classifier could change the answer -- routing directly saves the classifier call
             # on every plan-mode turn.
-            routed_model = await self._pick_model_for_tier(plan_floor, messages, resolved_messages, request_kwargs)
+            plan_placement: Final = gate.place(plan_floor, floor=plan_floor)
+            routed_model = (
+                await self._pick_model_for_tier(
+                    plan_placement.tier, messages, resolved_messages, request_kwargs, gate.pool_filter()
+                )
+                if plan_placement.tier is not None
+                else self._placed_default_model()
+            )
+            plan_cause: Final = gate.decision_cause(plan_placement, "plan_mode")
             verbose_router_logger.info(
-                "ComplexityRouter: routing decision cause=plan_mode, tier=%s, routed_model=%s",
-                _tier_name(plan_floor),
+                "ComplexityRouter: routing decision cause=%s, tier=%s, routed_model=%s",
+                plan_cause,
+                _tier_name(plan_placement.tier) if plan_placement.tier is not None else "n/a",
                 routed_model,
             )
             return PreRoutingHookResponse(
@@ -2503,11 +2647,12 @@ class ComplexityRouter(CustomLogger):
                 routing_decision=self._build_routing_decision(
                     routed_model=routed_model,
                     conversation_continuing=conversation_continuing,
-                    cause="plan_mode",
-                    tier=plan_floor,
+                    cause=plan_cause,
+                    tier=plan_placement.tier,
                     matched_keyword=plan_mode_sentinel,
                     escalation_keyword=escalation_keyword,
                     escalated=False,
+                    signals=gate.decision_signals(plan_placement),
                 ),
             )
 
@@ -2521,18 +2666,26 @@ class ComplexityRouter(CustomLogger):
                 self._apply_plan_mode_floor(escalated_tier) if plan_floor is not None else escalated_tier
             )
             keyword_plan_floored: Final = routed_tier != escalated_tier
-            routed_model = await self._pick_model_for_tier(routed_tier, messages, resolved_messages, request_kwargs)
-            keyword_tier_litellm_params: Final = self._litellm_params_for_model(routed_tier, routed_model)
-            keyword_cause: Final[RoutingDecisionCause] = (
+            keyword_placement: Final = gate.place(routed_tier, floor=plan_floor)
+            routed_model = (
+                await self._pick_model_for_tier(
+                    keyword_placement.tier, messages, resolved_messages, request_kwargs, gate.pool_filter()
+                )
+                if keyword_placement.tier is not None
+                else self._placed_default_model()
+            )
+            keyword_tier_litellm_params: Final = self._litellm_params_for_model(keyword_placement.tier, routed_model)
+            keyword_cause: Final[RoutingDecisionCause] = gate.decision_cause(
+                keyword_placement,
                 "plan_mode"
                 if keyword_plan_floored
-                else ("semantic_keyword_match" if self.config.semantic_keyword_matching else "literal_keyword_match")
+                else ("semantic_keyword_match" if self.config.semantic_keyword_matching else "literal_keyword_match"),
             )
             verbose_router_logger.info(
                 "ComplexityRouter: routing decision cause=%s, escalated=%s, tier=%s, routed_model=%s",
                 keyword_cause,
                 keyword_escalated,
-                _tier_name(routed_tier),
+                _tier_name(keyword_placement.tier) if keyword_placement.tier is not None else "n/a",
                 routed_model,
             )
             return PreRoutingHookResponse(
@@ -2543,11 +2696,12 @@ class ComplexityRouter(CustomLogger):
                     routed_model=routed_model,
                     conversation_continuing=conversation_continuing,
                     cause=keyword_cause,
-                    tier=routed_tier,
+                    tier=keyword_placement.tier,
                     matched_keyword=plan_mode_sentinel if keyword_plan_floored else override.matched_keyword,
                     escalation_keyword=escalation_keyword,
                     escalated=keyword_escalated,
                     tier_litellm_params=keyword_tier_litellm_params,
+                    signals=gate.decision_signals(keyword_placement),
                 ),
             )
 
@@ -2580,7 +2734,12 @@ class ComplexityRouter(CustomLogger):
         # pool that holds it, or MEDIUM when none does), so a placeholder at or above the floor
         # would otherwise route a plan-mode request to a model the floor cannot vouch for. The
         # clamped tier's pool is the destination the floor can guarantee.
-        if outcome.cause == "default_model_fallback" and fallback_model is not None and plan_mode_sentinel is None:
+        failure_default_placement: Final = (
+            gate.place(tier, default_priority="first")
+            if outcome.cause == "default_model_fallback" and fallback_model is not None and plan_mode_sentinel is None
+            else None
+        )
+        if failure_default_placement is not None and failure_default_placement.tier is None:
             # Classification failed and the operator asked for default_model, so route there
             # directly. Neither the tier pool nor the adaptive bandit gets a say: both answer
             # "which model suits this tier", and no tier was decided. Escalation is skipped for
@@ -2603,12 +2762,23 @@ class ComplexityRouter(CustomLogger):
                     routed_model=fallback_model,
                     conversation_continuing=conversation_continuing,
                     cause=outcome.cause,
-                    signals=outcome.signals,
+                    signals=gate.decision_signals(failure_default_placement, outcome.signals),
                     escalation_keyword=escalation_keyword,
                     escalated=False,
                 ),
             )
-        if self.config.adaptive:
+        # A classifier-failure default the gate displaced keeps its default-first intent, so the
+        # displacement is recorded on whichever placement finally serves the request.
+        main_placement: Final = gate.place(
+            tier, floor=plan_floor, default_priority="first" if failure_default_placement is not None else "last"
+        )
+        if main_placement.tier is None:
+            routed_model = self._placed_default_model()
+            verbose_router_logger.info(
+                "ComplexityRouter: routing decision cause=modality_escalation, tier=n/a, routed_model=%s",
+                routed_model,
+            )
+        elif self.config.adaptive:
             # hard_floor rather than a hard pick, and passed whenever the sentinel is present
             # rather than only when the floor moved the tier: a request classified AT the floor
             # has plan_floored False, yet adaptive_eligible="all" scores every model and only
@@ -2618,9 +2788,14 @@ class ComplexityRouter(CustomLogger):
             # and the plan-mode floor both move a housekeeping call up, and a ceiling still naming
             # the cheapest tier would then contradict the floor and bound the pick below the tier
             # the decision reports.
-            housekeeping_ceiling: Final = tier if outcome.cause == "housekeeping" else None
+            housekeeping_ceiling: Final = main_placement.tier if outcome.cause == "housekeeping" else None
             routed_model = self._soft_floor_pick(
-                tier, user_message, request_kwargs, hard_floor=plan_floor, hard_ceiling=housekeeping_ceiling
+                main_placement.tier,
+                user_message,
+                request_kwargs,
+                hard_floor=plan_floor,
+                hard_ceiling=housekeeping_ceiling,
+                eligible_models=gate.pool_filter(),
             )
             adaptive: Final = self._ensure_adaptive_router()
             if adaptive is not None:
@@ -2631,23 +2806,25 @@ class ComplexityRouter(CustomLogger):
             verbose_router_logger.info(
                 "ComplexityRouter[adaptive]: routing decision cause=%s, tier=%s, score=%s, signals=%s, routed_model=%s",
                 outcome.cause,
-                _tier_name(tier),
+                _tier_name(main_placement.tier),
                 score_repr,
                 signals,
                 routed_model,
             )
         else:
-            routed_model = await self._pick_model_for_tier(tier, messages, resolved_messages, request_kwargs)
+            routed_model = await self._pick_model_for_tier(
+                main_placement.tier, messages, resolved_messages, request_kwargs, gate.pool_filter()
+            )
             verbose_router_logger.info(
                 "ComplexityRouter: routing decision cause=%s, tier=%s, score=%s, signals=%s, routed_model=%s",
                 outcome.cause,
-                _tier_name(tier),
+                _tier_name(main_placement.tier),
                 score_repr,
                 signals,
                 routed_model,
             )
 
-        tier_litellm_params: Final = self._litellm_params_for_model(tier, routed_model)
+        tier_litellm_params: Final = self._litellm_params_for_model(main_placement.tier, routed_model)
         classifier_model: Final = (
             self.config.classifier_llm_config.model
             if outcome.cause == "llm_classifier" and self.config.classifier_llm_config is not None
@@ -2662,14 +2839,19 @@ class ComplexityRouter(CustomLogger):
         # failure path where no tier was decided and reporting one would fabricate a
         # classification.
         classified_pool_tier: Final = (
-            None if outcome.cause == "default_model_fallback" and plan_mode_sentinel is None else tier
+            None
+            if (outcome.cause == "default_model_fallback" and plan_mode_sentinel is None) or main_placement.tier is None
+            else main_placement.tier
         )
-        decision_signals: Final = (
-            (*signals, f"plugin-filtered-pool:{_tier_name(tier)}")
-            if outcome.cause == "default_model_fallback" and self.config.plugins
+        base_signals: Final = (
+            (*signals, f"plugin-filtered-pool:{_tier_name(main_placement.tier)}")
+            if outcome.cause == "default_model_fallback" and self.config.plugins and main_placement.tier is not None
             else signals
         )
-        decision_cause: Final[RoutingDecisionCause] = "plan_mode" if plan_floored else outcome.cause
+        decision_signals: Final = gate.decision_signals(main_placement, base_signals)
+        decision_cause: Final[RoutingDecisionCause] = gate.decision_cause(
+            main_placement, "plan_mode" if plan_floored else outcome.cause
+        )
         decision_keyword: Final = (
             plan_mode_sentinel if plan_floored else (housekeeping_sentinel if outcome.cause == "housekeeping" else None)
         )

--- a/litellm/router_strategy/complexity_router/config.py
+++ b/litellm/router_strategy/complexity_router/config.py
@@ -823,6 +823,22 @@ class ComplexityRouterConfig(BaseModel):
         ),
     )
 
+    modality_routing: bool = Field(
+        default=False,
+        description=(
+            "Route image-bearing requests only to tier models that can accept image input. "
+            "The complexity classifier reads text alone, so an image request whose text "
+            "classifies cheap otherwise lands on a text-only model and fails with a provider "
+            "400. When enabled, a request carrying an image content part is served by the "
+            "nearest tier (preferring higher) whose pool has a model not explicitly declared "
+            "supports_vision false, falling back to default_model when no tier qualifies, and "
+            "rejected with a clear 400 when nothing can serve it. Only an explicit "
+            "supports_vision false (deployment model_info or the model cost map) excludes a "
+            "model, so unmapped custom names stay routable. A session-affinity pin still wins: "
+            "a session pinned to a text-only model keeps it even when an image arrives."
+        ),
+    )
+
     # Semantic (embedding) matching for keyword_tier_rules instead of literal text matching
     semantic_keyword_matching: bool = Field(
         default=False,

--- a/litellm/router_strategy/complexity_router/modality_gate.py
+++ b/litellm/router_strategy/complexity_router/modality_gate.py
@@ -1,0 +1,146 @@
+"""Capability gate for image-bearing requests through the complexity router.
+
+The classifier reads text alone, so an image request whose text classifies cheap lands on a
+text-only model and fails with a provider 400 no fallback catches. When `modality_routing` is
+enabled, every NEW placement the router makes runs through one `ModalityGate` built per request;
+a session pin that is merely kept is not a new placement and stays ungated by design.
+
+The gate is a pure value so that every bound has exactly one implementation: the capability
+filter, the plan-mode floor (the walk starts at the floor when the decided tier sits below it
+and never steps under it), and the default_model arms (suppressed by a floor, and never offered
+on plugin-configured routers, where default_model was never checked against the plugin
+pipeline). An INACTIVE gate reproduces the router's pre-existing behavior identically, so the
+call sites are unconditional and the flag-off path cannot drift from them.
+"""
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from typing import Final, Literal, NamedTuple
+
+from litellm.types.utils import RoutingDecisionCause
+
+from .config import ComplexityTier
+
+DefaultModelPriority = Literal["first", "last", "never"]
+
+
+def _name(tier: ComplexityTier | str) -> str:
+    return tier.value if isinstance(tier, ComplexityTier) else tier
+
+
+class ModalityPlacement(NamedTuple):
+    """Where one request lands: a tier, or None when default_model serves it."""
+
+    tier: ComplexityTier | str | None
+    displaced_from: ComplexityTier | str | None
+    displaced_default_model: bool
+
+    @property
+    def moved(self) -> bool:
+        return self.displaced_from is not None or self.displaced_default_model
+
+
+@dataclass(frozen=True, slots=True)
+class ModalityGate:
+    """One request's capability constraint, built by `ComplexityRouter._build_modality_gate`."""
+
+    active: bool
+    eligible: frozenset[str]
+    tier_names: tuple[str, ...]
+    pools: Mapping[str, Sequence[str]]
+    default_model: str | None
+    default_model_available: bool
+    default_model_eligible: bool
+    has_custom_tiers: bool
+    router_name: str
+
+    def place(
+        self,
+        decided: ComplexityTier | str,
+        floor: ComplexityTier | str | None = None,
+        default_priority: DefaultModelPriority = "last",
+    ) -> ModalityPlacement:
+        """The placement for a decided tier, under this request's capability constraint.
+
+        `default_priority` is the seam's ORDERING intent only: "first" is the no-ask and
+        classifier-failure default-first paths, "last" the ordinary tier-first paths, "never"
+        the pin path. Whether default_model may serve at all is the gate's own call
+        (configured, plugin-free, capability-eligible, and no floor, since default_model
+        carries no tier guarantee a floor could vouch for).
+        """
+        default_first: Final = default_priority == "first" and self.default_model_available
+        if not self.active:
+            return ModalityPlacement(None if default_first else decided, None, False)
+        default_usable: Final = (
+            default_priority != "never"
+            and self.default_model_available
+            and self.default_model_eligible
+            and floor is None
+        )
+        if default_first and default_usable:
+            return ModalityPlacement(None, None, False)
+        decided_key: Final = _name(decided)
+        # A caller's stand-in for "the fallback pool" (the no-ask MEDIUM) is not a tier a
+        # custom set defines; the walk then starts at the cheapest configured tier and reports
+        # displacement against it, never against the stand-in's name.
+        effective_key: Final = decided_key if decided_key in self.tier_names else self._cheapest_pooled_name()
+        winner: Final = self._walk(effective_key, floor)
+        displaced_default: Final = default_first and not default_usable
+        if winner is not None:
+            displaced_from: Final = self._resolve(effective_key) if winner != effective_key else None
+            return ModalityPlacement(self._resolve(winner), displaced_from, displaced_default)
+        if default_usable:
+            return ModalityPlacement(None, self._resolve(effective_key), displaced_default)
+        import litellm
+
+        raise litellm.BadRequestError(
+            message=(
+                f"Auto-router {self.router_name} received a request with image input, but no model "
+                f"in its tiers accepts images and modality_routing is enabled. "
+                f"Tiers checked: {', '.join(self.tier_names)}. Add a vision-capable model to a tier, "
+                f"or set a vision-capable default_model, or remove the image content."
+            ),
+            model=self.router_name,
+            llm_provider="",
+        )
+
+    def decision_cause(self, placement: ModalityPlacement, base: RoutingDecisionCause) -> RoutingDecisionCause:
+        return "modality_escalation" if self.active and placement.moved else base
+
+    def decision_signals(
+        self, placement: ModalityPlacement, base: tuple[str, ...] | None = None
+    ) -> tuple[str, ...] | None:
+        if not self.active:
+            return base
+        return (
+            *(base or ()),
+            "modality:image",
+            *(
+                (f"modality_escalated_from:{_name(placement.displaced_from)}",)
+                if placement.displaced_from is not None
+                else ()
+            ),
+            *(("modality_displaced_default_model",) if placement.displaced_default_model else ()),
+        )
+
+    def pool_filter(self) -> frozenset[str] | None:
+        """The eligible set for the tier-to-model pickers, or None when the gate is inactive."""
+        return self.eligible if self.active else None
+
+    def _walk(self, effective_key: str, floor: ComplexityTier | str | None) -> str | None:
+        names: Final = self.tier_names
+        decided_idx: Final = names.index(effective_key) if effective_key in names else 0
+        floor_key: Final = _name(floor) if floor is not None else None
+        floor_idx: Final = names.index(floor_key) if floor_key is not None and floor_key in names else 0
+        start_idx: Final = max(decided_idx, floor_idx)
+        ordered: Final = (*names[start_idx:], *reversed(names[floor_idx:start_idx]))
+        return next(
+            (name for name in ordered if any(entry in self.eligible for entry in self.pools.get(name, ()))),
+            None,
+        )
+
+    def _cheapest_pooled_name(self) -> str:
+        return next((name for name in self.tier_names if self.pools.get(name)), self.tier_names[0])
+
+    def _resolve(self, name: str) -> ComplexityTier | str:
+        return name if self.has_custom_tiers else ComplexityTier(name)

--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -2840,6 +2840,12 @@ RoutingDecisionCause = Literal[
     # never called. The matched sentinel rides in matched_keyword. Distinct from the keyword causes,
     # which are operator-authored rules; these sentinels ship with the router.
     "housekeeping",
+    # modality_routing displaced the decided placement: the request carries an image and the
+    # decided tier had no model accepting image input, so the request was served by the nearest
+    # capable tier or default_model instead. The displaced tier rides in signals as
+    # "modality_escalated_from:<TIER>". Distinct from the escalation causes above, which raise a
+    # tier for what the request asks; this one moves it for what the request physically carries.
+    "modality_escalation",
     "session_affinity_pin",
     "session_affinity_escalation",
     "default_fallback",

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -2660,10 +2660,19 @@ def _is_explicitly_disabled_factory(model: str, custom_llm_provider: str | None,
     ``_supports_factory`` so caching, fallback, and normalisation improvements
     apply here automatically.
     """
+    from litellm.litellm_core_utils.get_llm_provider_logic import declared_authenticating_provider
+
     try:
-        model, custom_llm_provider, _, _ = litellm.get_llm_provider(
-            model=model, custom_llm_provider=custom_llm_provider
-        )
+        declared: Final = declared_authenticating_provider(model, custom_llm_provider)
+        if declared is not None:
+            model = model.removeprefix(
+                f"{declared}/"
+            )  # rebind-ok: mirrors get_llm_provider's split without its OAuth flow
+            custom_llm_provider = declared  # rebind-ok: same
+        else:
+            model, custom_llm_provider, _, _ = litellm.get_llm_provider(
+                model=model, custom_llm_provider=custom_llm_provider
+            )
         model_info: Final = _get_model_info_helper(model=model, custom_llm_provider=custom_llm_provider)
         val: Final = model_info.get(key)
         if val is False:
@@ -2749,6 +2758,15 @@ def supports_computer_use(model: str, custom_llm_provider: str | None = None) ->
         custom_llm_provider=custom_llm_provider,
         key="supports_computer_use",
     )
+
+
+def is_vision_explicitly_disabled(model: str, custom_llm_provider: str | None = None) -> bool:
+    """True only when supports_vision is explicitly declared false for the model.
+
+    The opt-out mirror of :func:`supports_vision`: a missing declaration reads as not
+    disabled, so unknown or newly added models stay eligible for image routing.
+    """
+    return _is_explicitly_disabled_factory(model, custom_llm_provider, "supports_vision")
 
 
 def supports_vision(model: str, custom_llm_provider: str | None = None) -> bool:

--- a/tests/test_litellm/litellm_core_utils/prompt_templates/test_litellm_core_utils_prompt_templates_common_utils.py
+++ b/tests/test_litellm/litellm_core_utils/prompt_templates/test_litellm_core_utils_prompt_templates_common_utils.py
@@ -1433,3 +1433,65 @@ class TestFlattenTopLevelSchemaCombinators:
         flatten_top_level_schema_combinators(schema)
 
         assert schema == snapshot
+
+
+class TestRequestContainsImageContent:
+    """One detector for every dialect that reaches pre-routing hooks untranslated."""
+
+    @pytest.mark.parametrize(
+        "part",
+        [
+            {"type": "image_url", "image_url": {"url": "data:image/png;base64,aGk="}},
+            {"type": "input_image", "image_url": "data:image/png;base64,aGk="},
+            {"type": "image", "source": {"type": "base64", "media_type": "image/png", "data": "aGk="}},
+        ],
+    )
+    def test_detects_every_image_dialect(self, part):
+        from litellm.litellm_core_utils.prompt_templates.common_utils import request_contains_image_content
+
+        messages = [{"role": "user", "content": [{"type": "text", "text": "hi"}, part]}]
+        assert request_contains_image_content(messages) is True
+
+    def test_detects_image_nested_in_tool_result(self):
+        from litellm.litellm_core_utils.prompt_templates.common_utils import request_contains_image_content
+
+        messages = [
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": "tu_1",
+                        "content": [
+                            {"type": "text", "text": "screenshot taken"},
+                            {"type": "image", "source": {"type": "base64", "media_type": "image/png", "data": "aGk="}},
+                        ],
+                    }
+                ],
+            }
+        ]
+        assert request_contains_image_content(messages) is True
+
+    @pytest.mark.parametrize(
+        "messages",
+        [
+            [{"role": "user", "content": "plain string"}],
+            [{"role": "user", "content": [{"type": "text", "text": "hi"}]}],
+            [{"role": "user", "content": [{"type": "input_audio", "input_audio": {"data": "x"}}]}],
+            [{"role": "user", "content": [{"type": "tool_result", "content": [{"type": "text", "text": "done"}]}]}],
+            [{"role": "user", "content": None}],
+            [],
+        ],
+    )
+    def test_ignores_text_audio_and_degenerate_shapes(self, messages):
+        from litellm.litellm_core_utils.prompt_templates.common_utils import request_contains_image_content
+
+        assert request_contains_image_content(messages) is False
+
+    def test_hostile_nesting_is_depth_bounded(self):
+        from litellm.litellm_core_utils.prompt_templates.common_utils import request_contains_image_content
+
+        nested: dict = {"type": "image", "source": {"type": "base64", "data": "aGk="}}
+        for _ in range(50):
+            nested = {"type": "tool_result", "content": [nested]}
+        assert request_contains_image_content([{"role": "user", "content": [nested]}]) is False

--- a/tests/test_litellm/router_strategy/test_complexity_router.py
+++ b/tests/test_litellm/router_strategy/test_complexity_router.py
@@ -479,7 +479,7 @@ class TestModelSelection:
                 "default_model": "mid",
             },
         )
-        pool = ["cheap", "premium"]
+        pool = ("cheap", "premium")
         with patch(
             "litellm.router_strategy.complexity_router.complexity_router.random.choice",
             return_value="premium",
@@ -3023,7 +3023,7 @@ class TestAdaptiveSoftFloors:
                 "default_model": "mid",
             },
         )
-        pool = ["cheap", "premium"]
+        pool = ("cheap", "premium")
         with patch(
             "litellm.router_strategy.complexity_router.complexity_router.random.choice",
             return_value="premium",
@@ -5291,7 +5291,7 @@ class TestEscalationKeywords:
             complexity_router_config={"tiers": {"SIMPLE": "gpt-4o-mini", "REASONING": ["o1-a", "o1-b", "o1-c"]}},
         )
         for pinned in ("o1-a", "o1-b", "o1-c"):
-            assert router._escalated_pin(pinned) == pinned
+            assert router._escalated_pin(pinned, router._build_modality_gate(None)) == pinned
 
     @pytest.mark.asyncio
     async def test_session_escalation_at_ceiling_keeps_multi_model_pin(self, mock_router_instance):
@@ -9762,3 +9762,345 @@ class TestHeuristicFirst:
         )
         outcome = await router.aclassify(NO_SIGNAL_PROMPT)
         assert outcome.cause == "default_model_fallback"
+
+
+IMG_PART = {"type": "image_url", "image_url": {"url": "data:image/png;base64,aGk="}}
+
+
+def _gate(**overrides):
+    from litellm.router_strategy.complexity_router.modality_gate import ModalityGate
+
+    base = {
+        "active": True,
+        "eligible": frozenset({"vision-mid", "vision-big", "vision-default"}),
+        "tier_names": ("SIMPLE", "MEDIUM", "COMPLEX", "REASONING"),
+        "pools": {
+            "SIMPLE": ("text-cheap",),
+            "MEDIUM": ("vision-mid",),
+            "COMPLEX": ("vision-big",),
+        },
+        "default_model": "vision-default",
+        "default_model_available": True,
+        "default_model_eligible": True,
+        "has_custom_tiers": False,
+        "router_name": "gate-test-router",
+    }
+    return ModalityGate(**{**base, **overrides})
+
+
+class TestModalityGatePlacement:
+    """place() owns every bound: capability walk, floor, and the default_model arms."""
+
+    @pytest.mark.parametrize(
+        "priority, expected_tier",
+        [("first", None), ("last", ComplexityTier.SIMPLE), ("never", ComplexityTier.SIMPLE)],
+    )
+    def test_inactive_gate_reproduces_preexisting_behavior(self, priority, expected_tier):
+        placement = _gate(active=False).place(ComplexityTier.SIMPLE, default_priority=priority)
+        assert placement == (expected_tier, None, False)
+
+    def test_default_first_serves_an_eligible_default(self):
+        assert _gate().place(ComplexityTier.SIMPLE, default_priority="first").tier is None
+
+    @pytest.mark.parametrize(
+        "overrides, floor",
+        [
+            ({"default_model_eligible": False}, None),
+            ({}, ComplexityTier.MEDIUM),
+            ({"default_model_available": False}, None),
+        ],
+    )
+    def test_default_first_is_displaced_by_ineligibility_floor_or_plugins(self, overrides, floor):
+        placement = _gate(**overrides).place(ComplexityTier.SIMPLE, floor=floor, default_priority="first")
+        assert placement.tier == ComplexityTier.MEDIUM
+        assert placement.displaced_default_model is (overrides != {"default_model_available": False})
+
+    def test_walk_goes_up_then_down_and_records_displacement(self):
+        up = _gate().place(ComplexityTier.SIMPLE)
+        assert up == (ComplexityTier.MEDIUM, ComplexityTier.SIMPLE, False)
+        down = _gate(eligible=frozenset({"vision-mid"})).place(ComplexityTier.REASONING)
+        assert down == (ComplexityTier.MEDIUM, ComplexityTier.REASONING, False)
+
+    def test_floor_bounds_both_walk_directions(self):
+        above = _gate().place(ComplexityTier.SIMPLE, floor=ComplexityTier.COMPLEX)
+        assert above.tier == ComplexityTier.COMPLEX
+        with pytest.raises(litellm.BadRequestError):
+            _gate(eligible=frozenset({"vision-mid"})).place(ComplexityTier.COMPLEX, floor=ComplexityTier.COMPLEX)
+
+    def test_no_capable_tier_falls_to_default_last_then_raises(self):
+        to_default = _gate(eligible=frozenset({"vision-default"})).place(ComplexityTier.SIMPLE)
+        assert to_default == (None, ComplexityTier.SIMPLE, False)
+        with pytest.raises(litellm.BadRequestError, match="no model"):
+            _gate(eligible=frozenset()).place(ComplexityTier.SIMPLE, default_priority="never")
+
+    def test_custom_set_normalizes_an_unknown_stand_in_to_its_cheapest_tier(self):
+        gate = _gate(
+            has_custom_tiers=True,
+            tier_names=("cheap", "premium"),
+            pools={"cheap": ("cheap-model",), "premium": ("premium-model",)},
+            eligible=frozenset({"premium-model"}),
+        )
+        placement = gate.place(ComplexityTier.MEDIUM, default_priority="never")
+        assert placement == ("premium", "cheap", False)
+
+    def test_decision_owner_stamps_cause_and_signals_only_when_moved(self):
+        gate = _gate()
+        moved = gate.place(ComplexityTier.SIMPLE)
+        kept = gate.place(ComplexityTier.MEDIUM)
+        assert gate.decision_cause(moved, "heuristic_scorer") == "modality_escalation"
+        assert gate.decision_cause(kept, "heuristic_scorer") == "heuristic_scorer"
+        assert gate.decision_signals(moved) == ("modality:image", "modality_escalated_from:SIMPLE")
+        assert gate.decision_signals(kept, ("base",)) == ("base", "modality:image")
+        assert _gate(active=False).decision_signals(kept) is None
+
+
+class TestModalityRouting:
+    """modality_routing end to end: image requests only route to models accepting image input."""
+
+    IMAGE_MESSAGE = [{"role": "user", "content": [{"type": "text", "text": "What color is this?"}, IMG_PART]}]
+    PLAN_BODY = {
+        "messages": [
+            {"role": "system", "content": [{"type": "text", "text": "Plan mode is active. Do not execute."}]}
+        ]
+    }
+
+    @staticmethod
+    def _router(mock_router_instance, config, vision_by_model):
+        """vision_by_model: pool entry -> True/False (deployment model_info) or None (undeclared)."""
+
+        def get_model_list(model_name=None):
+            if model_name not in vision_by_model:
+                return []
+            declared = vision_by_model[model_name]
+            return [
+                {
+                    "model_name": model_name,
+                    "litellm_params": {"model": f"openai/unmapped-{model_name}"},
+                    "model_info": {
+                        "adaptive_router_preferences": {"quality_tier": 2},
+                        **({} if declared is None else {"supports_vision": declared}),
+                    },
+                }
+            ]
+
+        mock_router_instance.get_model_list = get_model_list
+        return ComplexityRouter(
+            model_name="modality-test-router",
+            litellm_router_instance=mock_router_instance,
+            complexity_router_config=config,
+        )
+
+    BASE_TIERS = {"SIMPLE": "text-cheap", "MEDIUM": "vision-mid", "COMPLEX": "vision-big"}
+    BASE_VISION = {"text-cheap": False, "vision-mid": True, "vision-big": True, "vision-default": True}
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "config_extra, vision, messages, expected_model, expected_cause, gate_active",
+        [
+            ({}, {"text-cheap": False}, "image", "text-cheap", "heuristic_scorer", False),
+            ({"modality_routing": True}, {"text-cheap": False}, "text", "text-cheap", "heuristic_scorer", False),
+            ({"modality_routing": True}, {"text-cheap": None}, "image", "text-cheap", "heuristic_scorer", True),
+        ],
+        ids=["flag_off", "no_image", "undeclared_model_stays_eligible"],
+    )
+    async def test_gate_is_inert_without_flag_image_or_declaration(
+        self, mock_router_instance, config_extra, vision, messages, expected_model, expected_cause, gate_active
+    ):
+        router = self._router(mock_router_instance, {"tiers": dict(self.BASE_TIERS), **config_extra}, vision)
+        request = (
+            self.IMAGE_MESSAGE if messages == "image" else [{"role": "user", "content": "What color is the sky?"}]
+        )
+        result = await router.async_pre_routing_hook(model="m", request_kwargs={}, messages=request)
+        assert result.model == expected_model
+        assert result.routing_decision["cause"] == expected_cause
+        assert ("modality:image" in (result.routing_decision.get("signals") or ())) is gate_active
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "part",
+        [
+            IMG_PART,
+            {"type": "input_image", "image_url": "data:image/png;base64,aGk="},
+            {"type": "image", "source": {"type": "base64", "media_type": "image/png", "data": "aGk="}},
+            {"type": "tool_result", "tool_use_id": "tu_1", "content": [dict(IMG_PART, type="image")]},
+        ],
+        ids=["image_url", "input_image", "anthropic_image", "tool_result_nested"],
+    )
+    async def test_every_image_dialect_escalates(self, mock_router_instance, part):
+        router = self._router(
+            mock_router_instance, {"tiers": dict(self.BASE_TIERS), "modality_routing": True}, dict(self.BASE_VISION)
+        )
+        message = [{"role": "user", "content": [{"type": "text", "text": "What color is this?"}, part]}]
+        result = await router.async_pre_routing_hook(model="m", request_kwargs={}, messages=message)
+        assert result.model == "vision-mid"
+        assert result.routing_decision["cause"] == "modality_escalation"
+        assert "modality_escalated_from:SIMPLE" in result.routing_decision["signals"]
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "path, expected_model, expected_cause",
+        [
+            ("classifier", "vision-mid", "modality_escalation"),
+            ("mixed_pool_same_tier", "vision-cheap", "heuristic_scorer"),
+            ("keyword", "vision-mid", "modality_escalation"),
+            ("no_ask_default_first", "vision-default", "default_fallback"),
+            ("no_ask_displaced_default", "vision-mid", "modality_escalation"),
+            ("custom_tiers", "premium-model", "modality_escalation"),
+            ("pin_escalation", "vision-big", "session_affinity_escalation"),
+            ("pin_plan_floor", "vision-big", "plan_mode"),
+            ("adaptive", "vision-mid", "modality_escalation"),
+        ],
+    )
+    async def test_placements_across_decision_paths(self, mock_router_instance, path, expected_model, expected_cause):
+        config = {"tiers": dict(self.BASE_TIERS), "modality_routing": True}
+        vision = dict(self.BASE_VISION)
+        request_kwargs = {}
+        messages = self.IMAGE_MESSAGE
+        if path == "mixed_pool_same_tier":
+            config["tiers"]["SIMPLE"] = ["text-cheap", "vision-cheap"]
+            vision["vision-cheap"] = True
+        elif path == "keyword":
+            config["keyword_tier_rules"] = [{"keywords": ["quick lookup"], "tier": "SIMPLE"}]
+            messages = [
+                {"role": "user", "content": [{"type": "text", "text": "quick lookup: what is this?"}, IMG_PART]}
+            ]
+        elif path == "no_ask_default_first":
+            config["default_model"] = "vision-default"
+            messages = [{"role": "user", "content": [IMG_PART]}]
+        elif path == "no_ask_displaced_default":
+            config["default_model"] = "text-default"
+            vision["text-default"] = False
+            messages = [{"role": "user", "content": [IMG_PART]}]
+        elif path == "custom_tiers":
+            config = {
+                "classifier_type": "llm",
+                "classifier_llm_config": {"model": "gpt-4o-mini"},
+                "fallback_tier": "cheap",
+                "tier_definitions": [
+                    {"name": "cheap", "description": "trivial asks"},
+                    {"name": "premium", "description": "hard asks"},
+                ],
+                "tiers": {"cheap": "cheap-model", "premium": "premium-model"},
+                "keyword_tier_rules": [{"keywords": ["quick lookup"], "tier": "cheap"}],
+                "modality_routing": True,
+            }
+            vision = {"cheap-model": False, "premium-model": True}
+            messages = [
+                {"role": "user", "content": [{"type": "text", "text": "quick lookup: what is this?"}, IMG_PART]}
+            ]
+        elif path in ("pin_escalation", "pin_plan_floor"):
+            cache = AsyncMock()
+            cache.async_get_cache = AsyncMock(return_value={"model": "vision-cheap", "tier": "SIMPLE"})
+            mock_router_instance.cache = cache
+            config["tiers"]["SIMPLE"] = "vision-cheap"
+            config["tiers"]["MEDIUM"] = "text-mid"
+            vision.update({"vision-cheap": True, "text-mid": False})
+            config["session_affinity"] = True
+            request_kwargs = {"metadata": {"session_id": "s1"}}
+            if path == "pin_escalation":
+                messages = [
+                    {"role": "user", "content": [{"type": "text", "text": "LITELLM ESCALATE describe this"}, IMG_PART]}
+                ]
+            else:
+                config["plan_mode_min_tier"] = "MEDIUM"
+                request_kwargs["proxy_server_request"] = {"body": self.PLAN_BODY}
+        elif path == "adaptive":
+            config["adaptive"] = True
+            mock_router_instance.model_list = []
+            mock_router_instance.model_name_to_deployment_indices = {}
+        router = self._router(mock_router_instance, config, vision)
+        result = await router.async_pre_routing_hook(model="m", request_kwargs=request_kwargs, messages=messages)
+        assert result.model == expected_model
+        assert result.routing_decision["cause"] == expected_cause
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "default_model, default_vision, expect_error",
+        [(None, None, True), ("text-default", False, True), ("vision-default", True, False)],
+        ids=["no_default", "text_only_default", "vision_default_serves"],
+    )
+    async def test_no_capable_tier_uses_default_or_rejects(
+        self, mock_router_instance, default_model, default_vision, expect_error
+    ):
+        config = {"tiers": {"SIMPLE": "text-cheap", "COMPLEX": "text-big"}, "modality_routing": True}
+        vision = {"text-cheap": False, "text-big": False}
+        if default_model is not None:
+            config["default_model"] = default_model
+            vision[default_model] = default_vision
+        router = self._router(mock_router_instance, config, vision)
+        if expect_error:
+            with pytest.raises(litellm.BadRequestError, match="no model"):
+                await router.async_pre_routing_hook(model="m", request_kwargs={}, messages=self.IMAGE_MESSAGE)
+        else:
+            result = await router.async_pre_routing_hook(model="m", request_kwargs={}, messages=self.IMAGE_MESSAGE)
+            assert result.model == "vision-default"
+            assert result.routing_decision["cause"] == "modality_escalation"
+
+    @pytest.mark.asyncio
+    async def test_floor_blocks_default_and_below_floor_tiers_on_gated_no_ask_turns(self, mock_router_instance):
+        config = {
+            "tiers": {"SIMPLE": "vision-cheap", "MEDIUM": "text-mid", "COMPLEX": "vision-big"},
+            "default_model": "vision-default",
+            "plan_mode_min_tier": "MEDIUM",
+            "modality_routing": True,
+        }
+        vision = {"vision-cheap": True, "text-mid": False, "vision-big": True, "vision-default": True}
+        router = self._router(mock_router_instance, config, vision)
+        result = await router.async_pre_routing_hook(
+            model="m",
+            request_kwargs={"proxy_server_request": {"body": self.PLAN_BODY}},
+            messages=[{"role": "user", "content": [IMG_PART]}],
+        )
+        assert result.model == "vision-big"
+        assert result.routing_decision["cause"] == "modality_escalation"
+
+    @pytest.mark.asyncio
+    async def test_mixed_deployment_group_is_treated_text_only(self, mock_router_instance):
+        def get_model_list(model_name=None):
+            deployments = {
+                "mixed-group": [True, False],
+                "vision-big": [True],
+            }.get(model_name)
+            if deployments is None:
+                return []
+            return [
+                {
+                    "model_name": model_name,
+                    "litellm_params": {"model": f"openai/unmapped-{model_name}-{i}"},
+                    "model_info": {"supports_vision": declared},
+                }
+                for i, declared in enumerate(deployments)
+            ]
+
+        mock_router_instance.get_model_list = get_model_list
+        router = ComplexityRouter(
+            model_name="modality-test-router",
+            litellm_router_instance=mock_router_instance,
+            complexity_router_config={
+                "tiers": {"SIMPLE": "mixed-group", "COMPLEX": "vision-big"},
+                "modality_routing": True,
+            },
+        )
+        result = await router.async_pre_routing_hook(model="m", request_kwargs={}, messages=self.IMAGE_MESSAGE)
+        assert result.model == "vision-big"
+        assert result.routing_decision["cause"] == "modality_escalation"
+
+    @pytest.mark.asyncio
+    async def test_kept_pin_bypasses_the_gate_and_escalations_are_never_pinned(self, mock_router_instance):
+        from litellm.router_strategy.complexity_router.complexity_router import _decision_is_pinnable
+
+        cache = AsyncMock()
+        cache.async_get_cache = AsyncMock(return_value={"model": "text-cheap", "tier": "SIMPLE"})
+        mock_router_instance.cache = cache
+        router = self._router(
+            mock_router_instance,
+            {"tiers": dict(self.BASE_TIERS), "modality_routing": True, "session_affinity": True},
+            dict(self.BASE_VISION),
+        )
+        result = await router.async_pre_routing_hook(
+            model="m", request_kwargs={"metadata": {"session_id": "s1"}}, messages=self.IMAGE_MESSAGE
+        )
+        assert result.model == "text-cheap"
+        assert result.routing_decision["cause"] == "session_affinity_pin"
+        assert _decision_is_pinnable({"cause": "modality_escalation"}) is False
+        assert _decision_is_pinnable({"cause": "heuristic_scorer"}) is True

--- a/tests/test_litellm/test_utils.py
+++ b/tests/test_litellm/test_utils.py
@@ -5765,3 +5765,33 @@ class TestHuggingFaceConfigFetch:
         assert _get_max_position_embeddings("some-org/some-model") == 512
         request_timeout = hf_config_route.calls.last.request.extensions["timeout"]
         assert request_timeout["read"] == HF_CONFIG_FETCH_TIMEOUT_SECONDS
+
+
+class TestIsVisionExplicitlyDisabled:
+    """github_copilot and chatgpt run an OAuth device flow inside get_llm_provider; the
+    explicit-disable lookup must adopt the declared prefix instead of resolving it, exactly
+    as _supports_factory does, or a capability check on a copilot deployment blocks routing
+    on a device-code prompt."""
+
+    @pytest.mark.parametrize("model", ["github_copilot/gpt-4o", "chatgpt/gpt-5"])
+    def test_never_resolves_an_authenticating_prefix(self, model, monkeypatch):
+        from litellm.utils import is_vision_explicitly_disabled
+
+        lookups: list = []
+
+        def _record(*args, **kwargs):
+            lookups.append((args, kwargs))
+            raise RuntimeError("provider resolution must not run for an authenticating provider")
+
+        monkeypatch.setattr(litellm, "get_llm_provider", _record)
+
+        assert is_vision_explicitly_disabled(model) is False
+        assert lookups == []
+
+    def test_explicit_false_detected_and_absent_reads_enabled(self):
+        from litellm.utils import is_vision_explicitly_disabled
+
+        assert (
+            is_vision_explicitly_disabled("fireworks_ai/accounts/fireworks/models/deepseek-v4-flash-0731") is True
+        )
+        assert is_vision_explicitly_disabled("anthropic/claude-sonnet-4-5") is False

--- a/ui/litellm-dashboard/src/components/view_logs/LogDetailsDrawer/RoutingDecisionCard.test.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/LogDetailsDrawer/RoutingDecisionCard.test.tsx
@@ -186,6 +186,12 @@ describe("RoutingDecisionCard", () => {
     expect(screen.queryByText("housekeeping")).not.toBeInTheDocument();
   });
 
+  it("labels a modality escalation instead of showing the raw cause token", () => {
+    render(<RoutingDecisionCard decision={{ ...heuristic, cause: "modality_escalation" }} />);
+    expect(screen.getByText("Escalated for image input")).toBeInTheDocument();
+    expect(screen.queryByText("modality_escalation")).not.toBeInTheDocument();
+  });
+
   it("shows the escalation keyword", () => {
     render(
       <RoutingDecisionCard decision={{ ...heuristic, escalated: true, escalation_keyword: "LITELLM ESCALATE" }} />,

--- a/ui/litellm-dashboard/src/components/view_logs/LogDetailsDrawer/RoutingDecisionCard.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/LogDetailsDrawer/RoutingDecisionCard.tsx
@@ -89,6 +89,7 @@ const CONSTANT_CAUSE_LABELS: Record<string, string> = {
   semantic_keyword_match: "Semantic keyword match",
   session_affinity_pin: "Pinned to session",
   session_affinity_escalation: "Escalated from session pin",
+  modality_escalation: "Escalated for image input",
   quality_tier: "Quality tier mapping",
   bandit: "Adaptive bandit",
   default_fallback: "Default model, no route matched",

--- a/ui/litellm-dashboard/src/lib/http/schema.d.ts
+++ b/ui/litellm-dashboard/src/lib/http/schema.d.ts
@@ -34309,6 +34309,12 @@ export interface components {
              */
             match_threshold: number;
             /**
+             * Modality Routing
+             * @description Route image-bearing requests only to tier models that can accept image input. The complexity classifier reads text alone, so an image request whose text classifies cheap otherwise lands on a text-only model and fails with a provider 400. When enabled, a request carrying an image content part is served by the nearest tier (preferring higher) whose pool has a model not explicitly declared supports_vision false, falling back to default_model when no tier qualifies, and rejected with a clear 400 when nothing can serve it. Only an explicit supports_vision false (deployment model_info or the model cost map) excludes a model, so unmapped custom names stay routable. A session-affinity pin still wins: a session pinned to a text-only model keeps it even when an image arrives.
+             * @default false
+             */
+            modality_routing: boolean;
+            /**
              * Plan Mode Min Tier
              * @description When set, requests carrying a coding-agent plan-mode sentinel (Claude Code plan mode, VS Code Copilot Plan mode, Copilot CLI's exit_plan_mode tool) are routed to at least this tier: the classified tier still wins when it is higher, and the floor also overrides a session-affinity pin to a lower tier for exactly the turns carrying the sentinel, without rewriting the pin -- the first turn after plan mode exits routes as if plan mode had never happened. Names a built-in tier, or with tier_definitions set, one of the defined tier names (list order is ascending severity, same as keyword_tier_rules). Unset disables detection entirely. The sentinels ride in client-injected prompt text, so a caller who pastes one can spend up to this tier's models -- never down, and never outside the configured pools.
              */
@@ -35461,7 +35467,7 @@ export interface components {
              * Cause
              * @enum {string}
              */
-            cause?: "heuristic_scorer" | "reasoning_override" | "llm_classifier" | "heuristic_first_short_circuit" | "classifier_plugin" | "classifier_fallback" | "default_model_fallback" | "literal_keyword_match" | "semantic_keyword_match" | "plan_mode" | "housekeeping" | "session_affinity_pin" | "session_affinity_escalation" | "default_fallback" | "keyword" | "quality_tier" | "bandit";
+            cause?: "heuristic_scorer" | "reasoning_override" | "llm_classifier" | "heuristic_first_short_circuit" | "classifier_plugin" | "classifier_fallback" | "default_model_fallback" | "literal_keyword_match" | "semantic_keyword_match" | "plan_mode" | "housekeeping" | "modality_escalation" | "session_affinity_pin" | "session_affinity_escalation" | "default_fallback" | "keyword" | "quality_tier" | "bandit";
             /** Classifier Cost */
             classifier_cost?: number;
             /** Classifier Model */


### PR DESCRIPTION
## TLDR

Problem this solves:

- Image requests through an auto-router land on text-only tier models
- The provider rejects them with a 400 that no fallback catches
- The complexity classifier reads text alone, so it cannot see the image

How it solves it:

- Opt-in `modality_routing: true` inside `complexity_router_config`, off by default
- Image requests route to the nearest tier holding a vision-capable model
- Falls back to `default_model`, then rejects with a clear 400
- Routing decision records `cause: modality_escalation` plus the displaced tier

## User Flow

Before: a developer sends a screenshot through their auto-router and gets a Fireworks error, even though the router also serves vision models

1. They send POST https://litellm-domain/v1/chat/completions with model `my-auto-router` and a message carrying an `image_url` block
2. The prompt text is short, so the request is placed on the cheap DeepSeek tier
3. They get back 400 "Fireworks AI model accounts/fireworks/models/deepseek-v4-flash-0731 does not support image inputs"
4. Every image turn in the session fails the same way

After: the same request quietly runs on the router's vision-capable tier

1. The proxy admin adds `modality_routing: true` to the router's `complexity_router_config` and restarts
2. The developer sends the same POST with the same image message
3. They get 200 back, answered by the vision-capable model of the nearest capable tier
4. The log row at https://litellm-domain/ui/?page=logs shows the routing cause "Escalated for image input"
5. Text-only requests keep routing to the cheap tier exactly as before

## Relevant issues

- Adds opt-in modality-based capability routing to the complexity auto-router
- Rebuilt minimal after review: one response gate at the routing hook applies the whole policy, so the decision paths themselves are untouched and the walk is upward-only, which makes floor violations impossible by construction
- Image requests only route to tier models accepting image input: nearest capable tier first, then `default_model`, else a clear 400
- Stamps `cause: modality_escalation` on gate-changed routing decisions, with the displaced tier in `signals`

Related: PR #35225 filters non-vision deployments inside one model group at the generic router layer. This PR decides which tier serves the request, so the two compose rather than overlap

## Linear ticket

Resolves LIT-6505

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Shared setup: local proxy on :4611 backed by real Postgres, real LLM calls through the sandbox gateway to Fireworks (`deepseek-v4-flash-0731`, the exact model from the customer report) and Anthropic (`claude-opus-4-8`), costing real money. The test image is a solid red PNG. Config (three routers over the same two deployments):

```yaml
model_list:
  - model_name: modality-router
    litellm_params:
      model: auto_router/complexity_router
      complexity_router_config:
        classifier_type: heuristic
        modality_routing: true
        tiers:
          SIMPLE: deepseek-flash
          MEDIUM: deepseek-flash
          COMPLEX: claude-opus
          REASONING: claude-opus
  - model_name: modality-router-off      # same tiers, flag omitted
  - model_name: modality-router-nocap    # modality_routing: true, tiers only deepseek-flash
  - model_name: deepseek-flash
    litellm_params:
      model: openai/fireworks_ai/deepseek-v4-flash-0731
      api_base: https://gateway.litellm-sandbox.ai/v1
      api_key: os.environ/GW_KEY
    model_info:
      supports_vision: false
  - model_name: claude-opus
    litellm_params:
      model: openai/anthropic/claude-opus-4-8
      api_base: https://gateway.litellm-sandbox.ai/v1
      api_key: os.environ/GW_KEY
```

```bash
IMG="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAEAAAABACAIAAAAlC+aJAAAAeUlEQVR4nO3PQQkAMAzAwCqpfymTNRF7HINABFzm7H7dcEEDWtCAFjSgBQ1oQQNa0IAWNKAFDWhBA1rQgBY0oAUNaEEDWtCAFjSgBQ1oQQNa0IAWNKAFDWhBA1rQgBY0oAUNaEEDWtCAFjSgBQ1oQQNa0IAWNKAFj13Kp0DxHeM4GQAAAABJRU5ErkJggg=="
```

### Before (40edeaaecb)

#### Image request via /v1/chat/completions

1. `curl -s -D /tmp/h http://127.0.0.1:4611/v1/chat/completions -H "Authorization: Bearer sk-lit6505" -H "Content-Type: application/json" -d "{\"model\":\"modality-router\",\"max_tokens\":32,\"messages\":[{\"role\":\"user\",\"content\":[{\"type\":\"text\",\"text\":\"what color is this image? one word\"},{\"type\":\"image_url\",\"image_url\":{\"url\":\"$IMG\"}}]}]}"`
2. `HTTP/1.1 400 Bad Request` with `litellm.BadRequestError: OpenAIException - litellm.BadRequestError: Fireworks AI model accounts/fireworks/models/deepseek-v4-flash-0731 does not support image inputs. Use a Fireworks vision model or remove image_url content blocks.`
3. The base run used the identical config including `modality_routing: true`, which the base code accepts and silently ignores, proving both the failure and the unknown-key caveat
4. The base arm was certified before capture: the gate module does not import at the merge base

#### Text request via /v1/chat/completions

1. Same route, body `{"model":"modality-router","max_tokens":32,"messages":[{"role":"user","content":"say ok"}]}`
2. `HTTP/1.1 200 OK`, `x-litellm-model-name: openai/fireworks_ai/deepseek-v4-flash-0731`

#### Image request via /v1/messages

1. Same image as an Anthropic `{"type":"image","source":{...}}` block to POST /v1/messages
2. `HTTP/1.1 400 Bad Request`, same Fireworks image-input error

#### Image request via /v1/responses

1. Same image as an `input_image` part to POST /v1/responses
2. `HTTP/1.1 400 Bad Request`, same Fireworks image-input error

### After (62eb113dd8)

#### Image request via /v1/chat/completions

1. Same command as Before
2. `HTTP/1.1 200 OK`, `x-litellm-model-name: openai/anthropic/claude-opus-4-8`, content `Red`
3. Spend log row: `cause=modality_escalation, tier=COMPLEX, signals=["short (5 tokens)", "modality:image", "modality_escalated_from:SIMPLE"]`

#### Text request via /v1/chat/completions

1. Same command as Before
2. `HTTP/1.1 200 OK`, `x-litellm-model-name: openai/fireworks_ai/deepseek-v4-flash-0731` (cheap tier untouched)

#### Image request via /v1/messages

1. Same command as Before
2. `HTTP/1.1 200 OK`, answered `Red` by the escalated tier

#### Image request via /v1/responses

1. Same command as Before
2. `HTTP/1.1 200 OK`, answered `Red` by the escalated tier

#### Screenshot nested in a tool_result via /v1/messages

1. A three-turn Anthropic conversation where the image arrives inside a `tool_result` block, the shape a coding agent's screenshot tool produces
2. `HTTP/1.1 200 OK`, answered `Red`; the spend log row records `cause=modality_escalation` on the vision deployment

#### Flag omitted: behavior unchanged

1. Same image request against `modality-router-off` (identical tiers, no `modality_routing`)
2. `HTTP/1.1 400 Bad Request` with the original Fireworks error, byte for byte

#### No vision-capable model anywhere

1. Same image request against `modality-router-nocap` (every tier text-only, no default_model)
2. `HTTP/1.1 400 Bad Request` with `Auto-router modality-router-nocap received a request with image input, but no model in its tiers accepts images and modality_routing is enabled. Tiers checked: SIMPLE, MEDIUM. Add a vision-capable model to a tier, or set a vision-capable default_model, or remove the image content.`

## Type

🆕 New Feature

## Caveats (if any)

### Medium

- Older proxies accept `modality_routing` and silently ignore it (the config allows unknown keys)
- Only image input is gated; audio and file inputs are unchanged

### Low

- Only an explicit `supports_vision: false` (deployment `model_info` or the cost map) excludes a model, so undeclared custom names stay routable by design
- A group mixing vision and text-only deployments is treated text-only and escalated past, since in-group deployment selection happens after the gate; per-deployment filtering inside a group is PR #35225's layer
- Session-affinity pins bypass the gate on purpose: a pinned text-only model keeps serving even when an image arrives, per the config description
- With routing plugins configured, the `default_model` last resort is skipped so the gate cannot bypass a policy plugin; those routers get the clear 400 instead
- Under a plan-mode floor the `default_model` arm is skipped, because it carries no tier guarantee and could sit below the floor
- The walk is upward-only: a router whose only vision model sits below the decided tier gets the 400 with an actionable message
- A gated re-pick on an adaptive router chooses among capable pool members without the bandit's within-tier preference, and the adaptive chosen-model marker is restamped to the served model

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
