### PR TITLE
fix(ui): drop stray text next to Close in the model connection test dialog

### DIFF
--- a/ui/litellm-dashboard/src/components/add_model/AddModelForm.test.tsx
+++ b/ui/litellm-dashboard/src/components/add_model/AddModelForm.test.tsx
@@ -33,6 +33,7 @@ vi.mock("../networking", async () => {
         { model_group: "gpt-3.5-turbo", mode: "chat" },
       ],
     }),
+    testConnectionRequest: vi.fn().mockResolvedValue({ status: "success" }),
     getProviderCreateMetadata: vi.fn().mockResolvedValue([
       {
         provider: "OpenAI",
@@ -309,6 +310,20 @@ describe("AddModelForm", () => {
     expect(await screen.findByText("Provider")).toBeInTheDocument();
     expect((await screen.findAllByRole("button", { name: "Test Connect" })).length).toBeGreaterThan(0);
     expect(await screen.findByRole("button", { name: "Add Model" })).toBeInTheDocument();
+  });
+
+  it("shows only the Close button in the connection test dialog footer", async () => {
+    const mockUseAuthorized = vi.mocked(await import("@/app/(dashboard)/hooks/useAuthorized"));
+    mockUseAuthorized.default.mockReturnValue(mockAuthorizedUser("proxy_admin", "user-1", true));
+
+    renderWithProviders(<AddModelForm {...createTestProps()} />);
+
+    await userEvent.click(await screen.findByTestId("test-connect-btn"));
+
+    const dialog = await screen.findByRole("dialog");
+    const footer = dialog.querySelector('[data-slot="dialog-footer"]');
+    expect(footer).not.toBeNull();
+    expect(footer!.textContent?.trim()).toBe("Close");
   });
 
   describe("the enterprise gate on the Team-BYOK switch", () => {

--- a/ui/litellm-dashboard/src/components/add_model/AddModelForm.tsx
+++ b/ui/litellm-dashboard/src/components/add_model/AddModelForm.tsx
@@ -476,7 +476,6 @@ const AddModelForm: React.FC<AddModelFormProps> = ({
             />
           )}
           <DialogFooter>
-            {" "}
             <Button
               variant="outline"
               onClick={() => {
@@ -486,7 +485,6 @@ const AddModelForm: React.FC<AddModelFormProps> = ({
             >
               Close
             </Button>
-            , ]
           </DialogFooter>
         </DialogContent>
       </Dialog>


### PR DESCRIPTION
## TLDR

Problem this solves:

- Connection test dialog shows a stray ", ]" next to Close

How it solves it:

- Removes the leftover text node from the dialog footer
- Adds a component test pinning the footer to just Close

## User Flow

Before: an admin testing a new model sees junk characters in the results dialog

1. They open http://localhost:4000/ui/?page=new_model and pick a provider, model, and key
2. They click Test Connect
3. The Connection Test Results dialog opens, and the footer reads "Close , ]" instead of just "Close"

After: the same dialog shows only the Close button

1. They open http://localhost:4000/ui/?page=new_model and pick a provider, model, and key
2. They click Test Connect
3. The Connection Test Results dialog opens with a single Close button and no leftover characters

## Relevant issues

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

### Before (ff2f06e37f)

### After (795c036279)

## Type

🐛 Bug Fix

## Caveats (if any)

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
