### PR TITLE
[Backport rc/1.99.0] fix(anthropic): translate tool_result document blocks in the /v1/messages bridge

### DIFF
--- a/litellm/llms/anthropic/experimental_pass_through/adapters/transformation.py
+++ b/litellm/llms/anthropic/experimental_pass_through/adapters/transformation.py
@@ -433,7 +433,7 @@ class LiteLLMAnthropicMessagesAdapter:
                                 content_items = list(content.get("content", []))
 
                                 # Single-item text keeps the backward-compatible string format; a single
-                                # image becomes a structured image_url part
+                                # image or document becomes a structured image_url part
                                 if len(content_items) == 1:
                                     c = content_items[0]
                                     if isinstance(c, str):
@@ -453,7 +453,7 @@ class LiteLLMAnthropicMessagesAdapter:
                                             )
                                             self._add_cache_control_if_applicable(content, tool_result, model)
                                             tool_message_list.append(tool_result)
-                                        elif c.get("type") == "image":
+                                        elif c.get("type") in ("image", "document"):
                                             image_part = self._tool_result_image_part(c.get("source"))
                                             tool_result = ChatCompletionToolMessage(
                                                 role="tool",
@@ -481,7 +481,7 @@ class LiteLLMAnthropicMessagesAdapter:
                                                         text=c.get("text", ""),
                                                     )
                                                 )
-                                            elif c.get("type") == "image":
+                                            elif c.get("type") in ("image", "document"):
                                                 image_part = self._tool_result_image_part(c.get("source"))
                                                 if image_part:
                                                     combined_content_parts.append(image_part)

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_anthropic_experimental_pass_through_adapters_transformation.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_anthropic_experimental_pass_through_adapters_transformation.py
@@ -1,3 +1,4 @@
+import base64
 from typing import Any, cast
 
 import pytest
@@ -11,6 +12,7 @@ from litellm.litellm_core_utils.prompt_templates.common_utils import (
 )
 from litellm.litellm_core_utils.prompt_templates.factory import (
     THOUGHT_SIGNATURE_SEPARATOR,
+    _bedrock_converse_messages_pt,
 )
 from litellm.llms.anthropic.experimental_pass_through.adapters.transformation import (
     OPENAI_MAX_TOOL_NAME_LENGTH,
@@ -3828,6 +3830,75 @@ def test_tool_result_plain_text_unchanged_by_openai_transform():
     assert len(tool_messages) == 1
     assert tool_messages[0]["content"] == "42 files found"
     assert _image_urls_in_user_messages(result) == []
+
+
+TOOL_RESULT_PDF_B64 = base64.b64encode(b"%PDF-1.4 minimal regression fixture").decode()
+
+
+def _base64_pdf_block():
+    return {
+        "type": "document",
+        "source": {"type": "base64", "media_type": "application/pdf", "data": TOOL_RESULT_PDF_B64},
+    }
+
+
+def test_tool_result_single_document_kept_as_pdf_data_url():
+    adapter = LiteLLMAnthropicMessagesAdapter()
+    translated = adapter.translate_anthropic_messages_to_openai(
+        messages=[
+            _anthropic_tool_use_turn("toolu_01"),
+            _anthropic_tool_result_turn({"toolu_01": [_base64_pdf_block()]}),
+        ]
+    )
+
+    tool_messages = [m for m in translated if m.get("role") == "tool"]
+    assert len(tool_messages) == 1
+    assert tool_messages[0]["content"] == [
+        {
+            "type": "image_url",
+            "image_url": {"url": f"data:application/pdf;base64,{TOOL_RESULT_PDF_B64}"},
+        }
+    ]
+
+
+def test_tool_result_text_and_document_reach_bedrock_converse_tool_result():
+    """Claude Code >= 2.1.245 sends Read-tool PDF output as a document block inside
+    tool_result; dropping it left bedrock converse models blind to the PDF content."""
+    adapter = LiteLLMAnthropicMessagesAdapter()
+    translated = adapter.translate_anthropic_messages_to_openai(
+        messages=[
+            AnthropicMessagesUserMessageParam(role="user", content="Read pong.pdf"),
+            _anthropic_tool_use_turn("toolu_01"),
+            _anthropic_tool_result_turn(
+                {
+                    "toolu_01": [
+                        {"type": "text", "text": "PDF file read: pong.pdf (579 bytes)"},
+                        _base64_pdf_block(),
+                    ]
+                }
+            ),
+        ]
+    )
+
+    converse_messages = _bedrock_converse_messages_pt(
+        messages=translated,
+        model="anthropic.claude-haiku-4-5-20251001-v1:0",
+        llm_provider="bedrock_converse",
+    )
+
+    tool_results = [
+        block["toolResult"]
+        for message in converse_messages
+        for block in message["content"]
+        if "toolResult" in block
+    ]
+    assert len(tool_results) == 1
+    documents = [part["document"] for part in tool_results[0]["content"] if "document" in part]
+    assert len(documents) == 1
+    assert documents[0]["format"] == "pdf"
+    assert documents[0]["source"]["bytes"] == TOOL_RESULT_PDF_B64
+    texts = [part["text"] for part in tool_results[0]["content"] if "text" in part]
+    assert texts == ["PDF file read: pong.pdf (579 bytes)"]
 
 
 def test_translate_anthropic_to_openai_carries_prompt_cache_breakpoint_on_system_and_user_blocks():


### PR DESCRIPTION
Backport of #38251 (`17845b4fb0`) onto `rc/1.99.0`. Cherry-picked with `-x`; clean apply, no conflicts.

## Why

`claude_code/pdf_input/test_bedrock_converse.py::test_pdf_input_bedrock_converse` fails on `rc/1.99.0` and passes on `litellm_internal_staging`. Bedrock **Converse** reaches the model through the `/v1/messages` → OpenAI adapter bridge, and that bridge only translated `text` and `image` blocks inside a `tool_result`. A `document` block matched neither branch and was silently dropped, so the model received Claude Code's "read 579 bytes" text with no PDF attached and answered that it could not see the content. Bedrock **Invoke** is native (`BedrockAnthropicMessagesConfig`), which is why its twin test stayed green.

`rc/1.99.0` branched from staging at `947dbbf02` on 2026-08-22, three days before the fix landed, so it never picked it up.

## Evidence

Buildkite `litellm-e2e`, all 93 builds:

| Builds | Line | Result |
|---|---|---|
| 51–64 (08-22 → 08-24) | staging | pass |
| 66–69 (08-25) | staging | **fail** |
| 70–90, 93 | staging | pass |
| 91, 92 | rc/1.99.0 | **fail** |

Build 70 is the first SHA (`434add75`) containing `17845b4fb0`, and it is exactly where staging went green.

The earlier green window (51–64) sat on the same unfixed code. The Claude Code CLI in the e2e runner is unpinned and rebuilds every 6h; it went 2.1.241 (build 65) → 2.1.243 (build 66, first red), so the gap most likely only became reachable once the CLI started returning PDF reads as `document` blocks. That part is inference — builds 60–64 reused a cached runner image and never printed their CLI version.

## Verification on this branch

- Divergence audit vs the original commit: `+`/`-` content identical, only blob hashes and line offsets differ (one line earlier on rc).
- Backported tests red on the rc base, green with the pick — `test_tool_result_single_document_kept_as_pdf_data_url` and `test_tool_result_text_and_document_reach_bedrock_converse_tool_result` both fail with `assert 0 == 1` on `HEAD~1`.
- `tests/test_litellm/litellm_core_utils/prompt_templates`: 214 passed.
- `tests/test_litellm/llms/anthropic/experimental_pass_through`: 27 failed / 658 passed both before and after the pick — identical failing sets, zero introduced. The 27 are pre-existing on `rc/1.99.0` (`context_management/test_compact.py`). `messages/test_streaming_iterator.py` is excluded from both runs: it fails to import on a missing local `orjson`, an environment gap unrelated to this change.

## Not included

Three sibling document-drop fixes landed the same day and are also absent from `rc/1.99.0`: #38261, #38267, and `61ee2f5ecb` (responses bridge, user-content documents). Same bug class, but only this one is proven by the e2e failure, so this PR keeps to the minimal pick.
