### PR TITLE
fix(router): record savings metadata for adaptive strategies

### DIFF
--- a/litellm/router.py
+++ b/litellm/router.py
@@ -8637,6 +8637,7 @@ class Router:
             config=config,
             model_to_prefs=model_to_prefs,
             model_to_cost=model_to_cost,
+            litellm_router_instance=self,
         )
         self._register_pre_routing_strategy(
             registry=self.adaptive_routers,

--- a/litellm/router_strategy/adaptive_router/adaptive_router.py
+++ b/litellm/router_strategy/adaptive_router/adaptive_router.py
@@ -16,7 +16,6 @@ from __future__ import annotations
 import asyncio
 import time
 from collections import OrderedDict
-from collections.abc import Mapping
 from dataclasses import asdict, dataclass
 from typing import TYPE_CHECKING, Any, Final, cast
 
@@ -204,27 +203,30 @@ class AdaptiveRouter:
         if isinstance(kwargs_metadata, dict):
             kwargs_metadata[ADAPTIVE_ROUTER_CHOSEN_MODEL_KEY] = chosen_model
 
+        routing_decision: Final = StandardLoggingRoutingDecision(
+            router_model_name=self.router_name,
+            router_type="adaptive",
+            routed_model=chosen_model,
+            cause="bandit",
+            request_type=request_type.value,
+            conversation_continuing=conversation_is_continuing(messages),
+        )
+        routing_decision.update(self._savings_baseline_fields())
         return PreRoutingHookResponse(
             model=chosen_model,
             messages=messages,
-            routing_decision=StandardLoggingRoutingDecision(
-                router_model_name=self.router_name,
-                router_type="adaptive",
-                routed_model=chosen_model,
-                cause="bandit",
-                request_type=request_type.value,
-                conversation_continuing=conversation_is_continuing(messages),
-                **self._savings_baseline_fields(),
-            ),
+            routing_decision=routing_decision,
         )
 
-    def _savings_baseline_fields(self) -> Mapping[str, str]:
+    def _savings_baseline_fields(self) -> StandardLoggingRoutingDecision:
         if self.litellm_router_instance is None:
             return {}  # mutable-ok: immutable empty result for absent router
         baseline = resolve_baseline(self.litellm_router_instance, self.config.available_models)
         if baseline is None:
             return {}  # mutable-ok: immutable empty result for unresolved baseline
-        fields = {"savings_baseline_model": baseline.model}  # mutable-ok: assemble TypedDict kwargs
+        fields: StandardLoggingRoutingDecision = {
+            "savings_baseline_model": baseline.model,
+        }  # mutable-ok: assemble TypedDict kwargs
         if baseline.deployment_id is not None:
             fields["savings_baseline_deployment_id"] = baseline.deployment_id
         return fields

--- a/litellm/router_strategy/adaptive_router/adaptive_router.py
+++ b/litellm/router_strategy/adaptive_router/adaptive_router.py
@@ -17,7 +17,7 @@ import asyncio
 import time
 from collections import OrderedDict
 from dataclasses import asdict, dataclass
-from typing import Any, Final, cast
+from typing import TYPE_CHECKING, Any, Final, cast
 
 from litellm._logging import verbose_router_logger
 from litellm.litellm_core_utils.prompt_templates.common_utils import (
@@ -50,7 +50,14 @@ from litellm.router_strategy.adaptive_router.signals import (
 from litellm.router_strategy.adaptive_router.update_queue import (
     AdaptiveRouterUpdateQueue,
 )
+from litellm.router_strategy.savings_baseline import (
+    conversation_is_continuing,
+    resolve_baseline,
+)
 from litellm.types.utils import StandardLoggingRoutingDecision
+
+if TYPE_CHECKING:
+    from litellm.router import Router
 
 # Sweep session-state cache when it exceeds this many live entries. Expired
 # entries are dropped in bulk; amortizes to O(1) per insert.
@@ -91,11 +98,13 @@ class AdaptiveRouter:
         config: AdaptiveRouterConfig,
         model_to_prefs: dict[str, AdaptiveRouterPreferences],
         model_to_cost: dict[str, float],
+        litellm_router_instance: Router | None = None,
     ) -> None:
         self.router_name = router_name
         self.config = config
         self.model_to_prefs = model_to_prefs
         self.model_to_cost = model_to_cost
+        self.litellm_router_instance = litellm_router_instance
         self.queue = AdaptiveRouterUpdateQueue()
 
         self._cells: dict[tuple[RequestType, str], BanditCell] = {}
@@ -203,8 +212,21 @@ class AdaptiveRouter:
                 routed_model=chosen_model,
                 cause="bandit",
                 request_type=request_type.value,
+                conversation_continuing=conversation_is_continuing(messages),
+                **self._savings_baseline_fields(),
             ),
         )
+
+    def _savings_baseline_fields(self) -> dict[str, str]:
+        if self.litellm_router_instance is None:
+            return {}
+        baseline = resolve_baseline(self.litellm_router_instance, self.config.available_models)
+        if baseline is None:
+            return {}
+        fields = {"savings_baseline_model": baseline.model}
+        if baseline.deployment_id is not None:
+            fields["savings_baseline_deployment_id"] = baseline.deployment_id
+        return fields
 
     # ---- Pick model ------------------------------------------------------
 

--- a/litellm/router_strategy/adaptive_router/adaptive_router.py
+++ b/litellm/router_strategy/adaptive_router/adaptive_router.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import asyncio
 import time
 from collections import OrderedDict
+from collections.abc import Mapping
 from dataclasses import asdict, dataclass
 from typing import TYPE_CHECKING, Any, Final, cast
 
@@ -217,13 +218,13 @@ class AdaptiveRouter:
             ),
         )
 
-    def _savings_baseline_fields(self) -> dict[str, str]:
+    def _savings_baseline_fields(self) -> Mapping[str, str]:
         if self.litellm_router_instance is None:
-            return {}
+            return {}  # mutable-ok: immutable empty result for absent router
         baseline = resolve_baseline(self.litellm_router_instance, self.config.available_models)
         if baseline is None:
-            return {}
-        fields = {"savings_baseline_model": baseline.model}
+            return {}  # mutable-ok: immutable empty result for unresolved baseline
+        fields = {"savings_baseline_model": baseline.model}  # mutable-ok: assemble TypedDict kwargs
         if baseline.deployment_id is not None:
             fields["savings_baseline_deployment_id"] = baseline.deployment_id
         return fields

--- a/litellm/router_strategy/adaptive_router/adaptive_router.py
+++ b/litellm/router_strategy/adaptive_router/adaptive_router.py
@@ -224,12 +224,14 @@ class AdaptiveRouter:
         baseline = resolve_baseline(self.litellm_router_instance, self.config.available_models)
         if baseline is None:
             return {}  # mutable-ok: immutable empty result for unresolved baseline
-        fields: StandardLoggingRoutingDecision = {
+        return {
             "savings_baseline_model": baseline.model,
-        }  # mutable-ok: assemble TypedDict kwargs
-        if baseline.deployment_id is not None:
-            fields["savings_baseline_deployment_id"] = baseline.deployment_id
-        return fields
+            **(
+                {"savings_baseline_deployment_id": baseline.deployment_id}
+                if baseline.deployment_id is not None
+                else {}
+            ),
+        }
 
     # ---- Pick model ------------------------------------------------------
 

--- a/litellm/router_strategy/adaptive_router/adaptive_router.py
+++ b/litellm/router_strategy/adaptive_router/adaptive_router.py
@@ -227,9 +227,7 @@ class AdaptiveRouter:
         return {
             "savings_baseline_model": baseline.model,
             **(
-                {"savings_baseline_deployment_id": baseline.deployment_id}
-                if baseline.deployment_id is not None
-                else {}
+                {"savings_baseline_deployment_id": baseline.deployment_id} if baseline.deployment_id is not None else {}
             ),
         }
 

--- a/litellm/router_strategy/complexity_router/complexity_router.py
+++ b/litellm/router_strategy/complexity_router/complexity_router.py
@@ -1751,6 +1751,7 @@ class ComplexityRouter(CustomLogger):
             ),
             model_to_prefs=model_to_prefs,
             model_to_cost=model_to_cost,
+            litellm_router_instance=self.litellm_router_instance,
         )
         self._adaptive_chosen_model_key = ADAPTIVE_ROUTER_CHOSEN_MODEL_KEY
         return self.adaptive_router

--- a/litellm/router_strategy/quality_router/quality_router.py
+++ b/litellm/router_strategy/quality_router/quality_router.py
@@ -16,6 +16,7 @@ then cheapest `model_info.input_cost_per_token`).
 """
 
 import math
+from collections.abc import Mapping
 from typing import TYPE_CHECKING, Any, Final, Optional
 
 from litellm._logging import verbose_router_logger
@@ -322,11 +323,11 @@ class QualityRouter(CustomLogger):
         if isinstance(metadata, dict):
             metadata["quality_router_decision"] = decision
 
-    def _savings_fields(self) -> dict[str, str]:
+    def _savings_fields(self) -> Mapping[str, str]:
         baseline = resolve_baseline(self.litellm_router_instance, self.config.available_models)
         if baseline is None:
-            return {}
-        fields = {"savings_baseline_model": baseline.model}
+            return {}  # mutable-ok: immutable empty result for unresolved baseline
+        fields = {"savings_baseline_model": baseline.model}  # mutable-ok: assemble TypedDict kwargs
         if baseline.deployment_id is not None:
             fields["savings_baseline_deployment_id"] = baseline.deployment_id
         return fields

--- a/litellm/router_strategy/quality_router/quality_router.py
+++ b/litellm/router_strategy/quality_router/quality_router.py
@@ -16,7 +16,6 @@ then cheapest `model_info.input_cost_per_token`).
 """
 
 import math
-from collections.abc import Mapping
 from typing import TYPE_CHECKING, Any, Final, Optional
 
 from litellm._logging import verbose_router_logger
@@ -323,11 +322,13 @@ class QualityRouter(CustomLogger):
         if isinstance(metadata, dict):
             metadata["quality_router_decision"] = decision
 
-    def _savings_fields(self) -> Mapping[str, str]:
+    def _savings_fields(self) -> StandardLoggingRoutingDecision:
         baseline = resolve_baseline(self.litellm_router_instance, self.config.available_models)
         if baseline is None:
             return {}  # mutable-ok: immutable empty result for unresolved baseline
-        fields = {"savings_baseline_model": baseline.model}  # mutable-ok: assemble TypedDict kwargs
+        fields: StandardLoggingRoutingDecision = {
+            "savings_baseline_model": baseline.model,
+        }  # mutable-ok: assemble TypedDict kwargs
         if baseline.deployment_id is not None:
             fields["savings_baseline_deployment_id"] = baseline.deployment_id
         return fields
@@ -370,17 +371,18 @@ class QualityRouter(CustomLogger):
             verbose_router_logger.debug("QualityRouter: No user message found, routing to default model")
             if not self.config.default_model:
                 raise ValueError("QualityRouter: no user message and no default_model configured")
+            default_routing_decision: Final = StandardLoggingRoutingDecision(
+                router_model_name=self.model_name,
+                router_type="quality",
+                routed_model=self.config.default_model,
+                cause="default_fallback",
+                conversation_continuing=conversation_is_continuing(messages),
+            )
+            default_routing_decision.update(self._savings_fields())
             return PreRoutingHookResponse(
                 model=self.config.default_model,
                 messages=messages,
-                routing_decision=StandardLoggingRoutingDecision(
-                    router_model_name=self.model_name,
-                    router_type="quality",
-                    routed_model=self.config.default_model,
-                    cause="default_fallback",
-                    conversation_continuing=conversation_is_continuing(messages),
-                    **self._savings_fields(),
-                ),
+                routing_decision=default_routing_decision,
             )
 
         # Try keyword override first — it short-circuits complexity classification.
@@ -404,25 +406,24 @@ class QualityRouter(CustomLogger):
                     "quality_tier": self._model_quality.get(routed_model),
                     "complexity_tier": None,
                     "conversation_continuing": conversation_is_continuing(messages),
-                    **self._savings_fields(),
                 },
             )
-            routing_decision: Final = StandardLoggingRoutingDecision(
+            keyword_routing_decision: Final = StandardLoggingRoutingDecision(
                 router_model_name=self.model_name,
                 router_type="quality",
                 routed_model=routed_model,
                 cause="keyword",
                 matched_keyword=matched_keyword,
                 conversation_continuing=conversation_is_continuing(messages),
-                **self._savings_fields(),
             )
+            keyword_routing_decision.update(self._savings_fields())
             keyword_quality_tier: Final = self._model_quality.get(routed_model)
             if keyword_quality_tier is not None:
-                routing_decision["tier"] = str(keyword_quality_tier)
+                keyword_routing_decision["tier"] = str(keyword_quality_tier)
             return PreRoutingHookResponse(
                 model=routed_model,
                 messages=messages,
-                routing_decision=routing_decision,
+                routing_decision=keyword_routing_decision,
             )
 
         # No keyword match → complexity classification flow.
@@ -454,22 +455,22 @@ class QualityRouter(CustomLogger):
                 "quality_tier": int(quality_tier),
                 "complexity_tier": complexity_name,
                 "conversation_continuing": conversation_is_continuing(messages),
-                **self._savings_fields(),
             },
         )
 
+        quality_routing_decision: Final = StandardLoggingRoutingDecision(
+            router_model_name=self.model_name,
+            router_type="quality",
+            routed_model=routed_model,
+            cause="quality_tier",
+            tier=str(int(quality_tier)),
+            score=score,
+            signals=list(signals),
+            conversation_continuing=conversation_is_continuing(messages),
+        )
+        quality_routing_decision.update(self._savings_fields())
         return PreRoutingHookResponse(
             model=routed_model,
             messages=messages,
-            routing_decision=StandardLoggingRoutingDecision(
-                router_model_name=self.model_name,
-                router_type="quality",
-                routed_model=routed_model,
-                cause="quality_tier",
-                tier=str(int(quality_tier)),
-                score=score,
-                signals=list(signals),
-                conversation_continuing=conversation_is_continuing(messages),
-                **self._savings_fields(),
-            ),
+            routing_decision=quality_routing_decision,
         )

--- a/litellm/router_strategy/quality_router/quality_router.py
+++ b/litellm/router_strategy/quality_router/quality_router.py
@@ -23,6 +23,10 @@ from litellm.integrations.custom_logger import CustomLogger
 from litellm.router_strategy.complexity_router.complexity_router import (
     ComplexityRouter,
 )
+from litellm.router_strategy.savings_baseline import (
+    conversation_is_continuing,
+    resolve_baseline,
+)
 from litellm.types.utils import StandardLoggingRoutingDecision
 
 from .config import QualityRouterConfig, RoutingPreferences
@@ -318,6 +322,15 @@ class QualityRouter(CustomLogger):
         if isinstance(metadata, dict):
             metadata["quality_router_decision"] = decision
 
+    def _savings_fields(self) -> dict[str, str]:
+        baseline = resolve_baseline(self.litellm_router_instance, self.config.available_models)
+        if baseline is None:
+            return {}
+        fields = {"savings_baseline_model": baseline.model}
+        if baseline.deployment_id is not None:
+            fields["savings_baseline_deployment_id"] = baseline.deployment_id
+        return fields
+
     async def async_pre_routing_hook(
         self,
         model: str,
@@ -364,6 +377,8 @@ class QualityRouter(CustomLogger):
                     router_type="quality",
                     routed_model=self.config.default_model,
                     cause="default_fallback",
+                    conversation_continuing=conversation_is_continuing(messages),
+                    **self._savings_fields(),
                 ),
             )
 
@@ -387,6 +402,8 @@ class QualityRouter(CustomLogger):
                     "matched_keyword": matched_keyword,
                     "quality_tier": self._model_quality.get(routed_model),
                     "complexity_tier": None,
+                    "conversation_continuing": conversation_is_continuing(messages),
+                    **self._savings_fields(),
                 },
             )
             routing_decision: Final = StandardLoggingRoutingDecision(
@@ -395,6 +412,8 @@ class QualityRouter(CustomLogger):
                 routed_model=routed_model,
                 cause="keyword",
                 matched_keyword=matched_keyword,
+                conversation_continuing=conversation_is_continuing(messages),
+                **self._savings_fields(),
             )
             keyword_quality_tier: Final = self._model_quality.get(routed_model)
             if keyword_quality_tier is not None:
@@ -433,6 +452,8 @@ class QualityRouter(CustomLogger):
                 "matched_keyword": None,
                 "quality_tier": int(quality_tier),
                 "complexity_tier": complexity_name,
+                "conversation_continuing": conversation_is_continuing(messages),
+                **self._savings_fields(),
             },
         )
 
@@ -447,5 +468,7 @@ class QualityRouter(CustomLogger):
                 tier=str(int(quality_tier)),
                 score=score,
                 signals=list(signals),
+                conversation_continuing=conversation_is_continuing(messages),
+                **self._savings_fields(),
             ),
         )

--- a/litellm/router_strategy/quality_router/quality_router.py
+++ b/litellm/router_strategy/quality_router/quality_router.py
@@ -326,12 +326,14 @@ class QualityRouter(CustomLogger):
         baseline = resolve_baseline(self.litellm_router_instance, self.config.available_models)
         if baseline is None:
             return {}  # mutable-ok: immutable empty result for unresolved baseline
-        fields: StandardLoggingRoutingDecision = {
+        return {
             "savings_baseline_model": baseline.model,
-        }  # mutable-ok: assemble TypedDict kwargs
-        if baseline.deployment_id is not None:
-            fields["savings_baseline_deployment_id"] = baseline.deployment_id
-        return fields
+            **(
+                {"savings_baseline_deployment_id": baseline.deployment_id}
+                if baseline.deployment_id is not None
+                else {}
+            ),
+        }
 
     async def async_pre_routing_hook(
         self,
@@ -347,6 +349,9 @@ class QualityRouter(CustomLogger):
         if messages is None or len(messages) == 0:
             verbose_router_logger.debug("QualityRouter: No messages provided, skipping routing")
             return None
+
+        conversation_continuing: Final = conversation_is_continuing(messages)
+        savings_fields: Final = self._savings_fields()
 
         # Extract last user message and last system prompt — same rules as
         # ComplexityRouter.async_pre_routing_hook.
@@ -376,9 +381,9 @@ class QualityRouter(CustomLogger):
                 router_type="quality",
                 routed_model=self.config.default_model,
                 cause="default_fallback",
-                conversation_continuing=conversation_is_continuing(messages),
+                conversation_continuing=conversation_continuing,
             )
-            default_routing_decision.update(self._savings_fields())
+            default_routing_decision.update(savings_fields)
             return PreRoutingHookResponse(
                 model=self.config.default_model,
                 messages=messages,
@@ -405,7 +410,7 @@ class QualityRouter(CustomLogger):
                     "matched_keyword": matched_keyword,
                     "quality_tier": self._model_quality.get(routed_model),
                     "complexity_tier": None,
-                    "conversation_continuing": conversation_is_continuing(messages),
+                    "conversation_continuing": conversation_continuing,
                 },
             )
             keyword_routing_decision: Final = StandardLoggingRoutingDecision(
@@ -414,9 +419,9 @@ class QualityRouter(CustomLogger):
                 routed_model=routed_model,
                 cause="keyword",
                 matched_keyword=matched_keyword,
-                conversation_continuing=conversation_is_continuing(messages),
+                conversation_continuing=conversation_continuing,
             )
-            keyword_routing_decision.update(self._savings_fields())
+            keyword_routing_decision.update(savings_fields)
             keyword_quality_tier: Final = self._model_quality.get(routed_model)
             if keyword_quality_tier is not None:
                 keyword_routing_decision["tier"] = str(keyword_quality_tier)
@@ -454,7 +459,7 @@ class QualityRouter(CustomLogger):
                 "matched_keyword": None,
                 "quality_tier": int(quality_tier),
                 "complexity_tier": complexity_name,
-                "conversation_continuing": conversation_is_continuing(messages),
+                "conversation_continuing": conversation_continuing,
             },
         )
 
@@ -466,9 +471,9 @@ class QualityRouter(CustomLogger):
             tier=str(int(quality_tier)),
             score=score,
             signals=list(signals),
-            conversation_continuing=conversation_is_continuing(messages),
+            conversation_continuing=conversation_continuing,
         )
-        quality_routing_decision.update(self._savings_fields())
+        quality_routing_decision.update(savings_fields)
         return PreRoutingHookResponse(
             model=routed_model,
             messages=messages,

--- a/litellm/router_strategy/quality_router/quality_router.py
+++ b/litellm/router_strategy/quality_router/quality_router.py
@@ -329,9 +329,7 @@ class QualityRouter(CustomLogger):
         return {
             "savings_baseline_model": baseline.model,
             **(
-                {"savings_baseline_deployment_id": baseline.deployment_id}
-                if baseline.deployment_id is not None
-                else {}
+                {"savings_baseline_deployment_id": baseline.deployment_id} if baseline.deployment_id is not None else {}
             ),
         }
 

--- a/litellm/router_strategy/savings_baseline.py
+++ b/litellm/router_strategy/savings_baseline.py
@@ -47,7 +47,7 @@ class Baseline(NamedTuple):
 
 def conversation_is_continuing(messages: Sequence[Mapping[str, object]] | None) -> bool:
     """Return whether the request contains evidence of an earlier assistant turn."""
-    return any(message.get("role") == "assistant" for message in messages or ())
+    return not messages or any(message.get("role") == "assistant" for message in messages)
 
 
 def canonical_model(model: str, custom_llm_provider: str | None = None) -> str | None:

--- a/litellm/router_strategy/savings_baseline.py
+++ b/litellm/router_strategy/savings_baseline.py
@@ -14,7 +14,7 @@ bare string with no provider beside them; an operator who writes ``deepseek-r1``
 Azure would otherwise be priced against whoever else owns that name.
 """
 
-from collections.abc import Iterable
+from collections.abc import Iterable, Mapping, Sequence
 from typing import TYPE_CHECKING, Final, NamedTuple
 
 from litellm._logging import verbose_router_logger
@@ -43,6 +43,11 @@ class Baseline(NamedTuple):
 
     model: str
     deployment_id: str | None = None
+
+
+def conversation_is_continuing(messages: Sequence[Mapping[str, object]] | None) -> bool:
+    """Return whether the request contains evidence of an earlier assistant turn."""
+    return any(message.get("role") == "assistant" for message in messages or ())
 
 
 def canonical_model(model: str, custom_llm_provider: str | None = None) -> str | None:

--- a/tests/test_litellm/router_strategy/adaptive_router/test_async_pre_routing.py
+++ b/tests/test_litellm/router_strategy/adaptive_router/test_async_pre_routing.py
@@ -7,12 +7,11 @@ model on metadata, and return a PreRoutingHookResponse.
 Routing is stateless per-turn — `pick_model` does not take a session id.
 """
 
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
 from litellm.router_strategy.adaptive_router.adaptive_router import AdaptiveRouter
-from litellm.router_strategy.savings_baseline import Baseline
 from litellm.types.router import (
     AdaptiveRouterConfig,
     PreRoutingHookResponse,
@@ -45,14 +44,20 @@ async def test_returns_pre_routing_hook_response_with_chosen_model():
 
 
 @pytest.mark.asyncio
-async def test_records_savings_baseline_and_conversation_shape(monkeypatch):
+async def test_records_savings_baseline_and_conversation_shape():
     router = _make_router()
-    router.litellm_router_instance = object()
+    router_instance = MagicMock()
+    router_instance.model_name_to_deployment_indices = {"fast": [0], "smart": [1]}
+    router_instance.model_list = [
+        {"litellm_params": {"model": "openai/fast"}, "model_info": {"id": "fast-id"}},
+        {"litellm_params": {"model": "openai/smart"}, "model_info": {"id": "smart-id"}},
+    ]
+    router_instance.get_deployment_model_info.side_effect = lambda deployment_id, model: {
+        "input_cost_per_token": 0.00000015 if deployment_id == "fast-id" else 0.000005,
+        "output_cost_per_token": 0.00000015 if deployment_id == "fast-id" else 0.000005,
+    }
+    router.litellm_router_instance = router_instance
     router.pick_model = AsyncMock(return_value="smart")  # type: ignore[method-assign]
-    monkeypatch.setattr(
-        "litellm.router_strategy.adaptive_router.adaptive_router.resolve_baseline",
-        lambda router, models: Baseline("openai/smart", "deployment-id"),
-    )
 
     response = await router.async_pre_routing_hook(
         model="smart-cheap-router",
@@ -67,7 +72,20 @@ async def test_records_savings_baseline_and_conversation_shape(monkeypatch):
     assert response is not None
     assert response.routing_decision["conversation_continuing"] is True
     assert response.routing_decision["savings_baseline_model"] == "openai/smart"
-    assert response.routing_decision["savings_baseline_deployment_id"] == "deployment-id"
+    assert response.routing_decision["savings_baseline_deployment_id"] == "smart-id"
+
+
+@pytest.mark.asyncio
+async def test_empty_messages_use_conservative_continuing_shape():
+    router = _make_router()
+    router.pick_model = AsyncMock(return_value="smart")  # type: ignore[method-assign]
+
+    response = await router.async_pre_routing_hook(
+        model="smart-cheap-router", request_kwargs={}, messages=None
+    )
+
+    assert response is not None
+    assert response.routing_decision["conversation_continuing"] is True
 
 
 @pytest.mark.asyncio

--- a/tests/test_litellm/router_strategy/adaptive_router/test_async_pre_routing.py
+++ b/tests/test_litellm/router_strategy/adaptive_router/test_async_pre_routing.py
@@ -12,6 +12,7 @@ from unittest.mock import AsyncMock
 import pytest
 
 from litellm.router_strategy.adaptive_router.adaptive_router import AdaptiveRouter
+from litellm.router_strategy.savings_baseline import Baseline
 from litellm.types.router import (
     AdaptiveRouterConfig,
     PreRoutingHookResponse,
@@ -41,6 +42,32 @@ async def test_returns_pre_routing_hook_response_with_chosen_model():
 
     assert isinstance(response, PreRoutingHookResponse)
     assert response.model == "smart"
+
+
+@pytest.mark.asyncio
+async def test_records_savings_baseline_and_conversation_shape(monkeypatch):
+    router = _make_router()
+    router.litellm_router_instance = object()
+    router.pick_model = AsyncMock(return_value="smart")  # type: ignore[method-assign]
+    monkeypatch.setattr(
+        "litellm.router_strategy.adaptive_router.adaptive_router.resolve_baseline",
+        lambda router, models: Baseline("openai/smart", "deployment-id"),
+    )
+
+    response = await router.async_pre_routing_hook(
+        model="smart-cheap-router",
+        request_kwargs={},
+        messages=[
+            {"role": "user", "content": "first"},
+            {"role": "assistant", "content": "answer"},
+            {"role": "user", "content": "next"},
+        ],
+    )
+
+    assert response is not None
+    assert response.routing_decision["conversation_continuing"] is True
+    assert response.routing_decision["savings_baseline_model"] == "openai/smart"
+    assert response.routing_decision["savings_baseline_deployment_id"] == "deployment-id"
 
 
 @pytest.mark.asyncio

--- a/tests/test_litellm/router_strategy/test_quality_router.py
+++ b/tests/test_litellm/router_strategy/test_quality_router.py
@@ -845,6 +845,14 @@ class TestDecisionMetadata:
         assert response.routing_decision["savings_baseline_model"] == "openai/opus-next"
         assert response.routing_decision["savings_baseline_deployment_id"] == "id-opus-next"
 
+        first_turn = await quality_router.async_pre_routing_hook(
+            model="quality-router-test",
+            request_kwargs={},
+            messages=[{"role": "user", "content": "first request"}],
+        )
+        assert first_turn is not None
+        assert first_turn.routing_decision["conversation_continuing"] is False
+
     @pytest.mark.asyncio
     async def test_hook_stashes_decision_in_request_kwargs_metadata(
         self, quality_router

--- a/tests/test_litellm/router_strategy/test_quality_router.py
+++ b/tests/test_litellm/router_strategy/test_quality_router.py
@@ -19,7 +19,6 @@ from litellm.router_strategy.quality_router.config import (
     DEFAULT_COMPLEXITY_TO_QUALITY,
 )
 from litellm.router_strategy.quality_router.quality_router import QualityRouter
-from litellm.router_strategy.savings_baseline import Baseline
 
 
 def _make_model_list(spec: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
@@ -824,10 +823,23 @@ class TestKeywordOverride:
 
 class TestDecisionMetadata:
     @pytest.mark.asyncio
-    async def test_decision_includes_savings_baseline_and_conversation_shape(self, quality_router, monkeypatch):
-        monkeypatch.setattr(
-            "litellm.router_strategy.quality_router.quality_router.resolve_baseline",
-            lambda router, models: Baseline("openai/opus-next", "id-opus-next"),
+    async def test_decision_includes_savings_baseline_and_conversation_shape(self, quality_router):
+        quality_router.litellm_router_instance.model_name_to_deployment_indices = {
+            "haiku": [0],
+            "sonnet": [1],
+            "opus": [2],
+            "opus-next": [3],
+        }
+        quality_router.litellm_router_instance.get_deployment_model_info.side_effect = (
+            lambda deployment_id, model: {
+                "input_cost_per_token": {
+                    "id-haiku": 0.000001,
+                    "id-sonnet": 0.000002,
+                    "id-opus": 0.000003,
+                    "id-opus-next": 0.000004,
+                }[deployment_id],
+                "output_cost_per_token": 0.000001,
+            }
         )
         request_kwargs: Dict[str, Any] = {}
         response = await quality_router.async_pre_routing_hook(
@@ -842,8 +854,8 @@ class TestDecisionMetadata:
 
         assert response is not None
         assert response.routing_decision["conversation_continuing"] is True
-        assert response.routing_decision["savings_baseline_model"] == "openai/opus-next"
-        assert response.routing_decision["savings_baseline_deployment_id"] == "id-opus-next"
+        assert response.routing_decision["savings_baseline_model"] == "openai/sonnet"
+        assert response.routing_decision["savings_baseline_deployment_id"] == "id-sonnet"
 
         first_turn = await quality_router.async_pre_routing_hook(
             model="quality-router-test",

--- a/tests/test_litellm/router_strategy/test_quality_router.py
+++ b/tests/test_litellm/router_strategy/test_quality_router.py
@@ -19,6 +19,7 @@ from litellm.router_strategy.quality_router.config import (
     DEFAULT_COMPLEXITY_TO_QUALITY,
 )
 from litellm.router_strategy.quality_router.quality_router import QualityRouter
+from litellm.router_strategy.savings_baseline import Baseline
 
 
 def _make_model_list(spec: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
@@ -822,6 +823,28 @@ class TestKeywordOverride:
 
 
 class TestDecisionMetadata:
+    @pytest.mark.asyncio
+    async def test_decision_includes_savings_baseline_and_conversation_shape(self, quality_router, monkeypatch):
+        monkeypatch.setattr(
+            "litellm.router_strategy.quality_router.quality_router.resolve_baseline",
+            lambda router, models: Baseline("openai/opus-next", "id-opus-next"),
+        )
+        request_kwargs: Dict[str, Any] = {}
+        response = await quality_router.async_pre_routing_hook(
+            model="quality-router-test",
+            request_kwargs=request_kwargs,
+            messages=[
+                {"role": "user", "content": "hi"},
+                {"role": "assistant", "content": "hello"},
+                {"role": "user", "content": "continue"},
+            ],
+        )
+
+        assert response is not None
+        assert response.routing_decision["conversation_continuing"] is True
+        assert response.routing_decision["savings_baseline_model"] == "openai/opus-next"
+        assert response.routing_decision["savings_baseline_deployment_id"] == "id-opus-next"
+
     @pytest.mark.asyncio
     async def test_hook_stashes_decision_in_request_kwargs_metadata(
         self, quality_router

--- a/tests/test_litellm/router_strategy/test_quality_router.py
+++ b/tests/test_litellm/router_strategy/test_quality_router.py
@@ -823,6 +823,27 @@ class TestKeywordOverride:
 
 class TestDecisionMetadata:
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("content, cause", [("hi", "quality_tier"), ("write python", "keyword")])
+    async def test_conversation_shape_is_read_once_for_metadata_and_savings(self, keyword_router, content, cause):
+        class CountedMessage(dict):
+            role_reads = 0
+
+            def get(self, key, default=None):
+                if key == "role":
+                    self.role_reads += 1
+                return super().get(key, default)
+
+        message = CountedMessage(role="user", content=content)
+        kwargs: Dict[str, Any] = {}
+        response = await keyword_router.async_pre_routing_hook("qr", kwargs, [message])
+
+        assert response is not None
+        assert response.routing_decision["cause"] == cause
+        assert response.routing_decision["conversation_continuing"] is False
+        assert kwargs["metadata"]["quality_router_decision"]["conversation_continuing"] is False
+        assert message.role_reads == 2
+
+    @pytest.mark.asyncio
     async def test_decision_includes_savings_baseline_and_conversation_shape(self, quality_router):
         quality_router.litellm_router_instance.model_name_to_deployment_indices = {
             "haiku": [0],

--- a/tests/test_litellm/router_strategy/test_savings_baseline.py
+++ b/tests/test_litellm/router_strategy/test_savings_baseline.py
@@ -4,6 +4,7 @@ from litellm.router import Router
 from litellm.router_strategy.savings_baseline import (
     Baseline,
     canonical_model,
+    conversation_is_continuing,
     _models_in,
     _most_expensive,
     resolve_baseline,
@@ -20,6 +21,19 @@ def parent() -> Router:
             {"model_name": "pool", "litellm_params": {"model": "anthropic/claude-opus-5"}},
         ]
     )
+
+
+@pytest.mark.parametrize(
+    "messages, expected",
+    [
+        (None, True),
+        ([], True),
+        ([{"role": "user", "content": "hello"}], False),
+        ([{"role": "user"}, {"role": "assistant"}, {"role": "user"}], True),
+    ],
+)
+def test_conversation_shape_for_savings(messages, expected):
+    assert conversation_is_continuing(messages) is expected
 
 
 class TestCanonicalModel:


### PR DESCRIPTION
## TLDR

Fixes #38814 by recording the savings baseline and conversation shape for direct adaptive and quality routing.

## User Flow

Before: an adaptive or quality-routed request reaches spend tracking without enough routing metadata to calculate savings.

1. An operator configures an adaptive or quality router with multiple local model deployments.
2. A developer sends a first or continuing chat request through the router.
3. The request is routed successfully, but the spend record lacks the baseline model and/or first-turn information.
4. Autorouter savings are missing or can apply the wrong cache counterfactual.

After: the same request carries the shared baseline and explicit conversation shape.

1. An operator configures the same adaptive or quality router with multiple local model deployments.
2. A developer sends the same first or continuing chat request through the router.
3. The request is routed successfully with the baseline model, deployment id when available, and conversation shape recorded.
4. Autorouter savings can apply the correct cache counterfactual without a provider call.

## Relevant issues

Fixes #38814

## Type

🐛 Bug Fix

## Tests

- `uv run --frozen pytest tests/test_litellm/router_strategy/test_quality_router.py tests/test_litellm/router_strategy/adaptive_router/test_async_pre_routing.py -q`
- 57 passed
- `uv run ruff check` passes for the changed Python source paths.

## Caveats

The regression tests use mocked routing and baseline resolution; no provider credentials or real LLM calls are required.
