### PR TITLE
test(e2e): backport the select-anchoring and router-fallback spec de-flakes

### DIFF
--- a/tests/e2e/models.py
+++ b/tests/e2e/models.py
@@ -229,6 +229,7 @@ class ChatBody(BaseModel):
     reasoning_effort: str | None = None
     thinking: ThinkingParam | None = None
     service_tier: str | None = None
+    prompt_cache_key: str | None = None
     tools: Sequence[ChatTool | McpChatTool] | None = None
     tool_choice: str | None = None
     guardrails: list[str] | None = None

--- a/tests/e2e/quota_management/spend_tracking/test_cost_headers_e2e.py
+++ b/tests/e2e/quota_management/spend_tracking/test_cost_headers_e2e.py
@@ -102,11 +102,8 @@ class TestCostHeaders:
                     return response
             return None
 
-        measured: StreamingResponse | None = None
-        for _ in range(CACHE_ATTEMPTS):
-            measured = prime_then_reread()
-            if measured is not None:
-                break
+        rounds = (prime_then_reread() for _ in range(CACHE_ATTEMPTS))
+        measured = next((response for response in rounds if response is not None), None)
         if measured is None:
             pytest.fail(
                 f"no cache read landed across {CACHE_ATTEMPTS} prime rounds of "

--- a/tests/e2e/quota_management/spend_tracking/test_cost_headers_e2e.py
+++ b/tests/e2e/quota_management/spend_tracking/test_cost_headers_e2e.py
@@ -12,10 +12,15 @@ header is exercised with a real nonzero value instead of passing vacuously. The
 backend is gpt-5.5 because it reports cached tokens on the second call; the
 gpt-5.6 line reports cache writes and never a read, which would leave the
 cache-read header at zero forever. The raw-transport send is used because the
-typed chat client validates bodies and drops headers. OpenAI caching is
-best-effort, so the prime+measure round retries with a fresh prefix before
-failing.
+typed chat client validates bodies and drops headers.
+
+OpenAI publishes a primed prefix asynchronously and routes lookups by
+prompt_cache_key, so a measure fired the instant the prime returns can miss a
+prefix that is about to become readable. Each round pins a cache key and re-reads
+the prefix it already paid to prime before spending a fresh one.
 """
+
+import time
 
 import pytest
 
@@ -31,6 +36,8 @@ pytestmark = pytest.mark.e2e
 BACKEND = "openai/gpt-5.5"
 OPENAI_API_KEY = "os.environ/OPENAI_API_KEY"
 CACHE_ATTEMPTS = 3
+CACHE_REREADS = 3
+CACHE_SETTLE_SECONDS = 2.0
 
 INPUT_RATE = 4e-05
 OUTPUT_RATE = 8e-05
@@ -70,7 +77,7 @@ class TestCostHeaders:
             ),
         )
 
-        def priced_call(content: str) -> StreamingResponse:
+        def priced_call(content: str, cache_key: str) -> StreamingResponse:
             response = client.proxy.transport.send(
                 "/chat/completions",
                 headers=client.proxy.transport.bearer(scoped_key),
@@ -78,21 +85,33 @@ class TestCostHeaders:
                     model=model,
                     messages=[ChatMessage(role="user", content=content)],
                     max_completion_tokens=4000,
+                    prompt_cache_key=cache_key,
                 ),
             )
             assert response.ok, f"chat failed (status {response.status_code}): {response.body[:300]}"
             return response
 
+        def prime_then_reread() -> StreamingResponse | None:
+            marker = unique_marker()
+            prefix = cacheable_prefix(marker)
+            priced_call(f"{prefix}\nReply with the single word ready.", marker)
+            for _ in range(CACHE_REREADS):
+                time.sleep(CACHE_SETTLE_SECONDS)
+                response = priced_call(f"{prefix}\nReply with the single word measured.", marker)
+                if _header_cost(response, "x-litellm-response-cost-cache-read") > 0:
+                    return response
+            return None
+
+        measured: StreamingResponse | None = None
         for _ in range(CACHE_ATTEMPTS):
-            prefix = cacheable_prefix(unique_marker())
-            priced_call(f"{prefix}\nReply with the single word ready.")
-            measured = priced_call(f"{prefix}\nReply with the single word measured.")
-            if _header_cost(measured, "x-litellm-response-cost-cache-read") > 0:
+            measured = prime_then_reread()
+            if measured is not None:
                 break
-        else:
+        if measured is None:
             pytest.fail(
-                f"no cache read landed across {CACHE_ATTEMPTS} prime+measure rounds; "
-                "the cache-read cost header was never exercised with a nonzero value"
+                f"no cache read landed across {CACHE_ATTEMPTS} prime rounds of "
+                f"{CACHE_REREADS} re-reads each; the cache-read cost header was never "
+                "exercised with a nonzero value"
             )
 
         total = measured.response_cost

--- a/tests/e2e/ui/tests/modelsPage/autoRouterTemplateSelect.spec.ts
+++ b/tests/e2e/ui/tests/modelsPage/autoRouterTemplateSelect.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test, type Page as PlaywrightPage } from "@playwright/test";
+import { expect, test, type Locator, type Page as PlaywrightPage } from "@playwright/test";
 import { ADMIN_STORAGE_PATH } from "../../constants";
 import { navigateToPage } from "../../helpers/navigation";
 import { Page } from "../../fixtures/pages";
@@ -17,43 +17,49 @@ async function openTemplateSelect(page: PlaywrightPage) {
   return trigger;
 }
 
+function pollPixelsBelowTrigger(trigger: Locator, popup: Locator) {
+  return expect.poll(async () => {
+    const triggerBox = await trigger.boundingBox();
+    const popupBox = await popup.boundingBox();
+    if (!triggerBox || !popupBox) return null;
+    return popupBox.y - (triggerBox.y + triggerBox.height);
+  });
+}
+
+function pollPopupOverlapsTrigger(trigger: Locator, popup: Locator) {
+  return expect.poll(async () => {
+    const triggerBox = await trigger.boundingBox();
+    const popupBox = await popup.boundingBox();
+    if (!triggerBox || !popupBox) return null;
+    return popupBox.y < triggerBox.y + triggerBox.height && popupBox.y + popupBox.height > triggerBox.y;
+  });
+}
+
 test.describe("Auto Router template select anchoring", () => {
   test.use({ storageState: ADMIN_STORAGE_PATH });
 
   test("opens the options below the trigger rather than over it", async ({ page }) => {
     await page.setViewportSize({ width: 1280, height: 900 });
     const trigger = await openTemplateSelect(page);
-    const triggerBox = await trigger.boundingBox();
 
     await trigger.click();
     const popup = page.locator('[data-slot="select-content"]');
     await expect(popup).toBeVisible();
-    const popupBox = await popup.boundingBox();
-
-    expect(triggerBox).not.toBeNull();
-    expect(popupBox).not.toBeNull();
 
     // Item-aligned mode reports "none" and puts the active item over the trigger.
     await expect(popup).toHaveAttribute("data-side", "bottom");
-    expect(popupBox!.y).toBeGreaterThanOrEqual(triggerBox!.y + triggerBox!.height);
+    await pollPixelsBelowTrigger(trigger, popup).toBeGreaterThanOrEqual(0);
   });
 
   test("flips above the trigger instead of covering it when there is no room below", async ({ page }) => {
     await page.setViewportSize({ width: 1280, height: 560 });
     const trigger = await openTemplateSelect(page);
     await trigger.scrollIntoViewIfNeeded();
-    const triggerBox = await trigger.boundingBox();
 
     await trigger.click();
     const popup = page.locator('[data-slot="select-content"]');
     await expect(popup).toBeVisible();
-    const popupBox = await popup.boundingBox();
 
-    expect(triggerBox).not.toBeNull();
-    expect(popupBox).not.toBeNull();
-
-    const overlaps =
-      popupBox!.y < triggerBox!.y + triggerBox!.height && popupBox!.y + popupBox!.height > triggerBox!.y;
-    expect(overlaps).toBe(false);
+    await pollPopupOverlapsTrigger(trigger, popup).toBe(false);
   });
 });

--- a/tests/e2e/ui/tests/settings/routerSettings.spec.ts
+++ b/tests/e2e/ui/tests/settings/routerSettings.spec.ts
@@ -139,24 +139,18 @@ async function patchRouterSettings(
 }
 
 /**
- * Requires a consecutive streak because a single reply only proves the one replica that
- * served it has reloaded, not the sibling still answering from the pre-update config.
+ * Spreads its samples across more than one reload cycle: a single reply only proves the one
+ * replica that served it has reloaded, not the sibling still on the pre-update config.
  */
-async function pollUntilSettled(
-  probe: () => Promise<number>,
-  matches: (status: number) => boolean,
-  message: string,
-): Promise<void> {
-  let streak = 0;
-  await expect
-    .poll(
-      async () => {
-        streak = matches(await probe()) ? streak + 1 : 0;
-        return streak;
-      },
-      { timeout: SETTLE_TIMEOUT_MS, intervals: [SETTLE_INTERVAL_MS], message },
-    )
-    .toBeGreaterThanOrEqual(SETTLE_PROBES);
+async function sampleStatuses(probe: () => Promise<number>): Promise<readonly number[]> {
+  return Array.from({ length: SETTLE_PROBES }).reduce<Promise<readonly number[]>>(
+    async (taken, _unused, index) => {
+      const sofar = await taken;
+      if (index > 0) await new Promise((resolve) => setTimeout(resolve, SETTLE_INTERVAL_MS));
+      return [...sofar, await probe()];
+    },
+    Promise.resolve([]),
+  );
 }
 
 test.describe("Router Settings - Loadbalancing", () => {
@@ -289,19 +283,24 @@ test.describe("Router Settings - Fallbacks serve the request", () => {
         })
       ).status();
 
-    // The control: it proves the reply below could only have come from the fallback.
-    await pollUntilSettled(
-      chatStatus,
-      (status) => status >= 400,
-      "broken primary unexpectedly succeeded on its own",
-    );
+    // The control: every replica must reject, or the reply below could have come from one
+    // that was still serving a fallback left behind by an earlier attempt.
+    await expect
+      .poll(async () => (await sampleStatuses(chatStatus)).every((status) => status >= 400), {
+        timeout: SETTLE_TIMEOUT_MS,
+        message: "broken primary unexpectedly succeeded on its own",
+      })
+      .toBe(true);
 
     await patchRouterSettings(request, {
       fallbacks: [{ [BROKEN_PRIMARY]: [PRIMARY] }],
     } as Partial<NonNullable<ConfigYAML["router_settings"]>>);
 
-    // Same call now succeeds, served by the fallback model.
-    await pollUntilSettled(chatStatus, (status) => status === 200, "fallback never took effect");
+    // One success is the whole claim here, so this waits for a first sighting rather than
+    // for every replica: demanding a streak would also assert a fallback hit rate.
+    await expect
+      .poll(chatStatus, { timeout: SETTLE_TIMEOUT_MS, message: "fallback never took effect" })
+      .toBe(200);
 
     // And the playground renders a reply for a model whose own upstream is down.
     await openPlayground(page);

--- a/tests/e2e/ui/tests/settings/routerSettings.spec.ts
+++ b/tests/e2e/ui/tests/settings/routerSettings.spec.ts
@@ -117,6 +117,11 @@ const ADMIN_AUTH = {
   Authorization: `Bearer ${users[Role.ProxyAdmin].password}`,
 };
 
+// Five probes 2s apart outlast the e2e stack's proxy_config_reload_interval_seconds of 7.
+const SETTLE_INTERVAL_MS = 2_000;
+const SETTLE_PROBES = 5;
+const SETTLE_TIMEOUT_MS = 60_000;
+
 /**
  * Apply a router_settings patch through the typed /config/update contract. The
  * server merges it over existing settings (request wins), so only the passed keys
@@ -131,6 +136,27 @@ async function patchRouterSettings(
     data: { router_settings: patch },
   });
   expect(res.ok(), `seed /config/update failed: ${res.status()} ${await res.text()}`).toBeTruthy();
+}
+
+/**
+ * Requires a consecutive streak because a single reply only proves the one replica that
+ * served it has reloaded, not the sibling still answering from the pre-update config.
+ */
+async function pollUntilSettled(
+  probe: () => Promise<number>,
+  matches: (status: number) => boolean,
+  message: string,
+): Promise<void> {
+  let streak = 0;
+  await expect
+    .poll(
+      async () => {
+        streak = matches(await probe()) ? streak + 1 : 0;
+        return streak;
+      },
+      { timeout: SETTLE_TIMEOUT_MS, intervals: [SETTLE_INTERVAL_MS], message },
+    )
+    .toBeGreaterThanOrEqual(SETTLE_PROBES);
 }
 
 test.describe("Router Settings - Loadbalancing", () => {
@@ -252,29 +278,30 @@ test.describe("Router Settings - Fallbacks serve the request", () => {
   });
 
   test("a request to an unreachable model is answered by its fallback", async ({ page, request }) => {
-    const chat = async () =>
-      request.post("/v1/chat/completions", {
-        headers: { ...ADMIN_AUTH, "Content-Type": "application/json" },
-        data: {
-          model: BROKEN_PRIMARY,
-          messages: [{ role: "user", content: "fallback probe" }],
-        },
-      });
+    const chatStatus = async () =>
+      (
+        await request.post("/v1/chat/completions", {
+          headers: { ...ADMIN_AUTH, "Content-Type": "application/json" },
+          data: {
+            model: BROKEN_PRIMARY,
+            messages: [{ role: "user", content: "fallback probe" }],
+          },
+        })
+      ).status();
 
     // The control: it proves the reply below could only have come from the fallback.
-    expect((await chat()).status(), "broken primary unexpectedly succeeded on its own").toBeGreaterThanOrEqual(400);
+    await pollUntilSettled(
+      chatStatus,
+      (status) => status >= 400,
+      "broken primary unexpectedly succeeded on its own",
+    );
 
     await patchRouterSettings(request, {
       fallbacks: [{ [BROKEN_PRIMARY]: [PRIMARY] }],
     } as Partial<NonNullable<ConfigYAML["router_settings"]>>);
 
     // Same call now succeeds, served by the fallback model.
-    await expect
-      .poll(async () => (await chat()).status(), {
-        timeout: 30_000,
-        message: "fallback never took effect",
-      })
-      .toBe(200);
+    await pollUntilSettled(chatStatus, (status) => status === 200, "fallback never took effect");
 
     // And the playground renders a reply for a model whose own upstream is down.
     await openPlayground(page);


### PR DESCRIPTION
## TLDR

Problem this solves:

- Three e2e tests flake on rc/1.99.0, not on staging
- The two UI ones sank litellm-e2e builds 94 and 96
- Their de-flakes landed on staging and were never backported

How it solves it:

- Cherry-picks the three de-flake commits onto rc/1.99.0
- Polls the select popup until it settles instead of measuring mid-animation
- Samples the fallback control across a config-reload cycle, not once
- Re-reads a primed prefix under a pinned cache key

## User Flow

Before: someone qualifying an rc/1.99.0 candidate gets a red e2e build for reasons that have nothing to do with the candidate

1. They start a build at https://buildkite.com/berriai-1/litellm-e2e against the rc/1.99.0 head
2. The Playwright suite reports `1 failed`: the auto-router Template picker opened 441.8px down the page where the check wanted 446px, a 4.2px miss
3. On the previous build the same suite passed that test on a retry and failed a different one instead, so the red step moves between runs on identical code
4. They re-run, get a different red, and cannot tell the candidate apart from the harness

After: the same candidate comes back green, and a red result means something

1. They start a build at https://buildkite.com/berriai-1/litellm-e2e against the rc/1.99.0 head
2. The Playwright suite reports `104 passed`, with no retries recorded against the auto-router or router-settings specs
3. A red step from here on points at the candidate rather than at measurement timing

## Relevant issues

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

Both sides run the same product image, the rc/1.99.0 head `1411852684`. Only the runner image moves, so the suite is the only variable. Buildkite's `litellm-e2e-ui` pipeline takes `litellm_sha` for the gateway and `suite_sha` for the tests, which is what makes that isolation possible.

### Before (141185268450a248cb5bb251da3ac503273a1648)

1. Run: https://buildkite.com/berriai-1/litellm-e2e-ui/builds/99
2. Result: `1 failed`, `1 flaky`, `3 skipped`, `99 passed (9.3m)`
3. The failure, after both retries: `Expected: >= 446`, `Received: 441.79998779296875` at `autoRouterTemplateSelect.spec.ts:38`
4. The flake: `routerSettings.spec.ts:254` failed once with `fallback never took effect` (`Expected: 200`, `Received: 400`), then failed the opposite way on retry with `broken primary unexpectedly succeeded on its own` (`Expected: >= 400`, `Received: 200`), then passed
5. The prior build on the same commit, https://buildkite.com/berriai-1/litellm-e2e-ui/builds/97, failed the other one: `1 failed` on `routerSettings.spec.ts:254`, with both auto-router tests recorded as flaky

### After (da1d292dceeaf8f098ea9955eeaf7e7fb2a74a02)

1. Run: https://buildkite.com/berriai-1/litellm-e2e-ui/builds/100
2. Result: `3 skipped`, `101 passed (7.9m)`, with no `failed` and no `flaky` line, so both specs passed on their first attempt rather than being rescued by a retry
3. Second sample: https://buildkite.com/berriai-1/litellm-e2e-ui/builds/101
4. Result: `3 skipped`, `101 passed (12.7m)`, again with no `failed` and no `flaky` line
5. Every rc run before this recorded at least one of the two specs as flaky or failed (builds 94, 95, 97, 99); the first two runs carrying the fix record neither

## Type

✅ Test

## Caveats (if any)

- Test-only backport, no product code touched
- `models.py` gains one field the cost-header test sends
- A separate otel trace failure on this line is unresolved
- That one is under investigation and deliberately not patched here

## QA runbook

- `tests/e2e/ui/tests/modelsPage/autoRouterTemplateSelect.spec.ts:23` - the Template picker's options open below the select box rather than on top of it
  - [ ] Open http://localhost:3000/model-hub-table (or `?page=models` on a built proxy), go to Add Model, and pick Auto Router as the provider
  - [ ] Set the browser window to 1280x900 and click the Template select
  - [ ] Expect the options panel to sit entirely below the select box, with the box still readable above it
  - [ ] Watch the panel as it opens: it animates into place, so judge the position only once it has stopped moving, which is the whole point of the change
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey or potentially flaky
- `tests/e2e/ui/tests/modelsPage/autoRouterTemplateSelect.spec.ts:41` - the same picker flips above the box when there is no room below
  - [ ] Repeat the steps above with the window at 1280x560 so the select sits near the bottom
  - [ ] Expect the options panel to open upward and to not overlap the select box at any point after it settles
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey or potentially flaky
- `tests/e2e/ui/tests/settings/routerSettings.spec.ts:254` - a request to a model whose upstream is dead is answered by its fallback
  - [ ] Point a deployment at an unreachable upstream, then POST /v1/chat/completions for it and expect 4xx
  - [ ] Send that same request five times about two seconds apart and expect every one of them to fail
  - [ ] Add a fallback for it through http://localhost:4000/ui/?page=settings, then POST the same request again
  - [ ] Expect a 200 within a minute, and expect the Playground to render a reply for that model
  - [ ] Note the stack serves this from more than one replica with a 7 second config reload, so one reply only tells you about the replica that answered; that is why the negative check samples across a reload cycle and the positive one does not
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey or potentially flaky
- `tests/e2e/quota_management/spend_tracking/test_cost_headers_e2e.py::TestCostHeaders::test_cost_headers_match_spend_log` - the cache-read cost header comes back with a real nonzero value
  - [ ] Register an openai/gpt-5.5 deployment with custom pricing and generate a key scoped to it
  - [ ] POST /v1/chat/completions with a long cacheable prefix and a `prompt_cache_key` you choose, to prime it
  - [ ] Wait about two seconds and POST the same prefix under the same `prompt_cache_key`
  - [ ] Expect `x-litellm-response-cost-cache-read` above zero, retrying the re-read up to three times before priming a fresh prefix
  - [ ] Needs OPENAI_API_KEY; OpenAI publishes a primed prefix asynchronously, so an immediate re-read can legitimately miss
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey or potentially flaky

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
