### PR TITLE
fix(tests): derive the no-cache-read-rate savings baseline from the model map

### DIFF
--- a/tests/test_litellm/proxy/spend_tracking/test_savings.py
+++ b/tests/test_litellm/proxy/spend_tracking/test_savings.py
@@ -6,6 +6,7 @@ import litellm
 from litellm.litellm_core_utils.llm_cost_calc.utils import generic_cost_per_token
 from litellm.proxy.spend_tracking.savings import (
     _baseline_usage,
+    _resolve_model,
     compute_autorouter_savings,
     compute_savings_spend,
     marks_gateway_injection,
@@ -754,24 +755,55 @@ def test_a_baseline_that_prices_caching_implicitly_still_pays_for_its_prompt():
     assert reported > 0, "routing a cold first turn onto a cheaper model is a saving, not a loss"
 
 
+def _priced_chat_model_without_cache_read_rate() -> tuple[str, str, str]:
+    """A chat model the bundled map prices per token for input and output but not for cache
+    reads, derived from the map itself: a hardcoded pick goes stale the moment the registry
+    prices that model's cache reads, which is exactly how this test's premise last broke.
+    Candidates go through the savings module's own resolver, so the pick is one the code
+    under test can actually price."""
+    for key in sorted(litellm.model_cost):
+        entry = litellm.model_cost[key]
+        provider = entry.get("litellm_provider")
+        if not isinstance(provider, str) or not key.startswith(f"{provider}/"):
+            continue
+        if entry.get("mode") != "chat" or entry.get("cache_read_input_token_cost") is not None:
+            continue
+        if not entry.get("input_cost_per_token") or not entry.get("output_cost_per_token"):
+            continue
+        if _resolve_model(key, None) is None:
+            continue
+        priced = compute_autorouter_savings(
+            baseline_model=key,
+            selected_model="claude-haiku-4-5",
+            selected_provider="anthropic",
+            usage=_usage(fresh=1_000, cached=0, written=0, out=100),
+            conversation_continuing=True,
+        )
+        if priced == 0.0:
+            continue
+        return key, key.removeprefix(f"{provider}/"), provider
+    raise AssertionError("the bundled map has no per-token chat model without a cache-read rate")
+
+
 def test_a_baseline_with_no_cache_read_rate_is_charged_its_input_rate():
     """The same hole on the other bucket. A baseline whose entry has no
     `cache_read_input_token_cost` reads for 0.0, so a continuing turn priced the whole
     prompt at nothing and every switch away from it reported a loss.
     """
+    baseline_key, baseline_name, baseline_provider = _priced_chat_model_without_cache_read_rate()
     continuing = _usage(fresh=0, cached=0, written=20_000, out=1_000)
     reported = compute_autorouter_savings(
-        baseline_model="xai/grok-4",
+        baseline_model=baseline_key,
         selected_model="claude-haiku-4-5",
         selected_provider="anthropic",
         usage=continuing,
         conversation_continuing=True,
     )
 
-    grok = litellm.get_model_info("grok-4", "xai")
-    assert grok.get("cache_read_input_token_cost") is None, "pick a baseline with no cache-read rate"
+    baseline = litellm.get_model_info(baseline_name, baseline_provider)
+    assert baseline.get("cache_read_input_token_cost") is None, "pick a baseline with no cache-read rate"
     haiku = litellm.get_model_info("claude-haiku-4-5", "anthropic")
-    baseline_pays_input = 20_000 * grok["input_cost_per_token"] + 1_000 * grok["output_cost_per_token"]
+    baseline_pays_input = 20_000 * baseline["input_cost_per_token"] + 1_000 * baseline["output_cost_per_token"]
     actually_paid = 20_000 * haiku["cache_creation_input_token_cost"] + 1_000 * haiku["output_cost_per_token"]
     assert reported == pytest.approx(baseline_pays_input - actually_paid)
 


### PR DESCRIPTION
## TLDR

Problem this solves:

- `test_savings.py` hardcodes `xai/grok-4` as a baseline with no cache-read rate
- The registry audit priced grok-4 cache reads, so the premise assert fails
- Every open PR's `proxy-infra / Run tests` job is red because of it

How it solves it:

- The baseline is now derived from the bundled model map at test time
- Candidates pass the savings module's own resolver and a priceability probe
- A future repricing of any one model can no longer invalidate the premise

## User Flow

Before: a contributor pushes an unrelated PR and CI fails on a savings test they never touched

1. They open any PR against litellm_internal_staging
2. The proxy-infra job fails with "AssertionError: pick a baseline with no cache-read rate"
3. They spend time proving the red is not theirs

After: the same PR runs the savings test green

1. They open the same PR
2. The savings test derives a currently rate-less baseline from the map and passes
3. Future map repricings shift which model gets picked instead of breaking the test

## Relevant issues

- Fixes the staging-wide `proxy-infra / Run tests` red introduced by the grok-4 cache-read repricing
- Test fixture now derives its baseline from the bundled map instead of hardcoding a model
- Candidates are screened through `_resolve_model` and a real pricing probe, so the pick is always priceable

## Linear ticket

Resolves LIT-6519

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Test-infra change, so the proof is the failing test on pristine staging and the same test passing with the fix, no proxy or provider call involved. Verified against both cost map sources: the network-fetched main map (`LITELLM_LOCAL_MODEL_COST_MAP=""`, what CI reads) and the bundled in-repo map (`LITELLM_LOCAL_MODEL_COST_MAP=True`); both now price grok-4 cache reads at 2e-07, so the old premise fails under either

### Before (d44d281d1d)

1. `pytest tests/test_litellm/proxy/spend_tracking/test_savings.py -q`
2. `FAILED ...::test_a_baseline_with_no_cache_read_rate_is_charged_its_input_rate - AssertionError: pick a baseline with no cache-read rate` (`assert 2e-07 is None` on grok-4's now-priced cache reads) under both map sources

### After (f62aa1b3a8)

1. Same command
2. `67 passed` under both map sources; the derivation currently picks `azure/computer-use-preview` and will move on its own when that entry gains a cache-read rate

## Type

✅ Test

## Caveats (if any)

### Low

- The derived pick is deterministic per map snapshot (sorted first match) but changes across map updates by design

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

- [x] f62aa1b3a82eef2213e742f750a486ca0daae0e0 passes /live-pr-risk
