### PR TITLE
fix(websearch): recognize conventional function tool name

### DIFF
--- a/litellm/integrations/websearch_interception/tools.py
+++ b/litellm/integrations/websearch_interception/tools.py
@@ -156,12 +156,12 @@ def is_web_search_tool_chat_completion(tool: dict[str, Any]) -> bool:
     """
     Check if a tool is a web search tool for Chat Completions API (strict check).
 
-    This is a stricter version that ONLY checks for the exact LiteLLM web search tool name.
+    This is a stricter version that checks the recognized web search tool names.
     Use this for Chat Completions API to avoid false positives with user-defined tools.
 
     Detects ONLY:
     - LiteLLM standard: name == "litellm_web_search" (Anthropic format)
-    - OpenAI format: type == "function" with function.name == "litellm_web_search"
+    - OpenAI format: type == "function" with function.name == "litellm_web_search" or "web_search"
 
     Args:
         tool: Tool dictionary to check
@@ -186,7 +186,7 @@ def is_web_search_tool_chat_completion(tool: dict[str, Any]) -> bool:
     if tool_type == "function" and "function" in tool:
         function_def: Final = tool.get("function", {})
         function_name: Final = function_def.get("name", "")
-        if function_name == LITELLM_WEB_SEARCH_TOOL_NAME:
+        if function_name in (LITELLM_WEB_SEARCH_TOOL_NAME, "web_search"):
             return True
 
     # Check for LiteLLM standard tool (Anthropic format)
@@ -270,7 +270,7 @@ def is_web_search_tool(tool: dict[str, Any]) -> bool:
     if tool_type == "function" and "function" in tool:
         function_def: Final = tool.get("function", {})
         function_name: Final = function_def.get("name", "")
-        if function_name == LITELLM_WEB_SEARCH_TOOL_NAME:
+        if function_name in (LITELLM_WEB_SEARCH_TOOL_NAME, "web_search"):
             return True
 
     # Check for LiteLLM standard tool (Anthropic format)

--- a/litellm/integrations/websearch_interception/tools.py
+++ b/litellm/integrations/websearch_interception/tools.py
@@ -195,7 +195,7 @@ def is_web_search_tool_chat_completion(tool: dict[str, Any]) -> bool:
         # The conventional name is only recognized for the name-only shape.
         # A user-defined function may also be named ``web_search``; preserving
         # any additional definition fields lets that tool pass through intact.
-        if function_name == "web_search" and set(function_def) == {"name"}:
+        if function_name == "web_search" and len(function_def) == 1 and "name" in function_def:
             return True
 
     # Check for LiteLLM standard tool (Anthropic format)
@@ -285,7 +285,7 @@ def is_web_search_tool(tool: dict[str, Any]) -> bool:
             return True
         # Do not hijack a user-defined function that happens to use the
         # conventional name and carries its own schema or description.
-        if function_name == "web_search" and set(function_def) == {"name"}:
+        if function_name == "web_search" and len(function_def) == 1 and "name" in function_def:
             return True
 
     # Check for LiteLLM standard tool (Anthropic format)

--- a/litellm/integrations/websearch_interception/tools.py
+++ b/litellm/integrations/websearch_interception/tools.py
@@ -161,7 +161,9 @@ def is_web_search_tool_chat_completion(tool: dict[str, Any]) -> bool:
 
     Detects ONLY:
     - LiteLLM standard: name == "litellm_web_search" (Anthropic format)
-    - OpenAI format: type == "function" with function.name == "litellm_web_search" or "web_search"
+    - OpenAI format: type == "function" with function.name == "litellm_web_search"
+      or a bare function definition whose name is "web_search"
+      or a bare function definition whose name is "web_search"
 
     Args:
         tool: Tool dictionary to check
@@ -185,8 +187,15 @@ def is_web_search_tool_chat_completion(tool: dict[str, Any]) -> bool:
     # Check for OpenAI format: {"type": "function", "function": {"name": "litellm_web_search"}}
     if tool_type == "function" and "function" in tool:
         function_def: Final = tool.get("function", {})
+        if not isinstance(function_def, dict):
+            return False
         function_name: Final = function_def.get("name", "")
-        if function_name in (LITELLM_WEB_SEARCH_TOOL_NAME, "web_search"):
+        if function_name == LITELLM_WEB_SEARCH_TOOL_NAME:
+            return True
+        # The conventional name is only recognized for the name-only shape.
+        # A user-defined function may also be named ``web_search``; preserving
+        # any additional definition fields lets that tool pass through intact.
+        if function_name == "web_search" and set(function_def) == {"name"}:
             return True
 
     # Check for LiteLLM standard tool (Anthropic format)
@@ -269,8 +278,14 @@ def is_web_search_tool(tool: dict[str, Any]) -> bool:
     # Check for OpenAI format: {"type": "function", "function": {"name": "..."}}
     if tool_type == "function" and "function" in tool:
         function_def: Final = tool.get("function", {})
+        if not isinstance(function_def, dict):
+            return False
         function_name: Final = function_def.get("name", "")
-        if function_name in (LITELLM_WEB_SEARCH_TOOL_NAME, "web_search"):
+        if function_name == LITELLM_WEB_SEARCH_TOOL_NAME:
+            return True
+        # Do not hijack a user-defined function that happens to use the
+        # conventional name and carries its own schema or description.
+        if function_name == "web_search" and set(function_def) == {"name"}:
             return True
 
     # Check for LiteLLM standard tool (Anthropic format)

--- a/tests/test_litellm/integrations/websearch_interception/test_websearch_tools.py
+++ b/tests/test_litellm/integrations/websearch_interception/test_websearch_tools.py
@@ -28,6 +28,7 @@ def test_openai_function_web_search_shapes_are_detected(tool: dict[str, Any]):
     [
         {"type": "function", "function": {"name": "web_search_helper"}},
         {"type": "function", "function": {"name": "search"}},
+        {"type": "function", "function": None},
     ],
 )
 def test_unrelated_openai_function_tools_are_not_detected(tool: dict[str, Any]):

--- a/tests/test_litellm/integrations/websearch_interception/test_websearch_tools.py
+++ b/tests/test_litellm/integrations/websearch_interception/test_websearch_tools.py
@@ -1,5 +1,7 @@
 """Unit tests for web search tool shape detection."""
 
+from typing import Any
+
 import pytest
 
 from litellm.integrations.websearch_interception.tools import (
@@ -15,7 +17,7 @@ from litellm.integrations.websearch_interception.tools import (
         {"type": "function", "function": {"name": "web_search"}},
     ],
 )
-def test_openai_function_web_search_shapes_are_detected(tool):
+def test_openai_function_web_search_shapes_are_detected(tool: dict[str, Any]):
     """Recognize both LiteLLM and conventional web_search function names."""
     assert is_web_search_tool(tool) is True
     assert is_web_search_tool_chat_completion(tool) is True
@@ -28,7 +30,26 @@ def test_openai_function_web_search_shapes_are_detected(tool):
         {"type": "function", "function": {"name": "search"}},
     ],
 )
-def test_unrelated_openai_function_tools_are_not_detected(tool):
+def test_unrelated_openai_function_tools_are_not_detected(tool: dict[str, Any]):
     """Do not classify similarly named user tools as web search."""
+    assert is_web_search_tool(tool) is False
+    assert is_web_search_tool_chat_completion(tool) is False
+
+
+@pytest.mark.parametrize(
+    "tool",
+    [
+        {
+            "type": "function",
+            "function": {
+                "name": "web_search",
+                "description": "Search a private index",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        },
+    ],
+)
+def test_user_defined_web_search_functions_are_not_detected(tool: dict[str, Any]):
+    """Preserve user-defined schemas even when their name is web_search."""
     assert is_web_search_tool(tool) is False
     assert is_web_search_tool_chat_completion(tool) is False

--- a/tests/test_litellm/integrations/websearch_interception/test_websearch_tools.py
+++ b/tests/test_litellm/integrations/websearch_interception/test_websearch_tools.py
@@ -1,0 +1,34 @@
+"""Unit tests for web search tool shape detection."""
+
+import pytest
+
+from litellm.integrations.websearch_interception.tools import (
+    is_web_search_tool,
+    is_web_search_tool_chat_completion,
+)
+
+
+@pytest.mark.parametrize(
+    "tool",
+    [
+        {"type": "function", "function": {"name": "litellm_web_search"}},
+        {"type": "function", "function": {"name": "web_search"}},
+    ],
+)
+def test_openai_function_web_search_shapes_are_detected(tool):
+    """Recognize both LiteLLM and conventional web_search function names."""
+    assert is_web_search_tool(tool) is True
+    assert is_web_search_tool_chat_completion(tool) is True
+
+
+@pytest.mark.parametrize(
+    "tool",
+    [
+        {"type": "function", "function": {"name": "web_search_helper"}},
+        {"type": "function", "function": {"name": "search"}},
+    ],
+)
+def test_unrelated_openai_function_tools_are_not_detected(tool):
+    """Do not classify similarly named user tools as web search."""
+    assert is_web_search_tool(tool) is False
+    assert is_web_search_tool_chat_completion(tool) is False


### PR DESCRIPTION
## TLDR

Problem this solves:

- Chat Completions clients using `function.name="web_search"` are not intercepted.
- The request falls through to provider mapping and can fail with a missing-name error.

How it solves it:

- Recognize the conventional `web_search` function name in both web-search detectors.
- Keep unrelated function tools excluded and add focused regression coverage.

## User Flow

Before: a client using the conventional web-search function shape cannot reach web-search interception.

1. The client sends `POST /v1/chat/completions` with a function tool whose name is `web_search`.
2. The gateway does not recognize that tool as web search.
3. The request reaches provider tool mapping and may fail with `Missing required parameter: name`.

After: the same request is recognized as a web-search request.

1. The client sends the same `POST /v1/chat/completions` request with the `web_search` function tool.
2. The gateway recognizes the function envelope and routes it through web-search interception.
3. Unrelated function tools continue through the normal provider mapping path.

## Relevant issues

Fixes #38831

## Pre-Submission checklist

- [x] I have added meaningful tests
- [ ] The focused pytest file passes locally (the local editable build is blocked by the machine's Rust/cache permissions)
- [ ] My PR passes all required CI/CD checks
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile Confidence Score of at least 4/5

## Type

🐛 Bug Fix
✅ Test

## Caveats (if any)

The conventional name is matched only when it appears in the OpenAI function-tool envelope; unrelated tool names remain unchanged.
