### PR TITLE
fix(proxy): treat explicit zero cache rates as configured prices in savings baseline

### DIFF
--- a/litellm/proxy/spend_tracking/savings.py
+++ b/litellm/proxy/spend_tracking/savings.py
@@ -236,11 +236,16 @@ def _baseline_cache_rate_keys(baseline_info: ModelInfo | None) -> tuple[bool, bo
     Gemini entry for cache writes, would carry the whole prompt for nothing and turn a
     profitable route into a reported loss. Such a model pays its plain input rate for
     those tokens, so the buckets it cannot price become ordinary input below.
+
+    Presence is `is not None`, not truthiness: a configured `0.0` is a real price the
+    operator set, reads that genuinely cost nothing, and must stay in the cache bucket
+    priced at zero instead of being moved to ordinary input.
     """
     if baseline_info is None:
         return True, True
-    return bool(baseline_info.get("cache_read_input_token_cost")), bool(
-        baseline_info.get("cache_creation_input_token_cost")
+    return (
+        baseline_info.get("cache_read_input_token_cost") is not None,
+        baseline_info.get("cache_creation_input_token_cost") is not None,
     )
 
 

--- a/tests/test_litellm/proxy/spend_tracking/test_savings.py
+++ b/tests/test_litellm/proxy/spend_tracking/test_savings.py
@@ -455,6 +455,61 @@ def test_moving_one_token_between_cache_buckets_does_not_move_the_answer():
     assert reads_one == pytest.approx(reads_nothing, abs=1e-4)
 
 
+def test_an_explicit_zero_cache_read_rate_is_a_price_not_a_gap():
+    """A baseline deployment configured with `cache_read_input_token_cost: 0.0` has
+    reads that genuinely cost nothing. Truthiness read that configured price as a
+    missing rate, moved the cached tokens into ordinary input and charged them at the
+    full input rate, overstating savings on every continuing conversation.
+    """
+    sonnet = litellm.get_model_info("claude-sonnet-5", "anthropic")
+    free_reads = dict(sonnet)
+    free_reads["cache_read_input_token_cost"] = 0.0
+
+    usage = _usage(fresh=0, cached=20_000, written=0, out=1_000)
+    result = compute_autorouter_savings(
+        baseline_model="claude-sonnet-5",
+        selected_model="claude-haiku-4-5",
+        selected_provider="anthropic",
+        usage=usage,
+        conversation_continuing=True,
+        baseline_info=free_reads,
+    )
+
+    haiku = litellm.get_model_info("claude-haiku-4-5", "anthropic")
+    paid = 20_000 * haiku["cache_read_input_token_cost"] + 1_000 * haiku["output_cost_per_token"]
+    reads_free = 1_000 * sonnet["output_cost_per_token"] - paid
+    reads_at_input = 20_000 * sonnet["input_cost_per_token"] + 1_000 * sonnet["output_cost_per_token"] - paid
+    assert result == pytest.approx(reads_free), "a configured $0 read rate must price reads at $0"
+    assert result != pytest.approx(reads_at_input), "reads must not fall back to the input rate"
+
+
+def test_an_explicit_zero_cache_creation_rate_is_a_price_not_a_gap():
+    """The same hole on the write bucket. A first turn against a baseline configured
+    with `cache_creation_input_token_cost: 0.0` writes for nothing; truthiness read
+    the configured price as missing and charged the write at the input rate.
+    """
+    sonnet = litellm.get_model_info("claude-sonnet-5", "anthropic")
+    free_writes = dict(sonnet)
+    free_writes["cache_creation_input_token_cost"] = 0.0
+
+    usage = _usage(fresh=0, cached=0, written=20_000, out=1_000)
+    result = compute_autorouter_savings(
+        baseline_model="claude-sonnet-5",
+        selected_model="claude-haiku-4-5",
+        selected_provider="anthropic",
+        usage=usage,
+        conversation_continuing=False,
+        baseline_info=free_writes,
+    )
+
+    haiku = litellm.get_model_info("claude-haiku-4-5", "anthropic")
+    paid = 20_000 * haiku["cache_creation_input_token_cost"] + 1_000 * haiku["output_cost_per_token"]
+    writes_free = 1_000 * sonnet["output_cost_per_token"] - paid
+    writes_at_input = 20_000 * sonnet["input_cost_per_token"] + 1_000 * sonnet["output_cost_per_token"] - paid
+    assert result == pytest.approx(writes_free), "a configured $0 write rate must price writes at $0"
+    assert result != pytest.approx(writes_at_input), "writes must not fall back to the input rate"
+
+
 def test_multimodal_prompts_are_priced_on_the_baseline_too():
     """The baseline is this same request met by a warm cache, so every field it was
     priced on has to survive. Rebuilding the details from the cache buckets alone


### PR DESCRIPTION
## TLDR

Problem this solves:

- A baseline configured with `cache_read_input_token_cost: 0.0` had its cached tokens charged at the full input rate
- Savings on continuing conversations were overstated by the whole cache-read charge

How it solves it:

- `_baseline_cache_rate_keys` now tests rate presence with `is not None` instead of `bool()`
- A configured `0.0` stays in its cache bucket priced at zero; an absent rate still falls back to ordinary input

## User Flow

Before: an operator with free cache reads sees savings overstated because the baseline arm is charged the full input rate for cached tokens

1. The operator configures a cache-capable baseline deployment with `cache_read_input_token_cost: 0.0`
2. A developer sends `POST https://litellm-domain/v1/chat/completions` for a continuing cached conversation and receives `200 OK`
3. The operator opens `https://litellm-domain/ui/?page=cost-optimization` and the cached prompt on the baseline arm is priced at the ordinary input rate, overstating savings

After: the same cached prompt is priced at the configured free read rate

1. The operator configures the same cache-capable baseline deployment with `cache_read_input_token_cost: 0.0`
2. A developer sends the same `POST https://litellm-domain/v1/chat/completions` for a continuing cached conversation and receives `200 OK`
3. The operator opens `https://litellm-domain/ui/?page=cost-optimization` and the baseline arm's cached prompt is priced at `$0.00`

## Relevant issues

Fixes #38815

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Setup (shared by Before and After): a checkout of this repository, Python 3.11, no provider credentials needed — the script prices a recorded usage object through the public savings entry point with a baseline whose `cache_read_input_token_cost` is explicitly `0.0`:

```python
import litellm
from litellm.proxy.spend_tracking.savings import compute_autorouter_savings
from litellm.types.utils import Usage

sonnet = litellm.get_model_info("claude-sonnet-5", "anthropic")
free_reads = dict(sonnet)
free_reads["cache_read_input_token_cost"] = 0.0

usage = Usage(
    prompt_tokens=20_000,
    completion_tokens=1_000,
    total_tokens=21_000,
    prompt_tokens_details={"cached_tokens": 20_000, "cache_creation_tokens": 0, "text_tokens": 0},
)
savings = compute_autorouter_savings(
    baseline_model="claude-sonnet-5",
    selected_model="claude-haiku-4-5",
    selected_provider="anthropic",
    usage=usage,
    conversation_continuing=True,
    baseline_info=free_reads,
)
haiku = litellm.get_model_info("claude-haiku-4-5", "anthropic")
paid = 20_000 * haiku["cache_read_input_token_cost"] + 1_000 * haiku["output_cost_per_token"]
print(f"reported savings = {savings:.6f}")
print(f"expected savings = {1_000 * sonnet['output_cost_per_token'] - paid:.6f}")
print(f"baseline cache-read charge = {savings + paid - 1_000 * sonnet['output_cost_per_token']:.6f} (expected 0.000000)")
```

### Before (5e4b3838aa — litellm_internal_staging)

1. `python proof_38815.py` on clean `main` at `d44d281`
2. Observed:
   ```
   reported savings = 0.043000
   expected savings = 0.003000
   baseline cache-read charge = 0.040000 (expected 0.000000)
   ```
3. The baseline arm charged $0.04 for 20k tokens the operator configured as free reads

### After (ecc71c863f)

1. `python proof_38815.py` at the PR tip `6d22049`
2. Observed:
   ```
   reported savings = 0.003000
   expected savings = 0.003000
   baseline cache-read charge = 0.000000 (expected 0.000000)
   ```
3. The baseline arm charges $0.00 for the free reads and reported savings matches the hand-computed expectation

Tests: `tests/test_litellm/proxy/spend_tracking/test_savings.py` — 68 passed. The two new regression tests (`test_an_explicit_zero_cache_read_rate_is_a_price_not_a_gap`, `test_an_explicit_zero_cache_creation_rate_is_a_price_not_a_gap`) fail at the merge base and pass at the PR tip. `tests/test_litellm/router_strategy/test_savings_baseline.py` and `tests/test_litellm/proxy/spend_tracking/test_compression_savings.py`: 52 passed.

Note: `test_a_baseline_with_no_cache_read_rate_is_charged_its_input_rate` fails at the merge base already (it asserts `xai/grok-4` has no `cache_read_input_token_cost`, but the pricing data on `main` now carries `2e-07`), so that failure is pre-existing and unrelated to this change.

## Type

🐛 Bug Fix

## Caveats (if any)

### Low

- Only the savings baseline arm is affected; per-request billing always priced explicit zero rates correctly
- The other direction (an absent rate still falling back to ordinary input) is unchanged and covered by existing tests

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

