### PR TITLE
feat(model_prices): add zai/glm-5.2 vendor entry

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -44879,6 +44879,21 @@
         "source": "https://docs.z.ai/guides/overview/pricing",
         "supports_vision": true
     },
+    "zai/glm-5.2": {
+        "cache_creation_input_token_cost": 0,
+        "cache_read_input_token_cost": 2.6e-07,
+        "input_cost_per_token": 1.4e-06,
+        "litellm_provider": "zai",
+        "max_input_tokens": 1000000,
+        "max_output_tokens": 128000,
+        "mode": "chat",
+        "output_cost_per_token": 4.4e-06,
+        "source": "https://docs.z.ai/guides/overview/pricing",
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true
+    },
     "zai/glm-5.1": {
         "cache_creation_input_token_cost": 0,
         "cache_read_input_token_cost": 2.6e-07,

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -44879,6 +44879,21 @@
         "source": "https://docs.z.ai/guides/overview/pricing",
         "supports_vision": true
     },
+    "zai/glm-5.2": {
+        "cache_creation_input_token_cost": 0,
+        "cache_read_input_token_cost": 2.6e-07,
+        "input_cost_per_token": 1.4e-06,
+        "litellm_provider": "zai",
+        "max_input_tokens": 1000000,
+        "max_output_tokens": 128000,
+        "mode": "chat",
+        "output_cost_per_token": 4.4e-06,
+        "source": "https://docs.z.ai/guides/overview/pricing",
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true
+    },
     "zai/glm-5.1": {
         "cache_creation_input_token_cost": 0,
         "cache_read_input_token_cost": 2.6e-07,


### PR DESCRIPTION
## Summary

Adds the official Z.AI vendor entry `zai/glm-5.2` to `model_prices_and_context_window.json` and `litellm/model_prices_and_context_window_backup.json`.

The registry currently covers GLM-5.2 only through third-party deployments (`dashscope/glm-5.2`, `together_ai/zai-org/GLM-5.2`, `deepinfra/zai-org/glm-5.2`, `cloudflare/@cf/zai-org/glm-5.2`, `novita/zai-org/glm-5.2`, ...). The two-segment `zai/` vendor entry is missing, so `zai/glm-5.2` resolves without pricing/context metadata.

## Values (per official docs)

| Field | Value | Source |
| --- | --- | --- |
| `input_cost_per_token` | `1.4e-06` ($1.4/M) | pricing page, GLM-5.2 row |
| `cache_read_input_token_cost` | `2.6e-07` ($0.26/M) | pricing page, "Cached Input" |
| `cache_creation_input_token_cost` | `0` | "Cached Input Storage: Limited-time Free" |
| `output_cost_per_token` | `4.4e-06` ($4.4/M) | pricing page, GLM-5.2 row |
| `max_input_tokens` | `1000000` | model page, "Context Length: 1M" |
| `max_output_tokens` | `128000` | model page, "Maximum Output Tokens: 128K" |
| capability flags | function calling / prompt caching / reasoning / tool choice = `true` | model page capability cards |

Sources:
- https://docs.z.ai/guides/llm/glm-5.2
- https://docs.z.ai/guides/overview/pricing

The entry mirrors sibling `zai/glm-5.3` field-for-field: on the official pricing page GLM-5.2 and GLM-5.3 sit in the same row group ($1.4 / $0.26 / $4.4), and the model pages document the same 1M / 128K limits and the same capability set (text-only input/output, so no `supports_vision`, consistent with the sibling).

## Tests

- [x] Both JSONs parse after the change
- [x] New blocks in the two files are byte-identical; `git diff` shows only the two +15-line additions
- [x] No duplicate `zai/glm-5.2` key; no other registry entries touched