### PR TITLE
fix(bedrock): forward freeform tools as parameterless toolSpecs, dropping the custom field

### DIFF
--- a/litellm/litellm_core_utils/prompt_templates/factory.py
+++ b/litellm/litellm_core_utils/prompt_templates/factory.py
@@ -5080,7 +5080,10 @@ def _bedrock_tools_pt(tools: list, model: str | None = None) -> list[BedrockTool
             freeform_name = tool.get("name")
             if not (isinstance(freeform_name, str) and freeform_name.strip()):
                 continue
-            parameters = {"type": "object", "properties": {}}
+            parameters = {  # mutable-ok: Bedrock toolSpec input schemas are plain JSON dicts
+                "type": "object",
+                "properties": {},  # mutable-ok: empty JSON schema object, consumed by the request builder
+            }
             raw_name = freeform_name
             _tool_description = tool.get("description", None)
         elif isinstance(tool, dict) and "function" not in tool and "input_schema" not in tool:

--- a/litellm/litellm_core_utils/prompt_templates/factory.py
+++ b/litellm/litellm_core_utils/prompt_templates/factory.py
@@ -5064,14 +5064,29 @@ def _bedrock_tools_pt(tools: list, model: str | None = None) -> list[BedrockTool
             tool_block_list.append(tool)
             continue
 
-        # Responses built-in tools (web_search, image_generation, namespace, tool_search,
-        # custom) carry neither an OpenAI "function" nor an Anthropic "input_schema" and have
-        # no Bedrock toolSpec equivalent; drop them instead of emitting an empty junk toolSpec.
-        if isinstance(tool, dict) and "function" not in tool and "input_schema" not in tool:
+        # OpenAI Agents SDK freeform tools ({"type": "custom", "name": ...,
+        # "description": ..., "custom": {...}}) carry a top-level name and no
+        # function payload; forward them as parameterless toolSpecs, dropping
+        # provider-specific extras like `custom`, which Bedrock rejects (#38799).
+        # Other named-but-builtin tools (e.g. namespace) and nameless Responses
+        # built-ins (web_search, image_generation, ...) have no Bedrock toolSpec
+        # equivalent and are still dropped below.
+        if (
+            isinstance(tool, dict)
+            and "function" not in tool
+            and "input_schema" not in tool
+            and tool.get("type") == "custom"
+        ):
+            freeform_name = tool.get("name")
+            if not (isinstance(freeform_name, str) and freeform_name.strip()):
+                continue
+            parameters = {"type": "object", "properties": {}}
+            raw_name = freeform_name
+            _tool_description = tool.get("description", None)
+        elif isinstance(tool, dict) and "function" not in tool and "input_schema" not in tool:
             continue
-
         # OpenAI function tools, or Anthropic Messages / Claude Code ({name, input_schema, type, ...})
-        if isinstance(tool, dict) and "input_schema" in tool and "function" not in tool:
+        elif isinstance(tool, dict) and "input_schema" in tool and "function" not in tool:
             parameters = copy.deepcopy(tool.get("input_schema") or {"type": "object", "properties": {}})
             raw_name = tool.get("name", "") or ""
             _tool_description = tool.get("description", None)

--- a/tests/test_litellm/litellm_core_utils/prompt_templates/test_litellm_core_utils_prompt_templates_factory.py
+++ b/tests/test_litellm/litellm_core_utils/prompt_templates/test_litellm_core_utils_prompt_templates_factory.py
@@ -1057,11 +1057,13 @@ def test_bedrock_tools_pt_forwards_freeform_tool_without_custom_field():
 
 def test_bedrock_tools_pt_still_drops_unnamed_builtin_tools():
     """Responses built-in tools (web_search, image_generation, ...) have no top-level
-    name and no Bedrock toolSpec equivalent; they must stay dropped.
+    name and no Bedrock toolSpec equivalent; they must stay dropped. A `custom`-typed
+    tool without a name is equally unmappable — only a named one is forwarded.
     """
     tools = [
         {"type": "web_search_preview"},
         {"type": "image_generation"},
+        {"type": "custom"},
     ]
     assert _bedrock_tools_pt(tools, model="us.anthropic.claude-sonnet-5") == []
 

--- a/tests/test_litellm/litellm_core_utils/prompt_templates/test_litellm_core_utils_prompt_templates_factory.py
+++ b/tests/test_litellm/litellm_core_utils/prompt_templates/test_litellm_core_utils_prompt_templates_factory.py
@@ -1030,6 +1030,42 @@ def test_bedrock_tools_pt_strict_parameter():
     assert "additionalProperties" not in result[0]["toolSpec"]["inputSchema"]["json"]
 
 
+def test_bedrock_tools_pt_forwards_freeform_tool_without_custom_field():
+    """OpenAI Agents SDK freeform tools carry a top-level name and a provider-specific
+    `custom` dict instead of a function payload. Bedrock rejects the `custom` key
+    outright (400 "tools.0.custom.strict: Extra inputs are not permitted"), so the
+    tool must be forwarded as a parameterless toolSpec with the extras stripped
+    rather than dropped or passed through.
+    """
+    tools = [
+        {
+            "type": "custom",
+            "name": "apply_patch",
+            "description": "Apply a unified diff patch to the workspace.",
+            "custom": {"strict": None},
+        }
+    ]
+    result = _bedrock_tools_pt(tools, model="us.anthropic.claude-sonnet-5")
+    assert len(result) == 1, "the freeform tool must not be dropped"
+    tool_spec = result[0]["toolSpec"]
+    assert tool_spec["name"] == "apply_patch"
+    assert tool_spec["description"] == "Apply a unified diff patch to the workspace."
+    assert tool_spec["inputSchema"]["json"] == {"type": "object", "properties": {}, "required": []}
+    assert "custom" not in tool_spec
+    assert "strict" not in tool_spec
+
+
+def test_bedrock_tools_pt_still_drops_unnamed_builtin_tools():
+    """Responses built-in tools (web_search, image_generation, ...) have no top-level
+    name and no Bedrock toolSpec equivalent; they must stay dropped.
+    """
+    tools = [
+        {"type": "web_search_preview"},
+        {"type": "image_generation"},
+    ]
+    assert _bedrock_tools_pt(tools, model="us.anthropic.claude-sonnet-5") == []
+
+
 def test_bedrock_image_processor_content_type_fallback_url_extension():
     """
     Test that _post_call_image_processing falls back to URL extension
@@ -1632,9 +1668,13 @@ def test_bedrock_tools_pt_does_not_handle_system_tool():
 def test_bedrock_tools_pt_drops_unmappable_responses_builtin_tools():
     """
     Regression for LIT-3858: Responses built-in tools (image_generation, namespace,
-    tool_search, custom) have no Bedrock toolSpec equivalent. They must be dropped, not
+    tool_search) have no Bedrock toolSpec equivalent. They must be dropped, not
     emitted as junk ``litellm_unnamed_tool_N`` toolSpecs the model can hallucinate calls to.
     Mappable ``function`` and Anthropic ``input_schema`` tools must survive untouched.
+
+    Named ``custom`` tools (freeform tools, e.g. the OpenAI Agents SDK's apply_patch)
+    ARE mappable — a parameterless toolSpec — and are forwarded since #38799; only
+    nameless built-ins stay dropped.
     """
     from litellm.litellm_core_utils.prompt_templates.factory import _bedrock_tools_pt
 
@@ -1657,7 +1697,7 @@ def test_bedrock_tools_pt_drops_unmappable_responses_builtin_tools():
     )
 
     names = [block["toolSpec"]["name"] for block in result if "toolSpec" in block]
-    assert names == ["noop"]
+    assert names == ["noop", "free_form"], "named built-ins like namespace must stay dropped"
     assert not any(name.startswith("litellm_unnamed_tool_") for name in names)
 
 


### PR DESCRIPTION
## TLDR

Problem this solves:

- OpenAI Agents SDK freeform tools (`{"type": "custom", "name": ..., "custom": {...}}`) failed against Bedrock Converse
- On v1.90.1 the `custom` key reached Bedrock → 400 `tools.0.custom.strict: Extra inputs are not permitted`; on current main the tool is silently dropped, so the model never sees it

How it solves it:

- `_bedrock_tools_pt` forwards a named `type: "custom"` tool as a parameterless `toolSpec`, stripping provider-specific extras like `custom`
- Nameless built-ins (web_search, image_generation) and other named built-ins (namespace, tool_search) are still dropped

## User Flow

Before: an agent run against Bedrock with a freeform tool either crashes or silently loses the tool

1. The developer configures their agent (OpenAI Agents SDK LiteLLM wrapper) with model `bedrock/us.anthropic.claude-sonnet-5` and a custom freeform tool (`apply_patch`)
2. They run the agent; the chat request carries a tool entry with a top-level `custom: {"strict": null}` field
3. On v1.90.1 the call fails immediately with `BedrockException - tools.0.custom.strict: Extra inputs are not permitted`; on current `main` the tool is dropped and the model answers without ever being able to call `apply_patch`

After: the same agent run streams back a normal response and the model can call the tool

1. Same setup: model `bedrock/us.anthropic.claude-sonnet-5`, same `apply_patch` freeform tool
2. They run the agent; the identical request is sent
3. The tool list sent to Bedrock Converse now contains `{"toolSpec": {"name": "apply_patch", "description": "...", "inputSchema": {"json": {"type": "object", "properties": {}, "required": []}}}}` with no `custom` key
4. The request succeeds; the model can emit an `apply_patch` tool call

## Relevant issues

Fixes #38799

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally. Leave the suites to CI
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

Setup (shared by Before and After): checkout of this repository, Python 3.11, no AWS credentials — this exercises the request-transformation function the Bedrock Converse path calls with the exact tool list from the issue, so it shows what would be sent over the wire:

```python
import json
from litellm.litellm_core_utils.prompt_templates.factory import _bedrock_tools_pt

tools = [
    {"type": "custom", "name": "apply_patch", "description": "Apply a unified diff patch to the workspace.", "custom": {"strict": None}},
    {"type": "web_search_preview"},
    {"type": "namespace", "name": "grp", "description": "g", "tools": []},
]
print(json.dumps(_bedrock_tools_pt(tools, model="us.anthropic.claude-sonnet-5"), indent=1))
```

### Before (5e4b3838aa — litellm_internal_staging)

1. `python proof_38799.py` on clean `main`
2. Observed: `[]` — `tool names sent to Bedrock: []`
3. The freeform tool is silently dropped; the model never sees `apply_patch` (on v1.90.1 the same input produced the 400 from the issue instead)

### After (37ee0468fe — PR tip)

1. `python proof_38799.py` at the PR tip
2. Observed:
   ```json
   [{"toolSpec": {"inputSchema": {"json": {"type": "object", "properties": {}, "required": []}}, "name": "apply_patch", "description": "Apply a unified diff patch to the workspace."}}]
   ```
   `tool names sent to Bedrock: ['apply_patch']`
3. The tool is forwarded as a parameterless toolSpec, `custom` is stripped, and the nameless/other built-ins (`web_search_preview`, `namespace`) stay dropped

A full e2e run against real Bedrock needs AWS credentials I don't have; the transformation-level proof above is the exact payload that would be sent.

Tests: `tests/test_litellm/litellm_core_utils/prompt_templates/test_litellm_core_utils_prompt_templates_factory.py` — 102 passed (2 new regression tests fail at the merge base and pass at the tip). Related suites: `tests/llm_translation/test_prompt_factory.py` + `test_bedrock_converse_strict_tools_opus_47_48.py` — 125 passed, 1 pre-existing failure (`test_alternating_roles_e2e`, fails on clean checkout); `tests/test_litellm/responses/litellm_completion_transformation/test_litellm_completion_responses.py` — 130 passed.

## Type

🐛 Bug Fix

## Caveats (if any)

### Medium

- Deliberately changes behavior asserted by the LIT-3858 regression test: a **named** `type: "custom"` tool was dropped as "unmappable" and is now forwarded. I updated that test accordingly — its original concern (junk `litellm_unnamed_tool_N` toolSpecs) only applies to nameless tools, which are still dropped. Maintainers, please veto if the drop was intentional for the Responses path

### Low

- A model calling the freeform tool gets a regular Bedrock toolUse (freeform text as input), not an OpenAI-style `custom_tool_call`; callers inspecting call shapes may notice

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

