### PR TITLE
fix(ui): hide model write affordances from view-only admin sessions

### DIFF
--- a/ui/litellm-dashboard/src/app/(dashboard)/models-and-endpoints/components/AutoRouters/AutoRoutersPanel.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/models-and-endpoints/components/AutoRouters/AutoRoutersPanel.test.tsx
@@ -140,6 +140,7 @@ const renderPanel = (canModify = true) =>
       accessToken="token"
       userRole="Admin"
       userID="u-admin"
+      isViewOnly={false}
       teams={null}
       createScope={canModify ? "unscoped-ok" : "forbidden"}
     />,

--- a/ui/litellm-dashboard/src/app/(dashboard)/models-and-endpoints/components/AutoRouters/AutoRoutersPanel.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/models-and-endpoints/components/AutoRouters/AutoRoutersPanel.tsx
@@ -21,12 +21,20 @@ interface AutoRoutersPanelProps {
   accessToken: string;
   userRole: string;
   userID: string | null;
+  isViewOnly: boolean;
   teams: Team[] | null;
   /** Owned by the page, which knows how this caller must scope what they create. */
   createScope: ModelWriteScope;
 }
 
-export function AutoRoutersPanel({ accessToken, userRole, userID, teams, createScope }: AutoRoutersPanelProps) {
+export function AutoRoutersPanel({
+  accessToken,
+  userRole,
+  userID,
+  isViewOnly,
+  teams,
+  createScope,
+}: AutoRoutersPanelProps) {
   const canCreate = createScope !== "forbidden";
   const { data: deployments, isLoading } = useAutoRouters();
   const invalidateAutoRouters = useInvalidateAutoRouters();
@@ -39,8 +47,8 @@ export function AutoRoutersPanel({ accessToken, userRole, userID, teams, createS
   const [isDeleting, setIsDeleting] = useState(false);
 
   const routers = useMemo(
-    () => toAutoRouterRows(deployments ?? [], { userRole, userID }, teams),
-    [deployments, userRole, userID, teams],
+    () => toAutoRouterRows(deployments ?? [], { userRole, userID, isViewOnly }, teams),
+    [deployments, userRole, userID, isViewOnly, teams],
   );
 
   const handleCreated = () => {

--- a/ui/litellm-dashboard/src/app/(dashboard)/models-and-endpoints/components/AutoRouters/autoRouterRows.test.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/models-and-endpoints/components/AutoRouters/autoRouterRows.test.ts
@@ -5,8 +5,9 @@ import { toAutoRouterRow, toAutoRouterRows } from "./autoRouterRows";
 
 // Existing cases assert resource classification, so they run as a proxy admin: the actor
 // gate is then a pass-through and canEdit/canDelete still reflect the row itself.
-const ADMIN = { userRole: "Admin", userID: "u-admin" };
-const TEAM_ADMIN = { userRole: "Internal User", userID: "u-team-admin" };
+const ADMIN = { userRole: "Admin", userID: "u-admin", isViewOnly: false };
+const TEAM_ADMIN = { userRole: "Internal User", userID: "u-team-admin", isViewOnly: false };
+const VIEW_ONLY_ADMIN = { userRole: "Admin", userID: "u-viewer", isViewOnly: true };
 
 const complexityDeployment = {
   model_name: "tri-tier-router",
@@ -224,7 +225,7 @@ describe("autoRouterRows actor gating", () => {
     { team_id: "team-1", members_with_roles: [{ user_id: "u-team-admin", user_email: "t@t", role: "admin" }] },
   ] as never;
 
-  const rowIn = (actor: { userRole: string; userID: string }, teamId: string | null) =>
+  const rowIn = (actor: { userRole: string; userID: string; isViewOnly: boolean }, teamId: string | null) =>
     toAutoRouterRow(
       { ...complexityDeployment, model_info: { id: "cid-1", db_model: true, team_id: teamId } },
       0,
@@ -258,5 +259,13 @@ describe("autoRouterRows actor gating", () => {
     const row = rowIn(ADMIN, "other-team");
     expect(row.canEdit).toBe(true);
     expect(row.canDelete).toBe(true);
+  });
+
+  // A proxy_admin_viewer session reads "Admin" through the masquerade, but PATCH and
+  // DELETE both 403 it, so its rows must not offer the affordances.
+  it("hides write affordances from a view-only admin session", () => {
+    const row = rowIn(VIEW_ONLY_ADMIN, null);
+    expect(row.canEdit).toBe(false);
+    expect(row.canDelete).toBe(false);
   });
 });

--- a/ui/litellm-dashboard/src/app/(dashboard)/models-and-endpoints/page.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/models-and-endpoints/page.test.tsx
@@ -38,8 +38,17 @@ vi.mock("./useModelDashboardData", () => ({
   useModelDashboardData: () => ({ availableModelAccessGroups: [], allModelsOnProxy: [], availableModelGroups: [] }),
 }));
 
-const ADMIN = { accessToken: "at", token: "t", userRole: "Admin", userId: "u1", premiumUser: false };
-const NON_ADMIN = { accessToken: "at", token: "t", userRole: "Internal User", userId: "u1", premiumUser: false };
+const ADMIN = { accessToken: "at", token: "t", userRole: "Admin", userId: "u1", premiumUser: false, isViewOnly: false };
+const NON_ADMIN = {
+  accessToken: "at",
+  token: "t",
+  userRole: "Internal User",
+  userId: "u1",
+  premiumUser: false,
+  isViewOnly: false,
+};
+// A proxy_admin_viewer session: effectiveSessionRole masquerades the role as "Admin".
+const VIEW_ONLY_ADMIN = { ...ADMIN, isViewOnly: true };
 
 const renderPage = () => {
   const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false, gcTime: 0 } } });
@@ -97,6 +106,22 @@ describe("ModelsAndEndpointsPage", () => {
     const { queryByRole } = renderPage();
     expect(queryByRole("tab", { name: "LLM Credentials" })).not.toBeInTheDocument();
     expect(queryByRole("tab", { name: "Health Status" })).not.toBeInTheDocument();
+  });
+
+  // POST /model/new 403s a proxy_admin_viewer, so the form's tab must not render for one.
+  it("hides the Add Model tab for a view-only admin session", () => {
+    mockUseAuthorized.mockReturnValue(VIEW_ONLY_ADMIN);
+    const { getByRole, queryByRole } = renderPage();
+    expect(queryByRole("tab", { name: "Add Model" })).not.toBeInTheDocument();
+    expect(getByRole("tab", { name: "All Models" })).toBeInTheDocument();
+  });
+
+  // Read parity: the Auto-Routers list stays reachable for a view-only admin; only the
+  // create affordance inside it is withheld, which AutoRoutersTabPanel decides.
+  it("keeps the Auto-Routers tab for a view-only admin session", () => {
+    mockUseAuthorized.mockReturnValue(VIEW_ONLY_ADMIN);
+    const { getByRole } = renderPage();
+    expect(getByRole("tab", { name: /Auto-Routers/ })).toBeInTheDocument();
   });
 
   // Auto-routers are excluded from the All Models table, so this tab is their home: the only

--- a/ui/litellm-dashboard/src/app/(dashboard)/models-and-endpoints/page.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/models-and-endpoints/page.tsx
@@ -80,7 +80,7 @@ const renderPanel = (key: string) => {
 };
 
 export default function ModelsAndEndpointsPage() {
-  const { accessToken, userRole, userId: userID, premiumUser } = useAuthorized();
+  const { accessToken, userRole, userId: userID, premiumUser, isViewOnly } = useAuthorized();
   const { data: teams } = useTeams();
   const { data: uiSettings } = useUISettings();
   const queryClient = useQueryClient();
@@ -92,7 +92,7 @@ export default function ModelsAndEndpointsPage() {
 
   const isInternalUser = userRole && internalUserRoles.includes(userRole);
   const canCreate = canCreateModels(
-    { userRole, userID },
+    { userRole, userID, isViewOnly },
     {
       teams: teams ?? null,
       disabledForInternalUsers:
@@ -182,6 +182,7 @@ export default function ModelsAndEndpointsPage() {
             accessToken={accessToken}
             userID={userID}
             userRole={userRole}
+            isViewOnly={isViewOnly}
             onModelUpdate={invalidateModels}
             modelAccessGroups={availableModelAccessGroups}
           />

--- a/ui/litellm-dashboard/src/app/(dashboard)/models-and-endpoints/panels/AutoRoutersTabPanel.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/models-and-endpoints/panels/AutoRoutersTabPanel.test.tsx
@@ -1,0 +1,39 @@
+/* @vitest-environment jsdom */
+import { render } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import AutoRoutersTabPanel from "./AutoRoutersTabPanel";
+
+const panelProps = vi.fn();
+vi.mock("../components/AutoRouters/AutoRoutersPanel", () => ({
+  AutoRoutersPanel: (props: Record<string, unknown>) => {
+    panelProps(props);
+    return <div data-testid="auto-routers-panel" />;
+  },
+}));
+
+const mockUseAuthorized = vi.fn();
+vi.mock("@/app/(dashboard)/hooks/useAuthorized", () => ({ default: () => mockUseAuthorized() }));
+vi.mock("@/app/(dashboard)/hooks/teams/useTeams", () => ({ useTeams: () => ({ data: [] }) }));
+vi.mock("@/app/(dashboard)/hooks/uiSettings/useUISettings", () => ({
+  useUISettings: () => ({ data: { values: {} } }),
+}));
+
+const SESSION = { accessToken: "at", userRole: "Admin", userId: "u1", isViewOnly: false };
+
+const lastProps = () => panelProps.mock.calls.at(-1)?.[0] as { createScope: string };
+
+describe("AutoRoutersTabPanel", () => {
+  it("grants an unscoped create to a real proxy admin", () => {
+    mockUseAuthorized.mockReturnValue(SESSION);
+    render(<AutoRoutersTabPanel />);
+    expect(lastProps().createScope).toBe("unscoped-ok");
+  });
+
+  // The masqueraded "Admin" a proxy_admin_viewer session carries: POST /model/new 403s it,
+  // so the panel must not be told it may create.
+  it("withholds the create affordance from a view-only admin session", () => {
+    mockUseAuthorized.mockReturnValue({ ...SESSION, isViewOnly: true });
+    render(<AutoRoutersTabPanel />);
+    expect(lastProps().createScope).toBe("forbidden");
+  });
+});

--- a/ui/litellm-dashboard/src/app/(dashboard)/models-and-endpoints/panels/AutoRoutersTabPanel.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/models-and-endpoints/panels/AutoRoutersTabPanel.tsx
@@ -15,13 +15,13 @@ import { AutoRoutersPanel } from "../components/AutoRouters/AutoRoutersPanel";
  * Viewer roles reach the list without write affordances.
  */
 export default function AutoRoutersTabPanel() {
-  const { accessToken, userRole, userId: userID } = useAuthorized();
+  const { accessToken, userRole, userId: userID, isViewOnly } = useAuthorized();
   const { data: teams } = useTeams();
   const { data: uiSettings } = useUISettings();
 
   const isInternalUser = userRole != null && internalUserRoles.includes(userRole);
   const scope = modelCreationScope(
-    { userRole, userID },
+    { userRole, userID, isViewOnly },
     {
       teams: teams ?? null,
       disabledForInternalUsers: isInternalUser && uiSettings?.values?.disable_model_add_for_internal_users === true,
@@ -33,6 +33,7 @@ export default function AutoRoutersTabPanel() {
       accessToken={accessToken}
       userRole={userRole ?? ""}
       userID={userID ?? null}
+      isViewOnly={isViewOnly}
       teams={teams ?? null}
       createScope={scope}
     />

--- a/ui/litellm-dashboard/src/components/add_model/AddModelForm.tsx
+++ b/ui/litellm-dashboard/src/components/add_model/AddModelForm.tsx
@@ -82,7 +82,7 @@ const AddModelForm: React.FC<AddModelFormProps> = ({
   // Using a unique ID to force the ConnectionErrorDisplay to remount and run a fresh test
   const [connectionTestId, setConnectionTestId] = useState<string>("");
 
-  const { accessToken, userRole, premiumUser, userId } = useAuthorized();
+  const { accessToken, userRole, premiumUser, userId, isViewOnly } = useAuthorized();
   const {
     data: providerMetadata,
     isLoading: isProviderMetadataLoading,
@@ -157,7 +157,10 @@ const AddModelForm: React.FC<AddModelFormProps> = ({
   const isTeamAdmin = isUserTeamAdminForAnyTeam(teams, userId);
   // Same owner the Auto-Routers tab uses, so the two creation forms cannot disagree about
   // who has to name a team. This form is only reachable when creation is allowed at all.
-  const createScope = modelCreationScope({ userRole, userID: userId }, { teams, disabledForInternalUsers: false });
+  const createScope = modelCreationScope(
+    { userRole, userID: userId, isViewOnly },
+    { teams, disabledForInternalUsers: false },
+  );
   const requiresTeamScope = createScope === "team-required";
 
   return (

--- a/ui/litellm-dashboard/src/components/model_info_view.test.tsx
+++ b/ui/litellm-dashboard/src/components/model_info_view.test.tsx
@@ -87,6 +87,7 @@ describe("ModelInfoView", () => {
     accessToken: "test-token",
     userID: "123",
     userRole: "Admin",
+    isViewOnly: false,
     onModelUpdate: vi.fn(),
     modelAccessGroups: ["group1", "group2"],
   };
@@ -326,6 +327,16 @@ describe("ModelInfoView", () => {
     await waitFor(() => {
       expect(screen.getByRole("button", { name: /delete model/i })).toBeInTheDocument();
     });
+  });
+
+  // A proxy_admin_viewer session reads "Admin" through effectiveSessionRole, but the update
+  // and delete endpoints 403 it, so the write buttons must not be offered.
+  it("should disable delete and update buttons for a view-only admin session", async () => {
+    render(<ModelInfoView {...DEFAULT_ADMIN_PROPS} isViewOnly={true} />, { wrapper });
+    await waitFor(() => {
+      expect(screen.getByTestId("delete-model-button")).toBeDisabled();
+    });
+    expect(screen.getByTestId("update-api-key-button")).toBeDisabled();
   });
 
   it("should disable delete button when model is not a DB model", async () => {

--- a/ui/litellm-dashboard/src/components/model_info_view.tsx
+++ b/ui/litellm-dashboard/src/components/model_info_view.tsx
@@ -53,6 +53,7 @@ interface ModelInfoViewProps {
   accessToken: string | null;
   userID: string | null;
   userRole: string | null;
+  isViewOnly: boolean;
   onModelUpdate?: (updatedModel: any) => void;
   modelAccessGroups: string[] | null;
 }
@@ -117,6 +118,7 @@ export default function ModelInfoView({
   accessToken,
   userID,
   userRole,
+  isViewOnly,
   onModelUpdate,
   modelAccessGroups,
 }: ModelInfoViewProps) {
@@ -167,7 +169,7 @@ export default function ModelInfoView({
   // Keep modelData variable name for backwards compatibility
   const modelData = transformedModelData;
 
-  const canEditModel = canModifyModel({ userRole, userID }, teams ?? null, {
+  const canEditModel = canModifyModel({ userRole, userID, isViewOnly }, teams ?? null, {
     teamId: modelData?.model_info?.team_id,
     isDbModel: modelData?.model_info?.db_model === true,
   });

--- a/ui/litellm-dashboard/src/utils/modelPermissions.test.ts
+++ b/ui/litellm-dashboard/src/utils/modelPermissions.test.ts
@@ -53,11 +53,11 @@ describe("modelCreationScope", () => {
     expect(canCreateModels(VIEW_ONLY_ADMIN, { teams: [], ...noLimits })).toBe(false);
   });
 
-  // A blunt view-only gate would fail this: team-admin membership legitimately grants
-  // team-scoped creation, whatever the session role says.
-  it("still requires a team from a view-only admin who admins a team", () => {
+  // _check_proxy_admin_viewer_access (route_checks.py) 403s /model/new on the session role
+  // alone, before the team-scoped carve-out in ModelManagementAuthChecks can run.
+  it("forbids a view-only admin even when they admin a team", () => {
     expect(modelCreationScope(VIEW_ONLY_ADMIN, { teams: teamWhere("u-viewer", "admin"), ...noLimits })).toBe(
-      "team-required",
+      "forbidden",
     );
   });
 });
@@ -105,7 +105,9 @@ describe("canModifyModel", () => {
     expect(canModifyModel(VIEW_ONLY_ADMIN, null, teamRow)).toBe(false);
   });
 
-  it("lets a view-only user who admins the owning team act on its row", () => {
-    expect(canModifyModel(VIEW_ONLY_ADMIN, teamWhere("u-viewer", "admin"), teamRow)).toBe(true);
+  // The route RBAC blocks /model/update and /model/delete for the viewer role before the
+  // team-scoped carve-out runs, so team-admin membership changes nothing here either.
+  it("refuses a view-only user even when they admin the owning team", () => {
+    expect(canModifyModel(VIEW_ONLY_ADMIN, teamWhere("u-viewer", "admin"), teamRow)).toBe(false);
   });
 });

--- a/ui/litellm-dashboard/src/utils/modelPermissions.test.ts
+++ b/ui/litellm-dashboard/src/utils/modelPermissions.test.ts
@@ -1,14 +1,16 @@
 import { describe, expect, it } from "vitest";
 
 import { Team } from "@/components/networking";
-import { canModifyModel, modelCreationScope } from "./modelPermissions";
+import { canCreateModels, canModifyModel, modelCreationScope } from "./modelPermissions";
 
 const teamWhere = (userId: string, role: string, teamId = "team-1"): Team[] =>
   [{ team_id: teamId, members_with_roles: [{ user_id: userId, user_email: "t@test.com", role }] }] as unknown as Team[];
 
-const PROXY_ADMIN = { userRole: "Admin", userID: "u-admin" };
-const TEAM_ADMIN = { userRole: "Internal User", userID: "u-team-admin" };
-const MEMBER = { userRole: "Internal User", userID: "u-member" };
+const PROXY_ADMIN = { userRole: "Admin", userID: "u-admin", isViewOnly: false };
+const TEAM_ADMIN = { userRole: "Internal User", userID: "u-team-admin", isViewOnly: false };
+const MEMBER = { userRole: "Internal User", userID: "u-member", isViewOnly: false };
+// proxy_admin_viewer sessions: effectiveSessionRole masquerades the role as "Admin".
+const VIEW_ONLY_ADMIN = { userRole: "Admin", userID: "u-viewer", isViewOnly: true };
 
 const noLimits = { disabledForInternalUsers: false };
 
@@ -40,8 +42,23 @@ describe("modelCreationScope", () => {
   // an unscoped create from them 403s. Treating them as admins here is what let a form submit
   // a payload the backend always rejected.
   it("does not treat an org admin as able to create unscoped", () => {
-    const orgAdmin = { userRole: "org_admin", userID: "u-org" };
+    const orgAdmin = { userRole: "org_admin", userID: "u-org", isViewOnly: false };
     expect(modelCreationScope(orgAdmin, { teams: teamWhere("u-org", "admin"), ...noLimits })).toBe("team-required");
+  });
+
+  // Server-side, POST /model/new 403s the viewer roles, so the "Admin" the masquerade
+  // reports must not read as a proxy admin here.
+  it("forbids a view-only admin session despite the masqueraded Admin role", () => {
+    expect(modelCreationScope(VIEW_ONLY_ADMIN, { teams: [], ...noLimits })).toBe("forbidden");
+    expect(canCreateModels(VIEW_ONLY_ADMIN, { teams: [], ...noLimits })).toBe(false);
+  });
+
+  // A blunt view-only gate would fail this: team-admin membership legitimately grants
+  // team-scoped creation, whatever the session role says.
+  it("still requires a team from a view-only admin who admins a team", () => {
+    expect(modelCreationScope(VIEW_ONLY_ADMIN, { teams: teamWhere("u-viewer", "admin"), ...noLimits })).toBe(
+      "team-required",
+    );
   });
 });
 
@@ -80,6 +97,15 @@ describe("canModifyModel", () => {
   });
 
   it("does not treat two absent identities as a match", () => {
-    expect(canModifyModel({ userRole: "Internal User", userID: null }, null, teamRow)).toBe(false);
+    expect(canModifyModel({ userRole: "Internal User", userID: null, isViewOnly: false }, null, teamRow)).toBe(false);
+  });
+
+  // PATCH /model/{id}/update and POST /model/delete 403 the viewer roles like /model/new does.
+  it("refuses a view-only admin session on a DB row", () => {
+    expect(canModifyModel(VIEW_ONLY_ADMIN, null, teamRow)).toBe(false);
+  });
+
+  it("lets a view-only user who admins the owning team act on its row", () => {
+    expect(canModifyModel(VIEW_ONLY_ADMIN, teamWhere("u-viewer", "admin"), teamRow)).toBe(true);
   });
 });

--- a/ui/litellm-dashboard/src/utils/modelPermissions.ts
+++ b/ui/litellm-dashboard/src/utils/modelPermissions.ts
@@ -3,14 +3,17 @@ import { Team } from "@/components/networking";
 import { isProxyAdminRole, isUserTeamAdminForAnyTeam, isUserTeamAdminForSingleTeam } from "./roles";
 
 /**
- * The dashboard's mirror of ModelManagementAuthChecks in
- * litellm/proxy/management_endpoints/model_management_endpoints.py.
+ * The dashboard's mirror of the two server layers that gate model writes: the role-level
+ * route RBAC (`_check_proxy_admin_viewer_access` in litellm/proxy/auth/route_checks.py),
+ * which 403s /model/new, /model/update, and /model/delete for every view-only session
+ * before the endpoint runs, and ModelManagementAuthChecks in
+ * litellm/proxy/management_endpoints/model_management_endpoints.py behind it.
  *
- * Both questions below are answered there by exactly two inputs: the caller's role, and
- * whether the caller admins the team named in `model_info.team_id`. `created_by` is written
- * at creation and never read by an auth check, so it is deliberately absent here; gating on
- * it hid controls from team admins the API accepts, and showed controls to former team admins
- * the API rejects.
+ * Past that route gate, both questions below are answered by exactly two inputs: the
+ * caller's role, and whether the caller admins the team named in `model_info.team_id`.
+ * `created_by` is written at creation and never read by an auth check, so it is deliberately
+ * absent here; gating on it hid controls from team admins the API accepts, and showed
+ * controls to former team admins the API rejects.
  */
 export interface ModelActor {
   userRole: string | null;
@@ -42,13 +45,18 @@ const isTeamAdminOf = (teams: Team[] | null, userID: string, teamId: string): bo
 
 /**
  * POST /model/new takes a proxy admin unconditionally, or a team admin whose payload names a
- * team; an unscoped create from anyone else is a 403. Returning the requirement rather than a
- * pair of booleans keeps "may not create" and "may create unscoped" from being confused.
+ * team; an unscoped create from anyone else is a 403. A view-only session is 403d by the
+ * route RBAC on its role alone, so team-admin membership cannot rescue it. Returning the
+ * requirement rather than a pair of booleans keeps "may not create" and "may create
+ * unscoped" from being confused.
  */
 export const modelCreationScope = (
   actor: ModelActor,
   { teams, disabledForInternalUsers }: ModelCreationLimits,
 ): ModelWriteScope => {
+  if (actor.isViewOnly) {
+    return "forbidden";
+  }
   if (isWritableProxyAdmin(actor)) {
     return "unscoped-ok";
   }
@@ -76,7 +84,7 @@ export const canModifyModel = (
   teams: Team[] | null,
   { teamId, isDbModel }: ModelRowOrigin,
 ): boolean => {
-  if (!isDbModel) {
+  if (actor.isViewOnly || !isDbModel) {
     return false;
   }
   if (isWritableProxyAdmin(actor)) {

--- a/ui/litellm-dashboard/src/utils/modelPermissions.ts
+++ b/ui/litellm-dashboard/src/utils/modelPermissions.ts
@@ -15,7 +15,16 @@ import { isProxyAdminRole, isUserTeamAdminForAnyTeam, isUserTeamAdminForSingleTe
 export interface ModelActor {
   userRole: string | null;
   userID: string | null;
+  /**
+   * From useAuthorized(). A proxy_admin_viewer session masquerades as "Admin" in userRole
+   * (effectiveSessionRole, for read parity), yet every management write 403s it, so the role
+   * alone cannot answer a write question.
+   */
+  isViewOnly: boolean;
 }
+
+const isWritableProxyAdmin = ({ userRole, isViewOnly }: ModelActor): boolean =>
+  !isViewOnly && userRole != null && isProxyAdminRole(userRole);
 
 /** How this actor must scope a deployment they create, or that they may not create one. */
 export type ModelWriteScope = "forbidden" | "unscoped-ok" | "team-required";
@@ -37,16 +46,16 @@ const isTeamAdminOf = (teams: Team[] | null, userID: string, teamId: string): bo
  * pair of booleans keeps "may not create" and "may create unscoped" from being confused.
  */
 export const modelCreationScope = (
-  { userRole, userID }: ModelActor,
+  actor: ModelActor,
   { teams, disabledForInternalUsers }: ModelCreationLimits,
 ): ModelWriteScope => {
-  if (userRole != null && isProxyAdminRole(userRole)) {
+  if (isWritableProxyAdmin(actor)) {
     return "unscoped-ok";
   }
   if (disabledForInternalUsers) {
     return "forbidden";
   }
-  if (userID != null && isUserTeamAdminForAnyTeam(teams, userID)) {
+  if (actor.userID != null && isUserTeamAdminForAnyTeam(teams, actor.userID)) {
     return "team-required";
   }
   return "forbidden";
@@ -63,18 +72,18 @@ export interface ModelRowOrigin {
 
 /** May this actor edit or delete this specific deployment? */
 export const canModifyModel = (
-  { userRole, userID }: ModelActor,
+  actor: ModelActor,
   teams: Team[] | null,
   { teamId, isDbModel }: ModelRowOrigin,
 ): boolean => {
   if (!isDbModel) {
     return false;
   }
-  if (userRole != null && isProxyAdminRole(userRole)) {
+  if (isWritableProxyAdmin(actor)) {
     return true;
   }
-  if (userID == null || teamId == null) {
+  if (actor.userID == null || teamId == null) {
     return false;
   }
-  return isTeamAdminOf(teams, userID, teamId);
+  return isTeamAdminOf(teams, actor.userID, teamId);
 };


### PR DESCRIPTION
## TLDR

Problem this solves:

- View-only admins get the Add Model tab, but every save 403s
- Auto-Routers offers them create, edit, and delete that also 403
- Model detail view shows them enabled Delete and Update API Key buttons

How it solves it:

- The dashboard's model actor now carries the session's view-only flag
- A masqueraded "Admin" viewer no longer counts as a writable proxy admin
- A view-only session gets no write affordances at all: route-level RBAC 403s every model write on the role alone, team admin or not
- Team-admin membership still grants team-scoped creation for non-view-only roles, matching the API

## User Flow

Before: a view-only admin is offered model write controls that every save rejects with a 403

1. An operator adds a teammate with the view-only admin role (`proxy_admin_viewer`); the teammate logs in at https://litellm-domain/ui
2. They open the Models + Endpoints page and see an Add Model tab next to All Models
3. They fill out the form and click Add Model; the POST to https://litellm-domain/model/new comes back 403
4. On the Auto-Routers tab they see an Add Auto Router button and edit/delete icons on every row; each of those actions ends in a 403 too
5. They click into a model and the Delete Model and Update API Key buttons are enabled; both requests 403 as well
6. The API refused every write all along; the UI just kept offering the forms

After: the same view-only admin gets read-only pages with no dead-end write controls

1. An operator adds a teammate with the view-only admin role (`proxy_admin_viewer`); the teammate logs in at https://litellm-domain/ui
2. They open the Models + Endpoints page; the Add Model tab is gone and All Models still lists every deployment
3. The Auto-Routers tab still shows the full router list, now with no Add Auto Router button and no edit/delete icons
4. They click into a model and the Delete Model and Update API Key buttons are disabled
5. Even a view-only admin who also admins a team gets no write controls: the proxy 403s the viewer role on every model write route, team-scoped payloads included

## Relevant issues

## Linear ticket

Resolves LIT-6516

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

The regression tests below render the dashboard pages as a `{ userRole: "Admin", isViewOnly: true }` session, the exact shape a `proxy_admin_viewer` login produces (its effective role masquerades as "Admin" for read parity). Server-side that session's POST /model/new already returns 403, so before this PR the UI was offering forms that could only fail. The real-UI run at the end of this section proves the same end to end in a live dashboard

### Before (d44d281d1d873fe3bf813e931bed27a8ac3ae7ee)

1. `cd ui/litellm-dashboard && npx vitest run src/utils/modelPermissions.test.ts "src/app/(dashboard)/models-and-endpoints/page.test.tsx" "src/app/(dashboard)/models-and-endpoints/components/AutoRouters/autoRouterRows.test.ts" "src/app/(dashboard)/models-and-endpoints/panels/AutoRoutersTabPanel.test.tsx"`
2. Observed: the view-only cases fail exactly as the ticket describes

```
FAIL |unit| src/utils/modelPermissions.test.ts > modelCreationScope > forbids a view-only admin session despite the masqueraded Admin role
FAIL |unit| src/utils/modelPermissions.test.ts > modelCreationScope > forbids a view-only admin even when they admin a team
FAIL |unit| src/utils/modelPermissions.test.ts > canModifyModel > refuses a view-only admin session on a DB row
FAIL |unit| src/utils/modelPermissions.test.ts > canModifyModel > refuses a view-only user even when they admin the owning team
FAIL |unit| src/app/(dashboard)/models-and-endpoints/components/AutoRouters/autoRouterRows.test.ts > autoRouterRows actor gating > hides write affordances from a view-only admin session
FAIL |component| src/app/(dashboard)/models-and-endpoints/page.test.tsx > ModelsAndEndpointsPage > hides the Add Model tab for a view-only admin session
FAIL |component| src/app/(dashboard)/models-and-endpoints/panels/AutoRoutersTabPanel.test.tsx > AutoRoutersTabPanel > withholds the create affordance from a view-only admin session

Test Files  4 failed (4)
     Tests  7 failed | 43 passed (50)
```

The page test's failure output shows the rendered `<button role="tab">Add Model</button>` for the view-only session

### After (b6bd749c02891b76b9f504794c3cb6eced8b8d49)

1. Same command, plus the two component suites the fix touches and the adjacent role helpers:
   `cd ui/litellm-dashboard && npx vitest run src/utils/modelPermissions.test.ts "src/app/(dashboard)/models-and-endpoints/page.test.tsx" "src/app/(dashboard)/models-and-endpoints/components/AutoRouters/autoRouterRows.test.ts" "src/app/(dashboard)/models-and-endpoints/panels/AutoRoutersTabPanel.test.tsx" "src/app/(dashboard)/models-and-endpoints/components/AutoRouters/AutoRoutersPanel.test.tsx" src/components/model_info_view.test.tsx src/utils/roles.test.ts src/utils/capabilities.test.ts`
2. Observed: everything green, type check included

```
 Test Files  8 passed (8)
      Tests  439 passed (439)
Type Errors  no errors
```

### Real UI, end to end (Playwright chromium against a live proxy, zero mocks)

Both legs ran a real proxy (`litellm --num_workers 2`, Postgres, `STORE_MODEL_IN_DB=True`) with the dashboard dev server pointed at it, logging in through the actual /login form. Seed per leg: one model `qa-gpt`, viewer A (`proxy_admin_viewer`), viewer B (`proxy_admin_viewer` who is also team admin of `qa-team`), virtual keys for both

Before, at d44d281d1d:

- Viewer A and viewer B both get the full admin surface: the Add Model tab with the unscoped admin form (admin-only Model Access Group field, no team-selection prompt), an Add Auto Router button, and enabled Delete Model / Update API Key buttons on model detail
- Clicking that enabled Delete Model as viewer A and confirming fires `POST /model/delete`, which comes back 403 and surfaces the "Failed to delete model" error toast
- The API refuses the same writes directly, viewer B's team-scoped payload (`model_info.team_id` of the qa-team they admin) included; exact commands and real output ($KEY_A / $KEY_B are the viewers' virtual keys):

```
$ curl -sS -X POST http://127.0.0.1:28517/model/new -H "Authorization: Bearer $KEY_A" \
    -H 'Content-Type: application/json' \
    -d '{"model_name":"qa-viewer-attempt","litellm_params":{"model":"openai/gpt-4o-mini","api_key":"sk-fake"}}'
# HTTP 403: "user not allowed to access this route, role= proxy_admin_viewer. Trying to access: /model/new"

$ curl -sS -X POST http://127.0.0.1:28517/model/new -H "Authorization: Bearer $KEY_B" \
    -H 'Content-Type: application/json' \
    -d '{"model_name":"qa-team-attempt","litellm_params":{"model":"openai/gpt-4o-mini","api_key":"sk-fake"},"model_info":{"team_id":"a9f2f3f0-bac7-4c01-9950-c2d285ce71c0"}}'
# HTTP 403: same message; team-admin membership does not help on this route
```

After, at b6bd749c02, same seed and same flows:

- Admin baseline unchanged: Add Model tab, Add Auto Router button, enabled Delete Model and Update API Key on model detail
- Viewer A: no Add Model tab, All Models still lists `qa-gpt`, the Auto-Routers tab renders with no Add Auto Router button, and Delete Model / Update API Key are disabled
- Viewer B: identical to viewer A; team-admin membership adds no model write affordance, matching the route RBAC that 403s the viewer role on model writes regardless of team payloads
- API cross-check unchanged, both viewer keys still refused; exact commands and real output:

```
$ curl -sS http://127.0.0.1:27431/model/new -H "Authorization: Bearer $KEY_A" -H 'Content-Type: application/json' \
    -d '{"model_name":"qa-viewer-model","litellm_params":{"model":"openai/gpt-4o-mini","api_key":"sk-fake"}}'
{"error":{"message":"user not allowed to access this route, role= proxy_admin_viewer. Trying to access: /model/new","type":"auth_error","param":"None","code":"403"}}

$ curl -sS http://127.0.0.1:27431/model/new -H "Authorization: Bearer $KEY_B" -H 'Content-Type: application/json' \
    -d '{"model_name":"qa-team-model","litellm_params":{"model":"openai/gpt-4o-mini","api_key":"sk-fake"},"model_info":{"team_id":"f9db4253-f9c6-4f0b-9d94-8a3aaa24572d"}}'
{"error":{"message":"user not allowed to access this route, role= proxy_admin_viewer. Trying to access: /model/new","type":"auth_error","param":"None","code":"403"}}
```

## Type

🐛 Bug Fix

## Caveats (if any)

### Low

- Re-use Credentials button still enabled for view-only admins; separate literal role check, untouched here
- Client never modeled the premium requirement for team-scoped model writes; pre-existing, untouched
- Auto-Routers tab itself stays visible to viewers on purpose (read parity); tests pin that

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

CHECKED: live-pr-risk at b6bd749c02. Delta from 74fb398f9b is confined to modelPermissions.ts (view-only now forbidden on the team-admin branch too) plus its tests; exported signatures unchanged, so the 5 ModelActor construction sites need no change; full dashboard vitest with typecheck green at this tree (773 files, 9227 tests, no type errors); affected suites green on head merged with current staging 5e4b3838aa (153/153, no ui/ drift); no wire, config, or DB contract touched. The browser walkthrough is now verified by the real-UI e2e run in Proof of Fix


- [x] 74fb398f9baddda91b0de27dfdc6ecdad6c0ffe9 passes /live-pr-risk
- [x] b6bd749c02891b76b9f504794c3cb6eced8b8d49 passes /live-pr-risk

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only permission gating aligned with existing route RBAC; no API or data contract changes.
> 
> **Overview**
> **proxy_admin_viewer** sessions masquerade as **Admin** for reads but the API 403s every model write. The dashboard now passes **`isViewOnly`** from **`useAuthorized()`** into **`ModelActor`** and treats view-only actors as never writable—**`modelCreationScope`** and **`canModifyModel`** return forbidden before team-admin or proxy-admin rules apply.
> 
> That flag flows through Models + Endpoints (**Add Model** tab hidden via **`canCreateModels`**), **Auto-Routers** (create scope **`forbidden`**, row **`canEdit`/`canDelete`** false), **AddModelForm**, and **ModelInfoView** (update/delete disabled). Read paths stay open: **All Models** and the Auto-Routers list remain visible. Tests cover permissions, page tabs, tab panel, auto-router rows, and model detail buttons for **`{ userRole: "Admin", isViewOnly: true }`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b6bd749c02891b76b9f504794c3cb6eced8b8d49. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
