### PR TITLE
fix(proxy): return 200 from /model/block and /model/unblock instead of 500

### DIFF
--- a/litellm/models/model.py
+++ b/litellm/models/model.py
@@ -29,6 +29,8 @@ class LiteLLM_ProxyModelTable(LiteLLMPydanticObjectBase):
     @model_validator(mode="before")
     @classmethod
     def check_potential_json_str(cls, values):
+        if not isinstance(values, dict):
+            return values
         if isinstance(values.get("litellm_params"), str):
             try:
                 values["litellm_params"] = json.loads(values["litellm_params"])

--- a/tests/e2e/management/test_model_tag_accessgroup_e2e.py
+++ b/tests/e2e/management/test_model_tag_accessgroup_e2e.py
@@ -180,6 +180,12 @@ class ModelBlockBody(BaseModel):
     model_id: str
 
 
+class ModelBlockResponse(BaseModel):
+    model_config = ConfigDict(protected_namespaces=())
+    model_id: str
+    blocked: bool
+
+
 class ModelInfoBlockDetail(BaseModel):
     id: str | None = None
     blocked: bool | None = None
@@ -245,11 +251,6 @@ class TestModelRoutes:
     def test_block_then_unblock_persists_to_model_info(
         self, client: ManagementClient, resources: ResourceManager
     ) -> None:
-        """The blocked flag's persistence is read back from /model/info, not from the
-        /model/block response: that route currently returns a non-2xx serialization
-        envelope even though the DB write lands, so the /model/info read-back is the
-        authoritative persistence contract and keeps this test valid once the
-        response shape is fixed."""
         model_name = f"e2e-mgmt-model-block-{unique_marker()}"
         model_id = _create_db_model(client, resources, model_name)
 
@@ -257,27 +258,25 @@ class TestModelRoutes:
             f"{model_name!r} already reports blocked in /model/info before /model/block ran"
         )
 
-        _ = client.proxy.transport.send(
-            "/model/block",
-            headers=client.proxy.transport.master,
-            json=ModelBlockBody(model_id=model_id),
-        )
-        _ = _poll(
-            client.proxy,
-            lambda: True if _model_blocked_flag(client, model_id) is True else None,
-            f"/model/info never reported {model_name!r} blocked after /model/block",
-        )
-
-        _ = client.proxy.transport.send(
-            "/model/unblock",
-            headers=client.proxy.transport.master,
-            json=ModelBlockBody(model_id=model_id),
-        )
-        _ = _poll(
-            client.proxy,
-            lambda: True if _model_blocked_flag(client, model_id) is not True else None,
-            f"/model/info never cleared blocked for {model_name!r} after /model/unblock",
-        )
+        for action, expected in (("block", True), ("unblock", False)):
+            response = unwrap(
+                client.proxy.transport.post(
+                    f"/model/{action}",
+                    headers=client.proxy.transport.master,
+                    json=ModelBlockBody(model_id=model_id),
+                    response_type=ModelBlockResponse,
+                )
+            )
+            assert response.model_id == model_id
+            assert response.blocked is expected
+            _ = _poll(
+                client.proxy,
+                lambda: True
+                if _model_blocked_flag(client, model_id) is expected
+                else None,
+                f"/model/info never reported blocked={expected} for {model_name!r} "
+                f"after /model/{action}",
+            )
 
 
 class TestTagRoutes:

--- a/tests/e2e/management/test_model_tag_accessgroup_e2e.py
+++ b/tests/e2e/management/test_model_tag_accessgroup_e2e.py
@@ -271,8 +271,8 @@ class TestModelRoutes:
             assert response.blocked is expected
             _ = _poll(
                 client.proxy,
-                lambda: True
-                if _model_blocked_flag(client, model_id) is expected
+                lambda want=expected: True
+                if _model_blocked_flag(client, model_id) is want
                 else None,
                 f"/model/info never reported blocked={expected} for {model_name!r} "
                 f"after /model/{action}",

--- a/tests/test_litellm/models/test_models.py
+++ b/tests/test_litellm/models/test_models.py
@@ -5,6 +5,7 @@ Tests for backend domain models.
 from datetime import datetime
 
 import pytest
+from pydantic import BaseModel, TypeAdapter
 
 from litellm.models.access_group import LiteLLM_AccessGroupTable
 from litellm.models.budget import (
@@ -129,6 +130,33 @@ class TestModel:
         )
         assert model.litellm_params == {"model": "gpt-4"}
         assert model.model_info == {"team_id": "t1"}
+
+    def test_response_type_adapter_accepts_pydantic_row(self):
+        class PrismaModelRow(BaseModel):
+            model_id: str
+            model_name: str
+            litellm_params: dict[str, str]
+            model_info: dict[str, str] | None = None
+            blocked: bool = False
+
+        row = PrismaModelRow(
+            model_id="m1",
+            model_name="gpt-4",
+            litellm_params={"model": "gpt-4"},
+            model_info={"team_id": "t1"},
+            blocked=True,
+        )
+
+        model = TypeAdapter(LiteLLM_ProxyModelTable | None).validate_python(
+            row,
+            from_attributes=True,
+        )
+
+        assert model is not None
+        assert model.model_id == "m1"
+        assert model.litellm_params == {"model": "gpt-4"}
+        assert model.model_info == {"team_id": "t1"}
+        assert model.blocked is True
 
     def test_team_helpers_none_when_no_model_info(self):
         model = LiteLLM_ProxyModelTable(

--- a/tests/test_litellm/proxy/management_endpoints/test_model_management_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_model_management_endpoints.py
@@ -4466,3 +4466,71 @@ class TestEnforceRpmTpmOnModelAdd:
             _raise_if_rate_limits_required_but_missing(litellm_params=params, enforced=True)
         assert expected_missing in str(exc_info.value.message)
         assert exc_info.value.code == "400"
+
+
+class TestBlockModelResponseSerialization:
+    """POST /model/block and /model/unblock return the raw prisma row through this
+    route's `LiteLLM_ProxyModelTable | None` response validation. The row is not a
+    dict, so the dict-assuming before-validator used to raise AttributeError inside
+    FastAPI's serialization layer: a 500 for the caller after the DB write already
+    landed. The routes must serialize the row to a 200 with the updated blocked flag."""
+
+    @pytest.mark.parametrize(
+        ("route", "blocked"), [("/model/block", True), ("/model/unblock", False)]
+    )
+    def test_block_routes_serialize_prisma_row_to_200(self, route, blocked):
+        from datetime import datetime, timezone
+
+        from prisma import models as prisma_models
+
+        import litellm.proxy.proxy_server as ps
+        from litellm.proxy.proxy_server import app
+
+        written_at = datetime(2026, 8, 29, tzinfo=timezone.utc)
+        row_fields = {
+            "model_id": "m-block-1",
+            "model_name": "gpt-4o-mini",
+            "litellm_params": json.dumps({"model": "openai/gpt-4o-mini", "api_key": "encrypted-value"}),
+            "model_info": json.dumps({"id": "m-block-1"}),
+            "created_at": written_at,
+            "created_by": "admin",
+            "updated_at": written_at,
+            "updated_by": "admin",
+        }
+        existing_row = prisma_models.LiteLLM_ProxyModelTable(blocked=not blocked, **row_fields)
+        updated_row = prisma_models.LiteLLM_ProxyModelTable(blocked=blocked, **row_fields)
+
+        mock_prisma = MagicMock()
+        mock_prisma.db.litellm_proxymodeltable.find_unique = AsyncMock(return_value=existing_row)
+        mock_prisma.db.litellm_proxymodeltable.update = AsyncMock(return_value=updated_row)
+
+        admin = UserAPIKeyAuth(user_id="admin", user_role=LitellmUserRoles.PROXY_ADMIN)
+        app.dependency_overrides[ps.user_api_key_auth] = lambda: admin
+        try:
+            with (
+                patch("litellm.proxy.proxy_server.prisma_client", mock_prisma),  # test-quality-ok: proxy_server module global is the endpoint's only injection point
+                patch("litellm.proxy.proxy_server.store_model_in_db", True),  # test-quality-ok: proxy_server module global is the endpoint's only injection point
+                patch(  # test-quality-ok: proxy_server module global is the endpoint's only injection point
+                    "litellm.proxy.proxy_server.llm_router",
+                    MagicMock(**{"get_model_ids.return_value": ["m-block-1"]}),
+                ),
+                patch("litellm.proxy.proxy_server.redis_usage_cache", None),  # test-quality-ok: proxy_server module global is the endpoint's only injection point
+                patch(  # test-quality-ok: stubs the cache write so the test observes only response serialization
+                    "litellm.proxy.management_endpoints.model_management_endpoints.clear_cache",
+                    new=AsyncMock(return_value=ReconcileOutcome(still_desired=None, live_after=None)),
+                ),
+                patch(  # test-quality-ok: audit logging is a background side effect outside this test's contract
+                    "litellm.proxy.management_endpoints.model_management_endpoints.create_object_audit_log",
+                    new=AsyncMock(return_value=None),
+                ),
+            ):
+                client = TestClient(app)
+                response = client.post(route, json={"model_id": "m-block-1"})
+        finally:
+            app.dependency_overrides.pop(ps.user_api_key_auth, None)
+
+        assert response.status_code == 200, response.text
+        body = response.json()
+        assert body["model_id"] == "m-block-1"
+        assert body["blocked"] is blocked
+        assert body["litellm_params"] == {"model": "openai/gpt-4o-mini", "api_key": "encrypted-value"}

--- a/tests/test_litellm/proxy/management_endpoints/test_model_management_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_model_management_endpoints.py
@@ -4469,12 +4469,6 @@ class TestEnforceRpmTpmOnModelAdd:
 
 
 class TestBlockModelResponseSerialization:
-    """POST /model/block and /model/unblock return the raw prisma row through this
-    route's `LiteLLM_ProxyModelTable | None` response validation. The row is not a
-    dict, so the dict-assuming before-validator used to raise AttributeError inside
-    FastAPI's serialization layer: a 500 for the caller after the DB write already
-    landed. The routes must serialize the row to a 200 with the updated blocked flag."""
-
     @pytest.mark.parametrize(
         ("route", "blocked"), [("/model/block", True), ("/model/unblock", False)]
     )


### PR DESCRIPTION
## TLDR

Problem this solves:

- POST /model/block and /model/unblock answer 500 on every call
- The write still lands, so callers see failure for a change that applied

How it solves it:

- The row's pre-validation step now passes non-dict input through untouched
- Route-level regression test plus response assertions in the existing e2e test

## User Flow

Before: a proxy admin blocks a model and gets a 500, even though the block actually applied

1. The admin creates a DB model: POST https://litellm-domain/model/new with a model_name and litellm_params, and gets back a 200 with a new model id
2. A developer sends POST https://litellm-domain/v1/chat/completions with that model and gets a 200 completion
3. The admin blocks it: POST https://litellm-domain/model/block with `{"model_id": "..."}` returns HTTP 500 `{"error":{"message":"Internal server error","type":"internal_server_error"}}`
4. The developer's same completion request now returns 403 "Model is blocked", so the admin's 500 was wrong: the block landed
5. The admin unblocks: POST https://litellm-domain/model/unblock with the same body returns HTTP 500 again, while the developer's completions quietly return 200 again

After: the same block and unblock calls return 200 with the updated model row

1. The admin creates a DB model: POST https://litellm-domain/model/new with a model_name and litellm_params, and gets back a 200 with a new model id
2. A developer sends POST https://litellm-domain/v1/chat/completions with that model and gets a 200 completion
3. The admin blocks it: POST https://litellm-domain/model/block with `{"model_id": "..."}` returns HTTP 200 with the model row showing `"blocked": true`
4. The developer's same completion request returns 403 "Model is blocked", matching what the admin was told
5. The admin unblocks: POST https://litellm-domain/model/unblock with the same body returns HTTP 200 with `"blocked": false`, and the developer's completions return 200 again

## Relevant issues

Fixes #35597

Supersedes #35598 (its commit is carried here with the author's attribution intact) and #37808, which proposed the same two-line guard

## Linear ticket

Resolves LIT-6515

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Shared setup for both legs: a live proxy from the leg's commit with `--num_workers 2`, a fresh Postgres DB each, `store_model_in_db: true`, one config model `gpt-4o-mini` (`openai/gpt-4o-mini`), and real OpenAI calls. `$MASTER_KEY` is the proxy master key; the before leg ran on port 27412, the after leg on port 28931 (shown as `$PORT`). Steps 2, 4, and 6 send the same request. Tip 739f61df7d only deletes a test docstring, so the proof below at fd72ae830c carries over:

```bash
curl -sS -w "\nHTTP %{http_code}\n" -X POST http://127.0.0.1:$PORT/v1/chat/completions \
  -H "Authorization: Bearer $MASTER_KEY" -H "Content-Type: application/json" \
  -d '{"model": "qa-gpt-4o-mini", "messages": [{"role": "user", "content": "Reply with exactly: qa-1"}]}'
```

### Before (d44d281d1d)

1. Create a DB model:
   ```bash
   curl -sS -X POST http://127.0.0.1:$PORT/model/new -H "Authorization: Bearer $MASTER_KEY" -H "Content-Type: application/json" \
     -d '{"model_name": "qa-gpt-4o-mini", "litellm_params": {"model": "openai/gpt-4o-mini", "api_key": "os.environ/OPENAI_API_KEY"}}'
   ```
   Returned model id `5c6df97a-fbf3-4f88-865a-7178673cf564`
2. Completion while unblocked: `HTTP 200`, content `qa-before-1` (real OpenAI call)
3. Block it:
   ```bash
   curl -sS -w "\nHTTP %{http_code}\n" -X POST http://127.0.0.1:$PORT/model/block -H "Authorization: Bearer $MASTER_KEY" -H "Content-Type: application/json" \
     -d '{"model_id": "5c6df97a-fbf3-4f88-865a-7178673cf564"}'
   ```
   ```
   {"error":{"message":"Internal server error","type":"internal_server_error"}}
   HTTP 500
   ```
4. Completion again: `HTTP 403` `{"error":{"message":"litellm.PermissionDeniedError: Model is blocked","type":null,"param":null,"code":"403"}}`, so the block landed despite the 500
5. Unblock with the same body:
   ```
   {"error":{"message":"Internal server error","type":"internal_server_error"}}
   HTTP 500
   ```
6. Completion again: `HTTP 200`, content `qa-before-3`, so the unblock landed despite its 500

### After (fd72ae830c)

1. Same `POST /model/new`: returned model id `cb76bd10-80c8-45b7-aefe-b92eb7442521`
2. Completion while unblocked: `HTTP 200`, content `qa-after-1` (real OpenAI call)
3. Same `POST /model/block`:
   ```
   {"model_id":"cb76bd10-80c8-45b7-aefe-b92eb7442521","model_name":"qa-gpt-4o-mini","litellm_params":{"model":"MypuTmiM_9qedrYuEnY29DvRAUs0k11h979og5S9ujoNbHWIaFe4diCp-7m6a6-_1j2_GNGRFdmOyw==","api_key":"rOvCzmL1crcPpmIKtLQ3y_mwb-gt-6w0phrxSQPkELHn1amE_1aiJW4L826iXTvj-qLOITrrI2osy1RwDOfYRDM=","use_xai_oauth":false,"use_litellm_proxy":false,"use_in_pass_through":false,"allow_client_keepalive_override":false,"merge_reasoning_content_in_choices":false},"model_info":{"id":"cb76bd10-80c8-45b7-aefe-b92eb7442521","db_model":false},"blocked":true,...}
   HTTP 200
   ```
4. Completion again: `HTTP 403` `Model is blocked`, same enforcement as before
5. Same `POST /model/unblock`: `HTTP 200` with the row showing `"blocked":false`
6. Completion again: `HTTP 200`, content `qa-after-3`

Observations from the run:

- litellm_params values in the 200 body are encrypted; sibling routes do the same
- Before leg: block enforced (403) even though the call 500'd

## Type

🐛 Bug Fix

## Caveats (if any)

### Low

- The 200 response carries encrypted litellm_params values, matching sibling model routes
- Other pods learn the blocked flag on their poll interval (pre-existing)

## QA runbook

- tests/e2e/management/test_model_tag_accessgroup_e2e.py::TestModelRoutes::test_block_then_unblock_persists_to_model_info - block and unblock answer 200 with the toggled flag and the flag persists to /model/info
  - [ ] POST /model/new with the master key and any model to get a model id (needs STORE_MODEL_IN_DB=True)
  - [ ] POST /model/block with `{"model_id": "<id>"}` and expect 200 with `"blocked": true` in the body
  - [ ] GET /model/info and expect that id's model_info to report blocked true
  - [ ] POST /model/unblock with the same body and expect 200 with `"blocked": false`
  - [ ] GET /model/info and expect that id's model_info to report blocked false or unset
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey (e.g., assert actual expected spend instead of just spend > 0) or potentially flaky

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

- [x] fd72ae830c passes /live-pr-risk (carries to 739f61df7d, a comment-only commit): no dependents beyond the two fixed routes, CircleCI suites green, merges clean with current staging

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow validator guard on one domain model plus test coverage; no auth or persistence logic changes beyond fixing response serialization for two admin routes.
> 
> **Overview**
> **POST `/model/block` and `/model/unblock` now return HTTP 200** with the updated model row (including the toggled `blocked` flag) instead of 500, while the DB write behavior is unchanged.
> 
> The fix is in `LiteLLM_ProxyModelTable`’s `check_potential_json_str` **before** validator: it **no longer assumes dict input** and passes non-dicts through unchanged. That lets Pydantic validate Prisma ORM rows via `from_attributes` without the JSON-string coercion path blowing up during response serialization.
> 
> Tests add a **route-level regression** (mocked Prisma → 200 + parsed `litellm_params`), a **model `TypeAdapter` case** for attribute-backed rows, and **e2e assertions** on typed block/unblock responses—not only `/model/info` read-back.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 739f61df7dff60e6f37d847bcd6015a9346e29de. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->