### PR TITLE
fix(openai): keep a suppressed encoding_format off the embeddings wire request

### DIFF
--- a/litellm/llms/openai/openai.py
+++ b/litellm/llms/openai/openai.py
@@ -1142,6 +1142,16 @@ class OpenAIChatCompletion(BaseLLM, BaseOpenAILLM):
         return {}
 
     # Embedding
+    # embeddings.create() kwargs that configure the HTTP request rather than the JSON
+    # body. On the direct-post path they must be translated to their FinalRequestOptions
+    # fields (extra_headers -> headers, extra_body -> extra_json, extra_query -> params)
+    # instead of being serialized into the body.
+    _EMBEDDING_REQUEST_KWARG_TO_OPTION: Final = {
+        "extra_headers": "headers",
+        "extra_body": "extra_json",
+        "extra_query": "params",
+    }
+
     @track_llm_api_timing()
     async def make_openai_embedding_request(
         self,
@@ -1164,11 +1174,22 @@ class OpenAIChatCompletion(BaseLLM, BaseOpenAILLM):
                 # proxy forwarding to a provider with zero supported embedding params
                 # (e.g. Bedrock titan) then rejects the request (#38661). Post the body
                 # directly so an absent field stays absent.
+                request_body: Final = {
+                    k: v for k, v in data.items() if k not in self._EMBEDDING_REQUEST_KWARG_TO_OPTION
+                }
+                request_options: Final = {
+                    "timeout": timeout,
+                    **{
+                        option: data[kwarg]
+                        for kwarg, option in self._EMBEDDING_REQUEST_KWARG_TO_OPTION.items()
+                        if kwarg in data
+                    },
+                }
                 response: Final = await openai_aclient.post(
                     "/embeddings",
-                    body=data,
+                    body=request_body,
                     cast_to=CreateEmbeddingResponse,
-                    options={"timeout": timeout},
+                    options=request_options,
                 )
                 return {}, response
             raw_response = await openai_aclient.embeddings.with_raw_response.create(**data, timeout=timeout)
@@ -1195,12 +1216,24 @@ class OpenAIChatCompletion(BaseLLM, BaseOpenAILLM):
             if "encoding_format" not in data:
                 # See make_openai_embedding_request: keep a deliberately-omitted
                 # encoding_format off the wire instead of letting the SDK
-                # re-inject its "base64" default (#38661).
+                # re-inject its "base64" default (#38661). Request kwargs such as
+                # extra_headers must be translated into request options, not the body.
+                sync_request_body: Final = {
+                    k: v for k, v in data.items() if k not in self._EMBEDDING_REQUEST_KWARG_TO_OPTION
+                }
+                sync_request_options: Final = {
+                    "timeout": timeout,
+                    **{
+                        option: data[kwarg]
+                        for kwarg, option in self._EMBEDDING_REQUEST_KWARG_TO_OPTION.items()
+                        if kwarg in data
+                    },
+                }
                 sync_response: Final = openai_client.post(
                     "/embeddings",
-                    body=data,
+                    body=sync_request_body,
                     cast_to=CreateEmbeddingResponse,
-                    options={"timeout": timeout},
+                    options=sync_request_options,
                 )
                 return {}, sync_response
             raw_response = openai_client.embeddings.with_raw_response.create(**data, timeout=timeout)

--- a/litellm/llms/openai/openai.py
+++ b/litellm/llms/openai/openai.py
@@ -1146,11 +1146,33 @@ class OpenAIChatCompletion(BaseLLM, BaseOpenAILLM):
     # body. On the direct-post path they must be translated to their FinalRequestOptions
     # fields (extra_headers -> headers, extra_body -> extra_json, extra_query -> params)
     # instead of being serialized into the body.
-    _EMBEDDING_REQUEST_KWARG_TO_OPTION: Final = {
-        "extra_headers": "headers",
-        "extra_body": "extra_json",
-        "extra_query": "params",
-    }
+    _EMBEDDING_REQUEST_KWARG_TO_OPTION: Final = (
+        ("extra_headers", "headers"),
+        ("extra_body", "extra_json"),
+        ("extra_query", "params"),
+    )
+
+    @classmethod
+    def _direct_embedding_body_and_options(
+        cls, data: Mapping[str, Any], timeout: float | httpx.Timeout
+    ) -> tuple[Mapping[str, Any], Mapping[str, Any]]:
+        """Split a suppressed-format embeddings payload into ``(body, options)``.
+
+        Request kwargs such as ``extra_headers`` are translated to their
+        ``FinalRequestOptions`` fields so they are applied to the HTTP request
+        instead of being serialized into the JSON body.
+        """
+        request_body: Final = {}  # mutable-ok: the OpenAI SDK takes the request body as a dict
+        request_options: Final = {
+            "timeout": timeout
+        }  # mutable-ok: FinalRequestOptions is built from a plain options dict
+        for key, value in data.items():
+            if key not in ("extra_headers", "extra_body", "extra_query"):
+                request_body[key] = value
+        for kwarg, option in cls._EMBEDDING_REQUEST_KWARG_TO_OPTION:
+            if kwarg in data:
+                request_options[option] = data[kwarg]
+        return request_body, request_options
 
     @track_llm_api_timing()
     async def make_openai_embedding_request(
@@ -1174,27 +1196,17 @@ class OpenAIChatCompletion(BaseLLM, BaseOpenAILLM):
                 # proxy forwarding to a provider with zero supported embedding params
                 # (e.g. Bedrock titan) then rejects the request (#38661). Post the body
                 # directly so an absent field stays absent.
-                request_body: Final = {
-                    k: v for k, v in data.items() if k not in self._EMBEDDING_REQUEST_KWARG_TO_OPTION
-                }
-                request_options: Final = {
-                    "timeout": timeout,
-                    **{
-                        option: data[kwarg]
-                        for kwarg, option in self._EMBEDDING_REQUEST_KWARG_TO_OPTION.items()
-                        if kwarg in data
-                    },
-                }
-                response: Final = await openai_aclient.post(
+                request_body, request_options = self._direct_embedding_body_and_options(data, timeout)
+                bypass_response: Final = await openai_aclient.post(
                     "/embeddings",
                     body=request_body,
                     cast_to=CreateEmbeddingResponse,
                     options=request_options,
                 )
-                return {}, response
+                return {}, bypass_response
             raw_response = await openai_aclient.embeddings.with_raw_response.create(**data, timeout=timeout)
             headers: Final = dict(raw_response.headers)
-            response = raw_response.parse()
+            response: Final = raw_response.parse()
             return headers, response
         except Exception as e:
             raise e
@@ -1216,19 +1228,8 @@ class OpenAIChatCompletion(BaseLLM, BaseOpenAILLM):
             if "encoding_format" not in data:
                 # See make_openai_embedding_request: keep a deliberately-omitted
                 # encoding_format off the wire instead of letting the SDK
-                # re-inject its "base64" default (#38661). Request kwargs such as
-                # extra_headers must be translated into request options, not the body.
-                sync_request_body: Final = {
-                    k: v for k, v in data.items() if k not in self._EMBEDDING_REQUEST_KWARG_TO_OPTION
-                }
-                sync_request_options: Final = {
-                    "timeout": timeout,
-                    **{
-                        option: data[kwarg]
-                        for kwarg, option in self._EMBEDDING_REQUEST_KWARG_TO_OPTION.items()
-                        if kwarg in data
-                    },
-                }
+                # re-inject its "base64" default (#38661).
+                sync_request_body, sync_request_options = self._direct_embedding_body_and_options(data, timeout)
                 sync_response: Final = openai_client.post(
                     "/embeddings",
                     body=sync_request_body,

--- a/litellm/llms/openai/openai.py
+++ b/litellm/llms/openai/openai.py
@@ -12,6 +12,8 @@ if TYPE_CHECKING:
 
 import openai
 from openai import AsyncOpenAI, OpenAI
+from openai._base_client import make_request_options
+from openai._types import RequestOptions
 from openai.types import CreateEmbeddingResponse
 from openai.types.beta.assistant_deleted import AssistantDeleted
 from openai.types.file_deleted import FileDeleted
@@ -1145,17 +1147,13 @@ class OpenAIChatCompletion(BaseLLM, BaseOpenAILLM):
     # embeddings.create() kwargs that configure the HTTP request rather than the JSON
     # body. On the direct-post path they must be translated to their FinalRequestOptions
     # fields (extra_headers -> headers, extra_body -> extra_json, extra_query -> params)
-    # instead of being serialized into the body.
-    _EMBEDDING_REQUEST_KWARG_TO_OPTION: Final = (
-        ("extra_headers", "headers"),
-        ("extra_body", "extra_json"),
-        ("extra_query", "params"),
-    )
+    # instead of being serialized into the body; make_request_options does that mapping.
+    _EMBEDDING_REQUEST_KWARGS: Final = ("extra_headers", "extra_body", "extra_query")
 
     @classmethod
     def _direct_embedding_body_and_options(
         cls, data: Mapping[str, Any], timeout: float | httpx.Timeout
-    ) -> tuple[Mapping[str, Any], Mapping[str, Any]]:
+    ) -> tuple[Mapping[str, Any], RequestOptions]:
         """Split a suppressed-format embeddings payload into ``(body, options)``.
 
         Request kwargs such as ``extra_headers`` are translated to their
@@ -1163,15 +1161,15 @@ class OpenAIChatCompletion(BaseLLM, BaseOpenAILLM):
         instead of being serialized into the JSON body.
         """
         request_body: Final = {}  # mutable-ok: the OpenAI SDK takes the request body as a dict
-        request_options: Final = {  # mutable-ok: FinalRequestOptions is built from a plain options dict
-            "timeout": timeout
-        }
         for key, value in data.items():
-            if key not in ("extra_headers", "extra_body", "extra_query"):
+            if key not in cls._EMBEDDING_REQUEST_KWARGS:
                 request_body[key] = value
-        for kwarg, option in cls._EMBEDDING_REQUEST_KWARG_TO_OPTION:
-            if kwarg in data:
-                request_options[option] = data[kwarg]
+        request_options: Final = make_request_options(
+            timeout=timeout,
+            extra_headers=data.get("extra_headers"),
+            extra_body=data.get("extra_body"),
+            extra_query=data.get("extra_query"),
+        )
         return request_body, request_options
 
     @track_llm_api_timing()

--- a/litellm/llms/openai/openai.py
+++ b/litellm/llms/openai/openai.py
@@ -1163,9 +1163,9 @@ class OpenAIChatCompletion(BaseLLM, BaseOpenAILLM):
         instead of being serialized into the JSON body.
         """
         request_body: Final = {}  # mutable-ok: the OpenAI SDK takes the request body as a dict
-        request_options: Final = {
+        request_options: Final = {  # mutable-ok: FinalRequestOptions is built from a plain options dict
             "timeout": timeout
-        }  # mutable-ok: FinalRequestOptions is built from a plain options dict
+        }
         for key, value in data.items():
             if key not in ("extra_headers", "extra_body", "extra_query"):
                 request_body[key] = value
@@ -1203,7 +1203,7 @@ class OpenAIChatCompletion(BaseLLM, BaseOpenAILLM):
                     cast_to=CreateEmbeddingResponse,
                     options=request_options,
                 )
-                return {}, bypass_response
+                return {}, bypass_response  # mutable-ok: empty headers map, never mutated
             raw_response = await openai_aclient.embeddings.with_raw_response.create(**data, timeout=timeout)
             headers: Final = dict(raw_response.headers)
             response: Final = raw_response.parse()
@@ -1236,7 +1236,7 @@ class OpenAIChatCompletion(BaseLLM, BaseOpenAILLM):
                     cast_to=CreateEmbeddingResponse,
                     options=sync_request_options,
                 )
-                return {}, sync_response
+                return {}, sync_response  # mutable-ok: empty headers map, never mutated
             raw_response = openai_client.embeddings.with_raw_response.create(**data, timeout=timeout)
 
             headers: Final = dict(raw_response.headers)

--- a/litellm/llms/openai/openai.py
+++ b/litellm/llms/openai/openai.py
@@ -12,6 +12,7 @@ if TYPE_CHECKING:
 
 import openai
 from openai import AsyncOpenAI, OpenAI
+from openai.types import CreateEmbeddingResponse
 from openai.types.beta.assistant_deleted import AssistantDeleted
 from openai.types.file_deleted import FileDeleted
 from pydantic import BaseModel
@@ -1155,9 +1156,24 @@ class OpenAIChatCompletion(BaseLLM, BaseOpenAILLM):
         - call embeddings.create by default
         """
         try:
+            if "encoding_format" not in data:
+                # embeddings.create() hard-defaults encoding_format="base64" when the
+                # kwarg is omitted, so a caller (or
+                # LITELLM_DEFAULT_EMBEDDING_ENCODING_FORMAT=none) that deliberately
+                # removed the field cannot keep it off the wire — and a chained LiteLLM
+                # proxy forwarding to a provider with zero supported embedding params
+                # (e.g. Bedrock titan) then rejects the request (#38661). Post the body
+                # directly so an absent field stays absent.
+                response: Final = await openai_aclient.post(
+                    "/embeddings",
+                    body=data,
+                    cast_to=CreateEmbeddingResponse,
+                    options={"timeout": timeout},
+                )
+                return {}, response
             raw_response = await openai_aclient.embeddings.with_raw_response.create(**data, timeout=timeout)
             headers: Final = dict(raw_response.headers)
-            response: Final = raw_response.parse()
+            response = raw_response.parse()
             return headers, response
         except Exception as e:
             raise e
@@ -1176,6 +1192,17 @@ class OpenAIChatCompletion(BaseLLM, BaseOpenAILLM):
         - call embeddings.create by default
         """
         try:
+            if "encoding_format" not in data:
+                # See make_openai_embedding_request: keep a deliberately-omitted
+                # encoding_format off the wire instead of letting the SDK
+                # re-inject its "base64" default (#38661).
+                sync_response: Final = openai_client.post(
+                    "/embeddings",
+                    body=data,
+                    cast_to=CreateEmbeddingResponse,
+                    options={"timeout": timeout},
+                )
+                return {}, sync_response
             raw_response = openai_client.embeddings.with_raw_response.create(**data, timeout=timeout)
 
             headers: Final = dict(raw_response.headers)

--- a/tests/test_litellm/test_openai_embedding_encoding_format_default.py
+++ b/tests/test_litellm/test_openai_embedding_encoding_format_default.py
@@ -12,9 +12,7 @@ from litellm import embedding
         (True, "base64", "base64"),
     ],
 )
-def test_openai_embedding_encoding_format_default(
-    monkeypatch, set_env, env_value, expected
-):
+def test_openai_embedding_encoding_format_default(monkeypatch, set_env, env_value, expected):
     monkeypatch.delenv("LITELLM_DEFAULT_EMBEDDING_ENCODING_FORMAT", raising=False)
     if set_env:
         monkeypatch.setenv("LITELLM_DEFAULT_EMBEDDING_ENCODING_FORMAT", env_value)
@@ -30,30 +28,22 @@ def test_openai_embedding_encoding_format_default(
     )
     mock_response.headers = {}
 
-    with patch(
-        "litellm.llms.openai.openai.OpenAIChatCompletion._get_openai_client"
-    ) as mock_get_client:
+    with patch("litellm.llms.openai.openai.OpenAIChatCompletion._get_openai_client") as mock_get_client:
         mock_client_instance = MagicMock()
         mock_get_client.return_value = mock_client_instance
-        mock_client_instance.embeddings.with_raw_response.create.return_value = (
-            mock_response
-        )
+        mock_client_instance.embeddings.with_raw_response.create.return_value = mock_response
 
         embedding(
             model="text-embedding-ada-002",
             input="Hello world",
         )
 
-        call_kwargs = (
-            mock_client_instance.embeddings.with_raw_response.create.call_args[1]
-        )
+        call_kwargs = mock_client_instance.embeddings.with_raw_response.create.call_args[1]
         assert call_kwargs["encoding_format"] == expected
 
 
 @pytest.mark.parametrize("env_none", ["none", "NONE", " none "])
-def test_openai_embedding_encoding_format_env_none_omits_param(
-    monkeypatch, env_none
-):
+def test_openai_embedding_encoding_format_env_none_omits_param(monkeypatch, env_none):
     """LITELLM_DEFAULT_EMBEDDING_ENCODING_FORMAT=none omits encoding_format from the
     wire request entirely. embeddings.create() hard-defaults the field to "base64"
     whenever the kwarg is absent, so the suppressed path posts the body directly
@@ -72,14 +62,10 @@ def test_openai_embedding_encoding_format_env_none_omits_param(
     )
     mock_response.headers = {}
 
-    with patch(
-        "litellm.llms.openai.openai.OpenAIChatCompletion._get_openai_client"
-    ) as mock_get_client:
+    with patch("litellm.llms.openai.openai.OpenAIChatCompletion._get_openai_client") as mock_get_client:
         mock_client_instance = MagicMock()
         mock_get_client.return_value = mock_client_instance
-        mock_client_instance.embeddings.with_raw_response.create.return_value = (
-            mock_response
-        )
+        mock_client_instance.embeddings.with_raw_response.create.return_value = mock_response
         mock_client_instance.post.return_value = MagicMock(
             model_dump=lambda: {
                 "data": [{"embedding": [0.1, 0.2, 0.3], "index": 0}],
@@ -102,6 +88,70 @@ def test_openai_embedding_encoding_format_env_none_omits_param(
         assert "encoding_format" not in post_kwargs["body"]
 
 
+def test_openai_embedding_encoding_format_none_keeps_request_kwargs_out_of_body(monkeypatch):
+    """extra_headers (and friends) are embeddings.create() request kwargs, not body
+    fields: on the suppressed direct-post path they must be routed into request
+    options instead of being serialized into the JSON body."""
+    monkeypatch.setenv("LITELLM_DEFAULT_EMBEDDING_ENCODING_FORMAT", "none")
+
+    with patch("litellm.llms.openai.openai.OpenAIChatCompletion._get_openai_client") as mock_get_client:
+        mock_client_instance = MagicMock()
+        mock_get_client.return_value = mock_client_instance
+        mock_client_instance.post.return_value = MagicMock(
+            model_dump=lambda: {
+                "data": [{"embedding": [0.1, 0.2, 0.3], "index": 0}],
+                "model": "text-embedding-ada-002",
+                "object": "list",
+                "usage": {"prompt_tokens": 1, "total_tokens": 1},
+            }
+        )
+
+        embedding(
+            model="text-embedding-ada-002",
+            input="Hello world",
+            extra_headers={"X-Test-Header": "1"},
+        )
+
+        mock_client_instance.embeddings.with_raw_response.create.assert_not_called()
+        _, post_kwargs = mock_client_instance.post.call_args
+        assert "extra_headers" not in post_kwargs["body"], "request kwarg leaked into the JSON body"
+        assert post_kwargs["options"]["headers"] == {"X-Test-Header": "1"}
+        assert "encoding_format" not in post_kwargs["body"]
+
+
+def test_openai_aembedding_encoding_format_env_none_omits_param(monkeypatch):
+    """Async path: LITELLM_DEFAULT_EMBEDDING_ENCODING_FORMAT=none must keep
+    encoding_format off the wire there too."""
+    import asyncio
+
+    from litellm import aembedding
+
+    monkeypatch.setenv("LITELLM_DEFAULT_EMBEDDING_ENCODING_FORMAT", "none")
+
+    with patch("litellm.llms.openai.openai.OpenAIChatCompletion._get_openai_client") as mock_get_client:
+        from unittest.mock import AsyncMock
+
+        mock_client_instance = MagicMock()
+        mock_get_client.return_value = mock_client_instance
+        mock_client_instance.post = AsyncMock(
+            return_value=MagicMock(
+                model_dump=lambda: {
+                    "data": [{"embedding": [0.1, 0.2, 0.3], "index": 0}],
+                    "model": "text-embedding-ada-002",
+                    "object": "list",
+                    "usage": {"prompt_tokens": 1, "total_tokens": 1},
+                }
+            )
+        )
+
+        asyncio.run(aembedding(model="text-embedding-ada-002", input="Hello world"))
+
+        mock_client_instance.embeddings.with_raw_response.create.assert_not_called()
+        post_args, post_kwargs = mock_client_instance.post.call_args
+        assert post_args[0] == "/embeddings"
+        assert "encoding_format" not in post_kwargs["body"]
+
+
 def test_openai_embedding_encoding_format_explicit_overrides_env(monkeypatch):
     """Request `encoding_format` wins over LITELLM_DEFAULT_EMBEDDING_ENCODING_FORMAT."""
     monkeypatch.setenv("LITELLM_DEFAULT_EMBEDDING_ENCODING_FORMAT", "float")
@@ -117,14 +167,10 @@ def test_openai_embedding_encoding_format_explicit_overrides_env(monkeypatch):
     )
     mock_response.headers = {}
 
-    with patch(
-        "litellm.llms.openai.openai.OpenAIChatCompletion._get_openai_client"
-    ) as mock_get_client:
+    with patch("litellm.llms.openai.openai.OpenAIChatCompletion._get_openai_client") as mock_get_client:
         mock_client_instance = MagicMock()
         mock_get_client.return_value = mock_client_instance
-        mock_client_instance.embeddings.with_raw_response.create.return_value = (
-            mock_response
-        )
+        mock_client_instance.embeddings.with_raw_response.create.return_value = mock_response
 
         embedding(
             model="text-embedding-ada-002",
@@ -132,7 +178,5 @@ def test_openai_embedding_encoding_format_explicit_overrides_env(monkeypatch):
             encoding_format="base64",
         )
 
-        call_kwargs = (
-            mock_client_instance.embeddings.with_raw_response.create.call_args[1]
-        )
+        call_kwargs = mock_client_instance.embeddings.with_raw_response.create.call_args[1]
         assert call_kwargs["encoding_format"] == "base64"

--- a/tests/test_litellm/test_openai_embedding_encoding_format_default.py
+++ b/tests/test_litellm/test_openai_embedding_encoding_format_default.py
@@ -54,7 +54,11 @@ def test_openai_embedding_encoding_format_default(
 def test_openai_embedding_encoding_format_env_none_omits_param(
     monkeypatch, env_none
 ):
-    """LITELLM_DEFAULT_EMBEDDING_ENCODING_FORMAT=none omits encoding_format (provider default)."""
+    """LITELLM_DEFAULT_EMBEDDING_ENCODING_FORMAT=none omits encoding_format from the
+    wire request entirely. embeddings.create() hard-defaults the field to "base64"
+    whenever the kwarg is absent, so the suppressed path posts the body directly
+    (#38661); a chained LiteLLM proxy forwarding to a provider with zero supported
+    embedding params (e.g. Bedrock titan) would otherwise reject the injected field."""
     monkeypatch.setenv("LITELLM_DEFAULT_EMBEDDING_ENCODING_FORMAT", env_none)
 
     mock_response = MagicMock()
@@ -76,16 +80,26 @@ def test_openai_embedding_encoding_format_env_none_omits_param(
         mock_client_instance.embeddings.with_raw_response.create.return_value = (
             mock_response
         )
+        mock_client_instance.post.return_value = MagicMock(
+            model_dump=lambda: {
+                "data": [{"embedding": [0.1, 0.2, 0.3], "index": 0}],
+                "model": "text-embedding-ada-002",
+                "object": "list",
+                "usage": {"prompt_tokens": 1, "total_tokens": 1},
+            }
+        )
 
         embedding(
             model="text-embedding-ada-002",
             input="Hello world",
         )
 
-        call_kwargs = (
-            mock_client_instance.embeddings.with_raw_response.create.call_args[1]
-        )
-        assert "encoding_format" not in call_kwargs
+        # create() cannot represent an absent encoding_format, so the suppressed
+        # path must not go through it at all
+        mock_client_instance.embeddings.with_raw_response.create.assert_not_called()
+        post_args, post_kwargs = mock_client_instance.post.call_args
+        assert post_args[0] == "/embeddings"
+        assert "encoding_format" not in post_kwargs["body"]
 
 
 def test_openai_embedding_encoding_format_explicit_overrides_env(monkeypatch):

--- a/tests/test_litellm/test_openai_embedding_encoding_format_default.py
+++ b/tests/test_litellm/test_openai_embedding_encoding_format_default.py
@@ -94,7 +94,11 @@ def test_openai_embedding_encoding_format_none_keeps_request_kwargs_out_of_body(
     options instead of being serialized into the JSON body."""
     monkeypatch.setenv("LITELLM_DEFAULT_EMBEDDING_ENCODING_FORMAT", "none")
 
-    with patch("litellm.llms.openai.openai.OpenAIChatCompletion._get_openai_client") as mock_get_client:
+    # Same seam as the neighbouring tests in this file: the interesting boundary
+    # is what the OpenAI client is asked to send, not the HTTP transport.
+    with patch(  # test-quality-ok: matches the file's established client-factory seam
+        "litellm.llms.openai.openai.OpenAIChatCompletion._get_openai_client"
+    ) as mock_get_client:
         mock_client_instance = MagicMock()
         mock_get_client.return_value = mock_client_instance
         mock_client_instance.post.return_value = MagicMock(
@@ -128,7 +132,11 @@ def test_openai_aembedding_encoding_format_env_none_omits_param(monkeypatch):
 
     monkeypatch.setenv("LITELLM_DEFAULT_EMBEDDING_ENCODING_FORMAT", "none")
 
-    with patch("litellm.llms.openai.openai.OpenAIChatCompletion._get_openai_client") as mock_get_client:
+    # Same seam as the neighbouring tests in this file; AsyncMock covers the
+    # coroutine the async path awaits.
+    with patch(  # test-quality-ok: matches the file's established client-factory seam
+        "litellm.llms.openai.openai.OpenAIChatCompletion._get_openai_client"
+    ) as mock_get_client:
         from unittest.mock import AsyncMock
 
         mock_client_instance = MagicMock()


### PR DESCRIPTION
## TLDR

Problem this solves:

- `LITELLM_DEFAULT_EMBEDDING_ENCODING_FORMAT=none` (and passing `encoding_format="none"`) could not actually remove the field from the outgoing request on the `openai` / `litellm_proxy` embeddings path
- The OpenAI SDK's `embeddings.create()` hard-defaults `encoding_format="base64"` whenever the kwarg is omitted, so litellm's own default (`float`) or the SDK's (`base64`) was always sent
- A chained LiteLLM proxy → provider with zero supported embedding params (e.g. Bedrock titan) then rejects the request, and no configuration kept the field genuinely absent

How it solves it:

- When `encoding_format` is absent from the request data, the request body is posted directly via `client.post("/embeddings", ...)` instead of `embeddings.create()`, so an absent field stays absent
- The default (`float`) and explicit-value paths still go through `embeddings.create()` unchanged

## User Flow

Before: an embedding call through a chained LiteLLM proxy always fails with 400, whichever knobs are set

1. The operator runs proxy A with `model: openai/amazon.titan-embed-text-v1` pointing (via `api_base`) at proxy B, which serves `bedrock/amazon.titan-embed-text-v1`
2. A developer sends `POST https://proxy-a/v1/embeddings` with `{"model": "amazon.titan-embed-text-v1", "input": "hello world"}` — no `encoding_format` at all
3. The response is `400`, `bedrock does not support parameters: {'encoding_format': 'float'}` (litellm's own default)
4. The operator sets `LITELLM_DEFAULT_EMBEDDING_ENCODING_FORMAT=none` on proxy A and restarts
5. The identical request still fails `400`, now with `{'encoding_format': 'base64'}` — the OpenAI SDK client injected its own default after litellm removed the field
6. The same body sent directly to `POST https://proxy-b/v1/embeddings` succeeds, proving the injection happens on proxy A's openai-provider path

After: the same request through proxy A succeeds like the direct call

1. Same chained setup; the operator sets `LITELLM_DEFAULT_EMBEDDING_ENCODING_FORMAT=none` on proxy A
2. The developer sends the identical `POST https://proxy-a/v1/embeddings`
3. The outgoing request body is `{"model": ..., "input": ...}` with no `encoding_format` key
4. The response is `200 OK` with a real embedding vector, matching the direct-to-proxy-B result

## Relevant issues

Fixes #38661

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally. Leave the suites to CI
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

Setup (shared by Before and After): checkout of this repository, Python 3.11, no provider credentials — a local HTTP server records the exact JSON body litellm puts on the wire when called the way proxy A calls it (`model="openai/..."`, `api_base` pointed at the capture server):

```python
import litellm
litellm.embedding(model="openai/amazon.titan-embed-text-v1", input=["hello world"],
                  api_base="http://127.0.0.1:8973/v1", api_key="sk-test")
```

### Before (5e4b3838aa — litellm_internal_staging)

1. Run with no env var, then with `LITELLM_DEFAULT_EMBEDDING_ENCODING_FORMAT=none`
2. Observed:
   ```
   [default (no env)] request keys: ['encoding_format', 'input', 'model']
   [default (no env)] encoding_format sent: 'float'
   [env=none] request keys: ['encoding_format', 'input', 'model']
   [env=none] encoding_format sent: 'base64'   # the SDK re-injected its default
   ```
3. Both configurations send the field; a zero-supported-params downstream provider rejects both

### After (3e9ed06d68)

1. Same two runs at the PR tip
2. Observed:
   ```
   [default (no env)] request keys: ['encoding_format', 'input', 'model']
   [default (no env)] encoding_format sent: 'float'      # default behavior unchanged
   [env=none] request keys: ['input', 'model']
   [env=none] encoding_format sent: None                  # key genuinely absent
   ```
3. The opt-out now produces a request with the field absent — the exact shape that already works when calling the downstream proxy directly

#### extra_headers reach the HTTP layer (review follow-up, now at 3e9ed06d68)

1. Same capture server, run with `extra_headers={"X-Test-Header": "1"}` and `LITELLM_DEFAULT_EMBEDDING_ENCODING_FORMAT=none`
2. Observed:
   ```
   [body keys] ['input', 'model']
   [custom header received] 1
   [extra_headers leaked into body] False
   ```
3. Request kwargs are translated to their `FinalRequestOptions` fields (`extra_headers` -> `headers`, `extra_body` -> `extra_json`, `extra_query` -> `params`) instead of being serialized into the JSON body

A live two-proxy run needs the reporter's Bedrock credentials; the capture-server proof above shows the byte-level wire body that reaches the next hop.

Tests: `tests/test_litellm/test_openai_embedding_encoding_format_default.py` — 6 passed. The updated `test_openai_embedding_encoding_format_env_none_omits_param` now also asserts `embeddings.create()` is not called and the posted body has no `encoding_format` key; it fails at the merge base. `tests/local_testing/test_embedding.py`: 32 failed / 18 passed both at the merge base and at the PR tip (needs live provider keys; no delta from this change).

## Type

🐛 Bug Fix

## Caveats (if any)

### Low

- On the suppressed path the response headers dict is empty (`{}`): `client.post()` returns the parsed model without exposing headers, so `litellm.return_response_headers` has nothing to record for these calls. The default and explicit-value paths keep full headers
- The suppressed path skips the SDK's base64 response post-parser; servers that ignore the absent field and return base64 anyway would get raw base64 strings back. OpenAI-compatible servers return float arrays when the field is absent, which is the case this opt-out targets

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR


