### PR TITLE
fix(proxy): preserve model table columns on master key rotation

### DIFF
--- a/litellm/proxy/management_endpoints/key_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/key_management_endpoints.py
@@ -25,6 +25,7 @@ from typing import TYPE_CHECKING, Any, Final, Literal, Optional, Protocol, TypeV
 import fastapi
 import yaml
 from fastapi import APIRouter, Depends, Header, HTTPException, Query, Request, status
+from typing_extensions import ReadOnly, TypedDict
 
 import litellm
 from litellm._logging import verbose_proxy_logger
@@ -154,6 +155,7 @@ from litellm.types.utils import (
 )
 
 if TYPE_CHECKING:
+    import prisma
     from prisma import Prisma
     from prisma import models as prisma_models
 
@@ -179,6 +181,14 @@ class _UserRowLike(Protocol):
 
 class _TxTables(Protocol):
     litellm_proxymodeltable: TableActions[object]
+
+
+class _ModelParamsUpdate(TypedDict):
+    litellm_params: ReadOnly["prisma.Json"]
+
+
+class _ModelRowWhere(TypedDict):
+    model_id: ReadOnly[str]
 
 
 class _ConfigTableActions(Protocol):
@@ -4427,28 +4437,29 @@ async def _rotate_master_key(
     if models:
         decrypted_models: Final = proxy_config.decrypt_model_list_from_db(new_models=models)
         verbose_proxy_logger.debug("ABLE TO DECRYPT MODELS - len(decrypted_models): %s", len(decrypted_models))
-        new_models: Final[list[dict[str, object]]] = []
-        for model in decrypted_models:
-            new_model = await _add_model_to_db(
-                model_params=Deployment(**model),
-                user_api_key_dict=user_api_key_dict,
-                prisma_client=prisma_client,
-                new_encryption_key=new_master_key,
-                should_create_model_in_db=False,
-            )
-            if new_model:
-                _dumped = new_model.model_dump(exclude_none=True)
-                _dumped["litellm_params"] = prisma.Json(_dumped["litellm_params"])
-                _dumped["model_info"] = prisma.Json(_dumped["model_info"])
-                new_models.append(_dumped)
-        verbose_proxy_logger.debug("Resetting proxy model table")
-        async with prisma_client.db.tx() as tx_ctx:
+        reencrypted_models: Final = tuple(
+            [
+                reencrypted
+                for model in decrypted_models
+                if (
+                    reencrypted := await _add_model_to_db(
+                        model_params=Deployment(**model),
+                        user_api_key_dict=user_api_key_dict,
+                        prisma_client=prisma_client,
+                        new_encryption_key=new_master_key,
+                        should_create_model_in_db=False,
+                    )
+                )
+            ]
+        )
+        verbose_proxy_logger.debug("Re-encrypting litellm_params on %s model rows", len(reencrypted_models))
+        async with prisma_client.db.tx(timeout=timedelta(minutes=2)) as tx_ctx:
             tx: Final[_TxTables] = tx_ctx
-            await tx.litellm_proxymodeltable.delete_many()
-            verbose_proxy_logger.debug("Creating %s models", len(new_models))
-            await tx.litellm_proxymodeltable.create_many(
-                data=new_models,
-            )
+            for reencrypted_model in reencrypted_models:
+                await tx.litellm_proxymodeltable.update_many(
+                    data=_ModelParamsUpdate(litellm_params=prisma.Json(reencrypted_model.litellm_params)),
+                    where=_ModelRowWhere(model_id=reencrypted_model.model_id),
+                )
         await publish_config_change(redis_cache=coordination_redis_cache(), object_type="litellm_proxymodeltable")
     # 3. process config table
     try:

--- a/tests/test_litellm/proxy/management_endpoints/test_key_management_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_key_management_endpoints.py
@@ -8312,15 +8312,17 @@ async def test_key_does_not_override_explicit_budget_duration():
 @patch(
     "litellm.proxy.management_endpoints.key_management_endpoints.rotate_mcp_server_credentials_master_key"
 )
-async def test_rotate_master_key_model_data_valid_for_prisma(
+async def test_rotate_master_key_reencrypts_model_params_in_place(
     mock_rotate_mcp,
 ):
     """
-    Test that _rotate_master_key produces valid data for Prisma create_many().
-
-    Regression test for: master key rotation fails with Prisma validation error
-    because created_at/updated_at are None (non-nullable DateTime) and
-    litellm_params/model_info are JSON strings (create_many expects dicts).
+    Regression test for: master key rotation wipes every non-credential column
+    on LiteLLM_ProxyModelTable. Rotation used to rebuild the table via
+    delete_many + create_many from Deployment objects, which carry no
+    blocked/created_at/created_by/updated_at/updated_by, so every rotation
+    reset blocked to False (silently unblocking blocked models) and rewrote the
+    audit columns. Rotation must instead update only litellm_params (the sole
+    encrypted column) on each existing row, keyed by model_id.
     """
     from unittest.mock import AsyncMock, MagicMock
 
@@ -8352,6 +8354,7 @@ async def test_rotate_master_key_model_data_valid_for_prisma(
     mock_tx.litellm_proxymodeltable = MagicMock()
     mock_tx.litellm_proxymodeltable.delete_many = AsyncMock()
     mock_tx.litellm_proxymodeltable.create_many = AsyncMock()
+    mock_tx.litellm_proxymodeltable.update_many = AsyncMock()
     mock_prisma_client.db.tx = MagicMock(
         return_value=AsyncMock(
             __aenter__=AsyncMock(return_value=mock_tx),
@@ -8400,36 +8403,33 @@ async def test_rotate_master_key_model_data_valid_for_prisma(
             new_master_key="sk-new-master-key",
         )
 
-    # Verify create_many was called
-    mock_tx.litellm_proxymodeltable.create_many.assert_called_once()
+    # Rotation must never rewrite whole rows: no delete + recreate
+    mock_tx.litellm_proxymodeltable.delete_many.assert_not_called()
+    mock_tx.litellm_proxymodeltable.create_many.assert_not_called()
 
-    # Get the data passed to create_many
-    call_args = mock_tx.litellm_proxymodeltable.create_many.call_args
-    created_models = call_args.kwargs.get("data") or call_args[1].get("data")
+    mock_tx.litellm_proxymodeltable.update_many.assert_called_once()
+    call_args = mock_tx.litellm_proxymodeltable.update_many.call_args
 
-    assert len(created_models) == 1
-    model_data = created_models[0]
+    assert call_args.kwargs["where"] == {
+        "model_id": "model-1"
+    }, "the re-encrypted params must land on the same row, keyed by model_id"
 
-    # Verify timestamps are NOT present (Prisma @default(now()) should apply)
-    assert (
-        "created_at" not in model_data
-    ), "created_at should be excluded so Prisma @default(now()) applies"
-    assert (
-        "updated_at" not in model_data
-    ), "updated_at should be excluded so Prisma @default(now()) applies"
+    update_data = call_args.kwargs["data"]
+    assert set(update_data.keys()) == {"litellm_params"}, (
+        "rotation must touch only the encrypted litellm_params column; writing any "
+        f"other column wipes it (blocked, audit columns), got {sorted(update_data.keys())}"
+    )
 
-    # Verify litellm_params and model_info are prisma.Json wrappers, NOT JSON strings
     import prisma
 
     assert isinstance(
-        model_data["litellm_params"], prisma.Json
-    ), f"litellm_params should be prisma.Json for create_many(), got {type(model_data['litellm_params'])}"
-    assert isinstance(
-        model_data["model_info"], prisma.Json
-    ), f"model_info should be prisma.Json for create_many(), got {type(model_data['model_info'])}"
-
-    # Verify delete_many was called inside the transaction (before create_many)
-    mock_tx.litellm_proxymodeltable.delete_many.assert_called_once()
+        update_data["litellm_params"], prisma.Json
+    ), f"litellm_params should be prisma.Json for update_many(), got {type(update_data['litellm_params'])}"
+    reencrypted_params = update_data["litellm_params"].data
+    assert set(reencrypted_params.keys()) >= {"model", "api_key"}
+    assert (
+        reencrypted_params["api_key"] != "sk-decrypted-key"
+    ), "api_key must be stored re-encrypted under the new master key, not in plaintext"
 
 
 async def test_default_key_generate_params_duration(monkeypatch):


### PR DESCRIPTION
## TLDR

Problem this solves:

- Master key rotation set `blocked` back to false on every DB model row
- It also reset `created_at`/`updated_at`/`created_by`/`updated_by` on every row
- A model an admin had blocked silently started serving again after rotation

How it solves it:

- Rotation now re-encrypts `litellm_params` in place, one `update_many` per row
- The old delete-all + recreate-all rebuild of the model table is gone
- Every column rotation never needed to touch is preserved by construction

## User Flow

Before: an admin blocks a model, rotates the master key, and the block silently vanishes

1. The admin sends POST https://litellm-domain/model/block with `{"model_id": "..."}`; GET https://litellm-domain/v1/model/info now shows `"blocked": true` for that model
2. A developer's POST https://litellm-domain/v1/chat/completions naming that model comes back HTTP 403 `litellm.PermissionDeniedError: Model is blocked`
3. The admin rotates the master key: POST https://litellm-domain/key/{old-master-key}/regenerate with `{"new_master_key": "sk-..."}` returns HTTP 200
4. The admin restarts the proxy with the new master key
5. The same developer request now returns HTTP 200 with a real model response, and /v1/model/info shows `"blocked": false`
6. Anyone with a valid key can once again reach the model the admin had blocked

After: the same rotation leaves the block in place

1. The admin sends POST https://litellm-domain/model/block with `{"model_id": "..."}`; GET https://litellm-domain/v1/model/info now shows `"blocked": true` for that model
2. A developer's POST https://litellm-domain/v1/chat/completions naming that model comes back HTTP 403 `litellm.PermissionDeniedError: Model is blocked`
3. The admin rotates the master key: POST https://litellm-domain/key/{old-master-key}/regenerate with `{"new_master_key": "sk-..."}` returns HTTP 200
4. The admin restarts the proxy with the new master key
5. The developer request still returns HTTP 403 `Model is blocked`, and /v1/model/info still shows `"blocked": true`
6. Other models keep answering HTTP 200, so the stored credentials really were re-encrypted under the new key
7. Nobody can reach the blocked model until the admin unblocks it

## Relevant issues

## Linear ticket

Resolves LIT-6514

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Both legs: real proxy (2 uvicorn workers) on a random port, real Postgres 16 in docker, real OpenAI traffic on `openai/gpt-5.6`, no mocks. Proof re-run 2026-08-31 at the tip after merge commit 611750cd11 resolved the conflict with the base's typing sweep (the resolution also drops the base's `_tx_tables_context` helper, whose only caller was the replaced rotation block); the Before leg is the tip's merge base 4ba8517134. Shared setup per leg, run in order:

```
docker run -d --name lit6514r-pg -e POSTGRES_PASSWORD=... -e POSTGRES_DB=lit6514r -p <pgport>:5432 postgres:16-alpine
DATABASE_URL=... .venv/bin/prisma db push --schema schema.prisma --skip-generate
LITELLM_MASTER_KEY=<old-master> python litellm/proxy/proxy_cli.py --config config.yaml --port <port> --num_workers 2   # config: one config model + general_settings.store_model_in_db: true
curl -X POST http://localhost:<port>/model/new -H "Authorization: Bearer <old-master>" -d '{"model_name": "gpt56-db", "litellm_params": {"model": "openai/gpt-5.6", "api_key": "<real-openai-key>"}, "model_info": {"id": "lit6514r-blocked-model"}}'          # HTTP 200
curl -X POST http://localhost:<port>/model/new -H "Authorization: Bearer <old-master>" -d '{"model_name": "gpt56-db-control", "litellm_params": {"model": "openai/gpt-5.6", "api_key": "<real-openai-key>"}, "model_info": {"id": "lit6514r-control-model"}}'  # HTTP 200
curl -X POST http://localhost:<port>/model/block -H "Authorization: Bearer <old-master>" -d '{"model_id": "lit6514r-blocked-model"}'   # HTTP 500 on both legs (response serialization bug, pre-existing at the merge base, tracked in LIT-6518) but the block itself lands
```

### Before (4ba8517134)

1. Pre-rotation, chat on the blocked model (control model chat returns HTTP 200 "OK"):

```
$ curl -s -w '\nHTTP %{http_code}' -X POST http://localhost:50417/v1/chat/completions -H 'Authorization: Bearer <old-master>' -H 'Content-Type: application/json' -d '{"model": "gpt56-db", "messages": [{"role": "user", "content": "Say OK"}], "max_tokens": 20}'
{"error":{"message":"litellm.PermissionDeniedError: Model is blocked","type":null,"param":null,"code":"403"}}
HTTP 403
```

2. Pre-rotation, the DB row carries the block:

```
$ docker exec lit6514r-pg psql -U postgres -d lit6514r -t -c 'SELECT model_id, blocked FROM "LiteLLM_ProxyModelTable" ORDER BY model_id;'
 lit6514r-blocked-model | t
 lit6514r-control-model | f
```

3. Rotate: HTTP 200, and the DB row flips to blocked=f immediately, before any restart (the bug at the storage layer):

```
$ curl -s -o /dev/null -w 'HTTP %{http_code}' -X POST http://localhost:50417/key/<old-master>/regenerate -H 'Authorization: Bearer <old-master>' -d '{"new_master_key": "<new-master>"}'
HTTP 200
$ docker exec lit6514r-pg psql -U postgres -d lit6514r -t -c 'SELECT model_id, blocked FROM "LiteLLM_ProxyModelTable" ORDER BY model_id;'
 lit6514r-blocked-model | f
 lit6514r-control-model | f
```

4. Restart the proxy with the new master key; the same chat on the blocked model now goes through (the bug at the user surface):

```
$ curl -s -w '\nHTTP %{http_code}' -X POST http://localhost:50417/v1/chat/completions -H 'Authorization: Bearer <new-master>' -H 'Content-Type: application/json' -d '{"model": "gpt56-db", "messages": [{"role": "user", "content": "Say OK"}], "max_tokens": 20}'
{"id":"chatcmpl-EIzFBqLO3SnEg6vQOLXPjQhrRjwpq", ... "message":{"content":"OK","role":"assistant", ...}, "usage":{"completion_tokens":4,"prompt_tokens":8,"total_tokens":12, ...}}
HTTP 200
```

5. Post-restart /v1/model/info shows the block wiped:

```
$ curl -s http://localhost:50417/v1/model/info -H 'Authorization: Bearer <new-master>' | <print id+blocked per row>
[{'id': 'lit6514r-control-model', 'blocked': False}, {'id': 'lit6514r-blocked-model', 'blocked': False}]
```

### After (611750cd11, the tip)

1. Pre-rotation, chat on the blocked model (identical to Before; control model chat returns HTTP 200 "OK"):

```
$ curl -s -w '\nHTTP %{http_code}' -X POST http://localhost:37589/v1/chat/completions -H 'Authorization: Bearer <old-master>' -H 'Content-Type: application/json' -d '{"model": "gpt56-db", "messages": [{"role": "user", "content": "Say OK"}], "max_tokens": 20}'
{"error":{"message":"litellm.PermissionDeniedError: Model is blocked","type":null,"param":null,"code":"403"}}
HTTP 403
```

2. Pre-rotation, the DB row carries the block:

```
$ docker exec lit6514r-pg psql -U postgres -d lit6514r -t -c 'SELECT model_id, blocked FROM "LiteLLM_ProxyModelTable" ORDER BY model_id;'
 lit6514r-blocked-model | t
 lit6514r-control-model | f
```

3. Rotate: HTTP 200, and the DB row keeps blocked=t before any restart:

```
$ curl -s -o /dev/null -w 'HTTP %{http_code}' -X POST http://localhost:37589/key/<old-master>/regenerate -H 'Authorization: Bearer <old-master>' -d '{"new_master_key": "<new-master>"}'
HTTP 200
$ docker exec lit6514r-pg psql -U postgres -d lit6514r -t -c 'SELECT model_id, blocked FROM "LiteLLM_ProxyModelTable" ORDER BY model_id;'
 lit6514r-blocked-model | t
 lit6514r-control-model | f
```

4. Restart the proxy with the new master key; the block survives:

```
$ curl -s -w '\nHTTP %{http_code}' -X POST http://localhost:37589/v1/chat/completions -H 'Authorization: Bearer <new-master>' -H 'Content-Type: application/json' -d '{"model": "gpt56-db", "messages": [{"role": "user", "content": "Say OK"}], "max_tokens": 20}'
{"error":{"message":"litellm.PermissionDeniedError: Model is blocked","type":null,"param":null,"code":"403"}}
HTTP 403
```

5. Post-restart /v1/model/info still shows the block, and the control model still answers HTTP 200 "OK" through real OpenAI, proving `litellm_params` (the stored api_key included) really was re-encrypted under the new key:

```
$ curl -s http://localhost:37589/v1/model/info -H 'Authorization: Bearer <new-master>' | <print id+blocked per row>
[{'id': 'lit6514r-control-model', 'blocked': False}, {'id': 'lit6514r-blocked-model', 'blocked': True}]
```

QA observations:

- /model/block returns 500 though the block lands; pre-existing, unchanged (LIT-6518)
- The block takes ~30s to reach every worker after /model/block (both legs; pre-existing DB polling behavior)
- Rotation no longer rewrites stored model_info; row keeps admin's exact JSON
- Undecryptable rows are no longer silently deleted by rotation

## Type

🐛 Bug Fix

## Caveats (if any)

### Medium

- Rows whose params fail decryption now survive rotation still old-key encrypted
  - Before this PR rotation silently deleted them outright
- The per-row rewrite runs in one transaction with a 2 minute timeout
  - Thousands of model rows beyond that abort the rotation unchanged

### Low

- /model/block answers HTTP 500 though the block lands (pre-existing, LIT-6518)
- Rotation used to overwrite stored model_info with injected runtime keys; it no longer touches it
- A model row created mid-rotation keeps old-key encryption
  - Before this PR the rebuild deleted such a row entirely

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

- [x] a928c1429e passes /live-pr-risk; 611750cd11 changes nothing outside the conflict resolution (`_tx_tables_context` had no other caller) and the A/B above re-proves the fix live at that tip

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes critical master-key rotation and encrypted credential storage in the proxy DB; behavior improves data preservation but rows that fail decryption are no longer removed during rotation.
> 
> **Overview**
> **Master key rotation** no longer wipes and rebuilds `LiteLLM_ProxyModelTable`. It re-encrypts credentials by running **`update_many` per row**, updating only **`litellm_params`** (wrapped as `prisma.Json`) with **`where: { model_id }`**, inside a **2-minute** DB transaction.
> 
> That replaces **`delete_many` + `create_many`** from `Deployment` dumps, which had been resetting **`blocked`**, audit timestamps, and other columns not present on deployment objects—so blocked models could start serving again after rotation.
> 
> Typing helpers **`_ModelParamsUpdate`** / **`_ModelRowWhere`** were added; **`_tx_tables_context`** was removed in favor of opening **`db.tx`** directly. The regression test was renamed and now asserts no delete/recreate, a single targeted **`update_many`**, and re-encrypted **`api_key`** under the new master key.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 611750cd11d459ff2b29f43955816002377261f2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
