### PR TITLE
fix(vector_stores): stop sharing one list across default-constructed registries

### DIFF
--- a/litellm/vector_stores/vector_store_registry.py
+++ b/litellm/vector_stores/vector_store_registry.py
@@ -32,8 +32,10 @@ else:
 
 
 class VectorStoreIndexRegistry:
-    def __init__(self, vector_store_indexes: list[LiteLLM_ManagedVectorStoreIndex] = []):
-        self.vector_store_indexes: list[LiteLLM_ManagedVectorStoreIndex] = vector_store_indexes
+    def __init__(self, vector_store_indexes: list[LiteLLM_ManagedVectorStoreIndex] | None = None):
+        self.vector_store_indexes: list[LiteLLM_ManagedVectorStoreIndex] = (
+            vector_store_indexes if vector_store_indexes is not None else []
+        )
 
     def get_vector_store_indexes(self) -> list[LiteLLM_ManagedVectorStoreIndex]:
         """
@@ -101,8 +103,8 @@ class VectorStoreIndexRegistry:
 
 
 class VectorStoreRegistry:
-    def __init__(self, vector_stores: list[LiteLLM_ManagedVectorStore] = []):
-        self.vector_stores: list[LiteLLM_ManagedVectorStore] = vector_stores
+    def __init__(self, vector_stores: list[LiteLLM_ManagedVectorStore] | None = None):
+        self.vector_stores: list[LiteLLM_ManagedVectorStore] = vector_stores if vector_stores is not None else []
         self.vector_store_ids_to_vector_store_map: dict[str, LiteLLM_ManagedVectorStore] = {}
 
     def _extract_tool_params(self, tool: dict) -> VectorStoreToolParams:

--- a/tests/test_litellm/vector_stores/test_vector_store_registry.py
+++ b/tests/test_litellm/vector_stores/test_vector_store_registry.py
@@ -13,7 +13,10 @@ from unittest.mock import MagicMock
 import litellm
 from litellm.types.vector_stores import LiteLLM_ManagedVectorStore
 from litellm.vector_stores.main import search
-from litellm.vector_stores.vector_store_registry import VectorStoreRegistry
+from litellm.vector_stores.vector_store_registry import (
+    VectorStoreIndexRegistry,
+    VectorStoreRegistry,
+)
 
 
 @pytest.fixture(autouse=True)
@@ -182,3 +185,38 @@ def test_search_uses_registry_credentials():
             assert getattr(called_params, "aws_region_name") == "us-east-1"
     finally:
         litellm.vector_store_registry = original_registry
+
+
+class TestRegistriesDoNotShareDefaultState:
+    """#38874: a mutable default argument made every default-constructed registry share
+    one list, so upserting into one polluted every other instance and the class default."""
+
+    def test_vector_store_registries_do_not_share_a_list(self):
+        first = VectorStoreRegistry()
+        second = VectorStoreRegistry()
+        assert first.vector_stores is not second.vector_stores
+
+    def test_index_registries_do_not_share_a_list(self):
+        first = VectorStoreIndexRegistry()
+        second = VectorStoreIndexRegistry()
+        assert first.vector_store_indexes is not second.vector_store_indexes
+
+    def test_mutating_one_registry_leaves_the_next_one_empty(self):
+        first = VectorStoreRegistry()
+        first.vector_stores.append(
+            LiteLLM_ManagedVectorStore(vector_store_id="vs-leak", custom_llm_provider="bedrock")
+        )
+        assert VectorStoreRegistry().vector_stores == []
+
+    def test_mutating_one_index_registry_leaves_the_next_one_empty(self):
+        first = VectorStoreIndexRegistry()
+        first.vector_store_indexes.append({"index_name": "leak"})
+        assert VectorStoreIndexRegistry().get_vector_store_indexes() == []
+
+    def test_a_supplied_list_is_still_used_as_given(self):
+        supplied = [LiteLLM_ManagedVectorStore(vector_store_id="vs-1", custom_llm_provider="bedrock")]
+        assert VectorStoreRegistry(vector_stores=supplied).vector_stores is supplied
+
+    def test_a_supplied_empty_list_is_still_used_as_given(self):
+        supplied: list = []
+        assert VectorStoreRegistry(vector_stores=supplied).vector_stores is supplied


### PR DESCRIPTION
## TLDR

Problem this solves:

- Both vector store registries default their list argument to `[]`
- Python evaluates that once, so every default-built registry shares it
- The proxy builds one that way at startup
- An upsert into it leaks into every registry made afterwards

How it solves it:

- Default to `None` and build a fresh list per instance
- Keep using a caller-supplied list as given, empty ones included

## User Flow

Before: an operator sees vector stores they never configured, and cannot get rid of them

1. They start the proxy with no vector stores in `config.yaml`, so startup builds an empty registry
2. They add one store at runtime through `POST https://litellm-domain/vector_store/new`
3. Anything that later builds a registry of its own starts out already holding that store, because both registries are the same list
4. `GET https://litellm-domain/vector_store/list` reports stores that the fresh registry was never given
5. Restarting the proxy clears it, so it looks intermittent and tracks nothing an operator changed

After: each registry starts with its own empty list

1. They start the proxy the same way with no vector stores configured
2. They add the same store through `POST https://litellm-domain/vector_store/new`
3. A registry built afterwards starts empty, as it was asked to
4. `GET https://litellm-domain/vector_store/list` reports only the stores that registry actually holds
5. Passing an explicit list still hands that exact list to the registry, so callers that manage their own list are unaffected

## Relevant issues

Fixes #38874

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## One difference from the issue's suggestion

The issue proposes `Optional[list[...]] = None`. This uses `list[...] | None`, which is the modern spelling and what the rest of this file already uses. The `is not None` check is kept rather than `or []`, so a caller that passes its own empty list still gets that same list back instead of a new one, which `or []` would quietly replace.

## Screenshots / Proof of Fix

`proxy_server.py:5832` builds `VectorStoreRegistry()` with no arguments during startup, so the shared default is on a live path. The shortest way to see it is to build two registries and mutate one:

```python
from litellm.vector_stores.vector_store_registry import VectorStoreRegistry, VectorStoreIndexRegistry
from litellm.types.vector_stores import LiteLLM_ManagedVectorStore

a, b = VectorStoreRegistry(), VectorStoreRegistry()
print("shared list?", a.vector_stores is b.vector_stores)
a.vector_stores.append(LiteLLM_ManagedVectorStore(vector_store_id="vs-leak", custom_llm_provider="bedrock"))
print("next fresh registry len:", len(VectorStoreRegistry().vector_stores))

c, d = VectorStoreIndexRegistry(), VectorStoreIndexRegistry()
print("index shared list?", c.vector_store_indexes is d.vector_store_indexes)
```

### Before (5e4b3838aa)

#### two default-built registries are the same object

1. `python repro.py`
2. ```
   shared list? True
   next fresh registry len: 1
   index shared list? True
   ```
3. A registry that was never given a store reports one

### After (97594804f6)

#### each default-built registry gets its own list

1. `python repro.py`
2. ```
   shared list? False
   next fresh registry len: 0
   index shared list? False
   ```
3. A caller-supplied empty list is still the same object the registry holds

No provider call is involved, since this is process-local state rather than anything on the wire.

## Type

🐛 Bug Fix

## Caveats (if any)

### Low

- The registry still holds the caller's list rather than a copy, so a caller that keeps mutating the list it passed in still shares state with the registry
  - That is existing behaviour and some callers may rely on it, so this change leaves it alone
  - Only the shared default is fixed, which is what the issue reports

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Process-local initialization fix with targeted tests; no auth, wire, or persistence logic changes beyond stopping accidental cross-instance list sharing.
> 
> **Overview**
> Fixes a **mutable default argument** bug on `VectorStoreRegistry` and `VectorStoreIndexRegistry`: both used `= []`, so every no-arg construction (including proxy startup at `VectorStoreRegistry()`) shared one in-memory list. Runtime upserts could show up on unrelated fresh registries and skew `GET /vector_store/list` until restart.
> 
> Constructors now default to **`None`** and assign a **new empty list per instance**; an explicitly passed list (including `[]`) is still stored **by reference**, unchanged from prior caller semantics.
> 
> Adds **`TestRegistriesDoNotShareDefaultState`** to lock in isolation between default instances and preserve supplied-list behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 97594804f6338a688fa332e26e549fe2c914d66d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->