### PR TITLE
fix(router): resolve fallbacks against the tier a pre-routing hook selected

### DIFF
--- a/litellm/router.py
+++ b/litellm/router.py
@@ -143,6 +143,7 @@ from litellm.router_utils.cooldown_handlers import (
 from litellm.router_utils.fallback_event_handlers import (
     AttemptedFallbackTargets,
     _check_non_standard_fallback_format,
+    clear_pre_routing_selection,
     get_fallback_model_group,
     get_pre_routing_selection,
     record_pre_routing_selection,
@@ -7049,6 +7050,7 @@ class Router:
         If it fails after num_retries, fall back to another model group
         """
         model_group: Final[str | None] = kwargs.get("model")
+        clear_pre_routing_selection(cast("Mapping[str, object]", kwargs))
         if not isinstance(kwargs.get("attempted_targets"), AttemptedFallbackTargets):
             _fallback_metadata_key: Final = _get_router_metadata_variable_name(
                 function_name=getattr(kwargs.get("original_function"), "__name__", None)

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -7050,7 +7050,7 @@ class Router:
         If it fails after num_retries, fall back to another model group
         """
         model_group: Final[str | None] = kwargs.get("model")
-        clear_pre_routing_selection(cast("Mapping[str, object]", kwargs))
+        clear_pre_routing_selection(kwargs)  # pyright: ignore[reportUnknownArgumentType]  # **kwargs is untyped at this boundary
         if not isinstance(kwargs.get("attempted_targets"), AttemptedFallbackTargets):
             _fallback_metadata_key: Final = _get_router_metadata_variable_name(
                 function_name=getattr(kwargs.get("original_function"), "__name__", None)

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -144,6 +144,8 @@ from litellm.router_utils.fallback_event_handlers import (
     AttemptedFallbackTargets,
     _check_non_standard_fallback_format,
     get_fallback_model_group,
+    get_pre_routing_selection,
+    record_pre_routing_selection,
     run_async_fallback,
 )
 from litellm.router_utils.get_retry_from_policy import (
@@ -6805,6 +6807,9 @@ class Router:
         original_exception: Final = e
         fallback_model_group = None
         original_model_group: Final[str | None] = kwargs.get("model")
+        # A pre-routing hook (complexity / auto / adaptive / quality routers) picks a tier
+        # behind the router name, and fallbacks are configured per tier, not per router.
+        fallback_lookup_group: Final[str | None] = get_pre_routing_selection(kwargs) or model_group
         fallback_failure_exception_str = ""
 
         if disable_fallbacks is True or original_model_group is None:
@@ -6849,7 +6854,7 @@ class Router:
             ]
             # Get external fallbacks — handle both standard and non-standard formats
             external_fallback_group: list | None = None
-            if fallbacks is not None and model_group is not None:
+            if fallbacks is not None and fallback_lookup_group is not None:
                 if _check_non_standard_fallback_format(fallbacks=fallbacks):
                     # Non-standard formats (e.g. ["claude-3-haiku"] or
                     # [{"model": "...", "messages": [...]}]) are passed through directly
@@ -6857,7 +6862,7 @@ class Router:
                 else:
                     external_fallback_group, generic_idx = get_fallback_model_group(
                         fallbacks=fallbacks,
-                        model_group=cast(str, model_group),
+                        model_group=cast(str, fallback_lookup_group),
                     )
                     if external_fallback_group is None and generic_idx is not None:
                         external_fallback_group = fallbacks[generic_idx]["*"]
@@ -6917,7 +6922,7 @@ class Router:
                     context_window_fallback_model_group: Final[list[str] | None] = (
                         self._get_fallback_model_group_from_fallbacks(
                             fallbacks=context_window_fallbacks,
-                            model_group=model_group,
+                            model_group=fallback_lookup_group,
                         )
                     )
                     if context_window_fallback_model_group is None:
@@ -6950,7 +6955,7 @@ class Router:
                     content_policy_fallback_model_group: Final[list[str] | None] = (
                         self._get_fallback_model_group_from_fallbacks(
                             fallbacks=content_policy_fallbacks,
-                            model_group=model_group,
+                            model_group=fallback_lookup_group,
                         )
                     )
                     if content_policy_fallback_model_group is None:
@@ -6977,14 +6982,14 @@ class Router:
 
                     if litellm.expose_router_debug_in_errors:
                         e.message += f"\n{error_message}"
-            if fallbacks is not None and model_group is not None:
+            if fallbacks is not None and fallback_lookup_group is not None:
                 verbose_router_logger.debug("inside model fallbacks: %s", mask_sensitive_structure(fallbacks))
                 (
                     fallback_model_group,
                     generic_fallback_idx,
                 ) = get_fallback_model_group(
                     fallbacks=fallbacks,  # if fallbacks = [{"gpt-3.5-turbo": ["claude-3-haiku"]}]
-                    model_group=cast(str, model_group),
+                    model_group=cast(str, fallback_lookup_group),
                 )
                 ## if none, check for generic fallback
                 if fallback_model_group is None and generic_fallback_idx is not None:
@@ -6994,11 +6999,11 @@ class Router:
                     masked_fallbacks: Final = mask_sensitive_structure(fallbacks)
                     verbose_router_logger.info(
                         "No fallback model group found for original model_group=%s. Fallbacks=%s",
-                        model_group,
+                        fallback_lookup_group,
                         masked_fallbacks,
                     )
                     if hasattr(original_exception, "message") and litellm.expose_router_debug_in_errors:
-                        original_exception.message += f"No fallback model group found for original model_group={model_group}. Fallbacks={masked_fallbacks}"
+                        original_exception.message += f"No fallback model group found for original model_group={fallback_lookup_group}. Fallbacks={masked_fallbacks}"
                     raise original_exception
 
                 input_kwargs.update(
@@ -12023,6 +12028,7 @@ class Router:
             if pre_routing_hook_response is not None:
                 model = pre_routing_hook_response.model
                 messages = pre_routing_hook_response.messages
+                record_pre_routing_selection(request_kwargs, model)
                 if pre_routing_hook_response.litellm_params:
                     accepted_tier_params: Final = self._tier_params_the_target_accepts(
                         model, pre_routing_hook_response.litellm_params, request_kwargs
@@ -12138,6 +12144,7 @@ class Router:
             if pre_routing_hook_response is not None:
                 model = pre_routing_hook_response.model
                 messages = pre_routing_hook_response.messages
+                record_pre_routing_selection(request_kwargs, model)
                 if pre_routing_hook_response.litellm_params:
                     accepted_tier_params: Final = self._tier_params_the_target_accepts(
                         model, pre_routing_hook_response.litellm_params, request_kwargs

--- a/litellm/router_utils/fallback_event_handlers.py
+++ b/litellm/router_utils/fallback_event_handlers.py
@@ -214,6 +214,38 @@ def _check_stripped_model_group(model_group: str, fallback_key: str) -> bool:
     return False
 
 
+PRE_ROUTING_SELECTED_MODEL_KEY: Final = "pre_routing_selected_model"
+_ROUTER_METADATA_BUCKETS: Final = ("metadata", "litellm_metadata")
+
+
+def record_pre_routing_selection(request_kwargs: dict | None, selected_model: str) -> None:
+    """
+    Remember which model a pre-routing hook picked, so fallback lookup can key off it.
+
+    Fallback resolution runs on an outer kwargs dict that ``**kwargs`` already copied, so
+    writing the model there is invisible by the time routing picks a tier. The metadata
+    buckets are nested dicts shared by reference across those copies, which is how the
+    router already carries values back up.
+    """
+    if request_kwargs is None:
+        return
+    for bucket_name in _ROUTER_METADATA_BUCKETS:
+        bucket: Final = request_kwargs.get(bucket_name)
+        if isinstance(bucket, dict):
+            bucket[PRE_ROUTING_SELECTED_MODEL_KEY] = selected_model
+
+
+def get_pre_routing_selection(kwargs: Mapping[str, Any]) -> str | None:
+    """The model a pre-routing hook selected for this request, if one did."""
+    for bucket_name in _ROUTER_METADATA_BUCKETS:
+        bucket: Final = kwargs.get(bucket_name)
+        if isinstance(bucket, dict):
+            selected: Final = bucket.get(PRE_ROUTING_SELECTED_MODEL_KEY)
+            if isinstance(selected, str) and selected:
+                return selected
+    return None
+
+
 def get_fallback_model_group(fallbacks: list[Any], model_group: str) -> tuple[list[str] | None, int | None]:
     """
     Returns:

--- a/litellm/router_utils/fallback_event_handlers.py
+++ b/litellm/router_utils/fallback_event_handlers.py
@@ -234,6 +234,23 @@ def record_pre_routing_selection(request_kwargs: Mapping[str, Any] | None, selec
             bucket[PRE_ROUTING_SELECTED_MODEL_KEY] = selected_model
 
 
+def clear_pre_routing_selection(request_kwargs: Mapping[str, object] | None) -> None:
+    """
+    Drop any selection the router did not make itself on this hop.
+
+    The buckets carry whatever the caller sent, so an inbound value is the caller
+    choosing a fallback chain rather than the router choosing a tier. A fallback hop
+    also inherits the previous hop's selection, which would key its own failure off
+    the tier that already failed. Clearing at the start of every hop leaves only a
+    value the pre-routing hook wrote while routing that hop.
+    """
+    if request_kwargs is None:
+        return
+    for bucket in (request_kwargs.get(name) for name in _ROUTER_METADATA_BUCKETS):
+        if isinstance(bucket, dict) and PRE_ROUTING_SELECTED_MODEL_KEY in bucket:
+            del bucket[PRE_ROUTING_SELECTED_MODEL_KEY]
+
+
 def get_pre_routing_selection(kwargs: Mapping[str, Any]) -> str | None:
     """The model a pre-routing hook selected for this request, if one did."""
     buckets: Final = (kwargs.get(name) for name in _ROUTER_METADATA_BUCKETS)

--- a/litellm/router_utils/fallback_event_handlers.py
+++ b/litellm/router_utils/fallback_event_handlers.py
@@ -218,7 +218,7 @@ PRE_ROUTING_SELECTED_MODEL_KEY: Final = "pre_routing_selected_model"
 _ROUTER_METADATA_BUCKETS: Final = ("metadata", "litellm_metadata")
 
 
-def record_pre_routing_selection(request_kwargs: dict | None, selected_model: str) -> None:
+def record_pre_routing_selection(request_kwargs: Mapping[str, Any] | None, selected_model: str) -> None:
     """
     Remember which model a pre-routing hook picked, so fallback lookup can key off it.
 

--- a/litellm/router_utils/fallback_event_handlers.py
+++ b/litellm/router_utils/fallback_event_handlers.py
@@ -229,21 +229,18 @@ def record_pre_routing_selection(request_kwargs: Mapping[str, Any] | None, selec
     """
     if request_kwargs is None:
         return
-    for bucket_name in _ROUTER_METADATA_BUCKETS:
-        bucket: Final = request_kwargs.get(bucket_name)
+    for bucket in (request_kwargs.get(name) for name in _ROUTER_METADATA_BUCKETS):
         if isinstance(bucket, dict):
             bucket[PRE_ROUTING_SELECTED_MODEL_KEY] = selected_model
 
 
 def get_pre_routing_selection(kwargs: Mapping[str, Any]) -> str | None:
     """The model a pre-routing hook selected for this request, if one did."""
-    for bucket_name in _ROUTER_METADATA_BUCKETS:
-        bucket: Final = kwargs.get(bucket_name)
-        if isinstance(bucket, dict):
-            selected: Final = bucket.get(PRE_ROUTING_SELECTED_MODEL_KEY)
-            if isinstance(selected, str) and selected:
-                return selected
-    return None
+    buckets: Final = (kwargs.get(name) for name in _ROUTER_METADATA_BUCKETS)
+    selections: Final = (
+        bucket.get(PRE_ROUTING_SELECTED_MODEL_KEY) for bucket in buckets if isinstance(bucket, dict)
+    )
+    return next((selected for selected in selections if isinstance(selected, str) and selected), None)
 
 
 def get_fallback_model_group(fallbacks: list[Any], model_group: str) -> tuple[list[str] | None, int | None]:

--- a/litellm/router_utils/fallback_event_handlers.py
+++ b/litellm/router_utils/fallback_event_handlers.py
@@ -237,9 +237,7 @@ def record_pre_routing_selection(request_kwargs: Mapping[str, Any] | None, selec
 def get_pre_routing_selection(kwargs: Mapping[str, Any]) -> str | None:
     """The model a pre-routing hook selected for this request, if one did."""
     buckets: Final = (kwargs.get(name) for name in _ROUTER_METADATA_BUCKETS)
-    selections: Final = (
-        bucket.get(PRE_ROUTING_SELECTED_MODEL_KEY) for bucket in buckets if isinstance(bucket, dict)
-    )
+    selections: Final = (bucket.get(PRE_ROUTING_SELECTED_MODEL_KEY) for bucket in buckets if isinstance(bucket, dict))
     return next((selected for selected in selections if isinstance(selected, str) and selected), None)
 
 

--- a/tests/test_litellm/router_utils/test_fallback_event_handlers.py
+++ b/tests/test_litellm/router_utils/test_fallback_event_handlers.py
@@ -12,6 +12,8 @@ from litellm.router_utils.fallback_event_handlers import (
     _trigger_cooldown_for_failed_deployment,
     fallback_attempt_key,
     get_fallback_model_group,
+    get_pre_routing_selection,
+    record_pre_routing_selection,
     run_async_fallback,
 )
 
@@ -1090,3 +1092,44 @@ async def test_run_async_fallback_preserves_original_model_group_on_nested_fallb
     metadata = router.received_kwargs["metadata"]
     assert metadata["attempted_fallbacks"] == 2
     assert metadata["original_model_group"] == "primary-model"
+
+
+class TestPreRoutingSelectionCarriesToFallbacks:
+    """#38832: a complexity/auto router picks a tier behind the router name, but fallback
+    lookup kept using the router name, so the tier's configured chain never ran."""
+
+    def test_selection_is_recorded_in_the_metadata_bucket(self):
+        kwargs = {"model": "smart-router", "metadata": {}}
+        record_pre_routing_selection(kwargs, "tier1")
+        assert kwargs["metadata"]["pre_routing_selected_model"] == "tier1"
+        assert get_pre_routing_selection(kwargs) == "tier1"
+
+    def test_selection_is_recorded_in_the_litellm_metadata_bucket(self):
+        kwargs = {"model": "smart-router", "litellm_metadata": {}}
+        record_pre_routing_selection(kwargs, "tier2")
+        assert get_pre_routing_selection(kwargs) == "tier2"
+
+    def test_a_bucket_survives_the_kwargs_copy_that_fallbacks_run_on(self):
+        """The bucket is shared by reference, which is the whole reason this works."""
+        outer = {"model": "smart-router", "metadata": {}}
+        inner = {**outer}
+        record_pre_routing_selection(inner, "tier1")
+        assert get_pre_routing_selection(outer) == "tier1"
+
+    def test_no_selection_reads_as_none(self):
+        assert get_pre_routing_selection({"model": "smart-router", "metadata": {}}) is None
+        assert get_pre_routing_selection({"model": "smart-router"}) is None
+
+    def test_missing_kwargs_is_tolerated(self):
+        record_pre_routing_selection(None, "tier1")
+
+    def test_a_non_dict_bucket_is_ignored(self):
+        kwargs = {"model": "smart-router", "metadata": "not-a-dict"}
+        record_pre_routing_selection(kwargs, "tier1")
+        assert get_pre_routing_selection(kwargs) is None
+
+    def test_fallbacks_resolve_against_the_selected_tier(self):
+        """The lookup the router performs, keyed on the tier rather than the router name."""
+        fallbacks = [{"tier1": ["backup-a", "backup-b"]}, {"tier2": ["backup-c"]}]
+        assert get_fallback_model_group(fallbacks=fallbacks, model_group="tier1")[0] == ["backup-a", "backup-b"]
+        assert get_fallback_model_group(fallbacks=fallbacks, model_group="smart-router")[0] is None

--- a/tests/test_litellm/router_utils/test_fallback_event_handlers.py
+++ b/tests/test_litellm/router_utils/test_fallback_event_handlers.py
@@ -1120,8 +1120,11 @@ class TestPreRoutingSelectionCarriesToFallbacks:
         assert get_pre_routing_selection({"model": "smart-router", "metadata": {}}) is None
         assert get_pre_routing_selection({"model": "smart-router"}) is None
 
-    def test_missing_kwargs_is_tolerated(self):
+    def test_missing_kwargs_is_a_no_op(self):
+        """A caller with no kwargs must not raise, and must not leak the selection anywhere."""
         record_pre_routing_selection(None, "tier1")
+
+        assert get_pre_routing_selection({}) is None
 
     def test_a_non_dict_bucket_is_ignored(self):
         kwargs = {"model": "smart-router", "metadata": "not-a-dict"}

--- a/tests/test_litellm/router_utils/test_fallback_event_handlers.py
+++ b/tests/test_litellm/router_utils/test_fallback_event_handlers.py
@@ -11,6 +11,7 @@ from litellm.router_utils.fallback_event_handlers import (
     AttemptedFallbackTargets,
     _trigger_cooldown_for_failed_deployment,
     fallback_attempt_key,
+    clear_pre_routing_selection,
     get_fallback_model_group,
     get_pre_routing_selection,
     record_pre_routing_selection,
@@ -1136,3 +1137,50 @@ class TestPreRoutingSelectionCarriesToFallbacks:
         fallbacks = [{"tier1": ["backup-a", "backup-b"]}, {"tier2": ["backup-c"]}]
         assert get_fallback_model_group(fallbacks=fallbacks, model_group="tier1")[0] == ["backup-a", "backup-b"]
         assert get_fallback_model_group(fallbacks=fallbacks, model_group="smart-router")[0] is None
+
+
+class TestPreRoutingSelectionIsPerHop:
+    """#38832 review: the buckets also carry whatever the caller sent, and a fallback hop
+    inherits the previous hop's tier, so a hop must start without a selection."""
+
+    def test_a_caller_supplied_selection_is_dropped(self):
+        kwargs = {"model": "plain", "metadata": {"pre_routing_selected_model": "tier1"}}
+
+        clear_pre_routing_selection(kwargs)
+
+        assert get_pre_routing_selection(kwargs) is None
+        assert "pre_routing_selected_model" not in kwargs["metadata"]
+
+    def test_both_buckets_are_cleared(self):
+        kwargs = {
+            "metadata": {"pre_routing_selected_model": "tier1"},
+            "litellm_metadata": {"pre_routing_selected_model": "tier2"},
+        }
+
+        clear_pre_routing_selection(kwargs)
+
+        assert get_pre_routing_selection(kwargs) is None
+
+    def test_the_rest_of_the_bucket_is_left_alone(self):
+        kwargs = {"metadata": {"pre_routing_selected_model": "tier1", "tags": ["a"]}}
+
+        clear_pre_routing_selection(kwargs)
+
+        assert kwargs["metadata"] == {"tags": ["a"]}
+
+    def test_clearing_is_a_no_op_without_a_usable_bucket(self):
+        kwargs = {"model": "plain", "metadata": "not-a-dict"}
+
+        clear_pre_routing_selection(None)
+        clear_pre_routing_selection(kwargs)
+
+        assert kwargs == {"model": "plain", "metadata": "not-a-dict"}
+
+    def test_a_selection_recorded_after_clearing_is_kept(self):
+        """Clearing runs before routing, so the hook's own write must survive it."""
+        kwargs = {"model": "smart-router", "metadata": {"pre_routing_selected_model": "stale"}}
+
+        clear_pre_routing_selection(kwargs)
+        record_pre_routing_selection(kwargs, "tier1")
+
+        assert get_pre_routing_selection(kwargs) == "tier1"

--- a/tests/test_litellm/test_router.py
+++ b/tests/test_litellm/test_router.py
@@ -11571,6 +11571,30 @@ class TestPreRoutingTierDrivesFallbacks:
                         "mock_response": "from backup-a",
                     },
                 },
+                {
+                    "model_name": "backup-b",
+                    "litellm_params": {
+                        "model": "openai/gpt-4o-mini",
+                        "api_key": "sk-x",
+                        "mock_response": "from backup-b",
+                    },
+                },
+                {
+                    "model_name": "failing-backup",
+                    "litellm_params": {
+                        "model": "openai/gpt-4o-mini",
+                        "api_key": "sk-x",
+                        "mock_response": "litellm.RateLimitError",
+                    },
+                },
+                {
+                    "model_name": "plain",
+                    "litellm_params": {
+                        "model": "openai/gpt-4o-mini",
+                        "api_key": "sk-x",
+                        "mock_response": "litellm.RateLimitError",
+                    },
+                },
             ],
             fallbacks=fallbacks,
             num_retries=0,
@@ -11603,3 +11627,24 @@ class TestPreRoutingTierDrivesFallbacks:
         )
 
         assert response.choices[0].message.content == "from backup-a"
+
+    @pytest.mark.asyncio
+    async def test_a_caller_cannot_pick_the_chain_by_sending_the_selection(self):
+        """The metadata bucket carries caller-supplied keys, so only the hook may set the tier."""
+        router = self._router([{"tier1": ["backup-a"]}])
+
+        with pytest.raises(litellm.RateLimitError):
+            await router.acompletion(
+                model="plain",
+                messages=[{"role": "user", "content": "hi"}],
+                metadata={"pre_routing_selected_model": "tier1"},
+            )
+
+    @pytest.mark.asyncio
+    async def test_each_fallback_hop_resolves_its_own_chain(self):
+        """The second hop must key off the group it is running, not the tier that failed."""
+        router = self._router([{"tier1": ["failing-backup"]}, {"failing-backup": ["backup-b"]}])
+
+        response = await router.acompletion(model="smart-router", messages=[{"role": "user", "content": "hi"}])
+
+        assert response.choices[0].message.content == "from backup-b"

--- a/tests/test_litellm/test_router.py
+++ b/tests/test_litellm/test_router.py
@@ -11530,3 +11530,76 @@ class TestTierParamsTheTargetAccepts:
         accepted = router._tier_params_the_target_accepts("no-such-group", {"reasoning_effort": "max"}, {})
 
         assert accepted == {"reasoning_effort": "max"}
+
+
+class TestPreRoutingTierDrivesFallbacks:
+    """#38832: a complexity/auto router picks a tier behind the router name, but fallback
+    lookup stayed on the router name, so the tier's configured chain never ran and a
+    provider failure on the tier's first hop was returned to the client."""
+
+    class _TierRouter(litellm.Router):
+        async def async_pre_routing_hook(
+            self, model, request_kwargs, messages=None, input=None, specific_deployment=False
+        ):
+            from litellm.types.router import PreRoutingHookResponse
+
+            if model == "smart-router":
+                return PreRoutingHookResponse(model="tier1", messages=messages)
+            return None
+
+    @classmethod
+    def _router(cls, fallbacks) -> "litellm.Router":
+        return cls._TierRouter(
+            model_list=[
+                {
+                    "model_name": "smart-router",
+                    "litellm_params": {"model": "openai/gpt-4o-mini", "api_key": "sk-x"},
+                },
+                {
+                    "model_name": "tier1",
+                    "litellm_params": {
+                        "model": "openai/gpt-4o-mini",
+                        "api_key": "sk-x",
+                        "mock_response": "litellm.RateLimitError",
+                    },
+                },
+                {
+                    "model_name": "backup-a",
+                    "litellm_params": {
+                        "model": "openai/gpt-4o-mini",
+                        "api_key": "sk-x",
+                        "mock_response": "from backup-a",
+                    },
+                },
+            ],
+            fallbacks=fallbacks,
+            num_retries=0,
+        )
+
+    @pytest.mark.asyncio
+    async def test_the_selected_tier_fallback_chain_runs(self):
+        router = self._router([{"tier1": ["backup-a"]}])
+
+        response = await router.acompletion(
+            model="smart-router", messages=[{"role": "user", "content": "hi"}]
+        )
+
+        assert response.choices[0].message.content == "from backup-a"
+
+    @pytest.mark.asyncio
+    async def test_a_chain_keyed_on_the_router_name_is_not_used(self):
+        """The router name has no chain of its own, so nothing should rescue this call."""
+        router = self._router([{"tier2": ["backup-a"]}])
+
+        with pytest.raises(litellm.RateLimitError):
+            await router.acompletion(model="smart-router", messages=[{"role": "user", "content": "hi"}])
+
+    @pytest.mark.asyncio
+    async def test_a_request_without_a_pre_routing_hook_still_uses_its_own_group(self):
+        router = self._router([{"tier1": ["backup-a"]}])
+
+        response = await router.acompletion(
+            model="tier1", messages=[{"role": "user", "content": "hi"}]
+        )
+
+        assert response.choices[0].message.content == "from backup-a"


### PR DESCRIPTION
## TLDR

Problem this solves:

- Complexity and auto routers pick a tier behind the router name
- Fallback lookup still keys off the router name the client sent
- The tier's configured fallback chain never runs
- A provider failure on the tier's first hop goes straight to the client

How it solves it:

- Record the tier the pre-routing hook selected, in the metadata bucket
- Key fallback lookup off that selection when there is one
- Leave reporting on the router name, which is what the caller asked for

## User Flow

Before: a team puts a complexity router in front of their tiers, configures fallbacks per tier, and the fallbacks never fire

1. They configure `smart-router` with `model: auto_router/complexity_router`, and `router_settings.fallbacks` as `[{"tier1": ["backup-a", "backup-b"]}, {"tier2": [...]}]`
2. A client sends POST https://litellm-domain/v1/chat/completions with `"model": "smart-router"`
3. The router picks `tier1` for that request, and `tier1`'s first deployment returns a 429
4. The call fails back to the client with the provider error, and the proxy log says `No fallback model group found for original model_group=smart-router. Fallbacks=[{'tier1': [...]}, {'tier2': [...]}]`
5. `backup-a` and `backup-b` are never tried, so the fallback config is dead weight for every request that goes through the router

After: the chain configured for the tier actually runs

1. They configure the same `smart-router` and the same per-tier `router_settings.fallbacks`
2. The client sends the same POST with `"model": "smart-router"`
3. The router picks `tier1`, and `tier1`'s first deployment returns the same 429
4. `backup-a` is tried next, as `{"tier1": ["backup-a", "backup-b"]}` says it should be, and the client gets an answer instead of the 429
5. A client that calls `tier1` directly is unchanged, and a chain keyed on the router name still matches nothing, since the router group has no deployments of its own

## Relevant issues

Fixes #38832

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Why not just set kwargs["model"]

That was my first instinct and it does not work. `async_function_with_fallbacks` hands its kwargs down with `**kwargs`, so every level below it holds a different dict. By the time the pre-routing hook picks a tier inside `async_get_available_deployment`, writing the model into the dict it was given cannot be seen by the fallback handler further up.

Nested buckets are the exception, since they are shared by reference across those copies. The router already relies on that: `async_function_with_fallbacks` writes `attempted_fallbacks` and `original_model_group` into the metadata bucket for exactly this reason, with a comment saying a rebind would detach the write-backs. This change follows the same route rather than inventing a second mechanism.

## Where the selection is trusted from

The buckets are not a private channel. They carry whatever the caller sent, so an inbound `pre_routing_selected_model` would be a client choosing which fallback chain its request falls into, and a fallback hop inherits the previous hop's copy, so the second hop would key its own failure off the tier that already failed instead of running its own chain.

Both come down to the same thing: a hop must start with no selection and re-derive its own. `async_function_with_fallbacks` clears the key before routing, and every hop re-enters there, so the only value ever read is the one the pre-routing hook wrote while routing that hop.

Reporting deliberately stays on the router name. `original_model_group` is what the caller asked for, and it feeds response headers and spend metadata, so only the fallback lookup key moves to the tier.

## Screenshots / Proof of Fix

Two tiers behind a router, with a fallback chain configured for the tier and the tier's deployment failing. `mock_response` stands in for the provider so the failure is deterministic; no real key is involved.

```python
class TierRouter(Router):
    async def async_pre_routing_hook(self, model, request_kwargs, messages=None, input=None, specific_deployment=False):
        if model == "smart-router":
            return PreRoutingHookResponse(model="tier1", messages=messages)
        return None

router = TierRouter(
    model_list=[
        {"model_name": "smart-router", "litellm_params": {"model": "openai/gpt-4o-mini", "api_key": "sk-x"}},
        {"model_name": "tier1", "litellm_params": {"model": "openai/gpt-4o-mini", "api_key": "sk-x",
                                                    "mock_response": "litellm.RateLimitError"}},
        {"model_name": "backup-a", "litellm_params": {"model": "openai/gpt-4o-mini", "api_key": "sk-x",
                                                       "mock_response": "from backup-a"}},
    ],
    fallbacks=[{"tier1": ["backup-a"]}],
    num_retries=0,
)
await router.acompletion(model="smart-router", messages=[{"role": "user", "content": "hi"}])
```

### Before (5e4b3838aa)

#### the tier's chain is skipped and the provider error is returned

1. `python repro.py`
2. ```
   LiteLLM Router:ERROR: async_function_with_fallbacks() - Error occurred while trying to do fallbacks
   No fallback model group found for original model_group=smart-router. Fallbacks=[{'tier1': ['backup-a']}]
   RESULT: no fallback -> RateLimitError litellm.RateLimitError: this is a mock rate limit error
   ```
3. That is the message from the issue, reproduced

### After (c471f59879)

#### the tier's chain runs

1. `python repro.py`
2. ```
   RESULT: fallback ran, answered: from backup-a
   ```
3. A chain keyed on `tier2` instead still rescues nothing, and calling `tier1` directly still uses its own chain

## Type

🐛 Bug Fix

## Caveats (if any)

### Medium

- Fallbacks now fire for router-fronted requests that previously failed outright
  - That is the fix, but a deployment whose fallback chain was effectively dormant will start taking traffic
  - Only requests whose pre-routing hook selected a different model are affected; everything else keys off the same name as before

### Low

- A caller that sends `pre_routing_selected_model` in `metadata` no longer sees it in spend logs, since the router clears the key before routing
- The selection rides in the metadata bucket, so a caller that passes neither `metadata` nor `litellm_metadata` gets the old behaviour
  - Both proxy and SDK paths populate one of them, so this is the fallback for a hand-built kwargs dict rather than a normal request
- Only the async path is touched, since the pre-routing hook is async only and the sync router never selects a tier

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which fallback chain runs for router-fronted requests, so previously inert per-tier fallbacks may start taking traffic; metadata bucket writes are cleared each hop but follow existing router patterns.
> 
> **Overview**
> Fixes **#38832**: when a pre-routing hook (complexity/auto/adaptive routers) routes `smart-router` to a tier like `tier1`, **fallback chains keyed on that tier now run** instead of lookup failing on the client-facing router name.
> 
> The router **records the hook’s chosen model** in shared `metadata` / `litellm_metadata` via `record_pre_routing_selection`, and **fallback resolution** (standard fallbacks, order fallbacks, context-window, and content-policy paths) uses `get_pre_routing_selection(kwargs) or model_group` as the lookup key. **`original_model_group` stays the caller’s model** for logging and headers.
> 
> Each **`async_function_with_fallbacks` hop clears** `pre_routing_selected_model` first so callers cannot steer fallback chains and later hops resolve against their own group, not a stale tier from the prior failure.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5eefd64ade3424a49c502f915cf5a33f7e90aeab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->