### PR TITLE
fix(websearch): keep the provider prefix on the agentic follow-up model

### DIFF
--- a/litellm/integrations/websearch_interception/handler.py
+++ b/litellm/integrations/websearch_interception/handler.py
@@ -1794,11 +1794,9 @@ class WebSearchInterceptionLogger(CustomLogger):
             k: v for k, v in kwargs.items() if not k.startswith("_websearch_interception") and k not in internal_params
         }
 
-        full_model_name = model
-        if "custom_llm_provider" in kwargs:
-            custom_llm_provider: Final = kwargs["custom_llm_provider"]
-            if not model.startswith(custom_llm_provider) and "/" not in model:
-                full_model_name = f"{custom_llm_provider}/{model}"
+        from litellm.litellm_core_utils.core_helpers import qualify_provider_stripped_model
+
+        full_model_name: Final = qualify_provider_stripped_model(model, kwargs.get("custom_llm_provider", ""))
 
         verbose_logger.debug(
             "WebSearchInterception: Built chat completion request patch model=%s messages=%d",

--- a/litellm/litellm_core_utils/core_helpers.py
+++ b/litellm/litellm_core_utils/core_helpers.py
@@ -30,13 +30,10 @@ def is_codex_user_agent(user_agent: str) -> bool:
 
 
 def qualify_provider_stripped_model(model: str, custom_llm_provider: str) -> str:
-    """
-    Put the provider prefix back on a model an agentic follow-up re-dispatches with.
+    """Put the provider prefix back on a provider-stripped model.
 
-    Handlers are handed the provider-stripped model, and for providers that route through
-    a sub-path (``bedrock/mantle/...``, ``openrouter/openai/...``) that remainder still
-    holds a slash. Treating any slash as "already qualified" drops the prefix and leaves a
-    string no provider can be resolved from.
+    A sub-path provider (``bedrock/mantle/...``) leaves a slash in the remainder, so
+    treating any slash as "already qualified" would drop the prefix.
     """
     if not custom_llm_provider or model.startswith(f"{custom_llm_provider}/"):
         return model

--- a/litellm/litellm_core_utils/core_helpers.py
+++ b/litellm/litellm_core_utils/core_helpers.py
@@ -30,11 +30,7 @@ def is_codex_user_agent(user_agent: str) -> bool:
 
 
 def qualify_provider_stripped_model(model: str, custom_llm_provider: str) -> str:
-    """Put the provider prefix back on a provider-stripped model.
-
-    A sub-path provider (``bedrock/mantle/...``) leaves a slash in the remainder, so
-    treating any slash as "already qualified" would drop the prefix.
-    """
+    """Put the provider prefix back on a provider-stripped model."""
     if not custom_llm_provider or model.startswith(f"{custom_llm_provider}/"):
         return model
     return f"{custom_llm_provider}/{model}"

--- a/litellm/litellm_core_utils/core_helpers.py
+++ b/litellm/litellm_core_utils/core_helpers.py
@@ -29,6 +29,20 @@ def is_codex_user_agent(user_agent: str) -> bool:
     return bool(_CODEX_CLIENT_PREFIX_RE.match(user_agent))
 
 
+def qualify_provider_stripped_model(model: str, custom_llm_provider: str) -> str:
+    """
+    Put the provider prefix back on a model an agentic follow-up re-dispatches with.
+
+    Handlers are handed the provider-stripped model, and for providers that route through
+    a sub-path (``bedrock/mantle/...``, ``openrouter/openai/...``) that remainder still
+    holds a slash. Treating any slash as "already qualified" drops the prefix and leaves a
+    string no provider can be resolved from.
+    """
+    if not custom_llm_provider or model.startswith(f"{custom_llm_provider}/"):
+        return model
+    return f"{custom_llm_provider}/{model}"
+
+
 def safe_divide_seconds(seconds: float, denominator: float, default: float | None = None) -> float | None:
     """
     Safely divide seconds by denominator, handling zero division.

--- a/litellm/llms/custom_httpx/llm_http_handler.py
+++ b/litellm/llms/custom_httpx/llm_http_handler.py
@@ -5599,9 +5599,9 @@ class BaseLLMHTTPHandler:
         if patch.messages is None:
             raise ValueError("Agentic loop plan missing patched messages")
 
-        full_model_name = patch.model or model
-        if "/" not in full_model_name:
-            full_model_name = f"{custom_llm_provider}/{full_model_name}"
+        from litellm.litellm_core_utils.core_helpers import qualify_provider_stripped_model
+
+        full_model_name: Final = qualify_provider_stripped_model(patch.model or model, custom_llm_provider)
 
         optional_params_for_followup: Final = dict(optional_params)
         optional_params_for_followup.update(patch.optional_params)

--- a/tests/test_litellm/litellm_core_utils/test_core_helpers.py
+++ b/tests/test_litellm/litellm_core_utils/test_core_helpers.py
@@ -11,6 +11,7 @@ from litellm.litellm_core_utils.core_helpers import (
     get_or_create_metadata_bucket,
     map_finish_reason,
     normalize_drop_params,
+    qualify_provider_stripped_model,
     reconstruct_model_name,
     redact_nested_match_and_regex_keys,
 )
@@ -406,3 +407,43 @@ class TestIsExpectedClientError:
             category=RateLimitErrorCategory.VENDOR_RATE_LIMIT,
         )
         assert is_expected_client_error(vendor_limit) is False
+
+
+class TestQualifyProviderStrippedModel:
+    """#38829: an agentic follow-up re-dispatched the provider-stripped model. For providers
+    that route through a sub-path the remainder still holds a slash, and the old
+    "any slash means already qualified" test dropped the prefix, leaving a string
+    litellm.acompletion could not resolve a provider from."""
+
+    @pytest.mark.parametrize(
+        "model,provider,expected",
+        [
+            # the reported case: bedrock's OpenAI-compatible sub-path
+            ("mantle/anthropic.claude-sonnet-5", "bedrock", "bedrock/mantle/anthropic.claude-sonnet-5"),
+            ("invoke/anthropic.claude-v2", "bedrock", "bedrock/invoke/anthropic.claude-v2"),
+            # another provider whose stripped model keeps a slash
+            ("openai/gpt-4o", "openrouter", "openrouter/openai/gpt-4o"),
+            # the ordinary case still works
+            ("gpt-4o", "openai", "openai/gpt-4o"),
+            ("claude-sonnet-4-5", "anthropic", "anthropic/claude-sonnet-4-5"),
+        ],
+    )
+    def test_the_provider_prefix_is_restored(self, model, provider, expected):
+        assert qualify_provider_stripped_model(model, provider) == expected
+
+    @pytest.mark.parametrize(
+        "model,provider",
+        [
+            ("bedrock/mantle/anthropic.claude-sonnet-5", "bedrock"),
+            ("openai/gpt-4o", "openai"),
+        ],
+    )
+    def test_an_already_qualified_model_is_left_alone(self, model, provider):
+        assert qualify_provider_stripped_model(model, provider) == model
+
+    def test_a_provider_that_only_shares_a_prefix_is_still_qualified(self):
+        """`openai` must not be read as a prefix of `openai_like`."""
+        assert qualify_provider_stripped_model("openai_like/foo", "openai") == "openai/openai_like/foo"
+
+    def test_no_provider_leaves_the_model_untouched(self):
+        assert qualify_provider_stripped_model("gpt-4o", "") == "gpt-4o"

--- a/tests/test_litellm/litellm_core_utils/test_core_helpers.py
+++ b/tests/test_litellm/litellm_core_utils/test_core_helpers.py
@@ -410,10 +410,7 @@ class TestIsExpectedClientError:
 
 
 class TestQualifyProviderStrippedModel:
-    """#38829: an agentic follow-up re-dispatched the provider-stripped model. For providers
-    that route through a sub-path the remainder still holds a slash, and the old
-    "any slash means already qualified" test dropped the prefix, leaving a string
-    litellm.acompletion could not resolve a provider from."""
+    """#38829: a model whose remainder still holds a slash must keep its provider prefix."""
 
     @pytest.mark.parametrize(
         "model,provider,expected",
@@ -439,7 +436,6 @@ class TestQualifyProviderStrippedModel:
         assert qualify_provider_stripped_model(model, provider) == model
 
     def test_a_provider_that_only_shares_a_prefix_is_still_qualified(self):
-        """`openai` must not be read as a prefix of `openai_like`."""
         assert qualify_provider_stripped_model("openai_like/foo", "openai") == "openai/openai_like/foo"
 
     def test_no_provider_leaves_the_model_untouched(self):

--- a/tests/test_litellm/litellm_core_utils/test_core_helpers.py
+++ b/tests/test_litellm/litellm_core_utils/test_core_helpers.py
@@ -418,12 +418,9 @@ class TestQualifyProviderStrippedModel:
     @pytest.mark.parametrize(
         "model,provider,expected",
         [
-            # the reported case: bedrock's OpenAI-compatible sub-path
             ("mantle/anthropic.claude-sonnet-5", "bedrock", "bedrock/mantle/anthropic.claude-sonnet-5"),
             ("invoke/anthropic.claude-v2", "bedrock", "bedrock/invoke/anthropic.claude-v2"),
-            # another provider whose stripped model keeps a slash
             ("openai/gpt-4o", "openrouter", "openrouter/openai/gpt-4o"),
-            # the ordinary case still works
             ("gpt-4o", "openai", "openai/gpt-4o"),
             ("claude-sonnet-4-5", "anthropic", "anthropic/claude-sonnet-4-5"),
         ],

--- a/tests/test_litellm/llms/custom_httpx/test_llm_http_handler.py
+++ b/tests/test_litellm/llms/custom_httpx/test_llm_http_handler.py
@@ -3713,3 +3713,51 @@ def test_image_edit_handler_keeps_the_sync_transform():
     assert config.transform_calls == ["sync"]
     assert captured["body"] == {"transformed_by": "sync"}
     assert response.data[0].b64_json == "sync"
+
+
+class TestAgenticFollowUpKeepsTheProviderPrefix:
+    """#38829: the follow-up re-dispatched the provider-stripped model. For a provider that
+    routes through a sub-path the remainder still holds a slash, so the old
+    "a slash means already qualified" test dropped the prefix and the follow-up raised
+    "LLM Provider NOT provided"."""
+
+    @staticmethod
+    def _plan():
+        from litellm.types.integrations.custom_logger import (
+            AgenticLoopPlan,
+            AgenticLoopRequestPatch,
+        )
+
+        return AgenticLoopPlan(
+            run_agentic_loop=True,
+            request_patch=AgenticLoopRequestPatch(messages=[{"role": "user", "content": "hi"}]),
+        )
+
+    async def _run_followup(self, model: str, custom_llm_provider: str):
+        from litellm.llms.custom_httpx.llm_http_handler import BaseLLMHTTPHandler
+
+        return await BaseLLMHTTPHandler()._execute_chat_completion_agentic_plan(
+            plan=self._plan(),
+            model=model,
+            messages=[{"role": "user", "content": "hi"}],
+            optional_params={"mock_response": "ok from followup"},
+            kwargs={},
+            custom_llm_provider=custom_llm_provider,
+            depth=0,
+            max_loops=2,
+            fingerprints=[],
+            fingerprint="fp",
+        )
+
+    @pytest.mark.asyncio
+    async def test_a_sub_path_model_still_resolves_a_provider(self):
+        """bedrock/mantle/... reaches the handler as mantle/..., which alone is unroutable."""
+        response = await self._run_followup("mantle/anthropic.claude-sonnet-5", "bedrock")
+
+        assert response.choices[0].message.content == "ok from followup"
+
+    @pytest.mark.asyncio
+    async def test_an_ordinary_model_still_resolves_a_provider(self):
+        response = await self._run_followup("gpt-4o-mini", "openai")
+
+        assert response.choices[0].message.content == "ok from followup"

--- a/tests/test_litellm/llms/custom_httpx/test_llm_http_handler.py
+++ b/tests/test_litellm/llms/custom_httpx/test_llm_http_handler.py
@@ -3716,10 +3716,7 @@ def test_image_edit_handler_keeps_the_sync_transform():
 
 
 class TestAgenticFollowUpKeepsTheProviderPrefix:
-    """#38829: the follow-up re-dispatched the provider-stripped model. For a provider that
-    routes through a sub-path the remainder still holds a slash, so the old
-    "a slash means already qualified" test dropped the prefix and the follow-up raised
-    "LLM Provider NOT provided"."""
+    """#38829: the follow-up must re-dispatch a model litellm.acompletion can route."""
 
     @staticmethod
     def _plan():
@@ -3751,7 +3748,6 @@ class TestAgenticFollowUpKeepsTheProviderPrefix:
 
     @pytest.mark.asyncio
     async def test_a_sub_path_model_still_resolves_a_provider(self):
-        """bedrock/mantle/... reaches the handler as mantle/..., which alone is unroutable."""
         response = await self._run_followup("mantle/anthropic.claude-sonnet-5", "bedrock")
 
         assert response.choices[0].message.content == "ok from followup"


### PR DESCRIPTION
## TLDR

The agentic follow-up rebuilds the model string it re-dispatches with, and treats any slash as "already has a provider prefix". Providers that route through a sub-path still have a slash after the provider is stripped, so the prefix gets dropped and the follow-up cannot resolve a provider.

Fix: prefix unless the model already starts with that provider *plus a separator*, in one helper used by both copies of the old heuristic.

## User Flow

**Before** — web search works on the first hop, then the follow-up dies.

1. Operator deploys `bedrock/mantle/anthropic.claude-sonnet-5` with `websearch_interception` enabled
2. Client POSTs `/v1/chat/completions` with `"stream": true` and a web-search tool
3. Search runs, results come back — first hop looks healthy
4. Follow-up fails: `litellm.BadRequestError: LLM Provider NOT provided. ... You passed model=mantle/anthropic.claude-sonnet-5`
5. No config change helps; the model string is rebuilt internally

**After** — step 4 dispatches to `bedrock/mantle/anthropic.claude-sonnet-5` and answers. `openrouter/openai/gpt-4o` behaves the same way.

## Relevant issues

Fixes #38829

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## One correction to the issue's diagnosis

The issue reads `custom_llm_provider` as resolving to `mantle`. It actually resolves to `bedrock`:

```
litellm.get_llm_provider("bedrock/mantle/anthropic.claude-sonnet-5")
  -> model='mantle/anthropic.claude-sonnet-5', provider='bedrock'
```

The handler is handed the provider-stripped model, and that remainder still holds a slash — so `if "/" not in name` concluded it was already qualified and `bedrock/` was lost. Same failure and same fix the issue asks for, but the cause is the slash test, not provider resolution.

Two places carried that heuristic (the handler and the websearch patch builder that feeds it), so both now call one helper. The patch builder's copy also used `model.startswith(custom_llm_provider)` with no separator, which reads `openai` as a prefix of `openai_like`; the helper compares against `openai/`.

## Screenshots / Proof of Fix

The bug is in the model string the follow-up re-dispatches with, so the proof is what that string resolves to. No provider call and no key involved.

```python
DEPLOYMENT = "bedrock/mantle/anthropic.claude-sonnet-5"
stripped, provider, _, _ = litellm.get_llm_provider(model=DEPLOYMENT)   # what the handler is handed

def old_logic(model, custom_llm_provider):
    if "/" not in model:
        return f"{custom_llm_provider}/{model}"
    return model

litellm.get_llm_provider(model=old_logic(stripped, provider))                        # before
litellm.get_llm_provider(model=qualify_provider_stripped_model(stripped, provider))  # after
```

### Before (aea5358c48)

```
deployment            : bedrock/mantle/anthropic.claude-sonnet-5
handler receives      : model='mantle/anthropic.claude-sonnet-5' custom_llm_provider='bedrock'
BEFORE follow-up model: 'mantle/anthropic.claude-sonnet-5' -> BadRequestError: LLM Provider NOT provided.
```

That is the error from the issue, reproduced.

### After (cbdffd27f9)

```
AFTER  follow-up model: 'bedrock/mantle/anthropic.claude-sonnet-5' -> routable
```

`openrouter` + `openai/gpt-4o` gives `openrouter/openai/gpt-4o`, and an already-qualified model is left untouched.

## Type

🐛 Bug Fix

## Caveats (if any)

- This is the second of two failures the reporter hit. #38828 (the `aws_region_name` kwarg collision) is separate and still open — both are needed for the flow to run end to end.
- The end-to-end run needs a Bedrock Mantle deployment I don't have, so the proof is at model-resolution level rather than a live search.
- `patch.model` still wins over the handler's model when the plan sets one. Unchanged; only the qualification rule moved.

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
