### PR TITLE
fix(ui): stop adding non-additive savings into Total saved

### DIFF
--- a/ui/litellm-dashboard/src/app/(dashboard)/cost-optimization/_components/UsageTab.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/cost-optimization/_components/UsageTab.test.tsx
@@ -329,7 +329,7 @@ describe("UsageTab", () => {
 
     const slices = JSON.parse(getByTestId("donut-chart").getAttribute("data-slices") ?? "[]");
     expect(slices.map((d: { driver: string }) => d.driver)).toEqual(["Compression", "Prompt caching"]);
-    expect(getByTestId("donut-chart").getAttribute("data-label")).toBeNull();
+    expect(getByTestId("donut-chart")).not.toHaveAttribute("data-label");
   });
 
   it("carries auto-router savings into the summary card, donut slice, and cumulative series", () => {

--- a/ui/litellm-dashboard/src/app/(dashboard)/cost-optimization/_components/UsageTab.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/cost-optimization/_components/UsageTab.test.tsx
@@ -138,8 +138,8 @@ describe("UsageTab", () => {
 
   it("sums compression and caching dollars across days into the summary cards", () => {
     // Total caching and the LiteLLM-injected share deliberately differ so these
-    // assertions pin which one each figure uses: the caching headline and the
-    // Total-saved tile take the injected share, the secondary keeps the total.
+    // assertions pin which one each figure uses: the caching headline takes the
+    // injected share, the secondary keeps the total. There is no combined tile.
     const firstDay: Partial<SpendMetrics> = {
       compression_savings_spend: 0.04,
       prompt_caching_savings_spend: 0.006,
@@ -152,13 +152,14 @@ describe("UsageTab", () => {
       gateway_injected_caching_savings_spend: 0.006,
       compression_saved_tokens: 100000,
     };
-    const { getByText } = renderWith([day("2026-07-12", firstDay), day("2026-07-13", secondDay)]);
+    const { getByText, queryByText } = renderWith([day("2026-07-12", firstDay), day("2026-07-13", secondDay)]);
 
-    expect(getByText("$0.1500")).toBeInTheDocument();
     expect(getByText("$0.1400")).toBeInTheDocument();
     expect(getByText("$0.0100")).toBeInTheDocument();
     expect(getByText("$0.0160")).toBeInTheDocument();
     expect(getByText("140,000 tokens compressed")).toBeInTheDocument();
+    expect(queryByText("$0.1500")).not.toBeInTheDocument();
+    expect(queryByText("Total saved")).not.toBeInTheDocument();
   });
 
   const twoDays = () => [
@@ -236,7 +237,7 @@ describe("UsageTab", () => {
   it("says what the line means and over what range", async () => {
     const { getByText, getByRole } = renderWith(twoDays());
 
-    expect(getByText("Running total saved · Jul 1 – Jul 14 (UTC)")).toBeInTheDocument();
+    expect(getByText("Running total by driver · Jul 1 – Jul 14 (UTC)")).toBeInTheDocument();
     await userEvent.click(getByRole("tab", { name: "Per day" }));
     expect(getByText("Saved per day · Jul 1 – Jul 14 (UTC)")).toBeInTheDocument();
   });
@@ -277,7 +278,7 @@ describe("UsageTab", () => {
   });
 
   it("lays the savings header out with the card's own slots so nothing shifts between tabs", async () => {
-    // The subtitle differs in length between the tabs ("Running total saved" vs "Saved
+    // The subtitle differs in length between the tabs ("Running total by driver" vs "Saved
     // per day"). Hand-rolled rows made it compete with the legend and the toggle for
     // width, so the header grew a line on one tab and the chart moved with it. CardHeader
     // sizes the action column to its content and gives the rest to the title column.
@@ -298,7 +299,7 @@ describe("UsageTab", () => {
     expect(before.action.contains(getByRole("tablist"))).toBe(true);
     // the subtitle lives outside that slot, so its length cannot reposition the controls
     expect(before.action.contains(before.description)).toBe(false);
-    expect(before.description).toHaveTextContent(/Running total saved/);
+    expect(before.description).toHaveTextContent(/Running total by driver/);
 
     await userEvent.click(getByRole("tab", { name: "Per day" }));
 
@@ -310,11 +311,12 @@ describe("UsageTab", () => {
     expect(container).toHaveTextContent(/Savings/);
   });
 
-  it("subtracts a losing auto-router route from the total and keeps it out of the donut", () => {
+  it("keeps a losing auto-router route on its card and out of the donut", () => {
     // Switching models leaves the new one with a cold cache, so a route can cost more
-    // than the baseline would have. A negative slice is meaningless in a donut, but the
-    // total has to keep the loss or the page can only ever report good news.
-    const { getByText, getByTestId } = renderWith([
+    // than the baseline would have. A negative slice is meaningless in a donut; the
+    // auto-router card still shows the loss. The page does not add that loss into a
+    // combined headline.
+    const { getByText, queryByText, getByTestId } = renderWith([
       day("2026-07-12", {
         compression_savings_spend: 0.1,
         gateway_injected_caching_savings_spend: 0.02,
@@ -322,16 +324,16 @@ describe("UsageTab", () => {
       }),
     ]);
 
-    expect(getByText("$0.0700")).toBeInTheDocument();
     expect(getByText("-$0.0500")).toBeInTheDocument();
+    expect(queryByText("$0.0700")).not.toBeInTheDocument();
 
     const slices = JSON.parse(getByTestId("donut-chart").getAttribute("data-slices") ?? "[]");
     expect(slices.map((d: { driver: string }) => d.driver)).toEqual(["Compression", "Prompt caching"]);
-    expect(getByTestId("donut-chart")).toHaveAttribute("data-label", "$0.1200");
+    expect(getByTestId("donut-chart").getAttribute("data-label")).toBeNull();
   });
 
   it("carries auto-router savings into the summary card, donut slice, and cumulative series", () => {
-    const { getByText, getByTestId } = renderWith([
+    const { getByText, queryByText, getByTestId } = renderWith([
       day("2026-07-12", {
         compression_savings_spend: 0.04,
         gateway_injected_caching_savings_spend: 0.006,
@@ -344,9 +346,8 @@ describe("UsageTab", () => {
       }),
     ]);
 
-    // Total saved now sums three drivers, and the auto-router card carries its own total.
-    expect(getByText("$0.2260")).toBeInTheDocument();
     expect(getByText("$0.0700")).toBeInTheDocument();
+    expect(queryByText("$0.2260")).not.toBeInTheDocument();
 
     // The driver donut gains a third slice priced from the range totals.
     const slices = JSON.parse(getByTestId("donut-chart").getAttribute("data-slices") ?? "[]");

--- a/ui/litellm-dashboard/src/app/(dashboard)/cost-optimization/_components/UsageTab.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/cost-optimization/_components/UsageTab.tsx
@@ -87,7 +87,7 @@ const UsageTab: React.FC<UsageTabProps> = ({ accessToken, activity }) => {
   const intervalLabel = "Per day";
   const rangeLabel = formatRangeLabel(startTime ?? undefined, endTime ?? undefined);
   const savingsSubtitle = [
-    accumulation === "cumulative" ? "Running total saved" : `Saved ${intervalLabel.toLowerCase()}`,
+    accumulation === "cumulative" ? "Running total by driver" : `Saved ${intervalLabel.toLowerCase()}`,
     rangeLabel && `${rangeLabel} (UTC)`,
   ]
     .filter(Boolean)
@@ -105,8 +105,6 @@ const UsageTab: React.FC<UsageTabProps> = ({ accessToken, activity }) => {
       })).filter((d) => d.usd > 0),
     [results],
   );
-  const plottedDriverTotal = useMemo(() => byDriver.reduce((sum, d) => sum + d.usd, 0), [byDriver]);
-
   const topTools = useMemo(() => topToolsBySpend(toolSpend?.by_tool ?? []), [toolSpend]);
   const topToolNames = useMemo(() => topTools.map((t) => t.tool_name), [topTools]);
   const topToolsChart = useMemo<Record<string, string | number>[]>(
@@ -180,6 +178,7 @@ const UsageTab: React.FC<UsageTabProps> = ({ accessToken, activity }) => {
         <Card>
           <CardHeader>
             <CardTitle>Savings by driver</CardTitle>
+            <CardDescription>Alternative views, not parts of one total</CardDescription>
           </CardHeader>
           <CardContent>
             <DonutChart
@@ -189,8 +188,6 @@ const UsageTab: React.FC<UsageTabProps> = ({ accessToken, activity }) => {
               category="usd"
               colors={byDriver.map((d) => d.color)}
               valueFormatter={usd}
-              showLabel
-              label={usd(plottedDriverTotal)}
             />
           </CardContent>
         </Card>

--- a/ui/litellm-dashboard/src/app/(dashboard)/cost-optimization/_components/costOptimizationUtils.test.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/cost-optimization/_components/costOptimizationUtils.test.ts
@@ -12,6 +12,7 @@ import {
   isAnthropicModel,
   localIsoDay,
   savingsSeriesOf,
+  savingsTotalsOf,
   toCumulative,
   topToolsBySpend,
   usd,
@@ -398,6 +399,38 @@ describe("usd", () => {
     expect(usd(-0.05)).toBe("-$0.0500");
     expect(usd(-0.0004)).toBe("-$0.0004");
     expect(usd(-12.4)).toBe("-$12.40");
+  });
+});
+
+describe("savingsTotalsOf", () => {
+  it("does not expose a summed total for non-additive caching and auto-router views", () => {
+    const results: DailyData[] = [
+      {
+        date: "2026-08-29",
+        metrics: metrics({
+          spend: 6,
+          compression_savings_spend: 0,
+          prompt_caching_savings_spend: 4,
+          gateway_injected_caching_savings_spend: 4,
+          autorouter_savings_spend: 6,
+        }),
+        breakdown: {
+          models: {},
+          model_groups: {},
+          mcp_servers: {},
+          providers: {},
+          entities: {},
+          api_keys: {},
+        },
+      },
+    ];
+
+    const totals = savingsTotalsOf(results);
+
+    expect(totals.compression).toBe(0);
+    expect(totals.gatewayAttributedCaching).toBe(4);
+    expect(totals.autorouter).toBe(6);
+    expect(totals).not.toHaveProperty("total");
   });
 });
 

--- a/ui/litellm-dashboard/src/app/(dashboard)/cost-optimization/_components/costOptimizationUtils.test.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/cost-optimization/_components/costOptimizationUtils.test.ts
@@ -404,16 +404,17 @@ describe("usd", () => {
 
 describe("savingsTotalsOf", () => {
   it("does not expose a summed total for non-additive caching and auto-router views", () => {
+    const overlappingDrivers: Partial<SpendMetrics> = {
+      spend: 6,
+      compression_savings_spend: 0,
+      prompt_caching_savings_spend: 4,
+      gateway_injected_caching_savings_spend: 4,
+      autorouter_savings_spend: 6,
+    };
     const results: DailyData[] = [
       {
         date: "2026-08-29",
-        metrics: metrics({
-          spend: 6,
-          compression_savings_spend: 0,
-          prompt_caching_savings_spend: 4,
-          gateway_injected_caching_savings_spend: 4,
-          autorouter_savings_spend: 6,
-        }),
+        metrics: metrics(overlappingDrivers),
         breakdown: {
           models: {},
           model_groups: {},

--- a/ui/litellm-dashboard/src/app/(dashboard)/cost-optimization/_components/costOptimizationUtils.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/cost-optimization/_components/costOptimizationUtils.ts
@@ -206,6 +206,22 @@ type SavingsDriverName = (typeof SAVINGS_DRIVERS)[number]["name"];
 export const sumOverDays = (results: readonly DailyData[], of: (m: SpendMetrics) => number): number =>
   results.reduce((sum, d) => sum + of(d.metrics), 0);
 
+export type SavingsTotals = {
+  readonly compression: number;
+  readonly caching: number;
+  readonly autorouter: number;
+  readonly gatewayAttributedCaching: number;
+  readonly savedTokens: number;
+};
+
+export const savingsTotalsOf = (results: readonly DailyData[]): SavingsTotals => ({
+  compression: sumOverDays(results, compressionOf),
+  caching: sumOverDays(results, cachingOf),
+  autorouter: sumOverDays(results, autorouterOf),
+  gatewayAttributedCaching: sumOverDays(results, gatewayAttributedCachingOf),
+  savedTokens: sumOverDays(results, savedTokensOf),
+});
+
 /**
  * One point per day, each driver plotting the metric its SAVINGS_DRIVERS entry
  * names. The rollup arrives newest first, so sort on the raw ISO date before

--- a/ui/litellm-dashboard/src/components/shared/SavingsTiles.test.tsx
+++ b/ui/litellm-dashboard/src/components/shared/SavingsTiles.test.tsx
@@ -1,0 +1,50 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import SavingsTiles from "./SavingsTiles";
+import type { DailyData, SpendMetrics } from "@/components/UsagePage/types";
+
+const metrics = (overrides: Partial<SpendMetrics>): SpendMetrics => ({
+  spend: 6,
+  prompt_tokens: 0,
+  completion_tokens: 0,
+  total_tokens: 0,
+  api_requests: 1,
+  successful_requests: 1,
+  failed_requests: 0,
+  cache_read_input_tokens: 0,
+  cache_creation_input_tokens: 0,
+  ...overrides,
+});
+
+const day = (overrides: Partial<SpendMetrics>): DailyData => ({
+  date: "2026-08-29",
+  metrics: metrics(overrides),
+  breakdown: {
+    models: {},
+    model_groups: {},
+    mcp_servers: {},
+    providers: {},
+    entities: {},
+    api_keys: {},
+  },
+});
+
+describe("SavingsTiles", () => {
+  it("does not add caching and auto-router cards into one Total saved headline", () => {
+    const overlappingDrivers: Partial<SpendMetrics> = {
+      compression_savings_spend: 0,
+      prompt_caching_savings_spend: 4,
+      gateway_injected_caching_savings_spend: 4,
+      autorouter_savings_spend: 6,
+    };
+    const { queryByTestId, getByTestId, queryByText } = render(
+      <SavingsTiles isLoading={false} results={[day(overlappingDrivers)]} />,
+    );
+
+    expect(queryByTestId("summary-card-total-saved")).not.toBeInTheDocument();
+    expect(queryByText("$10.00")).not.toBeInTheDocument();
+    expect(getByTestId("summary-card-prompt-caching-savings")).toHaveTextContent("$4.00");
+    expect(getByTestId("summary-card-auto-router-savings")).toHaveTextContent("$6.00");
+  });
+});

--- a/ui/litellm-dashboard/src/components/shared/SavingsTiles.tsx
+++ b/ui/litellm-dashboard/src/components/shared/SavingsTiles.tsx
@@ -3,63 +3,33 @@
 import React, { useMemo } from "react";
 
 import SummaryCard from "@/components/shared/SummaryCard";
-import {
-  autorouterOf,
-  cachingOf,
-  compressionOf,
-  gatewayAttributedCachingOf,
-  SAVINGS_DRIVERS,
-  savedTokensOf,
-  sumOverDays,
-  usd,
-} from "@/app/(dashboard)/cost-optimization/_components/costOptimizationUtils";
+import { savingsTotalsOf, usd } from "@/app/(dashboard)/cost-optimization/_components/costOptimizationUtils";
 import { DailyData } from "@/components/UsagePage/types";
 import { formatNumberWithCommas } from "@/utils/dataUtils";
 
-// The total sums SAVINGS_DRIVERS, so it is by construction the sum of what the
-// charts plot; the donut and timelines derive from the same list in costOptimizationUtils.
-const useSavingsTotals = (results: DailyData[]) =>
-  useMemo(
-    () => ({
-      compression: sumOverDays(results, compressionOf),
-      caching: sumOverDays(results, cachingOf),
-      autorouter: sumOverDays(results, autorouterOf),
-      gatewayAttributedCaching: sumOverDays(results, gatewayAttributedCachingOf),
-      savedTokens: sumOverDays(results, savedTokensOf),
-      total: SAVINGS_DRIVERS.reduce((sum, { of }) => sum + sumOverDays(results, of), 0),
-    }),
-    [results],
-  );
-
 const SavingsTiles = ({ results, isLoading }: { results: DailyData[]; isLoading: boolean }) => {
-  const totals = useSavingsTotals(results);
+  const totals = useMemo(() => savingsTotalsOf(results), [results]);
 
   return (
-    <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-4">
-      <SummaryCard
-        label="Total saved"
-        value={usd(totals.total)}
-        hint={isLoading ? "Loading..." : "Compression + prompt caching + auto-router"}
-        info="The sum of the three tiles beside it. Its caching term is the LiteLLM-injected share, so this total is what the gateway itself delivered; caching that clients or providers brought on their own appears only in the caching tile's Total figure."
-      />
+    <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3">
       <SummaryCard
         label="Compression savings"
         value={usd(totals.compression)}
         hint={`${formatNumberWithCommas(totals.savedTokens)} tokens compressed`}
-        info="Tokens Headroom removed before the call, priced at the model's input rate."
+        info="Tokens Headroom removed before the call, priced at the model's input rate. This is its own counterfactual, not a slice of a combined total."
       />
       <SummaryCard
         label="Prompt caching savings"
         value={usd(totals.gatewayAttributedCaching)}
         hint="LiteLLM injected"
         secondary={{ label: "Total", value: usd(totals.caching) }}
-        info="What caching saved against paying the input rate for every token: the discount on tokens served from cache, less the premium providers charge to write a cache entry. The headline figure is the share LiteLLM earned by inserting the breakpoints itself, through configured injection points or auto prompt caching. The total beside it also counts requests that arrived with their own cache_control and providers that cache implicitly. Either can be negative on traffic that writes more cache than it reuses, which is why the headline is not always the smaller of the two."
+        info="What caching saved against paying the input rate for every token: the discount on tokens served from cache, less the premium providers charge to write a cache entry. The headline figure is the share LiteLLM earned by inserting the breakpoints itself, through configured injection points or auto prompt caching. The total beside it also counts requests that arrived with their own cache_control and providers that cache implicitly. Either can be negative on traffic that writes more cache than it reuses, which is why the headline is not always the smaller of the two. This view is not added to auto-router savings."
       />
       <SummaryCard
         label="Auto-router savings"
         value={usd(totals.autorouter)}
-        hint="vs. the priciest model it could pick"
-        info="What this traffic would have cost had every request gone to the most expensive model the auto-router can route to, minus what it actually cost. Switching leaves the new model with a cold cache, so it pays to write the prompt again while the baseline is priced as already warm; a route that thrashes the cache can total below zero, and a genuine first turn, where neither side had anything cached, is undercounted."
+        hint={isLoading ? "Loading..." : "vs. the priciest model it could pick"}
+        info="What this traffic would have cost had every request gone to the most expensive model the auto-router can route to, minus what it actually cost. That baseline is already cache-aware, so adding prompt-caching savings on top would count the same cache effect twice. Switching leaves the new model with a cold cache, so it pays to write the prompt again while the baseline is priced as already warm; a route that thrashes the cache can total below zero, and a genuine first turn, where neither side had anything cached, is undercounted."
       />
     </div>
   );

--- a/ui/litellm-dashboard/src/components/templates/KeySavingsTab.integration.test.tsx
+++ b/ui/litellm-dashboard/src/components/templates/KeySavingsTab.integration.test.tsx
@@ -87,7 +87,8 @@ describe("KeySavingsTab", () => {
 
     renderTab();
 
-    expect(screen.getByTestId("summary-card-total-saved")).toHaveTextContent("$5.40");
+    expect(screen.queryByTestId("summary-card-total-saved")).not.toBeInTheDocument();
+    expect(screen.queryByText("$5.40")).not.toBeInTheDocument();
     expect(screen.getByTestId("summary-card-compression-savings")).toHaveTextContent("$2.00");
     expect(screen.getByTestId("summary-card-compression-savings")).toHaveTextContent("1,000 tokens compressed");
     // the card leads with what LiteLLM's own injection earned and carries the total beneath it,

--- a/ui/litellm-dashboard/src/components/templates/KeySavingsTab.tsx
+++ b/ui/litellm-dashboard/src/components/templates/KeySavingsTab.tsx
@@ -59,7 +59,7 @@ const KeySavingsTab: React.FC<KeySavingsTabProps> = ({ accessToken, keyToken, us
   const intervalLabel = "Per day";
   const rangeLabel = formatRangeLabel(startTime ?? undefined, endTime ?? undefined);
   const savingsSubtitle = [
-    accumulation === "cumulative" ? "Running total saved" : `Saved ${intervalLabel.toLowerCase()}`,
+    accumulation === "cumulative" ? "Running total by driver" : `Saved ${intervalLabel.toLowerCase()}`,
     rangeLabel && `${rangeLabel} (UTC)`,
   ]
     .filter(Boolean)


### PR DESCRIPTION
## TLDR

Problem this solves:

- Cost Optimization added caching and auto-router savings into one Total saved figure
- Those two numbers use different baselines, so the sum can count the same cache effect twice
- Operators then saw a dollar total larger than the auto-router baseline itself

How it solves it:

- Drops the combined Total saved card
- Leaves compression, prompt caching, and auto-router as separate alternative views
- Adds tests that $4 caching plus $6 auto-router must not become $10

## User Flow

Before: an operator sees Total saved exceed the saving against the auto-router baseline

1. A developer sends POST https://litellm-domain/v1/chat/completions through an auto-router on traffic that also uses prompt caching and receives 200 OK
2. The operator opens https://litellm-domain/ui/?page=cost-optimization and sees separate prompt-caching and auto-router savings cards
3. The page adds both cards into Total saved, even though each uses a different counterfactual

After: the page does not present a non-additive sum as one dollar saving

1. A developer sends POST https://litellm-domain/v1/chat/completions through the same auto-router on traffic that also uses prompt caching and receives 200 OK
2. The operator opens https://litellm-domain/ui/?page=cost-optimization and sees separate prompt-caching and auto-router savings cards
3. There is no Total saved headline. The cards stay as alternative views, and the donut is labeled as alternative views rather than parts of one total

## Relevant issues

Fixes #38817

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Shared setup: one daily metrics row with prompt-caching savings $4 and auto-router savings $6, compression $0. Selected-model cost with caching $6, selected-model cost without caching $10, cache-aware auto-router baseline $12

### Before (<hash>)

Captured at 5e4b3838aa

1. Opened Cost Optimization savings tiles with that row
2. Prompt caching card: $4.00. Auto-router card: $6.00
3. Total saved card: $10.00 with hint "Compression + prompt caching + auto-router". That $10 implies a $16 counterfactual while the displayed auto-router baseline is $12

### After (<hash>)

Captured at 63e482817a

1. Opened Cost Optimization savings tiles with the same row
2. Prompt caching card: $4.00. Auto-router card: $6.00
3. No Total saved card and no $10.00 headline

```text
npx vitest run --project component src/components/shared/SavingsTiles.test.tsx
npx vitest run --project component src/app/(dashboard)/cost-optimization/_components/UsageTab.test.tsx
npx vitest run --project unit src/app/(dashboard)/cost-optimization/_components/costOptimizationUtils.test.ts
```

All three files passed (19 component tests, 33 unit tests)

## Type

🐛 Bug Fix

## Caveats (if any)

### Medium

- There is still no single sequential total. The daily row only has the overlapping savings fields, so a one-baseline decomposition is not computable here

### Low

- The donut still draws slices next to each other. The subtitle now says they are alternative views

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
