### PR TITLE
test(ui): cover auto-router tier model replacement

### DIFF
--- a/ui/litellm-dashboard/src/components/edit_auto_router/auto_router_tier_model_replacement.test.ts
+++ b/ui/litellm-dashboard/src/components/edit_auto_router/auto_router_tier_model_replacement.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+
+import { applyTierSetAction } from "../add_model/tier_set_actions";
+import { buildUpdatedComplexityRouterConfig, hydrateComplexityRouterConfig } from "./edit_auto_router_modal";
+
+describe("auto-router tier model replacement", () => {
+  it("writes the replacement model and drops params tied to the removed model", () => {
+    const stored = {
+      tiers: {
+        SIMPLE: ["gemma4:12b-it-qat"],
+        MEDIUM: [],
+        COMPLEX: [],
+        REASONING: [],
+      },
+      tier_model_configs: {
+        SIMPLE: [
+          {
+            model_name: "gemma4:12b-it-qat",
+            litellm_params: { reasoning_effort: "medium" },
+          },
+        ],
+      },
+      classifier_type: "heuristic" as const,
+    };
+
+    const hydrated = hydrateComplexityRouterConfig(stored, "gemma4:12b-it-qat");
+    const changed = applyTierSetAction(hydrated, [], {
+      kind: "models",
+      id: "SIMPLE",
+      models: ["gemma4-12b-it-optiq-4bit"],
+    }).value;
+    const saved = buildUpdatedComplexityRouterConfig(stored, changed);
+
+    expect(saved.tiers).toEqual({
+      SIMPLE: ["gemma4-12b-it-optiq-4bit"],
+      MEDIUM: [],
+      COMPLEX: [],
+      REASONING: [],
+    });
+    expect(saved).not.toHaveProperty("tier_model_configs");
+  });
+});


### PR DESCRIPTION
Refs #38894.

I traced the edit path on current staging before changing production code. Replacing a tier model already updates `tiers`, and the tier action drops per-model params that belonged to the removed model.

This test pins the reported A → B case using the model names from the issue. It checks that the saved config contains only the replacement model and does not retain `tier_model_configs` for the removed one.

If this stays green in CI, the stale routing report is coming from a different part of the edit/reload path and should not be papered over with a UI change that does not reproduce the bug.