### PR TITLE
fix(anthropic): import NotRequired from typing_extensions for py3.10 compat

### DIFF
--- a/litellm/llms/anthropic/experimental_pass_through/context_management/editors/compact.py
+++ b/litellm/llms/anthropic/experimental_pass_through/context_management/editors/compact.py
@@ -14,9 +14,9 @@ Mirrors Anthropic's native ``compact_20260112`` for non-Anthropic providers:
 
 import re
 from collections.abc import Mapping, Sequence
-from typing import TYPE_CHECKING, Any, Final, Literal, NotRequired, Optional, TypedDict, Union, cast
+from typing import TYPE_CHECKING, Any, Final, Literal, Optional, TypedDict, Union, cast
 
-from typing_extensions import ReadOnly
+from typing_extensions import NotRequired, ReadOnly
 
 import litellm
 from litellm._logging import verbose_logger

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/context_management/test_compact.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/context_management/test_compact.py
@@ -2605,3 +2605,33 @@ def test_build_summary_messages_keeps_midturn_system_correction_in_place():
     assert summary_messages[0]["content"] == "caller system prompt"
     assert summary_messages[2]["content"] == "use the corrected result"
     assert summary_messages[-1]["content"] == "summarize the conversation"
+
+
+def test_notrequired_not_imported_from_stdlib_typing() -> None:
+    """Regression test for GH #38892.
+
+    ``NotRequired`` was added to the stdlib ``typing`` module in Python 3.11.
+    litellm declares ``requires-python = ">=3.10"``, so importing
+    ``NotRequired`` from ``typing`` (instead of ``typing_extensions``, which
+    backports it) breaks ``import litellm`` on Python 3.10. This statically
+    checks the source so the regression is caught regardless of which Python
+    version actually runs this test.
+    """
+    import ast
+    import inspect
+
+    from litellm.llms.anthropic.experimental_pass_through.context_management.editors import (
+        compact,
+    )
+
+    source = inspect.getsource(compact)
+    tree = ast.parse(source)
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom) and node.module == "typing":
+            imported_names = {alias.name for alias in node.names}
+            assert "NotRequired" not in imported_names, (
+                "`NotRequired` must be imported from `typing_extensions`, not "
+                "`typing` (NotRequired is Python 3.11+, litellm supports "
+                ">=3.10). See GH #38892."
+            )


### PR DESCRIPTION
## TLDR

Problem this solves:

- `pip install litellm` then `import litellm` crashes on Python 3.10
- Cause: `compact.py` imports `NotRequired` from `typing` (that's 3.11+)

How it solves it:

- Moves `NotRequired` to the existing `typing_extensions` import on the next line

## User Flow

Before: a developer on Python 3.10 can't use litellm at all after upgrading

1. They run `pip install litellm==1.98.0` (or later) on Python 3.10
2. They run `python3.10 -c "import litellm"`
3. It crashes: `ImportError: cannot import name 'NotRequired' from 'typing'`

After: the same install and import work normally on Python 3.10

1. They run `pip install litellm` on Python 3.10
2. They run `python3.10 -c "import litellm"`
3. It succeeds with no error

## Relevant issues

Fixes #38892

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v` — see note below, I could only partially verify this locally
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

**Note on local verification:** I couldn't run `make install-dev` in my environment (its editable install needs a Rust toolchain via maturin, and my network is locked down to a small allowlist that doesn't include `static.rust-lang.org`). Instead I installed the published `litellm` wheel for its dependencies and pointed `PYTHONPATH` at this checkout, on a real Python 3.10.12 interpreter. That reproduced the exact reported crash before the fix and confirmed it's gone after. Running the full `test_compact.py` file that way, 62/84 tests pass including the new one; the other 22 fail on an unrelated `PydanticUserError: Message is not fully defined` — looks like a forward-ref that only resolves once the full proxy import chain runs, which my minimal environment doesn't do. Every one of those 22 was completely unreachable before this fix (the module couldn't import at all), so I don't believe this PR caused them, but I can't rule it out without CI or a proper dev environment, so flagging rather than checking the box.

`make lint` (ruff format + ruff check) passes clean on both changed files with the pinned `ruff==0.15.3`.

## Screenshots / Proof of Fix

### Before (5e4b3838aabf00d135be800404d03728c8afa506)

1. `python3.10 -c "import litellm"`
2. Output:
   ```
   File ".../litellm/llms/anthropic/experimental_pass_through/context_management/editors/compact.py", line 17, in <module>
       from typing import TYPE_CHECKING, Any, Final, Literal, NotRequired, Optional, TypedDict, Union, cast
   ImportError: cannot import name 'NotRequired' from 'typing' (/usr/lib/python3.10/typing.py)
   ```

### After (40b90ca9bb31eaeecd3ebf9d77021dfa62a2edd0)

1. `python3.10 -c "import litellm; print('OK, imported from:', litellm.__file__)"`
2. Output:
   ```
   OK, imported from: .../litellm/__init__.py
   ```

## Type

🐛 Bug Fix

## Caveats (if any)

### Low

- See the "Note on local verification" above re: 22 pre-existing-looking test failures in `test_compact.py` under my minimal local environment, unrelated to `NotRequired`/`typing_extensions`

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
