### PR TITLE
fix(integrations): stop PostHog batch logger from silently dropping events

### DIFF
--- a/litellm/integrations/posthog.py
+++ b/litellm/integrations/posthog.py
@@ -35,6 +35,11 @@ from litellm.types.utils import StandardCallbackDynamicParams, StandardLoggingPa
 
 
 class PostHogLogger(CustomBatchLogger):
+    # Without this, CustomBatchLogger.flush_queue() clears the *entire* live
+    # queue after a successful send, including events appended by concurrent
+    # requests while the batch POST was in flight, silently dropping them.
+    preserve_events_added_during_flush = True
+
     def __init__(self, **kwargs):
         """
         Initializes the PostHog logger, checks if the correct env variables are set
@@ -321,18 +326,27 @@ class PostHogLogger(CustomBatchLogger):
         """
         Sends the in memory logs queue to PostHog API
 
+        Note: does NOT remove events from ``self.log_queue`` - the caller
+        (``CustomBatchLogger.flush_queue``) owns queue draining, using the
+        queue length it captured before this call started so events
+        appended concurrently are preserved (see
+        ``preserve_events_added_during_flush``).
+
         Raises:
-            Raises a NON Blocking verbose_logger.exception if an error occurs
+            Re-raises any error from sending the batch so the caller does
+            NOT treat a failed send as success and clear the queue. The
+            un-acknowledged events are preserved by
+            ``CustomBatchLogger.flush_queue`` and retried on the next flush.
         """
+        if not self.log_queue:
+            return
+
+        verbose_logger.debug("PostHog: Sending batch of %s events", len(self.log_queue))
+
+        if self.is_mock_mode:
+            verbose_logger.debug("[POSTHOG MOCK] Mock mode enabled - API calls will be intercepted")
+
         try:
-            if not self.log_queue:
-                return
-
-            verbose_logger.debug("PostHog: Sending batch of %s events", len(self.log_queue))
-
-            if self.is_mock_mode:
-                verbose_logger.debug("[POSTHOG MOCK] Mock mode enabled - API calls will be intercepted")
-
             # Group events by credentials for batch sending
             batches_by_credentials: Final[dict[tuple[str, str], list]] = {}
             for item in self.log_queue:
@@ -361,13 +375,14 @@ class PostHogLogger(CustomBatchLogger):
                     raise Exception(
                         f"Response from PostHog API status_code: {response.status_code}, text: {response.text}"
                     )
-
-            if self.is_mock_mode:
-                verbose_logger.debug("[POSTHOG MOCK] Batch of %s events successfully mocked", len(self.log_queue))
-            else:
-                verbose_logger.debug("PostHog: Batch of %s events successfully sent", len(self.log_queue))
         except Exception as e:
             verbose_logger.exception("PostHog Error sending batch API - %s", e)
+            raise
+
+        if self.is_mock_mode:
+            verbose_logger.debug("[POSTHOG MOCK] Batch of %s events successfully mocked", len(self.log_queue))
+        else:
+            verbose_logger.debug("PostHog: Batch of %s events successfully sent", len(self.log_queue))
 
     def _ensure_async_setup(self):
         if not self._async_initialized:

--- a/tests/test_litellm/integrations/test_posthog.py
+++ b/tests/test_litellm/integrations/test_posthog.py
@@ -149,6 +149,31 @@ class TestPostHogBatchFlush:
 
         assert handler.log_queue == [_queue_item("a")]
 
+    async def test_async_send_batch_noop_when_queue_empty(self, handler):
+        """An empty queue must not attempt any network call."""
+        handler.log_queue = []
+        handler.async_client = AsyncMock()
+
+        await handler.async_send_batch()
+
+        handler.async_client.post.assert_not_called()
+
+    async def test_async_send_batch_mock_mode_logs_and_sends(self, handler):
+        """Mock mode takes the same send path, just with extra debug logging -
+        exercise it so both mock-mode branches (pre-send and post-success) run."""
+        handler.is_mock_mode = True
+        handler.log_queue = [_queue_item("a")]
+
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.raise_for_status = Mock()
+        handler.async_client = AsyncMock()
+        handler.async_client.post = AsyncMock(return_value=mock_response)
+
+        await handler.async_send_batch()
+
+        handler.async_client.post.assert_called_once()
+
     async def test_flush_queue_preserves_events_added_during_failed_send(self, handler):
         """Combined case: a send that both fails AND has a concurrent append
         mid-flight must preserve both the original snapshot and the new event."""

--- a/tests/test_litellm/integrations/test_posthog.py
+++ b/tests/test_litellm/integrations/test_posthog.py
@@ -1,0 +1,178 @@
+"""
+Regression tests for GH #38904: the PostHog batch callback logger silently
+lost events in two independent ways:
+
+1. ``flush_queue()`` cleared the *entire* live queue after a successful send,
+   including events appended by concurrent requests while the batch POST was
+   in flight (fixed by opting in to
+   ``CustomBatchLogger.preserve_events_added_during_flush``).
+2. ``PostHogLogger.async_send_batch()`` caught send failures and only logged
+   them instead of re-raising, so the base ``flush_queue()`` treated a failed
+   send as success and cleared the queue anyway instead of preserving events
+   for retry.
+
+Mirrors the equivalent coverage in ``tests/test_litellm/integrations/test_rubrik.py``.
+"""
+
+import asyncio
+import os
+from unittest.mock import AsyncMock, Mock, patch
+
+import httpx
+import pytest
+
+from litellm.integrations.posthog import PostHogLogger
+
+
+@pytest.fixture
+def mock_env():
+    with patch.dict(os.environ, {"POSTHOG_API_KEY": "test-api-key"}, clear=False):
+        yield
+
+
+@pytest.fixture
+def handler(mock_env):
+    return PostHogLogger()
+
+
+def _queue_item(msg: str) -> dict:
+    return {
+        "event": {"event": "$ai_generation", "properties": {"msg": msg}},
+        "api_key": "test-api-key",
+        "api_url": "https://us.i.posthog.com",
+    }
+
+
+@pytest.mark.asyncio
+class TestPostHogBatchFlush:
+    async def test_flush_queue_sends_batch_and_drains_on_success(self, handler):
+        handler.log_queue = [_queue_item("a"), _queue_item("b")]
+        handler.flush_lock = asyncio.Lock()
+
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.raise_for_status = Mock()
+        handler.async_client = AsyncMock()
+        handler.async_client.post = AsyncMock(return_value=mock_response)
+
+        await handler.flush_queue()
+
+        handler.async_client.post.assert_called_once()
+        assert handler.log_queue == []
+
+    async def test_flush_queue_preserves_events_added_during_send(self, handler):
+        """Regression for bug 1: an event queued while the batch POST is
+        in flight must survive the flush, not be wiped by the post-send
+        ``self.log_queue.clear()``."""
+        handler.log_queue = [_queue_item("a"), _queue_item("b")]
+        handler.flush_lock = asyncio.Lock()
+
+        async def mock_post(*_args, **_kwargs):
+            handler.log_queue.append(_queue_item("c"))
+            mock_response = Mock()
+            mock_response.status_code = 200
+            mock_response.raise_for_status = Mock()
+            return mock_response
+
+        handler.async_client = AsyncMock()
+        handler.async_client.post = mock_post
+
+        await handler.flush_queue()
+
+        assert len(handler.log_queue) == 1
+        assert handler.log_queue[0]["event"]["properties"]["msg"] == "c"
+
+    async def test_async_send_batch_does_not_drain_events(self, handler):
+        """``async_send_batch`` itself must never mutate the queue - queue
+        draining is ``flush_queue``'s job, using the pre-send length so
+        concurrently appended events are preserved."""
+        handler.log_queue = [_queue_item("a"), _queue_item("b")]
+
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.raise_for_status = Mock()
+        handler.async_client = AsyncMock()
+        handler.async_client.post = AsyncMock(return_value=mock_response)
+
+        await handler.async_send_batch()
+
+        assert len(handler.log_queue) == 2
+
+    async def test_async_send_batch_raises_on_http_error(self, handler):
+        """Regression for bug 2: a failed send must propagate instead of
+        being swallowed, so the caller knows not to treat it as delivered."""
+        handler.log_queue = [_queue_item("a")]
+
+        mock_response = Mock()
+        mock_response.status_code = 500
+        mock_response.text = "Internal Server Error"
+        mock_response.raise_for_status = Mock(
+            side_effect=httpx.HTTPStatusError("err", request=Mock(), response=mock_response)
+        )
+        handler.async_client = AsyncMock()
+        handler.async_client.post = AsyncMock(return_value=mock_response)
+
+        with pytest.raises(httpx.HTTPStatusError):
+            await handler.async_send_batch()
+
+        # async_send_batch itself still must not have drained the queue.
+        assert handler.log_queue == [_queue_item("a")]
+
+    async def test_flush_queue_preserves_events_on_http_error(self, handler):
+        """End-to-end: a failed batch send must leave the original events in
+        the queue for retry on the next flush, not silently drop them."""
+        handler.log_queue = [_queue_item("a"), _queue_item("b")]
+        handler.flush_lock = asyncio.Lock()
+
+        mock_response = Mock()
+        mock_response.status_code = 500
+        mock_response.text = "Internal Server Error"
+        mock_response.raise_for_status = Mock(
+            side_effect=httpx.HTTPStatusError("err", request=Mock(), response=mock_response)
+        )
+        handler.async_client = AsyncMock()
+        handler.async_client.post = AsyncMock(return_value=mock_response)
+
+        await handler.flush_queue()
+
+        assert handler.log_queue == [_queue_item("a"), _queue_item("b")]
+
+    async def test_flush_queue_preserves_events_on_network_error(self, handler):
+        """Network/timeout errors must also preserve the in-flight events."""
+        handler.log_queue = [_queue_item("a")]
+        handler.flush_lock = asyncio.Lock()
+
+        handler.async_client = AsyncMock()
+        handler.async_client.post = AsyncMock(side_effect=httpx.TimeoutException("timeout"))
+
+        await handler.flush_queue()
+
+        assert handler.log_queue == [_queue_item("a")]
+
+    async def test_flush_queue_preserves_events_added_during_failed_send(self, handler):
+        """Combined case: a send that both fails AND has a concurrent append
+        mid-flight must preserve both the original snapshot and the new event."""
+        handler.log_queue = [_queue_item("a"), _queue_item("b")]
+        handler.flush_lock = asyncio.Lock()
+
+        async def mock_post(*_args, **_kwargs):
+            handler.log_queue.append(_queue_item("c"))
+            mock_response = Mock()
+            mock_response.status_code = 500
+            mock_response.text = "boom"
+            mock_response.raise_for_status = Mock(
+                side_effect=httpx.HTTPStatusError("err", request=Mock(), response=mock_response)
+            )
+            return mock_response
+
+        handler.async_client = AsyncMock()
+        handler.async_client.post = mock_post
+
+        await handler.flush_queue()
+
+        assert len(handler.log_queue) == 3
+        assert [item["event"]["properties"]["msg"] for item in handler.log_queue] == [
+            "a",
+            "b",
+            "c",
+        ]


### PR DESCRIPTION
## TLDR

Problem this solves:

- Successful LLM requests silently never show up in PostHog under normal concurrent load or a transient PostHog outage
- Two independent causes in the batch queue/send path, both losing already-logged events with no error surfaced

How it solves it:

- `PostHogLogger` opts in to `preserve_events_added_during_flush` (already built into `CustomBatchLogger`, used by `RubrikLogger`) so an event queued while a batch POST is in flight survives the flush
- `async_send_batch()` now re-raises send failures instead of swallowing them, so `CustomBatchLogger.flush_queue()`'s existing retry/preserve logic actually engages instead of treating a failed send as delivered

## User Flow

Before: an operator enables the PostHog callback and some successful requests never appear in PostHog, with no error anywhere

1. They configure `success_callback: ["posthog"]` on a LiteLLM proxy
2. Applications send successful requests through the OpenAI-compatible proxy endpoint
3. Either another request's event is queued while a batch flush to PostHog is already in flight, or PostHog briefly returns an error/times out
4. The proxy requests all return 200 normally, but the `$ai_generation` event for the request from step 3 never appears in PostHog, and nothing in the proxy's own logs points at a lost event

After: the same request sequence preserves every event

1. Same PostHog callback configuration
2. Same requests
3. An event queued mid-flush stays in the retry queue instead of being cleared with the batch it wasn't part of; a failed POST leaves its events queued for the next flush interval instead of being dropped
4. Every successfully-processed request's event eventually reaches PostHog (immediately in the common case, or on the next flush after a transient failure)

## Relevant issues

Fixes #38904

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

**Note on local verification:** same as my other open PR (#38903) - I couldn't run `make install-dev`/the full CI matrix locally (its editable install needs a Rust toolchain my network can't reach), so I installed the published `litellm` wheel for its dependencies and pointed `PYTHONPATH` at this checkout on a real Python 3.10.12 interpreter. `tests/test_litellm/integrations/test_posthog.py` (new, 7 tests) passes in full against the fix and, before pushing, I confirmed 5 of those 7 fail against the pre-fix code with exactly the two bugs this PR describes - the other 2 are the plain success-path tests, unaffected either way. `make lint` (ruff format + ruff check) passes clean on both changed files with the pinned `ruff==0.15.3`.

## Screenshots / Proof of Fix

This is a background batch-queue race/retry bug, not something an LLM call reproduces - the issue's own reproduction is a deterministic, mocked-network scenario for the same reason. The before/after here is that same kind of proof, run against `PostHogLogger` directly instead of the synthetic base-class example in the issue.

### Before (4ba8517134)

#### Concurrent append during an in-flight send

1. `pytest tests/test_litellm/integrations/test_posthog.py::TestPostHogBatchFlush::test_flush_queue_preserves_events_added_during_send -v`
2. `FAILED` - the event appended during the mocked POST is wiped by `flush_queue`'s `self.log_queue.clear()`

#### Failed send

1. `pytest tests/test_litellm/integrations/test_posthog.py::TestPostHogBatchFlush::test_flush_queue_preserves_events_on_http_error -v`
2. `FAILED` - `async_send_batch` swallows the `HTTPStatusError`, so `flush_queue` sees no exception and clears the queue anyway

### After (6ae652b08a)

#### Concurrent append during an in-flight send

1. `pytest tests/test_litellm/integrations/test_posthog.py::TestPostHogBatchFlush::test_flush_queue_preserves_events_added_during_send -v`
2. `PASSED` - only the originally-flushed events are removed; the concurrently-appended event remains queued

#### Failed send

1. `pytest tests/test_litellm/integrations/test_posthog.py::TestPostHogBatchFlush::test_flush_queue_preserves_events_on_http_error -v`
2. `PASSED` - `async_send_batch` re-raises, `flush_queue` catches it and preserves the events for retry

## Type

🐛 Bug Fix

## Caveats (if any)

### Low

- If a single flush batches events under more than one PostHog credential (per-request `standard_callback_dynamic_params` overrides) and the send to the first credential succeeds but a later one in the same flush fails, the whole batch (including the already-delivered first group) is preserved and retried, which could re-send already-acknowledged events to PostHog on the next flush. The issue's own "Expected behavior" section anticipates this class of edge case (asking for "stable event IDs for downstream deduplication"); fixing it fully felt like a separate, larger change from the two deterministically-proven bugs this PR fixes, so I left it as a known gap rather than folding it in here.

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
