### PR TITLE
feat(providers): add PZERO as OpenAI-compatible provider

### DIFF
--- a/litellm/constants.py
+++ b/litellm/constants.py
@@ -806,6 +806,7 @@ openai_compatible_endpoints: Final[list] = [
     "https://api.meta.ai/v1",
     "https://api.cognition.ai/v1",
     "https://api.scx.ai/v1",
+    "https://api.pzero.studio/v1",
 ]
 
 
@@ -875,6 +876,7 @@ openai_compatible_providers: Final[list] = [
     "meta",  # Meta Model API (Muse Spark) - JSON-configured provider
     "cognition",
     "scx-ai",
+    "pzero",  # PZERO - JSON-configured provider
 ]
 openai_text_completion_compatible_providers: Final[list] = [  # providers that support `/v1/completions`
     "together_ai",

--- a/litellm/llms/openai_like/providers.json
+++ b/litellm/llms/openai_like/providers.json
@@ -200,5 +200,10 @@
       "temperature_max": 1.99
     },
     "supported_endpoints": ["/v1/chat/completions"]
+  },
+  "pzero": {
+    "base_url": "https://api.pzero.studio/v1",
+    "api_key_env": "PZERO_API_KEY",
+    "supported_endpoints": ["/v1/chat/completions", "/v1/responses"]
   }
 }

--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -3847,6 +3847,7 @@ class LlmProviders(str, Enum):
     PINSTRIPES = "pinstripes"
     COGNITION = "cognition"
     SCX_AI = "scx-ai"
+    PZERO = "pzero"
     DARKBLOOM = "darkbloom"
     META = "meta"
     LITELLM_AGENT = "litellm_agent"

--- a/tests/test_litellm/llms/openai_like/test_pzero_provider.py
+++ b/tests/test_litellm/llms/openai_like/test_pzero_provider.py
@@ -1,0 +1,119 @@
+"""
+Tests for PZERO provider configuration and integration.
+
+PZERO (https://pzero.studio) is a prepaid inference marketplace (OpenAI chat
+completions and Responses API) sitting in front of Venice's upstream, distinct
+from the already-registered `veniceai` provider, which points at Venice's own
+host directly. See GH #38632.
+"""
+
+import litellm
+
+
+class TestPZEROProviderConfig:
+    """Test PZERO provider configuration"""
+
+    def test_pzero_in_provider_list(self):
+        """Test that pzero is in the provider list"""
+        from litellm import LlmProviders
+
+        assert hasattr(LlmProviders, "PZERO")
+        assert LlmProviders.PZERO.value == "pzero"
+        assert "pzero" in litellm.provider_list
+
+    def test_pzero_json_config_exists(self):
+        """Test that pzero is configured in providers.json"""
+        from litellm.llms.openai_like.json_loader import JSONProviderRegistry
+
+        assert JSONProviderRegistry.exists("pzero")
+
+        pzero = JSONProviderRegistry.get("pzero")
+        assert pzero is not None
+        assert pzero.base_url == "https://api.pzero.studio/v1"
+        assert pzero.api_key_env == "PZERO_API_KEY"
+
+    def test_pzero_in_openai_compatible_providers(self):
+        """Test that pzero is in the openai_compatible_providers list"""
+        from litellm.constants import openai_compatible_providers
+
+        assert "pzero" in openai_compatible_providers
+
+    def test_pzero_supports_responses_api(self):
+        """PZERO exposes OpenAI Responses API, distinct from veniceai which doesn't."""
+        from litellm.llms.openai_like.json_loader import JSONProviderRegistry
+
+        assert JSONProviderRegistry.supports_responses_api("pzero") is True
+
+    def test_pzero_distinct_from_veniceai(self):
+        """PZERO must not be conflated with the already-registered veniceai
+        provider - they point at different hosts (see GH #38632)."""
+        from litellm.llms.openai_like.json_loader import JSONProviderRegistry
+
+        pzero = JSONProviderRegistry.get("pzero")
+        veniceai = JSONProviderRegistry.get("veniceai")
+        assert pzero is not None
+        assert veniceai is not None
+        assert pzero.base_url != veniceai.base_url
+        assert pzero.api_key_env != veniceai.api_key_env
+
+    def test_pzero_provider_resolution(self):
+        """Test that provider resolution finds pzero and returns the default base URL"""
+        from litellm.litellm_core_utils.get_llm_provider_logic import get_llm_provider
+
+        model, provider, api_key, api_base = get_llm_provider(
+            model="pzero/deepseek-v4-flash",
+            custom_llm_provider=None,
+            api_base=None,
+            api_key=None,
+        )
+
+        assert model == "deepseek-v4-flash"
+        assert provider == "pzero"
+        assert api_base == "https://api.pzero.studio/v1"
+
+    def test_pzero_api_base_override(self):
+        """Test that an explicit api_base / api_key overrides the default"""
+        from litellm.litellm_core_utils.get_llm_provider_logic import get_llm_provider
+
+        model, provider, api_key, api_base = get_llm_provider(
+            model="pzero/deepseek-v4-flash",
+            custom_llm_provider=None,
+            api_base="https://custom.pzero.studio/v1",
+            api_key="sk-test",
+        )
+
+        assert provider == "pzero"
+        assert api_base == "https://custom.pzero.studio/v1"
+        assert api_key == "sk-test"
+
+    def test_pzero_url_autodetection(self):
+        """Test that api_base=api.pzero.studio/v1 auto-sets custom_llm_provider=pzero"""
+        from litellm.litellm_core_utils.get_llm_provider_logic import get_llm_provider
+
+        model, provider, api_key, api_base = get_llm_provider(
+            model="deepseek-v4-flash",
+            custom_llm_provider=None,
+            api_base="https://api.pzero.studio/v1",
+            api_key=None,
+        )
+        assert provider == "pzero"
+        assert api_base == "https://api.pzero.studio/v1"
+
+    def test_pzero_router_config(self):
+        """Test that pzero can be used in Router configuration"""
+        from litellm import Router
+
+        router = Router(
+            model_list=[
+                {
+                    "model_name": "pzero-chat",
+                    "litellm_params": {
+                        "model": "pzero/deepseek-v4-flash",
+                        "api_key": "test-key",
+                    },
+                }
+            ]
+        )
+
+        assert len(router.model_list) == 1
+        assert router.model_list[0]["model_name"] == "pzero-chat"


### PR DESCRIPTION
## TLDR

Problem this solves:

- LiteLLM has no named provider for PZERO, so callers can't write `model="pzero/<id>"`
- Users have to fake it as `model="openai/<id>"` plus a manually-supplied `api_base`/`api_key`, on every call

How it solves it:

- Registers `pzero` as a JSON-configured OpenAI-compatible provider (same mechanism as e.g. Charity Engine, Pinstripes, SCX.ai) - a `providers.json` entry, an `LlmProviders` enum member, and the two routing-constant lists so both `pzero/<model>` prefix routing and `api_base` autodetection work
- Declares Responses API support (`/v1/responses`) via the existing generic `supported_endpoints` mechanism, in addition to chat completions

## User Flow

Before: a developer routing traffic to PZERO cannot use a named provider prefix

1. They set `PZERO_API_KEY` to a `pzero_` key
2. They call `litellm.completion(model="pzero/deepseek-v4-flash", ...)`
3. LiteLLM raises `BadRequestError: LLM Provider NOT provided`
4. Workaround: they rewrite the call as `model="openai/deepseek-v4-flash"` plus `api_base="https://api.pzero.studio/v1"` and `api_key=PZERO_API_KEY`, on every call site

After: PZERO works as a first-class provider prefix

1. Same `PZERO_API_KEY` setup
2. They call `litellm.completion(model="pzero/deepseek-v4-flash", ...)`, no `api_base` needed
3. LiteLLM resolves it to `https://api.pzero.studio/v1` and sends `POST https://api.pzero.studio/v1/chat/completions` with `Authorization: Bearer <PZERO_API_KEY>`
4. The same works via `api_base="https://api.pzero.studio/v1"` autodetection with no `pzero/` prefix, and via the Responses API

## Relevant issues

Fixes #38632

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v` - see note below, one pre-existing test failure is unrelated to this change
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

**Note on local verification:** same environment caveat as my other open PRs (#38903, #38905) - no Rust toolchain available for `make install-dev`, so I installed the published `litellm` wheel for dependencies and pointed `PYTHONPATH` at this checkout on Python 3.10.12. 8 of 9 tests in the new `test_pzero_provider.py` pass; the 9th (`test_pzero_router_config`) fails on `PydanticUserError: LiteLLM_Params is not fully defined`, which I confirmed is a pre-existing environment artifact unrelated to this PR - the identical `Router(...)` construction fails the exact same way for already-merged providers (e.g. `test_scx_ai_provider.py::test_scx_ai_router_config`) in this same minimal environment, and 22 other pre-existing tests across this same test directory fail identically. `make lint` (ruff format + ruff check) passes clean on all four changed files with the pinned `ruff==0.15.3`, and `providers.json` was hand-verified to still be valid JSON.

## Screenshots / Proof of Fix

Not an LLM-call-shaped change (no real PZERO credentials available to spend real money against) - proof here is the actual resolution logic and the JSON config, run for real against this checkout.

### Before (4ba8517134)

1. `python3 -c "from litellm.litellm_core_utils.get_llm_provider_logic import get_llm_provider; get_llm_provider(model='pzero/deepseek-v4-flash', custom_llm_provider=None, api_base=None, api_key=None)"`
2. Output:
   ```
   litellm.exceptions.BadRequestError: litellm.BadRequestError: LLM Provider NOT provided. Pass in the LLM provider you are trying to call. You passed model=pzero/deepseek-v4-flash
   ```

### After (4d7e97a372)

1. `pytest tests/test_litellm/llms/openai_like/test_pzero_provider.py -v`
2. Output (8/9 passed, see local-verification note above for the 9th):
   ```
   test_pzero_in_provider_list PASSED
   test_pzero_json_config_exists PASSED
   test_pzero_in_openai_compatible_providers PASSED
   test_pzero_supports_responses_api PASSED
   test_pzero_distinct_from_veniceai PASSED
   test_pzero_provider_resolution PASSED
   test_pzero_api_base_override PASSED
   test_pzero_url_autodetection PASSED
   test_pzero_router_config FAILED (pre-existing environment artifact, see note)
   ```

## Type

🆕 New Feature

## Caveats (if any)

### Low

- No cost-map (`model_prices_and_context_window.json`) or Admin UI "add model" dropdown (`provider_create_fields.json`) entries - the issue didn't supply real per-model pricing for PZERO's catalog, and I didn't want to invent numbers. This follows the Charity Engine precedent (registration + resolution only) rather than the fuller SCX.ai-style integration; happy to add pricing/dashboard entries in a follow-up if a maintainer points me at real numbers.

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
