### PR TITLE
fix(proxy): keep reasoning_items on the streaming fast-serialization path

### DIFF
--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -8266,6 +8266,7 @@ def _fast_serialize_simple_model_response_stream(
         "annotations",
         "reasoning_content",
         "thinking_blocks",
+        "reasoning_items",
         "provider_specific_fields",
         "refusal",
     )

--- a/tests/test_litellm/proxy/proxy_server/test_streaming_helpers.py
+++ b/tests/test_litellm/proxy/proxy_server/test_streaming_helpers.py
@@ -517,6 +517,16 @@ def test_fast_serialize_simple_model_response_stream_with_usage_returns_none_inv
     assert _fast_serialize_simple_model_response_stream(chunk) is None
 
 
+def test_fast_serialize_simple_model_response_stream_with_reasoning_items_returns_none():
+    """``reasoning_items`` carries the provider's encrypted reasoning state, which
+    the fast path cannot emit — it must bail so the slow path serializes it."""
+    chunk = _simple_chunk(content="")
+    chunk.choices[0].delta.reasoning_items = [
+        {"id": "rs_abc", "type": "reasoning", "encrypted_content": "ENCRYPTED-BLOB"}
+    ]
+    assert _fast_serialize_simple_model_response_stream(chunk) is None
+
+
 # ---------------------------------------------------------------------------
 # _serialize_streaming_chunk
 # ---------------------------------------------------------------------------
@@ -538,6 +548,20 @@ def test_serialize_streaming_chunk_simple_uses_fast_path_bytes():
             }
         ],
     }
+
+
+def test_serialize_streaming_chunk_preserves_reasoning_items():
+    """End-to-end pin for the bug: a chunk whose only payload beside text is
+    ``reasoning_items`` must still reach the wire with those items. The fast
+    path emits ``role``/``content`` only, so it has to decline this chunk."""
+    chunk = _simple_chunk(content="")
+    chunk.choices[0].delta.reasoning_items = [
+        {"id": "rs_abc", "type": "reasoning", "encrypted_content": "ENCRYPTED-BLOB"}
+    ]
+    payload = json.loads(_serialize_streaming_chunk(chunk))
+    assert payload["choices"][0]["delta"]["reasoning_items"] == [
+        {"id": "rs_abc", "type": "reasoning", "encrypted_content": "ENCRYPTED-BLOB"}
+    ]
 
 
 def test_serialize_streaming_chunk_invalid_input_raises_attribute_error():


### PR DESCRIPTION
## Title

fix(proxy): keep `reasoning_items` on the streaming fast-serialization path

## Relevant issues

Fixes #38907

## Pre-Submission checklist

- [x] I have added testing in the `tests/` directory: `tests/test_litellm/proxy/proxy_server/test_streaming_helpers.py`
- [x] My PR passes all unit tests
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem

## Type

🐛 Bug Fix

## Changes

`_fast_serialize_simple_model_response_stream` hand-builds the JSON for "simple" text chunks and emits only `role` and `content`, declining anything richer through `unsupported_delta_fields`. `reasoning_items` was missing from that tuple.

The Responses-to-chat bridge emits its `response.completed` chunk as `Delta(content="", reasoning_items=[...])` — `content` is an empty string and none of the guarded fields is set, so the chunk looks like plain text, takes the fast path, and its encrypted reasoning state never reaches the client. `CustomStreamWrapper` carries the field correctly, so the loss is entirely in proxy serialization; that is why it shows up through the proxy but not in SDK streaming.

Adding `reasoning_items` to the guard lets such a chunk fall through to the canonical `model_dump_json(exclude_none=True, exclude_unset=True)` path, which already serializes it.

Before / after on the minimal case, `Delta(content="", reasoning_items=[...])`:

```json
// before
{"id":"chatcmpl-x","object":"chat.completion.chunk","created":0,"model":"gpt-5.1","choices":[{"index":0,"delta":{"content":""}}]}
// after
{"id":"chatcmpl-x","created":0,"model":"gpt-5.1","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"reasoning_items":[{"id":"rs_abc","type":"reasoning","encrypted_content":"ENCRYPTED-BLOB"}],"content":""}}]}
```

## Testing

Two tests added to the existing pins file: one asserting the fast path declines a chunk carrying `reasoning_items`, one end-to-end through `_serialize_streaming_chunk` asserting the items reach the wire.

Run against the unpatched tree, to show they actually catch the bug:

```
FAILED tests/test_litellm/proxy/proxy_server/test_streaming_helpers.py::test_fast_serialize_simple_model_response_stream_with_reasoning_items_returns_none
FAILED tests/test_litellm/proxy/proxy_server/test_streaming_helpers.py::test_serialize_streaming_chunk_preserves_reasoning_items
2 failed, 78 deselected in 13.63s
```

On the branch, the two files that cover these helpers:

```
$ pytest tests/test_litellm/proxy/proxy_server/test_streaming_helpers.py tests/test_litellm/proxy/test_response_model_sanitization.py -q
88 passed, 1 warning in 265.97s
```

`ruff check` reports the same 448 pre-existing findings on both touched files before and after the change, none of them on the changed lines; `ruff format --check` reports both files already formatted.

To be explicit about the verification boundary: I observed the dropped field on a live proxy (the streaming chunk arrives as `{"delta":{"content":""}}` while the identical non-streaming request returns `reasoning_items` with a ~5 KB `encrypted_content`), and I verified the fix at the serialization level and through the test suite. I did not re-run a live paid reasoning-model stream against a proxy built from this branch.