### PR TITLE
refactor(router_strategy): optimize least busy deployment selection l…

### DIFF
--- a/litellm/router_strategy/least_busy.py
+++ b/litellm/router_strategy/least_busy.py
@@ -165,26 +165,23 @@ class LeastBusyLoggingHandler(CustomLogger):
         """
         Helper to get deployments using least busy strategy
         """
-        for d in healthy_deployments:
-            ## if healthy deployment not yet used
-            if d["model_info"]["id"] not in all_deployments:
-                all_deployments[d["model_info"]["id"]] = 0
-        # map deployment to id
-        # pick least busy deployment
+        if not healthy_deployments:
+            return None
+
         min_traffic = float("inf")
-        min_deployment = None
-        for k, v in all_deployments.items():
-            if v < min_traffic:
-                min_traffic = v
-                min_deployment = k
-        if min_deployment is not None:
-            ## check if min deployment is a string, if so, cast it to int
-            for m in healthy_deployments:
-                if m["model_info"]["id"] == min_deployment:
-                    return m
-            min_deployment = random.choice(healthy_deployments)
-        else:
-            min_deployment = random.choice(healthy_deployments)
+        min_deployment = healthy_deployments[0]
+
+        for deployment in healthy_deployments:
+            dep_id = str(deployment.get("model_info", {}).get("id", ""))
+            traffic = all_deployments.get(dep_id, 0)
+
+            if traffic == 0:
+                return deployment
+
+            if traffic < min_traffic:
+                min_traffic = traffic
+                min_deployment = deployment
+
         return min_deployment
 
     def get_available_deployments(


### PR DESCRIPTION
### PR Title
perf(router): optimize least-busy deployment selection with early exit and single-pass lookup

---

### PR Description

#### Why the Current Implementation Needs Improvement
- **Silent Degradation to Random Routing:** Evaluates `all_deployments` across the entire model group instead of filtering healthy ones first. If an unhealthy/cooldown deployment has `0` in-flight requests, it gets selected as minimum, fails the healthy lookup, and silently falls back to `random.choice()`.
- **Inefficient 3-Loop Design:** Runs 3 separate passes (seeding, global min search, object lookup) even when an idle deployment with `0` traffic is immediately available.
- **Type Mismatches & Mutation:** Unnormalized `int` vs `str` ID comparisons cause lookups to fail, and the method mutates the input cache dictionary in-place during a read operation.

---

#### Summary of Changes
- Refactors `LeastBusyLoggingHandler._get_available_deployments` into a single pass over `healthy_deployments`.
- Adds an O(1) early-exit return when encountering any deployment with `traffic <= 0`.
- Normalizes deployment IDs to `str` for safe, deterministic cache lookups.

---

#### Complexity Comparison

Let $H$ = count of healthy deployments, and $A$ = total cached deployments in model group ($A \ge H$).

| Metric | Previous Implementation | Proposed Implementation |
| :--- | :--- | :--- |
| **Best-Case Time** | $\mathcal{O}(H + A + H) = \mathcal{O}(A + H)$ | $\mathcal{O}(1)$ (first healthy deployment is idle) |
| **Worst-Case Time** | $\mathcal{O}(H + A + H) = \mathcal{O}(A + H)$ | $\mathcal{O}(H)$ (all deployments active) |
| **Space** | $\mathcal{O}(1)$ (mutates input cache in-place) | $\mathcal{O}(1)$ (pure read) |

---

#### Checklist
- [x] Passed existing test suite (`tests/local_testing/test_least_busy_routing.py`)
- [x] No breaking API changes
- [x] Pure read operation without mutating cache input