### PR TITLE
fix(infinity): avoid shared default error headers

### DIFF
--- a/litellm/llms/infinity/common_utils.py
+++ b/litellm/llms/infinity/common_utils.py
@@ -12,9 +12,7 @@ class InfinityError(BaseLLMException):
     ):
         self.status_code = status_code
         self.message = message
-        self.request = httpx.Request(
-            method="POST", url="https://github.com/michaelfeil/infinity"
-        )
+        self.request = httpx.Request(method="POST", url="https://github.com/michaelfeil/infinity")
         self.response = httpx.Response(status_code=status_code, request=self.request)
         super().__init__(
             status_code=status_code,

--- a/litellm/llms/infinity/common_utils.py
+++ b/litellm/llms/infinity/common_utils.py
@@ -4,10 +4,17 @@ from litellm.llms.base_llm.chat.transformation import BaseLLMException
 
 
 class InfinityError(BaseLLMException):
-    def __init__(self, status_code: int, message: str, headers: dict | httpx.Headers = {}):
+    def __init__(
+        self,
+        status_code: int,
+        message: str,
+        headers: dict | httpx.Headers | None = None,
+    ):
         self.status_code = status_code
         self.message = message
-        self.request = httpx.Request(method="POST", url="https://github.com/michaelfeil/infinity")
+        self.request = httpx.Request(
+            method="POST", url="https://github.com/michaelfeil/infinity"
+        )
         self.response = httpx.Response(status_code=status_code, request=self.request)
         super().__init__(
             status_code=status_code,

--- a/tests/llm_translation/test_infinity.py
+++ b/tests/llm_translation/test_infinity.py
@@ -5,6 +5,7 @@ from unittest.mock import AsyncMock
 
 
 import litellm
+from litellm.llms.infinity.common_utils import InfinityError
 
 from unittest.mock import patch, MagicMock
 
@@ -15,6 +16,14 @@ from test_rerank import assert_response_shape
 from base_embedding_unit_tests import BaseLLMEmbeddingTest
 from litellm.llms.custom_httpx.http_handler import HTTPHandler, AsyncHTTPHandler
 from litellm.types.utils import EmbeddingResponse, Usage
+
+
+def test_infinity_error_default_headers_are_not_shared() -> None:
+    first_error = InfinityError(status_code=500, message="first")
+    second_error = InfinityError(status_code=500, message="second")
+
+    assert first_error.headers is None
+    assert second_error.headers is None
 
 
 @pytest.mark.asyncio()

--- a/tests/test_litellm/llms/infinity/test_common_utils.py
+++ b/tests/test_litellm/llms/infinity/test_common_utils.py
@@ -1,0 +1,9 @@
+from litellm.llms.infinity.common_utils import InfinityError
+
+
+def test_infinity_error_default_headers_are_not_shared() -> None:
+    first_error = InfinityError(status_code=500, message="first")
+    second_error = InfinityError(status_code=500, message="second")
+
+    assert first_error.headers is None
+    assert second_error.headers is None

--- a/tests/test_litellm/llms/infinity/test_common_utils.py
+++ b/tests/test_litellm/llms/infinity/test_common_utils.py
@@ -1,9 +1,0 @@
-from litellm.llms.infinity.common_utils import InfinityError
-
-
-def test_infinity_error_default_headers_are_not_shared() -> None:
-    first_error = InfinityError(status_code=500, message="first")
-    second_error = InfinityError(status_code=500, message="second")
-
-    assert first_error.headers is None
-    assert second_error.headers is None


### PR DESCRIPTION
## TLDR

Problem this solves:

- Infinity errors reuse one mutable default headers dictionary
- A mutation can leak into unrelated later exceptions

How it solves it:

- Default missing headers to `None`, matching sibling providers
- Add a regression test for independent default state

## User Flow

Before: a developer catches two Infinity provider errors and sees state leak between them

1. They make two requests that fail without response headers
2. They attach diagnostic metadata to the first error's headers
3. The second error unexpectedly contains the first error's metadata

After: each error has no shared mutable default state

1. They make two requests that fail without response headers
2. Both errors expose `None` for missing headers
3. Metadata cannot leak through a shared default dictionary

## Relevant issues

Fixes #38909

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [ ] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

### Before (4ba8517134816b98a040300032e7e0185ccffbc7)

1. Instantiate two `InfinityError` objects without passing headers
2. `first.headers is second.headers` prints `True`
3. Adding `x-debug` to the first prints `{'x-debug': 'leaked'}` for the second

### After (d724636365b9ceaa85aee7a8bd4b2265beb4dbb6)

1. Instantiate the same two `InfinityError` objects without passing headers
2. Both `first.headers` and `second.headers` print `None`
3. No mutable default object exists for state to leak through

## Type

🐛 Bug Fix
✅ Test

## Caveats (if any)

### Low

- Focused pytest setup hit a Windows Rust linker file-lock error
- Python compilation, Black, and the isolated regression check pass

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
