### PR TITLE
fix(infinity): don't share a mutable default dict across InfinityError instances

### DIFF
--- a/litellm/llms/infinity/common_utils.py
+++ b/litellm/llms/infinity/common_utils.py
@@ -4,7 +4,7 @@ from litellm.llms.base_llm.chat.transformation import BaseLLMException
 
 
 class InfinityError(BaseLLMException):
-    def __init__(self, status_code: int, message: str, headers: dict | httpx.Headers = {}):
+    def __init__(self, status_code: int, message: str, headers: dict | httpx.Headers | None = None):
         self.status_code = status_code
         self.message = message
         self.request = httpx.Request(method="POST", url="https://github.com/michaelfeil/infinity")

--- a/tests/test_litellm/llms/infinity/test_common_utils.py
+++ b/tests/test_litellm/llms/infinity/test_common_utils.py
@@ -1,0 +1,69 @@
+"""
+#38909: InfinityError's `headers` parameter defaulted to a mutable `{}`,
+so every InfinityError raised without an explicit `headers=` argument
+(e.g. litellm/llms/infinity/embedding/transformation.py and
+litellm/llms/infinity/rerank/transformation.py) shared the exact same
+dict object. Mutating one instance's `.headers` would silently leak into
+every other default-constructed InfinityError, including ones raised by
+unrelated requests.
+"""
+
+import httpx
+
+from litellm.llms.infinity.common_utils import InfinityError
+
+
+class TestInfinityErrorDoesNotShareDefaultHeaders:
+    def test_default_headers_is_not_a_mutable_shared_dict(self):
+        """The old `headers: dict = {}` default meant every default-constructed
+        InfinityError's `.headers` was literally the same dict object, created
+        once at function-definition time. The fix defaults to `None` instead,
+        so there is nothing shared to mutate."""
+        first = InfinityError(status_code=500, message="first failure")
+
+        assert first.headers is None
+
+    def test_two_default_constructed_errors_do_not_share_headers_identity(self):
+        """Reproduces the shared-default-object bug directly: with the buggy
+        `= {}` default, `first.headers is second.headers` would be True
+        because both point at the one dict created when the function was
+        defined. Guard against ever reintroducing a mutable default here by
+        asserting the default itself is never a dict."""
+        first = InfinityError(status_code=500, message="first failure")
+        second = InfinityError(status_code=502, message="second failure")
+
+        assert not isinstance(first.headers, dict)
+        assert not isinstance(second.headers, dict)
+
+    def test_mutating_a_dict_passed_to_one_instance_does_not_leak_to_another(self):
+        """When a caller *does* pass an explicit headers dict, mutating it
+        must not affect a different, independently default-constructed
+        InfinityError -- this is exactly what happened before the fix,
+        since the mutated object was the shared default itself."""
+        explicit_headers = {"retry-after": "5"}
+        first = InfinityError(status_code=429, message="rate limited", headers=explicit_headers)
+        second = InfinityError(status_code=500, message="unrelated failure")
+
+        first.headers["x-request-id"] = "abc-123"
+
+        assert second.headers is None
+        assert "x-request-id" not in (second.headers or {})
+
+    def test_explicit_headers_argument_is_still_used_by_identity(self):
+        """The fix should not change behavior when a caller *does* pass
+        headers explicitly -- the same object should be used as-is."""
+        supplied = httpx.Headers({"content-type": "application/json"})
+        err = InfinityError(status_code=500, message="failure", headers=supplied)
+
+        assert err.headers is supplied
+
+    def test_call_sites_that_omit_headers_do_not_crash(self):
+        """litellm/llms/infinity/embedding/transformation.py and
+        litellm/llms/infinity/rerank/transformation.py both raise
+        InfinityError without a `headers=` kwarg -- confirm that still
+        works and yields None rather than a stale shared dict."""
+        err = InfinityError(message="raw response text", status_code=500)
+
+        assert err.status_code == 500
+        assert err.message == "raw response text"
+        assert err.headers is None


### PR DESCRIPTION
<!-- The whole description's target audience is humans, not AI agents -->

## TLDR

Problem this solves:

- `InfinityError.__init__` defaults `headers` to a mutable `{}`, created once when the function is defined
- Every `InfinityError` raised without an explicit `headers=` (both real call sites do this: `litellm/llms/infinity/embedding/transformation.py` and `litellm/llms/infinity/rerank/transformation.py`) gets the *same* dict object back on `.headers`
- If anything ever mutates one instance's `.headers`, that mutation silently leaks into every other default-constructed `InfinityError`, including ones from unrelated requests

How it solves it:

- Changes the default from `headers: dict | httpx.Headers = {}` to `headers: dict | httpx.Headers | None = None`, matching the pattern `BaseLLMException` (the parent class) already uses for the same parameter

## User Flow

Before: a shared mutable default silently links unrelated errors together

1. An Infinity embedding/rerank request fails without a response `headers` object, raising `InfinityError(message=..., status_code=...)` with no `headers=` kwarg
2. Something downstream reads and mutates that error's `.headers` dict
3. A completely unrelated Infinity request later fails the same way and raises its own `InfinityError` — its `.headers` already contains the leaked mutation from step 2, because it's literally the same dict object

After: each default-constructed `InfinityError` has independent, empty state

1. Same failure path, no `headers=` kwarg
2. `.headers` is `None` by default and is never shared across instances

## Relevant issues

Fixes #38909

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v` — see note below, I could only partially verify this locally
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

**Note on local verification:** I couldn't run `make install-dev` in my environment (its editable install needs a Rust toolchain via maturin, and my network is locked down to a small allowlist that doesn't include `static.rust-lang.org`). Instead I installed the published `litellm` wheel for its dependencies plus `pytest`/`respx` and pointed `PYTHONPATH` at this checkout, on Python 3.10.12. All 5 new tests in `tests/test_litellm/llms/infinity/test_common_utils.py` pass against the fix. To confirm they're a real regression test and not just tautologies, I reverted the fix locally (`git stash`) and reran: 4 of the 5 tests fail against the original `= {}` default (the 5th test, which only checks that an *explicitly passed* headers object is used by identity, is unaffected by this bug either way, as expected). I did not run the full existing suite since there's no pre-existing `tests/test_litellm/llms/infinity/` directory to check for regressions against (this PR creates it).

`make lint` (ruff format + ruff check) passes clean on both changed/added files with the pinned `ruff==0.15.3`.

## Screenshots / Proof of Fix

### Before (fix reverted locally via `git stash`)

```
tests/test_litellm/llms/infinity/test_common_utils.py::TestInfinityErrorDoesNotShareDefaultHeaders::test_call_sites_that_omit_headers_do_not_crash FAILED
tests/test_litellm/llms/infinity/test_common_utils.py::TestInfinityErrorDoesNotShareDefaultHeaders::test_default_headers_is_not_a_mutable_shared_dict FAILED
tests/test_litellm/llms/infinity/test_common_utils.py::TestInfinityErrorDoesNotShareDefaultHeaders::test_mutating_a_dict_passed_to_one_instance_does_not_leak_to_another FAILED
tests/test_litellm/llms/infinity/test_common_utils.py::TestInfinityErrorDoesNotShareDefaultHeaders::test_two_default_constructed_errors_do_not_share_headers_identity FAILED
4 failed, 1 passed in 0.53s
```

Example failure:
```
>       assert second.headers is None
E       AssertionError: assert {} is None
E        +  where {} = InfinityError('unrelated failure').headers
```

### After (fix applied)

```
tests/test_litellm/llms/infinity/test_common_utils.py::TestInfinityErrorDoesNotShareDefaultHeaders::test_call_sites_that_omit_headers_do_not_crash PASSED
tests/test_litellm/llms/infinity/test_common_utils.py::TestInfinityErrorDoesNotShareDefaultHeaders::test_default_headers_is_not_a_mutable_shared_dict PASSED
tests/test_litellm/llms/infinity/test_common_utils.py::TestInfinityErrorDoesNotShareDefaultHeaders::test_explicit_headers_argument_is_still_used_by_identity PASSED
tests/test_litellm/llms/infinity/test_common_utils.py::TestInfinityErrorDoesNotShareDefaultHeaders::test_mutating_a_dict_passed_to_one_instance_does_not_leak_to_another PASSED
tests/test_litellm/llms/infinity/test_common_utils.py::TestInfinityErrorDoesNotShareDefaultHeaders::test_two_default_constructed_errors_do_not_share_headers_identity PASSED
5 passed in 0.50s
```

## Type

🐛 Bug Fix

## Caveats (if any)

### Low

- I couldn't find an existing test directory for `litellm/llms/infinity/` to check this change against for regressions (this PR adds the first one)

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
