### PR TITLE
test(ocr): enforce Python/Rust function-trace parity

### DIFF
--- a/litellm-rust/Cargo.lock
+++ b/litellm-rust/Cargo.lock
@@ -1393,6 +1393,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1439,6 +1445,7 @@ dependencies = [
  "sha2 0.10.9",
  "thiserror 2.0.19",
  "tokio",
+ "tracing",
  "url",
 ]
 
@@ -1457,6 +1464,8 @@ dependencies = [
  "serde_json",
  "tokio",
  "tokio-tungstenite",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -2285,6 +2294,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shlex"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2420,6 +2438,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 3.0.0",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ad99c4c6d32803332c548b1af0540b357b3f5fc0be8f6c6bfe8b2e6ae784070"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -2668,6 +2695,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "sharded-slab",
+ "thread_local",
+ "tracing-core",
 ]
 
 [[package]]

--- a/litellm-rust/Cargo.toml
+++ b/litellm-rust/Cargo.toml
@@ -14,6 +14,8 @@ license = "MIT"
 repository = "https://github.com/BerriAI/litellm"
 
 [workspace.dependencies]
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", default-features = false, features = ["registry", "std"] }
 litellm-core = { path = "crates/core" }
 litellm-ai-gateway = { path = "crates/ai-gateway", default-features = false }
 litellm-python-interop = { path = "crates/python-interop" }

--- a/litellm-rust/crates/ai-gateway/src/ocr/hooks.rs
+++ b/litellm-rust/crates/ai-gateway/src/ocr/hooks.rs
@@ -87,7 +87,14 @@ impl OcrLifecycleHooks {
             &request.optional_params,
             &env_lookup,
         )?;
-        let filtered_params = config.map_ocr_params(&request.optional_params);
+        let supported_params = config.get_supported_ocr_params();
+        let non_default_params = request
+            .optional_params
+            .iter()
+            .filter(|(param, _)| supported_params.contains(&param.as_str()))
+            .map(|(param, value)| (param.clone(), value.clone()))
+            .collect();
+        let filtered_params = config.map_ocr_params(&non_default_params);
         let model = request.model.clone();
         let custom_llm_provider = request.custom_llm_provider.clone();
         let document = if config.requires_data_uri_document() {

--- a/litellm-rust/crates/ai-gateway/src/ocr/tests.rs
+++ b/litellm-rust/crates/ai-gateway/src/ocr/tests.rs
@@ -18,6 +18,14 @@ use crate::integrations::custom_logger::{
 };
 use crate::integrations::types::RequestMetadata;
 
+type LifecycleEvents = Arc<Mutex<Vec<&'static str>>>;
+
+fn record_lifecycle_event(events: Option<&LifecycleEvents>, event: &'static str) {
+    if let Some(events) = events {
+        events.lock().unwrap().push(event);
+    }
+}
+
 async fn read_http_headers(socket: &mut TcpStream) -> String {
     let mut request = Vec::new();
     let mut buffer = [0_u8; 1024];
@@ -80,9 +88,17 @@ struct RecordedLogEvent {
 #[derive(Default)]
 struct RecordingOcrLogger {
     events: Mutex<Vec<RecordedLogEvent>>,
+    lifecycle_events: Option<LifecycleEvents>,
 }
 
 impl RecordingOcrLogger {
+    fn with_lifecycle_events(lifecycle_events: LifecycleEvents) -> Self {
+        Self {
+            events: Mutex::new(Vec::new()),
+            lifecycle_events: Some(lifecycle_events),
+        }
+    }
+
     fn events(&self) -> Vec<RecordedLogEvent> {
         self.events.lock().unwrap().clone()
     }
@@ -96,6 +112,7 @@ impl CustomLogger for RecordingOcrLogger {
         _timing: CallbackTiming,
     ) -> LogFuture<'a> {
         Box::pin(async move {
+            record_lifecycle_event(self.lifecycle_events.as_ref(), "async_log_success_event");
             self.events.lock().unwrap().push(RecordedLogEvent {
                 hook: "async_log_success_event",
                 model: model_call_details.model.clone(),
@@ -115,6 +132,7 @@ impl CustomLogger for RecordingOcrLogger {
         _timing: CallbackTiming,
     ) -> LogFuture<'a> {
         Box::pin(async move {
+            record_lifecycle_event(self.lifecycle_events.as_ref(), "async_log_failure_event");
             self.events.lock().unwrap().push(RecordedLogEvent {
                 hook: "async_log_failure_event",
                 model: model_call_details.model.clone(),
@@ -135,22 +153,41 @@ struct RecordingOcrGuardrail {
     hooks: Vec<GuardrailEventHook>,
     events: Mutex<Vec<&'static str>>,
     block_pre_call: bool,
+    block_during_call: bool,
+    lifecycle_events: Option<LifecycleEvents>,
 }
 
 impl RecordingOcrGuardrail {
-    fn new(hooks: Vec<GuardrailEventHook>) -> Self {
+    fn with_lifecycle_events(
+        hooks: Vec<GuardrailEventHook>,
+        lifecycle_events: LifecycleEvents,
+    ) -> Self {
         Self {
             hooks,
             events: Mutex::new(Vec::new()),
             block_pre_call: false,
+            block_during_call: false,
+            lifecycle_events: Some(lifecycle_events),
         }
     }
 
-    fn blocking_pre_call() -> Self {
+    fn blocking_pre_call(lifecycle_events: LifecycleEvents) -> Self {
         Self {
             hooks: vec![GuardrailEventHook::PreCall],
             events: Mutex::new(Vec::new()),
             block_pre_call: true,
+            block_during_call: false,
+            lifecycle_events: Some(lifecycle_events),
+        }
+    }
+
+    fn blocking_during_call(lifecycle_events: LifecycleEvents) -> Self {
+        Self {
+            hooks: vec![GuardrailEventHook::PreCall, GuardrailEventHook::DuringCall],
+            events: Mutex::new(Vec::new()),
+            block_pre_call: false,
+            block_during_call: true,
+            lifecycle_events: Some(lifecycle_events),
         }
     }
 
@@ -174,6 +211,7 @@ impl CustomGuardrail for RecordingOcrGuardrail {
         mut request: GuardrailRequest,
     ) -> GuardrailFuture<'a> {
         Box::pin(async move {
+            record_lifecycle_event(self.lifecycle_events.as_ref(), "async_pre_call_hook");
             self.events.lock().unwrap().push("async_pre_call_hook");
             if self.block_pre_call {
                 return Ok(GuardrailDecision::Block(GuardrailError::blocked(
@@ -191,7 +229,13 @@ impl CustomGuardrail for RecordingOcrGuardrail {
         mut request: GuardrailRequest,
     ) -> GuardrailFuture<'a> {
         Box::pin(async move {
+            record_lifecycle_event(self.lifecycle_events.as_ref(), "async_moderation_hook");
             self.events.lock().unwrap().push("async_moderation_hook");
+            if self.block_during_call {
+                return Ok(GuardrailDecision::Block(GuardrailError::blocked(
+                    "blocked during provider preparation",
+                )));
+            }
             request.data["body"]["guarded_during"] = json!(true);
             Ok(GuardrailDecision::Mask(request))
         })
@@ -242,7 +286,7 @@ fn ocr_dispatch_supports_migrated_providers() {
     assert!(
         ocr_provider_config("vertex_ai", "deepseek-ocr-maas")
             .expect("vertex deepseek config resolves")
-            .supported_ocr_params()
+            .get_supported_ocr_params()
             .contains(&"temperature")
     );
     assert!(ocr_provider_config("openai", "gpt-4o").is_none());
@@ -281,14 +325,17 @@ fn auth_header_detection_is_case_insensitive() {
 
 #[tokio::test]
 async fn ocr_lifecycle_runs_pre_during_and_success_hooks() {
+    let lifecycle_events: LifecycleEvents = Arc::new(Mutex::new(Vec::new()));
     let listener = TcpListener::bind("127.0.0.1:0")
         .await
         .expect("test listener binds");
     let addr = listener.local_addr().expect("listener has local addr");
 
+    let provider_events = lifecycle_events.clone();
     let server = tokio::spawn(async move {
         let (mut socket, _) = listener.accept().await.expect("accepts one request");
         let request = read_http_request(&mut socket).await;
+        record_lifecycle_event(Some(&provider_events), "provider_request_received");
         let response_body = r#"{"pages":[{"index":0,"markdown":"ok"}],"model":"mistral-ocr-latest","usage_info":{"pages_processed":1}}"#;
         let response = format!(
             "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{}",
@@ -302,11 +349,13 @@ async fn ocr_lifecycle_runs_pre_during_and_success_hooks() {
         request
     });
 
-    let logger = Arc::new(RecordingOcrLogger::default());
-    let guardrail = Arc::new(RecordingOcrGuardrail::new(vec![
-        GuardrailEventHook::PreCall,
-        GuardrailEventHook::DuringCall,
-    ]));
+    let logger = Arc::new(RecordingOcrLogger::with_lifecycle_events(
+        lifecycle_events.clone(),
+    ));
+    let guardrail = Arc::new(RecordingOcrGuardrail::with_lifecycle_events(
+        vec![GuardrailEventHook::PreCall, GuardrailEventHook::DuringCall],
+        lifecycle_events.clone(),
+    ));
     let response = ocr(OcrRequest {
         model: "mistral-ocr-latest",
         document: json!({
@@ -346,6 +395,15 @@ async fn ocr_lifecycle_runs_pre_during_and_success_hooks() {
             error_kind: None,
         }]
     );
+    assert_eq!(
+        lifecycle_events.lock().unwrap().as_slice(),
+        [
+            "async_pre_call_hook",
+            "async_moderation_hook",
+            "provider_request_received",
+            "async_log_success_event",
+        ]
+    );
 
     let request = server.await.expect("server task completes");
     assert!(request.contains(r#""guarded_pre":true"#), "{request}");
@@ -353,15 +411,65 @@ async fn ocr_lifecycle_runs_pre_during_and_success_hooks() {
 }
 
 #[tokio::test]
+async fn ocr_lifecycle_during_call_block_skips_provider_and_runs_failure_callback() {
+    let lifecycle_events: LifecycleEvents = Arc::new(Mutex::new(Vec::new()));
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("test listener binds");
+    let addr = listener.local_addr().expect("listener has local addr");
+    let logger = Arc::new(RecordingOcrLogger::with_lifecycle_events(
+        lifecycle_events.clone(),
+    ));
+    let guardrail = Arc::new(RecordingOcrGuardrail::blocking_during_call(
+        lifecycle_events.clone(),
+    ));
+
+    let error = ocr(OcrRequest {
+        model: "mistral-ocr-latest",
+        document: json!({
+            "type": "document_url",
+            "document_url": "https://example.com/doc.pdf"
+        }),
+        api_key: Some("sk-test"),
+        api_base: Some(&format!("http://{addr}")),
+        custom_llm_provider: Some("mistral"),
+        extra_headers: None,
+        optional_params: Map::new(),
+        timeout: Some(Duration::from_millis(100)),
+        callbacks: vec![logger],
+        guardrails: vec![guardrail],
+        request_metadata: RequestMetadata::default(),
+        litellm_call_id: Some("ocr-call-during-block"),
+    })
+    .await
+    .expect_err("during-call guardrail blocks request");
+
+    assert!(matches!(error, Error::InvalidRequest(_)));
+    assert_eq!(
+        lifecycle_events.lock().unwrap().as_slice(),
+        [
+            "async_pre_call_hook",
+            "async_moderation_hook",
+            "async_log_failure_event",
+        ]
+    );
+    let accepted = tokio::time::timeout(Duration::from_millis(100), listener.accept()).await;
+    assert!(accepted.is_err(), "provider socket should not be touched");
+}
+
+#[tokio::test]
 async fn ocr_lifecycle_runs_failure_hook_on_provider_error() {
+    let lifecycle_events: LifecycleEvents = Arc::new(Mutex::new(Vec::new()));
     let listener = TcpListener::bind("127.0.0.1:0")
         .await
         .expect("test listener binds");
     let addr = listener.local_addr().expect("listener has local addr");
 
+    let provider_events = lifecycle_events.clone();
     let server = tokio::spawn(async move {
         let (mut socket, _) = listener.accept().await.expect("accepts one request");
         let _request = read_http_request(&mut socket).await;
+        record_lifecycle_event(Some(&provider_events), "provider_request_received");
         let response_body = "provider failed";
         let response = format!(
             "HTTP/1.1 500 Internal Server Error\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{}",
@@ -374,7 +482,9 @@ async fn ocr_lifecycle_runs_failure_hook_on_provider_error() {
             .expect("writes response");
     });
 
-    let logger = Arc::new(RecordingOcrLogger::default());
+    let logger = Arc::new(RecordingOcrLogger::with_lifecycle_events(
+        lifecycle_events.clone(),
+    ));
     let err = ocr(OcrRequest {
         model: "mistral-ocr-latest",
         document: json!({
@@ -408,16 +518,25 @@ async fn ocr_lifecycle_runs_failure_hook_on_provider_error() {
             error_kind: Some("HttpError".to_string()),
         }]
     );
+    assert_eq!(
+        lifecycle_events.lock().unwrap().as_slice(),
+        ["provider_request_received", "async_log_failure_event"]
+    );
 }
 
 #[tokio::test]
 async fn ocr_lifecycle_pre_call_block_skips_provider_socket() {
+    let lifecycle_events: LifecycleEvents = Arc::new(Mutex::new(Vec::new()));
     let listener = TcpListener::bind("127.0.0.1:0")
         .await
         .expect("test listener binds");
     let addr = listener.local_addr().expect("listener has local addr");
-    let logger = Arc::new(RecordingOcrLogger::default());
-    let guardrail = Arc::new(RecordingOcrGuardrail::blocking_pre_call());
+    let logger = Arc::new(RecordingOcrLogger::with_lifecycle_events(
+        lifecycle_events.clone(),
+    ));
+    let guardrail = Arc::new(RecordingOcrGuardrail::blocking_pre_call(
+        lifecycle_events.clone(),
+    ));
 
     let err = ocr(OcrRequest {
         model: "mistral-ocr-latest",
@@ -451,6 +570,10 @@ async fn ocr_lifecycle_pre_call_block_skips_provider_socket() {
             response_object: Some("error".to_string()),
             error_kind: Some("InvalidRequest".to_string()),
         }]
+    );
+    assert_eq!(
+        lifecycle_events.lock().unwrap().as_slice(),
+        ["async_pre_call_hook", "async_log_failure_event"]
     );
     let accepted = tokio::time::timeout(Duration::from_millis(100), listener.accept()).await;
     assert!(accepted.is_err(), "provider socket should not be touched");

--- a/litellm-rust/crates/core/Cargo.toml
+++ b/litellm-rust/crates/core/Cargo.toml
@@ -6,6 +6,7 @@ license.workspace = true
 repository.workspace = true
 
 [dependencies]
+tracing.workspace = true
 base64.workspace = true
 futures-util.workspace = true
 bytes.workspace = true

--- a/litellm-rust/crates/core/src/ocr/transformation.rs
+++ b/litellm-rust/crates/core/src/ocr/transformation.rs
@@ -25,16 +25,16 @@ pub enum OcrResponseHandling {
 }
 
 pub trait OcrProviderConfig: Sync {
-    fn supported_ocr_params(&self) -> &'static [&'static str];
+    fn get_supported_ocr_params(&self) -> &'static [&'static str];
 
+    #[tracing::instrument(target = "litellm::function_trace", level = "trace", skip_all)]
     fn map_ocr_params(&self, non_default_params: &Map<String, Value>) -> Map<String, Value> {
-        let mut mapped_params = Map::new();
-        for (param, value) in non_default_params {
-            if self.supported_ocr_params().contains(&param.as_str()) {
-                mapped_params.insert(param.clone(), value.clone());
-            }
-        }
-        mapped_params
+        let supported_params = self.get_supported_ocr_params();
+        non_default_params
+            .iter()
+            .filter(|(param, _)| supported_params.contains(&param.as_str()))
+            .map(|(param, value)| (param.clone(), value.clone()))
+            .collect()
     }
 
     fn transform_ocr_request(

--- a/litellm-rust/crates/core/src/providers/azure_ai/ocr/transformation.rs
+++ b/litellm-rust/crates/core/src/providers/azure_ai/ocr/transformation.rs
@@ -281,8 +281,8 @@ fn page_dimensions(page: &Map<String, Value>) -> Value {
 }
 
 impl OcrProviderConfig for AzureAiOcrConfig {
-    fn supported_ocr_params(&self) -> &'static [&'static str] {
-        MISTRAL_OCR_CONFIG.supported_ocr_params()
+    fn get_supported_ocr_params(&self) -> &'static [&'static str] {
+        MISTRAL_OCR_CONFIG.get_supported_ocr_params()
     }
 
     fn transform_ocr_request(
@@ -326,7 +326,7 @@ impl OcrProviderConfig for AzureAiOcrConfig {
 }
 
 impl OcrProviderConfig for AzureDocumentIntelligenceOcrConfig {
-    fn supported_ocr_params(&self) -> &'static [&'static str] {
+    fn get_supported_ocr_params(&self) -> &'static [&'static str] {
         AZURE_DOCUMENT_INTELLIGENCE_SUPPORTED_OCR_PARAMS
     }
 

--- a/litellm-rust/crates/core/src/providers/mistral/ocr/transformation.rs
+++ b/litellm-rust/crates/core/src/providers/mistral/ocr/transformation.rs
@@ -70,10 +70,12 @@ pub struct MistralOcrConfig;
 pub const MISTRAL_OCR_CONFIG: MistralOcrConfig = MistralOcrConfig;
 
 impl OcrProviderConfig for MistralOcrConfig {
-    fn supported_ocr_params(&self) -> &'static [&'static str] {
+    #[tracing::instrument(target = "litellm::function_trace", level = "trace", skip_all)]
+    fn get_supported_ocr_params(&self) -> &'static [&'static str] {
         SUPPORTED_OCR_PARAMS
     }
 
+    #[tracing::instrument(target = "litellm::function_trace", level = "trace", skip_all)]
     fn transform_ocr_request(
         &self,
         model: &str,
@@ -100,6 +102,7 @@ impl OcrProviderConfig for MistralOcrConfig {
         })
     }
 
+    #[tracing::instrument(target = "litellm::function_trace", level = "trace", skip_all)]
     fn transform_ocr_response(
         &self,
         model: &str,
@@ -153,8 +156,8 @@ impl OcrProviderConfig for MistralOcrConfig {
     }
 }
 
-pub fn supported_ocr_params() -> &'static [&'static str] {
-    MISTRAL_OCR_CONFIG.supported_ocr_params()
+pub fn get_supported_ocr_params() -> &'static [&'static str] {
+    MISTRAL_OCR_CONFIG.get_supported_ocr_params()
 }
 
 pub fn map_ocr_params(non_default_params: &Map<String, Value>) -> Map<String, Value> {
@@ -181,7 +184,7 @@ mod tests {
     #[test]
     fn supported_params_match_python_mistral_ocr_config() {
         assert_eq!(
-            supported_ocr_params(),
+            get_supported_ocr_params(),
             &[
                 "pages",
                 "include_image_base64",

--- a/litellm-rust/crates/core/src/providers/vertex_ai/ocr/transformation.rs
+++ b/litellm-rust/crates/core/src/providers/vertex_ai/ocr/transformation.rs
@@ -208,8 +208,8 @@ fn ocr_data_from_content(content: Value, usage: Option<Value>, model: &str) -> V
 }
 
 impl OcrProviderConfig for VertexAiOcrConfig {
-    fn supported_ocr_params(&self) -> &'static [&'static str] {
-        MISTRAL_OCR_CONFIG.supported_ocr_params()
+    fn get_supported_ocr_params(&self) -> &'static [&'static str] {
+        MISTRAL_OCR_CONFIG.get_supported_ocr_params()
     }
 
     fn transform_ocr_request(
@@ -253,7 +253,7 @@ impl OcrProviderConfig for VertexAiOcrConfig {
 }
 
 impl OcrProviderConfig for VertexAiDeepSeekOcrConfig {
-    fn supported_ocr_params(&self) -> &'static [&'static str] {
+    fn get_supported_ocr_params(&self) -> &'static [&'static str] {
         DEEPSEEK_SUPPORTED_OCR_PARAMS
     }
 

--- a/litellm-rust/crates/python-bridge/Cargo.toml
+++ b/litellm-rust/crates/python-bridge/Cargo.toml
@@ -16,6 +16,8 @@ extension-module = ["pyo3/extension-module"]
 panic-test = []
 
 [dependencies]
+tracing.workspace = true
+tracing-subscriber.workspace = true
 futures-util.workspace = true
 litellm-core = { workspace = true, features = ["bedrock-auth"] }
 litellm-ai-gateway = { workspace = true, default-features = false }

--- a/litellm-rust/crates/python-bridge/src/function_trace.rs
+++ b/litellm-rust/crates/python-bridge/src/function_trace.rs
@@ -1,0 +1,129 @@
+use std::sync::{Arc, Mutex};
+
+use serde::Serialize;
+use tracing::span::{Attributes, Id};
+use tracing::{Dispatch, Level, Subscriber};
+use tracing_subscriber::filter::{LevelFilter, filter_fn};
+use tracing_subscriber::layer::Context;
+use tracing_subscriber::prelude::*;
+use tracing_subscriber::registry::LookupSpan;
+use tracing_subscriber::{Layer, Registry};
+
+const TARGET: &str = "litellm::function_trace";
+
+#[derive(Clone, Debug, PartialEq, Serialize)]
+pub(crate) struct FunctionTraceEvent {
+    pub(crate) function: &'static str,
+    pub(crate) depth: usize,
+}
+
+#[derive(Clone, Default)]
+pub(crate) struct FunctionTrace {
+    events: Arc<Mutex<Vec<FunctionTraceEvent>>>,
+}
+
+impl FunctionTrace {
+    pub(crate) fn dispatcher(&self) -> Dispatch {
+        let filter = filter_fn(|metadata| {
+            metadata.is_span() && metadata.target() == TARGET && *metadata.level() == Level::TRACE
+        })
+        .with_max_level_hint(LevelFilter::TRACE);
+        Dispatch::new(
+            Registry::default().with(
+                FunctionTraceLayer {
+                    trace: self.clone(),
+                }
+                .with_filter(filter),
+            ),
+        )
+    }
+
+    pub(crate) fn events(&self) -> Vec<FunctionTraceEvent> {
+        self.events
+            .lock()
+            .unwrap_or_else(|error| error.into_inner())
+            .clone()
+    }
+}
+
+struct FunctionTraceLayer {
+    trace: FunctionTrace,
+}
+
+impl<S> Layer<S> for FunctionTraceLayer
+where
+    S: Subscriber + for<'lookup> LookupSpan<'lookup>,
+{
+    fn on_new_span(&self, attributes: &Attributes<'_>, id: &Id, context: Context<'_, S>) {
+        let depth = context
+            .span(id)
+            .map(|span| span.scope().skip(1).count())
+            .unwrap_or_default();
+        self.trace
+            .events
+            .lock()
+            .unwrap_or_else(|error| error.into_inner())
+            .push(FunctionTraceEvent {
+                function: attributes.metadata().name(),
+                depth,
+            });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn records_matching_spans_in_creation_order() {
+        let trace = FunctionTrace::default();
+        let dispatch = trace.dispatcher();
+
+        tracing::dispatcher::with_default(&dispatch, || {
+            let _ignored = tracing::trace_span!(target: "other", "ignored");
+            let _first = tracing::trace_span!(target: TARGET, "same_name");
+            let _wrong_level = tracing::debug_span!(target: TARGET, "wrong_level");
+            let _second = tracing::trace_span!(target: TARGET, "same_name");
+        });
+
+        assert_eq!(
+            trace.events(),
+            vec![
+                FunctionTraceEvent {
+                    function: "same_name",
+                    depth: 0,
+                },
+                FunctionTraceEvent {
+                    function: "same_name",
+                    depth: 0,
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn records_matching_span_nesting_depth() {
+        let trace = FunctionTrace::default();
+        let dispatch = trace.dispatcher();
+
+        tracing::dispatcher::with_default(&dispatch, || {
+            let outer = tracing::trace_span!(target: TARGET, "outer");
+            let _outer_guard = outer.enter();
+            let _inner = tracing::trace_span!(target: TARGET, "inner");
+        });
+
+        assert_eq!(
+            trace.events(),
+            vec![
+                FunctionTraceEvent {
+                    function: "outer",
+                    depth: 0,
+                },
+                FunctionTraceEvent {
+                    function: "inner",
+                    depth: 1,
+                },
+            ]
+        );
+    }
+}

--- a/litellm-rust/crates/python-bridge/src/lib.rs
+++ b/litellm-rust/crates/python-bridge/src/lib.rs
@@ -1,5 +1,6 @@
 mod diagnostics;
 mod errors;
+mod function_trace;
 mod marshal;
 mod routes;
 

--- a/litellm-rust/crates/python-bridge/src/routes/definition.rs
+++ b/litellm-rust/crates/python-bridge/src/routes/definition.rs
@@ -154,7 +154,7 @@ mod tests {
                 (
                     "ocr",
                     "aocr",
-                    "(model, document, api_key=None, api_base=None, custom_llm_provider=None, extra_headers=None, optional_params=None, timeout_seconds=None)",
+                    "(model, document, api_key=None, api_base=None, custom_llm_provider=None, extra_headers=None, optional_params=None, timeout_seconds=None, trace=None)",
                 ),
                 (
                     "transcription",

--- a/litellm-rust/crates/python-bridge/src/routes/ocr.rs
+++ b/litellm-rust/crates/python-bridge/src/routes/ocr.rs
@@ -4,8 +4,10 @@ use std::future::Future;
 use litellm_ai_gateway::io::ocr::{OcrRequest, ocr as run_ocr};
 use pyo3::prelude::*;
 use serde_json::Value;
+use tracing::instrument::WithSubscriber;
 
 use crate::errors::core_error_to_pyerr;
+use crate::function_trace::FunctionTrace;
 use crate::marshal::{RouteOptions, RouteOptionsInputs, object_or_empty};
 
 fn prepare_ocr(
@@ -22,6 +24,7 @@ fn prepare_ocr(
     })?;
     let optional_params = object_or_empty("optional_params", inputs.optional_params)?;
 
+    let trace = inputs.trace.unwrap_or(false).then(FunctionTrace::default);
     Ok(async move {
         let RouteOptions {
             model,
@@ -31,7 +34,7 @@ fn prepare_ocr(
             extra_headers,
             timeout,
         } = options;
-        run_ocr(OcrRequest {
+        let future = run_ocr(OcrRequest {
             model: &model,
             document,
             api_key: api_key.as_deref(),
@@ -44,8 +47,14 @@ fn prepare_ocr(
             guardrails: Vec::new(),
             request_metadata: Default::default(),
             litellm_call_id: None,
-        })
-        .await
+        });
+        match trace {
+            Some(trace) => {
+                let response = future.with_subscriber(trace.dispatcher()).await?;
+                Ok(serde_json::json!({ "response": response, "trace": trace.events() }))
+            }
+            None => future.await,
+        }
     })
 }
 
@@ -67,6 +76,7 @@ bridge_route! {
         #[pyo3(from_py_with = litellm_python_interop::from_py)]
         optional_params: Option<Value>,
         timeout_seconds: Option<f64>,
+        trace: Option<bool>,
     },
     prepare = prepare_ocr,
     errors = core_error_to_pyerr,

--- a/tests/sdk_function_trace/README.md
+++ b/tests/sdk_function_trace/README.md
@@ -1,0 +1,15 @@
+# Local SDK parity report
+
+From the repository root:
+
+```bash
+uv run python -m tests.sdk_function_trace.local_parity
+```
+
+One invocation groups SDK response parity and function-trace parity by Rust SDK route, with separate sync and async rows. Every case is marked non-strict xfail: XPASS means the comparison matched; XFAIL prints a mismatch, unsupported operation, or missing-coverage reason. Ordinary parity failures do not fail the command; collection and runner errors still do
+
+SDK comparisons call the public Python SDK with `rust=False` and `rust=True` against a local HTTP mock provider. They require the native extension and verify Rust execution attribution so Python fallback cannot count as a match. Responses are compared after excluding hidden metadata and, for chat completions, generated IDs and creation timestamps. No provider credentials or running proxy are needed
+
+Implemented comparisons cover Mistral OCR and Anthropic chat completions/Messages. Function coverage currently reuses the Mistral OCR transformation trace tests. Other rows explicitly report coverage gaps; the report is not exhaustive provider, streaming, error, or request-shape coverage
+
+The module is outside pytest's default filename patterns and the entry point refuses to run when `CI` is set. Existing function-parity tests retain their normal failure behavior

--- a/tests/sdk_function_trace/__init__.py
+++ b/tests/sdk_function_trace/__init__.py
@@ -1,0 +1,13 @@
+from tests.sdk_function_trace.harness import (
+    TraceScenario,
+    TraceStep,
+    assert_function_trace_parity,
+)
+from tests.sdk_function_trace.profiler import FunctionTraceEvent
+
+__all__ = [
+    "FunctionTraceEvent",
+    "TraceScenario",
+    "TraceStep",
+    "assert_function_trace_parity",
+]

--- a/tests/sdk_function_trace/harness.py
+++ b/tests/sdk_function_trace/harness.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass
+from types import FunctionType
+from typing import Final, cast
+
+from tests.sdk_function_trace.profiler import FunctionTraceEvent, profile_python
+
+
+@dataclass(frozen=True, slots=True)
+class TraceStep:
+    function: FunctionType
+    depth: int
+
+
+@dataclass(frozen=True, slots=True)
+class TraceScenario:
+    steps: tuple[TraceStep, ...]
+    invoke_python: Callable[[], object]
+    invoke_rust: Callable[[], Sequence[FunctionTraceEvent]]
+
+
+def assert_function_trace_parity(scenario: TraceScenario) -> None:
+    expected: Final = tuple(
+        FunctionTraceEvent(function=step.function.__name__, depth=step.depth) for step in scenario.steps
+    )
+    functions: Final = cast(tuple[FunctionType, ...], tuple(step.function for step in scenario.steps))
+    with profile_python(functions) as profiler:
+        scenario.invoke_python()
+    python_trace: Final = tuple(profiler.events)
+    rust_trace: Final = tuple(scenario.invoke_rust())
+
+    if python_trace != expected:
+        raise AssertionError(f"Python function trace differs: {python_trace!r} != {expected!r}")
+    if rust_trace != expected:
+        raise AssertionError(f"Rust function trace differs: {rust_trace!r} != {expected!r}")
+    if python_trace != rust_trace:
+        raise AssertionError(f"Python and Rust function traces differ: {python_trace!r} != {rust_trace!r}")

--- a/tests/sdk_function_trace/local_parity.py
+++ b/tests/sdk_function_trace/local_parity.py
@@ -1,0 +1,252 @@
+"""Local SDK parity report: uv run python -m tests.sdk_function_trace.local_parity."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Final, Literal
+
+import pytest
+from _pytest._code.code import ExceptionRepr
+from _pytest.terminal import TerminalReporter
+from pydantic import BaseModel, JsonValue, TypeAdapter
+
+from tests.sdk_function_trace.mock_provider import MockProviderResponse, mock_provider
+
+Route = Literal["/ocr", "/chat/completions", "/v1/messages", "/audio/transcriptions", "/v1/responses (websocket)"]
+Kind = Literal["SDK E2E", "Functions"]
+JSON_OBJECT: Final = TypeAdapter(dict[str, JsonValue])
+ROUTES: Final[tuple[Route, ...]] = (
+    "/ocr",
+    "/chat/completions",
+    "/v1/messages",
+    "/audio/transcriptions",
+    "/v1/responses (websocket)",
+)
+KINDS: Final[tuple[Kind, ...]] = ("SDK E2E", "Functions")
+ANTHROPIC_RESPONSE: Final = MockProviderResponse(
+    status_code=200,
+    headers=(("content-type", "application/json"),),
+    body=json.dumps(
+        {
+            "id": "msg_parity",
+            "type": "message",
+            "role": "assistant",
+            "model": "claude-sonnet-4-6",
+            "content": [{"type": "text", "text": "hello"}],
+            "stop_reason": "end_turn",
+            "stop_sequence": None,
+            "usage": {"input_tokens": 2, "output_tokens": 3},
+        }
+    ).encode(),
+)
+
+
+@dataclass(frozen=True, slots=True)
+class Case:
+    route: Route
+    kind: Kind
+    asynchronous: bool
+
+    @property
+    def label(self) -> str:
+        return f"{self.route} | {self.kind} | {'async' if self.asynchronous else 'sync'}"
+
+
+CASES: Final = tuple(
+    Case(route, kind, asynchronous) for route in ROUTES for kind in KINDS for asynchronous in (False, True)
+)
+
+
+def invoke_sdk(case: Case, *, rust: bool, api_base: str) -> object:
+    import litellm
+    from litellm.llms.anthropic.experimental_pass_through.messages.handler import (
+        anthropic_messages,
+        anthropic_messages_handler,
+    )
+    from tests.test_litellm.ocr import test_function_trace as ocr_trace
+
+    match case.route:
+        case "/ocr":
+            if case.asynchronous:
+                return asyncio.run(
+                    litellm.aocr(
+                        model=f"mistral/{ocr_trace.MODEL}",
+                        document=ocr_trace.DOCUMENT,
+                        api_key="test-key",
+                        api_base=api_base,
+                        pages=[0],
+                        rust=rust,
+                        timeout=5,
+                    )
+                )
+            return litellm.ocr(
+                model=f"mistral/{ocr_trace.MODEL}",
+                document=ocr_trace.DOCUMENT,
+                api_key="test-key",
+                api_base=api_base,
+                pages=[0],
+                rust=rust,
+                timeout=5,
+            )
+        case "/chat/completions":
+            if case.asynchronous:
+                return asyncio.run(
+                    litellm.acompletion(
+                        model="anthropic/claude-sonnet-4-6",
+                        messages=[{"role": "user", "content": "hello"}],
+                        max_tokens=16,
+                        api_key="test-key",
+                        api_base=api_base,
+                        rust=rust,
+                        timeout=5,
+                        num_retries=0,
+                    )
+                )
+            return litellm.completion(
+                model="anthropic/claude-sonnet-4-6",
+                messages=[{"role": "user", "content": "hello"}],
+                max_tokens=16,
+                api_key="test-key",
+                api_base=api_base,
+                rust=rust,
+                timeout=5,
+                num_retries=0,
+            )
+        case "/v1/messages":
+            if case.asynchronous:
+                return asyncio.run(
+                    anthropic_messages(
+                        model="anthropic/claude-sonnet-4-6",
+                        messages=[{"role": "user", "content": "hello"}],
+                        max_tokens=16,
+                        api_key="test-key",
+                        api_base=api_base,
+                        rust=rust,
+                        timeout=5,
+                    )
+                )
+            return anthropic_messages_handler(
+                model="anthropic/claude-sonnet-4-6",
+                messages=[{"role": "user", "content": "hello"}],
+                max_tokens=16,
+                api_key="test-key",
+                api_base=api_base,
+                rust=rust,
+                timeout=5,
+            )
+        case _:
+            pytest.xfail("SDK parity scenario not implemented for this route")
+
+
+def response_body(response: object, *, rust: bool, route: Route) -> dict[str, JsonValue]:
+    raw: Final = response.model_dump(mode="json") if isinstance(response, BaseModel) else response
+    body: Final = JSON_OBJECT.validate_python(raw)
+    hidden: Final = JSON_OBJECT.validate_python(getattr(response, "_hidden_params", body.get("_hidden_params", {})))
+    expected_engine: Final = "rust" if rust else "python"
+    if rust or route != "/chat/completions":
+        assert hidden.get("core_engine") == expected_engine, (
+            f"expected {expected_engine} execution, got {hidden.get('core_engine')!r}"
+        )
+    excluded: Final = frozenset(
+        {"_hidden_params", "id", "created"} if route == "/chat/completions" else {"_hidden_params"}
+    )
+    return {key: value for key, value in body.items() if key not in excluded}
+
+
+def sdk_response(case: Case, *, rust: bool) -> dict[str, JsonValue]:
+    from tests.test_litellm.ocr import test_function_trace as ocr_trace
+
+    provider_response: Final = ocr_trace.PROVIDER_RESPONSE if case.route == "/ocr" else ANTHROPIC_RESPONSE
+    with mock_provider(provider_response) as api_base:
+        return response_body(invoke_sdk(case, rust=rust, api_base=api_base), rust=rust, route=case.route)
+
+
+@pytest.mark.xfail(strict=False, reason="Local migration parity diagnostic")
+@pytest.mark.parametrize("case", CASES, ids=tuple(case.label for case in CASES))
+def test_parity(case: Case) -> None:
+    if os.getenv("CI"):
+        pytest.skip("Local-only parity report")
+    from litellm.rust_bridge import get_native_bridge
+    from tests.test_litellm.ocr import test_function_trace as ocr_trace
+
+    if case.kind == "Functions":
+        if case.route != "/ocr":
+            pytest.xfail("Function trace parity not implemented for this route")
+        ocr_trace.test_mistral_ocr_transformation_function_trace_parity(case.asynchronous)
+        return
+    if case.route == "/audio/transcriptions":
+        pytest.xfail("Bedrock transcription is Rust-only; no Python reference implementation")
+    if case.route == "/v1/responses (websocket)":
+        pytest.xfail("Websocket SDK parity scenario not implemented")
+    assert get_native_bridge() is not None, "Native Rust extension is required"
+    python: Final = sdk_response(case, rust=False)
+    native: Final = sdk_response(case, rust=True)
+    differences: Final = tuple(
+        key
+        for key in sorted(python.keys() | native.keys())
+        if key not in python or key not in native or python[key] != native[key]
+    )
+    assert python == native, f"Response mismatch in: {', '.join(differences)}\nPython: {python!r}\nRust: {native!r}"
+
+
+class ParityReport:
+    def __init__(self) -> None:
+        self.reports: tuple[pytest.TestReport, ...] = ()
+
+    def pytest_runtest_logreport(self, report: pytest.TestReport) -> None:
+        if report.when == "call" or (report.when == "setup" and report.outcome != "passed"):
+            self.reports = (*self.reports, report)
+
+    def pytest_terminal_summary(self, terminalreporter: TerminalReporter) -> None:
+        terminalreporter.section("Local SDK parity: XPASS = matched, XFAIL = mismatch or coverage gap")
+        for route in ROUTES:
+            terminalreporter.write_line(f"\n{route}", bold=True)
+            for report in self.reports:
+                if not report.nodeid.split("[", 1)[-1].startswith(f"{route} |"):
+                    continue
+                label: Final = report.nodeid.split(" | ", 1)[-1].removesuffix("]")
+                status: Final = (
+                    "XPASS" if report.passed else "XFAIL" if hasattr(report, "wasxfail") else report.outcome.upper()
+                )
+                terminalreporter.write_line(f"  {status:7} {label}", green=report.passed, yellow=not report.passed)
+                if report.longrepr:
+                    reason: Final = (
+                        report.longrepr.reprcrash.message
+                        if isinstance(report.longrepr, ExceptionRepr) and report.longrepr.reprcrash is not None
+                        else str(report.longrepr)
+                    )
+                    terminalreporter.write_line(
+                        f"          {reason.splitlines()[0].removeprefix('_pytest.outcomes.XFailed: ')}"
+                    )
+
+
+def main() -> int:
+    if os.getenv("CI"):
+        print("Local-only parity report; refusing to run in CI")
+        return 0
+    os.environ.setdefault("LITELLM_LOCAL_MODEL_COST_MAP", "True")
+    return int(
+        pytest.main(
+            [
+                str(Path(__file__).resolve()),
+                "--disable-plugin-autoload",
+                "-q",
+                "--tb=no",
+                "--no-header",
+                "--disable-warnings",
+                "-W",
+                "ignore::pytest.PytestConfigWarning",
+                "-r",
+                "N",
+            ],
+            plugins=[ParityReport()],
+        )
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/sdk_function_trace/mock_provider.py
+++ b/tests/sdk_function_trace/mock_provider.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+from collections.abc import Generator
+from contextlib import contextmanager
+from dataclasses import dataclass
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from threading import Lock, Thread
+from typing import Final, cast
+
+
+@dataclass(frozen=True, slots=True)
+class MockProviderResponse:
+    status_code: int
+    headers: tuple[tuple[str, str], ...]
+    body: bytes
+
+
+class _MockProviderServer(ThreadingHTTPServer):
+    def __init__(self, response: MockProviderResponse) -> None:
+        super().__init__(("127.0.0.1", 0), _MockProviderHandler)
+        self.response: Final = response
+        self._request_count = 0
+        self._request_count_lock: Final = Lock()
+
+    def record_request(self) -> None:
+        with self._request_count_lock:
+            self._request_count += 1
+
+    @property
+    def request_count(self) -> int:
+        with self._request_count_lock:
+            return self._request_count
+
+
+class _MockProviderHandler(BaseHTTPRequestHandler):
+    protocol_version = "HTTP/1.1"
+
+    def do_POST(self) -> None:
+        content_length: Final = int(self.headers.get("content-length", "0"))
+        self.rfile.read(content_length)
+        server: Final = cast(_MockProviderServer, self.server)
+        server.record_request()
+        self.send_response(server.response.status_code)
+        for name, value in server.response.headers:
+            self.send_header(name, value)
+        self.send_header("content-length", str(len(server.response.body)))
+        self.end_headers()
+        self.wfile.write(server.response.body)
+
+    def log_message(self, format: str, *args: object) -> None:  # noqa: A002  # matches BaseHTTPRequestHandler
+        pass
+
+
+@contextmanager
+def mock_provider(response: MockProviderResponse) -> Generator[str]:
+    server: Final = _MockProviderServer(response)
+    thread: Final = Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    host, port = cast(tuple[str, int], server.server_address)
+    try:
+        yield f"http://{host}:{port}"
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join()
+    if server.request_count != 1:
+        raise AssertionError(f"expected one provider request, received {server.request_count}")

--- a/tests/sdk_function_trace/profiler.py
+++ b/tests/sdk_function_trace/profiler.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import sys
+from collections.abc import Generator, Sequence
+from contextlib import contextmanager
+from dataclasses import dataclass
+from types import FrameType, FunctionType
+from typing import Final
+
+
+@dataclass(frozen=True, slots=True)
+class FunctionTraceEvent:
+    function: str
+    depth: int
+
+
+class PythonProfiler:
+    def __init__(self, functions: Sequence[FunctionType]) -> None:
+        self._names_by_code: Final = {function.__code__: function.__name__ for function in functions}
+        self._seen_frames: Final[set[FrameType]] = set()
+        self.events: Final[list[FunctionTraceEvent]] = []
+
+    def __call__(self, frame: FrameType, event: str, _arg: object) -> None:
+        if event != "call" or frame in self._seen_frames:
+            return
+        function_name: Final = self._names_by_code.get(frame.f_code)
+        if function_name is None:
+            return
+        depth: Final = sum(ancestor.f_code in self._names_by_code for ancestor in _frame_ancestors(frame))
+        self._seen_frames.add(frame)
+        self.events.append(FunctionTraceEvent(function=function_name, depth=depth))
+
+
+def _frame_ancestors(frame: FrameType) -> Generator[FrameType]:
+    ancestor: Final = frame.f_back
+    if ancestor is not None:
+        yield ancestor
+        yield from _frame_ancestors(ancestor)
+
+
+@contextmanager
+def profile_python(functions: Sequence[FunctionType]) -> Generator[PythonProfiler]:
+    profiler: Final = PythonProfiler(functions)
+    previous: Final = sys.getprofile()
+    sys.setprofile(profiler)
+    try:
+        yield profiler
+    finally:
+        sys.setprofile(previous)

--- a/tests/test_litellm/ocr/test_function_trace.py
+++ b/tests/test_litellm/ocr/test_function_trace.py
@@ -1,0 +1,182 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import sys
+from collections.abc import Awaitable
+from functools import partial
+from types import FunctionType
+from typing import Final, Protocol, cast
+
+import pytest
+from pydantic import StrictInt, StrictStr, TypeAdapter
+from typing_extensions import ReadOnly, TypedDict
+
+import litellm
+from litellm.llms.mistral.ocr.transformation import MistralOCRConfig
+from litellm.rust_bridge import get_native_bridge
+from litellm.rust_bridge import ocr as rust_ocr_bridge
+from tests.sdk_function_trace import (
+    FunctionTraceEvent,
+    TraceScenario,
+    TraceStep,
+    assert_function_trace_parity,
+)
+from tests.sdk_function_trace.mock_provider import MockProviderResponse, mock_provider
+from tests.sdk_function_trace.profiler import profile_python
+
+MODEL: Final = "mistral-ocr-latest"
+DOCUMENT: Final[dict[str, str]] = {
+    "type": "document_url",
+    "document_url": "https://example.com/document.pdf",
+}
+OPTIONAL_PARAMS: Final[dict[str, object]] = {"pages": [0], "unsupported": True}
+RESPONSE_DATA: Final[dict[str, object]] = {
+    "pages": [{"index": 0, "markdown": "hello"}],
+    "model": "mistral-ocr-latest",
+    "usage_info": {"pages_processed": 1},
+}
+PROVIDER_RESPONSE: Final = MockProviderResponse(
+    status_code=200,
+    headers=(("content-type", "application/json"),),
+    body=json.dumps(RESPONSE_DATA).encode(),
+)
+
+
+class _TraceEventPayload(TypedDict):
+    function: ReadOnly[StrictStr]
+    depth: ReadOnly[StrictInt]
+
+
+class _TraceResponsePayload(TypedDict):
+    response: ReadOnly[object]
+    trace: ReadOnly[list[_TraceEventPayload]]
+
+
+_TRACE_RESPONSE: Final = TypeAdapter(_TraceResponsePayload)
+
+
+class _NativeTraceOcr(Protocol):
+    def __call__(
+        self,
+        *,
+        model: str,
+        document: dict[str, str],
+        api_key: str,
+        api_base: str,
+        optional_params: dict[str, object],
+        trace: bool,
+    ) -> object: ...
+
+
+def _invoke_python() -> object:
+    previous_enabled: Final = rust_ocr_bridge.rust_ocr_enabled()
+    rust_ocr_bridge.use_litellm_rust(False)
+    try:
+        with mock_provider(PROVIDER_RESPONSE) as api_base:
+            return litellm.ocr(
+                model=f"mistral/{MODEL}",
+                document=DOCUMENT,
+                api_key="test-key",
+                api_base=api_base,
+                pages=[0],
+                unsupported=True,
+            )
+    finally:
+        rust_ocr_bridge.use_litellm_rust(previous_enabled)
+
+
+def _invoke_rust(*, asynchronous: bool = False) -> tuple[FunctionTraceEvent, ...]:
+    bridge: Final = get_native_bridge()
+    if bridge is None:
+        raise AssertionError("The native Rust bridge is required for function-trace parity")
+    trace_ocr: Final = cast(_NativeTraceOcr, bridge.aocr if asynchronous else bridge.ocr)
+    with mock_provider(PROVIDER_RESPONSE) as api_base:
+        invoke: Final = partial(
+            trace_ocr,
+            model=f"mistral/{MODEL}",
+            document=DOCUMENT,
+            api_key="test-key",
+            api_base=api_base,
+            optional_params=OPTIONAL_PARAMS,
+            trace=True,
+        )
+
+        async def invoke_async() -> object:
+            return await cast(Awaitable[object], invoke())
+
+        raw_result: Final = asyncio.run(invoke_async()) if asynchronous else invoke()
+    result: Final = _TRACE_RESPONSE.validate_python(raw_result)
+    return tuple(
+        FunctionTraceEvent(
+            function=event["function"],
+            depth=event["depth"],
+        )
+        for event in result["trace"]
+    )
+
+
+@pytest.mark.parametrize("asynchronous", [False, True], ids=["sync", "async"])
+def test_mistral_ocr_transformation_function_trace_parity(asynchronous: bool) -> None:
+    assert_function_trace_parity(
+        TraceScenario(
+            steps=(
+                TraceStep(cast(FunctionType, MistralOCRConfig.get_supported_ocr_params), depth=0),
+                TraceStep(cast(FunctionType, MistralOCRConfig.map_ocr_params), depth=0),
+                TraceStep(cast(FunctionType, MistralOCRConfig.get_supported_ocr_params), depth=1),
+                TraceStep(cast(FunctionType, MistralOCRConfig.transform_ocr_request), depth=0),
+                TraceStep(cast(FunctionType, MistralOCRConfig.transform_ocr_response), depth=0),
+            ),
+            invoke_python=_invoke_python,
+            invoke_rust=partial(_invoke_rust, asynchronous=asynchronous),
+        )
+    )
+
+
+class First:
+    @staticmethod
+    def run() -> None:
+        return None
+
+
+class Second:
+    @staticmethod
+    def run() -> None:
+        return None
+
+
+def test_profiler_matches_code_objects_and_keeps_repeated_calls() -> None:
+    with profile_python((First.run,)) as profiler:
+        Second.run()
+        First.run()
+        First.run()
+
+    assert profiler.events == [
+        FunctionTraceEvent(function="run", depth=0),
+        FunctionTraceEvent(function="run", depth=0),
+    ]
+
+
+def test_profiler_records_selected_function_nesting_depth() -> None:
+    class Nested:
+        @staticmethod
+        def run() -> None:
+            First.run()
+
+    with profile_python((Nested.run, First.run)) as profiler:
+        Nested.run()
+
+    assert profiler.events == [
+        FunctionTraceEvent(function="run", depth=0),
+        FunctionTraceEvent(function="run", depth=1),
+    ]
+
+
+def test_profiler_restores_previous_profiler_after_failure() -> None:
+    previous: Final = sys.getprofile()
+
+    with pytest.raises(RuntimeError, match="stop"):
+        with profile_python((First.run,)):
+            raise RuntimeError("stop")
+
+    assert sys.getprofile() is previous


### PR DESCRIPTION
## TLDR

Problem this solves:

- Python and Rust function scope can drift silently
- Handwritten step aliases can hide function renames

How it solves it:

- Profiles Python through direct function references
- Compares Rust function names, call order, and nesting depth
- Adds a local SDK parity report grouped by route

## User Flow

Before: a contributor cannot prove a migrated SDK path calls the same functions in the same order

1. They change an OCR transformation function
2. Existing behavior tests still pass
3. Function-scope drift is not reported

After: the same change is checked against both real OCR call graphs

1. They change an OCR transformation function
2. The parity test runs Python and sync/async Rust OCR calls
3. A function-name, ordering, or nesting mismatch fails with both traces
4. They run `uv run python -m tests.sdk_function_trace.local_parity`
5. They see SDK and function parity grouped by route, with XPASS matches and XFAIL reasons

## Relevant issues

- Stacked on #39330

## Linear ticket

Resolves LIT-6533

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The focused test files covering my change pass locally
- [ ] My PR passes all required CI/CD checks
- [x] My PR scope is as isolated as possible
- [ ] I have received a Greptile Confidence Score of at least 4/5

## Screenshots / Proof of Fix

This adds internal parity enforcement with no user-visible behavior change

## Type

Infrastructure

Test

## Caveats (if any)

### Low

- Initial coverage targets Mistral OCR transformation functions
- Function tests enforce scope, call order, and nesting depth
- Local report compares SDK responses against mock HTTP providers
- Report is excluded from default collection and refuses CI
- Missing coverage appears as XFAIL alongside response mismatches
- Chat response differences remain in choices and usage fields
- Cross-language verification requires the local native extension
- Existing realtime code triggers three strict server Clippy warnings

## Final Attestation

- [x] Tests exercise real Python/Rust OCR calls and lifecycle ordering

