### PR TITLE
test(streaming): pin tool-call delta granularity with include_usage

### DIFF
--- a/tests/test_litellm/litellm_core_utils/test_streaming_handler.py
+++ b/tests/test_litellm/litellm_core_utils/test_streaming_handler.py
@@ -4692,3 +4692,84 @@ async def test_async_stream_assembled_response_keeps_vertex_traffic_type(logging
     assembled = litellm.stream_chunk_builder(chunks=received, messages=[{"role": "user", "content": "hi"}])
     assert assembled is not None
     assert assembled._hidden_params["provider_specific_fields"]["traffic_type"] == "ON_DEMAND_FLEX"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("continuous_usage", [False, True])
+async def test_include_usage_preserves_tool_argument_deltas(
+    logging_obj: Logging,
+    continuous_usage: bool,
+):
+    fragment_count = 128
+
+    async def upstream():
+        for index in range(fragment_count):
+            function = {"arguments": f"fragment-{index:03d}"}
+            tool_call = {
+                "index": 0,
+                "type": "function",
+                "function": function,
+            }
+            if index == 0:
+                function["name"] = "submit_document"
+                tool_call["id"] = "call_1"
+            usage = None
+            if continuous_usage:
+                usage = Usage(
+                    prompt_tokens=50,
+                    completion_tokens=index + 1,
+                    total_tokens=51 + index,
+                )
+            yield ModelResponseStream(
+                id="chatcmpl-tool-stream",
+                created=1,
+                model="test-model",
+                choices=[
+                    StreamingChoices(
+                        index=0,
+                        finish_reason=None,
+                        delta=Delta(tool_calls=[tool_call]),
+                    )
+                ],
+                usage=usage,
+            )
+        yield ModelResponseStream(
+            id="chatcmpl-tool-stream",
+            created=1,
+            model="test-model",
+            choices=[
+                StreamingChoices(
+                    index=0,
+                    finish_reason="tool_calls",
+                    delta=Delta(),
+                )
+            ],
+        )
+        yield ModelResponseStream(
+            id="chatcmpl-tool-stream",
+            created=1,
+            model="test-model",
+            choices=[],
+            usage=Usage(
+                prompt_tokens=50,
+                completion_tokens=fragment_count,
+                total_tokens=50 + fragment_count,
+            ),
+        )
+
+    wrapper = CustomStreamWrapper(
+        completion_stream=upstream(),
+        model="test-model",
+        logging_obj=logging_obj,
+        custom_llm_provider="openai",
+        stream_options={"include_usage": True},
+    )
+
+    seen = []
+    async for chunk in wrapper:
+        for choice in chunk.choices:
+            for tool_call in choice.delta.tool_calls or []:
+                if tool_call.function.arguments:
+                    seen.append(tool_call.function.arguments)
+
+    assert seen == [f"fragment-{index:03d}" for index in range(fragment_count)]

--- a/tests/test_litellm/proxy/test_common_request_processing.py
+++ b/tests/test_litellm/proxy/test_common_request_processing.py
@@ -7665,3 +7665,59 @@ def test_log_llm_api_exception_traceback_only_for_unexpected_errors(exc, expect_
     records = [r for r in caplog.records if "_handle_llm_api_exception(): Exception occured" in r.getMessage()]
     assert len(records) == 1
     assert (records[0].exc_info is not None) is expect_traceback
+
+
+class TestIncludeUsageToolArgumentStreaming:
+    @staticmethod
+    async def _aiter(items):
+        for item in items:
+            yield item
+
+    @pytest.mark.asyncio
+    async def test_fast_path_preserves_tool_argument_delta_granularity(self, monkeypatch):
+        from litellm.types.utils import Delta, ModelResponseStream, StreamingChoices
+
+        monkeypatch.setattr(litellm, "callbacks", [])
+        ProxyLogging._callback_capabilities_cache.clear()
+        fragment_count = 128
+        chunks = [
+            ModelResponseStream(
+                id="chatcmpl-tool-stream",
+                created=1,
+                model="test-model",
+                choices=[
+                    StreamingChoices(
+                        index=0,
+                        finish_reason=None,
+                        delta=Delta(
+                            tool_calls=[
+                                {
+                                    "index": 0,
+                                    "function": {"arguments": f"fragment-{index:03d}"},
+                                }
+                            ]
+                        ),
+                    )
+                ],
+            )
+            for index in range(fragment_count)
+        ]
+
+        proxy_logging_obj = ProxyLogging(user_api_key_cache=MagicMock())
+        out = [
+            chunk
+            async for chunk in ProxyBaseLLMRequestProcessing.async_streaming_data_generator(
+                response=self._aiter(chunks),
+                user_api_key_dict=MagicMock(spec=UserAPIKeyAuth),
+                request_data={"model": "test-model"},
+                proxy_logging_obj=proxy_logging_obj,
+                serialize_chunk=lambda chunk: chunk,
+                serialize_error=lambda error: error,
+            )
+        ]
+
+        arguments = [
+            chunk.choices[0].delta.tool_calls[0].function.arguments
+            for chunk in out
+        ]
+        assert arguments == [f"fragment-{index:03d}" for index in range(fragment_count)]


### PR DESCRIPTION
## TLDR

Problem this solves:

- Reported streams collapse 128 tool argument deltas near completion
- The first draft failed before exercising streaming behavior

How it solves it:

- Uses realistic start-only tool metadata
- Pins wrapper and proxy granularity at 128 deltas
- Rebases coverage onto current staging

## User Flow

Before: a developer reports frozen tool streaming, but CI cannot identify whether LiteLLM's default stream path loses fragments

1. They send POST https://litellm-domain/v1/chat/completions with `"stream": true` and `"include_usage": true`
2. The production topology returns roughly ten end-loaded tool argument chunks
3. The original regression test fails while constructing its logging fixture

After: the characterization tests exercise both default forwarding boundaries without changing production behavior

1. They send the same POST https://litellm-domain/v1/chat/completions request
2. Tests feed 128 ordered tool argument deltas through the wrapper and proxy generator
3. CI verifies all 128 deltas remain ordered at both boundaries

## Relevant issues

Refs #38926

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The focused test nodes pass locally
- [ ] My PR passes all required CI/CD checks
- [x] My PR's scope is as isolated as possible
- [ ] I have received a Greptile Confidence Score of at least 4/5

## Screenshots / Proof of Fix

Shared setup uses a fake OpenAI-compatible SSE upstream that emits 128 tool argument fragments five milliseconds apart

### Before (4ba8517134816b98a040300032e7e0185ccffbc7)

1. The original tests instantiate `Logging` with an unsupported `stream_options` argument
2. All three tests stop with `TypeError` before consuming a stream

### After (1370057fa3cbd77cce10efc05f18e7b9533c82b2)

1. Run the two focused pytest nodes for wrapper and proxy forwarding
2. Both wrapper variants and the proxy generator pass, preserving 128 ordered fragments
3. Live proxy checks preserve 128 fragments on both `v1.98.0-rc.1` and current staging
4. The checks pass through both native `hosted_vllm` and Chat Completions to Responses bridge routes

## Type

Test

## Caveats

### Medium

- The reported production collapse does not reproduce on default proxy paths
- Exact callback or guardrail configuration is still required
- This draft intentionally contains no speculative production change

## Final Attestation

- [x] The tests cover the wrapper and proxy forwarding boundaries
- [ ] The production topology is not yet fully represented by the tests
