### PR TITLE
Fix: parse comma-separated `langfuse_tags` header into a list so router retry/fallback doesn't crash

### DIFF
--- a/litellm/integrations/langfuse/langfuse.py
+++ b/litellm/integrations/langfuse/langfuse.py
@@ -288,7 +288,14 @@ class LangFuseLogger:
                     verbose_logger.warning("Overwriting Langfuse `%s` from request header", trace_param_key)
                 else:
                     verbose_logger.debug("Found Langfuse `%s` in request header", trace_param_key)
-                metadata[trace_param_key] = proxy_headers.get(metadata_param_key)
+                header_value = proxy_headers.get(metadata_param_key)
+                if trace_param_key == "tags" and isinstance(header_value, str):
+                    # Langfuse tags are a list. Parse the comma-separated header string
+                    # here, so the shared litellm_params metadata never holds a raw
+                    # string: the router's tag handling reuses that dict across retry
+                    # attempts and crashes on a string during retry/fallback (#38927).
+                    header_value = [tag.strip() for tag in header_value.split(",") if tag.strip()]
+                metadata[trace_param_key] = header_value
 
         return metadata
 

--- a/tests/test_litellm/integrations/test_langfuse.py
+++ b/tests/test_litellm/integrations/test_langfuse.py
@@ -1554,3 +1554,63 @@ def test_langfuse_deployment_environment_fallback_never_raises(monkeypatch, env_
         langfuse_host="https://test.langfuse.com",
     )
     assert logger.langfuse_environment == expected
+
+
+def test_tags_header_is_parsed_into_a_list():
+    """A ``langfuse_tags`` header arrives as one comma-separated string."""
+    metadata: dict = {}
+    litellm_params = {
+        "metadata": metadata,
+        "proxy_server_request": {"headers": {"langfuse_tags": "org:acme, agent:support"}},
+    }
+
+    returned = LangFuseLogger.add_metadata_from_header(litellm_params, metadata)
+
+    assert returned["tags"] == ["org:acme", "agent:support"]
+
+
+def test_tags_header_never_leaves_a_string_in_shared_metadata():
+    """``add_metadata_from_header`` mutates the caller's metadata dict in place, and the
+    router reuses that dict across retry attempts: a raw header string in ``tags``
+    crashes ``Router._update_kwargs_with_deployment`` with ``'str' object has no
+    attribute 'append'`` on any retry/fallback deployment that has
+    ``litellm_credential_name`` (https://github.com/BerriAI/litellm/issues/38927)."""
+    metadata: dict = {}
+    litellm_params = {
+        "metadata": metadata,
+        "proxy_server_request": {"headers": {"langfuse_tags": "org:acme,agent:support"}},
+    }
+
+    returned = LangFuseLogger.add_metadata_from_header(litellm_params, metadata)
+
+    assert returned is metadata
+    assert metadata["tags"] == ["org:acme", "agent:support"]
+    # What the router's "CREDENTIAL NAME AS TAG" branch does on the next attempt:
+    metadata["tags"].append("Credential: my-credential")
+    assert "Credential: my-credential" in metadata["tags"]
+
+
+def test_tags_already_in_metadata_pass_through_unchanged():
+    """Body-supplied tags are already a list; only header ingestion needs parsing."""
+    metadata: dict = {"tags": ["pre:set"]}
+    litellm_params = {
+        "metadata": metadata,
+        "proxy_server_request": {"headers": {}},
+    }
+
+    returned = LangFuseLogger.add_metadata_from_header(litellm_params, metadata)
+
+    assert returned["tags"] == ["pre:set"]
+
+
+def test_other_langfuse_headers_stay_raw_strings():
+    """Only ``tags`` needs list parsing; other steering headers keep their raw value."""
+    metadata: dict = {}
+    litellm_params = {
+        "metadata": metadata,
+        "proxy_server_request": {"headers": {"langfuse_existing_trace_id": "trace-123"}},
+    }
+
+    LangFuseLogger.add_metadata_from_header(litellm_params, metadata)
+
+    assert metadata["existing_trace_id"] == "trace-123"


### PR DESCRIPTION
## Title

Fix `langfuse_tags` header crashing router retry/fallback (#38927)

## Relevant issues

Fixes #38927

## Pre-Submission checklist

- [x] I have Added testing in the `tests/test_litellm/` directory
- [x] I have added a screenshot of my new test passing locally (see Testing below)
- [x] My PR passes all unit tests on `make test-unit`
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

🐛 Bug Fix

## Changes

`LangFuseLogger.add_metadata_from_header` copied the raw `langfuse_tags` HTTP header value — a comma-separated **string** — into the shared `litellm_params["metadata"]["tags"]` in place. Langfuse tags are a list everywhere else, and the router reuses that same metadata dict across retry attempts:

- `Router._update_kwargs_with_deployment` (`## CREDENTIAL NAME AS TAG`) calls `existing_tags.append(credential_tag)` → `AttributeError: 'str' object has no attribute 'append'`. The whole request fails with a client-facing 400 `invalid_request_error` instead of failing over. Every retry/fallback under the header crashes when the next deployment has `litellm_credential_name`.
- The sibling `## DEPLOYMENT-LEVEL TAGS` branch calls `list(existing_tags)`, which explodes the string into single characters (silent tag corruption).

This PR fixes the problem at ingestion: the `tags` header value is parsed into a stripped list before it is written into the shared metadata, mirroring how the other `langfuse_*` steering headers were hardened in #36740. Other header keys keep their existing raw-string behavior. Both `langfuse.py` and `langfuse_otel.py` are covered, since `langfuse_otel._extract_langfuse_metadata` reuses this helper.

Deliberately **no `router.py` changes**, to stay clear of open #30042 (which rewrites the credential-tag branch — its list handling receives an actual list once this lands).

## Testing

Four new unit tests in `tests/test_litellm/integrations/test_langfuse.py`:

```
tests/test_litellm/integrations/test_langfuse.py::test_tags_header_is_parsed_into_a_list PASSED
tests/test_litellm/integrations/test_langfuse.py::test_tags_header_never_leaves_a_string_in_shared_metadata PASSED
tests/test_litellm/integrations/test_langfuse.py::test_tags_already_in_metadata_pass_through_unchanged PASSED
tests/test_litellm/integrations/test_langfuse.py::test_other_langfuse_headers_stay_raw_strings PASSED
```

Also verified live against a v1.96.2 proxy (patched in place): pre-fix, tagged requests that hit a failing first deployment returned 400 `Invalid request format: 'str' object has no attribute 'append'` on the retry; post-fix, the same tagged requests succeed and Langfuse receives `tags` as a proper list (`['org:acme','agent:support']`) end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
