### PR TITLE
fix(rag): reject unsupported ingest providers

### DIFF
--- a/litellm/proxy/rag_endpoints/endpoints.py
+++ b/litellm/proxy/rag_endpoints/endpoints.py
@@ -13,6 +13,7 @@ from typing import TYPE_CHECKING, Any, Final
 import orjson
 from fastapi import APIRouter, Depends, HTTPException, Request, Response, status
 from fastapi.responses import ORJSONResponse, StreamingResponse
+from typing_extensions import ReadOnly, TypedDict
 
 import litellm
 from litellm._logging import verbose_proxy_logger
@@ -44,6 +45,15 @@ if TYPE_CHECKING:
     from litellm.proxy.utils import PrismaClient
 
 router: Final = APIRouter()
+
+
+class _RAGIngestErrorDetail(TypedDict):
+    error: ReadOnly[str]
+
+
+def _rag_ingest_bad_request(message: str) -> HTTPException:
+    detail: Final[_RAGIngestErrorDetail] = {"error": message}
+    return HTTPException(status_code=400, detail=detail)
 
 
 def _raise_vector_store_scan_depth_exceeded() -> None:
@@ -430,14 +440,13 @@ async def parse_rag_ingest_request(
                 )
 
         provider: Final = vector_store_opts.get("custom_llm_provider", "openai")
-        if isinstance(provider, str):
-            try:
-                get_ingestion_class(provider)
-            except ValueError as error:
-                raise HTTPException(
-                    status_code=400,
-                    detail={"error": str(error)},
-                ) from error
+        if not isinstance(provider, str):
+            raise _rag_ingest_bad_request("custom_llm_provider must be a string")
+
+        try:
+            get_ingestion_class(provider)
+        except ValueError as error:
+            raise _rag_ingest_bad_request(str(error)) from error
 
     return ingest_options, secured_file_data, file_url, file_id
 

--- a/litellm/proxy/rag_endpoints/endpoints.py
+++ b/litellm/proxy/rag_endpoints/endpoints.py
@@ -37,6 +37,7 @@ from litellm.proxy.rag_endpoints.upload_security import (
 from litellm.proxy.vector_store_endpoints.utils import (
     assert_user_can_access_vector_store_id,
 )
+from litellm.rag.main import get_ingestion_class
 from litellm.repositories.table_repositories import ManagedVectorStoresRepository
 
 if TYPE_CHECKING:
@@ -427,6 +428,16 @@ async def parse_rag_ingest_request(
                         "Credentials must be configured server-side."
                     },
                 )
+
+        provider: Final = vector_store_opts.get("custom_llm_provider", "openai")
+        if isinstance(provider, str):
+            try:
+                get_ingestion_class(provider)
+            except ValueError as error:
+                raise HTTPException(
+                    status_code=400,
+                    detail={"error": str(error)},
+                ) from error
 
     return ingest_options, secured_file_data, file_url, file_id
 

--- a/tests/test_litellm/proxy/rag_endpoints/test_rag_endpoints.py
+++ b/tests/test_litellm/proxy/rag_endpoints/test_rag_endpoints.py
@@ -6,6 +6,7 @@ Covers:
 """
 
 import io
+from typing import Final
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -45,6 +46,35 @@ def client_internal_user():
         yield TestClient(app)
     finally:
         app.dependency_overrides = original_overrides
+
+
+def test_rag_ingest_rejects_unsupported_provider_before_execution(
+    client_internal_user: TestClient,
+) -> None:
+    with (
+        patch(
+            "litellm.proxy.rag_endpoints.endpoints.litellm.aingest",
+            new_callable=AsyncMock,
+            return_value={"status": "completed", "vector_store_id": "vs_unexpected"},
+        ) as mock_aingest,
+        patch("litellm.proxy.proxy_server.prisma_client", None),
+    ):
+        response: Final = client_internal_user.post(
+            "/v1/rag/ingest",
+            json={
+                "file_id": "file-test",
+                "ingest_options": {"vector_store": {"custom_llm_provider": "milvus"}},
+            },
+        )
+
+    assert response.status_code == 400
+    assert response.json() == {
+        "detail": {
+            "error": "Provider 'milvus' is not supported for RAG ingestion. "
+            "Supported providers: openai, bedrock, gemini, s3_vectors, vertex_ai"
+        }
+    }
+    mock_aingest.assert_not_awaited()
 
 
 def test_internal_user_viewer_rag_ingest_without_vector_store_id_rejected(

--- a/tests/test_litellm/proxy/rag_endpoints/test_rag_endpoints.py
+++ b/tests/test_litellm/proxy/rag_endpoints/test_rag_endpoints.py
@@ -7,11 +7,10 @@ Covers:
 
 import io
 from typing import Final
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 from fastapi.testclient import TestClient
-
 
 from litellm.proxy._types import LitellmUserRoles, UserAPIKeyAuth
 from litellm.proxy.auth.user_api_key_auth import user_api_key_auth
@@ -73,6 +72,33 @@ def test_rag_ingest_rejects_unsupported_provider_before_execution(
             "error": "Provider 'milvus' is not supported for RAG ingestion. "
             "Supported providers: openai, bedrock, gemini, s3_vectors, vertex_ai"
         }
+    }
+    mock_aingest.assert_not_awaited()
+
+
+def test_rag_ingest_rejects_non_string_provider_before_execution(
+    client_internal_user: TestClient,
+) -> None:
+    with (
+        patch(
+            "litellm.proxy.rag_endpoints.endpoints.litellm.aingest",
+            new_callable=AsyncMock,
+        ) as mock_aingest,
+        patch("litellm.proxy.proxy_server.prisma_client", None),
+    ):
+        response: Final = client_internal_user.post(
+            "/v1/rag/ingest",
+            json={
+                "file_id": "file-test",
+                "ingest_options": {
+                    "vector_store": {"custom_llm_provider": {"provider": "milvus"}}
+                },
+            },
+        )
+
+    assert response.status_code == 400
+    assert response.json() == {
+        "detail": {"error": "custom_llm_provider must be a string"}
     }
     mock_aingest.assert_not_awaited()
 

--- a/tests/test_litellm/proxy/rag_endpoints/test_rag_endpoints.py
+++ b/tests/test_litellm/proxy/rag_endpoints/test_rag_endpoints.py
@@ -47,24 +47,16 @@ def client_internal_user():
         app.dependency_overrides = original_overrides
 
 
-def test_rag_ingest_rejects_unsupported_provider_before_execution(
+def test_rag_ingest_rejects_unsupported_provider(
     client_internal_user: TestClient,
 ) -> None:
-    with (
-        patch(
-            "litellm.proxy.rag_endpoints.endpoints.litellm.aingest",
-            new_callable=AsyncMock,
-            return_value={"status": "completed", "vector_store_id": "vs_unexpected"},
-        ) as mock_aingest,
-        patch("litellm.proxy.proxy_server.prisma_client", None),
-    ):
-        response: Final = client_internal_user.post(
-            "/v1/rag/ingest",
-            json={
-                "file_id": "file-test",
-                "ingest_options": {"vector_store": {"custom_llm_provider": "milvus"}},
-            },
-        )
+    response: Final = client_internal_user.post(
+        "/v1/rag/ingest",
+        json={
+            "file_id": "file-test",
+            "ingest_options": {"vector_store": {"custom_llm_provider": "milvus"}},
+        },
+    )
 
     assert response.status_code == 400
     assert response.json() == {
@@ -73,34 +65,25 @@ def test_rag_ingest_rejects_unsupported_provider_before_execution(
             "Supported providers: openai, bedrock, gemini, s3_vectors, vertex_ai"
         }
     }
-    mock_aingest.assert_not_awaited()
 
 
-def test_rag_ingest_rejects_non_string_provider_before_execution(
+def test_rag_ingest_rejects_non_string_provider(
     client_internal_user: TestClient,
 ) -> None:
-    with (
-        patch(
-            "litellm.proxy.rag_endpoints.endpoints.litellm.aingest",
-            new_callable=AsyncMock,
-        ) as mock_aingest,
-        patch("litellm.proxy.proxy_server.prisma_client", None),
-    ):
-        response: Final = client_internal_user.post(
-            "/v1/rag/ingest",
-            json={
-                "file_id": "file-test",
-                "ingest_options": {
-                    "vector_store": {"custom_llm_provider": {"provider": "milvus"}}
-                },
+    response: Final = client_internal_user.post(
+        "/v1/rag/ingest",
+        json={
+            "file_id": "file-test",
+            "ingest_options": {
+                "vector_store": {"custom_llm_provider": {"provider": "milvus"}}
             },
-        )
+        },
+    )
 
     assert response.status_code == 400
     assert response.json() == {
         "detail": {"error": "custom_llm_provider must be a string"}
     }
-    mock_aingest.assert_not_awaited()
 
 
 def test_internal_user_viewer_rag_ingest_without_vector_store_id_rejected(


### PR DESCRIPTION
## TLDR

Problem this solves:

- Providers without a RAG ingestion implementation reach execution and return internal server errors.
- Milvus is one example. LiteLLM supports searching registered Milvus collections, but it does not support creating or populating them through `/v1/rag/ingest`.

How it solves it:

- Validate providers against the RAG ingestion registry before starting ingestion.

## User Flow

Before: a provider unsupported by RAG ingestion fails as an internal error

1. They POST `http://localhost:4000/v1/rag/ingest` with provider `milvus`.
2. The proxy returns HTTP 500 with an internal traceback.

After: the same invalid request receives an actionable client error

1. They POST `http://localhost:4000/v1/rag/ingest` with provider `milvus`.
2. The proxy returns HTTP 400 listing supported ingestion providers.

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Shared setup: run the proxy with `general_settings.master_key: sk-local-rag-validation`.

### Before (4ba8517134)

1. Start the proxy: `litellm --config config.yaml --port 4000`.
2. Send `POST /v1/rag/ingest` with `{"file_id":"file-test","ingest_options":{"vector_store":{"custom_llm_provider":"milvus"}}}`.
3. Observe `HTTP/1.1 500 Internal Server Error` with a provider traceback.

### After (e4fe911273)

1. Start the proxy: `litellm --config config.yaml --port 4000`.
2. Send the identical `POST /v1/rag/ingest` request.
3. Observe `HTTP/1.1 400 Bad Request` and `Provider 'milvus' is not supported for RAG ingestion`.

## Type

🐛 Bug Fix
✅ Test

## Caveats (if any)

Milvus remains supported for vector-store search against existing, registered collections. That integration generates query embeddings and calls Milvus's REST endpoint at `/v2/vectordb/entities/search`.

This PR only handles the unsupported document-upload path. It does not add Milvus ingestion, change embedding-alias resolution, add gRPC transport, or remove Milvus from the dashboard's Create Vector Store provider list. Milvus collections must still be created and populated separately before LiteLLM searches them.

## QA runbook

- `tests/test_litellm/proxy/rag_endpoints/test_rag_endpoints.py::test_rag_ingest_rejects_unsupported_provider` - rejects unsupported providers before ingestion starts
  - [ ] POST `/v1/rag/ingest` with `file_id: file-test` and provider `milvus`
  - [ ] Expect HTTP 400 listing every supported ingestion provider
  - [ ] Confirm no provider-side ingestion request is attempted
  - [ ] Sanity check: the assertion matches the live proxy response exactly
- `tests/test_litellm/proxy/rag_endpoints/test_rag_endpoints.py::test_rag_ingest_rejects_non_string_provider` - rejects malformed provider values before ingestion starts
  - [ ] POST `/v1/rag/ingest` with an object-valued `custom_llm_provider`
  - [ ] Expect HTTP 400 stating that `custom_llm_provider` must be a string
  - [ ] Confirm no provider-side ingestion request is attempted

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
