### PR TITLE
fix(vector-stores): preserve S3 ingest embedding model

### DIFF
--- a/litellm/proxy/rag_endpoints/endpoints.py
+++ b/litellm/proxy/rag_endpoints/endpoints.py
@@ -225,6 +225,11 @@ async def _save_vector_store_to_db_from_rag_ingest(
         if key not in excluded_keys and value is not None:
             provider_specific_params[key] = value
 
+    embedding_config: Final = ingest_options.get("embedding")
+    embedding_model: Final = embedding_config.get("model") if embedding_config else None
+    if custom_llm_provider == "s3_vectors" and isinstance(embedding_model, str) and embedding_model:
+        provider_specific_params["embedding_model"] = embedding_model
+
     # Build file metadata entry using helper
     file_entry: Final = _build_file_metadata_entry(
         response=response,

--- a/litellm/proxy/rag_endpoints/endpoints.py
+++ b/litellm/proxy/rag_endpoints/endpoints.py
@@ -219,16 +219,18 @@ async def _save_vector_store_to_db_from_rag_ingest(
 
     # Extract provider-specific params from vector_store_config to save as litellm_params
     # This ensures params like aws_region_name, embedding_model, etc. are available for search
-    provider_specific_params: Final = {}
     excluded_keys: Final = {"custom_llm_provider", "vector_store_id"}
-    for key, value in vector_store_config.items():
-        if key not in excluded_keys and value is not None:
-            provider_specific_params[key] = value
-
     embedding_config: Final = ingest_options.get("embedding")
     embedding_model: Final = embedding_config.get("model") if embedding_config else None
-    if custom_llm_provider == "s3_vectors" and isinstance(embedding_model, str) and embedding_model:
-        provider_specific_params["embedding_model"] = embedding_model
+    s3_embedding_params: Final = (
+        {"embedding_model": embedding_model}
+        if custom_llm_provider == "s3_vectors" and isinstance(embedding_model, str) and embedding_model
+        else {}
+    )
+    provider_specific_params: Final = {
+        **{key: value for key, value in vector_store_config.items() if key not in excluded_keys and value is not None},
+        **s3_embedding_params,
+    }
 
     # Build file metadata entry using helper
     file_entry: Final = _build_file_metadata_entry(

--- a/tests/test_litellm/proxy/rag_endpoints/test_rag_endpoints.py
+++ b/tests/test_litellm/proxy/rag_endpoints/test_rag_endpoints.py
@@ -6,6 +6,7 @@ Covers:
 """
 
 import io
+import json
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -45,6 +46,41 @@ def client_internal_user():
         yield TestClient(app)
     finally:
         app.dependency_overrides = original_overrides
+
+
+@pytest.mark.asyncio
+async def test_s3_rag_ingest_persists_embedding_model_for_managed_search():
+    from litellm.proxy.rag_endpoints.endpoints import (
+        _save_vector_store_to_db_from_rag_ingest,
+    )
+
+    table = MagicMock()
+    table.find_unique = AsyncMock(return_value=None)
+    created_row = MagicMock()
+    created_row.model_dump.return_value = {
+        "vector_store_id": "documents:index",
+        "custom_llm_provider": "s3_vectors",
+    }
+    table.create = AsyncMock(return_value=created_row)
+    prisma_client = MagicMock()
+    prisma_client.db.litellm_managedvectorstorestable = table
+
+    await _save_vector_store_to_db_from_rag_ingest(
+        response={"vector_store_id": "documents:index"},
+        ingest_options={
+            "embedding": {"model": "text-embedding-3-large"},
+            "vector_store": {
+                "custom_llm_provider": "s3_vectors",
+                "vector_bucket_name": "documents",
+            },
+        },
+        prisma_client=prisma_client,
+        user_api_key_dict=UserAPIKeyAuth(user_id="user-1", team_id="team-1"),
+    )
+
+    persisted_params = json.loads(table.create.await_args.kwargs["data"]["litellm_params"])
+    assert persisted_params["embedding_model"] == "text-embedding-3-large"
+    assert persisted_params["vector_bucket_name"] == "documents"
 
 
 def test_internal_user_viewer_rag_ingest_without_vector_store_id_rejected(

--- a/ui/litellm-dashboard/src/components/networking.test.ts
+++ b/ui/litellm-dashboard/src/components/networking.test.ts
@@ -806,3 +806,55 @@ describe("daily activity api_key filter", () => {
     expect(requestedUrl(mockFetch)).toContain("user_id=");
   });
 });
+
+describe("ragIngestCall", () => {
+  const originalFetch = global.fetch;
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  const sendRequest = async (provider: string, providerParams: Record<string, unknown>) => {
+    const mockFetch = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response(JSON.stringify({ status: "completed" }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+    global.fetch = mockFetch;
+
+    await Networking.ragIngestCall(
+      "sk-key",
+      new File(["content"], "document.txt"),
+      provider,
+      undefined,
+      undefined,
+      undefined,
+      providerParams,
+    );
+
+    const body = mockFetch.mock.calls[0][1]?.body as FormData;
+    return JSON.parse(String(body.get("request")));
+  };
+
+  it("serializes embedding_model at the provider-defined ingest level", async () => {
+    const s3Request = await sendRequest("s3_vectors", {
+      vector_bucket_name: "documents",
+      embedding_model: "text-embedding-3-large",
+    });
+    const bedrockRequest = await sendRequest("bedrock", {
+      embedding_model: "amazon.titan-embed-text-v2:0",
+    });
+
+    expect(s3Request).toEqual({
+      ingest_options: {
+        embedding: { model: "text-embedding-3-large" },
+        vector_store: {
+          custom_llm_provider: "s3_vectors",
+          vector_bucket_name: "documents",
+        },
+      },
+    });
+    expect(bedrockRequest.ingest_options.vector_store.embedding_model).toBe("amazon.titan-embed-text-v2:0");
+  });
+});

--- a/ui/litellm-dashboard/src/components/networking.tsx
+++ b/ui/litellm-dashboard/src/components/networking.tsx
@@ -5805,11 +5805,10 @@ export const ragIngestCall = async (
     const formData = new FormData();
     formData.append("file", file);
 
-    const vectorStoreParams = { ...(providerSpecificParams ?? {}) };
-    const s3EmbeddingModel = customLlmProvider === "s3_vectors" ? vectorStoreParams.embedding_model : undefined;
-    if (customLlmProvider === "s3_vectors") {
-      delete vectorStoreParams.embedding_model;
-    }
+    const { embedding_model: providerEmbeddingModel, ...paramsWithoutEmbeddingModel } = providerSpecificParams ?? {};
+    const s3EmbeddingModel = customLlmProvider === "s3_vectors" ? providerEmbeddingModel : undefined;
+    const vectorStoreParams =
+      customLlmProvider === "s3_vectors" ? paramsWithoutEmbeddingModel : providerSpecificParams ?? {};
 
     const ingestOptions: any = {
       ingest_options: {

--- a/ui/litellm-dashboard/src/components/networking.tsx
+++ b/ui/litellm-dashboard/src/components/networking.tsx
@@ -5805,12 +5805,19 @@ export const ragIngestCall = async (
     const formData = new FormData();
     formData.append("file", file);
 
+    const vectorStoreParams = { ...(providerSpecificParams ?? {}) };
+    const s3EmbeddingModel = customLlmProvider === "s3_vectors" ? vectorStoreParams.embedding_model : undefined;
+    if (customLlmProvider === "s3_vectors") {
+      delete vectorStoreParams.embedding_model;
+    }
+
     const ingestOptions: any = {
       ingest_options: {
+        ...(typeof s3EmbeddingModel === "string" && s3EmbeddingModel && { embedding: { model: s3EmbeddingModel } }),
         vector_store: {
           custom_llm_provider: customLlmProvider,
           ...(vectorStoreId && { vector_store_id: vectorStoreId }),
-          ...(providerSpecificParams && providerSpecificParams),
+          ...vectorStoreParams,
         },
       },
     };


### PR DESCRIPTION
## TLDR

Problem this solves:

- S3 ingestion ignored the dashboard's selected embedding model
- Ingestion and managed search could use different models

How it solves it:

- Send S3 models through canonical embedding options
- Persist the same model for later S3 searches

## User Flow

Before: an admin selects an S3 embedding model, but ingestion and search silently use different models

1. They open `https://litellm-domain/ui/vector-stores`, select Amazon S3 Vectors, choose `text-embedding-3-large`, and upload a document
2. The dashboard sends `POST https://litellm-domain/rag/ingest` and shows a successful vector store ID, but ingestion uses `text-embedding-3-small`
3. They send `POST https://litellm-domain/v1/vector_stores/{vector_store_id}/search`; search uses `text-embedding-3-large`, so retrieval compares vectors from different embedding spaces

After: the same workflow uses the selected model consistently

1. They open `https://litellm-domain/ui/vector-stores`, select Amazon S3 Vectors, choose `text-embedding-3-large`, and upload a document
2. The dashboard sends `POST https://litellm-domain/rag/ingest` and shows a successful vector store ID; ingestion uses `text-embedding-3-large`
3. They send `POST https://litellm-domain/v1/vector_stores/{vector_store_id}/search`; search also uses `text-embedding-3-large`, so document and query vectors share one embedding space

## Relevant issues

Fixes #28905

## History and compatibility

The RAG ingest API has accepted embedding settings at `ingest_options.embedding.model` since #17109 merged on November 25, 2025

#19895 added the S3 dashboard on January 28, 2026 and accidentally serialized the selected model as `ingest_options.vector_store.embedding_model`. S3 ingestion never read that location, while managed search persisted and used it. #28905 reported the resulting mismatch, and #28920 and #31626 proposed accepting the accidental nested field as a server fallback

LiteLLM's self-hosted UI and server ship together, and the nested field was never part of `S3VectorsVectorStoreOptions`. This PR corrects the paired dashboard and server contract instead of retaining the accidental alias

The persistence change applies to newly created managed-store records. Existing `litellm_params` remain unchanged by design, and changing embedding models on existing S3 indexes is unsupported

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA)

## Screenshots / Proof of Fix

### Before (44f2a63c09)

#### Dashboard request contract

1. Run `npm run test:unit -- src/components/networking.test.ts -t ragIngestCall`
2. The test fails because `embedding_model` is inside `vector_store` instead of `embedding.model`

#### Managed search configuration

1. Run `pytest tests/test_litellm/proxy/rag_endpoints/test_rag_endpoints.py::test_s3_rag_ingest_persists_embedding_model_for_managed_search -q`
2. The test fails because persisted S3 parameters omit `embedding_model`

### After (396dfc7af2)

#### Dashboard request contract

1. Run `npm run test:unit -- src/components/networking.test.ts -t ragIngestCall`
2. The test passes: 1 passed and 41 skipped

#### Managed search configuration

1. Run `pytest tests/test_litellm/proxy/rag_endpoints/test_rag_endpoints.py::test_s3_rag_ingest_persists_embedding_model_for_managed_search -q`
2. The test passes: 1 passed

## Type

🐛 Bug Fix
✅ Test

## Caveats (if any)

### Low

- Existing managed-store parameters are not migrated
- Live AWS S3 Vectors proof was not run locally

## Final Attestation

- [ ] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
