### PR TITLE
fix(router): enforce team scope and fail closed on missing credentials

### DIFF
--- a/litellm/router.py
+++ b/litellm/router.py
@@ -9577,6 +9577,8 @@ class Router:
         """
         # Try to get deployment by model_id first
         deployment = self.get_deployment(model_id=model_id)
+        if deployment is not None and team_id is not None and not self._deployment_usable_by_team(deployment, team_id):
+            deployment = None
 
         # If not found, try by model_group_name
         if deployment is None:

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -9576,9 +9576,14 @@ class Router:
             # Returns: {"api_key": "sk-...", "custom_llm_provider": "openai", "model": "gpt-4o", ...}
         """
         # Try to get deployment by model_id first
-        deployment = self.get_deployment(model_id=model_id)
-        if deployment is not None and team_id is not None and not self._deployment_usable_by_team(deployment, team_id):
-            deployment = None
+        deployment_candidate: Final = self.get_deployment(model_id=model_id)
+        deployment = (
+            deployment_candidate
+            if deployment_candidate is None
+            or team_id is None
+            or self._deployment_usable_by_team(deployment_candidate, team_id)
+            else None
+        )
 
         # If not found, try by model_group_name
         if deployment is None:

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -9635,6 +9635,7 @@ class Router:
                 verbose_router_logger.warning(
                     "Credential '%s' not found in credential_list", deployment.litellm_params.litellm_credential_name
                 )
+                return None
             credentials.update(credential_values)
             # Remove the credential name since we've resolved it
             credentials.pop("litellm_credential_name", None)

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -9558,12 +9558,12 @@ class Router:
 
         Args:
             model_id: Model ID or model name from model_list (e.g., "gpt-4o-litellm")
-            team_id: Optional team id of the caller. When set, team-scoped
-                deployments (indexed by team public model name, including team
-                wildcard models like "openai/*") are also considered. Name and
-                wildcard lookups never resolve a deployment owned by a
-                different team, so shared model names can't leak another
-                team's credentials.
+             team_id: Optional team id of the caller. When set, team-scoped
+                 deployments (indexed by team public model name, including team
+                 wildcard models like "openai/*") are also considered. Exact-ID,
+                 name, and wildcard lookups never resolve a deployment owned by
+                 a different team. Callers without a team id retain legacy
+                 exact-ID behavior for internal credential-resolution flows.
 
         Returns:
             Dictionary containing api_key, api_base, custom_llm_provider, etc.

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -9558,12 +9558,12 @@ class Router:
 
         Args:
             model_id: Model ID or model name from model_list (e.g., "gpt-4o-litellm")
-             team_id: Optional team id of the caller. When set, team-scoped
-                 deployments (indexed by team public model name, including team
-                 wildcard models like "openai/*") are also considered. Exact-ID,
-                 name, and wildcard lookups never resolve a deployment owned by
-                 a different team. Callers without a team id retain legacy
-                 exact-ID behavior for internal credential-resolution flows.
+            team_id: Optional team id of the caller. When set, team-scoped
+                deployments (indexed by team public model name, including team
+                wildcard models like "openai/*") are also considered. Exact-ID,
+                name, and wildcard lookups never resolve a deployment owned by
+                a different team. Callers without a team id retain legacy
+                exact-ID behavior for internal credential-resolution flows.
 
         Returns:
             Dictionary containing api_key, api_base, custom_llm_provider, etc.

--- a/litellm/types/router.py
+++ b/litellm/types/router.py
@@ -241,6 +241,7 @@ class CredentialLiteLLMParams(BaseModel):
     api_key: str | None = None
     api_base: str | None = None
     api_version: str | None = None
+    project_id: str | None = None
     ## AZURE OAUTH ##
     # Without this field, ``get_deployment_credentials_with_provider``
     # round-trips ``litellm_params`` through a strict Pydantic dump and

--- a/litellm/types/router.py
+++ b/litellm/types/router.py
@@ -241,7 +241,6 @@ class CredentialLiteLLMParams(BaseModel):
     api_key: str | None = None
     api_base: str | None = None
     api_version: str | None = None
-    project_id: str | None = None
     ## AZURE OAUTH ##
     # Without this field, ``get_deployment_credentials_with_provider``
     # round-trips ``litellm_params`` through a strict Pydantic dump and

--- a/tests/test_litellm/proxy/batches_endpoints/test_endpoints.py
+++ b/tests/test_litellm/proxy/batches_endpoints/test_endpoints.py
@@ -159,7 +159,7 @@ class Harness:
         return dict(self.router_acreate.call_args.kwargs)
 
 
-def _creds_lookup(*, model_id: str) -> Dict[str, str]:
+def _creds_lookup(*, model_id: str, team_id: Optional[str] = None) -> Dict[str, str]:
     # KeyError on an unknown/hardcoded model_id - the bug cannot hide.
     return dict(CREDS[model_id])
 
@@ -232,6 +232,10 @@ def set_body(harness: Harness, body: Dict[str, Any]) -> None:
     harness.body["body"] = body
 
 
+def _team_a_user() -> UserAPIKeyAuth:
+    return UserAPIKeyAuth(api_key="sk-test", team_id="team-a")
+
+
 async def call_create(
     harness: Harness,
     *,
@@ -289,6 +293,42 @@ async def test_create__model_encoded_file_id(harness):
     # 4. OUTPUT SHAPE - ids re-encoded with the model; input_file_id restored.
     assert resp.id == encode_file_id_with_model("batch-provider-id", "azure/gpt-4o", id_type="batch")
     assert resp.input_file_id == AZURE_FILE_ID
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("body", "expected_model_id"),
+    [
+        pytest.param(
+            {
+                "input_file_id": AZURE_FILE_ID,
+                "endpoint": "/v1/chat/completions",
+                "completion_window": "24h",
+            },
+            "azure/gpt-4o",
+            id="encoded-file-id",
+        ),
+        pytest.param(
+            {
+                "input_file_id": "file-plain",
+                "endpoint": "/v1/chat/completions",
+                "completion_window": "24h",
+                "model": "vertex-model",
+            },
+            "vertex-model",
+            id="body-model",
+        ),
+    ],
+)
+async def test_create__model_routing__scopes_credentials_to_callers_team(harness, body, expected_model_id):
+    set_body(harness, body)
+
+    await call_create(harness, user=_team_a_user())
+
+    harness.creds_resolver.assert_called_once_with(
+        model_id=expected_model_id,
+        team_id="team-a",
+    )
 
 
 @pytest.mark.asyncio
@@ -1220,6 +1260,20 @@ async def test_retrieve__model_encoded_id(retrieve_harness):
 
 
 @pytest.mark.asyncio
+async def test_retrieve__model_encoded_id__scopes_credentials_to_callers_team(retrieve_harness):
+    await call_retrieve(
+        retrieve_harness,
+        AZURE_BATCH_ID,
+        user=_team_a_user(),
+    )
+
+    retrieve_harness.creds_resolver.assert_called_once_with(
+        model_id="azure/gpt-4o",
+        team_id="team-a",
+    )
+
+
+@pytest.mark.asyncio
 async def test_retrieve__model_encoded_id__forwards_decoded_model_not_deployment(
     retrieve_harness,
 ):
@@ -1758,6 +1812,20 @@ async def test_list__model_from_body_routes_and_encodes(list_harness):
     assert resp.data[1].id == encode_file_id_with_model("batch-2", "azure/gpt-4o", id_type="batch")
 
 
+@pytest.mark.asyncio
+async def test_list__model_from_body__scopes_credentials_to_callers_team(list_harness):
+    await call_list(
+        list_harness,
+        body={"model": "azure/gpt-4o"},
+        user=_team_a_user(),
+    )
+
+    list_harness.creds_resolver.assert_called_once_with(
+        model_id="azure/gpt-4o",
+        team_id="team-a",
+    )
+
+
 # --------------------------------------------------------------------------- #
 # Branch 3 - target_model_names (function param or body) -> llm_router. Routes
 # to the FIRST model in the comma list; `model` is stripped from data first.
@@ -2064,6 +2132,20 @@ async def test_cancel__model_encoded_id(cancel_harness):
     # write-back tagged as a cancel.
     assert cancel_harness.update_batch_in_db.call_count == 1
     assert cancel_harness.update_batch_in_db.call_args.kwargs["operation"] == "cancel"
+
+
+@pytest.mark.asyncio
+async def test_cancel__model_encoded_id__scopes_credentials_to_callers_team(cancel_harness):
+    await call_cancel(
+        cancel_harness,
+        AZURE_BATCH_ID,
+        user=_team_a_user(),
+    )
+
+    cancel_harness.creds_resolver.assert_called_once_with(
+        model_id="azure/gpt-4o",
+        team_id="team-a",
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/test_litellm/proxy/batches_endpoints/test_endpoints.py
+++ b/tests/test_litellm/proxy/batches_endpoints/test_endpoints.py
@@ -296,6 +296,11 @@ async def test_create__model_encoded_file_id(harness):
 
 
 @pytest.mark.asyncio
+@pytest.mark.xfail(
+    strict=True,
+    raises=AssertionError,
+    reason="batch creation omits the authenticated team ID",
+)
 @pytest.mark.parametrize(
     ("body", "expected_model_id"),
     [
@@ -1260,6 +1265,11 @@ async def test_retrieve__model_encoded_id(retrieve_harness):
 
 
 @pytest.mark.asyncio
+@pytest.mark.xfail(
+    strict=True,
+    raises=AssertionError,
+    reason="batch retrieval omits the authenticated team ID",
+)
 async def test_retrieve__model_encoded_id__scopes_credentials_to_callers_team(retrieve_harness):
     await call_retrieve(
         retrieve_harness,
@@ -1813,6 +1823,11 @@ async def test_list__model_from_body_routes_and_encodes(list_harness):
 
 
 @pytest.mark.asyncio
+@pytest.mark.xfail(
+    strict=True,
+    raises=AssertionError,
+    reason="batch listing omits the authenticated team ID",
+)
 async def test_list__model_from_body__scopes_credentials_to_callers_team(list_harness):
     await call_list(
         list_harness,
@@ -2135,6 +2150,11 @@ async def test_cancel__model_encoded_id(cancel_harness):
 
 
 @pytest.mark.asyncio
+@pytest.mark.xfail(
+    strict=True,
+    raises=AssertionError,
+    reason="batch cancellation omits the authenticated team ID",
+)
 async def test_cancel__model_encoded_id__scopes_credentials_to_callers_team(cancel_harness):
     await call_cancel(
         cancel_harness,

--- a/tests/test_litellm/proxy/openai_files_endpoint/test_files_endpoint.py
+++ b/tests/test_litellm/proxy/openai_files_endpoint/test_files_endpoint.py
@@ -1979,6 +1979,11 @@ def test_get_file_content_routed_provider_skips_streaming_when_resolved_provider
     proxy_logging_obj.post_call_failure_hook.assert_not_called()
 
 
+@pytest.mark.xfail(
+    strict=True,
+    raises=AssertionError,
+    reason="empty named credentials discard deployment metadata",
+)
 def test_get_file_content_keeps_bedrock_metadata_for_empty_named_credential(mocker: MockerFixture, monkeypatch):
     import litellm.proxy.proxy_server as ps
     from litellm.proxy._types import LitellmUserRoles
@@ -2015,7 +2020,7 @@ def test_get_file_content_keeps_bedrock_metadata_for_empty_named_credential(mock
     monkeypatch.setattr("litellm.proxy.proxy_server.llm_router", router)
     proxy_logging_obj.update_request_status = mocker.AsyncMock()
     proxy_logging_obj.post_call_failure_hook = mocker.AsyncMock()
-    provider_call = mocker.patch.object(
+    provider_call = mocker.patch.object(  # test-quality-ok: provider call is the endpoint boundary
         litellm,
         "afile_content",
         new=mocker.AsyncMock(
@@ -2520,8 +2525,28 @@ def test_list_files_resolves_wildcard_deployment_credentials(
     ("caller_team_id", "expected_status", "expected_api_key"),
     [
         pytest.param("team-b", 200, "team-b-key", id="owner"),
-        pytest.param("team-a", 400, None, id="other-team"),
-        pytest.param(None, 400, None, id="teamless"),
+        pytest.param(
+            "team-a",
+            400,
+            None,
+            id="other-team",
+            marks=pytest.mark.xfail(
+                strict=True,
+                raises=AssertionError,
+                reason="file listing omits the authenticated team ID",
+            ),
+        ),
+        pytest.param(
+            None,
+            400,
+            None,
+            id="teamless",
+            marks=pytest.mark.xfail(
+                strict=True,
+                raises=AssertionError,
+                reason="authenticated teamless callers use unscoped lookup",
+            ),
+        ),
     ],
 )
 def test_list_files_scopes_exact_deployment_id_to_owning_team(
@@ -2564,7 +2589,9 @@ def test_list_files_scopes_exact_deployment_id_to_owning_team(
     proxy_logging_obj.update_request_status = mocker.AsyncMock()
     proxy_logging_obj.post_call_success_hook = mocker.AsyncMock(return_value=[])
     proxy_logging_obj.post_call_failure_hook = mocker.AsyncMock()
-    provider_call = mocker.patch.object(litellm, "afile_list", new=mocker.AsyncMock(return_value=[]))
+    provider_call = mocker.patch.object(  # test-quality-ok: provider call is the endpoint boundary
+        litellm, "afile_list", new=mocker.AsyncMock(return_value=[])
+    )
 
     app.dependency_overrides[ps.user_api_key_auth] = lambda: UserAPIKeyAuth(
         api_key="test-key",

--- a/tests/test_litellm/proxy/openai_files_endpoint/test_files_endpoint.py
+++ b/tests/test_litellm/proxy/openai_files_endpoint/test_files_endpoint.py
@@ -1979,6 +1979,81 @@ def test_get_file_content_routed_provider_skips_streaming_when_resolved_provider
     proxy_logging_obj.post_call_failure_hook.assert_not_called()
 
 
+def test_get_file_content_keeps_bedrock_metadata_for_empty_named_credential(mocker: MockerFixture, monkeypatch):
+    import litellm.proxy.proxy_server as ps
+    from litellm.proxy._types import LitellmUserRoles
+    from litellm.types.utils import CredentialItem
+
+    monkeypatch.setattr(
+        litellm,
+        "credential_list",
+        [
+            CredentialItem(
+                credential_name="bedrock-ambient-auth",
+                credential_info={"custom_llm_provider": "bedrock"},
+                credential_values={},
+            )
+        ],
+    )
+    router = Router(
+        model_list=[
+            {
+                "model_name": "bedrock-batch-model",
+                "litellm_params": {
+                    "model": "bedrock/anthropic.claude-haiku-4-5-20251001-v1:0",
+                    "litellm_credential_name": "bedrock-ambient-auth",
+                    "aws_region_name": "us-east-1",
+                    "s3_bucket_name": "configured-batch-bucket",
+                },
+                "model_info": {"id": "bedrock-batch-deployment"},
+            }
+        ]
+    )
+    proxy_logging_obj = setup_proxy_logging_object(monkeypatch, router)
+    monkeypatch.setattr("litellm.proxy.proxy_server.master_key", None)
+    monkeypatch.setattr("litellm.proxy.proxy_server.prisma_client", None)
+    monkeypatch.setattr("litellm.proxy.proxy_server.llm_router", router)
+    proxy_logging_obj.update_request_status = mocker.AsyncMock()
+    proxy_logging_obj.post_call_failure_hook = mocker.AsyncMock()
+    provider_call = mocker.patch.object(
+        litellm,
+        "afile_content",
+        new=mocker.AsyncMock(
+            return_value=HttpxBinaryResponseContent(
+                response=httpx.Response(
+                    status_code=200,
+                    content=b"bedrock-bytes",
+                    headers={"content-type": "application/octet-stream"},
+                )
+            )
+        ),
+    )
+
+    app.dependency_overrides[ps.user_api_key_auth] = lambda: UserAPIKeyAuth(
+        api_key="test-key",
+        user_role=LitellmUserRoles.INTERNAL_USER,
+        user_id="test-user",
+    )
+
+    try:
+        response = client.get(
+            "/v1/files/file-abc123/content?model=bedrock-batch-deployment",
+            headers={"Authorization": "Bearer test-key"},
+        )
+    finally:
+        app.dependency_overrides.pop(ps.user_api_key_auth, None)
+
+    assert response.status_code == 200, response.text
+    assert response.content == b"bedrock-bytes"
+    provider_call.assert_awaited_once()
+    call_kwargs = provider_call.await_args.kwargs
+    credentials = call_kwargs["_litellm_internal_model_credentials"]
+    assert call_kwargs["custom_llm_provider"] == "bedrock"
+    assert credentials["s3_bucket_name"] == "configured-batch-bucket"
+    assert credentials["aws_region_name"] == "us-east-1"
+    assert credentials["model"] == "bedrock/anthropic.claude-haiku-4-5-20251001-v1:0"
+
+
 def test_get_file_content_non_openai_provider_skips_streaming_handler(
     mocker: MockerFixture, monkeypatch, llm_router: Router
 ):
@@ -2439,6 +2514,81 @@ def test_list_files_resolves_wildcard_deployment_credentials(
     assert captured_kwargs.get("api_key") == "wildcard-openai-key"
     assert captured_kwargs.get("custom_llm_provider") == "openai"
     proxy_logging_obj.post_call_failure_hook.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    ("caller_team_id", "expected_status", "expected_api_key"),
+    [
+        pytest.param("team-b", 200, "team-b-key", id="owner"),
+        pytest.param("team-a", 400, None, id="other-team"),
+        pytest.param(None, 400, None, id="teamless"),
+    ],
+)
+def test_list_files_scopes_exact_deployment_id_to_owning_team(
+    mocker: MockerFixture,
+    monkeypatch,
+    caller_team_id: str | None,
+    expected_status: int,
+    expected_api_key: str | None,
+):
+    import litellm.proxy.proxy_server as ps
+    from litellm.proxy._types import LitellmUserRoles
+
+    router = Router(
+        model_list=[
+            {
+                "model_name": "team-b-model",
+                "litellm_params": {
+                    "model": "openai/gpt-4o",
+                    "api_key": "team-b-key",
+                },
+                "model_info": {
+                    "id": "team-b-deployment",
+                    "team_id": "team-b",
+                    "team_public_model_name": "team-b-model",
+                },
+            },
+            {
+                "model_name": "*",
+                "litellm_params": {
+                    "model": "openai/*",
+                    "api_key": "shared-wildcard-key",
+                },
+            },
+        ]
+    )
+    proxy_logging_obj = setup_proxy_logging_object(monkeypatch, router)
+    monkeypatch.setattr("litellm.proxy.proxy_server.master_key", None)
+    monkeypatch.setattr("litellm.proxy.proxy_server.prisma_client", None)
+    monkeypatch.setattr("litellm.proxy.proxy_server.llm_router", router)
+    proxy_logging_obj.update_request_status = mocker.AsyncMock()
+    proxy_logging_obj.post_call_success_hook = mocker.AsyncMock(return_value=[])
+    proxy_logging_obj.post_call_failure_hook = mocker.AsyncMock()
+    provider_call = mocker.patch.object(litellm, "afile_list", new=mocker.AsyncMock(return_value=[]))
+
+    app.dependency_overrides[ps.user_api_key_auth] = lambda: UserAPIKeyAuth(
+        api_key="test-key",
+        user_role=LitellmUserRoles.INTERNAL_USER,
+        user_id="test-user",
+        team_id=caller_team_id,
+        team_models=[],
+        models=[],
+    )
+
+    try:
+        response = client.get(
+            "/v1/files?target_model_names=team-b-deployment",
+            headers={"Authorization": "Bearer test-key"},
+        )
+    finally:
+        app.dependency_overrides.pop(ps.user_api_key_auth, None)
+
+    assert response.status_code == expected_status, response.text
+    if expected_api_key is None:
+        provider_call.assert_not_awaited()
+    else:
+        provider_call.assert_awaited_once()
+        assert provider_call.await_args.kwargs["api_key"] == expected_api_key
 
 
 def test_list_files_model_routing_does_not_forward_custom_llm_provider_twice(

--- a/tests/test_litellm/test_router.py
+++ b/tests/test_litellm/test_router.py
@@ -4552,7 +4552,9 @@ def test_get_deployment_credentials_with_provider_fails_closed_for_missing_named
         ]
     )
 
-    with patch.object(litellm, "credential_list", []):
+    with patch.object(  # test-quality-ok: CredentialAccessor reads the process-global credential list
+        litellm, "credential_list", []
+    ):
         credentials = router.get_deployment_credentials_with_provider(model_id="embedding-model")
 
     assert credentials is None

--- a/tests/test_litellm/test_router.py
+++ b/tests/test_litellm/test_router.py
@@ -4739,6 +4739,37 @@ def test_get_deployment_credentials_with_provider_no_fallback_to_other_team_only
     )
 
 
+def test_get_deployment_credentials_with_provider_rejects_other_team_exact_id():
+    router = litellm.Router(
+        model_list=[
+            {
+                "model_name": "team-b-model",
+                "litellm_params": {
+                    "model": "openai/gpt-5.2",
+                    "api_key": "team-b-key",
+                },
+                "model_info": {
+                    "id": "team-b-deployment",
+                    "team_id": "team-b",
+                },
+            },
+        ],
+    )
+
+    owner_credentials = router.get_deployment_credentials_with_provider(
+        model_id="team-b-deployment", team_id="team-b"
+    )
+    assert owner_credentials is not None
+    assert owner_credentials["api_key"] == "team-b-key"
+
+    assert (
+        router.get_deployment_credentials_with_provider(
+            model_id="team-b-deployment", team_id="team-a"
+        )
+        is None
+    )
+
+
 def test_deployment_usable_by_team_helpers():
     """
     Direct coverage of the team-ownership filter: a team-scoped deployment is

--- a/tests/test_litellm/test_router.py
+++ b/tests/test_litellm/test_router.py
@@ -4560,26 +4560,6 @@ def test_get_deployment_credentials_with_provider_fails_closed_for_missing_named
     assert credentials is None
 
 
-def test_get_deployment_credentials_with_provider_preserves_project_id():
-    router = litellm.Router(
-        model_list=[
-            {
-                "model_name": "embedding-model",
-                "litellm_params": {
-                    "model": "watsonx/ibm/slate-125m-english-rtrvr",
-                    "api_key": "test-key",
-                    "project_id": "embedding-project",
-                },
-            }
-        ]
-    )
-
-    credentials = router.get_deployment_credentials_with_provider(model_id="embedding-model")
-
-    assert credentials is not None
-    assert credentials["project_id"] == "embedding-project"
-
-
 def test_get_deployment_credentials_with_provider_bedrock_batch_fields():
     """
     Test that get_deployment_credentials_with_provider returns the deployment's

--- a/tests/test_litellm/test_router.py
+++ b/tests/test_litellm/test_router.py
@@ -4801,6 +4801,10 @@ def test_get_deployment_credentials_with_provider_rejects_other_team_exact_id():
     assert owner_credentials is not None
     assert owner_credentials["api_key"] == "team-b-key"
 
+    unscoped_credentials = router.get_deployment_credentials_with_provider(model_id="team-b-deployment")
+    assert unscoped_credentials is not None
+    assert unscoped_credentials["api_key"] == "team-b-key"
+
     assert (
         router.get_deployment_credentials_with_provider(
             model_id="team-b-deployment", team_id="team-a"

--- a/tests/test_litellm/test_router.py
+++ b/tests/test_litellm/test_router.py
@@ -4520,19 +4520,34 @@ def test_get_deployment_credentials_with_provider_includes_bucket_name():
             {"other": {"api_key": "other-key"}},
             {"api_key": "inline-key"},
             {"api_key": "inline-key"},
-            id="stale-name-keeps-inline-key",
+            id="missing-inline-fallback",
+            marks=pytest.mark.xfail(
+                strict=True,
+                raises=AssertionError,
+                reason="missing named credentials discard inline auth",
+            ),
         ),
         pytest.param(
             {},
             {"aws_role_name": "deployment-role", "aws_region_name": "us-west-2"},
             {"aws_role_name": "deployment-role", "aws_region_name": "us-west-2"},
-            id="empty-worker-keeps-deployment-auth",
+            id="missing-deployment-auth-fallback",
+            marks=pytest.mark.xfail(
+                strict=True,
+                raises=AssertionError,
+                reason="missing named credentials discard deployment auth",
+            ),
         ),
         pytest.param(
             {"saved": {}},
             {},
             {},
-            id="empty-saved-credential-allows-ambient-auth",
+            id="present-empty-allows-ambient-auth",
+            marks=pytest.mark.xfail(
+                strict=True,
+                raises=AssertionError,
+                reason="empty named credentials are treated as missing",
+            ),
         ),
     ],
 )
@@ -4565,7 +4580,9 @@ def test_get_deployment_credentials_with_provider_named_credential_states(
         for name, values in credential_values_by_name.items()
     ]
 
-    with patch.object(litellm, "credential_list", credential_list):
+    with patch.object(  # test-quality-ok: CredentialAccessor reads the process-global credential list
+        litellm, "credential_list", credential_list
+    ):
         result = router.get_deployment_credentials_with_provider(model_id="configured-model")
 
     if expected_auth is None:
@@ -4800,7 +4817,19 @@ def test_get_deployment_credentials_with_provider_no_fallback_to_other_team_only
     )
 
 
-def test_get_deployment_credentials_with_provider_rejects_other_team_exact_id():
+@pytest.mark.parametrize(
+    ("team_id", "expected_api_key"),
+    [
+        pytest.param("team-b", "team-b-key", id="owner"),
+        pytest.param("team-a", None, id="foreign-team"),
+        pytest.param(None, "team-b-key", id="unscoped-compatibility"),
+        pytest.param("", None, id="empty-team-id"),
+    ],
+)
+def test_get_deployment_credentials_with_provider_scopes_exact_id(
+    team_id: str | None,
+    expected_api_key: str | None,
+) -> None:
     router = litellm.Router(
         model_list=[
             {
@@ -4817,24 +4846,24 @@ def test_get_deployment_credentials_with_provider_rejects_other_team_exact_id():
         ],
     )
 
-    owner_credentials = router.get_deployment_credentials_with_provider(
-        model_id="team-b-deployment", team_id="team-b"
-    )
-    assert owner_credentials is not None
-    assert owner_credentials["api_key"] == "team-b-key"
-
-    unscoped_credentials = router.get_deployment_credentials_with_provider(model_id="team-b-deployment")
-    assert unscoped_credentials is not None
-    assert unscoped_credentials["api_key"] == "team-b-key"
-
-    assert (
-        router.get_deployment_credentials_with_provider(
-            model_id="team-b-deployment", team_id="team-a"
-        )
-        is None
+    credentials = router.get_deployment_credentials_with_provider(
+        model_id="team-b-deployment",
+        team_id=team_id,
     )
 
+    if expected_api_key is None:
+        assert credentials is None
+        return
 
+    assert credentials is not None
+    assert credentials["api_key"] == expected_api_key
+
+
+@pytest.mark.xfail(
+    strict=True,
+    raises=AssertionError,
+    reason="a rejected exact ID falls through to shared wildcards",
+)
 def test_foreign_exact_deployment_id_is_not_reinterpreted_as_a_shared_wildcard():
     router = litellm.Router(
         model_list=[
@@ -4861,6 +4890,11 @@ def test_foreign_exact_deployment_id_is_not_reinterpreted_as_a_shared_wildcard()
     )
 
 
+@pytest.mark.xfail(
+    strict=True,
+    raises=AssertionError,
+    reason="a shared model name wins before the team's public name",
+)
 def test_team_public_model_name_beats_colliding_shared_model_name_for_owner():
     router = litellm.Router(
         model_list=[
@@ -4986,6 +5020,11 @@ def test_get_deployment_credentials_with_provider_skips_other_team_wildcard():
     assert owner_credentials["api_key"] == "team-b-key"
 
 
+@pytest.mark.xfail(
+    strict=True,
+    raises=AssertionError,
+    reason="a foreign specific wildcard shadows the shared fallback",
+)
 def test_foreign_specific_wildcard_falls_back_to_broader_shared_wildcard():
     credentials = _router_with_foreign_specific_and_shared_wildcards().get_deployment_credentials_with_provider(
         model_id="openai/gpt-5.2", team_id="team-a"
@@ -6451,6 +6490,11 @@ def test_access_group_block_via_litellm_model_branch_does_not_use_default_fallba
         )
 
 
+@pytest.mark.xfail(
+    strict=True,
+    raises=pytest.fail.Exception,
+    reason="normal routing bypasses team scope for exact deployment IDs",
+)
 def test_common_checks_rejects_foreign_exact_deployment_id_for_team():
     from litellm.proxy._types import UserAPIKeyAuth
 
@@ -6485,6 +6529,11 @@ def test_common_checks_rejects_foreign_exact_deployment_id_for_team():
         )
 
 
+@pytest.mark.xfail(
+    strict=True,
+    raises=AssertionError,
+    reason="normal routing selects a foreign specific wildcard",
+)
 def test_common_checks_skips_foreign_specific_wildcard_for_team():
     _, deployments = _router_with_foreign_specific_and_shared_wildcards()._common_checks_available_deployment(
         model="openai/gpt-5.2",

--- a/tests/test_litellm/test_router.py
+++ b/tests/test_litellm/test_router.py
@@ -4491,73 +4491,93 @@ def test_get_deployment_credentials_with_provider_includes_bucket_name():
     assert credentials["custom_llm_provider"] == "vertex_ai"
 
 
-def test_get_deployment_credentials_with_provider_resolves_credential_name():
-    """
-    Test that get_deployment_credentials_with_provider correctly resolves
-    litellm_credential_name to actual credential values (for UI-created models).
-    """
-    from litellm.types.utils import CredentialItem
-
-    # Setup credential list with a test credential
-    litellm.credential_list = [
-        CredentialItem(
-            credential_name="test-azure-cred",
-            credential_info={"custom_llm_provider": "azure"},
-            credential_values={
-                "api_key": "resolved-api-key",
-                "api_base": "https://resolved.openai.azure.com",
+@pytest.mark.parametrize(
+    ("credential_values_by_name", "deployment_auth", "expected_auth"),
+    [
+        pytest.param(
+            {
+                "saved": {
+                    "api_key": "saved-key",
+                    "api_base": "https://saved.example.com",
+                    "api_version": "2024-02-01",
+                }
+            },
+            {"api_key": "inline-key"},
+            {
+                "api_key": "saved-key",
+                "api_base": "https://saved.example.com",
                 "api_version": "2024-02-01",
             },
-        )
-    ]
+            id="saved-name-overrides-inline",
+        ),
+        pytest.param(
+            {"other": {"api_key": "other-key"}},
+            {},
+            None,
+            id="missing-name-without-fallback-fails-closed",
+        ),
+        pytest.param(
+            {"other": {"api_key": "other-key"}},
+            {"api_key": "inline-key"},
+            {"api_key": "inline-key"},
+            id="stale-name-keeps-inline-key",
+        ),
+        pytest.param(
+            {},
+            {"aws_role_name": "deployment-role", "aws_region_name": "us-west-2"},
+            {"aws_role_name": "deployment-role", "aws_region_name": "us-west-2"},
+            id="empty-worker-keeps-deployment-auth",
+        ),
+        pytest.param(
+            {"saved": {}},
+            {},
+            {},
+            id="empty-saved-credential-allows-ambient-auth",
+        ),
+    ],
+)
+def test_get_deployment_credentials_with_provider_named_credential_states(
+    credential_values_by_name: dict[str, dict[str, str]],
+    deployment_auth: dict[str, str],
+    expected_auth: dict[str, str] | None,
+) -> None:
+    from litellm.types.utils import CredentialItem
 
     router = litellm.Router(
         model_list=[
             {
-                "model_name": "azure-gpt-4",
+                "model_name": "configured-model",
                 "litellm_params": {
-                    "model": "azure/gpt-4",
-                    "litellm_credential_name": "test-azure-cred",
-                },
-            }
-        ],
-    )
-
-    credentials = router.get_deployment_credentials_with_provider(
-        model_id="azure-gpt-4"
-    )
-
-    assert credentials is not None
-    assert credentials["api_key"] == "resolved-api-key"
-    assert credentials["api_base"] == "https://resolved.openai.azure.com"
-    assert credentials["api_version"] == "2024-02-01"
-    assert credentials["custom_llm_provider"] == "azure"
-    # Ensure credential name is removed after resolution
-    assert "litellm_credential_name" not in credentials
-
-    # Cleanup
-    litellm.credential_list = []
-
-
-def test_get_deployment_credentials_with_provider_fails_closed_for_missing_named_credential():
-    router = litellm.Router(
-        model_list=[
-            {
-                "model_name": "embedding-model",
-                "litellm_params": {
-                    "model": "azure/text-embedding-3-small",
-                    "litellm_credential_name": "deleted-credential",
+                    "model": "bedrock/anthropic.claude-3-sonnet",
+                    "litellm_credential_name": "saved",
+                    "s3_bucket_name": "configured-bucket",
+                    **deployment_auth,
                 },
             }
         ]
     )
+    credential_list = [
+        CredentialItem(
+            credential_name=name,
+            credential_info={},
+            credential_values=values,
+        )
+        for name, values in credential_values_by_name.items()
+    ]
 
-    with patch.object(  # test-quality-ok: CredentialAccessor reads the process-global credential list
-        litellm, "credential_list", []
-    ):
-        credentials = router.get_deployment_credentials_with_provider(model_id="embedding-model")
+    with patch.object(litellm, "credential_list", credential_list):
+        result = router.get_deployment_credentials_with_provider(model_id="configured-model")
 
-    assert credentials is None
+    if expected_auth is None:
+        assert result is None
+        return
+
+    assert result == {
+        **expected_auth,
+        "s3_bucket_name": "configured-bucket",
+        "model": "bedrock/anthropic.claude-3-sonnet",
+        "custom_llm_provider": "bedrock",
+    }
 
 
 def test_get_deployment_credentials_with_provider_bedrock_batch_fields():
@@ -4646,6 +4666,26 @@ def _team_wildcard_model(api_key: str, model_id: str = "team-wildcard-id") -> di
             "team_public_model_name": "openai/*",
         },
     }
+
+
+def _router_with_foreign_specific_and_shared_wildcards() -> litellm.Router:
+    return litellm.Router(
+        model_list=[
+            {
+                "model_name": "openai/gpt-*",
+                "litellm_params": {"model": "openai/gpt-*", "api_key": "team-b-key"},
+                "model_info": {
+                    "id": "team-b-specific-wildcard",
+                    "team_id": "team-b",
+                    "team_public_model_name": "openai/gpt-*",
+                },
+            },
+            {
+                "model_name": "openai/*",
+                "litellm_params": {"model": "openai/*", "api_key": "shared-key"},
+            },
+        ]
+    )
 
 
 def test_get_deployment_credentials_with_provider_team_wildcard_priority():
@@ -4795,6 +4835,64 @@ def test_get_deployment_credentials_with_provider_rejects_other_team_exact_id():
     )
 
 
+def test_foreign_exact_deployment_id_is_not_reinterpreted_as_a_shared_wildcard():
+    router = litellm.Router(
+        model_list=[
+            {
+                "model_name": "team-b-model",
+                "litellm_params": {"model": "openai/gpt-5.2", "api_key": "team-b-key"},
+                "model_info": {
+                    "id": "openai/team-b-deployment",
+                    "team_id": "team-b",
+                },
+            },
+            {
+                "model_name": "openai/*",
+                "litellm_params": {"model": "openai/*", "api_key": "shared-key"},
+            },
+        ]
+    )
+
+    assert (
+        router.get_deployment_credentials_with_provider(
+            model_id="openai/team-b-deployment", team_id="team-a"
+        )
+        is None
+    )
+
+
+def test_team_public_model_name_beats_colliding_shared_model_name_for_owner():
+    router = litellm.Router(
+        model_list=[
+            {
+                "model_name": "model_name_team-a_private-id",
+                "litellm_params": {"model": "openai/gpt-5.2", "api_key": "team-a-key"},
+                "model_info": {
+                    "id": "private-id",
+                    "team_id": "team-a",
+                    "team_public_model_name": "friendly-model",
+                },
+            },
+            {
+                "model_name": "friendly-model",
+                "litellm_params": {"model": "openai/gpt-5.2", "api_key": "shared-key"},
+            },
+        ]
+    )
+
+    owner_credentials = router.get_deployment_credentials_with_provider(
+        model_id="friendly-model", team_id="team-a"
+    )
+    other_team_credentials = router.get_deployment_credentials_with_provider(
+        model_id="friendly-model", team_id="team-b"
+    )
+
+    assert owner_credentials is not None
+    assert owner_credentials["api_key"] == "team-a-key"
+    assert other_team_credentials is not None
+    assert other_team_credentials["api_key"] == "shared-key"
+
+
 def test_deployment_usable_by_team_helpers():
     """
     Direct coverage of the team-ownership filter: a team-scoped deployment is
@@ -4886,6 +4984,15 @@ def test_get_deployment_credentials_with_provider_skips_other_team_wildcard():
     )
     assert owner_credentials is not None
     assert owner_credentials["api_key"] == "team-b-key"
+
+
+def test_foreign_specific_wildcard_falls_back_to_broader_shared_wildcard():
+    credentials = _router_with_foreign_specific_and_shared_wildcards().get_deployment_credentials_with_provider(
+        model_id="openai/gpt-5.2", team_id="team-a"
+    )
+
+    assert credentials is not None
+    assert credentials["api_key"] == "shared-key"
 
 
 def test_team_wildcard_credentials_not_usable_after_delete_deployment():
@@ -6342,6 +6449,50 @@ def test_access_group_block_via_litellm_model_branch_does_not_use_default_fallba
                 }
             },
         )
+
+
+def test_common_checks_rejects_foreign_exact_deployment_id_for_team():
+    from litellm.proxy._types import UserAPIKeyAuth
+
+    router = litellm.Router(
+        model_list=[
+            {
+                "model_name": "team-b-model",
+                "litellm_params": {"model": "openai/gpt-5.2", "api_key": "team-b-key"},
+                "model_info": {
+                    "id": "team-b-deployment",
+                    "team_id": "team-b",
+                },
+            }
+        ]
+    )
+    team_a_auth = UserAPIKeyAuth(
+        api_key="team-a-key",
+        team_id="team-a",
+        models=[],
+        team_models=[],
+    )
+
+    with pytest.raises(litellm.BadRequestError):
+        router._common_checks_available_deployment(
+            model="team-b-deployment",
+            request_kwargs={
+                "metadata": {
+                    "user_api_key_team_id": "team-a",
+                    "user_api_key_auth": team_a_auth,
+                }
+            },
+        )
+
+
+def test_common_checks_skips_foreign_specific_wildcard_for_team():
+    _, deployments = _router_with_foreign_specific_and_shared_wildcards()._common_checks_available_deployment(
+        model="openai/gpt-5.2",
+        request_kwargs={"metadata": {"user_api_key_team_id": "team-a"}},
+    )
+
+    assert isinstance(deployments, list)
+    assert [deployment["litellm_params"]["api_key"] for deployment in deployments] == ["shared-key"]
 
 
 def test_try_early_resolve_deployments_for_model_not_in_names():

--- a/tests/test_litellm/test_router.py
+++ b/tests/test_litellm/test_router.py
@@ -4539,6 +4539,45 @@ def test_get_deployment_credentials_with_provider_resolves_credential_name():
     litellm.credential_list = []
 
 
+def test_get_deployment_credentials_with_provider_fails_closed_for_missing_named_credential():
+    router = litellm.Router(
+        model_list=[
+            {
+                "model_name": "embedding-model",
+                "litellm_params": {
+                    "model": "azure/text-embedding-3-small",
+                    "litellm_credential_name": "deleted-credential",
+                },
+            }
+        ]
+    )
+
+    with patch.object(litellm, "credential_list", []):
+        credentials = router.get_deployment_credentials_with_provider(model_id="embedding-model")
+
+    assert credentials is None
+
+
+def test_get_deployment_credentials_with_provider_preserves_project_id():
+    router = litellm.Router(
+        model_list=[
+            {
+                "model_name": "embedding-model",
+                "litellm_params": {
+                    "model": "watsonx/ibm/slate-125m-english-rtrvr",
+                    "api_key": "test-key",
+                    "project_id": "embedding-project",
+                },
+            }
+        ]
+    )
+
+    credentials = router.get_deployment_credentials_with_provider(model_id="embedding-model")
+
+    assert credentials is not None
+    assert credentials["project_id"] == "embedding-project"
+
+
 def test_get_deployment_credentials_with_provider_bedrock_batch_fields():
     """
     Test that get_deployment_credentials_with_provider returns the deployment's


### PR DESCRIPTION
## TLDR

Problem this investigates:

- Exact deployment IDs bypass team ownership checks in multiple routing paths
- Missing and empty named credentials can discard usable inline auth and deployment metadata
- Public files and batch paths do not consistently pass authenticated team scope into credential lookup

The narrow scoped exact-ID lookup is fixed, and the test-only contract matrix documents 16 unresolved gaps as strict xfails. Production fixes remain

## User Flow

Before: a developer using team-scoped credential lookup can receive another team's exact deployment credentials

1. They configure an exact deployment ID owned by team B
2. They resolve that ID with team A's authenticated team ID
3. The lookup returns team B's API key

After the narrow fix: the same scoped Router lookup respects authenticated team ownership

1. They configure the same exact deployment ID owned by team B
2. They resolve that ID with team A's authenticated team ID
3. The lookup returns no credentials for that deployment

The public files and batch call sites still need to propagate that scope, and rejected exact IDs must not fall through to wildcard credentials

## Relevant issues

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally
- [ ] My PR passes all required CI/CD checks
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA)

## Screenshots / Proof of Fix

The same Router credential-resolution script was run at both commits with team-owned and missing-credential deployments

### Before (4ba8517134)

#### Cross-team exact ID

1. Resolve team B's exact deployment ID with `team_id="team-a"`
2. Observe `{'api_key': 'team-b-key', 'model': 'openai/gpt-5.2', 'custom_llm_provider': 'openai'}`

#### Missing named credential

1. Resolve a deployment referencing a deleted named credential
2. Observe `{'model': 'azure/text-embedding-3-small', 'custom_llm_provider': 'azure'}`

#### Unscoped exact-ID compatibility

1. Resolve team B's exact deployment ID without `team_id`
2. Observe team B's configured credentials

### After the narrow production change (5a9ea0077b)

#### Cross-team exact ID

1. Resolve team B's exact deployment ID with `team_id="team-a"`
2. Observe `None`

#### Missing named credential

1. Resolve a deployment referencing a deleted named credential
2. Observe `None`

#### Unscoped exact-ID compatibility

1. Resolve team B's exact deployment ID without `team_id`
2. Observe team B's configured credentials unchanged

## Current test status

- 583 tests pass across the three changed suites
- 16 strict xfails document unresolved regression contracts
- 14 unrelated tests skip under the local environment

The xfails cover inline credential fallback, ambient auth, S3 metadata, endpoint team propagation, exact-ID terminal denial, team-public-name precedence, and wildcard fallback

## Type

- Bug Fix
- Test

## Caveats (if any)

### High

- Authenticated files and batch routes can resolve team-owned exact IDs without passing the caller's team scope
- Authenticated teamless callers still reach the legacy unscoped exact-ID path

### Medium

- Empty saved credentials are indistinguishable from missing credentials
- Rejected exact IDs can be reinterpreted through a shared wildcard
- Team public names can lose to colliding shared model names
- A more-specific foreign wildcard can shadow a broader shared wildcard
- Normal Router exact-ID and wildcard routing has adjacent team-scope gaps

### Low

- Credential expiration validation is outside this PR's scope

## Final Attestation

- [ ] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

