### PR TITLE
fix(proxy): compare budget window reset_at in UTC

### DIFF
--- a/litellm/proxy/common_utils/reset_budget_job.py
+++ b/litellm/proxy/common_utils/reset_budget_job.py
@@ -1215,7 +1215,12 @@ class ResetBudgetJob:
         reset_at_str: Final = window.get("reset_at")
         if not reset_at_str:
             return False
-        reset_at: Final = datetime.fromisoformat(reset_at_str.replace("Z", "+00:00")).replace(tzinfo=None)
+        parsed_reset_at: Final = datetime.fromisoformat(reset_at_str.replace("Z", "+00:00"))
+        reset_at: Final = (
+            parsed_reset_at.replace(tzinfo=timezone.utc)
+            if parsed_reset_at.tzinfo is None
+            else parsed_reset_at.astimezone(timezone.utc)
+        )
         if reset_at > now:
             return False
         new_value: Final = await ResetBudgetJob._window_carried_spend(window, counter_key, spend_counter_cache)
@@ -1259,7 +1264,7 @@ class ResetBudgetJob:
 
         from litellm.proxy.proxy_server import spend_counter_cache
 
-        now: Final = datetime.utcnow()
+        now: Final = datetime.now(timezone.utc)
         for source in _WINDOW_SOURCES:
             try:
                 await self._reset_windows_for(source=source, now=now, spend_counter_cache=spend_counter_cache)

--- a/tests/test_litellm/proxy/common_utils/test_reset_budget_job.py
+++ b/tests/test_litellm/proxy/common_utils/test_reset_budget_job.py
@@ -944,6 +944,75 @@ def test_reset_budget_windows_resets_expired_team_window(monkeypatch):
     spend_counter_cache.in_memory_cache.set_cache.assert_any_call(key="spend:team:team-expired:window:30d", value=0.0)
 
 
+def test_reset_budget_windows_resets_expired_window_with_non_utc_offset(monkeypatch):
+    """Regression: a `reset_at` serialized with a non-UTC offset (what
+    `litellm_settings.timezone: Asia/Shanghai` produces) must be compared in UTC.
+    Dropping the offset kept an already-expired window blocked for the length of
+    the offset, so the window never reset on time."""
+    shanghai = timezone(timedelta(hours=8))
+    expired = (datetime.now(shanghai) - timedelta(minutes=5)).isoformat()
+
+    key_rows = [
+        {
+            "token": "sk-shanghai-expired",
+            "budget_limits": [{"budget_duration": "24h", "reset_at": expired}],
+        }
+    ]
+    job, prisma_client, spend_counter_cache = _make_reset_budget_windows_job(
+        monkeypatch, key_rows=key_rows, team_rows=[]
+    )
+
+    asyncio.run(job.reset_budget_windows())
+
+    prisma_client.db.litellm_verificationtoken.update.assert_awaited_once()
+    spend_counter_cache.in_memory_cache.set_cache.assert_any_call(
+        key="spend:key:sk-shanghai-expired:window:24h", value=0.0
+    )
+
+
+def test_reset_budget_windows_skips_unexpired_window_with_non_utc_offset(monkeypatch):
+    """The mirror of the guard above: a `+08:00` timestamp still in the future must
+    not reset early just because its wall-clock value already trails naive UTC now."""
+    shanghai = timezone(timedelta(hours=8))
+    future = (datetime.now(shanghai) + timedelta(minutes=5)).isoformat()
+
+    key_rows = [
+        {
+            "token": "sk-shanghai-future",
+            "budget_limits": [{"budget_duration": "24h", "reset_at": future}],
+        }
+    ]
+    job, prisma_client, _ = _make_reset_budget_windows_job(monkeypatch, key_rows=key_rows, team_rows=[])
+
+    asyncio.run(job.reset_budget_windows())
+
+    prisma_client.db.litellm_verificationtoken.update.assert_not_awaited()
+
+
+def test_reset_budget_windows_keeps_window_span_at_one_duration(monkeypatch):
+    """The offset-dropping bug also widened the metered span: the window start is
+    derived as `reset_at - budget_duration`, so a reset that fires `offset` late
+    metered `24h + offset` of spend against a 24h budget, shrinking the effective
+    daily allowance. Assert the reset fires close enough to the stored `reset_at`
+    that the span stays one duration."""
+    shanghai = timezone(timedelta(hours=8))
+    reset_at = datetime.now(shanghai) - timedelta(minutes=1)
+
+    key_rows = [
+        {
+            "token": "sk-shanghai-span",
+            "budget_limits": [{"budget_duration": "24h", "reset_at": reset_at.isoformat()}],
+        }
+    ]
+    job, prisma_client, _ = _make_reset_budget_windows_job(monkeypatch, key_rows=key_rows, team_rows=[])
+
+    asyncio.run(job.reset_budget_windows())
+
+    prisma_client.db.litellm_verificationtoken.update.assert_awaited_once()
+    overshoot = datetime.now(timezone.utc) - reset_at
+    assert overshoot < timedelta(hours=1), f"reset fired {overshoot} after reset_at, widening the metered window"
+
+
 def test_reset_budget_windows_handles_string_budget_limits(monkeypatch):
     """Defensive: if `query_raw` returns `budget_limits` as a JSON-encoded
     string (driver-dependent), the code still parses and resets it.


### PR DESCRIPTION
## TLDR

Problem this solves:

- Budget windows reset one timezone offset late
- Worse, the late reset meters 24h + offset of spend
- So a 24h/$100 budget effectively allows only ~$75/day

How it solves it:

- Convert `reset_at` to UTC before comparing it
- Compare against an aware UTC now

## User Flow

Before: a team on `Asia/Shanghai` sets a $100/24h budget, and their developers get cut off before the day is over

1. The proxy admin sets `timezone: "Asia/Shanghai"` and `budget_reset_time: "00:00"`, then creates a key with a $100 budget over 24h
2. A developer sends POST https://litellm-domain/v1/messages with that key all day
3. Spend crosses $100 around 21:30 Shanghai time and the key starts returning `ExceededBudget: Key over 24h budget`
4. Midnight Shanghai passes, but the key stays blocked: the reset does not fire until 08:00 the next morning
5. When it does fire, the fresh window is already counting spend from midnight, so the day's $100 covered 32 hours instead of 24

After: the same budget resets at Shanghai midnight and covers a full 24 hours

1. Same config, same key
2. The developer sends the same requests and hits `ExceededBudget` at the same point
3. At midnight Shanghai the key starts working again
4. The new window counts from midnight, so the $100 covers exactly 24 hours

## Relevant issues

Fixes #34896
Fixes #37454

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

Ran on our production proxy, real paid traffic, 86 keys each on a 24h budget window, `timezone: "Asia/Shanghai"`

### Before (4d7144160a)

1. Every key's stored window still carried a UTC offset, so resets landed at 08:00 Shanghai instead of midnight:

```
$ psql -c "SELECT budget_limits->0->>'reset_at' reset_at, count(*) keys
           FROM \"LiteLLM_VerificationToken\"
           WHERE budget_limits IS NOT NULL GROUP BY 1;"

         reset_at          | keys
---------------------------+------
 2026-08-31T00:00:00+00:00 |   86
```

2. Shanghai midnight came and went with the windows untouched (checked at 00:42 local, reset still pending):

```
$ TZ=Asia/Shanghai date
Mon Aug 31 00:42:23 CST 2026
```

3. A key that had crossed its limit stayed blocked past local midnight:

```
$ docker logs litellm 2>&1 | grep ExceededBudget | tail -1
litellm.exceptions.BudgetExceededError: ExceededBudget: Key over 24h budget. Spend=$100.0053, Limit=$100.00
```

### After (f28186926f)

1. The reset fired and rewrote every window with the configured offset:

```
$ psql -c "SELECT budget_limits->0->>'reset_at' reset_at, count(*) keys
           FROM \"LiteLLM_VerificationToken\"
           WHERE budget_limits IS NOT NULL GROUP BY 1;"

         reset_at          | keys
---------------------------+------
 2026-09-01T00:00:00+08:00 |   86
```

2. The window now spans exactly one duration. Start is derived as `reset_at - budget_duration`:

```
window start   Shanghai 08-31 00:00
reset fires    Shanghai 09-01 00:00
span           24h
```

3. Spend for the live window lines up with that start (`Shanghai 08-31 00:00` = `UTC 08-30 16:00`), and keys under their limit keep serving:

```
$ psql -c "SELECT round(sum(spend)::numeric,2) spend
           FROM \"LiteLLM_SpendLogs\" WHERE \"startTime\" >= '2026-08-30 16:00:00'
           GROUP BY api_key ORDER BY 1 DESC LIMIT 3;"

 spend
--------
 161.40
 133.48
 120.86
```

(those three keys are on a $1000 window, so they are correctly not blocked)

## Type

🐛 Bug Fix

## Caveats (if any)

### Low

- Only `budget_limits` windows were affected
- Top-level `budget_duration` already handled the offset right

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

