### PR TITLE
fix(guardrails): carry Anthropic url image sources through to guardrails

### DIFF
--- a/litellm/llms/anthropic/chat/guardrail_translation/handler.py
+++ b/litellm/llms/anthropic/chat/guardrail_translation/handler.py
@@ -861,21 +861,9 @@ class AnthropicMessagesHandler(BaseTranslation):
     def _image_sources(block: Mapping[str, object]) -> tuple[str, ...]:
         """Normalize an Anthropic image block into strings a guardrail can read.
 
-        `source` is one of three shapes (`AnthropicMessagesImageParam.source`):
-
-            {"type": "base64", "media_type": "image/png", "data": "<b64>"}
-            {"type": "url",    "url": "https://..."}
-            {"type": "file",   "file_id": "..."}
-
-        base64 is returned as a data URI rather than the bare payload: consumers of
-        ``GenericGuardrailAPIInputs["images"]`` otherwise have no way to know the
-        format, and an API like Bedrock's ApplyGuardrail requires it. url is passed
-        through so the consumer can fetch it under its own SSRF policy.
-
-        file is not resolvable here (the bytes live behind the Files API), so it
-        yields nothing. That is a silent gap for any consumer that treats a missing
-        entry as "no image to scan"; scanning a file_id needs a fetch this extractor
-        has no client for.
+        base64 becomes a data URI so the format travels with the payload, which is what
+        the OpenAI path already puts in this field. A file source yields nothing: those
+        bytes live behind the Files API and this extractor has no client to fetch them.
         """
         source: Final = block.get("source")
         if not isinstance(source, Mapping):

--- a/litellm/llms/anthropic/chat/guardrail_translation/handler.py
+++ b/litellm/llms/anthropic/chat/guardrail_translation/handler.py
@@ -861,7 +861,7 @@ class AnthropicMessagesHandler(BaseTranslation):
     def _image_sources(block: Mapping[str, object]) -> tuple[str, ...]:
         """Normalize an Anthropic image block into strings a guardrail can read.
 
-        `source` is one of three shapes (types/llms/anthropic.py:259):
+        `source` is one of three shapes (`AnthropicMessagesImageParam.source`):
 
             {"type": "base64", "media_type": "image/png", "data": "<b64>"}
             {"type": "url",    "url": "https://..."}

--- a/litellm/llms/anthropic/chat/guardrail_translation/handler.py
+++ b/litellm/llms/anthropic/chat/guardrail_translation/handler.py
@@ -859,12 +859,40 @@ class AnthropicMessagesHandler(BaseTranslation):
 
     @staticmethod
     def _image_sources(block: Mapping[str, object]) -> tuple[str, ...]:
+        """Normalize an Anthropic image block into strings a guardrail can read.
+
+        `source` is one of three shapes (types/llms/anthropic.py:259):
+
+            {"type": "base64", "media_type": "image/png", "data": "<b64>"}
+            {"type": "url",    "url": "https://..."}
+            {"type": "file",   "file_id": "..."}
+
+        base64 is returned as a data URI rather than the bare payload: consumers of
+        ``GenericGuardrailAPIInputs["images"]`` otherwise have no way to know the
+        format, and an API like Bedrock's ApplyGuardrail requires it. url is passed
+        through so the consumer can fetch it under its own SSRF policy.
+
+        file is not resolvable here (the bytes live behind the Files API), so it
+        yields nothing. That is a silent gap for any consumer that treats a missing
+        entry as "no image to scan"; scanning a file_id needs a fetch this extractor
+        has no client for.
+        """
         source: Final = block.get("source")
         if not isinstance(source, Mapping):
             return ()
-        # Could be base64 or url
+
+        source_type: Final = source.get("type")
+        if source_type == "url":
+            url: Final = source.get("url")
+            return (url,) if isinstance(url, str) and url else ()
+
         data: Final = source.get("data")
-        return (data,) if data else ()
+        if not isinstance(data, str) or not data:
+            return ()
+        media_type: Final = source.get("media_type")
+        if isinstance(media_type, str) and media_type:
+            return (f"data:{media_type};base64,{data}",)
+        return (data,)
 
     async def _apply_guardrail_responses_to_input(
         self,

--- a/tests/test_litellm/llms/anthropic/chat/guardrail_translation/test_anthropic_guardrail_handler.py
+++ b/tests/test_litellm/llms/anthropic/chat/guardrail_translation/test_anthropic_guardrail_handler.py
@@ -1490,6 +1490,92 @@ class MockCanaryMaskingGuardrail(CustomGuardrail):
         return inputs
 
 
+class TestAnthropicMessagesImageSources:
+    """An Anthropic image block has three source shapes (types/llms/anthropic.py:259).
+
+    Only the base64 one carries "data", so reading that key alone drops url images
+    entirely -- for every guardrail consuming GenericGuardrailAPIInputs["images"],
+    not just Bedrock.
+    """
+
+    def _data(self, messages):
+        return {"model": "claude-sonnet-4-5", "messages": messages}
+
+    async def _images_seen(self, content) -> list[str]:
+        handler = AnthropicMessagesHandler()
+
+        class ImageRecordingGuardrail(MockCanaryMaskingGuardrail):
+            def __init__(self):
+                super().__init__()
+                self.seen_images: list[str] = []  # mutable-ok: accumulator for the assertion
+
+            async def apply_guardrail(self, inputs, request_data, input_type, logging_obj=None):
+                self.seen_images.extend(inputs.get("images") or [])
+                return await super().apply_guardrail(inputs, request_data, input_type, logging_obj)
+
+        guardrail = ImageRecordingGuardrail()
+        # The text block is what gets the guardrail invoked at all: a message with
+        # no text gives the handler nothing to scan, so it never reaches the
+        # guardrail and every source shape would look equally "dropped".
+        await handler.process_input_messages(
+            data=self._data([{"role": "user", "content": [{"type": "text", "text": "describe it"}, *content]}]),
+            guardrail_to_apply=guardrail,
+        )
+        return guardrail.seen_images
+
+    @pytest.mark.asyncio
+    async def test_url_source_reaches_the_guardrail(self):
+        """A url source has no "data" key, so it used to yield nothing at all."""
+        seen = await self._images_seen(
+            [{"type": "image", "source": {"type": "url", "url": "https://example.com/a.png"}}]
+        )
+
+        assert seen == ["https://example.com/a.png"]
+
+    @pytest.mark.asyncio
+    async def test_base64_source_carries_its_media_type(self):
+        """Bare base64 leaves the consumer no way to recover the format.
+
+        An API like Bedrock's ApplyGuardrail needs it to build the request, so the
+        media_type travels with the payload as a data URI.
+        """
+        seen = await self._images_seen(
+            [{"type": "image", "source": {"type": "base64", "media_type": "image/png", "data": "AAAA"}}]
+        )
+
+        assert seen == ["data:image/png;base64,AAAA"]
+
+    @pytest.mark.asyncio
+    async def test_base64_source_without_a_media_type_is_passed_through(self):
+        """There is no format to attach, so the payload goes through unchanged."""
+        seen = await self._images_seen([{"type": "image", "source": {"type": "base64", "data": "AAAA"}}])
+
+        assert seen == ["AAAA"]
+
+    @pytest.mark.asyncio
+    async def test_file_source_yields_nothing(self):
+        """The bytes live behind the Files API and this extractor has no client.
+
+        Documented as a known gap rather than silently handed on as a file_id string,
+        which a consumer would try to decode as an image.
+        """
+        seen = await self._images_seen([{"type": "image", "source": {"type": "file", "file_id": "file_abc"}}])
+
+        assert seen == []
+
+    @pytest.mark.asyncio
+    async def test_a_malformed_source_is_dropped_rather_than_passed_on(self):
+        seen = await self._images_seen(
+            [
+                {"type": "image", "source": {"type": "base64"}},
+                {"type": "image", "source": {"type": "url"}},
+                {"type": "image", "source": {"type": "base64", "data": ""}},
+            ]
+        )
+
+        assert seen == []
+
+
 class TestAnthropicMessagesToolResultScanning:
     """LIT-5251: tool_result blocks carry whatever a client's local tool fetched, so
     they are the request-path payload an indirect prompt injection actually arrives in.

--- a/tests/test_litellm/llms/anthropic/chat/guardrail_translation/test_anthropic_guardrail_handler.py
+++ b/tests/test_litellm/llms/anthropic/chat/guardrail_translation/test_anthropic_guardrail_handler.py
@@ -1491,7 +1491,7 @@ class MockCanaryMaskingGuardrail(CustomGuardrail):
 
 
 class TestAnthropicMessagesImageSources:
-    """An Anthropic image block has three source shapes (types/llms/anthropic.py:259).
+    """An Anthropic image block has three source shapes (`AnthropicMessagesImageParam.source`).
 
     Only the base64 one carries "data", so reading that key alone drops url images
     entirely -- for every guardrail consuming GenericGuardrailAPIInputs["images"],


### PR DESCRIPTION
## TLDR

Problem this solves:

- Image URLs sent to /v1/messages never reach guardrails
- Base64 images reach them stripped of their media type
- Guardrails see nothing, so they report a clean pass

How it solves it:

- Read the image source's declared type, not just its data key
- Pass a URL through as-is, and label base64 as a data URI

## User Flow

Before: a team running an image-aware guardrail on /v1/messages gets a clean verdict on images that were never looked at

1. The proxy admin turns on a guardrail that inspects images
2. A user sends POST https://litellm-domain/v1/messages with a text block plus an image block whose source is `{"type": "url", "url": "https://example.com/cat.png"}`
3. The response comes back 200 and the guardrail records a pass, having received zero images to check
4. The user sends the same picture as `{"type": "base64", "media_type": "image/png", "data": "..."}` instead
5. The guardrail receives the raw payload with no indication of what format it is, so a check that needs the format cannot run
6. Another user submitting a policy-violating picture gets it past the guardrail by sending it as a url source

After: the same guardrail actually sees both images and can act on them

1. The proxy admin turns on a guardrail that inspects images
2. A user sends POST https://litellm-domain/v1/messages with a text block plus an image block whose source is `{"type": "url", "url": "https://example.com/cat.png"}`
3. The guardrail receives the URL, inspects the picture, and blocks the request with a 400 when the picture violates its policy
4. The user sends the same picture as `{"type": "base64", "media_type": "image/png", "data": "..."}` instead
5. The guardrail receives `data:image/png;base64,...`, so the format travels with the payload and the same policy applies
6. Another user submitting a policy-violating picture as a url source now gets the 400 block instead of a clean pass

## Relevant issues

Contributes to #35332, which is fixed in full by #38175. This is the Anthropic half, split out because it stands alone

## Linear ticket

Resolves LIT-6547

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Two live proxies, each booted with 2 uvicorn workers from the exact commit under test and hitting the real Anthropic API: before at the merge base `4ba8517134` (port 36604), after at the PR tip `dc034a086a` (port 21096). Both boot logs show two `Started server process` lines. Config:

```yaml
model_list:
  - model_name: vision-test
    litellm_params:
      model: anthropic/claude-haiku-4-5
      api_key: os.environ/ANTHROPIC_API_KEY

guardrails:
  - guardrail_name: image-word-filter
    litellm_params:
      guardrail: litellm_content_filter
      mode: pre_call
      default_on: true
      image_model: vision-test
      blocked_words:
        - keyword: dog
          action: BLOCK

general_settings:
  master_key: sk-qa-lit6547
```

Started per leg with `python litellm/proxy/proxy_cli.py --config qa_config.yaml --port <port> --num_workers 2`. The picture is https://raw.githubusercontent.com/pytorch/hub/master/images/dog.jpg (a white dog), sent as a url source and as a base64 source, plus a benign control, https://raw.githubusercontent.com/EliSchwartz/imagenet-sample-images/master/n02123045_tabby.JPEG (a cat)

### Before (4ba8517134)

#### URL image source: 200, guardrail bypassed

1. Run:

```bash
curl -sS -w '\n%{http_code}\n' -X POST http://localhost:36604/v1/messages \
  -H 'Authorization: Bearer sk-qa-lit6547' -H 'Content-Type: application/json' \
  -d '{"model":"vision-test","max_tokens":64,"messages":[{"role":"user","content":[
       {"type":"text","text":"What is in this picture?"},
       {"type":"image","source":{"type":"url","url":"https://raw.githubusercontent.com/pytorch/hub/master/images/dog.jpg"}}]}]}'
```

2. Output (`msg_011CebX4GYVeAcv3inqq3Cvc`):

```
{"model": "vision-test", "id": "msg_011CebX4GYVeAcv3inqq3Cvc", "type": "message", "role": "assistant", "content": [{"type": "text", "text": "This picture shows a **white fluffy dog**, likely a **Samoyed** or similar spitz-type breed, sitting on green grass. ..."}], ...}
HTTP 200
```

3. The blocked word "dog" sailed straight through: the url-source image never reached the guardrail, which recorded a clean pass

#### Base64 image source: 400 from a transform crash, not a verdict

1. Run the same curl with `{"type":"base64","media_type":"image/jpeg","data":"<the jpeg, base64 encoded>"}` as the source
2. Output:

```
{"error":{"message":"litellm.BadRequestError: AnthropicException - Image url not in expected format. Example Expected input - \"image_url\": \"data:image/jpeg;base64,{base64_image}\". Supported formats - ['image/jpeg', 'image/png', 'image/gif', 'image/webp']. Error: list index out of range\nReceived Messages=[{'role': 'user', 'content': [{'type': 'image_url', 'image_url': {'url': '/9j/4AAQSkZJRg...
HTTP 400
```

3. The guardrail received the bare base64 with no format label, built an invalid `image_url` from it, and its vision call died in `transform_request` (the 400 body echoes the whole 880KB payload back)

#### Benign control, cat url: 200

1. Run the same curl with the tabby URL as a url source
2. Output (`msg_011CebX8zdRfDzJ4oRxMQKyK`): HTTP 200, "This picture shows a close-up portrait of a cat's face..."

### After (dc034a086a)

#### URL image source: 400, blocked

1. Run the same curl as the Before URL case against port 21096
2. Output:

```
{"error":{"message":"Content blocked: keyword 'dog' detected (Image description): # White American Eskimo Dog\n\nThis is a beautiful **American Eskimo Dog**, characterized by its striking features...","keyword":"dog","description":null,"guardrail_name":"image-word-filter","guardrail_mode":"pre_call"}}
HTTP 400
```

3. The guardrail received the URL, described the picture, and blocked the request before the provider was called

#### Base64 image source: 400, blocked

1. Run the same curl as the Before base64 case
2. Output:

```
{"error":{"message":"Content blocked: keyword 'dog' detected (Image description): # White Dog Portrait\n\nThis is a beautiful photograph of a fluffy white dog...","keyword":"dog","description":null,"guardrail_name":"image-word-filter","guardrail_mode":"pre_call"}}
HTTP 400
```

3. The same picture is caught through the base64 route too, because the format now travels with the payload

#### Benign control, cat url: 200

1. Run the same curl with the tabby URL
2. Output (`msg_011CebX47o8uxLoBvpCk1FGV`): HTTP 200, "This picture shows a close-up portrait of a **cat's face**..."
3. No over-blocking: the benign image passes on both legs

## Type

🐛 Bug Fix

## Caveats (if any)

### Medium

- A file source still yields nothing, it needs a Files API fetch
- URL images now reach consumers that fetch them, see the review thread

### Low

- Base64 images change shape from a bare payload to a data URI
- No consumer decodes that string locally, each forwards it onward

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Closes a security gap where image guardrails could pass without seeing URL-sourced images; base64 image strings may change shape for downstream guardrails, and URL images can now trigger guardrail fetches.
> 
> **Overview**
> Fixes a **guardrail bypass** on `/v1/messages` where Anthropic **URL image blocks** never appeared in `GenericGuardrailAPIInputs["images"]` because `_image_sources` only read `source.data`.
> 
> **`_image_sources`** now branches on `source.type`: **url** passes the URL through; **base64** emits a **`data:{media_type};base64,...` URI** when `media_type` is set (otherwise bare data); **file** and malformed sources are omitted so `file_id` is not mistaken for image bytes.
> 
> New **`TestAnthropicMessagesImageSources`** exercises the full `process_input_messages` path for each source shape.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dc034a086a17d349e005fc2b547ed8a6b9c2654e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


- [x] dc034a086a17d349e005fc2b547ed8a6b9c2654e passes /live-pr-risk
