### PR TITLE
fix(responses): stream guardrail block events

### DIFF
--- a/litellm/proxy/response_api_endpoints/endpoints.py
+++ b/litellm/proxy/response_api_endpoints/endpoints.py
@@ -29,7 +29,7 @@ from litellm.proxy.common_utils.http_parsing_utils import (
 )
 from litellm.responses.streaming_iterator import CachedResponsesAPIStreamingIterator
 from litellm.types.llms.openai import REASONING_EFFORT, ResponsesAPIResponse
-from litellm.types.responses.main import DeleteResponseResult
+from litellm.types.responses.main import DeleteResponseResult, GenericResponseOutputItem, OutputText
 
 if TYPE_CHECKING:
     from litellm.router import Router
@@ -51,7 +51,7 @@ _EMPTY_TOOL_PAYLOAD: Final[Mapping[str, Any]] = MappingProxyType({})
 def _blocked_responses_api_stream(
     response: ResponsesAPIResponse,
     logging_obj: object,
-    request_data: dict,
+    request_data: Mapping[str, object],
 ) -> CachedResponsesAPIStreamingIterator:
     return CachedResponsesAPIStreamingIterator(
         response=response,
@@ -429,23 +429,25 @@ async def responses_api(
         violation_text: Final = e.message
         response_id: Final = f"resp_{uuid4()}"
         output_item_id: Final = f"msg_{uuid4()}"
+        blocked_output: Final = GenericResponseOutputItem(
+            id=output_item_id,
+            type="message",
+            role="assistant",
+            status="completed",
+            content=(
+                OutputText(
+                    type="output_text",
+                    text=violation_text,
+                    annotations=[],  # mutable-ok: the OpenAI response schema requires a list
+                ),
+            ),
+        )
         response_obj: Final = ResponsesAPIResponse(
             id=response_id,
             object="response",
             created_at=int(time.time()),
             model=e.model or data.get("model"),
-            output=cast(
-                Any,
-                [
-                    {
-                        "id": output_item_id,
-                        "type": "message",
-                        "role": "assistant",
-                        "status": "completed",
-                        "content": [{"type": "output_text", "text": violation_text, "annotations": []}],
-                    }
-                ],
-            ),
+            output=[blocked_output],  # mutable-ok: ResponsesAPIResponse.output is specified as a list
             status="completed",
             usage=_blocked_responses_api_usage(e.original_response),
         )

--- a/litellm/proxy/response_api_endpoints/endpoints.py
+++ b/litellm/proxy/response_api_endpoints/endpoints.py
@@ -457,7 +457,9 @@ async def responses_api(
         if data.get("stream") is True:
             streaming_response: Final = _blocked_responses_api_stream(
                 response=response_obj,
-                logging_obj=cast(LiteLLMLoggingObj, exception_logging_obj),  # cast-ok: guardrail request data carries call logging
+                logging_obj=cast(
+                    LiteLLMLoggingObj, exception_logging_obj
+                ),  # cast-ok: guardrail request data carries call logging
                 request_data=_data,
             )
             selected_data_generator: Final = select_data_generator(

--- a/litellm/proxy/response_api_endpoints/endpoints.py
+++ b/litellm/proxy/response_api_endpoints/endpoints.py
@@ -32,7 +32,10 @@ from litellm.types.llms.openai import REASONING_EFFORT, ResponsesAPIResponse
 from litellm.types.responses.main import DeleteResponseResult, GenericResponseOutputItem, OutputText
 
 if TYPE_CHECKING:
+    from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObj
     from litellm.router import Router
+else:
+    from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObj
 
 router: Final = APIRouter()
 
@@ -50,8 +53,8 @@ _EMPTY_TOOL_PAYLOAD: Final[Mapping[str, Any]] = MappingProxyType({})
 
 def _blocked_responses_api_stream(
     response: ResponsesAPIResponse,
-    logging_obj: object,
-    request_data: Mapping[str, object],
+    logging_obj: LiteLLMLoggingObj,
+    request_data: dict[str, object],
 ) -> CachedResponsesAPIStreamingIterator:
     return CachedResponsesAPIStreamingIterator(
         response=response,
@@ -419,7 +422,7 @@ async def responses_api(
     except ModifyResponseException as e:
         # Guardrail passthrough: return violation message in Responses API format (200)
         _data: Final = e.request_data
-        _logging_obj: Final = _data.get("litellm_logging_obj")
+        exception_logging_obj: Final = _data.get("litellm_logging_obj") or proxy_logging_obj
         await proxy_logging_obj.post_call_failure_hook(
             user_api_key_dict=user_api_key_dict,
             original_exception=e,
@@ -434,19 +437,19 @@ async def responses_api(
             type="message",
             role="assistant",
             status="completed",
-            content=(
+            content=[
                 OutputText(
                     type="output_text",
                     text=violation_text,
                     annotations=[],  # mutable-ok: the OpenAI response schema requires a list
                 ),
-            ),
+            ],
         )
         response_obj: Final = ResponsesAPIResponse(
             id=response_id,
             object="response",
             created_at=int(time.time()),
-            model=e.model or data.get("model"),
+            model=e.model,
             output=[blocked_output],  # mutable-ok: ResponsesAPIResponse.output is specified as a list
             status="completed",
             usage=_blocked_responses_api_usage(e.original_response),
@@ -454,7 +457,7 @@ async def responses_api(
         if data.get("stream") is True:
             streaming_response: Final = _blocked_responses_api_stream(
                 response=response_obj,
-                logging_obj=_logging_obj,
+                logging_obj=cast(LiteLLMLoggingObj, exception_logging_obj),  # cast-ok: guardrail request data carries call logging
                 request_data=_data,
             )
             selected_data_generator: Final = select_data_generator(

--- a/litellm/proxy/response_api_endpoints/endpoints.py
+++ b/litellm/proxy/response_api_endpoints/endpoints.py
@@ -54,7 +54,7 @@ _EMPTY_TOOL_PAYLOAD: Final[Mapping[str, Any]] = MappingProxyType({})
 def _blocked_responses_api_stream(
     response: ResponsesAPIResponse,
     logging_obj: LiteLLMLoggingObj,
-    request_data: dict[str, object],
+    request_data: Mapping[str, object],
 ) -> CachedResponsesAPIStreamingIterator:
     return CachedResponsesAPIStreamingIterator(  # mutable-ok: the iterator stores advancing stream state
         response=response,

--- a/litellm/proxy/response_api_endpoints/endpoints.py
+++ b/litellm/proxy/response_api_endpoints/endpoints.py
@@ -48,6 +48,19 @@ _TOOL_PAYLOAD_KEYS: Final[Mapping[str, tuple[str, ...]]] = MappingProxyType(
 _EMPTY_TOOL_PAYLOAD: Final[Mapping[str, Any]] = MappingProxyType({})
 
 
+def _blocked_responses_api_stream(
+    response: ResponsesAPIResponse,
+    logging_obj: object,
+    request_data: dict,
+) -> CachedResponsesAPIStreamingIterator:
+    return CachedResponsesAPIStreamingIterator(
+        response=response,
+        logging_obj=logging_obj,
+        request_data=request_data,
+        call_type="aresponses",
+    )
+
+
 def _convert_tool_payload_value(key: str, value: object, *, to_chat: bool) -> object:
     if key != "format" or not isinstance(value, dict):
         return value
@@ -437,11 +450,10 @@ async def responses_api(
             usage=_blocked_responses_api_usage(e.original_response),
         )
         if data.get("stream") is True:
-            streaming_response: Final = CachedResponsesAPIStreamingIterator(
+            streaming_response: Final = _blocked_responses_api_stream(
                 response=response_obj,
                 logging_obj=_logging_obj,
                 request_data=_data,
-                call_type="aresponses",
             )
             selected_data_generator: Final = select_data_generator(
                 response=streaming_response,

--- a/litellm/proxy/response_api_endpoints/endpoints.py
+++ b/litellm/proxy/response_api_endpoints/endpoints.py
@@ -27,6 +27,7 @@ from litellm.proxy.common_utils.http_parsing_utils import (
     _read_request_body,
     _safe_set_request_parsed_body,
 )
+from litellm.responses.streaming_iterator import CachedResponsesAPIStreamingIterator
 from litellm.types.llms.openai import REASONING_EFFORT, ResponsesAPIResponse
 from litellm.types.responses.main import DeleteResponseResult
 
@@ -45,40 +46,6 @@ _TOOL_PAYLOAD_KEYS: Final[Mapping[str, tuple[str, ...]]] = MappingProxyType(
     }
 )
 _EMPTY_TOOL_PAYLOAD: Final[Mapping[str, Any]] = MappingProxyType({})
-
-
-async def _blocked_responses_api_stream(response: ResponsesAPIResponse) -> AsyncIterator[str]:
-    response_data: Final = response.model_dump(mode="json", exclude_none=True)
-    output: Final = response_data["output"][0]
-    content: Final = output["content"][0]
-    output_item_id: Final = output["id"]
-    text: Final = content["text"]
-    created_response: Final = {**response_data, "output": [], "status": "in_progress"}
-    added_item: Final = {**output, "status": "in_progress"}
-    events: Final = (
-        {"type": "response.created", "response": created_response},
-        {"type": "response.in_progress", "response": created_response},
-        {"type": "response.output_item.added", "output_index": 0, "item": added_item},
-        {
-            "type": "response.output_text.delta",
-            "item_id": output_item_id,
-            "output_index": 0,
-            "content_index": 0,
-            "delta": text,
-        },
-        {
-            "type": "response.output_text.done",
-            "item_id": output_item_id,
-            "output_index": 0,
-            "content_index": 0,
-            "text": text,
-        },
-        {"type": "response.output_item.done", "output_index": 0, "item": output},
-        {"type": "response.completed", "response": response_data},
-    )
-    for event in events:
-        yield f"data: {json.dumps(event)}\n\n"
-    yield "data: [DONE]\n\n"
 
 
 def _convert_tool_payload_value(key: str, value: object, *, to_chat: bool) -> object:
@@ -439,6 +406,7 @@ async def responses_api(
     except ModifyResponseException as e:
         # Guardrail passthrough: return violation message in Responses API format (200)
         _data: Final = e.request_data
+        _logging_obj: Final = _data.get("litellm_logging_obj")
         await proxy_logging_obj.post_call_failure_hook(
             user_api_key_dict=user_api_key_dict,
             original_exception=e,
@@ -469,7 +437,19 @@ async def responses_api(
             usage=_blocked_responses_api_usage(e.original_response),
         )
         if data.get("stream") is True:
-            return StreamingResponse(_blocked_responses_api_stream(response_obj), media_type="text/event-stream")
+            streaming_response: Final = CachedResponsesAPIStreamingIterator(
+                response=response_obj,
+                logging_obj=_logging_obj,
+                request_data=_data,
+                call_type="aresponses",
+            )
+            selected_data_generator: Final = select_data_generator(
+                response=streaming_response,
+                user_api_key_dict=user_api_key_dict,
+                request_data=_data,
+                request=request,
+            )
+            return StreamingResponse(selected_data_generator, media_type="text/event-stream")
         return response_obj
     except Exception as e:
         raise await processor._handle_llm_api_exception(

--- a/litellm/proxy/response_api_endpoints/endpoints.py
+++ b/litellm/proxy/response_api_endpoints/endpoints.py
@@ -8,6 +8,7 @@ from uuid import uuid4
 
 import fastapi
 from fastapi import APIRouter, Depends, HTTPException, Request, Response
+from fastapi.responses import StreamingResponse
 from starlette.websockets import WebSocket, WebSocketDisconnect
 
 from litellm._logging import verbose_proxy_logger
@@ -44,6 +45,40 @@ _TOOL_PAYLOAD_KEYS: Final[Mapping[str, tuple[str, ...]]] = MappingProxyType(
     }
 )
 _EMPTY_TOOL_PAYLOAD: Final[Mapping[str, Any]] = MappingProxyType({})
+
+
+async def _blocked_responses_api_stream(response: ResponsesAPIResponse) -> AsyncIterator[str]:
+    response_data: Final = response.model_dump(mode="json", exclude_none=True)
+    output: Final = response_data["output"][0]
+    content: Final = output["content"][0]
+    output_item_id: Final = output["id"]
+    text: Final = content["text"]
+    created_response: Final = {**response_data, "output": [], "status": "in_progress"}
+    added_item: Final = {**output, "status": "in_progress"}
+    events: Final = (
+        {"type": "response.created", "response": created_response},
+        {"type": "response.in_progress", "response": created_response},
+        {"type": "response.output_item.added", "output_index": 0, "item": added_item},
+        {
+            "type": "response.output_text.delta",
+            "item_id": output_item_id,
+            "output_index": 0,
+            "content_index": 0,
+            "delta": text,
+        },
+        {
+            "type": "response.output_text.done",
+            "item_id": output_item_id,
+            "output_index": 0,
+            "content_index": 0,
+            "text": text,
+        },
+        {"type": "response.output_item.done", "output_index": 0, "item": output},
+        {"type": "response.completed", "response": response_data},
+    )
+    for event in events:
+        yield f"data: {json.dumps(event)}\n\n"
+    yield "data: [DONE]\n\n"
 
 
 def _convert_tool_payload_value(key: str, value: object, *, to_chat: bool) -> object:
@@ -411,15 +446,30 @@ async def responses_api(
         )
 
         violation_text: Final = e.message
+        response_id: Final = f"resp_{uuid4()}"
+        output_item_id: Final = f"msg_{uuid4()}"
         response_obj: Final = ResponsesAPIResponse(
-            id=f"resp_{uuid4()}",
+            id=response_id,
             object="response",
             created_at=int(time.time()),
             model=e.model or data.get("model"),
-            output=cast(Any, [{"content": [{"type": "text", "text": violation_text}]}]),
+            output=cast(
+                Any,
+                [
+                    {
+                        "id": output_item_id,
+                        "type": "message",
+                        "role": "assistant",
+                        "status": "completed",
+                        "content": [{"type": "output_text", "text": violation_text, "annotations": []}],
+                    }
+                ],
+            ),
             status="completed",
             usage=_blocked_responses_api_usage(e.original_response),
         )
+        if data.get("stream") is True:
+            return StreamingResponse(_blocked_responses_api_stream(response_obj), media_type="text/event-stream")
         return response_obj
     except Exception as e:
         raise await processor._handle_llm_api_exception(

--- a/litellm/proxy/response_api_endpoints/endpoints.py
+++ b/litellm/proxy/response_api_endpoints/endpoints.py
@@ -56,7 +56,7 @@ def _blocked_responses_api_stream(
     logging_obj: LiteLLMLoggingObj,
     request_data: dict[str, object],
 ) -> CachedResponsesAPIStreamingIterator:
-    return CachedResponsesAPIStreamingIterator(
+    return CachedResponsesAPIStreamingIterator(  # mutable-ok: the iterator stores advancing stream state
         response=response,
         logging_obj=logging_obj,
         request_data=request_data,

--- a/litellm/responses/streaming_iterator.py
+++ b/litellm/responses/streaming_iterator.py
@@ -1063,7 +1063,7 @@ class CachedResponsesAPIStreamingIterator(BaseResponsesAPIStreamingIterator):
         self,
         response: ResponsesAPIResponse,
         logging_obj: LiteLLMLoggingObj,
-        request_data: dict[str, object] | None = None,
+        request_data: Mapping[str, object] | None = None,
         call_type: str | None = None,
     ):
         BaseResponsesAPIStreamingIterator.__init__(
@@ -1074,7 +1074,7 @@ class CachedResponsesAPIStreamingIterator(BaseResponsesAPIStreamingIterator):
             logging_obj=logging_obj,
             litellm_metadata=None,
             custom_llm_provider="cached_response",
-            request_data=request_data,
+            request_data=dict(request_data) if request_data is not None else None,
             call_type=call_type,
         )
         self._completed_response_cache_hit = True

--- a/tests/test_litellm/proxy/response_api_endpoints/test_endpoints.py
+++ b/tests/test_litellm/proxy/response_api_endpoints/test_endpoints.py
@@ -721,52 +721,33 @@ def _auth_override():
 
 
 @pytest.mark.asyncio
-async def test_streaming_responses_guardrail_block_returns_sse_events():
-    from litellm.integrations.custom_guardrail import ModifyResponseException
-    from litellm.proxy.auth.user_api_key_auth import user_api_key_auth
-    from litellm.proxy.common_request_processing import ProxyBaseLLMRequestProcessing
+async def test_blocked_responses_api_stream_emits_canonical_events():
+    from litellm.proxy.response_api_endpoints.endpoints import _blocked_responses_api_stream
+    from litellm.types.llms.openai import ResponsesAPIResponse
 
-    import litellm.proxy.proxy_server as ps
-
-    guardrail_exception = ModifyResponseException(
-        message="blocked by test",
+    response = ResponsesAPIResponse(
+        id="resp_test",
+        created_at=1234567890,
         model="gpt-4o",
-        request_data={"model": "gpt-4o", "stream": True, "litellm_logging_obj": MagicMock()},
+        object="response",
+        status="completed",
+        output=[
+            {
+                "id": "msg_test",
+                "type": "message",
+                "role": "assistant",
+                "status": "completed",
+                "content": [{"type": "output_text", "text": "blocked by test", "annotations": []}],
+            }
+        ],
     )
-    app.dependency_overrides[user_api_key_auth] = _auth_override
-    try:
-        with (
-            patch.object(ps, "general_settings", {}),
-            patch.object(ps, "llm_router", MagicMock()),
-            patch.object(ps, "proxy_config", MagicMock()),
-            patch.object(ps, "user_api_base", None),
-            patch.object(ps, "user_max_tokens", None),
-            patch.object(ps, "user_model", None),
-            patch.object(ps, "user_request_timeout", None),
-            patch.object(ps, "user_temperature", None),
-            patch.object(ps, "version", "1.0.0"),
-            patch.object(
-                ProxyBaseLLMRequestProcessing,
-                "base_process_llm_request",
-                new_callable=AsyncMock,
-                side_effect=guardrail_exception,
-            ),
-        ):
-            client = TestClient(app)
-            response = client.post(
-                "/v1/responses",
-                json={"model": "gpt-4o", "stream": True, "input": "hello"},
-                headers={"Authorization": "Bearer sk-test-cursor"},
-            )
-    finally:
-        app.dependency_overrides.pop(user_api_key_auth, None)
-
-    assert response.status_code == 200
-    assert response.headers["content-type"].startswith("text/event-stream")
-    frames = [line.removeprefix("data: ") for line in response.text.splitlines() if line.startswith("data: ")]
-    assert frames[-1] == "[DONE]"
-    events = [json.loads(frame) for frame in frames[:-1]]
-    event_types = [event["type"] for event in events]
+    stream = _blocked_responses_api_stream(
+        response=response,
+        logging_obj=MagicMock(),
+        request_data={"model": "gpt-4o"},
+    )
+    events = [event async for event in stream]
+    event_types = [event.type for event in events]
     assert event_types[:4] == [
         "response.created",
         "response.in_progress",
@@ -780,11 +761,11 @@ async def test_streaming_responses_guardrail_block_returns_sse_events():
         "response.completed",
     ]
     assert event_types[4:-4] == ["response.output_text.delta"] * len(event_types[4:-4])
-    assert events[0]["response"]["status"] == "in_progress"
-    assert events[0]["response"]["output"] == []
-    assert "".join(event["delta"] for event in events if event["type"] == "response.output_text.delta") == "blocked by test"
-    assert events[-1]["response"]["status"] == "completed"
-    assert events[-1]["response"]["output"][0]["content"][0]["text"] == "blocked by test"
+    assert events[0].response.status == "in_progress"
+    assert events[0].response.output == []
+    assert "".join(event.delta for event in events if event.type == "response.output_text.delta") == "blocked by test"
+    assert events[-1].response.status == "completed"
+    assert events[-1].response.output[0].content[0].text == "blocked by test"
 
 
 def test_cursor_chat_completions_messages_body_uses_chat_pipeline():

--- a/tests/test_litellm/proxy/response_api_endpoints/test_endpoints.py
+++ b/tests/test_litellm/proxy/response_api_endpoints/test_endpoints.py
@@ -720,6 +720,70 @@ def _auth_override():
     return UserAPIKeyAuth(api_key="sk-test-cursor", user_id="cursor-user")
 
 
+@pytest.mark.asyncio
+async def test_streaming_responses_guardrail_block_returns_sse_events():
+    import litellm.proxy.proxy_server as ps
+
+    from litellm.integrations.custom_guardrail import ModifyResponseException
+    from litellm.proxy.auth.user_api_key_auth import user_api_key_auth
+    from litellm.proxy.common_request_processing import ProxyBaseLLMRequestProcessing
+
+    guardrail_exception = ModifyResponseException(
+        message="blocked by test",
+        model="gpt-4o",
+        request_data={"model": "gpt-4o", "stream": True},
+    )
+    app.dependency_overrides[user_api_key_auth] = _auth_override
+    try:
+        with (
+            patch.object(ps, "general_settings", {}),
+            patch.object(ps, "llm_router", MagicMock()),
+            patch.object(ps, "proxy_config", MagicMock()),
+            patch.object(ps, "proxy_logging_obj", AsyncMock()),
+            patch.object(ps, "select_data_generator", MagicMock()),
+            patch.object(ps, "user_api_base", None),
+            patch.object(ps, "user_max_tokens", None),
+            patch.object(ps, "user_model", None),
+            patch.object(ps, "user_request_timeout", None),
+            patch.object(ps, "user_temperature", None),
+            patch.object(ps, "version", "1.0.0"),
+            patch.object(
+                ProxyBaseLLMRequestProcessing,
+                "base_process_llm_request",
+                new_callable=AsyncMock,
+                side_effect=guardrail_exception,
+            ),
+        ):
+            client = TestClient(app)
+            response = client.post(
+                "/v1/responses",
+                json={"model": "gpt-4o", "stream": True, "input": "hello"},
+                headers={"Authorization": "Bearer sk-test-cursor"},
+            )
+    finally:
+        app.dependency_overrides.pop(user_api_key_auth, None)
+
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("text/event-stream")
+    frames = [line.removeprefix("data: ") for line in response.text.splitlines() if line.startswith("data: ")]
+    assert frames[-1] == "[DONE]"
+    events = [json.loads(frame) for frame in frames[:-1]]
+    assert [event["type"] for event in events] == [
+        "response.created",
+        "response.in_progress",
+        "response.output_item.added",
+        "response.output_text.delta",
+        "response.output_text.done",
+        "response.output_item.done",
+        "response.completed",
+    ]
+    assert events[0]["response"]["status"] == "in_progress"
+    assert events[0]["response"]["output"] == []
+    assert events[3]["delta"] == "blocked by test"
+    assert events[-1]["response"]["status"] == "completed"
+    assert events[-1]["response"]["output"][0]["content"][0]["text"] == "blocked by test"
+
+
 def test_cursor_chat_completions_messages_body_uses_chat_pipeline():
     """A genuine chat-completions body (``messages`` present; what Cursor sends for
     models whose BYOK it already fixed) must run through the standard chat pipeline

--- a/tests/test_litellm/proxy/response_api_endpoints/test_endpoints.py
+++ b/tests/test_litellm/proxy/response_api_endpoints/test_endpoints.py
@@ -722,16 +722,16 @@ def _auth_override():
 
 @pytest.mark.asyncio
 async def test_streaming_responses_guardrail_block_returns_sse_events():
-    import litellm.proxy.proxy_server as ps
-
     from litellm.integrations.custom_guardrail import ModifyResponseException
     from litellm.proxy.auth.user_api_key_auth import user_api_key_auth
     from litellm.proxy.common_request_processing import ProxyBaseLLMRequestProcessing
 
+    import litellm.proxy.proxy_server as ps
+
     guardrail_exception = ModifyResponseException(
         message="blocked by test",
         model="gpt-4o",
-        request_data={"model": "gpt-4o", "stream": True},
+        request_data={"model": "gpt-4o", "stream": True, "litellm_logging_obj": MagicMock()},
     )
     app.dependency_overrides[user_api_key_auth] = _auth_override
     try:
@@ -739,8 +739,6 @@ async def test_streaming_responses_guardrail_block_returns_sse_events():
             patch.object(ps, "general_settings", {}),
             patch.object(ps, "llm_router", MagicMock()),
             patch.object(ps, "proxy_config", MagicMock()),
-            patch.object(ps, "proxy_logging_obj", AsyncMock()),
-            patch.object(ps, "select_data_generator", MagicMock()),
             patch.object(ps, "user_api_base", None),
             patch.object(ps, "user_max_tokens", None),
             patch.object(ps, "user_model", None),
@@ -768,18 +766,23 @@ async def test_streaming_responses_guardrail_block_returns_sse_events():
     frames = [line.removeprefix("data: ") for line in response.text.splitlines() if line.startswith("data: ")]
     assert frames[-1] == "[DONE]"
     events = [json.loads(frame) for frame in frames[:-1]]
-    assert [event["type"] for event in events] == [
+    event_types = [event["type"] for event in events]
+    assert event_types[:4] == [
         "response.created",
         "response.in_progress",
         "response.output_item.added",
-        "response.output_text.delta",
+        "response.content_part.added",
+    ]
+    assert event_types[-4:] == [
         "response.output_text.done",
+        "response.content_part.done",
         "response.output_item.done",
         "response.completed",
     ]
+    assert event_types[4:-4] == ["response.output_text.delta"] * len(event_types[4:-4])
     assert events[0]["response"]["status"] == "in_progress"
     assert events[0]["response"]["output"] == []
-    assert events[3]["delta"] == "blocked by test"
+    assert "".join(event["delta"] for event in events if event["type"] == "response.output_text.delta") == "blocked by test"
     assert events[-1]["response"]["status"] == "completed"
     assert events[-1]["response"]["output"][0]["content"][0]["text"] == "blocked by test"
 


### PR DESCRIPTION
## TLDR

Problem this solves:

- Blocked streaming Responses calls return a flat JSON response
- SSE clients cannot parse the guardrail message

How it solves it:

- Emits standard Responses API SSE events for blocked streams
- Keeps the existing non-streaming response unchanged

## User Flow

Before: a developer streams a Responses API request that a pre-call guardrail blocks, and their SSE client receives a JSON body instead of stream events

1. They send POST https://litellm-domain/v1/responses with `"stream": true`
2. A pre-call guardrail blocks the request with a passthrough violation message
3. The proxy returns HTTP 200 with `content-type: application/json` and one response object
4. Their SSE client cannot parse the response or display the violation message

After: the same blocked request returns a valid Responses API SSE stream

1. They send the same POST https://litellm-domain/v1/responses with `"stream": true`
2. A pre-call guardrail blocks the request with the same violation message
3. The proxy returns HTTP 200 with `content-type: text/event-stream`
4. Their client receives `response.created`, `response.in_progress`, output text, `response.completed`, and `[DONE]`

## Relevant issues


## Linear ticket


## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The focused endpoint test file passes locally
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Shared setup uses a local proxy with a mock model and a `custom_code` pre-call guardrail that returns `block("blocked for testing", {})`

### Before (4ba8517134)

1. Send POST http://127.0.0.1:4010/v1/responses with `{"model":"test-model","stream":true,"input":"hi"}`
2. Observe HTTP 200 with `content-type: application/json` and a flat `response` object containing `blocked for testing`

### After (HEAD)

1. Send the same POST http://127.0.0.1:4010/v1/responses with `{"model":"test-model","stream":true,"input":"hi"}`
2. Observe HTTP 200 with `content-type: text/event-stream`
3. Observe events in order: `response.created`, `response.in_progress`, `response.output_item.added`, `response.content_part.added`, `response.output_text.delta`, `response.output_text.done`, `response.content_part.done`, `response.output_item.done`, `response.completed`, `[DONE]`
4. Run `uv run pytest tests/test_litellm/proxy/response_api_endpoints/test_endpoints.py -q` and observe `109 passed`

## Type

🐛 Bug Fix

## Caveats (if any)

### Low

- The synthetic stream reports zero usage for pre-call blocks

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
