### PR TITLE
fix(mcp): stop an empty tool-routing cache from rejecting valid tool calls

### DIFF
--- a/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
+++ b/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
@@ -2399,13 +2399,54 @@ class MCPServerManager:
             normalize_server_name(value) for value in (*iter_known_server_prefixes(server), server.name) if value
         )
 
+    def _has_mapped_tools(self, server: MCPServer) -> bool:
+        """Whether ``tool_name_to_mcp_server_name_mapping`` holds any tool for ``server``.
+
+        Distinguishes "this server's tools are known and the name is not among them" from
+        "nothing is known about this server's tools", which the mapping alone cannot express.
+        """
+        owned: Final = self._owned_mapping_values(server)
+        return any(
+            normalize_server_name(owner) in owned for owner in self.tool_name_to_mcp_server_name_mapping.values()
+        )
+
     def _server_exposes_tool(self, server: MCPServer, tool_name: str) -> bool:
+        """Whether ``server`` is known NOT to expose ``tool_name``.
+
+        ``tool_name_to_mcp_server_name_mapping`` is a routing cache, not an inventory. It is
+        filled by a tool listing, which for a server whose credential comes from the caller
+        only happens inside an authenticated request: the startup warm-up skips
+        ``needs_user_oauth_token`` servers and swallows the upstream 401 for the rest. So on a
+        second replica, or on any replica after a restart, the mapping is empty for exactly
+        those servers and treating a miss as "no such tool" rejects calls the upstream would
+        have served.
+
+        A miss against an empty mapping is therefore inconclusive, and the upstream stays the
+        authority on its own tool list. A miss against a populated one still means the tool
+        belongs elsewhere, and a name the local tool registry already owns still belongs to the
+        legacy ``mcp_tools`` dispatch in ``execute_mcp_tool`` rather than to this server.
+        """
         owned: Final = self._owned_mapping_values(server)
         mapped_owners: Final = (
             self.tool_name_to_mcp_server_name_mapping.get(spelling)
             for spelling in iter_known_tool_name_spellings(tool_name, server)
         )
-        return any(owner is not None and normalize_server_name(owner) in owned for owner in mapped_owners)
+        if any(owner is not None and normalize_server_name(owner) in owned for owner in mapped_owners):
+            return True
+        return not self._has_mapped_tools(server) and not self._is_locally_registered_tool(tool_name)
+
+    @staticmethod
+    def _is_locally_registered_tool(tool_name: str) -> bool:
+        """Whether a bare ``mcp_tools``-style handler owns this name.
+
+        Such a tool is dispatched locally by ``execute_mcp_tool``, which only reaches that arm
+        when no server resolves, so resolving one here would route it upstream instead.
+        """
+        from litellm.proxy._experimental.mcp_server.tool_registry import (  # noqa: PLC0415
+            global_mcp_tool_registry,
+        )
+
+        return global_mcp_tool_registry.get_tool(tool_name) is not None
 
     def remove_server(self, mcp_server: LiteLLM_MCPServerTable):
         """

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server_manager.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server_manager.py
@@ -4868,10 +4868,12 @@ class TestMCPServerManager:
         resolved = manager._resolve_mcp_server_for_tool_call("zapier-alias", "create_zap")
         assert resolved is server
 
-    def test_resolve_mcp_server_for_tool_call_unknown_tool_with_empty_mapping(self):
-        """Server-name match alone must not let unknown tools through when the
-        mapping has no entries for that server (e.g. listing has not completed
-        or the server is OAuth2 and the user has not yet listed tools).
+    def test_resolve_mcp_server_for_tool_call_defers_to_upstream_with_empty_mapping(self):
+        """A mapping holding nothing for the server cannot say the tool is absent.
+
+        The mapping is filled by a tool listing, which for a server whose credential
+        comes from the caller only happens inside an authenticated request. Rejecting
+        here would refuse every call on a replica that has not served one.
         """
         manager = MCPServerManager()
         server = MCPServer(
@@ -4882,8 +4884,95 @@ class TestMCPServerManager:
         )
         manager.registry = {"srv-uuid-123": server}
 
-        with pytest.raises(ValueError, match="Tool create_zap not found"):
-            manager._resolve_mcp_server_for_tool_call("zapier-alias", "create_zap")
+        assert manager._resolve_mcp_server_for_tool_call("zapier-alias", "create_zap") is server
+
+    def test_resolve_mcp_server_for_tool_call_rejects_foreign_tool_when_mapping_is_warm(self):
+        """Once the server's tools ARE mapped, a name that is not among them is still refused.
+
+        This is the half of the guard worth keeping: the mapping is only inconclusive when
+        it is empty for the server, not when it disagrees.
+        """
+        manager = MCPServerManager()
+        server = MCPServer(
+            server_id="srv-uuid-123",
+            name="zapier",
+            alias="zapier-alias",
+            transport=MCPTransport.http,
+        )
+        manager.registry = {"srv-uuid-123": server}
+        manager.tool_name_to_mcp_server_name_mapping["create_zap"] = "zapier"
+
+        with pytest.raises(ValueError, match="Tool delete_everything not found"):
+            manager._resolve_mcp_server_for_tool_call("zapier-alias", "delete_everything")
+
+    def test_resolve_mcp_server_for_tool_call_cold_server_beside_a_warm_one(self):
+        """Another server's tools being mapped says nothing about this one.
+
+        This is the multi-replica shape: the replica that served a listing knows that
+        server's tools, and a second server listed by nobody must not inherit its silence
+        as a rejection.
+        """
+        manager = MCPServerManager()
+        warm = MCPServer(server_id="jira", name="jira", transport=MCPTransport.http)
+        cold = MCPServer(
+            server_id="srv-uuid-123",
+            name="zapier",
+            alias="zapier-alias",
+            transport=MCPTransport.http,
+        )
+        manager.registry = {"jira": warm, "srv-uuid-123": cold}
+        manager.tool_name_to_mcp_server_name_mapping["search_issues"] = "jira"
+        manager.tool_name_to_mcp_server_name_mapping["jira-search_issues"] = "jira"
+
+        assert manager._resolve_mcp_server_for_tool_call("zapier-alias", "create_zap") is cold
+
+    def test_get_mcp_server_from_tool_name_resolves_prefixed_name_on_cold_mapping(self):
+        """A registered server prefix routes on its own when nothing is mapped yet.
+
+        Without this the MCP JSON-RPC path fails too, not just REST: the prefixed lookup
+        is what ``execute_mcp_tool`` calls before any server_id is consulted.
+        """
+        manager = MCPServerManager()
+        server = MCPServer(server_id="jira", name="jira", transport=MCPTransport.http)
+        manager.registry = {"jira": server}
+
+        assert manager._get_mcp_server_from_tool_name("jira-search_issues") is server
+
+    def test_get_mcp_server_from_tool_name_leaves_locally_registered_tools_alone(self):
+        """A bare ``mcp_tools`` handler keeps its legacy local dispatch.
+
+        ``execute_mcp_tool`` only reaches that arm when no server resolves, so resolving one
+        on a cold mapping would silently route a local tool to the upstream instead.
+        """
+        from litellm.proxy._experimental.mcp_server.tool_registry import (
+            global_mcp_tool_registry,
+        )
+
+        manager = MCPServerManager()
+        server = MCPServer(server_id="petstore", name="petstore", transport=MCPTransport.http)
+        manager.registry = {"petstore": server}
+        global_mcp_tool_registry.register_tool(
+            name="dump_pets",
+            description="bare tool from the mcp_tools config block",
+            input_schema={"type": "object", "properties": {}},
+            handler=lambda **kwargs: "ran locally",
+        )
+        try:
+            assert manager._get_mcp_server_from_tool_name("petstore-dump_pets") is None
+            # A name the local registry does not own still resolves on the same cold mapping.
+            assert manager._get_mcp_server_from_tool_name("petstore-list_pets") is server
+        finally:
+            global_mcp_tool_registry.tools.pop("dump_pets", None)
+
+    def test_get_mcp_server_from_tool_name_rejects_prefixed_name_when_mapping_is_warm(self):
+        """The prefixed path keeps the same guard: a populated mapping still decides."""
+        manager = MCPServerManager()
+        server = MCPServer(server_id="jira", name="jira", transport=MCPTransport.http)
+        manager.registry = {"jira": server}
+        manager.tool_name_to_mcp_server_name_mapping["search_issues"] = "jira"
+        manager.tool_name_to_mcp_server_name_mapping["jira-search_issues"] = "jira"
+
+        assert manager._get_mcp_server_from_tool_name("jira-delete_everything") is None
 
     def test_resolve_mcp_server_for_tool_call_fallback_to_unprefixed_lookup(self):
         """Fallback to unprefixed _get_mcp_server_from_tool_name when other paths fail."""


### PR DESCRIPTION
## TLDR

Problem this solves:

- MCP tool calls fail with "Tool <name> not found"
- Happens whenever a replica has not listed that server
- Hits every server whose credential comes from the caller
- More than one replica makes it a coin flip

How it solves it:

- The tool-name mapping is a cache, not an inventory
- An empty cache no longer counts as "no such tool"
- A populated one still rejects tools belonging elsewhere
- Locally registered `mcp_tools` handlers keep their legacy dispatch

## User Flow

Before: a developer whose key can reach an `oauth_delegate` MCP server can list its tools but cannot call any of them

1. They authorize the server, then GET https://litellm-domain/mcp-rest/tools/list?server_id=their_server and get the full tool list back
2. They POST https://litellm-domain/mcp-rest/tools/call with `{"server_id": "their_server", "name": "search_threads", "arguments": {...}}`
3. The response is 500 with `An unexpected error occurred: Tool search_threads not found`, naming a tool the previous step just advertised
4. Retrying sometimes works and sometimes does not, because the two requests land on different instances behind the load balancer
5. After any restart or rollout it fails again for everyone until each person re-lists

After: the same call reaches the server and returns its result

1. They authorize the server, then GET https://litellm-domain/mcp-rest/tools/list?server_id=their_server and get the full tool list back
2. They POST https://litellm-domain/mcp-rest/tools/call with `{"server_id": "their_server", "name": "search_threads", "arguments": {...}}`
3. The response is 200 carrying the tool's own output
4. The result no longer depends on which instance answered, or on whether this one has served a listing
5. A name the server does not have still fails, now with that server's own "Unknown tool" message rather than a local one

## Relevant issues

Same mapping as #24089, reached by a different trigger.

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally
- [x] My PR passes all required CI/CD checks
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

Shared setup. A config with one HTTP MCP server, deliberately started while that server is unreachable so the boot-time warm-up cannot fill the mapping, which is the same state a second replica or a fresh pod is in:

```yaml
model_list: []
mcp_servers:
  slackfixture:
    transport: "http"
    url: "http://127.0.0.1:9030/mcp"
    auth_type: "bearer_token"
    auth_value: "utok_..."
general_settings:
  master_key: sk-1234
  store_model_in_db: false
```

```
Failed to get tools from server slackfixture during tool name mapping initialization
```

The upstream is then brought up, so every request below reaches a real MCP server over the network. Nothing is mocked.

### Before (4ba8517134)

#### case 1: a real tool, routing cache cold

1. `curl -s -X POST http://127.0.0.1:4000/mcp-rest/tools/call -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" -d '{"server_id":"slackfixture","name":"search_threads","arguments":{"query":"hello"}}'`
2. `{"detail":{"error":"internal_server_error","message":"An unexpected error occurred: Tool search_threads not found"}}`

#### case 2: a tool that does not exist, routing cache cold

1. `curl -s -X POST http://127.0.0.1:4000/mcp-rest/tools/call -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" -d '{"server_id":"slackfixture","name":"delete_everything","arguments":{}}'`
2. `{"detail":{"error":"internal_server_error","message":"An unexpected error occurred: Tool delete_everything not found"}}`

#### case 3: a tool that does not exist, routing cache warm

1. `curl -s "http://127.0.0.1:4000/mcp-rest/tools/list?server_id=slackfixture" -H "Authorization: Bearer sk-1234"` lists `['search_threads', 'get_thread']`
2. `curl -s -X POST http://127.0.0.1:4000/mcp-rest/tools/call -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" -d '{"server_id":"slackfixture","name":"delete_everything","arguments":{}}'`
3. `{"detail":{"error":"internal_server_error","message":"An unexpected error occurred: Tool delete_everything not found"}}`

### After (976063a1a9)

#### case 1: a real tool, routing cache cold

1. `curl -s -X POST http://127.0.0.1:4000/mcp-rest/tools/call -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" -d '{"server_id":"slackfixture","name":"search_threads","arguments":{"query":"hello"}}'`
2. `{"_meta":null,"content":[{"type":"text","text":"[repro-user] 2 results for 'hello'","annotations":null,"_meta":null}],"structuredContent":{"result":"[repro-user] 2 results for 'hello'"},"isError":false}`

#### case 2: a tool that does not exist, routing cache cold

1. `curl -s -X POST http://127.0.0.1:4000/mcp-rest/tools/call -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" -d '{"server_id":"slackfixture","name":"delete_everything","arguments":{}}'`
2. `{"_meta":null,"content":[{"type":"text","text":"Unknown tool: delete_everything","annotations":null,"_meta":null}],"structuredContent":null,"isError":true}` — the server itself refuses it, so nothing is falsely accepted

#### case 3: a tool that does not exist, routing cache warm

1. `curl -s "http://127.0.0.1:4000/mcp-rest/tools/list?server_id=slackfixture" -H "Authorization: Bearer sk-1234"` lists `['search_threads', 'get_thread']`
2. `curl -s -X POST http://127.0.0.1:4000/mcp-rest/tools/call -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" -d '{"server_id":"slackfixture","name":"delete_everything","arguments":{}}'`
3. `{"detail":{"error":"internal_server_error","message":"An unexpected error occurred: Tool delete_everything not found"}}` — unchanged, the guard still decides when the mapping can actually tell

## Type

🐛 Bug Fix

## Changes

`tool_name_to_mcp_server_name_mapping` is filled by `_create_prefixed_tools`, which only runs during a tool listing. `_initialize_tool_name_to_mcp_server_name_mapping` cannot fill it for a server whose credential comes from the caller: it skips `needs_user_oauth_token` servers outright and swallows `MCPUpstreamAuthError` for the rest, both correctly, because at startup there is no caller. So for those servers the mapping is empty on any instance that has not served an authenticated listing.

`_server_exposes_tool` treated a miss in that mapping as proof the tool does not exist, and both routing paths consulted it: `_get_mcp_server_from_tool_name` for prefixed names, which is what the MCP JSON-RPC path uses, and `_resolve_mcp_server_for_tool_call` for a caller-supplied server name, which is what the REST path uses. A miss therefore refused the call locally even though the server would have served it.

A miss now only decides when the mapping holds something for that server. `_has_mapped_tools` draws that line. Two things are deliberately left alone:

- A populated mapping still rejects a tool that belongs to another server, which is the half of the guard that can actually tell.
- A name the local tool registry owns still resolves to no server, so a bare `mcp_tools` handler keeps the legacy dispatch in `execute_mcp_tool`, which is only reached when nothing resolves. Without this, such a tool would silently route upstream instead.

Authorization is untouched. `allowed_tools` / `disallowed_tools` and the key/team/org tool ceilings are enforced in `call_tool` through `check_allowed_or_banned_tools` and `check_tool_permission_for_key_team`, and the mapping is populated before any of that filtering, so it never was an allowlist.

`test_resolve_mcp_server_for_tool_call_unknown_tool_with_empty_mapping` asserted the old behaviour, including in its docstring ("the server is OAuth2 and the user has not yet listed tools"), so it is rewritten rather than kept. Five tests replace and extend it, pinning the change from both directions: reverting the fix fails three of them, removing the guard entirely fails the other two plus two that already existed.

## Caveats (if any)

### Medium

- A wrong tool name now costs a round trip to the server
- Only when that server has no mapped tools yet

### Low

- `_has_mapped_tools` scans the mapping values
- Short-circuits on the first hit, so warm servers are cheap
