### PR TITLE
feat: add ai& (aiand) provider

### DIFF
--- a/litellm/constants.py
+++ b/litellm/constants.py
@@ -786,6 +786,7 @@ openai_compatible_endpoints: Final[list] = [
     "https://api-inference.modelscope.cn/v1",
     "https://api.moonshot.ai/v1",
     "https://api.publicai.co/v1",
+    "https://api.aiand.com/v1",
     "https://api.synthetic.new/openai/v1",
     "https://serverless.tensormesh.ai/v1",
     "https://api.stima.tech/v1",
@@ -843,6 +844,7 @@ openai_compatible_providers: Final[list] = [
     "novita",
     "meta_llama",
     "publicai",  # PublicAI - JSON-configured provider
+    "aiand",  # ai& - JSON-configured provider
     "synthetic",  # Synthetic - JSON-configured provider
     "tensormesh",  # Tensormesh - JSON-configured provider
     "apertis",  # Apertis - JSON-configured provider

--- a/litellm/llms/openai_like/providers.json
+++ b/litellm/llms/openai_like/providers.json
@@ -107,6 +107,12 @@
     "api_key_env": "AIHUBMIX_API_KEY",
     "api_base_env": "AIHUBMIX_API_BASE"
   },
+  "aiand": {
+    "base_url": "https://api.aiand.com/v1",
+    "api_key_env": "AIAND_API_KEY",
+    "api_base_env": "AIAND_API_BASE",
+    "supported_endpoints": ["/v1/chat/completions", "/v1/responses"]
+  },
   "crusoe": {
     "base_url": "https://managed-inference-api-proxy.crusoecloud.com/v1",
     "api_key_env": "CRUSOE_API_KEY",

--- a/litellm/provider_endpoints_support_backup.json
+++ b/litellm/provider_endpoints_support_backup.json
@@ -120,6 +120,23 @@
         "interactions": true
       }
     },
+    "aiand": {
+      "display_name": "ai& (`aiand`)",
+      "url": "https://docs.aiand.com/api/chat-completions/",
+      "endpoints": {
+        "chat_completions": true,
+        "messages": false,
+        "responses": true,
+        "embeddings": false,
+        "image_generations": false,
+        "audio_transcriptions": false,
+        "audio_speech": false,
+        "moderations": false,
+        "batches": false,
+        "rerank": false,
+        "a2a": false
+      }
+    },
     "amazon_nova": {
       "display_name": "Amazon Nova (`amazon_nova`)",
       "url": "https://docs.litellm.ai/docs/providers/amazon_nova",

--- a/litellm/proxy/public_endpoints/provider_create_fields.json
+++ b/litellm/proxy/public_endpoints/provider_create_fields.json
@@ -1,5 +1,33 @@
 [
   {
+    "provider": "AIAND",
+    "provider_display_name": "ai&",
+    "litellm_provider": "aiand",
+    "credential_fields": [
+      {
+        "key": "api_base",
+        "label": "API Base",
+        "placeholder": "https://api.aiand.com/v1",
+        "tooltip": null,
+        "required": false,
+        "field_type": "text",
+        "options": null,
+        "default_value": null
+      },
+      {
+        "key": "api_key",
+        "label": "API Key",
+        "placeholder": null,
+        "tooltip": null,
+        "required": true,
+        "field_type": "password",
+        "options": null,
+        "default_value": null
+      }
+    ],
+    "default_model_placeholder": "aiand/openai/gpt-oss-120b"
+  },
+  {
     "provider": "AIML",
     "provider_display_name": "AI/ML API",
     "litellm_provider": "aiml",

--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -3840,6 +3840,7 @@ class LlmProviders(str, Enum):
     POE = "poe"
     CHUTES = "chutes"
     NEOSANTARA = "neosantara"
+    AIAND = "aiand"
     PARASAIL = "parasail"
     XIAOMI_MIMO = "xiaomi_mimo"
     TENSORMESH = "tensormesh"

--- a/provider_endpoints_support.json
+++ b/provider_endpoints_support.json
@@ -120,6 +120,23 @@
         "interactions": true
       }
     },
+    "aiand": {
+      "display_name": "ai& (`aiand`)",
+      "url": "https://docs.aiand.com/api/chat-completions/",
+      "endpoints": {
+        "chat_completions": true,
+        "messages": false,
+        "responses": true,
+        "embeddings": false,
+        "image_generations": false,
+        "audio_transcriptions": false,
+        "audio_speech": false,
+        "moderations": false,
+        "batches": false,
+        "rerank": false,
+        "a2a": false
+      }
+    },
     "amazon_nova": {
       "display_name": "Amazon Nova (`amazon_nova`)",
       "url": "https://docs.litellm.ai/docs/providers/amazon_nova",

--- a/tests/test_litellm/llms/openai_like/test_aiand_provider.py
+++ b/tests/test_litellm/llms/openai_like/test_aiand_provider.py
@@ -1,8 +1,11 @@
+import json
+
+import httpx
 import pytest
+import respx
 
 import litellm
 from litellm.litellm_core_utils.get_llm_provider_logic import get_llm_provider
-from litellm.llms.openai_like.dynamic_config import create_config_class
 from litellm.llms.openai_like.json_loader import JSONProviderRegistry
 from litellm.utils import ProviderConfigManager
 
@@ -26,17 +29,47 @@ def test_aiand_chat_provider(monkeypatch: pytest.MonkeyPatch):
     assert api_key == "test-key"
     assert api_base == AIAND_API_BASE
 
-    config = create_config_class(provider_config)()
-    assert (
-        config.get_complete_url(
-            api_base=None,
-            api_key=None,
-            model=model,
-            optional_params={},
-            litellm_params={},
+
+
+def test_aiand_completion_request(respx_mock: respx.MockRouter):
+    messages = [{"role": "user", "content": "Hello"}]
+    route = respx_mock.post(f"{AIAND_API_BASE}/chat/completions").mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "id": "chatcmpl-test",
+                "object": "chat.completion",
+                "created": 1,
+                "model": "openai/gpt-oss-120b",
+                "choices": [
+                    {
+                        "index": 0,
+                        "message": {"role": "assistant", "content": "Hello"},
+                        "finish_reason": "stop",
+                    }
+                ],
+                "usage": {
+                    "prompt_tokens": 1,
+                    "completion_tokens": 1,
+                    "total_tokens": 2,
+                },
+            },
         )
-        == f"{AIAND_API_BASE}/chat/completions"
     )
+
+    litellm.completion(
+        model="aiand/openai/gpt-oss-120b",
+        api_key="test-key",
+        messages=messages,
+    )
+
+    assert route.called
+    request = route.calls.last.request
+    assert str(request.url) == f"{AIAND_API_BASE}/chat/completions"
+    assert request.headers["Authorization"] == "Bearer test-key"
+    request_body = json.loads(request.read())
+    assert request_body["model"] == "openai/gpt-oss-120b"
+    assert request_body["messages"] == messages
 
 
 def test_aiand_responses_provider():

--- a/tests/test_litellm/llms/openai_like/test_aiand_provider.py
+++ b/tests/test_litellm/llms/openai_like/test_aiand_provider.py
@@ -1,0 +1,50 @@
+import pytest
+
+import litellm
+from litellm.litellm_core_utils.get_llm_provider_logic import get_llm_provider
+from litellm.llms.openai_like.dynamic_config import create_config_class
+from litellm.llms.openai_like.json_loader import JSONProviderRegistry
+from litellm.utils import ProviderConfigManager
+
+AIAND_API_BASE = "https://api.aiand.com/v1"
+
+
+def test_aiand_chat_provider(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("AIAND_API_KEY", "test-key")
+
+    provider_config = JSONProviderRegistry.get("aiand")
+    assert provider_config is not None
+    assert litellm.LlmProviders.AIAND.value == "aiand"
+    assert "aiand" in litellm.openai_compatible_providers
+    assert provider_config.base_url == AIAND_API_BASE
+    assert provider_config.api_key_env == "AIAND_API_KEY"
+    assert provider_config.api_base_env == "AIAND_API_BASE"
+
+    model, provider, api_key, api_base = get_llm_provider("aiand/openai/gpt-oss-120b")
+    assert model == "openai/gpt-oss-120b"
+    assert provider == "aiand"
+    assert api_key == "test-key"
+    assert api_base == AIAND_API_BASE
+
+    config = create_config_class(provider_config)()
+    assert (
+        config.get_complete_url(
+            api_base=None,
+            api_key=None,
+            model=model,
+            optional_params={},
+            litellm_params={},
+        )
+        == f"{AIAND_API_BASE}/chat/completions"
+    )
+
+
+def test_aiand_responses_provider():
+    config = ProviderConfigManager.get_provider_responses_api_config(
+        provider="aiand",
+        model="aiand/openai/gpt-oss-120b",
+    )
+
+    assert config is not None
+    assert config.custom_llm_provider == "aiand"
+    assert config.get_complete_url(api_base=None, litellm_params={}) == f"{AIAND_API_BASE}/responses"


### PR DESCRIPTION
## TLDR

Problem this solves:

- ai& is not available as a first-class LiteLLM provider
- Users cannot select ai& from the Add Model form

How it solves it:

- Adds the `aiand/<model>` provider route
- Adds ai& to the Add Model form
- Supports Chat Completions and Responses API requests

## User Flow

Before: an admin cannot configure ai& directly in LiteLLM

1. They open `http://localhost:4000/ui/?page=models`
2. They click **Add Model** and search for `ai&`
3. ai& does not appear as a provider option

After: an admin can configure any supported ai& model

1. They open `http://localhost:4000/ui/?page=models`
2. They click **Add Model** and select `ai&`
3. They enter their API key and an ai& model ID
4. LiteLLM routes requests using the `aiand/<model>` format

For example, `aiand/openai/gpt-oss-120b` routes requests to the `openai/gpt-oss-120b` model available through ai&

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] `uv run pytest tests/test_litellm/llms/openai_like/test_aiand_provider.py -q` passes locally
- [x] My PR passes all required CI/CD checks
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

### Setup

The proxy was started with:

```bash
python litellm/proxy/proxy_cli.py \
  --config litellm/proxy/dev_config.yaml \
  --detailed_debug \
  --reload
```

`AIAND_API_KEY` and `LITELLM_MASTER_KEY` were set in the environment

The API checks used `aiand/openai/gpt-oss-120b`. The Admin UI check used `aiand/zai-org/glm-5.3` to confirm that the provider is not limited to one model

### Verified at cb1bb59d02

#### Chat Completions

Request:

```bash
curl http://localhost:4000/v1/chat/completions \
  -H "Content-Type: application/json" \
  -H "Authorization: Bearer $LITELLM_MASTER_KEY" \
  -d '{
    "model": "aiand-gpt-oss-120b",
    "messages": [
      {
        "role": "user",
        "content": "Say hello in exactly 3 words"
      }
    ]
  }'
```

Relevant response fields:

```json
{
  "model": "aiand-gpt-oss-120b",
  "object": "chat.completion",
  "choices": [
    {
      "finish_reason": "stop",
      "message": {
        "content": "Hello there, friend",
        "role": "assistant"
      }
    }
  ],
  "usage": {
    "completion_tokens": 143,
    "prompt_tokens": 74,
    "total_tokens": 217
  }
}
```

#### Responses API

Request:

```bash
curl http://localhost:4000/v1/responses \
  -H "Content-Type: application/json" \
  -H "Authorization: Bearer $LITELLM_MASTER_KEY" \
  -d '{
    "model": "aiand-gpt-oss-120b",
    "input": "Say hello in exactly 3 words"
  }'
```

Relevant response fields:

```json
{
  "object": "response",
  "model": "aiand-gpt-oss-120b",
  "status": "completed",
  "output": [
    {
      "type": "message",
      "role": "assistant",
      "content": [
        {
          "type": "output_text",
          "text": "Hello there friend"
        }
      ]
    }
  ]
}
```

#### Admin UI

1. Opened `http://localhost:4000/ui/?page=models`
2. Confirmed that ai& appears as a selectable provider
3. Configured `aiand/zai-org/glm-5.3` as another representative ai& model
4. Confirmed the default API Base and API Key fields
5. Sent a successful Chat Completions request from the playground

<img width="1216" height="266" alt="ai& in the provider selection list" src="https://github.com/user-attachments/assets/05cd78a8-f057-4f86-ba4e-486f1d3072a6" />

<img width="1242" height="564" alt="ai& provider configuration" src="https://github.com/user-attachments/assets/100aeb77-845b-44de-a0ec-81903776059b" />

<img width="1301" height="617" alt="Successful ai& Chat Completions request" src="https://github.com/user-attachments/assets/f3101df4-4730-4f3a-adba-77ef99efcdfd" />

## Type

🆕 New Feature  
✅ Test

## Caveats (if any)

### Medium

- Provider-specific pricing metadata is not included

### Low

- ai& model IDs must currently be entered manually

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR