### PR TITLE
fix: add reasoning_items to unsupported_delta_fields to preserve streaming chunks

### DIFF
--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -8268,6 +8268,7 @@ def _fast_serialize_simple_model_response_stream(
         "thinking_blocks",
         "provider_specific_fields",
         "refusal",
+        "reasoning_items",
     )
     if any(getattr(delta, field, None) is not None for field in unsupported_delta_fields):
         return None


### PR DESCRIPTION
﻿## Summary

Fixes #38907

The `_fast_serialize_simple_model_response_stream` function in proxy_server.py checks `unsupported_delta_fields` to decide whether a streaming chunk can be fast-serialized (only role + content) or needs full `model_dump_json`. However, `reasoning_items` was missing from that tuple.

A chunk with `delta.content=''` and `delta.reasoning_items=[...]` (e.g. the Responses-to-chat bridge's `response.completed` chunk) was classified as simple text, serialized as just `{content: ''}`, and the encrypted reasoning items were silently dropped. This breaks multi-turn tool loops that rely on reasoning state round-tripping through the proxy.

## Change

**`litellm/proxy/proxy_server.py`** — 1 line added to `unsupported_delta_fields`:

Added `reasoning_items` to the tuple so chunks carrying this field fall through to the full `model_dump_json` serialization path which preserves it correctly.

## How to verify

Construct a `ModelResponseStream` with `delta.content=''` and `delta.reasoning_items=[{...}]` and confirm `_serialize_streaming_chunk` no longer drops the items (as described in the issue reproduction steps).
