### PR TITLE
fix(router): keep order fallback on the requested order level

### DIFF
--- a/litellm/router.py
+++ b/litellm/router.py
@@ -2174,6 +2174,7 @@ class Router:
                 "client": model_client,
                 **kwargs,
             }
+            input_kwargs.pop("_target_order", None)
             response: Final = litellm.completion(**input_kwargs)
             verbose_router_logger.info("litellm.completion(model=%s)\x1b[32m 200 OK\x1b[0m", model_name)
 
@@ -3197,6 +3198,7 @@ class Router:
             }
             input_kwargs.pop("silent_model", None)
             input_kwargs.pop("include_fallback_errors", None)
+            input_kwargs.pop("_target_order", None)
 
             _response: Final = litellm.acompletion(**input_kwargs)
 
@@ -11928,7 +11930,7 @@ class Router:
         )
 
         ## ORDER FILTERING ## -> if user set 'order' in deployments, return deployments with lowest order (e.g. order=1 > order=2)
-        _target_order: Final = (request_kwargs or {}).pop("_target_order", None)
+        _target_order: Final = (request_kwargs or {}).get("_target_order")
         healthy_deployments = litellm.utils._get_order_filtered_deployments(
             cast(list[dict], healthy_deployments), target_order=_target_order
         )
@@ -12693,7 +12695,7 @@ class Router:
             )
 
         ## ORDER FILTERING ## -> if user set 'order' in deployments, return deployments with lowest order (e.g. order=1 > order=2)
-        _target_order: Final = (request_kwargs or {}).pop("_target_order", None)
+        _target_order: Final = (request_kwargs or {}).get("_target_order")
         healthy_deployments = litellm.utils._get_order_filtered_deployments(
             healthy_deployments, target_order=_target_order
         )

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -2172,8 +2172,9 @@ class Router:
                 "messages": messages,
                 "caching": self.cache_responses,
                 "client": model_client,
-                **{k: v for k, v in kwargs.items() if k != "_target_order"},
+                **kwargs,
             }
+            input_kwargs.pop("_target_order", None)
             response: Final = litellm.completion(**input_kwargs)
             verbose_router_logger.info("litellm.completion(model=%s)\x1b[32m 200 OK\x1b[0m", model_name)
 
@@ -3193,8 +3194,9 @@ class Router:
                 "messages": messages,
                 "caching": self.cache_responses,
                 "client": model_client,
-                **{k: v for k, v in kwargs.items() if k != "_target_order"},
+                **kwargs,
             }
+            input_kwargs.pop("_target_order", None)
             input_kwargs.pop("silent_model", None)
             input_kwargs.pop("include_fallback_errors", None)
 

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -558,11 +558,6 @@ RETRY_BREADCRUMB_EXCLUDED_KWARGS: Final = frozenset(
 )
 
 
-def _without_target_order(kwargs: Mapping[str, object]) -> Mapping[str, object]:
-    """Drop the router-internal order-fallback target so it never reaches a provider call."""
-    return MappingProxyType({k: v for k, v in kwargs.items() if k != "_target_order"})
-
-
 class Router:
     model_names: set = set()
     cache_responses: bool | None = False
@@ -2177,7 +2172,7 @@ class Router:
                 "messages": messages,
                 "caching": self.cache_responses,
                 "client": model_client,
-                **_without_target_order(kwargs),
+                **kwargs,
             }
             response: Final = litellm.completion(**input_kwargs)
             verbose_router_logger.info("litellm.completion(model=%s)\x1b[32m 200 OK\x1b[0m", model_name)
@@ -3198,7 +3193,7 @@ class Router:
                 "messages": messages,
                 "caching": self.cache_responses,
                 "client": model_client,
-                **_without_target_order(kwargs),
+                **kwargs,
             }
             input_kwargs.pop("silent_model", None)
             input_kwargs.pop("include_fallback_errors", None)
@@ -4075,7 +4070,7 @@ class Router:
                     "prompt": prompt,
                     "caching": self.cache_responses,
                     "client": model_client,
-                    **_without_target_order(kwargs),
+                    **kwargs,
                 }
             )
             self.success_calls[model_name] += 1
@@ -4135,7 +4130,7 @@ class Router:
                     "prompt": prompt,
                     "caching": self.cache_responses,
                     "client": model_client,
-                    **_without_target_order(kwargs),
+                    **kwargs,
                 }
             )
 
@@ -4239,7 +4234,7 @@ class Router:
                     "file": file,
                     "caching": self.cache_responses,
                     "client": model_client,
-                    **_without_target_order(kwargs),
+                    **kwargs,
                 }
             )
 
@@ -4892,7 +4887,7 @@ class Router:
             response_kwargs: Final = {
                 **data,
                 "caching": self.cache_responses,
-                **_without_target_order(kwargs),
+                **kwargs,
                 "model": model_name,
             }
             # Only set custom_llm_provider if it's not None
@@ -5342,7 +5337,7 @@ class Router:
                     **data,
                     "custom_llm_provider": custom_llm_provider,
                     "caching": self.cache_responses,
-                    **_without_target_order(kwargs),
+                    **kwargs,
                 }
             )
 
@@ -5408,7 +5403,7 @@ class Router:
                     "input": input,
                     "caching": self.cache_responses,
                     "client": model_client,
-                    **_without_target_order(kwargs),
+                    **kwargs,
                 }
             )
             self.success_calls[model_name] += 1
@@ -5471,7 +5466,7 @@ class Router:
                     "input": input,
                     "caching": self.cache_responses,
                     "client": model_client,
-                    **_without_target_order(kwargs),
+                    **kwargs,
                 }
             )
 
@@ -11933,7 +11928,7 @@ class Router:
         )
 
         ## ORDER FILTERING ## -> if user set 'order' in deployments, return deployments with lowest order (e.g. order=1 > order=2)
-        _target_order: Final = (request_kwargs or {}).get("_target_order")
+        _target_order: Final = (request_kwargs or {}).pop("_target_order", None)
         healthy_deployments = litellm.utils._get_order_filtered_deployments(
             cast(list[dict], healthy_deployments), target_order=_target_order
         )
@@ -12698,7 +12693,7 @@ class Router:
             )
 
         ## ORDER FILTERING ## -> if user set 'order' in deployments, return deployments with lowest order (e.g. order=1 > order=2)
-        _target_order: Final = (request_kwargs or {}).get("_target_order")
+        _target_order: Final = (request_kwargs or {}).pop("_target_order", None)
         healthy_deployments = litellm.utils._get_order_filtered_deployments(
             healthy_deployments, target_order=_target_order
         )

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -558,6 +558,11 @@ RETRY_BREADCRUMB_EXCLUDED_KWARGS: Final = frozenset(
 )
 
 
+def _without_target_order(kwargs: Mapping[str, object]) -> Mapping[str, object]:
+    """Drop the router-internal order-fallback target so it never reaches a provider call."""
+    return MappingProxyType({k: v for k, v in kwargs.items() if k != "_target_order"})
+
+
 class Router:
     model_names: set = set()
     cache_responses: bool | None = False
@@ -2172,9 +2177,8 @@ class Router:
                 "messages": messages,
                 "caching": self.cache_responses,
                 "client": model_client,
-                **kwargs,
+                **_without_target_order(kwargs),
             }
-            input_kwargs.pop("_target_order", None)
             response: Final = litellm.completion(**input_kwargs)
             verbose_router_logger.info("litellm.completion(model=%s)\x1b[32m 200 OK\x1b[0m", model_name)
 
@@ -3194,9 +3198,8 @@ class Router:
                 "messages": messages,
                 "caching": self.cache_responses,
                 "client": model_client,
-                **kwargs,
+                **_without_target_order(kwargs),
             }
-            input_kwargs.pop("_target_order", None)
             input_kwargs.pop("silent_model", None)
             input_kwargs.pop("include_fallback_errors", None)
 
@@ -4072,7 +4075,7 @@ class Router:
                     "prompt": prompt,
                     "caching": self.cache_responses,
                     "client": model_client,
-                    **kwargs,
+                    **_without_target_order(kwargs),
                 }
             )
             self.success_calls[model_name] += 1
@@ -4132,7 +4135,7 @@ class Router:
                     "prompt": prompt,
                     "caching": self.cache_responses,
                     "client": model_client,
-                    **kwargs,
+                    **_without_target_order(kwargs),
                 }
             )
 
@@ -4236,7 +4239,7 @@ class Router:
                     "file": file,
                     "caching": self.cache_responses,
                     "client": model_client,
-                    **kwargs,
+                    **_without_target_order(kwargs),
                 }
             )
 
@@ -4889,7 +4892,7 @@ class Router:
             response_kwargs: Final = {
                 **data,
                 "caching": self.cache_responses,
-                **kwargs,
+                **_without_target_order(kwargs),
                 "model": model_name,
             }
             # Only set custom_llm_provider if it's not None
@@ -5339,7 +5342,7 @@ class Router:
                     **data,
                     "custom_llm_provider": custom_llm_provider,
                     "caching": self.cache_responses,
-                    **kwargs,
+                    **_without_target_order(kwargs),
                 }
             )
 
@@ -5405,7 +5408,7 @@ class Router:
                     "input": input,
                     "caching": self.cache_responses,
                     "client": model_client,
-                    **kwargs,
+                    **_without_target_order(kwargs),
                 }
             )
             self.success_calls[model_name] += 1
@@ -5468,7 +5471,7 @@ class Router:
                     "input": input,
                     "caching": self.cache_responses,
                     "client": model_client,
-                    **kwargs,
+                    **_without_target_order(kwargs),
                 }
             )
 

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -2172,9 +2172,8 @@ class Router:
                 "messages": messages,
                 "caching": self.cache_responses,
                 "client": model_client,
-                **kwargs,
+                **{k: v for k, v in kwargs.items() if k != "_target_order"},
             }
-            input_kwargs.pop("_target_order", None)
             response: Final = litellm.completion(**input_kwargs)
             verbose_router_logger.info("litellm.completion(model=%s)\x1b[32m 200 OK\x1b[0m", model_name)
 
@@ -3194,11 +3193,10 @@ class Router:
                 "messages": messages,
                 "caching": self.cache_responses,
                 "client": model_client,
-                **kwargs,
+                **{k: v for k, v in kwargs.items() if k != "_target_order"},
             }
             input_kwargs.pop("silent_model", None)
             input_kwargs.pop("include_fallback_errors", None)
-            input_kwargs.pop("_target_order", None)
 
             _response: Final = litellm.acompletion(**input_kwargs)
 

--- a/litellm/router_utils/fallback_event_handlers.py
+++ b/litellm/router_utils/fallback_event_handlers.py
@@ -412,9 +412,7 @@ async def run_async_fallback(
             # LOGGING
             kwargs = litellm_router.log_retry(kwargs=kwargs, e=original_exception)
             verbose_router_logger.info("Falling back to model_group = %s", mask_sensitive_structure(mg))
-            kwargs = {
-                k: v for k, v in kwargs.items() if k != "_target_order"
-            }  # rebind-ok: next hop must not inherit the previous order target
+            kwargs.pop("_target_order", None)  # rebind-ok: next hop must not inherit the previous order target
             if isinstance(mg, str):
                 kwargs["model"] = mg
             elif isinstance(mg, dict):

--- a/litellm/router_utils/fallback_event_handlers.py
+++ b/litellm/router_utils/fallback_event_handlers.py
@@ -412,11 +412,10 @@ async def run_async_fallback(
             # LOGGING
             kwargs = litellm_router.log_retry(kwargs=kwargs, e=original_exception)
             verbose_router_logger.info("Falling back to model_group = %s", mask_sensitive_structure(mg))
+            kwargs = {k: v for k, v in kwargs.items() if k != "_target_order"}  # rebind-ok: next hop must not inherit the previous order target
             if isinstance(mg, str):
                 kwargs["model"] = mg
-                kwargs.pop("_target_order", None)
             elif isinstance(mg, dict):
-                kwargs.pop("_target_order", None)
                 kwargs.update(mg)
             fallback_depth = fallback_depth + 1
             _hop_metadata = dict(kwargs.get(metadata_variable_name) or {})

--- a/litellm/router_utils/fallback_event_handlers.py
+++ b/litellm/router_utils/fallback_event_handlers.py
@@ -414,7 +414,9 @@ async def run_async_fallback(
             verbose_router_logger.info("Falling back to model_group = %s", mask_sensitive_structure(mg))
             if isinstance(mg, str):
                 kwargs["model"] = mg
+                kwargs.pop("_target_order", None)
             elif isinstance(mg, dict):
+                kwargs.pop("_target_order", None)
                 kwargs.update(mg)
             fallback_depth = fallback_depth + 1
             _hop_metadata = dict(kwargs.get(metadata_variable_name) or {})

--- a/litellm/router_utils/fallback_event_handlers.py
+++ b/litellm/router_utils/fallback_event_handlers.py
@@ -412,7 +412,9 @@ async def run_async_fallback(
             # LOGGING
             kwargs = litellm_router.log_retry(kwargs=kwargs, e=original_exception)
             verbose_router_logger.info("Falling back to model_group = %s", mask_sensitive_structure(mg))
-            kwargs = {k: v for k, v in kwargs.items() if k != "_target_order"}  # rebind-ok: next hop must not inherit the previous order target
+            kwargs = {
+                k: v for k, v in kwargs.items() if k != "_target_order"
+            }  # rebind-ok: next hop must not inherit the previous order target
             if isinstance(mg, str):
                 kwargs["model"] = mg
             elif isinstance(mg, dict):

--- a/litellm/router_utils/pre_call_checks/deployment_affinity_check.py
+++ b/litellm/router_utils/pre_call_checks/deployment_affinity_check.py
@@ -427,6 +427,8 @@ class DeploymentAffinityCheck(CustomLogger):
         """
         request_kwargs = request_kwargs or {}
         typed_healthy_deployments: Final = cast(list[dict], healthy_deployments)
+        if request_kwargs.get("_target_order") is not None:
+            return typed_healthy_deployments
 
         (
             enable_user_key,

--- a/litellm/router_utils/pre_call_checks/prompt_caching_deployment_check.py
+++ b/litellm/router_utils/pre_call_checks/prompt_caching_deployment_check.py
@@ -58,6 +58,9 @@ class PromptCachingDeploymentCheck(CustomLogger):
         request_kwargs: dict | None = None,
         parent_otel_span: Span | None = None,
     ) -> list[dict]:
+        if request_kwargs is not None and request_kwargs.get("_target_order") is not None:
+            return healthy_deployments
+
         if messages is not None and is_prompt_caching_valid_prompt(
             messages=messages,
             model=model,

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -4859,11 +4859,7 @@ def _get_deployment_order(deployment: dict | Any) -> int | None:
 
 def _get_order_filtered_deployments(healthy_deployments: list[dict], target_order: int | None = None) -> list:
     if target_order is not None:
-        filtered: Final = [d for d in healthy_deployments if _get_deployment_order(d) == target_order]
-        if filtered:
-            return filtered
-        # target_order doesn't match any deployment (e.g., external fallback model) — return all
-        return healthy_deployments
+        return [d for d in healthy_deployments if _get_deployment_order(d) == target_order]
 
     # Default: pick min order group
     _valid_orders: Final[list[int]] = [

--- a/tests/test_litellm/router_utils/pre_call_checks/test_deployment_affinity_check.py
+++ b/tests/test_litellm/router_utils/pre_call_checks/test_deployment_affinity_check.py
@@ -599,6 +599,45 @@ async def test_async_filter_deployments_falls_back_when_cached_deployment_is_unh
 
 
 @pytest.mark.asyncio
+async def test_async_filter_deployments_does_not_pin_when_target_order_is_set():
+    user_key = "user-key-order-fallback"
+    stable_model_map_key = "claude-sonnet-4-5@20250929"
+    cache = AsyncMock()
+    cache.async_get_cache = AsyncMock(return_value={"model_id": "deployment-1"})
+    callback = DeploymentAffinityCheck(
+        cache=cache,
+        ttl_seconds=123,
+        enable_user_key_affinity=True,
+        enable_responses_api_affinity=False,
+    )
+    healthy_deployments = [
+        {
+            "model_name": stable_model_map_key,
+            "litellm_params": {"model": f"vertex_ai/{stable_model_map_key}"},
+            "model_info": {"id": "deployment-1"},
+        },
+        {
+            "model_name": stable_model_map_key,
+            "litellm_params": {
+                "model": f"bedrock/global.anthropic.{stable_model_map_key}-v1:0"
+            },
+            "model_info": {"id": "deployment-2"},
+        },
+    ]
+
+    filtered = await callback.async_filter_deployments(
+        model="some-router-model-group",
+        healthy_deployments=healthy_deployments,
+        messages=None,
+        request_kwargs={"_target_order": 2, "metadata": {"user_api_key_hash": user_key}},
+        parent_otel_span=None,
+    )
+
+    assert filtered == healthy_deployments
+    cache.async_get_cache.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_async_user_key_affinity_ttl_expiry_allows_reroute():
     """
     After affinity TTL expires, cached pinning should no longer filter deployments.

--- a/tests/test_litellm/router_utils/pre_call_checks/test_prompt_caching_deployment_check.py
+++ b/tests/test_litellm/router_utils/pre_call_checks/test_prompt_caching_deployment_check.py
@@ -151,6 +151,25 @@ async def test_async_filter_deployments_narrows_prompt_above_model_minimum():
 
 
 @pytest.mark.asyncio
+async def test_async_filter_deployments_does_not_pin_when_target_order_is_set():
+    cache = DualCache()
+    check = PromptCachingDeploymentCheck(cache=cache)
+    deployments = _deployments("anthropic/claude-opus-4-6", "anthropic/claude-opus-4-6")
+    messages = _messages(word_count=5000)
+
+    await PromptCachingCache(cache=cache).async_add_model_id(model_id="dep-2", messages=messages, tools=None)
+
+    filtered = await check.async_filter_deployments(
+        model=MODEL_GROUP_ALIAS,
+        healthy_deployments=deployments,
+        messages=messages,
+        request_kwargs={"_target_order": 2},
+    )
+
+    assert filtered == deployments
+
+
+@pytest.mark.asyncio
 async def test_async_filter_deployments_narrows_for_group_whose_model_minimum_is_lower():
     """
     Same ~1400-token prompt that must not pin an Opus 4.6 group, on an Opus 4.8 group whose real

--- a/tests/test_litellm/test_router_order_fallback.py
+++ b/tests/test_litellm/test_router_order_fallback.py
@@ -14,6 +14,7 @@ import litellm
 from litellm import Router
 from litellm.integrations.custom_logger import CustomLogger
 from litellm.router_utils.prompt_caching_cache import PromptCachingCache
+from litellm.types.router import RouterRateLimitError
 from litellm.utils import _get_deployment_order, _get_order_filtered_deployments
 
 # ---------------------------------------------------------------------------
@@ -454,13 +455,12 @@ async def test_router_order_fallback_does_not_reselect_order_1_when_order_2_is_f
     )
     litellm.callbacks.append(drop_order_2)
     try:
-        with pytest.raises(Exception) as exc_info:
+        with pytest.raises(RouterRateLimitError, match="No deployments available") as exc_info:
             await router.acompletion(
                 model="test-model",
                 messages=[{"role": "user", "content": "hi"}],
             )
         assert "success from order 2" not in str(exc_info.value)
-        assert getattr(exc_info.value, "_hidden_params", {}).get("model_id") != "1"
     finally:
         litellm.callbacks.remove(drop_order_2)
 

--- a/tests/test_litellm/test_router_order_fallback.py
+++ b/tests/test_litellm/test_router_order_fallback.py
@@ -6,8 +6,10 @@ should be tried first, and higher order deployments should be used as fallbacks
 when lower order deployments fail.
 """
 
+import json
 from typing import Final, Optional
 
+import httpx
 import pytest
 
 import litellm
@@ -578,6 +580,64 @@ async def test_generic_api_call_strips_target_order_from_provider_kwargs():
     assert response == "ok"
     assert captured["model"] == "gpt-4o"
     assert "_target_order" not in captured
+
+
+@pytest.mark.asyncio
+async def test_text_completion_order_fallback_hop_does_not_send_target_order_upstream():
+    upstream_bodies: Final[list[dict]] = []
+
+    def _upstream(request: httpx.Request) -> httpx.Response:
+        upstream_bodies.append(json.loads(request.content))
+        return httpx.Response(
+            200,
+            json={
+                "id": "cmpl-1",
+                "object": "text_completion",
+                "created": 0,
+                "model": "gpt-3.5-turbo-instruct",
+                "choices": [{"text": "ok from order 2", "index": 0, "logprobs": None, "finish_reason": "stop"}],
+                "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+            },
+        )
+
+    session: Final = httpx.AsyncClient(transport=httpx.MockTransport(_upstream))
+    litellm.in_memory_llm_clients_cache.flush_cache()
+    litellm.aclient_session = session
+    router = Router(
+        model_list=[
+            {
+                "model_name": "test-model",
+                "litellm_params": {
+                    "model": "text-completion-openai/gpt-3.5-turbo-instruct",
+                    "api_key": "key",
+                    "mock_response": Exception("fail order 1"),
+                    "order": 1,
+                },
+                "model_info": {"id": "1"},
+            },
+            {
+                "model_name": "test-model",
+                "litellm_params": {
+                    "model": "text-completion-openai/gpt-3.5-turbo-instruct",
+                    "api_key": "key",
+                    "api_base": "http://upstream.test",
+                    "order": 2,
+                },
+                "model_info": {"id": "2"},
+            },
+        ],
+        num_retries=0,
+    )
+    try:
+        response = await router.atext_completion(model="test-model", prompt="hi")
+    finally:
+        litellm.aclient_session = None
+        litellm.in_memory_llm_clients_cache.flush_cache()
+        await session.aclose()
+
+    assert response._hidden_params["model_id"] == "2"
+    assert upstream_bodies
+    assert all("_target_order" not in body for body in upstream_bodies)
 
 
 def test_check_non_standard_fallback_format():

--- a/tests/test_litellm/test_router_order_fallback.py
+++ b/tests/test_litellm/test_router_order_fallback.py
@@ -11,6 +11,7 @@ from typing import Final, Optional
 
 import httpx
 import pytest
+from openai import AsyncOpenAI
 
 import litellm
 from litellm import Router
@@ -600,9 +601,11 @@ async def test_text_completion_order_fallback_hop_does_not_send_target_order_ups
             },
         )
 
-    session: Final = httpx.AsyncClient(transport=httpx.MockTransport(_upstream))
-    litellm.in_memory_llm_clients_cache.flush_cache()
-    litellm.aclient_session = session
+    upstream_client: Final = AsyncOpenAI(
+        api_key="key",
+        base_url="http://upstream.test",
+        http_client=httpx.AsyncClient(transport=httpx.MockTransport(_upstream)),
+    )
     router = Router(
         model_list=[
             {
@@ -629,11 +632,9 @@ async def test_text_completion_order_fallback_hop_does_not_send_target_order_ups
         num_retries=0,
     )
     try:
-        response = await router.atext_completion(model="test-model", prompt="hi")
+        response = await router.atext_completion(model="test-model", prompt="hi", client=upstream_client)
     finally:
-        litellm.aclient_session = None
-        litellm.in_memory_llm_clients_cache.flush_cache()
-        await session.aclose()
+        await upstream_client.close()
 
     assert response._hidden_params["model_id"] == "2"
     assert upstream_bodies

--- a/tests/test_litellm/test_router_order_fallback.py
+++ b/tests/test_litellm/test_router_order_fallback.py
@@ -6,12 +6,15 @@ should be tried first, and higher order deployments should be used as fallbacks
 when lower order deployments fail.
 """
 
-from typing import Optional
+from typing import Final, Optional
 
 import pytest
 
+import litellm
 from litellm import Router
-from litellm.utils import _get_order_filtered_deployments
+from litellm.integrations.custom_logger import CustomLogger
+from litellm.router_utils.prompt_caching_cache import PromptCachingCache
+from litellm.utils import _get_deployment_order, _get_order_filtered_deployments
 
 # ---------------------------------------------------------------------------
 # Unit tests for _get_order_filtered_deployments
@@ -49,13 +52,22 @@ class TestGetOrderFilteredDeployments:
         assert len(result) == 1
         assert result[0]["model_info"]["id"] == "b"
 
-    def test_target_order_no_match_returns_all(self):
+    def test_target_order_no_match_returns_empty(self):
         deps = [
             self._make_deployment(1, "a"),
             self._make_deployment(2, "b"),
         ]
         result = _get_order_filtered_deployments(deps, target_order=99)
-        assert len(result) == 2
+        assert result == []
+
+    def test_target_order_no_match_does_not_reselect_lower_order(self):
+        deps = [
+            self._make_deployment(1, "a"),
+            self._make_deployment(2, "b"),
+        ]
+        remaining_after_pre_call = [deps[0]]
+        result = _get_order_filtered_deployments(remaining_after_pre_call, target_order=2)
+        assert result == []
 
     def test_no_order_set_returns_all(self):
         deps = [
@@ -404,6 +416,140 @@ async def test_router_order_fallback_with_hidden_model_group_alias():
     )
 
     assert response._hidden_params["model_id"] == "2"
+
+
+@pytest.mark.asyncio
+async def test_router_order_fallback_does_not_reselect_order_1_when_order_2_is_filtered_out():
+    class _DropOrder2(CustomLogger):
+        async def async_filter_deployments(
+            self, model, healthy_deployments, messages, request_kwargs=None, parent_otel_span=None
+        ):
+            return [d for d in healthy_deployments if _get_deployment_order(d) != 2]
+
+    drop_order_2: Final = _DropOrder2()
+    router = Router(
+        model_list=[
+            {
+                "model_name": "test-model",
+                "litellm_params": {
+                    "model": "gpt-4o",
+                    "api_key": "key",
+                    "mock_response": "litellm.RateLimitError",
+                    "order": 1,
+                },
+                "model_info": {"id": "1"},
+            },
+            {
+                "model_name": "test-model",
+                "litellm_params": {
+                    "model": "gpt-4o",
+                    "api_key": "key",
+                    "mock_response": "success from order 2",
+                    "order": 2,
+                },
+                "model_info": {"id": "2"},
+            },
+        ],
+        num_retries=0,
+    )
+    litellm.callbacks.append(drop_order_2)
+    try:
+        with pytest.raises(Exception) as exc_info:
+            await router.acompletion(
+                model="test-model",
+                messages=[{"role": "user", "content": "hi"}],
+            )
+        assert "success from order 2" not in str(exc_info.value)
+        assert getattr(exc_info.value, "_hidden_params", {}).get("model_id") != "1"
+    finally:
+        litellm.callbacks.remove(drop_order_2)
+
+
+@pytest.mark.asyncio
+async def test_router_order_fallback_ignores_prompt_cache_pin_on_target_order():
+    messages = [{"role": "user", "content": "word " * 5000}]
+    router = Router(
+        model_list=[
+            {
+                "model_name": "test-model",
+                "litellm_params": {
+                    "model": "gpt-4o",
+                    "api_key": "bad",
+                    "mock_response": Exception("azure peak load"),
+                    "order": 1,
+                },
+                "model_info": {"id": "1"},
+            },
+            {
+                "model_name": "test-model",
+                "litellm_params": {
+                    "model": "gpt-4o",
+                    "api_key": "good",
+                    "mock_response": "success from order 2",
+                    "order": 2,
+                },
+                "model_info": {"id": "2"},
+            },
+        ],
+        num_retries=0,
+        optional_pre_call_checks=["prompt_caching"],
+    )
+    await PromptCachingCache(cache=router.cache).async_add_model_id(
+        model_id="1",
+        messages=messages,
+        tools=None,
+    )
+    response = await router.acompletion(model="test-model", messages=messages)
+    assert response._hidden_params["model_id"] == "2"
+
+
+@pytest.mark.asyncio
+async def test_router_order_fallback_retries_keep_target_order():
+    seen_target_orders: Final = []
+
+    class _RecordTargetOrder(CustomLogger):
+        async def async_filter_deployments(
+            self, model, healthy_deployments, messages, request_kwargs=None, parent_otel_span=None
+        ):
+            seen_target_orders.append((request_kwargs or {}).get("_target_order"))
+            return healthy_deployments
+
+    recorder: Final = _RecordTargetOrder()
+    router = Router(
+        model_list=[
+            {
+                "model_name": "test-model",
+                "litellm_params": {
+                    "model": "gpt-4o",
+                    "api_key": "bad",
+                    "mock_response": Exception("fail order 1"),
+                    "order": 1,
+                },
+                "model_info": {"id": "1"},
+            },
+            {
+                "model_name": "test-model",
+                "litellm_params": {
+                    "model": "gpt-4o",
+                    "api_key": "bad",
+                    "mock_response": Exception("fail order 2"),
+                    "order": 2,
+                },
+                "model_info": {"id": "2"},
+            },
+        ],
+        num_retries=1,
+    )
+    litellm.callbacks.append(recorder)
+    try:
+        with pytest.raises(Exception, match="fail order 2"):
+            await router.acompletion(
+                model="test-model",
+                messages=[{"role": "user", "content": "hi"}],
+            )
+    finally:
+        litellm.callbacks.remove(recorder)
+    assert seen_target_orders.count(2) >= 2
 
 
 def test_check_non_standard_fallback_format():

--- a/tests/test_litellm/test_router_order_fallback.py
+++ b/tests/test_litellm/test_router_order_fallback.py
@@ -552,35 +552,48 @@ async def test_router_order_fallback_retries_keep_target_order():
     assert seen_target_orders.count(2) >= 2
 
 
+@pytest.mark.asyncio
+async def test_generic_api_call_strips_target_order_from_provider_kwargs():
+    captured: Final = {}
+
+    async def _fake_provider(**provider_kwargs):
+        captured.update(provider_kwargs)
+        return "ok"
+
+    router = Router(
+        model_list=[
+            {
+                "model_name": "test-model",
+                "litellm_params": {"model": "gpt-4o", "api_key": "key", "order": 2},
+                "model_info": {"id": "2"},
+            },
+        ],
+    )
+    response = await router._ageneric_api_call_with_fallbacks_helper(
+        model="test-model",
+        original_generic_function=_fake_provider,
+        _target_order=2,
+        messages=[{"role": "user", "content": "hi"}],
+    )
+    assert response == "ok"
+    assert captured["model"] == "gpt-4o"
+    assert "_target_order" not in captured
+
+
 def test_check_non_standard_fallback_format():
     from litellm.router_utils.fallback_event_handlers import (
         _check_non_standard_fallback_format,
     )
 
     # Standard formats
-    assert (
-        _check_non_standard_fallback_format([{"gpt-3.5-turbo": ["claude-3-haiku"]}])
-        == False
-    )
+    assert _check_non_standard_fallback_format([{"gpt-3.5-turbo": ["claude-3-haiku"]}]) == False
     assert _check_non_standard_fallback_format([{"model": ["qwen-backup"]}]) == False
-    assert (
-        _check_non_standard_fallback_format(
-            [{"model": ["qwen-backup"], "region": ["us-east-1"]}]
-        )
-        == False
-    )
+    assert _check_non_standard_fallback_format([{"model": ["qwen-backup"], "region": ["us-east-1"]}]) == False
 
     # Non-standard formats
     assert _check_non_standard_fallback_format([{"model": "qwen-backup"}]) == True
     assert (
-        _check_non_standard_fallback_format(
-            [{"model": "qwen-backup", "messages": [{"role": "user", "content": "hi"}]}]
-        )
+        _check_non_standard_fallback_format([{"model": "qwen-backup", "messages": [{"role": "user", "content": "hi"}]}])
         == True
     )
-    assert (
-        _check_non_standard_fallback_format(
-            [{"model": ["qwen-backup"], "api_key": "some-key"}]
-        )
-        == True
-    )
+    assert _check_non_standard_fallback_format([{"model": ["qwen-backup"], "api_key": "some-key"}]) == True


### PR DESCRIPTION
## TLDR

Problem this solves:

- Order fallback reselected the Azure deployment that just 429'd
- Prompt-cache affinity could hide every order-2 backup before selection

How it solves it:

- A requested target order with no match stays empty
- Prompt-cache and deployment affinity do not pin while a target order is set
- Target order is consumed at deployment selection, so it never reaches a provider call
- Each fallback hop clears the previous target order before it re-targets

## User Flow

Before: a developer calling a model group with Azure as `order: 1` and Bedrock as `order: 2` still gets Azure's 429 when Azure is at peak load

1. An admin configures `POST` model deployments for `gpt-5.6-luna` with Azure `order: 1` and Bedrock `order: 2`, enables prompt-caching pre-call checks, and restarts the proxy
2. A client sends a long-prompt `POST http://localhost:4000/v1/messages` with `"model": "gpt-5.6-luna"`
3. Azure answers 429 `no_capacity` for that request size during peak load
4. The client receives HTTP 429. The JSON `error.message` still names the Azure `no_capacity` body, `Received Model Group=gpt-5.6-luna`, and `Available Model Group Fallbacks=None`. No Bedrock request is made

After: the same long prompt is served by the `order: 2` Bedrock deployment when Azure returns 429

1. The admin uses the same deployments and the same prompt-caching pre-call checks
2. The client sends the same `POST http://localhost:4000/v1/messages` with `"model": "gpt-5.6-luna"`
3. Azure answers 429 `no_capacity`
4. The client receives HTTP 200 from Bedrock. Fallback headers show a fallback was used. `GET http://localhost:4000/ui/?page=logs` for that request names the Bedrock deployment

## Relevant issues

Fixes #38968

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Config the proxy ran with (secrets redacted). Live proxy, real Azure OpenAI, real Bedrock:

```yaml
model_list:
  - model_name: gpt-5.6-luna
    litellm_params:
      model: azure/gpt-5.6-luna
      api_base: https://<redacted>.openai.azure.com/
      api_key: os.environ/AZURE_API_KEY
      order: 1
      rpm: 15000
      tpm: 15000000
  - model_name: gpt-5.6-luna
    litellm_params:
      model: bedrock_mantle/openai.gpt-5.6-luna
      aws_region_name: us-east-1
      order: 2
  - model_name: gpt-5.6-luna
    litellm_params:
      model: bedrock_mantle/openai.gpt-5.6-luna
      aws_region_name: us-east-2
      order: 2
  - model_name: gpt-5.6-luna
    litellm_params:
      model: bedrock_mantle/openai.gpt-5.6-luna
      aws_region_name: us-west-2
      order: 2

router_settings:
  num_retries: 5
  max_fallbacks: 5
  enable_pre_call_checks: true
  optional_pre_call_checks:
    - prompt_caching
  fallbacks: null
```

Azure `no_capacity` is peak-load dependent and cannot be forced on a quiet localhost proxy. Before is the live request captured in #38968. After is the same request shape against this tip. A reviewer can replay it the next time Azure returns `no_capacity` on that group

### Before (4ba8517134)

1. Client sent `POST /v1/messages` with `"model": "gpt-5.6-luna"` and a long prompt
2. Proxy logged `Falling back to model_group = {'model': 'gpt-5.6-luna', '_target_order': 2}` then `get_available_deployment` selected `azure/gpt-5.6-luna` `order: 1`. Sampled window: 185 order-2 fallback attempts, 0 order-2 selections
3. Client received:

```
Error code: 429 - {'error': {'message': 'litellm.RateLimitError: AzureException RateLimitError - {
  "error": {
    "message": "The system is currently experiencing high demand and cannot process your request. Your request exceeds the maximum usage size allowed during peak load. For improved capacity reliability, consider switching to Provisioned Throughput.",
    "type": "too_many_requests",
    "param": null,
    "code": "no_capacity"
  }
}. Received Model Group=gpt-5.6-luna
Available Model Group Fallbacks=None', 'type': 'throttling_error', 'param': None, 'code': '429'}}
```

### After (0b89c59be2)

1. Same `POST /v1/messages` with `"model": "gpt-5.6-luna"` and a long prompt
2. On the next live Azure `no_capacity`, `get_available_deployment` after `_target_order: 2` should name a `bedrock_mantle/openai.gpt-5.6-luna` deployment, not Azure `order: 1`
3. Client should receive HTTP 200 from Bedrock, or a Bedrock error if that backup is also down, not a second Azure `no_capacity` from the same order-1 deployment

## Type

Bug Fix

## Caveats (if any)

### Medium

- Encrypted-content affinity still pins during an order fallback, so an encrypted request may stay on a compatible primary instead of crossing providers
- External fallback hops that used to inherit a leftover `_target_order` now clear it unless the fallback entry sets it. Generated order fallbacks still set it

### Low

- Client error text can still say `Available Model Group Fallbacks=None` because that string is the conventional fallbacks map, not the generated order list

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

https://claude.ai/code/session_01XKkTFa6g7Rmd6vtHL91GMn
