### PR TITLE
fix(ui): paginate request logs by session rows

### DIFF
--- a/litellm/proxy/spend_tracking/spend_management_endpoints.py
+++ b/litellm/proxy/spend_tracking/spend_management_endpoints.py
@@ -2229,6 +2229,11 @@ async def ui_view_spend_logs(
         default=None,
         description="Filter spend logs by session_id (partial string match)",
     ),
+    group_by_session: bool = fastapi.Query(
+        default=False,
+        description="Return one representative row per session for dashboard pagination",
+        include_in_schema=False,
+    ),
     team_id: str | None = fastapi.Query(
         default=None,
         description="Filter spend logs by team_id",
@@ -2310,6 +2315,7 @@ async def ui_view_spend_logs(
     from litellm.proxy.auth.auth_utils import get_request_route  # noqa: PLC0415
 
     is_v2: Final = "/spend/logs/v2" in get_request_route(request)
+    is_grouped_by_session: Final = group_by_session is True and not is_v2
 
     # Validate sort_by and sort_order
     valid_sort_fields: Final = {
@@ -2637,10 +2643,15 @@ async def ui_view_spend_logs(
         else:
             _order_expr = order_column
 
+        grouped_order_expr: Final = "session_total_spend" if order_column == "spend" else _order_expr
+        session_group_expr: Final = "COALESCE('session:' || NULLIF(session_id, ''), 'request:' || request_id)"
+        # Grouped mode must deduplicate the filtered window before this limit;
+        # the cap bounds the reported group count, not the raw rows scanned.
+        count_selection: Final = f"SELECT DISTINCT {session_group_expr}" if is_grouped_by_session else "SELECT 1"
         count_query: Final = f"""
             SELECT COUNT(*) AS total_count
             FROM (
-                SELECT 1
+                {count_selection}
                 FROM "LiteLLM_SpendLogs"
                 WHERE {" AND ".join(sql_conditions)}
                 LIMIT ${p}
@@ -2653,8 +2664,7 @@ async def ui_view_spend_logs(
         total_is_capped: Final = raw_total > SPEND_LOGS_PAGINATION_COUNT_CAP
         total_records: Final = SPEND_LOGS_PAGINATION_COUNT_CAP if total_is_capped else raw_total
 
-        sql_query: Final = f"""
-            SELECT
+        select_columns: Final = """
                 request_id, call_type, api_key, spend, total_tokens,
                 prompt_tokens, completion_tokens, "startTime", "endTime",
                 "completionStartTime", model, model_id, model_group,
@@ -2663,11 +2673,53 @@ async def ui_view_spend_logs(
                 organization_id, end_user, requester_ip_address,
                 session_id, status, mcp_namespaced_tool_name, agent_id,
                 COALESCE(request_duration_ms, (EXTRACT(EPOCH FROM ("endTime" - "startTime")) * 1000)::INTEGER) AS request_duration_ms
+        """
+        ungrouped_query: Final = f"""
+            SELECT {select_columns}
             FROM "LiteLLM_SpendLogs"
             WHERE {" AND ".join(sql_conditions)}
             ORDER BY {_order_expr} {_sql_dir}{_nulls_clause}
             LIMIT ${p} OFFSET ${p + 1}
         """
+        grouped_query: Final = f"""
+            WITH filtered_rows AS (
+                SELECT {select_columns},
+                    (COUNT(*) OVER session_window)::int AS session_total_count,
+                    COALESCE(SUM(spend) OVER session_window, 0)::double precision AS session_total_spend,
+                    (COUNT(*) FILTER (
+                        WHERE call_type NOT IN ('call_mcp_tool', 'list_mcp_tools', 'asend_message')
+                    ) OVER session_window)::int AS session_llm_count,
+                    (COUNT(*) FILTER (
+                        WHERE call_type IN ('call_mcp_tool', 'list_mcp_tools')
+                    ) OVER session_window)::int AS session_mcp_count,
+                    (COUNT(*) FILTER (
+                        WHERE call_type = 'asend_message'
+                    ) OVER session_window)::int AS session_agent_count,
+                    (COUNT(*) FILTER (
+                        WHERE call_type IN ('call_mcp_tool', 'list_mcp_tools')
+                    ) OVER session_window)::int AS mcp_tool_call_count,
+                    COALESCE(SUM(spend) FILTER (
+                        WHERE call_type IN ('call_mcp_tool', 'list_mcp_tools')
+                    ) OVER session_window, 0)::double precision AS mcp_tool_call_spend,
+                    (COUNT(*) FILTER (
+                        WHERE LOWER(cache_hit) = 'true'
+                    ) OVER session_window)::int AS session_cache_hit_count
+                FROM "LiteLLM_SpendLogs"
+                WHERE {" AND ".join(sql_conditions)}
+                WINDOW session_window AS (PARTITION BY {session_group_expr})
+            ),
+            session_rows AS (
+                SELECT DISTINCT ON ({session_group_expr}) *
+                FROM filtered_rows
+                ORDER BY {session_group_expr},
+                    CASE WHEN call_type IN ('call_mcp_tool', 'list_mcp_tools') THEN 1 ELSE 0 END,
+                    {_order_expr} {_sql_dir}{_nulls_clause}, request_id
+            )
+            SELECT * FROM session_rows
+            ORDER BY {grouped_order_expr} {_sql_dir}{_nulls_clause}, {session_group_expr}
+            LIMIT ${p} OFFSET ${p + 1}
+        """
+        sql_query: Final = grouped_query if is_grouped_by_session else ungrouped_query
         sql_params.extend([page_size, skip])
 
         data: Final = await prisma_client.db.query_raw(sql_query, *sql_params)
@@ -2686,7 +2738,7 @@ async def ui_view_spend_logs(
             page,
             page_size,
             total_pages,
-            enrich_session_counts=not is_v2,
+            enrich_session_counts=not is_v2 and not is_grouped_by_session,
             total_is_capped=total_is_capped,
         )
     except Exception as e:
@@ -4074,8 +4126,8 @@ async def _build_ui_spend_logs_response(
     fetches the total number of logs in each referenced session.  Rows without
     a ``session_id`` default to ``1``.
 
-    When ``enrich_session_counts`` is ``False`` (v2 endpoint), rows are
-    serialised without the extra query.
+    When ``enrich_session_counts`` is ``False`` (v2 or pre-enriched grouped
+    rows), data is returned without the extra queries.
 
     Args:
         prisma_client: The connected Prisma client instance.

--- a/tests/test_litellm/proxy/spend_tracking/test_spend_management_endpoints.py
+++ b/tests/test_litellm/proxy/spend_tracking/test_spend_management_endpoints.py
@@ -168,6 +168,28 @@ def make_ui_spend_logs_mock_prisma(mock_spend_logs, filter_fn, team_lookup_fn=No
                         If provided, adds litellm_teamtable to db.
     """
 
+    def visible_group_key(log):
+        return ("session", log["session_id"]) if log.get("session_id") else ("request", log["request_id"])
+
+    def build_grouped_row(members):
+        mcp_members = [member for member in members if member.get("call_type") in {"call_mcp_tool", "list_mcp_tools"}]
+        agent_members = [member for member in members if member.get("call_type") == "asend_message"]
+        representative = min(
+            members,
+            key=lambda member: member.get("call_type") in {"call_mcp_tool", "list_mcp_tools"},
+        )
+        return {
+            **representative,
+            "session_total_count": len(members),
+            "session_total_spend": sum(float(member.get("spend") or 0.0) for member in members),
+            "session_llm_count": len(members) - len(mcp_members) - len(agent_members),
+            "session_mcp_count": len(mcp_members),
+            "session_agent_count": len(agent_members),
+            "mcp_tool_call_count": len(mcp_members),
+            "mcp_tool_call_spend": sum(float(member.get("spend") or 0.0) for member in mcp_members),
+            "session_cache_hit_count": sum(str(member.get("cache_hit")).lower() == "true" for member in members),
+        }
+
     class MockDB:
         async def count(self, *args, **kwargs):
             return len(filter_fn(kwargs.get("where", {})))
@@ -185,16 +207,24 @@ def make_ui_spend_logs_mock_prisma(mock_spend_logs, filter_fn, team_lookup_fn=No
         async def query_raw(self, sql_query, *params):
             if query_observer is not None:
                 query_observer(sql_query, params)
-            if "mcp_tool_call_count" in sql_query:
+            is_grouped_page = "WITH filtered_rows AS" in sql_query
+            if "mcp_tool_call_count" in sql_query and not is_grouped_page:
                 return []
             filtered = filter_fn(_reconstruct_ui_where_from_sql(sql_query, params))
-            total = len(filtered)
-            if "COUNT(*)" in sql_query:
+            group_keys = dict.fromkeys(visible_group_key(log) for log in filtered)
+            grouped_rows = [
+                build_grouped_row([log for log in filtered if visible_group_key(log) == group_key])
+                for group_key in group_keys
+            ]
+            is_grouped_count = "SELECT DISTINCT COALESCE('session:'" in sql_query
+            total = len(grouped_rows) if is_grouped_count else len(filtered)
+            if "SELECT COUNT(*) AS total_count" in sql_query:
                 cap_plus_one = params[-1]
                 return [{"total_count": min(total, cap_plus_one)}]
             page_size = params[-2] if len(params) >= 2 else 50
             skip = params[-1] if len(params) >= 1 else 0
-            return [row for row in filtered[skip : skip + page_size]]
+            page_rows = grouped_rows if is_grouped_page else filtered
+            return [row for row in page_rows[skip : skip + page_size]]
 
     class MockPrismaClient:
         def __init__(self):
@@ -1464,8 +1494,11 @@ async def test_ui_view_spend_logs_internal_user_scoped_without_user_id(
         app.dependency_overrides.pop(ps.user_api_key_auth, None)
 
 
+@pytest.mark.parametrize("group_by_session", [False, True])
 @pytest.mark.asyncio
-async def test_ui_view_spend_logs_explicit_user_filter_cannot_escape_own_scope(client, monkeypatch):
+async def test_ui_view_spend_logs_explicit_user_filter_cannot_escape_own_scope(
+    client, monkeypatch, group_by_session: bool
+):
     caller_log = {
         "id": "log1",
         "request_id": "req1",
@@ -1500,6 +1533,7 @@ async def test_ui_view_spend_logs_explicit_user_filter_cannot_escape_own_scope(c
             "/spend/logs/ui",
             params={
                 "user_id": "someone-else@example.com",
+                "group_by_session": group_by_session,
                 "start_date": start_date,
                 "end_date": end_date,
             },
@@ -1508,7 +1542,9 @@ async def test_ui_view_spend_logs_explicit_user_filter_cannot_escape_own_scope(c
 
         assert response.status_code == 200
         assert response.json()["data"] == []
-        page_sql, page_params = next((sql, params) for sql, params in observed_queries if "SELECT\n" in sql)
+        page_sql, page_params = next(
+            (sql, params) for sql, params in observed_queries if "LIMIT $" in sql and "OFFSET $" in sql
+        )
         assert page_sql.count('"user" = $') == 2
         assert page_params[2:4] == ("someone-else@example.com", "caller@example.com")
     finally:
@@ -1801,6 +1837,101 @@ async def test_ui_view_spend_logs_pagination(client, monkeypatch):
         assert data["total"] == 25
         assert len(data["data"]) == 10
         assert data["page"] == 2
+    finally:
+        app.dependency_overrides.pop(ps.user_api_key_auth, None)
+
+
+@pytest.mark.asyncio
+async def test_ui_view_spend_logs_group_by_session_paginates_visible_rows(
+    client, monkeypatch
+):
+    now = datetime.datetime.now(timezone.utc).isoformat()
+    mock_spend_logs = [
+        {
+            "id": f"log-{session_index}-{message_index}",
+            "request_id": f"req-{session_index}-{message_index}",
+            "session_id": f"session-{session_index:02d}",
+            "call_type": ("call_mcp_tool" if session_index == 0 and message_index == 0 else "acompletion"),
+            "api_key": ("sk-other-test-key" if session_index == 0 and message_index == 0 else "sk-test-key"),
+            "startTime": now,
+            "model": "gpt-4",
+        }
+        for session_index in range(26)
+        for message_index in range(2)
+    ] + [
+        {
+            "id": f"standalone-log-{index}",
+            "request_id": ("session-00" if index == 0 else f"standalone-req-{index}"),
+            "session_id": None if index == 0 else "",
+            "call_type": "acompletion",
+            "api_key": "sk-test-key",
+            "startTime": now,
+            "model": "gpt-4",
+        }
+        for index in range(2)
+    ]
+
+    monkeypatch.setattr(
+        "litellm.proxy.proxy_server.prisma_client",
+        make_ui_spend_logs_mock_prisma(mock_spend_logs, lambda where: mock_spend_logs),
+    )
+    app.dependency_overrides[ps.user_api_key_auth] = lambda: UserAPIKeyAuth(
+        user_role=LitellmUserRoles.PROXY_ADMIN, user_id="admin_user"
+    )
+
+    try:
+        start_date, end_date = _default_date_range()
+        common_params = {
+            "page_size": 25,
+            "group_by_session": True,
+            "start_date": start_date,
+            "end_date": end_date,
+        }
+        first_response = client.get(
+            "/spend/logs/ui",
+            params={**common_params, "page": 1},
+            headers={"Authorization": "Bearer sk-test"},
+        )
+        second_response = client.get(
+            "/spend/logs/ui",
+            params={**common_params, "page": 2},
+            headers={"Authorization": "Bearer sk-test"},
+        )
+        v2_response = client.get(
+            "/spend/logs/v2",
+            params={**common_params, "page": 1, "page_size": 100},
+            headers={"Authorization": "Bearer sk-test"},
+        )
+
+        assert first_response.status_code == 200
+        assert second_response.status_code == 200
+        assert v2_response.status_code == 200
+        first_page = first_response.json()
+        second_page = second_response.json()
+        first_group_ids = {
+            (f"session:{row['session_id']}" if row.get("session_id") else f"request:{row['request_id']}")
+            for row in first_page["data"]
+        }
+        second_group_ids = {
+            (f"session:{row['session_id']}" if row.get("session_id") else f"request:{row['request_id']}")
+            for row in second_page["data"]
+        }
+        all_rows = first_page["data"] + second_page["data"]
+        assert first_page["total"] == 28
+        assert first_page["total_pages"] == 2
+        assert len(first_page["data"]) == 25
+        assert len(second_page["data"]) == 3
+        assert first_group_ids.isdisjoint(second_group_ids)
+        assert {"request:session-00", "request:standalone-req-1"}.issubset(first_group_ids | second_group_ids)
+        assert next(row for row in all_rows if row.get("session_id") == "session-00")["request_id"] == "req-0-1"
+        assert all(row["session_total_count"] == 2 for row in all_rows if row.get("session_id"))
+        assert all(row["session_total_count"] == 1 for row in all_rows if not row.get("session_id"))
+        mixed_key_session = next(row for row in all_rows if row.get("session_id") == "session-00")
+        assert mixed_key_session["session_llm_count"] == 1
+        assert mixed_key_session["session_mcp_count"] == 1
+        assert mixed_key_session["session_agent_count"] == 0
+        assert v2_response.json()["total"] == len(mock_spend_logs)
+        assert len(v2_response.json()["data"]) == len(mock_spend_logs)
     finally:
         app.dependency_overrides.pop(ps.user_api_key_auth, None)
 

--- a/tests/test_litellm/proxy/spend_tracking/test_spend_query_optimization.py
+++ b/tests/test_litellm/proxy/spend_tracking/test_spend_query_optimization.py
@@ -216,14 +216,29 @@ def _make_ui_spend_logs_mock(count_total, page_rows):
     return mock_prisma
 
 
+@pytest.mark.parametrize(
+    "group_by_session, count_selection, grouped_page",
+    [
+        (False, "SELECT 1", False),
+        (
+            True,
+            "SELECT DISTINCT COALESCE('session:' || NULLIF(session_id, ''), 'request:' || request_id)",
+            True,
+        ),
+    ],
+)
 @pytest.mark.asyncio
-async def test_spend_logs_ui_uses_bounded_count_not_full_scan(monkeypatch):
+async def test_spend_logs_ui_uses_capped_count_query(
+    monkeypatch: pytest.MonkeyPatch,
+    group_by_session: bool,
+    count_selection: str,
+    grouped_page: bool,
+):
     """
-    /spend/logs/ui must compute its pagination total with a bounded
-    `SELECT COUNT(*) FROM (SELECT 1 ... LIMIT $cap+1)` so it never scans the
-    whole time window of a huge LiteLLM_SpendLogs table (Aurora ACU spike,
-    LIT-4119). It must also avoid the unbounded prisma `.count()` /
-    `COUNT(*) OVER ()` full-window count that reads every matching row.
+    /spend/logs/ui must compute its pagination total in a capped subquery and
+    keep the count out of the page query. Raw-log mode can stop after cap+1
+    rows; grouped mode must deduplicate the filtered window before applying
+    the cap so its reported total counts visible session rows.
     """
     from litellm.proxy._types import LitellmUserRoles, UserAPIKeyAuth
     from litellm.proxy.spend_tracking.spend_management_endpoints import (
@@ -251,6 +266,7 @@ async def test_spend_logs_ui_uses_bounded_count_not_full_scan(monkeypatch):
         end_date="2026-02-16 23:59:59",
         page=1,
         page_size=50,
+        group_by_session=group_by_session,
         sort_by="startTime",
         sort_order="desc",
         user_api_key_dict=auth,
@@ -262,18 +278,20 @@ async def test_spend_logs_ui_uses_bounded_count_not_full_scan(monkeypatch):
     count_sql = count_call[0][0]
     assert "COUNT(*) OVER ()" not in count_sql
     assert "LIMIT" in count_sql and "FROM (" in count_sql, (
-        "the total must come from a bounded subquery count, not a full-window "
-        f"scan. SQL was:\n{count_sql}"
+        f"the total must come from a capped subquery count. SQL was:\n{count_sql}"
     )
+    assert count_selection in count_sql
     assert count_call[0][-1] == SPEND_LOGS_PAGINATION_COUNT_CAP + 1, (
-        "the bounded count must probe at most cap+1 rows"
+        "the count result must contain at most cap+1 rows or groups"
     )
 
     page_sql = mock_prisma.db.query_raw.call_args_list[1][0][0]
     assert "COUNT(*) OVER ()" not in page_sql, (
-        "the page query must not carry a window count that forces a full-window "
-        f"scan. SQL was:\n{page_sql}"
+        f"the page query must not carry a window count that forces a full-window scan. SQL was:\n{page_sql}"
     )
+    assert ("WITH filtered_rows AS" in page_sql) is grouped_page
+    assert ("OVER session_window" in page_sql) is grouped_page
+    assert ("DISTINCT ON (COALESCE('session:'" in page_sql) is grouped_page
 
     assert response["total"] == 137
     assert response["total_is_capped"] is False
@@ -281,6 +299,39 @@ async def test_spend_logs_ui_uses_bounded_count_not_full_scan(monkeypatch):
 
     for row in response["data"]:
         assert "total_count" not in row, "the window-function helper column must be stripped before serialising rows"
+
+
+@pytest.mark.asyncio
+async def test_spend_logs_ui_grouped_cost_sort_uses_session_total(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    from litellm.proxy._types import LitellmUserRoles, UserAPIKeyAuth
+    from litellm.proxy.spend_tracking.spend_management_endpoints import (
+        ui_view_spend_logs,
+    )
+
+    mock_prisma = _make_ui_spend_logs_mock(count_total=2, page_rows=[])
+    monkeypatch.setattr("litellm.proxy.proxy_server.prisma_client", mock_prisma)
+
+    auth = UserAPIKeyAuth(user_role=LitellmUserRoles.PROXY_ADMIN, user_id="admin")
+    request = MagicMock()
+    request.url.path = "/spend/logs/ui"
+
+    await ui_view_spend_logs(
+        request=request,
+        start_date="2026-02-16 00:00:00",
+        end_date="2026-02-16 23:59:59",
+        page=1,
+        page_size=50,
+        group_by_session=True,
+        sort_by="spend",
+        sort_order="desc",
+        user_api_key_dict=auth,
+    )
+
+    page_sql = mock_prisma.db.query_raw.call_args_list[1][0][0]
+    outer_query = page_sql.split("SELECT * FROM session_rows", maxsplit=1)[1]
+    assert "ORDER BY session_total_spend DESC" in outer_query
 
 
 @pytest.mark.asyncio

--- a/ui/litellm-dashboard/src/components/networking.test.ts
+++ b/ui/litellm-dashboard/src/components/networking.test.ts
@@ -539,12 +539,28 @@ describe("uiSpendLogsCall exclude_internal_health_checks serialization", () => {
     expect(lastUrl(mockFetch).searchParams.get("exclude_internal_health_checks")).toBe("true");
   });
 
+  it("appends group_by_session=true for session-aware pagination", async () => {
+    const mockFetch = mockOkFetch();
+
+    await callWith({ group_by_session: true });
+
+    expect(lastUrl(mockFetch).searchParams.get("group_by_session")).toBe("true");
+  });
+
   it("omits exclude_internal_health_checks when the toggle is off", async () => {
     const mockFetch = mockOkFetch();
 
     await callWith({ exclude_internal_health_checks: false });
 
     expect(lastUrl(mockFetch).searchParams.has("exclude_internal_health_checks")).toBe(false);
+  });
+
+  it("omits group_by_session when it is false", async () => {
+    const mockFetch = mockOkFetch();
+
+    await callWith({ group_by_session: false });
+
+    expect(lastUrl(mockFetch).searchParams.has("group_by_session")).toBe(false);
   });
 
   it("omits exclude_internal_health_checks when the param is absent", async () => {

--- a/ui/litellm-dashboard/src/components/networking.tsx
+++ b/ui/litellm-dashboard/src/components/networking.tsx
@@ -2024,6 +2024,7 @@ interface UiSpendLogsParams {
   team_id?: string;
   request_id?: string;
   session_id?: string;
+  group_by_session?: boolean;
   user_id?: string;
   end_user?: string;
   status_filter?: string;

--- a/ui/litellm-dashboard/src/components/view_logs/RequestLogsPanel.test.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/RequestLogsPanel.test.tsx
@@ -171,6 +171,26 @@ describe("RequestLogsPanel", () => {
       expect(within(row("req-llm") as HTMLElement).getByText("3")).toBeInTheDocument();
     });
 
+    it("keeps server composition when a page contains only the representative row", async () => {
+      const user = userEvent.setup();
+      const representativeOverrides: Partial<LogEntry> = {
+        request_id: "req-representative",
+        session_id: "sess-grouped",
+        session_total_count: 5,
+        session_llm_count: 4,
+        session_mcp_count: 1,
+        session_agent_count: 0,
+        session_cache_hit_count: 2,
+      };
+      const representative = logEntry(representativeOverrides);
+      respondWith([representative]);
+      renderPanel();
+
+      const badge = await screen.findByLabelText("5 calls");
+      await user.hover(badge);
+      expect(await screen.findByText("5 calls: 4 LLM, 1 MCP, 2 cache hits")).toBeInTheDocument();
+    });
+
     it("leaves single-call rows untouched", async () => {
       respondWith([
         logEntry({ request_id: "req-solo-a", session_id: "sess-a", session_total_count: 1 }),

--- a/ui/litellm-dashboard/src/components/view_logs/RequestLogsPanel.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/RequestLogsPanel.tsx
@@ -190,9 +190,9 @@ export default function RequestLogsPanel({ accessToken, token, userRole, userID,
         const sessionComposition = log.session_id ? sessionCompositionById[log.session_id] : undefined;
         return {
           ...log,
-          session_llm_count: sessionComposition?.llm ?? undefined,
-          session_mcp_count: sessionComposition?.mcp ?? undefined,
-          session_agent_count: sessionComposition?.agent ?? undefined,
+          session_llm_count: log.session_llm_count ?? sessionComposition?.llm ?? undefined,
+          session_mcp_count: log.session_mcp_count ?? sessionComposition?.mcp ?? undefined,
+          session_agent_count: log.session_agent_count ?? sessionComposition?.agent ?? undefined,
         };
       })
       .filter((log) => {

--- a/ui/litellm-dashboard/src/components/view_logs/RequestLogsTableColumns.test.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/RequestLogsTableColumns.test.tsx
@@ -75,6 +75,27 @@ describe("Cost column", () => {
   });
 });
 
+describe("Calls column", () => {
+  it("shows the call count for a multi-call MCP-only session", async () => {
+    const user = userEvent.setup();
+    renderRows([
+      logEntry({
+        request_id: "req-mcp-session",
+        call_type: "call_mcp_tool",
+        session_id: "sess-mcp",
+        session_total_count: 3,
+        session_llm_count: 0,
+        session_mcp_count: 3,
+        session_agent_count: 0,
+      }),
+    ]);
+
+    const badge = screen.getByLabelText("3 calls");
+    await user.hover(badge);
+    expect(await screen.findByText("3 calls: 3 MCP")).toBeInTheDocument();
+  });
+});
+
 describe("row action cells", () => {
   it("reports the key hash through the injected dependency rather than a row field", async () => {
     const user = userEvent.setup();
@@ -99,6 +120,7 @@ describe("sortable headers", () => {
   it("exposes sort controls only for the backend-sortable fields", () => {
     renderRows([logEntry({})]);
 
+    expect(screen.getByText("Calls")).toBeInTheDocument();
     for (const field of ["startTime", "spend", "request_duration_ms", "ttft_ms", "model", "total_tokens"]) {
       expect(screen.getByTestId(`sort-trigger-${field}`)).toBeInTheDocument();
     }

--- a/ui/litellm-dashboard/src/components/view_logs/RequestLogsTableColumns.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/RequestLogsTableColumns.tsx
@@ -36,6 +36,30 @@ function TruncatedText({ value }: { value: string | undefined }) {
   return <CellTooltip content={display} trigger={<span className="max-w-[15ch] truncate block">{display}</span>} />;
 }
 
+interface SessionCallsTooltipInput {
+  sessionCount: number;
+  sessionLlmCount: number;
+  sessionAgentCount: number;
+  sessionMcpCount: number;
+  cacheHitCount: number;
+}
+
+function getSessionCallsTooltip({
+  sessionCount,
+  sessionLlmCount,
+  sessionAgentCount,
+  sessionMcpCount,
+  cacheHitCount,
+}: SessionCallsTooltipInput): string {
+  const compositionParts = [
+    sessionLlmCount > 0 && `${sessionLlmCount} LLM`,
+    sessionAgentCount > 0 && `${sessionAgentCount} Agent`,
+    sessionMcpCount > 0 && `${sessionMcpCount} MCP`,
+  ].filter(Boolean);
+  const cacheHitPart = cacheHitCount > 0 ? `${cacheHitCount} cache ${cacheHitCount === 1 ? "hit" : "hits"}` : null;
+  return `${sessionCount} calls: ${[...compositionParts, cacheHitPart].filter(Boolean).join(", ")}`;
+}
+
 export const getRequestLogsTableColumns = ({
   onKeyHashClick,
   onSessionClick,
@@ -50,7 +74,7 @@ export const getRequestLogsTableColumns = ({
   },
   {
     id: "type",
-    header: "Type",
+    header: "Calls",
     size: 90,
     enableSorting: false,
     meta: { skeleton: "badge" },
@@ -63,12 +87,17 @@ export const getRequestLogsTableColumns = ({
       const sessionAgentCount = log.session_agent_count ?? (isAgent ? sessionCount : 0);
       const sessionMcpCount = log.session_mcp_count ?? (isMcp ? sessionCount : 0);
 
-      if (isMcp) return <McpBadge />;
-      if (isAgent && sessionCount <= 1) return <AgentBadge />;
-      if (sessionCount <= 1) return <LlmBadge />;
+      if (sessionCount <= 1) {
+        if (isMcp) return <McpBadge />;
+        if (isAgent) return <AgentBadge />;
+        return <LlmBadge />;
+      }
 
       const sessionTypeBadge = (
-        <span className="inline-flex items-center gap-1 px-2 py-0.5 bg-info/10 text-info border border-info/20 rounded-full text-[11px] font-medium whitespace-nowrap">
+        <span
+          aria-label={`${sessionCount} calls`}
+          className="inline-flex items-center gap-1 px-2 py-0.5 bg-info/10 text-info border border-info/20 rounded-full text-[11px] font-medium whitespace-nowrap"
+        >
           <SparkleIcon />
           <span>{sessionCount}</span>
           {sessionAgentCount > 0 && (
@@ -86,13 +115,15 @@ export const getRequestLogsTableColumns = ({
         </span>
       );
 
-      const tooltipParts = [
-        sessionLlmCount > 0 && `${sessionLlmCount} LLM`,
-        sessionAgentCount > 0 && `${sessionAgentCount} Agent`,
-        sessionMcpCount > 0 && `${sessionMcpCount} MCP`,
-        log.session_cache_hit_count != null && `${log.session_cache_hit_count} cache hit`,
-      ].filter(Boolean);
-      return <CellTooltip content={tooltipParts.join(" • ")} trigger={sessionTypeBadge} />;
+      const cacheHitCount = log.session_cache_hit_count || 0;
+      const tooltipInput: SessionCallsTooltipInput = {
+        sessionCount,
+        sessionLlmCount,
+        sessionAgentCount,
+        sessionMcpCount,
+        cacheHitCount,
+      };
+      return <CellTooltip content={getSessionCallsTooltip(tooltipInput)} trigger={sessionTypeBadge} />;
     },
   },
   {

--- a/ui/litellm-dashboard/src/components/view_logs/log_filter_logic.test.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/log_filter_logic.test.tsx
@@ -122,6 +122,7 @@ describe("useLogFilterLogic", () => {
 
       await waitFor(() => expect(uiSpendLogsCall).toHaveBeenCalled());
       expect(lastCallParams()).toMatchObject({ page: 3, page_size: 25 });
+      expect(lastCallParams()?.params).toMatchObject({ group_by_session: true });
     });
 
     it("passes start_date, end_date, sort_by, and sort_order", async () => {

--- a/ui/litellm-dashboard/src/components/view_logs/log_filter_logic.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/log_filter_logic.tsx
@@ -169,6 +169,7 @@ export function useLogFilterLogic({
           team_id: getFilterValue(columnFilters, LOG_FILTER_IDS.TEAM_ID),
           request_id: getFilterValue(columnFilters, LOG_FILTER_IDS.REQUEST_ID),
           session_id: getFilterValue(columnFilters, LOG_FILTER_IDS.SESSION_ID),
+          group_by_session: true,
           user_id: userIdFilter,
           end_user: getFilterValue(columnFilters, LOG_FILTER_IDS.END_USER),
           status_filter: getFilterValue(columnFilters, LOG_FILTER_IDS.STATUS),


### PR DESCRIPTION
## TLDR

Problem this solves:

- Request log pages contain fewer sessions than selected
- Pagination counts raw calls instead of visible sessions

How it solves it:

- Groups and paginates request logs by session server-side
- Returns session totals and call composition with each row

## User Flow

Before: an admin cannot reliably page through sessions because each page is filled with raw calls before the UI collapses them

1. They open `http://litellm-domain/ui/logs/`
2. They select 25 rows per page
3. The first page receives 25 calls but shows only 11 sessions
4. The footer reports 14 pages for 337 calls

After: the same admin can page through complete session rows

1. They open `http://litellm-domain/ui/logs/`
2. They select 25 rows per page
3. The first page receives and shows 25 sessions
4. The footer reports 6 pages for 135 sessions

## Relevant issues

Fixes #38060

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Shared setup: PostgreSQL 18.3 with 337 synthetic calls across 135 sessions. Both revisions used the same database and request parameters.

### Before (4ba8517134)

#### 25 rows, page 1

1. Send `GET /spend/logs/ui?group_by_session=true&page_size=25&page=1` for the seeded date range
2. Observe `{"rows":25,"visible_groups":11,"total":337,"page":1,"page_size":25,"total_pages":14}`

#### 100 rows, page 2

1. Send `GET /spend/logs/ui?group_by_session=true&page_size=100&page=2` for the same date range
2. Observe `{"rows":100,"visible_groups":40,"total":337,"page":2,"page_size":100,"total_pages":4}`

### After (277ed368b9)

#### 25 rows, page 1

1. Send `GET /spend/logs/ui?group_by_session=true&page_size=25&page=1` for the seeded date range
2. Observe `{"rows":25,"visible_groups":25,"total":135,"page":1,"page_size":25,"total_pages":6}`

#### 100 rows, page 2

1. Send `GET /spend/logs/ui?group_by_session=true&page_size=100&page=2` for the same date range
2. Observe `{"rows":35,"visible_groups":35,"total":135,"page":2,"page_size":100,"total_pages":2}`

## Type

Bug Fix

## Caveats (if any)

### Medium

- Grouped queries scan the filtered window before the count cap

### Low

- Client-side session grouping remains as a fallback for older workers
- When the backend returns grouped sessions, the UI uses the server values

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
