### PR TITLE
fix(docker): bump wolfi-base for glibc 2.44 and pin apk python to 3.13 in migrations image

### DIFF
--- a/migrations/Dockerfile
+++ b/migrations/Dockerfile
@@ -1,5 +1,5 @@
-ARG LITELLM_BUILD_IMAGE=cgr.dev/chainguard/wolfi-base@sha256:a31344ab2cb8618db84f535eec56f76f6178b142cb92cb2e48676cc2dcebea72
-ARG LITELLM_RUNTIME_IMAGE=cgr.dev/chainguard/wolfi-base@sha256:a31344ab2cb8618db84f535eec56f76f6178b142cb92cb2e48676cc2dcebea72
+ARG LITELLM_BUILD_IMAGE=cgr.dev/chainguard/wolfi-base@sha256:e624c5d5e42382ce7165ddafcbbf8e6769a24cbd02ea6114b880b05ae5ba2a8d
+ARG LITELLM_RUNTIME_IMAGE=cgr.dev/chainguard/wolfi-base@sha256:e624c5d5e42382ce7165ddafcbbf8e6769a24cbd02ea6114b880b05ae5ba2a8d
 ARG UV_IMAGE=ghcr.io/astral-sh/uv:0.11.7@sha256:240fb85ab0f263ef12f492d8476aa3a2e4e1e333f7d67fbdd923d00a506a516a
 
 FROM $UV_IMAGE AS uvbin
@@ -35,7 +35,7 @@ COPY --from=uvbin /uv /uvx /usr/local/bin/
 # instead of nodeenv downloading one whose dynamic deps may not be in Wolfi
 # (e.g. Node 26.2.0 needs libatomic). Retry for transient apk.cgr.dev flakes.
 RUN for i in 1 2 3; do \
-      apk add --no-cache bash gcc python3 python3-dev openssl openssl-dev libsndfile nodejs npm && break; \
+      apk add --no-cache bash gcc python-3.13 python-3.13-dev openssl openssl-dev libsndfile nodejs npm && break; \
       [ $i = 3 ] && { echo "apk add failed after 3 retries" >&2; exit 1; }; \
       sleep 5; \
     done
@@ -56,7 +56,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
     uv sync --frozen --no-install-project --no-install-workspace --no-default-groups --no-editable \
         --extra proxy \
         --extra extra_proxy \
-        --python python3
+        --python python3.13
 
 # Stage 2 — copy source and install the project + workspace members.
 COPY . .
@@ -65,7 +65,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
     uv sync --frozen --no-default-groups --no-editable \
         --extra proxy \
         --extra extra_proxy \
-        --python python3
+        --python python3.13
 
 COPY migrations/run.py /app/run.py
 
@@ -87,7 +87,7 @@ FROM $LITELLM_RUNTIME_IMAGE AS runtime
 USER root
 
 RUN for i in 1 2 3; do \
-      apk add --no-cache bash openssl tzdata python3 nodejs libsndfile libatomic && break; \
+      apk add --no-cache bash openssl tzdata python-3.13 nodejs libsndfile libatomic && break; \
       [ $i = 3 ] && { echo "apk add failed after 3 retries" >&2; exit 1; }; \
       sleep 5; \
     done


### PR DESCRIPTION
## TLDR

Problem this solves:

- the migrations-image job is red on the nightly Image Scan run
- migrations/Dockerfile still installs wolfi's rolling `python3` meta package
- wolfi rebuilt python against glibc 2.44; the pinned base ships 2.43
- `/usr/bin/python3` can't even `import math` (`GLIBC_2.44' not found`)
- `UV_PYTHON_DOWNLOADS=0` (already set here) makes uv fail loud with exit 2
- #38917 fixed the five main Dockerfiles but deliberately left this one out

How it solves it:

- same pattern as #38917, applied to migrations/Dockerfile
- bump the wolfi-base digest (glibc 2.44)
- pin `python-3.13`/`python-3.13-dev` instead of the rolling `python3` meta
- pass `--python python3.13` to both `uv sync` calls
- `UV_PYTHON_DOWNLOADS=0` was already present; kept

This is CI hygiene: the migrations-image check is not merge-required, so nothing is blocked from landing while it's red, but the nightly scan and the check on image PRs stay red until this merges.

## User Flow

Before: a maintainer building the DB migrations image (or reading the nightly Image Scan run) hits a build error on code nobody touched

1. They run `docker build -f migrations/Dockerfile .` at the repo root, or open the nightly run at https://github.com/BerriAI/litellm/actions/runs/33366552407
2. The first dependency-install layer dies with `error: Failed to inspect Python interpreter from first executable in the search path at /usr/bin/python3` and `ImportError: /usr/lib/libm.so.6: version 'GLIBC_2.44' not found`, exit code 1
3. The `migrations-image` check shows red on the nightly scan and on every PR touching image paths

After: the same build completes and the image migrates a fresh database

1. They run `docker build -f migrations/Dockerfile .` at the repo root
2. The dependency-install layer prints `Using CPython 3.13.15 interpreter at: /usr/bin/python3.13` and the build exits 0
3. They run the built image with a `DATABASE_URL` pointing at a fresh Postgres and it applies every Prisma migration, logging `All migrations have been successfully applied` and exiting 0
4. The `migrations-image` check shows green on this PR's tip

## Relevant issues

Follow-up to #38917 (same wolfi drift; this is the migrations/Dockerfile its Low caveat promised)

## Linear ticket

Resolves LIT-6553

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have added meaningful tests (no unit-testable surface: the migrations-image CI job is the regression test for this Dockerfile)
- [ ] The handful of test files covering my change pass locally (no mapped test files; the docker build and migrate run below are the local verification), e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

CI evidence: nightly Image Scan run 33366552407 (litellm_internal_staging, 2026-08-31 07:01 UTC) fails migrations-image with the exact signature below, and #38917's tip shows the same check red while its five fixed images went green.

### Before (d6cce13308, the litellm_internal_staging merge base)

1. `docker build -f migrations/Dockerfile .`
2. The first `uv sync` layer fails with exactly the CI signature:

```
#13 0.901 error: Failed to inspect Python interpreter from first executable in the search path at `/usr/bin/python3`
#13 0.902 ImportError: /usr/lib/libm.so.6: version `GLIBC_2.44' not found (required by /usr/lib/python3.13/lib-dynload/math.cpython-313-aarch64-linux-gnu.so)
ERROR: failed to build: failed to solve: process "/bin/sh -c uv sync --frozen ... --python python3" did not complete successfully: exit code: 2
```

CI's amd64 log is byte-identical apart from the arch suffix: https://github.com/BerriAI/litellm/actions/runs/33366552407/job/99408289416

### After (39473745ddb6759b14397df3e9f9499e7b49ce0b)

1. `docker build -f migrations/Dockerfile -t litellm-migrations .`
2. The dependency layer now uses the apk-pinned interpreter and the build completes:

```
#13 0.591 Using CPython 3.13.15 interpreter at: /usr/bin/python3.13
#13 43.32 Installed 132 packages in 2.29s
#21 naming to docker.io/library/litellm-migrations:latest
#21 DONE 325.2s
(exit 0)
```

3. Running the built image against a fresh Postgres 16 applies the migrations end to end:

```
$ docker run --rm --network lit6553net -e DATABASE_URL='postgresql://postgres:***@lit6553-pg:5432/litellm' litellm-migrations
...
All migrations have been successfully applied.
2026-08-31 16:51:26,759 - litellm_proxy_extras - INFO - Migration job completed successfully.
(exit 0)

$ docker exec lit6553-pg psql -U postgres -d litellm -tAc "select count(*) from information_schema.tables where table_schema='public'; select count(*) from _prisma_migrations where finished_at is not null;"
78
161
```

4. `migrations-image` at this PR's tip: green (the same job that failed on the nightly run)

## Type

🐛 Bug Fix
🚄 Infrastructure

## Caveats (if any)

### Low

- the other four image jobs stay red at this tip until #38917 merges (their Dockerfiles are out of this PR's scope)
- this path lifts the PR to 2 required approvals (`**/migrations/**` sensitive-files rule)
- the image stays on Python 3.13 until the pin is bumped deliberately
- if wolfi ever drops `python-3.13`, `apk add` fails loud at build time

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR


- [x] 39473745ddb6759b14397df3e9f9499e7b49ce0b passes /live-pr-risk

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docker-only CI hygiene for the migrations image; no application logic, auth, or data-path changes.
> 
> **Overview**
> **Fixes the red `migrations-image` CI job** by applying the same wolfi/Python alignment that #38917 used for the main images, which this Dockerfile was intentionally left out of.
> 
> In `migrations/Dockerfile`, the **wolfi-base digest** is bumped so the base ships **glibc 2.44**, matching Wolfi’s rebuilt Python. The rolling **`python3` apk packages** are replaced with **`python-3.13` / `python-3.13-dev`** in the builder and **`python-3.13`** in the runtime layer, and both **`uv sync`** steps now pass **`--python python3.13`** instead of `python3`. With **`UV_PYTHON_DOWNLOADS=0`** already set, the old combo failed at build time (`GLIBC_2.44` not found when inspecting `/usr/bin/python3`).
> 
> No change to migration runtime behavior beyond restoring a successful image build and deploy path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 39473745ddb6759b14397df3e9f9499e7b49ce0b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->