### PR TITLE
fix(proxy): surface runtime-registered callbacks in UI Logging page

### DIFF
--- a/litellm/litellm_core_utils/logging_callback_manager.py
+++ b/litellm/litellm_core_utils/logging_callback_manager.py
@@ -441,6 +441,14 @@ class LoggingCallbackManager:
 
         return result
 
+    def get_callback_objects(self) -> tuple[tuple[str, CustomLogger | Callable], ...]:
+        """Every non-string active callback paired with the name `get_callbacks_by_type` reports it under."""
+        return tuple(
+            (self._get_callback_string(callback), callback)
+            for callback in self._get_all_callbacks()
+            if not isinstance(callback, str)
+        )
+
     def _get_callback_string(self, callback: CustomLogger | Callable | str) -> str:
         from litellm.litellm_core_utils.custom_logger_registry import (
             CustomLoggerRegistry,

--- a/litellm/litellm_core_utils/logging_callback_manager.py
+++ b/litellm/litellm_core_utils/logging_callback_manager.py
@@ -442,7 +442,6 @@ class LoggingCallbackManager:
         return result
 
     def get_callback_objects(self) -> tuple[tuple[str, CustomLogger | Callable], ...]:
-        """Every non-string active callback paired with the name `get_callbacks_by_type` reports it under."""
         return tuple(
             (self._get_callback_string(callback), callback)
             for callback in self._get_all_callbacks()

--- a/litellm/litellm_core_utils/logging_callback_manager.py
+++ b/litellm/litellm_core_utils/logging_callback_manager.py
@@ -450,6 +450,7 @@ class LoggingCallbackManager:
         )
 
     def _get_callback_string(self, callback: CustomLogger | Callable | str) -> str:
+        from litellm.integrations.opentelemetry import OpenTelemetry
         from litellm.litellm_core_utils.custom_logger_registry import (
             CustomLoggerRegistry,
         )
@@ -457,6 +458,8 @@ class LoggingCallbackManager:
         """Convert a callback to its string representation"""
         if isinstance(callback, str):
             return callback
+        elif isinstance(callback, OpenTelemetry) and callback.callback_name is not None:
+            return callback.callback_name
         elif isinstance(callback, CustomLogger):
             # Try to get the string representation from the registry
             callback_str: Final = CustomLoggerRegistry.get_callback_str_from_class_type(type(callback))

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -17571,13 +17571,27 @@ def _callback_module_name(callback: CustomLogger | Callable[..., object]) -> str
     return type(callback).__module__
 
 
-def _is_litellm_internal_callback(callback: CustomLogger | Callable[..., object]) -> bool:
+def _is_litellm_internal_callback(callback_name: str, callback: CustomLogger | Callable[..., object]) -> bool:
     """Hooks litellm registers on its own (router, proxy, service logging) are not user logging callbacks."""
     from litellm.litellm_core_utils.custom_logger_registry import CustomLoggerRegistry
 
     module_owner: Final = _callback_module_name(callback).partition(".")[0]
-    is_registered_integration: Final = CustomLoggerRegistry.get_callback_str_from_class_type(type(callback)) is not None
+    is_registered_integration: Final = (
+        _normalize_callback_alias(callback_name) in CustomLoggerRegistry.CALLBACK_CLASS_STR_TO_CLASS_TYPE
+    )
     return not is_registered_integration and module_owner in ("litellm", "litellm_enterprise")
+
+
+def _is_instance_of_configured_callback(
+    callback_name: str, callback: CustomLogger | Callable[..., object], configured_classes: tuple[type, ...]
+) -> bool:
+    """A configured string callback is replaced at init by an instance that may only be identifiable by class
+    (`logfire` initializes a bare `OpenTelemetry`). An instance that names itself (`arize`, `weave_otel`) is
+    matched by name instead, so a configured OTel-family callback does not hide its YAML-configured siblings."""
+    from litellm.litellm_core_utils.custom_logger_registry import CustomLoggerRegistry
+
+    class_derived_name: Final = CustomLoggerRegistry.get_callback_str_from_class_type(type(callback))
+    return isinstance(callback, configured_classes) and callback_name in (class_derived_name, type(callback).__name__)
 
 
 def _hidden_runtime_callback_names(configured_callback_names: frozenset[str]) -> frozenset[str]:
@@ -17595,8 +17609,8 @@ def _hidden_runtime_callback_names(configured_callback_names: frozenset[str]) ->
         callback_name
         for callback_name, callback in litellm.logging_callback_manager.get_callback_objects()
         if isinstance(callback, CustomGuardrail)
-        or _is_litellm_internal_callback(callback)
-        or isinstance(callback, configured_classes)
+        or _is_litellm_internal_callback(callback_name, callback)
+        or _is_instance_of_configured_callback(callback_name, callback, configured_classes)
         or _callback_module_name(callback) in configured_modules
     )
 

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -17648,7 +17648,7 @@ async def get_config(
                 return (callback,)
             if callback is None:
                 return ()
-            return tuple(callback) if isinstance(callback, list) else ()
+            return tuple(callback) if isinstance(callback, (list, dict)) else ()
 
         _success_callbacks = normalize_callback(_success_callbacks)
         _failure_callbacks = normalize_callback(_failure_callbacks)

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -268,7 +268,7 @@ from litellm.constants import (
     WEEKLY_SPEND_REPORT_JOB_ID,
 )
 from litellm.exceptions import RejectedRequestError
-from litellm.integrations.custom_guardrail import ModifyResponseException
+from litellm.integrations.custom_guardrail import CustomGuardrail, ModifyResponseException
 from litellm.integrations.custom_logger import CustomLogger
 from litellm.integrations.SlackAlerting.slack_alerting import SlackAlerting
 from litellm.litellm_core_utils.agentic_loop_settings import (
@@ -17551,19 +17551,66 @@ async def delete_callback(
 
 
 def _normalize_callback_alias(callback_name: str) -> str:
-    """
-    Normalize callback name aliases to their canonical form for deduplication.
-    Examples: opentelemetry → otel, s3_v2 → s3, aws_sqs → sqs, custom_callback_api → generic_api.
-    """
-    if not isinstance(callback_name, str):
-        return str(callback_name)
-    _alias_map: Final[dict[str, str]] = {
-        "opentelemetry": "otel",
-        "s3_v2": "s3",
-        "aws_sqs": "sqs",
-        "custom_callback_api": "generic_api",
-    }
-    return _alias_map.get(callback_name, callback_name)
+    """Return the canonical callback name used for display and deduplication."""
+    callback_aliases: Final = (
+        ("opentelemetry", "otel"),
+        ("s3_v2", "s3"),
+        ("aws_sqs", "sqs"),
+        ("custom_callback_api", "generic_api"),
+    )
+    return next(
+        (canonical_name for alias, canonical_name in callback_aliases if alias == callback_name),
+        callback_name,
+    )
+
+
+def _callback_display_name(callback: CustomLogger) -> str:
+    """Return the name an active callback instance is displayed under."""
+    from litellm.litellm_core_utils.custom_logger_registry import CustomLoggerRegistry
+
+    return CustomLoggerRegistry.get_callback_str_from_class_type(type(callback)) or type(callback).__name__
+
+
+def _hidden_runtime_callback_names(configured_callback_names: frozenset[str]) -> frozenset[str]:
+    """Return runtime callback names that are guardrails or instances of an already configured callback."""
+    from litellm.litellm_core_utils.custom_logger_registry import CustomLoggerRegistry
+
+    guardrail_names: Final = frozenset(
+        _callback_display_name(guardrail)
+        for guardrail in litellm.logging_callback_manager.get_custom_loggers_for_type(CustomGuardrail)
+    )
+    configured_instance_names: Final = frozenset(
+        _callback_display_name(instance)
+        for configured_name in configured_callback_names
+        if configured_name in CustomLoggerRegistry.CALLBACK_CLASS_STR_TO_CLASS_TYPE
+        for instance in litellm.logging_callback_manager.get_custom_loggers_for_type(
+            CustomLoggerRegistry.CALLBACK_CLASS_STR_TO_CLASS_TYPE[configured_name]
+        )
+    )
+    return guardrail_names | configured_instance_names
+
+
+def _is_runtime_logging_callback(callback_name: str, hidden_callback_names: frozenset[str]) -> bool:
+    """Return whether a runtime callback name belongs in the logging inventory."""
+    internal_callback_names: Final = frozenset(
+        (
+            "_ProxyDBLogger",
+            "async_deployment_callback_on_failure",
+            "cache",
+            "deployment_callback_on_failure",
+            "deployment_callback_on_success",
+            "ResponsesIDSecurity",
+            "ServiceLogging",
+            "ShadowEvalLogger",
+            "SkillsInjectionHook",
+            "sync_deployment_callback_on_success",
+        )
+    )
+    return (
+        not callback_name.startswith("_PROXY_")
+        and callback_name not in internal_callback_names
+        and callback_name not in hidden_callback_names
+    )
 
 
 @router.get(
@@ -17598,14 +17645,10 @@ async def get_config(
         # Normalize string callbacks to lists
         def normalize_callback(callback):
             if isinstance(callback, str):
-                return [callback]
-            elif callback is None:
-                return []
-            elif isinstance(callback, list):
-                return callback
-            # Convert dict, tuple, set, or any other type to empty list
-            # (config validation should prevent non-list types, but guard here)
-            return []
+                return (callback,)
+            if callback is None:
+                return ()
+            return tuple(callback) if isinstance(callback, list) else ()
 
         _success_callbacks = normalize_callback(_success_callbacks)
         _failure_callbacks = normalize_callback(_failure_callbacks)
@@ -17636,55 +17679,51 @@ async def get_config(
         for _callback in _success_and_failure_callbacks:
             _data_to_return.append(process_callback(_callback, "success_and_failure", environment_variables))
 
-        # Append runtime-only callbacks (registered but not in config).
-        # Build a set of configured callback names (normalized for alias matching).
-        _configured_callback_names_normalized: Final[set] = set()
-        for _cb in _success_callbacks + _failure_callbacks + _success_and_failure_callbacks:
-            _normalized = _normalize_callback_alias(_cb)
-            _configured_callback_names_normalized.add(_normalized)
-
-        # Collect runtime-registered callbacks from LoggingCallbackManager.
-        try:
-            _runtime_callbacks_by_type = litellm.logging_callback_manager.get_callbacks_by_type()
-            # Flatten all runtime callbacks with their types.
-            _runtime_items: Final[list[tuple[str, str]]] = []
-            for _cb_name in _runtime_callbacks_by_type.get("success", []):
-                _runtime_items.append((_cb_name, "success"))
-            for _cb_name in _runtime_callbacks_by_type.get("failure", []):
-                _runtime_items.append((_cb_name, "failure"))
-            for _cb_name in _runtime_callbacks_by_type.get("success_and_failure", []):
-                _runtime_items.append((_cb_name, "success_and_failure"))
-
-            # Track normalized names of rows already added to avoid duplicates.
-            _added_normalized_names: Final[set] = set(_configured_callback_names_normalized)
-
-            # Append runtime-only rows (those not in config).
-            # Filter out internal proxy hooks (names starting with _PROXY or known internal names).
-            _internal_callback_prefixes: Final[tuple] = (
-                "_PROXY",
-                "_Async",
-                "ShadowEval",
-                "ServiceLogging",
-                "SkillsInjection",
-                "ResponsesID",
+        configured_callback_names: Final = frozenset(
+            _normalize_callback_alias(callback)
+            for callback in (_success_callbacks + _failure_callbacks + _success_and_failure_callbacks)
+        )
+        runtime_callback_types: Final = (
+            ("success", "success"),
+            ("failure", "failure"),
+            ("success_and_failure", "success_and_failure"),
+        )
+        runtime_callbacks_by_type: Final = litellm.logging_callback_manager.get_callbacks_by_type()
+        hidden_callback_names: Final = _hidden_runtime_callback_names(configured_callback_names)
+        runtime_callbacks: Final = tuple(
+            (callback, callback_mode)
+            for callback_type, callback_mode in runtime_callback_types
+            for callback in runtime_callbacks_by_type.get(callback_type, ())
+            if _is_runtime_logging_callback(callback, hidden_callback_names)
+        )
+        runtime_callback_rows: Final = tuple(
+            (
+                _normalize_callback_alias(callback),
+                callback_mode,
             )
-            for _runtime_cb_name, _runtime_cb_type in _runtime_items:
-                # Skip internal proxy callbacks (these are infrastructure, not user-configured).
-                if isinstance(_runtime_cb_name, str) and any(
-                    _runtime_cb_name.startswith(p) for p in _internal_callback_prefixes
-                ):
-                    continue
+            for callback, callback_mode in runtime_callbacks
+        )
+        unique_runtime_callback_rows: Final = tuple(
+            sorted(
+                (callback_name, callback_mode)
+                for index, (callback_name, callback_mode) in enumerate(runtime_callback_rows)
+                if callback_name not in configured_callback_names
+                and (callback_name, callback_mode) not in runtime_callback_rows[:index]
+            )
+        )
+        runtime_rows: Final = tuple(
+            dict(
+                process_callback(
+                    callback_name,
+                    callback_mode,
+                    environment_variables,
+                ),
+                read_only=True,
+            )
+            for callback_name, callback_mode in unique_runtime_callback_rows
+        )
 
-                _normalized_runtime = _normalize_callback_alias(_runtime_cb_name)
-                # Skip if this callback is in config or already appended.
-                if _normalized_runtime not in _added_normalized_names:
-                    _added_normalized_names.add(_normalized_runtime)
-                    _runtime_row = process_callback(_runtime_cb_name, _runtime_cb_type, environment_variables)
-                    _runtime_row["read_only"] = True
-                    _data_to_return.append(_runtime_row)
-        except Exception as _e:
-            # If runtime callback discovery fails, log but don't block the response.
-            verbose_proxy_logger.warning("Failed to append runtime callbacks to get_config response: %s", _e)
+        _data_to_return.extend(runtime_rows)
 
         _data_to_return = _apply_callback_role_gate(_data_to_return, is_full_admin)
 

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -17590,7 +17590,8 @@ def _hidden_runtime_callback_names(configured_callback_names: frozenset[str]) ->
         if name in CustomLoggerRegistry.CALLBACK_CLASS_STR_TO_CLASS_TYPE
     )
     configured_modules: Final = frozenset(name.rsplit(".", 1)[0] for name in configured_callback_names if "." in name)
-    return frozenset(
+    internal_callback_strings: Final = frozenset({"cache"})
+    return internal_callback_strings | frozenset(
         callback_name
         for callback_name, callback in litellm.logging_callback_manager.get_callback_objects()
         if isinstance(callback, CustomGuardrail)

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -17575,9 +17575,7 @@ def _is_litellm_internal_callback(callback_name: str, callback: CustomLogger | C
     from litellm.litellm_core_utils.custom_logger_registry import CustomLoggerRegistry
 
     module_owner: Final = _callback_module_name(callback).partition(".")[0]
-    is_registered_integration: Final = (
-        _normalize_callback_alias(callback_name) in CustomLoggerRegistry.CALLBACK_CLASS_STR_TO_CLASS_TYPE
-    )
+    is_registered_integration: Final = callback_name in CustomLoggerRegistry.CALLBACK_CLASS_STR_TO_CLASS_TYPE
     return not is_registered_integration and module_owner in ("litellm", "litellm_enterprise")
 
 

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -17671,13 +17671,22 @@ async def get_config(
         """
 
         for _callback in _success_callbacks:
-            _data_to_return.append(process_callback(_callback, "success", environment_variables))
+            row: Final = process_callback(_callback, "success", environment_variables)
+            if isinstance(_callback, str) and "." in _callback:
+                row["read_only"] = True
+            _data_to_return.append(row)
 
         for _callback in _failure_callbacks:
-            _data_to_return.append(process_callback(_callback, "failure", environment_variables))
+            row: Final = process_callback(_callback, "failure", environment_variables)
+            if isinstance(_callback, str) and "." in _callback:
+                row["read_only"] = True
+            _data_to_return.append(row)
 
         for _callback in _success_and_failure_callbacks:
-            _data_to_return.append(process_callback(_callback, "success_and_failure", environment_variables))
+            row: Final = process_callback(_callback, "success_and_failure", environment_variables)
+            if isinstance(_callback, str) and "." in _callback:
+                row["read_only"] = True
+            _data_to_return.append(row)
 
         configured_callback_names: Final = frozenset(
             _normalize_callback_alias(callback)

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -17587,7 +17587,15 @@ def _hidden_runtime_callback_names(configured_callback_names: frozenset[str]) ->
             CustomLoggerRegistry.CALLBACK_CLASS_STR_TO_CLASS_TYPE[configured_name]
         )
     )
-    return guardrail_names | configured_instance_names
+    configured_modules: Final = frozenset(
+        configured_name.rsplit(".", 1)[0] for configured_name in configured_callback_names if "." in configured_name
+    )
+    dotted_instance_names: Final = frozenset(
+        _callback_display_name(instance)
+        for instance in litellm.logging_callback_manager.get_custom_loggers_for_type(CustomLogger)
+        if type(instance).__module__ in configured_modules
+    )
+    return guardrail_names | configured_instance_names | dotted_instance_names
 
 
 def _is_runtime_logging_callback(callback_name: str, hidden_callback_names: frozenset[str]) -> bool:
@@ -17671,22 +17679,13 @@ async def get_config(
         """
 
         for _callback in _success_callbacks:
-            row: Final = process_callback(_callback, "success", environment_variables)
-            if isinstance(_callback, str) and "." in _callback:
-                row["read_only"] = True
-            _data_to_return.append(row)
+            _data_to_return.append(process_callback(_callback, "success", environment_variables))
 
         for _callback in _failure_callbacks:
-            row: Final = process_callback(_callback, "failure", environment_variables)
-            if isinstance(_callback, str) and "." in _callback:
-                row["read_only"] = True
-            _data_to_return.append(row)
+            _data_to_return.append(process_callback(_callback, "failure", environment_variables))
 
         for _callback in _success_and_failure_callbacks:
-            row: Final = process_callback(_callback, "success_and_failure", environment_variables)
-            if isinstance(_callback, str) and "." in _callback:
-                row["read_only"] = True
-            _data_to_return.append(row)
+            _data_to_return.append(process_callback(_callback, "success_and_failure", environment_variables))
 
         configured_callback_names: Final = frozenset(
             _normalize_callback_alias(callback)

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -17590,8 +17590,8 @@ def _hidden_runtime_callback_names(configured_callback_names: frozenset[str]) ->
         if name in CustomLoggerRegistry.CALLBACK_CLASS_STR_TO_CLASS_TYPE
     )
     configured_modules: Final = frozenset(name.rsplit(".", 1)[0] for name in configured_callback_names if "." in name)
-    internal_callback_strings: Final = frozenset({"cache"})
-    return internal_callback_strings | frozenset(
+    internal_callback_names: Final = frozenset({"cache", "vector_store_pre_call_hook"})
+    return internal_callback_names | frozenset(
         callback_name
         for callback_name, callback in litellm.logging_callback_manager.get_callback_objects()
         if isinstance(callback, CustomGuardrail)

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -17572,7 +17572,6 @@ def _callback_module_name(callback: CustomLogger | Callable[..., object]) -> str
 
 
 def _is_litellm_internal_callback(callback_name: str, callback: CustomLogger | Callable[..., object]) -> bool:
-    """Hooks litellm registers on its own (router, proxy, service logging) are not user logging callbacks."""
     from litellm.litellm_core_utils.custom_logger_registry import CustomLoggerRegistry
 
     module_owner: Final = _callback_module_name(callback).partition(".")[0]
@@ -17585,9 +17584,8 @@ def _is_litellm_internal_callback(callback_name: str, callback: CustomLogger | C
 def _is_instance_of_configured_callback(
     callback_name: str, callback: CustomLogger | Callable[..., object], configured_classes: tuple[type, ...]
 ) -> bool:
-    """A configured string callback is replaced at init by an instance that may only be identifiable by class
-    (`logfire` initializes a bare `OpenTelemetry`). An instance that names itself (`arize`, `weave_otel`) is
-    matched by name instead, so a configured OTel-family callback does not hide its YAML-configured siblings."""
+    """Self-naming OTel-family instances (`arize`, `weave_otel`) match by name, so a configured `logfire` (a bare
+    `OpenTelemetry`) does not hide YAML-configured siblings of the same class."""
     from litellm.litellm_core_utils.custom_logger_registry import CustomLoggerRegistry
 
     class_derived_name: Final = CustomLoggerRegistry.get_callback_str_from_class_type(type(callback))
@@ -17595,7 +17593,6 @@ def _is_instance_of_configured_callback(
 
 
 def _hidden_runtime_callback_names(configured_callback_names: frozenset[str]) -> frozenset[str]:
-    """Return runtime callback names that are internal hooks, guardrails, or instances of a configured callback."""
     from litellm.litellm_core_utils.custom_logger_registry import CustomLoggerRegistry
 
     configured_classes: Final = tuple(

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -17655,7 +17655,13 @@ async def get_config(
             _added_normalized_names: Final[set] = set(_configured_callback_names_normalized)
 
             # Append runtime-only rows (those not in config).
+            # Filter out internal proxy hooks (names starting with _PROXY or known internal names).
+            _internal_callback_prefixes: Final[tuple] = ("_PROXY", "_Async", "ShadowEval", "ServiceLogging", "SkillsInjection", "ResponsesID")
             for _runtime_cb_name, _runtime_cb_type in _runtime_items:
+                # Skip internal proxy callbacks (these are infrastructure, not user-configured).
+                if isinstance(_runtime_cb_name, str) and any(_runtime_cb_name.startswith(p) for p in _internal_callback_prefixes):
+                    continue
+
                 _normalized_runtime = _normalize_callback_alias(_runtime_cb_name)
                 # Skip if this callback is in config or already appended.
                 if _normalized_runtime not in _added_normalized_names:

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -17550,6 +17550,22 @@ async def delete_callback(
         )
 
 
+def _normalize_callback_alias(callback_name: str) -> str:
+    """
+    Normalize callback name aliases to their canonical form for deduplication.
+    Examples: opentelemetry → otel, s3_v2 → s3, aws_sqs → sqs, custom_callback_api → generic_api.
+    """
+    if not isinstance(callback_name, str):
+        return str(callback_name)
+    _alias_map: Final[dict[str, str]] = {
+        "opentelemetry": "otel",
+        "s3_v2": "s3",
+        "aws_sqs": "sqs",
+        "custom_callback_api": "generic_api",
+    }
+    return _alias_map.get(callback_name, callback_name)
+
+
 @router.get(
     "/get/config/callbacks",
     tags=["config.yaml"],
@@ -17615,6 +17631,41 @@ async def get_config(
 
         for _callback in _success_and_failure_callbacks:
             _data_to_return.append(process_callback(_callback, "success_and_failure", environment_variables))
+
+        # Append runtime-only callbacks (registered but not in config).
+        # Build a set of configured callback names (normalized for alias matching).
+        _configured_callback_names_normalized: Final[set] = set()
+        for _cb in _success_callbacks + _failure_callbacks + _success_and_failure_callbacks:
+            _normalized = _normalize_callback_alias(_cb)
+            _configured_callback_names_normalized.add(_normalized)
+
+        # Collect runtime-registered callbacks from LoggingCallbackManager.
+        try:
+            _runtime_callbacks_by_type = litellm.logging_callback_manager.get_callbacks_by_type()
+            # Flatten all runtime callbacks with their types.
+            _runtime_items: Final[list[tuple[str, str]]] = []
+            for _cb_name in _runtime_callbacks_by_type.get("success", []):
+                _runtime_items.append((_cb_name, "success"))
+            for _cb_name in _runtime_callbacks_by_type.get("failure", []):
+                _runtime_items.append((_cb_name, "failure"))
+            for _cb_name in _runtime_callbacks_by_type.get("success_and_failure", []):
+                _runtime_items.append((_cb_name, "success_and_failure"))
+
+            # Track normalized names of rows already added to avoid duplicates.
+            _added_normalized_names: Final[set] = set(_configured_callback_names_normalized)
+
+            # Append runtime-only rows (those not in config).
+            for _runtime_cb_name, _runtime_cb_type in _runtime_items:
+                _normalized_runtime = _normalize_callback_alias(_runtime_cb_name)
+                # Skip if this callback is in config or already appended.
+                if _normalized_runtime not in _added_normalized_names:
+                    _added_normalized_names.add(_normalized_runtime)
+                    _runtime_row = process_callback(_runtime_cb_name, _runtime_cb_type, environment_variables)
+                    _runtime_row["read_only"] = True
+                    _data_to_return.append(_runtime_row)
+        except Exception as _e:
+            # If runtime callback discovery fails, log but don't block the response.
+            verbose_proxy_logger.warning("Failed to append runtime callbacks to get_config response: %s", _e)
 
         _data_to_return = _apply_callback_role_gate(_data_to_return, is_full_admin)
 

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -17551,7 +17551,6 @@ async def delete_callback(
 
 
 def _normalize_callback_alias(callback_name: str) -> str:
-    """Return the canonical callback name used for display and deduplication."""
     callback_aliases: Final = (
         ("opentelemetry", "otel"),
         ("s3_v2", "s3"),
@@ -17564,60 +17563,40 @@ def _normalize_callback_alias(callback_name: str) -> str:
     )
 
 
-def _callback_display_name(callback: CustomLogger) -> str:
-    """Return the name an active callback instance is displayed under."""
+def _callback_module_name(callback: CustomLogger | Callable[..., object]) -> str:
+    if inspect.ismethod(callback):
+        return callback.__func__.__module__
+    if inspect.isfunction(callback):
+        return callback.__module__
+    return type(callback).__module__
+
+
+def _is_litellm_internal_callback(callback: CustomLogger | Callable[..., object]) -> bool:
+    """Hooks litellm registers on its own (router, proxy, service logging) are not user logging callbacks."""
     from litellm.litellm_core_utils.custom_logger_registry import CustomLoggerRegistry
 
-    return CustomLoggerRegistry.get_callback_str_from_class_type(type(callback)) or type(callback).__name__
+    module_owner: Final = _callback_module_name(callback).partition(".")[0]
+    is_registered_integration: Final = CustomLoggerRegistry.get_callback_str_from_class_type(type(callback)) is not None
+    return not is_registered_integration and module_owner in ("litellm", "litellm_enterprise")
 
 
 def _hidden_runtime_callback_names(configured_callback_names: frozenset[str]) -> frozenset[str]:
-    """Return runtime callback names that are guardrails or instances of an already configured callback."""
+    """Return runtime callback names that are internal hooks, guardrails, or instances of a configured callback."""
     from litellm.litellm_core_utils.custom_logger_registry import CustomLoggerRegistry
 
-    guardrail_names: Final = frozenset(
-        _callback_display_name(guardrail)
-        for guardrail in litellm.logging_callback_manager.get_custom_loggers_for_type(CustomGuardrail)
+    configured_classes: Final = tuple(
+        CustomLoggerRegistry.CALLBACK_CLASS_STR_TO_CLASS_TYPE[name]
+        for name in configured_callback_names
+        if name in CustomLoggerRegistry.CALLBACK_CLASS_STR_TO_CLASS_TYPE
     )
-    configured_instance_names: Final = frozenset(
-        _callback_display_name(instance)
-        for configured_name in configured_callback_names
-        if configured_name in CustomLoggerRegistry.CALLBACK_CLASS_STR_TO_CLASS_TYPE
-        for instance in litellm.logging_callback_manager.get_custom_loggers_for_type(
-            CustomLoggerRegistry.CALLBACK_CLASS_STR_TO_CLASS_TYPE[configured_name]
-        )
-    )
-    configured_modules: Final = frozenset(
-        configured_name.rsplit(".", 1)[0] for configured_name in configured_callback_names if "." in configured_name
-    )
-    dotted_instance_names: Final = frozenset(
-        _callback_display_name(instance)
-        for instance in litellm.logging_callback_manager.get_custom_loggers_for_type(CustomLogger)
-        if type(instance).__module__ in configured_modules
-    )
-    return guardrail_names | configured_instance_names | dotted_instance_names
-
-
-def _is_runtime_logging_callback(callback_name: str, hidden_callback_names: frozenset[str]) -> bool:
-    """Return whether a runtime callback name belongs in the logging inventory."""
-    internal_callback_names: Final = frozenset(
-        (
-            "_ProxyDBLogger",
-            "async_deployment_callback_on_failure",
-            "cache",
-            "deployment_callback_on_failure",
-            "deployment_callback_on_success",
-            "ResponsesIDSecurity",
-            "ServiceLogging",
-            "ShadowEvalLogger",
-            "SkillsInjectionHook",
-            "sync_deployment_callback_on_success",
-        )
-    )
-    return (
-        not callback_name.startswith("_PROXY_")
-        and callback_name not in internal_callback_names
-        and callback_name not in hidden_callback_names
+    configured_modules: Final = frozenset(name.rsplit(".", 1)[0] for name in configured_callback_names if "." in name)
+    return frozenset(
+        callback_name
+        for callback_name, callback in litellm.logging_callback_manager.get_callback_objects()
+        if isinstance(callback, CustomGuardrail)
+        or _is_litellm_internal_callback(callback)
+        or isinstance(callback, configured_classes)
+        or _callback_module_name(callback) in configured_modules
     )
 
 
@@ -17691,47 +17670,25 @@ async def get_config(
             _normalize_callback_alias(callback)
             for callback in (_success_callbacks + _failure_callbacks + _success_and_failure_callbacks)
         )
-        runtime_callback_types: Final = (
-            ("success", "success"),
-            ("failure", "failure"),
-            ("success_and_failure", "success_and_failure"),
-        )
         runtime_callbacks_by_type: Final = litellm.logging_callback_manager.get_callbacks_by_type()
         hidden_callback_names: Final = _hidden_runtime_callback_names(configured_callback_names)
-        runtime_callbacks: Final = tuple(
-            (callback, callback_mode)
-            for callback_type, callback_mode in runtime_callback_types
-            for callback in runtime_callbacks_by_type.get(callback_type, ())
-            if _is_runtime_logging_callback(callback, hidden_callback_names)
-        )
         runtime_callback_rows: Final = tuple(
-            (
-                _normalize_callback_alias(callback),
-                callback_mode,
+            (_normalize_callback_alias(callback_name), callback_type)
+            for callback_type, callback_names in (
+                ("success", runtime_callbacks_by_type["success"]),
+                ("failure", runtime_callbacks_by_type["failure"]),
+                ("success_and_failure", runtime_callbacks_by_type["success_and_failure"]),
             )
-            for callback, callback_mode in runtime_callbacks
+            for callback_name in callback_names
+            if callback_name not in hidden_callback_names
         )
-        unique_runtime_callback_rows: Final = tuple(
-            sorted(
-                (callback_name, callback_mode)
-                for index, (callback_name, callback_mode) in enumerate(runtime_callback_rows)
-                if callback_name not in configured_callback_names
-                and (callback_name, callback_mode) not in runtime_callback_rows[:index]
-            )
+        runtime_only_rows: Final = sorted(
+            frozenset(row for row in runtime_callback_rows if row[0] not in configured_callback_names)
         )
-        runtime_rows: Final = tuple(
-            dict(
-                process_callback(
-                    callback_name,
-                    callback_mode,
-                    environment_variables,
-                ),
-                read_only=True,
-            )
-            for callback_name, callback_mode in unique_runtime_callback_rows
+        _data_to_return.extend(
+            dict(process_callback(callback_name, callback_type, environment_variables), read_only=True)
+            for callback_name, callback_type in runtime_only_rows
         )
-
-        _data_to_return.extend(runtime_rows)
 
         _data_to_return = _apply_callback_role_gate(_data_to_return, is_full_admin)
 

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -17601,7 +17601,11 @@ async def get_config(
                 return [callback]
             elif callback is None:
                 return []
-            return callback
+            elif isinstance(callback, list):
+                return callback
+            # Convert dict, tuple, set, or any other type to empty list
+            # (config validation should prevent non-list types, but guard here)
+            return []
 
         _success_callbacks = normalize_callback(_success_callbacks)
         _failure_callbacks = normalize_callback(_failure_callbacks)
@@ -17656,10 +17660,19 @@ async def get_config(
 
             # Append runtime-only rows (those not in config).
             # Filter out internal proxy hooks (names starting with _PROXY or known internal names).
-            _internal_callback_prefixes: Final[tuple] = ("_PROXY", "_Async", "ShadowEval", "ServiceLogging", "SkillsInjection", "ResponsesID")
+            _internal_callback_prefixes: Final[tuple] = (
+                "_PROXY",
+                "_Async",
+                "ShadowEval",
+                "ServiceLogging",
+                "SkillsInjection",
+                "ResponsesID",
+            )
             for _runtime_cb_name, _runtime_cb_type in _runtime_items:
                 # Skip internal proxy callbacks (these are infrastructure, not user-configured).
-                if isinstance(_runtime_cb_name, str) and any(_runtime_cb_name.startswith(p) for p in _internal_callback_prefixes):
+                if isinstance(_runtime_cb_name, str) and any(
+                    _runtime_cb_name.startswith(p) for p in _internal_callback_prefixes
+                ):
                     continue
 
                 _normalized_runtime = _normalize_callback_alias(_runtime_cb_name)

--- a/tests/proxy_unit_tests/test_proxy_server.py
+++ b/tests/proxy_unit_tests/test_proxy_server.py
@@ -2922,18 +2922,21 @@ async def test_get_config_callbacks_with_all_types(client_no_auth):
 
         callbacks = result["callbacks"]
 
-        # Verify we have all 5 callbacks (2 success + 1 failure + 2 success_and_failure)
-        assert len(callbacks) == 5
+        # Filter out internal/runtime-only callbacks (read_only=True) to test configured callbacks
+        configured_callbacks = [cb for cb in callbacks if not cb.get("read_only", False)]
 
-        # Group callbacks by type
-        success_callbacks = [cb for cb in callbacks if cb.get("type") == "success"]
-        failure_callbacks = [cb for cb in callbacks if cb.get("type") == "failure"]
+        # Verify we have all 5 configured callbacks (2 success + 1 failure + 2 success_and_failure)
+        assert len(configured_callbacks) == 5
+
+        # Group callbacks by type (configured only)
+        success_callbacks = [cb for cb in configured_callbacks if cb.get("type") == "success"]
+        failure_callbacks = [cb for cb in configured_callbacks if cb.get("type") == "failure"]
         success_and_failure_callbacks = [
-            cb for cb in callbacks if cb.get("type") == "success_and_failure"
+            cb for cb in configured_callbacks if cb.get("type") == "success_and_failure"
         ]
 
-        # Verify all callbacks have required fields
-        for callback in callbacks:
+        # Verify all configured callbacks have required fields
+        for callback in configured_callbacks:
             assert "name" in callback
             assert "variables" in callback
             assert "type" in callback

--- a/tests/proxy_unit_tests/test_proxy_server.py
+++ b/tests/proxy_unit_tests/test_proxy_server.py
@@ -2920,23 +2920,20 @@ async def test_get_config_callbacks_with_all_types(client_no_auth):
         assert result["status"] == "success"
         assert "callbacks" in result
 
-        callbacks = result["callbacks"]
+        callbacks = [cb for cb in result["callbacks"] if not cb.get("read_only", False)]
 
-        # Filter out internal/runtime-only callbacks (read_only=True) to test configured callbacks
-        configured_callbacks = [cb for cb in callbacks if not cb.get("read_only", False)]
+        # Verify we have all 5 callbacks (2 success + 1 failure + 2 success_and_failure)
+        assert len(callbacks) == 5
 
-        # Verify we have all 5 configured callbacks (2 success + 1 failure + 2 success_and_failure)
-        assert len(configured_callbacks) == 5
-
-        # Group callbacks by type (configured only)
-        success_callbacks = [cb for cb in configured_callbacks if cb.get("type") == "success"]
-        failure_callbacks = [cb for cb in configured_callbacks if cb.get("type") == "failure"]
+        # Group callbacks by type
+        success_callbacks = [cb for cb in callbacks if cb.get("type") == "success"]
+        failure_callbacks = [cb for cb in callbacks if cb.get("type") == "failure"]
         success_and_failure_callbacks = [
-            cb for cb in configured_callbacks if cb.get("type") == "success_and_failure"
+            cb for cb in callbacks if cb.get("type") == "success_and_failure"
         ]
 
-        # Verify all configured callbacks have required fields
-        for callback in configured_callbacks:
+        # Verify all callbacks have required fields
+        for callback in callbacks:
             assert "name" in callback
             assert "variables" in callback
             assert "type" in callback

--- a/tests/test_litellm/proxy/proxy_server/test_routes_config.py
+++ b/tests/test_litellm/proxy/proxy_server/test_routes_config.py
@@ -1306,6 +1306,7 @@ def test_get_config_callbacks_excludes_internal_runtime_callbacks(client, auth_a
         pass
 
     router = Router(model_list=[])
+    monkeypatch.setattr(litellm, "input_callback", [])
     monkeypatch.setattr(litellm, "success_callback", [LangsmithLogger(), router.sync_deployment_callback_on_success])
     monkeypatch.setattr(litellm, "_async_success_callback", [router.deployment_callback_on_success])
     monkeypatch.setattr(litellm, "failure_callback", [user_code_function])
@@ -1321,6 +1322,8 @@ def test_get_config_callbacks_excludes_internal_runtime_callbacks(client, auth_a
             _UserCodeLogger(),
         ],
     )
+    monkeypatch.setattr(litellm, "cache", litellm.Cache(type="local"))
+    assert "cache" in litellm.success_callback and "cache" in litellm._async_success_callback
 
     with auth_as(LitellmUserRoles.PROXY_ADMIN):
         response = client.get("/get/config/callbacks")

--- a/tests/test_litellm/proxy/proxy_server/test_routes_config.py
+++ b/tests/test_litellm/proxy/proxy_server/test_routes_config.py
@@ -1204,6 +1204,61 @@ def test_get_config_callbacks_deduplicates_configured_and_runtime(client, auth_a
     assert {callback["name"] for callback in callbacks} == {"langfuse"}
 
 
+def test_get_config_callbacks_deduplicates_dotted_path_callback(client, auth_as, mock_prisma, monkeypatch):
+    """A dotted-path callback stays a single editable row instead of duplicating under its class name."""
+    from litellm.proxy import proxy_server as ps
+    from litellm.proxy._types import LitellmUserRoles
+
+    _install_litellm_config(mock_prisma)
+    monkeypatch.setattr(ps, "prisma_client", mock_prisma)
+    monkeypatch.setattr(ps, "llm_router", None)
+
+    import litellm
+    from litellm.integrations.custom_logger import CustomLogger
+
+    class _DottedPathTestHandler(CustomLogger):
+        pass
+
+    dotted_handler = _DottedPathTestHandler()
+    dotted_path = f"{__name__}.dotted_handler"
+
+    fake_proxy_config = MagicMock()
+    fake_proxy_config.get_config = AsyncMock(
+        return_value={
+            "litellm_settings": {"success_callback": [dotted_path]},
+            "general_settings": {},
+            "environment_variables": dict(_CALLBACK_ENV_FIXTURE),
+        }
+    )
+    monkeypatch.setattr(ps, "proxy_config", fake_proxy_config)
+
+    monkeypatch.setattr(litellm, "callbacks", [dotted_handler])
+    monkeypatch.setattr(litellm, "success_callback", [])
+    monkeypatch.setattr(litellm, "failure_callback", [])
+    monkeypatch.setattr(litellm, "_async_success_callback", [])
+    monkeypatch.setattr(litellm, "_async_failure_callback", [])
+    monkeypatch.setattr(
+        litellm.logging_callback_manager,
+        "get_callbacks_by_type",
+        MagicMock(
+            return_value={
+                "success": [],
+                "failure": [],
+                "success_and_failure": ["_DottedPathTestHandler"],
+            }
+        ),
+    )
+
+    with auth_as(LitellmUserRoles.PROXY_ADMIN):
+        response = client.get("/get/config/callbacks")
+
+    assert response.status_code == 200
+    callbacks = response.json()["callbacks"]
+    assert [(callback["name"], callback["type"], callback.get("read_only", False)) for callback in callbacks] == [
+        (dotted_path, "success", False)
+    ]
+
+
 def test_get_config_callbacks_lists_dict_shaped_config_callbacks(client, auth_as, mock_prisma, monkeypatch):
     """Dict-shaped success_callback config values list their keys as editable rows."""
     from litellm.proxy import proxy_server as ps

--- a/tests/test_litellm/proxy/proxy_server/test_routes_config.py
+++ b/tests/test_litellm/proxy/proxy_server/test_routes_config.py
@@ -1194,31 +1194,28 @@ def test_get_config_callbacks_appends_runtime_only_callbacks(
     # Mock runtime callbacks: register otel in addition to langfuse in config.
     import litellm
 
-    original = litellm.callbacks
-    try:
-        litellm.callbacks = ["otel"]
-        with auth_as(LitellmUserRoles.PROXY_ADMIN):
-            response = client.get("/get/config/callbacks")
-        assert response.status_code == 200
-        body = response.json()
+    monkeypatch.setattr(litellm, "callbacks", ["otel"])
 
-        callbacks = body["callbacks"]
-        callback_names = [cb["name"] for cb in callbacks]
+    with auth_as(LitellmUserRoles.PROXY_ADMIN):
+        response = client.get("/get/config/callbacks")
+    assert response.status_code == 200
+    body = response.json()
 
-        # Both should be present
-        assert "langfuse" in callback_names
-        assert "otel" in callback_names
+    callbacks = body["callbacks"]
+    callback_names = [cb["name"] for cb in callbacks]
 
-        # Configured callback should NOT be marked read_only
-        langfuse_cb = next(cb for cb in callbacks if cb["name"] == "langfuse")
-        assert langfuse_cb.get("read_only") != True
+    # Both should be present
+    assert "langfuse" in callback_names
+    assert "otel" in callback_names
 
-        # Runtime-only callback should be marked read_only
-        otel_cb = next(cb for cb in callbacks if cb["name"] == "otel")
-        assert otel_cb["read_only"] is True
-        assert otel_cb["type"] == "success_and_failure"
-    finally:
-        litellm.callbacks = original
+    # Configured callback should NOT be marked read_only
+    langfuse_cb = next(cb for cb in callbacks if cb["name"] == "langfuse")
+    assert langfuse_cb.get("read_only") != True
+
+    # Runtime-only callback should be marked read_only
+    otel_cb = next(cb for cb in callbacks if cb["name"] == "otel")
+    assert otel_cb["read_only"] is True
+    assert otel_cb["type"] == "success_and_failure"
 
 
 def test_get_config_callbacks_deduplicates_configured_and_runtime(
@@ -1288,36 +1285,33 @@ def test_get_config_callbacks_redacts_runtime_only_row_secrets_for_view_only_adm
     # Mock runtime: register otel
     import litellm
 
-    original = litellm.callbacks
-    try:
-        litellm.callbacks = ["otel"]
-        # View-only admin
-        with auth_as(LitellmUserRoles.PROXY_ADMIN_VIEW_ONLY):
-            response = client.get("/get/config/callbacks")
-        assert response.status_code == 200
-        body = response.json()
+    monkeypatch.setattr(litellm, "callbacks", ["otel"])
 
-        callbacks = body["callbacks"]
-        otel_cb = next((cb for cb in callbacks if cb["name"] == "otel"), None)
-        assert otel_cb is not None
+    # View-only admin
+    with auth_as(LitellmUserRoles.PROXY_ADMIN_VIEW_ONLY):
+        response = client.get("/get/config/callbacks")
+    assert response.status_code == 200
+    body = response.json()
 
-        # Secret env vars must be redacted
-        assert otel_cb["variables"]["OTEL_HEADERS"] == "REDACTED"
-        # Non-secret vars should pass through
-        assert otel_cb["variables"]["OTEL_ENDPOINT"] == _CALLBACK_ENV_FIXTURE["OTEL_ENDPOINT"]
+    callbacks = body["callbacks"]
+    otel_cb = next((cb for cb in callbacks if cb["name"] == "otel"), None)
+    assert otel_cb is not None
 
-        # Full admin sees secrets
-        with auth_as(LitellmUserRoles.PROXY_ADMIN):
-            admin_response = client.get("/get/config/callbacks")
-        assert admin_response.status_code == 200
-        admin_body = admin_response.json()
-        admin_otel = next(
-            (cb for cb in admin_body["callbacks"] if cb["name"] == "otel"), None
-        )
-        assert admin_otel is not None
-        assert admin_otel["variables"]["OTEL_HEADERS"] == _CALLBACK_ENV_FIXTURE["OTEL_HEADERS"]
-    finally:
-        litellm.callbacks = original
+    # Secret env vars must be redacted
+    assert otel_cb["variables"]["OTEL_HEADERS"] == "REDACTED"
+    # Non-secret vars should pass through
+    assert otel_cb["variables"]["OTEL_ENDPOINT"] == _CALLBACK_ENV_FIXTURE["OTEL_ENDPOINT"]
+
+    # Full admin sees secrets
+    with auth_as(LitellmUserRoles.PROXY_ADMIN):
+        admin_response = client.get("/get/config/callbacks")
+    assert admin_response.status_code == 200
+    admin_body = admin_response.json()
+    admin_otel = next(
+        (cb for cb in admin_body["callbacks"] if cb["name"] == "otel"), None
+    )
+    assert admin_otel is not None
+    assert admin_otel["variables"]["OTEL_HEADERS"] == _CALLBACK_ENV_FIXTURE["OTEL_HEADERS"]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_litellm/proxy/proxy_server/test_routes_config.py
+++ b/tests/test_litellm/proxy/proxy_server/test_routes_config.py
@@ -1135,6 +1135,45 @@ def test_get_config_callbacks_appends_runtime_only_callbacks(client, auth_as, mo
     ]
 
 
+def test_get_config_callbacks_accepts_scalar_and_null_yaml_callbacks(client, auth_as, mock_prisma, monkeypatch):
+    """`success_callback: langfuse` (a YAML scalar) is one configured callback, not eight single-letter ones, and a
+    `callbacks: null` key contributes nothing."""
+    from litellm.proxy import proxy_server as ps
+    from litellm.proxy._types import LitellmUserRoles
+
+    _install_litellm_config(mock_prisma)
+    monkeypatch.setattr(ps, "prisma_client", mock_prisma)
+    monkeypatch.setattr(ps, "llm_router", None)
+
+    fake_proxy_config = MagicMock()
+    fake_proxy_config.get_config = AsyncMock(
+        return_value={
+            "litellm_settings": {"success_callback": "langfuse", "failure_callback": None, "callbacks": None},
+            "general_settings": {},
+            "environment_variables": dict(_CALLBACK_ENV_FIXTURE),
+        }
+    )
+    monkeypatch.setattr(ps, "proxy_config", fake_proxy_config)
+
+    import litellm
+    from litellm.integrations.langsmith import LangsmithLogger
+
+    monkeypatch.setattr(litellm, "success_callback", ["langfuse", LangsmithLogger()])
+    monkeypatch.setattr(litellm, "_async_success_callback", [])
+    monkeypatch.setattr(litellm, "failure_callback", [])
+    monkeypatch.setattr(litellm, "_async_failure_callback", [])
+    monkeypatch.setattr(litellm, "callbacks", [])
+
+    with auth_as(LitellmUserRoles.PROXY_ADMIN):
+        response = client.get("/get/config/callbacks")
+    assert response.status_code == 200
+
+    assert [(cb["name"], cb["type"], cb.get("read_only", False)) for cb in response.json()["callbacks"]] == [
+        ("langfuse", "success", False),
+        ("langsmith", "success", True),
+    ]
+
+
 def test_get_config_callbacks_deduplicates_configured_and_runtime(client, auth_as, mock_prisma, monkeypatch):
     """A configured callback shows once as editable, whether the runtime holds its string or an initialized instance
     (arize initializes an ArizeLogger, logfire a bare OpenTelemetry that only its class identifies)."""
@@ -1347,6 +1386,8 @@ def test_get_config_callbacks_excludes_internal_runtime_callbacks(client, auth_a
     )
     monkeypatch.setattr(ps, "proxy_config", fake_proxy_config)
 
+    from litellm_enterprise.proxy.hooks.managed_files import _PROXY_LiteLLMManagedFiles
+
     import litellm
     from litellm._service_logger import ServiceLogging
     from litellm.integrations.custom_guardrail import CustomGuardrail
@@ -1355,7 +1396,6 @@ def test_get_config_callbacks_excludes_internal_runtime_callbacks(client, auth_a
     from litellm.integrations.vector_store_integrations.vector_store_pre_call_hook import VectorStorePreCallHook
     from litellm.proxy.hooks.max_budget_limiter import _PROXY_MaxBudgetLimiter
     from litellm.router import Router
-    from litellm_enterprise.proxy.hooks.managed_files import _PROXY_LiteLLMManagedFiles
 
     class _InventoryTestGuardrail(CustomGuardrail):
         pass

--- a/tests/test_litellm/proxy/proxy_server/test_routes_config.py
+++ b/tests/test_litellm/proxy/proxy_server/test_routes_config.py
@@ -229,10 +229,7 @@ def test_config_update_no_db_error(client, auth_as, monkeypatch):
             json={"general_settings": {"alerting": ["slack"]}},
         )
     assert response.status_code != 200
-    assert (
-        "db" in str(response.json()).lower()
-        or "connect" in str(response.json()).lower()
-    )
+    assert "db" in str(response.json()).lower() or "connect" in str(response.json()).lower()
 
 
 # ---------------------------------------------------------------------------
@@ -273,9 +270,7 @@ def test_config_field_update_happy_admin(client, auth_as, mock_prisma, monkeypat
     }
 
 
-def test_config_field_update_non_admin_rejected(
-    client, auth_as, mock_prisma, monkeypatch
-):
+def test_config_field_update_non_admin_rejected(client, auth_as, mock_prisma, monkeypatch):
     """Non-admin cannot update config fields — returns 400 with not-allowed
     detail (handler uses 400 for the auth gate, not 403)."""
     from litellm.proxy import proxy_server as ps
@@ -335,9 +330,7 @@ def test_config_field_info_happy_admin(client, auth_as, mock_prisma, monkeypatch
     monkeypatch.setattr(ps, "prisma_client", mock_prisma)
 
     with auth_as(LitellmUserRoles.PROXY_ADMIN):
-        response = client.get(
-            "/config/field/info", params={"field_name": "max_parallel_requests"}
-        )
+        response = client.get("/config/field/info", params={"field_name": "max_parallel_requests"})
     assert response.status_code == 200
     assert normalize(response.json()) == {
         "field_name": "max_parallel_requests",
@@ -345,9 +338,7 @@ def test_config_field_info_happy_admin(client, auth_as, mock_prisma, monkeypatch
     }
 
 
-def test_config_field_info_non_admin_rejected(
-    client, auth_as, mock_prisma, monkeypatch
-):
+def test_config_field_info_non_admin_rejected(client, auth_as, mock_prisma, monkeypatch):
     """Non-admin (INTERNAL_USER) is denied — admin-view gate fires."""
     from litellm.proxy import proxy_server as ps
     from litellm.proxy._types import LitellmUserRoles
@@ -356,9 +347,7 @@ def test_config_field_info_non_admin_rejected(
     monkeypatch.setattr(ps, "prisma_client", mock_prisma)
 
     with auth_as(LitellmUserRoles.INTERNAL_USER):
-        response = client.get(
-            "/config/field/info", params={"field_name": "max_parallel_requests"}
-        )
+        response = client.get("/config/field/info", params={"field_name": "max_parallel_requests"})
     assert response.status_code == 400
     assert "error" in response.json().get("detail", {})
 
@@ -375,16 +364,12 @@ def test_config_field_info_field_not_in_db(client, auth_as, mock_prisma, monkeyp
     monkeypatch.setattr(ps, "prisma_client", mock_prisma)
 
     with auth_as(LitellmUserRoles.PROXY_ADMIN):
-        response = client.get(
-            "/config/field/info", params={"field_name": "max_parallel_requests"}
-        )
+        response = client.get("/config/field/info", params={"field_name": "max_parallel_requests"})
     assert response.status_code == 400
     assert "not in DB" in response.json().get("detail", {}).get("error", "")
 
 
-def test_config_field_info_redacts_nested_secret_for_view_only_admin(
-    client, auth_as, mock_prisma, monkeypatch
-):
+def test_config_field_info_redacts_nested_secret_for_view_only_admin(client, auth_as, mock_prisma, monkeypatch):
     """A view-only admin reading a structured field must not receive nested
     credentials. database_args carries aws_web_identity_token (a DynamoDB
     role-assumption credential); it must come back redacted while non-secret
@@ -405,9 +390,7 @@ def test_config_field_info_redacts_nested_secret_for_view_only_admin(
     monkeypatch.setattr(ps, "prisma_client", mock_prisma)
 
     with auth_as(LitellmUserRoles.PROXY_ADMIN_VIEW_ONLY):
-        response = client.get(
-            "/config/field/info", params={"field_name": "database_args"}
-        )
+        response = client.get("/config/field/info", params={"field_name": "database_args"})
     assert response.status_code == 200
     value = response.json()["field_value"]
     assert value["aws_web_identity_token"] == "REDACTED"
@@ -415,9 +398,7 @@ def test_config_field_info_redacts_nested_secret_for_view_only_admin(
     assert value["user_table_name"] == "LiteLLM_UserTable"
 
 
-def test_config_field_info_full_admin_sees_nested_secret(
-    client, auth_as, mock_prisma, monkeypatch
-):
+def test_config_field_info_full_admin_sees_nested_secret(client, auth_as, mock_prisma, monkeypatch):
     """The redaction must not over-redact for a full PROXY_ADMIN, who needs
     the real nested value to populate the edit form."""
     from litellm.proxy import proxy_server as ps
@@ -435,18 +416,14 @@ def test_config_field_info_full_admin_sees_nested_secret(
     monkeypatch.setattr(ps, "prisma_client", mock_prisma)
 
     with auth_as(LitellmUserRoles.PROXY_ADMIN):
-        response = client.get(
-            "/config/field/info", params={"field_name": "database_args"}
-        )
+        response = client.get("/config/field/info", params={"field_name": "database_args"})
     assert response.status_code == 200
     value = response.json()["field_value"]
     assert value["aws_web_identity_token"] == "sk-super-secret-token"
     assert value["region_name"] == "us-east-1"
 
 
-def test_config_field_info_redacts_top_level_scalar_for_view_only(
-    client, auth_as, mock_prisma, monkeypatch
-):
+def test_config_field_info_redacts_top_level_scalar_for_view_only(client, auth_as, mock_prisma, monkeypatch):
     """The top-level scalar branch must also redact for a view-only admin.
     database_url carries DB credentials and is not caught by the name masker,
     so it is in the explicit secret set."""
@@ -460,9 +437,7 @@ def test_config_field_info_redacts_top_level_scalar_for_view_only(
     monkeypatch.setattr(ps, "prisma_client", mock_prisma)
 
     with auth_as(LitellmUserRoles.PROXY_ADMIN_VIEW_ONLY):
-        response = client.get(
-            "/config/field/info", params={"field_name": "database_url"}
-        )
+        response = client.get("/config/field/info", params={"field_name": "database_url"})
     assert response.status_code == 200
     assert response.json()["field_value"] == "REDACTED"
 
@@ -476,17 +451,12 @@ def test_redact_general_setting_value_recurses_list_of_dicts():
         {"path": "/foo", "headers": {"Authorization": "Bearer sk-x"}},
         {"path": "/bar", "client_secret": "sk-y"},
     ]
-    redacted = ps._redact_general_setting_value(
-        "some_list_field", value, is_full_admin=False
-    )
+    redacted = ps._redact_general_setting_value("some_list_field", value, is_full_admin=False)
     assert redacted[0]["headers"]["Authorization"] == "REDACTED"
     assert redacted[0]["path"] == "/foo"
     assert redacted[1]["client_secret"] == "REDACTED"
     assert redacted[1]["path"] == "/bar"
-    assert (
-        ps._redact_general_setting_value("some_list_field", value, is_full_admin=True)
-        == value
-    )
+    assert ps._redact_general_setting_value("some_list_field", value, is_full_admin=True) == value
 
 
 def test_redact_secret_values_in_obj_fails_closed_at_max_depth():
@@ -504,22 +474,16 @@ def test_redact_secret_values_in_obj_fails_closed_at_max_depth():
     for _ in range(ps._REDACT_SECRET_MAX_DEPTH + 2):
         nested = {"wrap": nested}
 
-    out = ps._redact_general_setting_value(
-        "some_struct_field", nested, is_full_admin=False
-    )
+    out = ps._redact_general_setting_value("some_struct_field", nested, is_full_admin=False)
     # the secret must not survive anywhere in the returned tree
     assert "sk-leak-bottom" not in repr(out)
 
     # full admin is unaffected by the cap — the value comes back untouched
-    admin_out = ps._redact_general_setting_value(
-        "some_struct_field", nested, is_full_admin=True
-    )
+    admin_out = ps._redact_general_setting_value("some_struct_field", nested, is_full_admin=True)
     assert admin_out is nested
 
 
-def test_config_list_redacts_pass_through_secret_for_view_only(
-    client, auth_as, mock_prisma, monkeypatch
-):
+def test_config_list_redacts_pass_through_secret_for_view_only(client, auth_as, mock_prisma, monkeypatch):
     """/config/list must not leak pass_through_endpoints upstream credentials
     to a view-only admin. pass_through_endpoints is a known secret-bearing
     field, so a non-admin gets it redacted; a full admin still sees it."""
@@ -546,24 +510,16 @@ def test_config_list_redacts_pass_through_secret_for_view_only(
     )
 
     def _pass_through_value(body):
-        return next(
-            entry["field_value"]
-            for entry in body
-            if entry["field_name"] == "pass_through_endpoints"
-        )
+        return next(entry["field_value"] for entry in body if entry["field_name"] == "pass_through_endpoints")
 
     with auth_as(LitellmUserRoles.PROXY_ADMIN_VIEW_ONLY):
-        view_resp = client.get(
-            "/config/list", params={"config_type": "general_settings"}
-        )
+        view_resp = client.get("/config/list", params={"config_type": "general_settings"})
     assert view_resp.status_code == 200
     assert "sk-UPSTREAM-SECRET" not in view_resp.text
     assert _pass_through_value(view_resp.json()) == "REDACTED"
 
     with auth_as(LitellmUserRoles.PROXY_ADMIN):
-        admin_resp = client.get(
-            "/config/list", params={"config_type": "general_settings"}
-        )
+        admin_resp = client.get("/config/list", params={"config_type": "general_settings"})
     assert admin_resp.status_code == 200
     admin_value = _pass_through_value(admin_resp.json())
     assert admin_value[0]["headers"]["Authorization"] == "Bearer sk-UPSTREAM-SECRET"
@@ -587,9 +543,7 @@ def test_config_list_happy_admin(client, auth_as, mock_prisma, monkeypatch):
     monkeypatch.setattr(ps, "prisma_client", mock_prisma)
 
     with auth_as(LitellmUserRoles.PROXY_ADMIN):
-        response = client.get(
-            "/config/list", params={"config_type": "general_settings"}
-        )
+        response = client.get("/config/list", params={"config_type": "general_settings"})
     assert response.status_code == 200
     body = response.json()
     assert isinstance(body, list)
@@ -695,9 +649,7 @@ def test_config_list_non_admin_rejected(client, auth_as, mock_prisma, monkeypatc
     monkeypatch.setattr(ps, "prisma_client", mock_prisma)
 
     with auth_as(LitellmUserRoles.INTERNAL_USER):
-        response = client.get(
-            "/config/list", params={"config_type": "general_settings"}
-        )
+        response = client.get("/config/list", params={"config_type": "general_settings"})
     assert response.status_code == 400
     assert "role" in response.json().get("detail", {}).get("error", "").lower()
 
@@ -710,9 +662,7 @@ def test_config_list_no_db_error(client, auth_as, monkeypatch):
     monkeypatch.setattr(ps, "prisma_client", None)
 
     with auth_as(LitellmUserRoles.PROXY_ADMIN):
-        response = client.get(
-            "/config/list", params={"config_type": "general_settings"}
-        )
+        response = client.get("/config/list", params={"config_type": "general_settings"})
     assert response.status_code == 400
     assert "error" in response.json().get("detail", {})
 
@@ -756,9 +706,7 @@ def test_config_field_delete_happy_admin(client, auth_as, mock_prisma, monkeypat
     }
 
 
-def test_config_field_delete_non_admin_rejected(
-    client, auth_as, mock_prisma, monkeypatch
-):
+def test_config_field_delete_non_admin_rejected(client, auth_as, mock_prisma, monkeypatch):
     """Non-admin caller hits the 400 not-allowed branch with role in detail."""
     from litellm.proxy import proxy_server as ps
     from litellm.proxy._types import LitellmUserRoles
@@ -778,9 +726,7 @@ def test_config_field_delete_non_admin_rejected(
     assert "role" in response.json().get("detail", {}).get("error", "").lower()
 
 
-def test_config_field_delete_field_not_in_config(
-    client, auth_as, mock_prisma, monkeypatch
-):
+def test_config_field_delete_field_not_in_config(client, auth_as, mock_prisma, monkeypatch):
     """If there is no general_settings row at all, returns 400 'not in config'."""
     from litellm.proxy import proxy_server as ps
     from litellm.proxy._types import LitellmUserRoles
@@ -825,9 +771,7 @@ def test_config_callback_delete_happy_admin(client, auth_as, mock_prisma, monkey
     monkeypatch.setattr(ps, "proxy_config", fake_proxy_config)
 
     with auth_as(LitellmUserRoles.PROXY_ADMIN):
-        response = client.post(
-            "/config/callback/delete", json={"callback_name": "langfuse"}
-        )
+        response = client.post("/config/callback/delete", json={"callback_name": "langfuse"})
     assert response.status_code == 200
     # `deleted_at` is an ISO timestamp generated at request time — extend
     # the volatile set just for this assertion so dict-equality still works.
@@ -840,9 +784,7 @@ def test_config_callback_delete_happy_admin(client, auth_as, mock_prisma, monkey
     }
 
 
-def test_config_callback_delete_non_admin_rejected(
-    client, auth_as, mock_prisma, monkeypatch
-):
+def test_config_callback_delete_non_admin_rejected(client, auth_as, mock_prisma, monkeypatch):
     """Non-admin caller is rejected with 400 not-allowed."""
     from litellm.proxy import proxy_server as ps
     from litellm.proxy._types import LitellmUserRoles
@@ -852,9 +794,7 @@ def test_config_callback_delete_non_admin_rejected(
     monkeypatch.setattr(ps, "store_model_in_db", True)
 
     with auth_as(LitellmUserRoles.INTERNAL_USER):
-        response = client.post(
-            "/config/callback/delete", json={"callback_name": "langfuse"}
-        )
+        response = client.post("/config/callback/delete", json={"callback_name": "langfuse"})
     assert response.status_code == 400
     assert "role" in response.json().get("detail", {}).get("error", "").lower()
 
@@ -869,22 +809,15 @@ def test_config_callback_delete_not_found(client, auth_as, mock_prisma, monkeypa
     monkeypatch.setattr(ps, "store_model_in_db", True)
 
     fake_proxy_config = MagicMock()
-    fake_proxy_config.get_config = AsyncMock(
-        return_value={"litellm_settings": {"success_callback": ["slack"]}}
-    )
+    fake_proxy_config.get_config = AsyncMock(return_value={"litellm_settings": {"success_callback": ["slack"]}})
     monkeypatch.setattr(ps, "proxy_config", fake_proxy_config)
 
     with auth_as(LitellmUserRoles.PROXY_ADMIN):
-        response = client.post(
-            "/config/callback/delete", json={"callback_name": "langfuse"}
-        )
+        response = client.post("/config/callback/delete", json={"callback_name": "langfuse"})
     # The handler re-raises HTTPException(404) verbatim (only generic
     # `Exception` becomes a 500 ProxyException), so pin 404 strictly.
     assert response.status_code == 404
-    assert (
-        "langfuse" in str(response.json()).lower()
-        or "not found" in str(response.json()).lower()
-    )
+    assert "langfuse" in str(response.json()).lower() or "not found" in str(response.json()).lower()
 
 
 # ---------------------------------------------------------------------------
@@ -948,10 +881,7 @@ def test_get_config_callbacks_internal_error(client, auth_as, mock_prisma, monke
     with auth_as(LitellmUserRoles.PROXY_ADMIN):
         response = client.get("/get/config/callbacks")
     assert response.status_code >= 400
-    assert (
-        "boom" in str(response.json()).lower()
-        or "error" in str(response.json()).lower()
-    )
+    assert "boom" in str(response.json()).lower() or "error" in str(response.json()).lower()
 
 
 _CALLBACK_ENV_FIXTURE = {
@@ -985,14 +915,10 @@ def _install_callbacks_config(monkeypatch, mock_prisma):
 
 
 def _callback_variables(body: dict, name: str) -> dict:
-    return next(
-        cb["variables"] for cb in body["callbacks"] if cb["name"] == name
-    )
+    return next(cb["variables"] for cb in body["callbacks"] if cb["name"] == name)
 
 
-def test_get_config_callbacks_redacts_secret_env_vars_for_view_only_admin(
-    client, auth_as, mock_prisma, monkeypatch
-):
+def test_get_config_callbacks_redacts_secret_env_vars_for_view_only_admin(client, auth_as, mock_prisma, monkeypatch):
     from litellm.proxy._types import LitellmUserRoles
 
     _install_callbacks_config(monkeypatch, mock_prisma)
@@ -1024,9 +950,7 @@ def test_get_config_callbacks_redacts_secret_env_vars_for_view_only_admin(
     assert otel_vars["OTEL_ENDPOINT"] == _CALLBACK_ENV_FIXTURE["OTEL_ENDPOINT"]
 
 
-def test_get_config_callbacks_full_admin_still_sees_secret_env_vars(
-    client, auth_as, mock_prisma, monkeypatch
-):
+def test_get_config_callbacks_full_admin_still_sees_secret_env_vars(client, auth_as, mock_prisma, monkeypatch):
     from litellm.proxy._types import LitellmUserRoles
 
     _install_callbacks_config(monkeypatch, mock_prisma)
@@ -1047,9 +971,7 @@ def test_get_config_callbacks_full_admin_still_sees_secret_env_vars(
     assert otel_vars["OTEL_HEADERS"] == _CALLBACK_ENV_FIXTURE["OTEL_HEADERS"]
 
 
-def test_get_config_callbacks_redacts_slack_webhook_urls_for_view_only_admin(
-    client, auth_as, mock_prisma, monkeypatch
-):
+def test_get_config_callbacks_redacts_slack_webhook_urls_for_view_only_admin(client, auth_as, mock_prisma, monkeypatch):
     from litellm.proxy import proxy_server as ps
     from litellm.proxy._types import LitellmUserRoles
 
@@ -1170,9 +1092,7 @@ def test_get_config_callbacks_redacts_email_alerting_vars_for_view_only_admin(
     assert admin_email["SMTP_HOST"] == "smtp.resend.com"
 
 
-def test_get_config_callbacks_appends_runtime_only_callbacks(
-    client, auth_as, mock_prisma, monkeypatch
-):
+def test_get_config_callbacks_appends_runtime_only_callbacks(client, auth_as, mock_prisma, monkeypatch):
     """Runtime-registered callbacks (not in config) are appended as read_only rows."""
     from litellm.proxy import proxy_server as ps
     from litellm.proxy._types import LitellmUserRoles
@@ -1195,6 +1115,17 @@ def test_get_config_callbacks_appends_runtime_only_callbacks(
     import litellm
 
     monkeypatch.setattr(litellm, "callbacks", ["otel"])
+    monkeypatch.setattr(
+        litellm.logging_callback_manager,
+        "get_callbacks_by_type",
+        MagicMock(
+            return_value={
+                "success": [],
+                "failure": [],
+                "success_and_failure": ["otel"],
+            }
+        ),
+    )
 
     with auth_as(LitellmUserRoles.PROXY_ADMIN):
         response = client.get("/get/config/callbacks")
@@ -1210,17 +1141,16 @@ def test_get_config_callbacks_appends_runtime_only_callbacks(
 
     # Configured callback should NOT be marked read_only
     langfuse_cb = next(cb for cb in callbacks if cb["name"] == "langfuse")
-    assert langfuse_cb.get("read_only") != True
+    assert not langfuse_cb.get("read_only")
 
     # Runtime-only callback should be marked read_only
     otel_cb = next(cb for cb in callbacks if cb["name"] == "otel")
     assert otel_cb["read_only"] is True
     assert otel_cb["type"] == "success_and_failure"
+    assert {callback["name"] for callback in callbacks} == {"langfuse", "otel"}
 
 
-def test_get_config_callbacks_deduplicates_configured_and_runtime(
-    client, auth_as, mock_prisma, monkeypatch
-):
+def test_get_config_callbacks_deduplicates_configured_and_runtime(client, auth_as, mock_prisma, monkeypatch):
     """When same callback is in both config and runtime, show only once as configured."""
     from litellm.proxy import proxy_server as ps
     from litellm.proxy._types import LitellmUserRoles
@@ -1242,23 +1172,96 @@ def test_get_config_callbacks_deduplicates_configured_and_runtime(
     # Mock runtime: same callback registered that is also in config
     import litellm
 
-    original = litellm.success_callback
-    try:
-        litellm.success_callback = ["langfuse"]
-        with auth_as(LitellmUserRoles.PROXY_ADMIN):
-            response = client.get("/get/config/callbacks")
-        assert response.status_code == 200
-        body = response.json()
+    monkeypatch.setattr(litellm, "success_callback", ["langfuse"])
+    monkeypatch.setattr(litellm, "callbacks", [])
+    monkeypatch.setattr(litellm, "failure_callback", [])
+    monkeypatch.setattr(litellm, "_async_success_callback", [])
+    monkeypatch.setattr(litellm, "_async_failure_callback", [])
+    monkeypatch.setattr(
+        litellm.logging_callback_manager,
+        "get_callbacks_by_type",
+        MagicMock(
+            return_value={
+                "success": ["langfuse"],
+                "failure": [],
+                "success_and_failure": [],
+            }
+        ),
+    )
 
-        callbacks = body["callbacks"]
-        langfuse_rows = [cb for cb in callbacks if cb["name"] == "langfuse"]
+    with auth_as(LitellmUserRoles.PROXY_ADMIN):
+        response = client.get("/get/config/callbacks")
+    assert response.status_code == 200
+    body = response.json()
 
-        # Should appear exactly once, not duplicated
-        assert len(langfuse_rows) == 1
-        # And it should NOT be marked read_only (it's in config)
-        assert langfuse_rows[0].get("read_only") != True
-    finally:
-        litellm.success_callback = original
+    callbacks = body["callbacks"]
+    langfuse_rows = [cb for cb in callbacks if cb["name"] == "langfuse"]
+
+    # Should appear exactly once, not duplicated
+    assert len(langfuse_rows) == 1
+    # And it should NOT be marked read_only (it's in config)
+    assert not langfuse_rows[0].get("read_only")
+    assert {callback["name"] for callback in callbacks} == {"langfuse"}
+
+
+def test_get_config_callbacks_excludes_internal_runtime_callbacks(client, auth_as, mock_prisma, monkeypatch):
+    """Proxy infrastructure callbacks are excluded from callback inventory."""
+    from litellm.proxy import proxy_server as ps
+    from litellm.proxy._types import LitellmUserRoles
+
+    _install_litellm_config(mock_prisma)
+    monkeypatch.setattr(ps, "prisma_client", mock_prisma)
+    monkeypatch.setattr(ps, "llm_router", None)
+
+    fake_proxy_config = MagicMock()
+    fake_proxy_config.get_config = AsyncMock(
+        return_value={
+            "litellm_settings": {"success_callback": []},
+            "general_settings": {},
+            "environment_variables": dict(_CALLBACK_ENV_FIXTURE),
+        }
+    )
+    monkeypatch.setattr(ps, "proxy_config", fake_proxy_config)
+
+    import litellm
+    from litellm.integrations.custom_guardrail import CustomGuardrail
+
+    class _InventoryTestGuardrail(CustomGuardrail):
+        pass
+
+    monkeypatch.setattr(
+        litellm.logging_callback_manager,
+        "get_callbacks_by_type",
+        MagicMock(
+            return_value={
+                "success": ["langsmith", "deployment_callback_on_success", "cache"],
+                "failure": ["deployment_callback_on_failure"],
+                "success_and_failure": ["_ProxyDBLogger", "SkillsInjectionHook", "_InventoryTestGuardrail"],
+            }
+        ),
+    )
+    monkeypatch.setattr(
+        litellm.logging_callback_manager,
+        "get_custom_loggers_for_type",
+        MagicMock(return_value=[_InventoryTestGuardrail(guardrail_name="inventory-test-guardrail")]),
+    )
+
+    with auth_as(LitellmUserRoles.PROXY_ADMIN):
+        response = client.get("/get/config/callbacks")
+
+    assert response.status_code == 200
+    assert response.json()["callbacks"] == [
+        {
+            "name": "langsmith",
+            "variables": {
+                "LANGSMITH_API_KEY": None,
+                "LANGSMITH_PROJECT": None,
+                "LANGSMITH_DEFAULT_RUN_NAME": None,
+            },
+            "type": "success",
+            "read_only": True,
+        },
+    ]
 
 
 def test_get_config_callbacks_redacts_runtime_only_row_secrets_for_view_only_admin(
@@ -1286,6 +1289,17 @@ def test_get_config_callbacks_redacts_runtime_only_row_secrets_for_view_only_adm
     import litellm
 
     monkeypatch.setattr(litellm, "callbacks", ["otel"])
+    monkeypatch.setattr(
+        litellm.logging_callback_manager,
+        "get_callbacks_by_type",
+        MagicMock(
+            return_value={
+                "success": [],
+                "failure": [],
+                "success_and_failure": ["otel"],
+            }
+        ),
+    )
 
     # View-only admin
     with auth_as(LitellmUserRoles.PROXY_ADMIN_VIEW_ONLY):
@@ -1307,9 +1321,7 @@ def test_get_config_callbacks_redacts_runtime_only_row_secrets_for_view_only_adm
         admin_response = client.get("/get/config/callbacks")
     assert admin_response.status_code == 200
     admin_body = admin_response.json()
-    admin_otel = next(
-        (cb for cb in admin_body["callbacks"] if cb["name"] == "otel"), None
-    )
+    admin_otel = next((cb for cb in admin_body["callbacks"] if cb["name"] == "otel"), None)
     assert admin_otel is not None
     assert admin_otel["variables"]["OTEL_HEADERS"] == _CALLBACK_ENV_FIXTURE["OTEL_HEADERS"]
 
@@ -1327,9 +1339,7 @@ def test_config_yaml_returns_demo_payload(client, auth_as):
         response = client.request("GET", "/config/yaml", json={})
     shape = {
         "status": response.status_code,
-        "media_type_yaml": response.headers.get("content-type", "").startswith(
-            "application/json"
-        ),
+        "media_type_yaml": response.headers.get("content-type", "").startswith("application/json"),
         "has_body": len(response.content) > 0,
     }
     assert shape == {

--- a/tests/test_litellm/proxy/proxy_server/test_routes_config.py
+++ b/tests/test_litellm/proxy/proxy_server/test_routes_config.py
@@ -1204,6 +1204,41 @@ def test_get_config_callbacks_deduplicates_configured_and_runtime(client, auth_a
     assert {callback["name"] for callback in callbacks} == {"langfuse"}
 
 
+def test_get_config_callbacks_lists_dict_shaped_config_callbacks(client, auth_as, mock_prisma, monkeypatch):
+    """Dict-shaped success_callback config values list their keys as editable rows."""
+    from litellm.proxy import proxy_server as ps
+    from litellm.proxy._types import LitellmUserRoles
+
+    _install_litellm_config(mock_prisma)
+    monkeypatch.setattr(ps, "prisma_client", mock_prisma)
+    monkeypatch.setattr(ps, "llm_router", None)
+
+    fake_proxy_config = MagicMock()
+    fake_proxy_config.get_config = AsyncMock(
+        return_value={
+            "litellm_settings": {"success_callback": {"langsmith": {"batch_size": 1}}},
+            "general_settings": {},
+            "environment_variables": dict(_CALLBACK_ENV_FIXTURE),
+        }
+    )
+    monkeypatch.setattr(ps, "proxy_config", fake_proxy_config)
+
+    import litellm
+
+    monkeypatch.setattr(
+        litellm.logging_callback_manager,
+        "get_callbacks_by_type",
+        MagicMock(return_value={"success": ["langsmith"], "failure": [], "success_and_failure": []}),
+    )
+
+    with auth_as(LitellmUserRoles.PROXY_ADMIN):
+        response = client.get("/get/config/callbacks")
+
+    assert response.status_code == 200
+    callbacks = response.json()["callbacks"]
+    assert [(callback["name"], callback.get("read_only", False)) for callback in callbacks] == [("langsmith", False)]
+
+
 def test_get_config_callbacks_excludes_internal_runtime_callbacks(client, auth_as, mock_prisma, monkeypatch):
     """Proxy infrastructure callbacks are excluded from callback inventory."""
     from litellm.proxy import proxy_server as ps

--- a/tests/test_litellm/proxy/proxy_server/test_routes_config.py
+++ b/tests/test_litellm/proxy/proxy_server/test_routes_config.py
@@ -1292,6 +1292,7 @@ def test_get_config_callbacks_excludes_internal_runtime_callbacks(client, auth_a
     from litellm.integrations.custom_guardrail import CustomGuardrail
     from litellm.integrations.custom_logger import CustomLogger
     from litellm.integrations.langsmith import LangsmithLogger
+    from litellm.integrations.vector_store_integrations.vector_store_pre_call_hook import VectorStorePreCallHook
     from litellm.proxy.hooks.max_budget_limiter import _PROXY_MaxBudgetLimiter
     from litellm.router import Router
     from litellm_enterprise.proxy.hooks.managed_files import _PROXY_LiteLLMManagedFiles
@@ -1318,6 +1319,7 @@ def test_get_config_callbacks_excludes_internal_runtime_callbacks(client, auth_a
             _PROXY_MaxBudgetLimiter(),
             _PROXY_LiteLLMManagedFiles(internal_usage_cache=MagicMock(), prisma_client=MagicMock()),
             ServiceLogging(),
+            VectorStorePreCallHook(),
             _InventoryTestGuardrail(guardrail_name="inventory-test-guardrail"),
             _UserCodeLogger(),
         ],

--- a/tests/test_litellm/proxy/proxy_server/test_routes_config.py
+++ b/tests/test_litellm/proxy/proxy_server/test_routes_config.py
@@ -1095,7 +1095,8 @@ def test_get_config_callbacks_redacts_email_alerting_vars_for_view_only_admin(
 
 
 def test_get_config_callbacks_appends_runtime_only_callbacks(client, auth_as, mock_prisma, monkeypatch):
-    """Runtime-registered callbacks (not in config) are appended as read_only rows."""
+    """LIT-5281: a YAML callback that the DB callback list replaced in the merged config still runs, so it must
+    show up as a read_only row next to the editable DB-configured one."""
     from litellm.proxy import proxy_server as ps
     from litellm.proxy._types import LitellmUserRoles
 
@@ -1113,47 +1114,30 @@ def test_get_config_callbacks_appends_runtime_only_callbacks(client, auth_as, mo
     )
     monkeypatch.setattr(ps, "proxy_config", fake_proxy_config)
 
-    # Mock runtime callbacks: register otel in addition to langfuse in config.
     import litellm
+    from litellm.integrations.langsmith import LangsmithLogger
+    from litellm.integrations.opentelemetry import OpenTelemetry
 
-    monkeypatch.setattr(litellm, "callbacks", ["otel"])
-    monkeypatch.setattr(
-        litellm.logging_callback_manager,
-        "get_callbacks_by_type",
-        MagicMock(
-            return_value={
-                "success": [],
-                "failure": [],
-                "success_and_failure": ["otel"],
-            }
-        ),
-    )
+    monkeypatch.setattr(litellm, "success_callback", ["langfuse", LangsmithLogger()])
+    monkeypatch.setattr(litellm, "_async_success_callback", [])
+    monkeypatch.setattr(litellm, "failure_callback", [])
+    monkeypatch.setattr(litellm, "_async_failure_callback", [])
+    monkeypatch.setattr(litellm, "callbacks", [OpenTelemetry()])
 
     with auth_as(LitellmUserRoles.PROXY_ADMIN):
         response = client.get("/get/config/callbacks")
     assert response.status_code == 200
-    body = response.json()
 
-    callbacks = body["callbacks"]
-    callback_names = [cb["name"] for cb in callbacks]
-
-    # Both should be present
-    assert "langfuse" in callback_names
-    assert "otel" in callback_names
-
-    # Configured callback should NOT be marked read_only
-    langfuse_cb = next(cb for cb in callbacks if cb["name"] == "langfuse")
-    assert not langfuse_cb.get("read_only")
-
-    # Runtime-only callback should be marked read_only
-    otel_cb = next(cb for cb in callbacks if cb["name"] == "otel")
-    assert otel_cb["read_only"] is True
-    assert otel_cb["type"] == "success_and_failure"
-    assert {callback["name"] for callback in callbacks} == {"langfuse", "otel"}
+    assert [(cb["name"], cb["type"], cb.get("read_only", False)) for cb in response.json()["callbacks"]] == [
+        ("langfuse", "success", False),
+        ("langsmith", "success", True),
+        ("otel", "success_and_failure", True),
+    ]
 
 
 def test_get_config_callbacks_deduplicates_configured_and_runtime(client, auth_as, mock_prisma, monkeypatch):
-    """When same callback is in both config and runtime, show only once as configured."""
+    """A configured callback shows once as editable, whether the runtime holds its string or an initialized instance
+    registered under a different alias (arize initializes an OpenTelemetry instance)."""
     from litellm.proxy import proxy_server as ps
     from litellm.proxy._types import LitellmUserRoles
 
@@ -1164,48 +1148,37 @@ def test_get_config_callbacks_deduplicates_configured_and_runtime(client, auth_a
     fake_proxy_config = MagicMock()
     fake_proxy_config.get_config = AsyncMock(
         return_value={
-            "litellm_settings": {"success_callback": ["langfuse"]},
+            "litellm_settings": {"success_callback": ["langfuse", "arize"]},
             "general_settings": {},
             "environment_variables": dict(_CALLBACK_ENV_FIXTURE),
         }
     )
     monkeypatch.setattr(ps, "proxy_config", fake_proxy_config)
 
-    # Mock runtime: same callback registered that is also in config
     import litellm
+    from litellm.integrations.opentelemetry import OpenTelemetry
 
-    monkeypatch.setattr(litellm, "success_callback", ["langfuse"])
+    monkeypatch.setattr(litellm, "success_callback", ["langfuse", OpenTelemetry()])
     monkeypatch.setattr(litellm, "callbacks", [])
     monkeypatch.setattr(litellm, "failure_callback", [])
     monkeypatch.setattr(litellm, "_async_success_callback", [])
     monkeypatch.setattr(litellm, "_async_failure_callback", [])
-    monkeypatch.setattr(
-        litellm.logging_callback_manager,
-        "get_callbacks_by_type",
-        MagicMock(
-            return_value={
-                "success": ["langfuse"],
-                "failure": [],
-                "success_and_failure": [],
-            }
-        ),
-    )
 
     with auth_as(LitellmUserRoles.PROXY_ADMIN):
         response = client.get("/get/config/callbacks")
     assert response.status_code == 200
-    body = response.json()
 
-    callbacks = body["callbacks"]
-    langfuse_rows = [cb for cb in callbacks if cb["name"] == "langfuse"]
-
-    # Should appear exactly once, not duplicated
-    assert len(langfuse_rows) == 1
-    # And it should NOT be marked read_only (it's in config)
-    assert not langfuse_rows[0].get("read_only")
-    assert {callback["name"] for callback in callbacks} == {"langfuse"}
+    assert [(cb["name"], cb["type"], cb.get("read_only", False)) for cb in response.json()["callbacks"]] == [
+        ("langfuse", "success", False),
+        ("arize", "success", False),
+    ]
 
 
+def _dotted_path_test_function(*args, **kwargs):
+    pass
+
+
+@pytest.mark.parametrize("handler_kind", ["instance", "function"])
 @pytest.mark.parametrize(
     "config_key,expected_type",
     [
@@ -1215,9 +1188,9 @@ def test_get_config_callbacks_deduplicates_configured_and_runtime(client, auth_a
     ],
 )
 def test_get_config_callbacks_deduplicates_dotted_path_callback(
-    client, auth_as, mock_prisma, monkeypatch, config_key, expected_type
+    client, auth_as, mock_prisma, monkeypatch, config_key, expected_type, handler_kind
 ):
-    """A dotted-path callback stays a single editable row instead of duplicating under its class name."""
+    """A dotted-path callback stays a single editable row instead of duplicating under its class or function name."""
     from litellm.proxy import proxy_server as ps
     from litellm.proxy._types import LitellmUserRoles
 
@@ -1231,7 +1204,7 @@ def test_get_config_callbacks_deduplicates_dotted_path_callback(
     class _DottedPathTestHandler(CustomLogger):
         pass
 
-    dotted_handler = _DottedPathTestHandler()
+    dotted_handler = _DottedPathTestHandler() if handler_kind == "instance" else _dotted_path_test_function
     dotted_path = f"{__name__}.dotted_handler"
 
     fake_proxy_config = MagicMock()
@@ -1249,17 +1222,6 @@ def test_get_config_callbacks_deduplicates_dotted_path_callback(
     monkeypatch.setattr(litellm, "failure_callback", [])
     monkeypatch.setattr(litellm, "_async_success_callback", [])
     monkeypatch.setattr(litellm, "_async_failure_callback", [])
-    monkeypatch.setattr(
-        litellm.logging_callback_manager,
-        "get_callbacks_by_type",
-        MagicMock(
-            return_value={
-                "success": [],
-                "failure": [],
-                "success_and_failure": ["_DottedPathTestHandler"],
-            }
-        ),
-    )
 
     with auth_as(LitellmUserRoles.PROXY_ADMIN):
         response = client.get("/get/config/callbacks")
@@ -1326,43 +1288,50 @@ def test_get_config_callbacks_excludes_internal_runtime_callbacks(client, auth_a
     monkeypatch.setattr(ps, "proxy_config", fake_proxy_config)
 
     import litellm
+    from litellm._service_logger import ServiceLogging
     from litellm.integrations.custom_guardrail import CustomGuardrail
+    from litellm.integrations.custom_logger import CustomLogger
+    from litellm.integrations.langsmith import LangsmithLogger
+    from litellm.proxy.hooks.max_budget_limiter import _PROXY_MaxBudgetLimiter
+    from litellm.router import Router
+    from litellm_enterprise.proxy.hooks.managed_files import _PROXY_LiteLLMManagedFiles
 
     class _InventoryTestGuardrail(CustomGuardrail):
         pass
 
+    class _UserCodeLogger(CustomLogger):
+        pass
+
+    def user_code_function(*args, **kwargs):
+        pass
+
+    router = Router(model_list=[])
+    monkeypatch.setattr(litellm, "success_callback", [LangsmithLogger(), router.sync_deployment_callback_on_success])
+    monkeypatch.setattr(litellm, "_async_success_callback", [router.deployment_callback_on_success])
+    monkeypatch.setattr(litellm, "failure_callback", [user_code_function])
+    monkeypatch.setattr(litellm, "_async_failure_callback", [router.async_deployment_callback_on_failure])
     monkeypatch.setattr(
-        litellm.logging_callback_manager,
-        "get_callbacks_by_type",
-        MagicMock(
-            return_value={
-                "success": ["langsmith", "deployment_callback_on_success", "cache"],
-                "failure": ["deployment_callback_on_failure"],
-                "success_and_failure": ["_ProxyDBLogger", "SkillsInjectionHook", "_InventoryTestGuardrail"],
-            }
-        ),
-    )
-    monkeypatch.setattr(
-        litellm.logging_callback_manager,
-        "get_custom_loggers_for_type",
-        MagicMock(return_value=[_InventoryTestGuardrail(guardrail_name="inventory-test-guardrail")]),
+        litellm,
+        "callbacks",
+        [
+            _PROXY_MaxBudgetLimiter(),
+            _PROXY_LiteLLMManagedFiles(internal_usage_cache=MagicMock(), prisma_client=MagicMock()),
+            ServiceLogging(),
+            _InventoryTestGuardrail(guardrail_name="inventory-test-guardrail"),
+            _UserCodeLogger(),
+        ],
     )
 
     with auth_as(LitellmUserRoles.PROXY_ADMIN):
         response = client.get("/get/config/callbacks")
 
     assert response.status_code == 200
-    assert response.json()["callbacks"] == [
-        {
-            "name": "langsmith",
-            "variables": {
-                "LANGSMITH_API_KEY": None,
-                "LANGSMITH_PROJECT": None,
-                "LANGSMITH_DEFAULT_RUN_NAME": None,
-            },
-            "type": "success",
-            "read_only": True,
-        },
+    assert [
+        (callback["name"], callback["type"], callback["read_only"]) for callback in response.json()["callbacks"]
+    ] == [
+        ("_UserCodeLogger", "success_and_failure", True),
+        ("langsmith", "success", True),
+        ("user_code_function", "failure", True),
     ]
 
 
@@ -1387,23 +1356,14 @@ def test_get_config_callbacks_redacts_runtime_only_row_secrets_for_view_only_adm
     )
     monkeypatch.setattr(ps, "proxy_config", fake_proxy_config)
 
-    # Mock runtime: register otel
     import litellm
 
+    monkeypatch.setattr(litellm, "success_callback", [])
+    monkeypatch.setattr(litellm, "_async_success_callback", [])
+    monkeypatch.setattr(litellm, "failure_callback", [])
+    monkeypatch.setattr(litellm, "_async_failure_callback", [])
     monkeypatch.setattr(litellm, "callbacks", ["otel"])
-    monkeypatch.setattr(
-        litellm.logging_callback_manager,
-        "get_callbacks_by_type",
-        MagicMock(
-            return_value={
-                "success": [],
-                "failure": [],
-                "success_and_failure": ["otel"],
-            }
-        ),
-    )
 
-    # View-only admin
     with auth_as(LitellmUserRoles.PROXY_ADMIN_VIEW_ONLY):
         response = client.get("/get/config/callbacks")
     assert response.status_code == 200
@@ -1412,13 +1372,11 @@ def test_get_config_callbacks_redacts_runtime_only_row_secrets_for_view_only_adm
     callbacks = body["callbacks"]
     otel_cb = next((cb for cb in callbacks if cb["name"] == "otel"), None)
     assert otel_cb is not None
-
-    # Secret env vars must be redacted
+    assert otel_cb["type"] == "success_and_failure"
+    assert otel_cb["read_only"] is True
     assert otel_cb["variables"]["OTEL_HEADERS"] == "REDACTED"
-    # Non-secret vars should pass through
     assert otel_cb["variables"]["OTEL_ENDPOINT"] == _CALLBACK_ENV_FIXTURE["OTEL_ENDPOINT"]
 
-    # Full admin sees secrets
     with auth_as(LitellmUserRoles.PROXY_ADMIN):
         admin_response = client.get("/get/config/callbacks")
     assert admin_response.status_code == 200

--- a/tests/test_litellm/proxy/proxy_server/test_routes_config.py
+++ b/tests/test_litellm/proxy/proxy_server/test_routes_config.py
@@ -1170,6 +1170,156 @@ def test_get_config_callbacks_redacts_email_alerting_vars_for_view_only_admin(
     assert admin_email["SMTP_HOST"] == "smtp.resend.com"
 
 
+def test_get_config_callbacks_appends_runtime_only_callbacks(
+    client, auth_as, mock_prisma, monkeypatch
+):
+    """Runtime-registered callbacks (not in config) are appended as read_only rows."""
+    from litellm.proxy import proxy_server as ps
+    from litellm.proxy._types import LitellmUserRoles
+
+    _install_litellm_config(mock_prisma)
+    monkeypatch.setattr(ps, "prisma_client", mock_prisma)
+    monkeypatch.setattr(ps, "llm_router", None)
+
+    fake_proxy_config = MagicMock()
+    fake_proxy_config.get_config = AsyncMock(
+        return_value={
+            "litellm_settings": {"success_callback": ["langfuse"]},
+            "general_settings": {},
+            "environment_variables": dict(_CALLBACK_ENV_FIXTURE),
+        }
+    )
+    monkeypatch.setattr(ps, "proxy_config", fake_proxy_config)
+
+    # Mock runtime callbacks: register otel in addition to langfuse in config.
+    import litellm
+
+    original = litellm.callbacks
+    try:
+        litellm.callbacks = ["otel"]
+        with auth_as(LitellmUserRoles.PROXY_ADMIN):
+            response = client.get("/get/config/callbacks")
+        assert response.status_code == 200
+        body = response.json()
+
+        callbacks = body["callbacks"]
+        callback_names = [cb["name"] for cb in callbacks]
+
+        # Both should be present
+        assert "langfuse" in callback_names
+        assert "otel" in callback_names
+
+        # Configured callback should NOT be marked read_only
+        langfuse_cb = next(cb for cb in callbacks if cb["name"] == "langfuse")
+        assert langfuse_cb.get("read_only") != True
+
+        # Runtime-only callback should be marked read_only
+        otel_cb = next(cb for cb in callbacks if cb["name"] == "otel")
+        assert otel_cb["read_only"] is True
+        assert otel_cb["type"] == "success_and_failure"
+    finally:
+        litellm.callbacks = original
+
+
+def test_get_config_callbacks_deduplicates_configured_and_runtime(
+    client, auth_as, mock_prisma, monkeypatch
+):
+    """When same callback is in both config and runtime, show only once as configured."""
+    from litellm.proxy import proxy_server as ps
+    from litellm.proxy._types import LitellmUserRoles
+
+    _install_litellm_config(mock_prisma)
+    monkeypatch.setattr(ps, "prisma_client", mock_prisma)
+    monkeypatch.setattr(ps, "llm_router", None)
+
+    fake_proxy_config = MagicMock()
+    fake_proxy_config.get_config = AsyncMock(
+        return_value={
+            "litellm_settings": {"success_callback": ["langfuse"]},
+            "general_settings": {},
+            "environment_variables": dict(_CALLBACK_ENV_FIXTURE),
+        }
+    )
+    monkeypatch.setattr(ps, "proxy_config", fake_proxy_config)
+
+    # Mock runtime: same callback registered that is also in config
+    import litellm
+
+    original = litellm.success_callback
+    try:
+        litellm.success_callback = ["langfuse"]
+        with auth_as(LitellmUserRoles.PROXY_ADMIN):
+            response = client.get("/get/config/callbacks")
+        assert response.status_code == 200
+        body = response.json()
+
+        callbacks = body["callbacks"]
+        langfuse_rows = [cb for cb in callbacks if cb["name"] == "langfuse"]
+
+        # Should appear exactly once, not duplicated
+        assert len(langfuse_rows) == 1
+        # And it should NOT be marked read_only (it's in config)
+        assert langfuse_rows[0].get("read_only") != True
+    finally:
+        litellm.success_callback = original
+
+
+def test_get_config_callbacks_redacts_runtime_only_row_secrets_for_view_only_admin(
+    client, auth_as, mock_prisma, monkeypatch
+):
+    """Runtime-only callback rows are subject to the same redaction gate as configured."""
+    from litellm.proxy import proxy_server as ps
+    from litellm.proxy._types import LitellmUserRoles
+
+    _install_litellm_config(mock_prisma)
+    monkeypatch.setattr(ps, "prisma_client", mock_prisma)
+    monkeypatch.setattr(ps, "llm_router", None)
+
+    fake_proxy_config = MagicMock()
+    fake_proxy_config.get_config = AsyncMock(
+        return_value={
+            "litellm_settings": {"success_callback": []},
+            "general_settings": {},
+            "environment_variables": dict(_CALLBACK_ENV_FIXTURE),
+        }
+    )
+    monkeypatch.setattr(ps, "proxy_config", fake_proxy_config)
+
+    # Mock runtime: register otel
+    import litellm
+
+    original = litellm.callbacks
+    try:
+        litellm.callbacks = ["otel"]
+        # View-only admin
+        with auth_as(LitellmUserRoles.PROXY_ADMIN_VIEW_ONLY):
+            response = client.get("/get/config/callbacks")
+        assert response.status_code == 200
+        body = response.json()
+
+        callbacks = body["callbacks"]
+        otel_cb = next((cb for cb in callbacks if cb["name"] == "otel"), None)
+        assert otel_cb is not None
+
+        # Secret env vars must be redacted
+        assert otel_cb["variables"]["OTEL_HEADERS"] == "REDACTED"
+        # Non-secret vars should pass through
+        assert otel_cb["variables"]["OTEL_ENDPOINT"] == _CALLBACK_ENV_FIXTURE["OTEL_ENDPOINT"]
+
+        # Full admin sees secrets
+        with auth_as(LitellmUserRoles.PROXY_ADMIN):
+            admin_response = client.get("/get/config/callbacks")
+        assert admin_response.status_code == 200
+        admin_body = admin_response.json()
+        admin_otel = next(
+            (cb for cb in admin_body["callbacks"] if cb["name"] == "otel"), None
+        )
+        assert admin_otel is not None
+        assert admin_otel["variables"]["OTEL_HEADERS"] == _CALLBACK_ENV_FIXTURE["OTEL_HEADERS"]
+    finally:
+        litellm.callbacks = original
+
+
 # ---------------------------------------------------------------------------
 # GET /config/yaml
 # ---------------------------------------------------------------------------

--- a/tests/test_litellm/proxy/proxy_server/test_routes_config.py
+++ b/tests/test_litellm/proxy/proxy_server/test_routes_config.py
@@ -13,6 +13,7 @@ Routes covered:
 
 from __future__ import annotations
 
+import asyncio
 import json
 from unittest.mock import AsyncMock, MagicMock
 
@@ -1393,6 +1394,8 @@ def test_get_config_callbacks_excludes_internal_runtime_callbacks(client, auth_a
     from litellm.integrations.custom_guardrail import CustomGuardrail
     from litellm.integrations.custom_logger import CustomLogger
     from litellm.integrations.langsmith import LangsmithLogger
+    from litellm.integrations.s3_v2 import S3Logger
+    from litellm.integrations.sqs import SQSLogger
     from litellm.integrations.vector_store_integrations.vector_store_pre_call_hook import VectorStorePreCallHook
     from litellm.proxy.hooks.max_budget_limiter import _PROXY_MaxBudgetLimiter
     from litellm.router import Router
@@ -1406,10 +1409,16 @@ def test_get_config_callbacks_excludes_internal_runtime_callbacks(client, auth_a
     def user_code_function(*args, **kwargs):
         pass
 
+    async def build_aws_loggers() -> tuple[S3Logger, SQSLogger]:
+        return S3Logger(s3_bucket_name="inventory-bucket"), SQSLogger(sqs_queue_url="https://sqs.example/inventory")
+
+    s3_logger, sqs_logger = asyncio.run(build_aws_loggers())
     router = Router(model_list=[])
     monkeypatch.setattr(litellm, "input_callback", [])
-    monkeypatch.setattr(litellm, "success_callback", [LangsmithLogger(), router.sync_deployment_callback_on_success])
-    monkeypatch.setattr(litellm, "_async_success_callback", [router.deployment_callback_on_success])
+    monkeypatch.setattr(
+        litellm, "success_callback", [LangsmithLogger(), s3_logger, router.sync_deployment_callback_on_success]
+    )
+    monkeypatch.setattr(litellm, "_async_success_callback", [sqs_logger, router.deployment_callback_on_success])
     monkeypatch.setattr(litellm, "failure_callback", [user_code_function])
     monkeypatch.setattr(litellm, "_async_failure_callback", [router.async_deployment_callback_on_failure])
     monkeypatch.setattr(
@@ -1436,6 +1445,8 @@ def test_get_config_callbacks_excludes_internal_runtime_callbacks(client, auth_a
     ] == [
         ("_UserCodeLogger", "success_and_failure", True),
         ("langsmith", "success", True),
+        ("s3", "success", True),
+        ("sqs", "success", True),
         ("user_code_function", "failure", True),
     ]
 

--- a/tests/test_litellm/proxy/proxy_server/test_routes_config.py
+++ b/tests/test_litellm/proxy/proxy_server/test_routes_config.py
@@ -1137,7 +1137,7 @@ def test_get_config_callbacks_appends_runtime_only_callbacks(client, auth_as, mo
 
 def test_get_config_callbacks_deduplicates_configured_and_runtime(client, auth_as, mock_prisma, monkeypatch):
     """A configured callback shows once as editable, whether the runtime holds its string or an initialized instance
-    registered under a different alias (arize initializes an OpenTelemetry instance)."""
+    (arize initializes an ArizeLogger, logfire a bare OpenTelemetry that only its class identifies)."""
     from litellm.proxy import proxy_server as ps
     from litellm.proxy._types import LitellmUserRoles
 
@@ -1148,7 +1148,7 @@ def test_get_config_callbacks_deduplicates_configured_and_runtime(client, auth_a
     fake_proxy_config = MagicMock()
     fake_proxy_config.get_config = AsyncMock(
         return_value={
-            "litellm_settings": {"success_callback": ["langfuse", "arize"]},
+            "litellm_settings": {"success_callback": ["langfuse", "arize", "logfire"]},
             "general_settings": {},
             "environment_variables": dict(_CALLBACK_ENV_FIXTURE),
         }
@@ -1156,9 +1156,11 @@ def test_get_config_callbacks_deduplicates_configured_and_runtime(client, auth_a
     monkeypatch.setattr(ps, "proxy_config", fake_proxy_config)
 
     import litellm
-    from litellm.integrations.opentelemetry import OpenTelemetry
+    from litellm.integrations.arize.arize import ArizeLogger
+    from litellm.integrations.opentelemetry import OpenTelemetry, OpenTelemetryConfig
 
-    monkeypatch.setattr(litellm, "success_callback", ["langfuse", OpenTelemetry()])
+    arize_logger = ArizeLogger(config=OpenTelemetryConfig(exporter="console"), callback_name="arize")
+    monkeypatch.setattr(litellm, "success_callback", ["langfuse", arize_logger, OpenTelemetry()])
     monkeypatch.setattr(litellm, "callbacks", [])
     monkeypatch.setattr(litellm, "failure_callback", [])
     monkeypatch.setattr(litellm, "_async_success_callback", [])
@@ -1171,6 +1173,64 @@ def test_get_config_callbacks_deduplicates_configured_and_runtime(client, auth_a
     assert [(cb["name"], cb["type"], cb.get("read_only", False)) for cb in response.json()["callbacks"]] == [
         ("langfuse", "success", False),
         ("arize", "success", False),
+        ("logfire", "success", False),
+    ]
+
+
+def test_get_config_callbacks_keeps_yaml_otel_family_callbacks_next_to_configured_one(
+    client, auth_as, mock_prisma, monkeypatch
+):
+    """LIT-5281: arize, weave_otel and langfuse_otel all initialize OpenTelemetry subclasses. Saving one of them
+    from the dashboard replaces the YAML `callbacks` list, so the YAML siblings keep running and must stay listed
+    under their own names instead of being hidden as duplicates of the configured OTel callback."""
+    from litellm.proxy import proxy_server as ps
+    from litellm.proxy._types import LitellmUserRoles
+
+    _install_litellm_config(mock_prisma)
+    monkeypatch.setattr(ps, "prisma_client", mock_prisma)
+    monkeypatch.setattr(ps, "llm_router", None)
+
+    fake_proxy_config = MagicMock()
+    fake_proxy_config.get_config = AsyncMock(
+        return_value={
+            "litellm_settings": {"callbacks": ["langfuse_otel"]},
+            "general_settings": {},
+            "environment_variables": dict(_CALLBACK_ENV_FIXTURE),
+        }
+    )
+    monkeypatch.setattr(ps, "proxy_config", fake_proxy_config)
+
+    import litellm
+    from litellm.integrations.arize.arize import ArizeLogger
+    from litellm.integrations.langfuse.langfuse_otel import LangfuseOtelLogger
+    from litellm.integrations.langsmith import LangsmithLogger
+    from litellm.integrations.opentelemetry import OpenTelemetryConfig
+    from litellm.integrations.weave.weave_otel import WeaveOtelLogger
+
+    console_config = OpenTelemetryConfig(exporter="console")
+    monkeypatch.setattr(litellm, "success_callback", [LangsmithLogger()])
+    monkeypatch.setattr(litellm, "_async_success_callback", [])
+    monkeypatch.setattr(litellm, "failure_callback", [])
+    monkeypatch.setattr(litellm, "_async_failure_callback", [])
+    monkeypatch.setattr(
+        litellm,
+        "callbacks",
+        [
+            ArizeLogger(config=console_config, callback_name="arize"),
+            WeaveOtelLogger(config=console_config),
+            LangfuseOtelLogger(config=console_config, callback_name="langfuse_otel"),
+        ],
+    )
+
+    with auth_as(LitellmUserRoles.PROXY_ADMIN):
+        response = client.get("/get/config/callbacks")
+    assert response.status_code == 200
+
+    assert [(cb["name"], cb["type"], cb.get("read_only", False)) for cb in response.json()["callbacks"]] == [
+        ("langfuse_otel", "success_and_failure", False),
+        ("arize", "success_and_failure", True),
+        ("langsmith", "success", True),
+        ("weave_otel", "success_and_failure", True),
     ]
 
 

--- a/tests/test_litellm/proxy/proxy_server/test_routes_config.py
+++ b/tests/test_litellm/proxy/proxy_server/test_routes_config.py
@@ -16,6 +16,8 @@ from __future__ import annotations
 import json
 from unittest.mock import AsyncMock, MagicMock
 
+import pytest
+
 from .conftest import VOLATILE_KEYS, normalize
 
 
@@ -1204,7 +1206,17 @@ def test_get_config_callbacks_deduplicates_configured_and_runtime(client, auth_a
     assert {callback["name"] for callback in callbacks} == {"langfuse"}
 
 
-def test_get_config_callbacks_deduplicates_dotted_path_callback(client, auth_as, mock_prisma, monkeypatch):
+@pytest.mark.parametrize(
+    "config_key,expected_type",
+    [
+        ("success_callback", "success"),
+        ("failure_callback", "failure"),
+        ("callbacks", "success_and_failure"),
+    ],
+)
+def test_get_config_callbacks_deduplicates_dotted_path_callback(
+    client, auth_as, mock_prisma, monkeypatch, config_key, expected_type
+):
     """A dotted-path callback stays a single editable row instead of duplicating under its class name."""
     from litellm.proxy import proxy_server as ps
     from litellm.proxy._types import LitellmUserRoles
@@ -1225,7 +1237,7 @@ def test_get_config_callbacks_deduplicates_dotted_path_callback(client, auth_as,
     fake_proxy_config = MagicMock()
     fake_proxy_config.get_config = AsyncMock(
         return_value={
-            "litellm_settings": {"success_callback": [dotted_path]},
+            "litellm_settings": {config_key: [dotted_path]},
             "general_settings": {},
             "environment_variables": dict(_CALLBACK_ENV_FIXTURE),
         }
@@ -1255,7 +1267,7 @@ def test_get_config_callbacks_deduplicates_dotted_path_callback(client, auth_as,
     assert response.status_code == 200
     callbacks = response.json()["callbacks"]
     assert [(callback["name"], callback["type"], callback.get("read_only", False)) for callback in callbacks] == [
-        (dotted_path, "success", False)
+        (dotted_path, expected_type, False)
     ]
 
 

--- a/ui/litellm-dashboard/src/components/Settings/LoggingAndAlerts/LoggingCallbacks/LoggingCallbacksTable.test.tsx
+++ b/ui/litellm-dashboard/src/components/Settings/LoggingAndAlerts/LoggingCallbacks/LoggingCallbacksTable.test.tsx
@@ -97,6 +97,23 @@ describe("LoggingCallbacksTable", () => {
     expect(onDelete).toHaveBeenCalledWith(callback);
   });
 
+  it("hides the actions menu for read-only runtime callback rows", () => {
+    render(
+      <LoggingCallbacksTable
+        callbacks={[
+          { name: "langfuse", type: "success" as const, variables: baseVars },
+          { name: "datadog", type: "success" as const, variables: baseVars, read_only: true },
+        ]}
+        availableCallbacks={{}}
+        onTest={vi.fn()}
+        onEdit={vi.fn()}
+        onDelete={vi.fn()}
+      />,
+    );
+    expect(screen.getByTestId("callback-actions-langfuse-success")).toBeInTheDocument();
+    expect(screen.queryByTestId("callback-actions-datadog-success")).not.toBeInTheDocument();
+  });
+
   // Regression: `/get_callbacks` returns the same `name` twice when a
   // callback is registered for both success and failure (e.g. `generic_api`
   // → POST to spend-log on both 200 and 4xx/5xx). The UI used to ignore

--- a/ui/litellm-dashboard/src/components/Settings/LoggingAndAlerts/LoggingCallbacks/LoggingCallbacksTable.test.tsx
+++ b/ui/litellm-dashboard/src/components/Settings/LoggingAndAlerts/LoggingCallbacks/LoggingCallbacksTable.test.tsx
@@ -97,7 +97,7 @@ describe("LoggingCallbacksTable", () => {
     expect(onDelete).toHaveBeenCalledWith(callback);
   });
 
-  it("hides the actions menu for read-only runtime callback rows", () => {
+  it("shows a read-only label instead of the actions menu for runtime-only callback rows", () => {
     render(
       <LoggingCallbacksTable
         callbacks={[
@@ -112,6 +112,7 @@ describe("LoggingCallbacksTable", () => {
     );
     expect(screen.getByTestId("callback-actions-langfuse-success")).toBeInTheDocument();
     expect(screen.queryByTestId("callback-actions-datadog-success")).not.toBeInTheDocument();
+    expect(screen.getAllByText("Read only")).toHaveLength(1);
   });
 
   // Regression: `/get_callbacks` returns the same `name` twice when a

--- a/ui/litellm-dashboard/src/components/Settings/LoggingAndAlerts/LoggingCallbacks/LoggingCallbacksTableColumns.tsx
+++ b/ui/litellm-dashboard/src/components/Settings/LoggingAndAlerts/LoggingCallbacks/LoggingCallbacksTableColumns.tsx
@@ -50,6 +50,10 @@ interface CallbackRowActionsProps {
 }
 
 function CallbackRowActions({ callback, onTest, onEdit, onDelete }: CallbackRowActionsProps) {
+  // Hide actions for read-only (runtime-only) callbacks.
+  if (callback.read_only) {
+    return null;
+  }
   return (
     <DropdownMenu>
       <DropdownMenuTrigger

--- a/ui/litellm-dashboard/src/components/Settings/LoggingAndAlerts/LoggingCallbacks/LoggingCallbacksTableColumns.tsx
+++ b/ui/litellm-dashboard/src/components/Settings/LoggingAndAlerts/LoggingCallbacks/LoggingCallbacksTableColumns.tsx
@@ -50,9 +50,15 @@ interface CallbackRowActionsProps {
 }
 
 function CallbackRowActions({ callback, onTest, onEdit, onDelete }: CallbackRowActionsProps) {
-  // Hide actions for read-only (runtime-only) callbacks.
   if (callback.read_only) {
-    return null;
+    return (
+      <span
+        className="text-xs text-muted-foreground"
+        title="Active callback that was not added through the dashboard. Edit it where it was configured."
+      >
+        Read only
+      </span>
+    );
   }
   return (
     <DropdownMenu>

--- a/ui/litellm-dashboard/src/components/Settings/LoggingAndAlerts/LoggingCallbacks/types.ts
+++ b/ui/litellm-dashboard/src/components/Settings/LoggingAndAlerts/LoggingCallbacks/types.ts
@@ -8,6 +8,9 @@ export interface AlertingObject {
   // every row to render as "Success".
   type?: "success" | "failure" | "success_and_failure";
   variables: AlertingVariables;
+  // read_only is true for runtime-only callbacks (not in DB/YAML config).
+  // UI hides edit/delete/test controls for read-only rows.
+  read_only?: boolean;
 }
 
 export interface AlertingVariables {

--- a/ui/litellm-dashboard/src/components/Settings/LoggingAndAlerts/LoggingCallbacks/types.ts
+++ b/ui/litellm-dashboard/src/components/Settings/LoggingAndAlerts/LoggingCallbacks/types.ts
@@ -8,8 +8,6 @@ export interface AlertingObject {
   // every row to render as "Success".
   type?: "success" | "failure" | "success_and_failure";
   variables: AlertingVariables;
-  // read_only is true for runtime-only callbacks (not in DB/YAML config).
-  // UI hides edit/delete/test controls for read-only rows.
   read_only?: boolean;
 }
 


### PR DESCRIPTION
## TLDR

Problem this solves:

- Logging & Alerts page only listed callbacks saved through the dashboard
- A YAML callback kept firing but disappeared from the page
- Users assumed the dashboard callback had replaced the YAML one

How it solves it:

- `GET /get/config/callbacks` appends every active callback missing from the saved config
- Those extra rows are flagged `read_only: true` and the UI hides their actions
- Internal proxy hooks, guardrails, cache and the vector store hook stay hidden

## User Flow

Before: an admin adds a second callback in the dashboard and the YAML one vanishes from the page even though both keep logging

1. The admin starts the proxy with `success_callback: ["langsmith"]` in the YAML config
2. They open https://litellm-domain/ui/?page=logging-and-alerts and add Langfuse through Add Callback
3. They send POST https://litellm-domain/v1/chat/completions and both Langsmith and Langfuse receive the trace
4. They reload https://litellm-domain/ui/?page=logging-and-alerts and only Langfuse is listed
5. GET https://litellm-domain/get/config/callbacks returns one row, `langfuse`, so they conclude Langsmith was overwritten

After: the page lists both callbacks, and the YAML one is marked read only

1. The admin starts the proxy with `success_callback: ["langsmith"]` in the YAML config
2. They open https://litellm-domain/ui/?page=logging-and-alerts and add Langfuse through Add Callback
3. They send POST https://litellm-domain/v1/chat/completions and both Langsmith and Langfuse receive the trace
4. They reload https://litellm-domain/ui/?page=logging-and-alerts and see Langfuse with its actions menu plus Langsmith tagged "Read only"
5. GET https://litellm-domain/get/config/callbacks returns two rows, `langfuse` and `langsmith` with `"read_only": true`

## Relevant issues

## Linear ticket

Resolves LIT-5281

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Shared setup: two proxies from the same Postgres database, one at the merge base and one at the PR tip, each started with `--num_workers 2`. The YAML config has `success_callback: ["langsmith"]`, `callbacks: ["arize", "weave_otel", "s3_v2"]` and `store_model_in_db: true`. `langfuse_otel` was added through the dashboard payload (`POST /config/update`), so it lives in the saved config only. LangSmith EU, Arize, Weave and Langfuse Cloud are real destinations and the model is real `openai/gpt-5.4-mini`. The `s3_v2` callback points at a bucket this rig has no access to (the upload fails with a 404 in the proxy log), it is there to prove the `s3_v2` -> `s3` alias row is listed. `$PORT` is 20381 for Before and 20383 for After. Dashboard screenshots for this run, plus an earlier Langfuse-only run with Langfuse UI screenshots, are in PR comments

### Before (ef3a3c16ae)

#### Real request reaches the YAML callbacks

1. `curl -s localhost:$PORT/v1/chat/completions -H "Authorization: Bearer $LITELLM_MASTER_KEY" -H 'Content-Type: application/json' -d '{"model":"gpt-5.4-mini","messages":[{"role":"user","content":"Reply with exactly: ok"}],"metadata":{"tags":["lit5281-1789004664-$PORT"]}}'`
2. `{"model": "gpt-5.4-mini", "content": "ok"}`
3. `curl -s -X POST "$LANGSMITH_BASE_URL/api/v1/runs/query" -H "x-api-key: $LANGSMITH_API_KEY" -d '{"session":["<project id>"],"filter":"has(tags, \"lit5281-1789004664-20381\")"}'` returns one `LLMRun` with `status: success` whose output id matches the completion id
4. `curl -s -u "api:$WANDB_API_KEY" -X POST https://trace.wandb.ai/calls/stream_query -d '{"project_id":"$WANDB_PROJECT_ID","limit":400}'` contains one `litellm_request` call carrying that tag, exported by the YAML `weave_otel` callback

#### Callback inventory

1. `for i in 1 2 3 4 5 6; do curl -s localhost:$PORT/get/config/callbacks -H "Authorization: Bearer $LITELLM_MASTER_KEY"; done`
2. Every sample lists `langsmith` and `langfuse_otel` only. The YAML `arize`, `weave_otel` and `s3_v2` callbacks that just ran are missing

#### Dashboard

1. Open http://localhost:3281/logging-and-alerts/ (dev UI pointed at the proxy)
2. The Active Logging Callbacks table shows two rows, `Langsmith` and `langfuse_otel`, each with the actions menu

#### Deleting and re-saving callbacks from the dashboard

1. `curl -s -X POST localhost:$PORT/config/callback/delete -H "Authorization: Bearer $LITELLM_MASTER_KEY" -H 'Content-Type: application/json' -d '{"callback_name":"arize"}'`
2. `404 {"detail":{"error":"Callback 'arize' not found in active configuration"}}`, inventory unchanged
3. Same call with `"callback_name":"langfuse_otel"` is also `404` because the delete route only searches `success_callback` and this row was saved under `callbacks` (pre-existing, unchanged)
4. `POST /config/update` with `{"litellm_settings":{"success_callback":["langfuse_otel"],"failure_callback":["langfuse_otel"]}, "environment_variables": {...}}` returns `200`. Within the config sync interval the inventory is three `langfuse_otel` rows (`success`, `failure`, `success_and_failure`) and `langsmith` is gone, even though the YAML LangSmith callback is still registered. This is the ticket scenario

#### Cache enabled does not leak internal hooks

1. Same YAML plus `cache: true` under `litellm_settings` on port 20387, two identical chat completions, the second carries an `x-litellm-cache-key` header
2. `curl -s localhost:20387/callbacks/list -H "Authorization: Bearer $LITELLM_MASTER_KEY"` shows `cache`, `_ProxyDBLogger` and the deployment hooks as active
3. `curl -s localhost:20387/get/config/callbacks ...` lists `langsmith` and `langfuse_otel` only, no `cache` row

#### Error and auth paths

1. `curl -s localhost:$PORT/v1/chat/completions ... -d '{"model":"does-not-exist","messages":[{"role":"user","content":"hi"}]}'` returns `400 Invalid model name passed in model=does-not-exist` and the inventory is unchanged
2. `curl -s -o /dev/null -w "%{http_code}\n" localhost:$PORT/get/config/callbacks` is `401`
3. Users minted via `POST /user/new` with `user_role` `internal_user` and `internal_user_viewer` get `401 Only proxy admin can be used ...`, a `proxy_admin_viewer` user gets `200` with `LANGSMITH_API_KEY`, `LANGFUSE_PUBLIC_KEY` and `LANGFUSE_SECRET_KEY` as `REDACTED` and `LANGSMITH_PROJECT`, `LANGFUSE_HOST` visible

### After (d63e655a5e)

#### Real request reaches the YAML callbacks

1. `curl -s localhost:$PORT/v1/chat/completions -H "Authorization: Bearer $LITELLM_MASTER_KEY" -H 'Content-Type: application/json' -d '{"model":"gpt-5.4-mini","messages":[{"role":"user","content":"Reply with exactly: ok"}],"metadata":{"tags":["lit5281-1789004664-$PORT"]}}'`
2. `{"model": "gpt-5.4-mini", "content": "ok"}`
3. The same LangSmith runs query with tag `lit5281-1789004664-20383` returns one `LLMRun` with `status: success` whose output id matches the completion id
4. The same Weave `calls/stream_query` contains one `litellm_request` call carrying that tag

#### Callback inventory

1. `for i in 1 2 3 4 5 6; do curl -s localhost:$PORT/get/config/callbacks -H "Authorization: Bearer $LITELLM_MASTER_KEY"; done`
2. Every sample lists `langsmith` (`success`), `langfuse_otel` (`success_and_failure`), plus `arize`, `s3` and `weave_otel` (`success_and_failure`) with `"read_only": true`. `s3` is the YAML `s3_v2` callback under the name the dashboard uses; at f3b76f1a02 that row was missing because the alias check looked the display name up in the integration registry
3. Same output for 12 samples in a row against a `--num_workers 4` proxy on port 20385 whose log shows four `Started server process` lines

#### Dashboard

1. Open http://localhost:3283/logging-and-alerts/ (dev UI pointed at the proxy)
2. The table shows `Langsmith` and `langfuse_otel` with the actions menu (Test, Edit, Delete) and `arize`, `s3 Bucket (AWS)` and `weave_otel` with a "Read only" label in place of the menu

#### Deleting and re-saving callbacks from the dashboard

1. `curl -s -X POST localhost:$PORT/config/callback/delete -H "Authorization: Bearer $LITELLM_MASTER_KEY" -H 'Content-Type: application/json' -d '{"callback_name":"arize"}'`
2. `404 {"detail":{"error":"Callback 'arize' not found in active configuration"}}`, inventory unchanged, so the read-only row cannot be removed from the dashboard. Same `404` for `"callback_name":"s3"` and `"s3_v2"`
3. Same call with `"callback_name":"langfuse_otel"` is `404` for the same pre-existing reason as Before
4. The same `POST /config/update` returns `200`. Within the config sync interval the inventory is the three `langfuse_otel` rows, `arize` and `weave_otel` read only, and `langsmith` now `"read_only": true` instead of disappearing, so the page keeps showing the still registered callback

#### Cache enabled does not leak internal hooks

1. Same YAML plus `cache: true` on port 20388, two identical chat completions, the second carries an `x-litellm-cache-key` header
2. `curl -s localhost:20388/callbacks/list ...` shows `cache`, `_ProxyDBLogger`, `ServiceLogging` and the deployment hooks as active
3. `curl -s localhost:20388/get/config/callbacks ...` lists `langsmith`, `langfuse_otel`, `arize` (read only), `weave_otel` (read only), no `cache` row and no internal hook

#### Error and auth paths

1. `curl -s localhost:$PORT/v1/chat/completions ... -d '{"model":"does-not-exist","messages":[{"role":"user","content":"hi"}]}'` returns `400 Invalid model name passed in model=does-not-exist` and the inventory is unchanged
2. `curl -s -o /dev/null -w "%{http_code}\n" localhost:$PORT/get/config/callbacks` is `401`
3. `internal_user` and `internal_user_viewer` users get `401 Only proxy admin can be used ...`, same as Before, so that 401 comes from route auth and never reaches this code
4. A `proxy_admin_viewer` user gets `200` with the same rows as the master key. Secrets are `REDACTED` (`LANGSMITH_API_KEY`, `LANGFUSE_PUBLIC_KEY`, `LANGFUSE_SECRET_KEY`, and `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` on the read-only `s3` row), non-secrets stay visible (`LANGSMITH_PROJECT`, `LANGFUSE_HOST`, `AWS_REGION_NAME`), and the `arize` and `weave_otel` rows carry `read_only: true` with no variables

Observations from the run:

- Arize span readback empty, proxy log shows OTLP `UNAVAILABLE`; Arize ingestion unverified
- `arize` inventory row does not depend on that export
- Same happy, unauth 401 and read-only delete 404 checks on the GitHub merge ref 8eeb423b01 (staging b22ca7ac6d merged with tip d63e655a5e), 2 workers: identical output
- Deleting a callback saved under `callbacks` returns 404 on both sides (pre-existing)

## Type

🐛 Bug Fix

## Caveats (if any)

### Low

- Runtime rows for callbacks outside `CustomLoggerRegistry` show their class or function name
- Dotted-path config entries dedup by module, so a handler class defined in another module still shows twice (pre-existing)
- `/config/callback/delete` only searches `success_callback` (pre-existing, unchanged)
- Internal hooks are excluded by module owner plus an explicit list (`cache`, `vector_store_pre_call_hook`); a new auto-registered registry hook would need adding to that list

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

- [x] d63e655a5e passes /live-pr-risk


Link to Devin session: https://app.devin.ai/sessions/e724cebb80f249c391598984099c3329
Open in Devin Desktop: https://app.devin.ai/desktop/session/e724cebb80f249c391598984099c3329?variant=devin
Requested by: @yucheng-berri