### PR TITLE
feat(models): add Azure Foundry model pricing

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -9858,7 +9858,7 @@
         "max_tokens": 163840,
         "mode": "chat",
         "output_cost_per_token": 1.68e-06,
-        "source": "https://techcommunity.microsoft.com/blog/azure-ai-foundry-blog/introducing-deepseek-v3-2-and-deepseek-v3-2-speciale-in-microsoft-foundry/4477549",
+        "source": "https://azure.microsoft.com/en-us/pricing/details/ai-foundry-models/deepseek/",
         "supports_assistant_prefill": true,
         "supports_function_calling": true,
         "supports_prompt_caching": true,
@@ -9873,7 +9873,7 @@
         "max_tokens": 163840,
         "mode": "chat",
         "output_cost_per_token": 1.68e-06,
-        "source": "https://techcommunity.microsoft.com/blog/azure-ai-foundry-blog/introducing-deepseek-v3-2-and-deepseek-v3-2-speciale-in-microsoft-foundry/4477549",
+        "source": "https://azure.microsoft.com/en-us/pricing/details/ai-foundry-models/deepseek/",
         "supports_assistant_prefill": true,
         "supports_function_calling": true,
         "supports_prompt_caching": true,
@@ -9889,7 +9889,7 @@
         "max_tokens": 8192,
         "mode": "chat",
         "output_cost_per_token": 5.4e-06,
-        "source": "https://techcommunity.microsoft.com/blog/machinelearningblog/deepseek-r1-improved-performance-higher-limits-and-transparent-pricing/4386367",
+        "source": "https://azure.microsoft.com/en-us/pricing/details/ai-foundry-models/deepseek/",
         "supports_reasoning": true,
         "supports_tool_choice": true
     },
@@ -9901,7 +9901,7 @@
         "max_tokens": 8192,
         "mode": "chat",
         "output_cost_per_token": 4.56e-06,
-        "source": "https://techcommunity.microsoft.com/blog/machinelearningblog/announcing-deepseek-v3-on-azure-ai-foundry-and-github/4390438",
+        "source": "https://azure.microsoft.com/en-us/pricing/details/ai-foundry-models/deepseek/",
         "supports_tool_choice": true
     },
     "azure_ai/deepseek-v3-0324": {
@@ -9913,7 +9913,7 @@
         "max_tokens": 8192,
         "mode": "chat",
         "output_cost_per_token": 4.56e-06,
-        "source": "https://techcommunity.microsoft.com/blog/machinelearningblog/announcing-deepseek-v3-on-azure-ai-foundry-and-github/4390438",
+        "source": "https://azure.microsoft.com/en-us/pricing/details/ai-foundry-models/deepseek/",
         "supports_function_calling": true,
         "supports_tool_choice": true
     },
@@ -9932,6 +9932,7 @@
         "supports_tool_choice": true
     },
     "azure_ai/deepseek-v4-pro": {
+        "cache_read_input_token_cost": 1.45e-07,
         "deprecation_date": "2028-02-20",
         "input_cost_per_token": 1.74e-06,
         "litellm_provider": "azure_ai",
@@ -9942,10 +9943,12 @@
         "output_cost_per_token": 3.48e-06,
         "source": "https://azure.microsoft.com/en-us/pricing/details/ai-foundry-models/deepseek/",
         "supports_function_calling": true,
+        "supports_prompt_caching": true,
         "supports_reasoning": true,
         "supports_tool_choice": true
     },
     "azure_ai/deepseek-v4-flash": {
+        "cache_read_input_token_cost": 2.8e-08,
         "deprecation_date": "2028-02-20",
         "input_cost_per_token": 1.9e-07,
         "litellm_provider": "azure_ai",
@@ -9956,6 +9959,7 @@
         "output_cost_per_token": 5.1e-07,
         "source": "https://azure.microsoft.com/en-us/pricing/details/ai-foundry-models/deepseek/",
         "supports_function_calling": true,
+        "supports_prompt_caching": true,
         "supports_reasoning": true,
         "supports_tool_choice": true
     },
@@ -10164,6 +10168,7 @@
         "supports_tool_choice": true
     },
     "azure_ai/kimi-k2.5": {
+        "cache_read_input_token_cost": 1e-07,
         "deprecation_date": "2027-01-26",
         "input_cost_per_token": 6e-07,
         "litellm_provider": "azure_ai",
@@ -10172,13 +10177,15 @@
         "max_tokens": 262144,
         "mode": "chat",
         "output_cost_per_token": 3e-06,
-        "source": "https://techcommunity.microsoft.com/blog/azure-ai-foundry-blog/kimi-k2-5-now-in-microsoft-foundry/4492321",
+        "source": "https://azure.microsoft.com/en-us/pricing/details/ai-foundry-models/kimi/",
         "supports_function_calling": true,
+        "supports_prompt_caching": true,
         "supports_tool_choice": true,
         "supports_video_input": true,
         "supports_vision": true
     },
     "azure_ai/kimi-k2.6": {
+        "cache_read_input_token_cost": 1.6e-07,
         "deprecation_date": "2027-04-16",
         "input_cost_per_token": 9.5e-07,
         "litellm_provider": "azure_ai",
@@ -10187,7 +10194,7 @@
         "max_tokens": 262144,
         "mode": "chat",
         "output_cost_per_token": 4e-06,
-        "source": "https://techcommunity.microsoft.com/blog/azure-ai-foundry-blog/introducing-kimi-k2-6-in-microsoft-foundry/4513125",
+        "source": "https://azure.microsoft.com/en-us/pricing/details/ai-foundry-models/kimi/",
         "supported_modalities": [
             "text",
             "image"
@@ -10196,6 +10203,7 @@
             "text"
         ],
         "supports_function_calling": true,
+        "supports_prompt_caching": true,
         "supports_reasoning": true,
         "supports_tool_choice": true,
         "supports_vision": true
@@ -10303,6 +10311,45 @@
         "mode": "chat",
         "output_cost_per_token": 3e-07,
         "supports_function_calling": true,
+        "supports_tool_choice": true,
+        "supports_vision": true
+    },
+    "azure_ai/DeepSeek-V4-Flash-0731": {
+        "cache_read_input_token_cost": 2.8e-08,
+        "deprecation_date": "2028-02-20",
+        "input_cost_per_token": 1.9e-07,
+        "litellm_provider": "azure_ai",
+        "max_input_tokens": 1000000,
+        "max_output_tokens": 384000,
+        "max_tokens": 384000,
+        "mode": "chat",
+        "output_cost_per_token": 5.1e-07,
+        "source": "https://azure.microsoft.com/en-us/pricing/details/ai-foundry-models/deepseek/",
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true
+    },
+    "azure_ai/kimi-k2.7-code": {
+        "cache_read_input_token_cost": 1.9e-07,
+        "input_cost_per_token": 9.5e-07,
+        "litellm_provider": "azure_ai",
+        "max_input_tokens": 262144,
+        "max_output_tokens": 262144,
+        "max_tokens": 262144,
+        "mode": "chat",
+        "output_cost_per_token": 4e-06,
+        "source": "https://azure.microsoft.com/en-us/pricing/details/ai-foundry-models/kimi/",
+        "supported_modalities": [
+            "text",
+            "image"
+        ],
+        "supported_output_modalities": [
+            "text"
+        ],
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
         "supports_tool_choice": true,
         "supports_vision": true
     },

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -9858,7 +9858,7 @@
         "max_tokens": 163840,
         "mode": "chat",
         "output_cost_per_token": 1.68e-06,
-        "source": "https://techcommunity.microsoft.com/blog/azure-ai-foundry-blog/introducing-deepseek-v3-2-and-deepseek-v3-2-speciale-in-microsoft-foundry/4477549",
+        "source": "https://azure.microsoft.com/en-us/pricing/details/ai-foundry-models/deepseek/",
         "supports_assistant_prefill": true,
         "supports_function_calling": true,
         "supports_prompt_caching": true,
@@ -9873,7 +9873,7 @@
         "max_tokens": 163840,
         "mode": "chat",
         "output_cost_per_token": 1.68e-06,
-        "source": "https://techcommunity.microsoft.com/blog/azure-ai-foundry-blog/introducing-deepseek-v3-2-and-deepseek-v3-2-speciale-in-microsoft-foundry/4477549",
+        "source": "https://azure.microsoft.com/en-us/pricing/details/ai-foundry-models/deepseek/",
         "supports_assistant_prefill": true,
         "supports_function_calling": true,
         "supports_prompt_caching": true,
@@ -9889,7 +9889,7 @@
         "max_tokens": 8192,
         "mode": "chat",
         "output_cost_per_token": 5.4e-06,
-        "source": "https://techcommunity.microsoft.com/blog/machinelearningblog/deepseek-r1-improved-performance-higher-limits-and-transparent-pricing/4386367",
+        "source": "https://azure.microsoft.com/en-us/pricing/details/ai-foundry-models/deepseek/",
         "supports_reasoning": true,
         "supports_tool_choice": true
     },
@@ -9901,7 +9901,7 @@
         "max_tokens": 8192,
         "mode": "chat",
         "output_cost_per_token": 4.56e-06,
-        "source": "https://techcommunity.microsoft.com/blog/machinelearningblog/announcing-deepseek-v3-on-azure-ai-foundry-and-github/4390438",
+        "source": "https://azure.microsoft.com/en-us/pricing/details/ai-foundry-models/deepseek/",
         "supports_tool_choice": true
     },
     "azure_ai/deepseek-v3-0324": {
@@ -9913,7 +9913,7 @@
         "max_tokens": 8192,
         "mode": "chat",
         "output_cost_per_token": 4.56e-06,
-        "source": "https://techcommunity.microsoft.com/blog/machinelearningblog/announcing-deepseek-v3-on-azure-ai-foundry-and-github/4390438",
+        "source": "https://azure.microsoft.com/en-us/pricing/details/ai-foundry-models/deepseek/",
         "supports_function_calling": true,
         "supports_tool_choice": true
     },
@@ -9932,6 +9932,7 @@
         "supports_tool_choice": true
     },
     "azure_ai/deepseek-v4-pro": {
+        "cache_read_input_token_cost": 1.45e-07,
         "deprecation_date": "2028-02-20",
         "input_cost_per_token": 1.74e-06,
         "litellm_provider": "azure_ai",
@@ -9942,10 +9943,12 @@
         "output_cost_per_token": 3.48e-06,
         "source": "https://azure.microsoft.com/en-us/pricing/details/ai-foundry-models/deepseek/",
         "supports_function_calling": true,
+        "supports_prompt_caching": true,
         "supports_reasoning": true,
         "supports_tool_choice": true
     },
     "azure_ai/deepseek-v4-flash": {
+        "cache_read_input_token_cost": 2.8e-08,
         "deprecation_date": "2028-02-20",
         "input_cost_per_token": 1.9e-07,
         "litellm_provider": "azure_ai",
@@ -9956,6 +9959,7 @@
         "output_cost_per_token": 5.1e-07,
         "source": "https://azure.microsoft.com/en-us/pricing/details/ai-foundry-models/deepseek/",
         "supports_function_calling": true,
+        "supports_prompt_caching": true,
         "supports_reasoning": true,
         "supports_tool_choice": true
     },
@@ -10164,6 +10168,7 @@
         "supports_tool_choice": true
     },
     "azure_ai/kimi-k2.5": {
+        "cache_read_input_token_cost": 1e-07,
         "deprecation_date": "2027-01-26",
         "input_cost_per_token": 6e-07,
         "litellm_provider": "azure_ai",
@@ -10172,13 +10177,15 @@
         "max_tokens": 262144,
         "mode": "chat",
         "output_cost_per_token": 3e-06,
-        "source": "https://techcommunity.microsoft.com/blog/azure-ai-foundry-blog/kimi-k2-5-now-in-microsoft-foundry/4492321",
+        "source": "https://azure.microsoft.com/en-us/pricing/details/ai-foundry-models/kimi/",
         "supports_function_calling": true,
+        "supports_prompt_caching": true,
         "supports_tool_choice": true,
         "supports_video_input": true,
         "supports_vision": true
     },
     "azure_ai/kimi-k2.6": {
+        "cache_read_input_token_cost": 1.6e-07,
         "deprecation_date": "2027-04-16",
         "input_cost_per_token": 9.5e-07,
         "litellm_provider": "azure_ai",
@@ -10187,7 +10194,7 @@
         "max_tokens": 262144,
         "mode": "chat",
         "output_cost_per_token": 4e-06,
-        "source": "https://techcommunity.microsoft.com/blog/azure-ai-foundry-blog/introducing-kimi-k2-6-in-microsoft-foundry/4513125",
+        "source": "https://azure.microsoft.com/en-us/pricing/details/ai-foundry-models/kimi/",
         "supported_modalities": [
             "text",
             "image"
@@ -10196,6 +10203,7 @@
             "text"
         ],
         "supports_function_calling": true,
+        "supports_prompt_caching": true,
         "supports_reasoning": true,
         "supports_tool_choice": true,
         "supports_vision": true
@@ -10303,6 +10311,45 @@
         "mode": "chat",
         "output_cost_per_token": 3e-07,
         "supports_function_calling": true,
+        "supports_tool_choice": true,
+        "supports_vision": true
+    },
+    "azure_ai/DeepSeek-V4-Flash-0731": {
+        "cache_read_input_token_cost": 2.8e-08,
+        "deprecation_date": "2028-02-20",
+        "input_cost_per_token": 1.9e-07,
+        "litellm_provider": "azure_ai",
+        "max_input_tokens": 1000000,
+        "max_output_tokens": 384000,
+        "max_tokens": 384000,
+        "mode": "chat",
+        "output_cost_per_token": 5.1e-07,
+        "source": "https://azure.microsoft.com/en-us/pricing/details/ai-foundry-models/deepseek/",
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true
+    },
+    "azure_ai/kimi-k2.7-code": {
+        "cache_read_input_token_cost": 1.9e-07,
+        "input_cost_per_token": 9.5e-07,
+        "litellm_provider": "azure_ai",
+        "max_input_tokens": 262144,
+        "max_output_tokens": 262144,
+        "max_tokens": 262144,
+        "mode": "chat",
+        "output_cost_per_token": 4e-06,
+        "source": "https://azure.microsoft.com/en-us/pricing/details/ai-foundry-models/kimi/",
+        "supported_modalities": [
+            "text",
+            "image"
+        ],
+        "supported_output_modalities": [
+            "text"
+        ],
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
         "supports_tool_choice": true,
         "supports_vision": true
     },


### PR DESCRIPTION
## TLDR

Basically I scrape https://azure.microsoft.com/en-us/pricing/details/ai-foundry-models/kimi and sync our json.

Problem this solves:

- Azure direct model entries were missing
- Current cached-token prices were absent

How it solves it:

- Adds two verified Azure model entries
- Refreshes Kimi and DeepSeek pricing metadata

## User Flow

Before: a developer cannot verify exact pricing for supported Azure model IDs

1. They search the LiteLLM model registry for `azure_ai/DeepSeek-V4-Flash-0731`
2. No exact entry appears, so its Azure pricing is unavailable
3. They search for `azure_ai/kimi-k2.7-code` with the same result

After: the same supported Azure model IDs have pricing metadata

1. They search the LiteLLM model registry for `azure_ai/DeepSeek-V4-Flash-0731`
2. The entry shows input, cached-input, and output pricing
3. `azure_ai/kimi-k2.7-code` also shows verified Azure pricing

## Relevant issues

[Pylon #8009](https://app.usepylon.com/support/issues/views/inbox?view=fs&issueNumber=8009)

## Linear ticket

Resolves LIT-6555

## Pre-Submission checklist

- [ ] I have added meaningful tests
- [x] The handful of test files covering my change pass locally
- [ ] My PR passes all required CI/CD checks
- [x] My PR's scope is as isolated as possible
- [ ] I have received a Greptile Confidence Score of at least 4/5

## Screenshots / Proof of Fix

### Before (d6cce13308)

1. Run `git show d6cce13308:model_prices_and_context_window.json | jq '{deepseek: has("azure_ai/DeepSeek-V4-Flash-0731"), kimi: has("azure_ai/kimi-k2.7-code"), deepseek_cache: .["azure_ai/deepseek-v4-flash"].cache_read_input_token_cost, kimi_cache: .["azure_ai/kimi-k2.6"].cache_read_input_token_cost}'`
2. Observe `{"deepseek":false,"kimi":false,"deepseek_cache":null,"kimi_cache":null}`

### After (701ddd90c5)

1. Run `jq '{deepseek: has("azure_ai/DeepSeek-V4-Flash-0731"), kimi: has("azure_ai/kimi-k2.7-code"), deepseek_cache: .["azure_ai/deepseek-v4-flash"].cache_read_input_token_cost, kimi_cache: .["azure_ai/kimi-k2.6"].cache_read_input_token_cost}' model_prices_and_context_window.json`
2. Observe `{"deepseek":true,"kimi":true,"deepseek_cache":2.8e-08,"kimi_cache":1.6e-07}`

## Type

New Feature

## Caveats (if any)

### Low

- Direct Azure Kimi-K3 is not currently available
- Kimi-K3 remains available through Fireworks on Foundry

## Final Attestation

- [ ] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
