### PR TITLE
fix(panw_prisma_airs): apply experimental_use_latest_role_message_only to every request shape

### DIFF
--- a/litellm/proxy/guardrails/guardrail_hooks/panw_prisma_airs/panw_prisma_airs.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/panw_prisma_airs/panw_prisma_airs.py
@@ -194,8 +194,7 @@ class PanwPrismaAirsHandler(CustomGuardrail):
         # internal '<=' comparison and surfaces as a misleading api_error.
         self.timeout = float(timeout) if timeout is not None else 10.0
 
-        # Tri-state: None = not set (latest-only for Anthropic /v1/messages, full history
-        # otherwise), True = latest-only for every request shape, False = full history everywhere
+        # Tri-state scan-scope flag; resolution semantics in _use_latest_user_only()
         self.experimental_use_latest_role_message_only: bool | None = kwargs.get(
             "experimental_use_latest_role_message_only"
         )
@@ -1774,8 +1773,6 @@ class PanwPrismaAirsHandler(CustomGuardrail):
         if input_type == "request":
             structured_messages: Final = inputs.get("structured_messages")
             if structured_messages:
-                # Latest-user-only scanning: flag-controlled for every request shape,
-                # default-on only for Anthropic /v1/messages (see _use_latest_user_only).
                 # Uses request_data["messages"] (original format), NOT structured_messages
                 # (which has injected system content from adapter translation).
                 if self._use_latest_user_only(request_data, logging_obj):

--- a/litellm/proxy/guardrails/guardrail_hooks/panw_prisma_airs/panw_prisma_airs.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/panw_prisma_airs/panw_prisma_airs.py
@@ -194,7 +194,8 @@ class PanwPrismaAirsHandler(CustomGuardrail):
         # internal '<=' comparison and surfaces as a misleading api_error.
         self.timeout = float(timeout) if timeout is not None else 10.0
 
-        # Tri-state: None = not set (default-on for Anthropic), True = explicit on, False = explicit off
+        # Tri-state: None = not set (latest-only for Anthropic /v1/messages, full history
+        # otherwise), True = latest-only for every request shape, False = full history everywhere
         self.experimental_use_latest_role_message_only: bool | None = kwargs.get(
             "experimental_use_latest_role_message_only"
         )
@@ -1568,16 +1569,14 @@ class PanwPrismaAirsHandler(CustomGuardrail):
     ) -> bool:
         """Resolve whether to scan only the latest user message.
 
-        - Non-Anthropic requests: always False (existing behavior)
-        - Anthropic requests:
-          - Flag explicitly True/False: respect it
-          - Flag None (not set): default to True
+        - Flag explicitly True/False: respect it for every request shape,
+          matching the bedrock guardrail's semantics for the same flag
+        - Flag None (not set): keep the historical defaults - True for
+          Anthropic /v1/messages requests, False for everything else
         """
-        if not self._is_anthropic_request(request_data, logging_obj):
-            return False
-        if self.experimental_use_latest_role_message_only is None:
-            return True  # Default-on for Anthropic
-        return self.experimental_use_latest_role_message_only
+        if self.experimental_use_latest_role_message_only is not None:
+            return self.experimental_use_latest_role_message_only
+        return self._is_anthropic_request(request_data, logging_obj)
 
     @staticmethod
     def _get_latest_user_text_indices(
@@ -1775,7 +1774,8 @@ class PanwPrismaAirsHandler(CustomGuardrail):
         if input_type == "request":
             structured_messages: Final = inputs.get("structured_messages")
             if structured_messages:
-                # For Anthropic /v1/messages: default to latest-user-only scanning.
+                # Latest-user-only scanning: flag-controlled for every request shape,
+                # default-on only for Anthropic /v1/messages (see _use_latest_user_only).
                 # Uses request_data["messages"] (original format), NOT structured_messages
                 # (which has injected system content from adapter translation).
                 if self._use_latest_user_only(request_data, logging_obj):
@@ -1783,7 +1783,7 @@ class PanwPrismaAirsHandler(CustomGuardrail):
                     if original_messages:
                         scannable_indices = self._get_latest_user_text_indices(texts, original_messages)
                 # Fall through to existing role filtering if:
-                # - not Anthropic, OR flag explicitly False, OR
+                # - latest-only not enabled for this request, OR
                 # - no original messages, OR
                 # - latest-user extraction returned None (no user / count mismatch)
                 if scannable_indices is None:

--- a/litellm/proxy/guardrails/guardrail_hooks/panw_prisma_airs/panw_prisma_airs.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/panw_prisma_airs/panw_prisma_airs.py
@@ -205,6 +205,12 @@ class PanwPrismaAirsHandler(CustomGuardrail):
                 guardrail_name,
             )
 
+        if self.experimental_use_latest_role_message_only is True:
+            verbose_proxy_logger.warning(
+                "PANW Prisma AIRS Guardrail '%s': experimental_use_latest_role_message_only=true - only the latest user/developer message is scanned on the request side. Earlier turns in caller-supplied history are not rescanned before being forwarded to the model. Enable only where every turn is scanned while it is the latest message, or where conversation history is server-controlled.",
+                guardrail_name,
+            )
+
         verbose_proxy_logger.info(
             "Initialized PANW Prisma AIRS Guardrail: %s (profile=%s, mask_request=%s, mask_response=%s, fallback_on_error=%s, timeout=%s)",
             guardrail_name,

--- a/litellm/proxy/guardrails/guardrail_hooks/panw_prisma_airs/panw_prisma_airs.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/panw_prisma_airs/panw_prisma_airs.py
@@ -1779,12 +1779,27 @@ class PanwPrismaAirsHandler(CustomGuardrail):
         if input_type == "request":
             structured_messages: Final = inputs.get("structured_messages")
             if structured_messages:
-                # Uses request_data["messages"] (original format), NOT structured_messages
-                # (which has injected system content from adapter translation).
+                # Neither message source aligns with `texts` on every request shape,
+                # so try both and let the count check in
+                # _get_latest_user_text_indices pick the one that does:
+                #   - request_data["messages"] is the original, unfiltered list. It
+                #     is the aligned source for Anthropic /v1/messages, whose
+                #     structured_messages carries a system entry injected by
+                #     translation that has no counterpart in `texts`.
+                #   - structured_messages is built alongside `texts` by the
+                #     translation handler. It is the aligned source when a skip flag
+                #     scoped a message out upstream, and the only source at all for
+                #     /v1/responses, whose request_data carries `input` rather than
+                #     `messages`.
+                # If neither walks to the same text count, scannable_indices stays
+                # None and the existing role filter below engages unchanged.
                 if self._use_latest_user_only(request_data, logging_obj):
-                    original_messages: Final = request_data.get("messages")
-                    if original_messages:
-                        scannable_indices = self._get_latest_user_text_indices(texts, original_messages)
+                    for candidate in (request_data.get("messages"), structured_messages):
+                        if not candidate:
+                            continue
+                        scannable_indices = self._get_latest_user_text_indices(texts, candidate)
+                        if scannable_indices is not None:
+                            break
                 # Fall through to existing role filtering if:
                 # - latest-only not enabled for this request, OR
                 # - no original messages, OR

--- a/litellm/types/proxy/guardrails/guardrail_hooks/panw_prisma_airs.py
+++ b/litellm/types/proxy/guardrails/guardrail_hooks/panw_prisma_airs.py
@@ -54,9 +54,11 @@ class PanwPrismaAirsGuardrailConfigModel(GuardrailConfigModel):
 
     experimental_use_latest_role_message_only: bool | None = Field(
         default=None,
-        description="Anthropic /v1/messages only. When unset: scans only latest user/developer "
-        "message on request side. Set false to scan all user/system/developer messages. "
-        "Non-Anthropic unaffected.",
+        description="Scan only the latest user/developer message on the request side instead of "
+        "the full conversation history. Set true to enable for every request shape (avoids "
+        "rescanning prior turns on every call of a multi-turn conversation); set false to always "
+        "scan all user/system/developer messages. When unset: defaults to latest-only for "
+        "Anthropic /v1/messages requests and full-history for all other request shapes.",
     )
 
     @staticmethod

--- a/litellm/types/proxy/guardrails/guardrail_hooks/panw_prisma_airs.py
+++ b/litellm/types/proxy/guardrails/guardrail_hooks/panw_prisma_airs.py
@@ -58,7 +58,10 @@ class PanwPrismaAirsGuardrailConfigModel(GuardrailConfigModel):
         "the full conversation history. Set true to enable for every request shape (avoids "
         "rescanning prior turns on every call of a multi-turn conversation); set false to always "
         "scan all user/system/developer messages. When unset: defaults to latest-only for "
-        "Anthropic /v1/messages requests and full-history for all other request shapes.",
+        "Anthropic /v1/messages requests and full-history for all other request shapes. "
+        "Latest-only scanning trusts caller-supplied history: earlier messages in the request "
+        "are not rescanned, so enable it only where each turn was scanned when it was the "
+        "latest message (well-behaved chat clients) or history is server-controlled.",
     )
 
     @staticmethod

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_panw_prisma_airs.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_panw_prisma_airs.py
@@ -5121,12 +5121,14 @@ class TestPanwAirsLatestRoleMessageOnlyOpenAIShape:
         ) as mock_api:
             mock_api.return_value = {"action": "allow", "category": "benign"}
 
-            await handler.apply_guardrail(
+            result = await handler.apply_guardrail(
                 inputs=inputs,
                 request_data=request_data,
                 input_type="request",
             )
 
+            # All texts pass through unmodified on allow
+            assert result["texts"] == ["system text", "assistant text"]
             # Fallback role-filter scan: system scanned, assistant skipped
             assert mock_api.call_count == 1
             assert mock_api.call_args.kwargs["content"] == "system text"
@@ -5229,12 +5231,14 @@ class TestPanwAirsLatestRoleMessageOnlyOpenAIShape:
         ) as mock_api:
             mock_api.return_value = {"action": "allow", "category": "benign"}
 
-            await handler.apply_guardrail(
+            result = await handler.apply_guardrail(
                 inputs=inputs,
                 request_data=openai_multiturn_request_data,
                 input_type="response",
             )
 
+            # All texts pass through unmodified on allow
+            assert result["texts"] == ["response text one", "response text two"]
             # Both response texts scanned; scope filtering is request-side only
             assert mock_api.call_count == 2
 

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_panw_prisma_airs.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_panw_prisma_airs.py
@@ -4538,10 +4538,19 @@ class TestPanwAirsLatestRoleMessageOnly:
             assert mock_api.call_args.kwargs["content"] == "Latest user message"
 
     @pytest.mark.asyncio
-    async def test_non_anthropic_any_flag_unchanged(self):
-        """Non-Anthropic + any flag state: existing role-filter behavior."""
-        # Even with flag explicitly True, non-Anthropic should not change
-        handler = make_handler(experimental_use_latest_role_message_only=True)
+    @pytest.mark.parametrize("flag_value", [None, False])
+    async def test_non_anthropic_flag_unset_or_false_full_scan(self, flag_value):
+        """Non-Anthropic + flag unset or False: existing role-filter behavior.
+
+        The unset default for non-Anthropic requests must stay full-history:
+        only an explicit True opts a request shape into latest-only scanning.
+        """
+        overrides = (
+            {}
+            if flag_value is None
+            else {"experimental_use_latest_role_message_only": flag_value}
+        )
+        handler = make_handler(**overrides)
 
         inputs: GenericGuardrailAPIInputs = {
             "texts": ["user prompt", "assistant reply", "system instruction"],
@@ -4922,6 +4931,312 @@ class TestPanwAirsLatestRoleMessageOnly:
                 mock_api.call_args.kwargs["content"]
                 == "Developer instruction after user"
             )
+
+
+class TestPanwAirsLatestRoleMessageOnlyOpenAIShape:
+    """Latest-user-only scanning for OpenAI-shaped /v1/chat/completions requests.
+
+    Before this behavior was added, experimental_use_latest_role_message_only was
+    silently ignored for any request the handler did not classify as a native
+    Anthropic /v1/messages call, so every turn of a multi-turn conversation
+    rescanned the full user/system history (per-turn scan size grows linearly
+    with turn count, cumulative scanned tokens grow quadratically). An explicit
+    True now scopes scanning to the latest user/developer message for every
+    request shape; the unset default is unchanged (full history for
+    non-Anthropic requests).
+    """
+
+    @pytest.fixture
+    def openai_multiturn_request_data(self):
+        """Multi-turn OpenAI chat-completions request data (system + history)."""
+        return {
+            "litellm_call_id": "test-call-id",
+            "model": "gemini-2.5-flash",
+            "messages": [
+                {"role": "system", "content": "You are a helpful assistant"},
+                {"role": "user", "content": "First user message"},
+                {"role": "assistant", "content": "First assistant reply"},
+                {"role": "user", "content": "Second user message"},
+                {"role": "assistant", "content": "Second assistant reply"},
+                {"role": "user", "content": "Latest user message"},
+            ],
+            "proxy_server_request": {
+                "url": "http://localhost:4000/v1/chat/completions",
+            },
+        }
+
+    @pytest.fixture
+    def openai_multiturn_inputs(self):
+        """Inputs matching openai_multiturn_request_data (texts in message order)."""
+        return GenericGuardrailAPIInputs(
+            texts=[
+                "You are a helpful assistant",
+                "First user message",
+                "First assistant reply",
+                "Second user message",
+                "Second assistant reply",
+                "Latest user message",
+            ],
+            structured_messages=[
+                {"role": "system", "content": "You are a helpful assistant"},
+                {"role": "user", "content": "First user message"},
+                {"role": "assistant", "content": "First assistant reply"},
+                {"role": "user", "content": "Second user message"},
+                {"role": "assistant", "content": "Second assistant reply"},
+                {"role": "user", "content": "Latest user message"},
+            ],
+        )
+
+    @pytest.mark.asyncio
+    async def test_flag_true_openai_scans_latest_user_only(
+        self, openai_multiturn_request_data, openai_multiturn_inputs
+    ):
+        """OpenAI shape + flag True: only the latest user message is scanned."""
+        handler = make_handler(experimental_use_latest_role_message_only=True)
+
+        with patch.object(
+            handler, "_call_panw_api", new_callable=AsyncMock
+        ) as mock_api:
+            mock_api.return_value = {"action": "allow", "category": "benign"}
+
+            result = await handler.apply_guardrail(
+                inputs=openai_multiturn_inputs,
+                request_data=openai_multiturn_request_data,
+                input_type="request",
+            )
+
+            assert mock_api.call_count == 1
+            assert mock_api.call_args.kwargs["content"] == "Latest user message"
+            # All texts preserved in output
+            assert result["texts"] == list(openai_multiturn_inputs["texts"])
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("flag_value", [None, False])
+    async def test_flag_unset_or_false_openai_full_history_scan(
+        self, flag_value, openai_multiturn_request_data, openai_multiturn_inputs
+    ):
+        """OpenAI shape + flag unset or False: full-history role-filter scan.
+
+        Guards against silently flipping the default: users who have not set the
+        flag must keep today's behavior (system + every user turn scanned).
+        """
+        overrides = (
+            {}
+            if flag_value is None
+            else {"experimental_use_latest_role_message_only": flag_value}
+        )
+        handler = make_handler(**overrides)
+
+        with patch.object(
+            handler, "_call_panw_api", new_callable=AsyncMock
+        ) as mock_api:
+            mock_api.return_value = {"action": "allow", "category": "benign"}
+
+            await handler.apply_guardrail(
+                inputs=openai_multiturn_inputs,
+                request_data=openai_multiturn_request_data,
+                input_type="request",
+            )
+
+            # system + 3 user messages scanned, 2 assistant replies skipped
+            assert mock_api.call_count == 4
+            scanned = [call.kwargs["content"] for call in mock_api.call_args_list]
+            assert "You are a helpful assistant" in scanned
+            assert "First user message" in scanned
+            assert "Second user message" in scanned
+            assert "Latest user message" in scanned
+            assert "First assistant reply" not in scanned
+            assert "Second assistant reply" not in scanned
+
+    @pytest.mark.asyncio
+    async def test_flag_true_count_mismatch_falls_back_to_role_filter(self):
+        """OpenAI shape + flag True + texts/messages count mismatch: safety fallback.
+
+        When request_data["messages"] does not walk to the same text count as
+        the flattened texts (e.g. a message was scoped out upstream),
+        _get_latest_user_text_indices returns None and the existing role-filter
+        scan over structured_messages must engage.
+        """
+        handler = make_handler(experimental_use_latest_role_message_only=True)
+
+        inputs: GenericGuardrailAPIInputs = {
+            "texts": ["system text", "user one", "user two"],
+            "structured_messages": [
+                {"role": "system", "content": "system text"},
+                {"role": "user", "content": "user one"},
+                {"role": "user", "content": "user two"},
+            ],
+        }
+        # messages has one extra entry vs texts → count mismatch → fallback
+        request_data = {
+            "litellm_call_id": "test-call-id",
+            "model": "gemini-2.5-flash",
+            "messages": [
+                {"role": "system", "content": "system text"},
+                {"role": "user", "content": "user one"},
+                {"role": "user", "content": "user two"},
+                {"role": "user", "content": "not represented in texts"},
+            ],
+        }
+
+        with patch.object(
+            handler, "_call_panw_api", new_callable=AsyncMock
+        ) as mock_api:
+            mock_api.return_value = {"action": "allow", "category": "benign"}
+
+            await handler.apply_guardrail(
+                inputs=inputs,
+                request_data=request_data,
+                input_type="request",
+            )
+
+            # Fallback role-filter scan: all system/user texts scanned
+            assert mock_api.call_count == 3
+            scanned = [call.kwargs["content"] for call in mock_api.call_args_list]
+            assert scanned == ["system text", "user one", "user two"]
+
+    @pytest.mark.asyncio
+    async def test_flag_true_no_user_message_falls_back(self):
+        """OpenAI shape + flag True + no user/developer message: safety fallback."""
+        handler = make_handler(experimental_use_latest_role_message_only=True)
+
+        inputs: GenericGuardrailAPIInputs = {
+            "texts": ["system text", "assistant text"],
+            "structured_messages": [
+                {"role": "system", "content": "system text"},
+                {"role": "assistant", "content": "assistant text"},
+            ],
+        }
+        request_data = {
+            "litellm_call_id": "test-call-id",
+            "model": "gemini-2.5-flash",
+            "messages": [
+                {"role": "system", "content": "system text"},
+                {"role": "assistant", "content": "assistant text"},
+            ],
+        }
+
+        with patch.object(
+            handler, "_call_panw_api", new_callable=AsyncMock
+        ) as mock_api:
+            mock_api.return_value = {"action": "allow", "category": "benign"}
+
+            await handler.apply_guardrail(
+                inputs=inputs,
+                request_data=request_data,
+                input_type="request",
+            )
+
+            # Fallback role-filter scan: system scanned, assistant skipped
+            assert mock_api.call_count == 1
+            assert mock_api.call_args.kwargs["content"] == "system text"
+
+    @pytest.mark.asyncio
+    async def test_flag_true_tool_calls_still_scanned(
+        self, openai_multiturn_request_data, openai_multiturn_inputs
+    ):
+        """OpenAI shape + flag True: tool-call scanning is unaffected by scan scope."""
+        handler = make_handler(experimental_use_latest_role_message_only=True)
+
+        inputs = dict(openai_multiturn_inputs)
+        inputs["tool_calls"] = [
+            {
+                "id": "call_1",
+                "type": "function",
+                "function": {"name": "get_weather", "arguments": '{"city": "Paris"}'},
+            }
+        ]
+
+        with patch.object(
+            handler, "_call_panw_api", new_callable=AsyncMock
+        ) as mock_api:
+            mock_api.return_value = {"action": "allow", "category": "benign"}
+
+            await handler.apply_guardrail(
+                inputs=inputs,
+                request_data=openai_multiturn_request_data,
+                input_type="request",
+            )
+
+            # 1 text scan (latest user message) + 1 tool-call scan
+            assert mock_api.call_count == 2
+            scanned = [call.kwargs["content"] for call in mock_api.call_args_list]
+            assert "Latest user message" in scanned
+            assert 'get_weather\n{"city": "Paris"}' in scanned
+
+    @pytest.mark.asyncio
+    async def test_flag_true_masking_applies_to_latest_message_only(
+        self, openai_multiturn_request_data, openai_multiturn_inputs
+    ):
+        """OpenAI shape + flag True + DLP masking: masked text replaces only the
+        scanned (latest) message; unscanned history texts pass through untouched."""
+        handler = make_handler(experimental_use_latest_role_message_only=True)
+
+        with patch.object(
+            handler, "_call_panw_api", new_callable=AsyncMock
+        ) as mock_api:
+            mock_api.return_value = {
+                "action": "allow",
+                "category": "dlp",
+                "prompt_masked_data": {"data": "Latest user message [MASKED]"},
+            }
+
+            result = await handler.apply_guardrail(
+                inputs=openai_multiturn_inputs,
+                request_data=openai_multiturn_request_data,
+                input_type="request",
+            )
+
+            assert mock_api.call_count == 1
+            expected = list(openai_multiturn_inputs["texts"])
+            expected[-1] = "Latest user message [MASKED]"
+            assert result["texts"] == expected
+
+    @pytest.mark.asyncio
+    async def test_flag_true_block_on_latest_message_still_blocks(
+        self, openai_multiturn_request_data, openai_multiturn_inputs
+    ):
+        """OpenAI shape + flag True: a block verdict on the latest message raises."""
+        handler = make_handler(experimental_use_latest_role_message_only=True)
+
+        with patch.object(
+            handler, "_call_panw_api", new_callable=AsyncMock
+        ) as mock_api:
+            mock_api.return_value = {"action": "block", "category": "injection"}
+
+            with pytest.raises(HTTPException) as exc_info:
+                await handler.apply_guardrail(
+                    inputs=openai_multiturn_inputs,
+                    request_data=openai_multiturn_request_data,
+                    input_type="request",
+                )
+
+            assert exc_info.value.status_code == 400
+
+    @pytest.mark.asyncio
+    async def test_flag_true_response_side_unaffected(
+        self, openai_multiturn_request_data
+    ):
+        """Response-side scanning ignores the request-side scope flag."""
+        handler = make_handler(experimental_use_latest_role_message_only=True)
+
+        inputs: GenericGuardrailAPIInputs = {
+            "texts": ["response text one", "response text two"],
+        }
+
+        with patch.object(
+            handler, "_call_panw_api", new_callable=AsyncMock
+        ) as mock_api:
+            mock_api.return_value = {"action": "allow", "category": "benign"}
+
+            await handler.apply_guardrail(
+                inputs=inputs,
+                request_data=openai_multiturn_request_data,
+                input_type="response",
+            )
+
+            # Both response texts scanned; scope filtering is request-side only
+            assert mock_api.call_count == 2
 
 
 class TestPanwAirsMcpToolCallWithoutCallId:

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_panw_prisma_airs.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_panw_prisma_airs.py
@@ -5051,12 +5051,14 @@ class TestPanwAirsLatestRoleMessageOnlyOpenAIShape:
 
     @pytest.mark.asyncio
     async def test_flag_true_count_mismatch_falls_back_to_role_filter(self):
-        """OpenAI shape + flag True + texts/messages count mismatch: safety fallback.
+        """OpenAI shape + flag True + request_data["messages"] mismatch:
+        structured_messages carries the scope.
 
         When request_data["messages"] does not walk to the same text count as
         the flattened texts (e.g. a message was scoped out upstream),
-        _get_latest_user_text_indices returns None and the existing role-filter
-        scan over structured_messages must engage.
+        structured_messages is the source that stays aligned with `texts`, so
+        latest-only scanning still engages through it rather than degrading to
+        a full-history scan.
         """
         handler = make_handler(experimental_use_latest_role_message_only=True)
 
@@ -5091,10 +5093,11 @@ class TestPanwAirsLatestRoleMessageOnlyOpenAIShape:
                 input_type="request",
             )
 
-            # Fallback role-filter scan: all system/user texts scanned
-            assert mock_api.call_count == 3
+            # structured_messages aligns with texts, so only the latest user
+            # message is scanned - no degradation to a full-history scan.
+            assert mock_api.call_count == 1
             scanned = [call.kwargs["content"] for call in mock_api.call_args_list]
-            assert scanned == ["system text", "user one", "user two"]
+            assert scanned == ["user two"]
 
     @pytest.mark.asyncio
     async def test_flag_true_no_user_message_falls_back(self):
@@ -5242,6 +5245,116 @@ class TestPanwAirsLatestRoleMessageOnlyOpenAIShape:
             assert result["texts"] == ["response text one", "response text two"]
             # Both response texts scanned; scope filtering is request-side only
             assert mock_api.call_count == 2
+
+
+class TestPanwAirsLatestRoleMessageOnlyResponsesShape:
+    """/v1/responses requests carry `input`, not `messages`, so request_data has no
+    messages list. structured_messages is the only aligned source there."""
+
+    @pytest.mark.asyncio
+    async def test_responses_shape_scans_latest_user_only(self):
+        handler = make_handler(experimental_use_latest_role_message_only=True)
+
+        inputs: GenericGuardrailAPIInputs = {
+            "texts": ["first user turn", "first assistant turn", "latest user turn"],
+            "structured_messages": [
+                {"role": "user", "content": "first user turn"},
+                {"role": "assistant", "content": "first assistant turn"},
+                {"role": "user", "content": "latest user turn"},
+            ],
+        }
+        # No "messages" key - this is what a Responses request looks like.
+        request_data = {
+            "litellm_call_id": "test-call-id",
+            "model": "gpt-4.1",
+            "input": "latest user turn",
+            "proxy_server_request": {"url": "http://localhost:4000/v1/responses"},
+        }
+
+        with patch.object(
+            handler, "_call_panw_api", new_callable=AsyncMock
+        ) as mock_api:
+            mock_api.return_value = {"action": "allow", "category": "benign"}
+
+            await handler.apply_guardrail(
+                inputs=inputs, request_data=request_data, input_type="request"
+            )
+
+            assert mock_api.call_count == 1
+            scanned = [c.kwargs["content"] for c in mock_api.call_args_list]
+            assert scanned == ["latest user turn"]
+
+    @pytest.mark.asyncio
+    async def test_responses_shape_full_history_when_flag_unset(self):
+        handler = make_handler()
+
+        inputs: GenericGuardrailAPIInputs = {
+            "texts": ["first user turn", "latest user turn"],
+            "structured_messages": [
+                {"role": "user", "content": "first user turn"},
+                {"role": "user", "content": "latest user turn"},
+            ],
+        }
+        request_data = {
+            "litellm_call_id": "test-call-id",
+            "model": "gpt-4.1",
+            "input": "latest user turn",
+            "proxy_server_request": {"url": "http://localhost:4000/v1/responses"},
+        }
+
+        with patch.object(
+            handler, "_call_panw_api", new_callable=AsyncMock
+        ) as mock_api:
+            mock_api.return_value = {"action": "allow", "category": "benign"}
+
+            result = await handler.apply_guardrail(
+                inputs=inputs, request_data=request_data, input_type="request"
+            )
+
+            # Unset default is unchanged for non-Anthropic shapes: every user turn
+            # is sent for scanning, and all texts pass through on allow.
+            scanned = [c.kwargs["content"] for c in mock_api.call_args_list]
+            assert scanned == ["first user turn", "latest user turn"]
+            assert result["texts"] == ["first user turn", "latest user turn"]
+
+    @pytest.mark.asyncio
+    async def test_both_sources_mismatch_falls_back_to_role_filter(self):
+        """When neither message source walks to the same text count, the existing
+        role-filter scan engages - the original safety fallback."""
+        handler = make_handler(experimental_use_latest_role_message_only=True)
+
+        inputs: GenericGuardrailAPIInputs = {
+            "texts": ["system text", "user one", "user two"],
+            "structured_messages": [
+                {"role": "system", "content": "system text"},
+                {"role": "user", "content": "user one"},
+                {"role": "user", "content": "user two"},
+                {"role": "user", "content": "extra, not in texts"},
+            ],
+        }
+        request_data = {
+            "litellm_call_id": "test-call-id",
+            "model": "gemini-2.5-flash",
+            "messages": [
+                {"role": "system", "content": "system text"},
+                {"role": "user", "content": "user one"},
+                {"role": "user", "content": "user two"},
+                {"role": "user", "content": "also not in texts"},
+            ],
+        }
+
+        with patch.object(
+            handler, "_call_panw_api", new_callable=AsyncMock
+        ) as mock_api:
+            mock_api.return_value = {"action": "allow", "category": "benign"}
+
+            await handler.apply_guardrail(
+                inputs=inputs, request_data=request_data, input_type="request"
+            )
+
+            assert mock_api.call_count == 3
+            scanned = [c.kwargs["content"] for c in mock_api.call_args_list]
+            assert scanned == ["system text", "user one", "user two"]
 
 
 class TestPanwAirsLatestRoleMessageOnlyStartupWarning:

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_panw_prisma_airs.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_panw_prisma_airs.py
@@ -11,6 +11,7 @@ This test file follows LiteLLM's testing patterns and covers:
 
 import copy
 import json
+import logging
 from datetime import datetime
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -5247,24 +5248,24 @@ class TestPanwAirsLatestRoleMessageOnlyStartupWarning:
     """Enabling latest-only scanning trusts caller-supplied history, so the operator
     gets an explicit startup warning - same treatment as fallback_on_error='allow'."""
 
-    def test_warns_when_explicitly_enabled(self):
-        with patch(
-            "litellm.proxy.guardrails.guardrail_hooks.panw_prisma_airs.panw_prisma_airs.verbose_proxy_logger"
-        ) as mock_logger:
+    def test_warns_when_explicitly_enabled(self, caplog):
+        with caplog.at_level(logging.WARNING, logger="LiteLLM Proxy"):
             make_handler(experimental_use_latest_role_message_only=True)
 
-        warned = " ".join(str(c) for c in mock_logger.warning.call_args_list)
+        warned = " ".join(
+            r.getMessage() for r in caplog.records if r.levelno >= logging.WARNING
+        )
         assert "experimental_use_latest_role_message_only=true" in warned
         assert "not rescanned" in warned
 
     @pytest.mark.parametrize("flag", [None, False])
-    def test_no_warning_when_unset_or_disabled(self, flag):
-        with patch(
-            "litellm.proxy.guardrails.guardrail_hooks.panw_prisma_airs.panw_prisma_airs.verbose_proxy_logger"
-        ) as mock_logger:
+    def test_no_warning_when_unset_or_disabled(self, caplog, flag):
+        with caplog.at_level(logging.WARNING, logger="LiteLLM Proxy"):
             make_handler(experimental_use_latest_role_message_only=flag)
 
-        warned = " ".join(str(c) for c in mock_logger.warning.call_args_list)
+        warned = " ".join(
+            r.getMessage() for r in caplog.records if r.levelno >= logging.WARNING
+        )
         assert "experimental_use_latest_role_message_only" not in warned
 
 

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_panw_prisma_airs.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_panw_prisma_airs.py
@@ -5243,6 +5243,31 @@ class TestPanwAirsLatestRoleMessageOnlyOpenAIShape:
             assert mock_api.call_count == 2
 
 
+class TestPanwAirsLatestRoleMessageOnlyStartupWarning:
+    """Enabling latest-only scanning trusts caller-supplied history, so the operator
+    gets an explicit startup warning - same treatment as fallback_on_error='allow'."""
+
+    def test_warns_when_explicitly_enabled(self):
+        with patch(
+            "litellm.proxy.guardrails.guardrail_hooks.panw_prisma_airs.panw_prisma_airs.verbose_proxy_logger"
+        ) as mock_logger:
+            make_handler(experimental_use_latest_role_message_only=True)
+
+        warned = " ".join(str(c) for c in mock_logger.warning.call_args_list)
+        assert "experimental_use_latest_role_message_only=true" in warned
+        assert "not rescanned" in warned
+
+    @pytest.mark.parametrize("flag", [None, False])
+    def test_no_warning_when_unset_or_disabled(self, flag):
+        with patch(
+            "litellm.proxy.guardrails.guardrail_hooks.panw_prisma_airs.panw_prisma_airs.verbose_proxy_logger"
+        ) as mock_logger:
+            make_handler(experimental_use_latest_role_message_only=flag)
+
+        warned = " ".join(str(c) for c in mock_logger.warning.call_args_list)
+        assert "experimental_use_latest_role_message_only" not in warned
+
+
 class TestPanwAirsMcpToolCallWithoutCallId:
     """Tests for MCP tool invocations flowing through apply_guardrail without
     litellm_call_id — the bug fix for _convert_mcp_to_llm_format synthetic data."""


### PR DESCRIPTION
## Problem

`experimental_use_latest_role_message_only` is silently ignored for any request that is not a native Anthropic `/v1/messages` call. For standard OpenAI-compatible `/v1/chat/completions` traffic (Vertex/Gemini, Azure OpenAI, Bedrock, including Bedrock-hosted Claude), the guardrail rescans the system prompt and every prior user turn on every call of a multi-turn conversation, so cumulative scanned tokens grow quadratically with session length.

Measured live against the AIRS Scan API on an 8-turn conversation: 3,121 tokens scanned vs 419 latest-message-only, a 7.45x multiplier (86.6% reduction), projected ~23.5x at 40 turns.

## Change

`_use_latest_user_only()` now resolves the flag first and only uses the request shape to pick the unset default:

- Flag explicitly `true`/`false`: respected for every request shape.
- Flag unset: unchanged defaults, latest-only for Anthropic `/v1/messages`, full history otherwise.

`_get_latest_user_text_indices()` is already provider-agnostic and its safety fallbacks (count mismatch, no user message) apply unchanged on the new path. Masking, DLP, tool-call, and MCP scanning are untouched. The config field description is updated to match.

This matches the semantics the `bedrock` guardrail already has for the same flag and the provider-agnostic description on `BaseLitellmParams`; the only behavior cell that changes (explicit `true` on a non-Anthropic request) was a silent no-op. `only_scan_new_messages` is not a substitute: it needs a session id plus a shared cache, falls back to full scans, and is incompatible with masking.

## Tests

- New `TestPanwAirsLatestRoleMessageOnlyOpenAIShape`: latest-only with flag on, full-history preserved with flag unset/false, both safety fallbacks, tool-call scanning, masking scoped to the scanned message, block behavior, response-side independence.
- Updated the one existing test that pinned the old no-op.
- Full `test_panw_prisma_airs.py` suite: 221 passed. Anthropic-path tests unchanged and green.

## End-to-end validation

Replayed the same 8-turn conversation through a local proxy running this patch (`/v1/chat/completions` to a Gemini-backed alias), guardrail `api_base` routed through a recording forwarder to the live AIRS endpoint:

| | Scan calls | Tokens scanned |
|---|---|---|
| Flag unset (default, unchanged) | 44 | 3,126 |
| Flag `true` | 8 (1 per turn, latest message only) | 419 |

7.46x / 86.6% reduction, matching the direct-API baseline. Every scan returned a live verdict and scan_id.

## Behavior changes

None for flag unset or explicit `false`. Explicit `true` now takes effect on non-Anthropic request shapes (previously a no-op). No public API changes, no new dependencies.

https://claude.ai/code/session_019e3TmBntsNQTBbXB9iu9uZ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which prompt text is sent to the security scanner; explicit `true` can skip rescanning prior turns in client-controlled history, though defaults and explicit `false` are unchanged.
> 
> **Overview**
> Fixes **`experimental_use_latest_role_message_only`** being a no-op outside native Anthropic `/v1/messages` traffic. On OpenAI-style `/v1/chat/completions` and similar paths, multi-turn requests were still sending the system prompt and every prior user turn to PANW on each call.
> 
> **`_use_latest_user_only()`** now applies explicit **`true`/`false`** for every request shape (aligned with how operators expect the shared flag to work). When the flag is **unset**, behavior is unchanged: latest-user-only for Anthropic `/v1/messages`, full user/system/developer history elsewhere.
> 
> **Request-side index selection** tries **`request_data["messages"]`** then **`structured_messages`**, so latest-only scanning works for `/v1/responses` (no `messages`) and when upstream scoping desyncs the raw message list from flattened `texts`. Existing fallbacks (count mismatch, no user message → role-filter scan) stay the same.
> 
> Operators who set the flag to **`true`** get a **startup warning** that caller-supplied history is not rescanned. Config field docs are updated. Tests cover OpenAI and Responses shapes, masking, blocks, tool calls, and the warning.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7a1cf6509f3d86958fd9b6ddda41b9641ae32a3e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/berriai/litellm/pull/38977" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->