### PR TITLE
feat(bedrock): allow configuring batch job timeout beyond the 24h default

### DIFF
--- a/litellm/llms/bedrock/batches/transformation.py
+++ b/litellm/llms/bedrock/batches/transformation.py
@@ -68,7 +68,7 @@ _BEDROCK_BATCH_TIMEOUT_HOURS_ADAPTER: Final[TypeAdapter[int]] = TypeAdapter(int)
 
 def _validate_bedrock_batch_timeout_hours(raw_value: object) -> int:
     try:
-        hours = _BEDROCK_BATCH_TIMEOUT_HOURS_ADAPTER.validate_python(raw_value, strict=True)
+        hours: Final = _BEDROCK_BATCH_TIMEOUT_HOURS_ADAPTER.validate_python(raw_value, strict=True)
     except ValidationError as e:
         raise ValueError(
             f"Invalid 'bedrock_batch_timeout_hours' value {raw_value!r}. Expected an int between "

--- a/litellm/llms/bedrock/batches/transformation.py
+++ b/litellm/llms/bedrock/batches/transformation.py
@@ -60,6 +60,28 @@ def _validate_bedrock_tags(raw_tags: object) -> list[BedrockTag]:
         ) from e
 
 
+BEDROCK_BATCH_TIMEOUT_MIN_HOURS: Final = 24
+BEDROCK_BATCH_TIMEOUT_MAX_HOURS: Final = 168
+
+_BEDROCK_BATCH_TIMEOUT_HOURS_ADAPTER: Final[TypeAdapter[int]] = TypeAdapter(int)
+
+
+def _validate_bedrock_batch_timeout_hours(raw_value: object) -> int:
+    try:
+        hours = _BEDROCK_BATCH_TIMEOUT_HOURS_ADAPTER.validate_python(raw_value, strict=True)
+    except ValidationError as e:
+        raise ValueError(
+            f"Invalid 'bedrock_batch_timeout_hours' value {raw_value!r}. Expected an int between "
+            f"{BEDROCK_BATCH_TIMEOUT_MIN_HOURS} and {BEDROCK_BATCH_TIMEOUT_MAX_HOURS}."
+        ) from e
+    if not (BEDROCK_BATCH_TIMEOUT_MIN_HOURS <= hours <= BEDROCK_BATCH_TIMEOUT_MAX_HOURS):
+        raise ValueError(
+            f"'bedrock_batch_timeout_hours' must be between {BEDROCK_BATCH_TIMEOUT_MIN_HOURS} and "
+            f"{BEDROCK_BATCH_TIMEOUT_MAX_HOURS} (Bedrock's supported range), got {hours}."
+        )
+    return hours
+
+
 class BedrockBatchesConfig(BaseAWSLLM, BaseBatchesConfig):
     """
     Config for Bedrock Batches - handles batch job creation and management for Bedrock
@@ -234,12 +256,19 @@ class BedrockBatchesConfig(BaseAWSLLM, BaseBatchesConfig):
             bedrock_request["tags"] = _validate_bedrock_tags(bedrock_tags)
 
         # Add optional parameters if provided
+        config_batch_timeout_hours: Final = litellm_params.get("bedrock_batch_timeout_hours")
+        batch_timeout_hours: Final = (
+            config_batch_timeout_hours
+            if config_batch_timeout_hours is not None
+            else optional_params.get("bedrock_batch_timeout_hours")
+        )
         completion_window: Final = create_batch_data.get("completion_window")
-        if completion_window:
+        if batch_timeout_hours is not None:
+            bedrock_request["timeoutDurationInHours"] = _validate_bedrock_batch_timeout_hours(batch_timeout_hours)
+        elif completion_window == "24h":
             # Map OpenAI completion window to Bedrock timeout
             # OpenAI uses "24h", Bedrock expects timeout in hours
-            if completion_window == "24h":
-                bedrock_request["timeoutDurationInHours"] = 24
+            bedrock_request["timeoutDurationInHours"] = 24
 
         # For Bedrock, we need to return a pre-signed request with AWS auth headers
         # Use common utility for AWS signing

--- a/litellm/proxy/auth/auth_utils.py
+++ b/litellm/proxy/auth/auth_utils.py
@@ -297,6 +297,7 @@ _BANNED_REQUEST_BODY_PARAMS: Final[tuple[str, ...]] = (
     # reachable with the deployment's shared AWS credentials.
     "aws_bedrock_project_id",
     "bedrock_tags",
+    "bedrock_batch_timeout_hours",
     # Provider-specific endpoint overrides that flow into the outbound
     # request via ``optional_params``. Same threat as ``api_base``:
     # ``s3_endpoint_url`` redirects Bedrock file uploads to attacker

--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -3525,6 +3525,7 @@ bedrock_batch_litellm_params: Final = (
     "s3_region_name",
     "s3_output_bucket_name",
     "bedrock_tags",
+    "bedrock_batch_timeout_hours",
 )
 
 all_litellm_params = (

--- a/tests/test_litellm/llms/bedrock/batches/test_transformation.py
+++ b/tests/test_litellm/llms/bedrock/batches/test_transformation.py
@@ -255,7 +255,9 @@ def test_create_request_no_timeout_for_non_24h_window(config):
     assert "timeoutDurationInHours" not in mock_sign.call_args.kwargs["data"]
 
 
-def test_create_request_bedrock_batch_timeout_hours_from_litellm_params(config):  # test-quality-ok: asserts the built request payload, only observable via the mocked signer's call args
+def test_create_request_bedrock_batch_timeout_hours_from_litellm_params(  # test-quality-ok: like bedrock_tags
+    config,
+):
     with patch.object(
         config.common_utils,
         "generate_unique_job_name",
@@ -274,7 +276,9 @@ def test_create_request_bedrock_batch_timeout_hours_from_litellm_params(config):
     assert mock_sign.call_args.kwargs["data"]["timeoutDurationInHours"] == 72
 
 
-def test_create_request_bedrock_batch_timeout_hours_from_optional_params(config):  # test-quality-ok: asserts the built request payload, only observable via the mocked signer's call args
+def test_create_request_bedrock_batch_timeout_hours_from_optional_params(  # test-quality-ok: like bedrock_tags
+    config,
+):
     with patch.object(
         config.common_utils,
         "generate_unique_job_name",
@@ -290,7 +294,7 @@ def test_create_request_bedrock_batch_timeout_hours_from_optional_params(config)
     assert mock_sign.call_args.kwargs["data"]["timeoutDurationInHours"] == 100
 
 
-def test_create_request_bedrock_batch_timeout_hours_litellm_params_takes_precedence_over_optional_params(  # test-quality-ok: asserts the built request payload, only observable via the mocked signer's call args
+def test_create_request_bedrock_batch_timeout_hours_prefers_litellm_params(  # test-quality-ok: like bedrock_tags
     config,
 ):
     with patch.object(
@@ -311,7 +315,9 @@ def test_create_request_bedrock_batch_timeout_hours_litellm_params_takes_precede
     assert mock_sign.call_args.kwargs["data"]["timeoutDurationInHours"] == 168
 
 
-def test_create_request_bedrock_batch_timeout_hours_overrides_completion_window(config):  # test-quality-ok: asserts the built request payload, only observable via the mocked signer's call args
+def test_create_request_bedrock_batch_timeout_hours_overrides_completion_window(  # test-quality-ok: like bedrock_tags
+    config,
+):
     with patch.object(
         config.common_utils,
         "generate_unique_job_name",
@@ -333,7 +339,7 @@ def test_create_request_bedrock_batch_timeout_hours_overrides_completion_window(
     assert mock_sign.call_args.kwargs["data"]["timeoutDurationInHours"] == 96
 
 
-def test_create_request_bedrock_batch_timeout_hours_absent_falls_back_to_completion_window(  # test-quality-ok: asserts the built request payload, only observable via the mocked signer's call args
+def test_create_request_bedrock_batch_timeout_hours_default_completion_window(  # test-quality-ok: like bedrock_tags
     config,
 ):
     with patch.object(

--- a/tests/test_litellm/llms/bedrock/batches/test_transformation.py
+++ b/tests/test_litellm/llms/bedrock/batches/test_transformation.py
@@ -255,6 +255,128 @@ def test_create_request_no_timeout_for_non_24h_window(config):
     assert "timeoutDurationInHours" not in mock_sign.call_args.kwargs["data"]
 
 
+def test_create_request_bedrock_batch_timeout_hours_from_litellm_params(config):  # test-quality-ok: asserts the built request payload, only observable via the mocked signer's call args
+    with patch.object(
+        config.common_utils,
+        "generate_unique_job_name",
+        return_value="litellm-batch-1",
+    ), patch.object(config.common_utils, "sign_aws_request") as mock_sign:
+        mock_sign.return_value = ({}, b"{}")
+        config.transform_create_batch_request(
+            model="m",
+            create_batch_data={"input_file_id": "s3://b/in.jsonl"},
+            optional_params={},
+            litellm_params={
+                "aws_batch_role_arn": "arn:aws:iam::1:role/r",
+                "bedrock_batch_timeout_hours": 72,
+            },
+        )
+    assert mock_sign.call_args.kwargs["data"]["timeoutDurationInHours"] == 72
+
+
+def test_create_request_bedrock_batch_timeout_hours_from_optional_params(config):  # test-quality-ok: asserts the built request payload, only observable via the mocked signer's call args
+    with patch.object(
+        config.common_utils,
+        "generate_unique_job_name",
+        return_value="litellm-batch-1",
+    ), patch.object(config.common_utils, "sign_aws_request") as mock_sign:
+        mock_sign.return_value = ({}, b"{}")
+        config.transform_create_batch_request(
+            model="m",
+            create_batch_data={"input_file_id": "s3://b/in.jsonl"},
+            optional_params={"bedrock_batch_timeout_hours": 100},
+            litellm_params={"aws_batch_role_arn": "arn:aws:iam::1:role/r"},
+        )
+    assert mock_sign.call_args.kwargs["data"]["timeoutDurationInHours"] == 100
+
+
+def test_create_request_bedrock_batch_timeout_hours_litellm_params_takes_precedence_over_optional_params(  # test-quality-ok: asserts the built request payload, only observable via the mocked signer's call args
+    config,
+):
+    with patch.object(
+        config.common_utils,
+        "generate_unique_job_name",
+        return_value="litellm-batch-1",
+    ), patch.object(config.common_utils, "sign_aws_request") as mock_sign:
+        mock_sign.return_value = ({}, b"{}")
+        config.transform_create_batch_request(
+            model="m",
+            create_batch_data={"input_file_id": "s3://b/in.jsonl"},
+            optional_params={"bedrock_batch_timeout_hours": 48},
+            litellm_params={
+                "aws_batch_role_arn": "arn:aws:iam::1:role/r",
+                "bedrock_batch_timeout_hours": 168,
+            },
+        )
+    assert mock_sign.call_args.kwargs["data"]["timeoutDurationInHours"] == 168
+
+
+def test_create_request_bedrock_batch_timeout_hours_overrides_completion_window(config):  # test-quality-ok: asserts the built request payload, only observable via the mocked signer's call args
+    with patch.object(
+        config.common_utils,
+        "generate_unique_job_name",
+        return_value="litellm-batch-1",
+    ), patch.object(config.common_utils, "sign_aws_request") as mock_sign:
+        mock_sign.return_value = ({}, b"{}")
+        config.transform_create_batch_request(
+            model="m",
+            create_batch_data={
+                "input_file_id": "s3://b/in.jsonl",
+                "completion_window": "24h",
+            },
+            optional_params={},
+            litellm_params={
+                "aws_batch_role_arn": "arn:aws:iam::1:role/r",
+                "bedrock_batch_timeout_hours": 96,
+            },
+        )
+    assert mock_sign.call_args.kwargs["data"]["timeoutDurationInHours"] == 96
+
+
+def test_create_request_bedrock_batch_timeout_hours_absent_falls_back_to_completion_window(  # test-quality-ok: asserts the built request payload, only observable via the mocked signer's call args
+    config,
+):
+    with patch.object(
+        config.common_utils,
+        "generate_unique_job_name",
+        return_value="litellm-batch-1",
+    ), patch.object(config.common_utils, "sign_aws_request") as mock_sign:
+        mock_sign.return_value = ({}, b"{}")
+        config.transform_create_batch_request(
+            model="m",
+            create_batch_data={
+                "input_file_id": "s3://b/in.jsonl",
+                "completion_window": "24h",
+            },
+            optional_params={},
+            litellm_params={"aws_batch_role_arn": "arn:aws:iam::1:role/r"},
+        )
+    assert mock_sign.call_args.kwargs["data"]["timeoutDurationInHours"] == 24
+
+
+@pytest.mark.parametrize(
+    "bad_value",
+    [23, 169, "48", 24.5, True, [24]],
+)
+def test_create_request_rejects_invalid_bedrock_batch_timeout_hours(config, bad_value):
+    with patch.object(
+        config.common_utils,
+        "generate_unique_job_name",
+        return_value="litellm-batch-1",
+    ), patch.object(config.common_utils, "sign_aws_request") as mock_sign:
+        mock_sign.return_value = ({}, b"{}")
+        with pytest.raises(ValueError, match="bedrock_batch_timeout_hours"):
+            config.transform_create_batch_request(
+                model="m",
+                create_batch_data={"input_file_id": "s3://b/in.jsonl"},
+                optional_params={},
+                litellm_params={
+                    "aws_batch_role_arn": "arn:aws:iam::1:role/r",
+                    "bedrock_batch_timeout_hours": bad_value,
+                },
+            )
+
+
 def test_create_request_forwards_bedrock_tags_from_litellm_params(config):
     tags = [
         {"key": "application", "value": "genai-proxy"},


### PR DESCRIPTION
## TLDR

Problem this solves:

- Bedrock batch jobs can only be created with a 24h timeout today
- Any other `completion_window` value is silently ignored, no error
- Bedrock itself supports 24-168h (up to 7 days) for this exact job

How it solves it:

- Add `bedrock_batch_timeout_hours`, a Bedrock-only override
- Read it from `litellm_params` or `optional_params`, same as `bedrock_tags`
- Validate it against Bedrock's 24-168h range before sending it
- Register it alongside `bedrock_tags` in the batch-only param lists, so it neither leaks into non-batch requests on a shared deployment nor becomes caller-settable in the request body

## User Flow

Before: a developer submitting a long-running Bedrock batch job has no way to ask for more than a 24h timeout, and gets no warning that their request was ignored

1. They call `litellm.create_batch(model="bedrock/...", completion_window="24h", input_file_id=..., custom_llm_provider="bedrock", aws_batch_role_arn=...)` for a large job they expect to run past 24h
2. The batch is created against AWS Bedrock's `CreateModelInvocationJob` with `timeoutDurationInHours` fixed at 24, since that is the only value LiteLLM ever sends
3. If the job is still running at the 24h mark, AWS Bedrock force-stops it, and any records not yet processed are lost

After: the same developer can ask for a longer window and see it actually take effect

1. They call the same `litellm.create_batch(...)`, now also passing `bedrock_batch_timeout_hours=168`
2. The batch is created against AWS Bedrock's `CreateModelInvocationJob` with `timeoutDurationInHours` set to 168
3. The job now has up to 7 days to finish before AWS Bedrock force-stops it

## Relevant issues

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally: `uv run pytest tests/test_litellm/llms/bedrock/batches/test_transformation.py -v` (82 passed, 1 skipped, pre-existing skip unrelated to this change)
- [x] My PR passes all required CI/CD checks (ran `make lint-ruff`, `make lint-basedpyright`, `make lint-type-discipline`, `make lint-test-quality`, `check_circular_imports`, and the `from litellm import *` import-safety check locally against this branch's base; all pass)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

Both runs call `BedrockBatchesConfig.transform_create_batch_request` directly with `sign_aws_request` mocked (the same seam this file's existing tests mock), since this fix is entirely in request construction and needs no live AWS call to demonstrate: the thing under test is the JSON body LiteLLM builds and hands to Bedrock's `CreateModelInvocationJob`, not Bedrock's own behavior.

```python
from unittest.mock import patch
from litellm.llms.bedrock.batches.transformation import BedrockBatchesConfig

config = BedrockBatchesConfig()
with patch.object(config.common_utils, "generate_unique_job_name", return_value="litellm-batch-demo"), \
     patch.object(config.common_utils, "sign_aws_request") as mock_sign:
    mock_sign.return_value = ({}, b"{}")
    config.transform_create_batch_request(
        model="qwen.qwen3-235b-a22b-2507-v1:0",
        create_batch_data={
            "input_file_id": "s3://my-batch-bucket/input.jsonl",
            "endpoint": "/v1/chat/completions",
            "completion_window": "24h",
        },
        optional_params={},
        litellm_params={
            "aws_batch_role_arn": "arn:aws:iam::123456789012:role/my-batch-role",
            "bedrock_batch_timeout_hours": 168,
        },
    )

sent_request = mock_sign.call_args.kwargs["data"]
print("timeoutDurationInHours sent to Bedrock:", sent_request.get("timeoutDurationInHours"))
```

### Before (c09fa5b712)

1. Run the script above against this commit (the merge base this PR branches from)
2. Output: `timeoutDurationInHours sent to Bedrock: 24`
3. `bedrock_batch_timeout_hours` does not exist yet, so it is silently ignored and the hardcoded 24h mapping wins regardless of what the caller asked for

### After (c39c7c5c9a)

1. Run the same script, unchanged, against this PR's tip
2. Output: `timeoutDurationInHours sent to Bedrock: 168`
3. The requested 168h window is now honored

## Type

🆕 New Feature
✅ Test

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
