### PR TITLE
fix(cost): bill OCR annotation pages via annotation_cost_per_page

### DIFF
--- a/litellm/cost_calculator.py
+++ b/litellm/cost_calculator.py
@@ -1910,12 +1910,15 @@ def ocr_cost(
     if credits is not None and cost_per_credit is not None:
         return cost_per_credit * credits, 0.0
 
-    ocr_cost_per_page: float | None = None
-    if model_info is not None:
-        ocr_cost_per_page = model_info.get("ocr_cost_per_page")
+    ocr_cost_per_page: Final = model_info.get("ocr_cost_per_page") if model_info is not None else None
+    annotation_cost_per_page: Final = model_info.get("annotation_cost_per_page") if model_info is not None else None
+    annotation_rate: Final = annotation_cost_per_page if annotation_cost_per_page is not None else ocr_cost_per_page
 
     pages_processed: Final = response.usage_info.pages_processed
-    if pages_processed is None:
+    annotation_pages: Final = response.usage_info.pages_processed_annotation or 0
+    has_billable_annotation_pages: Final = annotation_rate is not None and annotation_pages > 0
+
+    if pages_processed is None and not has_billable_annotation_pages:
         if cost_per_credit is not None or ocr_cost_per_page is None:
             # Surface missing usage data instead of silently under-reporting
             # cost. The previous behavior raised ValueError; we now return 0.0
@@ -1931,7 +1934,7 @@ def ocr_cost(
             return 0.0, 0.0
         raise ValueError("OCR response pages_processed is None")
 
-    if ocr_cost_per_page is None:
+    if ocr_cost_per_page is None and not has_billable_annotation_pages:
         # No per-page pricing configured. Either the model is on credit-based
         # pricing (and credits weren't returned, so the credit branch above did
         # not match) or the model has no OCR pricing entry at all. Surface a
@@ -1947,8 +1950,9 @@ def ocr_cost(
         )
         return 0.0, 0.0
 
-    total_ocr_processing_cost: Final[float] = ocr_cost_per_page * pages_processed
-    return total_ocr_processing_cost, 0.0
+    ocr_pages_cost: Final = (ocr_cost_per_page or 0.0) * (pages_processed or 0)
+    annotation_pages_cost: Final = (annotation_rate or 0.0) * annotation_pages
+    return ocr_pages_cost + annotation_pages_cost, 0.0
 
 
 def vector_store_search_cost(

--- a/litellm/llms/base_llm/ocr/transformation.py
+++ b/litellm/llms/base_llm/ocr/transformation.py
@@ -75,6 +75,7 @@ class OCRUsageInfo(LiteLLMPydanticObjectBase):
     """Usage information from OCR response."""
 
     pages_processed: int | None = None
+    pages_processed_annotation: int | None = None
     credits: float | None = None
     doc_size_bytes: int | None = None
 

--- a/tests/test_litellm/llms/mistral/ocr/test_mistral_ocr_cost.py
+++ b/tests/test_litellm/llms/mistral/ocr/test_mistral_ocr_cost.py
@@ -24,12 +24,23 @@ OCR3_MODEL = "mistral/mistral-ocr-2512"
 OCR3_COST_PER_PAGE = 0.002
 OCR3_ANNOTATION_COST_PER_PAGE = 0.003
 
+AZURE_DOC_AI_MODEL = "azure_ai/mistral-document-ai-2512"
+AZURE_DOC_AI_COST_PER_PAGE = 0.003
+
 
 def _ocr_response(model: str, pages_processed: int) -> OCRResponse:
     return OCRResponse(
         pages=[OCRPage(index=i, markdown=f"page {i}") for i in range(pages_processed)],
         model=model,
         usage_info=OCRUsageInfo(pages_processed=pages_processed),
+    )
+
+
+def _annotated_ocr_response(model: str, pages_processed: int | None, annotation_pages: int) -> OCRResponse:
+    return OCRResponse(
+        pages=[],
+        model=model,
+        usage_info=OCRUsageInfo(pages_processed=pages_processed, pages_processed_annotation=annotation_pages),
     )
 
 
@@ -79,3 +90,46 @@ def test_ocr3_cost_scales_with_pages(local_model_cost_map, pages_processed: int)
         call_type="ocr",
     )
     assert cost == pytest.approx(OCR3_COST_PER_PAGE * pages_processed)
+
+
+def test_ocr3_bills_ocr_and_annotation_pages_at_their_own_rates(local_model_cost_map) -> None:
+    cost = completion_cost(
+        completion_response=_annotated_ocr_response("mistral-ocr-2512", 2, 3),
+        model=OCR3_MODEL,
+        custom_llm_provider="mistral",
+        call_type="ocr",
+    )
+    assert cost == pytest.approx(2 * OCR3_COST_PER_PAGE + 3 * OCR3_ANNOTATION_COST_PER_PAGE)
+
+
+def test_ocr3_bills_annotation_only_response(local_model_cost_map) -> None:
+    cost = completion_cost(
+        completion_response=_annotated_ocr_response("mistral-ocr-2512", 0, 3),
+        model=OCR3_MODEL,
+        custom_llm_provider="mistral",
+        call_type="ocr",
+    )
+    assert cost == pytest.approx(3 * OCR3_ANNOTATION_COST_PER_PAGE)
+
+
+def test_ocr3_bills_annotation_pages_when_pages_processed_missing(local_model_cost_map) -> None:
+    cost = completion_cost(
+        completion_response=_annotated_ocr_response("mistral-ocr-2512", None, 4),
+        model=OCR3_MODEL,
+        custom_llm_provider="mistral",
+        call_type="ocr",
+    )
+    assert cost == pytest.approx(4 * OCR3_ANNOTATION_COST_PER_PAGE)
+
+
+def test_azure_doc_ai_annotation_pages_fall_back_to_ocr_rate(local_model_cost_map) -> None:
+    info = litellm.get_model_info(model=AZURE_DOC_AI_MODEL, custom_llm_provider="azure_ai")
+    assert info.get("annotation_cost_per_page") is None
+    assert info["ocr_cost_per_page"] == AZURE_DOC_AI_COST_PER_PAGE
+    cost = completion_cost(
+        completion_response=_annotated_ocr_response("mistral-document-ai-2512", 0, 1),
+        model=AZURE_DOC_AI_MODEL,
+        custom_llm_provider="azure_ai",
+        call_type="ocr",
+    )
+    assert cost == pytest.approx(AZURE_DOC_AI_COST_PER_PAGE)


### PR DESCRIPTION
## TLDR

Problem this solves:

- OCR cost calc only billed `pages_processed`, never annotation pages
- Annotation-only Document AI calls (Azure reports all pages as annotation) billed $0
- Mixed OCR + annotation responses were undercharged

How it solves it:

- `usage_info.pages_processed_annotation` is now a declared, billed field
- Annotation pages bill at `annotation_cost_per_page`, falling back to `ocr_cost_per_page`
- Responses with only annotation pages no longer short-circuit to $0

## User Flow

Before: a platform admin whose team runs document annotation through the gateway sees every such call tracked at $0 spend

1. A developer sends POST https://litellm-domain/v1/ocr with a Mistral Document AI model, a `document_url`, and a `document_annotation_format` JSON schema
2. The response comes back 200 with the extracted annotation and `"usage_info": {"pages_processed": 0, "pages_processed_annotation": 1}`
3. The response headers carry `x-litellm-response-cost-original: 0.0`, and the plain `x-litellm-response-cost` header is missing entirely
4. GET https://litellm-domain/spend/logs shows the request at `"spend": 0.0`, even though the provider billed one annotated page

After: the same call is billed for its annotated pages, so spend tracking matches the provider's bill

1. A developer sends POST https://litellm-domain/v1/ocr with a Mistral Document AI model, a `document_url`, and a `document_annotation_format` JSON schema
2. The response comes back 200 with the extracted annotation and `"usage_info": {"pages_processed": 0, "pages_processed_annotation": 1}`
3. The response headers now carry `x-litellm-response-cost: 0.003` ($3 per 1,000 pages)
4. GET https://litellm-domain/spend/logs shows the request at `"spend": 0.003`

## Relevant issues

Fixes #38546

## Linear ticket

Resolves LIT-6428

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Both legs: live proxy from this repo, 2 uvicorn workers, real Azure AI Foundry (Mistral Document AI 2512) and Mistral (mistral-ocr-2512) calls, Postgres-backed spend logs. Shared setup:

config.yaml:

```yaml
model_list:
  - model_name: doc-ai
    litellm_params:
      model: azure_ai/mistral-document-ai-2512
      api_base: os.environ/AZURE_AI_API_BASE
      api_key: os.environ/AZURE_AI_API_KEY
  - model_name: mistral-ocr
    litellm_params:
      model: mistral/mistral-ocr-2512
      api_key: os.environ/MISTRAL_API_KEY
general_settings:
  master_key: sk-lit6428-repro
  database_url: os.environ/DATABASE_URL
```

Annotation request body (`annot_1p.json`; `annot_10p.json` is identical with `"pages": [0,1,2,3,4,5,6,7,8,9]`, and `mistral_3p.json` uses `"model": "mistral-ocr"` with `"pages": [0,1,2]`):

```json
{"model": "doc-ai", "document": {"type": "document_url", "document_url": "https://arxiv.org/pdf/2201.04234"}, "pages": [0], "document_annotation_format": {"type": "json_schema", "json_schema": {"name": "doc", "schema": {"type": "object", "properties": {"title": {"type": "string"}, "summary": {"type": "string"}}}}}}
```

### Before (c03a38d501)

#### Azure Document AI annotation-only, 1 page, POST /v1/ocr

1. `curl -s -D - http://localhost:26417/v1/ocr -H "Authorization: Bearer sk-lit6428-repro" -H "Content-Type: application/json" -d @annot_1p.json`
2. 200 OK, `usage_info: {'pages_processed': 0, 'credits': None, 'doc_size_bytes': 3002783, 'pages_processed_annotation': 1}`, and NO `x-litellm-response-cost` header (cost computed as 0.0)

#### Azure Document AI annotation-only, 10 pages, POST /ocr

1. `curl -s -D - http://localhost:26417/ocr -H "Authorization: Bearer sk-lit6428-repro" -H "Content-Type: application/json" -d @annot_10p.json`
2. 200 OK, `usage_info: {'pages_processed': 0, ..., 'pages_processed_annotation': 10}`, and NO `x-litellm-response-cost` header

#### Mistral plain OCR, 3 pages, POST /v1/ocr (unchanged path)

1. `curl -s -D - http://localhost:26417/v1/ocr -H "Authorization: Bearer sk-lit6428-repro" -H "Content-Type: application/json" -d @mistral_3p.json`
2. 200 OK, `usage_info: {'pages_processed': 3, ...}`, `x-litellm-response-cost: 0.006`

#### Spend logs

1. `curl -s http://localhost:26417/spend/logs -H "Authorization: Bearer sk-lit6428-repro"`
2. Output (Azure bills $3/1K pages, so the two annotation calls should be 0.003 and 0.030, not 0.0):

```json
[
 {"model": "mistral/mistral-ocr-2512", "call_type": "aocr", "spend": 0.006},
 {"model": "azure_ai/mistral-document-ai-2512", "call_type": "aocr", "spend": 0.0},
 {"model": "azure_ai/mistral-document-ai-2512", "call_type": "aocr", "spend": 0.0}
]
```

### After (797848dd82)

#### Azure Document AI annotation-only, 1 page, POST /v1/ocr

1. `curl -s -D - http://localhost:27833/v1/ocr -H "Authorization: Bearer sk-lit6428-repro" -H "Content-Type: application/json" -d @annot_1p.json`
2. 200 OK, same `usage_info` with `'pages_processed_annotation': 1`, and now `x-litellm-response-cost: 0.003`

#### Azure Document AI annotation-only, 10 pages, POST /ocr

1. `curl -s -D - http://localhost:27833/ocr -H "Authorization: Bearer sk-lit6428-repro" -H "Content-Type: application/json" -d @annot_10p.json`
2. 200 OK, same `usage_info` with `'pages_processed_annotation': 10`, and now `x-litellm-response-cost: 0.03`

#### Mistral plain OCR, 3 pages, POST /v1/ocr (unchanged path)

1. `curl -s -D - http://localhost:27833/v1/ocr -H "Authorization: Bearer sk-lit6428-repro" -H "Content-Type: application/json" -d @mistral_3p.json`
2. 200 OK, `usage_info: {'pages_processed': 3, 'pages_processed_annotation': None, ...}`, `x-litellm-response-cost: 0.006` (unchanged)

#### Spend logs

1. `curl -s http://localhost:27833/spend/logs -H "Authorization: Bearer sk-lit6428-repro"`
2. Output:

```json
[
 {"model": "mistral/mistral-ocr-2512", "call_type": "aocr", "spend": 0.006},
 {"model": "azure_ai/mistral-document-ai-2512", "call_type": "aocr", "spend": 0.03},
 {"model": "azure_ai/mistral-document-ai-2512", "call_type": "aocr", "spend": 0.003}
]
```

Notes from the run:

- Azure reports every annotated page in `pages_processed_annotation` with `pages_processed: 0`
- Mistral's own API currently reports no `pages_processed_annotation` at all
- So the mixed split-rate case (OCR pages + annotation pages) is unit-test-only today
- This PR leaves both provider reporting shapes alone; it only prices them

## Type

🐛 Bug Fix

## Caveats (if any)

### Low

- `azure_ai/mistral-document-ai-*` has no `annotation_cost_per_page`; fallback to `ocr_cost_per_page` matches Azure's single $3/1K-pages meter
- Mistral OCR responses now carry `"pages_processed_annotation": null` where the key was absent
- Older recorded $0 spend rows are not backfilled

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

live-pr-risk CHECKED at 797848dd82: ocr_cost has one caller (response_cost_calculator, call_type ocr/aocr) and no string-dispatch, subclass, kwargs, UI, or proxy-client dependents of pages_processed_annotation; the other OCRUsageInfo producers (azure_ai document_intelligence, reducto, vertex deepseek) never set annotation pages, so their costing is unchanged. Live A/B above ran at the current staging tip on both /ocr and /v1/ocr with real Azure Foundry and Mistral calls

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes OCR billing and proxy spend headers/logs for annotation traffic; misconfiguration could still warn and return $0, but the fix intentionally raises reported cost for previously undercharged calls.
> 
> **Overview**
> **OCR spend tracking** now includes document-annotation usage, not only `pages_processed`.
> 
> `OCRUsageInfo` adds **`pages_processed_annotation`**. **`ocr_cost`** sums per-page OCR charges and per-page annotation charges (`annotation_cost_per_page`, falling back to **`ocr_cost_per_page`** when annotation pricing is absent). Annotation-only responses (e.g. `pages_processed: 0` with annotation pages, or missing `pages_processed`) no longer exit early with **$0** when a billable annotation rate exists.
> 
> Mistral OCR cost tests cover mixed OCR + annotation, annotation-only, missing `pages_processed`, and Azure Document AI using the OCR rate for annotation pages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 797848dd8243fe10c4bbb58126c97b373ecb87ca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->