### PR TITLE
fix(redis): keep connection pools local during client initialization

### DIFF
--- a/litellm/caching/redis_cache.py
+++ b/litellm/caching/redis_cache.py
@@ -422,8 +422,9 @@ class RedisCache(BaseCache):
             redis_async_client = cast(async_redis_client | async_redis_cluster_client, cached_client)
         else:
             # Create new connection pool and client for current event loop
-            self.async_redis_conn_pool = get_redis_connection_pool(**self.redis_kwargs)
-            redis_async_client = get_redis_async_client(connection_pool=self.async_redis_conn_pool, **self.redis_kwargs)
+            async_redis_conn_pool: Final = get_redis_connection_pool(**self.redis_kwargs)
+            self.async_redis_conn_pool = async_redis_conn_pool
+            redis_async_client = get_redis_async_client(connection_pool=async_redis_conn_pool, **self.redis_kwargs)
             in_memory_llm_clients_cache.set_cache(key=cache_key, value=redis_async_client)
 
         self.redis_async_client = redis_async_client

--- a/tests/test_litellm/caching/test_redis_cache.py
+++ b/tests/test_litellm/caching/test_redis_cache.py
@@ -144,11 +144,11 @@ def test_init_async_client_keeps_pool_local_during_concurrent_initialization():
 
     with (
         patch(
-            "litellm._redis.get_redis_connection_pool",
+            "redis.asyncio.BlockingConnectionPool",
             side_effect=[pool_a, pool_b],
         ),
         patch(
-            "litellm._redis.get_redis_async_client",
+            "redis.asyncio.Redis",
             side_effect=build_client,
         ),
         ThreadPoolExecutor(max_workers=2) as executor,

--- a/tests/test_litellm/caching/test_redis_cache.py
+++ b/tests/test_litellm/caching/test_redis_cache.py
@@ -1,4 +1,6 @@
 import asyncio
+import threading
+from concurrent.futures import ThreadPoolExecutor
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -101,6 +103,64 @@ async def test_redis_client_init_with_socket_timeout(monkeypatch, redis_no_ping,
     client = redis_cache.init_async_client()
     assert client is not None
     assert client.connection_pool.connection_kwargs["socket_timeout"] == 1.0
+
+
+def test_init_async_client_keeps_pool_local_during_concurrent_initialization():
+    pool_a = MagicMock()
+    pool_b = MagicMock()
+    first_pool_assigned = threading.Event()
+    second_pool_assigned = threading.Event()
+
+    class CoordinatedRedisCache(RedisCache):
+        @property
+        def async_redis_conn_pool(self):
+            return self._async_redis_conn_pool
+
+        @async_redis_conn_pool.setter
+        def async_redis_conn_pool(self, value):
+            self._async_redis_conn_pool = value
+            if value is pool_a:
+                first_pool_assigned.set()
+                if not second_pool_assigned.wait(timeout=5):
+                    raise TimeoutError("second pool was not assigned")
+            elif value is pool_b:
+                second_pool_assigned.set()
+
+    redis_cache = CoordinatedRedisCache.__new__(CoordinatedRedisCache)
+    redis_cache.redis_kwargs = {"host": "cache.example"}
+    redis_cache.redis_async_client = None
+    redis_cache._async_redis_conn_pool = None
+
+    def build_client(connection_pool, **kwargs):
+        client = MagicMock()
+        client.connection_pool = connection_pool
+        return client
+
+    def initialize_client():
+        async def initialize():
+            return redis_cache.init_async_client()
+
+        return asyncio.run(initialize())
+
+    with (
+        patch(
+            "litellm._redis.get_redis_connection_pool",
+            side_effect=[pool_a, pool_b],
+        ),
+        patch(
+            "litellm._redis.get_redis_async_client",
+            side_effect=build_client,
+        ),
+        ThreadPoolExecutor(max_workers=2) as executor,
+    ):
+        future_a = executor.submit(initialize_client)
+        assert first_pool_assigned.wait(timeout=5)
+        future_b = executor.submit(initialize_client)
+        client_b = future_b.result(timeout=5)
+        client_a = future_a.result(timeout=5)
+
+    assert client_a.connection_pool is pool_a
+    assert client_b.connection_pool is pool_b
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## TLDR

Problem this solves:

- Concurrent loop setup can swap Redis connection pools
- Failure accounting can miss shared Redis updates

How it solves it:

- Pass each local pool directly to its client
- Cover the exact two-thread interleaving with a regression

## User Flow

Before: concurrent requests can attach failure accounting to the wrong Redis event loop

1. A developer sends overlapping POST http://localhost:4000/v1/responses requests with `"stream": true`
2. One stream returns a provider error while another request opens a Redis connection
3. The proxy logs `Future attached to a different loop`, and the shared failure count is not updated

After: the same requests keep each Redis client on its own event loop

1. A developer sends the same overlapping POST http://localhost:4000/v1/responses requests with `"stream": true`
2. One stream returns a provider error while another request opens a Redis connection
3. The proxy records the failure in Redis without a cross-loop exception

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA)

## Screenshots / Proof of Fix

Shared setup used a live Redis 7 container and two concurrent event loops. The harness pauses the first pool assignment until the second client has used its pool, then sends `PING` from both clients

```bash
docker run --rm -d --name litellm-redis-loop-proof -p 127.0.0.1::6379 redis:7-alpine
docker port litellm-redis-loop-proof 6379/tcp
```

### Before (c03a38d501)

1. Run the concurrent live-Redis harness from the merge-base checkout
2. The second client succeeds, but the first client receives the second loop's pool and fails

```text
second_client_uses_own_pool=True ping=ok
first_client_uses_own_pool=false ping=RuntimeError: Task ... got Future <Future pending> attached to a different loop
```

### After (0a427266e9)

1. Run the same concurrent live-Redis harness from this commit
2. Both clients retain their locally created pools and successfully ping Redis

```text
second_client_uses_own_pool=True ping=ok
first_client_uses_own_pool=True ping=ok
```

## Type

Bug Fix

## Caveats (if any)

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

