### PR TITLE
fix(bedrock): stop duplicating Converse config blocks inside inferenceConfig

### DIFF
--- a/litellm/llms/bedrock/chat/converse_transformation.py
+++ b/litellm/llms/bedrock/chat/converse_transformation.py
@@ -1631,6 +1631,11 @@ class AmazonConverseConfig(BaseConfig):
                 bedrock_tool_config["toolChoice"] = tool_choice_values
                 self._drop_tool_choice_type_conflicting_with_tool_config(additional_request_params)
 
+        config_block_entries: Final = tuple(
+            (config_name, config_class, inference_params.pop(config_name, None))
+            for config_name, config_class in self.get_config_blocks().items()
+        )
+
         data: Final[CommonRequestObject] = {
             "inferenceConfig": self._transform_inference_params(inference_params=inference_params),
         }
@@ -1641,9 +1646,7 @@ class AmazonConverseConfig(BaseConfig):
         if system_content_blocks:
             data["system"] = system_content_blocks
 
-        # Handle all config blocks
-        for config_name, config_class in self.get_config_blocks().items():
-            config_value = inference_params.pop(config_name, None)
+        for config_name, config_class, config_value in config_block_entries:
             if config_value is not None:
                 data[config_name] = config_class(**config_value)
 

--- a/tests/test_litellm/llms/bedrock/chat/test_converse_transformation.py
+++ b/tests/test_litellm/llms/bedrock/chat/test_converse_transformation.py
@@ -957,6 +957,28 @@ def test_transform_request_helper_includes_anthropic_beta_and_tools():
     assert fields["tools"][0]["type"] == "computer_20250124"
 
 
+def test_config_blocks_do_not_leak_into_inference_config():
+    """Regression: inferenceConfig was built before the config blocks were popped, so a dead
+    nested copy of each block (guardrailConfig, performanceConfig, serviceTier) rode inside
+    inferenceConfig alongside the real top-level one."""
+    data = AmazonConverseConfig()._transform_request_helper(
+        model="anthropic.claude-haiku-4-5-20251001-v1:0",
+        system_content_blocks=[],
+        optional_params={
+            "maxTokens": 100,
+            "guardrailConfig": {"guardrailIdentifier": "gr-id", "guardrailVersion": "DRAFT"},
+            "performanceConfig": {"latency": "optimized"},
+            "serviceTier": {"type": "priority"},
+        },
+        messages=[{"role": "user", "content": "hi"}],
+    )
+
+    assert data["inferenceConfig"] == {"maxTokens": 100}
+    assert data["guardrailConfig"] == {"guardrailIdentifier": "gr-id", "guardrailVersion": "DRAFT"}
+    assert data["performanceConfig"] == {"latency": "optimized"}
+    assert data["serviceTier"] == {"type": "priority"}
+
+
 def test_parallel_tool_calls_config_kept_for_sonnet_5(monkeypatch):
     old_env = os.environ.get("LITELLM_LOCAL_MODEL_COST_MAP")
     old_cost = litellm.model_cost
@@ -2853,17 +2875,11 @@ def test_guarded_text_guardrail_config_preserved():
         headers={},
     )
 
-    # GuardrailConfig should be present at top level
     assert "guardrailConfig" in result
     assert result["guardrailConfig"]["guardrailIdentifier"] == "gr-abc123"
 
-    # GuardrailConfig should also be in inferenceConfig
     assert "inferenceConfig" in result
-    assert "guardrailConfig" in result["inferenceConfig"]
-    assert (
-        result["inferenceConfig"]["guardrailConfig"]["guardrailIdentifier"]
-        == "gr-abc123"
-    )
+    assert "guardrailConfig" not in result["inferenceConfig"]
 
 
 def test_auto_convert_last_user_message_to_guarded_text():


### PR DESCRIPTION
## TLDR

Problem this solves:

- Converse requests with `guardrailConfig` sent the block twice
- A dead nested copy rode inside `inferenceConfig`
- Same leak for `performanceConfig` and `serviceTier`
- Breaks the day Bedrock validates `inferenceConfig` strictly

How it solves it:

- Pop the config blocks before building `inferenceConfig`
- Emit each block once, top-level, where AWS documents it

## User Flow

Before: a proxy admin who applies an AWS Bedrock guardrail to a model sees the gateway send the guardrail block twice in every request

1. They add `guardrailConfig` (identifier + version) to a Bedrock model in the proxy config and start the proxy with `--detailed_debug`
2. They send POST http://localhost:4000/v1/chat/completions for that model with a normal prompt and get a 200 answer back
3. In the logged outgoing request to https://bedrock-runtime.us-east-1.amazonaws.com/model/.../converse, the body carries `"inferenceConfig": {"guardrailConfig": {...}}` plus the real top-level `"guardrailConfig": {...}`: the same block twice
4. AWS ignores the unknown nested field today, so nothing visibly fails, but any strict validation of `inferenceConfig` on AWS's side would start rejecting every guarded request

After: the same request carries the guardrail block exactly once, where AWS documents it

1. They add `guardrailConfig` (identifier + version) to a Bedrock model in the proxy config and start the proxy with `--detailed_debug`
2. They send POST http://localhost:4000/v1/chat/completions for that model with a normal prompt and get a 200 answer back
3. In the logged outgoing request, `guardrailConfig` appears only at the top level and `inferenceConfig` holds only real inference settings
4. A prompt the guardrail denies still comes back with the guardrail's blocked message and `finish_reason: "content_filter"`

## Relevant issues

## Linear ticket

Resolves LIT-6437

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Shared setup: live proxies (no DB) booted with 2 uvicorn workers (`--num_workers 2`) on random free ports from the worktree, real Bedrock calls in us-east-1. Guardrail `qfqs7hp0u7qp` (version DRAFT) denies the topic "bread" with blocked messaging "Blocked by guardrail."

```yaml
model_list:
  - model_name: haiku-guardrail
    litellm_params:
      model: bedrock/us.anthropic.claude-haiku-4-5-20251001-v1:0
      aws_region_name: us-east-1
      guardrailConfig:
        guardrailIdentifier: qfqs7hp0u7qp
        guardrailVersion: "DRAFT"
general_settings:
  master_key: sk-lit6437-qa
```

Control (documented shape, straight to AWS): `aws bedrock-runtime converse ... --guardrail-config '{"guardrailIdentifier":"qfqs7hp0u7qp","guardrailVersion":"DRAFT"}'` returns `"stopReason": "guardrail_intervened"` for the bread prompt; the CLI request carries `guardrailConfig` top-level only.

### Before (c03a38d501)

#### Raw Converse request body: guardrail block emitted twice

1. `curl -s http://localhost:41733/v1/chat/completions -H "Authorization: Bearer sk-lit6437-qa" -H "Content-Type: application/json" -d '{"model": "haiku-guardrail", "messages": [{"role": "user", "content": "Give me a great recipe for baking bread"}]}'`
2. Proxy debug log, the exact request sent to Bedrock (nested dead copy inside `inferenceConfig` plus the real top-level block):

```
POST Request Sent from LiteLLM:
curl -X POST \
https://bedrock-runtime.us-east-1.amazonaws.com/model/us.anthropic.claude-haiku-4-5-20251001-v1%3A0/converse \
-d '{"messages": [{"role": "user", "content": [{"guardContent": {"text": {"text": "Give me a great recipe for baking bread"}}}]}], "inferenceConfig": {"guardrailConfig": {"guardrailIdentifier": "qfqs7hp0u7qp", "guardrailVersion": "DRAFT"}}, "guardrailConfig": {"guardrailIdentifier": "qfqs7hp0u7qp", "guardrailVersion": "DRAFT"}}'
```

#### Guardrail intervenes on a denied topic

1. Same curl as above
2. Response: `"content": "Blocked by guardrail."`, `"finish_reason": "content_filter"`

#### Benign prompt answers normally

1. `curl -s http://localhost:41733/v1/chat/completions -H "Authorization: Bearer sk-lit6437-qa" -H "Content-Type: application/json" -d '{"model": "haiku-guardrail", "messages": [{"role": "user", "content": "Say hello in exactly three words"}]}'`
2. Response: `"content": "Hello, world friend."`, `"finish_reason": "stop"`

### After (cf1b431d58)

#### Raw Converse request body: guardrail block emitted once

1. `curl -s http://localhost:29154/v1/chat/completions -H "Authorization: Bearer sk-lit6437-qa" -H "Content-Type: application/json" -d '{"model": "haiku-guardrail", "messages": [{"role": "user", "content": "Give me a great recipe for baking bread"}]}'`
2. Proxy debug log, the exact request sent to Bedrock (`guardrailConfig` top-level only, matching the AWS CLI control):

```
POST Request Sent from LiteLLM:
curl -X POST \
https://bedrock-runtime.us-east-1.amazonaws.com/model/us.anthropic.claude-haiku-4-5-20251001-v1%3A0/converse \
-d '{"messages": [{"role": "user", "content": [{"guardContent": {"text": {"text": "Give me a great recipe for baking bread"}}}]}], "inferenceConfig": {}, "guardrailConfig": {"guardrailIdentifier": "qfqs7hp0u7qp", "guardrailVersion": "DRAFT"}}'
```

#### Guardrail intervenes on a denied topic

1. Same curl as above
2. Response: `"content": "Blocked by guardrail."`, `"finish_reason": "content_filter"`

#### Benign prompt answers normally

1. `curl -s http://localhost:29154/v1/chat/completions -H "Authorization: Bearer sk-lit6437-qa" -H "Content-Type: application/json" -d '{"model": "haiku-guardrail", "messages": [{"role": "user", "content": "Say hello in exactly three words"}]}'`
2. Response: `"content": "Hello there friend"`, `"finish_reason": "stop"`

## Type

🐛 Bug Fix

## Caveats (if any)

### Low

- An empty `"inferenceConfig": {}` is still emitted; pre-existing, unchanged here
- Batch-files Converse path shares this fixed transform; covered by unit tests only

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow ordering fix in request transformation with regression tests; behavior improves API compliance without changing auth or data paths.
> 
> **Overview**
> **Bedrock Converse request shaping** no longer nests `guardrailConfig`, `performanceConfig`, or `serviceTier` inside `inferenceConfig`. Those blocks are popped out of `inference_params` **before** `_transform_inference_params` runs, then attached only as top-level fields on the Converse body (matching AWS).
> 
> Previously the config-block loop ran after `inferenceConfig` was built, so the same blocks appeared twice—once incorrectly under `inferenceConfig` and once at the root.
> 
> Tests add a regression for mixed optional params and update guardrail expectations so `inferenceConfig` must not contain `guardrailConfig`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cf1b431d58264399c0cf6f7a53e7bfd73b8560b3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

- [x] cf1b431d58264399c0cf6f7a53e7bfd73b8560b3 passes /live-pr-risk

