### PR TITLE
fix(proxy): ship psycopg so partitioned SpendLogs detection actually runs

### DIFF
--- a/litellm-proxy-extras/litellm_proxy_extras/utils.py
+++ b/litellm-proxy-extras/litellm_proxy_extras/utils.py
@@ -512,6 +512,13 @@ class ProxyExtrasDBManager:
         try:
             import psycopg
         except ImportError:
+            logger.warning(
+                "psycopg is not installed; skipping the LiteLLM_SpendLogs "
+                "partition check. If this table is partitioned (see "
+                "db_scripts/partition_spend_logs.sql), schema reconciliation "
+                "will try to rewrite its primary key and fail. Install the "
+                "litellm[extra_proxy] extra, which now includes psycopg."
+            )
             return False
 
         cleaned_url = ProxyExtrasDBManager._strip_prisma_query_params(database_url)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,6 +91,11 @@ cli = [
 ]
 extra_proxy = [
     "prisma>=0.11.0,<1.0",
+    # Used by ProxyExtrasDBManager.spend_logs_is_partitioned() to detect a
+    # partitioned LiteLLM_SpendLogs and keep schema reconciliation from
+    # fighting its composite primary key.
+    "psycopg>=3.2,<4.0",
+    "psycopg-binary>=3.2,<4.0",
     "azure-identity>=1.25.2,<2.0",
     "azure-keyvault-secrets>=4.10.0,<5.0",
     # Not in PyPI proxy extra.

--- a/tests/litellm-proxy-extras/test_litellm_proxy_extras_utils.py
+++ b/tests/litellm-proxy-extras/test_litellm_proxy_extras_utils.py
@@ -681,3 +681,25 @@ class TestSpendLogsPartitionDetectionSchemaScope:
     def test_only_partitioned_relations_match(self, monkeypatch):
         query, _ = self._detect(monkeypatch, "postgresql://u:p@localhost:5432/db")
         assert "pg_partitioned_table" in query
+
+
+class TestSpendLogsPartitionDetectionMissingPsycopg:
+    """psycopg ships in the `extra_proxy` install, but a stripped-down image
+    can still lack it. When it does, detection must fail closed to False
+    (never crash the migration path) and say so loudly, because a silent
+    False here is what let a genuinely partitioned LiteLLM_SpendLogs hit the
+    unfiltered primary-key rewrite in production."""
+
+    def test_missing_psycopg_returns_false(self, monkeypatch):
+        monkeypatch.setitem(sys.modules, "psycopg", None)
+        monkeypatch.setenv("DATABASE_URL", "postgresql://u:p@localhost:5432/db")
+        assert ProxyExtrasDBManager.spend_logs_is_partitioned() is False
+
+    def test_missing_psycopg_logs_a_warning(self, monkeypatch, caplog):
+        monkeypatch.setitem(sys.modules, "psycopg", None)
+        monkeypatch.setenv("DATABASE_URL", "postgresql://u:p@localhost:5432/db")
+        with caplog.at_level("WARNING", logger="litellm_proxy_extras"):
+            ProxyExtrasDBManager.spend_logs_is_partitioned()
+        assert any(
+            "psycopg is not installed" in record.message for record in caplog.records
+        )

--- a/uv.lock
+++ b/uv.lock
@@ -4306,6 +4306,8 @@ extra-proxy = [
     { name = "google-cloud-iam" },
     { name = "google-cloud-kms" },
     { name = "prisma" },
+    { name = "psycopg" },
+    { name = "psycopg-binary" },
     { name = "redisvl" },
     { name = "resend" },
 ]
@@ -4544,6 +4546,8 @@ requires-dist = [
     { name = "polars", marker = "extra == 'proxy'", specifier = ">=1.38.1,<2.0" },
     { name = "prisma", marker = "extra == 'extra-proxy'", specifier = ">=0.11.0,<1.0" },
     { name = "prometheus-client", marker = "extra == 'proxy-runtime'", specifier = ">=0.20.0,<1.0" },
+    { name = "psycopg", marker = "extra == 'extra-proxy'", specifier = ">=3.2,<4.0" },
+    { name = "psycopg-binary", marker = "extra == 'extra-proxy'", specifier = ">=3.2,<4.0" },
     { name = "pydantic", specifier = ">=2.10.0,<3.0.0" },
     { name = "pydantic-settings", specifier = ">=2.14.1,<3.0" },
     { name = "pyjwt", marker = "extra == 'proxy'", specifier = ">=2.13.0,<3.0" },


### PR DESCRIPTION
<!-- template comments removed -->

## TLDR

Problem this solves:

- #38452's partition detection always returns False in production
- psycopg, the detector's own dependency, never shipped in extra_proxy
- Partitioned LiteLLM_SpendLogs still hits the primary-key rewrite crash

How it solves it:

- Add psycopg to the extra_proxy install so every proxy image has it
- Log a warning when psycopg is still missing instead of failing silently

## User Flow

Before: an operator who partitioned SpendLogs and upgraded to a release carrying #38452's fix still cannot migrate

1. They exec into a pod running the current image and run `python litellm/proxy/prisma_migration.py`
2. Migration hits a routine "column already exists" recovery step and regenerates a schema diff against schema.prisma
3. Startup fails with `Error: ERROR: unique constraint on partitioned table must include all partitioning columns` naming LiteLLM_SpendLogs, with no log line about partition detection at all
4. The proxy cannot start; SpendLogs stay out of sync with newer migrations

After: the same operator upgrades cleanly

1. They exec into a pod running the image built from this PR and run the same command
2. Logs show "LiteLLM_SpendLogs is partitioned; removed its primary-key rewrite and partitioning artifacts from the drift script"
3. Migration finishes: "All migrations resolved."
4. The proxy starts, serves a real chat completion, and the spend log for it lands in the partitioned table with its composite primary key intact

## Relevant issues

## Linear ticket

Resolves LIT-6138

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Shared setup for both arms, on a live local Postgres: deploy all shipped migrations, run the documented partitioning runbook, then drop `_prisma_migrations` so schema reconciliation has real work to do, matching #38452's own proof

```
psql "$URL" -f db_scripts/partition_spend_logs.sql
psql "$URL" -c 'DROP TABLE "_prisma_migrations"'
psql "$URL" -c "SELECT relkind FROM pg_class WHERE relname='LiteLLM_SpendLogs'"
 relkind
---------
 p
```

Both arms ran `python litellm/proxy/prisma_migration.py` from a venv built with the exact extras the Dockerfile installs (`uv sync --extra proxy --extra proxy-runtime --extra extra_proxy --extra semantic-router --extra saml`, no dev/test groups), so the venv matches what a real image actually ships

### Before (c09fa5b7124708fcffdf7b03719bf3ea7ba800f6)

1. `python -c "import psycopg"` in that venv: `ModuleNotFoundError: No module named 'psycopg'`, confirming the shipped image never had the detector's own dependency
2. Run the migration script:

```
Database schema is not empty, creating baseline migration.
Generating migration diff between DB and schema.prisma...
Migration diff created at /tmp/litellm_migration_diff_.../migration.sql
WARNING - Failed to apply migration diff: Error: ERROR: unique constraint on partitioned table must include all partitioning columns
DETAIL: PRIMARY KEY constraint on table "LiteLLM_SpendLogs" lacks column "startTime" which is part of the partition key.
WARNING - Drift script failed to apply; NOT marking migrations as applied so a later migration run can retry them
```

No "LiteLLM_SpendLogs is partitioned" log line anywhere: `spend_logs_is_partitioned()` silently returned False

### After (4f6a11b58997fc80a2c290e3eedd93639a699b0e)

Same partitioned database, ledger dropped again, psycopg installed into the same venv this PR adds to extra_proxy

1. Run the same migration script:

```
Generating migration diff between DB and schema.prisma...
Migration diff created at /tmp/litellm_migration_diff_.../migration.sql
LiteLLM_SpendLogs is partitioned; removed its primary-key rewrite and partitioning artifacts from the drift script
Drift script is empty after filtering; nothing to apply
Resolving 162 migrations
...
✅ All migrations resolved.
```

2. Verify the partitioning and new columns survived:

```
SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid='"LiteLLM_SpendLogs"'::regclass AND contype='p';
        conname         |         pg_get_constraintdef
------------------------+---------------------------------------
 LiteLLM_SpendLogs_pkey | PRIMARY KEY (request_id, "startTime")

SELECT count(*), count(*) FILTER (WHERE finished_at IS NOT NULL) FROM "_prisma_migrations";
 count | count
-------+-------
   162 |   162
```

3. Start the proxy on this venv and send a real request:

```
curl -s http://localhost:4501/v1/chat/completions -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
  -d '{"model":"anthropic-haiku-4-5","messages":[{"role":"user","content":"Say hi in three words"}]}'
{"id":"chatcmpl-...","model":"anthropic-haiku-4-5","choices":[{"message":{"content":"Hey there, friend!", ...}}], ...}
```

4. The spend log for that call landed in the partitioned table:

```
SELECT request_id IS NOT NULL AS has_id, model, spend > 0 AS spent, created_at IS NOT NULL AS has_created_at FROM "LiteLLM_SpendLogs" ORDER BY "startTime" DESC LIMIT 1;
 has_id |           model            | spent | has_created_at
--------+----------------------------+-------+----------------
 t      | anthropic/claude-haiku-4-5 | t     | t
```

## Type

🐛 Bug Fix

## Caveats (if any)

### Medium

- Detection still needs a reachable DATABASE_URL at migration time; unreachable falls back to the old (unfiltered) behavior, unchanged from #38452
- schema.prisma still declares the single-column key, so `prisma migrate dev` diffs keep proposing the rewrite; the runtime filter and push guard contain it

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
