### PR TITLE
feat(openai): support workload identity federation (OIDC token exchange)

### DIFF
--- a/basedpyright-code-budget.json
+++ b/basedpyright-code-budget.json
@@ -3,7 +3,7 @@
     "limit": 16171
   },
   "reportArgumentType": {
-    "limit": 2226
+    "limit": 2224
   },
   "reportAssignmentType": {
     "limit": 319

--- a/litellm/llms/openai/common_utils.py
+++ b/litellm/llms/openai/common_utils.py
@@ -268,6 +268,7 @@ class BaseOpenAILLM:
             "max_retries",
             "organization",
             "api_base",
+            "workload_identity_config",
         )
         openai_client_fields: Final = (
             BaseOpenAILLM.get_openai_client_initialization_param_fields(client_type=client_type)

--- a/litellm/llms/openai/openai.py
+++ b/litellm/llms/openai/openai.py
@@ -51,6 +51,7 @@ from .common_utils import (
     drop_params_from_unprocessable_entity_error,
     is_output_token_limit_error,
 )
+from .workload_identity import resolve_openai_workload_identity_config
 
 openaiOSeriesConfig: Final = OpenAIOSeriesConfig()
 openAIGPT5Config: Final = OpenAIGPT5Config()
@@ -349,6 +350,7 @@ class OpenAIChatCompletion(BaseLLM, BaseOpenAILLM):
         client: OpenAI | AsyncOpenAI | None = None,
         shared_session: Optional["ClientSession"] = None,
     ) -> OpenAI | AsyncOpenAI | None:
+        workload_identity_config: Final = resolve_openai_workload_identity_config(api_key=api_key, api_base=api_base)
         client_initialization_params: Final[dict] = locals()
         if client is None:
             if not isinstance(max_retries, int):
@@ -364,28 +366,49 @@ class OpenAIChatCompletion(BaseLLM, BaseOpenAILLM):
             if cached_client:
                 if isinstance(cached_client, OpenAI) or isinstance(cached_client, AsyncOpenAI):
                     return cached_client
-            http_client: Final[httpx.Client | httpx.AsyncClient | None] = (
-                OpenAIChatCompletion._get_async_http_client(shared_session=shared_session)
-                if is_async
-                else OpenAIChatCompletion._get_sync_http_client()
-            )
             if is_async:
-                _new_client: OpenAI | AsyncOpenAI = AsyncOpenAI(
-                    api_key=api_key,
-                    base_url=api_base,
-                    http_client=http_client,
-                    timeout=timeout,
-                    max_retries=max_retries,
-                    organization=organization,
+                async_http_client: Final = OpenAIChatCompletion._get_async_http_client(shared_session=shared_session)
+                http_client: httpx.Client | httpx.AsyncClient | None = async_http_client
+                _new_client: OpenAI | AsyncOpenAI = (
+                    AsyncOpenAI(
+                        workload_identity=workload_identity_config.to_sdk_workload_identity(),
+                        base_url=api_base,
+                        http_client=async_http_client,
+                        timeout=timeout,
+                        max_retries=max_retries,
+                        organization=organization,
+                    )
+                    if workload_identity_config is not None
+                    else AsyncOpenAI(
+                        api_key=api_key,
+                        base_url=api_base,
+                        http_client=async_http_client,
+                        timeout=timeout,
+                        max_retries=max_retries,
+                        organization=organization,
+                    )
                 )
             else:
-                _new_client = OpenAI(
-                    api_key=api_key,
-                    base_url=api_base,
-                    http_client=http_client,
-                    timeout=timeout,
-                    max_retries=max_retries,
-                    organization=organization,
+                sync_http_client: Final = OpenAIChatCompletion._get_sync_http_client()
+                http_client = sync_http_client
+                _new_client = (
+                    OpenAI(
+                        workload_identity=workload_identity_config.to_sdk_workload_identity(),
+                        base_url=api_base,
+                        http_client=sync_http_client,
+                        timeout=timeout,
+                        max_retries=max_retries,
+                        organization=organization,
+                    )
+                    if workload_identity_config is not None
+                    else OpenAI(
+                        api_key=api_key,
+                        base_url=api_base,
+                        http_client=sync_http_client,
+                        timeout=timeout,
+                        max_retries=max_retries,
+                        organization=organization,
+                    )
                 )
 
             ## SAVE CACHE KEY

--- a/litellm/llms/openai/responses/transformation.py
+++ b/litellm/llms/openai/responses/transformation.py
@@ -21,6 +21,7 @@ from litellm.types.router import GenericLiteLLMParams
 from litellm.types.utils import LlmProviders
 
 from ..common_utils import OpenAIError
+from ..workload_identity import get_workload_identity_bearer_token, resolve_openai_workload_identity_config
 
 OPENAI_RESPONSES_API_MIN_MAX_OUTPUT_TOKENS: Final = 16
 
@@ -392,6 +393,16 @@ class OpenAIResponsesAPIConfig(BaseResponsesAPIConfig):
         litellm_params = litellm_params or GenericLiteLLMParams()
         api_key = litellm_params.api_key or litellm.api_key or litellm.openai_key or get_secret_str("OPENAI_API_KEY")
         headers.setdefault("Content-Type", "application/json")
+        workload_identity_config: Final = resolve_openai_workload_identity_config(
+            api_key=api_key,
+            api_base=litellm_params.api_base
+            or litellm.api_base
+            or get_secret_str("OPENAI_BASE_URL")
+            or get_secret_str("OPENAI_API_BASE"),
+        )
+        if workload_identity_config is not None:
+            headers["Authorization"] = f"Bearer {get_workload_identity_bearer_token(workload_identity_config)}"
+            return headers
         headers["Authorization"] = f"Bearer {api_key}"
         return headers
 

--- a/litellm/llms/openai/responses/transformation.py
+++ b/litellm/llms/openai/responses/transformation.py
@@ -393,12 +393,10 @@ class OpenAIResponsesAPIConfig(BaseResponsesAPIConfig):
         litellm_params = litellm_params or GenericLiteLLMParams()
         api_key = litellm_params.api_key or litellm.api_key or litellm.openai_key or get_secret_str("OPENAI_API_KEY")
         headers.setdefault("Content-Type", "application/json")
-        workload_identity_config: Final = resolve_openai_workload_identity_config(
-            api_key=api_key,
-            api_base=litellm_params.api_base
-            or litellm.api_base
-            or get_secret_str("OPENAI_BASE_URL")
-            or get_secret_str("OPENAI_API_BASE"),
+        workload_identity_config: Final = (
+            resolve_openai_workload_identity_config(api_key=api_key, api_base=litellm_params.api_base)
+            if self.custom_llm_provider is LlmProviders.OPENAI
+            else None
         )
         if workload_identity_config is not None:
             headers["Authorization"] = f"Bearer {get_workload_identity_bearer_token(workload_identity_config)}"

--- a/litellm/llms/openai/workload_identity.py
+++ b/litellm/llms/openai/workload_identity.py
@@ -71,7 +71,8 @@ def get_workload_identity_bearer_token(config: OpenAIWorkloadIdentityConfig) -> 
 def _targets_openai_api(api_base: str | None) -> bool:
     if api_base is None:
         return True
-    return urlparse(api_base).hostname == _OPENAI_API_HOST
+    parsed: Final = urlparse(api_base)
+    return parsed.scheme == "https" and parsed.hostname == _OPENAI_API_HOST
 
 
 @lru_cache(maxsize=16)

--- a/litellm/llms/openai/workload_identity.py
+++ b/litellm/llms/openai/workload_identity.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from functools import lru_cache
+from typing import TYPE_CHECKING, Final
+from urllib.parse import urlparse
+
+from litellm.secret_managers.main import get_secret_str
+
+from .common_utils import OpenAIError
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from openai.auth import SubjectTokenProvider, WorkloadIdentity, WorkloadIdentityAuth
+
+OPENAI_WIF_CLIENT_ID: Final = "litellm"
+_OPENAI_API_HOST: Final = "api.openai.com"
+_SDK_UPGRADE_MESSAGE: Final = (
+    "OpenAI workload identity federation requires openai>=2.32.0. "
+    "Upgrade the installed openai package to use OPENAI_IDENTITY_PROVIDER_ID / "
+    "OPENAI_SERVICE_ACCOUNT_ID / OPENAI_IDENTITY_TOKEN_FILE."
+)
+
+
+@dataclass(frozen=True, slots=True)
+class OpenAIWorkloadIdentityConfig:
+    identity_provider_id: str
+    service_account_id: str
+    token_file: str
+
+    def to_sdk_workload_identity(self) -> WorkloadIdentity:
+        k8s_token_provider: Final = _load_sdk_k8s_token_provider()
+        workload_identity: Final[WorkloadIdentity] = {
+            "client_id": OPENAI_WIF_CLIENT_ID,
+            "identity_provider_id": self.identity_provider_id,
+            "service_account_id": self.service_account_id,
+            "provider": k8s_token_provider(self.token_file),
+        }
+        return workload_identity
+
+
+def resolve_openai_workload_identity_config(
+    api_key: str | None,
+    api_base: str | None,
+) -> OpenAIWorkloadIdentityConfig | None:
+    if api_key is not None:
+        return None
+    if not _targets_openai_api(api_base):
+        return None
+    identity_provider_id: Final = get_secret_str("OPENAI_IDENTITY_PROVIDER_ID")
+    service_account_id: Final = get_secret_str("OPENAI_SERVICE_ACCOUNT_ID")
+    token_file: Final = get_secret_str("OPENAI_IDENTITY_TOKEN_FILE")
+    if not identity_provider_id or not service_account_id or not token_file:
+        return None
+    return OpenAIWorkloadIdentityConfig(
+        identity_provider_id=identity_provider_id,
+        service_account_id=service_account_id,
+        token_file=token_file,
+    )
+
+
+def get_workload_identity_bearer_token(config: OpenAIWorkloadIdentityConfig) -> str:
+    return _workload_identity_auth(config).get_token()
+
+
+def _targets_openai_api(api_base: str | None) -> bool:
+    if api_base is None:
+        return True
+    return urlparse(api_base).hostname == _OPENAI_API_HOST
+
+
+@lru_cache(maxsize=16)
+def _workload_identity_auth(config: OpenAIWorkloadIdentityConfig) -> WorkloadIdentityAuth:
+    sdk_workload_identity_auth: Final = _load_sdk_workload_identity_auth()
+    return sdk_workload_identity_auth(workload_identity=config.to_sdk_workload_identity())
+
+
+def _load_sdk_workload_identity_auth() -> type[WorkloadIdentityAuth]:
+    try:
+        from openai.auth import WorkloadIdentityAuth as sdk_workload_identity_auth
+    except ImportError as e:
+        raise OpenAIError(status_code=500, message=_SDK_UPGRADE_MESSAGE) from e
+    return sdk_workload_identity_auth
+
+
+def _load_sdk_k8s_token_provider() -> Callable[[str], SubjectTokenProvider]:
+    try:
+        from openai.auth import k8s_service_account_token_provider
+    except ImportError as e:
+        raise OpenAIError(status_code=500, message=_SDK_UPGRADE_MESSAGE) from e
+    return k8s_service_account_token_provider

--- a/litellm/llms/openai/workload_identity.py
+++ b/litellm/llms/openai/workload_identity.py
@@ -45,7 +45,7 @@ def resolve_openai_workload_identity_config(
     api_key: str | None,
     api_base: str | None,
 ) -> OpenAIWorkloadIdentityConfig | None:
-    if api_key is not None or get_secret_str("OPENAI_API_KEY") is not None:
+    if api_key or get_secret_str("OPENAI_API_KEY"):
         return None
     effective_api_base: Final = (
         api_base or litellm.api_base or get_secret_str("OPENAI_BASE_URL") or get_secret_str("OPENAI_API_BASE")

--- a/litellm/llms/openai/workload_identity.py
+++ b/litellm/llms/openai/workload_identity.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING, Final
 from urllib.parse import urlparse
 
 import litellm
-from litellm.secret_managers.main import get_secret_str
+from litellm.secret_managers.main import get_secret_str, normalize_nonempty_secret_str
 
 from .common_utils import OpenAIError
 
@@ -45,7 +45,10 @@ def resolve_openai_workload_identity_config(
     api_key: str | None,
     api_base: str | None,
 ) -> OpenAIWorkloadIdentityConfig | None:
-    if api_key or get_secret_str("OPENAI_API_KEY"):
+    static_api_key: Final = normalize_nonempty_secret_str(api_key) or normalize_nonempty_secret_str(
+        get_secret_str("OPENAI_API_KEY")
+    )
+    if static_api_key is not None:
         return None
     effective_api_base: Final = (
         api_base or litellm.api_base or get_secret_str("OPENAI_BASE_URL") or get_secret_str("OPENAI_API_BASE")

--- a/litellm/llms/openai/workload_identity.py
+++ b/litellm/llms/openai/workload_identity.py
@@ -5,6 +5,7 @@ from functools import lru_cache
 from typing import TYPE_CHECKING, Final
 from urllib.parse import urlparse
 
+import litellm
 from litellm.secret_managers.main import get_secret_str
 
 from .common_utils import OpenAIError
@@ -44,9 +45,12 @@ def resolve_openai_workload_identity_config(
     api_key: str | None,
     api_base: str | None,
 ) -> OpenAIWorkloadIdentityConfig | None:
-    if api_key is not None:
+    if api_key is not None or get_secret_str("OPENAI_API_KEY") is not None:
         return None
-    if not _targets_openai_api(api_base):
+    effective_api_base: Final = (
+        api_base or litellm.api_base or get_secret_str("OPENAI_BASE_URL") or get_secret_str("OPENAI_API_BASE")
+    )
+    if not _targets_openai_api(effective_api_base):
         return None
     identity_provider_id: Final = get_secret_str("OPENAI_IDENTITY_PROVIDER_ID")
     service_account_id: Final = get_secret_str("OPENAI_SERVICE_ACCOUNT_ID")

--- a/tests/test_litellm/llms/openai/test_openai_workload_identity.py
+++ b/tests/test_litellm/llms/openai/test_openai_workload_identity.py
@@ -69,6 +69,9 @@ class TestResolveConfig:
     def test_openai_api_base_allows(self, wif_env: OpenAIWorkloadIdentityConfig) -> None:
         assert resolve_openai_workload_identity_config(api_key=None, api_base="https://api.openai.com/v1") == wif_env
 
+    def test_plaintext_http_api_base_disables(self, wif_env: OpenAIWorkloadIdentityConfig) -> None:
+        assert resolve_openai_workload_identity_config(api_key=None, api_base="http://api.openai.com/v1") is None
+
     def test_foreign_env_base_url_disables(
         self, wif_env: OpenAIWorkloadIdentityConfig, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/tests/test_litellm/llms/openai/test_openai_workload_identity.py
+++ b/tests/test_litellm/llms/openai/test_openai_workload_identity.py
@@ -63,14 +63,18 @@ class TestResolveConfig:
         monkeypatch.setenv("OPENAI_API_KEY", "sk-from-env")
         assert resolve_openai_workload_identity_config(api_key=None, api_base=None) is None
 
-    def test_empty_env_openai_api_key_counts_as_unset(
-        self, wif_env: OpenAIWorkloadIdentityConfig, monkeypatch: pytest.MonkeyPatch
+    @pytest.mark.parametrize("empty_key", ["", "   "])
+    def test_empty_api_key_arg_does_not_disable_wif(
+        self, wif_env: OpenAIWorkloadIdentityConfig, empty_key: str
     ) -> None:
-        monkeypatch.setenv("OPENAI_API_KEY", "")
-        assert resolve_openai_workload_identity_config(api_key=None, api_base=None) == wif_env
+        assert resolve_openai_workload_identity_config(api_key=empty_key, api_base=None) == wif_env
 
-    def test_empty_api_key_param_counts_as_unset(self, wif_env: OpenAIWorkloadIdentityConfig) -> None:
-        assert resolve_openai_workload_identity_config(api_key="", api_base=None) == wif_env
+    @pytest.mark.parametrize("empty_key", ["", "   "])
+    def test_empty_env_openai_api_key_does_not_disable_wif(
+        self, wif_env: OpenAIWorkloadIdentityConfig, monkeypatch: pytest.MonkeyPatch, empty_key: str
+    ) -> None:
+        monkeypatch.setenv("OPENAI_API_KEY", empty_key)
+        assert resolve_openai_workload_identity_config(api_key=None, api_base=None) == wif_env
 
     def test_foreign_api_base_disables(self, wif_env: OpenAIWorkloadIdentityConfig) -> None:
         assert resolve_openai_workload_identity_config(api_key=None, api_base="https://my-vllm.internal/v1") is None

--- a/tests/test_litellm/llms/openai/test_openai_workload_identity.py
+++ b/tests/test_litellm/llms/openai/test_openai_workload_identity.py
@@ -1,0 +1,188 @@
+import json
+import sys
+from pathlib import Path
+from typing import Final
+
+import httpx
+import pytest
+import respx
+from openai import AsyncOpenAI, OpenAI
+
+import litellm
+from litellm.llms.openai.common_utils import BaseOpenAILLM, OpenAIError
+from litellm.llms.openai.openai import OpenAIChatCompletion
+from litellm.llms.openai.responses.transformation import OpenAIResponsesAPIConfig
+from litellm.llms.openai.workload_identity import (
+    OpenAIWorkloadIdentityConfig,
+    _workload_identity_auth,
+    get_workload_identity_bearer_token,
+    resolve_openai_workload_identity_config,
+)
+from litellm.types.router import GenericLiteLLMParams
+
+TOKEN_EXCHANGE_URL: Final = "https://auth.openai.com/oauth/token"
+
+
+@pytest.fixture
+def wif_env(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> OpenAIWorkloadIdentityConfig:
+    token_file: Final = tmp_path / "subject_token.jwt"
+    token_file.write_text("subject-token-from-file")
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.setenv("OPENAI_IDENTITY_PROVIDER_ID", "idp_test123")
+    monkeypatch.setenv("OPENAI_SERVICE_ACCOUNT_ID", "user-test456")
+    monkeypatch.setenv("OPENAI_IDENTITY_TOKEN_FILE", str(token_file))
+    _workload_identity_auth.cache_clear()
+    litellm.in_memory_llm_clients_cache.flush_cache()
+    return OpenAIWorkloadIdentityConfig(
+        identity_provider_id="idp_test123",
+        service_account_id="user-test456",
+        token_file=str(token_file),
+    )
+
+
+def mock_token_exchange(access_token: str = "exchanged-bearer-token") -> respx.Route:
+    return respx.post(TOKEN_EXCHANGE_URL).mock(
+        return_value=httpx.Response(200, json={"access_token": access_token, "expires_in": 3600})
+    )
+
+
+class TestResolveConfig:
+    def test_resolves_from_env(self, wif_env: OpenAIWorkloadIdentityConfig) -> None:
+        assert resolve_openai_workload_identity_config(api_key=None, api_base=None) == wif_env
+
+    def test_static_api_key_wins(self, wif_env: OpenAIWorkloadIdentityConfig) -> None:
+        assert resolve_openai_workload_identity_config(api_key="sk-static", api_base=None) is None
+
+    def test_foreign_api_base_disables(self, wif_env: OpenAIWorkloadIdentityConfig) -> None:
+        assert resolve_openai_workload_identity_config(api_key=None, api_base="https://my-vllm.internal/v1") is None
+
+    def test_openai_api_base_allows(self, wif_env: OpenAIWorkloadIdentityConfig) -> None:
+        assert resolve_openai_workload_identity_config(api_key=None, api_base="https://api.openai.com/v1") == wif_env
+
+    @pytest.mark.parametrize(
+        "missing_var",
+        ["OPENAI_IDENTITY_PROVIDER_ID", "OPENAI_SERVICE_ACCOUNT_ID", "OPENAI_IDENTITY_TOKEN_FILE"],
+    )
+    def test_partial_env_disables(
+        self, wif_env: OpenAIWorkloadIdentityConfig, monkeypatch: pytest.MonkeyPatch, missing_var: str
+    ) -> None:
+        monkeypatch.delenv(missing_var)
+        assert resolve_openai_workload_identity_config(api_key=None, api_base=None) is None
+
+
+class TestTokenExchange:
+    @respx.mock
+    def test_exchanges_subject_token_for_bearer(self, wif_env: OpenAIWorkloadIdentityConfig) -> None:
+        route: Final = mock_token_exchange()
+        assert get_workload_identity_bearer_token(wif_env) == "exchanged-bearer-token"
+        request_body: Final = json.loads(route.calls.last.request.content)
+        assert request_body["grant_type"] == "urn:ietf:params:oauth:grant-type:token-exchange"
+        assert request_body["subject_token"] == "subject-token-from-file"
+        assert request_body["subject_token_type"] == "urn:ietf:params:oauth:token-type:jwt"
+        assert request_body["identity_provider_id"] == "idp_test123"
+        assert request_body["service_account_id"] == "user-test456"
+
+    @respx.mock
+    def test_token_cached_across_mints(self, wif_env: OpenAIWorkloadIdentityConfig) -> None:
+        route: Final = mock_token_exchange()
+        first: Final = get_workload_identity_bearer_token(wif_env)
+        second: Final = get_workload_identity_bearer_token(wif_env)
+        assert first == second == "exchanged-bearer-token"
+        assert route.call_count == 1
+
+    def test_old_sdk_raises_upgrade_error(
+        self, wif_env: OpenAIWorkloadIdentityConfig, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import openai as openai_module
+
+        monkeypatch.delattr(openai_module, "auth", raising=False)
+        monkeypatch.setitem(sys.modules, "openai.auth", None)
+        with pytest.raises(OpenAIError, match=r"openai>=2\.32\.0"):
+            wif_env.to_sdk_workload_identity()
+
+
+class TestClientConstruction:
+    def test_sync_client_uses_workload_identity(self, wif_env: OpenAIWorkloadIdentityConfig) -> None:
+        client: Final = OpenAIChatCompletion()._get_openai_client(is_async=False, api_key=None, api_base=None)
+        assert isinstance(client, OpenAI)
+        assert client.api_key == "workload-identity-auth"
+        assert client._workload_identity_auth is not None
+
+    def test_async_client_uses_workload_identity(self, wif_env: OpenAIWorkloadIdentityConfig) -> None:
+        client: Final = OpenAIChatCompletion()._get_openai_client(is_async=True, api_key=None, api_base=None)
+        assert isinstance(client, AsyncOpenAI)
+        assert client.api_key == "workload-identity-auth"
+        assert client._workload_identity_auth is not None
+
+    def test_static_key_client_unaffected(self, wif_env: OpenAIWorkloadIdentityConfig) -> None:
+        client: Final = OpenAIChatCompletion()._get_openai_client(is_async=False, api_key="sk-static", api_base=None)
+        assert isinstance(client, OpenAI)
+        assert client.api_key == "sk-static"
+        assert client._workload_identity_auth is None
+
+    def test_cache_key_separates_wif_identities(self, wif_env: OpenAIWorkloadIdentityConfig) -> None:
+        other_config: Final = OpenAIWorkloadIdentityConfig(
+            identity_provider_id="idp_other",
+            service_account_id="user-other",
+            token_file=wif_env.token_file,
+        )
+        keys: Final = tuple(
+            BaseOpenAILLM.get_openai_client_cache_key(
+                client_initialization_params={"api_key": None, "is_async": False, "workload_identity_config": config},
+                client_type="openai",
+            )
+            for config in (wif_env, other_config, None)
+        )
+        assert len(set(keys)) == 3
+
+    @respx.mock
+    def test_request_carries_exchanged_bearer(self, wif_env: OpenAIWorkloadIdentityConfig) -> None:
+        mock_token_exchange()
+        completion_route: Final = respx.post("https://api.openai.com/v1/chat/completions").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "id": "chatcmpl-wif",
+                    "object": "chat.completion",
+                    "created": 1,
+                    "model": "gpt-4o-mini",
+                    "choices": [
+                        {
+                            "index": 0,
+                            "message": {"role": "assistant", "content": "ok"},
+                            "finish_reason": "stop",
+                        }
+                    ],
+                    "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+                },
+            )
+        )
+        client = OpenAIChatCompletion()._get_openai_client(is_async=False, api_key=None, api_base=None)
+        assert isinstance(client, OpenAI)
+        client.chat.completions.create(model="gpt-4o-mini", messages=[{"role": "user", "content": "hi"}])
+        auth_header: Final = completion_route.calls.last.request.headers["Authorization"]
+        assert auth_header == "Bearer exchanged-bearer-token"
+
+
+class TestResponsesValidateEnvironment:
+    @respx.mock
+    def test_mints_bearer_when_wif_configured(self, wif_env: OpenAIWorkloadIdentityConfig) -> None:
+        mock_token_exchange()
+        headers: Final = OpenAIResponsesAPIConfig().validate_environment(
+            headers={}, model="gpt-4o-mini", litellm_params=GenericLiteLLMParams()
+        )
+        assert headers["Authorization"] == "Bearer exchanged-bearer-token"
+
+    def test_static_key_wins(self, wif_env: OpenAIWorkloadIdentityConfig) -> None:
+        headers: Final = OpenAIResponsesAPIConfig().validate_environment(
+            headers={}, model="gpt-4o-mini", litellm_params=GenericLiteLLMParams(api_key="sk-responses")
+        )
+        assert headers["Authorization"] == "Bearer sk-responses"
+
+    def test_foreign_api_base_skips_wif(self, wif_env: OpenAIWorkloadIdentityConfig) -> None:
+        headers: Final = OpenAIResponsesAPIConfig().validate_environment(
+            headers={},
+            model="gpt-4o-mini",
+            litellm_params=GenericLiteLLMParams(api_base="https://my-vllm.internal/v1"),
+        )
+        assert headers["Authorization"] == "Bearer None"

--- a/tests/test_litellm/llms/openai/test_openai_workload_identity.py
+++ b/tests/test_litellm/llms/openai/test_openai_workload_identity.py
@@ -63,6 +63,15 @@ class TestResolveConfig:
         monkeypatch.setenv("OPENAI_API_KEY", "sk-from-env")
         assert resolve_openai_workload_identity_config(api_key=None, api_base=None) is None
 
+    def test_empty_env_openai_api_key_counts_as_unset(
+        self, wif_env: OpenAIWorkloadIdentityConfig, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("OPENAI_API_KEY", "")
+        assert resolve_openai_workload_identity_config(api_key=None, api_base=None) == wif_env
+
+    def test_empty_api_key_param_counts_as_unset(self, wif_env: OpenAIWorkloadIdentityConfig) -> None:
+        assert resolve_openai_workload_identity_config(api_key="", api_base=None) == wif_env
+
     def test_foreign_api_base_disables(self, wif_env: OpenAIWorkloadIdentityConfig) -> None:
         assert resolve_openai_workload_identity_config(api_key=None, api_base="https://my-vllm.internal/v1") is None
 

--- a/tests/test_litellm/llms/openai/test_openai_workload_identity.py
+++ b/tests/test_litellm/llms/openai/test_openai_workload_identity.py
@@ -9,6 +9,7 @@ import respx
 from openai import AsyncOpenAI, OpenAI
 
 import litellm
+from litellm.llms.litellm_proxy.responses.transformation import LiteLLMProxyResponsesAPIConfig
 from litellm.llms.openai.common_utils import BaseOpenAILLM, OpenAIError
 from litellm.llms.openai.openai import OpenAIChatCompletion
 from litellm.llms.openai.responses.transformation import OpenAIResponsesAPIConfig
@@ -28,6 +29,9 @@ def wif_env(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> OpenAIWorkloadId
     token_file: Final = tmp_path / "subject_token.jwt"
     token_file.write_text("subject-token-from-file")
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
+    monkeypatch.delenv("OPENAI_API_BASE", raising=False)
+    monkeypatch.setattr(litellm, "api_base", None)
     monkeypatch.setenv("OPENAI_IDENTITY_PROVIDER_ID", "idp_test123")
     monkeypatch.setenv("OPENAI_SERVICE_ACCOUNT_ID", "user-test456")
     monkeypatch.setenv("OPENAI_IDENTITY_TOKEN_FILE", str(token_file))
@@ -53,11 +57,35 @@ class TestResolveConfig:
     def test_static_api_key_wins(self, wif_env: OpenAIWorkloadIdentityConfig) -> None:
         assert resolve_openai_workload_identity_config(api_key="sk-static", api_base=None) is None
 
+    def test_env_openai_api_key_wins(
+        self, wif_env: OpenAIWorkloadIdentityConfig, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-from-env")
+        assert resolve_openai_workload_identity_config(api_key=None, api_base=None) is None
+
     def test_foreign_api_base_disables(self, wif_env: OpenAIWorkloadIdentityConfig) -> None:
         assert resolve_openai_workload_identity_config(api_key=None, api_base="https://my-vllm.internal/v1") is None
 
     def test_openai_api_base_allows(self, wif_env: OpenAIWorkloadIdentityConfig) -> None:
         assert resolve_openai_workload_identity_config(api_key=None, api_base="https://api.openai.com/v1") == wif_env
+
+    def test_foreign_env_base_url_disables(
+        self, wif_env: OpenAIWorkloadIdentityConfig, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("OPENAI_BASE_URL", "https://my-vllm.internal/v1")
+        assert resolve_openai_workload_identity_config(api_key=None, api_base=None) is None
+
+    def test_openai_env_base_url_allows(
+        self, wif_env: OpenAIWorkloadIdentityConfig, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("OPENAI_BASE_URL", "https://api.openai.com/v1")
+        assert resolve_openai_workload_identity_config(api_key=None, api_base=None) == wif_env
+
+    def test_foreign_litellm_api_base_disables(
+        self, wif_env: OpenAIWorkloadIdentityConfig, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(litellm, "api_base", "https://my-vllm.internal/v1")
+        assert resolve_openai_workload_identity_config(api_key=None, api_base=None) is None
 
     @pytest.mark.parametrize(
         "missing_var",
@@ -184,5 +212,11 @@ class TestResponsesValidateEnvironment:
             headers={},
             model="gpt-4o-mini",
             litellm_params=GenericLiteLLMParams(api_base="https://my-vllm.internal/v1"),
+        )
+        assert headers["Authorization"] == "Bearer None"
+
+    def test_litellm_proxy_subclass_never_mints_wif(self, wif_env: OpenAIWorkloadIdentityConfig) -> None:
+        headers: Final = LiteLLMProxyResponsesAPIConfig().validate_environment(
+            headers={}, model="gpt-4o-mini", litellm_params=GenericLiteLLMParams()
         )
         assert headers["Authorization"] == "Bearer None"


### PR DESCRIPTION
## TLDR

Problem this solves:

- Keyless OpenAI auth (Workload Identity Federation) is unsupported
- Kubernetes pods must mount long-lived `sk-` keys instead
- Requested in #31649; also a customer roadmap ask

How it solves it:

- Three env vars enable RFC 8693 token exchange at auth.openai.com
- `OPENAI_IDENTITY_PROVIDER_ID`, `OPENAI_SERVICE_ACCOUNT_ID`, `OPENAI_IDENTITY_TOKEN_FILE`
- Covers chat, streaming, embeddings, images, audio, moderations, and responses
- A static `api_key` wins, and so does a discoverable `OPENAI_API_KEY` (env or secret manager), so existing deployments behave exactly as before
- WIF activates only when the effective api_base targets api.openai.com over https: the per-model `api_base`, `litellm.api_base`, `OPENAI_BASE_URL`, and `OPENAI_API_BASE` are all consulted, so a bearer is never minted for, or sent in cleartext to, a foreign host
- On `/v1/responses` the WIF branch is gated to the openai provider, so the `litellm_proxy` responses management endpoints (which reuse the same base class) can never mint a real OpenAI bearer and send it to the operator's proxy host
- Bearer tokens auto-refresh (1h life, refreshed at 40min); WIF vars set to empty strings are treated as unset, and so is an empty or whitespace-only `OPENAI_API_KEY` (via the shared `normalize_nonempty_secret_str` helper), so a pod exporting `OPENAI_API_KEY=` with the WIF trio set still authenticates

Design note: this is standalone from #38818 (Anthropic WIF), with zero file overlap, because the OpenAI SDK ships native workload identity support since 2.32.0: single-flight token refresh, a 10s exchange timeout, and automatic 401 re-exchange. We pass the SDK's `workload_identity=` argument rather than a token-minting `api_key` callable because the SDK writes callable results into `client.api_key`, which LiteLLM's debug logging prints; with `workload_identity=` the client only ever holds the placeholder `workload-identity-auth` and injects the real bearer per request

## User Flow

Before: a platform engineer running the proxy on Kubernetes sets the three WIF env vars from #31649, and every OpenAI call still fails for lack of an API key

1. They deploy the proxy with `OPENAI_IDENTITY_PROVIDER_ID`, `OPENAI_SERVICE_ACCOUNT_ID`, and `OPENAI_IDENTITY_TOKEN_FILE` (the projected service account token path) set, and no `OPENAI_API_KEY` anywhere
2. They send POST https://litellm-domain/v1/chat/completions with an `openai/` model and get a 500: "The api_key client option must be set either by passing api_key to the client or by setting the OPENAI_API_KEY environment variable"
3. They send POST https://litellm-domain/v1/responses and get a 401 from OpenAI: "Incorrect API key provided: None", because the proxy sent `Authorization: Bearer None` upstream
4. They send POST https://litellm-domain/v1/embeddings and get the same 500, so they fall back to minting and distributing a long-lived `sk-` key

After: the same keyless deployment authenticates via OIDC token exchange and every call succeeds

1. They deploy the proxy with `OPENAI_IDENTITY_PROVIDER_ID`, `OPENAI_SERVICE_ACCOUNT_ID`, and `OPENAI_IDENTITY_TOKEN_FILE` set, and no `OPENAI_API_KEY` anywhere
2. They send POST https://litellm-domain/v1/chat/completions and get a 200 with the completion and real token usage
3. They send POST https://litellm-domain/v1/responses and get a 200 with a `resp_...` id and output text
4. They send POST https://litellm-domain/v1/embeddings and get a 200 with a real embedding vector
5. Streaming the same chat request returns normal SSE chunks
6. GET https://litellm-domain/health reports those keyless deployments healthy
7. Deployments carrying a static `api_key`, and any deployment whose api_base is not api.openai.com (per-model or via `OPENAI_BASE_URL` / `OPENAI_API_BASE` / `litellm.api_base`), behave exactly as before the PR
8. The exchanged bearer expires after an hour and the proxy refreshes it on its own, so there is no key to rotate or leak

## Relevant issues

Fixes #31649

## Linear ticket

Resolves LIT-6108

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Setup, identical on both sides: a real identity provider registered in the OpenAI dashboard (uploaded JWKS, claim mapping on `sub`, service account `user-eb4df5aacd2ce68a9d9ca089` with project access), a locally minted RS256 JWT as the subject token, and a keyless proxy

```yaml
model_list:
  - model_name: gpt-5.6
    litellm_params:
      model: openai/gpt-5.6
  - model_name: text-embedding-3-small
    litellm_params:
      model: openai/text-embedding-3-small
general_settings:
  master_key: os.environ/LITELLM_MASTER_KEY
```

```bash
export OPENAI_IDENTITY_PROVIDER_ID="idp_79ebff2759f9a3b0145fce5a"
export OPENAI_SERVICE_ACCOUNT_ID="user-eb4df5aacd2ce68a9d9ca089"
export OPENAI_IDENTITY_TOKEN_FILE="$PWD/subject_token.jwt"
# OPENAI_API_KEY deliberately unset
python litellm/proxy/proxy_cli.py --config lit6108_config.yaml --port <port> --num_workers 2 --detailed_debug
```

### Before (c03a38d501)

#### chat completion

1. `curl -s http://localhost:28731/v1/chat/completions -H "Authorization: Bearer $MK" -H 'Content-Type: application/json' -d '{"model":"gpt-5.6","messages":[{"role":"user","content":"Say RISK-A-OK and nothing else"}]}'`
2. `{"error":{"message":"litellm.AuthenticationError: AuthenticationError: OpenAIException - The api_key client option must be set either by passing api_key to the client or by setting the OPENAI_API_KEY environment variable. ...","code":"500"}}`

#### chat completion streaming

1. Same request with `"stream": true`
2. `{"error":{"message":"litellm.AuthenticationError: AuthenticationError: OpenAIException - The api_key client option must be set either by passing api_key to the client or by setting the OPENAI_API_KEY environment variable. ...","code":"500"}}`

#### responses

1. `curl -s http://localhost:28731/v1/responses -H "Authorization: Bearer $MK" -H 'Content-Type: application/json' -d '{"model":"gpt-5.6","input":"Say RISK-A-OK and nothing else"}'`
2. HTTP 401, the proxy sent `Authorization: Bearer None` upstream: `{"error":{"message":"litellm.AuthenticationError: AuthenticationError: OpenAIException - ... \"Incorrect API key provided: None. ...\" ...","code":"401"}}`

#### embeddings

1. `curl -s http://localhost:28731/v1/embeddings -H "Authorization: Bearer $MK" -H 'Content-Type: application/json' -d '{"model":"text-embedding-3-small","input":"hello"}'`
2. `{"error":{"message":"litellm.AuthenticationError: AuthenticationError: OpenAIException - The api_key client option must be set either by passing api_key to the client or by setting the OPENAI_API_KEY environment variable. ...","code":"500"}}`

### After (ae83444a3e)

#### chat completion

1. `curl -s http://localhost:29417/v1/chat/completions -H "Authorization: Bearer $MK" -H 'Content-Type: application/json' -d '{"model":"gpt-5.6","messages":[{"role":"user","content":"Say RISK-A-OK and nothing else"}]}'`
2. `{"id":"chatcmpl-EJ2qziKgeikalsVlhKVobqIkOBnKV","created":1788207909,"model":"gpt-5.6","object":"chat.completion","choices":[{"finish_reason":"stop","index":0,"message":{"content":"RISK-A-OK","role":"assistant",...}}],"usage":{"completion_tokens":8,"prompt_tokens":15,"total_tokens":23,...}}`

#### chat completion streaming

1. Same request with `"stream": true`
2. Normal SSE chunks stream back: `data: {"id":"chatcmpl-EJ2uSUOEYpXqWHDLSYl8D8toDrgjZ","object":"chat.completion.chunk",...,"choices":[{"index":0,"delta":{"content":"W"}}]}` ... spelling out `WIF-STREAM-OK`, then a `finish_reason":"stop"` chunk and `data: [DONE]`

#### responses

1. `curl -s http://localhost:29417/v1/responses -H "Authorization: Bearer $MK" -H 'Content-Type: application/json' -d '{"model":"gpt-5.6","input":"Say RISK-A-OK and nothing else"}'`
2. `{"id":"resp_ci-vs4paoMSELKwIvtffGnO7qla2LT4RL20_s7WU0BE3DD6IceZSilEg...","model":"gpt-5.6","object":"response","output":[{"content":[{"text":"RISK-A-OK","type":"output_text",...}],"role":"assistant","status":"completed","type":"message"}],...}`

#### embeddings

1. `curl -s http://localhost:29417/v1/embeddings -H "Authorization: Bearer $MK" -H 'Content-Type: application/json' -d '{"model":"text-embedding-3-small","input":"hello"}'`
2. `{"model":"text-embedding-3-small","data":[{"embedding":[...(1536 floats)...],"index":0,"object":"embedding"}],"object":"list","usage":{"prompt_tokens":1,"total_tokens":1}}`

#### precedence and scoping guards (same run)

1. A deployment with a static `api_key` alongside the WIF env vars answers 200 from the static key, identical to before the PR
2. A keyless deployment pointed at `https://api.groq.com/openai/v1` fails with the same pre-PR error on both sides; the head's debug log shows zero requests to auth.openai.com
3. Booting the proxy with a foreign `OPENAI_BASE_URL` exported plus the WIF vars reproduces pre-PR behavior byte for byte on chat, embeddings, and responses
4. Booting with the three WIF vars exported as empty strings reproduces pre-PR behavior byte for byte
5. Booting with `OPENAI_API_KEY=''` exported alongside the real WIF vars: base answers 401 "You didn't provide an API key" on chat while head answers 200 (`chatcmpl-EJ2tIejOW5lRTuuWbaPzjDQ4RjOyp`, "EK2-OK") and 200 on responses (`resp_-42XsBuHSZzYeO_UBCv71Ylx5GzH6JKlfTE`); a whitespace-only `OPENAI_API_KEY='   '` behaves the same on head (`chatcmpl-EJ2tOkOQjDurxziFrvxuESp1k0MhT`, `resp_1tKciPKwpbmUBzFYTXhUwIUKyuV-9s6qcw1`), so a present-but-blank key no longer disables federation
6. `GET /health` flips the two keyless openai deployments to `healthy_endpoints`; every other deployment's health result is unchanged

## Type

🆕 New Feature

## Caveats (if any)

### Low

- On `/v1/responses` the token mint is synchronous, so it briefly blocks the event loop once per ~40min refresh cycle (typically sub-second, 10s ceiling from the SDK's exchange timeout). Same blocking class as the sync secret-manager reads already in `validate_environment`; making that contract async across providers is not worth a bounded, rare latency blip
- Assistants, files, batches, fine-tuning, legacy text completions, and image variations are out of scope by design: #31649 asks for inference surfaces only, and those paths build fresh uncached clients per call, so WIF there would mean one token exchange per request. They fail keyless exactly as before the PR
- With WIF env vars set but `openai < 2.32.0` installed, calls fail with a 500 naming the required upgrade
- WIF activates only when the effective api_base is exactly `https://api.openai.com` (or nothing sets one); regional hosts like `eu.api.openai.com` do not activate it
- Keyless requests read up to six env/secret-manager keys per call before the client cache lookup; with a secret manager whose misses are uncached (e.g. AWS SM) that is measurable

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how upstream OpenAI credentials are chosen and attached, but WIF is gated behind env config, api_base host checks, and explicit precedence over static keys; extensive tests cover mis-routing cases.
> 
> **Overview**
> Adds **keyless OpenAI authentication** via workload identity federation when `OPENAI_IDENTITY_PROVIDER_ID`, `OPENAI_SERVICE_ACCOUNT_ID`, and `OPENAI_IDENTITY_TOKEN_FILE` are set and no non-empty static `OPENAI_API_KEY` is in play.
> 
> A new `workload_identity` module resolves that config only for **https://api.openai.com** (foreign or HTTP bases skip WIF). Cached sync/async `OpenAI` clients are built with the SDK’s `workload_identity=` hook (openai≥2.32.0) instead of `api_key`, and `workload_identity_config` is included in the client cache key. The **Responses API** path separately mints an exchanged bearer for the real OpenAI provider only (not `litellm_proxy` subclasses).
> 
> Static API keys and discoverable `OPENAI_API_KEY` still win; empty keys are treated as unset so WIF can activate. Tests cover resolution guards, token exchange/caching, client construction, and Responses headers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ae83444a3e0eca7536f49101557bc8ec044b501a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
