### PR TITLE
fix(proxy): accept both deferred-stream arg shapes in native branch

### DIFF
--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -4719,7 +4719,11 @@ def _init_custom_logger_compatible_class(
             return newrelic_logger
         return None
     except Exception as e:
-        verbose_logger.exception("[Non-Blocking Error] Error initializing custom logger: %s", e)
+        verbose_logger.exception(
+            "Failed to initialize custom logger for integration %r: %s. Callback will not be registered.",
+            logging_integration,
+            e,
+        )
         return None
     return None
 

--- a/litellm/proxy/common_request_processing.py
+++ b/litellm/proxy/common_request_processing.py
@@ -4,7 +4,7 @@ import json
 import logging
 import math
 import traceback
-from collections.abc import AsyncGenerator, Awaitable, Callable, Coroutine, Mapping, Sequence
+from collections.abc import AsyncGenerator, Awaitable, Callable, Mapping, Sequence
 from datetime import datetime
 from functools import lru_cache
 from types import MappingProxyType
@@ -3138,10 +3138,31 @@ class ProxyBaseLLMRequestProcessing:
 
         from litellm.litellm_core_utils.logging_worker import GLOBAL_LOGGING_WORKER
 
-        async def _on_deferred_native_stream_complete(
-            logging_coroutine: Coroutine[object, object, object],
-        ) -> None:
-            GLOBAL_LOGGING_WORKER.ensure_initialized_and_enqueue(async_coroutine=logging_coroutine)
+        _captured_native_logging_obj: Final = logging_obj
+
+        async def _on_deferred_native_stream_complete(*args: object) -> None:
+            # 1-arg (logging_coroutine,) is what the native passthrough/responses
+            # iterators write; 2-arg (assembled_response, cache_hit) is what the
+            # /v1/messages completion bridge writes via its inner CustomStreamWrapper.
+            # The proxy sees a bare byte generator in both cases, so arity dispatch
+            # here is the only place we can tell them apart.
+            if len(args) == 1 and asyncio.iscoroutine(args[0]):
+                GLOBAL_LOGGING_WORKER.ensure_initialized_and_enqueue(async_coroutine=args[0])
+                return
+            if len(args) == 2:
+                assembled_response, cache_hit = args
+                await _as_success_dispatcher(_captured_native_logging_obj).dispatch_success_handlers(
+                    assembled_response,
+                    cache_hit=cache_hit,
+                    start_time=None,
+                    end_time=None,
+                    prefer_async_handlers=True,
+                )
+                return
+            verbose_proxy_logger.error(
+                "Deferred stream logging received unexpected args shape (len=%d); dropping to avoid double-logging",
+                len(args),
+            )
 
         logging_obj._on_deferred_stream_complete = _on_deferred_native_stream_complete
 

--- a/tests/test_litellm/proxy/guardrails/test_deferred_guardrail_logging.py
+++ b/tests/test_litellm/proxy/guardrails/test_deferred_guardrail_logging.py
@@ -1416,6 +1416,34 @@ class TestArmDeferredStreamDispatch:
         coro.close()
 
     @pytest.mark.asyncio
+    async def test_native_stream_closure_accepts_bridge_two_arg_shape(self):
+        """/v1/messages via the completion bridge returns a bare byte generator,
+        so arming lands in the native branch. But the inner CustomStreamWrapper
+        writes the 2-arg (assembled_response, cache_hit) shape at end-of-stream,
+        which the pre-fix 1-arg closure blew up on."""
+        logging_obj, recorded = self._dispatch_recording_logging_obj()
+
+        async def _agen():
+            yield b"x"
+
+        self._processor()._arm_deferred_stream_dispatch(
+            response=_agen(),
+            route_type="anthropic_messages",
+            user_api_key_dict=MagicMock(),
+            logging_obj=logging_obj,
+        )
+        closure = logging_obj._on_deferred_stream_complete
+        assert closure is not None
+
+        assembled = object()
+        await closure(assembled, False)
+        await asyncio.sleep(0)
+
+        assert recorded["result"] is assembled
+        assert recorded["cache_hit"] is False
+        assert recorded["prefer_async_handlers"] is True
+
+    @pytest.mark.asyncio
     async def test_csw_closure_routes_through_deferred_stream_guardrails(self, monkeypatch):
         from litellm.litellm_core_utils.streaming_handler import CustomStreamWrapper
 


### PR DESCRIPTION
## TLDR

Problem this solves:

- streaming /v1/messages via a non-Anthropic provider crashes when a post-call guardrail is active
- the crash raises TypeError inside the deferred-logging fire, so spend logs go missing
- root cause of the failing Together AI /v1/messages streaming e2e in stage build 2026-08-31

How it solves it:

- native deferred closure now accepts both the 1-arg and 2-arg writer shapes
- 1-arg native passthrough enqueues on the rooted logging worker as before
- 2-arg bridged CustomStreamWrapper shape dispatches success handlers directly

## User Flow

Before: a developer whose app calls /v1/messages against a non-Anthropic model with streaming on gets a 200 response, but the last SSE event is followed by a server crash and no spend record for that request

1. They send POST https://litellm-domain/v1/messages with `"stream": true` and a model backed by a non-Anthropic provider (e.g. Together AI)
2. The SSE stream carries content_block_delta events normally and ends with message_stop
3. Right after message_stop the proxy raises TypeError inside its deferred-logging path, the request never lands in /spend/logs, and cost dashboards read zero for that call
4. They open https://litellm-domain/ui/?page=logs and the request is missing

After: the same request completes cleanly and its spend record shows up

1. The developer sends the same POST https://litellm-domain/v1/messages with `"stream": true` and the same non-Anthropic model
2. The SSE stream carries content_block_delta events and ends with message_stop as before
3. No TypeError is raised, deferred logging fires against the assembled response, and the request lands in /spend/logs with real token counts and cost
4. https://litellm-domain/ui/?page=logs shows the request at non-zero spend

## Relevant issues

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Proxy config used (post-call guardrail is what arms the deferred-logging path this PR fixes):

```yaml
model_list:
  - model_name: anthropic-haiku
    litellm_params:
      model: anthropic/claude-haiku-4-5
      api_key: os.environ/ANTHROPIC_API_KEY
  - model_name: openai-gpt-4o-mini
    litellm_params:
      model: openai/gpt-4o-mini
      api_key: os.environ/OPENAI_API_KEY

litellm_settings:
  callbacks: ["presidio"]

guardrails:
  - guardrail_name: presidio-post-call
    litellm_params:
      guardrail: presidio
      mode: post_call
      default_on: true

general_settings:
  master_key: sk-1234
```

Bridge case shared payload:

```
data-bridge.json:
{"model": "openai-gpt-4o-mini", "max_tokens": 32, "stream": true,
 "messages": [{"role": "user", "content": "say hi once"}]}
```

Native case shared payload:

```
data-native.json:
{"model": "anthropic-haiku", "max_tokens": 32, "stream": true,
 "messages": [{"role": "user", "content": "say hi once"}]}
```

### Before (c03a38d501)

#### Bridge path: /v1/messages -> openai (completion bridge)

1. `curl -sSN http://localhost:4000/v1/messages -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" --data @data-bridge.json` streams events and returns 200
2. proxy log shows `TypeError: _on_deferred_native_stream_complete() takes 1 positional argument but 2 were given` right after message_stop
3. `curl -s http://localhost:4000/spend/logs?request_id=<from x-litellm-response-id>` returns `[]` -- the request never got billed

#### Native path: /v1/messages -> anthropic (native passthrough)

1. `curl -sSN http://localhost:4000/v1/messages -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" --data @data-native.json` streams and returns 200
2. proxy log is clean, no TypeError
3. `curl -s http://localhost:4000/spend/logs?request_id=<from x-litellm-response-id>` returns one entry with real token counts

### After (17fce8a20b)

#### Bridge path: /v1/messages -> openai (completion bridge)

1. `curl -sSN http://localhost:4000/v1/messages -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" --data @data-bridge.json` streams and returns 200
2. proxy log is clean, no TypeError
3. `curl -s http://localhost:4000/spend/logs?request_id=<from x-litellm-response-id>` returns one entry with real token counts and cost

#### Native path: /v1/messages -> anthropic (native passthrough)

1. `curl -sSN http://localhost:4000/v1/messages -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" --data @data-native.json` streams and returns 200
2. proxy log is clean, no TypeError (same as before, this regression-checks the native branch)
3. `curl -s http://localhost:4000/spend/logs?request_id=<from x-litellm-response-id>` returns one entry with real token counts

## Type

Bug Fix

## Caveats (if any)

### Low

- The two deferred-args writer shapes are still positional and untyped, this PR unblocks e2e without refactoring them
- A follow-up should turn the payload into a tagged union so a new writer cannot silently paint itself into the wrong callback again
- The `_init_custom_logger_compatible_class` log line now names the failing integration; that is a diagnostic improvement only, it does not by itself fix S3/GCS callback registration failures that are stage config or premium-license issues

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
