### PR TITLE
fix(proxy): use x-api-key for auth when Authorization is an Anthropic OAuth token

### DIFF
--- a/litellm/proxy/auth/user_api_key_auth.py
+++ b/litellm/proxy/auth/user_api_key_auth.py
@@ -647,6 +647,7 @@ def get_api_key(
     Returns:
         Tuple[Optional[str], Optional[str]]: Tuple of the api_key and the passed_in_key
     """
+    from litellm.llms.anthropic.common_utils import is_anthropic_oauth_key
     from litellm.proxy.auth.route_checks import RouteChecks
     from litellm.proxy.common_utils.http_parsing_utils import (
         _safe_get_request_query_params,
@@ -658,8 +659,24 @@ def get_api_key(
         passed_in_key = custom_litellm_key_header
         api_key = _get_bearer_token_or_received_api_key(custom_litellm_key_header)
     elif isinstance(api_key, str) and len(api_key) > 0:
-        passed_in_key = api_key
-        api_key = _get_bearer_token(api_key=api_key)
+        bearer_api_key = _get_bearer_token(api_key=api_key)
+        if (
+            is_anthropic_oauth_key(bearer_api_key)
+            and isinstance(anthropic_api_key_header, str)
+            and len(anthropic_api_key_header) > 0
+        ):
+            # The Authorization header carries an upstream Anthropic OAuth token
+            # (`sk-ant-oat*`), which is never a LiteLLM credential. Clients like
+            # the Claude Code tab in Claude Desktop send that session token
+            # alongside the user's LiteLLM virtual key in `x-api-key` — use
+            # `x-api-key` for proxy auth instead of failing the OAuth token's
+            # lookup. The OAuth token itself stays on the request for the
+            # provider passthrough handling in litellm_pre_call_utils.
+            passed_in_key = anthropic_api_key_header
+            api_key = anthropic_api_key_header
+        else:
+            passed_in_key = api_key
+            api_key = bearer_api_key
     elif isinstance(azure_api_key_header, str):
         passed_in_key = azure_api_key_header
         api_key = azure_api_key_header

--- a/litellm/proxy/litellm_pre_call_utils.py
+++ b/litellm/proxy/litellm_pre_call_utils.py
@@ -1741,13 +1741,23 @@ async def add_litellm_data_to_request(
         forward_llm_auth = getattr(litellm, "forward_llm_provider_auth_headers", False)
     # Determine which header was used for authentication
     # This enables forwarding provider keys (e.g., x-api-key) when they weren't used for LiteLLM auth
+    from litellm.llms.anthropic.common_utils import is_anthropic_oauth_key
+
     authenticated_with_header = None
     if "x-litellm-api-key" in request.headers:
         # If x-litellm-api-key is present, it was used for auth
         authenticated_with_header = "x-litellm-api-key"
     elif "authorization" in request.headers:
-        # Authorization header was used for auth
-        authenticated_with_header = "authorization"
+        if is_anthropic_oauth_key(request.headers.get("authorization")) and request.headers.get("x-api-key"):
+            # Authorization carries an upstream Anthropic OAuth token
+            # (`sk-ant-oat*`), so `user_api_key_auth.get_api_key` authenticated
+            # with `x-api-key` instead (see #29190). Mirror that here so the
+            # OAuth token stays forwardable to Anthropic and the LiteLLM
+            # virtual key in `x-api-key` is not forwarded upstream.
+            authenticated_with_header = "x-api-key"
+        else:
+            # Authorization header was used for auth
+            authenticated_with_header = "authorization"
     else:
         # x-api-key or another header was used for auth
         authenticated_with_header = "x-api-key"

--- a/tests/test_litellm/proxy/auth/test_user_api_key_auth.py
+++ b/tests/test_litellm/proxy/auth/test_user_api_key_auth.py
@@ -68,6 +68,87 @@ def test_get_api_key():
     ) == (api_key, passed_in_key)
 
 
+_ANTHROPIC_OAUTH_BEARER = "Bearer sk-ant-oat01-fake-claude-desktop-session-token"
+
+
+def _get_api_key_result(
+    api_key=None,
+    anthropic_api_key_header=None,
+    custom_litellm_key_header=None,
+    route="/v1/messages",
+):
+    return get_api_key(
+        custom_litellm_key_header=custom_litellm_key_header,
+        api_key=api_key,
+        azure_api_key_header=None,
+        anthropic_api_key_header=anthropic_api_key_header,
+        google_ai_studio_api_key_header=None,
+        azure_apim_header=None,
+        pass_through_endpoints=None,
+        route=route,
+        request=MagicMock(),
+    )
+
+
+def test_get_api_key_prefers_x_api_key_over_anthropic_oauth_authorization():
+    """Claude Code (the Claude Desktop 3P tab) sends its Anthropic OAuth session
+    token in `Authorization` alongside the user's LiteLLM virtual key in
+    `x-api-key`. `sk-ant-oat*` is an upstream credential, never a LiteLLM key —
+    proxy auth must use `x-api-key`. Regression test for #29190."""
+    litellm_key = "sk-my-litellm-virtual-key"
+    assert _get_api_key_result(
+        api_key=_ANTHROPIC_OAUTH_BEARER,
+        anthropic_api_key_header=litellm_key,
+    ) == (litellm_key, litellm_key)
+
+
+def test_get_api_key_authorization_still_wins_over_x_api_key_for_regular_keys():
+    """A regular bearer key in `Authorization` keeps precedence over `x-api-key`."""
+    assert _get_api_key_result(
+        api_key="Bearer sk-regular-litellm-key",
+        anthropic_api_key_header="sk-some-other-key",
+    ) == ("sk-regular-litellm-key", "Bearer sk-regular-litellm-key")
+
+
+def test_get_api_key_oauth_authorization_without_x_api_key_unchanged():
+    """With no `x-api-key` fallback available, the OAuth bearer is still treated
+    as the (failing) auth credential — existing behavior preserved."""
+    assert _get_api_key_result(api_key=_ANTHROPIC_OAUTH_BEARER) == (
+        "sk-ant-oat01-fake-claude-desktop-session-token",
+        _ANTHROPIC_OAUTH_BEARER,
+    )
+
+
+def test_get_api_key_oauth_authorization_with_empty_x_api_key_unchanged():
+    """An empty `x-api-key` is not a usable fallback credential."""
+    assert _get_api_key_result(
+        api_key=_ANTHROPIC_OAUTH_BEARER,
+        anthropic_api_key_header="",
+    ) == (
+        "sk-ant-oat01-fake-claude-desktop-session-token",
+        _ANTHROPIC_OAUTH_BEARER,
+    )
+
+
+def test_get_api_key_x_api_key_only_unchanged():
+    """`x-api-key` alone keeps working (Claude Code CLI / Cowork tab)."""
+    litellm_key = "sk-my-litellm-virtual-key"
+    assert _get_api_key_result(anthropic_api_key_header=litellm_key) == (
+        litellm_key,
+        litellm_key,
+    )
+
+
+def test_get_api_key_custom_litellm_key_header_still_supersedes_oauth_handling():
+    """`x-litellm-api-key` keeps top precedence even when the OAuth + x-api-key
+    combination is present."""
+    assert _get_api_key_result(
+        api_key=_ANTHROPIC_OAUTH_BEARER,
+        anthropic_api_key_header="sk-my-litellm-virtual-key",
+        custom_litellm_key_header="Bearer sk-custom-header-key",
+    ) == ("sk-custom-header-key", "Bearer sk-custom-header-key")
+
+
 def test_route_requires_auth_despite_public_for_metrics(monkeypatch):
     monkeypatch.setattr(litellm, "require_auth_for_metrics_endpoint", True)
 
@@ -1515,6 +1596,76 @@ async def test_master_key_auth_sets_via_virtual_key_marker():
 
         assert isinstance(result, UserAPIKeyAuth)
         assert result.via_virtual_key is True
+        assert result.api_key == LITELLM_PROXY_MASTER_KEY_ALIAS
+    finally:
+        for attr, val in _original_values.items():
+            setattr(_proxy_server_mod, attr, val)
+
+
+@pytest.mark.asyncio
+async def test_auth_builder_dual_headers_authenticates_via_x_api_key_when_authorization_is_anthropic_oauth():
+    """End-to-end regression test for #29190: `Authorization: Bearer sk-ant-oat...`
+    (the Claude Desktop session's Anthropic OAuth token) together with a valid
+    LiteLLM key in `x-api-key` must authenticate via `x-api-key` instead of
+    failing the OAuth token's virtual-key lookup."""
+    from fastapi import Request
+    from starlette.datastructures import URL
+
+    from litellm.constants import LITELLM_PROXY_MASTER_KEY_ALIAS
+    from litellm.proxy.auth.user_api_key_auth import _user_api_key_auth_builder
+
+    master_key = "sk-master-key"
+
+    mock_cache = AsyncMock()
+    mock_cache.async_get_cache = AsyncMock(return_value=None)
+    mock_cache.delete_cache = MagicMock()
+
+    mock_proxy_logging_obj = MagicMock()
+    mock_proxy_logging_obj.internal_usage_cache = MagicMock()
+    mock_proxy_logging_obj.internal_usage_cache.dual_cache = AsyncMock()
+    mock_proxy_logging_obj.internal_usage_cache.dual_cache.async_delete_cache = (
+        AsyncMock()
+    )
+    mock_proxy_logging_obj.post_call_failure_hook = AsyncMock(return_value=None)
+
+    import litellm.proxy.proxy_server as _proxy_server_mod
+
+    _attrs_to_set = {
+        "prisma_client": MagicMock(),
+        "user_api_key_cache": mock_cache,
+        "proxy_logging_obj": mock_proxy_logging_obj,
+        "master_key": master_key,
+        "general_settings": {},
+        "llm_model_list": [],
+        "llm_router": None,
+        "open_telemetry_logger": None,
+        "model_max_budget_limiter": MagicMock(),
+        "user_custom_auth": None,
+        "jwt_handler": None,
+        "litellm_proxy_admin_name": "admin",
+    }
+    _original_values = {
+        attr: getattr(_proxy_server_mod, attr, None) for attr in _attrs_to_set
+    }
+    try:
+        for attr, val in _attrs_to_set.items():
+            setattr(_proxy_server_mod, attr, val)
+
+        request = Request(scope={"type": "http"})
+        request._url = URL(url="/v1/messages")
+
+        result = await _user_api_key_auth_builder(
+            request=request,
+            api_key=_ANTHROPIC_OAUTH_BEARER,
+            azure_api_key_header="",
+            anthropic_api_key_header=master_key,
+            google_ai_studio_api_key_header=None,
+            azure_apim_header=None,
+            request_data={},
+        )
+
+        assert isinstance(result, UserAPIKeyAuth)
+        assert result.user_role == LitellmUserRoles.PROXY_ADMIN
         assert result.api_key == LITELLM_PROXY_MASTER_KEY_ALIAS
     finally:
         for attr, val in _original_values.items():

--- a/tests/test_litellm/proxy/test_litellm_pre_call_utils.py
+++ b/tests/test_litellm/proxy/test_litellm_pre_call_utils.py
@@ -6507,6 +6507,70 @@ async def test_add_litellm_data_to_request_redacts_oauth_header_from_logging_cop
 
 
 @pytest.mark.asyncio
+async def test_add_litellm_data_to_request_dual_headers_keeps_oauth_forwardable_and_virtual_key_private():
+    """Claude Code (Desktop 3P tab) sends `authorization: Bearer sk-ant-oat...`
+    plus the LiteLLM virtual key in `x-api-key`; proxy auth consumes `x-api-key`
+    (#29190). The OAuth token must stay scoped for Anthropic passthrough, and the
+    consumed virtual key must NOT be forwarded upstream even with
+    `forward_llm_provider_auth_headers` enabled."""
+    virtual_key = "sk-litellm-virtual-key-lit29190"
+    request_mock = _make_request_mock(
+        "/v1/messages",
+        {
+            "content-type": "application/json",
+            "anthropic-version": "2023-06-01",
+            "authorization": _OAUTH_TOKEN,
+            "x-api-key": virtual_key,
+        },
+    )
+
+    updated = await add_litellm_data_to_request(
+        data={"model": "anthropic-claude", "messages": [{"role": "user", "content": "hello"}]},
+        request=request_mock,
+        user_api_key_dict=UserAPIKeyAuth(api_key="hashed-key"),
+        proxy_config=MagicMock(),
+        general_settings={"forward_llm_provider_auth_headers": True},
+        version="test-version",
+    )
+
+    from litellm.litellm_core_utils.get_provider_specific_headers import (
+        ProviderSpecificHeaderUtils,
+    )
+
+    anthropic_headers = ProviderSpecificHeaderUtils.get_provider_specific_headers(
+        provider_specific_header=updated["provider_specific_header"],
+        custom_llm_provider="anthropic",
+    )
+    assert anthropic_headers["authorization"] == _OAUTH_TOKEN
+    assert virtual_key not in json.dumps(updated["provider_specific_header"], default=repr)
+
+
+@pytest.mark.asyncio
+async def test_add_litellm_data_to_request_oauth_authorization_without_x_api_key_stays_consumed():
+    """Without an `x-api-key`, the Authorization header (even OAuth-shaped) is
+    still the auth credential and is not forwarded — existing behavior."""
+    request_mock = _make_request_mock(
+        "/v1/messages",
+        {
+            "content-type": "application/json",
+            "anthropic-version": "2023-06-01",
+            "authorization": _OAUTH_TOKEN,
+        },
+    )
+
+    updated = await add_litellm_data_to_request(
+        data={"model": "anthropic-claude", "messages": [{"role": "user", "content": "hello"}]},
+        request=request_mock,
+        user_api_key_dict=UserAPIKeyAuth(api_key="hashed-key"),
+        proxy_config=MagicMock(),
+        general_settings={"forward_llm_provider_auth_headers": True},
+        version="test-version",
+    )
+
+    assert "sk-ant-oat01" not in json.dumps(updated.get("provider_specific_header"), default=repr)
+
+
+@pytest.mark.asyncio
 async def test_add_litellm_data_to_request_keeps_every_forwarded_credential_out_of_logging_copies():
     """Credentials kept for transport must not survive anywhere under proxy_server_request."""
     secrets = {


### PR DESCRIPTION
## TLDR

Problem this solves:

- Claude Code 3P tab in Claude Desktop gets a 401 from the LiteLLM proxy despite a valid key
- The client sends its Anthropic OAuth session token (`sk-ant-oat-...`) in `Authorization` alongside the LiteLLM virtual key in `x-api-key`
- Proxy auth gives `Authorization` unconditional precedence, looks the OAuth token up as a virtual key, and rejects the request

How it solves it:

- When the `Authorization` bearer is `sk-ant-oat*` and `x-api-key` is present, authenticate with `x-api-key`
- `sk-ant-oat*` is an upstream passthrough credential the codebase already recognizes (`is_anthropic_oauth_key`), never a LiteLLM key
- Requests with only `Authorization`, only `x-api-key`, or a regular bearer key are all unchanged

## User Flow

Before: a user pointing the Claude Code tab in Claude Desktop at a LiteLLM proxy cannot sign in, even though their key is valid

1. They sign into Claude Desktop with their Anthropic account, open the Claude Code tab, and configure a third-party provider with base URL `https://litellm-domain` and their LiteLLM key `sk-...`
2. The tab sends POST `https://litellm-domain/v1/messages` carrying their LiteLLM key in `x-api-key`, plus the desktop session's own token in `Authorization`
3. Back comes 401 `Unable to find token in cache or LiteLLM_VerificationTokenTable`, and the tab shows "Authentication failed. Sign in again to continue."
4. The same key works fine from the Claude Code CLI and the Cowork tab, which send only `x-api-key`

After: the same setup signs in and completes requests

1. They sign into Claude Desktop, open the Claude Code tab, and configure the same third-party provider with the same LiteLLM key
2. The tab sends the same POST `https://litellm-domain/v1/messages` with both headers, and now gets the model's response back with their key's spend tracked as usual
3. The Claude Code CLI and Cowork tab keep working exactly as before

## Relevant issues

Fixes #29190

Note to maintainers: #29190 was closed by the stale bot without a fix — please reopen it (or attach this PR to it) so the closure reflects reality.

Related but distinct: #24436 / #24454 / #24539 fixed the *outbound* OAuth-header collision (what LiteLLM forwards to Anthropic). This PR fixes the *inbound* side (which header proxy auth consumes), which failed before any upstream call was made. #24680 shares the surface error text but has an unrelated cause.

## Why this shape of fix

- `get_api_key()` in `litellm/proxy/auth/user_api_key_auth.py` is the single chokepoint that picks the auth header, so the change covers `/v1/messages`, `/v1/messages/count_tokens`, and the `/anthropic/*` routes at once
- The gate is deliberately narrow and deterministic: it engages only when the bearer is `sk-ant-oat*` (never a LiteLLM credential) AND a non-empty `x-api-key` is present. No lookup-failure fallback/retry logic was added, so no auth path is weakened — an invalid `x-api-key` still 401s, and an OAuth bearer without `x-api-key` fails exactly as today
- `add_litellm_data_to_request()` derives `authenticated_with_header` with the same precedence assumption, so it is mirrored there: the OAuth token stays forwardable to Anthropic (the behavior #24454/#24539 built), and the virtual key that was consumed for auth is *not* forwarded upstream when `forward_llm_provider_auth_headers` is enabled

## Changes

- `litellm/proxy/auth/user_api_key_auth.py`: in `get_api_key()`, prefer `x-api-key` when the `Authorization` bearer is an Anthropic OAuth token and `x-api-key` is non-empty
- `litellm/proxy/litellm_pre_call_utils.py`: mirror that rule when deriving `authenticated_with_header`
- `tests/test_litellm/proxy/auth/test_user_api_key_auth.py`: 6 new `get_api_key()` unit tests (dual-header OAuth case, regular-bearer precedence, single-header cases, empty `x-api-key`, `x-litellm-api-key` still wins) + 1 end-to-end `_user_api_key_auth_builder` test
- `tests/test_litellm/proxy/test_litellm_pre_call_utils.py`: 2 new tests (OAuth stays scoped for Anthropic passthrough and the consumed virtual key is not forwarded; Authorization-only behavior unchanged)

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally: `pytest tests/test_litellm/proxy/auth/test_user_api_key_auth.py tests/test_litellm/proxy/test_litellm_pre_call_utils.py` (the only failures are two pre-existing ones that fail identically on the merge base without this change)
- [x] My PR passes all required CI/CD checks (verified locally: `ruff check`, `ruff format --check` on changed files, `ruff check --config ruff-tests.toml`, and zero basedpyright delta vs base)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (5/5 received on the current tip)

## Screenshots / Proof of Fix

Fully end-to-end against a live proxy run from source with a real Postgres and real calls to `api.anthropic.com` — no mocks and no `pytest`. The upstream key in the config is deliberately invalid, so a request that passes proxy auth surfaces a *real Anthropic API* error instead of LiteLLM's own auth error; that transition is the proof, with zero spend.

Shared setup (identical for Before and After):

```yaml
# config.yaml
model_list:
  - model_name: claude-sonnet-4-5
    litellm_params:
      model: anthropic/claude-sonnet-4-5
      api_key: sk-ant-api03-not-a-real-upstream-key

router_settings:
  disable_cooldowns: true

general_settings:
  master_key: sk-1234
```

- Proxy started with `DATABASE_URL` pointing at a local Postgres, then a virtual key generated once: `curl -X POST http://127.0.0.1:4000/key/generate -H "Authorization: Bearer sk-1234" -d '{"key_alias":"claude-desktop-3p-proof","models":[]}'` → `sk-<REDACTED-VIRTUAL-KEY>`
- `OAUTH` below is a deliberately fake stand-in for the Claude Desktop session token: `Bearer sk-ant-oat01-fake-desktop-session-token-0123456789`
- Every case is the same request body against POST `/v1/messages` with `anthropic-version: 2023-06-01`: `{"model":"claude-sonnet-4-5","max_tokens":32,"messages":[{"role":"user","content":"ping"}]}`

### Before (9f9236e8d5, the PR's merge base on `litellm_internal_staging`)

#### case 1: x-api-key only (the shape Claude Code CLI / Cowork send)

1. `curl -X POST http://127.0.0.1:4010/v1/messages -H "x-api-key: sk-<REDACTED-VIRTUAL-KEY>" ...`
2. Proxy auth passes; the request reaches Anthropic, which rejects the config's fake upstream key:

```
HTTP 401
{"error":{"message":"litellm.AuthenticationError: AnthropicException - {\"type\":\"error\",\"error\":{\"type\":\"authentication_error\",\"message\":\"API key is invalid.\"},\"request_id\":null}. Received Model Group=claude-sonnet-4-5\nAvailable Model Group Fallbacks=None","type":null,"param":null,"code":"401"}}
```

#### case 2: Authorization (Anthropic OAuth token) + x-api-key (virtual key) — the Claude Code 3P tab shape

1. `curl -X POST http://127.0.0.1:4010/v1/messages -H "Authorization: $OAUTH" -H "x-api-key: sk-<REDACTED-VIRTUAL-KEY>" ...`
2. Proxy auth fails on the OAuth token — the exact error from the issue, despite the valid key in `x-api-key`:

```
HTTP 401
{"error":{"message":"Authentication Error, Invalid proxy server token passed. Received API Key = sk-...6789, Key Hash (Token) =54a967f1ee102eea489271653a09773093864dd40c33e64927d76e9ca6bb8eac. Unable to find token in cache or `LiteLLM_VerificationTokenTable`","type":"token_not_found_in_db","param":"key","code":"401"}}
```

#### case 3: Authorization (Anthropic OAuth token) only — control

1. `curl -X POST http://127.0.0.1:4010/v1/messages -H "Authorization: $OAUTH" ...`
2. No LiteLLM key anywhere — correctly rejected:

```
HTTP 401
{"error":{"message":"Authentication Error, Invalid proxy server token passed. Received API Key = sk-...6789, Key Hash (Token) =54a967f1ee102eea489271653a09773093864dd40c33e64927d76e9ca6bb8eac. Unable to find token in cache or `LiteLLM_VerificationTokenTable`","type":"token_not_found_in_db","param":"key","code":"401"}}
```

### After (821628ac7e, this PR's tip)

#### case 1: x-api-key only (the shape Claude Code CLI / Cowork send)

1. Same request as Before
2. Unchanged — proxy auth passes, upstream rejects the fake configured key:

```
HTTP 401
{"error":{"message":"litellm.AuthenticationError: AnthropicException - {\"type\":\"error\",\"error\":{\"type\":\"authentication_error\",\"message\":\"API key is invalid.\"},\"request_id\":null}. Received Model Group=claude-sonnet-4-5\nAvailable Model Group Fallbacks=None","type":null,"param":null,"code":"401"}}
```

#### case 2: Authorization (Anthropic OAuth token) + x-api-key (virtual key) — the Claude Code 3P tab shape

1. Same request as Before
2. Proxy auth now passes via `x-api-key`, and the request reaches Anthropic — which evaluates the *forwarded OAuth token* (the existing passthrough behavior, now reachable):

```
HTTP 401
{"error":{"message":"litellm.AuthenticationError: AnthropicException - {\"type\":\"error\",\"error\":{\"type\":\"authentication_error\",\"message\":\"OAuth access token is invalid.\"},\"request_id\":null}. Received Model Group=claude-sonnet-4-5\nAvailable Model Group Fallbacks=None","type":null,"param":null,"code":"401"}}
```

3. With a real desktop session token this request completes and is billed to the user's Claude subscription; with a valid configured upstream key and no client OAuth token it completes on the operator's key — either way the LiteLLM-side 401 from the issue is gone

#### case 3: Authorization (Anthropic OAuth token) only — control

1. Same request as Before
2. Unchanged — still correctly rejected:

```
HTTP 401
{"error":{"message":"Authentication Error, Invalid proxy server token passed. Received API Key = sk-...6789, Key Hash (Token) =54a967f1ee102eea489271653a09773093864dd40c33e64927d76e9ca6bb8eac. Unable to find token in cache or `LiteLLM_VerificationTokenTable`","type":"token_not_found_in_db","param":"key","code":"401"}}
```

## Type

🐛 Bug Fix

## Caveats (if any)

### Medium

- When the client sends an OAuth token, the upstream call uses it, not the operator's configured key
  - This is the pre-existing outbound passthrough design from #24454/#24539, previously unreachable in this header combination because auth 401'd first
- Proxy operators may have shipped workarounds (e.g., stripping `Authorization` at a fronting LB); those keep working but become unnecessary

### Low

- A virtual key whose value literally starts with `sk-ant-oat`, sent together with an `x-api-key` header, would now authenticate via `x-api-key`; proxy-generated keys never have that prefix
- The reproduction uses a fake OAuth token; #29190 notes the exact Claude Desktop header combination is inferred from symptoms, not from a client-side capture — but the fixed precedence bug is real and reproducible either way, and harmless if a client never sends that combination

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015FBgVxUsEwirANwuCfJfLG
