### PR TITLE
fix(proxy): derive generic passthrough logging model from target URL path

### DIFF
--- a/litellm/proxy/pass_through_endpoints/pass_through_endpoints.py
+++ b/litellm/proxy/pass_through_endpoints/pass_through_endpoints.py
@@ -804,6 +804,31 @@ from litellm.passthrough.timeout_utils import (
 )
 
 
+def _derive_passthrough_model_from_target_url(target_url: str) -> str | None:
+    """Derive a stable model identifier for logging from the pass-through target URL.
+
+    Generic pass-through upstreams (fal.ai, Modal, ComfyUI-style workflow and
+    image-gen APIs) often carry the model identity in the URL path rather than a
+    ``model`` field in the request body. When the body has no model, fall back
+    to the target URL path (``https://fal.run/fal-ai/flux/schnell`` ->
+    ``fal-ai/flux/schnell``; host when there is no path) so Langfuse / Spend
+    Logs entries stay distinguishable per upstream endpoint instead of all
+    reading ``unknown``. Deterministic string handling only - never a network
+    call. Query params and fragments are dropped (they carry per-request noise,
+    e.g. API keys or cursors, not model identity).
+    """
+    try:
+        parsed: Final = urlparse(target_url)
+        path: Final = (parsed.path or "").strip("/")
+        if path:
+            return path
+        # urlparse only raises lazily (e.g. invalid ports/IPv6 hosts surface on
+        # attribute access), so ``.hostname`` stays inside the try block.
+        return parsed.hostname or None
+    except ValueError:
+        return None
+
+
 async def pass_through_request(
     request: Request,
     target: str,
@@ -927,8 +952,18 @@ async def pass_through_request(
 
         ## LOGGING OBJECT ## - initialize before pre_call_hook so guardrails can access it
         # Surface the requested model (when the body carries one) so logging/spans
-        # read e.g. ``chat gpt-4o`` instead of ``chat unknown``.
-        passthrough_model: Final = (_parsed_body.get("model") if isinstance(_parsed_body, dict) else None) or "unknown"
+        # read e.g. ``chat gpt-4o`` instead of ``chat unknown``. Generic bodies
+        # without a ``model`` field (fal.ai, Modal, ComfyUI-style upstreams
+        # identify the model in the URL path) fall back to the target path so
+        # Langfuse / Spend Logs entries stay distinguishable per endpoint.
+        # Provider-specific routes keep the ``unknown`` sentinel: their logging
+        # handlers (e.g. Anthropic) compare against it to decide whether to
+        # recover the model from response chunks / litellm_params.
+        passthrough_model: Final = (
+            (_parsed_body.get("model") if isinstance(_parsed_body, dict) else None)
+            or (_derive_passthrough_model_from_target_url(str(url)) if endpoint_type == EndpointType.GENERIC else None)
+            or "unknown"
+        )
         start_time: Final = datetime.now()
         logging_obj = Logging(
             model=passthrough_model,
@@ -2054,9 +2089,12 @@ async def websocket_passthrough_request(
             ]:
                 upstream_headers[header_name] = header_value
 
-    # Initialize logging object similar to HTTP passthrough
+    # Initialize logging object similar to HTTP passthrough. WebSocket frames
+    # carry no ``model`` field up front, so fall back to the target URL path
+    # (Vertex AI Live setup frames overwrite this once a model is extracted).
+    websocket_passthrough_model: Final = _derive_passthrough_model_from_target_url(target) or "unknown"
     logging_obj: Final = Logging(
-        model="unknown",
+        model=websocket_passthrough_model,
         messages=[{"role": "user", "content": "WebSocket connection"}],
         stream=True,  # WebSockets are inherently streaming
         call_type="pass_through_endpoint",
@@ -2102,7 +2140,7 @@ async def websocket_passthrough_request(
 
     # Update logging environment variables
     logging_obj.update_environment_variables(
-        model="unknown",
+        model=websocket_passthrough_model,
         user="unknown",
         optional_params={},
         litellm_params=dict(kwargs.get("litellm_params", {})),

--- a/litellm/proxy/pass_through_endpoints/pass_through_endpoints.py
+++ b/litellm/proxy/pass_through_endpoints/pass_through_endpoints.py
@@ -820,13 +820,12 @@ def _derive_passthrough_model_from_target_url(target_url: str) -> str | None:
     try:
         parsed: Final = urlparse(target_url)
         path: Final = (parsed.path or "").strip("/")
-        if path:
-            return path
         # urlparse only raises lazily (e.g. invalid ports/IPv6 hosts surface on
         # attribute access), so ``.hostname`` stays inside the try block.
-        return parsed.hostname or None
+        hostname: Final = parsed.hostname
     except ValueError:
         return None
+    return path or hostname or None
 
 
 async def pass_through_request(

--- a/tests/test_litellm/proxy/pass_through_endpoints/test_pass_through_endpoints.py
+++ b/tests/test_litellm/proxy/pass_through_endpoints/test_pass_through_endpoints.py
@@ -20,6 +20,7 @@ from litellm.proxy.pass_through_endpoints.pass_through_endpoints import (
     HttpPassThroughEndpointHelpers,
     InitPassThroughEndpointHelpers,
     LITELLM_PASS_THROUGH_CUSTOM_BODY_STATE_KEY,
+    _derive_passthrough_model_from_target_url,
     _registered_pass_through_routes,
     create_pass_through_route,
     initialize_pass_through_endpoints,
@@ -4335,6 +4336,199 @@ async def test_pass_through_request_upstream_error_body_stays_buffered():
     finally:
         cleanup()
         await fake_client.aclose()
+
+
+@pytest.mark.parametrize(
+    "target_url, expected",
+    [
+        ("https://fal.run/fal-ai/flux/schnell", "fal-ai/flux/schnell"),
+        # query params / fragments are per-request noise, not model identity
+        ("https://fal.run/fal-ai/nano-banana-2/edit?key=abc#frag", "fal-ai/nano-banana-2/edit"),
+        ("https://fal.run/fal-ai/flux/schnell/", "fal-ai/flux/schnell"),
+        # no path -> host keeps the record readable and distinguishable
+        ("https://fal.run", "fal.run"),
+        ("https://fal.run/", "fal.run"),
+        ("", None),
+        # urlparse raises lazily on invalid netlocs; helper must swallow it
+        ("http://[::1:80/bad", None),
+    ],
+)
+def test_derive_passthrough_model_from_target_url(target_url, expected):
+    """The URL -> model derivation is deterministic: target path, then host,
+    then None (caller falls back to "unknown")."""
+    assert _derive_passthrough_model_from_target_url(target_url) == expected
+
+
+def _passthrough_model_client_request(body: bytes) -> MagicMock:
+    mock_request = MagicMock(spec=Request)
+    mock_request.method = "POST"
+    mock_request.url = "http://localhost:4000/my-fal/fal-ai/flux/schnell"
+    mock_request.body = AsyncMock(return_value=body)
+    mock_request.headers = Headers({})
+    mock_request.query_params = QueryParams({})
+    return mock_request
+
+
+@pytest.mark.asyncio
+async def test_pass_through_request_body_without_model_logs_target_path_as_model():
+    """
+    Regression (issue #30932): a generic pass-through request whose body has no
+    ``model`` field (fal.ai, Modal, ComfyUI-style upstreams carry the model in
+    the URL path) used to log model="unknown" to Langfuse/SpendLogs, making all
+    endpoints of one pass-through target indistinguishable. The logging object
+    must instead surface the target URL path as the model identifier.
+    """
+    from litellm.proxy._types import UserAPIKeyAuth
+
+    request_body = {"prompt": "test", "num_images": 1}
+    upstream_stream = _RecordingUpstreamByteStream((b'{"images": []}',))
+    fake_client, cleanup = _inject_fake_passthrough_client(
+        _FakeUpstreamTransport(
+            status_code=200,
+            headers={"content-type": "application/json"},
+            stream=upstream_stream,
+        ),
+        timeout=314.0,
+    )
+    try:
+        with ExitStack() as stack:
+            _, mock_success_handler = _enter_relay_logging_mocks(stack, dict(request_body))
+
+            await pass_through_request(
+                request=_passthrough_model_client_request(json.dumps(request_body).encode()),
+                target="https://fal.run/fal-ai/flux/schnell",
+                custom_headers={},
+                user_api_key_dict=UserAPIKeyAuth(api_key="sk-relay-test"),
+                timeout=314.0,
+            )
+
+            mock_success_handler.assert_called_once()
+            logging_obj = mock_success_handler.call_args.kwargs["logging_obj"]
+            assert logging_obj.model == "fal-ai/flux/schnell"
+            assert logging_obj.model_call_details["model"] == "fal-ai/flux/schnell"
+    finally:
+        cleanup()
+        await fake_client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_pass_through_request_body_model_wins_over_target_path():
+    """A body that does carry a ``model`` field keeps using it - the URL-derived
+    fallback only applies when the body has no model."""
+    from litellm.proxy._types import UserAPIKeyAuth
+
+    request_body = {"model": "flux-schnell-v2", "prompt": "test"}
+    upstream_stream = _RecordingUpstreamByteStream((b'{"images": []}',))
+    fake_client, cleanup = _inject_fake_passthrough_client(
+        _FakeUpstreamTransport(
+            status_code=200,
+            headers={"content-type": "application/json"},
+            stream=upstream_stream,
+        ),
+        timeout=315.0,
+    )
+    try:
+        with ExitStack() as stack:
+            _, mock_success_handler = _enter_relay_logging_mocks(stack, dict(request_body))
+
+            await pass_through_request(
+                request=_passthrough_model_client_request(json.dumps(request_body).encode()),
+                target="https://fal.run/fal-ai/flux/schnell",
+                custom_headers={},
+                user_api_key_dict=UserAPIKeyAuth(api_key="sk-relay-test"),
+                timeout=315.0,
+            )
+
+            mock_success_handler.assert_called_once()
+            logging_obj = mock_success_handler.call_args.kwargs["logging_obj"]
+            assert logging_obj.model == "flux-schnell-v2"
+            assert logging_obj.model_call_details["model"] == "flux-schnell-v2"
+    finally:
+        cleanup()
+        await fake_client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_pass_through_request_provider_route_keeps_unknown_sentinel():
+    """Provider-specific routes (Anthropic/OpenAI/Vertex) must keep the
+    ``unknown`` sentinel when the body has no model: their logging handlers
+    compare against it to decide whether to recover the model from response
+    chunks / litellm_params, so the URL fallback is generic-endpoints only."""
+    from litellm.proxy._types import UserAPIKeyAuth
+
+    upstream_stream = _RecordingUpstreamByteStream((b'{"type": "message"}',))
+    fake_client, cleanup = _inject_fake_passthrough_client(
+        _FakeUpstreamTransport(
+            status_code=200,
+            headers={"content-type": "application/json"},
+            stream=upstream_stream,
+        ),
+        timeout=316.0,
+    )
+    try:
+        with ExitStack() as stack:
+            _, mock_success_handler = _enter_relay_logging_mocks(stack, {"max_tokens": 10})
+
+            await pass_through_request(
+                request=_passthrough_model_client_request(b'{"max_tokens": 10}'),
+                target="https://api.anthropic.com/v1/messages",
+                custom_headers={},
+                user_api_key_dict=UserAPIKeyAuth(api_key="sk-relay-test"),
+                timeout=316.0,
+            )
+
+            mock_success_handler.assert_called_once()
+            logging_obj = mock_success_handler.call_args.kwargs["logging_obj"]
+            assert logging_obj.model_call_details["model"] == "unknown"
+    finally:
+        cleanup()
+        await fake_client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_pass_through_request_streaming_body_without_model_logs_target_path_as_model():
+    """Streaming requests share the same logging object, so a body without a
+    ``model`` field must surface the same URL-derived identifier as the
+    non-streaming path instead of "unknown"."""
+    with patch("litellm.proxy.proxy_server.proxy_logging_obj") as mock_proxy_logging:
+        with patch(
+            "litellm.proxy.pass_through_endpoints.pass_through_endpoints.get_async_httpx_client"
+        ) as mock_get_client:
+            with patch(
+                "litellm.proxy.pass_through_endpoints.pass_through_endpoints.PassThroughStreamingHandler.chunk_processor"
+            ) as mock_chunk_processor:
+                mock_proxy_logging.pre_call_hook = AsyncMock(return_value={"prompt": "test", "stream": True})
+                mock_proxy_logging.post_call_failure_hook = AsyncMock()
+                mock_proxy_logging.post_call_response_headers_hook = AsyncMock(return_value=None)
+
+                upstream_response = MagicMock()
+                upstream_response.status_code = 200
+                upstream_response.headers = {}
+                upstream_response.raise_for_status = MagicMock()
+
+                async_client = MagicMock()
+                async_client.build_request = MagicMock(return_value=MagicMock())
+                async_client.send = AsyncMock(return_value=upstream_response)
+                mock_get_client.return_value = MagicMock(client=async_client)
+
+                async def _empty_chunks(*args, **kwargs):
+                    return
+                    yield  # pragma: no cover
+
+                mock_chunk_processor.return_value = _empty_chunks()
+
+                await pass_through_request(
+                    request=_passthrough_model_client_request(b'{"prompt": "test", "stream": true}'),
+                    target="https://fal.run/fal-ai/flux/schnell",
+                    custom_headers={},
+                    user_api_key_dict=MagicMock(),
+                    stream=True,
+                )
+
+                mock_chunk_processor.assert_called_once()
+                logging_obj = mock_chunk_processor.call_args.kwargs["litellm_logging_obj"]
+                assert logging_obj.model == "fal-ai/flux/schnell"
+                assert logging_obj.model_call_details["model"] == "fal-ai/flux/schnell"
 
 
 _PARTIAL_RELAY_WARNING_MARKER = "ended before upstream body was fully relayed"

--- a/tests/test_litellm/proxy/pass_through_endpoints/test_pass_through_endpoints.py
+++ b/tests/test_litellm/proxy/pass_through_endpoints/test_pass_through_endpoints.py
@@ -4490,45 +4490,53 @@ async def test_pass_through_request_streaming_body_without_model_logs_target_pat
     """Streaming requests share the same logging object, so a body without a
     ``model`` field must surface the same URL-derived identifier as the
     non-streaming path instead of "unknown"."""
-    with patch("litellm.proxy.proxy_server.proxy_logging_obj") as mock_proxy_logging:
-        with patch(
-            "litellm.proxy.pass_through_endpoints.pass_through_endpoints.get_async_httpx_client"
-        ) as mock_get_client:
-            with patch(
-                "litellm.proxy.pass_through_endpoints.pass_through_endpoints.PassThroughStreamingHandler.chunk_processor"
-            ) as mock_chunk_processor:
-                mock_proxy_logging.pre_call_hook = AsyncMock(return_value={"prompt": "test", "stream": True})
-                mock_proxy_logging.post_call_failure_hook = AsyncMock()
-                mock_proxy_logging.post_call_response_headers_hook = AsyncMock(return_value=None)
+    from litellm.proxy._types import UserAPIKeyAuth
 
-                upstream_response = MagicMock()
-                upstream_response.status_code = 200
-                upstream_response.headers = {}
-                upstream_response.raise_for_status = MagicMock()
-
-                async_client = MagicMock()
-                async_client.build_request = MagicMock(return_value=MagicMock())
-                async_client.send = AsyncMock(return_value=upstream_response)
-                mock_get_client.return_value = MagicMock(client=async_client)
-
-                async def _empty_chunks(*args, **kwargs):
-                    return
-                    yield  # pragma: no cover
-
-                mock_chunk_processor.return_value = _empty_chunks()
-
-                await pass_through_request(
-                    request=_passthrough_model_client_request(b'{"prompt": "test", "stream": true}'),
-                    target="https://fal.run/fal-ai/flux/schnell",
-                    custom_headers={},
-                    user_api_key_dict=MagicMock(),
-                    stream=True,
+    upstream_stream = _RecordingUpstreamByteStream((MESSAGE_START_SSE_FRAME,))
+    fake_client, cleanup = _inject_fake_passthrough_client(
+        _FakeUpstreamTransport(
+            status_code=200,
+            headers={"content-type": "text/event-stream"},
+            stream=upstream_stream,
+        ),
+        timeout=317.0,
+    )
+    try:
+        with ExitStack() as stack:
+            mock_proxy_logging = stack.enter_context(
+                patch("litellm.proxy.proxy_server.proxy_logging_obj")  # test-quality-ok: read at call time
+            )
+            mock_proxy_logging.pre_call_hook = AsyncMock(return_value={"prompt": "test", "stream": True})
+            mock_proxy_logging.post_call_failure_hook = AsyncMock()
+            mock_proxy_logging.post_call_response_headers_hook = AsyncMock(return_value=None)
+            mock_chunk_processor = stack.enter_context(
+                patch(  # test-quality-ok: stream-boundary capture point for the asserted logging object; no seam exists
+                    "litellm.proxy.pass_through_endpoints.pass_through_endpoints.PassThroughStreamingHandler.chunk_processor"
                 )
+            )
 
-                mock_chunk_processor.assert_called_once()
-                logging_obj = mock_chunk_processor.call_args.kwargs["litellm_logging_obj"]
-                assert logging_obj.model == "fal-ai/flux/schnell"
-                assert logging_obj.model_call_details["model"] == "fal-ai/flux/schnell"
+            async def _empty_chunks(*args, **kwargs):
+                return
+                yield  # pragma: no cover
+
+            mock_chunk_processor.return_value = _empty_chunks()
+
+            await pass_through_request(
+                request=_passthrough_model_client_request(b'{"prompt": "test", "stream": true}'),
+                target="https://fal.run/fal-ai/flux/schnell",
+                custom_headers={},
+                user_api_key_dict=UserAPIKeyAuth(api_key="sk-relay-test"),
+                stream=True,
+                timeout=317.0,
+            )
+
+            mock_chunk_processor.assert_called_once()
+            logging_obj = mock_chunk_processor.call_args.kwargs["litellm_logging_obj"]
+            assert logging_obj.model == "fal-ai/flux/schnell"
+            assert logging_obj.model_call_details["model"] == "fal-ai/flux/schnell"
+    finally:
+        cleanup()
+        await fake_client.aclose()
 
 
 _PARTIAL_RELAY_WARNING_MARKER = "ended before upstream body was fully relayed"


### PR DESCRIPTION
## TLDR

Problem this solves:

- Generic pass-through requests all log `model="unknown"` when body has no model
- fal.ai / Modal / ComfyUI-style upstreams carry model identity in the URL path
- Langfuse traces and SpendLogs rows become indistinguishable per endpoint

How it solves it:

- Body has no model: log the target URL path (e.g. `fal-ai/flux/schnell`)
- Body model still wins; provider routes (Anthropic/OpenAI/Vertex) keep the `unknown` sentinel
- WebSocket passthrough initializer gets the same URL-derived fallback

## User Flow

Before: an operator proxying fal.ai cannot tell their image models apart in Langfuse

1. Operator configures `pass_through_endpoints` with `path: /my-fal`, `target: https://fal.run`, `include_subpath: true`, and the `langfuse` callback
2. A user sends POST http://localhost:4000/my-fal/fal-ai/flux/schnell with `{"prompt": "test", "num_images": 1}` and gets 200 back
3. Another user sends POST http://localhost:4000/my-fal/fal-ai/nano-banana-2/edit with `{"prompt": "test"}` and gets 200 back
4. In Langfuse both traces show `observation.model = "unknown"` and nothing else identifies which fal endpoint was called, so spend cannot be grouped per model

After: each endpoint shows up under its own model name

1. Operator configures the same `pass_through_endpoints` entry and the `langfuse` callback
2. A user sends POST http://localhost:4000/my-fal/fal-ai/flux/schnell with `{"prompt": "test", "num_images": 1}` and gets 200 back
3. Another user sends POST http://localhost:4000/my-fal/fal-ai/nano-banana-2/edit with `{"prompt": "test"}` and gets 200 back
4. In Langfuse the first trace shows `observation.model = "fal-ai/flux/schnell"` and the second `"fal-ai/nano-banana-2/edit"`, so the operator can filter, group, and cost-attribute per upstream model
5. A request whose body does carry `"model": "flux-schnell-v2"` keeps logging that body model, unchanged

## Relevant issues

Fixes #30932

Related prior art: #30970 attempted the same fix but is a stale draft its author cannot mark ready, and it applies the URL fallback on every route: provider-specific handlers (e.g. Anthropic streaming) compare the logged model against the `"unknown"` sentinel to recover the real model from response chunks / `litellm_params`, so an ungated fallback silently breaks that recovery. This PR gates the fallback to generic endpoints and pins the sentinel behavior with a test.

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Shared setup: a real local upstream standing in for fal.run (`python upstream.py`, an HTTP server on 127.0.0.1:9412 answering every request with 200 `{"ok": true, "endpoint": "<path>"}`), and the proxy started with this config plus a success callback (`ModelPrinter(CustomLogger)`) that prints the model every pass-through request is handed to logging callbacks with:

```yaml
general_settings:
  master_key: sk-1234
  pass_through_endpoints:
    - path: "/my-fal"
      target: "http://127.0.0.1:9412"
      include_subpath: true

litellm_settings:
  callbacks: custom_callbacks.proxy_handler_instance
```

```python
class ModelPrinter(CustomLogger):
    async def async_log_success_event(self, kwargs, response_obj, start_time, end_time):
        slo = kwargs.get("standard_logging_object") or {}
        print(f"PROOF call_type={kwargs.get('call_type')} kwargs_model={kwargs.get('model')!r} slo_model={slo.get('model')!r}", flush=True)
```

### Before (a73e77079818a74d8bb54db591766a71de727301)

#### body without model, two different endpoints

1. `curl -s -X POST http://127.0.0.1:4010/my-fal/fal-ai/flux/schnell -H 'Authorization: Bearer sk-1234' -H 'content-type: application/json' -d '{"prompt": "test", "num_images": 1}'` -> `{"ok": true, "endpoint": "/fal-ai/flux/schnell"}` (HTTP 200)
2. `curl -s -X POST http://127.0.0.1:4010/my-fal/fal-ai/nano-banana-2/edit -H 'Authorization: Bearer sk-1234' -H 'content-type: application/json' -d '{"prompt": "test"}'` -> `{"ok": true, "endpoint": "/fal-ai/nano-banana-2/edit"}` (HTTP 200)
3. Proxy log shows both requests logged identically, indistinguishable:

```
PROOF call_type=pass_through_endpoint kwargs_model='unknown' slo_model='unknown'
PROOF call_type=pass_through_endpoint kwargs_model='unknown' slo_model='unknown'
```

#### body with model

1. `curl -s -X POST http://127.0.0.1:4010/my-fal/fal-ai/flux/schnell -H 'Authorization: Bearer sk-1234' -H 'content-type: application/json' -d '{"model": "flux-schnell-v2", "prompt": "test"}'` -> `{"ok": true, "endpoint": "/fal-ai/flux/schnell"}` (HTTP 200)
2. Proxy log:

```
PROOF call_type=pass_through_endpoint kwargs_model='flux-schnell-v2' slo_model='flux-schnell-v2'
```

### After (c7380e86b969ef1a1e2568ed901c92a3c7e40712)

#### body without model, two different endpoints

1. `curl -s -X POST http://127.0.0.1:4013/my-fal/fal-ai/flux/schnell -H 'Authorization: Bearer sk-1234' -H 'content-type: application/json' -d '{"prompt": "test", "num_images": 1}'` -> `{"ok": true, "endpoint": "/fal-ai/flux/schnell"}` (HTTP 200)
2. `curl -s -X POST http://127.0.0.1:4013/my-fal/fal-ai/nano-banana-2/edit -H 'Authorization: Bearer sk-1234' -H 'content-type: application/json' -d '{"prompt": "test"}'` -> `{"ok": true, "endpoint": "/fal-ai/nano-banana-2/edit"}` (HTTP 200)
3. Proxy log now identifies each endpoint:

```
PROOF call_type=pass_through_endpoint kwargs_model='fal-ai/flux/schnell' slo_model='fal-ai/flux/schnell'
PROOF call_type=pass_through_endpoint kwargs_model='fal-ai/nano-banana-2/edit' slo_model='fal-ai/nano-banana-2/edit'
```

#### body with model

1. `curl -s -X POST http://127.0.0.1:4013/my-fal/fal-ai/flux/schnell -H 'Authorization: Bearer sk-1234' -H 'content-type: application/json' -d '{"model": "flux-schnell-v2", "prompt": "test"}'` -> `{"ok": true, "endpoint": "/fal-ai/flux/schnell"}` (HTTP 200)
2. Proxy log (unchanged behavior):

```
PROOF call_type=pass_through_endpoint kwargs_model='flux-schnell-v2' slo_model='flux-schnell-v2'
```

Local test runs at the After commit:

- `pytest tests/test_litellm/proxy/pass_through_endpoints/` -> 685 passed
- `ruff check` / `ruff format --check` on both touched files -> clean (pre-existing findings on the test file are unchanged)

## Type

🐛 Bug Fix

## Caveats (if any)

### Low

- `osv-scan` fails on every PR run started after ~2026-08-31 20:00 UTC: a new mlflow 3.15.0 advisory (GHSA-h7x2-h6g9-p789, no fixed release) in `uv.lock`; unrelated to this PR (no dependency changes; runs at 19:55 passed, 20:14 failed repo-wide)

- Generic model-less requests now log per-path values instead of one shared `unknown`
  - dashboards or alerts keyed on the literal `unknown` see new names
  - per-model rate-limit buckets for such requests split per target path
- WebSocket passthrough logs the target path too; Vertex AI Live setup-frame extraction still overwrites it

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
