### PR TITLE
fix(pass_through): keep upstream-reported cost and tokens on non-streaming responses

### DIFF
--- a/litellm/proxy/pass_through_endpoints/llm_provider_handlers/anthropic_passthrough_logging_handler.py
+++ b/litellm/proxy/pass_through_endpoints/llm_provider_handlers/anthropic_passthrough_logging_handler.py
@@ -28,6 +28,9 @@ from litellm.proxy.pass_through_endpoints.llm_provider_handlers.batch_attributio
     optional_str,
     request_tags_from_metadata,
 )
+from litellm.proxy.pass_through_endpoints.upstream_usage_headers import (
+    get_upstream_reported_usage,
+)
 from litellm.types.passthrough_endpoints.pass_through_endpoints import (
     PassthroughStandardLoggingPayload,
 )
@@ -37,6 +40,7 @@ from litellm.types.utils import (
     Message,
     ModelResponse,
     TextCompletionResponse,
+    Usage,
 )
 
 if TYPE_CHECKING:
@@ -278,8 +282,21 @@ class AnthropicPassthroughLoggingHandler:
                 litellm_params=(logging_obj.litellm_params if hasattr(logging_obj, "litellm_params") else None)
             )
 
+            # An upstream that reported its own totals via the x-litellm-*
+            # response headers owns the whole request's cost and token count
+            # (see upstream_usage_headers.py); never overwrite them with a
+            # recompute from the response body. Mirrors the precedence
+            # _set_cost_per_request and the streaming path already apply.
+            upstream_usage: Final = get_upstream_reported_usage(logging_obj)
+            if upstream_usage is not None and upstream_usage.total_tokens is not None:
+                setattr(  # noqa: B010  # ModelResponse does not declare `usage` as a typed field
+                    litellm_model_response, "usage", Usage(total_tokens=upstream_usage.total_tokens)
+                )
+
             response_cost: Final = (
-                0.0
+                upstream_usage.billable_response_cost
+                if upstream_usage is not None
+                else 0.0
                 if logging_obj.model_call_details.get("cache_hit") is True
                 else litellm.completion_cost(
                     completion_response=litellm_model_response,

--- a/litellm/proxy/pass_through_endpoints/upstream_usage_headers.py
+++ b/litellm/proxy/pass_through_endpoints/upstream_usage_headers.py
@@ -36,6 +36,15 @@ class UpstreamReportedUsage:
     response_cost: float | None
     total_tokens: int | None
 
+    @property
+    def billable_response_cost(self) -> float:
+        """The reported cost, with an unusable or missing value billed as 0.
+
+        A target that speaks this contract owns the cost for the request, so a
+        header we could not parse means zero, never someone else's estimate.
+        """
+        return self.response_cost if self.response_cost is not None else 0.0
+
 
 def _parse_response_cost(raw_value: str | None) -> float | None:
     if raw_value is None:
@@ -127,6 +136,14 @@ def apply_upstream_reported_usage(
     return reported
 
 
+def get_upstream_reported_usage(logging_obj: LiteLLMLoggingObj) -> UpstreamReportedUsage | None:
+    """The totals the upstream reported on this request's response, if any."""
+    reported: Final = logging_obj.model_call_details.get(UPSTREAM_REPORTED_USAGE_KEY)
+    if isinstance(reported, UpstreamReportedUsage):
+        return reported
+    return None
+
+
 def has_upstream_reported_usage(logging_obj: LiteLLMLoggingObj) -> bool:
     """Whether the upstream spoke this contract on the request's response.
 
@@ -134,4 +151,4 @@ def has_upstream_reported_usage(logging_obj: LiteLLMLoggingObj) -> bool:
     own totals owns the cost for the request, and a header we could not parse
     means zero, never a fallback to someone else's estimate.
     """
-    return isinstance(logging_obj.model_call_details.get(UPSTREAM_REPORTED_USAGE_KEY), UpstreamReportedUsage)
+    return get_upstream_reported_usage(logging_obj) is not None

--- a/tests/test_litellm/proxy/pass_through_endpoints/llm_provider_handlers/test_anthropic_passthrough_logging_handler.py
+++ b/tests/test_litellm/proxy/pass_through_endpoints/llm_provider_handlers/test_anthropic_passthrough_logging_handler.py
@@ -4,6 +4,7 @@ from datetime import datetime
 from typing import Any, Dict, List
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import httpx
 import pytest
 
 
@@ -11,6 +12,10 @@ from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLogging
 from litellm.proxy.pass_through_endpoints.llm_provider_handlers.anthropic_passthrough_logging_handler import (
     AnthropicPassthroughLoggingHandler,
 )
+from litellm.proxy.pass_through_endpoints.upstream_usage_headers import (
+    apply_upstream_reported_usage,
+)
+from litellm.types.utils import Choices, Message, ModelResponse, Usage
 
 
 async def _drain_tasks():
@@ -2441,3 +2446,85 @@ class TestAnthropicPassthroughFastMode:
 
         assert served_standard.usage.speed == "standard"
         assert self._cost(served_standard) == pytest.approx(self._cost(standard))
+
+
+class TestUpstreamReportedUsageWinsOverBodyRecompute:
+    """A config pass-through whose path contains /messages is logged by this
+    handler even when the target is not Anthropic. When that target reported
+    its own totals via the x-litellm-response-cost / x-litellm-total-tokens
+    response headers, the non-streaming payload builder must keep them instead
+    of recomputing cost and tokens from the response body, matching the
+    precedence the streaming path already applies."""
+
+    def _logging_obj_with_reported_usage(self, headers: dict) -> LiteLLMLoggingObj:
+        logging_obj = LiteLLMLoggingObj(
+            model="my-router-alias",
+            messages=[],
+            stream=False,
+            call_type="pass_through_endpoint",
+            start_time=datetime.now(),
+            litellm_call_id="upstream-usage-call-id",
+            function_id="upstream-usage",
+        )
+        apply_upstream_reported_usage(logging_obj=logging_obj, headers=httpx.Headers(headers))
+        return logging_obj
+
+    def _priced_body_response(self) -> ModelResponse:
+        return ModelResponse(
+            id="msg_repro",
+            choices=[
+                Choices(
+                    finish_reason="stop",
+                    index=0,
+                    message=Message(content="pong", role="assistant"),
+                )
+            ],
+            created=1234567890,
+            model="gpt-4o",
+            usage={"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15},
+        )
+
+    def _create_payload(self, logging_obj: LiteLLMLoggingObj, response: ModelResponse) -> dict:
+        return AnthropicPassthroughLoggingHandler._create_anthropic_response_logging_payload(
+            litellm_model_response=response,
+            model="gpt-4o",
+            kwargs={},
+            start_time=datetime.now(),
+            end_time=datetime.now(),
+            logging_obj=logging_obj,
+        )
+
+    def test_non_streaming_keeps_upstream_reported_cost_and_tokens(self):
+        logging_obj = self._logging_obj_with_reported_usage(
+            {"x-litellm-response-cost": "0.777777", "x-litellm-total-tokens": "4242"}
+        )
+        response = self._priced_body_response()
+
+        kwargs = self._create_payload(logging_obj, response)
+
+        assert kwargs["response_cost"] == 0.777777
+        assert logging_obj.model_call_details["response_cost"] == 0.777777
+        assert response.usage.total_tokens == 4242
+        assert logging_obj.model_call_details["combined_usage_object"] == Usage(total_tokens=4242)
+
+    def test_non_streaming_unusable_reported_cost_records_zero_not_body_estimate(self):
+        logging_obj = self._logging_obj_with_reported_usage(
+            {"x-litellm-response-cost": "not-a-number", "x-litellm-total-tokens": "4242"}
+        )
+        response = self._priced_body_response()
+
+        kwargs = self._create_payload(logging_obj, response)
+
+        assert kwargs["response_cost"] == 0.0
+        assert logging_obj.model_call_details["response_cost"] == 0.0
+        assert response.usage.total_tokens == 4242
+
+    def test_non_streaming_without_reported_usage_still_prices_from_body(self):
+        logging_obj = self._logging_obj_with_reported_usage({"content-type": "application/json"})
+        response = self._priced_body_response()
+
+        kwargs = self._create_payload(logging_obj, response)
+
+        assert kwargs["response_cost"] > 0
+        assert kwargs["response_cost"] == logging_obj.model_call_details["response_cost"]
+        assert response.usage.total_tokens == 15

--- a/tests/test_litellm/proxy/pass_through_endpoints/test_upstream_usage_headers.py
+++ b/tests/test_litellm/proxy/pass_through_endpoints/test_upstream_usage_headers.py
@@ -7,6 +7,7 @@ from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLogging
 from litellm.proxy.pass_through_endpoints.upstream_usage_headers import (
     UpstreamReportedUsage,
     apply_upstream_reported_usage,
+    get_upstream_reported_usage,
     parse_upstream_reported_usage,
 )
 from litellm.types.utils import Usage
@@ -126,3 +127,16 @@ def test_apply_only_overwrites_what_upstream_reported():
 
     assert logging_obj.model_call_details["response_cost"] == 0.5
     assert logging_obj.model_call_details["combined_usage_object"] == Usage(total_tokens=42)
+
+
+def test_get_returns_what_apply_recorded_and_none_before():
+    logging_obj = _logging_obj()
+
+    assert get_upstream_reported_usage(logging_obj) is None
+
+    apply_upstream_reported_usage(
+        logging_obj=logging_obj,
+        headers=_headers(**{"x-litellm-response-cost": "0.5"}),
+    )
+
+    assert get_upstream_reported_usage(logging_obj) == UpstreamReportedUsage(response_cost=0.5, total_tokens=None)


### PR DESCRIPTION
## TLDR

Problem this solves:

- Pass-through targets can report request totals via `x-litellm-response-cost` / `x-litellm-total-tokens`
- Streaming responses recorded those values, non-streaming responses silently discarded them
- Non-streaming spend rows showed a body-derived price the upstream never sent

How it solves it:

- Non-streaming logging now keeps the upstream-reported cost and token count
- Cost is only derived from the response body when the upstream reported nothing
- An unusable reported cost records 0, never a recomputed estimate

## User Flow

Before: a proxy admin routing to an upstream that prices its own requests sees wrong spend on every non-streaming call

1. The admin configures a pass-through endpoint `/repro` pointing at that upstream and restarts the proxy
2. A developer sends POST http://litellm-domain/repro/v1/messages with `"stream": true`, and the upstream answers with `x-litellm-response-cost: 0.777777` and `x-litellm-total-tokens: 4242`
3. The admin opens http://litellm-domain/ui/?page=logs and sees that request at $0.777777 with 4242 tokens
4. The developer sends the same request without `"stream": true`, and the upstream reports the same values
5. The admin sees that request logged at $0.000075 with 15 tokens, numbers the upstream never sent

After: both requests are recorded at what the upstream reported

1. The admin configures the same pass-through endpoint `/repro` and restarts the proxy
2. The developer sends the same streaming request, and the admin sees it logged at $0.777777 with 4242 tokens
3. The developer sends the same non-streaming request, and the admin now sees it logged at $0.777777 with 4242 tokens too

## Relevant issues

Fixes #37105

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/proxy/pass_through_endpoints/ -v` (678 passed)
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Self-contained, no credentials and no real provider calls: the stdlib upstream and pass-through config are exactly the `upstream.py` / `config.yaml` from issue #37105 (upstream on port 8177, reporting `x-litellm-response-cost: 0.777777` and `x-litellm-total-tokens: 4242` on every response, body naming `gpt-4o` with 15 tokens of usage), plus Postgres for spend logs

```bash
docker run -d --name litellm-repro-pg -e POSTGRES_USER=litellm -e POSTGRES_PASSWORD=litellm \
  -e POSTGRES_DB=litellm -p 127.0.0.1:5455:5432 postgres:17-alpine
python upstream.py 8177 &
DATABASE_URL=postgresql://litellm:litellm@127.0.0.1:5455/litellm LITELLM_MASTER_KEY=sk-repro \
  python litellm/proxy/proxy_cli.py --config config.yaml --port 4177
```

### Before (a73e770798)

1. Non-streaming request through the proxy

   ```bash
   curl -s -o /dev/null -w 'http_code=%{http_code}\n' -X POST http://127.0.0.1:4177/repro/v1/messages \
     -H 'Authorization: Bearer sk-repro' -H 'content-type: application/json' \
     -d '{"model":"my-router-alias","max_tokens":16,"messages":[{"role":"user","content":"ping"}]}'
   ```

   ```
   http_code=200
   ```

2. Same request with `"stream": true`

   ```bash
   curl -s -N -o /dev/null -w 'http_code=%{http_code}\n' -X POST http://127.0.0.1:4177/repro/v1/messages \
     -H 'Authorization: Bearer sk-repro' -H 'content-type: application/json' \
     -d '{"model":"my-router-alias","max_tokens":16,"stream":true,"messages":[{"role":"user","content":"ping"}]}'
   ```

   ```
   http_code=200
   ```

3. Spend rows: the non-streaming row discarded both reported values, the streaming row kept them

   ```bash
   docker exec litellm-repro-pg psql -U litellm -d litellm \
     -c 'select model, spend, total_tokens, call_type from "LiteLLM_SpendLogs" order by "startTime" asc;'
   ```

   ```
         model      |         spend         | total_tokens |       call_type
   -----------------+-----------------------+--------------+-----------------------
    gpt-4o          | 7.500000000000001e-05 |           15 | pass_through_endpoint
    my-router-alias |              0.777777 |         4242 | pass_through_endpoint
   (2 rows)
   ```

### After (034b868f57)

1. Same non-streaming request

   ```bash
   curl -s -o /dev/null -w 'http_code=%{http_code}\n' -X POST http://127.0.0.1:4177/repro/v1/messages \
     -H 'Authorization: Bearer sk-repro' -H 'content-type: application/json' \
     -d '{"model":"my-router-alias","max_tokens":16,"messages":[{"role":"user","content":"ping"}]}'
   ```

   ```
   http_code=200
   ```

2. Same streaming request

   ```bash
   curl -s -N -o /dev/null -w 'http_code=%{http_code}\n' -X POST http://127.0.0.1:4177/repro/v1/messages \
     -H 'Authorization: Bearer sk-repro' -H 'content-type: application/json' \
     -d '{"model":"my-router-alias","max_tokens":16,"stream":true,"messages":[{"role":"user","content":"ping"}]}'
   ```

   ```
   http_code=200
   ```

3. Spend rows: both requests now record the upstream-reported cost and tokens

   ```bash
   docker exec litellm-repro-pg psql -U litellm -d litellm \
     -c 'select model, spend, total_tokens, call_type from "LiteLLM_SpendLogs" order by "startTime" asc;'
   ```

   ```
         model      |  spend   | total_tokens |       call_type
   -----------------+----------+--------------+-----------------------
    gpt-4o          | 0.777777 |         4242 | pass_through_endpoint
    my-router-alias | 0.777777 |         4242 | pass_through_endpoint
   (2 rows)
   ```

## Type

🐛 Bug Fix

## Caveats (if any)

### Low

- The non-streaming spend row still names the model from the response body (`gpt-4o` above) rather than the request alias, same as before this PR

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
