### PR TITLE
fix(otel): don't cast None metadata values to empty-string span attributes

### DIFF
--- a/litellm/integrations/opentelemetry.py
+++ b/litellm/integrations/opentelemetry.py
@@ -2361,7 +2361,15 @@ class OpenTelemetry(OTELGenAISemconvMixin, CustomLogger):
             #############################################
             metadata: Final = standard_logging_payload["metadata"]
             for key, value in metadata.items():
-                self.safe_set_attribute(span=span, key=f"metadata.{key}", value=value)
+                # Skip None values instead of letting safe_set_attribute cast them to "".
+                # Fields that are sometimes a real value (e.g. an ISO timestamp string
+                # like user_api_key_budget_reset_at) and sometimes None would otherwise
+                # send two different shapes for the same attribute, and backends that
+                # infer a field's type from the first value they see (e.g. OpenSearch's
+                # dynamic mapping) lock onto whichever shape arrives first -- causing the
+                # other shape to fail once the mapping is set. See issue #29583.
+                if value is not None:
+                    self.safe_set_attribute(span=span, key=f"metadata.{key}", value=value)
 
             # get hidden params
             hidden_params: Final = getattr(standard_logging_payload, "hidden_params", None) or (

--- a/tests/test_litellm/integrations/test_opentelemetry.py
+++ b/tests/test_litellm/integrations/test_opentelemetry.py
@@ -391,6 +391,86 @@ class TestOpenTelemetryCostBreakdown(unittest.TestCase):
         assert ("gen_ai.cost.original_cost", 0.004) not in call_args_list
 
 
+class TestOpenTelemetryMetadataNoneValues(unittest.TestCase):
+    """
+    Regression test for https://github.com/BerriAI/litellm/issues/29583
+
+    None-valued metadata fields (e.g. user_api_key_budget_reset_at for a key
+    with no budget configured) were being cast to "" and set on the span like
+    any other value. A field that is sometimes a real value and sometimes ""
+    sends two different shapes for the same attribute -- backends that infer
+    a field's type from the first value they see (e.g. OpenSearch's dynamic
+    mapping) lock onto whichever shape arrives first, so the other shape then
+    fails. None-valued metadata should be omitted from the span instead.
+    """
+
+    def test_none_metadata_value_is_not_set_on_span(self):
+        otel = OpenTelemetry()
+        mock_span = MagicMock()
+
+        kwargs = {
+            "model": "gpt-4",
+            "messages": [{"role": "user", "content": "Hello"}],
+            "optional_params": {},
+            "litellm_params": {"custom_llm_provider": "openai"},
+            "standard_logging_object": {
+                "id": "test-id",
+                "call_type": "completion",
+                "metadata": {
+                    "user_api_key_budget_reset_at": None,
+                    "user_api_key_team_id": "team-123",
+                },
+            },
+        }
+
+        response_obj = {
+            "id": "test-response-id",
+            "model": "gpt-4",
+            "choices": [],
+            "usage": {"prompt_tokens": 10, "completion_tokens": 20, "total_tokens": 30},
+        }
+
+        otel.set_attributes(span=mock_span, kwargs=kwargs, response_obj=response_obj)
+
+        call_args_list = [call[0] for call in mock_span.set_attribute.call_args_list]
+        set_keys = [args[0] for args in call_args_list]
+
+        assert "metadata.user_api_key_budget_reset_at" not in set_keys
+        assert ("metadata.user_api_key_budget_reset_at", "") not in call_args_list
+        mock_span.set_attribute.assert_any_call("metadata.user_api_key_team_id", "team-123")
+
+    def test_real_timestamp_metadata_value_is_still_set_on_span(self):
+        otel = OpenTelemetry()
+        mock_span = MagicMock()
+
+        kwargs = {
+            "model": "gpt-4",
+            "messages": [{"role": "user", "content": "Hello"}],
+            "optional_params": {},
+            "litellm_params": {"custom_llm_provider": "openai"},
+            "standard_logging_object": {
+                "id": "test-id",
+                "call_type": "completion",
+                "metadata": {
+                    "user_api_key_budget_reset_at": "2026-09-15T00:00:00+00:00",
+                },
+            },
+        }
+
+        response_obj = {
+            "id": "test-response-id",
+            "model": "gpt-4",
+            "choices": [],
+            "usage": {"prompt_tokens": 10, "completion_tokens": 20, "total_tokens": 30},
+        }
+
+        otel.set_attributes(span=mock_span, kwargs=kwargs, response_obj=response_obj)
+
+        mock_span.set_attribute.assert_any_call(
+            "metadata.user_api_key_budget_reset_at", "2026-09-15T00:00:00+00:00"
+        )
+
+
 class TestOpenTelemetryProviderInitialization(unittest.TestCase):
     """Test suite for verifying provider initialization respects existing providers"""
 


### PR DESCRIPTION
## TLDR

Problem this solves:
- None-valued OTel span attributes get sent as empty strings, not omitted
- Same field sends two shapes (empty string vs real value) to observability backends

How it solves it:
- Skip None values in the metadata attribute loop before setting them on the span
- Matches the existing pattern already used two loops below for cost_breakdown

## User Flow

Before: an operator watching LLM traces in OpenSearch hits an ingest error after some requests

1. They run the proxy with OTel tracing enabled, exporting to an OpenSearch-backed collector
2. Some requests come from API keys with no budget configured
3. OpenSearch logs `Field [attributes.user_api_key_budget_reset_at] of type [text] does not support custom formats` on ingest for a later request from a key that *does* have a budget, because the field's type got locked in as `text` from an earlier empty-string value
4. Some traces silently fail to index because of this

After: every trace ingests cleanly regardless of which requests came first

1. They run the proxy the same way
2. A request from a key with no budget configured simply doesn't carry a `user_api_key_budget_reset_at` attribute on its span, instead of carrying an empty string
3. A request from a key with a budget still carries the real ISO timestamp, unchanged
4. OpenSearch never sees two different shapes for the same field, so no mapping conflict

## Relevant issues

Fixes #29583

## Linear ticket



## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/integrations/test_opentelemetry.py -v`
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

Reproduced with real captured production-shaped kwargs (`tests/test_litellm/integrations/open_telemetry/data/captured_kwargs.json`, the same fixture the existing test suite uses for this code path) fed through the real `OpenTelemetry._handle_success` -> real OTel SDK `TracerProvider` + `InMemorySpanExporter`. Only `metadata.user_api_key_budget_reset_at` was set to `None` to represent a key with no budget configured; everything else is untouched captured data.

### Before (be3386f)

1. Ran the repro script against `be3386f` (this branch's merge-base)
2. Output: `metadata.user_api_key_budget_reset_at present on span: True`
3. Output: `metadata.user_api_key_budget_reset_at value: ''`

### After (d010ed4)

1. Ran the same script against this branch's tip
2. Output: `metadata.user_api_key_budget_reset_at present on span: False`

## Type

🐛 Bug Fix
✅ Test

## Caveats (if any)

### Low
- Only the `metadata.*` attribute loop was touched; other places `safe_set_attribute` is called (e.g. `cost_breakdown`) already had this guard and were left as-is

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR