### PR TITLE
fix(proxy): enforce auth defaults for raw pass-through config

### DIFF
--- a/litellm/proxy/auth/user_api_key_auth.py
+++ b/litellm/proxy/auth/user_api_key_auth.py
@@ -2423,7 +2423,11 @@ async def _run_centralized_common_checks(
     pass_through_endpoints: Final = general_settings.get("pass_through_endpoints", None)
     if pass_through_endpoints is not None:
         for endpoint in pass_through_endpoints:
-            if isinstance(endpoint, dict) and endpoint.get("path", "") == route and endpoint.get("auth") is not True:
+            if (
+                isinstance(endpoint, dict)
+                and endpoint.get("path", "") == route
+                and endpoint.get("auth", True) is not True
+            ):
                 return
 
     # No-auth dev mode: master_key unset AND no JWT/OAuth2 auth

--- a/litellm/proxy/pass_through_endpoints/pass_through_endpoints.py
+++ b/litellm/proxy/pass_through_endpoints/pass_through_endpoints.py
@@ -3060,7 +3060,7 @@ async def _register_pass_through_endpoint(
     forward_headers: Final = endpoint_data.get("forward_headers")
     merge_query_params: Final = endpoint_data.get("merge_query_params")
     default_query_params: Final = endpoint_data.get("default_query_params")
-    auth: Final[bool | str | None] = endpoint_data.get("auth")
+    auth: Final[bool | str | None] = endpoint_data.get("auth", True)
     dependencies = None
     auth_enforced: Final = auth is not None and str(auth).lower() == "true"
 

--- a/tests/test_litellm/proxy/auth/test_user_api_key_auth.py
+++ b/tests/test_litellm/proxy/auth/test_user_api_key_auth.py
@@ -3835,6 +3835,50 @@ async def test_centralized_common_checks_runs_for_standard_auth():
 
 
 @pytest.mark.asyncio
+async def test_centralized_common_checks_runs_for_raw_passthrough_without_auth():
+    import litellm.proxy.proxy_server as _proxy_server_mod
+    from fastapi import Request
+    from starlette.datastructures import URL
+
+    route = "/chat/completions"
+    token = UserAPIKeyAuth(api_key="sk-test")
+    request = Request(scope={"type": "http", "headers": []})
+    request._url = URL(url=route)
+    attrs = _proxy_attrs_for_centralized_checks(user_custom_auth=None)
+    attrs["general_settings"] = {
+        "reject_clientside_metadata_tags": True,
+        "pass_through_endpoints": [
+            {
+                "path": route,
+                "target": "https://example.com",
+            }
+        ]
+    }
+    originals = {
+        attribute: getattr(_proxy_server_mod, attribute, None)
+        for attribute in attrs
+    }
+    try:
+        for attribute, value in attrs.items():
+            setattr(_proxy_server_mod, attribute, value)
+        with pytest.raises(ProxyException) as exc_info:
+            await _run_centralized_common_checks(
+                user_api_key_auth_obj=token,
+                request=request,
+                request_data={
+                    "model": "gpt-4o",
+                    "metadata": {"tags": ["client-supplied"]},
+                },
+                route=route,
+            )
+    finally:
+        for attribute, value in originals.items():
+            setattr(_proxy_server_mod, attribute, value)
+
+    assert exc_info.value.type == ProxyErrorTypes.bad_request_error
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     "route",
     [

--- a/tests/test_litellm/proxy/pass_through_endpoints/test_passthrough_auth_default.py
+++ b/tests/test_litellm/proxy/pass_through_endpoints/test_passthrough_auth_default.py
@@ -25,11 +25,12 @@ import pytest
 from fastapi import FastAPI
 
 
-from litellm.proxy._types import PassThroughGenericEndpoint
+from litellm.proxy._types import LiteLLMRoutes, PassThroughGenericEndpoint
 from litellm.proxy.auth.user_api_key_auth import (
     check_api_key_for_custom_headers_or_pass_through_endpoints,
 )
 from litellm.proxy.pass_through_endpoints.pass_through_endpoints import (
+    _registered_pass_through_routes,
     _register_pass_through_endpoint,
 )
 
@@ -77,6 +78,32 @@ async def test_register_passthrough_with_auth_true_works_for_oss(monkeypatch):
         premium_user=False,
         visited_endpoints=visited,
     )
+
+
+@pytest.mark.asyncio
+async def test_register_raw_passthrough_defaults_to_authentication():
+    path = "/raw-auth-default"
+    route_key = f"raw-auth-default:exact:{path}:GET"
+    endpoint: dict[str, object] = {
+        "id": "raw-auth-default",
+        "path": path,
+        "target": "https://example.com",
+        "methods": ["GET"],
+    }
+
+    try:
+        await _register_pass_through_endpoint(
+            endpoint=endpoint,
+            app=FastAPI(),
+            premium_user=False,
+            visited_endpoints=set(),
+        )
+        assert _registered_pass_through_routes[route_key]["auth"] is True
+        assert path in LiteLLMRoutes.openai_routes.value
+    finally:
+        _registered_pass_through_routes.pop(route_key, None)
+        if path in LiteLLMRoutes.openai_routes.value:
+            LiteLLMRoutes.openai_routes.value.remove(path)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## TLDR

Problem this solves:

- Raw pass-through config can skip centralized policy checks
- Missing `auth` disagrees with the typed secure default

How it solves it:

- Defaults missing raw `auth` values to `true`
- Covers route registration and centralized checks with regressions

## User Flow

Before: a proxy admin omits `auth` and an exhausted key can still reach the pass-through upstream

1. The admin configures `/internal/provider` without an `auth` field and restarts the proxy
2. A developer sends POST https://litellm-domain/internal/provider with a valid virtual key whose budget is exhausted
3. The request reaches the configured upstream instead of returning a budget error
4. The developer can continue using the upstream beyond the key's configured policy

After: the same request is stopped by the policy already attached to the key

1. The admin configures `/internal/provider` without an `auth` field and restarts the proxy
2. A developer sends POST https://litellm-domain/internal/provider with a valid virtual key whose budget is exhausted
3. The proxy returns HTTP 429 with the budget-exceeded error before contacting the upstream
4. The developer can no longer bypass the key's configured policy through this route

## Relevant issues

Fixes #35534

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The test files covering my change pass locally
- [ ] My PR passes all required CI/CD checks
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile Confidence Score of at least 4/5 on the latest head

## Local checks

- Related auth selection: 36 passed, 133 deselected
- The branch is rebased onto the latest `litellm_internal_staging`
- The PR has no merge conflicts

## Screenshots / Proof of Fix

A live before/after curl run needs a DB-backed proxy so the same virtual key can be placed over budget. This checkout has no PostgreSQL service or `DATABASE_URL`

### Before (97dbd8efcb)

1. Not captured locally because the required DB-backed key state is unavailable

### After (754c3d5414)

1. Not captured locally for the same reason

## Type

Bug Fix

## Caveats (if any)

### CI baseline

- OSV currently flags pypdf 6.15.0 and tornado 6.5.7 from the staging `uv.lock`
- Fork PRs are prohibited from modifying `uv.lock` by the repository dependency guard
- Canonical dependency PR #39188 is tracking the staging security update

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
