### PR TITLE
build(rust): configure native extension profiles

### DIFF
--- a/.github/actions/cache-cargo-build/action.yml
+++ b/.github/actions/cache-cargo-build/action.yml
@@ -25,6 +25,6 @@ runs:
           ~/.cargo/registry
           ~/.cargo/git
           litellm-rust/target
-        key: ${{ runner.os }}-cargo-dev-${{ hashFiles('litellm-rust/Cargo.lock') }}
+        key: ${{ runner.os }}-maturin-dev-${{ hashFiles('litellm-rust/Cargo.lock') }}
         restore-keys: |
-          ${{ runner.os }}-cargo-dev-
+          ${{ runner.os }}-maturin-dev-

--- a/.github/actions/cache-cargo-build/action.yml
+++ b/.github/actions/cache-cargo-build/action.yml
@@ -4,17 +4,16 @@ description: >-
   so only the first job on a given Cargo.lock compiles the bridge from scratch.
 
   litellm builds through maturin, which compiles litellm-rust/crates/python-bridge
-  in release mode before it can produce a wheel. `uv sync` therefore pays a full
-  build in every job that installs the workspace: measured at 2m40s per unit shard
-  on 2026-08-21, more than the whole unit tier spends running tests. Nothing caught
-  it, because the uv cache holds wheels uv downloads rather than wheels it builds,
-  and a path dependency whose source moves every commit could never hit that cache
-  anyway. Cargo rebuilds only what changed when its target directory survives, so a
-  warm job pays for the bridge crate alone.
+  in the dev profile for editable installs. `uv sync` therefore pays a full build
+  in every job that installs the workspace. Nothing caught it, because the uv cache
+  holds wheels uv downloads rather than wheels it builds, and a path dependency
+  whose source moves every commit could never hit that cache anyway. Cargo rebuilds
+  only what changed when its target directory survives, so a warm job pays for the
+  bridge crate alone.
 
-  The key namespace is separate from test-rust.yml's. Both cache the same directory,
-  but that workflow fills it with debug and clippy artifacts, which a release build
-  cannot reuse, and a shared key would let whichever ran first deny the other a save.
+  The key namespace is separate from test-rust.yml's check and release caches. They
+  cache the same directory for different workloads, and a shared key would let
+  whichever ran first deny the others a save.
 
 runs:
   using: composite
@@ -26,6 +25,6 @@ runs:
           ~/.cargo/registry
           ~/.cargo/git
           litellm-rust/target
-        key: ${{ runner.os }}-cargo-release-${{ hashFiles('litellm-rust/Cargo.lock') }}
+        key: ${{ runner.os }}-cargo-dev-${{ hashFiles('litellm-rust/Cargo.lock') }}
         restore-keys: |
-          ${{ runner.os }}-cargo-release-
+          ${{ runner.os }}-cargo-dev-

--- a/litellm-rust/Cargo.toml
+++ b/litellm-rust/Cargo.toml
@@ -30,3 +30,12 @@ tokio = { version = "1", features = ["rt-multi-thread", "macros", "time", "net"]
 tokio-tungstenite = { version = "0.24", default-features = false, features = ["connect", "rustls-tls-native-roots"] }
 futures-util = { version = "0.3", default-features = false, features = ["sink", "std"] }
 base64 = "0.22"
+
+[profile.release]
+opt-level = 3
+lto = "thin"
+codegen-units = 1
+panic = "unwind"
+debug = false
+incremental = false
+strip = "symbols"

--- a/litellm-rust/crates/python-bridge/Cargo.toml
+++ b/litellm-rust/crates/python-bridge/Cargo.toml
@@ -10,7 +10,8 @@ name = "_native"
 crate-type = ["cdylib"]
 
 [features]
-default = ["extension-module"]
+default = ["abi3"]
+abi3 = ["pyo3/abi3-py310"]
 extension-module = ["pyo3/extension-module"]
 
 [dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -262,7 +262,7 @@ healthcheck = [
 ]
 
 [build-system]
-requires = ["maturin==1.9.4"]
+requires = ["maturin==1.15.0"]
 build-backend = "maturin"
 
 [tool.maturin]
@@ -270,6 +270,9 @@ manifest-path = "litellm-rust/crates/python-bridge/Cargo.toml"
 module-name = "litellm.rust_bridge._native"
 python-source = "."
 bindings = "pyo3"
+features = ["extension-module"]
+profile = "release"
+editable-profile = "dev"
 include = ["litellm/proxy/_experimental/out/**"]
 exclude = [
     "litellm/proxy/enterprise",


### PR DESCRIPTION
## TLDR

Problem this solves:

- Release builds rewrote exact Cargo manifest text for ABI3
- A missed rewrite could expand PyPI from 200 MB to 900 MB
- Native release wheels lacked an explicit optimization contract
- Editable builds shared the wrong Cargo cache namespace

How it solves it:

- Enable ABI3 in the bridge's default Cargo features
- Keep extension-module opt-in owned by Maturin
- Select release in Maturin and strip through Cargo
- Isolate editable builds under a Maturin cache namespace

## User Flow

Before: a release maintainer depends on a manifest rewrite to keep the wheel matrix small

1. They approve a release SHA after the required end-to-end tests
2. The release pipeline rewrites dependency syntax to enable ABI3
3. A syntax change can make the patcher warn and skip ABI3
4. The release expands from 7 build legs and 200 MB to 11 legs and 900 MB

After: the same release maintainer gets the compact ABI3 matrix without rewriting the manifest

1. They approve a release SHA after the required end-to-end tests
2. The release build uses ABI3 from the default Cargo features
3. It produces one `cp310-abi3` wheel per platform
4. The release stays at 7 build legs and about 200 MB

## Why this design

Symbol stripping lives in `litellm-rust/Cargo.toml` under `[profile.release]` as `strip = "symbols"`. `pyproject.toml` only selects `profile = "release"` instead of repeating the policy through Maturin's `strip` setting. Cargo owns the native artifact policy, while Maturin owns profile and extension selection

The bridge defaults to `abi3`, which maps to `pyo3/abi3-py310`. `extension-module` remains separate and Maturin enables it for Python wheels. Cargo builds outside Maturin still get the stable ABI without taking on extension-module behavior

`editable-profile = "dev"` is intentional for editable installs such as `uv sync`. Python test jobs need fast incremental bridge builds and should not pay the optimized release build cost after every source change. Those jobs therefore cache their Cargo target artifacts under `maturin-dev-*`, outside the Rust test workflow's broad `cargo-*` restore prefix. A bridge-focused editable cache can no longer be selected in place of the full-workspace Rust cache, while production wheel builds continue to use `profile = "release"`

`panic = "unwind"` is explicit even though it is Cargo's current release default. PyO3 can catch an unwinding Rust panic and raise `PanicException` in Python, while `panic = "abort"` would terminate the interpreter process. Keeping this in the release profile makes the Python host safety contract visible and prevents a future profile change from silently switching behavior. The stacked validation in #39021 proves the exception is catchable and the native module remains usable afterward

## Regression context

[#38764](https://github.com/BerriAI/litellm/pull/38764) changed the bridge's PyO3 dependency declaration from an inline table to a dotted key. The release pipeline only knew how to rewrite the old text shape, so it skipped ABI3 with a warning. That expanded the matrix from 7 to 11 build legs and could grow the PyPI release from about 200 MB to 900 MB, as seen in the [cancelled release run](https://github.com/BerriAI/project-releaser/actions/runs/33287834391)

[project-releaser #211](https://github.com/BerriAI/project-releaser/pull/211) and [#213](https://github.com/BerriAI/project-releaser/pull/213) patched the immediate release issue by supporting both declaration forms. This PR removes the underlying need for that manifest rewrite by enabling ABI3 by default. Future PyO3 declaration changes will no longer control the wheel matrix

## Relevant issues

Related to #38853

Related to #38764

Followed by #39021

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have added meaningful tests
- [ ] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA)

## Screenshots / Proof of Fix

Local proof was not captured because this task explicitly excludes checks and tests

### Before (0f84a7053a)

1. No validation output was captured

### After (2c2d0885fe)

1. No validation output was captured

## Type

🚄 Infrastructure

## Caveats (if any)

### Low

- Thin LTO may lengthen uncached release builds
- Release pipeline can remove its ABI3 manifest rewrite after merge

## Final Attestation

- [ ] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
