### PR TITLE
test(e2e): cover SCIM token creation and SCIM API auth in the Admin UI suite

### DIFF
--- a/tests/e2e/ui/tests/settings/scim.spec.ts
+++ b/tests/e2e/ui/tests/settings/scim.spec.ts
@@ -1,0 +1,66 @@
+import { test, expect, Page as PlaywrightPage } from "@playwright/test";
+import { ADMIN_STORAGE_PATH } from "../../constants";
+import { Page } from "../../fixtures/pages";
+import { navigateToPage } from "../../helpers/navigation";
+import { masterKey } from "../../helpers/traffic";
+
+const rootPath = (): string => process.env.SERVER_ROOT_PATH ?? "";
+
+async function createScimTokenViaUi(page: PlaywrightPage, alias: string): Promise<string> {
+  await navigateToPage(page, Page.AdminPanel);
+  await page.getByRole("tab", { name: "SCIM" }).click();
+
+  await expect(page.getByText("SCIM Tenant URL")).toBeVisible();
+  await expect(page.locator("input[disabled]").first()).toHaveValue(/\/scim\/v2$/);
+
+  await page.getByLabel("Token Name").fill(alias);
+  await page.getByRole("button", { name: "Create SCIM Token" }).click();
+
+  await expect(page.getByText(/copy this token now/i)).toBeVisible({ timeout: 15_000 });
+  const token = await page.locator('input[type="password"]').inputValue();
+  expect(token, "the one-time token panel shows a usable virtual key").toMatch(/^sk-/);
+  return token;
+}
+
+test.describe("Admin Settings - SCIM", () => {
+  test.use({ storageState: ADMIN_STORAGE_PATH });
+
+  test("Create SCIM Token shows the token once and offers to create another", async ({ page }) => {
+    const token = await createScimTokenViaUi(page, `e2e-scim-ui-${Date.now()}`);
+
+    await page.getByRole("button", { name: "Create Another Token" }).click();
+    await expect(page.getByRole("button", { name: "Create SCIM Token" })).toBeVisible();
+    await expect(page.getByText(/copy this token now/i)).toBeHidden();
+
+    await deleteKey(page, token);
+  });
+
+  test("a UI-minted SCIM token authorizes the SCIM API", async ({ page, request }) => {
+    test.skip(!process.env.LITELLM_LICENSE, "LITELLM_LICENSE not set in test env — /scim/v2 is premium-gated");
+
+    const token = await createScimTokenViaUi(page, `e2e-scim-api-${Date.now()}`);
+
+    const denied = await request.get(`${rootPath()}/scim/v2/Groups`, {
+      headers: { Authorization: "Bearer sk-not-a-real-key" },
+    });
+    expect(denied.status(), "an unknown key must not reach SCIM").toBe(401);
+
+    const res = await request.get(`${rootPath()}/scim/v2/Groups`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    expect(res.status(), `SCIM Groups listing failed: ${await res.text()}`).toBe(200);
+    const body = await res.json();
+    expect(body.schemas, "SCIM answers with a ListResponse").toContain("urn:ietf:params:scim:api:messages:2.0:ListResponse");
+    expect(Array.isArray(body.Resources), "SCIM ListResponse carries a Resources array").toBe(true);
+
+    await deleteKey(page, token);
+  });
+});
+
+async function deleteKey(page: PlaywrightPage, key: string): Promise<void> {
+  const res = await page.request.post(`${rootPath()}/key/delete`, {
+    headers: { Authorization: `Bearer ${masterKey()}`, "Content-Type": "application/json" },
+    data: { keys: [key] },
+  });
+  expect(res.ok(), `cleanup of the SCIM token failed (${res.status()})`).toBe(true);
+}

--- a/tests/e2e/ui/tests/settings/scim.spec.ts
+++ b/tests/e2e/ui/tests/settings/scim.spec.ts
@@ -2,7 +2,6 @@ import { test, expect, Page as PlaywrightPage } from "@playwright/test";
 import { ADMIN_STORAGE_PATH } from "../../constants";
 import { Page } from "../../fixtures/pages";
 import { navigateToPage } from "../../helpers/navigation";
-import { masterKey } from "../../helpers/traffic";
 
 const rootPath = (): string => process.env.SERVER_ROOT_PATH ?? "";
 
@@ -26,13 +25,11 @@ test.describe("Admin Settings - SCIM", () => {
   test.use({ storageState: ADMIN_STORAGE_PATH });
 
   test("Create SCIM Token shows the token once and offers to create another", async ({ page }) => {
-    const token = await createScimTokenViaUi(page, `e2e-scim-ui-${Date.now()}`);
+    await createScimTokenViaUi(page, `e2e-scim-ui-${Date.now()}`);
 
     await page.getByRole("button", { name: "Create Another Token" }).click();
     await expect(page.getByRole("button", { name: "Create SCIM Token" })).toBeVisible();
     await expect(page.getByText(/copy this token now/i)).toBeHidden();
-
-    await deleteKey(page, token);
   });
 
   test("a UI-minted SCIM token authorizes the SCIM API", async ({ page, request }) => {
@@ -52,15 +49,5 @@ test.describe("Admin Settings - SCIM", () => {
     const body = await res.json();
     expect(body.schemas, "SCIM answers with a ListResponse").toContain("urn:ietf:params:scim:api:messages:2.0:ListResponse");
     expect(Array.isArray(body.Resources), "SCIM ListResponse carries a Resources array").toBe(true);
-
-    await deleteKey(page, token);
   });
 });
-
-async function deleteKey(page: PlaywrightPage, key: string): Promise<void> {
-  const res = await page.request.post(`${rootPath()}/key/delete`, {
-    headers: { Authorization: `Bearer ${masterKey()}`, "Content-Type": "application/json" },
-    data: { keys: [key] },
-  });
-  expect(res.ok(), `cleanup of the SCIM token failed (${res.status()})`).toBe(true);
-}


### PR DESCRIPTION
## TLDR

Problem this solves:

- SCIM token creation is a manual item on the RC QA checklist
- Nothing proved a UI-minted SCIM token actually authenticates SCIM calls

How it solves it:

- New Playwright spec drives Admin Settings > SCIM end to end
- A second test calls the SCIM API with the minted token
- The API test gates on LITELLM_LICENSE, so it runs on licensed stacks and skips elsewhere

## User Flow

Before: an admin preparing an rc has to click through SCIM token creation by hand every release

1. They open http://localhost:4000/ui/?page=admin-panel and click the SCIM tab
2. They see the SCIM Tenant URL ending in /scim/v2, type a token name, click Create SCIM Token
3. They copy the one time token from the panel that warns it will not be shown again
4. They paste it into a curl against GET http://localhost:4000/scim/v2/Groups and eyeball the 200

After: the suite walks the same clicks on every run, so the checklist item is automated

1. The same flow runs headlessly in the UI e2e suite, on every PR and rc candidate
2. The suite also sends GET /scim/v2/Groups with the minted token and expects a 200 SCIM ListResponse, and expects 401 for an unknown key

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

### Before (0f84a7053a)

1. `ls tests/e2e/ui/tests/settings/` shows only `routerSettings.spec.ts`; SCIM has no coverage anywhere in the suite

### After (94f6827530)

#### SCIM token creation and API auth against a live licensed proxy

1. Stack: `E2E_KEEP_ALIVE=1 PROXY_PORT=4210 POSTGRES_PORT=5632 MOCK_LLM_PORT=8290 ./run_e2e.sh` with LITELLM_LICENSE exported
2. `npx playwright test tests/settings/scim.spec.ts --reporter=list`

```
✓  1 [chromium] › tests/settings/scim.spec.ts:27:7 › Admin Settings - SCIM › Create SCIM Token shows the token once and offers to create another (1.1s)
✓  2 [chromium] › tests/settings/scim.spec.ts:35:7 › Admin Settings - SCIM › a UI-minted SCIM token authorizes the SCIM API (1.1s)

2 passed (3.4s)
```

3. The same SCIM call the test makes, by hand against the same proxy:

```
curl -s -w "\nstatus: %{http_code}\n" http://127.0.0.1:4210/scim/v2/Groups -H "Authorization: Bearer $SCIM_TOKEN"
```

```
{"schemas":["urn:ietf:params:scim:api:messages:2.0:ListResponse"],"totalResults":4,"startIndex":1,"itemsPerPage":4,"Resources":[{"schemas":["urn:ietf:params:scim:schemas:core:2.0:Group"],"id":"e2e-team-no-admin",...
status: 200
```

#### Unlicensed run skips the API test instead of failing

1. Same command with LITELLM_LICENSE unset:

```
-  2 [chromium] › tests/settings/scim.spec.ts:35:7 › Admin Settings - SCIM › a UI-minted SCIM token authorizes the SCIM API
✓  1 [chromium] › tests/settings/scim.spec.ts:27:7 › Admin Settings - SCIM › Create SCIM Token shows the token once and offers to create another (974ms)

1 skipped
1 passed (3.4s)
```

## Type

✅ Test

## Caveats (if any)

### Medium

- GET /scim/v2/Users returns 500 when any user email has a reserved TLD like `.local`
  - Pre-existing serialization gap found while writing this; deployments with internal domains would hit it
  - The test uses /scim/v2/Groups so it stays green; the Users gap deserves its own ticket and fix

### Low

- The API test needs LITELLM_LICENSE in the runner env; CircleCI currently runs unlicensed so it skips there

## QA runbook

- tests/e2e/ui/tests/settings/scim.spec.ts "Create SCIM Token shows the token once and offers to create another" - the SCIM tab mints a token, shows it exactly once, and resets for another
  - [ ] Open http://localhost:4000/ui/?page=admin-panel as admin and click the SCIM tab
  - [ ] Expect the SCIM Tenant URL field to end in /scim/v2
  - [ ] Enter a token name and click Create SCIM Token
  - [ ] Expect a panel warning you to copy the token now, holding an sk- value
  - [ ] Click Create Another Token and expect the form back, with the one time panel gone
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey (e.g., assert actual expected spend instead of just spend > 0) or potentially flaky

- tests/e2e/ui/tests/settings/scim.spec.ts "a UI-minted SCIM token authorizes the SCIM API" - the minted token is accepted by SCIM while unknown keys are rejected (needs LITELLM_LICENSE, since /scim/v2 is premium gated)
  - [ ] Mint a token through the SCIM tab as above and copy it
  - [ ] curl GET http://localhost:4000/scim/v2/Groups with "Authorization: Bearer sk-not-a-real-key" and expect 401
  - [ ] curl the same URL with the minted token and expect 200 with a SCIM ListResponse carrying a Resources array
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey (e.g., assert actual expected spend instead of just spend > 0) or potentially flaky

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
