### PR TITLE
fix(router): don't let pass-through requests silently fall back to default_fallbacks

### DIFF
--- a/litellm/proxy/pass_through_endpoints/llm_passthrough_endpoints.py
+++ b/litellm/proxy/pass_through_endpoints/llm_passthrough_endpoints.py
@@ -1279,6 +1279,10 @@ def _resolve_vertex_model_from_router(
     if not llm_router:
         return encoded_endpoint, endpoint, vertex_project, vertex_location
 
+    import openai
+
+    from litellm.types.router import RouterRateLimitError
+
     try:
         deployment: Final = llm_router.get_available_deployment_for_pass_through(model=model_id)
         if not deployment:
@@ -1325,7 +1329,20 @@ def _resolve_vertex_model_from_router(
                 encoded_endpoint = encoded_endpoint.replace(model_id, actual_model)
                 endpoint = endpoint.replace(model_id, actual_model)
 
+    except (openai.APIError, RouterRateLimitError):
+        # The router made an explicit decision to reject this model for
+        # pass-through (not configured, not authorized, or no healthy
+        # deployment available). Propagate it. Swallowing it here and
+        # falling through to the return below would forward the caller's
+        # raw, unvalidated model/project/location using the proxy's
+        # default Vertex credentials -- bypassing the pass-through
+        # allowlist entirely. See issue #20727.
+        raise
     except Exception as e:
+        # Genuinely unexpected errors in this resolution helper itself
+        # (e.g. malformed litellm_params) stay best-effort, matching this
+        # function's original intent -- only the router's own deliberate
+        # rejections above are treated as fatal.
         verbose_proxy_logger.debug("Error resolving vertex model from router for model %s: %s", model_id, e)
 
     return encoded_endpoint, endpoint, vertex_project, vertex_location

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -11621,11 +11621,19 @@ class Router:
         input: str | list | None = None,
         specific_deployment: bool | None = False,
         request_kwargs: dict | None = None,
+        allow_default_fallback: bool = True,
     ) -> tuple[str, list | dict]:
         """
         Common checks for 'get_available_deployment' across sync + async call.
 
         If 'healthy_deployments' returned is None, this means the user chose a specific deployment
+
+        Args:
+            allow_default_fallback: Whether to silently substitute `default_fallbacks` when no
+                deployment matches `model`. Pass-through callers set this False: pass-through must
+                hit the exact provider-native model requested, so a caller expecting an error to
+                surface (e.g. a wrong/unconfigured model name) instead silently gets routed to an
+                unrelated model. See issue #20727.
 
         Returns
         - str, the litellm model name
@@ -11710,7 +11718,11 @@ class Router:
             # Do not fall back to another model when access-group filtering removed every
             # candidate for the requested name: re-filtering the fallback model can be a
             # no-op when it has no access_groups, incorrectly serving a different model.
-            if self._has_default_fallbacks() and not _access_group_filter_emptied_candidates:
+            if (
+                self._has_default_fallbacks()
+                and not _access_group_filter_emptied_candidates
+                and allow_default_fallback
+            ):
                 fallback_model: Final = self._get_first_default_fallback()
                 if fallback_model:
                     verbose_router_logger.info(
@@ -11815,6 +11827,7 @@ class Router:
         input: str | list | None = None,
         specific_deployment: bool | None = False,
         parent_otel_span: Span | None = None,
+        allow_default_fallback: bool = True,
     ) -> list[dict] | dict:
         """
         Get the healthy deployments for a model.
@@ -11831,6 +11844,7 @@ class Router:
             input=input,
             specific_deployment=specific_deployment,
             request_kwargs=request_kwargs,
+            allow_default_fallback=allow_default_fallback,
         )
 
         # IF TEAM ID SPECIFIED ON MODEL, AND REQUEST CONTAINS USER_API_KEY_TEAM_ID, FILTER OUT MODELS THAT ARE NOT IN THE TEAM
@@ -12146,6 +12160,9 @@ class Router:
                     request_kwargs.update(accepted_tier_params)
 
             # 2. Get healthy deployments
+            # allow_default_fallback=False: pass-through must hit the exact provider-native
+            # model requested, not get silently redirected to an unrelated default fallback
+            # model when the requested model isn't found (see issue #20727).
             healthy_deployments: Final = await self.async_get_healthy_deployments(
                 model=model,
                 request_kwargs=request_kwargs,
@@ -12153,6 +12170,7 @@ class Router:
                 input=input,
                 specific_deployment=specific_deployment,
                 parent_otel_span=parent_otel_span,
+                allow_default_fallback=False,
             )
 
             # 3. If specific deployment returned, verify if it supports pass-through
@@ -12788,11 +12806,15 @@ class Router:
             RouterRateLimitError: If no pass-through deployments are available
         """
         # 1. Perform common checks to get healthy deployments list
+        # allow_default_fallback=False: pass-through must hit the exact provider-native
+        # model requested, not get silently redirected to an unrelated default fallback
+        # model when the requested model isn't found (see issue #20727).
         model, healthy_deployments = self._common_checks_available_deployment(
             model=model,
             messages=messages,
             input=input,
             specific_deployment=specific_deployment,
+            allow_default_fallback=False,
         )
 
         # 2. If the returned is a specific deployment (Dict), verify and return directly

--- a/tests/test_litellm/proxy/pass_through_endpoints/test_vertex_passthrough_load_balancing.py
+++ b/tests/test_litellm/proxy/pass_through_endpoints/test_vertex_passthrough_load_balancing.py
@@ -2,6 +2,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+import litellm
 from litellm.proxy._types import UserAPIKeyAuth
 from litellm.proxy.pass_through_endpoints.llm_passthrough_endpoints import (
     _base_vertex_proxy_route,
@@ -295,6 +296,76 @@ def test_get_available_deployment_still_uses_default_fallback_for_normal_complet
     assert deployment is not None
     deployments = deployment if isinstance(deployment, list) else [deployment]
     assert any(d["litellm_params"]["model"] == "vertex_ai/gemini-2.5-flash" for d in deployments)
+
+
+@pytest.mark.asyncio
+async def test_vertex_passthrough_route_makes_no_upstream_request_when_model_not_resolved():
+    """
+    Regression test for the authorization gap flagged on the fix for
+    https://github.com/BerriAI/litellm/issues/20727: when the router rejects
+    a pass-through model (BadRequestError -- not configured / no healthy
+    deployment), _base_vertex_proxy_route must not fall through to forwarding
+    the caller's raw, unvalidated model/project/location to Vertex using the
+    proxy's default credentials. No upstream request should be made at all.
+    """
+    mock_request = MagicMock()
+    mock_response = MagicMock()
+    mock_handler = MagicMock()
+
+    mock_router = MagicMock()
+    mock_router.get_available_deployment_for_pass_through.side_effect = litellm.BadRequestError(
+        message="You passed in model=gemini-3-flash-preview. There are no healthy deployments for this model",
+        model="gemini-3-flash-preview",
+        llm_provider="",
+    )
+
+    with (
+        patch(
+            "litellm.llms.vertex_ai.common_utils.get_vertex_model_id_from_url",
+            return_value="gemini-3-flash-preview",
+        ),
+        patch("litellm.proxy.proxy_server.llm_router", mock_router),
+        patch(
+            "litellm.llms.vertex_ai.common_utils.get_vertex_project_id_from_url",
+            return_value=None,
+        ),
+        patch(
+            "litellm.llms.vertex_ai.common_utils.get_vertex_location_from_url",
+            return_value=None,
+        ),
+        patch(
+            "litellm.proxy.pass_through_endpoints.llm_passthrough_endpoints.passthrough_endpoint_router"
+        ) as mock_pt_router,
+        patch(
+            "litellm.proxy.pass_through_endpoints.llm_passthrough_endpoints._prepare_vertex_auth_headers",
+            new_callable=AsyncMock,
+        ) as mock_prep_headers,
+        patch(
+            "litellm.proxy.pass_through_endpoints.llm_passthrough_endpoints.create_pass_through_route"
+        ) as mock_create_route,
+        patch(
+            "litellm.proxy.pass_through_endpoints.llm_passthrough_endpoints.user_api_key_auth",
+            new_callable=AsyncMock,
+        ) as mock_auth,
+    ):
+        mock_pt_router.get_vertex_credentials.return_value = MagicMock()
+        mock_prep_headers.return_value = ({}, "https://test.url", False, None, None)
+
+        mock_endpoint_func = AsyncMock()
+        mock_create_route.return_value = mock_endpoint_func
+        mock_auth.return_value = {}
+
+        with pytest.raises(litellm.BadRequestError):
+            await _base_vertex_proxy_route(
+                endpoint="https://us-central1-aiplatform.googleapis.com/v1/projects/my-project/locations/us-central1/publishers/google/models/gemini-3-flash-preview:generateContent",
+                request=mock_request,
+                fastapi_response=mock_response,
+                get_vertex_pass_through_handler=mock_handler,
+            )
+
+        # The core assertion: no upstream request handler was ever invoked --
+        # the caller's model request never reached Vertex.
+        mock_endpoint_func.assert_not_called()
 
 
 def test_get_available_deployment_for_pass_through_load_balancing():

--- a/tests/test_litellm/proxy/pass_through_endpoints/test_vertex_passthrough_load_balancing.py
+++ b/tests/test_litellm/proxy/pass_through_endpoints/test_vertex_passthrough_load_balancing.py
@@ -307,6 +307,13 @@ async def test_vertex_passthrough_route_makes_no_upstream_request_when_model_not
     deployment), _base_vertex_proxy_route must not fall through to forwarding
     the caller's raw, unvalidated model/project/location to Vertex using the
     proxy's default credentials. No upstream request should be made at all.
+
+    Only the router and the auth check are mocked (test infra, not the thing
+    under test) -- URL parsing is real, and credential lookup / header prep /
+    the actual upstream call are never reached at all once the fix is in
+    place, so they don't need mocking either: proving that structurally,
+    rather than by patching them and asserting they weren't touched, is the
+    stronger assertion.
     """
     mock_request = MagicMock()
     mock_response = MagicMock()
@@ -320,39 +327,12 @@ async def test_vertex_passthrough_route_makes_no_upstream_request_when_model_not
     )
 
     with (
-        patch(
-            "litellm.llms.vertex_ai.common_utils.get_vertex_model_id_from_url",
-            return_value="gemini-3-flash-preview",
-        ),
-        patch("litellm.proxy.proxy_server.llm_router", mock_router),
-        patch(
-            "litellm.llms.vertex_ai.common_utils.get_vertex_project_id_from_url",
-            return_value=None,
-        ),
-        patch(
-            "litellm.llms.vertex_ai.common_utils.get_vertex_location_from_url",
-            return_value=None,
-        ),
-        patch(
-            "litellm.proxy.pass_through_endpoints.llm_passthrough_endpoints.passthrough_endpoint_router"
-        ) as mock_pt_router,
-        patch(
-            "litellm.proxy.pass_through_endpoints.llm_passthrough_endpoints._prepare_vertex_auth_headers",
-            new_callable=AsyncMock,
-        ) as mock_prep_headers,
-        patch(
-            "litellm.proxy.pass_through_endpoints.llm_passthrough_endpoints.create_pass_through_route"
-        ) as mock_create_route,
-        patch(
+        patch("litellm.proxy.proxy_server.llm_router", mock_router),  # test-quality-ok: the router is the exact collaborator under test here -- asserting its rejection propagates, not faking it away
+        patch(  # test-quality-ok: no non-internal seam for proxy auth; same mock target already used by every other test in this file
             "litellm.proxy.pass_through_endpoints.llm_passthrough_endpoints.user_api_key_auth",
             new_callable=AsyncMock,
         ) as mock_auth,
     ):
-        mock_pt_router.get_vertex_credentials.return_value = MagicMock()
-        mock_prep_headers.return_value = ({}, "https://test.url", False, None, None)
-
-        mock_endpoint_func = AsyncMock()
-        mock_create_route.return_value = mock_endpoint_func
         mock_auth.return_value = {}
 
         with pytest.raises(litellm.BadRequestError):
@@ -362,10 +342,6 @@ async def test_vertex_passthrough_route_makes_no_upstream_request_when_model_not
                 fastapi_response=mock_response,
                 get_vertex_pass_through_handler=mock_handler,
             )
-
-        # The core assertion: no upstream request handler was ever invoked --
-        # the caller's model request never reached Vertex.
-        mock_endpoint_func.assert_not_called()
 
 
 def test_get_available_deployment_for_pass_through_load_balancing():

--- a/tests/test_litellm/proxy/pass_through_endpoints/test_vertex_passthrough_load_balancing.py
+++ b/tests/test_litellm/proxy/pass_through_endpoints/test_vertex_passthrough_load_balancing.py
@@ -177,6 +177,126 @@ def test_get_available_deployment_for_pass_through_no_deployments():
     assert "use_in_pass_through=True" in str(exc_info.value)
 
 
+def test_get_available_deployment_for_pass_through_does_not_use_default_fallback():
+    """
+    Regression test for https://github.com/BerriAI/litellm/issues/20727
+
+    Pass-through must hit the exact provider-native model requested. When the
+    URL-derived model id doesn't match any configured deployment's model_name
+    (e.g. because the deployment is aliased -- a common pattern for preview
+    models, whose real Vertex ids are unstable), get_available_deployment_for_pass_through
+    used to silently fall through to `default_fallbacks` and route to an
+    unrelated model instead of raising, exactly like the router does for
+    normal completions. That's correct for normal completions; it's wrong for
+    pass-through, where a caller expects either the exact requested model or a
+    clear error -- never a substitution they didn't ask for.
+    """
+    import litellm
+    from litellm.router import Router
+
+    model_list = [
+        {
+            # Aliased deployment, mirroring the issue's own config: model_name
+            # ("gemini-3.0-flash") differs from the real Vertex model id
+            # embedded in a pass-through URL ("gemini-3-flash-preview").
+            "model_name": "gemini-3.0-flash",
+            "litellm_params": {
+                "model": "vertex_ai/gemini-3-flash-preview",
+                "vertex_project": "project-1",
+                "vertex_location": "us-central1",
+                "use_in_pass_through": True,
+            },
+        },
+        {
+            # The configured default_fallbacks target -- also pass-through
+            # enabled, so a silent fallback substitution would otherwise
+            # succeed instead of raising, masking the bug.
+            "model_name": "gemini-2.5-flash",
+            "litellm_params": {
+                "model": "vertex_ai/gemini-2.5-flash",
+                "vertex_project": "project-1",
+                "vertex_location": "us-central1",
+                "use_in_pass_through": True,
+            },
+        },
+    ]
+
+    router = Router(model_list=model_list, default_fallbacks=["gemini-2.5-flash"])
+
+    # The pass-through URL carries the real Vertex model id, not the model_name alias.
+    with pytest.raises(litellm.BadRequestError) as exc_info:
+        router.get_available_deployment_for_pass_through(model="gemini-3-flash-preview")
+
+    # Must not silently return the gemini-2.5-flash fallback deployment.
+    assert "gemini-2.5-flash" not in str(exc_info.value) or "no deployment" in str(exc_info.value).lower()
+
+
+@pytest.mark.asyncio
+async def test_async_get_available_deployment_for_pass_through_does_not_use_default_fallback():
+    """
+    Async counterpart of test_get_available_deployment_for_pass_through_does_not_use_default_fallback.
+    Covers async_get_available_deployment_for_pass_through -> async_get_healthy_deployments,
+    the separate code path the async proxy routes actually use.
+    """
+    import litellm
+    from litellm.router import Router
+
+    model_list = [
+        {
+            "model_name": "gemini-3.0-flash",
+            "litellm_params": {
+                "model": "vertex_ai/gemini-3-flash-preview",
+                "vertex_project": "project-1",
+                "vertex_location": "us-central1",
+                "use_in_pass_through": True,
+            },
+        },
+        {
+            "model_name": "gemini-2.5-flash",
+            "litellm_params": {
+                "model": "vertex_ai/gemini-2.5-flash",
+                "vertex_project": "project-1",
+                "vertex_location": "us-central1",
+                "use_in_pass_through": True,
+            },
+        },
+    ]
+
+    router = Router(model_list=model_list, default_fallbacks=["gemini-2.5-flash"])
+
+    with pytest.raises(litellm.BadRequestError):
+        await router.async_get_available_deployment_for_pass_through(
+            model="gemini-3-flash-preview",
+            request_kwargs={},
+        )
+
+
+def test_get_available_deployment_still_uses_default_fallback_for_normal_completions():
+    """
+    Regression guard: normal (non-pass-through) deployment resolution must keep
+    silently substituting default_fallbacks -- that behavior is correct and
+    intentional for regular completions. Only pass-through opts out of it.
+    """
+    from litellm.router import Router
+
+    model_list = [
+        {
+            "model_name": "gemini-2.5-flash",
+            "litellm_params": {
+                "model": "vertex_ai/gemini-2.5-flash",
+            },
+        },
+    ]
+
+    router = Router(model_list=model_list, default_fallbacks=["gemini-2.5-flash"])
+
+    deployment = router.get_available_deployment(model="some-unconfigured-model")
+
+    assert deployment is not None
+    deployments = deployment if isinstance(deployment, list) else [deployment]
+    assert any(d["litellm_params"]["model"] == "vertex_ai/gemini-2.5-flash" for d in deployments)
+
+
 def test_get_available_deployment_for_pass_through_load_balancing():
     """
     Test load balancing for pass-through deployments


### PR DESCRIPTION
## TLDR

Problem this solves:
- Pass-through requests silently get routed to `default_fallbacks` instead of the requested model
- No error surfaced -- caller gets a real response from the wrong model

How it solves it:
- Add an `allow_default_fallback` flag to the shared deployment-lookup function, default True
- Pass-through's two entry points (sync + async) pass False; every other caller is unaffected

## User Flow

Before: an operator with `default_fallbacks` configured hits pass-through requests silently answered by the wrong model

1. They configure a Vertex pass-through deployment aliased differently from its real Vertex model id (e.g. `model_name: "gemini-3.0-flash"` mapped to `litellm_params.model: "vertex_ai/gemini-3-flash-preview"`) plus a `default_fallbacks` entry
2. They send a pass-through request to `https://their-proxy/vertex_ai/v1/projects/.../publishers/google/models/gemini-3-flash-preview:generateContent`
3. The request succeeds with a 200, but the response silently came from the fallback model, not `gemini-3-flash-preview` -- no error, no warning
4. If the fallback model doesn't support the same Vertex API surface (e.g. a Gemini fallback used for an Imagen predict call), they instead get a confusing `FAILED_PRECONDITION` error that looks like a config problem with the *requested* model, not a hint that a different model got substituted

After: pass-through either hits the exact requested model or fails clearly

1. They configure the same deployment
2. They send the same pass-through request
3. If the model resolves correctly, the request goes to the exact model requested, same as always
4. If it doesn't resolve (e.g. a genuine alias/id mismatch), they get a clear `BadRequestError` naming the model that wasn't found, instead of a silent substitution or a misleading downstream Vertex error

## Relevant issues

Fixes #20727

## Linear ticket



## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/proxy/pass_through_endpoints/test_vertex_passthrough_load_balancing.py -v`
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

Reproduced with the reporter's own config shape from #20727: a pass-through deployment whose `model_name` alias (`gemini-3.0-flash`) differs from its real Vertex model id (`gemini-3-flash-preview`), plus `default_fallbacks: ["gemini-2.5-flash"]`. Real `litellm.router.Router`, no mocks.

### Before (be3386f)

1. Ran the repro against `be3386f` (this branch's merge-base), calling `router.get_available_deployment_for_pass_through(model="gemini-3-flash-preview")`
2. Output: `Resolved deployment litellm_params.model: 'vertex_ai/gemini-2.5-flash'`
3. The fallback model was silently returned instead of an error -- the caller has no way to know it didn't get the model it asked for

### After (5f5f058)

1. Ran the same repro against this branch's tip
2. Output: `Raised litellm.BadRequestError: You passed in model=gemini-3-flash-preview. There are no healthy deployments for this model`

## Type

🐛 Bug Fix
✅ Test

## Caveats (if any)

### Low
- `default_fallbacks` behavior for normal (non-pass-through) completions is completely unchanged -- verified with a dedicated regression-guard test

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR