### PR TITLE
fix(policy_engine): keep cross-mode guardrail stages active when a pipeline manages one mode

### DIFF
--- a/litellm/proxy/litellm_pre_call_utils.py
+++ b/litellm/proxy/litellm_pre_call_utils.py
@@ -3012,7 +3012,8 @@ def _apply_resolved_guardrails_to_metadata(
     # Combine existing guardrails with policy-resolved guardrails (no duplicates).
     # Drop a name only when pipelines cover every stage it supports: a pipeline
     # manages just its own mode, so the guardrail must stay in the flat list for
-    # its stages outside that mode (mode-scoped execution skips prevent doubles).
+    # its stages outside that mode. The executor's pre_call skips keyed on
+    # _pipeline_managed_guardrails prevent double runs at that stage.
     combined = set(existing_guardrails)
     combined.update(resolved_guardrails)
     combined -= fully_pipeline_covered_guardrails

--- a/litellm/proxy/litellm_pre_call_utils.py
+++ b/litellm/proxy/litellm_pre_call_utils.py
@@ -2991,6 +2991,7 @@ def _apply_resolved_guardrails_to_metadata(
 
     # Track pipeline-managed guardrails to exclude from independent execution
     pipeline_managed_guardrails: set = set()
+    fully_pipeline_covered_guardrails: Final = PolicyResolver.get_guardrails_fully_covered_by_pipelines(pipelines)
     if pipelines:
         pipeline_managed_guardrails = PolicyResolver.get_pipeline_managed_guardrails(pipelines)
         data[metadata_variable_name]["_guardrail_pipelines"] = pipelines
@@ -3008,11 +3009,13 @@ def _apply_resolved_guardrails_to_metadata(
     if not isinstance(existing_guardrails, list):
         existing_guardrails = []
 
-    # Combine existing guardrails with policy-resolved guardrails (no duplicates)
-    # Exclude pipeline-managed guardrails from the flat list
+    # Combine existing guardrails with policy-resolved guardrails (no duplicates).
+    # Drop a name only when pipelines cover every stage it supports: a pipeline
+    # manages just its own mode, so the guardrail must stay in the flat list for
+    # its stages outside that mode (mode-scoped execution skips prevent doubles).
     combined = set(existing_guardrails)
     combined.update(resolved_guardrails)
-    combined -= pipeline_managed_guardrails
+    combined -= fully_pipeline_covered_guardrails
     data[metadata_variable_name]["guardrails"] = list(combined)
 
     verbose_proxy_logger.debug("Policy engine: added guardrails to request metadata: %s", list(combined))

--- a/litellm/proxy/policy_engine/policy_resolver.py
+++ b/litellm/proxy/policy_engine/policy_resolver.py
@@ -11,6 +11,7 @@ Handles:
 from collections.abc import Sequence
 from typing import Final
 
+import litellm
 from litellm._logging import verbose_proxy_logger
 from litellm.types.guardrails import GuardrailEventHooks
 from litellm.types.proxy.policy_engine import (
@@ -29,21 +30,7 @@ def _plain_stage(hook: object) -> str | None:
     return None
 
 
-def _list_gated_stages_for_guardrail(guardrail_name: str) -> frozenset[str] | None:
-    """
-    The lifecycle stages where this guardrail only runs if its name is in the
-    request's flat guardrails list, or None when they cannot be determined
-    statically (enterprise tag-based Mode hooks, whose stages depend on
-    request tags).
-
-    An unregistered name or an event_hook of None yields an empty set: the
-    flat list never gates such a guardrail, so dropping the name from the
-    list cannot suppress anything.
-    """
-    from litellm.proxy.policy_engine.pipeline_executor import PipelineExecutor
-
-    callback: Final = PipelineExecutor.find_guardrail_callback(guardrail_name)
-    event_hook: Final = callback.event_hook if callback is not None else None
+def _gated_stages_for_event_hook(event_hook: object) -> frozenset[str] | None:
     if event_hook is None:
         return frozenset()
     hooks: Final = tuple(event_hook) if isinstance(event_hook, list) else (event_hook,)
@@ -51,6 +38,35 @@ def _list_gated_stages_for_guardrail(guardrail_name: str) -> frozenset[str] | No
     if any(stage is None for stage in stages):
         return None
     return frozenset(stage for stage in stages if stage is not None and stage != GuardrailEventHooks.logging_only.value)
+
+
+def _list_gated_stages_for_guardrail(guardrail_name: str) -> frozenset[str] | None:
+    """
+    The lifecycle stages where this guardrail only runs if its name is in the
+    request's flat guardrails list, or None when they cannot be determined
+    statically (enterprise tag-based Mode hooks, whose stages depend on
+    request tags).
+
+    Stages are unioned across every registered callback carrying the name:
+    one guardrail_name can map to several callbacks with different hooks
+    (e.g. Presidio registers a post_call output-masking sibling alongside the
+    configured one, and duplicate-name deployments are supported for load
+    balancing), and stripping the name gates all of them.
+
+    An unregistered name or an event_hook of None yields an empty set: the
+    flat list never gates such a guardrail, so dropping the name from the
+    list cannot suppress anything.
+    """
+    from litellm.integrations.custom_guardrail import CustomGuardrail
+
+    stage_sets: Final = tuple(
+        _gated_stages_for_event_hook(callback.event_hook)
+        for callback in litellm.callbacks
+        if isinstance(callback, CustomGuardrail) and callback.guardrail_name == guardrail_name
+    )
+    if any(stages is None for stages in stage_sets):
+        return None
+    return frozenset(stage for stages in stage_sets if stages is not None for stage in stages)
 
 
 class PolicyResolver:

--- a/litellm/proxy/policy_engine/policy_resolver.py
+++ b/litellm/proxy/policy_engine/policy_resolver.py
@@ -8,15 +8,49 @@ Handles:
 - Combining guardrails from multiple matching policies
 """
 
+from collections.abc import Sequence
 from typing import Final
 
 from litellm._logging import verbose_proxy_logger
+from litellm.types.guardrails import GuardrailEventHooks
 from litellm.types.proxy.policy_engine import (
     GuardrailPipeline,
     Policy,
     PolicyMatchContext,
     ResolvedPolicy,
 )
+
+
+def _plain_stage(hook: object) -> str | None:
+    if isinstance(hook, GuardrailEventHooks):
+        return hook.value
+    if isinstance(hook, str):
+        return hook
+    return None
+
+
+def _list_gated_stages_for_guardrail(guardrail_name: str) -> frozenset[str] | None:
+    """
+    The lifecycle stages where this guardrail only runs if its name is in the
+    request's flat guardrails list, or None when they cannot be determined
+    statically (enterprise tag-based Mode hooks, whose stages depend on
+    request tags).
+
+    An unregistered name or an event_hook of None yields an empty set: the
+    flat list never gates such a guardrail, so dropping the name from the
+    list cannot suppress anything.
+    """
+    from litellm.proxy.policy_engine.pipeline_executor import PipelineExecutor
+
+    callback: Final = PipelineExecutor.find_guardrail_callback(guardrail_name)
+    event_hook: Final = callback.event_hook if callback is not None else None
+    if event_hook is None:
+        return frozenset()
+    hooks: Final = tuple(event_hook) if isinstance(event_hook, list) else (event_hook,)
+    stages: Final = tuple(_plain_stage(hook) for hook in hooks)
+    if any(stage is None for stage in stages):
+        return None
+    return frozenset(stage for stage in stages if stage is not None and stage != GuardrailEventHooks.logging_only.value)
 
 
 class PolicyResolver:
@@ -252,6 +286,34 @@ class PolicyResolver:
             for step in pipeline.steps:
                 managed.add(step.guardrail)
         return managed
+
+    @staticmethod
+    def get_guardrails_fully_covered_by_pipelines(
+        pipelines: Sequence[tuple[str, GuardrailPipeline]],
+    ) -> frozenset[str]:
+        """
+        Guardrail names whose every list-gated stage is covered by the mode of
+        a pipeline naming them.
+
+        Only these may be dropped from the request's flat guardrails list. A
+        pipeline manages just its own mode, so a guardrail that also runs in a
+        stage no pipeline covers must stay in the list or that stage's
+        independent activation is silently suppressed.
+        """
+        managed_names: Final = frozenset(
+            step.guardrail for _policy_name, pipeline in pipelines for step in pipeline.steps
+        )
+        return frozenset(
+            name
+            for name in managed_names
+            if (gated_stages := _list_gated_stages_for_guardrail(name)) is not None
+            and gated_stages
+            <= frozenset(
+                pipeline.mode
+                for _policy_name, pipeline in pipelines
+                if any(step.guardrail == name for step in pipeline.steps)
+            )
+        )
 
     @staticmethod
     def get_all_resolved_policies(

--- a/litellm/proxy/policy_engine/policy_resolver.py
+++ b/litellm/proxy/policy_engine/policy_resolver.py
@@ -48,10 +48,11 @@ def _list_gated_stages_for_guardrail(guardrail_name: str) -> frozenset[str] | No
     request tags).
 
     Stages are unioned across every registered callback carrying the name:
-    one guardrail_name can map to several callbacks with different hooks
-    (e.g. Presidio registers a post_call output-masking sibling alongside the
-    configured one, and duplicate-name deployments are supported for load
-    balancing), and stripping the name gates all of them.
+    one guardrail_name can back several callbacks with different hooks, via
+    load-balanced duplicate-name deployments (init_guardrails) or sibling
+    registrations from a single initializer (presidio registers post_call
+    output callbacks next to the primary), and stripping the name gates
+    all of them.
 
     An unregistered name or an event_hook of None yields an empty set: the
     flat list never gates such a guardrail, so dropping the name from the

--- a/tests/test_litellm/proxy/test_litellm_pre_call_utils.py
+++ b/tests/test_litellm/proxy/test_litellm_pre_call_utils.py
@@ -5,6 +5,7 @@ import os
 import time
 from datetime import datetime, timezone
 from types import SimpleNamespace
+from typing import TYPE_CHECKING
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -43,6 +44,12 @@ from litellm.litellm_core_utils.initialize_dynamic_callback_params import (
 )
 from litellm.llms.bedrock.base_aws_llm import BaseAWSLLM
 from litellm.types.utils import CredentialItem
+
+if TYPE_CHECKING:
+    from litellm.integrations.custom_guardrail import CustomGuardrail
+    from litellm.proxy.policy_engine.attachment_registry import AttachmentRegistry
+    from litellm.proxy.policy_engine.policy_registry import PolicyRegistry
+    from litellm.types.proxy.policy_engine import Policy
 
 
 
@@ -4226,7 +4233,11 @@ async def test_add_guardrails_from_policy_engine():
     attachment_registry._initialized = False
 
 
-def _policy_engine_pipeline_registries(policies, monkeypatch, callbacks):
+def _policy_engine_pipeline_registries(
+    policies: "dict[str, Policy]",
+    monkeypatch: pytest.MonkeyPatch,
+    callbacks: "list[CustomGuardrail]",
+) -> "tuple[PolicyRegistry, AttachmentRegistry]":
     from litellm.proxy.policy_engine.attachment_registry import get_attachment_registry
     from litellm.proxy.policy_engine.policy_registry import get_policy_registry
     from litellm.types.proxy.policy_engine import PolicyAttachment
@@ -4244,14 +4255,16 @@ def _policy_engine_pipeline_registries(policies, monkeypatch, callbacks):
     return policy_registry, attachment_registry
 
 
-def _reset_policy_engine_registries(policy_registry, attachment_registry):
+def _reset_policy_engine_registries(
+    policy_registry: "PolicyRegistry", attachment_registry: "AttachmentRegistry"
+) -> None:
     policy_registry._policies = {}
     policy_registry._initialized = False
     attachment_registry._attachments = []
     attachment_registry._initialized = False
 
 
-def _word_guard_pipeline_policy(mode: str):
+def _word_guard_pipeline_policy(mode: str) -> "Policy":
     from litellm.types.proxy.policy_engine import (
         GuardrailPipeline,
         PipelineStep,

--- a/tests/test_litellm/proxy/test_litellm_pre_call_utils.py
+++ b/tests/test_litellm/proxy/test_litellm_pre_call_utils.py
@@ -4398,13 +4398,13 @@ async def test_pipeline_keeps_guardrail_with_stage_no_pipeline_can_cover(monkeyp
 
 
 @pytest.mark.asyncio
-async def test_pipeline_keeps_guardrail_when_sibling_callback_adds_stages(monkeypatch):
+async def test_pipeline_keeps_guardrail_when_same_name_deployment_adds_stages(monkeypatch):
     """
-    One guardrail_name can map to several registered callbacks (Presidio adds
-    a post_call output-masking sibling; duplicate-name deployments are a
-    supported load-balancing setup). Coverage must union stages across all of
-    them, so a pre_call pipeline does not strip a name whose sibling still
-    needs the flat list at post_call.
+    One guardrail_name can back several callbacks with different hooks:
+    load-balanced duplicate-name deployments, and presidio's initializer
+    registering post_call output siblings next to the primary. Coverage must
+    union stages across all of them, so a pre_call pipeline does not strip a
+    name another callback still needs in the flat list at post_call.
     """
     from litellm.integrations.custom_guardrail import CustomGuardrail
     from litellm.types.guardrails import GuardrailEventHooks
@@ -4428,6 +4428,35 @@ async def test_pipeline_keeps_guardrail_when_sibling_callback_adds_stages(monkey
         _reset_policy_engine_registries(policy_registry, attachment_registry)
 
     assert data["metadata"]["guardrails"] == ["word_guard"]
+
+
+@pytest.mark.asyncio
+async def test_pipeline_strips_guardrail_with_none_event_hook(monkeypatch):
+    """
+    A callback with event_hook None runs at every stage without consulting the
+    flat guardrails list, so dropping the name cannot suppress it and the
+    pre-LIT-6536 dedup behavior stands.
+    """
+    from litellm.integrations.custom_guardrail import CustomGuardrail
+
+    guardrail = CustomGuardrail(guardrail_name="word_guard", event_hook=None)
+    policy_registry, attachment_registry = _policy_engine_pipeline_registries(
+        {"input-pipeline": _word_guard_pipeline_policy("pre_call")},
+        monkeypatch,
+        callbacks=[guardrail],
+    )
+
+    data = {"model": "gpt-4", "messages": [{"role": "user", "content": "Hello"}], "metadata": {}}
+    try:
+        await add_guardrails_from_policy_engine(
+            data=data,
+            metadata_variable_name="metadata",
+            user_api_key_dict=UserAPIKeyAuth(api_key="test-key"),
+        )
+    finally:
+        _reset_policy_engine_registries(policy_registry, attachment_registry)
+
+    assert data["metadata"]["guardrails"] == []
 
 
 @pytest.mark.asyncio

--- a/tests/test_litellm/proxy/test_litellm_pre_call_utils.py
+++ b/tests/test_litellm/proxy/test_litellm_pre_call_utils.py
@@ -4226,6 +4226,164 @@ async def test_add_guardrails_from_policy_engine():
     attachment_registry._initialized = False
 
 
+def _policy_engine_pipeline_registries(policies, monkeypatch, callbacks):
+    from litellm.proxy.policy_engine.attachment_registry import get_attachment_registry
+    from litellm.proxy.policy_engine.policy_registry import get_policy_registry
+    from litellm.types.proxy.policy_engine import PolicyAttachment
+
+    monkeypatch.setattr(litellm, "callbacks", callbacks)
+
+    policy_registry = get_policy_registry()
+    policy_registry._policies = policies
+    policy_registry._initialized = True
+
+    attachment_registry = get_attachment_registry()
+    attachment_registry._attachments = [PolicyAttachment(policy=name, scope="*") for name in policies]
+    attachment_registry._initialized = True
+
+    return policy_registry, attachment_registry
+
+
+def _reset_policy_engine_registries(policy_registry, attachment_registry):
+    policy_registry._policies = {}
+    policy_registry._initialized = False
+    attachment_registry._attachments = []
+    attachment_registry._initialized = False
+
+
+def _word_guard_pipeline_policy(mode: str):
+    from litellm.types.proxy.policy_engine import (
+        GuardrailPipeline,
+        PipelineStep,
+        Policy,
+        PolicyGuardrails,
+    )
+
+    return Policy(
+        guardrails=PolicyGuardrails(add=["word_guard"]),
+        pipeline=GuardrailPipeline(mode=mode, steps=[PipelineStep(guardrail="word_guard")]),
+    )
+
+
+@pytest.mark.asyncio
+async def test_pipeline_keeps_cross_mode_guardrail_in_flat_list(monkeypatch):
+    """
+    Regression for a mode-blind strip: a guardrail supporting pre_call and
+    post_call, activated independently by one policy while another policy's
+    pre_call pipeline names it, must stay in the flat guardrails list so its
+    post_call stage keeps running (LIT-6536).
+    """
+    from litellm.integrations.custom_guardrail import CustomGuardrail
+    from litellm.types.proxy.policy_engine import Policy, PolicyGuardrails
+
+    guardrail = CustomGuardrail(guardrail_name="word_guard", event_hook=["pre_call", "post_call"])
+    policy_registry, attachment_registry = _policy_engine_pipeline_registries(
+        {
+            "activate-guard": Policy(guardrails=PolicyGuardrails(add=["word_guard"])),
+            "input-pipeline": _word_guard_pipeline_policy("pre_call"),
+        },
+        monkeypatch,
+        callbacks=[guardrail],
+    )
+
+    data = {"model": "gpt-4", "messages": [{"role": "user", "content": "Hello"}], "metadata": {}}
+    try:
+        await add_guardrails_from_policy_engine(
+            data=data,
+            metadata_variable_name="metadata",
+            user_api_key_dict=UserAPIKeyAuth(api_key="test-key"),
+        )
+    finally:
+        _reset_policy_engine_registries(policy_registry, attachment_registry)
+
+    assert data["metadata"]["guardrails"] == ["word_guard"]
+    assert data["metadata"]["_pipeline_managed_guardrails"] == {"word_guard"}
+
+
+@pytest.mark.asyncio
+async def test_pipelines_covering_every_stage_strip_guardrail_from_flat_list(monkeypatch):
+    """
+    When pipelines cover every stage the guardrail supports, the name is
+    dropped from the flat list so nothing runs it independently.
+    """
+    from litellm.integrations.custom_guardrail import CustomGuardrail
+
+    guardrail = CustomGuardrail(guardrail_name="word_guard", event_hook=["pre_call", "post_call"])
+    policy_registry, attachment_registry = _policy_engine_pipeline_registries(
+        {
+            "input-pipeline": _word_guard_pipeline_policy("pre_call"),
+            "output-pipeline": _word_guard_pipeline_policy("post_call"),
+        },
+        monkeypatch,
+        callbacks=[guardrail],
+    )
+
+    data = {"model": "gpt-4", "messages": [{"role": "user", "content": "Hello"}], "metadata": {}}
+    try:
+        await add_guardrails_from_policy_engine(
+            data=data,
+            metadata_variable_name="metadata",
+            user_api_key_dict=UserAPIKeyAuth(api_key="test-key"),
+        )
+    finally:
+        _reset_policy_engine_registries(policy_registry, attachment_registry)
+
+    assert data["metadata"]["guardrails"] == []
+
+
+@pytest.mark.asyncio
+async def test_pipeline_strips_guardrail_with_no_registered_callback(monkeypatch):
+    """
+    A pipeline-managed name with no registered callback is dropped from the
+    flat list: the name is inert there, so the pre-LIT-6536 behavior stands.
+    """
+    policy_registry, attachment_registry = _policy_engine_pipeline_registries(
+        {"input-pipeline": _word_guard_pipeline_policy("pre_call")},
+        monkeypatch,
+        callbacks=[],
+    )
+
+    data = {"model": "gpt-4", "messages": [{"role": "user", "content": "Hello"}], "metadata": {}}
+    try:
+        await add_guardrails_from_policy_engine(
+            data=data,
+            metadata_variable_name="metadata",
+            user_api_key_dict=UserAPIKeyAuth(api_key="test-key"),
+        )
+    finally:
+        _reset_policy_engine_registries(policy_registry, attachment_registry)
+
+    assert data["metadata"]["guardrails"] == []
+
+
+@pytest.mark.asyncio
+async def test_pipeline_keeps_guardrail_with_stage_no_pipeline_can_cover(monkeypatch):
+    """
+    A guardrail with a during_call stage can never be fully covered, since
+    pipelines only have pre_call and post_call modes, so it stays listed.
+    """
+    from litellm.integrations.custom_guardrail import CustomGuardrail
+
+    guardrail = CustomGuardrail(guardrail_name="word_guard", event_hook=["pre_call", "during_call"])
+    policy_registry, attachment_registry = _policy_engine_pipeline_registries(
+        {"input-pipeline": _word_guard_pipeline_policy("pre_call")},
+        monkeypatch,
+        callbacks=[guardrail],
+    )
+
+    data = {"model": "gpt-4", "messages": [{"role": "user", "content": "Hello"}], "metadata": {}}
+    try:
+        await add_guardrails_from_policy_engine(
+            data=data,
+            metadata_variable_name="metadata",
+            user_api_key_dict=UserAPIKeyAuth(api_key="test-key"),
+        )
+    finally:
+        _reset_policy_engine_registries(policy_registry, attachment_registry)
+
+    assert data["metadata"]["guardrails"] == ["word_guard"]
+
+
 @pytest.mark.asyncio
 async def test_add_guardrails_from_policy_engine_accepts_dynamic_policies_and_pops_from_data():
     """

--- a/tests/test_litellm/proxy/test_litellm_pre_call_utils.py
+++ b/tests/test_litellm/proxy/test_litellm_pre_call_utils.py
@@ -4398,6 +4398,71 @@ async def test_pipeline_keeps_guardrail_with_stage_no_pipeline_can_cover(monkeyp
 
 
 @pytest.mark.asyncio
+async def test_pipeline_keeps_guardrail_when_sibling_callback_adds_stages(monkeypatch):
+    """
+    One guardrail_name can map to several registered callbacks (Presidio adds
+    a post_call output-masking sibling; duplicate-name deployments are a
+    supported load-balancing setup). Coverage must union stages across all of
+    them, so a pre_call pipeline does not strip a name whose sibling still
+    needs the flat list at post_call.
+    """
+    from litellm.integrations.custom_guardrail import CustomGuardrail
+    from litellm.types.guardrails import GuardrailEventHooks
+
+    input_callback = CustomGuardrail(guardrail_name="word_guard", event_hook="pre_call")
+    output_sibling = CustomGuardrail(guardrail_name="word_guard", event_hook=GuardrailEventHooks.post_call)
+    policy_registry, attachment_registry = _policy_engine_pipeline_registries(
+        {"input-pipeline": _word_guard_pipeline_policy("pre_call")},
+        monkeypatch,
+        callbacks=[input_callback, output_sibling],
+    )
+
+    data = {"model": "gpt-4", "messages": [{"role": "user", "content": "Hello"}], "metadata": {}}
+    try:
+        await add_guardrails_from_policy_engine(
+            data=data,
+            metadata_variable_name="metadata",
+            user_api_key_dict=UserAPIKeyAuth(api_key="test-key"),
+        )
+    finally:
+        _reset_policy_engine_registries(policy_registry, attachment_registry)
+
+    assert data["metadata"]["guardrails"] == ["word_guard"]
+
+
+@pytest.mark.asyncio
+async def test_pipeline_keeps_guardrail_with_tag_based_mode(monkeypatch):
+    """
+    A tag-based Mode event_hook resolves its stages per request, so coverage
+    cannot be determined statically and the name must stay in the flat list.
+    """
+    from litellm.integrations.custom_guardrail import CustomGuardrail
+    from litellm.types.guardrails import Mode
+
+    guardrail = CustomGuardrail(
+        guardrail_name="word_guard",
+        event_hook=Mode(tags={"team": "security"}, default="pre_call"),
+    )
+    policy_registry, attachment_registry = _policy_engine_pipeline_registries(
+        {"input-pipeline": _word_guard_pipeline_policy("pre_call")},
+        monkeypatch,
+        callbacks=[guardrail],
+    )
+
+    data = {"model": "gpt-4", "messages": [{"role": "user", "content": "Hello"}], "metadata": {}}
+    try:
+        await add_guardrails_from_policy_engine(
+            data=data,
+            metadata_variable_name="metadata",
+            user_api_key_dict=UserAPIKeyAuth(api_key="test-key"),
+        )
+    finally:
+        _reset_policy_engine_registries(policy_registry, attachment_registry)
+
+    assert data["metadata"]["guardrails"] == ["word_guard"]
+
+
+@pytest.mark.asyncio
 async def test_add_guardrails_from_policy_engine_accepts_dynamic_policies_and_pops_from_data():
     """
     Test that add_guardrails_from_policy_engine accepts dynamic 'policies' from the request body


### PR DESCRIPTION
## TLDR

Problem this solves:

- A policy pipeline silently disabled its guardrail everywhere, not just its own mode
- Blocked content then flowed through requests and responses unchecked
- Hit all three LLM endpoints, both guardrail stages

How it solves it:

- Strip a name only when pipelines cover every stage it runs in
- Stages are unioned across all callbacks sharing the name
  - Covers load-balanced duplicate-name deployments and presidio's post_call output siblings
- Guardrails with stages outside the pipeline's mode stay independently active
- The executor's pre_call skips still prevent double runs inside the pipeline's own mode

## User Flow

Before: an admin who protects all traffic with a content guardrail adds a policy pipeline for the response stage, and the guardrail silently stops running everywhere, letting blocked content flow both ways

1. The admin's config activates a banned-words guardrail on all traffic through a policy, checking both requests and responses: POST https://litellm-domain/v1/chat/completions with a banned word returns 400 "Content blocked: keyword 'zebrafish' detected", and a clean prompt whose answer contains the banned word also comes back 400
2. The admin adds a second policy whose `pipeline` runs that same guardrail on the response stage (`mode: post_call`) and restarts the proxy
3. They resend the same POST https://litellm-domain/v1/chat/completions with the banned word in the prompt: HTTP 200 and a full answer about zebrafish comes back
4. They send the clean prompt that elicits the banned word: HTTP 200 and the response containing "zebrafish" reaches the client unchecked
5. The same 200 sail-through happens on POST https://litellm-domain/v1/responses and POST https://litellm-domain/v1/messages, and https://litellm-domain/ui/?page=logs shows every request billed and unblocked

After: the same config blocks banned content again in both directions

1. The admin's config activates a banned-words guardrail on all traffic through a policy, checking both requests and responses: POST https://litellm-domain/v1/chat/completions with a banned word returns 400 "Content blocked: keyword 'zebrafish' detected", and a clean prompt whose answer contains the banned word also comes back 400
2. The admin adds a second policy whose `pipeline` runs that same guardrail on the response stage (`mode: post_call`) and restarts the proxy
3. They resend the same POST https://litellm-domain/v1/chat/completions with the banned word in the prompt: HTTP 400 "Content blocked: keyword 'zebrafish' detected" (today the block fires on the model's answer, so the request still shows provider spend in the logs; blocking it before it leaves the gateway additionally needs #38721's mode-scoped execution skips)
4. They send the clean prompt that elicits the banned word: HTTP 400, and the "zebrafish" answer never reaches the client
5. POST https://litellm-domain/v1/responses and POST https://litellm-domain/v1/messages return the same 400 block on both prompts

## Relevant issues

Raised by Greptile on PR #38721 (https://github.com/BerriAI/litellm/pull/38721#discussion_r3890349823); the mode-blind strip dates back to #21177

## Linear ticket

Resolves LIT-6536

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Shared setup: each leg boots one no-DB proxy process per config with 2 uvicorn workers on a random free port, hitting real OpenAI gpt-5.4-mini. `word_guard` is a `litellm_content_filter` guardrail with `mode: [pre_call, post_call]`, `default_on: false`, blocking the word "zebrafish". Two configs, identical except for the pipeline policy:

```yaml
model_list:
  - model_name: gpt-5.4-mini
    litellm_params:
      model: openai/gpt-5.4-mini
      api_key: os.environ/OPENAI_API_KEY

guardrails:
  - guardrail_name: word_guard
    litellm_params:
      guardrail: litellm_content_filter
      mode: [pre_call, post_call]
      default_on: false
      blocked_words:
        - keyword: "zebrafish"
          action: BLOCK

policies:
  activate-guard:
    guardrails:
      add:
        - word_guard

  # pipeline config only; the control config stops at activate-guard
  input-pipeline:
    guardrails:
      add:
        - word_guard
    pipeline:
      mode: post_call
      steps:
        - guardrail: word_guard
          on_fail: block
          on_pass: allow

policy_attachments:
  - policy: activate-guard
    scope: "*"
  - policy: input-pipeline   # pipeline config only
    scope: "*"

general_settings:
  master_key: sk-repro-6536
```

Boot command per config (before leg at the merge base, after leg at the PR tip):

```bash
python litellm/proxy/proxy_cli.py --config <config>.yaml --port $PORT --num_workers 2
```

Six requests per config, all with `-H 'Authorization: Bearer sk-repro-6536' -H 'Content-Type: application/json' -w '\nHTTP %{http_code}\n'`. Leg A plants the banned word in the request; leg B is a clean prompt whose one-word answer is "zebrafish", so it can only be caught on the response:

```bash
# chat leg A / leg B
curl -sS -X POST http://localhost:$PORT/v1/chat/completions -d '{"model":"gpt-5.4-mini","messages":[{"role":"user","content":"Tell me a fun fact about the zebrafish."}]}'
curl -sS -X POST http://localhost:$PORT/v1/chat/completions -d '{"model":"gpt-5.4-mini","messages":[{"role":"user","content":"Join these three fragments into one single lowercase English word and reply with only that word: ze bra fish"}]}'
# responses leg A / leg B
curl -sS -X POST http://localhost:$PORT/v1/responses -d '{"model":"gpt-5.4-mini","input":"Tell me a fun fact about the zebrafish."}'
curl -sS -X POST http://localhost:$PORT/v1/responses -d '{"model":"gpt-5.4-mini","input":"Join these three fragments into one single lowercase English word and reply with only that word: ze bra fish"}'
# messages leg A / leg B
curl -sS -X POST http://localhost:$PORT/v1/messages -d '{"model":"gpt-5.4-mini","max_tokens":200,"messages":[{"role":"user","content":"Tell me a fun fact about the zebrafish."}]}'
curl -sS -X POST http://localhost:$PORT/v1/messages -d '{"model":"gpt-5.4-mini","max_tokens":200,"messages":[{"role":"user","content":"Join these three fragments into one single lowercase English word and reply with only that word: ze bra fish"}]}'
```

The block response, everywhere it appears below, is this exact body:

```json
{"error":{"message":"Content blocked: keyword 'zebrafish' detected","type":"None","param":"None","code":"400","provider_specific_fields":{"error":"Content blocked: keyword 'zebrafish' detected","keyword":"zebrafish","description":null,"guardrail_name":"word_guard","guardrail_mode":["pre_call","post_call"]}}}
```

### Before (5a0ed05765)

#### Control config (no pipeline)

1. chat leg A (port 23704): HTTP 400, block body above
2. chat leg B: HTTP 400, block body above (after the real model call)
3. responses leg A: HTTP 400, block body above
4. responses leg B: HTTP 400, block body above
5. messages leg A: HTTP 400, block body above
6. messages leg B: HTTP 400, block body above

#### Pipeline config (post_call pipeline added)

1. chat leg A (port 22728): HTTP 200, content `"Fun fact: zebrafish can **regrow damaged heart tissue** after injury, which is why scientists study them to learn more about healing in humans."`
2. chat leg B: HTTP 200, content `"zebrafish"` handed to the client unchecked
3. responses leg A: HTTP 200, fun fact about zebrafish returned
4. responses leg B: HTTP 200, answer `"zebrafish"` returned
5. messages leg A: HTTP 200, fun fact about zebrafish returned
6. messages leg B: HTTP 200, answer `"zebrafish"` returned

### After (808b5e90c5)

#### Control config (no pipeline)

1. chat leg A (port 45898): HTTP 400, block body above
2. chat leg B: HTTP 400, block body above (after the real model call)
3. responses leg A: HTTP 400, block body above
4. responses leg B: HTTP 400, block body above
5. messages leg A: HTTP 400, block body above
6. messages leg B: HTTP 400, block body above

#### Pipeline config (post_call pipeline added)

1. chat leg A (port 25645): HTTP 400, block body above
2. chat leg B: HTTP 400, block body above
3. responses leg A: HTTP 400, block body above
4. responses leg B: HTTP 400, block body above
5. messages leg A: HTTP 400, block body above
6. messages leg B: HTTP 400, block body above

QA observations:

- Before: suppression covered /v1/responses and /v1/messages too, both stages
- After: all three endpoints block again; control unchanged, no regression
- Pipeline-config leg A still reaches OpenAI, blocks on the response (#38721)
- Block body serializes `type`/`param` as string "None"; pre-existing, untouched

Commit ee3c6fa350 since this proof is docstring and test-only, so it cannot change proxy behavior

## Type

🐛 Bug Fix

## Caveats (if any)

### Medium

- With a post_call pipeline, the request-stage block still needs #38721's mode-scoped execution skips
  - Until then the guardrail catches banned content on the response instead, so the request reaches the provider
- Coverage math trusts post_call pipelines, which only execute once #38721 lands
  - A post_call-only guardrail named by one is stripped while nothing replaces it
  - Same suppression as before this PR, which stripped unconditionally
- A pre-existing executor bug (LIT-6587, fix in review at #39038) can re-wipe retained names
  - After an allowing pre_call pipeline run, it overwrites the request's guardrail list with the last step's own guardrail

### Low

- A pipeline-named guardrail with no registered callback is still stripped everywhere
  - Pre-existing behavior, kept: the name is inert in the flat list
- Guardrails using enterprise tag-based modes are conservatively never stripped from the list
- The `x-litellm-applied-guardrails` response header now includes the retained names
- Realtime in-session guardrail scanning resumes for retained names (pipelines never scanned in-session events, so this restores pre-pipeline coverage)
- Stale presidio siblings surviving re-init (pre-existing leak, LIT-6590) only widen the union
  - They make stripping rarer, never wider
- A PATCH mode change leaves `event_hook` stale until re-init (pre-existing, LIT-6591)
  - The strip decision reads the same stale value the runtime gate reads, so both stay consistent

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

- [x] ee3c6fa350 passes /live-pr-risk
