### PR TITLE
fix(anthropic_endpoints): return Anthropic type:error envelope for /v1/messages errors

### DIFF
--- a/litellm/anthropic_interface/exceptions/exceptions.py
+++ b/litellm/anthropic_interface/exceptions/exceptions.py
@@ -1,8 +1,9 @@
 """Anthropic error format type definitions."""
 
+from collections.abc import Mapping
 from typing import Literal
 
-from typing_extensions import Required, TypedDict
+from typing_extensions import NotRequired, ReadOnly, Required, TypedDict
 
 # Known Anthropic error types
 # Source: https://docs.anthropic.com/en/api/errors
@@ -23,6 +24,7 @@ class AnthropicErrorDetail(TypedDict):
 
     type: AnthropicErrorType
     message: str
+    provider_specific_fields: NotRequired[ReadOnly[Mapping[str, object]]]
 
 
 class AnthropicErrorResponse(TypedDict, total=False):

--- a/litellm/proxy/anthropic_endpoints/endpoints.py
+++ b/litellm/proxy/anthropic_endpoints/endpoints.py
@@ -9,7 +9,7 @@ from fastapi.responses import JSONResponse
 
 import litellm
 from litellm._logging import verbose_proxy_logger
-from litellm.anthropic_interface.exceptions import AnthropicExceptionMapping
+from litellm.anthropic_interface.exceptions import AnthropicErrorResponse, AnthropicExceptionMapping
 from litellm.integrations.custom_guardrail import ModifyResponseException
 from litellm.llms.anthropic.experimental_pass_through.context_management import (
     AnthropicContextManagementError,
@@ -28,6 +28,27 @@ from litellm.proxy.common_utils.http_parsing_utils import _read_request_body
 from litellm.types.utils import TokenCountResponse
 
 router: Final = APIRouter()
+
+
+def _anthropic_error_json_response(exc: ProxyException, request: Request) -> JSONResponse:
+    from litellm.proxy.proxy_server import (
+        _close_dangling_otel_server_span,  # pyright: ignore[reportPrivateUsage]  # proxy_server keeps the span-close helper private; error JSONResponses returned by the route must stamp the OTel server span like the global ProxyException handler does
+    )
+
+    status_code: Final = int(exc.code) if exc.code is not None and exc.code.isdigit() else 500
+    _close_dangling_otel_server_span(request, status_code, exc=exc)
+    envelope: Final = AnthropicExceptionMapping.transform_to_anthropic_error(
+        status_code=status_code,
+        raw_message=exc.message,
+        request_id=request.headers.get("x-request-id"),
+    )
+    if not exc.provider_specific_fields:
+        return JSONResponse(status_code=status_code, content=envelope, headers=exc.headers)
+    content: Final[AnthropicErrorResponse] = {
+        **envelope,
+        "error": {**envelope["error"], "provider_specific_fields": exc.provider_specific_fields},
+    }
+    return JSONResponse(status_code=status_code, content=content, headers=exc.headers)
 
 
 def _strip_total_tokens_from_anthropic_response(response: Any) -> None:
@@ -195,7 +216,7 @@ async def anthropic_response(
         verbose_proxy_logger.exception("litellm.proxy.proxy_server.anthropic_response(): Exception occured - %s", e)
 
         if isinstance(e, ProxyException):
-            raise
+            return _anthropic_error_json_response(e, request)
 
         # Extract model_id from request metadata (same as success path)
         litellm_metadata: Final = data.get("litellm_metadata", {}) or {}
@@ -216,15 +237,18 @@ async def anthropic_response(
         )
 
         if isinstance(e, HTTPException):
-            raise proxy_exception_from_http_exception(e, headers)
+            return _anthropic_error_json_response(proxy_exception_from_http_exception(e, headers), request)
 
         error_msg: Final = f"{e}"
-        raise ProxyException(
-            message=getattr(e, "message", error_msg),
-            type=getattr(e, "type", "None"),
-            param=getattr(e, "param", "None"),
-            code=getattr(e, "status_code", 500),
-            headers=headers,
+        return _anthropic_error_json_response(
+            ProxyException(
+                message=getattr(e, "message", error_msg),
+                type=getattr(e, "type", "None"),
+                param=getattr(e, "param", "None"),
+                code=getattr(e, "status_code", 500),
+                headers=headers,
+            ),
+            request,
         )
 
 

--- a/tests/test_litellm/proxy/anthropic_endpoints/test_endpoints.py
+++ b/tests/test_litellm/proxy/anthropic_endpoints/test_endpoints.py
@@ -125,11 +125,12 @@ class TestBlockedResponseUsage:
         mock_logging.post_call_failure_hook.assert_awaited_once()
 
 
-class TestProxyExceptionPassthrough:
+class TestProxyExceptionAnthropicEnvelope:
     @pytest.mark.asyncio
-    async def test_anthropic_response_reraises_proxy_exception_unwrapped(self):
-        """A 400 ProxyException from request validation must surface as-is,
-        not be re-wrapped into a code-500 ProxyException."""
+    async def test_anthropic_response_maps_proxy_exception_to_anthropic_envelope(self):
+        """LIT-6468: a 400 ProxyException from request validation must surface as
+        Anthropic's documented {"type": "error", "error": {...}} envelope with the
+        original status and message, not the OpenAI {"error": {...}} envelope."""
         import litellm.proxy.anthropic_endpoints.endpoints as ep
         import litellm.proxy.proxy_server as proxy_server
         from litellm.proxy._types import ProxyErrorTypes, ProxyException
@@ -140,6 +141,8 @@ class TestProxyExceptionPassthrough:
             param="metadata",
             code=400,
         )
+        request = MagicMock()
+        request.headers = {"x-request-id": "req_test_6468"}
 
         with (
             patch.object(ep, "_read_request_body", new=AsyncMock(return_value={})),
@@ -151,30 +154,61 @@ class TestProxyExceptionPassthrough:
             patch.object(proxy_server, "proxy_logging_obj") as mock_logging,
         ):
             mock_logging.post_call_failure_hook = AsyncMock()
-            with pytest.raises(ProxyException) as exc_info:
-                await ep.anthropic_response(
-                    fastapi_response=MagicMock(),
-                    request=MagicMock(),
-                    user_api_key_dict=MagicMock(),
-                )
+            response = await ep.anthropic_response(
+                fastapi_response=MagicMock(),
+                request=request,
+                user_api_key_dict=MagicMock(),
+            )
 
-        assert exc_info.value is exc
-        assert exc_info.value.code == "400"
-        assert exc_info.value.param == "metadata"
+        assert response.status_code == 400
+        body = json.loads(response.body)
+        assert body == {
+            "type": "error",
+            "error": {
+                "type": "invalid_request_error",
+                "message": "Invalid type for 'metadata': expected an object, but got a string instead.",
+            },
+            "request_id": "req_test_6468",
+        }
         mock_logging.post_call_failure_hook.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_anthropic_response_maps_429_to_rate_limit_error(self):
+        """The Anthropic error type follows the status code (429 -> rate_limit_error),
+        and a code-less exception falls back to 500 api_error."""
+        import litellm.proxy.anthropic_endpoints.endpoints as ep
+        from litellm.proxy._types import ProxyException
+
+        request = MagicMock()
+        request.headers = {}
+
+        response = ep._anthropic_error_json_response(
+            ProxyException(message="Rate limit exceeded", type="rate_limit_error", param=None, code=429),
+            request,
+        )
+        assert response.status_code == 429
+        assert json.loads(response.body)["error"]["type"] == "rate_limit_error"
+
+        fallback = ep._anthropic_error_json_response(
+            ProxyException(message="boom", type="None", param=None, code=None),
+            request,
+        )
+        assert fallback.status_code == 500
+        assert json.loads(fallback.body)["error"]["type"] == "api_error"
 
 
 class TestHttpExceptionDictDetail:
     @pytest.mark.asyncio
     async def test_anthropic_response_serializes_dict_detail_http_exception(self):
-        """LIT-6466: a post_call guardrail's HTTPException(detail=<dict>) must
-        surface with a clean message plus provider_specific_fields, matching
-        /v1/chat/completions and /v1/responses, not the str() of the exception."""
+        """LIT-6466 + LIT-6468: a post_call guardrail's HTTPException(detail=<dict>)
+        must surface as Anthropic's {"type": "error", "error": {...}} envelope with
+        the guardrail's clean message plus provider_specific_fields, not the str()
+        of the exception and not the OpenAI envelope."""
         from fastapi import HTTPException
 
         import litellm.proxy.anthropic_endpoints.endpoints as ep
         import litellm.proxy.proxy_server as proxy_server
-        from litellm.proxy._types import ProxyException, UserAPIKeyAuth
+        from litellm.proxy._types import UserAPIKeyAuth
 
         detail = {
             "error": "Content blocked: keyword 'kumquat' detected",
@@ -182,6 +216,8 @@ class TestHttpExceptionDictDetail:
             "guardrail": "keyword-block",
         }
         exc = HTTPException(status_code=400, detail=detail)
+        request = MagicMock()
+        request.headers = {}
 
         with (
             patch.object(ep, "_read_request_body", new=AsyncMock(return_value={})),  # test-quality-ok: endpoint reads the body via a module function; no injection seam
@@ -193,17 +229,19 @@ class TestHttpExceptionDictDetail:
             patch.object(proxy_server, "proxy_logging_obj") as mock_logging,  # test-quality-ok: module global imported at call time; no injection seam
         ):
             mock_logging.post_call_failure_hook = AsyncMock()
-            with pytest.raises(ProxyException) as exc_info:
-                await ep.anthropic_response(
-                    fastapi_response=MagicMock(),
-                    request=MagicMock(),
-                    user_api_key_dict=UserAPIKeyAuth(),
-                )
+            response = await ep.anthropic_response(
+                fastapi_response=MagicMock(),
+                request=request,
+                user_api_key_dict=UserAPIKeyAuth(),
+            )
 
-        assert exc_info.value.message == "Content blocked: keyword 'kumquat' detected"
-        assert "{'error'" not in exc_info.value.message
-        assert exc_info.value.provider_specific_fields == detail
-        assert exc_info.value.code == "400"
+        assert response.status_code == 400
+        body = json.loads(response.body)
+        assert body["type"] == "error"
+        assert body["error"]["type"] == "invalid_request_error"
+        assert body["error"]["message"] == "Content blocked: keyword 'kumquat' detected"
+        assert "{'error'" not in body["error"]["message"]
+        assert body["error"]["provider_specific_fields"] == detail
         mock_logging.post_call_failure_hook.assert_awaited_once()
 
 
@@ -215,7 +253,7 @@ class TestFailureHookRequestData:
         handler must pass that replaced dict, not the raw request body dict."""
         import litellm.proxy.anthropic_endpoints.endpoints as ep
         import litellm.proxy.proxy_server as proxy_server
-        from litellm.proxy._types import ProxyException, UserAPIKeyAuth
+        from litellm.proxy._types import UserAPIKeyAuth
 
         captured = {}
 
@@ -224,18 +262,23 @@ class TestFailureHookRequestData:
             captured["processor_data"] = self.data
             raise RuntimeError("provider timeout")
 
+        request = MagicMock()
+        request.headers = {}
+
         with (
             patch.object(ep, "_read_request_body", new=AsyncMock(return_value={"model": "claude-sonnet"})),
             patch.object(ep.ProxyBaseLLMRequestProcessing, "base_process_llm_request", new=fake_process),
             patch.object(proxy_server, "proxy_logging_obj") as mock_logging,
         ):
             mock_logging.post_call_failure_hook = AsyncMock()
-            with pytest.raises(ProxyException):
-                await ep.anthropic_response(
-                    fastapi_response=MagicMock(),
-                    request=MagicMock(),
-                    user_api_key_dict=UserAPIKeyAuth(),
-                )
+            response = await ep.anthropic_response(
+                fastapi_response=MagicMock(),
+                request=request,
+                user_api_key_dict=UserAPIKeyAuth(),
+            )
+
+        assert response.status_code == 500
+        assert json.loads(response.body)["error"]["message"] == "provider timeout"
 
         hook_request_data = mock_logging.post_call_failure_hook.await_args.kwargs["request_data"]
         assert hook_request_data is captured["processor_data"]


### PR DESCRIPTION
## TLDR

Problem this solves:

- Errors on `/v1/messages` came back in OpenAI's error envelope
- `type` and `param` were the literal string `"None"`
- Anthropic-format clients expect `{"type":"error","error":{...}}` per Anthropic's docs

How it solves it:

- The route now returns Anthropic's documented error envelope for every error it handles
- Error type is mapped from the status code (400 -> `invalid_request_error`, 429 -> `rate_limit_error`, ...)
- Guardrail detail from dict-detail blocks still rides along under `error.provider_specific_fields`
- `request_id` echoes the client's `x-request-id`, matching the existing context-management error path
- Response headers (`x-litellm-call-id`, ...) and OTel server-span error stamping are preserved

## User Flow

Before: a developer whose Anthropic-format app hits a guardrail block gets an OpenAI-shaped error with `"None"` strings, so their Anthropic error handling can't classify it

1. Their app sends POST https://litellm-domain/v1/messages with `{"model": "claude-sonnet-5", "messages": [...]}` and the message trips the admin's content guardrail
2. The response is HTTP 400 with `{"error": {"message": "Content blocked: keyword 'kumquat' detected", "type": "None", "param": "None", "code": "400"}}`
3. That is OpenAI's envelope, not the `{"type": "error", "error": {"type": ..., "message": ...}}` shape api.anthropic.com returns, and the error type reads as the string `"None"`
4. Their error handling, written against Anthropic's documented format, finds no `type: "error"` marker and no usable error type, so the block surfaces as an unclassified failure

After: the same request comes back exactly in Anthropic's documented error format

1. Their app sends the same POST https://litellm-domain/v1/messages and the message trips the same guardrail
2. The response is HTTP 400 with `{"type": "error", "error": {"type": "invalid_request_error", "message": "Content blocked: keyword 'kumquat' detected", "provider_specific_fields": {...}}, "request_id": "req-..."}`
3. That matches what api.anthropic.com itself returns for a 400, so their Anthropic error handling classifies it like any other invalid-request error, and the guardrail detail is still there under `error.provider_specific_fields`

## Relevant issues

## Linear ticket

Resolves LIT-6468

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Shared setup: proxy run from the worktree with `python litellm/proxy/proxy_cli.py --config config.yaml --port <port>` (before leg on 35768 at the merge base, after leg on 20535 at this PR's tip), real Anthropic API key, master key `sk-1234`

```yaml
model_list:
  - model_name: claude-sonnet-5
    litellm_params:
      model: anthropic/claude-sonnet-5
      api_key: os.environ/ANTHROPIC_API_KEY

guardrails:
  - guardrail_name: "keyword-block"
    litellm_params:
      guardrail: custom_guardrail.myCustomGuardrail
      mode: ["pre_call", "post_call"]
      default_on: true

general_settings:
  master_key: sk-1234
```

`custom_guardrail.py` raises `HTTPException(400, detail={"error": "Content blocked: keyword 'kumquat' detected", "keyword": "kumquat", "guardrail": "keyword-block"})` from `async_post_call_success_hook` when the request mentions kumquat, and the same from `async_pre_call_hook` for durian

Reference: what api.anthropic.com itself returns for a 400 (the target shape)

```
$ curl -sS -w '\nHTTP %{http_code}\n' https://api.anthropic.com/v1/messages -H "x-api-key: $ANTHROPIC_API_KEY" -H 'anthropic-version: 2023-06-01' -H 'content-type: application/json' -d '{"model":"claude-sonnet-5","max_tokens":-5,"messages":[{"role":"user","content":"hi"}]}'
{"type":"error","error":{"type":"invalid_request_error","message":"max_tokens: must be greater than or equal to 0"},"request_id":"req_011CebgCquxQ6fxUGmhUPnv1"}
HTTP 400
```

### Before (81c8c93bef)

#### /v1/messages post_call guardrail block (non-streaming)

1. `curl -sS -w '\nHTTP %{http_code}\n' http://localhost:35768/v1/messages -H 'Authorization: Bearer sk-1234' -H 'content-type: application/json' -H 'x-request-id: req-lit6468-demo' -d '{"model":"claude-sonnet-5","max_tokens":100,"messages":[{"role":"user","content":"Say the word kumquat back to me"}]}'`
2. OpenAI envelope with `"type":"None","param":"None"`, no `request_id`:

```
{"error":{"message":"Content blocked: keyword 'kumquat' detected","type":"None","param":"None","code":"400","provider_specific_fields":{"error":"Content blocked: keyword 'kumquat' detected","keyword":"kumquat","guardrail":"keyword-block","guardrail_name":"keyword-block","guardrail_mode":["pre_call","post_call"]}}}
HTTP 400
```

#### /v1/messages pre_call guardrail block with stream: true

1. `curl -sS -w '\nHTTP %{http_code}\n' http://localhost:35768/v1/messages -H 'Authorization: Bearer sk-1234' -H 'content-type: application/json' -d '{"model":"claude-sonnet-5","max_tokens":50,"stream":true,"messages":[{"role":"user","content":"Tell me about durian fruit"}]}'`
2. Same OpenAI envelope:

```
{"error":{"message":"Content blocked: keyword 'durian' detected","type":"None","param":"None","code":"400","provider_specific_fields":{"error":"Content blocked: keyword 'durian' detected","keyword":"durian","guardrail":"keyword-block-pre","guardrail_name":"keyword-block","guardrail_mode":["pre_call","post_call"]}}}
HTTP 400
```

#### /v1/messages invalid model

1. `curl -sS -w '\nHTTP %{http_code}\n' http://localhost:35768/v1/messages -H 'Authorization: Bearer sk-1234' -H 'content-type: application/json' -d '{"model":"no-such-model","max_tokens":50,"messages":[{"role":"user","content":"hi"}]}'`
2. OpenAI envelope again:

```
{"error":{"message":"anthropic_messages: Invalid model name passed in model=no-such-model. Call `/v1/models` to view available models for your key.","type":"None","param":"None","code":"400","provider_specific_fields":{"error":"anthropic_messages: Invalid model name passed in model=no-such-model. Call `/v1/models` to view available models for your key."}}}
HTTP 400
```

#### /v1/messages happy path

1. `curl -sS -w '\nHTTP %{http_code}\n' http://localhost:35768/v1/messages -H 'Authorization: Bearer sk-1234' -H 'content-type: application/json' -d '{"model":"claude-sonnet-5","max_tokens":50,"messages":[{"role":"user","content":"Reply with exactly: hello from QA"}]}'`
2. Real completion, HTTP 200:

```
{"model":"claude-sonnet-5","id":"msg_011Cebg9m1whJLUU4QVTvUq3","type":"message","role":"assistant","content":[{"type":"text","text":"hello from QA"}],"stop_reason":"end_turn",...}
HTTP 200
```

#### Anthropic python SDK

1. `anthropic.Anthropic(base_url="http://localhost:35768", api_key="sk-1234")` then `client.messages.create(...)` with the kumquat message
2. The SDK raises `BadRequestError` whose body is the OpenAI envelope with the `"None"` strings:

```
BadRequestError 400
body: {'error': {'message': "Content blocked: keyword 'kumquat' detected", 'type': 'None', 'param': 'None', 'code': '400', ...}}
```

#### /v1/chat/completions and /v1/responses (OpenAI-format surfaces)

1. Same kumquat/durian requests against `http://localhost:35768/v1/chat/completions` (non-streaming and `stream:true`) and `http://localhost:35768/v1/responses`
2. All three return the OpenAI envelope, e.g.:

```
{"error":{"message":"Content blocked: keyword 'kumquat' detected","type":"None","param":"None","code":"400","provider_specific_fields":{...}}}
HTTP 400
```

### After (562664f117)

#### /v1/messages post_call guardrail block (non-streaming)

1. Same curl as before against port 20535
2. Anthropic's documented envelope, `request_id` echoing the client's `x-request-id`, guardrail detail preserved:

```
{"type":"error","error":{"type":"invalid_request_error","message":"Content blocked: keyword 'kumquat' detected","provider_specific_fields":{"error":"Content blocked: keyword 'kumquat' detected","keyword":"kumquat","guardrail":"keyword-block","guardrail_name":"keyword-block","guardrail_mode":["pre_call","post_call"]}},"request_id":"req-lit6468-demo"}
HTTP 400
```

#### /v1/messages pre_call guardrail block with stream: true

1. Same curl as before against port 20535
2. Anthropic envelope:

```
{"type":"error","error":{"type":"invalid_request_error","message":"Content blocked: keyword 'durian' detected","provider_specific_fields":{"error":"Content blocked: keyword 'durian' detected","keyword":"durian","guardrail":"keyword-block-pre","guardrail_name":"keyword-block","guardrail_mode":["pre_call","post_call"]}}}
HTTP 400
```

#### /v1/messages invalid model

1. Same curl as before against port 20535
2. Anthropic envelope:

```
{"type":"error","error":{"type":"invalid_request_error","message":"anthropic_messages: Invalid model name passed in model=no-such-model. Call `/v1/models` to view available models for your key.","provider_specific_fields":{"error":"anthropic_messages: Invalid model name passed in model=no-such-model. Call `/v1/models` to view available models for your key."}}}
HTTP 400
```

3. Response headers still carry the LiteLLM ids: `x-litellm-call-id: 244ef570-e175-482f-ad76-6e5b778e4914`, `x-litellm-version: 1.100.0`

#### /v1/messages happy path

1. Same curl as before against port 20535
2. Identical 200 completion shape:

```
{"model":"claude-sonnet-5","id":"msg_011CebgFXKrFhKPE5jKAHbsm","type":"message","role":"assistant","content":[{"type":"text","text":"hello from QA"}],"stop_reason":"end_turn",...}
HTTP 200
```

#### Anthropic python SDK

1. Same SDK call against port 20535
2. Still `BadRequestError` (the SDK keys its error classes on the status code), body now the documented envelope:

```
BadRequestError 400
body: {'type': 'error', 'error': {'type': 'invalid_request_error', 'message': "Content blocked: keyword 'kumquat' detected", 'provider_specific_fields': {...}}}
```

#### /v1/chat/completions and /v1/responses (OpenAI-format surfaces)

1. Same requests against port 20535
2. All three responses are byte-identical to the Before leg (verified with `diff`), so the OpenAI-format surfaces are untouched

## Type

🐛 Bug Fix

## Caveats (if any)

### Medium

- Deliberate wire-format change: clients parsing the old OpenAI envelope on `/v1/messages` errors must adapt
  - Status codes and message text are unchanged; official Anthropic SDKs are unaffected (they key on status)
  - This is the ticket's requested behavior; the surface serves Anthropic-format clients by definition
- Errors raised before the route runs keep the OpenAI envelope
  - Auth failures (bad proxy key) and malformed multipart bodies exit through the global handler
- Mid-stream SSE error frames are still OpenAI-shaped
  - That serializer is shared streaming infrastructure owned by separate in-flight work

### Low

- `param` is no longer surfaced on this route's errors; Anthropic's envelope has no slot for it
- `/v1/messages/count_tokens` errors are unchanged (FastAPI `{"detail": ...}` wrapping, out of scope)
- The Rust gateway's separate `/v1/messages` implementation still emits its own OpenAI-ish envelope

Test expectation changes in `tests/test_litellm/proxy/anthropic_endpoints/test_endpoints.py`, all because the route now returns an Anthropic-envelope `JSONResponse` instead of re-raising `ProxyException`:

- `TestProxyExceptionPassthrough` -> `TestProxyExceptionAnthropicEnvelope`: `pytest.raises(ProxyException)` flips to asserting the returned 400 envelope (and a new 429 -> `rate_limit_error` case)
- `TestHttpExceptionDictDetail`: same flip; still proves the LIT-6466 clean message and the dict detail, now under `error.provider_specific_fields`
- `TestFailureHookRequestData`: same flip to a returned 500 envelope; the hook-data assertions it exists for are unchanged

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR



- [x] 562664f117 passes /live-pr-risk

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> This is an intentional wire-format change on a primary API surface; status and messages stay the same but clients that parsed the old OpenAI envelope on `/v1/messages` must adapt.
> 
> **Overview**
> **`/v1/messages` error responses now use Anthropic’s documented `{"type":"error","error":{...}}` shape** instead of bubbling `ProxyException` through the global OpenAI-style handler (which produced `"type":"None"` / `"param":"None"`).
> 
> A new `_anthropic_error_json_response` helper builds the envelope via `AnthropicExceptionMapping`, preserves status codes and LiteLLM headers, stamps OTel server spans like the global handler, echoes `x-request-id` as `request_id`, and maps HTTP status to Anthropic error types (e.g. 400 → `invalid_request_error`, 429 → `rate_limit_error`). Guardrail and other dict-detail failures still attach their payload under **`error.provider_specific_fields`**, now typed on `AnthropicErrorDetail`.
> 
> `ProxyException`, `HTTPException`, and generic failures in `anthropic_response` **return** this `JSONResponse` rather than re-raising. Tests were updated to assert the Anthropic envelope instead of `pytest.raises(ProxyException)`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 562664f117abaa7a98b6b6f85877cf5acf8d9ffd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
