### PR TITLE
fix(policy_engine): restore request guardrails list after pipeline allow

### DIFF
--- a/litellm/proxy/policy_engine/pipeline_executor.py
+++ b/litellm/proxy/policy_engine/pipeline_executor.py
@@ -6,6 +6,7 @@ pass/fail actions (allow, block, next, modify_response) and data forwarding.
 """
 
 import time
+from collections.abc import Sequence
 from typing import Any, Final, Literal
 
 import litellm
@@ -114,11 +115,7 @@ class PipelineExecutor:
 
             # Handle terminal actions
             if action == "allow":
-                return PipelineExecutionResult(
-                    terminal_action="allow",
-                    step_results=step_results,
-                    modified_data=working_data if working_data != data else None,
-                )
+                return _allow_result(step_results=step_results, working_data=working_data, request_data=data)
 
             if action == "block":
                 return PipelineExecutionResult(
@@ -138,11 +135,7 @@ class PipelineExecutor:
             # action == "next" → continue to next step
 
         # Ran out of steps without a terminal action → default allow
-        return PipelineExecutionResult(
-            terminal_action="allow",
-            step_results=step_results,
-            modified_data=working_data if working_data != data else None,
-        )
+        return _allow_result(step_results=step_results, working_data=working_data, request_data=data)
 
     @staticmethod
     async def _run_step(
@@ -249,6 +242,45 @@ class PipelineExecutor:
                 if callback.guardrail_name == guardrail_name:
                     return callback
         return None
+
+
+def _allow_result(
+    step_results: Sequence[PipelineStepResult],
+    working_data: dict,  # mutable-ok: same request-payload shape as execute_steps' data
+    request_data: dict,  # mutable-ok: same request-payload shape as execute_steps' data
+) -> PipelineExecutionResult:
+    """Build the terminal-allow result, propagating pipeline modifications without the per-step guardrail override."""
+    restored: Final = _restore_request_guardrails(working_data, request_data)
+    return PipelineExecutionResult(
+        terminal_action="allow",
+        step_results=list(step_results),  # mutable-ok: PipelineExecutionResult field is a list
+        modified_data=restored if restored != request_data else None,
+    )
+
+
+def _restore_request_guardrails(
+    working_data: dict,  # mutable-ok: same request-payload shape as execute_steps' data
+    request_data: dict,  # mutable-ok: same request-payload shape as execute_steps' data
+) -> dict:  # mutable-ok: merged back into the request dict, which downstream code mutates
+    """
+    Restore the request's own metadata["guardrails"] activation list.
+
+    _run_step overrides it to [step.guardrail] so should_run_guardrail() allows each
+    step; letting that override escape via modified_data permanently drops every
+    independently activated guardrail from later lifecycle stages (post_call, etc.).
+    """
+    working_metadata: Final = working_data.get("metadata")
+    if not isinstance(working_metadata, dict):
+        return working_data
+    request_metadata: Final = request_data.get("metadata")
+    original_guardrails: Final = request_metadata.get("guardrails") if isinstance(request_metadata, dict) else None
+    stripped: Final = {k: v for k, v in working_metadata.items() if k != "guardrails"}  # mutable-ok: request dict
+    if original_guardrails is not None:
+        restored: Final = {**stripped, "guardrails": original_guardrails}  # mutable-ok: request dict
+        return {**working_data, "metadata": restored}  # mutable-ok: request dict
+    if not stripped and not isinstance(request_metadata, dict):
+        return {k: v for k, v in working_data.items() if k != "metadata"}  # mutable-ok: request dict
+    return {**working_data, "metadata": stripped}  # mutable-ok: request dict
 
 
 def _pipeline_action_for_outcome(step: PipelineStep, outcome: str) -> str:

--- a/tests/test_litellm/proxy/policy_engine/test_pipeline_executor.py
+++ b/tests/test_litellm/proxy/policy_engine/test_pipeline_executor.py
@@ -750,6 +750,106 @@ async def test_single_step_pipeline_allow(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_allow_restores_independent_guardrails_list(monkeypatch):
+    """
+    Request activates an independent guardrail; an unrelated pipeline runs and allows.
+    Expected: no modified_data escapes, so the request's guardrails list survives
+    and the independent guardrail still runs at later lifecycle stages (post_call).
+    Regression: LIT-6587 (pipeline clobbered the list with its last step's guardrail).
+    """
+    pipeline_guard = AlwaysPassGuardrail(guardrail_name="input-scan")
+
+    pipeline = GuardrailPipeline(
+        mode="pre_call",
+        steps=[PipelineStep(guardrail="input-scan", on_fail="block", on_pass="allow")],
+    )
+
+    monkeypatch.setattr(litellm, "callbacks", [pipeline_guard])
+
+    data = {
+        "messages": [{"role": "user", "content": "clean content"}],
+        "metadata": {"guardrails": ["independent-output-guard"]},
+    }
+    result = await PipelineExecutor.execute_steps(
+        steps=pipeline.steps,
+        mode=pipeline.mode,
+        data=data,
+        user_api_key_dict=MagicMock(),
+        call_type="completion",
+        policy_name="input-pipeline-policy",
+    )
+
+    assert pipeline_guard.calls == 1
+    assert result.terminal_action == "allow"
+    propagated = result.modified_data or data
+    assert propagated["metadata"]["guardrails"] == ["independent-output-guard"]
+    assert data["metadata"]["guardrails"] == ["independent-output-guard"]
+
+
+@pytest.mark.asyncio
+async def test_allow_does_not_leak_guardrails_into_bare_request(monkeypatch):
+    """A request without metadata must not gain a metadata.guardrails list from the pipeline."""
+    pipeline_guard = AlwaysPassGuardrail(guardrail_name="input-scan")
+
+    pipeline = GuardrailPipeline(
+        mode="pre_call",
+        steps=[PipelineStep(guardrail="input-scan", on_fail="block", on_pass="allow")],
+    )
+
+    monkeypatch.setattr(litellm, "callbacks", [pipeline_guard])
+
+    data = {"messages": [{"role": "user", "content": "clean content"}]}
+    result = await PipelineExecutor.execute_steps(
+        steps=pipeline.steps,
+        mode=pipeline.mode,
+        data=data,
+        user_api_key_dict=MagicMock(),
+        call_type="completion",
+        policy_name="input-pipeline-policy",
+    )
+
+    assert result.terminal_action == "allow"
+    propagated = result.modified_data or data
+    assert "guardrails" not in propagated.get("metadata", {})
+    assert "metadata" not in data
+
+
+@pytest.mark.asyncio
+async def test_data_forwarding_keeps_changes_and_restores_guardrails_list(monkeypatch):
+    """A pass_data pipeline's modifications propagate while the request's guardrails list is restored."""
+    pii_guard = PiiMaskingGuardrail(guardrail_name="pii-masker")
+    content_guard = ContentCheckGuardrail(guardrail_name="content-check")
+
+    pipeline = GuardrailPipeline(
+        mode="pre_call",
+        steps=[
+            PipelineStep(guardrail="pii-masker", on_fail="block", on_pass="next", pass_data=True),
+            PipelineStep(guardrail="content-check", on_fail="block", on_pass="allow"),
+        ],
+    )
+
+    monkeypatch.setattr(litellm, "callbacks", [pii_guard, content_guard])
+
+    data = {
+        "messages": [{"role": "user", "content": "Hello John Smith"}],
+        "metadata": {"guardrails": ["independent-output-guard"]},
+    }
+    result = await PipelineExecutor.execute_steps(
+        steps=pipeline.steps,
+        mode=pipeline.mode,
+        data=data,
+        user_api_key_dict=MagicMock(),
+        call_type="completion",
+        policy_name="pii-then-safety",
+    )
+
+    assert result.terminal_action == "allow"
+    assert result.modified_data is not None
+    assert result.modified_data["messages"][0]["content"] == "Hello [REDACTED]"
+    assert result.modified_data["metadata"]["guardrails"] == ["independent-output-guard"]
+
+
+@pytest.mark.asyncio
 async def test_step_results_include_duration(monkeypatch):
     """Step results should include timing information."""
     guard = AlwaysPassGuardrail(guardrail_name="timed")


### PR DESCRIPTION
## TLDR

Problem this solves:

- A guardrail pipeline permanently replaced the request's guardrail activation list
- Every independently attached guardrail then silently skipped later stages (post_call, during_call)
- Example: an output content filter never ran once any unrelated pre_call pipeline was attached

How it solves it:

- Restore the request's own guardrails list when a pipeline finishes with allow
- Pipeline data changes (masking, rewrites) still propagate unchanged

## User Flow

Before: attaching an unrelated pre_call pipeline to a model silently disables its post_call content filter

1. The proxy admin attaches two policies to `gpt-5.4-mini`: one adds a post_call content filter blocking the word "zanzibar", the other runs an unrelated pre_call input-scan pipeline
2. A developer sends POST https://litellm-domain/v1/chat/completions with `"model": "gpt-5.4-mini"` and a prompt asking the model to reply with exactly "zanzibar"
3. The response comes back 200 with `"content": "zanzibar"`: the banned word reaches the developer and nothing mentions the content filter
4. The same request to `gpt-5.4-mini-control`, an identical model with only the content-filter policy attached, returns 400 `Content blocked: keyword 'zanzibar' detected`, so the filter itself works

After: the same request is blocked by the post_call filter even with the pipeline attached

1. The proxy admin attaches the same two policies to `gpt-5.4-mini`
2. The developer sends the same POST https://litellm-domain/v1/chat/completions with `"model": "gpt-5.4-mini"`
3. The response is now 400 `Content blocked: keyword 'zanzibar' detected`, naming guardrail `output-word-block`, mode post_call
4. A request with a banned input word still returns 400 blocked by the pipeline's own `input-scan` guardrail, so the pipeline keeps working

## Relevant issues

## Linear ticket

Resolves LIT-6587

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

All runs hit a live DB-less proxy with real OpenAI calls. Shared config (`repro_config.yaml`): two models routing to `openai/gpt-5.4-mini`; guardrail `output-word-block` (litellm_content_filter, post_call, blocks "zanzibar", default_on false) attached to both via policy `independent-output-policy`; guardrail `input-scan` (pre_call, blocks "picklewombat") run as a single-step pre_call pipeline in policy `input-pipeline-policy` attached to `gpt-5.4-mini` only

```yaml
model_list:
  - model_name: gpt-5.4-mini
    litellm_params:
      model: openai/gpt-5.4-mini
      api_key: os.environ/OPENAI_API_KEY
  - model_name: gpt-5.4-mini-control
    litellm_params:
      model: openai/gpt-5.4-mini
      api_key: os.environ/OPENAI_API_KEY

guardrails:
  - guardrail_name: output-word-block
    litellm_params:
      guardrail: litellm_content_filter
      mode: post_call
      default_on: false
      blocked_words:
        - keyword: "zanzibar"
          action: BLOCK
  - guardrail_name: input-scan
    litellm_params:
      guardrail: litellm_content_filter
      mode: pre_call
      default_on: false
      blocked_words:
        - keyword: "picklewombat"
          action: BLOCK

policies:
  independent-output-policy:
    guardrails:
      add: [output-word-block]
  input-pipeline-policy:
    guardrails:
      add: [input-scan]
    pipeline:
      mode: pre_call
      steps:
        - guardrail: input-scan
          on_fail: block
          on_pass: allow

policy_attachments:
  - policy: independent-output-policy
    models: [gpt-5.4-mini, gpt-5.4-mini-control]
  - policy: input-pipeline-policy
    models: [gpt-5.4-mini]

general_settings:
  master_key: sk-lit6587-qa
```

Regression window (bug leg = ask `gpt-5.4-mini` to reply with the banned output word "zanzibar"):

| Checkpoint | Commit | Bug leg | Control | Pipeline alive |
|---|---|---|---|---|
| Pipeline feature (#21177) | 08b61f49a4 | 500 NameError | 403 blocked | 500 NameError |
| Clobber introduced (#21188) | 96802e177b | 200 "zanzibar" | 403 blocked | 400 blocked |
| Merge base | f93d9b6b67 | 200 "zanzibar" | 400 blocked | 400 blocked |
| This fix | 92b46538e1 | 400 blocked | 400 blocked | 400 blocked |

At #21177 every pipeline request failed with `name 'copy' is not defined`; #21188 made pipelines run and introduced this bug in the same commit. It even saved `original_guardrails` intending to restore it, never used it, and a later lint fix (6caedfd2a5) deleted the variable instead of completing the restore

### Before (f93d9b6b67)

#### post_call filter on the pipeline model

1. `curl -sS -X POST http://localhost:34712/v1/chat/completions -H 'Authorization: Bearer sk-lit6587-qa' -H 'Content-Type: application/json' -d '{"model": "gpt-5.4-mini", "messages": [{"role": "user", "content": "Reply with exactly this single word and nothing else: zanzibar"}]}'`
2. `{"id":"chatcmpl-EJ5lv7S6L28xWmcb2wVjdGB4KF5jZ",...,"choices":[{"finish_reason":"stop","index":0,"message":{"content":"zanzibar","role":"assistant",...}}],...}` (200, banned word returned)

#### control model without the pipeline blocks

1. `curl -sS -X POST http://localhost:34712/v1/chat/completions -H 'Authorization: Bearer sk-lit6587-qa' -H 'Content-Type: application/json' -d '{"model": "gpt-5.4-mini-control", "messages": [{"role": "user", "content": "Reply with exactly this single word and nothing else: zanzibar"}]}'`
2. `{"error":{"message":"Content blocked: keyword 'zanzibar' detected",...,"code":"400","provider_specific_fields":{...,"guardrail_name":"output-word-block","guardrail_mode":"post_call"}}}`

#### the pipeline itself runs

1. `curl -sS -X POST http://localhost:34712/v1/chat/completions -H 'Authorization: Bearer sk-lit6587-qa' -H 'Content-Type: application/json' -d '{"model": "gpt-5.4-mini", "messages": [{"role": "user", "content": "Tell me about picklewombat"}]}'`
2. `{"error":{"message":"Content blocked: keyword 'picklewombat' detected",...,"code":"400","provider_specific_fields":{...,"guardrail_name":"input-scan","guardrail_mode":"pre_call"}}}`

### After (92b46538e1)

#### post_call filter on the pipeline model

1. `curl -sS -X POST http://localhost:23285/v1/chat/completions -H 'Authorization: Bearer sk-lit6587-qa' -H 'Content-Type: application/json' -d '{"model": "gpt-5.4-mini", "messages": [{"role": "user", "content": "Reply with exactly this single word and nothing else: zanzibar"}]}'`
2. `{"error":{"message":"Content blocked: keyword 'zanzibar' detected",...,"code":"400","provider_specific_fields":{...,"guardrail_name":"output-word-block","guardrail_mode":"post_call"}}}`

#### control model without the pipeline blocks

1. `curl -sS -X POST http://localhost:23285/v1/chat/completions -H 'Authorization: Bearer sk-lit6587-qa' -H 'Content-Type: application/json' -d '{"model": "gpt-5.4-mini-control", "messages": [{"role": "user", "content": "Reply with exactly this single word and nothing else: zanzibar"}]}'`
2. `{"error":{"message":"Content blocked: keyword 'zanzibar' detected",...,"code":"400","provider_specific_fields":{...,"guardrail_name":"output-word-block","guardrail_mode":"post_call"}}}`

#### the pipeline itself runs

1. `curl -sS -X POST http://localhost:23285/v1/chat/completions -H 'Authorization: Bearer sk-lit6587-qa' -H 'Content-Type: application/json' -d '{"model": "gpt-5.4-mini", "messages": [{"role": "user", "content": "Tell me about picklewombat"}]}'`
2. `{"error":{"message":"Content blocked: keyword 'picklewombat' detected",...,"code":"400","provider_specific_fields":{...,"guardrail_name":"input-scan","guardrail_mode":"pre_call"}}}`

## Type

🐛 Bug Fix

## Caveats (if any)

### Low

- Pre-existing, untouched here: a pass_data step whose guardrail returns a partial dict replaces request metadata wholesale, dropping unrelated keys
- POST /policies/test-pipeline responses no longer include the leaked `guardrails` key in `modified_data.metadata`; that key was the bug artifact itself, and the dashboard's test-pipeline view does not render it

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

- [x] 92b46538e1 passes /live-pr-risk
