### PR TITLE
fix(ui): let the auto-router scoring tier list follow the theme

### DIFF
--- a/ui/litellm-dashboard/src/components/add_model/ClassificationMethodConfig.tsx
+++ b/ui/litellm-dashboard/src/components/add_model/ClassificationMethodConfig.tsx
@@ -111,7 +111,7 @@ const HowClassificationWorks: React.FC<{ value: ComplexityRouterConfigValue }> =
         <strong className="block mb-2 font-semibold">How Classification Works</strong>
         <span className="text-[13px] text-muted-foreground">{scoringExplanation(value)}</span>
         {scorerRuns && ranges && (
-          <ul style={{ marginTop: 8, marginBottom: 0, paddingLeft: 20, fontSize: 13, color: "rgba(0, 0, 0, 0.45)" }}>
+          <ul className="mt-2 pl-5 text-[13px] text-muted-foreground">
             <li>
               <strong>{effectiveTierLabel("SIMPLE", value.tier_labels)}</strong>: Score &lt; {ranges.simpleMedium}
             </li>

--- a/ui/litellm-dashboard/src/components/add_model/ComplexityRouterConfig.test.tsx
+++ b/ui/litellm-dashboard/src/components/add_model/ComplexityRouterConfig.test.tsx
@@ -80,6 +80,14 @@ describe("ComplexityRouterConfig", () => {
     expect(screen.getByText(/Score > 0.60/)).toBeInTheDocument();
   });
 
+  it("leaves the score threshold list color to the theme instead of an inline style", () => {
+    renderWithProviders(<ComplexityRouterConfig {...baseProps} />);
+    fireEvent.click(screen.getByText("Advanced: Classification Method"));
+    const list = screen.getByText(/Score < 0.15/).closest<HTMLUListElement>("ul");
+    expect(list).toBeInTheDocument();
+    expect(list?.style.color).toBe("");
+  });
+
   it("should default to heuristic and hide classifier model/timeout fields", () => {
     renderWithProviders(<ComplexityRouterConfig modelInfo={mockModelInfo} value={defaultValue} onChange={vi.fn()} />);
     expect(screen.getByText("Advanced: Classification Method")).toBeInTheDocument();

--- a/ui/litellm-dashboard/src/components/add_model/ComplexityRouterConfig.test.tsx
+++ b/ui/litellm-dashboard/src/components/add_model/ComplexityRouterConfig.test.tsx
@@ -85,6 +85,7 @@ describe("ComplexityRouterConfig", () => {
     fireEvent.click(screen.getByText("Advanced: Classification Method"));
     const list = screen.getByText(/Score < 0.15/).closest<HTMLUListElement>("ul");
     expect(list).toBeInTheDocument();
+    expect(list).toHaveClass("text-muted-foreground");
     expect(list?.style.color).toBe("");
   });
 


### PR DESCRIPTION
## TLDR

Problem this solves:

- Auto-router scoring tier list is invisible in dark mode
- The list hardcoded 45% black text via an inline style

How it solves it:

- Swap the inline style for the theme's muted-foreground token
- Same pattern the rest of the card already uses

## User Flow

Before: an admin using the dashboard in dark mode cannot read the score thresholds

1. They open http://localhost:4000/ui/?page=models with the dashboard in dark mode, go to the Auto-Routers tab and click Add Auto Router
2. They expand Detailed Configuration, then Advanced: Classification Method, then Advanced scoring
3. The How Classification Works card shows the intro paragraph fine, but the Simple/Medium/Complex/Reasoning threshold list below it renders black on black and is only visible when text-selected

After: the same list is legible in both themes

1. They open the same page in dark mode and expand the same three sections
2. The threshold list renders in the same muted grey as the paragraph above it
3. Switching to light mode, the list stays legible and now matches the card's other text exactly

## Relevant issues

- Reported directly from a dark mode session, no tracked issue
- Same defect class as #37651, which converted inline color literals to theme tokens but missed this file. The `rgba(0, 0, 0, 0.45)` literal was the last one in the dashboard, an antd default that survived the shadcn migration
- One known sibling of the class remains in `skill_detail.tsx` (hardcoded hex palette on an unrelated page), left out to keep this scoped

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Setup: proxy on localhost:4000 (`python litellm/proxy/proxy_cli.py --config litellm/proxy/dev_config.yaml`), UI dev server on localhost:3000 (`npm run dev` in ui/litellm-dashboard), dashboard in dark mode

### Before (3829418878)

1. Open http://localhost:3000/models-and-endpoints/ in dark mode, Auto-Routers tab, Add Auto Router
2. Expand Detailed Configuration, Advanced: Classification Method, Advanced scoring
3. The tier list under How Classification Works is unreadable; computed style on the `<ul>` is `color: rgba(0, 0, 0, 0.45)` from its inline style, on a `bg-muted` card that is near black in dark mode

### After (23d0cf5566)

1. Same steps on the same rig
2. The tier list renders in the theme's muted grey; the `<ul>` carries no inline style and its computed color follows the `.dark` class (verified by toggling the theme live on the open dialog: dark and light both legible)

Dark mode:

<img width="1190" height="353" alt="tier list legible in dark mode" src="https://github.com/user-attachments/assets/cb35f4da-2b45-4814-928a-91bda8b2edc8" />

Light mode regression check:

<img width="1190" height="353" alt="tier list unchanged in light mode" src="https://github.com/user-attachments/assets/24eb36a6-4771-4920-bdd3-98c48a8ee521" />

## Type

🐛 Bug Fix

## Caveats (if any)

### Low

- Light mode shade shifts slightly, from the antd literal to the theme token the paragraph above already uses

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
