### PR TITLE
fix(vector-stores): resolve embedding aliases at search time

### DIFF
--- a/litellm/proxy/vector_store_endpoints/endpoints.py
+++ b/litellm/proxy/vector_store_endpoints/endpoints.py
@@ -1,3 +1,4 @@
+from types import MappingProxyType
 from typing import (
     Annotated,
     Any,  # noqa: TID251  # jsonify_object in proxy/utils.py is annotated with a bare dict
@@ -66,29 +67,26 @@ async def _update_request_data_with_litellm_managed_vector_store_registry(
 
         if "litellm_params" in vector_store_to_run:
             litellm_params = vector_store_to_run.get("litellm_params", {}) or {}
-            # Resolve ``litellm_embedding_config`` here, at request-handling
-            # time, instead of at row-creation time. The resolved
-            # ``api_key`` / ``api_base`` / ``api_version`` lives only in
-            # this per-request ``data`` dict and is never persisted.
-            # Legacy rows that already carry a resolved (cleartext)
-            # ``litellm_embedding_config`` skip the lookup and pass through
-            # unchanged so the embed call keeps working.
             embedding_model: Final = litellm_params.get("litellm_embedding_model")
-            if embedding_model and not litellm_params.get("litellm_embedding_config"):
+            if embedding_model:
                 from litellm.proxy.proxy_server import prisma_client
 
                 resolved_config: Final = await _resolve_embedding_config(
                     embedding_model=embedding_model, prisma_client=prisma_client
                 )
                 if resolved_config:
-                    # Build a fresh dict via spread instead of mutating
-                    # ``litellm_params`` in place — the registry hands back
-                    # a reference to its cached object, so an in-place
-                    # update would persist the resolved cleartext into the
-                    # in-memory cache for the lifetime of the process.
+                    embedding_config: Final = MappingProxyType(
+                        {
+                            **resolved_config,
+                            **(litellm_params.get("litellm_embedding_config") or MappingProxyType({})),
+                        }
+                    )
                     litellm_params = {
                         **litellm_params,
-                        "litellm_embedding_config": resolved_config,
+                        "litellm_embedding_model": embedding_config.get("model", embedding_model),
+                        "litellm_embedding_config": {
+                            key: value for key, value in embedding_config.items() if key != "model"
+                        },
                     }
             data.update(litellm_params)
     return data

--- a/litellm/proxy/vector_store_endpoints/management_endpoints.py
+++ b/litellm/proxy/vector_store_endpoints/management_endpoints.py
@@ -10,6 +10,8 @@ All /vector_store management endpoints
 
 import copy
 import json
+from collections.abc import Mapping
+from types import MappingProxyType
 from typing import TYPE_CHECKING, Any, Final
 
 from fastapi import APIRouter, Depends, HTTPException
@@ -155,7 +157,30 @@ async def _fetch_and_authorize_vector_store(
     return typed
 
 
-def _resolve_embedding_config_from_router(embedding_model: str, llm_router) -> dict[str, object] | None:
+def _embedding_config_from_params(params: Mapping[str, object]) -> Mapping[str, object]:
+    return MappingProxyType(
+        {
+            key: get_secret(value)
+            if key in ("api_key", "api_base") and isinstance(value, str) and value.startswith("os.environ/")
+            else value
+            for key, value in params.items()
+            if key
+            in (
+                "model",
+                "custom_llm_provider",
+                "api_key",
+                "api_base",
+                "api_version",
+                "project_id",
+            )
+            and value
+        }
+    )
+
+
+def _resolve_embedding_config_from_router(
+    embedding_model: str, llm_router: "Router | None"
+) -> Mapping[str, object] | None:
     """
     Resolve embedding config from router's config-defined models.
 
@@ -187,43 +212,8 @@ def _resolve_embedding_config_from_router(embedding_model: str, llm_router) -> d
             # Try to get deployment by model group name (model_name in config)
             deployment = llm_router.get_deployment_by_model_group_name(model_group_name=model_name)
 
-            if deployment is not None and deployment.litellm_params is not None:
-                litellm_params = deployment.litellm_params
-
-                # Build embedding config from model params
-                embedding_config: dict[str, object] = {}
-
-                # Extract api_key
-                api_key = getattr(litellm_params, "api_key", None)
-                if api_key:
-                    # Handle os.environ/ prefix
-                    if isinstance(api_key, str) and api_key.startswith("os.environ/"):
-                        api_key = get_secret(api_key)
-                    embedding_config["api_key"] = api_key
-
-                # Extract api_base
-                api_base = getattr(litellm_params, "api_base", None)
-                if api_base:
-                    # Handle os.environ/ prefix
-                    if isinstance(api_base, str) and api_base.startswith("os.environ/"):
-                        api_base = get_secret(api_base)
-                    embedding_config["api_base"] = api_base
-
-                # Extract api_version
-                api_version = getattr(litellm_params, "api_version", None)
-                if api_version:
-                    embedding_config["api_version"] = api_version
-
-                project_id = getattr(litellm_params, "project_id", None)
-                if project_id:
-                    embedding_config["project_id"] = project_id
-
-                # Only return config if we have at least api_key or api_base
-                if embedding_config:
-                    verbose_proxy_logger.debug(
-                        "Resolved embedding config from router model %s: %s", model_name, list(embedding_config.keys())
-                    )
-                    return embedding_config
+            if deployment is not None:
+                return _embedding_config_from_params(deployment.litellm_params.model_dump(exclude_none=True))
         except Exception as e:
             verbose_proxy_logger.debug("Error resolving embedding config from router for model %s: %s", model_name, e)
             continue
@@ -233,7 +223,7 @@ def _resolve_embedding_config_from_router(embedding_model: str, llm_router) -> d
 
 async def _resolve_embedding_config_from_db(
     embedding_model: str, prisma_client: "PrismaClient"
-) -> dict[str, object] | None:
+) -> Mapping[str, object] | None:
     """
     Resolve embedding config from database model configuration.
 
@@ -284,36 +274,12 @@ async def _resolve_embedding_config_from_db(
                 else:
                     decrypted_params = model_params
 
-                # Build embedding config from model params
-                embedding_config = {}
-
-                # Extract api_key
-                api_key = decrypted_params.get("api_key")
-                if api_key:
-                    # Handle os.environ/ prefix (after decryption, values may be os.environ/ prefixed)
-                    if isinstance(api_key, str) and api_key.startswith("os.environ/"):
-                        api_key = get_secret(api_key)
-                    embedding_config["api_key"] = api_key
-
-                # Extract api_base
-                api_base = decrypted_params.get("api_base")
-                if api_base:
-                    # Handle os.environ/ prefix (after decryption, values may be os.environ/ prefixed)
-                    if isinstance(api_base, str) and api_base.startswith("os.environ/"):
-                        api_base = get_secret(api_base)
-                    embedding_config["api_base"] = api_base
-
-                # Extract api_version
-                api_version = decrypted_params.get("api_version")
-                if api_version:
-                    embedding_config["api_version"] = api_version
-
-                # Only return config if we have at least api_key or api_base
+                embedding_config = _embedding_config_from_params(decrypted_params)
                 if embedding_config:
                     verbose_proxy_logger.debug(
                         "Resolved embedding config from database model %s: %s",
                         model_name,
-                        list(embedding_config.keys()),
+                        tuple(embedding_config),
                     )
                     return embedding_config
         except Exception as e:
@@ -325,7 +291,7 @@ async def _resolve_embedding_config_from_db(
 
 async def _resolve_embedding_config(
     embedding_model: str, prisma_client: "PrismaClient | None", llm_router: "Router | None" = None
-) -> dict[str, object] | None:
+) -> Mapping[str, object] | None:
     """
     Resolve embedding config from either router (config-defined) or database models.
 

--- a/tests/test_litellm/proxy/vector_store_endpoints/test_vector_store_endpoints.py
+++ b/tests/test_litellm/proxy/vector_store_endpoints/test_vector_store_endpoints.py
@@ -512,9 +512,9 @@ async def test_update_request_data_resolves_embedding_config_at_use_time():
     persisted."""
     mock_vector_store: LiteLLM_ManagedVectorStore = {
         "vector_store_id": "test_store",
-        "custom_llm_provider": "azure_ai",
+        "custom_llm_provider": "milvus",
         "litellm_params": {
-            "litellm_embedding_model": "azure/text-embedding-3-large",
+            "litellm_embedding_model": "multilingual-e5-large",
             # Note: no litellm_embedding_config persisted
         },
     }
@@ -525,6 +525,7 @@ async def test_update_request_data_resolves_embedding_config_at_use_time():
     )
 
     resolved = {
+        "model": "openai/multilingual-e5-large",
         "api_key": "use-time-resolved-key",
         "api_base": "https://my-azure.example",
         "api_version": "2024-09-01",
@@ -541,8 +542,12 @@ async def test_update_request_data_resolves_embedding_config_at_use_time():
             data={}, vector_store_id="test_store"
         )
 
-    assert result["litellm_embedding_model"] == "azure/text-embedding-3-large"
-    assert result["litellm_embedding_config"] == resolved
+    assert result["litellm_embedding_model"] == "openai/multilingual-e5-large"
+    assert result["litellm_embedding_config"] == {
+        "api_key": "use-time-resolved-key",
+        "api_base": "https://my-azure.example",
+        "api_version": "2024-09-01",
+    }
 
 
 @pytest.mark.asyncio
@@ -571,7 +576,13 @@ async def test_update_request_data_passes_through_legacy_embedding_config():
         mock_vector_store
     )
 
-    resolve_mock = AsyncMock()
+    resolve_mock = AsyncMock(
+        return_value={
+            "model": "azure/text-embedding-3-large",
+            "api_key": "resolved-key",
+            "api_base": "https://resolved-azure.example",
+        }
+    )
 
     with (
         patch.object(litellm, "vector_store_registry", mock_registry),
@@ -584,8 +595,13 @@ async def test_update_request_data_passes_through_legacy_embedding_config():
             data={}, vector_store_id="legacy_store"
         )
 
-    assert result["litellm_embedding_config"] == legacy_config
-    resolve_mock.assert_not_awaited()
+    assert result["litellm_embedding_model"] == "azure/text-embedding-3-large"
+    assert result["litellm_embedding_config"] == {
+        "api_key": "legacy-cleartext-key",
+        "api_base": "https://legacy-azure.example",
+        "api_version": "2024-01-01",
+    }
+    resolve_mock.assert_awaited_once()
 
 
 class TestCheckVectorStorePermission:
@@ -2010,6 +2026,8 @@ async def test_resolve_embedding_config_from_db():
     # Mock database model with litellm_params
     mock_db_model = MagicMock()
     mock_db_model.litellm_params = {
+        "model": "openai/text-embedding-ada-002",
+        "custom_llm_provider": "openai",
         "api_key": "test-api-key",
         "api_base": "https://api.openai.com",
         "api_version": "2024-01-01",
@@ -2028,6 +2046,8 @@ async def test_resolve_embedding_config_from_db():
         )
 
     assert result is not None
+    assert result["model"] == "openai/text-embedding-ada-002"
+    assert result["custom_llm_provider"] == "openai"
     assert result["api_key"] == "test-api-key"
     assert result["api_base"] == "https://api.openai.com"
     assert result["api_version"] == "2024-01-01"
@@ -2164,6 +2184,13 @@ def test_resolve_embedding_config_from_router():
     mock_litellm_params.api_key = "config-api-key"
     mock_litellm_params.api_base = "https://config-api-base.com"
     mock_litellm_params.api_version = "2024-02-01"
+    mock_litellm_params.model_dump.return_value = {
+        "model": "openai/text-embedding-ada-002",
+        "custom_llm_provider": "openai",
+        "api_key": "config-api-key",
+        "api_base": "https://config-api-base.com",
+        "api_version": "2024-02-01",
+    }
 
     mock_deployment = MagicMock(spec=Deployment)
     mock_deployment.litellm_params = mock_litellm_params
@@ -2176,6 +2203,8 @@ def test_resolve_embedding_config_from_router():
     )
 
     assert result is not None
+    assert result["model"] == "openai/text-embedding-ada-002"
+    assert result["custom_llm_provider"] == "openai"
     assert result["api_key"] == "config-api-key"
     assert result["api_base"] == "https://config-api-base.com"
     assert result["api_version"] == "2024-02-01"
@@ -2197,6 +2226,13 @@ def test_resolve_embedding_config_from_router_with_provider_prefix():
     mock_litellm_params.api_key = "azure-api-key"
     mock_litellm_params.api_base = "https://azure-endpoint.openai.azure.com"
     mock_litellm_params.api_version = "2024-02-15"
+    mock_litellm_params.model_dump.return_value = {
+        "model": "azure/text-embedding-3-large",
+        "custom_llm_provider": "azure",
+        "api_key": "azure-api-key",
+        "api_base": "https://azure-endpoint.openai.azure.com",
+        "api_version": "2024-02-15",
+    }
 
     mock_deployment = MagicMock(spec=Deployment)
     mock_deployment.litellm_params = mock_litellm_params
@@ -2239,6 +2275,11 @@ def test_resolve_embedding_config_from_router_handles_os_environ():
     mock_litellm_params.api_key = "os.environ/OPENAI_API_KEY"
     mock_litellm_params.api_base = "https://direct-url.com"
     mock_litellm_params.api_version = None
+    mock_litellm_params.model_dump.return_value = {
+        "model": "openai/text-embedding-ada-002",
+        "api_key": "os.environ/OPENAI_API_KEY",
+        "api_base": "https://direct-url.com",
+    }
 
     mock_deployment = MagicMock(spec=Deployment)
     mock_deployment.litellm_params = mock_litellm_params
@@ -2274,6 +2315,11 @@ async def test_resolve_embedding_config_tries_router_then_db():
     mock_litellm_params.api_key = "router-api-key"
     mock_litellm_params.api_base = "https://router-api-base.com"
     mock_litellm_params.api_version = None
+    mock_litellm_params.model_dump.return_value = {
+        "model": "openai/text-embedding-ada-002",
+        "api_key": "router-api-key",
+        "api_base": "https://router-api-base.com",
+    }
 
     mock_deployment = MagicMock(spec=Deployment)
     mock_deployment.litellm_params = mock_litellm_params
@@ -2310,6 +2356,11 @@ async def test_resolve_embedding_config_caches_result():
     mock_litellm_params.api_key = "router-api-key"
     mock_litellm_params.api_base = "https://router-api-base.com"
     mock_litellm_params.api_version = None
+    mock_litellm_params.model_dump.return_value = {
+        "model": "openai/cached-model",
+        "api_key": "router-api-key",
+        "api_base": "https://router-api-base.com",
+    }
 
     mock_deployment = MagicMock(spec=Deployment)
     mock_deployment.litellm_params = mock_litellm_params
@@ -2395,6 +2446,12 @@ async def test_new_vector_store_auto_resolves_from_router():
     mock_litellm_params.api_key = "router-resolved-api-key"
     mock_litellm_params.api_base = "https://router-resolved-base.com"
     mock_litellm_params.api_version = "2024-03-01"
+    mock_litellm_params.model_dump.return_value = {
+        "model": "openai/config-embedding-model",
+        "api_key": "router-resolved-api-key",
+        "api_base": "https://router-resolved-base.com",
+        "api_version": "2024-03-01",
+    }
 
     mock_deployment = MagicMock(spec=Deployment)
     mock_deployment.litellm_params = mock_litellm_params


### PR DESCRIPTION
## TLDR

Problem this solves:

- Vector-store embedding aliases lose their underlying provider
- Search fails before the vector store is called

How it solves it:

- Resolves the alias model and provider at request time
- Preserves legacy per-store credential overrides
- Keeps resolved credentials out of persisted registry data

## User Flow

Before: a proxy admin cannot search using an embedding model alias

1. They register a vector store with `litellm_embedding_model: multilingual-e5-large`
2. Their app sends `POST https://litellm-domain/v1/vector_stores/documents/search` with `{"query":"transport probe"}`
3. The app receives HTTP 400 with `LLM Provider NOT provided`

After: the same alias resolves to its configured embedding deployment

1. They keep `litellm_embedding_model: multilingual-e5-large`
2. Their app sends the same `POST https://litellm-domain/v1/vector_stores/documents/search` request
3. The app receives HTTP 200 with ranked `vector_store.search_results.page` data

## Relevant issues

Follow-up to #38756

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Shared setup: a local OpenAI-compatible embedding deployment is registered as `multilingual-e5-large`, and local Milvus 2.6.22 contains known vectors

### Before (3829418878)

1. Configure the vector store with `litellm_embedding_model: multilingual-e5-large`
2. Send `POST /v1/vector_stores/transport_probe/search` with `{"query":"transport probe","max_num_results":2}`
3. The proxy returns HTTP 400 with `LLM Provider NOT provided`

### After (dac3325d17)

1. Keep the same embedding alias and request
2. The proxy calls the alias deployment at `/v1/embeddings`
3. The proxy returns HTTP 200 with `closest` at score `1` and `orthogonal` at score `0`

## Type

🐛 Bug Fix

## Caveats (if any)

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
