### PR TITLE
fix(bedrock): mask signed request headers in guardrail debug log

### DIFF
--- a/litellm/proxy/guardrails/guardrail_hooks/bedrock_guardrails.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/bedrock_guardrails.py
@@ -32,6 +32,9 @@ from litellm.constants import BEDROCK_APPLY_GUARDRAIL_CHUNK_BUDGET_CHARS
 from litellm.exceptions import ModifyResponseException
 from litellm.integrations.custom_guardrail import CustomGuardrail
 from litellm.litellm_core_utils.core_helpers import redact_nested_match_and_regex_keys
+from litellm.litellm_core_utils.litellm_logging import (
+    _get_masked_values,  # pyright: ignore[reportPrivateUsage]  # the shared header-masking helper has no public name
+)
 from litellm.litellm_core_utils.llm_cost_calc.guardrail_cost import bedrock_guardrail_cost
 from litellm.llms.anthropic.chat.guardrail_translation.handler import AnthropicMessagesHandler
 from litellm.llms.base_llm.guardrail_translation.utils import (
@@ -1172,11 +1175,12 @@ class BedrockGuardrail(CustomGuardrail, BaseAWSLLM):
             aws_region_name=aws_region_name,
             api_key=api_key,
         )
+        headers_dict: Final = dict(prepared_request.headers)  # mutable-ok: the masking helper requires a dict
         verbose_proxy_logger.debug(
             "Bedrock AI request body: %s, url %s, headers: %s",
             bedrock_request_data,
             prepared_request.url,
-            prepared_request.headers,
+            _get_masked_values(headers_dict),
         )
 
         httpx_response: Final = await self._sign_and_post(

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_bedrock_guardrails.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_bedrock_guardrails.py
@@ -5590,3 +5590,52 @@ async def test_streaming_end_of_stream_block_emits_error_frame_instead_of_trunca
     assert payload["error"]["message"] == "Violated guardrail policy"
     assert payload["error"]["code"] == "400"
     assert payload["error"]["provider_specific_fields"]["guardrailIdentifier"] == "test-guardrail"
+
+
+@pytest.mark.asyncio
+async def test_apply_guardrail_debug_log_masks_signed_request_headers():
+    import logging
+
+    from litellm._logging import verbose_proxy_logger
+
+    session_token = "FakeSessionTokenValueThatMustNeverAppearInLogs1234567890"
+    guardrail = BedrockGuardrail(
+        guardrailIdentifier="test-guardrail",
+        guardrailVersion="DRAFT",
+        aws_access_key_id="ASIAFAKEACCESSKEYID1",
+        aws_secret_access_key="fakeSecretAccessKeyForSigning",
+        aws_session_token=session_token,
+        aws_region_name="us-east-1",
+    )
+
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {"action": "NONE", "outputs": []}
+
+    captured_records: list[logging.LogRecord] = []
+
+    class _RecordingHandler(logging.Handler):
+        def emit(self, record: logging.LogRecord) -> None:
+            captured_records.append(record)
+
+    handler = _RecordingHandler(level=logging.DEBUG)
+    previous_level = verbose_proxy_logger.level
+    verbose_proxy_logger.addHandler(handler)
+    verbose_proxy_logger.setLevel(logging.DEBUG)
+    try:
+        with patch.object(guardrail.async_handler, "post", new_callable=AsyncMock) as mock_post:
+            mock_post.return_value = mock_response
+            await guardrail.make_bedrock_api_request(
+                source="INPUT",
+                messages=[{"role": "user", "content": "hello"}],
+                request_data={},
+            )
+    finally:
+        verbose_proxy_logger.removeHandler(handler)
+        verbose_proxy_logger.setLevel(previous_level)
+
+    rendered_messages = [record.getMessage() for record in captured_records]
+    header_lines = [message for message in rendered_messages if "headers:" in message]
+    assert header_lines, "expected the signed-request debug line to be logged"
+    assert any("X-Amz-Security-Token" in message for message in header_lines)
+    assert all(session_token not in message for message in rendered_messages)

--- a/tests/test_litellm/proxy/guardrails/test_guardrail_endpoints.py
+++ b/tests/test_litellm/proxy/guardrails/test_guardrail_endpoints.py
@@ -917,7 +917,9 @@ async def test_bedrock_guardrail_make_api_request_passes_api_key():
             "Content-Type": "application/json",
             "Authorization": "Bearer test-api-key-789",
         }
-        mock_request_instance.prepare.return_value = Mock()
+        mock_request_instance.prepare.return_value = Mock(
+            headers=mock_request_instance.headers
+        )
         mock_aws_request.return_value = mock_request_instance
 
         await guardrail_hook.make_bedrock_api_request(


### PR DESCRIPTION
## TLDR

Problem this solves:

- Guardrail debug log printed the full `X-Amz-Security-Token` value
- Anyone with log access could lift live temporary AWS credentials

How it solves it:

- Masks the signed request headers before logging them
- Sensitive values show first and last 2 chars only (`IQ****z/`)

## User Flow

Before: an operator running the proxy with debug logging finds their full AWS session token printed in the log after any guardrail-checked request

1. The operator boots the proxy with a Bedrock guardrail configured with temporary AWS credentials (an `aws_session_token`) and `--detailed_debug`
2. A developer sends POST http://litellm-domain/v1/chat/completions with any prompt and gets a normal 200 with the model's reply
3. The proxy log now carries the guardrail's signed request headers with the complete `X-Amz-Security-Token` value in plain text
4. Anyone who can read the logs (a log aggregator, a teammate tailing the file) holds working AWS credentials for that account until the token expires

After: the same request logs the guardrail call with every credential header masked, so the logs are safe to share

1. The operator boots the proxy with a Bedrock guardrail configured with temporary AWS credentials (an `aws_session_token`) and `--detailed_debug`
2. A developer sends POST http://litellm-domain/v1/chat/completions with any prompt and gets a normal 200 with the model's reply
3. The proxy log's guardrail request line now shows `'X-Amz-Security-Token': 'IQ****z/', 'Authorization': 'AW****24'`
4. Log readers no longer see usable AWS credentials

## Relevant issues

## Linear ticket

Resolves LIT-6446

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Setup: live proxy on port 35694 with a Bedrock guardrail (`mode: pre_call`, `default_on: true`, real guardrail in us-east-1) using temporary AWS session credentials, booted with `--detailed_debug`. Same request both legs, hitting the real OpenAI and Bedrock APIs:

```bash
curl -s http://127.0.0.1:35694/v1/chat/completions \
  -H "Authorization: Bearer sk-lit6446-qa" -H "Content-Type: application/json" \
  -d '{"model":"gpt-5.6","messages":[{"role":"user","content":"Say hello in five words"}]}'
```

### Before (99703a30f0)

1. The curl above returns 200: `{"model": "gpt-5.6", ... "content": "Hello there, how are you?"}`
2. The proxy log prints the signed guardrail request with the raw session token (raw values elided here, they are real live credentials):

```
17:03:50 - LiteLLM Proxy:DEBUG: bedrock_guardrails.py:1175 - Bedrock AI request body: {'source': 'INPUT', 'content': ({'text': {'text': 'Say hello in five words'}},)}, url https://bedrock-runtime.us-east-1.amazonaws.com/guardrail/wk4ijrsk7ska/version/DRAFT/apply, headers: {'Content-Type': 'application/json', 'X-Amz-Date': '20260901T000350Z', 'X-Amz-Security-Token': '<1168-char value, RAW, elided>', 'Authorization': '<217-char value, RAW, elided>', 'Content-Length': '79'}
```

3. Counting occurrences of the full session token value in the log: `python3 -c 'import os; print(open("litellm.log").read().count(os.environ["AWS_SESSION_TOKEN"]))'` prints `1`

### After (76cfa6339b)

1. The same curl returns 200: `{"model": "gpt-5.6", ... "content": "Hello, wonderful to meet you."}`
2. The same log line now masks every credential header:

```
17:31:24 - LiteLLM Proxy:DEBUG: bedrock_guardrails.py:1179 - Bedrock AI request body: {'source': 'INPUT', 'content': ({'text': {'text': 'Say hello in five words'}},)}, url https://bedrock-runtime.us-east-1.amazonaws.com/guardrail/wk4ijrsk7ska/version/DRAFT/apply, headers: {'Content-Type': 'application/json', 'X-Amz-Date': '20260901T003124Z', 'X-Amz-Security-Token': 'IQ****z/', 'Authorization': 'AW****24', 'Content-Length': '79'}
```

3. The same token count now prints `0`

## Type

🐛 Bug Fix

## Caveats (if any)

### Low

- Debug log no longer shows the full SigV4 `Authorization` header when debugging signature issues

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

- [x] 76cfa6339b13 passes /live-pr-risk

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Change is limited to debug logging of outbound guardrail HTTP headers; request signing and API behavior are unchanged.
> 
> **Overview**
> **Stops leaking temporary AWS credentials in proxy debug logs** when Bedrock ApplyGuardrail runs with SigV4 signing.
> 
> The ApplyGuardrail debug line in `_post_apply_guardrail_content` no longer logs raw `prepared_request.headers`. Headers are copied to a dict and passed through the shared `_get_masked_values` helper so values like `X-Amz-Security-Token` and `Authorization` appear partially redacted instead of in full.
> 
> A new async unit test captures `verbose_proxy_logger` output during `make_bedrock_api_request` and asserts the session token never appears in any log line while header logging still occurs. An endpoint test mock was updated so `prepare()` returns headers, matching the real signed-request shape.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 76cfa6339b13c5437bda88d617367ecb7c2ffa22. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->