### PR TITLE
fix(proxy): include litellm_model_table in GET /v2/team/list

### DIFF
--- a/litellm/proxy/management_endpoints/team_endpoints.py
+++ b/litellm/proxy/management_endpoints/team_endpoints.py
@@ -5153,6 +5153,7 @@ async def list_team_v2(
             skip=skip,
             take=page_size,
             order=order_by if order_by else {"created_at": "desc"},  # Default sort
+            include=_INCLUDE_MODEL_TABLE,
         )
         # Get total count for pagination
         total_count = await _deleted_team_db(prisma_client).count(where=where_conditions)
@@ -5162,6 +5163,7 @@ async def list_team_v2(
             skip=skip,
             take=page_size,
             order=order_by if order_by else {"created_at": "desc"},  # Default sort
+            include=_INCLUDE_MODEL_TABLE,
         )
         # Get total count for pagination
         total_count = await _team_db(prisma_client).count(where=where_conditions)

--- a/litellm/proxy/management_endpoints/team_endpoints.py
+++ b/litellm/proxy/management_endpoints/team_endpoints.py
@@ -5148,12 +5148,12 @@ async def list_team_v2(
 
     # Get teams with pagination
     if use_deleted_table:
+        # LiteLLM_DeletedTeamTable has no litellm_model_table relation, unlike below
         teams = await _deleted_team_db(prisma_client).find_many(
             where=where_conditions,
             skip=skip,
             take=page_size,
             order=order_by if order_by else {"created_at": "desc"},  # Default sort
-            include=_INCLUDE_MODEL_TABLE,
         )
         # Get total count for pagination
         total_count = await _deleted_team_db(prisma_client).count(where=where_conditions)

--- a/tests/test_litellm/proxy/management_endpoints/test_team_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_team_endpoints.py
@@ -3747,16 +3747,17 @@ async def test_list_team_v2_includes_litellm_model_table():
     Regression test for GH #26312: GET /v2/team/list must eagerly load the
     litellm_model_table relation, same as /team/info and /team/list, or a
     team's model_aliases always read back as null from this endpoint.
+
+    The fake find_many below only attaches litellm_model_table when its own
+    `include` kwarg actually asks for the relation, so the assertions below
+    are on what the caller gets back, not on how find_many was called.
     """
     from unittest.mock import AsyncMock, Mock, patch
 
     from fastapi import Request
 
     from litellm.proxy._types import LitellmUserRoles, UserAPIKeyAuth
-    from litellm.proxy.management_endpoints.team_endpoints import (
-        _INCLUDE_MODEL_TABLE,
-        list_team_v2,
-    )
+    from litellm.proxy.management_endpoints.team_endpoints import list_team_v2
 
     mock_request = Mock(spec=Request)
     mock_user_api_key_dict_admin = UserAPIKeyAuth(
@@ -3764,14 +3765,38 @@ async def test_list_team_v2_includes_litellm_model_table():
         user_id="admin_user_123",
     )
 
-    with patch("litellm.proxy.proxy_server.prisma_client") as mock_prisma_client:
+    def _team_row(team_id: str, include) -> Mock:
+        model_table = (
+            {
+                "id": 1,
+                "model_aliases": {"my-fast-model": "fake-model"},
+                "created_by": "u",
+                "updated_by": "u",
+                "team": None,
+            }
+            if (include or {}).get("litellm_model_table")
+            else None
+        )
+        return Mock(
+            team_id=team_id,
+            model_dump=lambda: {
+                "team_id": team_id,
+                "team_alias": "t",
+                "litellm_model_table": model_table,
+            },
+        )
+
+    with patch("litellm.proxy.proxy_server.prisma_client") as mock_prisma_client:  # test-quality-ok: this file's DB-mock convention
         mock_db = Mock()
         mock_prisma_client.db = mock_db
 
-        mock_db.litellm_teamtable.find_many = AsyncMock(return_value=[])
-        mock_db.litellm_teamtable.count = AsyncMock(return_value=0)
+        mock_db.litellm_teamtable.find_many = AsyncMock(
+            side_effect=lambda **kw: [_team_row("team_1", kw.get("include"))]
+        )
+        mock_db.litellm_teamtable.count = AsyncMock(return_value=1)
+        mock_db.litellm_verificationtoken.group_by = AsyncMock(return_value=[])
 
-        await list_team_v2(
+        result = await list_team_v2(
             http_request=mock_request,
             user_id=None,
             user_api_key_dict=mock_user_api_key_dict_admin,
@@ -3780,12 +3805,15 @@ async def test_list_team_v2_includes_litellm_model_table():
             status=None,
         )
 
-        assert mock_db.litellm_teamtable.find_many.call_args.kwargs["include"] == _INCLUDE_MODEL_TABLE
+        assert result["teams"][0].litellm_model_table is not None
+        assert result["teams"][0].litellm_model_table.model_aliases == {"my-fast-model": "fake-model"}
 
-        mock_db.litellm_deletedteamtable.find_many = AsyncMock(return_value=[])
-        mock_db.litellm_deletedteamtable.count = AsyncMock(return_value=0)
+        mock_db.litellm_deletedteamtable.find_many = AsyncMock(
+            side_effect=lambda **kw: [_team_row("team_2", kw.get("include"))]
+        )
+        mock_db.litellm_deletedteamtable.count = AsyncMock(return_value=1)
 
-        await list_team_v2(
+        result = await list_team_v2(
             http_request=mock_request,
             user_id=None,
             user_api_key_dict=mock_user_api_key_dict_admin,
@@ -3794,7 +3822,8 @@ async def test_list_team_v2_includes_litellm_model_table():
             status="deleted",
         )
 
-        assert mock_db.litellm_deletedteamtable.find_many.call_args.kwargs["include"] == _INCLUDE_MODEL_TABLE
+        assert result["teams"][0].litellm_model_table is not None
+        assert result["teams"][0].litellm_model_table.model_aliases == {"my-fast-model": "fake-model"}
 
 
 @pytest.mark.asyncio

--- a/tests/test_litellm/proxy/management_endpoints/test_team_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_team_endpoints.py
@@ -3745,8 +3745,11 @@ async def test_list_team_v2_with_status_deleted():
 async def test_list_team_v2_includes_litellm_model_table():
     """
     Regression test for GH #26312: GET /v2/team/list must eagerly load the
-    litellm_model_table relation, same as /team/info and /team/list, or a
-    team's model_aliases always read back as null from this endpoint.
+    litellm_model_table relation for active teams, same as /team/info and
+    /team/list, or a team's model_aliases always read back as null from this
+    endpoint. Deleted teams are excluded: LiteLLM_DeletedTeamTable has no such
+    relation in the Prisma schema, so requesting it there raises
+    UnknownRelationalFieldError against a real database.
 
     The fake find_many below only attaches litellm_model_table when its own
     `include` kwarg actually asks for the relation, so the assertions below
@@ -3813,7 +3816,7 @@ async def test_list_team_v2_includes_litellm_model_table():
         )
         mock_db.litellm_deletedteamtable.count = AsyncMock(return_value=1)
 
-        result = await list_team_v2(
+        await list_team_v2(
             http_request=mock_request,
             user_id=None,
             user_api_key_dict=mock_user_api_key_dict_admin,
@@ -3822,8 +3825,7 @@ async def test_list_team_v2_includes_litellm_model_table():
             status="deleted",
         )
 
-        assert result["teams"][0].litellm_model_table is not None
-        assert result["teams"][0].litellm_model_table.model_aliases == {"my-fast-model": "fake-model"}
+        assert "include" not in mock_db.litellm_deletedteamtable.find_many.call_args.kwargs
 
 
 @pytest.mark.asyncio

--- a/tests/test_litellm/proxy/management_endpoints/test_team_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_team_endpoints.py
@@ -3742,6 +3742,62 @@ async def test_list_team_v2_with_status_deleted():
 
 
 @pytest.mark.asyncio
+async def test_list_team_v2_includes_litellm_model_table():
+    """
+    Regression test for GH #26312: GET /v2/team/list must eagerly load the
+    litellm_model_table relation, same as /team/info and /team/list, or a
+    team's model_aliases always read back as null from this endpoint.
+    """
+    from unittest.mock import AsyncMock, Mock, patch
+
+    from fastapi import Request
+
+    from litellm.proxy._types import LitellmUserRoles, UserAPIKeyAuth
+    from litellm.proxy.management_endpoints.team_endpoints import (
+        _INCLUDE_MODEL_TABLE,
+        list_team_v2,
+    )
+
+    mock_request = Mock(spec=Request)
+    mock_user_api_key_dict_admin = UserAPIKeyAuth(
+        user_role=LitellmUserRoles.PROXY_ADMIN,
+        user_id="admin_user_123",
+    )
+
+    with patch("litellm.proxy.proxy_server.prisma_client") as mock_prisma_client:
+        mock_db = Mock()
+        mock_prisma_client.db = mock_db
+
+        mock_db.litellm_teamtable.find_many = AsyncMock(return_value=[])
+        mock_db.litellm_teamtable.count = AsyncMock(return_value=0)
+
+        await list_team_v2(
+            http_request=mock_request,
+            user_id=None,
+            user_api_key_dict=mock_user_api_key_dict_admin,
+            page=1,
+            page_size=10,
+            status=None,
+        )
+
+        assert mock_db.litellm_teamtable.find_many.call_args.kwargs["include"] == _INCLUDE_MODEL_TABLE
+
+        mock_db.litellm_deletedteamtable.find_many = AsyncMock(return_value=[])
+        mock_db.litellm_deletedteamtable.count = AsyncMock(return_value=0)
+
+        await list_team_v2(
+            http_request=mock_request,
+            user_id=None,
+            user_api_key_dict=mock_user_api_key_dict_admin,
+            page=1,
+            page_size=10,
+            status="deleted",
+        )
+
+        assert mock_db.litellm_deletedteamtable.find_many.call_args.kwargs["include"] == _INCLUDE_MODEL_TABLE
+
+
+@pytest.mark.asyncio
 async def test_list_team_v2_org_admin_sees_org_teams():
     """
     Test that an org admin (internal_user role with org_admin membership)


### PR DESCRIPTION
## TLDR

Problem this solves:

- `GET /v2/team/list` always returns `litellm_model_table: null` for active teams
- So a team's `model_aliases` can never be read back from this endpoint

How it solves it:

- Add the missing `include={"litellm_model_table": True}` to the active-team `find_many` query in `list_team_v2`
- Deliberately leave the deleted-team `find_many` alone: `LiteLLM_DeletedTeamTable` has no such relation in the schema, so this include would raise a database error there

## User Flow

Before: an operator listing teams through the API never sees a team's configured model aliases, even though they are stored and routing correctly

1. They set `model_aliases` on a team, e.g. via `POST /team/update` with `{"team_id": "<id>", "model_aliases": {"my-fast-model": "gpt-4o"}}`
2. They call `GET /v2/team/list?team_id=<id>`
3. The returned team object always shows `"litellm_model_table": null`, even though the alias exists and routes correctly

After: the same list call reflects the real state

1. They set `model_aliases` on a team the same way
2. They call `GET /v2/team/list?team_id=<id>`
3. The returned team object now shows `"litellm_model_table": {"id": ..., "model_aliases": {"my-fast-model": "gpt-4o"}, ...}`, matching what `GET /team/info` and `GET /team/list` already returned correctly

## Relevant issues

Related to #26312 (litellm_model_table read back as null). That issue was about `/team/info`, and was fixed there and on `/team/list` by #33047; this PR closes the same gap on `/v2/team/list`, which #33047 didn't touch.

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Ran the proxy locally against a real Postgres (`python litellm/proxy/proxy_cli.py --config <config> --use_v2_migration_resolver`).

### Before (68cfe1697b4a23df9dab634cb60fde2bcac87fb5)

1. `curl -X POST http://127.0.0.1:14099/team/new -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" -d '{"team_alias": "v2team-repro-before", "models": ["fake-model"], "model_aliases": {"my-fast-model": "fake-model"}}'` -> `team_id=4572ff65-5c2a-4dd9-bf1e-57dfd3faa933`
2. `curl "http://127.0.0.1:14099/v2/team/list?team_id=4572ff65-5c2a-4dd9-bf1e-57dfd3faa933" -H "Authorization: Bearer sk-1234"` returns:
   ```json
   {"team_alias":"v2team-repro-before","team_id":"4572ff65-5c2a-4dd9-bf1e-57dfd3faa933","model_id":1,"litellm_model_table":null, ...}
   ```
   `model_aliases` is unreadable from this endpoint even though it was just set

### After (aab515d23b)

1. `curl -X POST http://127.0.0.1:14199/team/new -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" -d '{"team_alias": "v2team-final-active", "models": ["fake-model"], "model_aliases": {"my-fast-model": "fake-model"}}'` -> `team_id=1c109696-4d2c-4903-9527-3c58cae33eed`
2. `curl "http://127.0.0.1:14199/v2/team/list?team_id=1c109696-4d2c-4903-9527-3c58cae33eed" -H "Authorization: Bearer sk-1234"` returns `litellm_model_table` populated:
   ```json
   {"id": 1, "model_aliases": {"my-fast-model": "fake-model"}, "created_by": "default_user_id", ...}
   ```
3. Sanity check for the scoping decision above: `curl -X POST http://127.0.0.1:14199/team/delete -d '{"team_ids": ["1c109696-4d2c-4903-9527-3c58cae33eed"]}'` then `curl "http://127.0.0.1:14199/v2/team/list?status=deleted"` -> `HTTP 200` with the deleted team listed, confirming the deleted-team branch (which never gets the include) still works

## Type

🐛 Bug Fix

## Caveats (if any)

### Low

- Scope is limited to the active-team branch of `/v2/team/list`. Deleted teams still can't show `model_aliases` from this endpoint (`LiteLLM_DeletedTeamTable` has no relation to join), same as before this PR; `/team/info` and `/team/list` (non-deleted) were already fixed by #33047

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
