### PR TITLE
fix: keep litellm_credential_name from LiteLLM Params JSON and gate stored credential attach to proxy admins

### DIFF
--- a/litellm/proxy/management_endpoints/model_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/model_management_endpoints.py
@@ -701,15 +701,11 @@ async def patch_model(
                 param="blocked",
             )
 
-        if (
-            patch_data.litellm_params is not None
-            and patch_data.litellm_params.litellm_credential_name is not None
-            and patch_data.litellm_params.litellm_credential_name != db_model.litellm_params.litellm_credential_name
-        ):
-            ModelManagementAuthChecks.can_user_attach_credential(
-                litellm_params=patch_data.litellm_params,
-                user_api_key_dict=user_api_key_dict,
-            )
+        ModelManagementAuthChecks.can_user_attach_credential(
+            litellm_params=patch_data.litellm_params,
+            user_api_key_dict=user_api_key_dict,
+            existing_litellm_params=db_model.litellm_params,
+        )
 
         _raise_on_strategy_router_write_violation(
             incoming_params=patch_data.litellm_params,
@@ -1478,8 +1474,13 @@ class ModelManagementAuthChecks:
     def can_user_attach_credential(
         litellm_params: GenericLiteLLMParams | None,
         user_api_key_dict: UserAPIKeyAuth,
+        existing_litellm_params: GenericLiteLLMParams | None = None,
     ) -> Literal[True]:
         if litellm_params is None or litellm_params.litellm_credential_name is None:
+            return True
+        if existing_litellm_params is not None and (
+            litellm_params.litellm_credential_name == existing_litellm_params.litellm_credential_name
+        ):
             return True
         if user_api_key_dict.user_role == LitellmUserRoles.PROXY_ADMIN:
             return True
@@ -1989,15 +1990,11 @@ async def update_model(
             premium_user=premium_user,
         )
 
-        if (
-            model_params.litellm_params is not None
-            and model_params.litellm_params.litellm_credential_name is not None
-            and model_params.litellm_params.litellm_credential_name != deployment.litellm_params.litellm_credential_name
-        ):
-            ModelManagementAuthChecks.can_user_attach_credential(
-                litellm_params=model_params.litellm_params,
-                user_api_key_dict=user_api_key_dict,
-            )
+        ModelManagementAuthChecks.can_user_attach_credential(
+            litellm_params=model_params.litellm_params,
+            user_api_key_dict=user_api_key_dict,
+            existing_litellm_params=deployment.litellm_params,
+        )
 
         _raise_on_strategy_router_write_violation(
             incoming_params=model_params.litellm_params,

--- a/litellm/proxy/management_endpoints/model_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/model_management_endpoints.py
@@ -701,6 +701,16 @@ async def patch_model(
                 param="blocked",
             )
 
+        if (
+            patch_data.litellm_params is not None
+            and patch_data.litellm_params.litellm_credential_name is not None
+            and patch_data.litellm_params.litellm_credential_name != db_model.litellm_params.litellm_credential_name
+        ):
+            ModelManagementAuthChecks.can_user_attach_credential(
+                litellm_params=patch_data.litellm_params,
+                user_api_key_dict=user_api_key_dict,
+            )
+
         _raise_on_strategy_router_write_violation(
             incoming_params=patch_data.litellm_params,
             existing_params=db_model.litellm_params,
@@ -1465,6 +1475,22 @@ class ModelManagementAuthChecks:
         return True
 
     @staticmethod
+    def can_user_attach_credential(
+        litellm_params: GenericLiteLLMParams | None,
+        user_api_key_dict: UserAPIKeyAuth,
+    ) -> Literal[True]:
+        if litellm_params is None or litellm_params.litellm_credential_name is None:
+            return True
+        if user_api_key_dict.user_role == LitellmUserRoles.PROXY_ADMIN:
+            return True
+        raise HTTPException(
+            status_code=403,
+            detail={
+                "error": f"Only a proxy admin can attach a stored credential (litellm_credential_name) to a model. Your role={user_api_key_dict.user_role}."
+            },
+        )
+
+    @staticmethod
     async def allow_team_model_action(
         model_params: Deployment | updateDeployment,
         user_api_key_dict: UserAPIKeyAuth,
@@ -1784,6 +1810,11 @@ async def add_new_model(
             user_api_key_dict=user_api_key_dict,
             prisma_client=prisma_client,
             premium_user=premium_user,
+        )
+
+        ModelManagementAuthChecks.can_user_attach_credential(
+            litellm_params=model_params.litellm_params,
+            user_api_key_dict=user_api_key_dict,
         )
 
         _raise_on_strategy_router_write_violation(

--- a/litellm/proxy/management_endpoints/model_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/model_management_endpoints.py
@@ -54,7 +54,10 @@ from litellm.proxy.common_utils.config_sync_pubsub import (
     coordination_redis_cache,
     publish_config_change,
 )
-from litellm.proxy.common_utils.encrypt_decrypt_utils import encrypt_value_helper
+from litellm.proxy.common_utils.encrypt_decrypt_utils import (
+    decrypt_value_helper,
+    encrypt_value_helper,
+)
 from litellm.proxy.common_utils.user_api_key_cache import UserApiKeyCache
 from litellm.proxy.management_endpoints.common_utils import _is_user_team_admin
 from litellm.proxy.management_endpoints.team_endpoints import (
@@ -1478,10 +1481,15 @@ class ModelManagementAuthChecks:
     ) -> Literal[True]:
         if litellm_params is None or litellm_params.litellm_credential_name is None:
             return True
-        if existing_litellm_params is not None and (
-            litellm_params.litellm_credential_name == existing_litellm_params.litellm_credential_name
-        ):
-            return True
+        if existing_litellm_params is not None and existing_litellm_params.litellm_credential_name is not None:
+            existing_credential_name: Final = decrypt_value_helper(
+                value=existing_litellm_params.litellm_credential_name,
+                key="litellm_credential_name",
+                exception_type="debug",
+                return_original_value=True,
+            )
+            if litellm_params.litellm_credential_name == existing_credential_name:
+                return True
         if user_api_key_dict.user_role == LitellmUserRoles.PROXY_ADMIN:
             return True
         raise ProxyException(

--- a/litellm/proxy/management_endpoints/model_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/model_management_endpoints.py
@@ -1483,11 +1483,11 @@ class ModelManagementAuthChecks:
             return True
         if user_api_key_dict.user_role == LitellmUserRoles.PROXY_ADMIN:
             return True
-        raise HTTPException(
-            status_code=403,
-            detail={
-                "error": f"Only a proxy admin can attach a stored credential (litellm_credential_name) to a model. Your role={user_api_key_dict.user_role}."
-            },
+        raise ProxyException(
+            message=f"Only a proxy admin can attach a stored credential (litellm_credential_name) to a model. Your role={user_api_key_dict.user_role}.",
+            type=ProxyErrorTypes.auth_error.value,
+            code=status.HTTP_403_FORBIDDEN,
+            param="litellm_credential_name",
         )
 
     @staticmethod
@@ -1988,6 +1988,16 @@ async def update_model(
             prisma_client=prisma_client,
             premium_user=premium_user,
         )
+
+        if (
+            model_params.litellm_params is not None
+            and model_params.litellm_params.litellm_credential_name is not None
+            and model_params.litellm_params.litellm_credential_name != deployment.litellm_params.litellm_credential_name
+        ):
+            ModelManagementAuthChecks.can_user_attach_credential(
+                litellm_params=model_params.litellm_params,
+                user_api_key_dict=user_api_key_dict,
+            )
 
         _raise_on_strategy_router_write_violation(
             incoming_params=model_params.litellm_params,

--- a/tests/test_litellm/proxy/management_endpoints/test_model_management_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_model_management_endpoints.py
@@ -18,6 +18,7 @@ from litellm.proxy._types import (
     ReconcileOutcome,
     UserAPIKeyAuth,
 )
+from litellm.proxy.common_utils.encrypt_decrypt_utils import encrypt_value_helper
 from litellm.proxy.management_endpoints.model_management_endpoints import (
     ModelManagementAuthChecks,
     _get_team_deployments,
@@ -290,6 +291,17 @@ class TestModelManagementAuthChecks:
             litellm_params=LiteLLM_Params(model="test_model", litellm_credential_name="shared-credential"),
             user_api_key_dict=self.team_admin_user,
             existing_litellm_params=LiteLLM_Params(model="test_model", litellm_credential_name="shared-credential"),
+        )
+        assert result is True
+
+    def test_can_user_attach_credential_unchanged_encrypted_existing_allows_any_role(self, monkeypatch):
+        monkeypatch.setenv("LITELLM_SALT_KEY", "sk-1234")
+        encrypted_name = encrypt_value_helper(value="shared-credential")
+        assert encrypted_name != "shared-credential"
+        result = ModelManagementAuthChecks.can_user_attach_credential(
+            litellm_params=LiteLLM_Params(model="test_model", litellm_credential_name="shared-credential"),
+            user_api_key_dict=self.team_admin_user,
+            existing_litellm_params=LiteLLM_Params(model="test_model", litellm_credential_name=encrypted_name),
         )
         assert result is True
 

--- a/tests/test_litellm/proxy/management_endpoints/test_model_management_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_model_management_endpoints.py
@@ -283,7 +283,7 @@ class TestModelManagementAuthChecks:
                 litellm_params=LiteLLM_Params(model="test_model", litellm_credential_name="shared-credential"),
                 user_api_key_dict=self.team_admin_user,
             )
-        assert "403" in str(exc_info.value)
+        assert exc_info.value.code == "403"
 
     def test_can_user_attach_credential_internal_user_fails(self):
         with pytest.raises(Exception, match="Only a proxy admin can attach a stored credential") as exc_info:
@@ -291,7 +291,7 @@ class TestModelManagementAuthChecks:
                 litellm_params=LiteLLM_Params(model="test_model", litellm_credential_name="shared-credential"),
                 user_api_key_dict=self.normal_user,
             )
-        assert "403" in str(exc_info.value)
+        assert exc_info.value.code == "403"
 
 
 class MockModelTable:

--- a/tests/test_litellm/proxy/management_endpoints/test_model_management_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_model_management_endpoints.py
@@ -314,10 +314,10 @@ class TestModelManagementAuthChecks:
 
         mock_prisma = MagicMock()
         with (
-            patch("litellm.proxy.proxy_server.prisma_client", mock_prisma),
-            patch("litellm.proxy.proxy_server.store_model_in_db", True),
-            patch("litellm.proxy.proxy_server.premium_user", True),
-            patch(
+            patch("litellm.proxy.proxy_server.prisma_client", mock_prisma),  # test-quality-ok: endpoint reads proxy server globals with no injection seam
+            patch("litellm.proxy.proxy_server.store_model_in_db", True),  # test-quality-ok: endpoint reads proxy server globals with no injection seam
+            patch("litellm.proxy.proxy_server.premium_user", True),  # test-quality-ok: endpoint reads proxy server globals with no injection seam
+            patch(  # test-quality-ok: prior auth check needs a live DB; only the credential check is under test
                 "litellm.proxy.management_endpoints.model_management_endpoints.ModelManagementAuthChecks.can_user_make_model_call",
                 new=AsyncMock(return_value=None),
             ),
@@ -351,19 +351,19 @@ class TestModelManagementAuthChecks:
             model_info={"id": model_id},
         )
         with (
-            patch("litellm.proxy.proxy_server.prisma_client", MagicMock()),
-            patch("litellm.proxy.proxy_server.llm_router", MagicMock()),
-            patch("litellm.proxy.proxy_server.store_model_in_db", True),
-            patch("litellm.proxy.proxy_server.premium_user", True),
-            patch(
+            patch("litellm.proxy.proxy_server.prisma_client", MagicMock()),  # test-quality-ok: endpoint reads proxy server globals with no injection seam
+            patch("litellm.proxy.proxy_server.llm_router", MagicMock()),  # test-quality-ok: endpoint reads proxy server globals with no injection seam
+            patch("litellm.proxy.proxy_server.store_model_in_db", True),  # test-quality-ok: endpoint reads proxy server globals with no injection seam
+            patch("litellm.proxy.proxy_server.premium_user", True),  # test-quality-ok: endpoint reads proxy server globals with no injection seam
+            patch(  # test-quality-ok: stubs the DB row fetch; only the credential check is under test
                 "litellm.proxy.management_endpoints.model_management_endpoints.get_db_model",
                 new=AsyncMock(return_value=db_model),
             ),
-            patch(
+            patch(  # test-quality-ok: prior auth check needs a live DB; only the credential check is under test
                 "litellm.proxy.management_endpoints.model_management_endpoints.ModelManagementAuthChecks.can_user_make_model_call",
                 new=AsyncMock(return_value=None),
             ),
-            patch(
+            patch(  # test-quality-ok: asserts the DB write is never reached on rejection
                 "litellm.proxy.management_endpoints.model_management_endpoints._update_team_model_in_db",
                 new=AsyncMock(),
             ) as mock_update,

--- a/tests/test_litellm/proxy/management_endpoints/test_model_management_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_model_management_endpoints.py
@@ -285,6 +285,14 @@ class TestModelManagementAuthChecks:
             )
         assert exc_info.value.code == "403"
 
+    def test_can_user_attach_credential_unchanged_existing_allows_any_role(self):
+        result = ModelManagementAuthChecks.can_user_attach_credential(
+            litellm_params=LiteLLM_Params(model="test_model", litellm_credential_name="shared-credential"),
+            user_api_key_dict=self.team_admin_user,
+            existing_litellm_params=LiteLLM_Params(model="test_model", litellm_credential_name="shared-credential"),
+        )
+        assert result is True
+
     def test_can_user_attach_credential_internal_user_fails(self):
         with pytest.raises(Exception, match="Only a proxy admin can attach a stored credential") as exc_info:
             ModelManagementAuthChecks.can_user_attach_credential(

--- a/tests/test_litellm/proxy/management_endpoints/test_model_management_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_model_management_endpoints.py
@@ -305,6 +305,82 @@ class TestModelManagementAuthChecks:
         )
         assert result is True
 
+    @pytest.mark.asyncio
+    async def test_add_new_model_rejects_credential_attach_for_non_admin(self):
+        from litellm.proxy._types import ProxyException
+        from litellm.proxy.management_endpoints.model_management_endpoints import (
+            add_new_model,
+        )
+
+        mock_prisma = MagicMock()
+        with (
+            patch("litellm.proxy.proxy_server.prisma_client", mock_prisma),
+            patch("litellm.proxy.proxy_server.store_model_in_db", True),
+            patch("litellm.proxy.proxy_server.premium_user", True),
+            patch(
+                "litellm.proxy.management_endpoints.model_management_endpoints.ModelManagementAuthChecks.can_user_make_model_call",
+                new=AsyncMock(return_value=None),
+            ),
+        ):
+            with pytest.raises(ProxyException) as exc_info:
+                await add_new_model(
+                    model_params=Deployment(
+                        model_name="credential-model",
+                        litellm_params=LiteLLM_Params(
+                            model="openai/gpt-4o", litellm_credential_name="shared-credential"
+                        ),
+                        model_info={"id": "credential-create-test"},
+                    ),
+                    user_api_key_dict=self.team_admin_user,
+                )
+            assert exc_info.value.code == "403"
+            mock_prisma.db.litellm_proxymodeltable.create.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_patch_model_rejects_credential_attach_for_non_admin(self):
+        from litellm.proxy._types import ProxyException
+        from litellm.proxy.management_endpoints.model_management_endpoints import (
+            patch_model,
+        )
+        from litellm.types.router import updateLiteLLMParams
+
+        model_id = "credential-patch-test"
+        db_model = Deployment(
+            model_name="credential-model",
+            litellm_params=LiteLLM_Params(model="openai/gpt-4o"),
+            model_info={"id": model_id},
+        )
+        with (
+            patch("litellm.proxy.proxy_server.prisma_client", MagicMock()),
+            patch("litellm.proxy.proxy_server.llm_router", MagicMock()),
+            patch("litellm.proxy.proxy_server.store_model_in_db", True),
+            patch("litellm.proxy.proxy_server.premium_user", True),
+            patch(
+                "litellm.proxy.management_endpoints.model_management_endpoints.get_db_model",
+                new=AsyncMock(return_value=db_model),
+            ),
+            patch(
+                "litellm.proxy.management_endpoints.model_management_endpoints.ModelManagementAuthChecks.can_user_make_model_call",
+                new=AsyncMock(return_value=None),
+            ),
+            patch(
+                "litellm.proxy.management_endpoints.model_management_endpoints._update_team_model_in_db",
+                new=AsyncMock(),
+            ) as mock_update,
+        ):
+            with pytest.raises(ProxyException) as exc_info:
+                await patch_model(
+                    model_id=model_id,
+                    patch_data=updateDeployment(
+                        litellm_params=updateLiteLLMParams(
+                            model="openai/gpt-4o", litellm_credential_name="shared-credential"
+                        )
+                    ),
+                    user_api_key_dict=self.team_admin_user,
+                )
+            assert exc_info.value.code == "403"
+            mock_update.assert_not_awaited()
+
     def test_can_user_attach_credential_internal_user_fails(self):
         with pytest.raises(Exception, match="Only a proxy admin can attach a stored credential") as exc_info:
             ModelManagementAuthChecks.can_user_attach_credential(

--- a/tests/test_litellm/proxy/management_endpoints/test_model_management_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_model_management_endpoints.py
@@ -263,6 +263,36 @@ class TestModelManagementAuthChecks:
             )
         assert "403" in str(exc_info.value)
 
+    def test_can_user_attach_credential_admin_success(self):
+        result = ModelManagementAuthChecks.can_user_attach_credential(
+            litellm_params=LiteLLM_Params(model="test_model", litellm_credential_name="shared-credential"),
+            user_api_key_dict=self.admin_user,
+        )
+        assert result is True
+
+    def test_can_user_attach_credential_without_credential_allows_any_role(self):
+        result = ModelManagementAuthChecks.can_user_attach_credential(
+            litellm_params=LiteLLM_Params(model="test_model"),
+            user_api_key_dict=self.team_admin_user,
+        )
+        assert result is True
+
+    def test_can_user_attach_credential_team_admin_fails(self):
+        with pytest.raises(Exception, match="Only a proxy admin can attach a stored credential") as exc_info:
+            ModelManagementAuthChecks.can_user_attach_credential(
+                litellm_params=LiteLLM_Params(model="test_model", litellm_credential_name="shared-credential"),
+                user_api_key_dict=self.team_admin_user,
+            )
+        assert "403" in str(exc_info.value)
+
+    def test_can_user_attach_credential_internal_user_fails(self):
+        with pytest.raises(Exception, match="Only a proxy admin can attach a stored credential") as exc_info:
+            ModelManagementAuthChecks.can_user_attach_credential(
+                litellm_params=LiteLLM_Params(model="test_model", litellm_credential_name="shared-credential"),
+                user_api_key_dict=self.normal_user,
+            )
+        assert "403" in str(exc_info.value)
+
 
 class MockModelTable:
     def __init__(self, model_aliases: Dict[str, str], include: Optional[dict] = None):

--- a/ui/litellm-dashboard/src/app/(dashboard)/models-and-endpoints/panels/AddModelPanel.integration.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/models-and-endpoints/panels/AddModelPanel.integration.test.tsx
@@ -87,7 +87,6 @@ const alwaysMounted = {
   api_key: undefined,
   api_base: undefined,
   custom_llm_provider: "openai",
-  litellm_credential_name: null,
   model: "gpt-4o",
 };
 

--- a/ui/litellm-dashboard/src/components/add_model/handle_add_model_submit.test.tsx
+++ b/ui/litellm-dashboard/src/components/add_model/handle_add_model_submit.test.tsx
@@ -1,7 +1,18 @@
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { prepareModelAddRequest } from "./handle_add_model_submit";
+import { credentialListCall } from "../networking";
+
+vi.mock("../networking", () => ({
+  credentialListCall: vi.fn(),
+  modelCreateCall: vi.fn(),
+}));
+
+const credentialListCallMock = vi.mocked(credentialListCall);
 
 describe("prepareModelAddRequest", () => {
+  beforeEach(() => {
+    credentialListCallMock.mockReset();
+  });
   it("returns deployment data for the most basic form", async () => {
     const formValues = {
       model_mappings: [
@@ -74,7 +85,11 @@ describe("prepareModelAddRequest", () => {
     expect(deployment.litellmParamsObj.timeout).toBe(5);
   });
 
-  it("keeps litellm_credential_name from LiteLLM Params JSON when no credential is selected", async () => {
+  it("keeps litellm_credential_name from LiteLLM Params JSON when it matches an accessible credential", async () => {
+    credentialListCallMock.mockResolvedValue({
+      success: true,
+      credentials: [{ credential_name: "from-json", credential_values: {}, credential_info: {} }],
+    });
     const formValues = {
       model_mappings: [
         {
@@ -96,5 +111,30 @@ describe("prepareModelAddRequest", () => {
     const [deployment] = deployments!;
     expect(deployment.litellmParamsObj.litellm_credential_name).toBe("from-json");
     expect(deployment.litellmParamsObj.timeout).toBe(5);
+    expect(credentialListCallMock).toHaveBeenCalledWith("token");
+  });
+
+  it("rejects a JSON litellm_credential_name that matches no accessible credential", async () => {
+    credentialListCallMock.mockResolvedValue({
+      success: true,
+      credentials: [{ credential_name: "someone-elses-credential", credential_values: {}, credential_info: {} }],
+    });
+    const formValues = {
+      model_mappings: [
+        {
+          public_name: "Public Model",
+          litellm_model: "litellm/public",
+        },
+      ],
+      model_name: "custom-model-name",
+      litellm_extra_params: JSON.stringify({
+        litellm_credential_name: "from-json",
+      }),
+      litellm_credential_name: null,
+    };
+
+    const deployments = await prepareModelAddRequest({ ...formValues }, "token", null);
+
+    expect(deployments).toBeUndefined();
   });
 });

--- a/ui/litellm-dashboard/src/components/add_model/handle_add_model_submit.test.tsx
+++ b/ui/litellm-dashboard/src/components/add_model/handle_add_model_submit.test.tsx
@@ -73,4 +73,28 @@ describe("prepareModelAddRequest", () => {
     expect(deployment.litellmParamsObj.litellm_credential_name).toBe("selected-credential");
     expect(deployment.litellmParamsObj.timeout).toBe(5);
   });
+
+  it("keeps litellm_credential_name from LiteLLM Params JSON when no credential is selected", async () => {
+    const formValues = {
+      model_mappings: [
+        {
+          public_name: "Public Model",
+          litellm_model: "litellm/public",
+        },
+      ],
+      model_name: "custom-model-name",
+      litellm_extra_params: JSON.stringify({
+        litellm_credential_name: "from-json",
+        timeout: 5,
+      }),
+      litellm_credential_name: null,
+    };
+
+    const deployments = await prepareModelAddRequest({ ...formValues }, "token", null);
+
+    expect(deployments).toHaveLength(1);
+    const [deployment] = deployments!;
+    expect(deployment.litellmParamsObj.litellm_credential_name).toBe("from-json");
+    expect(deployment.litellmParamsObj.timeout).toBe(5);
+  });
 });

--- a/ui/litellm-dashboard/src/components/add_model/handle_add_model_submit.test.tsx
+++ b/ui/litellm-dashboard/src/components/add_model/handle_add_model_submit.test.tsx
@@ -1,18 +1,11 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { prepareModelAddRequest } from "./handle_add_model_submit";
-import { credentialListCall } from "../networking";
 
 vi.mock("../networking", () => ({
-  credentialListCall: vi.fn(),
   modelCreateCall: vi.fn(),
 }));
 
-const credentialListCallMock = vi.mocked(credentialListCall);
-
 describe("prepareModelAddRequest", () => {
-  beforeEach(() => {
-    credentialListCallMock.mockReset();
-  });
   it("returns deployment data for the most basic form", async () => {
     const formValues = {
       model_mappings: [
@@ -85,11 +78,7 @@ describe("prepareModelAddRequest", () => {
     expect(deployment.litellmParamsObj.timeout).toBe(5);
   });
 
-  it("keeps litellm_credential_name from LiteLLM Params JSON when it matches an accessible credential", async () => {
-    credentialListCallMock.mockResolvedValue({
-      success: true,
-      credentials: [{ credential_name: "from-json", credential_values: {}, credential_info: {} }],
-    });
+  it("keeps litellm_credential_name from LiteLLM Params JSON when no credential is selected", async () => {
     const formValues = {
       model_mappings: [
         {
@@ -111,30 +100,5 @@ describe("prepareModelAddRequest", () => {
     const [deployment] = deployments!;
     expect(deployment.litellmParamsObj.litellm_credential_name).toBe("from-json");
     expect(deployment.litellmParamsObj.timeout).toBe(5);
-    expect(credentialListCallMock).toHaveBeenCalledWith("token");
-  });
-
-  it("rejects a JSON litellm_credential_name that matches no accessible credential", async () => {
-    credentialListCallMock.mockResolvedValue({
-      success: true,
-      credentials: [{ credential_name: "someone-elses-credential", credential_values: {}, credential_info: {} }],
-    });
-    const formValues = {
-      model_mappings: [
-        {
-          public_name: "Public Model",
-          litellm_model: "litellm/public",
-        },
-      ],
-      model_name: "custom-model-name",
-      litellm_extra_params: JSON.stringify({
-        litellm_credential_name: "from-json",
-      }),
-      litellm_credential_name: null,
-    };
-
-    const deployments = await prepareModelAddRequest({ ...formValues }, "token", null);
-
-    expect(deployments).toBeUndefined();
   });
 });

--- a/ui/litellm-dashboard/src/components/add_model/handle_add_model_submit.tsx
+++ b/ui/litellm-dashboard/src/components/add_model/handle_add_model_submit.tsx
@@ -91,6 +91,9 @@ export const prepareModelAddRequest = async (formValues: Record<string, any>, ac
         if (value === "") {
           continue;
         }
+        if (key === "litellm_credential_name" && value == null) {
+          continue;
+        }
         // Skip the custom_pricing and pricing_model fields as they're only used for UI control
         if (key === "custom_pricing" || key === "pricing_model" || key === "cache_control") {
           continue;
@@ -124,7 +127,7 @@ export const prepareModelAddRequest = async (formValues: Record<string, any>, ac
           if (value && value != undefined) {
             try {
               litellmExtraParams = JSON.parse(value);
-              if ("litellm_credential_name" in litellmExtraParams) {
+              if ("litellm_credential_name" in litellmExtraParams && formValues.litellm_credential_name) {
                 delete litellmExtraParams.litellm_credential_name;
               }
             } catch (error) {

--- a/ui/litellm-dashboard/src/components/add_model/handle_add_model_submit.tsx
+++ b/ui/litellm-dashboard/src/components/add_model/handle_add_model_submit.tsx
@@ -1,7 +1,20 @@
 import { toast } from "@/lib/toast";
-import { Model, modelCreateCall } from "../networking";
+import { credentialListCall, Model, modelCreateCall } from "../networking";
 import { provider_map } from "../provider_info_helpers";
 import { ptuPickerToUtcIso } from "../../utils/ptuDatetime";
+
+const assertCredentialAccessible = async (credentialName: unknown, accessToken: string) => {
+  if (typeof credentialName !== "string" || credentialName === "") {
+    throw new Error("litellm_credential_name in LiteLLM Params must be a non-empty string");
+  }
+  const response = await credentialListCall(accessToken);
+  const accessibleNames = (response?.credentials ?? []).map(
+    (credential: { credential_name: string }) => credential.credential_name,
+  );
+  if (!accessibleNames.includes(credentialName)) {
+    throw new Error(`Credential '${credentialName}' does not match any credential you have access to`);
+  }
+};
 
 export const prepareModelAddRequest = async (formValues: Record<string, any>, accessToken: string, form: any) => {
   try {
@@ -127,12 +140,16 @@ export const prepareModelAddRequest = async (formValues: Record<string, any>, ac
           if (value && value != undefined) {
             try {
               litellmExtraParams = JSON.parse(value);
-              if ("litellm_credential_name" in litellmExtraParams && formValues.litellm_credential_name) {
-                delete litellmExtraParams.litellm_credential_name;
-              }
             } catch (error) {
               toast.fromError("Failed to parse LiteLLM Extra Params: " + error);
               throw new Error("Failed to parse litellm_extra_params: " + error);
+            }
+            if ("litellm_credential_name" in litellmExtraParams) {
+              if (formValues.litellm_credential_name) {
+                delete litellmExtraParams.litellm_credential_name;
+              } else {
+                await assertCredentialAccessible(litellmExtraParams.litellm_credential_name, accessToken);
+              }
             }
             for (const [key, value] of Object.entries(litellmExtraParams)) {
               litellmParamsObj[key] = value;

--- a/ui/litellm-dashboard/src/components/add_model/handle_add_model_submit.tsx
+++ b/ui/litellm-dashboard/src/components/add_model/handle_add_model_submit.tsx
@@ -1,20 +1,7 @@
 import { toast } from "@/lib/toast";
-import { credentialListCall, Model, modelCreateCall } from "../networking";
+import { Model, modelCreateCall } from "../networking";
 import { provider_map } from "../provider_info_helpers";
 import { ptuPickerToUtcIso } from "../../utils/ptuDatetime";
-
-const assertCredentialAccessible = async (credentialName: unknown, accessToken: string) => {
-  if (typeof credentialName !== "string" || credentialName === "") {
-    throw new Error("litellm_credential_name in LiteLLM Params must be a non-empty string");
-  }
-  const response = await credentialListCall(accessToken);
-  const accessibleNames = (response?.credentials ?? []).map(
-    (credential: { credential_name: string }) => credential.credential_name,
-  );
-  if (!accessibleNames.includes(credentialName)) {
-    throw new Error(`Credential '${credentialName}' does not match any credential you have access to`);
-  }
-};
 
 export const prepareModelAddRequest = async (formValues: Record<string, any>, accessToken: string, form: any) => {
   try {
@@ -144,12 +131,8 @@ export const prepareModelAddRequest = async (formValues: Record<string, any>, ac
               toast.fromError("Failed to parse LiteLLM Extra Params: " + error);
               throw new Error("Failed to parse litellm_extra_params: " + error);
             }
-            if ("litellm_credential_name" in litellmExtraParams) {
-              if (formValues.litellm_credential_name) {
-                delete litellmExtraParams.litellm_credential_name;
-              } else {
-                await assertCredentialAccessible(litellmExtraParams.litellm_credential_name, accessToken);
-              }
+            if ("litellm_credential_name" in litellmExtraParams && formValues.litellm_credential_name) {
+              delete litellmExtraParams.litellm_credential_name;
             }
             for (const [key, value] of Object.entries(litellmExtraParams)) {
               litellmParamsObj[key] = value;


### PR DESCRIPTION
## TLDR

Problem this solves:

- Add Model silently dropped `litellm_credential_name` typed into LiteLLM Params JSON
- Any team admin could attach any stored credential to a model
- Credential authorization only lived in the dashboard, not the proxy

How it solves it:

- UI keeps the JSON credential name when the dropdown is empty
- An explicitly selected dropdown credential still wins over JSON
- `/model/new` and `/model/update` now reject credential attach unless proxy admin

## User Flow

Before: a proxy admin adding a model through the UI loses the credential they typed into the JSON box, and a team admin can borrow any stored credential over the API

1. Admin opens http://localhost:4000/ui/?page=add-model, leaves the credentials dropdown empty, and puts `{"litellm_credential_name": "shared-openai-credential-2"}` in the LiteLLM Params JSON box
2. They click Add Model; the model is created but the credential reference is gone, so calls to it fail with an auth error from the provider
3. Separately, a team admin sends POST http://localhost:4000/model/new with `"litellm_credential_name": "shared-openai-credential-2"` in `litellm_params` and gets HTTP 200, so their team's model now runs on a credential the proxy admin never granted them

After: the same JSON credential sticks, and the team admin's borrow attempt is refused

1. Admin opens http://localhost:4000/ui/?page=add-model, leaves the dropdown empty, and puts the same JSON in the LiteLLM Params box
2. They click Add Model; the model is created with `litellm_credential_name` intact and calls to it resolve the stored credential as expected
3. The team admin sends the same POST http://localhost:4000/model/new and gets HTTP 403 with "Only a proxy admin can attach a stored credential (litellm_credential_name) to a model"

## Relevant issues

Reopens #39005 (reverted for the credential authorization gap flagged in review)

## Linear ticket

Resolves LIT-6563

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Shared setup: proxy running on http://localhost:4000 with a Postgres DB, master key `sk-1234`. A stored credential, a team, a team admin user, and a team-scoped key are created first:

```bash
H='Authorization: Bearer sk-1234'
J='Content-Type: application/json'
B=http://localhost:4000

curl -s -X POST $B/credentials -H "$H" -H "$J" -d '{"credential_name": "shared-openai-credential-2", "credential_values": {"api_key": "sk-..."}, "credential_info": {"custom_llm_provider": "openai"}}'
# {"success":true,"message":"Credential created successfully"}

curl -s -X POST $B/user/new -H "$H" -H "$J" -d '{"user_id": "team-admin-user", "user_role": "internal_user"}'
TEAM=$(curl -s -X POST $B/team/new -H "$H" -H "$J" -d '{"team_alias": "credential-test-team", "members_with_roles": [{"user_id": "team-admin-user", "role": "admin"}]}' | python3 -c 'import sys,json; print(json.load(sys.stdin)["team_id"])')
KEY=$(curl -s -X POST $B/key/generate -H "$H" -H "$J" -d "{\"user_id\": \"team-admin-user\", \"team_id\": \"$TEAM\"}" | python3 -c 'import sys,json; print(json.load(sys.stdin)["key"])')
```

### Before (9f67a58198)

#### Team admin attaches a stored credential to a team model

1. `curl -s -w 'HTTP %{http_code}\n' -X POST $B/model/new -H "Authorization: Bearer $KEY" -H "$J" -d "{\"model_name\": \"team-gpt\", \"litellm_params\": {\"model\": \"openai/gpt-5.2\", \"litellm_credential_name\": \"shared-openai-credential-2\"}, \"model_info\": {\"team_id\": \"$TEAM\"}}"`
2. Observed: `HTTP 200` and the created deployment carries the borrowed credential reference in `litellm_params.litellm_credential_name`

#### JSON credential name in the Add Model form

1. Open http://localhost:4000/ui/?page=add-model, leave the credentials dropdown empty, put `{"litellm_credential_name": "shared-openai-credential-2"}` in the LiteLLM Params JSON box, click Add Model
2. Observed: the created model has no `litellm_credential_name`; the JSON value was dropped

### After (e064a8cdc5)

#### Team admin attaches a stored credential to a team model

1. Same curl as Before
2. Observed:

```
HTTP 403
{"error":{"message":"Only a proxy admin can attach a stored credential (litellm_credential_name) to a model. Your role=internal_user.","type":"auth_error","param":"litellm_credential_name","code":"403"}}
```

3. The same team admin creating a model without a stored credential still works:

```
HTTP 200
{"model_name": "model_name_4e7266ba-..._c4824944-...", "model_id": "aa7ea795-bfc5-4e63-949f-9432175f9b2e"}
```

4. A proxy admin attaching the stored credential still works:

```
HTTP 200
{"model_name": "admin-gpt", "litellm_params": {"litellm_credential_name": "<encrypted in DB>"}}
```

#### Team admin updates a model that already carries a stored credential

The stored name is encrypted at rest, so the unchanged check decrypts it before comparing:

1. Proxy admin creates a team model with `litellm_credential_name` attached, then the team admin re-submits the same plaintext name while changing `rpm`:

```
curl -s -w 'HTTP %{http_code}\n' -X PATCH $B/model/$MODEL_ID/update -H "Authorization: Bearer $KEY" -H "$J" -d "{\"litellm_params\": {\"model\": \"openai/gpt-5.2\", \"litellm_credential_name\": \"$CRED\", \"rpm\": 42}}"
HTTP 200
```

2. The same team admin swapping to a different stored credential is still refused:

```
HTTP 403
{"error":{"message":"Only a proxy admin can attach a stored credential (litellm_credential_name) to a model. Your role=internal_user.","type":"auth_error","param":"litellm_credential_name","code":"403"}}
```

#### JSON credential name in the Add Model form

1. Open http://localhost:4000/ui/?page=add-model as a proxy admin, leave the credentials dropdown empty, put `{"litellm_credential_name": "shared-openai-credential-2"}` in the LiteLLM Params JSON box, click Add Model
2. Observed: the created model keeps `litellm_credential_name` and requests to it resolve the stored credential

## Type

🐛 Bug Fix

## Caveats (if any)

### Medium

- Attaching stored credentials to models is now proxy admin only
  - Team admins who relied on it must ask a proxy admin, or set provider keys directly in `litellm_params`

### Low

- Runtime credential resolution is unchanged; this gates only model create and update

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR


Link to Devin session: https://app.devin.ai/sessions/95f70feab5aa4253b49826b2001de000
Open in Devin Desktop: https://app.devin.ai/desktop/session/95f70feab5aa4253b49826b2001de000?variant=devin
Requested by: @yassin-berriai