### PR TITLE
fix(guardrails): record not_run evaluation when scoping leaves nothing to scan

### DIFF
--- a/litellm/llms/openai/chat/guardrail_translation/handler.py
+++ b/litellm/llms/openai/chat/guardrail_translation/handler.py
@@ -191,6 +191,15 @@ class OpenAIChatCompletionsHandler(BaseTranslation):
                         task_mappings=tool_call_task_mappings,
                     )
 
+        elif not guardrail_to_apply.records_own_guardrail_information:
+            # Every guardrail in applied_guardrails needs a persisted evaluation record,
+            # or request logs report it as silently missing (LIT-6314).
+            guardrail_to_apply.add_standard_logging_guardrail_information_to_request_data(
+                guardrail_json_response="no scannable content after message scoping",
+                request_data=data,
+                guardrail_status="not_run",
+            )
+
         verbose_proxy_logger.debug(
             "OpenAI Chat Completions: Processed input messages: %s",
             data.get("messages"),

--- a/litellm/proxy/compliance_checks.py
+++ b/litellm/proxy/compliance_checks.py
@@ -26,7 +26,8 @@ class ComplianceChecker:
 
     def __init__(self, data: ComplianceCheckRequest):
         self.data = data
-        self.guardrails = data.guardrail_information or []
+        # a not_run entry records a guardrail that never evaluated the request, so it cannot evidence compliance
+        self.guardrails = [g for g in (data.guardrail_information or []) if g.get("guardrail_status") != "not_run"]
 
     def _get_guardrails_by_mode(self, mode: str) -> list[dict]:
         """

--- a/litellm/proxy/guardrails/usage_endpoints.py
+++ b/litellm/proxy/guardrails/usage_endpoints.py
@@ -256,7 +256,7 @@ class UsageDetailResponse(BaseModel):
 class UsageLogEntry(BaseModel):
     id: str
     timestamp: str
-    action: str  # blocked | passed | flagged
+    action: str  # blocked | passed | flagged | not_run
     score: float | None
     latency_ms: float | None
     model: str | None
@@ -691,7 +691,9 @@ def _usage_log_entry_from_row(
     reason_val = None
     if entry_for_guardrail:
         st: Final = (entry_for_guardrail.get("guardrail_status") or "").lower()
-        if "intervened" in st or "block" in st:
+        if st == "not_run":
+            action_val = "not_run"
+        elif "intervened" in st or "block" in st:
             action_val = "blocked"
         elif "fail" in st or "error" in st:
             action_val = "flagged"

--- a/litellm/proxy/guardrails/usage_tracking.py
+++ b/litellm/proxy/guardrails/usage_tracking.py
@@ -316,15 +316,18 @@ async def process_spend_logs_guardrail_usage(
             guardrail_id = entry.get("guardrail_id") or entry.get("guardrail_name") or ""
             if not guardrail_id:
                 continue
-            key = _MetricsKey(guardrail_id, date_key)
-            daily_guardrail[key]["requests_evaluated"] += 1
-            action = _guardrail_status_to_action(entry.get("guardrail_status"))
-            if action == "passed":
-                daily_guardrail[key]["passed_count"] += 1
-            elif action == "blocked":
-                daily_guardrail[key]["blocked_count"] += 1
-            else:
-                daily_guardrail[key]["flagged_count"] += 1
+            status = entry.get("guardrail_status")
+            # not_run means the guardrail never evaluated the request: index it for drill-down, keep it out of counts
+            if status != "not_run":
+                key = _MetricsKey(guardrail_id, date_key)
+                daily_guardrail[key]["requests_evaluated"] += 1
+                action = _guardrail_status_to_action(status)
+                if action == "passed":
+                    daily_guardrail[key]["passed_count"] += 1
+                elif action == "blocked":
+                    daily_guardrail[key]["blocked_count"] += 1
+                else:
+                    daily_guardrail[key]["flagged_count"] += 1
             policy_id = entry.get("policy_id")
             index_rows.append(
                 {

--- a/litellm/proxy/hooks/proxy_track_cost_callback.py
+++ b/litellm/proxy/hooks/proxy_track_cost_callback.py
@@ -269,20 +269,6 @@ class _ProxyDBLogger(CustomLogger):
                 served_model_id=sl_object.get("model_id") if sl_object is not None else None,
                 router=get_llm_router(),
             )
-            # LIT-6314: post-call guardrail evaluations run after SLP is built, so
-            # guardrail_information is missing from SLP. Populate it from post-call evals
-            # before spend-log write so reports show accurate guardrail results.
-            if sl_object is not None:
-                litellm_metadata: Final = kwargs.get("litellm_metadata")
-                guardrail_info_from_hooks: Final = (
-                    litellm_metadata.get("standard_logging_guardrail_information")
-                    if isinstance(litellm_metadata, dict)
-                    else None
-                )
-                if guardrail_info_from_hooks is not None and not sl_object.get("guardrail_information"):
-                    sl_object["guardrail_information"] = (
-                        guardrail_info_from_hooks  # mutable-ok: populate SLP before spend-log write
-                    )
 
             if response_cost is not None:
                 user_api_key: Final = metadata.get("user_api_key", None)

--- a/litellm/proxy/hooks/proxy_track_cost_callback.py
+++ b/litellm/proxy/hooks/proxy_track_cost_callback.py
@@ -269,6 +269,17 @@ class _ProxyDBLogger(CustomLogger):
                 served_model_id=sl_object.get("model_id") if sl_object is not None else None,
                 router=get_llm_router(),
             )
+            # LIT-6314: post-call guardrail evaluations run after SLP is built, so
+            # guardrail_information is missing from SLP. Populate it from post-call evals
+            # before spend-log write so reports show accurate guardrail results.
+            if sl_object is not None:
+                guardrail_info_from_hooks: Final = (
+                    kwargs.get("litellm_metadata", {}).get("standard_logging_guardrail_information")
+                    if isinstance(kwargs.get("litellm_metadata"), dict)
+                    else None
+                )
+                if guardrail_info_from_hooks is not None and not sl_object.get("guardrail_information"):
+                    sl_object["guardrail_information"] = guardrail_info_from_hooks
 
             if response_cost is not None:
                 user_api_key: Final = metadata.get("user_api_key", None)

--- a/litellm/proxy/hooks/proxy_track_cost_callback.py
+++ b/litellm/proxy/hooks/proxy_track_cost_callback.py
@@ -273,13 +273,16 @@ class _ProxyDBLogger(CustomLogger):
             # guardrail_information is missing from SLP. Populate it from post-call evals
             # before spend-log write so reports show accurate guardrail results.
             if sl_object is not None:
+                litellm_metadata: Final = kwargs.get("litellm_metadata")
                 guardrail_info_from_hooks: Final = (
-                    kwargs.get("litellm_metadata", {}).get("standard_logging_guardrail_information")
-                    if isinstance(kwargs.get("litellm_metadata"), dict)
+                    litellm_metadata.get("standard_logging_guardrail_information")
+                    if isinstance(litellm_metadata, dict)
                     else None
                 )
                 if guardrail_info_from_hooks is not None and not sl_object.get("guardrail_information"):
-                    sl_object["guardrail_information"] = guardrail_info_from_hooks
+                    sl_object["guardrail_information"] = (
+                        guardrail_info_from_hooks  # mutable-ok: populate SLP before spend-log write
+                    )
 
             if response_cost is not None:
                 user_api_key: Final = metadata.get("user_api_key", None)

--- a/tests/test_litellm/llms/openai/chat/guardrail_translation/test_openai_guardrail_handler.py
+++ b/tests/test_litellm/llms/openai/chat/guardrail_translation/test_openai_guardrail_handler.py
@@ -1559,3 +1559,53 @@ class TestScanOnlyToolResults:
         assert data["messages"][3]["content"] == "page says [BLOCKED] here"
         assert data["messages"][3]["tool_call_id"] == "call_1"
         assert data["messages"][4]["content"] == "and then?"
+
+
+class TestNoScannableContentRecordsNotRun:
+    """LIT-6314: a guardrail whose scoping leaves nothing to scan must still persist an evaluation record"""
+
+    def _system_only_data(self) -> dict:
+        return {"messages": [{"role": "system", "content": "SYSTEM-PROMPT"}]}
+
+    def _recorded_entries(self, data: dict) -> list:
+        metadata = data.get("metadata") or data.get("litellm_metadata") or {}
+        return metadata.get("standard_logging_guardrail_information") or []
+
+    @pytest.mark.asyncio
+    async def test_skipped_scan_records_not_run_entry(self):
+        handler = OpenAIChatCompletionsHandler()
+        guardrail = MockGuardrail(guardrail_name="skip-system-guardrail")
+        guardrail.skip_system_message_in_guardrail = True
+        data = self._system_only_data()
+
+        await handler.process_input_messages(data=data, guardrail_to_apply=guardrail)
+
+        assert guardrail.last_inputs is None, "nothing survived scoping, apply_guardrail must not run"
+        entries = self._recorded_entries(data)
+        assert len(entries) == 1
+        assert entries[0]["guardrail_name"] == "skip-system-guardrail"
+        assert entries[0]["guardrail_status"] == "not_run"
+
+    @pytest.mark.asyncio
+    async def test_self_recording_guardrail_is_left_alone(self):
+        handler = OpenAIChatCompletionsHandler()
+        guardrail = MockGuardrail(guardrail_name="self-recording-guardrail")
+        guardrail.skip_system_message_in_guardrail = True
+        guardrail.records_own_guardrail_information = True
+        data = self._system_only_data()
+
+        await handler.process_input_messages(data=data, guardrail_to_apply=guardrail)
+
+        assert guardrail.last_inputs is None
+        assert self._recorded_entries(data) == []
+
+    @pytest.mark.asyncio
+    async def test_scannable_content_records_no_extra_entry(self):
+        handler = OpenAIChatCompletionsHandler()
+        guardrail = MockGuardrail(guardrail_name="normal-guardrail")
+        data = {"messages": [{"role": "user", "content": "hello"}]}
+
+        await handler.process_input_messages(data=data, guardrail_to_apply=guardrail)
+
+        assert guardrail.last_inputs is not None
+        assert all(e.get("guardrail_status") != "not_run" for e in self._recorded_entries(data))

--- a/tests/test_litellm/proxy/guardrails/test_usage_endpoints.py
+++ b/tests/test_litellm/proxy/guardrails/test_usage_endpoints.py
@@ -9,12 +9,10 @@ orphans), and logs missed their logical-name alias.
 """
 
 from datetime import datetime
-from typing import Any, Optional
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-
-
 from fastapi import HTTPException
 from prisma.errors import TableNotFoundError
 
@@ -47,7 +45,7 @@ def _yaml_guardrail(
     guardrail_id: str = "yaml-1",
     name: str = "yaml-pii",
     provider: str = "presidio",
-    info: Optional[dict] = None,
+    info: dict | None = None,
 ) -> Guardrail:
     return Guardrail(
         guardrail_id=guardrail_id,
@@ -433,3 +431,67 @@ async def test_detail_prev_trend_query_is_bounded():
     prev_wheres = [w for w in wheres if "lt" in w.get("date", {})]
     assert prev_wheres
     assert all("gte" in w["date"] for w in prev_wheres)
+
+
+@pytest.mark.asyncio
+async def test_logs_report_not_run_entries_as_not_run_not_passed():
+    """LIT-6314: a guardrail that never scanned must not be reported as a pass in the drill-down."""
+    index_row = MagicMock()
+    index_row.request_id = "req-nr"
+    index_row.guardrail_id = "db-1"
+    index_row.start_time = datetime(2026, 4, 22)
+    spend_log = MagicMock()
+    spend_log.request_id = "req-nr"
+    spend_log.model = "gpt-4o-mini"
+    spend_log.startTime = datetime(2026, 4, 22)
+    spend_log.metadata = {
+        "guardrail_information": [
+            {"guardrail_name": "db-1", "guardrail_status": "not_run", "duration": 0.0},
+        ]
+    }
+    prisma = _prisma(find_unique=_db_row(), index_find_many=[index_row])
+    prisma.db.litellm_spendlogs.find_many = AsyncMock(return_value=[spend_log])
+    handler = _config_handler()
+    p1, p2 = _patches(prisma, handler)
+    with p1, p2:
+        resp = await guardrails_usage_logs(
+            guardrail_id="db-1",
+            policy_id=None,
+            page=1,
+            page_size=50,
+            action=None,
+            start_date=START,
+            end_date=END,
+            user_api_key_dict=ADMIN,
+        )
+    assert [log.action for log in resp.logs] == ["not_run"]
+
+
+@pytest.mark.asyncio
+async def test_logs_action_passed_filter_excludes_not_run_entries():
+    """LIT-6314: filtering the drill-down for passes must not return unscanned requests."""
+    index_row = MagicMock()
+    index_row.request_id = "req-nr"
+    index_row.guardrail_id = "db-1"
+    index_row.start_time = datetime(2026, 4, 22)
+    spend_log = MagicMock()
+    spend_log.request_id = "req-nr"
+    spend_log.model = "gpt-4o-mini"
+    spend_log.startTime = datetime(2026, 4, 22)
+    spend_log.metadata = {"guardrail_information": [{"guardrail_name": "db-1", "guardrail_status": "not_run"}]}
+    prisma = _prisma(find_unique=_db_row(), index_find_many=[index_row])
+    prisma.db.litellm_spendlogs.find_many = AsyncMock(return_value=[spend_log])
+    handler = _config_handler()
+    p1, p2 = _patches(prisma, handler)
+    with p1, p2:
+        resp = await guardrails_usage_logs(
+            guardrail_id="db-1",
+            policy_id=None,
+            page=1,
+            page_size=50,
+            action="passed",
+            start_date=START,
+            end_date=END,
+            user_api_key_dict=ADMIN,
+        )
+    assert resp.logs == []

--- a/tests/test_litellm/proxy/guardrails/test_usage_tracking.py
+++ b/tests/test_litellm/proxy/guardrails/test_usage_tracking.py
@@ -307,6 +307,37 @@ async def test_zero_and_non_int_usage_counters_are_skipped():
 
 
 @pytest.mark.asyncio
+async def test_not_run_entries_are_indexed_but_not_counted_as_evaluations():
+    """
+    LIT-6314 records a not_run entry when message scoping leaves a guardrail
+    nothing to scan. The guardrail never evaluated the request, so counting it
+    as a passed evaluation would inflate daily pass rates; it still gets an
+    index row so per-request drill-down finds the spend log.
+    """
+    prisma = _prisma()
+    logs = [_payload("r1", guardrail_status="not_run"), _payload("r2")]
+
+    await process_spend_logs_guardrail_usage(prisma, logs)
+
+    metrics_create = prisma.db.litellm_dailyguardrailmetrics.upsert.call_args.kwargs["data"]["create"]
+    assert metrics_create["requests_evaluated"] == 1
+    assert metrics_create["passed_count"] == 1
+    index_rows = prisma.db.litellm_spendlogguardrailindex.create_many.call_args.kwargs["data"]
+    assert sorted(row["request_id"] for row in index_rows) == ["r1", "r2"]
+
+
+@pytest.mark.asyncio
+async def test_batch_of_only_not_run_entries_writes_no_metrics_row():
+    prisma = _prisma()
+
+    await process_spend_logs_guardrail_usage(prisma, [_payload("r1", guardrail_status="not_run")])
+
+    assert prisma.db.litellm_dailyguardrailmetrics.upsert.call_count == 0
+    index_rows = prisma.db.litellm_spendlogguardrailindex.create_many.call_args.kwargs["data"]
+    assert [row["request_id"] for row in index_rows] == ["r1"]
+
+
+@pytest.mark.asyncio
 async def test_payload_without_request_id_is_skipped_like_the_metrics_path():
     prisma = _prisma()
     logs = [

--- a/tests/test_litellm/proxy/hooks/test_proxy_track_cost_callback.py
+++ b/tests/test_litellm/proxy/hooks/test_proxy_track_cost_callback.py
@@ -1,4 +1,3 @@
-
 from datetime import datetime
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -70,9 +69,7 @@ async def test_async_post_call_failure_hook():
 
         # Check that metadata was properly updated
         assert "litellm_params" in call_args["kwargs"]
-        assert call_args["kwargs"]["litellm_params"]["proxy_server_request"] == {
-            "request_id": "test_request_id"
-        }
+        assert call_args["kwargs"]["litellm_params"]["proxy_server_request"] == {"request_id": "test_request_id"}
         metadata = call_args["kwargs"]["litellm_params"]["metadata"]
         assert metadata["user_api_key"] == "test_api_key"
         assert metadata["status"] == "failure"
@@ -336,9 +333,7 @@ async def test_should_continue_failure_tracking_when_budget_release_fails():
         )
         assert mock_invalidate_budget_reservation_counters.await_count == 1
         assert (
-            mock_invalidate_budget_reservation_counters.await_args.kwargs[
-                "budget_reservation"
-            ]
+            mock_invalidate_budget_reservation_counters.await_args.kwargs["budget_reservation"]
             is user_api_key_dict.budget_reservation
         )
         assert user_api_key_dict.budget_reservation["finalized"] is True
@@ -433,36 +428,21 @@ def test_get_budget_reservation_from_metadata_handles_dict_auth_object():
         "entries": [{"counter_key": "spend:key:test_api_key"}],
     }
 
+    assert _get_budget_reservation_from_metadata(metadata={"user_api_key_auth": dict(UserAPIKeyAuth())}) is None
     assert (
         _get_budget_reservation_from_metadata(
-            metadata={"user_api_key_auth": dict(UserAPIKeyAuth())}
-        )
-        is None
-    )
-    assert (
-        _get_budget_reservation_from_metadata(
-            metadata={
-                "user_api_key_auth": UserAPIKeyAuth(
-                    budget_reservation=budget_reservation
-                )
-            }
+            metadata={"user_api_key_auth": UserAPIKeyAuth(budget_reservation=budget_reservation)}
         )
         == budget_reservation
     )
     assert (
         _get_budget_reservation_from_metadata(
-            metadata={
-                "user_api_key_auth": dict(
-                    UserAPIKeyAuth(budget_reservation=budget_reservation)
-                )
-            }
+            metadata={"user_api_key_auth": dict(UserAPIKeyAuth(budget_reservation=budget_reservation))}
         )
         == budget_reservation
     )
     assert (
-        _get_budget_reservation_from_metadata(
-            metadata={"user_api_key_budget_reservation": budget_reservation}
-        )
+        _get_budget_reservation_from_metadata(metadata={"user_api_key_budget_reservation": budget_reservation})
         is budget_reservation
     )
 
@@ -470,9 +450,7 @@ def test_get_budget_reservation_from_metadata_handles_dict_auth_object():
 @pytest.mark.asyncio
 async def test_update_database_and_spend_counters_releases_reservation_when_db_update_fails():
     proxy_logging_obj = MagicMock()
-    proxy_logging_obj.db_spend_update_writer.update_database = AsyncMock(
-        side_effect=Exception("db unavailable")
-    )
+    proxy_logging_obj.db_spend_update_writer.update_database = AsyncMock(side_effect=Exception("db unavailable"))
     increment_spend_counters = AsyncMock()
     budget_reservation = {"reserved_cost": 0.5, "entries": []}
 
@@ -508,9 +486,7 @@ async def test_update_database_and_spend_counters_releases_reservation_when_db_u
 async def test_update_database_and_spend_counters_preserves_db_exception_when_release_fails():
     proxy_logging_obj = MagicMock()
     db_exception = RuntimeError("db unavailable")
-    proxy_logging_obj.db_spend_update_writer.update_database = AsyncMock(
-        side_effect=db_exception
-    )
+    proxy_logging_obj.db_spend_update_writer.update_database = AsyncMock(side_effect=db_exception)
     increment_spend_counters = AsyncMock()
     budget_reservation = {"reserved_cost": 0.5, "entries": []}
 
@@ -554,12 +530,8 @@ async def test_update_database_and_spend_counters_preserves_db_exception_when_re
             budget_reservation=budget_reservation,
         )
         assert mock_log_exception.call_count == 2
-        mock_log_exception.assert_any_call(
-            "Failed to release budget reservation after database update failed"
-        )
-        mock_log_exception.assert_any_call(
-            "Failed to invalidate budget reservation counters after release failed"
-        )
+        mock_log_exception.assert_any_call("Failed to release budget reservation after database update failed")
+        mock_log_exception.assert_any_call("Failed to invalidate budget reservation counters after release failed")
 
     increment_spend_counters.assert_not_awaited()
 
@@ -1101,10 +1073,7 @@ async def test_async_post_call_failure_hook_propagates_trace_id_from_logging_obj
 
         # standard_logging_object should have been propagated from logging obj
         assert call_kwargs.get("standard_logging_object") is not None
-        assert (
-            call_kwargs["standard_logging_object"]["trace_id"]
-            == "trace-id-from-logging-obj"
-        )
+        assert call_kwargs["standard_logging_object"]["trace_id"] == "trace-id-from-logging-obj"
         # litellm_trace_id should also be propagated as a fallback
         assert call_kwargs.get("litellm_trace_id") == "trace-id-from-logging-obj"
 
@@ -1691,9 +1660,7 @@ async def test_async_post_call_failure_hook_records_recovered_partial_spend():
         "metadata": {},
         "proxy_server_request": {"request_id": "rid"},
         "response_cost": 3.5e-05,
-        "combined_usage_object": Usage(
-            prompt_tokens=30, completion_tokens=1, total_tokens=31
-        ),
+        "combined_usage_object": Usage(prompt_tokens=30, completion_tokens=1, total_tokens=31),
     }
 
     with patch(
@@ -1772,15 +1739,10 @@ async def test_track_cost_callback_enriches_user_id_for_mcp_style_metadata():
         assert mock_increment.call_args.kwargs["team_id"] == "team-123"
         assert mock_increment.call_args.kwargs["org_id"] == "org-456"
 
-        update_kwargs = (
-            mock_proxy_logging.db_spend_update_writer.update_database.await_args.kwargs
-        )
+        update_kwargs = mock_proxy_logging.db_spend_update_writer.update_database.await_args.kwargs
         assert update_kwargs["user_id"] == "mcp-user@example.com"
         assert update_kwargs["team_id"] == "team-123"
-        assert (
-            kwargs["litellm_params"]["metadata"]["user_api_key_user_id"]
-            == "mcp-user@example.com"
-        )
+        assert kwargs["litellm_params"]["metadata"]["user_api_key_user_id"] == "mcp-user@example.com"
 
 
 @pytest.mark.parametrize(
@@ -1828,9 +1790,7 @@ def test_should_track_cost_callback_pass_through_without_owner(call_type, expect
     ],
 )
 @pytest.mark.asyncio
-async def test_track_cost_callback_logs_unauthenticated_pass_through_request(
-    call_type, expect_spend_log
-):
+async def test_track_cost_callback_logs_unauthenticated_pass_through_request(call_type, expect_spend_log):
     """Regression for LIT-3782: a pass-through request with auth=false reaches the
     cost callback with no key/user/team/end-user. Before the fix the spend-log
     write was skipped and the request never appeared in request/usage logs. It
@@ -1876,9 +1836,7 @@ async def test_track_cost_callback_logs_unauthenticated_pass_through_request(
             end_time=datetime.now(),
         )
 
-        assert mock_proxy_logging.db_spend_update_writer.update_database.await_count == (
-            1 if expect_spend_log else 0
-        )
+        assert mock_proxy_logging.db_spend_update_writer.update_database.await_count == (1 if expect_spend_log else 0)
 
 
 class _FakeDeploymentLookup:
@@ -1989,3 +1947,61 @@ async def test_spend_counters_keep_every_granted_group_when_the_deployment_is_un
     )
 
     assert charged == ("premium", "tier0")
+
+
+@pytest.mark.asyncio
+async def test_proxy_track_cost_callback_carries_guardrail_info_to_sl_object():
+    """
+    LIT-6314 regression: post-call guardrails append evaluations to
+    request_data["litellm_metadata"]["standard_logging_guardrail_information"],
+    but the standard_logging_object (built pre-post-call) lacks this field.
+    The callback must populate standard_logging_object["guardrail_information"]
+    from post-call evals before spend-log write so reports show results.
+    """
+    logger = _ProxyDBLogger()
+    guardrail_info = [
+        {
+            "guardrail_name": "bedrock-guard",
+            "guardrail_status": "success",
+            "guardrail_cost": 0.0001,
+        }
+    ]
+    sl_object = {"response_cost": 0.01}
+    kwargs = {
+        "model": "gpt-4",
+        "messages": [{"role": "user", "content": "Hello"}],
+        "litellm_metadata": {"standard_logging_guardrail_information": guardrail_info},
+        "litellm_params": {
+            "metadata": {"user_api_key": "test_key"},
+        },
+        "call_type": CallTypes.completion.value,
+        "response_cost": 0.01,
+        "standard_logging_object": sl_object,
+    }
+
+    with (
+        patch(
+            "litellm.proxy.proxy_server.increment_spend_counters",
+            new_callable=AsyncMock,
+        ),
+        patch(
+            "litellm.proxy.proxy_server.update_cache",
+            new_callable=AsyncMock,
+        ),
+        patch(
+            "litellm.proxy.proxy_server.proxy_logging_obj",
+        ) as mock_proxy_logging,
+    ):
+        mock_proxy_logging.db_spend_update_writer.update_database = AsyncMock()
+        mock_proxy_logging.slack_alerting_instance.customer_spend_alert = AsyncMock()
+        mock_proxy_logging.failed_tracking_alert = AsyncMock()
+
+        await logger._PROXY_track_cost_callback(
+            kwargs=kwargs,
+            completion_response=None,
+            start_time=datetime.now(),
+            end_time=datetime.now(),
+        )
+
+        assert mock_proxy_logging.db_spend_update_writer.update_database.await_count == 1
+        assert sl_object.get("guardrail_information") == guardrail_info

--- a/tests/test_litellm/proxy/hooks/test_proxy_track_cost_callback.py
+++ b/tests/test_litellm/proxy/hooks/test_proxy_track_cost_callback.py
@@ -1980,15 +1980,15 @@ async def test_proxy_track_cost_callback_carries_guardrail_info_to_sl_object():
     }
 
     with (
-        patch(
+        patch(  # test-quality-ok: spend counters are a proxy_server global the callback reads lazily, no seam
             "litellm.proxy.proxy_server.increment_spend_counters",
             new_callable=AsyncMock,
         ),
-        patch(
+        patch(  # test-quality-ok: update_cache is a proxy_server global the callback reads lazily, no seam
             "litellm.proxy.proxy_server.update_cache",
             new_callable=AsyncMock,
         ),
-        patch(
+        patch(  # test-quality-ok: callback imports proxy_logging_obj off proxy_server in its body, no seam
             "litellm.proxy.proxy_server.proxy_logging_obj",
         ) as mock_proxy_logging,
     ):

--- a/tests/test_litellm/proxy/hooks/test_proxy_track_cost_callback.py
+++ b/tests/test_litellm/proxy/hooks/test_proxy_track_cost_callback.py
@@ -1,3 +1,4 @@
+
 from datetime import datetime
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -69,7 +70,9 @@ async def test_async_post_call_failure_hook():
 
         # Check that metadata was properly updated
         assert "litellm_params" in call_args["kwargs"]
-        assert call_args["kwargs"]["litellm_params"]["proxy_server_request"] == {"request_id": "test_request_id"}
+        assert call_args["kwargs"]["litellm_params"]["proxy_server_request"] == {
+            "request_id": "test_request_id"
+        }
         metadata = call_args["kwargs"]["litellm_params"]["metadata"]
         assert metadata["user_api_key"] == "test_api_key"
         assert metadata["status"] == "failure"
@@ -333,7 +336,9 @@ async def test_should_continue_failure_tracking_when_budget_release_fails():
         )
         assert mock_invalidate_budget_reservation_counters.await_count == 1
         assert (
-            mock_invalidate_budget_reservation_counters.await_args.kwargs["budget_reservation"]
+            mock_invalidate_budget_reservation_counters.await_args.kwargs[
+                "budget_reservation"
+            ]
             is user_api_key_dict.budget_reservation
         )
         assert user_api_key_dict.budget_reservation["finalized"] is True
@@ -428,21 +433,36 @@ def test_get_budget_reservation_from_metadata_handles_dict_auth_object():
         "entries": [{"counter_key": "spend:key:test_api_key"}],
     }
 
-    assert _get_budget_reservation_from_metadata(metadata={"user_api_key_auth": dict(UserAPIKeyAuth())}) is None
     assert (
         _get_budget_reservation_from_metadata(
-            metadata={"user_api_key_auth": UserAPIKeyAuth(budget_reservation=budget_reservation)}
+            metadata={"user_api_key_auth": dict(UserAPIKeyAuth())}
+        )
+        is None
+    )
+    assert (
+        _get_budget_reservation_from_metadata(
+            metadata={
+                "user_api_key_auth": UserAPIKeyAuth(
+                    budget_reservation=budget_reservation
+                )
+            }
         )
         == budget_reservation
     )
     assert (
         _get_budget_reservation_from_metadata(
-            metadata={"user_api_key_auth": dict(UserAPIKeyAuth(budget_reservation=budget_reservation))}
+            metadata={
+                "user_api_key_auth": dict(
+                    UserAPIKeyAuth(budget_reservation=budget_reservation)
+                )
+            }
         )
         == budget_reservation
     )
     assert (
-        _get_budget_reservation_from_metadata(metadata={"user_api_key_budget_reservation": budget_reservation})
+        _get_budget_reservation_from_metadata(
+            metadata={"user_api_key_budget_reservation": budget_reservation}
+        )
         is budget_reservation
     )
 
@@ -450,7 +470,9 @@ def test_get_budget_reservation_from_metadata_handles_dict_auth_object():
 @pytest.mark.asyncio
 async def test_update_database_and_spend_counters_releases_reservation_when_db_update_fails():
     proxy_logging_obj = MagicMock()
-    proxy_logging_obj.db_spend_update_writer.update_database = AsyncMock(side_effect=Exception("db unavailable"))
+    proxy_logging_obj.db_spend_update_writer.update_database = AsyncMock(
+        side_effect=Exception("db unavailable")
+    )
     increment_spend_counters = AsyncMock()
     budget_reservation = {"reserved_cost": 0.5, "entries": []}
 
@@ -486,7 +508,9 @@ async def test_update_database_and_spend_counters_releases_reservation_when_db_u
 async def test_update_database_and_spend_counters_preserves_db_exception_when_release_fails():
     proxy_logging_obj = MagicMock()
     db_exception = RuntimeError("db unavailable")
-    proxy_logging_obj.db_spend_update_writer.update_database = AsyncMock(side_effect=db_exception)
+    proxy_logging_obj.db_spend_update_writer.update_database = AsyncMock(
+        side_effect=db_exception
+    )
     increment_spend_counters = AsyncMock()
     budget_reservation = {"reserved_cost": 0.5, "entries": []}
 
@@ -530,8 +554,12 @@ async def test_update_database_and_spend_counters_preserves_db_exception_when_re
             budget_reservation=budget_reservation,
         )
         assert mock_log_exception.call_count == 2
-        mock_log_exception.assert_any_call("Failed to release budget reservation after database update failed")
-        mock_log_exception.assert_any_call("Failed to invalidate budget reservation counters after release failed")
+        mock_log_exception.assert_any_call(
+            "Failed to release budget reservation after database update failed"
+        )
+        mock_log_exception.assert_any_call(
+            "Failed to invalidate budget reservation counters after release failed"
+        )
 
     increment_spend_counters.assert_not_awaited()
 
@@ -1073,7 +1101,10 @@ async def test_async_post_call_failure_hook_propagates_trace_id_from_logging_obj
 
         # standard_logging_object should have been propagated from logging obj
         assert call_kwargs.get("standard_logging_object") is not None
-        assert call_kwargs["standard_logging_object"]["trace_id"] == "trace-id-from-logging-obj"
+        assert (
+            call_kwargs["standard_logging_object"]["trace_id"]
+            == "trace-id-from-logging-obj"
+        )
         # litellm_trace_id should also be propagated as a fallback
         assert call_kwargs.get("litellm_trace_id") == "trace-id-from-logging-obj"
 
@@ -1660,7 +1691,9 @@ async def test_async_post_call_failure_hook_records_recovered_partial_spend():
         "metadata": {},
         "proxy_server_request": {"request_id": "rid"},
         "response_cost": 3.5e-05,
-        "combined_usage_object": Usage(prompt_tokens=30, completion_tokens=1, total_tokens=31),
+        "combined_usage_object": Usage(
+            prompt_tokens=30, completion_tokens=1, total_tokens=31
+        ),
     }
 
     with patch(
@@ -1739,10 +1772,15 @@ async def test_track_cost_callback_enriches_user_id_for_mcp_style_metadata():
         assert mock_increment.call_args.kwargs["team_id"] == "team-123"
         assert mock_increment.call_args.kwargs["org_id"] == "org-456"
 
-        update_kwargs = mock_proxy_logging.db_spend_update_writer.update_database.await_args.kwargs
+        update_kwargs = (
+            mock_proxy_logging.db_spend_update_writer.update_database.await_args.kwargs
+        )
         assert update_kwargs["user_id"] == "mcp-user@example.com"
         assert update_kwargs["team_id"] == "team-123"
-        assert kwargs["litellm_params"]["metadata"]["user_api_key_user_id"] == "mcp-user@example.com"
+        assert (
+            kwargs["litellm_params"]["metadata"]["user_api_key_user_id"]
+            == "mcp-user@example.com"
+        )
 
 
 @pytest.mark.parametrize(
@@ -1790,7 +1828,9 @@ def test_should_track_cost_callback_pass_through_without_owner(call_type, expect
     ],
 )
 @pytest.mark.asyncio
-async def test_track_cost_callback_logs_unauthenticated_pass_through_request(call_type, expect_spend_log):
+async def test_track_cost_callback_logs_unauthenticated_pass_through_request(
+    call_type, expect_spend_log
+):
     """Regression for LIT-3782: a pass-through request with auth=false reaches the
     cost callback with no key/user/team/end-user. Before the fix the spend-log
     write was skipped and the request never appeared in request/usage logs. It
@@ -1836,7 +1876,9 @@ async def test_track_cost_callback_logs_unauthenticated_pass_through_request(cal
             end_time=datetime.now(),
         )
 
-        assert mock_proxy_logging.db_spend_update_writer.update_database.await_count == (1 if expect_spend_log else 0)
+        assert mock_proxy_logging.db_spend_update_writer.update_database.await_count == (
+            1 if expect_spend_log else 0
+        )
 
 
 class _FakeDeploymentLookup:
@@ -1947,61 +1989,3 @@ async def test_spend_counters_keep_every_granted_group_when_the_deployment_is_un
     )
 
     assert charged == ("premium", "tier0")
-
-
-@pytest.mark.asyncio
-async def test_proxy_track_cost_callback_carries_guardrail_info_to_sl_object():
-    """
-    LIT-6314 regression: post-call guardrails append evaluations to
-    request_data["litellm_metadata"]["standard_logging_guardrail_information"],
-    but the standard_logging_object (built pre-post-call) lacks this field.
-    The callback must populate standard_logging_object["guardrail_information"]
-    from post-call evals before spend-log write so reports show results.
-    """
-    logger = _ProxyDBLogger()
-    guardrail_info = [
-        {
-            "guardrail_name": "bedrock-guard",
-            "guardrail_status": "success",
-            "guardrail_cost": 0.0001,
-        }
-    ]
-    sl_object = {"response_cost": 0.01}
-    kwargs = {
-        "model": "gpt-4",
-        "messages": [{"role": "user", "content": "Hello"}],
-        "litellm_metadata": {"standard_logging_guardrail_information": guardrail_info},
-        "litellm_params": {
-            "metadata": {"user_api_key": "test_key"},
-        },
-        "call_type": CallTypes.completion.value,
-        "response_cost": 0.01,
-        "standard_logging_object": sl_object,
-    }
-
-    with (
-        patch(  # test-quality-ok: spend counters are a proxy_server global the callback reads lazily, no seam
-            "litellm.proxy.proxy_server.increment_spend_counters",
-            new_callable=AsyncMock,
-        ),
-        patch(  # test-quality-ok: update_cache is a proxy_server global the callback reads lazily, no seam
-            "litellm.proxy.proxy_server.update_cache",
-            new_callable=AsyncMock,
-        ),
-        patch(  # test-quality-ok: callback imports proxy_logging_obj off proxy_server in its body, no seam
-            "litellm.proxy.proxy_server.proxy_logging_obj",
-        ) as mock_proxy_logging,
-    ):
-        mock_proxy_logging.db_spend_update_writer.update_database = AsyncMock()
-        mock_proxy_logging.slack_alerting_instance.customer_spend_alert = AsyncMock()
-        mock_proxy_logging.failed_tracking_alert = AsyncMock()
-
-        await logger._PROXY_track_cost_callback(
-            kwargs=kwargs,
-            completion_response=None,
-            start_time=datetime.now(),
-            end_time=datetime.now(),
-        )
-
-        assert mock_proxy_logging.db_spend_update_writer.update_database.await_count == 1
-        assert sl_object.get("guardrail_information") == guardrail_info

--- a/tests/test_litellm/proxy/management_endpoints/test_compliance_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_compliance_endpoints.py
@@ -2,9 +2,7 @@
 Unit tests for compliance check endpoints (EU AI Act and GDPR).
 """
 
-
 import pytest
-
 
 from litellm.proxy.compliance_checks import ComplianceChecker
 from litellm.types.proxy.compliance_endpoints import ComplianceCheckRequest
@@ -591,3 +589,37 @@ class TestModeMatching:
                     continue
                 if matched:
                     assert mode in _guaranteed_modes(g_mode), (g_mode, mode)
+
+
+class TestNotRunGuardrails:
+    """LIT-6314 logs a not_run entry for a guardrail that message scoping left nothing to scan."""
+
+    def test_not_run_alone_never_evidences_compliance(self):
+        data = ComplianceCheckRequest(
+            request_id="req-601",
+            user_id="user-1",
+            model="gpt-4",
+            timestamp="2026-02-17T00:00:00Z",
+            guardrail_information=[
+                {"guardrail_name": "pii_detection", "guardrail_status": "not_run", "guardrail_mode": "pre_call"},
+            ],
+        )
+        results = {c.check_name: c.passed for c in ComplianceChecker(data).check_eu_ai_act()}
+        assert results["Guardrails applied"] is False
+        assert results["Content screened before LLM"] is False
+        assert results["Audit record complete"] is False
+
+    def test_not_run_sibling_does_not_fail_a_passing_request(self):
+        data = ComplianceCheckRequest(
+            request_id="req-602",
+            user_id="user-1",
+            model="gpt-4",
+            timestamp="2026-02-17T00:00:00Z",
+            pii_detected=True,
+            guardrail_information=[
+                {"guardrail_name": "pii_detection", "guardrail_status": "success", "guardrail_mode": "pre_call"},
+                {"guardrail_name": "system_only", "guardrail_status": "not_run", "guardrail_mode": "pre_call"},
+            ],
+        )
+        results = {c.check_name: c.passed for c in ComplianceChecker(data).check_gdpr()}
+        assert results["Sensitive data protected"] is True

--- a/ui/litellm-dashboard/eslint-suppressions.json
+++ b/ui/litellm-dashboard/eslint-suppressions.json
@@ -2352,7 +2352,7 @@
   },
   "src/components/view_logs/GuardrailViewer/GuardrailViewer.tsx": {
     "no-nested-ternary": {
-      "count": 4
+      "count": 3
     }
   },
   "src/components/view_logs/LogDetailsDrawer/LogDetailContent.tsx": {

--- a/ui/litellm-dashboard/src/components/GuardrailsMonitor/LogViewer.tsx
+++ b/ui/litellm-dashboard/src/components/GuardrailsMonitor/LogViewer.tsx
@@ -1,4 +1,4 @@
-import { CircleCheck, ChevronDown, TriangleAlert, X } from "lucide-react";
+import { CircleCheck, ChevronDown, MinusCircle, TriangleAlert, X } from "lucide-react";
 import { useQuery } from "@tanstack/react-query";
 import moment from "moment";
 import React, { useState } from "react";
@@ -10,9 +10,16 @@ import type { LogEntry as ViewLogsLogEntry } from "@/components/view_logs/column
 import type { LogEntry } from "./mockData";
 
 const actionConfig: Record<
-  "blocked" | "passed" | "flagged",
+  "blocked" | "passed" | "flagged" | "not_run",
   { icon: React.ElementType; color: string; bg: string; border: string; label: string }
 > = {
+  not_run: {
+    icon: MinusCircle,
+    color: "text-muted-foreground",
+    bg: "bg-muted",
+    border: "border-border",
+    label: "Not run",
+  },
   blocked: {
     icon: X,
     color: "text-destructive",

--- a/ui/litellm-dashboard/src/components/GuardrailsMonitor/mockData.ts
+++ b/ui/litellm-dashboard/src/components/GuardrailsMonitor/mockData.ts
@@ -43,7 +43,7 @@ export interface LogEntry {
   input_snippet?: string;
   output_snippet?: string;
   score?: number;
-  action: "blocked" | "passed" | "flagged";
+  action: "blocked" | "passed" | "flagged" | "not_run";
   model?: string;
   reason?: string;
   latency_ms?: number;

--- a/ui/litellm-dashboard/src/components/view_logs/GuardrailViewer/GuardrailViewer.test.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/GuardrailViewer/GuardrailViewer.test.tsx
@@ -33,6 +33,16 @@ describe("GuardrailViewer", () => {
     expect(screen.getByText("1235ms")).toBeInTheDocument();
   });
 
+  it("renders not_run entries as not run instead of failed", () => {
+    const data = makeGuardrailInformation({ guardrail_status: "not_run", guardrail_mode: "pre_call" });
+    renderWithProviders(<GuardrailViewer data={data} />);
+
+    expect(screen.getByText(/1 Not run/)).toBeInTheDocument();
+    // one NOT RUN badge in the timeline, one in the evaluation card
+    expect(screen.getAllByText("NOT RUN")).toHaveLength(2);
+    expect(screen.queryByText("FAILED")).not.toBeInTheDocument();
+  });
+
   it("calculates and displays masked entity totals", async () => {
     const user = userEvent.setup();
     const data = makeGuardrailInformation({

--- a/ui/litellm-dashboard/src/components/view_logs/GuardrailViewer/GuardrailViewer.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/GuardrailViewer/GuardrailViewer.tsx
@@ -137,6 +137,36 @@ const isEntrySuccess = (entry: GuardrailInformation): boolean => {
   return (entry.guardrail_status ?? "").toLowerCase() === "success";
 };
 
+const isEntryNotRun = (entry: GuardrailInformation): boolean => {
+  return (entry.guardrail_status ?? "").toLowerCase() === "not_run";
+};
+
+type EntryStatusLabel = "PASSED" | "NOT RUN" | "FAILED";
+
+const entryStatusLabel = (entry: GuardrailInformation): EntryStatusLabel => {
+  if (isEntrySuccess(entry)) return "PASSED";
+  if (isEntryNotRun(entry)) return "NOT RUN";
+  return "FAILED";
+};
+
+const StatusIcon = ({ status }: { status: EntryStatusLabel }) => {
+  if (status === "PASSED") return <CheckCircleIcon />;
+  if (status === "NOT RUN") return <GrayDotIcon />;
+  return <FailCircleIcon />;
+};
+
+const timelineStatusClass = (status: EntryStatusLabel): string => {
+  if (status === "PASSED") return "bg-success/15 text-success";
+  if (status === "NOT RUN") return "bg-muted text-muted-foreground";
+  return "bg-destructive/15 text-destructive";
+};
+
+const cardStatusClass = (status: EntryStatusLabel): string => {
+  if (status === "PASSED") return "bg-success/15 text-success border border-success/20";
+  if (status === "NOT RUN") return "bg-muted text-muted-foreground border border-border";
+  return "bg-destructive/15 text-destructive border border-destructive/20";
+};
+
 const getRiskColor = (score: number): string => {
   if (score <= 3) return "text-success bg-success/10 border-success/20";
   if (score <= 6) return "text-warning bg-warning/10 border-warning/20";
@@ -318,8 +348,7 @@ interface TimelineEntry {
   type: "request" | "guardrail" | "llm" | "response";
   label: string;
   offsetMs: number;
-  status?: string;
-  isSuccess?: boolean;
+  status?: EntryStatusLabel;
 }
 
 const RequestLifecycle = ({ entries }: { entries: GuardrailInformation[] }) => {
@@ -348,8 +377,7 @@ const RequestLifecycle = ({ entries }: { entries: GuardrailInformation[] }) => {
         type: "guardrail",
         label: `Pre-call guardrail: ${getDisplayName(e)}`,
         offsetMs,
-        status: isEntrySuccess(e) ? "PASSED" : "FAILED",
-        isSuccess: isEntrySuccess(e),
+        status: entryStatusLabel(e),
       });
     }
 
@@ -372,8 +400,7 @@ const RequestLifecycle = ({ entries }: { entries: GuardrailInformation[] }) => {
         type: "guardrail",
         label: `During-call guardrail: ${getDisplayName(e)}`,
         offsetMs,
-        status: isEntrySuccess(e) ? "PASSED" : "FAILED",
-        isSuccess: isEntrySuccess(e),
+        status: entryStatusLabel(e),
       });
     }
 
@@ -384,8 +411,7 @@ const RequestLifecycle = ({ entries }: { entries: GuardrailInformation[] }) => {
         type: "guardrail",
         label: `Post-call guardrail: ${getDisplayName(e)}`,
         offsetMs,
-        status: isEntrySuccess(e) ? "PASSED" : "FAILED",
-        isSuccess: isEntrySuccess(e),
+        status: entryStatusLabel(e),
       });
     }
 
@@ -410,10 +436,8 @@ const RequestLifecycle = ({ entries }: { entries: GuardrailInformation[] }) => {
                   <GrayDotIcon />
                 ) : item.type === "llm" ? (
                   <PlayCircleIcon />
-                ) : item.isSuccess ? (
-                  <CheckCircleIcon />
                 ) : (
-                  <FailCircleIcon />
+                  <StatusIcon status={item.status ?? "FAILED"} />
                 )}
               </div>
               {idx < timeline.length - 1 && <div className="w-0.5 bg-border grow" style={{ minHeight: "24px" }} />}
@@ -427,9 +451,7 @@ const RequestLifecycle = ({ entries }: { entries: GuardrailInformation[] }) => {
                 </span>
                 {item.status && (
                   <span
-                    className={`px-1.5 py-0.5 rounded text-[10px] font-bold uppercase ${
-                      item.isSuccess ? "bg-success/15 text-success" : "bg-destructive/15 text-destructive"
-                    }`}
+                    className={`px-1.5 py-0.5 rounded text-[10px] font-bold uppercase ${timelineStatusClass(item.status)}`}
                   >
                     {item.status}
                   </span>
@@ -456,6 +478,7 @@ const formatGuardrailCost = (cost: number): string => {
 const EvaluationCard = ({ entry }: { entry: GuardrailInformation }) => {
   const [expanded, setExpanded] = useState(false);
   const success = isEntrySuccess(entry);
+  const statusLabel = entryStatusLabel(entry);
   const totalMasked = getTotalMasked(entry);
   const displayName = getDisplayName(entry);
   const durationStr = formatDurationMs(entry.duration);
@@ -490,7 +513,9 @@ const EvaluationCard = ({ entry }: { entry: GuardrailInformation }) => {
         onClick={() => setExpanded(!expanded)}
       >
         {/* Status icon */}
-        <div className="shrink-0">{success ? <CheckCircleIcon /> : <FailCircleIcon />}</div>
+        <div className="shrink-0">
+          <StatusIcon status={statusLabel} />
+        </div>
 
         {/* Name + badges */}
         <div className="flex items-center gap-2 flex-wrap flex-1 min-w-0">
@@ -501,13 +526,9 @@ const EvaluationCard = ({ entry }: { entry: GuardrailInformation }) => {
           </span>
 
           <span
-            className={`px-2 py-0.5 rounded text-[11px] font-semibold uppercase shrink-0 ${
-              success
-                ? "bg-success/15 text-success border border-success/20"
-                : "bg-destructive/15 text-destructive border border-destructive/20"
-            }`}
+            className={`px-2 py-0.5 rounded text-[11px] font-semibold uppercase shrink-0 ${cardStatusClass(statusLabel)}`}
           >
-            {success ? "PASSED" : "FAILED"}
+            {statusLabel}
           </span>
 
           {matchCountStr && (
@@ -673,7 +694,8 @@ const GuardrailViewer = ({ data, accessToken, logEntry }: GuardrailViewerProps) 
   }, [data]);
 
   const passedCount = guardrailEntries.filter(isEntrySuccess).length;
-  const allPassed = passedCount === guardrailEntries.length;
+  const notRunCount = guardrailEntries.filter(isEntryNotRun).length;
+  const allPassed = passedCount === guardrailEntries.length - notRunCount;
 
   const totalOverheadMs = useMemo(() => {
     return Math.round(guardrailEntries.reduce((sum, e) => sum + (e.duration ?? 0), 0) * 1000);
@@ -728,6 +750,11 @@ const GuardrailViewer = ({ data, accessToken, logEntry }: GuardrailViewerProps) 
                 ) : null}
                 {passedCount} Passed
               </span>
+              {notRunCount > 0 && (
+                <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-semibold bg-muted text-muted-foreground border border-border">
+                  {notRunCount} Not run
+                </span>
+              )}
             </div>
           </div>
         </div>

--- a/ui/litellm-dashboard/src/components/view_logs/LogDetailsDrawer/LogDetailContent.test.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/LogDetailsDrawer/LogDetailContent.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
-import { LogDetailContent } from "./LogDetailContent";
+import { GuardrailJumpLink, LogDetailContent } from "./LogDetailContent";
 import type { LogEntry } from "../columns";
 
 vi.mock("../GuardrailViewer/GuardrailViewer", () => ({
@@ -487,5 +487,32 @@ describe("LogDetailContent", () => {
     const descriptions = screen.getByText("Provider").parentElement as HTMLElement;
     expect(descriptions).toBeInTheDocument();
     expect(within(descriptions).getByText("-")).toBeInTheDocument();
+  });
+});
+
+describe("GuardrailJumpLink", () => {
+  it("does not render a not_run entry as a failure", () => {
+    render(
+      <GuardrailJumpLink
+        guardrailEntries={[
+          { guardrail_name: "pii-rail", guardrail_status: "success" },
+          { guardrail_name: "system-only", guardrail_status: "not_run" },
+        ]}
+      />,
+    );
+    expect(screen.getByText(/2 guardrails/)).toHaveTextContent("✓");
+    expect(screen.getByText(/2 guardrails/)).not.toHaveTextContent("✗");
+  });
+
+  it("still renders a real failure as failed", () => {
+    render(
+      <GuardrailJumpLink
+        guardrailEntries={[
+          { guardrail_name: "pii-rail", guardrail_status: "guardrail_intervened" },
+          { guardrail_name: "system-only", guardrail_status: "not_run" },
+        ]}
+      />,
+    );
+    expect(screen.getByText(/2 guardrails/)).toHaveTextContent("✗");
   });
 });

--- a/ui/litellm-dashboard/src/components/view_logs/LogDetailsDrawer/LogDetailContent.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/LogDetailsDrawer/LogDetailContent.tsx
@@ -636,7 +636,9 @@ function RequestResponseSection({
 }
 
 export function GuardrailJumpLink({ guardrailEntries }: { guardrailEntries: any[] }) {
-  const allPassed = guardrailEntries.every((e) => {
+  // a not_run entry never evaluated the request, so it neither passes nor fails the banner
+  const evaluated = guardrailEntries.filter((e) => (e?.guardrail_status || e?.status) !== "not_run");
+  const allPassed = evaluated.every((e) => {
     const status = e?.guardrail_status || e?.status;
     return status === "pass" || status === "passed" || status === "success";
   });


### PR DESCRIPTION
## TLDR

Problem this solves:

- Guardrails listed in applied_guardrails but missing from guardrail_information in request logs
- Happens when message scoping leaves the guardrail nothing to scan
- Readers of guardrail_information had no neutral state, so any new entry read as pass or fail

How it solves it:

- Records a not_run evaluation entry when the scan has nothing to check
- The reason says "after message scoping" only when scoping is what removed the content
- Guardrails that record their own information are left alone
- Usage metrics, usage logs, compliance checks and the dashboard treat not_run as neutral
- Usage index keys a not_run row by its sibling evaluation's guardrail_id, one row per request and guardrail

## User Flow

Before: a proxy admin with content filter guardrails that skip system messages sees them run on a request but log zero evaluations

1. They send POST http://litellm-domain/v1/chat/completions where only the system message carries content and the guardrail is scoped to skip system messages
2. The response comes back 200 with the guardrail named in the x-litellm-applied-guardrails header
3. They open http://litellm-domain/ui/?page=logs, click the request, and the Guardrails tab shows no evaluation for that guardrail, so they cannot tell whether it ran, passed, or silently broke
4. They open the Guardrails Monitor drill-down for that guardrail and the request is not listed at all

After: the same request logs a not_run evaluation for that guardrail

1. They send the same POST http://litellm-domain/v1/chat/completions
2. The response comes back 200 with the same x-litellm-applied-guardrails header
3. http://litellm-domain/ui/?page=logs now shows the guardrail with a grey NOT RUN badge and the reason "no scannable content after message scoping", so the gap between applied and evaluated is gone
4. The Guardrails Monitor drill-down lists the request with action not_run. The guardrail's evaluated count, pass rate and fail rate do not move, because nothing was evaluated

## Relevant issues

Fixes #36566

## Affected release

## Linear ticket

Resolves LIT-6314

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Setup: two proxies from the same config, each with 2 uvicorn workers and its own fresh Postgres database, merge base on :46321 and PR tip on :46320, model `openai/gpt-5.6` with a real OpenAI key. Twelve `litellm_content_filter` guardrails cover every scoping branch. The ones that matter below are all `default_on` with a `forbiddenzebra` blocked word: `g-pre-skipsys` (`pre_call`, `skip_system_message_in_guardrail: true`), `g-pre-inherit` (`pre_call`, inherits the same flag from `guardrail_settings`), `g-pre-null` (`pre_call`, flag set to null, inherits), `g-pre-noskip` (`pre_call`, flag false), `g-during-skipsys`, `g-logonly-skipsys`, `g-post`. Requests are plain curl against `/v1/chat/completions` with the master key, then the spend log table, the usage endpoint and the compliance endpoint are read back after the spend log flush. This is the same rig the full live audit (55 cells across chat, messages and responses, curl and OpenAI and Anthropic SDKs, sync and async, sad paths, config and key and team updates, Postgres outage, slow Postgres, worker kill, proxy restart) ran on

```bash
# A. system-only: scoping skips the only message
curl -s http://localhost:$PORT/v1/chat/completions -H "Authorization: Bearer $KEY" -H "Content-Type: application/json" \
  -d '{"model":"openai-live","messages":[{"role":"system","content":"You are a terse assistant. Reply OK."}],"max_tokens":20}'
# B. same request with "stream": true
# C. system + user, so there is text to scan
curl -s ... -d '{"model":"openai-live","messages":[{"role":"system","content":"Reply OK."},{"role":"user","content":"hello"}],"max_tokens":20}'
# D. blocked keyword, enforcement must still return 400
curl -s ... -d '{"model":"openai-live","messages":[{"role":"user","content":"tell me about forbiddenzebra"}],"max_tokens":20}'
# E. system + image-only user, no text to scan but not a scoping skip
curl -s ... -d '{"model":"openai-live","messages":[{"role":"system","content":"Reply OK."},{"role":"user","content":[{"type":"image_url","image_url":{"url":"data:image/png;base64,<8x8 png>"}}]}],"max_tokens":20}'
# F. content-free user message with skip flags on: nothing to scan, and scoping removed nothing
curl -s ... -d '{"model":"openai-live","messages":[{"role":"user","content":[]}],"max_tokens":20}'
# G. system message carrying text and an image, no user message: scoping removes the text
curl -s ... -d '{"model":"openai-live","messages":[{"role":"system","content":[{"type":"text","text":"Reply OK."},{"type":"image_url","image_url":{"url":"data:image/png;base64,<8x8 png>"}}]}],"max_tokens":20}'
# H. system message carrying only an image, no user message: nothing scannable was removed
curl -s ... -d '{"model":"openai-live","messages":[{"role":"system","content":[{"type":"image_url","image_url":{"url":"data:image/png;base64,<8x8 png>"}}]}],"max_tokens":20}'
# read back per request id
psql ... -c "select g->>'guardrail_name', g->>'guardrail_status', left(g->>'guardrail_response',45) from \"LiteLLM_SpendLogs\", jsonb_array_elements(metadata->'guardrail_information') g where request_id='$ID'"
curl -s "http://localhost:$PORT/guardrails/usage/logs?guardrail_id=$GID&action=$ACTION&page_size=100" -H "Authorization: Bearer $KEY"
```

### Before (c16c172a65)

#### System-only request, non streaming and streaming

1. A returns 200, id `chatcmpl-EOFvBy5YGKhSqjPtL9UfuQwtic47D`, header `x-litellm-applied-guardrails: g-pre-skipsys,g-pre-noskip,g-pre-inherit,g-pre-null,g-post`. B returns 200, id `chatcmpl-EOFvOB2lCyDZMjCYSdueoWjBLTC95`
2. `guardrail_information` for both: `g-logonly-skipsys:success:[] ; g-post:success:[] ; g-pre-noskip:success:[]`. Four pre_call and during_call guardrails the header says were applied have no entry, which is the reported symptom

#### Scannable, blocked, image-only and content-free requests

1. C returns 200, `guardrail_information` has all eight guardrails as `success:[]`
2. D returns `HTTP 400` `Content blocked: keyword 'forbiddenzebra' detected`
3. E returns 200, `guardrail_information`: `g-logonly-skipsys:success:[] ; g-post:success:[] ; g-pre-noskip:success:[]`. The image is never dispatched to the guardrail by this handler
4. F returns 200, `guardrail_information` is `null`. No guardrail left any trace on a content-free request
5. G returns 200, id `chatcmpl-EOFxNaRHDNZSVIN7AdF1QzNOj3Eby`, header names `g-pre-skipsys,g-pre-noskip,g-pre-inherit,g-pre-null,g-post`, `guardrail_information` has only `g-pre-noskip`, `g-post` and `g-logonly-skipsys` as `success`. The three scoped guardrails have no entry
6. H returns 200 with empty completion content, id `chatcmpl-EOFxlsKeOgwFId6dvRjVRRD2Nnwlw`, `guardrail_information` is `null`

#### Usage endpoint and daily metrics for g-pre-skipsys

1. `GET /guardrails/usage/logs?guardrail_id=<g-pre-skipsys>` lists C as `passed`; A, B and G are absent from the drill-down. `action=not_run` returns 0 rows
2. `LiteLLM_DailyGuardrailMetrics` for today: `evaluated=3 passed=2 blocked=1 flagged=0`

#### Compliance check on request A

1. `POST /compliance/eu-ai-act` with the persisted `guardrail_information` of A: `compliant=True`, `Art. 9: 3 guardrail(s) applied`, `Art. 5: 1 pre-call guardrail(s) screened content`, `Art. 12: All required audit fields present`

#### Request Logs Guardrails tab for a system-only request

1. Open http://localhost:46321/ui/?page=logs, click the request, open the Guardrails tab
2. Only the three evaluated guardrails are listed. The scoped-out ones are absent even though the response header named them

### After (fe0fb97fd2)

#### System-only request, non streaming and streaming

1. A returns 200, id `chatcmpl-EOFvbxrR6TbViPkcwKEfGAa19mtwc`, same `x-litellm-applied-guardrails` header. B returns 200, id `chatcmpl-EOFvjKSBNCdy0nN30gE9NWei1ot0b`
2. `guardrail_information` for both: `g-during-skipsys:not_run:no scannable content after message scoping ; g-logonly-skipsys:success:[] ; g-logonly-skipsys:not_run:no scannable content after message scoping ; g-post:success:[] ; g-pre-inherit:not_run:... ; g-pre-noskip:success:[] ; g-pre-null:not_run:... ; g-pre-skipsys:not_run:...`. Every applied guardrail now has an entry, per-guardrail, inherited and null scoping flags all record the skip, and the logging_only guardrail shows its not_run input scan next to its real output scan

#### Scannable, blocked, image-only and content-free requests

1. C returns 200, id `chatcmpl-EOFvrrca4hWOI9akcRsNMxK30Vblp`, `guardrail_information` has all eight guardrails as `success:[]` and no not_run entry
2. D returns `HTTP 400` `Content blocked: keyword 'forbiddenzebra' detected`, unchanged
3. E returns 200, id `chatcmpl-EOFvwc4QbPN1mElk2H64Ofjnz328B`, `guardrail_information` identical to Before: `g-logonly-skipsys:success:[] ; g-post:success:[] ; g-pre-noskip:success:[]`. An image-only message is a pre-existing scan gap in this handler, not a message-scoping skip, so it records nothing rather than a misleading not_run entry
4. F returns 200, id `chatcmpl-EOFx0xHghPcGZFBU0f4evrvUwzWE7`, `guardrail_information`: `g-during-skipsys:not_run:no scannable content ; g-logonly-skipsys:not_run:no scannable content ; g-pre-inherit:not_run:no scannable content ; g-pre-noskip:not_run:no scannable content ; g-pre-null:not_run:no scannable content ; g-pre-skipsys:not_run:no scannable content`. The skip flags are on for most of these guardrails, but the request was empty to begin with, so the reason does not blame scoping. Only A, B and G, where the unscoped messages do carry text, say "after message scoping"
5. G returns 200, id `chatcmpl-EOFw937cc6rc4zarL01NORYvSYis2`, `guardrail_information` matches A: the five scoped guardrails record `not_run:no scannable content after message scoping` next to the three `success` entries. The system message carried text next to the image, scoping removed that text, so the skip is recorded even though an image sat beside it
6. H returns 200, id `chatcmpl-EOFwJCpXN63agX1IpUOFXEEfqQlHt`, `guardrail_information` is `null`, same as Before. The only content was an image, which this handler never dispatches, so nothing scannable was removed and no not_run entry is written

#### Usage endpoint and daily metrics for g-pre-skipsys

1. `GET /guardrails/usage/logs?guardrail_id=<g-pre-skipsys>` lists `A not_run`, `B not_run`, `G not_run`, `C passed`, and the blocked D row. `action=not_run` returns A, B and G, `action=passed` returns C only, `action=blocked` returns the D rows only
2. `LiteLLM_DailyGuardrailMetrics` for today: `evaluated=4 passed=2 blocked=2 flagged=0`, exactly the two C and two D requests this database saw today. A, B, F and G moved nothing. The not_run rows are indexed for drill-down but none of them is counted as evaluated

#### Compliance check on request A

1. `POST /compliance/eu-ai-act` with the persisted `guardrail_information` of A (`not_run` x5, `success` x3): `compliant=True`, `Art. 9: 3 guardrail(s) applied`, `Art. 5: 1 pre-call guardrail(s) screened content`, `Art. 12: All required audit fields present`. The not_run entries are filtered out before counting, so the result matches Before

#### Request Logs Guardrails tab for a system-only request

1. Open http://localhost:46320/ui/?page=logs, click a system-only request, open the Guardrails tab
2. Header reads `3 guardrails evaluated, 5 not run`, `3 Passed`, `5 Not run`: PASSED cards for `g-pre-noskip`, `g-post` and the output scan of `g-logonly-skipsys`, then five grey NOT RUN cards for `g-pre-skipsys`, `g-pre-null`, `g-pre-inherit`, `g-during-skipsys`, `g-logonly-skipsys`, each expanding to `no scannable content after message scoping`
3. Open http://localhost:3002/guardrails-monitor, click `g-pre-skipsys`: the log viewer shows the system-only requests as neutral grey `Not run` rows and the Passed filter hides them while keeping the scannable control
4. Dashboard evidence was recorded at 33fb6625ad, the last commit that changed the dashboard. The commits since then touch only the OpenAI chat handler and its tests. Screenshots and the recording are in a PR comment, not embedded here

## Type

🐛 Bug Fix

## Caveats (if any)

### Medium

- Only the OpenAI chat translation handler is fixed. The Anthropic messages and Responses handlers have the same early return and still log nothing for a fully scoped-out request. Verified live at both base and tip
- Readers of guardrail_information see new not_run entries where before there were none. Daily metrics deliberately exclude them; the per-request index row is still written for drill-down
- not_run already existed as the request-level default meaning "no guardrail ran". Per-guardrail entries now reuse it, so a consumer cannot tell "configured but nothing to scan" from "not configured" by status alone; the reason string carries that distinction

### Low

- Deciding the reason runs the message extraction a second time without the skip flags. It only happens on the branch where nothing was scanned
- Image-only messages were never dispatched to the guardrail by this handler before either. They still record nothing (cells E and H), so that pre-existing gap is not mislabelled as a scoping skip. When a scoped-out message carried text or tool calls next to an image (cell G), the skip is recorded, because scoping did remove scannable content
- Fail rate on the Guardrail Monitor is computed over evaluated requests only, so a guardrail whose scans are mostly not_run can change health status. Counting them as passes was the alternative
- A day on which a guardrail only recorded not_run writes no daily metrics row, so it is absent from the trend chart for that day. Its per-request rows are still in the drill-down
- The usage logs `total` is computed before the action filter is applied. Pre-existing behavior
- The Guardrails Monitor filter chips stay at all, blocked, flagged, passed. not_run rows show under all
- not_run entries carry no timing, so the Request Logs lifecycle timeline skips them and their card shows a `—` duration
- The lifecycle timeline can print `LLM call T+1000ms` before `Response returned T+1ms` when a request has pre-call entries and no post-call entry. The fallback that adds one second is pre-existing and untouched here
- A non-stream request whose completion has empty content records no post_call entry at all. Response-side scoping, separate from this fix
- An unknown request-level guardrail name is silently ignored with HTTP 200, same as base
- An earlier revision moved guardrail metadata in the cost callback; reverted as dead code
- The branch briefly renamed the status to skipped and reverted it with revert commits, so the history carries both directions

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

ran /live-pr-risk and found no regressions/backward incompatible risks

- [x] fe0fb97fd2d0a39ad022739547f464b48a7a061b passes the Before/After proof above at the tip itself; the full 55-cell live audit ran at 937179bde1699b2c758a31f8850181d22fcb2302 and every commit since then was re-proven with cells A to H and the affected unit and component tests




Link to Devin session: https://app.devin.ai/sessions/11ea3621adc4479cba570efd56ec6c58
Open in Devin Desktop: https://app.devin.ai/desktop/session/11ea3621adc4479cba570efd56ec6c58?variant=devin
Requested by: @yucheng-berri