### PR TITLE
fix(gemini): return enabled thinking content by default

### DIFF
--- a/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
+++ b/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
@@ -949,7 +949,7 @@ class VertexGeminiConfig(VertexAIBaseConfig, BaseConfig):
         # For Gemini 3+ models, use thinkingLevel instead of thinkingBudget
         if model and VertexGeminiConfig._is_gemini_3_or_newer(model):
             if thinking_enabled:
-                if thinking_budget is None or thinking_budget == 0:
+                if thinking_budget == 0:
                     params["includeThoughts"] = False
                 else:
                     params["includeThoughts"] = True

--- a/tests/test_litellm/llms/vertex_ai/gemini/test_vertex_and_google_ai_studio_gemini.py
+++ b/tests/test_litellm/llms/vertex_ai/gemini/test_vertex_and_google_ai_studio_gemini.py
@@ -1185,6 +1185,18 @@ def test_vertex_ai_map_thinking_param_with_budget_tokens_0():
     }
 
 
+def test_vertex_ai_map_thinking_param_without_budget_tokens_for_gemini_3():
+    v = VertexGeminiConfig()
+    result = v.map_openai_params(
+        non_default_params={"thinking": {"type": "enabled"}},
+        optional_params={},
+        model="gemini-3.5-flash",
+        drop_params=False,
+    )
+
+    assert result["thinkingConfig"] == {"includeThoughts": True}
+
+
 def test_vertex_ai_map_tools():
     v = VertexGeminiConfig()
     optional_params = {}


### PR DESCRIPTION
## TLDR

Problem this solves:

- Gemini 3 enabled thinking without `budget_tokens` returned no thinking content
- The mapping sent `includeThoughts: false` whenever `budget_tokens` was omitted
- Thinking tokens were still counted and billed

How it solves it:

- Enabled thinking without a budget now maps to `includeThoughts: true`
- Only an explicit `budget_tokens: 0` disables thought content
- Matches how older Gemini models already handle the same input

## User Flow

Before: a developer enabling thinking on a Gemini 3 model gets billed for reasoning tokens but never sees any reasoning content

1. They send POST https://litellm-domain/v1/chat/completions with `"model": "gemini/gemini-3-flash"`, a user message, and `"thinking": {"type": "enabled"}` with no `budget_tokens`
2. The response comes back 200 with `usage.completion_tokens_details.reasoning_tokens` above zero
3. The assistant message carries only `content`, with no `reasoning_content` field, so their app has nothing to show for the reasoning they paid for

After: the same request returns the reasoning content alongside the answer

1. They send POST https://litellm-domain/v1/chat/completions with `"model": "gemini/gemini-3-flash"`, a user message, and `"thinking": {"type": "enabled"}` with no `budget_tokens`
2. The response comes back 200 with `usage.completion_tokens_details.reasoning_tokens` above zero
3. The assistant message now also carries `reasoning_content` with the model's thought summary, and an explicit `"budget_tokens": 0` still returns no reasoning content

## Relevant issues

## Linear ticket

Resolves LIT-6615

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

`uv run pytest -q tests/test_litellm/llms/vertex_ai/gemini/test_vertex_and_google_ai_studio_gemini.py` -> `152 passed`

`make pre-commit` passed against the latest `litellm_internal_staging`, including Python lint, test lint, formatting, strict-rule budgets, type discipline, and basedpyright

The branch was rebased onto `litellm_internal_staging` at `ec3f8183c3` and now points to `7ca035f310`

## Type

🐛 Bug Fix

## Caveats (if any)

## Final Attestation

- [ ] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to Gemini 3+ thinking param mapping with a targeted test; behavior shifts only for enabled thinking without budget_tokens (more reasoning content returned).
> 
> **Overview**
> Fixes Gemini 3+ requests where **`thinking: { "type": "enabled" }`** omitted **`budget_tokens`** but still incurred reasoning token usage without surfacing **`reasoning_content`**.
> 
> For Gemini 3+ in **`_map_thinking_param`**, **`includeThoughts`** is now set to **`false`** only when **`budget_tokens`** is explicitly **`0`**. A missing budget no longer disables thought output; enabled thinking maps to **`includeThoughts: true`** (optionally with default **`thinkingLevel`** when the legacy flag is on), aligning with pre–Gemini 3 behavior.
> 
> Adds a regression test on **`gemini-3.5-flash`** via **`map_openai_params`** asserting **`thinkingConfig`** is **`{ "includeThoughts": true }`** when no budget is provided.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7ca035f310f891eea216f3162191739f3720bcb1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->