### PR TITLE
fix(openai): forward reasoning_effort for unknown model aliases instead of failing closed

### DIFF
--- a/litellm/llms/openai/chat/gpt_transformation.py
+++ b/litellm/llms/openai/chat/gpt_transformation.py
@@ -178,6 +178,10 @@ class OpenAIGPTConfig(BaseLLMModelInfo, BaseConfig):
             model_specific_params.append(
                 "user"
             )  # user is not a param supported by all openai-compatible endpoints - e.g. azure ai
+        else:
+            model_specific_params.append(
+                "reasoning_effort"
+            )  # unknown model: likely a proxy alias for a reasoning-capable model, so forward and let the server decide
         return base_params + model_specific_params
 
     def _map_openai_params(

--- a/litellm/llms/openai/chat/gpt_transformation.py
+++ b/litellm/llms/openai/chat/gpt_transformation.py
@@ -170,19 +170,19 @@ class OpenAIGPTConfig(BaseLLMModelInfo, BaseConfig):
         if model != "gpt-3.5-turbo-16k" and model != "gpt-4":  # gpt-4 does not support 'response_format'
             model_specific_params.append("response_format")
 
-        # Normalize model name for responses API (e.g., "responses/gpt-4.1" -> "gpt-4.1")
-        model_for_check: Final = model.split("responses/", 1)[1] if "responses/" in model else model
-        if (
-            model_for_check in litellm.open_ai_chat_completion_models
-        ) or model_for_check in litellm.open_ai_text_completion_models:
+        if OpenAIGPTConfig.is_openai_catalog_model(model):
             model_specific_params.append(
                 "user"
             )  # user is not a param supported by all openai-compatible endpoints - e.g. azure ai
-        else:
-            model_specific_params.append(
-                "reasoning_effort"
-            )  # unknown model: likely a proxy alias for a reasoning-capable model, so forward and let the server decide
         return base_params + model_specific_params
+
+    @staticmethod
+    def is_openai_catalog_model(model: str) -> bool:
+        model_for_check: Final = model.split("responses/", 1)[1] if "responses/" in model else model
+        return (
+            model_for_check in litellm.open_ai_chat_completion_models
+            or model_for_check in litellm.open_ai_text_completion_models
+        )
 
     def _map_openai_params(
         self,
@@ -757,6 +757,14 @@ class OpenAIGPTConfig(BaseLLMModelInfo, BaseConfig):
             sync_stream=sync_stream,
             json_mode=json_mode,
         )
+
+
+class OpenAIUnknownModelConfig(OpenAIGPTConfig):
+    """A model the openai provider does not recognize is typically a LiteLLM proxy alias, so
+    forward reasoning_effort and let the server decide whether it is supported."""
+
+    def get_supported_openai_params(self, model: str) -> list:  # mutable-ok: inherited contract
+        return super().get_supported_openai_params(model) + ["reasoning_effort"]  # mutable-ok: inherited contract
 
 
 class OpenAIChatCompletionStreamingHandler(BaseModelResponseIterator):

--- a/litellm/llms/openai/openai.py
+++ b/litellm/llms/openai/openai.py
@@ -43,6 +43,7 @@ from litellm.utils import (
 from ...types.llms.openai import *
 from ..base import BaseLLM
 from .chat.gpt_5_transformation import OpenAIGPT5Config
+from .chat.gpt_transformation import OpenAIGPTConfig, OpenAIUnknownModelConfig
 from .chat.o_series_transformation import OpenAIOSeriesConfig
 from .common_utils import (
     BaseOpenAILLM,
@@ -189,7 +190,12 @@ class OpenAIConfig(BaseConfig):
         elif litellm.openAIGPTAudioConfig.is_model_gpt_audio_model(model=model):
             return litellm.openAIGPTAudioConfig.get_supported_openai_params(model=model)
         else:
-            return litellm.openAIGPTConfig.get_supported_openai_params(model=model)
+            return self._gpt_config_for_model(model).get_supported_openai_params(model=model)
+
+    def _gpt_config_for_model(self, model: str) -> OpenAIGPTConfig:
+        if type(self) is OpenAIConfig and not OpenAIGPTConfig.is_openai_catalog_model(model):
+            return OpenAIUnknownModelConfig()
+        return litellm.openAIGPTConfig
 
     def _map_openai_params(self, non_default_params: dict, optional_params: dict, model: str) -> dict:
         supported_openai_params: Final = self.get_supported_openai_params(model)
@@ -231,7 +237,7 @@ class OpenAIConfig(BaseConfig):
                 drop_params=drop_params,
             )
 
-        return litellm.openAIGPTConfig.map_openai_params(
+        return self._gpt_config_for_model(model).map_openai_params(
             non_default_params=non_default_params,
             optional_params=optional_params,
             model=model,

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -8278,10 +8278,17 @@ class ProviderConfigManager:
         """
         # Handle OpenAI special cases (O-series and GPT-5 models)
         if provider == LlmProviders.OPENAI:
+            from litellm.llms.openai.chat.gpt_transformation import (
+                OpenAIGPTConfig,
+                OpenAIUnknownModelConfig,
+            )
+
             if litellm.openaiOSeriesConfig.is_model_o_series_model(model=model):
                 return litellm.openaiOSeriesConfig
             if litellm.OpenAIGPT5Config.is_model_gpt_5_model(model=model):
                 return litellm.OpenAIGPT5Config()
+            if not OpenAIGPTConfig.is_openai_catalog_model(model):
+                return OpenAIUnknownModelConfig()
 
         # Handle Azure before the generic map so base_model can be threaded through
         if provider == LlmProviders.AZURE:

--- a/tests/test_litellm/llms/openai/chat/test_openai_gpt_transformation.py
+++ b/tests/test_litellm/llms/openai/chat/test_openai_gpt_transformation.py
@@ -148,17 +148,39 @@ class TestGetOptionalParamsIntegration:
     def test_reasoning_effort_supported_for_unknown_model_alias(self):
         """An openai/-routed model litellm doesn't recognize is likely a proxy alias:
         reasoning_effort must be forwarded so the server decides support."""
-        supported_params = OpenAIGPTConfig().get_supported_openai_params(
+        from litellm.llms.openai.openai import OpenAIConfig
+
+        supported_params = OpenAIConfig().get_supported_openai_params(
             "my-claude-alias"
         )
         assert "reasoning_effort" in supported_params
 
     def test_reasoning_effort_not_supported_for_known_non_reasoning_models(self):
         """Known OpenAI models keep failing closed client-side."""
-        config = OpenAIGPTConfig()
+        from litellm.llms.openai.openai import OpenAIConfig
+
+        config = OpenAIConfig()
         assert "reasoning_effort" not in config.get_supported_openai_params("gpt-4o")
         assert "reasoning_effort" not in config.get_supported_openai_params(
             "responses/gpt-4.1-mini"
+        )
+
+    def test_reasoning_effort_not_inherited_by_openai_compatible_subclasses(self):
+        """Providers subclassing either openai config keep their own reasoning_effort gating
+        for their models, which are all unknown to the openai catalog."""
+        from litellm.llms.openai.openai import OpenAIConfig
+
+        class InheritingDispatcherConfig(OpenAIConfig):
+            pass
+
+        class InheritingGPTConfig(OpenAIGPTConfig):
+            pass
+
+        assert "reasoning_effort" not in InheritingDispatcherConfig().get_supported_openai_params(
+            "some-unknown-model"
+        )
+        assert "reasoning_effort" not in InheritingGPTConfig().get_supported_openai_params(
+            "some-unknown-model"
         )
 
     def test_reasoning_effort_forwarded_in_optional_params_for_unknown_model_alias(

--- a/tests/test_litellm/llms/openai/chat/test_openai_gpt_transformation.py
+++ b/tests/test_litellm/llms/openai/chat/test_openai_gpt_transformation.py
@@ -145,6 +145,47 @@ class TestGetOptionalParamsIntegration:
         assert regular_params.get("user") == "my-end-user"
         assert responses_params.get("user") == "my-end-user"
 
+    def test_reasoning_effort_supported_for_unknown_model_alias(self):
+        """An openai/-routed model litellm doesn't recognize is likely a proxy alias:
+        reasoning_effort must be forwarded so the server decides support."""
+        supported_params = OpenAIGPTConfig().get_supported_openai_params(
+            "my-claude-alias"
+        )
+        assert "reasoning_effort" in supported_params
+
+    def test_reasoning_effort_not_supported_for_known_non_reasoning_models(self):
+        """Known OpenAI models keep failing closed client-side."""
+        config = OpenAIGPTConfig()
+        assert "reasoning_effort" not in config.get_supported_openai_params("gpt-4o")
+        assert "reasoning_effort" not in config.get_supported_openai_params(
+            "responses/gpt-4.1-mini"
+        )
+
+    def test_reasoning_effort_forwarded_in_optional_params_for_unknown_model_alias(
+        self,
+    ):
+        """Regression test for reasoning_effort raising UnsupportedParamsError
+        client-side for openai/-prefixed proxy aliases before any HTTP request."""
+        from litellm.utils import get_optional_params
+
+        optional_params = get_optional_params(
+            model="my-claude-alias",
+            custom_llm_provider="openai",
+            reasoning_effort="low",
+        )
+        assert optional_params.get("reasoning_effort") == "low"
+
+    def test_reasoning_effort_still_rejected_for_known_non_reasoning_model(self):
+        """A real OpenAI model that doesn't reason still rejects the param client-side."""
+        from litellm.utils import get_optional_params
+
+        with pytest.raises(litellm.utils.UnsupportedParamsError):
+            get_optional_params(
+                model="gpt-4o",
+                custom_llm_provider="openai",
+                reasoning_effort="low",
+            )
+
 
 class TestOpenAIChatCompletionStreamingHandler:
     """Tests for OpenAIChatCompletionStreamingHandler.chunk_parser()"""


### PR DESCRIPTION
## TLDR

Problem this solves:

- SDK rejects `reasoning_effort` client-side for `openai/`-prefixed proxy aliases
- The backing model supports it, so users can't request reasoning

How it solves it:

- Unknown model names on the openai route now forward `reasoning_effort`
- The server decides support instead of the client failing closed
- Known OpenAI model names keep today's client-side validation
- Providers subclassing the shared openai configs keep their own gating

## User Flow

Before: a developer pointing the litellm SDK at their LiteLLM proxy can't request reasoning through an alias

1. Their proxy serves `my-claude-alias`, backed by a Claude model; they call `litellm.completion(model="openai/my-claude-alias", api_base="https://litellm-domain/v1", reasoning_effort="low", ...)`
2. The call raises `litellm.UnsupportedParamsError: openai does not support parameters: ['reasoning_effort'], for model=my-claude-alias` before anything reaches https://litellm-domain/v1/chat/completions (the proxy log shows no request)
3. They drop `reasoning_effort` and the same call returns 200 with an answer, but they never get to pick an effort level
4. The same body sent by curl to POST https://litellm-domain/v1/chat/completions with `"reasoning_effort": "low"` returns 200 with `reasoning_content` populated, so only the SDK stands in the way

After: the same call goes through and reasoning comes back

1. Their proxy serves `my-claude-alias`, backed by a Claude model; they call `litellm.completion(model="openai/my-claude-alias", api_base="https://litellm-domain/v1", reasoning_effort="low", ...)`
2. The SDK sends POST https://litellm-domain/v1/chat/completions with `"reasoning_effort": "low"`
3. The response is 200 with the answer and `reasoning_content` populated

## Relevant issues

## Linear ticket

Resolves LIT-6426

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

QA against two live proxies, each booted with `--num_workers 2` (1 master + 2 uvicorn workers verified via `ps`): the before leg from the merge base d1320404fe, the after leg from this PR's head 0a9676bd4f, each in its own worktree and venv. Config maps `my-claude-alias` -> `anthropic/claude-opus-5` and `my-gemini-alias` -> `gemini/gemini-3.7-flash` with real provider keys, `master_key: sk-lit6426-repro`. The client is the litellm Python SDK from the same leg's commit, running this script (`client.py <port> <alias> [effort]`):

```python
import sys

import litellm

port = sys.argv[1]
alias = sys.argv[2]
effort = sys.argv[3] if len(sys.argv) > 3 else None

kwargs = dict(
    model=f"openai/{alias}",
    api_base=f"http://localhost:{port}/v1",
    api_key="sk-lit6426-repro",
    messages=[{"role": "user", "content": "What is 17*23? Answer with just the number."}],
    max_tokens=2000,
)
if effort:
    kwargs["reasoning_effort"] = effort

try:
    resp = litellm.completion(**kwargs)
    print("OK:", resp.choices[0].message.content)
    rc = getattr(resp.choices[0].message, "reasoning_content", None)
    print("reasoning_content present:", bool(rc))
except Exception as e:
    print(f"RAISED {type(e).__name__}: {e}")
```

The curl case pipes the response through `python3 -c "..."` printing `content` and whether `choices[0].message.reasoning_content` is populated

### Before (merge base d1320404fe, SDK + proxy on :24519)

#### Alias backed by Claude, reasoning_effort=low

1. `.venv/bin/python client.py 24519 my-claude-alias low`
2. Output: `RAISED UnsupportedParamsError: litellm.UnsupportedParamsError: openai does not support parameters: ['reasoning_effort'], for model=my-claude-alias. To drop these, set litellm.drop_params=True ...`
3. Proxy log line count across this and the Gemini call: 43 -> 43, so the SDK raised before any request went out

#### Alias backed by Gemini, reasoning_effort=low

1. `.venv/bin/python client.py 24519 my-gemini-alias low`
2. Output: `RAISED UnsupportedParamsError: litellm.UnsupportedParamsError: openai does not support parameters: ['reasoning_effort'], for model=my-gemini-alias. To drop these, set litellm.drop_params=True ...`

#### Alias without reasoning_effort

1. `.venv/bin/python client.py 24519 my-claude-alias`
2. Output: `OK: 391` and `reasoning_content present: False`

#### Known model gpt-4o, reasoning_effort=low

1. `.venv/bin/python client.py 24519 gpt-4o low`
2. Output: `RAISED UnsupportedParamsError: litellm.UnsupportedParamsError: openai does not support parameters: ['reasoning_effort'], for model=gpt-4o. To drop these, set litellm.drop_params=True ...`

#### Curl straight at the proxy, reasoning_effort=low

1. `curl -s http://localhost:24519/v1/chat/completions -H "Authorization: Bearer sk-lit6426-repro" -H "Content-Type: application/json" -d '{"model": "my-claude-alias", "messages": [{"role": "user", "content": "What is 17*23? Answer with just the number."}], "reasoning_effort": "low", "max_tokens": 2000}'`
2. Output: `content: 391` and `reasoning_content present: True`, so the server accepts the param and only the SDK stands in the way

### After (PR head 0a9676bd4f, SDK + proxy on :24520)

#### Alias backed by Claude, reasoning_effort=low

1. `.venv/bin/python client.py 24520 my-claude-alias low`
2. Output: `OK: 391` and `reasoning_content present: True`

#### Alias backed by Gemini, reasoning_effort=low

1. `.venv/bin/python client.py 24520 my-gemini-alias low`
2. Output: `OK: 391` and `reasoning_content present: True`

#### Alias without reasoning_effort

1. `.venv/bin/python client.py 24520 my-claude-alias`
2. Output: `OK: 391` and `reasoning_content present: False`

#### Known model gpt-4o, reasoning_effort=low

1. `.venv/bin/python client.py 24520 gpt-4o low`
2. Output: `RAISED UnsupportedParamsError: litellm.UnsupportedParamsError: openai does not support parameters: ['reasoning_effort'], for model=gpt-4o. To drop these, set litellm.drop_params=True ...`

#### Curl straight at the proxy, reasoning_effort=low

1. `curl -s http://localhost:24520/v1/chat/completions -H "Authorization: Bearer sk-lit6426-repro" -H "Content-Type: application/json" -d '{"model": "my-claude-alias", "messages": [{"role": "user", "content": "What is 17*23? Answer with just the number."}], "reasoning_effort": "low", "max_tokens": 2000}'`
2. Output: `content: 391` and `reasoning_content present: True`

Observations from the run:

- Without `reasoning_effort`, no reasoning comes back; both legs identical
- Known-model validation unchanged: `gpt-4o` still fails closed client-side

## Type

🐛 Bug Fix

## Caveats (if any)

### Medium

- Aliases on non-reasoning models now get the server's 4xx
- With `drop_params`, unknown-alias `reasoning_effort` is now forwarded, not dropped, so a call that silently succeeded can now get the server's 4xx; `additional_drop_params: ["reasoning_effort"]` restores the old behavior

### Low

- Known OpenAI names still validate client-side, `gpt-5-chat` and `codex-mini-latest` included

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

- [x] 0a9676bd4f7af7880a49aafe665b3951343e1cd9 passes /live-pr-risk
