### PR TITLE
fix(bedrock): forward aws_external_id in files and batches credential loading

### DIFF
--- a/litellm/llms/bedrock/common_utils.py
+++ b/litellm/llms/bedrock/common_utils.py
@@ -1487,6 +1487,7 @@ class CommonBatchFilesUtils:
             aws_role_name=optional_params.get("aws_role_name"),
             aws_web_identity_token=optional_params.get("aws_web_identity_token"),
             aws_sts_endpoint=optional_params.get("aws_sts_endpoint"),
+            aws_external_id=optional_params.get("aws_external_id"),
         )
 
         # Prepare the request data

--- a/litellm/llms/bedrock/files/handler.py
+++ b/litellm/llms/bedrock/files/handler.py
@@ -113,6 +113,7 @@ class BedrockFilesHandler(BaseAWSLLM):
             aws_role_name=optional_params.get("aws_role_name"),
             aws_web_identity_token=optional_params.get("aws_web_identity_token"),
             aws_sts_endpoint=optional_params.get("aws_sts_endpoint"),
+            aws_external_id=optional_params.get("aws_external_id"),
         )
 
         # Create S3 client

--- a/litellm/llms/bedrock/files/transformation.py
+++ b/litellm/llms/bedrock/files/transformation.py
@@ -146,6 +146,7 @@ class _BedrockS3RequestParams(BaseModel):
     aws_role_name: str | None = None
     aws_web_identity_token: str | None = None
     aws_sts_endpoint: str | None = None
+    aws_external_id: str | None = None
     s3_region_name: str | None = None
     s3_endpoint_url: str | None = None
 
@@ -1029,6 +1030,7 @@ class BedrockFilesConfig(BaseAWSLLM, BaseFilesConfig):
             aws_role_name=optional_params.get("aws_role_name"),
             aws_web_identity_token=optional_params.get("aws_web_identity_token"),
             aws_sts_endpoint=optional_params.get("aws_sts_endpoint"),
+            aws_external_id=optional_params.get("aws_external_id"),
         )
 
         # Calculate SHA256 hash of the content (REQUIRED for S3)
@@ -1290,6 +1292,7 @@ class BedrockFilesConfig(BaseAWSLLM, BaseFilesConfig):
             aws_role_name=request_params.aws_role_name,
             aws_web_identity_token=request_params.aws_web_identity_token,
             aws_sts_endpoint=request_params.aws_sts_endpoint,
+            aws_external_id=request_params.aws_external_id,
         )
 
         empty_body_hash: Final = hashlib.sha256(b"").hexdigest()

--- a/tests/test_litellm/llms/bedrock/files/test_bedrock_files_handler.py
+++ b/tests/test_litellm/llms/bedrock/files/test_bedrock_files_handler.py
@@ -204,3 +204,71 @@ def test_should_forward_trusted_model_credentials_to_retrieve_provider_config():
     assert response is mock_response
     litellm_params = mock_retrieve_file.call_args.kwargs["litellm_params"]
     assert litellm_params["_litellm_internal_model_credentials"] is trusted_credentials
+
+
+@pytest.mark.asyncio
+async def test_afile_content_assumes_role_with_external_id(monkeypatch):
+    """A trust policy requiring sts:ExternalId must be satisfied by the deployment's aws_external_id."""
+    import datetime
+
+    import boto3
+    from botocore.exceptions import ClientError
+
+    monkeypatch.delenv("AWS_EXTERNAL_ID", raising=False)
+
+    class FakeSTSClient:
+        def get_caller_identity(self):
+            return {"Arn": "arn:aws:iam::111111111111:user/litellm-proxy-pod"}
+
+        def assume_role(self, **params):
+            if params.get("ExternalId") != "external-id-files-download":
+                raise ClientError(
+                    {"Error": {"Code": "AccessDenied", "Message": "is not authorized to perform: sts:AssumeRole"}},
+                    "AssumeRole",
+                )
+            return {
+                "Credentials": {
+                    "AccessKeyId": "ASIAFILESDOWNLOADROLE",
+                    "SecretAccessKey": "assumed-secret",
+                    "SessionToken": "assumed-session-token",
+                    "Expiration": datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(minutes=30),
+                }
+            }
+
+    class FakeS3Body:
+        def read(self):
+            return b'{"custom_id": "req-1"}'
+
+    class FakeS3Client:
+        def get_object(self, Bucket, Key):
+            return {"Body": FakeS3Body()}
+
+    s3_client_kwargs = {}
+
+    def fake_boto3_client(service_name, **kwargs):
+        if service_name == "sts":
+            return FakeSTSClient()
+        s3_client_kwargs.update(kwargs)
+        return FakeS3Client()
+
+    optional_params = {
+        "_litellm_internal_model_credentials": MappingProxyType({"s3_bucket_name": "safe-bucket"}),
+        "aws_region_name": "us-east-1",
+        "aws_access_key_id": "AKIAFILESDOWNLOADCALLER",
+        "aws_secret_access_key": "pod-caller-secret",
+        "aws_role_name": "arn:aws:iam::999999999999:role/litellm-files-download-role",
+        "aws_session_name": "litellm-files-download-session",
+        "aws_external_id": "external-id-files-download",
+    }
+
+    with patch.object(boto3, "client", side_effect=fake_boto3_client):
+        response = await BedrockFilesHandler().afile_content(
+            file_content_request={"file_id": "s3://safe-bucket/litellm-bedrock-files-model-id-abc.jsonl"},
+            optional_params=optional_params,
+            timeout=10.0,
+            max_retries=None,
+        )
+
+    assert s3_client_kwargs["aws_access_key_id"] == "ASIAFILESDOWNLOADROLE"
+    assert s3_client_kwargs["aws_session_token"] == "assumed-session-token"
+    assert response.content == b'{"custom_id": "req-1"}'

--- a/tests/test_litellm/llms/bedrock/files/test_bedrock_files_handler.py
+++ b/tests/test_litellm/llms/bedrock/files/test_bedrock_files_handler.py
@@ -243,12 +243,9 @@ async def test_afile_content_assumes_role_with_external_id(monkeypatch):
         def get_object(self, Bucket, Key):
             return {"Body": FakeS3Body()}
 
-    s3_client_kwargs = {}
-
     def fake_boto3_client(service_name, **kwargs):
         if service_name == "sts":
             return FakeSTSClient()
-        s3_client_kwargs.update(kwargs)
         return FakeS3Client()
 
     optional_params = {
@@ -261,7 +258,7 @@ async def test_afile_content_assumes_role_with_external_id(monkeypatch):
         "aws_external_id": "external-id-files-download",
     }
 
-    with patch.object(boto3, "client", side_effect=fake_boto3_client):
+    with patch.object(boto3, "client", side_effect=fake_boto3_client) as mock_boto3_client:
         response = await BedrockFilesHandler().afile_content(
             file_content_request={"file_id": "s3://safe-bucket/litellm-bedrock-files-model-id-abc.jsonl"},
             optional_params=optional_params,
@@ -269,6 +266,7 @@ async def test_afile_content_assumes_role_with_external_id(monkeypatch):
             max_retries=None,
         )
 
+    s3_client_kwargs = next(call.kwargs for call in mock_boto3_client.call_args_list if call.args[0] == "s3")
     assert s3_client_kwargs["aws_access_key_id"] == "ASIAFILESDOWNLOADROLE"
     assert s3_client_kwargs["aws_session_token"] == "assumed-session-token"
     assert response.content == b'{"custom_id": "req-1"}'

--- a/tests/test_litellm/llms/bedrock/files/test_bedrock_files_transformation.py
+++ b/tests/test_litellm/llms/bedrock/files/test_bedrock_files_transformation.py
@@ -2404,3 +2404,111 @@ class TestBedrockFilesS3SignatureEncoding:
             body=None,
             headers=litellm_params[S3_SIGNED_GET_HEADERS_PARAM],
         )
+
+
+def test_sign_s3_request_assumes_role_with_external_id(monkeypatch):
+    """A trust policy requiring sts:ExternalId must be satisfied when signing the S3 upload request."""
+    import datetime
+    from unittest.mock import patch
+
+    import boto3
+    from botocore.exceptions import ClientError
+
+    from litellm.llms.bedrock.files.transformation import BedrockFilesConfig
+
+    monkeypatch.delenv("AWS_EXTERNAL_ID", raising=False)
+
+    class FakeSTSClient:
+        def get_caller_identity(self):
+            return {"Arn": "arn:aws:iam::111111111111:user/litellm-proxy-pod"}
+
+        def assume_role(self, **params):
+            if params.get("ExternalId") != "external-id-files-put":
+                raise ClientError(
+                    {"Error": {"Code": "AccessDenied", "Message": "is not authorized to perform: sts:AssumeRole"}},
+                    "AssumeRole",
+                )
+            return {
+                "Credentials": {
+                    "AccessKeyId": "ASIAFILESPUTROLE",
+                    "SecretAccessKey": "assumed-secret",
+                    "SessionToken": "assumed-session-token",
+                    "Expiration": datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(minutes=30),
+                }
+            }
+
+    optional_params = {
+        "aws_region_name": "us-east-1",
+        "aws_access_key_id": "AKIAFILESPUTCALLER",
+        "aws_secret_access_key": "pod-caller-secret",
+        "aws_role_name": "arn:aws:iam::999999999999:role/litellm-files-put-role",
+        "aws_session_name": "litellm-files-put-session",
+        "aws_external_id": "external-id-files-put",
+    }
+
+    with patch.object(boto3, "client", return_value=FakeSTSClient()):
+        signed_headers, _signed_body = BedrockFilesConfig()._sign_s3_request(
+            content='{"custom_id": "req-1"}',
+            api_base="https://s3.us-east-1.amazonaws.com/safe-bucket/litellm-bedrock-files-model-id-abc.jsonl",
+            optional_params=optional_params,
+        )
+
+    authorization = {key.lower(): value for key, value in signed_headers.items()}["authorization"]
+    assert "ASIAFILESPUTROLE" in authorization
+
+
+def test_sign_s3_get_request_assumes_role_with_external_id(monkeypatch):
+    """A trust policy requiring sts:ExternalId must be satisfied when signing the S3 download request."""
+    import datetime
+    from unittest.mock import patch
+
+    import boto3
+    from botocore.exceptions import ClientError
+
+    from litellm.llms.bedrock.files.transformation import (
+        BedrockFilesConfig,
+        _BedrockS3RequestParams,
+    )
+
+    monkeypatch.delenv("AWS_EXTERNAL_ID", raising=False)
+
+    class FakeSTSClient:
+        def get_caller_identity(self):
+            return {"Arn": "arn:aws:iam::111111111111:user/litellm-proxy-pod"}
+
+        def assume_role(self, **params):
+            if params.get("ExternalId") != "external-id-files-get":
+                raise ClientError(
+                    {"Error": {"Code": "AccessDenied", "Message": "is not authorized to perform: sts:AssumeRole"}},
+                    "AssumeRole",
+                )
+            return {
+                "Credentials": {
+                    "AccessKeyId": "ASIAFILESGETROLE",
+                    "SecretAccessKey": "assumed-secret",
+                    "SessionToken": "assumed-session-token",
+                    "Expiration": datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(minutes=30),
+                }
+            }
+
+    request_params = _BedrockS3RequestParams.model_validate(
+        {
+            "aws_region_name": "us-east-1",
+            "aws_access_key_id": "AKIAFILESGETCALLER",
+            "aws_secret_access_key": "pod-caller-secret",
+            "aws_role_name": "arn:aws:iam::999999999999:role/litellm-files-get-role",
+            "aws_session_name": "litellm-files-get-session",
+            "aws_external_id": "external-id-files-get",
+        }
+    )
+    assert request_params.aws_external_id == "external-id-files-get"
+
+    with patch.object(boto3, "client", return_value=FakeSTSClient()):
+        signed_headers = BedrockFilesConfig()._sign_s3_get_request(
+            api_base="https://s3.us-east-1.amazonaws.com/safe-bucket/litellm-bedrock-files-model-id-abc.jsonl",
+            aws_region_name="us-east-1",
+            request_params=request_params,
+        )
+
+    authorization = {key.lower(): value for key, value in signed_headers.items()}["authorization"]
+    assert "ASIAFILESGETROLE" in authorization

--- a/tests/test_litellm/llms/bedrock/test_bedrock_common_utils.py
+++ b/tests/test_litellm/llms/bedrock/test_bedrock_common_utils.py
@@ -520,3 +520,56 @@ def test_merge_bedrock_aws_request_params_keeps_caller_credentials_without_stati
     assert merged["aws_secret_access_key"] == "caller-secret"
     assert merged["aws_session_token"] == "caller-token"
     assert merged["aws_region_name"] == "us-west-2"
+
+
+def test_sign_aws_request_assumes_role_with_external_id(monkeypatch):
+    """A trust policy requiring sts:ExternalId must be satisfied when signing batch API requests."""
+    import datetime
+    from unittest.mock import patch
+
+    import boto3
+    from botocore.exceptions import ClientError
+
+    from litellm.llms.bedrock.common_utils import CommonBatchFilesUtils
+
+    monkeypatch.delenv("AWS_EXTERNAL_ID", raising=False)
+
+    class FakeSTSClient:
+        def get_caller_identity(self):
+            return {"Arn": "arn:aws:iam::111111111111:user/litellm-proxy-pod"}
+
+        def assume_role(self, **params):
+            if params.get("ExternalId") != "external-id-batch-sign":
+                raise ClientError(
+                    {"Error": {"Code": "AccessDenied", "Message": "is not authorized to perform: sts:AssumeRole"}},
+                    "AssumeRole",
+                )
+            return {
+                "Credentials": {
+                    "AccessKeyId": "ASIABATCHSIGNROLE",
+                    "SecretAccessKey": "assumed-secret",
+                    "SessionToken": "assumed-session-token",
+                    "Expiration": datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(minutes=30),
+                }
+            }
+
+    optional_params = {
+        "aws_region_name": "us-east-1",
+        "aws_access_key_id": "AKIABATCHSIGNCALLER",
+        "aws_secret_access_key": "pod-caller-secret",
+        "aws_role_name": "arn:aws:iam::999999999999:role/litellm-batch-sign-role",
+        "aws_session_name": "litellm-batch-sign-session",
+        "aws_external_id": "external-id-batch-sign",
+    }
+
+    with patch.object(boto3, "client", return_value=FakeSTSClient()):
+        signed_headers, signed_data = CommonBatchFilesUtils().sign_aws_request(
+            service_name="bedrock",
+            data={"jobName": "litellm-batch-job"},
+            endpoint_url="https://bedrock.us-east-1.amazonaws.com/model-invocation-job",
+            optional_params=optional_params,
+        )
+
+    authorization = {key.lower(): value for key, value in signed_headers.items()}["authorization"]
+    assert "ASIABATCHSIGNROLE" in authorization
+    assert signed_data == b'{"jobName": "litellm-batch-job"}'


### PR DESCRIPTION
## TLDR

Problem this solves:

- Bedrock files and batches dropped the deployment's `aws_external_id`
- Role trust policies requiring `sts:ExternalId` denied AssumeRole, killing the whole batch workflow

How it solves it:

- Forward `aws_external_id` at the four credential call sites that still dropped it
- Regression tests pin each site with a fake STS that requires the external id

## User Flow

Before: a team whose Bedrock deployment assumes a role with a required external id cannot run batches: the first step, uploading the batch input file, dies

1. The proxy admin configures a Bedrock batch model with `aws_role_name`, `aws_external_id`, and `s3_bucket_name`
2. A developer sends POST http://litellm-domain/v1/files with `purpose=batch`, `target_model_names`, and their JSONL file
3. The response is HTTP 500: "An error occurred (AccessDenied) when calling the AssumeRole operation: User ... is not authorized to perform: sts:AssumeRole"
4. With no file id, POST http://litellm-domain/v1/batches is unreachable, so no batch can ever be created
5. A plain POST http://litellm-domain/v1/chat/completions on the same role and external id returns 200, proving the credentials themselves are fine

After: the same upload succeeds and the batch flow runs end to end

1. The proxy admin configures the same Bedrock batch model
2. The developer sends the same POST http://litellm-domain/v1/files and gets 200 with a file id
3. POST http://litellm-domain/v1/batches with that file id returns 200 with a batch id
4. GET http://litellm-domain/v1/batches/{batch_id} shows the job progress to `completed`
5. GET http://litellm-domain/v1/files/{output_file_id}/content returns the model's batch results

## Relevant issues

## Linear ticket

Resolves LIT-6460

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Shared setup, identical for both legs: proxy booted with 2 uvicorn workers on a random free port, no `AWS_EXTERNAL_ID` env var, `batch_input.jsonl` holding 100 small chat requests (Bedrock rejects invocation jobs under 100 records), deployment config:

```yaml
model_list:
  - model_name: bedrock-batch
    litellm_params:
      model: bedrock/us.amazon.nova-lite-v1:0
      aws_region_name: us-east-1
      s3_bucket_name: litellm-lit6460-files-qa
      aws_role_name: arn:aws:iam::654278500801:role/litellm-lit6341-extid-qa
      aws_session_name: lit6460-batch
      aws_external_id: lit6341-qa-external-id
      aws_batch_role_arn: arn:aws:iam::654278500801:role/litellm-lit6460-batch-svc
    model_info:
      mode: batch
  - model_name: bedrock-chat-control
    litellm_params:
      model: bedrock/converse/us.amazon.nova-lite-v1:0
      aws_region_name: us-east-1
      aws_role_name: arn:aws:iam::654278500801:role/litellm-lit6341-extid-qa
      aws_session_name: lit6460-chat
      aws_external_id: lit6341-qa-external-id
```

The IAM role's trust policy requires `sts:ExternalId == lit6341-qa-external-id`, and the proxy's IAM user has no other route to the role

### Before (d1320404fe)

#### Chat control: same role and external id, non-batch path

1. Command, sent twice so both workers serve one:

```
curl -s -w '\nHTTP %{http_code}\n' http://localhost:27341/v1/chat/completions \
  -H 'Authorization: Bearer sk-lit6460-qa' -H 'Content-Type: application/json' \
  -d '{"model":"bedrock-chat-control","messages":[{"role":"user","content":"Say hi in three words"}]}'
```

2. HTTP 200 both times, e.g. `"content":"Hi, there, friend."` with real usage: the role, external id, and account all work on paths that forward the external id

#### Batch file upload

1. Command, sent twice so both workers serve one:

```
curl -s -w '\nHTTP %{http_code}\n' http://localhost:27341/v1/files \
  -H 'Authorization: Bearer sk-lit6460-qa' \
  -F purpose=batch -F target_model_names=bedrock-batch -F file=@batch_input.jsonl
```

2. HTTP 500 both times:

```
{"error":{"message":"An error occurred (AccessDenied) when calling the AssumeRole operation: User: arn:aws:iam::654278500801:user/litellm-lit6341-proxy is not authorized to perform: sts:AssumeRole on resource: arn:aws:iam::654278500801:role/litellm-lit6341-extid-qa","type":"None","param":"None","code":"500"}}
```

#### Batch create, retrieve, and output download

1. Unreachable: the upload above never returns a file id, so POST /v1/batches has nothing to submit and the rest of the flow cannot start

### After (76839ca9d8)

The one commit since, 60b24abd3e, only rewrites how a test captures mock kwargs, so it cannot change proxy behavior

#### Chat control: same role and external id, non-batch path

1. Same command as the before leg, sent twice so both workers serve one
2. HTTP 200 both times, e.g. `"content":"Hi, there, friend."` with real usage

#### Batch file upload

1. The exact command that returned 500 before, sent twice so both workers serve one:

```
curl -s -w '\nHTTP %{http_code}\n' http://localhost:22446/v1/files \
  -H 'Authorization: Bearer sk-lit6460-qa' \
  -F purpose=batch -F target_model_names=bedrock-batch -F file=@batch_input.jsonl
```

2. HTTP 200 both times, e.g.:

```
{"id":"bGl0ZWxsbV9wcm94eTphcHBsaWNhdGlvbi9vY3RldC1zdHJlYW07...","bytes":16183,"created_at":1788236644,"filename":"litellm-bedrock-files-us.amazon.nova-lite-v1-0-2a62a1d3-5d45-4a09-a568-0e3d19853392.jsonl","object":"file","purpose":"batch","status":"uploaded",...}
HTTP 200
```

#### Batch create, retrieve, and output download

1. Create from the uploaded file id:

```
curl -s -w '\nHTTP %{http_code}\n' http://localhost:22446/v1/batches \
  -H 'Authorization: Bearer sk-lit6460-qa' -H 'Content-Type: application/json' \
  -d '{"input_file_id":"<file id from the upload>","endpoint":"/v1/chat/completions","completion_window":"24h"}'
```

2. HTTP 200 with `"status":"validating"` and a real Bedrock job behind it: `arn:aws:bedrock:us-east-1:654278500801:model-invocation-job/vzu8tysl94ra`
3. GET /v1/batches/{batch_id}, polled every 30s, walks `validating` -> `in_progress` -> `completed` in about 8 minutes, ending with:

```
"status": "completed",
"request_counts": {"completed": 100, "failed": 0, "total": 100}
```

4. GET /v1/files/{output_file_id}/content returns HTTP 200 with all 100 result records, e.g.:

```
{"modelInput":{"messages":[{"role":"user","content":[{"text":"Say the number 3 in words"}]}],...},"modelOutput":{"output":{"message":{"content":[{"text":"The number 3 is \"three.\""}],"role":"assistant"}},"stopReason":"end_turn","usage":{"inputTokens":7,"outputTokens":9,"totalTokens":16}},"recordId":"req-3"}
```

## Type

🐛 Bug Fix

## Caveats (if any)

- Low: a deployment whose `aws_external_id` value is wrong and that only appeared to work because files and batches dropped it will now fail as configured, matching how chat, embeddings, and realtime already treat that value

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
- [x] 60b24abd3e passes /live-pr-risk
