### PR TITLE
fix(credentials): publish cross-pod config sync on credential writes

### DIFF
--- a/litellm/proxy/credential_endpoints/endpoints.py
+++ b/litellm/proxy/credential_endpoints/endpoints.py
@@ -15,6 +15,10 @@ from litellm.litellm_core_utils.credential_accessor import CredentialAccessor
 from litellm.litellm_core_utils.litellm_logging import _get_masked_values
 from litellm.proxy._types import CommonProxyErrors, UserAPIKeyAuth
 from litellm.proxy.auth.user_api_key_auth import user_api_key_auth
+from litellm.proxy.common_utils.config_sync_pubsub import (
+    coordination_redis_cache,
+    publish_config_change,
+)
 from litellm.proxy.common_utils.encrypt_decrypt_utils import encrypt_value_helper
 from litellm.proxy.utils import handle_exception_on_proxy, jsonify_object
 from litellm.repositories.credentials_repository import CredentialsRepository
@@ -104,6 +108,7 @@ async def create_credential(
 
         ## ADD TO LITELLM ##
         CredentialAccessor.upsert_credentials([processed_credential])
+        await publish_config_change(redis_cache=coordination_redis_cache(), object_type="litellm_credentialstable")
 
         return {"success": True, "message": "Credential created successfully"}
     except Exception as e:
@@ -243,6 +248,7 @@ async def delete_credential(
 
         ## DELETE FROM LITELLM ##
         litellm.credential_list = [cred for cred in litellm.credential_list if cred.credential_name != credential_name]
+        await publish_config_change(redis_cache=coordination_redis_cache(), object_type="litellm_credentialstable")
         return {"success": True, "message": "Credential deleted successfully"}
     except Exception as e:
         return handle_exception_on_proxy(e)
@@ -351,6 +357,7 @@ async def update_credential(
                 litellm.credential_list = [c for c in litellm.credential_list if c.credential_name != credential_name]
             CredentialAccessor.upsert_credentials([updated_in_memory])
 
+        await publish_config_change(redis_cache=coordination_redis_cache(), object_type="litellm_credentialstable")
         return {"success": True, "message": "Credential updated successfully"}
     except Exception as e:
         raise handle_exception_on_proxy(e)

--- a/tests/test_litellm/proxy/credential_endpoints/test_endpoints.py
+++ b/tests/test_litellm/proxy/credential_endpoints/test_endpoints.py
@@ -2,9 +2,7 @@
 
 from unittest.mock import AsyncMock, MagicMock, patch
 
-import pytest
 from fastapi.testclient import TestClient
-
 
 from litellm.proxy._types import UserAPIKeyAuth
 from litellm.proxy.auth.user_api_key_auth import user_api_key_auth
@@ -19,12 +17,17 @@ def _as_admin():
 
 
 def _patch_credential(name: str, body: dict):
+    return _request_as_admin("PATCH", f"/credentials/{name}", body)
+
+
+def _request_as_admin(method: str, path: str, body: dict | None):
     missing = object()
     previous_override = app.dependency_overrides.get(user_api_key_auth, missing)
     app.dependency_overrides[user_api_key_auth] = _as_admin
     try:
-        return client.patch(
-            f"/credentials/{name}",
+        return client.request(
+            method,
+            path,
             json=body,
             headers={"Authorization": "Bearer test-key"},
         )
@@ -40,14 +43,19 @@ def test_update_credential_answers_404_when_the_credential_does_not_exist():
     the exception the response body and lets FastAPI answer 200, so a write the handler
     rejected read as a success to every caller that checks the status. The dashboard's API
     client branches on the status, so it reported a failed edit as applied."""
-    with patch("litellm.proxy.proxy_server.prisma_client", MagicMock()), patch(
-        "litellm.proxy.credential_endpoints.endpoints.CredentialsRepository"
-    ) as repository:
+    with (
+        patch("litellm.proxy.proxy_server.prisma_client", MagicMock()),
+        patch("litellm.proxy.credential_endpoints.endpoints.CredentialsRepository") as repository,
+    ):
         repository.return_value.find_by_name = AsyncMock(return_value=None)
 
         response = _patch_credential(
             "definitely-not-there",
-            {"credential_name": "definitely-not-there", "credential_values": {"api_key": "sk-x"}, "credential_info": {}},
+            {
+                "credential_name": "definitely-not-there",
+                "credential_values": {"api_key": "sk-x"},
+                "credential_info": {},
+            },
         )
 
     assert response.status_code == 404, f"rejected write answered {response.status_code}: {response.text}"
@@ -73,9 +81,11 @@ def test_update_credential_still_answers_200_on_a_successful_write():
         credential_values={"api_key": "sk-old"},
         credential_info={"custom_llm_provider": "openai"},
     )
-    with patch("litellm.proxy.proxy_server.prisma_client", MagicMock()), patch(
-        "litellm.proxy.proxy_server.master_key", "sk-test-master"
-    ), patch("litellm.proxy.credential_endpoints.endpoints.CredentialsRepository") as repository:
+    with (
+        patch("litellm.proxy.proxy_server.prisma_client", MagicMock()),
+        patch("litellm.proxy.proxy_server.master_key", "sk-test-master"),
+        patch("litellm.proxy.credential_endpoints.endpoints.CredentialsRepository") as repository,
+    ):
         repository.return_value.find_by_name = AsyncMock(return_value=stored)
         repository.return_value.update_by_name = AsyncMock(return_value=None)
 
@@ -86,3 +96,86 @@ def test_update_credential_still_answers_200_on_a_successful_write():
 
     assert response.status_code == 200, response.text
     assert response.json()["success"] is True
+
+
+def test_create_credential_publishes_a_cross_pod_sync_event():
+    with (
+        patch("litellm.proxy.proxy_server.prisma_client", MagicMock()),
+        patch("litellm.proxy.proxy_server.master_key", "sk-test-master"),
+        patch("litellm.proxy.credential_endpoints.endpoints.CredentialsRepository") as repository,
+        patch("litellm.proxy.credential_endpoints.endpoints.publish_config_change", new_callable=AsyncMock) as publish,
+    ):
+        repository.return_value.create = AsyncMock(return_value=None)
+
+        response = _request_as_admin(
+            "POST",
+            "/credentials",
+            {
+                "credential_name": "sync-create",
+                "credential_values": {"api_key": "sk-x", "api_base": "http://127.0.0.1:1"},
+                "credential_info": {"custom_llm_provider": "openai"},
+            },
+        )
+
+    assert response.status_code == 200, response.text
+    publish.assert_awaited_once()
+    assert publish.await_args.kwargs["object_type"] == "litellm_credentialstable"
+
+
+def test_update_credential_publishes_a_cross_pod_sync_event():
+    stored = CredentialItem(
+        credential_name="sync-update",
+        credential_values={"api_key": "sk-old"},
+        credential_info={"custom_llm_provider": "openai"},
+    )
+    with (
+        patch("litellm.proxy.proxy_server.prisma_client", MagicMock()),
+        patch("litellm.proxy.proxy_server.master_key", "sk-test-master"),
+        patch("litellm.proxy.credential_endpoints.endpoints.CredentialsRepository") as repository,
+        patch("litellm.proxy.credential_endpoints.endpoints.publish_config_change", new_callable=AsyncMock) as publish,
+    ):
+        repository.return_value.find_by_name = AsyncMock(return_value=stored)
+        repository.return_value.update_by_name = AsyncMock(return_value=None)
+
+        response = _request_as_admin(
+            "PATCH",
+            "/credentials/sync-update",
+            {"credential_name": "sync-update", "credential_values": {"api_key": "sk-new"}, "credential_info": {}},
+        )
+
+    assert response.status_code == 200, response.text
+    publish.assert_awaited_once()
+    assert publish.await_args.kwargs["object_type"] == "litellm_credentialstable"
+
+
+def test_delete_credential_publishes_a_cross_pod_sync_event():
+    with (
+        patch("litellm.proxy.proxy_server.prisma_client", MagicMock()),
+        patch("litellm.proxy.credential_endpoints.endpoints.CredentialsRepository") as repository,
+        patch("litellm.proxy.credential_endpoints.endpoints.publish_config_change", new_callable=AsyncMock) as publish,
+    ):
+        repository.return_value.delete_by_name = AsyncMock(return_value=None)
+
+        response = _request_as_admin("DELETE", "/credentials/sync-delete", None)
+
+    assert response.status_code == 200, response.text
+    publish.assert_awaited_once()
+    assert publish.await_args.kwargs["object_type"] == "litellm_credentialstable"
+
+
+def test_rejected_update_does_not_publish_a_sync_event():
+    with (
+        patch("litellm.proxy.proxy_server.prisma_client", MagicMock()),
+        patch("litellm.proxy.credential_endpoints.endpoints.CredentialsRepository") as repository,
+        patch("litellm.proxy.credential_endpoints.endpoints.publish_config_change", new_callable=AsyncMock) as publish,
+    ):
+        repository.return_value.find_by_name = AsyncMock(return_value=None)
+
+        response = _request_as_admin(
+            "PATCH",
+            "/credentials/not-there",
+            {"credential_name": "not-there", "credential_values": {"api_key": "sk-x"}, "credential_info": {}},
+        )
+
+    assert response.status_code == 404, response.text
+    publish.assert_not_awaited()


### PR DESCRIPTION
## TLDR

Problem this solves:

- On multi-instance deployments, a new credential is unusable for up to 30s
- Peer instances only pick up credential writes on a 30s poll
- Save credential then Test Connect in the UI fails intermittently

How it solves it:

- Credential create, update, and delete now publish a config sync event
- Peer instances resync immediately, same as key and model writes already do

## User Flow

Before: an admin saves a credential and the connection test that uses it fails

1. They POST https://litellm-domain/credentials with a credential name, an api key, and an api base, and get back 200 "Credential created successfully"
2. On https://litellm-domain/ui/?page=models-and-endpoints they open Add Model, pick that credential under Existing Credentials, and click Test Connect
3. The Connection Test Results modal shows a failure even though the credential is correct, because the instance answering the test has not seen the new credential yet
4. Retrying up to 30 seconds later, the same test passes with nothing changed

After: the same steps pass on the first try

1. They POST https://litellm-domain/credentials with the same body and get back 200 "Credential created successfully"
2. On https://litellm-domain/ui/?page=models-and-endpoints they open Add Model, pick that credential under Existing Credentials, and click Test Connect
3. The Connection Test Results modal shows success immediately

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

The race only exists when the instance that stores the credential and the instance that answers the connection test are different processes, so a single local proxy cannot reproduce it. The reproduction below is from the multi-instance e2e lane; the After side is the regression tests plus the same lane on this PR

### Before (aabfbd6e37)

1. The base branch carries this exact code path: `git diff aabfbd6e37 4a163f1a6a -- litellm/proxy/credential_endpoints/endpoints.py litellm/litellm_core_utils/credential_accessor.py` is empty
2. Buildkite litellm-e2e-ui build 122 (multi-instance stack, https://buildkite.com/berriai-1/litellm-e2e-ui/builds/122) ran the flow above via the Playwright spec "Add a model with a stored credential, pass Test Connect, and serve traffic" and failed all 3 attempts the same way:

```
Error: expect(locator).toBeVisible() failed
Locator: getByTestId('connection-success-msg')
Timeout: 30000ms
```

3. Each attempt created a fresh credential over POST /credentials seconds before clicking Test Connect, so every attempt landed inside the poll gap. The sibling spec that types the api base into the form directly passed in the same run, which isolates the failure to reading the just-stored credential from another instance

### After (b462be816b)

1. Command:

```
uv run pytest tests/test_litellm/proxy/credential_endpoints/test_endpoints.py -v
```

2. Result: 7 passed. The 4 new tests assert create, update, and delete each publish the sync event and a rejected write does not; with the publish calls reverted they fail 4/4, so the poll-gap dependence cannot come back silently
3. The buildkite e2e lane on this PR runs the same stored-credential Playwright spec on the multi-instance stack; one pass there was previously possible by winning the poll timing, so the deterministic guard is the regression tests above

## Type

🐛 Bug Fix

## Caveats (if any)

### Low

- The publish is best effort: without a coordination redis, peers still fall back to the 30s poll, which is today's behavior unchanged
- Single-instance deployments were never affected and see no behavior change

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
