### PR TITLE
test(websearch): register configured search tool in pre-request hook test

### DIFF
--- a/tests/pass_through_unit_tests/test_websearch_interception_e2e.py
+++ b/tests/pass_through_unit_tests/test_websearch_interception_e2e.py
@@ -995,7 +995,10 @@ async def test_pre_request_hook_modifies_request_body():
     with patch(
         "litellm.llms.anthropic.experimental_pass_through.messages.handler.anthropic_messages_handler",
         side_effect=mock_anthropic_messages_handler,
-    ), patch("litellm.proxy.proxy_server.llm_router", mock_router):
+    ), patch(  # test-quality-ok: the hook imports this process-global router at call time; no injection seam exists to register search_tools
+        "litellm.proxy.proxy_server.llm_router",
+        mock_router,
+    ):
 
         print(
             "\n📝 Making request with native web_search_20250305 tool (stream=True)..."

--- a/tests/pass_through_unit_tests/test_websearch_interception_e2e.py
+++ b/tests/pass_through_unit_tests/test_websearch_interception_e2e.py
@@ -937,6 +937,14 @@ async def test_pre_request_hook_modifies_request_body():
 
     print("✅ WebSearchInterceptionLogger initialized")
 
+    mock_router = MagicMock()
+    mock_router.search_tools = [
+        {
+            "search_tool_name": "test-search-tool",
+            "litellm_params": {"search_provider": "tavily"},
+        }
+    ]
+
     # Track what actually gets sent to the API
     captured_request = {}
 
@@ -987,7 +995,7 @@ async def test_pre_request_hook_modifies_request_body():
     with patch(
         "litellm.llms.anthropic.experimental_pass_through.messages.handler.anthropic_messages_handler",
         side_effect=mock_anthropic_messages_handler,
-    ):
+    ), patch("litellm.proxy.proxy_server.llm_router", mock_router):
 
         print(
             "\n📝 Making request with native web_search_20250305 tool (stream=True)..."


### PR DESCRIPTION
## TLDR

Problem this solves:

- PR #38113 broke `test_pre_request_hook_modifies_request_body` on staging
- It names a search tool the test rig never registers, so the new fail-fast raises
- `pass_through_unit_testing` is red for every PR based on current staging

How it solves it:

- Stub the proxy router with the named search tool in the test
- The test exercises the tool-conversion path again instead of dying in validation

## User Flow

Before: a contributor's PR based on current staging shows a red `pass_through_unit_testing` CI job they did not cause

1. They open any PR off litellm_internal_staging with the run-ci label
2. CircleCI runs `pass_through_unit_testing` and it fails on `test_pre_request_hook_modifies_request_body` with "Configured search tool 'test-search-tool' was not found"
3. Their PR shows a failing required-suite job for code they never touched

After: the same suite is green again

1. They open any PR off litellm_internal_staging with the run-ci label
2. CircleCI runs `pass_through_unit_testing` and all 249 tests pass
3. Their PR's CI reflects only their own changes

## Relevant issues

Follow-up to #38113

## Linear ticket

https://linear.app/litellm-ai/issue/LIT-6625/review-pr-39074-testwebsearch-register-configured-search-tool-in-pre

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

This PR repairs a broken test, so the proof is the test run itself at both commits

### Before (174acf90c1, staging tip)

1. `PYTHONPATH=$PWD ./.venv/bin/python -m pytest tests/pass_through_unit_tests/test_websearch_interception_e2e.py::test_pre_request_hook_modifies_request_body -q`
2. Observed: `FAILED ... ValueError: Configured search tool 'test-search-tool' was not found`, raised from `_select_search_tool_from_list` (the validation added by #38113)
3. The same failure appears on CircleCI `pass_through_unit_testing` for any PR whose merge base includes 65a46a5f32, e.g. https://app.circleci.com/workflow/720fdd8f-638a-4e0b-80c4-e46c958e696d/job/c095ad15-90ba-4a22-a14e-3c58b3838612 (1 failed of 249)

### After (f65bee6d74)

1. `PYTHONPATH=$PWD ./.venv/bin/python -m pytest tests/pass_through_unit_tests/test_websearch_interception_e2e.py -q`
2. Observed: `8 passed, 1 warning in 32.01s`, with the fixed test still asserting the native `web_search_20250305` tool is converted to `litellm_web_search` and stream is coerced to False
3. CircleCI `pass_through_unit_testing` at 191313e756 already confirmed the fix in CI (249 passed); f65bee6d74 only adds a reasoned `# test-quality-ok` suppression for the lint job's TQ008 gate

## Type

✅ Test

## Caveats (if any)

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change; no production behavior is modified.
> 
> **Overview**
> Repairs **`test_pre_request_hook_modifies_request_body`** after fail-fast search-tool validation (from #38113): the test configures `WebSearchInterceptionLogger` with `search_tool_name="test-search-tool"` but never exposed that tool on the proxy router, so the hook raised before the mocked Anthropic handler ran.
> 
> The fix adds a **`MagicMock` router** whose `search_tools` includes `test-search-tool`, and **patches `litellm.proxy.proxy_server.llm_router`** for the duration of the test (with a `# test-quality-ok` note that the hook reads that global at call time). The test again exercises native `web_search_20250305` → `litellm_web_search` conversion and `stream=True` → `False` coercion.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f65bee6d74322804dea454ef0e6c904a26f89198. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->