### PR TITLE
fix: resolve TypeScript errors in UI tests

### DIFF
--- a/ui/litellm-dashboard/src/components/templates/key_info_view.test.tsx
+++ b/ui/litellm-dashboard/src/components/templates/key_info_view.test.tsx
@@ -162,9 +162,13 @@ describe("KeyInfoView", () => {
 
   // Base mock for useAuthorized hook
   const baseUseAuthorizedMock = {
+    isLoading: false,
+    isAuthorized: true,
     accessToken: "test-token",
     userId: "test-user",
     userRole: "admin",
+    userRoleLabel: "Admin",
+    isViewOnly: false,
     premiumUser: true,
     token: "test-token",
     userEmail: null,

--- a/ui/litellm-dashboard/src/lib/autorouter_presets.test.ts
+++ b/ui/litellm-dashboard/src/lib/autorouter_presets.test.ts
@@ -245,7 +245,12 @@ describe("autorouter_presets", () => {
       ["some-model", "prov/some-model-20991399"],
     ])("never lets %s be satisfied by a deployment of %s", (presetModel, underlying) => {
       const availability = availabilityFor("some-group", underlying);
-      const config = { tiers: { SIMPLE: [presetModel], MEDIUM: [], COMPLEX: [], REASONING: [] }, classifier_type: "heuristic" as const, session_affinity: false, deployment_affinity: true };
+      const config = {
+        tiers: { SIMPLE: [presetModel], MEDIUM: [], COMPLEX: [], REASONING: [] },
+        classifier_type: "heuristic" as const,
+        session_affinity: false,
+        deployment_affinity: true,
+      };
       expect(getMissingModels(config, availability)).toEqual([presetModel]);
     });
 

--- a/ui/litellm-dashboard/src/lib/autorouter_presets.test.ts
+++ b/ui/litellm-dashboard/src/lib/autorouter_presets.test.ts
@@ -245,7 +245,7 @@ describe("autorouter_presets", () => {
       ["some-model", "prov/some-model-20991399"],
     ])("never lets %s be satisfied by a deployment of %s", (presetModel, underlying) => {
       const availability = availabilityFor("some-group", underlying);
-      const config = { tiers: { SIMPLE: [presetModel], MEDIUM: [], COMPLEX: [], REASONING: [] } };
+      const config = { tiers: { SIMPLE: [presetModel], MEDIUM: [], COMPLEX: [], REASONING: [] }, classifier_type: "heuristic" as const, session_affinity: false, deployment_affinity: true };
       expect(getMissingModels(config, availability)).toEqual([presetModel]);
     });
 
@@ -680,6 +680,8 @@ describe("autorouter_presets", () => {
           ],
         },
         classifier_type: "heuristic" as const,
+        session_affinity: false,
+        deployment_affinity: true,
       };
       const prefill = buildPresetPrefill(config, groupsOnly(["claude-sonnet-4.5"]));
       // temperature survives from the spelling that would otherwise have been overwritten;

--- a/ui/litellm-dashboard/src/lib/http/api.test.ts
+++ b/ui/litellm-dashboard/src/lib/http/api.test.ts
@@ -84,7 +84,7 @@ describe("typed api client middleware", () => {
     const { streamBodiedInits } = spyOnRequestConstruction();
     const { fetch, requests } = capturingFetch(jsonResponse(200, { key: "sk-new" }));
 
-    await fetchClient.POST("/key/generate", { fetch, body: { key_alias: "my-key" } });
+    await fetchClient.POST("/key/generate", { fetch, body: { key_alias: "my-key" } as any });
 
     expect(streamBodiedInits()).toEqual([]);
     expect(requests[0].headers.get("Authorization")).toBe("Bearer sk-test");
@@ -97,7 +97,7 @@ describe("typed api client middleware", () => {
     const { streamBodiedInits } = spyOnRequestConstruction();
     const { fetch, requests } = capturingFetch(jsonResponse(200, { key: "sk-new" }));
 
-    await fetchClient.POST("/key/generate", { fetch, body: { key_alias: "my-key" } });
+    await fetchClient.POST("/key/generate", { fetch, body: { key_alias: "my-key" } as any });
 
     expect(streamBodiedInits()).toEqual([]);
     const sent = requests[0];

--- a/ui/litellm-dashboard/src/lib/http/client.test.ts
+++ b/ui/litellm-dashboard/src/lib/http/client.test.ts
@@ -31,7 +31,7 @@ describe("createApiClient", () => {
 
     expect(result).toEqual({ ok: true });
     expect(fetchImpl).toHaveBeenCalledTimes(1);
-    const [url, init] = fetchImpl.mock.calls[0];
+    const [url, init] = fetchImpl.mock.calls[0] as [string, RequestInit];
     expect(url).toBe("https://proxy.example/models?team=t1&page=2");
     expect(init).toMatchObject({ method: "GET" });
     expect(init.headers).toEqual({
@@ -47,7 +47,7 @@ describe("createApiClient", () => {
 
     await client.post("/model/new", { accessToken: "sk", body: { model_name: "gpt" } });
 
-    const [, init] = fetchImpl.mock.calls[0];
+    const [, init] = fetchImpl.mock.calls[0] as [string, RequestInit];
     expect(init.method).toBe("POST");
     expect(init.body).toBe(JSON.stringify({ model_name: "gpt" }));
   });
@@ -100,7 +100,7 @@ describe("createApiClient", () => {
 
     await client.get("/public/info");
 
-    const [, init] = fetchImpl.mock.calls[0];
+    const [, init] = fetchImpl.mock.calls[0] as [string, RequestInit];
     expect(init.headers).toEqual({ "Content-Type": "application/json" });
   });
 

--- a/ui/litellm-dashboard/src/utils/returnUrlUtils.test.ts
+++ b/ui/litellm-dashboard/src/utils/returnUrlUtils.test.ts
@@ -1,5 +1,6 @@
 // @vitest-environment jsdom
 
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import {
   buildLoginUrlWithReturn,
   clearStoredReturnUrl,

--- a/ui/litellm-dashboard/src/utils/roles.test.ts
+++ b/ui/litellm-dashboard/src/utils/roles.test.ts
@@ -104,6 +104,7 @@ describe("roles", () => {
           created_at: "2024-01-01",
           keys: [],
           members_with_roles: [{ user_id: "user-1", user_email: "user1@test.com", role: "user" }],
+          spend: 0,
         },
         {
           team_id: "team-2",
@@ -117,6 +118,7 @@ describe("roles", () => {
           created_at: "2024-01-01",
           keys: [],
           members_with_roles: [{ user_id: "user-1", user_email: "user1@test.com", role: "admin" }],
+          spend: 0,
         },
       ];
       expect(isUserTeamAdminForAnyTeam(teams, "user-1")).toBe(true);
@@ -136,6 +138,7 @@ describe("roles", () => {
           created_at: "2024-01-01",
           keys: [],
           members_with_roles: [{ user_id: "user-1", user_email: "user1@test.com", role: "user" }],
+          spend: 0,
         },
         {
           team_id: "team-2",
@@ -149,6 +152,7 @@ describe("roles", () => {
           created_at: "2024-01-01",
           keys: [],
           members_with_roles: [{ user_id: "user-2", user_email: "user2@test.com", role: "admin" }],
+          spend: 0,
         },
       ];
       expect(isUserTeamAdminForAnyTeam(teams, "user-1")).toBe(false);

--- a/ui/litellm-dashboard/tests/top_key_view.test.tsx
+++ b/ui/litellm-dashboard/tests/top_key_view.test.tsx
@@ -28,6 +28,8 @@ describe("TopKeyView", () => {
     teams: null,
     premiumUser: true,
     showTags: false,
+    topKeysLimit: 5,
+    setTopKeysLimit: vi.fn(),
   };
 
   const mockKeysWithTags = [
@@ -65,11 +67,15 @@ describe("TopKeyView", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockUseAuthorized.mockReturnValue({
+      isLoading: false,
+      isAuthorized: true,
       token: "mock-token",
       accessToken: mockProps.accessToken,
       userId: mockProps.userID,
       userEmail: "test@example.com",
       userRole: mockProps.userRole,
+      userRoleLabel: "Admin",
+      isViewOnly: false,
       premiumUser: mockProps.premiumUser,
       disabledPersonalKeyCreation: false,
       showSSOBanner: false,


### PR DESCRIPTION
Fixes GitHub Actions build failures in UI tests by:
- Adding missing useAuthorized properties (isLoading, isAuthorized, userRoleLabel, isViewOnly) to test mocks
- Adding required session_affinity and deployment_affinity to ComplexityRouterConfigPayload test mocks
- Fixing GenerateKeyRequest body type in api.test.ts
- Adding type assertions for mock fetch calls in client.test.ts
- Adding vitest imports to returnUrlUtils.test.ts
- Adding spend property to Team mocks in roles.test.ts
- Adding missing topKeysLimit and setTopKeysLimit props to TopKeyView test
- Formatting autorouter_presets.test.ts with prettier