### PR TITLE
fix(vertex): send audio/webm for Gemini transcription of webm

### DIFF
--- a/litellm/llms/vertex_ai/audio_transcription/gemini_transcribe_transformation.py
+++ b/litellm/llms/vertex_ai/audio_transcription/gemini_transcribe_transformation.py
@@ -44,6 +44,7 @@ from litellm.types.utils import (
 
 DEFAULT_GEMINI_TRANSCRIBE_LOCATION: Final = "global"
 AUDIO_MODALITY: Final = "AUDIO"
+AMBIGUOUS_WEBM_MIME_TYPES: Final = frozenset({"application/webm", "application/x-webm", "video/webm", "video/x-webm"})
 
 
 class VertexGeminiAudioTranscriptionConfig(BaseAudioTranscriptionConfig, VertexBase):
@@ -151,6 +152,7 @@ class VertexGeminiAudioTranscriptionConfig(BaseAudioTranscriptionConfig, VertexB
         litellm_params: Mapping[str, object],
     ) -> AudioTranscriptionRequestData:
         processed_audio: Final = process_audio_file(audio_file)
+        mime_type: Final = _audio_transcription_mime_type(audio_file, processed_audio.content_type)
         request_body: Final = VertexGeminiTranscriptionRequest(
             contents=(
                 VertexGeminiTranscriptionContent(
@@ -158,7 +160,7 @@ class VertexGeminiAudioTranscriptionConfig(BaseAudioTranscriptionConfig, VertexB
                     parts=(
                         VertexGeminiTranscriptionPart(
                             inlineData=VertexGeminiTranscriptionInlineData(
-                                mimeType=processed_audio.content_type,
+                                mimeType=mime_type,
                                 data=base64.b64encode(processed_audio.file_content).decode("utf-8"),
                             )
                         ),
@@ -208,6 +210,16 @@ class VertexGeminiAudioTranscriptionConfig(BaseAudioTranscriptionConfig, VertexB
                 ),
             )
         return response
+
+
+def _audio_transcription_mime_type(audio_file: FileTypes, processed_content_type: str) -> str:
+    incoming_content_type: Final = audio_file[2] if isinstance(audio_file, tuple) and len(audio_file) >= 3 else None
+    if isinstance(incoming_content_type, str) and incoming_content_type.split(";", 1)[0].strip().lower().startswith(
+        "audio/"
+    ):
+        return incoming_content_type
+    processed_media_type: Final = processed_content_type.split(";", 1)[0].strip().lower()
+    return "audio/webm" if processed_media_type in AMBIGUOUS_WEBM_MIME_TYPES else processed_content_type
 
 
 def _audio_transcription_config(language: object) -> VertexGeminiTranscriptionAudioConfig:

--- a/tests/test_litellm/llms/vertex_ai/audio_transcription/test_vertex_ai_gemini_transcribe_transformation.py
+++ b/tests/test_litellm/llms/vertex_ai/audio_transcription/test_vertex_ai_gemini_transcribe_transformation.py
@@ -1,6 +1,7 @@
 import base64
 import json
 import os
+from unittest.mock import Mock
 
 import httpx
 import pytest
@@ -216,6 +217,30 @@ class TestTransformRequest:
         round_tripped = json.loads(json.dumps(request_data.data))
         assert round_tripped["generationConfig"] == {"audioTranscriptionConfig": {"languageCodes": ["en-US"]}}
         assert round_tripped["contents"][0]["role"] == "user"
+
+    def test_webm_audio_uses_audio_mime_type(self, config):
+        audio_file = Mock(spec=["name", "read", "seek"])
+        audio_file.name = "speech.webm"
+        audio_file.read.return_value = AUDIO_BYTES
+
+        request_data = config.transform_audio_transcription_request(
+            model="gemini-3.5-transcribe-preview",
+            audio_file=audio_file,
+            optional_params={},
+            litellm_params={},
+        )
+
+        assert request_data.data["contents"][0]["parts"][0]["inlineData"]["mimeType"] == "audio/webm"
+
+    def test_incoming_audio_mime_type_is_preserved(self, config):
+        request_data = config.transform_audio_transcription_request(
+            model="gemini-3.5-transcribe-preview",
+            audio_file=("speech.webm", AUDIO_BYTES, "audio/webm; codecs=opus"),
+            optional_params={},
+            litellm_params={},
+        )
+
+        assert request_data.data["contents"][0]["parts"][0]["inlineData"]["mimeType"] == "audio/webm; codecs=opus"
 
 
 class TestTransformResponse:


### PR DESCRIPTION
## TLDR

Problem this solves:

- Vertex Gemini treats `.webm` audio as video
- Transcription returns empty text and zero audio tokens

How it solves it:

- Sends ambiguous WebM containers as `audio/webm`
- Preserves explicit incoming `audio/*` content types

## User Flow

Before: a developer transcribing browser-recorded WebM audio gets an empty transcript

1. They send POST https://litellm-domain/v1/audio/transcriptions with a `.webm` audio file
2. The request returns 200 with empty text and zero audio tokens

After: the same WebM recording is sent with an audio MIME type and transcribes normally

1. They send POST https://litellm-domain/v1/audio/transcriptions with the same `.webm` audio file
2. The request returns 200 with transcript text and processed audio tokens

## Problem

Vertex Gemini audio transcription silently returns an empty transcript for audio-only WebM uploads

## Root cause

`process_audio_file()` resolves `.webm` through the global file map as `video/webm`. The Vertex Gemini transcription request passed that value directly to `inlineData.mimeType`, so Gemini treated the audio-only container as video

## Solution

Normalize ambiguous WebM MIME values to `audio/webm` inside the Vertex Gemini transcription request transformation. Keep explicit incoming `audio/*` values unchanged and leave the global `FILE_MIME_TYPES` map untouched

## Tests

- `make format`
- `make lint`
- `uv run --no-sync pytest tests/test_litellm/llms/vertex_ai/audio_transcription/test_vertex_ai_gemini_transcribe_transformation.py -v` (42 passed)

## Relevant issues

Closes #38963

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally
- [x] My PR passes all required local CI/CD checks
- [x] My PR scope is as isolated as possible
- [ ] I have received a Greptile Confidence Score of at least 4/5

## Type

🐛 Bug Fix

## Final Attestation

- [x] The tests check the right things, including the reported WebM regression