### PR TITLE
fix(router): resolve provider-prefixed model pricing in lowest-cost routing

### DIFF
--- a/litellm/router_strategy/lowest_cost.py
+++ b/litellm/router_strategy/lowest_cost.py
@@ -1,7 +1,7 @@
 #### What this does ####
 #   picks based on response time (for streaming, this is time to first token)
 from datetime import datetime, timedelta
-from typing import Final
+from typing import Final, Literal
 
 import litellm
 from litellm import ModelResponse, token_counter, verbose_logger
@@ -26,6 +26,14 @@ def _resolve_model_cost(model: str | None, custom_llm_provider: str | None) -> M
             e,
         )
         return None
+
+
+def _token_cost(
+    model_info: ModelInfo | None,
+    key: Literal["input_cost_per_token", "output_cost_per_token"],
+) -> float:
+    cost: Final = model_info.get(key) if model_info is not None else None
+    return cost if cost is not None else 5.0
 
 
 class LowestCostLoggingHandler(CustomLogger):
@@ -262,11 +270,11 @@ class LowestCostLoggingHandler(CustomLogger):
                 or _deployment.get("model_info", {}).get("rpm", None)
                 or float("inf")
             )
-            item_litellm_model_name: Final = _deployment.get("litellm_params", {}).get("model")
-            custom_llm_provider: Final = _deployment.get("litellm_params", {}).get("custom_llm_provider")
-            item_litellm_model_cost_map: Final = _resolve_model_cost(
-                model=item_litellm_model_name,
-                custom_llm_provider=custom_llm_provider,
+            (item_litellm_model_cost_map,) = (
+                _resolve_model_cost(
+                    model=_deployment.get("litellm_params", {}).get("model"),
+                    custom_llm_provider=_deployment.get("litellm_params", {}).get("custom_llm_provider"),
+                ),
             )
 
             # check if user provided input_cost_per_token and output_cost_per_token in litellm_params
@@ -279,17 +287,15 @@ class LowestCostLoggingHandler(CustomLogger):
                 item_output_cost = _deployment.get("litellm_params", {}).get("output_cost_per_token")
 
             if item_input_cost is None:
-                item_input_cost = (
-                    item_litellm_model_cost_map.get("input_cost_per_token", 5.0)
-                    if item_litellm_model_cost_map is not None
-                    else 5.0
+                item_input_cost = _token_cost(
+                    model_info=item_litellm_model_cost_map,
+                    key="input_cost_per_token",
                 )
 
             if item_output_cost is None:
-                item_output_cost = (
-                    item_litellm_model_cost_map.get("output_cost_per_token", 5.0)
-                    if item_litellm_model_cost_map is not None
-                    else 5.0
+                item_output_cost = _token_cost(
+                    model_info=item_litellm_model_cost_map,
+                    key="output_cost_per_token",
                 )
 
             # if litellm["model"] is not in model_cost map -> use item_cost = $10

--- a/litellm/router_strategy/lowest_cost.py
+++ b/litellm/router_strategy/lowest_cost.py
@@ -8,6 +8,24 @@ from litellm import ModelResponse, token_counter, verbose_logger
 from litellm._logging import verbose_router_logger
 from litellm.caching.caching import DualCache
 from litellm.integrations.custom_logger import CustomLogger
+from litellm.types.utils import ModelInfo
+
+
+def _resolve_model_cost(model: str | None, custom_llm_provider: str | None) -> ModelInfo | None:
+    if model is None:
+        return None
+    try:
+        return litellm.get_model_info(
+            model=model,
+            custom_llm_provider=custom_llm_provider,
+        )
+    except Exception as e:  # noqa: BLE001  # unavailable pricing uses the existing default cost
+        verbose_router_logger.debug(
+            "Failed to resolve model info for %s: %s",
+            model,
+            e,
+        )
+        return None
 
 
 class LowestCostLoggingHandler(CustomLogger):
@@ -244,29 +262,12 @@ class LowestCostLoggingHandler(CustomLogger):
                 or _deployment.get("model_info", {}).get("rpm", None)
                 or float("inf")
             )
-            item_litellm_model_name = _deployment.get("litellm_params", {}).get("model")
-            item_litellm_model_cost_map = litellm.model_cost.get(item_litellm_model_name, {})
-            if not item_litellm_model_cost_map and item_litellm_model_name:
-                try:
-                    custom_llm_provider = _deployment.get("litellm_params", {}).get(
-                        "custom_llm_provider"
-                    )
-                    _resolved_info = litellm.get_model_info(
-                        model=item_litellm_model_name,
-                        custom_llm_provider=custom_llm_provider,
-                    )
-                    item_litellm_model_cost_map = dict(_resolved_info)
-                    # Cache so subsequent routing calls skip get_model_info
-                    litellm.model_cost[item_litellm_model_name] = (
-                        item_litellm_model_cost_map
-                    )
-                except Exception as e:
-                    verbose_router_logger.debug(
-                        "Failed to resolve model info for %s: %s",
-                        item_litellm_model_name,
-                        e,
-                    )
-                    item_litellm_model_cost_map = {}
+            item_litellm_model_name: Final = _deployment.get("litellm_params", {}).get("model")
+            custom_llm_provider: Final = _deployment.get("litellm_params", {}).get("custom_llm_provider")
+            item_litellm_model_cost_map: Final = _resolve_model_cost(
+                model=item_litellm_model_name,
+                custom_llm_provider=custom_llm_provider,
+            )
 
             # check if user provided input_cost_per_token and output_cost_per_token in litellm_params
             item_input_cost = None
@@ -278,10 +279,18 @@ class LowestCostLoggingHandler(CustomLogger):
                 item_output_cost = _deployment.get("litellm_params", {}).get("output_cost_per_token")
 
             if item_input_cost is None:
-                item_input_cost = item_litellm_model_cost_map.get("input_cost_per_token", 5.0)
+                item_input_cost = (
+                    item_litellm_model_cost_map.get("input_cost_per_token", 5.0)
+                    if item_litellm_model_cost_map is not None
+                    else 5.0
+                )
 
             if item_output_cost is None:
-                item_output_cost = item_litellm_model_cost_map.get("output_cost_per_token", 5.0)
+                item_output_cost = (
+                    item_litellm_model_cost_map.get("output_cost_per_token", 5.0)
+                    if item_litellm_model_cost_map is not None
+                    else 5.0
+                )
 
             # if litellm["model"] is not in model_cost map -> use item_cost = $10
 

--- a/litellm/router_strategy/lowest_cost.py
+++ b/litellm/router_strategy/lowest_cost.py
@@ -246,6 +246,27 @@ class LowestCostLoggingHandler(CustomLogger):
             )
             item_litellm_model_name = _deployment.get("litellm_params", {}).get("model")
             item_litellm_model_cost_map = litellm.model_cost.get(item_litellm_model_name, {})
+            if not item_litellm_model_cost_map and item_litellm_model_name:
+                try:
+                    custom_llm_provider = _deployment.get("litellm_params", {}).get(
+                        "custom_llm_provider"
+                    )
+                    _resolved_info = litellm.get_model_info(
+                        model=item_litellm_model_name,
+                        custom_llm_provider=custom_llm_provider,
+                    )
+                    item_litellm_model_cost_map = dict(_resolved_info)
+                    # Cache so subsequent routing calls skip get_model_info
+                    litellm.model_cost[item_litellm_model_name] = (
+                        item_litellm_model_cost_map
+                    )
+                except Exception as e:
+                    verbose_router_logger.debug(
+                        "Failed to resolve model info for %s: %s",
+                        item_litellm_model_name,
+                        e,
+                    )
+                    item_litellm_model_cost_map = {}
 
             # check if user provided input_cost_per_token and output_cost_per_token in litellm_params
             item_input_cost = None

--- a/tests/test_litellm/router_strategy/test_lowest_cost_provider_prefix.py
+++ b/tests/test_litellm/router_strategy/test_lowest_cost_provider_prefix.py
@@ -64,6 +64,10 @@ async def test_lowest_cost_routing_keeps_provider_pricing_isolated(monkeypatch: 
         assert custom_llm_provider is not None
         cost: Final = 1.0 if custom_llm_provider == "expensive-provider" else 1e-07
         return {
+            "key": model,
+            "max_tokens": None,
+            "max_input_tokens": None,
+            "max_output_tokens": None,
             "input_cost_per_token": cost,
             "output_cost_per_token": cost,
             "litellm_provider": custom_llm_provider,

--- a/tests/test_litellm/router_strategy/test_lowest_cost_provider_prefix.py
+++ b/tests/test_litellm/router_strategy/test_lowest_cost_provider_prefix.py
@@ -135,11 +135,18 @@ async def test_lowest_cost_routing_uses_direct_match():
 
 
 @pytest.mark.asyncio
-async def test_lowest_cost_routing_fallback_for_unmapped_model():
+@pytest.mark.parametrize(
+    "litellm_params",
+    [
+        {"model": "custom-unknown-provider/unknown-model-xyz"},
+        {},
+    ],
+)
+async def test_lowest_cost_routing_fallback_for_unmapped_model(litellm_params: dict[str, str]):
     deployments = [
         {
             "model_name": "test-group-unmapped",
-            "litellm_params": {"model": "custom-unknown-provider/unknown-model-xyz"},
+            "litellm_params": litellm_params,
             "model_info": {"id": "unmapped-1"},
         },
     ]

--- a/tests/test_litellm/router_strategy/test_lowest_cost_provider_prefix.py
+++ b/tests/test_litellm/router_strategy/test_lowest_cost_provider_prefix.py
@@ -1,12 +1,15 @@
+from typing import Final
+
 import pytest
+
 import litellm
 from litellm.caching.caching import DualCache
 from litellm.router_strategy.lowest_cost import LowestCostLoggingHandler
+from litellm.types.utils import ModelInfo
 
 
 @pytest.fixture(autouse=True)
 def _cleanup_model_cost():
-    """Snapshot litellm.model_cost before each test and restore it afterwards."""
     keys_before = set(litellm.model_cost.keys())
     yield
     keys_after = set(litellm.model_cost.keys())
@@ -16,11 +19,6 @@ def _cleanup_model_cost():
 
 @pytest.mark.asyncio
 async def test_lowest_cost_routing_resolves_provider_prefixed_model():
-    """
-    When model_cost only has the bare model name (e.g. 'test-gpt-luna'),
-    the router should still resolve 'openai/test-gpt-luna' via get_model_info
-    fallback and pick the cheapest deployment.
-    """
     litellm.model_cost["test-gpt-luna"] = {
         "input_cost_per_token": 2e-07,
         "output_cost_per_token": 2e-07,
@@ -58,49 +56,55 @@ async def test_lowest_cost_routing_resolves_provider_prefixed_model():
 
 
 @pytest.mark.asyncio
-async def test_lowest_cost_routing_caches_resolved_model():
-    """
-    After the first routing call resolves a provider-prefixed model via
-    get_model_info, the result should be cached in litellm.model_cost
-    so subsequent calls do not re-invoke get_model_info.
-    """
-    litellm.model_cost["test-gpt-cached"] = {
-        "input_cost_per_token": 1e-07,
-        "output_cost_per_token": 1e-07,
-        "litellm_provider": "openai",
-        "mode": "chat",
-    }
+async def test_lowest_cost_routing_keeps_provider_pricing_isolated(monkeypatch: pytest.MonkeyPatch):
+    shared_model: Final = "shared-provider-model"
+
+    def provider_model_info(model: str, custom_llm_provider: str | None = None) -> ModelInfo:
+        assert model == shared_model
+        assert custom_llm_provider is not None
+        cost: Final = 1.0 if custom_llm_provider == "expensive-provider" else 1e-07
+        return {
+            "input_cost_per_token": cost,
+            "output_cost_per_token": cost,
+            "litellm_provider": custom_llm_provider,
+            "mode": "chat",
+            "supported_openai_params": None,
+        }
+
+    monkeypatch.setattr(litellm, "get_model_info", provider_model_info)
 
     deployments = [
         {
-            "model_name": "test-cache-group",
-            "litellm_params": {"model": "openai/test-gpt-cached"},
-            "model_info": {"id": "cached-1"},
+            "model_name": "test-provider-group",
+            "litellm_params": {
+                "model": shared_model,
+                "custom_llm_provider": "expensive-provider",
+            },
+            "model_info": {"id": "expensive"},
+        },
+        {
+            "model_name": "test-provider-group",
+            "litellm_params": {
+                "model": shared_model,
+                "custom_llm_provider": "cheap-provider",
+            },
+            "model_info": {"id": "cheap"},
         },
     ]
 
     handler = LowestCostLoggingHandler(router_cache=DualCache())
-
-    # Before routing, the prefixed key should not exist in model_cost
-    assert "openai/test-gpt-cached" not in litellm.model_cost
-
-    await handler.async_get_available_deployments(
-        model_group="test-cache-group",
+    selected = await handler.async_get_available_deployments(
+        model_group="test-provider-group",
         healthy_deployments=deployments,
     )
 
-    # After routing, the prefixed key should now be cached in model_cost
-    assert "openai/test-gpt-cached" in litellm.model_cost
-    cached = litellm.model_cost["openai/test-gpt-cached"]
-    assert cached["input_cost_per_token"] == 1e-07
+    assert selected is not None
+    assert selected["model_info"]["id"] == "cheap"
+    assert shared_model not in litellm.model_cost
 
 
 @pytest.mark.asyncio
-async def test_lowest_cost_routing_direct_match_no_fallback():
-    """
-    When the full model name (including provider prefix) already exists
-    in model_cost, routing should use it directly without needing fallback.
-    """
+async def test_lowest_cost_routing_uses_direct_match():
     litellm.model_cost["openai/test-direct-match"] = {
         "input_cost_per_token": 1e-07,
         "output_cost_per_token": 1e-07,
@@ -128,10 +132,6 @@ async def test_lowest_cost_routing_direct_match_no_fallback():
 
 @pytest.mark.asyncio
 async def test_lowest_cost_routing_fallback_for_unmapped_model():
-    """
-    When a model cannot be resolved in model_cost or get_model_info,
-    it should gracefully fall back to default 5.0 cost without crashing.
-    """
     deployments = [
         {
             "model_name": "test-group-unmapped",
@@ -152,10 +152,6 @@ async def test_lowest_cost_routing_fallback_for_unmapped_model():
 
 @pytest.mark.asyncio
 async def test_lowest_cost_routing_explicit_params_override():
-    """
-    Explicit input_cost_per_token and output_cost_per_token in litellm_params
-    should override whatever is in model_cost.
-    """
     litellm.model_cost["test-expensive-base"] = {
         "input_cost_per_token": 1.0,
         "output_cost_per_token": 1.0,

--- a/tests/test_litellm/router_strategy/test_lowest_cost_provider_prefix.py
+++ b/tests/test_litellm/router_strategy/test_lowest_cost_provider_prefix.py
@@ -1,0 +1,185 @@
+import pytest
+import litellm
+from litellm.caching.caching import DualCache
+from litellm.router_strategy.lowest_cost import LowestCostLoggingHandler
+
+
+@pytest.fixture(autouse=True)
+def _cleanup_model_cost():
+    """Snapshot litellm.model_cost before each test and restore it afterwards."""
+    keys_before = set(litellm.model_cost.keys())
+    yield
+    keys_after = set(litellm.model_cost.keys())
+    for key in keys_after - keys_before:
+        del litellm.model_cost[key]
+
+
+@pytest.mark.asyncio
+async def test_lowest_cost_routing_resolves_provider_prefixed_model():
+    """
+    When model_cost only has the bare model name (e.g. 'test-gpt-luna'),
+    the router should still resolve 'openai/test-gpt-luna' via get_model_info
+    fallback and pick the cheapest deployment.
+    """
+    litellm.model_cost["test-gpt-luna"] = {
+        "input_cost_per_token": 2e-07,
+        "output_cost_per_token": 2e-07,
+        "litellm_provider": "openai",
+        "mode": "chat",
+    }
+    litellm.model_cost["test-gpt-sol"] = {
+        "input_cost_per_token": 5e-06,
+        "output_cost_per_token": 5e-06,
+        "litellm_provider": "openai",
+        "mode": "chat",
+    }
+
+    deployments = [
+        {
+            "model_name": "test-group",
+            "litellm_params": {"model": "openai/test-gpt-sol"},
+            "model_info": {"id": "sol"},
+        },
+        {
+            "model_name": "test-group",
+            "litellm_params": {"model": "openai/test-gpt-luna"},
+            "model_info": {"id": "luna"},
+        },
+    ]
+
+    handler = LowestCostLoggingHandler(router_cache=DualCache())
+    selected = await handler.async_get_available_deployments(
+        model_group="test-group",
+        healthy_deployments=deployments,
+    )
+
+    assert selected is not None
+    assert selected["model_info"]["id"] == "luna"
+
+
+@pytest.mark.asyncio
+async def test_lowest_cost_routing_caches_resolved_model():
+    """
+    After the first routing call resolves a provider-prefixed model via
+    get_model_info, the result should be cached in litellm.model_cost
+    so subsequent calls do not re-invoke get_model_info.
+    """
+    litellm.model_cost["test-gpt-cached"] = {
+        "input_cost_per_token": 1e-07,
+        "output_cost_per_token": 1e-07,
+        "litellm_provider": "openai",
+        "mode": "chat",
+    }
+
+    deployments = [
+        {
+            "model_name": "test-cache-group",
+            "litellm_params": {"model": "openai/test-gpt-cached"},
+            "model_info": {"id": "cached-1"},
+        },
+    ]
+
+    handler = LowestCostLoggingHandler(router_cache=DualCache())
+
+    # Before routing, the prefixed key should not exist in model_cost
+    assert "openai/test-gpt-cached" not in litellm.model_cost
+
+    await handler.async_get_available_deployments(
+        model_group="test-cache-group",
+        healthy_deployments=deployments,
+    )
+
+    # After routing, the prefixed key should now be cached in model_cost
+    assert "openai/test-gpt-cached" in litellm.model_cost
+    cached = litellm.model_cost["openai/test-gpt-cached"]
+    assert cached["input_cost_per_token"] == 1e-07
+
+
+@pytest.mark.asyncio
+async def test_lowest_cost_routing_direct_match_no_fallback():
+    """
+    When the full model name (including provider prefix) already exists
+    in model_cost, routing should use it directly without needing fallback.
+    """
+    litellm.model_cost["openai/test-direct-match"] = {
+        "input_cost_per_token": 1e-07,
+        "output_cost_per_token": 1e-07,
+        "litellm_provider": "openai",
+        "mode": "chat",
+    }
+
+    deployments = [
+        {
+            "model_name": "test-direct",
+            "litellm_params": {"model": "openai/test-direct-match"},
+            "model_info": {"id": "direct-1"},
+        },
+    ]
+
+    handler = LowestCostLoggingHandler(router_cache=DualCache())
+    selected = await handler.async_get_available_deployments(
+        model_group="test-direct",
+        healthy_deployments=deployments,
+    )
+
+    assert selected is not None
+    assert selected["model_info"]["id"] == "direct-1"
+
+
+@pytest.mark.asyncio
+async def test_lowest_cost_routing_fallback_for_unmapped_model():
+    """
+    When a model cannot be resolved in model_cost or get_model_info,
+    it should gracefully fall back to default 5.0 cost without crashing.
+    """
+    deployments = [
+        {
+            "model_name": "test-group-unmapped",
+            "litellm_params": {"model": "custom-unknown-provider/unknown-model-xyz"},
+            "model_info": {"id": "unmapped-1"},
+        },
+    ]
+
+    handler = LowestCostLoggingHandler(router_cache=DualCache())
+    selected = await handler.async_get_available_deployments(
+        model_group="test-group-unmapped",
+        healthy_deployments=deployments,
+    )
+
+    assert selected is not None
+    assert selected["model_info"]["id"] == "unmapped-1"
+
+
+@pytest.mark.asyncio
+async def test_lowest_cost_routing_explicit_params_override():
+    """
+    Explicit input_cost_per_token and output_cost_per_token in litellm_params
+    should override whatever is in model_cost.
+    """
+    litellm.model_cost["test-expensive-base"] = {
+        "input_cost_per_token": 1.0,
+        "output_cost_per_token": 1.0,
+        "litellm_provider": "openai",
+        "mode": "chat",
+    }
+
+    deployments = [
+        {
+            "model_name": "test-override",
+            "litellm_params": {
+                "model": "openai/test-expensive-base",
+                "input_cost_per_token": 1e-08,
+                "output_cost_per_token": 1e-08,
+            },
+            "model_info": {"id": "discounted-deployment"},
+        },
+    ]
+
+    handler = LowestCostLoggingHandler(router_cache=DualCache())
+    selected = await handler.async_get_available_deployments(
+        model_group="test-override",
+        healthy_deployments=deployments,
+    )
+
+    assert selected is not None
+    assert selected["model_info"]["id"] == "discounted-deployment"


### PR DESCRIPTION
## TLDR

Problem this solves:

- Provider-prefixed models lose known pricing
- Shared names can cross provider boundaries

How it solves it:

- Resolve pricing with model and provider identity
- Reuse the provider-aware model-info cache
- Keep process-global pricing data unchanged

## User Flow

Before: a developer enables lowest-cost routing, but a costlier deployment can win

1. They configure `openai/gpt-5.6-sol` before `openai/gpt-5.6-luna`
2. They route a request through the shared model group
3. The router treats both prefixed names as unknown and selects `sol`

After: the same configuration selects the deployment with lower known pricing

1. They configure `openai/gpt-5.6-sol` before `openai/gpt-5.6-luna`
2. They route a request through the shared model group
3. The router resolves provider-aware pricing and selects `luna`

## Relevant issues

Fixes #35787

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The focused test file passes locally
- [x] My PR passes all required CI/CD checks
- [x] My PR only solves this routing-pricing bug
- [x] Greptile has reviewed the latest commit at 4/5 or higher

## Delays in PR merge?

If review is delayed, I will follow the repository review process

## Screenshots / Proof of Fix

Shared setup: run the issue reproduction with `sol` listed before the cheaper `luna` deployment

### Before (ec3f8183c3)

1. Checked out the merge-base revision
2. Ran the issue reproduction
3. Observed `selected=sol`

### After (a7c0b53aed)

1. Checked out the PR revision
2. Ran the same issue reproduction
3. Observed `selected=luna`

## Type

🐛 Bug Fix

## Caveats (if any)

## Final Attestation

- [x] The regression tests cover provider prefixes, provider isolation, explicit prices, direct matches, and unknown models


