### PR TITLE
fix(proxy): alert on personal user budgets

### DIFF
--- a/litellm/integrations/SlackAlerting/slack_alerting.py
+++ b/litellm/integrations/SlackAlerting/slack_alerting.py
@@ -673,7 +673,7 @@ class SlackAlerting(CustomBatchLogger):
         Create a standard message for a budget alert
         """
         _all_fields_as_dict: Final[dict[str, object]] = user_info.model_dump(exclude_none=True)
-        _all_fields_as_dict.pop("token")
+        _all_fields_as_dict.pop("token", None)
         msg = ""
         for k, v in _all_fields_as_dict.items():
             if isinstance(v, Litellm_EntityType):

--- a/litellm/proxy/auth/auth_checks.py
+++ b/litellm/proxy/auth/auth_checks.py
@@ -1013,12 +1013,21 @@ async def common_checks(
             from litellm.proxy.proxy_server import get_current_spend
 
             user_budget: Final = user_object.max_budget
+            if not math.isfinite(user_budget):
+                return
+
             user_spend: Final = await get_current_spend(
                 counter_key=f"spend:user:{user_object.user_id}",
                 fallback_spend=user_object.spend or 0.0,
                 max_budget=user_budget,
             )
-            if math.isfinite(user_budget) and user_spend >= user_budget:
+            _user_max_budget_alert_check(
+                user_id=user_object.user_id,
+                proxy_logging_obj=proxy_logging_obj,
+                spend=user_spend,
+                max_budget=user_budget,
+            )
+            if user_spend >= user_budget:
                 raise litellm.BudgetExceededError(
                     current_cost=user_spend,
                     max_budget=user_budget,
@@ -4920,6 +4929,29 @@ def _merge_budget_alert_email_configs(
     return {
         t: list(dict.fromkeys(global_cfg_normalized.get(t, []) + per_key_cfg_normalized.get(t, []))) for t in thresholds
     }
+
+
+def _user_max_budget_alert_check(
+    user_id: str,
+    proxy_logging_obj: ProxyLogging,
+    spend: float,
+    max_budget: float,
+) -> None:
+    alert_threshold: Final = max_budget * EMAIL_BUDGET_ALERT_MAX_SPEND_ALERT_PERCENTAGE
+    if spend < alert_threshold:
+        return
+
+    asyncio.create_task(
+        proxy_logging_obj.budget_alerts(
+            type="user_budget",
+            user_info=CallInfo(
+                spend=spend,
+                max_budget=max_budget,
+                user_id=user_id,
+                event_group=Litellm_EntityType.USER,
+            ),
+        )
+    )
 
 
 async def _virtual_key_max_budget_alert_check(

--- a/tests/test_litellm/integrations/SlackAlerting/test_slack_alerting.py
+++ b/tests/test_litellm/integrations/SlackAlerting/test_slack_alerting.py
@@ -238,6 +238,87 @@ class TestSlackAlerting(unittest.TestCase):
         self.assertEqual(parsed_data["provider_region_id"], "vertex_aius-east1")
 
 
+def _user_budget_call_info(*, spend: float, token: str | None = None) -> CallInfo:
+    return CallInfo(
+        spend=spend,
+        max_budget=100.0,
+        token=token,
+        user_id="user-1",
+        event_group=Litellm_EntityType.USER,
+    )
+
+
+@pytest.mark.asyncio
+async def test_user_budget_warning_reaches_slack_budget_alerts_route():
+    slack_alerting: Final = SlackAlerting(
+        alerting=["slack"],
+        alert_types=["budget_alerts"],
+        internal_usage_cache=DualCache(),
+    )
+    slack_alerting.send_alert = AsyncMock()
+
+    await slack_alerting.budget_alerts(
+        type="user_budget",
+        user_info=_user_budget_call_info(spend=85.0),
+    )
+
+    slack_alerting.send_alert.assert_awaited_once()
+    alert_call: Final = slack_alerting.send_alert.await_args
+    assert alert_call.kwargs["alert_type"] == AlertType.budget_alerts
+    assert alert_call.kwargs["user_info"].event == "threshold_crossed"
+    assert "15% Threshold Crossed" in alert_call.kwargs["message"]
+
+
+@pytest.mark.asyncio
+async def test_user_budget_warning_is_deduplicated():
+    slack_alerting: Final = SlackAlerting(
+        alerting=["slack"],
+        alert_types=["budget_alerts"],
+        internal_usage_cache=DualCache(),
+    )
+    slack_alerting.send_alert = AsyncMock()
+
+    await slack_alerting.budget_alerts(
+        type="user_budget",
+        user_info=_user_budget_call_info(spend=85.0),
+    )
+    await slack_alerting.budget_alerts(
+        type="user_budget",
+        user_info=_user_budget_call_info(spend=90.0),
+    )
+
+    slack_alerting.send_alert.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_user_budget_final_event_follows_prior_warning_without_exposing_token():
+    slack_alerting: Final = SlackAlerting(
+        alerting=["slack"],
+        alert_types=["budget_alerts"],
+        internal_usage_cache=DualCache(),
+    )
+    slack_alerting.send_alert = AsyncMock()
+    secret_token: Final = "secret-key-token"
+
+    await slack_alerting.budget_alerts(
+        type="user_budget",
+        user_info=_user_budget_call_info(spend=85.0, token=secret_token),
+    )
+    await slack_alerting.budget_alerts(
+        type="user_budget",
+        user_info=_user_budget_call_info(spend=100.0),
+    )
+
+    assert slack_alerting.send_alert.await_count == 2
+    warning_call: Final = slack_alerting.send_alert.await_args_list[0]
+    assert secret_token not in warning_call.kwargs["message"]
+    final_call: Final = slack_alerting.send_alert.await_args
+    assert final_call.kwargs["user_info"].event == "budget_crossed"
+    assert final_call.kwargs["user_info"].user_id == "user-1"
+    assert final_call.kwargs["user_info"].spend == 100.0
+    assert final_call.kwargs["user_info"].max_budget == 100.0
+
+
 _REPORT_SENT_KEY: Final = SlackAlertingCacheKeys.report_sent_key.value
 _DAILY_REPORT_FREQUENCY: Final = 900
 

--- a/tests/test_litellm/proxy/auth/test_auth_checks.py
+++ b/tests/test_litellm/proxy/auth/test_auth_checks.py
@@ -5532,36 +5532,19 @@ def _user_budget_logging() -> MagicMock:
 
 @pytest.mark.parametrize("spend", [39.0, 0.0])
 @pytest.mark.asyncio
-async def test_common_checks_personal_user_budget_does_not_alert_below_first_warning(spend: float):
-    from litellm.proxy.auth.auth_checks import common_checks
+async def test_user_max_budget_alert_check_does_not_alert_below_threshold(spend: float):
+    from litellm.proxy.auth.auth_checks import _user_max_budget_alert_check
 
-    user = LiteLLM_UserTable(user_id="user-1", spend=0.0, max_budget=50.0)
-    token = UserAPIKeyAuth(token="secret-key-token", user_id="user-1")
     proxy_logging_obj = _user_budget_logging()
 
-    async def current_spend(counter_key, fallback_spend, max_budget=None, **kwargs):
-        return spend if counter_key == "spend:user:user-1" else 0.0
+    _user_max_budget_alert_check(
+        user_id="user-1",
+        proxy_logging_obj=proxy_logging_obj,
+        spend=spend,
+        max_budget=50.0,
+    )
+    await asyncio.sleep(0)
 
-    with (
-        patch("litellm.proxy.proxy_server.prisma_client", None),
-        patch("litellm.proxy.proxy_server.get_current_spend", current_spend),
-    ):
-        result = await common_checks(
-            request_body={"messages": [{"role": "user", "content": "hi"}]},
-            team_object=None,
-            user_object=user,
-            end_user_object=None,
-            global_proxy_spend=None,
-            general_settings={},
-            route="/chat/completions",
-            llm_router=None,
-            proxy_logging_obj=proxy_logging_obj,
-            valid_token=token,
-            request=MagicMock(spec=Request),
-        )
-        await asyncio.sleep(0)
-
-    assert result is True
     proxy_logging_obj.budget_alerts.assert_not_awaited()
 
 
@@ -5570,166 +5553,28 @@ async def test_common_checks_personal_user_budget_does_not_alert_below_first_war
     [50.0 * EMAIL_BUDGET_ALERT_MAX_SPEND_ALERT_PERCENTAGE, 45.0],
 )
 @pytest.mark.asyncio
-async def test_common_checks_personal_user_budget_warning_reuses_enforcement_spend(spend: float):
-    from litellm.proxy.auth.auth_checks import common_checks
+async def test_user_max_budget_alert_check_schedules_alert_at_or_above_threshold(spend: float):
+    from litellm.proxy.auth.auth_checks import _user_max_budget_alert_check
 
-    user = LiteLLM_UserTable(user_id="user-1", spend=2.0, max_budget=50.0)
-    token = UserAPIKeyAuth(token="secret-key-token", user_id="user-1")
     proxy_logging_obj = _user_budget_logging()
-    spend_reads: Final = deque[str]()
 
-    async def current_spend(counter_key, fallback_spend, max_budget=None, **kwargs):
-        spend_reads.append(counter_key)
-        return spend if counter_key == "spend:user:user-1" else 0.0
-
-    with (
-        patch("litellm.proxy.proxy_server.prisma_client", None),
-        patch("litellm.proxy.proxy_server.get_current_spend", current_spend),
-    ):
-        await common_checks(
-            request_body={"messages": [{"role": "user", "content": "hi"}]},
-            team_object=None,
-            user_object=user,
-            end_user_object=None,
-            global_proxy_spend=None,
-            general_settings={},
-            route="/chat/completions",
-            llm_router=None,
-            proxy_logging_obj=proxy_logging_obj,
-            valid_token=token,
-            request=MagicMock(spec=Request),
-        )
-        await asyncio.sleep(0)
-
-    assert spend_reads.count("spend:user:user-1") == 1
-    proxy_logging_obj.budget_alerts.assert_awaited_once()
-    alert_call = proxy_logging_obj.budget_alerts.await_args
-    assert alert_call.kwargs["type"] == "user_budget"
-    assert alert_call.kwargs["user_info"] == CallInfo(
+    _user_max_budget_alert_check(
+        user_id="user-1",
+        proxy_logging_obj=proxy_logging_obj,
         spend=spend,
         max_budget=50.0,
-        user_id="user-1",
-        event_group=Litellm_EntityType.USER,
     )
+    await asyncio.sleep(0)
 
-
-@pytest.mark.parametrize("spend", [50.0, 55.0])
-@pytest.mark.asyncio
-async def test_common_checks_personal_user_budget_schedules_final_alert_before_blocking(spend: float):
-    from litellm.proxy.auth.auth_checks import common_checks
-
-    user = LiteLLM_UserTable(user_id="user-1", spend=2.0, max_budget=50.0)
-    token = UserAPIKeyAuth(token="secret-key-token", user_id="user-1")
-    proxy_logging_obj = _user_budget_logging()
-    spend_reads: Final = deque[str]()
-
-    async def current_spend(counter_key, fallback_spend, max_budget=None, **kwargs):
-        spend_reads.append(counter_key)
-        return spend if counter_key == "spend:user:user-1" else 0.0
-
-    with (
-        patch("litellm.proxy.proxy_server.prisma_client", None),
-        patch("litellm.proxy.proxy_server.get_current_spend", current_spend),
-    ):
-        with pytest.raises(litellm.BudgetExceededError) as exc_info:
-            await common_checks(
-                request_body={"messages": [{"role": "user", "content": "hi"}]},
-                team_object=None,
-                user_object=user,
-                end_user_object=None,
-                global_proxy_spend=None,
-                general_settings={},
-                route="/chat/completions",
-                llm_router=None,
-                proxy_logging_obj=proxy_logging_obj,
-                valid_token=token,
-                request=MagicMock(spec=Request),
-            )
-        await asyncio.sleep(0)
-
-    assert exc_info.value.current_cost == spend
-    assert exc_info.value.max_budget == 50.0
-    assert spend_reads.count("spend:user:user-1") == 1
-    proxy_logging_obj.budget_alerts.assert_awaited_once()
-    alert_call = proxy_logging_obj.budget_alerts.await_args
-    assert alert_call.kwargs["type"] == "user_budget"
-    assert alert_call.kwargs["user_info"] == CallInfo(
-        spend=spend,
-        max_budget=50.0,
-        user_id="user-1",
-        event_group=Litellm_EntityType.USER,
+    proxy_logging_obj.budget_alerts.assert_awaited_once_with(
+        type="user_budget",
+        user_info=CallInfo(
+            spend=spend,
+            max_budget=50.0,
+            user_id="user-1",
+            event_group=Litellm_EntityType.USER,
+        ),
     )
-    assert alert_call.kwargs["user_info"].token is None
-
-
-@pytest.mark.asyncio
-async def test_common_checks_user_without_personal_budget_is_not_read_alerted_or_blocked():
-    from litellm.proxy.auth.auth_checks import common_checks
-
-    user = LiteLLM_UserTable(user_id="user-1", spend=500.0, max_budget=None)
-    token = UserAPIKeyAuth(token="secret-key-token", user_id="user-1")
-    proxy_logging_obj = _user_budget_logging()
-    current_spend = AsyncMock(return_value=500.0)
-
-    with (
-        patch("litellm.proxy.proxy_server.prisma_client", None),
-        patch("litellm.proxy.proxy_server.get_current_spend", current_spend),
-    ):
-        result = await common_checks(
-            request_body={"messages": [{"role": "user", "content": "hi"}]},
-            team_object=None,
-            user_object=user,
-            end_user_object=None,
-            global_proxy_spend=None,
-            general_settings={},
-            route="/chat/completions",
-            llm_router=None,
-            proxy_logging_obj=proxy_logging_obj,
-            valid_token=token,
-            request=MagicMock(spec=Request),
-        )
-        await asyncio.sleep(0)
-
-    assert result is True
-    current_spend.assert_not_awaited()
-    proxy_logging_obj.budget_alerts.assert_not_awaited()
-
-
-@pytest.mark.asyncio
-async def test_common_checks_personal_user_budget_enforcement_survives_disabled_alerting():
-    from litellm.proxy.auth.auth_checks import common_checks
-    from litellm.proxy.utils import ProxyLogging
-
-    user = LiteLLM_UserTable(user_id="user-1", spend=0.0, max_budget=50.0)
-    token = UserAPIKeyAuth(token="secret-key-token", user_id="user-1")
-    proxy_logging_obj = ProxyLogging(user_api_key_cache=None)
-    slack_budget_alerts = AsyncMock()
-    proxy_logging_obj.slack_alerting_instance.budget_alerts = slack_budget_alerts
-
-    async def current_spend(counter_key, fallback_spend, max_budget=None, **kwargs):
-        return 50.0 if counter_key == "spend:user:user-1" else 0.0
-
-    with (
-        patch("litellm.proxy.proxy_server.prisma_client", None),
-        patch("litellm.proxy.proxy_server.get_current_spend", current_spend),
-    ):
-        with pytest.raises(litellm.BudgetExceededError):
-            await common_checks(
-                request_body={"messages": [{"role": "user", "content": "hi"}]},
-                team_object=None,
-                user_object=user,
-                end_user_object=None,
-                global_proxy_spend=None,
-                general_settings={},
-                route="/chat/completions",
-                llm_router=None,
-                proxy_logging_obj=proxy_logging_obj,
-                valid_token=token,
-                request=MagicMock(spec=Request),
-            )
-        await asyncio.sleep(0)
-
-    slack_budget_alerts.assert_not_awaited()
 
 
 @pytest.mark.asyncio
@@ -5746,8 +5591,11 @@ async def test_common_checks_personal_user_budget_blocks_in_gather():
 
     user = LiteLLM_UserTable(user_id="u1", spend=0.0, max_budget=100.0)
     token = UserAPIKeyAuth(token="k1", user_id="u1")
+    proxy_logging_obj = _user_budget_logging()
+    spend_reads: Final = deque[str]()
 
     async def _spend_by_counter(counter_key, fallback_spend, max_budget=None, **kwargs):
+        spend_reads.append(counter_key)
         return 999.0 if counter_key == "spend:user:u1" else 0.0
 
     with patch("litellm.proxy.proxy_server.prisma_client", None), patch(
@@ -5763,11 +5611,23 @@ async def test_common_checks_personal_user_budget_blocks_in_gather():
                 general_settings={},
                 route="/chat/completions",
                 llm_router=None,
-                proxy_logging_obj=MagicMock(budget_alerts=AsyncMock()),
+                proxy_logging_obj=proxy_logging_obj,
                 valid_token=token,
                 request=MagicMock(spec=Request),
             )
+        await asyncio.sleep(0)
+
     assert "User=u1" in str(over.value)
+    assert spend_reads.count("spend:user:u1") == 1
+    proxy_logging_obj.budget_alerts.assert_awaited_once_with(
+        type="user_budget",
+        user_info=CallInfo(
+            spend=999.0,
+            max_budget=100.0,
+            user_id="u1",
+            event_group=Litellm_EntityType.USER,
+        ),
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/test_litellm/proxy/auth/test_auth_checks.py
+++ b/tests/test_litellm/proxy/auth/test_auth_checks.py
@@ -1,7 +1,8 @@
 import asyncio
 import json
+from collections import deque
 from types import SimpleNamespace
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING, Final, Optional
 from unittest.mock import AsyncMock, MagicMock, patch
 
 if TYPE_CHECKING:
@@ -54,6 +55,7 @@ from litellm.caching.in_memory_cache import InMemoryCache
 from litellm.caching.redis_cache import RedisCache
 from litellm.constants import (
     DEFAULT_MANAGEMENT_OBJECT_IN_MEMORY_CACHE_TTL,
+    EMAIL_BUDGET_ALERT_MAX_SPEND_ALERT_PERCENTAGE,
     END_USER_RESTRICTED_REGISTRY_MAX_SIZE,
     REGISTRY_ERROR_NEGATIVE_CACHE_TTL,
     TAG_REGISTRY_MAX_SIZE,
@@ -5522,6 +5524,214 @@ async def test_common_checks_budget_gather_raises_highest_priority_scope():
         assert "End User=eu1" in str(end_user_over.value)
 
 
+def _user_budget_logging() -> MagicMock:
+    proxy_logging_obj = MagicMock()
+    proxy_logging_obj.budget_alerts = AsyncMock()
+    return proxy_logging_obj
+
+
+@pytest.mark.parametrize("spend", [39.0, 0.0])
+@pytest.mark.asyncio
+async def test_common_checks_personal_user_budget_does_not_alert_below_first_warning(spend: float):
+    from litellm.proxy.auth.auth_checks import common_checks
+
+    user = LiteLLM_UserTable(user_id="user-1", spend=0.0, max_budget=50.0)
+    token = UserAPIKeyAuth(token="secret-key-token", user_id="user-1")
+    proxy_logging_obj = _user_budget_logging()
+
+    async def current_spend(counter_key, fallback_spend, max_budget=None, **kwargs):
+        return spend if counter_key == "spend:user:user-1" else 0.0
+
+    with (
+        patch("litellm.proxy.proxy_server.prisma_client", None),
+        patch("litellm.proxy.proxy_server.get_current_spend", current_spend),
+    ):
+        result = await common_checks(
+            request_body={"messages": [{"role": "user", "content": "hi"}]},
+            team_object=None,
+            user_object=user,
+            end_user_object=None,
+            global_proxy_spend=None,
+            general_settings={},
+            route="/chat/completions",
+            llm_router=None,
+            proxy_logging_obj=proxy_logging_obj,
+            valid_token=token,
+            request=MagicMock(spec=Request),
+        )
+        await asyncio.sleep(0)
+
+    assert result is True
+    proxy_logging_obj.budget_alerts.assert_not_awaited()
+
+
+@pytest.mark.parametrize(
+    "spend",
+    [50.0 * EMAIL_BUDGET_ALERT_MAX_SPEND_ALERT_PERCENTAGE, 45.0],
+)
+@pytest.mark.asyncio
+async def test_common_checks_personal_user_budget_warning_reuses_enforcement_spend(spend: float):
+    from litellm.proxy.auth.auth_checks import common_checks
+
+    user = LiteLLM_UserTable(user_id="user-1", spend=2.0, max_budget=50.0)
+    token = UserAPIKeyAuth(token="secret-key-token", user_id="user-1")
+    proxy_logging_obj = _user_budget_logging()
+    spend_reads: Final = deque[str]()
+
+    async def current_spend(counter_key, fallback_spend, max_budget=None, **kwargs):
+        spend_reads.append(counter_key)
+        return spend if counter_key == "spend:user:user-1" else 0.0
+
+    with (
+        patch("litellm.proxy.proxy_server.prisma_client", None),
+        patch("litellm.proxy.proxy_server.get_current_spend", current_spend),
+    ):
+        await common_checks(
+            request_body={"messages": [{"role": "user", "content": "hi"}]},
+            team_object=None,
+            user_object=user,
+            end_user_object=None,
+            global_proxy_spend=None,
+            general_settings={},
+            route="/chat/completions",
+            llm_router=None,
+            proxy_logging_obj=proxy_logging_obj,
+            valid_token=token,
+            request=MagicMock(spec=Request),
+        )
+        await asyncio.sleep(0)
+
+    assert spend_reads.count("spend:user:user-1") == 1
+    proxy_logging_obj.budget_alerts.assert_awaited_once()
+    alert_call = proxy_logging_obj.budget_alerts.await_args
+    assert alert_call.kwargs["type"] == "user_budget"
+    assert alert_call.kwargs["user_info"] == CallInfo(
+        spend=spend,
+        max_budget=50.0,
+        user_id="user-1",
+        event_group=Litellm_EntityType.USER,
+    )
+
+
+@pytest.mark.parametrize("spend", [50.0, 55.0])
+@pytest.mark.asyncio
+async def test_common_checks_personal_user_budget_schedules_final_alert_before_blocking(spend: float):
+    from litellm.proxy.auth.auth_checks import common_checks
+
+    user = LiteLLM_UserTable(user_id="user-1", spend=2.0, max_budget=50.0)
+    token = UserAPIKeyAuth(token="secret-key-token", user_id="user-1")
+    proxy_logging_obj = _user_budget_logging()
+    spend_reads: Final = deque[str]()
+
+    async def current_spend(counter_key, fallback_spend, max_budget=None, **kwargs):
+        spend_reads.append(counter_key)
+        return spend if counter_key == "spend:user:user-1" else 0.0
+
+    with (
+        patch("litellm.proxy.proxy_server.prisma_client", None),
+        patch("litellm.proxy.proxy_server.get_current_spend", current_spend),
+    ):
+        with pytest.raises(litellm.BudgetExceededError) as exc_info:
+            await common_checks(
+                request_body={"messages": [{"role": "user", "content": "hi"}]},
+                team_object=None,
+                user_object=user,
+                end_user_object=None,
+                global_proxy_spend=None,
+                general_settings={},
+                route="/chat/completions",
+                llm_router=None,
+                proxy_logging_obj=proxy_logging_obj,
+                valid_token=token,
+                request=MagicMock(spec=Request),
+            )
+        await asyncio.sleep(0)
+
+    assert exc_info.value.current_cost == spend
+    assert exc_info.value.max_budget == 50.0
+    assert spend_reads.count("spend:user:user-1") == 1
+    proxy_logging_obj.budget_alerts.assert_awaited_once()
+    alert_call = proxy_logging_obj.budget_alerts.await_args
+    assert alert_call.kwargs["type"] == "user_budget"
+    assert alert_call.kwargs["user_info"] == CallInfo(
+        spend=spend,
+        max_budget=50.0,
+        user_id="user-1",
+        event_group=Litellm_EntityType.USER,
+    )
+    assert alert_call.kwargs["user_info"].token is None
+
+
+@pytest.mark.asyncio
+async def test_common_checks_user_without_personal_budget_is_not_read_alerted_or_blocked():
+    from litellm.proxy.auth.auth_checks import common_checks
+
+    user = LiteLLM_UserTable(user_id="user-1", spend=500.0, max_budget=None)
+    token = UserAPIKeyAuth(token="secret-key-token", user_id="user-1")
+    proxy_logging_obj = _user_budget_logging()
+    current_spend = AsyncMock(return_value=500.0)
+
+    with (
+        patch("litellm.proxy.proxy_server.prisma_client", None),
+        patch("litellm.proxy.proxy_server.get_current_spend", current_spend),
+    ):
+        result = await common_checks(
+            request_body={"messages": [{"role": "user", "content": "hi"}]},
+            team_object=None,
+            user_object=user,
+            end_user_object=None,
+            global_proxy_spend=None,
+            general_settings={},
+            route="/chat/completions",
+            llm_router=None,
+            proxy_logging_obj=proxy_logging_obj,
+            valid_token=token,
+            request=MagicMock(spec=Request),
+        )
+        await asyncio.sleep(0)
+
+    assert result is True
+    current_spend.assert_not_awaited()
+    proxy_logging_obj.budget_alerts.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_common_checks_personal_user_budget_enforcement_survives_disabled_alerting():
+    from litellm.proxy.auth.auth_checks import common_checks
+    from litellm.proxy.utils import ProxyLogging
+
+    user = LiteLLM_UserTable(user_id="user-1", spend=0.0, max_budget=50.0)
+    token = UserAPIKeyAuth(token="secret-key-token", user_id="user-1")
+    proxy_logging_obj = ProxyLogging(user_api_key_cache=None)
+    slack_budget_alerts = AsyncMock()
+    proxy_logging_obj.slack_alerting_instance.budget_alerts = slack_budget_alerts
+
+    async def current_spend(counter_key, fallback_spend, max_budget=None, **kwargs):
+        return 50.0 if counter_key == "spend:user:user-1" else 0.0
+
+    with (
+        patch("litellm.proxy.proxy_server.prisma_client", None),
+        patch("litellm.proxy.proxy_server.get_current_spend", current_spend),
+    ):
+        with pytest.raises(litellm.BudgetExceededError):
+            await common_checks(
+                request_body={"messages": [{"role": "user", "content": "hi"}]},
+                team_object=None,
+                user_object=user,
+                end_user_object=None,
+                global_proxy_spend=None,
+                general_settings={},
+                route="/chat/completions",
+                llm_router=None,
+                proxy_logging_obj=proxy_logging_obj,
+                valid_token=token,
+                request=MagicMock(spec=Request),
+            )
+        await asyncio.sleep(0)
+
+    slack_budget_alerts.assert_not_awaited()
+
+
 @pytest.mark.asyncio
 async def test_common_checks_personal_user_budget_blocks_in_gather():
     """The personal-key user budget scope is enforced inside the gather.
@@ -5553,7 +5763,7 @@ async def test_common_checks_personal_user_budget_blocks_in_gather():
                 general_settings={},
                 route="/chat/completions",
                 llm_router=None,
-                proxy_logging_obj=MagicMock(),
+                proxy_logging_obj=MagicMock(budget_alerts=AsyncMock()),
                 valid_token=token,
                 request=MagicMock(spec=Request),
             )
@@ -5576,6 +5786,7 @@ async def test_common_checks_personal_user_budget_skipped_for_team_key():
     user = LiteLLM_UserTable(user_id="u1", spend=0.0, max_budget=100.0)
     team = LiteLLM_TeamTable(team_id="t1", spend=0.0, max_budget=1000.0)
     token = UserAPIKeyAuth(token="k1", user_id="u1", team_id="t1")
+    proxy_logging_obj = _user_budget_logging()
 
     async def _spend_by_counter(counter_key, fallback_spend, max_budget=None, **kwargs):
         return 999.0 if counter_key == "spend:user:u1" else 0.0
@@ -5595,11 +5806,12 @@ async def test_common_checks_personal_user_budget_skipped_for_team_key():
             general_settings={},
             route="/chat/completions",
             llm_router=None,
-            proxy_logging_obj=MagicMock(),
+            proxy_logging_obj=proxy_logging_obj,
             valid_token=token,
             request=MagicMock(spec=Request),
         )
     assert result is True
+    proxy_logging_obj.budget_alerts.assert_not_awaited()
 
 
 @pytest.mark.asyncio
@@ -5637,7 +5849,7 @@ async def test_common_checks_personal_user_budget_enforced_on_team_key_when_flag
                 general_settings={"apply_user_budget_to_team_keys": True},
                 route="/chat/completions",
                 llm_router=None,
-                proxy_logging_obj=MagicMock(),
+                proxy_logging_obj=MagicMock(budget_alerts=AsyncMock()),
                 valid_token=token,
                 request=MagicMock(spec=Request),
             )
@@ -5670,7 +5882,7 @@ async def test_common_checks_personal_user_budget_still_enforced_on_personal_key
                 general_settings={"apply_user_budget_to_team_keys": True},
                 route="/chat/completions",
                 llm_router=None,
-                proxy_logging_obj=MagicMock(),
+                proxy_logging_obj=MagicMock(budget_alerts=AsyncMock()),
                 valid_token=token,
                 request=MagicMock(spec=Request),
             )


### PR DESCRIPTION

## Issue

LiteLLM blocks users when they reach their spend cap, but it does not send Slack alerts. Virtual Key-level alerts are working as expected, so the issue appears to be specific to the user-budget path.

## TLDR

Problem this solves:

- Personal budget blocks arrive without Slack alerts
- User warnings differed from existing virtual-key alert scheduling

How it solves it:

- Schedules user alerts before personal budget enforcement
- Reuses the existing user spend read
- Follows the current virtual-key threshold flow
- Keeps existing team-key behavior unchanged

## User Flow

Before: a user reaches their personal budget, but the final Slack alert may never arrive

1. They send POST https://litellm-domain/v1/chat/completions using their personal key
2. Their recorded personal spend reaches the configured maximum budget
3. The request is rejected with the existing budget-exceeded response
4. The deployment's `budget_alerts` Slack destination receives no final user-budget alert

After: the same request is blocked and the final Slack alert is scheduled first

1. They send POST https://litellm-domain/v1/chat/completions using their personal key
2. Their recorded personal spend reaches the configured maximum budget
3. The `budget_alerts` Slack destination receives a user-budget alert with the current spend and personal maximum budget
4. The request is rejected with the existing budget-exceeded response

## Relevant issues


## Linear ticket


## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally
- [ ] My PR passes all required CI/CD checks
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile Confidence Score of at least 4/5 before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA)

## Screenshots / Proof of Fix

### Before (ec3f8183c3a5b40b5ca55fb915b7b6f4873d9112)

1. Start the proxy with Slack `budget_alerts` enabled and a personal user near their maximum budget
2. Send POST http://localhost:4000/v1/chat/completions using that user's personal key until the personal budget is reached
3. Observe the budget-exceeded response without a final personal-user Slack alert

### After (9bbbf03386432708dc0a91f237d2e78462e173d1)

1. Start the proxy with the same Slack configuration and personal user budget
2. Send POST http://localhost:4000/v1/chat/completions using that user's personal key until the personal budget is reached
3. Observe the final personal-user Slack alert and the same budget-exceeded response

## Type

🐛 Bug Fix

## Caveats (if any)

### Low

- Warning classification matches the existing virtual-key flow
- Team keys still require `apply_user_budget_to_team_keys`

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
