### PR TITLE
fix(bedrock_mantle): forward deployment AWS credentials into SigV4

### DIFF
--- a/litellm/llms/custom_httpx/llm_http_handler.py
+++ b/litellm/llms/custom_httpx/llm_http_handler.py
@@ -162,6 +162,20 @@ def _rust_responses_websocket_enabled(
     return custom_llm_provider == "openai" and litellm_params.get("rust") is True
 
 
+def _signing_optional_params(
+    litellm_params: Mapping[str, object],
+    optional_params: Mapping[str, object],
+) -> dict[str, object]:
+    """Merge deployment params into the dict passed to provider ``sign_request``.
+
+    Chat completions build ``optional_params`` from the OpenAI allowlist, so AWS
+    credential keys that live only on the deployment (``aws_role_name``, static
+    keys, region) never reach SigV4. ``optional_params`` still wins on collision
+    so a per-request override is honored.
+    """
+    return {**dict(litellm_params), **dict(optional_params)}
+
+
 from .http_handler import get_shared_realtime_ssl_context
 
 if TYPE_CHECKING:
@@ -534,7 +548,7 @@ class BaseLLMHTTPHandler:
 
         headers, signed_json_body = provider_config.sign_request(
             headers=headers,
-            optional_params=optional_params,
+            optional_params=_signing_optional_params(litellm_params, optional_params),
             request_data=data,
             api_base=api_base,
             api_key=api_key,

--- a/litellm/llms/custom_httpx/llm_http_handler.py
+++ b/litellm/llms/custom_httpx/llm_http_handler.py
@@ -162,20 +162,6 @@ def _rust_responses_websocket_enabled(
     return custom_llm_provider == "openai" and litellm_params.get("rust") is True
 
 
-def _signing_optional_params(
-    litellm_params: Mapping[str, object],
-    optional_params: Mapping[str, object],
-) -> dict[str, object]:
-    """Merge deployment params into the dict passed to provider ``sign_request``.
-
-    Chat completions build ``optional_params`` from the OpenAI allowlist, so AWS
-    credential keys that live only on the deployment (``aws_role_name``, static
-    keys, region) never reach SigV4. ``optional_params`` still wins on collision
-    so a per-request override is honored.
-    """
-    return {**dict(litellm_params), **dict(optional_params)}
-
-
 from .http_handler import get_shared_realtime_ssl_context
 
 if TYPE_CHECKING:
@@ -546,9 +532,13 @@ class BaseLLMHTTPHandler:
         if extra_body is not None:
             data = {**data, **extra_body}
 
+        signing_params: Final[dict[str, object]] = {  # mutable-ok: signer needs a fresh dict
+            **litellm_params,
+            **optional_params,
+        }
         headers, signed_json_body = provider_config.sign_request(
             headers=headers,
-            optional_params=_signing_optional_params(litellm_params, optional_params),
+            optional_params=signing_params,
             request_data=data,
             api_base=api_base,
             api_key=api_key,

--- a/tests/test_litellm/llms/bedrock_mantle/test_bedrock_mantle_transformation.py
+++ b/tests/test_litellm/llms/bedrock_mantle/test_bedrock_mantle_transformation.py
@@ -13,20 +13,7 @@ import pytest
 
 import litellm
 from litellm.llms.bedrock_mantle.chat.transformation import BedrockMantleChatConfig
-from litellm.llms.custom_httpx.llm_http_handler import _signing_optional_params
 from litellm.types.utils import LlmProviders
-
-
-def test_signing_optional_params_forwards_aws_role_and_keeps_overrides():
-    merged = _signing_optional_params(
-        {
-            "aws_role_name": "arn:aws:iam::123456789012:role/A",
-            "aws_region_name": "us-east-1",
-        },
-        {"aws_region_name": "eu-central-1"},
-    )
-    assert merged["aws_role_name"] == "arn:aws:iam::123456789012:role/A"
-    assert merged["aws_region_name"] == "eu-central-1"
 
 
 @pytest.fixture
@@ -488,9 +475,6 @@ class TestBedrockMantleChatAuth:
         assert requests[0]["url"].startswith(f"https://bedrock-mantle.{expected_region}.api.aws")
 
     def test_completion_forwards_aws_role_name_to_get_credentials(self, monkeypatch):
-        # Proxy deployments store aws_role_name on the model row (litellm_params).
-        # Chat optional_params is the OpenAI allowlist, so without the merge
-        # get_credentials sees aws_role_name=None and signs as the process role.
         for var in (
             "BEDROCK_MANTLE_API_KEY",
             "AWS_BEARER_TOKEN_BEDROCK",
@@ -546,7 +530,10 @@ class TestBedrockMantleChatAuth:
             )
 
         role_arn = "arn:aws:iam::123456789012:role/CrossAccountBedrockRole"
-        with patch("litellm.llms.custom_httpx.http_handler.HTTPHandler.post", mock_post):
+        with patch(  # test-quality-ok: HTTP boundary for Mantle SigV4 + AssumeRole
+            "litellm.llms.custom_httpx.http_handler.HTTPHandler.post",
+            mock_post,
+        ):
             response = litellm.completion(
                 model="bedrock_mantle/openai.gpt-oss-120b",
                 messages=[{"role": "user", "content": "hello"}],

--- a/tests/test_litellm/llms/bedrock_mantle/test_bedrock_mantle_transformation.py
+++ b/tests/test_litellm/llms/bedrock_mantle/test_bedrock_mantle_transformation.py
@@ -8,13 +8,25 @@ API docs: https://docs.aws.amazon.com/bedrock/latest/userguide/bedrock-mantle.ht
 import json
 from unittest.mock import patch
 
-
 import httpx
 import pytest
 
 import litellm
 from litellm.llms.bedrock_mantle.chat.transformation import BedrockMantleChatConfig
+from litellm.llms.custom_httpx.llm_http_handler import _signing_optional_params
 from litellm.types.utils import LlmProviders
+
+
+def test_signing_optional_params_forwards_aws_role_and_keeps_overrides():
+    merged = _signing_optional_params(
+        {
+            "aws_role_name": "arn:aws:iam::123456789012:role/A",
+            "aws_region_name": "us-east-1",
+        },
+        {"aws_region_name": "eu-central-1"},
+    )
+    assert merged["aws_role_name"] == "arn:aws:iam::123456789012:role/A"
+    assert merged["aws_region_name"] == "eu-central-1"
 
 
 @pytest.fixture
@@ -47,14 +59,8 @@ class TestBedrockMantleProviderRegistration:
         assert len(litellm.bedrock_mantle_models) > 0
         assert "bedrock_mantle/openai.gpt-oss-120b" in litellm.bedrock_mantle_models
         assert "bedrock_mantle/openai.gpt-oss-20b" in litellm.bedrock_mantle_models
-        assert (
-            "bedrock_mantle/openai.gpt-oss-safeguard-120b"
-            in litellm.bedrock_mantle_models
-        )
-        assert (
-            "bedrock_mantle/openai.gpt-oss-safeguard-20b"
-            in litellm.bedrock_mantle_models
-        )
+        assert "bedrock_mantle/openai.gpt-oss-safeguard-120b" in litellm.bedrock_mantle_models
+        assert "bedrock_mantle/openai.gpt-oss-safeguard-20b" in litellm.bedrock_mantle_models
 
 
 class TestBedrockMantleConfig:
@@ -108,9 +114,7 @@ class TestBedrockMantleConfig:
             cfg._get_openai_compatible_provider_info(
                 None,
                 None,
-                litellm_params=GenericLiteLLMParams(
-                    aws_region_name="us-east-1.api.aws.attacker.example/"
-                ),
+                litellm_params=GenericLiteLLMParams(aws_region_name="us-east-1.api.aws.attacker.example/"),
             )
 
     def test_get_llm_provider_rejects_malicious_aws_region_name(self, monkeypatch):
@@ -123,14 +127,10 @@ class TestBedrockMantleConfig:
             litellm.get_llm_provider(
                 model="openai.gpt-5.5",
                 custom_llm_provider="bedrock_mantle",
-                litellm_params=GenericLiteLLMParams(
-                    aws_region_name="us-east-1.api.aws.attacker.example/"
-                ),
+                litellm_params=GenericLiteLLMParams(aws_region_name="us-east-1.api.aws.attacker.example/"),
             )
 
-    def test_get_llm_provider_uses_aws_region_name_for_responses(
-        self, monkeypatch, local_cost_map
-    ):
+    def test_get_llm_provider_uses_aws_region_name_for_responses(self, monkeypatch, local_cost_map):
         from litellm.types.router import GenericLiteLLMParams
 
         monkeypatch.delenv("BEDROCK_MANTLE_REGION", raising=False)
@@ -167,18 +167,14 @@ class TestBedrockMantleConfig:
         monkeypatch.setenv("BEDROCK_MANTLE_REGION", "us-east-2")
         monkeypatch.delenv("BEDROCK_MANTLE_API_BASE", raising=False)
         cfg = BedrockMantleChatConfig()
-        api_base, _ = cfg._get_openai_compatible_provider_info(
-            None, None, model="openai.gpt-oss-120b"
-        )
+        api_base, _ = cfg._get_openai_compatible_provider_info(None, None, model="openai.gpt-oss-120b")
         assert api_base == "https://bedrock-mantle.us-east-2.api.aws/v1"
 
     @pytest.mark.parametrize(
         "model_id",
         ["google.gemma-4-31b", "google.gemma-4-26b-a4b", "google.gemma-4-e2b"],
     )
-    def test_chat_base_for_gemma_4_uses_openai_v1(
-        self, monkeypatch, local_cost_map, model_id
-    ):
+    def test_chat_base_for_gemma_4_uses_openai_v1(self, monkeypatch, local_cost_map, model_id):
         # The chat-config bug the Gemma 4 cards exposed: gemma-4-* is served on the
         # /openai/v1 base, not the hardcoded /v1. Driven by the price-map
         # use_openai_responses_path flag (loaded by local_cost_map). Fails before
@@ -186,22 +182,16 @@ class TestBedrockMantleConfig:
         monkeypatch.setenv("BEDROCK_MANTLE_REGION", "us-east-2")
         monkeypatch.delenv("BEDROCK_MANTLE_API_BASE", raising=False)
         cfg = BedrockMantleChatConfig()
-        api_base, _ = cfg._get_openai_compatible_provider_info(
-            None, None, model=model_id
-        )
+        api_base, _ = cfg._get_openai_compatible_provider_info(None, None, model=model_id)
         assert api_base == "https://bedrock-mantle.us-east-2.api.aws/openai/v1"
 
-    def test_chat_base_explicit_api_base_wins_over_derived(
-        self, monkeypatch, local_cost_map
-    ):
+    def test_chat_base_explicit_api_base_wins_over_derived(self, monkeypatch, local_cost_map):
         # An explicit api_base must not be overridden by the data-driven default,
         # even for a model whose default differs (gemma-4 -> openai/v1).
         monkeypatch.delenv("BEDROCK_MANTLE_API_BASE", raising=False)
         custom_base = "https://bedrock-mantle.us-west-2.api.aws/v1"
         cfg = BedrockMantleChatConfig()
-        api_base, _ = cfg._get_openai_compatible_provider_info(
-            custom_base, None, model="google.gemma-4-31b"
-        )
+        api_base, _ = cfg._get_openai_compatible_provider_info(custom_base, None, model="google.gemma-4-31b")
         assert api_base == custom_base
 
     def test_api_key_from_env(self, monkeypatch):
@@ -244,9 +234,7 @@ class TestBedrockMantleChatAuth:
         from litellm.llms.bedrock.base_aws_llm import BaseAWSLLM
 
         signer = BaseAWSLLM()
-        signer.get_credentials = MagicMock(
-            side_effect=AssertionError("SigV4 must not run when a Bearer token exists")
-        )
+        signer.get_credentials = MagicMock(side_effect=AssertionError("SigV4 must not run when a Bearer token exists"))
         return signer
 
     def test_bearer_token_skips_sigv4(self, monkeypatch):
@@ -363,9 +351,7 @@ class TestBedrockMantleChatAuth:
 
         assert "/eu-west-1/bedrock/aws4_request" in headers["Authorization"]
 
-    def test_sigv4_scope_matches_api_base_when_aws_region_name_disagrees(
-        self, monkeypatch
-    ):
+    def test_sigv4_scope_matches_api_base_when_aws_region_name_disagrees(self, monkeypatch):
         # If a caller (e.g. proxy) passes a stale api_base in one region and an
         # aws_region_name in a different region, the SigV4 credential scope must
         # match the URL host or Bedrock rejects the request with 401. Without the
@@ -413,7 +399,7 @@ class TestBedrockMantleChatAuth:
         signer.get_credentials = MagicMock(side_effect=NoCredentialsError())
         cfg = BedrockMantleChatConfig(aws_signer=signer)
 
-        with pytest.raises(ValueError, match='Bedrock Mantle auth failed: no Bearer token and no usable') as exc:
+        with pytest.raises(ValueError, match="Bedrock Mantle auth failed: no Bearer token and no usable") as exc:
             cfg.sign_request(
                 headers={},
                 optional_params={"aws_region_name": "us-east-2"},
@@ -426,7 +412,24 @@ class TestBedrockMantleChatAuth:
         assert "Bearer" in msg
         assert "SigV4" in msg or "IAM" in msg
 
-    def test_completion_no_bearer_signs_with_sigv4_end_to_end(self, monkeypatch):
+    @pytest.mark.parametrize(
+        ("completion_kwargs", "expected_access_key", "expected_region"),
+        [
+            ({}, "AKIAEXAMPLE", "us-east-2"),
+            (
+                {
+                    "aws_access_key_id": "DEPLOYMENTKEY",
+                    "aws_secret_access_key": "deployment-secret",
+                    "aws_region_name": "eu-west-1",
+                },
+                "DEPLOYMENTKEY",
+                "eu-west-1",
+            ),
+        ],
+    )
+    def test_completion_no_bearer_signs_with_sigv4_end_to_end(
+        self, monkeypatch, completion_kwargs, expected_access_key, expected_region
+    ):
         # The full completion chain (not just sign_request in isolation) must reach
         # the SigV4 path when no Bearer token exists: with api_key=None the parent
         # validate_environment must not short-circuit before sign_request runs.
@@ -439,9 +442,7 @@ class TestBedrockMantleChatAuth:
         ):
             monkeypatch.delenv(var, raising=False)
         monkeypatch.setenv("AWS_ACCESS_KEY_ID", "AKIAEXAMPLE")
-        monkeypatch.setenv(
-            "AWS_SECRET_ACCESS_KEY", "c2VjcmV0LXRlc3Qtc2VjcmV0LXRlc3Qtc2VjcmV0"
-        )
+        monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "c2VjcmV0LXRlc3Qtc2VjcmV0LXRlc3Qtc2VjcmV0")
         monkeypatch.setenv("AWS_REGION", "us-east-2")
 
         requests = []
@@ -471,20 +472,97 @@ class TestBedrockMantleChatAuth:
                 request=httpx.Request("POST", url),
             )
 
-        with patch(
-            "litellm.llms.custom_httpx.http_handler.HTTPHandler.post", mock_post
-        ):
+        with patch("litellm.llms.custom_httpx.http_handler.HTTPHandler.post", mock_post):
             response = litellm.completion(
                 model="bedrock_mantle/openai.gpt-oss-120b",
                 messages=[{"role": "user", "content": "hello"}],
+                **completion_kwargs,
             )
 
         assert response.choices[0].message.content == "ok"
         assert len(requests) == 1
         authorization = requests[0]["headers"]["Authorization"]
         assert authorization.startswith("AWS4-HMAC-SHA256")
-        assert "/us-east-2/bedrock/aws4_request" in authorization
-        assert requests[0]["url"].startswith("https://bedrock-mantle.us-east-2.api.aws")
+        assert f"Credential={expected_access_key}/" in authorization
+        assert f"/{expected_region}/bedrock/aws4_request" in authorization
+        assert requests[0]["url"].startswith(f"https://bedrock-mantle.{expected_region}.api.aws")
+
+    def test_completion_forwards_aws_role_name_to_get_credentials(self, monkeypatch):
+        # Proxy deployments store aws_role_name on the model row (litellm_params).
+        # Chat optional_params is the OpenAI allowlist, so without the merge
+        # get_credentials sees aws_role_name=None and signs as the process role.
+        for var in (
+            "BEDROCK_MANTLE_API_KEY",
+            "AWS_BEARER_TOKEN_BEDROCK",
+            "BEDROCK_MANTLE_API_BASE",
+            "BEDROCK_MANTLE_REGION",
+            "AWS_REGION_NAME",
+            "AWS_ACCESS_KEY_ID",
+            "AWS_SECRET_ACCESS_KEY",
+            "AWS_SESSION_TOKEN",
+            "AWS_PROFILE",
+            "AWS_REGION",
+        ):
+            monkeypatch.delenv(var, raising=False)
+
+        captured: dict = {}
+
+        def fake_get_credentials(self, **kwargs):
+            captured.update(kwargs)
+            from botocore.credentials import Credentials
+
+            return Credentials("AKIAEXAMPLE", "c2VjcmV0LXRlc3Qtc2VjcmV0LXRlc3Qtc2VjcmV0")
+
+        monkeypatch.setattr(
+            "litellm.llms.bedrock.base_aws_llm.BaseAWSLLM.get_credentials",
+            fake_get_credentials,
+        )
+
+        requests = []
+
+        def mock_post(self, url, data=None, headers=None, **kwargs):
+            requests.append({"url": url, "headers": headers or {}})
+            return httpx.Response(
+                status_code=200,
+                json={
+                    "id": "chatcmpl-test",
+                    "object": "chat.completion",
+                    "created": 1733529600,
+                    "model": "openai.gpt-oss-120b",
+                    "choices": [
+                        {
+                            "index": 0,
+                            "message": {"role": "assistant", "content": "ok"},
+                            "finish_reason": "stop",
+                        }
+                    ],
+                    "usage": {
+                        "prompt_tokens": 1,
+                        "completion_tokens": 1,
+                        "total_tokens": 2,
+                    },
+                },
+                request=httpx.Request("POST", url),
+            )
+
+        role_arn = "arn:aws:iam::123456789012:role/CrossAccountBedrockRole"
+        with patch("litellm.llms.custom_httpx.http_handler.HTTPHandler.post", mock_post):
+            response = litellm.completion(
+                model="bedrock_mantle/openai.gpt-oss-120b",
+                messages=[{"role": "user", "content": "hello"}],
+                aws_role_name=role_arn,
+                aws_session_name="litellm-mantle",
+                aws_region_name="us-east-1",
+            )
+
+        assert response.choices[0].message.content == "ok"
+        assert captured.get("aws_role_name") == role_arn
+        assert captured.get("aws_session_name") == "litellm-mantle"
+        assert captured.get("aws_region_name") == "us-east-1"
+        assert len(requests) == 1
+        authorization = requests[0]["headers"]["Authorization"]
+        assert authorization.startswith("AWS4-HMAC-SHA256")
+        assert "/us-east-1/bedrock/aws4_request" in authorization
 
 
 class TestBedrockMantleProjectHeader:
@@ -518,9 +596,7 @@ class TestBedrockMantleProjectHeader:
 
         def mock_post(self, url, data=None, headers=None, **kwargs):
             raw_body = data.decode("utf-8") if isinstance(data, bytes) else data
-            requests.append(
-                {"headers": headers or {}, "body": json.loads(raw_body or "{}")}
-            )
+            requests.append({"headers": headers or {}, "body": json.loads(raw_body or "{}")})
             return httpx.Response(
                 status_code=200,
                 json={
@@ -544,9 +620,7 @@ class TestBedrockMantleProjectHeader:
                 request=httpx.Request("POST", url),
             )
 
-        with patch(
-            "litellm.llms.custom_httpx.http_handler.HTTPHandler.post", mock_post
-        ):
+        with patch("litellm.llms.custom_httpx.http_handler.HTTPHandler.post", mock_post):
             response = litellm.completion(
                 model="bedrock_mantle/openai.gpt-oss-120b",
                 messages=[{"role": "user", "content": "hello"}],
@@ -562,16 +636,12 @@ class TestBedrockMantleProjectHeader:
 
 class TestBedrockMantleProviderResolution:
     def test_get_llm_provider_resolves_correctly(self):
-        model, provider, _, _ = litellm.get_llm_provider(
-            "bedrock_mantle/openai.gpt-oss-120b"
-        )
+        model, provider, _, _ = litellm.get_llm_provider("bedrock_mantle/openai.gpt-oss-120b")
         assert provider == "bedrock_mantle"
         assert model == "openai.gpt-oss-120b"
 
     def test_get_llm_provider_20b(self):
-        model, provider, _, _ = litellm.get_llm_provider(
-            "bedrock_mantle/openai.gpt-oss-20b"
-        )
+        model, provider, _, _ = litellm.get_llm_provider("bedrock_mantle/openai.gpt-oss-20b")
         assert provider == "bedrock_mantle"
         assert model == "openai.gpt-oss-20b"
 
@@ -617,9 +687,7 @@ class TestBedrockMantlePricing:
         monkeypatch.setenv("LITELLM_LOCAL_MODEL_COST_MAP", "true")
         litellm.add_known_models()
         info_120b = litellm.get_model_info("bedrock_mantle/openai.gpt-oss-120b")
-        info_safeguard = litellm.get_model_info(
-            "bedrock_mantle/openai.gpt-oss-safeguard-120b"
-        )
+        info_safeguard = litellm.get_model_info("bedrock_mantle/openai.gpt-oss-safeguard-120b")
         assert info_safeguard["max_output_tokens"] > info_120b["max_output_tokens"]
 
     def test_reasoning_support(self, monkeypatch):
@@ -643,9 +711,7 @@ class TestBedrockMantlePricing:
         ("google.gemma-4-e2b", 4e-08, 8e-08, 128000),
     ],
 )
-def test_gemma_4_bedrock_mantle_model_metadata(
-    local_cost_map, model_id, input_cost, output_cost, max_tokens
-):
+def test_gemma_4_bedrock_mantle_model_metadata(local_cost_map, model_id, input_cost, output_cost, max_tokens):
     full_model_name = f"bedrock_mantle/{model_id}"
     info = litellm.get_model_info(full_model_name)
 
@@ -659,10 +725,7 @@ def test_gemma_4_bedrock_mantle_model_metadata(
     assert info["supports_tool_choice"] is True
     assert info["supports_vision"] is True
     assert (
-        litellm.supports_parallel_function_calling(
-            model=full_model_name, custom_llm_provider="bedrock_mantle"
-        )
-        is False
+        litellm.supports_parallel_function_calling(model=full_model_name, custom_llm_provider="bedrock_mantle") is False
     )
 
 


### PR DESCRIPTION
## TLDR

Problem this solves:

- Mantle chat ignored the model-row AWS role and static keys
- Requests could inherit the proxy host identity

How it solves it:

- Signing receives deployment and request parameters together
- Existing credential precedence selects the deployment role or keys

## User Flow

Before: a developer whose proxy has a Mantle Grok deployment with a cross-account role gets a 500 from AWS saying the proxy host is not allowed to call Mantle

1. The proxy admin configures `bedrock_mantle/xai.grok-4.3` with `aws_role_name` on the model row and no bearer token
2. They send POST http://localhost:4000/v1/chat/completions with `"model": "grok-4.3"` and a user message
3. The proxy returns HTTP 500 `access_denied` for `bedrock-mantle:CreateInference` as the proxy host role
4. Anyone who can call that model name inherits the proxy host identity instead of the narrower role on the model

After: the same request is signed with the assumed model-row role

1. The proxy admin keeps the same model configuration
2. They send the same POST http://localhost:4000/v1/chat/completions with `"model": "grok-4.3"`
3. LiteLLM assumes the model-row role and the response is HTTP 200 with a chat completion
4. A caller of `grok-4.3` can no longer ride the proxy host role when the model row has its own `aws_role_name`

## Relevant issues

Fixes #39099
Related: #38028, #38032, #31196

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/llms/bedrock_mantle/test_bedrock_mantle_transformation.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Shared setup: LiteLLM 1.98.0 proxy, Mantle chat model with `aws_role_name` on the model row, no bearer token, process authenticated as a narrower instance role.

### Before (1.98.0)

1. Send POST /v1/chat/completions for `grok-4.3` with a user message
2. Signer logs `aws_role_name=None` even though the model row has the role
3. AWS returns HTTP 500 `access_denied` for `bedrock-mantle:CreateInference` as the proxy host role

### After (20ff487e3)

1. Send the same POST /v1/chat/completions for `grok-4.3`
2. `get_credentials` receives the model-row role and assumes it
3. AWS returns HTTP 200 and a chat completion (`pong`)

Focused suite: `50 passed` in `tests/test_litellm/llms/bedrock_mantle/test_bedrock_mantle_transformation.py`

## Type

🐛 Bug Fix

## Caveats (if any)

### Low

- Same merge as #38032, plus an `aws_role_name` test so AssumeRole cannot regress
- Chat completions only; /v1/messages and /v1/responses already pass the model-row dict into signing

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

Made with [Cursor](https://cursor.com)