### PR TITLE
fix(ui): show the invite user button to org admins

### DIFF
--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -1711,6 +1711,18 @@ class NewUserRequest(GenerateRequestBase):
     sso_user_id: str | None = None
     organizations: list[str] | None = None
 
+    @model_validator(mode="before")
+    @classmethod
+    def _accept_singular_organization_id(cls, values: object) -> object:
+        if not isinstance(values, dict):
+            return values
+        organization_id: Final = values.get("organization_id")
+        current: Final = values.get("organizations")
+        organizations: Final[list[object]] = list(current) if isinstance(current, list) else []
+        if not isinstance(organization_id, str) or organization_id in organizations:
+            return values
+        return {**values, "organizations": [*organizations, organization_id]}
+
 
 class NewUserResponse(GenerateKeyResponse):
     max_budget: float | None = None

--- a/tests/test_litellm/proxy/test__types.py
+++ b/tests/test_litellm/proxy/test__types.py
@@ -10,6 +10,7 @@ from litellm.proxy._types import (
     LiteLLM_AuditLogs,
     LiteLLM_TeamMembership,
     LitellmUserRoles,
+    NewUserRequest,
     OrganizationMemberUpdateRequest,
     ResetSpendRequest,
     UpdateKeyRequest,
@@ -277,3 +278,32 @@ def test_team_membership_budget_table_present_still_works():
     }
     result = LiteLLM_TeamMembership.model_validate(data)
     assert result.litellm_budget_table is None
+
+
+def test_a_singular_organization_id_reaches_the_organizations_list():
+    request = NewUserRequest.model_validate({"user_email": "member@org.test", "organization_id": "org-1"})
+
+    assert request.organizations == ["org-1"]
+
+
+def test_a_singular_organization_id_is_merged_with_an_organizations_list():
+    request = NewUserRequest.model_validate(
+        {"user_email": "member@org.test", "organization_id": "org-2", "organizations": ["org-1"]}
+    )
+
+    assert request.organizations == ["org-1", "org-2"]
+
+
+def test_an_organization_named_both_ways_is_not_duplicated():
+    request = NewUserRequest.model_validate(
+        {"user_email": "member@org.test", "organization_id": "org-1", "organizations": ["org-1"]}
+    )
+
+    assert request.organizations == ["org-1"]
+
+
+@pytest.mark.parametrize("body", [{}, {"organization_id": None}])
+def test_a_request_without_an_organization_id_keeps_its_organizations_untouched(body):
+    request = NewUserRequest.model_validate({"user_email": "member@org.test", **body})
+
+    assert request.organizations is None

--- a/ui/litellm-dashboard/src/app/(dashboard)/users/_components/view_users.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/users/_components/view_users.test.tsx
@@ -66,6 +66,25 @@ const makeUser = (userId: string, email: string) => ({
   budget_duration: null,
 });
 
+const session = vi.hoisted(() => ({
+  userId: "admin-user-id",
+  userRole: "Admin",
+  organizations: [] as unknown[],
+}));
+
+vi.mock("@/app/(dashboard)/hooks/useAuthorized", () => ({
+  default: () => ({
+    accessToken: "test-token",
+    token: "test-token",
+    userId: session.userId,
+    userRole: session.userRole,
+  }),
+}));
+
+vi.mock("@/app/(dashboard)/hooks/organizations/useOrganizations", () => ({
+  useOrganizations: () => ({ data: session.organizations }),
+}));
+
 const createQueryClient = () =>
   new QueryClient({
     defaultOptions: {
@@ -84,16 +103,21 @@ const defaultProps = {
   teams: [],
 };
 
-const renderDashboard = (overrides: Partial<typeof defaultProps> = {}) =>
-  renderWithProviders(
+const renderDashboard = (overrides: Partial<typeof defaultProps> = {}) => {
+  const props = { ...defaultProps, ...overrides };
+  session.userId = props.userID;
+  session.userRole = props.userRole;
+  return renderWithProviders(
     <QueryClientProvider client={createQueryClient()}>
-      <ViewUserDashboard {...defaultProps} {...overrides} />
+      <ViewUserDashboard {...props} />
     </QueryClientProvider>,
   );
+};
 
 describe("ViewUserDashboard", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    session.organizations = [];
     userListCall.mockResolvedValue({
       users: [makeUser("user-1", "test@example.com")],
       total: 1,
@@ -159,6 +183,29 @@ describe("ViewUserDashboard", () => {
     expect(screen.queryByTestId("toggle-user-selection")).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: /\+ invite user/i })).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: /\+ bulk invite users/i })).not.toBeInTheDocument();
+  });
+
+  it("shows the invite button to an org admin, whose session role is only Internal User", async () => {
+    session.organizations = [
+      { organization_id: "org-1", members: [{ user_id: "org-admin-user", user_role: "org_admin" }] },
+    ];
+
+    renderDashboard({ userRole: "Internal User", userID: "org-admin-user" });
+
+    expect(await screen.findByRole("button", { name: /\+ invite user/i })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /\+ bulk invite users/i })).not.toBeInTheDocument();
+    expect(screen.queryByTestId("toggle-user-selection")).not.toBeInTheDocument();
+  });
+
+  it("keeps the invite button hidden from a plain member of an organization", async () => {
+    session.organizations = [
+      { organization_id: "org-1", members: [{ user_id: "member-user", user_role: "internal_user" }] },
+    ];
+
+    renderDashboard({ userRole: "Internal User", userID: "member-user" });
+
+    expect(await screen.findByText("test@example.com")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /\+ invite user/i })).not.toBeInTheDocument();
   });
 
   it("keeps actions unavailable while the user list is loading", () => {

--- a/ui/litellm-dashboard/src/app/(dashboard)/users/_components/view_users.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/users/_components/view_users.tsx
@@ -18,6 +18,7 @@ import OnboardingModal, { InvitationLink } from "@/components/onboarding_link";
 
 import { DEBOUNCE_WAIT_MS } from "@/utils/debounceConstants";
 import { isAdminRole, isProxyAdminRole } from "@/utils/roles";
+import useIsOrgAdmin from "@/app/(dashboard)/hooks/useIsOrgAdmin";
 import { useDebouncedValue } from "@tanstack/react-pacer/debouncer";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import {
@@ -59,6 +60,7 @@ const ViewUserDashboard: React.FC<ViewUserDashboardProps> = ({
   orgAdminOrgIds,
 }) => {
   const isProxyAdmin = userRole ? isProxyAdminRole(userRole) : false;
+  const isOrgAdmin = useIsOrgAdmin();
   const queryClient = useQueryClient();
 
   const [pagination, setPagination] = useState<PaginationState>({ pageIndex: 0, pageSize: DEFAULT_PAGE_SIZE });
@@ -327,7 +329,7 @@ const ViewUserDashboard: React.FC<ViewUserDashboardProps> = ({
           )}
           {!userListQuery.isLoading && userID && accessToken && (
             <>
-              {isProxyAdmin && (
+              {(isProxyAdmin || isOrgAdmin) && (
                 <CreateUserButton userID={userID} accessToken={accessToken} possibleUIRoles={possibleUIRoles} />
               )}
 

--- a/ui/litellm-dashboard/src/components/CreateUserButton.test.tsx
+++ b/ui/litellm-dashboard/src/components/CreateUserButton.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor, within } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import userEvent, { PointerEventsCheckLevel } from "@testing-library/user-event";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { describe, it, expect, vi, beforeEach } from "vitest";
@@ -338,6 +338,54 @@ describe("CreateUserButton", () => {
           expect.objectContaining({
             organizations: ["org-1"],
           }),
+        );
+      });
+    });
+
+    it("preselects and posts the organization the caller administers", async () => {
+      const { useOrganizations } = await import("@/app/(dashboard)/hooks/organizations/useOrganizations");
+      vi.mocked(useOrganizations).mockReturnValue({
+        data: [
+          {
+            organization_id: "org-1",
+            organization_alias: "My Org",
+            members: [{ user_id: "123", user_role: "org_admin" }],
+          },
+          {
+            organization_id: "org-2",
+            organization_alias: "Someone Else's Org",
+            members: [{ user_id: "999", user_role: "org_admin" }],
+          },
+        ],
+        isLoading: false,
+      } as any);
+
+      const user = userEvent.setup({ pointerEventsCheck: PointerEventsCheckLevel.Never });
+      mockUserCreateCall.mockResolvedValue({ data: { user_id: "org-user" } });
+      mockInvitationCreateCall.mockResolvedValue({
+        id: "inv-preselect",
+        user_id: "org-user",
+        has_user_setup_sso: false,
+      } as any);
+
+      renderWithProviders(
+        <CreateUserButton {...defaultProps} possibleUIRoles={{ proxy_user: { ui_label: "User", description: "" } }} />,
+      );
+
+      await waitFor(() => {
+        expect(screen.getByRole("button", { name: /\+ invite user/i })).toBeInTheDocument();
+      });
+      await user.click(screen.getByRole("button", { name: /\+ invite user/i }));
+
+      const dialog = screen.getByRole("dialog", { name: /invite user/i });
+      fireEvent.change(within(dialog).getByLabelText(/user email/i), { target: { value: "member@example.com" } });
+      await user.click(within(dialog).getByRole("button", { name: /invite user/i }));
+
+      await waitFor(() => {
+        expect(mockUserCreateCall).toHaveBeenCalledWith(
+          "token",
+          null,
+          expect.objectContaining({ organizations: ["org-1"] }),
         );
       });
     });

--- a/ui/litellm-dashboard/src/components/CreateUserButton.tsx
+++ b/ui/litellm-dashboard/src/components/CreateUserButton.tsx
@@ -26,6 +26,7 @@ import {
   userCreateCall,
 } from "./networking";
 import OnboardingModal, { InvitationLink } from "./onboarding_link";
+import { orgsAdministeredBy } from "@/utils/roles";
 
 // Helper function to generate UUID compatible across all environments
 const generateUUID = (): string => {
@@ -170,6 +171,9 @@ export const CreateUserButton: React.FC<CreateuserProps> = ({
     label: `${org.organization_alias} (${org.organization_id})`,
     value: org.organization_id ?? "",
   }));
+  const administeredOrganizationIds = orgsAdministeredBy(organizations, userID)
+    .map((org) => org.organization_id)
+    .filter((id): id is string => Boolean(id));
 
   useEffect(() => {
     const fetchData = async () => {
@@ -192,6 +196,14 @@ export const CreateUserButton: React.FC<CreateuserProps> = ({
     setBaseUrl(getProxyBaseUrl());
     fetchData();
   }, []);
+
+  const handleOpen = () => {
+    form.reset({
+      ...defaultValues,
+      organization_ids: administeredOrganizationIds.length > 0 ? administeredOrganizationIds : undefined,
+    });
+    setIsModalVisible(true);
+  };
 
   const handleCancel = () => {
     setIsModalVisible(false);
@@ -325,7 +337,7 @@ export const CreateUserButton: React.FC<CreateuserProps> = ({
   // Original return for standalone mode
   return (
     <>
-      <Button type="button" onClick={() => setIsModalVisible(true)}>
+      <Button type="button" onClick={handleOpen}>
         + Invite User
       </Button>
       <Dialog open={isModalVisible} onOpenChange={(open) => !open && handleCancel()}>

--- a/ui/litellm-dashboard/src/utils/roles.test.ts
+++ b/ui/litellm-dashboard/src/utils/roles.test.ts
@@ -6,6 +6,7 @@ import {
   isAdminRole,
   spendScopeUserId,
   isOrgAdminForAnyOrg,
+  orgsAdministeredBy,
   isOrgAdminSessionRole,
   isProxyAdminRole,
   isUserTeamAdminForAnyTeam,
@@ -189,6 +190,27 @@ describe("roles", () => {
       expect(isOrgAdminForAnyOrg([{ organization_id: "org-1" } as unknown as Organization], "user-1")).toBe(false);
       expect(isOrgAdminForAnyOrg([orgWithMembers([{ user_id: "user-1", user_role: "org_admin" }])], null)).toBe(false);
       expect(isOrgAdminForAnyOrg([orgWithMembers([{ user_id: "user-1", user_role: "org_admin" }])], "")).toBe(false);
+    });
+  });
+
+  describe("orgsAdministeredBy", () => {
+    const org = (organization_id: string, members: { user_id: string; user_role: string }[]): Organization =>
+      ({ organization_id, members }) as unknown as Organization;
+
+    it("returns only the organizations the user administers", () => {
+      const organizations = [
+        org("org-1", [{ user_id: "user-1", user_role: "internal_user" }]),
+        org("org-2", [{ user_id: "user-1", user_role: "org_admin" }]),
+        org("org-3", [{ user_id: "user-2", user_role: "org_admin" }]),
+      ];
+
+      expect(orgsAdministeredBy(organizations, "user-1").map((o) => o.organization_id)).toEqual(["org-2"]);
+    });
+
+    it("returns an empty list for missing organizations or a missing user id", () => {
+      expect(orgsAdministeredBy(null, "user-1")).toEqual([]);
+      expect(orgsAdministeredBy(undefined, "user-1")).toEqual([]);
+      expect(orgsAdministeredBy([org("org-1", [{ user_id: "user-1", user_role: "org_admin" }])], null)).toEqual([]);
     });
   });
 

--- a/ui/litellm-dashboard/src/utils/roles.ts
+++ b/ui/litellm-dashboard/src/utils/roles.ts
@@ -46,18 +46,23 @@ export const isUserTeamAdminForSingleTeam = (teamMemberWithRoles: Member[] | nul
   return teamMemberWithRoles.some((member) => member.user_id === userID && member.role === "admin");
 };
 
-export const isOrgAdminForAnyOrg = (
+export const orgsAdministeredBy = (
   organizations: Organization[] | null | undefined,
   userID: string | null | undefined,
-): boolean => {
+): Organization[] => {
   if (organizations == null || !userID) {
-    return false;
+    return [];
   }
-  return organizations.some((org) => {
+  return organizations.filter((org) => {
     const members: OrganizationMembership[] = org.members ?? [];
     return members.some((member) => member.user_id === userID && member.user_role === ORG_ADMIN_MEMBERSHIP_ROLE);
   });
 };
+
+export const isOrgAdminForAnyOrg = (
+  organizations: Organization[] | null | undefined,
+  userID: string | null | undefined,
+): boolean => orgsAdministeredBy(organizations, userID).length > 0;
 
 export const formatUserRole = (userRole: string): string => {
   if (!userRole) {


### PR DESCRIPTION
<!-- The whole description's target audience is humans, not AI agents: write it in plain, simple,
     everyday engineering language, extremely parsable and readable at a glance. This goes double for
     the TLDR, User Flow, and Caveats sections -->

## TLDR

<!-- Fill in the bullets below and keep each one short and concrete: one line per bullet, roughly 10 words max -->

Problem this solves:

- An org admin cannot add a user to their own organization
- The Internal Users page hides the invite button from them
- The API path accepts their organization id, then ignores it
- The user gets created belonging to no organization, with no warning

How it solves it:

- Show the invite button to org admins, not just proxy admins
- Preselect the organizations the caller administers on the form
- Accept `organization_id` on user create as a one-item organization list

## User Flow

<!-- Two ordered lists, Before and After, walking the same end user through the same task, written strictly from that user's seat
     Read the linked issue, ticket, or customer thread first so the flow reflects the real application and the routes its users actually hit; don't invent a generic scenario
     Lead each list with one plain sentence saying where the flow fails (Before) or succeeds (After), then number the steps
     Every step is something the user does or observes: the HTTP method and full URL they hit, what they sent, and what visibly came back (status code, error text, the shape of an ID). UI steps name the page URL and what is on screen
     No LiteLLM internals: never name functions, files, DB tables, config classes, hooks, callbacks, or code paths. "The upload hands back an ID that looks like OpenAI's own `file-abc123` instead of the scrambled one the gateway returned" is right, "no managed-file row was registered" is wrong
     Keep the two lists step-for-step identical until they diverge, so the changed step is obvious
     If the bug had a security or authorization consequence, end each list with what another user could or could no longer do
     Regenerate this section whenever new commits change the PR's behavior, so it never describes an older revision

Example:

Before: a developer whose app streams chat completions gets no token counts back, so their cost dashboard reads zero

1. They send POST https://litellm-domain/v1/chat/completions with `"stream": true` and no `stream_options`
2. The last SSE chunk arrives with `"usage": null`, so their app records 0 prompt and 0 completion tokens
3. They open https://litellm-domain/ui/?page=logs and see the request logged at $0 spend

After: the same request comes back with real token counts, so the dashboard shows real spend

1. The proxy admin sets `always_include_stream_usage: true` and restarts the proxy
2. The developer sends the same POST https://litellm-domain/v1/chat/completions with `"stream": true` and no `stream_options`
3. The last SSE chunk now carries a `usage` object with real prompt and completion token counts
4. https://litellm-domain/ui/?page=logs shows that request at non-zero spend
-->

Before: an admin who runs one organization has no working way to add a person to it

1. A proxy admin creates the user `mab1@org.admin`, creates the organization Org1, and adds mab1 to Org1 with the organization role `org_admin`
2. mab1 signs in at https://litellm-domain/ui/ and opens Internal Users
3. They see their organization's users listed, but there is no **+ Invite User** button anywhere on the page
4. They fall back to the API and send POST https://litellm-domain/user/new with their own key and `{"user_email": "member@org.mab1", "user_role": "internal_user"}`
5. It comes back 401: `Only proxy admin can be used to generate, delete, update info for new keys/users/teams. Route=/user/new. Your role=internal_user`
6. They add `"organization_id": "<Org1's id>"` and send it again. This time it returns 200 with a new user id
7. They open Internal Users again and the new person is not in the list. GET https://litellm-domain/organization/info?organization_id=<Org1's id> shows the same member count as before, so the user they just created belongs to nothing

After: the same admin invites someone from the page in two clicks

1. A proxy admin creates the user `mab1@org.admin`, creates the organization Org1, and adds mab1 to Org1 with the organization role `org_admin`
2. mab1 signs in at https://litellm-domain/ui/ and opens Internal Users
3. **+ Invite User** is now on the page, above the user list
4. They click it. The Organization field on the form already shows Org1, so they do not have to know which organization to pick
5. They type an email, click **Invite User**, and get the invite link dialog back
6. The new person is in the list on Internal Users, and GET https://litellm-domain/organization/info?organization_id=<Org1's id> now counts one more member
7. The API path works the same way: POST https://litellm-domain/user/new with `"organization_id": "<Org1's id>"` returns 200 and the member count goes up

On authorization, nothing widened. mab1 sending POST https://litellm-domain/user/new with another organization's id still gets the same 401, whether that id is sent on its own or mixed in with Org1's. A plain member of Org1, who is not an org admin, still sees no invite button on Internal Users.

## Relevant issues

<!-- e.g., "Fixes #000" -->

Fixes #30843

## Linear ticket

<!-- if you are an internal contributor, add "Resolves " followed by the Linear ticket e.g., "Resolves LIT-1234" to link the Linear ticket to the GitHub PR. If you don't have one, leave the section blank rather than guessing -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

<!-- Include screenshots, screen recordings, or command (e.g., curl) + output demonstrating that your changes work as expected
     The proof must be completely e2e with no mocks, using actual LLM calls costing real $$$ if applicable. `pytest` commands are not enough
     Show ONLY the latest run: capture Before at the merge base and After at the PR's current tip, and when new commits change behavior, replace this whole section with the fresh run instead of stacking it on top of older ones. The run must be up to date. As soon as a new commit is made and it makes this PR description's after sha stale (it's no longer tip of PR), you must re-run the QA
     Structure the section exactly as below: Before and After one heading level below this section, each naming the commit hash it was captured at, one lower-level heading per case inside each, the same case names in the same order on both sides, and numbered steps (command, observed output) under every case, never loose prose; shared setup (config, payloads) goes above Before, and with a single case, drop the case headings and number the steps directly

### Before (<hash>)

#### <case 1>

1. ...
2. ...

#### <case 2>

1. ...

### After (<hash>)

#### <case 1>

1. ...
2. ...

#### <case 2>

1. ...

     For bug fixes: Before shows the reproduction, After shows the same steps passing
     For new features: Before shows the capability missing, After shows it working end-to-end
     If the change applies to all three LLM endpoints (/v1/responses, /v1/chat/completions, /v1/messages), make each endpoint its own case, not just one
     For UI changes: before/after screenshots under the same headings -->

Shared setup, run once against a proxy on localhost:4000 with a database, as the proxy admin:

```bash
# organization
ORG=$(curl -s -X POST http://localhost:4000/organization/new \
  -H "Authorization: Bearer sk-1234" -H 'Content-Type: application/json' \
  -d '{"organization_alias":"Org1","models":[]}' | jq -r .organization_id)

# the org admin: a normal internal user, made org_admin inside Org1
MAB1=$(curl -s -X POST http://localhost:4000/user/new \
  -H "Authorization: Bearer sk-1234" -H 'Content-Type: application/json' \
  -d '{"user_email":"mab1@org.admin","user_role":"internal_user"}')
MAB1_ID=$(echo "$MAB1" | jq -r .user_id)
MAB1_KEY=$(echo "$MAB1" | jq -r .key)

curl -s -X POST http://localhost:4000/organization/member_add \
  -H "Authorization: Bearer sk-1234" -H 'Content-Type: application/json' \
  -d "{\"organization_id\":\"$ORG\",\"member\":{\"role\":\"org_admin\",\"user_id\":\"$MAB1_ID\"}}"

curl -s -X POST http://localhost:4000/user/update \
  -H "Authorization: Bearer sk-1234" -H 'Content-Type: application/json' \
  -d '{"user_email":"mab1@org.admin","password":"OrgAdmin123!"}'
```

Helper used in both runs to read the member count:

```bash
members() { curl -s "http://localhost:4000/organization/info?organization_id=$ORG" \
  -H "Authorization: Bearer sk-1234" | jq '.members | length'; }
```

### Before (ec3f8183c3)

#### Internal Users page as the org admin

1. Sign in at http://localhost:4000/ui/login as `mab1@org.admin` / `OrgAdmin123!` and open Internal Users
2. The page lists the organization's users and has no **+ Invite User** button

<!-- attach the before screenshot of Internal Users signed in as mab1@org.admin, no buttons above the table -->

#### Creating a user through the API as the org admin

1. Send the create with no organization named:

```bash
curl -s -X POST http://localhost:4000/user/new \
  -H "Authorization: Bearer $MAB1_KEY" -H 'Content-Type: application/json' \
  -d '{"user_email":"before-1@org.mab1","user_role":"internal_user"}'
```

```json
{"error":{"message":"Authentication Error, Only proxy admin can be used to generate, delete, update info for new keys/users/teams. Route=/user/new. Your role=internal_user. Your user_id=b77647****30","type":"auth_error","param":"None","code":"401"}}
```

2. Read the member count, name the organization, create again, read the count again:

```bash
members   # 5
curl -s -o /dev/null -w '%{http_code}\n' -X POST http://localhost:4000/user/new \
  -H "Authorization: Bearer $MAB1_KEY" -H 'Content-Type: application/json' \
  -d "{\"user_email\":\"before-2@org.mab1\",\"user_role\":\"internal_user\",\"organization_id\":\"$ORG\"}"
# 200
members   # 5
```

The create succeeded and the organization gained nobody.

### After (528b9bc871)

#### Internal Users page as the org admin

1. Sign in at http://localhost:4000/ui/login as `mab1@org.admin` / `OrgAdmin123!` and open Internal Users
2. **+ Invite User** is on the page. Clicking it opens the form with the Organization field already set to Org1
3. Enter an email and submit. The new person appears in the list, shown here as `ui-invited-…@org.mab1` at the top

<img width="1280" height="650" alt="after_fix" src="https://github.com/user-attachments/assets/12ec80a4-095c-4eec-8455-a206269bb033" />


#### Creating a user through the API as the org admin

1. Send the create with no organization named. Unchanged and still refused, by design:

```bash
curl -s -X POST http://localhost:4000/user/new \
  -H "Authorization: Bearer $MAB1_KEY" -H 'Content-Type: application/json' \
  -d '{"user_email":"after-1@org.mab1","user_role":"internal_user"}'
```

```json
{"error":{"message":"Authentication Error, Only proxy admin can be used to generate, delete, update info for new keys/users/teams. Route=/user/new. Your role=internal_user. Your user_id=b77647****30","type":"auth_error","param":"None","code":"401"}}
```

2. Read the member count, name the organization, create again, read the count again:

```bash
members   # 6
curl -s -o /dev/null -w '%{http_code}\n' -X POST http://localhost:4000/user/new \
  -H "Authorization: Bearer $MAB1_KEY" -H 'Content-Type: application/json' \
  -d "{\"user_email\":\"after-2@org.mab1\",\"user_role\":\"internal_user\",\"organization_id\":\"$ORG\"}"
# 200
members   # 7
```

3. The same caller still cannot reach an organization they do not administer:

```bash
OTHER=$(curl -s -X POST http://localhost:4000/organization/new \
  -H "Authorization: Bearer sk-1234" -H 'Content-Type: application/json' \
  -d '{"organization_alias":"Org2","models":[]}' | jq -r .organization_id)

curl -s -X POST http://localhost:4000/user/new \
  -H "Authorization: Bearer $MAB1_KEY" -H 'Content-Type: application/json' \
  -d "{\"user_email\":\"escalate@x.test\",\"user_role\":\"internal_user\",\"organization_id\":\"$OTHER\"}"
```

```json
{"error":{"message":"Authentication Error, Only proxy admin can be used to generate, delete, update info for new keys/users/teams. Route=/user/new. Your role=internal_user. Your user_id=b77647****30","type":"auth_error","param":"None","code":"401"}}
```

Sending Org2's id together with Org1's is refused the same way.

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix

## Caveats (if any)

<!-- Group caveats under severity subheadings (### Severe, ### High, ### Medium, ### Low), with
     short bullet points inside each, just like the TLDR: one line per bullet, roughly 10 words max
     Call out known limllow-up work, or anything a reviewer should watch out for
     Include only the tiers that have caveats; drop the empty ones
     - Severe: inherent to what the PR deliberately ships, there even when the code works as intended:
       it can degrade or take down a running deployment (e.g. a slow or table-locking boot migration),
       rewrite data by design, break an existing workflow on purpose, or change auth behavior. An
       operator must plan around it before rollout
     - High: an unintended hole: a correctness, security, data-loss, or backward-compatibility bug,
       unsafe to ship as is
     - Medium: a real gap someone can hit, but with a workaround or a narrow blast radius
     - Low: anything else worth noting: naming, cleanup, an edge case nobody hits
     Nest bullets as deep as helps: hierarchy beats one long line when it makes things clearer to a
     human reader
     Leave this section empty if there are none -->

### Medium

- Bulk invite still hidden from org admins, it has no organization field
- Select users stays hidden, bulk edit can target every user

### Low

- API callers must still name an organization, unchanged behaviour
- Adding an org member by email is broken separately, not touched here

## Implementation notes

Why the change looks the way it does, since a few options were on the table.

- Reused the org-admin check the dashboard already has, instead of adding a new one
  - An org admin's authority lives in the organization membership list, while the browser session only carries their global role, which stays `internal_user`. That mismatch is the whole bug
  - The sidebar already asks this exact question, so the users page now asks it the same way
  - Keeps the page change to one condition, and avoids a second permission concept that can drift from the first
- Opened up the single invite button only
  - Bulk invite has no organization field, so every row it sends would be refused. That would be a button that always fails
  - Bulk edit can target every user on the proxy and has no per-organization scoping, so it is not safe for an org-scoped caller
  - Both stay proxy admin only, which is also how this shipped originally
- Preselected the organization on the invite form rather than leaving it empty
  - An empty dropdown means the create names no organization, which is refused, so the admin would hit the original error from the form
  - Preselecting the organizations they administer makes the default path work, and they can still change it
- Accepted `organization_id` on user create instead of rejecting it
  - The authorization layer already reads that field to decide which organization the caller is acting in
  - Accepting it there and dropping it on create was the inconsistency, so honouring the same field lines the two up
  - Left alone the rule that a caller must name an organization at all. That is deliberate and already has a test
- Left the separate organization member bug alone
  - Adding a member by email fails for everyone, master key included, because of a different lookup bug
  - Out of scope here and worth its own issue

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
