### PR TITLE
fix(alerting): clarify budget threshold messages

### DIFF
--- a/litellm/integrations/SlackAlerting/slack_alerting.py
+++ b/litellm/integrations/SlackAlerting/slack_alerting.py
@@ -632,10 +632,10 @@ class SlackAlerting(CustomBatchLogger):
                 event_message += f"Budget Crossed\n Total Budget:`{user_info.max_budget}`"
             elif percent_left <= SLACK_ALERTING_THRESHOLD_5_PERCENT:
                 event = "threshold_crossed"
-                event_message += "5% Threshold Crossed "
+                event_message += "5% or less of budget remaining"
             elif percent_left <= SLACK_ALERTING_THRESHOLD_15_PERCENT:
                 event = "threshold_crossed"
-                event_message += "15% Threshold Crossed"
+                event_message += "15% or less of budget remaining"
 
         return event, event_message
 

--- a/tests/test_litellm/integrations/SlackAlerting/test_slack_alerting.py
+++ b/tests/test_litellm/integrations/SlackAlerting/test_slack_alerting.py
@@ -10,6 +10,7 @@ import pytest
 
 import litellm
 from litellm.caching.caching import DualCache
+from litellm.integrations.SlackAlerting.budget_alert_types import get_budget_alert_type
 from litellm.integrations.SlackAlerting.slack_alerting import SlackAlerting
 from litellm.proxy._types import CallInfo, Litellm_EntityType
 from litellm.types.integrations.slack_alerting import AlertType, SlackAlertingCacheKeys
@@ -46,9 +47,8 @@ class TestSlackAlerting(unittest.TestCase):
         self.assertEqual(result, -0.2)
 
     def test_get_event_and_event_message_max_budget(self):
-        # Initial setup with no event
         event = None
-        event_message = "Test Message: "
+        event_message = get_budget_alert_type("user_budget").get_event_message()
 
         # Test case 1: When spend exceeds max_budget
         user_info = CallInfo(
@@ -63,7 +63,7 @@ class TestSlackAlerting(unittest.TestCase):
         self.assertEqual(event, "budget_crossed")
         self.assertTrue("Budget Crossed" in event_message)
 
-        # Test case 2: When 5% of max_budget is left
+        event_message = get_budget_alert_type("user_budget").get_event_message()
         user_info = CallInfo(
             max_budget=100.0,
             spend=95.0,
@@ -74,9 +74,9 @@ class TestSlackAlerting(unittest.TestCase):
             user_info=user_info, event=event, event_message=event_message
         )
         self.assertEqual(event, "threshold_crossed")
-        self.assertTrue("5% Threshold Crossed" in event_message)
+        self.assertEqual(event_message, "User Budget: 5% or less of budget remaining")
 
-        # Test case 3: When 15% of max_budget is left
+        event_message = get_budget_alert_type("user_budget").get_event_message()
         user_info = CallInfo(
             max_budget=100.0,
             spend=85.0,
@@ -87,7 +87,7 @@ class TestSlackAlerting(unittest.TestCase):
             user_info=user_info, event=event, event_message=event_message
         )
         self.assertEqual(event, "threshold_crossed")
-        self.assertTrue("15% Threshold Crossed" in event_message)
+        self.assertEqual(event_message, "User Budget: 15% or less of budget remaining")
 
     def test_get_event_and_event_message_soft_budget(self):
         # Initial setup with no event


### PR DESCRIPTION
## TLDR

Problem this solves:

- `15% Threshold Crossed` is ambiguous
- It means 15% remains, or 85% was used
- Readers may think only 15% was used

How it solves it:

- Says `15% or less of budget remaining`
- Applies the same clarification to the 5% warning

## User Flow

Before: an operator receives a budget warning with an ambiguous percentage

1. The operator enables budget alerts and configures a maximum budget
2. A developer sends POST https://litellm-domain/v1/chat/completions until 15% or less of that budget remains
3. The operator receives a notification saying `15% Threshold Crossed`
4. The operator cannot tell whether 15% was spent or remains

After: the same warning clearly describes the remaining budget

1. The operator enables budget alerts and configures a maximum budget
2. A developer sends POST https://litellm-domain/v1/chat/completions until 15% or less of that budget remains
3. The operator receives a notification saying `15% or less of budget remaining`
4. The operator immediately knows how much budget remains

## Relevant issues

## Affected release

## Linear ticket

Resolves LIT-6959

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Same flow on both legs, differing only in the commit the proxy was booted from. Each leg: one proxy started with `litellm --config qa.yaml --num_workers 2` on a random free port, its own fresh local Postgres database, no Redis, model `gpt-5.4-nano` through the real OpenAI API. `general_settings` carries `alerting: ["slack", "webhook"]` and `alert_types: ["budget_alerts"]`, `SLACK_WEBHOOK_URL` points at a real Slack incoming webhook (the operator's DM) and `WEBHOOK_URL` at a local HTTP receiver that appends every POST body it gets, standing in for the operator's generic webhook consumer. The Slack text below is read back through `conversations.history` on that DM. Before ran on port 47211 (receiver 28778), after on 31789 (receiver 30711)

Commands run on both legs (`$BASE` is the proxy, `$MASTER` the master key):

```bash
# 15% case: a key with a $0.001 budget, then chat until the alert lands in Slack
KEY=$(curl -s $BASE/key/generate -H "Authorization: Bearer $MASTER" -H 'Content-Type: application/json' \
  -d '{"key_alias":"lit6959-<leg>-15pct","max_budget":0.001}' | jq -r .key)
for i in $(seq 1 150); do
  curl -s -o /dev/null -w "request $i -> HTTP %{http_code}\n" $BASE/v1/chat/completions -H "Authorization: Bearer $KEY" -H 'Content-Type: application/json' \
    -d '{"model":"gpt-5.4-nano","messages":[{"role":"user","content":"Say hi"}],"max_completion_tokens":16}'
  sleep 3   # stop as soon as the Slack DM shows a message for this key_alias
done
curl -s "$BASE/key/info?key=$KEY" -H "Authorization: Bearer $MASTER" | jq -c '.info | {key_alias, spend, max_budget}'

# 5% case: a key with no budget, six longer chats, then the budget set so about 4% remains, then chat again
KEY=$(curl -s $BASE/key/generate -H "Authorization: Bearer $MASTER" -H 'Content-Type: application/json' -d '{"key_alias":"lit6959-<leg>-5pct"}' | jq -r .key)
for i in $(seq 1 6); do curl -s -o /dev/null $BASE/v1/chat/completions -H "Authorization: Bearer $KEY" -H 'Content-Type: application/json' \
  -d '{"model":"gpt-5.4-nano","messages":[{"role":"user","content":"Write a 300 word story about a lighthouse"}],"max_completion_tokens":600}'; done
sleep 20; SPEND=$(curl -s "$BASE/key/info?key=$KEY" -H "Authorization: Bearer $MASTER" | jq -r .info.spend)
curl -s $BASE/key/update -H "Authorization: Bearer $MASTER" -H 'Content-Type: application/json' -d "{\"key\":\"$KEY\",\"max_budget\":$(python3 -c "print(round($SPEND / 0.96, 8))")}" | jq -c '{key_alias, max_budget}'
sleep 65; # then the same "Say hi" loop as above until the Slack DM shows a message for this key_alias
```

### Before (5fc510a6fd)

```
### 15% case: operator creates a key with max_budget 0.001, developer sends requests until the alert arrives
requests 1..46 -> HTTP 200, no alert yet
request 47 -> HTTP 200, Slack alert so far: yes
key spend when the alert arrived:
{"key_alias":"lit6959-before-15pct","spend":0.0008976999999999998,"max_budget":0.001}
Slack DM, messages for lit6959-before-15pct:
[Num Alerts: 2] | Alert type: `budget_alerts` | Level: `High` | Timestamp: `03:00:30` | Message: Key Budget: 15% Threshold Crossed | *spend:* `0.0008594999999999998` | *max_budget:* `0.001` | *key_alias:* `lit6959-before-15pct` | *event_group:* `key` | Proxy URL: `<http://localhost:4000>`
WEBHOOK_URL receiver, events for lit6959-before-15pct:
{"event":"threshold_crossed","event_message":"Key Budget: 15% Threshold Crossed","spend":0.0008594999999999998,"max_budget":0.001}
{"event":"threshold_crossed","event_message":"Key Budget: 15% Threshold Crossed","spend":0.0008594999999999998,"max_budget":0.001}
### 5% case: operator lowers the budget on a used key so about 4% remains, developer sends requests
warm-up requests 1..6 -> HTTP 200
spend so far 0.00317425, setting max_budget to 0.00330651
{"key_alias":"lit6959-before-5pct","max_budget":0.00330651}
request 1 -> HTTP 200, Slack alert so far: yes
Slack DM, messages for lit6959-before-5pct:
[Num Alerts: 2] | Alert type: `budget_alerts` | Level: `High` | Timestamp: `03:02:19` | Message: Key Budget: 5% Threshold Crossed | *spend:* `0.00317425` | *max_budget:* `0.00330651` | *key_alias:* `lit6959-before-5pct` | *event_group:* `key` | Proxy URL: `<http://localhost:4000>`
WEBHOOK_URL receiver, events for lit6959-before-5pct:
{"event":"threshold_crossed","event_message":"Key Budget: 5% Threshold Crossed ","spend":0.00317425,"max_budget":0.00330651}
{"event":"threshold_crossed","event_message":"Key Budget: 5% Threshold Crossed ","spend":0.00317425,"max_budget":0.00330651}
```

The 15% alert as the operator sees it in Slack:

![pr39102-e0ebcb79fc-slack-before-15pct.png](https://github.com/mateo-berri/qa-screenshots/releases/download/assets/pr39102-e0ebcb79fc-slack-before-15pct.png)

### After (e0ebcb79fc)

```
### 15% case: operator creates a key with max_budget 0.001, developer sends requests until the alert arrives
requests 1..47 -> HTTP 200, no alert yet
request 48 -> HTTP 200, Slack alert so far: yes
key spend when the alert arrived:
{"key_alias":"lit6959-after-15pct","spend":0.0009167999999999997,"max_budget":0.001}
Slack DM, messages for lit6959-after-15pct:
Alert type: `budget_alerts` | Level: `High` | Timestamp: `02:59:34` | Message: Key Budget: 15% or less of budget remaining | *spend:* `0.0008594999999999997` | *max_budget:* `0.001` | *key_alias:* `lit6959-after-15pct` | *event_group:* `key` | Proxy URL: `<http://localhost:4000>`
WEBHOOK_URL receiver, events for lit6959-after-15pct:
{"event":"threshold_crossed","event_message":"Key Budget: 15% or less of budget remaining","spend":0.0008594999999999997,"max_budget":0.001}
### 5% case: operator lowers the budget on a used key so about 4% remains, developer sends requests
warm-up requests 1..6 -> HTTP 200
spend so far 0.0031255, setting max_budget to 0.00325573
{"key_alias":"lit6959-after-5pct","max_budget":0.00325573}
request 1 -> HTTP 200, Slack alert so far: none
request 2 -> HTTP 200, Slack alert so far: yes
Slack DM, messages for lit6959-after-5pct:
[Num Alerts: 2] | Alert type: `budget_alerts` | Level: `High` | Timestamp: `03:01:21` | Message: Key Budget: 5% or less of budget remaining | *spend:* `0.0031255` | *max_budget:* `0.00325573` | *key_alias:* `lit6959-after-5pct` | *event_group:* `key` | Proxy URL: `<http://localhost:4000>`
WEBHOOK_URL receiver, events for lit6959-after-5pct:
{"event":"threshold_crossed","event_message":"Key Budget: 5% or less of budget remaining","spend":0.0031255,"max_budget":0.00325573}
{"event":"threshold_crossed","event_message":"Key Budget: 5% or less of budget remaining","spend":0.0031255,"max_budget":0.00325573}
{"event":"threshold_crossed","event_message":"Key Budget: 5% or less of budget remaining","spend":0.0031255,"max_budget":0.00325573}
```

The 15% alert as the operator sees it in Slack:

![pr39102-e0ebcb79fc-slack-after-15pct.png](https://github.com/mateo-berri/qa-screenshots/releases/download/assets/pr39102-e0ebcb79fc-slack-after-15pct.png)

Not run: the email surface (`alerting: ["email"]`, subject `LiteLLM: {event_message}`, no SMTP available locally) and MS Teams. Both format the same `event_message` string the Slack and webhook outputs above show

Observed on both legs, none caused by this PR:

- Alerts repeat 2-3 times across two workers; pre-existing, unchanged
- Before 5% webhook text has a trailing space; PR removes it
- Proxy URL reads localhost:4000 on any port; unchanged
- Slack groups alerts under a [Num Alerts: N] header; unchanged

## Type

🐛 Bug Fix

## Caveats (if any)

### Low

- Consumers that match the old `event_message` text must update
  - the documented discriminator `event: threshold_crossed` is unchanged
  - the before 5% text carried a trailing space, gone now
- Email subject and MS Teams text not driven, no SMTP or Teams webhook here
  - both format the same `event_message` the webhook JSON above shows, never parse it
  - if wrong, those channels keep the old wording, nothing breaks
- CircleCI does not build fork heads, so its alerting suite never ran on this PR
  - `tests/logging_callback_tests/test_alerting.py` run locally at the tip: 20 passed
  - no test outside this PR asserts the changed text

## Live PR risk (e0ebcb79fc)

Verdict: nothing breaks; one backward incompatible text change, which is what the PR ships. Both legs above ran the same topology (one proxy, `--num_workers 2`, fresh Postgres, no Redis, gpt-5.4-nano through OpenAI, a real Slack webhook read back through the Slack API, a local recorder on `WEBHOOK_URL`) and differ only in the message text. Status, key spend, `event`, `event_group`, `spend`, and `max_budget` match on both sides

Breaking: none observed

Backward incompatible: `event_message` in the budget webhook JSON, the Slack and MS Teams text, and the SMTP subject `LiteLLM: {event_message}` change from `<group> Budget: 15% Threshold Crossed` and `<group> Budget: 5% Threshold Crossed ` to `<group> Budget: 15% or less of budget remaining` and `<group> Budget: 5% or less of budget remaining`. A consumer that matches the old string stops matching; docs/proxy/alerting.md calls `event_message` the human-readable description and keeps `event` as the discriminator. Shipped as the purpose of this PR, approved by mateo-berri in the merging review

Regression risk: none reachable through the proxy that was not driven. The dedupe key `budget_alerts:{event}:{_id}` carries no text, so alert count and timing cannot move with this change; the 2-3 duplicate alerts seen on both legs predate the PR and are tracked in LIT-8168

Dependency graph: `_get_event_and_event_message` (unit-tested in `test_slack_alerting.py`) -> `budget_alerts` (dedupe, unchanged) -> `send_alert` -> webhook JSON (verified live), Slack text (verified live), MS Teams text (untested, unreachable here), SMTP email subject `LiteLLM: {event_message}` via `send_email_alert_using_smtp` and `send_team_budget_alert` (untested, unreachable here); MS Teams puts the same Slack `formatted_message` into an Adaptive Card TextBlock. The 16 `budget_alerts` call sites in auth_checks, user_api_key_auth, proxy_server, utils, and the health endpoint pass `type` and `user_info` only. The enterprise email budget alerts in `base_email.py` build their own text and are untouched. Nothing in the dashboard, the proxy client, or the DB reads `event_message`; the other `Threshold Crossed` strings in the tree are the daily and monthly user spend alerts in `user_spend_alerts.py`, untouched. The legacy suites that reach `budget_alerts` never assert on this text: `tests/proxy_unit_tests` checks `ExceededBudget:` errors, and `tests/logging_callback_tests/test_alerting.py` (budget, webhook, and send_alert cases) passed locally at the tip, 20 passed, since CircleCI does not build fork heads. An independent sweep by a second agent over the same reference kinds (string dispatch, subclass overrides, Pydantic fields, dashboard, cache keys, Prisma schema, docs) found no consumer beyond these. `main` has not moved since the merge base, so the merged tree is the tip

Not verified: email delivery (`alerting: ["email"]`, no SMTP available locally) and MS Teams delivery (`alerting: ["ms_teams"]`, no Teams webhook available) of the new text

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

- [x] e0ebcb79fc49415135bf9e8ff6bb5f75195c5170 passes /live-pr-risk
