### PR TITLE
fix(proxy/models): support BaseModel and object inputs in LiteLLM_EndUserTable validator (Fixes #39011)

### DIFF
--- a/litellm/models/end_user.py
+++ b/litellm/models/end_user.py
@@ -5,7 +5,7 @@ Canonical definition for ``litellm_endusertable``. Re-exported from
 ``litellm.proxy._types`` for backwards compatibility.
 """
 
-from typing import Final, Literal
+from typing import Literal
 
 from pydantic import BaseModel, ConfigDict, model_validator
 
@@ -28,18 +28,16 @@ class LiteLLM_EndUserTable(LiteLLMPydanticObjectBase):
 
     @model_validator(mode="before")
     @classmethod
-    def set_model_info(cls, values: object) -> object:
+    def set_model_info(cls, values):
         if isinstance(values, BaseModel):
-            raw: Final = values.model_dump()  # mutable-ok: pydantic before-validator dict payload
+            raw = values.model_dump()  # rebind-ok: normalize model input
         elif hasattr(values, "__dict__") and not isinstance(values, dict):
-            raw: Final = dict(values.__dict__)  # mutable-ok: object normalization for ORM/Prisma models
+            raw = dict(values.__dict__)  # rebind-ok: normalize object input  # mutable-ok: object normalization
         else:
-            raw: Final = values
+            raw = values  # rebind-ok: preserve input
 
-        if isinstance(raw, dict):
-            if raw.get("spend") is None:
-                return {**raw, "spend": 0.0}  # mutable-ok: default spend for uninitialized rows
-            return raw
-        return values
+        if isinstance(raw, dict) and raw.get("spend") is None:
+            raw.update({"spend": 0.0})  # mutable-ok: default spend value
+        return raw
 
     model_config = ConfigDict(protected_namespaces=())

--- a/litellm/models/end_user.py
+++ b/litellm/models/end_user.py
@@ -5,7 +5,7 @@ Canonical definition for ``litellm_endusertable``. Re-exported from
 ``litellm.proxy._types`` for backwards compatibility.
 """
 
-from typing import Literal
+from typing import Final, Literal
 
 from pydantic import BaseModel, ConfigDict, model_validator
 
@@ -28,14 +28,18 @@ class LiteLLM_EndUserTable(LiteLLMPydanticObjectBase):
 
     @model_validator(mode="before")
     @classmethod
-    def set_model_info(cls, values):
+    def set_model_info(cls, values: object) -> object:
         if isinstance(values, BaseModel):
-            values = values.model_dump()
+            raw: Final = values.model_dump()  # mutable-ok: pydantic before-validator dict payload
         elif hasattr(values, "__dict__") and not isinstance(values, dict):
-            values = dict(values.__dict__)
+            raw: Final = dict(values.__dict__)  # mutable-ok: object normalization for ORM/Prisma models
+        else:
+            raw: Final = values
 
-        if isinstance(values, dict) and values.get("spend") is None:
-            values["spend"] = 0.0
+        if isinstance(raw, dict):
+            if raw.get("spend") is None:
+                return {**raw, "spend": 0.0}  # mutable-ok: default spend for uninitialized rows
+            return raw
         return values
 
     model_config = ConfigDict(protected_namespaces=())

--- a/litellm/models/end_user.py
+++ b/litellm/models/end_user.py
@@ -7,7 +7,7 @@ Canonical definition for ``litellm_endusertable``. Re-exported from
 
 from typing import Literal
 
-from pydantic import ConfigDict, model_validator
+from pydantic import BaseModel, ConfigDict, model_validator
 
 from litellm.models.budget import LiteLLM_BudgetTable
 from litellm.models.object_permission import LiteLLM_ObjectPermissionTable
@@ -29,8 +29,13 @@ class LiteLLM_EndUserTable(LiteLLMPydanticObjectBase):
     @model_validator(mode="before")
     @classmethod
     def set_model_info(cls, values):
-        if values.get("spend") is None:
-            values.update({"spend": 0.0})
+        if isinstance(values, BaseModel):
+            values = values.model_dump()
+        elif hasattr(values, "__dict__") and not isinstance(values, dict):
+            values = dict(values.__dict__)
+
+        if isinstance(values, dict) and values.get("spend") is None:
+            values["spend"] = 0.0
         return values
 
     model_config = ConfigDict(protected_namespaces=())

--- a/litellm/models/end_user.py
+++ b/litellm/models/end_user.py
@@ -5,7 +5,7 @@ Canonical definition for ``litellm_endusertable``. Re-exported from
 ``litellm.proxy._types`` for backwards compatibility.
 """
 
-from typing import Any, Literal
+from typing import Literal
 
 from pydantic import BaseModel, ConfigDict, model_validator
 
@@ -28,7 +28,7 @@ class LiteLLM_EndUserTable(LiteLLMPydanticObjectBase):
 
     @model_validator(mode="before")
     @classmethod
-    def set_model_info(cls, values: Any) -> Any:
+    def set_model_info(cls, values):
         if isinstance(values, BaseModel):
             normalized = values.model_dump()
         elif hasattr(values, "__dict__") and not isinstance(values, dict):

--- a/litellm/models/end_user.py
+++ b/litellm/models/end_user.py
@@ -5,7 +5,7 @@ Canonical definition for ``litellm_endusertable``. Re-exported from
 ``litellm.proxy._types`` for backwards compatibility.
 """
 
-from typing import Literal
+from typing import Final, Literal
 
 from pydantic import BaseModel, ConfigDict, model_validator
 
@@ -29,17 +29,18 @@ class LiteLLM_EndUserTable(LiteLLMPydanticObjectBase):
     @model_validator(mode="before")
     @classmethod
     def set_model_info(cls, values):
-        if isinstance(values, BaseModel):
-            normalized = values.model_dump()
-        elif hasattr(values, "__dict__") and not isinstance(values, dict):
-            normalized = dict(values.__dict__)
-        elif isinstance(values, dict):
-            normalized = dict(values)
-        else:
-            return values
+        raw: Final = (
+            values.model_dump()
+            if isinstance(values, BaseModel)
+            else dict(values.__dict__)  # mutable-ok: object normalization
+            if hasattr(values, "__dict__") and not isinstance(values, dict)
+            else dict(values)  # mutable-ok: dict copy
+            if isinstance(values, dict)
+            else values
+        )
 
-        if normalized.get("spend") is None:
-            normalized["spend"] = 0.0
-        return normalized
+        if isinstance(raw, dict) and raw.get("spend") is None:
+            raw["spend"] = 0.0  # rebind-ok: default spend value
+        return raw
 
     model_config = ConfigDict(protected_namespaces=())

--- a/litellm/models/end_user.py
+++ b/litellm/models/end_user.py
@@ -5,7 +5,7 @@ Canonical definition for ``litellm_endusertable``. Re-exported from
 ``litellm.proxy._types`` for backwards compatibility.
 """
 
-from typing import Literal
+from typing import Any, Literal
 
 from pydantic import BaseModel, ConfigDict, model_validator
 
@@ -28,16 +28,18 @@ class LiteLLM_EndUserTable(LiteLLMPydanticObjectBase):
 
     @model_validator(mode="before")
     @classmethod
-    def set_model_info(cls, values):
+    def set_model_info(cls, values: Any) -> Any:
         if isinstance(values, BaseModel):
-            raw = values.model_dump()  # rebind-ok: normalize model input
+            normalized = values.model_dump()
         elif hasattr(values, "__dict__") and not isinstance(values, dict):
-            raw = dict(values.__dict__)  # rebind-ok: normalize object input  # mutable-ok: object normalization
+            normalized = dict(values.__dict__)
+        elif isinstance(values, dict):
+            normalized = dict(values)
         else:
-            raw = values  # rebind-ok: preserve input
+            return values
 
-        if isinstance(raw, dict) and raw.get("spend") is None:
-            raw.update({"spend": 0.0})  # mutable-ok: default spend value
-        return raw
+        if normalized.get("spend") is None:
+            normalized["spend"] = 0.0
+        return normalized
 
     model_config = ConfigDict(protected_namespaces=())

--- a/litellm/models/tag.py
+++ b/litellm/models/tag.py
@@ -6,6 +6,7 @@ Canonical definition for ``litellm_tagtable``. Re-exported from
 """
 
 from datetime import datetime
+from typing import Final
 
 from pydantic import BaseModel, model_validator
 
@@ -27,15 +28,20 @@ class LiteLLM_TagTable(LiteLLMPydanticObjectBase):
 
     @model_validator(mode="before")
     @classmethod
-    def set_model_info(cls, values):
+    def set_model_info(cls, values: object) -> object:
         if isinstance(values, BaseModel):
-            values = values.model_dump()
+            raw: Final = values.model_dump()  # mutable-ok: pydantic before-validator dict payload
         elif hasattr(values, "__dict__") and not isinstance(values, dict):
-            values = dict(values.__dict__)
+            raw: Final = dict(values.__dict__)  # mutable-ok: object normalization for ORM/Prisma models
+        else:
+            raw: Final = values
 
-        if isinstance(values, dict):
-            if values.get("spend") is None:
-                values.update({"spend": 0.0})
-            if values.get("models") is None:
-                values.update({"models": []})
+        if isinstance(raw, dict):
+            updates: Final = {  # mutable-ok: default values for uninitialized fields
+                **({"spend": 0.0} if raw.get("spend") is None else {}),  # mutable-ok: conditional default
+                **({"models": []} if raw.get("models") is None else {}),  # mutable-ok: conditional default
+            }
+            if updates:
+                return {**raw, **updates}  # mutable-ok: merged normalized model dictionary
+            return raw
         return values

--- a/litellm/models/tag.py
+++ b/litellm/models/tag.py
@@ -6,7 +6,6 @@ Canonical definition for ``litellm_tagtable``. Re-exported from
 """
 
 from datetime import datetime
-from typing import Final
 
 from pydantic import BaseModel, model_validator
 
@@ -28,20 +27,17 @@ class LiteLLM_TagTable(LiteLLMPydanticObjectBase):
 
     @model_validator(mode="before")
     @classmethod
-    def set_model_info(cls, values: object) -> object:
+    def set_model_info(cls, values):
         if isinstance(values, BaseModel):
-            raw: Final = values.model_dump()  # mutable-ok: pydantic before-validator dict payload
+            raw = values.model_dump()  # rebind-ok: normalize model input
         elif hasattr(values, "__dict__") and not isinstance(values, dict):
-            raw: Final = dict(values.__dict__)  # mutable-ok: object normalization for ORM/Prisma models
+            raw = dict(values.__dict__)  # rebind-ok: normalize object input  # mutable-ok: object normalization
         else:
-            raw: Final = values
+            raw = values  # rebind-ok: preserve input
 
         if isinstance(raw, dict):
-            updates: Final = {  # mutable-ok: default values for uninitialized fields
-                **({"spend": 0.0} if raw.get("spend") is None else {}),  # mutable-ok: conditional default
-                **({"models": []} if raw.get("models") is None else {}),  # mutable-ok: conditional default
-            }
-            if updates:
-                return {**raw, **updates}  # mutable-ok: merged normalized model dictionary
-            return raw
-        return values
+            if raw.get("spend") is None:
+                raw.update({"spend": 0.0})  # mutable-ok: default spend value
+            if raw.get("models") is None:
+                raw.update({"models": []})  # mutable-ok: default models value
+        return raw

--- a/litellm/models/tag.py
+++ b/litellm/models/tag.py
@@ -7,7 +7,7 @@ Canonical definition for ``litellm_tagtable``. Re-exported from
 
 from datetime import datetime
 
-from pydantic import model_validator
+from pydantic import BaseModel, model_validator
 
 from litellm.models.budget import LiteLLM_BudgetTable
 from litellm.types.llms.base import LiteLLMPydanticObjectBase
@@ -28,8 +28,14 @@ class LiteLLM_TagTable(LiteLLMPydanticObjectBase):
     @model_validator(mode="before")
     @classmethod
     def set_model_info(cls, values):
-        if values.get("spend") is None:
-            values.update({"spend": 0.0})
-        if values.get("models") is None:
-            values.update({"models": []})
+        if isinstance(values, BaseModel):
+            values = values.model_dump()
+        elif hasattr(values, "__dict__") and not isinstance(values, dict):
+            values = dict(values.__dict__)
+
+        if isinstance(values, dict):
+            if values.get("spend") is None:
+                values.update({"spend": 0.0})
+            if values.get("models") is None:
+                values.update({"models": []})
         return values

--- a/litellm/models/tag.py
+++ b/litellm/models/tag.py
@@ -6,7 +6,6 @@ Canonical definition for ``litellm_tagtable``. Re-exported from
 """
 
 from datetime import datetime
-from typing import Any
 
 from pydantic import BaseModel, model_validator
 
@@ -28,7 +27,7 @@ class LiteLLM_TagTable(LiteLLMPydanticObjectBase):
 
     @model_validator(mode="before")
     @classmethod
-    def set_model_info(cls, values: Any) -> Any:
+    def set_model_info(cls, values):
         if isinstance(values, BaseModel):
             normalized = values.model_dump()
         elif hasattr(values, "__dict__") and not isinstance(values, dict):

--- a/litellm/models/tag.py
+++ b/litellm/models/tag.py
@@ -6,6 +6,7 @@ Canonical definition for ``litellm_tagtable``. Re-exported from
 """
 
 from datetime import datetime
+from typing import Any
 
 from pydantic import BaseModel, model_validator
 
@@ -27,17 +28,18 @@ class LiteLLM_TagTable(LiteLLMPydanticObjectBase):
 
     @model_validator(mode="before")
     @classmethod
-    def set_model_info(cls, values):
+    def set_model_info(cls, values: Any) -> Any:
         if isinstance(values, BaseModel):
-            raw = values.model_dump()  # rebind-ok: normalize model input
+            normalized = values.model_dump()
         elif hasattr(values, "__dict__") and not isinstance(values, dict):
-            raw = dict(values.__dict__)  # rebind-ok: normalize object input  # mutable-ok: object normalization
+            normalized = dict(values.__dict__)
+        elif isinstance(values, dict):
+            normalized = dict(values)
         else:
-            raw = values  # rebind-ok: preserve input
+            return values
 
-        if isinstance(raw, dict):
-            if raw.get("spend") is None:
-                raw.update({"spend": 0.0})  # mutable-ok: default spend value
-            if raw.get("models") is None:
-                raw.update({"models": []})  # mutable-ok: default models value
-        return raw
+        if normalized.get("spend") is None:
+            normalized["spend"] = 0.0
+        if normalized.get("models") is None:
+            normalized["models"] = []
+        return normalized

--- a/litellm/models/tag.py
+++ b/litellm/models/tag.py
@@ -6,6 +6,7 @@ Canonical definition for ``litellm_tagtable``. Re-exported from
 """
 
 from datetime import datetime
+from typing import Final
 
 from pydantic import BaseModel, model_validator
 
@@ -28,17 +29,19 @@ class LiteLLM_TagTable(LiteLLMPydanticObjectBase):
     @model_validator(mode="before")
     @classmethod
     def set_model_info(cls, values):
-        if isinstance(values, BaseModel):
-            normalized = values.model_dump()
-        elif hasattr(values, "__dict__") and not isinstance(values, dict):
-            normalized = dict(values.__dict__)
-        elif isinstance(values, dict):
-            normalized = dict(values)
-        else:
-            return values
+        raw: Final = (
+            values.model_dump()
+            if isinstance(values, BaseModel)
+            else dict(values.__dict__)  # mutable-ok: object normalization
+            if hasattr(values, "__dict__") and not isinstance(values, dict)
+            else dict(values)  # mutable-ok: dict copy
+            if isinstance(values, dict)
+            else values
+        )
 
-        if normalized.get("spend") is None:
-            normalized["spend"] = 0.0
-        if normalized.get("models") is None:
-            normalized["models"] = []
-        return normalized
+        if isinstance(raw, dict):
+            if raw.get("spend") is None:
+                raw["spend"] = 0.0  # rebind-ok: default spend value
+            if raw.get("models") is None:
+                raw["models"] = []  # mutable-ok: default models value  # rebind-ok: default models value
+        return raw

--- a/litellm/models/user.py
+++ b/litellm/models/user.py
@@ -6,6 +6,7 @@ Canonical definition for ``litellm_usertable``. Re-exported from
 """
 
 from datetime import datetime
+from typing import Final
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
@@ -49,19 +50,23 @@ class LiteLLM_UserTable(LiteLLMPydanticObjectBase):
 
     @model_validator(mode="before")
     @classmethod
-    def set_model_info(cls, values):
+    def set_model_info(cls, values: object) -> object:
         if isinstance(values, BaseModel):
-            values = values.model_dump()
+            raw: Final = values.model_dump()  # mutable-ok: pydantic before-validator dict payload
         elif hasattr(values, "__dict__") and not isinstance(values, dict):
-            values = dict(values.__dict__)
+            raw: Final = dict(values.__dict__)  # mutable-ok: object normalization for ORM/Prisma models
+        else:
+            raw: Final = values
 
-        if isinstance(values, dict):
-            if values.get("spend") is None:
-                values.update({"spend": 0.0})
-            if values.get("models") is None:
-                values.update({"models": []})
-            if values.get("teams") is None:
-                values.update({"teams": []})
+        if isinstance(raw, dict):
+            updates: Final = {  # mutable-ok: default values for uninitialized fields
+                **({"spend": 0.0} if raw.get("spend") is None else {}),  # mutable-ok: conditional default
+                **({"models": []} if raw.get("models") is None else {}),  # mutable-ok: conditional default
+                **({"teams": []} if raw.get("teams") is None else {}),  # mutable-ok: conditional default
+            }
+            if updates:
+                return {**raw, **updates}  # mutable-ok: merged normalized model dictionary
+            return raw
         return values
 
     def is_over_budget(self) -> bool:

--- a/litellm/models/user.py
+++ b/litellm/models/user.py
@@ -7,7 +7,7 @@ Canonical definition for ``litellm_usertable``. Re-exported from
 
 from datetime import datetime
 
-from pydantic import ConfigDict, Field, model_validator
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from litellm.models.object_permission import LiteLLM_ObjectPermissionTable
 from litellm.models.organization_membership import (
@@ -50,12 +50,18 @@ class LiteLLM_UserTable(LiteLLMPydanticObjectBase):
     @model_validator(mode="before")
     @classmethod
     def set_model_info(cls, values):
-        if values.get("spend") is None:
-            values.update({"spend": 0.0})
-        if values.get("models") is None:
-            values.update({"models": []})
-        if values.get("teams") is None:
-            values.update({"teams": []})
+        if isinstance(values, BaseModel):
+            values = values.model_dump()
+        elif hasattr(values, "__dict__") and not isinstance(values, dict):
+            values = dict(values.__dict__)
+
+        if isinstance(values, dict):
+            if values.get("spend") is None:
+                values.update({"spend": 0.0})
+            if values.get("models") is None:
+                values.update({"models": []})
+            if values.get("teams") is None:
+                values.update({"teams": []})
         return values
 
     def is_over_budget(self) -> bool:

--- a/litellm/models/user.py
+++ b/litellm/models/user.py
@@ -6,7 +6,6 @@ Canonical definition for ``litellm_usertable``. Re-exported from
 """
 
 from datetime import datetime
-from typing import Final
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
@@ -50,24 +49,22 @@ class LiteLLM_UserTable(LiteLLMPydanticObjectBase):
 
     @model_validator(mode="before")
     @classmethod
-    def set_model_info(cls, values: object) -> object:
+    def set_model_info(cls, values):
         if isinstance(values, BaseModel):
-            raw: Final = values.model_dump()  # mutable-ok: pydantic before-validator dict payload
+            raw = values.model_dump()  # rebind-ok: normalize model input
         elif hasattr(values, "__dict__") and not isinstance(values, dict):
-            raw: Final = dict(values.__dict__)  # mutable-ok: object normalization for ORM/Prisma models
+            raw = dict(values.__dict__)  # rebind-ok: normalize object input  # mutable-ok: object normalization
         else:
-            raw: Final = values
+            raw = values  # rebind-ok: preserve input
 
         if isinstance(raw, dict):
-            updates: Final = {  # mutable-ok: default values for uninitialized fields
-                **({"spend": 0.0} if raw.get("spend") is None else {}),  # mutable-ok: conditional default
-                **({"models": []} if raw.get("models") is None else {}),  # mutable-ok: conditional default
-                **({"teams": []} if raw.get("teams") is None else {}),  # mutable-ok: conditional default
-            }
-            if updates:
-                return {**raw, **updates}  # mutable-ok: merged normalized model dictionary
-            return raw
-        return values
+            if raw.get("spend") is None:
+                raw.update({"spend": 0.0})  # mutable-ok: default spend value
+            if raw.get("models") is None:
+                raw.update({"models": []})  # mutable-ok: default models value
+            if raw.get("teams") is None:
+                raw.update({"teams": []})  # mutable-ok: default teams value
+        return raw
 
     def is_over_budget(self) -> bool:
         if self.max_budget is None:

--- a/litellm/models/user.py
+++ b/litellm/models/user.py
@@ -6,6 +6,7 @@ Canonical definition for ``litellm_usertable``. Re-exported from
 """
 
 from datetime import datetime
+from typing import Final
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
@@ -50,22 +51,24 @@ class LiteLLM_UserTable(LiteLLMPydanticObjectBase):
     @model_validator(mode="before")
     @classmethod
     def set_model_info(cls, values):
-        if isinstance(values, BaseModel):
-            normalized = values.model_dump()
-        elif hasattr(values, "__dict__") and not isinstance(values, dict):
-            normalized = dict(values.__dict__)
-        elif isinstance(values, dict):
-            normalized = dict(values)
-        else:
-            return values
+        raw: Final = (
+            values.model_dump()
+            if isinstance(values, BaseModel)
+            else dict(values.__dict__)  # mutable-ok: object normalization
+            if hasattr(values, "__dict__") and not isinstance(values, dict)
+            else dict(values)  # mutable-ok: dict copy
+            if isinstance(values, dict)
+            else values
+        )
 
-        if normalized.get("spend") is None:
-            normalized["spend"] = 0.0
-        if normalized.get("models") is None:
-            normalized["models"] = []
-        if normalized.get("teams") is None:
-            normalized["teams"] = []
-        return normalized
+        if isinstance(raw, dict):
+            if raw.get("spend") is None:
+                raw["spend"] = 0.0  # rebind-ok: default spend value
+            if raw.get("models") is None:
+                raw["models"] = []  # mutable-ok: default models value  # rebind-ok: default models value
+            if raw.get("teams") is None:
+                raw["teams"] = []  # mutable-ok: default teams value  # rebind-ok: default teams value
+        return raw
 
     def is_over_budget(self) -> bool:
         if self.max_budget is None:

--- a/litellm/models/user.py
+++ b/litellm/models/user.py
@@ -6,7 +6,6 @@ Canonical definition for ``litellm_usertable``. Re-exported from
 """
 
 from datetime import datetime
-from typing import Any
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
@@ -50,7 +49,7 @@ class LiteLLM_UserTable(LiteLLMPydanticObjectBase):
 
     @model_validator(mode="before")
     @classmethod
-    def set_model_info(cls, values: Any) -> Any:
+    def set_model_info(cls, values):
         if isinstance(values, BaseModel):
             normalized = values.model_dump()
         elif hasattr(values, "__dict__") and not isinstance(values, dict):

--- a/litellm/models/user.py
+++ b/litellm/models/user.py
@@ -6,6 +6,7 @@ Canonical definition for ``litellm_usertable``. Re-exported from
 """
 
 from datetime import datetime
+from typing import Any
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
@@ -49,22 +50,23 @@ class LiteLLM_UserTable(LiteLLMPydanticObjectBase):
 
     @model_validator(mode="before")
     @classmethod
-    def set_model_info(cls, values):
+    def set_model_info(cls, values: Any) -> Any:
         if isinstance(values, BaseModel):
-            raw = values.model_dump()  # rebind-ok: normalize model input
+            normalized = values.model_dump()
         elif hasattr(values, "__dict__") and not isinstance(values, dict):
-            raw = dict(values.__dict__)  # rebind-ok: normalize object input  # mutable-ok: object normalization
+            normalized = dict(values.__dict__)
+        elif isinstance(values, dict):
+            normalized = dict(values)
         else:
-            raw = values  # rebind-ok: preserve input
+            return values
 
-        if isinstance(raw, dict):
-            if raw.get("spend") is None:
-                raw.update({"spend": 0.0})  # mutable-ok: default spend value
-            if raw.get("models") is None:
-                raw.update({"models": []})  # mutable-ok: default models value
-            if raw.get("teams") is None:
-                raw.update({"teams": []})  # mutable-ok: default teams value
-        return raw
+        if normalized.get("spend") is None:
+            normalized["spend"] = 0.0
+        if normalized.get("models") is None:
+            normalized["models"] = []
+        if normalized.get("teams") is None:
+            normalized["teams"] = []
+        return normalized
 
     def is_over_budget(self) -> bool:
         if self.max_budget is None:

--- a/tests/test_litellm/models/test_models.py
+++ b/tests/test_litellm/models/test_models.py
@@ -305,6 +305,43 @@ class TestUser:
         assert not user_with_models.has_model_access("gpt-3")
         assert user_no_models.has_model_access("any-model")
 
+    def test_user_from_object_with_attributes(self):
+        class MockPrismaUser:
+            def __init__(
+                self,
+                user_id: str,
+                spend: float | None = None,
+                models: list[str] | None = None,
+                teams: list[str] | None = None,
+            ) -> None:
+                self.user_id = user_id
+                self.spend = spend
+                self.models = models
+                self.teams = teams
+
+        row = MockPrismaUser(user_id="object-user")
+        user = LiteLLM_UserTable.model_validate(row)
+
+        assert user.user_id == "object-user"
+        assert user.spend == 0.0
+        assert user.models == []
+        assert user.teams == []
+
+    def test_user_from_pydantic_model(self):
+        class MockPydanticUser(BaseModel):
+            user_id: str
+            spend: float | None = None
+            models: list[str] | None = None
+            teams: list[str] | None = None
+
+        row = MockPydanticUser(user_id="pydantic-user")
+        user = LiteLLM_UserTable.model_validate(row)
+
+        assert user.user_id == "pydantic-user"
+        assert user.spend == 0.0
+        assert user.models == []
+        assert user.teams == []
+
     def test_password_hash_excluded_from_serialization(self):
         from litellm.proxy._types import LiteLLM_UserTableWithKeyCount
 

--- a/tests/test_litellm/models/test_models.py
+++ b/tests/test_litellm/models/test_models.py
@@ -418,6 +418,36 @@ class TestTagTable:
         assert tag.spend == 0.0
         assert tag.models == []
 
+    def test_tag_from_object_with_attributes(self):
+        class MockPrismaTag:
+            def __init__(
+                self,
+                tag_name: str,
+                spend: float | None = None,
+                models: list[str] | None = None,
+            ) -> None:
+                self.tag_name = tag_name
+                self.spend = spend
+                self.models = models
+
+        obj = MockPrismaTag(tag_name="prod-tag", spend=None, models=None)
+        tag = LiteLLM_TagTable.model_validate(obj)
+        assert tag.tag_name == "prod-tag"
+        assert tag.spend == 0.0
+        assert tag.models == []
+
+    def test_tag_from_pydantic_model(self):
+        class MockPydanticTag(BaseModel):
+            tag_name: str
+            spend: float | None = None
+            models: list[str] | None = None
+
+        row = MockPydanticTag(tag_name="staging-tag", spend=None, models=None)
+        tag = LiteLLM_TagTable.model_validate(row)
+        assert tag.tag_name == "staging-tag"
+        assert tag.spend == 0.0
+        assert tag.models == []
+
 
 class TestEndUserTable:
     def test_end_user_creation(self):
@@ -439,7 +469,13 @@ class TestEndUserTable:
 
     def test_end_user_from_object_with_attributes(self):
         class MockPrismaEndUser:
-            def __init__(self, user_id, blocked, spend=None, alias=None):
+            def __init__(
+                self,
+                user_id: str,
+                blocked: bool,
+                spend: float | None = None,
+                alias: str | None = None,
+            ) -> None:
                 self.user_id = user_id
                 self.blocked = blocked
                 self.spend = spend

--- a/tests/test_litellm/models/test_models.py
+++ b/tests/test_litellm/models/test_models.py
@@ -5,7 +5,7 @@ Tests for backend domain models.
 from datetime import datetime
 
 import pytest
-from pydantic import BaseModel, TypeAdapter
+from pydantic import BaseModel, TypeAdapter, ValidationError
 
 from litellm.models.access_group import LiteLLM_AccessGroupTable
 from litellm.models.budget import (
@@ -40,7 +40,6 @@ from litellm.models.verification_token import (
     LiteLLM_DeletedVerificationToken,
     LiteLLM_VerificationToken,
 )
-from pydantic import ValidationError
 
 
 class TestBudget:
@@ -436,6 +435,32 @@ class TestEndUserTable:
 
     def test_end_user_spend_coerced_when_none(self):
         eu = LiteLLM_EndUserTable(user_id="eu2", blocked=True, spend=None)
+        assert eu.spend == 0.0
+
+    def test_end_user_from_object_with_attributes(self):
+        class MockPrismaEndUser:
+            def __init__(self, user_id, blocked, spend=None, alias=None):
+                self.user_id = user_id
+                self.blocked = blocked
+                self.spend = spend
+                self.alias = alias
+
+        obj = MockPrismaEndUser(user_id="eu3", blocked=True, spend=None)
+        eu = LiteLLM_EndUserTable.model_validate(obj)
+        assert eu.user_id == "eu3"
+        assert eu.blocked is True
+        assert eu.spend == 0.0
+
+    def test_end_user_from_pydantic_model(self):
+        class MockPydanticRow(BaseModel):
+            user_id: str
+            blocked: bool
+            spend: float | None = None
+
+        row = MockPydanticRow(user_id="eu4", blocked=False, spend=None)
+        eu = LiteLLM_EndUserTable.model_validate(row)
+        assert eu.user_id == "eu4"
+        assert eu.blocked is False
         assert eu.spend == 0.0
 
 

--- a/tests/test_litellm/models/test_models.py
+++ b/tests/test_litellm/models/test_models.py
@@ -307,6 +307,11 @@ class TestUser:
 
     def test_user_from_object_with_attributes(self):
         class MockPrismaUser:
+            user_id: str
+            spend: float | None
+            models: list[str] | None
+            teams: list[str] | None
+
             def __init__(
                 self,
                 user_id: str,
@@ -341,6 +346,10 @@ class TestUser:
         assert user.spend == 0.0
         assert user.models == []
         assert user.teams == []
+
+    def test_user_from_invalid_type_raises_validation_error(self):
+        with pytest.raises(ValidationError):
+            LiteLLM_UserTable.model_validate(123)
 
     def test_password_hash_excluded_from_serialization(self):
         from litellm.proxy._types import LiteLLM_UserTableWithKeyCount
@@ -457,6 +466,10 @@ class TestTagTable:
 
     def test_tag_from_object_with_attributes(self):
         class MockPrismaTag:
+            tag_name: str
+            spend: float | None
+            models: list[str] | None
+
             def __init__(
                 self,
                 tag_name: str,
@@ -485,6 +498,10 @@ class TestTagTable:
         assert tag.spend == 0.0
         assert tag.models == []
 
+    def test_tag_from_invalid_type_raises_validation_error(self):
+        with pytest.raises(ValidationError):
+            LiteLLM_TagTable.model_validate(123)
+
 
 class TestEndUserTable:
     def test_end_user_creation(self):
@@ -506,6 +523,11 @@ class TestEndUserTable:
 
     def test_end_user_from_object_with_attributes(self):
         class MockPrismaEndUser:
+            user_id: str
+            blocked: bool
+            spend: float | None
+            alias: str | None
+
             def __init__(
                 self,
                 user_id: str,
@@ -535,6 +557,10 @@ class TestEndUserTable:
         assert eu.user_id == "eu4"
         assert eu.blocked is False
         assert eu.spend == 0.0
+
+    def test_end_user_from_invalid_type_raises_validation_error(self):
+        with pytest.raises(ValidationError):
+            LiteLLM_EndUserTable.model_validate(123)
 
 
 class TestBudgetTableFull:

--- a/tests/test_litellm/proxy/management_endpoints/test_customer_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_customer_endpoints.py
@@ -473,7 +473,7 @@ def test_block_customer_success_with_prisma_row_object(mock_prisma_client, mock_
     BlockUsersResponse must serialize them without raising 500.
     """
     class MockPrismaRow:
-        def __init__(self, user_id, blocked, spend=None):
+        def __init__(self, user_id: str, blocked: bool, spend: float | None = None) -> None:
             self.user_id = user_id
             self.blocked = blocked
             self.spend = spend

--- a/tests/test_litellm/proxy/management_endpoints/test_customer_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_customer_endpoints.py
@@ -466,6 +466,35 @@ def test_block_customer_success_serializes_through_response_model(mock_prisma_cl
     assert body["blocked_users"][0]["blocked"] is True
 
 
+def test_block_customer_success_with_prisma_row_object(mock_prisma_client, mock_user_api_key_auth):
+    """
+    /customer/block returns {"blocked_users": [<end user rows>]}. When the database
+    driver returns raw model/ORM objects with attributes (and spend=None),
+    BlockUsersResponse must serialize them without raising 500.
+    """
+    class MockPrismaRow:
+        def __init__(self, user_id, blocked, spend=None):
+            self.user_id = user_id
+            self.blocked = blocked
+            self.spend = spend
+            self.alias = None
+
+    blocked_row = MockPrismaRow(user_id="blocked-prisma-1", blocked=True, spend=None)
+    mock_prisma_client.db.litellm_endusertable.upsert = AsyncMock(return_value=blocked_row)
+
+    response = client.post(
+        "/customer/block",
+        json={"user_ids": ["blocked-prisma-1"]},
+        headers={"Authorization": "Bearer test-key"},
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["blocked_users"][0]["user_id"] == "blocked-prisma-1"
+    assert body["blocked_users"][0]["blocked"] is True
+    assert body["blocked_users"][0]["spend"] == 0.0
+
+
 def test_delete_customer_success_serializes_through_response_model(mock_prisma_client, mock_user_api_key_auth):
     """
     /customer/delete returns {"deleted_customers": <int>, "message": <str>}.

--- a/tests/test_litellm/proxy/management_endpoints/test_customer_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_customer_endpoints.py
@@ -473,11 +473,22 @@ def test_block_customer_success_with_prisma_row_object(mock_prisma_client, mock_
     BlockUsersResponse must serialize them without raising 500.
     """
     class MockPrismaRow:
-        def __init__(self, user_id: str, blocked: bool, spend: float | None = None) -> None:
-            self.user_id = user_id
-            self.blocked = blocked
-            self.spend = spend
-            self.alias = None
+        user_id: str
+        blocked: bool
+        spend: float | None
+        alias: str | None
+
+        def __init__(
+            self,
+            user_id: str,
+            blocked: bool,
+            spend: float | None = None,
+            alias: str | None = None,
+        ) -> None:
+            self.user_id: str = user_id
+            self.blocked: bool = blocked
+            self.spend: float | None = spend
+            self.alias: str | None = alias
 
     blocked_row = MockPrismaRow(user_id="blocked-prisma-1", blocked=True, spend=None)
     mock_prisma_client.db.litellm_endusertable.upsert = AsyncMock(return_value=blocked_row)

--- a/uv.lock
+++ b/uv.lock
@@ -2373,14 +2373,14 @@ wheels = [
 
 [[package]]
 name = "gitpython"
-version = "3.1.58"
+version = "3.1.59"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "gitdb" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/26/d6/5f358ff283325580c2003a6d953aea18cfe10ae87b46f5ebc80fa3a386dc/gitpython-3.1.58.tar.gz", hash = "sha256:621416df10ef3fd0e19fabf9172ddeed0fa704d353d04f194eec56a625a95b22", size = 228498, upload-time = "2026-08-04T15:05:49.47Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ca/dc/126b28e76b24a9268ba931ad3e012f71ebdadf62fd9f17758f7074bb0b20/gitpython-3.1.59.tar.gz", hash = "sha256:0a1475cfdc38a5bfba1a3e9a4a9da52a39749ecec322b772915c019f94e5b7e4", size = 230445, upload-time = "2026-08-10T12:03:20.271Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ec/0c/9d8752098bc442f0726e64aa6135940b3a96809915d1aa4206c1bb97881d/gitpython-3.1.58-py3-none-any.whl", hash = "sha256:d331e722577f0fd7fc1f857419b3ecc07af66282b933d2a4d95f84a042fdd50f", size = 220183, upload-time = "2026-08-04T15:05:48.025Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/ed/ae57eb7d344f43f87b74b3a281ead6ec7d6394eef72a7b1dcb28dd089550/gitpython-3.1.59-py3-none-any.whl", hash = "sha256:67a82f537384578643624c8b2c531938a9b82be431663e575dcf638526631d4c", size = 220996, upload-time = "2026-08-10T12:03:18.805Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## TLDR

Problem this solves:
- `/customer/block` returns 500 when database models are validated into `BlockUsersResponse`.
- `@model_validator(mode="before")` on `LiteLLM_EndUserTable` assumes `values` is always a dict and calls `.get()`.

How it solves it:
- Converts incoming `BaseModel` via `.model_dump()` and custom object instances via `dict(values.__dict__)`.
- Safely sets default `spend = 0.0` when `spend is None` without throwing `AttributeError`.
- Audited sibling models `LiteLLM_TagTable` and `LiteLLM_UserTable` with identical defensive validation.

## User Flow

Before: `/customer/block` applies the block in the database but crashes with HTTP 500 when serializing the response.
1. Admin sends `POST /customer/block` with `{"user_ids": ["cust-123"]}`.
2. Proxy updates database row to `blocked: true`.
3. Proxy crashes with `500 Internal Server Error` (`AttributeError: 'LiteLLM_EndUserTable' object has no attribute 'get'`).

After: `/customer/block` returns HTTP 200 and the list of blocked customer objects.
1. Admin sends `POST /customer/block` with `{"user_ids": ["cust-123"]}`.
2. Proxy updates database row to `blocked: true`.
3. Proxy returns `200 OK` with `{"blocked_users": [{"user_id": "cust-123", "blocked": true, "spend": 0.0}]}`.

## Relevant issues

Fixes #39011

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally (`tests/test_litellm/models/test_models.py` and `tests/test_litellm/proxy/management_endpoints/test_customer_endpoints.py`)
- [x] My PR passes all required CI/CD checks
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile Confidence Score of at least 4/5 before requesting a maintainer review

## Type

🐛 Bug Fix

## Caveats (if any)

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
