### PR TITLE
fix(prometheus): route increment_deployment_cooled_down through the label factory

### DIFF
--- a/litellm/integrations/prometheus.py
+++ b/litellm/integrations/prometheus.py
@@ -3307,13 +3307,17 @@ class PrometheusLogger(CustomLogger):
         """
         increment metric when litellm.Router / load balancing logic places a deployment in cool down
         """
-        self.litellm_deployment_cooled_down.labels(
-            _sanitize_prometheus_label_value(litellm_model_name),
-            _sanitize_prometheus_label_value(model_id),
-            _sanitize_prometheus_label_value(api_base),
-            _sanitize_prometheus_label_value(api_provider),
-            _sanitize_prometheus_label_value(exception_status),
-        ).inc()
+        _labels: Final = prometheus_label_factory(
+            supported_enum_labels=self.get_labels_for_metric(metric_name="litellm_deployment_cooled_down"),
+            enum_values=UserAPIKeyLabelValues(
+                litellm_model_name=litellm_model_name,
+                model_id=model_id,
+                api_base=api_base,
+                api_provider=api_provider,
+                exception_status=exception_status,
+            ),
+        )
+        self.litellm_deployment_cooled_down.labels(**_labels).inc()
 
     def increment_callback_logging_failure(
         self,

--- a/tests/enterprise/litellm_enterprise/enterprise_callbacks/test_prometheus_logging_callbacks.py
+++ b/tests/enterprise/litellm_enterprise/enterprise_callbacks/test_prometheus_logging_callbacks.py
@@ -1204,7 +1204,11 @@ def test_increment_deployment_cooled_down(prometheus_logger):
     )
 
     prometheus_logger.litellm_deployment_cooled_down.labels.assert_called_once_with(
-        "gpt-5-mini", "model-123", "https://api.openai.com", "openai", "429"
+        litellm_model_name="gpt-5-mini",
+        model_id="model-123",
+        api_base="https://api.openai.com",
+        api_provider="openai",
+        exception_status="429",
     )
     mock_chain.inc.assert_called_once()
 

--- a/tests/test_litellm/integrations/test_prometheus_custom_metadata_label_counts.py
+++ b/tests/test_litellm/integrations/test_prometheus_custom_metadata_label_counts.py
@@ -157,3 +157,29 @@ def test_virtual_key_rate_limit_metrics_preserve_zero_remaining_values(
     assert any(sample.value == 0 for sample in token_samples)
     assert not any(sample.value == sys.maxsize for sample in request_samples)
     assert not any(sample.value == sys.maxsize for sample in token_samples)
+
+
+def test_increment_deployment_cooled_down_accepts_custom_metadata_labels(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+):
+    prometheus_logger = _create_prometheus_logger_with_custom_labels(monkeypatch)
+
+    with caplog.at_level(logging.ERROR):
+        prometheus_logger.increment_deployment_cooled_down(
+            litellm_model_name="gpt-4o-mini",
+            model_id="model-123",
+            api_base="https://api.openai.com",
+            api_provider="openai",
+            exception_status="429",
+        )
+
+    assert "Incorrect label count" not in caplog.text
+    samples = _metric_samples("litellm_deployment_cooled_down_total")
+    assert any(
+        sample.labels.get("litellm_model_name") == "gpt-4o-mini"
+        and sample.labels.get("exception_status") == "429"
+        and "metadata_department" in sample.labels
+        and "metadata_environment" in sample.labels
+        and sample.value == 1
+        for sample in samples
+    )


### PR DESCRIPTION
Moved from danielva-monday — supersedes https://github.com/BerriAI/litellm/pull/38495## Title

fix(prometheus): route `increment_deployment_cooled_down` through the label factory

## Relevant issues

Fixes #38494

## Summary

`increment_deployment_cooled_down` was the last metric emitter still using a fixed positional `.labels(...)` call. Because `get_labels_for_metric()` appends `custom_prometheus_metadata_labels` to the declared label set, any deployment cooldown raised `ValueError: Incorrect label count` and the `litellm_deployment_cooled_down` metric recorded nothing.

This routes the emission through `prometheus_label_factory` and `get_labels_for_metric`, matching what `set_litellm_deployment_state` already does. The factory fills every declared label, so the emitted count always matches the declared count regardless of how many custom labels are configured. The custom labels resolve to empty values here since a cooldown has no request context.

## Type

🐛 Bug Fix

## Changes

- `litellm/integrations/prometheus.py`: build the cooldown labels with `prometheus_label_factory` instead of a fixed positional `.labels(...)` call.
- Added a regression test in `tests/test_litellm/integrations/test_prometheus_custom_metadata_label_counts.py`.

## Testing

Ran the affected test module locally:

```
tests/test_litellm/integrations/test_prometheus_custom_metadata_label_counts.py .... 4 passed
```

The new test fails on `main` with `ValueError: Incorrect label count` and passes with this change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow observability fix that aligns one metric emitter with existing label-factory patterns; no auth, routing, or data-path changes.
> 
> **Overview**
> Fixes **deployment cooldown Prometheus metrics** silently failing when `custom_prometheus_metadata_labels` (or other dynamic label sets) are enabled.
> 
> `increment_deployment_cooled_down` no longer passes five fixed positional label values. It now builds labels via **`prometheus_label_factory`** and **`get_labels_for_metric`**, matching **`set_litellm_deployment_state`** and other deployment emitters, so the label count always matches the counter’s declared `labelnames`. Custom metadata labels are emitted as empty on cooldown events (no request context).
> 
> Tests were updated for keyword-style `.labels(...)` assertions, and a regression test confirms cooldown increments work with custom metadata labels without `Incorrect label count` errors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 75cd5951e0f46ca0bea0e83b4ed10844a9a4cf25. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

Made with [Cursor](https://cursor.com)