### PR TITLE
fix(router): resolve session.model to the picked deployment in _ageneric_api_call_with_fallbacks_helper

### DIFF
--- a/litellm/router.py
+++ b/litellm/router.py
@@ -4894,6 +4894,16 @@ class Router:
             if custom_llm_provider is not None:
                 response_kwargs["custom_llm_provider"] = custom_llm_provider
 
+            # kwargs["session"] (e.g. realtime client_secrets) still has whatever
+            # model string the caller/proxy originally sent (a model_name/alias),
+            # not model_name resolved above. acreate_realtime_client_secret
+            # prioritizes session.model over the model kwarg, so leaving it
+            # unresolved would silently route with the alias instead of the
+            # deployment litellm picked. See BerriAI/litellm#36742.
+            session = response_kwargs.get("session")
+            if isinstance(session, dict) and session.get("model"):
+                response_kwargs["session"] = {**session, "model": model_name}
+
             response = original_generic_function(**response_kwargs)
 
             rpm_semaphore: Final = self._get_client(

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -4894,15 +4894,12 @@ class Router:
             if custom_llm_provider is not None:
                 response_kwargs["custom_llm_provider"] = custom_llm_provider
 
-            # kwargs["session"] (e.g. realtime client_secrets) still has whatever
-            # model string the caller/proxy originally sent (a model_name/alias),
-            # not model_name resolved above. acreate_realtime_client_secret
-            # prioritizes session.model over the model kwarg, so leaving it
-            # unresolved would silently route with the alias instead of the
-            # deployment litellm picked. See BerriAI/litellm#36742.
-            session = response_kwargs.get("session")
+            session: Final = response_kwargs.get("session")
             if isinstance(session, dict) and session.get("model"):
-                response_kwargs["session"] = {**session, "model": model_name}
+                response_kwargs["session"] = {  # mutable-ok: rewrite session.model without mutating the caller dict
+                    **session,
+                    "model": model_name,
+                }
 
             response = original_generic_function(**response_kwargs)
 

--- a/tests/router_unit_tests/test_router_endpoints.py
+++ b/tests/router_unit_tests/test_router_endpoints.py
@@ -521,6 +521,42 @@ def test_generic_api_call_with_fallbacks_basic(sync_mode):
 
 
 @pytest.mark.asyncio
+async def test_ageneric_api_call_with_fallbacks_resolves_session_model():
+    """
+    Regression test for https://github.com/BerriAI/litellm/issues/36742: when a
+    call has a nested session.model (realtime client_secrets), it must be
+    rewritten to the deployment litellm actually picked for the model_group,
+    not left as the caller's original alias.
+    """
+    mock_function = AsyncMock()
+    mock_function.__name__ = "acreate_realtime_client_secret"
+    mock_function.return_value = {"value": "ek_test"}
+
+    router = Router(
+        model_list=[
+            {
+                "model_name": "gpt-realtime-2-1-mini",
+                "litellm_params": {
+                    "model": "azure/gpt-realtime-2-1-mini-deployment",
+                    "api_key": "fake-api-key",
+                    "api_base": "https://fake.openai.azure.com",
+                },
+            }
+        ]
+    )
+
+    await router._ageneric_api_call_with_fallbacks(
+        model="gpt-realtime-2-1-mini",
+        original_function=mock_function,
+        session={"type": "realtime", "model": "gpt-realtime-2-1-mini"},
+    )
+
+    call_kwargs = mock_function.call_args.kwargs
+    assert call_kwargs["model"] == "azure/gpt-realtime-2-1-mini-deployment"
+    assert call_kwargs["session"]["model"] == "azure/gpt-realtime-2-1-mini-deployment"
+
+
+@pytest.mark.asyncio
 async def test_aadapter_completion():
     """
     Test the aadapter_completion method which uses async_function_with_fallbacks

--- a/tests/router_unit_tests/test_router_endpoints.py
+++ b/tests/router_unit_tests/test_router_endpoints.py
@@ -521,42 +521,6 @@ def test_generic_api_call_with_fallbacks_basic(sync_mode):
 
 
 @pytest.mark.asyncio
-async def test_ageneric_api_call_with_fallbacks_resolves_session_model():
-    """
-    Regression test for https://github.com/BerriAI/litellm/issues/36742: when a
-    call has a nested session.model (realtime client_secrets), it must be
-    rewritten to the deployment litellm actually picked for the model_group,
-    not left as the caller's original alias.
-    """
-    mock_function = AsyncMock()
-    mock_function.__name__ = "acreate_realtime_client_secret"
-    mock_function.return_value = {"value": "ek_test"}
-
-    router = Router(
-        model_list=[
-            {
-                "model_name": "gpt-realtime-2-1-mini",
-                "litellm_params": {
-                    "model": "azure/gpt-realtime-2-1-mini-deployment",
-                    "api_key": "fake-api-key",
-                    "api_base": "https://fake.openai.azure.com",
-                },
-            }
-        ]
-    )
-
-    await router._ageneric_api_call_with_fallbacks(
-        model="gpt-realtime-2-1-mini",
-        original_function=mock_function,
-        session={"type": "realtime", "model": "gpt-realtime-2-1-mini"},
-    )
-
-    call_kwargs = mock_function.call_args.kwargs
-    assert call_kwargs["model"] == "azure/gpt-realtime-2-1-mini-deployment"
-    assert call_kwargs["session"]["model"] == "azure/gpt-realtime-2-1-mini-deployment"
-
-
-@pytest.mark.asyncio
 async def test_aadapter_completion():
     """
     Test the aadapter_completion method which uses async_function_with_fallbacks

--- a/tests/test_litellm/test_router_session_model.py
+++ b/tests/test_litellm/test_router_session_model.py
@@ -1,0 +1,36 @@
+from unittest.mock import AsyncMock
+
+import pytest
+
+from litellm import Router
+
+
+@pytest.mark.asyncio
+async def test_ageneric_api_call_with_fallbacks_resolves_session_model():
+    """Realtime session.model must use the picked deployment, not the caller alias."""
+    mock_function = AsyncMock()
+    mock_function.__name__ = "acreate_realtime_client_secret"
+    mock_function.return_value = {"value": "ek_test"}
+
+    router = Router(
+        model_list=[
+            {
+                "model_name": "gpt-realtime-2-1-mini",
+                "litellm_params": {
+                    "model": "azure/gpt-realtime-2-1-mini-deployment",
+                    "api_key": "fake-api-key",
+                    "api_base": "https://fake.openai.azure.com",
+                },
+            }
+        ]
+    )
+
+    await router._ageneric_api_call_with_fallbacks(
+        model="gpt-realtime-2-1-mini",
+        original_function=mock_function,
+        session={"type": "realtime", "model": "gpt-realtime-2-1-mini"},
+    )
+
+    call_kwargs = mock_function.call_args.kwargs
+    assert call_kwargs["model"] == "azure/gpt-realtime-2-1-mini-deployment"
+    assert call_kwargs["session"]["model"] == "azure/gpt-realtime-2-1-mini-deployment"


### PR DESCRIPTION
Moved from danielva-monday — supersedes https://github.com/BerriAI/litellm/pull/36749## TLDR

Problem this solves:

- Realtime `client_secrets` calls through a Router model group ignore the resolved deployment
- `session.model` still holds the caller's original alias, not the picked deployment
- `acreate_realtime_client_secret` prefers `session.model`, so it fails provider inference

How it solves it:

- `Router._ageneric_api_call_with_fallbacks_helper` now rewrites `session.model` to the resolved deployment
- Only touches that one helper; direct-caller session-first priority is untouched

## User Flow

Before: an admin routes realtime client secrets through a Router model group whose name isn't itself a valid model string

1. Proxy config has `model_name: gpt-realtime-2-1-mini` mapped to `litellm_params.model: azure/gpt-realtime-2-1-mini-deployment`
2. A client sends `POST /v1/realtime/client_secrets` with `{"model": "gpt-realtime-2-1-mini", "session": {"model": "gpt-realtime-2-1-mini"}}`
3. The response is `400` with `"litellm.BadRequestError: LLM Provider NOT provided... You passed model=gpt-realtime-2-1-mini"`, even though the Router correctly matched the model group

After: the same request routes correctly

1. Same proxy config and same request body
2. The Router resolves the model group to `azure/gpt-realtime-2-1-mini-deployment` and now also rewrites `session.model` to that same value before calling the provider
3. The response is `200` with a real ephemeral `value` and `session.model` reflecting the resolved deployment

## Relevant issues

Fixes #36742 (also referenced from #24659, a related but distinct Azure-endpoint-URL bug in the same code path)

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

Reproduced against the real, currently-released code path (proxy endpoint -> `_prepare_client_secret_session` -> `route_request` -> a real `Router` with a model-group config shaped exactly like the bug report -> `Router._ageneric_api_call_with_fallbacks_helper` -> `acreate_realtime_client_secret`) using a `TestClient` against the actual `proxy_server.app`, stubbing only the final outbound HTTP call to the LLM provider (`async_realtime_client_secret_handler`) so it needs no paid provider credentials while every other line in the reported bug still executes for real.

Before fix (current `main`, commit `a7397b2`):
```
HTTP status: 400
{"error":{"message":"litellm.BadRequestError: LLM Provider NOT provided. Pass in the LLM provider you are trying to call. You passed model=gpt-realtime-2-1-mini\n ... Received Model Group=gpt-realtime-2-1-mini\nAvailable Model Group Fallbacks=None", ...}}
Captured, as seen right before the (stubbed) network call:
{}
```

After fix (this branch, commit `bd32a08`):
```
HTTP status: 200
{"expires_at":null,"value":"<redacted ephemeral value>","session":{"type":"realtime","model":"gpt-realtime-2-1-mini-deployment"}}
Captured, as seen right before the (stubbed) network call:
{
  "model_kwarg_seen_by_provider_layer": "gpt-realtime-2-1-mini-deployment",
  "session_model_seen_by_provider_layer": "gpt-realtime-2-1-mini-deployment"
}
```

I originally hit this against a real deployed proxy backed by a real Azure OpenAI realtime deployment (not a toy repro) — reproduced identically on both `litellm==1.92.0` and `litellm==1.96.2`, and confirmed via git history still present on current `main`. Full writeup is in #36742.

## Type

🐛 Bug Fix
✅ Test

## Caveats (if any)

- Doesn't change `acreate_realtime_client_secret`'s own session-first priority for direct (non-Router) callers — that's intentional, existing, tested behavior for a different use case
- Doesn't address the separate Azure realtime endpoint URL bug tracked in #24659

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

Made with [Cursor](https://cursor.com)