### PR TITLE
fix(ui): stop checkboxes stretching to the full width of a form field

### DIFF
--- a/ui/litellm-dashboard/src/components/CreateUserButton.test.tsx
+++ b/ui/litellm-dashboard/src/components/CreateUserButton.test.tsx
@@ -5,6 +5,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { CreateUserButton } from "./CreateUserButton";
 import * as networking from "./networking";
 import { toast } from "@/lib/toast";
+import { expectControlBesideLabel } from "../../tests/fieldOrientation";
 
 vi.mock("./networking", () => ({
   userCreateCall: vi.fn(),
@@ -304,9 +305,8 @@ describe("CreateUserButton", () => {
     await user.click(screen.getByRole("button", { name: /\+ invite user/i }));
 
     const dialog = screen.getByRole("dialog", { name: /invite user/i });
-    const checkbox = within(dialog).getByRole("checkbox");
 
-    expect(checkbox.closest('[data-slot="field"]')).toHaveAttribute("data-orientation", "horizontal");
+    expectControlBesideLabel(within(dialog).getByRole("checkbox"));
   });
 
   describe("organizations", () => {

--- a/ui/litellm-dashboard/src/components/CreateUserButton.test.tsx
+++ b/ui/litellm-dashboard/src/components/CreateUserButton.test.tsx
@@ -294,6 +294,21 @@ describe("CreateUserButton", () => {
     });
   });
 
+  it("lays the send invitation email checkbox out beside its label", async () => {
+    const user = userEvent.setup({ pointerEventsCheck: PointerEventsCheckLevel.Never });
+    renderWithProviders(<CreateUserButton {...defaultProps} />);
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /\+ invite user/i })).toBeInTheDocument();
+    });
+    await user.click(screen.getByRole("button", { name: /\+ invite user/i }));
+
+    const dialog = screen.getByRole("dialog", { name: /invite user/i });
+    const checkbox = within(dialog).getByRole("checkbox");
+
+    expect(checkbox.closest('[data-slot="field"]')).toHaveAttribute("data-orientation", "horizontal");
+  });
+
   describe("organizations", () => {
     it("should send organizations list in POST body when organizations are selected", async () => {
       const { useOrganizations } = await import("@/app/(dashboard)/hooks/organizations/useOrganizations");

--- a/ui/litellm-dashboard/src/components/CreateUserButton.tsx
+++ b/ui/litellm-dashboard/src/components/CreateUserButton.tsx
@@ -270,7 +270,7 @@ export const CreateUserButton: React.FC<CreateuserProps> = ({
   );
 
   const sendInviteEmailField = (
-    <FormField control={form.control} name="send_invite_email" label="Send invitation email">
+    <FormField control={form.control} name="send_invite_email" label="Send invitation email" orientation="horizontal">
       {({ id, value, onChange, onBlur }) => (
         <Checkbox id={id} checked={value} onCheckedChange={onChange} onBlur={onBlur} />
       )}

--- a/ui/litellm-dashboard/src/components/Settings/AdminSettings/SSOSettings/Modals/BaseSSOSettingsForm.test.tsx
+++ b/ui/litellm-dashboard/src/components/Settings/AdminSettings/SSOSettings/Modals/BaseSSOSettingsForm.test.tsx
@@ -9,6 +9,7 @@ import BaseSSOSettingsForm, {
   submitMountedSSOValues,
   useSSOSettingsForm,
 } from "./BaseSSOSettingsForm";
+import { expectControlBesideLabel } from "../../../../../../tests/fieldOrientation";
 
 const user = () => userEvent.setup({ pointerEventsCheck: 0 });
 
@@ -232,6 +233,38 @@ describe("BaseSSOSettingsForm", () => {
     });
 
     expect(screen.queryByText("Use Team Mappings")).not.toBeInTheDocument();
+  });
+
+  it("lays a provider checkbox field out beside its label", async () => {
+    const TestWrapper = () => {
+      const form = useSSOSettingsForm("sso-settings");
+
+      return <BaseSSOSettingsForm form={form} onFormSubmit={vi.fn()} />;
+    };
+
+    renderWithProviders(<TestWrapper />);
+
+    await openProviderDropdown();
+    await user().click(await screen.findByText(/saml sso/i));
+
+    expectControlBesideLabel(
+      await screen.findByRole("checkbox", { name: "Allow IdP-initiated (unsolicited) responses" }),
+    );
+  });
+
+  it.each(["Use Role Mappings", "Use Team Mappings"])("lays the %s toggle out beside its label", async (label) => {
+    const TestWrapper = () => {
+      const form = useSSOSettingsForm("sso-settings");
+
+      return <BaseSSOSettingsForm form={form} onFormSubmit={vi.fn()} />;
+    };
+
+    renderWithProviders(<TestWrapper />);
+
+    await openProviderDropdown();
+    await user().click(await screen.findByText(/okta/i));
+
+    expectControlBesideLabel(await screen.findByRole("checkbox", { name: label }));
   });
 });
 

--- a/ui/litellm-dashboard/src/components/Settings/AdminSettings/SSOSettings/Modals/BaseSSOSettingsForm.tsx
+++ b/ui/litellm-dashboard/src/components/Settings/AdminSettings/SSOSettings/Modals/BaseSSOSettingsForm.tsx
@@ -303,7 +303,7 @@ const SSOProviderField = ({ field }: { field: SSOProviderConfig["fields"][number
 
   if (field.type === "checkbox") {
     return (
-      <FormField control={control} name={field.name} label={field.label}>
+      <FormField control={control} name={field.name} label={field.label} orientation="horizontal">
         {({ value, onChange, onBlur, id, ...rest }) => (
           <Checkbox
             id={id}
@@ -413,7 +413,7 @@ export const MappingToggleField = ({
   const { control } = useFormContext<SSOSettingsFormValues>();
 
   return (
-    <FormField control={control} name={name} label={label}>
+    <FormField control={control} name={name} label={label} orientation="horizontal">
       {({ value, onChange, onBlur, id, ...rest }) => (
         <Checkbox
           id={id}

--- a/ui/litellm-dashboard/src/components/ui/field.test.tsx
+++ b/ui/litellm-dashboard/src/components/ui/field.test.tsx
@@ -14,6 +14,7 @@ import {
   FieldSet,
   FieldTitle,
 } from "./field";
+import { ROW_LAYOUT_CLASSES, STRETCH_CHILDREN_CLASS } from "../../../tests/fieldOrientation";
 
 describe("FieldError", () => {
   it("renders nothing when there are no errors and no children", () => {
@@ -84,6 +85,20 @@ describe("Field", () => {
     render(<Field orientation="horizontal" />);
 
     expect(screen.getByRole("group")).toHaveAttribute("data-orientation", "horizontal");
+  });
+
+  it("stretches every child when vertical, which is what inputs, selects and textareas want", () => {
+    render(<Field />);
+
+    expect(screen.getByRole("group")).toHaveClass("flex-col", STRETCH_CHILDREN_CLASS);
+  });
+
+  it("lays children in a row at their own width when horizontal, so a checkbox stays square", () => {
+    render(<Field orientation="horizontal" />);
+    const field = screen.getByRole("group");
+
+    expect(field).toHaveClass(...ROW_LAYOUT_CLASSES);
+    expect(field).not.toHaveClass(STRETCH_CHILDREN_CLASS);
   });
 });
 

--- a/ui/litellm-dashboard/tests/fieldOrientation.ts
+++ b/ui/litellm-dashboard/tests/fieldOrientation.ts
@@ -1,0 +1,18 @@
+import { expect } from "vitest";
+
+export const ROW_LAYOUT_CLASSES = ["flex-row", "items-center"] as const;
+export const STRETCH_CHILDREN_CLASS = "*:w-full";
+
+/**
+ * Asserts a control sits beside its label at its own width instead of being stretched across the
+ * field. Reaches for the resolved classes because the defect is purely visual: nothing accessible
+ * distinguishes a square checkbox from a full-width bar.
+ */
+export const expectControlBesideLabel = (control: HTMLElement): void => {
+  const field = control.closest('[data-slot="field"]');
+  if (field === null) throw new Error("control is not rendered inside a form field");
+
+  expect(field).toHaveAttribute("data-orientation", "horizontal");
+  expect(field).toHaveClass(...ROW_LAYOUT_CLASSES);
+  expect(field).not.toHaveClass(STRETCH_CHILDREN_CLASS);
+};


### PR DESCRIPTION

## TLDR

<!-- Fill in the bullets below and keep each one short and concrete: one line per bullet, roughly 10 words max -->

Problem this solves:

- The invite dialog draws a checkbox as a full-width dark bar
- Its caption sits above it like a heading, not beside it
- The click target grows to the whole dialog width, invisibly
- Two SSO settings checkboxes have the same problem

How it solves it:

- Lay those checkboxes out horizontally, the orientation the field already supports
- Horizontal does not stretch its children, so the box stays square

## User Flow

<!-- Two ordered lists, Before and After, walking the same end user through the same task, written strictly from that user's seat
     Read the linked issue, ticket, or customer thread first so the flow reflects the real application and the routes its users actually hit; don't invent a generic scenario
     Lead each list with one plain sentence saying where the flow fails (Before) or succeeds (After), then number the steps
     Every step is something the user does or observes: the HTTP method and full URL they hit, what they sent, and what visibly came back (status code, error text, the shape of an ID). UI steps name the page URL and what is on screen
     No LiteLLM internals: never name functions, files, DB tables, config classes, hooks, callbacks, or code paths. "The upload hands back an ID that looks like OpenAI's own `file-abc123` instead of the scrambled one the gateway returned" is right, "no managed-file row was registered" is wrong
     Keep the two lists step-for-step identical until they diverge, so the changed step is obvious
     If the bug had a security or authorization consequence, end each list with what another user could or could no longer do
     Regenerate this section whenever new commits change the PR's behavior, so it never describes an older revision

Example:

Before: a developer whose app streams chat completions gets no token counts back, so their cost dashboard reads zero

1. They send POST https://litellm-domain/v1/chat/completions with `"stream": true` and no `stream_options`
2. The last SSE chunk arrives with `"usage": null`, so their app records 0 prompt and 0 completion tokens
3. They open https://litellm-domain/ui/?page=logs and see the request logged at $0 spend

After: the same request comes back with real token counts, so the dashboard shows real spend

1. The proxy admin sets `always_include_stream_usage: true` and restarts the proxy
2. The developer sends the same POST https://litellm-domain/v1/chat/completions with `"stream": true` and no `stream_options`
3. The last SSE chunk now carries a `usage` object with real prompt and completion token counts
4. https://litellm-domain/ui/?page=logs shows that request at non-zero spend
-->

Before: an admin inviting a user cannot tell whether the invitation email will be sent

1. They open http://127.0.0.1:4100/ui/users/ and click **+ Invite User**
2. The dialog opens with User Email, Global Proxy Role, Team, Organization and Metadata, each label stacked above a full-width control
3. Below Metadata is a **Send invitation email** label, and under it a solid dark bar running the full width of the dialog, about 16px tall, with a small tick centred in it. Nothing on screen looks like a checkbox
4. They click the bar. It becomes an empty full-width outlined rectangle of the same height, which reads as a disabled or broken text input
5. They cannot tell which of the two states means the email gets sent, so they submit and find out afterwards
6. The same shape appears in the SSO provider settings modal at http://127.0.0.1:4100/ui/admin-panel, where its checkboxes are drawn as full-width bars too

After: the same admin sees a normal checkbox and reads its state at a glance

1. They open http://127.0.0.1:4100/ui/users/ and click **+ Invite User**
2. The dialog opens with the same fields
3. Below Metadata, **Send invitation email** sits on one line with a small square checkbox at the end of the row, ticked by default
4. They click the checkbox and it clears to an empty square of the same size, unambiguously unchecked
5. Clicking the empty space in that row no longer toggles anything, so the control does only what it looks like it does
6. The SSO provider settings modal renders its checkboxes the same way

## Relevant issues

<!-- e.g., "Fixes #000" -->

Fixes #39103

## Linear ticket

<!-- if you are an internal contributor, add "Resolves " followed by the Linear ticket e.g., "Resolves LIT-1234" to link the Linear ticket to the GitHub PR. If you don't have one, leave the section blank rather than guessing -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

<!-- Include screenshots, screen recordings, or command (e.g., curl) + output demonstrating that your changes work as expected
     The proof must be completely e2e with no mocks, using actual LLM calls costing real $$$ if applicable. `pytest` commands are not enough
     Show ONLY the latest run: capture Before at the merge base and After at the PR's current tip, and when new commits change behavior, replace this whole section with the fresh run instead of stacking it on top of older ones. The run must be up to date. As soon as a new commit is made and it makes this PR description's after sha stale (it's no longer tip of PR), you must re-run the QA
     Structure the section exactly as below: Before and After one heading level below this section, each naming the commit hash it was captured at, one lower-level heading per case inside each, the same case names in the same order on both sides, and numbered steps (command, observed output) under every case, never loose prose; shared setup (config, payloads) goes above Before, and with a single case, drop the case headings and number the steps directly

### Before (<hash>)

#### <case 1>

1. ...
2. ...

#### <case 2>

1. ...

### After (<hash>)

#### <case 1>

1. ...
2. ...

#### <case 2>

1. ...

     For bug fixes: Before shows the reproduction, After shows the same steps passing
     For new features: Before shows the capability missing, After shows it working end-to-end
     If the change applies to all three LLM endpoints (/v1/responses, /v1/chat/completions, /v1/messages), make each endpoint its own case, not just one
     For UI changes: before/after screenshots under the same headings -->

### Before (ec3f8183c3)

#### Invite User dialog

1. Open http://127.0.0.1:4100/ui/users/ and click **+ Invite User**
2. See the screenshot

<img width="1236" height="1280" alt="WhatsApp Image 2026-09-01 at 16 35 54" src="https://github.com/user-attachments/assets/6080fe5d-7e26-416d-bbdd-b7373ae51bde" />


#### SSO provider settings modal

1. Open http://127.0.0.1:4100/ui/admin-panel, go to SSO and open a provider's settings
2. See the screenshot

<img width="1211" height="1280" alt="WhatsApp Image 2026-09-01 at 16 35 38" src="https://github.com/user-attachments/assets/a842159c-eef2-449f-be67-51f8ae1e8bfc" />


### After (054acb2223; the newer commit adds tests only, so the rendered UI is unchanged)

#### Invite User dialog

1. Open http://127.0.0.1:4100/ui/users/ and click **+ Invite User**
2. See the screenshot
<img width="798" height="950" alt="Screenshot 2026-09-01 at 5 14 40 PM" src="https://github.com/user-attachments/assets/c55f69bf-41fc-426a-9dd5-ee5ec3d8ed6e" />



#### SSO provider settings modal

1. Open http://127.0.0.1:4100/ui/admin-panel, go to SSO and open a provider's settings
2. See the screenshot
<img width="799" height="445" alt="Screenshot 2026-09-01 at 5 16 58 PM" src="https://github.com/user-attachments/assets/4771abe2-a938-400d-aa09-561c34cb1d25" />


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix

## Caveats (if any)

<!-- Group caveats under severity subheadings (### Severe, ### High, ### Medium, ### Low), with
     short bullet points inside each, just like the TLDR: one line per bullet, roughly 10 words max
     Call out known limllow-up work, or anything a reviewer should watch out for
     Include only the tiers that have caveats; drop the empty ones
     - Severe: inherent to what the PR deliberately ships, there even when the code works as intended:
       it can degrade or take down a running deployment (e.g. a slow or table-locking boot migration),
       rewrite data by design, break an existing workflow on purpose, or change auth behavior. An
       operator must plan around it before rollout
     - High: an unintended hole: a correctness, security, data-loss, or backward-compatibility bug,
       unsafe to ship as is
     - Medium: a real gap someone can hit, but with a workaround or a narrow blast radius
     - Low: anything else worth noting: naming, cleanup, an edge case nobody hits
     Nest bullets as deep as helps: hierarchy beats one long line when it makes things clearer to a
     human reader
     Leave this section empty if there are none -->

### Low

- Label sits left, checkbox at the row's end, matching the existing switch rows
- The stretching rule itself is untouched, so a future checkbox can hit this again
  - Now guarded on the shared field as well as at each of the three call sites

## Implementation notes

- Used the orientation the field component already supports, rather than new styling
  - Its vertical mode stretches every direct child to full width, which is right for inputs, selects and textareas and wrong for a checkbox
  - Its horizontal mode does not stretch children, and already carries alignment rules for checkboxes and radios
  - The model info form uses horizontal for its toggle, so this follows existing precedent
- Fixed all three checkboxes with this shape, not just the reported one
  - The invite dialog, plus two in the SSO provider settings form
  - Every other checkbox in the dashboard is either outside a field or wrapped in a label first, so none of them stretch
- Left switches alone after checking them
  - About 25 switches sit in vertical fields and render correctly
  - Their width comes from an attribute-qualified rule that outranks the stretching rule, so only plain checkboxes lose
- Did not change the shared field component
  - Making vertical mode skip checkboxes would fix the width but leave the caption stacked above the box
  - Horizontal fixes width, caption placement and hit area together, and does not touch every other form in the dashboard
- Tests assert the classes that actually drive the layout, not only the orientation attribute
  - The field primitive pins both halves of the contract: vertical stretches its children, horizontal does not
  - The invite dialog and both SSO checkboxes each assert their control sits beside its label at its own width
  - All four fail on the pre-PR code, and again when the horizontal variant is mutated to stretch or to stop being a row, so a regression in the shared wrapper cannot slip past them

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only layout changes in dashboard forms; no API, auth, or submission logic changes.
> 
> **Overview**
> Fixes **checkbox fields** that looked like full-width bars because vertical `FormField` layout stretches controls to the dialog width.
> 
> **Send invitation email** on the invite-user flow and **SSO settings** checkboxes (provider checkbox fields and role/team mapping toggles) now use `orientation="horizontal"` on `FormField`, so the label and a normal square checkbox sit on one row and the click target matches the control.
> 
> A test on the invite dialog asserts the send-invitation field wrapper has `data-orientation="horizontal"`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 054acb2223cb4e4a0c8c2a2b57fc0ad00a854fa5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
