### PR TITLE
fix(mcp): preserve logical permissions across regions

### DIFF
--- a/basedpyright-code-budget.json
+++ b/basedpyright-code-budget.json
@@ -1,6 +1,6 @@
 {
   "reportAny": {
-    "limit": 14765
+    "limit": 14759
   },
   "reportArgumentType": {
     "limit": 2216
@@ -24,7 +24,7 @@
     "limit": 19
   },
   "reportExplicitAny": {
-    "limit": 4493
+    "limit": 4492
   },
   "reportFunctionMemberAccess": {
     "limit": 7
@@ -84,7 +84,7 @@
     "limit": 56
   },
   "reportPrivateUsage": {
-    "limit": 1808
+    "limit": 1806
   },
   "reportRedeclaration": {
     "limit": 8
@@ -123,7 +123,7 @@
     "limit": 5
   },
   "reportUnnecessaryIsInstance": {
-    "limit": 828
+    "limit": 827
   },
   "reportUntypedBaseClass": {
     "limit": 0

--- a/litellm/proxy/_experimental/mcp_server/auth/user_api_key_auth_mcp.py
+++ b/litellm/proxy/_experimental/mcp_server/auth/user_api_key_auth_mcp.py
@@ -2092,7 +2092,10 @@ class MCPRequestHandler:
             )
 
             key_direct_tools: Final = (
-                global_mcp_server_manager.expand_tool_permissions(key_obj_perm.mcp_tool_permissions).get(server_id)
+                global_mcp_server_manager.get_tool_permissions_for_server(
+                    key_obj_perm.mcp_tool_permissions,
+                    server_id,
+                )
                 if key_obj_perm
                 else None
             )
@@ -2115,7 +2118,10 @@ class MCPRequestHandler:
                 else None
             )
             team_direct_tools: Final = (
-                global_mcp_server_manager.expand_tool_permissions(team_obj_perm.mcp_tool_permissions).get(server_id)
+                global_mcp_server_manager.get_tool_permissions_for_server(
+                    team_obj_perm.mcp_tool_permissions,
+                    server_id,
+                )
                 if team_obj_perm
                 else None
             )
@@ -2126,8 +2132,8 @@ class MCPRequestHandler:
             team_tools: Final = MCPRequestHandler._union_tool_grants(team_direct_tools, team_toolset_tools)
 
             # Apply same inheritance logic as get_allowed_mcp_servers
-            if team_tools:
-                if key_tools:
+            if team_tools is not None:
+                if key_tools is not None:
                     # Both have restrictions → intersection
                     allowed_tools = list(set(team_tools) & set(key_tools))
                 else:
@@ -2210,7 +2216,10 @@ class MCPRequestHandler:
                 )
                 return allowed_tools
             org_direct_tools: Final = (
-                global_mcp_server_manager.expand_tool_permissions(org_obj_perm.mcp_tool_permissions).get(server_id)
+                global_mcp_server_manager.get_tool_permissions_for_server(
+                    org_obj_perm.mcp_tool_permissions,
+                    server_id,
+                )
                 if org_obj_perm and org_obj_perm.mcp_tool_permissions
                 else None
             )
@@ -2991,9 +3000,10 @@ class MCPRequestHandler:
         if object_permissions is None:
             return allowed_tools
 
-        user_direct_tools: Final = global_mcp_server_manager.expand_tool_permissions(
-            object_permissions.mcp_tool_permissions
-        ).get(server_id)
+        user_direct_tools: Final = global_mcp_server_manager.get_tool_permissions_for_server(
+            object_permissions.mcp_tool_permissions,
+            server_id,
+        )
         user_toolset_tools: Final = await MCPRequestHandler._toolset_tools_for_server(object_permissions, server_id)
         user_tools: Final = MCPRequestHandler._union_tool_grants(user_direct_tools, user_toolset_tools)
         if user_tools is None:
@@ -3156,8 +3166,11 @@ class MCPRequestHandler:
                 global_mcp_server_manager,
             )
 
-            tools: Final = global_mcp_server_manager.expand_tool_permissions(mcp_tool_permissions).get(server_id)
-            return list(tools) if tools else None
+            tools: Final = global_mcp_server_manager.get_tool_permissions_for_server(
+                mcp_tool_permissions,
+                server_id,
+            )
+            return list(tools) if tools is not None else None
         except Exception as e:
             verbose_logger.warning("Failed to get agent tool permissions for server: %s", e)
             return None

--- a/litellm/proxy/_experimental/mcp_server/gateway_dcr_flow.py
+++ b/litellm/proxy/_experimental/mcp_server/gateway_dcr_flow.py
@@ -43,6 +43,7 @@ import html
 import secrets
 from base64 import urlsafe_b64encode
 from collections.abc import Awaitable, Callable, Iterable, Mapping
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from types import MappingProxyType
 from typing import Final, Literal, Protocol, TypeVar
@@ -387,14 +388,22 @@ def relative_request_url(request: Request) -> str:
     return f"{path}?{request.url.query}" if request.url.query else path
 
 
-def resolve_scoped_resource_server(request: Request, resource: str | None) -> MCPServer | None:
+@dataclass(frozen=True, slots=True)
+class _AmbiguousScopedResource:
+    reference: str
+
+
+def resolve_scoped_resource_server(
+    request: Request, resource: str | None
+) -> MCPServer | _AmbiguousScopedResource | None:
     """Resolve an RFC 8707 ``resource`` value to the single gateway-managed oauth2 server it
-    names, or ``None`` for every other shape: absent, the aggregate resource, a foreign
-    host, an unparseable value, a multi-server path, an unknown name, or any server mode the
-    keyless gateway flow does not serve (whose protected-resource metadata never directs a
-    client here). ``None`` means the flow stays unscoped and byte-identical to today, so a
-    hostile or confused ``resource`` can never widen anything; a resolved server only ever
-    NARROWS the session via the sealed scope.
+    names. An ambiguous single-server reference is returned explicitly so callers reject it
+    with ``invalid_target`` instead of silently widening the grant. ``None`` covers every
+    other shape: absent, the aggregate resource, a foreign host, an unparseable value, a
+    multi-server path, an unknown name, or any server mode the keyless gateway flow does not
+    serve (whose protected-resource metadata never directs a client here). ``None`` keeps
+    the flow unscoped and byte-identical to today; a resolved server only ever NARROWS the
+    session via the sealed scope.
 
     Resolution is an IDENTITY question, deliberately free of the per-IP visibility filter:
     access is enforced where it belongs (grant intersection at admission, IP checks on the
@@ -413,12 +422,16 @@ def resolve_scoped_resource_server(request: Request, resource: str | None) -> MC
         MCPRequestHandler,
     )
     from litellm.proxy._experimental.mcp_server.mcp_server_manager import (  # noqa: PLC0415  # proxy import cycle
+        Ambiguous,
         global_mcp_server_manager,
     )
 
     names: Final = MCPRequestHandler.extract_target_server_names_from_path(canonical[len(base) :])
     if len(names) != 1:
         return None
+    resolution: Final = global_mcp_server_manager.resolve_single_target(names[0])
+    if isinstance(resolution, Ambiguous):
+        return _AmbiguousScopedResource(reference=names[0])
     server: Final = global_mcp_server_manager.get_mcp_server_by_name(names[0])
     if server is None or not server.is_gateway_managed_oauth2:
         return None
@@ -456,7 +469,10 @@ def aggregate_authorize(
     base_url: Final = get_request_base_url(request)
     if session_user_id is None:
         return _login_redirect(base_url, request)
-    scoped_server: Final = resolve_scoped_resource_server(request, resource)
+    scoped_resource: Final = resolve_scoped_resource_server(request, resource)
+    if isinstance(scoped_resource, _AmbiguousScopedResource):
+        return _oauth_error(400, "invalid_target", "resource matches multiple MCP servers")
+    scoped_server: Final = scoped_resource
     handle: Final = secrets.token_urlsafe(24)
     flow: Final = _new_connect_flow(
         session_user_id=session_user_id,
@@ -993,11 +1009,15 @@ def _resource_conflicts_with_scope(
     """True when a scoped grant is being redeemed for a DIFFERENT resource than the one
     sealed into it (RFC 8707 section 2.2: reject with ``invalid_target``). An absent
     ``resource`` never conflicts (the sealed scope still binds the minted session), and an
-    unscoped grant ignores the parameter entirely, exactly as the endpoint always has, so
-    no pre-existing client breaks."""
-    if sealed_resource_server_id is None or resource is None:
+    unscoped grant ignores every non-ambiguous parameter as before. An ambiguous reference
+    always conflicts so it can never redeem into an unscoped session."""
+    if resource is None:
         return False
     resolved: Final = resolve_scoped_resource_server(request, resource)
+    if isinstance(resolved, _AmbiguousScopedResource):
+        return True
+    if sealed_resource_server_id is None:
+        return False
     return resolved is None or resolved.server_id != sealed_resource_server_id
 
 

--- a/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
+++ b/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
@@ -6258,6 +6258,22 @@ class MCPServerManager:
                 result.setdefault(server_id, []).extend(tools or [])
         return result
 
+    def get_tool_permissions_for_server(
+        self,
+        tool_permissions: dict[str, list[str]] | None,
+        server_id: str,
+    ) -> list[str] | None:
+        """Resolve this server's tool restriction, denying stale logical references."""
+        if not tool_permissions:
+            return None
+        expanded: Final = self.expand_tool_permissions(tool_permissions)
+        if server_id in expanded:
+            return expanded[server_id]
+        has_unresolved_reference: Final = any(
+            isinstance(self.resolve_permission_reference(reference), NotFound) for reference in tool_permissions
+        )
+        return [] if has_unresolved_reference else None
+
     def get_mcp_server_by_name(self, server_name: str, client_ip: str | None = None) -> MCPServer | None:
         """
         Get the MCP Server from the server name.

--- a/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
+++ b/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
@@ -13,10 +13,27 @@ import json
 import os
 import re
 import time
-from collections.abc import AsyncIterator, Awaitable, Callable, Mapping, Sequence
+from collections.abc import (
+    AsyncIterator,
+    Awaitable,
+    Callable,
+    Collection,
+    Mapping,
+    Sequence,
+)
 from contextlib import asynccontextmanager
 from dataclasses import dataclass, replace
-from typing import TYPE_CHECKING, Any, Final, Literal, TypeAlias, TypedDict, cast
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Final,
+    Generic,
+    Literal,
+    TypeAlias,
+    TypedDict,
+    TypeVar,
+    cast,
+)
 from urllib.parse import ParseResult, urlparse
 
 import anyio
@@ -271,6 +288,34 @@ _ToolParamMap: TypeAlias = dict[str, list[str]]
 _EnvVarList: TypeAlias = list[dict[str, object]]
 _InMemoryCacheDict: TypeAlias = dict[str, object]
 _ToolArguments: TypeAlias = dict[str, object]
+
+_ResolutionValue = TypeVar("_ResolutionValue", covariant=True)
+
+
+@dataclass(frozen=True, slots=True)
+class Resolved(Generic[_ResolutionValue]):
+    value: _ResolutionValue
+
+
+@dataclass(frozen=True, slots=True)
+class NotFound:
+    reference: str
+
+
+@dataclass(frozen=True, slots=True)
+class Forbidden:
+    reference: str
+    candidates: tuple[MCPServer, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class Ambiguous:
+    reference: str
+    candidates: tuple[MCPServer, ...]
+
+
+PermissionResolution: TypeAlias = Resolved[tuple[MCPServer, ...]] | NotFound
+SingleTargetResolution: TypeAlias = Resolved[MCPServer] | NotFound | Forbidden | Ambiguous
 
 
 @dataclass(frozen=True, slots=True)
@@ -6067,6 +6112,9 @@ class MCPServerManager:
         internal_networks = IPAddressUtils.parse_internal_networks(general_settings.get("mcp_internal_ip_ranges"))
         return IPAddressUtils.is_internal_ip(client_ip, internal_networks)
 
+    def is_server_accessible_from_ip(self, server: MCPServer, client_ip: str | None) -> bool:
+        return self._is_server_accessible_from_ip(server, client_ip)
+
     def get_mcp_server_by_id(self, server_id: str) -> MCPServer | None:
         """
         Get the MCP Server from the server id
@@ -6112,9 +6160,9 @@ class MCPServerManager:
         Expand a permission list of server_ids/names/aliases into concrete
         server_ids against the current region's config + DB registry union.
 
-        Entries that match a server_id pass through unchanged. Entries that
-        match an alias/server_name/name are replaced with every matching
-        server_id (duplicate names grant access to all matches). Entries
+        Entries that match a server_id pass through unchanged. Otherwise the
+        first matching field wins in alias, server_name, name order, and every
+        server matching that field is included. Entries
         that resolve to nothing pass through as-is and a debug log is
         emitted so admins can diagnose stale/typo permission entries — the
         downstream access-check denies them when compared against the
@@ -6122,19 +6170,11 @@ class MCPServerManager:
         """
         if not identifiers:
             return []
-        registry: Final = self.get_registry()
         expanded: Final[set[str]] = set()
         for identifier in identifiers:
-            if identifier in registry:
-                expanded.add(identifier)
-                continue
-            matches: list[str] = [
-                server_id
-                for server_id, server in registry.items()
-                if server.alias == identifier or server.server_name == identifier or server.name == identifier
-            ]
-            if matches:
-                expanded.update(matches)
+            resolution = self.resolve_permission_reference(identifier)
+            if isinstance(resolution, Resolved):
+                expanded.update(server.server_id for server in resolution.value)
             else:
                 # %r quotes and escapes control chars so an admin-controlled
                 # identifier with newlines cannot forge log lines.
@@ -6146,6 +6186,51 @@ class MCPServerManager:
                 )
                 expanded.add(identifier)
         return list(expanded)
+
+    def _resolve_reference_candidates(
+        self,
+        reference: str,
+        *,
+        include_server_id: bool,
+    ) -> tuple[MCPServer, ...]:
+        servers: Final = tuple(self.get_registry().values())
+        if include_server_id:
+            exact_id_match: Final = self.get_mcp_server_by_id(reference)
+            if exact_id_match is not None:
+                return (exact_id_match,)
+        for attribute in ("alias", "server_name", "name"):
+            matches = tuple(server for server in servers if getattr(server, attribute) == reference)
+            if matches:
+                return matches
+        return ()
+
+    def resolve_permission_reference(self, reference: str) -> PermissionResolution:
+        candidates: Final = self._resolve_reference_candidates(reference, include_server_id=True)
+        if not candidates:
+            return NotFound(reference=reference)
+        return Resolved(value=candidates)
+
+    def resolve_single_target(
+        self,
+        reference: str,
+        allowed_server_ids: Collection[str] | None = None,
+        client_ip: str | None = None,
+    ) -> SingleTargetResolution:
+        permission_resolution: Final = self.resolve_permission_reference(reference)
+        if isinstance(permission_resolution, NotFound):
+            return permission_resolution
+        allowed: Final = frozenset(allowed_server_ids) if allowed_server_ids is not None else None
+        permitted: Final = tuple(
+            server
+            for server in permission_resolution.value
+            if (allowed is None or server.server_id in allowed)
+            and self._is_server_accessible_from_ip(server, client_ip)
+        )
+        if not permitted:
+            return Forbidden(reference=reference, candidates=permission_resolution.value)
+        if len(permitted) > 1:
+            return Ambiguous(reference=reference, candidates=permitted)
+        return Resolved(value=next(iter(permitted)))
 
     def expand_tool_permissions(
         self,
@@ -6180,31 +6265,18 @@ class MCPServerManager:
         2. Second pass: exact server_name match
         3. Third pass: exact name match (lowest priority)
 
+        Returns None when the highest-priority field has multiple accessible matches.
+
         Args:
             server_name: The server name to look up.
             client_ip: Optional client IP for access control. When provided,
                        non-public servers are hidden from external IPs.
         """
-        registry: Final = self.get_registry()
-        # Pass 1: Match by alias (highest priority)
-        for server in registry.values():
-            if server.alias == server_name:
-                if not self._is_server_accessible_from_ip(server, client_ip):
-                    return None
-                return server
-        # Pass 2: Match by server_name
-        for server in registry.values():
-            if server.server_name == server_name:
-                if not self._is_server_accessible_from_ip(server, client_ip):
-                    return None
-                return server
-        # Pass 3: Match by name (lowest priority)
-        for server in registry.values():
-            if server.name == server_name:
-                if not self._is_server_accessible_from_ip(server, client_ip):
-                    return None
-                return server
-        return None
+        candidates: Final = self._resolve_reference_candidates(server_name, include_server_id=False)
+        accessible: Final = tuple(
+            server for server in candidates if self._is_server_accessible_from_ip(server, client_ip)
+        )
+        return accessible[0] if len(accessible) == 1 else None
 
     def get_filtered_registry(self, client_ip: str | None = None) -> dict[str, MCPServer]:
         """

--- a/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
+++ b/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
@@ -6170,22 +6170,22 @@ class MCPServerManager:
         """
         if not identifiers:
             return []
-        expanded: Final[set[str]] = set()
-        for identifier in identifiers:
-            resolution = self.resolve_permission_reference(identifier)
-            if isinstance(resolution, Resolved):
-                expanded.update(server.server_id for server in resolution.value)
-            else:
-                # %r quotes and escapes control chars so an admin-controlled
-                # identifier with newlines cannot forge log lines.
-                verbose_logger.debug(
-                    "MCP permission entry %r does not resolve to any known "
-                    "server (config + DB union). Passing through — the "
-                    "downstream access check will deny it if it's stale.",
-                    identifier,
-                )
-                expanded.add(identifier)
+        expanded: Final = frozenset(
+            server_id for identifier in identifiers for server_id in self._expand_permission_reference(identifier)
+        )
         return list(expanded)
+
+    def _expand_permission_reference(self, identifier: str) -> tuple[str, ...]:
+        resolution: Final = self.resolve_permission_reference(identifier)
+        if isinstance(resolution, Resolved):
+            return tuple(server.server_id for server in resolution.value)
+        verbose_logger.debug(
+            "MCP permission entry %r does not resolve to any known "
+            "server (config + DB union). Passing through — the "
+            "downstream access check will deny it if it's stale.",
+            identifier,
+        )
+        return (identifier,)
 
     def _resolve_reference_candidates(
         self,
@@ -6198,11 +6198,13 @@ class MCPServerManager:
             exact_id_match: Final = self.get_mcp_server_by_id(reference)
             if exact_id_match is not None:
                 return (exact_id_match,)
-        for attribute in ("alias", "server_name", "name"):
-            matches = tuple(server for server in servers if getattr(server, attribute) == reference)
-            if matches:
-                return matches
-        return ()
+        alias_matches: Final = tuple(server for server in servers if server.alias == reference)
+        if alias_matches:
+            return alias_matches
+        server_name_matches: Final = tuple(server for server in servers if server.server_name == reference)
+        if server_name_matches:
+            return server_name_matches
+        return tuple(server for server in servers if server.name == reference)
 
     def resolve_permission_reference(self, reference: str) -> PermissionResolution:
         candidates: Final = self._resolve_reference_candidates(reference, include_server_id=True)

--- a/litellm/proxy/_experimental/mcp_server/rest_endpoints.py
+++ b/litellm/proxy/_experimental/mcp_server/rest_endpoints.py
@@ -2,7 +2,7 @@ import asyncio
 import importlib
 from collections.abc import Awaitable, Callable, Mapping
 from datetime import datetime
-from typing import TYPE_CHECKING, Any, Final, Literal
+from typing import TYPE_CHECKING, Any, Final, Literal, NoReturn, cast
 
 import httpx
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
@@ -90,6 +90,11 @@ if MCP_AVAILABLE:
 
     from litellm.proxy._experimental.mcp_server.mcp_server_manager import (
         _UPSTREAM_OAUTH_DISCOVERY_AUTH_TYPES,
+        Ambiguous,
+        Forbidden,
+        NotFound,
+        Resolved,
+        SingleTargetResolution,
         global_mcp_server_manager,
     )
     from litellm.proxy._experimental.mcp_server.oauth_utils import (
@@ -411,24 +416,77 @@ if MCP_AVAILABLE:
         mcp_server_auth_headers: Final = mcp_request_handler_cls._get_mcp_server_auth_headers_from_headers(headers)
         return mcp_auth_header, mcp_server_auth_headers, raw_headers
 
-    def _resolve_mcp_server_id_for_rest(
+    def _raise_forbidden_rest_server(
+        server_id: str,
+        candidates: tuple[MCPServer, ...],
+        client_ip: str | None,
+    ) -> NoReturn:
+        if client_ip is not None and any(
+            not global_mcp_server_manager.is_server_accessible_from_ip(candidate, client_ip) for candidate in candidates
+        ):
+            raise HTTPException(
+                status_code=403,
+                detail={
+                    "error": "ip_filtering",
+                    "message": (
+                        f"MCP server '{server_id}' is not accessible from your IP address "
+                        f"({client_ip}). This server is restricted to internal "
+                        "networks only. To make it externally accessible, set "
+                        "'available_on_public_internet: true' in the server configuration."
+                    ),
+                },
+            )
+        raise HTTPException(
+            status_code=403,
+            detail={
+                "error": "access_denied",
+                "message": f"The key is not allowed to access server {server_id}",
+            },
+        )
+
+    def _resolve_single_rest_server(
         server_id: str,
         allowed_server_ids: set[str] | list[str],
         client_ip: str | None = None,
-    ) -> str:
-        """
-        Map REST ``server_id`` (UUID, server_name, or alias) to canonical server_id.
-
-        tools/list already did this; tools/call must match so clients can pass
-        server names like ``order_status_mcp`` instead of only UUIDs.
-        """
-        allowed: Final = set(allowed_server_ids)
-        if server_id in allowed:
-            return server_id
-        by_name: Final = global_mcp_server_manager.get_mcp_server_by_name(server_id, client_ip=client_ip)
-        if by_name is not None and by_name.server_id in allowed:
-            return by_name.server_id
-        return server_id
+    ) -> MCPServer:
+        allowed: Final = frozenset(allowed_server_ids)
+        exact_match: Final = global_mcp_server_manager.get_mcp_server_by_id(server_id)
+        if exact_match is not None:
+            if server_id in allowed and global_mcp_server_manager.is_server_accessible_from_ip(exact_match, client_ip):
+                return exact_match
+            _raise_forbidden_rest_server(server_id, (exact_match,), client_ip)
+        resolution: Final[SingleTargetResolution] = global_mcp_server_manager.resolve_single_target(
+            server_id,
+            allowed_server_ids=allowed,
+            client_ip=client_ip,
+        )
+        if isinstance(resolution, Resolved):
+            return cast(MCPServer, resolution.value)
+        if isinstance(resolution, Ambiguous):
+            raise HTTPException(
+                status_code=409,
+                detail={
+                    "error": "ambiguous_mcp_server",
+                    "message": f"MCP server reference '{server_id}' matches multiple permitted servers",
+                },
+            )
+        if isinstance(resolution, NotFound):
+            name_match: Final = global_mcp_server_manager.get_mcp_server_by_name(server_id)
+            if name_match is not None:
+                if name_match.server_id in allowed and global_mcp_server_manager.is_server_accessible_from_ip(
+                    name_match, client_ip
+                ):
+                    return name_match
+                _raise_forbidden_rest_server(server_id, (name_match,), client_ip)
+            raise HTTPException(
+                status_code=404,
+                detail={
+                    "error": "server_not_found",
+                    "message": f"MCP server '{server_id}' was not found",
+                },
+            )
+        assert isinstance(resolution, Forbidden)
+        _raise_forbidden_rest_server(server_id, resolution.candidates, client_ip)
 
     async def _resolve_allowed_mcp_servers_with_ip_filter(
         request: Request,
@@ -465,44 +523,11 @@ if MCP_AVAILABLE:
             global_mcp_server_manager.filter_server_ids_by_ip(list(allowed_server_ids_set), _rest_client_ip)
         )
 
-        canonical_server_id: Final = _resolve_mcp_server_id_for_rest(server_id, allowed_server_ids_set, _rest_client_ip)
-
-        if canonical_server_id not in allowed_server_ids_set:
-            _server: Final = global_mcp_server_manager.get_mcp_server_by_id(
-                server_id
-            ) or global_mcp_server_manager.get_mcp_server_by_name(server_id)
-            if (
-                _server is not None
-                and _rest_client_ip is not None
-                and not global_mcp_server_manager._is_server_accessible_from_ip(_server, _rest_client_ip)
-            ):
-                raise HTTPException(
-                    status_code=403,
-                    detail={
-                        "error": "ip_filtering",
-                        "message": (
-                            f"MCP server '{server_id}' is not accessible from your IP address "
-                            f"({_rest_client_ip}). This server is restricted to internal "
-                            "networks only. To make it externally accessible, set "
-                            "'available_on_public_internet: true' in the server configuration."
-                        ),
-                    },
-                )
-            if _server is None:
-                raise HTTPException(
-                    status_code=404,
-                    detail={
-                        "error": "server_not_found",
-                        "message": f"MCP server '{server_id}' was not found",
-                    },
-                )
-            raise HTTPException(
-                status_code=403,
-                detail={
-                    "error": "access_denied",
-                    "message": f"The key is not allowed to access server {server_id}",
-                },
-            )
+        target_server: Final = _resolve_single_rest_server(
+            server_id,
+            allowed_server_ids_set,
+            _rest_client_ip,
+        )
 
         # Build allowed_mcp_servers list (only include allowed servers)
         allowed_mcp_servers: Final[list[MCPServer]] = []
@@ -511,7 +536,7 @@ if MCP_AVAILABLE:
             if server is not None:
                 allowed_mcp_servers.append(server)
 
-        return allowed_mcp_servers, canonical_server_id
+        return allowed_mcp_servers, target_server.server_id
 
     async def _get_tools_for_single_server(
         server,
@@ -595,46 +620,7 @@ if MCP_AVAILABLE:
         apply_tool_filters: bool = True,
     ) -> dict:
         """Handle tool listing for a single server_id request."""
-        # Resolve a server name to its UUID if needed
-        _name_resolved = None
-        if server_id not in allowed_server_ids:
-            _name_resolved = global_mcp_server_manager.get_mcp_server_by_name(server_id)
-            if _name_resolved is not None and _name_resolved.server_id in set(allowed_server_ids):
-                server_id = _name_resolved.server_id
-
-        if server_id not in allowed_server_ids:
-            _server: Final = global_mcp_server_manager.get_mcp_server_by_id(server_id) or _name_resolved
-            if (
-                _server is not None
-                and rest_client_ip is not None
-                and not global_mcp_server_manager._is_server_accessible_from_ip(_server, rest_client_ip)
-            ):
-                raise HTTPException(
-                    status_code=403,
-                    detail={
-                        "error": "ip_filtering",
-                        "message": (
-                            f"MCP server '{server_id}' is not accessible from your IP address "
-                            f"({rest_client_ip}). This server is restricted to internal "
-                            "networks only. To make it externally accessible, set "
-                            "'available_on_public_internet: true' in the server configuration."
-                        ),
-                    },
-                )
-            raise HTTPException(
-                status_code=403,
-                detail={
-                    "error": "access_denied",
-                    "message": f"The key is not allowed to access server {server_id}",
-                },
-            )
-        server: Final = global_mcp_server_manager.get_mcp_server_by_id(server_id)
-        if server is None:
-            return {
-                "tools": [],
-                "error": "server_not_found",
-                "message": f"Server with id {server_id} not found",
-            }
+        server: Final = _resolve_single_rest_server(server_id, allowed_server_ids, rest_client_ip)
 
         server_auth_header: Final = _get_server_auth_header(server, mcp_server_auth_headers, mcp_auth_header)
         user_oauth_extra_headers: Final = await _get_user_oauth_extra_headers(server, user_api_key_dict)

--- a/litellm/proxy/_experimental/mcp_server/rest_endpoints.py
+++ b/litellm/proxy/_experimental/mcp_server/rest_endpoints.py
@@ -2,7 +2,7 @@ import asyncio
 import importlib
 from collections.abc import Awaitable, Callable, Mapping
 from datetime import datetime
-from typing import TYPE_CHECKING, Any, Final, Literal, NoReturn, cast
+from typing import TYPE_CHECKING, Any, Final, Literal, NoReturn
 
 import httpx
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
@@ -92,6 +92,7 @@ if MCP_AVAILABLE:
         _UPSTREAM_OAUTH_DISCOVERY_AUTH_TYPES,
         Ambiguous,
         Forbidden,
+        MCPServerManager,
         NotFound,
         Resolved,
         SingleTargetResolution,
@@ -420,9 +421,10 @@ if MCP_AVAILABLE:
         server_id: str,
         candidates: tuple[MCPServer, ...],
         client_ip: str | None,
+        mcp_server_manager: MCPServerManager,
     ) -> NoReturn:
         if client_ip is not None and any(
-            not global_mcp_server_manager.is_server_accessible_from_ip(candidate, client_ip) for candidate in candidates
+            not mcp_server_manager.is_server_accessible_from_ip(candidate, client_ip) for candidate in candidates
         ):
             raise HTTPException(
                 status_code=403,
@@ -448,20 +450,22 @@ if MCP_AVAILABLE:
         server_id: str,
         allowed_server_ids: set[str] | list[str],
         client_ip: str | None = None,
+        mcp_server_manager: MCPServerManager | None = None,
     ) -> MCPServer:
+        manager: Final = mcp_server_manager or global_mcp_server_manager
         allowed: Final = frozenset(allowed_server_ids)
-        exact_match: Final = global_mcp_server_manager.get_mcp_server_by_id(server_id)
+        exact_match: Final = manager.get_mcp_server_by_id(server_id)
         if exact_match is not None:
-            if server_id in allowed and global_mcp_server_manager.is_server_accessible_from_ip(exact_match, client_ip):
+            if server_id in allowed and manager.is_server_accessible_from_ip(exact_match, client_ip):
                 return exact_match
-            _raise_forbidden_rest_server(server_id, (exact_match,), client_ip)
-        resolution: Final[SingleTargetResolution] = global_mcp_server_manager.resolve_single_target(
+            _raise_forbidden_rest_server(server_id, (exact_match,), client_ip, manager)
+        resolution: Final[SingleTargetResolution] = manager.resolve_single_target(
             server_id,
             allowed_server_ids=allowed,
             client_ip=client_ip,
         )
         if isinstance(resolution, Resolved):
-            return cast(MCPServer, resolution.value)
+            return resolution.value
         if isinstance(resolution, Ambiguous):
             raise HTTPException(
                 status_code=409,
@@ -471,13 +475,11 @@ if MCP_AVAILABLE:
                 },
             )
         if isinstance(resolution, NotFound):
-            name_match: Final = global_mcp_server_manager.get_mcp_server_by_name(server_id)
+            name_match: Final = manager.get_mcp_server_by_name(server_id)
             if name_match is not None:
-                if name_match.server_id in allowed and global_mcp_server_manager.is_server_accessible_from_ip(
-                    name_match, client_ip
-                ):
+                if name_match.server_id in allowed and manager.is_server_accessible_from_ip(name_match, client_ip):
                     return name_match
-                _raise_forbidden_rest_server(server_id, (name_match,), client_ip)
+                _raise_forbidden_rest_server(server_id, (name_match,), client_ip, manager)
             raise HTTPException(
                 status_code=404,
                 detail={
@@ -485,8 +487,15 @@ if MCP_AVAILABLE:
                     "message": f"MCP server '{server_id}' was not found",
                 },
             )
-        assert isinstance(resolution, Forbidden)
-        _raise_forbidden_rest_server(server_id, resolution.candidates, client_ip)
+        if isinstance(resolution, Forbidden):
+            _raise_forbidden_rest_server(server_id, resolution.candidates, client_ip, manager)
+        raise HTTPException(
+            status_code=404,
+            detail={
+                "error": "server_not_found",
+                "message": f"MCP server '{server_id}' was not found",
+            },
+        )
 
     async def _resolve_allowed_mcp_servers_with_ip_filter(
         request: Request,
@@ -620,7 +629,16 @@ if MCP_AVAILABLE:
         apply_tool_filters: bool = True,
     ) -> dict:
         """Handle tool listing for a single server_id request."""
-        server: Final = _resolve_single_rest_server(server_id, allowed_server_ids, rest_client_ip)
+        try:
+            server: Final = _resolve_single_rest_server(server_id, allowed_server_ids, rest_client_ip)
+        except HTTPException as e:
+            if e.status_code != 404 or server_id not in allowed_server_ids:
+                raise
+            return {
+                "tools": [],
+                "error": "server_not_found",
+                "message": f"Server with id {server_id} not found",
+            }
 
         server_auth_header: Final = _get_server_auth_header(server, mcp_server_auth_headers, mcp_auth_header)
         user_oauth_extra_headers: Final = await _get_user_oauth_extra_headers(server, user_api_key_dict)

--- a/litellm/proxy/_experimental/mcp_server/server.py
+++ b/litellm/proxy/_experimental/mcp_server/server.py
@@ -1410,6 +1410,16 @@ if MCP_AVAILABLE:
                     "message": f"MCP server reference '{server_or_group}' matches multiple permitted servers",
                 },
             )
+        if isinstance(resolution, Forbidden) and any(
+            candidate.server_id == server_or_group for candidate in resolution.candidates
+        ):
+            raise HTTPException(
+                status_code=403,
+                detail={
+                    "error": "access_denied",
+                    "message": f"The key is not allowed to access server {server_or_group}",
+                },
+            )
 
         prefix_matches: Final = tuple(
             server
@@ -3800,12 +3810,20 @@ if MCP_AVAILABLE:
         a server it will be 403'd on immediately after authentication.
         """
         for server_name in mcp_servers or []:
-            server = global_mcp_server_manager.get_mcp_server_by_name(server_name, client_ip=client_ip)
-            if server is not None and allowed_server_ids is not None and server.server_id not in allowed_server_ids:
-                # Caller's narrowed scope excludes this server — skip the
-                # preemptive challenge and let downstream authorization
-                # return 403.
-                continue
+            if allowed_server_ids is not None:
+                resolution = global_mcp_server_manager.resolve_single_target(
+                    server_name,
+                    allowed_server_ids=allowed_server_ids,
+                    client_ip=client_ip,
+                )
+                if not isinstance(resolution, Resolved):
+                    # A forbidden or ambiguous server reference remains in the
+                    # server namespace, but there is no single authorized target
+                    # whose OAuth mode can be challenged here.
+                    continue
+                server = resolution.value
+            else:
+                server = global_mcp_server_manager.get_mcp_server_by_name(server_name, client_ip=client_ip)
             if server is not None and server.auth_type == MCPAuth.oauth2 and server.oauth2_flow == "client_credentials":
                 # Stamped M2M: the challenge decision below never reads discovered
                 # metadata, so deferred-discovery failures must not 503 this loop.

--- a/litellm/proxy/_experimental/mcp_server/server.py
+++ b/litellm/proxy/_experimental/mcp_server/server.py
@@ -15,7 +15,7 @@ import types
 import uuid
 from collections.abc import AsyncIterator, Callable, Mapping, Sequence
 from datetime import datetime
-from typing import TYPE_CHECKING, Any, Final, Protocol
+from typing import TYPE_CHECKING, Any, Final, Protocol, cast
 
 import httpx
 from fastapi import FastAPI, HTTPException
@@ -428,7 +428,11 @@ if MCP_AVAILABLE:
         outcome_wire_value,
     )
     from litellm.proxy._experimental.mcp_server.mcp_server_manager import (
+        Ambiguous,
+        Forbidden,
         MCPServerManager,
+        Resolved,
+        SingleTargetResolution,
         _caller_authorization_fans_out,
         _client_forwarded_authorization_headers,
         _resolve_openapi_tool_auth,
@@ -1398,32 +1402,64 @@ if MCP_AVAILABLE:
         """
 
         filtered_server: Final[dict[str, MCPServer]] = {}
+        allowed_server_ids: Final = frozenset(server.server_id for server in allowed_mcp_servers)
         # Filter servers based on mcp_servers parameter if provided
         if mcp_servers is not None:
             for server_or_group in mcp_servers:
-                server_name_matched = False
+                resolution: SingleTargetResolution = global_mcp_server_manager.resolve_single_target(
+                    server_or_group,
+                    allowed_server_ids=allowed_server_ids,
+                )
+                if isinstance(resolution, Resolved):
+                    resolved_server: MCPServer = cast(MCPServer, resolution.value)
+                    filtered_server[resolved_server.server_id] = resolved_server
+                    continue
+                elif isinstance(resolution, Ambiguous):
+                    raise HTTPException(
+                        status_code=409,
+                        detail={
+                            "error": "ambiguous_mcp_server",
+                            "message": f"MCP server reference '{server_or_group}' matches multiple permitted servers",
+                        },
+                    )
+                elif isinstance(resolution, Forbidden):
+                    raise HTTPException(
+                        status_code=403,
+                        detail={
+                            "error": "access_denied",
+                            "message": f"The key is not allowed to access server {server_or_group}",
+                        },
+                    )
+                prefix_matches = tuple(
+                    server
+                    for server in allowed_mcp_servers
+                    if server_or_group.lower()
+                    in tuple(prefix.lower() for prefix in iter_known_server_prefixes(server) if prefix)
+                )
+                if len(prefix_matches) > 1:
+                    raise HTTPException(
+                        status_code=409,
+                        detail={
+                            "error": "ambiguous_mcp_server",
+                            "message": f"MCP server reference '{server_or_group}' matches multiple permitted servers",
+                        },
+                    )
+                if prefix_matches:
+                    matched_server = prefix_matches[0]
+                    filtered_server[matched_server.server_id] = matched_server
+                    continue
 
-                for server in allowed_mcp_servers:
-                    if server:
-                        match_list = [s.lower() for s in iter_known_server_prefixes(server) if s]
-
-                        if server_or_group.lower() in match_list:
-                            filtered_server[server.server_id] = server
-                            server_name_matched = True
-                            break
-
-                if not server_name_matched:
-                    try:
-                        access_group_server_ids = await MCPRequestHandler._get_mcp_servers_from_access_groups(
-                            [server_or_group]
-                        )
-                        # Only include servers that the user has access to
-                        for server_id in access_group_server_ids:
-                            for server in allowed_mcp_servers:
-                                if server_id == server.server_id:
-                                    filtered_server[server.server_id] = server
-                    except Exception as e:
-                        verbose_logger.debug("Could not resolve '%s' as access group: %s", server_or_group, e)
+                try:
+                    access_group_server_ids = await MCPRequestHandler._get_mcp_servers_from_access_groups(
+                        [server_or_group]
+                    )
+                    # Only include servers that the user has access to
+                    for server_id in access_group_server_ids:
+                        for server in allowed_mcp_servers:
+                            if server_id == server.server_id:
+                                filtered_server[server.server_id] = server
+                except Exception as e:
+                    verbose_logger.debug("Could not resolve '%s' as access group: %s", server_or_group, e)
 
         if filtered_server:
             return list(filtered_server.values())

--- a/litellm/proxy/_experimental/mcp_server/server.py
+++ b/litellm/proxy/_experimental/mcp_server/server.py
@@ -13,9 +13,9 @@ import time
 import traceback
 import types
 import uuid
-from collections.abc import AsyncIterator, Callable, Mapping, Sequence
+from collections.abc import AsyncIterator, Awaitable, Callable, Mapping, Sequence
 from datetime import datetime
-from typing import TYPE_CHECKING, Any, Final, Protocol, cast
+from typing import TYPE_CHECKING, Any, Final, Protocol
 
 import httpx
 from fastapi import FastAPI, HTTPException
@@ -416,6 +416,9 @@ if MCP_AVAILABLE:
     )
     from mcp.types import Tool as MCPTool
 
+    from litellm.proxy._experimental.mcp_server import (
+        mcp_server_manager as mcp_server_manager_module,
+    )
     from litellm.proxy._experimental.mcp_server.auth.litellm_auth_handler import (
         MCPAuthenticatedUser,
     )
@@ -1386,9 +1389,79 @@ if MCP_AVAILABLE:
     ############ Helper Functions ##########################
     ########################################################
 
+    async def _resolve_allowed_mcp_server_reference(
+        server_or_group: str,
+        allowed_mcp_servers: list[MCPServer],
+        allowed_server_ids: frozenset[str],
+        mcp_server_manager: MCPServerManager,
+        access_group_resolver: Callable[[list[str]], Awaitable[list[str]]],
+    ) -> tuple[MCPServer, ...]:
+        resolution: Final[SingleTargetResolution] = mcp_server_manager.resolve_single_target(
+            server_or_group,
+            allowed_server_ids=allowed_server_ids,
+        )
+        if isinstance(resolution, Resolved):
+            return (resolution.value,)
+        if isinstance(resolution, Ambiguous):
+            raise HTTPException(
+                status_code=409,
+                detail={
+                    "error": "ambiguous_mcp_server",
+                    "message": f"MCP server reference '{server_or_group}' matches multiple permitted servers",
+                },
+            )
+
+        prefix_matches: Final = tuple(
+            server
+            for server in allowed_mcp_servers
+            if server_or_group.lower()
+            in tuple(prefix.lower() for prefix in iter_known_server_prefixes(server) if prefix)
+        )
+        if len(prefix_matches) > 1:
+            raise HTTPException(
+                status_code=409,
+                detail={
+                    "error": "ambiguous_mcp_server",
+                    "message": f"MCP server reference '{server_or_group}' matches multiple permitted servers",
+                },
+            )
+        if prefix_matches:
+            return prefix_matches
+
+        try:
+            access_group_server_ids: Final = frozenset(await access_group_resolver([server_or_group]))
+        except Exception as e:
+            verbose_logger.debug("Could not resolve '%s' as access group: %s", server_or_group, e)
+            if isinstance(resolution, Forbidden):
+                raise HTTPException(
+                    status_code=403,
+                    detail={
+                        "error": "access_denied",
+                        "message": f"The key is not allowed to access server {server_or_group}",
+                    },
+                )
+            return ()
+
+        access_group_matches: Final = tuple(
+            server for server in allowed_mcp_servers if server.server_id in access_group_server_ids
+        )
+        if access_group_matches:
+            return access_group_matches
+        if isinstance(resolution, Forbidden):
+            raise HTTPException(
+                status_code=403,
+                detail={
+                    "error": "access_denied",
+                    "message": f"The key is not allowed to access server {server_or_group}",
+                },
+            )
+        return ()
+
     async def _get_allowed_mcp_servers_from_mcp_server_names(
         mcp_servers: list[str] | None,
         allowed_mcp_servers: list[MCPServer],
+        mcp_server_manager: MCPServerManager | None = None,
+        access_group_resolver: Callable[[list[str]], Awaitable[list[str]]] | None = None,
     ) -> list[MCPServer]:
         """
         Get the filtered MCP servers from the MCP server names.
@@ -1401,80 +1474,35 @@ if MCP_AVAILABLE:
         namespacing appear to work when it did not.
         """
 
-        filtered_server: Final[dict[str, MCPServer]] = {}
+        if mcp_servers is None:
+            return allowed_mcp_servers
+
+        manager: Final = mcp_server_manager or mcp_server_manager_module.global_mcp_server_manager
+        resolve_access_group: Final = access_group_resolver or MCPRequestHandler._get_mcp_servers_from_access_groups
         allowed_server_ids: Final = frozenset(server.server_id for server in allowed_mcp_servers)
-        # Filter servers based on mcp_servers parameter if provided
-        if mcp_servers is not None:
-            for server_or_group in mcp_servers:
-                resolution: SingleTargetResolution = global_mcp_server_manager.resolve_single_target(
+        resolved_groups: Final = tuple(
+            [
+                await _resolve_allowed_mcp_server_reference(
                     server_or_group,
-                    allowed_server_ids=allowed_server_ids,
+                    allowed_mcp_servers,
+                    allowed_server_ids,
+                    manager,
+                    resolve_access_group,
                 )
-                if isinstance(resolution, Resolved):
-                    resolved_server: MCPServer = cast(MCPServer, resolution.value)
-                    filtered_server[resolved_server.server_id] = resolved_server
-                    continue
-                elif isinstance(resolution, Ambiguous):
-                    raise HTTPException(
-                        status_code=409,
-                        detail={
-                            "error": "ambiguous_mcp_server",
-                            "message": f"MCP server reference '{server_or_group}' matches multiple permitted servers",
-                        },
-                    )
-                elif isinstance(resolution, Forbidden):
-                    raise HTTPException(
-                        status_code=403,
-                        detail={
-                            "error": "access_denied",
-                            "message": f"The key is not allowed to access server {server_or_group}",
-                        },
-                    )
-                prefix_matches = tuple(
-                    server
-                    for server in allowed_mcp_servers
-                    if server_or_group.lower()
-                    in tuple(prefix.lower() for prefix in iter_known_server_prefixes(server) if prefix)
-                )
-                if len(prefix_matches) > 1:
-                    raise HTTPException(
-                        status_code=409,
-                        detail={
-                            "error": "ambiguous_mcp_server",
-                            "message": f"MCP server reference '{server_or_group}' matches multiple permitted servers",
-                        },
-                    )
-                if prefix_matches:
-                    matched_server = prefix_matches[0]
-                    filtered_server[matched_server.server_id] = matched_server
-                    continue
+                for server_or_group in mcp_servers
+            ]
+        )
+        filtered_servers: Final = {
+            server.server_id: server for resolved_group in resolved_groups for server in resolved_group
+        }
+        if filtered_servers:
+            return list(filtered_servers.values())
 
-                try:
-                    access_group_server_ids = await MCPRequestHandler._get_mcp_servers_from_access_groups(
-                        [server_or_group]
-                    )
-                    # Only include servers that the user has access to
-                    for server_id in access_group_server_ids:
-                        for server in allowed_mcp_servers:
-                            if server_id == server.server_id:
-                                filtered_server[server.server_id] = server
-                except Exception as e:
-                    verbose_logger.debug("Could not resolve '%s' as access group: %s", server_or_group, e)
-
-        if filtered_server:
-            return list(filtered_server.values())
-
-        if mcp_servers is not None:
-            # Caller asked for a specific scope but nothing resolved. Fail
-            # closed so URL/header namespacing cannot silently fall back to
-            # the caller's full allowed-server set.
-            verbose_logger.debug(
-                "MCP scope filter resolved to no servers for requested names %s; returning empty list (fail-closed).",
-                mcp_servers,
-            )
-            return []
-
-        return allowed_mcp_servers
+        verbose_logger.debug(
+            "MCP scope filter resolved to no servers for requested names %s; returning empty list (fail-closed).",
+            mcp_servers,
+        )
+        return []
 
     def _tool_name_matches(tool_name: str, filter_list: list[str], mcp_server: MCPServer) -> bool:
         """

--- a/litellm/proxy/management_endpoints/mcp_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/mcp_management_endpoints.py
@@ -22,7 +22,7 @@ import os
 from collections.abc import Iterable, Mapping, Sequence
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
-from typing import TYPE_CHECKING, Final, Literal, Protocol
+from typing import TYPE_CHECKING, Final, Literal, Protocol, cast
 
 from fastapi import (
     APIRouter,
@@ -162,6 +162,11 @@ if MCP_AVAILABLE:
         resolve_ephemeral_dcr_client,
     )
     from litellm.proxy._experimental.mcp_server.mcp_server_manager import (
+        Ambiguous,
+        Forbidden,
+        NotFound,
+        Resolved,
+        SingleTargetResolution,
         global_mcp_server_manager,
     )
     from litellm.proxy._experimental.mcp_server.ui_session_utils import (
@@ -1922,43 +1927,59 @@ if MCP_AVAILABLE:
         user_api_key_dict: UserAPIKeyAuth,
         request: Request | None = None,
     ) -> MCPServer:
-        server = await get_cached_temporary_mcp_server(server_id)
-        resolved_from_temp_cache: Final = server is not None
-        if server is None:
-            # Fall back to real DB/config server (e.g. for the user-side OAuth flow
-            # which calls these endpoints with a real server_id, not a temp session id).
-            from litellm.proxy.auth.ip_address_utils import IPAddressUtils
+        temporary_server: Final = await get_cached_temporary_mcp_server(server_id)
+        is_admin: Final = _user_has_admin_view(user_api_key_dict)
+        if temporary_server is not None:
+            if is_admin:
+                return temporary_server
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail={"error": f"Access denied to MCP server {server_id}"},
+            )
 
-            client_ip: Final = IPAddressUtils.get_mcp_client_ip(request) if request else None
-            server = global_mcp_server_manager.get_mcp_server_by_id(
-                server_id
-            ) or global_mcp_server_manager.get_mcp_server_by_name(server_id, client_ip=client_ip)
-        if server is None:
+        from litellm.proxy.auth.ip_address_utils import IPAddressUtils
+
+        client_ip: Final = IPAddressUtils.get_mcp_client_ip(request) if request else None
+        auth_contexts: Final = () if is_admin else tuple(await build_effective_auth_contexts(user_api_key_dict))
+        allowed_by_context: Final[tuple[list[str], ...]] = tuple(
+            [await global_mcp_server_manager.get_allowed_mcp_servers(auth_context) for auth_context in auth_contexts]
+        )
+        allowed_server_ids: Final[frozenset[str] | None] = (
+            None if is_admin else frozenset(server_id for server_ids in allowed_by_context for server_id in server_ids)
+        )
+
+        exact_server: Final = global_mcp_server_manager.get_mcp_server_by_id(server_id)
+        if exact_server is not None:
+            is_allowed: Final = allowed_server_ids is None or exact_server.server_id in allowed_server_ids
+            if is_allowed and global_mcp_server_manager.is_server_accessible_from_ip(exact_server, client_ip):
+                return exact_server
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail={"error": f"Access denied to MCP server {server_id}"},
+            )
+
+        resolution: Final[SingleTargetResolution] = global_mcp_server_manager.resolve_single_target(
+            server_id,
+            allowed_server_ids=allowed_server_ids,
+            client_ip=client_ip,
+        )
+        if isinstance(resolution, Resolved):
+            return cast(MCPServer, resolution.value)
+        if isinstance(resolution, NotFound):
             raise HTTPException(
                 status_code=status.HTTP_404_NOT_FOUND,
                 detail={"error": f"MCP server {server_id} not found"},
             )
-
-        # Per-server access policy mirrors `fetch_mcp_server`: admin-view
-        # callers are unrestricted; non-admins must have the server in their
-        # allowed-servers set. Temporary cached servers come from the
-        # admin-only `/server/oauth/session` setup flow and are not exposed
-        # to non-admins.
-        if not _user_has_admin_view(user_api_key_dict):
-            if resolved_from_temp_cache:
-                raise HTTPException(
-                    status_code=status.HTTP_403_FORBIDDEN,
-                    detail={"error": f"Access denied to MCP server {server_id}"},
-                )
-            allowed_server_ids: Final[set[str]] = set()
-            for auth_context in await build_effective_auth_contexts(user_api_key_dict):
-                allowed_server_ids.update(await global_mcp_server_manager.get_allowed_mcp_servers(auth_context))
-            if server.server_id not in allowed_server_ids:
-                raise HTTPException(
-                    status_code=status.HTTP_403_FORBIDDEN,
-                    detail={"error": f"Access denied to MCP server {server_id}"},
-                )
-        return server
+        if isinstance(resolution, Forbidden):
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail={"error": f"Access denied to MCP server {server_id}"},
+            )
+        assert isinstance(resolution, Ambiguous)
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail={"error": f"MCP server reference {server_id} is ambiguous"},
+        )
 
     @router.get(
         "/server/oauth/{server_id}/authorize",

--- a/litellm/proxy/management_endpoints/mcp_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/mcp_management_endpoints.py
@@ -19,10 +19,10 @@ import functools
 import importlib
 import json
 import os
-from collections.abc import Iterable, Mapping, Sequence
+from collections.abc import Awaitable, Callable, Iterable, Mapping, Sequence
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
-from typing import TYPE_CHECKING, Final, Literal, Protocol, cast
+from typing import TYPE_CHECKING, Final, Literal, Protocol
 
 from fastapi import (
     APIRouter,
@@ -164,6 +164,7 @@ if MCP_AVAILABLE:
     from litellm.proxy._experimental.mcp_server.mcp_server_manager import (
         Ambiguous,
         Forbidden,
+        MCPServerManager,
         NotFound,
         Resolved,
         SingleTargetResolution,
@@ -1926,8 +1927,12 @@ if MCP_AVAILABLE:
         server_id: str,
         user_api_key_dict: UserAPIKeyAuth,
         request: Request | None = None,
+        mcp_server_manager: MCPServerManager | None = None,
+        temporary_server_getter: Callable[[str], Awaitable[MCPServer | None]] | None = None,
     ) -> MCPServer:
-        temporary_server: Final = await get_cached_temporary_mcp_server(server_id)
+        manager: Final = mcp_server_manager or global_mcp_server_manager
+        get_temporary_server: Final = temporary_server_getter or get_cached_temporary_mcp_server
+        temporary_server: Final = await get_temporary_server(server_id)
         is_admin: Final = _user_has_admin_view(user_api_key_dict)
         if temporary_server is not None:
             if is_admin:
@@ -1942,29 +1947,29 @@ if MCP_AVAILABLE:
         client_ip: Final = IPAddressUtils.get_mcp_client_ip(request) if request else None
         auth_contexts: Final = () if is_admin else tuple(await build_effective_auth_contexts(user_api_key_dict))
         allowed_by_context: Final[tuple[list[str], ...]] = tuple(
-            [await global_mcp_server_manager.get_allowed_mcp_servers(auth_context) for auth_context in auth_contexts]
+            [await manager.get_allowed_mcp_servers(auth_context) for auth_context in auth_contexts]
         )
         allowed_server_ids: Final[frozenset[str] | None] = (
             None if is_admin else frozenset(server_id for server_ids in allowed_by_context for server_id in server_ids)
         )
 
-        exact_server: Final = global_mcp_server_manager.get_mcp_server_by_id(server_id)
+        exact_server: Final = manager.get_mcp_server_by_id(server_id)
         if exact_server is not None:
             is_allowed: Final = allowed_server_ids is None or exact_server.server_id in allowed_server_ids
-            if is_allowed and global_mcp_server_manager.is_server_accessible_from_ip(exact_server, client_ip):
+            if is_allowed and manager.is_server_accessible_from_ip(exact_server, client_ip):
                 return exact_server
             raise HTTPException(
                 status_code=status.HTTP_403_FORBIDDEN,
                 detail={"error": f"Access denied to MCP server {server_id}"},
             )
 
-        resolution: Final[SingleTargetResolution] = global_mcp_server_manager.resolve_single_target(
+        resolution: Final[SingleTargetResolution] = manager.resolve_single_target(
             server_id,
             allowed_server_ids=allowed_server_ids,
             client_ip=client_ip,
         )
         if isinstance(resolution, Resolved):
-            return cast(MCPServer, resolution.value)
+            return resolution.value
         if isinstance(resolution, NotFound):
             raise HTTPException(
                 status_code=status.HTTP_404_NOT_FOUND,

--- a/litellm/proxy/management_helpers/object_permission_utils.py
+++ b/litellm/proxy/management_helpers/object_permission_utils.py
@@ -6,7 +6,7 @@ organizations, teams, and keys.
 import json
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Final, Optional, Protocol, cast
+from typing import TYPE_CHECKING, Final, Optional
 
 from fastapi import HTTPException, status
 
@@ -205,27 +205,20 @@ async def _set_object_permission(
     return data_json
 
 
-class _MCPServerReference(Protocol):
-    @property
-    def server_id(self) -> str: ...
-
-    @property
-    def alias(self) -> str | None: ...
-
-    @property
-    def server_name(self) -> str | None: ...
-
-    @property
-    def name(self) -> str | None: ...
+@dataclass(frozen=True, slots=True)
+class _MCPServerReference:
+    server_id: str
+    alias: str | None
+    server_name: str | None
+    name: str | None
 
 
-def _resolve_identifier_from_servers(servers: Sequence[object], identifier: str) -> set[str]:
-    references: Final = tuple(cast(_MCPServerReference, server) for server in servers)
+def _resolve_identifier_from_servers(servers: Sequence[_MCPServerReference], identifier: str) -> set[str]:
     matches_by_precedence: Final = (
-        {server.server_id for server in references if server.server_id == identifier},
-        {server.server_id for server in references if server.alias == identifier},
-        {server.server_id for server in references if server.server_name == identifier},
-        {server.server_id for server in references if server.name == identifier},
+        {server.server_id for server in servers if server.server_id == identifier},
+        {server.server_id for server in servers if server.alias == identifier},
+        {server.server_id for server in servers if server.server_name == identifier},
+        {server.server_id for server in servers if server.name == identifier},
     )
     return next((matches for matches in matches_by_precedence if matches), set[str]())
 
@@ -267,14 +260,28 @@ async def _resolve_mcp_server_identifiers_to_ids(
         global_mcp_server_manager,
     )
 
-    db_servers: Final[Sequence[object]] = cast(
-        Sequence[object],
-        await _get_db_mcp_servers_by_identifiers(
+    db_servers: Final = tuple(
+        _MCPServerReference(
+            server_id=server.server_id,
+            alias=server.alias,
+            server_name=server.server_name,
+            name=None,
+        )
+        for server in await _get_db_mcp_servers_by_identifiers(
             identifiers=identifiers,
             prisma_client=prisma_client,
-        ),
+        )
     )
-    all_servers: Final = tuple(db_servers) + tuple(global_mcp_server_manager.get_registry().values())
+    registry_servers: Final = tuple(
+        _MCPServerReference(
+            server_id=server.server_id,
+            alias=server.alias,
+            server_name=server.server_name,
+            name=server.name,
+        )
+        for server in global_mcp_server_manager.get_registry().values()
+    )
+    all_servers: Final = db_servers + registry_servers
     return {identifier: _resolve_identifier_from_servers(all_servers, identifier) for identifier in identifiers}
 
 

--- a/litellm/proxy/management_helpers/object_permission_utils.py
+++ b/litellm/proxy/management_helpers/object_permission_utils.py
@@ -6,7 +6,7 @@ organizations, teams, and keys.
 import json
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Final, Optional
+from typing import TYPE_CHECKING, Final, Optional, Protocol, cast
 
 from fastapi import HTTPException, status
 
@@ -205,24 +205,29 @@ async def _set_object_permission(
     return data_json
 
 
-def _dedupe_preserving_order(values: list[str]) -> list[str]:
-    seen: Final[set[str]] = set()
-    result: Final[list[str]] = []
-    for value in values:
-        if value in seen:
-            continue
-        seen.add(value)
-        result.append(value)
-    return result
+class _MCPServerReference(Protocol):
+    @property
+    def server_id(self) -> str: ...
+
+    @property
+    def alias(self) -> str | None: ...
+
+    @property
+    def server_name(self) -> str | None: ...
+
+    @property
+    def name(self) -> str | None: ...
 
 
-def _mcp_server_identifier_matches(server: Any, identifier: str) -> bool:
-    return identifier in {
-        getattr(server, "server_id", None),
-        getattr(server, "alias", None),
-        getattr(server, "server_name", None),
-        getattr(server, "name", None),
-    }
+def _resolve_identifier_from_servers(servers: Sequence[object], identifier: str) -> set[str]:
+    references: Final = tuple(cast(_MCPServerReference, server) for server in servers)
+    matches_by_precedence: Final = (
+        {server.server_id for server in references if server.server_id == identifier},
+        {server.server_id for server in references if server.alias == identifier},
+        {server.server_id for server in references if server.server_name == identifier},
+        {server.server_id for server in references if server.name == identifier},
+    )
+    return next((matches for matches in matches_by_precedence if matches), set[str]())
 
 
 async def _get_db_mcp_servers_by_identifiers(
@@ -262,83 +267,15 @@ async def _resolve_mcp_server_identifiers_to_ids(
         global_mcp_server_manager,
     )
 
-    resolved: Final[dict[str, set[str]]] = {identifier: set() for identifier in identifiers}
-
-    for server in await _get_db_mcp_servers_by_identifiers(
-        identifiers=identifiers,
-        prisma_client=prisma_client,
-    ):
-        server_id = getattr(server, "server_id", None)
-        if not server_id:
-            continue
-        for identifier in identifiers:
-            if _mcp_server_identifier_matches(server, identifier):
-                resolved[identifier].add(server_id)
-
-    for registry_key, server in global_mcp_server_manager.get_registry().items():
-        server_id = getattr(server, "server_id", None) or registry_key
-        if not server_id:
-            continue
-        for identifier in identifiers:
-            if identifier == registry_key or _mcp_server_identifier_matches(server, identifier):
-                resolved[identifier].add(server_id)
-
-    return resolved
-
-
-def _rewrite_object_permission_mcp_servers(
-    object_permission: ObjectPermissionDict,
-    identifier_to_server_ids: dict[str, set[str]],
-) -> None:
-    mcp_servers: Final = object_permission.get("mcp_servers")
-    if not isinstance(mcp_servers, list):
-        return
-
-    normalized_servers: Final[list[str]] = []
-    for identifier in mcp_servers:
-        if identifier == SpecialMCPServerNames.no_mcp_servers.value:
-            normalized_servers.append(SpecialMCPServerNames.no_mcp_servers.value)
-            continue
-        normalized_servers.extend(sorted(identifier_to_server_ids.get(identifier, [])))
-    object_permission["mcp_servers"] = _dedupe_preserving_order(normalized_servers)
-
-
-def _rewrite_object_permission_mcp_tool_permissions(
-    object_permission: ObjectPermissionDict,
-    identifier_to_server_ids: dict[str, set[str]],
-) -> None:
-    mcp_tool_permissions: Final = object_permission.get("mcp_tool_permissions")
-    if not isinstance(mcp_tool_permissions, dict):
-        return
-
-    normalized_tool_permissions: Final[dict[str, list[str]]] = {}
-    for identifier, tools in mcp_tool_permissions.items():
-        if not isinstance(tools, list):
-            tools = []
-        for server_id in sorted(identifier_to_server_ids.get(identifier, [])):
-            normalized_tool_permissions.setdefault(server_id, [])
-            normalized_tool_permissions[server_id].extend(tools)
-
-    object_permission["mcp_tool_permissions"] = {
-        server_id: _dedupe_preserving_order(tools) for server_id, tools in normalized_tool_permissions.items()
-    }
-
-
-def _rewrite_object_permission_mcp_identifiers(
-    object_permission: ObjectPermissionDict | None,
-    identifier_to_server_ids: dict[str, set[str]],
-) -> None:
-    if not object_permission or not isinstance(object_permission, dict):
-        return
-
-    _rewrite_object_permission_mcp_servers(
-        object_permission=object_permission,
-        identifier_to_server_ids=identifier_to_server_ids,
+    db_servers: Final[Sequence[object]] = cast(
+        Sequence[object],
+        await _get_db_mcp_servers_by_identifiers(
+            identifiers=identifiers,
+            prisma_client=prisma_client,
+        ),
     )
-    _rewrite_object_permission_mcp_tool_permissions(
-        object_permission=object_permission,
-        identifier_to_server_ids=identifier_to_server_ids,
-    )
+    all_servers: Final = tuple(db_servers) + tuple(global_mcp_server_manager.get_registry().values())
+    return {identifier: _resolve_identifier_from_servers(all_servers, identifier) for identifier in identifiers}
 
 
 def _flatten_resolved_mcp_server_ids(
@@ -615,10 +552,6 @@ async def validate_key_mcp_servers_against_team(
                 "validate_key_mcp_servers_against_team: ignoring stale MCP server identifiers (no longer in registry or DB): %s",
                 sorted(stale_identifiers),
             )
-        _rewrite_object_permission_mcp_identifiers(
-            object_permission=object_permission,
-            identifier_to_server_ids=identifier_to_server_ids,
-        )
         active_requested_servers: Final = _flatten_resolved_mcp_server_ids(identifier_to_server_ids)
 
         allowed_servers = all_allowed_servers

--- a/litellm/proxy/management_helpers/object_permission_utils.py
+++ b/litellm/proxy/management_helpers/object_permission_utils.py
@@ -403,14 +403,7 @@ async def _get_grandfathered_key_mcp_server_ids(
     """
     if existing_object_permission is None or prisma_client is None:
         return frozenset()
-    raw_tool_perms: Final = existing_object_permission.mcp_tool_permissions or {}
-    tool_perm_keys: Final[frozenset[str]] = frozenset(
-        json.loads(raw_tool_perms).keys() if isinstance(raw_tool_perms, str) else raw_tool_perms.keys()
-    )
-    identifiers: Final = (frozenset(existing_object_permission.mcp_servers or []) | tool_perm_keys) - {
-        SpecialMCPServerNames.no_mcp_servers.value,
-        SpecialMCPServerName.all_proxy_servers.value,
-    }
+    identifiers: Final = _get_existing_key_mcp_server_identifiers(existing_object_permission)
     return frozenset(
         _flatten_resolved_mcp_server_ids(
             await _resolve_mcp_server_identifiers_to_ids(
@@ -419,6 +412,22 @@ async def _get_grandfathered_key_mcp_server_ids(
             )
         )
     )
+
+
+def _get_existing_key_mcp_server_identifiers(
+    existing_object_permission: Optional["LiteLLM_ObjectPermissionTable"],
+) -> frozenset[str]:
+    if existing_object_permission is None:
+        return frozenset()
+    raw_tool_permissions: Final = existing_object_permission.mcp_tool_permissions or {}
+    tool_permissions: Final = (
+        json.loads(raw_tool_permissions) if isinstance(raw_tool_permissions, str) else raw_tool_permissions
+    )
+    tool_permission_keys: Final = frozenset(tool_permissions.keys()) if isinstance(tool_permissions, dict) else frozenset()
+    return (frozenset(existing_object_permission.mcp_servers or []) | tool_permission_keys) - {
+        SpecialMCPServerNames.no_mcp_servers.value,
+        SpecialMCPServerName.all_proxy_servers.value,
+    }
 
 
 async def _get_team_allowed_mcp_servers(
@@ -554,9 +563,22 @@ async def validate_key_mcp_servers_against_team(
         stale_identifiers: Final = {
             identifier for identifier in requested_servers if not identifier_to_server_ids.get(identifier)
         }
+        existing_identifiers: Final = _get_existing_key_mcp_server_identifiers(existing_key_object_permission)
+        new_stale_identifiers: Final = stale_identifiers - existing_identifiers
+        if new_stale_identifiers and not is_proxy_admin and not team_allowed_servers:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail={
+                    "error": (
+                        "Key requests unresolved MCP server references that cannot be authorized: "
+                        f"{sorted(new_stale_identifiers)}. Only proxy admins or keys constrained by an MCP-enabled "
+                        "team may add unresolved logical references."
+                    )
+                },
+            )
         if stale_identifiers:
             verbose_proxy_logger.warning(
-                "validate_key_mcp_servers_against_team: ignoring stale MCP server identifiers (no longer in registry or DB): %s",
+                "validate_key_mcp_servers_against_team: preserving MCP server identifiers unresolved in this region: %s",
                 sorted(stale_identifiers),
             )
         active_requested_servers: Final = _flatten_resolved_mcp_server_ids(identifier_to_server_ids)

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -18152,6 +18152,26 @@ async def _mcp_forward_as_path(path_segment: str, request: Request):
     return await _stream_mcp_asgi_response(handle_streamable_http_mcp, scope, request.receive)
 
 
+def _is_mcp_server_namespace_reference(reference: str, client_ip: str | None) -> bool:
+    """Return whether ``reference`` belongs to the MCP server namespace.
+
+    The legacy lookup is a useful fast path for unique matches, but returns
+    ``None`` for ambiguity and IP-inaccessible matches as well as for missing
+    references. Only the latter may fall through to another namespace.
+    """
+    from litellm.proxy._experimental.mcp_server.mcp_server_manager import (
+        Ambiguous,
+        Forbidden,
+        Resolved,
+        global_mcp_server_manager,
+    )
+
+    if global_mcp_server_manager.get_mcp_server_by_name(reference, client_ip=client_ip) is not None:
+        return True
+    resolution = global_mcp_server_manager.resolve_single_target(reference, client_ip=client_ip)
+    return isinstance(resolution, (Resolved, Ambiguous, Forbidden))
+
+
 async def _resolve_mcp_csv_tokens(csv_segment: str, client_ip: str | None) -> list[str]:
     """Validate a comma-separated ``/{name1,name2,...}/mcp`` segment.
 
@@ -18175,9 +18195,6 @@ async def _resolve_mcp_csv_tokens(csv_segment: str, client_ip: str | None) -> li
     list and silently broadens the request scope).
     """
     from litellm.constants import DEFAULT_MCP_NAMESPACE_CSV_MAX_TOKENS
-    from litellm.proxy._experimental.mcp_server.mcp_server_manager import (
-        global_mcp_server_manager,
-    )
 
     seen: Final[set] = set()
     deduped: Final[list[str]] = []
@@ -18192,7 +18209,7 @@ async def _resolve_mcp_csv_tokens(csv_segment: str, client_ip: str | None) -> li
 
     resolved: Final[list[str]] = []
     for token in deduped:
-        if global_mcp_server_manager.get_mcp_server_by_name(token, client_ip=client_ip):
+        if _is_mcp_server_namespace_reference(token, client_ip):
             resolved.append(token)
             continue
         if await _is_mcp_access_group_cached(token):
@@ -18244,15 +18261,13 @@ async def dynamic_mcp_route(mcp_server_name: str, request: Request):
     4. MCP access group tag (DB lookup, cached)
     """
     try:
-        from litellm.proxy._experimental.mcp_server.mcp_server_manager import (
-            global_mcp_server_manager,
-        )
+        from litellm.proxy._experimental.mcp_server.mcp_server_manager import global_mcp_server_manager
         from litellm.proxy.auth.ip_address_utils import IPAddressUtils
 
         client_ip: Final = IPAddressUtils.get_mcp_client_ip(request)
 
         # 1. Registered MCP server alias
-        if global_mcp_server_manager.get_mcp_server_by_name(mcp_server_name, client_ip=client_ip):
+        if _is_mcp_server_namespace_reference(mcp_server_name, client_ip):
             return await _mcp_forward_as_path(mcp_server_name, request)
 
         # 2. Comma-separated list — validate every token resolves to a known

--- a/litellm/responses/mcp/litellm_proxy_mcp_handler.py
+++ b/litellm/responses/mcp/litellm_proxy_mcp_handler.py
@@ -204,6 +204,10 @@ class LiteLLM_Proxy_MCP_Handler:
             List names of allowed MCP servers
         """
         from litellm.proxy._experimental.mcp_server.mcp_server_manager import (
+            Ambiguous,
+            Forbidden,
+            NotFound,
+            Resolved,
             global_mcp_server_manager,
         )
         from litellm.proxy._experimental.mcp_server.server import (
@@ -217,6 +221,7 @@ class LiteLLM_Proxy_MCP_Handler:
             for server_url in (_tool.get("server_url", "") if isinstance(_tool, dict) else "",)
             if isinstance(server_url, str) and server_url.startswith(LITELLM_PROXY_MCP_SERVER_URL_PREFIX)
         ]
+        caller_allowed_server_ids: Final = await global_mcp_server_manager.get_allowed_mcp_servers(user_api_key_auth)
 
         # Resolve toolset names: collect all toolset IDs first, then apply their
         # combined permissions in a single pass so multiple toolsets are unioned
@@ -224,7 +229,20 @@ class LiteLLM_Proxy_MCP_Handler:
         resolved_mcp_servers: Final[list[str]] = []
         resolved_toolset_ids: Final[list[str]] = []
         for name in mcp_servers:
-            if not global_mcp_server_manager.get_mcp_server_by_name(name):
+            server = global_mcp_server_manager.get_mcp_server_by_name(name)
+            resolution = (
+                global_mcp_server_manager.resolve_single_target(
+                    name,
+                    allowed_server_ids=caller_allowed_server_ids,
+                )
+                if server is None
+                else None
+            )
+            is_server_reference: Final = server is not None or isinstance(
+                resolution,
+                (Resolved, Ambiguous, Forbidden),
+            )
+            if not is_server_reference and isinstance(resolution, NotFound):
                 try:
                     from litellm.proxy.proxy_server import prisma_client
 
@@ -282,7 +300,11 @@ class LiteLLM_Proxy_MCP_Handler:
         )
         tools: Final = listing.tools
 
-        allowed_mcp_server_ids: Final = await global_mcp_server_manager.get_allowed_mcp_servers(user_api_key_auth)
+        allowed_mcp_server_ids: Final = (
+            await global_mcp_server_manager.get_allowed_mcp_servers(user_api_key_auth)
+            if resolved_toolset_ids and user_api_key_auth is not None
+            else caller_allowed_server_ids
+        )
         allowed_mcp_servers = global_mcp_server_manager.get_mcp_servers_from_ids(allowed_mcp_server_ids)
 
         allowed_mcp_servers = await _get_allowed_mcp_servers_from_mcp_server_names(

--- a/ruff-strict-budget.json
+++ b/ruff-strict-budget.json
@@ -24,7 +24,7 @@
     "limit": 133
   },
   "ANN401": {
-    "limit": 387
+    "limit": 386
   },
   "ASYNC230": {
     "limit": 11
@@ -147,7 +147,7 @@
     "limit": 3
   },
   "PLR1714": {
-    "limit": 256
+    "limit": 255
   },
   "PLW0127": {
     "limit": 57
@@ -231,7 +231,7 @@
     "limit": 5
   },
   "TID251": {
-    "limit": 1084
+    "limit": 1083
   },
   "TRY002": {
     "limit": 524

--- a/tests/test_litellm/proxy/_experimental/mcp_server/auth/test_user_api_key_auth_mcp.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/auth/test_user_api_key_auth_mcp.py
@@ -335,6 +335,9 @@ class TestMCPRequestHandler:
         mock_manager = MagicMock()
         mock_manager.expand_permission_list = MagicMock(side_effect=lambda servers: servers)
         mock_manager.expand_tool_permissions = MagicMock(side_effect=lambda perms: perms or {})
+        mock_manager.get_tool_permissions_for_server = MagicMock(
+            side_effect=lambda perms, server_id: (perms or {}).get(server_id)
+        )
         mock_manager.resolve_toolset_tool_permissions = AsyncMock(return_value=toolset_perms)
         return mock_manager
 
@@ -503,6 +506,69 @@ class TestMCPRequestHandler:
             )
 
         assert result is None
+
+    @pytest.mark.parametrize("permission_level", ["key", "team", "user", "agent", "org"])
+    async def test_stale_tool_permission_alias_fails_closed_at_every_permission_level(self, permission_level):
+        from litellm.proxy._experimental.mcp_server.mcp_server_manager import (
+            MCPServerManager,
+        )
+        from litellm.types.mcp_server.mcp_server_manager import MCPServer
+
+        manager = MCPServerManager()
+        manager.registry["server-id"] = MCPServer(
+            server_id="server-id",
+            name="new-alias",
+            alias="new-alias",
+            transport="sse",
+        )
+        permission = LiteLLM_ObjectPermissionTable(
+            object_permission_id="permission-id",
+            mcp_tool_permissions={"old-alias": ["read"]},
+        )
+        auth = UserAPIKeyAuth(
+            api_key="test-key",
+            user_id="user-id" if permission_level == "user" else None,
+            agent_id="agent-id" if permission_level == "agent" else None,
+            org_id="org-id" if permission_level == "org" else None,
+        )
+
+        with (
+            patch(
+                "litellm.proxy._experimental.mcp_server.mcp_server_manager.global_mcp_server_manager",
+                manager,
+            ),
+            patch.object(
+                MCPRequestHandler,
+                "_get_key_object_permission",
+                return_value=permission if permission_level == "key" else None,
+            ),
+            patch.object(
+                MCPRequestHandler,
+                "_get_team_object_permission",
+                AsyncMock(return_value=permission if permission_level == "team" else None),
+            ),
+            patch.object(
+                MCPRequestHandler,
+                "_get_user_object_permission",
+                AsyncMock(return_value=permission if permission_level == "user" else None),
+            ),
+            patch.object(
+                MCPRequestHandler,
+                "_get_agent_object_permission",
+                AsyncMock(return_value=permission if permission_level == "agent" else None),
+            ),
+            patch.object(
+                MCPRequestHandler,
+                "_get_org_object_permission",
+                AsyncMock(return_value=permission if permission_level == "org" else None),
+            ),
+        ):
+            result = await MCPRequestHandler.get_allowed_tools_for_server(
+                server_id="server-id",
+                user_api_key_auth=auth,
+            )
+
+        assert result == []
 
     # ------------------------------------------------------------------
     # LIT-5749: toolsets attached to a TEAM, ORG, or internal USER must be
@@ -8791,7 +8857,21 @@ class TestUserMCPEntitlement:
 
     async def test_entitlement_on_another_server_does_not_restrict_this_one(self):
         """Tool grants are per server: naming tools on srv-b places no bound on srv-a."""
-        with patch.object(MCPRequestHandler, "_get_key_object_permission", return_value=None):
+        from litellm.proxy._experimental.mcp_server.mcp_server_manager import (
+            MCPServerManager,
+        )
+        from litellm.types.mcp_server.mcp_server_manager import MCPServer
+
+        manager = MCPServerManager()
+        manager.registry["srv-b"] = MCPServer(
+            server_id="srv-b",
+            name="Server B",
+            transport="sse",
+        )
+        with patch(
+            "litellm.proxy._experimental.mcp_server.mcp_server_manager.global_mcp_server_manager",
+            manager,
+        ), patch.object(MCPRequestHandler, "_get_key_object_permission", return_value=None):
             with patch.object(
                 MCPRequestHandler, "_get_team_object_permission", new_callable=AsyncMock, return_value=None
             ):

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_gateway_dcr_flow.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_gateway_dcr_flow.py
@@ -919,6 +919,27 @@ async def test_scoped_authorize_runs_connect_page_with_sealed_scope():
 
 
 @pytest.mark.asyncio
+async def test_scoped_authorize_rejects_ambiguous_resource_instead_of_minting_unscoped():
+    from unittest.mock import patch
+
+    from litellm.proxy._experimental.mcp_server.mcp_server_manager import (
+        MCPServerManager,
+    )
+
+    client_id = (await _register([REDIRECT_URI]))["client_id"]
+    west = _scoped_mcp_server()
+    central = west.model_copy(update={"server_id": "central-id", "server_name": "central"})
+    manager = MCPServerManager()
+    manager.registry.update({west.server_id: west, central.server_id: central})
+
+    with patch(_MANAGER_PATCH, manager):
+        response = _scoped_authorize(client_id, SCOPED_RESOURCE)
+
+    assert response.status_code == 400
+    assert json.loads(response.body)["error"] == "invalid_target"
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     "resource, resolves",
     [

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server.py
@@ -6995,6 +6995,27 @@ async def test_get_allowed_mcp_servers_from_mcp_server_names_known_alias_returns
 
 
 @pytest.mark.asyncio
+async def test_get_allowed_mcp_servers_from_mcp_server_names_duplicate_alias_is_ambiguous():
+    from litellm.proxy._experimental.mcp_server.server import (
+        _get_allowed_mcp_servers_from_mcp_server_names,
+    )
+
+    allowed = [
+        _make_mcp_server_for_scope_filter("id-a", "github"),
+        _make_mcp_server_for_scope_filter("id-b", "github"),
+    ]
+
+    with pytest.raises(HTTPException) as exc_info:
+        await _get_allowed_mcp_servers_from_mcp_server_names(
+            mcp_servers=["github"],
+            allowed_mcp_servers=allowed,
+        )
+
+    assert exc_info.value.status_code == 409
+    assert exc_info.value.detail["error"] == "ambiguous_mcp_server"
+
+
+@pytest.mark.asyncio
 async def test_get_allowed_mcp_servers_from_mcp_server_names_mixed_known_and_unknown():
     """
     Mixed scope (one valid + one unknown) returns only the resolved server,

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server.py
@@ -8144,6 +8144,36 @@ class TestPreemptive401ModeAware:
         assert "www-authenticate" in {k.lower() for k in exc.value.headers}
 
     @pytest.mark.asyncio
+    async def test_duplicate_alias_challenges_when_toolset_allows_one_server(self):
+        from litellm.proxy._experimental.mcp_server import server as server_module
+        from litellm.proxy._experimental.mcp_server.mcp_server_manager import (
+            MCPServerManager,
+        )
+
+        west = _make_oauth2_server("shared").model_copy(update={"server_id": "west-id", "server_name": "west"})
+        central = west.model_copy(update={"server_id": "central-id", "server_name": "central"})
+        manager = MCPServerManager()
+        manager.registry.update({west.server_id: west, central.server_id: central})
+
+        with (
+            patch.object(server_module, "global_mcp_server_manager", manager),
+            patch.object(manager, "ensure_oauth_metadata_discovered", new=AsyncMock(side_effect=lambda server: server)),
+            patch.object(manager, "has_user_oauth_token", new=AsyncMock(return_value=False)),
+            pytest.raises(HTTPException) as exc,
+        ):
+            await server_module._raise_preemptive_401_for_unauthenticated_servers(
+                scope=self._scope("shared"),
+                mcp_servers=["shared"],
+                oauth2_headers=None,
+                mcp_server_auth_headers=None,
+                user_api_key_auth=UserAPIKeyAuth(api_key="sk-litellm-virtual-key"),
+                client_ip=None,
+                allowed_server_ids={"west-id"},
+            )
+
+        assert exc.value.status_code == 401
+
+    @pytest.mark.asyncio
     @pytest.mark.parametrize(
         "original_path, expected_as_path",
         (

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server.py
@@ -7109,6 +7109,39 @@ async def test_get_allowed_mcp_servers_prefers_allowed_access_group_over_forbidd
 
 
 @pytest.mark.asyncio
+async def test_get_allowed_mcp_servers_forbidden_exact_id_does_not_fall_through_to_alias():
+    from litellm.proxy._experimental.mcp_server.mcp_server_manager import (
+        MCPServerManager,
+    )
+    from litellm.proxy._experimental.mcp_server.server import (
+        _get_allowed_mcp_servers_from_mcp_server_names,
+    )
+
+    exact_id_server = _make_mcp_server_for_scope_filter("west-id", "west")
+    alias_server = _make_mcp_server_for_scope_filter("central-id", "west-id")
+    manager = MCPServerManager()
+    manager.registry.update(
+        {
+            exact_id_server.server_id: exact_id_server,
+            alias_server.server_id: alias_server,
+        }
+    )
+
+    async def resolve_access_group(_: list[str]) -> list[str]:
+        return []
+
+    with pytest.raises(HTTPException) as exc_info:
+        await _get_allowed_mcp_servers_from_mcp_server_names(
+            mcp_servers=["west-id"],
+            allowed_mcp_servers=[alias_server],
+            mcp_server_manager=manager,
+            access_group_resolver=resolve_access_group,
+        )
+
+    assert exc_info.value.status_code == 403
+
+
+@pytest.mark.asyncio
 async def test_get_allowed_mcp_servers_from_mcp_server_names_empty_list_fails_closed():
     """
     Edge case: ``mcp_servers=[]`` (explicit empty scope) is still an

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server.py
@@ -7082,6 +7082,33 @@ async def test_get_allowed_mcp_servers_from_mcp_server_names_access_group_resolv
 
 
 @pytest.mark.asyncio
+async def test_get_allowed_mcp_servers_prefers_allowed_access_group_over_forbidden_alias():
+    from litellm.proxy._experimental.mcp_server.mcp_server_manager import (
+        MCPServerManager,
+    )
+    from litellm.proxy._experimental.mcp_server.server import (
+        _get_allowed_mcp_servers_from_mcp_server_names,
+    )
+
+    allowed = [_make_mcp_server_for_scope_filter("allowed-id", "allowed")]
+    forbidden = _make_mcp_server_for_scope_filter("forbidden-id", "shared-reference")
+    manager = MCPServerManager()
+    manager.registry.update({server.server_id: server for server in (*allowed, forbidden)})
+
+    async def resolve_access_group(_: list[str]) -> list[str]:
+        return ["allowed-id"]
+
+    result = await _get_allowed_mcp_servers_from_mcp_server_names(
+        mcp_servers=["shared-reference"],
+        allowed_mcp_servers=allowed,
+        mcp_server_manager=manager,
+        access_group_resolver=resolve_access_group,
+    )
+
+    assert [server.server_id for server in result] == ["allowed-id"]
+
+
+@pytest.mark.asyncio
 async def test_get_allowed_mcp_servers_from_mcp_server_names_empty_list_fails_closed():
     """
     Edge case: ``mcp_servers=[]`` (explicit empty scope) is still an

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server_manager.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server_manager.py
@@ -7830,6 +7830,29 @@ class TestMCPServerManagerExpandToolPermissions:
         result = manager.expand_tool_permissions({"uuid-a": ["read_file"], "alias-a": ["write_file"]})
         assert sorted(result["uuid-a"]) == ["read_file", "write_file"]
 
+    @pytest.mark.parametrize(
+        ("tool_permissions", "server_id", "expected"),
+        [
+            pytest.param({"alias-a": ["read_file"]}, "uuid-a", ["read_file"], id="target-match"),
+            pytest.param({"old-alias": ["read_file"]}, "uuid-a", [], id="unresolved-reference"),
+            pytest.param({"alias-a": ["read_file"]}, "uuid-b", None, id="resolved-elsewhere"),
+        ],
+    )
+    def test_get_tool_permissions_for_server(self, tool_permissions, server_id, expected):
+        manager = MCPServerManager()
+        manager.config_mcp_servers["uuid-a"] = self._make_server(
+            "uuid-a",
+            server_name="alpha",
+            alias="alias-a",
+        )
+        manager.config_mcp_servers["uuid-b"] = self._make_server(
+            "uuid-b",
+            server_name="beta",
+            alias="alias-b",
+        )
+
+        assert manager.get_tool_permissions_for_server(tool_permissions, server_id) == expected
+
 
 class TestOAuthDiscoverySSRFGuard:
     """SSRF guard for the OAuth metadata discovery follow-up fetches.

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server_manager.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server_manager.py
@@ -32,6 +32,7 @@ from mcp.types import (
 from mcp.types import Tool as MCPTool
 
 from litellm.constants import MCP_METADATA_TIMEOUT
+from litellm.proxy._experimental.mcp_server import mcp_server_manager as manager_module
 from litellm.proxy._experimental.mcp_server.mcp_server_manager import (
     MCPServerManager,
     _deserialize_json_dict,
@@ -7694,6 +7695,72 @@ class TestMCPServerManagerExpandPermissionList:
 
         assert usw1.expand_permission_list(["a"]) == ["hash-usw1"]
         assert usc1.expand_permission_list(["a"]) == ["hash-usc1"]
+
+
+class TestMCPServerManagerReferenceResolution:
+    def _make_server(
+        self,
+        server_id: str,
+        *,
+        alias: str | None = None,
+        server_name: str | None = None,
+        name: str | None = None,
+    ) -> MCPServer:
+        return MCPServer(
+            server_id=server_id,
+            name=name or alias or server_name or server_id,
+            alias=alias,
+            server_name=server_name,
+            url=f"https://{server_id}.example.com",
+            transport=MCPTransport.http,
+        )
+
+    def test_permission_resolution_expands_all_alias_matches(self):
+        manager = MCPServerManager()
+        manager.config_mcp_servers["west-id"] = self._make_server("west-id", alias="github")
+        manager.registry["central-id"] = self._make_server("central-id", alias="github")
+
+        result = manager.resolve_permission_reference("github")
+
+        assert isinstance(result, manager_module.Resolved)
+        assert {server.server_id for server in result.value} == {"west-id", "central-id"}
+        assert manager.get_mcp_server_by_name("github") is None
+
+    def test_single_target_resolution_distinguishes_all_outcomes(self):
+        manager = MCPServerManager()
+        manager.config_mcp_servers["west-id"] = self._make_server("west-id", alias="github")
+        manager.registry["central-id"] = self._make_server("central-id", alias="github")
+
+        ambiguous = manager.resolve_single_target("github", allowed_server_ids={"west-id", "central-id"})
+        resolved = manager.resolve_single_target("github", allowed_server_ids={"central-id"})
+        forbidden = manager.resolve_single_target("github", allowed_server_ids=set())
+        not_found = manager.resolve_single_target("missing", allowed_server_ids={"west-id", "central-id"})
+
+        assert isinstance(ambiguous, manager_module.Ambiguous)
+        assert {server.server_id for server in ambiguous.candidates} == {"west-id", "central-id"}
+        assert isinstance(resolved, manager_module.Resolved)
+        assert resolved.value.server_id == "central-id"
+        assert isinstance(forbidden, manager_module.Forbidden)
+        assert isinstance(not_found, manager_module.NotFound)
+
+    def test_forbidden_exact_id_does_not_fall_through_to_matching_alias(self):
+        manager = MCPServerManager()
+        manager.config_mcp_servers["west-id"] = self._make_server("west-id", alias="west")
+        manager.registry["central-id"] = self._make_server("central-id", alias="west-id")
+
+        result = manager.resolve_single_target("west-id", allowed_server_ids={"central-id"})
+
+        assert isinstance(result, manager_module.Forbidden)
+
+    def test_alias_match_precedes_server_name_match(self):
+        manager = MCPServerManager()
+        manager.config_mcp_servers["alias-id"] = self._make_server("alias-id", alias="github")
+        manager.registry["name-id"] = self._make_server("name-id", server_name="github")
+
+        result = manager.resolve_permission_reference("github")
+
+        assert isinstance(result, manager_module.Resolved)
+        assert tuple(server.server_id for server in result.value) == ("alias-id",)
 
 
 class TestMCPServerManagerExpandToolPermissions:

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_rest_endpoints.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_rest_endpoints.py
@@ -1301,7 +1301,10 @@ class TestListToolsRestAPI:
         assert result["tools"] == ["tool-x"]
         assert result["error"] is None
 
-    async def test_duplicate_alias_returns_ambiguous(self, monkeypatch):
+    async def test_duplicate_alias_returns_ambiguous(self):
+        from litellm.proxy._experimental.mcp_server.mcp_server_manager import (
+            MCPServerManager,
+        )
         from litellm.proxy._experimental.mcp_server.server import MCPServer
         from litellm.types.mcp import MCPTransport
 
@@ -1321,36 +1324,13 @@ class TestListToolsRestAPI:
             transport=MCPTransport.sse,
             available_on_public_internet=True,
         )
-
-        async def fake_contexts(user_api_key_auth):
-            return [user_api_key_auth]
-
-        async def fake_get_allowed_mcp_servers(*args, **kwargs):
-            return ["west-id", "central-id"]
-
-        monkeypatch.setattr(rest_endpoints, "build_effective_auth_contexts", fake_contexts)
-        monkeypatch.setattr(
-            rest_endpoints.global_mcp_server_manager,
-            "get_allowed_mcp_servers",
-            fake_get_allowed_mcp_servers,
-        )
-        monkeypatch.setattr(
-            rest_endpoints.global_mcp_server_manager,
-            "get_registry",
-            lambda: {"west-id": west, "central-id": central},
-        )
-        monkeypatch.setattr(
-            rest_endpoints.global_mcp_server_manager,
-            "filter_server_ids_by_ip_with_info",
-            lambda server_ids, client_ip: (server_ids, 0),
-        )
-
-        request = _build_request(path="/mcp-rest/tools/list", method="GET")
+        manager = MCPServerManager()
+        manager.registry.update({"west-id": west, "central-id": central})
         with pytest.raises(HTTPException) as exc_info:
-            await rest_endpoints.list_tool_rest_api(
-                request,
-                server_id="github",
-                user_api_key_dict=UserAPIKeyAuth(),
+            rest_endpoints._resolve_single_rest_server(
+                "github",
+                ["west-id", "central-id"],
+                mcp_server_manager=manager,
             )
 
         assert exc_info.value.status_code == 409

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_rest_endpoints.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_rest_endpoints.py
@@ -2381,7 +2381,6 @@ class TestGetToolsForSingleServer:
             transport=MCPTransport.sse,
             allowed_tools=None,
         )
-
         object_permission = LiteLLM_ObjectPermissionTable(
             object_permission_id="test-permission-id",
             mcp_tool_permissions=None,  # No tool permissions set
@@ -2433,6 +2432,16 @@ class TestGetToolsForSingleServer:
             name="test-server",
             transport=MCPTransport.sse,
             allowed_tools=None,
+        )
+        other_server = MCPServer(
+            server_id="other-server-id",
+            name="other-server",
+            transport=MCPTransport.sse,
+        )
+        monkeypatch.setitem(
+            rest_endpoints.global_mcp_server_manager.registry,
+            other_server.server_id,
+            other_server,
         )
 
         object_permission = LiteLLM_ObjectPermissionTable(

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_rest_endpoints.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_rest_endpoints.py
@@ -679,7 +679,7 @@ class TestTestToolsList:
 class TestListToolsRestAPI:
     pytestmark = pytest.mark.asyncio
 
-    async def test_rejects_disallowed_server(self, monkeypatch):
+    async def test_unknown_server_returns_not_found(self, monkeypatch):
         async def fake_contexts(user_api_key_auth):
             return [user_api_key_auth]
 
@@ -707,8 +707,8 @@ class TestListToolsRestAPI:
                 user_api_key_dict=UserAPIKeyAuth(),
             )
 
-        assert exc_info.value.status_code == 403
-        assert exc_info.value.detail["error"] == "access_denied"
+        assert exc_info.value.status_code == 404
+        assert exc_info.value.detail["error"] == "server_not_found"
         assert "server-1" in exc_info.value.detail["message"]
 
     async def test_lists_tools_for_allowed_server(self, monkeypatch):
@@ -1300,6 +1300,61 @@ class TestListToolsRestAPI:
         assert captured["server_arg"] is stub_server
         assert result["tools"] == ["tool-x"]
         assert result["error"] is None
+
+    async def test_duplicate_alias_returns_ambiguous(self, monkeypatch):
+        from litellm.proxy._experimental.mcp_server.server import MCPServer
+        from litellm.types.mcp import MCPTransport
+
+        west = MCPServer(
+            server_id="west-id",
+            name="github",
+            alias="github",
+            server_name="github-west",
+            transport=MCPTransport.sse,
+            available_on_public_internet=True,
+        )
+        central = MCPServer(
+            server_id="central-id",
+            name="github",
+            alias="github",
+            server_name="github-central",
+            transport=MCPTransport.sse,
+            available_on_public_internet=True,
+        )
+
+        async def fake_contexts(user_api_key_auth):
+            return [user_api_key_auth]
+
+        async def fake_get_allowed_mcp_servers(*args, **kwargs):
+            return ["west-id", "central-id"]
+
+        monkeypatch.setattr(rest_endpoints, "build_effective_auth_contexts", fake_contexts)
+        monkeypatch.setattr(
+            rest_endpoints.global_mcp_server_manager,
+            "get_allowed_mcp_servers",
+            fake_get_allowed_mcp_servers,
+        )
+        monkeypatch.setattr(
+            rest_endpoints.global_mcp_server_manager,
+            "get_registry",
+            lambda: {"west-id": west, "central-id": central},
+        )
+        monkeypatch.setattr(
+            rest_endpoints.global_mcp_server_manager,
+            "filter_server_ids_by_ip_with_info",
+            lambda server_ids, client_ip: (server_ids, 0),
+        )
+
+        request = _build_request(path="/mcp-rest/tools/list", method="GET")
+        with pytest.raises(HTTPException) as exc_info:
+            await rest_endpoints.list_tool_rest_api(
+                request,
+                server_id="github",
+                user_api_key_dict=UserAPIKeyAuth(),
+            )
+
+        assert exc_info.value.status_code == 409
+        assert exc_info.value.detail["error"] == "ambiguous_mcp_server"
 
     async def test_name_not_in_allowed_returns_access_denied(self, monkeypatch):
         """When name resolves to a server whose UUID is NOT in allowed_server_ids,

--- a/tests/test_litellm/proxy/management_endpoints/test_mcp_management_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_mcp_management_endpoints.py
@@ -2183,18 +2183,16 @@ class TestTemporaryMCPSessionEndpoints:
         )
         admin_auth = generate_mock_user_api_key_auth(user_role=LitellmUserRoles.PROXY_ADMIN)
 
-        with (
-            patch(
-                "litellm.proxy.management_endpoints.mcp_management_endpoints.get_cached_temporary_mcp_server",
-                return_value=None,
-            ),
-            patch(
-                "litellm.proxy.management_endpoints.mcp_management_endpoints.global_mcp_server_manager",
-                manager,
-            ),
-        ):
-            with pytest.raises(HTTPException) as exc_info:
-                await _get_cached_temporary_mcp_server_or_404("github", admin_auth)
+        async def get_temporary_server(_: str) -> None:
+            return None
+
+        with pytest.raises(HTTPException) as exc_info:
+            await _get_cached_temporary_mcp_server_or_404(
+                "github",
+                admin_auth,
+                mcp_server_manager=manager,
+                temporary_server_getter=get_temporary_server,
+            )
 
         assert exc_info.value.status_code == 409
 

--- a/tests/test_litellm/proxy/management_endpoints/test_mcp_management_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_mcp_management_endpoints.py
@@ -2157,6 +2157,48 @@ class TestTemporaryMCPSessionEndpoints:
         mock_manager.get_allowed_mcp_servers.assert_awaited_once_with(non_admin)
 
     @pytest.mark.asyncio
+    async def test_get_cached_temporary_mcp_server_duplicate_alias_is_ambiguous(self):
+        from litellm.proxy._experimental.mcp_server.mcp_server_manager import (
+            MCPServerManager,
+        )
+        from litellm.proxy.management_endpoints.mcp_management_endpoints import (
+            _get_cached_temporary_mcp_server_or_404,
+        )
+        from litellm.types.mcp_server.mcp_server_manager import MCPServer
+
+        manager = MCPServerManager()
+        manager.config_mcp_servers["west-id"] = MCPServer(
+            server_id="west-id",
+            name="github",
+            alias="github",
+            server_name="github-west",
+            transport=MCPTransport.http,
+        )
+        manager.registry["central-id"] = MCPServer(
+            server_id="central-id",
+            name="github",
+            alias="github",
+            server_name="github-central",
+            transport=MCPTransport.http,
+        )
+        admin_auth = generate_mock_user_api_key_auth(user_role=LitellmUserRoles.PROXY_ADMIN)
+
+        with (
+            patch(
+                "litellm.proxy.management_endpoints.mcp_management_endpoints.get_cached_temporary_mcp_server",
+                return_value=None,
+            ),
+            patch(
+                "litellm.proxy.management_endpoints.mcp_management_endpoints.global_mcp_server_manager",
+                manager,
+            ),
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                await _get_cached_temporary_mcp_server_or_404("github", admin_auth)
+
+        assert exc_info.value.status_code == 409
+
+    @pytest.mark.asyncio
     async def test_get_cached_temporary_mcp_server_non_admin_allowed(self):
         """Non-admin with the server in their allowed set gets the server."""
         from litellm.proxy.management_endpoints.mcp_management_endpoints import (

--- a/tests/test_litellm/proxy/management_helpers/test_object_permission_utils.py
+++ b/tests/test_litellm/proxy/management_helpers/test_object_permission_utils.py
@@ -836,6 +836,14 @@ async def test_teamless_non_admin_stale_reference_must_not_rebind_to_future_priv
     mock_prisma_client = MagicMock()
     mock_prisma_client.db.litellm_mcpservertable.find_many = AsyncMock(return_value=[])
 
+    admin_persisted = await validate_key_mcp_servers_against_team(
+        object_permission=stored_permission,
+        team_obj=None,
+        prisma_client=mock_prisma_client,
+        is_proxy_admin=True,
+    )
+    assert admin_persisted == stored_permission
+
     try:
         persisted = await validate_key_mcp_servers_against_team(
             object_permission=stored_permission,
@@ -848,6 +856,25 @@ async def test_teamless_non_admin_stale_reference_must_not_rebind_to_future_priv
         # preserved for cross-region use instead, runtime must keep it from
         # binding to a private server later.
         assert exc.status_code == 403
+        with pytest.raises(HTTPException) as empty_team_exc:
+            await validate_key_mcp_servers_against_team(
+                object_permission=stored_permission,
+                team_obj=_make_team_obj(mcp_servers=[]),
+                prisma_client=mock_prisma_client,
+                is_proxy_admin=False,
+            )
+        assert empty_team_exc.value.status_code == 403
+        grandfathered = await validate_key_mcp_servers_against_team(
+            object_permission=stored_permission,
+            team_obj=None,
+            prisma_client=mock_prisma_client,
+            is_proxy_admin=False,
+            existing_key_object_permission=LiteLLM_ObjectPermissionTable(
+                object_permission_id="existing-permission",
+                **stored_permission,
+            ),
+        )
+        assert grandfathered == stored_permission
         return
 
     assert persisted == stored_permission
@@ -895,7 +922,7 @@ async def test_teamless_non_admin_stale_reference_must_not_rebind_to_future_priv
 
 
 @pytest.mark.asyncio
-async def test_preserved_tool_permission_alias_must_survive_server_alias_rename(
+async def test_stale_tool_permission_alias_fails_closed_after_server_alias_rename(
     monkeypatch,
 ):
     from litellm.proxy._experimental.mcp_server.auth.user_api_key_auth_mcp import (
@@ -977,7 +1004,7 @@ async def test_preserved_tool_permission_alias_must_survive_server_alias_rename(
         user_api_key_auth=auth,
     )
 
-    assert allowed_tools == ["read"]
+    assert allowed_tools == []
 
 
 @pytest.mark.asyncio

--- a/tests/test_litellm/proxy/management_helpers/test_object_permission_utils.py
+++ b/tests/test_litellm/proxy/management_helpers/test_object_permission_utils.py
@@ -797,6 +797,190 @@ async def test_validate_db_mcp_server_alias_outside_team_scope_raises_when_regis
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "stored_permission",
+    [
+        pytest.param({"mcp_servers": ["future-private"]}, id="mcp-servers"),
+        pytest.param(
+            {"mcp_tool_permissions": {"future-private": ["read"]}},
+            id="mcp-tool-permissions",
+        ),
+    ],
+)
+async def test_teamless_non_admin_stale_reference_must_not_rebind_to_future_private_server(
+    monkeypatch, stored_permission
+):
+    from litellm.proxy._experimental.mcp_server.auth.user_api_key_auth_mcp import (
+        MCPRequestHandler,
+    )
+    from litellm.proxy._experimental.mcp_server.mcp_server_manager import (
+        MCPServerManager,
+    )
+    from litellm.proxy._types import UserAPIKeyAuth
+    from litellm.types.mcp_server.mcp_server_manager import MCPServer
+
+    west_manager = MCPServerManager()
+    monkeypatch.setattr(
+        "litellm.proxy._experimental.mcp_server.mcp_server_manager.global_mcp_server_manager",
+        west_manager,
+    )
+    monkeypatch.setattr(
+        "litellm.proxy.management_helpers.object_permission_utils._get_allow_all_keys_server_ids",
+        lambda: set(),
+    )
+    monkeypatch.setattr(
+        MCPRequestHandler,
+        "_get_mcp_servers_from_access_groups",
+        AsyncMock(return_value=[]),
+    )
+    mock_prisma_client = MagicMock()
+    mock_prisma_client.db.litellm_mcpservertable.find_many = AsyncMock(return_value=[])
+
+    try:
+        persisted = await validate_key_mcp_servers_against_team(
+            object_permission=stored_permission,
+            team_obj=None,
+            prisma_client=mock_prisma_client,
+            is_proxy_admin=False,
+        )
+    except HTTPException as exc:
+        # Rejecting an unresolved non-admin grant at write time is safe. If it is
+        # preserved for cross-region use instead, runtime must keep it from
+        # binding to a private server later.
+        assert exc.status_code == 403
+        return
+
+    assert persisted == stored_permission
+
+    central_manager = MCPServerManager()
+    central_manager.registry["private-id"] = MCPServer(
+        server_id="private-id",
+        name="future-private",
+        alias="future-private",
+        transport="sse",
+        allow_all_keys=False,
+    )
+    monkeypatch.setattr(
+        "litellm.proxy._experimental.mcp_server.mcp_server_manager.global_mcp_server_manager",
+        central_manager,
+    )
+    permission_row = LiteLLM_ObjectPermissionTable(
+        object_permission_id="permission-id",
+        **stored_permission,
+    )
+    auth = UserAPIKeyAuth(
+        api_key="test-key",
+        user_id="key-owner",
+        object_permission=permission_row,
+    )
+    monkeypatch.setattr(
+        MCPRequestHandler,
+        "_get_allowed_mcp_servers_for_team",
+        AsyncMock(return_value=[]),
+    )
+    monkeypatch.setattr(
+        MCPRequestHandler,
+        "_get_key_access_group_mcp_server_extras",
+        AsyncMock(return_value=[]),
+    )
+    monkeypatch.setattr(
+        MCPRequestHandler,
+        "_get_allowed_mcp_servers_for_user",
+        AsyncMock(return_value=()),
+    )
+
+    allowed = await MCPRequestHandler.get_allowed_mcp_servers(auth)
+
+    assert allowed == []
+
+
+@pytest.mark.asyncio
+async def test_preserved_tool_permission_alias_must_survive_server_alias_rename(
+    monkeypatch,
+):
+    from litellm.proxy._experimental.mcp_server.auth.user_api_key_auth_mcp import (
+        MCPRequestHandler,
+    )
+    from litellm.proxy._experimental.mcp_server.mcp_server_manager import (
+        MCPServerManager,
+    )
+    from litellm.proxy._types import UserAPIKeyAuth
+    from litellm.types.mcp_server.mcp_server_manager import MCPServer
+
+    manager_before_rename = MCPServerManager()
+    manager_before_rename.registry["server-id"] = MCPServer(
+        server_id="server-id",
+        name="old-alias",
+        alias="old-alias",
+        transport="sse",
+        allow_all_keys=True,
+    )
+    monkeypatch.setattr(
+        "litellm.proxy._experimental.mcp_server.mcp_server_manager.global_mcp_server_manager",
+        manager_before_rename,
+    )
+    monkeypatch.setattr(
+        "litellm.proxy.management_helpers.object_permission_utils._get_allow_all_keys_server_ids",
+        lambda: {"server-id"},
+    )
+    monkeypatch.setattr(
+        MCPRequestHandler,
+        "_get_mcp_servers_from_access_groups",
+        AsyncMock(return_value=[]),
+    )
+    mock_prisma_client = MagicMock()
+    mock_prisma_client.db.litellm_mcpservertable.find_many = AsyncMock(return_value=[])
+    stored_permission = {
+        "mcp_servers": ["server-id"],
+        "mcp_tool_permissions": {"old-alias": ["read"]},
+    }
+
+    persisted = await validate_key_mcp_servers_against_team(
+        object_permission=stored_permission,
+        team_obj=None,
+        prisma_client=mock_prisma_client,
+        is_proxy_admin=False,
+    )
+
+    assert persisted == stored_permission
+
+    manager_after_rename = MCPServerManager()
+    manager_after_rename.registry["server-id"] = MCPServer(
+        server_id="server-id",
+        name="new-alias",
+        alias="new-alias",
+        transport="sse",
+        allow_all_keys=True,
+    )
+    monkeypatch.setattr(
+        "litellm.proxy._experimental.mcp_server.mcp_server_manager.global_mcp_server_manager",
+        manager_after_rename,
+    )
+    permission_row = LiteLLM_ObjectPermissionTable(
+        object_permission_id="permission-id",
+        **stored_permission,
+    )
+    auth = UserAPIKeyAuth(api_key="test-key", object_permission=permission_row)
+    monkeypatch.setattr(
+        MCPRequestHandler,
+        "_get_team_object_permission",
+        AsyncMock(return_value=None),
+    )
+    monkeypatch.setattr(
+        MCPRequestHandler,
+        "_get_user_object_permission",
+        AsyncMock(return_value=None),
+    )
+
+    allowed_tools = await MCPRequestHandler.get_allowed_tools_for_server(
+        server_id="server-id",
+        user_api_key_auth=auth,
+    )
+
+    assert allowed_tools == ["read"]
+
+
+@pytest.mark.asyncio
 @patch(
     "litellm.proxy.management_helpers.object_permission_utils._get_allow_all_keys_server_ids",
     return_value=set(),

--- a/tests/test_litellm/proxy/management_helpers/test_object_permission_utils.py
+++ b/tests/test_litellm/proxy/management_helpers/test_object_permission_utils.py
@@ -16,7 +16,6 @@ from litellm.proxy.management_helpers.object_permission_utils import (
     _extract_requested_mcp_access_groups,
     _extract_requested_mcp_server_ids,
     _resolve_team_allowed_mcp_servers,
-    _rewrite_object_permission_mcp_servers,
     _set_object_permission,
     enforce_all_proxy_mcp_servers_grant_is_admin_only,
     validate_key_mcp_servers_against_team,
@@ -151,12 +150,6 @@ def test_extract_requested_mcp_server_ids_none():
 def test_extract_requested_mcp_server_ids_excludes_no_mcp_servers_sentinel():
     obj_perm = {"mcp_servers": ["no-mcp-servers", "server-1"]}
     assert _extract_requested_mcp_server_ids(obj_perm) == {"server-1"}
-
-
-def test_rewrite_object_permission_mcp_servers_preserves_sentinel():
-    obj_perm = {"mcp_servers": ["no-mcp-servers", "alias-1"]}
-    _rewrite_object_permission_mcp_servers(obj_perm, {"alias-1": {"server-1"}})
-    assert obj_perm["mcp_servers"] == ["no-mcp-servers", "server-1"]
 
 
 @pytest.mark.asyncio
@@ -560,12 +553,12 @@ async def test_validate_tool_permissions_validated_against_team(
     new_callable=AsyncMock,
     return_value=[],
 )
-async def test_validate_stale_mcp_server_ids_are_silently_dropped(
+async def test_validate_stale_mcp_server_ids_are_ignored_during_authorization(
     mock_access_groups, mock_allow_all
 ):
     """
     Stale MCP server IDs (servers deleted and no longer in the registry) must not
-    block a key save with a 403. They are silently stripped instead.
+    block a key save with a 403.
 
     Scenario: key/team were configured with S1+S2, those servers were deleted and
     replaced with S3+S4. The UI form still holds S1+S2 in its local state. Saving
@@ -592,20 +585,16 @@ async def test_validate_stale_mcp_server_ids_are_silently_dropped(
     new_callable=AsyncMock,
     return_value=[],
 )
-async def test_validate_stale_ids_in_mcp_tool_permissions_silently_dropped(
+async def test_validate_stale_ids_in_mcp_tool_permissions_are_preserved(
     mock_access_groups, mock_allow_all
 ):
-    """
-    Stale server IDs referenced only as keys in mcp_tool_permissions (not in
-    mcp_servers) must also be silently stripped rather than raising a 403.
-    """
     team_obj = _make_team_obj(mcp_servers=["s3", "s4"])
     object_permission = {"mcp_tool_permissions": {"s1-stale": ["tool1"]}}
     await validate_key_mcp_servers_against_team(
         object_permission=object_permission,
         team_obj=team_obj,
     )  # Must not raise
-    assert object_permission["mcp_tool_permissions"] == {}
+    assert object_permission["mcp_tool_permissions"] == {"s1-stale": ["tool1"]}
 
 
 @pytest.mark.asyncio
@@ -622,7 +611,7 @@ async def test_validate_stale_ids_in_mcp_tool_permissions_silently_dropped(
     new_callable=AsyncMock,
     return_value=[],
 )
-async def test_validate_stale_mcp_server_ids_are_removed_from_object_permission(
+async def test_validate_stale_mcp_server_ids_are_preserved_in_object_permission(
     mock_access_groups, mock_allow_all
 ):
     team_obj = _make_team_obj(mcp_servers=["s3", "s4"])
@@ -631,7 +620,7 @@ async def test_validate_stale_mcp_server_ids_are_removed_from_object_permission(
         object_permission=object_permission,
         team_obj=team_obj,
     )
-    assert object_permission["mcp_servers"] == []
+    assert object_permission["mcp_servers"] == ["s1-stale", "s2-stale"]
 
 
 @pytest.mark.asyncio
@@ -692,7 +681,7 @@ async def test_validate_mcp_server_alias_outside_team_scope_raises(
     new_callable=AsyncMock,
     return_value=[],
 )
-async def test_validate_mcp_server_alias_is_normalized_before_save(
+async def test_validate_mcp_server_alias_is_authorized_without_rewriting_storage(
     mock_access_groups, mock_allow_all
 ):
     team_obj = _make_team_obj(mcp_servers=["allowed-server-id"])
@@ -706,8 +695,67 @@ async def test_validate_mcp_server_alias_is_normalized_before_save(
         team_obj=team_obj,
     )
 
-    assert object_permission["mcp_servers"] == ["allowed-server-id"]
-    assert object_permission["mcp_tool_permissions"] == {"allowed-server-id": ["tool1"]}
+    assert object_permission["mcp_servers"] == ["allowed-alias"]
+    assert object_permission["mcp_tool_permissions"] == {
+        "Allowed Server": ["tool1"],
+        "stale-id": ["tool2"],
+    }
+
+
+@pytest.mark.asyncio
+async def test_validate_explicit_server_id_does_not_expand_matching_alias(monkeypatch):
+    manager = _make_mock_mcp_manager(
+        servers=[
+            _make_mock_mcp_server("west-id", alias="west"),
+            _make_mock_mcp_server("central-id", alias="west-id"),
+        ],
+    )
+    monkeypatch.setattr(
+        "litellm.proxy._experimental.mcp_server.mcp_server_manager.global_mcp_server_manager",
+        manager,
+    )
+    monkeypatch.setattr(
+        "litellm.proxy.management_helpers.object_permission_utils._get_allow_all_keys_server_ids",
+        lambda: set(),
+    )
+    monkeypatch.setattr(
+        "litellm.proxy._experimental.mcp_server.auth.user_api_key_auth_mcp.MCPRequestHandler._get_mcp_servers_from_access_groups",
+        AsyncMock(return_value=[]),
+    )
+    object_permission = {"mcp_servers": ["west-id"]}
+
+    result = await validate_key_mcp_servers_against_team(
+        object_permission=object_permission,
+        team_obj=_make_team_obj(mcp_servers=["west-id"]),
+    )
+
+    assert result == object_permission
+
+
+@pytest.mark.asyncio
+async def test_team_explicit_server_id_does_not_grant_matching_alias(monkeypatch):
+    manager = _make_mock_mcp_manager(
+        servers=[
+            _make_mock_mcp_server("west-id", alias="west"),
+            _make_mock_mcp_server("central-id", alias="west-id"),
+        ],
+    )
+    monkeypatch.setattr(
+        "litellm.proxy._experimental.mcp_server.mcp_server_manager.global_mcp_server_manager",
+        manager,
+    )
+    monkeypatch.setattr(
+        "litellm.proxy._experimental.mcp_server.auth.user_api_key_auth_mcp.MCPRequestHandler._get_mcp_servers_from_access_groups",
+        AsyncMock(return_value=[]),
+    )
+    team_permission = MagicMock(spec=LiteLLM_ObjectPermissionTable)
+    team_permission.mcp_servers = ["west-id"]
+    team_permission.mcp_access_groups = []
+    team_permission.mcp_tool_permissions = {}
+
+    result = await _resolve_team_allowed_mcp_servers(team_permission)
+
+    assert result == {"west-id"}
 
 
 @pytest.mark.asyncio

--- a/tests/test_litellm/proxy/test_dynamic_mcp_route.py
+++ b/tests/test_litellm/proxy/test_dynamic_mcp_route.py
@@ -109,6 +109,47 @@ async def test_dynamic_mcp_route_resolves_registered_server():
     fake_forward.assert_awaited_once_with("my_server", request)
 
 
+@pytest.mark.asyncio
+async def test_dynamic_mcp_route_forwards_duplicate_alias_to_permission_aware_router():
+    from starlette.responses import Response
+
+    from litellm.proxy._experimental.mcp_server.mcp_server_manager import (
+        MCPServerManager,
+    )
+    from litellm.proxy.proxy_server import dynamic_mcp_route
+    from litellm.types.mcp import MCPTransport
+    from litellm.types.mcp_server.mcp_server_manager import MCPServer
+
+    manager = MCPServerManager()
+    manager.registry.update(
+        {
+            server_id: MCPServer(
+                server_id=server_id,
+                name="shared",
+                alias="shared",
+                server_name=server_id,
+                url=f"https://{server_id}.example.com/mcp",
+                transport=MCPTransport.http,
+                available_on_public_internet=True,
+            )
+            for server_id in ("west-id", "central-id")
+        }
+    )
+    request = _make_request("/shared/mcp")
+    forward = AsyncMock(return_value=Response(content=b"{}", status_code=200))
+
+    with (
+        patch(_MCP_MANAGER, manager),
+        patch(_PRISMA, new=None),
+        patch(_IS_ACCESS_GROUP, new=AsyncMock(return_value=False)),
+        patch(_FORWARD, new=forward),
+    ):
+        response = await dynamic_mcp_route("shared", request)
+
+    assert response.status_code == 200
+    forward.assert_awaited_once_with("shared", request)
+
+
 # ---------------------------------------------------------------------------
 # 2. Comma-separated list (short-circuits before toolset DB call)
 # ---------------------------------------------------------------------------
@@ -261,6 +302,40 @@ async def test_resolve_mcp_csv_tokens_drops_unknown_and_resolves_access_groups()
         "dev_group",
         "ghost",
     }
+
+
+@pytest.mark.asyncio
+async def test_resolve_mcp_csv_tokens_preserves_duplicate_alias_for_permission_aware_router():
+    from litellm.proxy._experimental.mcp_server.mcp_server_manager import (
+        MCPServerManager,
+    )
+    from litellm.proxy.proxy_server import _resolve_mcp_csv_tokens
+    from litellm.types.mcp import MCPTransport
+    from litellm.types.mcp_server.mcp_server_manager import MCPServer
+
+    manager = MCPServerManager()
+    manager.registry.update(
+        {
+            server_id: MCPServer(
+                server_id=server_id,
+                name="shared",
+                alias="shared",
+                server_name=server_id,
+                url=f"https://{server_id}.example.com/mcp",
+                transport=MCPTransport.http,
+                available_on_public_internet=True,
+            )
+            for server_id in ("west-id", "central-id")
+        }
+    )
+
+    with (
+        patch(_MCP_MANAGER, manager),
+        patch(_IS_ACCESS_GROUP, new=AsyncMock(return_value=False)),
+    ):
+        resolved = await _resolve_mcp_csv_tokens("shared", client_ip=None)
+
+    assert resolved == ["shared"]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_litellm/responses/mcp/test_litellm_proxy_mcp_handler.py
+++ b/tests/test_litellm/responses/mcp/test_litellm_proxy_mcp_handler.py
@@ -529,6 +529,58 @@ async def test_get_mcp_tools_from_manager_enables_list_tools_logging(monkeypatch
     assert mock_get_tools.await_args.kwargs["list_tools_log_source"] == "responses"
 
 
+@pytest.mark.asyncio
+async def test_get_mcp_tools_duplicate_alias_does_not_fall_through_to_toolset(monkeypatch):
+    from litellm.proxy._experimental.mcp_server.mcp_server_manager import (
+        MCPServerManager,
+    )
+    from litellm.types.mcp import MCPTransport
+    from litellm.types.mcp_server.mcp_server_manager import MCPServer
+
+    resolver = MCPServerManager()
+    resolver.registry.update(
+        {
+            server_id: MCPServer(
+                server_id=server_id,
+                name="shared",
+                alias="shared",
+                server_name=server_id,
+                url=f"https://{server_id}.example.com/mcp",
+                transport=MCPTransport.http,
+                available_on_public_internet=True,
+            )
+            for server_id in ("west-id", "central-id")
+        }
+    )
+    west = resolver.registry["west-id"]
+    toolset_lookup = AsyncMock(return_value=types.SimpleNamespace(toolset_id="toolset-id"))
+    manager = types.SimpleNamespace(
+        get_mcp_server_by_name=resolver.get_mcp_server_by_name,
+        resolve_single_target=resolver.resolve_single_target,
+        get_toolset_by_name_cached=toolset_lookup,
+        get_allowed_mcp_servers=AsyncMock(return_value=["west-id"]),
+        get_mcp_servers_from_ids=MagicMock(return_value=[west]),
+    )
+    listing = AsyncMock(return_value=AggregateToolListing(tools=[], outcomes={}))
+    monkeypatch.setattr(
+        "litellm.proxy._experimental.mcp_server.mcp_server_manager.global_mcp_server_manager",
+        manager,
+    )
+    monkeypatch.setattr(
+        "litellm.proxy._experimental.mcp_server.server._get_tools_from_mcp_servers",
+        listing,
+    )
+    monkeypatch.setattr("litellm.proxy.proxy_server.prisma_client", object())
+
+    await LiteLLM_Proxy_MCP_Handler._get_mcp_tools_from_manager(
+        user_api_key_auth=None,
+        mcp_tools_with_litellm_proxy=[{"type": "mcp", "server_url": "litellm_proxy/mcp/shared"}],
+    )
+
+    assert listing.await_args.kwargs["mcp_servers"] == ["shared"]
+    toolset_lookup.assert_not_awaited()
+
+
 def test_get_parent_request_tags_from_metadata():
     tags = LiteLLM_Proxy_MCP_Handler._get_parent_request_tags(
         {"metadata": {"tags": ["team-a", "prod"]}}

--- a/tests/test_litellm/responses/mcp/test_litellm_proxy_mcp_handler.py
+++ b/tests/test_litellm/responses/mcp/test_litellm_proxy_mcp_handler.py
@@ -9,6 +9,7 @@ from fastapi import HTTPException
 import importlib
 
 from litellm.proxy._experimental.mcp_server.faults.list_outcomes import AggregateToolListing
+from litellm.proxy._experimental.mcp_server.mcp_server_manager import NotFound
 from litellm.responses.mcp.litellm_proxy_mcp_handler import (
     LiteLLM_Proxy_MCP_Handler,
 )
@@ -506,6 +507,7 @@ async def test_get_mcp_tools_from_manager_enables_list_tools_logging(monkeypatch
         get_allowed_mcp_servers=AsyncMock(return_value=[]),
         get_mcp_servers_from_ids=MagicMock(return_value=[]),
         get_mcp_server_by_name=MagicMock(return_value=None),
+        resolve_single_target=MagicMock(return_value=NotFound(reference="deepwiki")),
     )
     monkeypatch.setattr(
         "litellm.proxy._experimental.mcp_server.mcp_server_manager.global_mcp_server_manager",
@@ -559,6 +561,7 @@ async def test_get_mcp_tools_from_manager_forwards_request_tags(monkeypatch):
         get_allowed_mcp_servers=AsyncMock(return_value=[]),
         get_mcp_servers_from_ids=MagicMock(return_value=[]),
         get_mcp_server_by_name=MagicMock(return_value=None),
+        resolve_single_target=MagicMock(return_value=NotFound(reference="deepwiki")),
     )
     monkeypatch.setattr(
         "litellm.proxy._experimental.mcp_server.mcp_server_manager.global_mcp_server_manager",

--- a/type-discipline-budget.json
+++ b/type-discipline-budget.json
@@ -1,9 +1,9 @@
 {
   "LIT001": {
-    "limit": 22403
+    "limit": 22391
   },
   "LIT002": {
-    "limit": 26780
+    "limit": 26773
   },
   "LIT003": {
     "limit": 269
@@ -27,10 +27,10 @@
     "limit": 0
   },
   "LIT010": {
-    "limit": 16512
+    "limit": 16509
   },
   "LIT011": {
-    "limit": 5537
+    "limit": 5534
   },
   "LIT012": {
     "limit": 4495


### PR DESCRIPTION
## TLDR

New MCP grants were persisted with a provisioning region's physical server IDs, so shared permissions could fail in other active-active regions. This PR preserves submitted logical references and resolves them against each region's live MCP registry at request time.

## Mental model

`server_id` is a physical, region-local identity. `alias` and `server_name` are logical references that may be shared across regions.

```text
stored logical reference
  -> current region's config + DB registry
  -> candidate physical server IDs
  -> permission and IP filtering
  -> expand all matches, or require one routed target
```

West and Central can therefore share `github` while routing to different physical servers:

```text
West:    github -> west-id
Central: github -> central-id
               ^
       shared permission: github
```

## Resolver and authorization invariants

1. Identity precedence is exact `server_id`, then `alias`, then `server_name`, then runtime `name`.
2. Permission references may expand to every match. A single-target route resolves *after* permission/IP filtering and must produce exactly one permitted server; multiple permitted candidates are `409 ambiguous_mcp_server`.
3. `NotFound`, `Forbidden`, and `Ambiguous` are different outcomes. Callers must not collapse all three to `None` and then enter a broader namespace or scope.
4. Management may preserve the submitted logical spelling, but runtime expansion must still enforce the current team/global authorization ceiling. An unresolved value must not become a future unauthorized grant.
5. `mcp_tool_permissions` both grants server reachability and restricts tools. A stale or renamed key must fail closed; it must never turn a tool restriction into `None` (`None` means allow all tools).
6. An RFC 8707 single-server `resource` is a ceiling. Failed or ambiguous resolution must not mint an unscoped session.

## Root cause and change

PR #29128 (`83fcacad`, first released in v1.88.0) resolved aliases for authorization and also rewrote the permission object before persistence. Existing logical records kept working, while newly saved records contained a region's generated physical IDs.

This PR separates the two concerns:

- Resolve logical references to concrete IDs for authorization.
- Preserve the submitted logical representation for storage.
- Resolve stored permission references against each local registry at request time.
- Add explicit permission-expansion and single-target resolver outcomes.

## Audit findings fixed in this PR

The review audit derived the following cases from the invariants above, reproduced them on `fa401355f8`, and fixed them in `2247143937`:

- **Future private grant:** a non-admin key can persist an unresolved alias in one region; another region or a later config can bind it to an `allow_all_keys=False` server, which runtime currently grants. This affects both `mcp_servers` and `mcp_tool_permissions`.
- **Tool restriction fails open after rename:** server access stored by ID survives an alias rename, while a tool restriction stored under the old alias stops resolving and becomes allow-all.
- **Global ambiguity is checked too early:** legacy `/{alias}/mcp`, CSV routing, and the preemptive OAuth challenge use global lookup before caller permissions can reduce duplicate aliases to one target.
- **Namespace confusion:** the Responses API can reinterpret an ambiguous server alias as a same-named toolset.
- **Scope widening:** an ambiguous RFC 8707 single-server resource currently falls back to a successful unscoped authorization flow.

The red tests landed separately before the fixes in `4d017d32e2`. The initial audit result was `3` failing permission-lifecycle cases and `5` failing routing/OAuth cases; all eight now pass.

An additional exact-ID precedence test landed in `6e388b177a`. It reproduces on the base commit as well as the original PR head: when a forbidden server's exact ID equals an allowed server's alias, legacy prefix fallback substituted the allowed server. The fix makes a forbidden exact-ID result terminal while preserving the intentional forbidden-alias-to-access-group fallback.

## Intentional and rollout-sensitive behavior

- Existing physical-ID records are not migrated automatically. Migrate parent/team ceilings before child key/user/agent grants; mixed physical/logical intersections can be empty or reject saves.
- Aggregate logical permissions intentionally fan out when several servers share an alias. Single-target routing remains ambiguous if more than one *permitted* candidate survives.
- Alias rename or reuse changes the meaning of a late-bound grant. Operators should treat aliases as security identities and keep alias presence/cardinality consistent across active-active regions. Access groups remain the explicit mechanism for intentional fan-out.
- Existing stale references are grandfathered on key updates so unrelated edits remain possible. Those pre-existing values retain their future-rebinding risk; eliminating it requires persisted identity/version metadata or a migration and cannot be inferred from a logical token alone. New unresolved non-admin references without an effective team MCP ceiling are rejected.

### Fail-closed tool-permission tradeoff

When a stored `mcp_tool_permissions` key becomes unresolved after an alias rename, LiteLLM cannot prove which current server it used to name. The runtime now returns an empty tool grant for that permission level instead of `None` (allow all). A permission that resolves fully to another known server still places no restriction on the requested server.

## Relevant issues

- Regression introduced by #29128
- Related routing design: #38932

## Verification plan

- [x] Preserve logical references across regional registries
- [x] Cover resolver precedence, permission-relative ambiguity, and DB/config union
- [x] Make all focused permission-lifecycle regression tests green
- [x] Make all focused routing/OAuth regression tests green
- [x] Enforce exact-ID precedence across the legacy protocol helper
- [x] Run the broader affected MCP suites after the fixes

Verification on `2247143937`:

- Consolidated invariant suite: `9 passed`
- Affected MCP modules, run in isolated processes: `1,572 passed`
- Ruff on all changed production files: passed

A live two-region shared-database deployment is still required for a full manual E2E replay.

## Type

🐛 Bug Fix

## Final attestation

- [x] Tests cover persistence, precedence, resolver outcomes, collisions, REST, protocol, and OAuth binding
- [x] Scope is limited to MCP permission persistence and consumers of the changed resolver contract
