### PR TITLE
fix(ci): pin setup-uv to v10.0.1

### DIFF
--- a/.github/actions/setup-uv-with-retries/action.yml
+++ b/.github/actions/setup-uv-with-retries/action.yml
@@ -1,11 +1,7 @@
 name: "Set up uv with retries"
 description: >-
-  Install uv via astral-sh/setup-uv, retrying on transient failures. Even with
-  an exact pinned version, the action resolves the artifact URL by fetching
-  https://raw.githubusercontent.com/astral-sh/versions/main/v1/uv.ndjson in a
-  single request with no retry, timeout, or fallback, so one connection-level
-  network error ("fetch failed") fails the whole job before any test runs.
-  Retrying the full step covers the manifest fetch and the binary download.
+  Install uv via astral-sh/setup-uv, retrying the full setup step so manifest
+  resolution and binary downloads get fresh attempts after transient failures.
 
 inputs:
   version:
@@ -18,7 +14,7 @@ runs:
     - name: Set up uv (attempt 1)
       id: attempt-1
       continue-on-error: true
-      uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
+      uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
       with:
         version: ${{ inputs.version }}
 
@@ -31,7 +27,7 @@ runs:
       id: attempt-2
       if: steps.attempt-1.outcome == 'failure'
       continue-on-error: true
-      uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
+      uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
       with:
         version: ${{ inputs.version }}
 
@@ -42,6 +38,6 @@ runs:
 
     - name: Set up uv (attempt 3)
       if: steps.attempt-2.outcome == 'failure'
-      uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
+      uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
       with:
         version: ${{ inputs.version }}


### PR DESCRIPTION
## TLDR

Problem this solves:

- setup-uv v7.6.0 could forward tokens to untrusted origins

How it solves it:

- Pin setup-uv v10.0.1 by its full commit SHA

## Security context

- [Upstream PR #878](https://github.com/astral-sh/setup-uv/pull/878) added an exact `https://github.com` origin gate before forwarding the GitHub token
- [setup-uv v8.2.0](https://github.com/astral-sh/setup-uv/releases/tag/v8.2.0) first released that token-handling fix
- [setup-uv v10.0.1](https://github.com/astral-sh/setup-uv/releases/tag/v10.0.1) retains the fix and adds transient manifest-timeout handling
- The full commit SHA prevents the selected action code from moving

## User Flow

Before: a CI maintainer runs a workflow that installs uv through setup-uv v7.6.0

1. They trigger any workflow using the shared setup-uv action
2. The action resolves and downloads the requested uv version
3. A compromised manifest could direct the GitHub token to another origin

After: the same workflow installs uv through setup-uv v10.0.1

1. They trigger any workflow using the shared setup-uv action
2. The action resolves and downloads the requested uv version
3. The action only forwards the GitHub token to the exact GitHub origin

## Relevant issues

Extracted from #39021

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have added meaningful tests
- [ ] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA)

## Screenshots / Proof of Fix

### Before (ec3f8183c3)

1. `git show ec3f8183c3:.github/actions/setup-uv-with-retries/action.yml | rg 'uses: astral-sh/setup-uv@'`
2. All three attempts reference `37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0`

### After (7c2940771a)

1. `git show 7c2940771a:.github/actions/setup-uv-with-retries/action.yml | rg 'uses: astral-sh/setup-uv@'`
2. All three attempts reference `20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1`
3. `gh api repos/astral-sh/setup-uv/git/ref/tags/v10.0.1 --jq '.object.type + " " + .object.sha'` returns `commit 20cfd1bf945f4377ade1205e4dbc17946fc9a30d`
4. The action YAML parses successfully and `make check` passes

## Type

🚄 Infrastructure

## Caveats (if any)

## Final Attestation

- [ ] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
