### PR TITLE
fix(proxy): write the Prisma engine through the public setter, not the mangled name

### DIFF
--- a/litellm/proxy/db/prisma_client.py
+++ b/litellm/proxy/db/prisma_client.py
@@ -53,10 +53,7 @@ class _PrismaEngine(Protocol):
 
 
 class _PrismaClient(Protocol):
-    _Prisma__engine: _PrismaEngine
-
-    @property
-    def _engine(self) -> _PrismaEngine: ...
+    _engine: _PrismaEngine
 
 
 class _PrismaDrainTracker:
@@ -240,7 +237,9 @@ class PrismaWrapper:
 
     @staticmethod
     def _write_engine(prisma_client: _PrismaClient, engine: _PrismaEngine) -> None:
-        prisma_client._Prisma__engine = engine
+        # Public setter: prisma <0.13 stored the engine on the mangled `Prisma.__engine`,
+        # 0.13+ on `BasePrisma._internal_engine`. Both are __slots__ classes.
+        prisma_client._engine = engine  # rebind-ok: third-party Prisma client instance, not a local param we own
 
     def _instrument_prisma_client(self, prisma_client: _PrismaClient) -> _PrismaDrainTracker | None:
         from prisma.errors import ClientNotConnectedError

--- a/tests/test_litellm/proxy/db/test_prisma_client.py
+++ b/tests/test_litellm/proxy/db/test_prisma_client.py
@@ -171,6 +171,35 @@ def test_get_engine_pid_returns_zero_for_disconnected_client(disconnected_prisma
     assert wrapper._get_engine_pid() == 0
 
 
+def test_write_engine_uses_the_public_setter_not_the_mangled_name():
+    """Real Prisma clients (>=0.13) are __slots__ classes exposing only a public
+    `_engine` property/setter, with no `_Prisma__engine` slot. Writing to the
+    mangled name raises AttributeError instead of storing the engine."""
+
+    class _FakeSlotsBasedPrismaClient:
+        __slots__ = ("_internal_engine",)
+
+        def __init__(self):
+            self._internal_engine = None
+
+        @property
+        def _engine(self):
+            if self._internal_engine is None:
+                raise AttributeError("not connected")
+            return self._internal_engine
+
+        @_engine.setter
+        def _engine(self, engine):
+            self._internal_engine = engine
+
+    client = _FakeSlotsBasedPrismaClient()
+    sentinel = object()
+
+    PrismaWrapper._write_engine(client, sentinel)
+
+    assert PrismaWrapper._read_engine(client) is sentinel
+
+
 @pytest.mark.asyncio
 async def test_recreate_prisma_client_recovers_from_disconnected_client(
     mock_prisma_binary, disconnected_prisma

--- a/tests/test_litellm/proxy/db/test_prisma_planned_engine_restart.py
+++ b/tests/test_litellm/proxy/db/test_prisma_planned_engine_restart.py
@@ -60,7 +60,7 @@ def _make_wrapper(engine_pid: int = 111, iam: bool = False) -> PrismaWrapper:
     prisma = GeneratedPrisma(use_dotenv=False)
     engine = MagicMock()
     engine.process.pid = engine_pid
-    setattr(prisma, "_Prisma__engine", engine)
+    prisma._engine = engine
     return PrismaWrapper(original_prisma=prisma, iam_token_db_auth=iam)
 
 
@@ -158,7 +158,7 @@ def _token_db_url(created: datetime, expires_in: int = 900) -> str:
 def test_wrapper_instruments_generated_prisma_engine() -> None:
     prisma = GeneratedPrisma(use_dotenv=False)
     engine = MagicMock()
-    setattr(prisma, "_Prisma__engine", engine)
+    prisma._engine = engine
 
     wrapper = PrismaWrapper(original_prisma=prisma, iam_token_db_auth=False)
 


### PR DESCRIPTION
## TLDR

Problem this solves:

- Proxy retries connecting to Prisma forever when `prisma>=0.13` is installed, spiking CPU
- `pyproject.toml` allows `prisma>=0.11.0,<1.0`, but only `0.11.0` (mangled-attribute era) is ever tested

How it solves it:

- `_write_engine` now writes through the public `_engine` setter instead of the mangled `_Prisma__engine` name

## User Flow

Before: an operator running the proxy with `prisma==0.15.0` gets a proxy that never finishes connecting to its database.

1. They run `litellm --config config.yaml --num_workers 4 --detailed_debug` with `prisma==0.15.0` installed
2. Logs repeat `AttributeError: 'Prisma' object has no attribute '_Prisma__engine'`, followed by `backoff` retry messages, indefinitely
3. `docker stats` shows sustained high CPU (200-300%) with growing memory
4. Database-backed endpoints like `/key/generate` never succeed

After: the same proxy, same `prisma==0.15.0` install, connects immediately.

1. They run the same command
2. No `AttributeError` or retry messages appear
3. `docker stats` shows CPU near idle shortly after start-up
4. Database-backed endpoints succeed immediately

## Relevant issues

Fixes #39114

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally
- [ ] My PR passes all required CI/CD checks
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile Confidence Score of at least 4/5

## Screenshots / Proof of Fix

### Before (fa647f742d)

1. `docker stats --no-stream aii-copilot-router` -> `196.49% CPU, 3.022GiB`
2. `docker compose logs router | grep -c "_Prisma__engine"` -> `12` (5 min window)

### After (7ab6e4313e)

1. `docker stats --no-stream aii-copilot-router` -> `4.19% CPU`
2. `docker compose logs router | grep -c "_Prisma__engine"` -> `0` (5 min window)

## Type

🐛 Bug Fix

## Caveats (if any)

- No regression risk for `prisma==0.11.0`: the public `_engine` setter exists on both old and new Prisma client versions

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
