### PR TITLE
fix(mcp): persist alias MCP grants verbatim instead of rewriting to local server ids

### DIFF
--- a/litellm/proxy/management_helpers/object_permission_utils.py
+++ b/litellm/proxy/management_helpers/object_permission_utils.py
@@ -286,7 +286,7 @@ async def _resolve_mcp_server_identifiers_to_ids(
     return resolved
 
 
-def _rewrite_object_permission_mcp_servers(
+def _drop_stale_object_permission_mcp_servers(
     object_permission: ObjectPermissionDict,
     identifier_to_server_ids: dict[str, set[str]],
 ) -> None:
@@ -294,16 +294,18 @@ def _rewrite_object_permission_mcp_servers(
     if not isinstance(mcp_servers, list):
         return
 
-    normalized_servers: Final[list[str]] = []
-    for identifier in mcp_servers:
-        if identifier == SpecialMCPServerNames.no_mcp_servers.value:
-            normalized_servers.append(SpecialMCPServerNames.no_mcp_servers.value)
-            continue
-        normalized_servers.extend(sorted(identifier_to_server_ids.get(identifier, [])))
-    object_permission["mcp_servers"] = _dedupe_preserving_order(normalized_servers)
+    # Persist original identifiers, never resolved ids: shared-DB multi-region
+    # instances each expand a name/alias to their own local server id at read
+    # time. Only entries resolving to nothing (deleted servers, typos) drop.
+    kept_servers: Final = [
+        identifier
+        for identifier in mcp_servers
+        if identifier == SpecialMCPServerNames.no_mcp_servers.value or identifier_to_server_ids.get(identifier)
+    ]
+    object_permission["mcp_servers"] = _dedupe_preserving_order(kept_servers)
 
 
-def _rewrite_object_permission_mcp_tool_permissions(
+def _drop_stale_object_permission_mcp_tool_permissions(
     object_permission: ObjectPermissionDict,
     identifier_to_server_ids: dict[str, set[str]],
 ) -> None:
@@ -311,31 +313,25 @@ def _rewrite_object_permission_mcp_tool_permissions(
     if not isinstance(mcp_tool_permissions, dict):
         return
 
-    normalized_tool_permissions: Final[dict[str, list[str]]] = {}
-    for identifier, tools in mcp_tool_permissions.items():
-        if not isinstance(tools, list):
-            tools = []
-        for server_id in sorted(identifier_to_server_ids.get(identifier, [])):
-            normalized_tool_permissions.setdefault(server_id, [])
-            normalized_tool_permissions[server_id].extend(tools)
-
     object_permission["mcp_tool_permissions"] = {
-        server_id: _dedupe_preserving_order(tools) for server_id, tools in normalized_tool_permissions.items()
+        identifier: _dedupe_preserving_order(tools if isinstance(tools, list) else [])
+        for identifier, tools in mcp_tool_permissions.items()
+        if identifier_to_server_ids.get(identifier)
     }
 
 
-def _rewrite_object_permission_mcp_identifiers(
+def _drop_stale_object_permission_mcp_identifiers(
     object_permission: ObjectPermissionDict | None,
     identifier_to_server_ids: dict[str, set[str]],
 ) -> None:
     if not object_permission or not isinstance(object_permission, dict):
         return
 
-    _rewrite_object_permission_mcp_servers(
+    _drop_stale_object_permission_mcp_servers(
         object_permission=object_permission,
         identifier_to_server_ids=identifier_to_server_ids,
     )
-    _rewrite_object_permission_mcp_tool_permissions(
+    _drop_stale_object_permission_mcp_tool_permissions(
         object_permission=object_permission,
         identifier_to_server_ids=identifier_to_server_ids,
     )
@@ -615,7 +611,7 @@ async def validate_key_mcp_servers_against_team(
                 "validate_key_mcp_servers_against_team: ignoring stale MCP server identifiers (no longer in registry or DB): %s",
                 sorted(stale_identifiers),
             )
-        _rewrite_object_permission_mcp_identifiers(
+        _drop_stale_object_permission_mcp_identifiers(
             object_permission=object_permission,
             identifier_to_server_ids=identifier_to_server_ids,
         )

--- a/tests/e2e/coverage_registry/mcp.yaml
+++ b/tests/e2e/coverage_registry/mcp.yaml
@@ -15,6 +15,14 @@
   assertions: [access_group_scoped]
   source: "test_mcp_access_group_e2e.py"
   rationale: "A key granted an MCP access group sees the tagged server's tools; a key with a different group does not. Access-group-scoped tool selection at key creation"
+- id: mcp.list_tools.api_key.alias_grant_persists
+  module: mcp
+  tier: P1
+  operation: list_tools
+  auth_family: api_key
+  assertions: [alias_grant_persists]
+  source: "object_permission_utils.py validate_key_mcp_servers_against_team"
+  rationale: "A key granted an MCP server by alias keeps the alias verbatim in its stored object_permission (shared-DB multi-region instances each resolve it to their local server id at read time) and still lists the server's tools"
 - id: mcp.list_tools.api_key.denied_without_permission
   module: mcp
   tier: P0

--- a/tests/e2e/coverage_registry/mcp.yaml
+++ b/tests/e2e/coverage_registry/mcp.yaml
@@ -15,14 +15,6 @@
   assertions: [access_group_scoped]
   source: "test_mcp_access_group_e2e.py"
   rationale: "A key granted an MCP access group sees the tagged server's tools; a key with a different group does not. Access-group-scoped tool selection at key creation"
-- id: mcp.list_tools.api_key.alias_grant_persists
-  module: mcp
-  tier: P1
-  operation: list_tools
-  auth_family: api_key
-  assertions: [alias_grant_persists]
-  source: "object_permission_utils.py validate_key_mcp_servers_against_team"
-  rationale: "A key granted an MCP server by alias keeps the alias verbatim in its stored object_permission (shared-DB multi-region instances each resolve it to their local server id at read time) and still lists the server's tools"
 - id: mcp.list_tools.api_key.denied_without_permission
   module: mcp
   tier: P0

--- a/tests/e2e/mcp/test_mcp_key_access_e2e.py
+++ b/tests/e2e/mcp/test_mcp_key_access_e2e.py
@@ -30,6 +30,35 @@ def _key(client: McpClient, resources: ResourceManager, *, mcp_servers: list[str
     return key
 
 
+class TestMcpKeyGrantByAlias:
+    @pytest.mark.covers("mcp.list_tools.api_key.alias_grant_persists")
+    def test_alias_grant_persists_verbatim_and_lists_tools(
+        self,
+        client: McpClient,
+        resources: ResourceManager,
+    ) -> None:
+        """A key granted an MCP server by its alias must store the alias, not the
+        resolved server_id: in a shared-DB multi-region deployment each instance
+        derives a different id for the same config server, so only the alias
+        grants access on every region. The same key must still see the server's
+        tools, proving the alias grant is honored at request time."""
+        server_id = register_datadog_mcp(client, resources)
+        client.await_registered(server_id)
+        alias = next(row.alias for row in client.registered_servers() if row.server_id == server_id)
+        assert alias, f"registered server {server_id} has no alias to grant by"
+
+        key = _key(client, resources, mcp_servers=[alias])
+
+        stored = client.proxy.key_info(key).object_permission
+        assert stored is not None and stored.mcp_servers == [alias], (
+            f"alias grant was rewritten before persisting (expected [{alias!r}]): "
+            f"{stored.mcp_servers if stored else None}. A stored server_id is region-local "
+            f"and breaks the grant on every other instance sharing this database"
+        )
+
+        _ = client.await_tool(key, server_id, SEARCH_LOGS_TOOL)
+
+
 class TestMcpKeyWithoutAccessIsDenied:
     @pytest.mark.covers("mcp.list_tools.api_key.denied_without_permission")
     def test_list_tools_denied_without_permission(

--- a/tests/e2e/mcp/test_mcp_key_access_e2e.py
+++ b/tests/e2e/mcp/test_mcp_key_access_e2e.py
@@ -31,7 +31,6 @@ def _key(client: McpClient, resources: ResourceManager, *, mcp_servers: list[str
 
 
 class TestMcpKeyGrantByAlias:
-    @pytest.mark.covers("mcp.list_tools.api_key.alias_grant_persists")
     def test_alias_grant_persists_verbatim_and_lists_tools(
         self,
         client: McpClient,

--- a/tests/e2e/models.py
+++ b/tests/e2e/models.py
@@ -114,6 +114,7 @@ class KeyInfo(BaseModel):
     budget_id: str | None = None
     litellm_budget_table: LiteLLMBudgetTable | None = None
     budget_limits: list[BudgetWindowState] | None = None
+    object_permission: ObjectPermission | None = None
 
 
 class KeyInfoResponse(BaseModel):

--- a/tests/test_litellm/proxy/management_helpers/test_object_permission_utils.py
+++ b/tests/test_litellm/proxy/management_helpers/test_object_permission_utils.py
@@ -709,33 +709,16 @@ async def test_validate_mcp_server_alias_persists_verbatim(mock_access_groups, m
     assert object_permission["mcp_tool_permissions"] == {"Allowed Server": ["tool1"]}
 
 
-@pytest.mark.asyncio
-@patch(
-    "litellm.proxy.management_helpers.object_permission_utils._get_allow_all_keys_server_ids",
-    return_value=set(),
-)
-@patch(
-    "litellm.proxy._experimental.mcp_server.auth.user_api_key_auth_mcp.MCPRequestHandler._get_mcp_servers_from_access_groups",
-    new_callable=AsyncMock,
-    return_value=[],
-)
-async def test_validate_alias_grant_expands_on_other_region_after_save(mock_access_groups, mock_allow_all):
-    """Full cross-region flow: save a key on the west instance (alias resolves to
-    west's hash-derived id), then expand the persisted grant on the central
-    instance, whose registry maps the same alias to a different id."""
+def test_alias_grant_expands_on_other_region_after_save():
+    """Cross-region flow: the west instance saves an alias grant (its resolver maps
+    the alias to west's hash-derived id), then the central instance, whose registry
+    maps the same alias to a different id, expands the persisted grant. Rewriting
+    to west's id at save time is exactly the regression this guards against."""
     west_mgr = _make_mock_mcp_manager(servers=[_make_mock_mcp_server("west-id", alias="github-mcp")])
     central_mgr = _make_mock_mcp_manager(servers=[_make_mock_mcp_server("central-id", alias="github-mcp")])
 
-    team_obj = _make_team_obj(mcp_servers=["west-id"])
     object_permission = {"mcp_servers": ["github-mcp"]}
-    with patch(
-        "litellm.proxy._experimental.mcp_server.mcp_server_manager.global_mcp_server_manager",
-        west_mgr,
-    ):
-        await validate_key_mcp_servers_against_team(
-            object_permission=object_permission,
-            team_obj=team_obj,
-        )
+    _drop_stale_object_permission_mcp_servers(object_permission, {"github-mcp": {"west-id"}})
     assert object_permission["mcp_servers"] == ["github-mcp"]
 
     from litellm.proxy._experimental.mcp_server.mcp_server_manager import MCPServerManager

--- a/tests/test_litellm/proxy/management_helpers/test_object_permission_utils.py
+++ b/tests/test_litellm/proxy/management_helpers/test_object_permission_utils.py
@@ -1,10 +1,8 @@
 import json
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from fastapi import HTTPException
-
-
-from unittest.mock import AsyncMock, MagicMock, patch
 
 from litellm.proxy._types import (
     LiteLLM_ObjectPermissionBase,
@@ -13,10 +11,10 @@ from litellm.proxy._types import (
     SpecialMCPServerName,
 )
 from litellm.proxy.management_helpers.object_permission_utils import (
+    _drop_stale_object_permission_mcp_servers,
     _extract_requested_mcp_access_groups,
     _extract_requested_mcp_server_ids,
     _resolve_team_allowed_mcp_servers,
-    _rewrite_object_permission_mcp_servers,
     _set_object_permission,
     enforce_all_proxy_mcp_servers_grant_is_admin_only,
     validate_key_mcp_servers_against_team,
@@ -153,10 +151,10 @@ def test_extract_requested_mcp_server_ids_excludes_no_mcp_servers_sentinel():
     assert _extract_requested_mcp_server_ids(obj_perm) == {"server-1"}
 
 
-def test_rewrite_object_permission_mcp_servers_preserves_sentinel():
-    obj_perm = {"mcp_servers": ["no-mcp-servers", "alias-1"]}
-    _rewrite_object_permission_mcp_servers(obj_perm, {"alias-1": {"server-1"}})
-    assert obj_perm["mcp_servers"] == ["no-mcp-servers", "server-1"]
+def test_drop_stale_object_permission_mcp_servers_preserves_sentinel_and_alias():
+    obj_perm = {"mcp_servers": ["no-mcp-servers", "alias-1", "gone-id"]}
+    _drop_stale_object_permission_mcp_servers(obj_perm, {"alias-1": {"server-1"}, "gone-id": set()})
+    assert obj_perm["mcp_servers"] == ["no-mcp-servers", "alias-1"]
 
 
 @pytest.mark.asyncio
@@ -692,9 +690,10 @@ async def test_validate_mcp_server_alias_outside_team_scope_raises(
     new_callable=AsyncMock,
     return_value=[],
 )
-async def test_validate_mcp_server_alias_is_normalized_before_save(
-    mock_access_groups, mock_allow_all
-):
+async def test_validate_mcp_server_alias_persists_verbatim(mock_access_groups, mock_allow_all):
+    """Regression for the multi-region shared-DB setup: an alias grant must be
+    stored as the alias, so every instance can expand it to its own local id.
+    Rewriting to this instance's server_id breaks access on the other region."""
     team_obj = _make_team_obj(mcp_servers=["allowed-server-id"])
     object_permission = {
         "mcp_servers": ["allowed-alias"],
@@ -706,8 +705,44 @@ async def test_validate_mcp_server_alias_is_normalized_before_save(
         team_obj=team_obj,
     )
 
-    assert object_permission["mcp_servers"] == ["allowed-server-id"]
-    assert object_permission["mcp_tool_permissions"] == {"allowed-server-id": ["tool1"]}
+    assert object_permission["mcp_servers"] == ["allowed-alias"]
+    assert object_permission["mcp_tool_permissions"] == {"Allowed Server": ["tool1"]}
+
+
+@pytest.mark.asyncio
+@patch(
+    "litellm.proxy.management_helpers.object_permission_utils._get_allow_all_keys_server_ids",
+    return_value=set(),
+)
+@patch(
+    "litellm.proxy._experimental.mcp_server.auth.user_api_key_auth_mcp.MCPRequestHandler._get_mcp_servers_from_access_groups",
+    new_callable=AsyncMock,
+    return_value=[],
+)
+async def test_validate_alias_grant_expands_on_other_region_after_save(mock_access_groups, mock_allow_all):
+    """Full cross-region flow: save a key on the west instance (alias resolves to
+    west's hash-derived id), then expand the persisted grant on the central
+    instance, whose registry maps the same alias to a different id."""
+    west_mgr = _make_mock_mcp_manager(servers=[_make_mock_mcp_server("west-id", alias="github-mcp")])
+    central_mgr = _make_mock_mcp_manager(servers=[_make_mock_mcp_server("central-id", alias="github-mcp")])
+
+    team_obj = _make_team_obj(mcp_servers=["west-id"])
+    object_permission = {"mcp_servers": ["github-mcp"]}
+    with patch(
+        "litellm.proxy._experimental.mcp_server.mcp_server_manager.global_mcp_server_manager",
+        west_mgr,
+    ):
+        await validate_key_mcp_servers_against_team(
+            object_permission=object_permission,
+            team_obj=team_obj,
+        )
+    assert object_permission["mcp_servers"] == ["github-mcp"]
+
+    from litellm.proxy._experimental.mcp_server.mcp_server_manager import MCPServerManager
+
+    expand = MCPServerManager.expand_permission_list
+    assert expand(west_mgr, object_permission["mcp_servers"]) == ["west-id"]
+    assert expand(central_mgr, object_permission["mcp_servers"]) == ["central-id"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## TLDR

Problem this solves:

- Key saves rewrote MCP alias grants into region-local server ids
- In shared-DB multi-region setups, the other region then denied the key
- Regressed in v1.88.0 (#29128); older keys kept working, new ones broke

How it solves it:

- Persist the caller's original identifiers after validating them
- Still drop identifiers that resolve to nothing (deleted servers, typos)
- Each region keeps resolving the alias to its own local server at read time

## User Flow

Before: an admin runs two regional proxies with the same MCP server alias in each region's config, sharing one database. A key granted the server by alias only works in the region that created it

1. Admin sends POST https://litellm-west/key/generate with `{"object_permission": {"mcp_servers": ["github_mcp"]}}` and gets a key back
2. GET https://litellm-west/key/info for that key shows the grant as a UUID like `aadf6043-...` instead of `github_mcp`
3. GET https://litellm-west/mcp-rest/tools/list with the key returns the server's tools
4. The same GET on https://litellm-central/mcp-rest/tools/list returns no tools for that server, because central knows the same alias under a different UUID

After: the same grant works from both regions

1. Admin sends the same POST https://litellm-west/key/generate with `{"object_permission": {"mcp_servers": ["github_mcp"]}}`
2. GET https://litellm-west/key/info shows the grant stored as `["github_mcp"]`, exactly what was sent
3. GET https://litellm-west/mcp-rest/tools/list with the key returns the server's tools
4. GET https://litellm-central/mcp-rest/tools/list with the same key also returns the tools, since each region maps the alias to its own server

## Relevant issues

Regressed by #29128. Reported by a customer running two regional instances against one shared database

## Linear ticket

Resolves LIT-6603

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Shared setup for the two-region case, mirroring the reporting deployment exactly: two proxies from this branch sharing one DATABASE_URL, "West" on :4191 and "Central" on :4192, each launched with `python litellm/proxy/proxy_cli.py --config <region>.yaml --port <port> --use_v2_migration_resolver`. Each config defines the same server name with a region-specific real upstream, so each instance hash-derives a different server_id for it (West `b39685ae...`, Central `4d384b80...`):

```yaml
# west.yaml                                # central.yaml
mcp_servers:                               mcp_servers:
  github_mcp:                                github_mcp:
    url: https://mcp.deepwiki.com/mcp          url: https://learn.microsoft.com/api/mcp
    transport: http                            transport: http
```

The single-instance case runs one proxy on :4189 with a DB-registered server. Master key sk-1234 throughout

### Before (ec3f8183c3)

#### Two regions, one key granted by name

1. Create a key on West granting the server by name:
   ```
   curl -s http://localhost:4191/key/generate -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' \
     -d '{"key_alias":"qa_multiregion_alias_key_before","object_permission":{"mcp_servers":["github_mcp"]}}'
   # -> "key":"sk-zkZitVCRVScXBqiqQsGkYQ"
   ```
2. Read the stored grant back:
   ```
   curl -s http://localhost:4191/key/info -H 'Authorization: Bearer sk-zkZitVCRVScXBqiqQsGkYQ' | python -c "import json,sys; print(json.load(sys.stdin)['info']['object_permission']['mcp_servers'])"
   # -> ['b39685aed2f9282cedb787a599b49343']
   ```
   The name was rewritten to West's server_id before hitting the shared database
3. List tools with the key on both regions:
   ```
   curl -s http://localhost:4191/mcp-rest/tools/list -H 'x-litellm-api-key: sk-zkZitVCRVScXBqiqQsGkYQ' ...
   # WEST tools: ['ask_question', 'read_wiki_contents', 'read_wiki_structure']
   curl -s http://localhost:4192/mcp-rest/tools/list -H 'x-litellm-api-key: sk-zkZitVCRVScXBqiqQsGkYQ' ...
   # CENTRAL tools: []
   ```
   Central denies the key because West's id doesn't exist there: the reported bug

#### Single instance: name persists, stale id drops

1. Register a server by alias:
   ```
   curl -s http://localhost:4189/v1/mcp/server -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' \
     -d '{"server_name":"qa_alias_mcp_west_before","alias":"github_mcp_qa_before","url":"https://mcp.deepwiki.com/mcp","transport":"http"}'
   # -> {"server_id":"aadf6043-68e0-4418-867a-000139ad4724","alias":"github_mcp_qa_before",...}
   ```
2. Grant a key by that alias (plus a stale id):
   ```
   curl -s http://localhost:4189/key/generate -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' \
     -d '{"key_alias":"qa_alias_grant_key_before","object_permission":{"mcp_servers":["github_mcp_qa_before","stale-id-gone-123"]}}'
   # -> "key":"sk-mDbG1jgvUuVqWjvnynD-vg"
   ```
3. Read the stored grant back:
   ```
   curl -s http://localhost:4189/key/info -H 'Authorization: Bearer sk-mDbG1jgvUuVqWjvnynD-vg' | python -c "import json,sys; print(json.load(sys.stdin)['info']['object_permission']['mcp_servers'])"
   # -> ['aadf6043-68e0-4418-867a-000139ad4724']
   ```
   The alias was rewritten to this instance's UUID, so any other instance sharing the database denies the key

### After (4118db5a50)

#### Two regions, one key granted by name

1. Create a key on West granting the server by name:
   ```
   curl -s http://localhost:4191/key/generate -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' \
     -d '{"key_alias":"qa_mr_key_v2","object_permission":{"mcp_servers":["github_mcp"]}}'
   # -> "key":"sk-CT7X-Uq0oj4C3SKMBF3UQQ"
   ```
2. Read the stored grant back:
   ```
   curl -s http://localhost:4191/key/info -H 'Authorization: Bearer sk-CT7X-Uq0oj4C3SKMBF3UQQ' | python -c "import json,sys; print(json.load(sys.stdin)['info']['object_permission']['mcp_servers'])"
   # -> ['github_mcp']
   ```
3. List tools with the same key on both regions:
   ```
   curl -s http://localhost:4191/mcp-rest/tools/list -H 'x-litellm-api-key: sk-CT7X-Uq0oj4C3SKMBF3UQQ' ...
   # WEST tools: ['ask_question', 'read_wiki_contents', 'read_wiki_structure']
   curl -s http://localhost:4192/mcp-rest/tools/list -H 'x-litellm-api-key: sk-CT7X-Uq0oj4C3SKMBF3UQQ' ...
   # CENTRAL tools: ['microsoft_code_sample_search', 'microsoft_docs_fetch', 'microsoft_docs_search']
   ```
   Each region resolves the one stored name to its own regional server
4. Call a real tool through each region with the same key:
   ```
   curl -s -X POST http://localhost:4191/mcp-rest/tools/call -H 'x-litellm-api-key: sk-CT7X-Uq0oj4C3SKMBF3UQQ' -H 'Content-Type: application/json' \
     -d '{"server_id":"github_mcp","name":"ask_question","arguments":{"repoName":"BerriAI/litellm","question":"What is LiteLLM in one sentence?"}}'
   # -> {"content":[{"type":"text","text":"LiteLLM is an open-source AI Gateway that provides a unified interface to interact with over 100 ..."}]}
   curl -s -X POST http://localhost:4192/mcp-rest/tools/call -H 'x-litellm-api-key: sk-CT7X-Uq0oj4C3SKMBF3UQQ' -H 'Content-Type: application/json' \
     -d '{"server_id":"github_mcp","name":"microsoft_docs_search","arguments":{"query":"azure openai quota"}}'
   # -> {"content":[{"type":"text","text":"{\"results\":[{\"title\":\"Manage Azure OpenAI in Azure AI Foundry Models quota\", ..."}]}
   ```

#### Single instance: name persists, stale id drops

1. Register a server by alias:
   ```
   curl -s http://localhost:4189/v1/mcp/server -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' \
     -d '{"server_name":"qa_alias_mcp_west","alias":"github_mcp_qa","url":"https://mcp.deepwiki.com/mcp","transport":"http"}'
   # -> {"server_id":"fdc623a9-956f-4d04-8607-fe586c9d511d","alias":"github_mcp_qa",...}
   ```
2. Grant a key by that alias (plus a stale id):
   ```
   curl -s http://localhost:4189/key/generate -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' \
     -d '{"key_alias":"qa_alias_key_v2","object_permission":{"mcp_servers":["github_mcp_qa","stale-id-gone-123"]}}'
   # -> "key":"sk-1WUMxUsQ1vi85Ow6qM4JLA"
   ```
3. Read the stored grant back:
   ```
   curl -s http://localhost:4189/key/info -H 'Authorization: Bearer sk-1WUMxUsQ1vi85Ow6qM4JLA' | python -c "import json,sys; print(json.load(sys.stdin)['info']['object_permission']['mcp_servers'])"
   # -> ['github_mcp_qa']
   ```
   The alias persisted verbatim and the stale id was still dropped (the #29128 behavior this PR keeps)
4. Call the gateway with the alias-granted key:
   ```
   curl -s http://localhost:4189/mcp-rest/tools/list -H 'x-litellm-api-key: sk-1WUMxUsQ1vi85Ow6qM4JLA' | python -c "import json,sys; print([t['name'] for t in json.load(sys.stdin)['tools']])"
   # -> ['ask_question', 'read_wiki_contents', 'read_wiki_structure']
   ```

## Type

🐛 Bug Fix
✅ Test

## Caveats (if any)

### Medium

- Keys saved while broken keep the baked region-local ids until re-saved with the alias

### Low

- Team grants never rewrote, so teams were unaffected; only key create/update/regenerate changed
- Alias entries still 403 on non-admin GET /v1/mcp/server/{id}, a pre-existing gap in a raw-id read path

## QA runbook

- tests/e2e/mcp/test_mcp_key_access_e2e.py::TestMcpKeyGrantByAlias::test_alias_grant_persists_verbatim_and_lists_tools - a key granted an MCP server by alias stores the alias unrewritten and still lists the server's tools (needs DD_API_KEY and DD_APP_KEY)
  - [ ] POST /v1/mcp/server with the master key registering the Datadog MCP server with a unique alias
  - [ ] POST /key/generate with `{"object_permission": {"mcp_servers": ["<that alias>"]}}`
  - [ ] GET /key/info with the new key and expect `object_permission.mcp_servers` to equal exactly `["<that alias>"]`, not the server's UUID
  - [ ] GET /mcp-rest/tools/list with the new key and expect the server's `search_datadog_logs` tool to appear
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey (e.g., assert actual expected spend instead of just spend > 0) or potentially flaky

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
