### PR TITLE
fix(sap): cache_control correctly handled

### DIFF
--- a/litellm/llms/sap/chat/models.py
+++ b/litellm/llms/sap/chat/models.py
@@ -2,7 +2,15 @@ import warnings
 from enum import Enum
 from typing import Final, Literal
 
-from pydantic import BaseModel, Field, field_validator, model_validator
+from pydantic import (
+    BaseModel,
+    Field,
+    SerializationInfo,
+    SerializerFunctionWrapHandler,
+    field_validator,
+    model_serializer,
+    model_validator,
+)
 
 
 def validate_different_content(v: str | dict | list) -> str:
@@ -24,9 +32,30 @@ def validate_different_content(v: str | dict | list) -> str:
     raise ValueError("Content must be a string")
 
 
+class CacheControl(BaseModel):
+    type: Literal["ephemeral"]
+
+
 class TextContent(BaseModel):
     type_: Literal["text"] = Field(default="text", alias="type")
     text: str
+    cache_control: CacheControl | None = None
+
+    def model_dump(
+        self,
+        **kwargs: object,  # kwargs-ok: pydantic model_dump passthrough
+    ) -> dict:  # mutable-ok: pydantic override; wire serialization output
+        kwargs["exclude_none"] = True
+        return super().model_dump(**kwargs)  # pyright: ignore[reportArgumentType]  # kwargs forwarded verbatim to pydantic model_dump
+
+    @model_serializer(mode="wrap")
+    def _serialize(
+        self, handler: SerializerFunctionWrapHandler, info: SerializationInfo
+    ) -> dict:  # mutable-ok: pydantic serializer contract requires bare dict return
+        result = handler(self)
+        if result.get("cache_control") is None:
+            result.pop("cache_control", None)
+        return result
 
 
 class ImageURLContent(BaseModel):
@@ -50,9 +79,9 @@ class FunctionTool(BaseModel):
     parameters: dict = {"type": "object", "properties": {}}
     strict: bool = False
 
-    def model_dump(self, **kwargs) -> dict:
+    def model_dump(self, **kwargs: object) -> dict:
         kwargs["exclude_unset"] = False
-        return super().model_dump(**kwargs)
+        return super().model_dump(**kwargs)  # pyright: ignore[reportArgumentType]  # kwargs forwarded verbatim to pydantic model_dump
 
     @field_validator("parameters", mode="before")
     @classmethod
@@ -71,9 +100,9 @@ class ChatCompletionTool(BaseModel):
     type_: Literal["function"] = Field(default="function", alias="type")
     function: FunctionTool
 
-    def model_dump(self, **kwargs) -> dict:
+    def model_dump(self, **kwargs: object) -> dict:
         kwargs["exclude_unset"] = False
-        return super().model_dump(**kwargs)
+        return super().model_dump(**kwargs)  # pyright: ignore[reportArgumentType]  # kwargs forwarded verbatim to pydantic model_dump
 
 
 class MessageToolCall(BaseModel):
@@ -88,9 +117,7 @@ class SAPMessage(BaseModel):
     """
 
     role: Literal["system", "developer"] = "system"
-    content: str
-
-    _content_validator = field_validator("content", mode="before")(validate_different_content)
+    content: list[TextContent] | str  # mutable-ok: pydantic field; list[TextContent] carries cache_control natively
 
 
 class SAPUserMessage(BaseModel):
@@ -184,7 +211,9 @@ class Template(BaseModel):
     template: list[ChatMessage]
     defaults: dict[str, str] | None = None
     response_format: ResponseFormat | ResponseFormatJSONSchema | None = None
-    tools: list[ChatCompletionTool] | None = None
+    tools: list[dict] | None = (
+        None  # mutable-ok: already-validated dicts passed to wire; list preserves insertion order, dict preserves extension fields like cache_control
+    )
 
 
 class LLMModelDetails(BaseModel):

--- a/litellm/llms/sap/chat/transformation.py
+++ b/litellm/llms/sap/chat/transformation.py
@@ -53,8 +53,59 @@ _SAP_MODEL_PARAMS_EXCLUDED_KEYS: Final[frozenset[str]] = frozenset(
 )
 
 
-def validate_dict(data: dict, model) -> dict:
+def validate_dict(
+    data: dict, model
+) -> dict:  # mutable-ok: pydantic validation boundary; both input and output are untyped wire dicts
     return model(**data).model_dump(by_alias=True, exclude_unset=True)
+
+
+def _validate_tool(
+    tool: dict,  # mutable-ok: untyped tool dict from litellm boundary
+) -> dict:  # mutable-ok: wire serialization helper; dict is the required output shape for JSON encoding
+    """Validate a tool definition against ChatCompletionTool and preserve cache_control.
+
+    cache_control is an Anthropic prompt-caching extension that sits on the tool
+    object itself (not inside `function`).  ChatCompletionTool does not declare it
+    as a field because its model_dump forces exclude_unset=False for FunctionTool
+    defaults -- adding cache_control there would emit `cache_control: null` for every
+    tool that omits it, which the API rejects.  We therefore validate the known schema
+    and re-attach the extension field explicitly.
+    """
+    result = validate_dict(tool, ChatCompletionTool)
+    if "cache_control" in tool and tool["cache_control"] is not None:
+        result["cache_control"] = tool["cache_control"]
+    return result
+
+
+def _fold_message_cache_control(message: dict) -> dict:  # mutable-ok: message dicts are untyped at the litellm boundary
+    """Fold a message-level cache_control onto the content block.
+
+    litellm's cache_control_injection_points hook places cache_control on the
+    message dict itself when content is a plain string.  SAPMessage has no such
+    field, so it would be silently dropped.  Convert to a single-element content
+    list so the marker reaches the wire payload.
+    """
+    cc = message.get("cache_control")
+    if cc is None:
+        return message
+    content = message.get("content")
+    if isinstance(content, str):
+        return {  # mutable-ok: ephemeral wire dict; built once and immediately returned to caller
+            **{
+                k: v for k, v in message.items() if k != "cache_control"
+            },  # mutable-ok: dict comprehension filters one key; returned immediately
+            "content": [  # mutable-ok: list literal builds the wire content block in one shot
+                {
+                    "type": "text",
+                    "text": content,
+                    "cache_control": cc,
+                },  # mutable-ok: inner dict literal is the wire content block
+            ],
+        }
+    # content already a list -- marker is redundant; drop it to avoid duplication
+    return {
+        k: v for k, v in message.items() if k != "cache_control"
+    }  # mutable-ok: dict comprehension filters one key; returned immediately
 
 
 def _messages_to_sap_template(messages: list[dict[str, str]]) -> list:
@@ -67,34 +118,8 @@ def _messages_to_sap_template(messages: list[dict[str, str]]) -> list:
         elif message["role"] == "tool":
             template.append(validate_dict(message, SAPToolChatMessage))
         else:
-            template.append(validate_dict(message, SAPMessage))
+            template.append(validate_dict(_fold_message_cache_control(message), SAPMessage))
     return template
-
-
-def _tools_response_format_and_stream(optional_params: dict, model_params: dict) -> tuple[dict, dict, dict]:
-    tools_ = optional_params.pop("tools", [])
-    tools_ = [validate_dict(tool, ChatCompletionTool) for tool in tools_]
-    tools: Final[dict] = {"tools": tools_} if tools_ else {}
-
-    response_format = model_params.pop("response_format", {})
-    resp_type: Final = response_format.get("type", None)
-    if resp_type:
-        if resp_type == "json_schema":
-            response_format = validate_dict(response_format, ResponseFormatJSONSchema)
-        else:
-            response_format = validate_dict(response_format, ResponseFormat)
-        response_format = {"response_format": response_format}
-
-    model_params.pop("stream", False)
-    stream_config: Final[dict] = {}
-    if "stream_options" in optional_params:
-        stream_options: Final = optional_params.pop("stream_options", {})
-        if "chunk_size" in stream_options:
-            stream_config["chunk_size"] = stream_options.get("chunk_size")
-        if "delimiters" in stream_options:
-            stream_config["delimiters"] = stream_options.get("delimiters")
-
-    return tools, response_format, stream_config
 
 
 class GenAIHubOrchestrationConfig(OpenAIGPTConfig):
@@ -268,7 +293,7 @@ class GenAIHubOrchestrationConfig(OpenAIGPTConfig):
         model_version: Final = params.pop("model_version", "latest")
 
         tools_ = params.pop("tools", [])
-        tools_ = [validate_dict(tool, ChatCompletionTool) for tool in tools_]
+        tools_ = [_validate_tool(tool) for tool in tools_]
         tools: Final = {"tools": tools_} if tools_ else {}
 
         response_format = params.pop("response_format", {})

--- a/tests/test_litellm/llms/sap/chat/test_sap_transformation.py
+++ b/tests/test_litellm/llms/sap/chat/test_sap_transformation.py
@@ -1,4 +1,5 @@
 import warnings
+
 import pytest
 from pydantic import ValidationError
 
@@ -611,31 +612,193 @@ class TestSAPTransformationIntegration:
             assert translation["input"]["config"]["source_language"] == "en-US"
             assert translation["input"]["config"]["target_language"] == "de-DE"
             assert translation["output"]["config"]["target_language"] == "fr-FR"
+            assert config["config"]["modules"][1]["prompt_templating"]["model"]["name"] == "gpt-5"
+            assert config["config"]["modules"][0]["prompt_templating"]["model"]["name"] == "gpt-4o"
+            assert config["config"]["modules"][0]["prompt_templating"]["model"]["params"] == {}
             assert (
-                config["config"]["modules"][1]["prompt_templating"]["model"]["name"]
-                == "gpt-5"
-            )
-            assert (
-                config["config"]["modules"][0]["prompt_templating"]["model"]["name"]
-                == "gpt-4o"
-            )
-            assert (
-                config["config"]["modules"][0]["prompt_templating"]["model"]["params"]
-                == {}
-            )
-            assert (
-                config["config"]["modules"][1]["prompt_templating"]["prompt"][
-                    "template"
-                ][0]["content"]
+                config["config"]["modules"][1]["prompt_templating"]["prompt"]["template"][0]["content"]
                 == "Hello world!"
             )
-            assert (
-                config["config"]["modules"][0]["prompt_templating"]["prompt"][
-                    "template"
-                ][0]["content"]
-                == "Hello."
-            )
-            assert (
-                config["config"]["modules"][1]["translation"]["input"]["type"]
-                == "sap_document_translation"
-            )
+            assert config["config"]["modules"][0]["prompt_templating"]["prompt"]["template"][0]["content"] == "Hello."
+            assert config["config"]["modules"][1]["translation"]["input"]["type"] == "sap_document_translation"
+
+
+class TestCacheControl:
+    """Unit tests for cache_control preservation on message content parts."""
+
+    def _transform(self, model: str, messages: list) -> dict:
+        from litellm.llms.sap.chat.transformation import GenAIHubOrchestrationConfig
+
+        cfg = GenAIHubOrchestrationConfig()
+        return cfg.transform_request(
+            model=model,
+            messages=messages,
+            optional_params={},
+            litellm_params={},
+            headers={},
+        )
+
+    def _template(self, body: dict) -> list:
+        return body["config"]["modules"]["prompt_templating"]["prompt"]["template"]
+
+    def test_cache_control_preserved_on_text_content(self):
+        """cache_control on a TextContent part survives validation and appears in payload."""
+        messages = [
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "text",
+                        "text": "Hello",
+                        "cache_control": {"type": "ephemeral"},
+                    }
+                ],
+            }
+        ]
+        body = self._transform("anthropic--claude-3-5-sonnet", messages)
+        template = self._template(body)
+        content = template[0]["content"]
+        assert isinstance(content, list)
+        assert content[0].get("cache_control") == {"type": "ephemeral"}
+
+    def test_plain_text_content_unaffected(self):
+        """Text content without cache_control still serialises cleanly."""
+        messages = [{"role": "user", "content": "Hello"}]
+        body = self._transform("anthropic--claude-3-5-sonnet", messages)
+        template = self._template(body)
+        assert template[0]["content"] == "Hello"
+
+    def test_cache_control_preserved_on_multiple_parts(self):
+        """cache_control is preserved on each part independently."""
+        messages = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "Part A", "cache_control": {"type": "ephemeral"}},
+                    {"type": "text", "text": "Part B"},
+                ],
+            }
+        ]
+        body = self._transform("anthropic--claude-3-5-sonnet", messages)
+        content = self._template(body)[0]["content"]
+        assert content[0].get("cache_control") == {"type": "ephemeral"}
+        assert "cache_control" not in content[1]
+
+    def test_cache_control_preserved_on_system_message(self):
+        """cache_control on a system message content part reaches the payload."""
+        messages = [
+            {
+                "role": "system",
+                "content": [
+                    {
+                        "type": "text",
+                        "text": "You are a helpful assistant.",
+                        "cache_control": {"type": "ephemeral"},
+                    }
+                ],
+            },
+            {"role": "user", "content": "Hello"},
+        ]
+        body = self._transform("anthropic--claude-3-5-sonnet", messages)
+        template = self._template(body)
+        system_content = template[0]["content"]
+        assert isinstance(system_content, list)
+        assert system_content[0].get("cache_control") == {"type": "ephemeral"}
+
+    def test_system_message_without_cache_control_stays_string(self):
+        """A plain system message is still serialised as a string, not a list."""
+        messages = [
+            {"role": "system", "content": "You are a helpful assistant."},
+            {"role": "user", "content": "Hello"},
+        ]
+        body = self._transform("anthropic--claude-3-5-sonnet", messages)
+        template = self._template(body)
+        assert isinstance(template[0]["content"], str)
+
+    def test_cache_control_preserved_on_tool_definition(self):
+        """cache_control on a tool definition reaches the payload."""
+        tool = {
+            "type": "function",
+            "function": {
+                "name": "get_weather",
+                "description": "Get weather",
+                "parameters": {"type": "object", "properties": {}},
+            },
+            "cache_control": {"type": "ephemeral"},
+        }
+        messages = [{"role": "user", "content": "Hi"}]
+        from litellm.llms.sap.chat.transformation import GenAIHubOrchestrationConfig
+
+        cfg = GenAIHubOrchestrationConfig()
+        body = cfg.transform_request(
+            model="anthropic--claude-3-5-sonnet",
+            messages=messages,
+            optional_params={"tools": [tool]},
+            litellm_params={},
+            headers={},
+        )
+        tools = body["config"]["modules"]["prompt_templating"]["prompt"]["tools"]
+        assert tools[0].get("cache_control") == {"type": "ephemeral"}
+
+    def test_tool_without_cache_control_omits_field(self):
+        """A tool without cache_control does not emit cache_control: null."""
+        tool = {
+            "type": "function",
+            "function": {
+                "name": "get_weather",
+                "description": "Get weather",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        }
+        messages = [{"role": "user", "content": "Hi"}]
+        from litellm.llms.sap.chat.transformation import GenAIHubOrchestrationConfig
+
+        cfg = GenAIHubOrchestrationConfig()
+        body = cfg.transform_request(
+            model="anthropic--claude-3-5-sonnet",
+            messages=messages,
+            optional_params={"tools": [tool]},
+            litellm_params={},
+            headers={},
+        )
+        tools = body["config"]["modules"]["prompt_templating"]["prompt"]["tools"]
+        assert "cache_control" not in tools[0]
+
+    def test_message_level_cache_control_folded_onto_string_content(self):
+        """cache_control on the message dict (string content) is folded into a content block.
+
+        litellm's cache_control_injection_points hook produces this shape for
+        plain-string content.  The marker must not be silently dropped.
+        """
+        messages = [
+            {
+                "role": "system",
+                "content": "You are a helpful assistant.",
+                "cache_control": {"type": "ephemeral"},
+            },
+            {"role": "user", "content": "Hello"},
+        ]
+        body = self._transform("anthropic--claude-3-5-sonnet", messages)
+        template = self._template(body)
+        system_content = template[0]["content"]
+        assert isinstance(system_content, list), "string content should have been promoted to a list"
+        assert system_content[0]["text"] == "You are a helpful assistant."
+        assert system_content[0].get("cache_control") == {"type": "ephemeral"}
+
+    def test_null_cache_control_on_content_block_is_omitted(self):
+        """cache_control: null on a content block must not appear in the payload.
+
+        Sending null reaches AI Core and causes a 400 ('None is not of type object').
+        """
+        messages = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "Hello", "cache_control": None},
+                ],
+            }
+        ]
+        body = self._transform("anthropic--claude-3-5-sonnet", messages)
+        content = self._template(body)[0]["content"]
+        assert isinstance(content, list)
+        assert "cache_control" not in content[0]


### PR DESCRIPTION
<!-- The whole description's target audience is humans, not AI agents: write it in plain, simple,
     everyday engineering language, extremely parsable and readable at a glance. This goes double for
     the TLDR, User Flow, and Caveats sections -->

## TLDR

<!-- Fill in the bullets below and keep each one short and concrete: one line per bullet, roughly 10 words max -->

Problem this solves:

- <blah>
- ...

How it solves it:

- <blah>
- ...

## User Flow

<!-- Two ordered lists, Before and After, walking the same end user through the same task, written strictly from that user's seat
     Read the linked issue, ticket, or customer thread first so the flow reflects the real application and the routes its users actually hit; don't invent a generic scenario
     Lead each list with one plain sentence saying where the flow fails (Before) or succeeds (After), then number the steps
     Every step is something the user does or observes: the HTTP method and full URL they hit, what they sent, and what visibly came back (status code, error text, the shape of an ID). UI steps name the page URL and what is on screen
     No LiteLLM internals: never name functions, files, DB tables, config classes, hooks, callbacks, or code paths. "The upload hands back an ID that looks like OpenAI's own `file-abc123` instead of the scrambled one the gateway returned" is right, "no managed-file row was registered" is wrong
     Keep the two lists step-for-step identical until they diverge, so the changed step is obvious
     If the bug had a security or authorization consequence, end each list with what another user could or could no longer do
     Regenerate this section whenever new commits change the PR's behavior, so it never describes an older revision

Example:

Before: a developer whose app streams chat completions gets no token counts back, so their cost dashboard reads zero

1. They send POST https://litellm-domain/v1/chat/completions with `"stream": true` and no `stream_options`
2. The last SSE chunk arrives with `"usage": null`, so their app records 0 prompt and 0 completion tokens
3. They open https://litellm-domain/ui/?page=logs and see the request logged at $0 spend

After: the same request comes back with real token counts, so the dashboard shows real spend

1. The proxy admin sets `always_include_stream_usage: true` and restarts the proxy
2. The developer sends the same POST https://litellm-domain/v1/chat/completions with `"stream": true` and no `stream_options`
3. The last SSE chunk now carries a `usage` object with real prompt and completion token counts
4. https://litellm-domain/ui/?page=logs shows that request at non-zero spend
-->

## Relevant issues

<!-- e.g., "Fixes #000" -->

## Linear ticket

<!-- if you are an internal contributor, add "Resolves " followed by the Linear ticket e.g., "Resolves LIT-1234" to link the Linear ticket to the GitHub PR. If you don't have one, leave the section blank rather than guessing -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have added meaningful tests
- [ ] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [ ] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

<!-- Include screenshots, screen recordings, or command (e.g., curl) + output demonstrating that your changes work as expected
     The proof must be completely e2e with no mocks, using actual LLM calls costing real $$$ if applicable. `pytest` commands are not enough
     Show ONLY the latest run: capture Before at the merge base and After at the PR's current tip, and when new commits change behavior, replace this whole section with the fresh run instead of stacking it on top of older ones. The run must be up to date. As soon as a new commit is made and it makes this PR description's after sha stale (it's no longer tip of PR), you must re-run the QA
     Structure the section exactly as below: Before and After one heading level below this section, each naming the commit hash it was captured at, one lower-level heading per case inside each, the same case names in the same order on both sides, and numbered steps (command, observed output) under every case, never loose prose; shared setup (config, payloads) goes above Before, and with a single case, drop the case headings and number the steps directly

### Before (<hash>)

#### <case 1>

1. ...
2. ...

#### <case 2>

1. ...

### After (<hash>)

#### <case 1>

1. ...
2. ...

#### <case 2>

1. ...

     For bug fixes: Before shows the reproduction, After shows the same steps passing
     For new features: Before shows the capability missing, After shows it working end-to-end
     If the change applies to all three LLM endpoints (/v1/responses, /v1/chat/completions, /v1/messages), make each endpoint its own case, not just one
     For UI changes: before/after screenshots under the same headings -->

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
🐛 Bug Fix
🧹 Refactoring
📖 Documentation
🚄 Infrastructure
✅ Test

## Caveats (if any)

<!-- Group caveats under severity subheadings (### Severe, ### High, ### Medium, ### Low), with
     short bullet points inside each, just like the TLDR: one line per bullet, roughly 10 words max
     Call out known limitations, follow-up work, or anything a reviewer should watch out for
     Include only the tiers that have caveats; drop the empty ones
     - Severe: inherent to what the PR deliberately ships, there even when the code works as intended:
       it can degrade or take down a running deployment (e.g. a slow or table-locking boot migration),
       rewrite data by design, break an existing workflow on purpose, or change auth behavior. An
       operator must plan around it before rollout
     - High: an unintended hole: a correctness, security, data-loss, or backward-compatibility bug,
       unsafe to ship as is
     - Medium: a real gap someone can hit, but with a workaround or a narrow blast radius
     - Low: anything else worth noting: naming, cleanup, an edge case nobody hits
     Nest bullets as deep as helps: hierarchy beats one long line when it makes things clearer to a
     human reader
     Leave this section empty if there are none -->

## QA runbook

<!-- Only needed when your PR edits tests/e2e; delete this section otherwise

For each e2e test you added or changed, list the manual steps a reviewer can follow to reproduce it by hand against a live proxy, mapping 1:1 to what the test asserts: one top-level bullet per test giving its pytest node id followed by what it proves in plain words, then a nested "- [ ]" checklist where each item is a concrete action (route, request body, expected response) and the final item is the sanity-check step shown in the examples. Note environment prerequisites (provider credentials, config flags) and any nuances a manual run will hit. See PRs #32914 and #32963 for full examples

Example checklists:

- tests/e2e/quota_management/ratelimit/test_rate_limit_e2e.py::TestKeyRateLimits::test_rpm_limit_blocks_over_limit - a key allowed 2 requests a minute serves exactly 2 and refuses the 3rd
  - [ ] Generate a limited key: curl -X POST http://localhost:4000/key/generate -H "Authorization: Bearer sk-1234" -d '{"rpm_limit": 2}'
  - [ ] Send three /v1/chat/completions requests with that key inside one minute
  - [ ] Expect the first two to return 200 and the third to return 429 naming the rpm limit
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey (e.g., assert actual expected spend instead of just spend > 0) or potentially flaky

- tests/e2e/management/test_management_e2e.py::TestModelRoutes::test_model_create_appears_in_ui - a deployment created through the API shows up on the Admin UI models page
  - [ ] POST /model/new with the master key, a bedrock model, and aws_region_name (needs STORE_MODEL_IN_DB=True and AWS credentials)
  - [ ] Open http://localhost:4000/ui/?page=models and expect a deployment row showing the returned model id
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey (e.g., assert actual expected spend instead of just spend > 0) or potentially flaky
-->

## Final Attestation

- [ ] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
