### PR TITLE
fix(sap): correctly handle cache_control

### DIFF
--- a/litellm/llms/sap/chat/models.py
+++ b/litellm/llms/sap/chat/models.py
@@ -2,7 +2,15 @@ import warnings
 from enum import Enum
 from typing import Final, Literal
 
-from pydantic import BaseModel, Field, field_validator, model_validator
+from pydantic import (
+    BaseModel,
+    Field,
+    SerializationInfo,
+    SerializerFunctionWrapHandler,
+    field_validator,
+    model_serializer,
+    model_validator,
+)
 
 
 def validate_different_content(v: str | dict | list) -> str:
@@ -24,9 +32,60 @@ def validate_different_content(v: str | dict | list) -> str:
     raise ValueError("Content must be a string")
 
 
+class CacheControl(BaseModel):
+    type: Literal["ephemeral"]
+    ttl: str | None = None
+
+    def model_dump(self, **kwargs: object) -> dict:  # kwargs-ok: forwarded verbatim to pydantic model_dump
+        kwargs["exclude_unset"] = False  # rebind-ok: sets serialization option before forwarding to pydantic
+        return super().model_dump(**kwargs)  # pyright: ignore[reportArgumentType]  # kwargs forwarded verbatim to pydantic model_dump
+
+    @model_serializer(mode="wrap")
+    def _serialize(
+        self, handler: SerializerFunctionWrapHandler, info: SerializationInfo
+    ) -> dict:  # mutable-ok: pydantic serializer contract requires bare dict return
+        result = handler(self)
+        if result.get("ttl") is None:
+            result.pop("ttl", None)
+        return result
+
+
 class TextContent(BaseModel):
     type_: Literal["text"] = Field(default="text", alias="type")
     text: str
+    cache_control: CacheControl | None = None
+
+    @model_serializer(mode="wrap")
+    def _serialize(
+        self, handler: SerializerFunctionWrapHandler, info: SerializationInfo
+    ) -> dict:  # mutable-ok: pydantic serializer contract requires bare dict return
+        result = handler(self)
+        if result.get("cache_control") is None:
+            result.pop("cache_control", None)
+        return result
+
+
+def validate_or_preserve_content(
+    v: str | dict[str, object] | list[object],
+) -> str | TextContent | list[TextContent]:
+    """Validate and normalize a content field value.
+
+    Strings and empty values are coerced via validate_different_content.
+    A dict is validated as a single TextContent block.
+    A list is validated as a list of TextContent blocks.
+    """
+    if isinstance(v, dict):
+        return TextContent.model_validate(dict(v))  # mutable-ok: ephemeral copy to satisfy model_validate dict contract
+    if isinstance(v, list):
+        return [  # mutable-ok: new list built and returned immediately
+            TextContent.model_validate(dict(item))  # mutable-ok: ephemeral copy to satisfy model_validate dict contract
+            if isinstance(item, dict)
+            else TextContent.model_validate(
+                {"type": "text", "text": item}
+            )  # mutable-ok: ephemeral literal passed directly to model_validate
+            for item in v
+        ]
+    return validate_different_content(v)
 
 
 class ImageURLContent(BaseModel):
@@ -50,9 +109,9 @@ class FunctionTool(BaseModel):
     parameters: dict = {"type": "object", "properties": {}}
     strict: bool = False
 
-    def model_dump(self, **kwargs) -> dict:
+    def model_dump(self, **kwargs: object) -> dict:
         kwargs["exclude_unset"] = False
-        return super().model_dump(**kwargs)
+        return super().model_dump(**kwargs)  # pyright: ignore[reportArgumentType]  # kwargs forwarded verbatim to pydantic model_dump
 
     @field_validator("parameters", mode="before")
     @classmethod
@@ -70,10 +129,14 @@ class FunctionTool(BaseModel):
 class ChatCompletionTool(BaseModel):
     type_: Literal["function"] = Field(default="function", alias="type")
     function: FunctionTool
+    cache_control: CacheControl | None = None
 
-    def model_dump(self, **kwargs) -> dict:
+    def model_dump(self, **kwargs: object) -> dict:
         kwargs["exclude_unset"] = False
-        return super().model_dump(**kwargs)
+        result = super().model_dump(**kwargs)  # pyright: ignore[reportArgumentType]  # kwargs forwarded verbatim to pydantic model_dump
+        if result.get("cache_control") is None:
+            result.pop("cache_control", None)
+        return result
 
 
 class MessageToolCall(BaseModel):
@@ -88,31 +151,33 @@ class SAPMessage(BaseModel):
     """
 
     role: Literal["system", "developer"] = "system"
-    content: str
+    content: list[TextContent] | str  # mutable-ok: pydantic field; list[TextContent] carries cache_control natively
 
-    _content_validator = field_validator("content", mode="before")(validate_different_content)
+    _content_validator = field_validator("content", mode="before")(validate_or_preserve_content)
 
 
 class SAPUserMessage(BaseModel):
     role: Literal["user"] = "user"
     content: str | TextContent | ImageContent | list[TextContent | ImageContent]
 
+    _content_validator = field_validator("content", mode="before")(validate_or_preserve_content)
+
 
 class SAPAssistantMessage(BaseModel):
     role: Literal["assistant"] = "assistant"
-    content: str = ""
+    content: list[TextContent] | str = ""
     refusal: str = ""
     tool_calls: list[MessageToolCall] = []
 
-    _content_validator = field_validator("content", mode="before")(validate_different_content)
+    _content_validator = field_validator("content", mode="before")(validate_or_preserve_content)
 
 
 class SAPToolChatMessage(BaseModel):
     role: Literal["tool"] = "tool"
     tool_call_id: str
-    content: str
+    content: list[TextContent] | str
 
-    _content_validator = field_validator("content", mode="before")(validate_different_content)
+    _content_validator = field_validator("content", mode="before")(validate_or_preserve_content)
 
 
 ChatMessage = SAPMessage | SAPUserMessage | SAPAssistantMessage | SAPToolChatMessage

--- a/litellm/llms/sap/chat/models.py
+++ b/litellm/llms/sap/chat/models.py
@@ -36,10 +36,6 @@ class CacheControl(BaseModel):
     type: Literal["ephemeral"]
     ttl: str | None = None
 
-    def model_dump(self, **kwargs: object) -> dict:  # kwargs-ok: forwarded verbatim to pydantic model_dump
-        kwargs["exclude_unset"] = False  # rebind-ok: sets serialization option before forwarding to pydantic
-        return super().model_dump(**kwargs)  # pyright: ignore[reportArgumentType]  # kwargs forwarded verbatim to pydantic model_dump
-
     @model_serializer(mode="wrap")
     def _serialize(
         self, handler: SerializerFunctionWrapHandler, info: SerializationInfo

--- a/litellm/llms/sap/chat/models.py
+++ b/litellm/llms/sap/chat/models.py
@@ -50,6 +50,16 @@ class ImageURLContent(BaseModel):
 class ImageContent(BaseModel):
     type_: Literal["image_url"] = Field(default="image_url", alias="type")
     image_url: ImageURLContent
+    cache_control: CacheControl | None = None
+
+    @model_serializer(mode="wrap")
+    def _serialize(
+        self, handler: SerializerFunctionWrapHandler, info: SerializationInfo
+    ) -> dict:  # mutable-ok: pydantic serializer contract requires bare dict return
+        result = handler(self)
+        if result.get("cache_control") is None:
+            result.pop("cache_control", None)
+        return result
 
 
 class FunctionObj(BaseModel):

--- a/litellm/llms/sap/chat/models.py
+++ b/litellm/llms/sap/chat/models.py
@@ -13,25 +13,6 @@ from pydantic import (
 )
 
 
-def validate_different_content(v: str | dict | list) -> str:
-    if v in ((), {}, []):
-        return ""
-    elif isinstance(v, dict) and "text" in v:
-        return v["text"]
-    elif isinstance(v, list):
-        new_v: Final = []
-        for item in v:
-            if isinstance(item, dict) and "text" in item:
-                if item["text"]:
-                    new_v.append(item["text"])
-            elif isinstance(item, str):
-                new_v.append(item)
-        return "\n".join(new_v)
-    elif isinstance(v, str):
-        return v
-    raise ValueError("Content must be a string")
-
-
 class CacheControl(BaseModel):
     type: Literal["ephemeral"]
     ttl: str | None = None
@@ -59,29 +40,6 @@ class TextContent(BaseModel):
         if result.get("cache_control") is None:
             result.pop("cache_control", None)
         return result
-
-
-def validate_or_preserve_content(
-    v: str | dict[str, object] | list[object],
-) -> str | TextContent | list[TextContent]:
-    """Validate and normalize a content field value.
-
-    Strings and empty values are coerced via validate_different_content.
-    A dict is validated as a single TextContent block.
-    A list is validated as a list of TextContent blocks.
-    """
-    if isinstance(v, dict):
-        return TextContent.model_validate(dict(v))  # mutable-ok: ephemeral copy to satisfy model_validate dict contract
-    if isinstance(v, list):
-        return [  # mutable-ok: new list built and returned immediately
-            TextContent.model_validate(dict(item))  # mutable-ok: ephemeral copy to satisfy model_validate dict contract
-            if isinstance(item, dict)
-            else TextContent.model_validate(
-                {"type": "text", "text": item}
-            )  # mutable-ok: ephemeral literal passed directly to model_validate
-            for item in v
-        ]
-    return validate_different_content(v)
 
 
 class ImageURLContent(BaseModel):
@@ -147,33 +105,25 @@ class SAPMessage(BaseModel):
     """
 
     role: Literal["system", "developer"] = "system"
-    content: list[TextContent] | str  # mutable-ok: pydantic field; list[TextContent] carries cache_control natively
-
-    _content_validator = field_validator("content", mode="before")(validate_or_preserve_content)
+    content: str | TextContent | list[TextContent]
 
 
 class SAPUserMessage(BaseModel):
     role: Literal["user"] = "user"
     content: str | TextContent | ImageContent | list[TextContent | ImageContent]
 
-    _content_validator = field_validator("content", mode="before")(validate_or_preserve_content)
-
 
 class SAPAssistantMessage(BaseModel):
     role: Literal["assistant"] = "assistant"
-    content: list[TextContent] | str = ""
+    content: str | TextContent | list[TextContent] = ""
     refusal: str = ""
     tool_calls: list[MessageToolCall] = []
-
-    _content_validator = field_validator("content", mode="before")(validate_or_preserve_content)
 
 
 class SAPToolChatMessage(BaseModel):
     role: Literal["tool"] = "tool"
     tool_call_id: str
-    content: list[TextContent] | str
-
-    _content_validator = field_validator("content", mode="before")(validate_or_preserve_content)
+    content: str | TextContent | list[TextContent]
 
 
 ChatMessage = SAPMessage | SAPUserMessage | SAPAssistantMessage | SAPToolChatMessage

--- a/litellm/llms/sap/chat/transformation.py
+++ b/litellm/llms/sap/chat/transformation.py
@@ -31,6 +31,7 @@ from .handler import (
 )
 from .models import (
     ChatCompletionTool,
+    ChatMessage,
     OrchestrationRequest,
     ResponseFormat,
     ResponseFormatJSONSchema,
@@ -53,48 +54,63 @@ _SAP_MODEL_PARAMS_EXCLUDED_KEYS: Final[frozenset[str]] = frozenset(
 )
 
 
-def validate_dict(data: dict, model) -> dict:
+def validate_dict(
+    data: dict, model: type
+) -> dict:  # mutable-ok: pydantic validation boundary; both input and output are untyped wire dicts
     return model(**data).model_dump(by_alias=True, exclude_unset=True)
+
+
+def _fold_message_cache_control(
+    message: dict[str, object],
+) -> dict[str, object]:
+    """Move a message-level cache_control marker onto the content block.
+
+    litellm's cache_control_injection_points hook attaches cache_control to the
+    message dict itself when content is a plain string.  The SAP message models
+    have no such top-level field, so it would be silently dropped.  When content
+    is a string, promote it to a one-element list so the marker survives.
+    When content is already a non-empty list whose last element is a
+        dict, propagate the marker onto that element — it marks the cache
+    breakpoint for the whole block.  In all other cases (empty list, None,
+    unrecognized type) the marker is silently dropped.
+    """
+    cc = message.get("cache_control")
+    if cc is None:
+        return message
+    base = {
+        k: v for k, v in message.items() if k != "cache_control"
+    }  # mutable-ok: new dict built from message; returned immediately
+    content = message.get("content")
+    if isinstance(content, str):
+        base["content"] = [
+            {"type": "text", "text": content, "cache_control": cc}
+        ]  # mutable-ok: new list+dict built and assigned to output dict
+        return base
+    if isinstance(content, list) and content and isinstance(content[-1], dict):
+        base["content"] = [
+            *content[:-1],
+            {**content[-1], "cache_control": cc},
+        ]  # mutable-ok: new list+dict built and assigned to output dict
+        return base
+    return base
+
+
+def _message_role_mapping(role: str) -> type[ChatMessage]:  # returns the SAP message model class, not an instance
+    return {  # mutable-ok: ephemeral dispatch dict; not stored
+        "user": SAPUserMessage,
+        "assistant": SAPAssistantMessage,
+        "tool": SAPToolChatMessage,
+    }.get(role, SAPMessage)
 
 
 def _messages_to_sap_template(messages: list[dict[str, str]]) -> list:
     template: Final = []
     for message in messages:
-        if message["role"] == "user":
-            template.append(validate_dict(message, SAPUserMessage))
-        elif message["role"] == "assistant":
-            template.append(validate_dict(message, SAPAssistantMessage))
-        elif message["role"] == "tool":
-            template.append(validate_dict(message, SAPToolChatMessage))
-        else:
-            template.append(validate_dict(message, SAPMessage))
+        folded_message = _fold_message_cache_control(message)
+        message_role_class = _message_role_mapping(str(folded_message["role"]))
+        validated_message = validate_dict(folded_message, message_role_class)
+        template.append(validated_message)
     return template
-
-
-def _tools_response_format_and_stream(optional_params: dict, model_params: dict) -> tuple[dict, dict, dict]:
-    tools_ = optional_params.pop("tools", [])
-    tools_ = [validate_dict(tool, ChatCompletionTool) for tool in tools_]
-    tools: Final[dict] = {"tools": tools_} if tools_ else {}
-
-    response_format = model_params.pop("response_format", {})
-    resp_type: Final = response_format.get("type", None)
-    if resp_type:
-        if resp_type == "json_schema":
-            response_format = validate_dict(response_format, ResponseFormatJSONSchema)
-        else:
-            response_format = validate_dict(response_format, ResponseFormat)
-        response_format = {"response_format": response_format}
-
-    model_params.pop("stream", False)
-    stream_config: Final[dict] = {}
-    if "stream_options" in optional_params:
-        stream_options: Final = optional_params.pop("stream_options", {})
-        if "chunk_size" in stream_options:
-            stream_config["chunk_size"] = stream_options.get("chunk_size")
-        if "delimiters" in stream_options:
-            stream_config["delimiters"] = stream_options.get("delimiters")
-
-    return tools, response_format, stream_config
 
 
 class GenAIHubOrchestrationConfig(OpenAIGPTConfig):

--- a/litellm/llms/sap/chat/transformation.py
+++ b/litellm/llms/sap/chat/transformation.py
@@ -448,6 +448,6 @@ class GenAIHubOrchestrationConfig(OpenAIGPTConfig):
         json_mode: bool | None = False,
     ):
         if sync_stream:
-            return SAPStreamIterator(response=streaming_response)
+            return SAPStreamIterator(response=streaming_response) # pyright: ignore[reportArgumentType]
         else:
-            return AsyncSAPStreamIterator(response=streaming_response)
+            return AsyncSAPStreamIterator(response=streaming_response) # pyright: ignore[reportArgumentType]

--- a/litellm/llms/sap/chat/transformation.py
+++ b/litellm/llms/sap/chat/transformation.py
@@ -103,7 +103,7 @@ def _message_role_mapping(role: str) -> type[ChatMessage]:  # returns the SAP me
     }.get(role, SAPMessage)
 
 
-def _messages_to_sap_template(messages: list[dict[str, str]]) -> list:
+def _messages_to_sap_template(messages: list[dict[str, object]]) -> list:
     template: Final = []
     for message in messages:
         folded_message = _fold_message_cache_control(message)

--- a/litellm/llms/sap/chat/transformation.py
+++ b/litellm/llms/sap/chat/transformation.py
@@ -448,6 +448,6 @@ class GenAIHubOrchestrationConfig(OpenAIGPTConfig):
         json_mode: bool | None = False,
     ):
         if sync_stream:
-            return SAPStreamIterator(response=streaming_response)  # pyright: ignore[reportArgumentType]
+            return SAPStreamIterator(response=streaming_response)  # pyright: ignore[reportArgumentType]  # streaming_response type matches at runtime
         else:
-            return AsyncSAPStreamIterator(response=streaming_response)  # pyright: ignore[reportArgumentType]
+            return AsyncSAPStreamIterator(response=streaming_response)  # pyright: ignore[reportArgumentType]  # streaming_response type matches at runtime

--- a/litellm/llms/sap/chat/transformation.py
+++ b/litellm/llms/sap/chat/transformation.py
@@ -448,6 +448,6 @@ class GenAIHubOrchestrationConfig(OpenAIGPTConfig):
         json_mode: bool | None = False,
     ):
         if sync_stream:
-            return SAPStreamIterator(response=streaming_response) # pyright: ignore[reportArgumentType]
+            return SAPStreamIterator(response=streaming_response)  # pyright: ignore[reportArgumentType]
         else:
-            return AsyncSAPStreamIterator(response=streaming_response) # pyright: ignore[reportArgumentType]
+            return AsyncSAPStreamIterator(response=streaming_response)  # pyright: ignore[reportArgumentType]

--- a/tests/test_litellm/llms/sap/chat/test_sap_models.py
+++ b/tests/test_litellm/llms/sap/chat/test_sap_models.py
@@ -1,0 +1,221 @@
+import pytest
+from pydantic import ValidationError
+
+from litellm.llms.sap.chat.models import (
+    SAPAssistantMessage,
+    SAPMessage,
+    SAPToolChatMessage,
+    SAPUserMessage,
+    TextContent,
+)
+
+
+class TestSAPMessage:
+    def test_role_system(self):
+        msg = SAPMessage(role="system", content="Hi")
+        assert msg.role == "system"
+
+    def test_role_developer(self):
+        msg = SAPMessage(role="developer", content="Hi")
+        assert msg.role == "developer"
+
+    def test_role_defaults_to_system(self):
+        msg = SAPMessage(content="Hi")
+        assert msg.role == "system"
+
+    def test_invalid_role_rejected(self):
+        with pytest.raises(ValidationError):
+            SAPMessage(role="user", content="Hi")
+
+    def test_missing_content_rejected(self):
+        with pytest.raises(ValidationError):
+            SAPMessage(role="system")
+
+    def test_string_content_accepted(self):
+        msg = SAPMessage(role="system", content="Hello")
+        assert msg.content == "Hello"
+
+    def test_text_content_block_accepted(self):
+        msg = SAPMessage(role="system", content={"type": "text", "text": "Hello"})
+        assert isinstance(msg.content, TextContent)
+        assert msg.content.text == "Hello"
+
+    def test_list_of_text_content_blocks_accepted(self):
+        msg = SAPMessage(
+            role="system",
+            content=[{"type": "text", "text": "A"}, {"type": "text", "text": "B"}],
+        )
+        assert isinstance(msg.content, list)
+        assert len(msg.content) == 2
+        assert isinstance(msg.content[0], TextContent)
+
+    def test_invalid_content_type_rejected(self):
+        with pytest.raises(ValidationError):
+            SAPMessage(role="system", content=123)
+
+    def test_cache_control_on_content_block(self):
+        msg = SAPMessage(
+            role="system",
+            content={"type": "text", "text": "Hi", "cache_control": {"type": "ephemeral"}},
+        )
+        assert isinstance(msg.content, TextContent)
+        assert msg.content.cache_control is not None
+        assert msg.content.cache_control.type == "ephemeral"
+
+
+class TestSAPUserMessage:
+    def test_role_is_always_user(self):
+        msg = SAPUserMessage(content="Hi")
+        assert msg.role == "user"
+
+    def test_invalid_role_rejected(self):
+        with pytest.raises(ValidationError):
+            SAPUserMessage(role="system", content="Hi")
+
+    def test_missing_content_rejected(self):
+        with pytest.raises(ValidationError):
+            SAPUserMessage()
+
+    def test_string_content_accepted(self):
+        msg = SAPUserMessage(content="Hello")
+        assert msg.content == "Hello"
+
+    def test_text_content_block_accepted(self):
+        msg = SAPUserMessage(content={"type": "text", "text": "Hello"})
+        assert isinstance(msg.content, TextContent)
+
+    def test_image_content_accepted(self):
+        from litellm.llms.sap.chat.models import ImageContent
+
+        msg = SAPUserMessage(
+            content={"type": "image_url", "image_url": {"url": "https://example.com/img.png"}}
+        )
+        assert isinstance(msg.content, ImageContent)
+
+    def test_mixed_list_of_text_and_image_accepted(self):
+        msg = SAPUserMessage(
+            content=[
+                {"type": "text", "text": "Look at this:"},
+                {"type": "image_url", "image_url": {"url": "https://example.com/img.png"}},
+            ]
+        )
+        assert isinstance(msg.content, list)
+        assert len(msg.content) == 2
+
+    def test_invalid_content_type_rejected(self):
+        with pytest.raises(ValidationError):
+            SAPUserMessage(content=123)
+
+    def test_cache_control_on_content_block(self):
+        msg = SAPUserMessage(
+            content={"type": "text", "text": "Hi", "cache_control": {"type": "ephemeral"}},
+        )
+        assert isinstance(msg.content, TextContent)
+        assert msg.content.cache_control is not None
+        assert msg.content.cache_control.type == "ephemeral"
+
+
+class TestSAPAssistantMessage:
+    def test_role_is_always_assistant(self):
+        msg = SAPAssistantMessage(content="Hi")
+        assert msg.role == "assistant"
+
+    def test_invalid_role_rejected(self):
+        with pytest.raises(ValidationError):
+            SAPAssistantMessage(role="user", content="Hi")
+
+    def test_refusal_defaults_to_empty_string(self):
+        msg = SAPAssistantMessage()
+        assert msg.refusal == ""
+
+    def test_refusal_accepted(self):
+        msg = SAPAssistantMessage(refusal="I cannot help with that.")
+        assert msg.refusal == "I cannot help with that."
+
+    def test_tool_calls_default_to_empty_list(self):
+        msg = SAPAssistantMessage()
+        assert msg.tool_calls == []
+
+    def test_string_content_accepted(self):
+        msg = SAPAssistantMessage(content="Hello")
+        assert msg.content == "Hello"
+
+    def test_default_empty_string(self):
+        msg = SAPAssistantMessage()
+        assert msg.content == ""
+
+    def test_text_content_block_accepted(self):
+        msg = SAPAssistantMessage(content={"type": "text", "text": "Hello"})
+        assert isinstance(msg.content, TextContent)
+
+    def test_list_of_text_blocks_accepted(self):
+        msg = SAPAssistantMessage(
+            content=[{"type": "text", "text": "A"}, {"type": "text", "text": "B"}]
+        )
+        assert isinstance(msg.content, list)
+        assert len(msg.content) == 2
+
+    def test_invalid_content_type_rejected(self):
+        with pytest.raises(ValidationError):
+            SAPAssistantMessage(content={"type": "image_url", "image_url": {"url": "x"}})
+
+    def test_cache_control_on_content_block(self):
+        msg = SAPAssistantMessage(
+            content={"type": "text", "text": "Hi", "cache_control": {"type": "ephemeral"}},
+        )
+        assert isinstance(msg.content, TextContent)
+        assert msg.content.cache_control is not None
+        assert msg.content.cache_control.type == "ephemeral"
+
+
+class TestSAPToolChatMessage:
+    def test_role_is_always_tool(self):
+        msg = SAPToolChatMessage(tool_call_id="call_1", content="ok")
+        assert msg.role == "tool"
+
+    def test_invalid_role_rejected(self):
+        with pytest.raises(ValidationError):
+            SAPToolChatMessage(role="user", tool_call_id="call_1", content="ok")
+
+    def test_tool_call_id_accepted(self):
+        msg = SAPToolChatMessage(tool_call_id="call_abc123", content="result")
+        assert msg.tool_call_id == "call_abc123"
+
+    def test_missing_tool_call_id_rejected(self):
+        with pytest.raises(ValidationError):
+            SAPToolChatMessage(content="result")
+
+    def test_string_content_accepted(self):
+        msg = SAPToolChatMessage(tool_call_id="call_1", content="result")
+        assert msg.content == "result"
+
+    def test_text_content_block_accepted(self):
+        msg = SAPToolChatMessage(
+            tool_call_id="call_1", content={"type": "text", "text": "result"}
+        )
+        assert isinstance(msg.content, TextContent)
+
+    def test_list_of_text_blocks_accepted(self):
+        msg = SAPToolChatMessage(
+            tool_call_id="call_1",
+            content=[{"type": "text", "text": "A"}, {"type": "text", "text": "B"}],
+        )
+        assert isinstance(msg.content, list)
+        assert len(msg.content) == 2
+
+    def test_missing_content_rejected(self):
+        with pytest.raises(ValidationError):
+            SAPToolChatMessage(tool_call_id="call_1")
+
+    def test_invalid_content_type_rejected(self):
+        with pytest.raises(ValidationError):
+            SAPToolChatMessage(tool_call_id="call_1", content=99)
+
+    def test_cache_control_on_content_block(self):
+        msg = SAPToolChatMessage(
+            tool_call_id="call_1",
+            content={"type": "text", "text": "result", "cache_control": {"type": "ephemeral"}},
+        )
+        assert isinstance(msg.content, TextContent)
+        assert msg.content.cache_control is not None
+        assert msg.content.cache_control.type == "ephemeral"

--- a/tests/test_litellm/llms/sap/chat/test_sap_models.py
+++ b/tests/test_litellm/llms/sap/chat/test_sap_models.py
@@ -12,52 +12,52 @@ from litellm.llms.sap.chat.models import (
 
 class TestSAPMessage:
     def test_role_system(self):
-        msg = SAPMessage(role="system", content="Hi")
+        msg = SAPMessage.model_validate({"role": "system", "content": "Hi"})
         assert msg.role == "system"
 
     def test_role_developer(self):
-        msg = SAPMessage(role="developer", content="Hi")
+        msg = SAPMessage.model_validate({"role": "developer", "content": "Hi"})
         assert msg.role == "developer"
 
     def test_role_defaults_to_system(self):
-        msg = SAPMessage(content="Hi")
+        msg = SAPMessage.model_validate({"content": "Hi"})
         assert msg.role == "system"
 
     def test_invalid_role_rejected(self):
         with pytest.raises(ValidationError):
-            SAPMessage(role="user", content="Hi")
+            SAPMessage.model_validate({"role": "user", "content": "Hi"})
 
     def test_missing_content_rejected(self):
         with pytest.raises(ValidationError):
-            SAPMessage(role="system")
+            SAPMessage.model_validate({"role": "system"})
 
     def test_string_content_accepted(self):
-        msg = SAPMessage(role="system", content="Hello")
+        msg = SAPMessage.model_validate({"role": "system", "content": "Hello"})
         assert msg.content == "Hello"
 
     def test_text_content_block_accepted(self):
-        msg = SAPMessage(role="system", content={"type": "text", "text": "Hello"})
+        msg = SAPMessage.model_validate({"role": "system", "content": {"type": "text", "text": "Hello"}})
         assert isinstance(msg.content, TextContent)
         assert msg.content.text == "Hello"
 
     def test_list_of_text_content_blocks_accepted(self):
-        msg = SAPMessage(
-            role="system",
-            content=[{"type": "text", "text": "A"}, {"type": "text", "text": "B"}],
-        )
+        msg = SAPMessage.model_validate({
+            "role": "system",
+            "content": [{"type": "text", "text": "A"}, {"type": "text", "text": "B"}],
+        })
         assert isinstance(msg.content, list)
         assert len(msg.content) == 2
         assert isinstance(msg.content[0], TextContent)
 
     def test_invalid_content_type_rejected(self):
         with pytest.raises(ValidationError):
-            SAPMessage(role="system", content=123)
+            SAPMessage.model_validate({"role": "system", "content": 123})
 
     def test_cache_control_on_content_block(self):
-        msg = SAPMessage(
-            role="system",
-            content={"type": "text", "text": "Hi", "cache_control": {"type": "ephemeral"}},
-        )
+        msg = SAPMessage.model_validate({
+            "role": "system",
+            "content": {"type": "text", "text": "Hi", "cache_control": {"type": "ephemeral"}},
+        })
         assert isinstance(msg.content, TextContent)
         assert msg.content.cache_control is not None
         assert msg.content.cache_control.type == "ephemeral"
@@ -65,51 +65,51 @@ class TestSAPMessage:
 
 class TestSAPUserMessage:
     def test_role_is_always_user(self):
-        msg = SAPUserMessage(content="Hi")
+        msg = SAPUserMessage.model_validate({"content": "Hi"})
         assert msg.role == "user"
 
     def test_invalid_role_rejected(self):
         with pytest.raises(ValidationError):
-            SAPUserMessage(role="system", content="Hi")
+            SAPUserMessage.model_validate({"role": "system", "content": "Hi"})
 
     def test_missing_content_rejected(self):
         with pytest.raises(ValidationError):
-            SAPUserMessage()
+            SAPUserMessage.model_validate({})
 
     def test_string_content_accepted(self):
-        msg = SAPUserMessage(content="Hello")
+        msg = SAPUserMessage.model_validate({"content": "Hello"})
         assert msg.content == "Hello"
 
     def test_text_content_block_accepted(self):
-        msg = SAPUserMessage(content={"type": "text", "text": "Hello"})
+        msg = SAPUserMessage.model_validate({"content": {"type": "text", "text": "Hello"}})
         assert isinstance(msg.content, TextContent)
 
     def test_image_content_accepted(self):
         from litellm.llms.sap.chat.models import ImageContent
 
-        msg = SAPUserMessage(
-            content={"type": "image_url", "image_url": {"url": "https://example.com/img.png"}}
-        )
+        msg = SAPUserMessage.model_validate({
+            "content": {"type": "image_url", "image_url": {"url": "https://example.com/img.png"}}
+        })
         assert isinstance(msg.content, ImageContent)
 
     def test_mixed_list_of_text_and_image_accepted(self):
-        msg = SAPUserMessage(
-            content=[
+        msg = SAPUserMessage.model_validate({
+            "content": [
                 {"type": "text", "text": "Look at this:"},
                 {"type": "image_url", "image_url": {"url": "https://example.com/img.png"}},
             ]
-        )
+        })
         assert isinstance(msg.content, list)
         assert len(msg.content) == 2
 
     def test_invalid_content_type_rejected(self):
         with pytest.raises(ValidationError):
-            SAPUserMessage(content=123)
+            SAPUserMessage.model_validate({"content": 123})
 
     def test_cache_control_on_content_block(self):
-        msg = SAPUserMessage(
-            content={"type": "text", "text": "Hi", "cache_control": {"type": "ephemeral"}},
-        )
+        msg = SAPUserMessage.model_validate({
+            "content": {"type": "text", "text": "Hi", "cache_control": {"type": "ephemeral"}},
+        })
         assert isinstance(msg.content, TextContent)
         assert msg.content.cache_control is not None
         assert msg.content.cache_control.type == "ephemeral"
@@ -117,52 +117,52 @@ class TestSAPUserMessage:
 
 class TestSAPAssistantMessage:
     def test_role_is_always_assistant(self):
-        msg = SAPAssistantMessage(content="Hi")
+        msg = SAPAssistantMessage.model_validate({"content": "Hi"})
         assert msg.role == "assistant"
 
     def test_invalid_role_rejected(self):
         with pytest.raises(ValidationError):
-            SAPAssistantMessage(role="user", content="Hi")
+            SAPAssistantMessage.model_validate({"role": "user", "content": "Hi"})
 
     def test_refusal_defaults_to_empty_string(self):
-        msg = SAPAssistantMessage()
+        msg = SAPAssistantMessage.model_validate({})
         assert msg.refusal == ""
 
     def test_refusal_accepted(self):
-        msg = SAPAssistantMessage(refusal="I cannot help with that.")
+        msg = SAPAssistantMessage.model_validate({"refusal": "I cannot help with that."})
         assert msg.refusal == "I cannot help with that."
 
     def test_tool_calls_default_to_empty_list(self):
-        msg = SAPAssistantMessage()
+        msg = SAPAssistantMessage.model_validate({})
         assert msg.tool_calls == []
 
     def test_string_content_accepted(self):
-        msg = SAPAssistantMessage(content="Hello")
+        msg = SAPAssistantMessage.model_validate({"content": "Hello"})
         assert msg.content == "Hello"
 
     def test_default_empty_string(self):
-        msg = SAPAssistantMessage()
+        msg = SAPAssistantMessage.model_validate({})
         assert msg.content == ""
 
     def test_text_content_block_accepted(self):
-        msg = SAPAssistantMessage(content={"type": "text", "text": "Hello"})
+        msg = SAPAssistantMessage.model_validate({"content": {"type": "text", "text": "Hello"}})
         assert isinstance(msg.content, TextContent)
 
     def test_list_of_text_blocks_accepted(self):
-        msg = SAPAssistantMessage(
-            content=[{"type": "text", "text": "A"}, {"type": "text", "text": "B"}]
-        )
+        msg = SAPAssistantMessage.model_validate({
+            "content": [{"type": "text", "text": "A"}, {"type": "text", "text": "B"}]
+        })
         assert isinstance(msg.content, list)
         assert len(msg.content) == 2
 
     def test_invalid_content_type_rejected(self):
         with pytest.raises(ValidationError):
-            SAPAssistantMessage(content={"type": "image_url", "image_url": {"url": "x"}})
+            SAPAssistantMessage.model_validate({"content": {"type": "image_url", "image_url": {"url": "x"}}})
 
     def test_cache_control_on_content_block(self):
-        msg = SAPAssistantMessage(
-            content={"type": "text", "text": "Hi", "cache_control": {"type": "ephemeral"}},
-        )
+        msg = SAPAssistantMessage.model_validate({
+            "content": {"type": "text", "text": "Hi", "cache_control": {"type": "ephemeral"}},
+        })
         assert isinstance(msg.content, TextContent)
         assert msg.content.cache_control is not None
         assert msg.content.cache_control.type == "ephemeral"
@@ -170,52 +170,52 @@ class TestSAPAssistantMessage:
 
 class TestSAPToolChatMessage:
     def test_role_is_always_tool(self):
-        msg = SAPToolChatMessage(tool_call_id="call_1", content="ok")
+        msg = SAPToolChatMessage.model_validate({"tool_call_id": "call_1", "content": "ok"})
         assert msg.role == "tool"
 
     def test_invalid_role_rejected(self):
         with pytest.raises(ValidationError):
-            SAPToolChatMessage(role="user", tool_call_id="call_1", content="ok")
+            SAPToolChatMessage.model_validate({"role": "user", "tool_call_id": "call_1", "content": "ok"})
 
     def test_tool_call_id_accepted(self):
-        msg = SAPToolChatMessage(tool_call_id="call_abc123", content="result")
+        msg = SAPToolChatMessage.model_validate({"tool_call_id": "call_abc123", "content": "result"})
         assert msg.tool_call_id == "call_abc123"
 
     def test_missing_tool_call_id_rejected(self):
         with pytest.raises(ValidationError):
-            SAPToolChatMessage(content="result")
+            SAPToolChatMessage.model_validate({"content": "result"})
 
     def test_string_content_accepted(self):
-        msg = SAPToolChatMessage(tool_call_id="call_1", content="result")
+        msg = SAPToolChatMessage.model_validate({"tool_call_id": "call_1", "content": "result"})
         assert msg.content == "result"
 
     def test_text_content_block_accepted(self):
-        msg = SAPToolChatMessage(
-            tool_call_id="call_1", content={"type": "text", "text": "result"}
-        )
+        msg = SAPToolChatMessage.model_validate({
+            "tool_call_id": "call_1", "content": {"type": "text", "text": "result"}
+        })
         assert isinstance(msg.content, TextContent)
 
     def test_list_of_text_blocks_accepted(self):
-        msg = SAPToolChatMessage(
-            tool_call_id="call_1",
-            content=[{"type": "text", "text": "A"}, {"type": "text", "text": "B"}],
-        )
+        msg = SAPToolChatMessage.model_validate({
+            "tool_call_id": "call_1",
+            "content": [{"type": "text", "text": "A"}, {"type": "text", "text": "B"}],
+        })
         assert isinstance(msg.content, list)
         assert len(msg.content) == 2
 
     def test_missing_content_rejected(self):
         with pytest.raises(ValidationError):
-            SAPToolChatMessage(tool_call_id="call_1")
+            SAPToolChatMessage.model_validate({"tool_call_id": "call_1"})
 
     def test_invalid_content_type_rejected(self):
         with pytest.raises(ValidationError):
-            SAPToolChatMessage(tool_call_id="call_1", content=99)
+            SAPToolChatMessage.model_validate({"tool_call_id": "call_1", "content": 99})
 
     def test_cache_control_on_content_block(self):
-        msg = SAPToolChatMessage(
-            tool_call_id="call_1",
-            content={"type": "text", "text": "result", "cache_control": {"type": "ephemeral"}},
-        )
+        msg = SAPToolChatMessage.model_validate({
+            "tool_call_id": "call_1",
+            "content": {"type": "text", "text": "result", "cache_control": {"type": "ephemeral"}},
+        })
         assert isinstance(msg.content, TextContent)
         assert msg.content.cache_control is not None
         assert msg.content.cache_control.type == "ephemeral"

--- a/tests/test_litellm/llms/sap/chat/test_sap_transformation.py
+++ b/tests/test_litellm/llms/sap/chat/test_sap_transformation.py
@@ -1,4 +1,5 @@
 import warnings
+
 import pytest
 from pydantic import ValidationError
 
@@ -611,31 +612,310 @@ class TestSAPTransformationIntegration:
             assert translation["input"]["config"]["source_language"] == "en-US"
             assert translation["input"]["config"]["target_language"] == "de-DE"
             assert translation["output"]["config"]["target_language"] == "fr-FR"
+            assert config["config"]["modules"][1]["prompt_templating"]["model"]["name"] == "gpt-5"
+            assert config["config"]["modules"][0]["prompt_templating"]["model"]["name"] == "gpt-4o"
+            assert config["config"]["modules"][0]["prompt_templating"]["model"]["params"] == {}
             assert (
-                config["config"]["modules"][1]["prompt_templating"]["model"]["name"]
-                == "gpt-5"
-            )
-            assert (
-                config["config"]["modules"][0]["prompt_templating"]["model"]["name"]
-                == "gpt-4o"
-            )
-            assert (
-                config["config"]["modules"][0]["prompt_templating"]["model"]["params"]
-                == {}
-            )
-            assert (
-                config["config"]["modules"][1]["prompt_templating"]["prompt"][
-                    "template"
-                ][0]["content"]
+                config["config"]["modules"][1]["prompt_templating"]["prompt"]["template"][0]["content"]
                 == "Hello world!"
             )
-            assert (
-                config["config"]["modules"][0]["prompt_templating"]["prompt"][
-                    "template"
-                ][0]["content"]
-                == "Hello."
-            )
-            assert (
-                config["config"]["modules"][1]["translation"]["input"]["type"]
-                == "sap_document_translation"
-            )
+            assert config["config"]["modules"][0]["prompt_templating"]["prompt"]["template"][0]["content"] == "Hello."
+            assert config["config"]["modules"][1]["translation"]["input"]["type"] == "sap_document_translation"
+
+
+class TestCacheControl:
+    """Unit tests for cache_control preservation on message content parts."""
+
+    def _transform(self, model: str, messages: list) -> dict:
+        from litellm.llms.sap.chat.transformation import GenAIHubOrchestrationConfig
+
+        cfg = GenAIHubOrchestrationConfig()
+        return cfg.transform_request(
+            model=model,
+            messages=messages,
+            optional_params={},
+            litellm_params={},
+            headers={},
+        )
+
+    def _template(self, body: dict) -> list:
+        return body["config"]["modules"]["prompt_templating"]["prompt"]["template"]
+
+    def test_cache_control_preserved_on_text_content(self):
+        """cache_control on a TextContent part survives validation and appears in payload."""
+        messages = [
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "text",
+                        "text": "Hello",
+                        "cache_control": {"type": "ephemeral"},
+                    }
+                ],
+            }
+        ]
+        body = self._transform("anthropic--claude-3-5-sonnet", messages)
+        template = self._template(body)
+        content = template[0]["content"]
+        assert isinstance(content, list)
+        assert content[0].get("cache_control") == {"type": "ephemeral"}
+
+    def test_plain_text_content_unaffected(self):
+        """Text content without cache_control still serialises cleanly."""
+        messages = [{"role": "user", "content": "Hello"}]
+        body = self._transform("anthropic--claude-3-5-sonnet", messages)
+        template = self._template(body)
+        assert template[0]["content"] == "Hello"
+
+    def test_cache_control_preserved_on_multiple_parts(self):
+        """cache_control is preserved on each part independently."""
+        messages = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "Part A", "cache_control": {"type": "ephemeral"}},
+                    {"type": "text", "text": "Part B"},
+                ],
+            }
+        ]
+        body = self._transform("anthropic--claude-3-5-sonnet", messages)
+        content = self._template(body)[0]["content"]
+        assert content[0].get("cache_control") == {"type": "ephemeral"}
+        assert "cache_control" not in content[1]
+
+    def test_cache_control_preserved_on_system_message(self):
+        """cache_control on a system message content part reaches the payload."""
+        messages = [
+            {
+                "role": "system",
+                "content": [
+                    {
+                        "type": "text",
+                        "text": "You are a helpful assistant.",
+                        "cache_control": {"type": "ephemeral"},
+                    }
+                ],
+            },
+            {"role": "user", "content": "Hello"},
+        ]
+        body = self._transform("anthropic--claude-3-5-sonnet", messages)
+        template = self._template(body)
+        system_content = template[0]["content"]
+        assert isinstance(system_content, list)
+        assert system_content[0].get("cache_control") == {"type": "ephemeral"}
+
+    def test_system_message_without_cache_control_stays_string(self):
+        """A plain system message is still serialised as a string, not a list."""
+        messages = [
+            {"role": "system", "content": "You are a helpful assistant."},
+            {"role": "user", "content": "Hello"},
+        ]
+        body = self._transform("anthropic--claude-3-5-sonnet", messages)
+        template = self._template(body)
+        assert isinstance(template[0]["content"], str)
+
+    def test_cache_control_preserved_on_tool_definition(self):
+        """cache_control on a tool definition reaches the payload."""
+        tool = {
+            "type": "function",
+            "function": {
+                "name": "get_weather",
+                "description": "Get weather",
+                "parameters": {"type": "object", "properties": {}},
+            },
+            "cache_control": {"type": "ephemeral"},
+        }
+        messages = [{"role": "user", "content": "Hi"}]
+        from litellm.llms.sap.chat.transformation import GenAIHubOrchestrationConfig
+
+        cfg = GenAIHubOrchestrationConfig()
+        body = cfg.transform_request(
+            model="anthropic--claude-3-5-sonnet",
+            messages=messages,
+            optional_params={"tools": [tool]},
+            litellm_params={},
+            headers={},
+        )
+        tools = body["config"]["modules"]["prompt_templating"]["prompt"]["tools"]
+        assert tools[0].get("cache_control") == {"type": "ephemeral"}
+
+    def test_tool_without_cache_control_omits_field(self):
+        """A tool without cache_control does not emit cache_control: null."""
+        tool = {
+            "type": "function",
+            "function": {
+                "name": "get_weather",
+                "description": "Get weather",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        }
+        messages = [{"role": "user", "content": "Hi"}]
+        from litellm.llms.sap.chat.transformation import GenAIHubOrchestrationConfig
+
+        cfg = GenAIHubOrchestrationConfig()
+        body = cfg.transform_request(
+            model="anthropic--claude-3-5-sonnet",
+            messages=messages,
+            optional_params={"tools": [tool]},
+            litellm_params={},
+            headers={},
+        )
+        tools = body["config"]["modules"]["prompt_templating"]["prompt"]["tools"]
+        assert "cache_control" not in tools[0]
+
+    def test_message_level_cache_control_folded_onto_string_content(self):
+        """cache_control on the message dict (string content) is folded into a content block.
+
+        litellm's cache_control_injection_points hook produces this shape for
+        plain-string content.  The marker must not be silently dropped.
+        """
+        messages = [
+            {
+                "role": "system",
+                "content": "You are a helpful assistant.",
+                "cache_control": {"type": "ephemeral"},
+            },
+            {"role": "user", "content": "Hello"},
+        ]
+        body = self._transform("anthropic--claude-3-5-sonnet", messages)
+        template = self._template(body)
+        system_content = template[0]["content"]
+        assert isinstance(system_content, list), "string content should have been promoted to a list"
+        assert system_content[0]["text"] == "You are a helpful assistant."
+        assert system_content[0].get("cache_control") == {"type": "ephemeral"}
+
+    def test_null_cache_control_on_content_block_is_omitted(self):
+        """cache_control: null on a content block must not appear in the payload.
+
+        Sending null reaches AI Core and causes a 400 ('None is not of type object').
+        """
+        messages = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "Hello", "cache_control": None},
+                ],
+            }
+        ]
+        body = self._transform("anthropic--claude-3-5-sonnet", messages)
+        content = self._template(body)[0]["content"]
+        assert isinstance(content, list)
+        assert "cache_control" not in content[0]
+
+    def test_message_level_cache_control_folded_on_user_message(self):
+        """cache_control on the message dict (string user content) is folded into a content block.
+
+        The injection hook can attach cache_control at the message level for any role.
+        User messages must receive the same folding treatment as system messages.
+        """
+        messages = [
+            {
+                "role": "user",
+                "content": "What is the weather today?",
+                "cache_control": {"type": "ephemeral"},
+            }
+        ]
+        body = self._transform("anthropic--claude-3-5-sonnet", messages)
+        content = self._template(body)[0]["content"]
+        assert isinstance(content, list), "string content should have been promoted to a list"
+        assert content[0]["text"] == "What is the weather today?"
+        assert content[0].get("cache_control") == {"type": "ephemeral"}
+
+    def test_cache_control_ttl_omitted_when_absent(self):
+        """cache_control without ttl must not emit ttl: null in the payload."""
+        messages = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "Hello", "cache_control": {"type": "ephemeral"}},
+                ],
+            }
+        ]
+        body = self._transform("anthropic--claude-3-5-sonnet", messages)
+        cc = self._template(body)[0]["content"][0]["cache_control"]
+        assert cc == {"type": "ephemeral"}
+        assert "ttl" not in cc
+
+    def test_cache_control_ttl_preserved_when_set(self):
+        """cache_control with ttl must include ttl in the payload."""
+        messages = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "Hello", "cache_control": {"type": "ephemeral", "ttl": "300"}},
+                ],
+            }
+        ]
+        body = self._transform("anthropic--claude-3-5-sonnet", messages)
+        cc = self._template(body)[0]["content"][0]["cache_control"]
+        assert cc == {"type": "ephemeral", "ttl": "300"}
+
+    def test_message_level_cache_control_folded_on_assistant_message(self):
+        """cache_control on an assistant turn is folded into a content block."""
+        messages = [
+            {"role": "user", "content": "Hi"},
+            {
+                "role": "assistant",
+                "content": "Hello! How can I help?",
+                "cache_control": {"type": "ephemeral"},
+            },
+            {"role": "user", "content": "Continue"},
+        ]
+        body = self._transform("anthropic--claude-3-5-sonnet", messages)
+        template = self._template(body)
+        assistant_content = template[1]["content"]
+        assert isinstance(assistant_content, list), "string content should have been promoted to a list"
+        assert assistant_content[0]["text"] == "Hello! How can I help?"
+        assert assistant_content[0].get("cache_control") == {"type": "ephemeral"}
+
+    def test_message_level_cache_control_folded_on_tool_message(self):
+        """cache_control on a tool result is folded into a content block."""
+        messages = [
+            {"role": "user", "content": "What is the weather?"},
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {"name": "get_weather", "arguments": "{}"},
+                    }
+                ],
+            },
+            {
+                "role": "tool",
+                "tool_call_id": "call_1",
+                "content": "Sunny, 22C",
+                "cache_control": {"type": "ephemeral"},
+            },
+        ]
+        body = self._transform("anthropic--claude-3-5-sonnet", messages)
+        template = self._template(body)
+        tool_content = template[2]["content"]
+        assert isinstance(tool_content, list), "string content should have been promoted to a list"
+        assert tool_content[0]["text"] == "Sunny, 22C"
+        assert tool_content[0].get("cache_control") == {"type": "ephemeral"}
+
+    def test_message_level_cache_control_folded_onto_last_list_element(self):
+        """A top-level cache_control with list content marks the last element.
+
+        Per the Anthropic spec, a message-level marker indicates the cache
+        breakpoint for the whole block.  It must land on the final content
+        part, not be silently dropped.
+        """
+        messages = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "Part A"},
+                    {"type": "text", "text": "Part B"},
+                ],
+                "cache_control": {"type": "ephemeral"},
+            }
+        ]
+        body = self._transform("anthropic--claude-3-5-sonnet", messages)
+        content = self._template(body)[0]["content"]
+        assert "cache_control" not in content[0]
+        assert content[1].get("cache_control") == {"type": "ephemeral"}

--- a/tests/test_litellm/llms/sap/chat/test_sap_transformation.py
+++ b/tests/test_litellm/llms/sap/chat/test_sap_transformation.py
@@ -919,3 +919,25 @@ class TestCacheControl:
         content = self._template(body)[0]["content"]
         assert "cache_control" not in content[0]
         assert content[1].get("cache_control") == {"type": "ephemeral"}
+
+    def test_message_level_cache_control_folded_onto_trailing_image_block(self):
+        """A top-level cache_control with a trailing image part lands on that image.
+
+        The Anthropic spec allows cache_control on any content block including
+        image_url. Previously ImageContent had no cache_control field, so the
+        marker was silently dropped by Pydantic validation.
+        """
+        messages = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "Describe this image."},
+                    {"type": "image_url", "image_url": {"url": "data:image/png;base64,abc="}},
+                ],
+                "cache_control": {"type": "ephemeral"},
+            }
+        ]
+        body = self._transform("anthropic--claude-3-5-sonnet", messages)
+        content = self._template(body)[0]["content"]
+        assert "cache_control" not in content[0]
+        assert content[1].get("cache_control") == {"type": "ephemeral"}


### PR DESCRIPTION
<!-- The whole description's target audience is humans, not AI agents: write it in plain, simple,
     everyday engineering language, extremely parsable and readable at a glance. This goes double for
     the TLDR, User Flow, and Caveats sections -->

## TLDR

<!-- Fill in the bullets below and keep each one short and concrete: one line per bullet, roughly 10 words max -->

Problem this solves:

- SAP provider silently drops `cache_control` on messages and tools
- Message-level `cache_control`  from litellm's injection hook is lost
- `cache_control: null` in the serialized payload causes a 400 from SAP                                                                                                    

How it solves it:
- Adds `CacheControl` and wires it onto `TextContent` and `ChatCompletionTool`
- `_fold_message_cache_control` promotes the marker into the content block
- `_serialize` on `TextContent`/`CacheControl` suppresses `null` fields

## User Flow

Before: a developer using Anthropic models via SAP provider sends a request with `cache_control` on the sys message and gets either a 400 bad req or no cache activity in the response.

1. They send `POST /v1/chat/completions` with a system message whose `content` is a list containing `{"type": "text", "text": "...", "cache_control": {"type": "ephemeral"}}`.
2. The SAP provider serializes the message, drops `cache_control` (no field for it), and forwards the request without it
3. SAP returns 200 but `prompt_tokens_details.cached_tokens` and `cache_write_tokens` are both 0, so no cache activity

After: the same request reaches SAP with `cache_control` intact and cache activity is visible in the response

1. They send the same `POST /v1/chat/completions` with the same `cache_control`-annotated system message
2. The SAP provider folds the marker into the content block and serializes it correctly
3. SAP returns 200 and `prompt_tokens_details.cache_write_tokens > 0` on the first call, `cached_tokens > 0` on the second

## Relevant issues

Fixes #34797

## Linear ticket

<!-- if you are an internal contributor, add "Resolves " followed by the Linear ticket e.g., "Resolves LIT-1234" to link the Linear ticket to the GitHub PR. If you don't have one, leave the section blank rather than guessing -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

<!-- Include screenshots, screen recordings, or command (e.g., curl) + output demonstrating that your changes work as expected
     The proof must be completely e2e with no mocks, using actual LLM calls costing real $$$ if applicable. `pytest` commands are not enough
     Show ONLY the latest run: capture Before at the merge base and After at the PR's current tip, and when new commits change behavior, replace this whole section with the fresh run instead of stacking it on top of older ones. The run must be up to date. As soon as a new commit is made and it makes this PR description's after sha stale (it's no longer tip of PR), you must re-run the QA
     Structure the section exactly as below: Before and After one heading level below this section, each naming the commit hash it was captured at, one lower-level heading per case inside each, the same case names in the same order on both sides, and numbered steps (command, observed output) under every case, never loose prose; shared setup (config, payloads) goes above Before, and with a single case, drop the case headings and number the steps directly

### Before (<hash>)

#### <case 1>

1. ...
2. ...

#### <case 2>

1. ...

### After (<hash>)

#### <case 1>

1. ...
2. ...

#### <case 2>

1. ...

     For bug fixes: Before shows the reproduction, After shows the same steps passing
     For new features: Before shows the capability missing, After shows it working end-to-end
     If the change applies to all three LLM endpoints (/v1/responses, /v1/chat/completions, /v1/messages), make each endpoint its own case, not just one
     For UI changes: before/after screenshots under the same headings -->

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
🐛 Bug Fix
🧹 Refactoring
📖 Documentation
🚄 Infrastructure
✅ Test

## Caveats (if any)

<!-- Group caveats under severity subheadings (### Severe, ### High, ### Medium, ### Low), with
     short bullet points inside each, just like the TLDR: one line per bullet, roughly 10 words max
     Call out known limitations, follow-up work, or anything a reviewer should watch out for
     Include only the tiers that have caveats; drop the empty ones
     - Severe: inherent to what the PR deliberately ships, there even when the code works as intended:
       it can degrade or take down a running deployment (e.g. a slow or table-locking boot migration),
       rewrite data by design, break an existing workflow on purpose, or change auth behavior. An
       operator must plan around it before rollout
     - High: an unintended hole: a correctness, security, data-loss, or backward-compatibility bug,
       unsafe to ship as is
     - Medium: a real gap someone can hit, but with a workaround or a narrow blast radius
     - Low: anything else worth noting: naming, cleanup, an edge case nobody hits
     Nest bullets as deep as helps: hierarchy beats one long line when it makes things clearer to a
     human reader
     Leave this section empty if there are none -->

## QA runbook

<!-- Only needed when your PR edits tests/e2e; delete this section otherwise

For each e2e test you added or changed, list the manual steps a reviewer can follow to reproduce it by hand against a live proxy, mapping 1:1 to what the test asserts: one top-level bullet per test giving its pytest node id followed by what it proves in plain words, then a nested "- [ ]" checklist where each item is a concrete action (route, request body, expected response) and the final item is the sanity-check step shown in the examples. Note environment prerequisites (provider credentials, config flags) and any nuances a manual run will hit. See PRs #32914 and #32963 for full examples

Example checklists:

- tests/e2e/quota_management/ratelimit/test_rate_limit_e2e.py::TestKeyRateLimits::test_rpm_limit_blocks_over_limit - a key allowed 2 requests a minute serves exactly 2 and refuses the 3rd
  - [ ] Generate a limited key: curl -X POST http://localhost:4000/key/generate -H "Authorization: Bearer sk-1234" -d '{"rpm_limit": 2}'
  - [ ] Send three /v1/chat/completions requests with that key inside one minute
  - [ ] Expect the first two to return 200 and the third to return 429 naming the rpm limit
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey (e.g., assert actual expected spend instead of just spend > 0) or potentially flaky

- tests/e2e/management/test_management_e2e.py::TestModelRoutes::test_model_create_appears_in_ui - a deployment created through the API shows up on the Admin UI models page
  - [ ] POST /model/new with the master key, a bedrock model, and aws_region_name (needs STORE_MODEL_IN_DB=True and AWS credentials)
  - [ ] Open http://localhost:4000/ui/?page=models and expect a deployment row showing the returned model id
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey (e.g., assert actual expected spend instead of just spend > 0) or potentially flaky
-->

## Final Attestation

- [ ] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes request serialization for all SAP chat messages (content shape and validators), which could affect callers relying on implicit string normalization, though tests lock in the new cache_control behavior.
> 
> **Overview**
> Fixes SAP GenAI Hub orchestration so **Anthropic-style `cache_control`** on messages and tools is kept in the outbound payload instead of being dropped or sent as `null` (which caused SAP AI Core 400s).
> 
> Adds a **`CacheControl`** model and optional **`cache_control`** on text/image content blocks and tool definitions, with Pydantic serializers that **omit** unset `cache_control` and `ttl`. Message models now accept **structured content** directly; the old `validate_different_content` coercion is removed.
> 
> In **`transformation.py`**, **`_fold_message_cache_control`** moves LiteLLM’s message-level `cache_control` (plain string or list content) onto the right content block before validation. **`_messages_to_sap_template`** runs that fold step for every role.
> 
> New unit tests cover model validation and end-to-end transform behavior for content blocks, tools, TTL, and message-level folding (including trailing image parts).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6ef0eed7c71d5f5ed36e489aa0f6751d584ff312. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->