### PR TITLE
fix(openai): translate anthropic token count requests

### DIFF
--- a/litellm/llms/openai/responses/count_tokens/token_counter.py
+++ b/litellm/llms/openai/responses/count_tokens/token_counter.py
@@ -63,8 +63,8 @@ class OpenAITokenCounter(BaseTokenCounter):
         input_items, instructions = OpenAICountTokensConfig.messages_to_responses_input(messages)
 
         # Use system param if instructions not extracted from messages
-        if instructions is None and system is not None:
-            instructions = system if isinstance(system, str) else str(system)
+        if instructions is None:
+            instructions = OpenAICountTokensConfig.system_to_instructions(system)
 
         # If no input items were produced (e.g., system-only messages), fall back to local counting
         if not input_items:

--- a/litellm/llms/openai/responses/count_tokens/transformation.py
+++ b/litellm/llms/openai/responses/count_tokens/transformation.py
@@ -170,17 +170,18 @@ class OpenAICountTokensConfig:
         Chat format:  {"type": "function", "function": {"name": "...", "parameters": {...}}}
         Responses format: {"type": "function", "name": "...", "parameters": {...}}
         """
-        if any("input_schema" in tool for tool in tools):
-            return LiteLLMAnthropicToResponsesAPIAdapter().translate_tools_to_responses_api(
-                cast(  # cast-ok: input_schema identifies the Anthropic tool surface
-                    list[AllAnthropicToolsValues],
-                    tools,
-                )
-            )
-
         transformed: Final = []
         for tool in tools:
-            if tool.get("type") == "function" and "function" in tool:
+            if "input_schema" in tool:
+                transformed.extend(
+                    LiteLLMAnthropicToResponsesAPIAdapter().translate_tools_to_responses_api(
+                        cast(  # cast-ok: input_schema identifies the Anthropic tool surface
+                            list[AllAnthropicToolsValues],
+                            [tool],  # mutable-ok: adapter accepts batches; one item preserves mixed formats
+                        )
+                    )
+                )
+            elif tool.get("type") == "function" and "function" in tool:
                 func = tool["function"]
                 item: dict[str, Any] = {
                     "type": "function",

--- a/litellm/llms/openai/responses/count_tokens/transformation.py
+++ b/litellm/llms/openai/responses/count_tokens/transformation.py
@@ -5,9 +5,17 @@ This module handles the transformation of requests to OpenAI's /v1/responses/inp
 """
 
 from collections.abc import Mapping, Sequence
-from typing import Any, Final, Literal
+from typing import Any, Final, Literal, cast  # noqa: TID251  # legacy request signatures need shape-specific casts
 
 from typing_extensions import ReadOnly, TypedDict
+
+from litellm.llms.anthropic.experimental_pass_through.responses_adapters.transformation import (
+    LiteLLMAnthropicToResponsesAPIAdapter,
+)
+from litellm.types.llms.anthropic import (
+    AllAnthropicPassThroughMessageValues,
+    AllAnthropicToolsValues,
+)
 
 
 class ResponsesInputTextPart(TypedDict):
@@ -162,6 +170,14 @@ class OpenAICountTokensConfig:
         Chat format:  {"type": "function", "function": {"name": "...", "parameters": {...}}}
         Responses format: {"type": "function", "name": "...", "parameters": {...}}
         """
+        if any("input_schema" in tool for tool in tools):
+            return LiteLLMAnthropicToResponsesAPIAdapter().translate_tools_to_responses_api(
+                cast(  # cast-ok: input_schema identifies the Anthropic tool surface
+                    list[AllAnthropicToolsValues],
+                    tools,
+                )
+            )
+
         transformed: Final = []
         for tool in tools:
             if tool.get("type") == "function" and "function" in tool:
@@ -181,6 +197,30 @@ class OpenAICountTokensConfig:
         return transformed
 
     @staticmethod
+    def system_to_instructions(system: object) -> str | None:
+        if isinstance(system, str):
+            return system
+        if not isinstance(system, list):
+            return None
+        instructions: Final = "\n".join(
+            text
+            for block in system
+            if isinstance(block, Mapping) and block.get("type") == "text" and isinstance(text := block.get("text"), str)
+        )
+        return instructions or None
+
+    @staticmethod
+    def _uses_anthropic_tool_blocks(messages: Sequence[Mapping[str, object]]) -> bool:
+        return any(
+            isinstance(content, list)
+            and any(
+                isinstance(block, Mapping) and block.get("type") in ("tool_use", "tool_result") for block in content
+            )
+            for message in messages
+            if (content := message.get("content")) is not None
+        )
+
+    @staticmethod
     def messages_to_responses_input(
         messages: list[dict[str, Any]],
     ) -> tuple:
@@ -191,6 +231,17 @@ class OpenAICountTokensConfig:
             (input_items, instructions) tuple where instructions is extracted
             from system/developer messages.
         """
+        if OpenAICountTokensConfig._uses_anthropic_tool_blocks(messages):
+            return (
+                LiteLLMAnthropicToResponsesAPIAdapter().translate_messages_to_responses_input(
+                    cast(  # cast-ok: tool blocks identify the Anthropic message surface
+                        list[AllAnthropicPassThroughMessageValues],
+                        messages,
+                    )
+                ),
+                None,
+            )
+
         input_items: Final[list[dict[str, Any]]] = []
         instructions_parts: Final[list[str]] = []
 

--- a/tests/test_litellm/llms/openai/responses/test_openai_count_tokens_transformation.py
+++ b/tests/test_litellm/llms/openai/responses/test_openai_count_tokens_transformation.py
@@ -221,6 +221,35 @@ def test_anthropic_tool_roundtrip_and_schema_use_responses_format():
             "strict": False,
         }
     ]
+    assert OpenAICountTokensConfig._transform_tools_for_responses_api(
+        tools
+        + [
+            {
+                "type": "function",
+                "function": {
+                    "name": "get_forecast",
+                    "description": "Get forecast",
+                    "parameters": {"type": "object"},
+                    "strict": True,
+                },
+            }
+        ]
+    ) == [
+        {
+            "type": "function",
+            "name": "get_weather",
+            "description": "Get weather",
+            "parameters": tools[0]["input_schema"],
+            "strict": False,
+        },
+        {
+            "type": "function",
+            "name": "get_forecast",
+            "description": "Get forecast",
+            "parameters": {"type": "object"},
+            "strict": True,
+        },
+    ]
     assert (
         OpenAICountTokensConfig.system_to_instructions(
             [

--- a/tests/test_litellm/llms/openai/responses/test_openai_count_tokens_transformation.py
+++ b/tests/test_litellm/llms/openai/responses/test_openai_count_tokens_transformation.py
@@ -1,4 +1,3 @@
-
 import pytest
 
 from litellm.llms.openai.responses.count_tokens.transformation import (
@@ -102,9 +101,7 @@ def test_messages_to_responses_input_basic():
         {"role": "user", "content": "How are you?"},
     ]
 
-    input_items, instructions = OpenAICountTokensConfig.messages_to_responses_input(
-        messages
-    )
+    input_items, instructions = OpenAICountTokensConfig.messages_to_responses_input(messages)
 
     assert len(input_items) == 3
     assert input_items[0] == {"role": "user", "content": "Hello"}
@@ -120,9 +117,7 @@ def test_messages_to_responses_input_with_system():
         {"role": "user", "content": "Hello"},
     ]
 
-    input_items, instructions = OpenAICountTokensConfig.messages_to_responses_input(
-        messages
-    )
+    input_items, instructions = OpenAICountTokensConfig.messages_to_responses_input(messages)
 
     assert len(input_items) == 1
     assert input_items[0] == {"role": "user", "content": "Hello"}
@@ -136,9 +131,7 @@ def test_messages_to_responses_input_with_developer():
         {"role": "user", "content": "Hello"},
     ]
 
-    input_items, instructions = OpenAICountTokensConfig.messages_to_responses_input(
-        messages
-    )
+    input_items, instructions = OpenAICountTokensConfig.messages_to_responses_input(messages)
 
     assert len(input_items) == 1
     assert instructions == "Be concise."
@@ -151,9 +144,7 @@ def test_messages_to_responses_input_with_tool():
         {"role": "tool", "content": "72°F", "tool_call_id": "call_123"},
     ]
 
-    input_items, instructions = OpenAICountTokensConfig.messages_to_responses_input(
-        messages
-    )
+    input_items, instructions = OpenAICountTokensConfig.messages_to_responses_input(messages)
 
     assert len(input_items) == 2
     assert input_items[1] == {
@@ -161,6 +152,84 @@ def test_messages_to_responses_input_with_tool():
         "call_id": "call_123",
         "output": "72°F",
     }
+
+
+def test_anthropic_tool_roundtrip_and_schema_use_responses_format():
+    messages = [
+        {"role": "user", "content": [{"type": "text", "text": "Check Chicago."}]},
+        {
+            "role": "assistant",
+            "content": [
+                {
+                    "type": "tool_use",
+                    "id": "call_123",
+                    "name": "get_weather",
+                    "input": {"city": "Chicago"},
+                }
+            ],
+        },
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "tool_result",
+                    "tool_use_id": "call_123",
+                    "content": [{"type": "text", "text": "72°F"}],
+                }
+            ],
+        },
+    ]
+    tools = [
+        {
+            "name": "get_weather",
+            "description": "Get weather",
+            "input_schema": {
+                "type": "object",
+                "properties": {"city": {"type": "string"}},
+                "required": ["city"],
+            },
+        }
+    ]
+
+    input_items, instructions = OpenAICountTokensConfig.messages_to_responses_input(messages)
+
+    assert instructions is None
+    assert input_items == [
+        {
+            "type": "message",
+            "role": "user",
+            "content": [{"type": "input_text", "text": "Check Chicago."}],
+        },
+        {
+            "type": "function_call",
+            "call_id": "call_123",
+            "name": "get_weather",
+            "arguments": '{"city": "Chicago"}',
+        },
+        {
+            "type": "function_call_output",
+            "call_id": "call_123",
+            "output": "72°F",
+        },
+    ]
+    assert OpenAICountTokensConfig._transform_tools_for_responses_api(tools) == [
+        {
+            "type": "function",
+            "name": "get_weather",
+            "description": "Get weather",
+            "parameters": tools[0]["input_schema"],
+            "strict": False,
+        }
+    ]
+    assert (
+        OpenAICountTokensConfig.system_to_instructions(
+            [
+                {"type": "text", "text": "Use tool results."},
+                {"type": "text", "text": "Be concise."},
+            ]
+        )
+        == "Use tool results.\nBe concise."
+    )
 
 
 def test_messages_to_responses_input_preserves_images():
@@ -424,10 +493,7 @@ def test_validate_request_missing_input():
 def test_get_endpoint_default():
     """Test default endpoint URL."""
     config = OpenAICountTokensConfig()
-    assert (
-        config.get_openai_count_tokens_endpoint()
-        == "https://api.openai.com/v1/responses/input_tokens"
-    )
+    assert config.get_openai_count_tokens_endpoint() == "https://api.openai.com/v1/responses/input_tokens"
 
 
 def test_get_endpoint_custom_base():


### PR DESCRIPTION
## Relevant issues

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile Confidence Score of at least 4/5 before requesting a maintainer review

## Screenshots / Proof of Fix

Executed the branch OpenAITokenCounter against POST /responses/input_tokens with gpt-5.6-luna, two system text blocks, an Anthropic tool_use/tool_result round trip, and an input_schema tool. OpenAI returned {"object":"response.input_tokens","input_tokens":84}

## Type

Bug Fix

## Changes

Anthropic count-token requests with tool history were being converted as OpenAI Chat Completion messages, which dropped tool_use and tool_result blocks and left input_schema tools invalid for the Responses input-token endpoint

This change routes Anthropic tool histories and schemas through the existing Anthropic-to-Responses adapter. It also converts list-shaped Anthropic system blocks to newline-joined instructions instead of Python repr strings

Native OpenAI chat messages and tools keep their existing conversion path