### PR TITLE
fix(prometheus): bound requested_model label cardinality on client failure paths

### DIFF
--- a/litellm/integrations/prometheus.py
+++ b/litellm/integrations/prometheus.py
@@ -59,6 +59,8 @@ from litellm.types.utils import (
 if TYPE_CHECKING:
     from apscheduler.schedulers.asyncio import AsyncIOScheduler
     from prometheus_client.metrics import MetricWrapperBase
+
+    from litellm.router import Router
 else:
     AsyncIOScheduler = Any
 
@@ -66,6 +68,8 @@ _BudgetRowT: Final = TypeVar("_BudgetRowT")
 _TableRowT: Final = TypeVar("_TableRowT", bound=BaseModel)
 
 _DEFAULT_BUDGET_METRICS_PER_REQUEST_TIMEOUT: Final = 5.0
+
+UNRECOGNIZED_REQUESTED_MODEL_LABEL: Final = "other"
 
 _NON_ENUM_METRIC_LABELS: Final[frozenset[str]] = frozenset(
     (
@@ -152,6 +156,34 @@ def _get_budget_metrics_per_request_timeout() -> float:
         )
         return _DEFAULT_BUDGET_METRICS_PER_REQUEST_TIMEOUT
     return parsed
+
+
+def _get_proxy_llm_router() -> Router | None:
+    try:
+        from litellm.proxy.proxy_server import llm_router
+    except ImportError:
+        return None
+    return llm_router
+
+
+def _bounded_requested_model_label(requested_model: str | None) -> str | None:
+    """
+    Bound ``requested_model`` label cardinality: names the router recognizes
+    (model names, deployment ids, aliases, routing groups) or matches via a
+    wildcard/pattern route keep their own label value; any other
+    client-supplied string collapses into the single ``other`` bucket. With no
+    router to vouch for the string, it also collapses to ``other``.
+    """
+    if not requested_model:
+        return requested_model
+    llm_router: Final = _get_proxy_llm_router()
+    if llm_router is None:
+        return UNRECOGNIZED_REQUESTED_MODEL_LABEL
+    if llm_router.is_recognized_model(requested_model):
+        return requested_model
+    if llm_router.pattern_router.route(requested_model) is not None:
+        return requested_model
+    return UNRECOGNIZED_REQUESTED_MODEL_LABEL
 
 
 class PrometheusLogger(CustomLogger):
@@ -2407,7 +2439,7 @@ class PrometheusLogger(CustomLogger):
                 team_alias=user_api_key_dict.team_alias,
                 org_id=user_api_key_dict.org_id,
                 org_alias=user_api_key_dict.organization_alias,
-                requested_model=request_data.get("model", ""),
+                requested_model=_bounded_requested_model_label(request_data.get("model", "")),
                 status_code=str(status_code),
                 exception_status=str(status_code),
                 exception_class=self._get_exception_class_name(original_exception),
@@ -2627,7 +2659,7 @@ class PrometheusLogger(CustomLogger):
                 label_model_id = ""
                 label_api_base = ""
                 label_api_provider = ""
-                label_requested_model = litellm_model_name or model_group or ""
+                label_requested_model = _bounded_requested_model_label(litellm_model_name or model_group) or ""
 
             enum_values: Final = UserAPIKeyLabelValues(
                 litellm_model_name=label_litellm_model_name,
@@ -3186,7 +3218,7 @@ class PrometheusLogger(CustomLogger):
         _tags: Final = cast(list[str], kwargs.get("tags") or [])
 
         enum_values: Final = UserAPIKeyLabelValues(
-            requested_model=original_model_group,
+            requested_model=_bounded_requested_model_label(original_model_group),
             fallback_model=_new_model,
             hashed_api_key=standard_metadata["user_api_key_hash"],
             api_key_alias=standard_metadata["user_api_key_alias"],
@@ -3227,7 +3259,7 @@ class PrometheusLogger(CustomLogger):
         )
 
         enum_values: Final = UserAPIKeyLabelValues(
-            requested_model=original_model_group,
+            requested_model=_bounded_requested_model_label(original_model_group),
             fallback_model=_new_model,
             hashed_api_key=standard_metadata["user_api_key_hash"],
             api_key_alias=standard_metadata["user_api_key_alias"],

--- a/litellm/integrations/prometheus.py
+++ b/litellm/integrations/prometheus.py
@@ -169,10 +169,11 @@ def _get_proxy_llm_router() -> Router | None:
 def _bounded_requested_model_label(requested_model: str | None) -> str | None:
     """
     Bound ``requested_model`` label cardinality: names the router recognizes
-    (model names, deployment ids, aliases, routing groups) or matches via a
-    wildcard/pattern route keep their own label value; any other
-    client-supplied string collapses into the single ``other`` bucket. With no
-    router to vouch for the string, it also collapses to ``other``.
+    (model names, deployment ids, aliases, routing groups, team public model
+    names) or matches via a global or team wildcard/pattern route keep their
+    own label value; any other client-supplied string collapses into the
+    single ``other`` bucket. With no router to vouch for the string, it also
+    collapses to ``other``.
     """
     if not requested_model:
         return requested_model
@@ -181,7 +182,14 @@ def _bounded_requested_model_label(requested_model: str | None) -> str | None:
         return UNRECOGNIZED_REQUESTED_MODEL_LABEL
     if llm_router.is_recognized_model(requested_model):
         return requested_model
+    if requested_model in llm_router.team_public_model_names:
+        return requested_model
     if llm_router.pattern_router.route(requested_model) is not None:
+        return requested_model
+    if any(
+        team_pattern_router.route(requested_model) is not None
+        for team_pattern_router in llm_router.team_pattern_routers.values()
+    ):
         return requested_model
     return UNRECOGNIZED_REQUESTED_MODEL_LABEL
 

--- a/litellm/integrations/prometheus.py
+++ b/litellm/integrations/prometheus.py
@@ -161,25 +161,27 @@ def _get_budget_metrics_per_request_timeout() -> float:
 def _get_proxy_llm_router() -> Router | None:
     try:
         from litellm.proxy.proxy_server import llm_router
-    except ImportError:
+    except Exception:
         return None
     return llm_router
 
 
-def _bounded_requested_model_label(requested_model: str | None) -> str | None:
+def _bounded_requested_model_label(requested_model: str | None, router_originated: bool = False) -> str | None:
     """
     Bound ``requested_model`` label cardinality: names the router recognizes
     (model names, deployment ids, aliases, routing groups, team public model
     names) or matches via a global or team wildcard/pattern route keep their
     own label value; any other client-supplied string collapses into the
-    single ``other`` bucket. With no router to vouch for the string, it also
-    collapses to ``other``.
+    single ``other`` bucket. With no proxy router to vouch for the string,
+    client-supplied values collapse to ``other`` while ``router_originated``
+    values (emitted by an SDK ``Router``'s own deployment failure and
+    fallback events, where the proxy router never exists) pass through.
     """
     if not requested_model:
         return requested_model
     llm_router: Final = _get_proxy_llm_router()
     if llm_router is None:
-        return UNRECOGNIZED_REQUESTED_MODEL_LABEL
+        return requested_model if router_originated else UNRECOGNIZED_REQUESTED_MODEL_LABEL
     if llm_router.is_recognized_model(requested_model):
         return requested_model
     if requested_model in llm_router.team_public_model_names:
@@ -2667,7 +2669,9 @@ class PrometheusLogger(CustomLogger):
                 label_model_id = ""
                 label_api_base = ""
                 label_api_provider = ""
-                label_requested_model = _bounded_requested_model_label(litellm_model_name or model_group) or ""
+                label_requested_model = (
+                    _bounded_requested_model_label(litellm_model_name or model_group, router_originated=True) or ""
+                )
 
             enum_values: Final = UserAPIKeyLabelValues(
                 litellm_model_name=label_litellm_model_name,
@@ -3226,7 +3230,7 @@ class PrometheusLogger(CustomLogger):
         _tags: Final = cast(list[str], kwargs.get("tags") or [])
 
         enum_values: Final = UserAPIKeyLabelValues(
-            requested_model=_bounded_requested_model_label(original_model_group),
+            requested_model=_bounded_requested_model_label(original_model_group, router_originated=True),
             fallback_model=_new_model,
             hashed_api_key=standard_metadata["user_api_key_hash"],
             api_key_alias=standard_metadata["user_api_key_alias"],
@@ -3267,7 +3271,7 @@ class PrometheusLogger(CustomLogger):
         )
 
         enum_values: Final = UserAPIKeyLabelValues(
-            requested_model=_bounded_requested_model_label(original_model_group),
+            requested_model=_bounded_requested_model_label(original_model_group, router_originated=True),
             fallback_model=_new_model,
             hashed_api_key=standard_metadata["user_api_key_hash"],
             api_key_alias=standard_metadata["user_api_key_alias"],

--- a/tests/enterprise/litellm_enterprise/enterprise_callbacks/test_prometheus_logging_callbacks.py
+++ b/tests/enterprise/litellm_enterprise/enterprise_callbacks/test_prometheus_logging_callbacks.py
@@ -40,6 +40,24 @@ def prometheus_logger() -> PrometheusLogger:
     return PrometheusLogger()
 
 
+@pytest.fixture
+def known_model_router():
+    router = litellm.Router(
+        model_list=[
+            {
+                "model_name": "gpt-5-mini",
+                "litellm_params": {"model": "openai/gpt-5-mini", "api_key": "fake-key"},
+            },
+            {
+                "model_name": "us/azure/openai/gpt-5-mini",
+                "litellm_params": {"model": "openai/gpt-5-mini", "api_key": "fake-key"},
+            },
+        ]
+    )
+    with patch("litellm.proxy.proxy_server.llm_router", router, create=True):  # test-quality-ok: production reads proxy_server.llm_router lazily, no injection seam
+        yield router
+
+
 def create_standard_logging_payload() -> StandardLoggingPayload:
     return StandardLoggingPayload(
         id="test_id",
@@ -741,7 +759,7 @@ async def test_async_log_failure_event(prometheus_logger):
 
 
 @pytest.mark.asyncio
-async def test_async_log_failure_event_litellm_side_rate_limit(prometheus_logger):
+async def test_async_log_failure_event_litellm_side_rate_limit(prometheus_logger, known_model_router):
     """LiteLLM-side reject (no deployment picked) routes the requested model
     into `requested_model` and skips the partial-outage flag."""
     standard_logging_object = create_standard_logging_payload()
@@ -786,7 +804,7 @@ async def test_async_log_failure_event_litellm_side_rate_limit(prometheus_logger
 
 
 @pytest.mark.asyncio
-async def test_async_post_call_failure_hook(prometheus_logger):
+async def test_async_post_call_failure_hook(prometheus_logger, known_model_router):
     """
     Test for the async_post_call_failure_hook method
 
@@ -1069,7 +1087,7 @@ def test_set_llm_deployment_success_metrics(prometheus_logger):
 
 
 @pytest.mark.asyncio
-async def test_log_success_fallback_event(prometheus_logger):
+async def test_log_success_fallback_event(prometheus_logger, known_model_router):
     prometheus_logger.litellm_deployment_successful_fallbacks = MagicMock()
 
     original_model_group = "gpt-5-mini"
@@ -1107,7 +1125,7 @@ async def test_log_success_fallback_event(prometheus_logger):
 
 
 @pytest.mark.asyncio
-async def test_log_failure_fallback_event(prometheus_logger):
+async def test_log_failure_fallback_event(prometheus_logger, known_model_router):
     prometheus_logger.litellm_deployment_failed_fallbacks = MagicMock()
 
     original_model_group = "gpt-5-mini"

--- a/tests/test_litellm/integrations/test_prometheus_requested_model_cardinality.py
+++ b/tests/test_litellm/integrations/test_prometheus_requested_model_cardinality.py
@@ -1,0 +1,196 @@
+"""
+LIT-6611: every unique client-supplied model name that fails routing used to
+mint permanent Prometheus series carrying ``requested_model="<junk>"`` on the
+proxy request metrics and the deployment metrics, with no eviction. The fix
+collapses any requested model the router does not recognize (and no wildcard
+pattern matches) into the single ``other`` label bucket, while recognized
+names, aliases, and wildcard-matched names keep their own label values.
+"""
+
+from unittest.mock import patch
+
+import pytest
+from prometheus_client import REGISTRY
+
+import litellm
+from litellm.integrations.prometheus import (
+    UNRECOGNIZED_REQUESTED_MODEL_LABEL,
+    PrometheusLogger,
+)
+from litellm.proxy._types import UserAPIKeyAuth
+
+
+class _ClientSideError(Exception):
+    status_code = 400
+
+
+@pytest.fixture(autouse=True)
+def cleanup_prometheus_registry():
+    for collector in list(REGISTRY._collector_to_names.keys()):
+        try:
+            REGISTRY.unregister(collector)
+        except Exception:
+            pass
+
+    yield
+
+    for collector in list(REGISTRY._collector_to_names.keys()):
+        try:
+            REGISTRY.unregister(collector)
+        except Exception:
+            pass
+
+
+@pytest.fixture
+def router():
+    return litellm.Router(
+        model_list=[
+            {
+                "model_name": "gpt-4o-mini",
+                "litellm_params": {"model": "openai/gpt-4o-mini", "api_key": "fake-key"},
+            },
+            {
+                "model_name": "openai/*",
+                "litellm_params": {"model": "openai/*", "api_key": "fake-key"},
+            },
+        ],
+        model_group_alias={"gpt4o-alias": "gpt-4o-mini"},
+    )
+
+
+def _requested_model_values(metric) -> set[str]:
+    index = metric._labelnames.index("requested_model")
+    return {sample_key[index] for sample_key in metric._metrics}
+
+
+def _series_count(metric) -> int:
+    return len(metric._metrics)
+
+
+def _total_value(metric) -> float:
+    return sum(child._value.get() for child in metric._metrics.values())
+
+
+async def _fire_proxy_failure(logger: PrometheusLogger, model: str) -> None:
+    await logger.async_post_call_failure_hook(
+        request_data={"model": model, "metadata": {}, "proxy_server_request": {}},
+        original_exception=_ClientSideError(f"model {model} does not exist"),
+        user_api_key_dict=UserAPIKeyAuth(api_key="hashed-key-1"),
+    )
+
+
+@pytest.mark.asyncio
+async def test_unknown_models_collapse_to_one_series_on_proxy_request_metrics(router):
+    logger = PrometheusLogger()
+
+    with patch("litellm.proxy.proxy_server.llm_router", router, create=True):  # test-quality-ok: production reads proxy_server.llm_router lazily, no injection seam
+        for index in range(25):
+            await _fire_proxy_failure(logger, f"agent-typo-{index}")
+
+    for metric in (
+        logger.litellm_proxy_failed_requests_metric,
+        logger.litellm_proxy_total_requests_metric,
+    ):
+        assert _requested_model_values(metric) == {UNRECOGNIZED_REQUESTED_MODEL_LABEL}
+        assert _series_count(metric) == 1
+        assert _total_value(metric) == 25
+
+
+@pytest.mark.asyncio
+async def test_known_alias_and_wildcard_models_keep_their_own_labels(router):
+    logger = PrometheusLogger()
+
+    with patch("litellm.proxy.proxy_server.llm_router", router, create=True):  # test-quality-ok: production reads proxy_server.llm_router lazily, no injection seam
+        await _fire_proxy_failure(logger, "gpt-4o-mini")
+        await _fire_proxy_failure(logger, "gpt4o-alias")
+        await _fire_proxy_failure(logger, "openai/gpt-4o-audio-preview")
+        await _fire_proxy_failure(logger, "agent-typo-hallucinated")
+
+    for metric in (
+        logger.litellm_proxy_failed_requests_metric,
+        logger.litellm_proxy_total_requests_metric,
+    ):
+        assert _requested_model_values(metric) == {
+            "gpt-4o-mini",
+            "gpt4o-alias",
+            "openai/gpt-4o-audio-preview",
+            UNRECOGNIZED_REQUESTED_MODEL_LABEL,
+        }
+
+
+@pytest.mark.asyncio
+async def test_unknown_models_collapse_to_other_when_router_is_unavailable():
+    logger = PrometheusLogger()
+
+    with patch("litellm.proxy.proxy_server.llm_router", None, create=True):  # test-quality-ok: production reads proxy_server.llm_router lazily, no injection seam
+        await _fire_proxy_failure(logger, "agent-typo-no-router")
+        await _fire_proxy_failure(logger, "gpt-4o-mini")
+
+    assert _requested_model_values(logger.litellm_proxy_failed_requests_metric) == {
+        UNRECOGNIZED_REQUESTED_MODEL_LABEL
+    }
+
+
+def test_unknown_models_collapse_to_one_series_on_deployment_metrics(router):
+    logger = PrometheusLogger()
+
+    with patch("litellm.proxy.proxy_server.llm_router", router, create=True):  # test-quality-ok: production reads proxy_server.llm_router lazily, no injection seam
+        for index in range(25):
+            logger.set_llm_deployment_failure_metrics(
+                request_kwargs={
+                    "model": f"agent-typo-{index}",
+                    "litellm_params": {"metadata": {}},
+                    "standard_logging_object": {},
+                    "exception": _ClientSideError("model does not exist"),
+                }
+            )
+        logger.set_llm_deployment_failure_metrics(
+            request_kwargs={
+                "model": "gpt-4o-mini",
+                "litellm_params": {"metadata": {}},
+                "standard_logging_object": {},
+                "exception": _ClientSideError("all deployments cooling down"),
+            }
+        )
+
+    for metric in (
+        logger.litellm_deployment_failure_responses,
+        logger.litellm_deployment_total_requests,
+    ):
+        assert _requested_model_values(metric) == {
+            UNRECOGNIZED_REQUESTED_MODEL_LABEL,
+            "gpt-4o-mini",
+        }
+        assert _series_count(metric) == 2
+        assert _total_value(metric) == 26
+
+
+@pytest.mark.asyncio
+async def test_fallback_event_requested_model_is_bounded(router):
+    logger = PrometheusLogger()
+    kwargs = {"model": "gpt-4o-mini", "metadata": {}}
+
+    with patch("litellm.proxy.proxy_server.llm_router", router, create=True):  # test-quality-ok: production reads proxy_server.llm_router lazily, no injection seam
+        await logger.log_failure_fallback_event(
+            original_model_group="agent-typo-hallucinated",
+            kwargs=kwargs,
+            original_exception=_ClientSideError("model does not exist"),
+        )
+        await logger.log_success_fallback_event(
+            original_model_group="agent-typo-hallucinated",
+            kwargs=kwargs,
+            original_exception=_ClientSideError("model does not exist"),
+        )
+        await logger.log_failure_fallback_event(
+            original_model_group="gpt-4o-mini",
+            kwargs=kwargs,
+            original_exception=_ClientSideError("upstream unavailable"),
+        )
+
+    assert _requested_model_values(logger.litellm_deployment_failed_fallbacks) == {
+        UNRECOGNIZED_REQUESTED_MODEL_LABEL,
+        "gpt-4o-mini",
+    }
+    assert _requested_model_values(logger.litellm_deployment_successful_fallbacks) == {
+        UNRECOGNIZED_REQUESTED_MODEL_LABEL
+    }

--- a/tests/test_litellm/integrations/test_prometheus_requested_model_cardinality.py
+++ b/tests/test_litellm/integrations/test_prometheus_requested_model_cardinality.py
@@ -58,6 +58,24 @@ def router():
     )
 
 
+@pytest.fixture
+def team_router():
+    return litellm.Router(
+        model_list=[
+            {
+                "model_name": "team-internal-gpt",
+                "litellm_params": {"model": "openai/gpt-4o-mini", "api_key": "fake-key"},
+                "model_info": {"team_id": "team-1", "team_public_model_name": "team-alias-gpt"},
+            },
+            {
+                "model_name": "team-internal-bedrock",
+                "litellm_params": {"model": "openai/*", "api_key": "fake-key"},
+                "model_info": {"team_id": "team-1", "team_public_model_name": "team-models/*"},
+            },
+        ]
+    )
+
+
 def _requested_model_values(metric) -> set[str]:
     index = metric._labelnames.index("requested_model")
     return {sample_key[index] for sample_key in metric._metrics}
@@ -114,6 +132,26 @@ async def test_known_alias_and_wildcard_models_keep_their_own_labels(router):
             "gpt-4o-mini",
             "gpt4o-alias",
             "openai/gpt-4o-audio-preview",
+            UNRECOGNIZED_REQUESTED_MODEL_LABEL,
+        }
+
+
+@pytest.mark.asyncio
+async def test_team_alias_and_team_wildcard_models_keep_their_own_labels(team_router):
+    logger = PrometheusLogger()
+
+    with patch("litellm.proxy.proxy_server.llm_router", team_router, create=True):  # test-quality-ok: production reads proxy_server.llm_router lazily, no injection seam
+        await _fire_proxy_failure(logger, "team-alias-gpt")
+        await _fire_proxy_failure(logger, "team-models/gpt-4o-audio-preview")
+        await _fire_proxy_failure(logger, "agent-typo-hallucinated")
+
+    for metric in (
+        logger.litellm_proxy_failed_requests_metric,
+        logger.litellm_proxy_total_requests_metric,
+    ):
+        assert _requested_model_values(metric) == {
+            "team-alias-gpt",
+            "team-models/gpt-4o-audio-preview",
             UNRECOGNIZED_REQUESTED_MODEL_LABEL,
         }
 

--- a/tests/test_litellm/integrations/test_prometheus_requested_model_cardinality.py
+++ b/tests/test_litellm/integrations/test_prometheus_requested_model_cardinality.py
@@ -7,6 +7,8 @@ pattern matches) into the single ``other`` label bucket, while recognized
 names, aliases, and wildcard-matched names keep their own label values.
 """
 
+import sys
+import types
 from unittest.mock import patch
 
 import pytest
@@ -167,6 +169,49 @@ async def test_unknown_models_collapse_to_other_when_router_is_unavailable():
     assert _requested_model_values(logger.litellm_proxy_failed_requests_metric) == {
         UNRECOGNIZED_REQUESTED_MODEL_LABEL
     }
+
+
+@pytest.mark.asyncio
+async def test_sdk_router_originated_metrics_keep_labels_without_proxy_router():
+    logger = PrometheusLogger()
+
+    with patch("litellm.proxy.proxy_server.llm_router", None, create=True):  # test-quality-ok: production reads proxy_server.llm_router lazily, no injection seam
+        logger.set_llm_deployment_failure_metrics(
+            request_kwargs={
+                "model": "sdk-deployment-group",
+                "litellm_params": {"metadata": {}},
+                "standard_logging_object": {},
+                "exception": _ClientSideError("model does not exist"),
+            }
+        )
+        await logger.log_failure_fallback_event(
+            original_model_group="sdk-fallback-group",
+            kwargs={"model": "sdk-fallback-group", "metadata": {}},
+            original_exception=_ClientSideError("upstream unavailable"),
+        )
+
+    assert _requested_model_values(logger.litellm_deployment_failure_responses) == {"sdk-deployment-group"}
+    assert _requested_model_values(logger.litellm_deployment_failed_fallbacks) == {"sdk-fallback-group"}
+
+
+@pytest.mark.asyncio
+async def test_sdk_fallback_labels_survive_non_import_errors_from_proxy_module(monkeypatch):
+    logger = PrometheusLogger()
+    broken_proxy_module = types.ModuleType("litellm.proxy.proxy_server")
+
+    def _raise_value_error(_name: str):
+        raise ValueError("bad proxy env var")
+
+    broken_proxy_module.__getattr__ = _raise_value_error  # test-quality-ok: reproduces a proxy_server import raising non-ImportError, no injection seam
+    monkeypatch.setitem(sys.modules, "litellm.proxy.proxy_server", broken_proxy_module)  # test-quality-ok: reproduces a proxy_server import raising non-ImportError, no injection seam
+
+    await logger.log_failure_fallback_event(
+        original_model_group="sdk-fallback-group",
+        kwargs={"model": "sdk-fallback-group", "metadata": {}},
+        original_exception=_ClientSideError("upstream unavailable"),
+    )
+
+    assert _requested_model_values(logger.litellm_deployment_failed_fallbacks) == {"sdk-fallback-group"}
 
 
 def test_unknown_models_collapse_to_one_series_on_deployment_metrics(router):


### PR DESCRIPTION
## TLDR

Problem this solves:

- Every unique junk model name a client sends mints permanent Prometheus series
- `requested_model` label cardinality grows unbounded, leaking memory until restart
- Agents sending typo'd or hallucinated model names make `/metrics` huge

How it solves it:

- Failure paths now validate the client model string against the router
- Known names, aliases, team model names, and wildcard-matched names keep their own label
- Everything else collapses into one `requested_model="other"` series
- SDK `Router` deployment failure and fallback events, where no proxy router exists to vouch for names the router itself emitted, keep their labels

## User Flow

Before: an operator whose agents send typo'd model names watches proxy memory and `/metrics` grow without bound

1. An agent sends POST https://litellm-domain/v1/chat/completions with `"model": "gpt-4o-mimi"` (a typo) and gets a 400 back
2. The operator runs `curl -s https://litellm-domain/metrics | grep -o 'requested_model="[^"]*"' | sort -u | wc -l` and the count went up by one
3. Each new typo'd name repeats this: after a week of agent traffic the count is in the tens of thousands, every scrape ships megabytes, and pod memory climbs until a restart
4. A request with a real model name, POST https://litellm-domain/v1/chat/completions with `"model": "gpt-4o-mini"`, still shows up as `requested_model="gpt-4o-mini"`

After: the same junk traffic folds into a single label value and the count stays flat

1. An agent sends POST https://litellm-domain/v1/chat/completions with `"model": "gpt-4o-mimi"` (a typo) and gets a 400 back
2. The operator runs the same `grep | sort -u | wc -l` and the count did not move: the failure was recorded under `requested_model="other"`
3. Ten thousand more unique junk names later, the count is still the same, `/metrics` stays small, and memory stays flat
4. A request with a real model name, POST https://litellm-domain/v1/chat/completions with `"model": "gpt-4o-mini"`, still shows up as `requested_model="gpt-4o-mini"`, and wildcard traffic like `"model": "openai/gpt-4o-audio-preview"` under an `openai/*` route keeps its own label too
5. Team-scoped names behave the same: a request against a team model alias or a team wildcard match keeps its own `requested_model` label

## Relevant issues

## Linear ticket

Resolves LIT-6611

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Both legs ran against a live proxy with `--num_workers 2` (two uvicorn workers confirmed via startup logs and per-pid multiproc db files), a dedicated empty `PROMETHEUS_MULTIPROC_DIR`, and this config:

```yaml
model_list:
  - model_name: gpt-4o-mini
    litellm_params:
      model: openai/gpt-4o-mini
      api_key: os.environ/OPENAI_API_KEY
  - model_name: openai/*
    litellm_params:
      model: openai/*
      api_key: os.environ/OPENAI_API_KEY

litellm_settings:
  callbacks: ["prometheus"]
  require_auth_for_metrics_endpoint: false
  prometheus_metrics_config:
    - group: request_tracking
      metrics:
        - litellm_proxy_total_requests_metric
        - litellm_proxy_failed_requests_metric
      include_labels:
        - requested_model
        - end_user
        - hashed_api_key
        - api_key_alias
        - team
        - user
    - group: deployment_health
      metrics:
        - litellm_deployment_total_requests
        - litellm_deployment_success_responses
        - litellm_deployment_failure_responses
      include_labels:
        - requested_model
        - litellm_model_name
        - api_provider
    - group: performance
      metrics:
        - litellm_request_total_latency_metric
        - litellm_llm_api_latency_metric
      include_labels:
        - requested_model
        - model
        - api_provider

general_settings:
  master_key: sk-lit6611-qa-39be45e8cb31cbeef8c90137
```

The traffic mix hits all three unified endpoints with one unique junk name per request (`KEY` below is the throwaway master key above):

```zsh
for n in $(seq 1 50); do curl -s -o /dev/null -w '%{http_code}\n' http://localhost:PORT/v1/chat/completions -H "Authorization: Bearer $KEY" -H 'Content-Type: application/json' -d "{\"model\":\"junk-${n}\",\"messages\":[{\"role\":\"user\",\"content\":\"hi\"}]}"; done
for n in $(seq 51 100); do curl -s -o /dev/null -w '%{http_code}\n' http://localhost:PORT/v1/responses -H "Authorization: Bearer $KEY" -H 'Content-Type: application/json' -d "{\"model\":\"junk-${n}\",\"input\":\"hi\"}"; done
for n in $(seq 101 150); do curl -s -o /dev/null -w '%{http_code}\n' http://localhost:PORT/v1/messages -H "Authorization: Bearer $KEY" -H 'Content-Type: application/json' -d "{\"model\":\"junk-${n}\",\"max_tokens\":16,\"messages\":[{\"role\":\"user\",\"content\":\"hi\"}]}"; done
```

Each checkpoint below is 10 consecutive `curl -sL http://localhost:PORT/metrics` scrapes, counting `grep -o 'requested_model="[^"]*"' | sort -u | wc -l` per scrape; min and max across the 10 were identical at every checkpoint in both legs

### Before (4db165379ab1614c2ced0b09dad33c9e65560874)

| Checkpoint | Traffic | Unique labels | HTTP codes |
| --- | --- | --- | --- |
| 0 | 1 valid gpt-4o-mini call | 1 | 1x 200 |
| 1 | 150 unique junk names | 151 | 150x 400 |
| 2 | 150 more junk + 2 valid | 302 | 150x 400, 2x 200 |
| 3 | 50 reuses of one junk name | 302 | 50x 400 |

- Every junk name is a permanent series on all 4 requested_model-labeled counter families (1200 series lines at checkpoint 3), and counts never shrank across any of the 40 scrapes
- Reuse increments instead of minting: `junk-1` on `litellm_proxy_failed_requests_metric_total` went 1.0 to 51.0
- Valid names label as themselves: `requested_model="gpt-4o-mini"` and `requested_model="openai/gpt-4o-mini-2024-07-18"` via the wildcard route

### After (2adae6b4757aaaa9677785195ed68c8996a5d915)

Success controls first: real completions on `/v1/chat/completions`, `/v1/responses`, and `/v1/messages` with `gpt-4o-mini`, plus `openai/gpt-4o-mini-2024-07-18` through `openai/*`, all 200

| Checkpoint | Traffic | Unique labels | Label value union |
| --- | --- | --- | --- |
| 0 | 4 successes | 2 | gpt-4o-mini, openai/gpt-4o-mini-2024-07-18 |
| 1 | 150 unique junk names | 3 | + other |
| 2 | 150 more unique junk | 3 | same 3 |
| 3 | 50 reuses of one junk name | 3 | same 3 |

- All junk requests still surfaced as 4xx model-not-found to the client; no 200s, no 5xx
- `grep -c qa-typo` (the junk name prefix) on every saved snapshot: 0, 0, 0, 0; the raw names never reach /metrics
- The `other` series absorbs everything: all four counter families read 150.0 at checkpoint 1, 300.0 at checkpoint 2, 350.0 at checkpoint 3, matching the junk request counts exactly
- Known-name labeling unchanged: `litellm_deployment_success_responses_total{api_provider="openai",litellm_model_name="gpt-4o-mini",requested_model="gpt-4o-mini"} 3.0` and the wildcard-routed name keeps its full client-sent value
- Scrape payload froze at 14632 bytes from checkpoint 1 on; the before leg's kept growing with every new name

Surprises:

- deployment_health metrics also mint per-name series, doubling the cost
- Concurrent proxies share the auto-created multiproc dir; legs isolated
- Identical after-leg numbers at all three tips reached mid-run

## Type

🐛 Bug Fix

## Caveats (if any)

### Low

- Fallback metrics' `requested_model` is bounded the same way; junk groups read `other`
- `litellm_llm_api_failed_requests_metric`'s `model` label still carries raw strings; left for the generalized series cap
- Strings matching a configured wildcard (any team's included) keep their raw label, so suffix cardinality under wildcards is also left for the generalized cap
- Dashboards keyed on exact junk names (unlikely) now see `other`
- A configured model literally named `other` would share its label value with the bucket

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

- [x] 2adae6b4757aaaa9677785195ed68c8996a5d915 passes /live-pr-risk
