### PR TITLE
fix(ui): honor model view scope

### DIFF
--- a/ui/litellm-dashboard/src/app/(dashboard)/models-and-endpoints/components/AllModelsTab.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/models-and-endpoints/components/AllModelsTab.test.tsx
@@ -231,16 +231,21 @@ describe("AllModelsTab", () => {
 
   it("removes the team filter while viewing all available models", async () => {
     const user = userEvent.setup();
+    setModelsInfo([makeRow()], 137);
     render(<AllModelsTab {...defaultProps} />);
 
     await user.click(screen.getByTestId("models-team-select"));
     await user.click(await screen.findByRole("option", { name: "Engineering" }));
     await waitFor(() => expect(lastModelsInfoCall().teamId).toBe("team-1"));
 
+    await user.click(screen.getByTestId("pagination-next"));
+    await waitFor(() => expect(lastModelsInfoCall().page).toBe(2));
+
     await user.click(screen.getByTestId("models-view-select"));
     await user.click(await screen.findByRole("option", { name: "All Available Models" }));
 
-    await waitFor(() => expect(lastModelsInfoCall().teamId).toBeUndefined());
+    await waitFor(() => expect(lastModelsInfoCall().page).toBe(1));
+    expect(lastModelsInfoCall().teamId).toBeUndefined();
 
     await user.click(screen.getByTestId("models-view-select"));
     await user.click(await screen.findByRole("option", { name: "Current Team Models" }));

--- a/ui/litellm-dashboard/src/app/(dashboard)/models-and-endpoints/components/AllModelsTab.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/models-and-endpoints/components/AllModelsTab.test.tsx
@@ -229,6 +229,25 @@ describe("AllModelsTab", () => {
     expect(lastModelsInfoCall().page).toBe(1);
   });
 
+  it("removes the team filter while viewing all available models", async () => {
+    const user = userEvent.setup();
+    render(<AllModelsTab {...defaultProps} />);
+
+    await user.click(screen.getByTestId("models-team-select"));
+    await user.click(await screen.findByRole("option", { name: "Engineering" }));
+    await waitFor(() => expect(lastModelsInfoCall().teamId).toBe("team-1"));
+
+    await user.click(screen.getByTestId("models-view-select"));
+    await user.click(await screen.findByRole("option", { name: "All Available Models" }));
+
+    await waitFor(() => expect(lastModelsInfoCall().teamId).toBeUndefined());
+
+    await user.click(screen.getByTestId("models-view-select"));
+    await user.click(await screen.findByRole("option", { name: "Current Team Models" }));
+
+    await waitFor(() => expect(lastModelsInfoCall().teamId).toBe("team-1"));
+  });
+
   it("debounces the model name search into the server query", async () => {
     const user = userEvent.setup();
     render(<AllModelsTab {...defaultProps} />);

--- a/ui/litellm-dashboard/src/app/(dashboard)/models-and-endpoints/components/AllModelsTab.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/models-and-endpoints/components/AllModelsTab.test.tsx
@@ -1,5 +1,5 @@
 import * as useAuthorizedModule from "@/app/(dashboard)/hooks/useAuthorized";
-import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import { configure, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -96,6 +96,11 @@ const setModelsInfo = (rows: Record<string, unknown>[], totalCount = rows.length
 };
 
 const lastModelsInfoCall = (): ModelsInfoArgs => modelsInfoCalls[modelsInfoCalls.length - 1];
+
+// Each interaction here waits on a debounced refetch, so the 1s default that
+// @testing-library/react gives waitFor/findBy* leaves no headroom on a loaded
+// CI runner. The same assertions take ~2.5s locally.
+configure({ asyncUtilTimeout: 10_000 });
 
 const SEARCH_SETTLE_MS = 400;
 

--- a/ui/litellm-dashboard/src/app/(dashboard)/models-and-endpoints/components/AllModelsTab.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/models-and-endpoints/components/AllModelsTab.tsx
@@ -80,7 +80,8 @@ const AllModelsTab = ({
     debouncedUpdateSearch(modelNameSearch);
   }, [modelNameSearch, debouncedUpdateSearch]);
 
-  const teamIdForQuery = selectedTeamValue === PERSONAL_TEAM_VALUE ? undefined : selectedTeamValue;
+  const teamIdForQuery =
+    modelViewMode === "current_team" && selectedTeamValue !== PERSONAL_TEAM_VALUE ? selectedTeamValue : undefined;
   const isConcreteModelGroup =
     Boolean(selectedModelGroup) &&
     selectedModelGroup !== ALL_MODEL_GROUPS_VALUE &&

--- a/ui/litellm-dashboard/src/app/(dashboard)/models-and-endpoints/components/AllModelsTab.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/models-and-endpoints/components/AllModelsTab.tsx
@@ -186,6 +186,11 @@ const AllModelsTab = ({
     resetToFirstPage();
   };
 
+  const handleViewModeChange = (nextViewMode: ModelViewMode) => {
+    setModelViewMode(nextViewMode);
+    resetToFirstPage();
+  };
+
   const resetFilters = () => {
     setModelNameSearch("");
     setSelectedModelGroup(ALL_MODEL_GROUPS_VALUE);
@@ -290,7 +295,7 @@ const AllModelsTab = ({
           onTeamChange={handleTeamChange}
           isLoadingTeams={isLoadingTeams}
           viewMode={modelViewMode}
-          onViewModeChange={setModelViewMode}
+          onViewModeChange={handleViewModeChange}
           onOpenModelSettings={handleOpenModelSettings}
           availableModelGroups={availableModelGroups}
           availableModelAccessGroups={availableModelAccessGroups}


### PR DESCRIPTION
## TLDR

Problem this solves:

- All Available Models still used the selected team filter
- Scope changes retained pagination from the previous dataset
- The current UI lint budget exceeded its `prefer-screen-queries` limit

How it solves it:

- Omit teamId when viewing all available models
- Reset pagination whenever the view scope changes
- Restore the selected team scope when switching back
- Replace render-result queries in the models page tests with `screen` queries

## User Flow

Before: an admin cannot reliably leave the selected team's model scope

1. They open https://litellm-domain/ui/models-and-endpoints
2. They select Team "Engineering" and go to page 2
3. They select View "All Available Models"
4. The model request still includes `teamId=team-1` and `page=2`
5. The table remains team-scoped or appears empty

After: the same view switch loads all available models from the first page

1. They open https://litellm-domain/ui/models-and-endpoints
2. They select Team "Engineering" and go to page 2
3. They select View "All Available Models"
4. The model request omits `teamId` and uses `page=1`
5. The table shows all available models
6. Switching back restores `teamId=team-1` from page 1

## Relevant issues

Discovered through a static query-state audit and the PR lint check

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The focused component test files pass locally
- [x] The complete UI lint budget check passes locally
- [ ] My PR passes all required CI/CD checks
- [x] My PR's changes are limited to the models-and-endpoints UI
- [x] I have received a Greptile Confidence Score of at least 4/5 on the latest head

## Screenshots / Proof of Fix

### Before (bad55da9bf)

1. Select Engineering in the team control and advance to page 2
2. Select All Available Models in the view control
3. The interaction regression receives `teamId: "team-1"` and `page: 2`
4. The new test fails because the expected unscoped first-page query never occurs
5. UI Lint reports `testing-library/prefer-screen-queries: 21 | max: 18`

### After (e3ed5fd5c6)

1. Repeat the same team, pagination, and view selections
2. The interaction regression receives `teamId: undefined` and `page: 1`
3. Switch back to Current Team Models
4. The next request receives `teamId: "team-1"` from page 1
5. Both focused component files pass: 40 tests
6. The full lint budget reports `testing-library/prefer-screen-queries: 18 | max: 18`

## Type

Bug Fix

## Caveats (if any)

### CI baseline

- OSV currently flags pypdf 6.15.0 and tornado 6.5.7 from the staging `uv.lock`
- Fork PRs are prohibited from modifying `uv.lock` by the repository dependency guard
- Canonical dependency PR #39188 is tracking the staging security update

## Final Attestation

- [x] The tests cover scope changes from page 2 and the restore path
- [x] The complete lint budget check passes at its configured limits
