### PR TITLE
fix(responses): tool call id shape breaks gpt-5 -> claude fallback conversations

### DIFF
--- a/litellm/litellm_core_utils/prompt_templates/factory.py
+++ b/litellm/litellm_core_utils/prompt_templates/factory.py
@@ -1696,9 +1696,9 @@ def convert_function_to_anthropic_tool_invoke(
 
 def _find_server_tool_result(
     tool_id: str,
-    web_search_results: Sequence[Any] | None,
-    tool_results: Sequence[Any] | None,
-) -> dict[str, Any] | None:
+    web_search_results: Sequence[object] | None,
+    tool_results: Sequence[object] | None,
+) -> dict[str, object] | None:
     candidates: Final = (*(web_search_results or ()), *(tool_results or ()))
     return next(
         (result for result in candidates if isinstance(result, dict) and result.get("tool_use_id") == tool_id),

--- a/litellm/litellm_core_utils/prompt_templates/factory.py
+++ b/litellm/litellm_core_utils/prompt_templates/factory.py
@@ -1694,6 +1694,18 @@ def convert_function_to_anthropic_tool_invoke(
         raise e
 
 
+def _find_server_tool_result(
+    tool_id: str,
+    web_search_results: Sequence[Any] | None,
+    tool_results: Sequence[Any] | None,
+) -> dict[str, Any] | None:
+    candidates: Final = (*(web_search_results or ()), *(tool_results or ()))
+    return next(
+        (result for result in candidates if isinstance(result, dict) and result.get("tool_use_id") == tool_id),
+        None,
+    )
+
+
 def convert_to_anthropic_tool_invoke(
     tool_calls: list[ChatCompletionAssistantToolCall],
     web_search_results: list[Any] | None = None,
@@ -1758,32 +1770,22 @@ def convert_to_anthropic_tool_invoke(
             context="Anthropic tool invoke",
         )
 
-        # Check if this is a server-side tool (web_search, tool_search, etc.)
-        # Server tool IDs start with "srvtoolu_"
-        if tool_id.startswith("srvtoolu_"):
-            # Create server_tool_use block instead of tool_use
-            _anthropic_server_tool_use: dict[str, object] = {
-                "type": "server_tool_use",
-                "id": tool_id,
-                "name": tool_name,
-                "input": tool_input,
-            }
-            anthropic_tool_invoke.append(_anthropic_server_tool_use)
-
-            # Add corresponding tool result if available.
-            # Check both web_search_results (web_search_tool_result / web_fetch_tool_result)
-            # and tool_results (bash_code_execution_tool_result, etc.)
-            _all_tool_results: list[Any] = []
-            if web_search_results:
-                _all_tool_results.extend(web_search_results)
-            if tool_results:
-                _all_tool_results.extend(tool_results)
-            for result in _all_tool_results:
-                if result.get("tool_use_id") == tool_id:
-                    anthropic_tool_invoke.append(result)
-                    break
+        server_tool_result = (
+            _find_server_tool_result(tool_id, web_search_results, tool_results)
+            if tool_id.startswith("srvtoolu_")
+            else None
+        )
+        if server_tool_result is not None:
+            anthropic_tool_invoke.append(
+                {
+                    "type": "server_tool_use",
+                    "id": tool_id,
+                    "name": tool_name,
+                    "input": tool_input,
+                }
+            )
+            anthropic_tool_invoke.append(server_tool_result)
         else:
-            # Regular tool_use
             sanitized_tool_id = _sanitize_anthropic_tool_use_id(tool_id)
             _anthropic_tool_use_param = AnthropicMessagesToolUseParam(
                 type="tool_use",

--- a/litellm/llms/openai/responses/transformation.py
+++ b/litellm/llms/openai/responses/transformation.py
@@ -14,6 +14,7 @@ from litellm.litellm_core_utils.llm_response_utils.convert_dict_to_response impo
 )
 from litellm.litellm_core_utils.url_utils import encode_url_path_segment
 from litellm.llms.base_llm.responses.transformation import BaseResponsesAPIConfig
+from litellm.responses.litellm_completion_transformation.custom_tools import TOOL_CALL_ITEM_ID_PREFIX_BY_TYPE
 from litellm.secret_managers.main import get_secret_str
 from litellm.types.llms.openai import *
 from litellm.types.responses.main import *
@@ -35,6 +36,7 @@ else:
 _NO_TOOL_UPDATE: Final[Mapping[str, object]] = MappingProxyType({})
 _MODEL_FAMILIES_REJECTING_TOP_LEVEL_SCHEMA_COMBINATORS: Final = ("gpt-4", "gpt-3.5", "chatgpt-4o", "o1", "o3", "o4")
 _PROVIDERS_WITH_COMBINATOR_REJECTING_VALIDATOR: Final = frozenset({LlmProviders.AZURE, LlmProviders.OPENAI})
+_PROVIDERS_VALIDATING_TOOL_CALL_ITEM_IDS: Final = frozenset({LlmProviders.AZURE, LlmProviders.OPENAI})
 
 
 class OpenAIResponsesAPIConfig(BaseResponsesAPIConfig):
@@ -179,8 +181,9 @@ class OpenAIResponsesAPIConfig(BaseResponsesAPIConfig):
         )
         if sanitized_tools is not None:
             response_api_optional_request_params["tools"] = sanitized_tools
+        replay_safe_input: Final = self._drop_foreign_tool_call_item_ids(input)
         final_request_params: Final = dict(
-            ResponsesAPIRequestParams(model=model, input=input, **response_api_optional_request_params)
+            ResponsesAPIRequestParams(model=model, input=replay_safe_input, **response_api_optional_request_params)
         )
 
         return final_request_params
@@ -216,6 +219,23 @@ class OpenAIResponsesAPIConfig(BaseResponsesAPIConfig):
                     filter_value_from_dict(cast(dict, tool), "cache_control")
 
         return input, tools
+
+    def _drop_foreign_tool_call_item_ids(self, input: str | ResponseInputParam) -> str | ResponseInputParam:
+        if self.custom_llm_provider not in _PROVIDERS_VALIDATING_TOOL_CALL_ITEM_IDS or not isinstance(input, list):
+            return input
+        sanitized_items: Final = [self._without_foreign_tool_call_item_id(item) for item in input]
+        return cast("ResponseInputParam", sanitized_items)  # cast-ok: items keep their shape, minus a rejected id
+
+    @staticmethod
+    def _without_foreign_tool_call_item_id(item: object) -> object:
+        if not isinstance(item, dict):
+            return item
+        item_type: Final = item.get("type")
+        item_id: Final = item.get("id")
+        genuine_prefix: Final = TOOL_CALL_ITEM_ID_PREFIX_BY_TYPE.get(item_type) if isinstance(item_type, str) else None
+        if genuine_prefix is None or not isinstance(item_id, str) or item_id.startswith(genuine_prefix):
+            return item
+        return {key: value for key, value in item.items() if key != "id"}  # mutable-ok: outgoing JSON request item
 
     def _flatten_tool_schema_combinators_for_openai(
         self,
@@ -742,7 +762,10 @@ class OpenAIResponsesAPIConfig(BaseResponsesAPIConfig):
         )
         if sanitized_tools is not None:
             response_api_optional_request_params["tools"] = sanitized_tools
-        data: Final = dict(ResponsesAPIRequestParams(model=model, input=input, **response_api_optional_request_params))
+        replay_safe_input: Final = self._drop_foreign_tool_call_item_ids(input)
+        data: Final = dict(
+            ResponsesAPIRequestParams(model=model, input=replay_safe_input, **response_api_optional_request_params)
+        )
 
         return url, data
 

--- a/litellm/responses/litellm_completion_transformation/custom_tools.py
+++ b/litellm/responses/litellm_completion_transformation/custom_tools.py
@@ -17,6 +17,7 @@ logic.
 
 import json
 from collections.abc import Mapping, Sequence
+from types import MappingProxyType
 from typing import Final
 
 from pydantic import BaseModel, TypeAdapter, ValidationError
@@ -27,6 +28,15 @@ from litellm.types.llms.openai import (
 )
 
 _MAX_ARGUMENTS_LEN: Final = 1_000_000
+
+TOOL_CALL_ITEM_ID_PREFIX_BY_TYPE: Final = MappingProxyType({"function_call": "fc", "custom_tool_call": "ctc"})
+
+
+def openai_shaped_tool_call_item_id(item_type: str, tool_id: str) -> str:
+    prefix: Final = TOOL_CALL_ITEM_ID_PREFIX_BY_TYPE.get(item_type)
+    if prefix is None or not tool_id or tool_id.startswith(prefix):
+        return tool_id
+    return f"{prefix}_{tool_id}"
 
 
 def extract_custom_tool_names(tools: Sequence[object] | None) -> set[str]:
@@ -103,7 +113,7 @@ def build_tool_call_item_kwargs(
     item_type: Final = "custom_tool_call" if custom else "function_call"
     kwargs: Final[dict[str, str]] = {
         "type": item_type,
-        "id": call_id,
+        "id": openai_shaped_tool_call_item_id(item_type, call_id),
         "call_id": call_id,
         "name": name,
         "status": status,

--- a/litellm/responses/litellm_completion_transformation/streaming_iterator.py
+++ b/litellm/responses/litellm_completion_transformation/streaming_iterator.py
@@ -114,6 +114,7 @@ class LiteLLMCompletionStreamingIterator(ResponsesAPIStreamingIterator):
         self._pending_tool_events: list[BaseLiteLLMOpenAIResponseObject] = []
         self._tool_output_index_by_call_id: dict[str, int] = {}
         self._tool_args_by_call_id: dict[str, str] = {}
+        self._tool_item_id_by_call_id: dict[str, str] = {}  # mutable-ok: filled per call id as tool call events stream
         self._tool_call_id_by_index: dict[int, str] = {}
         self._ambiguous_tool_call_indexes: set[int] = set()
         self._next_tool_output_index: int = 1  # output_index=0 reserved for the message item
@@ -227,6 +228,7 @@ class LiteLLMCompletionStreamingIterator(ResponsesAPIStreamingIterator):
                 self._sequence_number += 1
                 names = self._custom_tool_names
                 item_kwargs = build_tool_call_item_kwargs(call_id, tool_name, "", "in_progress", names)
+                self._tool_item_id_by_call_id[call_id] = item_kwargs["id"]
                 if tool_namespace:
                     item_kwargs["namespace"] = tool_namespace
                 event = OutputItemAddedEvent(
@@ -248,7 +250,7 @@ class LiteLLMCompletionStreamingIterator(ResponsesAPIStreamingIterator):
                     self._sequence_number += 1
                     delta_event: BaseLiteLLMOpenAIResponseObject = FunctionCallArgumentsDeltaEvent(
                         type=ResponsesAPIStreamEvents.FUNCTION_CALL_ARGUMENTS_DELTA,
-                        item_id=call_id,
+                        item_id=self._tool_item_id_by_call_id.get(call_id, call_id),
                         output_index=output_index,
                         delta=delta_chunk,
                     )
@@ -300,6 +302,7 @@ class LiteLLMCompletionStreamingIterator(ResponsesAPIStreamingIterator):
                 self._sequence_number += 1
                 names = self._custom_tool_names
                 item_kwargs = build_tool_call_item_kwargs(call_id, tool_name, "", "in_progress", names)
+                self._tool_item_id_by_call_id[call_id] = item_kwargs["id"]
                 if tool_namespace:
                     item_kwargs["namespace"] = tool_namespace
                 event = OutputItemAddedEvent(
@@ -325,7 +328,7 @@ class LiteLLMCompletionStreamingIterator(ResponsesAPIStreamingIterator):
                     self._sequence_number += 1
                     delta_event = FunctionCallArgumentsDeltaEvent(
                         type=ResponsesAPIStreamEvents.FUNCTION_CALL_ARGUMENTS_DELTA,
-                        item_id=call_id,
+                        item_id=self._tool_item_id_by_call_id.get(call_id, call_id),
                         output_index=output_index,
                         delta=delta_chunk,
                     )
@@ -335,7 +338,7 @@ class LiteLLMCompletionStreamingIterator(ResponsesAPIStreamingIterator):
             self._sequence_number += 1
             done_event = FunctionCallArgumentsDoneEvent(
                 type=ResponsesAPIStreamEvents.FUNCTION_CALL_ARGUMENTS_DONE,
-                item_id=call_id,
+                item_id=self._tool_item_id_by_call_id.get(call_id, call_id),
                 output_index=output_index,
                 arguments=final_args,
             )
@@ -345,6 +348,7 @@ class LiteLLMCompletionStreamingIterator(ResponsesAPIStreamingIterator):
             self._sequence_number += 1
             names = self._custom_tool_names
             item_kwargs = build_tool_call_item_kwargs(call_id, tool_name, final_args, "completed", names)
+            item_kwargs["id"] = self._tool_item_id_by_call_id.setdefault(call_id, item_kwargs["id"])
             if tool_namespace:
                 item_kwargs["namespace"] = tool_namespace
             item_done_event = OutputItemDoneEvent(

--- a/litellm/responses/litellm_completion_transformation/transformation.py
+++ b/litellm/responses/litellm_completion_transformation/transformation.py
@@ -93,6 +93,7 @@ from .custom_tools import (
     convert_custom_tool_to_function_tool,
     extract_custom_tool_names,
     is_custom_tool_call,
+    openai_shaped_tool_call_item_id,
     serialize_tool_call_arguments,
     unwrap_custom_tool_arguments,
     validated_allowed_callers,
@@ -2034,7 +2035,7 @@ class LiteLLMCompletionResponsesConfig:
                     custom_item = CustomToolCallOutputItem(
                         type="custom_tool_call",
                         call_id=tool_id,
-                        id=tool_id,
+                        id=openai_shaped_tool_call_item_id("custom_tool_call", tool_id),
                         name=tool_name,
                         input=input_str,
                         status=function_definition.get("status") or "completed",
@@ -2065,7 +2066,7 @@ class LiteLLMCompletionResponsesConfig:
                         name=tool_name,
                         arguments=tool_arguments,
                         call_id=tool_id,
-                        id=tool_id,
+                        id=openai_shaped_tool_call_item_id("function_call", tool_id),
                         type="function_call",
                         status=function_definition.get("status") or "completed",
                     )
@@ -2502,8 +2503,7 @@ class LiteLLMCompletionResponsesConfig:
                     choice=choice,
                 )
                 message_output_items.extend(image_generation_items)
-            else:
-                # Regular message output
+            elif choice.message.content is not None:
                 message_output_items.append(
                     GenericResponseOutputItem(
                         type="message",

--- a/tests/llm_translation/test_prompt_factory.py
+++ b/tests/llm_translation/test_prompt_factory.py
@@ -1446,9 +1446,17 @@ def test_convert_to_anthropic_tool_invoke_sanitizes_invalid_ids():
 
 def test_convert_to_anthropic_tool_invoke_server_tool():
     """
-    Test that server_tool_use (srvtoolu_) is reconstructed as server_tool_use.
+    Test that a server tool call (srvtoolu_) with no stored result is replayed
+    as a regular tool_use block.
 
-    Fixes: https://github.com/BerriAI/litellm/issues/17737
+    A server_tool_use block is only valid when paired with its result block, so
+    an unpaired one must degrade to tool_use for Anthropic to accept the replay.
+    A paired call still becomes server_tool_use, covered by
+    test_convert_to_anthropic_tool_invoke_with_web_search_results.
+
+    Context: https://github.com/BerriAI/litellm/issues/17737 (original
+    server_tool_use reconstruction) and LIT-6622 / PR #39144 (unpaired calls
+    degrade instead of 400ing at Anthropic).
     """
     tool_calls = [
         {
@@ -1464,7 +1472,7 @@ def test_convert_to_anthropic_tool_invoke_server_tool():
     result = convert_to_anthropic_tool_invoke(tool_calls)
 
     assert len(result) == 1
-    assert result[0]["type"] == "server_tool_use"  # NOT tool_use
+    assert result[0]["type"] == "tool_use"
     assert result[0]["id"] == "srvtoolu_01ABC123"
     assert result[0]["name"] == "web_search"
     assert result[0]["input"] == {"query": "elephant weight"}

--- a/tests/test_litellm/litellm_core_utils/prompt_templates/test_litellm_core_utils_prompt_templates_factory.py
+++ b/tests/test_litellm/litellm_core_utils/prompt_templates/test_litellm_core_utils_prompt_templates_factory.py
@@ -3627,3 +3627,67 @@ def test_convert_gemini_tool_call_result_answers_tool_reference_only_result():
     )
 
     assert result == {"function_response": {"name": "ToolSearch", "response": {"content": ""}}}
+
+
+def test_convert_to_anthropic_tool_invoke_degrades_unpaired_server_tool_use():
+    """A replayed srvtoolu_ call whose server tool result is not available
+    (e.g. the Responses bridge replays items without provider_specific_fields)
+    must become a plain client tool_use so the client's tool_result can pair
+    with it. A dangling server_tool_use makes Anthropic 400 the request with
+    "unexpected `tool_use_id` found in `tool_result` blocks"."""
+    from litellm.litellm_core_utils.prompt_templates.factory import convert_to_anthropic_tool_invoke
+
+    result = convert_to_anthropic_tool_invoke(
+        tool_calls=[
+            {
+                "id": "srvtoolu_01Unpaired",
+                "type": "function",
+                "function": {"name": "web_search", "arguments": '{"query": "zig version"}'},
+            }
+        ],
+        web_search_results=None,
+        tool_results=None,
+    )
+
+    assert result == [
+        {
+            "type": "tool_use",
+            "id": "srvtoolu_01Unpaired",
+            "name": "web_search",
+            "input": {"query": "zig version"},
+        }
+    ]
+
+
+def test_convert_to_anthropic_tool_invoke_keeps_paired_server_tool_use():
+    """When the paired server tool result is available, the srvtoolu_ call is
+    still reconstructed as server_tool_use followed by its result block."""
+    from litellm.litellm_core_utils.prompt_templates.factory import convert_to_anthropic_tool_invoke
+
+    server_result = {
+        "type": "web_search_tool_result",
+        "tool_use_id": "srvtoolu_01Paired",
+        "content": [{"type": "web_search_result", "url": "https://ziglang.org", "title": "Zig"}],
+    }
+
+    result = convert_to_anthropic_tool_invoke(
+        tool_calls=[
+            {
+                "id": "srvtoolu_01Paired",
+                "type": "function",
+                "function": {"name": "web_search", "arguments": '{"query": "zig version"}'},
+            }
+        ],
+        web_search_results=[server_result],
+        tool_results=None,
+    )
+
+    assert result == [
+        {
+            "type": "server_tool_use",
+            "id": "srvtoolu_01Paired",
+            "name": "web_search",
+            "input": {"query": "zig version"},
+        },
+        server_result,
+    ]

--- a/tests/test_litellm/llms/openai/responses/test_openai_responses_transformation.py
+++ b/tests/test_litellm/llms/openai/responses/test_openai_responses_transformation.py
@@ -220,6 +220,111 @@ class TestOpenAIResponsesAPIConfig:
 
         assert result["input"] == input_clean
 
+    def test_transform_drops_foreign_tool_call_item_ids(self):
+        """Replayed tool call items whose ids are not OpenAI-shaped (e.g.
+        Anthropic toolu_/srvtoolu_ ids after a router fallback) must be sent
+        without an id: OpenAI 400s foreign ids ("Expected an ID that begins
+        with 'fc'") but accepts the items with no id at all. Genuine fc_/ctc_
+        ids and non-tool-call items pass through untouched."""
+        replayed_input = [
+            {"role": "user", "content": [{"type": "input_text", "text": "hi"}]},
+            {
+                "type": "function_call",
+                "id": "toolu_01Foreign",
+                "call_id": "toolu_01Foreign",
+                "name": "get_weather",
+                "arguments": '{"city": "SF"}',
+            },
+            {"type": "function_call_output", "call_id": "toolu_01Foreign", "output": "sunny"},
+            {
+                "type": "custom_tool_call",
+                "id": "srvtoolu_01Foreign",
+                "call_id": "srvtoolu_01Foreign",
+                "name": "apply_patch",
+                "input": "patch",
+            },
+            {
+                "type": "function_call",
+                "id": "fc_genuine",
+                "call_id": "call_genuine",
+                "name": "get_weather",
+                "arguments": "{}",
+            },
+            {"type": "message", "id": "msg_1", "role": "assistant", "content": []},
+        ]
+
+        result = self.config.transform_responses_api_request(
+            model=self.model,
+            input=replayed_input,
+            response_api_optional_request_params={},
+            litellm_params={},
+            headers={},
+        )
+
+        assert "id" not in result["input"][1]
+        assert result["input"][1]["call_id"] == "toolu_01Foreign"
+        assert "id" not in result["input"][3]
+        assert result["input"][3]["call_id"] == "srvtoolu_01Foreign"
+        assert result["input"][4]["id"] == "fc_genuine"
+        assert result["input"][5]["id"] == "msg_1"
+        assert replayed_input[1]["id"] == "toolu_01Foreign"
+        assert replayed_input[3]["id"] == "srvtoolu_01Foreign"
+
+    def test_transform_keeps_foreign_tool_call_item_ids_for_other_providers(self):
+        """Providers reusing this config that do not enforce OpenAI's id
+        shapes must keep replayed ids untouched."""
+        from litellm.types.utils import LlmProviders
+
+        class _OpenRouterLikeConfig(OpenAIResponsesAPIConfig):
+            @property
+            def custom_llm_provider(self) -> LlmProviders:
+                return LlmProviders.OPENROUTER
+
+        replayed_input = [
+            {
+                "type": "function_call",
+                "id": "toolu_01Foreign",
+                "call_id": "toolu_01Foreign",
+                "name": "get_weather",
+                "arguments": "{}",
+            }
+        ]
+
+        result = _OpenRouterLikeConfig().transform_responses_api_request(
+            model="openrouter/some-model",
+            input=replayed_input,
+            response_api_optional_request_params={},
+            litellm_params={},
+            headers={},
+        )
+
+        assert result["input"][0]["id"] == "toolu_01Foreign"
+
+    def test_transform_compact_drops_foreign_tool_call_item_ids(self):
+        """The compact request path replays input the same way, so it must
+        apply the same id drop."""
+        replayed_input = [
+            {
+                "type": "function_call",
+                "id": "toolu_01Foreign",
+                "call_id": "toolu_01Foreign",
+                "name": "get_weather",
+                "arguments": "{}",
+            }
+        ]
+
+        _url, data = self.config.transform_compact_response_api_request(
+            model=self.model,
+            input=replayed_input,
+            response_api_optional_request_params={},
+            api_base="https://api.openai.com/v1/responses",
+            litellm_params=GenericLiteLLMParams(),
+            headers={},
+        )
+
+        assert "id" not in data["input"][0]
+        assert data["input"][0]["call_id"] == "toolu_01Foreign"
+
     def test_transform_streaming_response(self):
         """Test streaming response transformation"""
         # Test with a text delta event

--- a/tests/test_litellm/responses/litellm_completion_transformation/test_litellm_completion_responses.py
+++ b/tests/test_litellm/responses/litellm_completion_transformation/test_litellm_completion_responses.py
@@ -3409,6 +3409,7 @@ class TestEnsureOutputItemContentPartAdded:
         iterator._pending_tool_events = []
         iterator._tool_output_index_by_call_id = {}
         iterator._tool_args_by_call_id = {}
+        iterator._tool_item_id_by_call_id = {}
         iterator._tool_call_id_by_index = {}
         iterator._ambiguous_tool_call_indexes = set()
         iterator._next_tool_output_index = 1

--- a/tests/test_litellm/responses/litellm_completion_transformation/test_litellm_completion_responses.py
+++ b/tests/test_litellm/responses/litellm_completion_transformation/test_litellm_completion_responses.py
@@ -648,6 +648,72 @@ class TestLiteLLMCompletionResponsesConfig:
 
         assert responses_api_response.status == "incomplete"
 
+    def test_tool_call_only_response_emits_no_null_text_message_item(self):
+        """A tool-calls-only turn (message content None, e.g. from Anthropic)
+        must not emit a message output item whose output_text has text null.
+        OpenAI rejects such an item on replay with
+        "Invalid type for 'input[..].content[..].text': expected a string, but
+        got null instead." Native OpenAI tool-only turns carry no message item."""
+        chat_completion_response = ModelResponse(
+            id="test-response-id",
+            created=1234567890,
+            model="claude-sonnet-4-5",
+            object="chat.completion",
+            choices=[
+                Choices(
+                    finish_reason="tool_calls",
+                    index=0,
+                    message=Message(
+                        content=None,
+                        role="assistant",
+                        tool_calls=[
+                            ChatCompletionMessageToolCall(
+                                id="toolu_01OnlyToolCall",
+                                type="function",
+                                function=Function(name="get_weather", arguments='{"city": "SF"}'),
+                            )
+                        ],
+                    ),
+                )
+            ],
+        )
+
+        responses_api_response = LiteLLMCompletionResponsesConfig.transform_chat_completion_response_to_responses_api_response(
+            request_input="what's the weather in SF?",
+            responses_api_request={},
+            chat_completion_response=chat_completion_response,
+        )
+
+        output_types = [item.type for item in responses_api_response.output]
+        assert "message" not in output_types
+        assert "function_call" in output_types
+
+    def test_content_bearing_response_still_emits_message_item(self):
+        """Turns with real text content must keep their message output item."""
+        chat_completion_response = ModelResponse(
+            id="test-response-id",
+            created=1234567890,
+            model="claude-sonnet-4-5",
+            object="chat.completion",
+            choices=[
+                Choices(
+                    finish_reason="stop",
+                    index=0,
+                    message=Message(content="It is sunny.", role="assistant"),
+                )
+            ],
+        )
+
+        responses_api_response = LiteLLMCompletionResponsesConfig.transform_chat_completion_response_to_responses_api_response(
+            request_input="what's the weather in SF?",
+            responses_api_request={},
+            chat_completion_response=chat_completion_response,
+        )
+
+        message_items = [item for item in responses_api_response.output if item.type == "message"]
+        assert len(message_items) == 1
+        assert message_items[0].content[0].text == "It is sunny."
+
     def test_transform_chat_completion_response_preserves_hidden_params(self):
         """Test that _hidden_params from chat completion response are preserved in responses API response"""
         # Setup

--- a/tests/test_litellm/responses/litellm_completion_transformation/test_streaming_iterator_transformation.py
+++ b/tests/test_litellm/responses/litellm_completion_transformation/test_streaming_iterator_transformation.py
@@ -349,7 +349,8 @@ def test_tool_call_delta_without_id_uses_index_mapping():
         if evt.type == ResponsesAPIStreamEvents.OUTPUT_ITEM_ADDED
     ]
     assert len(output_item_added_events) == 1
-    assert output_item_added_events[0].item.id == "call_abc123"
+    assert output_item_added_events[0].item.id == "fc_call_abc123"
+    assert output_item_added_events[0].item.call_id == "call_abc123"
 
 
 def test_parallel_tool_calls_without_ids_use_index_mapping():

--- a/tests/test_litellm/responses/litellm_completion_transformation/test_streaming_iterator_transformation.py
+++ b/tests/test_litellm/responses/litellm_completion_transformation/test_streaming_iterator_transformation.py
@@ -132,7 +132,7 @@ def test_tool_call_delta_is_emitted_as_responses_events():
     evt2 = iterator._transform_chat_completion_chunk_to_response_api_chunk(chunk)
     assert evt2 is not None
     assert evt2.type == ResponsesAPIStreamEvents.FUNCTION_CALL_ARGUMENTS_DELTA
-    assert evt2.item_id == "call_1"
+    assert evt2.item_id == "fc_call_1"
     assert evt2.output_index == 1
     # The delta will be a chunk of the arguments, not the full arguments
     assert len(evt2.delta) <= 10  # Chunks are max 10 characters
@@ -197,7 +197,7 @@ def test_tool_calls_present_only_in_final_response_are_emitted_before_completed(
 
     # The last event should be FUNCTION_CALL_ARGUMENTS_DONE
     assert evt.type == ResponsesAPIStreamEvents.FUNCTION_CALL_ARGUMENTS_DONE
-    assert evt.item_id == "call_2"
+    assert evt.item_id == "fc_call_2"
     assert evt.output_index == 1
     assert evt.arguments == '{"y":2}'
 
@@ -291,7 +291,7 @@ def test_tool_call_arguments_are_chunked_to_match_openai_behavior():
     # Verify each delta is at most 10 characters
     for evt in delta_events:
         assert len(evt.delta) <= 10
-        assert evt.item_id == "call_test"
+        assert evt.item_id == "fc_call_test"
         assert evt.output_index == 1
         assert hasattr(evt, "__dict__") and "sequence_number" in evt.__dict__
 
@@ -405,8 +405,8 @@ def test_parallel_tool_calls_without_ids_use_index_mapping():
         arguments_by_call_id.setdefault(evt.item_id, "")
         arguments_by_call_id[evt.item_id] += evt.delta
 
-    assert arguments_by_call_id["call_a"] == '{"x":1}'
-    assert arguments_by_call_id["call_b"] == '{"y":2}'
+    assert arguments_by_call_id["fc_call_a"] == '{"x":1}'
+    assert arguments_by_call_id["fc_call_b"] == '{"y":2}'
 
 
 def test_reused_index_with_new_call_id_marks_fallback_ambiguous():
@@ -462,10 +462,10 @@ def test_reused_index_with_new_call_id_marks_fallback_ambiguous():
         arguments_by_call_id.setdefault(evt.item_id, "")
         arguments_by_call_id[evt.item_id] += evt.delta
 
-    assert arguments_by_call_id["call_a"] == '{"a":'
-    assert arguments_by_call_id["call_b"] == '{"b":'
-    assert arguments_by_call_id["call_a"] != '{"a":1}'
-    assert arguments_by_call_id["call_b"] != '{"b":1}'
+    assert arguments_by_call_id["fc_call_a"] == '{"a":'
+    assert arguments_by_call_id["fc_call_b"] == '{"b":'
+    assert arguments_by_call_id["fc_call_a"] != '{"a":1}'
+    assert arguments_by_call_id["fc_call_b"] != '{"b":1}'
 
 
 @pytest.mark.asyncio
@@ -558,3 +558,58 @@ def test_object_tool_call_arguments_stream_as_valid_json():
     )
 
     assert json.loads(streamed_arguments) == {"command": "ls", "flags": ["-l"]}
+
+
+def test_streamed_anthropic_tool_call_events_correlate_on_normalized_item_id():
+    iterator = LiteLLMCompletionStreamingIterator(
+        model="test-model",
+        litellm_custom_stream_wrapper=AsyncMock(),
+        request_input="Test input",
+        responses_api_request={},
+    )
+
+    response = ModelResponse(
+        id="resp-anthropic",
+        created=123,
+        model="test-model",
+        object="chat.completion",
+        choices=[
+            {
+                "index": 0,
+                "finish_reason": "tool_calls",
+                "message": {
+                    "role": "assistant",
+                    "content": None,
+                    "tool_calls": [
+                        {
+                            "id": "toolu_01AbCdEf",
+                            "type": "function",
+                            "function": {"name": "get_weather", "arguments": '{"city":"Paris"}'},
+                            "index": 0,
+                        }
+                    ],
+                },
+            }
+        ],
+    )
+    iterator.litellm_model_response = response
+
+    events = []
+    while True:
+        evt = iterator.common_done_event_logic(sync_mode=True)
+        events.append(evt)
+        if evt.type == ResponsesAPIStreamEvents.OUTPUT_ITEM_DONE:
+            break
+
+    added = [e for e in events if e.type == ResponsesAPIStreamEvents.OUTPUT_ITEM_ADDED]
+    deltas = [e for e in events if e.type == ResponsesAPIStreamEvents.FUNCTION_CALL_ARGUMENTS_DELTA]
+    dones = [e for e in events if e.type == ResponsesAPIStreamEvents.FUNCTION_CALL_ARGUMENTS_DONE]
+    item_dones = [e for e in events if e.type == ResponsesAPIStreamEvents.OUTPUT_ITEM_DONE]
+
+    assert len(added) == 1 and len(dones) == 1 and len(item_dones) == 1 and deltas
+    assert added[0].item.id == "fc_toolu_01AbCdEf"
+    assert added[0].item.call_id == "toolu_01AbCdEf"
+    assert item_dones[0].item.id == "fc_toolu_01AbCdEf"
+    assert item_dones[0].item.call_id == "toolu_01AbCdEf"
+    for evt in deltas + dones:
+        assert evt.item_id == added[0].item.id

--- a/tests/test_litellm/responses/test_custom_tool_call.py
+++ b/tests/test_litellm/responses/test_custom_tool_call.py
@@ -20,6 +20,7 @@ from litellm.responses.litellm_completion_transformation.transformation import (
 from litellm.responses.litellm_completion_transformation.custom_tools import (
     extract_custom_tool_names,
     is_custom_tool_call,
+    openai_shaped_tool_call_item_id,
     unwrap_custom_tool_arguments,
     build_tool_call_item_kwargs,
     convert_custom_tool_to_function_tool,
@@ -128,6 +129,41 @@ class TestCustomToolUtilities:
         assert kwargs["type"] == "function_call"
         assert kwargs["arguments"] == raw
         assert "input" not in kwargs
+
+    def test_openai_shaped_tool_call_item_id_prefixes_foreign_ids(self):
+        """Anthropic-style tool ids must be normalized to OpenAI's item id
+        shapes (fc/ctc prefixes) so replaying the item to OpenAI does not 400
+        with "Expected an ID that begins with 'fc'"."""
+        assert openai_shaped_tool_call_item_id("function_call", "toolu_01Abc") == "fc_toolu_01Abc"
+        assert openai_shaped_tool_call_item_id("function_call", "srvtoolu_01Xyz") == "fc_srvtoolu_01Xyz"
+        assert openai_shaped_tool_call_item_id("custom_tool_call", "toolu_01Abc") == "ctc_toolu_01Abc"
+        assert openai_shaped_tool_call_item_id("function_call", "fc_already") == "fc_already"
+        assert openai_shaped_tool_call_item_id("custom_tool_call", "ctc_already") == "ctc_already"
+        assert openai_shaped_tool_call_item_id("function_call", "") == ""
+        assert openai_shaped_tool_call_item_id("message", "toolu_01Abc") == "toolu_01Abc"
+
+    def test_build_tool_call_item_kwargs_normalizes_item_id_keeps_call_id(self):
+        """The streaming item id gets the OpenAI shape while call_id stays raw
+        so tool_result pairing (which keys off call_id) keeps working."""
+        function_kwargs = build_tool_call_item_kwargs(
+            call_id="toolu_01Abc",
+            name="get_weather",
+            arguments_or_input="{}",
+            status="completed",
+            custom_tool_names=set(),
+        )
+        assert function_kwargs["id"] == "fc_toolu_01Abc"
+        assert function_kwargs["call_id"] == "toolu_01Abc"
+
+        custom_kwargs = build_tool_call_item_kwargs(
+            call_id="toolu_01Def",
+            name="apply_patch",
+            arguments_or_input=json.dumps({"content": "patch"}),
+            status="completed",
+            custom_tool_names={"apply_patch"},
+        )
+        assert custom_kwargs["id"] == "ctc_toolu_01Def"
+        assert custom_kwargs["call_id"] == "toolu_01Def"
 
     def test_unwrap_custom_tool_arguments_oversized_returns_raw(self):
         """Arguments larger than the safety cap are returned unchanged to avoid
@@ -292,6 +328,52 @@ class TestTransformationCustomTools:
         assert item.type == "function_call"
         assert item.name == "regular_tool"
         assert item.arguments == json.dumps({"param": "value"})
+
+    def test_transform_anthropic_tool_call_ids_get_openai_item_id_shape(self):
+        """Anthropic tool ids (toolu_/srvtoolu_) surfacing through the bridge
+        must be emitted with fc/ctc-prefixed item ids so a Responses client can
+        replay them to OpenAI verbatim, while call_id stays raw for pairing."""
+        from litellm.types.utils import ModelResponse, Choices, Message, ChatCompletionMessageToolCall, Function
+
+        client_call = ChatCompletionMessageToolCall(
+            id="toolu_01ClientCall",
+            type="function",
+            function=Function(name="get_weather", arguments=json.dumps({"city": "SF"})),
+        )
+        server_call = ChatCompletionMessageToolCall(
+            id="srvtoolu_01ServerCall",
+            type="function",
+            function=Function(name="web_search", arguments=json.dumps({"query": "zig"})),
+        )
+        custom_call = ChatCompletionMessageToolCall(
+            id="toolu_01CustomCall",
+            type="function",
+            function=Function(name="apply_patch", arguments=json.dumps({"content": "patch content"})),
+        )
+
+        message = Message(role="assistant", content=None, tool_calls=[client_call, server_call, custom_call])
+        choices = [Choices(index=0, message=message, finish_reason="tool_calls")]
+        response = ModelResponse(
+            id="test_response", choices=choices, created=1234567890, model="claude-sonnet-4-5", object="chat.completion"
+        )
+        responses_api_request = {
+            "tools": [{"type": "custom", "name": "apply_patch"}, {"type": "function", "name": "get_weather"}]
+        }
+
+        result = LiteLLMCompletionResponsesConfig.transform_chat_completion_tools_to_responses_tools(
+            response, responses_api_request=responses_api_request
+        )
+
+        assert [item.id for item in result] == [
+            "fc_toolu_01ClientCall",
+            "fc_srvtoolu_01ServerCall",
+            "ctc_toolu_01CustomCall",
+        ]
+        assert [item.call_id for item in result] == [
+            "toolu_01ClientCall",
+            "srvtoolu_01ServerCall",
+            "toolu_01CustomCall",
+        ]
 
     def test_transform_mixed_tool_calls(self):
         """Test transformation with both custom and regular tool calls."""


### PR DESCRIPTION
## TLDR

Problem this solves:

- gpt-5 to claude fallback turns emit tool call ids OpenAI later rejects
- replaying a claude web_search turn also 400s at Anthropic
- tool-only fallback turns add a message item with null text

How it solves it:

- fallback output items get fc_/ctc_ shaped ids, call_id stays raw
- streamed tool call argument events carry that same fc_ item id
- requests to OpenAI drop foreign-shaped item ids instead of forwarding them
- web_search replays missing their results become plain tool calls
- tool-only turns no longer emit the null-text message item

## User Flow

Before: a Codex user whose gateway falls back from gpt-5 to claude loses the whole session on the turn after a tool call

1. Codex sends POST https://litellm-domain/v1/responses with model `gpt-5` and its tools; gpt-5 is erroring, so the gateway serves the turn from the claude fallback
2. The `function_call` item in the response carries `"id": "toolu_01Abc..."` instead of the `fc_...` shape every OpenAI item has; a web search turn carries `srvtoolu_...`, and a tool-only turn also contains a message whose `output_text` has `"text": null`
3. Codex runs the tool and replays the conversation verbatim in its next POST https://litellm-domain/v1/responses
4. With gpt-5 healthy again, the reply is 400 `Invalid 'input[3].id' ... Expected an ID that begins with 'fc'` (or 400 on the null text); if the turn lands on claude instead, a replayed web search turn gets 400 `unexpected tool_use_id found in tool_result blocks`. Either way the session is dead and Codex has to start over

After: the same fallback turn produces items Codex can replay to either model

1. Codex sends the same POST https://litellm-domain/v1/responses with model `gpt-5`, served by the claude fallback
2. The `function_call` item now comes back with `"id": "fc_toolu_01Abc..."` and `"call_id": "toolu_01Abc..."`; custom tool calls get `ctc_...` ids, and a tool-only turn carries no null-text message item
3. Codex runs the tool and replays the conversation verbatim in its next POST https://litellm-domain/v1/responses
4. OpenAI accepts the replay with 200, and a replayed claude web search turn is accepted by Anthropic too; the conversation just continues across the fallback and back

## Relevant issues

Related to #38270: same class of bug for Gemini-style ids, which #38303 and #38337 address. This PR covers the Anthropic id shapes (`toolu_`/`srvtoolu_`) and the replay side, touches different code paths, and composes with both without depending on either

## Linear ticket

Resolves LIT-6622

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Live before/after QA against real OpenAI and Anthropic (real spend, no mocks). Shared setup for both legs: fresh worktree with its own venv and .env, one proxy instance with 2 uvicorn workers (`litellm/proxy/proxy_cli.py --config <cfg> --num_workers 2`), model group `gpt-5` (openai/gpt-5) with a router fallback to `claude-sonnet-4-5` (anthropic/claude-sonnet-4-5), master key auth. Phase 1 of each leg runs with a deliberately broken gpt-5 key so the fallback serves the turn (the reported situation); phase 2 restarts the proxy with the real key. Clients: the real Codex CLI 0.145.0 driven interactively under tmux, plus Responses-contract curl replays that resend a turn's output items verbatim, ids included. The curl legs carry the id-replay proof because codex-cli strips item ids on replay while Codex Desktop (the reporting user's client) replays them verbatim. The changed code also serves /v1/chat/completions, so that endpoint is its own case; /v1/messages does not ride these code paths

### Before (f2a4172c8996)

#### Fallback tool turn emission (/v1/responses)

1. `curl -s http://localhost:41519/v1/responses -H "Authorization: Bearer $MK" -H 'Content-Type: application/json' -d '{"model": "gpt-5", "tools": [get_weather], "input": [...forces a tool call...]}'` with the gpt-5 key failing
2. HTTP 200 served by `"model": "claude-sonnet-4-5-20250929"`, but the item is `{"type": "function_call", "id": "toolu_01YCd1rcWMaKCmaLRX7iis5w", "call_id": "toolu_01YCd1rcWMaKCmaLRX7iis5w", "name": "get_weather", ...}` and the message item carries `{"type": "output_text", "text": null, "annotations": []}`

#### Fallback web search turn emission (/v1/responses)

1. Same request with `"tools": [{"type": "web_search"}]`
2. HTTP 200 with `{"type": "function_call", "id": "srvtoolu_01VsQW7ie3D7hHzR2GBVGsRb", "call_id": "srvtoolu_01VsQW7ie3D7hHzR2GBVGsRb", "name": "web_search"}` and no result item pairing it: a dangling server-tool call handed to the client

#### Streamed fallback tool turn (/v1/responses, stream: true)

1. The tool turn request with `"stream": true`, `curl -sN`, gpt-5 key failing
2. HTTP 200 stream served by the fallback: `response.output_item.added` carries `{"type": "function_call", "id": "toolu_01WQCHVjJ2fKREbVFktxMWqQ", "call_id": "toolu_01WQCHVjJ2fKREbVFktxMWqQ", ...}` and every `response.function_call_arguments.delta`/`done` event carries that raw `"item_id": "toolu_01WQCHVjJ2fKREbVFktxMWqQ"`; `grep -c 'fc_'` over the raw SSE: 0

#### Tool turn replay to healthy gpt-5 (/v1/responses)

1. Verbatim replay of the tool turn's output items plus a `function_call_output` and a user follow-up, POST model `gpt-5` with the real key
2. HTTP 200 but `"model": "claude-sonnet-4-5-20250929"`: OpenAI rejected the `toolu_` item id and the router silently rescued via claude, so the session never gets gpt-5 back

#### Web search turn replay to healthy gpt-5 (/v1/responses)

1. Same replay built from the web search turn
2. HTTP 400, the reported double failure: `"Invalid 'input[2].id': 'srvtoolu_01VsQW7ie3D7hHzR2GBVGsRb'. Expected an ID that begins with 'fc'."` then `Error doing the fallback: litellm.BadRequestError: AnthropicException - ... unexpected tool_use_id found in tool_result blocks: srvtoolu_01VsQW7ie3D7hHzR2GBVGsRb. Each tool_result block must have a corresponding tool_use block in the previous message.` then `No fallback model group found for original model_group=claude-sonnet-4-5`

#### Web search turn replay while gpt-5 is down (/v1/responses)

1. Same web search replay in phase 1, gpt-5 key still broken, so the fallback must serve it
2. Hard failure: the fallback dies on the same `unexpected tool_use_id found in tool_result blocks` AnthropicException (outer status 401 from the primary's auth error)

#### Tool id replay on /v1/chat/completions

1. `curl -s http://localhost:41519/v1/chat/completions ... -d '{"model": "claude-sonnet-4-5", "messages": [user, assistant with tool_calls id "srvtoolu_qa6622test01" name web_search, tool message answering it, user follow-up]}'`
2. HTTP 400: `AnthropicException - ... unexpected tool_use_id found in tool_result blocks: srvtoolu_qa6622test01 ...`

#### Codex CLI session across the fallback

1. Codex CLI 0.145.0 under tmux, turn 1 with the gpt-5 key broken: reads two files via its shell tool, answers correctly off the claude fallback
2. Turn 2 after the key recovers completes only because codex-cli strips item ids on replay; a Desktop-style client replaying ids verbatim hits the 400s above

### After (98ea5eaab422)

One commit since this run: fa581931f7, test-only (updates `tests/llm_translation/test_prompt_factory.py` to the unpaired-server-tool contract this PR ships), so it cannot change runtime behavior

#### Fallback tool turn emission (/v1/responses)

1. Same request against the fixed proxy on :63558, gpt-5 key failing
2. HTTP 200 served by `"model": "claude-sonnet-4-5-20250929"` with `{"type": "function_call", "id": "fc_toolu_01LvSLRBnGPDyzwtkmAWcN8M", "call_id": "toolu_01LvSLRBnGPDyzwtkmAWcN8M", "name": "get_weather", ...}`; the tool-only turn emits no message item and no null-text `output_text` anywhere

#### Fallback web search turn emission (/v1/responses)

1. Same request with `"tools": [{"type": "web_search"}]`
2. HTTP 200 with `{"type": "function_call", "id": "fc_srvtoolu_01LA3AUMe8Q2VSZB4sdZQKq3", "call_id": "srvtoolu_01LA3AUMe8Q2VSZB4sdZQKq3", "name": "web_search"}`

#### Streamed fallback tool turn (/v1/responses, stream: true)

1. Same streamed request, gpt-5 key failing
2. HTTP 200: `response.output_item.added` carries `{"type": "function_call", "id": "fc_toolu_01R9GG9nbsQrhyeQxTUZgpNm", "call_id": "toolu_01R9GG9nbsQrhyeQxTUZgpNm", ...}`, every `response.function_call_arguments.delta`/`done` event carries `"item_id": "fc_toolu_01R9GG9nbsQrhyeQxTUZgpNm"`, and `response.output_item.done` matches the added item exactly

#### Tool turn replay to healthy gpt-5 (/v1/responses)

1. Verbatim replay of the emitted items (fc_toolu_ id included) plus tool output and follow-up, model `gpt-5`, real key
2. HTTP 200 with `"model": "gpt-5"`: the turn actually lands on gpt-5 ("No—it's sunny in Paris, so you won't need an umbrella.")

#### Web search turn replay to healthy gpt-5 (/v1/responses)

1. Same replay from the web search turn, run both with a function-shaped web_search tool and with the `{"type": "web_search"}` tool
2. HTTP 200 with `"model": "gpt-5"` in both runs, coherent answers

#### Web search turn replay while gpt-5 is down (/v1/responses)

1. Same web search replay in phase 1, gpt-5 key still broken
2. HTTP 200 served by `"model": "claude-sonnet-4-5-20250929"`, coherent continuation: the fallback now rescues the turn instead of double-failing

#### Tool id replay on /v1/chat/completions

1. Same `srvtoolu_qa6622test01` chat-completions request
2. HTTP 200 with a coherent assistant reply

#### Codex CLI session across the fallback

1. Codex CLI 0.145.0 under tmux, turn 1 with the gpt-5 key broken: runs its shell tool and answers correctly off the claude fallback
2. Turn 2 after the key recovers continues the same session normally on gpt-5, no error banner

Design probes made directly against the provider APIs while building the fix: OpenAI 400s foreign item ids (`Expected an ID that begins with 'fc'`, ctc variant for custom tool calls) but accepts the same items with no `id` and a foreign `call_id`; Anthropic accepts a client `tool_use` reusing a `srvtoolu_` id and the `web_search` name with the server tool armed

Observations from the runs:

- broken-key replay returns 401 outer status; pre-existing, unchanged
- tool-only turns now emit no message item; intended by this PR
- streamed tool-only turns keep a message item with `""` text
- OpenAI accepts fc_srvtoolu_ item ids; prefix is all it checks
- codex-cli strips item ids on replay; Desktop-style clients hit the 400s

## Type

🐛 Bug Fix

## Caveats (if any)

### Low

- item ids change shape (`fc_` prefix added); clients pair by `call_id`, which stays raw
- a web_search replay without its stored results shows claude a plain tool call carrying the same query and result text
- the id drop only applies to requests bound for OpenAI and Azure; other providers reusing the config are untouched
- streamed tool-only turns still carry a message item with `""` text (pre-existing streaming iterator behavior), so streaming and non-streaming responses differ on message-item presence; replay-safe either way
- Bedrock Mantle's degenerate `call_N` call ids fall back to the item id for correlation, which now carries the `fc_` prefix; still a unique valid string, only the shape changed

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

/live-pr-risk CHECKED at fa581931f7: no breaking dependents. The anthropic replay change sits behind the single `prompt_factory` chokepoint shared by direct Anthropic, Azure Anthropic, Vertex Anthropic, Bedrock invoke Claude3+ and claude-platform, Databricks Claude, and guardrail translation; the direct-Anthropic leg ran live on both sides and unit tests pin the function. Emission and replay were driven A/B live at base and head (function + custom tool + replay to gpt-5) and again on a merged tree with current staging. Every in-tree id consumer pairs by `call_id` first; the one exception, Bedrock Mantle's `call_N` fallback, now carries the `fc_` prefix (still unique and valid). `previous_response_id` replay re-feeds the stored chat-completion shape, never the prefixed items, and is inert without a DB. CircleCI at the tip fails only tests that fail identically at the staging head (nvidia_nim embedding, gateway sdk embedding x2, encoding_format default, websearch-interception flake); the one legacy assertion this PR invalidated is fixed in this PR and passes. Not verified live: Bedrock/Vertex/Azure/Databricks-hosted Claude legs (same transformed payload as the live direct-Anthropic leg, no per-provider drive) and DB-backed `previous_response_id` replay (code-traced; rigs ran DB-less)

- [x] fa581931f73ea6b4094188220b8f06a14c3006b2 passes /live-pr-risk
