### PR TITLE
revert: restore search tool fallback when no router is configured

### DIFF
--- a/litellm/integrations/websearch_interception/handler.py
+++ b/litellm/integrations/websearch_interception/handler.py
@@ -1633,16 +1633,18 @@ class WebSearchInterceptionLogger(CustomLogger):
     def _select_search_tool_from_router(self, llm_router: object) -> "_SearchToolConfig | None":
         if llm_router is None or not hasattr(llm_router, "search_tools"):
             return None
-        search_tools: Final = list(getattr(llm_router, "search_tools", None) or [])
+        search_tools: Final = tuple(getattr(llm_router, "search_tools", None) or ())
         return self._select_search_tool_from_list(search_tools=search_tools, source="router")
 
     def _select_search_tool_from_list(
         self,
-        search_tools: list[_SearchToolConfig],
+        search_tools: Sequence[_SearchToolConfig],
         source: str,
     ) -> "_SearchToolConfig | None":
         if self.search_tool_name:
-            matching_tools = [tool for tool in search_tools if tool.get("search_tool_name") == self.search_tool_name]
+            matching_tools: Final = tuple(
+                tool for tool in search_tools if tool.get("search_tool_name") == self.search_tool_name
+            )
             if matching_tools:
                 search_provider = (matching_tools[0].get("litellm_params", {}) or {}).get("search_provider")
                 verbose_logger.debug(

--- a/litellm/integrations/websearch_interception/handler.py
+++ b/litellm/integrations/websearch_interception/handler.py
@@ -1633,7 +1633,7 @@ class WebSearchInterceptionLogger(CustomLogger):
     def _select_search_tool_from_router(self, llm_router: object) -> "_SearchToolConfig | None":
         if llm_router is None or not hasattr(llm_router, "search_tools"):
             return None
-        search_tools: Final = list(getattr(llm_router, "search_tools") or [])
+        search_tools: Final = list(getattr(llm_router, "search_tools", None) or [])
         return self._select_search_tool_from_list(search_tools=search_tools, source="router")
 
     def _select_search_tool_from_list(

--- a/litellm/integrations/websearch_interception/handler.py
+++ b/litellm/integrations/websearch_interception/handler.py
@@ -416,24 +416,14 @@ class WebSearchInterceptionLogger(CustomLogger):
         if not tools:
             return None
 
-        is_responses_call: Final = call_type in (CallTypes.responses, CallTypes.aresponses)
-        has_websearch: Final = (
-            any(is_web_search_tool_responses(tool) for tool in tools)
-            if is_responses_call
-            else any(is_web_search_tool(tool) for tool in tools)
-        )
+        if call_type in (CallTypes.responses, CallTypes.aresponses):
+            return self._convert_responses_tools(kwargs=kwargs, tools=tools)
+
+        # Check if any tool is a web search tool (native or already LiteLLM standard)
+        has_websearch: Final = any(is_web_search_tool(t) for t in tools)
+
         if not has_websearch:
             return None
-
-        if self.search_tool_name:
-            try:
-                from litellm.proxy.proxy_server import llm_router
-            except ImportError:
-                llm_router = None
-            self._select_search_tool_from_router(llm_router=llm_router)
-
-        if is_responses_call:
-            return self._convert_responses_tools(kwargs=kwargs, tools=tools)
 
         verbose_logger.debug("WebSearchInterception: Converting native web_search tools to LiteLLM standard")
 
@@ -1641,7 +1631,9 @@ class WebSearchInterceptionLogger(CustomLogger):
         return None
 
     def _select_search_tool_from_router(self, llm_router: object) -> "_SearchToolConfig | None":
-        search_tools: Final = list(getattr(llm_router, "search_tools", []) or [])
+        if llm_router is None or not hasattr(llm_router, "search_tools"):
+            return None
+        search_tools: Final = list(getattr(llm_router, "search_tools") or [])
         return self._select_search_tool_from_list(search_tools=search_tools, source="router")
 
     def _select_search_tool_from_list(
@@ -1651,26 +1643,20 @@ class WebSearchInterceptionLogger(CustomLogger):
     ) -> "_SearchToolConfig | None":
         if self.search_tool_name:
             matching_tools = [tool for tool in search_tools if tool.get("search_tool_name") == self.search_tool_name]
-            if not matching_tools:
-                raise ValueError(f"Configured search tool '{self.search_tool_name}' was not found")
-
-            selected_tool: Final = matching_tools[0]
-            litellm_params: Final = selected_tool.get("litellm_params")
-            selected_search_provider: Final = (
-                litellm_params.get("search_provider") if isinstance(litellm_params, Mapping) else None
-            )
-            if not isinstance(selected_search_provider, str) or not selected_search_provider.strip():
-                raise ValueError(
-                    f"Configured search tool '{self.search_tool_name}' does not define a valid search provider"
+            if matching_tools:
+                search_provider = (matching_tools[0].get("litellm_params", {}) or {}).get("search_provider")
+                verbose_logger.debug(
+                    "WebSearchInterception: Found search tool '%s' from %s with provider '%s'",
+                    self.search_tool_name,
+                    source,
+                    search_provider,
                 )
-
+                return matching_tools[0]
             verbose_logger.debug(
-                "WebSearchInterception: Found search tool '%s' from %s with provider '%s'",
+                "WebSearchInterception: Search tool '%s' not found in %s, falling back to first available or perplexity",
                 self.search_tool_name,
                 source,
-                selected_search_provider,
             )
-            return selected_tool
 
         if search_tools:
             first_tool: Final = search_tools[0]

--- a/tests/test_litellm/integrations/websearch_interception/test_websearch_interception_handler.py
+++ b/tests/test_litellm/integrations/websearch_interception/test_websearch_interception_handler.py
@@ -14,7 +14,7 @@ from litellm.integrations.websearch_interception.handler import (
 )
 from litellm.llms.base_llm.search.transformation import SearchResponse
 from litellm.proxy._types import LiteLLM_ObjectPermissionTable, LiteLLM_TeamTable, ProxyException, UserAPIKeyAuth
-from litellm.types.utils import CallTypes, LlmProviders
+from litellm.types.utils import LlmProviders
 
 
 def test_initialize_from_proxy_config():
@@ -231,124 +231,6 @@ async def test_execute_search_passes_selected_search_tool_litellm_params(monkeyp
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize(
-    ("search_tools", "error"),
-    [
-        pytest.param(None, "was not found", id="router-not-configured"),
-        pytest.param(
-            [{"search_tool_name": "other-search", "litellm_params": {"search_provider": "tavily"}}],
-            "was not found",
-            id="requested-tool-not-configured",
-        ),
-        pytest.param(
-            [{"search_tool_name": "parallel-search", "litellm_params": "not-a-mapping"}],
-            "does not define a valid search provider",
-            id="invalid-parameters",
-        ),
-        pytest.param(
-            [{"search_tool_name": "parallel-search", "litellm_params": {}}],
-            "does not define a valid search provider",
-            id="missing-provider",
-        ),
-        pytest.param(
-            [{"search_tool_name": "parallel-search", "litellm_params": {"search_provider": "   "}}],
-            "does not define a valid search provider",
-            id="whitespace-provider",
-        ),
-        pytest.param(
-            [{"search_tool_name": "parallel-search", "litellm_params": {"search_provider": 123}}],
-            "does not define a valid search provider",
-            id="invalid-provider",
-        ),
-    ],
-)
-async def test_execute_search_rejects_invalid_explicit_search_tool(monkeypatch, search_tools, error):
-    import litellm
-    from litellm.proxy import proxy_server
-
-    logger = WebSearchInterceptionLogger(search_tool_name="parallel-search")
-    router = None if search_tools is None else MagicMock(search_tools=search_tools)
-    mock_asearch = AsyncMock()
-
-    monkeypatch.setattr(proxy_server, "llm_router", router)
-    monkeypatch.setattr(litellm, "asearch", mock_asearch)
-
-    with pytest.raises(ValueError, match=f"Configured search tool 'parallel-search' {error}"):
-        await logger._execute_search("what is litellm")
-
-    mock_asearch.assert_not_awaited()
-
-
-@pytest.mark.asyncio
-async def test_execute_search_honors_explicit_parallel_search_tool(monkeypatch):
-    import litellm
-    from litellm.proxy import proxy_server
-
-    logger = WebSearchInterceptionLogger(search_tool_name="parallel-search")
-    router = MagicMock(
-        search_tools=[
-            {
-                "search_tool_name": "other-search",
-                "litellm_params": {"search_provider": "tavily", "api_key": "other-key"},
-            },
-            {
-                "search_tool_name": "parallel-search",
-                "litellm_params": {"search_provider": "parallel_ai", "api_key": "parallel-key"},
-            },
-        ],
-    )
-    mock_asearch = AsyncMock(return_value=SearchResponse(object="search", results=[]))
-
-    monkeypatch.setattr(proxy_server, "llm_router", router)
-    monkeypatch.setattr(litellm, "asearch", mock_asearch)
-
-    await logger._execute_search("what is litellm")
-
-    mock_asearch.assert_awaited_once_with(
-        query="what is litellm",
-        search_provider="parallel_ai",
-        api_key="parallel-key",
-    )
-
-
-@pytest.mark.asyncio
-@pytest.mark.parametrize(
-    ("search_tools", "expected_search_kwargs"),
-    [
-        pytest.param(None, {"search_provider": "perplexity"}, id="router-not-configured"),
-        pytest.param(
-            [
-                {
-                    "search_tool_name": "first-search",
-                    "litellm_params": {"search_provider": "tavily", "api_key": "first-key"},
-                },
-                {
-                    "search_tool_name": "parallel-search",
-                    "litellm_params": {"search_provider": "parallel_ai", "api_key": "parallel-key"},
-                },
-            ],
-            {"search_provider": "tavily", "api_key": "first-key"},
-            id="first-configured-tool",
-        ),
-    ],
-)
-async def test_execute_search_preserves_implicit_provider_selection(monkeypatch, search_tools, expected_search_kwargs):
-    import litellm
-    from litellm.proxy import proxy_server
-
-    logger = WebSearchInterceptionLogger()
-    router = None if search_tools is None else MagicMock(search_tools=search_tools)
-    mock_asearch = AsyncMock(return_value=SearchResponse(object="search", results=[]))
-
-    monkeypatch.setattr(proxy_server, "llm_router", router)
-    monkeypatch.setattr(litellm, "asearch", mock_asearch)
-
-    await logger._execute_search("what is litellm")
-
-    mock_asearch.assert_awaited_once_with(query="what is litellm", **expected_search_kwargs)
-
-
-@pytest.mark.asyncio
 async def test_execute_search_attributes_spend_to_the_calling_key(monkeypatch):
     """An intercepted search is billed and logged against the key that made the LLM request.
 
@@ -513,72 +395,6 @@ async def test_execute_search_enforces_team_search_tool_permission(monkeypatch):
 
     mock_get_team_object.assert_awaited_once()
     mock_asearch.assert_not_awaited()
-
-
-@pytest.mark.asyncio
-@pytest.mark.parametrize(
-    ("call_type", "web_search_tool"),
-    [
-        pytest.param(
-            CallTypes.acompletion,
-            {"type": "web_search_20250305", "name": "web_search"},
-            id="chat-completion",
-        ),
-        pytest.param(CallTypes.responses, {"type": "web_search"}, id="responses"),
-        pytest.param(CallTypes.aresponses, {"type": "web_search"}, id="async-responses"),
-        pytest.param(
-            CallTypes.anthropic_messages,
-            {"type": "web_search_20250305", "name": "web_search"},
-            id="anthropic-messages",
-        ),
-    ],
-)
-async def test_deployment_hook_dispatcher_propagates_missing_explicit_search_tool(
-    monkeypatch, call_type, web_search_tool
-):
-    import litellm
-    from litellm.proxy import proxy_server
-    from litellm.utils import async_pre_call_deployment_hook
-
-    logger = WebSearchInterceptionLogger(enabled_providers=["bedrock"], search_tool_name="parallel-search")
-    mock_asearch = AsyncMock()
-    kwargs = {
-        "model": "bedrock/claude-sonnet-4",
-        "tools": [web_search_tool],
-        "custom_llm_provider": "bedrock",
-    }
-
-    monkeypatch.setattr(
-        proxy_server,
-        "llm_router",
-        MagicMock(search_tools=[{"search_tool_name": "other-search", "litellm_params": {"search_provider": "tavily"}}]),
-    )
-    monkeypatch.setattr(litellm, "callbacks", [logger])
-    monkeypatch.setattr(litellm, "asearch", mock_asearch)
-
-    with pytest.raises(ValueError, match="Configured search tool 'parallel-search' was not found"):
-        await async_pre_call_deployment_hook(kwargs=kwargs, call_type=call_type.value)
-
-    assert kwargs["tools"] == [web_search_tool]
-    mock_asearch.assert_not_awaited()
-
-
-@pytest.mark.asyncio
-async def test_deployment_hook_skips_explicit_tool_validation_for_non_search_responses(monkeypatch):
-    from litellm.proxy import proxy_server
-
-    logger = WebSearchInterceptionLogger(enabled_providers=["bedrock"], search_tool_name="parallel-search")
-    monkeypatch.setattr(proxy_server, "llm_router", MagicMock(search_tools=[]))
-
-    result = await logger.async_pre_call_deployment_hook(
-        kwargs={
-            "tools": [{"type": "function", "name": "calculator"}],
-            "custom_llm_provider": "bedrock",
-        },
-        call_type=CallTypes.aresponses,
-    )
-
-    assert result is None
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## TLDR

Problem this solves:

- SDK requests with `search_tool_name` set now fail every time
- No way to satisfy the check without a proxy router
- Broke `pass_through_unit_testing` on staging

How it solves it:

- Reverts #38113 to restore the previous fallback
- Puts the pass-through websearch suite back to green

## User Flow

Before: a developer using the LiteLLM SDK with web search interception gets an error on every request instead of search results

1. They set `litellm.callbacks = [WebSearchInterceptionLogger(enabled_providers=[...], search_tool_name="my-search-tool")]` in their own Python process, with no proxy running
2. They call `litellm.acompletion(...)` with a native `web_search_20250305` tool in `tools`
3. The call raises `ValueError: Configured search tool 'my-search-tool' was not found` before any request reaches the provider
4. There is no configuration that makes it succeed, since the tool list only comes from a proxy router

After: the same request goes through and returns a normal completion

1. They set the same callback with the same `search_tool_name`, still with no proxy running
2. They call `litellm.acompletion(...)` with the same native `web_search_20250305` tool
3. The web search tool is converted as before and the call returns a normal completion response
4. The unmatched tool name is logged and the request falls back, as it did before #38113

## Relevant issues

Reverts #38113

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Why this is a regression

#38113 made two edits that compose into an unconditional failure.

It dropped the null-router guard:

```
-        if llm_router is None or not hasattr(llm_router, "search_tools"):
-            return None
-        search_tools: Final = list(getattr(llm_router, "search_tools") or [])
+        search_tools: Final = list(getattr(llm_router, "search_tools", []) or [])
```

so a missing router stopped returning early and instead produced an empty list. It then turned the no-match branch in `_select_search_tool_from_list` from a debug-logged fallback into `raise ValueError(...)`, and added a call site in `async_pre_call_deployment_hook` that runs the selection purely for the side effect of raising, discarding the return value.

Off the proxy, `llm_router` is `None`, so `getattr(None, "search_tools", [])` gives `[]` and the raise always fires. `search_tools` is only ever populated from the proxy router, so an SDK caller has no way to register a matching tool and no way to make the check pass.

`tests/pass_through_unit_tests/test_websearch_interception_e2e.py::test_pre_request_hook_modifies_request_body` catches exactly this, but #38113 only updated `tests/test_litellm/integrations/websearch_interception/test_websearch_interception_handler.py`, so the break reached staging.

Worth saying plainly: the stricter validation is right on the proxy path. Silently substituting a different search provider when the configured name does not exist is a real problem and rejecting it is the correct call. The bug is that the same change also converted the SDK path into an error with no way out. A follow-up should keep the rejection where a router exists and leave the no-router case on the old fallback

## Screenshots / Proof of Fix

Both runs are local pytest against the pass-through suite, which is what CI runs and what regressed. This code path is SDK-side callback wiring with no proxy involved, so there is no live proxy route to curl for it.

### Before (65a46a5f32, staging base)

1. `PYTHONPATH=$PWD python -m pytest tests/pass_through_unit_tests/test_websearch_interception_e2e.py::test_pre_request_hook_modifies_request_body -x -q`

```
E               ValueError: Configured search tool 'test-search-tool' was not found

litellm/integrations/websearch_interception/handler.py:1655: ValueError
=========================== short test summary info ============================
FAILED tests/pass_through_unit_tests/test_websearch_interception_e2e.py::test_pre_request_hook_modifies_request_body
1 failed in 5.40s
```

### After (2814aa54a3)

1. `PYTHONPATH=$PWD python -m pytest tests/pass_through_unit_tests/test_websearch_interception_e2e.py::test_pre_request_hook_modifies_request_body -q`

```
.                                                                        [100%]
1 passed in 1.40s
```

2. `PYTHONPATH=$PWD python -m pytest tests/pass_through_unit_tests/test_websearch_interception_e2e.py tests/test_litellm/integrations/websearch_interception/ -q`

```
178 passed, 2 skipped, 1 warning in 48.26s
```

## Type

🐛 Bug Fix

## Caveats (if any)

### Medium

- Restores the silent fallback #38113 set out to remove
- A proxy with a bad `search_tool_name` again picks another provider quietly
- Follow-up should reject on the proxy path only

### Low

- Not a pure revert: one line uses `getattr(x, "search_tools", None)`
- The two-arg form is ruff B009 and the budget has since tightened
- Behavior is unchanged, the preceding `hasattr` guard already covers it

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

