### PR TITLE
fix(openai): drop tool_choice when request has no tools on chat completions

### DIFF
--- a/litellm/llms/openai/chat/gpt_transformation.py
+++ b/litellm/llms/openai/chat/gpt_transformation.py
@@ -443,6 +443,8 @@ class OpenAIGPTConfig(BaseLLMModelInfo, BaseConfig):
                 optional_params["tools"] = tools
 
         optional_params.pop("max_retries", None)
+        if not optional_params.get("tools") and not optional_params.get("functions"):
+            optional_params.pop("tool_choice", None)
 
         return {
             "model": model,
@@ -473,6 +475,8 @@ class OpenAIGPTConfig(BaseLLMModelInfo, BaseConfig):
             if tools is not None and len(tools) > 0:
                 optional_params["tools"] = tools
         if self.__class__._is_base_class:
+            if not optional_params.get("tools") and not optional_params.get("functions"):
+                optional_params.pop("tool_choice", None)
             return {
                 "model": model,
                 "messages": transformed_messages,

--- a/tests/test_litellm/llms/openai/chat/test_openai_gpt_transformation.py
+++ b/tests/test_litellm/llms/openai/chat/test_openai_gpt_transformation.py
@@ -871,6 +871,134 @@ class TestCacheControlPreservationForCustomEndpoint:
         assert all("cache_control" not in m for m in body["messages"])
 
 
+class TestToolChoiceWithoutToolsDropped:
+    def setup_method(self):
+        self.config = OpenAIGPTConfig()
+
+    @staticmethod
+    def _pi_compact_summarization_messages():
+        return [
+            {
+                "role": "system",
+                "content": "You are a context summarization assistant. Your task is to read a conversation between a user and an AI assistant, then produce a structured summary following the exact format specified.",
+            },
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "text",
+                        "text": "<conversation>\n[User]: Reply with exactly: ok-1\n\n[Assistant]: ok-1\n</conversation>\n\nThe messages above are a conversation to summarize.",
+                    }
+                ],
+            },
+        ]
+
+    def _transform(self, optional_params, config=None, model="gpt-5.6-sol"):
+        return (config or self.config).transform_request(
+            model=model,
+            messages=self._pi_compact_summarization_messages(),
+            optional_params=optional_params,
+            litellm_params={"custom_llm_provider": "openai", "api_base": None},
+            headers={},
+        )
+
+    def test_pi_compact_shape_drops_tool_choice_none_without_tools(self):
+        body = self._transform(
+            {
+                "stream": True,
+                "stream_options": {"include_usage": True},
+                "store": False,
+                "max_completion_tokens": 13107,
+                "tool_choice": "none",
+            }
+        )
+        assert "tool_choice" not in body
+        assert "tools" not in body
+        assert body["model"] == "gpt-5.6-sol"
+        assert body["stream"] is True
+        assert body["stream_options"] == {"include_usage": True}
+        assert body["store"] is False
+        assert body["max_completion_tokens"] == 13107
+
+    def test_drops_tool_choice_auto_without_tools(self):
+        body = self._transform({"tool_choice": "auto"})
+        assert "tool_choice" not in body
+
+    def test_drops_named_function_tool_choice_without_tools(self):
+        body = self._transform(
+            {"tool_choice": {"type": "function", "function": {"name": "get_weather"}}}
+        )
+        assert "tool_choice" not in body
+
+    def test_drops_tool_choice_but_keeps_empty_tools_array(self):
+        body = self._transform({"tools": [], "tool_choice": "none"})
+        assert "tool_choice" not in body
+        assert body["tools"] == []
+
+    def test_gpt5_config_drops_tool_choice_without_tools(self):
+        body = self._transform({"tool_choice": "none"}, config=OpenAIGPT5Config())
+        assert "tool_choice" not in body
+
+    @pytest.mark.parametrize(
+        "tool_choice",
+        [
+            "none",
+            "auto",
+            "required",
+            {"type": "function", "function": {"name": "get_weather"}},
+        ],
+    )
+    def test_preserves_tool_choice_when_tools_present(self, tool_choice):
+        tools = [
+            {
+                "type": "function",
+                "function": {"name": "get_weather", "parameters": {}},
+            }
+        ]
+        body = self._transform({"tools": tools, "tool_choice": tool_choice})
+        assert body["tool_choice"] == tool_choice
+        assert body["tools"] == tools
+
+    def test_preserves_tool_choice_with_legacy_functions(self):
+        functions = [{"name": "get_weather", "parameters": {}}]
+        body = self._transform({"functions": functions, "tool_choice": "auto"})
+        assert body["tool_choice"] == "auto"
+        assert body["functions"] == functions
+
+    def test_preserves_function_call_without_functions(self):
+        body = self._transform({"function_call": "none"})
+        assert body["function_call"] == "none"
+
+    @pytest.mark.asyncio
+    async def test_async_transform_drops_tool_choice_without_tools(self):
+        body = await self.config.async_transform_request(
+            model="gpt-5.6-sol",
+            messages=self._pi_compact_summarization_messages(),
+            optional_params={"stream": True, "tool_choice": "none"},
+            litellm_params={"custom_llm_provider": "openai", "api_base": None},
+            headers={},
+        )
+        assert "tool_choice" not in body
+
+    @pytest.mark.asyncio
+    async def test_async_transform_preserves_tool_choice_when_tools_present(self):
+        tools = [
+            {
+                "type": "function",
+                "function": {"name": "get_weather", "parameters": {}},
+            }
+        ]
+        body = await self.config.async_transform_request(
+            model="gpt-5.6-sol",
+            messages=self._pi_compact_summarization_messages(),
+            optional_params={"tools": tools, "tool_choice": "auto"},
+            litellm_params={"custom_llm_provider": "openai", "api_base": None},
+            headers={},
+        )
+        assert body["tool_choice"] == "auto"
+        assert body["tools"] == tools
+
+
 class TestToolMessageImageHoisting:
     """transform_request moves tool-message images into a following user message
     (OpenAI-compatible APIs only accept text in role:"tool" messages)."""


### PR DESCRIPTION
## TLDR

Problem this solves:

- Pi coding agent 0.84.0-0.84.3 sends `tool_choice` with no `tools` on /compact
- OpenAI chat completions rejects that combo with a 400
- Router fallbacks resend the identical invalid body, so they 400 too
- Users on OpenAI model groups can never compact their sessions

How it solves it:

- OpenAI chat transform drops `tool_choice` when the request has no usable tools
- No usable tools = `tools` missing or empty, and no legacy `functions` either
- Runs per deployment attempt, so fallback retries are normalized too
- With tools (or `functions`) present, `tool_choice` passes through untouched

## User Flow

Before: a developer running the Pi coding agent (0.84.0-0.84.3) against a LiteLLM proxy with OpenAI models cannot compact their session; every /compact dies with a 400

1. They open the Pi TUI pointed at the proxy and chat normally; each turn is a POST https://litellm-domain/v1/chat/completions that returns 200
2. They type /compact to shrink the session
3. Pi sends the summarization request to POST https://litellm-domain/v1/chat/completions with `"tool_choice": "none"` and no `tools` field
4. OpenAI rejects it and the proxy returns 400: `Invalid value for 'tool_choice': 'tool_choice' is only allowed when 'tools' are specified.`
5. The proxy's fallback model group retries with the identical body and hits the identical 400
6. The TUI shows `Error: Compaction failed: Summarization failed: 400 ...` and the session stays uncompacted (the same /compact through the proxy's /v1/messages Anthropic route works, because Anthropic tolerates the combo)

After: the same /compact succeeds because the proxy drops the unusable `tool_choice` before calling OpenAI

1. They open the Pi TUI pointed at the proxy and chat normally; each turn is a POST https://litellm-domain/v1/chat/completions that returns 200
2. They type /compact to shrink the session
3. Pi sends the same summarization request with `"tool_choice": "none"` and no `tools` field
4. The proxy forwards it to OpenAI without `tool_choice` and streams back a 200 with the summary
5. The TUI reports the session compacted

## Relevant issues

Same coding-harness compatibility boundary as #38792 (Codex tool-schema normalization). Pi fixed this client-side in 0.84.4 (pi-mono commit 6b36eb59, "remove explicit tool choice from compaction calls"; the shape was introduced by 90305d90 and ef8dc738), but the proxy shields the 0.84.0-0.84.3 clients regardless.

## Linear ticket

Resolves LIT-6583

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Setup shared by both legs: each leg ran in its own git worktree with its own venv and .env, booting the proxy with `--num_workers 2` (2 uvicorn worker processes verified per leg) on a random free port, no DB. Proxy config mirrors the report: model group `gpt-5.6-sol` -> `openai/gpt-5.6-sol`, `gpt-5.4-mini` -> `openai/gpt-5.4-mini`, `fallbacks: [{gpt-5.6-sol: [gpt-5.4-mini]}]`, real OpenAI API. Case 1's client is the real Pi coding agent 0.84.3 TUI driven interactively under tmux (models.json custom provider, api `openai-completions`, baseUrl pointing at the leg's proxy; `compaction.keepRecentTokens: 1` so a small session is compactable). Cases 2-4 are curl against the same proxy. Case payloads: case 2 = `{"model": "gpt-5.6-sol", "max_tokens": 64, "messages": [...], "tool_choice": {"type": "none"}}` with no `tools`; case 3 = `{"model": "gpt-5.6-sol", "input": "Say ok", "tool_choice": "none"}` with no `tools`; case 4 = one `get_weather` function tool plus `tool_choice: "auto"`. Before ran on port 32645 (case 4 on a fresh boot of the same before worktree, port 47313, same 2-worker topology); After ran on port 54968.

### Before (4db165379ab1614c2ced0b09dad33c9e65560874)

#### Pi /compact via /v1/chat/completions

1. Launch the Pi TUI on the proxy (provider `litellm`, model `gpt-5.6-sol`), send "Reply with exactly: ok-1" then "Reply with exactly: ok-2"; both turns render 200 replies via `POST /v1/chat/completions`
2. Type `/compact`; observed on screen:

```text
Error: Compaction failed: Summarization failed: 400: {"message":"litellm.BadRequestError: OpenAIException - Invalid value for 'tool_choice': 'tool_choice' is only allowed when 'tools' are specified.. Received Model
Group=gpt-5.6-sol\nAvailable Model Group Fallbacks=['gpt-5.4-mini']\nError doing the fallback: litellm.BadRequestError: OpenAIException - Invalid value for 'tool_choice': 'tool_choice' is only allowed when 'tools' are
specified.No fallback model group found for original model_group=gpt-5.4-mini. Fallbacks=[{'gpt-5.6-sol': ['gpt-5.4-mini']}]. Received Model Group=gpt-5.4-mini\nAvailable Model Group Fallbacks=None\nError doing the
fallback: litellm.BadRequestError: OpenAIException - Invalid value for 'tool_choice': 'tool_choice' is only allowed when 'tools' are specified.No fallback model group found for original model_group=gpt-5.4-mini.
Fallbacks=[{'gpt-5.6-sol': ['gpt-5.4-mini']}]","type":"invalid_request_error","param":"tool_choice","code":"400"}
```

#### /v1/messages with an OpenAI model group

1. `curl -sS -X POST http://127.0.0.1:32645/v1/messages -H "Authorization: Bearer $LITELLM_MASTER_KEY" -H "Content-Type: application/json" -d @case2-request.json`; observed HTTP 200:

```text
{"id":"resp_...","type":"message","role":"assistant","model":"gpt-5.6-sol","content":[{"type":"text","text":"The user said \"OK\" twice."}],"stop_reason":"end_turn"}
HTTP_STATUS:200
```

#### /v1/responses with an OpenAI model group

1. `curl -sS -X POST http://127.0.0.1:32645/v1/responses -H "Authorization: Bearer $LITELLM_MASTER_KEY" -H "Content-Type: application/json" -d @case3-request.json`; observed HTTP 200, `"status": "completed"` (this path tolerates the combination)

#### tools + tool_choice preserved control

1. `curl -sS -X POST http://127.0.0.1:47313/v1/chat/completions -H "Authorization: Bearer $LITELLM_MASTER_KEY" -H "Content-Type: application/json" -d @case4-request.json`; observed HTTP 200, `finish_reason: tool_calls`, tool call `get_weather({"city":"Paris"})`

### After (93a03a9ffd0475aae4dd60f81f713d60eaf6a4df)

#### Pi /compact via /v1/chat/completions

1. Same TUI flow: launch on `gpt-5.6-sol`, two prompts render 200 replies via `POST /v1/chat/completions`
2. Type `/compact`; observed on screen:

```text
 [compaction]
 Compacted from 1,236 tokens (ctrl+o to expand)
```

No error; the session is compacted. Pi's summarization requests still carried `tool_choice` with no `tools` (client shape unchanged); both returned 200.

#### /v1/messages with an OpenAI model group

1. Same curl as Before against port 54968; observed HTTP 200:

```text
{"type": "message", "role": "assistant", "model": "gpt-5.6-sol", "stop_reason": "end_turn", "content": [{"type": "text", "text": "The user said “ok” twice."}]}
```

#### /v1/responses with an OpenAI model group

1. Same curl as Before against port 54968; observed HTTP 200, `"status": "completed"`, output text `ok` (unchanged by this PR)

#### tools + tool_choice preserved control

1. Same curl as Before against port 54968; observed HTTP 200, `finish_reason: tool_calls`, tool call `get_weather({"city":"Paris"})` (no over-stripping)

Observations from the run:

- Pi sends two summarization requests per /compact; both shielded
- /v1/messages with OpenAI models rides Responses API outbound; left alone
- /v1/responses tolerates toolless tool_choice already; left alone

## Type

🐛 Bug Fix

## Caveats (if any)

### Low

- Every provider config inheriting the shared OpenAI chat transform gets the drop
  - with no tools in the request the field selects nothing, so only previously-400ing requests change
- `tool_choice` alongside `tools: []` is dropped; the empty array itself is forwarded unchanged
- Legacy `function_call`/`functions` pair is never touched

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Request-shaping only removes an invalid parameter combination; tool-calling requests with tools or functions are unchanged.
> 
> **Overview**
> **OpenAI chat request normalization** now removes `tool_choice` from the outbound body when the request has no usable tools (`tools` missing or empty) and no legacy `functions`, in both `transform_request` and the base-class path of `async_transform_request`.
> 
> This fixes **400s from OpenAI** (`tool_choice` is only allowed when `tools` are specified) for clients such as Pi agent `/compact` summarization calls that send `tool_choice: "none"` without a `tools` array. **Router fallbacks** benefit because each deployment attempt runs the same transform. When `tools` or `functions` are present, `tool_choice` is unchanged; legacy `function_call` is not stripped.
> 
> Tests cover Pi-style payloads, empty `tools: []`, `OpenAIGPT5Config`, and sync/async preserve-vs-drop behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 93a03a9ffd0475aae4dd60f81f713d60eaf6a4df. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

- [x] 93a03a9ffd0475aae4dd60f81f713d60eaf6a4df passes /live-pr-risk
