### PR TITLE
feat(anthropic): add Claude Fable 5.1

### DIFF
--- a/litellm/llms/anthropic/chat/transformation.py
+++ b/litellm/llms/anthropic/chat/transformation.py
@@ -1466,7 +1466,9 @@ class AnthropicConfig(AnthropicModelInfo, BaseConfig):
                 )
 
                 if _tool_choice is not None:
-                    optional_params["tool_choice"] = _tool_choice
+                    optional_params["tool_choice"] = AnthropicConfig._apply_forced_tool_choice(
+                        model=model, tool_choice=_tool_choice, drop_params=drop_params
+                    )
             elif param == "stream" and value is True:
                 optional_params["stream"] = value
             elif param == "stop" and (isinstance(value, str) or isinstance(value, list)):

--- a/litellm/llms/anthropic/common_utils.py
+++ b/litellm/llms/anthropic/common_utils.py
@@ -28,10 +28,15 @@ from litellm.types.llms.anthropic import (
     ANTHROPIC_OAUTH_TOKEN_PREFIX,
     AllAnthropicToolsValues,
     AnthropicMcpServerTool,
+    AnthropicMessagesToolChoice,
 )
 from litellm.types.llms.openai import AllMessageValues
 from litellm.types.proxy.model_listing import ModelInfoResponse
 
+DROP_FORCED_TOOL_CHOICE_WARNING: Final = (
+    "Downgrading forced tool_choice to 'auto' for model=%s (drop_params=True): this model rejects tool_choice type "
+    "'any'/'tool' with a 400 because thinking is always on and a forced call would skip it."
+)
 DROP_DISABLED_THINKING_WARNING: Final = (
     "Dropping `thinking={'type': 'disabled'}` for model=%s: thinking is always on for this model and cannot be "
     "disabled (the alternative is a provider 400). The model will still think adaptively, its response can contain "
@@ -319,6 +324,35 @@ class AnthropicModelInfo(BaseLLMModelInfo):
                 ),
                 status_code=400,
             )
+
+    @staticmethod
+    def _apply_forced_tool_choice(
+        model: str,
+        tool_choice: AnthropicMessagesToolChoice,
+        drop_params: bool,
+    ) -> AnthropicMessagesToolChoice:
+        """Forward ``tool_choice`` unless the model map flags the model with
+        ``supports_forced_tool_use: false`` (Fable 5.1 / Mythos 5.1 400 on
+        ``any``/``tool``), in which case downgrade to ``auto`` (with
+        drop_params) or raise a clean client-side 400."""
+        if tool_choice["type"] not in ("any", "tool"):
+            return tool_choice
+        if AnthropicModelInfo._get_model_capability(model, "supports_forced_tool_use") is not False:
+            return tool_choice
+        if not (litellm.drop_params or drop_params):
+            raise litellm.utils.UnsupportedParamsError(
+                message=(
+                    f"{model} does not support forced tool use (tool_choice='required' or a named tool). "
+                    "Use tool_choice='auto' and tell the model in the prompt when to call the tool, or set "
+                    "`litellm.drop_params = True` to downgrade to 'auto' automatically."
+                ),
+                status_code=400,
+            )
+        litellm.verbose_logger.warning(DROP_FORCED_TOOL_CHOICE_WARNING, model)
+        disable_parallel: Final = tool_choice.get("disable_parallel_tool_use")
+        if disable_parallel is None:
+            return AnthropicMessagesToolChoice(type="auto")
+        return AnthropicMessagesToolChoice(type="auto", disable_parallel_tool_use=disable_parallel)
 
     @staticmethod
     def _strip_version_suffix(model: str) -> str:

--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -13028,6 +13028,47 @@
         "supports_native_structured_output": true,
         "source": "https://docs.anthropic.com/en/docs/about-claude/models/overview"
     },
+    "claude-fable-5-1": {
+        "deprecation_date": "2027-09-01",
+        "cache_creation_input_token_cost": 1.25e-05,
+        "cache_creation_input_token_cost_above_1hr": 2e-05,
+        "cache_read_input_token_cost": 2.5e-07,
+        "input_cost_per_token": 1e-05,
+        "litellm_provider": "anthropic",
+        "max_input_tokens": 1000000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "chat",
+        "output_cost_per_token": 5e-05,
+        "search_context_cost_per_query": {
+            "search_context_size_high": 0.01,
+            "search_context_size_low": 0.01,
+            "search_context_size_medium": 0.01
+        },
+        "supports_adaptive_thinking": true,
+        "thinking_always_on": true,
+        "supports_mid_conversation_system": true,
+        "supports_assistant_prefill": false,
+        "supports_computer_use": true,
+        "supports_forced_tool_use": false,
+        "supports_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_sampling_params": false,
+        "supports_tool_choice": true,
+        "supports_vision": true,
+        "supports_xhigh_reasoning_effort": true,
+        "supports_max_reasoning_effort": true,
+        "provider_specific_entry": {
+            "us": 1.1
+        },
+        "supports_output_config": true,
+        "prompt_cache_min_tokens": 512,
+        "supports_native_structured_output": true,
+        "source": "https://platform.claude.com/docs/en/models/fable-5-1/overview"
+    },
     "claude-opus-5": {
         "deprecation_date": "2027-07-24",
         "cache_creation_input_token_cost": 6.25e-06,

--- a/litellm/setup_wizard.py
+++ b/litellm/setup_wizard.py
@@ -53,11 +53,12 @@ PROVIDERS: Final[list[dict]] = [
     {
         "id": "anthropic",
         "name": "Anthropic",
-        "description": "Claude Fable 5, Opus 5, Opus 4.8, Opus 4.7, Opus 4.6, Sonnet 5, Sonnet 4.6, Haiku 4.5",
+        "description": "Claude Fable 5.1, Fable 5, Opus 5, Opus 4.8, Opus 4.7, Opus 4.6, Sonnet 5, Sonnet 4.6, Haiku 4.5",
         "env_key": "ANTHROPIC_API_KEY",
         "key_hint": "sk-ant-...",
         "test_model": "claude-haiku-4-5-20251001",
         "models": [
+            "claude-fable-5-1",
             "claude-fable-5",
             "claude-opus-5",
             "claude-sonnet-5",

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -13028,6 +13028,47 @@
         "supports_native_structured_output": true,
         "source": "https://docs.anthropic.com/en/docs/about-claude/models/overview"
     },
+    "claude-fable-5-1": {
+        "deprecation_date": "2027-09-01",
+        "cache_creation_input_token_cost": 1.25e-05,
+        "cache_creation_input_token_cost_above_1hr": 2e-05,
+        "cache_read_input_token_cost": 2.5e-07,
+        "input_cost_per_token": 1e-05,
+        "litellm_provider": "anthropic",
+        "max_input_tokens": 1000000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "chat",
+        "output_cost_per_token": 5e-05,
+        "search_context_cost_per_query": {
+            "search_context_size_high": 0.01,
+            "search_context_size_low": 0.01,
+            "search_context_size_medium": 0.01
+        },
+        "supports_adaptive_thinking": true,
+        "thinking_always_on": true,
+        "supports_mid_conversation_system": true,
+        "supports_assistant_prefill": false,
+        "supports_computer_use": true,
+        "supports_forced_tool_use": false,
+        "supports_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_sampling_params": false,
+        "supports_tool_choice": true,
+        "supports_vision": true,
+        "supports_xhigh_reasoning_effort": true,
+        "supports_max_reasoning_effort": true,
+        "provider_specific_entry": {
+            "us": 1.1
+        },
+        "supports_output_config": true,
+        "prompt_cache_min_tokens": 512,
+        "supports_native_structured_output": true,
+        "source": "https://platform.claude.com/docs/en/models/fable-5-1/overview"
+    },
     "claude-opus-5": {
         "deprecation_date": "2027-07-24",
         "cache_creation_input_token_cost": 6.25e-06,

--- a/model_prices_and_context_window.schema.json
+++ b/model_prices_and_context_window.schema.json
@@ -662,6 +662,9 @@
         "supports_embedding_image_input": {
           "type": "boolean"
         },
+        "supports_forced_tool_use": {
+          "type": "boolean"
+        },
         "supports_function_calling": {
           "type": "boolean"
         },

--- a/tests/llm_translation/reasoning_effort_grid/grid_spec.py
+++ b/tests/llm_translation/reasoning_effort_grid/grid_spec.py
@@ -164,6 +164,13 @@ _CAPS_NONE: FrozenSet[str] = frozenset()
 
 ANTHROPIC_DIRECT_MODELS: Tuple[ModelEntry, ...] = (
     ModelEntry(
+        alias="claude-fable-5-1",
+        model="anthropic/claude-fable-5-1",
+        mode="adaptive",
+        required_env=_ANTHROPIC_REQ,
+        caps=_CAPS_XHIGH_MAX,
+    ),
+    ModelEntry(
         alias="claude-fable-5",
         model="anthropic/claude-fable-5",
         mode="adaptive",

--- a/tests/test_litellm/litellm_core_utils/test_fallback_generalizations.py
+++ b/tests/test_litellm/litellm_core_utils/test_fallback_generalizations.py
@@ -366,7 +366,7 @@ def test_shipped_rules_stack_adaptive_and_mid_conversation_flags(shipped_cost_ma
 def test_shipped_rules_flag_unmapped_fable_as_always_on_thinking(shipped_cost_map):
     """An unmapped Fable/Mythos id picks up ``thinking_always_on`` from the
     claude-always-on-thinking rule, while other unmapped Claudes stay unflagged."""
-    model = "claude-fable-5-1"
+    model = "claude-fable-5-2"
     assert model not in litellm.model_cost
     info = litellm.get_model_info(model, custom_llm_provider="anthropic")
     assert info["thinking_always_on"] is True
@@ -419,7 +419,7 @@ def test_shipped_rules_cover_new_families_like_fable_at_5_plus(shipped_cost_map)
     """Both version gates accept any claude-<family>- id at major 5 or higher, bare
     major or major-minor, so a new family shaped like claude-fable-5 gets adaptive
     thinking and mid-conversation system support without a cost-map entry."""
-    model = "claude-fable-5-1"
+    model = "claude-fable-5-2"
     assert model not in litellm.model_cost
     info = litellm.get_model_info(model, custom_llm_provider="anthropic")
     assert info["supports_mid_conversation_system"] is True

--- a/tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_transformation.py
+++ b/tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_transformation.py
@@ -6176,9 +6176,10 @@ def test_is_anthropic_usage_object_rejects_responses_api_usage():
     [
         # always-on-thinking models reject thinking.type=disabled with a 400
         ("claude-fable-5", True),
+        ("claude-fable-5-1", True),
         ("claude-mythos-5", True),
         # unmapped future family member -> claude-always-on-thinking fallback rule
-        ("claude-fable-5-1", True),
+        ("claude-fable-5-2", True),
         # adaptive-capable models that ACCEPT disabled must keep it verbatim
         ("claude-opus-5", False),
         ("claude-sonnet-5", False),
@@ -6207,3 +6208,99 @@ def test_disabled_thinking_omitted_only_for_always_on_models(
         assert "thinking" not in request
     else:
         assert request["thinking"] == {"type": "disabled"}
+
+
+@pytest.mark.parametrize(
+    "tool_choice",
+    ["required", {"type": "required"}, {"type": "function", "function": {"name": "get_weather"}}],
+)
+def test_forced_tool_choice_raises_clean_error_on_fable_5_1_without_drop_params(tool_choice, monkeypatch):
+    """Fable 5.1 400s on tool_choice type any/tool (thinking is always on and a
+    forced call would skip it); without drop_params the caller gets a clean
+    client-side 400 that explains the workaround, not a provider error."""
+    monkeypatch.setattr(litellm, "drop_params", False)
+    config = AnthropicConfig()
+
+    with pytest.raises(litellm.utils.UnsupportedParamsError, match="forced tool use"):
+        config.map_openai_params(
+            non_default_params={"tool_choice": tool_choice},
+            optional_params={},
+            model="claude-fable-5-1",
+            drop_params=False,
+        )
+
+
+@pytest.mark.parametrize(
+    "tool_choice",
+    ["required", {"type": "required"}, {"type": "function", "function": {"name": "get_weather"}}],
+)
+def test_forced_tool_choice_downgraded_to_auto_on_fable_5_1_with_drop_params(tool_choice):
+    config = AnthropicConfig()
+
+    result = config.map_openai_params(
+        non_default_params={"tool_choice": tool_choice},
+        optional_params={},
+        model="claude-fable-5-1",
+        drop_params=True,
+    )
+
+    assert result["tool_choice"] == {"type": "auto"}
+
+
+def test_forced_tool_choice_downgrade_keeps_parallel_tool_calls_flag():
+    config = AnthropicConfig()
+
+    result = config.map_openai_params(
+        non_default_params={"tool_choice": "required", "parallel_tool_calls": False},
+        optional_params={},
+        model="claude-fable-5-1",
+        drop_params=True,
+    )
+
+    assert result["tool_choice"] == {"type": "auto", "disable_parallel_tool_use": True}
+
+
+@pytest.mark.parametrize("tool_choice, expected_type", [("auto", "auto"), ("none", "none")])
+def test_unforced_tool_choice_forwarded_on_fable_5_1(tool_choice, expected_type, monkeypatch):
+    monkeypatch.setattr(litellm, "drop_params", False)
+    config = AnthropicConfig()
+
+    result = config.map_openai_params(
+        non_default_params={"tool_choice": tool_choice},
+        optional_params={},
+        model="claude-fable-5-1",
+        drop_params=False,
+    )
+
+    assert result["tool_choice"]["type"] == expected_type
+
+
+@pytest.mark.parametrize("model", ["claude-fable-5", "claude-opus-5", "claude-sonnet-5"])
+def test_forced_tool_choice_forwarded_on_models_that_support_it(model, monkeypatch):
+    monkeypatch.setattr(litellm, "drop_params", False)
+    config = AnthropicConfig()
+
+    result = config.map_openai_params(
+        non_default_params={"tool_choice": "required"},
+        optional_params={},
+        model=model,
+        drop_params=True,
+    )
+
+    assert result["tool_choice"] == {"type": "any"}
+
+
+def test_forced_tool_choice_gating_driven_by_model_map_flag(monkeypatch):
+    """The gate must read ``supports_forced_tool_use`` from the model map, not
+    the model name: a flagged entry gates a model whose name says nothing."""
+    monkeypatch.setitem(litellm.model_cost, "claude-zeta-9", {"supports_forced_tool_use": False})
+    config = AnthropicConfig()
+
+    result = config.map_openai_params(
+        non_default_params={"tool_choice": "required"},
+        optional_params={},
+        model="claude-zeta-9",
+        drop_params=True,
+    )
+
+    assert result["tool_choice"] == {"type": "auto"}

--- a/tests/test_litellm/test_claude_fable_5_1_config.py
+++ b/tests/test_litellm/test_claude_fable_5_1_config.py
@@ -1,0 +1,100 @@
+"""
+Validate the Claude Fable 5.1 (Anthropic API) model configuration entry.
+
+Fable 5.1 keeps Fable 5's $10/$50 per MTok pricing and adaptive-only API
+surface, but prices cache reads at 0.025x base input ($0.25/MTok) instead of
+0.1x, and rejects forced tool use (``tool_choice`` type ``any``/``tool``) with
+a 400 because thinking is always on and a forced call would skip it.
+"""
+
+import json
+import os
+
+import litellm
+from litellm.litellm_core_utils.get_model_cost_map import GetModelCostMap
+
+REPO_ROOT = os.path.join(os.path.dirname(__file__), "../..")
+
+
+def _load_root_cost_map() -> dict:
+    json_path = os.path.join(REPO_ROOT, "model_prices_and_context_window.json")
+    with open(json_path) as f:
+        return json.load(f)
+
+
+def test_fable_5_1_pricing_and_capabilities():
+    info = _load_root_cost_map()["claude-fable-5-1"]
+
+    assert info["litellm_provider"] == "anthropic"
+    assert info["mode"] == "chat"
+    assert info["max_input_tokens"] == 1000000
+    assert info["max_output_tokens"] == 128000
+    assert info["max_tokens"] == 128000
+    assert info["deprecation_date"] == "2027-09-01"
+
+    assert info["input_cost_per_token"] == 1e-05
+    assert info["output_cost_per_token"] == 5e-05
+    assert info["cache_creation_input_token_cost"] == 1.25e-05
+    assert info["cache_creation_input_token_cost_above_1hr"] == 2e-05
+    assert info["cache_read_input_token_cost"] == 2.5e-07
+    assert "input_cost_per_token_above_200k_tokens" not in info
+    assert "output_cost_per_token_above_200k_tokens" not in info
+
+    assert info["supports_adaptive_thinking"] is True
+    assert info["thinking_always_on"] is True
+    assert info["supports_mid_conversation_system"] is True
+    assert info["supports_assistant_prefill"] is False
+    assert info["supports_sampling_params"] is False
+    assert info["supports_forced_tool_use"] is False
+    assert info["supports_function_calling"] is True
+    assert info["supports_tool_choice"] is True
+    assert info["supports_native_structured_output"] is True
+    assert info["supports_prompt_caching"] is True
+    assert info["prompt_cache_min_tokens"] == 512
+    assert info["supports_reasoning"] is True
+    assert info["supports_vision"] is True
+    assert info["supports_xhigh_reasoning_effort"] is True
+    assert info["supports_max_reasoning_effort"] is True
+    assert info["provider_specific_entry"] == {"us": 1.1}
+    assert "supports_speed" not in info
+
+
+def test_fable_5_1_cache_read_is_a_quarter_of_fable_5():
+    cost_map = _load_root_cost_map()
+    fable_5 = cost_map["claude-fable-5"]
+    fable_5_1 = cost_map["claude-fable-5-1"]
+    assert fable_5_1["cache_read_input_token_cost"] == fable_5["cache_read_input_token_cost"] / 4
+    for key in (
+        "input_cost_per_token",
+        "output_cost_per_token",
+        "cache_creation_input_token_cost",
+        "cache_creation_input_token_cost_above_1hr",
+    ):
+        assert fable_5_1[key] == fable_5[key], key
+
+
+def test_fable_5_1_present_in_bundled_backup():
+    backup = GetModelCostMap.load_local_model_cost_map()
+    root = _load_root_cost_map()
+    assert backup["claude-fable-5-1"] == root["claude-fable-5-1"]
+
+
+def test_fable_5_1_cost_uses_cheaper_cache_read(local_model_cost_map):
+    prompt_cost, completion_cost = litellm.cost_per_token(
+        model="claude-fable-5-1",
+        custom_llm_provider="anthropic",
+        prompt_tokens=1_000_000,
+        completion_tokens=0,
+        cache_read_input_tokens=1_000_000,
+    )
+    assert round(prompt_cost, 6) == 0.25
+    assert completion_cost == 0
+
+
+def test_fable_5_1_provider_resolves_via_model_info(local_model_cost_map):
+    info = litellm.get_model_info(model="claude-fable-5-1")
+    assert info["litellm_provider"] == "anthropic"
+    assert info["max_input_tokens"] == 1000000
+    assert info["max_output_tokens"] == 128000
+    assert info["supports_adaptive_thinking"] is True
+    assert info["thinking_always_on"] is True

--- a/tests/test_litellm/test_utils.py
+++ b/tests/test_litellm/test_utils.py
@@ -1005,6 +1005,7 @@ def test_aaamodel_prices_and_context_window_json_is_valid():
                 "gemini_native_audio": {"type": "boolean"},
                 "gemini_audio_only_live": {"type": "boolean"},
                 "supports_embedding_image_input": {"type": "boolean"},
+                "supports_forced_tool_use": {"type": "boolean"},
                 "supports_function_calling": {"type": "boolean"},
                 "supports_image_input": {"type": "boolean"},
                 "supports_nova_canvas_image_edit": {"type": "boolean"},


### PR DESCRIPTION
## TLDR

Problem this solves:

- Claude Fable 5.1 (`claude-fable-5-1`) is unknown to LiteLLM
- Requests with `reasoning_effort` get rejected with a 400
- Cached and uncached requests are billed at $0
- Forced tool calls get an opaque provider 400

How it solves it:

- Adds the Anthropic cost map entry with Fable 5.1 pricing and capabilities
- Cache reads priced at 0.025x input, a quarter of Fable 5
- New `supports_forced_tool_use: false` flag gates `tool_choice` any/tool
- Without `drop_params` that is a clear client-side 400, with it a downgrade to `auto`
- Lists the model in the setup wizard and reasoning-effort grid
- Registers the new flag in the cost map JSON schema

## User Flow

Before: a developer pointing their app at Fable 5.1 gets 400s and $0 spend

1. They add `anthropic/claude-fable-5-1` to the proxy model list and send POST http://localhost:4000/v1/chat/completions with `"reasoning_effort": "low"`
2. They get HTTP 400 saying `anthropic does not support parameters: ['reasoning_effort']`
3. They drop `reasoning_effort` and resend with a cached system prompt: HTTP 200, but `x-litellm-response-cost` is 0 and https://litellm-domain/ui/?page=logs shows the request at $0 spend
4. They send the same route with tools and `"tool_choice": "required"`: HTTP 400 quoting the raw provider error `tool_choice: type "tool" and "any" are not supported for this model`

After: the same requests are priced and the forced tool call fails clearly or downgrades

1. They add `anthropic/claude-fable-5-1` to the proxy model list and send POST http://localhost:4000/v1/chat/completions with `"reasoning_effort": "low"`
2. They get HTTP 200 with the answer and `x-litellm-response-cost` set (input $10/MTok, output $50/MTok)
3. They resend with a cached system prompt: the first call bills the cache write at $12.50/MTok and the second bills the cache read at $0.25/MTok, and the logs page shows real spend
4. They send the same route with tools and `"tool_choice": "required"`: HTTP 400 saying `claude-fable-5-1 does not support forced tool use` and pointing them at `tool_choice="auto"` or `drop_params`
5. On a deployment with `drop_params: true`, the same request gets HTTP 200 with a `get_weather` tool call and `finish_reason: tool_calls`

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Shared setup, real Anthropic API calls through a local proxy:

```yaml
# fable_5_1_config.yaml
model_list:
  - model_name: claude-fable-5-1
    litellm_params:
      model: anthropic/claude-fable-5-1
      api_key: os.environ/ANTHROPIC_API_KEY
  - model_name: claude-fable-5-1-drop-params
    litellm_params:
      model: anthropic/claude-fable-5-1
      api_key: os.environ/ANTHROPIC_API_KEY
      drop_params: true

general_settings:
  master_key: sk-1234
```

```bash
python litellm/proxy/proxy_cli.py --config fable_5_1_config.yaml --port 4000
```

`cache_body.json` used by the prompt caching case (system prompt is 89 "Rule N: ..." sentences, about 3.4k tokens, prefixed with a fresh nonce per run so the first call is a cache write):

```json
{
  "model": "claude-fable-5-1",
  "max_tokens": 50,
  "messages": [
    {"role": "system", "content": [{"type": "text", "text": "Session 3b46abb9. Rule 1: ... Rule 89: ...", "cache_control": {"type": "ephemeral"}}]},
    {"role": "user", "content": "Reply with the single word OK."}
  ]
}
```

### Before (f2a4172c89)

#### Chat completion with reasoning_effort

1. Command:
   ```bash
   curl -s http://localhost:4000/v1/chat/completions -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
     -d '{"model":"claude-fable-5-1","messages":[{"role":"user","content":"In one sentence, what model are you?"}],"reasoning_effort":"low","max_tokens":200}' -D -
   ```
2. Output (HTTP 400):
   ```
   {"error": {"message": "litellm.UnsupportedParamsError: anthropic does not support parameters: ['reasoning_effort'], for model=claude-fable-5-1. To drop these, set `litellm.drop_params=True` or for proxy:\n\n`litellm_settings:\n drop_params: true`\n. \n If you want to use these params dynamically send allowed_openai_params=['reasoning_effort'] in your request.. Received Model Group=claude-fable-5-1\nAvailable Model Group Fallbacks=None", "type": "None", "param": null, "code": "400"}}
   x-litellm-response-cost: 0
   ```

#### Forced tool_choice without drop_params

1. Command:
   ```bash
   curl -s -w "\nHTTP %{http_code}\n" http://localhost:4000/v1/chat/completions -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
     -d '{"model":"claude-fable-5-1","messages":[{"role":"user","content":"What is the weather in Paris?"}],"tools":[{"type":"function","function":{"name":"get_weather","description":"Get weather for a city","parameters":{"type":"object","properties":{"city":{"type":"string"}},"required":["city"]}}}],"tool_choice":"required","max_tokens":300}'
   ```
2. Output, the raw provider error after a round trip to Anthropic:
   ```
   {"error":{"message":"litellm.BadRequestError: AnthropicException - {\"type\":\"error\",\"error\":{\"type\":\"invalid_request_error\",\"message\":\"tool_choice: type \\\"tool\\\" and \\\"any\\\" are not supported for this model.\"},\"request_id\":\"req_011CedBqNQu6djk3P3sSGdTe\"}. Received Model Group=claude-fable-5-1\nAvailable Model Group Fallbacks=None","type":null,"param":null,"code":"400"}}
   HTTP 400
   ```

#### Forced tool_choice with drop_params

1. Command:
   ```bash
   curl -s -w "\nHTTP %{http_code}\n" http://localhost:4000/v1/chat/completions -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
     -d '{"model":"claude-fable-5-1-drop-params","messages":[{"role":"user","content":"Use the get_weather tool to answer: what is the weather in Paris?"}],"tools":[{"type":"function","function":{"name":"get_weather","description":"Get weather for a city","parameters":{"type":"object","properties":{"city":{"type":"string"}},"required":["city"]}}}],"tool_choice":"required","reasoning_effort":"low","max_tokens":300}'
   ```
2. Output, `drop_params` does not help because nothing knows the param is unsupported:
   ```
   {"error":{"message":"litellm.BadRequestError: AnthropicException - {\"type\":\"error\",\"error\":{\"type\":\"invalid_request_error\",\"message\":\"tool_choice: type \\\"tool\\\" and \\\"any\\\" are not supported for this model.\"},\"request_id\":\"req_011CedBqb1RrGf5hJumoFXwZ\"}. Received Model Group=claude-fable-5-1-drop-params\nAvailable Model Group Fallbacks=None","type":null,"param":null,"code":"400"}}
   HTTP 400
   ```

#### Prompt caching cost

1. Command, run twice:
   ```bash
   for n in 1 2; do curl -s http://localhost:4000/v1/chat/completions -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" -d @cache_body.json -D headers_$n.txt | jq -c '{content: .choices[0].message.content, usage}'; grep -i "^x-litellm-response-cost" headers_$n.txt; done
   ```
2. Output for request 1 (cache write, billed at $0):
   ```
   {"content": "OK", "prompt_tokens": 3401, "cache_creation_input_tokens": 3385, "cache_read_input_tokens": 0}
   x-litellm-response-cost-input: 0.0
   x-litellm-response-cost-output: 0.0
   ```
3. Output for request 2 (cache read, billed at $0):
   ```
   {"content": "OK", "prompt_tokens": 3401, "cache_creation_input_tokens": 0, "cache_read_input_tokens": 3385}
   x-litellm-response-cost-input: 0.0
   x-litellm-response-cost-output: 0.0
   ```

### After (40cd92de16)

#### Chat completion with reasoning_effort

1. Command:
   ```bash
   curl -s http://localhost:4000/v1/chat/completions -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
     -d '{"model":"claude-fable-5-1","messages":[{"role":"user","content":"In one sentence, what model are you?"}],"reasoning_effort":"low","max_tokens":200}' -D -
   ```
2. Output (HTTP 200), 19 x $10/MTok + 21 x $50/MTok:
   ```
   {"model": "claude-fable-5-1", "content": "I'm Claude, an AI model made by Anthropic.", "prompt_tokens": 19, "completion_tokens": 21}
   x-litellm-response-cost: 0.0012400000000000002
   x-litellm-response-cost-input: 0.00019
   x-litellm-response-cost-output: 0.0010500000000000002
   ```

#### Forced tool_choice without drop_params

1. Command:
   ```bash
   curl -s -w "\nHTTP %{http_code}\n" http://localhost:4000/v1/chat/completions -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
     -d '{"model":"claude-fable-5-1","messages":[{"role":"user","content":"What is the weather in Paris?"}],"tools":[{"type":"function","function":{"name":"get_weather","description":"Get weather for a city","parameters":{"type":"object","properties":{"city":{"type":"string"}},"required":["city"]}}}],"tool_choice":"required","max_tokens":300}'
   ```
2. Output, rejected client-side before any provider call:
   ```
   {"error":{"message":"litellm.UnsupportedParamsError: claude-fable-5-1 does not support forced tool use (tool_choice='required' or a named tool). Use tool_choice='auto' and tell the model in the prompt when to call the tool, or set `litellm.drop_params = True` to downgrade to 'auto' automatically.. Received Model Group=claude-fable-5-1\nAvailable Model Group Fallbacks=None","type":"None","param":null,"code":"400"}}
   HTTP 400
   ```

#### Forced tool_choice with drop_params

1. Command:
   ```bash
   curl -s -w "\nHTTP %{http_code}\n" http://localhost:4000/v1/chat/completions -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
     -d '{"model":"claude-fable-5-1-drop-params","messages":[{"role":"user","content":"Use the get_weather tool to answer: what is the weather in Paris?"}],"tools":[{"type":"function","function":{"name":"get_weather","description":"Get weather for a city","parameters":{"type":"object","properties":{"city":{"type":"string"}},"required":["city"]}}}],"tool_choice":"required","reasoning_effort":"low","max_tokens":300}'
   ```
2. Output, `tool_choice` downgraded to `auto` and the model still calls the tool:
   ```
   {"finish_reason": "tool_calls", "tool_calls": [{"index": 0, "caller": {"type": "direct"}, "function": {"arguments": "{\"city\": \"Paris\"}", "name": "get_weather"}, "id": "toolu_019Ysxs7ab6e1axvBYUEkqoa", "type": "function"}], "prompt_tokens": 386, "completion_tokens": 50}
   HTTP 200
   ```

#### Prompt caching cost

1. Command, run twice:
   ```bash
   for n in 1 2; do curl -s http://localhost:4000/v1/chat/completions -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" -d @cache_body.json -D headers_$n.txt | jq -c '{content: .choices[0].message.content, usage}'; grep -i "^x-litellm-response-cost" headers_$n.txt; done
   ```
2. Output for request 1, cache write: 3395 x $12.50/MTok = 0.0424375, plus 16 uncached input and 4 output tokens:
   ```
   {"content": "OK", "prompt_tokens": 3411, "cache_creation_input_tokens": 3395, "cache_read_input_tokens": 0}
   x-litellm-response-cost: 0.0427975
   x-litellm-response-cost-input: 0.00016000000000000042
   x-litellm-response-cost-output: 0.0002
   ```
3. Output for request 2, cache read: 3395 x $0.25/MTok = 0.00084875, plus the same 16 input and 4 output tokens:
   ```
   {"content": "OK", "prompt_tokens": 3411, "cache_creation_input_tokens": 0, "cache_read_input_tokens": 3395}
   x-litellm-response-cost: 0.0012087500000000002
   x-litellm-response-cost-input: 0.0001600000000000001
   x-litellm-response-cost-output: 0.0002
   ```

## Type

🆕 New Feature

## Caveats (if any)

### Medium

- The forced tool_choice guard covers `/v1/chat/completions` only
  - Native `/v1/messages` requests with `tool_choice` any/tool still get the provider's own 400

### Low

- Anthropic direct only: Bedrock, Vertex AI and Azure AI entries come in a follow-up
- `supports_forced_tool_use` is a new cost map flag, only Fable 5.1 sets it so far
- Tests that needed an unmapped Fable id now use `claude-fable-5-2` as the placeholder

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
