### PR TITLE
fix(s3): bound s3 object keys and download filenames for long Responses API ids

### DIFF
--- a/litellm/constants.py
+++ b/litellm/constants.py
@@ -13,6 +13,17 @@ DEFAULT_BATCH_SIZE: Final = int(os.getenv("DEFAULT_BATCH_SIZE", 512))
 DEFAULT_FLUSH_INTERVAL_SECONDS: Final = int(os.getenv("DEFAULT_FLUSH_INTERVAL_SECONDS", 5))
 DEFAULT_S3_FLUSH_INTERVAL_SECONDS: Final = int(os.getenv("DEFAULT_S3_FLUSH_INTERVAL_SECONDS", 10))
 DEFAULT_S3_BATCH_SIZE: Final = int(os.getenv("DEFAULT_S3_BATCH_SIZE", 512))
+# S3 caps an object key at 1024 UTF-8 bytes, prefixes and delimiters included.
+# https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-keys.html
+MAX_S3_OBJECT_KEY_BYTES: Final = 1024
+# Bytes of the original file name kept ahead of the hash when a key has to be bounded.
+# Wide enough for the `time-HH-MM-SS-ffffff` stamp plus the head of the response id.
+S3_BOUNDED_OBJECT_KEY_HEAD_BYTES: Final = 64
+# Hex chars of the prefix digest appended when a configured s3 path/alias prefix is trimmed.
+S3_PREFIX_DIGEST_CHARS: Final = 16
+# S3 caps a request's combined metadata headers at 2048 bytes, so the Content-Disposition
+# filename gets a budget that leaves room for the other headers the loggers send.
+MAX_S3_OBJECT_DOWNLOAD_FILENAME_BYTES: Final = 1024
 DEFAULT_SQS_FLUSH_INTERVAL_SECONDS: Final = int(os.getenv("DEFAULT_SQS_FLUSH_INTERVAL_SECONDS", 10))
 DEFAULT_NUM_WORKERS_LITELLM_PROXY: Final = int(os.getenv("DEFAULT_NUM_WORKERS_LITELLM_PROXY", 1))
 DYNAMIC_RATE_LIMIT_ERROR_THRESHOLD_PER_MINUTE = int(os.getenv("DYNAMIC_RATE_LIMIT_ERROR_THRESHOLD_PER_MINUTE", 1))

--- a/litellm/constants.py
+++ b/litellm/constants.py
@@ -21,8 +21,9 @@ MAX_S3_OBJECT_KEY_BYTES: Final = 1024
 S3_BOUNDED_OBJECT_KEY_HEAD_BYTES: Final = 64
 # Hex chars of the prefix digest appended when a configured s3 path/alias prefix is trimmed.
 S3_PREFIX_DIGEST_CHARS: Final = 16
-# S3 caps a request's combined metadata headers at 2048 bytes, so the Content-Disposition
-# filename gets a budget that leaves room for the other headers the loggers send.
+# S3 caps a request's combined metadata headers at 2048 bytes and Content-Disposition counts
+# against it, so half the cap goes to the filename and the rest covers the signing, content and
+# encryption headers the loggers send alongside it.
 MAX_S3_OBJECT_DOWNLOAD_FILENAME_BYTES: Final = 1024
 DEFAULT_SQS_FLUSH_INTERVAL_SECONDS: Final = int(os.getenv("DEFAULT_SQS_FLUSH_INTERVAL_SECONDS", 10))
 DEFAULT_NUM_WORKERS_LITELLM_PROXY: Final = int(os.getenv("DEFAULT_NUM_WORKERS_LITELLM_PROXY", 1))

--- a/litellm/constants.py
+++ b/litellm/constants.py
@@ -13,17 +13,11 @@ DEFAULT_BATCH_SIZE: Final = int(os.getenv("DEFAULT_BATCH_SIZE", 512))
 DEFAULT_FLUSH_INTERVAL_SECONDS: Final = int(os.getenv("DEFAULT_FLUSH_INTERVAL_SECONDS", 5))
 DEFAULT_S3_FLUSH_INTERVAL_SECONDS: Final = int(os.getenv("DEFAULT_S3_FLUSH_INTERVAL_SECONDS", 10))
 DEFAULT_S3_BATCH_SIZE: Final = int(os.getenv("DEFAULT_S3_BATCH_SIZE", 512))
-# S3 caps an object key at 1024 UTF-8 bytes, prefixes and delimiters included.
 # https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-keys.html
 MAX_S3_OBJECT_KEY_BYTES: Final = 1024
-# Bytes of the original file name kept ahead of the hash when a key has to be bounded.
-# Wide enough for the `time-HH-MM-SS-ffffff` stamp plus the head of the response id.
 S3_BOUNDED_OBJECT_KEY_HEAD_BYTES: Final = 64
-# Hex chars of the prefix digest appended when a configured s3 path/alias prefix is trimmed.
 S3_PREFIX_DIGEST_CHARS: Final = 16
-# S3 caps a request's combined metadata headers at 2048 bytes and Content-Disposition counts
-# against it, so half the cap goes to the filename and the rest covers the signing, content and
-# encryption headers the loggers send alongside it.
+# s3 allows 2048 bytes of combined metadata headers, which Content-Disposition counts against
 MAX_S3_OBJECT_DOWNLOAD_FILENAME_BYTES: Final = 1024
 DEFAULT_SQS_FLUSH_INTERVAL_SECONDS: Final = int(os.getenv("DEFAULT_SQS_FLUSH_INTERVAL_SECONDS", 10))
 DEFAULT_NUM_WORKERS_LITELLM_PROXY: Final = int(os.getenv("DEFAULT_NUM_WORKERS_LITELLM_PROXY", 1))

--- a/litellm/integrations/s3.py
+++ b/litellm/integrations/s3.py
@@ -1,11 +1,18 @@
 #### What this does ####
 #    On success + failure, log events to Supabase
 
+import hashlib
 from datetime import datetime
 from typing import Final, cast
 
 import litellm
 from litellm._logging import print_verbose, verbose_logger
+from litellm.constants import (
+    MAX_S3_OBJECT_DOWNLOAD_FILENAME_BYTES,
+    MAX_S3_OBJECT_KEY_BYTES,
+    S3_BOUNDED_OBJECT_KEY_HEAD_BYTES,
+    S3_PREFIX_DIGEST_CHARS,
+)
 from litellm.types.utils import StandardLoggingPayload
 
 
@@ -133,9 +140,7 @@ class S3Logger:
                 s3_file_name,
             )
 
-            s3_object_download_filename: Final = (
-                "time-" + start_time.strftime("%Y-%m-%dT%H-%M-%S-%f") + "_" + payload["id"] + ".json"
-            )
+            s3_object_download_filename: Final = get_s3_object_download_filename(start_time, payload["id"])
 
             from litellm.litellm_core_utils.safe_json_dumps import safe_dumps
 
@@ -198,6 +203,41 @@ def resolve_sse_params(
     return algorithm, valid_key_id
 
 
+def _truncate_to_utf8_bytes(value: str, max_bytes: int) -> str:
+    """Trim `value` so its UTF-8 encoding fits `max_bytes`, never splitting a character."""
+    if max_bytes <= 0:
+        return ""
+    encoded: Final = value.encode("utf-8")
+    if len(encoded) <= max_bytes:
+        return value
+    return encoded[:max_bytes].decode("utf-8", errors="ignore")
+
+
+def get_s3_object_download_filename(start_time: datetime, response_id: str) -> str:
+    """Content-Disposition filename, bounded because S3 caps a request's metadata headers at 2048 bytes."""
+    file_name: Final = f"time-{start_time.strftime('%Y-%m-%dT%H-%M-%S-%f')}_{response_id}"
+    budget: Final = MAX_S3_OBJECT_DOWNLOAD_FILENAME_BYTES - len(b".json")
+    if len(file_name.encode("utf-8")) <= budget:
+        return file_name + ".json"
+    return _bounded_s3_file_name(file_name, file_name) + ".json"
+
+
+def _bounded_s3_file_name(s3_file_name: str, sanitized_s3_file_name: str) -> str:
+    """Readable head of the file name plus the sha256 of the whole name, so shortening stays collision free."""
+    digest: Final = hashlib.sha256(s3_file_name.encode("utf-8")).hexdigest()
+    head: Final = _truncate_to_utf8_bytes(sanitized_s3_file_name, S3_BOUNDED_OBJECT_KEY_HEAD_BYTES)
+    return f"{head}_{digest}" if head else digest
+
+
+def _bounded_s3_prefix(configured_prefix: str, max_bytes: int) -> str:
+    """Whole leading path segments that fit, then a digest segment of the full prefix."""
+    digest_segment: Final = hashlib.sha256(configured_prefix.encode("utf-8")).hexdigest()[:S3_PREFIX_DIGEST_CHARS] + "/"
+    if max_bytes < len(digest_segment):
+        return ""
+    head: Final = _truncate_to_utf8_bytes(configured_prefix, max_bytes - len(digest_segment))
+    return head[: head.rfind("/") + 1] + digest_segment
+
+
 def get_s3_object_key(
     s3_path: str,
     prefix: str,
@@ -205,12 +245,21 @@ def get_s3_object_key(
     s3_file_name: str,
 ) -> str:
     sanitized_s3_file_name: Final = s3_file_name.replace("/", "_")
-    s3_object_key = (
-        (s3_path.rstrip("/") + "/" if s3_path else "")
-        + prefix
-        + start_time.strftime("%Y-%m-%d")
-        + "/"
-        + sanitized_s3_file_name
-    )  # we need the s3 key to include the time, so we log cache hits too
-    s3_object_key += ".json"
-    return s3_object_key
+    configured_prefix: Final = (s3_path.rstrip("/") + "/" if s3_path else "") + prefix
+    date_segment: Final = start_time.strftime("%Y-%m-%d") + "/"
+    # we need the s3 key to include the time, so we log cache hits too
+    s3_object_key: Final = configured_prefix + date_segment + sanitized_s3_file_name + ".json"
+    if len(s3_object_key.encode("utf-8")) <= MAX_S3_OBJECT_KEY_BYTES:
+        return s3_object_key
+
+    # S3 rejects an over-limit key with a 400, dropping the record, so bound it while keeping the
+    # `<prefix>/<date>/<file>` layout that lifecycle rules and prefix-scoped IAM policies match on.
+    bounded_file_name: Final = _bounded_s3_file_name(s3_file_name, sanitized_s3_file_name)
+    reserved_bytes: Final = len(bounded_file_name.encode("utf-8")) + len(b".json") + len(date_segment.encode("utf-8"))
+    prefix_budget: Final = MAX_S3_OBJECT_KEY_BYTES - reserved_bytes
+    bounded_prefix: Final = (
+        configured_prefix
+        if len(configured_prefix.encode("utf-8")) <= prefix_budget
+        else _bounded_s3_prefix(configured_prefix, prefix_budget)
+    )
+    return bounded_prefix + date_segment + bounded_file_name + ".json"

--- a/litellm/integrations/s3.py
+++ b/litellm/integrations/s3.py
@@ -203,6 +203,9 @@ def resolve_sse_params(
     return algorithm, valid_key_id
 
 
+S3_MIN_BOUNDED_FILE_NAME_BYTES: Final = 64
+
+
 def _truncate_to_utf8_bytes(value: str, max_bytes: int) -> str:
     """Trim `value` so its UTF-8 encoding fits `max_bytes`, never splitting a character."""
     if max_bytes <= 0:
@@ -215,27 +218,30 @@ def _truncate_to_utf8_bytes(value: str, max_bytes: int) -> str:
 
 def get_s3_object_download_filename(start_time: datetime, response_id: str) -> str:
     """Content-Disposition filename, bounded because S3 caps a request's metadata headers at 2048 bytes."""
+    sanitized_response_id: Final = response_id.replace("/", "_").replace('"', "_")
     file_name: Final = f"time-{start_time.strftime('%Y-%m-%dT%H-%M-%S-%f')}_{response_id}"
+    sanitized_file_name: Final = f"time-{start_time.strftime('%Y-%m-%dT%H-%M-%S-%f')}_{sanitized_response_id}"
     budget: Final = MAX_S3_OBJECT_DOWNLOAD_FILENAME_BYTES - len(b".json")
-    if len(file_name.encode("utf-8")) <= budget:
-        return file_name + ".json"
-    return _bounded_s3_file_name(file_name, file_name) + ".json"
+    if len(sanitized_file_name.encode("utf-8")) <= budget:
+        return sanitized_file_name + ".json"
+    return _bounded_s3_file_name(file_name, sanitized_file_name, budget) + ".json"
 
 
-def _bounded_s3_file_name(s3_file_name: str, sanitized_s3_file_name: str) -> str:
-    """Readable head of the file name plus the sha256 of the whole name, so shortening stays collision free."""
+def _bounded_s3_file_name(s3_file_name: str, sanitized_s3_file_name: str, max_bytes: int) -> str:
+    """As much of the file name as `max_bytes` allows, then the sha256 of the whole name."""
     digest: Final = hashlib.sha256(s3_file_name.encode("utf-8")).hexdigest()
-    head: Final = _truncate_to_utf8_bytes(sanitized_s3_file_name, S3_BOUNDED_OBJECT_KEY_HEAD_BYTES)
+    head_budget: Final = min(S3_BOUNDED_OBJECT_KEY_HEAD_BYTES, max_bytes - len(digest) - 1)
+    head: Final = _truncate_to_utf8_bytes(sanitized_s3_file_name, head_budget)
     return f"{head}_{digest}" if head else digest
 
 
 def _bounded_s3_prefix(configured_prefix: str, max_bytes: int) -> str:
-    """Whole leading path segments that fit, then a digest segment of the full prefix."""
+    """As much of the configured prefix as fits, then a digest segment naming the full prefix."""
     digest_segment: Final = hashlib.sha256(configured_prefix.encode("utf-8")).hexdigest()[:S3_PREFIX_DIGEST_CHARS] + "/"
     if max_bytes < len(digest_segment):
         return ""
-    head: Final = _truncate_to_utf8_bytes(configured_prefix, max_bytes - len(digest_segment))
-    return head[: head.rfind("/") + 1] + digest_segment
+    head: Final = _truncate_to_utf8_bytes(configured_prefix, max_bytes - len(digest_segment) - 1).rstrip("/")
+    return f"{head}/{digest_segment}" if head else digest_segment
 
 
 def get_s3_object_key(
@@ -252,14 +258,17 @@ def get_s3_object_key(
     if len(s3_object_key.encode("utf-8")) <= MAX_S3_OBJECT_KEY_BYTES:
         return s3_object_key
 
-    # S3 rejects an over-limit key with a 400, dropping the record, so bound it while keeping the
-    # `<prefix>/<date>/<file>` layout that lifecycle rules and prefix-scoped IAM policies match on.
-    bounded_file_name: Final = _bounded_s3_file_name(s3_file_name, sanitized_s3_file_name)
-    reserved_bytes: Final = len(bounded_file_name.encode("utf-8")) + len(b".json") + len(date_segment.encode("utf-8"))
-    prefix_budget: Final = MAX_S3_OBJECT_KEY_BYTES - reserved_bytes
-    bounded_prefix: Final = (
-        configured_prefix
-        if len(configured_prefix.encode("utf-8")) <= prefix_budget
-        else _bounded_s3_prefix(configured_prefix, prefix_budget)
+    # S3 rejects an over-limit key with a 400 and the record is dropped. Spend the whole budget:
+    # shorten the response id first, and only trim the operator's configured prefix if that is the
+    # part that does not fit, so lifecycle rules and prefix-scoped IAM policies keep matching.
+    budget: Final = MAX_S3_OBJECT_KEY_BYTES - len(date_segment.encode("utf-8")) - len(b".json")
+    prefix_bytes: Final = len(configured_prefix.encode("utf-8"))
+    if prefix_bytes + S3_MIN_BOUNDED_FILE_NAME_BYTES <= budget:
+        bounded_file_name: Final = _bounded_s3_file_name(s3_file_name, sanitized_s3_file_name, budget - prefix_bytes)
+        return configured_prefix + date_segment + bounded_file_name + ".json"
+
+    shortest_file_name: Final = _bounded_s3_file_name(
+        s3_file_name, sanitized_s3_file_name, S3_MIN_BOUNDED_FILE_NAME_BYTES
     )
-    return bounded_prefix + date_segment + bounded_file_name + ".json"
+    bounded_prefix: Final = _bounded_s3_prefix(configured_prefix, budget - len(shortest_file_name.encode("utf-8")))
+    return bounded_prefix + date_segment + shortest_file_name + ".json"

--- a/litellm/integrations/s3.py
+++ b/litellm/integrations/s3.py
@@ -217,7 +217,7 @@ def _truncate_to_utf8_bytes(value: str, max_bytes: int) -> str:
 
 
 def get_s3_object_download_filename(start_time: datetime, response_id: str) -> str:
-    """Content-Disposition filename, bounded because S3 caps a request's metadata headers at 2048 bytes."""
+    """Content-Disposition filename for the uploaded object, bounded to the metadata header cap."""
     sanitized_response_id: Final = response_id.replace("/", "_").replace('"', "_")
     file_name: Final = f"time-{start_time.strftime('%Y-%m-%dT%H-%M-%S-%f')}_{response_id}"
     sanitized_file_name: Final = f"time-{start_time.strftime('%Y-%m-%dT%H-%M-%S-%f')}_{sanitized_response_id}"
@@ -258,9 +258,8 @@ def get_s3_object_key(
     if len(s3_object_key.encode("utf-8")) <= MAX_S3_OBJECT_KEY_BYTES:
         return s3_object_key
 
-    # S3 rejects an over-limit key with a 400 and the record is dropped. Spend the whole budget:
-    # shorten the response id first, and only trim the operator's configured prefix if that is the
-    # part that does not fit, so lifecycle rules and prefix-scoped IAM policies keep matching.
+    # shorten the response id first and only trim the configured prefix if that is what does not
+    # fit, so prefix scoped IAM policies and lifecycle rules keep matching
     budget: Final = MAX_S3_OBJECT_KEY_BYTES - len(date_segment.encode("utf-8")) - len(b".json")
     prefix_bytes: Final = len(configured_prefix.encode("utf-8"))
     if prefix_bytes + S3_MIN_BOUNDED_FILE_NAME_BYTES <= budget:

--- a/litellm/integrations/s3_v2.py
+++ b/litellm/integrations/s3_v2.py
@@ -263,11 +263,11 @@ class S3Logger(CustomBatchLogger, BaseAWSLLM):
             now: Final = datetime.now(timezone.utc)
             audit_log_id: Final = audit_log.get("id", "unknown")
 
-            s3_path = cast(str | None, self.s3_path) or ""
-            s3_path = s3_path.rstrip("/") + "/" if s3_path else ""
-
-            s3_object_key: Final = (
-                f"{s3_path}audit_logs/{now.strftime('%Y-%m-%d')}/{now.strftime('%H-%M-%S')}_{audit_log_id}.json"
+            s3_object_key: Final = get_s3_object_key(
+                cast(str | None, self.s3_path) or "",
+                "audit_logs/",
+                now,
+                f"{now.strftime('%H-%M-%S')}_{audit_log_id}",
             )
 
             element: Final = s3BatchLoggingElement(

--- a/litellm/integrations/s3_v2.py
+++ b/litellm/integrations/s3_v2.py
@@ -16,7 +16,11 @@ from urllib.parse import quote
 import litellm
 from litellm._logging import print_verbose, verbose_logger
 from litellm.constants import DEFAULT_S3_BATCH_SIZE, DEFAULT_S3_FLUSH_INTERVAL_SECONDS
-from litellm.integrations.s3 import get_s3_object_key, resolve_sse_params
+from litellm.integrations.s3 import (
+    get_s3_object_download_filename,
+    get_s3_object_key,
+    resolve_sse_params,
+)
 from litellm.litellm_core_utils.aws_partition import get_aws_dns_suffix
 from litellm.litellm_core_utils.safe_json_dumps import safe_dumps
 from litellm.litellm_core_utils.sensitive_data_masker import SensitiveDataMasker
@@ -463,9 +467,7 @@ class S3Logger(CustomBatchLogger, BaseAWSLLM):
         )
         verbose_logger.debug("s3_object_key=%s", s3_object_key)
 
-        s3_object_download_filename: Final = (
-            f"time-{start_time.strftime('%Y-%m-%dT%H-%M-%S-%f')}_{standard_logging_payload['id']}.json"
-        )
+        s3_object_download_filename: Final = get_s3_object_download_filename(start_time, standard_logging_payload["id"])
 
         return s3BatchLoggingElement(
             payload=dict(standard_logging_payload),

--- a/tests/test_litellm/integrations/test_s3.py
+++ b/tests/test_litellm/integrations/test_s3.py
@@ -2,26 +2,27 @@ from datetime import datetime
 from unittest.mock import MagicMock, patch
 
 import litellm
+from litellm.constants import MAX_S3_OBJECT_DOWNLOAD_FILENAME_BYTES, MAX_S3_OBJECT_KEY_BYTES
 from litellm.integrations.s3 import S3Logger
 
 TEST_KMS_KEY_ARN = "arn:aws:kms:us-east-1:111122223333:key/test-key-id"
 
 
-def _standard_logging_payload() -> dict:
+def _standard_logging_payload(response_id: str = "chatcmpl-test-id") -> dict:
     return {
-        "id": "chatcmpl-test-id",
+        "id": response_id,
         "metadata": {"user_api_key_team_alias": None},
     }
 
 
-def _log_event_kwargs() -> dict:
+def _log_event_kwargs(response_id: str = "chatcmpl-test-id") -> dict:
     return {
         "litellm_params": {"metadata": {}},
-        "standard_logging_object": _standard_logging_payload(),
+        "standard_logging_object": _standard_logging_payload(response_id),
     }
 
 
-def _run_log_event(callback_params: dict) -> MagicMock:
+def _run_log_event(callback_params: dict, response_id: str = "chatcmpl-test-id") -> MagicMock:
     original = litellm.s3_callback_params
     litellm.s3_callback_params = callback_params
     try:
@@ -30,8 +31,8 @@ def _run_log_event(callback_params: dict) -> MagicMock:
             mock_boto3_client.return_value = mock_s3_client
             logger = S3Logger()
             logger.log_event(
-                kwargs=_log_event_kwargs(),
-                response_obj={},
+                kwargs=_log_event_kwargs(response_id),
+                response_obj={"id": response_id},
                 start_time=datetime(2026, 7, 30, 12, 0, 0),
                 end_time=datetime(2026, 7, 30, 12, 0, 1),
                 print_verbose=lambda *args, **kwargs: None,
@@ -154,3 +155,32 @@ def test_non_string_key_id_is_dropped_and_valid_algorithm_is_kept():
     put_object_kwargs = mock_s3_client.put_object.call_args.kwargs
     assert put_object_kwargs["ServerSideEncryption"] == "aws:kms"
     assert "SSEKMSKeyId" not in put_object_kwargs
+
+
+def test_put_object_key_and_filename_are_bounded_for_an_oversized_response_id():
+    """The reported failure hits the sync logger too: an oversized Responses API id pushed
+    the key past S3's 1024 byte limit, so the PUT came back 400 and the record was dropped."""
+    mock_s3_client = _run_log_event(
+        {"s3_bucket_name": "test-bucket", "s3_region_name": "us-west-2", "s3_path": "logs"},
+        response_id="resp_" + "A" * 1100,
+    )
+
+    put_object_kwargs = mock_s3_client.put_object.call_args.kwargs
+    assert len(put_object_kwargs["Key"].encode("utf-8")) <= MAX_S3_OBJECT_KEY_BYTES
+    assert put_object_kwargs["Key"].startswith("logs/2026-07-30/time-12-00-00-000000_resp_")
+    filename = put_object_kwargs["ContentDisposition"].removeprefix('inline; filename="').removesuffix('"')
+    assert len(filename.encode("utf-8")) <= MAX_S3_OBJECT_DOWNLOAD_FILENAME_BYTES
+
+
+def test_put_object_keeps_the_configured_path_intact_when_only_the_id_has_to_shrink():
+    """A long configured s3_path must survive whole whenever the id can be shortened instead,
+    or a prefix scoped IAM policy stops matching and the PUT is denied."""
+    long_path = "litellm-prod-logs/" + "t" * 921
+    mock_s3_client = _run_log_event(
+        {"s3_bucket_name": "test-bucket", "s3_region_name": "us-west-2", "s3_path": long_path},
+        response_id="resp_" + "B" * 100,
+    )
+
+    key = mock_s3_client.put_object.call_args.kwargs["Key"]
+    assert key.startswith(long_path + "/2026-07-30/")
+    assert len(key.encode("utf-8")) == MAX_S3_OBJECT_KEY_BYTES

--- a/tests/test_litellm/integrations/test_s3.py
+++ b/tests/test_litellm/integrations/test_s3.py
@@ -158,8 +158,7 @@ def test_non_string_key_id_is_dropped_and_valid_algorithm_is_kept():
 
 
 def test_put_object_key_and_filename_are_bounded_for_an_oversized_response_id():
-    """The reported failure hits the sync logger too: an oversized Responses API id pushed
-    the key past S3's 1024 byte limit, so the PUT came back 400 and the record was dropped."""
+    """The sync logger bounds both the key and the Content-Disposition filename."""
     mock_s3_client = _run_log_event(
         {"s3_bucket_name": "test-bucket", "s3_region_name": "us-west-2", "s3_path": "logs"},
         response_id="resp_" + "A" * 1100,
@@ -173,8 +172,7 @@ def test_put_object_key_and_filename_are_bounded_for_an_oversized_response_id():
 
 
 def test_put_object_keeps_the_configured_path_intact_when_only_the_id_has_to_shrink():
-    """A long configured s3_path must survive whole whenever the id can be shortened instead,
-    or a prefix scoped IAM policy stops matching and the PUT is denied."""
+    """A long configured s3_path survives whole when the id can be shortened instead."""
     long_path = "litellm-prod-logs/" + "t" * 921
     mock_s3_client = _run_log_event(
         {"s3_bucket_name": "test-bucket", "s3_region_name": "us-west-2", "s3_path": long_path},

--- a/tests/test_litellm/integrations/test_s3_v2.py
+++ b/tests/test_litellm/integrations/test_s3_v2.py
@@ -1173,9 +1173,9 @@ def test_create_s3_batch_logging_element_flat_key_for_arn_response_id():
 # --------------------------------------------------------------
 # object keys bounded to S3's 1024 UTF-8 byte limit
 # --------------------------------------------------------------
-def _oversized_response_id(marker: str = "") -> str:
+def _oversized_response_id() -> str:
     """A Responses API id long enough on its own to blow past the 1024 byte cap."""
-    return "resp_" + marker + "A" * 1100
+    return "resp_" + "A" * 1100
 
 
 def test_s3_object_key_at_the_byte_limit_is_left_alone():
@@ -1204,9 +1204,7 @@ def test_s3_object_key_is_bounded_for_oversized_response_id():
     start_time = datetime(2026, 8, 24, 6, 18, 41, 948021)
     file_name = f"time-06-18-41-948021_{_oversized_response_id()}"
 
-    key = get_s3_object_key(
-        s3_path="input", prefix="DefaultTeamProd/", start_time=start_time, s3_file_name=file_name
-    )
+    key = get_s3_object_key(s3_path="input", prefix="DefaultTeamProd/", start_time=start_time, s3_file_name=file_name)
 
     assert len(key.encode("utf-8")) <= MAX_S3_OBJECT_KEY_BYTES
     assert key.startswith("input/DefaultTeamProd/2026-08-24/time-06-18-41-948021_resp_")
@@ -1245,8 +1243,8 @@ def test_s3_object_key_is_bounded_for_long_paths_and_aliases(s3_path: str, prefi
 
 
 def test_s3_object_key_trimmed_prefixes_stay_distinct_per_operator():
-    """Two long configured prefixes sharing a head must not collapse into one folder,
-    and the readable leading segments a prefix-scoped IAM policy matches on survive."""
+    """Two configured prefixes that only differ past the trim point must not collapse into one
+    folder, or one operator's records land on top of another's."""
     from litellm.constants import MAX_S3_OBJECT_KEY_BYTES
     from litellm.integrations.s3 import get_s3_object_key
 
@@ -1254,32 +1252,39 @@ def test_s3_object_key_trimmed_prefixes_stay_distinct_per_operator():
     keys = [
         get_s3_object_key(
             s3_path="input",
-            prefix="team-" + "b" * 900 + suffix + "/",
+            prefix="team-" + "b" * 1000 + suffix + "/",
             start_time=start_time,
             s3_file_name=f"time-06-18-41-948021_{_oversized_response_id()}",
         )
         for suffix in ("-one", "-two")
     ]
 
+    # both prefixes trim to the same 900+ byte head, so only the digest keeps them apart
     assert keys[0] != keys[1]
-    assert all(key.startswith("input/") for key in keys)
-    assert all(len(key.encode("utf-8")) <= MAX_S3_OBJECT_KEY_BYTES for key in keys)
+    assert all(key.startswith("input/team-" + "b" * 900) for key in keys)
+    assert all(len(key.encode("utf-8")) == MAX_S3_OBJECT_KEY_BYTES for key in keys)
 
 
 def test_s3_object_key_bounded_prefix_never_splits_a_multibyte_character():
-    """A multibyte prefix is trimmed on a character boundary, so the key stays decodable."""
+    """A multibyte prefix is trimmed on a character boundary, so the surviving head is a
+    verbatim prefix of what the operator configured rather than a mangled partial character."""
     from litellm.constants import MAX_S3_OBJECT_KEY_BYTES
     from litellm.integrations.s3 import get_s3_object_key
 
+    s3_path = "\u65e5\u672c\u8a9e" * 200
+
     key = get_s3_object_key(
-        s3_path="\u65e5\u672c\u8a9e" * 200,
+        s3_path=s3_path,
         prefix="\u30c1\u30fc\u30e0" * 200 + "/",
         start_time=datetime(2026, 8, 24, 6, 18, 41, 948021),
         s3_file_name=f"time-06-18-41-948021_{_oversized_response_id()}",
     )
 
     assert len(key.encode("utf-8")) <= MAX_S3_OBJECT_KEY_BYTES
-    assert key.encode("utf-8").decode("utf-8") == key
+    # a byte slice would end on half a character, and decoding it with errors="replace"
+    # would leave U+FFFD where the operator's path used to be
+    assert key.startswith(s3_path[:100])
+    assert "\ufffd" not in key
 
 
 def test_s3_object_key_stays_unique_for_ids_sharing_a_head():
@@ -1300,16 +1305,80 @@ def test_s3_object_key_stays_unique_for_ids_sharing_a_head():
     assert len(keys) == 3
 
 
-def test_s3_object_key_bounding_is_deterministic():
-    """The same response id must always resolve to the same object key."""
+def test_s3_object_key_bounding_matches_the_documented_layout():
+    """The bounded key is a readable head of the file name plus the sha256 of the whole name,
+    under the configured prefix and date folders, so a reader can recompute it from the payload."""
+    import hashlib
+
     from litellm.integrations.s3 import get_s3_object_key
 
-    start_time = datetime(2026, 8, 24, 6, 18, 41, 948021)
     file_name = f"time-06-18-41-948021_{_oversized_response_id()}"
-    def build() -> str:
-        return get_s3_object_key(s3_path="input", prefix="team/", start_time=start_time, s3_file_name=file_name)
 
-    assert build() == build()
+    key = get_s3_object_key(
+        s3_path="input",
+        prefix="team/",
+        start_time=datetime(2026, 8, 24, 6, 18, 41, 948021),
+        s3_file_name=file_name,
+    )
+
+    digest = hashlib.sha256(file_name.encode("utf-8")).hexdigest()
+    assert key == f"input/team/2026-08-24/{file_name[:64]}_{digest}.json"
+
+
+def test_s3_object_key_keeps_the_configured_prefix_when_only_the_id_overflows():
+    """The id is what runs away, so it gets shortened first: an 940 byte configured prefix
+    survives whole and the key spends the rest of the budget rather than trimming folders."""
+    from litellm.constants import MAX_S3_OBJECT_KEY_BYTES
+    from litellm.integrations.s3 import get_s3_object_key
+
+    prefix = "team-" + "b" * 934 + "/"
+
+    key = get_s3_object_key(
+        s3_path="",
+        prefix=prefix,
+        start_time=datetime(2026, 8, 24, 6, 18, 41, 948021),
+        s3_file_name=f"time-06-18-41-948021_{_oversized_response_id()}",
+    )
+
+    assert key.startswith(prefix + "2026-08-24/")
+    assert len(key.encode("utf-8")) == MAX_S3_OBJECT_KEY_BYTES
+
+
+def test_s3_object_key_spends_the_whole_budget_when_the_prefix_must_be_trimmed():
+    """Trimming has to stop at the byte limit, not at the nearest folder boundary, or hundreds
+    of bytes of the operator's configured path are thrown away for nothing."""
+    from litellm.constants import MAX_S3_OBJECT_KEY_BYTES
+    from litellm.integrations.s3 import get_s3_object_key
+
+    s3_path = "p" * 400 + "/" + "q" * 600
+
+    key = get_s3_object_key(
+        s3_path=s3_path,
+        prefix="",
+        start_time=datetime(2026, 8, 24, 6, 18, 41, 948021),
+        s3_file_name="time-06-18-41-948021_abc",
+    )
+
+    assert len(key.encode("utf-8")) == MAX_S3_OBJECT_KEY_BYTES
+    # the second segment is where the trim lands, so it must survive as far as the budget allows
+    assert key.startswith("p" * 400 + "/" + "q" * 500)
+
+
+def test_s3_object_key_keeps_a_single_segment_path_as_far_as_it_fits():
+    """A configured path with no folder separator must not be discarded wholesale, or the object
+    lands at the bucket root outside the s3_path a prefix scoped IAM policy allows."""
+    from litellm.constants import MAX_S3_OBJECT_KEY_BYTES
+    from litellm.integrations.s3 import get_s3_object_key
+
+    key = get_s3_object_key(
+        s3_path="a" * 1050,
+        prefix="",
+        start_time=datetime(2026, 8, 24, 6, 18, 41, 948021),
+        s3_file_name="time-06-18-41-948021_chatcmpl-xyz",
+    )
+
+    assert len(key.encode("utf-8")) == MAX_S3_OBJECT_KEY_BYTES
+    assert key.startswith("a" * 900)
 
 
 def test_create_s3_batch_logging_element_bounds_key_and_keeps_full_response_id():
@@ -1339,9 +1408,7 @@ def test_s3_object_download_filename_is_bounded_for_oversized_response_id():
     from litellm.constants import MAX_S3_OBJECT_DOWNLOAD_FILENAME_BYTES
     from litellm.integrations.s3 import get_s3_object_download_filename
 
-    file_name = get_s3_object_download_filename(
-        datetime(2026, 8, 24, 6, 18, 41, 948021), _oversized_response_id()
-    )
+    file_name = get_s3_object_download_filename(datetime(2026, 8, 24, 6, 18, 41, 948021), _oversized_response_id())
 
     assert len(file_name.encode("utf-8")) <= MAX_S3_OBJECT_DOWNLOAD_FILENAME_BYTES
     assert file_name.startswith("time-2026-08-24T06-18-41-948021_resp_")
@@ -1382,6 +1449,32 @@ def test_create_s3_batch_logging_element_bounds_the_download_filename():
 
     assert result is not None
     assert len(result.s3_object_download_filename.encode("utf-8")) <= MAX_S3_OBJECT_DOWNLOAD_FILENAME_BYTES
+
+
+@pytest.mark.asyncio
+async def test_audit_log_object_key_is_bounded_for_a_long_configured_path():
+    """Audit logs build a key from the same configured s3_path, so they need the same bound
+    or the audit PUT is the one that comes back 400 and the record disappears."""
+    from litellm.constants import MAX_S3_OBJECT_KEY_BYTES
+
+    logger = S3Logger()
+    logger.s3_path = "audit-archive/" + "z" * 1100
+
+    await logger.async_log_audit_log_event({"id": "1a4f7bd0-6f1e-4d0a-9b3c-9f2e1d5a7c88"})
+
+    assert len(logger.log_queue) == 1
+    assert len(logger.log_queue[0].s3_object_key.encode("utf-8")) <= MAX_S3_OBJECT_KEY_BYTES
+    assert logger.log_queue[0].s3_object_key.startswith("audit-archive/" + "z" * 900)
+
+
+def test_s3_object_download_filename_drops_characters_that_break_the_header():
+    """The filename is interpolated into `Content-Disposition: inline; filename="..."`, so a
+    quote or a path separator in the response id must not escape the quoted string."""
+    from litellm.integrations.s3 import get_s3_object_download_filename
+
+    file_name = get_s3_object_download_filename(datetime(2026, 8, 24, 6, 18, 41, 948021), 'resp_a"b/c')
+
+    assert file_name == "time-2026-08-24T06-18-41-948021_resp_a_b_c.json"
 
 
 # --------------------------------------------------------------

--- a/tests/test_litellm/integrations/test_s3_v2.py
+++ b/tests/test_litellm/integrations/test_s3_v2.py
@@ -1174,12 +1174,11 @@ def test_create_s3_batch_logging_element_flat_key_for_arn_response_id():
 # object keys bounded to S3's 1024 UTF-8 byte limit
 # --------------------------------------------------------------
 def _oversized_response_id() -> str:
-    """A Responses API id long enough on its own to blow past the 1024 byte cap."""
     return "resp_" + "A" * 1100
 
 
 def test_s3_object_key_at_the_byte_limit_is_left_alone():
-    """A key that still fits must stay byte-identical, hash-free."""
+    """A key that still fits is left byte-identical."""
     from litellm.constants import MAX_S3_OBJECT_KEY_BYTES
     from litellm.integrations.s3 import get_s3_object_key
 
@@ -1194,8 +1193,7 @@ def test_s3_object_key_at_the_byte_limit_is_left_alone():
 
 
 def test_s3_object_key_is_bounded_for_oversized_response_id():
-    """The reported failure: an oversized Responses API id pushed the key past
-    1024 bytes and S3 rejected the PUT with a 400."""
+    """An oversized Responses API id is shortened to a readable head plus a digest."""
     import hashlib
 
     from litellm.constants import MAX_S3_OBJECT_KEY_BYTES
@@ -1218,13 +1216,12 @@ def test_s3_object_key_is_bounded_for_oversized_response_id():
         ("a" * 900, ""),
         ("input", "team-" + "b" * 900 + "/"),
         ("c" * 600, "team-" + "d" * 600 + "/key-" + "e" * 600 + "/"),
-        # many short segments: the whole-segment trim lands right at the budget edge,
-        # so this pins the byte arithmetic (date segment included) rather than just the cap
+        # many short segments, so the trim lands exactly on the budget edge
         ("", "ssss/" * 200),
     ],
 )
 def test_s3_object_key_is_bounded_for_long_paths_and_aliases(s3_path: str, prefix: str):
-    """Long configured paths, team aliases and key aliases must not reintroduce the overflow."""
+    """Long paths, team aliases and key aliases stay within the cap."""
     from litellm.constants import MAX_S3_OBJECT_KEY_BYTES
     from litellm.integrations.s3 import get_s3_object_key
 
@@ -1237,14 +1234,12 @@ def test_s3_object_key_is_bounded_for_long_paths_and_aliases(s3_path: str, prefi
 
     assert len(key.encode("utf-8")) <= MAX_S3_OBJECT_KEY_BYTES
     assert key.endswith(".json")
-    # lifecycle rules and prefix-scoped IAM policies are written against `<prefix>/<date>/<file>`
     assert "/2026-08-24/" in key or key.startswith("2026-08-24/")
     assert "/" not in key.rsplit("2026-08-24/", 1)[1]
 
 
 def test_s3_object_key_trimmed_prefixes_stay_distinct_per_operator():
-    """Two configured prefixes that only differ past the trim point must not collapse into one
-    folder, or one operator's records land on top of another's."""
+    """Prefixes that differ only past the trim point keep separate folders."""
     from litellm.constants import MAX_S3_OBJECT_KEY_BYTES
     from litellm.integrations.s3 import get_s3_object_key
 
@@ -1259,15 +1254,13 @@ def test_s3_object_key_trimmed_prefixes_stay_distinct_per_operator():
         for suffix in ("-one", "-two")
     ]
 
-    # both prefixes trim to the same 900+ byte head, so only the digest keeps them apart
     assert keys[0] != keys[1]
     assert all(key.startswith("input/team-" + "b" * 900) for key in keys)
     assert all(len(key.encode("utf-8")) == MAX_S3_OBJECT_KEY_BYTES for key in keys)
 
 
 def test_s3_object_key_bounded_prefix_never_splits_a_multibyte_character():
-    """A multibyte prefix is trimmed on a character boundary, so the surviving head is a
-    verbatim prefix of what the operator configured rather than a mangled partial character."""
+    """A multibyte prefix is trimmed on a character boundary."""
     from litellm.constants import MAX_S3_OBJECT_KEY_BYTES
     from litellm.integrations.s3 import get_s3_object_key
 
@@ -1281,14 +1274,12 @@ def test_s3_object_key_bounded_prefix_never_splits_a_multibyte_character():
     )
 
     assert len(key.encode("utf-8")) <= MAX_S3_OBJECT_KEY_BYTES
-    # a byte slice would end on half a character, and decoding it with errors="replace"
-    # would leave U+FFFD where the operator's path used to be
     assert key.startswith(s3_path[:100])
     assert "\ufffd" not in key
 
 
 def test_s3_object_key_stays_unique_for_ids_sharing_a_head():
-    """Shortening must not collide: two ids with the same visible head keep distinct keys."""
+    """Ids sharing a visible head still get distinct keys."""
     from litellm.integrations.s3 import get_s3_object_key
 
     start_time = datetime(2026, 8, 24, 6, 18, 41, 948021)
@@ -1306,8 +1297,7 @@ def test_s3_object_key_stays_unique_for_ids_sharing_a_head():
 
 
 def test_s3_object_key_bounding_matches_the_documented_layout():
-    """The bounded key is a readable head of the file name plus the sha256 of the whole name,
-    under the configured prefix and date folders, so a reader can recompute it from the payload."""
+    """The bounded key is `<prefix>/<date>/<head>_<sha256>.json`."""
     import hashlib
 
     from litellm.integrations.s3 import get_s3_object_key
@@ -1326,8 +1316,7 @@ def test_s3_object_key_bounding_matches_the_documented_layout():
 
 
 def test_s3_object_key_keeps_the_configured_prefix_when_only_the_id_overflows():
-    """The id is what runs away, so it gets shortened first: an 940 byte configured prefix
-    survives whole and the key spends the rest of the budget rather than trimming folders."""
+    """A 940 byte configured prefix survives whole when only the id overflows."""
     from litellm.constants import MAX_S3_OBJECT_KEY_BYTES
     from litellm.integrations.s3 import get_s3_object_key
 
@@ -1345,8 +1334,7 @@ def test_s3_object_key_keeps_the_configured_prefix_when_only_the_id_overflows():
 
 
 def test_s3_object_key_spends_the_whole_budget_when_the_prefix_must_be_trimmed():
-    """Trimming has to stop at the byte limit, not at the nearest folder boundary, or hundreds
-    of bytes of the operator's configured path are thrown away for nothing."""
+    """A trimmed prefix keeps every byte the budget allows, not whole segments."""
     from litellm.constants import MAX_S3_OBJECT_KEY_BYTES
     from litellm.integrations.s3 import get_s3_object_key
 
@@ -1360,13 +1348,11 @@ def test_s3_object_key_spends_the_whole_budget_when_the_prefix_must_be_trimmed()
     )
 
     assert len(key.encode("utf-8")) == MAX_S3_OBJECT_KEY_BYTES
-    # the second segment is where the trim lands, so it must survive as far as the budget allows
     assert key.startswith("p" * 400 + "/" + "q" * 500)
 
 
 def test_s3_object_key_keeps_a_single_segment_path_as_far_as_it_fits():
-    """A configured path with no folder separator must not be discarded wholesale, or the object
-    lands at the bucket root outside the s3_path a prefix scoped IAM policy allows."""
+    """A path with no separator is kept as far as it fits, never dropped to the bucket root."""
     from litellm.constants import MAX_S3_OBJECT_KEY_BYTES
     from litellm.integrations.s3 import get_s3_object_key
 
@@ -1382,8 +1368,7 @@ def test_s3_object_key_keeps_a_single_segment_path_as_far_as_it_fits():
 
 
 def test_create_s3_batch_logging_element_bounds_key_and_keeps_full_response_id():
-    """End to end through the s3_v2 element builder: the key is bounded while the
-    uploaded payload still carries the untouched response id."""
+    """The batch element bounds the key and keeps the full response id in the payload."""
     from litellm.constants import MAX_S3_OBJECT_KEY_BYTES
 
     logger = S3Logger(s3_use_team_prefix=True, s3_use_key_prefix=True)
@@ -1403,8 +1388,7 @@ def test_create_s3_batch_logging_element_bounds_key_and_keeps_full_response_id()
 
 
 def test_s3_object_download_filename_is_bounded_for_oversized_response_id():
-    """S3 caps combined metadata headers at 2048 bytes, so the Content-Disposition
-    filename has to be bounded too or the PUT still fails with MetadataTooLarge."""
+    """The Content-Disposition filename is bounded too, or the PUT fails with MetadataTooLarge."""
     from litellm.constants import MAX_S3_OBJECT_DOWNLOAD_FILENAME_BYTES
     from litellm.integrations.s3 import get_s3_object_download_filename
 
@@ -1416,8 +1400,7 @@ def test_s3_object_download_filename_is_bounded_for_oversized_response_id():
 
 
 def test_s3_object_download_filenames_stay_distinct_when_shortened():
-    """Shortened filenames must not collide, or two records downloaded from the
-    console arrive as the same file."""
+    """Shortened filenames stay distinct."""
     from litellm.integrations.s3 import get_s3_object_download_filename
 
     start_time = datetime(2026, 8, 24, 6, 18, 41, 948021)
@@ -1430,7 +1413,7 @@ def test_s3_object_download_filenames_stay_distinct_when_shortened():
 
 
 def test_s3_object_download_filename_short_id_is_unchanged():
-    """Ordinary response ids keep the exact filename they had before."""
+    """An ordinary response id keeps the filename it had before."""
     from litellm.integrations.s3 import get_s3_object_download_filename
 
     file_name = get_s3_object_download_filename(datetime(2026, 8, 24, 6, 18, 41, 948021), "resp_abc123")
@@ -1439,7 +1422,7 @@ def test_s3_object_download_filename_short_id_is_unchanged():
 
 
 def test_create_s3_batch_logging_element_bounds_the_download_filename():
-    """The element the uploader signs carries a bounded Content-Disposition filename."""
+    """The batch element carries a bounded Content-Disposition filename."""
     from litellm.constants import MAX_S3_OBJECT_DOWNLOAD_FILENAME_BYTES
 
     logger = S3Logger()
@@ -1453,8 +1436,7 @@ def test_create_s3_batch_logging_element_bounds_the_download_filename():
 
 @pytest.mark.asyncio
 async def test_audit_log_object_key_is_bounded_for_a_long_configured_path():
-    """Audit logs build a key from the same configured s3_path, so they need the same bound
-    or the audit PUT is the one that comes back 400 and the record disappears."""
+    """Audit log keys are bounded by the same builder."""
     from litellm.constants import MAX_S3_OBJECT_KEY_BYTES
 
     logger = S3Logger()
@@ -1468,8 +1450,7 @@ async def test_audit_log_object_key_is_bounded_for_a_long_configured_path():
 
 
 def test_s3_object_download_filename_drops_characters_that_break_the_header():
-    """The filename is interpolated into `Content-Disposition: inline; filename="..."`, so a
-    quote or a path separator in the response id must not escape the quoted string."""
+    """A quote or separator in the response id cannot escape the quoted header value."""
     from litellm.integrations.s3 import get_s3_object_download_filename
 
     file_name = get_s3_object_download_filename(datetime(2026, 8, 24, 6, 18, 41, 948021), 'resp_a"b/c')

--- a/tests/test_litellm/integrations/test_s3_v2.py
+++ b/tests/test_litellm/integrations/test_s3_v2.py
@@ -1171,6 +1171,220 @@ def test_create_s3_batch_logging_element_flat_key_for_arn_response_id():
 
 
 # --------------------------------------------------------------
+# object keys bounded to S3's 1024 UTF-8 byte limit
+# --------------------------------------------------------------
+def _oversized_response_id(marker: str = "") -> str:
+    """A Responses API id long enough on its own to blow past the 1024 byte cap."""
+    return "resp_" + marker + "A" * 1100
+
+
+def test_s3_object_key_at_the_byte_limit_is_left_alone():
+    """A key that still fits must stay byte-identical, hash-free."""
+    from litellm.constants import MAX_S3_OBJECT_KEY_BYTES
+    from litellm.integrations.s3 import get_s3_object_key
+
+    start_time = datetime(2026, 8, 24, 6, 18, 41, 948021)
+    fixed_len = len("input/2026-08-24/.json")
+    file_name = "x" * (MAX_S3_OBJECT_KEY_BYTES - fixed_len)
+
+    key = get_s3_object_key(s3_path="input", prefix="", start_time=start_time, s3_file_name=file_name)
+
+    assert key == f"input/2026-08-24/{file_name}.json"
+    assert len(key.encode("utf-8")) == MAX_S3_OBJECT_KEY_BYTES
+
+
+def test_s3_object_key_is_bounded_for_oversized_response_id():
+    """The reported failure: an oversized Responses API id pushed the key past
+    1024 bytes and S3 rejected the PUT with a 400."""
+    import hashlib
+
+    from litellm.constants import MAX_S3_OBJECT_KEY_BYTES
+    from litellm.integrations.s3 import get_s3_object_key
+
+    start_time = datetime(2026, 8, 24, 6, 18, 41, 948021)
+    file_name = f"time-06-18-41-948021_{_oversized_response_id()}"
+
+    key = get_s3_object_key(
+        s3_path="input", prefix="DefaultTeamProd/", start_time=start_time, s3_file_name=file_name
+    )
+
+    assert len(key.encode("utf-8")) <= MAX_S3_OBJECT_KEY_BYTES
+    assert key.startswith("input/DefaultTeamProd/2026-08-24/time-06-18-41-948021_resp_")
+    assert key.endswith(f"_{hashlib.sha256(file_name.encode('utf-8')).hexdigest()}.json")
+
+
+@pytest.mark.parametrize(
+    "s3_path,prefix",
+    [
+        ("input", ""),
+        ("a" * 900, ""),
+        ("input", "team-" + "b" * 900 + "/"),
+        ("c" * 600, "team-" + "d" * 600 + "/key-" + "e" * 600 + "/"),
+        # many short segments: the whole-segment trim lands right at the budget edge,
+        # so this pins the byte arithmetic (date segment included) rather than just the cap
+        ("", "ssss/" * 200),
+    ],
+)
+def test_s3_object_key_is_bounded_for_long_paths_and_aliases(s3_path: str, prefix: str):
+    """Long configured paths, team aliases and key aliases must not reintroduce the overflow."""
+    from litellm.constants import MAX_S3_OBJECT_KEY_BYTES
+    from litellm.integrations.s3 import get_s3_object_key
+
+    key = get_s3_object_key(
+        s3_path=s3_path,
+        prefix=prefix,
+        start_time=datetime(2026, 8, 24, 6, 18, 41, 948021),
+        s3_file_name=f"time-06-18-41-948021_{_oversized_response_id()}",
+    )
+
+    assert len(key.encode("utf-8")) <= MAX_S3_OBJECT_KEY_BYTES
+    assert key.endswith(".json")
+    # lifecycle rules and prefix-scoped IAM policies are written against `<prefix>/<date>/<file>`
+    assert "/2026-08-24/" in key or key.startswith("2026-08-24/")
+    assert "/" not in key.rsplit("2026-08-24/", 1)[1]
+
+
+def test_s3_object_key_trimmed_prefixes_stay_distinct_per_operator():
+    """Two long configured prefixes sharing a head must not collapse into one folder,
+    and the readable leading segments a prefix-scoped IAM policy matches on survive."""
+    from litellm.constants import MAX_S3_OBJECT_KEY_BYTES
+    from litellm.integrations.s3 import get_s3_object_key
+
+    start_time = datetime(2026, 8, 24, 6, 18, 41, 948021)
+    keys = [
+        get_s3_object_key(
+            s3_path="input",
+            prefix="team-" + "b" * 900 + suffix + "/",
+            start_time=start_time,
+            s3_file_name=f"time-06-18-41-948021_{_oversized_response_id()}",
+        )
+        for suffix in ("-one", "-two")
+    ]
+
+    assert keys[0] != keys[1]
+    assert all(key.startswith("input/") for key in keys)
+    assert all(len(key.encode("utf-8")) <= MAX_S3_OBJECT_KEY_BYTES for key in keys)
+
+
+def test_s3_object_key_bounded_prefix_never_splits_a_multibyte_character():
+    """A multibyte prefix is trimmed on a character boundary, so the key stays decodable."""
+    from litellm.constants import MAX_S3_OBJECT_KEY_BYTES
+    from litellm.integrations.s3 import get_s3_object_key
+
+    key = get_s3_object_key(
+        s3_path="\u65e5\u672c\u8a9e" * 200,
+        prefix="\u30c1\u30fc\u30e0" * 200 + "/",
+        start_time=datetime(2026, 8, 24, 6, 18, 41, 948021),
+        s3_file_name=f"time-06-18-41-948021_{_oversized_response_id()}",
+    )
+
+    assert len(key.encode("utf-8")) <= MAX_S3_OBJECT_KEY_BYTES
+    assert key.encode("utf-8").decode("utf-8") == key
+
+
+def test_s3_object_key_stays_unique_for_ids_sharing_a_head():
+    """Shortening must not collide: two ids with the same visible head keep distinct keys."""
+    from litellm.integrations.s3 import get_s3_object_key
+
+    start_time = datetime(2026, 8, 24, 6, 18, 41, 948021)
+    keys = {
+        get_s3_object_key(
+            s3_path="input",
+            prefix="",
+            start_time=start_time,
+            s3_file_name=f"time-06-18-41-948021_{_oversized_response_id()}{suffix}",
+        )
+        for suffix in ("first", "second", "third")
+    }
+
+    assert len(keys) == 3
+
+
+def test_s3_object_key_bounding_is_deterministic():
+    """The same response id must always resolve to the same object key."""
+    from litellm.integrations.s3 import get_s3_object_key
+
+    start_time = datetime(2026, 8, 24, 6, 18, 41, 948021)
+    file_name = f"time-06-18-41-948021_{_oversized_response_id()}"
+    def build() -> str:
+        return get_s3_object_key(s3_path="input", prefix="team/", start_time=start_time, s3_file_name=file_name)
+
+    assert build() == build()
+
+
+def test_create_s3_batch_logging_element_bounds_key_and_keeps_full_response_id():
+    """End to end through the s3_v2 element builder: the key is bounded while the
+    uploaded payload still carries the untouched response id."""
+    from litellm.constants import MAX_S3_OBJECT_KEY_BYTES
+
+    logger = S3Logger(s3_use_team_prefix=True, s3_use_key_prefix=True)
+    response_id = _oversized_response_id()
+    payload = StandardLoggingPayload(
+        id=response_id,
+        metadata={"user_api_key_team_alias": "DefaultTeamProd", "user_api_key_alias": "prod-key"},
+        messages=[],
+    )
+
+    result = logger.create_s3_batch_logging_element(datetime(2026, 8, 24, 6, 18, 41, 948021), payload)
+
+    assert result is not None
+    assert len(result.s3_object_key.encode("utf-8")) <= MAX_S3_OBJECT_KEY_BYTES
+    assert result.s3_object_key.startswith("DefaultTeamProd/prod-key/2026-08-24/")
+    assert result.payload["id"] == response_id
+
+
+def test_s3_object_download_filename_is_bounded_for_oversized_response_id():
+    """S3 caps combined metadata headers at 2048 bytes, so the Content-Disposition
+    filename has to be bounded too or the PUT still fails with MetadataTooLarge."""
+    from litellm.constants import MAX_S3_OBJECT_DOWNLOAD_FILENAME_BYTES
+    from litellm.integrations.s3 import get_s3_object_download_filename
+
+    file_name = get_s3_object_download_filename(
+        datetime(2026, 8, 24, 6, 18, 41, 948021), _oversized_response_id()
+    )
+
+    assert len(file_name.encode("utf-8")) <= MAX_S3_OBJECT_DOWNLOAD_FILENAME_BYTES
+    assert file_name.startswith("time-2026-08-24T06-18-41-948021_resp_")
+    assert file_name.endswith(".json")
+
+
+def test_s3_object_download_filenames_stay_distinct_when_shortened():
+    """Shortened filenames must not collide, or two records downloaded from the
+    console arrive as the same file."""
+    from litellm.integrations.s3 import get_s3_object_download_filename
+
+    start_time = datetime(2026, 8, 24, 6, 18, 41, 948021)
+    file_names = {
+        get_s3_object_download_filename(start_time, _oversized_response_id() + suffix)
+        for suffix in ("first", "second", "third")
+    }
+
+    assert len(file_names) == 3
+
+
+def test_s3_object_download_filename_short_id_is_unchanged():
+    """Ordinary response ids keep the exact filename they had before."""
+    from litellm.integrations.s3 import get_s3_object_download_filename
+
+    file_name = get_s3_object_download_filename(datetime(2026, 8, 24, 6, 18, 41, 948021), "resp_abc123")
+
+    assert file_name == "time-2026-08-24T06-18-41-948021_resp_abc123.json"
+
+
+def test_create_s3_batch_logging_element_bounds_the_download_filename():
+    """The element the uploader signs carries a bounded Content-Disposition filename."""
+    from litellm.constants import MAX_S3_OBJECT_DOWNLOAD_FILENAME_BYTES
+
+    logger = S3Logger()
+    payload = StandardLoggingPayload(id=_oversized_response_id(), metadata={}, messages=[])
+
+    result = logger.create_s3_batch_logging_element(datetime(2026, 8, 24, 6, 18, 41, 948021), payload)
+
+    assert result is not None
+    assert len(result.s3_object_download_filename.encode("utf-8")) <= MAX_S3_OBJECT_DOWNLOAD_FILENAME_BYTES
+
+
+# --------------------------------------------------------------
 # params_source / s3_callback_params_override (audit-log decoupling)
 # --------------------------------------------------------------
 def test_s3_callback_params_override_uses_alternate_dict(monkeypatch):


### PR DESCRIPTION
## TLDR

Problem this solves:

- Long Responses API ids push the s3 object key past 1,024 bytes
- S3 rejects the upload with a 400 and the log record is dropped
- The download filename overflows s3's 2,048 byte metadata cap too
- Session replay and the logs page lose the payload that was dropped

How it solves it:

- Shorten the response id first: readable head plus a sha256 of the full name
- Keep the operator's configured prefix whole whenever it still fits
- Trim the prefix by bytes only when the prefix is what overflows, then add a digest
- Keys that already fit stay byte for byte identical

## User Flow

Before: a developer chaining Responses API turns loses the earlier turn, and the logs page shows nothing for that request

1. They send POST https://litellm-domain/v1/responses with `"store": true` and get back a response id roughly 2,300 characters long
2. They send a second POST https://litellm-domain/v1/responses with `"previous_response_id"` set to that id
3. The model answers as if the first turn never happened, because only the new question ever reached it
4. They open https://litellm-domain/ui/?page=logs, click that first request, and the Request and Response panels are empty

After: the same two turns keep their history, and the logs page shows the request and the response

1. They send the same POST https://litellm-domain/v1/responses with `"store": true` and get back the same long response id
2. They send the same second POST https://litellm-domain/v1/responses with `"previous_response_id"` set to that id
3. The model now sees both turns: the earlier question is replayed ahead of the new one
4. https://litellm-domain/ui/?page=logs shows that first request with its Request and Response panels filled in

## Relevant issues

## Linear ticket

Resolves LIT-6044

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Shared setup for every case below. One proxy per side, same config, same real bucket in us-west-2, same Postgres, same upstream. The upstream returns a response id whose length is driven by an `idlen:` marker in the prompt, which is what a real OpenAI-compatible Responses provider does to litellm when its ids are long

```yaml
model_list:
  - model_name: stub-model
    litellm_params: {model: openai/stub-model, api_base: http://127.0.0.1:8644/v1, api_key: sk-stub}
  - model_name: stub-bridge
    litellm_params: {model: openai/stub-model, api_base: http://127.0.0.1:8644/v1, api_key: sk-stub, use_chat_completions_api: true}

litellm_settings:
  callbacks: ["s3_v2"]
  cold_storage_custom_logger: "s3_v2"
  s3_callback_params:
    s3_bucket_name: litellm-lit6044-s3keys
    s3_region_name: us-west-2
    s3_path: evidence-<side>
    s3_use_team_prefix: true
    s3_use_key_prefix: true
  s3_flush_interval_seconds: 2
  s3_batch_size: 1
```

### Before (ec3f8183c3)

#### Responses API session replay

1. `curl -sX POST :4645/v1/responses -d '{"model":"stub-bridge","input":"the capital of France idlen:1100","store":true}'` returns an id of 2365 bytes
2. `curl -sX POST :4645/v1/responses -d '{"model":"stub-bridge","input":"and its population","previous_response_id":"<id>","store":true}'`
3. The upstream receives `turn_count=1`: only "and its population". The first turn is gone

#### Admin UI log detail

1. `select metadata->>'cold_storage_object_key' from "LiteLLM_SpendLogs"` gives a key of 2408 bytes, past the 1024 cap
2. `curl -s :4645/spend/logs/ui/<request_id>` returns `messages=False response=False`: nothing to show in the drawer
3. The proxy log carries `KeyTooLongError`, and `aws s3api head-object` on that key returns 404
4. The Logs page drawer for that request shows `Request/Response Data Not Available`

![Admin UI log detail on base: Request/Response Data Not Available](https://raw.githubusercontent.com/BerriAI/litellm/assets-pr39164/assets/pr39164/base_drawer.png)

#### Legacy s3 logger

1. Same request with `litellm_settings.success_callback: ["s3"]` and `s3_path: v1logger-base`
2. `aws s3api list-objects-v2 --prefix v1logger-base/` lists 0 objects
3. The proxy log shows `KeyTooLongError` twice and `s3 Layer Error` once

#### Long team and key alias prefixes

1. Create a team with a 602 byte alias and a key with a 601 byte alias, both prefixes enabled, then send the same request
2. `aws s3api list-objects-v2 --prefix evidence-base/team-` lists 0 objects

### After (afa7dce005)

#### Responses API session replay

1. `curl -sX POST :4644/v1/responses -d '{"model":"stub-bridge","input":"the capital of France idlen:1100","store":true}'` returns the same 2365 byte id
2. `curl -sX POST :4644/v1/responses -d '{"model":"stub-bridge","input":"and its population","previous_response_id":"<id>","store":true}'`
3. The upstream receives `turn_count=2`: "the capital of France" replayed ahead of "and its population"

#### Admin UI log detail

1. `select metadata->>'cold_storage_object_key' from "LiteLLM_SpendLogs"` gives a key of 159 bytes
2. `curl -s :4644/spend/logs/ui/<request_id>` returns `messages=True response=True`
3. `aws s3api head-object` on that key succeeds, and no `KeyTooLongError` appears in the proxy log
4. The Logs page drawer for that request shows the Input and Output panels filled in

![Admin UI log detail on head: Request and Response filled in](https://raw.githubusercontent.com/BerriAI/litellm/assets-pr39164/assets/pr39164/head_drawer.png)

#### Legacy s3 logger

1. Same request with `litellm_settings.success_callback: ["s3"]` and `s3_path: v1logger-head`
2. `aws s3api list-objects-v2 --prefix v1logger-head/` lists 1 object with a 159 byte key
3. No `KeyTooLongError` and no `s3 Layer Error` in the proxy log

#### Long team and key alias prefixes

1. Create a team with a 602 byte alias and a key with a 601 byte alias, both prefixes enabled, then send the same request
2. `aws s3api list-objects-v2 --prefix evidence-head/team-` lists 1 object with a key of exactly 1024 bytes, laid out as `evidence-head / team-<602 bytes> / <key alias, kept as far as the budget reaches> / 739a03aa116f1359 / 2026-09-01 / <sha256>.json`
3. The configured path and the whole team alias segment survive, so a prefix scoped IAM policy or lifecycle rule written against them still matches. The key alias segment is kept up to the last byte the budget allows, and a 16 hex digest of the full configured prefix keeps two operators who share a head out of the same folder

## Type

🐛 Bug Fix

## Caveats (if any)

### Medium

- A shortened key no longer carries the full response id
  - the full id is still in the uploaded JSON payload
  - anyone scanning for an object by id has to read payloads, not key names

### Low

- A trimmed prefix keeps its longest fitting head and gains a 16 hex digest segment
  - only for a configured prefix long enough to overflow on its own
- The cold storage predicted key omits the team and key alias prefixes that the uploader adds
  - pre existing and unchanged here, reproduced identically on base with an in limit id
- The three limits are plain constants rather than config or env

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes cold-storage key layout for oversized ids/prefixes (full id remains in the JSON payload), which could affect operators who locate objects by key name alone; upload path behavior is otherwise additive for in-limit keys.
> 
> **Overview**
> Fixes **S3 logging uploads failing** when Responses API ids (or long team/key prefixes) push object keys past AWS’s **1024-byte UTF-8 key limit** or `Content-Disposition` filenames past the metadata cap—logs were dropped, cold storage lookups failed, and session replay broke.
> 
> **Shared helpers** in `litellm.integrations.s3` now build keys and download filenames with explicit byte budgets from new constants in `litellm.constants`. Keys that already fit stay unchanged. When they overflow, the **response id segment is shortened first** to a readable head plus full-name **SHA-256**; configured `s3_path`/team/key prefixes are kept whole when possible, and only trimmed by bytes (with a short digest segment) when the prefix itself is what overflows—so prefix-scoped IAM/lifecycle rules still match when they can.
> 
> **Legacy `S3Logger` and `s3_v2`** both call `get_s3_object_key` and `get_s3_object_download_filename` (audit log keys in v2 no longer use a separate ad-hoc path). Download filenames also sanitize quotes/slashes in ids before bounding.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e1a1b4bd9e06b84d2d41ddeff7f743143f680246. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


ran /live-pr-risk and found no regressions/backward incompatible risks