### PR TITLE
fix(anthropic): forward upstream response headers through the /v1/messages adapter conversion

### DIFF
--- a/litellm/llms/anthropic/experimental_pass_through/responses_adapters/handler.py
+++ b/litellm/llms/anthropic/experimental_pass_through/responses_adapters/handler.py
@@ -188,7 +188,26 @@ class LiteLLMMessagesToResponsesAPIHandler:
             wrapper: Final = AnthropicResponsesStreamWrapper(
                 responses_stream=result, model=local_model_name(model, kwargs.get("custom_llm_provider"))
             )
-            return wrapper.async_anthropic_sse_wrapper()
+            # The bare generator the wrapper returns cannot carry attributes,
+            # so the proxy would drop the upstream header mirror the inner
+            # Responses iterator built from its response headers.
+            # AnthropicMessagesStreamingResponse is the passthrough route's
+            # attribute-carrying shape for exactly this -- reuse it. It is
+            # still an AsyncIterator, so streaming detection is unchanged.
+            from litellm.llms.anthropic.experimental_pass_through.messages.streaming_iterator import (
+                AnthropicMessagesStreamHiddenParams,
+                AnthropicMessagesStreamingResponse,
+            )
+
+            sse_stream = wrapper.async_anthropic_sse_wrapper()
+            inner_hidden = getattr(result, "_hidden_params", None)
+            inner_additional = inner_hidden.get("additional_headers") if isinstance(inner_hidden, dict) else None
+            if inner_additional:
+                return AnthropicMessagesStreamingResponse(
+                    completion_stream=sse_stream,
+                    hidden_params=AnthropicMessagesStreamHiddenParams(additional_headers=dict(inner_additional)),
+                )
+            return sse_stream
 
         if not isinstance(result, ResponsesAPIResponse):
             raise ValueError(f"Expected ResponsesAPIResponse, got {type(result)}")

--- a/litellm/llms/anthropic/experimental_pass_through/responses_adapters/transformation.py
+++ b/litellm/llms/anthropic/experimental_pass_through/responses_adapters/transformation.py
@@ -686,7 +686,7 @@ class LiteLLMAnthropicToResponsesAPIAdapter:
 
         anthropic_usage: Final = self.translate_responses_api_usage_to_anthropic_usage(response.usage)
 
-        return AnthropicMessagesResponse(
+        anthropic_response = AnthropicMessagesResponse(
             id=response.id,
             type="message",
             role="assistant",
@@ -696,3 +696,16 @@ class LiteLLMAnthropicToResponsesAPIAdapter:
             content=content,
             stop_reason=stop_reason,
         )
+
+        # Keep the upstream header mirror visible to the proxy. The
+        # ResponsesAPIResponse carries `_hidden_params["additional_headers"]`
+        # (the llm_provider-* mirror); without this the TypedDict returned
+        # here drops it, so /v1/messages loses every upstream response header
+        # while /v1/chat/completions for the same deployment forwards them.
+        # The proxy reads a dict-shaped "_hidden_params" key via
+        # get_hidden_params_dict() and pops it from the body before
+        # serialising, so nothing leaks into the response.
+        response_hidden = getattr(response, "_hidden_params", None)
+        if isinstance(response_hidden, dict) and response_hidden.get("additional_headers"):
+            anthropic_response["_hidden_params"] = {"additional_headers": dict(response_hidden["additional_headers"])}
+        return anthropic_response

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/responses_adapters/test_responses_adapters_handler.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/responses_adapters/test_responses_adapters_handler.py
@@ -82,3 +82,80 @@ async def test_streaming_message_start_reports_the_provider_local_model(requeste
 
     message_start = next(e for e in events if e["type"] == "message_start")
     assert message_start["message"]["model"] == expected_reported_model
+
+
+class _FakeResponsesStream:
+    """Minimal stand-in for BaseResponsesAPIStreamingIterator: iterable, and
+    able to carry `_hidden_params` the way the real iterator does from its
+    response headers."""
+
+    def __init__(self, hidden_params=None):
+        self._hidden_params = hidden_params
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        if getattr(self, "_sent", False):
+            raise StopAsyncIteration
+        self._sent = True
+        return {
+            "type": "response.completed",
+            "response": {"id": "resp_001", "model": "gpt-5.6-luna", "usage": {}},
+        }
+
+
+@pytest.mark.asyncio
+async def test_streaming_headers_are_carried_on_the_returned_response_object():
+    """
+    The SSE wrapper returns a bare async generator, which cannot carry
+    attributes -- the proxy would drop the upstream header mirror the inner
+    Responses iterator built from its response headers. The handler must wrap
+    it in AnthropicMessagesStreamingResponse (the passthrough route's
+    attribute-carrying shape, introduced in #32160) so /v1/messages keeps
+    llm_provider-* headers, matching /v1/chat/completions.
+    """
+    from litellm.llms.anthropic.experimental_pass_through.messages.streaming_iterator import (
+        AnthropicMessagesStreamingResponse,
+    )
+
+    stream = _FakeResponsesStream(hidden_params={"additional_headers": {"llm_provider-x-cortecs-provider": "tensorix"}})
+    with patch.object(litellm, "aresponses", AsyncMock(return_value=stream)):
+        returned = await LiteLLMMessagesToResponsesAPIHandler.async_anthropic_messages_handler(
+            max_tokens=1024,
+            messages=MESSAGES,
+            model="openai/gpt-5.6-luna",
+            stream=True,
+            custom_llm_provider="openai",
+        )
+
+    assert isinstance(returned, AnthropicMessagesStreamingResponse)
+    assert returned._hidden_params["additional_headers"] == {"llm_provider-x-cortecs-provider": "tensorix"}
+
+    # the stream still flows through the wrapper as SSE bytes
+    chunks = [chunk async for chunk in returned]
+    assert any(b"message_stop" in chunk for chunk in chunks)
+
+
+@pytest.mark.asyncio
+async def test_streaming_without_headers_returns_the_bare_sse_generator():
+    """No mirror on the inner stream -> no wrapper; behaviour unchanged."""
+    stream = _FakeResponsesStream()  # no _hidden_params at all
+    with patch.object(litellm, "aresponses", AsyncMock(return_value=stream)):
+        returned = await LiteLLMMessagesToResponsesAPIHandler.async_anthropic_messages_handler(
+            max_tokens=1024,
+            messages=MESSAGES,
+            model="openai/gpt-5.6-luna",
+            stream=True,
+            custom_llm_provider="openai",
+        )
+
+    import inspect
+
+    assert inspect.isasyncgen(returned)
+    found_message_stop = False
+    async for chunk in returned:
+        if b"message_stop" in chunk:
+            found_message_stop = True
+            break
+    assert found_message_stop

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/responses_adapters/test_responses_adapters_transformation.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/responses_adapters/test_responses_adapters_transformation.py
@@ -1971,3 +1971,52 @@ class TestPromptCacheBreakpointToResponses:
             extra_kwargs={"prompt_cache_options": {"mode": "explicit"}},
         )
         assert kwargs["prompt_cache_options"] == {"mode": "explicit"}
+
+
+class TestTranslateResponseHeaders:
+    """The llm_provider-* header mirror must survive the Responses -> Anthropic conversion.
+
+    The proxy reads `_hidden_params["additional_headers"]` to forward upstream
+    response headers to clients as `llm_provider-*`. The inner
+    ResponsesAPIResponse carries the mirror; without propagation the returned
+    TypedDict (a shape that cannot carry attributes) drops it, so
+    /v1/messages loses every upstream response header while
+    /v1/chat/completions for the same deployment forwards them.
+    """
+
+    def test_additional_headers_are_copied_onto_the_anthropic_response(self):
+        response = _make_mock_response(output=[_make_output_message(["Hello!"])])
+        response._hidden_params = {
+            "additional_headers": {"llm_provider-x-cortecs-provider": "tensorix"},
+            "model_id": "deployment-1",
+        }
+        result: Any = _ADAPTER.translate_response(response)
+        assert result["_hidden_params"] == {
+            "additional_headers": {"llm_provider-x-cortecs-provider": "tensorix"}
+        }
+
+    def test_additional_headers_copy_is_isolated_from_the_inner_response(self):
+        response = _make_mock_response(output=[_make_output_message(["Hello!"])])
+        hidden = {"additional_headers": {"llm_provider-x-test": "1"}}
+        response._hidden_params = hidden
+        result: Any = _ADAPTER.translate_response(response)
+        result["_hidden_params"]["additional_headers"]["llm_provider-x-test"] = "mutated"
+        assert hidden["additional_headers"]["llm_provider-x-test"] == "1"
+
+    def test_no_hidden_params_means_no_key(self):
+        response = _make_mock_response(output=[_make_output_message(["Hello!"])])
+        del response._hidden_params  # MagicMock auto-attrs: remove, so getattr misses
+        result: Any = _ADAPTER.translate_response(response)
+        assert "_hidden_params" not in result
+
+    def test_hidden_params_without_additional_headers_means_no_key(self):
+        response = _make_mock_response(output=[_make_output_message(["Hello!"])])
+        response._hidden_params = {"model_id": "deployment-1"}
+        result: Any = _ADAPTER.translate_response(response)
+        assert "_hidden_params" not in result
+
+    def test_non_dict_hidden_params_are_ignored(self):
+        response = _make_mock_response(output=[_make_output_message(["Hello!"])])
+        response._hidden_params = "not-a-dict"
+        result: Any = _ADAPTER.translate_response(response)
+        assert "_hidden_params" not in result


### PR DESCRIPTION
## The bug

On `POST /v1/messages` with an OpenAI-compatible upstream (a deployment with `litellm_params.model: openai/<model>` and a custom `api_base`), requests are dispatched through the messages-to-Responses bridge. Both conversion outputs are shapes that cannot carry `_hidden_params`, so the upstream header mirror (`llm_provider-*`, built into `_hidden_params["additional_headers"]` by `get_response_headers`) is lost:

- **non-streaming:** `translate_response()` builds a fresh `AnthropicMessagesResponse` TypedDict from the `ResponsesAPIResponse`; the inner response's `_hidden_params["additional_headers"]` is discarded.
- **streaming:** `AnthropicResponsesStreamWrapper.async_anthropic_sse_wrapper()` returns a bare async generator; the inner `BaseResponsesAPIStreamingIterator` — which builds `_hidden_params["additional_headers"]` from its response headers at construction — is captured in a closure.

The proxy therefore sends **no `llm_provider-*` headers on `/v1/messages`**, while `/v1/chat/completions` for the *same deployment* forwards them. Measured on a live proxy (v1.99.0, proxying an OpenAI-compatible router):

```
$ curl -sS -D - .../v1/chat/completions -d '{"model":"m","stream":true,...}'
llm_provider-x-cortecs-provider: tensorix
llm_provider-x-cortecs-model: glm-5.3-flash

$ curl -sS -D - .../v1/messages   -d '{"model":"m","stream":true,...}'
(no llm_provider-* headers)
```

## Why no callback can fix it

The proxy logging object's `model_call_details` is never stamped with `response_headers` on this path (that stamp exists only in the chat-completions SDK paths), and the only carriers of the mirror are consumed inside the adapter before `post_call_response_headers_hook` runs — the proxy sees only the converted shapes. Verified with instrumented hooks against a running proxy.

## The fix

Propagate the mirror at the two conversion points, reusing the mechanism introduced for the passthrough path in #32160:

1. non-streaming: attach `_hidden_params = {"additional_headers": ...}` to the returned TypedDict. The proxy already reads a dict-shaped `_hidden_params` key via `get_hidden_params_dict()` and pops it from the body before serialising.
2. streaming: wrap the SSE generator in `AnthropicMessagesStreamingResponse` (the passthrough route's attribute-carrying shape; still an `AsyncIterator`, so streaming detection is unchanged), carrying the inner stream's `additional_headers` when present.

## Tests

- `translate_response` copies `additional_headers` when present (and the copy is isolated from the inner response), adds no key when absent or non-dict.
- the streaming handler returns `AnthropicMessagesStreamingResponse` carrying the mirror when the inner stream has one (SSE still flows through), the bare generator otherwise.

All 173 tests in `tests/test_litellm/llms/anthropic/experimental_pass_through/` pass (894 across the suite), plus `ruff format`/`ruff check` on the touched source files.

## Notes

The same loss exists in the messages-to-chat-completions bridge (`llms/anthropic/experimental_pass_through/adapters/handler.py`) and the sync handlers — happy to extend this PR (or split it) if you prefer those covered too.

- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
