### PR TITLE
fix(mcp): follow tools/list pagination from upstream servers

### DIFF
--- a/litellm/constants.py
+++ b/litellm/constants.py
@@ -136,6 +136,7 @@ MCP_CLIENT_TIMEOUT: Final = float(os.getenv("LITELLM_MCP_CLIENT_TIMEOUT", "60.0"
 MCP_TOOL_LISTING_TIMEOUT: Final = float(os.getenv("LITELLM_MCP_TOOL_LISTING_TIMEOUT", "30.0"))
 MCP_METADATA_TIMEOUT: Final = float(os.getenv("LITELLM_MCP_METADATA_TIMEOUT", "10.0"))
 MCP_HEALTH_CHECK_TIMEOUT: Final = float(os.getenv("LITELLM_MCP_HEALTH_CHECK_TIMEOUT", "10.0"))
+MCP_TOOL_LISTING_MAX_PAGES: Final = 1000
 
 # Allowlist of commands permitted for MCP stdio transport.
 # Prevents arbitrary command execution via /mcp-rest/test/* endpoints or server creation.

--- a/litellm/experimental_mcp_client/client.py
+++ b/litellm/experimental_mcp_client/client.py
@@ -39,7 +39,6 @@ from mcp.types import CallToolResult as MCPCallToolResult
 from mcp.types import (
     GetPromptRequestParams,
     GetPromptResult,
-    PaginatedRequestParams,
     Prompt,
     ResourceTemplate,
     TextContent,
@@ -48,7 +47,8 @@ from mcp.types import Tool as MCPTool
 from pydantic import AnyUrl
 
 from litellm._logging import verbose_logger
-from litellm.constants import MCP_CLIENT_TIMEOUT, MCP_NPM_CACHE_DIR, MCP_TOOL_LISTING_MAX_PAGES
+from litellm.constants import MCP_CLIENT_TIMEOUT, MCP_NPM_CACHE_DIR
+from litellm.experimental_mcp_client.tools import list_tools_with_pagination
 from litellm.llms.custom_httpx.http_handler import get_ssl_configuration
 from litellm.types.llms.custom_http import VerifyTypes
 from litellm.types.mcp import (
@@ -604,42 +604,10 @@ class MCPClient:
         """
         verbose_logger.debug("MCP client listing tools from %s", self.server_url or "stdio")
 
-        async def _list_tools_operation(session: ClientSession) -> list[MCPTool]:
-            tools: list[MCPTool] = []
-            cursor: Optional[str] = None
-            pages_fetched = 0
-            seen_cursors: set[str] = set()
-
-            while True:
-                result = (
-                    await session.list_tools()
-                    if cursor is None
-                    else await session.list_tools(params=PaginatedRequestParams(cursor=cursor))
-                )
-                pages_fetched += 1
-                tools.extend(result.tools)
-
-                next_cursor = getattr(result, "nextCursor", None)
-                if not isinstance(next_cursor, str):
-                    return tools
-                if next_cursor in seen_cursors:
-                    raise RuntimeError(
-                        f"MCP server returned a repeated tools/list cursor while listing tools: {next_cursor}"
-                    )
-                if pages_fetched >= MCP_TOOL_LISTING_MAX_PAGES:
-                    verbose_logger.warning(
-                        "MCP server tools/list pagination exceeded the maximum "
-                        f"of {MCP_TOOL_LISTING_MAX_PAGES} pages while listing tools; "
-                        f"returning {len(tools)} tools collected so far"
-                    )
-                    return tools
-                seen_cursors.add(next_cursor)
-                cursor = next_cursor
-
         try:
-            tools: Final = await self.run_with_session(_list_tools_operation, quiet_on_error=raise_on_error)
+            tools: Final = await self.run_with_session(list_tools_with_pagination, quiet_on_error=raise_on_error)
             tool_count: Final = len(tools)
-            tool_names: Final = [tool.name for tool in tools]
+            tool_names: Final = tuple(tool.name for tool in tools)
             verbose_logger.info(
                 "MCP client listed %s tools from %s: %s", tool_count, self.server_url or "stdio", tool_names
             )

--- a/litellm/experimental_mcp_client/client.py
+++ b/litellm/experimental_mcp_client/client.py
@@ -39,6 +39,7 @@ from mcp.types import CallToolResult as MCPCallToolResult
 from mcp.types import (
     GetPromptRequestParams,
     GetPromptResult,
+    PaginatedRequestParams,
     Prompt,
     ResourceTemplate,
     TextContent,
@@ -47,7 +48,7 @@ from mcp.types import Tool as MCPTool
 from pydantic import AnyUrl
 
 from litellm._logging import verbose_logger
-from litellm.constants import MCP_CLIENT_TIMEOUT, MCP_NPM_CACHE_DIR
+from litellm.constants import MCP_CLIENT_TIMEOUT, MCP_NPM_CACHE_DIR, MCP_TOOL_LISTING_MAX_PAGES
 from litellm.llms.custom_httpx.http_handler import get_ssl_configuration
 from litellm.types.llms.custom_http import VerifyTypes
 from litellm.types.mcp import (
@@ -603,17 +604,46 @@ class MCPClient:
         """
         verbose_logger.debug("MCP client listing tools from %s", self.server_url or "stdio")
 
-        async def _list_tools_operation(session: ClientSession):
-            return await session.list_tools()
+        async def _list_tools_operation(session: ClientSession) -> list[MCPTool]:
+            tools: list[MCPTool] = []
+            cursor: Optional[str] = None
+            pages_fetched = 0
+            seen_cursors: set[str] = set()
+
+            while True:
+                result = (
+                    await session.list_tools()
+                    if cursor is None
+                    else await session.list_tools(params=PaginatedRequestParams(cursor=cursor))
+                )
+                pages_fetched += 1
+                tools.extend(result.tools)
+
+                next_cursor = getattr(result, "nextCursor", None)
+                if not isinstance(next_cursor, str):
+                    return tools
+                if next_cursor in seen_cursors:
+                    raise RuntimeError(
+                        f"MCP server returned a repeated tools/list cursor while listing tools: {next_cursor}"
+                    )
+                if pages_fetched >= MCP_TOOL_LISTING_MAX_PAGES:
+                    verbose_logger.warning(
+                        "MCP server tools/list pagination exceeded the maximum "
+                        f"of {MCP_TOOL_LISTING_MAX_PAGES} pages while listing tools; "
+                        f"returning {len(tools)} tools collected so far"
+                    )
+                    return tools
+                seen_cursors.add(next_cursor)
+                cursor = next_cursor
 
         try:
-            result: Final = await self.run_with_session(_list_tools_operation, quiet_on_error=raise_on_error)
-            tool_count: Final = len(result.tools)
-            tool_names: Final = [tool.name for tool in result.tools]
+            tools: Final = await self.run_with_session(_list_tools_operation, quiet_on_error=raise_on_error)
+            tool_count: Final = len(tools)
+            tool_names: Final = [tool.name for tool in tools]
             verbose_logger.info(
                 "MCP client listed %s tools from %s: %s", tool_count, self.server_url or "stdio", tool_names
             )
-            return result.tools
+            return tools
         except asyncio.CancelledError:
             verbose_logger.warning("MCP client list_tools was cancelled")
             raise

--- a/litellm/experimental_mcp_client/client.py
+++ b/litellm/experimental_mcp_client/client.py
@@ -7,6 +7,7 @@ import base64
 import os
 from collections.abc import Awaitable, Callable, Generator
 from datetime import timedelta
+from functools import partial
 from importlib import metadata
 from typing import Any, Final, TypeVar
 
@@ -47,7 +48,7 @@ from mcp.types import Tool as MCPTool
 from pydantic import AnyUrl
 
 from litellm._logging import verbose_logger
-from litellm.constants import MCP_CLIENT_TIMEOUT, MCP_NPM_CACHE_DIR
+from litellm.constants import MCP_CLIENT_TIMEOUT, MCP_NPM_CACHE_DIR, MCP_TOOL_LISTING_TIMEOUT
 from litellm.experimental_mcp_client.tools import list_tools_with_pagination
 from litellm.llms.custom_httpx.http_handler import get_ssl_configuration
 from litellm.types.llms.custom_http import VerifyTypes
@@ -605,7 +606,12 @@ class MCPClient:
         verbose_logger.debug("MCP client listing tools from %s", self.server_url or "stdio")
 
         try:
-            tools: Final = await self.run_with_session(list_tools_with_pagination, quiet_on_error=raise_on_error)
+            # A per-server timeout above the global default extends the whole-walk deadline
+            listing_deadline: Final = max(self.timeout, MCP_TOOL_LISTING_TIMEOUT)
+            tools: Final = await self.run_with_session(
+                partial(list_tools_with_pagination, listing_deadline=listing_deadline),
+                quiet_on_error=raise_on_error,
+            )
             tool_count: Final = len(tools)
             tool_names: Final = tuple(tool.name for tool in tools)
             verbose_logger.info(

--- a/litellm/experimental_mcp_client/tools.py
+++ b/litellm/experimental_mcp_client/tools.py
@@ -4,11 +4,14 @@ from typing import Final, Literal
 from mcp import ClientSession
 from mcp.types import CallToolRequestParams as MCPCallToolRequestParams
 from mcp.types import CallToolResult as MCPCallToolResult
+from mcp.types import PaginatedRequestParams
 from mcp.types import Tool as MCPTool
 from openai.types.chat import ChatCompletionToolParam
 from openai.types.responses.function_tool_param import FunctionToolParam
 from openai.types.shared_params.function_definition import FunctionDefinition
 
+from litellm._logging import verbose_logger
+from litellm.constants import MCP_TOOL_LISTING_MAX_PAGES
 from litellm.types.llms.anthropic import AnthropicMessagesTool
 from litellm.types.utils import ChatCompletionMessageToolCall
 
@@ -90,6 +93,45 @@ def transform_mcp_tool_to_anthropic_tool(mcp_tool: MCPTool) -> AnthropicMessages
     )
 
 
+async def list_tools_with_pagination(session: ClientSession) -> list[MCPTool]:  # mutable-ok: list return contract
+    """Collect tools from every tools/list page by following nextCursor.
+
+    Stops and returns the tools collected so far when the upstream repeats a
+    cursor or the page cap is reached, so a buggy upstream yields a partial
+    catalog instead of an error.
+    """
+    tools: Final[list[MCPTool]] = []  # mutable-ok: accumulates each page's tools
+    seen_cursors: Final[set[str]] = set()  # mutable-ok: guards against cursor loops
+    cursor: str | None = None  # rebind-ok: advances to each page's nextCursor
+
+    for _ in range(MCP_TOOL_LISTING_MAX_PAGES):
+        result = (
+            await session.list_tools()
+            if cursor is None
+            else await session.list_tools(params=PaginatedRequestParams(cursor=cursor))
+        )
+        tools.extend(result.tools)
+
+        next_cursor = getattr(result, "nextCursor", None)
+        if not isinstance(next_cursor, str) or not next_cursor:
+            return tools
+        if next_cursor in seen_cursors:
+            verbose_logger.warning(
+                "MCP server repeated a tools/list cursor while listing tools; returning %s tools collected so far",
+                len(tools),
+            )
+            return tools
+        seen_cursors.add(next_cursor)
+        cursor = next_cursor
+
+    verbose_logger.warning(
+        "MCP server tools/list pagination exceeded the maximum of %s pages; returning %s tools collected so far",
+        MCP_TOOL_LISTING_MAX_PAGES,
+        len(tools),
+    )
+    return tools
+
+
 async def load_mcp_tools(
     session: ClientSession, format: Literal["mcp", "openai"] = "mcp"
 ) -> list[MCPTool] | list[ChatCompletionToolParam]:
@@ -103,10 +145,12 @@ async def load_mcp_tools(
 
     If format is set to "openai", the tools are converted to OpenAI API compatible tools.
     """
-    tools: Final = await session.list_tools()
+    tools: Final = await list_tools_with_pagination(session)
     if format == "openai":
-        return [transform_mcp_tool_to_openai_tool(mcp_tool=tool) for tool in tools.tools]
-    return tools.tools
+        return [  # mutable-ok: public API returns a list
+            transform_mcp_tool_to_openai_tool(mcp_tool=tool) for tool in tools
+        ]
+    return tools
 
 
 ########################################################

--- a/litellm/experimental_mcp_client/tools.py
+++ b/litellm/experimental_mcp_client/tools.py
@@ -98,12 +98,16 @@ def transform_mcp_tool_to_anthropic_tool(mcp_tool: MCPTool) -> AnthropicMessages
     )
 
 
-async def list_tools_with_pagination(session: ClientSession) -> list[MCPTool]:  # mutable-ok: list return contract
+async def list_tools_with_pagination(
+    session: ClientSession, listing_deadline: float | None = None
+) -> list[MCPTool]:  # mutable-ok: list return contract
     """Collect tools from every tools/list page by following nextCursor.
 
     Stops and returns the tools collected so far when the upstream repeats a
     cursor, the page cap is reached, or the whole-walk deadline expires, so a
     buggy or slow upstream yields a partial catalog instead of an error.
+    listing_deadline overrides the default whole-walk deadline; callers with a
+    per-server timeout above the global default pass it through here.
     """
     tools: Final[list[MCPTool]] = []  # mutable-ok: accumulates each page's tools
     seen_cursors: Final[set[str]] = set()  # mutable-ok: guards against cursor loops
@@ -112,9 +116,11 @@ async def list_tools_with_pagination(session: ClientSession) -> list[MCPTool]:  
     # walk needs its own overall deadline. max() keeps the pre-pagination guarantee
     # that a single page slower than the listing timeout but within the client
     # timeout still succeeds.
-    listing_deadline: Final = max(MCP_CLIENT_TIMEOUT, MCP_TOOL_LISTING_TIMEOUT)
+    effective_deadline: Final = (
+        listing_deadline if listing_deadline is not None else max(MCP_CLIENT_TIMEOUT, MCP_TOOL_LISTING_TIMEOUT)
+    )
 
-    with anyio.move_on_after(listing_deadline):
+    with anyio.move_on_after(effective_deadline):
         for _ in range(MCP_TOOL_LISTING_MAX_PAGES):
             result = (
                 await session.list_tools()
@@ -144,7 +150,7 @@ async def list_tools_with_pagination(session: ClientSession) -> list[MCPTool]:  
 
     verbose_logger.warning(
         "MCP server tools/list pagination exceeded the %s second listing deadline; returning %s tools collected so far",
-        listing_deadline,
+        effective_deadline,
         len(tools),
     )
     return tools

--- a/litellm/experimental_mcp_client/tools.py
+++ b/litellm/experimental_mcp_client/tools.py
@@ -1,6 +1,7 @@
 import json
 from typing import Final, Literal
 
+import anyio
 from mcp import ClientSession
 from mcp.types import CallToolRequestParams as MCPCallToolRequestParams
 from mcp.types import CallToolResult as MCPCallToolResult
@@ -11,7 +12,11 @@ from openai.types.responses.function_tool_param import FunctionToolParam
 from openai.types.shared_params.function_definition import FunctionDefinition
 
 from litellm._logging import verbose_logger
-from litellm.constants import MCP_TOOL_LISTING_MAX_PAGES
+from litellm.constants import (
+    MCP_CLIENT_TIMEOUT,
+    MCP_TOOL_LISTING_MAX_PAGES,
+    MCP_TOOL_LISTING_TIMEOUT,
+)
 from litellm.types.llms.anthropic import AnthropicMessagesTool
 from litellm.types.utils import ChatCompletionMessageToolCall
 
@@ -97,36 +102,49 @@ async def list_tools_with_pagination(session: ClientSession) -> list[MCPTool]:  
     """Collect tools from every tools/list page by following nextCursor.
 
     Stops and returns the tools collected so far when the upstream repeats a
-    cursor or the page cap is reached, so a buggy upstream yields a partial
-    catalog instead of an error.
+    cursor, the page cap is reached, or the whole-walk deadline expires, so a
+    buggy or slow upstream yields a partial catalog instead of an error.
     """
     tools: Final[list[MCPTool]] = []  # mutable-ok: accumulates each page's tools
     seen_cursors: Final[set[str]] = set()  # mutable-ok: guards against cursor loops
     cursor: str | None = None  # rebind-ok: advances to each page's nextCursor
+    # The per-request session read timeout restarts on every page, so a multi-page
+    # walk needs its own overall deadline. max() keeps the pre-pagination guarantee
+    # that a single page slower than the listing timeout but within the client
+    # timeout still succeeds.
+    listing_deadline: Final = max(MCP_CLIENT_TIMEOUT, MCP_TOOL_LISTING_TIMEOUT)
 
-    for _ in range(MCP_TOOL_LISTING_MAX_PAGES):
-        result = (
-            await session.list_tools()
-            if cursor is None
-            else await session.list_tools(params=PaginatedRequestParams(cursor=cursor))
-        )
-        tools.extend(result.tools)
-
-        next_cursor = getattr(result, "nextCursor", None)
-        if not isinstance(next_cursor, str) or not next_cursor:
-            return tools
-        if next_cursor in seen_cursors:
-            verbose_logger.warning(
-                "MCP server repeated a tools/list cursor while listing tools; returning %s tools collected so far",
-                len(tools),
+    with anyio.move_on_after(listing_deadline):
+        for _ in range(MCP_TOOL_LISTING_MAX_PAGES):
+            result = (
+                await session.list_tools()
+                if cursor is None
+                else await session.list_tools(params=PaginatedRequestParams(cursor=cursor))
             )
-            return tools
-        seen_cursors.add(next_cursor)
-        cursor = next_cursor
+            tools.extend(result.tools)
+
+            next_cursor = getattr(result, "nextCursor", None)
+            if not isinstance(next_cursor, str) or not next_cursor:
+                return tools
+            if next_cursor in seen_cursors:
+                verbose_logger.warning(
+                    "MCP server repeated a tools/list cursor while listing tools; returning %s tools collected so far",
+                    len(tools),
+                )
+                return tools
+            seen_cursors.add(next_cursor)
+            cursor = next_cursor
+
+        verbose_logger.warning(
+            "MCP server tools/list pagination exceeded the maximum of %s pages; returning %s tools collected so far",
+            MCP_TOOL_LISTING_MAX_PAGES,
+            len(tools),
+        )
+        return tools
 
     verbose_logger.warning(
-        "MCP server tools/list pagination exceeded the maximum of %s pages; returning %s tools collected so far",
-        MCP_TOOL_LISTING_MAX_PAGES,
+        "MCP server tools/list pagination exceeded the %s second listing deadline; returning %s tools collected so far",
+        listing_deadline,
         len(tools),
     )
     return tools

--- a/litellm/proxy/_experimental/mcp_server/rest_endpoints.py
+++ b/litellm/proxy/_experimental/mcp_server/rest_endpoints.py
@@ -4,10 +4,12 @@ from collections.abc import Awaitable, Callable, Mapping
 from datetime import datetime
 from typing import TYPE_CHECKING, Any, Final, Literal
 
+import anyio
 import httpx
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
 
 from litellm._logging import verbose_logger
+from litellm.constants import MCP_CLIENT_TIMEOUT, MCP_TOOL_LISTING_TIMEOUT
 from litellm.exceptions import (
     BlockedPiiEntityError,
     GuardrailRaisedException,
@@ -86,8 +88,6 @@ def _connection_error_message(exc: BaseException) -> str:
 
 
 if MCP_AVAILABLE:
-    from mcp.types import Tool as MCPTool
-
     from litellm.proxy._experimental.mcp_server.mcp_server_manager import (
         _UPSTREAM_OAUTH_DISCOVERY_AUTH_TYPES,
         global_mcp_server_manager,
@@ -1402,7 +1402,24 @@ if MCP_AVAILABLE:
             oauth2_headers = MCPRequestHandler._get_oauth2_headers_from_headers(headers)
 
         async def _list_tools_operation(client):
-            list_tools_result: Final[list[MCPTool]] = await client.list_tools(raise_on_error=True)
+            # Bound the whole pagination walk: without this the preview is limited only by the
+            # per-request timeout times the page cap. max() keeps the pre-pagination guarantee
+            # that a single slow page within the client timeout still succeeds.
+            listing_deadline: Final = max(MCP_CLIENT_TIMEOUT, MCP_TOOL_LISTING_TIMEOUT)
+            list_tools_result = None  # rebind-ok: set inside the timeout scope below
+            with anyio.move_on_after(listing_deadline):
+                list_tools_result = await client.list_tools(raise_on_error=True)
+            if list_tools_result is None:
+                verbose_logger.warning(
+                    "MCP tools/list preview timed out after %s seconds while paginating upstream tools",
+                    listing_deadline,
+                )
+                return {  # mutable-ok: error response payload
+                    "status": "error",
+                    "error": True,
+                    "message": f"Timed out listing tools after {listing_deadline} seconds. "
+                    "The MCP server may be responding slowly or paginating excessively.",
+                }
             model_dumped_tools: Final[list[dict]] = [tool.model_dump() for tool in list_tools_result]
             return {
                 "tools": model_dumped_tools,

--- a/litellm/proxy/_experimental/mcp_server/rest_endpoints.py
+++ b/litellm/proxy/_experimental/mcp_server/rest_endpoints.py
@@ -1404,8 +1404,12 @@ if MCP_AVAILABLE:
         async def _list_tools_operation(client):
             # Bound the whole pagination walk: without this the preview is limited only by the
             # per-request timeout times the page cap. max() keeps the pre-pagination guarantee
-            # that a single slow page within the client timeout still succeeds.
-            listing_deadline: Final = max(MCP_CLIENT_TIMEOUT, MCP_TOOL_LISTING_TIMEOUT)
+            # that a single slow page within the client timeout still succeeds, and a
+            # per-server timeout above the global default extends the deadline with it.
+            listing_deadline: Final = max(
+                getattr(client, "timeout", MCP_CLIENT_TIMEOUT) or MCP_CLIENT_TIMEOUT,
+                MCP_TOOL_LISTING_TIMEOUT,
+            )
             list_tools_result = None  # rebind-ok: set inside the timeout scope below
             with anyio.move_on_after(listing_deadline):
                 list_tools_result = await client.list_tools(raise_on_error=True)  # rebind-ok: fills the init above

--- a/litellm/proxy/_experimental/mcp_server/rest_endpoints.py
+++ b/litellm/proxy/_experimental/mcp_server/rest_endpoints.py
@@ -1402,11 +1402,7 @@ if MCP_AVAILABLE:
             oauth2_headers = MCPRequestHandler._get_oauth2_headers_from_headers(headers)
 
         async def _list_tools_operation(client):
-            async def _list_tools_session_operation(session):
-                return await session.list_tools()
-
-            list_tools_response: Final = await client.run_with_session(_list_tools_session_operation)
-            list_tools_result: Final[list[MCPTool]] = list_tools_response.tools
+            list_tools_result: Final[list[MCPTool]] = await client.list_tools(raise_on_error=True)
             model_dumped_tools: Final[list[dict]] = [tool.model_dump() for tool in list_tools_result]
             return {
                 "tools": model_dumped_tools,

--- a/litellm/proxy/_experimental/mcp_server/rest_endpoints.py
+++ b/litellm/proxy/_experimental/mcp_server/rest_endpoints.py
@@ -1408,7 +1408,7 @@ if MCP_AVAILABLE:
             listing_deadline: Final = max(MCP_CLIENT_TIMEOUT, MCP_TOOL_LISTING_TIMEOUT)
             list_tools_result = None  # rebind-ok: set inside the timeout scope below
             with anyio.move_on_after(listing_deadline):
-                list_tools_result = await client.list_tools(raise_on_error=True)
+                list_tools_result = await client.list_tools(raise_on_error=True)  # rebind-ok: fills the init above
             if list_tools_result is None:
                 verbose_logger.warning(
                     "MCP tools/list preview timed out after %s seconds while paginating upstream tools",

--- a/litellm/proxy/_experimental/mcp_server/rest_endpoints.py
+++ b/litellm/proxy/_experimental/mcp_server/rest_endpoints.py
@@ -1173,6 +1173,7 @@ if MCP_AVAILABLE:
                 transport=request.transport,
                 auth_type=request.auth_type,
                 mcp_info=request.mcp_info,
+                timeout=request.timeout,
                 command=request.command,
                 args=request.args,
                 env=request.env,

--- a/tests/mcp_tests/test_mcp_client_unit.py
+++ b/tests/mcp_tests/test_mcp_client_unit.py
@@ -11,7 +11,9 @@ from unittest.mock import AsyncMock, MagicMock, patch, ANY
 import litellm.experimental_mcp_client.client as mcp_client_module
 from litellm.experimental_mcp_client.client import MCPClient
 from litellm.types.mcp import MCPAuth, MCPTransport
-from mcp.types import Tool as MCPTool, CallToolResult as MCPCallToolResult
+from mcp.types import CallToolResult as MCPCallToolResult
+from mcp.types import ListToolsResult, PaginatedRequestParams
+from mcp.types import Tool as MCPTool
 
 
 def test_mcp_client_uses_configurable_default_timeout():
@@ -184,6 +186,119 @@ class TestMCPClientUnitTests:
         assert result == mock_tools
         mock_session_instance.initialize.assert_called_once()
         mock_session_instance.list_tools.assert_called_once()
+
+    @pytest.mark.asyncio
+    @patch.object(mcp_client_module, "streamable_http_client")
+    @patch.object(mcp_client_module, "ClientSession")
+    async def test_list_tools_follows_next_cursor_until_exhausted(
+        self,
+        mock_session_class,
+        mock_transport,
+    ):
+        """Test listing tools follows MCP pagination cursors until exhausted."""
+        mock_transport_ctx = AsyncMock()
+        mock_transport.return_value = mock_transport_ctx
+        mock_transport_instance = MagicMock()
+        mock_transport_ctx.__aenter__ = AsyncMock(return_value=mock_transport_instance)
+
+        mock_session_ctx = AsyncMock()
+        mock_session_class.return_value = mock_session_ctx
+        mock_session_instance = AsyncMock()
+        mock_session_ctx.__aenter__ = AsyncMock(return_value=mock_session_instance)
+
+        first_page_tools = [
+            MCPTool(name=f"tool_{idx}", description=f"Tool {idx}", inputSchema={}) for idx in range(100)
+        ]
+        second_page_tool = MCPTool(
+            name="tool_100",
+            description="Tool 100",
+            inputSchema={},
+        )
+        mock_session_instance.list_tools.side_effect = [
+            ListToolsResult(tools=first_page_tools, nextCursor="page-2"),
+            ListToolsResult(tools=[second_page_tool]),
+        ]
+
+        client = MCPClient("http://example.com")
+        result = await client.list_tools()
+
+        assert result == [*first_page_tools, second_page_tool]
+        assert mock_session_instance.list_tools.call_count == 2
+        second_call_params = mock_session_instance.list_tools.call_args_list[1].kwargs["params"]
+        assert isinstance(second_call_params, PaginatedRequestParams)
+        assert second_call_params.cursor == "page-2"
+
+    @pytest.mark.asyncio
+    @patch.object(mcp_client_module, "streamable_http_client")
+    @patch.object(mcp_client_module, "ClientSession")
+    async def test_list_tools_stops_when_pagination_reaches_page_cap(
+        self,
+        mock_session_class,
+        mock_transport,
+        monkeypatch,
+    ):
+        """Test listing tools returns accumulated tools if an upstream keeps returning new cursors."""
+        monkeypatch.setattr(mcp_client_module, "MCP_TOOL_LISTING_MAX_PAGES", 2, raising=False)
+
+        mock_transport_ctx = AsyncMock()
+        mock_transport.return_value = mock_transport_ctx
+        mock_transport_instance = MagicMock()
+        mock_transport_ctx.__aenter__ = AsyncMock(return_value=mock_transport_instance)
+
+        mock_session_ctx = AsyncMock()
+        mock_session_class.return_value = mock_session_ctx
+        mock_session_instance = AsyncMock()
+        mock_session_ctx.__aenter__ = AsyncMock(return_value=mock_session_instance)
+
+        mock_session_instance.list_tools.side_effect = [
+            ListToolsResult(
+                tools=[MCPTool(name="tool_0", description="Tool 0", inputSchema={})],
+                nextCursor="page-2",
+            ),
+            ListToolsResult(
+                tools=[MCPTool(name="tool_1", description="Tool 1", inputSchema={})],
+                nextCursor="page-3",
+            ),
+            ListToolsResult(
+                tools=[MCPTool(name="tool_2", description="Tool 2", inputSchema={})],
+            ),
+        ]
+
+        client = MCPClient("http://example.com")
+        result = await client.list_tools(raise_on_error=True)
+
+        assert [tool.name for tool in result] == ["tool_0", "tool_1"]
+        assert mock_session_instance.list_tools.call_count == 2
+
+    @pytest.mark.asyncio
+    @patch.object(mcp_client_module, "streamable_http_client")
+    @patch.object(mcp_client_module, "ClientSession")
+    async def test_list_tools_raises_on_repeated_next_cursor(
+        self,
+        mock_session_class,
+        mock_transport,
+    ):
+        """Test listing tools fails if an upstream repeats a cursor."""
+        mock_transport_ctx = AsyncMock()
+        mock_transport.return_value = mock_transport_ctx
+        mock_transport_instance = MagicMock()
+        mock_transport_ctx.__aenter__ = AsyncMock(return_value=mock_transport_instance)
+
+        mock_session_ctx = AsyncMock()
+        mock_session_class.return_value = mock_session_ctx
+        mock_session_instance = AsyncMock()
+        mock_session_ctx.__aenter__ = AsyncMock(return_value=mock_session_instance)
+
+        mock_session_instance.list_tools.side_effect = [
+            ListToolsResult(tools=[], nextCursor="same-cursor"),
+            ListToolsResult(tools=[], nextCursor="same-cursor"),
+        ]
+
+        client = MCPClient("http://example.com")
+        with pytest.raises(RuntimeError, match="repeated tools/list cursor"):
+            await client.list_tools(raise_on_error=True)
+
+        assert mock_session_instance.list_tools.call_count == 2
 
     @pytest.mark.asyncio
     @patch.object(mcp_client_module, "streamable_http_client")

--- a/tests/mcp_tests/test_mcp_client_unit.py
+++ b/tests/mcp_tests/test_mcp_client_unit.py
@@ -238,7 +238,7 @@ class TestMCPClientUnitTests:
         monkeypatch,
     ):
         """Test listing tools returns accumulated tools if an upstream keeps returning new cursors."""
-        monkeypatch.setattr(mcp_client_module, "MCP_TOOL_LISTING_MAX_PAGES", 2, raising=False)
+        monkeypatch.setattr("litellm.experimental_mcp_client.tools.MCP_TOOL_LISTING_MAX_PAGES", 2)
 
         mock_transport_ctx = AsyncMock()
         mock_transport.return_value = mock_transport_ctx
@@ -273,12 +273,12 @@ class TestMCPClientUnitTests:
     @pytest.mark.asyncio
     @patch.object(mcp_client_module, "streamable_http_client")
     @patch.object(mcp_client_module, "ClientSession")
-    async def test_list_tools_raises_on_repeated_next_cursor(
+    async def test_list_tools_stops_on_repeated_next_cursor(
         self,
         mock_session_class,
         mock_transport,
     ):
-        """Test listing tools fails if an upstream repeats a cursor."""
+        """Test listing tools returns collected tools when an upstream repeats a cursor."""
         mock_transport_ctx = AsyncMock()
         mock_transport.return_value = mock_transport_ctx
         mock_transport_instance = MagicMock()
@@ -290,14 +290,85 @@ class TestMCPClientUnitTests:
         mock_session_ctx.__aenter__ = AsyncMock(return_value=mock_session_instance)
 
         mock_session_instance.list_tools.side_effect = [
-            ListToolsResult(tools=[], nextCursor="same-cursor"),
-            ListToolsResult(tools=[], nextCursor="same-cursor"),
+            ListToolsResult(
+                tools=[MCPTool(name="tool_0", description="Tool 0", inputSchema={})],
+                nextCursor="same-cursor",
+            ),
+            ListToolsResult(
+                tools=[MCPTool(name="tool_1", description="Tool 1", inputSchema={})],
+                nextCursor="same-cursor",
+            ),
         ]
 
         client = MCPClient("http://example.com")
-        with pytest.raises(RuntimeError, match="repeated tools/list cursor"):
-            await client.list_tools(raise_on_error=True)
+        result = await client.list_tools(raise_on_error=True)
 
+        assert [tool.name for tool in result] == ["tool_0", "tool_1"]
+        assert mock_session_instance.list_tools.call_count == 2
+
+    @pytest.mark.asyncio
+    @patch.object(mcp_client_module, "streamable_http_client")
+    @patch.object(mcp_client_module, "ClientSession")
+    async def test_list_tools_treats_empty_cursor_as_terminal(
+        self,
+        mock_session_class,
+        mock_transport,
+    ):
+        """Test listing tools stops when an upstream returns an empty-string cursor."""
+        mock_transport_ctx = AsyncMock()
+        mock_transport.return_value = mock_transport_ctx
+        mock_transport_instance = MagicMock()
+        mock_transport_ctx.__aenter__ = AsyncMock(return_value=mock_transport_instance)
+
+        mock_session_ctx = AsyncMock()
+        mock_session_class.return_value = mock_session_ctx
+        mock_session_instance = AsyncMock()
+        mock_session_ctx.__aenter__ = AsyncMock(return_value=mock_session_instance)
+
+        mock_session_instance.list_tools.side_effect = [
+            ListToolsResult(
+                tools=[MCPTool(name="tool_0", description="Tool 0", inputSchema={})],
+                nextCursor="",
+            ),
+        ]
+
+        client = MCPClient("http://example.com")
+        result = await client.list_tools()
+
+        assert [tool.name for tool in result] == ["tool_0"]
+        mock_session_instance.list_tools.assert_called_once()
+
+    @pytest.mark.asyncio
+    @patch.object(mcp_client_module, "streamable_http_client")
+    @patch.object(mcp_client_module, "ClientSession")
+    async def test_list_tools_swallows_mid_walk_error_without_raise_on_error(
+        self,
+        mock_session_class,
+        mock_transport,
+    ):
+        """Test a mid-walk failure returns [] when raise_on_error is False."""
+        mock_transport_ctx = AsyncMock()
+        mock_transport.return_value = mock_transport_ctx
+        mock_transport_instance = MagicMock()
+        mock_transport_ctx.__aenter__ = AsyncMock(return_value=mock_transport_instance)
+
+        mock_session_ctx = AsyncMock()
+        mock_session_class.return_value = mock_session_ctx
+        mock_session_instance = AsyncMock()
+        mock_session_ctx.__aenter__ = AsyncMock(return_value=mock_session_instance)
+
+        mock_session_instance.list_tools.side_effect = [
+            ListToolsResult(
+                tools=[MCPTool(name="tool_0", description="Tool 0", inputSchema={})],
+                nextCursor="page-2",
+            ),
+            RuntimeError("transient upstream failure"),
+        ]
+
+        client = MCPClient("http://example.com")
+        result = await client.list_tools()
+
+        assert result == []
         assert mock_session_instance.list_tools.call_count == 2
 
     @pytest.mark.asyncio

--- a/tests/mcp_tests/test_mcp_client_unit.py
+++ b/tests/mcp_tests/test_mcp_client_unit.py
@@ -188,8 +188,8 @@ class TestMCPClientUnitTests:
         mock_session_instance.list_tools.assert_called_once()
 
     @pytest.mark.asyncio
-    @patch.object(mcp_client_module, "streamable_http_client")
-    @patch.object(mcp_client_module, "ClientSession")
+    @patch.object(mcp_client_module, "streamable_http_client")  # test-quality-ok: exercises MCPClient wiring; the walk itself is covered sessionless in test_tools.py
+    @patch.object(mcp_client_module, "ClientSession")  # test-quality-ok: exercises MCPClient wiring; the walk itself is covered sessionless in test_tools.py
     async def test_list_tools_follows_next_cursor_until_exhausted(
         self,
         mock_session_class,
@@ -229,118 +229,8 @@ class TestMCPClientUnitTests:
         assert second_call_params.cursor == "page-2"
 
     @pytest.mark.asyncio
-    @patch.object(mcp_client_module, "streamable_http_client")
-    @patch.object(mcp_client_module, "ClientSession")
-    async def test_list_tools_stops_when_pagination_reaches_page_cap(
-        self,
-        mock_session_class,
-        mock_transport,
-        monkeypatch,
-    ):
-        """Test listing tools returns accumulated tools if an upstream keeps returning new cursors."""
-        monkeypatch.setattr("litellm.experimental_mcp_client.tools.MCP_TOOL_LISTING_MAX_PAGES", 2)
-
-        mock_transport_ctx = AsyncMock()
-        mock_transport.return_value = mock_transport_ctx
-        mock_transport_instance = MagicMock()
-        mock_transport_ctx.__aenter__ = AsyncMock(return_value=mock_transport_instance)
-
-        mock_session_ctx = AsyncMock()
-        mock_session_class.return_value = mock_session_ctx
-        mock_session_instance = AsyncMock()
-        mock_session_ctx.__aenter__ = AsyncMock(return_value=mock_session_instance)
-
-        mock_session_instance.list_tools.side_effect = [
-            ListToolsResult(
-                tools=[MCPTool(name="tool_0", description="Tool 0", inputSchema={})],
-                nextCursor="page-2",
-            ),
-            ListToolsResult(
-                tools=[MCPTool(name="tool_1", description="Tool 1", inputSchema={})],
-                nextCursor="page-3",
-            ),
-            ListToolsResult(
-                tools=[MCPTool(name="tool_2", description="Tool 2", inputSchema={})],
-            ),
-        ]
-
-        client = MCPClient("http://example.com")
-        result = await client.list_tools(raise_on_error=True)
-
-        assert [tool.name for tool in result] == ["tool_0", "tool_1"]
-        assert mock_session_instance.list_tools.call_count == 2
-
-    @pytest.mark.asyncio
-    @patch.object(mcp_client_module, "streamable_http_client")
-    @patch.object(mcp_client_module, "ClientSession")
-    async def test_list_tools_stops_on_repeated_next_cursor(
-        self,
-        mock_session_class,
-        mock_transport,
-    ):
-        """Test listing tools returns collected tools when an upstream repeats a cursor."""
-        mock_transport_ctx = AsyncMock()
-        mock_transport.return_value = mock_transport_ctx
-        mock_transport_instance = MagicMock()
-        mock_transport_ctx.__aenter__ = AsyncMock(return_value=mock_transport_instance)
-
-        mock_session_ctx = AsyncMock()
-        mock_session_class.return_value = mock_session_ctx
-        mock_session_instance = AsyncMock()
-        mock_session_ctx.__aenter__ = AsyncMock(return_value=mock_session_instance)
-
-        mock_session_instance.list_tools.side_effect = [
-            ListToolsResult(
-                tools=[MCPTool(name="tool_0", description="Tool 0", inputSchema={})],
-                nextCursor="same-cursor",
-            ),
-            ListToolsResult(
-                tools=[MCPTool(name="tool_1", description="Tool 1", inputSchema={})],
-                nextCursor="same-cursor",
-            ),
-        ]
-
-        client = MCPClient("http://example.com")
-        result = await client.list_tools(raise_on_error=True)
-
-        assert [tool.name for tool in result] == ["tool_0", "tool_1"]
-        assert mock_session_instance.list_tools.call_count == 2
-
-    @pytest.mark.asyncio
-    @patch.object(mcp_client_module, "streamable_http_client")
-    @patch.object(mcp_client_module, "ClientSession")
-    async def test_list_tools_treats_empty_cursor_as_terminal(
-        self,
-        mock_session_class,
-        mock_transport,
-    ):
-        """Test listing tools stops when an upstream returns an empty-string cursor."""
-        mock_transport_ctx = AsyncMock()
-        mock_transport.return_value = mock_transport_ctx
-        mock_transport_instance = MagicMock()
-        mock_transport_ctx.__aenter__ = AsyncMock(return_value=mock_transport_instance)
-
-        mock_session_ctx = AsyncMock()
-        mock_session_class.return_value = mock_session_ctx
-        mock_session_instance = AsyncMock()
-        mock_session_ctx.__aenter__ = AsyncMock(return_value=mock_session_instance)
-
-        mock_session_instance.list_tools.side_effect = [
-            ListToolsResult(
-                tools=[MCPTool(name="tool_0", description="Tool 0", inputSchema={})],
-                nextCursor="",
-            ),
-        ]
-
-        client = MCPClient("http://example.com")
-        result = await client.list_tools()
-
-        assert [tool.name for tool in result] == ["tool_0"]
-        mock_session_instance.list_tools.assert_called_once()
-
-    @pytest.mark.asyncio
-    @patch.object(mcp_client_module, "streamable_http_client")
-    @patch.object(mcp_client_module, "ClientSession")
+    @patch.object(mcp_client_module, "streamable_http_client")  # test-quality-ok: exercises MCPClient wiring; the walk itself is covered sessionless in test_tools.py
+    @patch.object(mcp_client_module, "ClientSession")  # test-quality-ok: exercises MCPClient wiring; the walk itself is covered sessionless in test_tools.py
     async def test_list_tools_swallows_mid_walk_error_without_raise_on_error(
         self,
         mock_session_class,

--- a/tests/test_litellm/experimental_mcp_client/test_tools.py
+++ b/tests/test_litellm/experimental_mcp_client/test_tools.py
@@ -128,6 +128,29 @@ async def test_load_mcp_tools_follows_pagination(mock_session):
 
 
 @pytest.mark.asyncio()
+async def test_pagination_walk_stops_at_whole_walk_deadline(mock_session, monkeypatch):
+    import anyio
+
+    from litellm.experimental_mcp_client.tools import list_tools_with_pagination
+
+    monkeypatch.setattr("litellm.experimental_mcp_client.tools.MCP_CLIENT_TIMEOUT", 0.2)
+    monkeypatch.setattr("litellm.experimental_mcp_client.tools.MCP_TOOL_LISTING_TIMEOUT", 0.2)
+
+    async def slow_page(params=None):
+        await anyio.sleep(0.15)
+        idx = int(params.cursor) if params is not None else 0
+        return ListToolsResult(
+            tools=[MCPTool(name=f"tool_{idx}", description=str(idx), inputSchema={})],
+            nextCursor=str(idx + 1),
+        )
+
+    mock_session.list_tools = slow_page
+    result = await list_tools_with_pagination(mock_session)
+
+    assert [tool.name for tool in result] == ["tool_0"]
+
+
+@pytest.mark.asyncio()
 async def test_load_mcp_tools_openai_format_spans_pages(mock_session):
     mock_session.list_tools.side_effect = [
         ListToolsResult(

--- a/tests/test_litellm/experimental_mcp_client/test_tools.py
+++ b/tests/test_litellm/experimental_mcp_client/test_tools.py
@@ -14,6 +14,7 @@ from mcp.types import (
 from mcp.types import Tool as MCPTool
 
 from litellm.experimental_mcp_client.tools import (
+    list_tools_with_pagination,
     transform_mcp_tool_to_anthropic_tool,
     _get_function_arguments,
     _normalize_mcp_input_schema,
@@ -125,6 +126,55 @@ async def test_load_mcp_tools_follows_pagination(mock_session):
     second_call_params = mock_session.list_tools.call_args_list[1].kwargs["params"]
     assert isinstance(second_call_params, PaginatedRequestParams)
     assert second_call_params.cursor == "page-2"
+
+
+@pytest.mark.asyncio()
+async def test_pagination_walk_stops_at_page_cap(mock_session, monkeypatch):
+    monkeypatch.setattr("litellm.experimental_mcp_client.tools.MCP_TOOL_LISTING_MAX_PAGES", 2)
+    mock_session.list_tools.side_effect = [
+        ListToolsResult(
+            tools=[MCPTool(name="tool_0", description="0", inputSchema={})],
+            nextCursor="page-2",
+        ),
+        ListToolsResult(
+            tools=[MCPTool(name="tool_1", description="1", inputSchema={})],
+            nextCursor="page-3",
+        ),
+        ListToolsResult(tools=[MCPTool(name="tool_2", description="2", inputSchema={})]),
+    ]
+    result = await list_tools_with_pagination(mock_session)
+    assert [tool.name for tool in result] == ["tool_0", "tool_1"]
+    assert mock_session.list_tools.call_count == 2
+
+
+@pytest.mark.asyncio()
+async def test_pagination_walk_stops_on_repeated_cursor(mock_session):
+    mock_session.list_tools.side_effect = [
+        ListToolsResult(
+            tools=[MCPTool(name="tool_0", description="0", inputSchema={})],
+            nextCursor="same-cursor",
+        ),
+        ListToolsResult(
+            tools=[MCPTool(name="tool_1", description="1", inputSchema={})],
+            nextCursor="same-cursor",
+        ),
+    ]
+    result = await list_tools_with_pagination(mock_session)
+    assert [tool.name for tool in result] == ["tool_0", "tool_1"]
+    assert mock_session.list_tools.call_count == 2
+
+
+@pytest.mark.asyncio()
+async def test_pagination_walk_treats_empty_cursor_as_terminal(mock_session):
+    mock_session.list_tools.side_effect = [
+        ListToolsResult(
+            tools=[MCPTool(name="tool_0", description="0", inputSchema={})],
+            nextCursor="",
+        ),
+    ]
+    result = await list_tools_with_pagination(mock_session)
+    assert [tool.name for tool in result] == ["tool_0"]
+    mock_session.list_tools.assert_called_once()
 
 
 @pytest.mark.asyncio()

--- a/tests/test_litellm/experimental_mcp_client/test_tools.py
+++ b/tests/test_litellm/experimental_mcp_client/test_tools.py
@@ -8,6 +8,7 @@ from mcp.types import (
     CallToolRequestParams,
     CallToolResult,
     ListToolsResult,
+    PaginatedRequestParams,
     TextContent,
 )
 from mcp.types import Tool as MCPTool
@@ -104,6 +105,39 @@ async def test_load_mcp_tools_openai_format(mock_session, mock_list_tools_result
     assert result[0]["type"] == "function"
     assert result[0]["function"]["name"] == "test_tool"
     mock_session.list_tools.assert_called_once()
+
+
+@pytest.mark.asyncio()
+async def test_load_mcp_tools_follows_pagination(mock_session):
+    mock_session.list_tools.side_effect = [
+        ListToolsResult(
+            tools=[
+                MCPTool(name="tool_a", description="a", inputSchema={}),
+                MCPTool(name="tool_b", description="b", inputSchema={}),
+            ],
+            nextCursor="page-2",
+        ),
+        ListToolsResult(tools=[MCPTool(name="tool_c", description="c", inputSchema={})]),
+    ]
+    result = await load_mcp_tools(mock_session, format="mcp")
+    assert [tool.name for tool in result] == ["tool_a", "tool_b", "tool_c"]
+    assert mock_session.list_tools.call_count == 2
+    second_call_params = mock_session.list_tools.call_args_list[1].kwargs["params"]
+    assert isinstance(second_call_params, PaginatedRequestParams)
+    assert second_call_params.cursor == "page-2"
+
+
+@pytest.mark.asyncio()
+async def test_load_mcp_tools_openai_format_spans_pages(mock_session):
+    mock_session.list_tools.side_effect = [
+        ListToolsResult(
+            tools=[MCPTool(name="tool_a", description="a", inputSchema={})],
+            nextCursor="page-2",
+        ),
+        ListToolsResult(tools=[MCPTool(name="tool_b", description="b", inputSchema={})]),
+    ]
+    result = await load_mcp_tools(mock_session, format="openai")
+    assert [t["function"]["name"] for t in result] == ["tool_a", "tool_b"]
 
 
 def test_get_function_arguments():

--- a/tests/test_litellm/experimental_mcp_client/test_tools.py
+++ b/tests/test_litellm/experimental_mcp_client/test_tools.py
@@ -151,6 +151,29 @@ async def test_pagination_walk_stops_at_whole_walk_deadline(mock_session, monkey
 
 
 @pytest.mark.asyncio()
+async def test_pagination_walk_honors_explicit_deadline_over_globals(mock_session, monkeypatch):
+    import anyio
+
+    from litellm.experimental_mcp_client.tools import list_tools_with_pagination
+
+    monkeypatch.setattr("litellm.experimental_mcp_client.tools.MCP_CLIENT_TIMEOUT", 0.1)
+    monkeypatch.setattr("litellm.experimental_mcp_client.tools.MCP_TOOL_LISTING_TIMEOUT", 0.1)
+
+    async def slow_page(params=None):
+        await anyio.sleep(0.15)
+        idx = int(params.cursor) if params is not None else 0
+        tools = [MCPTool(name=f"tool_{idx}", description=str(idx), inputSchema={})]
+        if idx == 0:
+            return ListToolsResult(tools=tools, nextCursor="1")
+        return ListToolsResult(tools=tools)
+
+    mock_session.list_tools = slow_page
+    result = await list_tools_with_pagination(mock_session, listing_deadline=2.0)
+
+    assert [tool.name for tool in result] == ["tool_0", "tool_1"]
+
+
+@pytest.mark.asyncio()
 async def test_load_mcp_tools_openai_format_spans_pages(mock_session):
     mock_session.list_tools.side_effect = [
         ListToolsResult(

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_rest_endpoints.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_rest_endpoints.py
@@ -214,6 +214,46 @@ class TestExecuteWithMcpClient:
         assert server.scopes == ["read", "write"]
         assert server.has_client_credentials is True
 
+    async def test_preview_forwards_per_server_timeout_to_client_factory(self, monkeypatch):
+        """The request's per-server timeout must reach the temporary MCPServer model:
+        the client factory reads ``server.timeout`` for both the per-request timeout
+        and the preview's whole-walk listing deadline."""
+        captured: dict = {}
+
+        def fake_build_stdio_env(server, raw_headers):
+            return None
+
+        async def fake_create_client(*args, **kwargs):
+            captured["server"] = kwargs.get("server")
+            return object()
+
+        monkeypatch.setattr(
+            rest_endpoints.global_mcp_server_manager,
+            "_build_stdio_env",
+            fake_build_stdio_env,
+            raising=False,
+        )
+        monkeypatch.setattr(
+            rest_endpoints.global_mcp_server_manager,
+            "_create_mcp_client",
+            fake_create_client,
+            raising=False,
+        )
+
+        async def ok_operation(client):
+            return {"status": "ok"}
+
+        payload = NewMCPServerRequest(
+            server_name="slow-catalog-server",
+            url="https://example.com",
+            timeout=120.5,
+        )
+
+        result = await rest_endpoints._execute_with_mcp_client(payload, ok_operation)
+
+        assert result["status"] == "ok"
+        assert captured["server"].timeout == 120.5
+
     @pytest.mark.asyncio
     async def test_m2m_drops_incoming_oauth2_headers(self, monkeypatch):
         """For M2M OAuth servers the incoming Authorization header (which carries
@@ -605,6 +645,50 @@ class TestTestToolsList:
         assert result["message"] == "Successfully retrieved tools"
         assert [tool["name"] for tool in result["tools"]] == ["quick_tool"]
 
+    async def test_preview_tools_list_honors_per_server_timeout(self, monkeypatch):
+        """A per-server timeout above the global default extends the preview deadline."""
+        monkeypatch.setattr(rest_endpoints, "MCP_CLIENT_TIMEOUT", 0.05, raising=False)
+        monkeypatch.setattr(rest_endpoints, "MCP_TOOL_LISTING_TIMEOUT", 0.05, raising=False)
+
+        from mcp.types import Tool as MCPTool
+
+        class SlowConfiguredClient:
+            timeout = 1.0
+
+            async def list_tools(self, raise_on_error=False):
+                await asyncio.sleep(0.2)
+                return [MCPTool(name="slow_tool", description="s", inputSchema={})]
+
+        async def fake_execute(
+            request,
+            operation,
+            mcp_auth_header=None,
+            oauth2_headers=None,
+            raw_headers=None,
+        ):
+            return await operation(SlowConfiguredClient())
+
+        monkeypatch.setattr(rest_endpoints, "_execute_with_mcp_client", fake_execute, raising=False)
+
+        from litellm.proxy._types import LitellmUserRoles
+
+        request = _build_request()
+        payload = NewMCPServerRequest(
+            server_name="example",
+            url="https://example.com",
+            auth_type=MCPAuth.api_key,
+            credentials={"auth_value": "secret-key"},
+        )
+
+        result = await rest_endpoints.test_tools_list(
+            request,
+            payload,
+            user_api_key_dict=UserAPIKeyAuth(user_role=LitellmUserRoles.PROXY_ADMIN),
+        )
+
+        assert result["error"] is None
+        assert [tool["name"] for tool in result["tools"]] == ["slow_tool"]
+
     async def test_extracts_oauth2_headers(self, monkeypatch):
         """Ensure oauth2 auth type pulls oauth headers and omits MCP auth header."""
 
@@ -867,9 +951,7 @@ class TestListToolsRestAPI:
         they do for a gateway session, never to the bare session key."""
         from litellm.constants import UI_SESSION_TOKEN_TEAM_ID
 
-        session_auth = UserAPIKeyAuth(
-            team_id=UI_SESSION_TOKEN_TEAM_ID, user_id="grant-user", user_role="internal_user"
-        )
+        session_auth = UserAPIKeyAuth(team_id=UI_SESSION_TOKEN_TEAM_ID, user_id="grant-user", user_role="internal_user")
         admitted_auth = UserAPIKeyAuth(user_id="grant-user", org_id="admitted-org")
 
         async def fake_reload(user_id):
@@ -949,9 +1031,7 @@ class TestListToolsRestAPI:
         from litellm.constants import UI_SESSION_TOKEN_TEAM_ID
         from litellm.proxy._types import LiteLLM_ObjectPermissionTable
 
-        session_auth = UserAPIKeyAuth(
-            team_id=UI_SESSION_TOKEN_TEAM_ID, user_id="grant-user", user_role="internal_user"
-        )
+        session_auth = UserAPIKeyAuth(team_id=UI_SESSION_TOKEN_TEAM_ID, user_id="grant-user", user_role="internal_user")
         scoped_auth = UserAPIKeyAuth(
             object_permission=LiteLLM_ObjectPermissionTable(
                 object_permission_id="toolset-scope",
@@ -3219,9 +3299,7 @@ class TestRestListToolsetFiltering:
 
         mock_manager = MagicMock()
         mock_manager.expand_tool_permissions = MagicMock(side_effect=lambda perms: perms or {})
-        mock_manager.resolve_toolset_tool_permissions = AsyncMock(
-            return_value={"server-a": ["lookup_status"]}
-        )
+        mock_manager.resolve_toolset_tool_permissions = AsyncMock(return_value={"server-a": ["lookup_status"]})
 
         monkeypatch.setattr(
             rest_endpoints.global_mcp_server_manager,

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_rest_endpoints.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_rest_endpoints.py
@@ -524,6 +524,87 @@ class TestTestToolsList:
         assert captured["oauth2_headers"] is None
         assert oauth_call_counter["count"] == 0
 
+    async def test_preview_tools_list_times_out_on_slow_pagination(self, monkeypatch):
+        """A preview whose upstream paginates past the listing deadline returns a
+        timeout error instead of holding the request open."""
+        monkeypatch.setattr(rest_endpoints, "MCP_CLIENT_TIMEOUT", 0.05, raising=False)
+        monkeypatch.setattr(rest_endpoints, "MCP_TOOL_LISTING_TIMEOUT", 0.05, raising=False)
+
+        class SlowClient:
+            async def list_tools(self, raise_on_error=False):
+                await asyncio.sleep(1)
+                return []
+
+        async def fake_execute(
+            request,
+            operation,
+            mcp_auth_header=None,
+            oauth2_headers=None,
+            raw_headers=None,
+        ):
+            return await operation(SlowClient())
+
+        monkeypatch.setattr(rest_endpoints, "_execute_with_mcp_client", fake_execute, raising=False)
+
+        from litellm.proxy._types import LitellmUserRoles
+
+        request = _build_request()
+        payload = NewMCPServerRequest(
+            server_name="example",
+            url="https://example.com",
+            auth_type=MCPAuth.api_key,
+            credentials={"auth_value": "secret-key"},
+        )
+
+        result = await rest_endpoints.test_tools_list(
+            request,
+            payload,
+            user_api_key_dict=UserAPIKeyAuth(user_role=LitellmUserRoles.PROXY_ADMIN),
+        )
+
+        assert result["status"] == "error"
+        assert result["error"] is True
+        assert "Timed out listing tools" in result["message"]
+
+    async def test_preview_tools_list_succeeds_within_deadline(self, monkeypatch):
+        """The preview timeout scope passes a fast listing through untouched."""
+        from mcp.types import Tool as MCPTool
+
+        class QuickClient:
+            async def list_tools(self, raise_on_error=False):
+                return [MCPTool(name="quick_tool", description="q", inputSchema={})]
+
+        async def fake_execute(
+            request,
+            operation,
+            mcp_auth_header=None,
+            oauth2_headers=None,
+            raw_headers=None,
+        ):
+            return await operation(QuickClient())
+
+        monkeypatch.setattr(rest_endpoints, "_execute_with_mcp_client", fake_execute, raising=False)
+
+        from litellm.proxy._types import LitellmUserRoles
+
+        request = _build_request()
+        payload = NewMCPServerRequest(
+            server_name="example",
+            url="https://example.com",
+            auth_type=MCPAuth.api_key,
+            credentials={"auth_value": "secret-key"},
+        )
+
+        result = await rest_endpoints.test_tools_list(
+            request,
+            payload,
+            user_api_key_dict=UserAPIKeyAuth(user_role=LitellmUserRoles.PROXY_ADMIN),
+        )
+
+        assert result["error"] is None
+        assert result["message"] == "Successfully retrieved tools"
+        assert [tool["name"] for tool in result["tools"]] == ["quick_tool"]
+
     async def test_extracts_oauth2_headers(self, monkeypatch):
         """Ensure oauth2 auth type pulls oauth headers and omits MCP auth header."""
 

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_rest_endpoints.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_rest_endpoints.py
@@ -952,6 +952,123 @@ class TestListToolsRestAPI:
         assert scope_inputs == [session_auth]
         assert reload_calls == []
 
+    async def test_single_server_response_includes_paginated_upstream_tools(
+        self,
+        monkeypatch,
+    ):
+        """The REST tools/list path should include tools beyond the upstream first page."""
+        import litellm.experimental_mcp_client.client as mcp_client_module
+        from mcp.types import ListToolsResult, PaginatedRequestParams
+        from mcp.types import Tool as MCPTool
+
+        from litellm.proxy._experimental.mcp_server.server import MCPServer
+        from litellm.types.mcp import MCPTransport
+
+        async def fake_contexts(user_api_key_auth):
+            return [user_api_key_auth]
+
+        async def fake_get_allowed_mcp_servers(*args, **kwargs):
+            return ["server-1"]
+
+        stub_server = MCPServer(
+            server_id="server-1",
+            name="stub",
+            server_name="stub",
+            alias="stub",
+            url="https://example.com/mcp",
+            transport=MCPTransport.http,
+            mcp_info={"server_name": "stub"},
+        )
+        stub_server.available_on_public_internet = True
+
+        mock_transport_ctx = AsyncMock()
+        mock_transport_ctx.__aenter__ = AsyncMock(return_value=(MagicMock(), MagicMock()))
+        mock_transport_ctx.__aexit__ = AsyncMock(return_value=None)
+        monkeypatch.setattr(
+            mcp_client_module,
+            "streamable_http_client",
+            MagicMock(return_value=mock_transport_ctx),
+            raising=False,
+        )
+
+        mock_session_ctx = AsyncMock()
+        mock_session_instance = AsyncMock()
+        mock_session_instance.initialize = AsyncMock(return_value=None)
+        mock_session_instance.list_tools.side_effect = [
+            ListToolsResult(
+                tools=[
+                    MCPTool(
+                        name="first_page_tool",
+                        description="First page tool",
+                        inputSchema={},
+                    )
+                ],
+                nextCursor="page-2",
+            ),
+            ListToolsResult(
+                tools=[
+                    MCPTool(
+                        name="second_page_tool",
+                        description="Second page tool",
+                        inputSchema={},
+                    )
+                ]
+            ),
+        ]
+        mock_session_ctx.__aenter__ = AsyncMock(return_value=mock_session_instance)
+        mock_session_ctx.__aexit__ = AsyncMock(return_value=None)
+        monkeypatch.setattr(
+            mcp_client_module,
+            "ClientSession",
+            MagicMock(return_value=mock_session_ctx),
+            raising=False,
+        )
+
+        monkeypatch.setattr(
+            rest_endpoints,
+            "build_effective_auth_contexts",
+            fake_contexts,
+            raising=False,
+        )
+        monkeypatch.setattr(
+            rest_endpoints.global_mcp_server_manager,
+            "get_allowed_mcp_servers",
+            fake_get_allowed_mcp_servers,
+            raising=False,
+        )
+        monkeypatch.setattr(
+            rest_endpoints.global_mcp_server_manager,
+            "filter_server_ids_by_ip_with_info",
+            lambda server_ids, client_ip: (server_ids, 0),
+            raising=False,
+        )
+        monkeypatch.setattr(
+            rest_endpoints.global_mcp_server_manager,
+            "get_mcp_server_by_id",
+            lambda server_id: stub_server if server_id == "server-1" else None,
+            raising=False,
+        )
+
+        request = _build_request(path="/mcp-rest/tools/list", method="GET")
+        result = await rest_endpoints.list_tool_rest_api(
+            request,
+            server_id="server-1",
+            user_api_key_dict=UserAPIKeyAuth(),
+        )
+
+        assert set(result.keys()) == {"tools", "error", "message"}
+        assert [tool.name for tool in result["tools"]] == [
+            "first_page_tool",
+            "second_page_tool",
+        ]
+        assert result["error"] is None
+        assert result["message"] == "Successfully retrieved tools"
+
+        assert mock_session_instance.list_tools.call_count == 2
+        second_call_params = mock_session_instance.list_tools.call_args_list[1].kwargs["params"]
+        assert isinstance(second_call_params, PaginatedRequestParams)
+        assert second_call_params.cursor == "page-2"
+
     async def test_include_disabled_tools_is_admin_only(self, monkeypatch):
         """include_disabled_tools skips the allowlist filter only for PROXY_ADMIN;
         a non-admin passing it stays filtered so the REST endpoint can't be used


### PR DESCRIPTION
## TLDR

Problem this solves:

- LiteLLM only ever read the first tools/list page from an upstream MCP server
- Servers paginating with nextCursor silently lost every tool after page one

How it solves it:

- The MCP client now follows nextCursor until the catalog is complete
- One shared pagination walk backs the client, the REST endpoints, and the SDK load_mcp_tools helper
- A buggy upstream that repeats a cursor degrades to a partial catalog with a warning instead of an error
- The admin UI tools preview is bounded by the tool listing timeout instead of running up to 1000 pages

Credit: adopts https://github.com/BerriAI/litellm/pull/32244 by @Jupiter363, rebased onto litellm_internal_staging with review fixes on top

## User Flow

Before: a proxy admin connecting an MCP server with a paginated catalog sees only the first page of tools

1. They add an MCP server whose catalog spans multiple tools/list pages and open http://litellm-domain/ui/mcp-servers
2. They open the server's MCP Tools tab and see Available Tools 1 even though the server exposes more
3. They call GET http://litellm-domain/mcp-rest/tools/list?server_id=<id> and the response holds only the first page's tools
4. Agents routed through the gateway cannot call any tool that lives on page two or later

After: the same server shows its complete catalog everywhere

1. They add the same MCP server and open http://litellm-domain/ui/mcp-servers
2. The MCP Tools tab now shows every tool across all pages (Available Tools 6 for a six page catalog)
3. GET http://litellm-domain/mcp-rest/tools/list?server_id=<id> returns the full catalog
4. Agents can call tools from any page, and a server stuck repeating a cursor still serves the tools collected so far

## Relevant issues

Adopts #32244

## Linear ticket

Resolves LIT-6320

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Shared setup: three real stdio MCP servers driven over a live proxy with zero mocks. `paginated_stdio` serves 1 tool per page across 2 pages, `slow_stdio` serves 6 pages at 1.5s each, `loop_stdio` is a buggy server that repeats the same nextCursor forever. Config registers all three with `allow_all_keys: true`; requests use the master key

### Before (01de2837153e)

#### Case 1: paginated catalog is truncated to page one

1. `curl -H "Authorization: Bearer sk-1234" "http://127.0.0.1:16620/mcp-rest/tools/list?server_id=<paginated_id>"`
2. Observed: `tools: ['page-one']`, HTTP 200, the second page is missing

#### Case 2: buggy repeated-cursor upstream serves page one

1. `curl -H "Authorization: Bearer sk-1234" "http://127.0.0.1:16620/mcp-rest/tools/list?server_id=<loop_id>"`
2. Observed: `tools: ['loop-page-one']`, HTTP 200

#### Case 3: slow six page catalog is truncated

1. `curl -H "Authorization: Bearer sk-1234" "http://127.0.0.1:16620/mcp-rest/tools/list?server_id=<slow_id>"`
2. Observed: `tools: ['slow-tool-0']`, HTTP 200 in 1.9s

#### Case 4: admin UI preview shows one tool

1. `curl -X POST -H "Authorization: Bearer sk-1234" -d '{"server_name":"preview_paginated","transport":"stdio","command":"python3","args":["/tmp/paginated_mcp_server.py"]}' http://127.0.0.1:16620/mcp-rest/test/tools/list`
2. Observed: `tools: ['page-one']`
3. Admin UI MCP Tools tab shows Available Tools 1

![before paginated tools](https://raw.githubusercontent.com/BerriAI/litellm/assets-pr39172/assets/lit6320-base-paginated-tools.png)

### After (6df582d187)

#### Case 1: paginated catalog is complete

1. `curl -H "Authorization: Bearer sk-1234" "http://127.0.0.1:16621/mcp-rest/tools/list?server_id=<paginated_id>"`
2. Observed: `tools: ['page-one', 'page-two']`, HTTP 200

![after paginated tools](https://raw.githubusercontent.com/BerriAI/litellm/assets-pr39172/assets/lit6320-head-paginated-tools.png)

#### Case 2: buggy repeated-cursor upstream degrades to a partial catalog

1. `curl -H "Authorization: Bearer sk-1234" "http://127.0.0.1:16621/mcp-rest/tools/list?server_id=<loop_id>"`
2. Observed: `tools: ['loop-page-one', 'loop-page-repeat']`, HTTP 200, warning logged; the original #32244 turned this into an HTTP 500 that discarded every collected page

#### Case 3: slow six page catalog is complete

1. `curl -H "Authorization: Bearer sk-1234" "http://127.0.0.1:16621/mcp-rest/tools/list?server_id=<slow_id>"`
2. Observed: `tools: ['slow-tool-0' .. 'slow-tool-5']`, HTTP 200 in 9.3s, inside the default 30s listing timeout

![after slow tools](https://raw.githubusercontent.com/BerriAI/litellm/assets-pr39172/assets/lit6320-head-slow-tools.png)

#### Case 4: admin UI preview shows the full catalog and the walk is bounded

1. `curl -X POST -H "Authorization: Bearer sk-1234" -d '{"server_name":"preview_paginated","transport":"stdio","command":"python3","args":["/tmp/paginated_mcp_server.py"]}' http://127.0.0.1:16621/mcp-rest/test/tools/list`
2. Observed: `tools: ['page-one', 'page-two']`
3. With `LITELLM_MCP_TOOL_LISTING_TIMEOUT=3` and `LITELLM_MCP_CLIENT_TIMEOUT=2`, previewing `slow_stdio` returns in 3.1s with `{"status": "error", "message": "Timed out listing tools after 3.0 seconds. The MCP server may be responding slowly or paginating excessively."}` where the walk was previously bounded only by the per request timeout times the 1000 page cap

#### Case 5: preview honors the per-server timeout entered in the form

1. Same low-timeout proxy (`LITELLM_MCP_TOOL_LISTING_TIMEOUT=3`, `LITELLM_MCP_CLIENT_TIMEOUT=2`); the preview payload now carries `"timeout": 30` alongside the slow six page server config
2. `curl -X POST -H "Authorization: Bearer sk-1234" -d '{"server_name":"slow-preview","transport":"stdio","command":"python3","args":["/tmp/slow_mcp_server.py"],"timeout":30}' http://127.0.0.1:16622/mcp-rest/test/tools/list`
3. Observed: all 6 tools in 10s; the same payload without `timeout` still returns the 3.0s timeout message, and before this fix the `timeout` field was dropped on the way to the preview client so the same request timed out at 3.0s

Note: the Before commands ran at the 01de2837153e staging tip; no MCP code changed between that tip and the current merge base. After cases re-ran at 6df582d187 following the rebase onto current staging

Additional live check: `load_mcp_tools` driven in process against the real paginated stdio server returns `['page-one', 'page-two']` in both mcp and openai formats

## Type

🐛 Bug Fix

## Behavior changes

- tools/list now walks every nextCursor page; catalogs, aggregate listings, previews, and the SDK helper return the full set instead of page one
- A repeated nextCursor stops the walk with a warning and returns the tools collected so far
- An empty string nextCursor is treated as end of pagination
- The whole walk on managed servers runs under the existing MCP_TOOL_LISTING_TIMEOUT (default 30s, env LITELLM_MCP_TOOL_LISTING_TIMEOUT), so a catalog slower than the timeout end to end returns 504 where the first page alone previously fit
- The UI tools preview is bounded by max(MCP_CLIENT_TIMEOUT, MCP_TOOL_LISTING_TIMEOUT) and reports a timeout message instead of walking up to 1000 pages
- Direct SDK listings through MCPClient.list_tools and load_mcp_tools are bounded by the same deadline and return the tools collected so far when it expires
- A per-server timeout above the global default extends that deadline instead of being truncated at it, on both the SDK walk and the UI preview

## Caveats (if any)

### Medium

- A transient failure on page N still fails the whole listing, matching the old single request semantics
- Catalogs slower than MCP_TOOL_LISTING_TIMEOUT end to end now time out on managed servers; raise LITELLM_MCP_TOOL_LISTING_TIMEOUT for very slow upstreams

### Low

- list_prompts, list_resources, and list_resource_templates remain single page, as before this PR
- The gateway still returns one unpaginated tools/list response downstream, as before this PR
- The page cap is fixed at 1000 pages with no env override

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default MCP tool discovery behavior and timeouts across proxy and SDK paths; mis-tuned listing timeouts could hide tools or surface partial catalogs, but auth and credential handling are unchanged.
> 
> **Overview**
> **MCP tool catalogs now walk every `tools/list` page** instead of stopping at the first response, so proxy REST listings, the admin tools preview, `MCPClient.list_tools`, and `load_mcp_tools` can expose the full upstream catalog.
> 
> A shared **`list_tools_with_pagination`** helper follows `nextCursor`, caps the walk at **`MCP_TOOL_LISTING_MAX_PAGES` (1000)**, and stops on repeated cursors or an overall listing deadline—returning **partial results with warnings** rather than failing when upstreams are buggy or slow. **`MCPClient.list_tools`** passes **`max(per-server timeout, MCP_TOOL_LISTING_TIMEOUT)`** as that deadline.
> 
> The **admin `test/tools/list` preview** wraps listing in the same deadline (via **`anyio.move_on_after`**), returns a clear timeout error when the walk does not finish, and **forwards `timeout` from the preview request** into the temporary **`MCPServer`** model so per-server timeouts extend the preview as intended.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6df582d18719b7291b6e7181909c6da72115cc4a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->