### PR TITLE
test: allow dashscope domain in qwen alias default api_base check

### DIFF
--- a/tests/local_testing/test_get_llm_provider.py
+++ b/tests/local_testing/test_get_llm_provider.py
@@ -155,6 +155,11 @@ def test_default_api_base():
                         continue
                     elif provider == "github" and other_provider.value == "azure":
                         continue
+                    elif (
+                        provider in ("qwencloud", "qwen_ai_platform")
+                        and other_provider.value == "dashscope"
+                    ):
+                        continue
                     assert other_provider.value not in api_base.replace("/openai", "")
 
 


### PR DESCRIPTION
## TLDR

Problem this solves:

- `test_default_api_base` fails deterministically on `litellm_internal_staging`
- Every PR's `local_testing_part1` check is red because of it
- Broken since f3792fb700 added the qwencloud and qwen_ai_platform aliases

How it solves it:

- The aliases are deliberate dashscope brand aliases, so their default api_base is dashscope's real domain
- Adds an alias carve-out to the test's cross-provider check, like the existing codestral/mistral and github/azure ones
- No runtime code changes; alias behavior stays exactly as shipped

## User Flow

Before: a contributor opens any PR against `litellm_internal_staging` and CI goes red on a test their change never touched

1. They push a branch and open a PR at https://github.com/BerriAI/litellm targeting `litellm_internal_staging`
2. The `ci/circleci: local_testing_part1` check turns red
3. The job log shows `FAILED tests/local_testing/test_get_llm_provider.py::test_default_api_base - AssertionError: assert 'dashscope' not in 'https://dashscope-intl.aliyuncs.com/compatible-mode/v1'`
4. Re-running the job fails identically, so their PR cannot go green no matter what they change

After: the same PR only goes red when the contributor's own changes break something

1. They push a branch and open a PR at https://github.com/BerriAI/litellm targeting `litellm_internal_staging`
2. The `ci/circleci: local_testing_part1` check runs `test_default_api_base` and it passes
3. Their PR's check results reflect their own changes again

## Relevant issues

## Linear ticket

Resolves LIT-6633

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

This is a test-only change: the broken thing is the test itself, so the proof is the test run at both commits plus a check that both aliases still resolve their real endpoints. No runtime code path changes

### Before (a3e115f4cd)

1. `uv run pytest tests/local_testing/test_get_llm_provider.py::test_default_api_base -x -q` at the `litellm_internal_staging` tip
2. Observed output:

```
E                       AssertionError: assert 'dashscope' not in 'https://das...ible-mode/v1'
E
E                         'dashscope' is contained here:
E                           https://dashscope-intl.aliyuncs.com/compatible-mode/v1
E                         ?         +++++++++

tests/local_testing/test_get_llm_provider.py:158: AssertionError
1 failed in 0.15s
```

### After (356d2ad9a0)

1. `uv run pytest tests/local_testing/test_get_llm_provider.py -q`
2. Observed output:

```
47 passed in 0.17s
```

3. `uv run pytest tests/test_litellm/llms/dashscope/test_qwen_brand_aliases.py -q` (alias behavior untouched)
4. Observed output:

```
45 passed, 1 warning in 0.82s
```

5. Both aliases still resolve their intended endpoints, with dashscope unchanged:

```
$ uv run python -c "
from litellm.litellm_core_utils.get_llm_provider_logic import get_llm_provider
for m in ('qwencloud/qwen-plus', 'qwen_ai_platform/qwen-plus', 'dashscope/qwen-plus'):
    model, provider, key, base = get_llm_provider(model=m)
    print(provider, '->', base)
"
qwencloud -> https://dashscope-intl.aliyuncs.com/compatible-mode/v1
qwen_ai_platform -> https://dashscope.aliyuncs.com/compatible-mode/v1
dashscope -> https://dashscope-intl.aliyuncs.com/compatible-mode/v1
```

QA observations:

- `test_default_api_base` passes on this PR's CI run
- `local_testing_part1` stays red: pre-existing `test_encoding_format_omitted_by_default_for_openai_sdk` failure, this PR leaves it alone (LIT-6639)
- `llm_translation_testing` red: pre-existing embedding test failures, this PR leaves them alone (LIT-6639)
- `proxy_multi_instance_tests` fails identically on the staging tip's own pipeline, unrelated to this PR
- All three failed identically on staging pipelines before this PR existed

## Type

✅ Test

## Caveats (if any)

### Low

- The test's cross-provider check is still substring-based; future intentional aliases need their own carve-out

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change to cross-provider URL substring assertions; production LLM provider routing and api_base resolution are untouched.
> 
> **Overview**
> Fixes a **false failure** in `test_default_api_base` after `qwencloud` and `qwen_ai_platform` were added as DashScope brand aliases whose default `api_base` URLs legitimately contain `dashscope`.
> 
> The test normally asserts that each OpenAI-compatible provider’s default base URL does not include another provider’s name. This PR adds the same kind of **intentional-alias carve-out** already used for codestral/mistral and github/azure: when the provider is `qwencloud` or `qwen_ai_platform`, the check is skipped for `dashscope`.
> 
> **No runtime or provider behavior changes**—only the test expectation is aligned with the shipped alias endpoints.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 356d2ad9a01be1b12135ed56e32dcae1b73687da. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->