### PR TITLE
chore(release): backport #38716 to stable/1.99.x and cut 1.99.1

### DIFF
--- a/litellm/integrations/otel/mappers/genai.py
+++ b/litellm/integrations/otel/mappers/genai.py
@@ -62,6 +62,8 @@ class GenAIMapper:
         GenAI.RESPONSE_TIME_TO_FIRST_CHUNK: lambda d: d.time_to_first_chunk_seconds,
         GenAI.USAGE_INPUT_TOKENS: lambda d: d.usage.input_tokens,
         GenAI.USAGE_OUTPUT_TOKENS: lambda d: d.usage.output_tokens,
+        GenAI.USAGE_CACHE_CREATION_INPUT_TOKENS: lambda d: d.usage.cache_creation_input_tokens,
+        GenAI.USAGE_CACHE_READ_INPUT_TOKENS: lambda d: d.usage.cache_read_input_tokens,
         Error.TYPE: lambda d: d.error.error_type if d.error else None,
         Server.ADDRESS: lambda d: d.server.address if d.server else None,
         Server.PORT: lambda d: d.server.port if d.server else None,

--- a/litellm/integrations/otel/model/payloads.py
+++ b/litellm/integrations/otel/model/payloads.py
@@ -95,6 +95,22 @@ class LLMUsage:
     input_tokens: int | None = None
     output_tokens: int | None = None
     total_tokens: int | None = None
+    cache_creation_input_tokens: int | None = None
+    cache_read_input_tokens: int | None = None
+
+    @classmethod
+    def from_standard_logging_payload(cls, payload: StandardLoggingPayload) -> LLMUsage:
+        # Cache token counts only exist on the raw provider usage object under metadata
+        metadata: Final[Mapping[str, object]] = payload.get("metadata") or {}
+        raw_usage: Final = metadata.get("usage_object")
+        usage_object: Final[Mapping[str, object]] = raw_usage if isinstance(raw_usage, Mapping) else {}
+        return cls(
+            input_tokens=as_int(payload.get("prompt_tokens")),
+            output_tokens=as_int(payload.get("completion_tokens")),
+            total_tokens=as_int(payload.get("total_tokens")),
+            cache_creation_input_tokens=as_int(usage_object.get("cache_creation_input_tokens")),
+            cache_read_input_tokens=as_int(usage_object.get("cache_read_input_tokens")),
+        )
 
 
 @dataclass(frozen=True)
@@ -349,11 +365,7 @@ class LLMCallSpanData:
             response_model=context.response_model,
             response_id=as_str(response.get("id")),
             request_params=LLMRequestParams.from_model_parameters(params),
-            usage=LLMUsage(
-                input_tokens=as_int(payload.get("prompt_tokens")),
-                output_tokens=as_int(payload.get("completion_tokens")),
-                total_tokens=as_int(payload.get("total_tokens")),
-            ),
+            usage=LLMUsage.from_standard_logging_payload(payload),
             finish_reasons=finish_reasons,
             error=_parse_error(payload),
             response_cost=as_float(payload.get("response_cost")),

--- a/litellm/integrations/otel/model/semconv.py
+++ b/litellm/integrations/otel/model/semconv.py
@@ -109,6 +109,8 @@ class GenAI:
     # usage
     USAGE_INPUT_TOKENS: Final = "gen_ai.usage.input_tokens"
     USAGE_OUTPUT_TOKENS: Final = "gen_ai.usage.output_tokens"
+    USAGE_CACHE_CREATION_INPUT_TOKENS: Final = "gen_ai.usage.cache_creation.input_tokens"
+    USAGE_CACHE_READ_INPUT_TOKENS: Final = "gen_ai.usage.cache_read.input_tokens"
     # content (opt-in, gated by capture mode)
     INPUT_MESSAGES: Final = "gen_ai.input.messages"
     OUTPUT_MESSAGES: Final = "gen_ai.output.messages"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "litellm"
-version = "1.99.0"
+version = "1.99.1"
 description = "Library to easily interface with LLM API providers"
 readme = "README.md"
 requires-python = ">=3.10, <3.15"
@@ -310,7 +310,7 @@ members = ["enterprise", "litellm-proxy-extras"]
 profile = "black"
 
 [tool.commitizen]
-version = "1.99.0"
+version = "1.99.1"
 version_files = [
     "pyproject.toml:^version",
 ]

--- a/tests/test_litellm/integrations/otel/test_otel_v2_components.py
+++ b/tests/test_litellm/integrations/otel/test_otel_v2_components.py
@@ -3,6 +3,7 @@ baggage helpers, metrics, the typed coercion helpers, mapper branches, span-name
 builders, and the registry validator's failure paths. Needs the OTel SDK."""
 
 import json
+from dataclasses import replace
 
 import pytest
 
@@ -225,6 +226,27 @@ def test_genai_mapper_all_request_params():
     assert attrs[GenAI.REQUEST_STOP_SEQUENCES] == ["STOP"]
     assert attrs[GenAI.REQUEST_SEED] == 42
     assert attrs["server.port"] == 443
+
+
+def test_genai_mapper_cache_token_attrs():
+    cached = replace(
+        _full_llm_call(),
+        usage=LLMUsage(
+            input_tokens=10,
+            output_tokens=5,
+            total_tokens=15,
+            cache_creation_input_tokens=7,
+            cache_read_input_tokens=3,
+        ),
+    )
+    attrs = GenAIMapper().map(cached)
+    assert attrs[GenAI.USAGE_CACHE_CREATION_INPUT_TOKENS] == 7
+    assert attrs[GenAI.USAGE_CACHE_READ_INPUT_TOKENS] == 3
+
+    # No cache usage keeps the span sparse: neither key present.
+    uncached = GenAIMapper().map(_full_llm_call())
+    assert GenAI.USAGE_CACHE_CREATION_INPUT_TOKENS not in uncached
+    assert GenAI.USAGE_CACHE_READ_INPUT_TOKENS not in uncached
 
 
 def test_genai_mapper_stamps_input_output_messages():

--- a/tests/test_litellm/integrations/otel/test_otel_v2_sources_of_truth.py
+++ b/tests/test_litellm/integrations/otel/test_otel_v2_sources_of_truth.py
@@ -507,6 +507,28 @@ def test_llm_call_adapter_extracts_all_fields():
     assert data.identity.key_hash == "hsh"
 
 
+def test_llm_call_adapter_extracts_cache_tokens_from_usage_object():
+    payload = _sample_payload()
+    payload["metadata"] = {
+        **payload["metadata"],
+        "usage_object": {
+            "prompt_tokens": 10,
+            "completion_tokens": 5,
+            "cache_creation_input_tokens": 7,
+            "cache_read_input_tokens": 3,
+        },
+    }
+    data = LLMCallSpanData.from_standard_logging_payload(payload)
+    assert data.usage.cache_creation_input_tokens == 7
+    assert data.usage.cache_read_input_tokens == 3
+
+
+def test_llm_call_adapter_cache_tokens_none_without_usage_object():
+    data = LLMCallSpanData.from_standard_logging_payload(_sample_payload())
+    assert data.usage.cache_creation_input_tokens is None
+    assert data.usage.cache_read_input_tokens is None
+
+
 def test_llm_call_adapter_failure_path():
     payload = _sample_payload(
         status="failure",

--- a/uv.lock
+++ b/uv.lock
@@ -10,7 +10,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-08-19T15:53:37.294198Z"
+exclude-newer = "2026-08-29T19:50:55.983368Z"
 exclude-newer-span = "P3D"
 
 [manifest]
@@ -8261,11 +8261,11 @@ wheels = [
 
 [[package]]
 name = "restrictedpython"
-version = "8.1"
+version = "8.5"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/5f/1c/aec08bcb4ab14a1521579fbe21ceff2a634bb1f737f11cf7f9c8bb96e680/restrictedpython-8.1.tar.gz", hash = "sha256:4a69304aceacf6bee74bdf153c728221d4e3109b39acbfe00b3494927080d898", size = 838331, upload-time = "2025-10-19T14:11:32.531Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7c/3b/8e41f7cfabbb30b1013ebc7484303d6c87da2906ec432d69dea11d2f7d75/restrictedpython-8.5.tar.gz", hash = "sha256:4ed1269dbe3caa88db650d1af325198a952aeb1451eca05df0cfa65db4466215", size = 455879, upload-time = "2026-08-19T07:02:10.934Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1a/c0/3848f4006f7e164ee20833ca984067e4b3fc99fe7f1dfa88b4927e681299/restrictedpython-8.1-py3-none-any.whl", hash = "sha256:4769449c6cdb10f2071649ba386902befff0eff2a8fd6217989fa7b16aeae926", size = 27651, upload-time = "2025-10-19T14:11:30.201Z" },
+    { url = "https://files.pythonhosted.org/packages/58/57/16ce3c721f5a33317e4110575d5c9976c0c45f7fd96ca2e0adeab06e6026/restrictedpython-8.5-py3-none-any.whl", hash = "sha256:6c70e0a3af13e830d37225788cdc8ab5804a8df4b500c135086eaef34b5c01e0", size = 30962, upload-time = "2026-08-19T07:02:09.553Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -10,7 +10,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-08-29T19:50:55.983368Z"
+exclude-newer = "2026-08-29T19:55:59.005565Z"
 exclude-newer-span = "P3D"
 
 [manifest]
@@ -4266,7 +4266,7 @@ wheels = [
 
 [[package]]
 name = "litellm"
-version = "1.99.0"
+version = "1.99.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## TLDR

Problem this solves:

- stable/1.99.x OTel v2 spans carry cache cost but no cache token counts
- v1.99.0 has shipped, so this line needs a new patch version

How it solves it:

- Backports #38716 onto stable/1.99.x
- Refreshes RestrictedPython in the lock and cuts 1.99.1

## User Flow

Before: an operator running the 1.99.x stable image and exporting OTel v2 traces to a cost tool sees zero cache token counts, so cache spend computed from tokens comes out as zero

1. They deploy `litellm/litellm:v1.99.0`, enable OTel v2 tracing, and point the exporter at their observability backend
2. They send POST https://litellm-domain/v1/chat/completions with an Anthropic model and a `cache_control` block large enough to trigger prompt caching
3. The API response's `usage` shows real `cache_creation_input_tokens` and `cache_read_input_tokens`
4. The exported LLM span shows `litellm.cost.cache_read` but no cache token count attributes, so their cost tool records zero cache tokens

After: the same span carries the cache token counts, so token-based cost tools price cache usage correctly

1. They deploy the 1.99.1 image, enable OTel v2 tracing, and point the exporter at their observability backend
2. They send the same POST https://litellm-domain/v1/chat/completions with the same `cache_control` payload
3. The API response's `usage` shows the same real `cache_creation_input_tokens` and `cache_read_input_tokens`
4. The exported LLM span now carries `gen_ai.usage.cache_creation.input_tokens` and `gen_ai.usage.cache_read.input_tokens` matching the response, alongside the existing cost attributes

## Relevant issues

Backports the OTel v2 cache-token fix from #38716 onto stable/1.99.x and cuts 1.99.1. v1.99.0 is already published on DockerHub and GHCR and has both a `v1.99.0` tag and a `release/v1.99.0` branch, so the line needs a new patch version rather than reusing the tip

The lock also picks up RestrictedPython 8.5, matching what internal staging already resolves. It is a lock-only change inside the line's existing `>=8.1,<9.0` range, and the regenerated lock moves that one package and nothing else

## Linear ticket

Resolves LIT-6439

## What is included

- #38716 fix(otel): emit cache token counts on OTel v2 LLM spans, cherry-picked verbatim from `40edeaae` on internal staging
- chore(deps): bump restrictedpython to 8.5, a lock-only regeneration
- bump: version 1.99.0 to 1.99.1
- chore: refresh uv.lock for 1.99.1

## Adaptation notes

None. The pick is patch-id identical to its staging commit; the only difference `git range-diff` reports is the `-x` provenance footer cherry-pick adds to the message

`LLMUsage` on this line matched the pick's pre-image exactly, `StandardLoggingMetadata.usage_object` is already populated here, and `litellm/types/utils.py` shows no divergence from staging anywhere in the cache-token or usage-object surface, so the pick had nothing to adapt to

## Known noise on this line

None. The targeted suite on the line's tip before picking was 447 passed, 0 failed, so every failure a reviewer sees in CI is worth reading as real

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally
- [x] My PR passes all required CI/CD checks
- [x] My PR's scope is as isolated as possible
- [ ] I have received a Greptile Confidence Score of at least 4/5

## Screenshots / Proof of Fix

Shared setup, used identically on both sides: a proxy started against this line's own source with `LITELLM_OTEL_V2=true` and `OTEL_EXPORTER=console`, one deployment `claude-cache-test` pointing at `anthropic/claude-sonnet-5`, and a single request body carrying a 15599-character system prompt marked `cache_control: {"type": "ephemeral"}`, large enough for Anthropic to actually cache it. Real Anthropic calls, real cache billing

### Before (fa647f742d)

1. `curl -s "http://localhost:4010/v1/chat/completions" -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" -d @cache_body.json` returns usage with `cache_creation_input_tokens = 0` and `cache_read_input_tokens = 4803`, so the provider really did bill cache tokens
2. `grep -oE '"gen_ai\.usage\.cache_(creation|read)\.input_tokens": [0-9]+' proxy.log` returns nothing: the span carries no cache token attributes
3. Liveness gate for that absence, proving the span was exported at all rather than the grep matching nothing because nothing ran: `grep -oE '"gen_ai\.usage\.(input|output)_tokens": [0-9]+' proxy.log` returns `"gen_ai.usage.input_tokens": 4819` and `"gen_ai.usage.output_tokens": 4`

### After (3ebb415b54)

1. First call with the same body returns usage with `cache_creation_input_tokens = 4803`, `cache_read_input_tokens = 0`; the second returns `cache_creation_input_tokens = 0`, `cache_read_input_tokens = 4803`
2. `grep -oE '"gen_ai\.usage\.cache_(creation|read)\.input_tokens": [0-9]+' proxy.log` now returns all four, matching the two responses exactly:

```
1 "gen_ai.usage.cache_creation.input_tokens": 0
1 "gen_ai.usage.cache_creation.input_tokens": 4803
1 "gen_ai.usage.cache_read.input_tokens": 0
1 "gen_ai.usage.cache_read.input_tokens": 4803
```

### Supporting checks

1. Targeted suite as a delta: the line's tip gave `447 passed`, this branch gives `450 passed`, so the three tests #38716 adds all land and nothing that passed before regressed
2. The pick's own tests by name give `3 passed`: `test_genai_mapper_cache_token_attrs`, `test_llm_call_adapter_extracts_cache_tokens_from_usage_object`, `test_llm_call_adapter_cache_tokens_none_without_usage_object`
3. `uv run python -c "import importlib.metadata as m; print(m.version('RestrictedPython'))"` prints `8.5`. The lock regeneration's moved set is exactly `restrictedpython: 8.1 -> 8.5`, and the later refresh for the version bump moves only `litellm: 1.99.0 -> 1.99.1`
4. The RestrictedPython consumers were run on both sides as their own A/B: `39 passed` against 8.1 on the line's tip and `39 passed` against 8.5 on this branch
5. An adversarial review pass over the branch found no regression: every identifier the picked diff references resolves here, no existing caller of the modified functions breaks, and the dependency refresh regressed nothing. Its one substantive finding is a pre-existing product limitation, described under Caveats

## Type

🐛 Bug Fix

## Caveats (if any)

- pyproject.toml changes here are only the version bump
- RestrictedPython moves to 8.5 to match internal staging
- Cache token attributes are populated for Anthropic-shaped usage only

On that last point, since it came up in review of this backport: the adapter reads the top-level `cache_creation_input_tokens` and `cache_read_input_tokens` keys, which only Anthropic-shaped usage carries. OpenAI's native prompt caching reports its count under `prompt_tokens_details.cached_tokens` and DeepSeek uses `prompt_cache_hit_tokens`, so spans for those providers still carry no cache token attributes

This is inherited unchanged from #38716 rather than introduced here, and it is not a regression on this line: OTel v1 emits only total, input and output tokens, and OTel v2 emitted no cache attributes at all before that PR, so no provider is losing telemetry it used to have. Generalizing it is a follow-up on internal staging, most likely by reading the already provider-neutral `prompt_tokens_details` rather than the raw provider keys

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
