### PR TITLE
test: exempt MockTransport request-shape embedding tests from VCR replay

### DIFF
--- a/tests/llm_translation/conftest.py
+++ b/tests/llm_translation/conftest.py
@@ -44,7 +44,11 @@ _VCR_AUTO_MARKER_SKIP_FILES = frozenset(
     {"test_vcr_redis_persister.py", "test_ws_vcr.py"}
 )
 
-_VCR_INCOMPATIBLE_NODEID_SUFFIXES: tuple[str, ...] = ()
+_VCR_INCOMPATIBLE_NODEID_SUFFIXES: tuple[str, ...] = (
+    "test_nvidia_nim.py::test_embedding_nvidia_nim",
+    "test_litellm_proxy_provider.py::test_litellm_gateway_from_sdk_embedding[False]",
+    "test_litellm_proxy_provider.py::test_litellm_gateway_from_sdk_embedding[True]",
+)
 
 
 _verbose_state = VerboseReporterState()

--- a/tests/local_testing/conftest.py
+++ b/tests/local_testing/conftest.py
@@ -90,6 +90,7 @@ _VCR_INCOMPATIBLE_FILES = frozenset(
 #   carry no real provider cost.
 _VCR_INCOMPATIBLE_NODEID_SUFFIXES: tuple[str, ...] = (
     "test_router.py::test_router_text_completion_client",
+    "test_embedding.py::test_encoding_format_omitted_by_default_for_openai_sdk",
 )
 
 

--- a/tests/local_testing/test_get_llm_provider.py
+++ b/tests/local_testing/test_get_llm_provider.py
@@ -155,6 +155,11 @@ def test_default_api_base():
                         continue
                     elif provider == "github" and other_provider.value == "azure":
                         continue
+                    elif (
+                        provider in ("qwencloud", "qwen_ai_platform")
+                        and other_provider.value == "dashscope"
+                    ):
+                        continue
                     assert other_provider.value not in api_base.replace("/openai", "")
 
 


### PR DESCRIPTION
## TLDR

Problem this solves:

- Staging CI red since #38774 merged: 5 embedding request-shape tests fail
- `local_testing_part1` and `llm_translation_testing` fail on every run, blocking all PRs
- The tests capture request bodies with `httpx.MockTransport`; VCR cassette replay starves the capture handler
- #38774's own CI recorded the cassettes (green), every later run replays them (red)
- `local_testing_part1` has a second pre-existing break, `test_default_api_base` (LIT-6633)

How it solves it:

- Lists the 4 MockTransport tests in the conftests' `_VCR_INCOMPATIBLE_NODEID_SUFFIXES`
- Same mechanism and reason as the existing `test_router_text_completion_client` entry
- The tests still run fully; they just no longer get wrapped in cassette replay
- Carries the same one-hunk `test_default_api_base` carve-out as #39177 so the job can actually go green

## User Flow

Before: any engineer's PR against litellm_internal_staging fails two required CI jobs on embedding tests their change never touched

1. They push a branch, open a PR against litellm_internal_staging, and add the run-ci label
2. On the CircleCI workflow page, `local_testing_part1` goes red: `test_embedding.py::test_encoding_format_omitted_by_default_for_openai_sdk` fails with `IndexError: list index out of range`, right after a `[VCR HIT]` line for that test
3. `llm_translation_testing` goes red too: `test_embedding_nvidia_nim` and both `test_litellm_gateway_from_sdk_embedding` variants fail with the same IndexError after 3 attempts each
4. They rerun the jobs and get the identical failures, so their PR cannot go green no matter what they change

After: the same PR runs both jobs green

1. They push a branch, open a PR against litellm_internal_staging, and add the run-ci label
2. `local_testing_part1` runs the same embedding test and it passes
3. `llm_translation_testing` passes the nvidia and gateway embedding tests on the first attempt
4. The check rollup goes green and their PR can merge

## Relevant issues

## Linear ticket

Resolves LIT-6638

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Root cause: the 4 tests (5 items) rewritten by #38774 build their own OpenAI client on an `httpx.MockTransport` whose handler captures the outgoing request body. In CI the VCR layer (active whenever `CASSETTE_REDIS_URL` is set) auto-marks them and patches the httpx transport machinery, so on the first run the request records through the mock (test passes, cassette persists to the shared Redis) and on every later run the cassette replays: the handler never fires, `captured_bodies` stays empty, and `captured_bodies[0]` raises IndexError. Locally VCR is off, so the tests always pass in isolation. Repro below runs a throwaway Redis at `redis://127.0.0.1:40858/0` to mirror CI.

### Before (6c26345ab5)

#### local_testing_part1 embedding test: records green once, then replays red forever

1. `CASSETTE_REDIS_URL=redis://127.0.0.1:40858/0 uv run pytest 'tests/local_testing/test_embedding.py::test_encoding_format_omitted_by_default_for_openai_sdk' -vv -x -n 4 --timeout=300 --timeout_method=thread` (empty cassette store, first run)
2. `[VCR MISS:RECORDED] played=0 entries=1` and `1 passed` (this is what #38774's own PR pipeline did)
3. Same command again (cassette now present, which is every CI run since the merge)
4. `[VCR HIT] played=1 entries=1`, then `IndexError: list index out of range` at `test_embedding.py:1293`, `1 failed`

#### llm_translation_testing trio: same record-then-replay failure

1. `CASSETTE_REDIS_URL=redis://127.0.0.1:40858/0 uv run pytest 'tests/llm_translation/test_nvidia_nim.py::test_embedding_nvidia_nim' 'tests/llm_translation/test_litellm_proxy_provider.py::test_litellm_gateway_from_sdk_embedding' -v -n 4 --timeout=120 --timeout_method=thread --retries 2 --retry-delay 5 --max-worker-restart=5` (first run)
2. `3 passed`, all `[VCR MISS:RECORDED]`
3. Same command again
4. `3 failed, 6 retried`: each test fails all 3 attempts with `IndexError: list index out of range`, matching the staging jobs

#### test_default_api_base (pre-existing LIT-6633 break in the same job)

1. `pytest 'tests/local_testing/test_get_llm_provider.py::test_default_api_base' -q`
2. `AssertionError`: `'dashscope' is contained here: https://dashscope-intl.aliyuncs.com/compatible-mode/v1`, `1 failed`

### After (6a9dcb5ce6)

#### local_testing_part1 embedding test with the poisoned cassette still in Redis

1. `CASSETTE_REDIS_URL=redis://127.0.0.1:40858/0 uv run pytest 'tests/local_testing/test_embedding.py::test_encoding_format_omitted_by_default_for_openai_sdk' 'tests/local_testing/test_get_llm_provider.py::test_default_api_base' -vv -n 4 --timeout=300 --timeout_method=thread`
2. `2 passed`; skip-reason breakdown shows the embedding test as `incompatible`, cost-leak check `PASS` (MockTransport opens no live connection)

#### llm_translation_testing trio with the poisoned cassettes still in Redis

1. `CASSETTE_REDIS_URL=redis://127.0.0.1:40858/0 uv run pytest 'tests/llm_translation/test_nvidia_nim.py::test_embedding_nvidia_nim' 'tests/llm_translation/test_litellm_proxy_provider.py::test_litellm_gateway_from_sdk_embedding' -v -n 4 --timeout=120 --timeout_method=thread --retries 2 --retry-delay 5 --max-worker-restart=5`
2. `3 passed` on the first attempt, all 3 tagged `incompatible`, cost-leak check `PASS`

## Type

✅ Test

## Caveats (if any)

### Low

- The auto-marker cannot detect `httpx.MockTransport` the way it detects respx
- A future MockTransport test would hit the same trap; generic detection is a possible follow-up
- Stale cassettes for these 4 tests stay in the shared Redis until they expire; they are ignored, not read

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only VCR opt-outs and a narrow assertion carve-out; no production runtime or security impact.
> 
> **Overview**
> Unblocks staging CI by **excluding four embedding request-shape tests** from VCR cassette replay in `tests/local_testing/conftest.py` and `tests/llm_translation/conftest.py`. Those tests use `httpx.MockTransport` to capture outgoing bodies; after #38774, first CI runs recorded cassettes and later replays skipped the mock handler, causing `IndexError` on empty `captured_bodies`.
> 
> The new `_VCR_INCOMPATIBLE_NODEID_SUFFIXES` entries mirror the existing `test_router_text_completion_client` pattern—the tests still run live (or mocked) but are no longer auto-wrapped in VCR.
> 
> **Separately**, `test_default_api_base` in `test_get_llm_provider.py` now **skips the dashscope cross-provider check** when the provider is `qwencloud` or `qwen_ai_platform`, because their default API base legitimately contains `dashscope` in the hostname.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6a9dcb5ce65c9c34e37245cd8f5937fa7e927d64. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->