### PR TITLE
fix(bedrock): keep Converse chat completions working under bearer-token auth

### DIFF
--- a/litellm/llms/bedrock/base_aws_llm.py
+++ b/litellm/llms/bedrock/base_aws_llm.py
@@ -1442,7 +1442,7 @@ class BaseAWSLLM:
     @tracer.wrap()
     def get_request_headers(
         self,
-        credentials: Credentials,
+        credentials: Credentials | None,
         aws_region_name: str,
         extra_headers: dict | None,
         endpoint_url: str,

--- a/litellm/llms/bedrock/chat/converse_handler.py
+++ b/litellm/llms/bedrock/chat/converse_handler.py
@@ -95,7 +95,7 @@ class BedrockConverseLLM(BaseAWSLLM):
         stream,
         optional_params: dict,
         litellm_params: dict,
-        credentials: Credentials,
+        credentials: Credentials | None,
         logger_fn=None,
         headers={},
         client: AsyncHTTPHandler | None = None,
@@ -167,7 +167,7 @@ class BedrockConverseLLM(BaseAWSLLM):
         stream,
         optional_params: dict,
         litellm_params: dict,
-        credentials: Credentials,
+        credentials: Credentials | None,
         logger_fn=None,
         headers: dict = {},
         client: AsyncHTTPHandler | None = None,
@@ -331,7 +331,7 @@ class BedrockConverseLLM(BaseAWSLLM):
 
         litellm_params["aws_region_name"] = aws_region_name  # [DO NOT DELETE] important for async calls
 
-        credentials: Final[Credentials] = self.get_credentials(
+        credentials: Final[Credentials | None] = self.get_credentials(
             aws_access_key_id=aws_access_key_id,
             aws_secret_access_key=aws_secret_access_key,
             aws_session_token=aws_session_token,
@@ -368,15 +368,23 @@ class BedrockConverseLLM(BaseAWSLLM):
         # The Rust core owns the whole call for the subset it accepts. Ask
         # before transforming so whichever path runs emits pre_call once, and
         # hand down the credentials, region and endpoint this handler already
-        # resolved so both paths sign as the same principal.
+        # resolved so both paths sign as the same principal. Bearer-token
+        # deployments resolve no SigV4 credentials; the core then reads the
+        # token from api_key or AWS_BEARER_TOKEN_BEDROCK, as the Python path does.
         rust_optional_params: Final = {  # mutable-ok: json.dumps in the bridge rejects a mappingproxy
             **optional_params,
             **{  # mutable-ok: merged into its mutable parent above
                 key: value
                 for key, value in (
-                    ("aws_access_key_id", credentials.access_key),
-                    ("aws_secret_access_key", credentials.secret_key),
-                    ("aws_session_token", credentials.token),
+                    *(
+                        ()
+                        if credentials is None
+                        else (
+                            ("aws_access_key_id", credentials.access_key),
+                            ("aws_secret_access_key", credentials.secret_key),
+                            ("aws_session_token", credentials.token),
+                        )
+                    ),
                     ("aws_region_name", aws_region_name),
                 )
                 if value is not None

--- a/tests/test_litellm/llms/bedrock/chat/test_bedrock_converse_handler.py
+++ b/tests/test_litellm/llms/bedrock/chat/test_bedrock_converse_handler.py
@@ -12,6 +12,7 @@ import httpx
 import pytest
 
 from botocore.credentials import Credentials
+from litellm.llms.bedrock.base_aws_llm import BaseAWSLLM
 from litellm.llms.bedrock.chat.converse_handler import BedrockConverseLLM
 from litellm.llms.custom_httpx.http_handler import AsyncHTTPHandler, HTTPHandler
 from litellm.rust_bridge import chat_completions as bridge
@@ -487,3 +488,76 @@ def test_post_call_is_not_logged_twice_when_the_sync_rust_call_declines():
     assert response.choices[0].message.content == "hi"
     assert len(calls["post_call"]) == 1
     assert "hi" in calls["post_call"][0]["original_response"]
+
+
+@pytest.fixture
+def bearer_token_only(monkeypatch, tmp_path):
+    """Only a Bedrock API key is configured, so boto3 resolves no SigV4 credentials."""
+    for name in (
+        "AWS_ACCESS_KEY_ID",
+        "AWS_SECRET_ACCESS_KEY",
+        "AWS_SESSION_TOKEN",
+        "AWS_PROFILE",
+        "AWS_DEFAULT_PROFILE",
+        "AWS_PROFILE_NAME",
+        "AWS_ROLE_NAME",
+        "AWS_ROLE_ARN",
+        "AWS_WEB_IDENTITY_TOKEN",
+        "AWS_WEB_IDENTITY_TOKEN_FILE",
+        "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI",
+        "AWS_CONTAINER_CREDENTIALS_FULL_URI",
+    ):
+        monkeypatch.delenv(name, raising=False)
+    monkeypatch.setenv("AWS_SHARED_CREDENTIALS_FILE", str(tmp_path / "no-credentials"))
+    monkeypatch.setenv("AWS_CONFIG_FILE", str(tmp_path / "no-config"))
+    monkeypatch.setenv("AWS_EC2_METADATA_DISABLED", "true")
+    monkeypatch.setenv("AWS_BEARER_TOKEN_BEDROCK", "bedrock-api-key")
+    BaseAWSLLM._shared_iam_cache.flush_cache()
+    assert BedrockConverseLLM().get_credentials(aws_region_name="us-east-1") is None
+    yield
+    BaseAWSLLM._shared_iam_cache.flush_cache()
+
+
+def _recording_sync_client(posted: list[dict]):
+    client = MagicMock()
+
+    def post(**kwargs):
+        posted.append(kwargs)
+        return httpx.Response(
+            200,
+            json=CONVERSE_RESPONSE,
+            request=httpx.Request("POST", "https://bedrock-runtime.us-east-1.amazonaws.com"),
+        )
+
+    client.post = post
+    client.__class__ = HTTPHandler
+    return client
+
+
+@pytest.mark.parametrize(
+    "api_key, expected_token",
+    [(None, "bedrock-api-key"), ("key-from-the-deployment", "key-from-the-deployment")],
+)
+def test_bearer_token_auth_without_sigv4_credentials_sends_a_bearer_request(bearer_token_only, api_key, expected_token):
+    """Regression: an API-key deployment resolves no SigV4 credentials, and the
+    handler dereferenced them while preparing the Rust hand-off, so every Converse
+    call crashed with an AttributeError before the request was even built."""
+    posted: list[dict] = []
+    response = BedrockConverseLLM().completion(
+        **_completion_kwargs(litellm_params={}, api_key=api_key, client=_recording_sync_client(posted))
+    )
+
+    assert response.choices[0].message.content == "hi"
+    assert posted[0]["headers"]["Authorization"] == f"Bearer {expected_token}"
+
+
+def test_bearer_token_auth_without_sigv4_credentials_hands_the_core_no_aws_keys(bearer_token_only):
+    """The core reads the bearer token itself, so it must get the region and none
+    of the SigV4 keys this handler could not resolve."""
+    seen = _inject()
+    response = BedrockConverseLLM().completion(**_completion_kwargs())
+
+    assert response.choices[0].message.content == "hello from rust"
+    params = seen["call"][0]["optional_params"]
+    assert params["aws_region_name"] == "us-east-1"
+    assert params.keys().isdisjoint({"aws_access_key_id", "aws_secret_access_key", "aws_session_token"})


### PR DESCRIPTION
## TLDR

Problem this solves:

- Every Bedrock chat completion with a bearer token crashed
- Bearer-token deployments resolve no SigV4 credentials, so they are None
- The Converse handler dereferenced None while preparing the Rust hand-off
- Broken since #37241 on `main` and `litellm_internal_staging`

How it solves it:

- Hand SigV4 keys to the Rust core only when credentials resolved
- The Rust core already reads `api_key` or `AWS_BEARER_TOKEN_BEDROCK` itself
- Type the credentials as optional on the Converse path
- Regression tests cover the Python path and the Rust hand-off

## User Flow

Before: a proxy admin who authenticates to Bedrock with an API key (bearer token) cannot make any chat completion call to a Bedrock model

1. They set `AWS_BEARER_TOKEN_BEDROCK` (no `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY`) and add `bedrock/global.anthropic.claude-fable-5-1` with `aws_region_name: us-east-1` to the config
2. They send POST http://localhost:4000/v1/chat/completions with `{"model": "fable-bedrock-global", "messages": [...]}`
3. They get HTTP 400 with `litellm.APIConnectionError: 'NoneType' object has no attribute 'access_key'` and a Python traceback, after two retries
4. The same happens with `"stream": true`. `/v1/messages` to the same deployment keeps working, so only the chat completions route is dead

After: the same admin gets normal chat completions back

1. Same config, same env
2. They send the same POST http://localhost:4000/v1/chat/completions
3. They get HTTP 200 with the assistant message and token usage
4. With `"stream": true` they get the SSE chunks ending in `data: [DONE]`

## Relevant issues

Regression introduced by #37241

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Setup: proxy started with `python litellm/proxy/proxy_cli.py --config config.yaml --port 4771 --detailed_debug`, with only `AWS_BEARER_TOKEN_BEDROCK` set in the environment (no `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_SESSION_TOKEN`, or `AWS_PROFILE`). Real Bedrock calls to Claude Fable 5.1

```yaml
model_list:
  - model_name: fable-bedrock-global
    litellm_params:
      model: bedrock/global.anthropic.claude-fable-5-1
      aws_region_name: us-east-1

general_settings:
  master_key: sk-1234
```

Both cases use the same request, with `"stream": true` added for the streaming case

```bash
curl -sS http://127.0.0.1:4771/v1/chat/completions \
  -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
  -d '{"model":"fable-bedrock-global","messages":[{"role":"user","content":"Say hi in five words."}],"max_tokens":64}' \
  -w '\nHTTP %{http_code}\n'
```

### Before (8bc862f52c)

#### Non-streaming chat completion

1. Ran the curl above
2. Output:

```
{"error":{"message":"Invalid request format: litellm.APIConnectionError: 'NoneType' object has no attribute 'access_key'\nTraceback (most recent call last):\n  File \".../litellm/main.py\", line 5785, in completion\n    response = _complete_bedrock(_dispatch_ctx)\n  File \".../litellm/main.py\", line 4059, in _complete_bedrock\n    response = bedrock_converse_chat_completion.completion(\n  File \".../litellm/llms/bedrock/chat/converse_handler.py\", line 377, in completion\n    (\"aws_access_key_id\", credentials.access_key),\nAttributeError: 'NoneType' object has no attribute 'access_key'\n. Received Model Group=fable-bedrock-global\nAvailable Model Group Fallbacks=None LiteLLM Retried: 2 times, LiteLLM Max Retries: 2","type":"invalid_request_error","param":null,"code":"400"}}
HTTP 400
```

#### Streaming chat completion

1. Ran the curl above with `"stream":true` added to the body and `-N`
2. Output: the same 400 error body as the non-streaming case

```
{"error":{"message":"Invalid request format: litellm.APIConnectionError: 'NoneType' object has no attribute 'access_key'\n...AttributeError: 'NoneType' object has no attribute 'access_key'\n. Received Model Group=fable-bedrock-global\nAvailable Model Group Fallbacks=None LiteLLM Retried: 2 times, LiteLLM Max Retries: 2","type":"invalid_request_error","param":null,"code":"400"}}
HTTP 400
```

### After (cb886a51f7)

#### Non-streaming chat completion

1. Ran the curl above
2. Output:

```
{"id":"chatcmpl-e7cee220-cfdb-43b4-9a93-dbf566b8df32","created":1788297931,"model":"fable-bedrock-global","object":"chat.completion","choices":[{"finish_reason":"stop","index":0,"message":{"content":"Hi there, how are you?","role":"assistant"}}],"usage":{"completion_tokens":11,"prompt_tokens":16,"total_tokens":27,"completion_tokens_details":{"reasoning_tokens":0,"text_tokens":11},"prompt_tokens_details":{"cached_tokens":0,"text_tokens":16,"cache_write_tokens":0,"cache_creation_tokens":0},"cache_creation_input_tokens":0,"cache_read_input_tokens":0}}
HTTP 200
```

#### Streaming chat completion

1. Ran the curl above with `"stream":true` added to the body and `-N`
2. Output:

```
data: {"id":"chatcmpl-d0a995bd-206e-42d8-9b26-c0a8a4ed79b9","created":1788297943,"model":"fable-bedrock-global","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"content":"Hello","role":"assistant"}}],"provider_specific_fields":{}}

data: {"id":"chatcmpl-d0a995bd-206e-42d8-9b26-c0a8a4ed79b9","created":1788297943,"model":"fable-bedrock-global","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"content":" there"}}],"provider_specific_fields":{}}

data: {"id":"chatcmpl-d0a995bd-206e-42d8-9b26-c0a8a4ed79b9","created":1788297943,"model":"fable-bedrock-global","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"content":", n"}}],"provider_specific_fields":{}}

data: {"id":"chatcmpl-d0a995bd-206e-42d8-9b26-c0a8a4ed79b9","created":1788297943,"model":"fable-bedrock-global","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"content":"ice to meet you!"}}],"provider_specific_fields":{}}

data: {"id":"chatcmpl-d0a995bd-206e-42d8-9b26-c0a8a4ed79b9","created":1788297943,"model":"fable-bedrock-global","object":"chat.completion.chunk","choices":[{"finish_reason":"stop","index":0,"delta":{}}],"provider_specific_fields":{}}

data: [DONE]

HTTP 200
```

3. The proxy log shows the requests going to `https://bedrock-runtime.us-east-1.amazonaws.com/model/global.anthropic.claude-fable-5-1/converse` and `.../converse-stream`

## Type

🐛 Bug Fix

## Caveats (if any)

### Low

- `get_request_headers` now accepts `credentials: Credentials | None`. Passing None with no bearer token still fails inside botocore SigV4 signing, exactly as before

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
