### PR TITLE
fix(vertex): avoid duplicate DeepSeek OCR model namespace

### DIFF
--- a/litellm/llms/vertex_ai/ocr/deepseek_transformation.py
+++ b/litellm/llms/vertex_ai/ocr/deepseek_transformation.py
@@ -177,8 +177,9 @@ class VertexAIDeepSeekOCRConfig(BaseOCRConfig):
             content_item = {"type": "image_url", "image_url": document_url}
 
         # Build DeepSeek OCR request
+        provider_model: Final = model if model.startswith("deepseek-ai/") else f"deepseek-ai/{model}"
         data: Final = {
-            "model": "deepseek-ai/" + model,
+            "model": provider_model,
             "messages": [{"role": "user", "content": [content_item]}],
         }
 

--- a/tests/ocr_tests/test_ocr_vertex_ai.py
+++ b/tests/ocr_tests/test_ocr_vertex_ai.py
@@ -5,9 +5,11 @@ Note: Vertex AI OCR automatically converts URLs to base64 data URIs since
 the Vertex AI endpoint doesn't have internet access.
 """
 
-import os
 import json
+import os
 import tempfile
+from typing import Final
+
 import pytest
 from base_ocr_unit_tests import BaseOCRTest
 
@@ -139,3 +141,19 @@ def test_vertex_ai_ocr_routing():
     assert isinstance(
         deepseek_variant, VertexAIDeepSeekOCRConfig
     ), "DeepSeek variant should route to VertexAIDeepSeekOCRConfig"
+
+
+@pytest.mark.parametrize("model", ("deepseek-ocr-maas", "deepseek-ai/deepseek-ocr-maas"))
+def test_deepseek_request_uses_single_provider_namespace(model: str) -> None:
+    from litellm.llms.vertex_ai.ocr.deepseek_transformation import (
+        VertexAIDeepSeekOCRConfig,
+    )
+
+    request: Final = VertexAIDeepSeekOCRConfig().transform_ocr_request(
+        model=model,
+        document={"type": "image_url", "image_url": "data:image/png;base64,AA=="},
+        optional_params={},
+        headers={},
+    )
+
+    assert request.data["model"] == "deepseek-ai/deepseek-ocr-maas"


### PR DESCRIPTION
## TLDR

Problem this solves:

- LiteLLM strips `vertex_ai/` and hands the OCR transformer `deepseek-ai/deepseek-ocr-maas`
- The transformer always prepended `deepseek-ai/`, so Vertex got the namespace twice
- Vertex rejects `deepseek-ai/deepseek-ai/deepseek-ocr-maas` with a 400 (Malformed publisher model)
- The registered cost-map name `vertex_ai/deepseek-ai/deepseek-ocr-maas` never returned OCR output

How it solves it:

- Only add `deepseek-ai/` when the model does not already carry it
- The short form `vertex_ai/deepseek-ocr-maas` keeps working, it still gets the namespace added
- Tests cover both forms and assert exactly one `deepseek-ai/` namespace
- Mirrors the Rust port's existing `deepseek_model_name` normalization

## User Flow

Before: a developer OCR'ing a document through the registered DeepSeek OCR model gets a Vertex 400 instead of OCR output

1. The proxy admin registers `vertex_ai/deepseek-ai/deepseek-ocr-maas` (the name in the cost map) with their Vertex project and `us-central1`
2. The developer sends POST https://litellm-domain/v1/ocr with `"model": "vertex_ai/deepseek-ai/deepseek-ocr-maas"` and a `document` of `{"type": "image_url", "image_url": "data:image/png;base64,..."}`
3. They get a 400 back whose error text says `Malformed publisher model ('model': 'deepseek-ai/deepseek-ai/deepseek-ocr-maas') for the 'openapi' request endpoint ID; expected '<publisher>/<model>'`
4. They retry with `"model": "vertex_ai/deepseek-ocr-maas"` and only that short form returns a 200 with `pages[0].markdown`

After: the same request returns OCR output

1. The proxy admin registers `vertex_ai/deepseek-ai/deepseek-ocr-maas` (the name in the cost map) with their Vertex project and `us-central1`
2. The developer sends POST https://litellm-domain/v1/ocr with `"model": "vertex_ai/deepseek-ai/deepseek-ocr-maas"` and the same image document
3. They get a 200 whose body has `"object": "ocr"` and `pages[0].markdown` holding the text read from the image
4. The short form `"model": "vertex_ai/deepseek-ocr-maas"` keeps returning a 200 with the same shape

## Relevant issues

## Linear ticket

Resolves LIT-6656

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Two no-DB proxies, each booted from its own worktree and venv with 2 uvicorn workers (`python litellm/proxy/proxy_cli.py --config config.yaml --port <port> --num_workers 2`), the same config, and the same payload. Before is the merge base 5767a2da0f on port 22315, After is the PR tip 386946353a on port 58541. Both proxies hit the real Vertex AI DeepSeek OCR endpoint in us-central1

Shared `config.yaml` (`VERTEX_AI_API_KEY` holds a `gcloud auth print-access-token` bearer for the project):

```yaml
model_list:
  - model_name: vertex_ai/deepseek-ai/deepseek-ocr-maas
    litellm_params:
      model: vertex_ai/deepseek-ai/deepseek-ocr-maas
      vertex_project: vertex-check-481318
      vertex_location: us-central1
      api_key: os.environ/VERTEX_AI_API_KEY
  - model_name: vertex_ai/deepseek-ocr-maas
    litellm_params:
      model: vertex_ai/deepseek-ocr-maas
      vertex_project: vertex-check-481318
      vertex_location: us-central1
      api_key: os.environ/VERTEX_AI_API_KEY
general_settings:
  master_key: sk-lit6656-qa
```

Shared payload builder, `ocr.json` is a 900x578 PNG screenshot of the Admin UI sent as a data URL:

```bash
b64=$(base64 -i ocr-input.png | tr -d '\n')
printf '{"model": "%s", "document": {"type": "image_url", "image_url": "data:image/png;base64,%s"}}' "$MODEL" "$b64" > ocr.json
```

### Before (5767a2da0f)

#### Cost-map name via POST /v1/ocr

1. Command (`MODEL=vertex_ai/deepseek-ai/deepseek-ocr-maas`):
   ```bash
   curl -s -w '\nhttp=%{http_code} time=%{time_total}s\n' -X POST http://127.0.0.1:22315/v1/ocr -H "Authorization: Bearer sk-lit6656-qa" -H "Content-Type: application/json" --data-binary @ocr.json
   ```
2. Output:
   ```
   {"error":{"message":"litellm.BadRequestError: Vertex_aiException BadRequestError - [{\n  \"error\": {\n    \"code\": 400,\n    \"message\": \"Malformed publisher model (`model`: 'deepseek-ai/deepseek-ai/deepseek-ocr-maas') for the 'openapi' request endpoint ID; expected '\\u003cpublisher\\u003e/\\u003cmodel\\u003e'.\",\n    \"status\": \"INVALID_ARGUMENT\"\n  }\n}\n]. Received Model Group=vertex_ai/deepseek-ai/deepseek-ocr-maas\nAvailable Model Group Fallbacks=None","type":null,"param":null,"code":"400"}}
   http=400 time=4.816061s
   ```

#### Cost-map name via POST /ocr

1. Command (same `ocr.json`):
   ```bash
   curl -s -w '\nhttp=%{http_code} time=%{time_total}s\n' -X POST http://127.0.0.1:22315/ocr -H "Authorization: Bearer sk-lit6656-qa" -H "Content-Type: application/json" --data-binary @ocr.json
   ```
2. Output:
   ```
   {"error":{"message":"litellm.BadRequestError: Vertex_aiException BadRequestError - [{\n  \"error\": {\n    \"code\": 400,\n    \"message\": \"Malformed publisher model (`model`: 'deepseek-ai/deepseek-ai/deepseek-ocr-maas') for the 'openapi' request endpoint ID; expected '\\u003cpublisher\\u003e/\\u003cmodel\\u003e'.\",\n    \"status\": \"INVALID_ARGUMENT\"\n  }\n}\n]. Received Model Group=vertex_ai/deepseek-ai/deepseek-ocr-maas\nAvailable Model Group Fallbacks=None","type":null,"param":null,"code":"400"}}
   http=400 time=1.197225s
   ```

#### Short name via POST /v1/ocr

1. Command (`MODEL=vertex_ai/deepseek-ocr-maas`):
   ```bash
   curl -s -w '\nhttp=%{http_code} time=%{time_total}s\n' -X POST http://127.0.0.1:22315/v1/ocr -H "Authorization: Bearer sk-lit6656-qa" -H "Content-Type: application/json" --data-binary @ocr.json
   ```
2. Output (markdown trimmed):
   ```
   {"pages":[{"index":0,"markdown":"1.83.12\n\nAI GATEWAY\n\n- Virtual Keys\n  - Playground\n  - Models + Endpoints\n  - Agents\n  - MCP Servers\n  - Skills\n ...","images":null,"dimensions":null}],"model":"vertex_ai/deepseek-ocr-maas","document_annotation":null,"usage_info":{"pages_processed":null,"pages_processed_annotation":null,"credits":null,"doc_size_bytes":null,"completion_tokens":109,"extra_properties":{"google":{"traffic_type":"ON_DEMAND"}},"prompt_tokens":901,"prompt_tokens_details":null,"total_tokens":1010},"content":null,"tables":null,"keyValuePairs":null,"object":"ocr"}
   http=200 time=5.674506s
   ```

#### Cost-map name via the Python SDK

1. Command (run with the merge-base tree on `PYTHONPATH`):
   ```python
   import litellm, os
   print("litellm loaded from:", litellm.__file__)
   r = litellm.ocr(model="vertex_ai/deepseek-ai/deepseek-ocr-maas", document={"type": "image_url", "image_url": data_url}, vertex_project="vertex-check-481318", vertex_location="us-central1", api_key=os.environ["VERTEX_AI_API_KEY"])
   print("OK object=%s model=%s pages=%d" % (r.object, r.model, len(r.pages)))
   ```
2. Output:
   ```
   litellm loaded from: /Users/mateo/Development/litellm-wt-lit6656-before/litellm/__init__.py
   litellm.BadRequestError: Vertex_aiException BadRequestError - [{
     "error": {
       "code": 400,
       "message": "Malformed publisher model (`model`: 'deepseek-ai/deepseek-ai/deepseek-ocr-maas') for the 'openapi' request endpoint ID; expected '<publisher>/<model>'.",
       "status": "INVALID_ARGUMENT"
     }
   }
   ]
   ```

### After (386946353a)

#### Cost-map name via POST /v1/ocr

1. Command (`MODEL=vertex_ai/deepseek-ai/deepseek-ocr-maas`):
   ```bash
   curl -s -w '\nhttp=%{http_code} time=%{time_total}s\n' -X POST http://127.0.0.1:58541/v1/ocr -H "Authorization: Bearer sk-lit6656-qa" -H "Content-Type: application/json" --data-binary @ocr.json
   ```
2. Output (markdown trimmed):
   ```
   {"pages":[{"index":0,"markdown":"7cc6361-bc91-412c-b7f5-bc4562bac454\n\n# Overview\n\n## Virtual Keys\n- Failed to update team settings: {\"error\": \"Missing\\\"Cannot move team to organization. ...","images":null,"dimensions":null}],"model":"vertex_ai/deepseek-ai/deepseek-ocr-maas","document_annotation":null,"usage_info":{"pages_processed":null,"pages_processed_annotation":null,"credits":null,"doc_size_bytes":null,"completion_tokens":377,"extra_properties":{"google":{"traffic_type":"ON_DEMAND"}},"prompt_tokens":901,"prompt_tokens_details":null,"total_tokens":1278},"content":null,"tables":null,"keyValuePairs":null,"object":"ocr"}
   http=200 time=4.780455s
   ```

#### Cost-map name via POST /ocr

1. Command (same `ocr.json`):
   ```bash
   curl -s -w '\nhttp=%{http_code} time=%{time_total}s\n' -X POST http://127.0.0.1:58541/ocr -H "Authorization: Bearer sk-lit6656-qa" -H "Content-Type: application/json" --data-binary @ocr.json
   ```
2. Output (markdown trimmed):
   ```
   {"pages":[{"index":0,"markdown":"1.83.11.2\n\nAI GATEWAY\n\nVirtual Keys\n\n\nerror\n\nFailed to update team settings: {\"error\": {\"message\":\"Cannot move team to ...","images":null,"dimensions":null}],"model":"vertex_ai/deepseek-ai/deepseek-ocr-maas","document_annotation":null,"usage_info":{"pages_processed":null,"pages_processed_annotation":null,"credits":null,"doc_size_bytes":null,"completion_tokens":191,"extra_properties":{"google":{"traffic_type":"ON_DEMAND"}},"prompt_tokens":901,"prompt_tokens_details":null,"total_tokens":1092},"content":null,"tables":null,"keyValuePairs":null,"object":"ocr"}
   http=200 time=5.464104s
   ```

#### Short name via POST /v1/ocr

1. Command (`MODEL=vertex_ai/deepseek-ocr-maas`):
   ```bash
   curl -s -w '\nhttp=%{http_code} time=%{time_total}s\n' -X POST http://127.0.0.1:58541/v1/ocr -H "Authorization: Bearer sk-lit6656-qa" -H "Content-Type: application/json" --data-binary @ocr.json
   ```
2. Output (markdown trimmed):
   ```
   {"pages":[{"index":0,"markdown":"＜ Back to Teams\n\nentra-sso-team\n7ec63631-bc91-412c-b7f5-bc4562bac454\n\nOverview  Virtual Keys  Members  Member Permissions  Settings ...","images":null,"dimensions":null}],"model":"vertex_ai/deepseek-ocr-maas","document_annotation":null,"usage_info":{"pages_processed":null,"pages_processed_annotation":null,"credits":null,"doc_size_bytes":null,"completion_tokens":426,"extra_properties":{"google":{"traffic_type":"ON_DEMAND"}},"prompt_tokens":901,"prompt_tokens_details":null,"total_tokens":1327},"content":null,"tables":null,"keyValuePairs":null,"object":"ocr"}
   http=200 time=3.241286s
   ```

#### Cost-map name via the Python SDK

1. Command (same snippet, run with the PR tip on `PYTHONPATH`)
2. Output:
   ```
   litellm loaded from: /Users/mateo/Development/litellm-wt-lit6656/litellm/__init__.py
   OK object=ocr model=deepseek-ai/deepseek-ocr-maas pages=1
   ```

Observations from the run:

- DeepSeek OCR output for the same image varies run to run
- Short name still works on both sides, as intended
- Cost-map name: 200 with no `x-litellm-response-cost` headers (LIT-6727)
- Short name reports $0 on both sides, same ticket
- Pre-existing OCR pricing gap, this PR leaves it alone

## Type

🐛 Bug Fix

## Caveats (if any)

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR


- [x] 386946353a passes /live-pr-risk
