### PR TITLE
test(e2e): cover retry-on-timeout and the context-window fallback

### DIFF
--- a/tests/e2e/models.py
+++ b/tests/e2e/models.py
@@ -805,6 +805,7 @@ class LiteLLMParamsBody(BaseModel):
     mock_response: str | None = None
     timeout: float | None = None
     tpm: int | None = None
+    weight: int | None = None
 
 
 ModelMode = Literal["batch", "realtime", "image_generation"]
@@ -819,6 +820,7 @@ class ModelInfoBody(BaseModel):
     mode: ModelMode | None = None
     access_groups: list[str] | None = None
     team_id: str | None = None
+    allowed_fails_policy: dict[str, int] | None = None
 
 
 class ModelNewBody(BaseModel):

--- a/tests/e2e/router/reliability_support.py
+++ b/tests/e2e/router/reliability_support.py
@@ -19,12 +19,26 @@ from models import (
     ChatMessage,
     ChatResponse,
     LiteLLMParamsBody,
+    ModelInfoBody,
+    ModelNewBody,
     ReliabilityChatBody,
     RouterSettingsOverride,
 )
 
 REAL_MODEL = "openai/gpt-5.5"
 REAL_KEY = "os.environ/OPENAI_API_KEY"
+
+# The smallest-context chat model OpenAI still serves (16385 tokens). A prompt
+# past that limit comes back as a real `context_length_exceeded` 400, which is
+# what litellm maps to ContextWindowExceededError.
+SMALL_CONTEXT_MODEL = "openai/gpt-3.5-turbo"
+SMALL_CONTEXT_LIMIT_TOKENS = 16385
+
+
+def oversized_prompt(marker: str) -> str:
+    """A prompt comfortably past SMALL_CONTEXT_MODEL's context limit, so the
+    provider refuses it on length rather than answering a truncated version."""
+    return f"{marker} " + ("token " * (SMALL_CONTEXT_LIMIT_TOKENS + 4000))
 
 
 def create_bad_base_deployment(proxy: ProxyClient, name: str) -> str:
@@ -38,6 +52,38 @@ def create_bad_base_deployment(proxy: ProxyClient, name: str) -> str:
 def create_timeout_deployment(proxy: ProxyClient, name: str) -> str:
     """Register a deployment with a 1ms deadline the real backend always exceeds."""
     return proxy.create_model(name, LiteLLMParamsBody(model=REAL_MODEL, api_key=REAL_KEY, timeout=0.001))
+
+
+def create_small_context_deployment(proxy: ProxyClient, name: str) -> str:
+    """Register a deployment on the smallest-context model OpenAI still serves, so an
+    oversized prompt earns a real context-window refusal from the provider."""
+    return proxy.create_model(name, LiteLLMParamsBody(model=SMALL_CONTEXT_MODEL, api_key=REAL_KEY))
+
+
+def create_always_timing_out_deployment(proxy: ProxyClient, name: str) -> str:
+    """The always-picked half of a retry pair: a 1ms deadline the backend always
+    exceeds, all of the model group's shuffle weight, and a cooldown policy that
+    benches it on its first Timeout so the retry cannot land on it again."""
+    return proxy.register_model(
+        ModelNewBody(
+            model_name=name,
+            litellm_params=LiteLLMParamsBody(model=REAL_MODEL, api_key=REAL_KEY, timeout=0.001, weight=1),
+            model_info=ModelInfoBody(allowed_fails_policy={"TimeoutErrorAllowedFails": 0}),
+        )
+    )
+
+
+def create_zero_weight_backup_deployment(proxy: ProxyClient, name: str) -> str:
+    """The other half of a retry pair: healthy, but weight 0, so the weighted shuffle
+    never opens on it. It is reachable only once its sibling is benched and the
+    weighted pick falls through to a uniform one over what is left."""
+    return proxy.register_model(
+        ModelNewBody(
+            model_name=name,
+            litellm_params=LiteLLMParamsBody(model=REAL_MODEL, api_key=REAL_KEY, weight=0),
+            model_info=ModelInfoBody(),
+        )
+    )
 
 
 def chat_override(

--- a/tests/e2e/router/test_reliability_fallbacks_e2e.py
+++ b/tests/e2e/router/test_reliability_fallbacks_e2e.py
@@ -9,6 +9,10 @@ in the x-litellm-attempted-fallbacks header. Empty content is accepted only when
 `finish_reason == "length"` and the response billed completion tokens, since
 gpt-5.5 counts reasoning against max_tokens and can consume the whole budget
 before emitting any text; a fallback that produced nothing at all still fails.
+
+The context-window case is a different reroute from a plain failure: the provider
+refuses the prompt on length, and `context_window_fallbacks` is the setting that
+reroutes it, not `fallbacks`.
 """
 
 from __future__ import annotations
@@ -25,8 +29,10 @@ from reliability_support import (
     completion_tokens_of,
     content_of,
     create_bad_base_deployment,
+    create_small_context_deployment,
     create_timeout_deployment,
     finish_reason_of,
+    oversized_prompt,
     reasoning_tokens_of,
 )
 
@@ -80,5 +86,19 @@ class TestReliabilityFallbacks:
         resp = chat_override(
             client.proxy, scoped_key, primary, f"say hi {unique_marker()}",
             override=RouterSettingsOverride(fallbacks=[{primary: ["gpt-5.5"]}]),
+        )
+        _assert_served_by_fallback(resp)
+
+    @pytest.mark.covers("reliability.fallback.context_window.routes_to_fallback")
+    def test_context_window_routes_to_fallback(
+        self, client: ComplexityRouterClient, resources: ResourceManager, scoped_key: str
+    ) -> None:
+        primary = f"reliability-ctxfail-{unique_marker()}"
+        model_id = create_small_context_deployment(client.proxy, primary)
+        resources.defer(lambda: client.proxy.delete_model(model_id))
+
+        resp = chat_override(
+            client.proxy, scoped_key, primary, oversized_prompt(unique_marker()),
+            override=RouterSettingsOverride(context_window_fallbacks=[{primary: ["gpt-5.5"]}]),
         )
         _assert_served_by_fallback(resp)

--- a/tests/e2e/router/test_reliability_retries_e2e.py
+++ b/tests/e2e/router/test_reliability_retries_e2e.py
@@ -1,0 +1,73 @@
+"""Live e2e: a request that fails on its first deployment is retried inside its own
+model group and still comes back a completion.
+
+The model group is a pair: an always-timing-out deployment that holds all of the
+group's shuffle weight, and a healthy backup at weight 0. The weighted pick always
+opens on the timing-out one, its first Timeout benches it (an
+`allowed_fails_policy` of `TimeoutErrorAllowedFails: 0`), and the retry falls
+through to the only deployment left. So the customer sees a completion and the
+proxy reports that it took a retry to get there, with no random first pick in the
+middle of it.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from complexity_router_client import ComplexityRouterClient
+from e2e_config import unique_marker
+from lifecycle import ResourceManager
+from models import RouterSettingsOverride
+from reliability_support import (
+    chat_override,
+    completion_tokens_of,
+    content_of,
+    create_always_timing_out_deployment,
+    create_zero_weight_backup_deployment,
+    finish_reason_of,
+)
+
+pytestmark = pytest.mark.e2e
+
+
+class TestReliabilityRetries:
+    @pytest.mark.covers("reliability.retry.timeout.succeeds_within_retries")
+    def test_timeout_on_first_deployment_succeeds_on_retry(
+        self, client: ComplexityRouterClient, resources: ResourceManager, scoped_key: str
+    ) -> None:
+        group = f"reliability-retry-{unique_marker()}"
+        timing_out = create_always_timing_out_deployment(client.proxy, group)
+        resources.defer(lambda: client.proxy.delete_model(timing_out))
+        backup = create_zero_weight_backup_deployment(client.proxy, group)
+        resources.defer(lambda: client.proxy.delete_model(backup))
+
+        resp = chat_override(
+            client.proxy,
+            scoped_key,
+            group,
+            f"say hi {unique_marker()}",
+            override=RouterSettingsOverride(num_retries=2),
+        )
+
+        assert resp.status_code == 200, (
+            f"the retry should have landed on the healthy backup, got {resp.status_code}: {resp.body[:300]}"
+        )
+
+        attempted = resp.headers.get("x-litellm-attempted-retries")
+        assert attempted is not None, "response is missing the x-litellm-attempted-retries header"
+        assert int(attempted) >= 1, (
+            f"x-litellm-attempted-retries is {attempted!r}; a 200 with no retry means the request never "
+            "opened on the timing-out deployment, so this proves nothing about retries"
+        )
+
+        content = content_of(resp)
+        finish_reason = finish_reason_of(resp)
+        completion_tokens = completion_tokens_of(resp) or 0
+        assert isinstance(content, str), (
+            f"the retry should have returned a completion body, got content {content!r} (body={resp.body[:300]})"
+        )
+        assert content or (finish_reason == "length" and completion_tokens > 0), (
+            f"the retry returned empty content with finish_reason={finish_reason!r}, "
+            f"completion_tokens={completion_tokens}; empty content is only acceptable when the budget "
+            f"was spent on non-visible reasoning (body={resp.body[:300]})"
+        )


### PR DESCRIPTION
## TLDR

Problem this solves:

- Two P0 reliability rows had no e2e test
- Retry-on-timeout was never proven end to end
- Context-window reroute was never proven end to end

How it solves it:

- Adds a retry spec: timing-out deployment, healthy backup
- Adds a context-window fallback case to the existing spec
- Both use real OpenAI calls, no config change

## User Flow

Before: a developer whose model group has one flaky deployment has no proof the gateway recovers, because nothing in the suite exercises either recovery path

1. They send POST https://litellm-domain/v1/chat/completions to a model group whose first deployment times out
2. They get a completion back, but nothing in the repo tells them that outcome is guaranteed rather than luck of which deployment got picked
3. They send POST https://litellm-domain/v1/chat/completions with a prompt longer than the model accepts, and get back `400` with "This model's maximum context length is 16385 tokens"
4. They configure a bigger model to catch that case, and again have no test saying the gateway will actually use it

After: both recoveries are pinned by a test that fails if either one breaks

1. They send POST https://litellm-domain/v1/chat/completions to a model group whose first deployment times out, with `"router_settings_override": {"num_retries": 2}`
2. They get `200` with a real completion, and the response carries `x-litellm-attempted-retries: 1` saying the gateway had to retry to get there
3. They send POST https://litellm-domain/v1/chat/completions with an oversized prompt and `"router_settings_override": {"context_window_fallbacks": [{"<their group>": ["gpt-5.5"]}]}`
4. They get `200` with a completion from `gpt-5.5` and `x-litellm-attempted-fallbacks: 1`, instead of the 400 they used to get

## Relevant issues

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Shared setup, run against a live proxy on port 4127 with a throwaway postgres and real OpenAI credentials. Three deployments: a timing-out one holding all the group's weight, a healthy backup at weight 0, and a small-context `gpt-3.5-turbo`.

```
TO_ID=$(curl -s -X POST $P/model/new -H "Authorization: Bearer $MK" -H "Content-Type: application/json" \
  -d '{"model_name":"proof-retry-6354","litellm_params":{"model":"openai/gpt-5.5","api_key":"os.environ/OPENAI_API_KEY","timeout":0.001,"weight":1},"model_info":{"allowed_fails_policy":{"TimeoutErrorAllowedFails":0}}}')
BK_ID=$(curl -s -X POST $P/model/new -H "Authorization: Bearer $MK" -H "Content-Type: application/json" \
  -d '{"model_name":"proof-retry-6354","litellm_params":{"model":"openai/gpt-5.5","api_key":"os.environ/OPENAI_API_KEY","weight":0},"model_info":{}}')
CTX_ID=$(curl -s -X POST $P/model/new -H "Authorization: Bearer $MK" -H "Content-Type: application/json" \
  -d '{"model_name":"proof-ctx-14351","litellm_params":{"model":"openai/gpt-3.5-turbo","api_key":"os.environ/OPENAI_API_KEY"},"model_info":{}}')
```

### Before (3fadcd7155)

#### retry on timeout

1. Call the group with retries turned off

```
curl -s -D - -X POST $P/chat/completions -H "Authorization: Bearer $MK" -H "Content-Type: application/json" \
  -d '{"model":"proof-retry-6354","messages":[{"role":"user","content":"say hi 15240"}],"max_tokens":512,"cache":{"no-cache":true},"router_settings_override":{"num_retries":0}}'
```

2. The request dies on the timing-out deployment

```
HTTP/1.1 408 Request Timeout
{"error":{"message":"litellm.Timeout: APITimeoutError - Request timed out. Error_str: Request timed out. - timeout value=0.001, time taken=0.0 seconds\n\nDeployment Info: request_timeout: None\ntimeout: 0.001. Received Model Group=proof-retry-6354\nAvailable M...
```

#### context window fallback

1. Send a ~20k token prompt to the 16385-token model with no reroute configured

```
curl -s -D - -X POST $P/chat/completions -H "Authorization: Bearer $MK" -H "Content-Type: application/json" \
  -d @ctx_none.json   # {"model":"proof-ctx-14351","messages":[{"role":"user","content":"proof token token ... (20385x)"}],"max_tokens":512,"cache":{"no-cache":true}}
```

2. OpenAI refuses it on length

```
HTTP/1.1 400 Bad Request
{"error":{"message":"litellm.ContextWindowExceededError: litellm.BadRequestError: ContextWindowExceededError: OpenAIException - This model's maximum context length is 16385 tokens. However, your messages resulted in 20394 tokens. Please reduce the length of the messages.\nmodel=proof-ctx-14351. context_window_fallbacks...
```

### After (af11db9fe5)

#### retry on timeout

1. Same group, same weights, `num_retries: 2`

```
curl -s -D - -X POST $P/chat/completions -H "Authorization: Bearer $MK" -H "Content-Type: application/json" \
  -d '{"model":"proof-retry-6354","messages":[{"role":"user","content":"say hi 15240"}],"max_tokens":512,"cache":{"no-cache":true},"router_settings_override":{"num_retries":2}}'
```

2. The retry lands on the healthy backup and the gateway says it took one

```
HTTP/1.1 200 OK
x-litellm-attempted-retries: 1
x-litellm-attempted-fallbacks: 0
{"id":"chatcmpl-EJQcTFOOgAD992lZkkgr3R5zjuop8","created":1788299265,"model":"proof-retry-6354","object":"chat.completion","choices":[{"finish_reason":"stop","index":0,"message":{"content":"Hi 15240!","role":"assistant",...}}],"usage":{"completion_tokens":26,"prompt_tokens":11,"total_tokens":37,...}}
```

#### context window fallback

1. Same oversized prompt, now with `context_window_fallbacks` to `gpt-5.5`

```
curl -s -D - -X POST $P/chat/completions -H "Authorization: Bearer $MK" -H "Content-Type: application/json" \
  -d @ctx_fb.json   # same body plus "router_settings_override":{"context_window_fallbacks":[{"proof-ctx-14351":["gpt-5.5"]}]}
```

2. `gpt-5.5` answers it and the gateway reports the reroute

```
HTTP/1.1 200 OK
x-litellm-attempted-retries: 0
x-litellm-attempted-fallbacks: 1
{"id":"chatcmpl-EJQcWNJ1AGhfcnDBMbiCprIK5d1K5","created":1788299268,"model":"gpt-5.5-2026-04-23","object":"chat.completion","choices":[{"finish_reason":"stop","index":0,"message":{"content":"I'm not sure what you want proved-the message only contains \"proof\" followed by repeated \"token.\"\n\nPlease send the specific statement, theorem, or claim you'd like a proof for.",...}}]}
```

3. Clean up

```
for ID in $TO_ID $BK_ID $CTX_ID; do curl -s -X POST $P/model/delete -H "Authorization: Bearer $MK" -H "Content-Type: application/json" -d "{\"id\":\"$ID\"}"; done
{"message":"Model: 66419a9a-f740-4d95-aacd-c124658a5d9a deleted successfully"}
{"message":"Model: 512f99b4-c331-4f44-868b-02229b683c10 deleted successfully"}
{"message":"Model: 12b5578e-04d7-423c-b997-2458d18207ad deleted successfully"}
```

## Type

✅ Test

## Caveats

### Low

- Retry test leans on weights 1 and 0 for a deterministic first pick
- Uses `gpt-3.5-turbo`, the smallest-context chat model OpenAI still serves

## QA runbook

Prerequisites: a proxy with `store_model_in_db: true`, a `gpt-5.5` deployment in its config, and a real `OPENAI_API_KEY`. Both tests register and delete their own deployments.

- tests/e2e/router/test_reliability_retries_e2e.py::TestReliabilityRetries::test_timeout_on_first_deployment_succeeds_on_retry - a request that opens on a timing-out deployment still comes back a completion, and the gateway says it took a retry
  - [ ] POST /model/new with the master key, model_name `retry-check`, litellm_params `{"model": "openai/gpt-5.5", "api_key": "os.environ/OPENAI_API_KEY", "timeout": 0.001, "weight": 1}` and model_info `{"allowed_fails_policy": {"TimeoutErrorAllowedFails": 0}}`
  - [ ] POST /model/new again with the same model_name, litellm_params `{"model": "openai/gpt-5.5", "api_key": "os.environ/OPENAI_API_KEY", "weight": 0}` and model_info `{}`
  - [ ] POST /chat/completions with `{"model": "retry-check", "messages": [{"role": "user", "content": "say hi"}], "max_tokens": 512, "cache": {"no-cache": true}, "router_settings_override": {"num_retries": 2}}`
  - [ ] Expect 200 with a real assistant message, `x-litellm-attempted-retries` at 1 or more, and `x-litellm-attempted-fallbacks` at 0
  - [ ] Send the same request with `"num_retries": 0` instead and expect 408 naming `timeout value=0.001`, which is the negative control
  - [ ] Delete both deployments through POST /model/delete
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey (e.g., assert actual expected spend instead of just spend > 0) or potentially flaky

- tests/e2e/router/test_reliability_fallbacks_e2e.py::TestReliabilityFallbacks::test_context_window_routes_to_fallback - a prompt too long for the model it was sent to gets answered by the bigger model instead of refused
  - [ ] POST /model/new with the master key, model_name `ctx-check` and litellm_params `{"model": "openai/gpt-3.5-turbo", "api_key": "os.environ/OPENAI_API_KEY"}`
  - [ ] POST /chat/completions with model `ctx-check` and a user message of about 20000 tokens, no router_settings_override, and expect 400 saying the model's maximum context length is 16385 tokens, which is the negative control
  - [ ] POST /chat/completions with the same body plus `"router_settings_override": {"context_window_fallbacks": [{"ctx-check": ["gpt-5.5"]}]}`
  - [ ] Expect 200 with `"model"` in the body naming a gpt-5.5 build and `x-litellm-attempted-fallbacks` at 1 or more
  - [ ] Delete the deployment through POST /model/delete
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey (e.g., assert actual expected spend instead of just spend > 0) or potentially flaky

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

https://claude.ai/code/session_01QvQzYztinxj8ZuD5YxbVdL
