### PR TITLE
fix: normalize provider-specific cache token fields in OTel v2 usage

### DIFF
--- a/litellm/integrations/otel/model/payloads.py
+++ b/litellm/integrations/otel/model/payloads.py
@@ -6,6 +6,7 @@ import json
 from collections.abc import Mapping
 from dataclasses import dataclass, field
 from enum import Enum
+from types import MappingProxyType
 from typing import TYPE_CHECKING, ClassVar, Final, cast
 from urllib.parse import urlsplit
 
@@ -113,7 +114,9 @@ class LLMUsage:
         raw_usage: Final = metadata.get("usage_object")
         usage_object: Final[Mapping[str, object]] = raw_usage if isinstance(raw_usage, Mapping) else {}
         raw_details: Final = usage_object.get("prompt_tokens_details")
-        prompt_details: Final[Mapping[str, object]] = raw_details if isinstance(raw_details, Mapping) else {}
+        prompt_details: Final[Mapping[str, object]] = (
+            raw_details if isinstance(raw_details, Mapping) else MappingProxyType({})
+        )
         cache_creation_top_level: Final = as_int(usage_object.get("cache_creation_input_tokens"))
         cache_creation_write: Final = as_int(prompt_details.get("cache_write_tokens"))
         cache_creation_alias: Final = as_int(prompt_details.get("cache_creation_tokens"))

--- a/litellm/integrations/otel/model/payloads.py
+++ b/litellm/integrations/otel/model/payloads.py
@@ -62,6 +62,14 @@ if TYPE_CHECKING:
 # --- typed sub-structures ---------------------------------------------------- #
 
 
+def _cache_token_value(*values: object) -> int | None:
+    parsed: Final[tuple[int | None, ...]] = tuple(as_int(value) for value in values)
+    return next(
+        (value for value in parsed if value),
+        next((value for value in parsed if value is not None), None),
+    )
+
+
 @dataclass(frozen=True)
 class LLMRequestParams:
     temperature: float | None = None
@@ -104,12 +112,30 @@ class LLMUsage:
         metadata: Final[Mapping[str, object]] = payload.get("metadata") or {}
         raw_usage: Final = metadata.get("usage_object")
         usage_object: Final[Mapping[str, object]] = raw_usage if isinstance(raw_usage, Mapping) else {}
+        raw_details: Final = usage_object.get("prompt_tokens_details")
+        prompt_details: Final[Mapping[str, object]] = raw_details if isinstance(raw_details, Mapping) else {}
+        cache_creation_top_level: Final = as_int(usage_object.get("cache_creation_input_tokens"))
+        cache_creation_write: Final = as_int(prompt_details.get("cache_write_tokens"))
+        cache_creation_alias: Final = as_int(prompt_details.get("cache_creation_tokens"))
+        cache_creation_provider: Final = as_int(prompt_details.get("cache_creation_input_tokens"))
+        cache_read_top_level: Final = as_int(usage_object.get("cache_read_input_tokens"))
+        cache_read_details: Final = as_int(prompt_details.get("cached_tokens"))
+        cache_read_provider: Final = as_int(usage_object.get("prompt_cache_hit_tokens"))
         return cls(
             input_tokens=as_int(payload.get("prompt_tokens")),
             output_tokens=as_int(payload.get("completion_tokens")),
             total_tokens=as_int(payload.get("total_tokens")),
-            cache_creation_input_tokens=as_int(usage_object.get("cache_creation_input_tokens")),
-            cache_read_input_tokens=as_int(usage_object.get("cache_read_input_tokens")),
+            cache_creation_input_tokens=_cache_token_value(
+                cache_creation_top_level,
+                cache_creation_write,
+                cache_creation_alias,
+                cache_creation_provider,
+            ),
+            cache_read_input_tokens=_cache_token_value(
+                cache_read_top_level,
+                cache_read_details,
+                cache_read_provider,
+            ),
         )
 
 

--- a/litellm/integrations/otel/model/payloads.py
+++ b/litellm/integrations/otel/model/payloads.py
@@ -64,11 +64,28 @@ if TYPE_CHECKING:
 
 
 def _cache_token_value(*values: object) -> int | None:
-    parsed: Final[tuple[int | None, ...]] = tuple(as_int(value) for value in values)
-    return next(
-        (value for value in parsed if value),
-        next((value for value in parsed if value is not None), None),
-    )
+    explicit_zero = False
+    invalid_before_zero = False
+    for raw_value in values:
+        if raw_value is None:
+            continue
+        if isinstance(raw_value, bool):
+            parsed = None
+        else:
+            try:
+                parsed = as_int(raw_value)
+            except (OverflowError, ValueError):
+                parsed = None
+        if parsed is None:
+            if not explicit_zero:
+                invalid_before_zero = True
+        elif parsed > 0:
+            return parsed
+        elif parsed == 0:
+            explicit_zero = True
+        elif not explicit_zero:
+            invalid_before_zero = True
+    return 0 if explicit_zero and not invalid_before_zero else None
 
 
 @dataclass(frozen=True)
@@ -117,27 +134,20 @@ class LLMUsage:
         prompt_details: Final[Mapping[str, object]] = (
             raw_details if isinstance(raw_details, Mapping) else MappingProxyType({})
         )
-        cache_creation_top_level: Final = as_int(usage_object.get("cache_creation_input_tokens"))
-        cache_creation_write: Final = as_int(prompt_details.get("cache_write_tokens"))
-        cache_creation_alias: Final = as_int(prompt_details.get("cache_creation_tokens"))
-        cache_creation_provider: Final = as_int(prompt_details.get("cache_creation_input_tokens"))
-        cache_read_top_level: Final = as_int(usage_object.get("cache_read_input_tokens"))
-        cache_read_details: Final = as_int(prompt_details.get("cached_tokens"))
-        cache_read_provider: Final = as_int(usage_object.get("prompt_cache_hit_tokens"))
         return cls(
             input_tokens=as_int(payload.get("prompt_tokens")),
             output_tokens=as_int(payload.get("completion_tokens")),
             total_tokens=as_int(payload.get("total_tokens")),
             cache_creation_input_tokens=_cache_token_value(
-                cache_creation_top_level,
-                cache_creation_write,
-                cache_creation_alias,
-                cache_creation_provider,
+                usage_object.get("cache_creation_input_tokens"),
+                prompt_details.get("cache_write_tokens"),
+                prompt_details.get("cache_creation_tokens"),
+                prompt_details.get("cache_creation_input_tokens"),
             ),
             cache_read_input_tokens=_cache_token_value(
-                cache_read_top_level,
-                cache_read_details,
-                cache_read_provider,
+                usage_object.get("cache_read_input_tokens"),
+                prompt_details.get("cached_tokens"),
+                usage_object.get("prompt_cache_hit_tokens"),
             ),
         )
 

--- a/tests/test_litellm/integrations/otel/test_otel_v2_sources_of_truth.py
+++ b/tests/test_litellm/integrations/otel/test_otel_v2_sources_of_truth.py
@@ -571,6 +571,33 @@ def test_llm_call_adapter_prefers_nested_count_over_zero_top_level():
     assert data.usage.cache_creation_input_tokens == 7
 
 
+def test_llm_call_adapter_ignores_invalid_cache_values_before_valid_fallbacks():
+    payload = _sample_payload(
+        metadata={
+            "usage_object": {
+                "cache_read_input_tokens": -1,
+                "cache_creation_input_tokens": "5.0",
+                "prompt_tokens_details": {"cached_tokens": 5, "cache_write_tokens": 7},
+            }
+        }
+    )
+    data = LLMCallSpanData.from_standard_logging_payload(payload)
+    assert data.usage.cache_read_input_tokens == 5
+    assert data.usage.cache_creation_input_tokens == 7
+
+
+def test_llm_call_adapter_ignores_non_finite_cache_values():
+    payload = _sample_payload(
+        metadata={
+            "usage_object": {
+                "prompt_tokens_details": {"cached_tokens": float("nan")},
+            }
+        }
+    )
+    data = LLMCallSpanData.from_standard_logging_payload(payload)
+    assert data.usage.cache_read_input_tokens is None
+
+
 def test_llm_call_adapter_preserves_explicit_zero_and_omits_missing_cache_tokens():
     for usage_object, expected_read, expected_creation in (
         ({"prompt_tokens_details": {"cached_tokens": 0}}, 0, None),

--- a/tests/test_litellm/integrations/otel/test_otel_v2_sources_of_truth.py
+++ b/tests/test_litellm/integrations/otel/test_otel_v2_sources_of_truth.py
@@ -541,6 +541,47 @@ def test_llm_call_adapter_extracts_cache_tokens_from_usage_object():
     assert data.usage.cache_read_input_tokens == 3
 
 
+def test_llm_call_adapter_normalizes_nested_cache_tokens():
+    cases: Final = (
+        ({"prompt_tokens_details": {"cached_tokens": 3}}, 3, None),
+        ({"prompt_cache_hit_tokens": 11}, 11, None),
+        ({"prompt_tokens_details": {"cache_write_tokens": 7}}, None, 7),
+        ({"prompt_tokens_details": {"cache_creation_tokens": 13}}, None, 13),
+        ({"prompt_tokens_details": {"cache_creation_input_tokens": 17}}, None, 17),
+    )
+    for usage_object, expected_read, expected_creation in cases:
+        case_payload = _sample_payload(metadata={"usage_object": usage_object})
+        data = LLMCallSpanData.from_standard_logging_payload(case_payload)
+        assert data.usage.cache_read_input_tokens == expected_read
+        assert data.usage.cache_creation_input_tokens == expected_creation
+
+
+def test_llm_call_adapter_prefers_nested_count_over_zero_top_level():
+    payload = _sample_payload(
+        metadata={
+            "usage_object": {
+                "cache_read_input_tokens": 0,
+                "cache_creation_input_tokens": 0,
+                "prompt_tokens_details": {"cached_tokens": 5, "cache_write_tokens": 7},
+            }
+        }
+    )
+    data = LLMCallSpanData.from_standard_logging_payload(payload)
+    assert data.usage.cache_read_input_tokens == 5
+    assert data.usage.cache_creation_input_tokens == 7
+
+
+def test_llm_call_adapter_preserves_explicit_zero_and_omits_missing_cache_tokens():
+    for usage_object, expected_read, expected_creation in (
+        ({"prompt_tokens_details": {"cached_tokens": 0}}, 0, None),
+        ({}, None, None),
+    ):
+        case_payload = _sample_payload(metadata={"usage_object": usage_object})
+        data = LLMCallSpanData.from_standard_logging_payload(case_payload)
+        assert data.usage.cache_read_input_tokens == expected_read
+        assert data.usage.cache_creation_input_tokens == expected_creation
+
+
 def test_llm_call_adapter_cache_tokens_none_without_usage_object():
     data = LLMCallSpanData.from_standard_logging_payload(_sample_payload())
     assert data.usage.cache_creation_input_tokens is None


### PR DESCRIPTION
## TLDR

Problem this solves:

- OTel v2 drops provider-specific cache token usage fields
- Cached requests can arrive without cache usage span attributes

How it solves it:

- Normalizes Anthropic, OpenAI-compatible, DeepSeek, and DashScope cache fields
- Preserves explicit zero values while omitting missing fields

## User Flow

Before: an operator sends a cached completion through the proxy, but the trace has no cache-read usage attribute

1. They enable OTel v2 and POST `http://proxy.example/v1/chat/completions` with a cacheable prompt
2. The proxy returns `200 OK` with the provider's cache-hit usage count
3. They open the destination trace and do not see `gen_ai.usage.cache_read.input_tokens`

After: the same cached completion records the provider's cache-read usage on its destination trace

1. They enable OTel v2 and POST the same request to `http://proxy.example/v1/chat/completions`
2. The proxy returns `200 OK` with the provider's cache-hit usage count
3. They open the destination trace and see `gen_ai.usage.cache_read.input_tokens` with that count

## Relevant issues

None

## Linear ticket

Resolves LIT-6650

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The focused OTel v2 suite passes locally
- [ ] My PR passes all required CI/CD checks
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile Confidence Score of at least 4/5 before requesting a maintainer review

## Screenshots / Proof of Fix

Shared setup: two local proxies, each pinned to its worktree with `LITELLM_OTEL_V2=1`, sent real DeepSeek, OpenAI, Anthropic, and Gemini calls through `POST /v1/chat/completions`; OTel v2 exported to Langfuse Cloud and the console exporter. Gateway Anthropic environment overrides and database configuration were unset for both proxies. The real Langfuse observation for the head stored `gen_ai.usage.cache_read.input_tokens=4608`; the base observation had no cache attributes.

Final-head local Langfuse UI evidence (real OSS application, sanitized to remove customer-identifying text):

![Langfuse trace attributes showing the normalized cache-read value](https://raw.githubusercontent.com/BerriAI/litellm/assets-pr39181/assets/pr39202-langfuse-cache-read.png)

![Langfuse trace detail for the real DeepSeek cache-hit request](https://raw.githubusercontent.com/BerriAI/litellm/assets-pr39181/assets/pr39202-langfuse-trace.png)

The screenshots were captured from the real Langfuse trace detail after the final-head DeepSeek miss/hit drive; the displayed expanded attributes include the provider and OTel usage fields, and all sidebar/customer-identifying text was hidden before capture.

### Before (8bc862f52c)

#### DeepSeek cache hit

1. Sent a real cached DeepSeek completion through the base proxy and received `200 OK` with `prompt_cache_hit_tokens: 4608`
2. Read the emitted LLM-call span and observed both cache attributes absent
3. Read the corresponding Langfuse observation and observed no `gen_ai.usage.cache_*` attribute

#### Anthropic cache paths

1. Sent real cache-write, cache-read, and uncached requests through the base proxy and received `200 OK`
2. Observed the existing top-level cache fields on all three emitted LLM-call spans

#### Gemini without cache fields

1. Sent a real Gemini completion through the base proxy and received `200 OK`
2. Observed both cache attributes absent from the LLM-call span

#### OpenAI prompt caching

1. Sent the same ~4650-token prompt twice through the base proxy; upstream returned
   `prompt_tokens_details.cached_tokens: 0` then `4608`
2. Observed both LLM-call spans with no cache attribute on either leg

### After (1d24d9c9a5)

#### DeepSeek cache hit

1. Sent a real cached DeepSeek completion through the head proxy and received `200 OK` with `prompt_cache_hit_tokens: 4608`
2. Read the emitted LLM-call span and observed `gen_ai.usage.cache_read.input_tokens: 4608`
3. Read the Langfuse observation and observed the stored cache-read attribute

#### Anthropic cache paths

1. Sent real cache-write, cache-read, and uncached requests through the head proxy and received `200 OK`
2. Observed `cache_read/cache_creation` values `0/4864`, `4864/0`, and `0/0`, matching prior semantics

#### Gemini without cache fields

1. Sent a real Gemini completion through the head proxy and received `200 OK`
2. Observed both cache attributes absent from the LLM-call span

#### OpenAI prompt caching

1. Sent the same ~4650-token prompt twice through the head proxy; upstream returned
   `prompt_tokens_details.cached_tokens: 0` then `4608`
2. Observed `gen_ai.usage.cache_read.input_tokens: 0` on the miss span (the explicit-zero behavior change
   below, verified live) and `gen_ai.usage.cache_read.input_tokens: 4608` on the hit span

Azure was not driven live: the available Azure OpenAI resource has zero deployments and the service principal
sees no Cognitive Services accounts, so every call is `DeploymentNotFound`. Azure responses share the OpenAI
SDK usage shape (`prompt_tokens_details.cached_tokens`), which the live OpenAI legs above exercise

#### DashScope prompt caching

1. Sent the same ~4650-token prompt twice through each proxy using qwen-plus on the real DashScope
   international endpoint; upstream returned `prompt_tokens_details.cached_tokens: 0` then `4480`
2. Base emitted no cache attribute; head emitted `gen_ai.usage.cache_read.input_tokens: 0` then `4480`

Focused checks: `108 passed` for `test_otel_v2_sources_of_truth.py`; `509 passed` for `tests/test_litellm/integrations/otel/`; ruff and the basedpyright delta gate pass.

## Type

Bug Fix

## Behavior changes

- Explicit nested cache zeroes now emit a zero-valued OTel attribute. OpenAI and Azure responses ship
  `prompt_tokens_details.cached_tokens: 0` on effectively every completion, so nearly all OpenAI and Azure OTel v2
  spans gain `gen_ai.usage.cache_read.input_tokens: 0` where they previously had no cache attribute. Dashboards that
  filter on attribute presence will start matching these spans
- Nested nonzero counts supersede top-level placeholder zeroes. The proxy's usage combiner can zero out Anthropic's
  top-level `cache_read_input_tokens`/`cache_creation_input_tokens` (they live in `__pydantic_extra__`, which the
  merge does not enumerate) while `prompt_tokens_details` survives, so the nested count is the trustworthy one
- Malformed usage values (negative numbers, booleans, non-finite floats, non-numeric strings) are ignored instead of
  emitted or raised. If a malformed value appears ahead of an explicit zero, the attribute is omitted rather than
  reported as zero. Previously a NaN or Infinity in the top-level cache fields raised inside the exporter
- Prometheus metrics and spend tracking read the usage object directly and keep their existing top-level-first
  precedence; for raw dict usage payloads carrying both a top-level zero and a nested nonzero count, the span and the
  metric can disagree by design. Canonical `Usage` objects cannot hit this divergence
- Out of scope, unchanged: OTel v1 cache attributes and the native mapper's usage fields keep their existing behavior

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to OTel v2 usage normalization from standard logging metadata; behavior change is limited to cache token attribute population with tests for precedence and zero handling.
> 
> **Overview**
> **OTel v2** was only reading top-level `cache_*_input_tokens` on the provider `usage_object`, so traces often missed `gen_ai.usage.cache_read.input_tokens` / cache-creation usage when providers put counts in nested or alternate keys (e.g. DeepSeek `prompt_cache_hit_tokens`, OpenAI-style `prompt_tokens_details.cached_tokens`, Anthropic-style write/creation aliases).
> 
> `LLMUsage.from_standard_logging_payload` now aggregates those shapes via a new `_cache_token_value` helper: prefer the first **non-zero** candidate in a fixed order, then fall back to an explicit **0**, otherwise **None** so mappers still omit missing cache usage. Nested nonzero values can override misleading top-level `0` placeholders.
> 
> Tests in `test_otel_v2_sources_of_truth.py` cover nested field mapping, precedence over zero top-level fields, explicit zeros, and absent fields.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b3b297faa44f0bb7a4100a4f5041644179817700. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

ran /live-pr-risk and found no regressions/backward incompatible risks

