### PR TITLE
fix: stop a cleared Team field from blocking personal key creation

### DIFF
--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -1216,6 +1216,13 @@ class GenerateKeyRequest(KeyRequestBase):
     organization_id: str | None = None
     project_id: str | None = None
 
+    @field_validator("team_id", mode="before")
+    @classmethod
+    def treat_cleared_team_id_as_unset(cls, v: object) -> object:
+        if v == "":
+            return None
+        return v
+
 
 class GenerateKeyResponse(KeyRequestBase):
     key: str

--- a/tests/test_litellm/proxy/management_endpoints/test_key_management_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_key_management_endpoints.py
@@ -17489,3 +17489,49 @@ async def test_check_project_key_limits_still_rejects_real_model_outside_project
 
     assert exc_info.value.status_code == 400
     assert "Model 'gpt-5.4-mini' not in project's allowed models" in exc_info.value.detail["error"]
+
+
+def test_generate_key_request_blank_team_id_is_personal():
+    """The UI Team-field clear submits team_id=""; it must count as no team (LIT-3925)."""
+    from litellm.proxy._types import RegenerateKeyRequest
+    from litellm.proxy.management_endpoints.key_management_endpoints import (
+        _is_team_key,
+    )
+
+    cleared = GenerateKeyRequest(team_id="")
+    assert cleared.team_id is None
+    assert _is_team_key(data=cleared) is False
+    assert RegenerateKeyRequest(team_id="").team_id is None
+    assert GenerateKeyRequest(team_id="team-1").team_id == "team-1"
+
+
+def test_key_generation_check_blank_team_id_uses_personal_permissions(monkeypatch):
+    """key_generation_check with team_id="" must take the personal-key path instead
+    of failing the team lookup with "Unable to find team object" (LIT-3925)."""
+    from litellm.proxy._types import KeyManagementRoutes
+    from litellm.proxy.management_endpoints.key_management_endpoints import (
+        key_generation_check,
+    )
+
+    monkeypatch.setattr(
+        litellm,
+        "key_generation_settings",
+        {
+            "team_key_generation": {"allowed_team_member_roles": ["admin"]},
+            "personal_key_generation": {"allowed_user_roles": ["proxy_admin", "internal_user"]},
+        },
+    )
+
+    assert (
+        key_generation_check(
+            team_table=None,
+            user_api_key_dict=UserAPIKeyAuth(
+                user_role=LitellmUserRoles.INTERNAL_USER,
+                api_key="sk-alice",
+                user_id="alice",
+            ),
+            data=GenerateKeyRequest(key_alias="personal", team_id=""),
+            route=KeyManagementRoutes.KEY_GENERATE,
+        )
+        is True
+    )

--- a/ui/litellm-dashboard/src/app/(dashboard)/models-and-endpoints/page.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/models-and-endpoints/page.test.tsx
@@ -111,17 +111,17 @@ describe("ModelsAndEndpointsPage", () => {
   // POST /model/new 403s a proxy_admin_viewer, so the form's tab must not render for one.
   it("hides the Add Model tab for a view-only admin session", () => {
     mockUseAuthorized.mockReturnValue(VIEW_ONLY_ADMIN);
-    const { getByRole, queryByRole } = renderPage();
-    expect(queryByRole("tab", { name: "Add Model" })).not.toBeInTheDocument();
-    expect(getByRole("tab", { name: "All Models" })).toBeInTheDocument();
+    renderPage();
+    expect(screen.queryByRole("tab", { name: "Add Model" })).not.toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: "All Models" })).toBeInTheDocument();
   });
 
   // Read parity: the Auto-Routers list stays reachable for a view-only admin; only the
   // create affordance inside it is withheld, which AutoRoutersTabPanel decides.
   it("keeps the Auto-Routers tab for a view-only admin session", () => {
     mockUseAuthorized.mockReturnValue(VIEW_ONLY_ADMIN);
-    const { getByRole } = renderPage();
-    expect(getByRole("tab", { name: /Auto-Routers/ })).toBeInTheDocument();
+    renderPage();
+    expect(screen.getByRole("tab", { name: /Auto-Routers/ })).toBeInTheDocument();
   });
 
   // Auto-routers are excluded from the All Models table, so this tab is their home: the only

--- a/ui/litellm-dashboard/src/components/add_model/add_auto_router_tab.test.tsx
+++ b/ui/litellm-dashboard/src/components/add_model/add_auto_router_tab.test.tsx
@@ -101,18 +101,24 @@ vi.mock("./build_complexity_router_config", async (importOriginal) => {
 });
 
 // A real TeamDropdown fetches teams and renders an antd Select; the wiring under test is
-// whether team_id is registered, validated and forwarded, so a plain control stands in.
+// whether team_id is registered, validated and forwarded, so a plain control stands in. The
+// clear button mirrors the real dropdown's x, which emits null rather than a string.
 vi.mock("../common_components/team_dropdown", () => ({
-  default: ({ value, onChange }: { value?: string; onChange?: (next: string) => void }) => (
-    <select
-      data-testid="team-dropdown"
-      value={value ?? ""}
-      onChange={(event) => onChange?.(event.target.value)}
-      aria-label="Select Team"
-    >
-      <option value="">none</option>
-      <option value="team-1">team-1</option>
-    </select>
+  default: ({ value, onChange }: { value?: string; onChange?: (next: string | null) => void }) => (
+    <>
+      <select
+        data-testid="team-dropdown"
+        value={value ?? ""}
+        onChange={(event) => onChange?.(event.target.value)}
+        aria-label="Select Team"
+      >
+        <option value="">none</option>
+        <option value="team-1">team-1</option>
+      </select>
+      <button type="button" data-testid="team-dropdown-clear" onClick={() => onChange?.(null)}>
+        clear team
+      </button>
+    </>
   ),
 }));
 
@@ -348,6 +354,25 @@ describe("AddAutoRouterTab", () => {
     );
 
     await user.type(screen.getByPlaceholderText(/smart_router/i), "team-scoped-router");
+    await user.click(screen.getByRole("button", { name: /add auto router/i }));
+
+    expect(await screen.findByText("Please select a team to continue")).toBeInTheDocument();
+    expect(handleAddAutoRouterSubmit).not.toHaveBeenCalled();
+  });
+
+  // The shared dropdown emits null on clear while this form's schema wants a string, so the
+  // form maps null back to "": the user sees the pick-a-team message, not a zod type error.
+  it("treats a team picked and then cleared like no team at all", async () => {
+    const user = userEvent.setup();
+    vi.mocked(getMissingTiersError).mockReturnValue(null);
+
+    renderWithProviders(
+      <AddAutoRouterTab handleOk={vi.fn()} accessToken="token" userRole="Internal User" createScope="team-required" />,
+    );
+
+    await user.type(screen.getByPlaceholderText(/smart_router/i), "team-scoped-router");
+    await user.selectOptions(screen.getByTestId("team-dropdown"), "team-1");
+    await user.click(screen.getByTestId("team-dropdown-clear"));
     await user.click(screen.getByRole("button", { name: /add auto router/i }));
 
     expect(await screen.findByText("Please select a team to continue")).toBeInTheDocument();

--- a/ui/litellm-dashboard/src/components/add_model/add_auto_router_tab.tsx
+++ b/ui/litellm-dashboard/src/components/add_model/add_auto_router_tab.tsx
@@ -548,7 +548,9 @@ const AddAutoRouterTab: React.FC<AddAutoRouterTabProps> = ({
                     "Select the team this auto router belongs to. Only keys for this team will be able to call it.",
                   )}
                 >
-                  {({ id, value, onChange }) => <TeamDropdown id={id} value={value} onChange={onChange} />}
+                  {({ id, value, onChange }) => (
+                    <TeamDropdown id={id} value={value} onChange={(next) => onChange(next ?? "")} />
+                  )}
                 </FormField>
               )}
 

--- a/ui/litellm-dashboard/src/components/common_components/team_dropdown.test.tsx
+++ b/ui/litellm-dashboard/src/components/common_components/team_dropdown.test.tsx
@@ -40,7 +40,7 @@ describe("TeamDropdown", () => {
     const onTeamSelect = vi.fn();
     render(<TeamDropdown value="team-1" onChange={onChange} onTeamSelect={onTeamSelect} />);
 
-    await user.click(document.querySelector('[data-slot="combobox-clear"]') as HTMLElement);
+    await user.click(screen.getByRole("button", { name: "Clear" }));
 
     expect(onChange).toHaveBeenCalledWith(null);
     expect(onTeamSelect).toHaveBeenCalledWith(null);

--- a/ui/litellm-dashboard/src/components/common_components/team_dropdown.test.tsx
+++ b/ui/litellm-dashboard/src/components/common_components/team_dropdown.test.tsx
@@ -1,0 +1,48 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import { chooseSelectOption } from "../../../tests/test-utils";
+import type { Team } from "../key_team_helpers/key_list";
+import TeamDropdown from "./team_dropdown";
+
+const TEAMS = [
+  { team_id: "team-1", team_alias: "Alpha Team" },
+  { team_id: "team-2", team_alias: "Beta Team" },
+] as unknown as Team[];
+
+vi.mock("@/app/(dashboard)/hooks/teams/useTeams", () => ({
+  useInfiniteTeams: () => ({
+    data: { pages: [{ teams: TEAMS }] },
+    fetchNextPage: vi.fn(),
+    hasNextPage: false,
+    isFetchingNextPage: false,
+    isLoading: false,
+  }),
+}));
+
+describe("TeamDropdown", () => {
+  it("emits the picked team's id and full object", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    const onTeamSelect = vi.fn();
+    render(<TeamDropdown onChange={onChange} onTeamSelect={onTeamSelect} />);
+
+    await chooseSelectOption(user, screen.getByRole("combobox"), /^Beta Team/);
+
+    expect(onChange).toHaveBeenCalledWith("team-2");
+    expect(onTeamSelect).toHaveBeenCalledWith(TEAMS[1]);
+  });
+
+  it("emits null, never the empty string, when the selection is cleared", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    const onTeamSelect = vi.fn();
+    render(<TeamDropdown value="team-1" onChange={onChange} onTeamSelect={onTeamSelect} />);
+
+    await user.click(document.querySelector('[data-slot="combobox-clear"]') as HTMLElement);
+
+    expect(onChange).toHaveBeenCalledWith(null);
+    expect(onTeamSelect).toHaveBeenCalledWith(null);
+  });
+});

--- a/ui/litellm-dashboard/src/components/common_components/team_dropdown.tsx
+++ b/ui/litellm-dashboard/src/components/common_components/team_dropdown.tsx
@@ -5,7 +5,7 @@ import { Team } from "../key_team_helpers/key_list";
 
 interface TeamDropdownProps {
   value?: string;
-  onChange?: (value: string) => void;
+  onChange?: (value: string | null) => void;
   /** Callback with the full Team object (or null on clear). */
   onTeamSelect?: (team: Team | null) => void;
   disabled?: boolean;
@@ -47,7 +47,7 @@ const TeamDropdown: React.FC<TeamDropdownProps> = ({
   }, [data]);
 
   const handleChange = (teamId: string) => {
-    onChange?.(teamId);
+    onChange?.(teamId || null);
     if (onTeamSelect) {
       onTeamSelect(teamId ? teams.find((t) => t.team_id === teamId) ?? null : null);
     }


### PR DESCRIPTION
## TLDR

Problem this solves:

- Clearing the Team field still sends `team_id: ""` on /key/generate
- The proxy treats `""` as a team key and fails the team lookup
- Non-admins allowed to create personal keys get a 400

How it solves it:

- The Team dropdown emits null instead of `""` on clear
- /key/generate and /key/regenerate treat an empty `team_id` as no team
- The auto-router form, whose schema wants a string `team_id`, maps that null back to `""` so clearing still shows its pick-a-team message instead of a zod type error

## User Flow

Before: a non-admin team member who is allowed to create personal keys picks a team in the Create Key modal, changes their mind, and can no longer create a key

1. They sign in to http://localhost:4000/ui/ as an internal user with the `user` role in some team
2. They click Create Key, keep the owner as User Key, and fill in a key name
3. They pick a team in the Team field, then clear it with the `x` button so the field looks empty
4. They submit, and the request fails with `Team not found for team_id=. Non-admin users cannot create keys for non-existent teams.`
5. They only get a key by reloading the page and never touching the Team field

After: clearing the Team field behaves the same as never touching it

1. They sign in to http://localhost:4000/ui/ as an internal user with the `user` role in some team
2. They click Create Key, keep the owner as User Key, and fill in a key name
3. They pick a team in the Team field, then clear it with the `x` button so the field looks empty
4. They submit and get a personal key back, with no team attached

## Relevant issues

## Linear ticket

Resolves LIT-3925

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Shared setup: a live proxy on localhost:4381 with this config, plus one team and one internal user added to it with the `user` role

```yaml
litellm_settings:
  key_generation_settings:
    team_key_generation:
      allowed_team_member_roles: ["admin"]
    personal_key_generation:
      allowed_user_roles: ["proxy_admin", "internal_user"]
```

```bash
TID=$(curl -s -X POST localhost:4381/team/new -H "Authorization: Bearer sk-1234" -H 'Content-Type: application/json' -d '{"team_alias":"lit3925-qa-team"}' | jq -r .team_id)
URESP=$(curl -s -X POST localhost:4381/user/new -H "Authorization: Bearer sk-1234" -H 'Content-Type: application/json' -d '{"user_email":"lit3925-qa@example.com","user_role":"internal_user"}')
UKEY=$(echo "$URESP" | jq -r .key)
curl -s -X POST localhost:4381/team/member_add -H "Authorization: Bearer sk-1234" -H 'Content-Type: application/json' -d "{\"team_id\":\"$TID\",\"member\":[{\"user_id\":\"$(echo "$URESP" | jq -r .user_id)\",\"role\":\"user\"}]}"
```

### Before (bad55da9bf)

#### A: team selected

1. `curl -s -X POST localhost:4381/key/generate -H "Authorization: Bearer $UKEY" -H 'Content-Type: application/json' -d "{\"key_alias\":\"lit3925-a\",\"team_id\":\"$TID\"}"`
2. `{"error":{"message":"Team member role user not in allowed_team_member_roles=['admin']","type":"internal_server_error","param":"None","code":"400"}}`

#### B: team cleared in the UI, which sends an empty-string team_id

1. `curl -s -X POST localhost:4381/key/generate -H "Authorization: Bearer $UKEY" -H 'Content-Type: application/json' -d '{"key_alias":"lit3925-b","team_id":""}'`
2. `{"error":{"message":"Team not found for team_id=. Non-admin users cannot create keys for non-existent teams.","type":"internal_server_error","param":"None","code":"400"}}`

#### C: team never touched

1. `curl -s -X POST localhost:4381/key/generate -H "Authorization: Bearer $UKEY" -H 'Content-Type: application/json' -d '{"key_alias":"lit3925-c"}'`
2. `{"key_alias":"lit3925-c", ..., "team_id":null, ..., "key":"sk-_4UqdJmd9fe_24uTLo-mSg", ...}` with HTTP 200

#### In the Admin UI

Signed in as the internal user, Create Key, key name filled in, a team picked and then cleared with the `x`:

![before: Create Key modal with the Team field cleared](https://raw.githubusercontent.com/BerriAI/litellm/litellm_lit_3925_screenshots/lit3925_before_cleared_team.png)

Submitting fails:

![before: submit fails with Team not found for team_id=](https://raw.githubusercontent.com/BerriAI/litellm/litellm_lit_3925_screenshots/lit3925_before_submit_error.png)

### After (55d638412b)

#### A: team selected

1. `curl -s -X POST localhost:4381/key/generate -H "Authorization: Bearer $UKEY" -H 'Content-Type: application/json' -d "{\"key_alias\":\"lit3925-a\",\"team_id\":\"$TID\"}"`
2. `{"error":{"message":"Team member role user not in allowed_team_member_roles=['admin']","type":"internal_server_error","param":"None","code":"400"}}` (unchanged, a real team selection still runs the team checks)

#### B: team cleared in the UI, which sends an empty-string team_id

1. `curl -s -X POST localhost:4381/key/generate -H "Authorization: Bearer $UKEY" -H 'Content-Type: application/json' -d '{"key_alias":"lit3925-b","team_id":""}'`
2. `{"key_alias":"lit3925-b", ..., "team_id":null, ..., "key":"sk-u8sUMgHUPv4rsJJZCQ9QEg", ...}` with HTTP 200, identical in shape to case C

#### C: team never touched

1. `curl -s -X POST localhost:4381/key/generate -H "Authorization: Bearer $UKEY" -H 'Content-Type: application/json' -d '{"key_alias":"lit3925-c"}'`
2. `{"key_alias":"lit3925-c", ..., "team_id":null, ..., "key":"sk-A3j5pAGrAOjogJ4rNSyonA", ...}` with HTTP 200

#### In the Admin UI

The exact same flow, a team picked and then cleared with the `x`:

![after: Create Key modal with the Team field cleared](https://raw.githubusercontent.com/BerriAI/litellm/litellm_lit_3925_screenshots/lit3925_after_cleared_team.png)

Submitting now returns a personal key (the QA key and its team/user were deleted afterward):

![after: submit succeeds and shows the Save your Key dialog](https://raw.githubusercontent.com/BerriAI/litellm/litellm_lit_3925_screenshots/lit3925_after_key_created.png)

## Type

🐛 Bug Fix

## Caveats (if any)

### Low

- /key/update still accepts `team_id: ""` and fails the team lookup, unchanged here
- The dropdown fix also covers the other forms that reuse it (user create, model create, guardrails, agents)

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow normalization of empty `team_id` on key generate/regenerate plus UI dropdown semantics; no auth or data-model changes beyond treating cleared team like unset.
> 
> **Overview**
> Fixes **LIT-3925**: clearing the Team field in Create Key no longer blocks personal key creation with a bogus team lookup on `team_id=""`.
> 
> **Proxy:** `GenerateKeyRequest` (and inherited `RegenerateKeyRequest`) now normalizes `team_id: ""` to `None` via a Pydantic validator, so `/key/generate` and `/key/regenerate` follow the personal-key path like an omitted team. Proxy tests cover parsing, `_is_team_key`, and `key_generation_check` with blank `team_id`.
> 
> **Dashboard:** `TeamDropdown` calls `onChange(null)` when the selection is cleared (not `""`), with unit tests on pick and clear. **Add Auto Router** maps that `null` back to `""` for its string-based team-required validation so users still see “Please select a team” instead of a schema error.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4acc1d15fb7f9172d39417967445cf50176c5012. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->