### PR TITLE
fix(bedrock): gate Converse cachePoint emission on model prompt caching support

### DIFF
--- a/litellm/litellm_core_utils/prompt_templates/factory.py
+++ b/litellm/litellm_core_utils/prompt_templates/factory.py
@@ -4957,10 +4957,13 @@ def make_valid_bedrock_tool_name(input_tool_name: str) -> str:
 
 
 def add_cache_point_tool_block(tool: dict, model: str | None = None) -> BedrockToolBlock | None:
-    from litellm.llms.bedrock.common_utils import is_claude_4_5_on_bedrock
+    from litellm.llms.bedrock.common_utils import (
+        bedrock_model_accepts_cache_points,
+        is_claude_4_5_on_bedrock,
+    )
 
     cache_control: Final = tool.get("cache_control", None)
-    if cache_control is not None:
+    if cache_control is not None and bedrock_model_accepts_cache_points(model):
         cache_point: Final = cache_control.get("type", "ephemeral")
         if cache_point == "ephemeral":
             cache_point_block: Final[CachePointBlock] = {"type": "default"}

--- a/litellm/llms/bedrock/chat/converse_transformation.py
+++ b/litellm/llms/bedrock/chat/converse_transformation.py
@@ -87,6 +87,7 @@ from ..common_utils import (
     BedrockError,
     BedrockModelInfo,
     bedrock_converse_supports_parallel_tool_use_config,
+    bedrock_model_accepts_cache_points,
     get_anthropic_beta_from_headers,
     get_bedrock_tool_name,
     is_bedrock_application_inference_profile_arn,
@@ -1149,7 +1150,7 @@ class AmazonConverseConfig(BaseConfig):
         model: str | None = None,
     ) -> SystemContentBlock | ContentBlock | None:
         cache_control: Final = message_block.get("cache_control", None)
-        if cache_control is None:
+        if cache_control is None or not bedrock_model_accepts_cache_points(model):
             return None
 
         cache_point: Final = self._build_cache_point_block(cache_control, model)
@@ -1613,7 +1614,7 @@ class AmazonConverseConfig(BaseConfig):
 
         # Append cachePoint to tools if cache_control_injection_points has tool_config
         cache_injection_points: Final = additional_request_params.pop("cache_control_injection_points", None)
-        if cache_injection_points and len(bedrock_tools) > 0:
+        if cache_injection_points and len(bedrock_tools) > 0 and bedrock_model_accepts_cache_points(model):
             for point in cache_injection_points:
                 if point.get("location") == "tool_config":
                     cache_point = self._build_cache_point_block(point.get("control"), model)

--- a/litellm/llms/bedrock/common_utils.py
+++ b/litellm/llms/bedrock/common_utils.py
@@ -816,6 +816,30 @@ def bedrock_converse_supports_parallel_tool_use_config(model: str) -> bool:
     )
 
 
+def bedrock_model_accepts_cache_points(model: str | None) -> bool:
+    """
+    Whether Converse ``cachePoint`` blocks may be sent to this model.
+
+    Bedrock rejects requests carrying cachePoint blocks for models without prompt
+    caching support ("You invoked an unsupported model or your request did not allow
+    prompt caching"), so a model whose cost-map entry does not declare
+    ``supports_prompt_caching`` must not receive them. A model absent from the map
+    (an application inference profile ARN, a model newer than the map) keeps emitting
+    so existing caching setups never silently degrade. ``litellm.utils.supports_prompt_caching``
+    is not reusable here: it returns False for unmapped models, the opposite polarity.
+    """
+    if model is None:
+        return True
+    entries: Final = tuple(
+        entry
+        for candidate in (model, get_bedrock_base_model(model))
+        if (entry := litellm.model_cost.get(candidate)) is not None
+    )
+    if not entries:
+        return True
+    return any(entry.get("supports_prompt_caching") is True for entry in entries)
+
+
 def is_claude_4_5_on_bedrock(model: str) -> bool:
     """
     Check if the model supports Bedrock prompt caching with an extended '1h' TTL

--- a/tests/test_litellm/litellm_core_utils/prompt_templates/test_litellm_core_utils_prompt_templates_factory.py
+++ b/tests/test_litellm/litellm_core_utils/prompt_templates/test_litellm_core_utils_prompt_templates_factory.py
@@ -2932,6 +2932,28 @@ def test_add_cache_point_tool_block_passes_ttl_for_claude_4_5(monkeypatch):
             monkeypatch.setenv("LITELLM_LOCAL_MODEL_COST_MAP", old_env)
 
 
+def test_add_cache_point_tool_block_stands_down_for_model_without_prompt_caching(monkeypatch):
+    """A tool carrying cache_control must not become a cachePoint for a Bedrock model
+    whose cost-map entry lacks prompt caching support, since Bedrock rejects the whole
+    request. An unmapped id keeps emitting so ARN deployments do not lose caching."""
+    from litellm.litellm_core_utils.prompt_templates.factory import (
+        add_cache_point_tool_block,
+    )
+
+    monkeypatch.setenv("LITELLM_LOCAL_MODEL_COST_MAP", "True")
+    monkeypatch.setattr(litellm, "model_cost", litellm.get_model_cost_map(url=""))
+    tool = {"cache_control": {"type": "ephemeral"}}
+
+    assert add_cache_point_tool_block(tool, model="nvidia.nemotron-super-3-120b") is None
+    assert add_cache_point_tool_block(tool, model="us.nvidia.nemotron-super-3-120b") is None
+    assert add_cache_point_tool_block(
+        tool, model="arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/abc123"
+    ) == {"cachePoint": {"type": "default"}}
+    assert add_cache_point_tool_block(tool, model="us.anthropic.claude-sonnet-4-5-20250929-v1:0") == {
+        "cachePoint": {"type": "default"}
+    }
+
+
 def test_bedrock_tools_pt_passes_ttl_for_claude_4_5(monkeypatch):
     """
     End-to-end: _bedrock_tools_pt should produce cachePoint blocks with ttl

--- a/tests/test_litellm/llms/bedrock/chat/test_converse_transformation.py
+++ b/tests/test_litellm/llms/bedrock/chat/test_converse_transformation.py
@@ -5248,6 +5248,84 @@ def test_cache_control_injection_tool_config_drops_ttl_for_unsupported_model():
     assert tools[-1] == {"cachePoint": {"type": "default"}}
 
 
+@pytest.mark.parametrize(
+    ("model", "expects_cache_points"),
+    [
+        pytest.param("nvidia.nemotron-super-3-120b", False, id="mapped-model-without-prompt-caching"),
+        pytest.param("us.nvidia.nemotron-super-3-120b", False, id="regional-prefix-resolves-through-base-model"),
+        pytest.param(
+            "us.anthropic.claude-3-5-sonnet-20240620-v1:0", False, id="claude-named-but-not-caching-on-bedrock"
+        ),
+        pytest.param("us.anthropic.claude-sonnet-4-5-20250929-v1:0", True, id="mapped-model-with-prompt-caching"),
+        pytest.param(
+            "arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/abc123",
+            True,
+            id="unmapped-arn-keeps-emitting",
+        ),
+    ],
+)
+def test_cache_points_emitted_only_for_models_that_support_prompt_caching(model, expects_cache_points, monkeypatch):
+    """Bedrock rejects cachePoint blocks for models without prompt caching support
+    ("You invoked an unsupported model or your request did not allow prompt caching"),
+    and clients like Claude Code attach cache_control to every request, so a map-known
+    model without the capability must not receive them. Unmapped ids (application
+    inference profile ARNs, models newer than the map) keep emitting so existing
+    caching setups never silently degrade."""
+    monkeypatch.setenv("LITELLM_LOCAL_MODEL_COST_MAP", "True")
+    monkeypatch.setattr(litellm, "model_cost", litellm.get_model_cost_map(url=""))
+
+    body = AmazonConverseConfig().transform_request(
+        model=model,
+        messages=[
+            {"role": "system", "content": [{"type": "text", "text": "sys", "cache_control": {"type": "ephemeral"}}]},
+            {"role": "user", "content": [{"type": "text", "text": "hi", "cache_control": {"type": "ephemeral"}}]},
+        ],
+        optional_params={},
+        litellm_params={},
+        headers={},
+    )
+
+    assert ("cachePoint" in json.dumps(body)) is expects_cache_points
+    assert body["system"][0]["text"] == "sys"
+    assert body["messages"][0]["content"][0]["text"] == "hi"
+
+
+def test_tool_config_cachepoint_not_placed_or_credited_for_model_without_prompt_caching(monkeypatch):
+    """The tool_config injection point must stand down with the rest of the cachePoint
+    emission when the model cannot cache, and spend attribution must not credit the
+    gateway for a breakpoint that was never placed."""
+    monkeypatch.setenv("LITELLM_LOCAL_MODEL_COST_MAP", "True")
+    monkeypatch.setattr(litellm, "model_cost", litellm.get_model_cost_map(url=""))
+
+    bucket: dict = {"user_api_key": "sk-test"}
+    data = AmazonConverseConfig()._transform_request_helper(
+        model="nvidia.nemotron-super-3-120b",
+        system_content_blocks=[],
+        optional_params={
+            "tools": [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "get_weather",
+                        "description": "Get weather",
+                        "parameters": {
+                            "type": "object",
+                            "properties": {"location": {"type": "string"}},
+                            "required": ["location"],
+                        },
+                    },
+                }
+            ],
+            "cache_control_injection_points": [{"location": "tool_config"}],
+        },
+        messages=[{"role": "user", "content": "hi"}],
+        litellm_params={"metadata": bucket, "litellm_metadata": None, "model_info": {"id": "dep-bedrock"}},
+    )
+
+    assert "cachePoint" not in json.dumps(data.get("toolConfig", {}))
+    assert "litellm_gateway_injected_cache" not in bucket
+
+
 def test_translate_response_format_json_schema_still_injects_tool():
     """
     response_format with an explicit json_schema should still use the
@@ -6211,7 +6289,7 @@ def test_message_level_cache_control_drops_ttl_for_unsupported_model(ttl_target)
 
     result = _bedrock_converse_messages_pt(
         messages=_agentic_messages_with_ttl(ttl_target),
-        model="anthropic.claude-3-5-sonnet-20240620-v1:0",
+        model="anthropic.claude-3-5-sonnet-20241022-v2:0",
         llm_provider="bedrock_converse",
     )
 


### PR DESCRIPTION
## TLDR

Problem this solves:

- Claude Code traffic 403s on non-caching Bedrock models
- LiteLLM converts cache_control to cachePoint for every Converse model
- Bedrock rejects cachePoint on models without prompt caching support

How it solves it:

- New predicate reads supports_prompt_caching from the cost map
- Map-known non-caching models get no cachePoint blocks
- Unmapped ids (inference profile ARNs) keep emitting, nothing degrades

## User Flow

Before: a developer points Claude Code at a gateway whose auto-router SIMPLE tier is a Bedrock nemotron deployment, and every routed call dies

1. Claude Code sends POST https://litellm-domain/v1/chat/completions style traffic (a shadow eval arm, a router tier) carrying `cache_control: {"type": "ephemeral"}` markers on system and message blocks, as it always does
2. The call routed to `bedrock/converse/nvidia.nemotron-super-3-120b` returns 403 `You invoked an unsupported model or your request did not allow prompt caching`
3. The same request without cache_control returns 200, and swapping the tier to claude-haiku-4-5 makes the errors disappear, so the tier looks broken only for Claude Code traffic

After: the same traffic serves normally, and caching still happens where the model supports it

1. Claude Code sends the same request with the same cache_control markers
2. The nemotron-routed call returns 200 with a normal completion; the markers are simply not translated for a model that cannot cache
3. Requests routed to a caching-capable model like claude-haiku-4-5 still carry cachePoint blocks and still cache

## Relevant issues

- Reported by a customer running Claude Code against Bedrock tiers, and reproduced internally
- Bedrock Converse translation emitted cachePoint blocks unconditionally, with no capability check
- The auto prompt caching hook already gates its own injections on supports_prompt_caching; client-supplied markers had no gate
- Sibling fix #38790 covers the non-Anthropic /v1/messages passthrough ttl case; this PR is the Converse translation leg

## Linear ticket

Resolves LIT-6657

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Live proxy on port 4642 (`python litellm/proxy/proxy_cli.py --config rig/config.yaml --port 4642 --detailed_debug`), real AWS Bedrock in us-east-1, real spend. Config defines `nemotron-simple` (`bedrock/converse/nvidia.nemotron-super-3-120b`, no prompt caching support in the cost map), `claude-3-haiku-bedrock` (`bedrock/converse/anthropic.claude-3-haiku-20240307-v1:0`, claude-named but no caching support on Bedrock), `claude-haiku-bedrock` (`bedrock/converse/us.anthropic.claude-haiku-4-5-20251001-v1:0`, caching supported) and `cachepoint-router`, an auto-router whose every tier is nemotron. Same script both arms

### Before (bad55da9bf)

#### /v1/chat/completions, nemotron with cache_control

1. `curl -X POST http://127.0.0.1:4642/v1/chat/completions -H "Authorization: Bearer $KEY" -d '{"model":"nemotron-simple","max_tokens":32,"messages":[{"role":"system","content":[{"type":"text","text":"You are helpful","cache_control":{"type":"ephemeral"}}]},{"role":"user","content":"say hi in 3 words"}]}'`
2. HTTP 403 `litellm.PermissionDeniedError: BedrockException - {"message":"You invoked an unsupported model or your request did not allow prompt caching. See the documentation for more information."}`
3. The identical request without cache_control returns 200 `"Hi there!"`

#### /v1/messages, claude-named non-caching model with cache_control

1. `curl -X POST http://127.0.0.1:4642/v1/messages -H "Authorization: Bearer $KEY" -d '{"model":"claude-3-haiku-bedrock","max_tokens":32,"system":[{"type":"text","text":"You are Claude Code","cache_control":{"type":"ephemeral"}}],"messages":[{"role":"user","content":[{"type":"text","text":"say hi in 3 words"}]}]}'`
2. HTTP 403, same `did not allow prompt caching` BedrockException

#### /v1/messages, caching-capable model keeps caching (negative class)

1. Same shape against `claude-haiku-bedrock` with a long cache_control system block
2. HTTP 200, and the proxy's outgoing Converse body contains `{"cachePoint": {"type": "default"}}` after the system text

#### /v1/responses, nemotron with cache_control on an input block

1. `litellm.responses(model="bedrock/converse/nvidia.nemotron-super-3-120b", input=[{"role":"user","content":[{"type":"input_text","text":"say hi in 3 words","cache_control":{"type":"ephemeral"}}]}], max_output_tokens=32)`
2. `PermissionDeniedError: BedrockException - {"message":"You invoked an unsupported model or your request did not allow prompt caching. ..."}`

### After (ef3db9884c)

#### /v1/chat/completions, nemotron with cache_control

1. Same curl as before
2. HTTP 200 `"Hello there friend"`, usage `cache_creation_input_tokens=0 cache_read_input_tokens=0`

#### /v1/messages, claude-named non-caching model with cache_control

1. Same curl as before
2. The prompt caching 403 is gone; the request now reaches Bedrock's model access layer (this AWS account gets the model's own legacy access refusal, unrelated to cache_control), and the proxy's outgoing body for it carries no cachePoint

#### /v1/messages, caching-capable model keeps caching (negative class)

1. Same claude-haiku-bedrock curl as before
2. HTTP 200, and grepping the whole after-run's debug log for cachePoint finds exactly one occurrence, inside this request's outgoing body

#### /v1/responses, nemotron with cache_control on an input block

1. Same call
2. 200, `'Hi, howdy, hey!'`

#### Real Claude Code session through the auto-router

1. `ANTHROPIC_BASE_URL=http://127.0.0.1:4642 ANTHROPIC_AUTH_TOKEN=$KEY claude -p "Reply with the single word: pong" --max-turns 1 --model cachepoint-router`
2. Claude Code answers `pong`; the debug log shows 95 cache_control markers arriving from the client, the Claude Code system prompt landing on nemotron via Converse with zero cachePoint blocks, and zero provider errors

## Type

🐛 Bug Fix

## Caveats (if any)

### Low

- Models the cost map knows but marks non-caching silently lose cachePoints they never could use

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Bedrock Converse request shaping for all traffic carrying `cache_control`, but only suppresses `cachePoint` where the cost map says caching is unsupported; unmapped models keep prior behavior.
> 
> **Overview**
> **Stops translating `cache_control` into Bedrock Converse `cachePoint` blocks when the target model is known not to support prompt caching**, fixing 403s from clients (e.g. Claude Code) that always send cache markers.
> 
> A new **`bedrock_model_accepts_cache_points`** helper consults `litellm.model_cost` (`supports_prompt_caching`, with regional/base model resolution). When it returns false, **`add_cache_point_tool_block`**, message/system **`get_cache_point_block`**, and **`tool_config` cache injection** no longer emit `cachePoint` (and gateway spend attribution for tool_config breakpoints is skipped). **Unmapped model IDs** (e.g. inference profile ARNs) still emit cache points so caching is not silently dropped.
> 
> Tests cover mapped non-caching models, caching-capable Claude, ARNs, and tool_config injection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ef3db9884c9450da81538fc35be0beb2828e191f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->