### PR TITLE
feat(router): add cached capability routing

### DIFF
--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -860,6 +860,7 @@ class LiteLLMRoutes(enum.Enum):
         # proxy admin, or team admin naming their own team via team_id
         "/auto_router/test_routing",
         "/auto_router/validate_complexity_router_config",
+        "/auto_router/validate_capability_router_config",
         # Agent registry - reads are role-scoped and writes are proxy-admin-gated
         # inside agent_endpoints/endpoints.py
         *agent_management_routes,

--- a/litellm/proxy/management_endpoints/auto_router_endpoints.py
+++ b/litellm/proxy/management_endpoints/auto_router_endpoints.py
@@ -39,6 +39,7 @@ from litellm.proxy.litellm_pre_call_utils import (
 )
 from litellm.repositories.base_repository import SupportsModelDump
 from litellm.repositories.team_repository import TeamRepository
+from litellm.router_strategy.capability_router import CapabilityRouter
 from litellm.router_strategy.complexity_router import ComplexityRouter
 from litellm.router_utils.auto_router_model_naming import (
     StrategyRouterDependencyRole,
@@ -54,6 +55,8 @@ from litellm.types.management_endpoints.auto_router_endpoints import (
     AutoRouterCacheStats,
     AutoRouterRoutingTestRequest,
     AutoRouterRoutingTestResponse,
+    CapabilityRouterConfigValidationRequest,
+    CapabilityRouterConfigValidationResponse,
     ComplexityRouterConfigValidationRequest,
     ComplexityRouterConfigValidationResponse,
     RequestComplexityRouterConfig,
@@ -277,7 +280,19 @@ async def _authorize_models_this_test_can_call(
     the key's own budget is not checked either. Test Connection gets both for free by routing
     its calls through the proxy. Team and member budgets are already enforced on every route.
     """
-    models: Final = _models_this_test_can_call(config)
+    await _authorize_model_names_this_test_can_call(
+        models=_models_this_test_can_call(config),
+        user_api_key_dict=user_api_key_dict,
+        llm_router=llm_router,
+    )
+
+
+async def _authorize_model_names_this_test_can_call(
+    models: Sequence[str],
+    user_api_key_dict: UserAPIKeyAuth,
+    llm_router: "Router",
+) -> None:
+    """Apply model-access and key-budget checks to internal dry-run calls."""
     if not models:
         return
 
@@ -332,6 +347,27 @@ async def validate_complexity_router_config(
 
     error: Final = validate_complexity_router_config_write(data.complexity_router_config)
     return ComplexityRouterConfigValidationResponse(valid=error is None, error=error)
+
+
+@router.post(
+    "/auto_router/validate_capability_router_config",
+    tags=["model management"],
+    dependencies=[Depends(user_api_key_auth)],
+    response_model=CapabilityRouterConfigValidationResponse,
+    status_code=status.HTTP_200_OK,
+)
+async def validate_capability_router_config(
+    data: CapabilityRouterConfigValidationRequest,
+    user_api_key_dict: Annotated[UserAPIKeyAuth, Depends(user_api_key_auth)],
+) -> CapabilityRouterConfigValidationResponse:
+    """Validate a capability-router config without saving it."""
+    await _authorize_router_dry_run(user_api_key_dict=user_api_key_dict, team_id=data.team_id)
+    from litellm.router_utils.auto_router_model_naming import (
+        validate_capability_router_config_write,
+    )
+
+    error: Final = validate_capability_router_config_write(data.capability_router_config)
+    return CapabilityRouterConfigValidationResponse(valid=error is None, error=error)
 
 
 @router.post(
@@ -397,19 +433,31 @@ async def preview_auto_router_routing(
             },
         )
 
-    await _authorize_models_this_test_can_call(
-        config=data.complexity_router_config,
-        user_api_key_dict=user_api_key_dict,
-        llm_router=llm_router,
-    )
-
-    complexity_router: Final = ComplexityRouter(
-        model_name=data.router_name,
-        litellm_router_instance=llm_router,
-        complexity_router_config=data.complexity_router_config.model_dump(exclude_none=True),
-        default_model=data.default_model,
-        derive_savings_baseline=False,
-    )
+    if data.capability_router_config is not None:
+        await _authorize_model_names_this_test_can_call(
+            models=(data.capability_router_config.classifier.model,),
+            user_api_key_dict=user_api_key_dict,
+            llm_router=llm_router,
+        )
+        strategy = CapabilityRouter(
+            model_name=data.router_name,
+            litellm_router_instance=llm_router,
+            capability_router_config=data.capability_router_config.model_dump(exclude_none=True),
+        )
+    else:
+        assert data.complexity_router_config is not None
+        await _authorize_models_this_test_can_call(
+            config=data.complexity_router_config,
+            user_api_key_dict=user_api_key_dict,
+            llm_router=llm_router,
+        )
+        strategy = ComplexityRouter(
+            model_name=data.router_name,
+            litellm_router_instance=llm_router,
+            complexity_router_config=data.complexity_router_config.model_dump(exclude_none=True),
+            default_model=data.default_model,
+            derive_savings_baseline=False,
+        )
 
     request_kwargs: Final = LiteLLMProxyRequestSetup.add_user_api_key_auth_to_request_metadata(
         data={  # mutable-ok: the request-metadata helper takes and returns request kwargs as a dict
@@ -423,7 +471,7 @@ async def preview_auto_router_routing(
     refresh_proxy_server_request_body_snapshot(request_kwargs)
 
     try:
-        hook_response: Final = await complexity_router.async_pre_routing_hook(
+        hook_response: Final = await strategy.async_pre_routing_hook(
             model=data.router_name,
             request_kwargs=request_kwargs,
             messages=request_kwargs["messages"],

--- a/litellm/proxy/management_endpoints/model_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/model_management_endpoints.py
@@ -89,6 +89,7 @@ from litellm.router_strategy.complexity_router import (
 from litellm.router_utils.auto_router_model_naming import (
     STRATEGY_ROUTER_PARAM_FIELDS,
     carries_complexity_router_settings,
+    validate_capability_router_config_write,
     validate_complexity_router_config_placement,
     validate_complexity_router_config_write,
     validate_strategy_router_model_write,
@@ -226,6 +227,11 @@ def _strategy_router_write_violation(
     """
     if incoming_params is None:
         return None
+    capability_violation: Final = validate_capability_router_config_write(
+        capability_router_config=incoming_params.capability_router_config
+    )
+    if capability_violation is not None:
+        return capability_violation
     config_violation: Final = validate_complexity_router_config_write(
         complexity_router_config=incoming_params.complexity_router_config
     )
@@ -2562,6 +2568,7 @@ async def clear_cache() -> ReconcileOutcome:
             # on reload and abort it.
             for model_name in db_router_names:
                 llm_router.auto_routers.pop(model_name, None)
+                llm_router.capability_routers.pop(model_name, None)
                 llm_router.complexity_routers.pop(model_name, None)
                 llm_router.adaptive_routers.pop(model_name, None)
                 llm_router.quality_routers.pop(model_name, None)

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -265,6 +265,9 @@ if TYPE_CHECKING:
         AutoRouter,
         PreRoutingHookResponse,
     )
+    from litellm.router_strategy.capability_router.capability_router import (
+        CapabilityRouter,
+    )
     from litellm.router_strategy.complexity_router.complexity_router import (
         ComplexityRouter,
     )
@@ -788,6 +791,7 @@ class Router:
         self.pattern_router = PatternMatchRouter()
         self.team_pattern_routers: dict[str, PatternMatchRouter] = {}  # {"TEAM_ID": PatternMatchRouter}
         self.auto_routers: dict[str, list[TaggedPreRoutingStrategy[AutoRouter]]] = {}
+        self.capability_routers: dict[str, list[TaggedPreRoutingStrategy[CapabilityRouter]]] = {}
         self.complexity_routers: dict[str, list[TaggedPreRoutingStrategy[ComplexityRouter]]] = {}
         self.adaptive_routers: dict[str, list[TaggedPreRoutingStrategy[AdaptiveRouter]]] = {}
         self.quality_routers: dict[str, list[TaggedPreRoutingStrategy[QualityRouter]]] = {}
@@ -8427,6 +8431,31 @@ class Router:
         """
         return classify_strategy_router_model(litellm_params.model) == "complexity"
 
+    def _is_capability_router_deployment(self, litellm_params: LiteLLM_Params) -> bool:
+        """True when this deployment configures a capability router."""
+        return classify_strategy_router_model(litellm_params.model) == "capability"
+
+    def init_capability_router_deployment(self, deployment: Deployment) -> None:
+        """Initialize and register a capability router deployment."""
+        from litellm.router_strategy.capability_router import CapabilityRouter
+
+        config: Final = deployment.litellm_params.capability_router_config
+        if config is None:
+            raise ValueError(
+                "capability_router_config is required for capability-router deployments"
+            )
+        capability_router: Final = CapabilityRouter(
+            model_name=deployment.model_name,
+            litellm_router_instance=self,
+            capability_router_config=config,
+        )
+        self._register_pre_routing_strategy(
+            registry=self.capability_routers,
+            deployment=deployment,
+            strategy=capability_router,
+            strategy_label="Capability-router",
+        )
+
     def init_complexity_router_deployment(self, deployment: Deployment):
         """
         Initialize the complexity-router deployment.
@@ -8575,7 +8604,12 @@ class Router:
             return
         model_name: Final = deployment.model_name
         tags: Final = self._deployment_tags(deployment)
-        for registry in (self.auto_routers, self.complexity_routers, self.quality_routers):
+        for registry in (
+            self.auto_routers,
+            self.capability_routers,
+            self.complexity_routers,
+            self.quality_routers,
+        ):
             self._unregister_pre_routing_strategy(registry, model_name, tags)
         if self._unregister_pre_routing_strategy(self.adaptive_routers, model_name, tags):
             self._sync_adaptive_router_hooks()
@@ -8779,6 +8813,7 @@ class Router:
         # Reset per-strategy router registries so hot-reload doesn't leave
         # stale routers pointing at the old model_list.
         self.quality_routers = {}
+        self.capability_routers = {}
         self.complexity_routers = {}
         self.auto_routers = {}
         self._invalidate_model_group_info_cache()
@@ -8967,6 +9002,9 @@ class Router:
         #########################################################
         if self._is_complexity_router_deployment(litellm_params=deployment.litellm_params):
             self.init_complexity_router_deployment(deployment=deployment)
+
+        if self._is_capability_router_deployment(litellm_params=deployment.litellm_params):
+            self.init_capability_router_deployment(deployment=deployment)
 
         # NOTE: adaptive-router deployments are deferred to the end of
         # set_model_list() because their init needs visibility into the OTHER
@@ -12398,6 +12436,7 @@ class Router:
         """
         candidates: Final[list[TaggedPreRoutingStrategy[PreRoutingStrategy]]] = [
             *self.auto_routers.get(model, []),
+            *self.capability_routers.get(model, []),
             *self.complexity_routers.get(model, []),
             *self.adaptive_routers.get(model, []),
             *self.quality_routers.get(model, []),

--- a/litellm/router_strategy/capability_router/__init__.py
+++ b/litellm/router_strategy/capability_router/__init__.py
@@ -1,0 +1,3 @@
+from .capability_router import CapabilityRouter
+
+__all__ = ["CapabilityRouter"]

--- a/litellm/router_strategy/capability_router/capability_router.py
+++ b/litellm/router_strategy/capability_router/capability_router.py
@@ -1,0 +1,391 @@
+"""LLM capability forecasts with deterministic cheapest-qualified selection."""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import weakref
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Final, Literal, TypedDict, cast
+
+from pydantic import TypeAdapter, ValidationError
+from typing_extensions import ReadOnly
+
+from litellm._logging import verbose_router_logger
+from litellm.integrations.custom_logger import CustomLogger
+from litellm.litellm_core_utils.internal_call_metadata import forwarded_internal_call_metadata
+from litellm.types.llms.openai import (
+    AllMessageValues,
+    ChatCompletionNamedToolChoiceParam,
+    ChatCompletionSystemMessage,
+    ChatCompletionToolParam,
+    ChatCompletionUserMessage,
+)
+from litellm.types.utils import (
+    AUTOROUTER_CLASSIFIER_CALL_ORIGIN,
+    ModelResponse,
+    StandardLoggingRoutingDecision,
+    Usage,
+)
+
+from .config import CapabilityClassifierVerdict, CapabilityRouterConfig
+from .policy import CapabilityRoutingDecision, fallback_decision, select_capability_model
+from .pricing import estimate_model_group_cost
+from .prompts import build_classifier_prompt, build_classifier_response_schema
+
+if TYPE_CHECKING:
+    from litellm.router import Router
+    from litellm.types.router import PreRoutingHookResponse
+
+
+class _JsonSchemaSpec(TypedDict):
+    name: ReadOnly[str]
+    strict: ReadOnly[bool]
+    schema: ReadOnly[dict[str, Any]]
+
+
+class _JsonSchemaResponseFormat(TypedDict):
+    type: ReadOnly[Literal["json_schema"]]
+    json_schema: ReadOnly[_JsonSchemaSpec]
+
+
+class _ClassifierRequestBody(TypedDict):
+    model: ReadOnly[str]
+    messages: ReadOnly[Sequence[AllMessageValues]]
+    response_format: ReadOnly[_JsonSchemaResponseFormat]
+    max_tokens: ReadOnly[int]
+
+
+class _ClassifierProxyRequest(TypedDict):
+    body: ReadOnly[_ClassifierRequestBody]
+
+
+@dataclass(frozen=True)
+class _DecisionOutcome:
+    decision: CapabilityRoutingDecision
+    classifier_cost: float | None
+    cached: bool
+
+
+class CapabilityClassifierFailure(Exception):
+    def __init__(self, message: str, classifier_cost: float | None = None) -> None:
+        super().__init__(message)
+        self.classifier_cost = classifier_cost
+
+
+_TOOLS_ADAPTER: Final = TypeAdapter(list[ChatCompletionToolParam])
+_NAMED_TOOL_CHOICE_ADAPTER: Final = TypeAdapter(ChatCompletionNamedToolChoiceParam)
+
+
+def _hash(value: str) -> str:
+    return hashlib.sha256(value.encode()).hexdigest()
+
+
+def _response_cost(response: ModelResponse) -> float | None:
+    hidden_params = getattr(response, "_hidden_params", None)
+    value = hidden_params.get("response_cost") if hasattr(hidden_params, "get") else None
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return None
+    return float(value)
+
+
+def _normalize_json(content: str) -> str:
+    normalized = content.strip()
+    for prefix in ("```json", "```"):
+        if normalized.startswith(prefix) and normalized.endswith("```"):
+            return normalized[len(prefix) : -3].strip()
+    return normalized
+
+
+def _message_role(message: Mapping[str, object]) -> str:
+    role = message.get("role")
+    return role if isinstance(role, str) else ""
+
+
+def _classification_context(messages: Sequence[Mapping[str, object]]) -> tuple[Mapping[str, object], ...]:
+    """Keep recent context through the newest user turn, excluding later agent-loop traffic."""
+    last_user_index = next(
+        (index for index in range(len(messages) - 1, -1, -1) if _message_role(messages[index]) == "user"),
+        None,
+    )
+    if last_user_index is None:
+        return ()
+    through_user = messages[: last_user_index + 1]
+    recent = through_user[-8:]
+    selected: list[Mapping[str, object]] = []
+    for message in (*through_user, *recent):
+        if _message_role(message) == "system" or message in recent:
+            if message not in selected:
+                selected.append(message)
+    return tuple(selected)
+
+
+def _tool_names(request_kwargs: Mapping[str, object]) -> tuple[str, ...]:
+    tools = request_kwargs.get("tools")
+    if not isinstance(tools, Sequence) or isinstance(tools, (str, bytes)):
+        return ()
+    names: list[str] = []
+    for tool in tools:
+        if not isinstance(tool, Mapping):
+            continue
+        function = tool.get("function")
+        if isinstance(function, Mapping) and isinstance(function.get("name"), str):
+            names.append(cast(str, function["name"]))
+    return tuple(names)
+
+
+class CapabilityRouter(CustomLogger):
+    """Forecast success for each candidate and return the cheapest qualified group."""
+
+    def __init__(
+        self,
+        model_name: str,
+        litellm_router_instance: Router,
+        capability_router_config: Mapping[str, object],
+    ) -> None:
+        self.model_name = model_name
+        self.litellm_router_instance = litellm_router_instance
+        self.config = CapabilityRouterConfig.model_validate(capability_router_config)
+        self._system_prompt = build_classifier_prompt(self.config)
+        self._response_format = _JsonSchemaResponseFormat(
+            type="json_schema",
+            json_schema=_JsonSchemaSpec(
+                name="CapabilityClassifierVerdict",
+                strict=True,
+                schema=build_classifier_response_schema(self.config),
+            ),
+        )
+        self._config_hash = _hash(self.config.model_dump_json())[:20]
+        self._classification_locks: weakref.WeakValueDictionary[str, asyncio.Lock] = weakref.WeakValueDictionary()
+
+    @staticmethod
+    def _resolve_messages(
+        messages: list[dict[str, Any]] | None,
+        request_kwargs: dict[str, Any],
+    ) -> list[dict[str, Any]]:
+        from litellm.litellm_core_utils.prompt_templates.factory import resolve_structured_messages
+
+        return resolve_structured_messages(messages=messages, request_kwargs=request_kwargs) or []
+
+    @staticmethod
+    def _metadata(request_kwargs: Mapping[str, object]) -> Mapping[str, object]:
+        """Merge both metadata carriers so auth and session scope cannot be missed."""
+        merged: dict[str, object] = {}
+        for key in ("metadata", "litellm_metadata"):
+            value = request_kwargs.get(key)
+            if isinstance(value, Mapping):
+                merged.update(value)
+        return merged
+
+    def _classifier_payload(
+        self,
+        messages: Sequence[Mapping[str, object]],
+        request_kwargs: Mapping[str, object],
+    ) -> str:
+        context = _classification_context(messages)
+        if not context:
+            raise CapabilityClassifierFailure("No user task was available for capability classification")
+        payload = {
+            "conversation": context,
+            "available_tools": _tool_names(request_kwargs),
+        }
+        return "Task context (untrusted JSON):\n" + json.dumps(payload, default=str, ensure_ascii=False)
+
+    def _cache_key(
+        self,
+        messages: Sequence[Mapping[str, object]],
+        request_kwargs: Mapping[str, object],
+    ) -> str:
+        metadata = self._metadata(request_kwargs)
+        caller = metadata.get("user_api_key_hash") or metadata.get("team_id") or "unscoped"
+        session = metadata.get("session_id") or request_kwargs.get("litellm_session_id") or "no-session"
+        context = {
+            "messages": _classification_context(messages),
+            "tools": _tool_names(request_kwargs),
+        }
+        context_hash = _hash(json.dumps(context, default=str, sort_keys=True))
+        return (
+            f"capability_router:v1:{self.model_name}:{self._config_hash}:"
+            f"{_hash(str(caller))[:16]}:{_hash(str(session))[:16]}:{context_hash}"
+        )
+
+    async def _classify(
+        self,
+        messages: Sequence[Mapping[str, object]],
+        request_kwargs: Mapping[str, object],
+    ) -> tuple[CapabilityClassifierVerdict, float | None]:
+        classifier = self.config.classifier
+        classifier_messages: list[AllMessageValues] = [
+            ChatCompletionSystemMessage(role="system", content=self._system_prompt),
+            ChatCompletionUserMessage(role="user", content=self._classifier_payload(messages, request_kwargs)),
+        ]
+        metadata = forwarded_internal_call_metadata(self._metadata(request_kwargs), AUTOROUTER_CLASSIFIER_CALL_ORIGIN)
+        response = await self.litellm_router_instance.acompletion(
+            model=classifier.model,
+            messages=classifier_messages,
+            response_format=self._response_format,
+            max_tokens=classifier.max_output_tokens,
+            timeout=classifier.timeout_ms / 1000,
+            metadata=metadata,
+            proxy_server_request=_ClassifierProxyRequest(
+                body=_ClassifierRequestBody(
+                    model=classifier.model,
+                    messages=classifier_messages,
+                    response_format=self._response_format,
+                    max_tokens=classifier.max_output_tokens,
+                )
+            ),
+        )
+        classifier_cost = _response_cost(response)
+        content = response.choices[0].message.content
+        if not isinstance(content, str) or not content.strip():
+            raise CapabilityClassifierFailure("Capability classifier returned empty content", classifier_cost)
+        try:
+            return CapabilityClassifierVerdict.model_validate_json(_normalize_json(content)), classifier_cost
+        except ValidationError as exc:
+            raise CapabilityClassifierFailure("Capability classifier returned invalid JSON", classifier_cost) from exc
+
+    def _estimated_usage(
+        self,
+        messages: Sequence[Mapping[str, object]],
+        request_kwargs: Mapping[str, object],
+    ) -> Usage | None:
+        import litellm
+
+        try:
+            tools_value = request_kwargs.get("tools")
+            tools = _TOOLS_ADAPTER.validate_python(tools_value) if tools_value is not None else None
+            tool_choice_value = request_kwargs.get("tool_choice")
+            if tool_choice_value in ("none", "auto", "required", None):
+                tool_choice = tool_choice_value
+            else:
+                tool_choice = _NAMED_TOOL_CHOICE_ADAPTER.validate_python(tool_choice_value)
+            input_tokens = litellm.token_counter(
+                messages=list(messages),
+                tools=tools,
+                tool_choice=tool_choice,
+                use_default_image_token_count=True,
+            )
+        except Exception as exc:  # noqa: BLE001 - unpriceable requests use the explicit fallback
+            verbose_router_logger.warning("CapabilityRouter: token estimate failed (%s)", exc)
+            return None
+
+        requested_limits = tuple(
+            value
+            for field in ("max_completion_tokens", "max_tokens", "max_output_tokens")
+            if isinstance((value := request_kwargs.get(field)), int) and not isinstance(value, bool) and value > 0
+        )
+        output_tokens = min((self.config.estimated_output_tokens, *requested_limits))
+        return Usage(
+            prompt_tokens=input_tokens,
+            completion_tokens=output_tokens,
+            total_tokens=input_tokens + output_tokens,
+        )
+
+    async def _new_decision(
+        self,
+        messages: Sequence[Mapping[str, object]],
+        request_kwargs: Mapping[str, object],
+    ) -> tuple[CapabilityRoutingDecision, float | None]:
+        try:
+            verdict, classifier_cost = await self._classify(messages, request_kwargs)
+            usage = self._estimated_usage(messages, request_kwargs)
+            costs = {
+                candidate.model: (
+                    estimate_model_group_cost(self.litellm_router_instance, candidate.model, usage)
+                    if usage is not None
+                    else None
+                )
+                for candidate in self.config.candidates
+            }
+            return select_capability_model(self.config, verdict, costs), classifier_cost
+        except CapabilityClassifierFailure as exc:
+            verbose_router_logger.warning("CapabilityRouter: classifier failed; using fallback")
+            return fallback_decision(self.config, "classifier_error"), exc.classifier_cost
+        except Exception as exc:  # noqa: BLE001 - routing must fail safe
+            verbose_router_logger.warning("CapabilityRouter: selection failed (%s); using fallback", exc)
+            return fallback_decision(self.config, "classifier_error"), None
+
+    def _cached_decision(self, value: object) -> CapabilityRoutingDecision | None:
+        try:
+            decision = CapabilityRoutingDecision.model_validate(value)
+        except ValidationError:
+            return None
+        configured = {candidate.model for candidate in self.config.candidates}
+        return decision if decision.selected_model in configured else None
+
+    async def _decision(
+        self,
+        cache_key: str,
+        messages: Sequence[Mapping[str, object]],
+        request_kwargs: Mapping[str, object],
+    ) -> _DecisionOutcome:
+        cached = self._cached_decision(await self.litellm_router_instance.cache.async_get_cache(key=cache_key))
+        if cached is not None:
+            return _DecisionOutcome(cached, None, True)
+
+        lock = self._classification_locks.setdefault(cache_key, asyncio.Lock())
+        async with lock:
+            cached = self._cached_decision(await self.litellm_router_instance.cache.async_get_cache(key=cache_key))
+            if cached is not None:
+                return _DecisionOutcome(cached, None, True)
+            decision, classifier_cost = await self._new_decision(messages, request_kwargs)
+            await self.litellm_router_instance.cache.async_set_cache(
+                key=cache_key,
+                value=decision.model_dump(mode="json"),
+                ttl=self.config.cache_ttl_seconds,
+            )
+            return _DecisionOutcome(decision, classifier_cost, False)
+
+    def _routing_record(self, outcome: _DecisionOutcome) -> StandardLoggingRoutingDecision:
+        decision = outcome.decision
+        record = StandardLoggingRoutingDecision(
+            router_model_name=self.model_name,
+            router_type="capability",
+            routed_model=decision.selected_model,
+            cause=(
+                "capability_cache"
+                if outcome.cached
+                else "capability_classifier"
+                if decision.reason == "cheapest_qualified"
+                else "capability_fallback"
+            ),
+            classifier_model=self.config.classifier.model,
+            probability_threshold=self.config.probability_threshold,
+            candidate_probabilities={candidate.model: candidate.p_solve for candidate in decision.candidates},
+            candidate_costs={
+                candidate.model: candidate.estimated_cost
+                for candidate in decision.candidates
+                if candidate.estimated_cost is not None
+            },
+            qualified_models=[candidate.model for candidate in decision.candidates if candidate.qualified],
+            fallback_reason=(decision.reason if decision.reason != "cheapest_qualified" else None),
+            cached=outcome.cached,
+        )
+        if outcome.classifier_cost is not None:
+            record["classifier_cost"] = outcome.classifier_cost
+        return record
+
+    async def async_pre_routing_hook(
+        self,
+        model: str,
+        request_kwargs: dict,
+        messages: list[dict[str, Any]] | None = None,
+        input: str | list | None = None,
+        specific_deployment: bool | None = False,
+    ) -> PreRoutingHookResponse:
+        from litellm.types.router import PreRoutingHookResponse
+
+        resolved_messages = self._resolve_messages(messages, request_kwargs)
+        outcome = await self._decision(
+            self._cache_key(resolved_messages, request_kwargs),
+            resolved_messages,
+            request_kwargs,
+        )
+        return PreRoutingHookResponse(
+            model=outcome.decision.selected_model,
+            messages=messages,
+            routing_decision=self._routing_record(outcome),
+        )

--- a/litellm/router_strategy/capability_router/config.py
+++ b/litellm/router_strategy/capability_router/config.py
@@ -1,0 +1,137 @@
+"""Configuration and classifier output for capability routing."""
+
+import math
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+from typing_extensions import Self
+
+
+def _nonblank(value: str, field_name: str) -> str:
+    normalized = value.strip()
+    if not normalized:
+        raise ValueError(f"{field_name} must not be blank")
+    return normalized
+
+
+def _provider_model(value: str, field_name: str) -> str:
+    normalized = _nonblank(value, field_name)
+    if normalized.startswith("auto_router/"):
+        raise ValueError(f"{field_name} must name a provider model group")
+    return normalized
+
+
+class CapabilityRouterCandidate(BaseModel):
+    """A model group and the operator's description of when it succeeds."""
+
+    model: str
+    description: str
+
+    model_config = ConfigDict(extra="forbid")
+
+    @field_validator("model")
+    @classmethod
+    def validate_model(cls, value: str) -> str:
+        return _provider_model(value, "candidate model")
+
+    @field_validator("description")
+    @classmethod
+    def validate_description(cls, value: str) -> str:
+        return _nonblank(value, "candidate description")
+
+
+class CapabilityClassifierConfig(BaseModel):
+    """The model used to estimate each candidate's probability of success."""
+
+    model: str
+    timeout_ms: int = Field(default=3000, ge=1)
+    max_output_tokens: int = Field(default=1024, ge=1)
+
+    model_config = ConfigDict(extra="forbid")
+
+    @field_validator("model")
+    @classmethod
+    def validate_model(cls, value: str) -> str:
+        return _provider_model(value, "classifier model")
+
+
+class CapabilityRouterConfig(BaseModel):
+    """Operator configuration for cheapest-qualified model selection."""
+
+    candidates: tuple[CapabilityRouterCandidate, ...] = Field(min_length=2)
+    classifier: CapabilityClassifierConfig
+    probability_threshold: float = Field(default=0.7, ge=0.0, le=1.0)
+    fallback_model: str
+    estimated_output_tokens: int = Field(default=1000, ge=1)
+    cache_ttl_seconds: int = Field(default=3600, ge=1)
+
+    model_config = ConfigDict(extra="forbid")
+
+    @field_validator("fallback_model")
+    @classmethod
+    def validate_fallback_model(cls, value: str) -> str:
+        return _provider_model(value, "fallback_model")
+
+    @field_validator("probability_threshold", mode="before")
+    @classmethod
+    def validate_finite_threshold(cls, value: object) -> object:
+        if isinstance(value, (int, float)) and not math.isfinite(value):
+            raise ValueError("probability_threshold must be finite")
+        return value
+
+    @model_validator(mode="after")
+    def validate_candidates(self) -> Self:
+        models = tuple(candidate.model for candidate in self.candidates)
+        if len(models) != len(set(models)):
+            raise ValueError("candidate model names must be unique")
+        if self.fallback_model not in models:
+            raise ValueError("fallback_model must be one of the candidate models")
+        return self
+
+
+class CapabilityCandidateScore(BaseModel):
+    """One classifier estimate for the current task."""
+
+    model: str
+    p_solve: float = Field(ge=0.0, le=1.0)
+    reason: str
+
+    model_config = ConfigDict(extra="forbid")
+
+    @field_validator("model", "reason")
+    @classmethod
+    def validate_nonblank(cls, value: str, info) -> str:
+        return _nonblank(value, info.field_name)
+
+    @field_validator("p_solve", mode="before")
+    @classmethod
+    def validate_probability(cls, value: object) -> object:
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
+            raise ValueError("p_solve must be a JSON number")
+        if isinstance(value, float) and not math.isfinite(value):
+            raise ValueError("p_solve must be finite")
+        return value
+
+
+class CapabilityClassifierVerdict(BaseModel):
+    """Strict structured output returned by the classifier."""
+
+    candidates: tuple[CapabilityCandidateScore, ...] = Field(min_length=2)
+
+    model_config = ConfigDict(extra="forbid")
+
+    @model_validator(mode="after")
+    def validate_unique_models(self) -> Self:
+        models = tuple(candidate.model for candidate in self.candidates)
+        if len(models) != len(set(models)):
+            raise ValueError("classifier candidate model names must be unique")
+        return self
+
+
+CapabilitySelectionReason = Literal[
+    "cheapest_qualified",
+    "no_qualified_candidate",
+    "missing_candidate_price",
+    "classifier_error",
+    "invalid_classifier_verdict",
+]

--- a/litellm/router_strategy/capability_router/policy.py
+++ b/litellm/router_strategy/capability_router/policy.py
@@ -43,7 +43,7 @@ def select_capability_model(
     verdict: CapabilityClassifierVerdict,
     estimated_costs: Mapping[str, float | None],
 ) -> CapabilityRoutingDecision:
-    """Choose the cheapest candidate at or above the configured probability."""
+    """Choose the cheapest candidate above the configured probability."""
     configured_models = tuple(candidate.model for candidate in config.candidates)
     scores = {candidate.model: candidate for candidate in verdict.candidates}
     if set(scores) != set(configured_models):
@@ -55,7 +55,7 @@ def select_capability_model(
             p_solve=scores[model].p_solve,
             reason=scores[model].reason,
             estimated_cost=estimated_costs.get(model),
-            qualified=scores[model].p_solve >= config.probability_threshold,
+            qualified=scores[model].p_solve > config.probability_threshold,
         )
         for model in configured_models
     )

--- a/litellm/router_strategy/capability_router/policy.py
+++ b/litellm/router_strategy/capability_router/policy.py
@@ -1,0 +1,80 @@
+"""Deterministic policy for selecting the cheapest qualified model."""
+
+import math
+from collections.abc import Mapping
+
+from pydantic import BaseModel, ConfigDict
+
+from .config import CapabilityClassifierVerdict, CapabilityRouterConfig, CapabilitySelectionReason
+
+
+class CapabilityCandidateAssessment(BaseModel):
+    model: str
+    p_solve: float
+    reason: str
+    estimated_cost: float | None
+    qualified: bool
+
+    model_config = ConfigDict(extra="forbid")
+
+
+class CapabilityRoutingDecision(BaseModel):
+    selected_model: str
+    reason: CapabilitySelectionReason
+    candidates: tuple[CapabilityCandidateAssessment, ...] = ()
+
+    model_config = ConfigDict(extra="forbid")
+
+
+def fallback_decision(
+    config: CapabilityRouterConfig,
+    reason: CapabilitySelectionReason,
+    candidates: tuple[CapabilityCandidateAssessment, ...] = (),
+) -> CapabilityRoutingDecision:
+    return CapabilityRoutingDecision(
+        selected_model=config.fallback_model,
+        reason=reason,
+        candidates=candidates,
+    )
+
+
+def select_capability_model(
+    config: CapabilityRouterConfig,
+    verdict: CapabilityClassifierVerdict,
+    estimated_costs: Mapping[str, float | None],
+) -> CapabilityRoutingDecision:
+    """Choose the cheapest candidate at or above the configured probability."""
+    configured_models = tuple(candidate.model for candidate in config.candidates)
+    scores = {candidate.model: candidate for candidate in verdict.candidates}
+    if set(scores) != set(configured_models):
+        return fallback_decision(config, "invalid_classifier_verdict")
+
+    assessments = tuple(
+        CapabilityCandidateAssessment(
+            model=model,
+            p_solve=scores[model].p_solve,
+            reason=scores[model].reason,
+            estimated_cost=estimated_costs.get(model),
+            qualified=scores[model].p_solve >= config.probability_threshold,
+        )
+        for model in configured_models
+    )
+    qualified = tuple(candidate for candidate in assessments if candidate.qualified)
+    if not qualified:
+        return fallback_decision(config, "no_qualified_candidate", assessments)
+    if any(candidate.estimated_cost is None for candidate in qualified):
+        return fallback_decision(config, "missing_candidate_price", assessments)
+
+    order = {model: index for index, model in enumerate(configured_models)}
+    selected = min(
+        qualified,
+        key=lambda candidate: (
+            candidate.estimated_cost if candidate.estimated_cost is not None else math.inf,
+            order[candidate.model],
+        ),
+    )
+    return CapabilityRoutingDecision(
+        selected_model=selected.model,
+        reason="cheapest_qualified",
+        candidates=assessments,
+    )

--- a/litellm/router_strategy/capability_router/pricing.py
+++ b/litellm/router_strategy/capability_router/pricing.py
@@ -1,0 +1,79 @@
+"""Request-cost estimates used only by capability selection."""
+
+import math
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from litellm._logging import verbose_router_logger
+from litellm.litellm_core_utils.llm_cost_calc.utils import generic_cost_per_token
+from litellm.router_strategy.savings_baseline import canonical_model
+from litellm.types.utils import Usage
+
+if TYPE_CHECKING:
+    from litellm.router import Router
+
+
+@dataclass(frozen=True)
+class _PricedModel:
+    model: str
+    deployment_id: str | None = None
+
+
+def _deployment_model(deployment: Mapping[str, object]) -> _PricedModel | None:
+    params = deployment.get("litellm_params")
+    if not isinstance(params, Mapping):
+        return None
+    info_value = deployment.get("model_info")
+    info = info_value if isinstance(info_value, Mapping) else {}
+    model = info.get("base_model") or params.get("base_model") or params.get("model")
+    provider_value = params.get("custom_llm_provider")
+    provider = provider_value if isinstance(provider_value, str) else None
+    qualified = canonical_model(model, provider) if isinstance(model, str) else None
+    if qualified is None:
+        return None
+    deployment_id = info.get("id")
+    return _PricedModel(qualified, str(deployment_id) if deployment_id else None)
+
+
+def _models_served_by(router: "Router", model_group: str) -> tuple[_PricedModel, ...]:
+    deployments = tuple(router.get_model_list(model_name=model_group) or ())
+    if not deployments:
+        direct = canonical_model(model_group)
+        return (_PricedModel(direct),) if direct is not None else ()
+    candidates = tuple(
+        candidate
+        for deployment in deployments
+        if (candidate := _deployment_model(deployment)) is not None
+    )
+    return candidates if len(candidates) == len(deployments) else ()
+
+
+def _request_cost(router: "Router", candidate: _PricedModel, usage: Usage) -> float | None:
+    provider, _, model_name = candidate.model.partition("/")
+    try:
+        model_info = router.get_deployment_model_info(candidate.deployment_id or "", candidate.model)
+        if model_info is None:
+            return None
+        prompt_cost, completion_cost = generic_cost_per_token(
+            model=model_name or candidate.model,
+            usage=usage,
+            custom_llm_provider=provider,
+            model_info=model_info,
+        )
+    except Exception as exc:  # noqa: BLE001 - an unpriceable candidate uses the configured fallback
+        verbose_router_logger.debug("CapabilityRouter: no pricing for %s (%s)", candidate.model, exc)
+        return None
+    cost = prompt_cost + completion_cost
+    return cost if math.isfinite(cost) and cost >= 0 else None
+
+
+def estimate_model_group_cost(router: "Router", model_group: str, usage: Usage) -> float | None:
+    """Return a conservative cost estimate for every deployment behind a group."""
+    candidates = _models_served_by(router, model_group)
+    if not candidates:
+        return None
+    costs = tuple(_request_cost(router, candidate, usage) for candidate in candidates)
+    if any(cost is None for cost in costs):
+        return None
+    return max(cost for cost in costs if cost is not None)

--- a/litellm/router_strategy/capability_router/prompts.py
+++ b/litellm/router_strategy/capability_router/prompts.py
@@ -1,0 +1,45 @@
+"""Classifier prompt and response schema for capability routing."""
+
+from typing import Any
+
+from .config import CapabilityRouterConfig
+
+
+def build_classifier_prompt(config: CapabilityRouterConfig) -> str:
+    candidates = "\n".join(
+        f"- {candidate.model}: {candidate.description}" for candidate in config.candidates
+    )
+    return f"""You route tasks between language models.
+
+For each candidate below, estimate the probability that it can complete the user's task correctly and completely. Base the estimate only on the task and the operator-provided description. Do not consider price; price is handled separately.
+
+Candidates:
+{candidates}
+
+Return one score for every candidate using the exact model names. p_solve must be a number from 0 to 1. reason must briefly identify the capability that most affects the estimate."""
+
+
+def build_classifier_response_schema(config: CapabilityRouterConfig) -> dict[str, Any]:
+    model_names = [candidate.model for candidate in config.candidates]
+    return {
+        "type": "object",
+        "properties": {
+            "candidates": {
+                "type": "array",
+                "minItems": len(model_names),
+                "maxItems": len(model_names),
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "model": {"type": "string", "enum": model_names},
+                        "p_solve": {"type": "number", "minimum": 0, "maximum": 1},
+                        "reason": {"type": "string", "minLength": 1},
+                    },
+                    "required": ["model", "p_solve", "reason"],
+                    "additionalProperties": False,
+                },
+            }
+        },
+        "required": ["candidates"],
+        "additionalProperties": False,
+    }

--- a/litellm/router_utils/auto_router_model_naming.py
+++ b/litellm/router_utils/auto_router_model_naming.py
@@ -22,9 +22,9 @@ from litellm.router_strategy.complexity_router.config import (
 
 AUTO_ROUTER_MODEL_PREFIX: Final = "auto_router/"
 
-StrategyRouterKind = Literal["semantic", "complexity", "adaptive", "quality"]
+StrategyRouterKind = Literal["semantic", "complexity", "capability", "adaptive", "quality"]
 
-StrategyRouterDependencyRole: TypeAlias = Literal["tier", "default", "classifier", "embedding"]
+StrategyRouterDependencyRole: TypeAlias = Literal["tier", "candidate", "default", "classifier", "embedding"]
 
 
 @dataclass(frozen=True, slots=True)
@@ -44,6 +44,7 @@ STRATEGY_ROUTER_PARAM_FIELDS: Final[frozenset[str]] = frozenset(
         "auto_router_max_input_chars",
         "complexity_router_config",
         "complexity_router_default_model",
+        "capability_router_config",
         "adaptive_router_config",
         "quality_router_config",
         "quality_router_default_model",
@@ -57,6 +58,7 @@ _REQUIRED_FIELD_GROUPS: Final[Mapping[StrategyRouterKind, tuple[tuple[str, ...],
         ("auto_router_embedding_model",),
     ),
     "complexity": (("complexity_router_config", "complexity_router_default_model"),),
+    "capability": (("capability_router_config",),),
     "adaptive": (("adaptive_router_config",),),
     "quality": (("quality_router_config", "quality_router_default_model"),),
 }
@@ -74,6 +76,8 @@ def classify_strategy_router_model(model: str) -> StrategyRouterKind | None:
     remainder: Final = model[len(AUTO_ROUTER_MODEL_PREFIX) :]
     if remainder.startswith("complexity_router"):
         return "complexity"
+    if remainder.startswith("capability_router"):
+        return "capability"
     if remainder.startswith("adaptive_router"):
         return "adaptive"
     if remainder.startswith("quality_router"):
@@ -143,6 +147,26 @@ def strategy_router_dependencies(
                 )
             )
         )
+    if kind == "capability":
+        capability = _mapping(litellm_params.get("capability_router_config"))
+        classifier = _mapping(capability.get("classifier"))
+        candidates = capability.get("candidates")
+        candidate_dependencies = (
+            tuple(
+                dependency
+                for candidate in candidates
+                for dependency in _named(_mapping(candidate).get("model"), "candidate")
+            )
+            if isinstance(candidates, Sequence) and not isinstance(candidates, (str, bytes))
+            else ()
+        )
+        return tuple(
+            dict.fromkeys(
+                candidate_dependencies
+                + _named(capability.get("fallback_model"), "default")
+                + _named(classifier.get("model"), "classifier")
+            )
+        )
     complexity: Final = _mapping(litellm_params.get("complexity_router_config"))
     classifier: Final = _mapping(complexity.get("classifier_llm_config"))
     return tuple(
@@ -188,6 +212,23 @@ def validate_complexity_router_config_write(complexity_router_config: Mapping[st
             f"complexity_router_config is invalid at {location}: {first.get('msg', 'invalid value')}. "
             "The router would drop this deployment at load time, so the write is rejected instead."
         )
+    return None
+
+
+def validate_capability_router_config_write(capability_router_config: Mapping[str, object] | None) -> str | None:
+    """Reject a capability config the router itself would reject."""
+    from pydantic import ValidationError
+
+    from litellm.router_strategy.capability_router.config import CapabilityRouterConfig
+
+    if capability_router_config is None:
+        return None
+    try:
+        _ = CapabilityRouterConfig.model_validate(capability_router_config)
+    except ValidationError as exc:
+        first = exc.errors()[0]
+        location = ".".join(str(part) for part in first.get("loc", ())) or "capability_router_config"
+        return f"capability_router_config is invalid at {location}: {first.get('msg', 'invalid value')}"
     return None
 
 

--- a/litellm/types/management_endpoints/auto_router_endpoints.py
+++ b/litellm/types/management_endpoints/auto_router_endpoints.py
@@ -9,6 +9,7 @@ from typing import Final, Literal, TypeAlias
 
 from pydantic import BaseModel, Field, computed_field, field_validator, model_validator
 
+from litellm.router_strategy.capability_router.config import CapabilityRouterConfig
 from litellm.router_strategy.complexity_router.config import ComplexityRouterConfig
 from litellm.types.utils import StandardLoggingRoutingDecision
 
@@ -44,6 +45,18 @@ class ComplexityRouterConfigValidationResponse(BaseModel):
     error: str | None = None
 
 
+class CapabilityRouterConfigValidationRequest(BaseModel):
+    """A capability-router config to validate without saving."""
+
+    capability_router_config: Mapping[str, object]
+    team_id: str | None = None
+
+
+class CapabilityRouterConfigValidationResponse(BaseModel):
+    valid: bool
+    error: str | None = None
+
+
 class AutoRouterRoutingTestRequest(BaseModel):
     """A single request to classify against a complexity-router config that need not be saved yet.
 
@@ -69,8 +82,13 @@ class AutoRouterRoutingTestRequest(BaseModel):
         default=None,
         description="The tool definitions the request advertises, which decide whether the plan-mode floor applies",
     )
-    complexity_router_config: RequestComplexityRouterConfig = Field(
-        description="The complexity router config to route against, in the shape /model/new accepts",
+    complexity_router_config: RequestComplexityRouterConfig | None = Field(
+        default=None,
+        description="The complexity router config to route against",
+    )
+    capability_router_config: CapabilityRouterConfig | None = Field(
+        default=None,
+        description="The capability router config to route against",
     )
     default_model: str | None = Field(
         default=None,
@@ -114,6 +132,8 @@ class AutoRouterRoutingTestRequest(BaseModel):
             raise ValueError("messages must not be empty")
         if (self.prompt is None) == (self.messages is None):
             raise ValueError("provide exactly one of prompt or messages")
+        if (self.complexity_router_config is None) == (self.capability_router_config is None):
+            raise ValueError("provide exactly one router config")
         if self.messages is not None:
             return self
         return self.model_copy(

--- a/litellm/types/router.py
+++ b/litellm/types/router.py
@@ -348,6 +348,9 @@ class GenericLiteLLMParams(CredentialLiteLLMParams, CustomPricingLiteLLMParams):
     complexity_router_config: dict | None = None
     complexity_router_default_model: str | None = None
 
+    # capability-router params
+    capability_router_config: dict | None = None
+
     # adaptive-router params
     adaptive_router_default_model: str | None = None
     adaptive_router_config: dict | None = None

--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -2888,6 +2888,9 @@ RoutingDecisionCause = Literal[
     "keyword",
     "quality_tier",
     "bandit",
+    "capability_classifier",
+    "capability_cache",
+    "capability_fallback",
 ]
 
 
@@ -2910,7 +2913,7 @@ class StandardLoggingRoutingDecision(TypedDict, total=False):
     """Per-request provenance for a pre-routing strategy (auto-router) decision."""
 
     router_model_name: str
-    router_type: Literal["complexity", "adaptive", "quality"]
+    router_type: Literal["complexity", "adaptive", "quality", "capability"]
     routed_model: str
     cause: RoutingDecisionCause
     tier: str
@@ -2931,6 +2934,12 @@ class StandardLoggingRoutingDecision(TypedDict, total=False):
     savings_baseline_model: str
     savings_baseline_deployment_id: str
     tier_litellm_params: Mapping[str, object]  # writable-ok: Pydantic warns on ReadOnly TypedDict fields
+    probability_threshold: float
+    candidate_probabilities: Mapping[str, float]
+    candidate_costs: Mapping[str, float]
+    qualified_models: Sequence[str]
+    fallback_reason: str | None
+    cached: bool
 
 
 # Fields whose values quote the caller's prompt. Dropped when an operator turns message
@@ -2959,6 +2968,12 @@ DERIVED_ROUTING_DECISION_FIELDS: Final[frozenset[str]] = frozenset(
         "savings_baseline_model",
         "savings_baseline_deployment_id",
         "tier_litellm_params",
+        "probability_threshold",
+        "candidate_probabilities",
+        "candidate_costs",
+        "qualified_models",
+        "fallback_reason",
+        "cached",
     }
 )
 
@@ -3703,6 +3718,7 @@ all_litellm_params = (
         "auto_router_max_input_chars",
         "complexity_router_config",
         "complexity_router_default_model",
+        "capability_router_config",
         "adaptive_router_config",
         "adaptive_router_default_model",
         "quality_router_config",

--- a/tests/test_litellm/proxy/auth/test_route_checks.py
+++ b/tests/test_litellm/proxy/auth/test_route_checks.py
@@ -2,7 +2,6 @@ import os
 from datetime import datetime
 from unittest.mock import MagicMock, patch
 
-
 import pytest
 from fastapi import HTTPException, Request
 
@@ -803,7 +802,7 @@ def test_google_routes_with_dynamic_model_names_accessible_to_internal_users():
         # If no exception is raised, the test passes
     except Exception as e:
         pytest.fail(
-            f"Internal user should be able to access Google generateContent route. Got error: {str(e)}"
+            f"Internal user should be able to access Google generateContent route. Got error: {e!s}"
         )
 
 
@@ -1703,7 +1702,7 @@ def test_videos_route_accessible_to_internal_users():
         # If no exception is raised, the test passes
     except Exception as e:
         pytest.fail(
-            f"Internal user should be able to access /v1/videos route. Got error: {str(e)}"
+            f"Internal user should be able to access /v1/videos route. Got error: {e!s}"
         )
 
 
@@ -1803,7 +1802,7 @@ def test_proxy_admin_viewer_can_access_global_spend_tags():
         # If no exception is raised, the test passes
     except Exception as e:
         pytest.fail(
-            f"proxy_admin_viewer should be able to access /global/spend/tags route. Got error: {str(e)}"
+            f"proxy_admin_viewer should be able to access /global/spend/tags route. Got error: {e!s}"
         )
 
 
@@ -1964,7 +1963,7 @@ def test_proxy_admin_viewer_can_access_audit_logs(route):
         )
     except Exception as e:
         pytest.fail(
-            f"proxy_admin_viewer should be able to access {route} route. Got error: {str(e)}"
+            f"proxy_admin_viewer should be able to access {route} route. Got error: {e!s}"
         )
 
 
@@ -2029,7 +2028,7 @@ def test_proxy_admin_viewer_can_access_logs_page_endpoints(route):
         )
     except Exception as e:
         pytest.fail(
-            f"proxy_admin_viewer should be able to access {route}. Got error: {str(e)}"
+            f"proxy_admin_viewer should be able to access {route}. Got error: {e!s}"
         )
 
 
@@ -2141,7 +2140,7 @@ def test_proxy_admin_viewer_can_access_settings_read_endpoints(route):
         )
     except Exception as e:
         pytest.fail(
-            f"proxy_admin_viewer should be able to access {route}. Got error: {str(e)}"
+            f"proxy_admin_viewer should be able to access {route}. Got error: {e!s}"
         )
 
 
@@ -3407,7 +3406,11 @@ def test_organization_daily_activity_not_granted_by_org_admin_request_data_branc
 )
 @pytest.mark.parametrize(
     "dry_run_route",
-    ["/auto_router/test_routing", "/auto_router/validate_complexity_router_config"],
+    [
+        "/auto_router/test_routing",
+        "/auto_router/validate_complexity_router_config",
+        "/auto_router/validate_capability_router_config",
+    ],
 )
 def test_auto_router_dry_runs_share_model_new_audience(user_role, dry_run_route):
     """The dry runs serve whoever can draft a save on /model/new, no one else: a role

--- a/tests/test_litellm/proxy/management_endpoints/test_capability_router_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_capability_router_endpoints.py
@@ -1,0 +1,60 @@
+import pytest
+from pydantic import ValidationError
+
+from litellm.proxy._types import LitellmUserRoles, UserAPIKeyAuth
+from litellm.proxy.management_endpoints.auto_router_endpoints import validate_capability_router_config
+from litellm.types.management_endpoints.auto_router_endpoints import (
+    AutoRouterRoutingTestRequest,
+    CapabilityRouterConfigValidationRequest,
+)
+
+
+def config() -> dict:
+    return {
+        "candidates": [
+            {"model": "small", "description": "Reliable for short extraction tasks"},
+            {"model": "frontier", "description": "Reliable for ambiguous multi-step tasks"},
+        ],
+        "classifier": {"model": "classifier"},
+        "probability_threshold": 0.7,
+        "fallback_model": "frontier",
+    }
+
+
+def test_routing_preview_accepts_exactly_one_router_config() -> None:
+    request = AutoRouterRoutingTestRequest.model_validate(
+        {"prompt": "Extract the invoice number", "capability_router_config": config()}
+    )
+    assert request.capability_router_config is not None
+    assert request.complexity_router_config is None
+
+    with pytest.raises(ValidationError, match="exactly one router config"):
+        AutoRouterRoutingTestRequest.model_validate(
+            {
+                "prompt": "Extract the invoice number",
+                "capability_router_config": config(),
+                "complexity_router_config": {
+                    "tiers": {"SIMPLE": "small"},
+                    "classifier_type": "heuristic",
+                },
+            }
+        )
+
+
+@pytest.mark.asyncio
+async def test_validation_endpoint_uses_runtime_config_contract() -> None:
+    admin = UserAPIKeyAuth(user_role=LitellmUserRoles.PROXY_ADMIN, api_key="admin")
+    accepted = await validate_capability_router_config(
+        CapabilityRouterConfigValidationRequest(capability_router_config=config()),
+        admin,
+    )
+    rejected = await validate_capability_router_config(
+        CapabilityRouterConfigValidationRequest(
+            capability_router_config={**config(), "fallback_model": "missing"}
+        ),
+        admin,
+    )
+
+    assert accepted.valid is True
+    assert rejected.valid is False
+    assert rejected.error is not None and "fallback_model" in rejected.error

--- a/tests/test_litellm/router_strategy/capability_router/test_capability_router.py
+++ b/tests/test_litellm/router_strategy/capability_router/test_capability_router.py
@@ -84,6 +84,22 @@ def test_policy_falls_back_if_no_model_qualifies_or_price_is_unknown() -> None:
     )
 
 
+def test_probability_must_be_strictly_above_threshold() -> None:
+    parsed = CapabilityRouterConfig.model_validate(config())
+    verdict = CapabilityClassifierVerdict.model_validate(
+        {
+            "candidates": [
+                {"model": "small", "p_solve": 0.7, "reason": "on the boundary"},
+                {"model": "frontier", "p_solve": 0.7, "reason": "on the boundary"},
+            ]
+        }
+    )
+
+    assert select_capability_model(parsed, verdict, {"small": 0.01, "frontier": 0.05}).reason == (
+        "no_qualified_candidate"
+    )
+
+
 def test_router_registers_capability_strategy() -> None:
     router = Router(
         model_list=[

--- a/tests/test_litellm/router_strategy/capability_router/test_capability_router.py
+++ b/tests/test_litellm/router_strategy/capability_router/test_capability_router.py
@@ -1,0 +1,140 @@
+from unittest.mock import AsyncMock
+
+import pytest
+from pydantic import ValidationError
+
+from litellm.router import Router
+from litellm.router_strategy.capability_router.capability_router import CapabilityRouter
+from litellm.router_strategy.capability_router.config import (
+    CapabilityClassifierVerdict,
+    CapabilityRouterConfig,
+)
+from litellm.router_strategy.capability_router.policy import select_capability_model
+
+
+def config() -> dict:
+    return {
+        "candidates": [
+            {"model": "small", "description": "Reliable for short extraction tasks"},
+            {"model": "frontier", "description": "Reliable for ambiguous multi-step tasks"},
+        ],
+        "classifier": {"model": "classifier"},
+        "probability_threshold": 0.7,
+        "fallback_model": "frontier",
+        "cache_ttl_seconds": 60,
+    }
+
+
+def test_config_requires_unique_candidates_and_candidate_fallback() -> None:
+    duplicate = config()
+    duplicate["candidates"] = [
+        {"model": "small", "description": "one"},
+        {"model": "small", "description": "two"},
+    ]
+    with pytest.raises(ValidationError, match="unique"):
+        CapabilityRouterConfig.model_validate(duplicate)
+
+    missing_fallback = config()
+    missing_fallback["fallback_model"] = "other"
+    with pytest.raises(ValidationError, match="one of the candidate"):
+        CapabilityRouterConfig.model_validate(missing_fallback)
+
+
+def test_policy_selects_cheapest_model_above_global_threshold() -> None:
+    parsed = CapabilityRouterConfig.model_validate(config())
+    verdict = CapabilityClassifierVerdict.model_validate(
+        {
+            "candidates": [
+                {"model": "small", "p_solve": 0.78, "reason": "clear bounded task"},
+                {"model": "frontier", "p_solve": 0.95, "reason": "more capable"},
+            ]
+        }
+    )
+
+    decision = select_capability_model(parsed, verdict, {"small": 0.01, "frontier": 0.05})
+
+    assert decision.selected_model == "small"
+    assert decision.reason == "cheapest_qualified"
+    assert [candidate.qualified for candidate in decision.candidates] == [True, True]
+
+
+def test_policy_falls_back_if_no_model_qualifies_or_price_is_unknown() -> None:
+    parsed = CapabilityRouterConfig.model_validate(config())
+    verdict = CapabilityClassifierVerdict.model_validate(
+        {
+            "candidates": [
+                {"model": "small", "p_solve": 0.4, "reason": "too hard"},
+                {"model": "frontier", "p_solve": 0.6, "reason": "uncertain"},
+            ]
+        }
+    )
+    assert select_capability_model(parsed, verdict, {"small": 0.01, "frontier": 0.05}).reason == (
+        "no_qualified_candidate"
+    )
+
+    qualified = verdict.model_copy(
+        update={
+            "candidates": tuple(
+                candidate.model_copy(update={"p_solve": 0.9}) for candidate in verdict.candidates
+            )
+        }
+    )
+    assert select_capability_model(parsed, qualified, {"small": None, "frontier": 0.05}).reason == (
+        "missing_candidate_price"
+    )
+
+
+def test_router_registers_capability_strategy() -> None:
+    router = Router(
+        model_list=[
+            {"model_name": "small", "litellm_params": {"model": "openai/test-small"}},
+            {"model_name": "frontier", "litellm_params": {"model": "openai/test-frontier"}},
+            {"model_name": "classifier", "litellm_params": {"model": "openai/test-classifier"}},
+            {
+                "model_name": "cost-router",
+                "litellm_params": {
+                    "model": "auto_router/capability_router",
+                    "capability_router_config": config(),
+                },
+            },
+        ]
+    )
+
+    assert len(router.capability_routers["cost-router"]) == 1
+
+
+@pytest.mark.asyncio
+async def test_same_user_turn_reuses_cached_decision() -> None:
+    router = Router(model_list=[])
+    strategy = CapabilityRouter("cost-router", router, config())
+    strategy._new_decision = AsyncMock(  # type: ignore[method-assign]
+        return_value=(
+            select_capability_model(
+                strategy.config,
+                CapabilityClassifierVerdict.model_validate(
+                    {
+                        "candidates": [
+                            {"model": "small", "p_solve": 0.9, "reason": "fits"},
+                            {"model": "frontier", "p_solve": 0.95, "reason": "fits"},
+                        ]
+                    }
+                ),
+                {"small": 0.01, "frontier": 0.05},
+            ),
+            0.001,
+        )
+    )
+    messages = [{"role": "user", "content": "Extract the invoice number"}]
+    kwargs = {"messages": messages, "metadata": {"user_api_key_hash": "key", "session_id": "session"}}
+
+    first = await strategy.async_pre_routing_hook("cost-router", kwargs, messages)
+    second = await strategy.async_pre_routing_hook(
+        "cost-router",
+        {**kwargs, "messages": [*messages, {"role": "assistant", "content": "calling tool"}]},
+        [*messages, {"role": "assistant", "content": "calling tool"}],
+    )
+
+    assert first.model == second.model == "small"
+    assert first.routing_decision is not None and first.routing_decision["cached"] is False
+    assert second.routing_decision is not None and second.routing_decision["cached"] is True
+    strategy._new_decision.assert_awaited_once()

--- a/ui/litellm-dashboard/src/app/(dashboard)/hooks/models/useModels.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/hooks/models/useModels.ts
@@ -92,6 +92,7 @@ export interface AutoRouterDeployment extends AutoRouterCandidateDeployment {
     model?: string | null;
     complexity_router_config?: unknown;
     complexity_router_default_model?: string | null;
+    capability_router_config?: unknown;
     auto_router_config?: unknown;
     auto_router_default_model?: string | null;
     auto_router_embedding_model?: string | null;

--- a/ui/litellm-dashboard/src/app/(dashboard)/models-and-endpoints/components/AutoRouters/autoRouterRows.test.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/models-and-endpoints/components/AutoRouters/autoRouterRows.test.ts
@@ -42,6 +42,32 @@ const semanticDeployment = {
 };
 
 describe("autoRouterRows", () => {
+  it("classifies a capability router and lists its candidate models", () => {
+    const row = toAutoRouterRow(
+      {
+        model_name: "cost-router",
+        litellm_params: {
+          model: "auto_router/capability_router",
+          capability_router_config: {
+            candidates: [
+              { model: "small", description: "bounded tasks" },
+              { model: "frontier", description: "hard tasks" },
+            ],
+          },
+        },
+        model_info: { id: "cap-1", db_model: true },
+      },
+      0,
+      ADMIN,
+      null,
+    );
+
+    expect(row.kind).toBe("capability");
+    expect(row.typeLabel).toBe("Capability");
+    expect(row.targets).toEqual(["small", "frontier"]);
+    expect(row.canEdit).toBe(true);
+  });
+
   it("classifies a complexity router and unions its tier models as targets", () => {
     const row = toAutoRouterRow(complexityDeployment, 0, ADMIN, null);
 

--- a/ui/litellm-dashboard/src/app/(dashboard)/models-and-endpoints/components/AutoRouters/autoRouterRows.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/models-and-endpoints/components/AutoRouters/autoRouterRows.ts
@@ -78,6 +78,14 @@ const configManaged = (label: string, config: Record<string, unknown>): Presenta
 
 /** How each strategy renders itself, given its own config object. */
 const PRESENTERS: Record<AutoRouterKind, (config: Record<string, unknown>) => Presentation> = {
+  capability: (config) => ({
+    typeLabel: "Capability",
+    targets: dedupe(
+      (Array.isArray(config.candidates) ? config.candidates : [])
+        .map((candidate) => asRecord(candidate).model)
+        .filter((model): model is string => typeof model === "string" && model.length > 0),
+    ),
+  }),
   complexity: (config) => ({
     typeLabel: complexityTypeLabel(config),
     targets: dedupe(Object.values(asRecord(config.tiers)).flatMap(normalizeTierModels)),
@@ -115,7 +123,9 @@ export const toAutoRouterRow = (
     canDelete: canDelete && mayActOnRow,
     editBlockedReason,
     createdAt: info.created_at ?? undefined,
-    defaultModel: (params[strategy.defaultModelKey] as string | null | undefined) ?? null,
+    defaultModel: strategy.defaultModelKey
+      ? (params[strategy.defaultModelKey] as string | null | undefined) ?? null
+      : null,
     deployment,
     ...PRESENTERS[strategy.kind](asRecord(params[strategy.configKey])),
   };

--- a/ui/litellm-dashboard/src/components/add_model/AutoRouterRoutingTest.tsx
+++ b/ui/litellm-dashboard/src/components/add_model/AutoRouterRoutingTest.tsx
@@ -7,10 +7,12 @@ import RoutingDecisionCard from "@/components/view_logs/LogDetailsDrawer/Routing
 import { AutoRouterRoutingTestResult, testAutoRouterRouting } from "../networking";
 import { ComplexityRouterConfigPayload } from "./build_complexity_router_config";
 import { buildAutoRouterRoutingTestRequest } from "./build_auto_router_routing_test_request";
+import { CapabilityRouterConfigValue } from "./capability_router_config";
 
 interface AutoRouterRoutingTestProps {
   accessToken: string;
-  config: ComplexityRouterConfigPayload;
+  config?: ComplexityRouterConfigPayload;
+  capabilityConfig?: CapabilityRouterConfigValue;
   defaultModel: string | undefined;
   routerName: string | undefined;
   teamId: string | undefined;
@@ -25,6 +27,7 @@ type TestState =
 const AutoRouterRoutingTest: React.FC<AutoRouterRoutingTestProps> = ({
   accessToken,
   config,
+  capabilityConfig,
   defaultModel,
   routerName,
   teamId,
@@ -34,7 +37,7 @@ const AutoRouterRoutingTest: React.FC<AutoRouterRoutingTestProps> = ({
 
   const send = async () => {
     setState({ status: "running" });
-    const params = { prompt, config, defaultModel, routerName, teamId };
+    const params = { prompt, config, capabilityConfig, defaultModel, routerName, teamId };
     const request = buildAutoRouterRoutingTestRequest(params);
     const response = await testAutoRouterRouting(accessToken, request);
     setState(

--- a/ui/litellm-dashboard/src/components/add_model/CapabilityRouterConfig.tsx
+++ b/ui/litellm-dashboard/src/components/add_model/CapabilityRouterConfig.tsx
@@ -1,0 +1,151 @@
+import React from "react";
+import { Plus, Trash2 } from "lucide-react";
+
+import { type ModelGroup } from "@/components/llm_calls/fetch_models";
+import { SearchSelect } from "@/components/shared/SearchSelect";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { type CapabilityRouterConfigValue } from "./capability_router_config";
+
+interface Props {
+  modelInfo: ModelGroup[];
+  value: CapabilityRouterConfigValue;
+  onChange: (value: CapabilityRouterConfigValue) => void;
+}
+
+const CapabilityRouterConfig: React.FC<Props> = ({ modelInfo, value, onChange }) => {
+  const options = React.useMemo(
+    () =>
+      Array.from(new Set(modelInfo.filter((model) => model.mode !== "embedding").map((model) => model.model_group)))
+        .filter((model) => !model.startsWith("auto_router/"))
+        .map((model) => ({ value: model, label: model })),
+    [modelInfo],
+  );
+
+  const updateCandidate = (index: number, patch: Partial<CapabilityRouterConfigValue["candidates"][number]>) => {
+    const previousModel = value.candidates[index]?.model;
+    const candidates = value.candidates.map((candidate, row) =>
+      row === index ? { ...candidate, ...patch } : candidate,
+    );
+    const fallback_model =
+      previousModel === value.fallback_model && patch.model !== undefined ? patch.model : value.fallback_model;
+    onChange({ ...value, candidates, fallback_model });
+  };
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h3 className="text-base font-semibold">Candidate models</h3>
+        <p className="text-sm text-muted-foreground">
+          Describe the tasks each model can reliably complete. Price is calculated separately.
+        </p>
+      </div>
+      {value.candidates.map((candidate, index) => (
+        <div key={index} className="space-y-3 rounded-lg border border-border p-4">
+          <div className="flex items-center justify-between">
+            <Label>Candidate {index + 1}</Label>
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon-sm"
+              disabled={value.candidates.length <= 2}
+              aria-label={`Remove candidate ${index + 1}`}
+              onClick={() => {
+                const candidates = value.candidates.filter((_, row) => row !== index);
+                onChange({
+                  ...value,
+                  candidates,
+                  fallback_model: candidates.some((item) => item.model === value.fallback_model)
+                    ? value.fallback_model
+                    : candidates[0]?.model ?? "",
+                });
+              }}
+            >
+              <Trash2 />
+            </Button>
+          </div>
+          <SearchSelect
+            options={options.filter(
+              (option) =>
+                option.value === candidate.model ||
+                !value.candidates.some((item, row) => row !== index && item.model === option.value),
+            )}
+            value={candidate.model}
+            onValueChange={(model) => updateCandidate(index, { model })}
+            placeholder="Select a model group"
+            emptyText="No models found"
+          />
+          <Textarea
+            value={candidate.description}
+            onChange={(event) => updateCandidate(index, { description: event.target.value })}
+            placeholder="Example: Fast and reliable for extraction, summarization, and bounded code edits; weaker on long-horizon debugging."
+            rows={3}
+          />
+        </div>
+      ))}
+      <Button
+        type="button"
+        variant="outline"
+        onClick={() => onChange({ ...value, candidates: [...value.candidates, { model: "", description: "" }] })}
+      >
+        <Plus /> Add candidate
+      </Button>
+
+      <div className="grid gap-4 md:grid-cols-2">
+        <div className="space-y-2">
+          <Label>Classifier model</Label>
+          <SearchSelect
+            options={options}
+            value={value.classifier.model}
+            onValueChange={(model) => onChange({ ...value, classifier: { ...value.classifier, model } })}
+            placeholder="Select classifier"
+            emptyText="No models found"
+          />
+        </div>
+        <div className="space-y-2">
+          <Label>Fallback model</Label>
+          <SearchSelect
+            options={value.candidates
+              .filter((candidate) => candidate.model)
+              .map((candidate) => ({ value: candidate.model, label: candidate.model }))}
+            value={value.fallback_model}
+            onValueChange={(fallback_model) => onChange({ ...value, fallback_model })}
+            placeholder="Select fallback"
+            emptyText="Select candidates first"
+          />
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor="capability-probability-threshold">Probability threshold</Label>
+          <Input
+            id="capability-probability-threshold"
+            type="number"
+            min={0}
+            max={1}
+            step={0.05}
+            value={value.probability_threshold}
+            onChange={(event) => onChange({ ...value, probability_threshold: Number(event.target.value) })}
+          />
+          <p className="text-xs text-muted-foreground">
+            Higher values favor reliability; lower values favor cost savings.
+          </p>
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor="capability-cache-ttl">Decision cache TTL (seconds)</Label>
+          <Input
+            id="capability-cache-ttl"
+            type="number"
+            min={1}
+            step={1}
+            value={value.cache_ttl_seconds}
+            onChange={(event) => onChange({ ...value, cache_ttl_seconds: Number(event.target.value) })}
+          />
+          <p className="text-xs text-muted-foreground">Reuses the decision for repeated calls in the same user turn.</p>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default CapabilityRouterConfig;

--- a/ui/litellm-dashboard/src/components/add_model/add_auto_router_tab.tsx
+++ b/ui/litellm-dashboard/src/components/add_model/add_auto_router_tab.tsx
@@ -48,6 +48,12 @@ import { tierRowLabel } from "./complexity_router_tiers";
 import { buildAutoRouterTestTargets, AutoRouterTestTarget } from "./build_auto_router_test_targets";
 import AutoRouterConnectionTest from "./auto_router_connection_test";
 import AutoRouterRoutingTest from "./AutoRouterRoutingTest";
+import CapabilityRouterConfig from "./CapabilityRouterConfig";
+import {
+  capabilityRouterConfigError,
+  defaultCapabilityRouterConfig,
+  type CapabilityRouterConfigValue,
+} from "./capability_router_config";
 import { toast } from "@/lib/toast";
 import {
   getAllPresets,
@@ -180,6 +186,9 @@ const AddAutoRouterTab: React.FC<AddAutoRouterTabProps> = ({
     tiers: { SIMPLE: [], MEDIUM: [], COMPLEX: [], REASONING: [] },
     classifier_type: "heuristic",
   });
+  const [routerKind, setRouterKind] = useState<"complexity" | "capability">("complexity");
+  const [capabilityRouterConfig, setCapabilityRouterConfig] =
+    useState<CapabilityRouterConfigValue>(defaultCapabilityRouterConfig);
 
   const [customTechnicalKeywords, setCustomTechnicalKeywords] = useState<string[]>([]);
   const [keywordTierRules, setKeywordTierRules] = useState<KeywordTierRule[]>([]);
@@ -328,12 +337,15 @@ const AddAutoRouterTab: React.FC<AddAutoRouterTabProps> = ({
     defaultModel: complexityRouterConfig.default_model,
   };
 
-  const submitBlockedReason = getSubmitBlockedReason(
-    complexityRouterConfig,
-    keywordTierRules,
-    referencedModelsParams,
-    groupsOnlyAvailability,
-  );
+  const submitBlockedReason =
+    routerKind === "capability"
+      ? capabilityRouterConfigError(capabilityRouterConfig)
+      : getSubmitBlockedReason(
+          complexityRouterConfig,
+          keywordTierRules,
+          referencedModelsParams,
+          groupsOnlyAvailability,
+        );
 
   const complexityRouterConfigParams: BuildComplexityRouterConfigParams = {
     tiers: complexityRouterConfig.tiers,
@@ -441,21 +453,68 @@ const AddAutoRouterTab: React.FC<AddAutoRouterTabProps> = ({
 
     setIsSubmitting(true);
     try {
-      await submitRecommendedRouter(name);
+      if (routerKind === "capability") {
+        const blockedReason = capabilityRouterConfigError(capabilityRouterConfig);
+        if (blockedReason) {
+          toast.fromError(blockedReason);
+          return;
+        }
+        if (!(await form.trigger(requiresTeamScope ? ["auto_router_name", "team_id"] : ["auto_router_name"]))) {
+          return;
+        }
+        const serverVerdict = await validateAutoRouterConfig(
+          accessToken,
+          capabilityRouterConfig as unknown as Record<string, unknown>,
+          requiresTeamScope ? form.getValues("team_id") : undefined,
+          "capability",
+        );
+        const dryRunError = dryRunRejection(serverVerdict);
+        if (dryRunError) {
+          toast.fromError(dryRunError);
+          return;
+        }
+        await handleAddAutoRouterSubmit(
+          {
+            auto_router_name: name,
+            ...teamScopePayload(requiresTeamScope, form.getValues("team_id")),
+            model_type: "capability_router",
+            capability_router_config: capabilityRouterConfig,
+            model_access_group: form.getValues("model_access_group"),
+          },
+          accessToken,
+          () => form.reset(EMPTY_FORM_VALUES),
+          handleOk,
+        );
+      } else {
+        await submitRecommendedRouter(name);
+      }
     } finally {
       setIsSubmitting(false);
     }
   };
 
   const handleTestConnection = () => {
-    const testTargetParams = {
-      tiers: activeTierRows(complexityRouterConfig).map(
-        (row) => [activeTierName(row), row.models] as [string, string[]],
-      ),
-      semanticMatchingEnabled,
-      embeddingModel,
-      defaultModel: resolveComplexityDefaultModel(complexityRouterConfig, complexityRouterConfig.default_model),
-    };
+    const testTargetParams =
+      routerKind === "capability"
+        ? {
+            tiers: [
+              ["Candidates", capabilityRouterConfig.candidates.map((candidate) => candidate.model).filter(Boolean)] as [
+                string,
+                string[],
+              ],
+            ],
+            semanticMatchingEnabled: false,
+            embeddingModel: undefined,
+            defaultModel: capabilityRouterConfig.fallback_model,
+          }
+        : {
+            tiers: activeTierRows(complexityRouterConfig).map(
+              (row) => [activeTierName(row), row.models] as [string, string[]],
+            ),
+            semanticMatchingEnabled,
+            embeddingModel,
+            defaultModel: resolveComplexityDefaultModel(complexityRouterConfig, complexityRouterConfig.default_model),
+          };
     const targets = buildAutoRouterTestTargets(testTargetParams);
 
     if (targets.length === 0) {
@@ -483,61 +542,90 @@ const AddAutoRouterTab: React.FC<AddAutoRouterTabProps> = ({
                 {({ ref, ...field }) => <Input {...field} ref={ref} placeholder="e.g., smart_router, auto_router_1" />}
               </FormField>
 
-              <div>
-                <label className="block text-sm font-medium text-foreground mb-2">Template</label>
+              <div className="space-y-2">
+                <label className="block text-sm font-medium text-foreground">Router type</label>
                 <Select
-                  items={templateItems}
-                  value={selectedPreset ?? null}
-                  onValueChange={(presetKey: string | null) => handlePresetChange(presetKey ?? undefined)}
+                  value={routerKind}
+                  onValueChange={(value: string | null) =>
+                    setRouterKind(value === "capability" ? "capability" : "complexity")
+                  }
                 >
-                  <SelectTrigger data-testid="template-selector" className="w-full">
-                    <SelectValue placeholder="Choose a template or select Custom to define your own" />
+                  <SelectTrigger className="w-full" data-testid="router-type-selector">
+                    <SelectValue />
                   </SelectTrigger>
                   <SelectContent>
-                    {sortedPresetOptions.map(({ preset, availability: presetState }) => {
-                      const disabledHint = presetDisabledHint(presetState);
-                      const hintClass = isPresetHintAlarming(presetState)
-                        ? "text-destructive"
-                        : "text-muted-foreground";
-                      const matchedHint =
-                        presetState.kind === "available" && presetState.viaDeployments
-                          ? "Matches your deployments"
-                          : null;
-
-                      return (
-                        <SelectItem
-                          key={preset.key}
-                          value={preset.key}
-                          label={preset.label}
-                          disabled={disabledHint !== null}
-                          title={disabledHint ?? preset.description}
-                        >
-                          <div>
-                            <div className="font-medium">{preset.label}</div>
-                            <div className="text-xs text-muted-foreground">{preset.description}</div>
-                            {disabledHint && <div className={`text-xs mt-1 ${hintClass}`}>{disabledHint}</div>}
-                            {matchedHint && <div className="text-xs mt-1 text-success">{matchedHint}</div>}
-                          </div>
-                        </SelectItem>
-                      );
-                    })}
-                    <SelectItem value="custom" label="Custom Configuration">
-                      <div>
-                        <div className="font-medium">Custom Configuration</div>
-                        <div className="text-xs text-muted-foreground">Define your auto router from scratch</div>
-                      </div>
+                    <SelectItem value="complexity" label="Complexity">
+                      Complexity
+                    </SelectItem>
+                    <SelectItem value="capability" label="Capability">
+                      Capability
                     </SelectItem>
                   </SelectContent>
                 </Select>
-                {modelsUnverifiable && (
-                  <div className="text-xs mt-1 text-destructive">
-                    Could not load available models.{" "}
-                    <button type="button" className="underline" onClick={() => refetchModels()}>
-                      Retry
-                    </button>
-                  </div>
-                )}
+                <p className="text-xs text-muted-foreground">
+                  {routerKind === "capability"
+                    ? "Estimate each model's probability of success, then choose the cheapest model above your threshold."
+                    : "Route requests by estimated task complexity."}
+                </p>
               </div>
+
+              {routerKind === "complexity" && (
+                <div>
+                  <label className="block text-sm font-medium text-foreground mb-2">Template</label>
+                  <Select
+                    items={templateItems}
+                    value={selectedPreset ?? null}
+                    onValueChange={(presetKey: string | null) => handlePresetChange(presetKey ?? undefined)}
+                  >
+                    <SelectTrigger data-testid="template-selector" className="w-full">
+                      <SelectValue placeholder="Choose a template or select Custom to define your own" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {sortedPresetOptions.map(({ preset, availability: presetState }) => {
+                        const disabledHint = presetDisabledHint(presetState);
+                        const hintClass = isPresetHintAlarming(presetState)
+                          ? "text-destructive"
+                          : "text-muted-foreground";
+                        const matchedHint =
+                          presetState.kind === "available" && presetState.viaDeployments
+                            ? "Matches your deployments"
+                            : null;
+
+                        return (
+                          <SelectItem
+                            key={preset.key}
+                            value={preset.key}
+                            label={preset.label}
+                            disabled={disabledHint !== null}
+                            title={disabledHint ?? preset.description}
+                          >
+                            <div>
+                              <div className="font-medium">{preset.label}</div>
+                              <div className="text-xs text-muted-foreground">{preset.description}</div>
+                              {disabledHint && <div className={`text-xs mt-1 ${hintClass}`}>{disabledHint}</div>}
+                              {matchedHint && <div className="text-xs mt-1 text-success">{matchedHint}</div>}
+                            </div>
+                          </SelectItem>
+                        );
+                      })}
+                      <SelectItem value="custom" label="Custom Configuration">
+                        <div>
+                          <div className="font-medium">Custom Configuration</div>
+                          <div className="text-xs text-muted-foreground">Define your auto router from scratch</div>
+                        </div>
+                      </SelectItem>
+                    </SelectContent>
+                  </Select>
+                  {modelsUnverifiable && (
+                    <div className="text-xs mt-1 text-destructive">
+                      Could not load available models.{" "}
+                      <button type="button" className="underline" onClick={() => refetchModels()}>
+                        Retry
+                      </button>
+                    </div>
+                  )}
+                </div>
+              )}
 
               {requiresTeamScope && (
                 <FormField
@@ -552,56 +640,64 @@ const AddAutoRouterTab: React.FC<AddAutoRouterTabProps> = ({
                 </FormField>
               )}
 
-              <div className="border border-border rounded-lg">
-                <button
-                  type="button"
-                  onClick={() => setDetailsExpanded((expanded) => !expanded)}
-                  className="w-full flex flex-col gap-1 px-4 py-3 text-left hover:bg-muted"
-                  data-testid="detailed-configuration-toggle"
-                >
-                  <span className="flex items-center gap-2 font-medium text-foreground">
-                    {detailsExpanded ? (
-                      <ChevronDown className="size-3 text-muted-foreground" />
-                    ) : (
-                      <ChevronRight className="size-3 text-muted-foreground" />
-                    )}
-                    Detailed Configuration
-                  </span>
-                  {!detailsExpanded && (
-                    <span className="text-xs text-muted-foreground line-clamp-2">
-                      {tierConfigSummary(complexityRouterConfig)}
-                    </span>
-                  )}
-                </button>
-                {detailsExpanded && (
-                  <div className="px-4 pb-4">
-                    <ComplexityRouterConfig
-                      editingTiers={editingTiers}
-                      onEditingTiersChange={setEditingTiers}
-                      modelInfo={modelInfo}
-                      value={complexityRouterConfig}
-                      onChange={setComplexityRouterConfig}
-                      customTechnicalKeywords={customTechnicalKeywords}
-                      onCustomTechnicalKeywordsChange={setCustomTechnicalKeywords}
-                      keywordTierRules={keywordTierRules}
-                      onKeywordTierRulesChange={setKeywordTierRules}
-                      keywordRulesError={getKeywordTierRulesError(
-                        keywordTierRules,
-                        activeTierRows(complexityRouterConfig),
+              {routerKind === "complexity" ? (
+                <div className="border border-border rounded-lg">
+                  <button
+                    type="button"
+                    onClick={() => setDetailsExpanded((expanded) => !expanded)}
+                    className="w-full flex flex-col gap-1 px-4 py-3 text-left hover:bg-muted"
+                    data-testid="detailed-configuration-toggle"
+                  >
+                    <span className="flex items-center gap-2 font-medium text-foreground">
+                      {detailsExpanded ? (
+                        <ChevronDown className="size-3 text-muted-foreground" />
+                      ) : (
+                        <ChevronRight className="size-3 text-muted-foreground" />
                       )}
-                      semanticMatchingEnabled={semanticMatchingEnabled}
-                      onSemanticMatchingEnabledChange={setSemanticMatchingEnabled}
-                      embeddingModel={embeddingModel}
-                      onEmbeddingModelChange={setEmbeddingModel}
-                      matchThreshold={matchThreshold}
-                      onMatchThresholdChange={setMatchThreshold}
-                      escalationKeywords={escalationKeywords}
-                      onEscalationKeywordsChange={setEscalationKeywords}
-                      showValidationErrors={showValidationErrors}
-                    />
-                  </div>
-                )}
-              </div>
+                      Detailed Configuration
+                    </span>
+                    {!detailsExpanded && (
+                      <span className="text-xs text-muted-foreground line-clamp-2">
+                        {tierConfigSummary(complexityRouterConfig)}
+                      </span>
+                    )}
+                  </button>
+                  {detailsExpanded && (
+                    <div className="px-4 pb-4">
+                      <ComplexityRouterConfig
+                        editingTiers={editingTiers}
+                        onEditingTiersChange={setEditingTiers}
+                        modelInfo={modelInfo}
+                        value={complexityRouterConfig}
+                        onChange={setComplexityRouterConfig}
+                        customTechnicalKeywords={customTechnicalKeywords}
+                        onCustomTechnicalKeywordsChange={setCustomTechnicalKeywords}
+                        keywordTierRules={keywordTierRules}
+                        onKeywordTierRulesChange={setKeywordTierRules}
+                        keywordRulesError={getKeywordTierRulesError(
+                          keywordTierRules,
+                          activeTierRows(complexityRouterConfig),
+                        )}
+                        semanticMatchingEnabled={semanticMatchingEnabled}
+                        onSemanticMatchingEnabledChange={setSemanticMatchingEnabled}
+                        embeddingModel={embeddingModel}
+                        onEmbeddingModelChange={setEmbeddingModel}
+                        matchThreshold={matchThreshold}
+                        onMatchThresholdChange={setMatchThreshold}
+                        escalationKeywords={escalationKeywords}
+                        onEscalationKeywordsChange={setEscalationKeywords}
+                        showValidationErrors={showValidationErrors}
+                      />
+                    </div>
+                  )}
+                </div>
+              ) : (
+                <CapabilityRouterConfig
+                  modelInfo={modelInfo}
+                  value={capabilityRouterConfig}
+                  onChange={setCapabilityRouterConfig}
+                />
+              )}
 
               {isAdmin && (
                 <FormField
@@ -687,8 +783,15 @@ const AddAutoRouterTab: React.FC<AddAutoRouterTabProps> = ({
           {isRoutingTestVisible && (
             <AutoRouterRoutingTest
               accessToken={accessToken}
-              config={buildComplexityRouterConfig(complexityRouterConfigParams)}
-              defaultModel={resolveComplexityDefaultModel(complexityRouterConfig, complexityRouterConfig.default_model)}
+              config={
+                routerKind === "complexity" ? buildComplexityRouterConfig(complexityRouterConfigParams) : undefined
+              }
+              capabilityConfig={routerKind === "capability" ? capabilityRouterConfig : undefined}
+              defaultModel={
+                routerKind === "complexity"
+                  ? resolveComplexityDefaultModel(complexityRouterConfig, complexityRouterConfig.default_model)
+                  : undefined
+              }
               routerName={watchedName}
               teamId={requiresTeamScope ? watchedTeamId : undefined}
             />

--- a/ui/litellm-dashboard/src/components/add_model/add_capability_router_tab.integration.test.tsx
+++ b/ui/litellm-dashboard/src/components/add_model/add_capability_router_tab.integration.test.tsx
@@ -1,0 +1,90 @@
+import userEvent from "@testing-library/user-event";
+import { fireEvent, renderWithProviders, screen, testQueryClient, waitFor } from "../../../tests/test-utils";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import AddAutoRouterTab from "./add_auto_router_tab";
+import { handleAddAutoRouterSubmit } from "./handle_add_auto_router_submit";
+
+vi.mock(
+  "@/app/(dashboard)/hooks/autoRouter/useComplexityScorerDefaults",
+  async () => await import("../../../tests/mocks/complexityScorerDefaults"),
+);
+
+const { mockFetchAvailableModels, mockFetchAllModelDeployments, validateAutoRouterConfig } = vi.hoisted(() => ({
+  mockFetchAvailableModels: vi.fn(),
+  mockFetchAllModelDeployments: vi.fn(),
+  validateAutoRouterConfig: vi.fn().mockResolvedValue({ valid: true }),
+}));
+
+vi.mock("../networking", () => ({
+  modelAvailableCall: vi.fn().mockResolvedValue({ data: [] }),
+  validateAutoRouterConfig,
+}));
+vi.mock("@/components/llm_calls/fetch_models", () => ({ fetchAvailableModels: mockFetchAvailableModels }));
+vi.mock("@/app/(dashboard)/hooks/models/useModels", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/app/(dashboard)/hooks/models/useModels")>();
+  return { ...actual, fetchAllModelDeployments: mockFetchAllModelDeployments };
+});
+vi.mock("./handle_add_auto_router_submit", () => ({ handleAddAutoRouterSubmit: vi.fn() }));
+vi.mock("./CapabilityRouterConfig", () => ({
+  default: ({ onChange }: { onChange: (value: unknown) => void }) => (
+    <button
+      type="button"
+      onClick={() =>
+        onChange({
+          candidates: [
+            { model: "small", description: "Bounded extraction" },
+            { model: "frontier", description: "Ambiguous multi-step work" },
+          ],
+          classifier: { model: "classifier", timeout_ms: 3000, max_output_tokens: 1024 },
+          probability_threshold: 0.75,
+          fallback_model: "frontier",
+          estimated_output_tokens: 1000,
+          cache_ttl_seconds: 3600,
+        })
+      }
+    >
+      Fill capability config
+    </button>
+  ),
+}));
+
+describe("AddAutoRouterTab capability flow", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    testQueryClient.clear();
+    mockFetchAvailableModels.mockResolvedValue(
+      ["small", "frontier", "classifier"].map((model_group) => ({ model_group, mode: "chat" })),
+    );
+    mockFetchAllModelDeployments.mockResolvedValue([]);
+  });
+
+  it("validates and submits the capability config shown in the form", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<AddAutoRouterTab handleOk={vi.fn()} accessToken="token" userRole="Admin" />);
+
+    fireEvent.click(screen.getByTestId("router-type-selector"));
+    await user.click(screen.getByRole("option", { name: "Capability" }));
+    expect(screen.queryByTestId("template-selector")).not.toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Fill capability config" }));
+    await user.type(screen.getByPlaceholderText(/smart_router/i), "cost-router");
+    await user.click(screen.getByRole("button", { name: "Add Auto Router" }));
+
+    await waitFor(() => expect(handleAddAutoRouterSubmit).toHaveBeenCalledOnce());
+    expect(validateAutoRouterConfig).toHaveBeenCalledWith(
+      "token",
+      expect.objectContaining({ probability_threshold: 0.75, cache_ttl_seconds: 3600 }),
+      undefined,
+      "capability",
+    );
+    expect(vi.mocked(handleAddAutoRouterSubmit).mock.calls[0]?.[0]).toMatchObject({
+      auto_router_name: "cost-router",
+      model_type: "capability_router",
+      capability_router_config: {
+        fallback_model: "frontier",
+        probability_threshold: 0.75,
+        cache_ttl_seconds: 3600,
+      },
+    });
+  });
+});

--- a/ui/litellm-dashboard/src/components/add_model/auto_router_strategies.ts
+++ b/ui/litellm-dashboard/src/components/add_model/auto_router_strategies.ts
@@ -13,12 +13,13 @@
  * prefixes are matched first, and only a bare `auto_router/<name>` is the semantic router.
  */
 
-export type AutoRouterKind = "complexity" | "adaptive" | "quality" | "semantic";
+export type AutoRouterKind = "complexity" | "capability" | "adaptive" | "quality" | "semantic";
 
 export interface AutoRouterParams {
   model?: string | null;
   complexity_router_config?: unknown;
   complexity_router_default_model?: string | null;
+  capability_router_config?: unknown;
   auto_router_config?: unknown;
   auto_router_default_model?: string | null;
   adaptive_router_config?: unknown;
@@ -32,7 +33,7 @@ export interface AutoRouterStrategy {
   /** Type-pill label. The complexity router overrides this with its classifier. */
   label: string;
   configKey: keyof AutoRouterParams;
-  defaultModelKey: keyof AutoRouterParams;
+  defaultModelKey?: keyof AutoRouterParams;
   /** Whether the dashboard has a form that understands this strategy's config shape. */
   hasEditor: boolean;
   matches: (params: AutoRouterParams) => boolean;
@@ -42,6 +43,13 @@ const startsWith = (params: AutoRouterParams, prefix: string): boolean => params
 
 /** Ordered; the semantic entry matches anything left and must stay last. */
 export const AUTO_ROUTER_STRATEGIES: readonly AutoRouterStrategy[] = [
+  {
+    kind: "capability",
+    label: "Capability",
+    configKey: "capability_router_config",
+    hasEditor: true,
+    matches: (p) => startsWith(p, "auto_router/capability_router") || p.capability_router_config != null,
+  },
   {
     kind: "complexity",
     label: "Complexity",
@@ -84,10 +92,14 @@ export const autoRouterStrategy = (params: AutoRouterParams | null | undefined):
 export const isComplexityRouter = (params: AutoRouterParams | null | undefined): boolean =>
   autoRouterStrategy(params).kind === "complexity";
 
+export const isCapabilityRouter = (params: AutoRouterParams | null | undefined): boolean =>
+  autoRouterStrategy(params).kind === "capability";
+
 /** Any `auto_router/*` deployment, whatever its strategy. Use for listing and filtering. */
 export const isAutoRouterDeployment = (params: AutoRouterParams | null | undefined): boolean =>
   params?.model?.startsWith("auto_router/") === true ||
   params?.complexity_router_config != null ||
+  params?.capability_router_config != null ||
   params?.auto_router_config != null;
 
 /**

--- a/ui/litellm-dashboard/src/components/add_model/build_auto_router_routing_test_request.ts
+++ b/ui/litellm-dashboard/src/components/add_model/build_auto_router_routing_test_request.ts
@@ -1,9 +1,11 @@
 import { AutoRouterRoutingTestRequest } from "../networking";
 import { ComplexityRouterConfigPayload } from "./build_complexity_router_config";
+import { CapabilityRouterConfigValue } from "./capability_router_config";
 
 export interface BuildAutoRouterRoutingTestRequestParams {
   prompt: string;
-  config: ComplexityRouterConfigPayload;
+  config?: ComplexityRouterConfigPayload;
+  capabilityConfig?: CapabilityRouterConfigValue;
   defaultModel: string | undefined;
   routerName: string | undefined;
   teamId: string | undefined;
@@ -12,12 +14,15 @@ export interface BuildAutoRouterRoutingTestRequestParams {
 export const buildAutoRouterRoutingTestRequest = ({
   prompt,
   config,
+  capabilityConfig,
   defaultModel,
   routerName,
   teamId,
 }: BuildAutoRouterRoutingTestRequestParams): AutoRouterRoutingTestRequest => ({
   prompt,
-  complexity_router_config: config,
+  ...(capabilityConfig
+    ? { capability_router_config: capabilityConfig as unknown as Record<string, unknown> }
+    : { complexity_router_config: config }),
   ...(defaultModel ? { default_model: defaultModel } : {}),
   ...(routerName?.trim() ? { router_name: routerName.trim() } : {}),
   ...(teamId ? { team_id: teamId } : {}),

--- a/ui/litellm-dashboard/src/components/add_model/capability_router_config.test.ts
+++ b/ui/litellm-dashboard/src/components/add_model/capability_router_config.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  capabilityRouterConfigError,
+  defaultCapabilityRouterConfig,
+  hydrateCapabilityRouterConfig,
+} from "./capability_router_config";
+
+const validConfig = () => ({
+  ...defaultCapabilityRouterConfig(),
+  candidates: [
+    { model: "small", description: "Good for bounded extraction" },
+    { model: "frontier", description: "Good for ambiguous multi-step work" },
+  ],
+  classifier: { model: "classifier", timeout_ms: 3000, max_output_tokens: 1024 },
+  fallback_model: "frontier",
+});
+
+describe("capability router config", () => {
+  it("accepts the minimal complete configuration", () => {
+    expect(capabilityRouterConfigError(validConfig())).toBeNull();
+  });
+
+  it("requires descriptions, unique models, and a candidate fallback", () => {
+    expect(
+      capabilityRouterConfigError({
+        ...validConfig(),
+        candidates: [{ model: "small", description: "" }, validConfig().candidates[1]],
+      }),
+    ).toContain("Describe");
+    expect(
+      capabilityRouterConfigError({
+        ...validConfig(),
+        candidates: [validConfig().candidates[0], validConfig().candidates[0]],
+      }),
+    ).toContain("unique");
+    expect(capabilityRouterConfigError({ ...validConfig(), fallback_model: "other" })).toContain("fallback");
+  });
+
+  it("hydrates stored values while supplying newly introduced defaults", () => {
+    const hydrated = hydrateCapabilityRouterConfig({
+      candidates: validConfig().candidates,
+      classifier: { model: "classifier" },
+      fallback_model: "frontier",
+      probability_threshold: 0.8,
+    });
+
+    expect(hydrated.probability_threshold).toBe(0.8);
+    expect(hydrated.classifier.timeout_ms).toBe(3000);
+    expect(hydrated.cache_ttl_seconds).toBe(3600);
+  });
+});

--- a/ui/litellm-dashboard/src/components/add_model/capability_router_config.ts
+++ b/ui/litellm-dashboard/src/components/add_model/capability_router_config.ts
@@ -1,0 +1,63 @@
+export interface CapabilityCandidate {
+  model: string;
+  description: string;
+}
+
+export interface CapabilityRouterConfigValue {
+  candidates: CapabilityCandidate[];
+  classifier: { model: string; timeout_ms: number; max_output_tokens: number };
+  probability_threshold: number;
+  fallback_model: string;
+  estimated_output_tokens: number;
+  cache_ttl_seconds: number;
+}
+
+export const defaultCapabilityRouterConfig = (): CapabilityRouterConfigValue => ({
+  candidates: [
+    { model: "", description: "" },
+    { model: "", description: "" },
+  ],
+  classifier: { model: "", timeout_ms: 3000, max_output_tokens: 1024 },
+  probability_threshold: 0.7,
+  fallback_model: "",
+  estimated_output_tokens: 1000,
+  cache_ttl_seconds: 3600,
+});
+
+export const capabilityRouterConfigError = (config: CapabilityRouterConfigValue): string | null => {
+  if (config.candidates.length < 2) return "Add at least two candidate models";
+  if (config.candidates.some((candidate) => !candidate.model.trim())) return "Select a model for every candidate";
+  if (new Set(config.candidates.map((candidate) => candidate.model)).size !== config.candidates.length) {
+    return "Candidate models must be unique";
+  }
+  if (config.candidates.some((candidate) => !candidate.description.trim())) {
+    return "Describe what every candidate model is good at";
+  }
+  if (!config.classifier.model.trim()) return "Select a classifier model";
+  if (!config.candidates.some((candidate) => candidate.model === config.fallback_model)) {
+    return "Select one candidate as the fallback model";
+  }
+  if (
+    !Number.isFinite(config.probability_threshold) ||
+    config.probability_threshold < 0 ||
+    config.probability_threshold > 1
+  ) {
+    return "Probability threshold must be between 0 and 1";
+  }
+  if (!Number.isInteger(config.cache_ttl_seconds) || config.cache_ttl_seconds < 1) {
+    return "Cache TTL must be at least one second";
+  }
+  return null;
+};
+
+export const hydrateCapabilityRouterConfig = (stored: unknown): CapabilityRouterConfigValue => {
+  const defaults = defaultCapabilityRouterConfig();
+  if (typeof stored !== "object" || stored === null || Array.isArray(stored)) return defaults;
+  const value = stored as Partial<CapabilityRouterConfigValue>;
+  return {
+    ...defaults,
+    ...value,
+    candidates: Array.isArray(value.candidates) ? value.candidates : defaults.candidates,
+    classifier: { ...defaults.classifier, ...(value.classifier ?? {}) },
+  };
+};

--- a/ui/litellm-dashboard/src/components/add_model/handle_add_auto_router_submit.tsx
+++ b/ui/litellm-dashboard/src/components/add_model/handle_add_auto_router_submit.tsx
@@ -1,12 +1,14 @@
 import { modelCreateCall } from "../networking";
 import { toast } from "@/lib/toast";
 import type { ComplexityRouterConfigPayload } from "./build_complexity_router_config";
+import type { CapabilityRouterConfigValue } from "./capability_router_config";
 
 export interface AddAutoRouterValues {
   auto_router_name: string;
-  auto_router_default_model: string | undefined;
-  model_type: "complexity_router";
-  complexity_router_config: ComplexityRouterConfigPayload;
+  model_type: "complexity_router" | "capability_router";
+  auto_router_default_model?: string;
+  complexity_router_config?: ComplexityRouterConfigPayload;
+  capability_router_config?: CapabilityRouterConfigValue;
   team_id?: string;
   model_access_group?: string[];
 }
@@ -18,13 +20,20 @@ export const handleAddAutoRouterSubmit = async (
   callback?: () => void,
 ) => {
   try {
+    const litellmParams =
+      values.model_type === "capability_router"
+        ? {
+            model: "auto_router/capability_router",
+            capability_router_config: values.capability_router_config!,
+          }
+        : {
+            model: "auto_router/complexity_router",
+            complexity_router_config: values.complexity_router_config!,
+            complexity_router_default_model: values.auto_router_default_model,
+          };
     const autoRouterConfig = {
       model_name: values.auto_router_name,
-      litellm_params: {
-        model: "auto_router/complexity_router",
-        complexity_router_config: values.complexity_router_config,
-        complexity_router_default_model: values.auto_router_default_model,
-      },
+      litellm_params: litellmParams,
       model_info: {
         ...(values.team_id ? { team_id: values.team_id } : {}),
         ...(values.model_access_group?.length ? { access_groups: values.model_access_group } : {}),

--- a/ui/litellm-dashboard/src/components/edit_auto_router/edit_auto_router_modal.tsx
+++ b/ui/litellm-dashboard/src/components/edit_auto_router/edit_auto_router_modal.tsx
@@ -23,7 +23,14 @@ import {
   tierParamsByRowId,
   resolveComplexityDefaultModel,
 } from "../add_model/tier_rows";
-import { isComplexityRouter } from "../add_model/auto_router_strategies";
+import { isCapabilityRouter, isComplexityRouter } from "../add_model/auto_router_strategies";
+import CapabilityRouterConfig from "../add_model/CapabilityRouterConfig";
+import {
+  capabilityRouterConfigError,
+  defaultCapabilityRouterConfig,
+  hydrateCapabilityRouterConfig,
+  type CapabilityRouterConfigValue,
+} from "../add_model/capability_router_config";
 import {
   type BuildComplexityRouterConfigParams,
   buildComplexityRouterConfig,
@@ -409,28 +416,36 @@ const EditAutoRouterModal: React.FC<EditAutoRouterModalProps> = ({
     tiers: { SIMPLE: [], MEDIUM: [], COMPLEX: [], REASONING: [] },
     classifier_type: "heuristic",
   });
+  const [capabilityRouterConfig, setCapabilityRouterConfig] =
+    useState<CapabilityRouterConfigValue>(defaultCapabilityRouterConfig);
   const isComplexityRouterModel = isComplexityRouter(modelData?.litellm_params);
+  const isCapabilityRouterModel = isCapabilityRouter(modelData?.litellm_params);
 
   const schema = useMemo(
-    () => (isComplexityRouterModel ? complexityRouterSchema : semanticRouterSchema),
-    [isComplexityRouterModel],
+    () => (isComplexityRouterModel || isCapabilityRouterModel ? complexityRouterSchema : semanticRouterSchema),
+    [isCapabilityRouterModel, isComplexityRouterModel],
   );
   const form = useZodForm(schema, { defaultValues: EMPTY_FORM_VALUES });
 
   // Mirrors the create form: the button says why it is unavailable and disables on the same
   // answer. Tiers use this modal's own rule, which allows a partly filled router, so an edit that
   // is legal today stays legal.
-  const submitBlockedReason = !isComplexityRouterModel
-    ? null
-    : (complexityRouterConfig.custom_tier_set
-        ? getCustomTierRowsError(complexityRouterConfig.custom_tier_set) ??
-          getMissingTiersError(activeTierRows(complexityRouterConfig))
-        : (Object.values(complexityRouterConfig.tiers).every((models) => models.length === 0)
-            ? "Please select at least one model for a complexity tier"
-            : null) ?? getTierLabelsError(complexityRouterConfig.tier_labels)) ??
-      getPlanModeTierError(complexityRouterConfig.plan_mode_min_tier, activeTierRows(complexityRouterConfig)) ??
-      getKeywordTierRulesError(keywordTierRules, activeTierRows(complexityRouterConfig)) ??
-      getClassifierModelError(complexityRouterConfig);
+  const complexitySubmitBlockedReason =
+    (complexityRouterConfig.custom_tier_set
+      ? getCustomTierRowsError(complexityRouterConfig.custom_tier_set) ??
+        getMissingTiersError(activeTierRows(complexityRouterConfig))
+      : (Object.values(complexityRouterConfig.tiers).every((models) => models.length === 0)
+          ? "Please select at least one model for a complexity tier"
+          : null) ?? getTierLabelsError(complexityRouterConfig.tier_labels)) ??
+    getPlanModeTierError(complexityRouterConfig.plan_mode_min_tier, activeTierRows(complexityRouterConfig)) ??
+    getKeywordTierRulesError(keywordTierRules, activeTierRows(complexityRouterConfig)) ??
+    getClassifierModelError(complexityRouterConfig);
+  let submitBlockedReason: string | null = null;
+  if (isCapabilityRouterModel) {
+    submitBlockedReason = capabilityRouterConfigError(capabilityRouterConfig);
+  } else if (isComplexityRouterModel) {
+    submitBlockedReason = complexitySubmitBlockedReason;
+  }
 
   useEffect(() => {
     if (isVisible && modelData) {
@@ -468,6 +483,15 @@ const EditAutoRouterModal: React.FC<EditAutoRouterModalProps> = ({
   const initializeForm = () => {
     setEditingTiers(false);
     try {
+      if (isCapabilityRouterModel) {
+        setCapabilityRouterConfig(hydrateCapabilityRouterConfig(modelData.litellm_params?.capability_router_config));
+        form.reset({
+          ...EMPTY_FORM_VALUES,
+          auto_router_name: modelData.model_name,
+          model_access_group: modelData.model_info?.access_groups || [],
+        });
+        return;
+      }
       if (isComplexityRouterModel) {
         // Parse the complexity_router_config if it exists and is a string
         let parsedConfig = modelData.litellm_params?.complexity_router_config || {};
@@ -532,6 +556,46 @@ const EditAutoRouterModal: React.FC<EditAutoRouterModalProps> = ({
   };
 
   const saveValues = async (values: EditAutoRouterFormValues) => {
+    if (isCapabilityRouterModel) {
+      const validationError = capabilityRouterConfigError(capabilityRouterConfig);
+      if (validationError) {
+        toast.fromError(validationError);
+        return;
+      }
+      const serverVerdict = await validateAutoRouterConfig(
+        accessToken,
+        capabilityRouterConfig as unknown as Record<string, unknown>,
+        modelData?.model_info?.team_id,
+        "capability",
+      );
+      const dryRunError = dryRunRejection(serverVerdict);
+      if (dryRunError) {
+        toast.fromError(dryRunError);
+        return;
+      }
+      const updatedLitellmParams = {
+        ...modelData.litellm_params,
+        capability_router_config: capabilityRouterConfig,
+      };
+      const updatedModelInfo = {
+        ...modelData.model_info,
+        access_groups: values.model_access_group || [],
+      };
+      await modelPatchUpdateCall(
+        accessToken,
+        { model_name: values.auto_router_name, litellm_params: updatedLitellmParams, model_info: updatedModelInfo },
+        modelData.model_info.id,
+      );
+      toast.success("Auto router configuration updated successfully");
+      onSuccess({
+        ...modelData,
+        model_name: values.auto_router_name,
+        litellm_params: updatedLitellmParams,
+        model_info: updatedModelInfo,
+      });
+      onCancel();
+      return;
+    }
     if (isComplexityRouterModel) {
       const { tiers, custom_tier_set, classifier_llm_config } = complexityRouterConfig;
       const rows = activeTierRows(complexityRouterConfig);
@@ -696,78 +760,86 @@ const EditAutoRouterModal: React.FC<EditAutoRouterModalProps> = ({
                 {({ ref, ...field }) => <Input {...field} ref={ref} placeholder="e.g., auto_router_1, smart_routing" />}
               </FormField>
 
-              {isComplexityRouterModel ? (
-                /* Complexity Router Configuration */
-                <div className="w-full">
-                  <ComplexityRouterConfig
-                    editingTiers={editingTiers}
-                    onEditingTiersChange={setEditingTiers}
-                    showValidationErrors={showValidationErrors}
-                    modelInfo={modelInfo}
-                    value={complexityRouterConfig}
-                    onChange={(config) => {
-                      setComplexityRouterConfig(config);
-                    }}
-                    customTechnicalKeywords={customTechnicalKeywords}
-                    onCustomTechnicalKeywordsChange={setCustomTechnicalKeywords}
-                    keywordTierRules={keywordTierRules}
-                    onKeywordTierRulesChange={setKeywordTierRules}
-                    keywordRulesError={getKeywordTierRulesError(
-                      keywordTierRules,
-                      activeTierRows(complexityRouterConfig),
-                    )}
-                    semanticMatchingEnabled={semanticMatchingEnabled}
-                    onSemanticMatchingEnabledChange={setSemanticMatchingEnabled}
-                    embeddingModel={embeddingModel}
-                    onEmbeddingModelChange={setEmbeddingModel}
-                    matchThreshold={matchThreshold}
-                    onMatchThresholdChange={setMatchThreshold}
-                    escalationKeywords={escalationKeywords}
-                    onEscalationKeywordsChange={setEscalationKeywords}
-                  />
-                </div>
-              ) : (
-                <>
-                  {/* Router Configuration Builder */}
+              {isCapabilityRouterModel && (
+                <CapabilityRouterConfig
+                  modelInfo={modelInfo}
+                  value={capabilityRouterConfig}
+                  onChange={setCapabilityRouterConfig}
+                />
+              )}
+              {!isCapabilityRouterModel &&
+                (isComplexityRouterModel ? (
+                  /* Complexity Router Configuration */
                   <div className="w-full">
-                    <RouterConfigBuilder
+                    <ComplexityRouterConfig
+                      editingTiers={editingTiers}
+                      onEditingTiersChange={setEditingTiers}
+                      showValidationErrors={showValidationErrors}
                       modelInfo={modelInfo}
-                      value={routerConfig}
+                      value={complexityRouterConfig}
                       onChange={(config) => {
-                        setRouterConfig(config);
+                        setComplexityRouterConfig(config);
                       }}
+                      customTechnicalKeywords={customTechnicalKeywords}
+                      onCustomTechnicalKeywordsChange={setCustomTechnicalKeywords}
+                      keywordTierRules={keywordTierRules}
+                      onKeywordTierRulesChange={setKeywordTierRules}
+                      keywordRulesError={getKeywordTierRulesError(
+                        keywordTierRules,
+                        activeTierRows(complexityRouterConfig),
+                      )}
+                      semanticMatchingEnabled={semanticMatchingEnabled}
+                      onSemanticMatchingEnabledChange={setSemanticMatchingEnabled}
+                      embeddingModel={embeddingModel}
+                      onEmbeddingModelChange={setEmbeddingModel}
+                      matchThreshold={matchThreshold}
+                      onMatchThresholdChange={setMatchThreshold}
+                      escalationKeywords={escalationKeywords}
+                      onEscalationKeywordsChange={setEscalationKeywords}
                     />
                   </div>
-
-                  <FormField control={form.control} name="auto_router_default_model" label="Default Model">
-                    {({ id, value, onChange, "aria-invalid": ariaInvalid, "aria-describedby": ariaDescribedBy }) => (
-                      <ModelChoiceCombobox
-                        id={id}
-                        value={value}
-                        onChange={onChange}
-                        choices={modelChoices}
-                        placeholder="Select a default model"
-                        ariaInvalid={ariaInvalid}
-                        ariaDescribedBy={ariaDescribedBy}
+                ) : (
+                  <>
+                    {/* Router Configuration Builder */}
+                    <div className="w-full">
+                      <RouterConfigBuilder
+                        modelInfo={modelInfo}
+                        value={routerConfig}
+                        onChange={(config) => {
+                          setRouterConfig(config);
+                        }}
                       />
-                    )}
-                  </FormField>
+                    </div>
 
-                  <FormField control={form.control} name="auto_router_embedding_model" label="Embedding Model">
-                    {({ id, value, onChange, "aria-invalid": ariaInvalid, "aria-describedby": ariaDescribedBy }) => (
-                      <ModelChoiceCombobox
-                        id={id}
-                        value={value}
-                        onChange={onChange}
-                        choices={modelChoices}
-                        placeholder="Select an embedding model"
-                        ariaInvalid={ariaInvalid}
-                        ariaDescribedBy={ariaDescribedBy}
-                      />
-                    )}
-                  </FormField>
-                </>
-              )}
+                    <FormField control={form.control} name="auto_router_default_model" label="Default Model">
+                      {({ id, value, onChange, "aria-invalid": ariaInvalid, "aria-describedby": ariaDescribedBy }) => (
+                        <ModelChoiceCombobox
+                          id={id}
+                          value={value}
+                          onChange={onChange}
+                          choices={modelChoices}
+                          placeholder="Select a default model"
+                          ariaInvalid={ariaInvalid}
+                          ariaDescribedBy={ariaDescribedBy}
+                        />
+                      )}
+                    </FormField>
+
+                    <FormField control={form.control} name="auto_router_embedding_model" label="Embedding Model">
+                      {({ id, value, onChange, "aria-invalid": ariaInvalid, "aria-describedby": ariaDescribedBy }) => (
+                        <ModelChoiceCombobox
+                          id={id}
+                          value={value}
+                          onChange={onChange}
+                          choices={modelChoices}
+                          placeholder="Select an embedding model"
+                          ariaInvalid={ariaInvalid}
+                          ariaDescribedBy={ariaDescribedBy}
+                        />
+                      )}
+                    </FormField>
+                  </>
+                ))}
 
               {userRole === "Admin" && (
                 <FormField

--- a/ui/litellm-dashboard/src/components/networking.tsx
+++ b/ui/litellm-dashboard/src/components/networking.tsx
@@ -2392,7 +2392,8 @@ export const testModelGroupConnection = async (
 
 export interface AutoRouterRoutingTestRequest {
   prompt: string;
-  complexity_router_config: ComplexityRouterConfigPayload;
+  complexity_router_config?: ComplexityRouterConfigPayload;
+  capability_router_config?: Record<string, unknown>;
   default_model?: string;
   router_name?: string;
   team_id?: string;
@@ -2433,16 +2434,18 @@ export interface ComplexityRouterConfigValidation {
 // write gate stays authoritative.
 export const validateAutoRouterConfig = async (
   accessToken: string,
-  complexityRouterConfig: Record<string, unknown>,
+  routerConfig: Record<string, unknown>,
   teamId?: string,
+  routerType: "complexity" | "capability" = "complexity",
 ): Promise<ComplexityRouterConfigValidation> => {
   try {
-    return await apiClient.post<ComplexityRouterConfigValidation>("/auto_router/validate_complexity_router_config", {
+    const configKey = `${routerType}_router_config`;
+    return await apiClient.post<ComplexityRouterConfigValidation>(`/auto_router/validate_${routerType}_router_config`, {
       accessToken,
-      body: { complexity_router_config: complexityRouterConfig, ...(teamId && { team_id: teamId }) },
+      body: { [configKey]: routerConfig, ...(teamId && { team_id: teamId }) },
     });
   } catch (error) {
-    console.warn("Could not dry-run the complexity router config; the save will be validated server side", error);
+    console.warn(`Could not dry-run the ${routerType} router config; the save will be validated server side`, error);
     return { valid: true };
   }
 };

--- a/ui/litellm-dashboard/src/components/view_logs/LogDetailsDrawer/RoutingDecisionCard.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/LogDetailsDrawer/RoutingDecisionCard.tsx
@@ -27,12 +27,19 @@ export interface RoutingDecision {
   escalated?: boolean;
   tier_boundaries?: RoutingDecisionTierBoundaries;
   reasoning_override_min_score?: number;
+  probability_threshold?: number;
+  candidate_probabilities?: Record<string, number>;
+  candidate_costs?: Record<string, number>;
+  qualified_models?: string[];
+  fallback_reason?: string;
+  cached?: boolean;
 }
 
 const ROUTER_TYPE_LABELS: Record<string, string> = {
   complexity: "Auto-Router v2",
   adaptive: "Adaptive router",
   quality: "Quality router",
+  capability: "Capability router",
 };
 
 /**
@@ -96,6 +103,9 @@ const CONSTANT_CAUSE_LABELS: Record<string, string> = {
   default_fallback: "Default model, no route matched",
   classifier_fallback: "Fallback tier, LLM classifier failed",
   default_model_fallback: "Default model, LLM classifier failed",
+  capability_classifier: "Capability classifier",
+  capability_cache: "Cached capability decision",
+  capability_fallback: "Capability fallback",
 };
 
 function describeCause(decision: RoutingDecision): string {
@@ -168,6 +178,12 @@ export function RoutingDecisionCard({
     escalated,
     escalation_keyword: escalationKeyword,
     tier_boundaries: tierBoundaries,
+    probability_threshold: probabilityThreshold,
+    candidate_probabilities: candidateProbabilities,
+    candidate_costs: candidateCosts,
+    qualified_models: qualifiedModels,
+    fallback_reason: fallbackReason,
+    cached,
   } = decision;
 
   // On an override row the score did not decide the tier, so showing it against a
@@ -214,6 +230,25 @@ export function RoutingDecisionCard({
         )}
 
         {routedModel && <Row label="Routed to">{routedModel}</Row>}
+
+        {probabilityThreshold !== undefined && <Row label="Threshold">{Math.round(probabilityThreshold * 100)}%</Row>}
+
+        {candidateProbabilities && Object.keys(candidateProbabilities).length > 0 && (
+          <Row label="Candidates">
+            <span className="space-y-1">
+              {Object.entries(candidateProbabilities).map(([model, probability]) => (
+                <span key={model} className="block">
+                  {model}: {Math.round(probability * 100)}%
+                  {candidateCosts?.[model] !== undefined && ` · $${candidateCosts[model].toFixed(6)}`}
+                  {qualifiedModels?.includes(model) ? " · qualified" : ""}
+                </span>
+              ))}
+            </span>
+          </Row>
+        )}
+
+        {fallbackReason && <Row label="Fallback">{fallbackReason.replaceAll("_", " ")}</Row>}
+        {cached !== undefined && <Row label="Cached">{cached ? "Yes" : "No"}</Row>}
 
         {escalated !== undefined && <Row label="Escalated">{describeEscalation(escalated, escalationKeyword)}</Row>}
 


### PR DESCRIPTION
## Summary

- add a capability router that estimates each configured model's probability of completing the current task
- select the cheapest candidate whose `p_solve` is strictly above a configurable global threshold, with an explicit fallback
- cache decisions per caller, session, configuration, and user turn to avoid repeated classifier spend during tool loops
- add proxy validation and a routing-preview endpoint
- add dashboard create, edit, and test flows with candidate probability and estimated cost visibility

## Configuration

Each router defines:

- two or more candidate model groups with operator-written capability descriptions
- a classifier model
- a global probability threshold
- a fallback candidate
- estimated output tokens and a decision-cache TTL

## Tests

- 75 backend router tests
- 19 focused proxy and authentication tests
- 25 focused UI unit tests
- 125 affected UI component tests
- capability-router create-flow integration test

## Notes

- benchmark code and benchmark results are intentionally excluded from this PR
- the full production UI build could not complete locally because the host ran out of disk space; the focused UI lint and test suites passed
