### PR TITLE
fix(ui): show MCP servers and agents inherited from access groups on team overview

### DIFF
--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -4172,6 +4172,8 @@ class TeamAccessGroupModelGrant(LiteLLMPydanticObjectBase):
     access_group_id: str
     access_group_name: str
     models: tuple[str, ...]
+    mcp_server_ids: tuple[str, ...] = ()
+    agent_ids: tuple[str, ...] = ()
 
 
 class TeamInfoResponseObjectTeamTable(LiteLLM_TeamTable):

--- a/litellm/proxy/management_endpoints/team_endpoints.py
+++ b/litellm/proxy/management_endpoints/team_endpoints.py
@@ -4318,6 +4318,8 @@ async def _resolve_team_access_group_resources(
                     access_group_id=group.access_group_id,
                     access_group_name=group.access_group_name,
                     models=tuple(group.access_model_names or ()),
+                    mcp_server_ids=tuple(group.access_mcp_server_ids or ()),
+                    agent_ids=tuple(group.access_agent_ids or ()),
                 )
                 for group in resolved_groups
             ),

--- a/tests/test_litellm/proxy/management_endpoints/test_team_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_team_endpoints.py
@@ -9897,11 +9897,11 @@ class TestResolveTeamAccessGroupResources:
         assert resolved.access_group_mcp_server_ids == ["mcp-1"]
         assert resolved.access_group_agent_ids == ["agent-1"]
         assert [
-            (d.access_group_id, d.access_group_name, d.models)
+            (d.access_group_id, d.access_group_name, d.models, d.mcp_server_ids, d.agent_ids)
             for d in (resolved.access_group_details or [])
         ] == [
-            ("ag-1", "shared-models", ("gpt-4", "claude-3")),
-            ("ag-2", "extra-models", ("claude-3", "gemini")),
+            ("ag-1", "shared-models", ("gpt-4", "claude-3"), ("mcp-1",), ()),
+            ("ag-2", "extra-models", ("claude-3", "gemini"), (), ("agent-1",)),
         ]
 
     @pytest.mark.asyncio

--- a/ui/litellm-dashboard/src/app/(dashboard)/models-and-endpoints/page.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/models-and-endpoints/page.test.tsx
@@ -111,17 +111,17 @@ describe("ModelsAndEndpointsPage", () => {
   // POST /model/new 403s a proxy_admin_viewer, so the form's tab must not render for one.
   it("hides the Add Model tab for a view-only admin session", () => {
     mockUseAuthorized.mockReturnValue(VIEW_ONLY_ADMIN);
-    const { getByRole, queryByRole } = renderPage();
-    expect(queryByRole("tab", { name: "Add Model" })).not.toBeInTheDocument();
-    expect(getByRole("tab", { name: "All Models" })).toBeInTheDocument();
+    renderPage();
+    expect(screen.queryByRole("tab", { name: "Add Model" })).not.toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: "All Models" })).toBeInTheDocument();
   });
 
   // Read parity: the Auto-Routers list stays reachable for a view-only admin; only the
   // create affordance inside it is withheld, which AutoRoutersTabPanel decides.
   it("keeps the Auto-Routers tab for a view-only admin session", () => {
     mockUseAuthorized.mockReturnValue(VIEW_ONLY_ADMIN);
-    const { getByRole } = renderPage();
-    expect(getByRole("tab", { name: /Auto-Routers/ })).toBeInTheDocument();
+    renderPage();
+    expect(screen.getByRole("tab", { name: /Auto-Routers/ })).toBeInTheDocument();
   });
 
   // Auto-routers are excluded from the All Models table, so this tab is their home: the only

--- a/ui/litellm-dashboard/src/components/object_permissions_view.tsx
+++ b/ui/litellm-dashboard/src/components/object_permissions_view.tsx
@@ -6,6 +6,8 @@ import type { ObjectPermission } from "./object_permission_types";
 
 interface ObjectPermissionsViewProps {
   objectPermission?: ObjectPermission | null;
+  inheritedMcpServerIds?: string[];
+  inheritedAgentIds?: string[];
   variant?: "card" | "inline";
   className?: string;
   accessToken?: string | null;
@@ -13,6 +15,8 @@ interface ObjectPermissionsViewProps {
 
 export function ObjectPermissionsView({
   objectPermission,
+  inheritedMcpServerIds = [],
+  inheritedAgentIds = [],
   variant = "card",
   className = "",
   accessToken,
@@ -34,9 +38,15 @@ export function ObjectPermissionsView({
         mcpAccessGroups={mcpAccessGroups}
         mcpToolPermissions={mcpToolPermissions}
         mcpToolsets={mcpToolsets}
+        inheritedMcpServers={inheritedMcpServerIds}
         accessToken={accessToken}
       />
-      <AgentPermissions agents={agents} agentAccessGroups={agentAccessGroups} accessToken={accessToken} />
+      <AgentPermissions
+        agents={agents}
+        agentAccessGroups={agentAccessGroups}
+        inheritedAgents={inheritedAgentIds}
+        accessToken={accessToken}
+      />
       <div className="min-w-0 rounded-md border border-border p-4">
         <p className="text-sm font-medium text-foreground">Search tools</p>
         {searchTools.length === 0 ? (

--- a/ui/litellm-dashboard/src/components/object_permissions_view.tsx
+++ b/ui/litellm-dashboard/src/components/object_permissions_view.tsx
@@ -3,11 +3,12 @@ import VectorStorePermissions from "./permissions/VectorStorePermissions";
 import MCPServerPermissions from "./permissions/MCPServerPermissions";
 import AgentPermissions from "./permissions/AgentPermissions";
 import type { ObjectPermission } from "./object_permission_types";
+import type { InheritedGrant } from "./permissions/inheritedGrants";
 
 interface ObjectPermissionsViewProps {
   objectPermission?: ObjectPermission | null;
-  inheritedMcpServerIds?: string[];
-  inheritedAgentIds?: string[];
+  inheritedMcpServers?: InheritedGrant[];
+  inheritedAgents?: InheritedGrant[];
   variant?: "card" | "inline";
   className?: string;
   accessToken?: string | null;
@@ -15,8 +16,8 @@ interface ObjectPermissionsViewProps {
 
 export function ObjectPermissionsView({
   objectPermission,
-  inheritedMcpServerIds = [],
-  inheritedAgentIds = [],
+  inheritedMcpServers = [],
+  inheritedAgents = [],
   variant = "card",
   className = "",
   accessToken,
@@ -38,13 +39,13 @@ export function ObjectPermissionsView({
         mcpAccessGroups={mcpAccessGroups}
         mcpToolPermissions={mcpToolPermissions}
         mcpToolsets={mcpToolsets}
-        inheritedMcpServers={inheritedMcpServerIds}
+        inheritedMcpServers={inheritedMcpServers}
         accessToken={accessToken}
       />
       <AgentPermissions
         agents={agents}
         agentAccessGroups={agentAccessGroups}
-        inheritedAgents={inheritedAgentIds}
+        inheritedAgents={inheritedAgents}
         accessToken={accessToken}
       />
       <div className="min-w-0 rounded-md border border-border p-4">

--- a/ui/litellm-dashboard/src/components/permissions/AgentPermissions.test.tsx
+++ b/ui/litellm-dashboard/src/components/permissions/AgentPermissions.test.tsx
@@ -1,0 +1,50 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import AgentPermissions from "./AgentPermissions";
+import * as networking from "../networking";
+
+vi.mock("../networking");
+
+describe("AgentPermissions", () => {
+  const accessToken = "test-token";
+  const agentId = "90337622-756e-4f25-98f0-01fc8174aa24";
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("lists agents inherited from access groups with an Inherited tag and counts them", async () => {
+    vi.mocked(networking.getAgentsList).mockResolvedValue({
+      agents: [{ agent_id: agentId, agent_name: "support_agent" }],
+    });
+
+    render(<AgentPermissions agents={[]} inheritedAgents={[agentId]} accessToken={accessToken} />);
+
+    expect(await screen.findByText(/support_agent/)).toBeInTheDocument();
+    expect(screen.getByText("Inherited")).toBeInTheDocument();
+    expect(screen.getByText("1")).toBeInTheDocument();
+    expect(screen.queryByText("No agents or access groups configured")).not.toBeInTheDocument();
+    expect(networking.getAgentsList).toHaveBeenCalledWith(accessToken);
+  });
+
+  it("does not double-list an agent that is both granted directly and inherited", async () => {
+    vi.mocked(networking.getAgentsList).mockResolvedValue({
+      agents: [{ agent_id: agentId, agent_name: "support_agent" }],
+    });
+
+    render(<AgentPermissions agents={[agentId]} inheritedAgents={[agentId]} accessToken={accessToken} />);
+
+    expect(await screen.findByText(/support_agent/)).toBeInTheDocument();
+    expect(screen.getAllByText(/support_agent/)).toHaveLength(1);
+    expect(screen.queryByText("Inherited")).not.toBeInTheDocument();
+    expect(screen.getByText("1")).toBeInTheDocument();
+  });
+
+  it("shows the empty state when nothing is granted directly or inherited", () => {
+    render(<AgentPermissions agents={[]} inheritedAgents={[]} accessToken={accessToken} />);
+
+    expect(screen.getByText("No agents or access groups configured")).toBeInTheDocument();
+    expect(screen.getByText("0")).toBeInTheDocument();
+    expect(networking.getAgentsList).not.toHaveBeenCalled();
+  });
+});

--- a/ui/litellm-dashboard/src/components/permissions/AgentPermissions.test.tsx
+++ b/ui/litellm-dashboard/src/components/permissions/AgentPermissions.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import AgentPermissions from "./AgentPermissions";
 import * as networking from "../networking";
 
@@ -13,31 +14,51 @@ describe("AgentPermissions", () => {
     vi.clearAllMocks();
   });
 
-  it("lists agents inherited from access groups with an Inherited tag and counts them", async () => {
+  it("lists agents inherited from access groups, counts them, and names the groups on hover", async () => {
+    const user = userEvent.setup();
     vi.mocked(networking.getAgentsList).mockResolvedValue({
       agents: [{ agent_id: agentId, agent_name: "support_agent" }],
     });
 
-    render(<AgentPermissions agents={[]} inheritedAgents={[agentId]} accessToken={accessToken} />);
+    render(
+      <AgentPermissions
+        agents={[]}
+        inheritedAgents={[{ id: agentId, accessGroupNames: ["platform-tools", "support"] }]}
+        accessToken={accessToken}
+      />,
+    );
 
-    expect(await screen.findByText(/support_agent/)).toBeInTheDocument();
-    expect(screen.getByText("Inherited")).toBeInTheDocument();
+    const row = await screen.findByText(/support_agent/);
     expect(screen.getByText("1")).toBeInTheDocument();
     expect(screen.queryByText("No agents or access groups configured")).not.toBeInTheDocument();
     expect(networking.getAgentsList).toHaveBeenCalledWith(accessToken);
+
+    await user.hover(row);
+    expect(
+      await screen.findByText(`Granted via access groups platform-tools, support. Full ID: ${agentId}`),
+    ).toBeInTheDocument();
   });
 
   it("does not double-list an agent that is both granted directly and inherited", async () => {
+    const user = userEvent.setup();
     vi.mocked(networking.getAgentsList).mockResolvedValue({
       agents: [{ agent_id: agentId, agent_name: "support_agent" }],
     });
 
-    render(<AgentPermissions agents={[agentId]} inheritedAgents={[agentId]} accessToken={accessToken} />);
+    render(
+      <AgentPermissions
+        agents={[agentId]}
+        inheritedAgents={[{ id: agentId, accessGroupNames: ["support"] }]}
+        accessToken={accessToken}
+      />,
+    );
 
-    expect(await screen.findByText(/support_agent/)).toBeInTheDocument();
+    const row = await screen.findByText(/support_agent/);
     expect(screen.getAllByText(/support_agent/)).toHaveLength(1);
-    expect(screen.queryByText("Inherited")).not.toBeInTheDocument();
     expect(screen.getByText("1")).toBeInTheDocument();
+
+    await user.hover(row);
+    expect(await screen.findByText(`Full ID: ${agentId}`)).toBeInTheDocument();
   });
 
   it("shows the empty state when nothing is granted directly or inherited", () => {

--- a/ui/litellm-dashboard/src/components/permissions/AgentPermissions.tsx
+++ b/ui/litellm-dashboard/src/components/permissions/AgentPermissions.tsx
@@ -14,16 +14,26 @@ interface Agent {
 interface AgentPermissionsProps {
   agents: string[];
   agentAccessGroups?: string[];
+  inheritedAgents?: string[];
   accessToken?: string | null;
 }
 
-export function AgentPermissions({ agents, agentAccessGroups = [], accessToken }: AgentPermissionsProps) {
+const INHERITED_AGENT_TOOLTIP = "Granted through one of the team's access groups";
+
+export function AgentPermissions({
+  agents,
+  agentAccessGroups = [],
+  inheritedAgents = [],
+  accessToken,
+}: AgentPermissionsProps) {
   const [agentDetails, setAgentDetails] = useState<Agent[]>([]);
+  const inheritedOnlyAgents = inheritedAgents.filter((agent) => !agents.includes(agent));
+  const agentIdCount = agents.length + inheritedOnlyAgents.length;
 
   // Fetch agent details when component mounts
   useEffect(() => {
     const fetchAgentDetails = async () => {
-      if (accessToken && agents.length > 0) {
+      if (accessToken && agentIdCount > 0) {
         try {
           const response = await getAgentsList(accessToken);
           if (response && response.agents && Array.isArray(response.agents)) {
@@ -35,7 +45,7 @@ export function AgentPermissions({ agents, agentAccessGroups = [], accessToken }
       }
     };
     fetchAgentDetails();
-  }, [accessToken, agents.length]);
+  }, [accessToken, agentIdCount]);
 
   // Function to get display name for agent
   const getAgentDisplayName = (agentId: string) => {
@@ -47,10 +57,11 @@ export function AgentPermissions({ agents, agentAccessGroups = [], accessToken }
     return agentId;
   };
 
-  // Merge agents and access groups into one list
+  // Merge agents, inherited agents and access groups into one list
   const mergedItems = [
-    ...agents.map((agent) => ({ type: "agent", value: agent })),
-    ...agentAccessGroups.map((group) => ({ type: "accessGroup", value: group })),
+    ...agents.map((agent) => ({ type: "agent", value: agent, inherited: false })),
+    ...inheritedOnlyAgents.map((agent) => ({ type: "agent", value: agent, inherited: true })),
+    ...agentAccessGroups.map((group) => ({ type: "accessGroup", value: group, inherited: false })),
   ];
   const totalCount = mergedItems.length;
 
@@ -76,8 +87,17 @@ export function AgentPermissions({ agents, agentAccessGroups = [], accessToken }
                           <span className="text-sm font-medium text-foreground truncate">
                             {getAgentDisplayName(item.value)}
                           </span>
+                          {item.inherited && (
+                            <span className="ml-1 px-1.5 py-0.5 text-[9px] font-semibold text-purple-600 bg-purple-50 border border-purple-200 rounded-sm uppercase tracking-wide shrink-0 dark:text-purple-300 dark:bg-purple-950 dark:border-purple-800">
+                              Inherited
+                            </span>
+                          )}
                         </TooltipTrigger>
-                        <TooltipContent>{`Full ID: ${item.value}`}</TooltipContent>
+                        <TooltipContent>
+                          {item.inherited
+                            ? `${INHERITED_AGENT_TOOLTIP}. Full ID: ${item.value}`
+                            : `Full ID: ${item.value}`}
+                        </TooltipContent>
                       </Tooltip>
                     </TooltipProvider>
                   ) : (

--- a/ui/litellm-dashboard/src/components/permissions/AgentPermissions.tsx
+++ b/ui/litellm-dashboard/src/components/permissions/AgentPermissions.tsx
@@ -57,7 +57,6 @@ export function AgentPermissions({
     return agentId;
   };
 
-  // Merge agents, inherited agents and access groups into one list
   const mergedItems = [
     ...agents.map((agent) => ({ type: "agent", value: agent, inherited: false })),
     ...inheritedOnlyAgents.map((agent) => ({ type: "agent", value: agent, inherited: true })),

--- a/ui/litellm-dashboard/src/components/permissions/AgentPermissions.tsx
+++ b/ui/litellm-dashboard/src/components/permissions/AgentPermissions.tsx
@@ -3,6 +3,7 @@ import { UserGroupIcon } from "@heroicons/react/outline";
 import { Badge } from "@/components/ui/badge";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { getAgentsList } from "../networking";
+import { InheritedGrant, inheritedGrantTooltip } from "./inheritedGrants";
 
 interface Agent {
   agent_id: string;
@@ -14,11 +15,9 @@ interface Agent {
 interface AgentPermissionsProps {
   agents: string[];
   agentAccessGroups?: string[];
-  inheritedAgents?: string[];
+  inheritedAgents?: InheritedGrant[];
   accessToken?: string | null;
 }
-
-const INHERITED_AGENT_TOOLTIP = "Granted through one of the team's access groups";
 
 export function AgentPermissions({
   agents,
@@ -27,7 +26,7 @@ export function AgentPermissions({
   accessToken,
 }: AgentPermissionsProps) {
   const [agentDetails, setAgentDetails] = useState<Agent[]>([]);
-  const inheritedOnlyAgents = inheritedAgents.filter((agent) => !agents.includes(agent));
+  const inheritedOnlyAgents = inheritedAgents.filter((grant) => !agents.includes(grant.id));
   const agentIdCount = agents.length + inheritedOnlyAgents.length;
 
   // Fetch agent details when component mounts
@@ -58,9 +57,9 @@ export function AgentPermissions({
   };
 
   const mergedItems = [
-    ...agents.map((agent) => ({ type: "agent", value: agent, inherited: false })),
-    ...inheritedOnlyAgents.map((agent) => ({ type: "agent", value: agent, inherited: true })),
-    ...agentAccessGroups.map((group) => ({ type: "accessGroup", value: group, inherited: false })),
+    ...agents.map((agent) => ({ type: "agent", value: agent, tooltip: `Full ID: ${agent}` })),
+    ...inheritedOnlyAgents.map((grant) => ({ type: "agent", value: grant.id, tooltip: inheritedGrantTooltip(grant) })),
+    ...agentAccessGroups.map((group) => ({ type: "accessGroup", value: group, tooltip: "" })),
   ];
   const totalCount = mergedItems.length;
 
@@ -86,17 +85,8 @@ export function AgentPermissions({
                           <span className="text-sm font-medium text-foreground truncate">
                             {getAgentDisplayName(item.value)}
                           </span>
-                          {item.inherited && (
-                            <span className="ml-1 px-1.5 py-0.5 text-[9px] font-semibold text-purple-600 bg-purple-50 border border-purple-200 rounded-sm uppercase tracking-wide shrink-0 dark:text-purple-300 dark:bg-purple-950 dark:border-purple-800">
-                              Inherited
-                            </span>
-                          )}
                         </TooltipTrigger>
-                        <TooltipContent>
-                          {item.inherited
-                            ? `${INHERITED_AGENT_TOOLTIP}. Full ID: ${item.value}`
-                            : `Full ID: ${item.value}`}
-                        </TooltipContent>
+                        <TooltipContent>{item.tooltip}</TooltipContent>
                       </Tooltip>
                     </TooltipProvider>
                   ) : (

--- a/ui/litellm-dashboard/src/components/permissions/MCPServerPermissions.test.tsx
+++ b/ui/litellm-dashboard/src/components/permissions/MCPServerPermissions.test.tsx
@@ -406,4 +406,47 @@ describe("MCPServerPermissions", () => {
     );
     await waitFor(() => expect(screen.getByText("Blocked")).toHaveAttribute("data-variant", "destructive"));
   });
+
+  it("lists servers inherited from access groups with an Inherited tag and counts them", async () => {
+    vi.mocked(networking.fetchMCPServers).mockResolvedValue([
+      { server_id: mockServerId1, server_name: mockServerName1, alias: mockServerName1 },
+    ]);
+
+    render(
+      <MCPServerPermissions
+        mcpServers={[]}
+        mcpAccessGroups={[]}
+        mcpToolPermissions={{}}
+        inheritedMcpServers={[mockServerId1]}
+        accessToken={mockAccessToken}
+      />,
+    );
+
+    expect(await screen.findByText(/DW_MCP/)).toBeInTheDocument();
+    expect(screen.getByText("Inherited")).toBeInTheDocument();
+    expect(screen.getByText("1")).toBeInTheDocument();
+    expect(screen.queryByText("No MCP servers, access groups, or toolsets configured")).not.toBeInTheDocument();
+    expect(networking.fetchMCPServers).toHaveBeenCalledWith(mockAccessToken);
+  });
+
+  it("does not double-list a server that is both granted directly and inherited", async () => {
+    vi.mocked(networking.fetchMCPServers).mockResolvedValue([
+      { server_id: mockServerId2, server_name: mockServerName2, alias: mockServerName2 },
+    ]);
+
+    render(
+      <MCPServerPermissions
+        mcpServers={[mockServerId2]}
+        mcpAccessGroups={[]}
+        mcpToolPermissions={{}}
+        inheritedMcpServers={[mockServerId2]}
+        accessToken={mockAccessToken}
+      />,
+    );
+
+    expect(await screen.findByText(/Test Server/)).toBeInTheDocument();
+    expect(screen.getAllByText(/Test Server/)).toHaveLength(1);
+    expect(screen.queryByText("Inherited")).not.toBeInTheDocument();
+    expect(screen.getByText("1")).toBeInTheDocument();
+  });
 });

--- a/ui/litellm-dashboard/src/components/permissions/MCPServerPermissions.test.tsx
+++ b/ui/litellm-dashboard/src/components/permissions/MCPServerPermissions.test.tsx
@@ -407,7 +407,8 @@ describe("MCPServerPermissions", () => {
     await waitFor(() => expect(screen.getByText("Blocked")).toHaveAttribute("data-variant", "destructive"));
   });
 
-  it("lists servers inherited from access groups with an Inherited tag and counts them", async () => {
+  it("lists servers inherited from access groups, counts them, and names the group on hover", async () => {
+    const user = userEvent.setup();
     vi.mocked(networking.fetchMCPServers).mockResolvedValue([
       { server_id: mockServerId1, server_name: mockServerName1, alias: mockServerName1 },
     ]);
@@ -417,19 +418,24 @@ describe("MCPServerPermissions", () => {
         mcpServers={[]}
         mcpAccessGroups={[]}
         mcpToolPermissions={{}}
-        inheritedMcpServers={[mockServerId1]}
+        inheritedMcpServers={[{ id: mockServerId1, accessGroupNames: ["platform-tools"] }]}
         accessToken={mockAccessToken}
       />,
     );
 
-    expect(await screen.findByText(/DW_MCP/)).toBeInTheDocument();
-    expect(screen.getByText("Inherited")).toBeInTheDocument();
+    const row = await screen.findByText(/DW_MCP/);
     expect(screen.getByText("1")).toBeInTheDocument();
     expect(screen.queryByText("No MCP servers, access groups, or toolsets configured")).not.toBeInTheDocument();
     expect(networking.fetchMCPServers).toHaveBeenCalledWith(mockAccessToken);
+
+    await user.hover(row);
+    expect(
+      await screen.findByText(`Granted via access group platform-tools. Full ID: ${mockServerId1}`),
+    ).toBeInTheDocument();
   });
 
   it("does not double-list a server that is both granted directly and inherited", async () => {
+    const user = userEvent.setup();
     vi.mocked(networking.fetchMCPServers).mockResolvedValue([
       { server_id: mockServerId2, server_name: mockServerName2, alias: mockServerName2 },
     ]);
@@ -439,14 +445,16 @@ describe("MCPServerPermissions", () => {
         mcpServers={[mockServerId2]}
         mcpAccessGroups={[]}
         mcpToolPermissions={{}}
-        inheritedMcpServers={[mockServerId2]}
+        inheritedMcpServers={[{ id: mockServerId2, accessGroupNames: ["platform-tools"] }]}
         accessToken={mockAccessToken}
       />,
     );
 
-    expect(await screen.findByText(/Test Server/)).toBeInTheDocument();
+    const row = await screen.findByText(/Test Server/);
     expect(screen.getAllByText(/Test Server/)).toHaveLength(1);
-    expect(screen.queryByText("Inherited")).not.toBeInTheDocument();
     expect(screen.getByText("1")).toBeInTheDocument();
+
+    await user.hover(row);
+    expect(await screen.findByText(`Full ID: ${mockServerId2}`)).toBeInTheDocument();
   });
 });

--- a/ui/litellm-dashboard/src/components/permissions/MCPServerPermissions.tsx
+++ b/ui/litellm-dashboard/src/components/permissions/MCPServerPermissions.tsx
@@ -11,14 +11,18 @@ interface MCPServerPermissionsProps {
   mcpAccessGroups?: string[];
   mcpToolPermissions?: Record<string, string[]>;
   mcpToolsets?: string[];
+  inheritedMcpServers?: string[];
   accessToken?: string | null;
 }
+
+const INHERITED_MCP_SERVER_TOOLTIP = "Granted through one of the team's access groups";
 
 export function MCPServerPermissions({
   mcpServers,
   mcpAccessGroups = [],
   mcpToolPermissions = {},
   mcpToolsets = [],
+  inheritedMcpServers = [],
   accessToken,
 }: MCPServerPermissionsProps) {
   const [mcpServerDetails, setMCPServerDetails] = useState<MCPServer[]>([]);
@@ -50,10 +54,16 @@ export function MCPServerPermissions({
     });
   };
 
+  const directServerIds = mcpServers.filter(
+    (server) => server !== NO_MCP_SERVERS_SENTINEL && server !== ALL_PROXY_MCP_SERVERS_SENTINEL,
+  );
+  const inheritedOnlyServerIds = inheritedMcpServers.filter((server) => !mcpServers.includes(server));
+  const serverIdCount = directServerIds.length + inheritedOnlyServerIds.length;
+
   // Fetch MCP server details when component mounts
   useEffect(() => {
     const fetchMCPServerDetails = async () => {
-      if (accessToken && mcpServers.length > 0) {
+      if (accessToken && serverIdCount > 0) {
         try {
           const response = await fetchMCPServers(accessToken);
           if (response && Array.isArray(response)) {
@@ -67,7 +77,7 @@ export function MCPServerPermissions({
       }
     };
     fetchMCPServerDetails();
-  }, [accessToken, mcpServers.length]);
+  }, [accessToken, serverIdCount]);
 
   // Fetch toolset details
   useEffect(() => {
@@ -98,12 +108,11 @@ export function MCPServerPermissions({
   const blocksAllMcpServers = mcpServers.includes(NO_MCP_SERVERS_SENTINEL);
   const grantsAllProxyMcpServers = mcpServers.includes(ALL_PROXY_MCP_SERVERS_SENTINEL);
 
-  // Merge servers and access groups into one list
+  // Merge servers, inherited servers and access groups into one list
   const mergedItems = [
-    ...mcpServers
-      .filter((server) => server !== NO_MCP_SERVERS_SENTINEL && server !== ALL_PROXY_MCP_SERVERS_SENTINEL)
-      .map((server) => ({ type: "server", value: server })),
-    ...mcpAccessGroups.map((group) => ({ type: "accessGroup", value: group })),
+    ...directServerIds.map((server) => ({ type: "server", value: server, inherited: false })),
+    ...inheritedOnlyServerIds.map((server) => ({ type: "server", value: server, inherited: true })),
+    ...mcpAccessGroups.map((group) => ({ type: "accessGroup", value: group, inherited: false })),
   ];
   const totalCount = mergedItems.length + mcpToolsets.length;
 
@@ -152,8 +161,17 @@ export function MCPServerPermissions({
                           <span className="text-sm font-medium text-foreground truncate">
                             {getMCPServerDisplayName(item.value)}
                           </span>
+                          {item.inherited && (
+                            <span className="ml-1 px-1.5 py-0.5 text-[9px] font-semibold text-info bg-info/10 border border-info/20 rounded-sm uppercase tracking-wide shrink-0">
+                              Inherited
+                            </span>
+                          )}
                         </TooltipTrigger>
-                        <TooltipContent>{`Full ID: ${item.value}`}</TooltipContent>
+                        <TooltipContent>
+                          {item.inherited
+                            ? `${INHERITED_MCP_SERVER_TOOLTIP}. Full ID: ${item.value}`
+                            : `Full ID: ${item.value}`}
+                        </TooltipContent>
                       </Tooltip>
                     ) : (
                       <div className="inline-flex items-center gap-2 min-w-0">

--- a/ui/litellm-dashboard/src/components/permissions/MCPServerPermissions.tsx
+++ b/ui/litellm-dashboard/src/components/permissions/MCPServerPermissions.tsx
@@ -108,7 +108,6 @@ export function MCPServerPermissions({
   const blocksAllMcpServers = mcpServers.includes(NO_MCP_SERVERS_SENTINEL);
   const grantsAllProxyMcpServers = mcpServers.includes(ALL_PROXY_MCP_SERVERS_SENTINEL);
 
-  // Merge servers, inherited servers and access groups into one list
   const mergedItems = [
     ...directServerIds.map((server) => ({ type: "server", value: server, inherited: false })),
     ...inheritedOnlyServerIds.map((server) => ({ type: "server", value: server, inherited: true })),

--- a/ui/litellm-dashboard/src/components/permissions/MCPServerPermissions.tsx
+++ b/ui/litellm-dashboard/src/components/permissions/MCPServerPermissions.tsx
@@ -5,17 +5,16 @@ import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip
 import { fetchMCPServers, fetchMCPToolsets } from "../networking";
 import { MCPServer, MCPToolset } from "../mcp_tools/types";
 import { ALL_PROXY_MCP_SERVERS_SENTINEL, NO_MCP_SERVERS_SENTINEL } from "../mcp_tools/constants";
+import { InheritedGrant, inheritedGrantTooltip } from "./inheritedGrants";
 
 interface MCPServerPermissionsProps {
   mcpServers: string[];
   mcpAccessGroups?: string[];
   mcpToolPermissions?: Record<string, string[]>;
   mcpToolsets?: string[];
-  inheritedMcpServers?: string[];
+  inheritedMcpServers?: InheritedGrant[];
   accessToken?: string | null;
 }
-
-const INHERITED_MCP_SERVER_TOOLTIP = "Granted through one of the team's access groups";
 
 export function MCPServerPermissions({
   mcpServers,
@@ -57,8 +56,8 @@ export function MCPServerPermissions({
   const directServerIds = mcpServers.filter(
     (server) => server !== NO_MCP_SERVERS_SENTINEL && server !== ALL_PROXY_MCP_SERVERS_SENTINEL,
   );
-  const inheritedOnlyServerIds = inheritedMcpServers.filter((server) => !mcpServers.includes(server));
-  const serverIdCount = directServerIds.length + inheritedOnlyServerIds.length;
+  const inheritedOnlyServers = inheritedMcpServers.filter((grant) => !mcpServers.includes(grant.id));
+  const serverIdCount = directServerIds.length + inheritedOnlyServers.length;
 
   // Fetch MCP server details when component mounts
   useEffect(() => {
@@ -109,9 +108,13 @@ export function MCPServerPermissions({
   const grantsAllProxyMcpServers = mcpServers.includes(ALL_PROXY_MCP_SERVERS_SENTINEL);
 
   const mergedItems = [
-    ...directServerIds.map((server) => ({ type: "server", value: server, inherited: false })),
-    ...inheritedOnlyServerIds.map((server) => ({ type: "server", value: server, inherited: true })),
-    ...mcpAccessGroups.map((group) => ({ type: "accessGroup", value: group, inherited: false })),
+    ...directServerIds.map((server) => ({ type: "server", value: server, tooltip: `Full ID: ${server}` })),
+    ...inheritedOnlyServers.map((grant) => ({
+      type: "server",
+      value: grant.id,
+      tooltip: inheritedGrantTooltip(grant),
+    })),
+    ...mcpAccessGroups.map((group) => ({ type: "accessGroup", value: group, tooltip: "" })),
   ];
   const totalCount = mergedItems.length + mcpToolsets.length;
 
@@ -160,17 +163,8 @@ export function MCPServerPermissions({
                           <span className="text-sm font-medium text-foreground truncate">
                             {getMCPServerDisplayName(item.value)}
                           </span>
-                          {item.inherited && (
-                            <span className="ml-1 px-1.5 py-0.5 text-[9px] font-semibold text-info bg-info/10 border border-info/20 rounded-sm uppercase tracking-wide shrink-0">
-                              Inherited
-                            </span>
-                          )}
                         </TooltipTrigger>
-                        <TooltipContent>
-                          {item.inherited
-                            ? `${INHERITED_MCP_SERVER_TOOLTIP}. Full ID: ${item.value}`
-                            : `Full ID: ${item.value}`}
-                        </TooltipContent>
+                        <TooltipContent>{item.tooltip}</TooltipContent>
                       </Tooltip>
                     ) : (
                       <div className="inline-flex items-center gap-2 min-w-0">

--- a/ui/litellm-dashboard/src/components/permissions/inheritedGrants.test.ts
+++ b/ui/litellm-dashboard/src/components/permissions/inheritedGrants.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import { computeInheritedGrants, inheritedGrantTooltip } from "./inheritedGrants";
+import { TeamAccessGroupModelGrant } from "../team/teamModelAccess";
+
+const GRANTS: TeamAccessGroupModelGrant[] = [
+  { access_group_id: "ag-1", access_group_name: "platform-tools", models: [], mcp_server_ids: ["mcp-1", "mcp-2"] },
+  {
+    access_group_id: "ag-2",
+    access_group_name: "support",
+    models: [],
+    mcp_server_ids: ["mcp-2"],
+    agent_ids: ["agent-1"],
+  },
+];
+
+describe("computeInheritedGrants", () => {
+  it("attributes each id to every group that grants it, in group order", () => {
+    expect(computeInheritedGrants(["mcp-1", "mcp-2"], GRANTS, (g) => g.mcp_server_ids)).toEqual([
+      { id: "mcp-1", accessGroupNames: ["platform-tools"] },
+      { id: "mcp-2", accessGroupNames: ["platform-tools", "support"] },
+    ]);
+  });
+
+  it("keeps ids the flat list carries but no group detail explains, with no group names", () => {
+    expect(computeInheritedGrants(["agent-1", "agent-legacy"], GRANTS, (g) => g.agent_ids)).toEqual([
+      { id: "agent-1", accessGroupNames: ["support"] },
+      { id: "agent-legacy", accessGroupNames: [] },
+    ]);
+  });
+
+  it("falls back to the group details when the flat list is missing, without duplicates", () => {
+    expect(computeInheritedGrants(undefined, GRANTS, (g) => g.mcp_server_ids).map((g) => g.id)).toEqual([
+      "mcp-1",
+      "mcp-2",
+    ]);
+  });
+
+  it("returns nothing when neither source has ids", () => {
+    expect(computeInheritedGrants(undefined, undefined, (g) => g.agent_ids)).toEqual([]);
+  });
+});
+
+describe("inheritedGrantTooltip", () => {
+  it("names a single group", () => {
+    expect(inheritedGrantTooltip({ id: "mcp-1", accessGroupNames: ["platform-tools"] })).toBe(
+      "Granted via access group platform-tools. Full ID: mcp-1",
+    );
+  });
+
+  it("lists several groups", () => {
+    expect(inheritedGrantTooltip({ id: "mcp-2", accessGroupNames: ["platform-tools", "support"] })).toBe(
+      "Granted via access groups platform-tools, support. Full ID: mcp-2",
+    );
+  });
+
+  it("stays generic when the proxy did not say which group granted it", () => {
+    expect(inheritedGrantTooltip({ id: "agent-legacy", accessGroupNames: [] })).toBe(
+      "Granted via an access group. Full ID: agent-legacy",
+    );
+  });
+});

--- a/ui/litellm-dashboard/src/components/permissions/inheritedGrants.ts
+++ b/ui/litellm-dashboard/src/components/permissions/inheritedGrants.ts
@@ -1,0 +1,26 @@
+import { describeGroups, TeamAccessGroupModelGrant } from "../team/teamModelAccess";
+
+export interface InheritedGrant {
+  id: string;
+  accessGroupNames: string[];
+}
+
+export function computeInheritedGrants(
+  ids: string[] | undefined,
+  grants: TeamAccessGroupModelGrant[] | undefined,
+  idsOf: (grant: TeamAccessGroupModelGrant) => string[] | undefined,
+): InheritedGrant[] {
+  const known = grants ?? [];
+  const allIds = [...new Set([...(ids ?? []), ...known.flatMap((grant) => idsOf(grant) ?? [])])];
+  return allIds.map((id) => ({
+    id,
+    accessGroupNames: known
+      .filter((grant) => (idsOf(grant) ?? []).includes(id))
+      .map((grant) => grant.access_group_name),
+  }));
+}
+
+export const inheritedGrantTooltip = (grant: InheritedGrant): string => {
+  const source = grant.accessGroupNames.length > 0 ? describeGroups(grant.accessGroupNames) : "an access group";
+  return `Granted via ${source}. Full ID: ${grant.id}`;
+};

--- a/ui/litellm-dashboard/src/components/team/TeamInfo.test.tsx
+++ b/ui/litellm-dashboard/src/components/team/TeamInfo.test.tsx
@@ -38,6 +38,9 @@ vi.mock("@/components/networking", () => ({
   organizationInfoCall: vi.fn(),
   getRouterSettingsCall: vi.fn().mockResolvedValue({ fields: [] }),
   getPassThroughEndpointsCall: vi.fn(),
+  fetchMCPServers: vi.fn().mockResolvedValue([]),
+  fetchMCPToolsets: vi.fn().mockResolvedValue([]),
+  getAgentsList: vi.fn().mockResolvedValue({ agents: [] }),
 }));
 
 const can = vi.fn();
@@ -300,6 +303,31 @@ describe("TeamInfoView", () => {
         "href",
         expect.stringContaining("/models-and-endpoints?model_group=claude-sonnet-5"),
       );
+    });
+
+    it("shows MCP servers and agents inherited from access groups in the Object Permissions card", async () => {
+      vi.mocked(networking.fetchMCPServers).mockResolvedValue([
+        { server_id: "mcp-github-1234", server_name: "github", alias: "github" },
+      ]);
+      vi.mocked(networking.getAgentsList).mockResolvedValue({
+        agents: [{ agent_id: "agent-support-5678", agent_name: "support_agent" }],
+      });
+      vi.mocked(networking.teamInfoCall).mockResolvedValue(
+        createMockTeamData({
+          object_permission: null,
+          access_group_ids: ["ag-1"],
+          access_group_mcp_server_ids: ["mcp-github-1234"],
+          access_group_agent_ids: ["agent-support-5678"],
+        }),
+      );
+
+      renderWithProviders(<TeamInfoView {...defaultProps} />);
+
+      expect(await screen.findByText(/github \(mcp\.\.\.1234\)/)).toBeInTheDocument();
+      expect(await screen.findByText(/support_agent \(age\.\.\.5678\)/)).toBeInTheDocument();
+      expect(screen.getAllByText("Inherited")).toHaveLength(2);
+      expect(screen.queryByText("No MCP servers, access groups, or toolsets configured")).not.toBeInTheDocument();
+      expect(screen.queryByText("No agents or access groups configured")).not.toBeInTheDocument();
     });
 
     it("keeps the all-proxy-models badge non-clickable", async () => {

--- a/ui/litellm-dashboard/src/components/team/TeamInfo.test.tsx
+++ b/ui/litellm-dashboard/src/components/team/TeamInfo.test.tsx
@@ -305,7 +305,8 @@ describe("TeamInfoView", () => {
       );
     });
 
-    it("shows MCP servers and agents inherited from access groups in the Object Permissions card", async () => {
+    it("shows MCP servers and agents inherited from access groups in the Object Permissions card, naming the group on hover", async () => {
+      const user = userEvent.setup();
       vi.mocked(networking.fetchMCPServers).mockResolvedValue([
         { server_id: "mcp-github-1234", server_name: "github", alias: "github" },
       ]);
@@ -318,16 +319,33 @@ describe("TeamInfoView", () => {
           access_group_ids: ["ag-1"],
           access_group_mcp_server_ids: ["mcp-github-1234"],
           access_group_agent_ids: ["agent-support-5678"],
+          access_group_details: [
+            {
+              access_group_id: "ag-1",
+              access_group_name: "platform-tools",
+              models: [],
+              mcp_server_ids: ["mcp-github-1234"],
+              agent_ids: ["agent-support-5678"],
+            },
+          ],
         }),
       );
 
       renderWithProviders(<TeamInfoView {...defaultProps} />);
 
-      expect(await screen.findByText(/github \(mcp\.\.\.1234\)/)).toBeInTheDocument();
-      expect(await screen.findByText(/support_agent \(age\.\.\.5678\)/)).toBeInTheDocument();
-      expect(screen.getAllByText("Inherited")).toHaveLength(2);
+      const serverRow = await screen.findByText(/github \(mcp\.\.\.1234\)/);
+      const agentRow = await screen.findByText(/support_agent \(age\.\.\.5678\)/);
       expect(screen.queryByText("No MCP servers, access groups, or toolsets configured")).not.toBeInTheDocument();
       expect(screen.queryByText("No agents or access groups configured")).not.toBeInTheDocument();
+
+      await user.hover(serverRow);
+      expect(
+        await screen.findByText("Granted via access group platform-tools. Full ID: mcp-github-1234"),
+      ).toBeInTheDocument();
+      await user.hover(agentRow);
+      expect(
+        await screen.findByText("Granted via access group platform-tools. Full ID: agent-support-5678"),
+      ).toBeInTheDocument();
     });
 
     it("keeps the all-proxy-models badge non-clickable", async () => {

--- a/ui/litellm-dashboard/src/components/team/TeamInfo.test.tsx
+++ b/ui/litellm-dashboard/src/components/team/TeamInfo.test.tsx
@@ -313,23 +313,21 @@ describe("TeamInfoView", () => {
       vi.mocked(networking.getAgentsList).mockResolvedValue({
         agents: [{ agent_id: "agent-support-5678", agent_name: "support_agent" }],
       });
-      vi.mocked(networking.teamInfoCall).mockResolvedValue(
-        createMockTeamData({
-          object_permission: null,
-          access_group_ids: ["ag-1"],
-          access_group_mcp_server_ids: ["mcp-github-1234"],
-          access_group_agent_ids: ["agent-support-5678"],
-          access_group_details: [
-            {
-              access_group_id: "ag-1",
-              access_group_name: "platform-tools",
-              models: [],
-              mcp_server_ids: ["mcp-github-1234"],
-              agent_ids: ["agent-support-5678"],
-            },
-          ],
-        }),
-      );
+      const platformToolsGroup = {
+        access_group_id: "ag-1",
+        access_group_name: "platform-tools",
+        models: [],
+        mcp_server_ids: ["mcp-github-1234"],
+        agent_ids: ["agent-support-5678"],
+      };
+      const inheritedGrants = {
+        object_permission: null,
+        access_group_ids: ["ag-1"],
+        access_group_mcp_server_ids: ["mcp-github-1234"],
+        access_group_agent_ids: ["agent-support-5678"],
+        access_group_details: [platformToolsGroup],
+      };
+      vi.mocked(networking.teamInfoCall).mockResolvedValue(createMockTeamData(inheritedGrants));
 
       renderWithProviders(<TeamInfoView {...defaultProps} />);
 

--- a/ui/litellm-dashboard/src/components/team/TeamInfo.tsx
+++ b/ui/litellm-dashboard/src/components/team/TeamInfo.tsx
@@ -1033,7 +1033,13 @@ const TeamInfoView: React.FC<TeamInfoProps> = ({
             </div>
           </Card>
 
-          <ObjectPermissionsView objectPermission={info.object_permission} variant="card" accessToken={accessToken} />
+          <ObjectPermissionsView
+            objectPermission={info.object_permission}
+            inheritedMcpServerIds={info.access_group_mcp_server_ids}
+            inheritedAgentIds={info.access_group_agent_ids}
+            variant="card"
+            accessToken={accessToken}
+          />
 
           <Card className="block p-6">
             <GuardrailSettingsView
@@ -1883,6 +1889,8 @@ const TeamInfoView: React.FC<TeamInfoProps> = ({
 
               <ObjectPermissionsView
                 objectPermission={info.object_permission}
+                inheritedMcpServerIds={info.access_group_mcp_server_ids}
+                inheritedAgentIds={info.access_group_agent_ids}
                 variant="inline"
                 className="pt-4 border-t border-border"
                 accessToken={accessToken}

--- a/ui/litellm-dashboard/src/components/team/TeamInfo.tsx
+++ b/ui/litellm-dashboard/src/components/team/TeamInfo.tsx
@@ -58,6 +58,7 @@ import {
   TeamModelBadge,
   TeamModelBadgeKind,
 } from "./teamModelAccess";
+import { computeInheritedGrants } from "../permissions/inheritedGrants";
 import MetadataKeyValueFields, {
   metadataObjectToPairs,
   metadataPairsSchema,
@@ -936,6 +937,17 @@ const TeamInfoView: React.FC<TeamInfoProps> = ({
 
   const { team_info: info } = teamData;
 
+  const inheritedMcpServers = computeInheritedGrants(
+    info.access_group_mcp_server_ids,
+    info.access_group_details,
+    (grant) => grant.mcp_server_ids,
+  );
+  const inheritedAgents = computeInheritedGrants(
+    info.access_group_agent_ids,
+    info.access_group_details,
+    (grant) => grant.agent_ids,
+  );
+
   const initialKillSwitchOn = info.metadata?.disable_global_guardrails === true;
 
   const allGuardrails: GuardrailListItem[] = guardrailsData?.guardrails ?? [];
@@ -1035,8 +1047,8 @@ const TeamInfoView: React.FC<TeamInfoProps> = ({
 
           <ObjectPermissionsView
             objectPermission={info.object_permission}
-            inheritedMcpServerIds={info.access_group_mcp_server_ids}
-            inheritedAgentIds={info.access_group_agent_ids}
+            inheritedMcpServers={inheritedMcpServers}
+            inheritedAgents={inheritedAgents}
             variant="card"
             accessToken={accessToken}
           />
@@ -1889,8 +1901,8 @@ const TeamInfoView: React.FC<TeamInfoProps> = ({
 
               <ObjectPermissionsView
                 objectPermission={info.object_permission}
-                inheritedMcpServerIds={info.access_group_mcp_server_ids}
-                inheritedAgentIds={info.access_group_agent_ids}
+                inheritedMcpServers={inheritedMcpServers}
+                inheritedAgents={inheritedAgents}
                 variant="inline"
                 className="pt-4 border-t border-border"
                 accessToken={accessToken}

--- a/ui/litellm-dashboard/src/components/team/teamModelAccess.ts
+++ b/ui/litellm-dashboard/src/components/team/teamModelAccess.ts
@@ -5,6 +5,8 @@ export interface TeamAccessGroupModelGrant {
   access_group_id: string;
   access_group_name: string;
   models: string[];
+  mcp_server_ids?: string[];
+  agent_ids?: string[];
 }
 
 export type TeamModelBadgeKind = "all-proxy" | "no-default" | "direct" | "access-group";
@@ -19,7 +21,7 @@ export function normalizeTeamModelSelection(models: string[] | undefined): strin
   return models && models.length > 0 ? models : [NO_DEFAULT_MODELS];
 }
 
-const describeGroups = (names: string[]): string =>
+export const describeGroups = (names: string[]): string =>
   names.length > 1 ? `access groups ${names.join(", ")}` : `access group ${names[0]}`;
 
 export function computeTeamModelBadges(


### PR DESCRIPTION
## TLDR

Problem this solves:

- Team Overview says "MCP Servers 0" and "Agents 0" for access-group grants
- The Models card next to it already shows inherited models, so the page contradicts itself
- Enforcement is fine, only the display is wrong (Pylon 8024)

How it solves it:

- Object Permissions card now reads `access_group_mcp_server_ids` and `access_group_agent_ids` from `/team/info`
- Inherited servers and agents render in the MCP Servers and Agents lists, deduped against direct grants, and the counts include them
- Hovering an inherited row names the access group(s) that granted it; `/team/info` `access_group_details` now carries `mcp_server_ids` and `agent_ids` per group so the UI can say which one

## User Flow

Before: an admin puts an MCP server into an access group, attaches the group to a team, and the team page tells them the team has no MCP servers

1. They open http://localhost:4000/ui/?page=access-groups, create a group with one model and one MCP server, then attach it to a team from the team's Settings tab
2. They open the team at http://localhost:4000/ui/?page=teams&team=<team_id>, Overview tab
3. The Models card shows the inherited model as a green badge
4. The Object Permissions card right next to it shows `MCP Servers 0`, "No MCP servers, access groups, or toolsets configured", and `Agents 0`
5. A key on that team can still call `GET /v1/mcp/server` and see the server, so the admin files a bug

After: the same page lists the inherited server and agent

1. They open http://localhost:4000/ui/?page=access-groups, create a group with one model and one MCP server, then attach it to a team from the team's Settings tab
2. They open the team at http://localhost:4000/ui/?page=teams&team=<team_id>, Overview tab
3. The Models card shows the inherited model as a green badge
4. The Object Permissions card shows `MCP Servers 1` with the server's alias and `Agents 1` the same way, looking just like directly granted rows
5. Hovering an inherited row says "Granted via access group <name>. Full ID: <id>", so they can see where the access came from without leaving the page
6. The Settings tab shows the same inherited rows in its inline Object Permissions section

## Relevant issues

## Linear ticket

Resolves LIT-6592

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Setup, worktree proxy on `:4592` with the shared dev Postgres and the dashboard dev server on `:3592` pointed at it. Real MCP server, agent, access group and team created through the API:

```bash
P=http://localhost:4592; K="Authorization: Bearer sk-1234"
curl -s -X POST "$P/v1/mcp/server" -H "$K" -H 'Content-Type: application/json' \
  -d '{"server_name":"lit6592_github_mcp","alias":"lit6592_github_mcp","url":"https://api.githubcopilot.com/mcp/","transport":"http","auth_type":"none"}'
# -> {"server_id": "1c3a5519-1992-4dea-a469-faabcf090dd4", ...}
curl -s -X POST "$P/v1/agents" -H "$K" -H 'Content-Type: application/json' \
  -d '{"agent_name":"lit6592_support_agent","agent_card_params":{"name":"lit6592_support_agent","description":"repro agent","url":"https://example.invalid/a2a","version":"1.0.0","capabilities":{},"defaultInputModes":["text"],"defaultOutputModes":["text"],"skills":[]}}'
# -> {"agent_id":"90337622-756e-4f25-98f0-01fc8174aa24", ...}
curl -s -X POST "$P/v1/access_group" -H "$K" -H 'Content-Type: application/json' \
  -d '{"access_group_name":"lit-6592-platform-tools","access_model_names":["anthropic-haiku-4-5"],"access_mcp_server_ids":["1c3a5519-1992-4dea-a469-faabcf090dd4"],"access_agent_ids":["90337622-756e-4f25-98f0-01fc8174aa24"]}'
# -> {"access_group_id": "1936eb56-aeb4-4932-af4e-86012582d24f", ...}
curl -s -X POST "$P/team/new" -H "$K" -H 'Content-Type: application/json' \
  -d '{"team_alias":"lit-6593-team-alpha","models":["no-default-models"],"access_group_ids":["1936eb56-aeb4-4932-af4e-86012582d24f"]}'
# -> team_id 92851a2d-c6db-41ac-ae6e-f8e37786f82f
curl -s "$P/team/info?team_id=92851a2d-c6db-41ac-ae6e-f8e37786f82f" -H "$K"
# team_info: access_group_models=['anthropic-haiku-4-5']
#            access_group_mcp_server_ids=['1c3a5519-1992-4dea-a469-faabcf090dd4']
#            access_group_agent_ids=['90337622-756e-4f25-98f0-01fc8174aa24']
#            object_permission=None
```

### Before (97dbd8efcb)

1. Open http://localhost:3592/teams?team=92851a2d-c6db-41ac-ae6e-f8e37786f82f, Overview tab
2. Models card shows `anthropic-haiku-4-5`, Object Permissions shows `MCP Servers 0` and `Agents 0` with the empty-state text

![before](https://raw.githubusercontent.com/BerriAI/litellm/litellm_lit_6592_screenshots/lit6592_before.png)

### After (2fd6e19051)

`/team/info` for the same team now attributes each id to its group:

```bash
curl -s "$P/team/info?team_id=92851a2d-c6db-41ac-ae6e-f8e37786f82f" -H "$K" | jq '.team_info.access_group_details'
# [{"access_group_id": "1936eb56-aeb4-4932-af4e-86012582d24f", "access_group_name": "lit-6592-platform-tools",
#   "models": ["anthropic-haiku-4-5"], "mcp_server_ids": ["1c3a5519-1992-4dea-a469-faabcf090dd4"],
#   "agent_ids": ["90337622-756e-4f25-98f0-01fc8174aa24"]}]
```

#### Overview card, hovering the MCP server row

1. Open http://localhost:3592/teams?team=92851a2d-c6db-41ac-ae6e-f8e37786f82f, Overview tab
2. Object Permissions shows `MCP Servers 1` (`lit6592_github_mcp`) and `Agents 1` (`lit6592_support_agent`)
3. Hover `lit6592_github_mcp`: the tooltip reads "Granted via access group lit-6592-platform-tools. Full ID: 1c3a5519-1992-4dea-a469-faabcf090dd4"

![after mcp hover](https://raw.githubusercontent.com/BerriAI/litellm/litellm_lit_6592_screenshots/lit6592_after.png)

#### Overview card, hovering the agent row

4. Hover `lit6592_support_agent`: the tooltip reads "Granted via access group lit-6592-platform-tools. Full ID: 90337622-756e-4f25-98f0-01fc8174aa24"

![after agent hover](https://raw.githubusercontent.com/BerriAI/litellm/litellm_lit_6592_screenshots/lit6592_after_agent.png)

#### Settings tab, inline Object Permissions

5. Settings tab, the inline Object Permissions section shows the same rows with the same hover text

![after settings](https://raw.githubusercontent.com/BerriAI/litellm/litellm_lit_6592_screenshots/lit6592_after_settings.png)

## Type

🐛 Bug Fix

## Caveats (if any)

### Low

- Sibling fix for the access group page's "Attached Teams" count is a separate PR (LIT-6593)
- Drive-by: `models-and-endpoints/page.test.tsx` goes back to `screen.*` queries. The #38872 merge kept the destructured version, which puts staging over the `prefer-screen-queries` budget (21 > 18) and fails frontend-lint on every PR

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
