### PR TITLE
fix(proxy): keep passthrough logging metadata and model_info dicts when team callbacks are wired

### DIFF
--- a/litellm/proxy/pass_through_endpoints/pass_through_endpoints.py
+++ b/litellm/proxy/pass_through_endpoints/pass_through_endpoints.py
@@ -812,6 +812,8 @@ def _resolve_team_callback_wiring(
         else {  # mutable-ok: Logging arg
             **callback_vars,
             TRUSTED_CALLBACK_VARS_FIELD: callback_vars,
+            "metadata": {},  # mutable-ok: Logging arg
+            "model_info": {},  # mutable-ok: Logging arg
         }
     )
     return _TeamCallbackWiring(

--- a/tests/test_litellm/proxy/pass_through_endpoints/test_pass_through_endpoints.py
+++ b/tests/test_litellm/proxy/pass_through_endpoints/test_pass_through_endpoints.py
@@ -5492,7 +5492,7 @@ async def _drive_passthrough_request_and_capture_logging(
     mock_request.query_params = QueryParams({})
     mock_request.body = AsyncMock(return_value=b'{"model": "gemini-2.0-flash"}')
 
-    captured_data: dict = {}
+    captured_data: dict = {}  # mutable-ok: the pre-call hook records the request data into it
 
     async def capture_pre_call_hook(user_api_key_dict, data, call_type):
         captured_data.update(data)
@@ -5657,7 +5657,7 @@ async def test_pass_through_request_leaves_guardrail_readable_metadata():
         },
     )
 
-    observed: dict[str, dict[str, str] | BaseException] = {}
+    observed: dict[str, dict[str, str] | BaseException] = {}  # mutable-ok: the pre-call hook records into it
 
     def read_headers_the_way_a_guardrail_does(logging_obj: LiteLLMLoggingObj | None) -> None:
         assert logging_obj is not None

--- a/tests/test_litellm/proxy/pass_through_endpoints/test_pass_through_endpoints.py
+++ b/tests/test_litellm/proxy/pass_through_endpoints/test_pass_through_endpoints.py
@@ -2,6 +2,7 @@ import asyncio
 import json
 import logging
 import os
+from collections.abc import Callable
 from contextlib import ExitStack, contextmanager
 from io import BytesIO
 from types import SimpleNamespace
@@ -29,6 +30,7 @@ from litellm.proxy.pass_through_endpoints.pass_through_endpoints import (
     websocket_passthrough_request,
 )
 from litellm.integrations.custom_logger import CustomLogger
+from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObj
 from litellm.proxy._types import ProxyException, UserAPIKeyAuth
 from litellm.types.passthrough_endpoints.pass_through_endpoints import (
     LITELLM_PASS_THROUGH_RAW_BODY_STATE_KEY,
@@ -5464,7 +5466,10 @@ def test_the_marker_check_distinguishes_the_two_route_kinds():
     assert request_dispatched_to_pass_through_endpoint(builtin) is False
 
 
-async def _drive_passthrough_request_and_capture_logging(user_api_key_dict: UserAPIKeyAuth) -> tuple[int, object]:
+async def _drive_passthrough_request_and_capture_logging(
+    user_api_key_dict: UserAPIKeyAuth,
+    on_pre_call: Callable[[LiteLLMLoggingObj | None], None] | None = None,
+) -> tuple[int, LiteLLMLoggingObj | None]:
     import litellm
     from litellm.llms.custom_httpx.http_handler import get_async_httpx_client
     from litellm.types.llms.custom_http import httpxSpecialProvider
@@ -5491,6 +5496,8 @@ async def _drive_passthrough_request_and_capture_logging(user_api_key_dict: User
 
     async def capture_pre_call_hook(user_api_key_dict, data, call_type):
         captured_data.update(data)
+        if on_pre_call is not None:
+            on_pre_call(data.get("litellm_logging_obj"))
         return data
 
     mock_proxy_logging = MagicMock()
@@ -5623,3 +5630,103 @@ async def test_resolve_team_callback_wiring_fails_open_on_operational_error():
     assert wiring.success_callbacks is None
     assert wiring.failure_callbacks is None
     assert wiring.logging_kwargs is None
+
+
+@pytest.mark.asyncio
+async def test_pass_through_request_leaves_guardrail_readable_metadata():
+    """A pre-call guardrail reads the request headers off the passthrough logging
+    params without raising."""
+    from litellm.proxy.guardrails.guardrail_hooks.hiddenlayer.hiddenlayer import (
+        _logged_request_headers,
+    )
+
+    user_api_key_dict = UserAPIKeyAuth(
+        api_key="test-key",
+        team_id="test-team",
+        team_metadata={
+            "logging": [
+                {
+                    "callback_name": "langfuse",
+                    "callback_type": "success_and_failure",
+                    "callback_vars": {
+                        "langfuse_public_key": "pk_test",
+                        "langfuse_secret_key": "sk_test",
+                    },
+                }
+            ]
+        },
+    )
+
+    observed: dict[str, dict[str, str] | BaseException] = {}
+
+    def read_headers_the_way_a_guardrail_does(logging_obj: LiteLLMLoggingObj | None) -> None:
+        assert logging_obj is not None
+        try:
+            observed["headers"] = _logged_request_headers(logging_obj)
+        except Exception as exc:  # noqa: BLE001 - the regression is that this used to raise
+            observed["headers"] = exc
+
+    status_code, logging_obj = await _drive_passthrough_request_and_capture_logging(
+        user_api_key_dict, on_pre_call=read_headers_the_way_a_guardrail_does
+    )
+
+    assert "headers" in observed, "the pre-call hook never ran, so nothing was observed"
+    assert observed["headers"] == {}, f"guardrail header read failed: {observed['headers']!r}"
+    assert status_code == 200
+    assert logging_obj is not None
+    assert logging_obj.dynamic_success_callbacks, "team success callbacks must stay wired"
+    assert logging_obj.standard_callback_dynamic_params.get("langfuse_public_key") == "pk_test"
+
+
+@pytest.mark.asyncio
+async def test_pass_through_request_leaves_cost_router_logger_working():
+    """The cost router's logger reads the deployment id off the passthrough logging
+    params without raising. least_busy shares the read but swallows the exception,
+    so this is the strategy where the break is observable."""
+    from litellm._logging import verbose_logger
+    from litellm.caching.caching import DualCache
+    from litellm.router_strategy.lowest_cost import LowestCostLoggingHandler
+
+    handler = LowestCostLoggingHandler(router_cache=DualCache())
+
+    user_api_key_dict = UserAPIKeyAuth(
+        api_key="test-key",
+        team_id="test-team",
+        team_metadata={
+            "logging": [
+                {
+                    "callback_name": "langfuse",
+                    "callback_type": "success_and_failure",
+                    "callback_vars": {
+                        "langfuse_public_key": "pk_test",
+                        "langfuse_secret_key": "sk_test",
+                    },
+                }
+            ]
+        },
+    )
+
+    status_code, logging_obj = await _drive_passthrough_request_and_capture_logging(user_api_key_dict)
+    assert status_code == 200
+    assert logging_obj is not None
+
+    raised: list[logging.LogRecord] = []  # mutable-ok: logging.Handler records into it
+
+    class _RecordTracebacks(logging.Handler):
+        def emit(self, record: logging.LogRecord) -> None:
+            if record.exc_info is not None:
+                raised.append(record)
+
+    recorder = _RecordTracebacks()
+    verbose_logger.addHandler(recorder)
+    try:
+        await handler.async_log_success_event(
+            kwargs=logging_obj.model_call_details,
+            response_obj=None,
+            start_time=None,
+            end_time=None,
+        )
+    finally:
+        verbose_logger.removeHandler(recorder)
+
+    assert not raised, f"cost router logger raised on the passthrough logging params: {raised[0].exc_info}"


### PR DESCRIPTION
## TLDR

Problem this solves:

- Passthrough requests from a team with logging callbacks return 500
- Any pre-call guardrail on a passthrough route triggers it
- Router strategy loggers also log a traceback per request

How it solves it:

- Seed empty `metadata` and `model_info` into the logging kwargs
- Both now stay dicts instead of turning into `None`

## User Flow

Before: a developer on a team that has its own logging destination gets a 500 from every passthrough route, while their teammates on other teams are fine

1. A proxy admin turns on a pre-call guardrail and gives one team its own logging destination
2. A developer on that team sends POST https://litellm-domain/openai-pt with a normal chat body
3. The response is `HTTP 500` with `{"error":{"message":"'NoneType' object has no attribute 'get'"}}`, and nothing reaches the provider
4. The same request from a key on a team with no logging destination returns `HTTP 200`
5. Switching the route to Anthropic or Gemini passthrough gives the same 500

After: the same developer gets the provider's real answer, same as everyone else

1. A proxy admin turns on a pre-call guardrail and gives one team its own logging destination
2. A developer on that team sends POST https://litellm-domain/openai-pt with a normal chat body
3. The response is `HTTP 200` carrying the provider's real completion
4. The same request from a key on a team with no logging destination still returns `HTTP 200`
5. Anthropic and Gemini passthrough return `HTTP 200` too

## Relevant issues

Follow-up to #38979, which introduced the wiring this fixes

## Linear ticket

## Behavior changes

- Passthrough requests from a team with logging callbacks now reach the provider instead of returning 500. That is the fix, and it is the only user-visible change
- Anything reading `litellm_params["metadata"]` or `litellm_params["model_info"]` on a passthrough request now sees `{}` where it saw `None`. Every reader in the tree either guards on `None` and skips, or resolves the value as `.get(key, {}).get(...)`, so the outcome is unchanged for all of them except the ones that were crashing
- No config, no API response field, no DB column, and no public signature changes

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

Shared setup, identical on both sides. The two proxies run the same config against the same Postgres, one on the merge base and one on the PR tip, and both talk to the real OpenAI, Anthropic and Gemini APIs.

```yaml
# config.yaml
model_list:
  - model_name: chat-model
    litellm_params:
      model: openai/gpt-4.1-mini
      api_key: os.environ/OPENAI_API_KEY
  - model_name: chat-model
    litellm_params:
      model: openai/gpt-4.1-nano
      api_key: os.environ/OPENAI_API_KEY

general_settings:
  master_key: sk-1234
  pass_through_endpoints:
    - path: "/openai-pt"
      target: "https://api.openai.com/v1/chat/completions"
      headers:
        authorization: os.environ/OPENAI_AUTH_HEADER
        content-type: application/json
    - path: "/anthropic-pt"
      target: "https://api.anthropic.com/v1/messages"
      headers:
        x-api-key: os.environ/ANTHROPIC_API_KEY
        anthropic-version: "2023-06-01"
        content-type: application/json
    - path: "/gemini-pt"
      target: "https://generativelanguage.googleapis.com/v1beta/models/gemini-3.6-flash:generateContent"
      headers:
        x-goog-api-key: os.environ/GEMINI_API_KEY
        content-type: application/json

guardrails:
  - guardrail_name: hl-precall
    litellm_params:
      guardrail: hiddenlayer
      mode: pre_call
      default_on: true
      api_base: http://127.0.0.1:18979
```

```bash
# one team gets a logging destination, one does not
TEAM_CB=$(curl -sS -X POST http://127.0.0.1:$PORT/team/new \
  -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
  -d '{"team_alias":"with-callbacks"}' | jq -r .team_id)
TEAM_PLAIN=$(curl -sS -X POST http://127.0.0.1:$PORT/team/new \
  -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
  -d '{"team_alias":"no-callbacks"}' | jq -r .team_id)

curl -sS -X POST http://127.0.0.1:$PORT/team/$TEAM_CB/callback \
  -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
  -d '{"callback_name":"langfuse","callback_type":"success_and_failure",
       "callback_vars":{"langfuse_public_key":"pk-...","langfuse_secret_key":"sk-...",
                        "langfuse_host":"http://127.0.0.1:18979"}}'

KEY_CB=$(curl -sS -X POST http://127.0.0.1:$PORT/key/generate \
  -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
  -d "{\"team_id\":\"$TEAM_CB\"}" | jq -r .key)
KEY_PLAIN=$(curl -sS -X POST http://127.0.0.1:$PORT/key/generate \
  -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
  -d "{\"team_id\":\"$TEAM_PLAIN\"}" | jq -r .key)
```

### Before (9c417ba08b)

#### OpenAI passthrough, key on the team with logging callbacks

1. Send the request

```bash
curl -sS -w "\nHTTP %{http_code}\n" -X POST http://127.0.0.1:14950/openai-pt \
  -H "Authorization: Bearer $KEY_CB" -H "Content-Type: application/json" \
  -d '{"model":"gpt-4.1-mini","messages":[{"role":"user","content":"say hi"}],"max_tokens":8}'
```

2. Observed

```
{"error":{"message":"'NoneType' object has no attribute 'get'","type":"None","param":"None","code":"500"}}
HTTP 500
```

3. The proxy log shows where it died, before any call to OpenAI

```
LiteLLM Proxy:ERROR: pass_through_endpoints.py:1639 - litellm.proxy.proxy_server.pass_through_endpoint(): Exception occured - 'NoneType' object has no attribute 'get'
  File ".../litellm/proxy/guardrails/guardrail_hooks/hiddenlayer/hiddenlayer.py", line 148, in _logged_request_headers
    return logging_obj.model_call_details.get("litellm_params", {}).get("metadata", {}).get("headers", {})
AttributeError: 'NoneType' object has no attribute 'get'
```

#### Anthropic passthrough, same key

1. `POST http://127.0.0.1:14950/anthropic-pt` with a Messages body
2. Observed: `HTTP 500`, same error body

#### Gemini passthrough, same key

1. `POST http://127.0.0.1:14950/gemini-pt` with a generateContent body
2. Observed: `HTTP 500`, same error body

#### Control: same route, key on the team with no logging callbacks

1. `POST http://127.0.0.1:14950/openai-pt` with `$KEY_PLAIN`
2. Observed: `HTTP 200`, so the trigger is the team's logging destination, not the route

#### Router strategy logger, with only the metadata half of the fix applied

1. Run the same proxy under `router_settings: routing_strategy: cost-based-routing`
2. `POST /openai-pt` with `$KEY_CB` three times
3. Observed: `HTTP 200`, but six tracebacks in the log

```
  File ".../litellm/router_strategy/lowest_cost.py", line 108, in async_log_success_event
    id = kwargs["litellm_params"].get("model_info", {}).get("id", None)
AttributeError: 'NoneType' object has no attribute 'get'
```

#### Four workers

1. Launch the same base proxy with `--num_workers 4` (five listeners on the port)
2. `POST /openai-pt` with `$KEY_CB` twelve times
3. Observed: `500 500 500 500 500 500 500 500 500 500 500 500`, 24 tracebacks

#### A billing callback on the same route

1. Add `litellm_settings: callbacks: ["lago"]` and point `LAGO_API_BASE` at a local sink
2. `POST /openai-pt` with `$KEY_CB`
3. Observed: `HTTP 500`, the billing callback never runs, no event reaches the sink

#### Every routing strategy

1. Run the same base proxy under each of `simple-shuffle`, `cost-based-routing`, `least-busy`, `latency-based-routing` and `usage-based-routing-v2`
2. `POST /openai-pt`, `/anthropic-pt` and `/gemini-pt` with `$KEY_CB` on each
3. Observed: `HTTP 500` on all fifteen, six tracebacks per strategy

#### Websocket passthrough

1. Open `ws://127.0.0.1:14970/openai_passthrough/v1/realtime?model=gpt-realtime` with `$KEY_CB` and send a `response.create`
2. Observed: the real OpenAI session opens, the team's logging destination receives one event, no traceback. This path is not affected

#### Admin UI request log

1. Open http://127.0.0.1:14970/ui/?page=logs and sign in as `admin` with the master key
2. Observed: only the control team's two requests are listed. The callback team sent five and none of them reached the log, because they all 500'd

![base admin UI request log](https://raw.githubusercontent.com/BerriAI/litellm/assets-pr39216/base-logs.png)

### After (2176d5b60b)

#### OpenAI passthrough, key on the team with logging callbacks

1. Send the same request

```bash
curl -sS -w "\nHTTP %{http_code}\n" -X POST http://127.0.0.1:14951/openai-pt \
  -H "Authorization: Bearer $KEY_CB" -H "Content-Type: application/json" \
  -d '{"model":"gpt-4.1-mini","messages":[{"role":"user","content":"say hi"}],"max_tokens":8}'
```

2. Observed

```
{
  "id": "chatcmpl-EJREUlbQfLBgbYpnIyvvlVMGlZJWm",
  "object": "chat.completion",
  "model": "gpt-4.1-mini-2025-04-14",
  "choices": [
    {
      "index": 0,
      "message": {"role": "assistant", "content": "Hi! How can I help you today"},
      "finish_reason": "length"
    }
  ],
  "usage": {"prompt_tokens": 9, "completion_tokens": 8, "total_tokens": 17}
}
HTTP 200
```

#### Anthropic passthrough, same key

1. `POST http://127.0.0.1:14951/anthropic-pt` with a Messages body
2. Observed: `HTTP 200` with the real Claude answer

#### Gemini passthrough, same key

1. `POST http://127.0.0.1:14951/gemini-pt` with a generateContent body
2. Observed: `HTTP 200` with the real Gemini answer

#### Control: same route, key on the team with no logging callbacks

1. `POST http://127.0.0.1:14951/openai-pt` with `$KEY_PLAIN`
2. Observed: `HTTP 200`, unchanged

#### Router strategy logger

1. Run the fixed proxy under `router_settings: routing_strategy: cost-based-routing`
2. `POST /openai-pt` with `$KEY_CB` three times
3. Observed: `HTTP 200` and zero `lowest_cost.py` tracebacks. `least-busy` behaves the same way

#### Four workers

1. Launch the fixed proxy with `--num_workers 4` (five listeners on the port)
2. `POST /openai-pt` with `$KEY_CB` twelve times
3. Observed: `200 200 200 200 200 200 200 200 200 200 200 200`, zero tracebacks

#### A billing callback on the same route

1. Add `litellm_settings: callbacks: ["lago"]` and point `LAGO_API_BASE` at a local sink
2. `POST /openai-pt` with `$KEY_CB`
3. Observed: `HTTP 200`, the billing callback runs and logs `External Customer ID is not set`, no event reaches the sink
4. A proxy built at `3fadcd7155`, the commit right before #38979, answers exactly the same way on all three counts

#### Every routing strategy

1. Run the fixed proxy under each of `simple-shuffle`, `cost-based-routing`, `least-busy`, `latency-based-routing` and `usage-based-routing-v2`
2. `POST /openai-pt`, `/anthropic-pt` and `/gemini-pt` with `$KEY_CB` on each
3. Observed: `HTTP 200` on all fifteen, zero tracebacks on every strategy

#### Websocket passthrough

1. Open `ws://127.0.0.1:14971/openai_passthrough/v1/realtime?model=gpt-realtime` with `$KEY_CB` and send a `response.create`
2. Observed: identical to the base, the real OpenAI session opens, one event reaches the team's logging destination, no traceback

#### Admin UI request log

1. Open http://127.0.0.1:14971/ui/?page=logs and sign in as `admin` with the master key
2. Observed: all seven requests are listed, the callback team's five (`rig2-cb`) alongside the control team's two, each with real spend

![fixed admin UI request log](https://raw.githubusercontent.com/BerriAI/litellm/assets-pr39216/head-logs.png)

## Type

🐛 Bug Fix

## Caveats (if any)

### Medium

- Pre-existing, not touched here: team callback vars are spread into the logging kwargs unfiltered, so a name that collides with a reserved logging param takes effect
  - Live check: putting `no_log` in a team's `callback_vars` through `POST /team/update` silently stops that team's passthrough logging, with `HTTP 200` and no warning
  - `POST /team/{id}/callback` rejects it with a 422, so only the older metadata route reaches it
- Pre-call guardrails on passthrough routes still see an empty metadata, so they get no caller identity
  - That is the behavior from before #38979; the real metadata is only assembled after the pre-call hook runs
  - Giving them the populated metadata is a separate change

### Low

- The real cause sits in `get_litellm_params`, which writes 45 keys and defaults 42 of them to `None`
- Fixing it there changes every caller, so this seeds the two keys that have readers which break
- Sibling `Logging(kwargs=...)` callers outside passthrough can still produce a `None` `model_info`

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow passthrough-only change that only defaults two logging kwargs to empty dicts; no auth, routing, or API contract changes.
> 
> **Overview**
> Fixes **HTTP 500** on passthrough routes when the caller's team has logging callbacks configured—a regression from team callback wiring where `litellm_params["metadata"]` and `model_info` stayed **`None`**, breaking pre-call guardrails (e.g. Hiddenlayer header reads) and router strategy success loggers that chain `.get()` on those keys.
> 
> **`_resolve_team_callback_wiring`** now seeds empty **`metadata`** and **`model_info`** dicts into the logging kwargs passed to `Logging`, so downstream readers see `{}` instead of `None` while team callback vars and wiring stay the same.
> 
> Tests extend the passthrough logging harness with an optional pre-call hook and add coverage for guardrail header reads and **`LowestCostLoggingHandler`** on team-wired passthrough logging params.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2176d5b60ba84069fc10356edd5a626cbb618a7d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

ran /live-pr-risk and found no regressions/backward incompatible risks