### PR TITLE
fix(proxy): guard optional prisma imports so DB-less installs return 401, not 500

### DIFF
--- a/litellm/proxy/db/exception_handler.py
+++ b/litellm/proxy/db/exception_handler.py
@@ -1,4 +1,6 @@
 from collections.abc import Awaitable, Callable, Iterator
+from importlib import import_module
+from types import ModuleType
 from typing import Any, Final, TypeVar
 
 from litellm._logging import verbose_proxy_logger
@@ -47,6 +49,28 @@ def _exception_types(*candidates: object) -> tuple[type[BaseException], ...]:
     return tuple(c for c in candidates if isinstance(c, type) and issubclass(c, BaseException))
 
 
+def _optional_prisma() -> ModuleType | None:
+    """The ``prisma`` package, or None when it is not installed.
+
+    A DB-less proxy (config + master key, no ``DATABASE_URL``) is installed
+    without the optional ``prisma`` package, yet the predicates below still run
+    on every error path, auth failures that never touch a database included. An
+    unguarded import there raises ``ModuleNotFoundError`` from inside the error
+    handler itself, which replaces the intended response (e.g. a 401 for a
+    missing API key) with a generic 500. Without prisma installed no exception
+    can be a prisma one, so callers fall back to the non-prisma checks.
+
+    ``prisma.engine.errors`` is imported alongside it because that submodule is
+    not loaded by importing the top-level package.
+    """
+    try:
+        prisma: Final = import_module("prisma")
+        import_module("prisma.engine.errors")
+    except ImportError:
+        return None
+    return prisma
+
+
 class PrismaDBExceptionHandler:
     """
     Class to handle DB Exceptions or Connection Errors
@@ -88,11 +112,11 @@ class PrismaDBExceptionHandler:
         Reporting decisions want the opposite breadth; use
         ``is_database_infrastructure_error`` for those.
         """
-        import prisma.engine.errors
+        prisma: Final = _optional_prisma()
 
         if isinstance(e, DB_CONNECTION_ERROR_TYPES):
             return True
-        if isinstance(e, _exception_types(prisma.engine.errors.EngineConnectionError)):
+        if prisma is not None and isinstance(e, _exception_types(prisma.engine.errors.EngineConnectionError)):
             return True
         return isinstance(e, ProxyException) and e.type == ProxyErrorTypes.no_db_connection
 
@@ -112,22 +136,23 @@ class PrismaDBExceptionHandler:
         ``RecordNotFoundError``, etc.) are excluded — the DB IS reachable and
         the request itself is what failed.
         """
-        import prisma
+        prisma: Final = _optional_prisma()
 
-        data_layer_errors: Final = _exception_types(
-            prisma.errors.DataError,
-            prisma.errors.UniqueViolationError,
-            prisma.errors.ForeignKeyViolationError,
-            prisma.errors.MissingRequiredValueError,
-            prisma.errors.RawQueryError,
-            prisma.errors.TableNotFoundError,
-            prisma.errors.RecordNotFoundError,
-        )
-        if isinstance(e, data_layer_errors):
-            return False
+        if prisma is not None:
+            data_layer_errors: Final = _exception_types(
+                prisma.errors.DataError,
+                prisma.errors.UniqueViolationError,
+                prisma.errors.ForeignKeyViolationError,
+                prisma.errors.MissingRequiredValueError,
+                prisma.errors.RawQueryError,
+                prisma.errors.TableNotFoundError,
+                prisma.errors.RecordNotFoundError,
+            )
+            if isinstance(e, data_layer_errors):
+                return False
+            if isinstance(e, _exception_types(prisma.errors.PrismaError)):
+                return True
         if isinstance(e, DB_CONNECTION_ERROR_TYPES):
-            return True
-        if isinstance(e, _exception_types(prisma.errors.PrismaError)):
             return True
         if isinstance(e, ProxyException) and e.type == ProxyErrorTypes.no_db_connection:
             return True
@@ -152,9 +177,9 @@ class PrismaDBExceptionHandler:
         per-row data rejection has to additionally consult
         ``is_database_service_unavailable_error`` before acting on a True here.
         """
-        import prisma
+        prisma: Final = _optional_prisma()
 
-        return type(e) is prisma.errors.DataError
+        return prisma is not None and type(e) is prisma.errors.DataError
 
     @staticmethod
     def is_database_transport_error(e: Exception) -> bool:
@@ -165,36 +190,37 @@ class PrismaDBExceptionHandler:
         Use this for reconnect logic — data-layer errors like UniqueViolationError
         mean the DB IS reachable, so reconnecting would be pointless.
         """
-        import prisma
+        prisma: Final = _optional_prisma()
 
         if isinstance(e, DB_CONNECTION_ERROR_TYPES):
             return True
-        if isinstance(
-            e,
-            _exception_types(
-                prisma.errors.ClientNotConnectedError,
-                prisma.errors.HTTPClientClosedError,
-            ),
-        ):
-            return True
-        if isinstance(e, _exception_types(prisma.errors.PrismaError)):
-            error_message: Final = str(e).lower()
-            connection_keywords: Final = (
-                "can't reach database server",
-                "cannot reach database server",
-                "can't connect",
-                "cannot connect",
-                "connection error",
-                "connection closed",
-                "timed out",
-                "timeout",
-                "connection refused",
-                "network is unreachable",
-                "no route to host",
-                "broken pipe",
-            )
-            if any(keyword in error_message for keyword in connection_keywords):
+        if prisma is not None:
+            if isinstance(
+                e,
+                _exception_types(
+                    prisma.errors.ClientNotConnectedError,
+                    prisma.errors.HTTPClientClosedError,
+                ),
+            ):
                 return True
+            if isinstance(e, _exception_types(prisma.errors.PrismaError)):
+                error_message: Final = str(e).lower()
+                connection_keywords: Final = (
+                    "can't reach database server",
+                    "cannot reach database server",
+                    "can't connect",
+                    "cannot connect",
+                    "connection error",
+                    "connection closed",
+                    "timed out",
+                    "timeout",
+                    "connection refused",
+                    "network is unreachable",
+                    "no route to host",
+                    "broken pipe",
+                )
+                if any(keyword in error_message for keyword in connection_keywords):
+                    return True
         if isinstance(e, ProxyException) and e.type == ProxyErrorTypes.no_db_connection:
             return True
         return False
@@ -202,9 +228,9 @@ class PrismaDBExceptionHandler:
     @staticmethod
     def is_deadlock_error(e: Exception) -> bool:
         """True iff ``e`` is a Postgres deadlock (P2034 / 40P01) surfaced through prisma."""
-        import prisma
+        prisma: Final = _optional_prisma()
 
-        if not isinstance(e, _exception_types(prisma.errors.PrismaError)):
+        if prisma is None or not isinstance(e, _exception_types(prisma.errors.PrismaError)):
             return False
         if getattr(e, "code", None) == "P2034":
             return True
@@ -233,9 +259,9 @@ class PrismaDBExceptionHandler:
         are already classified by type/keyword above, and data-layer ones
         (the DB IS reachable) must stay 401.
         """
-        import prisma
+        prisma: Final = _optional_prisma()
 
-        if isinstance(e, _exception_types(prisma.errors.PrismaError)):
+        if prisma is None or isinstance(e, _exception_types(prisma.errors.PrismaError)):
             return False
         tb = getattr(e, "__traceback__", None)
         while tb is not None:

--- a/tests/test_litellm/proxy/auth/test_auth_exception_handler.py
+++ b/tests/test_litellm/proxy/auth/test_auth_exception_handler.py
@@ -1,5 +1,6 @@
 import asyncio
 import json
+import sys
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
@@ -871,3 +872,32 @@ async def test_handle_authentication_error_traceback_only_for_unexpected_errors(
     assert records[0].levelname == expect_level
     expected_logger_name = "LiteLLM Proxy.stdout" if expect_level == "WARNING" else "LiteLLM Proxy"
     assert records[0].name == expected_logger_name
+
+
+@pytest.mark.asyncio
+async def test_missing_api_key_returns_401_when_prisma_is_not_installed():
+    """
+    On a DB-less proxy (config + master key, no DATABASE_URL) the optional
+    prisma package is absent. Classifying the "no api key passed in" failure
+    must not crash on that missing import, or the intended 401 is replaced by a
+    generic 500 from the catch-all handler.
+    """
+    prisma_absent = dict.fromkeys(
+        ("prisma", "prisma.errors", "prisma.engine", "prisma.engine.errors"), None
+    )
+    handler = UserAPIKeyAuthExceptionHandler()
+
+    with patch.dict(sys.modules, prisma_absent):
+        with pytest.raises(ProxyException) as exc_info:
+            await handler._handle_authentication_error(
+                Exception("No api key passed in."),
+                MagicMock(),
+                {},
+                "/v1/chat/completions",
+                None,
+                None,
+            )
+
+    assert exc_info.value.type == ProxyErrorTypes.auth_error
+    assert exc_info.value.code == str(status.HTTP_401_UNAUTHORIZED)
+    assert "No api key passed in." in exc_info.value.message

--- a/tests/test_litellm/proxy/db/test_exception_handler.py
+++ b/tests/test_litellm/proxy/db/test_exception_handler.py
@@ -700,3 +700,71 @@ def test_connection_error_answers_when_prisma_is_mocked_after_import():
     with patch.dict(sys.modules, {"prisma": MagicMock()}):
         assert PrismaDBExceptionHandler.is_database_connection_error(Exception("x")) is False
         assert PrismaDBExceptionHandler.is_database_connection_error(httpx.ConnectError("refused")) is True
+
+
+_PRISMA_ABSENT: Final = dict.fromkeys(
+    ("prisma", "prisma.errors", "prisma.engine", "prisma.engine.errors"), None
+)
+
+
+@pytest.mark.parametrize(
+    "predicate",
+    [
+        PrismaDBExceptionHandler.is_database_connection_error,
+        PrismaDBExceptionHandler.is_database_infrastructure_error,
+        PrismaDBExceptionHandler.is_prisma_data_error,
+        PrismaDBExceptionHandler.is_database_transport_error,
+        PrismaDBExceptionHandler.is_deadlock_error,
+        PrismaDBExceptionHandler.is_prisma_engine_internal_error,
+        PrismaDBExceptionHandler.is_database_service_unavailable_error,
+        PrismaDBExceptionHandler.is_permanent_database_fault,
+        PrismaDBExceptionHandler.is_database_service_unavailable_error_in_chain,
+    ],
+    ids=lambda predicate: predicate.__name__,
+)
+def test_predicates_answer_false_when_prisma_is_not_installed(predicate):
+    """
+    A DB-less proxy install ships without the optional prisma package, so no
+    exception it sees can be a prisma one. Every predicate must answer False
+    instead of raising ModuleNotFoundError out of the error path it is being
+    used to handle.
+    """
+    with patch.dict(sys.modules, _PRISMA_ABSENT):
+        assert predicate(Exception("No api key passed in.")) is False
+
+
+def test_chain_helpers_answer_when_prisma_is_not_installed():
+    """
+    The chain walk and the 503 wording go through the same predicates, so they
+    have to survive a missing prisma too.
+    """
+    auth_failure = Exception("No api key passed in.")
+
+    with patch.dict(sys.modules, _PRISMA_ABSENT):
+        assert PrismaDBExceptionHandler.find_database_service_unavailable_error_in_chain(auth_failure) is None
+        assert PrismaDBExceptionHandler.database_unavailable_message(httpx.ConnectError("refused"))
+
+
+def test_non_prisma_db_signals_still_classified_when_prisma_is_not_installed():
+    """
+    Guarding the prisma import must not blind the predicates to the signals
+    that do not need prisma: httpx transport failures and the proxy's own
+    no_db_connection exception.
+    """
+    connect_error = httpx.ConnectError("All connection attempts failed")
+    no_db_connection = ProxyException(
+        message="No connected db.",
+        type=ProxyErrorTypes.no_db_connection,
+        param="None",
+        code=500,
+    )
+
+    with patch.dict(sys.modules, _PRISMA_ABSENT):
+        assert PrismaDBExceptionHandler.is_database_connection_error(connect_error) is True
+        assert PrismaDBExceptionHandler.is_database_infrastructure_error(connect_error) is True
+        assert PrismaDBExceptionHandler.is_database_transport_error(connect_error) is True
+        assert PrismaDBExceptionHandler.is_database_service_unavailable_error(connect_error) is True
+
+        assert PrismaDBExceptionHandler.is_database_connection_error(no_db_connection) is True
+        assert PrismaDBExceptionHandler.is_database_infrastructure_error(no_db_connection) is True
+        assert PrismaDBExceptionHandler.is_database_transport_error(no_db_connection) is True


### PR DESCRIPTION
## TLDR

Problem this solves:

- DB-less proxy answers 500 to requests with no API key
- The documented 401 never reaches the caller
- Real 5xx alerting gets polluted by an auth failure

How it solves it:

- Prisma is optional, so its imports are now guarded
- Missing prisma falls back to the non-prisma checks
- Nothing changes where prisma is installed

## User Flow

Before: a developer running a DB-less proxy (config + master key, no database) gets an opaque 500 when their client forgets the auth header, so they cannot tell a missing key from a broken server

1. The proxy admin starts LiteLLM with the config below (master key only, no `DATABASE_URL`), installed with `uv tool install 'litellm[proxy]'`
2. The developer sends POST http://localhost:4000/v1/chat/completions with a normal chat body and no `Authorization` header
3. The response is HTTP 500 `{"error":{"message":"Internal server error","type":"internal_server_error"}}`
4. They send the same POST with `Authorization: Bearer sk-wrong` and get HTTP 400 `No connected db.`, and a correct key still works — so only the missing-header case is broken
5. The proxy operator sees the request counted as a server fault in their 5xx alerting, and the client cannot distinguish "I forgot my key" from "the gateway is down"

After: the same request comes back as a plain 401 naming the missing key

1. The proxy admin keeps the same config and install
2. The developer sends the same POST http://localhost:4000/v1/chat/completions with no `Authorization` header
3. The response is HTTP 401 `{"error":{"message":"Authentication Error, No api key passed in.","type":"auth_error","param":"None","code":"401"}}`
4. The wrong-key and correct-key cases are unchanged (400 `No connected db.` and success)
5. The operator's 5xx alerting no longer counts unauthenticated requests as server faults

## Relevant issues

Fixes #38978

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

Shared setup — a DB-less install with no `prisma` package, exactly as in the issue:

```bash
uv venv dbless --python 3.13
uv pip install --python dbless/bin/python 'litellm[proxy]'
dbless/bin/python -c "import prisma"
# ModuleNotFoundError: No module named 'prisma'
```

`dbless_config.yaml`:

```yaml
model_list:
  - model_name: gpt-4o-mini
    litellm_params:
      model: openai/gpt-4o-mini
      api_key: os.environ/OPENAI_API_KEY

general_settings:
  master_key: sk-dbless-1234
```

The proxy is started from the checkout under test, against that prisma-free environment:

```bash
PYTHONPATH=$PWD dbless/bin/python -m litellm.proxy.proxy_cli --config dbless_config.yaml --port 4000
```

### Before (11a02b9581)

#### no Authorization header

1. `curl -s -i -X POST http://localhost:4000/v1/chat/completions -H 'Content-Type: application/json' -d '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"ping"}]}'`
2. ```
   HTTP/1.1 500 Internal Server Error
   {"error":{"message":"Internal server error","type":"internal_server_error"}}
   ```
3. The server log shows the auth handler itself crashing:
   ```
   File ".../litellm/proxy/auth/auth_exception_handler.py", line 62, in _as_proxy_exception
   File ".../litellm/proxy/db/exception_handler.py", line 244, in is_database_service_unavailable_error
   File ".../litellm/proxy/db/exception_handler.py", line 82, in is_database_infrastructure_error
   ModuleNotFoundError: No module named 'prisma'
   ```

#### wrong key

1. `curl -s -i -X POST http://localhost:4000/v1/chat/completions -H 'Authorization: Bearer sk-wrong' -H 'Content-Type: application/json' -d '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"ping"}]}'`
2. ```
   HTTP/1.1 400 Bad Request
   {"error":{"message":"No connected db.","type":"no_db_connection","param":null,"code":"400"}}
   ```

#### correct master key

1. `curl -s -i http://localhost:4000/v1/models -H 'Authorization: Bearer sk-dbless-1234'`
2. ```
   HTTP/1.1 200 OK
   {"data":[{"id":"gpt-4o-mini","object":"model","created":1677610602,"owned_by":"openai","mode":"chat","max_input_tokens":128000,"max_output_tokens":16384}],"object":"list"}
   ```

### After (4b98337a06)

#### no Authorization header

1. `curl -s -i -X POST http://localhost:4000/v1/chat/completions -H 'Content-Type: application/json' -d '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"ping"}]}'`
2. ```
   HTTP/1.1 401 Unauthorized
   {"error":{"message":"Authentication Error, No api key passed in.","type":"auth_error","param":"None","code":"401"}}
   ```
3. `grep -c "ModuleNotFoundError: No module named 'prisma'" proxy.log` returns `0` (it returned `2` on the Before run)

#### wrong key

1. `curl -s -i -X POST http://localhost:4000/v1/chat/completions -H 'Authorization: Bearer sk-wrong' -H 'Content-Type: application/json' -d '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"ping"}]}'`
2. ```
   HTTP/1.1 400 Bad Request
   {"error":{"message":"No connected db.","type":"no_db_connection","param":null,"code":"400"}}
   ```

#### correct master key

1. `curl -s -i http://localhost:4000/v1/models -H 'Authorization: Bearer sk-dbless-1234'`
2. ```
   HTTP/1.1 200 OK
   {"data":[{"id":"gpt-4o-mini","object":"model","created":1677610602,"owned_by":"openai","mode":"chat","max_input_tokens":128000,"max_output_tokens":16384}],"object":"list"}
   ```

## Type

🐛 Bug Fix

## Caveats (if any)

### Low

- Only `exception_handler.py` is guarded; other DB-less gaps stay open
- The 400 `No connected db.` on a wrong key is unchanged

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
