### PR TITLE
test(e2e): read JUnit properties off the real collected pytest Item

### DIFF
--- a/tests/e2e/test_junit_properties.py
+++ b/tests/e2e/test_junit_properties.py
@@ -24,25 +24,10 @@ from junit_properties import (
 )
 
 
-class FakeMarker:
-    def __init__(self, name: str, *args: object) -> None:
-        self.name = name
-        self.args = args
-
-
-class FakeItem:
-    """The three attributes junit_properties reads off a pytest Item."""
-
-    def __init__(
-        self, nodeid: str, location: tuple[str, int | None, str], markers: tuple[FakeMarker, ...] = ()
-    ) -> None:
-        self.nodeid = nodeid
-        self.location = location
-        self.user_properties: list[tuple[str, str]] = []
-        self._markers = markers
-
-    def iter_markers(self, name: str):
-        return (marker for marker in self._markers if marker.name == name)
+def collected_item(request: pytest.FixtureRequest, name: str) -> pytest.Item:
+    """The Item pytest collected for test ``name`` in this file: the real nodeid,
+    location and marker machinery the collection hook reads, as pytest built it."""
+    return next(item for item in request.session.items if item.path == request.path and item.name == name)
 
 
 def repo_root() -> Path | None:
@@ -109,22 +94,22 @@ class TestSourceFromLocation:
 
 
 class TestResultProperties:
-    def test_every_test_carries_package_covers_and_source(self) -> None:
-        item = FakeItem(
-            "logging/test_x.py::TestFoo::test_bar",
-            ("logging/test_x.py", 40, "TestFoo.test_bar"),
-            (FakeMarker("covers", "LOG-1", "LOG-2"),),
-        )
-        assert result_properties(item) == (
-            ("package", "logging"),
+    def test_every_test_carries_package_covers_and_source(self, request: pytest.FixtureRequest) -> None:
+        """Read off this test's own collected Item, so the nodeid and location are
+        whatever pytest reports for the launch shape in use, and the marker is added
+        at run time so the coverage registry's collect-only pass never sees it."""
+        test = type(self).test_every_test_carries_package_covers_and_source
+        request.applymarker(pytest.mark.covers("LOG-1", "LOG-2"))
+        assert result_properties(collected_item(request, test.__name__)) == (
+            ("package", "root"),
             ("covers", "LOG-1,LOG-2"),
-            ("source", "tests/e2e/logging/test_x.py:41"),
+            ("source", f"tests/e2e/test_junit_properties.py:{test.__code__.co_firstlineno}"),
         )
 
-    def test_attach_is_idempotent(self) -> None:
+    def test_attach_is_idempotent(self, request: pytest.FixtureRequest) -> None:
         """Collection can run the hook more than once; a second pass must not
         double the <property> entries in the report."""
-        item = FakeItem("logging/test_x.py::test_bar", ("logging/test_x.py", 40, "test_bar"))
+        item = collected_item(request, type(self).test_attach_is_idempotent.__name__)
         attach_result_properties(item)
         attach_result_properties(item)
         assert [name for name, _ in item.user_properties] == ["package", "covers", "source"]


### PR DESCRIPTION
## TLDR

Problem this solves:

- `uv run basedpyright tests/e2e` is red on staging: 3 errors in `tests/e2e/test_junit_properties.py`
- The test fed a hand-rolled `FakeItem` to functions typed `pytest.Item`
- Every `make check` that scopes a `litellm/` or `tests/e2e/` Python file fails on it today

How it solves it:

- Drops `FakeItem` and `FakeMarker` entirely
- Each test reads its own collected `pytest.Item` out of `request.session.items`
- The `covers` marker is applied at run time via `request.applymarker`, so the coverage registry's collect-only pass never sees it
- No casts, no ignores, no Protocol loosening, production types untouched

## User Flow

Before: a contributor on a clean staging branch runs the repo's pre-commit gate and it fails on code they never touched

1. They check out `litellm_internal_staging` and run `make check` with a `litellm/` or `tests/e2e/` Python change staged
2. The `lint-e2e-basedpyright` step prints `3 errors, 0 warnings, 0 notes` for `tests/e2e/test_junit_properties.py` and `make check` exits 1
3. They run `uv run basedpyright tests/e2e` directly and see the same three `"FakeItem" is not assignable to "Item"` errors
4. They cannot commit through the gate without fixing a file unrelated to their change

After: the same contributor runs the same gate and it passes

1. They check out `litellm_internal_staging` and run `make check` with a `litellm/` or `tests/e2e/` Python change staged
2. The `lint-e2e-basedpyright` step prints `0 errors, 0 warnings, 0 notes` and `make check` moves on to the next check
3. They run `uv run basedpyright tests/e2e` directly and see `0 errors, 0 warnings, 0 notes`
4. Their commit goes through with the gate green

## Relevant issues

## Linear ticket

Resolves LIT-6669

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

No proxy involved: the symptom is the e2e type gate itself, so the proof is the gate and the test file at each commit. Both runs from a fresh worktree after `make bootstrap`.

### Before (62f032cca5)

#### e2e type gate

1. `uv run basedpyright tests/e2e`
2. Observed:

```
tests/e2e/test_junit_properties.py
  tests/e2e/test_junit_properties.py:118:34 - error: Argument of type "FakeItem" cannot be assigned to parameter "item" of type "Item" in function "result_properties"
    "FakeItem" is not assignable to "Item" (reportArgumentType)
  tests/e2e/test_junit_properties.py:128:34 - error: Argument of type "FakeItem" cannot be assigned to parameter "item" of type "Item" in function "attach_result_properties"
    "FakeItem" is not assignable to "Item" (reportArgumentType)
  tests/e2e/test_junit_properties.py:129:34 - error: Argument of type "FakeItem" cannot be assigned to parameter "item" of type "Item" in function "attach_result_properties"
    "FakeItem" is not assignable to "Item" (reportArgumentType)
3 errors, 0 warnings, 0 notes
```

exit 1

#### test file

1. `uv run pytest tests/e2e/test_junit_properties.py -v -p no:cacheprovider`
2. Observed: `23 passed` (the red was the type gate only, the tests themselves ran green)

### After (f49a3e15a8)

#### e2e type gate

1. `uv run basedpyright tests/e2e`
2. Observed:

```
0 errors, 0 warnings, 0 notes
```

exit 0

#### test file

1. `uv run pytest tests/e2e/test_junit_properties.py -v -p no:cacheprovider`
2. Observed:

```
collected 23 items
...
tests/e2e/test_junit_properties.py::TestResultProperties::test_every_test_carries_package_covers_and_source PASSED [ 86%]
tests/e2e/test_junit_properties.py::TestResultProperties::test_attach_is_idempotent PASSED [ 91%]
...
============================== 23 passed in 0.02s ==============================
```

## Type

🐛 Bug Fix
✅ Test

## Caveats (if any)

### Low

- CI skips this gate for top-level `tests/e2e/*.py` changes
  - The `tests/e2e/**/*.py` pathspec needs a subdirectory, so the red landed with lint green
  - Widening it is a `.github/**` change, tracked in LIT-6673

## QA runbook

Neither test carries the `e2e` marker, so no proxy or credentials are needed; run from a bootstrapped checkout.

- tests/e2e/test_junit_properties.py::TestResultProperties::test_every_test_carries_package_covers_and_source - the JUnit `package`, `covers` and `source` properties read off a real collected Item come out as the suite root, the comma-joined covers ids, and a repo-relative `path:line`
  - [ ] Run `uv run pytest tests/e2e/test_junit_properties.py -k test_every_test_carries_package_covers_and_source -v` from the repo root and expect 1 passed
  - [ ] Run the same command from inside `tests/e2e` (the runner image's cwd) and expect 1 passed, proving the nodeid normalization holds for both launch shapes
  - [ ] Add `--junitxml=/tmp/j.xml` and confirm the testcase's `<property name="covers" value=""/>`: the marker applied inside the test is invisible to the collection hook that writes the report
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey (e.g., assert actual expected spend instead of just spend > 0) or potentially flaky
- tests/e2e/test_junit_properties.py::TestResultProperties::test_attach_is_idempotent - attaching the properties twice to the same collected Item leaves exactly one `package`, `covers`, `source` triple
  - [ ] Run `uv run pytest tests/e2e/test_junit_properties.py -k test_attach_is_idempotent -v` and expect 1 passed
  - [ ] Run `uv run basedpyright tests/e2e` and expect `0 errors, 0 warnings, 0 notes`
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey (e.g., assert actual expected spend instead of just spend > 0) or potentially flaky

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
- [x] f49a3e15a8 passes /live-pr-risk
